### PR TITLE
Add runtime session lifecycle contract

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -577,6 +577,236 @@ func TestAgentRuntimeConfigRestartsUnhealthyHostedAgent(t *testing.T) {
 	}
 }
 
+func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *testing.T) {
+	t.Parallel()
+
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	runtimeProvider.lifecycleForSession = func(index int) *pluginruntime.SessionLifecycle {
+		startedAt := time.Now().UTC()
+		expiresAt := startedAt.Add(time.Hour)
+		lifecycle := &pluginruntime.SessionLifecycle{
+			StartedAt: &startedAt,
+			ExpiresAt: &expiresAt,
+		}
+		if index == 1 {
+			recommendedDrainAt := startedAt.Add(75 * time.Millisecond)
+			lifecycle.RecommendedDrainAt = &recommendedDrainAt
+		}
+		return lifecycle
+	}
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.HealthCheckInterval = "25ms"
+	runtimeConfig.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command:   bin,
+					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
+					Runtime:   runtimeConfig,
+				},
+			},
+		},
+	}
+	deps := Deps{
+		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:         map[string]*config.ProviderEntry{"agent_state": {}},
+		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+
+	pool := hostedAgentProviderPoolForTest(t, agents[0])
+	backends := pool.readyBackends()
+	if len(backends) != 1 {
+		t.Fatalf("ready backends = %d, want 1", len(backends))
+	}
+	first := backends[0]
+	waitForAgentRuntimeCondition(t, 3*time.Second, func() bool {
+		ready := pool.readyBackends()
+		return len(runtimeProvider.startSessionRequests()) >= 2 && len(ready) == 1 && ready[0] != first
+	})
+	pool.mu.Lock()
+	firstRetired := first.draining || first.closed
+	pool.mu.Unlock()
+	if !firstRetired {
+		t.Fatal("first runtime backend was not marked draining or closed")
+	}
+	session, err := agents[0].CreateSession(context.Background(), coreagent.CreateSessionRequest{
+		SessionID: "session-after-runtime-drain",
+		Model:     "gpt-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession(after runtime drain): %v", err)
+	}
+	if session == nil || session.ID != "session-after-runtime-drain" {
+		t.Fatalf("CreateSession(after runtime drain) = %#v, want session-after-runtime-drain", session)
+	}
+}
+
+func TestAgentRuntimeConfigDoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntimeLifetime(t *testing.T) {
+	t.Parallel()
+
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	runtimeProvider.lifecycleForSession = func(index int) *pluginruntime.SessionLifecycle {
+		expiresAt := time.Now().UTC().Add(5 * time.Minute)
+		return &pluginruntime.SessionLifecycle{
+			ExpiresAt: &expiresAt,
+		}
+	}
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.StartupTimeout = "5m"
+	runtimeConfig.DrainTimeout = "2m"
+	runtimeConfig.HealthCheckInterval = "25ms"
+	runtimeConfig.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command:   bin,
+					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
+					Runtime:   runtimeConfig,
+				},
+			},
+		},
+	}
+	deps := Deps{
+		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:         map[string]*config.ProviderEntry{"agent_state": {}},
+		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	if got := len(runtimeProvider.startSessionRequests()); got != 1 {
+		t.Fatalf("start session requests after expiry health checks = %d, want 1", got)
+	}
+}
+
+func TestAgentRuntimeConfigReplacesExpiresOnlyRuntimeBeforeExpiry(t *testing.T) {
+	t.Parallel()
+
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	var expiryMu sync.Mutex
+	var firstExpiresAt time.Time
+	runtimeProvider.lifecycleForSession = func(index int) *pluginruntime.SessionLifecycle {
+		expiresAt := time.Now().UTC().Add(time.Hour)
+		if index == 1 {
+			expiresAt = time.Now().UTC().Add(2 * time.Second)
+			expiryMu.Lock()
+			firstExpiresAt = expiresAt
+			expiryMu.Unlock()
+		}
+		return &pluginruntime.SessionLifecycle{
+			ExpiresAt: &expiresAt,
+		}
+	}
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.StartupTimeout = "5m"
+	runtimeConfig.DrainTimeout = "2m"
+	runtimeConfig.HealthCheckInterval = "25ms"
+	runtimeConfig.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command:   bin,
+					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
+					Runtime:   runtimeConfig,
+				},
+			},
+		},
+	}
+	deps := Deps{
+		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:         map[string]*config.ProviderEntry{"agent_state": {}},
+		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+
+	waitForAgentRuntimeCondition(t, 3*time.Second, func() bool {
+		return len(runtimeProvider.startSessionRequests()) >= 2
+	})
+	startTimes := runtimeProvider.startSessionTimes()
+	if len(startTimes) < 2 {
+		t.Fatalf("start session times = %d, want at least 2", len(startTimes))
+	}
+	expiryMu.Lock()
+	expiresAt := firstExpiresAt
+	expiryMu.Unlock()
+	if expiresAt.IsZero() {
+		t.Fatal("first runtime expiry was not captured")
+	}
+	if !startTimes[1].Before(expiresAt) {
+		t.Fatalf("replacement started at %s, want before first runtime expiry %s", startTimes[1].Format(time.RFC3339Nano), expiresAt.Format(time.RFC3339Nano))
+	}
+}
+
 func TestHostedAgentProviderPoolPingChecksReadyBackendsInParallel(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -196,10 +196,13 @@ func (p *recordingHostedAuthorizationProvider) Calls() []authorizationSearchCall
 type capturingPluginRuntime struct {
 	provider *pluginruntime.LocalProvider
 
-	mu            sync.Mutex
-	startRequests []pluginruntime.StartSessionRequest
-	bindRequests  []pluginruntime.BindHostServiceRequest
-	stopCount     atomic.Int32
+	mu                  sync.Mutex
+	startRequests       []pluginruntime.StartSessionRequest
+	startTimes          []time.Time
+	bindRequests        []pluginruntime.BindHostServiceRequest
+	sessionLifecycles   map[string]*pluginruntime.SessionLifecycle
+	lifecycleForSession func(index int) *pluginruntime.SessionLifecycle
+	stopCount           atomic.Int32
 }
 
 func newCapturingPluginRuntime() *capturingPluginRuntime {
@@ -218,16 +221,44 @@ func (r *capturingPluginRuntime) StartSession(ctx context.Context, req pluginrun
 		Image:      req.Image,
 		Metadata:   cloneRuntimeMetadata(req.Metadata),
 	})
+	r.startTimes = append(r.startTimes, time.Now().UTC())
+	index := len(r.startRequests)
+	lifecycleForSession := r.lifecycleForSession
 	r.mu.Unlock()
-	return r.provider.StartSession(ctx, req)
+	session, err := r.provider.StartSession(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if lifecycleForSession != nil {
+		session.Lifecycle = clonePluginRuntimeSessionLifecycle(lifecycleForSession(index))
+		r.mu.Lock()
+		if r.sessionLifecycles == nil {
+			r.sessionLifecycles = map[string]*pluginruntime.SessionLifecycle{}
+		}
+		r.sessionLifecycles[session.ID] = clonePluginRuntimeSessionLifecycle(session.Lifecycle)
+		r.mu.Unlock()
+	}
+	return session, nil
 }
 
 func (r *capturingPluginRuntime) ListSessions(ctx context.Context) ([]pluginruntime.Session, error) {
-	return r.provider.ListSessions(ctx)
+	sessions, err := r.provider.ListSessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range sessions {
+		r.attachSessionLifecycle(&sessions[i])
+	}
+	return sessions, nil
 }
 
 func (r *capturingPluginRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
-	return r.provider.GetSession(ctx, req)
+	session, err := r.provider.GetSession(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	r.attachSessionLifecycle(session)
+	return session, nil
 }
 
 func (r *capturingPluginRuntime) StopSession(ctx context.Context, req pluginruntime.StopSessionRequest) error {
@@ -265,6 +296,12 @@ func (r *capturingPluginRuntime) startSessionRequests() []pluginruntime.StartSes
 	return out
 }
 
+func (r *capturingPluginRuntime) startSessionTimes() []time.Time {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]time.Time(nil), r.startTimes...)
+}
+
 func (r *capturingPluginRuntime) bindHostServiceRequests() []pluginruntime.BindHostServiceRequest {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -273,6 +310,35 @@ func (r *capturingPluginRuntime) bindHostServiceRequests() []pluginruntime.BindH
 		out[i] = cloneBindHostServiceRequest(req)
 	}
 	return out
+}
+
+func (r *capturingPluginRuntime) attachSessionLifecycle(session *pluginruntime.Session) {
+	if session == nil || session.ID == "" {
+		return
+	}
+	r.mu.Lock()
+	lifecycle := clonePluginRuntimeSessionLifecycle(r.sessionLifecycles[session.ID])
+	r.mu.Unlock()
+	session.Lifecycle = lifecycle
+}
+
+func clonePluginRuntimeSessionLifecycle(lifecycle *pluginruntime.SessionLifecycle) *pluginruntime.SessionLifecycle {
+	if lifecycle == nil {
+		return nil
+	}
+	return &pluginruntime.SessionLifecycle{
+		StartedAt:          cloneTestTime(lifecycle.StartedAt),
+		RecommendedDrainAt: cloneTestTime(lifecycle.RecommendedDrainAt),
+		ExpiresAt:          cloneTestTime(lifecycle.ExpiresAt),
+	}
+}
+
+func cloneTestTime(src *time.Time) *time.Time {
+	if src == nil {
+		return nil
+	}
+	out := src.UTC()
+	return &out
 }
 
 type capturingBundlePluginRuntime struct {

--- a/gestaltd/internal/bootstrap/hosted_agent_pool.go
+++ b/gestaltd/internal/bootstrap/hosted_agent_pool.go
@@ -13,8 +13,11 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 )
+
+const hostedAgentRuntimeLifecycleSafetyMargin = 5 * time.Second
 
 type hostedAgentProviderPool struct {
 	name         string
@@ -39,13 +42,18 @@ type hostedAgentProviderPool struct {
 }
 
 type hostedAgentPoolBackend struct {
-	id        int
-	provider  coreagent.Provider
-	active    int
-	liveTurns map[string]struct{}
-	draining  bool
-	closing   bool
-	closed    bool
+	id               int
+	provider         coreagent.Provider
+	runtimeProvider  pluginruntime.Provider
+	runtimeSessionID string
+	runtimeSession   *pluginruntime.Session
+	runtimeDrainAt   *time.Time
+	forceCloseAt     *time.Time
+	active           int
+	liveTurns        map[string]struct{}
+	draining         bool
+	closing          bool
+	closed           bool
 }
 
 func newHostedAgentProviderPool(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []providerhost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy) (coreagent.Provider, error) {
@@ -178,10 +186,11 @@ func (p *hostedAgentProviderPool) UpdateSession(ctx context.Context, req coreage
 
 func (p *hostedAgentProviderPool) CreateTurn(ctx context.Context, req coreagent.CreateTurnRequest) (*coreagent.Turn, error) {
 	preferred := p.turnBackend(req.TurnID)
+	allowDraining := preferred != nil
 	if preferred == nil {
 		preferred = p.sessionBackend(req.SessionID)
 	}
-	backend, release, err := p.acquireBackend(ctx, preferred, preferred != nil)
+	backend, release, err := p.acquireBackendForNewWork(ctx, preferred, allowDraining)
 	if err != nil {
 		return nil, err
 	}
@@ -590,6 +599,19 @@ func (p *hostedAgentProviderPool) acquireBackend(ctx context.Context, preferred 
 	}
 }
 
+func (p *hostedAgentProviderPool) acquireBackendForNewWork(ctx context.Context, preferred *hostedAgentPoolBackend, allowDraining bool) (*hostedAgentPoolBackend, func(), error) {
+	if preferred != nil {
+		backend, release, err := p.acquireBackend(ctx, preferred, allowDraining)
+		if err == nil {
+			return backend, release, nil
+		}
+		if ctx.Err() != nil {
+			return nil, nil, err
+		}
+	}
+	return p.acquireBackend(ctx, nil, false)
+}
+
 func (p *hostedAgentProviderPool) releaseBackend(backend *hostedAgentPoolBackend) func() {
 	return func() {
 		p.mu.Lock()
@@ -904,12 +926,129 @@ func (p *hostedAgentProviderPool) healthLoop() {
 		}
 		_ = p.ensureMinReady(p.ctx)
 		for _, backend := range p.readyBackends() {
+			session, drainAt, err := p.refreshBackendRuntimeSession(backend)
+			if err != nil {
+				slog.Warn("hosted agent runtime session refresh failed", "provider", p.name, "instance", backend.id, "error", err)
+				p.replaceBackend(backend)
+				continue
+			}
+			if reason := p.runtimeSessionRetirementReason(session, drainAt, time.Now().UTC()); reason != "" {
+				slog.Info("retiring hosted agent runtime instance", "provider", p.name, "instance", backend.id, "reason", reason)
+				p.replaceBackend(backend)
+				continue
+			}
 			if err := p.pingBackend(backend); err != nil {
 				slog.Warn("hosted agent runtime instance failed health check", "provider", p.name, "instance", backend.id, "error", err)
 				p.replaceBackend(backend)
 			}
 		}
 	}
+}
+
+func (p *hostedAgentProviderPool) refreshBackendRuntimeSession(backend *hostedAgentPoolBackend) (*pluginruntime.Session, *time.Time, error) {
+	if backend == nil {
+		return nil, nil, fmt.Errorf("runtime instance is unavailable")
+	}
+	p.mu.Lock()
+	runtimeProvider := backend.runtimeProvider
+	sessionID := strings.TrimSpace(backend.runtimeSessionID)
+	p.mu.Unlock()
+	if runtimeProvider == nil || sessionID == "" {
+		return nil, nil, nil
+	}
+	timeout := p.policy.HealthCheckInterval
+	if timeout <= 0 || timeout > 10*time.Second {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(p.ctx, timeout)
+	defer cancel()
+	session, err := runtimeProvider.GetSession(ctx, pluginruntime.GetSessionRequest{SessionID: sessionID})
+	if err != nil {
+		return nil, nil, fmt.Errorf("get runtime session %q: %w", sessionID, err)
+	}
+	drainAt := p.runtimeSessionDrainAt(session, time.Now().UTC())
+	p.mu.Lock()
+	if p.backendAvailableLocked(backend, true) {
+		if backend.runtimeDrainAt != nil && (drainAt == nil || backend.runtimeDrainAt.Before(*drainAt)) {
+			drainAt = cloneTime(backend.runtimeDrainAt)
+		}
+		backend.runtimeSession = session
+		backend.runtimeDrainAt = cloneTime(drainAt)
+		backend.forceCloseAt = runtimeSessionExpiresAt(session)
+	}
+	p.mu.Unlock()
+	return session, drainAt, nil
+}
+
+func (p *hostedAgentProviderPool) runtimeSessionRetirementReason(session *pluginruntime.Session, drainAt *time.Time, now time.Time) string {
+	if session == nil {
+		return ""
+	}
+	switch session.State {
+	case pluginruntime.SessionStateFailed, pluginruntime.SessionStateStopped:
+		return fmt.Sprintf("runtime session entered %q state", session.State)
+	}
+	if drainAt == nil || now.Before(*drainAt) {
+		return ""
+	}
+	if expiresAt := runtimeSessionExpiresAt(session); expiresAt != nil && !now.Before(*expiresAt) {
+		return fmt.Sprintf("runtime session expired at %s", expiresAt.Format(time.RFC3339Nano))
+	}
+	return fmt.Sprintf("runtime session reached drain deadline %s", drainAt.Format(time.RFC3339Nano))
+}
+
+func (p *hostedAgentProviderPool) runtimeSessionDrainAt(session *pluginruntime.Session, now time.Time) *time.Time {
+	if session == nil || session.Lifecycle == nil {
+		return nil
+	}
+	var drainAt *time.Time
+	if session.Lifecycle.RecommendedDrainAt != nil {
+		recommended := session.Lifecycle.RecommendedDrainAt.UTC()
+		drainAt = &recommended
+	}
+	if session.Lifecycle.ExpiresAt != nil {
+		expiryDrain := p.runtimeSessionExpiryDrainAt(session.Lifecycle, now)
+		if drainAt == nil || expiryDrain.Before(*drainAt) {
+			drainAt = &expiryDrain
+		}
+	}
+	return drainAt
+}
+
+func (p *hostedAgentProviderPool) runtimeSessionExpiryDrainAt(lifecycle *pluginruntime.SessionLifecycle, now time.Time) time.Time {
+	expiresAt := lifecycle.ExpiresAt.UTC()
+	reserve := p.policy.StartupTimeout + p.policy.DrainTimeout + p.policy.HealthCheckInterval + hostedAgentRuntimeLifecycleSafetyMargin
+	drainAt := expiresAt.Add(-reserve).UTC()
+	if lifecycle.StartedAt != nil {
+		startedAt := lifecycle.StartedAt.UTC()
+		lifetime := expiresAt.Sub(startedAt)
+		if lifetime > 0 {
+			minDrainAt := startedAt.Add(lifetime / 2).UTC()
+			if drainAt.Before(minDrainAt) {
+				return minDrainAt
+			}
+		}
+	}
+	if !now.IsZero() && expiresAt.After(now) && drainAt.Before(now) {
+		return now.Add(expiresAt.Sub(now) / 2).UTC()
+	}
+	return drainAt
+}
+
+func runtimeSessionExpiresAt(session *pluginruntime.Session) *time.Time {
+	if session == nil || session.Lifecycle == nil || session.Lifecycle.ExpiresAt == nil {
+		return nil
+	}
+	expiresAt := session.Lifecycle.ExpiresAt.UTC()
+	return &expiresAt
+}
+
+func cloneTime(src *time.Time) *time.Time {
+	if src == nil {
+		return nil
+	}
+	out := src.UTC()
+	return &out
 }
 
 func (p *hostedAgentProviderPool) maybeProbeAfterCallError(backend *hostedAgentPoolBackend, callErr error) {
@@ -1012,21 +1151,26 @@ func (p *hostedAgentProviderPool) ensureMinReady(ctx context.Context) error {
 func (p *hostedAgentProviderPool) startBackend(ctx context.Context) (*hostedAgentPoolBackend, error) {
 	startCtx, cancel := context.WithTimeout(ctx, p.policy.StartupTimeout)
 	defer cancel()
-	provider, err := startHostedAgentProviderInstance(startCtx, p.launch, p.hostServices, p.deps, false, nil)
+	instance, err := startHostedAgentProviderInstance(startCtx, p.launch, p.hostServices, p.deps, false, nil)
 	if err != nil {
 		return nil, err
 	}
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
-		_ = provider.Close()
+		_ = instance.provider.Close()
 		return nil, fmt.Errorf("hosted agent provider %q is closed", p.name)
 	}
 	p.nextID++
 	backend := &hostedAgentPoolBackend{
-		id:        p.nextID,
-		provider:  provider,
-		liveTurns: map[string]struct{}{},
+		id:               p.nextID,
+		provider:         instance.provider,
+		runtimeProvider:  instance.runtimeProvider,
+		runtimeSessionID: instance.runtimeSessionID,
+		runtimeSession:   instance.runtimeSession,
+		runtimeDrainAt:   p.runtimeSessionDrainAt(instance.runtimeSession, time.Now().UTC()),
+		forceCloseAt:     runtimeSessionExpiresAt(instance.runtimeSession),
+		liveTurns:        map[string]struct{}{},
 	}
 	p.backends = append(p.backends, backend)
 	ready, starting, draining := p.instanceCountsLocked()
@@ -1065,6 +1209,11 @@ func (p *hostedAgentProviderPool) drainAndCloseBackend(backend *hostedAgentPoolB
 	p.mu.Unlock()
 
 	deadline := time.Now().Add(p.policy.DrainTimeout)
+	p.mu.Lock()
+	if backend.forceCloseAt != nil && backend.forceCloseAt.Before(deadline) {
+		deadline = backend.forceCloseAt.UTC()
+	}
+	p.mu.Unlock()
 	for {
 		p.mu.Lock()
 		active := backend.active

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -847,7 +847,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 			_ = runtimeProvider.Close()
 		}
 	}()
-	if err := waitForPluginRuntimeSessionReady(ctx, runtimeProvider, sessionID); err != nil {
+	if _, err := waitForPluginRuntimeSessionReady(ctx, runtimeProvider, sessionID); err != nil {
 		return nil, fmt.Errorf("wait for plugin runtime session %q ready: %w", sessionID, err)
 	}
 
@@ -972,6 +972,13 @@ type hostedAgentProviderLaunch struct {
 	cleanup         func()
 }
 
+type hostedAgentProviderInstance struct {
+	provider         coreagent.Provider
+	runtimeProvider  pluginruntime.Provider
+	runtimeSessionID string
+	runtimeSession   *pluginruntime.Session
+}
+
 func (p *hostedAgentProviderLaunch) close() {
 	if p == nil {
 		return
@@ -1065,7 +1072,7 @@ func prepareHostedAgentProviderLaunch(ctx context.Context, name string, entry *c
 	return preparedLaunch, nil
 }
 
-func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []providerhost.HostService, deps Deps, closeRuntime bool, cleanup func()) (coreagent.Provider, error) {
+func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []providerhost.HostService, deps Deps, closeRuntime bool, cleanup func()) (*hostedAgentProviderInstance, error) {
 	if launch == nil {
 		return nil, fmt.Errorf("hosted agent launch is required")
 	}
@@ -1105,7 +1112,8 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 		}
 	}()
 	phaseStarted = time.Now()
-	if err := waitForPluginRuntimeSessionReady(ctx, runtimeProvider, sessionID); err != nil {
+	readySession, err := waitForPluginRuntimeSessionReady(ctx, runtimeProvider, sessionID)
+	if err != nil {
 		recordHostedAgentRuntimeStartPhase(ctx, name, "runtime_session_ready", phaseStarted, err)
 		return nil, fmt.Errorf("wait for hosted agent runtime session %q ready: %w", sessionID, err)
 	}
@@ -1212,7 +1220,12 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	stopSession = false
 	closeOnFailure = false
 	cleanup = nil
-	return provider, nil
+	return &hostedAgentProviderInstance{
+		provider:         provider,
+		runtimeProvider:  runtimeProvider,
+		runtimeSessionID: sessionID,
+		runtimeSession:   readySession,
+	}, nil
 }
 
 func effectiveConfiguredHostedRuntime(ctx context.Context, configPath string, entry *config.ProviderEntry, deps Deps) (config.EffectiveHostedRuntime, pluginruntime.Provider, bool, error) {
@@ -1367,22 +1380,22 @@ func stopPluginRuntimeSession(runtimeProvider pluginruntime.Provider, sessionID 
 	}
 }
 
-func waitForPluginRuntimeSessionReady(ctx context.Context, runtimeProvider pluginruntime.Provider, sessionID string) error {
+func waitForPluginRuntimeSessionReady(ctx context.Context, runtimeProvider pluginruntime.Provider, sessionID string) (*pluginruntime.Session, error) {
 	for {
 		session, err := runtimeProvider.GetSession(ctx, pluginruntime.GetSessionRequest{SessionID: sessionID})
 		if err != nil {
-			return err
+			return nil, err
 		}
 		switch session.State {
 		case pluginruntime.SessionStateReady, pluginruntime.SessionStateRunning:
-			return nil
+			return session, nil
 		case pluginruntime.SessionStateFailed, pluginruntime.SessionStateStopped:
-			return fmt.Errorf("session entered %q state", session.State)
+			return nil, fmt.Errorf("session entered %q state", session.State)
 		}
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, ctx.Err()
 		case <-time.After(25 * time.Millisecond):
 		}
 	}

--- a/gestaltd/internal/pluginruntime/executable.go
+++ b/gestaltd/internal/pluginruntime/executable.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type ExecutableConfig struct {
@@ -114,6 +115,27 @@ func (p *executableProvider) StartSession(ctx context.Context, req StartSessionR
 func (p *executableProvider) ListSessions(ctx context.Context) ([]Session, error) {
 	if p == nil {
 		return nil, fmt.Errorf("plugin runtime is not configured")
+	}
+
+	resp, err := p.runtime.ListSessions(ctx, &proto.ListPluginRuntimeSessionsRequest{})
+	if err == nil {
+		out := make([]Session, 0, len(resp.GetSessions()))
+		refreshed := make(map[string]*Session, len(resp.GetSessions()))
+		for _, protoSession := range resp.GetSessions() {
+			session := sessionFromProto(protoSession)
+			if session == nil || session.ID == "" {
+				continue
+			}
+			refreshed[session.ID] = cloneHostedSession(session)
+			out = append(out, *session)
+		}
+		p.mu.Lock()
+		p.sessions = refreshed
+		p.mu.Unlock()
+		return out, nil
+	}
+	if status.Code(err) != codes.Unimplemented {
+		return nil, fmt.Errorf("list runtime sessions: %w", err)
 	}
 
 	p.mu.Lock()
@@ -328,10 +350,39 @@ func sessionFromProto(src *proto.PluginRuntimeSession) *Session {
 		return nil
 	}
 	return &Session{
-		ID:       src.GetId(),
-		State:    SessionState(src.GetState()),
-		Metadata: cloneStringMap(src.GetMetadata()),
+		ID:           src.GetId(),
+		State:        SessionState(src.GetState()),
+		Metadata:     cloneStringMap(src.GetMetadata()),
+		Lifecycle:    sessionLifecycleFromProto(src.GetLifecycle()),
+		StateReason:  strings.TrimSpace(src.GetStateReason()),
+		StateMessage: strings.TrimSpace(src.GetStateMessage()),
 	}
+}
+
+func sessionLifecycleFromProto(src *proto.PluginRuntimeSessionLifecycle) *SessionLifecycle {
+	if src == nil {
+		return nil
+	}
+	lifecycle := &SessionLifecycle{
+		StartedAt:          timeFromProto(src.GetStartedAt()),
+		RecommendedDrainAt: timeFromProto(src.GetRecommendedDrainAt()),
+		ExpiresAt:          timeFromProto(src.GetExpiresAt()),
+	}
+	if lifecycle.StartedAt == nil && lifecycle.RecommendedDrainAt == nil && lifecycle.ExpiresAt == nil {
+		return nil
+	}
+	return lifecycle
+}
+
+func timeFromProto(src *timestamppb.Timestamp) *time.Time {
+	if src == nil {
+		return nil
+	}
+	ts := src.AsTime().UTC()
+	if ts.IsZero() {
+		return nil
+	}
+	return &ts
 }
 
 func (p *executableProvider) trackSession(session *Session) {
@@ -351,10 +402,32 @@ func cloneHostedSession(session *Session) *Session {
 		return nil
 	}
 	return &Session{
-		ID:       session.ID,
-		State:    session.State,
-		Metadata: cloneStringMap(session.Metadata),
+		ID:           session.ID,
+		State:        session.State,
+		Metadata:     cloneStringMap(session.Metadata),
+		Lifecycle:    cloneSessionLifecycle(session.Lifecycle),
+		StateReason:  session.StateReason,
+		StateMessage: session.StateMessage,
 	}
+}
+
+func cloneSessionLifecycle(lifecycle *SessionLifecycle) *SessionLifecycle {
+	if lifecycle == nil {
+		return nil
+	}
+	return &SessionLifecycle{
+		StartedAt:          cloneTimePtr(lifecycle.StartedAt),
+		RecommendedDrainAt: cloneTimePtr(lifecycle.RecommendedDrainAt),
+		ExpiresAt:          cloneTimePtr(lifecycle.ExpiresAt),
+	}
+}
+
+func cloneTimePtr(src *time.Time) *time.Time {
+	if src == nil {
+		return nil
+	}
+	out := src.UTC()
+	return &out
 }
 
 func hostServiceRelayToProto(src HostServiceRelay) *proto.PluginRuntimeHostServiceRelay {

--- a/gestaltd/internal/pluginruntime/runtime.go
+++ b/gestaltd/internal/pluginruntime/runtime.go
@@ -2,6 +2,7 @@ package pluginruntime
 
 import (
 	"context"
+	"time"
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
@@ -64,9 +65,18 @@ type Support struct {
 }
 
 type Session struct {
-	ID       string
-	State    SessionState
-	Metadata map[string]string
+	ID           string
+	State        SessionState
+	Metadata     map[string]string
+	Lifecycle    *SessionLifecycle
+	StateReason  string
+	StateMessage string
+}
+
+type SessionLifecycle struct {
+	StartedAt          *time.Time
+	RecommendedDrainAt *time.Time
+	ExpiresAt          *time.Time
 }
 
 type StartSessionRequest struct {

--- a/sdk/go/gen/v1/pluginruntime.pb.go
+++ b/sdk/go/gen/v1/pluginruntime.pb.go
@@ -354,10 +354,13 @@ func (x *PluginRuntimeSupport) GetExecutionTarget() *PluginRuntimeExecutionTarge
 }
 
 type PluginRuntimeSession struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	State         string                 `protobuf:"bytes,2,opt,name=state,proto3" json:"state,omitempty"`
-	Metadata      map[string]string      `protobuf:"bytes,3,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	state         protoimpl.MessageState         `protogen:"open.v1"`
+	Id            string                         `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	State         string                         `protobuf:"bytes,2,opt,name=state,proto3" json:"state,omitempty"`
+	Metadata      map[string]string              `protobuf:"bytes,3,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Lifecycle     *PluginRuntimeSessionLifecycle `protobuf:"bytes,4,opt,name=lifecycle,proto3" json:"lifecycle,omitempty"`
+	StateReason   string                         `protobuf:"bytes,5,opt,name=state_reason,json=stateReason,proto3" json:"state_reason,omitempty"`
+	StateMessage  string                         `protobuf:"bytes,6,opt,name=state_message,json=stateMessage,proto3" json:"state_message,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -413,6 +416,87 @@ func (x *PluginRuntimeSession) GetMetadata() map[string]string {
 	return nil
 }
 
+func (x *PluginRuntimeSession) GetLifecycle() *PluginRuntimeSessionLifecycle {
+	if x != nil {
+		return x.Lifecycle
+	}
+	return nil
+}
+
+func (x *PluginRuntimeSession) GetStateReason() string {
+	if x != nil {
+		return x.StateReason
+	}
+	return ""
+}
+
+func (x *PluginRuntimeSession) GetStateMessage() string {
+	if x != nil {
+		return x.StateMessage
+	}
+	return ""
+}
+
+type PluginRuntimeSessionLifecycle struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	StartedAt          *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	RecommendedDrainAt *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=recommended_drain_at,json=recommendedDrainAt,proto3" json:"recommended_drain_at,omitempty"`
+	ExpiresAt          *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *PluginRuntimeSessionLifecycle) Reset() {
+	*x = PluginRuntimeSessionLifecycle{}
+	mi := &file_v1_pluginruntime_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginRuntimeSessionLifecycle) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginRuntimeSessionLifecycle) ProtoMessage() {}
+
+func (x *PluginRuntimeSessionLifecycle) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_pluginruntime_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginRuntimeSessionLifecycle.ProtoReflect.Descriptor instead.
+func (*PluginRuntimeSessionLifecycle) Descriptor() ([]byte, []int) {
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *PluginRuntimeSessionLifecycle) GetStartedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartedAt
+	}
+	return nil
+}
+
+func (x *PluginRuntimeSessionLifecycle) GetRecommendedDrainAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RecommendedDrainAt
+	}
+	return nil
+}
+
+func (x *PluginRuntimeSessionLifecycle) GetExpiresAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return nil
+}
+
 type StartPluginRuntimeSessionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	PluginName    string                 `protobuf:"bytes,1,opt,name=plugin_name,json=pluginName,proto3" json:"plugin_name,omitempty"`
@@ -425,7 +509,7 @@ type StartPluginRuntimeSessionRequest struct {
 
 func (x *StartPluginRuntimeSessionRequest) Reset() {
 	*x = StartPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[3]
+	mi := &file_v1_pluginruntime_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -437,7 +521,7 @@ func (x *StartPluginRuntimeSessionRequest) String() string {
 func (*StartPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *StartPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[3]
+	mi := &file_v1_pluginruntime_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -450,7 +534,7 @@ func (x *StartPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*StartPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{3}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *StartPluginRuntimeSessionRequest) GetPluginName() string {
@@ -490,7 +574,7 @@ type GetPluginRuntimeSessionRequest struct {
 
 func (x *GetPluginRuntimeSessionRequest) Reset() {
 	*x = GetPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[4]
+	mi := &file_v1_pluginruntime_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -502,7 +586,7 @@ func (x *GetPluginRuntimeSessionRequest) String() string {
 func (*GetPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *GetPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[4]
+	mi := &file_v1_pluginruntime_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -515,7 +599,7 @@ func (x *GetPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{4}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *GetPluginRuntimeSessionRequest) GetSessionId() string {
@@ -523,6 +607,86 @@ func (x *GetPluginRuntimeSessionRequest) GetSessionId() string {
 		return x.SessionId
 	}
 	return ""
+}
+
+type ListPluginRuntimeSessionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListPluginRuntimeSessionsRequest) Reset() {
+	*x = ListPluginRuntimeSessionsRequest{}
+	mi := &file_v1_pluginruntime_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPluginRuntimeSessionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPluginRuntimeSessionsRequest) ProtoMessage() {}
+
+func (x *ListPluginRuntimeSessionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_pluginruntime_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListPluginRuntimeSessionsRequest.ProtoReflect.Descriptor instead.
+func (*ListPluginRuntimeSessionsRequest) Descriptor() ([]byte, []int) {
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{6}
+}
+
+type ListPluginRuntimeSessionsResponse struct {
+	state         protoimpl.MessageState  `protogen:"open.v1"`
+	Sessions      []*PluginRuntimeSession `protobuf:"bytes,1,rep,name=sessions,proto3" json:"sessions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListPluginRuntimeSessionsResponse) Reset() {
+	*x = ListPluginRuntimeSessionsResponse{}
+	mi := &file_v1_pluginruntime_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPluginRuntimeSessionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPluginRuntimeSessionsResponse) ProtoMessage() {}
+
+func (x *ListPluginRuntimeSessionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_pluginruntime_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListPluginRuntimeSessionsResponse.ProtoReflect.Descriptor instead.
+func (*ListPluginRuntimeSessionsResponse) Descriptor() ([]byte, []int) {
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ListPluginRuntimeSessionsResponse) GetSessions() []*PluginRuntimeSession {
+	if x != nil {
+		return x.Sessions
+	}
+	return nil
 }
 
 type StopPluginRuntimeSessionRequest struct {
@@ -534,7 +698,7 @@ type StopPluginRuntimeSessionRequest struct {
 
 func (x *StopPluginRuntimeSessionRequest) Reset() {
 	*x = StopPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[5]
+	mi := &file_v1_pluginruntime_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -546,7 +710,7 @@ func (x *StopPluginRuntimeSessionRequest) String() string {
 func (*StopPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *StopPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[5]
+	mi := &file_v1_pluginruntime_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -559,7 +723,7 @@ func (x *StopPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*StopPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{5}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *StopPluginRuntimeSessionRequest) GetSessionId() string {
@@ -578,7 +742,7 @@ type PluginRuntimeHostServiceRelay struct {
 
 func (x *PluginRuntimeHostServiceRelay) Reset() {
 	*x = PluginRuntimeHostServiceRelay{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[6]
+	mi := &file_v1_pluginruntime_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -590,7 +754,7 @@ func (x *PluginRuntimeHostServiceRelay) String() string {
 func (*PluginRuntimeHostServiceRelay) ProtoMessage() {}
 
 func (x *PluginRuntimeHostServiceRelay) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[6]
+	mi := &file_v1_pluginruntime_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -603,7 +767,7 @@ func (x *PluginRuntimeHostServiceRelay) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeHostServiceRelay.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeHostServiceRelay) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{6}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *PluginRuntimeHostServiceRelay) GetDialTarget() string {
@@ -624,7 +788,7 @@ type BindPluginRuntimeHostServiceRequest struct {
 
 func (x *BindPluginRuntimeHostServiceRequest) Reset() {
 	*x = BindPluginRuntimeHostServiceRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[7]
+	mi := &file_v1_pluginruntime_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -636,7 +800,7 @@ func (x *BindPluginRuntimeHostServiceRequest) String() string {
 func (*BindPluginRuntimeHostServiceRequest) ProtoMessage() {}
 
 func (x *BindPluginRuntimeHostServiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[7]
+	mi := &file_v1_pluginruntime_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -649,7 +813,7 @@ func (x *BindPluginRuntimeHostServiceRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use BindPluginRuntimeHostServiceRequest.ProtoReflect.Descriptor instead.
 func (*BindPluginRuntimeHostServiceRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{7}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *BindPluginRuntimeHostServiceRequest) GetSessionId() string {
@@ -685,7 +849,7 @@ type PluginRuntimeHostServiceBinding struct {
 
 func (x *PluginRuntimeHostServiceBinding) Reset() {
 	*x = PluginRuntimeHostServiceBinding{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[8]
+	mi := &file_v1_pluginruntime_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -697,7 +861,7 @@ func (x *PluginRuntimeHostServiceBinding) String() string {
 func (*PluginRuntimeHostServiceBinding) ProtoMessage() {}
 
 func (x *PluginRuntimeHostServiceBinding) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[8]
+	mi := &file_v1_pluginruntime_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -710,7 +874,7 @@ func (x *PluginRuntimeHostServiceBinding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeHostServiceBinding.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeHostServiceBinding) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{8}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *PluginRuntimeHostServiceBinding) GetId() string {
@@ -762,7 +926,7 @@ type StartHostedPluginRequest struct {
 
 func (x *StartHostedPluginRequest) Reset() {
 	*x = StartHostedPluginRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[9]
+	mi := &file_v1_pluginruntime_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -774,7 +938,7 @@ func (x *StartHostedPluginRequest) String() string {
 func (*StartHostedPluginRequest) ProtoMessage() {}
 
 func (x *StartHostedPluginRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[9]
+	mi := &file_v1_pluginruntime_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -787,7 +951,7 @@ func (x *StartHostedPluginRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartHostedPluginRequest.ProtoReflect.Descriptor instead.
 func (*StartHostedPluginRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{9}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *StartHostedPluginRequest) GetSessionId() string {
@@ -865,7 +1029,7 @@ type HostedPlugin struct {
 
 func (x *HostedPlugin) Reset() {
 	*x = HostedPlugin{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[10]
+	mi := &file_v1_pluginruntime_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -877,7 +1041,7 @@ func (x *HostedPlugin) String() string {
 func (*HostedPlugin) ProtoMessage() {}
 
 func (x *HostedPlugin) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[10]
+	mi := &file_v1_pluginruntime_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -890,7 +1054,7 @@ func (x *HostedPlugin) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostedPlugin.ProtoReflect.Descriptor instead.
 func (*HostedPlugin) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{10}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *HostedPlugin) GetId() string {
@@ -933,7 +1097,7 @@ type PluginRuntimeLogEntry struct {
 
 func (x *PluginRuntimeLogEntry) Reset() {
 	*x = PluginRuntimeLogEntry{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[11]
+	mi := &file_v1_pluginruntime_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -945,7 +1109,7 @@ func (x *PluginRuntimeLogEntry) String() string {
 func (*PluginRuntimeLogEntry) ProtoMessage() {}
 
 func (x *PluginRuntimeLogEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[11]
+	mi := &file_v1_pluginruntime_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -958,7 +1122,7 @@ func (x *PluginRuntimeLogEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeLogEntry.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeLogEntry) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{11}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *PluginRuntimeLogEntry) GetStream() PluginRuntimeLogStream {
@@ -999,7 +1163,7 @@ type AppendPluginRuntimeLogsRequest struct {
 
 func (x *AppendPluginRuntimeLogsRequest) Reset() {
 	*x = AppendPluginRuntimeLogsRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[12]
+	mi := &file_v1_pluginruntime_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1011,7 +1175,7 @@ func (x *AppendPluginRuntimeLogsRequest) String() string {
 func (*AppendPluginRuntimeLogsRequest) ProtoMessage() {}
 
 func (x *AppendPluginRuntimeLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[12]
+	mi := &file_v1_pluginruntime_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1024,7 +1188,7 @@ func (x *AppendPluginRuntimeLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppendPluginRuntimeLogsRequest.ProtoReflect.Descriptor instead.
 func (*AppendPluginRuntimeLogsRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{12}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *AppendPluginRuntimeLogsRequest) GetSessionId() string {
@@ -1050,7 +1214,7 @@ type AppendPluginRuntimeLogsResponse struct {
 
 func (x *AppendPluginRuntimeLogsResponse) Reset() {
 	*x = AppendPluginRuntimeLogsResponse{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[13]
+	mi := &file_v1_pluginruntime_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1062,7 +1226,7 @@ func (x *AppendPluginRuntimeLogsResponse) String() string {
 func (*AppendPluginRuntimeLogsResponse) ProtoMessage() {}
 
 func (x *AppendPluginRuntimeLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[13]
+	mi := &file_v1_pluginruntime_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1075,7 +1239,7 @@ func (x *AppendPluginRuntimeLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppendPluginRuntimeLogsResponse.ProtoReflect.Descriptor instead.
 func (*AppendPluginRuntimeLogsResponse) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{13}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *AppendPluginRuntimeLogsResponse) GetLastSeq() int64 {
@@ -1100,14 +1264,23 @@ const file_v1_pluginruntime_proto_rawDesc = "" +
 	"egressMode\x12M\n" +
 	"\vlaunch_mode\x18\x04 \x01(\x0e2,.gestalt.provider.v1.PluginRuntimeLaunchModeR\n" +
 	"launchMode\x12\\\n" +
-	"\x10execution_target\x18\x05 \x01(\v21.gestalt.provider.v1.PluginRuntimeExecutionTargetR\x0fexecutionTarget\"\xce\x01\n" +
+	"\x10execution_target\x18\x05 \x01(\v21.gestalt.provider.v1.PluginRuntimeExecutionTargetR\x0fexecutionTarget\"\xe8\x02\n" +
 	"\x14PluginRuntimeSession\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05state\x18\x02 \x01(\tR\x05state\x12S\n" +
-	"\bmetadata\x18\x03 \x03(\v27.gestalt.provider.v1.PluginRuntimeSession.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x03 \x03(\v27.gestalt.provider.v1.PluginRuntimeSession.MetadataEntryR\bmetadata\x12P\n" +
+	"\tlifecycle\x18\x04 \x01(\v22.gestalt.provider.v1.PluginRuntimeSessionLifecycleR\tlifecycle\x12!\n" +
+	"\fstate_reason\x18\x05 \x01(\tR\vstateReason\x12#\n" +
+	"\rstate_message\x18\x06 \x01(\tR\fstateMessage\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x93\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe3\x01\n" +
+	"\x1dPluginRuntimeSessionLifecycle\x129\n" +
+	"\n" +
+	"started_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12L\n" +
+	"\x14recommended_drain_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x12recommendedDrainAt\x129\n" +
+	"\n" +
+	"expires_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\"\x93\x02\n" +
 	" StartPluginRuntimeSessionRequest\x12\x1f\n" +
 	"\vplugin_name\x18\x01 \x01(\tR\n" +
 	"pluginName\x12\x1a\n" +
@@ -1119,7 +1292,10 @@ const file_v1_pluginruntime_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"?\n" +
 	"\x1eGetPluginRuntimeSessionRequest\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x01 \x01(\tR\tsessionId\"@\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"\"\n" +
+	" ListPluginRuntimeSessionsRequest\"j\n" +
+	"!ListPluginRuntimeSessionsResponse\x12E\n" +
+	"\bsessions\x18\x01 \x03(\v2).gestalt.provider.v1.PluginRuntimeSessionR\bsessions\"@\n" +
 	"\x1fStopPluginRuntimeSessionRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\"@\n" +
@@ -1195,13 +1371,14 @@ const file_v1_pluginruntime_proto_rawDesc = "" +
 	"!PLUGIN_RUNTIME_LOG_STREAM_RUNTIME\x10\x032\x8f\x01\n" +
 	"\x14PluginRuntimeLogHost\x12w\n" +
 	"\n" +
-	"AppendLogs\x123.gestalt.provider.v1.AppendPluginRuntimeLogsRequest\x1a4.gestalt.provider.v1.AppendPluginRuntimeLogsResponse2\x8a\x05\n" +
+	"AppendLogs\x123.gestalt.provider.v1.AppendPluginRuntimeLogsRequest\x1a4.gestalt.provider.v1.AppendPluginRuntimeLogsResponse2\x89\x06\n" +
 	"\x15PluginRuntimeProvider\x12O\n" +
 	"\n" +
 	"GetSupport\x12\x16.google.protobuf.Empty\x1a).gestalt.provider.v1.PluginRuntimeSupport\x12p\n" +
 	"\fStartSession\x125.gestalt.provider.v1.StartPluginRuntimeSessionRequest\x1a).gestalt.provider.v1.PluginRuntimeSession\x12l\n" +
 	"\n" +
-	"GetSession\x123.gestalt.provider.v1.GetPluginRuntimeSessionRequest\x1a).gestalt.provider.v1.PluginRuntimeSession\x12[\n" +
+	"GetSession\x123.gestalt.provider.v1.GetPluginRuntimeSessionRequest\x1a).gestalt.provider.v1.PluginRuntimeSession\x12}\n" +
+	"\fListSessions\x125.gestalt.provider.v1.ListPluginRuntimeSessionsRequest\x1a6.gestalt.provider.v1.ListPluginRuntimeSessionsResponse\x12[\n" +
 	"\vStopSession\x124.gestalt.provider.v1.StopPluginRuntimeSessionRequest\x1a\x16.google.protobuf.Empty\x12\x81\x01\n" +
 	"\x0fBindHostService\x128.gestalt.provider.v1.BindPluginRuntimeHostServiceRequest\x1a4.gestalt.provider.v1.PluginRuntimeHostServiceBinding\x12_\n" +
 	"\vStartPlugin\x12-.gestalt.provider.v1.StartHostedPluginRequest\x1a!.gestalt.provider.v1.HostedPluginB\xd6\x01\n" +
@@ -1220,7 +1397,7 @@ func file_v1_pluginruntime_proto_rawDescGZIP() []byte {
 }
 
 var file_v1_pluginruntime_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_v1_pluginruntime_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_v1_pluginruntime_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_v1_pluginruntime_proto_goTypes = []any{
 	(PluginRuntimeHostServiceAccess)(0),         // 0: gestalt.provider.v1.PluginRuntimeHostServiceAccess
 	(PluginRuntimeEgressMode)(0),                // 1: gestalt.provider.v1.PluginRuntimeEgressMode
@@ -1229,55 +1406,65 @@ var file_v1_pluginruntime_proto_goTypes = []any{
 	(*PluginRuntimeExecutionTarget)(nil),        // 4: gestalt.provider.v1.PluginRuntimeExecutionTarget
 	(*PluginRuntimeSupport)(nil),                // 5: gestalt.provider.v1.PluginRuntimeSupport
 	(*PluginRuntimeSession)(nil),                // 6: gestalt.provider.v1.PluginRuntimeSession
-	(*StartPluginRuntimeSessionRequest)(nil),    // 7: gestalt.provider.v1.StartPluginRuntimeSessionRequest
-	(*GetPluginRuntimeSessionRequest)(nil),      // 8: gestalt.provider.v1.GetPluginRuntimeSessionRequest
-	(*StopPluginRuntimeSessionRequest)(nil),     // 9: gestalt.provider.v1.StopPluginRuntimeSessionRequest
-	(*PluginRuntimeHostServiceRelay)(nil),       // 10: gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	(*BindPluginRuntimeHostServiceRequest)(nil), // 11: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
-	(*PluginRuntimeHostServiceBinding)(nil),     // 12: gestalt.provider.v1.PluginRuntimeHostServiceBinding
-	(*StartHostedPluginRequest)(nil),            // 13: gestalt.provider.v1.StartHostedPluginRequest
-	(*HostedPlugin)(nil),                        // 14: gestalt.provider.v1.HostedPlugin
-	(*PluginRuntimeLogEntry)(nil),               // 15: gestalt.provider.v1.PluginRuntimeLogEntry
-	(*AppendPluginRuntimeLogsRequest)(nil),      // 16: gestalt.provider.v1.AppendPluginRuntimeLogsRequest
-	(*AppendPluginRuntimeLogsResponse)(nil),     // 17: gestalt.provider.v1.AppendPluginRuntimeLogsResponse
-	nil,                                         // 18: gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
-	nil,                                         // 19: gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
-	nil,                                         // 20: gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
-	(*timestamppb.Timestamp)(nil),               // 21: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                       // 22: google.protobuf.Empty
+	(*PluginRuntimeSessionLifecycle)(nil),       // 7: gestalt.provider.v1.PluginRuntimeSessionLifecycle
+	(*StartPluginRuntimeSessionRequest)(nil),    // 8: gestalt.provider.v1.StartPluginRuntimeSessionRequest
+	(*GetPluginRuntimeSessionRequest)(nil),      // 9: gestalt.provider.v1.GetPluginRuntimeSessionRequest
+	(*ListPluginRuntimeSessionsRequest)(nil),    // 10: gestalt.provider.v1.ListPluginRuntimeSessionsRequest
+	(*ListPluginRuntimeSessionsResponse)(nil),   // 11: gestalt.provider.v1.ListPluginRuntimeSessionsResponse
+	(*StopPluginRuntimeSessionRequest)(nil),     // 12: gestalt.provider.v1.StopPluginRuntimeSessionRequest
+	(*PluginRuntimeHostServiceRelay)(nil),       // 13: gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	(*BindPluginRuntimeHostServiceRequest)(nil), // 14: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
+	(*PluginRuntimeHostServiceBinding)(nil),     // 15: gestalt.provider.v1.PluginRuntimeHostServiceBinding
+	(*StartHostedPluginRequest)(nil),            // 16: gestalt.provider.v1.StartHostedPluginRequest
+	(*HostedPlugin)(nil),                        // 17: gestalt.provider.v1.HostedPlugin
+	(*PluginRuntimeLogEntry)(nil),               // 18: gestalt.provider.v1.PluginRuntimeLogEntry
+	(*AppendPluginRuntimeLogsRequest)(nil),      // 19: gestalt.provider.v1.AppendPluginRuntimeLogsRequest
+	(*AppendPluginRuntimeLogsResponse)(nil),     // 20: gestalt.provider.v1.AppendPluginRuntimeLogsResponse
+	nil,                                         // 21: gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
+	nil,                                         // 22: gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
+	nil,                                         // 23: gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
+	(*timestamppb.Timestamp)(nil),               // 24: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                       // 25: google.protobuf.Empty
 }
 var file_v1_pluginruntime_proto_depIdxs = []int32{
 	0,  // 0: gestalt.provider.v1.PluginRuntimeSupport.host_service_access:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceAccess
 	1,  // 1: gestalt.provider.v1.PluginRuntimeSupport.egress_mode:type_name -> gestalt.provider.v1.PluginRuntimeEgressMode
 	2,  // 2: gestalt.provider.v1.PluginRuntimeSupport.launch_mode:type_name -> gestalt.provider.v1.PluginRuntimeLaunchMode
 	4,  // 3: gestalt.provider.v1.PluginRuntimeSupport.execution_target:type_name -> gestalt.provider.v1.PluginRuntimeExecutionTarget
-	18, // 4: gestalt.provider.v1.PluginRuntimeSession.metadata:type_name -> gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
-	19, // 5: gestalt.provider.v1.StartPluginRuntimeSessionRequest.metadata:type_name -> gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
-	10, // 6: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	10, // 7: gestalt.provider.v1.PluginRuntimeHostServiceBinding.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	20, // 8: gestalt.provider.v1.StartHostedPluginRequest.env:type_name -> gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
-	3,  // 9: gestalt.provider.v1.PluginRuntimeLogEntry.stream:type_name -> gestalt.provider.v1.PluginRuntimeLogStream
-	21, // 10: gestalt.provider.v1.PluginRuntimeLogEntry.observed_at:type_name -> google.protobuf.Timestamp
-	15, // 11: gestalt.provider.v1.AppendPluginRuntimeLogsRequest.logs:type_name -> gestalt.provider.v1.PluginRuntimeLogEntry
-	16, // 12: gestalt.provider.v1.PluginRuntimeLogHost.AppendLogs:input_type -> gestalt.provider.v1.AppendPluginRuntimeLogsRequest
-	22, // 13: gestalt.provider.v1.PluginRuntimeProvider.GetSupport:input_type -> google.protobuf.Empty
-	7,  // 14: gestalt.provider.v1.PluginRuntimeProvider.StartSession:input_type -> gestalt.provider.v1.StartPluginRuntimeSessionRequest
-	8,  // 15: gestalt.provider.v1.PluginRuntimeProvider.GetSession:input_type -> gestalt.provider.v1.GetPluginRuntimeSessionRequest
-	9,  // 16: gestalt.provider.v1.PluginRuntimeProvider.StopSession:input_type -> gestalt.provider.v1.StopPluginRuntimeSessionRequest
-	11, // 17: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:input_type -> gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
-	13, // 18: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:input_type -> gestalt.provider.v1.StartHostedPluginRequest
-	17, // 19: gestalt.provider.v1.PluginRuntimeLogHost.AppendLogs:output_type -> gestalt.provider.v1.AppendPluginRuntimeLogsResponse
-	5,  // 20: gestalt.provider.v1.PluginRuntimeProvider.GetSupport:output_type -> gestalt.provider.v1.PluginRuntimeSupport
-	6,  // 21: gestalt.provider.v1.PluginRuntimeProvider.StartSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
-	6,  // 22: gestalt.provider.v1.PluginRuntimeProvider.GetSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
-	22, // 23: gestalt.provider.v1.PluginRuntimeProvider.StopSession:output_type -> google.protobuf.Empty
-	12, // 24: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:output_type -> gestalt.provider.v1.PluginRuntimeHostServiceBinding
-	14, // 25: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:output_type -> gestalt.provider.v1.HostedPlugin
-	19, // [19:26] is the sub-list for method output_type
-	12, // [12:19] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	21, // 4: gestalt.provider.v1.PluginRuntimeSession.metadata:type_name -> gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
+	7,  // 5: gestalt.provider.v1.PluginRuntimeSession.lifecycle:type_name -> gestalt.provider.v1.PluginRuntimeSessionLifecycle
+	24, // 6: gestalt.provider.v1.PluginRuntimeSessionLifecycle.started_at:type_name -> google.protobuf.Timestamp
+	24, // 7: gestalt.provider.v1.PluginRuntimeSessionLifecycle.recommended_drain_at:type_name -> google.protobuf.Timestamp
+	24, // 8: gestalt.provider.v1.PluginRuntimeSessionLifecycle.expires_at:type_name -> google.protobuf.Timestamp
+	22, // 9: gestalt.provider.v1.StartPluginRuntimeSessionRequest.metadata:type_name -> gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
+	6,  // 10: gestalt.provider.v1.ListPluginRuntimeSessionsResponse.sessions:type_name -> gestalt.provider.v1.PluginRuntimeSession
+	13, // 11: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	13, // 12: gestalt.provider.v1.PluginRuntimeHostServiceBinding.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	23, // 13: gestalt.provider.v1.StartHostedPluginRequest.env:type_name -> gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
+	3,  // 14: gestalt.provider.v1.PluginRuntimeLogEntry.stream:type_name -> gestalt.provider.v1.PluginRuntimeLogStream
+	24, // 15: gestalt.provider.v1.PluginRuntimeLogEntry.observed_at:type_name -> google.protobuf.Timestamp
+	18, // 16: gestalt.provider.v1.AppendPluginRuntimeLogsRequest.logs:type_name -> gestalt.provider.v1.PluginRuntimeLogEntry
+	19, // 17: gestalt.provider.v1.PluginRuntimeLogHost.AppendLogs:input_type -> gestalt.provider.v1.AppendPluginRuntimeLogsRequest
+	25, // 18: gestalt.provider.v1.PluginRuntimeProvider.GetSupport:input_type -> google.protobuf.Empty
+	8,  // 19: gestalt.provider.v1.PluginRuntimeProvider.StartSession:input_type -> gestalt.provider.v1.StartPluginRuntimeSessionRequest
+	9,  // 20: gestalt.provider.v1.PluginRuntimeProvider.GetSession:input_type -> gestalt.provider.v1.GetPluginRuntimeSessionRequest
+	10, // 21: gestalt.provider.v1.PluginRuntimeProvider.ListSessions:input_type -> gestalt.provider.v1.ListPluginRuntimeSessionsRequest
+	12, // 22: gestalt.provider.v1.PluginRuntimeProvider.StopSession:input_type -> gestalt.provider.v1.StopPluginRuntimeSessionRequest
+	14, // 23: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:input_type -> gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
+	16, // 24: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:input_type -> gestalt.provider.v1.StartHostedPluginRequest
+	20, // 25: gestalt.provider.v1.PluginRuntimeLogHost.AppendLogs:output_type -> gestalt.provider.v1.AppendPluginRuntimeLogsResponse
+	5,  // 26: gestalt.provider.v1.PluginRuntimeProvider.GetSupport:output_type -> gestalt.provider.v1.PluginRuntimeSupport
+	6,  // 27: gestalt.provider.v1.PluginRuntimeProvider.StartSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
+	6,  // 28: gestalt.provider.v1.PluginRuntimeProvider.GetSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
+	11, // 29: gestalt.provider.v1.PluginRuntimeProvider.ListSessions:output_type -> gestalt.provider.v1.ListPluginRuntimeSessionsResponse
+	25, // 30: gestalt.provider.v1.PluginRuntimeProvider.StopSession:output_type -> google.protobuf.Empty
+	15, // 31: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:output_type -> gestalt.provider.v1.PluginRuntimeHostServiceBinding
+	17, // 32: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:output_type -> gestalt.provider.v1.HostedPlugin
+	25, // [25:33] is the sub-list for method output_type
+	17, // [17:25] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_v1_pluginruntime_proto_init() }
@@ -1291,7 +1478,7 @@ func file_v1_pluginruntime_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_pluginruntime_proto_rawDesc), len(file_v1_pluginruntime_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   17,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/sdk/go/gen/v1/pluginruntime_grpc.pb.go
+++ b/sdk/go/gen/v1/pluginruntime_grpc.pb.go
@@ -125,6 +125,7 @@ const (
 	PluginRuntimeProvider_GetSupport_FullMethodName      = "/gestalt.provider.v1.PluginRuntimeProvider/GetSupport"
 	PluginRuntimeProvider_StartSession_FullMethodName    = "/gestalt.provider.v1.PluginRuntimeProvider/StartSession"
 	PluginRuntimeProvider_GetSession_FullMethodName      = "/gestalt.provider.v1.PluginRuntimeProvider/GetSession"
+	PluginRuntimeProvider_ListSessions_FullMethodName    = "/gestalt.provider.v1.PluginRuntimeProvider/ListSessions"
 	PluginRuntimeProvider_StopSession_FullMethodName     = "/gestalt.provider.v1.PluginRuntimeProvider/StopSession"
 	PluginRuntimeProvider_BindHostService_FullMethodName = "/gestalt.provider.v1.PluginRuntimeProvider/BindHostService"
 	PluginRuntimeProvider_StartPlugin_FullMethodName     = "/gestalt.provider.v1.PluginRuntimeProvider/StartPlugin"
@@ -137,6 +138,7 @@ type PluginRuntimeProviderClient interface {
 	GetSupport(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*PluginRuntimeSupport, error)
 	StartSession(ctx context.Context, in *StartPluginRuntimeSessionRequest, opts ...grpc.CallOption) (*PluginRuntimeSession, error)
 	GetSession(ctx context.Context, in *GetPluginRuntimeSessionRequest, opts ...grpc.CallOption) (*PluginRuntimeSession, error)
+	ListSessions(ctx context.Context, in *ListPluginRuntimeSessionsRequest, opts ...grpc.CallOption) (*ListPluginRuntimeSessionsResponse, error)
 	StopSession(ctx context.Context, in *StopPluginRuntimeSessionRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	BindHostService(ctx context.Context, in *BindPluginRuntimeHostServiceRequest, opts ...grpc.CallOption) (*PluginRuntimeHostServiceBinding, error)
 	StartPlugin(ctx context.Context, in *StartHostedPluginRequest, opts ...grpc.CallOption) (*HostedPlugin, error)
@@ -180,6 +182,16 @@ func (c *pluginRuntimeProviderClient) GetSession(ctx context.Context, in *GetPlu
 	return out, nil
 }
 
+func (c *pluginRuntimeProviderClient) ListSessions(ctx context.Context, in *ListPluginRuntimeSessionsRequest, opts ...grpc.CallOption) (*ListPluginRuntimeSessionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListPluginRuntimeSessionsResponse)
+	err := c.cc.Invoke(ctx, PluginRuntimeProvider_ListSessions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *pluginRuntimeProviderClient) StopSession(ctx context.Context, in *StopPluginRuntimeSessionRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(emptypb.Empty)
@@ -217,6 +229,7 @@ type PluginRuntimeProviderServer interface {
 	GetSupport(context.Context, *emptypb.Empty) (*PluginRuntimeSupport, error)
 	StartSession(context.Context, *StartPluginRuntimeSessionRequest) (*PluginRuntimeSession, error)
 	GetSession(context.Context, *GetPluginRuntimeSessionRequest) (*PluginRuntimeSession, error)
+	ListSessions(context.Context, *ListPluginRuntimeSessionsRequest) (*ListPluginRuntimeSessionsResponse, error)
 	StopSession(context.Context, *StopPluginRuntimeSessionRequest) (*emptypb.Empty, error)
 	BindHostService(context.Context, *BindPluginRuntimeHostServiceRequest) (*PluginRuntimeHostServiceBinding, error)
 	StartPlugin(context.Context, *StartHostedPluginRequest) (*HostedPlugin, error)
@@ -238,6 +251,9 @@ func (UnimplementedPluginRuntimeProviderServer) StartSession(context.Context, *S
 }
 func (UnimplementedPluginRuntimeProviderServer) GetSession(context.Context, *GetPluginRuntimeSessionRequest) (*PluginRuntimeSession, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetSession not implemented")
+}
+func (UnimplementedPluginRuntimeProviderServer) ListSessions(context.Context, *ListPluginRuntimeSessionsRequest) (*ListPluginRuntimeSessionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListSessions not implemented")
 }
 func (UnimplementedPluginRuntimeProviderServer) StopSession(context.Context, *StopPluginRuntimeSessionRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method StopSession not implemented")
@@ -323,6 +339,24 @@ func _PluginRuntimeProvider_GetSession_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PluginRuntimeProvider_ListSessions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListPluginRuntimeSessionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginRuntimeProviderServer).ListSessions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginRuntimeProvider_ListSessions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginRuntimeProviderServer).ListSessions(ctx, req.(*ListPluginRuntimeSessionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _PluginRuntimeProvider_StopSession_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(StopPluginRuntimeSessionRequest)
 	if err := dec(in); err != nil {
@@ -395,6 +429,10 @@ var PluginRuntimeProvider_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetSession",
 			Handler:    _PluginRuntimeProvider_GetSession_Handler,
+		},
+		{
+			MethodName: "ListSessions",
+			Handler:    _PluginRuntimeProvider_ListSessions_Handler,
 		},
 		{
 			MethodName: "StopSession",

--- a/sdk/proto/v1/pluginruntime.proto
+++ b/sdk/proto/v1/pluginruntime.proto
@@ -43,6 +43,15 @@ message PluginRuntimeSession {
   string id = 1;
   string state = 2;
   map<string, string> metadata = 3;
+  PluginRuntimeSessionLifecycle lifecycle = 4;
+  string state_reason = 5;
+  string state_message = 6;
+}
+
+message PluginRuntimeSessionLifecycle {
+  google.protobuf.Timestamp started_at = 1;
+  google.protobuf.Timestamp recommended_drain_at = 2;
+  google.protobuf.Timestamp expires_at = 3;
 }
 
 message StartPluginRuntimeSessionRequest {
@@ -54,6 +63,12 @@ message StartPluginRuntimeSessionRequest {
 
 message GetPluginRuntimeSessionRequest {
   string session_id = 1;
+}
+
+message ListPluginRuntimeSessionsRequest {}
+
+message ListPluginRuntimeSessionsResponse {
+  repeated PluginRuntimeSession sessions = 1;
 }
 
 message StopPluginRuntimeSessionRequest {
@@ -133,6 +148,7 @@ service PluginRuntimeProvider {
   rpc GetSupport(google.protobuf.Empty) returns (PluginRuntimeSupport);
   rpc StartSession(StartPluginRuntimeSessionRequest) returns (PluginRuntimeSession);
   rpc GetSession(GetPluginRuntimeSessionRequest) returns (PluginRuntimeSession);
+  rpc ListSessions(ListPluginRuntimeSessionsRequest) returns (ListPluginRuntimeSessionsResponse);
   rpc StopSession(StopPluginRuntimeSessionRequest) returns (google.protobuf.Empty);
   rpc BindHostService(BindPluginRuntimeHostServiceRequest) returns (PluginRuntimeHostServiceBinding);
   rpc StartPlugin(StartHostedPluginRequest) returns (HostedPlugin);

--- a/sdk/typescript/gen/v1/pluginruntime_pb.ts
+++ b/sdk/typescript/gen/v1/pluginruntime_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file v1/pluginruntime.proto.
  */
 export const file_v1_pluginruntime: GenFile = /*@__PURE__*/
-  fileDesc("ChZ2MS9wbHVnaW5ydW50aW1lLnByb3RvEhNnZXN0YWx0LnByb3ZpZGVyLnYxIjwKHFBsdWdpblJ1bnRpbWVFeGVjdXRpb25UYXJnZXQSDAoEZ29vcxgBIAEoCRIOCgZnb2FyY2gYAiABKAki1QIKFFBsdWdpblJ1bnRpbWVTdXBwb3J0EhgKEGNhbl9ob3N0X3BsdWdpbnMYASABKAgSUAoTaG9zdF9zZXJ2aWNlX2FjY2VzcxgCIAEoDjIzLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUhvc3RTZXJ2aWNlQWNjZXNzEkEKC2VncmVzc19tb2RlGAMgASgOMiwuZ2VzdGFsdC5wcm92aWRlci52MS5QbHVnaW5SdW50aW1lRWdyZXNzTW9kZRJBCgtsYXVuY2hfbW9kZRgEIAEoDjIsLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUxhdW5jaE1vZGUSSwoQZXhlY3V0aW9uX3RhcmdldBgFIAEoCzIxLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUV4ZWN1dGlvblRhcmdldCKtAQoUUGx1Z2luUnVudGltZVNlc3Npb24SCgoCaWQYASABKAkSDQoFc3RhdGUYAiABKAkSSQoIbWV0YWRhdGEYAyADKAsyNy5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVTZXNzaW9uLk1ldGFkYXRhRW50cnkaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIuABCiBTdGFydFBsdWdpblJ1bnRpbWVTZXNzaW9uUmVxdWVzdBITCgtwbHVnaW5fbmFtZRgBIAEoCRIQCgh0ZW1wbGF0ZRgCIAEoCRINCgVpbWFnZRgDIAEoCRJVCghtZXRhZGF0YRgEIAMoCzJDLmdlc3RhbHQucHJvdmlkZXIudjEuU3RhcnRQbHVnaW5SdW50aW1lU2Vzc2lvblJlcXVlc3QuTWV0YWRhdGFFbnRyeRovCg1NZXRhZGF0YUVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiNAoeR2V0UGx1Z2luUnVudGltZVNlc3Npb25SZXF1ZXN0EhIKCnNlc3Npb25faWQYASABKAkiNQofU3RvcFBsdWdpblJ1bnRpbWVTZXNzaW9uUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJIjQKHVBsdWdpblJ1bnRpbWVIb3N0U2VydmljZVJlbGF5EhMKC2RpYWxfdGFyZ2V0GAEgASgJIpMBCiNCaW5kUGx1Z2luUnVudGltZUhvc3RTZXJ2aWNlUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEg8KB2Vudl92YXIYAiABKAkSQQoFcmVsYXkYBCABKAsyMi5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVIb3N0U2VydmljZVJlbGF5SgQIAxAEIpsBCh9QbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VCaW5kaW5nEgoKAmlkGAEgASgJEhIKCnNlc3Npb25faWQYAiABKAkSDwoHZW52X3ZhchgDIAEoCRJBCgVyZWxheRgFIAEoCzIyLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUhvc3RTZXJ2aWNlUmVsYXlKBAgEEAUiqwIKGFN0YXJ0SG9zdGVkUGx1Z2luUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEhMKC3BsdWdpbl9uYW1lGAIgASgJEg8KB2NvbW1hbmQYAyABKAkSDAoEYXJncxgEIAMoCRJDCgNlbnYYBSADKAsyNi5nZXN0YWx0LnByb3ZpZGVyLnYxLlN0YXJ0SG9zdGVkUGx1Z2luUmVxdWVzdC5FbnZFbnRyeRISCgpidW5kbGVfZGlyGAYgASgJEhUKDWFsbG93ZWRfaG9zdHMYByADKAkSFgoOZGVmYXVsdF9hY3Rpb24YCCABKAkSEwoLaG9zdF9iaW5hcnkYCSABKAkaKgoIRW52RW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASJYCgxIb3N0ZWRQbHVnaW4SCgoCaWQYASABKAkSEgoKc2Vzc2lvbl9pZBgCIAEoCRITCgtwbHVnaW5fbmFtZRgDIAEoCRITCgtkaWFsX3RhcmdldBgEIAEoCSKqAQoVUGx1Z2luUnVudGltZUxvZ0VudHJ5EjsKBnN0cmVhbRgBIAEoDjIrLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUxvZ1N0cmVhbRIPCgdtZXNzYWdlGAIgASgJEi8KC29ic2VydmVkX2F0GAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBISCgpzb3VyY2Vfc2VxGAQgASgDIm4KHkFwcGVuZFBsdWdpblJ1bnRpbWVMb2dzUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEjgKBGxvZ3MYAiADKAsyKi5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVMb2dFbnRyeSIzCh9BcHBlbmRQbHVnaW5SdW50aW1lTG9nc1Jlc3BvbnNlEhAKCGxhc3Rfc2VxGAEgASgDKrABCh5QbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VBY2Nlc3MSMgouUExVR0lOX1JVTlRJTUVfSE9TVF9TRVJWSUNFX0FDQ0VTU19VTlNQRUNJRklFRBAAEisKJ1BMVUdJTl9SVU5USU1FX0hPU1RfU0VSVklDRV9BQ0NFU1NfTk9ORRABEi0KKVBMVUdJTl9SVU5USU1FX0hPU1RfU0VSVklDRV9BQ0NFU1NfRElSRUNUEAIquAEKF1BsdWdpblJ1bnRpbWVFZ3Jlc3NNb2RlEioKJlBMVUdJTl9SVU5USU1FX0VHUkVTU19NT0RFX1VOU1BFQ0lGSUVEEAASIwofUExVR0lOX1JVTlRJTUVfRUdSRVNTX01PREVfTk9ORRABEiMKH1BMVUdJTl9SVU5USU1FX0VHUkVTU19NT0RFX0NJRFIQAhInCiNQTFVHSU5fUlVOVElNRV9FR1JFU1NfTU9ERV9IT1NUTkFNRRADKpYBChdQbHVnaW5SdW50aW1lTGF1bmNoTW9kZRIqCiZQTFVHSU5fUlVOVElNRV9MQVVOQ0hfTU9ERV9VTlNQRUNJRklFRBAAEiUKIVBMVUdJTl9SVU5USU1FX0xBVU5DSF9NT0RFX0JVTkRMRRABEigKJFBMVUdJTl9SVU5USU1FX0xBVU5DSF9NT0RFX0hPU1RfUEFUSBACKrYBChZQbHVnaW5SdW50aW1lTG9nU3RyZWFtEikKJVBMVUdJTl9SVU5USU1FX0xPR19TVFJFQU1fVU5TUEVDSUZJRUQQABIkCiBQTFVHSU5fUlVOVElNRV9MT0dfU1RSRUFNX1NURE9VVBABEiQKIFBMVUdJTl9SVU5USU1FX0xPR19TVFJFQU1fU1RERVJSEAISJQohUExVR0lOX1JVTlRJTUVfTE9HX1NUUkVBTV9SVU5USU1FEAMyjwEKFFBsdWdpblJ1bnRpbWVMb2dIb3N0EncKCkFwcGVuZExvZ3MSMy5nZXN0YWx0LnByb3ZpZGVyLnYxLkFwcGVuZFBsdWdpblJ1bnRpbWVMb2dzUmVxdWVzdBo0Lmdlc3RhbHQucHJvdmlkZXIudjEuQXBwZW5kUGx1Z2luUnVudGltZUxvZ3NSZXNwb25zZTKKBQoVUGx1Z2luUnVudGltZVByb3ZpZGVyEk8KCkdldFN1cHBvcnQSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaKS5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVTdXBwb3J0EnAKDFN0YXJ0U2Vzc2lvbhI1Lmdlc3RhbHQucHJvdmlkZXIudjEuU3RhcnRQbHVnaW5SdW50aW1lU2Vzc2lvblJlcXVlc3QaKS5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVTZXNzaW9uEmwKCkdldFNlc3Npb24SMy5nZXN0YWx0LnByb3ZpZGVyLnYxLkdldFBsdWdpblJ1bnRpbWVTZXNzaW9uUmVxdWVzdBopLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZVNlc3Npb24SWwoLU3RvcFNlc3Npb24SNC5nZXN0YWx0LnByb3ZpZGVyLnYxLlN0b3BQbHVnaW5SdW50aW1lU2Vzc2lvblJlcXVlc3QaFi5nb29nbGUucHJvdG9idWYuRW1wdHkSgQEKD0JpbmRIb3N0U2VydmljZRI4Lmdlc3RhbHQucHJvdmlkZXIudjEuQmluZFBsdWdpblJ1bnRpbWVIb3N0U2VydmljZVJlcXVlc3QaNC5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVIb3N0U2VydmljZUJpbmRpbmcSXwoLU3RhcnRQbHVnaW4SLS5nZXN0YWx0LnByb3ZpZGVyLnYxLlN0YXJ0SG9zdGVkUGx1Z2luUmVxdWVzdBohLmdlc3RhbHQucHJvdmlkZXIudjEuSG9zdGVkUGx1Z2luQjtaOWdpdGh1Yi5jb20vdmFsb24tdGVjaG5vbG9naWVzL2dlc3RhbHQvc2RrL2dvL2dlbi92MTtwcm90b2IGcHJvdG8z", [file_google_protobuf_empty, file_google_protobuf_timestamp]);
+  fileDesc("ChZ2MS9wbHVnaW5ydW50aW1lLnByb3RvEhNnZXN0YWx0LnByb3ZpZGVyLnYxIjwKHFBsdWdpblJ1bnRpbWVFeGVjdXRpb25UYXJnZXQSDAoEZ29vcxgBIAEoCRIOCgZnb2FyY2gYAiABKAki1QIKFFBsdWdpblJ1bnRpbWVTdXBwb3J0EhgKEGNhbl9ob3N0X3BsdWdpbnMYASABKAgSUAoTaG9zdF9zZXJ2aWNlX2FjY2VzcxgCIAEoDjIzLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUhvc3RTZXJ2aWNlQWNjZXNzEkEKC2VncmVzc19tb2RlGAMgASgOMiwuZ2VzdGFsdC5wcm92aWRlci52MS5QbHVnaW5SdW50aW1lRWdyZXNzTW9kZRJBCgtsYXVuY2hfbW9kZRgEIAEoDjIsLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUxhdW5jaE1vZGUSSwoQZXhlY3V0aW9uX3RhcmdldBgFIAEoCzIxLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUV4ZWN1dGlvblRhcmdldCKhAgoUUGx1Z2luUnVudGltZVNlc3Npb24SCgoCaWQYASABKAkSDQoFc3RhdGUYAiABKAkSSQoIbWV0YWRhdGEYAyADKAsyNy5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVTZXNzaW9uLk1ldGFkYXRhRW50cnkSRQoJbGlmZWN5Y2xlGAQgASgLMjIuZ2VzdGFsdC5wcm92aWRlci52MS5QbHVnaW5SdW50aW1lU2Vzc2lvbkxpZmVjeWNsZRIUCgxzdGF0ZV9yZWFzb24YBSABKAkSFQoNc3RhdGVfbWVzc2FnZRgGIAEoCRovCg1NZXRhZGF0YUVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiuQEKHVBsdWdpblJ1bnRpbWVTZXNzaW9uTGlmZWN5Y2xlEi4KCnN0YXJ0ZWRfYXQYASABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEjgKFHJlY29tbWVuZGVkX2RyYWluX2F0GAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIuCgpleHBpcmVzX2F0GAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCLgAQogU3RhcnRQbHVnaW5SdW50aW1lU2Vzc2lvblJlcXVlc3QSEwoLcGx1Z2luX25hbWUYASABKAkSEAoIdGVtcGxhdGUYAiABKAkSDQoFaW1hZ2UYAyABKAkSVQoIbWV0YWRhdGEYBCADKAsyQy5nZXN0YWx0LnByb3ZpZGVyLnYxLlN0YXJ0UGx1Z2luUnVudGltZVNlc3Npb25SZXF1ZXN0Lk1ldGFkYXRhRW50cnkaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIjQKHkdldFBsdWdpblJ1bnRpbWVTZXNzaW9uUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJIiIKIExpc3RQbHVnaW5SdW50aW1lU2Vzc2lvbnNSZXF1ZXN0ImAKIUxpc3RQbHVnaW5SdW50aW1lU2Vzc2lvbnNSZXNwb25zZRI7CghzZXNzaW9ucxgBIAMoCzIpLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZVNlc3Npb24iNQofU3RvcFBsdWdpblJ1bnRpbWVTZXNzaW9uUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJIjQKHVBsdWdpblJ1bnRpbWVIb3N0U2VydmljZVJlbGF5EhMKC2RpYWxfdGFyZ2V0GAEgASgJIpMBCiNCaW5kUGx1Z2luUnVudGltZUhvc3RTZXJ2aWNlUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEg8KB2Vudl92YXIYAiABKAkSQQoFcmVsYXkYBCABKAsyMi5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVIb3N0U2VydmljZVJlbGF5SgQIAxAEIpsBCh9QbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VCaW5kaW5nEgoKAmlkGAEgASgJEhIKCnNlc3Npb25faWQYAiABKAkSDwoHZW52X3ZhchgDIAEoCRJBCgVyZWxheRgFIAEoCzIyLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUhvc3RTZXJ2aWNlUmVsYXlKBAgEEAUiqwIKGFN0YXJ0SG9zdGVkUGx1Z2luUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEhMKC3BsdWdpbl9uYW1lGAIgASgJEg8KB2NvbW1hbmQYAyABKAkSDAoEYXJncxgEIAMoCRJDCgNlbnYYBSADKAsyNi5nZXN0YWx0LnByb3ZpZGVyLnYxLlN0YXJ0SG9zdGVkUGx1Z2luUmVxdWVzdC5FbnZFbnRyeRISCgpidW5kbGVfZGlyGAYgASgJEhUKDWFsbG93ZWRfaG9zdHMYByADKAkSFgoOZGVmYXVsdF9hY3Rpb24YCCABKAkSEwoLaG9zdF9iaW5hcnkYCSABKAkaKgoIRW52RW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASJYCgxIb3N0ZWRQbHVnaW4SCgoCaWQYASABKAkSEgoKc2Vzc2lvbl9pZBgCIAEoCRITCgtwbHVnaW5fbmFtZRgDIAEoCRITCgtkaWFsX3RhcmdldBgEIAEoCSKqAQoVUGx1Z2luUnVudGltZUxvZ0VudHJ5EjsKBnN0cmVhbRgBIAEoDjIrLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUxvZ1N0cmVhbRIPCgdtZXNzYWdlGAIgASgJEi8KC29ic2VydmVkX2F0GAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBISCgpzb3VyY2Vfc2VxGAQgASgDIm4KHkFwcGVuZFBsdWdpblJ1bnRpbWVMb2dzUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEjgKBGxvZ3MYAiADKAsyKi5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVMb2dFbnRyeSIzCh9BcHBlbmRQbHVnaW5SdW50aW1lTG9nc1Jlc3BvbnNlEhAKCGxhc3Rfc2VxGAEgASgDKrABCh5QbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VBY2Nlc3MSMgouUExVR0lOX1JVTlRJTUVfSE9TVF9TRVJWSUNFX0FDQ0VTU19VTlNQRUNJRklFRBAAEisKJ1BMVUdJTl9SVU5USU1FX0hPU1RfU0VSVklDRV9BQ0NFU1NfTk9ORRABEi0KKVBMVUdJTl9SVU5USU1FX0hPU1RfU0VSVklDRV9BQ0NFU1NfRElSRUNUEAIquAEKF1BsdWdpblJ1bnRpbWVFZ3Jlc3NNb2RlEioKJlBMVUdJTl9SVU5USU1FX0VHUkVTU19NT0RFX1VOU1BFQ0lGSUVEEAASIwofUExVR0lOX1JVTlRJTUVfRUdSRVNTX01PREVfTk9ORRABEiMKH1BMVUdJTl9SVU5USU1FX0VHUkVTU19NT0RFX0NJRFIQAhInCiNQTFVHSU5fUlVOVElNRV9FR1JFU1NfTU9ERV9IT1NUTkFNRRADKpYBChdQbHVnaW5SdW50aW1lTGF1bmNoTW9kZRIqCiZQTFVHSU5fUlVOVElNRV9MQVVOQ0hfTU9ERV9VTlNQRUNJRklFRBAAEiUKIVBMVUdJTl9SVU5USU1FX0xBVU5DSF9NT0RFX0JVTkRMRRABEigKJFBMVUdJTl9SVU5USU1FX0xBVU5DSF9NT0RFX0hPU1RfUEFUSBACKrYBChZQbHVnaW5SdW50aW1lTG9nU3RyZWFtEikKJVBMVUdJTl9SVU5USU1FX0xPR19TVFJFQU1fVU5TUEVDSUZJRUQQABIkCiBQTFVHSU5fUlVOVElNRV9MT0dfU1RSRUFNX1NURE9VVBABEiQKIFBMVUdJTl9SVU5USU1FX0xPR19TVFJFQU1fU1RERVJSEAISJQohUExVR0lOX1JVTlRJTUVfTE9HX1NUUkVBTV9SVU5USU1FEAMyjwEKFFBsdWdpblJ1bnRpbWVMb2dIb3N0EncKCkFwcGVuZExvZ3MSMy5nZXN0YWx0LnByb3ZpZGVyLnYxLkFwcGVuZFBsdWdpblJ1bnRpbWVMb2dzUmVxdWVzdBo0Lmdlc3RhbHQucHJvdmlkZXIudjEuQXBwZW5kUGx1Z2luUnVudGltZUxvZ3NSZXNwb25zZTKJBgoVUGx1Z2luUnVudGltZVByb3ZpZGVyEk8KCkdldFN1cHBvcnQSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaKS5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVTdXBwb3J0EnAKDFN0YXJ0U2Vzc2lvbhI1Lmdlc3RhbHQucHJvdmlkZXIudjEuU3RhcnRQbHVnaW5SdW50aW1lU2Vzc2lvblJlcXVlc3QaKS5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVTZXNzaW9uEmwKCkdldFNlc3Npb24SMy5nZXN0YWx0LnByb3ZpZGVyLnYxLkdldFBsdWdpblJ1bnRpbWVTZXNzaW9uUmVxdWVzdBopLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZVNlc3Npb24SfQoMTGlzdFNlc3Npb25zEjUuZ2VzdGFsdC5wcm92aWRlci52MS5MaXN0UGx1Z2luUnVudGltZVNlc3Npb25zUmVxdWVzdBo2Lmdlc3RhbHQucHJvdmlkZXIudjEuTGlzdFBsdWdpblJ1bnRpbWVTZXNzaW9uc1Jlc3BvbnNlElsKC1N0b3BTZXNzaW9uEjQuZ2VzdGFsdC5wcm92aWRlci52MS5TdG9wUGx1Z2luUnVudGltZVNlc3Npb25SZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EoEBCg9CaW5kSG9zdFNlcnZpY2USOC5nZXN0YWx0LnByb3ZpZGVyLnYxLkJpbmRQbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VSZXF1ZXN0GjQuZ2VzdGFsdC5wcm92aWRlci52MS5QbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VCaW5kaW5nEl8KC1N0YXJ0UGx1Z2luEi0uZ2VzdGFsdC5wcm92aWRlci52MS5TdGFydEhvc3RlZFBsdWdpblJlcXVlc3QaIS5nZXN0YWx0LnByb3ZpZGVyLnYxLkhvc3RlZFBsdWdpbkI7WjlnaXRodWIuY29tL3ZhbG9uLXRlY2hub2xvZ2llcy9nZXN0YWx0L3Nkay9nby9nZW4vdjE7cHJvdG9iBnByb3RvMw", [file_google_protobuf_empty, file_google_protobuf_timestamp]);
 
 /**
  * @generated from message gestalt.provider.v1.PluginRuntimeExecutionTarget
@@ -91,6 +91,21 @@ export type PluginRuntimeSession = Message<"gestalt.provider.v1.PluginRuntimeSes
    * @generated from field: map<string, string> metadata = 3;
    */
   metadata: { [key: string]: string };
+
+  /**
+   * @generated from field: gestalt.provider.v1.PluginRuntimeSessionLifecycle lifecycle = 4;
+   */
+  lifecycle?: PluginRuntimeSessionLifecycle | undefined;
+
+  /**
+   * @generated from field: string state_reason = 5;
+   */
+  stateReason: string;
+
+  /**
+   * @generated from field: string state_message = 6;
+   */
+  stateMessage: string;
 };
 
 /**
@@ -99,6 +114,33 @@ export type PluginRuntimeSession = Message<"gestalt.provider.v1.PluginRuntimeSes
  */
 export const PluginRuntimeSessionSchema: GenMessage<PluginRuntimeSession> = /*@__PURE__*/
   messageDesc(file_v1_pluginruntime, 2);
+
+/**
+ * @generated from message gestalt.provider.v1.PluginRuntimeSessionLifecycle
+ */
+export type PluginRuntimeSessionLifecycle = Message<"gestalt.provider.v1.PluginRuntimeSessionLifecycle"> & {
+  /**
+   * @generated from field: google.protobuf.Timestamp started_at = 1;
+   */
+  startedAt?: Timestamp | undefined;
+
+  /**
+   * @generated from field: google.protobuf.Timestamp recommended_drain_at = 2;
+   */
+  recommendedDrainAt?: Timestamp | undefined;
+
+  /**
+   * @generated from field: google.protobuf.Timestamp expires_at = 3;
+   */
+  expiresAt?: Timestamp | undefined;
+};
+
+/**
+ * Describes the message gestalt.provider.v1.PluginRuntimeSessionLifecycle.
+ * Use `create(PluginRuntimeSessionLifecycleSchema)` to create a new message.
+ */
+export const PluginRuntimeSessionLifecycleSchema: GenMessage<PluginRuntimeSessionLifecycle> = /*@__PURE__*/
+  messageDesc(file_v1_pluginruntime, 3);
 
 /**
  * @generated from message gestalt.provider.v1.StartPluginRuntimeSessionRequest
@@ -130,7 +172,7 @@ export type StartPluginRuntimeSessionRequest = Message<"gestalt.provider.v1.Star
  * Use `create(StartPluginRuntimeSessionRequestSchema)` to create a new message.
  */
 export const StartPluginRuntimeSessionRequestSchema: GenMessage<StartPluginRuntimeSessionRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 3);
+  messageDesc(file_v1_pluginruntime, 4);
 
 /**
  * @generated from message gestalt.provider.v1.GetPluginRuntimeSessionRequest
@@ -147,7 +189,37 @@ export type GetPluginRuntimeSessionRequest = Message<"gestalt.provider.v1.GetPlu
  * Use `create(GetPluginRuntimeSessionRequestSchema)` to create a new message.
  */
 export const GetPluginRuntimeSessionRequestSchema: GenMessage<GetPluginRuntimeSessionRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 4);
+  messageDesc(file_v1_pluginruntime, 5);
+
+/**
+ * @generated from message gestalt.provider.v1.ListPluginRuntimeSessionsRequest
+ */
+export type ListPluginRuntimeSessionsRequest = Message<"gestalt.provider.v1.ListPluginRuntimeSessionsRequest"> & {
+};
+
+/**
+ * Describes the message gestalt.provider.v1.ListPluginRuntimeSessionsRequest.
+ * Use `create(ListPluginRuntimeSessionsRequestSchema)` to create a new message.
+ */
+export const ListPluginRuntimeSessionsRequestSchema: GenMessage<ListPluginRuntimeSessionsRequest> = /*@__PURE__*/
+  messageDesc(file_v1_pluginruntime, 6);
+
+/**
+ * @generated from message gestalt.provider.v1.ListPluginRuntimeSessionsResponse
+ */
+export type ListPluginRuntimeSessionsResponse = Message<"gestalt.provider.v1.ListPluginRuntimeSessionsResponse"> & {
+  /**
+   * @generated from field: repeated gestalt.provider.v1.PluginRuntimeSession sessions = 1;
+   */
+  sessions: PluginRuntimeSession[];
+};
+
+/**
+ * Describes the message gestalt.provider.v1.ListPluginRuntimeSessionsResponse.
+ * Use `create(ListPluginRuntimeSessionsResponseSchema)` to create a new message.
+ */
+export const ListPluginRuntimeSessionsResponseSchema: GenMessage<ListPluginRuntimeSessionsResponse> = /*@__PURE__*/
+  messageDesc(file_v1_pluginruntime, 7);
 
 /**
  * @generated from message gestalt.provider.v1.StopPluginRuntimeSessionRequest
@@ -164,7 +236,7 @@ export type StopPluginRuntimeSessionRequest = Message<"gestalt.provider.v1.StopP
  * Use `create(StopPluginRuntimeSessionRequestSchema)` to create a new message.
  */
 export const StopPluginRuntimeSessionRequestSchema: GenMessage<StopPluginRuntimeSessionRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 5);
+  messageDesc(file_v1_pluginruntime, 8);
 
 /**
  * @generated from message gestalt.provider.v1.PluginRuntimeHostServiceRelay
@@ -181,7 +253,7 @@ export type PluginRuntimeHostServiceRelay = Message<"gestalt.provider.v1.PluginR
  * Use `create(PluginRuntimeHostServiceRelaySchema)` to create a new message.
  */
 export const PluginRuntimeHostServiceRelaySchema: GenMessage<PluginRuntimeHostServiceRelay> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 6);
+  messageDesc(file_v1_pluginruntime, 9);
 
 /**
  * @generated from message gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
@@ -208,7 +280,7 @@ export type BindPluginRuntimeHostServiceRequest = Message<"gestalt.provider.v1.B
  * Use `create(BindPluginRuntimeHostServiceRequestSchema)` to create a new message.
  */
 export const BindPluginRuntimeHostServiceRequestSchema: GenMessage<BindPluginRuntimeHostServiceRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 7);
+  messageDesc(file_v1_pluginruntime, 10);
 
 /**
  * @generated from message gestalt.provider.v1.PluginRuntimeHostServiceBinding
@@ -240,7 +312,7 @@ export type PluginRuntimeHostServiceBinding = Message<"gestalt.provider.v1.Plugi
  * Use `create(PluginRuntimeHostServiceBindingSchema)` to create a new message.
  */
 export const PluginRuntimeHostServiceBindingSchema: GenMessage<PluginRuntimeHostServiceBinding> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 8);
+  messageDesc(file_v1_pluginruntime, 11);
 
 /**
  * StartHostedPluginRequest describes the plugin process to launch inside a
@@ -302,7 +374,7 @@ export type StartHostedPluginRequest = Message<"gestalt.provider.v1.StartHostedP
  * Use `create(StartHostedPluginRequestSchema)` to create a new message.
  */
 export const StartHostedPluginRequestSchema: GenMessage<StartHostedPluginRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 9);
+  messageDesc(file_v1_pluginruntime, 12);
 
 /**
  * @generated from message gestalt.provider.v1.HostedPlugin
@@ -334,7 +406,7 @@ export type HostedPlugin = Message<"gestalt.provider.v1.HostedPlugin"> & {
  * Use `create(HostedPluginSchema)` to create a new message.
  */
 export const HostedPluginSchema: GenMessage<HostedPlugin> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 10);
+  messageDesc(file_v1_pluginruntime, 13);
 
 /**
  * @generated from message gestalt.provider.v1.PluginRuntimeLogEntry
@@ -366,7 +438,7 @@ export type PluginRuntimeLogEntry = Message<"gestalt.provider.v1.PluginRuntimeLo
  * Use `create(PluginRuntimeLogEntrySchema)` to create a new message.
  */
 export const PluginRuntimeLogEntrySchema: GenMessage<PluginRuntimeLogEntry> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 11);
+  messageDesc(file_v1_pluginruntime, 14);
 
 /**
  * @generated from message gestalt.provider.v1.AppendPluginRuntimeLogsRequest
@@ -388,7 +460,7 @@ export type AppendPluginRuntimeLogsRequest = Message<"gestalt.provider.v1.Append
  * Use `create(AppendPluginRuntimeLogsRequestSchema)` to create a new message.
  */
 export const AppendPluginRuntimeLogsRequestSchema: GenMessage<AppendPluginRuntimeLogsRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 12);
+  messageDesc(file_v1_pluginruntime, 15);
 
 /**
  * @generated from message gestalt.provider.v1.AppendPluginRuntimeLogsResponse
@@ -405,7 +477,7 @@ export type AppendPluginRuntimeLogsResponse = Message<"gestalt.provider.v1.Appen
  * Use `create(AppendPluginRuntimeLogsResponseSchema)` to create a new message.
  */
 export const AppendPluginRuntimeLogsResponseSchema: GenMessage<AppendPluginRuntimeLogsResponse> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 13);
+  messageDesc(file_v1_pluginruntime, 16);
 
 /**
  * @generated from enum gestalt.provider.v1.PluginRuntimeHostServiceAccess
@@ -563,6 +635,14 @@ export const PluginRuntimeProvider: GenService<{
     methodKind: "unary";
     input: typeof GetPluginRuntimeSessionRequestSchema;
     output: typeof PluginRuntimeSessionSchema;
+  },
+  /**
+   * @generated from rpc gestalt.provider.v1.PluginRuntimeProvider.ListSessions
+   */
+  listSessions: {
+    methodKind: "unary";
+    input: typeof ListPluginRuntimeSessionsRequestSchema;
+    output: typeof ListPluginRuntimeSessionsResponseSchema;
   },
   /**
    * @generated from rpc gestalt.provider.v1.PluginRuntimeProvider.StopSession


### PR DESCRIPTION
## Summary

Adds runtime-provider-owned session lifecycle to the plugin runtime contract and teaches hosted agent pools to rotate runtime-backed providers before provider-reported drain/expiry deadlines.

This keeps user YAML unchanged: lifecycle is provider-reported runtime state, not new user config.

## New Interfaces

```proto
message PluginRuntimeSession {
  string id = 1;
  string state = 2;
  map<string, string> metadata = 3;
  PluginRuntimeSessionLifecycle lifecycle = 4;
  string state_reason = 5;
  string state_message = 6;
}

message PluginRuntimeSessionLifecycle {
  google.protobuf.Timestamp started_at = 1;
  google.protobuf.Timestamp recommended_drain_at = 2;
  google.protobuf.Timestamp expires_at = 3;
}

message ListPluginRuntimeSessionsRequest {}

message ListPluginRuntimeSessionsResponse {
  repeated PluginRuntimeSession sessions = 1;
}

service PluginRuntimeProvider {
  rpc ListSessions(ListPluginRuntimeSessionsRequest) returns (ListPluginRuntimeSessionsResponse);
}
```

Internal Go runtime sessions now expose the same lifecycle data:

```go
type Session struct {
    ID           string
    State        SessionState
    Metadata     map[string]string
    Lifecycle    *SessionLifecycle
    StateReason  string
    StateMessage string
}

type SessionLifecycle struct {
    StartedAt          *time.Time
    RecommendedDrainAt *time.Time
    ExpiresAt          *time.Time
}
```

## Example Provider Response

```json
{
  "id": "session-modal-000001",
  "state": "running",
  "metadata": {
    "provider_kind": "agent",
    "provider_name": "simple"
  },
  "lifecycle": {
    "startedAt": "2026-04-27T14:00:00Z",
    "recommendedDrainAt": "2026-04-27T14:04:00Z",
    "expiresAt": "2026-04-27T14:05:00Z"
  },
  "stateReason": "",
  "stateMessage": ""
}
```

## YAML Example

No new config fields are required. Existing runtime lifecycle config continues to control host policy:

```yaml
providers:
  agent:
    simple:
      command: ./agent-provider
      indexeddb:
        provider: agent_state
      runtime:
        provider: modal
        image: python:3.14-slim-bookworm
        minReadyInstances: 1
        maxReadyInstances: 1
        startupTimeout: 5m
        healthCheckInterval: 30s
        restartPolicy: always
        drainTimeout: 2m
```

## Behavior

- Hosted agent backend launch now keeps the runtime provider/session handle alongside the agent provider.
- Health checks refresh runtime session lifecycle via `GetSession`.
- Backends are replaced when the runtime session is terminal, expired, or past the effective drain deadline.
- Effective drain deadline is the earlier of provider `recommended_drain_at` and a host-safe deadline derived from `expires_at`.
- Expiry-only runtimes get a stable backend drain deadline so the host does not keep moving the deadline forward on every health check.
- New turns avoid draining session backends unless they are retrying an already-recorded turn; reads, live turns, and interaction resolution can still use draining backends.
- `ListSessions` is now a real runtime-provider RPC; the executable client keeps an `Unimplemented` fallback for older providers.

## Validation

```bash
go test ./internal/pluginruntime ./internal/bootstrap -count=1
(cd sdk/go && go test ./...)
(cd gestaltd && go test ./...)
```

A separate reviewer agent checked the lifecycle/drain changes after implementation; final pass reported no remaining findings.