### PR TITLE
Skip incompatible remote provider-dev targets

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -76,10 +76,10 @@ keeps its existing config-relative behavior for backward compatibility.
 plugin implementations for the authenticated principal that created the session;
 all non-local plugins, credentials, policies, and host services continue to
 resolve through the remote instance. Remote servers expose attach targets for
-configured plugins, and existing plugin authorization decides whether the
-authenticated caller may attach. Remote mode tunnels plugin RPC, catalog,
-post-connect, host-service calls, and plugin-owned UI assets for mounted UIs
-that already exist on the remote server. Raw GraphQL surfaces are not tunneled
-in v1.
+configured plugins whose static provider metadata can be derived, and existing
+plugin authorization decides whether the authenticated caller may attach.
+Remote mode tunnels plugin RPC, catalog, post-connect, host-service calls, and
+plugin-owned UI assets for mounted UIs that already exist on the remote server.
+Raw GraphQL surfaces are not tunneled in v1.
 
 See [Configuration](/configuration) for the relationship between `init`, `serve --locked`, and `validate`.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1024,8 +1024,9 @@ source: ./manifest.yaml
 ```
 
 When a remote `gestaltd` instance is running the provider-dev endpoints,
-authenticated developers can attach a local implementation for any configured
-plugin they are authorized to access with `gestaltd provider dev --remote`.
+authenticated developers can attach a local implementation for configured
+plugins whose static provider metadata can be derived and that they are
+authorized to access with `gestaltd provider dev --remote`.
 
 Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider` or the legacy `[tool.gestalt].plugin`.
 

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"log/slog"
 	"maps"
 	"slices"
 
@@ -28,10 +29,18 @@ func buildProviderDevManager(cfg *config.Config, providers *registry.ProviderMap
 		}
 		spec, _, err := buildStartupProviderSpec(name, entry)
 		if err != nil {
+			if !providerDevEntryIsLocal(entry) {
+				slog.Warn("skipping provider dev target", "provider", name, "error", err)
+				continue
+			}
 			return nil, fmt.Errorf("provider dev target %q: %w", name, err)
 		}
 		pluginConfig, err := config.NodeToMap(entry.Config)
 		if err != nil {
+			if !providerDevEntryIsLocal(entry) {
+				slog.Warn("skipping provider dev target config", "provider", name, "error", err)
+				continue
+			}
 			return nil, fmt.Errorf("provider dev target %q config: %w", name, err)
 		}
 		targetName := name
@@ -49,6 +58,10 @@ func buildProviderDevManager(cfg *config.Config, providers *registry.ProviderMap
 		return nil, nil
 	}
 	return providerdev.NewManager(targets)
+}
+
+func providerDevEntryIsLocal(entry *config.ProviderEntry) bool {
+	return entry != nil && (entry.HasLocalSource() || entry.HasLocalReleaseSource())
 }
 
 func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps Deps, sessionID string) (providerdev.RuntimeEnv, error) {


### PR DESCRIPTION
## Summary

The toolshed deploy exposed a startup bug after config-free remote provider-dev target discovery: a hosted `gestaltd` instance failed to boot when any configured plugin could not derive static provider-dev metadata, even if that plugin was otherwise a valid release-backed runtime plugin.

This changes remote provider-dev target discovery to skip non-local plugins whose static provider metadata cannot be derived. Local source-backed plugins and local release-metadata-backed plugins still fail loudly, because those are active local-development inputs.

## Interface

No CLI syntax changes. Remote provider-dev continues to use the existing interface:

```sh
gestaltd provider dev --remote https://valon.tools --path ./deployment-viewer/plugin --name deploymentViewer
```

Remote servers now expose attach targets for configured plugins that can produce provider-dev metadata; incompatible release-backed plugins keep running normally and no longer block server startup.

## Verification

```sh
cd gestaltd && go test ./internal/bootstrap ./internal/providerdev ./internal/server
cd gestaltd && go test ./cmd/gestaltd -run 'TestE2EProviderDevServesSourceUI|TestE2EProviderDevAutoMountsSiblingUIForPlugin' -count=1
```
