### PR TITLE
Bootstrap TypeScript provider dev dependencies

### DIFF
--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -2521,7 +2521,7 @@ func writeFakeTypeScriptComponentReleaseBunForPlatforms(t *testing.T, expectedTa
 	sourceDir := "."
 	return fakebun.NewExecutable(t, fakebun.Config{
 		Install: &fakebun.InstallConfig{
-			ExpectedCwd:           sdkPath,
+			ExpectedCwds:          []string{sourceDir, sdkPath},
 			RequireFrozenLockfile: true,
 		},
 		Build: &fakebun.BuildConfig{
@@ -2560,7 +2560,7 @@ func writeFakeTypeScriptProviderReleaseBun(t *testing.T, expectedPluginName, exp
 	sourceDir := "."
 	return fakebun.NewExecutable(t, fakebun.Config{
 		Install: &fakebun.InstallConfig{
-			ExpectedCwd:           sdkPath,
+			ExpectedCwds:          []string{sourceDir, sdkPath},
 			RequireFrozenLockfile: true,
 		},
 		Runtime: &fakebun.RuntimeConfig{

--- a/gestaltd/internal/providerpkg/typescript_provider.go
+++ b/gestaltd/internal/providerpkg/typescript_provider.go
@@ -83,6 +83,9 @@ func typeScriptExecutionCommand(root, target string) (string, []string, func(), 
 	if err != nil {
 		return "", nil, nil, err
 	}
+	if err := ensureTypeScriptProjectDependencies(bunPath, root); err != nil {
+		return "", nil, nil, err
+	}
 	sdkPath, err := prepareLocalTypeScriptSDK(bunPath)
 	if err != nil {
 		return "", nil, nil, err
@@ -97,8 +100,8 @@ func typeScriptExecutionCommand(root, target string) (string, []string, func(), 
 		}, nil, nil
 	}
 	return bunPath, []string{
-		"--cwd", root,
 		"run",
+		"--cwd", root,
 		typeScriptRuntimeBin,
 		"--",
 		root,
@@ -122,6 +125,9 @@ func buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goar
 	if err != nil {
 		return "", fmt.Errorf("detect Bun executable: %w", err)
 	}
+	if err := ensureTypeScriptProjectDependencies(bunPath, sourceDir); err != nil {
+		return "", fmt.Errorf("prepare TypeScript provider dependencies: %w", err)
+	}
 
 	var args []string
 	sdkPath, err := prepareLocalTypeScriptSDK(bunPath)
@@ -142,8 +148,8 @@ func buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goar
 		}
 	} else {
 		args = []string{
-			"--cwd", sourceDir,
 			"run",
+			"--cwd", sourceDir,
 			typeScriptBuildBin,
 			"--",
 			sourceDir,
@@ -227,31 +233,39 @@ func prepareLocalTypeScriptSDK(bunPath string) (string, error) {
 	return sdkPath, nil
 }
 
+func ensureTypeScriptProjectDependencies(bunPath, root string) error {
+	return ensureTypeScriptDependencies(bunPath, root, "TypeScript provider")
+}
+
 func ensureLocalTypeScriptSDKDependencies(bunPath, sdkPath string) error {
-	nodeModulesPath := filepath.Join(sdkPath, "node_modules")
+	return ensureTypeScriptDependencies(bunPath, sdkPath, "local TypeScript SDK")
+}
+
+func ensureTypeScriptDependencies(bunPath, root, label string) error {
+	nodeModulesPath := filepath.Join(root, "node_modules")
 	if info, err := os.Stat(nodeModulesPath); err == nil {
 		if info.IsDir() {
 			return nil
 		}
-		return fmt.Errorf("local TypeScript SDK node_modules path %q is not a directory", nodeModulesPath)
+		return fmt.Errorf("%s node_modules path %q is not a directory", label, nodeModulesPath)
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat local TypeScript SDK node_modules: %w", err)
+		return fmt.Errorf("stat %s node_modules: %w", label, err)
 	}
 
-	args := []string{"install", "--cwd", sdkPath}
-	lockfilePath := filepath.Join(sdkPath, "bun.lock")
+	args := []string{"install", "--cwd", root}
+	lockfilePath := filepath.Join(root, "bun.lock")
 	if _, err := os.Stat(lockfilePath); err == nil {
 		args = append(args, "--frozen-lockfile")
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat local TypeScript SDK bun.lock: %w", err)
+		return fmt.Errorf("stat %s bun.lock: %w", label, err)
 	}
 
 	cmd := exec.Command(bunPath, args...)
-	cmd.Dir = sdkPath
+	cmd.Dir = root
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("bun install for local TypeScript SDK: %w", err)
+		return fmt.Errorf("bun install for %s: %w", label, err)
 	}
 	return nil
 }

--- a/gestaltd/internal/providerpkg/typescript_provider_test.go
+++ b/gestaltd/internal/providerpkg/typescript_provider_test.go
@@ -378,11 +378,59 @@ func TestSourceProviderExecutionCommand_TypeScriptInstallsLocalSDKDeps(t *testin
 	if command != bunPath {
 		t.Fatalf("command = %q, want %q", command, bunPath)
 	}
+	if _, err := os.Stat(filepath.Join(root, "node_modules", ".installed")); err != nil {
+		t.Fatalf("expected bun install marker in provider node_modules: %v", err)
+	}
 	if _, err := os.Stat(filepath.Join(sdkDir, "node_modules", ".installed")); err != nil {
 		t.Fatalf("expected bun install marker in fake SDK node_modules: %v", err)
 	}
 	if got := filepath.Dir(args[2]); got != filepath.Join(sdkDir, "src") {
 		t.Fatalf("runtime entry dir = %q, want %q", got, filepath.Join(sdkDir, "src"))
+	}
+}
+
+func TestSourceProviderExecutionCommand_TypeScriptPackageRuntime(t *testing.T) {
+	root := t.TempDir()
+	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
+	t.Setenv(typeScriptSDKDirEnvVar, filepath.Join(t.TempDir(), "missing-sdk"))
+
+	bunPath := fakebun.NewExecutable(t, fakebun.Config{
+		Install: &fakebun.InstallConfig{
+			ExpectedCwd: root,
+		},
+		Runtime: &fakebun.RuntimeConfig{
+			Mode:           fakebun.InvocationRun,
+			ExpectedCwd:    root,
+			ExpectedEntry:  typeScriptRuntimeBin,
+			ExpectedRoot:   root,
+			ExpectedTarget: typeScriptTestPluginTarget,
+		},
+	})
+	t.Setenv(typeScriptBunEnvVar, bunPath)
+
+	command, args, cleanup, err := SourceProviderExecutionCommand(root, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("SourceProviderExecutionCommand: %v", err)
+	}
+	if cleanup != nil {
+		t.Fatal("cleanup should be nil for TypeScript source providers")
+	}
+	if command != bunPath {
+		t.Fatalf("command = %q, want %q", command, bunPath)
+	}
+	if got := strings.Join(args, "\x00"); got != strings.Join([]string{
+		"run",
+		"--cwd",
+		root,
+		typeScriptRuntimeBin,
+		"--",
+		root,
+		typeScriptTestPluginTarget,
+	}, "\x00") {
+		t.Fatalf("args = %v", args)
+	}
+	if _, err := os.Stat(filepath.Join(root, "node_modules", ".installed")); err != nil {
+		t.Fatalf("expected bun install marker in provider node_modules: %v", err)
 	}
 }
 
@@ -567,8 +615,52 @@ func TestBuildSourceProviderReleaseBinary_TypeScriptInstallsLocalSDKDeps(t *test
 	if _, err := BuildSourceProviderReleaseBinary(root, outputPath, "ts-release", runtime.GOOS, runtime.GOARCH); err != nil {
 		t.Fatalf("BuildSourceProviderReleaseBinary: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(root, "node_modules", ".installed")); err != nil {
+		t.Fatalf("expected bun install marker in provider node_modules: %v", err)
+	}
 	if _, err := os.Stat(filepath.Join(sdkDir, "node_modules", ".installed")); err != nil {
 		t.Fatalf("expected bun install marker in fake SDK node_modules: %v", err)
+	}
+}
+
+func TestBuildSourceProviderReleaseBinary_TypeScriptPackageBuild(t *testing.T) {
+	root := t.TempDir()
+	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
+	t.Setenv(typeScriptSDKDirEnvVar, filepath.Join(t.TempDir(), "missing-sdk"))
+
+	bunPath := fakebun.NewExecutable(t, fakebun.Config{
+		Install: &fakebun.InstallConfig{
+			ExpectedCwd: root,
+		},
+		Build: &fakebun.BuildConfig{
+			Mode:               fakebun.InvocationRun,
+			ExpectedCwd:        root,
+			ExpectedEntry:      typeScriptBuildBin,
+			ExpectedSourceDir:  root,
+			ExpectedTarget:     typeScriptTestPluginTarget,
+			ExpectedPluginName: "ts-release",
+			AllowedPlatforms: []fakebun.Platform{{
+				GOOS:   runtime.GOOS,
+				GOARCH: runtime.GOARCH,
+			}},
+			BinaryContent: "#!/bin/sh\n# fake package ts release binary\nexit 0\n",
+		},
+	})
+	t.Setenv(typeScriptBunEnvVar, bunPath)
+
+	outputPath := filepath.Join(t.TempDir(), "gestalt-plugin-ts-release")
+	if _, err := BuildSourceProviderReleaseBinary(root, outputPath, "ts-release", runtime.GOOS, runtime.GOARCH); err != nil {
+		t.Fatalf("BuildSourceProviderReleaseBinary: %v", err)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", outputPath, err)
+	}
+	if !containsString(string(data), "fake package ts release binary") {
+		t.Fatalf("binary contents = %q, want fake build marker", string(data))
+	}
+	if _, err := os.Stat(filepath.Join(root, "node_modules", ".installed")); err != nil {
+		t.Fatalf("expected bun install marker in provider node_modules: %v", err)
 	}
 }
 
@@ -766,7 +858,7 @@ func writeFakeTypeScriptBun(t *testing.T, root, pluginName, expectedTarget, expe
 
 	return fakebun.NewExecutable(t, fakebun.Config{
 		Install: &fakebun.InstallConfig{
-			ExpectedCwd:           sdkPath,
+			ExpectedCwds:          []string{root, sdkPath},
 			RequireFrozenLockfile: true,
 		},
 		Runtime: &fakebun.RuntimeConfig{

--- a/gestaltd/internal/testutil/cmd/fakebun/main.go
+++ b/gestaltd/internal/testutil/cmd/fakebun/main.go
@@ -79,11 +79,24 @@ func runInstall(cfg *fakebun.InstallConfig, args []string) error {
 	if cwd == "" {
 		return fmt.Errorf("missing bun install --cwd")
 	}
-	if cfg.ExpectedCwd != "" && cwd != cfg.ExpectedCwd {
-		return fmt.Errorf("unexpected bun install cwd: %s != %s", cwd, cfg.ExpectedCwd)
+	if cfg.ExpectedCwd != "" || len(cfg.ExpectedCwds) > 0 {
+		allowed := cwd == cfg.ExpectedCwd
+		for _, expected := range cfg.ExpectedCwds {
+			if cwd == expected {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return fmt.Errorf("unexpected bun install cwd: %s", cwd)
+		}
 	}
 	if cfg.RequireFrozenLockfile && !frozen {
-		return fmt.Errorf("missing bun install --frozen-lockfile")
+		if _, err := os.Stat(filepath.Join(cwd, "bun.lock")); err == nil {
+			return fmt.Errorf("missing bun install --frozen-lockfile")
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("stat bun.lock: %w", err)
+		}
 	}
 
 	nodeModulesDir := filepath.Join(cwd, "node_modules")
@@ -192,13 +205,12 @@ func parseInvocation(mode fakebun.InvocationMode, args []string) (invocation, er
 	if mode == "" {
 		mode = fakebun.InvocationDirect
 	}
-	if len(args) < 3 || args[0] != "--cwd" {
-		return invocation{}, fmt.Errorf("unexpected fake bun args: %s", strings.Join(args, " "))
-	}
-
-	cwd := args[1]
 	switch mode {
 	case fakebun.InvocationDirect:
+		if len(args) < 3 || args[0] != "--cwd" {
+			return invocation{}, fmt.Errorf("unexpected fake bun args: %s", strings.Join(args, " "))
+		}
+		cwd := args[1]
 		entry := args[2]
 		tail := args[3:]
 		if len(tail) > 0 && tail[0] == "--" {
@@ -206,9 +218,22 @@ func parseInvocation(mode fakebun.InvocationMode, args []string) (invocation, er
 		}
 		return invocation{cwd: cwd, entry: entry, tail: tail}, nil
 	case fakebun.InvocationRun:
-		if len(args) < 4 || args[2] != "run" {
+		if args[0] == "run" {
+			if len(args) < 4 || args[1] != "--cwd" {
+				return invocation{}, fmt.Errorf("unexpected fake bun args: %s", strings.Join(args, " "))
+			}
+			cwd := args[2]
+			entry := args[3]
+			tail := args[4:]
+			if len(tail) > 0 && tail[0] == "--" {
+				tail = tail[1:]
+			}
+			return invocation{cwd: cwd, entry: entry, tail: tail}, nil
+		}
+		if len(args) < 4 || args[0] != "--cwd" || args[2] != "run" {
 			return invocation{}, fmt.Errorf("unexpected fake bun args: %s", strings.Join(args, " "))
 		}
+		cwd := args[1]
 		entry := args[3]
 		tail := args[4:]
 		if len(tail) > 0 && tail[0] == "--" {

--- a/gestaltd/internal/testutil/fakebun/fakebun.go
+++ b/gestaltd/internal/testutil/fakebun/fakebun.go
@@ -26,8 +26,9 @@ type Config struct {
 }
 
 type InstallConfig struct {
-	ExpectedCwd           string `json:"expected_cwd,omitempty"`
-	RequireFrozenLockfile bool   `json:"require_frozen_lockfile,omitempty"`
+	ExpectedCwd           string   `json:"expected_cwd,omitempty"`
+	ExpectedCwds          []string `json:"expected_cwds,omitempty"`
+	RequireFrozenLockfile bool     `json:"require_frozen_lockfile,omitempty"`
 }
 
 type RuntimeConfig struct {


### PR DESCRIPTION
## Summary

Make TypeScript source providers closer to "just works" for local and remote provider development:

- Install the provider package dependencies with `bun install --cwd <provider>` when `node_modules` is absent before runtime/build execution.
- Keep using `--frozen-lockfile` when the provider has `bun.lock`.
- Fix package-script fallback execution for current Bun by using `bun run --cwd <provider> ...` instead of the broken global `bun --cwd <provider> run ...` form.
- Extend the fake Bun test helper so existing provider release/dev contract tests can cover both local SDK execution and package-script fallback execution.

## Interface

No new CLI flags.

```sh
gestaltd provider dev --remote https://valon.tools --path ./deployment-viewer/plugin --name deploymentViewer
gestaltd provider release --path ./deployment-viewer/plugin
```

With this change, a TypeScript provider source tree does not need a pre-existing `node_modules` directory before those commands run.

## Verification

```sh
cd gestaltd && go test ./internal/providerpkg -run 'TestSourceProviderExecutionCommand_TypeScript|TestBuildSourceProviderReleaseBinary_TypeScript' -count=1
cd gestaltd && go test ./cmd/gestaltd -run 'TestRun_ProviderReleaseBuildsTypeScriptSourcePluginForCurrentPlatform|TestRun_ProviderReleaseBuildsTypeScriptComponentSourceProvider|TestRun_ProviderReleaseValidatesSourceProviderPackages' -count=1
```

Manual remote contract test against deployed `https://valon.tools` using a temporary token that was revoked afterward:

```sh
GESTALT_TYPESCRIPT_SDK_DIR=/nonexistent \
GESTALT_API_KEY=<temp-token> \
gestaltd provider dev --remote https://valon.tools \
  --path /tmp/provider-dev-ts-bootstrap.../deployment-viewer/plugin \
  --name deploymentViewer

GESTALT_API_KEY=<same-temp-token> \
gestalt invoke deploymentViewer rate-limit-status --format json
```

The source tree had no `node_modules`; provider dev ran `bun install`, attached the remote session, and the invocation returned the expected rate-limit payload.