### PR TITLE
[codex] Remove legacy Gestalt config YAML shapes

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -339,7 +339,7 @@ func TestE2EValidateRejectsInvalidConfigInput(t *testing.T) {
       path: /roadmap
     mountPath: /roadmap
 `,
-			wantError: "ui object cannot be combined with mountPath",
+			wantError: "mountPath is no longer supported; use ui.path",
 		},
 	}
 
@@ -487,8 +487,9 @@ plugins:
   support:
     source:
       path: %s
-    ui: roadmap
-    mountPath: /provider
+    ui:
+      bundle: roadmap
+      path: /provider
 `, filepath.ToSlash(uiRel), filepath.ToSlash(supportRel))
 	if err := os.WriteFile(baseCfgPath, []byte(baseCfg), 0o644); err != nil {
 		t.Fatalf("write support config: %v", err)

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -880,11 +880,15 @@ func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string,
 		"source":  providerLocalSourceOverride(manifestPath),
 		"runtime": nil,
 	}
-	if mountPath != "" {
-		pluginEntry["mountPath"] = mountPath
-	}
-	if uiName != "" {
-		pluginEntry["ui"] = uiName
+	if mountPath != "" || uiName != "" {
+		ui := map[string]any{}
+		if mountPath != "" {
+			ui["path"] = mountPath
+		}
+		if uiName != "" {
+			ui["bundle"] = uiName
+		}
+		pluginEntry["ui"] = ui
 	}
 
 	cfg := map[string]any{
@@ -987,7 +991,7 @@ func ensureNoPublicUIPathCollision(cfg *config.Config, pluginKey, mountPath stri
 			continue
 		}
 		if strings.TrimSpace(entry.MountPath) == mountPath {
-			return fmt.Errorf("auto-mounted ui path %q for plugins.%s collides with plugins.%s.mountPath", mountPath, pluginKey, name)
+			return fmt.Errorf("auto-mounted ui path %q for plugins.%s collides with plugins.%s.ui.path", mountPath, pluginKey, name)
 		}
 	}
 	return nil

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -2959,7 +2959,8 @@ providers:
 plugins:
   %s:
     source: %q
-    mountPath: %q
+    ui:
+      path: %q
 server:
   providers:
     externalCredentials: default

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -386,9 +386,9 @@ type ProviderEntry struct {
 	// AuthorizationPolicy binds this provider to a shared subject access policy.
 	AuthorizationPolicy string `yaml:"authorizationPolicy,omitempty"`
 
-	// Plugin-specific config fields (parsed from YAML, only valid on plugin entries)
-	MountPath         string                        `yaml:"mountPath,omitempty"`
-	UI                string                        `yaml:"ui,omitempty"`
+	// Plugin-specific runtime fields populated from the canonical ui object.
+	MountPath         string                        `yaml:"-"`
+	UI                string                        `yaml:"-"`
 	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
 	Invokes           []PluginInvocationDependency  `yaml:"invokes,omitempty"`
@@ -426,7 +426,8 @@ type providerEntryYAML struct {
 
 type providerEntryMarshalYAML struct {
 	providerEntryFields `yaml:",inline"`
-	Auth                *RouteAuthDef `yaml:"auth,omitempty"`
+	Auth                *RouteAuthDef          `yaml:"auth,omitempty"`
+	UI                  *pluginUIBindingConfig `yaml:"ui,omitempty"`
 }
 
 type uiEntryYAML struct {
@@ -460,9 +461,6 @@ func (e *ProviderEntry) UnmarshalYAML(value *yaml.Node) error {
 			decoded.UI = uiBinding.Bundle
 		}
 		if uiBinding.Path != "" {
-			if strings.TrimSpace(decoded.MountPath) != "" && !providerEntryUIPathsEqual(decoded.MountPath, uiBinding.Path) {
-				return fmt.Errorf("ui.path conflicts with mountPath")
-			}
 			decoded.MountPath = uiBinding.Path
 		}
 	}
@@ -471,10 +469,17 @@ func (e *ProviderEntry) UnmarshalYAML(value *yaml.Node) error {
 }
 
 func (e ProviderEntry) MarshalYAML() (any, error) {
-	return providerEntryMarshalYAML{
+	raw := providerEntryMarshalYAML{
 		providerEntryFields: providerEntryFieldsFromEntry(e),
 		Auth:                cloneRouteAuthDef(e.RouteAuth),
-	}, nil
+	}
+	if strings.TrimSpace(e.MountPath) != "" {
+		raw.UI = &pluginUIBindingConfig{
+			Bundle: strings.TrimSpace(e.UI),
+			Path:   strings.TrimSpace(e.MountPath),
+		}
+	}
+	return raw, nil
 }
 
 type ProviderSurfaceOverrides struct {
@@ -525,12 +530,12 @@ type HostedRuntimeConfig struct {
 	Image               string                     `yaml:"image,omitempty"`
 	Metadata            map[string]string          `yaml:"metadata,omitempty"`
 	Pool                *HostedRuntimePoolConfig   `yaml:"pool,omitempty"`
-	MinReadyInstances   int                        `yaml:"minReadyInstances,omitempty"`
-	MaxReadyInstances   int                        `yaml:"maxReadyInstances,omitempty"`
-	StartupTimeout      string                     `yaml:"startupTimeout,omitempty"`
-	HealthCheckInterval string                     `yaml:"healthCheckInterval,omitempty"`
-	RestartPolicy       HostedRuntimeRestartPolicy `yaml:"restartPolicy,omitempty"`
-	DrainTimeout        string                     `yaml:"drainTimeout,omitempty"`
+	MinReadyInstances   int                        `yaml:"-"`
+	MaxReadyInstances   int                        `yaml:"-"`
+	StartupTimeout      string                     `yaml:"-"`
+	HealthCheckInterval string                     `yaml:"-"`
+	RestartPolicy       HostedRuntimeRestartPolicy `yaml:"-"`
+	DrainTimeout        string                     `yaml:"-"`
 }
 
 type HostedRuntimePoolConfig struct {
@@ -642,28 +647,62 @@ type WorkflowsConfig struct {
 type WorkflowScheduleConfig struct {
 	Provider   string                `yaml:"provider,omitempty"`
 	Target     *WorkflowTargetConfig `yaml:"target,omitempty"`
-	Plugin     string                `yaml:"plugin,omitempty"`
-	Agent      *WorkflowAgentConfig  `yaml:"agent,omitempty"`
+	Plugin     string                `yaml:"-"`
+	Agent      *WorkflowAgentConfig  `yaml:"-"`
 	Cron       string                `yaml:"cron,omitempty"`
 	Timezone   string                `yaml:"timezone,omitempty"`
-	Operation  string                `yaml:"operation,omitempty"`
-	Connection string                `yaml:"connection,omitempty"`
-	Instance   string                `yaml:"instance,omitempty"`
-	Input      map[string]any        `yaml:"input,omitempty"`
+	Operation  string                `yaml:"-"`
+	Connection string                `yaml:"-"`
+	Instance   string                `yaml:"-"`
+	Input      map[string]any        `yaml:"-"`
 	Paused     bool                  `yaml:"paused,omitempty"`
 }
 
 type WorkflowEventTriggerConfig struct {
 	Provider   string                `yaml:"provider,omitempty"`
 	Target     *WorkflowTargetConfig `yaml:"target,omitempty"`
-	Plugin     string                `yaml:"plugin,omitempty"`
-	Agent      *WorkflowAgentConfig  `yaml:"agent,omitempty"`
+	Plugin     string                `yaml:"-"`
+	Agent      *WorkflowAgentConfig  `yaml:"-"`
 	Match      WorkflowEventMatch    `yaml:"match,omitempty"`
-	Operation  string                `yaml:"operation,omitempty"`
-	Connection string                `yaml:"connection,omitempty"`
-	Instance   string                `yaml:"instance,omitempty"`
-	Input      map[string]any        `yaml:"input,omitempty"`
+	Operation  string                `yaml:"-"`
+	Connection string                `yaml:"-"`
+	Instance   string                `yaml:"-"`
+	Input      map[string]any        `yaml:"-"`
 	Paused     bool                  `yaml:"paused,omitempty"`
+}
+
+type workflowScheduleMarshalYAML struct {
+	Provider string                `yaml:"provider,omitempty"`
+	Target   *WorkflowTargetConfig `yaml:"target,omitempty"`
+	Cron     string                `yaml:"cron,omitempty"`
+	Timezone string                `yaml:"timezone,omitempty"`
+	Paused   bool                  `yaml:"paused,omitempty"`
+}
+
+type workflowEventTriggerMarshalYAML struct {
+	Provider string                `yaml:"provider,omitempty"`
+	Target   *WorkflowTargetConfig `yaml:"target,omitempty"`
+	Match    WorkflowEventMatch    `yaml:"match,omitempty"`
+	Paused   bool                  `yaml:"paused,omitempty"`
+}
+
+func (c WorkflowScheduleConfig) MarshalYAML() (any, error) {
+	return workflowScheduleMarshalYAML{
+		Provider: c.Provider,
+		Target:   workflowTargetConfigFromFields(c.Target, c.Plugin, c.Agent, c.Operation, c.Connection, c.Instance, c.Input),
+		Cron:     c.Cron,
+		Timezone: c.Timezone,
+		Paused:   c.Paused,
+	}, nil
+}
+
+func (c WorkflowEventTriggerConfig) MarshalYAML() (any, error) {
+	return workflowEventTriggerMarshalYAML{
+		Provider: c.Provider,
+		Target:   workflowTargetConfigFromFields(c.Target, c.Plugin, c.Agent, c.Operation, c.Connection, c.Instance, c.Input),
+		Match:    c.Match,
+		Paused:   c.Paused,
+	}, nil
 }
 
 type WorkflowTargetConfig struct {
@@ -710,6 +749,31 @@ type WorkflowEventMatch struct {
 	Type    string `yaml:"type,omitempty"`
 	Source  string `yaml:"source,omitempty"`
 	Subject string `yaml:"subject,omitempty"`
+}
+
+func workflowTargetConfigFromFields(target *WorkflowTargetConfig, plugin string, agent *WorkflowAgentConfig, operation, connection, instance string, input map[string]any) *WorkflowTargetConfig {
+	if target != nil {
+		return target
+	}
+	if agent != nil {
+		return &WorkflowTargetConfig{Agent: agent}
+	}
+	if strings.TrimSpace(plugin) == "" &&
+		strings.TrimSpace(operation) == "" &&
+		strings.TrimSpace(connection) == "" &&
+		strings.TrimSpace(instance) == "" &&
+		len(input) == 0 {
+		return nil
+	}
+	return &WorkflowTargetConfig{
+		Plugin: &WorkflowPluginTargetConfig{
+			Name:       plugin,
+			Operation:  operation,
+			Connection: connection,
+			Instance:   instance,
+			Input:      input,
+		},
+	}
 }
 
 func (c *HostIndexedDBBindingConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -826,8 +890,11 @@ func normalizeProviderEntryUINode(node *yaml.Node) (*pluginUIBindingConfig, erro
 	for i := 0; i+1 < len(raw.Content); i += 2 {
 		key := raw.Content[i]
 		value := raw.Content[i+1]
-		if key == nil || strings.TrimSpace(key.Value) != "ui" || value == nil || value.Kind != yaml.MappingNode {
+		if key == nil || strings.TrimSpace(key.Value) != "ui" {
 			continue
+		}
+		if value == nil || value.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("ui must be an object with path")
 		}
 		var binding pluginUIBindingConfig
 		if err := decodeYAMLNodeKnownFields(value, &binding); err != nil {
@@ -839,31 +906,15 @@ func normalizeProviderEntryUINode(node *yaml.Node) (*pluginUIBindingConfig, erro
 			return nil, fmt.Errorf("ui.path is required when ui is an object")
 		}
 		if mappingValueNode(raw, "mountPath") != nil {
-			return nil, fmt.Errorf("ui object cannot be combined with mountPath")
+			return nil, fmt.Errorf("mountPath is no longer supported; use ui.path")
 		}
-		if binding.Bundle == "" {
-			raw.Content = append(raw.Content[:i], raw.Content[i+2:]...)
-		} else {
-			raw.Content[i+1] = &yaml.Node{
-				Kind:  yaml.ScalarNode,
-				Tag:   "!!str",
-				Value: binding.Bundle,
-			}
-		}
+		raw.Content = append(raw.Content[:i], raw.Content[i+2:]...)
 		return &binding, nil
 	}
-	return nil, nil
-}
-
-func providerEntryUIPathsEqual(left, right string) bool {
-	left = strings.TrimSpace(left)
-	right = strings.TrimSpace(right)
-	if left == right {
-		return true
+	if mappingValueNode(raw, "mountPath") != nil {
+		return nil, fmt.Errorf("mountPath is no longer supported; use ui.path")
 	}
-	normalizedLeft, leftErr := normalizeMountedUIPath(left)
-	normalizedRight, rightErr := normalizeMountedUIPath(right)
-	return leftErr == nil && rightErr == nil && normalizedLeft == normalizedRight
+	return nil, nil
 }
 
 func cloneRouteAuthDef(src *RouteAuthDef) *RouteAuthDef {
@@ -2935,13 +2986,13 @@ func applyPluginMountBindings(cfg *Config) error {
 
 		if plugin.MountPath == "" {
 			if plugin.UI != "" {
-				return fmt.Errorf("config validation: plugins.%s.ui requires plugins.%s.mountPath", pluginName, pluginName)
+				return fmt.Errorf("config validation: plugins.%s.ui.bundle requires plugins.%s.ui.path", pluginName, pluginName)
 			}
 			continue
 		}
 		normalizedPath, err := normalizeMountedUIPath(plugin.MountPath)
 		if err != nil {
-			return fmt.Errorf("config validation: plugins.%s.mountPath: %w", pluginName, err)
+			return fmt.Errorf("config validation: plugins.%s.ui.path: %w", pluginName, err)
 		}
 		plugin.MountPath = normalizedPath
 		if err := validateAuthorizationPolicyReference(cfg, "plugin", pluginName, plugin.AuthorizationPolicy); err != nil {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1895,7 +1895,7 @@ server:
 		}
 	})
 
-	t.Run("plugin mount path binds an explicit ui entry", func(t *testing.T) {
+	t.Run("plugin ui object binds an explicit ui entry", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -1912,8 +1912,9 @@ plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
-    ui: roadmap
-    mountPath: /create-customer-roadmap-review/
+    ui:
+      bundle: roadmap
+      path: /create-customer-roadmap-review/
     authorizationPolicy: roadmap_policy
 authorization:
   policies:
@@ -2041,7 +2042,7 @@ server:
 		}
 	})
 
-	t.Run("plugin-owned ui overlay still validates reserved mount paths", func(t *testing.T) {
+	t.Run("plugin-owned ui overlay still validates reserved paths", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -2049,7 +2050,8 @@ plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
-    mountPath: /api
+    ui:
+      path: /api
 providers:
   ui:
     roadmap:
@@ -2069,12 +2071,12 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `plugins.roadmap.mountPath "/api" conflicts with reserved path "/api"`) {
+		if !strings.Contains(err.Error(), `plugins.roadmap.ui.path "/api" conflicts with reserved path "/api"`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
-	t.Run("same-name plugin-owned ui overlay only suppresses duplicate mount checks", func(t *testing.T) {
+	t.Run("same-name plugin-owned ui overlay only suppresses duplicate path checks", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -2082,7 +2084,8 @@ plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
-    mountPath: /api
+    ui:
+      path: /api
 providers:
   ui:
     roadmap:
@@ -2103,12 +2106,12 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `plugins.roadmap.mountPath "/api" conflicts with reserved path "/api"`) {
+		if !strings.Contains(err.Error(), `plugins.roadmap.ui.path "/api" conflicts with reserved path "/api"`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
-	t.Run("plugin mount path prefix collision with mounted ui is rejected", func(t *testing.T) {
+	t.Run("plugin ui path prefix collision with mounted ui is rejected", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -2126,7 +2129,8 @@ plugins:
   admin:
     source:
       path: ./plugin/manifest.yaml
-    mountPath: /tools/admin
+    ui:
+      path: /tools/admin
 server:
   providers:
     indexeddb: sqlite
@@ -2137,7 +2141,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `ui.docs.path "/tools" conflicts with plugins.admin.mountPath "/tools/admin"`) {
+		if !strings.Contains(err.Error(), `ui.docs.path "/tools" conflicts with plugins.admin.ui.path "/tools/admin"`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -2491,7 +2495,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `ui.root.mountPath is only supported on plugins.*`) {
+		if !strings.Contains(err.Error(), `field mountPath not found`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -2873,22 +2877,26 @@ workflows:
   schedules:
     nightly:
       provider: temporal
-      plugin: roadmap
       cron: "0 2 * * *"
-      operation: nightly_sync
-      input:
-        source: yaml
+      target:
+        plugin:
+          name: roadmap
+          operation: nightly_sync
+          input:
+            source: yaml
   eventTriggers:
     task_updated:
       provider: temporal
-      plugin: roadmap
       match:
         type: roadmap.task.updated
         source: roadmap
-      operation: backfill_items
+      target:
+        plugin:
+          name: roadmap
+          operation: backfill_items
+          input:
+            source: event
       paused: true
-      input:
-        source: event
 providers:
   workflow:
     temporal:
@@ -2936,6 +2944,151 @@ server:
 		}
 		if got := cfg.Workflows.EventTriggers["task_updated"]; !reflect.DeepEqual(got, wantTrigger) {
 			t.Fatalf("Workflows.EventTriggers[task_updated] = %#v, want %#v", got, wantTrigger)
+		}
+	})
+
+	t.Run("legacy top-level workflow target fields are rejected", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			name string
+			yaml string
+			want string
+		}{
+			{
+				name: "schedule",
+				yaml: `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+workflows:
+  schedules:
+    nightly:
+      provider: temporal
+      cron: "0 2 * * *"
+      plugin: roadmap
+      operation: nightly_sync
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+server:
+  encryptionKey: server-key
+`,
+				want: `field plugin not found in type config.WorkflowScheduleConfig`,
+			},
+			{
+				name: "event trigger",
+				yaml: `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+workflows:
+  eventTriggers:
+    task_updated:
+      provider: temporal
+      match:
+        type: roadmap.task.updated
+      plugin: roadmap
+      operation: backfill_items
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+server:
+  encryptionKey: server-key
+`,
+				want: `field plugin not found in type config.WorkflowEventTriggerConfig`,
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				path := mustWriteConfigFile(t, tc.yaml)
+				_, err := Load(path)
+				if err == nil {
+					t.Fatal("Load succeeded, want error")
+				}
+				if !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("Load error = %v, want %q", err, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("workflow target validation errors use canonical paths", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			name string
+			yaml string
+			want string
+		}{
+			{
+				name: "unknown schedule plugin",
+				yaml: `
+workflows:
+  schedules:
+    nightly:
+      provider: temporal
+      cron: "0 2 * * *"
+      target:
+        plugin:
+          name: missing
+          operation: nightly_sync
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+server:
+  encryptionKey: server-key
+`,
+				want: `workflows.schedules.nightly.target.plugin.name references unknown plugin "missing"`,
+			},
+			{
+				name: "event trigger agent missing provider",
+				yaml: `
+workflows:
+  eventTriggers:
+    task_updated:
+      provider: temporal
+      match:
+        type: roadmap.task.updated
+      target:
+        agent:
+          model: gpt-5.5
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+server:
+  encryptionKey: server-key
+`,
+				want: `workflows.eventTriggers.task_updated.target.agent.provider is required`,
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				path := mustWriteConfigFile(t, tc.yaml)
+				_, err := Load(path)
+				if err == nil {
+					t.Fatal("Load succeeded, want error")
+				}
+				if !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("Load error = %v, want %q", err, tc.want)
+				}
+			})
 		}
 	})
 
@@ -2987,9 +3140,11 @@ workflows:
   schedules:
     nightly:
       provider: temporal
-      plugin: roadmap
       cron: "0 2 * * *"
-      operation: nightly_sync
+      target:
+        plugin:
+          name: roadmap
+          operation: nightly_sync
 providers:
   workflow:
     temporal:
@@ -3070,9 +3225,11 @@ workflows:
   schedules:
     nightly:
       provider: missing
-      plugin: roadmap
       cron: "0 2 * * *"
-      operation: nightly_sync
+      target:
+        plugin:
+          name: roadmap
+          operation: nightly_sync
 providers:
   workflow:
     temporal:
@@ -3109,9 +3266,11 @@ workflows:
   schedules:
     nightly:
       provider: temporal
-      plugin: roadmap
       cron: "0 2 * * *"
-      operation: nightly_sync
+      target:
+        plugin:
+          name: roadmap
+          operation: nightly_sync
 providers:
   workflow:
     temporal:
@@ -3153,9 +3312,11 @@ workflows:
   schedules:
     invalid:
       provider: temporal
-      plugin: roadmap
       cron: "*/5 * * * *"
-      operation: backfill_items
+      target:
+        plugin:
+          name: roadmap
+          operation: backfill_items
 providers:
   workflow:
     temporal:
@@ -3189,10 +3350,12 @@ workflows:
   eventTriggers:
     invalid:
       provider: temporal
-      plugin: roadmap
       match:
         type: roadmap.task.updated
-      operation: backfill_items
+      target:
+        plugin:
+          name: roadmap
+          operation: backfill_items
 providers:
   workflow:
     temporal:
@@ -3226,10 +3389,12 @@ workflows:
   eventTriggers:
     invalid:
       provider: temporal
-      plugin: roadmap
       match:
         source: roadmap
-      operation: nightly_sync
+      target:
+        plugin:
+          name: roadmap
+          operation: nightly_sync
 providers:
   workflow:
     temporal:
@@ -3266,10 +3431,12 @@ workflows:
   schedules:
     invalid:
       provider: temporal
-      plugin: roadmap
       cron: "0 0 0 * * *"
       timezone: Mars/Olympus
-      operation: nightly_sync
+      target:
+        plugin:
+          name: roadmap
+          operation: nightly_sync
 providers:
   workflow:
     temporal:
@@ -3490,55 +3657,7 @@ providers:
       indexeddb: agent_state
       runtime:
         provider: hosted
-        minReadyInstances: 1
-        maxReadyInstances: 2
-        startupTimeout: 5m
-        healthCheckInterval: 30s
-        restartPolicy: always
-        drainTimeout: 2m
-  indexeddb:
-    agent_state:
-      source:
-        path: ./providers/datastore/sqlite
-runtime:
-  providers:
-    hosted:
-      source:
-        path: ./providers/runtime/modal
-server:
-  encryptionKey: server-key
-`
-	t.Run("accepts required lifecycle fields directly under agent runtime", func(t *testing.T) {
-		t.Parallel()
-
-		path := mustWriteConfigFile(t, base)
-		cfg, err := Load(path)
-		if err != nil {
-			t.Fatalf("Load: %v", err)
-		}
-		runtimeCfg := cfg.Providers.Agent["simple"].Runtime
-		if runtimeCfg.MinReadyInstances != 1 || runtimeCfg.MaxReadyInstances != 2 {
-			t.Fatalf("runtime ready instances = %d/%d, want 1/2", runtimeCfg.MinReadyInstances, runtimeCfg.MaxReadyInstances)
-		}
-		if runtimeCfg.RestartPolicy != HostedRuntimeRestartPolicyAlways {
-			t.Fatalf("restartPolicy = %q, want %q", runtimeCfg.RestartPolicy, HostedRuntimeRestartPolicyAlways)
-		}
-	})
-
-	t.Run("accepts required lifecycle fields under agent execution runtime", func(t *testing.T) {
-		t.Parallel()
-
-		path := mustWriteConfigFile(t, `
-providers:
-  agent:
-    simple:
-      source:
-        path: ./providers/agent/simple
-      indexeddb: agent_state
-      execution:
-        mode: hosted
-        runtime:
-          provider: hosted
+        pool:
           minReadyInstances: 1
           maxReadyInstances: 2
           startupTimeout: 5m
@@ -3556,17 +3675,73 @@ runtime:
         path: ./providers/runtime/modal
 server:
   encryptionKey: server-key
+`
+	t.Run("accepts required lifecycle fields under agent runtime pool", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, base)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		runtimeCfg := cfg.Providers.Agent["simple"].Runtime
+		if runtimeCfg.Pool == nil {
+			t.Fatal("runtime pool = nil")
+		}
+		if runtimeCfg.Pool.MinReadyInstances != 1 || runtimeCfg.Pool.MaxReadyInstances != 2 {
+			t.Fatalf("runtime pool ready instances = %d/%d, want 1/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)
+		}
+		if runtimeCfg.Pool.RestartPolicy != HostedRuntimeRestartPolicyAlways {
+			t.Fatalf("restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, HostedRuntimeRestartPolicyAlways)
+		}
+	})
+
+	t.Run("accepts required lifecycle fields under agent execution runtime", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      indexeddb: agent_state
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          pool:
+            minReadyInstances: 1
+            maxReadyInstances: 2
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
+  indexeddb:
+    agent_state:
+      source:
+        path: ./providers/datastore/sqlite
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
 `)
 		cfg, err := Load(path)
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
 		runtimeCfg := cfg.Providers.Agent["simple"].Execution.Runtime
-		if runtimeCfg.MinReadyInstances != 1 || runtimeCfg.MaxReadyInstances != 2 {
-			t.Fatalf("execution runtime ready instances = %d/%d, want 1/2", runtimeCfg.MinReadyInstances, runtimeCfg.MaxReadyInstances)
+		if runtimeCfg.Pool == nil {
+			t.Fatal("execution runtime pool = nil")
 		}
-		if runtimeCfg.RestartPolicy != HostedRuntimeRestartPolicyAlways {
-			t.Fatalf("execution restartPolicy = %q, want %q", runtimeCfg.RestartPolicy, HostedRuntimeRestartPolicyAlways)
+		if runtimeCfg.Pool.MinReadyInstances != 1 || runtimeCfg.Pool.MaxReadyInstances != 2 {
+			t.Fatalf("execution runtime pool ready instances = %d/%d, want 1/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)
+		}
+		if runtimeCfg.Pool.RestartPolicy != HostedRuntimeRestartPolicyAlways {
+			t.Fatalf("execution restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, HostedRuntimeRestartPolicyAlways)
 		}
 	})
 
@@ -3575,6 +3750,26 @@ server:
 		yaml string
 		want string
 	}{
+		{
+			name: "rejects missing runtime pool",
+			yaml: `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      runtime:
+        provider: hosted
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: "providers.agent.simple.runtime.pool.minReadyInstances is required",
+		},
 		{
 			name: "rejects missing lifecycle fields",
 			yaml: `
@@ -3585,11 +3780,12 @@ providers:
         path: ./providers/agent/simple
       runtime:
         provider: hosted
-        minReadyInstances: 1
-        startupTimeout: 5m
-        healthCheckInterval: 30s
-        restartPolicy: always
-        drainTimeout: 2m
+        pool:
+          minReadyInstances: 1
+          startupTimeout: 5m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 2m
 runtime:
   providers:
     hosted:
@@ -3598,7 +3794,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.runtime.maxReadyInstances is required",
+			want: "providers.agent.simple.runtime.pool.maxReadyInstances is required",
 		},
 		{
 			name: "rejects missing execution runtime on hosted agent",
@@ -3632,7 +3828,35 @@ providers:
         mode: hosted
         runtime:
           provider: hosted
-          minReadyInstances: 1
+          pool:
+            minReadyInstances: 1
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: "providers.agent.simple.execution.runtime.pool.maxReadyInstances is required",
+		},
+		{
+			name: "rejects max below min",
+			yaml: `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      runtime:
+        provider: hosted
+        pool:
+          minReadyInstances: 2
+          maxReadyInstances: 1
           startupTimeout: 5m
           healthCheckInterval: 30s
           restartPolicy: always
@@ -3645,33 +3869,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.execution.runtime.maxReadyInstances is required",
-		},
-		{
-			name: "rejects max below min",
-			yaml: `
-providers:
-  agent:
-    simple:
-      source:
-        path: ./providers/agent/simple
-      runtime:
-        provider: hosted
-        minReadyInstances: 2
-        maxReadyInstances: 1
-        startupTimeout: 5m
-        healthCheckInterval: 30s
-        restartPolicy: always
-        drainTimeout: 2m
-runtime:
-  providers:
-    hosted:
-      source:
-        path: ./providers/runtime/modal
-server:
-  encryptionKey: server-key
-`,
-			want: "providers.agent.simple.runtime.maxReadyInstances must be greater than or equal to minReadyInstances",
+			want: "providers.agent.simple.runtime.pool.maxReadyInstances must be greater than or equal to minReadyInstances",
 		},
 		{
 			name: "rejects unknown restart policy",
@@ -3683,12 +3881,13 @@ providers:
         path: ./providers/agent/simple
       runtime:
         provider: hosted
-        minReadyInstances: 1
-        maxReadyInstances: 2
-        startupTimeout: 5m
-        healthCheckInterval: 30s
-        restartPolicy: sometimes
-        drainTimeout: 2m
+        pool:
+          minReadyInstances: 1
+          maxReadyInstances: 2
+          startupTimeout: 5m
+          healthCheckInterval: 30s
+          restartPolicy: sometimes
+          drainTimeout: 2m
 runtime:
   providers:
     hosted:
@@ -3697,7 +3896,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.runtime.restartPolicy must be one of",
+			want: "providers.agent.simple.runtime.pool.restartPolicy must be one of",
 		},
 		{
 			name: "rejects restart without agent indexeddb",
@@ -3709,12 +3908,13 @@ providers:
         path: ./providers/agent/simple
       runtime:
         provider: hosted
-        minReadyInstances: 1
-        maxReadyInstances: 2
-        startupTimeout: 5m
-        healthCheckInterval: 30s
-        restartPolicy: always
-        drainTimeout: 2m
+        pool:
+          minReadyInstances: 1
+          maxReadyInstances: 2
+          startupTimeout: 5m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 2m
 runtime:
   providers:
     hosted:
@@ -3723,7 +3923,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: `providers.agent.simple.runtime.restartPolicy "always" requires providers.agent.simple.indexeddb as the provider persistence hook`,
+			want: `providers.agent.simple.runtime.pool.restartPolicy "always" requires providers.agent.simple.indexeddb as the provider persistence hook`,
 		},
 		{
 			name: "rejects lifecycle fields on plugin runtime",
@@ -3734,12 +3934,13 @@ plugins:
       path: ./plugins/service/manifest.yaml
     runtime:
       provider: hosted
-      minReadyInstances: 1
-      maxReadyInstances: 2
-      startupTimeout: 5m
-      healthCheckInterval: 30s
-      restartPolicy: always
-      drainTimeout: 2m
+      pool:
+        minReadyInstances: 1
+        maxReadyInstances: 2
+        startupTimeout: 5m
+        healthCheckInterval: 30s
+        restartPolicy: always
+        drainTimeout: 2m
 runtime:
   providers:
     hosted:

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -374,7 +374,7 @@ func ValidateResolvedStructure(cfg *Config) error {
 			continue
 		}
 		if entry.ResolvedManifest == nil || entry.ManifestSpec() == nil || entry.ManifestSpec().UI == nil {
-			return fmt.Errorf("config validation: plugins.%s.mountPath requires plugins.%s.ui or plugin spec.ui", name, name)
+			return fmt.Errorf("config validation: plugins.%s.ui.path requires plugins.%s.ui.bundle or plugin spec.ui", name, name)
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
@@ -518,7 +518,7 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax
 		seenInvokes[key] = i
 	}
 	if entry.UI != "" && entry.MountPath == "" {
-		return fmt.Errorf("config validation: plugins.%s.ui requires plugins.%s.mountPath", name, name)
+		return fmt.Errorf("config validation: plugins.%s.ui.bundle requires plugins.%s.ui.path", name, name)
 	}
 	if err := validateProviderEntrySource("plugin", name, entry, sourceSyntax); err != nil {
 		return err
@@ -793,10 +793,7 @@ func validateHostedAgentRuntimeLifecyclePolicy(subject string, entry *ProviderEn
 		return fmt.Errorf("config validation: %s is required for hosted agent providers", runtimePath)
 	}
 	lifecycle := runtimeCfg.lifecyclePolicyConfig()
-	lifecycleSubject := runtimePath
-	if runtimeCfg.Pool != nil {
-		lifecycleSubject += ".pool"
-	}
+	lifecycleSubject := runtimePath + ".pool"
 	if lifecycle.MinReadyInstances <= 0 {
 		return fmt.Errorf("config validation: %s.minReadyInstances is required and must be greater than 0", lifecycleSubject)
 	}
@@ -1237,44 +1234,46 @@ func validateWorkflowScheduleTarget(cfg *Config, key string, schedule *WorkflowS
 	if schedule == nil {
 		return fmt.Errorf("config validation: workflows.schedules.%s is required", key)
 	}
+	targetPath := "workflows.schedules." + key + ".target"
 	hasAgent := schedule.Agent != nil
 	schedule.Plugin = strings.TrimSpace(schedule.Plugin)
 	hasPlugin := schedule.Plugin != ""
 	if hasAgent == hasPlugin {
-		return fmt.Errorf("config validation: workflows.schedules.%s must set exactly one of plugin or agent", key)
+		return fmt.Errorf("config validation: %s must set exactly one of plugin or agent", targetPath)
 	}
 	if hasAgent && workflowSchedulePluginFieldsSet(schedule) {
-		return fmt.Errorf("config validation: workflows.schedules.%s cannot set plugin target fields with agent", key)
+		return fmt.Errorf("config validation: %s cannot set plugin target fields with agent", targetPath)
 	}
 	if hasPlugin {
 		if _, ok := cfg.Plugins[schedule.Plugin]; !ok {
-			return fmt.Errorf("config validation: workflows.schedules.%s.plugin references unknown plugin %q", key, schedule.Plugin)
+			return fmt.Errorf("config validation: %s.plugin.name references unknown plugin %q", targetPath, schedule.Plugin)
 		}
 		return nil
 	}
-	return validateWorkflowAgentConfig(cfg, "workflows.schedules."+key+".agent", schedule.Agent)
+	return validateWorkflowAgentConfig(cfg, targetPath+".agent", schedule.Agent)
 }
 
 func validateWorkflowEventTriggerTarget(cfg *Config, key string, trigger *WorkflowEventTriggerConfig) error {
 	if trigger == nil {
 		return fmt.Errorf("config validation: workflows.eventTriggers.%s is required", key)
 	}
+	targetPath := "workflows.eventTriggers." + key + ".target"
 	hasAgent := trigger.Agent != nil
 	trigger.Plugin = strings.TrimSpace(trigger.Plugin)
 	hasPlugin := trigger.Plugin != ""
 	if hasAgent == hasPlugin {
-		return fmt.Errorf("config validation: workflows.eventTriggers.%s must set exactly one of plugin or agent", key)
+		return fmt.Errorf("config validation: %s must set exactly one of plugin or agent", targetPath)
 	}
 	if hasAgent && workflowEventTriggerPluginFieldsSet(trigger) {
-		return fmt.Errorf("config validation: workflows.eventTriggers.%s cannot set plugin target fields with agent", key)
+		return fmt.Errorf("config validation: %s cannot set plugin target fields with agent", targetPath)
 	}
 	if hasPlugin {
 		if _, ok := cfg.Plugins[trigger.Plugin]; !ok {
-			return fmt.Errorf("config validation: workflows.eventTriggers.%s.plugin references unknown plugin %q", key, trigger.Plugin)
+			return fmt.Errorf("config validation: %s.plugin.name references unknown plugin %q", targetPath, trigger.Plugin)
 		}
 		return nil
 	}
-	return validateWorkflowAgentConfig(cfg, "workflows.eventTriggers."+key+".agent", trigger.Agent)
+	return validateWorkflowAgentConfig(cfg, targetPath+".agent", trigger.Agent)
 }
 
 func normalizeWorkflowTargets(cfg *Config) error {
@@ -1587,7 +1586,7 @@ func validateMountedUICollisions(cfg *Config, pluginOwnedUIBindings map[string]s
 			}
 		}
 		subjects = append(subjects, mountedPathSubject{
-			label: "plugins." + name + ".mountPath",
+			label: "plugins." + name + ".ui.path",
 			path:  entry.MountPath,
 		})
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -2116,7 +2116,7 @@ func synthesizePluginOwnedUIEntries(cfg *config.Config) error {
 		}
 		manifestSpec := plugin.ManifestSpec()
 		if manifestSpec == nil || manifestSpec.UI == nil {
-			return fmt.Errorf("plugin %q mountPath requires spec.ui or plugins.%s.ui", pluginName, pluginName)
+			return fmt.Errorf("plugin %q ui.path requires spec.ui or plugins.%s.ui.bundle", pluginName, pluginName)
 		}
 		ownedUI := manifestSpec.UI
 		entry, err := ownedUIEntryForPlugin(plugin, ownedUI)
@@ -2238,7 +2238,7 @@ func validateSynthesizedPluginUIEntry(pluginName string, existing, expected *con
 		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with providers.ui.%s.source.path", pluginName, pluginName)
 	}
 	if current := strings.TrimSpace(existing.Path); current != "" && current != expected.Path {
-		return fmt.Errorf("config validation: plugins.%s.mountPath %q conflicts with providers.ui.%s.path", pluginName, expected.Path, pluginName)
+		return fmt.Errorf("config validation: plugins.%s.ui.path %q conflicts with providers.ui.%s.path", pluginName, expected.Path, pluginName)
 	}
 	if current := strings.TrimSpace(existing.AuthorizationPolicy); current != "" && current != expected.AuthorizationPolicy {
 		return fmt.Errorf("config validation: plugins.%s.authorizationPolicy conflicts with providers.ui.%s.authorizationPolicy", pluginName, pluginName)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1196,7 +1196,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalMountedUIWithoutLockfile(t *testing
 			wantPath: "/create-customer-roadmap-review",
 		},
 		{
-			name: "plugin mount binds explicit ui",
+			name: "plugin ui object binds explicit ui",
 			uiConfigYAML: `  ui:
     roadmap:
       source:
@@ -1205,8 +1205,9 @@ plugins:
     roadmap:
       source:
         path: ./plugin/manifest.yaml
-      ui: roadmap
-      mountPath: /create-customer-roadmap-review
+      ui:
+        bundle: roadmap
+        path: /create-customer-roadmap-review
       authorizationPolicy: roadmap_policy
 `,
 			extraYAML: `authorization:
@@ -1236,8 +1237,9 @@ plugins:
       disabled: true
       source:
         path: ./plugin/manifest.yaml
-      ui: roadmap
-      mountPath: /create-customer-roadmap-review
+      ui:
+        bundle: roadmap
+        path: /create-customer-roadmap-review
       authorizationPolicy: roadmap_policy
 `,
 			uiKey:   "roadmap",
@@ -1254,17 +1256,19 @@ plugins:
       disabled: true
       source:
         path: ./plugin/manifest.yaml
-      mountPath: /create-customer-roadmap-review
+      ui:
+        path: /create-customer-roadmap-review
 `,
 			wantErr: "field disabled not found",
 		},
 		{
-			name: "plugin owned ui via plugin mount",
+			name: "plugin owned ui via plugin ui path",
 			uiConfigYAML: `plugins:
     roadmap:
       source:
         path: ./plugin/manifest.yaml
-      mountPath: /create-customer-roadmap-review
+      ui:
+        path: /create-customer-roadmap-review
       authorizationPolicy: roadmap_policy
 `,
 			extraYAML: `authorization:
@@ -1281,12 +1285,13 @@ plugins:
 			ownedUIPath: "../ui/manifest.yaml",
 		},
 		{
-			name: "plugin owned ui via plugin mount with noncanonical manifest filename",
+			name: "plugin owned ui via plugin ui path with noncanonical manifest filename",
 			uiConfigYAML: `plugins:
     roadmap:
       source:
         path: ./plugin/manifest.yaml
-      mountPath: /create-customer-roadmap-review
+      ui:
+        path: /create-customer-roadmap-review
       authorizationPolicy: roadmap_policy
 `,
 			extraYAML: `authorization:
@@ -1313,7 +1318,8 @@ plugins:
     roadmap:
       source:
         path: ./plugin/manifest.yaml
-      mountPath: /create-customer-roadmap-review
+      ui:
+        path: /create-customer-roadmap-review
       authorizationPolicy: roadmap_policy
 `,
 			extraYAML: `authorization:
@@ -1340,7 +1346,8 @@ plugins:
     roadmap:
       source:
         path: ./plugin/manifest.yaml
-      mountPath: /create-customer-roadmap-review
+      ui:
+        path: /create-customer-roadmap-review
 `,
 			wantErr:     "field disabled not found",
 			ownedUIPath: "../ui/manifest.yaml",
@@ -1659,9 +1666,10 @@ func TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath(t *t
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
-    roadmap:
-      source: ` + srv.URL + `/providers/roadmap-plugin/v` + version + `/provider-release.yaml
-      mountPath: /create-customer-roadmap-review
+  roadmap:
+    source: ` + srv.URL + `/providers/roadmap-plugin/v` + version + `/provider-release.yaml
+    ui:
+      path: /create-customer-roadmap-review
 ` + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `
@@ -2145,9 +2153,10 @@ func TestInitAtPath_RejectsManagedPluginOwnedUIPathOutsidePackage(t *testing.T) 
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
-    roadmap:
-      source: ` + srv.URL + `/providers/roadmap-plugin/v` + version + `/provider-release.yaml
-      mountPath: /create-customer-roadmap-review
+  roadmap:
+    source: ` + srv.URL + `/providers/roadmap-plugin/v` + version + `/provider-release.yaml
+    ui:
+      path: /create-customer-roadmap-review
 server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `


### PR DESCRIPTION
## Summary

Removes the legacy YAML acceptance paths for the config-shape consolidation and keeps the canonical interfaces as the only YAML contract.

This covers plugin UI mounts, hosted runtime lifecycle policy, and workflow targets. The internal runtime structs still normalize into the existing execution model, but config YAML must now use the canonical object forms.

## New Interfaces

Plugin UI mounts:

```yaml
plugins:
  dataSchemaExplorer:
    ui:
      bundle: dataSchemaExplorer
      path: /data-schema-explorer
```

Hosted runtime lifecycle policy:

```yaml
providers:
  agent:
    simple:
      runtime:
        provider: modal
        image: python:3.14-alpine
        pool:
          minReadyInstances: 1
          maxReadyInstances: 2
          startupTimeout: 5m
          healthCheckInterval: 30s
          restartPolicy: always
          drainTimeout: 2m
```

Workflow plugin targets:

```yaml
workflows:
  schedules:
    nightly:
      provider: default
      cron: "0 2 * * *"
      target:
        plugin:
          name: github
          operation: repos/list-for-authenticated-user
          connection: default
          input:
            visibility: private
```

Workflow agent targets:

```yaml
workflows:
  eventTriggers:
    triage:
      provider: default
      match:
        type: github.pull_request.opened
      target:
        agent:
          provider: openai
          model: gpt-5.5
          messages:
            - role: user
              text: Triage the pull request
```

## Removed Legacy YAML Paths

- `plugins.<name>.ui: <bundle>` scalar form.
- `plugins.<name>.mountPath`.
- Flat hosted lifecycle fields under `runtime`.
- Flat workflow target fields such as `plugin`, `agent`, `operation`, `connection`, `instance`, and `input`.

## Implementation Notes

- Provider-local generated overlay configs now emit `ui.path` and `ui.bundle`.
- Config marshal paths preserve canonical `ui` and `target` objects even though the runtime structs keep normalized internal fields.
- Error messages now point at the canonical paths.

## Validation

- `go test ./internal/config ./internal/bootstrap ./internal/operator -count=1`
- `go test ./cmd/gestaltd -count=1`
- `git diff --check`

No new unit tests were added; existing parser, CLI, provider-local, and lifecycle contract tests were updated to exercise the canonical end-to-end config shapes.