### PR TITLE
Add gestaltd agent observability

### DIFF
--- a/docs/content/custom-providers/agent.mdx
+++ b/docs/content/custom-providers/agent.mdx
@@ -56,6 +56,20 @@ Providers can call back into Gestalt through the host service:
 These callbacks work the same way when the provider runs directly on the
 `gestaltd` host or inside a hosted runtime.
 
+## Observability
+
+Provider authors do not need to emit the baseline `gestaltd` agent metrics.
+`gestaltd` wraps the configured provider interface and records
+`gestaltd.agent.provider.operation.*` for every provider method. The public
+agent facade records `gestaltd.agent.operation.*`, tool resolution records
+`gestaltd.agent.tool.resolve.*`, and turn authorization metadata writes record
+`gestaltd.agent.run_metadata.write.*`.
+
+When OTLP tracing is enabled, the `context.Context` passed into provider
+methods carries the active trace. Preserve that context when calling back into
+`AgentHost.ExecuteTool` or starting provider-owned work that should remain part
+of the same trace tree.
+
 ## Canonical objects
 
 Provider methods exchange canonical objects rather than vendor-native payloads:

--- a/docs/content/custom-providers/authorization.mdx
+++ b/docs/content/custom-providers/authorization.mdx
@@ -37,6 +37,19 @@ The contract has three parts:
 The example below shows the shape of a minimal in-memory provider. The
 remaining methods follow the same request/response pattern.
 
+## Observability
+
+Provider authors do not need to emit the baseline `gestaltd` authorization
+metrics. `gestaltd` wraps the configured provider interface and records
+`gestaltd.authorization.provider.operation.*` for every provider method. When
+the provider is used for provider-backed human access, `gestaltd` also records
+`gestaltd.authorization.provider.evaluate.*` around the batched authorization
+checks it performs.
+
+When OTLP tracing is enabled, preserve the `context.Context` passed into
+provider methods for downstream calls so provider work remains attached to the
+same trace tree.
+
 ```go
 package exampleauthz
 

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -101,8 +101,9 @@ collectors can still split the stream by filtering on `log.type=audit`.
 
 The built-in metric surface covers Prometheus exporter metadata, inbound HTTP
 requests handled by `gestaltd`, broker operation execution, connection authentication
-flows, platform authentication actions, credentialed HTTP catalog discovery, IndexedDB operations, and outbound gRPC calls
-from `gestaltd` to provider processes.
+flows, platform authentication actions, agent lifecycle operations, authorization
+provider calls, credential resolution, catalog resolution, IndexedDB operations,
+and outbound gRPC calls from `gestaltd` to provider processes.
 
 Gestalt documents metric names using their OpenTelemetry instrument names. The
 Prometheus scrape endpoint translates those names to Prometheus-style metric
@@ -250,6 +251,78 @@ key), `gestalt.action` (currently `list_operations`), and
 credentialed session-catalog path fails, even if `gestaltd` falls back to a
 static catalog and still serves a successful HTTP response.
 
+### Agent Metrics
+
+Agent metrics are recorded at the `gestaltd` agent facade and at the configured
+agent provider boundary. They use the same triplet shape as other custom
+Gestalt metrics: `<family>.count`, `<family>.error_count`, and
+`<family>.duration`.
+
+| OpenTelemetry family | Prometheus families | Meaning |
+| --- | --- | --- |
+| `gestaltd.agent.operation.*` | `gestaltd_agent_operation_count_total`, `gestaltd_agent_operation_error_count_total`, `gestaltd_agent_operation_duration_seconds` | Public agent manager operations such as `create_session`, `create_turn`, `list_turn_events`, and `resolve_interaction` |
+| `gestaltd.agent.provider.operation.*` | `gestaltd_agent_provider_operation_count_total`, `gestaltd_agent_provider_operation_error_count_total`, `gestaltd_agent_provider_operation_duration_seconds` | Calls into the selected provider-owned agent system of record |
+| `gestaltd.agent.tool.resolve.*` | `gestaltd_agent_tool_resolve_count_total`, `gestaltd_agent_tool_resolve_error_count_total`, `gestaltd_agent_tool_resolve_duration_seconds` | Tool reference resolution before a turn is sent to a provider |
+| `gestaltd.agent.run_metadata.write.*` | `gestaltd_agent_run_metadata_write_count_total`, `gestaltd_agent_run_metadata_write_error_count_total`, `gestaltd_agent_run_metadata_write_duration_seconds` | Platform writes that map provider-owned turns back to caller authorization metadata |
+
+These metric families use low-cardinality attributes:
+
+- `gestalt.agent.operation` identifies the agent operation or provider method.
+- `gestalt.agent.provider` identifies the configured agent provider on
+  provider-bound and run-metadata metric families.
+- `gestalt.agent.tool.source` identifies tool binding mode for tool resolution:
+  `explicit` or `inherit_invokes`.
+
+Agent HTTP requests also form trace trees when OTLP tracing is enabled. A
+typical `POST /api/v1/agent/sessions/{id}/turns` trace contains
+`agent.operation`, `agent.tool.resolve`, `catalog.operation.resolve`,
+`agent.run_metadata.write`, and `agent.provider.operation` spans under the
+inbound HTTP server span.
+
+### Authorization Provider Metrics
+
+Authorization provider metrics cover both direct provider interface calls and
+provider-backed human-access evaluation performed by `gestaltd`.
+
+| OpenTelemetry family | Prometheus families | Meaning |
+| --- | --- | --- |
+| `gestaltd.authorization.provider.operation.*` | `gestaltd_authorization_provider_operation_count_total`, `gestaltd_authorization_provider_operation_error_count_total`, `gestaltd_authorization_provider_operation_duration_seconds` | Calls to the configured authorization provider interface |
+| `gestaltd.authorization.provider.evaluate.*` | `gestaltd_authorization_provider_evaluate_count_total`, `gestaltd_authorization_provider_evaluate_error_count_total`, `gestaltd_authorization_provider_evaluate_duration_seconds` | Batched authorization evaluations used by provider-backed human-access checks |
+
+These metrics carry low-cardinality attributes:
+
+- `gestalt.authorization.provider` identifies the configured authorization
+  provider.
+- `gestalt.authorization.operation` identifies the provider method for
+  `gestaltd.authorization.provider.operation.*`.
+- `gestalt.authorization.scope` identifies the resource type for
+  provider-backed evaluation, such as `integration` or `operation`.
+
+### Credential And Catalog Resolution Metrics
+
+Credential and catalog resolution metrics make the pre-invocation and agent
+tool paths visible before work reaches a plugin provider.
+
+| OpenTelemetry family | Prometheus families | Meaning |
+| --- | --- | --- |
+| `gestaltd.credential.provider.operation.*` | `gestaltd_credential_provider_operation_count_total`, `gestaltd_credential_provider_operation_error_count_total`, `gestaltd_credential_provider_operation_duration_seconds` | Calls to the configured external credential provider |
+| `gestaltd.credential.binding.resolve.*` | `gestaltd_credential_binding_resolve_count_total`, `gestaltd_credential_binding_resolve_error_count_total`, `gestaltd_credential_binding_resolve_duration_seconds` | Runtime credential binding selection |
+| `gestaltd.credential.token.resolve.*` | `gestaltd_credential_token_resolve_count_total`, `gestaltd_credential_token_resolve_error_count_total`, `gestaltd_credential_token_resolve_duration_seconds` | Token lookup for a resolved binding |
+| `gestaltd.catalog.operation.resolve.*` | `gestaltd_catalog_operation_resolve_count_total`, `gestaltd_catalog_operation_resolve_error_count_total`, `gestaltd_catalog_operation_resolve_duration_seconds` | Static or session-catalog operation resolution |
+
+These metrics carry low-cardinality attributes:
+
+- `gestalt.credential.provider` identifies the configured credential provider.
+- `gestalt.credential.operation` identifies the credential provider method.
+- `gestalt.credential.binding_mode` is `effective` or `requested`.
+- `gestalt.provider` identifies the plugin provider when the path has resolved
+  one.
+- `gestalt.operation` identifies the plugin operation for catalog operation
+  resolution.
+- `gestalt.catalog.source` is attached to catalog resolution spans and records
+  whether the resolved operation came from `static`, `session`, or a
+  pre-resolved `context` operation.
+
 ### IndexedDB Metrics
 
 These metrics are recorded around every ObjectStore and Index operation on the
@@ -309,6 +382,9 @@ need actor, target, and outcome details.
 | Connection auth start and completion | Yes: `gestaltd.connection.auth.*` | Yes | Covers OAuth start and completion plus manual connect completion. |
 | Connection credential refresh | Yes: `gestaltd.connection.auth.*` with `action=refresh` | No | Refresh is system maintenance behavior, not a user-facing audit event. |
 | Credentialed HTTP catalog discovery | Yes: `gestaltd.discovery.*` with `action=list_operations` | No | Operation listing stays metrics-only even when it resolves session catalogs. |
+| Agent lifecycle and provider calls | Yes: `gestaltd.agent.*` | No | Audit the user-facing invocation or workflow that created the agent work, not every provider poll or state read. |
+| Authorization provider calls | Yes: `gestaltd.authorization.*` | No | Provider interface calls are platform internals; explicit authorization-denied decisions are audited at the guarded action boundary. |
+| Credential and catalog resolution | Yes: `gestaltd.credential.*` and `gestaltd.catalog.*` | No | These are pre-invocation plumbing paths; audit the higher-level action instead. |
 | IndexedDB operations | Yes: `gestaltd.indexeddb.*` | No | Audit the higher-level user action instead of low-level storage calls. |
 | API token inventory read | No dedicated semantic metric family | Yes | `api_token.list` is audited because it exposes stored API-token inventory. |
 | API token lifecycle | No dedicated semantic metric family | Yes | `api_token.create`, `api_token.revoke`, and `api_token.revoke_all` are audited. |

--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -19,8 +19,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/observability"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 var (
@@ -136,7 +138,22 @@ func (m *Manager) Available() bool {
 	return len(m.agent.ProviderNames()) > 0
 }
 
-func (m *Manager) ResolveTools(ctx context.Context, p *principal.Principal, req coreagent.ResolveToolsRequest) ([]coreagent.Tool, error) {
+func startAgentOperation(ctx context.Context, operation string) (context.Context, func(error)) {
+	startedAt := time.Now()
+	attrs := []attribute.KeyValue{
+		observability.AttrAgentOperation.String(operation),
+	}
+	ctx, span := observability.StartSpan(ctx, "agent.operation", attrs...)
+	return ctx, func(err error) {
+		observability.EndSpan(span, err)
+		observability.RecordAgentOperation(ctx, startedAt, err != nil, attrs...)
+	}
+}
+
+func (m *Manager) ResolveTools(ctx context.Context, p *principal.Principal, req coreagent.ResolveToolsRequest) (tools []coreagent.Tool, err error) {
+	ctx, finish := startAgentOperation(ctx, "resolve_tools")
+	defer func() { finish(err) }()
+
 	p = principal.Canonicalized(p)
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
 		return nil, ErrAgentSubjectRequired
@@ -144,7 +161,10 @@ func (m *Manager) ResolveTools(ctx context.Context, p *principal.Principal, req 
 	return m.resolveTools(ctx, p, strings.TrimSpace(req.CallerPluginName), req.ToolRefs, req.ToolSource)
 }
 
-func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req coreagent.ManagerCreateSessionRequest) (*coreagent.Session, error) {
+func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req coreagent.ManagerCreateSessionRequest) (session *coreagent.Session, err error) {
+	ctx, finish := startAgentOperation(ctx, "create_session")
+	defer func() { finish(err) }()
+
 	p = principal.Canonicalized(p)
 	if m == nil || m.sessionMetadata == nil {
 		return nil, ErrAgentSessionMetadataNotConfigured
@@ -157,6 +177,7 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 	if err != nil {
 		return nil, err
 	}
+	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(providerName))
 	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
 	sessionID := uuid.NewString()
 	if idempotencyKey != "" {
@@ -191,7 +212,7 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 			sessionID = uuid.NewString()
 		}
 	}
-	session, err := provider.CreateSession(ctx, coreagent.CreateSessionRequest{
+	session, err = provider.CreateSession(ctx, coreagent.CreateSessionRequest{
 		SessionID:       sessionID,
 		IdempotencyKey:  idempotencyKey,
 		Model:           strings.TrimSpace(req.Model),
@@ -232,21 +253,31 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 	return normalized, nil
 }
 
-func (m *Manager) GetSession(ctx context.Context, p *principal.Principal, sessionID string) (*coreagent.Session, error) {
+func (m *Manager) GetSession(ctx context.Context, p *principal.Principal, sessionID string) (session *coreagent.Session, err error) {
+	ctx, finish := startAgentOperation(ctx, "get_session")
+	defer func() { finish(err) }()
+
 	ref, err := m.requireOwnedSessionMetadata(ctx, sessionID, p)
 	if err != nil {
 		return nil, err
 	}
+	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ref.ProviderName))
 	return m.getSessionByMetadata(ctx, p, ref)
 }
 
-func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, providerName string) ([]*coreagent.Session, error) {
+func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, providerName string) (sessions []*coreagent.Session, err error) {
+	ctx, finish := startAgentOperation(ctx, "list_sessions")
+	defer func() { finish(err) }()
+
 	refs, err := m.listOwnedSessionMetadata(ctx, p)
 	if err != nil {
 		return nil, err
 	}
 	refsByProvider := sessionRefsByProvider(refs)
 	providerName = strings.TrimSpace(providerName)
+	if providerName != "" {
+		observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(providerName))
+	}
 	if providerName != "" {
 		if providerRefs, ok := refsByProvider[providerName]; ok {
 			refsByProvider = map[string][]*coreagent.SessionReference{providerName: providerRefs}
@@ -293,16 +324,20 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, prov
 	return out, nil
 }
 
-func (m *Manager) UpdateSession(ctx context.Context, p *principal.Principal, req coreagent.ManagerUpdateSessionRequest) (*coreagent.Session, error) {
+func (m *Manager) UpdateSession(ctx context.Context, p *principal.Principal, req coreagent.ManagerUpdateSessionRequest) (session *coreagent.Session, err error) {
+	ctx, finish := startAgentOperation(ctx, "update_session")
+	defer func() { finish(err) }()
+
 	ref, err := m.requireOwnedSessionMetadata(ctx, req.SessionID, p)
 	if err != nil {
 		return nil, err
 	}
+	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ref.ProviderName))
 	provider, err := m.resolveProviderByName(ref.ProviderName)
 	if err != nil {
 		return nil, err
 	}
-	session, err := provider.UpdateSession(ctx, coreagent.UpdateSessionRequest{
+	session, err = provider.UpdateSession(ctx, coreagent.UpdateSessionRequest{
 		SessionID: strings.TrimSpace(req.SessionID),
 		ClientRef: strings.TrimSpace(req.ClientRef),
 		State:     req.State,
@@ -326,7 +361,10 @@ func (m *Manager) UpdateSession(ctx context.Context, p *principal.Principal, req
 	return normalized, nil
 }
 
-func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req coreagent.ManagerCreateTurnRequest) (*coreagent.Turn, error) {
+func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req coreagent.ManagerCreateTurnRequest) (turn *coreagent.Turn, err error) {
+	ctx, finish := startAgentOperation(ctx, "create_turn")
+	defer func() { finish(err) }()
+
 	p = principal.Canonicalized(p)
 	if m == nil || m.runMetadata == nil {
 		return nil, ErrAgentTurnMetadataNotConfigured
@@ -339,6 +377,7 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	if err != nil {
 		return nil, err
 	}
+	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(sessionRef.ProviderName))
 	provider, err := m.resolveProviderByName(sessionRef.ProviderName)
 	if err != nil {
 		return nil, err
@@ -384,7 +423,13 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 			turnID = uuid.NewString()
 		}
 	}
-	ref, err := m.runMetadata.Put(ctx, &coreagent.ExecutionReference{
+	metadataStartedAt := time.Now()
+	metadataAttrs := []attribute.KeyValue{
+		observability.AttrAgentProvider.String(sessionRef.ProviderName),
+		observability.AttrAgentOperation.String("create_turn"),
+	}
+	metadataCtx, metadataSpan := observability.StartSpan(ctx, "agent.run_metadata.write", metadataAttrs...)
+	ref, err := m.runMetadata.Put(metadataCtx, &coreagent.ExecutionReference{
 		ID:                  turnID,
 		SessionID:           sessionRef.ID,
 		ProviderName:        sessionRef.ProviderName,
@@ -394,13 +439,15 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 		Permissions:         principal.PermissionsToAccessPermissions(p.TokenPermissions),
 		Tools:               tools,
 	})
+	observability.EndSpan(metadataSpan, err)
+	observability.RecordAgentRunMetadataWrite(metadataCtx, metadataStartedAt, err != nil, metadataAttrs...)
 	if err != nil {
 		if idempotencyKey != "" {
 			_ = m.runMetadata.ReleaseIdempotency(ctx, subjectID, sessionRef.ProviderName, idempotencyKey)
 		}
 		return nil, err
 	}
-	turn, err := provider.CreateTurn(ctx, coreagent.CreateTurnRequest{
+	turn, err = provider.CreateTurn(ctx, coreagent.CreateTurnRequest{
 		TurnID:          turnID,
 		SessionID:       sessionRef.ID,
 		IdempotencyKey:  idempotencyKey,
@@ -430,24 +477,32 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	return normalized, nil
 }
 
-func (m *Manager) GetTurn(ctx context.Context, p *principal.Principal, turnID string) (*coreagent.Turn, error) {
+func (m *Manager) GetTurn(ctx context.Context, p *principal.Principal, turnID string) (turn *coreagent.Turn, err error) {
+	ctx, finish := startAgentOperation(ctx, "get_turn")
+	defer func() { finish(err) }()
+
 	ref, err := m.requireOwnedTurnMetadata(ctx, turnID, p)
 	if err != nil {
 		return nil, err
 	}
+	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ref.ProviderName))
 	return m.getTurnByMetadata(ctx, p, ref)
 }
 
-func (m *Manager) ListTurns(ctx context.Context, p *principal.Principal, sessionID string) ([]*coreagent.Turn, error) {
+func (m *Manager) ListTurns(ctx context.Context, p *principal.Principal, sessionID string) (turns []*coreagent.Turn, err error) {
+	ctx, finish := startAgentOperation(ctx, "list_turns")
+	defer func() { finish(err) }()
+
 	sessionRef, err := m.requireOwnedSessionMetadata(ctx, sessionID, p)
 	if err != nil {
 		return nil, err
 	}
+	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(sessionRef.ProviderName))
 	provider, err := m.resolveProviderByName(sessionRef.ProviderName)
 	if err != nil {
 		return nil, err
 	}
-	turns, err := provider.ListTurns(ctx, coreagent.ListTurnsRequest{SessionID: sessionRef.ID})
+	turns, err = provider.ListTurns(ctx, coreagent.ListTurnsRequest{SessionID: sessionRef.ID})
 	if err != nil {
 		return nil, err
 	}
@@ -482,16 +537,20 @@ func (m *Manager) ListTurns(ctx context.Context, p *principal.Principal, session
 	return out, nil
 }
 
-func (m *Manager) CancelTurn(ctx context.Context, p *principal.Principal, turnID, reason string) (*coreagent.Turn, error) {
+func (m *Manager) CancelTurn(ctx context.Context, p *principal.Principal, turnID, reason string) (turn *coreagent.Turn, err error) {
+	ctx, finish := startAgentOperation(ctx, "cancel_turn")
+	defer func() { finish(err) }()
+
 	ref, err := m.requireOwnedTurnMetadata(ctx, turnID, p)
 	if err != nil {
 		return nil, err
 	}
+	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ref.ProviderName))
 	provider, err := m.resolveProviderByName(ref.ProviderName)
 	if err != nil {
 		return nil, err
 	}
-	turn, err := provider.CancelTurn(ctx, coreagent.CancelTurnRequest{
+	turn, err = provider.CancelTurn(ctx, coreagent.CancelTurnRequest{
 		TurnID: strings.TrimSpace(turnID),
 		Reason: strings.TrimSpace(reason),
 	})
@@ -504,11 +563,15 @@ func (m *Manager) CancelTurn(ctx context.Context, p *principal.Principal, turnID
 	return normalizeProviderTurn(ref.ProviderName, ref.SessionID, ref.ID, turn)
 }
 
-func (m *Manager) ListTurnEvents(ctx context.Context, p *principal.Principal, turnID string, afterSeq int64, limit int) ([]*coreagent.TurnEvent, error) {
+func (m *Manager) ListTurnEvents(ctx context.Context, p *principal.Principal, turnID string, afterSeq int64, limit int) (events []*coreagent.TurnEvent, err error) {
+	ctx, finish := startAgentOperation(ctx, "list_turn_events")
+	defer func() { finish(err) }()
+
 	ref, err := m.requireOwnedTurnMetadata(ctx, turnID, p)
 	if err != nil {
 		return nil, err
 	}
+	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ref.ProviderName))
 	provider, err := m.resolveProviderByName(ref.ProviderName)
 	if err != nil {
 		return nil, err
@@ -520,11 +583,15 @@ func (m *Manager) ListTurnEvents(ctx context.Context, p *principal.Principal, tu
 	})
 }
 
-func (m *Manager) ListInteractions(ctx context.Context, p *principal.Principal, turnID string) ([]*coreagent.Interaction, error) {
+func (m *Manager) ListInteractions(ctx context.Context, p *principal.Principal, turnID string) (out []*coreagent.Interaction, err error) {
+	ctx, finish := startAgentOperation(ctx, "list_interactions")
+	defer func() { finish(err) }()
+
 	ref, err := m.requireOwnedTurnMetadata(ctx, turnID, p)
 	if err != nil {
 		return nil, err
 	}
+	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ref.ProviderName))
 	provider, err := m.resolveProviderByName(ref.ProviderName)
 	if err != nil {
 		return nil, err
@@ -533,7 +600,7 @@ func (m *Manager) ListInteractions(ctx context.Context, p *principal.Principal, 
 	if err != nil {
 		return nil, err
 	}
-	out := make([]*coreagent.Interaction, 0, len(interactions))
+	out = make([]*coreagent.Interaction, 0, len(interactions))
 	for _, interaction := range interactions {
 		if interaction == nil {
 			continue
@@ -549,11 +616,15 @@ func (m *Manager) ListInteractions(ctx context.Context, p *principal.Principal, 
 	return out, nil
 }
 
-func (m *Manager) ResolveInteraction(ctx context.Context, p *principal.Principal, turnID, interactionID string, resolution map[string]any) (*coreagent.Interaction, error) {
+func (m *Manager) ResolveInteraction(ctx context.Context, p *principal.Principal, turnID, interactionID string, resolution map[string]any) (interaction *coreagent.Interaction, err error) {
+	ctx, finish := startAgentOperation(ctx, "resolve_interaction")
+	defer func() { finish(err) }()
+
 	ref, err := m.requireOwnedTurnMetadata(ctx, turnID, p)
 	if err != nil {
 		return nil, err
 	}
+	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ref.ProviderName))
 	interactionID = strings.TrimSpace(interactionID)
 	if interactionID == "" {
 		return nil, ErrAgentInteractionRequired
@@ -562,7 +633,7 @@ func (m *Manager) ResolveInteraction(ctx context.Context, p *principal.Principal
 	if err != nil {
 		return nil, err
 	}
-	interaction, err := provider.ResolveInteraction(ctx, coreagent.ResolveInteractionRequest{
+	interaction, err = provider.ResolveInteraction(ctx, coreagent.ResolveInteractionRequest{
 		InteractionID: interactionID,
 		Resolution:    maps.Clone(resolution),
 	})
@@ -727,7 +798,21 @@ func (m *Manager) requireOwnedTurnMetadata(ctx context.Context, turnID string, p
 	return ref, nil
 }
 
-func (m *Manager) resolveTools(ctx context.Context, p *principal.Principal, callerPluginName string, explicit []coreagent.ToolRef, source coreagent.ToolSourceMode) ([]coreagent.Tool, error) {
+func (m *Manager) resolveTools(ctx context.Context, p *principal.Principal, callerPluginName string, explicit []coreagent.ToolRef, source coreagent.ToolSourceMode) (tools []coreagent.Tool, err error) {
+	startedAt := time.Now()
+	toolSource := string(source)
+	if strings.TrimSpace(toolSource) == "" {
+		toolSource = string(coreagent.ToolSourceModeExplicit)
+	}
+	attrs := []attribute.KeyValue{
+		observability.AttrAgentToolSource.String(toolSource),
+	}
+	ctx, span := observability.StartSpan(ctx, "agent.tool.resolve", attrs...)
+	defer func() {
+		observability.EndSpan(span, err)
+		observability.RecordAgentToolResolve(ctx, startedAt, err != nil, attrs...)
+	}()
+
 	refs := make([]coreagent.ToolRef, 0, len(explicit)+4)
 	refs = append(refs, explicit...)
 	if source == coreagent.ToolSourceModeInheritInvokes {
@@ -795,7 +880,7 @@ func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref c
 	}
 	boundCredential := invocation.CredentialBindingResolution{}
 	if bindingResolver, ok := m.invoker.(invocation.EffectiveCredentialBindingResolver); ok {
-		boundCredential, err = bindingResolver.ResolveEffectiveCredentialBinding(p, pluginName, connection, instance)
+		boundCredential, err = bindingResolver.ResolveEffectiveCredentialBinding(ctx, p, pluginName, connection, instance)
 		if err != nil {
 			return coreagent.Tool{}, err
 		}

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/observability"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type providerBackedRoleState struct {
@@ -495,7 +497,15 @@ func (a *ProviderBackedAuthorizer) resolveRoleVariants(ctx context.Context, subj
 				Resource: resource,
 			})
 		}
-		resp, err := a.provider.EvaluateMany(ctx, &core.AccessEvaluationsRequest{Requests: reqs})
+		startedAt := time.Now()
+		attrs := []attribute.KeyValue{
+			observability.AttrAuthorizationProvider.String(observability.AuthorizationProviderMetricName(a.provider)),
+			observability.AttrAuthorizationScope.String(resourceType),
+		}
+		evalCtx, span := observability.StartSpan(ctx, "authorization.provider.evaluate", attrs...)
+		resp, err := a.provider.EvaluateMany(evalCtx, &core.AccessEvaluationsRequest{Requests: reqs})
+		observability.EndSpan(span, err)
+		observability.RecordAuthorizationProviderEvaluate(evalCtx, startedAt, err != nil, attrs...)
 		if err != nil {
 			return "", false, err
 		}

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -18,7 +18,9 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/observability"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type agentRuntime struct {
@@ -131,7 +133,13 @@ func (r *agentRuntime) TrackTurn(ctx context.Context, providerName string, req c
 		}
 		return fmt.Errorf("%w: agent execution principal is required", invocation.ErrInternal)
 	}
-	_, err := runMetadata.Put(ctx, &coreagent.ExecutionReference{
+	startedAt := time.Now()
+	attrs := []attribute.KeyValue{
+		observability.AttrAgentProvider.String(strings.TrimSpace(providerName)),
+		observability.AttrAgentOperation.String("track_turn"),
+	}
+	metadataCtx, span := observability.StartSpan(ctx, "agent.run_metadata.write", attrs...)
+	_, err := runMetadata.Put(metadataCtx, &coreagent.ExecutionReference{
 		ID:                  turnID,
 		SessionID:           strings.TrimSpace(req.SessionID),
 		ProviderName:        strings.TrimSpace(providerName),
@@ -141,6 +149,8 @@ func (r *agentRuntime) TrackTurn(ctx context.Context, providerName string, req c
 		Permissions:         permissionsForAgentTools(req.Tools),
 		Tools:               append([]coreagent.Tool(nil), req.Tools...),
 	})
+	observability.EndSpan(span, err)
+	observability.RecordAgentRunMetadataWrite(metadataCtx, startedAt, err != nil, attrs...)
 	return err
 }
 

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -947,9 +947,13 @@ func hostedAgentProviderPoolForTest(t *testing.T, provider coreagent.Provider) *
 	if !ok {
 		t.Fatalf("agent provider type = %T, want *agentProviderWithTracking", provider)
 	}
-	pool, ok := tracked.delegate.(*hostedAgentProviderPool)
+	delegate := tracked.delegate
+	if wrapper, ok := delegate.(interface{ Unwrap() coreagent.Provider }); ok {
+		delegate = wrapper.Unwrap()
+	}
+	pool, ok := delegate.(*hostedAgentProviderPool)
 	if !ok {
-		t.Fatalf("tracked delegate type = %T, want *hostedAgentProviderPool", tracked.delegate)
+		t.Fatalf("tracked delegate type = %T, want *hostedAgentProviderPool", delegate)
 	}
 	return pool
 }

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -27,6 +27,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
+	"github.com/valon-technologies/gestalt/server/internal/observability"
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
@@ -1367,7 +1368,7 @@ func buildNamedExternalCredentialsProvider(ctx context.Context, name string, ent
 	if coredata.ExternalCredentialProviderMissing(provider) {
 		return nil, fmt.Errorf("bootstrap: external credentials provider %q returned nil", logicalName)
 	}
-	return provider, nil
+	return observability.InstrumentExternalCredentialProvider(logicalName, provider), nil
 }
 
 func defaultExternalCredentialsProviderEntry() *config.ProviderEntry {
@@ -1536,7 +1537,7 @@ func buildNamedAuthProvider(name string, authEntry *config.ProviderEntry, factor
 }
 
 func buildAuthorization(cfg *config.Config, factories *FactoryRegistry, deps Deps) (core.AuthorizationProvider, error) {
-	_, authzEntry, err := cfg.SelectedAuthorizationProvider()
+	authzName, authzEntry, err := cfg.SelectedAuthorizationProvider()
 	if err != nil {
 		return nil, err
 	}
@@ -1559,7 +1560,7 @@ func buildAuthorization(cfg *config.Config, factories *FactoryRegistry, deps Dep
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: authorization provider: %w", err)
 	}
-	return provider, nil
+	return observability.InstrumentAuthorizationProvider(authzName, provider), nil
 }
 
 func buildIndexedDB(entry *config.ProviderEntry, factories *FactoryRegistry) (indexeddb.IndexedDB, error) {
@@ -1772,6 +1773,7 @@ func buildAgent(ctx context.Context, name string, entry *config.ProviderEntry, f
 	if providerErr != nil {
 		return nil, fmt.Errorf("agent provider: %w", providerErr)
 	}
+	provider = observability.InstrumentAgentProvider(name, provider)
 	tracked := &agentProviderWithTracking{
 		delegate:     provider,
 		providerName: name,

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -38,8 +38,10 @@ import (
 	telemetrynoop "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/noop"
 	graphqlschema "github.com/valon-technologies/gestalt/server/internal/graphql"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1628,6 +1630,64 @@ func transportSecretRef(name string) string {
 	return config.EncodeSecretRefTransport(config.SecretRef{
 		Provider: "default",
 		Name:     name,
+	})
+}
+
+func TestBootstrapProviderBoundaryMetrics(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.ExternalCredentials = map[string]*config.ProviderEntry{
+		"remote-creds": {Source: config.ProviderSource{Path: "stub"}},
+	}
+	cfg.Server.Providers.ExternalCredentials = "remote-creds"
+	cfg.Providers.Authorization = map[string]*config.ProviderEntry{
+		"remote-authz": {Source: config.ProviderSource{Path: "stub"}},
+	}
+	cfg.Server.Providers.Authorization = "remote-authz"
+
+	factories := validFactories()
+	factories.Authorization = stubAuthorizationFactory("authorization-provider")
+	metrics := metrictest.NewManualMeterProvider(t)
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := result.Close(context.Background()); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+	<-result.ProvidersReady
+
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+	if err := result.Services.ExternalCredentials.PutCredential(ctx, &core.IntegrationToken{
+		SubjectID:   principal.UserSubjectID("metrics-user"),
+		Integration: "slack",
+		Connection:  "default",
+		Instance:    "default",
+		AccessToken: "tok_metrics",
+	}); err != nil {
+		t.Fatalf("PutCredential: %v", err)
+	}
+	if _, err := result.AuthorizationProvider.Evaluate(ctx, &core.AccessEvaluationRequest{
+		Subject:  &core.SubjectRef{Type: "user", Id: "metrics-user"},
+		Action:   &core.ActionRef{Name: "read"},
+		Resource: &core.ResourceRef{Type: "integration", Id: "slack"},
+	}); err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.credential.provider.operation.count", 1, map[string]string{
+		"gestalt.credential.provider":  "remote-creds",
+		"gestalt.credential.operation": "put_credential",
+		"gestalt.provider":             "slack",
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.authorization.provider.operation.count", 1, map[string]string{
+		"gestalt.authorization.provider":  "remote-authz",
+		"gestalt.authorization.operation": "evaluate",
 	})
 }
 

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -241,7 +241,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	ctx = withResolvedPrincipal(ctx, p)
 	setSubjectAttribute(p)
 	conn := ConnectionFromContext(ctx)
-	boundCredential, err := b.ResolveEffectiveCredentialBinding(p, providerName, conn, instance)
+	boundCredential, err := b.ResolveEffectiveCredentialBinding(ctx, p, providerName, conn, instance)
 	if err != nil {
 		return fail(err)
 	}
@@ -427,7 +427,7 @@ func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, prov
 	setSubjectAttribute(p)
 
 	conn := ConnectionFromContext(ctx)
-	boundCredential, err := b.ResolveEffectiveCredentialBinding(p, providerName, conn, instance)
+	boundCredential, err := b.ResolveEffectiveCredentialBinding(ctx, p, providerName, conn, instance)
 	if err != nil {
 		return fail(err)
 	}
@@ -500,12 +500,12 @@ func (b *Broker) MCPConnection(providerName string) string {
 	return b.mcpConnection(providerName)
 }
 
-func (b *Broker) ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
-	return ResolveEffectiveCredentialBinding(b.authorizer, p, providerName, connection, instance)
+func (b *Broker) ResolveEffectiveCredentialBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
+	return ResolveEffectiveCredentialBinding(ctx, b.authorizer, p, providerName, connection, instance)
 }
 
-func (b *Broker) ResolveRequestedCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
-	return ResolveRequestedCredentialBinding(b.authorizer, p, providerName, connection, instance)
+func (b *Broker) ResolveRequestedCredentialBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
+	return ResolveRequestedCredentialBinding(ctx, b.authorizer, p, providerName, connection, instance)
 }
 
 func toolResultToOperationResult(result *mcpgo.CallToolResult) (*core.OperationResult, error) {
@@ -572,7 +572,7 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 		}
 		return ctx, "", fmt.Errorf("%w: looking up provider: %v", ErrInternal, err)
 	}
-	boundCredential, err := b.ResolveRequestedCredentialBinding(p, providerName, connection, instance)
+	boundCredential, err := b.ResolveRequestedCredentialBinding(ctx, p, providerName, connection, instance)
 	if err != nil {
 		return ctx, "", err
 	}
@@ -607,7 +607,7 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 	}
 	if !boundCredential.HasBinding {
 		var err error
-		boundCredential, err = b.ResolveEffectiveCredentialBinding(p, providerName, connection, instance)
+		boundCredential, err = b.ResolveEffectiveCredentialBinding(ctx, p, providerName, connection, instance)
 		if err != nil {
 			return ctx, "", err
 		}

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -5,12 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/observability"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type TokenResolver interface {
@@ -82,8 +86,28 @@ func ResolveCatalogForTargetsWithMetadata(ctx context.Context, prov core.Provide
 	}, firstErr
 }
 
-func ResolveOperation(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, operation string, sessionConnections []string, instance string) (catalog.CatalogOperation, string, string, error) {
+func ResolveOperation(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, operation string, sessionConnections []string, instance string) (op catalog.CatalogOperation, transport string, resolvedConnection string, err error) {
+	startedAt := time.Now()
+	baseAttrs := []attribute.KeyValue{
+		attribute.String("gestalt.provider", provName),
+	}
+	ctx, span := observability.StartSpan(ctx, "catalog.operation.resolve", baseAttrs...)
+	catalogSource := ""
+	defer func() {
+		metricOperation := catalogOperationMetricValue(op.ID)
+		metricAttrs := append([]attribute.KeyValue{}, baseAttrs...)
+		metricAttrs = append(metricAttrs, attribute.String("gestalt.operation", metricOperation))
+		spanAttrs := append([]attribute.KeyValue{}, metricAttrs...)
+		if catalogSource != "" {
+			spanAttrs = append(spanAttrs, observability.AttrCatalogSource.String(catalogSource))
+		}
+		observability.SetSpanAttributes(ctx, spanAttrs...)
+		observability.EndSpan(span, err)
+		observability.RecordCatalogOperationResolve(ctx, startedAt, err != nil, metricAttrs...)
+	}()
+
 	if op, ok := CatalogOperationFromContext(ctx, provName, operation); ok {
+		catalogSource = "context"
 		return op, OperationTransport(op), "", nil
 	}
 
@@ -91,12 +115,14 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 	if staticOK {
 		if resolver, ok := prov.(requestStaticOperationResolver); ok {
 			if op, ok := resolver.ResolveStaticOperationForRequest(ctx, operation); ok {
+				catalogSource = "static"
 				return op, OperationTransport(op), "", nil
 			}
 		}
 	}
 	if !core.SupportsSessionCatalog(prov) {
 		if staticOK {
+			catalogSource = "static"
 			return staticOp, OperationTransport(staticOp), "", nil
 		}
 		return catalog.CatalogOperation{}, "", "", fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, provName)
@@ -105,17 +131,27 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 	sessionOp, sessionConnection, sessionFound, err := resolveSessionOperation(ctx, prov, provName, resolver, p, operation, sessionConnections, instance)
 	if err != nil {
 		if staticOK && sessionCatalogUnsupported(err) {
+			catalogSource = "static"
 			return staticOp, OperationTransport(staticOp), "", nil
 		}
 		return catalog.CatalogOperation{}, "", "", err
 	}
 	if sessionFound {
+		catalogSource = "session"
 		return sessionOp, OperationTransport(sessionOp), sessionConnection, nil
 	}
 	if instance == "" && staticOK {
+		catalogSource = "static"
 		return staticOp, OperationTransport(staticOp), "", nil
 	}
 	return catalog.CatalogOperation{}, "", "", fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, provName)
+}
+
+func catalogOperationMetricValue(operation string) string {
+	if operation = strings.TrimSpace(operation); operation != "" {
+		return operation
+	}
+	return "unknown"
 }
 
 func sessionCatalogUnsupported(err error) bool {
@@ -146,7 +182,7 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 	}
 	boundCredential := CredentialBindingResolution{}
 	if bindingResolver, ok := resolver.(EffectiveCredentialBindingResolver); ok && p != nil {
-		resolvedBinding, err := bindingResolver.ResolveEffectiveCredentialBinding(p, provName, connection, instance)
+		resolvedBinding, err := bindingResolver.ResolveEffectiveCredentialBinding(ctx, p, provName, connection, instance)
 		if err != nil {
 			return nil, true, err
 		}

--- a/gestaltd/internal/invocation/credential_binding.go
+++ b/gestaltd/internal/invocation/credential_binding.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/observability"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type CredentialBindingResolution struct {
@@ -19,22 +22,37 @@ type CredentialBindingResolution struct {
 }
 
 type EffectiveCredentialBindingResolver interface {
-	ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error)
+	ResolveEffectiveCredentialBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error)
 }
 
 type BindingTokenResolver interface {
 	ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error)
 }
 
-func ResolveEffectiveCredentialBinding(authz authorization.RuntimeAuthorizer, p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
-	return resolveCredentialBinding(authz, p, providerName, connection, instance, false)
+func ResolveEffectiveCredentialBinding(ctx context.Context, authz authorization.RuntimeAuthorizer, p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
+	return resolveCredentialBinding(ctx, authz, p, providerName, connection, instance, false)
 }
 
-func ResolveRequestedCredentialBinding(authz authorization.RuntimeAuthorizer, p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
-	return resolveCredentialBinding(authz, p, providerName, connection, instance, true)
+func ResolveRequestedCredentialBinding(ctx context.Context, authz authorization.RuntimeAuthorizer, p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
+	return resolveCredentialBinding(ctx, authz, p, providerName, connection, instance, true)
 }
 
-func resolveCredentialBinding(authz authorization.RuntimeAuthorizer, p *principal.Principal, providerName, connection, instance string, enforceRequested bool) (CredentialBindingResolution, error) {
+func resolveCredentialBinding(ctx context.Context, authz authorization.RuntimeAuthorizer, p *principal.Principal, providerName, connection, instance string, enforceRequested bool) (result CredentialBindingResolution, err error) {
+	startedAt := time.Now()
+	mode := "effective"
+	if enforceRequested {
+		mode = "requested"
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("gestalt.provider", strings.TrimSpace(providerName)),
+		attribute.String("gestalt.credential.binding_mode", mode),
+	}
+	ctx, span := observability.StartSpan(ctx, "credential.binding.resolve", attrs...)
+	defer func() {
+		observability.EndSpan(span, err)
+		observability.RecordCredentialBindingResolve(ctx, startedAt, err != nil, attrs...)
+	}()
+
 	if authz == nil || p == nil {
 		return CredentialBindingResolution{}, nil
 	}
@@ -93,13 +111,29 @@ func bindingSelectorOverrideError() error {
 }
 
 func ResolveTokenForBinding(ctx context.Context, resolver TokenResolver, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error) {
+	startedAt := time.Now()
+	attrs := []attribute.KeyValue{
+		attribute.String("gestalt.provider", strings.TrimSpace(providerName)),
+	}
+	ctx, span := observability.StartSpan(ctx, "credential.token.resolve", attrs...)
+	var err error
+	defer func() {
+		observability.EndSpan(span, err)
+		observability.RecordCredentialTokenResolve(ctx, startedAt, err != nil, attrs...)
+	}()
+
 	if resolver == nil {
-		return ctx, "", fmt.Errorf("token resolution not supported")
+		err = fmt.Errorf("token resolution not supported")
+		return ctx, "", err
 	}
 	if boundCredential.HasBinding {
 		if bindingResolver, ok := resolver.(BindingTokenResolver); ok {
-			return bindingResolver.ResolveTokenWithBinding(ctx, p, providerName, connection, instance, boundCredential)
+			var token string
+			ctx, token, err = bindingResolver.ResolveTokenWithBinding(ctx, p, providerName, connection, instance, boundCredential)
+			return ctx, token, err
 		}
 	}
-	return resolver.ResolveToken(ctx, p, providerName, connection, instance)
+	var token string
+	ctx, token, err = resolver.ResolveToken(ctx, p, providerName, connection, instance)
+	return ctx, token, err
 }

--- a/gestaltd/internal/invocation/guarded.go
+++ b/gestaltd/internal/invocation/guarded.go
@@ -236,9 +236,9 @@ func (g *GuardedInvoker) ResolveSubjectToken(ctx context.Context, prov core.Prov
 	return ctx, "", fmt.Errorf("subject token resolution not supported")
 }
 
-func (g *GuardedInvoker) ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
+func (g *GuardedInvoker) ResolveEffectiveCredentialBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
 	if r, ok := g.inner.(EffectiveCredentialBindingResolver); ok {
-		return r.ResolveEffectiveCredentialBinding(p, providerName, connection, instance)
+		return r.ResolveEffectiveCredentialBinding(ctx, p, providerName, connection, instance)
 	}
 	return CredentialBindingResolution{}, nil
 }

--- a/gestaltd/internal/mcp/binding.go
+++ b/gestaltd/internal/mcp/binding.go
@@ -84,7 +84,7 @@ func NewServer(cfg Config) *mcpserver.MCPServer {
 		hooks.AddBeforeCallTool(func(ctx context.Context, _ any, req *mcpgo.CallToolRequest) {
 			if provName := providerNameForTool(cfg.ToolPrefixes, dynamicProviders, req.Params.Name); provName != "" {
 				instance := normalizedSessionCatalogInstance(req.GetArguments()["_instance"])
-				if workloadInstanceOverrideRequested(cfg.Authorizer, principal.FromContext(ctx), provName, instance) {
+				if workloadInstanceOverrideRequested(ctx, cfg.Authorizer, principal.FromContext(ctx), provName, instance) {
 					return
 				}
 				hydrateSessionToolsForInstance(ctx, cfg, []string{provName}, staticToolNames, instance)

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -23,7 +23,7 @@ func makeHandler(cfg Config, provName, opName, connection string) mcpserver.Tool
 
 		rawArgs := req.GetArguments()
 		instance := normalizedSessionCatalogInstance(rawArgs["_instance"])
-		if workloadInstanceOverrideRequested(cfg.Authorizer, p, provName, instance) {
+		if workloadInstanceOverrideRequested(ctx, cfg.Authorizer, p, provName, instance) {
 			return mcpgo.NewToolResultError("workload callers may not override connection or instance bindings"), nil
 		}
 		args := make(map[string]any, len(rawArgs))

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -114,7 +114,7 @@ func resolveSessionToken(ctx context.Context, cfg Config, provName string, prov 
 		if cfg.TokenResolver != nil {
 			p := principal.FromContext(ctx)
 			if p != nil {
-				connection, instance, boundCredential, err := sessionTokenSelectors(cfg, p, provName, instanceOverride)
+				connection, instance, boundCredential, err := sessionTokenSelectors(ctx, cfg, p, provName, instanceOverride)
 				if err != nil {
 					return ctx, "", connection, err
 				}
@@ -134,7 +134,7 @@ func resolveSessionToken(ctx context.Context, cfg Config, provName string, prov 
 	if p == nil {
 		return ctx, "", "", fmt.Errorf("not authenticated")
 	}
-	connection, instance, boundCredential, err := sessionTokenSelectors(cfg, p, provName, instanceOverride)
+	connection, instance, boundCredential, err := sessionTokenSelectors(ctx, cfg, p, provName, instanceOverride)
 	if err != nil {
 		return ctx, "", connection, err
 	}
@@ -392,10 +392,10 @@ func internalSessionToolHandler(context.Context, mcpgo.CallToolRequest) (*mcpgo.
 	return mcpgo.NewToolResultError("tool not found"), nil
 }
 
-func sessionTokenSelectors(cfg Config, p *principal.Principal, provName, instanceOverride string) (string, string, invocation.CredentialBindingResolution, error) {
+func sessionTokenSelectors(ctx context.Context, cfg Config, p *principal.Principal, provName, instanceOverride string) (string, string, invocation.CredentialBindingResolution, error) {
 	connection := cfg.MCPConnection[provName]
 	instance := normalizedSessionCatalogInstance(instanceOverride)
-	boundCredential, err := invocation.ResolveEffectiveCredentialBinding(cfg.Authorizer, p, provName, connection, instance)
+	boundCredential, err := invocation.ResolveEffectiveCredentialBinding(ctx, cfg.Authorizer, p, provName, connection, instance)
 	if err != nil {
 		return connection, instance, invocation.CredentialBindingResolution{}, err
 	}
@@ -443,10 +443,10 @@ func normalizedSessionCatalogInstance(value any) string {
 	return strings.TrimSpace(instance)
 }
 
-func workloadInstanceOverrideRequested(authz authorization.RuntimeAuthorizer, p *principal.Principal, provider, instance string) bool {
+func workloadInstanceOverrideRequested(ctx context.Context, authz authorization.RuntimeAuthorizer, p *principal.Principal, provider, instance string) bool {
 	if authz == nil || p == nil || strings.TrimSpace(instance) == "" {
 		return false
 	}
-	_, err := invocation.ResolveRequestedCredentialBinding(authz, p, provider, "", instance)
+	_, err := invocation.ResolveRequestedCredentialBinding(ctx, authz, p, provider, "", instance)
 	return err != nil
 }

--- a/gestaltd/internal/observability/agent_provider.go
+++ b/gestaltd/internal/observability/agent_provider.go
@@ -1,0 +1,133 @@
+package observability
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type observedAgentProvider struct {
+	name     string
+	delegate coreagent.Provider
+}
+
+func InstrumentAgentProvider(name string, provider coreagent.Provider) coreagent.Provider {
+	if provider == nil {
+		return nil
+	}
+	if _, ok := provider.(*observedAgentProvider); ok {
+		return provider
+	}
+	return &observedAgentProvider{
+		name:     strings.TrimSpace(name),
+		delegate: provider,
+	}
+}
+
+func (p *observedAgentProvider) CreateSession(ctx context.Context, req coreagent.CreateSessionRequest) (session *coreagent.Session, err error) {
+	ctx, end := p.start(ctx, "create_session")
+	defer func() { end(err) }()
+	return p.delegate.CreateSession(ctx, req)
+}
+
+func (p *observedAgentProvider) GetSession(ctx context.Context, req coreagent.GetSessionRequest) (session *coreagent.Session, err error) {
+	ctx, end := p.start(ctx, "get_session")
+	defer func() { end(err) }()
+	return p.delegate.GetSession(ctx, req)
+}
+
+func (p *observedAgentProvider) ListSessions(ctx context.Context, req coreagent.ListSessionsRequest) (sessions []*coreagent.Session, err error) {
+	ctx, end := p.start(ctx, "list_sessions")
+	defer func() { end(err) }()
+	return p.delegate.ListSessions(ctx, req)
+}
+
+func (p *observedAgentProvider) UpdateSession(ctx context.Context, req coreagent.UpdateSessionRequest) (session *coreagent.Session, err error) {
+	ctx, end := p.start(ctx, "update_session")
+	defer func() { end(err) }()
+	return p.delegate.UpdateSession(ctx, req)
+}
+
+func (p *observedAgentProvider) CreateTurn(ctx context.Context, req coreagent.CreateTurnRequest) (turn *coreagent.Turn, err error) {
+	ctx, end := p.start(ctx, "create_turn")
+	defer func() { end(err) }()
+	return p.delegate.CreateTurn(ctx, req)
+}
+
+func (p *observedAgentProvider) GetTurn(ctx context.Context, req coreagent.GetTurnRequest) (turn *coreagent.Turn, err error) {
+	ctx, end := p.start(ctx, "get_turn")
+	defer func() { end(err) }()
+	return p.delegate.GetTurn(ctx, req)
+}
+
+func (p *observedAgentProvider) ListTurns(ctx context.Context, req coreagent.ListTurnsRequest) (turns []*coreagent.Turn, err error) {
+	ctx, end := p.start(ctx, "list_turns")
+	defer func() { end(err) }()
+	return p.delegate.ListTurns(ctx, req)
+}
+
+func (p *observedAgentProvider) CancelTurn(ctx context.Context, req coreagent.CancelTurnRequest) (turn *coreagent.Turn, err error) {
+	ctx, end := p.start(ctx, "cancel_turn")
+	defer func() { end(err) }()
+	return p.delegate.CancelTurn(ctx, req)
+}
+
+func (p *observedAgentProvider) ListTurnEvents(ctx context.Context, req coreagent.ListTurnEventsRequest) (events []*coreagent.TurnEvent, err error) {
+	ctx, end := p.start(ctx, "list_turn_events")
+	defer func() { end(err) }()
+	return p.delegate.ListTurnEvents(ctx, req)
+}
+
+func (p *observedAgentProvider) GetInteraction(ctx context.Context, req coreagent.GetInteractionRequest) (interaction *coreagent.Interaction, err error) {
+	ctx, end := p.start(ctx, "get_interaction")
+	defer func() { end(err) }()
+	return p.delegate.GetInteraction(ctx, req)
+}
+
+func (p *observedAgentProvider) ListInteractions(ctx context.Context, req coreagent.ListInteractionsRequest) (interactions []*coreagent.Interaction, err error) {
+	ctx, end := p.start(ctx, "list_interactions")
+	defer func() { end(err) }()
+	return p.delegate.ListInteractions(ctx, req)
+}
+
+func (p *observedAgentProvider) ResolveInteraction(ctx context.Context, req coreagent.ResolveInteractionRequest) (interaction *coreagent.Interaction, err error) {
+	ctx, end := p.start(ctx, "resolve_interaction")
+	defer func() { end(err) }()
+	return p.delegate.ResolveInteraction(ctx, req)
+}
+
+func (p *observedAgentProvider) GetCapabilities(ctx context.Context, req coreagent.GetCapabilitiesRequest) (caps *coreagent.ProviderCapabilities, err error) {
+	ctx, end := p.start(ctx, "get_capabilities")
+	defer func() { end(err) }()
+	return p.delegate.GetCapabilities(ctx, req)
+}
+
+func (p *observedAgentProvider) Ping(ctx context.Context) (err error) {
+	ctx, end := p.start(ctx, "ping")
+	defer func() { end(err) }()
+	return p.delegate.Ping(ctx)
+}
+
+func (p *observedAgentProvider) Close() error {
+	return p.delegate.Close()
+}
+
+func (p *observedAgentProvider) Unwrap() coreagent.Provider {
+	return p.delegate
+}
+
+func (p *observedAgentProvider) start(ctx context.Context, operation string) (context.Context, func(error)) {
+	startedAt := time.Now()
+	attrs := []attribute.KeyValue{
+		AttrAgentProvider.String(p.name),
+		AttrAgentOperation.String(operation),
+	}
+	ctx, span := StartSpan(ctx, "agent.provider.operation", attrs...)
+	return ctx, func(err error) {
+		EndSpan(span, err)
+		RecordAgentProviderOperation(ctx, startedAt, err != nil, attrs...)
+	}
+}

--- a/gestaltd/internal/observability/authorization_provider.go
+++ b/gestaltd/internal/observability/authorization_provider.go
@@ -1,0 +1,142 @@
+package observability
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type observedAuthorizationProvider struct {
+	name     string
+	delegate core.AuthorizationProvider
+}
+
+func InstrumentAuthorizationProvider(name string, provider core.AuthorizationProvider) core.AuthorizationProvider {
+	if provider == nil {
+		return nil
+	}
+	if _, ok := provider.(*observedAuthorizationProvider); ok {
+		return provider
+	}
+	return &observedAuthorizationProvider{
+		name:     strings.TrimSpace(name),
+		delegate: provider,
+	}
+}
+
+func AuthorizationProviderMetricName(provider core.AuthorizationProvider) string {
+	if provider == nil {
+		return ""
+	}
+	if observed, ok := provider.(*observedAuthorizationProvider); ok {
+		return observed.metricName()
+	}
+	return strings.TrimSpace(provider.Name())
+}
+
+func (p *observedAuthorizationProvider) Name() string {
+	return p.delegate.Name()
+}
+
+func (p *observedAuthorizationProvider) Evaluate(ctx context.Context, req *core.AccessEvaluationRequest) (decision *core.AccessDecision, err error) {
+	ctx, end := p.start(ctx, "evaluate")
+	defer func() { end(err) }()
+	return p.delegate.Evaluate(ctx, req)
+}
+
+func (p *observedAuthorizationProvider) EvaluateMany(ctx context.Context, req *core.AccessEvaluationsRequest) (resp *core.AccessEvaluationsResponse, err error) {
+	ctx, end := p.start(ctx, "evaluate_many")
+	defer func() { end(err) }()
+	return p.delegate.EvaluateMany(ctx, req)
+}
+
+func (p *observedAuthorizationProvider) SearchResources(ctx context.Context, req *core.ResourceSearchRequest) (resp *core.ResourceSearchResponse, err error) {
+	ctx, end := p.start(ctx, "search_resources")
+	defer func() { end(err) }()
+	return p.delegate.SearchResources(ctx, req)
+}
+
+func (p *observedAuthorizationProvider) SearchSubjects(ctx context.Context, req *core.SubjectSearchRequest) (resp *core.SubjectSearchResponse, err error) {
+	ctx, end := p.start(ctx, "search_subjects")
+	defer func() { end(err) }()
+	return p.delegate.SearchSubjects(ctx, req)
+}
+
+func (p *observedAuthorizationProvider) SearchActions(ctx context.Context, req *core.ActionSearchRequest) (resp *core.ActionSearchResponse, err error) {
+	ctx, end := p.start(ctx, "search_actions")
+	defer func() { end(err) }()
+	return p.delegate.SearchActions(ctx, req)
+}
+
+func (p *observedAuthorizationProvider) GetMetadata(ctx context.Context) (metadata *core.AuthorizationMetadata, err error) {
+	ctx, end := p.start(ctx, "get_metadata")
+	defer func() { end(err) }()
+	return p.delegate.GetMetadata(ctx)
+}
+
+func (p *observedAuthorizationProvider) ReadRelationships(ctx context.Context, req *core.ReadRelationshipsRequest) (resp *core.ReadRelationshipsResponse, err error) {
+	ctx, end := p.start(ctx, "read_relationships")
+	defer func() { end(err) }()
+	return p.delegate.ReadRelationships(ctx, req)
+}
+
+func (p *observedAuthorizationProvider) WriteRelationships(ctx context.Context, req *core.WriteRelationshipsRequest) (err error) {
+	ctx, end := p.start(ctx, "write_relationships")
+	defer func() { end(err) }()
+	return p.delegate.WriteRelationships(ctx, req)
+}
+
+func (p *observedAuthorizationProvider) GetActiveModel(ctx context.Context) (resp *core.GetActiveModelResponse, err error) {
+	ctx, end := p.start(ctx, "get_active_model")
+	defer func() { end(err) }()
+	return p.delegate.GetActiveModel(ctx)
+}
+
+func (p *observedAuthorizationProvider) ListModels(ctx context.Context, req *core.ListModelsRequest) (resp *core.ListModelsResponse, err error) {
+	ctx, end := p.start(ctx, "list_models")
+	defer func() { end(err) }()
+	return p.delegate.ListModels(ctx, req)
+}
+
+func (p *observedAuthorizationProvider) WriteModel(ctx context.Context, req *core.WriteModelRequest) (ref *core.AuthorizationModelRef, err error) {
+	ctx, end := p.start(ctx, "write_model")
+	defer func() { end(err) }()
+	return p.delegate.WriteModel(ctx, req)
+}
+
+func (p *observedAuthorizationProvider) Close() error {
+	closer, ok := p.delegate.(interface{ Close() error })
+	if !ok {
+		return nil
+	}
+	return closer.Close()
+}
+
+func (p *observedAuthorizationProvider) start(ctx context.Context, operation string) (context.Context, func(error)) {
+	startedAt := time.Now()
+	attrs := []attribute.KeyValue{
+		AttrAuthorizationProvider.String(p.metricName()),
+		AttrAuthorizationOperation.String(operation),
+	}
+	ctx, span := StartSpan(ctx, "authorization.provider.operation", attrs...)
+	return ctx, func(err error) {
+		EndSpan(span, err)
+		RecordAuthorizationProviderOperation(ctx, startedAt, err != nil, attrs...)
+	}
+}
+
+func (p *observedAuthorizationProvider) metricName() string {
+	if p == nil {
+		return ""
+	}
+	if name := strings.TrimSpace(p.name); name != "" {
+		return name
+	}
+	if p.delegate == nil {
+		return ""
+	}
+	return strings.TrimSpace(p.delegate.Name())
+}

--- a/gestaltd/internal/observability/external_credentials.go
+++ b/gestaltd/internal/observability/external_credentials.go
@@ -1,0 +1,101 @@
+package observability
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type observedExternalCredentialProvider struct {
+	name     string
+	delegate core.ExternalCredentialProvider
+}
+
+func InstrumentExternalCredentialProvider(name string, provider core.ExternalCredentialProvider) core.ExternalCredentialProvider {
+	if provider == nil {
+		return nil
+	}
+	if _, ok := provider.(*observedExternalCredentialProvider); ok {
+		return provider
+	}
+	return &observedExternalCredentialProvider{
+		name:     strings.TrimSpace(name),
+		delegate: provider,
+	}
+}
+
+func (p *observedExternalCredentialProvider) PutCredential(ctx context.Context, credential *core.ExternalCredential) (err error) {
+	ctx, end := p.start(ctx, "put_credential", credentialIntegration(credential))
+	defer func() { end(err) }()
+	return p.delegate.PutCredential(ctx, credential)
+}
+
+func (p *observedExternalCredentialProvider) RestoreCredential(ctx context.Context, credential *core.ExternalCredential) (err error) {
+	ctx, end := p.start(ctx, "restore_credential", credentialIntegration(credential))
+	defer func() { end(err) }()
+	return p.delegate.RestoreCredential(ctx, credential)
+}
+
+func (p *observedExternalCredentialProvider) GetCredential(ctx context.Context, subjectID, integration, connection, instance string) (credential *core.ExternalCredential, err error) {
+	ctx, end := p.start(ctx, "get_credential", integration)
+	defer func() { end(err) }()
+	return p.delegate.GetCredential(ctx, subjectID, integration, connection, instance)
+}
+
+func (p *observedExternalCredentialProvider) ListCredentials(ctx context.Context, subjectID string) (credentials []*core.ExternalCredential, err error) {
+	ctx, end := p.start(ctx, "list_credentials", "")
+	defer func() { end(err) }()
+	return p.delegate.ListCredentials(ctx, subjectID)
+}
+
+func (p *observedExternalCredentialProvider) ListCredentialsForProvider(ctx context.Context, subjectID, integration string) (credentials []*core.ExternalCredential, err error) {
+	ctx, end := p.start(ctx, "list_credentials_for_provider", integration)
+	defer func() { end(err) }()
+	return p.delegate.ListCredentialsForProvider(ctx, subjectID, integration)
+}
+
+func (p *observedExternalCredentialProvider) ListCredentialsForConnection(ctx context.Context, subjectID, integration, connection string) (credentials []*core.ExternalCredential, err error) {
+	ctx, end := p.start(ctx, "list_credentials_for_connection", integration)
+	defer func() { end(err) }()
+	return p.delegate.ListCredentialsForConnection(ctx, subjectID, integration, connection)
+}
+
+func (p *observedExternalCredentialProvider) DeleteCredential(ctx context.Context, id string) (err error) {
+	ctx, end := p.start(ctx, "delete_credential", "")
+	defer func() { end(err) }()
+	return p.delegate.DeleteCredential(ctx, id)
+}
+
+func (p *observedExternalCredentialProvider) Close() error {
+	closer, ok := p.delegate.(interface{ Close() error })
+	if !ok {
+		return nil
+	}
+	return closer.Close()
+}
+
+func (p *observedExternalCredentialProvider) start(ctx context.Context, operation string, integration string) (context.Context, func(error)) {
+	startedAt := time.Now()
+	attrs := []attribute.KeyValue{
+		AttrCredentialProvider.String(p.name),
+		AttrCredentialOperation.String(operation),
+	}
+	if strings.TrimSpace(integration) != "" {
+		attrs = append(attrs, attribute.String("gestalt.provider", strings.TrimSpace(integration)))
+	}
+	ctx, span := StartSpan(ctx, "credential.provider.operation", attrs...)
+	return ctx, func(err error) {
+		EndSpan(span, err)
+		RecordCredentialProviderOperation(ctx, startedAt, err != nil, attrs...)
+	}
+}
+
+func credentialIntegration(credential *core.ExternalCredential) string {
+	if credential == nil {
+		return ""
+	}
+	return credential.Integration
+}

--- a/gestaltd/internal/observability/observability.go
+++ b/gestaltd/internal/observability/observability.go
@@ -1,0 +1,148 @@
+package observability
+
+import (
+	"context"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const tracerName = "gestaltd"
+
+var (
+	AttrAgentOperation         = attribute.Key("gestalt.agent.operation")
+	AttrAgentProvider          = attribute.Key("gestalt.agent.provider")
+	AttrAgentToolSource        = attribute.Key("gestalt.agent.tool.source")
+	AttrAuthorizationOperation = attribute.Key("gestalt.authorization.operation")
+	AttrAuthorizationProvider  = attribute.Key("gestalt.authorization.provider")
+	AttrAuthorizationScope     = attribute.Key("gestalt.authorization.scope")
+	AttrCredentialProvider     = attribute.Key("gestalt.credential.provider")
+	AttrCredentialOperation    = attribute.Key("gestalt.credential.operation")
+	AttrCatalogSource          = attribute.Key("gestalt.catalog.source")
+)
+
+type metricSet struct {
+	count      metric.Int64Counter
+	errorCount metric.Int64Counter
+	duration   metric.Float64Histogram
+}
+
+var (
+	agentOperationMetrics                metricutil.MeterCache[metricSet]
+	agentProviderOperationMetrics        metricutil.MeterCache[metricSet]
+	agentToolResolveMetrics              metricutil.MeterCache[metricSet]
+	agentRunMetadataWriteMetrics         metricutil.MeterCache[metricSet]
+	authorizationProviderOperationMetric metricutil.MeterCache[metricSet]
+	authorizationProviderEvaluateMetrics metricutil.MeterCache[metricSet]
+	catalogOperationResolveMetrics       metricutil.MeterCache[metricSet]
+	credentialProviderOperationMetrics   metricutil.MeterCache[metricSet]
+	credentialBindingResolveMetrics      metricutil.MeterCache[metricSet]
+	credentialTokenResolveMetrics        metricutil.MeterCache[metricSet]
+)
+
+func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return otel.Tracer(tracerName).Start(ctx, name,
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(attrs...),
+	)
+}
+
+func EndSpan(span trace.Span, err error) {
+	if span == nil {
+		return
+	}
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End()
+}
+
+func SetSpanAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if span.IsRecording() {
+		span.SetAttributes(attrs...)
+	}
+}
+
+func RecordAgentOperation(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &agentOperationMetrics, "gestaltd.agent.operation", "gestaltd agent operations", startedAt, failed, attrs...)
+}
+
+func RecordAgentProviderOperation(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &agentProviderOperationMetrics, "gestaltd.agent.provider.operation", "gestaltd agent provider operations", startedAt, failed, attrs...)
+}
+
+func RecordAgentToolResolve(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &agentToolResolveMetrics, "gestaltd.agent.tool.resolve", "gestaltd agent tool resolution", startedAt, failed, attrs...)
+}
+
+func RecordAgentRunMetadataWrite(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &agentRunMetadataWriteMetrics, "gestaltd.agent.run_metadata.write", "gestaltd agent run metadata writes", startedAt, failed, attrs...)
+}
+
+func RecordAuthorizationProviderOperation(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &authorizationProviderOperationMetric, "gestaltd.authorization.provider.operation", "gestaltd authorization provider operations", startedAt, failed, attrs...)
+}
+
+func RecordAuthorizationProviderEvaluate(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &authorizationProviderEvaluateMetrics, "gestaltd.authorization.provider.evaluate", "gestaltd provider-backed authorization evaluations", startedAt, failed, attrs...)
+}
+
+func RecordCatalogOperationResolve(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &catalogOperationResolveMetrics, "gestaltd.catalog.operation.resolve", "gestaltd catalog operation resolution", startedAt, failed, attrs...)
+}
+
+func RecordCredentialProviderOperation(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &credentialProviderOperationMetrics, "gestaltd.credential.provider.operation", "gestaltd credential provider operations", startedAt, failed, attrs...)
+}
+
+func RecordCredentialBindingResolve(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &credentialBindingResolveMetrics, "gestaltd.credential.binding.resolve", "gestaltd credential binding resolution", startedAt, failed, attrs...)
+}
+
+func RecordCredentialTokenResolve(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &credentialTokenResolveMetrics, "gestaltd.credential.token.resolve", "gestaltd credential token resolution", startedAt, failed, attrs...)
+}
+
+func record(ctx context.Context, cache *metricutil.MeterCache[metricSet], prefix, desc string, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	metrics := cache.Load(ctx, tracerName, func(meter metric.Meter) metricSet {
+		return metricSet{
+			count: metricutil.NewInt64Counter(
+				meter,
+				prefix+".count",
+				"Counts "+desc+".",
+			),
+			errorCount: metricutil.NewInt64Counter(
+				meter,
+				prefix+".error_count",
+				"Counts failed "+desc+".",
+			),
+			duration: metricutil.NewFloat64Histogram(
+				meter,
+				prefix+".duration",
+				"Measures "+desc+" duration.",
+				"s",
+			),
+		}
+	})
+	metrics.count.Add(ctx, 1, metric.WithAttributes(attrs...))
+	metrics.duration.Record(ctx, time.Since(startedAt).Seconds(), metric.WithAttributes(attrs...))
+	if failed {
+		metrics.errorCount.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+}

--- a/gestaltd/internal/providerpkg/python_provider_test.go
+++ b/gestaltd/internal/providerpkg/python_provider_test.go
@@ -1,9 +1,7 @@
 package providerpkg
 
 import (
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -244,62 +242,11 @@ func pythonTestOtherPlatform() (string, string) {
 	return "linux", "amd64"
 }
 
-func pythonTestRuntimePath() (string, error) {
-	if value := os.Getenv("GESTALT_PYTHON"); value != "" {
-		if resolved, err := exec.LookPath(value); err == nil {
-			return resolved, nil
-		}
-		if info, err := os.Stat(value); err == nil && !info.IsDir() {
-			return value, nil
-		}
-	}
-	for _, candidate := range []string{"python3", "python"} {
-		if resolved, err := exec.LookPath(candidate); err == nil {
-			return resolved, nil
-		}
-	}
-	return "", exec.ErrNotFound
-}
-
 func pythonTestInterpreterPath(root, goos, suffix string) string {
 	if goos == "windows" {
 		return filepath.Join(root, suffix, "Scripts", "python.exe")
 	}
 	return filepath.Join(root, suffix, "bin", "python")
-}
-
-func mustWritePythonWithoutGRPCWrapper(t *testing.T, root, pythonPath string) string {
-	t.Helper()
-
-	path := filepath.Join(root, "python-no-grpc")
-	script := fmt.Sprintf(`#!%s
-import importlib.abc
-import runpy
-import sys
-
-class _BlockRuntimeDeps(importlib.abc.MetaPathFinder):
-    def find_spec(self, fullname, path=None, target=None):
-        if fullname == "grpc" or fullname.startswith("grpc."):
-            error = ModuleNotFoundError("No module named 'grpc'")
-            error.name = "grpc"
-            raise error
-        if fullname == "google" or fullname.startswith("google."):
-            error = ModuleNotFoundError("No module named 'google'")
-            error.name = "google"
-            raise error
-        return None
-
-sys.meta_path.insert(0, _BlockRuntimeDeps())
-
-if len(sys.argv) < 3 or sys.argv[1] != "-m":
-    raise SystemExit("unsupported invocation")
-
-module_name = sys.argv[2]
-sys.argv = [sys.argv[0], *sys.argv[3:]]
-runpy.run_module(module_name, run_name="__main__")
-`, pythonPath)
-	mustWriteFile(t, path, []byte(script), 0o755)
-	return path
 }
 
 func mustWritePythonInterpreter(t *testing.T, path string) {
@@ -311,30 +258,6 @@ func mustWritePythonInterpreter(t *testing.T, path string) {
 	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
-}
-
-func mustWritePythonSourceManifest(t *testing.T, root, pluginName string) string {
-	t.Helper()
-
-	data, err := EncodeSourceManifestFormat(&providermanifestv1.Manifest{
-		Kind:    providermanifestv1.KindPlugin,
-		Source:  "github.com/testowner/plugins/" + pluginName,
-		Version: "0.0.1",
-		Spec: &providermanifestv1.Spec{
-			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
-				"default": {
-					Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
-				},
-			},
-		},
-	}, ManifestFormatYAML)
-	if err != nil {
-		t.Fatalf("EncodeSourceManifestFormat: %v", err)
-	}
-
-	path := filepath.Join(root, "manifest.yaml")
-	mustWriteFile(t, path, data, 0o644)
-	return path
 }
 
 func containsString(haystack, needle string) bool {

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -18,8 +18,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
+	"github.com/valon-technologies/gestalt/server/internal/observability"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 )
 
 type stubAgentControl struct {
@@ -510,6 +512,86 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 		body, _ := io.ReadAll(cancelResp.Body)
 		t.Fatalf("cancel turn status = %d body=%s", cancelResp.StatusCode, body)
 	}
+}
+
+func TestAgentSessionAndTurnMetrics(t *testing.T) {
+	t.Parallel()
+
+	provider := observability.InstrumentAgentProvider("managed", newMemoryAgentProvider())
+	metrics := metrictest.NewManualMeterProvider(t)
+	services := coretesting.NewStubServices(t)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.MeterProvider = metrics.Provider
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "metric-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "metrics@example.com", DisplayName: "Metrics"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:           &stubAgentControl{defaultProviderName: "managed", provider: provider},
+			Providers:       testutil.NewProviderRegistry(t),
+			SessionMetadata: services.AgentSessions,
+			RunMetadata:     services.AgentRunMetadata,
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions", bytes.NewBufferString(`{"provider":"managed","model":"claude-sonnet"}`))
+	sessionReq.AddCookie(&http.Cookie{Name: "session_token", Value: "metric-session"})
+	sessionResp, err := http.DefaultClient.Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(sessionResp.Body)
+		t.Fatalf("create session status = %d body=%s", sessionResp.StatusCode, string(body))
+	}
+	var session map[string]any
+	if err := json.NewDecoder(sessionResp.Body).Decode(&session); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	sessionID, _ := session["id"].(string)
+	if sessionID == "" {
+		t.Fatalf("session response missing id: %#v", session)
+	}
+
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "metric-session"})
+	turnResp, err := http.DefaultClient.Do(turnReq)
+	if err != nil {
+		t.Fatalf("create turn: %v", err)
+	}
+	defer func() { _ = turnResp.Body.Close() }()
+	if turnResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(turnResp.Body)
+		t.Fatalf("create turn status = %d body=%s", turnResp.StatusCode, string(body))
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.agent.operation.count", 1, map[string]string{
+		"gestalt.agent.operation": "create_session",
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.agent.operation.count", 1, map[string]string{
+		"gestalt.agent.operation": "create_turn",
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.agent.provider.operation.count", 1, map[string]string{
+		"gestalt.agent.provider":  "managed",
+		"gestalt.agent.operation": "create_turn",
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.agent.tool.resolve.count", 1, map[string]string{
+		"gestalt.agent.tool.source": "explicit",
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.agent.run_metadata.write.count", 1, map[string]string{
+		"gestalt.agent.provider":  "managed",
+		"gestalt.agent.operation": "create_turn",
+	})
 }
 
 func TestAgentSessionsAndTurnsRoundTripWithoutAuth(t *testing.T) {

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -10,11 +10,14 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 )
 
 type stubProvider struct {
@@ -111,7 +114,7 @@ func (s *stubBoundTokenResolver) ResolveToken(ctx context.Context, _ *principal.
 	return ctx, s.token, nil
 }
 
-func (s *stubBoundTokenResolver) ResolveEffectiveCredentialBinding(_ *principal.Principal, _ string, _ string, _ string) (invocation.CredentialBindingResolution, error) {
+func (s *stubBoundTokenResolver) ResolveEffectiveCredentialBinding(_ context.Context, _ *principal.Principal, _ string, _ string, _ string) (invocation.CredentialBindingResolution, error) {
 	return s.boundCredential, nil
 }
 
@@ -308,6 +311,85 @@ func TestResolveCatalog_ModeNoneBoundPrincipalUsesEffectiveBindingSelectors(t *t
 	if len(cat.Operations) != 1 || cat.Operations[0].ID != "session_only" {
 		t.Fatalf("catalog operations = %+v, want session_only", cat.Operations)
 	}
+}
+
+func TestResolveCatalogAndOperationMetrics(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+	prov := &stubDynamicSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "metric-api",
+				connMode: core.ConnectionModeUser,
+			},
+			cat: &catalog.Catalog{
+				Name: "metric-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "static_op", Method: http.MethodGet},
+				},
+			},
+		},
+		sessionCatFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			if token != "bound-token" {
+				t.Fatalf("token = %q, want %q", token, "bound-token")
+			}
+			return &catalog.Catalog{
+				Name: "metric-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "session_op", Method: http.MethodPost},
+				},
+			}, nil
+		},
+	}
+	services := coretesting.NewStubServices(t)
+	if err := services.ExternalCredentials.PutCredential(ctx, &core.IntegrationToken{
+		SubjectID:   principal.UserSubjectID("metrics-user"),
+		Integration: "metric-api",
+		Connection:  "default",
+		Instance:    "default",
+		AccessToken: "bound-token",
+	}); err != nil {
+		t.Fatalf("PutCredential: %v", err)
+	}
+	resolver := invocation.NewBroker(testutil.NewProviderRegistry(t, prov), services.Users, services.ExternalCredentials)
+	p := &principal.Principal{
+		Kind:      principal.KindUser,
+		UserID:    "metrics-user",
+		SubjectID: principal.UserSubjectID("metrics-user"),
+	}
+
+	if _, err := invocation.ResolveCatalog(ctx, prov, "metric-api", resolver, p, "default", "default"); err != nil {
+		t.Fatalf("ResolveCatalog: %v", err)
+	}
+	if _, _, _, err := invocation.ResolveOperation(ctx, prov, "metric-api", resolver, p, "static_op", nil, ""); err != nil {
+		t.Fatalf("ResolveOperation: %v", err)
+	}
+	if _, _, _, err := invocation.ResolveOperation(ctx, prov, "metric-api", resolver, p, "raw-user-op", nil, ""); !errors.Is(err, invocation.ErrOperationNotFound) {
+		t.Fatalf("ResolveOperation(raw-user-op) error = %v, want ErrOperationNotFound", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.credential.binding.resolve.duration", map[string]string{
+		"gestalt.provider":                "metric-api",
+		"gestalt.credential.binding_mode": "effective",
+	})
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.credential.token.resolve.duration", map[string]string{
+		"gestalt.provider": "metric-api",
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.catalog.operation.resolve.count", 1, map[string]string{
+		"gestalt.provider":  "metric-api",
+		"gestalt.operation": "static_op",
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.catalog.operation.resolve.count", 1, map[string]string{
+		"gestalt.provider":  "metric-api",
+		"gestalt.operation": "unknown",
+	})
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.catalog.operation.resolve.count", map[string]string{
+		"gestalt.provider":  "metric-api",
+		"gestalt.operation": "raw-user-op",
+	})
 }
 
 func TestResolveCatalog_SameIDCollision_SessionWins(t *testing.T) {

--- a/gestaltd/internal/server/tracing_test.go
+++ b/gestaltd/internal/server/tracing_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,8 +12,11 @@ import (
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/observability"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
@@ -182,6 +186,117 @@ func TestTracing_BrokerSpanRecordsErrors(t *testing.T) { //nolint:paralleltest /
 	}
 }
 
+func TestTracing_AgentTurnTraceTree(t *testing.T) { //nolint:paralleltest // mutates global otel.TracerProvider
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	agentProvider := observability.InstrumentAgentProvider("managed", newMemoryAgentProvider())
+	services := coretesting.NewStubServices(t)
+	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+		N:        "docs",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+			ID:       "search",
+			Title:    "Search",
+			ReadOnly: true,
+		}}},
+	})
+	broker := invocation.NewBroker(providers, services.Users, services.ExternalCredentials)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "agent-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "agent-trace@example.com", DisplayName: "Trace"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = providers
+		cfg.Invoker = broker
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:           &stubAgentControl{defaultProviderName: "managed", provider: agentProvider},
+			Providers:       providers,
+			SessionMetadata: services.AgentSessions,
+			RunMetadata:     services.AgentRunMetadata,
+			Invoker:         broker,
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions", bytes.NewBufferString(`{"provider":"managed","model":"claude-sonnet"}`))
+	sessionReq.AddCookie(&http.Cookie{Name: "session_token", Value: "agent-session"})
+	sessionResp, err := http.DefaultClient.Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(sessionResp.Body)
+		t.Fatalf("create session status = %d body=%s", sessionResp.StatusCode, string(body))
+	}
+	var session map[string]any
+	if err := json.NewDecoder(sessionResp.Body).Decode(&session); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	sessionID, _ := session["id"].(string)
+	if sessionID == "" {
+		t.Fatalf("session response missing id: %#v", session)
+	}
+
+	turnBody := `{"messages":[{"role":"user","text":"search docs"}],"toolRefs":[{"pluginName":"docs","operation":"search"}]}`
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(turnBody))
+	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "agent-session"})
+	turnResp, err := http.DefaultClient.Do(turnReq)
+	if err != nil {
+		t.Fatalf("create turn: %v", err)
+	}
+	defer func() { _ = turnResp.Body.Close() }()
+	if turnResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(turnResp.Body)
+		t.Fatalf("create turn status = %d body=%s", turnResp.StatusCode, string(body))
+	}
+
+	_ = tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+	agentSpan := findSpanWithAttr(spans, "agent.operation", "gestalt.agent.operation", "create_turn")
+	if agentSpan == nil {
+		t.Fatalf("expected create_turn agent.operation span, got spans: %v", spanNames(spans))
+	}
+	providerSpan := findSpanWithAttr(spans, "agent.provider.operation", "gestalt.agent.operation", "create_turn")
+	if providerSpan == nil {
+		t.Fatal("expected create_turn agent.provider.operation span")
+	}
+	toolSpan := findSpan(spans, "agent.tool.resolve")
+	if toolSpan == nil {
+		t.Fatal("expected agent.tool.resolve span")
+	}
+	catalogSpan := findSpan(spans, "catalog.operation.resolve")
+	if catalogSpan == nil {
+		t.Fatal("expected catalog.operation.resolve span")
+	}
+	metadataSpan := findSpan(spans, "agent.run_metadata.write")
+	if metadataSpan == nil {
+		t.Fatal("expected agent.run_metadata.write span")
+	}
+	for _, child := range []*tracetest.SpanStub{providerSpan, toolSpan, catalogSpan, metadataSpan} {
+		if child.SpanContext.TraceID() != agentSpan.SpanContext.TraceID() {
+			t.Fatalf("span %q trace id = %s, want agent trace id %s", child.Name, child.SpanContext.TraceID(), agentSpan.SpanContext.TraceID())
+		}
+	}
+	assertSpanHasAttr(t, agentSpan, "gestalt.agent.provider", "managed")
+	assertSpanHasAttr(t, providerSpan, "gestalt.agent.provider", "managed")
+	assertSpanHasAttr(t, catalogSpan, "gestalt.provider", "docs")
+	assertSpanHasAttr(t, catalogSpan, "gestalt.operation", "search")
+	assertSpanHasAttr(t, catalogSpan, "gestalt.catalog.source", "static")
+}
+
 func findSpan(spans tracetest.SpanStubs, name string) *tracetest.SpanStub {
 	for i := range spans {
 		if spans[i].Name == name {
@@ -189,6 +304,28 @@ func findSpan(spans tracetest.SpanStubs, name string) *tracetest.SpanStub {
 		}
 	}
 	return nil
+}
+
+func findSpanWithAttr(spans tracetest.SpanStubs, name string, key string, value string) *tracetest.SpanStub {
+	for i := range spans {
+		if spans[i].Name != name {
+			continue
+		}
+		for _, attr := range spans[i].Attributes {
+			if string(attr.Key) == key && attr.Value.AsString() == value {
+				return &spans[i]
+			}
+		}
+	}
+	return nil
+}
+
+func spanNames(spans tracetest.SpanStubs) []string {
+	names := make([]string, 0, len(spans))
+	for _, span := range spans {
+		names = append(names, span.Name)
+	}
+	return names
 }
 
 func findSpanPrefix(spans tracetest.SpanStubs, prefix string) *tracetest.SpanStub {

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -767,7 +767,7 @@ func (m *Manager) resolvePluginTarget(ctx context.Context, p *principal.Principa
 	}
 	boundCredential := invocation.CredentialBindingResolution{}
 	if bindingResolver, ok := m.invoker.(invocation.EffectiveCredentialBindingResolver); ok {
-		boundCredential, err = bindingResolver.ResolveEffectiveCredentialBinding(p, pluginName, connection, instance)
+		boundCredential, err = bindingResolver.ResolveEffectiveCredentialBinding(ctx, p, pluginName, connection, instance)
 		if err != nil {
 			return coreworkflow.Target{}, err
 		}


### PR DESCRIPTION
## Summary

Adds platform-owned observability for the agent execution path and adjacent provider boundaries without requiring provider authors to emit baseline metrics themselves.

## Interfaces

- `observability.InstrumentAgentProvider(name, provider)` wraps the existing `core/agent.Provider` interface and emits `agent.provider.operation` spans plus `gestaltd.agent.provider.operation.{count,error_count,duration}` metrics.
- `observability.InstrumentAuthorizationProvider(name, provider)` wraps the existing `core.AuthorizationProvider` interface and emits `authorization.provider.operation` spans plus `gestaltd.authorization.provider.operation.*` metrics.
- `observability.InstrumentExternalCredentialProvider(name, provider)` wraps the existing `core.ExternalCredentialProvider` interface and emits `credential.provider.operation` spans plus `gestaltd.credential.provider.operation.*` metrics.
- `invocation.EffectiveCredentialBindingResolver` now accepts `context.Context` so credential binding and token resolution remain in the request trace tree: `ResolveEffectiveCredentialBinding(ctx, principal, providerName, connection, instance)`.

## Examples

- `POST /api/v1/agent/sessions/{id}/turns` now produces a trace tree with `agent.operation`, `agent.tool.resolve`, `catalog.operation.resolve`, `agent.run_metadata.write`, and `agent.provider.operation` spans.
- Agent provider calls emit metrics such as `gestaltd.agent.provider.operation.count{gestalt.agent.provider="managed", gestalt.agent.operation="create_turn"}`.
- Catalog resolution emits `gestaltd.catalog.operation.resolve.count{gestalt.provider="docs", gestalt.operation="search"}` and normalizes unresolved user-supplied operation names to `gestalt.operation="unknown"`.
- Provider-backed authorization emits `gestaltd.authorization.provider.evaluate.*` using the configured provider key in `gestalt.authorization.provider`.

## Notes

- Does not add GenAI semantic metrics or optional metric families.
- Keeps metric names under `gestaltd.*`; attributes remain under `gestalt.*`.
- Updates observability and provider-authoring docs for the new metric/span contract.

## Validation

- `cd gestaltd && go test ./internal/agentmanager ./internal/invocation ./internal/authorization ./internal/bootstrap ./internal/mcp ./internal/workflowmanager ./internal/server`
- `cd gestaltd && go test ./...`
- `cd docs && npm run typecheck`
- `cd docs && npm run build`