### PR TITLE
Inherit remote config for provider dev attach

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -829,14 +829,14 @@ suppressing others for a local session.
 
 Use remote provider dev when you want a remote Gestalt instance to handle auth,
 authorization, connections, secrets, and host services, but route a selected
-plugin implementation to your local machine. For a plugin that does not need
-provider config, a path-only attach is enough:
+plugin implementation to your local machine. For the normal single-plugin case,
+a path-only attach is enough:
 
 ```sh
 export GESTALT_URL=https://gestalt.example.com
 export GESTALT_API_KEY=vat_...
 
-gestaltd provider dev --remote "$GESTALT_URL" --path ./slack --name slack
+gestaltd provider dev --remote "$GESTALT_URL" --path ./slack
 ```
 
 The remote URL is environment-agnostic; it can point at any `gestaltd` instance
@@ -845,10 +845,19 @@ source plugin attached by your authenticated session. Providers that are not
 attached locally continue to run through the remote server and its existing
 configuration.
 
-The attached plugin's config comes from the local command, not by copying the
-remote server's plugin config. If the plugin needs config values, invokes,
-mounted UI settings, or secret references, pass the same layered configs you
-would use for a real deployment and add the local source override on top:
+For `--remote --path` without `--config`, Gestalt matches the local manifest
+`source` to a configured plugin on the remote server. The remote plugin's
+configured auth, authorization, connections, plugin config, mounted UI settings,
+secret references, and host services are preserved; only the implementation is
+routed to your local source tree. If more than one remote plugin uses the same
+manifest `source`, or the manifest has no `source`, pass `--name`:
+
+```sh
+gestaltd provider dev --remote "$GESTALT_URL" --path ./slack --name slack
+```
+
+Use layered config files only when you want explicit local config overrides or
+when you want to attach multiple local plugins in one session:
 
 ```sh
 gestaltd provider dev \
@@ -869,10 +878,11 @@ gestaltd provider dev \
   --config ./dev/local-plugins.yaml
 ```
 
-This uses the same merge behavior as local development, so overlays can choose
-which plugins are local by adding source-backed plugin entries, and choose which
-remote/supporting providers are disabled by setting inherited config entries to
-`null`.
+Config-driven remote attach uses the same merge behavior as local development,
+so overlays can choose which plugins are local by adding source-backed plugin
+entries, choose which remote/supporting providers are disabled by setting
+inherited config entries to `null`, and send explicit local plugin config to the
+remote session.
 Unlike local `provider dev` and `provider validate`, remote provider dev allows
 missing local environment substitutions while loading config. That keeps
 unrelated deployment-only env vars from blocking attach; if the attached plugin
@@ -887,11 +897,11 @@ not tunneled in v1.
 
 For TypeScript plugins, `provider dev` runs `bun install` automatically when the
 plugin has a `package.json` but no `node_modules`. Source UI release builds use
-the same dependency bootstrap before `release.build.command` when that build
-workdir has a `package.json`. Keep `@valon-technologies/gestalt` current enough
-for the host-service features your plugin uses; for example, remote IndexedDB
-host-service calls require an SDK version with `tls://` host-service transport
-support.
+the same dependency bootstrap for Bun-managed build workdirs before
+`release.build.command` when dependencies are missing. Keep
+`@valon-technologies/gestalt` current enough for the host-service features your
+plugin uses; for example, remote IndexedDB host-service calls require an SDK
+version with `tls://` host-service transport support.
 
 Hosted HTTP bindings stay layered on top of operations. A plugin defines an
 operation like `handle_command` in code, then attaches `/command` by declaring a

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -33,8 +33,8 @@ import { Callout } from 'nextra/components'
 | --- | --- |
 | `gestaltd provider dev --path PATH` | Run a local source plugin or UI bundle inside a synthesized Gestalt config. Serves `/admin` and any configured or inferred public UIs. |
 | `gestaltd provider dev --config PATH` | Layer supporting providers, plugins, and UI mounts on top of the synthesized local baseline. Repeat `--config` to merge left-to-right. |
-| `gestaltd provider dev --remote URL --path PATH` | Attach one local source plugin to an authenticated remote `gestaltd` session while the remote config keeps auth, authorization, connections, and host services. |
-| `gestaltd provider dev --remote URL --config PATH` | Attach every source-backed plugin in the layered config. Use repeated `--config` files the same way as local dev to choose which plugins are local and which remain remote. |
+| `gestaltd provider dev --remote URL --path PATH` | Attach one local source plugin to an authenticated remote `gestaltd` session. The remote server matches by manifest `source` and keeps its configured auth, authorization, connections, plugin config, and host services. |
+| `gestaltd provider dev --remote URL --config PATH` | Attach every source-backed plugin in the layered config. Use repeated `--config` files when you need explicit local config overrides or multiple local plugins. |
 | `gestaltd provider validate --path PATH` | Validate a local source plugin or UI bundle inside the same synthesized Gestalt config used by `provider dev`. |
 | `gestaltd provider validate --config PATH` | Validate the target provider together with selected supporting providers and `null` deletions from layered config overlays. |
 | `gestaltd provider release --version VERSION` | Build and package a provider release. Go, Python, Rust, and TypeScript source plugins default to the host platform. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
@@ -58,7 +58,8 @@ gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml 
 gestaltd provider dev --path ./plugins/support
 gestaltd provider dev --path ./ui/dashboard
 gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080
-GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --config ./base.yaml --config ./prod.yaml --path ./plugins/support --name support
+GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support
+GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support --name support
 GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --config ./remote.yaml --config ./local-overrides.yaml
 gestaltd provider release --version 0.0.1-alpha.1
 gestaltd provider release --version 0.0.1-alpha.1 --platform all
@@ -74,21 +75,26 @@ keeps its existing config-relative behavior for backward compatibility.
 `provider dev --remote` is environment-agnostic: the URL is just the remote
 `gestaltd` instance to attach to. The local command only replaces source-backed
 plugin implementations for the authenticated principal that created the session.
-The attached plugin's config is sent by the local command, so use `--config`
-layers when the plugin needs config values, invokes, mounted UI settings, or
-secret references. All non-local plugins and remote host services continue to
-resolve through the remote instance. Remote servers expose attach targets for
-configured plugins that are registered on the remote server, and existing plugin
-authorization decides whether the authenticated caller may attach.
-Remote mode allows missing local environment substitutions while loading config
-so unrelated deploy-only env vars do not block attach.
+With `--remote URL --path PATH` and no `--config`, the local command sends the
+manifest `source` and the local implementation only; the remote server chooses
+the configured plugin with the same manifest `source` and preserves that
+remote plugin's config. If multiple remote plugins share the same source, or the
+manifest has no source, pass `--name` to choose the configured remote plugin.
+All non-local plugins and remote host services continue to resolve through the
+remote instance.
+
+When `--config` is present, source-backed plugin entries in the layered local
+config are treated as explicit local overrides. Their plugin config is sent to
+the remote session instead of inheriting the remote server's config. Remote mode
+allows missing local environment substitutions while loading config so unrelated
+deploy-only env vars do not block attach.
 Remote mode tunnels plugin RPC, catalog, post-connect, host-service calls, and
 plugin-owned UI assets for mounted UIs that already exist on the remote server.
 Raw GraphQL surfaces are not tunneled in v1.
 
 For TypeScript source plugins, `provider dev` installs dependencies with
 `bun install` when a `package.json` is present and `node_modules` is missing.
-Source UI release builds use the same bootstrap before `release.build.command`
-when that build workdir has a `package.json`.
+Source UI release builds use the same bootstrap for Bun-managed build workdirs
+before `release.build.command` when dependencies are missing.
 
 See [Configuration](/configuration) for the relationship between `init`, `serve --locked`, and `validate`.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1054,7 +1054,10 @@ source: ./manifest.yaml
 When a remote `gestaltd` instance is running the provider-dev endpoints,
 authenticated developers can attach a local implementation for configured
 plugins that are registered on the remote server and that they are authorized to
-access with `gestaltd provider dev --remote`.
+access with `gestaltd provider dev --remote`. A path-only attach matches the
+local manifest `source` to the remote configured plugin and preserves the
+remote plugin config; layered `--config` files are only needed for explicit
+local config overrides or multi-plugin attach sessions.
 
 Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider` or the legacy `[tool.gestalt].plugin`.
 

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -159,8 +159,10 @@ func runProviderDev(args []string) error {
 }
 
 type providerRemoteTarget struct {
-	Name  string
-	Entry *config.ProviderEntry
+	Name                string
+	Source              string
+	Entry               *config.ProviderEntry
+	InheritRemoteConfig bool
 }
 
 func runProviderRemoteDev(opts providerLocalCommandOptions) error {
@@ -174,7 +176,8 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	if err != nil {
 		return fmt.Errorf("loading provider dev remote config: %w", err)
 	}
-	targets, err := collectProviderRemoteTargets(cfg, opts.Name)
+	inheritRemoteConfig := opts.Path != "" && len(opts.ConfigPaths) == 0
+	targets, err := collectProviderRemoteTargets(cfg, opts.Name, inheritRemoteConfig)
 	if err != nil {
 		return err
 	}
@@ -198,20 +201,30 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		Token:   token,
 	}
 	requestedProviders := make([]providerdev.AttachProvider, 0, len(targets))
-	localUIHandlers := make(map[string]http.Handler)
-	for _, target := range targets {
+	localUIHandlersByTarget := map[int]http.Handler{}
+	for i, target := range targets {
 		spec, _, err := bootstrap.BuildStartupProviderSpec(target.Name, target.Entry)
 		if err != nil {
 			return fmt.Errorf("build provider dev remote spec for plugins.%s: %w", target.Name, err)
 		}
-		pluginConfig, err := config.NodeToMap(target.Entry.Config)
-		if err != nil {
-			return fmt.Errorf("build provider dev remote config for plugins.%s: %w", target.Name, err)
+		attachName := target.Name
+		if target.InheritRemoteConfig && opts.Name == "" {
+			attachName = ""
 		}
 		requested := providerdev.AttachProvider{
-			Name:   target.Name,
+			Name:   attachName,
+			Source: target.Source,
 			Spec:   spec,
-			Config: pluginConfig,
+		}
+		if !target.InheritRemoteConfig {
+			pluginConfig, err := config.NodeToMap(target.Entry.Config)
+			if err != nil {
+				return fmt.Errorf("build provider dev remote config for plugins.%s: %w", target.Name, err)
+			}
+			if pluginConfig == nil {
+				pluginConfig = map[string]any{}
+			}
+			requested.Config = &pluginConfig
 		}
 		uiHandler, hasUI, err := providerRemoteUIHandler(cfg, target)
 		if err != nil {
@@ -219,7 +232,7 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		}
 		if hasUI {
 			requested.UI = &providerdev.AttachUI{}
-			localUIHandlers[target.Name] = uiHandler
+			localUIHandlersByTarget[i] = uiHandler
 		}
 		requestedProviders = append(requestedProviders, requested)
 	}
@@ -232,6 +245,20 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	sessionProviders := make(map[string]providerdev.CreateSessionProvider, len(session.Providers))
 	for _, provider := range session.Providers {
 		sessionProviders[provider.Name] = provider
+	}
+	localUIHandlers := make(map[string]http.Handler, len(localUIHandlersByTarget))
+	for i := range targets {
+		remoteName := targets[i].Name
+		if targets[i].InheritRemoteConfig && opts.Name == "" {
+			if len(targets) != 1 || len(session.Providers) != 1 {
+				return fmt.Errorf("remote provider dev could not resolve unique provider for source %q; pass --name", targets[i].Source)
+			}
+			remoteName = session.Providers[0].Name
+			targets[i].Name = remoteName
+		}
+		if handler, ok := localUIHandlersByTarget[i]; ok {
+			localUIHandlers[remoteName] = handler
+		}
 	}
 
 	processes := make([]*providerhost.PluginProcess, 0, len(targets))
@@ -536,7 +563,7 @@ func prepareProviderRemoteConfigPaths(opts providerLocalCommandOptions) ([]strin
 	return configPaths, cleanup, nil
 }
 
-func collectProviderRemoteTargets(cfg *config.Config, explicitName string) ([]providerRemoteTarget, error) {
+func collectProviderRemoteTargets(cfg *config.Config, explicitName string, inheritRemoteConfig bool) ([]providerRemoteTarget, error) {
 	if cfg == nil {
 		return nil, nil
 	}
@@ -568,7 +595,16 @@ func collectProviderRemoteTargets(cfg *config.Config, explicitName string) ([]pr
 		if kind != providermanifestv1.KindPlugin {
 			return nil, fmt.Errorf("provider dev --remote only supports plugins in v1 (plugins.%s has kind %q)", name, kind)
 		}
-		targets = append(targets, providerRemoteTarget{Name: name, Entry: entry})
+		source := strings.TrimSpace(manifest.Source)
+		if inheritRemoteConfig && explicitName == "" && source == "" {
+			return nil, fmt.Errorf("plugins.%s manifest source is required for provider dev --remote --path without --name", name)
+		}
+		targets = append(targets, providerRemoteTarget{
+			Name:                name,
+			Source:              source,
+			Entry:               entry,
+			InheritRemoteConfig: inheritRemoteConfig,
+		})
 	}
 	if explicitName != "" && len(targets) == 0 {
 		return nil, fmt.Errorf("no source-backed plugins.%s entry found in provider dev remote config", explicitName)

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -83,7 +83,7 @@ func TestProviderRemoteConfigPathSynthesizesSourcePlugin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config.LoadPaths: %v", err)
 	}
-	targets, err := collectProviderRemoteTargets(cfg, "")
+	targets, err := collectProviderRemoteTargets(cfg, "", true)
 	if err != nil {
 		t.Fatalf("collectProviderRemoteTargets: %v", err)
 	}
@@ -92,6 +92,12 @@ func TestProviderRemoteConfigPathSynthesizesSourcePlugin(t *testing.T) {
 	}
 	if targets[0].Entry.ResolvedManifestPath == "" {
 		t.Fatal("target resolved manifest path is empty")
+	}
+	if targets[0].Source != "github.com/test/plugins/provider" {
+		t.Fatalf("target source = %q, want manifest source", targets[0].Source)
+	}
+	if !targets[0].InheritRemoteConfig {
+		t.Fatal("target InheritRemoteConfig = false, want true")
 	}
 }
 

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -97,6 +98,7 @@ func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers
 		state: providerDevTargetAttachable,
 		target: providerdev.Target{
 			Name:   targetName,
+			Source: strings.TrimSpace(entry.ResolvedManifest.Source),
 			Spec:   providerDevStaticSpecFromProvider(targetName, entry, provider),
 			Config: pluginConfig,
 			RuntimeEnv: func(sessionID string) (providerdev.RuntimeEnv, error) {

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -48,6 +48,7 @@ type RuntimeEnvBuilder func(sessionID string) (RuntimeEnv, error)
 
 type Target struct {
 	Name       string
+	Source     string
 	Spec       providerhost.StaticProviderSpec
 	Config     map[string]any
 	UI         *AttachUI
@@ -67,8 +68,9 @@ type CreateSessionRequest struct {
 
 type AttachProvider struct {
 	Name   string                          `json:"name"`
+	Source string                          `json:"source,omitempty"`
 	Spec   providerhost.StaticProviderSpec `json:"spec"`
-	Config map[string]any                  `json:"config,omitempty"`
+	Config *map[string]any                 `json:"config,omitempty"`
 	UI     *AttachUI                       `json:"ui,omitempty"`
 }
 
@@ -199,22 +201,10 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 		return nil, status.Error(codes.InvalidArgument, "at least one provider is required")
 	}
 
-	m.mu.RLock()
-	targets := make([]Target, 0, len(requestedProviders))
-	for i := range requestedProviders {
-		requested := requestedProviders[i]
-		remoteTarget, ok := m.targets[requested.Name]
-		if !ok {
-			m.mu.RUnlock()
-			return nil, status.Errorf(codes.NotFound, "provider %q is not configured on this server", requested.Name)
-		}
-		target := remoteTarget
-		target.Spec = buildAttachSpec(remoteTarget.Spec, requested.Spec)
-		target.Config = requested.Config
-		target.UI = cloneAttachUI(requested.UI)
-		targets = append(targets, target)
+	targets, err := m.resolveAttachTargets(requestedProviders)
+	if err != nil {
+		return nil, err
 	}
-	m.mu.RUnlock()
 
 	sessionID, err := randomID()
 	if err != nil {
@@ -308,6 +298,84 @@ func (m *Manager) PollSession(ctx context.Context, p *principal.Principal, sessi
 			return nil, false, ctx.Err()
 		}
 	}
+}
+
+func (m *Manager) ResolveAttachProviderNames(req CreateSessionRequest) ([]string, error) {
+	if m == nil {
+		return nil, status.Error(codes.FailedPrecondition, "provider dev is not configured")
+	}
+	requestedProviders, err := normalizeAttachProviders(req.Providers)
+	if err != nil {
+		return nil, err
+	}
+	targets, err := m.resolveAttachTargets(requestedProviders)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(targets))
+	for i := range targets {
+		names = append(names, targets[i].Name)
+	}
+	slices.Sort(names)
+	names = slices.Compact(names)
+	return names, nil
+}
+
+func (m *Manager) resolveAttachTargets(requestedProviders []AttachProvider) ([]Target, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	targets := make([]Target, 0, len(requestedProviders))
+	for i := range requestedProviders {
+		requested := requestedProviders[i]
+		remoteTarget, err := m.resolveAttachTargetLocked(requested)
+		if err != nil {
+			return nil, err
+		}
+		target := remoteTarget
+		target.Spec = buildAttachSpec(remoteTarget.Spec, requested.Spec)
+		if requested.Config != nil {
+			target.Config = cloneAnyMap(*requested.Config)
+		}
+		target.UI = cloneAttachUI(requested.UI)
+		targets = append(targets, target)
+	}
+	return targets, nil
+}
+
+func (m *Manager) resolveAttachTargetLocked(requested AttachProvider) (Target, error) {
+	name := strings.TrimSpace(requested.Name)
+	if name != "" {
+		remoteTarget, ok := m.targets[name]
+		if !ok {
+			return Target{}, status.Errorf(codes.NotFound, "provider %q is not configured on this server", name)
+		}
+		return remoteTarget, nil
+	}
+
+	source := strings.TrimSpace(requested.Source)
+	if source == "" {
+		return Target{}, status.Error(codes.InvalidArgument, "provider name or source is required")
+	}
+	var matches []Target
+	for name := range m.targets {
+		target := m.targets[name]
+		if strings.TrimSpace(target.Source) == source {
+			matches = append(matches, target)
+		}
+	}
+	if len(matches) == 0 {
+		return Target{}, status.Errorf(codes.NotFound, "provider source %q is not configured on this server", source)
+	}
+	if len(matches) > 1 {
+		names := make([]string, 0, len(matches))
+		for i := range matches {
+			names = append(names, matches[i].Name)
+		}
+		slices.Sort(names)
+		return Target{}, status.Errorf(codes.InvalidArgument, "provider source %q matches multiple providers (%s); pass --name to choose one", source, strings.Join(names, ", "))
+	}
+	return matches[0], nil
 }
 
 func (m *Manager) CompleteCall(p *principal.Principal, sessionID, callID string, req CompleteCallRequest) error {
@@ -1178,35 +1246,62 @@ func encodeRPCError(err error) *RPCError {
 }
 
 func normalizeAttachProviders(values []AttachProvider) ([]AttachProvider, error) {
-	out := make([]string, 0, len(values))
-	seen := map[string]struct{}{}
+	type requestKey struct {
+		name   string
+		source string
+	}
+
+	keys := make([]requestKey, 0, len(values))
+	seen := map[requestKey]struct{}{}
 	for i := range values {
 		value := values[i]
 		name := strings.TrimSpace(value.Name)
+		source := strings.TrimSpace(value.Source)
+		key := requestKey{name: name}
 		if name == "" {
+			key.source = source
+		}
+		if name == "" && source == "" {
 			continue
 		}
-		if _, ok := seen[name]; ok {
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		if specName := strings.TrimSpace(value.Spec.Name); specName != "" && specName != name {
+		if specName := strings.TrimSpace(value.Spec.Name); name != "" && specName != "" && specName != name {
 			return nil, status.Errorf(codes.InvalidArgument, "provider spec name %q must match requested provider name %q", specName, name)
 		}
 		value.Name = name
-		value.Spec.Name = name
-		seen[name] = struct{}{}
-		out = append(out, name)
+		value.Source = source
+		if name != "" {
+			value.Spec.Name = name
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
 	}
-	slices.Sort(out)
-	requests := make([]AttachProvider, 0, len(out))
-	for _, name := range out {
+	slices.SortFunc(keys, func(a, b requestKey) int {
+		if c := strings.Compare(a.name, b.name); c != 0 {
+			return c
+		}
+		return strings.Compare(a.source, b.source)
+	})
+	requests := make([]AttachProvider, 0, len(keys))
+	for _, key := range keys {
 		for i := range values {
 			value := values[i]
-			if strings.TrimSpace(value.Name) != name {
+			name := strings.TrimSpace(value.Name)
+			source := strings.TrimSpace(value.Source)
+			valueKey := requestKey{name: name}
+			if name == "" {
+				valueKey.source = source
+			}
+			if valueKey != key {
 				continue
 			}
 			value.Name = name
-			value.Spec.Name = name
+			value.Source = source
+			if name != "" {
+				value.Spec.Name = name
+			}
 			requests = append(requests, value)
 			break
 		}
@@ -1331,6 +1426,17 @@ func cloneStringMap(values map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneAnyMap(values map[string]any) map[string]any {
+	if values == nil {
+		return nil
+	}
+	out := make(map[string]any, len(values))
 	for key, value := range values {
 		out[key] = value
 	}

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -71,6 +71,9 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	manager, err := NewManager([]Target{{
 		Name: "roadmap",
 		Spec: remoteSpec,
+		Config: map[string]any{
+			"remote": true,
+		},
 		RuntimeEnv: func(string) (RuntimeEnv, error) {
 			return RuntimeEnv{
 				Env:          map[string]string{"GESTALT_PLUGIN_INVOKER_SOCKET": "tls://gestalt.example.test:443"},
@@ -93,10 +96,9 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 		_, _ = fmt.Fprintf(w, "local ui %s?%s range=%s", r.URL.Path, r.URL.RawQuery, r.Header.Get("Range"))
 	})
 	session, err := client.CreateSession(context.Background(), CreateSessionRequest{Providers: []AttachProvider{{
-		Name:   "roadmap",
-		Spec:   spec,
-		Config: map[string]any{"remote": true},
-		UI:     &AttachUI{},
+		Name: "roadmap",
+		Spec: spec,
+		UI:   &AttachUI{},
 	}}})
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
@@ -278,6 +280,119 @@ func TestCompleteCallTreatsOKErrorCodeAsProtocolError(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("call response was not delivered")
+	}
+}
+
+func TestCreateSessionMatchesProviderBySource(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewManager([]Target{{
+		Name:   "workplaceHub",
+		Source: "github.com/valon-technologies/valon-tools/plugins/workplace-hub",
+		Spec: providerhost.StaticProviderSpec{
+			Name: "workplaceHub",
+		},
+		Config: map[string]any{"remote": true},
+	}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	resp, err := manager.CreateSession(context.Background(), p, CreateSessionRequest{Providers: []AttachProvider{{
+		Source: "github.com/valon-technologies/valon-tools/plugins/workplace-hub",
+		Spec: providerhost.StaticProviderSpec{
+			Name: "local-workplace-hub",
+		},
+	}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if len(resp.Providers) != 1 {
+		t.Fatalf("session providers = %#v, want one", resp.Providers)
+	}
+	if got := resp.Providers[0].Name; got != "workplaceHub" {
+		t.Fatalf("resolved provider name = %q, want workplaceHub", got)
+	}
+
+	names, err := manager.ResolveAttachProviderNames(CreateSessionRequest{Providers: []AttachProvider{{
+		Source: "github.com/valon-technologies/valon-tools/plugins/workplace-hub",
+	}}})
+	if err != nil {
+		t.Fatalf("ResolveAttachProviderNames: %v", err)
+	}
+	if len(names) != 1 || names[0] != "workplaceHub" {
+		t.Fatalf("ResolveAttachProviderNames = %#v, want [workplaceHub]", names)
+	}
+}
+
+func TestHTTPTransportCreateSessionExplicitConfigOverridesRemoteConfig(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewManager([]Target{{
+		Name:   "roadmap",
+		Config: map[string]any{"remote": true},
+	}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	ts := httptest.NewServer(providerDevTestHandler(t, manager, p))
+	t.Cleanup(ts.Close)
+
+	client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	localConfig := map[string]any{"local": true}
+	resp, err := client.CreateSession(context.Background(), CreateSessionRequest{Providers: []AttachProvider{{
+		Name:   "roadmap",
+		Config: &localConfig,
+	}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	manager.mu.RLock()
+	session := manager.sessions[resp.ID]
+	manager.mu.RUnlock()
+	if session == nil {
+		t.Fatalf("session %q was not recorded", resp.ID)
+	}
+	target := session.targets["roadmap"]
+	if target == nil {
+		t.Fatal("session target roadmap was not recorded")
+	}
+	if got := target.target.Config["remote"]; got != nil {
+		t.Fatalf("attached config remote = %#v, want omitted", got)
+	}
+	if got := target.target.Config["local"]; got != true {
+		t.Fatalf("attached config local = %#v, want true", got)
+	}
+}
+
+func TestCreateSessionRejectsAmbiguousProviderSource(t *testing.T) {
+	t.Parallel()
+
+	const source = "github.com/acme/plugins/shared"
+	manager, err := NewManager([]Target{{
+		Name:   "first",
+		Source: source,
+	}, {
+		Name:   "second",
+		Source: source,
+	}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	_, err = manager.CreateSession(context.Background(), p, CreateSessionRequest{Providers: []AttachProvider{{
+		Source: source,
+	}}})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("CreateSession error = %v, want InvalidArgument", err)
+	}
+	if !strings.Contains(err.Error(), "pass --name") {
+		t.Fatalf("CreateSession error = %v, want pass --name hint", err)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_provider_dev.go
+++ b/gestaltd/internal/server/handlers_provider_dev.go
@@ -40,9 +40,13 @@ func (s *Server) authorizeProviderDevSessionRequest(w http.ResponseWriter, r *ht
 	if err := rejectWorkloadCaller(w, p); err != nil {
 		return err
 	}
-	for i := range req.Providers {
-		provider := req.Providers[i]
-		name := strings.TrimSpace(provider.Name)
+	names, err := s.providerDevSessions.ResolveAttachProviderNames(req)
+	if err != nil {
+		writeProviderDevError(w, err)
+		return err
+	}
+	for _, name := range names {
+		name = strings.TrimSpace(name)
 		if name == "" {
 			continue
 		}


### PR DESCRIPTION
## Summary

Make `gestaltd provider dev --remote --path` the happy path for local provider development against a remote Gestalt instance. Path-only remote attach now sends the local manifest `source` and local implementation metadata, lets the remote server resolve the configured provider by that source, and preserves the remote provider config by default.

## New interfaces

- `gestaltd provider dev --remote URL --path PATH` matches the remote provider by the local manifest `source` and inherits the remote provider config.
- `gestaltd provider dev --remote URL --path PATH --name NAME` targets a specific configured remote provider when the manifest source is missing or ambiguous.
- `gestaltd provider dev --remote URL --config PATH` remains the explicit override mode for local config and multi-plugin attach sessions.
- Provider-dev session attach requests now support source-only targeting and distinguish omitted config from explicit config overrides on the wire.

## Examples

```sh
GESTALT_API_KEY=vat_... gestaltd provider dev \
  --remote https://gestalt.example.com \
  --path ./plugins/support
```

```sh
GESTALT_API_KEY=vat_... gestaltd provider dev \
  --remote https://gestalt.example.com \
  --path ./plugins/support \
  --name support
```

```sh
GESTALT_API_KEY=vat_... gestaltd provider dev \
  --remote https://gestalt.example.com \
  --config ./remote.yaml \
  --config ./local-overrides.yaml
```

## Tests

- `go test ./internal/providerdev`
- `go test ./cmd/gestaltd -run 'TestProviderRemoteConfigPathSynthesizesSourcePlugin|TestRun_ProviderCLIUsageAndErrors'`
- `go test ./internal/server -run ProviderDev`
- `go test ./internal/bootstrap -run ProviderDev`
- `go build -o /tmp/gestaltd-remote-config-inherit ./cmd/gestaltd`
- `npm run build` in `docs/`