### PR TITLE
Improve hosted agent runtime resilience

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_metrics.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_metrics.go
@@ -1,0 +1,84 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/observability"
+	"go.opentelemetry.io/otel/attribute"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	hostedAgentRuntimeReasonOK               = "ok"
+	hostedAgentRuntimeReasonError            = "error"
+	hostedAgentRuntimeReasonCanceled         = "canceled"
+	hostedAgentRuntimeReasonDeadlineExceeded = "deadline_exceeded"
+)
+
+func recordHostedAgentRuntimeInstances(ctx context.Context, providerName string, ready, starting, draining int) {
+	observability.RecordAgentRuntimeInstances(
+		ctx,
+		int64(ready),
+		int64(starting),
+		int64(draining),
+		observability.AttrAgentProvider.String(providerName),
+	)
+}
+
+func recordHostedAgentRuntimeStartPhase(ctx context.Context, providerName, phase string, startedAt time.Time, err error) {
+	observability.RecordAgentRuntimeStart(
+		ctx,
+		startedAt,
+		err != nil,
+		hostedAgentRuntimeAttrs(providerName, phase, err)...,
+	)
+}
+
+func recordHostedAgentRuntimeHealthCheck(ctx context.Context, providerName string, startedAt time.Time, err error) {
+	observability.RecordAgentRuntimeHealthCheck(
+		ctx,
+		startedAt,
+		err != nil,
+		hostedAgentRuntimeAttrs(providerName, "", err)...,
+	)
+}
+
+func recordHostedAgentRuntimeReplacement(ctx context.Context, providerName string, err error) {
+	observability.RecordAgentRuntimeReplacement(
+		ctx,
+		err != nil,
+		hostedAgentRuntimeAttrs(providerName, "", err)...,
+	)
+}
+
+func hostedAgentRuntimeAttrs(providerName, phase string, err error) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		observability.AttrAgentProvider.String(providerName),
+		observability.AttrAgentRuntimeReason.String(hostedAgentRuntimeReason(err)),
+	}
+	if strings.TrimSpace(phase) != "" {
+		attrs = append(attrs, observability.AttrAgentRuntimePhase.String(phase))
+	}
+	return attrs
+}
+
+func hostedAgentRuntimeReason(err error) string {
+	if err == nil {
+		return hostedAgentRuntimeReasonOK
+	}
+	if errors.Is(err, context.Canceled) {
+		return hostedAgentRuntimeReasonCanceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return hostedAgentRuntimeReasonDeadlineExceeded
+	}
+	code := status.Code(err)
+	if code != codes.OK && code != codes.Unknown {
+		return strings.ToLower(code.String())
+	}
+	return hostedAgentRuntimeReasonError
+}

--- a/gestaltd/internal/bootstrap/hosted_agent_pool.go
+++ b/gestaltd/internal/bootstrap/hosted_agent_pool.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 )
@@ -372,7 +373,7 @@ func (p *hostedAgentProviderPool) GetCapabilities(ctx context.Context, req corea
 func (p *hostedAgentProviderPool) Ping(ctx context.Context) error {
 	backends := p.readyBackends()
 	if len(backends) == 0 {
-		return fmt.Errorf("hosted agent provider %q has no ready runtime instances", p.name)
+		return p.unavailableError(fmt.Errorf("hosted agent provider %q has no ready runtime instances", p.name))
 	}
 	errs := make(chan error, len(backends))
 	var wg sync.WaitGroup
@@ -417,7 +418,9 @@ func (p *hostedAgentProviderPool) Close() error {
 			backend.draining = true
 		}
 	}
+	ready, starting, draining := p.instanceCountsLocked()
 	p.mu.Unlock()
+	p.recordInstanceCounts(context.Background(), ready, starting, draining)
 	p.cancel()
 
 	errs := make(chan error, len(backends))
@@ -540,30 +543,40 @@ func (p *hostedAgentProviderPool) acquireBackend(ctx context.Context, preferred 
 				return preferred, p.releaseBackend(preferred), nil
 			}
 			p.mu.Unlock()
-			return nil, nil, fmt.Errorf("hosted agent provider %q runtime instance is not ready", p.name)
+			return nil, nil, p.unavailableError(fmt.Errorf("hosted agent provider %q runtime instance is not ready", p.name))
 		}
 		if backend := p.pickReadyBackendLocked(); backend != nil {
+			var ready, starting, draining int
+			var scaled bool
 			if backend.active > 0 && p.canScaleOutLocked() {
-				p.startScaleOutLocked()
+				ready, starting, draining, scaled = p.startScaleOutLocked()
 			}
 			backend.active++
 			p.mu.Unlock()
+			if scaled {
+				p.recordInstanceCounts(ctx, ready, starting, draining)
+			}
 			return backend, p.releaseBackend(backend), nil
 		}
 		if p.canScaleOutLocked() {
 			p.starting++
+			ready, starting, draining := p.instanceCountsLocked()
 			p.mu.Unlock()
+			p.recordInstanceCounts(ctx, ready, starting, draining)
 			started, startErr := p.startBackend(ctx)
 			p.mu.Lock()
 			p.starting--
+			ready, starting, draining = p.instanceCountsLocked()
 			if startErr == nil && p.backendAvailableLocked(started, false) {
 				started.active++
 				p.mu.Unlock()
+				p.recordInstanceCounts(ctx, ready, starting, draining)
 				return started, p.releaseBackend(started), nil
 			}
 			p.mu.Unlock()
+			p.recordInstanceCounts(ctx, ready, starting, draining)
 			if startErr != nil {
-				return nil, nil, startErr
+				return nil, nil, p.unavailableError(startErr)
 			}
 			continue
 		}
@@ -624,22 +637,26 @@ func (p *hostedAgentProviderPool) canScaleOutLocked() bool {
 	return ready+p.starting < p.policy.MaxReadyInstances
 }
 
-func (p *hostedAgentProviderPool) startScaleOutLocked() {
+func (p *hostedAgentProviderPool) startScaleOutLocked() (ready, starting, draining int, scaled bool) {
 	if p.closed || !p.canScaleOutLocked() {
-		return
+		return 0, 0, 0, false
 	}
 	p.starting++
+	ready, starting, draining = p.instanceCountsLocked()
 	p.lifecycleWG.Add(1)
 	go func() {
 		defer p.lifecycleWG.Done()
 		_, err := p.startBackend(p.ctx)
 		p.mu.Lock()
 		p.starting--
+		ready, starting, draining := p.instanceCountsLocked()
 		p.mu.Unlock()
+		p.recordInstanceCounts(p.ctx, ready, starting, draining)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			slog.Warn("failed to scale out hosted agent runtime instance", "provider", p.name, "error", err)
 		}
 	}()
+	return ready, starting, draining, true
 }
 
 func (p *hostedAgentProviderPool) backendAvailableLocked(backend *hostedAgentPoolBackend, allowDraining bool) bool {
@@ -671,6 +688,47 @@ func (p *hostedAgentProviderPool) availableBackends(allowDraining bool) []*hoste
 		}
 	}
 	return out
+}
+
+func (p *hostedAgentProviderPool) unavailableError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return hostedAgentProviderUnavailableError{providerName: p.name, cause: err}
+}
+
+type hostedAgentProviderUnavailableError struct {
+	providerName string
+	cause        error
+}
+
+func (e hostedAgentProviderUnavailableError) Error() string {
+	return fmt.Sprintf("%s: %v", agentmanager.NewAgentProviderNotAvailableError(e.providerName), e.cause)
+}
+
+func (e hostedAgentProviderUnavailableError) Unwrap() []error {
+	return []error{agentmanager.NewAgentProviderNotAvailableError(e.providerName), e.cause}
+}
+
+func (p *hostedAgentProviderPool) instanceCountsLocked() (ready, starting, draining int) {
+	starting = p.starting
+	for _, backend := range p.backends {
+		if backend == nil || backend.closed {
+			continue
+		}
+		if backend.draining || backend.closing {
+			draining++
+			continue
+		}
+		if backend.provider != nil {
+			ready++
+		}
+	}
+	return ready, starting, draining
+}
+
+func (p *hostedAgentProviderPool) recordInstanceCounts(ctx context.Context, ready, starting, draining int) {
+	recordHostedAgentRuntimeInstances(ctx, p.name, ready, starting, draining)
 }
 
 func (p *hostedAgentProviderPool) sessionBackend(sessionID string) *hostedAgentPoolBackend {
@@ -844,7 +902,7 @@ func (p *hostedAgentProviderPool) healthLoop() {
 			return
 		case <-ticker.C:
 		}
-		p.ensureMinReady(p.ctx)
+		_ = p.ensureMinReady(p.ctx)
 		for _, backend := range p.readyBackends() {
 			if err := p.pingBackend(backend); err != nil {
 				slog.Warn("hosted agent runtime instance failed health check", "provider", p.name, "instance", backend.id, "error", err)
@@ -867,8 +925,11 @@ func (p *hostedAgentProviderPool) maybeProbeAfterCallError(backend *hostedAgentP
 }
 
 func (p *hostedAgentProviderPool) pingBackend(backend *hostedAgentPoolBackend) error {
+	startedAt := time.Now()
 	if backend == nil || backend.provider == nil {
-		return fmt.Errorf("runtime instance is unavailable")
+		err := fmt.Errorf("runtime instance is unavailable")
+		recordHostedAgentRuntimeHealthCheck(p.ctx, p.name, startedAt, err)
+		return err
 	}
 	timeout := p.policy.HealthCheckInterval
 	if timeout > 10*time.Second {
@@ -876,7 +937,9 @@ func (p *hostedAgentProviderPool) pingBackend(backend *hostedAgentPoolBackend) e
 	}
 	ctx, cancel := context.WithTimeout(p.ctx, timeout)
 	defer cancel()
-	return backend.provider.Ping(ctx)
+	err := backend.provider.Ping(ctx)
+	recordHostedAgentRuntimeHealthCheck(p.ctx, p.name, startedAt, err)
+	return err
 }
 
 func (p *hostedAgentProviderPool) replaceBackend(backend *hostedAgentPoolBackend) {
@@ -890,7 +953,11 @@ func (p *hostedAgentProviderPool) replaceBackend(backend *hostedAgentPoolBackend
 		defer p.lifecycleWG.Done()
 		// Replacement restores ready capacity. Session/turn recovery after the
 		// drained backend closes depends on the agent provider's durable store.
-		p.ensureMinReady(p.ctx)
+		startErr := p.ensureMinReady(p.ctx)
+		recordHostedAgentRuntimeReplacement(p.ctx, p.name, startErr)
+		if startErr != nil && !errors.Is(startErr, context.Canceled) {
+			slog.Warn("failed to replace hosted agent runtime instance", "provider", p.name, "instance", backend.id, "error", startErr)
+		}
 		if err := p.drainAndCloseBackend(backend); err != nil {
 			slog.Warn("failed to close unhealthy hosted agent runtime instance", "provider", p.name, "instance", backend.id, "error", err)
 		}
@@ -907,12 +974,12 @@ func (p *hostedAgentProviderPool) addLifecycleWork() bool {
 	return true
 }
 
-func (p *hostedAgentProviderPool) ensureMinReady(ctx context.Context) {
+func (p *hostedAgentProviderPool) ensureMinReady(ctx context.Context) error {
 	for {
 		p.mu.Lock()
 		if p.closed {
 			p.mu.Unlock()
-			return
+			return nil
 		}
 		ready := 0
 		for _, backend := range p.backends {
@@ -922,18 +989,22 @@ func (p *hostedAgentProviderPool) ensureMinReady(ctx context.Context) {
 		}
 		if ready+p.starting >= p.policy.MinReadyInstances {
 			p.mu.Unlock()
-			return
+			return nil
 		}
 		p.starting++
+		ready, starting, draining := p.instanceCountsLocked()
 		p.mu.Unlock()
+		p.recordInstanceCounts(ctx, ready, starting, draining)
 
 		_, err := p.startBackend(ctx)
 		p.mu.Lock()
 		p.starting--
+		ready, starting, draining = p.instanceCountsLocked()
 		p.mu.Unlock()
+		p.recordInstanceCounts(ctx, ready, starting, draining)
 		if err != nil {
 			slog.Warn("failed to start hosted agent runtime instance", "provider", p.name, "error", err)
-			return
+			return err
 		}
 	}
 }
@@ -958,7 +1029,9 @@ func (p *hostedAgentProviderPool) startBackend(ctx context.Context) (*hostedAgen
 		liveTurns: map[string]struct{}{},
 	}
 	p.backends = append(p.backends, backend)
+	ready, starting, draining := p.instanceCountsLocked()
 	p.mu.Unlock()
+	p.recordInstanceCounts(ctx, ready, starting, draining)
 	return backend, nil
 }
 
@@ -967,11 +1040,14 @@ func (p *hostedAgentProviderPool) markBackendDraining(backend *hostedAgentPoolBa
 		return false
 	}
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	if backend.draining || backend.closed {
+		p.mu.Unlock()
 		return false
 	}
 	backend.draining = true
+	ready, starting, draining := p.instanceCountsLocked()
+	p.mu.Unlock()
+	p.recordInstanceCounts(p.ctx, ready, starting, draining)
 	return true
 }
 
@@ -996,7 +1072,9 @@ func (p *hostedAgentProviderPool) drainAndCloseBackend(backend *hostedAgentPoolB
 		if (active == 0 && liveTurns == 0) || time.Now().After(deadline) {
 			backend.closed = true
 			p.removeBackendLocked(backend)
+			ready, starting, draining := p.instanceCountsLocked()
 			p.mu.Unlock()
+			p.recordInstanceCounts(p.ctx, ready, starting, draining)
 			break
 		}
 		p.mu.Unlock()

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1076,7 +1076,10 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	cfg := launch.cfg
 	runtimePlan := launch.runtimePlan
 	name := launch.name
+
+	phaseStarted := time.Now()
 	session, err := runtimeProvider.StartSession(ctx, buildHostedRuntimeStartSessionRequest(providermanifestv1.KindAgent, name, launch.runtimeConfig))
+	recordHostedAgentRuntimeStartPhase(ctx, name, "runtime_session_start", phaseStarted, err)
 	if err != nil {
 		if closeRuntime {
 			_ = runtimeProvider.Close()
@@ -1101,15 +1104,20 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 			cleanup()
 		}
 	}()
+	phaseStarted = time.Now()
 	if err := waitForPluginRuntimeSessionReady(ctx, runtimeProvider, sessionID); err != nil {
+		recordHostedAgentRuntimeStartPhase(ctx, name, "runtime_session_ready", phaseStarted, err)
 		return nil, fmt.Errorf("wait for hosted agent runtime session %q ready: %w", sessionID, err)
 	}
+	recordHostedAgentRuntimeStartPhase(ctx, name, "runtime_session_ready", phaseStarted, nil)
 
+	phaseStarted = time.Now()
 	startedHostServices, err := providerhost.StartHostServices(
 		hostServices,
 		providerhost.WithHostServicesProviderName(name),
 		providerhost.WithHostServicesTelemetry(deps.Telemetry),
 	)
+	recordHostedAgentRuntimeStartPhase(ctx, name, "host_services_start", phaseStarted, err)
 	if err != nil {
 		return nil, fmt.Errorf("start agent runtime host services: %w", err)
 	}
@@ -1119,12 +1127,15 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 
 	startEnv := maps.Clone(cfg.Env)
 	allowedHosts := hostedAgentAllowedHosts(cfg.AllowedHosts, runtimePlan)
+	phaseStarted = time.Now()
 	for _, hostService := range startedHostServices.Bindings() {
 		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect)
 		if err != nil {
+			recordHostedAgentRuntimeStartPhase(ctx, name, "host_services_bind", phaseStarted, err)
 			return nil, err
 		}
 		if _, err := runtimeProvider.BindHostService(ctx, bindingReq); err != nil {
+			recordHostedAgentRuntimeStartPhase(ctx, name, "host_services_bind", phaseStarted, err)
 			return nil, fmt.Errorf("bind host service %q: %w", hostService.EnvVar, err)
 		}
 		if len(bindingEnv) > 0 {
@@ -1137,8 +1148,11 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 			allowedHosts = appendAllowedHost(allowedHosts, relayHost)
 		}
 	}
+	recordHostedAgentRuntimeStartPhase(ctx, name, "host_services_bind", phaseStarted, nil)
 	if runtimePlan.HostnameEgressDelivery == RuntimeHostnameEgressDeliveryPublicProxy {
+		phaseStarted = time.Now()
 		proxyEnv, err := buildHostedRuntimePublicEgressProxy(name, sessionID, cfg.AllowedHosts, deps.Egress.DefaultAction, deps)
+		recordHostedAgentRuntimeStartPhase(ctx, name, "public_egress_proxy", phaseStarted, err)
 		if err != nil {
 			return nil, err
 		}
@@ -1150,6 +1164,7 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 		}
 	}
 
+	phaseStarted = time.Now()
 	hostedPlugin, err := runtimeProvider.StartPlugin(ctx, pluginruntime.StartPluginRequest{
 		SessionID:     sessionID,
 		PluginName:    name,
@@ -1161,16 +1176,20 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 		DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
 		HostBinary:    cfg.HostBinary,
 	})
+	recordHostedAgentRuntimeStartPhase(ctx, name, "plugin_start", phaseStarted, err)
 	if err != nil {
 		return nil, fmt.Errorf("start hosted agent provider: %w", err)
 	}
+	phaseStarted = time.Now()
 	conn, err := pluginruntime.DialHostedAgent(ctx, hostedPlugin.DialTarget,
 		pluginruntime.WithProviderName(name),
 		pluginruntime.WithTelemetry(deps.Telemetry),
 	)
+	recordHostedAgentRuntimeStartPhase(ctx, name, "provider_dial", phaseStarted, err)
 	if err != nil {
 		return nil, fmt.Errorf("dial hosted agent provider: %w", err)
 	}
+	phaseStarted = time.Now()
 	provider, err := providerhost.NewRemoteAgent(ctx, providerhost.RemoteAgentConfig{
 		Client:  conn.Agent(),
 		Runtime: conn.Lifecycle(),
@@ -1184,6 +1203,7 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 		Config: cfg.Config,
 		Name:   name,
 	})
+	recordHostedAgentRuntimeStartPhase(ctx, name, "provider_configure", phaseStarted, err)
 	if err != nil {
 		_ = conn.Close()
 		return nil, err

--- a/gestaltd/internal/metricutil/meter.go
+++ b/gestaltd/internal/metricutil/meter.go
@@ -61,6 +61,15 @@ func NewInt64Counter(meter metric.Meter, name, desc string) metric.Int64Counter 
 	return counter
 }
 
+func NewInt64Gauge(meter metric.Meter, name, desc string) metric.Int64Gauge {
+	gauge, err := meter.Int64Gauge(name, metric.WithDescription(desc))
+	if err != nil {
+		otel.Handle(err)
+		return noopmetric.Int64Gauge{}
+	}
+	return gauge
+}
+
 func NewFloat64Histogram(meter metric.Meter, name, desc, unit string) metric.Float64Histogram {
 	histogram, err := meter.Float64Histogram(
 		name,

--- a/gestaltd/internal/observability/observability.go
+++ b/gestaltd/internal/observability/observability.go
@@ -17,6 +17,8 @@ const tracerName = "gestaltd"
 var (
 	AttrAgentOperation         = attribute.Key("gestalt.agent.operation")
 	AttrAgentProvider          = attribute.Key("gestalt.agent.provider")
+	AttrAgentRuntimePhase      = attribute.Key("gestalt.agent.runtime.phase")
+	AttrAgentRuntimeReason     = attribute.Key("gestalt.agent.runtime.reason")
 	AttrAgentToolSource        = attribute.Key("gestalt.agent.tool.source")
 	AttrAuthorizationOperation = attribute.Key("gestalt.authorization.operation")
 	AttrAuthorizationProvider  = attribute.Key("gestalt.authorization.provider")
@@ -32,9 +34,24 @@ type metricSet struct {
 	duration   metric.Float64Histogram
 }
 
+type agentRuntimeInstanceMetricSet struct {
+	ready    metric.Int64Gauge
+	starting metric.Int64Gauge
+	draining metric.Int64Gauge
+}
+
+type countMetricSet struct {
+	count      metric.Int64Counter
+	errorCount metric.Int64Counter
+}
+
 var (
 	agentOperationMetrics                metricutil.MeterCache[metricSet]
 	agentProviderOperationMetrics        metricutil.MeterCache[metricSet]
+	agentRuntimeInstanceMetrics          metricutil.MeterCache[agentRuntimeInstanceMetricSet]
+	agentRuntimeStartMetrics             metricutil.MeterCache[metricSet]
+	agentRuntimeHealthCheckMetrics       metricutil.MeterCache[metricSet]
+	agentRuntimeReplacementMetrics       metricutil.MeterCache[countMetricSet]
 	agentToolResolveMetrics              metricutil.MeterCache[metricSet]
 	agentRunMetadataWriteMetrics         metricutil.MeterCache[metricSet]
 	authorizationProviderOperationMetric metricutil.MeterCache[metricSet]
@@ -82,6 +99,47 @@ func RecordAgentOperation(ctx context.Context, startedAt time.Time, failed bool,
 
 func RecordAgentProviderOperation(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
 	record(ctx, &agentProviderOperationMetrics, "gestaltd.agent.provider.operation", "gestaltd agent provider operations", startedAt, failed, attrs...)
+}
+
+func RecordAgentRuntimeInstances(ctx context.Context, ready, starting, draining int64, attrs ...attribute.KeyValue) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	metrics := agentRuntimeInstanceMetrics.Load(ctx, tracerName, func(meter metric.Meter) agentRuntimeInstanceMetricSet {
+		return agentRuntimeInstanceMetricSet{
+			ready: metricutil.NewInt64Gauge(
+				meter,
+				"gestaltd.agent.runtime.ready_instances",
+				"Records ready gestaltd agent runtime instances.",
+			),
+			starting: metricutil.NewInt64Gauge(
+				meter,
+				"gestaltd.agent.runtime.starting_instances",
+				"Records starting gestaltd agent runtime instances.",
+			),
+			draining: metricutil.NewInt64Gauge(
+				meter,
+				"gestaltd.agent.runtime.draining_instances",
+				"Records draining gestaltd agent runtime instances.",
+			),
+		}
+	})
+	opts := metric.WithAttributes(attrs...)
+	metrics.ready.Record(ctx, ready, opts)
+	metrics.starting.Record(ctx, starting, opts)
+	metrics.draining.Record(ctx, draining, opts)
+}
+
+func RecordAgentRuntimeStart(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &agentRuntimeStartMetrics, "gestaltd.agent.runtime.start", "gestaltd agent runtime starts", startedAt, failed, attrs...)
+}
+
+func RecordAgentRuntimeHealthCheck(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &agentRuntimeHealthCheckMetrics, "gestaltd.agent.runtime.health_check", "gestaltd agent runtime health checks", startedAt, failed, attrs...)
+}
+
+func RecordAgentRuntimeReplacement(ctx context.Context, failed bool, attrs ...attribute.KeyValue) {
+	recordCount(ctx, &agentRuntimeReplacementMetrics, "gestaltd.agent.runtime.replacement", "gestaltd agent runtime replacements", failed, attrs...)
 }
 
 func RecordAgentToolResolve(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
@@ -142,6 +200,30 @@ func record(ctx context.Context, cache *metricutil.MeterCache[metricSet], prefix
 	})
 	metrics.count.Add(ctx, 1, metric.WithAttributes(attrs...))
 	metrics.duration.Record(ctx, time.Since(startedAt).Seconds(), metric.WithAttributes(attrs...))
+	if failed {
+		metrics.errorCount.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+}
+
+func recordCount(ctx context.Context, cache *metricutil.MeterCache[countMetricSet], prefix, desc string, failed bool, attrs ...attribute.KeyValue) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	metrics := cache.Load(ctx, tracerName, func(meter metric.Meter) countMetricSet {
+		return countMetricSet{
+			count: metricutil.NewInt64Counter(
+				meter,
+				prefix+".count",
+				"Counts "+desc+".",
+			),
+			errorCount: metricutil.NewInt64Counter(
+				meter,
+				prefix+".error_count",
+				"Counts failed "+desc+".",
+			),
+		}
+	})
+	metrics.count.Add(ctx, 1, metric.WithAttributes(attrs...))
 	if failed {
 		metrics.errorCount.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}

--- a/gestaltd/internal/pluginruntime/executable.go
+++ b/gestaltd/internal/pluginruntime/executable.go
@@ -3,6 +3,7 @@ package pluginruntime
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 	"sync"
@@ -104,7 +105,7 @@ func (p *executableProvider) StartSession(ctx context.Context, req StartSessionR
 			SessionID:           session.ID,
 			Metadata:            metadata,
 		}); err != nil {
-			return nil, fmt.Errorf("register runtime session logs: %w", err)
+			slog.WarnContext(ctx, "failed to register runtime session logs", "runtime_provider", p.name, "session", session.ID, "error", err)
 		}
 	}
 	return session, nil

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -125,8 +126,7 @@ func (p *LocalProvider) StartSession(_ context.Context, req StartSessionRequest)
 			SessionID:           sessionID,
 			Metadata:            cloneStringMap(session.metadata),
 		}); err != nil {
-			_ = os.RemoveAll(rootDir)
-			return nil, fmt.Errorf("register runtime session logs: %w", err)
+			slog.Warn("failed to register runtime session logs", "runtime_provider", p.runtimeProviderName, "session", sessionID, "error", err)
 		}
 	}
 	p.sessions[sessionID] = session

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -863,10 +863,11 @@ func (s *Server) writeAgentManagerError(w http.ResponseWriter, r *http.Request, 
 	switch {
 	case errors.Is(err, agentmanager.ErrAgentNotConfigured),
 		errors.Is(err, agentmanager.ErrAgentProviderRequired),
-		errors.Is(err, agentmanager.ErrAgentProviderNotAvailable),
 		errors.Is(err, agentmanager.ErrAgentSessionMetadataNotConfigured),
 		errors.Is(err, agentmanager.ErrAgentTurnMetadataNotConfigured):
 		writeError(w, http.StatusPreconditionFailed, err.Error())
+	case errors.Is(err, agentmanager.ErrAgentProviderNotAvailable):
+		writeError(w, http.StatusServiceUnavailable, err.Error())
 	case errors.Is(err, agentmanager.ErrAgentSubjectRequired):
 		writeError(w, http.StatusUnauthorized, err.Error())
 	case errors.Is(err, agentmanager.ErrAgentSessionCreationInProgress),

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -24,7 +24,6 @@ import (
 const (
 	runtimeShutdownTimeout        = 15 * time.Second
 	readinessDatastorePingTimeout = 2 * time.Second
-	readinessAgentPingTimeout     = 5 * time.Second
 )
 
 func httpCatalogConnectionMap(connMaps bootstrap.ConnectionMaps) map[string]string {
@@ -103,14 +102,6 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 			defer cancel()
 			if err := result.Services.Ping(pingCtx); err != nil {
 				return "datastore unavailable"
-			}
-			if result.AgentControl != nil {
-				agentPingCtx, agentPingCancel := context.WithTimeout(context.Background(), readinessAgentPingTimeout)
-				defer agentPingCancel()
-				if err := result.AgentControl.Ping(agentPingCtx); err != nil {
-					slog.Warn("agent provider readiness check failed", "error", err)
-					return "agent providers unavailable"
-				}
 			}
 			return ""
 		},


### PR DESCRIPTION
## Summary

This PR makes hosted agent runtime failures observable and less disruptive:

- Runtime session log registration is warning-only instead of fatal.
- `/ready` no longer fails when an agent runtime pool has zero ready instances; server readiness remains tied to provider bootstrap and datastore health.
- Hosted runtime startup/no-ready failures are normalized through `agentmanager.ErrAgentProviderNotAvailable`, so HTTP callers get a provider-unavailable response instead of the generic `agent request failed` 500 path.
- Hosted agent runtime lifecycle metrics are emitted for instance state, startup phases, health checks, and replacements.

## New interfaces

```go
observability.RecordAgentRuntimeInstances(ctx, ready, starting, draining, attrs...)
observability.RecordAgentRuntimeStart(ctx, startedAt, failed, attrs...)
observability.RecordAgentRuntimeHealthCheck(ctx, startedAt, failed, attrs...)
observability.RecordAgentRuntimeReplacement(ctx, failed, attrs...)
metricutil.NewInt64Gauge(meter, name, desc)
```

## Metrics

```text
gestaltd.agent.runtime.ready_instances
gestaltd.agent.runtime.starting_instances
gestaltd.agent.runtime.draining_instances
gestaltd.agent.runtime.start.count
gestaltd.agent.runtime.start.error_count
gestaltd.agent.runtime.start.duration
gestaltd.agent.runtime.health_check.count
gestaltd.agent.runtime.health_check.error_count
gestaltd.agent.runtime.health_check.duration
gestaltd.agent.runtime.replacement.count
gestaltd.agent.runtime.replacement.error_count
```

Attributes:

```text
gestalt.agent.provider=simple
gestalt.agent.runtime.phase=runtime_session_start|runtime_session_ready|host_services_start|host_services_bind|public_egress_proxy|plugin_start|provider_dial|provider_configure
gestalt.agent.runtime.reason=ok|deadline_exceeded|canceled|unavailable|error
```

## Example behavior

```text
GET /ready -> 200 once providers/datastore are ready, even if hosted agent runtime pool is temporarily empty.
POST /api/v1/agent/sessions -> 503 {"error":"agent provider \"simple\" is not available: ..."} when no hosted runtime instance can be started.
```

## Validation

```bash
cd gestaltd
go test ./internal/metricutil ./internal/observability ./internal/pluginruntime ./internal/bootstrap ./internal/server
```