### PR TITLE
Remove workload bearer token auth

### DIFF
--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -31,7 +31,7 @@ These fields are emitted when available:
 
 | Field | Meaning |
 | --- | --- |
-| `auth_source` | Authentication mechanism for the caller: `session`, `api_token`, `workload_token`, or `env` |
+| `auth_source` | Authentication mechanism for the caller: `session`, `api_token`, or `env` |
 | `subject_id` | Canonical caller subject such as `user:<id>` or `workload:<id>` |
 | `subject_kind` | Canonical subject type, such as `user` or `workload` |
 | `target_kind` | Generic kind for the object the event acted on, such as `api_token` or `connection` |

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -11,9 +11,6 @@ authorization:
   # shared subject access policies
   policies: ...
 
-  # workload bearer tokens
-  workloads: ...
-
 plugins:
   <name>: ...               # each is a ProviderEntry
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -16,7 +16,6 @@ server:
   # listener, encryption, egress, host-provider selectors
 authorization:
   policies: {}
-  workloads: {}
 providers:
   audit: {}
   authentication: {}
@@ -129,13 +128,6 @@ authorization:
           role: admin
         - subjectID: workload:triage-bot
           role: viewer
-  workloads:
-    triage-bot:
-      displayName: Triage Bot
-      token:
-        secret:
-          provider: default
-          name: triage-bot-token
 ```
 
 `public.host` and `public.port` control the public listener address. Both default to all-interfaces on port `8080`.
@@ -158,9 +150,9 @@ authorization:
 
 Dynamic grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, operators can manage additional dynamic members for that plugin from the built-in admin UI at `/admin/?tab=members` or through `/admin/api/v1/authorization/...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for subjects that already have static authorization on that plugin. The `email` write field is a user-only convenience alias; `subjectId` accepts both `user:<id>` and `workload:<id>`.
 
-`authorization.workloads` configures non-human workload callers. Each workload uses a dedicated bearer token with the `gst_wld_` prefix. Workloads do not carry plugin-specific access lists or fixed credential selectors; grant plugin access with `authorization.policies` or provider-backed dynamic memberships using the workload subject ID, and store third-party credentials through the configured external credentials provider under `workload:<id>`.
+Non-human callers are modeled as canonical subjects, typically `workload:<id>`, and authenticate with Gestalt API tokens whose stored owner is that subject. Grant plugin access with `authorization.policies` or provider-backed dynamic memberships using the workload subject ID, and store third-party credentials through the configured external credentials provider under the same subject ID.
 
-Plugins without `authorizationPolicy` are open to any authenticated subject, including configured workloads. Bind a plugin to a policy when workload access should be explicit.
+Plugins without `authorizationPolicy` are open to any authenticated subject. Bind a plugin to a policy when non-human access should be explicit.
 
 | Field | Default | Description |
 | --- | --- | --- |
@@ -179,7 +171,6 @@ Plugins without `authorizationPolicy` are open to any authenticated subject, inc
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
 | `admin.ui` | | Optional named `providers.ui` bundle whose `admin/` assets should back `/admin`. When omitted, Gestalt auto-discovers `admin/` assets from the root UI bundle before using the built-in fallback. |
 | `authorization.policies` | | Shared subject access policies resolved by canonical `subjectID`. |
-| `authorization.workloads` | | Workload bearer tokens for non-human subjects. |
 
 When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/admin/api/v1/*`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener. When `server.admin.authorizationPolicy` is set, Gestalt does apply browser session auth plus role-based policy checks to `/admin` and `/admin/api/v1/*`.
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -6,7 +6,7 @@ The HTTP API uses "integrations" in route paths (e.g. `/api/v1/integrations`) as
 
 ## Authentication model
 
-Authenticated routes accept a `session_token` cookie or an `Authorization: Bearer <token>` header. Valid bearer tokens include Gestalt API tokens (`gst_api_...`), workload tokens (`gst_wld_...`), and tokens issued by the configured platform authentication provider when it supports direct token validation.
+Authenticated routes accept a `session_token` cookie or an `Authorization: Bearer <token>` header. Valid bearer tokens include Gestalt API tokens (`gst_api_...`) and tokens issued by the configured platform authentication provider when it supports direct token validation.
 
 ## Unauthenticated Routes
 

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -35,9 +35,8 @@ Requests are authenticated in the following order:
 
 1. Check for a `session_token` cookie
 2. Check for an `Authorization: Bearer` header with a `gst_api_` prefix (API token lookup via SHA-256 hash)
-3. Check for an `Authorization: Bearer` header with a `gst_wld_` prefix (workload token lookup)
-4. Check for an `Authorization: Bearer` header with a provider-issued token
-5. If no valid credentials are found, return 401
+3. Check for an `Authorization: Bearer` header with a provider-issued token
+4. If no valid credentials are found, return 401
 
 ## Security headers
 

--- a/gestaltd/core/subjects.go
+++ b/gestaltd/core/subjects.go
@@ -1,0 +1,10 @@
+package core
+
+import "strings"
+
+func ParseSubjectID(subjectID string) (kind, id string, ok bool) {
+	kind, id, ok = strings.Cut(strings.TrimSpace(subjectID), ":")
+	kind = strings.TrimSpace(kind)
+	id = strings.TrimSpace(id)
+	return kind, id, ok && kind != "" && id != ""
+}

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -50,7 +50,8 @@ type APIToken struct {
 }
 
 const (
-	APITokenOwnerKindUser = "user"
+	APITokenOwnerKindUser    = "user"
+	APITokenOwnerKindSubject = "subject"
 )
 
 type UserIdentity struct {

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -2,7 +2,6 @@ package authorization
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
@@ -13,11 +12,6 @@ import (
 const (
 	defaultSubjectRole = "viewer"
 )
-
-type Workload struct {
-	ID          string
-	DisplayName string
-}
 
 type AccessContext struct {
 	Policy string
@@ -36,14 +30,12 @@ type StaticSubjectMember struct {
 }
 
 type Authorizer struct {
-	workloadsByHash  map[string]*Workload
 	policies         map[string]*SubjectPolicy
 	providerPolicies map[string]string
 }
 
 func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderEntry) (*Authorizer, error) {
 	a := &Authorizer{
-		workloadsByHash:  map[string]*Workload{},
 		policies:         map[string]*SubjectPolicy{},
 		providerPolicies: map[string]string{},
 	}
@@ -71,31 +63,6 @@ func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderE
 		}
 	}
 
-	if len(cfg.Workloads) == 0 {
-		return a, nil
-	}
-
-	for workloadID, def := range cfg.Workloads {
-		token := strings.TrimSpace(def.Token)
-		if token == "" {
-			return nil, fmt.Errorf("authorization validation: workload %q token is required", workloadID)
-		}
-		if !strings.HasPrefix(token, "gst_wld_") {
-			return nil, fmt.Errorf("authorization validation: workload %q token must use gst_wld_ prefix", workloadID)
-		}
-		tokenHash := principal.HashToken(token)
-		if _, exists := a.workloadsByHash[tokenHash]; exists {
-			return nil, fmt.Errorf("authorization validation: workload %q token duplicates another workload", workloadID)
-		}
-
-		workload := &Workload{
-			ID:          workloadID,
-			DisplayName: def.DisplayName,
-		}
-
-		a.workloadsByHash[tokenHash] = workload
-	}
-
 	return a, nil
 }
 
@@ -111,17 +78,6 @@ func (a *Authorizer) Close() error {
 func (a *Authorizer) ReloadAuthorizationState(ctx context.Context) error {
 	_ = ctx
 	return nil
-}
-
-func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWorkload, bool) {
-	if a == nil {
-		return nil, false
-	}
-	workload, ok := a.workloadsByHash[principal.HashToken(token)]
-	if !ok || workload == nil {
-		return nil, false
-	}
-	return &principal.ResolvedWorkload{ID: workload.ID, DisplayName: workload.DisplayName}, true
 }
 
 func (a *Authorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -196,13 +196,6 @@ func (a *ProviderBackedAuthorizer) pollLoop(ctx context.Context, done chan struc
 	}
 }
 
-func (a *ProviderBackedAuthorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWorkload, bool) {
-	if a == nil {
-		return nil, false
-	}
-	return a.base.ResolveWorkloadToken(token)
-}
-
 func (a *ProviderBackedAuthorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
 	if a == nil {
 		return true

--- a/gestaltd/internal/authorization/runtime.go
+++ b/gestaltd/internal/authorization/runtime.go
@@ -8,11 +8,9 @@ import (
 )
 
 // RuntimeAuthorizer is the internal authorization interface used by gestaltd
-// request paths. Workload tokens authenticate non-human subjects; authorization
-// decisions are evaluated against the subject ID just like user subjects.
+// request paths. Authorization decisions are evaluated against canonical subject
+// IDs, regardless of how the caller authenticated.
 type RuntimeAuthorizer interface {
-	principal.WorkloadTokenResolver
-
 	Start(ctx context.Context) error
 	Close() error
 

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -6135,7 +6135,7 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
-	t.Run("workflow managed workload tokens stay unique across similar plugin names", func(t *testing.T) {
+	t.Run("workflow managed workload subjects stay unique across similar plugin names", func(t *testing.T) {
 		t.Parallel()
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -6852,42 +6852,6 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
-	t.Run("resolves config secret ref in workload tokens", func(t *testing.T) {
-		t.Parallel()
-
-		factories := validFactories()
-		factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
-			return &coretesting.StubSecretManager{
-				Secrets: map[string]string{"workload-token": "gst_wld_resolved-workload-token"},
-			}, nil
-		}
-		factories.Builtins = []core.Provider{
-			&coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
-		}
-
-		cfg := validConfig()
-		cfg.Authorization = config.AuthorizationConfig{
-			Workloads: map[string]config.WorkloadDef{
-				"triage-bot": {
-					Token: transportSecretRef("workload-token"),
-				},
-			},
-		}
-
-		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
-		if err != nil {
-			t.Fatalf("Bootstrap: %v", err)
-		}
-		<-result.ProvidersReady
-
-		if result.Authorizer == nil {
-			t.Fatal("Authorizer is nil")
-		}
-		if _, ok := result.Authorizer.ResolveWorkloadToken("gst_wld_resolved-workload-token"); !ok {
-			t.Fatal("expected resolved workload token to authenticate")
-		}
-	})
-
 	t.Run("authorization provider backs subject access decisions", func(t *testing.T) {
 		t.Parallel()
 
@@ -7086,11 +7050,6 @@ func TestBootstrapSecretResolution(t *testing.T) {
 						SubjectID: principal.WorkloadSubjectID("triage-bot"),
 						Role:      "viewer",
 					}},
-				},
-			},
-			Workloads: map[string]config.WorkloadDef{
-				"triage-bot": {
-					Token: "gst_wld_triage-bot",
 				},
 			},
 		}

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -3064,7 +3064,7 @@ func newGraphQLSurfaceInvokeHarness(t *testing.T, graphQLURL string, allowSurfac
 	coretesting.AttachStubExternalCredentials(services)
 	t.Cleanup(func() { _ = services.Close() })
 
-	if len(authCfg.Workloads) > 0 || len(authCfg.Policies) > 0 {
+	if len(authCfg.Policies) > 0 {
 		authz, err := authorization.New(authCfg, cfg.Plugins)
 		if err != nil {
 			t.Fatalf("authorization.New: %v", err)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1475,8 +1475,7 @@ type EgressConfig struct {
 }
 
 type AuthorizationConfig struct {
-	Workloads map[string]WorkloadDef      `yaml:"workloads,omitempty"`
-	Policies  map[string]SubjectPolicyDef `yaml:"policies,omitempty"`
+	Policies map[string]SubjectPolicyDef `yaml:"policies,omitempty"`
 }
 
 type SubjectPolicyDef struct {
@@ -1487,11 +1486,6 @@ type SubjectPolicyDef struct {
 type SubjectPolicyMemberDef struct {
 	SubjectID string `yaml:"subjectID,omitempty"`
 	Role      string `yaml:"role"`
-}
-
-type WorkloadDef struct {
-	DisplayName string `yaml:"displayName,omitempty"`
-	Token       string `yaml:"token"`
 }
 
 type ListenerConfig struct {
@@ -2940,9 +2934,6 @@ func normalizedAuthorizationConfig(cfg AuthorizationConfig) AuthorizationConfig 
 			policies[name] = normalizedSubjectPolicyDef(policy)
 		}
 		cfg.Policies = policies
-	}
-	if len(cfg.Workloads) == 0 {
-		cfg.Workloads = nil
 	}
 	return cfg
 }

--- a/gestaltd/internal/coredata/api_tokens.go
+++ b/gestaltd/internal/coredata/api_tokens.go
@@ -29,11 +29,29 @@ func (s *APITokenService) StoreAPIToken(ctx context.Context, token *core.APIToke
 	if ownerKind == "" || ownerID == "" {
 		return fmt.Errorf("store api token: owner_kind and owner_id are required")
 	}
-	if ownerKind != core.APITokenOwnerKindUser {
+	switch ownerKind {
+	case core.APITokenOwnerKindUser:
+		if token.CredentialSubjectID == "" {
+			token.CredentialSubjectID = apiTokenUserSubjectID(ownerID)
+		}
+	case core.APITokenOwnerKindSubject:
+		subjectKind, _, ok := core.ParseSubjectID(ownerID)
+		if !ok {
+			return fmt.Errorf("store api token: subject owner_id must be a canonical subject id")
+		}
+		if subjectKind == core.APITokenOwnerKindUser || subjectKind == "system" {
+			return fmt.Errorf("store api token: subject owner_id must be a non-user, non-system subject id")
+		}
+		credentialSubjectID := strings.TrimSpace(token.CredentialSubjectID)
+		if credentialSubjectID == "" {
+			credentialSubjectID = ownerID
+		}
+		if credentialSubjectID != ownerID {
+			return fmt.Errorf("store api token: subject-owned token credential_subject_id must match owner_id")
+		}
+		token.CredentialSubjectID = credentialSubjectID
+	default:
 		return fmt.Errorf("store api token: unsupported owner_kind %q", ownerKind)
-	}
-	if token.CredentialSubjectID == "" && ownerKind == core.APITokenOwnerKindUser {
-		token.CredentialSubjectID = apiTokenUserSubjectID(ownerID)
 	}
 	token.OwnerKind = ownerKind
 	token.OwnerID = ownerID
@@ -134,6 +152,9 @@ func recordToAPIToken(rec indexeddb.Record) *core.APIToken {
 	}
 	if token.CredentialSubjectID == "" && token.OwnerKind == core.APITokenOwnerKindUser && token.OwnerID != "" {
 		token.CredentialSubjectID = apiTokenUserSubjectID(token.OwnerID)
+	}
+	if token.CredentialSubjectID == "" && token.OwnerKind == core.APITokenOwnerKindSubject && token.OwnerID != "" {
+		token.CredentialSubjectID = token.OwnerID
 	}
 	if raw := recString(rec, "permissions_json"); raw != "" {
 		var permissions []core.AccessPermission

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -749,6 +749,66 @@ func TestAPITokenService(t *testing.T) {
 		}
 	})
 
+	t.Run("StoreAndValidate_subject_owner_defaults_credential_subject", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestServices(t)
+		ctx := context.Background()
+
+		if err := svc.APITokens.StoreAPIToken(ctx, &core.APIToken{
+			ID:          "api-subject",
+			OwnerKind:   core.APITokenOwnerKindSubject,
+			OwnerID:     principal.WorkloadSubjectID("triage-bot"),
+			Name:        "triage-bot",
+			HashedToken: "sha256:subject",
+		}); err != nil {
+			t.Fatalf("StoreAPIToken: %v", err)
+		}
+
+		got, err := svc.APITokens.ValidateAPIToken(ctx, "sha256:subject")
+		if err != nil {
+			t.Fatalf("ValidateAPIToken: %v", err)
+		}
+		if got.OwnerKind != core.APITokenOwnerKindSubject || got.OwnerID != principal.WorkloadSubjectID("triage-bot") {
+			t.Fatalf("owner = (%q, %q), want (%q, %q)", got.OwnerKind, got.OwnerID, core.APITokenOwnerKindSubject, principal.WorkloadSubjectID("triage-bot"))
+		}
+		if got.CredentialSubjectID != principal.WorkloadSubjectID("triage-bot") {
+			t.Fatalf("CredentialSubjectID = %q, want owner subject", got.CredentialSubjectID)
+		}
+	})
+
+	t.Run("StoreAPIToken_subject_owner_rejects_user_system_and_mismatched_credentials", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range []struct {
+			name                string
+			ownerID             string
+			credentialSubjectID string
+		}{
+			{name: "user subject", ownerID: principal.UserSubjectID("user-123")},
+			{name: "system subject", ownerID: "system:config"},
+			{name: "mismatched credential subject", ownerID: principal.WorkloadSubjectID("triage-bot"), credentialSubjectID: principal.WorkloadSubjectID("other-bot")},
+			{name: "borrowed user credential subject", ownerID: principal.WorkloadSubjectID("triage-bot"), credentialSubjectID: principal.UserSubjectID("user-123")},
+		} {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				svc := newTestServices(t)
+
+				err := svc.APITokens.StoreAPIToken(context.Background(), &core.APIToken{
+					ID:                  "api-invalid",
+					OwnerKind:           core.APITokenOwnerKindSubject,
+					OwnerID:             tc.ownerID,
+					CredentialSubjectID: tc.credentialSubjectID,
+					Name:                "invalid",
+					HashedToken:         "sha256:invalid",
+				})
+				if err == nil {
+					t.Fatal("StoreAPIToken succeeded, want error")
+				}
+			})
+		}
+	})
+
 	t.Run("ValidateAPIToken_not_found", func(t *testing.T) {
 		t.Parallel()
 		svc := newTestServices(t)

--- a/gestaltd/internal/invocation/broker_test.go
+++ b/gestaltd/internal/invocation/broker_test.go
@@ -82,7 +82,7 @@ func TestBrokerResolveToken_WorkloadUsesOwnExternalCredential(t *testing.T) {
 	workload := &principal.Principal{
 		SubjectID: principal.WorkloadSubjectID("workflow.roadmap"),
 		Kind:      principal.KindWorkload,
-		Source:    principal.SourceWorkloadToken,
+		Source:    principal.SourceAPIToken,
 	}
 	ctx := WithWorkflowContext(context.Background(), map[string]any{
 		"runId": "run-123",

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -141,7 +141,7 @@ func ctxWithWorkloadPrincipal(workloadID string) context.Context {
 	p := &principal.Principal{
 		Kind:      principal.KindWorkload,
 		SubjectID: principal.WorkloadSubjectID(workloadID),
-		Source:    principal.SourceWorkloadToken,
+		Source:    principal.SourceAPIToken,
 	}
 	return principal.WithPrincipal(context.Background(), p)
 }
@@ -1029,11 +1029,6 @@ func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	authz := mustAuthorizerWithPluginPolicies(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: "gst_wld_triage-bot-token",
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"clickhouse_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
@@ -1746,11 +1741,6 @@ func TestNewServer_WorkloadCallToolDeniedReturnsErrorResult(t *testing.T) {
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := coretesting.NewStubServices(t)
 	authz := mustAuthorizerWithPluginPolicies(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: "gst_wld_triage-bot-token",
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"clickhouse_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
@@ -1817,11 +1807,6 @@ func TestNewServer_WorkloadCallToolDeniedForUnboundSessionOnlyProvider(t *testin
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := coretesting.NewStubServices(t)
 	authz := mustAuthorizerWithPluginPolicies(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: "gst_wld_triage-bot-token",
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"clickhouse_policy": {},
 		},
@@ -1911,11 +1896,6 @@ func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *
 	}
 
 	authz := mustAuthorizerWithPluginPolicies(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: "gst_wld_triage-bot-token",
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"clickhouse_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
@@ -2029,11 +2009,6 @@ func TestNewServer_WorkloadCallToolUsesRequestedInstance(t *testing.T) {
 	}
 
 	authz := mustAuthorizerWithPluginPolicies(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: "gst_wld_triage-bot-token",
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"sampledb_policy": {
 				Members: []config.SubjectPolicyMemberDef{{

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -14,7 +14,6 @@ const (
 	SourceUnknown Source = iota
 	SourceSession
 	SourceAPIToken
-	SourceWorkloadToken
 	SourceEnv
 )
 
@@ -45,8 +44,6 @@ func (s Source) String() string {
 		return "session"
 	case SourceAPIToken:
 		return "api_token"
-	case SourceWorkloadToken:
-		return "workload_token"
 	case SourceEnv:
 		return "env"
 	default:
@@ -60,8 +57,6 @@ func ParseSource(value string) Source {
 		return SourceSession
 	case SourceAPIToken.String():
 		return SourceAPIToken
-	case SourceWorkloadToken.String():
-		return SourceWorkloadToken
 	case SourceEnv.String():
 		return SourceEnv
 	default:
@@ -98,6 +93,14 @@ func WorkloadSubjectID(workloadID string) string {
 		return ""
 	}
 	return string(KindWorkload) + ":" + workloadID
+}
+
+func KindFromSubjectID(subjectID string) Kind {
+	kind, _, ok := core.ParseSubjectID(subjectID)
+	if !ok {
+		return ""
+	}
+	return Kind(kind)
 }
 
 func IsSystemSubjectID(subjectID string) bool {
@@ -333,9 +336,7 @@ func Canonicalize(p *Principal) *Principal {
 		}
 	}
 	if p.Kind == "" {
-		if strings.HasPrefix(p.SubjectID, string(KindWorkload)+":") {
-			p.Kind = KindWorkload
-		}
+		p.Kind = KindFromSubjectID(p.SubjectID)
 	}
 	if p.SubjectID == "" && p.UserID != "" {
 		p.SubjectID = UserSubjectID(p.UserID)

--- a/gestaltd/internal/principal/resolver.go
+++ b/gestaltd/internal/principal/resolver.go
@@ -19,22 +19,15 @@ type TokenType int
 
 const (
 	TokenTypeAPI TokenType = iota
-	TokenTypeWorkload
+	TokenTypeRetiredWorkload
 )
 
 const (
-	prefixAPI      = "gst_api_"
-	prefixWorkload = "gst_wld_"
+	prefixAPI            = "gst_api_"
+	prefixLegacyWorkload = "gst_wld_"
 )
 
-type ResolvedWorkload struct {
-	ID          string
-	DisplayName string
-}
-
-type WorkloadTokenResolver interface {
-	ResolveWorkloadToken(token string) (*ResolvedWorkload, bool)
-}
+const AuthSourceRetiredWorkloadToken = "retired_workload_token"
 
 func GenerateToken(typ TokenType) (plaintext, hashed string, err error) {
 	b := make([]byte, 32)
@@ -47,8 +40,6 @@ func GenerateToken(typ TokenType) (plaintext, hashed string, err error) {
 	switch typ {
 	case TokenTypeAPI:
 		prefix = prefixAPI
-	case TokenTypeWorkload:
-		prefix = prefixWorkload
 	default:
 		return "", "", fmt.Errorf("unknown token type %d", typ)
 	}
@@ -62,8 +53,8 @@ func ParseTokenType(token string) (TokenType, bool) {
 	switch {
 	case strings.HasPrefix(token, prefixAPI):
 		return TokenTypeAPI, true
-	case strings.HasPrefix(token, prefixWorkload):
-		return TokenTypeWorkload, true
+	case strings.HasPrefix(token, prefixLegacyWorkload):
+		return TokenTypeRetiredWorkload, true
 	default:
 		return 0, false
 	}
@@ -73,26 +64,22 @@ type Resolver struct {
 	auth      core.AuthenticationProvider
 	users     *coredata.UserService
 	apiTokens *coredata.APITokenService
-	workloads WorkloadTokenResolver
 }
 
-func NewResolver(auth core.AuthenticationProvider, users *coredata.UserService, apiTokens *coredata.APITokenService, workloads WorkloadTokenResolver) *Resolver {
+func NewResolver(auth core.AuthenticationProvider, users *coredata.UserService, apiTokens *coredata.APITokenService) *Resolver {
 	return &Resolver{
 		auth:      auth,
 		users:     users,
 		apiTokens: apiTokens,
-		workloads: workloads,
 	}
 }
 
 func (r *Resolver) ResolveToken(ctx context.Context, token string) (*Principal, error) {
 	if typ, ok := ParseTokenType(token); ok {
-		switch typ {
-		case TokenTypeAPI:
+		if typ == TokenTypeAPI {
 			return r.resolveAPIToken(ctx, token)
-		case TokenTypeWorkload:
-			return r.resolveWorkloadToken(token)
 		}
+		return nil, ErrInvalidToken
 	}
 
 	startedAt := time.Now()
@@ -115,6 +102,9 @@ func (r *Resolver) ResolveToken(ctx context.Context, token string) (*Principal, 
 }
 
 func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principal, error) {
+	if r.apiTokens == nil {
+		return nil, ErrInvalidToken
+	}
 	hashed := HashToken(token)
 	apiToken, err := r.apiTokens.ValidateAPIToken(ctx, hashed)
 	if err != nil {
@@ -129,12 +119,20 @@ func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principa
 
 	switch ownerKind := r.apiTokenOwnerKind(apiToken); ownerKind {
 	case core.APITokenOwnerKindUser:
+		return r.resolveUserAPIToken(ctx, apiToken)
+	case core.APITokenOwnerKindSubject:
+		return resolveSubjectAPIToken(apiToken)
 	default:
 		return nil, ErrInvalidToken
 	}
+}
 
+func (r *Resolver) resolveUserAPIToken(ctx context.Context, apiToken *core.APIToken) (*Principal, error) {
 	ownerID := strings.TrimSpace(apiToken.OwnerID)
 	if ownerID == "" {
+		return nil, ErrInvalidToken
+	}
+	if r.users == nil {
 		return nil, ErrInvalidToken
 	}
 
@@ -164,20 +162,34 @@ func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principa
 	return p, nil
 }
 
-func (r *Resolver) resolveWorkloadToken(token string) (*Principal, error) {
-	if r.workloads == nil {
+func resolveSubjectAPIToken(apiToken *core.APIToken) (*Principal, error) {
+	subjectID := strings.TrimSpace(apiToken.OwnerID)
+	if subjectID == "" || UserIDFromSubjectID(subjectID) != "" || IsSystemSubjectID(subjectID) {
 		return nil, ErrInvalidToken
 	}
-	workload, ok := r.workloads.ResolveWorkloadToken(token)
-	if !ok || workload == nil || workload.ID == "" {
+	kind := KindFromSubjectID(subjectID)
+	if kind == "" {
 		return nil, ErrInvalidToken
 	}
-	return &Principal{
-		Kind:        KindWorkload,
-		SubjectID:   WorkloadSubjectID(workload.ID),
-		DisplayName: workload.DisplayName,
-		Source:      SourceWorkloadToken,
-	}, nil
+	credentialSubjectID := strings.TrimSpace(apiToken.CredentialSubjectID)
+	if credentialSubjectID == "" {
+		credentialSubjectID = subjectID
+	}
+	if credentialSubjectID != subjectID {
+		return nil, ErrInvalidToken
+	}
+	p := &Principal{
+		Kind:                kind,
+		SubjectID:           subjectID,
+		CredentialSubjectID: credentialSubjectID,
+		DisplayName:         strings.TrimSpace(apiToken.Name),
+		Source:              SourceAPIToken,
+	}
+	if perms := permissionsForAPIToken(apiToken); perms != nil {
+		p.TokenPermissions = perms
+		p.Scopes = PermissionPlugins(perms)
+	}
+	return Canonicalize(p), nil
 }
 
 func (r *Resolver) ResolveEmail(email string) *Principal {

--- a/gestaltd/internal/providerhost/provider_server.go
+++ b/gestaltd/internal/providerhost/provider_server.go
@@ -178,8 +178,6 @@ func sourceFromString(raw string) principal.Source {
 		return principal.SourceSession
 	case principal.SourceAPIToken.String():
 		return principal.SourceAPIToken
-	case principal.SourceWorkloadToken.String():
-		return principal.SourceWorkloadToken
 	case principal.SourceEnv.String():
 		return principal.SourceEnv
 	default:

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -225,10 +225,10 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 				SubjectID:   principal.WorkloadSubjectID("triage-bot"),
 				DisplayName: "Triage Bot",
 				Kind:        principal.KindWorkload,
-				Source:      principal.SourceWorkloadToken,
+				Source:      principal.SourceAPIToken,
 			},
-			wantExecuteBody:    "echo|secret-token|hi|acme|workload:triage-bot|workload|Triage Bot|false|workload_token|user|workload:triage-bot|roadmap|admin",
-			wantSessionCatalog: "token-123|workload:triage-bot|workload|Triage Bot|false|workload_token|user|roadmap|admin",
+			wantExecuteBody:    "echo|secret-token|hi|acme|workload:triage-bot|workload|Triage Bot|false|api_token|user|workload:triage-bot|roadmap|admin",
+			wantSessionCatalog: "token-123|workload:triage-bot|workload|Triage Bot|false|api_token|user|roadmap|admin",
 		},
 	}
 
@@ -321,7 +321,7 @@ func TestRequestContextProto_PreservesWorkloadDisplayName(t *testing.T) {
 		SubjectID:   principal.WorkloadSubjectID("triage-bot"),
 		DisplayName: "Triage Bot",
 		Kind:        principal.KindWorkload,
-		Source:      principal.SourceWorkloadToken,
+		Source:      principal.SourceAPIToken,
 	})
 	ctx = invocation.WithAccessContext(ctx, invocation.AccessContext{
 		Policy: "roadmap",
@@ -377,7 +377,7 @@ func TestPrincipalFromProto_WorkloadDisplayNameDoesNotCreateIdentity(t *testing.
 		Id:          principal.WorkloadSubjectID("triage-bot"),
 		Kind:        string(principal.KindWorkload),
 		DisplayName: "Triage Bot",
-		AuthSource:  principal.SourceWorkloadToken.String(),
+		AuthSource:  principal.SourceAPIToken.String(),
 	})
 	if p == nil {
 		t.Fatal("expected principal")

--- a/gestaltd/internal/server/audit_metadata_test.go
+++ b/gestaltd/internal/server/audit_metadata_test.go
@@ -230,6 +230,15 @@ func TestAuditMetadata_AuthMiddlewareFailures(t *testing.T) {
 			wantAuthSource: "session",
 		},
 		{
+			name:           "retired_workload_bearer",
+			method:         http.MethodGet,
+			path:           "/api/v1/integrations",
+			authHeader:     "Bearer gst_wld_retired-token",
+			wantSource:     "http",
+			wantError:      "invalid token",
+			wantAuthSource: principal.AuthSourceRetiredWorkloadToken,
+		},
+		{
 			name:         "missing_plugin_route_auth_uses_named_provider_in_audit",
 			method:       http.MethodGet,
 			path:         "/api/v1/locked/ping",
@@ -346,7 +355,7 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 	var auditBuf bytes.Buffer
 	auditSink := invocation.NewSlogAuditSink(&auditBuf)
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -366,19 +375,14 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 	}
 
 	providers := testutil.NewProviderRegistry(t, stub)
-	authz, err := authorization.New(config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: workloadToken,
-			},
-		},
-	}, nil)
+	authz, err := authorization.New(config.AuthorizationConfig{}, nil)
 
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
+	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 	if err := svc.ExternalCredentials.PutCredential(t.Context(), &core.ExternalCredential{
 		ID:          "identity-audit-token",
 		SubjectID:   principal.WorkloadSubjectID("triage-bot"),

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -711,11 +711,6 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 	}
 
 	authz, err := authorization.New(config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: "gst_wld_triage-bot-token",
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"clash_policy": {
 				Members: []config.SubjectPolicyMemberDef{{

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -140,8 +140,8 @@ func requestedAuthSource(r *http.Request) string {
 			switch typ {
 			case principal.TokenTypeAPI:
 				return principal.SourceAPIToken.String()
-			case principal.TokenTypeWorkload:
-				return principal.SourceWorkloadToken.String()
+			case principal.TokenTypeRetiredWorkload:
+				return principal.AuthSourceRetiredWorkloadToken
 			}
 		}
 		return principal.SourceSession.String()

--- a/gestaltd/internal/server/provider_dev_ui_test.go
+++ b/gestaltd/internal/server/provider_dev_ui_test.go
@@ -141,13 +141,12 @@ func TestProviderDevMountedUIHandlerUsesMountedAuthRuntime(t *testing.T) {
 			serverAuth,
 			services.Users,
 			services.APITokens,
-			nil,
 		),
 		authProviders: map[string]core.AuthenticationProvider{
 			"alt": altAuth,
 		},
 		authResolvers: map[string]*principal.Resolver{
-			"alt": principal.NewResolver(altAuth, services.Users, services.APITokens, nil),
+			"alt": principal.NewResolver(altAuth, services.Users, services.APITokens),
 		},
 		pluginDefs: map[string]*config.ProviderEntry{
 			"roadmap": {RouteAuth: &config.RouteAuthDef{Provider: "alt"}},
@@ -230,7 +229,7 @@ func TestProviderDevMountedUIHandlerUsesAnonymousForNoAuthMountedUI(t *testing.T
 		t.Fatalf("coredata.New: %v", err)
 	}
 	noneAuth := &coretesting.StubAuthProvider{N: "none"}
-	resolver := principal.NewResolver(noneAuth, services.Users, services.APITokens, nil)
+	resolver := principal.NewResolver(noneAuth, services.Users, services.APITokens)
 	s := &Server{
 		users:              services.Users,
 		auth:               noneAuth,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -251,7 +251,7 @@ func New(cfg Config) (*Server, error) {
 		return nil, fmt.Errorf("external credentials provider is required")
 	}
 	apiTokens := cfg.Services.APITokens
-	resolver := principal.NewResolver(cfg.Auth, users, apiTokens, cfg.Authorizer)
+	resolver := principal.NewResolver(cfg.Auth, users, apiTokens)
 	authProviders := make(map[string]core.AuthenticationProvider, len(cfg.AuthProviders)+1)
 	for name, provider := range cfg.AuthProviders {
 		if provider == nil {
@@ -266,7 +266,7 @@ func New(cfg Config) (*Server, error) {
 	}
 	authResolvers := make(map[string]*principal.Resolver, len(authProviders))
 	for name, provider := range authProviders {
-		authResolvers[name] = principal.NewResolver(provider, users, apiTokens, cfg.Authorizer)
+		authResolvers[name] = principal.NewResolver(provider, users, apiTokens)
 	}
 
 	router := chi.NewRouter()

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1215,6 +1215,22 @@ func seedAPIToken(t *testing.T, svc *coredata.Services, plaintext, hashed, userI
 	}
 }
 
+func seedSubjectAPIToken(t *testing.T, svc *coredata.Services, hashed, subjectID, name string) {
+	t.Helper()
+	exp := time.Now().Add(24 * time.Hour)
+	if err := svc.APITokens.StoreAPIToken(context.Background(), &core.APIToken{
+		ID:                  "api-tok-" + strings.ReplaceAll(subjectID, ":", "-"),
+		OwnerKind:           core.APITokenOwnerKindSubject,
+		OwnerID:             subjectID,
+		CredentialSubjectID: subjectID,
+		Name:                name,
+		HashedToken:         hashed,
+		ExpiresAt:           &exp,
+	}); err != nil {
+		t.Fatalf("seedSubjectAPIToken: StoreAPIToken: %v", err)
+	}
+}
+
 func seedUser(t *testing.T, svc *coredata.Services, email string) *core.User {
 	t.Helper()
 	ctx := context.Background()
@@ -5825,26 +5841,22 @@ func TestAuthMiddleware_ValidAPIToken(t *testing.T) {
 	}
 }
 
-func TestAuthMiddleware_ValidWorkloadToken(t *testing.T) {
+func TestAuthMiddleware_ValidSubjectOwnedAPIToken(t *testing.T) {
 	t.Parallel()
 
-	plaintext, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
+	svc := coretesting.NewStubServices(t)
+	seedSubjectAPIToken(t, svc, hashed, principal.WorkloadSubjectID("weather-bot"), "weather-bot")
 
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
 		ops:             []core.Operation{{Name: "forecast", Method: http.MethodGet}},
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"weather-bot": {
-				Token: plaintext,
-			},
-		},
-	}, nil)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{}, nil)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -5854,7 +5866,7 @@ func TestAuthMiddleware_ValidWorkloadToken(t *testing.T) {
 			},
 		}
 		cfg.Providers = providers
-		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Services = svc
 		cfg.Authorizer = authz
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -5870,6 +5882,54 @@ func TestAuthMiddleware_ValidWorkloadToken(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestAuthMiddleware_SubjectOwnedAPITokenRejectsBorrowedCredentialSubject(t *testing.T) {
+	t.Parallel()
+
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	svc := coretesting.NewStubServices(t)
+	now := time.Now()
+	if err := svc.DB.ObjectStore(coredata.StoreAPITokens).Add(context.Background(), indexeddb.Record{
+		"id":                    "api-tok-borrowed-credential",
+		"owner_kind":            core.APITokenOwnerKindSubject,
+		"owner_id":              principal.WorkloadSubjectID("triage-bot"),
+		"credential_subject_id": principal.UserSubjectID("other-user"),
+		"name":                  "triage-bot",
+		"hashed_token":          hashed,
+		"created_at":            now,
+		"updated_at":            now,
+	}); err != nil {
+		t.Fatalf("seed malformed api token: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				t.Fatal("OAuth ValidateToken must not be called for prefixed API tokens")
+				return nil, nil
+			},
+		}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401 for borrowed credential subject, got %d: %s", resp.StatusCode, body)
 	}
 }
 
@@ -6115,6 +6175,34 @@ func TestAuthMiddleware_PrefixedAPITokenSkipsOAuth(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestAuthMiddleware_LegacyWorkloadPrefixRejectedBeforeOAuth(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				t.Fatal("OAuth ValidateToken must not be called for legacy workload tokens")
+				return nil, nil
+			},
+		}
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("Authorization", "Bearer gst_wld_legacy-workload-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for legacy workload token prefix, got %d", resp.StatusCode)
 	}
 }
 
@@ -6470,12 +6558,13 @@ func TestListIntegrations_HumanAuthorizationFiltersByMountedUIAccessAndVisibleOp
 func TestWorkloadAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
+	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "svc", "workspace", "default", "identity-svc-token")
 
 	svcProvider := &stubIntegrationWithOps{
@@ -6500,11 +6589,6 @@ func TestWorkloadAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t
 	}
 	providers := testutil.NewProviderRegistry(t, svcProvider, weatherProvider, mcpOnlyProvider, secretProvider)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: workloadToken,
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"workload_policy": {
 				Default: "allow",
@@ -6626,10 +6710,12 @@ func TestWorkloadAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t
 func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelectors(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
+	authSvc := coretesting.NewStubServices(t)
+	seedSubjectAPIToken(t, authSvc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 
 	provider := &stubIntegrationWithCatalog{
 		StubIntegration: coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionModeUser},
@@ -6640,11 +6726,6 @@ func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelector
 	}
 	providers := testutil.NewProviderRegistry(t, provider)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: workloadToken,
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"svc_policy": {
 				Default: "allow",
@@ -6660,7 +6741,7 @@ func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelector
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
 		cfg.Providers = providers
-		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Services = authSvc
 		cfg.Authorizer = authz
 		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 	})
@@ -6690,6 +6771,7 @@ func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelector
 	}
 
 	svc := coretesting.NewStubServices(t)
+	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "svc-session", testDefaultConnection, "team-a", "session-bound-token")
 
 	var sessionCatalogToken string
@@ -6709,11 +6791,6 @@ func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelector
 	}
 	sessionProviders := testutil.NewProviderRegistry(t, sessionProvider)
 	sessionAuthz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: workloadToken,
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"svc_session_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
@@ -10142,12 +10219,13 @@ func TestExecuteOperation_NoStoredToken(t *testing.T) {
 func TestWorkloadAuthorization_ExecuteOperation_UsesSubjectCredentialAndSessionSelectors(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
+	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "svc", "workspace", "team-a", "identity-bound-token")
 
 	stub := &stubIntegrationWithCatalog{
@@ -10165,11 +10243,6 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesSubjectCredentialAndSessionS
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: workloadToken,
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"svc_policy": {
 				Default: "allow",
@@ -10240,10 +10313,12 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesSubjectCredentialAndSessionS
 func TestWorkloadAuthorization_ExecuteOperation_AllowsPolicylessPlugin(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
+	svc := coretesting.NewStubServices(t)
+	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
 			N:        "svc",
@@ -10254,17 +10329,11 @@ func TestWorkloadAuthorization_ExecuteOperation_AllowsPolicylessPlugin(t *testin
 		},
 		ops: []core.Operation{{Name: "run", Method: http.MethodGet}},
 	}
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: workloadToken,
-			},
-		},
-	}, nil)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{}, nil)
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
-		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Services = svc
 		cfg.Authorizer = authz
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -10690,7 +10759,7 @@ func TestHumanAuthorization_ExecuteOperation_UsesResolvedRoleAndRejectsDisallowe
 func TestWorkloadAuthorization_ExecuteOperation_MissingSubjectCredentialReturns412(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -10707,11 +10776,6 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingSubjectCredentialReturns4
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: workloadToken,
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"svc_policy": {
 				Default: "allow",
@@ -10724,6 +10788,7 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingSubjectCredentialReturns4
 	}, map[string]*config.ProviderEntry{"svc": {AuthorizationPolicy: "svc_policy"}})
 
 	svc := coretesting.NewStubServices(t)
+	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 	broker := invocation.NewBroker(providers, svc.Users, svc.ExternalCredentials, invocation.WithAuthorizer(authz))
 	guarded := invocation.NewGuarded(broker, broker, "http", auditSink, invocation.WithoutRateLimit())
 
@@ -10762,28 +10827,24 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingSubjectCredentialReturns4
 func TestWorkloadAuthorization_HumanRoutesReturn403(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
+	svc := coretesting.NewStubServices(t)
+	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
 		ops:             []core.Operation{{Name: "forecast", Method: http.MethodGet}},
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: workloadToken,
-			},
-		},
-	}, nil)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{}, nil)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
 		cfg.Providers = providers
-		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Services = svc
 		cfg.Authorizer = authz
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -12184,10 +12245,12 @@ func TestStartIntegrationOAuth(t *testing.T) {
 func TestStartIntegrationOAuth_WorkloadDeniedByPolicy(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
+	svc := coretesting.NewStubServices(t)
+	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 	stub := &stubIntegrationWithAuthURL{
 		StubIntegration: coretesting.StubIntegration{N: "slack"},
 		authURL:         "https://slack.com/oauth/v2/authorize",
@@ -12196,11 +12259,6 @@ func TestStartIntegrationOAuth_WorkloadDeniedByPolicy(t *testing.T) {
 		authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
 	}
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: workloadToken,
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"slack_policy": {
 				Default: "deny",
@@ -12213,7 +12271,7 @@ func TestStartIntegrationOAuth_WorkloadDeniedByPolicy(t *testing.T) {
 		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
 		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
 		cfg.Authorizer = authz
-		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -15936,17 +15994,13 @@ func TestConnectManual(t *testing.T) {
 	t.Run("workload denied by policy cannot connect", func(t *testing.T) {
 		t.Parallel()
 
-		workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+		workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 		if err != nil {
 			t.Fatalf("GenerateToken: %v", err)
 		}
 		svc := coretesting.NewStubServices(t)
+		seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 		authz := mustAuthorizer(t, config.AuthorizationConfig{
-			Workloads: map[string]config.WorkloadDef{
-				"triage-bot": {
-					Token: workloadToken,
-				},
-			},
 			Policies: map[string]config.SubjectPolicyDef{
 				"manual_policy": {
 					Default: "deny",
@@ -15989,18 +16043,14 @@ func TestConnectManual(t *testing.T) {
 	t.Run("workload external identity writes subject relationship", func(t *testing.T) {
 		t.Parallel()
 
-		workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+		workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 		if err != nil {
 			t.Fatalf("GenerateToken: %v", err)
 		}
 		svc := coretesting.NewStubServices(t)
+		seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 		authzProvider := newMemoryAuthorizationProvider("memory-authorization")
 		base, err := authorization.New(config.AuthorizationConfig{
-			Workloads: map[string]config.WorkloadDef{
-				"triage-bot": {
-					Token: workloadToken,
-				},
-			},
 			Policies: map[string]config.SubjectPolicyDef{
 				"manual_policy": {
 					Members: []config.SubjectPolicyMemberDef{{
@@ -18067,15 +18117,15 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	}
 
 	svc := coretesting.NewStubServices(t)
+	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
 	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "clickhouse", "default", "default", "identity-token")
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: "gst_wld_triage-bot-token",
-			},
-		},
 		Policies: map[string]config.SubjectPolicyDef{
 			"clickhouse_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
@@ -18098,7 +18148,7 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	defer ts.Close()
 
 	headers := map[string]string{
-		"Authorization": "Bearer gst_wld_triage-bot-token",
+		"Authorization": "Bearer " + workloadToken,
 	}
 
 	_, _, initHeaders := mcpJSONRPCWithHeaders(t, ts, headers, map[string]any{
@@ -18190,8 +18240,8 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	if auditRecord["allowed"] != false {
 		t.Fatalf("expected audit allowed=false, got %v", auditRecord["allowed"])
 	}
-	if auditRecord["auth_source"] != "workload_token" {
-		t.Fatalf("expected audit auth_source workload_token, got %v", auditRecord["auth_source"])
+	if auditRecord["auth_source"] != "api_token" {
+		t.Fatalf("expected audit auth_source api_token, got %v", auditRecord["auth_source"])
 	}
 	if auditRecord["subject_id"] != "workload:triage-bot" {
 		t.Fatalf("expected subject_id workload:triage-bot, got %v", auditRecord["subject_id"])

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -1441,7 +1441,7 @@ test("workflow provider target resolves and serves runtime metadata plus workflo
         subjectId: "workload:planner",
         subjectKind: "workload",
         displayName: "Planner",
-        authSource: "workload_token",
+        authSource: "api_token",
       },
       target: {
         pluginName: "roadmap",


### PR DESCRIPTION
## Summary
- remove `authorization.workloads`, `gst_wld_` token generation/parsing, and workload-token resolution from the runtime authorizer
- add `core.APITokenOwnerKindSubject` so API tokens can be owned by canonical non-user subjects like `workload:triage-bot`
- add `core.ParseSubjectID` so coredata and principal share one canonical subject parser
- update request/auth/audit docs and contract fixtures so non-human callers authenticate as `api_token` while retaining their canonical subject IDs
- reserve the retired `gst_wld_` prefix so old workload-shaped bearer tokens do not fall through to platform auth
- audit rejected `gst_wld_...` bearer attempts as `retired_workload_token` instead of `session`

## New interfaces
```go
const APITokenOwnerKindSubject = "subject"

kind, id, ok := core.ParseSubjectID("workload:triage-bot")

core.APIToken{
    OwnerKind: core.APITokenOwnerKindSubject,
    OwnerID: "workload:triage-bot",
    CredentialSubjectID: "workload:triage-bot",
    HashedToken: principal.HashToken(plaintextAPIToken),
}

const AuthSourceRetiredWorkloadToken = "retired_workload_token"
```

```yaml
authorization:
  policies:
    operations:
      members:
        - subjectID: workload:triage-bot
          role: viewer
```

## Behavior
- `gst_api_...` remains the only supported Gestalt-issued bearer prefix.
- `gst_wld_...` is reserved and rejected before platform token validation.
- Rejected `gst_wld_...` bearer attempts write `auth_source="retired_workload_token"` in audit logs.
- Subject-owned API tokens resolve to `principal.SourceAPIToken` and derive `Kind` from the canonical `owner_id`.
- Subject-owned API tokens must use the same `credential_subject_id` as `owner_id`; `user:` and `system:` subject owners are rejected. Human API tokens keep using `owner_kind=user`.

## Validation
- `go test ./core ./internal/principal ./internal/coredata ./internal/server`
- `go test ./internal/principal ./internal/coredata ./internal/authorization ./internal/providerhost ./internal/invocation ./internal/mcp ./internal/server ./internal/bootstrap -count=1`
- `go test ./internal/bootstrap -run TestAgentRuntimeConfigDoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntimeLifetime -count=1`
- `bun install --frozen-lockfile` in `sdk/typescript`
- `bun test` in `sdk/typescript`

Note: `go test ./...` on a previous rebased head hit the existing timing-sensitive bootstrap lifecycle test once (`start session requests after expiry health checks = 2, want 1`); the focused rerun and targeted package sweep passed.