### PR TITLE
gestalt cli: send agent tool refs with plugin

### DIFF
--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1128,7 +1128,7 @@ fn build_messages(system: &[String], messages: &[String]) -> Vec<Value> {
 
 fn agent_tool_ref_value(tool: &AgentToolArg) -> Value {
     json!({
-        "pluginName": tool.plugin,
+        "plugin": tool.plugin,
         "operation": tool.operation,
     })
 }

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -102,7 +102,7 @@ fn test_cli_creates_agent_session() {
 fn test_cli_creates_agent_turn_from_input() {
     let request_json = r#"{
         "model":"gpt-5.4",
-        "toolSource":"explicit",
+        "toolSource":"native_search",
         "metadata":{"ticket":"AIT-123"},
         "providerOptions":{"temperature":0.2},
         "responseSchema":{
@@ -115,7 +115,7 @@ fn test_cli_creates_agent_turn_from_input() {
         ],
         "toolRefs":[
             {
-                "pluginName":"roadmap",
+                "plugin":"roadmap",
                 "operation":"sync",
                 "connection":"workspace",
                 "instance":"prod",
@@ -336,7 +336,7 @@ fn test_cli_runs_interactive_agent_session() {
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
     .match_body(Matcher::JsonString(
-        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello\nthere"}]}"#.to_string(),
+        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello\nthere"}],"toolRefs":[{"plugin":"linear","operation":"searchIssues"}]}"#.to_string(),
     ))
     .with_body(TURN_JSON)
     .create();
@@ -377,6 +377,7 @@ fn test_cli_runs_interactive_agent_session() {
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
         .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
+        .args(["--tool", "linear:searchIssues"])
         .write_stdin("hello\\\nthere\n/quit\n")
         .assert()
         .success()


### PR DESCRIPTION
## Summary
- fix `gestalt agent --tool` serialization to use the REST API field `toolRefs[].plugin`
- update the existing CLI contract coverage/examples to use `toolSource: native_search`
- exercise `--tool linear:searchIssues` in the interactive agent contract test

## Interfaces
CLI input:
```sh
gestalt agent --provider simple --tool linear:searchIssues
```

Request body:
```json
{
  "toolRefs": [
    {"plugin": "linear", "operation": "searchIssues"}
  ]
}
```

## Usage Example
```sh
GESTALT_URL=https://valon.tools gestalt agent --provider simple --tool linear:searchIssues
```

This now matches `gestaltd`'s HTTP request schema, which expects `plugin`, not `pluginName`.

## Verification
- `cargo fmt --manifest-path gestalt/cli/Cargo.toml --check`
- `cargo test --manifest-path gestalt/cli/Cargo.toml --test agents_cli`
