### PR TITLE
Document remote provider dev and harden TS socket cleanup

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -825,6 +825,74 @@ Repeated `--config` flags merge left-to-right, and `null` deletes inherited
 entries. That makes it possible to boot some supporting providers while
 suppressing others for a local session.
 
+### Attaching local code to a remote server
+
+Use remote provider dev when you want a remote Gestalt instance to handle auth,
+authorization, connections, secrets, and host services, but route a selected
+plugin implementation to your local machine. For a plugin that does not need
+provider config, a path-only attach is enough:
+
+```sh
+export GESTALT_URL=https://gestalt.example.com
+export GESTALT_API_KEY=vat_...
+
+gestaltd provider dev --remote "$GESTALT_URL" --path ./slack --name slack
+```
+
+The remote URL is environment-agnostic; it can point at any `gestaltd` instance
+that exposes provider-dev attach targets. The local command replaces only the
+source plugin attached by your authenticated session. Providers that are not
+attached locally continue to run through the remote server and its existing
+configuration.
+
+The attached plugin's config comes from the local command, not by copying the
+remote server's plugin config. If the plugin needs config values, invokes,
+mounted UI settings, or secret references, pass the same layered configs you
+would use for a real deployment and add the local source override on top:
+
+```sh
+gestaltd provider dev \
+  --remote "$GESTALT_URL" \
+  --config ./base.yaml \
+  --config ./prod.yaml \
+  --path ./slack \
+  --name slack
+```
+
+You can also attach every source-backed plugin from layered config overlays:
+
+```sh
+gestaltd provider dev \
+  --remote "$GESTALT_URL" \
+  --config ./base.yaml \
+  --config ./prod.yaml \
+  --config ./dev/local-plugins.yaml
+```
+
+This uses the same merge behavior as local development, so overlays can choose
+which plugins are local by adding source-backed plugin entries, and choose which
+remote/supporting providers are disabled by setting inherited config entries to
+`null`.
+Unlike local `provider dev` and `provider validate`, remote provider dev allows
+missing local environment substitutions while loading config. That keeps
+unrelated deployment-only env vars from blocking attach; if the attached plugin
+itself needs a literal env-substituted value, set that env var locally or pass a
+small local overlay.
+
+Remote provider dev tunnels plugin RPC, catalog, post-connect, host-service
+calls, and plugin-owned UI assets for mounted UIs that already exist on the
+remote server. For the `plugin/` + sibling `ui/` layout, the sibling UI is
+bundled for the local provider session automatically. Raw GraphQL surfaces are
+not tunneled in v1.
+
+For TypeScript plugins, `provider dev` runs `bun install` automatically when the
+plugin has a `package.json` but no `node_modules`. Source UI release builds use
+the same dependency bootstrap before `release.build.command` when that build
+workdir has a `package.json`. Keep `@valon-technologies/gestalt` current enough
+for the host-service features your plugin uses; for example, remote IndexedDB
+host-service calls require an SDK version with `tls://` host-service transport
+support.
+
 Hosted HTTP bindings stay layered on top of operations. A plugin defines an
 operation like `handle_command` in code, then attaches `/command` by declaring a
 manifest `spec.http` binding that targets that operation. Local source

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -58,7 +58,7 @@ gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml 
 gestaltd provider dev --path ./plugins/support
 gestaltd provider dev --path ./ui/dashboard
 gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080
-GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support
+GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --config ./base.yaml --config ./prod.yaml --path ./plugins/support --name support
 GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --config ./remote.yaml --config ./local-overrides.yaml
 gestaltd provider release --version 0.0.1-alpha.1
 gestaltd provider release --version 0.0.1-alpha.1 --platform all
@@ -73,13 +73,22 @@ keeps its existing config-relative behavior for backward compatibility.
 
 `provider dev --remote` is environment-agnostic: the URL is just the remote
 `gestaltd` instance to attach to. The local command only replaces source-backed
-plugin implementations for the authenticated principal that created the session;
-all non-local plugins, credentials, policies, and host services continue to
+plugin implementations for the authenticated principal that created the session.
+The attached plugin's config is sent by the local command, so use `--config`
+layers when the plugin needs config values, invokes, mounted UI settings, or
+secret references. All non-local plugins and remote host services continue to
 resolve through the remote instance. Remote servers expose attach targets for
 configured plugins that are registered on the remote server, and existing plugin
 authorization decides whether the authenticated caller may attach.
+Remote mode allows missing local environment substitutions while loading config
+so unrelated deploy-only env vars do not block attach.
 Remote mode tunnels plugin RPC, catalog, post-connect, host-service calls, and
 plugin-owned UI assets for mounted UIs that already exist on the remote server.
 Raw GraphQL surfaces are not tunneled in v1.
+
+For TypeScript source plugins, `provider dev` installs dependencies with
+`bun install` when a `package.json` is present and `node_modules` is missing.
+Source UI release builds use the same bootstrap before `release.build.command`
+when that build workdir has a `package.json`.
 
 See [Configuration](/configuration) for the relationship between `init`, `serve --locked`, and `validate`.

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -170,7 +170,7 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	}
 	defer cleanup()
 
-	cfg, err := config.LoadPaths(configPaths)
+	cfg, err := config.LoadPartialAllowMissingEnvPaths(configPaths)
 	if err != nil {
 		return fmt.Errorf("loading provider dev remote config: %w", err)
 	}
@@ -516,7 +516,7 @@ func prepareProviderRemoteConfigPaths(opts providerLocalCommandOptions) ([]strin
 	if err != nil {
 		return nil, cleanup, err
 	}
-	resolvedKey, err := resolveProviderLocalPluginKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
+	resolvedKey, err := resolveProviderRemotePluginKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
 	if err != nil {
 		return nil, cleanup, err
 	}
@@ -691,7 +691,6 @@ func providerRemoteUIManifestPath(cfg *config.Config, target providerRemoteTarge
 		if err != nil || ok {
 			return manifestPath, ok, err
 		}
-		return "", false, nil
 	}
 	if entry.ResolvedManifest != nil && entry.ResolvedManifest.Spec != nil && entry.ResolvedManifest.Spec.UI != nil {
 		ownedUIPath := strings.TrimSpace(entry.ResolvedManifest.Spec.UI.Path)
@@ -799,7 +798,15 @@ func resolveProviderTargetManifest(pathFlag string) (string, *providermanifestv1
 }
 
 func resolveProviderLocalPluginKey(configPaths []string, targetManifestPath string, manifest *providermanifestv1.Manifest, explicitName string) (string, error) {
-	plugins, err := loadConfiguredPlugins(configPaths)
+	return resolveProviderPluginKey(configPaths, targetManifestPath, manifest, explicitName, loadConfiguredPlugins)
+}
+
+func resolveProviderRemotePluginKey(configPaths []string, targetManifestPath string, manifest *providermanifestv1.Manifest, explicitName string) (string, error) {
+	return resolveProviderPluginKey(configPaths, targetManifestPath, manifest, explicitName, loadConfiguredPluginsAllowMissingEnv)
+}
+
+func resolveProviderPluginKey(configPaths []string, targetManifestPath string, manifest *providermanifestv1.Manifest, explicitName string, loadPlugins func([]string) (map[string]*config.ProviderEntry, error)) (string, error) {
+	plugins, err := loadPlugins(configPaths)
 	if err != nil {
 		return "", err
 	}
@@ -1223,6 +1230,20 @@ func loadConfiguredPlugins(configPaths []string) (map[string]*config.ProviderEnt
 		return map[string]*config.ProviderEntry{}, nil
 	}
 	cfg, err := config.LoadPaths(configPaths)
+	if err != nil {
+		return nil, fmt.Errorf("load provider overlay config: %w", err)
+	}
+	if cfg.Plugins == nil {
+		return map[string]*config.ProviderEntry{}, nil
+	}
+	return cfg.Plugins, nil
+}
+
+func loadConfiguredPluginsAllowMissingEnv(configPaths []string) (map[string]*config.ProviderEntry, error) {
+	if len(configPaths) == 0 {
+		return map[string]*config.ProviderEntry{}, nil
+	}
+	cfg, err := config.LoadPartialAllowMissingEnvPaths(configPaths)
 	if err != nil {
 		return nil, fmt.Errorf("load provider overlay config: %w", err)
 	}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1819,6 +1819,15 @@ func LoadAllowMissingEnvPaths(paths []string) (*Config, error) {
 	return loadWithLookupPaths(paths, os.LookupEnv, true)
 }
 
+// LoadPartialAllowMissingEnvPaths loads config for commands that inspect a
+// local subset of a larger deployment config. It preserves shape
+// normalization, defaults, and relative path resolution, but skips full
+// structural validation so unrelated deployment-only entries with missing
+// local env vars do not block the caller.
+func LoadPartialAllowMissingEnvPaths(paths []string) (*Config, error) {
+	return loadWithLookupPathsValidation(paths, os.LookupEnv, true, false)
+}
+
 func NormalizeCompatibility(cfg *Config) error {
 	normalizeProviderSourceShapes(cfg)
 	normalizeProviderEntryCompatibility(cfg)
@@ -2025,6 +2034,10 @@ func normalizeConfigRoot(root *yaml.Node) error {
 }
 
 func loadWithLookupPaths(paths []string, lookup func(string) (string, bool), allowMissing bool) (*Config, error) {
+	return loadWithLookupPathsValidation(paths, lookup, allowMissing, true)
+}
+
+func loadWithLookupPathsValidation(paths []string, lookup func(string) (string, bool), allowMissing bool, validate bool) (*Config, error) {
 	mode := envMissingBlank
 	missingEnvSentinelContext := ""
 	if !allowMissing {
@@ -2075,8 +2088,10 @@ func loadWithLookupPaths(paths []string, lookup func(string) (string, bool), all
 	resolveBaseURL(&cfg)
 	resolveRelativePaths(primaryConfigPath(paths), &cfg)
 
-	if err := ValidateCanonicalStructure(&cfg); err != nil {
-		return nil, err
+	if validate {
+		if err := ValidateCanonicalStructure(&cfg); err != nil {
+			return nil, err
+		}
 	}
 
 	return &cfg, nil

--- a/gestaltd/internal/providerpkg/source_build.go
+++ b/gestaltd/internal/providerpkg/source_build.go
@@ -27,6 +27,9 @@ func RunSourceReleaseBuild(manifestPath string, manifest *providermanifestv1.Man
 	if !info.IsDir() {
 		return fmt.Errorf("release.build.workdir %q is not a directory", manifest.Release.Build.Workdir)
 	}
+	if err := ensureReleaseBuildDependencies(workdir); err != nil {
+		return err
+	}
 
 	cmd := exec.Command(manifest.Release.Build.Command[0], manifest.Release.Build.Command[1:]...)
 	cmd.Dir = workdir
@@ -34,6 +37,39 @@ func RunSourceReleaseBuild(manifestPath string, manifest *providermanifestv1.Man
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("run release.build.command: %w", err)
+	}
+	return nil
+}
+
+func ensureReleaseBuildDependencies(workdir string) error {
+	packagePath := filepath.Join(workdir, typeScriptProjectFile)
+	if _, err := os.Stat(packagePath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat release.build package.json: %w", err)
+	}
+	if _, err := os.Stat(filepath.Join(workdir, "bun.lock")); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat release.build bun.lock: %w", err)
+	}
+	if info, err := os.Stat(filepath.Join(workdir, "node_modules")); err == nil {
+		if info.IsDir() {
+			return nil
+		}
+		return fmt.Errorf("release build node_modules path %q is not a directory", filepath.Join(workdir, "node_modules"))
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat release build node_modules: %w", err)
+	}
+
+	bunPath, err := DetectBunExecutable()
+	if err != nil {
+		return err
+	}
+	if err := ensureTypeScriptDependencies(bunPath, workdir, "release build"); err != nil {
+		return fmt.Errorf("prepare release.build dependencies: %w", err)
 	}
 	return nil
 }

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -1,4 +1,4 @@
-import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http2";
 import { dirname, resolve } from "node:path";
 
@@ -351,9 +351,7 @@ export async function serve(provider: LoadedProvider): Promise<void> {
   if (!socketPath) {
     throw new Error(`${ENV_PROVIDER_SOCKET} is required`);
   }
-  if (existsSync(socketPath)) {
-    rmSync(socketPath);
-  }
+  rmSync(socketPath, { force: true });
 
   const handler = connectNodeAdapter({
     grpc: true,
@@ -380,9 +378,7 @@ export async function serve(provider: LoadedProvider): Promise<void> {
             server.close(() => resolveClose());
           });
         } finally {
-          if (existsSync(socketPath)) {
-            rmSync(socketPath);
-          }
+          rmSync(socketPath, { force: true });
         }
       }
     })();


### PR DESCRIPTION
## Summary
- Documents the remote `gestaltd provider dev` workflow for attaching local provider code to any remote Gestalt instance.
- Makes remote attach more practical with layered deploy configs by loading remote-dev config permissively for local inspection, so unrelated missing deploy env vars do not block attach.
- Keeps plugin-owned/sibling UI local when a configured mounted UI points at a non-source remote release.
- Bootstraps Bun dependencies before source `release.build.command` when the build workdir has `package.json`, and keeps TypeScript runtime socket cleanup idempotent with `rmSync(socketPath, { force: true })`.

## Interfaces
```sh
GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --path ./slack --name slack

gestaltd provider dev \
  --remote "$GESTALT_URL" \
  --config ./base.yaml \
  --config ./prod.yaml \
  --path ./slack \
  --name slack

gestaltd provider dev \
  --remote "$GESTALT_URL" \
  --config ./base.yaml \
  --config ./dev/local-plugins.yaml
```

## Verification
- `bun run check` in `sdk/typescript`
- `bun run build` in `docs`
- `go test ./internal/config ./internal/providerpkg` in `gestaltd`
- `go test ./cmd/gestaltd -run 'TestRun_ProviderReleaseBuildsUIAssetsBeforePackaging|TestRun_ProviderReleaseStagesOwnedUIPackage'` in `gestaltd`
- `go build -o /tmp/gestaltd-providerdev-followup ./cmd/gestaltd` in `gestaltd`
- Fresh-copy workplace-hub remote dogfood against `https://valon.tools` with no plugin/UI `node_modules` using `--config valon-tools/deploy/config.yaml --config valon-tools/deploy/prod/config.yaml --path ... --name workplaceHub`: attach reported `providers=[workplaceHub] ui_providers=[workplaceHub]`, `gestalt invoke workplaceHub listAppLinks --format json` succeeded, and `GET /workplace-hub/` returned 200.
- `git diff --check`
