### PR TITLE
Clarify provider execution and egress config

### DIFF
--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -12,9 +12,9 @@ fully declarative, and some are hybrid packages that combine both models.
 
 From a deployment point of view, `source` chooses the package, `config`
 passes provider-specific settings such as OAuth app credentials,
-`allowedOperations` publishes only part of a large catalog, `allowedHosts`
-declares outbound egress policy, and `runtime` opts an executable plugin into
-hosted execution.
+`allowedOperations` publishes only part of a large catalog,
+`egress.allowedHosts` declares outbound egress policy, and `execution` opts an
+executable plugin into hosted execution.
 
 If the manifest enables MCP, the same operations are also exposed through the
 server's `/mcp` endpoint.
@@ -96,7 +96,9 @@ plugins:
 ```
 
 By default, executable plugins run on the same machine as `gestaltd`. A plugin
-only uses a hosted runtime when it sets `plugins.<name>.runtime`.
+only uses a hosted runtime when it sets `execution.mode: hosted`. The legacy
+`plugins.<name>.runtime` field is still accepted as an alias for hosted
+execution.
 
 ## Choosing a runtime
 
@@ -115,21 +117,24 @@ runtime:
 
 server:
   runtime:
-    provider: modal
+    defaultHostedProvider: modal
 
 plugins:
   support:
     source: ./plugins/support/manifest.yaml
-    runtime:
-      template: python-dev
-      image: ghcr.io/example/support-plugin:2026-04-21
-      metadata:
-        environment: production
+    execution:
+      mode: hosted
+      runtime:
+        template: python-dev
+        image: ghcr.io/example/support-plugin:2026-04-21
+        metadata:
+          environment: production
 ```
 
-`plugins.<name>.runtime.provider` selects a named backend from
+`plugins.<name>.execution.runtime.provider` selects a named backend from
 `runtime.providers`. When `provider` is omitted, Gestalt uses
-`server.runtime.provider` or the one runtime entry marked `default: true`.
+`server.runtime.defaultHostedProvider` or the one runtime entry marked
+`default: true`.
 
 `template`, `image`, and `metadata` are forwarded to the runtime backend. Their
 meaning is backend-specific: one runtime may ignore them, while another may use
@@ -137,14 +142,15 @@ them to choose a sandbox template, container image, or lifecycle labels.
 
 A built-in `local` runtime is always available for same-machine execution. The
 first installable hosted runtime provider is `modal`. It requires
-`runtime.providers.<name>.config.app` and `plugins.<name>.runtime.image`.
+`runtime.providers.<name>.config.app` and
+`plugins.<name>.execution.runtime.image`.
 Gestalt only uses it for plain executable plugins today. Modal can still run
 plugins that need Gestalt-owned services or hostname-based egress when the host
 is configured for the public relay and proxy path. In practice that means
 `server.baseURL` and `server.encryptionKey` must be set, and the runtime must
 report a compatible support profile. Without those prerequisites, plugins that
 need `indexeddb`, `cache`, `s3`, workflow-manager access when workflows are
-configured, nested `invokes`, `allowedHosts`, or
+configured, nested `invokes`, `egress.allowedHosts`, or
 `server.egress.defaultAction: deny` stay on `local`.
 
 For the runtime-provider model itself, see [Providers > Runtime](/providers/runtime).
@@ -178,22 +184,24 @@ plugins:
         alias: get_ticket
 ```
 
-Use `allowedHosts` when a plugin needs explicit outbound access:
+Use `egress.allowedHosts` when a plugin needs explicit outbound access:
 
 ```yaml
 plugins:
   github:
-    allowedHosts:
-      - api.github.com
-      - "*.github.com"
+    egress:
+      allowedHosts:
+        - api.github.com
+        - "*.github.com"
 ```
 
-For executable plugins, `allowedHosts` is only a complete security boundary when
-the plugin is running inside a runtime backend that preserves Gestalt's
-hostname-based policy model. The current host-local wrappers are OS-dependent,
-so operators should treat `allowedHosts` as declarative policy plus best-effort
-enforcement unless the selected runtime explicitly supports hostname-based
-egress controls.
+For executable plugins, `egress.allowedHosts` is only a complete security
+boundary when the plugin is running inside a runtime backend that preserves
+Gestalt's hostname-based policy model. The legacy `allowedHosts` field is still
+accepted as an alias. The current host-local wrappers are OS-dependent, so
+operators should treat `egress.allowedHosts` as declarative policy plus
+best-effort enforcement unless the selected runtime explicitly supports
+hostname-based egress controls.
 
 ## Building your own plugin
 

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -1,6 +1,6 @@
 # Runtime
 
-Runtime providers manage **where executable plugins run**.
+Runtime providers manage **where executable plugins and hosted agent providers run**.
 
 A runtime provider is not the plugin itself, and it is not a host provider like
 authentication, IndexedDB, or workflow. Instead, it is a control-plane backend
@@ -10,24 +10,27 @@ over gRPC.
 
 ## Scope
 
-Runtime providers only apply to executable plugins under `plugins.<name>`.
+Runtime providers apply to executable plugins under `plugins.<name>` and agent
+providers under `providers.agent.<name>` when they opt into hosted execution.
 They do **not** replace host-local infrastructure providers such as
 authentication, authorization, IndexedDB, cache, S3, secrets, or workflow.
 Those providers still live on the `gestaltd` host. A runtime provider only
-changes where the plugin process runs.
+changes where the configured plugin or agent provider process runs.
 
 ## Mental model
 
-By default, executable plugins run on the same machine as `gestaltd`. A plugin
-only uses a runtime provider when it opts in with `plugins.<name>.runtime`.
+By default, executable plugins and agent providers run on the same machine as
+`gestaltd`. A provider only uses a runtime provider when it opts in with
+`execution.mode: hosted`. The legacy `plugins.<name>.runtime` and
+`providers.agent.<name>.runtime` fields are still accepted as aliases.
 
-When a plugin does opt in, Gestalt selects a backend from `runtime.providers`,
+When a provider does opt in, Gestalt selects a backend from `runtime.providers`,
 reads the backend's support profile, starts a runtime session, waits for that
 session to become ready, binds any required host-local services, starts the
-plugin process inside the session, then dials the plugin back over gRPC. From
-that point on, the hosted plugin behaves like any other plugin from the
-caller's point of view. Gestalt stops the runtime session during shutdown or
-after a bootstrap failure.
+provider process inside the session, then dials it back over gRPC. From that
+point on, the hosted provider behaves like any other configured provider from
+the caller's point of view. Gestalt stops the runtime session during shutdown
+or after a bootstrap failure.
 
 That is why the runtime interface is bigger than a single `StartPlugin` call:
 Gestalt needs an explicit lifecycle boundary, not just a fire-and-forget launch
@@ -50,37 +53,39 @@ runtime:
 
 server:
   runtime:
-    provider: modal
+    defaultHostedProvider: modal
 
 plugins:
   support:
     source: ./plugins/support/manifest.yaml
-    runtime:
-      image: ghcr.io/example/support-plugin:2026-04-21
-      template: python-dev
-      metadata:
-        environment: production
+    execution:
+      mode: hosted
+      runtime:
+        image: ghcr.io/example/support-plugin:2026-04-21
+        template: python-dev
+        metadata:
+          environment: production
 ```
 
 Selection is intentionally two-step. `runtime.providers` defines named
-backends, while `plugins.<name>.runtime` opts a specific plugin into hosted
-execution. `server.runtime.provider` is only a default selector for plugins
-that already set `plugins.<name>.runtime`.
+backends, while `execution.mode: hosted` opts a specific plugin or agent
+provider into hosted execution. `server.runtime.defaultHostedProvider` is only
+a default selector for providers that already opted into hosted execution.
 
 ## Runtime profiles
 
 Runtime backends are not interchangeable, but the compatibility check is meant
 to read in terms of behavior, not implementation details. Gestalt asks whether
 the runtime can host plugins, how hosted plugins reach Gestalt-owned services,
-whether the runtime can preserve hostname-based `allowedHosts`, and whether the
-plugin should launch from a host path or from a staged bundle.
+whether the runtime can preserve hostname-based `egress.allowedHosts`, and
+whether the plugin should launch from a host path or from a staged bundle.
 
 Host-service access is reported as `none`, `relay`, or `direct`. `direct`
 means the runtime can expose guest-local service sockets inside the session.
 `relay` means the current host deployment can provide those services through
 Gestalt's public relay path. Egress support is separate: a runtime must preserve
-Gestalt's hostname-based policy model before plugins with `allowedHosts` or a
-default-deny egress policy can run there.
+Gestalt's hostname-based policy model before plugins with `egress.allowedHosts`
+or a default-deny egress policy can run there.
 
 The admin inspection API exposes both sides of that decision. `GET
 /admin/api/v1/runtime/providers` includes `profile.advertised`, which is what
@@ -99,9 +104,10 @@ back to `gestaltd` over a scoped public relay target and `gestaltd` forwards
 the request to the real host-local service.
 
 That same split shows up in hostname-based egress. A runtime may preserve
-`allowedHosts` internally, or it may preserve it by routing hosted HTTP(S)
-traffic through Gestalt's public egress proxy. Either way, the contract is that
-the meaning of `allowedHosts` stays the same from the plugin's point of view.
+`egress.allowedHosts` internally, or it may preserve it by routing hosted
+HTTP(S) traffic through Gestalt's public egress proxy. Either way, the contract
+is that the meaning of `egress.allowedHosts` stays the same from the plugin's
+point of view.
 
 The runtime provider is also responsible for the plugin's own listener endpoint.
 `StartPlugin` must start the plugin, allocate or inject its provider listener,
@@ -115,7 +121,7 @@ Today there are two main runtime choices:
 | Backend | Type | Notes |
 | --- | --- | --- |
 | `local` | Built-in driver | Runs the plugin on the same machine as `gestaltd`. Supports host-path execution and the existing host-local runtime behavior. |
-| `modal` | Installable `kind: runtime` provider | Runs the plugin in a hosted Linux sandbox. Requires `runtime.providers.<name>.config.app` and `plugins.<name>.runtime.image`. When the host is configured for the public relay and proxy path, Modal can run plugins that need Gestalt-owned services and hostname-based egress. |
+| `modal` | Installable `kind: runtime` provider | Runs the plugin in a hosted Linux sandbox. Requires `runtime.providers.<name>.config.app` and `plugins.<name>.execution.runtime.image`. When the host is configured for the public relay and proxy path, Modal can run plugins that need Gestalt-owned services and hostname-based egress. |
 
 ## Bundle staging and host-path execution
 
@@ -126,9 +132,9 @@ plugin directly from local paths, including synthesized source-provider
 execution. When it advertises `bundle`, Gestalt stages a runtime bundle first
 and asks the backend to start the plugin from that staged bundle instead.
 
-This is why `plugins.<name>.runtime.image`, `template`, and `metadata` are
-forwarded to the runtime backend: they are runtime-specific launch hints, not
-universal plugin semantics.
+This is why `plugins.<name>.execution.runtime.image`, `template`, and
+`metadata` are forwarded to the runtime backend: they are runtime-specific
+launch hints, not universal plugin semantics.
 
 ## What to read next
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -66,9 +66,10 @@ server:
 plugins:
   github:
     source: ./plugins/github/manifest.yaml
-    allowedHosts:
-      - api.github.com
-      - uploads.github.com
+    egress:
+      allowedHosts:
+        - api.github.com
+        - uploads.github.com
 ```
 
 Override:
@@ -79,8 +80,9 @@ server:
     port: 9090
 plugins:
   github:
-    allowedHosts:
-      - api.github.com
+    egress:
+      allowedHosts:
+        - api.github.com
     iconFile: ./icons/github.svg
     displayName: null
 ```
@@ -92,7 +94,7 @@ gestaltd validate --config ./base.yaml --config ./overrides/local.yaml
 ```
 
 The resulting config keeps `server.public.port`, adds `server.management.port`,
-replaces `plugins.github.allowedHosts`, resolves `iconFile` relative to
+replaces `plugins.github.egress.allowedHosts`, resolves `iconFile` relative to
 `./overrides/local.yaml`, and deletes the inherited `displayName`.
 
 ## `server`
@@ -172,7 +174,7 @@ Plugins without `authorizationPolicy` are open to any authenticated subject, inc
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared `init` artifacts. |
 | `providers.audit` / `providers.authentication` / `providers.authorization` / `providers.indexeddb` / `providers.secrets` / `providers.telemetry` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
-| `runtime.provider` | | Default runtime-provider selector for plugins that opt into `plugins.<name>.runtime`. This does not move plugins into hosted runtimes by itself. |
+| `runtime.defaultHostedProvider` | | Default runtime-provider selector for plugins that opt into `execution.mode: hosted`. This does not move plugins into hosted runtimes by itself. |
 | `admin.authorizationPolicy` | | Shared subject access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
 | `admin.ui` | | Optional named `providers.ui` bundle whose `admin/` assets should back `/admin`. When omitted, Gestalt auto-discovers `admin/` assets from the root UI bundle before using the built-in fallback. |
@@ -184,8 +186,9 @@ When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth ro
 ## `runtime`
 
 `runtime.providers` defines named execution backends for executable plugins.
-These backends are only used when a plugin opts into `plugins.<name>.runtime`.
-If a plugin omits `runtime`, it still runs on the same machine as `gestaltd`.
+These backends are only used when a plugin opts into `execution.mode: hosted`.
+If a plugin omits `execution` or sets `execution.mode: local`, it still runs on
+the same machine as `gestaltd`.
 
 See [Providers > Runtime](/providers/runtime) for the lifecycle and capability
 model behind these fields.
@@ -204,14 +207,16 @@ runtime:
         environment: main
 ```
 
-`server.runtime.provider` supplies the default runtime name for plugins that set
-`plugins.<name>.runtime` without an explicit `provider`.
+`server.runtime.defaultHostedProvider` supplies the default runtime name for
+plugins that set `execution.mode: hosted` without an explicit
+`execution.runtime.provider`. The legacy `server.runtime.provider` field is
+still accepted as an alias.
 
 | Field | Description |
 | --- | --- |
 | `providers.<name>.driver` | Optional built-in runtime selector. The only built-in runtime is `local`. |
 | `providers.<name>.source` | Source or provider-release reference for an installable `kind: runtime` provider such as Modal. |
-| `providers.<name>.default` | Marks the runtime as the default selection when `server.runtime.provider` is omitted. Only one runtime may be default. |
+| `providers.<name>.default` | Marks the runtime as the default selection when `server.runtime.defaultHostedProvider` is omitted. Only one runtime may be default. |
 | `providers.<name>.config` | Runtime-provider-specific config blob. Built-ins such as `local` reject custom config entirely. |
 
 ### `runtime.providers.*.config` for the Modal runtime provider
@@ -250,14 +255,14 @@ runtime:
 | `cloud` | Optional cloud selector passed through to Modal. |
 | `regions` | Optional region allowlist passed through to Modal. |
 
-When a plugin uses the Modal runtime provider, `plugins.<name>.runtime.image` is
-required. Modal can still run hosted plugins that need Gestalt-owned services
-or hostname-based egress when the host is configured for the public relay and
-proxy path. In practice that means `server.baseURL` and `server.encryptionKey`
-must be set, and the runtime must report a compatible support profile. Without
-those prerequisites, Gestalt will reject Modal for plugins that need
-relay-backed host services, `allowedHosts`, or a server-wide default-deny
-egress policy.
+When a plugin uses the Modal runtime provider,
+`plugins.<name>.execution.runtime.image` is required. Modal can still run
+hosted plugins that need Gestalt-owned services or hostname-based egress when
+the host is configured for the public relay and proxy path. In practice that
+means `server.baseURL` and `server.encryptionKey` must be set, and the runtime
+must report a compatible support profile. Without those prerequisites, Gestalt
+will reject Modal for plugins that need relay-backed host services,
+`egress.allowedHosts`, or a server-wide default-deny egress policy.
 ## `providers.authentication`
 
 Platform authentication is optional. Omit the `providers.authentication` block entirely to disable it. When platform authentication is enabled, configure one or more named entries under `providers.authentication`. If more than one entry exists, set `server.providers.authentication` to pick which one the host should use.
@@ -318,7 +323,7 @@ Authentication providers use the same `ProviderEntry` shape under `providers.aut
 | `source.auth` | Optional metadata-fetch auth for release sources, including direct metadata URLs and `source.githubRelease`. |
 | `config` | Provider-specific config passed into the authentication provider. |
 | `env` | Extra environment variables passed to the provider process. |
-| `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `providers.indexeddb`
 
@@ -396,7 +401,7 @@ The exact config fields depend on the selected authorization provider package. T
 | `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
 | `config` | Provider-specific config passed into the authorization provider. |
 | `env` | Extra environment variables passed to the provider process. |
-| `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `providers.workflow`
 
@@ -465,7 +470,7 @@ allowlist logical stores exposed through that binding.
 | `config` | Provider-specific config passed into the workflow provider. |
 | `indexeddb` | Optional host IndexedDB binding for the workflow provider, including `provider`, optional `db`, and optional `objectStores`. |
 | `env` | Extra environment variables passed to the provider process. |
-| `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `providers.agent`
 
@@ -510,12 +515,14 @@ optional resolved `tools`, optional `responseSchema`, and provider-specific
 IndexedDB binding with `indexeddb`; the provider process then uses the SDK
 IndexedDB helper against `GESTALT_INDEXEDDB_SOCKET`.
 
-Agent providers may also opt into a hosted runtime with `runtime`, using the
-same runtime-provider selection model as executable plugins. When
-`providers.agent.<name>.runtime` is present, `gestaltd` starts the agent
-provider inside the selected hosted runtime instead of launching it directly on
-the `gestaltd` host. Tool callbacks still route back through the host agent
-socket, and `allowedHosts` remains the operator-facing egress policy.
+Agent providers may also opt into a hosted runtime with
+`execution.mode: hosted`, using the same runtime-provider selection model as
+executable plugins. When `providers.agent.<name>.execution.mode` is `hosted`,
+`gestaltd` starts the agent provider inside the selected hosted runtime instead
+of launching it directly on the `gestaltd` host. Tool callbacks still route
+back through the host agent socket, and `egress.allowedHosts` remains the
+operator-facing egress policy. Legacy `providers.agent.<name>.runtime` remains
+accepted as an alias for hosted execution.
 
 | Field | Description |
 | --- | --- |
@@ -525,8 +532,8 @@ socket, and `allowedHosts` remains the operator-facing egress policy.
 | `indexeddb` | Optional agent IndexedDB config. `indexeddb.provider` selects the named `providers.indexeddb` entry backing the agent's single IndexedDB SDK socket; unlike plugins, agents do not inherit the selected/default host IndexedDB automatically. `indexeddb.db` overrides the provider-visible database name and defaults to the agent provider key. `indexeddb.objectStores` optionally allowlists logical object stores the agent may use. |
 | `config` | Provider-specific config passed into the agent provider. |
 | `env` | Extra environment variables passed to the provider process. |
-| `runtime` | Optional hosted runtime selection for this agent provider. Supports `provider`, `template`, `image`, `metadata`, and `pool`. `pool` contains hosted agent lifecycle fields: `minReadyInstances`, `maxReadyInstances`, `startupTimeout`, `healthCheckInterval`, `restartPolicy`, and `drainTimeout`. The older flat lifecycle fields are still accepted, but cannot be combined with `pool`. |
-| `allowedHosts` | Outbound host allowlist. For executable providers, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `execution` | Optional hosted execution selection for this agent provider. `execution.mode` is `local` or `hosted`; `execution.runtime` supports `provider`, `template`, `image`, `metadata`, and `pool`. `pool` contains hosted agent lifecycle fields: `minReadyInstances`, `maxReadyInstances`, `startupTimeout`, `healthCheckInterval`, `restartPolicy`, and `drainTimeout`. The older flat lifecycle fields are still accepted, but cannot be combined with `pool`. Legacy `runtime` remains accepted as an alias for hosted execution. |
+| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable providers, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `workflows`
 
@@ -643,7 +650,7 @@ First-party cache providers are published at
 | `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
 | `config` | Arbitrary provider-specific config passed through to the cache provider. |
 | `env` | Extra environment variables passed to the provider process. |
-| `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `providers.s3`
 
@@ -983,6 +990,8 @@ plugins:
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
+| `execution` | Optional executable-plugin execution config. `execution.mode` is `local` or `hosted`; `execution.runtime` carries the hosted runtime fields. Legacy `runtime` remains accepted as an alias for `execution.mode: hosted` plus `execution.runtime`. |
+| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 | `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Schema-capable backends derive plugin scoping from that `db` name. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
 | `s3` | Optional list of named `providers.s3` bindings exposed to the executable plugin through the SDK transport. A single binding also populates the default S3 SDK env var for compatibility. |
 
@@ -1097,7 +1106,7 @@ Gestalt synthesizes Go and Rust executable wrappers automatically when needed an
 | `source.auth` | Optional metadata-fetch auth for release sources, including direct metadata URLs, `source.githubRelease`, and local `provider-release.yaml` metadata. |
 | `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either `server` or a named `providers.authentication` entry. Gestalt enforces this on plugin HTTP operation routes and on plugin-backed mounted UIs. Standalone `providers.ui` bundles, the built-in admin UI/admin API, and `/mcp` still use the server-wide auth provider in this phase. |
 | `env` | Extra environment variables passed to the provider process. |
-| `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ### `connections`
 
@@ -1256,7 +1265,8 @@ connections:
 ## `server.egress`
 
 `server.egress` sets the server-wide default for outbound network access.
-Per-provider `allowedHosts` lists declare which hosts each provider may reach.
+Per-provider `egress.allowedHosts` lists declare which hosts each provider may
+reach.
 For executable plugins, that declaration is only a complete enforcement
 boundary when the deployment is using a supported sandboxed runtime.
 
@@ -1267,25 +1277,29 @@ server:
 
 plugins:
   github:
-    allowedHosts:
-      - api.github.com
-      - "*.github.com"
+    egress:
+      allowedHosts:
+        - api.github.com
+        - "*.github.com"
   my-plugin:
     source: ./plugins/my-plugin/manifest.yaml
-    allowedHosts:
-      - external-api.com
+    egress:
+      allowedHosts:
+        - external-api.com
 ```
 
 | Field | Description |
 | --- | --- |
-| `defaultAction` | `allow` (default) or `deny`. Applies when a provider has no `allowedHosts`. |
+| `defaultAction` | `allow` (default) or `deny`. Applies when a provider has no `egress.allowedHosts`. |
 
-When `allowedHosts` is set on a provider, Gestalt applies that allowlist to
-host-mediated outbound checks using exact matches and `*.suffix` wildcards. When
-`allowedHosts` is empty, `defaultAction` decides: `allow` permits outbound
-requests, `deny` blocks them. For executable plugins, those rules are only a
-complete security boundary when the plugin is running inside a supported
-sandboxed runtime rather than relying on host-specific OS wrappers alone.
+When `egress.allowedHosts` is set on a provider, Gestalt applies that allowlist
+to host-mediated outbound checks using exact matches and `*.suffix` wildcards.
+When `egress.allowedHosts` is empty, `defaultAction` decides: `allow` permits
+outbound requests, `deny` blocks them. The legacy provider-level `allowedHosts`
+field is still accepted as an alias for `egress.allowedHosts`. For executable
+plugins, those rules are only a complete security boundary when the plugin is
+running inside a supported sandboxed runtime rather than relying on
+host-specific OS wrappers alone.
 
 ## `providers.ui`
 

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -63,9 +63,10 @@ capabilities, not just the host-local child-process wrapper.
 
 ### Egress control
 
-Every provider entry supports `allowedHosts` to declare which upstream hosts it
-can reach. When `server.egress.defaultAction` is `deny`, providers without an
-explicit allowlist are blocked from host-mediated outbound requests.
+Every provider entry supports `egress.allowedHosts` to declare which upstream
+hosts it can reach. The legacy provider-level `allowedHosts` field remains
+accepted as an alias. When `server.egress.defaultAction` is `deny`, providers
+without an explicit allowlist are blocked from host-mediated outbound requests.
 
 ```yaml
 server:
@@ -75,9 +76,10 @@ server:
 plugins:
   my-plugin:
     source: https://artifacts.example.com/plugin/my-plugin/v1.0.0/provider-release.yaml
-    allowedHosts:
-      - "api.example.com"
-      - "*.slack.com"
+    egress:
+      allowedHosts:
+        - "api.example.com"
+        - "*.slack.com"
 ```
 
 Wildcards are supported (`*.example.com` matches `api.example.com`). The same
@@ -86,20 +88,21 @@ check applies uniformly to REST, GraphQL, and MCP providers.
 ### OS-level sandbox
 
 Executable plugin providers can run with additional OS-level isolation when
-`allowedHosts` is configured or when `server.egress.defaultAction` is `deny`.
-That isolation currently depends on host-specific runtime support, so it should
-not be treated as a portable security boundary by itself.
+`egress.allowedHosts` is configured or when `server.egress.defaultAction` is
+`deny`. That isolation currently depends on host-specific runtime support, so
+it should not be treated as a portable security boundary by itself.
 
 The built-in `local` runtime uses this same host-local sandbox path. Hosted
 runtime providers may define a stronger or different execution boundary, but
 they only count as equivalent for security policy purposes when their support
-profile preserves the same policy. In particular, Gestalt's `allowedHosts`
-model is hostname-based, so a backend that only supports CIDR or firewall rules
-is not a drop-in replacement for hostname-aware egress enforcement.
+profile preserves the same policy. In particular, Gestalt's
+`egress.allowedHosts` model is hostname-based, so a backend that only supports
+CIDR or firewall rules is not a drop-in replacement for hostname-aware egress
+enforcement.
 
 **Filesystem.** On Linux, [Landlock](https://docs.kernel.org/userspace-api/landlock.html) restricts file access to system libraries, SSL certificates, and DNS configuration. Writes are limited to the socket directory and an isolated temp directory. On macOS, equivalent restrictions are applied via `sandbox-exec`.
 
-**Network.** `gestaltd` starts a local HTTP proxy and sets `HTTP_PROXY`/`HTTPS_PROXY` in the provider's environment. The proxy checks each request's hostname against the same `allowedHosts` and `defaultAction` rules used by all other provider types.
+**Network.** `gestaltd` starts a local HTTP proxy and sets `HTTP_PROXY`/`HTTPS_PROXY` in the provider's environment. The proxy checks each request's hostname against the same `egress.allowedHosts` and `defaultAction` rules used by all other provider types.
 
 **Process group.** Sandboxed providers run in their own process group. On shutdown, `gestaltd` signals the entire group to ensure child processes are also cleaned up.
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1720,7 +1720,7 @@ func buildAgent(ctx context.Context, name string, entry *config.ProviderEntry, f
 		provider    coreagent.Provider
 		providerErr error
 	)
-	if entry.Runtime != nil {
+	if entry.UsesHostedExecution() {
 		provider, providerErr = buildHostedAgentProvider(ctx, name, entry, node, hostServices, deps)
 	} else {
 		if factories.Agent == nil {

--- a/gestaltd/internal/bootstrap/egress.go
+++ b/gestaltd/internal/bootstrap/egress.go
@@ -19,10 +19,23 @@ func newEgressDeps(cfg *config.Config) EgressDeps {
 	return EgressDeps{DefaultAction: action}
 }
 
+func (d EgressDeps) Policy(allowedHosts []string) egress.Policy {
+	return egress.Policy{
+		AllowedHosts:  allowedHosts,
+		DefaultAction: d.DefaultAction,
+	}
+}
+
+func (d EgressDeps) ProviderPolicy(entry *config.ProviderEntry) egress.Policy {
+	if entry == nil {
+		return d.Policy(nil)
+	}
+	return d.Policy(entry.EffectiveAllowedHosts())
+}
+
 // CheckFunc returns an egress check function scoped to a particular
 // provider's allowed host list.
 func (d EgressDeps) CheckFunc(allowedHosts []string) func(string) error {
-	return func(host string) error {
-		return egress.CheckHost(allowedHosts, host, d.DefaultAction)
-	}
+	policy := d.Policy(allowedHosts)
+	return policy.CheckHost
 }

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -346,8 +346,9 @@ func (r *capturingBundlePluginRuntime) StartPlugin(ctx context.Context, req plug
 		Args:          slices.Clone(req.Args),
 		Env:           cloneRuntimeMetadata(req.Env),
 		BundleDir:     req.BundleDir,
-		AllowedHosts:  slices.Clone(req.AllowedHosts),
-		DefaultAction: req.DefaultAction,
+		Egress:        cloneRuntimeEgressPolicy(req.Egress),
+		AllowedHosts:  cloneLegacyStartPluginAllowedHosts(req),
+		DefaultAction: legacyStartPluginDefaultAction(req),
 		HostBinary:    req.HostBinary,
 	})
 	r.mu.Unlock()
@@ -1221,8 +1222,9 @@ func (r *capturingBundlePluginRuntime) startPluginRequestsCopy() []pluginruntime
 			Args:          slices.Clone(req.Args),
 			Env:           cloneRuntimeMetadata(req.Env),
 			BundleDir:     req.BundleDir,
-			AllowedHosts:  slices.Clone(req.AllowedHosts),
-			DefaultAction: req.DefaultAction,
+			Egress:        cloneRuntimeEgressPolicy(req.Egress),
+			AllowedHosts:  cloneLegacyStartPluginAllowedHosts(req),
+			DefaultAction: legacyStartPluginDefaultAction(req),
 			HostBinary:    req.HostBinary,
 		}
 	}
@@ -1248,6 +1250,37 @@ func cloneRuntimeMetadata(values map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
+}
+
+func cloneRuntimeEgressPolicy(policy pluginruntime.RuntimeEgressPolicy) pluginruntime.RuntimeEgressPolicy {
+	return pluginruntime.RuntimeEgressPolicy{
+		AllowedHosts:  slices.Clone(policy.AllowedHosts),
+		DefaultAction: policy.DefaultAction,
+	}
+}
+
+func cloneLegacyStartPluginAllowedHosts(req pluginruntime.StartPluginRequest) []string {
+	return slices.Clone(req.AllowedHosts) //nolint:staticcheck // Tests assert deprecated runtime compatibility fields remain populated.
+}
+
+func legacyStartPluginDefaultAction(req pluginruntime.StartPluginRequest) pluginruntime.PolicyAction {
+	return req.DefaultAction //nolint:staticcheck // Tests assert deprecated runtime compatibility fields remain populated.
+}
+
+func assertStartPluginEgressPolicy(t *testing.T, req pluginruntime.StartPluginRequest, allowedHosts []string, action pluginruntime.PolicyAction) {
+	t.Helper()
+	if got := req.Egress.AllowedHosts; !slices.Equal(got, allowedHosts) {
+		t.Fatalf("StartPlugin egress allowed hosts = %#v, want %#v", got, allowedHosts)
+	}
+	if got := req.Egress.DefaultAction; got != action {
+		t.Fatalf("StartPlugin egress default action = %q, want %q", got, action)
+	}
+	if got := cloneLegacyStartPluginAllowedHosts(req); !slices.Equal(got, allowedHosts) {
+		t.Fatalf("StartPlugin legacy allowed hosts = %#v, want %#v", got, allowedHosts)
+	}
+	if got := legacyStartPluginDefaultAction(req); got != action {
+		t.Fatalf("StartPlugin legacy default action = %q, want %q", got, action)
+	}
 }
 
 func cloneBindHostServiceRequest(req pluginruntime.BindHostServiceRequest) pluginruntime.BindHostServiceRequest {
@@ -3642,7 +3675,7 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -5271,10 +5304,13 @@ func TestPluginRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *te
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime: &config.HostedRuntimeConfig{
-					Template: "python-dev",
-					Image:    "ghcr.io/valon/gestalt-python-runtime:latest",
-					Metadata: map[string]string{"tenant": "eng"},
+				Execution: &config.ExecutionConfig{
+					Mode: config.ExecutionModeHosted,
+					Runtime: &config.HostedRuntimeConfig{
+						Template: "python-dev",
+						Image:    "ghcr.io/valon/gestalt-python-runtime:latest",
+						Metadata: map[string]string{"tenant": "eng"},
+					},
 				},
 			},
 		},
@@ -5655,7 +5691,7 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -5749,8 +5785,8 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 			t.Fatalf("StartPlugin env should include s3 relay token %s", providerhost.S3SocketTokenEnv(binding))
 		}
 	}
-	if !slices.Contains(startRequests[0].AllowedHosts, "gestalt.example.test") {
-		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", startRequests[0].AllowedHosts)
+	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, "gestalt.example.test") {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", allowedHosts)
 	}
 }
 
@@ -5936,8 +5972,8 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 	if got := startRequests[0].Env[providerhost.AuthorizationSocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the authorization relay token")
 	}
-	if !slices.Contains(startRequests[0].AllowedHosts, "gestalt.example.test") {
-		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", startRequests[0].AllowedHosts)
+	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, "gestalt.example.test") {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", allowedHosts)
 	}
 }
 
@@ -6051,8 +6087,8 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 	if got := startRequests[0].Env[providerhost.IndexedDBSocketTokenEnv("")]; got == "" {
 		t.Fatal("StartPlugin env should include the IndexedDB relay token")
 	}
-	if !slices.Contains(startRequests[0].AllowedHosts, "gestalt.example.test") {
-		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", startRequests[0].AllowedHosts)
+	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, "gestalt.example.test") {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", allowedHosts)
 	}
 }
 
@@ -6296,8 +6332,8 @@ func TestPluginRuntimeConfigUsesPublicCacheRelayWithoutHostServiceTunnelCapabili
 			t.Fatalf("StartPlugin env should include cache relay token %s", providerhost.CacheSocketTokenEnv(binding))
 		}
 	}
-	if !slices.Contains(startRequests[0].AllowedHosts, "gestalt.example.test") {
-		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", startRequests[0].AllowedHosts)
+	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, "gestalt.example.test") {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", allowedHosts)
 	}
 }
 
@@ -6737,8 +6773,8 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	if got := startRequests[0].Env[providerhost.PluginInvokerSocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the plugin invoker relay token")
 	}
-	if !slices.Contains(startRequests[0].AllowedHosts, relayURL.Hostname()) {
-		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host %q", startRequests[0].AllowedHosts, relayURL.Hostname())
+	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, relayURL.Hostname()) {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host %q", allowedHosts, relayURL.Hostname())
 	}
 	bindRequests := runtimeProvider.bindHostServiceRequests()
 	if len(bindRequests) != 1 {
@@ -6852,8 +6888,8 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 	if got := startRequests[0].Env[providerhost.WorkflowManagerSocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the workflow manager relay token")
 	}
-	if !slices.Contains(startRequests[0].AllowedHosts, "gestalt.example.test") {
-		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", startRequests[0].AllowedHosts)
+	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, "gestalt.example.test") {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", allowedHosts)
 	}
 }
 
@@ -6896,8 +6932,8 @@ func TestPluginRuntimeConfigRejectsMissingHostnameEgressCapability(t *testing.T)
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
-				AllowedHosts:         []string{"api.github.com"},
+				Execution:            &config.ExecutionConfig{Mode: config.ExecutionModeHosted},
+				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"api.github.com"}},
 			},
 		},
 	}
@@ -7563,9 +7599,7 @@ func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapa
 	if parsed.User == nil {
 		t.Fatal("HTTP_PROXY should include relay credentials")
 	}
-	if got := startRequests[0].AllowedHosts; !slices.Equal(got, []string{"api.github.com"}) {
-		t.Fatalf("StartPlugin allowed hosts = %#v, want original allowedHosts only", got)
-	}
+	assertStartPluginEgressPolicy(t, startRequests[0], []string{"api.github.com"}, pluginruntime.PolicyDeny)
 }
 
 func TestPluginRuntimeConfigSkipsPublicEgressProxyWhenHostnameEgressIsNotRequired(t *testing.T) {
@@ -7710,9 +7744,7 @@ func TestPluginRuntimeConfigUsesDirectHostServiceBindingsAndSkipsPublicEgressPro
 	if got := startRequests[0].Env[providerhost.CacheSocketTokenEnv("session")]; got != "" {
 		t.Fatalf("StartPlugin cache token env = %q, want empty for direct host service bindings", got)
 	}
-	if got := startRequests[0].AllowedHosts; !slices.Equal(got, []string{"api.github.com"}) {
-		t.Fatalf("StartPlugin allowed hosts = %#v, want original allowedHosts only", got)
-	}
+	assertStartPluginEgressPolicy(t, startRequests[0], []string{"api.github.com"}, pluginruntime.PolicyDeny)
 
 	bindRequests := runtimeProvider.bindHostServiceRequests()
 	if len(bindRequests) == 0 {

--- a/gestaltd/internal/bootstrap/plugin_runtime_executable.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_executable.go
@@ -35,7 +35,7 @@ func buildExecutablePluginRuntime(ctx context.Context, name string, entry *confi
 		Args:         append([]string(nil), entry.Args...),
 		Env:          maps.Clone(entry.Env),
 		Config:       runtimeConfig,
-		AllowedHosts: append([]string(nil), entry.AllowedHosts...),
+		AllowedHosts: entry.EffectiveAllowedHosts(),
 		HostBinary:   entry.HostBinary,
 		HostServices: buildRuntimeProviderHostServices(name, deps),
 		Telemetry:    deps.Telemetry,

--- a/gestaltd/internal/bootstrap/plugin_runtime_plan.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_plan.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 )
 
@@ -158,7 +157,7 @@ func pluginRuntimeRequirementsForPlugin(name string, entry *config.ProviderEntry
 	if len(entry.Invokes) > 0 {
 		requiresHostServiceAccess = true
 	}
-	return requiresHostServiceAccess, len(entry.AllowedHosts) > 0 || deps.Egress.DefaultAction == egress.PolicyDeny, nil
+	return requiresHostServiceAccess, deps.Egress.ProviderPolicy(entry).RequiresHostnameEnforcement(), nil
 }
 
 func agentRuntimeRequirementsForProvider(name string, entry *config.ProviderEntry, deps Deps) (bool, bool, error) {
@@ -168,7 +167,7 @@ func agentRuntimeRequirementsForProvider(name string, entry *config.ProviderEntr
 	if _, err := config.ResolveEffectiveAgentIndexedDB(name, entry, deps.IndexedDBDefs); err != nil {
 		return false, false, err
 	}
-	return true, len(entry.AllowedHosts) > 0 || deps.Egress.DefaultAction == egress.PolicyDeny, nil
+	return true, deps.Egress.ProviderPolicy(entry).RequiresHostnameEnforcement(), nil
 }
 
 func (p HostedRuntimePlan) Validate(label string) error {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -525,7 +525,7 @@ func buildConfiguredSpecComposite(ctx context.Context, name string, entry *confi
 	cfg := specProviderConfig{
 		manifestPlugin:       manifestPlugin,
 		allowedOperations:    allowedOperations,
-		allowedHosts:         entry.AllowedHosts,
+		allowedHosts:         entry.EffectiveAllowedHosts(),
 		baseURL:              config.EffectiveProviderSpecBaseURL(entry, manifestPlugin),
 		applyResponseMapping: true,
 		providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
@@ -870,7 +870,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		})
 	}
 	startEnv := maps.Clone(env)
-	allowedHosts := slices.Clone(entry.AllowedHosts)
+	allowedHosts := entry.EffectiveAllowedHosts()
 	for _, hostService := range startedHostServices.Bindings() {
 		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect)
 		if err != nil {
@@ -887,27 +887,29 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		}
 		allowedHosts = appendAllowedHost(allowedHosts, relayHost)
 	}
-	if runtimePlan.HostnameEgressDelivery == RuntimeHostnameEgressDeliveryPublicProxy {
-		proxyEnv, err := buildHostedRuntimePublicEgressProxy(name, sessionID, entry.AllowedHosts, deps.Egress.DefaultAction, deps)
-		if err != nil {
-			return nil, err
+	egressPlan, err := buildHostedRuntimeEgressLaunchPlan(name, sessionID, deps.Egress.ProviderPolicy(entry), allowedHosts, runtimePlan, deps)
+	if err != nil {
+		return nil, err
+	}
+	if len(egressPlan.Env) > 0 {
+		if startEnv == nil {
+			startEnv = make(map[string]string, len(egressPlan.Env))
 		}
-		if len(proxyEnv) > 0 {
-			if startEnv == nil {
-				startEnv = make(map[string]string, len(proxyEnv))
-			}
-			maps.Copy(startEnv, proxyEnv)
-		}
+		maps.Copy(startEnv, egressPlan.Env)
 	}
 
 	hostedPlugin, err := runtimeProvider.StartPlugin(ctx, pluginruntime.StartPluginRequest{
-		SessionID:     sessionID,
-		PluginName:    name,
-		Command:       command,
-		Args:          args,
-		Env:           startEnv,
-		BundleDir:     launch.bundleDir,
-		AllowedHosts:  allowedHosts,
+		SessionID:  sessionID,
+		PluginName: name,
+		Command:    command,
+		Args:       args,
+		Env:        startEnv,
+		BundleDir:  launch.bundleDir,
+		Egress: pluginruntime.RuntimeEgressPolicy{
+			AllowedHosts:  egressPlan.RuntimeAllowedHosts,
+			DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
+		},
+		AllowedHosts:  egressPlan.RuntimeAllowedHosts,
 		DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
 		HostBinary:    entry.HostBinary,
 	})
@@ -949,7 +951,8 @@ func buildHostedAgentProvider(ctx context.Context, name string, entry *config.Pr
 	if err != nil {
 		return nil, err
 	}
-	policy, err := entry.Runtime.LifecyclePolicy()
+	runtimeCfg := entry.HostedRuntimeConfig()
+	policy, err := runtimeCfg.LifecyclePolicy()
 	if err != nil {
 		launch.close()
 		return nil, fmt.Errorf("parse hosted agent runtime lifecycle policy: %w", err)
@@ -968,6 +971,7 @@ type hostedAgentProviderLaunch struct {
 	runtimeOwned    bool
 	runtimePlan     HostedRuntimePlan
 	cfg             componentprovider.YAMLConfig
+	allowedHosts    []string
 	launch          pluginRuntimeLaunch
 	cleanup         func()
 }
@@ -1058,6 +1062,7 @@ func prepareHostedAgentProviderLaunch(ctx context.Context, name string, entry *c
 		runtimeOwned:    runtimeOwned,
 		runtimePlan:     runtimePlan,
 		cfg:             cfg,
+		allowedHosts:    entry.EffectiveAllowedHosts(),
 		launch:          launch,
 		cleanup:         cleanup,
 	}
@@ -1126,7 +1131,11 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	})
 
 	startEnv := maps.Clone(cfg.Env)
-	allowedHosts := hostedAgentAllowedHosts(cfg.AllowedHosts, runtimePlan)
+	agentAllowedHosts := slices.Clone(cfg.AllowedHosts)
+	if len(agentAllowedHosts) == 0 {
+		agentAllowedHosts = slices.Clone(launch.allowedHosts)
+	}
+	allowedHosts := hostedAgentAllowedHosts(agentAllowedHosts, runtimePlan)
 	phaseStarted = time.Now()
 	for _, hostService := range startedHostServices.Bindings() {
 		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect)
@@ -1149,30 +1158,34 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 		}
 	}
 	recordHostedAgentRuntimeStartPhase(ctx, name, "host_services_bind", phaseStarted, nil)
+	phaseStarted = time.Now()
+	egressPlan, err := buildHostedRuntimeEgressLaunchPlan(name, sessionID, deps.Egress.Policy(agentAllowedHosts), allowedHosts, runtimePlan, deps)
 	if runtimePlan.HostnameEgressDelivery == RuntimeHostnameEgressDeliveryPublicProxy {
-		phaseStarted = time.Now()
-		proxyEnv, err := buildHostedRuntimePublicEgressProxy(name, sessionID, cfg.AllowedHosts, deps.Egress.DefaultAction, deps)
 		recordHostedAgentRuntimeStartPhase(ctx, name, "public_egress_proxy", phaseStarted, err)
-		if err != nil {
-			return nil, err
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(egressPlan.Env) > 0 {
+		if startEnv == nil {
+			startEnv = make(map[string]string, len(egressPlan.Env))
 		}
-		if len(proxyEnv) > 0 {
-			if startEnv == nil {
-				startEnv = make(map[string]string, len(proxyEnv))
-			}
-			maps.Copy(startEnv, proxyEnv)
-		}
+		maps.Copy(startEnv, egressPlan.Env)
 	}
 
 	phaseStarted = time.Now()
 	hostedPlugin, err := runtimeProvider.StartPlugin(ctx, pluginruntime.StartPluginRequest{
-		SessionID:     sessionID,
-		PluginName:    name,
-		Command:       launch.launch.command,
-		Args:          launch.launch.args,
-		Env:           startEnv,
-		BundleDir:     launch.launch.bundleDir,
-		AllowedHosts:  allowedHosts,
+		SessionID:  sessionID,
+		PluginName: name,
+		Command:    launch.launch.command,
+		Args:       launch.launch.args,
+		Env:        startEnv,
+		BundleDir:  launch.launch.bundleDir,
+		Egress: pluginruntime.RuntimeEgressPolicy{
+			AllowedHosts:  egressPlan.RuntimeAllowedHosts,
+			DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
+		},
+		AllowedHosts:  egressPlan.RuntimeAllowedHosts,
 		DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
 		HostBinary:    cfg.HostBinary,
 	})
@@ -1216,17 +1229,12 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 }
 
 func effectiveConfiguredHostedRuntime(ctx context.Context, configPath string, entry *config.ProviderEntry, deps Deps) (config.EffectiveHostedRuntime, pluginruntime.Provider, bool, error) {
-	if entry == nil || entry.Runtime == nil {
+	if entry == nil || !entry.UsesHostedExecution() {
 		return config.EffectiveHostedRuntime{}, nil, false, nil
 	}
+	explicitRuntimeConfig := providerEntryHostedRuntimeConfig(entry)
 	if deps.PluginRuntime != nil {
-		return config.EffectiveHostedRuntime{
-			Enabled:      true,
-			ProviderName: strings.TrimSpace(entry.Runtime.Provider),
-			Template:     strings.TrimSpace(entry.Runtime.Template),
-			Image:        strings.TrimSpace(entry.Runtime.Image),
-			Metadata:     maps.Clone(entry.Runtime.Metadata),
-		}, deps.PluginRuntime, false, nil
+		return explicitRuntimeConfig, deps.PluginRuntime, false, nil
 	}
 	if deps.PluginRuntimeRegistry != nil {
 		runtimeConfig, runtimeProvider, err := deps.PluginRuntimeRegistry.Resolve(ctx, configPath, entry)
@@ -1240,24 +1248,12 @@ func effectiveConfiguredHostedRuntime(ctx context.Context, configPath string, en
 			return runtimeConfig, newLocalPluginRuntime(runtimeConfig.ProviderName, deps), true, nil
 		}
 	}
-	return config.EffectiveHostedRuntime{
-		Enabled:      true,
-		ProviderName: strings.TrimSpace(entry.Runtime.Provider),
-		Template:     strings.TrimSpace(entry.Runtime.Template),
-		Image:        strings.TrimSpace(entry.Runtime.Image),
-		Metadata:     maps.Clone(entry.Runtime.Metadata),
-	}, newLocalPluginRuntime(strings.TrimSpace(entry.Runtime.Provider), deps), true, nil
+	return explicitRuntimeConfig, newLocalPluginRuntime(explicitRuntimeConfig.ProviderName, deps), true, nil
 }
 
 func effectivePluginRuntime(ctx context.Context, name string, entry *config.ProviderEntry, deps Deps) (config.EffectiveHostedRuntime, pluginruntime.Provider, bool, error) {
 	if deps.PluginRuntime != nil {
-		runtimeConfig := config.EffectiveHostedRuntime{}
-		if entry != nil && entry.Runtime != nil {
-			runtimeConfig.Template = strings.TrimSpace(entry.Runtime.Template)
-			runtimeConfig.Image = strings.TrimSpace(entry.Runtime.Image)
-			runtimeConfig.Metadata = maps.Clone(entry.Runtime.Metadata)
-		}
-		return runtimeConfig, deps.PluginRuntime, false, nil
+		return providerEntryHostedRuntimeConfig(entry), deps.PluginRuntime, false, nil
 	}
 	if deps.PluginRuntimeRegistry != nil {
 		runtimeConfig, runtimeProvider, err := deps.PluginRuntimeRegistry.Resolve(ctx, "plugins."+name, entry)
@@ -1272,6 +1268,23 @@ func effectivePluginRuntime(ctx context.Context, name string, entry *config.Prov
 		}
 	}
 	return config.EffectiveHostedRuntime{}, newLocalPluginRuntime("", deps), true, nil
+}
+
+func providerEntryHostedRuntimeConfig(entry *config.ProviderEntry) config.EffectiveHostedRuntime {
+	if entry == nil {
+		return config.EffectiveHostedRuntime{}
+	}
+	runtimeCfg := entry.HostedRuntimeConfig()
+	if runtimeCfg == nil {
+		return config.EffectiveHostedRuntime{Enabled: entry.UsesHostedExecution()}
+	}
+	return config.EffectiveHostedRuntime{
+		Enabled:      entry.UsesHostedExecution(),
+		ProviderName: strings.TrimSpace(runtimeCfg.Provider),
+		Template:     strings.TrimSpace(runtimeCfg.Template),
+		Image:        strings.TrimSpace(runtimeCfg.Image),
+		Metadata:     maps.Clone(runtimeCfg.Metadata),
+	}
 }
 
 func newLocalPluginRuntime(runtimeProviderName string, deps Deps) pluginruntime.Provider {
@@ -1290,6 +1303,13 @@ const (
 	pluginRuntimeHostServiceRelayTokenTTL = 30 * 24 * time.Hour
 	pluginRuntimeEgressProxyTokenTTL      = 30 * 24 * time.Hour
 )
+
+type RuntimeEgressLaunchPlan struct {
+	Policy              egress.Policy
+	Delivery            RuntimeHostnameEgressDelivery
+	Env                 map[string]string
+	RuntimeAllowedHosts []string
+}
 
 func hostedRuntimeLabel(runtimeConfig config.EffectiveHostedRuntime) string {
 	if name := strings.TrimSpace(runtimeConfig.ProviderName); name != "" {
@@ -1315,6 +1335,26 @@ func buildHostedRuntimeStartSessionRequest(kind, name string, runtimeConfig conf
 		Image:      runtimeConfig.Image,
 		Metadata:   metadata,
 	}
+}
+
+func buildHostedRuntimeEgressLaunchPlan(providerName, sessionID string, policy egress.Policy, runtimeAllowedHosts []string, runtimePlan HostedRuntimePlan, deps Deps) (RuntimeEgressLaunchPlan, error) {
+	plan := RuntimeEgressLaunchPlan{
+		Policy: egress.Policy{
+			AllowedHosts:  slices.Clone(policy.AllowedHosts),
+			DefaultAction: policy.DefaultAction,
+		},
+		Delivery:            runtimePlan.HostnameEgressDelivery,
+		RuntimeAllowedHosts: slices.Clone(runtimeAllowedHosts),
+	}
+	if runtimePlan.HostnameEgressDelivery != RuntimeHostnameEgressDeliveryPublicProxy {
+		return plan, nil
+	}
+	env, err := buildHostedRuntimePublicEgressProxy(providerName, sessionID, policy.AllowedHosts, policy.DefaultAction, deps)
+	if err != nil {
+		return RuntimeEgressLaunchPlan{}, err
+	}
+	plan.Env = env
+	return plan, nil
 }
 
 const pluginRuntimeStopTimeout = 3 * time.Second

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -183,7 +183,7 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 		allowedHosts = appendAllowedHost(allowedHosts, relayHost)
 	}
 	if deps.Egress.DefaultAction == egress.PolicyDeny {
-		proxyEnv, err := buildHostedRuntimePublicEgressProxy(name, sessionID, entry.AllowedHosts, deps.Egress.DefaultAction, deps)
+		proxyEnv, err := buildHostedRuntimePublicEgressProxy(name, sessionID, entry.EffectiveAllowedHosts(), deps.Egress.DefaultAction, deps)
 		if err != nil {
 			return providerdev.RuntimeEnv{}, err
 		}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -107,7 +107,7 @@ func (e *RuntimeProviderEntry) UnmarshalYAML(value *yaml.Node) error {
 	if err := decodeYAMLNodeKnownFields(value, &raw); err != nil {
 		return err
 	}
-	entry, err := raw.providerEntryYAML.decode()
+	entry, err := raw.decode()
 	if err != nil {
 		return err
 	}
@@ -370,10 +370,12 @@ func (g GitHubReleaseSourceDef) Location() string {
 
 // ProviderEntry is the universal configuration for any provider.
 type ProviderEntry struct {
-	Source          ProviderSource                 `yaml:"source"`
-	Config          yaml.Node                      `yaml:"config,omitempty"`
-	Default         bool                           `yaml:"default,omitempty"`
-	Env             map[string]string              `yaml:"env,omitempty"`
+	Source  ProviderSource        `yaml:"source"`
+	Config  yaml.Node             `yaml:"config,omitempty"`
+	Default bool                  `yaml:"default,omitempty"`
+	Env     map[string]string     `yaml:"env,omitempty"`
+	Egress  *ProviderEgressConfig `yaml:"egress,omitempty"`
+	// Deprecated: use egress.allowedHosts.
 	AllowedHosts    []string                       `yaml:"allowedHosts,omitempty"`
 	DisplayName     string                         `yaml:"displayName,omitempty"`
 	Description     string                         `yaml:"description,omitempty"`
@@ -393,9 +395,11 @@ type ProviderEntry struct {
 	IndexedDB         *HostIndexedDBBindingConfig   `yaml:"indexeddb,omitempty"`
 	Cache             []string                      `yaml:"cache,omitempty"`
 	S3                []string                      `yaml:"s3,omitempty"`
-	Runtime           *HostedRuntimeConfig          `yaml:"runtime,omitempty"`
-	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
-	MCP               bool                          `yaml:"mcp,omitempty"`
+	Execution         *ExecutionConfig              `yaml:"execution,omitempty"`
+	// Deprecated: use execution.mode=hosted and execution.runtime.
+	Runtime  *HostedRuntimeConfig      `yaml:"runtime,omitempty"`
+	Surfaces *ProviderSurfaceOverrides `yaml:"surfaces,omitempty"`
+	MCP      bool                      `yaml:"mcp,omitempty"`
 
 	// Runtime-resolved fields (populated during init/bootstrap, not from YAML)
 	Command              string                                `yaml:"-"`
@@ -497,6 +501,22 @@ type PluginIndexedDBConfig = HostIndexedDBBindingConfig
 type pluginUIBindingConfig struct {
 	Path   string `yaml:"path,omitempty"`
 	Bundle string `yaml:"bundle,omitempty"`
+}
+
+type ProviderEgressConfig struct {
+	AllowedHosts []string `yaml:"allowedHosts,omitempty"`
+}
+
+type ExecutionMode string
+
+const (
+	ExecutionModeLocal  ExecutionMode = "local"
+	ExecutionModeHosted ExecutionMode = "hosted"
+)
+
+type ExecutionConfig struct {
+	Mode    ExecutionMode        `yaml:"mode,omitempty"`
+	Runtime *HostedRuntimeConfig `yaml:"runtime,omitempty"`
 }
 
 type HostedRuntimeConfig struct {
@@ -767,6 +787,7 @@ func (e UIEntry) MarshalYAML() (any, error) {
 func (raw providerEntryYAML) decode() (ProviderEntry, error) {
 	entry := raw.toProviderEntry()
 	entry.RouteAuth = cloneRouteAuthDef(raw.Auth)
+	normalizeProviderEntryAliases(&entry)
 	return entry, nil
 }
 
@@ -859,7 +880,136 @@ func (f providerEntryFields) toProviderEntry() ProviderEntry {
 }
 
 func providerEntryFieldsFromEntry(e ProviderEntry) providerEntryFields {
+	e.Egress = cloneProviderEgressConfig(e.Egress)
+	e.Execution = cloneExecutionConfig(e.Execution)
+	e.Runtime = cloneHostedRuntimeConfig(e.Runtime)
+	normalizeProviderEntryAliases(&e)
+	if e.Egress != nil {
+		e.AllowedHosts = nil
+	}
+	if e.Execution != nil {
+		e.Runtime = nil
+	}
 	return providerEntryFields(e)
+}
+
+func normalizeProviderEntryAliases(entry *ProviderEntry) {
+	if entry == nil {
+		return
+	}
+	entry.AllowedHosts = trimStringSlice(entry.AllowedHosts)
+	if entry.Egress != nil {
+		entry.Egress.AllowedHosts = trimStringSlice(entry.Egress.AllowedHosts)
+		entry.AllowedHosts = slices.Clone(entry.Egress.AllowedHosts)
+	} else if len(entry.AllowedHosts) > 0 {
+		entry.Egress = &ProviderEgressConfig{AllowedHosts: slices.Clone(entry.AllowedHosts)}
+	}
+	if entry.Execution != nil {
+		entry.Execution.Mode = ExecutionMode(strings.ToLower(strings.TrimSpace(string(entry.Execution.Mode))))
+		entry.Runtime = entry.Execution.Runtime
+	}
+}
+
+func trimStringSlice(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	out := values[:0]
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (e *ProviderEntry) EffectiveAllowedHosts() []string {
+	if e == nil {
+		return nil
+	}
+	if e.Egress != nil {
+		return slices.Clone(e.Egress.AllowedHosts)
+	}
+	return slices.Clone(e.AllowedHosts)
+}
+
+func (e *ProviderEntry) UsesHostedExecution() bool {
+	if e == nil {
+		return false
+	}
+	if e.Execution != nil {
+		mode := ExecutionMode(strings.ToLower(strings.TrimSpace(string(e.Execution.Mode))))
+		if mode == "" {
+			return e.Execution.Runtime != nil
+		}
+		return mode == ExecutionModeHosted
+	}
+	return e.Runtime != nil
+}
+
+func (e *ProviderEntry) HostedRuntimeConfig() *HostedRuntimeConfig {
+	if e == nil {
+		return nil
+	}
+	if e.Execution != nil {
+		return e.Execution.Runtime
+	}
+	return e.Runtime
+}
+
+func cloneProviderEgressConfig(src *ProviderEgressConfig) *ProviderEgressConfig {
+	if src == nil {
+		return nil
+	}
+	return &ProviderEgressConfig{AllowedHosts: slices.Clone(src.AllowedHosts)}
+}
+
+func cloneExecutionConfig(src *ExecutionConfig) *ExecutionConfig {
+	if src == nil {
+		return nil
+	}
+	return &ExecutionConfig{
+		Mode:    src.Mode,
+		Runtime: cloneHostedRuntimeConfig(src.Runtime),
+	}
+}
+
+func cloneHostedRuntimeConfig(src *HostedRuntimeConfig) *HostedRuntimeConfig {
+	if src == nil {
+		return nil
+	}
+	return &HostedRuntimeConfig{
+		Provider:            src.Provider,
+		Template:            src.Template,
+		Image:               src.Image,
+		Metadata:            maps.Clone(src.Metadata),
+		Pool:                cloneHostedRuntimePoolConfig(src.Pool),
+		MinReadyInstances:   src.MinReadyInstances,
+		MaxReadyInstances:   src.MaxReadyInstances,
+		StartupTimeout:      src.StartupTimeout,
+		HealthCheckInterval: src.HealthCheckInterval,
+		RestartPolicy:       src.RestartPolicy,
+		DrainTimeout:        src.DrainTimeout,
+	}
+}
+
+func cloneHostedRuntimePoolConfig(src *HostedRuntimePoolConfig) *HostedRuntimePoolConfig {
+	if src == nil {
+		return nil
+	}
+	return &HostedRuntimePoolConfig{
+		MinReadyInstances:   src.MinReadyInstances,
+		MaxReadyInstances:   src.MaxReadyInstances,
+		StartupTimeout:      src.StartupTimeout,
+		HealthCheckInterval: src.HealthCheckInterval,
+		RestartPolicy:       src.RestartPolicy,
+		DrainTimeout:        src.DrainTimeout,
+	}
 }
 
 func cloneHTTPSecuritySchemes(src map[string]*HTTPSecurityScheme) map[string]*HTTPSecurityScheme {
@@ -1323,6 +1473,8 @@ type ServerConfig struct {
 }
 
 type ServerRuntimeConfig struct {
+	DefaultHostedProvider string `yaml:"defaultHostedProvider,omitempty"`
+	// Deprecated: use defaultHostedProvider.
 	Provider string `yaml:"provider,omitempty"`
 }
 
@@ -1669,6 +1821,8 @@ func LoadAllowMissingEnvPaths(paths []string) (*Config, error) {
 
 func NormalizeCompatibility(cfg *Config) error {
 	normalizeProviderSourceShapes(cfg)
+	normalizeProviderEntryCompatibility(cfg)
+	normalizeServerRuntimeCompatibility(cfg)
 	if err := normalizeAuthorizationConfig(cfg); err != nil {
 		return err
 	}
@@ -1676,6 +1830,69 @@ func NormalizeCompatibility(cfg *Config) error {
 		return err
 	}
 	return applyPluginMountBindings(cfg)
+}
+
+func normalizeServerRuntimeCompatibility(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.Server.Runtime.Provider = strings.TrimSpace(cfg.Server.Runtime.Provider)
+	cfg.Server.Runtime.DefaultHostedProvider = strings.TrimSpace(cfg.Server.Runtime.DefaultHostedProvider)
+	if cfg.Server.Runtime.DefaultHostedProvider == "" {
+		cfg.Server.Runtime.DefaultHostedProvider = cfg.Server.Runtime.Provider
+	}
+}
+
+func normalizeProviderEntryCompatibility(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	for _, entry := range cfg.Plugins {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.Authentication {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.Authorization {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.ExternalCredentials {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.Secrets {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.Telemetry {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.Audit {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.IndexedDB {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.Cache {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.S3 {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.Workflow {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.Agent {
+		normalizeProviderEntryAliases(entry)
+	}
+	for _, entry := range cfg.Providers.UI {
+		if entry != nil {
+			normalizeProviderEntryAliases(&entry.ProviderEntry)
+		}
+	}
+	for _, entry := range cfg.Runtime.Providers {
+		if entry != nil {
+			normalizeProviderEntryAliases(&entry.ProviderEntry)
+		}
+	}
 }
 
 func OverlayRemotePluginConfig(path string, cfg *Config) error {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3525,6 +3525,51 @@ server:
 		}
 	})
 
+	t.Run("accepts required lifecycle fields under agent execution runtime", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      indexeddb: agent_state
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          minReadyInstances: 1
+          maxReadyInstances: 2
+          startupTimeout: 5m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 2m
+  indexeddb:
+    agent_state:
+      source:
+        path: ./providers/datastore/sqlite
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		runtimeCfg := cfg.Providers.Agent["simple"].Execution.Runtime
+		if runtimeCfg.MinReadyInstances != 1 || runtimeCfg.MaxReadyInstances != 2 {
+			t.Fatalf("execution runtime ready instances = %d/%d, want 1/2", runtimeCfg.MinReadyInstances, runtimeCfg.MaxReadyInstances)
+		}
+		if runtimeCfg.RestartPolicy != HostedRuntimeRestartPolicyAlways {
+			t.Fatalf("execution restartPolicy = %q, want %q", runtimeCfg.RestartPolicy, HostedRuntimeRestartPolicyAlways)
+		}
+	})
+
 	cases := []struct {
 		name string
 		yaml string
@@ -3554,6 +3599,53 @@ server:
   encryptionKey: server-key
 `,
 			want: "providers.agent.simple.runtime.maxReadyInstances is required",
+		},
+		{
+			name: "rejects missing execution runtime on hosted agent",
+			yaml: `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      execution:
+        mode: hosted
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: "providers.agent.simple.execution.runtime is required",
+		},
+		{
+			name: "rejects missing lifecycle fields under execution runtime",
+			yaml: `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          minReadyInstances: 1
+          startupTimeout: 5m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: "providers.agent.simple.execution.runtime.maxReadyInstances is required",
 		},
 		{
 			name: "rejects max below min",
@@ -3672,6 +3764,53 @@ server:
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestLoadPathsPreferredProviderEntryAliasesOverrideLegacy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.yaml")
+	overridePath := filepath.Join(dir, "override.yaml")
+	if err := os.WriteFile(basePath, []byte(`
+server:
+  encryptionKey: server-key
+plugins:
+  service:
+    source:
+      path: ./plugins/service/manifest.yaml
+    runtime:
+      provider: missing
+    allowedHosts:
+      - api.github.com
+`), 0o644); err != nil {
+		t.Fatalf("writing base config: %v", err)
+	}
+	if err := os.WriteFile(overridePath, []byte(`
+plugins:
+  service:
+    execution:
+      mode: local
+    egress:
+      allowedHosts: []
+`), 0o644); err != nil {
+		t.Fatalf("writing override config: %v", err)
+	}
+
+	cfg, err := LoadPaths([]string{basePath, overridePath})
+	if err != nil {
+		t.Fatalf("LoadPaths: %v", err)
+	}
+	entry := cfg.Plugins["service"]
+	if entry.UsesHostedExecution() {
+		t.Fatal("UsesHostedExecution = true, want preferred execution.mode: local to override legacy runtime")
+	}
+	if entry.Runtime != nil {
+		t.Fatalf("Runtime = %#v, want nil after preferred execution override", entry.Runtime)
+	}
+	if got := entry.EffectiveAllowedHosts(); len(got) != 0 {
+		t.Fatalf("EffectiveAllowedHosts = %#v, want empty after preferred egress override", got)
 	}
 }
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -416,6 +416,10 @@ func validateRuntimeConfig(cfg *Config) error {
 	}
 	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	cfg.Server.Runtime.Provider = strings.TrimSpace(cfg.Server.Runtime.Provider)
+	cfg.Server.Runtime.DefaultHostedProvider = strings.TrimSpace(cfg.Server.Runtime.DefaultHostedProvider)
+	if cfg.Server.Runtime.Provider != "" && cfg.Server.Runtime.DefaultHostedProvider != "" && cfg.Server.Runtime.Provider != cfg.Server.Runtime.DefaultHostedProvider {
+		return fmt.Errorf("config validation: server.runtime.provider and server.runtime.defaultHostedProvider must match when both are set")
+	}
 	for name, entry := range cfg.Runtime.Providers {
 		if entry == nil {
 			return fmt.Errorf("config validation: runtime.providers.%s is required", name)
@@ -477,7 +481,11 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax
 			entry.IndexedDB.ObjectStores[i] = strings.TrimSpace(store)
 		}
 	}
-	if entry.Runtime != nil {
+	if entry.Execution != nil {
+		if err := normalizeExecutionConfig("plugins."+name, entry.Execution, false); err != nil {
+			return err
+		}
+	} else if entry.Runtime != nil {
 		if err := normalizeHostedRuntimeConfig("plugins."+name, entry.Runtime); err != nil {
 			return err
 		}
@@ -662,7 +670,11 @@ func validateAgentConfig(cfg *Config) error {
 				entry.IndexedDB.ObjectStores[i] = strings.TrimSpace(store)
 			}
 		}
-		if entry.Runtime != nil {
+		if entry.Execution != nil {
+			if err := normalizeExecutionConfig("providers.agent."+name, entry.Execution, true); err != nil {
+				return err
+			}
+		} else if entry.Runtime != nil {
 			if err := normalizeHostedRuntimeConfig("providers.agent."+name, entry.Runtime); err != nil {
 				return err
 			}
@@ -713,7 +725,7 @@ func validateAgentProviderFields(cfg *Config, name string, entry *ProviderEntry)
 	if _, err := cfg.EffectiveHostedRuntime(subject, entry); err != nil {
 		return err
 	}
-	if entry.Runtime != nil {
+	if entry.UsesHostedExecution() {
 		if err := validateHostedAgentRuntimeLifecyclePolicy(subject, entry); err != nil {
 			return err
 		}
@@ -773,12 +785,15 @@ func normalizeHostedRuntimeConfig(subject string, runtimeCfg *HostedRuntimeConfi
 }
 
 func validateHostedAgentRuntimeLifecyclePolicy(subject string, entry *ProviderEntry) error {
-	if entry == nil || entry.Runtime == nil {
+	if entry == nil || !entry.UsesHostedExecution() {
 		return nil
 	}
-	runtimeCfg := entry.Runtime
+	runtimeCfg, runtimePath := hostedRuntimeConfigAndPath(subject, entry)
+	if runtimeCfg == nil {
+		return fmt.Errorf("config validation: %s is required for hosted agent providers", runtimePath)
+	}
 	lifecycle := runtimeCfg.lifecyclePolicyConfig()
-	lifecycleSubject := subject + ".runtime"
+	lifecycleSubject := runtimePath
 	if runtimeCfg.Pool != nil {
 		lifecycleSubject += ".pool"
 	}
@@ -814,6 +829,16 @@ func validateHostedAgentRuntimeLifecyclePolicy(subject string, entry *ProviderEn
 	return nil
 }
 
+func hostedRuntimeConfigAndPath(subject string, entry *ProviderEntry) (*HostedRuntimeConfig, string) {
+	if entry != nil && entry.Execution != nil {
+		return entry.Execution.Runtime, subject + ".execution.runtime"
+	}
+	if entry != nil {
+		return entry.Runtime, subject + ".runtime"
+	}
+	return nil, subject + ".runtime"
+}
+
 func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEntry) error {
 	if entry == nil {
 		return nil
@@ -836,6 +861,9 @@ func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEnt
 	}
 	if len(entry.Invokes) > 0 {
 		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
+	}
+	if entry.Execution != nil {
+		return fmt.Errorf("config validation: %s.execution is only supported on plugins.* and providers.agent.*", subject)
 	}
 	if entry.Runtime != nil {
 		return fmt.Errorf("config validation: %s.runtime is only supported on plugins.*", subject)
@@ -891,6 +919,9 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	if len(entry.Invokes) > 0 {
 		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
 	}
+	if entry.Execution != nil {
+		return fmt.Errorf("config validation: %s.execution is only supported on plugins.* and providers.agent.*", subject)
+	}
 	if entry.Runtime != nil {
 		return fmt.Errorf("config validation: %s.runtime is only supported on plugins.*", subject)
 	}
@@ -899,6 +930,31 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	}
 	if entry.AuthorizationPolicy != "" && !strings.HasPrefix(subject, "ui.") {
 		return fmt.Errorf("config validation: %s.authorizationPolicy is only supported on plugins.* and ui.*", subject)
+	}
+	return nil
+}
+
+func normalizeExecutionConfig(subject string, execution *ExecutionConfig, allowLifecycle bool) error {
+	if execution == nil {
+		return nil
+	}
+	execution.Mode = ExecutionMode(strings.ToLower(strings.TrimSpace(string(execution.Mode))))
+	switch execution.Mode {
+	case "", ExecutionModeLocal, ExecutionModeHosted:
+	default:
+		return fmt.Errorf("config validation: %s.execution.mode must be %q or %q, got %q", subject, ExecutionModeLocal, ExecutionModeHosted, execution.Mode)
+	}
+	if execution.Mode == ExecutionModeLocal && execution.Runtime != nil {
+		return fmt.Errorf("config validation: %s.execution.runtime is only valid when execution.mode is %q", subject, ExecutionModeHosted)
+	}
+	if execution.Runtime == nil {
+		return nil
+	}
+	if err := normalizeHostedRuntimeConfig(subject+".execution", execution.Runtime); err != nil {
+		return err
+	}
+	if !allowLifecycle && execution.Runtime.LifecyclePolicyFieldsSet() {
+		return fmt.Errorf("config validation: %s.execution.runtime lifecycle fields are only supported on providers.agent.*.execution.runtime", subject)
 	}
 	return nil
 }
@@ -1225,13 +1281,15 @@ func normalizeWorkflowTargets(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
-	for key, schedule := range cfg.Workflows.Schedules {
+	for key := range cfg.Workflows.Schedules {
+		schedule := cfg.Workflows.Schedules[key]
 		if err := normalizeWorkflowScheduleTarget(key, &schedule); err != nil {
 			return err
 		}
 		cfg.Workflows.Schedules[key] = schedule
 	}
-	for key, trigger := range cfg.Workflows.EventTriggers {
+	for key := range cfg.Workflows.EventTriggers {
+		trigger := cfg.Workflows.EventTriggers[key]
 		if err := normalizeWorkflowEventTriggerTarget(key, &trigger); err != nil {
 			return err
 		}

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -109,7 +109,7 @@ func (c *Config) SelectedRuntimeProvider() (string, *RuntimeProviderEntry, error
 	if c == nil {
 		return "", nil, nil
 	}
-	return ResolveSelectedRuntimeProvider(c.Server.Runtime.Provider, c.Runtime.Providers)
+	return ResolveSelectedRuntimeProvider(c.Server.Runtime.SelectedDefaultHostedProvider(), c.Runtime.Providers)
 }
 
 type EffectiveHostIndexedDBBinding struct {
@@ -131,6 +131,11 @@ type EffectiveHostedRuntime struct {
 	Template     string
 	Image        string
 	Metadata     map[string]string
+}
+
+type EffectiveExecution struct {
+	Mode   ExecutionMode
+	Hosted EffectiveHostedRuntime
 }
 
 func (c *Config) EffectivePluginIndexedDB(pluginName string, entry *ProviderEntry) (EffectivePluginIndexedDB, error) {
@@ -180,11 +185,22 @@ func (c *Config) EffectiveAgentIndexedDB(name string, entry *ProviderEntry) (Eff
 }
 
 func (c *Config) EffectiveHostedRuntime(configPath string, entry *ProviderEntry) (EffectiveHostedRuntime, error) {
-	selectedName, _, err := c.SelectedRuntimeProvider()
+	execution, err := c.EffectiveExecution(configPath, entry)
 	if err != nil {
 		return EffectiveHostedRuntime{}, err
 	}
-	return ResolveEffectiveHostedRuntime(configPath, entry, selectedName, c.Runtime.Providers)
+	return execution.Hosted, nil
+}
+
+func (c *Config) EffectiveExecution(configPath string, entry *ProviderEntry) (EffectiveExecution, error) {
+	if c == nil {
+		return EffectiveExecution{Mode: ExecutionModeLocal}, nil
+	}
+	selectedName, _, err := c.SelectedRuntimeProvider()
+	if err != nil {
+		return EffectiveExecution{}, err
+	}
+	return ResolveEffectiveExecution(configPath, entry, selectedName, c.Runtime.Providers)
 }
 
 func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, selectedName string, entries map[string]*ProviderEntry) (EffectivePluginIndexedDB, error) {
@@ -289,11 +305,47 @@ func ResolveEffectiveAgentIndexedDB(name string, entry *ProviderEntry, entries m
 }
 
 func ResolveEffectiveHostedRuntime(configPath string, entry *ProviderEntry, selectedName string, entries map[string]*RuntimeProviderEntry) (EffectiveHostedRuntime, error) {
-	if entry == nil || entry.Runtime == nil {
-		return EffectiveHostedRuntime{}, nil
+	execution, err := ResolveEffectiveExecution(configPath, entry, selectedName, entries)
+	if err != nil {
+		return EffectiveHostedRuntime{}, err
+	}
+	return execution.Hosted, nil
+}
+
+func ResolveEffectiveExecution(configPath string, entry *ProviderEntry, selectedName string, entries map[string]*RuntimeProviderEntry) (EffectiveExecution, error) {
+	if entry == nil {
+		return EffectiveExecution{Mode: ExecutionModeLocal}, nil
+	}
+	runtimeCfg := entry.Runtime
+	mode := ExecutionModeLocal
+	providerPath := "runtime.provider"
+	if runtimeCfg != nil {
+		mode = ExecutionModeHosted
+	}
+	if entry.Execution != nil {
+		providerPath = "execution.runtime.provider"
+		mode = entry.Execution.Mode
+		if mode == "" {
+			if entry.Execution.Runtime != nil {
+				mode = ExecutionModeHosted
+			} else {
+				mode = ExecutionModeLocal
+			}
+		}
+		runtimeCfg = entry.Execution.Runtime
+	}
+	switch mode {
+	case "", ExecutionModeLocal:
+		return EffectiveExecution{Mode: ExecutionModeLocal}, nil
+	case ExecutionModeHosted:
+	default:
+		return EffectiveExecution{}, fmt.Errorf("config validation: %s.execution.mode must be %q or %q, got %q", configPath, ExecutionModeLocal, ExecutionModeHosted, mode)
+	}
+	if runtimeCfg == nil {
+		runtimeCfg = &HostedRuntimeConfig{}
 	}
 
-	providerName := strings.TrimSpace(entry.Runtime.Provider)
+	providerName := strings.TrimSpace(runtimeCfg.Provider)
 	if providerName == "" {
 		providerName = strings.TrimSpace(selectedName)
 	}
@@ -303,7 +355,7 @@ func ResolveEffectiveHostedRuntime(configPath string, entry *ProviderEntry, sele
 		var ok bool
 		provider, ok = entries[providerName]
 		if !ok || provider == nil {
-			return EffectiveHostedRuntime{}, fmt.Errorf("config validation: %s.runtime.provider references unknown runtime %q", configPath, providerName)
+			return EffectiveExecution{}, fmt.Errorf("config validation: %s.%s references unknown runtime %q", configPath, providerPath, providerName)
 		}
 	}
 
@@ -311,11 +363,18 @@ func ResolveEffectiveHostedRuntime(configPath string, entry *ProviderEntry, sele
 		Enabled:      true,
 		ProviderName: providerName,
 		Provider:     provider,
-		Template:     strings.TrimSpace(entry.Runtime.Template),
-		Image:        strings.TrimSpace(entry.Runtime.Image),
-		Metadata:     maps.Clone(entry.Runtime.Metadata),
+		Template:     strings.TrimSpace(runtimeCfg.Template),
+		Image:        strings.TrimSpace(runtimeCfg.Image),
+		Metadata:     maps.Clone(runtimeCfg.Metadata),
 	}
-	return runtime, nil
+	return EffectiveExecution{Mode: ExecutionModeHosted, Hosted: runtime}, nil
+}
+
+func (s ServerRuntimeConfig) SelectedDefaultHostedProvider() string {
+	if provider := strings.TrimSpace(s.DefaultHostedProvider); provider != "" {
+		return provider
+	}
+	return strings.TrimSpace(s.Provider)
 }
 func ResolveSelectedHostProvider(kind HostProviderKind, explicit string, entries map[string]*ProviderEntry) (string, *ProviderEntry, error) {
 	if len(entries) == 0 {

--- a/gestaltd/internal/config/runtime_config.go
+++ b/gestaltd/internal/config/runtime_config.go
@@ -8,15 +8,16 @@ import (
 )
 
 type componentRuntimeConfig struct {
-	Name         string            `yaml:"name"`
-	Source       *ProviderSource   `yaml:"source,omitempty"`
-	Command      string            `yaml:"command"`
-	Args         []string          `yaml:"args,omitempty"`
-	Env          map[string]string `yaml:"env,omitempty"`
-	AllowedHosts []string          `yaml:"allowedHosts,omitempty"`
-	HostBinary   string            `yaml:"hostBinary,omitempty"`
-	ManifestPath string            `yaml:"manifestPath,omitempty"`
-	Config       yaml.Node         `yaml:"config,omitempty"`
+	Name         string                `yaml:"name"`
+	Source       *ProviderSource       `yaml:"source,omitempty"`
+	Command      string                `yaml:"command"`
+	Args         []string              `yaml:"args,omitempty"`
+	Env          map[string]string     `yaml:"env,omitempty"`
+	Egress       *ProviderEgressConfig `yaml:"egress,omitempty"`
+	AllowedHosts []string              `yaml:"allowedHosts,omitempty"`
+	HostBinary   string                `yaml:"hostBinary,omitempty"`
+	ManifestPath string                `yaml:"manifestPath,omitempty"`
+	Config       yaml.Node             `yaml:"config,omitempty"`
 }
 
 func BuildComponentRuntimeConfigNode(name, kind string, entry *ProviderEntry, providerConfig yaml.Node) (yaml.Node, error) {
@@ -33,7 +34,8 @@ func BuildComponentRuntimeConfigNode(name, kind string, entry *ProviderEntry, pr
 		Command:      entry.Command,
 		Args:         append([]string(nil), entry.Args...),
 		Env:          entry.Env,
-		AllowedHosts: entry.AllowedHosts,
+		Egress:       cloneProviderEgressConfig(entry.Egress),
+		AllowedHosts: entry.EffectiveAllowedHosts(),
 		HostBinary:   entry.HostBinary,
 		ManifestPath: entry.ResolvedManifestPath,
 		Config:       providerConfig,

--- a/gestaltd/internal/egress/host_check.go
+++ b/gestaltd/internal/egress/host_check.go
@@ -15,6 +15,19 @@ const (
 	PolicyDeny  PolicyAction = "deny"
 )
 
+type Policy struct {
+	AllowedHosts  []string
+	DefaultAction PolicyAction
+}
+
+func (p Policy) CheckHost(host string) error {
+	return CheckHost(p.AllowedHosts, host, p.DefaultAction)
+}
+
+func (p Policy) RequiresHostnameEnforcement() bool {
+	return len(p.AllowedHosts) > 0 || p.DefaultAction == PolicyDeny
+}
+
 // ErrEgressDenied is returned when an outbound request is blocked by policy.
 var ErrEgressDenied = errors.New("egress denied")
 

--- a/gestaltd/internal/pluginruntime/executable.go
+++ b/gestaltd/internal/pluginruntime/executable.go
@@ -205,6 +205,7 @@ func (p *executableProvider) BindHostService(ctx context.Context, req BindHostSe
 }
 
 func (p *executableProvider) StartPlugin(ctx context.Context, req StartPluginRequest) (*HostedPlugin, error) {
+	egressPolicy := req.EgressPolicy()
 	resp, err := p.runtime.StartPlugin(ctx, &proto.StartHostedPluginRequest{
 		SessionId:     req.SessionID,
 		PluginName:    req.PluginName,
@@ -212,8 +213,8 @@ func (p *executableProvider) StartPlugin(ctx context.Context, req StartPluginReq
 		Args:          append([]string(nil), req.Args...),
 		Env:           cloneStringMap(req.Env),
 		BundleDir:     req.BundleDir,
-		AllowedHosts:  append([]string(nil), req.AllowedHosts...),
-		DefaultAction: string(req.DefaultAction),
+		AllowedHosts:  append([]string(nil), egressPolicy.AllowedHosts...),
+		DefaultAction: string(egressPolicy.DefaultAction),
 		HostBinary:    req.HostBinary,
 	})
 	if err != nil {

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -292,18 +292,21 @@ func (p *LocalProvider) StartPlugin(ctx context.Context, req StartPluginRequest)
 		}})
 	}
 
+	egressPolicy := req.EgressPolicy()
 	process, err := providerhost.StartPluginProcess(ctx, providerhost.ProcessConfig{
-		Command:       req.Command,
-		Args:          req.Args,
-		Env:           env,
-		AllowedHosts:  req.AllowedHosts,
-		DefaultAction: egress.PolicyAction(req.DefaultAction),
-		HostBinary:    req.HostBinary,
-		SocketDir:     rootDir,
-		ProviderName:  req.PluginName,
-		Telemetry:     p.telemetry,
-		Stdout:        stdout,
-		Stderr:        stderr,
+		Command: req.Command,
+		Args:    req.Args,
+		Env:     env,
+		Egress: egress.Policy{
+			AllowedHosts:  append([]string(nil), egressPolicy.AllowedHosts...),
+			DefaultAction: egress.PolicyAction(egressPolicy.DefaultAction),
+		},
+		HostBinary:   req.HostBinary,
+		SocketDir:    rootDir,
+		ProviderName: req.PluginName,
+		Telemetry:    p.telemetry,
+		Stdout:       stdout,
+		Stderr:       stderr,
 	})
 	if err != nil {
 		p.mu.Lock()

--- a/gestaltd/internal/pluginruntime/runtime.go
+++ b/gestaltd/internal/pluginruntime/runtime.go
@@ -106,15 +106,36 @@ type HostServiceBinding struct {
 // provider listener endpoint and must return a host-reachable dial target in
 // HostedPlugin.DialTarget.
 type StartPluginRequest struct {
-	SessionID     string
-	PluginName    string
-	Command       string
-	Args          []string
-	Env           map[string]string
-	BundleDir     string
-	AllowedHosts  []string
+	SessionID  string
+	PluginName string
+	Command    string
+	Args       []string
+	Env        map[string]string
+	BundleDir  string
+	Egress     RuntimeEgressPolicy
+	// Deprecated: use Egress.AllowedHosts.
+	AllowedHosts []string
+	// Deprecated: use Egress.DefaultAction.
 	DefaultAction PolicyAction
 	HostBinary    string
+}
+
+type RuntimeEgressPolicy struct {
+	AllowedHosts  []string
+	DefaultAction PolicyAction
+}
+
+func (r StartPluginRequest) EgressPolicy() RuntimeEgressPolicy {
+	if len(r.Egress.AllowedHosts) > 0 || r.Egress.DefaultAction != "" {
+		return RuntimeEgressPolicy{
+			AllowedHosts:  append([]string(nil), r.Egress.AllowedHosts...),
+			DefaultAction: r.Egress.DefaultAction,
+		}
+	}
+	return RuntimeEgressPolicy{
+		AllowedHosts:  append([]string(nil), r.AllowedHosts...),
+		DefaultAction: r.DefaultAction,
+	}
 }
 
 type HostedPlugin struct {

--- a/gestaltd/internal/providerhost/process.go
+++ b/gestaltd/internal/providerhost/process.go
@@ -34,10 +34,13 @@ const (
 )
 
 type ProcessConfig struct {
-	Command       string
-	Args          []string
-	Env           map[string]string
-	AllowedHosts  []string
+	Command string
+	Args    []string
+	Env     map[string]string
+	Egress  egress.Policy
+	// Deprecated: use Egress.AllowedHosts.
+	AllowedHosts []string
+	// Deprecated: use Egress.DefaultAction.
 	DefaultAction egress.PolicyAction
 	HostBinary    string
 	Cleanup       func()
@@ -50,12 +53,15 @@ type ProcessConfig struct {
 }
 
 type ExecConfig struct {
-	Command          string
-	Args             []string
-	Env              map[string]string
-	StaticSpec       StaticProviderSpec
-	Config           map[string]any
-	AllowedHosts     []string
+	Command    string
+	Args       []string
+	Env        map[string]string
+	StaticSpec StaticProviderSpec
+	Config     map[string]any
+	Egress     egress.Policy
+	// Deprecated: use Egress.AllowedHosts.
+	AllowedHosts []string
+	// Deprecated: use Egress.DefaultAction.
 	DefaultAction    egress.PolicyAction
 	HostBinary       string
 	Cleanup          func()
@@ -124,6 +130,7 @@ func (c ExecConfig) processConfig() ProcessConfig {
 		Command:       c.Command,
 		Args:          c.Args,
 		Env:           c.Env,
+		Egress:        c.egressPolicy(),
 		AllowedHosts:  c.AllowedHosts,
 		DefaultAction: c.DefaultAction,
 		HostBinary:    c.HostBinary,
@@ -134,12 +141,33 @@ func (c ExecConfig) processConfig() ProcessConfig {
 	}
 }
 
+func (c ExecConfig) egressPolicy() egress.Policy {
+	return egressPolicyFromFields(c.Egress, c.AllowedHosts, c.DefaultAction)
+}
+
 func StartPluginProcess(ctx context.Context, cfg ProcessConfig) (*PluginProcess, error) {
 	proc, err := startProviderProcess(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 	return &PluginProcess{proc: proc}, nil
+}
+
+func (c ProcessConfig) egressPolicy() egress.Policy {
+	return egressPolicyFromFields(c.Egress, c.AllowedHosts, c.DefaultAction)
+}
+
+func egressPolicyFromFields(preferred egress.Policy, allowedHosts []string, defaultAction egress.PolicyAction) egress.Policy {
+	if len(preferred.AllowedHosts) > 0 || preferred.DefaultAction != "" {
+		return egress.Policy{
+			AllowedHosts:  append([]string(nil), preferred.AllowedHosts...),
+			DefaultAction: preferred.DefaultAction,
+		}
+	}
+	return egress.Policy{
+		AllowedHosts:  append([]string(nil), allowedHosts...),
+		DefaultAction: defaultAction,
+	}
 }
 
 func (p *PluginProcess) Lifecycle() proto.ProviderLifecycleClient {
@@ -218,7 +246,8 @@ func startProviderProcess(ctx context.Context, cfg ProcessConfig) (*providerProc
 		return nil, fmt.Errorf("plugin command is required")
 	}
 
-	sandboxActive := len(cfg.AllowedHosts) > 0 || cfg.DefaultAction == egress.PolicyDeny
+	egressPolicy := cfg.egressPolicy()
+	sandboxActive := egressPolicy.RequiresHostnameEnforcement()
 
 	dir := strings.TrimSpace(cfg.SocketDir)
 	if dir == "" {
@@ -291,14 +320,11 @@ func startProviderProcess(ctx context.Context, cfg ProcessConfig) (*providerProc
 		policy := &sandbox.Policy{
 			ReadOnlyPaths:  append(sandbox.DefaultReadOnlyPaths(), filepath.Dir(cfg.Command)),
 			ReadWritePaths: []string{dir, sandboxTmp},
-			AllowedHosts:   cfg.AllowedHosts,
+			AllowedHosts:   egressPolicy.AllowedHosts,
 			HostBinary:     cfg.HostBinary,
 		}
 
-		defaultAction := cfg.DefaultAction
-		checkHost := func(host string) error {
-			return egress.CheckHost(policy.AllowedHosts, host, defaultAction)
-		}
+		checkHost := egressPolicy.CheckHost
 		proxy := sandbox.NewProxyServer(checkHost)
 		port, err := proxy.Start()
 		if err != nil {


### PR DESCRIPTION
## Summary

This PR separates provider execution placement from egress policy while keeping the old config aliases working:

- `execution.mode` now says whether a plugin/agent runs locally or in a hosted runtime.
- `execution.runtime` carries hosted runtime selection/options when `mode: hosted`.
- `egress.allowedHosts` carries network allow-list policy independent of runtime placement.
- `server.runtime.defaultHostedProvider` is the preferred name for the default hosted runtime selector.
- Legacy YAML aliases still load: `runtime`, `allowedHosts`, and `server.runtime.provider`.

## Preferred YAML interface

```yaml
server:
  runtime:
    defaultHostedProvider: modal

runtime:
  providers:
    modal:
      driver: modal

plugins:
  github:
    source:
      path: ./providers/github
    execution:
      mode: hosted
      runtime:
        provider: modal
        image: ghcr.io/acme/github-provider:latest
    egress:
      allowedHosts:
        - api.github.com
```

Local execution stays explicit and does not need runtime config:

```yaml
plugins:
  github:
    source:
      path: ./providers/github
    execution:
      mode: local
    egress:
      allowedHosts:
        - api.github.com
```

## Legacy YAML still accepted

```yaml
server:
  runtime:
    provider: modal

plugins:
  github:
    source:
      path: ./providers/github
    runtime:
      provider: modal
      image: ghcr.io/acme/github-provider:latest
    allowedHosts:
      - api.github.com
```

## Go interface changes

```go
type ProviderEntry struct {
    Egress    *ProviderEgressConfig `yaml:"egress,omitempty"`
    Execution *ExecutionConfig      `yaml:"execution,omitempty"`

    // Deprecated aliases retained for compatibility.
    AllowedHosts []string             `yaml:"allowedHosts,omitempty"`
    Runtime      *HostedRuntimeConfig `yaml:"runtime,omitempty"`
}

type ProviderEgressConfig struct {
    AllowedHosts []string `yaml:"allowedHosts,omitempty"`
}

type ExecutionConfig struct {
    Mode    ExecutionMode        `yaml:"mode,omitempty"`
    Runtime *HostedRuntimeConfig `yaml:"runtime,omitempty"`
}
```

Runtime launch code now carries a first-class egress policy instead of loose host/action fields:

```go
type StartPluginRequest struct {
    Egress RuntimeEgressPolicy

    // Deprecated aliases retained for callers not yet migrated.
    AllowedHosts  []string
    DefaultAction PolicyAction
}

type ProcessConfig struct {
    Egress egress.Policy

    // Deprecated aliases retained for callers not yet migrated.
    AllowedHosts  []string
    DefaultAction egress.PolicyAction
}
```

## Why this improves things

- `runtime` no longer has to mean both "hosted execution" and "runtime configuration".
- Egress policy applies consistently whether the provider runs locally, in a hosted runtime, or through a runtime egress proxy.
- Hosted runtime relay hosts remain separate from the provider's own public egress allow-list.
- Existing configs and Go callers continue to work through compatibility normalization and deprecated fields.

## Validation

- `go test ./internal/config ./internal/egress ./internal/providerhost ./internal/pluginruntime ./internal/bootstrap` from `gestaltd/`
- `npm run typecheck` from `docs/`
- `npm run build` from `docs/`
- `git diff --check`