### PR TITLE
Remove per-plugin providerDev remote-dev opt-in

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -75,9 +75,9 @@ keeps its existing config-relative behavior for backward compatibility.
 `gestaltd` instance to attach to. The local command only replaces source-backed
 plugin implementations for the authenticated principal that created the session;
 all non-local plugins, credentials, policies, and host services continue to
-resolve through the remote instance. Remote servers expose attach targets only
-for source-backed plugin config entries or release-backed plugin entries that
-explicitly set `providerDev: true`. Remote mode tunnels plugin RPC, catalog,
+resolve through the remote instance. Remote servers expose attach targets for
+configured plugins, and existing plugin authorization decides whether the
+authenticated caller may attach. Remote mode tunnels plugin RPC, catalog,
 post-connect, host-service calls, and plugin-owned UI assets for mounted UIs
 that already exist on the remote server. Raw GraphQL surfaces are not tunneled
 in v1.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1023,10 +1023,9 @@ For local development with a source provider package:
 source: ./manifest.yaml
 ```
 
-Set `providerDev: true` on a release-backed plugin only when that remote
-`gestaltd` instance should allow authenticated developers to attach a local
-implementation with `gestaltd provider dev --remote`. Source-backed plugin
-entries are already treated as explicit local-development targets.
+When a remote `gestaltd` instance is running the provider-dev endpoints,
+authenticated developers can attach a local implementation for any configured
+plugin they are authorized to access with `gestaltd provider dev --remote`.
 
 Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider` or the legacy `[tool.gestalt].plugin`.
 

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -23,9 +23,6 @@ func buildProviderDevManager(cfg *config.Config, providers *registry.ProviderMap
 		if entry == nil || !entry.HasResolvedManifest() {
 			continue
 		}
-		if !entry.HasLocalSource() && !entry.ProviderDev {
-			continue
-		}
 		if _, err := providers.Get(name); err != nil {
 			continue
 		}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -373,7 +373,6 @@ type ProviderEntry struct {
 	Cache             []string                      `yaml:"cache,omitempty"`
 	S3                []string                      `yaml:"s3,omitempty"`
 	Runtime           *HostedRuntimeConfig          `yaml:"runtime,omitempty"`
-	ProviderDev       bool                          `yaml:"providerDev,omitempty"`
 	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
 	MCP               bool                          `yaml:"mcp,omitempty"`
 


### PR DESCRIPTION
## Summary

Remove the per-plugin `providerDev: true` config syntax. Remote provider-dev attach targets are now derived from the existing configured plugin set: if a plugin is configured, resolved, and loaded by the remote `gestaltd`, it can be attached by an authenticated caller who already has permission for that plugin.

This keeps local development config-free for plugin authors and avoids requiring a server config edit just to work locally.

## New interface

No plugin config opt-in is required:

```bash
gestaltd provider dev --remote https://valon.tools --path ./deployment-viewer/plugin --name deploymentViewer
```

Layered local selection still works for developing multiple plugins while remote keeps the rest:

```bash
gestaltd provider dev --remote https://valon.tools \
  --config ./remote.yaml \
  --config ./local-overrides.yaml
```

Remote-side authorization remains the gate: existing plugin permissions decide whether the authenticated principal may attach a local override for a target plugin.

## Changes

- Include all configured, resolved, loaded plugins as provider-dev remote attach targets.
- Remove the `providerDev` field from `ProviderEntry` config decoding.
- Update CLI/config docs to remove references to `providerDev: true`.

## Verification

Run from a clean temporary worktree with only this patch applied:

```bash
go test ./internal/config ./internal/bootstrap ./internal/server ./internal/providerdev ./cmd/gestaltd
```