### PR TITLE
Consolidate canonical config shapes

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -101,7 +101,7 @@ server:
     port: ...
 ```
 
-ProviderEntry-backed entries accept `source` (where to load it from), `config` (provider-specific settings), `allowedHosts`, and optional metadata fields. Plugin entries additionally support plugin-only fields such as `connections`, `allowedOperations`, `mountPath`, `ui`, and `runtime`. See the [Config File](/reference/config-file) reference for every field.
+ProviderEntry-backed entries accept `source` (where to load it from), `config` (provider-specific settings), `allowedHosts`, and optional metadata fields. Plugin entries additionally support plugin-only fields such as `connections`, `allowedOperations`, `ui.path`, `ui.bundle`, and `runtime`. See the [Config File](/reference/config-file) reference for every field.
 
 ## Key concepts
 
@@ -115,7 +115,7 @@ Gestalt has ten core concepts you configure in YAML:
 - **[Authentication.](/providers/authentication)** Platform login for the Gestalt server. Separate from connection authentication, which is per-plugin and per-upstream.
 - **[Secrets.](/providers/secrets)** Resolves structured secret refs in the config at startup. Backed by environment variables, files, or cloud secret managers.
 - **[Workflow.](/providers/workflow)** Global workflow runs, schedules, and triggers backed by a workflow provider and optional host IndexedDB storage.
-- **[UI.](/providers/ui)** Public static UI bundles served under configured path prefixes, either directly from `providers.ui` or through `plugins.<name>.mountPath`. Omit `providers.ui` to run headless.
+- **[UI.](/providers/ui)** Public static UI bundles served under configured path prefixes, either directly from `providers.ui` or through `plugins.<name>.ui.path`. Omit `providers.ui` to run headless.
 - **Runtime.** Optional execution backends for executable plugins. Plugins stay host-local by default; `plugins.<name>.runtime` opts a plugin into hosted execution and `runtime.providers` names the available backends.
 
 ## Adding a plugin
@@ -130,8 +130,9 @@ plugins:
     surfaces:
       openapi:
         baseUrl: https://api.github.com
-    mountPath: /github
-    ui: github_console
+    ui:
+      path: /github
+      bundle: github_console
 ```
 
 For published providers, `source` usually points at a `provider-release.yaml` metadata URL. When the release is hosted in GitHub and you want checked-in config to stay readable, use `source.githubRelease` instead. Gestalt resolves the matching platform archive during `init` and records the exact release in the lockfile. First-party providers are published from `github.com/valon-technologies/gestalt-providers/`.
@@ -518,23 +519,28 @@ workflows:
   schedules:
     nightly_sync:
       provider: local
-      plugin: roadmap
       cron: "0 3 * * *"
       timezone: America/New_York
-      operation: sync_items
+      target:
+        plugin:
+          name: roadmap
+          operation: sync_items
   eventTriggers:
     item_updated:
       provider: local
-      plugin: roadmap
       match:
         type: roadmap.item.updated
-      operation: sync_items
+      target:
+        plugin:
+          name: roadmap
+          operation: sync_items
 ```
 
-Workflow targets are always explicit: `plugin`, `operation`, and optional
-`connection`, `instance`, and `input`. Config-managed schedules and event
-triggers are reconciled into the provider at startup. See
-[Workflow](/providers/workflow) for the user-facing and provider model.
+Workflow targets are always explicit through `target.plugin` or `target.agent`.
+For plugin targets, set `name`, `operation`, and optional `connection`,
+`instance`, and `input`. Config-managed schedules and event triggers are
+reconciled into the provider at startup. See [Workflow](/providers/workflow)
+for the user-facing and provider model.
 
 ## Configuring agent providers
 

--- a/docs/content/custom-providers/workflow.mdx
+++ b/docs/content/custom-providers/workflow.mdx
@@ -471,10 +471,12 @@ workflows:
   schedules:
     nightly_sync:
       provider: local
-      plugin: roadmap
       cron: "0 3 * * *"
       timezone: America/New_York
-      operation: sync_items
+      target:
+        plugin:
+          name: roadmap
+          operation: sync_items
 ```
 
 `providers.workflow.<name>.indexeddb` is optional. When present, Gestalt

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -74,6 +74,13 @@ providers:
       runtime:
         provider: modal
         image: ghcr.io/valon/gestalt-python-runtime:latest
+        pool:
+          minReadyInstances: 1
+          maxReadyInstances: 4
+          startupTimeout: 2m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 1m
       allowedHosts:
         - api.openai.com
         - api.anthropic.com
@@ -84,6 +91,10 @@ providers:
 This keeps the caller interface the same. The request still targets
 `provider: simple`. The only difference is where the provider executes and how
 `gestaltd` enforces host-service access and egress.
+
+`runtime.pool` is the canonical hosted agent lifecycle block. The older flat
+runtime lifecycle fields are still accepted for compatibility, but cannot be
+mixed with `pool`.
 
 ## Session and turn shape
 

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -2,7 +2,7 @@
 
 UI providers are static asset bundles. Gestalt serves each configured
 bundle either directly from `providers.ui.<name>.path` or via
-`plugins.<name>.mountPath`. The built-in admin UI at `/admin` remains available
+`plugins.<name>.ui.path`. The built-in admin UI at `/admin` remains available
 regardless of whether public UI bundles are configured.
 
 ## How UI providers work
@@ -63,8 +63,9 @@ providers:
 plugins:
   roadmap_review:
     source: ./customer-roadmap-review/plugin/manifest.yaml
-    ui: roadmap
-    mountPath: /create-customer-roadmap-review
+    ui:
+      bundle: roadmap
+      path: /create-customer-roadmap-review
     authorizationPolicy: roadmap_review
 ```
 
@@ -74,7 +75,8 @@ Or let the plugin manifest own the UI bundle and keep only the deployment bindin
 plugins:
   roadmap_review:
     source: ./customer-roadmap-review/plugin/manifest.yaml
-    mountPath: /create-customer-roadmap-review
+    ui:
+      path: /create-customer-roadmap-review
     authorizationPolicy: roadmap_review
 ```
 
@@ -142,7 +144,7 @@ Asset-root layout, build hooks, and release packaging now live under
 
 ## What to read next
 
-- [Configuration](/configuration): `providers.ui`, `plugins.<name>.mountPath`, and headless deployments
+- [Configuration](/configuration): `providers.ui`, `plugins.<name>.ui.path`, and headless deployments
 - [Client UI](/client/web): what the default client exposes
 - [Authorization](/providers/authorization): route and role semantics
 - [Custom UI](/custom-providers/ui): advanced authoring docs

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -2,11 +2,11 @@ import { Callout, Tabs } from 'nextra/components'
 
 # Workflow
 
-Gestalt workflows let you invoke a plugin operation later instead of right now.
+Gestalt workflows let you invoke a plugin operation or agent target later
+instead of right now.
 Today that primarily means cron-based schedules, triggers, workflow run
 history, event publishing, and run cancelation. The workflow model is global.
-A workflow target is always explicit: `plugin`, `operation`, and optional
-`connection`, `instance`, and `input`.
+A workflow target is always explicit: `target.plugin` or `target.agent`.
 
 <Callout type="info">
   The public workflow surface now covers schedules, triggers, event publishing,
@@ -106,15 +106,17 @@ workflows:
   schedules:
     nightly_sync:
       provider: local
-      plugin: roadmap
       cron: "0 3 * * *"
       timezone: America/New_York
-      operation: sync
-      connection: default
-      instance: tenant-a
-      input:
-        mode: incremental
-        includeArchived: false
+      target:
+        plugin:
+          name: roadmap
+          operation: sync
+          connection: default
+          instance: tenant-a
+          input:
+            mode: incremental
+            includeArchived: false
 ```
 
 This creates a durable schedule named `nightly_sync` that invokes
@@ -127,17 +129,19 @@ workflows:
   eventTriggers:
     roadmap_item_updated:
       provider: local
-      plugin: slack
       match:
         type: roadmap.item.updated
         source: roadmap
         subject: item
-      operation: chat.postMessage
-      connection: alerts
-      instance: engineering
-      input:
-        channel: C123456
-        text: "A roadmap item changed."
+      target:
+        plugin:
+          name: slack
+          operation: chat.postMessage
+          connection: alerts
+          instance: engineering
+          input:
+            channel: C123456
+            text: "A roadmap item changed."
 ```
 
 This creates a durable trigger that listens for published events with:
@@ -145,6 +149,11 @@ This creates a durable trigger that listens for published events with:
 `source = "roadmap"` and `subject = "item"`. When an event matches, Gestalt
 invokes `slack.chat.postMessage` with the static input above and records a
 workflow run.
+
+For compatibility, config-managed workflows still accept the older flat
+`plugin`, `operation`, `connection`, `instance`, `input`, and `agent` fields.
+New config should use `target`, and `target` cannot be mixed with those legacy
+fields.
 
 ### Match semantics
 
@@ -395,12 +404,14 @@ workflows:
   schedules:
     nightly_sync:
       provider: local
-      plugin: roadmap
-      operation: sync
       cron: "0 3 * * *"
       timezone: UTC
-      input:
-        mode: incremental
+      target:
+        plugin:
+          name: roadmap
+          operation: sync
+          input:
+            mode: incremental
 
   eventTriggers:
     notify_sync_completed:
@@ -408,23 +419,27 @@ workflows:
       match:
         type: roadmap.sync.completed
         source: roadmap
-      plugin: slack
-      operation: chat.postMessage
-      connection: alerts
-      input:
-        channel: C123456
-        text: "Nightly roadmap sync completed."
+      target:
+        plugin:
+          name: slack
+          operation: chat.postMessage
+          connection: alerts
+          input:
+            channel: C123456
+            text: "Nightly roadmap sync completed."
 
     refresh_search_index:
       provider: local
       match:
         type: roadmap.sync.completed
         source: roadmap
-      plugin: search
-      operation: reindex
-      connection: default
-      input:
-        scope: roadmap
+      target:
+        plugin:
+          name: search
+          operation: reindex
+          connection: default
+          input:
+            scope: roadmap
 ```
 
 In that example, `nightly_sync` only starts the first step. The

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -141,9 +141,11 @@ workflows:
   schedules:
     nightly_sync:
       provider: local
-      plugin: roadmap
       cron: "0 3 * * *"
-      operation: sync_items
+      target:
+        plugin:
+          name: roadmap
+          operation: sync_items
 ```
 
 | Name | Purpose |

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -435,17 +435,21 @@ workflows:
   schedules:
     nightly_sync:
       provider: local
-      plugin: roadmap
       cron: "0 3 * * *"
       timezone: America/New_York
-      operation: sync_items
+      target:
+        plugin:
+          name: roadmap
+          operation: sync_items
   eventTriggers:
     item_updated:
       provider: local
-      plugin: roadmap
       match:
         type: roadmap.item.updated
-      operation: sync_items
+      target:
+        plugin:
+          name: roadmap
+          operation: sync_items
 ```
 
 `providers.workflow.<name>.indexeddb` is optional. When present, it binds a
@@ -481,6 +485,16 @@ providers:
       indexeddb:
         provider: default
         db: simple_agent
+      runtime:
+        provider: modal
+        image: ghcr.io/valon/gestalt-python-runtime:latest
+        pool:
+          minReadyInstances: 1
+          maxReadyInstances: 4
+          startupTimeout: 2m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 1m
       config:
         runStore: runs
         idempotencyStore: run_idempotency
@@ -511,15 +525,15 @@ socket, and `allowedHosts` remains the operator-facing egress policy.
 | `indexeddb` | Optional agent IndexedDB config. `indexeddb.provider` selects the named `providers.indexeddb` entry backing the agent's single IndexedDB SDK socket; unlike plugins, agents do not inherit the selected/default host IndexedDB automatically. `indexeddb.db` overrides the provider-visible database name and defaults to the agent provider key. `indexeddb.objectStores` optionally allowlists logical object stores the agent may use. |
 | `config` | Provider-specific config passed into the agent provider. |
 | `env` | Extra environment variables passed to the provider process. |
-| `runtime` | Optional hosted runtime selection for this agent provider. Supports `provider`, `template`, `image`, and `metadata`, matching the executable-plugin runtime config shape. |
+| `runtime` | Optional hosted runtime selection for this agent provider. Supports `provider`, `template`, `image`, `metadata`, and `pool`. `pool` contains hosted agent lifecycle fields: `minReadyInstances`, `maxReadyInstances`, `startupTimeout`, `healthCheckInterval`, `restartPolicy`, and `drainTimeout`. The older flat lifecycle fields are still accepted, but cannot be combined with `pool`. |
 | `allowedHosts` | Outbound host allowlist. For executable providers, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `workflows`
 
 Top-level `workflows` declares config-managed schedules and triggers.
 These objects are reconciled into the selected workflow provider at startup and
-invoke explicit workflow targets: `plugin`, `operation`, and optional
-`connection`, `instance`, and `input`.
+invoke an explicit `target`. A target is exactly one of `target.plugin` or
+`target.agent`.
 
 Config-managed workflows are deployment-owned. They are created from YAML at
 startup, updated when config changes, and removed when deleted from config.
@@ -532,41 +546,50 @@ workflows:
   schedules:
     nightly_sync:
       provider: local
-      plugin: roadmap
       cron: "0 3 * * *"
       timezone: America/New_York
-      operation: sync_items
-      connection: default
-      instance: tenant-a
-      input:
-        mode: incremental
+      target:
+        plugin:
+          name: roadmap
+          operation: sync_items
+          connection: default
+          instance: tenant-a
+          input:
+            mode: incremental
       paused: false
 
   eventTriggers:
     item_updated:
       provider: local
-      plugin: roadmap
       match:
         type: roadmap.item.updated
         source: roadmap
-      operation: sync_items
-      input:
-        reason: sync
+      target:
+        plugin:
+          name: roadmap
+          operation: sync_items
+          input:
+            reason: sync
       paused: false
 ```
+
+For compatibility, schedules and triggers still accept the previous flat
+plugin fields (`plugin`, `operation`, `connection`, `instance`, `input`) and
+flat `agent`. Do not combine those fields with `target`.
 
 ### `workflows.schedules.*`
 
 | Field | Description |
 | --- | --- |
 | `provider` | Optional named `providers.workflow` entry. When omitted, Gestalt uses the sole/default workflow provider. |
-| `plugin` | **Required.** Target plugin key from `plugins`. |
+| `target.plugin.name` | Target plugin key from `plugins`. Required when `target.plugin` is used. |
+| `target.plugin.operation` | Target operation ID. Required when `target.plugin` is used. |
+| `target.plugin.connection` | Optional target connection name. |
+| `target.plugin.instance` | Optional target instance name. |
+| `target.plugin.input` | Optional static input merged into the invocation payload. |
+| `target.agent` | Optional agent target using the same shape as workflow agent requests: `provider`, `model`, `prompt`, `messages`, `tools`, `responseSchema`, `metadata`, `providerOptions`, and `timeout`. |
 | `cron` | **Required.** Five-field cron expression. |
 | `timezone` | IANA timezone name. Defaults to `UTC`. |
-| `operation` | **Required.** Target operation ID. |
-| `connection` | Optional target connection name. |
-| `instance` | Optional target instance name. |
-| `input` | Optional static input merged into the invocation payload. |
 | `paused` | When `true`, Gestalt reconciles the schedule in a paused state. |
 
 ### `workflows.eventTriggers.*`
@@ -574,14 +597,15 @@ workflows:
 | Field | Description |
 | --- | --- |
 | `provider` | Optional named `providers.workflow` entry. When omitted, Gestalt uses the sole/default workflow provider. |
-| `plugin` | **Required.** Target plugin key from `plugins`. |
+| `target.plugin.name` | Target plugin key from `plugins`. Required when `target.plugin` is used. |
+| `target.plugin.operation` | Target operation ID. Required when `target.plugin` is used. |
+| `target.plugin.connection` | Optional target connection name. |
+| `target.plugin.instance` | Optional target instance name. |
+| `target.plugin.input` | Optional static input merged into the invocation payload. |
+| `target.agent` | Optional agent target using the same shape as workflow agent requests. |
 | `match.type` | **Required.** Event type matcher. |
 | `match.source` | Optional event source matcher. |
 | `match.subject` | Optional event subject matcher. |
-| `operation` | **Required.** Target operation ID. |
-| `connection` | Optional target connection name. |
-| `instance` | Optional target instance name. |
-| `input` | Optional static input merged into the invocation payload. |
 | `paused` | When `true`, Gestalt reconciles the trigger in a paused state. |
 
 Event trigger matching is exact string matching. `match.type` is required;
@@ -915,8 +939,9 @@ plugins:
     description: Public GitHub operations
     iconFile: ./icons/github.svg
     authorizationPolicy: support_staff
-    mountPath: /github
-    ui: github_console
+    ui:
+      path: /github
+      bundle: github_console
     source: https://artifacts.example.com/plugin/github/v1.2.3/provider-release.yaml
     surfaces:
       openapi:
@@ -947,8 +972,8 @@ plugins:
 | `description` | Short description of the plugin. |
 | `iconFile` | SVG icon path, resolved relative to the config directory. |
 | `authorizationPolicy` | Optional shared subject access policy from `authorization.policies`. When set, host-side operation filtering and execution checks use the resolved role for this plugin, and the built-in admin UI / admin API can manage plugin-scoped dynamic grants for additional members. Static policy members still take precedence. |
-| `mountPath` | Optional public path prefix for a plugin-backed mounted UI. When set, Gestalt mounts either `plugins.<name>.ui` or the plugin manifest's `spec.ui`. |
-| `ui` | Optional UI key from `providers.ui` used with `mountPath`. Omit it to mount the plugin manifest's owned `spec.ui`. |
+| `ui` | Optional plugin-backed mounted UI binding. The canonical object form is `ui.path` plus optional `ui.bundle`. `ui.bundle` names a `providers.ui` entry; omit it to mount the plugin manifest's owned `spec.ui`. The older scalar `ui: <bundle>` plus `mountPath` form remains accepted. |
+| `mountPath` | Compatibility field for the older plugin-backed UI shape. Prefer `ui.path` for new config. |
 | `source` | **Required.** The backing provider source. See [source shape](#pluginssource) below. |
 | `source.auth` | Optional metadata-fetch auth for release sources. Use this for `source.url`, `source.githubRelease`, or local `provider-release.yaml` metadata. |
 | `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either the reserved `server` alias or a named entry from `providers.authentication`. Gestalt enforces this on plugin HTTP operation routes (`/api/v1/integrations/{name}/operations` and `/api/v1/{integration}/{operation}`) and on plugin-backed mounted UIs, including browser-login flows whose `next` path resolves into that plugin's mount. Standalone `providers.ui` bundles, the built-in admin UI/admin API, and `/mcp` still use the server-wide auth provider in this phase. |
@@ -1274,7 +1299,7 @@ providers:
         brandName: Acme
 ```
 
-`providers.ui` is a map of `ui` bundles. Entries may mount directly by setting `path`, or they may act as named UI bundles that `plugins.<name>.ui` binds to `plugins.<name>.mountPath`. When a plugin manifest declares `spec.ui`, `plugins.<name>.ui` may be omitted entirely and Gestalt synthesizes the mounted UI entry from the plugin-owned reference. `/admin` remains available regardless. A selected `server.admin.ui` bundle, or the root-mounted UI bundle when it contains `admin/index.html`, may also supply the static admin shell while Gestalt keeps the existing `/admin` auth and API semantics. Omit `providers.ui` entirely to run headless with no public UI bundles.
+`providers.ui` is a map of `ui` bundles. Entries may mount directly by setting `path`, or they may act as named UI bundles that `plugins.<name>.ui.bundle` binds to `plugins.<name>.ui.path`. When a plugin manifest declares `spec.ui`, `plugins.<name>.ui.bundle` may be omitted entirely and Gestalt synthesizes the mounted UI entry from the plugin-owned reference. `/admin` remains available regardless. A selected `server.admin.ui` bundle, or the root-mounted UI bundle when it contains `admin/index.html`, may also supply the static admin shell while Gestalt keeps the existing `/admin` auth and API semantics. Omit `providers.ui` entirely to run headless with no public UI bundles.
 
 Plugin-backed mounted UIs inherit the owning plugin's dynamic authorization grants when that plugin sets `authorizationPolicy`. Direct `providers.ui.<name>.authorizationPolicy` bindings remain static-only.
 
@@ -1282,8 +1307,8 @@ When `authorizationPolicy` is set on a mounted UI, the referenced UI manifest mu
 
 | Field | Description |
 | --- | --- |
-| `path` | Direct mount prefix for this UI when not bound through `plugins.<name>.mountPath`. |
-| `authorizationPolicy` | Direct policy binding for this UI when not bound through `plugins.<name>.mountPath`. |
+| `path` | Direct mount prefix for this UI when not bound through `plugins.<name>.ui.path`. |
+| `authorizationPolicy` | Direct policy binding for this UI when not bound through `plugins.<name>.ui.path`. |
 | `source` | A local UI manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
 | `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
 | `config` | Optional UI-provider config validated against the bundle schema when present. |
@@ -1308,7 +1333,7 @@ Only `connections.default` may define `params` or `discovery`. All connections i
 
 Each `providers.ui.<name>` entry must set `source` to exactly one loading mode: a local UI manifest path or a published `provider-release.yaml` metadata URL. `providers.ui.<name>.config` is only allowed when `providers.ui.<name>.source` is set.
 
-Each `plugins.<name>` entry may set `mountPath` to publish a plugin-backed UI. When `plugins.<name>.ui` is set, it must reference an existing UI bundle. When `plugins.<name>.ui` is omitted and `plugins.<name>.mountPath` is set, the plugin manifest must declare `spec.ui`. A given UI may be bound by at most one plugin entry. `plugins.<name>.mountPath` must use the same path rules as a directly mounted UI.
+Each `plugins.<name>` entry may set `ui.path` to publish a plugin-backed UI. When `ui.bundle` is set, it must reference an existing UI bundle. When `ui.bundle` is omitted, the plugin manifest must declare `spec.ui`. A given UI may be bound by at most one plugin entry. `ui.path` and the compatibility `mountPath` must use the same path rules as a directly mounted UI.
 
 When `server.admin.ui` is set, it must reference an existing `providers.ui.<name>` entry. Runtime startup then requires that entry's prepared asset root to include `admin/index.html`.
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -187,6 +187,116 @@ plugins:
 	}
 }
 
+func TestE2EValidateAcceptsCanonicalConfigShapes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+	pluginManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, filepath.Join(dir, "plugin")))
+	ui := setupMountedUIDir(t, dir)
+	workflowManifest := componentProviderManifestPath(t, setupExecutableProviderDir(t, dir, providermanifestv1.KindWorkflow, "workflow-indexeddb"))
+	agentManifest := componentProviderManifestPath(t, setupExecutableProviderDir(t, dir, providermanifestv1.KindAgent, "agent-simple"))
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`server:
+  encryptionKey: canonical-config-shapes-key
+  providers:
+    indexeddb: inmem
+  runtime:
+    provider: hosted
+providers:
+  indexeddb:
+    inmem:
+      source:
+        path: %s
+  ui:
+    roadmap:
+      source:
+        path: %s
+  workflow:
+    local:
+      source:
+        path: %s
+      default: true
+      indexeddb:
+        provider: inmem
+        db: workflow_state
+  agent:
+    simple:
+      source:
+        path: %s
+      default: true
+      indexeddb:
+        provider: inmem
+        db: agent_state
+      runtime:
+        provider: hosted
+        image: ghcr.io/example/agent:latest
+        pool:
+          minReadyInstances: 1
+          maxReadyInstances: 2
+          startupTimeout: 5m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      driver: local
+plugins:
+  roadmap:
+    source:
+      path: %s
+    ui:
+      path: /roadmap
+      bundle: roadmap
+workflows:
+  schedules:
+    nightly_sync:
+      cron: "0 2 * * *"
+      target:
+        plugin:
+          name: roadmap
+          operation: sync
+          connection: default
+          instance: tenant-a
+          input:
+            mode: incremental
+    nightly_summary:
+      cron: "0 3 * * *"
+      target:
+        agent:
+          provider: simple
+          model: fast
+          prompt: Summarize yesterday.
+          tools:
+            - plugin: roadmap
+              operation: sync
+  eventTriggers:
+    roadmap_updated:
+      match:
+        type: roadmap.item.updated
+        source: roadmap
+      target:
+        plugin:
+          name: roadmap
+          operation: sync
+          input:
+            mode: event
+`, indexedDBManifest, ui.ManifestPath, workflowManifest, agentManifest, pluginManifest)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd validate failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "config ok") {
+		t.Fatalf("expected config ok, got: %s", out)
+	}
+}
+
 func TestE2EValidateRejectsInvalidConfigInput(t *testing.T) {
 	t.Parallel()
 
@@ -207,6 +317,29 @@ func TestE2EValidateRejectsInvalidConfigInput(t *testing.T) {
   bogus: true
 `,
 			wantError: "bogus",
+		},
+		{
+			name: "ui object requires path",
+			cfg: `plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    ui:
+      bundle: roadmap
+`,
+			wantError: "ui.path is required when ui is an object",
+		},
+		{
+			name: "ui object rejects legacy mountPath",
+			cfg: `plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    ui:
+      path: /roadmap
+    mountPath: /roadmap
+`,
+			wantError: "ui object cannot be combined with mountPath",
 		},
 	}
 
@@ -969,6 +1102,79 @@ func setupCacheProviderDir(t *testing.T, baseDir, name string) string {
 		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactRel},
 	})
 	return providerDir
+}
+
+func setupExecutableProviderDir(t *testing.T, baseDir, kind, name string) string {
+	t.Helper()
+
+	providerDir := filepath.Join(baseDir, kind, name)
+	if err := os.MkdirAll(providerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", providerDir, err)
+	}
+
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "gestalt-"+name))
+	binDest := filepath.Join(providerDir, filepath.FromSlash(artifactRel))
+	if err := os.MkdirAll(filepath.Dir(binDest), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(binDest), err)
+	}
+
+	switch kind {
+	case providermanifestv1.KindWorkflow:
+		writeTestFile(t, providerDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/providers/workflow/"+name)), 0o644)
+		writeTestFile(t, providerDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
+		writeTestFile(t, providerDir, "workflow.go", []byte(testutil.GeneratedWorkflowPackageSource()), 0o644)
+		if _, err := providerpkg.BuildSourceComponentReleaseBinary(providerDir, binDest, providermanifestv1.KindWorkflow, runtime.GOOS, runtime.GOARCH); err != nil {
+			t.Fatalf("BuildSourceComponentReleaseBinary(%s): %v", providerDir, err)
+		}
+	case providermanifestv1.KindAgent:
+		if err := buildTarget(gestaltdRootForE2E(t), "./internal/testplugins/agent", binDest); err != nil {
+			t.Fatalf("build agent provider fixture: %v", err)
+		}
+	default:
+		binData, err := os.ReadFile(pluginBin)
+		if err != nil {
+			t.Fatalf("read provider binary: %v", err)
+		}
+		if err := os.WriteFile(binDest, binData, 0o755); err != nil {
+			t.Fatalf("write provider binary: %v", err)
+		}
+	}
+	binData, err := os.ReadFile(binDest)
+	if err != nil {
+		t.Fatalf("read provider artifact: %v", err)
+	}
+	sum := sha256.Sum256(binData)
+	writeManifestFile(t, providerDir, &providermanifestv1.Manifest{
+		Kind:        kind,
+		Source:      "github.com/test/providers/" + name,
+		Version:     "0.0.1-alpha.1",
+		DisplayName: name,
+		Spec:        &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{
+			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: artifactRel, SHA256: hex.EncodeToString(sum[:])},
+		},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactRel},
+	})
+	return providerDir
+}
+
+func gestaltdRootForE2E(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "internal", "testplugins", "agent")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find gestaltd root from %s", dir)
+		}
+		dir = parent
+	}
 }
 
 func authProviderSource(name string) string {
@@ -2044,13 +2250,13 @@ providers:
     roadmap:
       source:
         path: %s
-      path: /roadmap
 plugins:
   example:
     source:
       path: %s
-    ui: roadmap
-    mountPath: /roadmap
+    ui:
+      bundle: roadmap
+      path: /roadmap
 `, publicPort, indexedDBManifest, mountedUI.ManifestPath, pluginManifest)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write owned-ui config: %v", err)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -97,6 +97,27 @@ type RuntimeProviderEntry struct {
 	Driver        RuntimeProviderDriver `yaml:"driver,omitempty"`
 }
 
+type runtimeProviderEntryYAML struct {
+	providerEntryYAML `yaml:",inline"`
+	Driver            RuntimeProviderDriver `yaml:"driver,omitempty"`
+}
+
+func (e *RuntimeProviderEntry) UnmarshalYAML(value *yaml.Node) error {
+	var raw runtimeProviderEntryYAML
+	if err := decodeYAMLNodeKnownFields(value, &raw); err != nil {
+		return err
+	}
+	entry, err := raw.providerEntryYAML.decode()
+	if err != nil {
+		return err
+	}
+	*e = RuntimeProviderEntry{
+		ProviderEntry: entry,
+		Driver:        raw.Driver,
+	}
+	return nil
+}
+
 type HostProviderKind string
 
 const (
@@ -369,7 +390,7 @@ type ProviderEntry struct {
 	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
 	Invokes           []PluginInvocationDependency  `yaml:"invokes,omitempty"`
-	IndexedDB         *PluginIndexedDBConfig        `yaml:"indexeddb,omitempty"`
+	IndexedDB         *HostIndexedDBBindingConfig   `yaml:"indexeddb,omitempty"`
 	Cache             []string                      `yaml:"cache,omitempty"`
 	S3                []string                      `yaml:"s3,omitempty"`
 	Runtime           *HostedRuntimeConfig          `yaml:"runtime,omitempty"`
@@ -415,13 +436,31 @@ type uiEntryMarshalYAML struct {
 }
 
 func (e *ProviderEntry) UnmarshalYAML(value *yaml.Node) error {
+	normalized := cloneYAMLNode(value)
+	uiBinding, err := normalizeProviderEntryUINode(normalized)
+	if err != nil {
+		return err
+	}
 	var raw providerEntryYAML
-	if err := decodeYAMLNodeKnownFields(value, &raw); err != nil {
+	if err := decodeYAMLNodeKnownFields(normalized, &raw); err != nil {
 		return err
 	}
 	decoded, err := raw.decode()
 	if err != nil {
 		return err
+	}
+	if uiBinding != nil {
+		uiBinding.Path = strings.TrimSpace(uiBinding.Path)
+		uiBinding.Bundle = strings.TrimSpace(uiBinding.Bundle)
+		if uiBinding.Bundle != "" {
+			decoded.UI = uiBinding.Bundle
+		}
+		if uiBinding.Path != "" {
+			if strings.TrimSpace(decoded.MountPath) != "" && !providerEntryUIPathsEqual(decoded.MountPath, uiBinding.Path) {
+				return fmt.Errorf("ui.path conflicts with mountPath")
+			}
+			decoded.MountPath = uiBinding.Path
+		}
 	}
 	*e = decoded
 	return nil
@@ -444,10 +483,20 @@ type ProviderSurfaceOverrides struct {
 type HTTPSecurityScheme = providermanifestv1.HTTPSecurityScheme
 type HTTPBinding = providermanifestv1.HTTPBinding
 
-type PluginIndexedDBConfig struct {
+type HostIndexedDBBindingConfig struct {
 	Provider     string   `yaml:"provider,omitempty"`
 	DB           string   `yaml:"db,omitempty"`
 	ObjectStores []string `yaml:"objectStores,omitempty"`
+}
+
+// PluginIndexedDBConfig is kept as a source-compatible alias for older code and
+// tests. The binding is no longer plugin-specific: plugins, workflow providers,
+// and agent providers all use the same host IndexedDB service shape.
+type PluginIndexedDBConfig = HostIndexedDBBindingConfig
+
+type pluginUIBindingConfig struct {
+	Path   string `yaml:"path,omitempty"`
+	Bundle string `yaml:"bundle,omitempty"`
 }
 
 type HostedRuntimeConfig struct {
@@ -455,6 +504,16 @@ type HostedRuntimeConfig struct {
 	Template            string                     `yaml:"template,omitempty"`
 	Image               string                     `yaml:"image,omitempty"`
 	Metadata            map[string]string          `yaml:"metadata,omitempty"`
+	Pool                *HostedRuntimePoolConfig   `yaml:"pool,omitempty"`
+	MinReadyInstances   int                        `yaml:"minReadyInstances,omitempty"`
+	MaxReadyInstances   int                        `yaml:"maxReadyInstances,omitempty"`
+	StartupTimeout      string                     `yaml:"startupTimeout,omitempty"`
+	HealthCheckInterval string                     `yaml:"healthCheckInterval,omitempty"`
+	RestartPolicy       HostedRuntimeRestartPolicy `yaml:"restartPolicy,omitempty"`
+	DrainTimeout        string                     `yaml:"drainTimeout,omitempty"`
+}
+
+type HostedRuntimePoolConfig struct {
 	MinReadyInstances   int                        `yaml:"minReadyInstances,omitempty"`
 	MaxReadyInstances   int                        `yaml:"maxReadyInstances,omitempty"`
 	StartupTimeout      string                     `yaml:"startupTimeout,omitempty"`
@@ -483,6 +542,26 @@ func (c *HostedRuntimeConfig) LifecyclePolicyFieldsSet() bool {
 	if c == nil {
 		return false
 	}
+	return c.flatLifecyclePolicyFieldsSet() ||
+		(c.Pool != nil && c.Pool.lifecyclePolicyFieldsSet())
+}
+
+func (c *HostedRuntimeConfig) flatLifecyclePolicyFieldsSet() bool {
+	if c == nil {
+		return false
+	}
+	return c.MinReadyInstances != 0 ||
+		c.MaxReadyInstances != 0 ||
+		strings.TrimSpace(c.StartupTimeout) != "" ||
+		strings.TrimSpace(c.HealthCheckInterval) != "" ||
+		strings.TrimSpace(string(c.RestartPolicy)) != "" ||
+		strings.TrimSpace(c.DrainTimeout) != ""
+}
+
+func (c *HostedRuntimePoolConfig) lifecyclePolicyFieldsSet() bool {
+	if c == nil {
+		return false
+	}
 	return c.MinReadyInstances != 0 ||
 		c.MaxReadyInstances != 0 ||
 		strings.TrimSpace(c.StartupTimeout) != "" ||
@@ -495,26 +574,44 @@ func (c *HostedRuntimeConfig) LifecyclePolicy() (HostedRuntimeLifecyclePolicy, e
 	if c == nil {
 		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("runtime config is required")
 	}
-	startupTimeout, err := ParseDuration(strings.TrimSpace(c.StartupTimeout))
+	lifecycle := c.lifecyclePolicyConfig()
+	startupTimeout, err := ParseDuration(strings.TrimSpace(lifecycle.StartupTimeout))
 	if err != nil {
 		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("startupTimeout: %w", err)
 	}
-	healthCheckInterval, err := ParseDuration(strings.TrimSpace(c.HealthCheckInterval))
+	healthCheckInterval, err := ParseDuration(strings.TrimSpace(lifecycle.HealthCheckInterval))
 	if err != nil {
 		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("healthCheckInterval: %w", err)
 	}
-	drainTimeout, err := ParseDuration(strings.TrimSpace(c.DrainTimeout))
+	drainTimeout, err := ParseDuration(strings.TrimSpace(lifecycle.DrainTimeout))
 	if err != nil {
 		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("drainTimeout: %w", err)
 	}
 	return HostedRuntimeLifecyclePolicy{
-		MinReadyInstances:   c.MinReadyInstances,
-		MaxReadyInstances:   c.MaxReadyInstances,
+		MinReadyInstances:   lifecycle.MinReadyInstances,
+		MaxReadyInstances:   lifecycle.MaxReadyInstances,
 		StartupTimeout:      startupTimeout,
 		HealthCheckInterval: healthCheckInterval,
-		RestartPolicy:       HostedRuntimeRestartPolicy(strings.TrimSpace(string(c.RestartPolicy))),
+		RestartPolicy:       HostedRuntimeRestartPolicy(strings.TrimSpace(string(lifecycle.RestartPolicy))),
 		DrainTimeout:        drainTimeout,
 	}, nil
+}
+
+func (c *HostedRuntimeConfig) lifecyclePolicyConfig() HostedRuntimePoolConfig {
+	if c == nil {
+		return HostedRuntimePoolConfig{}
+	}
+	if c.Pool != nil {
+		return *c.Pool
+	}
+	return HostedRuntimePoolConfig{
+		MinReadyInstances:   c.MinReadyInstances,
+		MaxReadyInstances:   c.MaxReadyInstances,
+		StartupTimeout:      c.StartupTimeout,
+		HealthCheckInterval: c.HealthCheckInterval,
+		RestartPolicy:       c.RestartPolicy,
+		DrainTimeout:        c.DrainTimeout,
+	}
 }
 
 type WorkflowsConfig struct {
@@ -523,28 +620,43 @@ type WorkflowsConfig struct {
 }
 
 type WorkflowScheduleConfig struct {
-	Provider   string               `yaml:"provider,omitempty"`
-	Plugin     string               `yaml:"plugin,omitempty"`
-	Agent      *WorkflowAgentConfig `yaml:"agent,omitempty"`
-	Cron       string               `yaml:"cron,omitempty"`
-	Timezone   string               `yaml:"timezone,omitempty"`
-	Operation  string               `yaml:"operation,omitempty"`
-	Connection string               `yaml:"connection,omitempty"`
-	Instance   string               `yaml:"instance,omitempty"`
-	Input      map[string]any       `yaml:"input,omitempty"`
-	Paused     bool                 `yaml:"paused,omitempty"`
+	Provider   string                `yaml:"provider,omitempty"`
+	Target     *WorkflowTargetConfig `yaml:"target,omitempty"`
+	Plugin     string                `yaml:"plugin,omitempty"`
+	Agent      *WorkflowAgentConfig  `yaml:"agent,omitempty"`
+	Cron       string                `yaml:"cron,omitempty"`
+	Timezone   string                `yaml:"timezone,omitempty"`
+	Operation  string                `yaml:"operation,omitempty"`
+	Connection string                `yaml:"connection,omitempty"`
+	Instance   string                `yaml:"instance,omitempty"`
+	Input      map[string]any        `yaml:"input,omitempty"`
+	Paused     bool                  `yaml:"paused,omitempty"`
 }
 
 type WorkflowEventTriggerConfig struct {
-	Provider   string               `yaml:"provider,omitempty"`
-	Plugin     string               `yaml:"plugin,omitempty"`
-	Agent      *WorkflowAgentConfig `yaml:"agent,omitempty"`
-	Match      WorkflowEventMatch   `yaml:"match,omitempty"`
-	Operation  string               `yaml:"operation,omitempty"`
-	Connection string               `yaml:"connection,omitempty"`
-	Instance   string               `yaml:"instance,omitempty"`
-	Input      map[string]any       `yaml:"input,omitempty"`
-	Paused     bool                 `yaml:"paused,omitempty"`
+	Provider   string                `yaml:"provider,omitempty"`
+	Target     *WorkflowTargetConfig `yaml:"target,omitempty"`
+	Plugin     string                `yaml:"plugin,omitempty"`
+	Agent      *WorkflowAgentConfig  `yaml:"agent,omitempty"`
+	Match      WorkflowEventMatch    `yaml:"match,omitempty"`
+	Operation  string                `yaml:"operation,omitempty"`
+	Connection string                `yaml:"connection,omitempty"`
+	Instance   string                `yaml:"instance,omitempty"`
+	Input      map[string]any        `yaml:"input,omitempty"`
+	Paused     bool                  `yaml:"paused,omitempty"`
+}
+
+type WorkflowTargetConfig struct {
+	Plugin *WorkflowPluginTargetConfig `yaml:"plugin,omitempty"`
+	Agent  *WorkflowAgentConfig        `yaml:"agent,omitempty"`
+}
+
+type WorkflowPluginTargetConfig struct {
+	Name       string         `yaml:"name,omitempty"`
+	Operation  string         `yaml:"operation,omitempty"`
+	Connection string         `yaml:"connection,omitempty"`
+	Instance   string         `yaml:"instance,omitempty"`
+	Input      map[string]any `yaml:"input,omitempty"`
 }
 
 type WorkflowAgentConfig struct {
@@ -580,20 +692,20 @@ type WorkflowEventMatch struct {
 	Subject string `yaml:"subject,omitempty"`
 }
 
-func (c *PluginIndexedDBConfig) UnmarshalYAML(value *yaml.Node) error {
+func (c *HostIndexedDBBindingConfig) UnmarshalYAML(value *yaml.Node) error {
 	switch value.Kind {
 	case yaml.ScalarNode:
 		c.Provider = strings.TrimSpace(value.Value)
 		return nil
 	case yaml.SequenceNode:
-		return fmt.Errorf("plugin indexeddb must be a mapping or scalar provider name")
+		return fmt.Errorf("indexeddb must be a mapping or scalar provider name")
 	default:
 		for i := 0; i+1 < len(value.Content); i += 2 {
 			if key := value.Content[i]; key != nil && key.Value == "disabled" {
 				return fmt.Errorf("field disabled not found in type config.raw")
 			}
 		}
-		type raw PluginIndexedDBConfig
+		type raw HostIndexedDBBindingConfig
 		return value.Decode((*raw)(c))
 	}
 }
@@ -669,6 +781,68 @@ func decodeYAMLNodeKnownFields(node *yaml.Node, out any) error {
 		return err
 	}
 	return nil
+}
+
+func cloneYAMLNode(node *yaml.Node) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	cloned := *node
+	if len(node.Content) > 0 {
+		cloned.Content = make([]*yaml.Node, len(node.Content))
+		for i, child := range node.Content {
+			cloned.Content[i] = cloneYAMLNode(child)
+		}
+	}
+	return &cloned
+}
+
+func normalizeProviderEntryUINode(node *yaml.Node) (*pluginUIBindingConfig, error) {
+	raw := documentValueNode(node)
+	if raw == nil || raw.Kind != yaml.MappingNode {
+		return nil, nil
+	}
+	for i := 0; i+1 < len(raw.Content); i += 2 {
+		key := raw.Content[i]
+		value := raw.Content[i+1]
+		if key == nil || strings.TrimSpace(key.Value) != "ui" || value == nil || value.Kind != yaml.MappingNode {
+			continue
+		}
+		var binding pluginUIBindingConfig
+		if err := decodeYAMLNodeKnownFields(value, &binding); err != nil {
+			return nil, err
+		}
+		binding.Path = strings.TrimSpace(binding.Path)
+		binding.Bundle = strings.TrimSpace(binding.Bundle)
+		if binding.Path == "" {
+			return nil, fmt.Errorf("ui.path is required when ui is an object")
+		}
+		if mappingValueNode(raw, "mountPath") != nil {
+			return nil, fmt.Errorf("ui object cannot be combined with mountPath")
+		}
+		if binding.Bundle == "" {
+			raw.Content = append(raw.Content[:i], raw.Content[i+2:]...)
+		} else {
+			raw.Content[i+1] = &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Tag:   "!!str",
+				Value: binding.Bundle,
+			}
+		}
+		return &binding, nil
+	}
+	return nil, nil
+}
+
+func providerEntryUIPathsEqual(left, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == right {
+		return true
+	}
+	normalizedLeft, leftErr := normalizeMountedUIPath(left)
+	normalizedRight, rightErr := normalizeMountedUIPath(right)
+	return leftErr == nil && rightErr == nil && normalizedLeft == normalizedRight
 }
 
 func cloneRouteAuthDef(src *RouteAuthDef) *RouteAuthDef {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2756,7 +2756,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `plugin indexeddb must be a mapping or scalar provider name`) {
+		if !strings.Contains(err.Error(), `indexeddb must be a mapping or scalar provider name`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -39,6 +39,9 @@ func CanonicalizeStructure(cfg *Config) error {
 	if err := NormalizeCompatibility(cfg); err != nil {
 		return err
 	}
+	if err := normalizeWorkflowTargets(cfg); err != nil {
+		return err
+	}
 	pluginOwnedUIBindings := pluginOwnedUIBindings(cfg)
 	if err := normalizeMountedUIPaths(cfg, pluginOwnedUIBindings); err != nil {
 		return err
@@ -739,6 +742,15 @@ func normalizeHostedRuntimeConfig(subject string, runtimeCfg *HostedRuntimeConfi
 	if runtimeCfg == nil {
 		return nil
 	}
+	if runtimeCfg.Pool != nil {
+		if runtimeCfg.flatLifecyclePolicyFieldsSet() {
+			return fmt.Errorf("config validation: %s.runtime.pool cannot be combined with flat runtime lifecycle fields", subject)
+		}
+		runtimeCfg.Pool.StartupTimeout = strings.TrimSpace(runtimeCfg.Pool.StartupTimeout)
+		runtimeCfg.Pool.HealthCheckInterval = strings.TrimSpace(runtimeCfg.Pool.HealthCheckInterval)
+		runtimeCfg.Pool.RestartPolicy = HostedRuntimeRestartPolicy(strings.TrimSpace(string(runtimeCfg.Pool.RestartPolicy)))
+		runtimeCfg.Pool.DrainTimeout = strings.TrimSpace(runtimeCfg.Pool.DrainTimeout)
+	}
 	runtimeCfg.Provider = strings.TrimSpace(runtimeCfg.Provider)
 	runtimeCfg.Template = strings.TrimSpace(runtimeCfg.Template)
 	runtimeCfg.Image = strings.TrimSpace(runtimeCfg.Image)
@@ -765,34 +777,39 @@ func validateHostedAgentRuntimeLifecyclePolicy(subject string, entry *ProviderEn
 		return nil
 	}
 	runtimeCfg := entry.Runtime
-	if runtimeCfg.MinReadyInstances <= 0 {
-		return fmt.Errorf("config validation: %s.runtime.minReadyInstances is required and must be greater than 0", subject)
+	lifecycle := runtimeCfg.lifecyclePolicyConfig()
+	lifecycleSubject := subject + ".runtime"
+	if runtimeCfg.Pool != nil {
+		lifecycleSubject += ".pool"
 	}
-	if runtimeCfg.MaxReadyInstances <= 0 {
-		return fmt.Errorf("config validation: %s.runtime.maxReadyInstances is required and must be greater than 0", subject)
+	if lifecycle.MinReadyInstances <= 0 {
+		return fmt.Errorf("config validation: %s.minReadyInstances is required and must be greater than 0", lifecycleSubject)
 	}
-	if runtimeCfg.MaxReadyInstances < runtimeCfg.MinReadyInstances {
-		return fmt.Errorf("config validation: %s.runtime.maxReadyInstances must be greater than or equal to minReadyInstances", subject)
+	if lifecycle.MaxReadyInstances <= 0 {
+		return fmt.Errorf("config validation: %s.maxReadyInstances is required and must be greater than 0", lifecycleSubject)
 	}
-	if strings.TrimSpace(runtimeCfg.StartupTimeout) == "" {
-		return fmt.Errorf("config validation: %s.runtime.startupTimeout is required", subject)
+	if lifecycle.MaxReadyInstances < lifecycle.MinReadyInstances {
+		return fmt.Errorf("config validation: %s.maxReadyInstances must be greater than or equal to minReadyInstances", lifecycleSubject)
 	}
-	if strings.TrimSpace(runtimeCfg.HealthCheckInterval) == "" {
-		return fmt.Errorf("config validation: %s.runtime.healthCheckInterval is required", subject)
+	if strings.TrimSpace(lifecycle.StartupTimeout) == "" {
+		return fmt.Errorf("config validation: %s.startupTimeout is required", lifecycleSubject)
 	}
-	if strings.TrimSpace(runtimeCfg.DrainTimeout) == "" {
-		return fmt.Errorf("config validation: %s.runtime.drainTimeout is required", subject)
+	if strings.TrimSpace(lifecycle.HealthCheckInterval) == "" {
+		return fmt.Errorf("config validation: %s.healthCheckInterval is required", lifecycleSubject)
 	}
-	switch runtimeCfg.RestartPolicy {
+	if strings.TrimSpace(lifecycle.DrainTimeout) == "" {
+		return fmt.Errorf("config validation: %s.drainTimeout is required", lifecycleSubject)
+	}
+	switch lifecycle.RestartPolicy {
 	case HostedRuntimeRestartPolicyAlways, HostedRuntimeRestartPolicyNever:
 	default:
-		return fmt.Errorf("config validation: %s.runtime.restartPolicy must be one of %q or %q", subject, HostedRuntimeRestartPolicyAlways, HostedRuntimeRestartPolicyNever)
+		return fmt.Errorf("config validation: %s.restartPolicy must be one of %q or %q", lifecycleSubject, HostedRuntimeRestartPolicyAlways, HostedRuntimeRestartPolicyNever)
 	}
-	if runtimeCfg.RestartPolicy == HostedRuntimeRestartPolicyAlways && entry.IndexedDB == nil {
-		return fmt.Errorf("config validation: %s.runtime.restartPolicy %q requires %s.indexeddb as the provider persistence hook; runtime replacement does not make backend-local state durable", subject, HostedRuntimeRestartPolicyAlways, subject)
+	if lifecycle.RestartPolicy == HostedRuntimeRestartPolicyAlways && entry.IndexedDB == nil {
+		return fmt.Errorf("config validation: %s.restartPolicy %q requires %s.indexeddb as the provider persistence hook; runtime replacement does not make backend-local state durable", lifecycleSubject, HostedRuntimeRestartPolicyAlways, subject)
 	}
 	if _, err := runtimeCfg.LifecyclePolicy(); err != nil {
-		return fmt.Errorf("config validation: %s.runtime.%w", subject, err)
+		return fmt.Errorf("config validation: %s.%w", lifecycleSubject, err)
 	}
 	return nil
 }
@@ -1202,6 +1219,125 @@ func validateWorkflowEventTriggerTarget(cfg *Config, key string, trigger *Workfl
 		return nil
 	}
 	return validateWorkflowAgentConfig(cfg, "workflows.eventTriggers."+key+".agent", trigger.Agent)
+}
+
+func normalizeWorkflowTargets(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	for key, schedule := range cfg.Workflows.Schedules {
+		if err := normalizeWorkflowScheduleTarget(key, &schedule); err != nil {
+			return err
+		}
+		cfg.Workflows.Schedules[key] = schedule
+	}
+	for key, trigger := range cfg.Workflows.EventTriggers {
+		if err := normalizeWorkflowEventTriggerTarget(key, &trigger); err != nil {
+			return err
+		}
+		cfg.Workflows.EventTriggers[key] = trigger
+	}
+	return nil
+}
+
+func normalizeWorkflowScheduleTarget(key string, schedule *WorkflowScheduleConfig) error {
+	if schedule == nil || schedule.Target == nil {
+		return nil
+	}
+	if workflowScheduleLegacyTargetFieldsSet(schedule) {
+		return fmt.Errorf("config validation: workflows.schedules.%s cannot combine target with legacy plugin or agent target fields", key)
+	}
+	err := normalizeWorkflowTarget(
+		"workflows.schedules."+key+".target",
+		schedule.Target,
+		func(target WorkflowPluginTargetConfig) {
+			schedule.Plugin = target.Name
+			schedule.Operation = target.Operation
+			schedule.Connection = target.Connection
+			schedule.Instance = target.Instance
+			schedule.Input = target.Input
+		},
+		func(agent *WorkflowAgentConfig) {
+			schedule.Agent = agent
+		},
+	)
+	if err != nil {
+		return err
+	}
+	schedule.Target = nil
+	return nil
+}
+
+func normalizeWorkflowEventTriggerTarget(key string, trigger *WorkflowEventTriggerConfig) error {
+	if trigger == nil || trigger.Target == nil {
+		return nil
+	}
+	if workflowEventTriggerLegacyTargetFieldsSet(trigger) {
+		return fmt.Errorf("config validation: workflows.eventTriggers.%s cannot combine target with legacy plugin or agent target fields", key)
+	}
+	err := normalizeWorkflowTarget(
+		"workflows.eventTriggers."+key+".target",
+		trigger.Target,
+		func(target WorkflowPluginTargetConfig) {
+			trigger.Plugin = target.Name
+			trigger.Operation = target.Operation
+			trigger.Connection = target.Connection
+			trigger.Instance = target.Instance
+			trigger.Input = target.Input
+		},
+		func(agent *WorkflowAgentConfig) {
+			trigger.Agent = agent
+		},
+	)
+	if err != nil {
+		return err
+	}
+	trigger.Target = nil
+	return nil
+}
+
+func normalizeWorkflowTarget(path string, target *WorkflowTargetConfig, applyPlugin func(WorkflowPluginTargetConfig), applyAgent func(*WorkflowAgentConfig)) error {
+	if target == nil {
+		return nil
+	}
+	hasPlugin := target.Plugin != nil
+	hasAgent := target.Agent != nil
+	if hasPlugin == hasAgent {
+		return fmt.Errorf("config validation: %s must set exactly one of plugin or agent", path)
+	}
+	if hasPlugin {
+		plugin := *target.Plugin
+		plugin.Name = strings.TrimSpace(plugin.Name)
+		plugin.Operation = strings.TrimSpace(plugin.Operation)
+		plugin.Connection = strings.TrimSpace(plugin.Connection)
+		plugin.Instance = strings.TrimSpace(plugin.Instance)
+		if plugin.Name == "" {
+			return fmt.Errorf("config validation: %s.plugin.name is required", path)
+		}
+		if plugin.Operation == "" {
+			return fmt.Errorf("config validation: %s.plugin.operation is required", path)
+		}
+		if applyPlugin != nil {
+			applyPlugin(plugin)
+		}
+		return nil
+	}
+	if applyAgent != nil {
+		applyAgent(target.Agent)
+	}
+	return nil
+}
+
+func workflowScheduleLegacyTargetFieldsSet(schedule *WorkflowScheduleConfig) bool {
+	return schedule.Agent != nil ||
+		strings.TrimSpace(schedule.Plugin) != "" ||
+		workflowSchedulePluginFieldsSet(schedule)
+}
+
+func workflowEventTriggerLegacyTargetFieldsSet(trigger *WorkflowEventTriggerConfig) bool {
+	return trigger.Agent != nil ||
+		strings.TrimSpace(trigger.Plugin) != "" ||
+		workflowEventTriggerPluginFieldsSet(trigger)
 }
 
 func workflowSchedulePluginFieldsSet(schedule *WorkflowScheduleConfig) bool {

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -112,7 +112,7 @@ func (c *Config) SelectedRuntimeProvider() (string, *RuntimeProviderEntry, error
 	return ResolveSelectedRuntimeProvider(c.Server.Runtime.Provider, c.Runtime.Providers)
 }
 
-type EffectivePluginIndexedDB struct {
+type EffectiveHostIndexedDBBinding struct {
 	Enabled      bool
 	ProviderName string
 	Provider     *ProviderEntry
@@ -120,21 +120,9 @@ type EffectivePluginIndexedDB struct {
 	ObjectStores []string
 }
 
-type EffectiveWorkflowIndexedDB struct {
-	Enabled      bool
-	ProviderName string
-	Provider     *ProviderEntry
-	DB           string
-	ObjectStores []string
-}
-
-type EffectiveAgentIndexedDB struct {
-	Enabled      bool
-	ProviderName string
-	Provider     *ProviderEntry
-	DB           string
-	ObjectStores []string
-}
+type EffectivePluginIndexedDB = EffectiveHostIndexedDBBinding
+type EffectiveWorkflowIndexedDB = EffectiveHostIndexedDBBinding
+type EffectiveAgentIndexedDB = EffectiveHostIndexedDBBinding
 
 type EffectiveHostedRuntime struct {
 	Enabled      bool


### PR DESCRIPTION
## Summary

Consolidates the YAML/API model where the same concept was already shared at runtime:

- workflow schedules/triggers now accept canonical nested `target.plugin` and `target.agent`
- hosted agent lifecycle settings now accept canonical `runtime.pool`
- plugin UI bindings now accept canonical `ui.path` and optional `ui.bundle`
- host IndexedDB bindings now share neutral internal config/effective binding types, with old aliases retained for compatibility
- `runtime.providers.*.driver` now decodes correctly for `driver: local`

Compatibility is retained for the older YAML shapes, but the new canonical forms cannot be mixed with their legacy counterparts.

## New Interfaces

### Workflow Targets

Before:

```yaml
workflows:
  schedules:
    nightly:
      cron: "0 2 * * *"
      plugin: roadmap
      operation: sync
      connection: default
      input:
        mode: incremental
```

After:

```yaml
workflows:
  schedules:
    nightly:
      cron: "0 2 * * *"
      target:
        plugin:
          name: roadmap
          operation: sync
          connection: default
          input:
            mode: incremental
```

Agent targets use the same target slot:

```yaml
workflows:
  schedules:
    summary:
      cron: "0 3 * * *"
      target:
        agent:
          provider: simple
          model: fast
          prompt: Summarize yesterday.
```

### Hosted Agent Runtime Pool

Before:

```yaml
providers:
  agent:
    simple:
      runtime:
        provider: hosted
        image: ghcr.io/example/agent:latest
        minReadyInstances: 1
        maxReadyInstances: 2
        startupTimeout: 5m
        healthCheckInterval: 30s
        restartPolicy: always
        drainTimeout: 2m
```

After:

```yaml
providers:
  agent:
    simple:
      runtime:
        provider: hosted
        image: ghcr.io/example/agent:latest
        pool:
          minReadyInstances: 1
          maxReadyInstances: 2
          startupTimeout: 5m
          healthCheckInterval: 30s
          restartPolicy: always
          drainTimeout: 2m
```

### Plugin UI Binding

Before:

```yaml
plugins:
  roadmap:
    ui: roadmap
    mountPath: /roadmap
```

After:

```yaml
plugins:
  roadmap:
    ui:
      path: /roadmap
      bundle: roadmap
```

Plugin-owned UI omits `bundle`:

```yaml
plugins:
  roadmap:
    ui:
      path: /roadmap
```

### Host IndexedDB Binding

`indexeddb` stays the YAML key, but the internal model is now neutral:

```go
type HostIndexedDBBindingConfig struct {
    Provider     string   `yaml:"provider,omitempty"`
    DB           string   `yaml:"db,omitempty"`
    ObjectStores []string `yaml:"objectStores,omitempty"`
}

type EffectiveHostIndexedDBBinding struct {
    Enabled      bool
    ProviderName string
    Provider     *ProviderEntry
    DB           string
    ObjectStores []string
}
```

The older `PluginIndexedDBConfig`, `EffectivePluginIndexedDB`, `EffectiveWorkflowIndexedDB`, and `EffectiveAgentIndexedDB` names remain aliases.

## Compatibility Rules

- Legacy workflow fields `plugin`, `operation`, `connection`, `instance`, `input`, and flat `agent` still load, but cannot be combined with `target`.
- Legacy hosted agent lifecycle fields still load when `runtime.pool` is omitted, but cannot be combined with `pool`.
- Legacy plugin `ui: <bundle>` plus `mountPath` still loads.

## Functional / Integration Coverage

- `go test ./internal/config`
- `go test ./internal/bootstrap`
- `go test ./cmd/gestaltd -run TestE2EValidateAcceptsCanonicalConfigShapes -count=1`
- `go test ./cmd/gestaltd -run TestE2EServePluginOwnedUIWiring -count=1`
- `go test ./cmd/gestaltd -run 'TestE2EValidateAcceptsCanonicalConfigShapes|TestE2EServePluginOwnedUIWiring' -count=1`

No new unit tests were added; the new behavior is covered through command-level config validation and serve wiring, with one existing assertion updated for the neutral IndexedDB error wording.