### PR TITLE
Respect visible=false on HTTP surfaces and invoke credential modes

### DIFF
--- a/gestaltd/core/agent/agent.go
+++ b/gestaltd/core/agent/agent.go
@@ -78,10 +78,11 @@ type MessagePart struct {
 }
 
 type ToolTarget struct {
-	Plugin     string
-	Operation  string
-	Connection string
-	Instance   string
+	Plugin         string
+	Operation      string
+	Connection     string
+	Instance       string
+	CredentialMode core.ConnectionMode
 }
 
 type Tool struct {
@@ -93,12 +94,13 @@ type Tool struct {
 }
 
 type ToolRef struct {
-	Plugin      string
-	Operation   string
-	Connection  string
-	Instance    string
-	Title       string
-	Description string
+	Plugin         string
+	Operation      string
+	Connection     string
+	Instance       string
+	CredentialMode core.ConnectionMode
+	Title          string
+	Description    string
 }
 
 type ResolveToolsRequest struct {

--- a/gestaltd/core/catalog/catalog.go
+++ b/gestaltd/core/catalog/catalog.go
@@ -51,6 +51,10 @@ type CatalogOperation struct {
 	Query          string               `yaml:"query,omitempty"          json:"query,omitempty"`
 }
 
+func OperationVisibleByDefault(op CatalogOperation) bool {
+	return op.Visible == nil || *op.Visible
+}
+
 func (o *CatalogOperation) UnmarshalYAML(value *yaml.Node) error {
 	type catalogOperationYAML struct {
 		ID             string               `yaml:"id"`

--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -170,6 +170,10 @@ func (m *Manager) ResolveTools(ctx context.Context, p *principal.Principal, req 
 	if err != nil {
 		return nil, err
 	}
+	refs, err = m.applyCallerInvokeCredentialModes(req.CallerPluginName, refs)
+	if err != nil {
+		return nil, err
+	}
 	candidates, err := m.searchToolCandidates(ctx, p, refs, "")
 	if err != nil {
 		return nil, err
@@ -407,10 +411,11 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	if err != nil {
 		return nil, err
 	}
-	if err := requireNativeToolSearch(ctx, provider); err != nil {
+	toolRefs, err := normalizeToolRefs(req.ToolRefs)
+	if err != nil {
 		return nil, err
 	}
-	toolRefs, err := normalizeToolRefs(req.ToolRefs)
+	toolRefs, err = m.applyCallerInvokeCredentialModes(req.CallerPluginName, toolRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -418,6 +423,16 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 		return nil, err
 	}
 	var tools []coreagent.Tool
+	nativeToolSearch, err := agentProviderSupportsNativeToolSearch(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+	if !nativeToolSearch && len(toolRefs) > 0 {
+		tools, err = m.resolveExactAgentToolRefs(ctx, p, toolRefs)
+		if err != nil {
+			return nil, err
+		}
+	}
 	turnID := uuid.NewString()
 	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
 	if idempotencyKey != "" {
@@ -911,6 +926,29 @@ func (m *Manager) resolveAgentToolCandidates(ctx context.Context, p *principal.P
 	return tools, nil
 }
 
+func (m *Manager) resolveExactAgentToolRefs(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef) ([]coreagent.Tool, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	out := make([]coreagent.Tool, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for i := range refs {
+		if strings.TrimSpace(refs[i].Operation) == "" {
+			return nil, fmt.Errorf("%w: agent tool_refs[%d] requires native tool search", invocation.ErrInternal, i)
+		}
+		tool, err := m.resolveTool(ctx, p, refs[i])
+		if err != nil {
+			return nil, fmt.Errorf("agent tool_refs[%d]: %w", i, err)
+		}
+		if _, ok := seen[tool.ID]; ok {
+			continue
+		}
+		seen[tool.ID] = struct{}{}
+		out = append(out, tool)
+	}
+	return out, nil
+}
+
 func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref coreagent.ToolRef) (coreagent.Tool, error) {
 	if m == nil || m.providers == nil {
 		return coreagent.Tool{}, fmt.Errorf("%w: agent providers are not configured", invocation.ErrInternal)
@@ -942,6 +980,16 @@ func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref c
 	instance := strings.TrimSpace(ref.Instance)
 	if instance != "" && !config.SafeInstanceValue(instance) {
 		return coreagent.Tool{}, fmt.Errorf("instance name contains invalid characters")
+	}
+	credentialMode, err := normalizeAgentToolCredentialMode(ref.CredentialMode)
+	if err != nil {
+		return coreagent.Tool{}, err
+	}
+	if credentialMode != "" {
+		ctx = invocation.WithCredentialModeOverride(ctx, credentialMode)
+	}
+	if m.authorizer != nil && principal.IsWorkloadPrincipal(p) && (connection != "" || instance != "") {
+		return coreagent.Tool{}, fmt.Errorf("%w: workloads may not override connection or instance bindings", invocation.ErrAuthorizationDenied)
 	}
 
 	ctx = invocation.WithAccessContext(ctx, m.providerAccessContext(ctx, p, pluginName))
@@ -994,15 +1042,16 @@ func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref c
 		description = strings.TrimSpace(opMeta.Description)
 	}
 	return coreagent.Tool{
-		ID:               agentToolID(pluginName, opMeta.ID, connection, sessionInstance),
+		ID:               agentToolID(pluginName, opMeta.ID, connection, sessionInstance, credentialMode),
 		Name:             name,
 		Description:      description,
 		ParametersSchema: parametersSchema,
 		Target: coreagent.ToolTarget{
-			Plugin:     pluginName,
-			Operation:  opMeta.ID,
-			Connection: connection,
-			Instance:   sessionInstance,
+			Plugin:         pluginName,
+			Operation:      opMeta.ID,
+			Connection:     connection,
+			Instance:       sessionInstance,
+			CredentialMode: credentialMode,
 		},
 	}, nil
 }
@@ -1052,6 +1101,9 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 				if operation == "" || !agentToolSearchRefAllows(searchRef, operation) {
 					continue
 				}
+				if strings.TrimSpace(searchRef.Operation) == "" && !catalog.OperationVisibleByDefault(op) {
+					continue
+				}
 				if !m.allowOperation(ctx, p, pluginName, operation) || !principal.AllowsOperationPermission(p, pluginName, operation) {
 					continue
 				}
@@ -1093,6 +1145,16 @@ func (m *Manager) catalogForAgentToolSearch(ctx context.Context, p *principal.Pr
 	instance := strings.TrimSpace(ref.Instance)
 	if instance != "" && !config.SafeInstanceValue(instance) {
 		return nil, fmt.Errorf("instance name contains invalid characters")
+	}
+	credentialMode, err := normalizeAgentToolCredentialMode(ref.CredentialMode)
+	if err != nil {
+		return nil, err
+	}
+	if credentialMode != "" {
+		ctx = invocation.WithCredentialModeOverride(ctx, credentialMode)
+	}
+	if m.authorizer != nil && principal.IsWorkloadPrincipal(p) && (connection != "" || instance != "") {
+		return nil, fmt.Errorf("%w: workloads may not override connection or instance bindings", invocation.ErrAuthorizationDenied)
 	}
 	var resolver invocation.TokenResolver
 	if tr, ok := m.invoker.(invocation.TokenResolver); ok {
@@ -1287,8 +1349,8 @@ func (m *Manager) allowRun(ctx context.Context, p *principal.Principal, ref *cor
 	if len(ref.Tools) == 0 {
 		return true
 	}
-	for _, tool := range ref.Tools {
-		if !m.allowTool(ctx, p, tool) {
+	for i := range ref.Tools {
+		if !m.allowTool(ctx, p, ref.Tools[i]) {
 			return false
 		}
 	}
@@ -1453,7 +1515,7 @@ func operationInputSchema(op catalog.CatalogOperation) (map[string]any, error) {
 	return out, nil
 }
 
-func agentToolID(pluginName, operation, connection, instance string) string {
+func agentToolID(pluginName, operation, connection, instance string, credentialMode core.ConnectionMode) string {
 	id := strings.TrimSpace(pluginName) + "/" + strings.TrimSpace(operation)
 	if strings.TrimSpace(connection) != "" {
 		id += "?connection=" + strings.TrimSpace(connection)
@@ -1464,6 +1526,13 @@ func agentToolID(pluginName, operation, connection, instance string) string {
 			sep = "&"
 		}
 		id += sep + "instance=" + strings.TrimSpace(instance)
+	}
+	if credentialMode != "" {
+		sep := "?"
+		if strings.Contains(id, "?") {
+			sep = "&"
+		}
+		id += sep + "credentialMode=" + string(credentialMode)
 	}
 	return id
 }
@@ -1495,6 +1564,11 @@ func normalizeToolRefs(refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
 		ref.Instance = strings.TrimSpace(ref.Instance)
 		ref.Title = strings.TrimSpace(ref.Title)
 		ref.Description = strings.TrimSpace(ref.Description)
+		credentialMode, err := normalizeAgentToolCredentialMode(ref.CredentialMode)
+		if err != nil {
+			return nil, err
+		}
+		ref.CredentialMode = credentialMode
 		if ref.Plugin == "" {
 			return nil, fmt.Errorf("%w: agent tool_refs[%d].plugin is required", invocation.ErrProviderNotFound, idx)
 		}
@@ -1503,18 +1577,84 @@ func normalizeToolRefs(refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
 	return out, nil
 }
 
-func requireNativeToolSearch(ctx context.Context, provider coreagent.Provider) error {
+func (m *Manager) applyCallerInvokeCredentialModes(callerPluginName string, refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
+	callerPluginName = strings.TrimSpace(callerPluginName)
+	if len(refs) == 0 || m == nil {
+		return refs, nil
+	}
+	modes := make(map[string]core.ConnectionMode)
+	if callerPluginName != "" {
+		for _, invoke := range m.pluginInvokes[callerPluginName] {
+			if strings.TrimSpace(invoke.Surface) != "" {
+				continue
+			}
+			pluginName := strings.TrimSpace(invoke.Plugin)
+			operation := strings.TrimSpace(invoke.Operation)
+			if pluginName == "" || operation == "" {
+				continue
+			}
+			mode, err := normalizeAgentToolCredentialMode(core.ConnectionMode(invoke.CredentialMode))
+			if err != nil {
+				return nil, err
+			}
+			if mode != "" {
+				modes[agentToolInvokeKey(pluginName, operation)] = mode
+			}
+		}
+	}
+	out := append([]coreagent.ToolRef(nil), refs...)
+	for i := range out {
+		operation := strings.TrimSpace(out[i].Operation)
+		if out[i].CredentialMode != "" && callerPluginName == "" {
+			return nil, fmt.Errorf("%w: agent tool_refs[%d].credentialMode requires a caller plugin declaration", invocation.ErrAuthorizationDenied, i)
+		}
+		if operation == "" {
+			if out[i].CredentialMode != "" {
+				return nil, fmt.Errorf("%w: agent tool_refs[%d].credentialMode requires an exact operation", invocation.ErrAuthorizationDenied, i)
+			}
+			continue
+		}
+		mode, ok := modes[agentToolInvokeKey(out[i].Plugin, operation)]
+		if !ok {
+			if out[i].CredentialMode != "" {
+				return nil, fmt.Errorf("%w: agent tool_refs[%d].credentialMode requires a declared invoke mode", invocation.ErrAuthorizationDenied, i)
+			}
+			continue
+		}
+		if out[i].CredentialMode != "" && out[i].CredentialMode != mode {
+			return nil, fmt.Errorf("%w: agent tool_refs[%d].credentialMode %q exceeds declared invoke mode %q", invocation.ErrAuthorizationDenied, i, out[i].CredentialMode, mode)
+		}
+		out[i].CredentialMode = mode
+	}
+	return out, nil
+}
+
+func agentToolInvokeKey(pluginName, operation string) string {
+	return strings.TrimSpace(pluginName) + "\x00" + strings.TrimSpace(operation)
+}
+
+func agentProviderSupportsNativeToolSearch(ctx context.Context, provider coreagent.Provider) (bool, error) {
 	if provider == nil {
-		return ErrAgentProviderNotAvailable
+		return false, ErrAgentProviderNotAvailable
 	}
 	caps, err := provider.GetCapabilities(ctx, coreagent.GetCapabilitiesRequest{})
 	if err != nil {
-		return err
+		return false, err
 	}
-	if caps == nil || !caps.NativeToolSearch {
-		return fmt.Errorf("%w: agent provider does not support native tool search", invocation.ErrInternal)
+	return caps != nil && caps.NativeToolSearch, nil
+}
+
+func normalizeAgentToolCredentialMode(mode core.ConnectionMode) (core.ConnectionMode, error) {
+	switch core.ConnectionMode(strings.ToLower(strings.TrimSpace(string(mode)))) {
+	case "":
+		return "", nil
+	case core.ConnectionModeNone:
+		return core.ConnectionModeNone, nil
+	case core.ConnectionModeUser:
+		return core.ConnectionModeUser, nil
+	default:
+		return "", fmt.Errorf("unsupported agent tool credential mode %q", mode)
 	}
-	return nil
 }
 
 func agentActorFromPrincipal(p *principal.Principal) coreagent.Actor {

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -9,9 +9,11 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
 type catalogCountingProvider struct {
@@ -96,6 +98,54 @@ func TestSearchToolsRestrictsToDefinedRefs(t *testing.T) {
 	}
 	if resp.Tools[0].Target.Plugin != "docs" || resp.Tools[0].Target.Operation != "search" {
 		t.Fatalf("tool target = %#v, want docs.search", resp.Tools[0].Target)
+	}
+}
+
+func TestSearchToolsOmitsHiddenOperationsUnlessExplicitlyScoped(t *testing.T) {
+	t.Parallel()
+
+	hidden := false
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
+				{
+					ID:       "chat.postMessage",
+					Title:    "Post Message",
+					ReadOnly: false,
+				},
+				{
+					ID:      "events.reply",
+					Title:   "Reply to Event",
+					Visible: &hidden,
+				},
+			}},
+		},
+	}
+	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query: "reply",
+	})
+	if err != nil {
+		t.Fatalf("SearchTools: %v", err)
+	}
+	if len(resp.Tools) != 0 {
+		t.Fatalf("SearchTools returned %d hidden tools, want 0", len(resp.Tools))
+	}
+
+	tools, err := manager.ResolveTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.ResolveToolsRequest{
+		ToolRefs: []coreagent.ToolRef{{Plugin: "slack", Operation: "events.reply"}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTools: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Target.Operation != "events.reply" {
+		t.Fatalf("ResolveTools = %#v, want explicit hidden events.reply", tools)
 	}
 }
 
@@ -227,5 +277,106 @@ func TestResolveToolsExpandsPluginOnlyRefs(t *testing.T) {
 	}
 	if tools[0].Target.Operation != "search" || tools[1].Target.Operation != "summarize" {
 		t.Fatalf("ResolveTools operations = %q, %q; want search, summarize", tools[0].Target.Operation, tools[1].Target.Operation)
+	}
+}
+
+func TestResolveToolsAppliesDeclaredInvokeCredentialMode(t *testing.T) {
+	t.Parallel()
+
+	hidden := false
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:      "events.reply",
+				Title:   "Reply",
+				Visible: &hidden,
+			}}},
+		},
+	}
+	manager := New(Config{
+		Providers: testutil.NewProviderRegistry(t, provider),
+		PluginInvokes: map[string][]config.PluginInvocationDependency{
+			"slackbot": {{
+				Plugin:         "slack",
+				Operation:      "events.reply",
+				CredentialMode: providermanifestv1.ConnectionModeNone,
+			}},
+		},
+	})
+
+	tools, err := manager.ResolveTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.ResolveToolsRequest{
+		CallerPluginName: "slackbot",
+		ToolRefs: []coreagent.ToolRef{{
+			Plugin:    "slack",
+			Operation: "events.reply",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTools: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("ResolveTools returned %d tools, want 1", len(tools))
+	}
+	if tools[0].Target.Plugin != "slack" || tools[0].Target.Operation != "events.reply" {
+		t.Fatalf("tool target = %#v, want slack.events.reply", tools[0].Target)
+	}
+	if tools[0].Target.CredentialMode != core.ConnectionModeNone {
+		t.Fatalf("tool credential mode = %q, want %q", tools[0].Target.CredentialMode, core.ConnectionModeNone)
+	}
+}
+
+func TestResolveToolsRejectsUndeclaredCredentialMode(t *testing.T) {
+	t.Parallel()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:    "events.reply",
+				Title: "Reply",
+			}}},
+		},
+	}
+	manager := New(Config{
+		Providers: testutil.NewProviderRegistry(t, provider),
+		PluginInvokes: map[string][]config.PluginInvocationDependency{
+			"slackbot": {{
+				Plugin:         "slack",
+				Operation:      "chat.postMessage",
+				CredentialMode: providermanifestv1.ConnectionModeNone,
+			}},
+		},
+	})
+
+	for _, tc := range []struct {
+		name             string
+		callerPluginName string
+	}{
+		{name: "public request"},
+		{name: "caller without matching invoke", callerPluginName: "slackbot"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := manager.ResolveTools(context.Background(), &principal.Principal{
+				SubjectID: principal.UserSubjectID("user-1"),
+			}, coreagent.ResolveToolsRequest{
+				CallerPluginName: tc.callerPluginName,
+				ToolRefs: []coreagent.ToolRef{{
+					Plugin:         "slack",
+					Operation:      "events.reply",
+					CredentialMode: core.ConnectionModeNone,
+				}},
+			})
+			if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+				t.Fatalf("ResolveTools error = %v, want ErrAuthorizationDenied", err)
+			}
+		})
 	}
 }

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -375,6 +375,9 @@ func (r *agentRuntime) ExecuteTool(ctx context.Context, req coreagent.ExecuteToo
 	if connection := strings.TrimSpace(tool.Target.Connection); connection != "" {
 		ctx = invocation.WithConnection(ctx, connection)
 	}
+	if mode := tool.Target.CredentialMode; mode != "" {
+		ctx = invocation.WithCredentialModeOverride(ctx, mode)
+	}
 	params := maps.Clone(req.Arguments)
 	result, err := invoker.Invoke(ctx, principalValue, tool.Target.Plugin, strings.TrimSpace(tool.Target.Instance), tool.Target.Operation, params)
 	if err != nil {
@@ -490,9 +493,9 @@ func (r *agentRuntime) SearchTools(ctx context.Context, req coreagent.SearchTool
 
 func lookupAgentTool(tools []coreagent.Tool, toolID string) (coreagent.Tool, bool) {
 	toolID = strings.TrimSpace(toolID)
-	for _, tool := range tools {
-		if strings.TrimSpace(tool.ID) == toolID {
-			return tool, true
+	for i := range tools {
+		if strings.TrimSpace(tools[i].ID) == toolID {
+			return tools[i], true
 		}
 	}
 	return coreagent.Tool{}, false
@@ -504,13 +507,13 @@ func mergeAgentTools(existing []coreagent.Tool, loaded []coreagent.Tool) []corea
 	}
 	out := append([]coreagent.Tool(nil), existing...)
 	seen := make(map[string]struct{}, len(out)+len(loaded))
-	for _, tool := range out {
-		if id := strings.TrimSpace(tool.ID); id != "" {
+	for i := range out {
+		if id := strings.TrimSpace(out[i].ID); id != "" {
 			seen[id] = struct{}{}
 		}
 	}
-	for _, tool := range loaded {
-		id := strings.TrimSpace(tool.ID)
+	for i := range loaded {
+		id := strings.TrimSpace(loaded[i].ID)
 		if id == "" {
 			continue
 		}
@@ -518,7 +521,7 @@ func mergeAgentTools(existing []coreagent.Tool, loaded []coreagent.Tool) []corea
 			continue
 		}
 		seen[id] = struct{}{}
-		out = append(out, tool)
+		out = append(out, loaded[i])
 	}
 	return out
 }
@@ -534,21 +537,21 @@ func validateAgentToolSearchResults(p *principal.Principal, refs []coreagent.Too
 	if source != coreagent.ToolSourceModeNativeSearch {
 		return fmt.Errorf("%w: unsupported agent tool source %q", invocation.ErrInternal, source)
 	}
-	for _, tool := range tools {
-		if strings.TrimSpace(tool.ID) == "" {
+	for i := range tools {
+		if strings.TrimSpace(tools[i].ID) == "" {
 			return fmt.Errorf("%w: searched agent tool id is required", invocation.ErrAuthorizationDenied)
 		}
-		target := tool.Target
+		target := tools[i].Target
 		pluginName := strings.TrimSpace(target.Plugin)
 		operation := strings.TrimSpace(target.Operation)
 		if pluginName == "" || operation == "" {
 			return fmt.Errorf("%w: searched agent tool target is incomplete", invocation.ErrAuthorizationDenied)
 		}
 		if !principal.AllowsProviderPermission(p, pluginName) || !principal.AllowsOperationPermission(p, pluginName, operation) {
-			return fmt.Errorf("%w: searched agent tool %q is not authorized", invocation.ErrAuthorizationDenied, tool.ID)
+			return fmt.Errorf("%w: searched agent tool %q is not authorized", invocation.ErrAuthorizationDenied, tools[i].ID)
 		}
 		if len(refs) > 0 && !agentToolMatchesRefs(target, refs) {
-			return fmt.Errorf("%w: searched agent tool %q is outside the turn tool scope", invocation.ErrAuthorizationDenied, tool.ID)
+			return fmt.Errorf("%w: searched agent tool %q is outside the turn tool scope", invocation.ErrAuthorizationDenied, tools[i].ID)
 		}
 	}
 	return nil
@@ -569,6 +572,9 @@ func agentToolMatchesRefs(target coreagent.ToolTarget, refs []coreagent.ToolRef)
 		if instance := strings.TrimSpace(ref.Instance); instance != "" && instance != strings.TrimSpace(target.Instance) {
 			continue
 		}
+		if ref.CredentialMode != "" && ref.CredentialMode != target.CredentialMode {
+			continue
+		}
 		return true
 	}
 	return false
@@ -579,9 +585,9 @@ func permissionsForAgentTools(tools []coreagent.Tool) []core.AccessPermission {
 		return nil
 	}
 	operationsByPlugin := make(map[string]map[string]struct{}, len(tools))
-	for _, tool := range tools {
-		pluginName := strings.TrimSpace(tool.Target.Plugin)
-		operation := strings.TrimSpace(tool.Target.Operation)
+	for i := range tools {
+		pluginName := strings.TrimSpace(tools[i].Target.Plugin)
+		operation := strings.TrimSpace(tools[i].Target.Operation)
 		if pluginName == "" || operation == "" {
 			continue
 		}

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -17,6 +17,7 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
@@ -46,10 +47,11 @@ func testHostedAgentRuntimeConfig() *config.HostedRuntimeConfig {
 }
 
 type agentRuntimeInvokerCall struct {
-	providerName string
-	operation    string
-	params       map[string]any
-	subjectID    string
+	providerName           string
+	operation              string
+	params                 map[string]any
+	subjectID              string
+	credentialModeOverride core.ConnectionMode
 }
 
 type recordingAgentRuntimeInvoker struct {
@@ -60,10 +62,11 @@ type recordingAgentRuntimeInvoker struct {
 func (i *recordingAgentRuntimeInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	i.mu.Lock()
 	i.calls = append(i.calls, agentRuntimeInvokerCall{
-		providerName: providerName,
-		operation:    operation,
-		params:       cloneAnyMap(params),
-		subjectID:    p.SubjectID,
+		providerName:           providerName,
+		operation:              operation,
+		params:                 cloneAnyMap(params),
+		subjectID:              p.SubjectID,
+		credentialModeOverride: invocation.CredentialModeOverrideFromContext(ctx),
 	})
 	i.mu.Unlock()
 
@@ -774,8 +777,9 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 			ID:   "lookup",
 			Name: "Lookup roadmap task",
 			Target: coreagent.ToolTarget{
-				Plugin:    "roadmap",
-				Operation: "sync",
+				Plugin:         "roadmap",
+				Operation:      "sync",
+				CredentialMode: core.ConnectionModeNone,
 			},
 		}},
 	})
@@ -826,6 +830,9 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 	}
 	if calls[0].subjectID != "user:user-123" {
 		t.Fatalf("invoker subject_id = %q, want user:user-123", calls[0].subjectID)
+	}
+	if calls[0].credentialModeOverride != core.ConnectionModeNone {
+		t.Fatalf("invoker credential mode override = %q, want %q", calls[0].credentialModeOverride, core.ConnectionModeNone)
 	}
 
 	events, err := agents[0].ListTurnEvents(context.Background(), coreagent.ListTurnEventsRequest{

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1463,9 +1463,10 @@ func EffectiveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *provider
 type OperationOverride = providermanifestv1.ManifestOperationOverride
 
 type PluginInvocationDependency struct {
-	Plugin    string `yaml:"plugin,omitempty"`
-	Operation string `yaml:"operation,omitempty"`
-	Surface   string `yaml:"surface,omitempty"`
+	Plugin         string                            `yaml:"plugin,omitempty"`
+	Operation      string                            `yaml:"operation,omitempty"`
+	Surface        string                            `yaml:"surface,omitempty"`
+	CredentialMode providermanifestv1.ConnectionMode `yaml:"credentialMode,omitempty"`
 }
 
 func Load(path string) (*Config, error) {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -487,6 +487,7 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax
 		entry.Invokes[i].Plugin = strings.TrimSpace(entry.Invokes[i].Plugin)
 		entry.Invokes[i].Operation = strings.TrimSpace(entry.Invokes[i].Operation)
 		entry.Invokes[i].Surface = strings.ToLower(strings.TrimSpace(entry.Invokes[i].Surface))
+		entry.Invokes[i].CredentialMode = providermanifestv1.ConnectionMode(strings.ToLower(strings.TrimSpace(string(entry.Invokes[i].CredentialMode))))
 		switch {
 		case entry.Invokes[i].Plugin == "":
 			return fmt.Errorf("config validation: plugins.%s.invokes[%d].plugin is required", name, i)
@@ -496,6 +497,8 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax
 			return fmt.Errorf("config validation: plugins.%s.invokes[%d] may set only one of .operation or .surface", name, i)
 		case entry.Invokes[i].Surface != "" && entry.Invokes[i].Surface != string(SpecSurfaceGraphQL):
 			return fmt.Errorf("config validation: plugins.%s.invokes[%d].surface %q is not supported", name, i, entry.Invokes[i].Surface)
+		case entry.Invokes[i].CredentialMode != "" && entry.Invokes[i].CredentialMode != providermanifestv1.ConnectionModeNone && entry.Invokes[i].CredentialMode != providermanifestv1.ConnectionModeUser:
+			return fmt.Errorf("config validation: plugins.%s.invokes[%d].credentialMode %q is not supported", name, i, entry.Invokes[i].CredentialMode)
 		}
 		key := entry.Invokes[i].Plugin + "\x00op:" + entry.Invokes[i].Operation + "\x00surface:" + entry.Invokes[i].Surface
 		if prev, ok := seenInvokes[key]; ok {

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -180,6 +180,15 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 	if !core.SupportsSessionCatalog(prov) {
 		return nil, false, nil
 	}
+	if CredentialModeOverrideFromContext(ctx) == core.ConnectionModeNone {
+		ctx = WithCredentialContext(ctx, CredentialContext{
+			Mode:       core.ConnectionModeNone,
+			Connection: strings.TrimSpace(connection),
+			Instance:   strings.TrimSpace(instance),
+		})
+		cat, _, err := core.CatalogForRequest(ctx, prov, "")
+		return cat, true, err
+	}
 	if effectiveConnectionMode(ctx, prov) == core.ConnectionModeNone {
 		if resolver != nil && p != nil {
 			enrichedCtx, token, err := resolver.ResolveToken(ctx, p, provName, connection, instance)

--- a/gestaltd/internal/providerhost/agent_convert.go
+++ b/gestaltd/internal/providerhost/agent_convert.go
@@ -138,8 +138,8 @@ func agentToolsToProto(tools []coreagent.Tool) ([]*proto.ResolvedAgentTool, erro
 		return nil, nil
 	}
 	out := make([]*proto.ResolvedAgentTool, 0, len(tools))
-	for _, tool := range tools {
-		value, err := agentToolToProto(tool)
+	for i := range tools {
+		value, err := agentToolToProto(tools[i])
 		if err != nil {
 			return nil, err
 		}

--- a/gestaltd/internal/providerhost/invocation_grants.go
+++ b/gestaltd/internal/providerhost/invocation_grants.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 )
 
 type invocationGrant struct {
 	AllOperations bool
-	Operations    map[string]struct{}
+	Operations    map[string]core.ConnectionMode
 	Surfaces      map[string]struct{}
 }
 
@@ -20,9 +21,10 @@ type InvocationGrant = invocationGrant
 type InvocationGrants = invocationGrants
 
 type invocationGrantClaims struct {
-	AllOperations bool     `json:"all_operations,omitempty"`
-	Operations    []string `json:"operations,omitempty"`
-	Surfaces      []string `json:"surfaces,omitempty"`
+	AllOperations  bool              `json:"all_operations,omitempty"`
+	Operations     []string          `json:"operations,omitempty"`
+	OperationModes map[string]string `json:"operation_modes,omitempty"`
+	Surfaces       []string          `json:"surfaces,omitempty"`
 }
 
 func InvocationDependencyGrants(deps []config.PluginInvocationDependency) InvocationGrants {
@@ -40,9 +42,9 @@ func InvocationDependencyGrants(deps []config.PluginInvocationDependency) Invoca
 		grant := grants[plugin]
 		if operation != "" {
 			if grant.Operations == nil {
-				grant.Operations = make(map[string]struct{})
+				grant.Operations = make(map[string]core.ConnectionMode)
 			}
-			grant.Operations[operation] = struct{}{}
+			grant.Operations[operation] = core.ConnectionMode(dep.CredentialMode)
 		}
 		if surface != "" {
 			if grant.Surfaces == nil {
@@ -81,9 +83,9 @@ func decodePluginInvocationGrantProto(grants []*proto.PluginInvocationGrant) inv
 				continue
 			}
 			if decodedGrant.Operations == nil {
-				decodedGrant.Operations = make(map[string]struct{})
+				decodedGrant.Operations = make(map[string]core.ConnectionMode)
 			}
-			decodedGrant.Operations[operation] = struct{}{}
+			decodedGrant.Operations[operation] = ""
 		}
 		for _, surface := range grant.GetSurfaces() {
 			surface = strings.ToLower(strings.TrimSpace(surface))
@@ -118,9 +120,9 @@ func cloneInvocationGrants(src invocationGrants) invocationGrants {
 			AllOperations: grant.AllOperations,
 		}
 		if len(grant.Operations) > 0 {
-			cloned.Operations = make(map[string]struct{}, len(grant.Operations))
-			for operation := range grant.Operations {
-				cloned.Operations[operation] = struct{}{}
+			cloned.Operations = make(map[string]core.ConnectionMode, len(grant.Operations))
+			for operation, mode := range grant.Operations {
+				cloned.Operations[operation] = mode
 			}
 		}
 		if len(grant.Surfaces) > 0 {
@@ -141,9 +143,10 @@ func encodeInvocationGrantClaims(src invocationGrants) map[string]invocationGran
 	out := make(map[string]invocationGrantClaims, len(src))
 	for plugin, grant := range src {
 		out[plugin] = invocationGrantClaims{
-			AllOperations: grant.AllOperations,
-			Operations:    sortedGrantKeys(grant.Operations),
-			Surfaces:      sortedGrantKeys(grant.Surfaces),
+			AllOperations:  grant.AllOperations,
+			Operations:     sortedGrantKeys(grant.Operations),
+			OperationModes: grantOperationModes(grant.Operations),
+			Surfaces:       sortedGrantKeys(grant.Surfaces),
 		}
 	}
 	return out
@@ -164,9 +167,19 @@ func decodeInvocationGrantClaims(src map[string]invocationGrantClaims) invocatio
 				continue
 			}
 			if decoded.Operations == nil {
-				decoded.Operations = make(map[string]struct{})
+				decoded.Operations = make(map[string]core.ConnectionMode)
 			}
-			decoded.Operations[operation] = struct{}{}
+			decoded.Operations[operation] = ""
+		}
+		for operation, mode := range grant.OperationModes {
+			operation = strings.TrimSpace(operation)
+			if operation == "" {
+				continue
+			}
+			if _, ok := decoded.Operations[operation]; !ok {
+				continue
+			}
+			decoded.Operations[operation] = core.ConnectionMode(strings.TrimSpace(mode))
 		}
 		for _, surface := range grant.Surfaces {
 			surface = strings.ToLower(strings.TrimSpace(surface))
@@ -199,8 +212,12 @@ func invocationGrantSubset(candidate, allowed invocationGrants) bool {
 			return false
 		}
 		if len(grant.Operations) > 0 && !allowedGrant.AllOperations {
-			for operation := range grant.Operations {
-				if _, ok := allowedGrant.Operations[operation]; !ok {
+			for operation, mode := range grant.Operations {
+				allowedMode, ok := allowedGrant.Operations[operation]
+				if !ok {
+					return false
+				}
+				if mode != "" && allowedMode != "" && mode != allowedMode {
 					return false
 				}
 			}
@@ -212,6 +229,23 @@ func invocationGrantSubset(candidate, allowed invocationGrants) bool {
 		}
 	}
 	return true
+}
+
+func inheritInvocationGrantModes(candidate, parent invocationGrants) invocationGrants {
+	out := cloneInvocationGrants(candidate)
+	for plugin, grant := range out {
+		parentGrant, ok := parent[plugin]
+		if !ok || len(grant.Operations) == 0 {
+			continue
+		}
+		for operation, mode := range grant.Operations {
+			if mode == "" {
+				grant.Operations[operation] = parentGrant.Operations[operation]
+			}
+		}
+		out[plugin] = grant
+	}
+	return out
 }
 
 func allowsOperation(grants invocationGrants, plugin, operation string) bool {
@@ -229,6 +263,17 @@ func allowsOperation(grants invocationGrants, plugin, operation string) bool {
 	return ok
 }
 
+func operationCredentialMode(grants invocationGrants, plugin, operation string) core.ConnectionMode {
+	if len(grants) == 0 {
+		return ""
+	}
+	grant, ok := grants[plugin]
+	if !ok || grant.AllOperations {
+		return ""
+	}
+	return grant.Operations[operation]
+}
+
 func allowsSurface(grants invocationGrants, plugin, surface string) bool {
 	if len(grants) == 0 {
 		return false
@@ -241,7 +286,7 @@ func allowsSurface(grants invocationGrants, plugin, surface string) bool {
 	return ok
 }
 
-func sortedGrantKeys(values map[string]struct{}) []string {
+func sortedGrantKeys[V any](values map[string]V) []string {
 	if len(values) == 0 {
 		return nil
 	}
@@ -251,4 +296,20 @@ func sortedGrantKeys(values map[string]struct{}) []string {
 	}
 	slices.Sort(keys)
 	return keys
+}
+
+func grantOperationModes(operations map[string]core.ConnectionMode) map[string]string {
+	if len(operations) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(operations))
+	for operation, mode := range operations {
+		if mode != "" {
+			out[operation] = string(mode)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/gestaltd/internal/providerhost/invocation_token.go
+++ b/gestaltd/internal/providerhost/invocation_token.go
@@ -70,13 +70,14 @@ type invocationClaims struct {
 }
 
 type invocationTokenContext struct {
-	principal   *principal.Principal
-	requestMeta invocation.RequestMeta
-	credential  invocation.CredentialContext
-	invocation  *invocation.InvocationMeta
-	surface     invocation.InvocationSurface
-	connection  string
-	grants      invocationGrants
+	principal              *principal.Principal
+	requestMeta            invocation.RequestMeta
+	credential             invocation.CredentialContext
+	credentialModeOverride core.ConnectionMode
+	invocation             *invocation.InvocationMeta
+	surface                invocation.InvocationSurface
+	connection             string
+	grants                 invocationGrants
 }
 
 func NewInvocationTokenManager(secret []byte) (*InvocationTokenManager, error) {
@@ -121,6 +122,8 @@ func (m *InvocationTokenManager) ExchangeToken(parentToken, pluginName string, g
 		grants = parentGrants
 	case !invocationGrantSubset(grants, parentGrants):
 		return "", fmt.Errorf("requested invocation grants exceed the parent token")
+	default:
+		grants = inheritInvocationGrantModes(grants, parentGrants)
 	}
 	child := *claims
 	child.ID = uuid.NewString()
@@ -301,6 +304,9 @@ func restoreInvocationTokenContext(ctx context.Context, tokenCtx invocationToken
 	}
 	if tokenCtx.credential != (invocation.CredentialContext{}) {
 		ctx = invocation.WithCredentialContext(ctx, tokenCtx.credential)
+	}
+	if tokenCtx.credentialModeOverride != "" {
+		ctx = invocation.WithCredentialModeOverride(ctx, tokenCtx.credentialModeOverride)
 	}
 	if tokenCtx.surface != "" {
 		ctx = invocation.WithInvocationSurface(ctx, tokenCtx.surface)

--- a/gestaltd/internal/providerhost/invocation_token_test.go
+++ b/gestaltd/internal/providerhost/invocation_token_test.go
@@ -38,7 +38,7 @@ func TestInvocationTokenExchangePreservesAbsoluteDelegationExpiry(t *testing.T) 
 		&invocation.InvocationMeta{RequestID: "req-1"},
 	)
 	rootToken, err := manager.MintRootToken(ctx, "caller", invocationGrants{
-		"example": {Operations: map[string]struct{}{"request_context": {}}},
+		"example": {Operations: map[string]core.ConnectionMode{"request_context": ""}},
 	})
 	if err != nil {
 		t.Fatalf("MintRootToken: %v", err)
@@ -104,7 +104,7 @@ func TestInvocationTokenExchangeAllowsNarrowingWildcardGrants(t *testing.T) {
 	}
 
 	if _, err := manager.ExchangeToken(rootToken, "caller", invocationGrants{
-		"example": {Operations: map[string]struct{}{"request_context": {}}},
+		"example": {Operations: map[string]core.ConnectionMode{"request_context": ""}},
 	}, time.Minute); err != nil {
 		t.Fatalf("ExchangeToken should allow narrowing wildcard grants: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestInvocationTokenResolvePreservesEmailOnlyPrincipals(t *testing.T) {
 		},
 	)
 	token, err := manager.MintRootToken(ctx, "caller", invocationGrants{
-		"example": {Operations: map[string]struct{}{"request_context": {}}},
+		"example": {Operations: map[string]core.ConnectionMode{"request_context": ""}},
 	})
 	if err != nil {
 		t.Fatalf("MintRootToken: %v", err)
@@ -148,5 +148,27 @@ func TestInvocationTokenResolvePreservesEmailOnlyPrincipals(t *testing.T) {
 	}
 	if got := tokenCtx.principal.Identity.Email; got != "ada@example.com" {
 		t.Fatalf("resolved email = %q, want ada@example.com", got)
+	}
+}
+
+func TestDecodeInvocationGrantClaimsIgnoresModesForUndeclaredOperations(t *testing.T) {
+	t.Parallel()
+
+	grants := decodeInvocationGrantClaims(map[string]invocationGrantClaims{
+		"slack": {
+			Operations: []string{"chat.postMessage"},
+			OperationModes: map[string]string{
+				"chat.postMessage": "user",
+				"events.reply":     "none",
+			},
+		},
+	})
+
+	slackGrant := grants["slack"]
+	if _, ok := slackGrant.Operations["events.reply"]; ok {
+		t.Fatal("decodeInvocationGrantClaims should not add operations that only appear in operation_modes")
+	}
+	if got := slackGrant.Operations["chat.postMessage"]; got != core.ConnectionModeUser {
+		t.Fatalf("chat.postMessage mode = %q, want %q", got, core.ConnectionModeUser)
 	}
 }

--- a/gestaltd/internal/providerhost/plugin_invoker.go
+++ b/gestaltd/internal/providerhost/plugin_invoker.go
@@ -174,6 +174,10 @@ func (s *PluginInvokerServer) tokenContextForInvoke(req *proto.PluginInvokeReque
 	if !allowsOperation(tokenCtx.grants, targetPlugin, targetOperation) || !s.allows(targetPlugin, targetOperation) {
 		return invocationTokenContext{}, status.Errorf(codes.PermissionDenied, "plugin %q may not invoke %s.%s", s.pluginName, targetPlugin, targetOperation)
 	}
+	tokenCtx.credentialModeOverride = operationCredentialMode(tokenCtx.grants, targetPlugin, targetOperation)
+	if tokenCtx.credentialModeOverride == "" {
+		tokenCtx.credentialModeOverride = operationCredentialMode(s.allowed, targetPlugin, targetOperation)
+	}
 	return tokenCtx, nil
 }
 

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -113,6 +113,15 @@ func (s *stubBoundTokenResolver) ResolveToken(ctx context.Context, _ *principal.
 	return ctx, s.token, nil
 }
 
+type recordingBindingTokenResolver struct {
+	tokenCalls int
+}
+
+func (s *recordingBindingTokenResolver) ResolveToken(ctx context.Context, _ *principal.Principal, _ string, _ string, _ string) (context.Context, string, error) {
+	s.tokenCalls++
+	return ctx, "user-token", nil
+}
+
 func TestResolveCatalog_StaticCatalog(t *testing.T) {
 	t.Parallel()
 
@@ -296,6 +305,46 @@ func TestResolveCatalog_ModeNonePrincipalUsesRequestedSelectors(t *testing.T) {
 	}
 	if resolver.lastInstance != "team-a" {
 		t.Fatalf("resolver instance = %q, want team-a", resolver.lastInstance)
+	}
+	if len(cat.Operations) != 1 || cat.Operations[0].ID != "session_only" {
+		t.Fatalf("catalog operations = %+v, want session_only", cat.Operations)
+	}
+}
+
+func TestResolveCatalog_CredentialModeNoneOverrideSkipsSessionTokenResolution(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubDynamicSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "override-none-api",
+				connMode: core.ConnectionModeUser,
+			},
+		},
+		sessionCatFn: func(ctx context.Context, token string) (*catalog.Catalog, error) {
+			if token != "" {
+				t.Fatalf("token = %q, want empty token for credentialMode none override", token)
+			}
+			if got := invocation.CredentialContextFromContext(ctx).Mode; got != core.ConnectionModeNone {
+				t.Fatalf("credential mode = %q, want %q", got, core.ConnectionModeNone)
+			}
+			return &catalog.Catalog{
+				Name: "override-none-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "session_only", Method: http.MethodGet},
+				},
+			}, nil
+		},
+	}
+	resolver := &recordingBindingTokenResolver{}
+
+	ctx := invocation.WithCredentialModeOverride(context.Background(), core.ConnectionModeNone)
+	cat, err := invocation.ResolveCatalog(ctx, prov, "override-none-api", resolver, &principal.Principal{UserID: "u1"}, "default", "workspace-a")
+	if err != nil {
+		t.Fatalf("ResolveCatalog: %v", err)
+	}
+	if resolver.tokenCalls != 0 {
+		t.Fatalf("token resolver calls = %d, want 0", resolver.tokenCalls)
 	}
 	if len(cat.Operations) != 1 || cat.Operations[0].ID != "session_only" {
 		t.Fatalf("catalog operations = %+v, want session_only", cat.Operations)

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -640,10 +640,18 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
 		resolver = tr
 	}
+	if visible, ok := staticCatalogOperationVisibleByDefault(surfaceProv, operationName); ok && !visible {
+		s.writeInvocationError(w, r, providerName, operationName, invocation.ErrOperationNotFound)
+		return
+	}
 	sessionConnections := s.catalogSelectorConfig().SessionCatalogConnections(providerName, connection)
 	opMeta, _, resolvedConnection, err := invocation.ResolveOperation(ctx, surfaceProv, providerName, resolver, p, operationName, sessionConnections, instance)
 	if err != nil {
 		s.writeInvocationError(w, r, providerName, operationName, err)
+		return
+	}
+	if !catalog.OperationVisibleByDefault(opMeta) {
+		s.writeInvocationError(w, r, providerName, operationName, invocation.ErrOperationNotFound)
 		return
 	}
 	metricutil.AddHTTPAttributes(r.Context(),
@@ -774,12 +782,26 @@ func httpVisibleCatalogOperations(ops []catalog.CatalogOperation) []catalog.Cata
 	filtered := make([]catalog.CatalogOperation, 0, len(ops))
 	for i := range ops {
 		op := ops[i]
+		if !catalog.OperationVisibleByDefault(op) {
+			continue
+		}
 		if invocation.OperationTransport(op) == catalog.TransportMCPPassthrough {
 			continue
 		}
 		filtered = append(filtered, op)
 	}
 	return filtered
+}
+
+func staticCatalogOperationVisibleByDefault(prov core.Provider, operation string) (bool, bool) {
+	if prov == nil {
+		return true, false
+	}
+	op, ok := invocation.CatalogOperation(prov.Catalog(), operation)
+	if !ok {
+		return true, false
+	}
+	return catalog.OperationVisibleByDefault(op), true
 }
 
 func safeOperationErrorMessage(err error) (string, bool) {

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -64,12 +64,13 @@ type agentMessagePartImageRefRequest struct {
 }
 
 type agentToolRefRequest struct {
-	Plugin      string `json:"plugin,omitempty"`
-	Operation   string `json:"operation,omitempty"`
-	Connection  string `json:"connection,omitempty"`
-	Instance    string `json:"instance,omitempty"`
-	Title       string `json:"title,omitempty"`
-	Description string `json:"description,omitempty"`
+	Plugin         string `json:"plugin,omitempty"`
+	Operation      string `json:"operation,omitempty"`
+	Connection     string `json:"connection,omitempty"`
+	Instance       string `json:"instance,omitempty"`
+	CredentialMode string `json:"credentialMode,omitempty"`
+	Title          string `json:"title,omitempty"`
+	Description    string `json:"description,omitempty"`
 }
 
 type agentSessionCreateRequest struct {
@@ -657,12 +658,13 @@ func agentToolRefsFromRequest(refs []agentToolRefRequest) []coreagent.ToolRef {
 	out := make([]coreagent.ToolRef, 0, len(refs))
 	for _, ref := range refs {
 		out = append(out, coreagent.ToolRef{
-			Plugin:      strings.TrimSpace(ref.Plugin),
-			Operation:   strings.TrimSpace(ref.Operation),
-			Connection:  strings.TrimSpace(ref.Connection),
-			Instance:    strings.TrimSpace(ref.Instance),
-			Title:       strings.TrimSpace(ref.Title),
-			Description: strings.TrimSpace(ref.Description),
+			Plugin:         strings.TrimSpace(ref.Plugin),
+			Operation:      strings.TrimSpace(ref.Operation),
+			Connection:     strings.TrimSpace(ref.Connection),
+			Instance:       strings.TrimSpace(ref.Instance),
+			CredentialMode: core.ConnectionMode(strings.ToLower(strings.TrimSpace(ref.CredentialMode))),
+			Title:          strings.TrimSpace(ref.Title),
+			Description:    strings.TrimSpace(ref.Description),
 		})
 	}
 	return out
@@ -675,12 +677,13 @@ func agentToolRefsToRequest(refs []coreagent.ToolRef) []agentToolRefRequest {
 	out := make([]agentToolRefRequest, 0, len(refs))
 	for _, ref := range refs {
 		out = append(out, agentToolRefRequest{
-			Plugin:      strings.TrimSpace(ref.Plugin),
-			Operation:   strings.TrimSpace(ref.Operation),
-			Connection:  strings.TrimSpace(ref.Connection),
-			Instance:    strings.TrimSpace(ref.Instance),
-			Title:       strings.TrimSpace(ref.Title),
-			Description: strings.TrimSpace(ref.Description),
+			Plugin:         strings.TrimSpace(ref.Plugin),
+			Operation:      strings.TrimSpace(ref.Operation),
+			Connection:     strings.TrimSpace(ref.Connection),
+			Instance:       strings.TrimSpace(ref.Instance),
+			CredentialMode: string(ref.CredentialMode),
+			Title:          strings.TrimSpace(ref.Title),
+			Description:    strings.TrimSpace(ref.Description),
 		})
 	}
 	return out
@@ -690,6 +693,11 @@ func validateAgentToolRefs(refs []agentToolRefRequest) error {
 	for idx, ref := range refs {
 		if strings.TrimSpace(ref.Plugin) == "" {
 			return fmt.Errorf("toolRefs[%d].plugin is required", idx)
+		}
+		switch strings.ToLower(strings.TrimSpace(ref.CredentialMode)) {
+		case "":
+		default:
+			return fmt.Errorf("toolRefs[%d].credentialMode is not supported on public agent requests", idx)
 		}
 	}
 	return nil

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -13874,6 +13874,168 @@ func TestHostedHTTPBinding_APIKeySyncInvokesOperation(t *testing.T) {
 	}
 }
 
+func TestVisibleFalseHidesOperationFromHTTPSurfacesButAllowsHostedBinding(t *testing.T) {
+	t.Parallel()
+
+	hidden := false
+	invocations := make(chan string, 1)
+	provider := &stubIntegrationWithCatalog{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "events",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				invocations <- op
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		catalog: serverTestCatalog("events", []catalog.CatalogOperation{
+			{ID: "visible_status", Method: http.MethodGet, Path: "/visible_status", Transport: catalog.TransportREST},
+			{ID: "handle_event", Method: http.MethodPost, Path: "/handle_event", Transport: catalog.TransportREST, Visible: &hidden},
+		}),
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"events": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type:   providermanifestv1.HTTPSecuritySchemeTypeAPIKey,
+						Name:   "X-Webhook-Key",
+						In:     providermanifestv1.HTTPInHeader,
+						Secret: &providermanifestv1.HTTPSecretRef{Secret: "shared-key"},
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.PluginDefs)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/api/v1/integrations/events/operations")
+	if err != nil {
+		t.Fatalf("list operations: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("list operations status = %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
+	}
+	var ops []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode operations: %v", err)
+	}
+	_ = resp.Body.Close()
+	if len(ops) != 1 || ops[0]["id"] != "visible_status" {
+		t.Fatalf("operations = %#v, want only visible_status", ops)
+	}
+
+	resp, err = http.Post(ts.URL+"/api/v1/events/handle_event", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("generic hidden operation request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("generic hidden operation status = %d, want %d: %s", resp.StatusCode, http.StatusNotFound, body)
+	}
+	select {
+	case op := <-invocations:
+		t.Fatalf("generic hidden operation unexpectedly invoked %q", op)
+	default:
+	}
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/events/event", strings.NewReader(`{"event":"opened"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Webhook-Key", "shared-key")
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("hosted binding request: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("hosted binding status = %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
+	}
+	select {
+	case op := <-invocations:
+		if op != "handle_event" {
+			t.Fatalf("hosted binding invoked %q, want handle_event", op)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for hosted binding invocation")
+	}
+}
+
+func TestVisibleFalseGenericRouteSkipsSessionCatalogCredentialResolution(t *testing.T) {
+	t.Parallel()
+
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	svc := coretesting.NewStubServices(t)
+	seedAPIToken(t, svc, plaintext, hashed, "viewer-user")
+	seedUser(t, svc, "viewer-user@test.local")
+
+	hidden := false
+	var sessionCatalogCalls atomic.Int64
+	provider := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "events",
+				ConnMode: core.ConnectionModeUser,
+			},
+		},
+		catalog: serverTestCatalog("events", []catalog.CatalogOperation{
+			{ID: "handle_event", Method: http.MethodPost, Path: "/handle_event", Transport: catalog.TransportREST, Visible: &hidden},
+		}),
+		catalogForRequestFn: func(context.Context, string) (*catalog.Catalog, error) {
+			sessionCatalogCalls.Add(1)
+			return nil, fmt.Errorf("session catalog should not be resolved for static hidden operations")
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/events/handle_event", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("generic hidden operation request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("generic hidden operation status = %d, want %d: %s", resp.StatusCode, http.StatusNotFound, body)
+	}
+	if calls := sessionCatalogCalls.Load(); calls != 0 {
+		t.Fatalf("session catalog calls = %d, want 0", calls)
+	}
+}
+
 func TestHostedHTTPBinding_APIKeyQueryDoesNotLeakCredentialParam(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Hide `catalog.CatalogOperation.Visible=false` operations from HTTP operation discovery, broad agent native-search discovery, and generic HTTP operation execution.
- Preserve explicit hosted HTTP bindings to hidden operations, so webhook-only operations still work.
- Add `credentialMode: none|user` to declared plugin invokes and agent tool refs/targets as an internal host/provider contract.
- Reject public agent HTTP `toolRefs[].credentialMode`; exact tool-ref credential modes are inferred only from the caller plugin's declared `invokes`.
- Make credential-mode overrides authoritative during session catalog resolution, so `credentialMode: none` does not resolve a user token during tool discovery or operation resolution.
- Keep invocation grant claim decoding scoped to explicitly granted operations, so `operation_modes` cannot mint extra operation grants.
- Keep existing exact-tool agent providers compatible by pre-resolving exact tool refs when the selected agent provider does not implement dynamic native tool search.

## Interfaces
```go
catalog.CatalogOperation{
    ID: "events.handle",
    Method: http.MethodPost,
    Transport: catalog.TransportREST,
    Visible: ptr(false),
}

catalog.OperationVisibleByDefault(op)
```

```yaml
http:
  event:
    path: /event
    method: POST
    credentialMode: none
    target: events.handle

invokes:
  - plugin: slack
    operation: events.reply
    credentialMode: none
```

```json
{
  "toolSource": "native_search",
  "toolRefs": [{
    "plugin": "slack",
    "operation": "events.reply"
  }]
}
```

## Examples
- `GET /api/v1/integrations/slack/operations` omits `events.handle` when `visible=false`.
- `POST /api/v1/slack/events.handle` returns 404 for that hidden operation before credential/session-catalog resolution.
- `POST /api/v1/slack/event` can still invoke `events.handle` through the signed hosted HTTP binding.
- A Slackbot plugin can create a native-search agent turn scoped to `slack.events.reply`; Gestalt applies the caller plugin's declared `credentialMode: none`, so reply discovery and execution use provider config rather than requiring or touching the Slack user OAuth token.
- If the selected agent provider does not support dynamic native tool search, exact refs such as `slack.events.reply` are pre-resolved and passed as normal resolved tools.
- A public HTTP caller that sends `toolRefs[].credentialMode` receives a validation error instead of being allowed to choose a credential mode.

## Testing
- `golangci-lint run ./...`
- `go test ./internal/invocation ./internal/server ./internal/agentmanager`
- `go test ./internal/agentmanager ./internal/bootstrap ./internal/server ./internal/mcp ./internal/providerhost ./internal/workflowmanager`
