### PR TITLE
Prepare gestalt CLI v0.0.1-alpha.7 release

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 edition = "2024"


### PR DESCRIPTION
## Summary
- Bumps the `gestalt` Rust workspace package version to `0.0.1-alpha.7` so the CLI release workflow accepts tag `gestalt/v0.0.1-alpha.7`.
- Leaves `gestaltd` source unchanged because the daemon release workflow derives version from tag `gestaltd/v0.0.1-alpha.5` via build ldflags and updates formula/chart after release.

## Release interfaces
- GitHub tag: `gestalt/v0.0.1-alpha.7`
- GitHub tag: `gestaltd/v0.0.1-alpha.5`
- Docker: `docker pull valontechnologies/gestalt:0.0.1-alpha.7`
- Docker: `docker pull valontechnologies/gestaltd:0.0.1-alpha.5`
- Homebrew: `brew upgrade valon-technologies/gestalt/gestalt valon-technologies/gestalt/gestaltd`

## Examples
- `gestalt agent`
- `gestalt agent --provider managed --model gpt-5.4`
- `gestaltd version`

## Tests
- `cargo metadata --manifest-path gestalt/Cargo.toml --format-version 1 --no-deps`
- `cargo test --manifest-path gestalt/cli/Cargo.toml`