### PR TITLE
Remove legacy runtime and egress config paths

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -90,7 +90,7 @@ server:
 
   # default runtime selection for plugins that opt in
   runtime:
-    provider: ...
+    defaultHostedProvider: ...
 
   # public listener (default port 8080)
   public:
@@ -98,7 +98,12 @@ server:
     port: ...
 ```
 
-ProviderEntry-backed entries accept `source` (where to load it from), `config` (provider-specific settings), `allowedHosts`, and optional metadata fields. Plugin entries additionally support plugin-only fields such as `connections`, `allowedOperations`, `ui.path`, `ui.bundle`, and `runtime`. See the [Config File](/reference/config-file) reference for every field.
+ProviderEntry-backed entries accept `source` (where to load it from), `config`
+(provider-specific settings), `egress.allowedHosts`, and optional metadata
+fields. Plugin entries additionally support plugin-only fields such as
+`connections`, `allowedOperations`, `ui.path`, `ui.bundle`, and
+`execution.runtime`. See the [Config File](/reference/config-file) reference for
+every field.
 
 ## Key concepts
 
@@ -113,7 +118,7 @@ Gestalt has ten core concepts you configure in YAML:
 - **[Secrets.](/providers/secrets)** Resolves structured secret refs in the config at startup. Backed by environment variables, files, or cloud secret managers.
 - **[Workflow.](/providers/workflow)** Global workflow runs, schedules, and triggers backed by a workflow provider and optional host IndexedDB storage.
 - **[UI.](/providers/ui)** Public static UI bundles served under configured path prefixes, either directly from `providers.ui` or through `plugins.<name>.ui.path`. Omit `providers.ui` to run headless.
-- **Runtime.** Optional execution backends for executable plugins. Plugins stay host-local by default; `plugins.<name>.runtime` opts a plugin into hosted execution and `runtime.providers` names the available backends.
+- **Runtime.** Optional execution backends for executable plugins. Plugins stay host-local by default; `plugins.<name>.execution.mode: hosted` opts a plugin into hosted execution and `runtime.providers` names the available backends.
 
 ## Adding a plugin
 
@@ -177,22 +182,23 @@ Each entry can set an `alias` to rename the operation as it appears to callers.
 
 ### Egress control
 
-Every provider supports `allowedHosts` to declare which upstream hosts it can
-reach. When `server.egress.defaultAction` is `deny`, providers without an
+Every provider supports `egress.allowedHosts` to declare which upstream hosts it
+can reach. When `server.egress.defaultAction` is `deny`, providers without an
 explicit allowlist are blocked from host-mediated outbound requests. Executable
 plugin providers may also use runtime-backed isolation when egress restrictions
 are active, but the selected runtime has to preserve Gestalt's hostname-based
 policy model. Backends that only support CIDR or firewall controls cannot
-faithfully implement `allowedHosts` by themselves, so Gestalt rejects those
-runtime/plugin combinations instead of silently weakening policy.
+faithfully implement `egress.allowedHosts` by themselves, so Gestalt rejects
+those runtime/plugin combinations instead of silently weakening policy.
 
 ```yaml
 plugins:
   example:
     source: https://artifacts.example.com/plugin/example/v1.0.0/provider-release.yaml
-    allowedHosts:
-      - api.example.com
-      - cdn.example.com
+    egress:
+      allowedHosts:
+        - api.example.com
+        - cdn.example.com
 ```
 
 ## Choosing a plugin runtime
@@ -200,11 +206,11 @@ plugins:
 Executable plugins run on the same machine as `gestaltd` unless the plugin opts
 into a hosted runtime. Runtime selection is two-step: define named backends
 under `runtime.providers`, then opt an individual plugin in with
-`plugins.<name>.runtime`.
+`plugins.<name>.execution.mode: hosted`.
 
-`server.runtime.provider` is only a default selector for plugins that already
-set `plugins.<name>.runtime`; it does not move every plugin into a hosted
-runtime automatically.
+`server.runtime.defaultHostedProvider` is only a default selector for plugins
+that already set `execution.mode: hosted`; it does not move every plugin into a
+hosted runtime automatically.
 
 ```yaml
 runtime:
@@ -219,29 +225,31 @@ runtime:
 
 server:
   runtime:
-    provider: modal
+    defaultHostedProvider: modal
 
 plugins:
   support:
     source: ./plugins/support/manifest.yaml
-    runtime:
-      template: python-dev
-      image: ghcr.io/example/support-plugin:2026-04-21
-      metadata:
-        environment: production
-        owner: support-platform
+    execution:
+      mode: hosted
+      runtime:
+        template: python-dev
+        image: ghcr.io/example/support-plugin:2026-04-21
+        metadata:
+          environment: production
+          owner: support-platform
 ```
 
-`plugins.<name>.runtime.template`, `image`, and `metadata` are forwarded to the
-selected runtime backend. Their meaning is backend-specific: a local runtime may
-ignore them, while a hosted runtime may use them to choose a sandbox template,
-container image, or labels/tags for lifecycle management.
+`plugins.<name>.execution.runtime.template`, `image`, and `metadata` are
+forwarded to the selected runtime backend. Their meaning is backend-specific: a
+local runtime may ignore them, while a hosted runtime may use them to choose a
+sandbox template, container image, or labels/tags for lifecycle management.
 
 The built-in `local` runtime handles same-machine execution. Installable
 `kind: runtime` providers such as Modal handle hosted execution.
 
 The current Modal backend requires `runtime.providers.<name>.config.app` and
-`plugins.<name>.runtime.image`. Modal can satisfy plugins that need
+`plugins.<name>.execution.runtime.image`. Modal can satisfy plugins that need
 Gestalt-owned services or hostname-based egress when the host is configured for
 the public relay and proxy path. In practice that means `server.baseURL` and
 `server.encryptionKey` must be set, and the runtime must report a compatible

--- a/docs/content/custom-providers/runtime.mdx
+++ b/docs/content/custom-providers/runtime.mdx
@@ -59,7 +59,8 @@ runtime:
         pool: default
 ```
 
-Plugins then opt into that runtime with `plugins.<name>.runtime`.
+Plugins then opt into that runtime with `plugins.<name>.execution.mode: hosted`
+and `plugins.<name>.execution.runtime`.
 
 ## Provider interface
 

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -63,27 +63,30 @@ the standard SDK `GESTALT_INDEXEDDB_SOCKET`, but the provider still owns the
 canonical session, turn, interaction, and event records stored there.
 
 If you want the provider to run in a hosted sandbox instead of directly on the
-`gestaltd` host, add a `runtime` block to that same `providers.agent.<name>`
-entry:
+`gestaltd` host, add `execution.mode: hosted` and `execution.runtime` to that
+same `providers.agent.<name>` entry:
 
 ```yaml
 providers:
   agent:
     simple:
       source: ./providers/agent/simple/manifest.yaml
-      runtime:
-        provider: modal
-        image: ghcr.io/valon/gestalt-python-runtime:latest
-        pool:
-          minReadyInstances: 1
-          maxReadyInstances: 4
-          startupTimeout: 2m
-          healthCheckInterval: 30s
-          restartPolicy: always
-          drainTimeout: 1m
-      allowedHosts:
-        - api.openai.com
-        - api.anthropic.com
+      execution:
+        mode: hosted
+        runtime:
+          provider: modal
+          image: ghcr.io/valon/gestalt-python-runtime:latest
+          pool:
+            minReadyInstances: 1
+            maxReadyInstances: 4
+            startupTimeout: 2m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 1m
+      egress:
+        allowedHosts:
+          - api.openai.com
+          - api.anthropic.com
       config:
         defaultModel: fast
 ```
@@ -92,9 +95,7 @@ This keeps the caller interface the same. The request still targets
 `provider: simple`. The only difference is where the provider executes and how
 `gestaltd` enforces host-service access and egress.
 
-`runtime.pool` is the canonical hosted agent lifecycle block. The older flat
-runtime lifecycle fields are still accepted for compatibility, but cannot be
-mixed with `pool`.
+`execution.runtime.pool` is the hosted agent lifecycle block.
 
 ## Session and turn shape
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -96,9 +96,7 @@ plugins:
 ```
 
 By default, executable plugins run on the same machine as `gestaltd`. A plugin
-only uses a hosted runtime when it sets `execution.mode: hosted`. The legacy
-`plugins.<name>.runtime` field is still accepted as an alias for hosted
-execution.
+only uses a hosted runtime when it sets `execution.mode: hosted`. Use `execution.mode: hosted` with `execution.runtime`; legacy `plugins.<name>.runtime` is no longer accepted.
 
 ## Choosing a runtime
 
@@ -197,8 +195,8 @@ plugins:
 
 For executable plugins, `egress.allowedHosts` is only a complete security
 boundary when the plugin is running inside a runtime backend that preserves
-Gestalt's hostname-based policy model. The legacy `allowedHosts` field is still
-accepted as an alias. The current host-local wrappers are OS-dependent, so
+Gestalt's hostname-based policy model. Provider-level `allowedHosts` is no
+longer accepted; use `egress.allowedHosts`. The current host-local wrappers are OS-dependent, so
 operators should treat `egress.allowedHosts` as declarative policy plus
 best-effort enforcement unless the selected runtime explicitly supports
 hostname-based egress controls.

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -21,8 +21,9 @@ changes where the configured plugin or agent provider process runs.
 
 By default, executable plugins and agent providers run on the same machine as
 `gestaltd`. A provider only uses a runtime provider when it opts in with
-`execution.mode: hosted`. The legacy `plugins.<name>.runtime` and
-`providers.agent.<name>.runtime` fields are still accepted as aliases.
+`execution.mode: hosted`. Use `execution.mode: hosted` with
+`execution.runtime`; legacy `plugins.<name>.runtime` and
+`providers.agent.<name>.runtime` fields are no longer accepted.
 
 When a provider does opt in, Gestalt selects a backend from `runtime.providers`,
 reads the backend's support profile, starts a runtime session, waits for that

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -91,7 +91,7 @@ providers:
 
 Runtime providers manage hosted execution backends for executable plugins. They
 are configured under top-level `runtime.providers`, and plugins opt into them
-with `plugins.<name>.runtime`.
+with `plugins.<name>.execution.mode: hosted`.
 
 ```yaml
 runtime:
@@ -105,8 +105,10 @@ runtime:
 plugins:
   support:
     source: ./plugins/support/manifest.yaml
-    runtime:
-      image: ghcr.io/example/support-plugin:2026-04-21
+    execution:
+      mode: hosted
+      runtime:
+        image: ghcr.io/example/support-plugin:2026-04-21
 ```
 
 | Name | Purpose |

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -200,8 +200,7 @@ runtime:
 
 `server.runtime.defaultHostedProvider` supplies the default runtime name for
 plugins that set `execution.mode: hosted` without an explicit
-`execution.runtime.provider`. The legacy `server.runtime.provider` field is
-still accepted as an alias.
+`execution.runtime.provider`. The legacy `server.runtime.provider` field is no longer accepted.
 
 | Field | Description |
 | --- | --- |
@@ -314,7 +313,7 @@ Authentication providers use the same `ProviderEntry` shape under `providers.aut
 | `source.auth` | Optional metadata-fetch auth for release sources, including direct metadata URLs and `source.githubRelease`. |
 | `config` | Provider-specific config passed into the authentication provider. |
 | `env` | Extra environment variables passed to the provider process. |
-| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `providers.indexeddb`
 
@@ -392,7 +391,7 @@ The exact config fields depend on the selected authorization provider package. T
 | `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
 | `config` | Provider-specific config passed into the authorization provider. |
 | `env` | Extra environment variables passed to the provider process. |
-| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `providers.workflow`
 
@@ -461,7 +460,7 @@ allowlist logical stores exposed through that binding.
 | `config` | Provider-specific config passed into the workflow provider. |
 | `indexeddb` | Optional host IndexedDB binding for the workflow provider, including `provider`, optional `db`, and optional `objectStores`. |
 | `env` | Extra environment variables passed to the provider process. |
-| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `providers.agent`
 
@@ -481,16 +480,18 @@ providers:
       indexeddb:
         provider: default
         db: simple_agent
-      runtime:
-        provider: modal
-        image: ghcr.io/valon/gestalt-python-runtime:latest
-        pool:
-          minReadyInstances: 1
-          maxReadyInstances: 4
-          startupTimeout: 2m
-          healthCheckInterval: 30s
-          restartPolicy: always
-          drainTimeout: 1m
+      execution:
+        mode: hosted
+        runtime:
+          provider: modal
+          image: ghcr.io/valon/gestalt-python-runtime:latest
+          pool:
+            minReadyInstances: 1
+            maxReadyInstances: 4
+            startupTimeout: 2m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 1m
       config:
         runStore: runs
         idempotencyStore: run_idempotency
@@ -512,8 +513,8 @@ executable plugins. When `providers.agent.<name>.execution.mode` is `hosted`,
 `gestaltd` starts the agent provider inside the selected hosted runtime instead
 of launching it directly on the `gestaltd` host. Tool callbacks still route
 back through the host agent socket, and `egress.allowedHosts` remains the
-operator-facing egress policy. Legacy `providers.agent.<name>.runtime` remains
-accepted as an alias for hosted execution.
+operator-facing egress policy. Legacy `providers.agent.<name>.runtime` is no
+longer accepted; use `providers.agent.<name>.execution.runtime`.
 
 | Field | Description |
 | --- | --- |
@@ -523,8 +524,8 @@ accepted as an alias for hosted execution.
 | `indexeddb` | Optional agent IndexedDB config. `indexeddb.provider` selects the named `providers.indexeddb` entry backing the agent's single IndexedDB SDK socket; unlike plugins, agents do not inherit the selected/default host IndexedDB automatically. `indexeddb.db` overrides the provider-visible database name and defaults to the agent provider key. `indexeddb.objectStores` optionally allowlists logical object stores the agent may use. |
 | `config` | Provider-specific config passed into the agent provider. |
 | `env` | Extra environment variables passed to the provider process. |
-| `execution` | Optional hosted execution selection for this agent provider. `execution.mode` is `local` or `hosted`; `execution.runtime` supports `provider`, `template`, `image`, `metadata`, and `pool`. `pool` contains hosted agent lifecycle fields: `minReadyInstances`, `maxReadyInstances`, `startupTimeout`, `healthCheckInterval`, `restartPolicy`, and `drainTimeout`. The older flat lifecycle fields are still accepted, but cannot be combined with `pool`. Legacy `runtime` remains accepted as an alias for hosted execution. |
-| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable providers, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `execution` | Optional hosted execution selection for this agent provider. `execution.mode` is `local` or `hosted`; `execution.runtime` supports `provider`, `template`, `image`, `metadata`, and `pool`. `pool` contains hosted agent lifecycle fields: `minReadyInstances`, `maxReadyInstances`, `startupTimeout`, `healthCheckInterval`, `restartPolicy`, and `drainTimeout`. |
+| `egress.allowedHosts` | Outbound host allowlist. For executable providers, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `workflows`
 
@@ -641,7 +642,7 @@ First-party cache providers are published at
 | `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
 | `config` | Arbitrary provider-specific config passed through to the cache provider. |
 | `env` | Extra environment variables passed to the provider process. |
-| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `providers.s3`
 
@@ -970,8 +971,7 @@ plugins:
 | `description` | Short description of the plugin. |
 | `iconFile` | SVG icon path, resolved relative to the config directory. |
 | `authorizationPolicy` | Optional shared subject access policy from `authorization.policies`. When set, host-side operation filtering and execution checks use the resolved role for this plugin, and the built-in admin UI / admin API can manage plugin-scoped dynamic grants for additional members. Static policy members still take precedence. |
-| `ui` | Optional plugin-backed mounted UI binding. The canonical object form is `ui.path` plus optional `ui.bundle`. `ui.bundle` names a `providers.ui` entry; omit it to mount the plugin manifest's owned `spec.ui`. The older scalar `ui: <bundle>` plus `mountPath` form remains accepted. |
-| `mountPath` | Compatibility field for the older plugin-backed UI shape. Prefer `ui.path` for new config. |
+| `ui` | Optional plugin-backed mounted UI binding. Use `ui.path` plus optional `ui.bundle`. `ui.bundle` names a `providers.ui` entry; omit it to mount the plugin manifest's owned `spec.ui`. |
 | `source` | **Required.** The backing provider source. See [source shape](#pluginssource) below. |
 | `source.auth` | Optional metadata-fetch auth for release sources. Use this for `source.url`, `source.githubRelease`, or local `provider-release.yaml` metadata. |
 | `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either the reserved `server` alias or a named entry from `providers.authentication`. Gestalt enforces this on plugin HTTP operation routes (`/api/v1/integrations/{name}/operations` and `/api/v1/{integration}/{operation}`) and on plugin-backed mounted UIs, including browser-login flows whose `next` path resolves into that plugin's mount. Standalone `providers.ui` bundles, the built-in admin UI/admin API, and `/mcp` still use the server-wide auth provider in this phase. |
@@ -981,8 +981,8 @@ plugins:
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
-| `execution` | Optional executable-plugin execution config. `execution.mode` is `local` or `hosted`; `execution.runtime` carries the hosted runtime fields. Legacy `runtime` remains accepted as an alias for `execution.mode: hosted` plus `execution.runtime`. |
-| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `execution` | Optional executable-plugin execution config. `execution.mode` is `local` or `hosted`; `execution.runtime` carries the hosted runtime fields. |
+| `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 | `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Schema-capable backends derive plugin scoping from that `db` name. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
 | `s3` | Optional list of named `providers.s3` bindings exposed to the executable plugin through the SDK transport. A single binding also populates the default S3 SDK env var for compatibility. |
 
@@ -1100,7 +1100,7 @@ Gestalt synthesizes Go and Rust executable wrappers automatically when needed an
 | `source.auth` | Optional metadata-fetch auth for release sources, including direct metadata URLs, `source.githubRelease`, and local `provider-release.yaml` metadata. |
 | `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either `server` or a named `providers.authentication` entry. Gestalt enforces this on plugin HTTP operation routes and on plugin-backed mounted UIs. Standalone `providers.ui` bundles, the built-in admin UI/admin API, and `/mcp` still use the server-wide auth provider in this phase. |
 | `env` | Extra environment variables passed to the provider process. |
-| `egress.allowedHosts` | Outbound host allowlist. Legacy `allowedHosts` remains accepted as an alias. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+| `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ### `connections`
 
@@ -1289,9 +1289,9 @@ plugins:
 When `egress.allowedHosts` is set on a provider, Gestalt applies that allowlist
 to host-mediated outbound checks using exact matches and `*.suffix` wildcards.
 When `egress.allowedHosts` is empty, `defaultAction` decides: `allow` permits
-outbound requests, `deny` blocks them. The legacy provider-level `allowedHosts`
-field is still accepted as an alias for `egress.allowedHosts`. For executable
-plugins, those rules are only a complete security boundary when the plugin is
+outbound requests, `deny` blocks them. Provider-level `allowedHosts` is no
+longer accepted; use `egress.allowedHosts`. For executable plugins, those rules
+are only a complete security boundary when the plugin is
 running inside a supported sandboxed runtime rather than relying on
 host-specific OS wrappers alone.
 
@@ -1341,7 +1341,7 @@ Only `connections.default` may define `params` or `discovery`. All connections i
 
 Each `providers.ui.<name>` entry must set `source` to exactly one loading mode: a local UI manifest path or a published `provider-release.yaml` metadata URL. `providers.ui.<name>.config` is only allowed when `providers.ui.<name>.source` is set.
 
-Each `plugins.<name>` entry may set `ui.path` to publish a plugin-backed UI. When `ui.bundle` is set, it must reference an existing UI bundle. When `ui.bundle` is omitted, the plugin manifest must declare `spec.ui`. A given UI may be bound by at most one plugin entry. `ui.path` and the compatibility `mountPath` must use the same path rules as a directly mounted UI.
+Each `plugins.<name>` entry may set `ui.path` to publish a plugin-backed UI. When `ui.bundle` is set, it must reference an existing UI bundle. When `ui.bundle` is omitted, the plugin manifest must declare `spec.ui`. A given UI may be bound by at most one plugin entry. `ui.path` must use the same path rules as a directly mounted UI.
 
 When `server.admin.ui` is set, it must reference an existing `providers.ui.<name>` entry. Runtime startup then requires that entry's prepared asset root to include `admin/index.html`.
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -112,7 +112,7 @@ Plugins that back mounted apps may declare their UI artifact in the plugin manif
 | `version`    | string | Optional version for `ref`. Defaults to the plugin manifest version when omitted.                                                                                                  |
 | `auth.token` | string | Optional source token used when resolving a private managed `ref`. Only valid with `ref`.                                                                                          |
 
-When a deployment sets `plugins.<name>.mountPath` and omits `plugins.<name>.ui`, Gestalt synthesizes the mounted UI binding from this block.
+When a deployment sets `plugins.<name>.ui.path` and omits `plugins.<name>.ui.bundle`, Gestalt synthesizes the mounted UI binding from this block.
 
 Source-manifest example:
 

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -63,9 +63,9 @@ capabilities, not just the host-local child-process wrapper.
 ### Egress control
 
 Every provider entry supports `egress.allowedHosts` to declare which upstream
-hosts it can reach. The legacy provider-level `allowedHosts` field remains
-accepted as an alias. When `server.egress.defaultAction` is `deny`, providers
-without an explicit allowlist are blocked from host-mediated outbound requests.
+hosts it can reach. Provider-level `allowedHosts` is no longer accepted. When
+`server.egress.defaultAction` is `deny`, providers without an explicit allowlist
+are blocked from host-mediated outbound requests.
 
 ```yaml
 server:

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -203,7 +203,7 @@ func TestE2EValidateAcceptsCanonicalConfigShapes(t *testing.T) {
   providers:
     indexeddb: inmem
   runtime:
-    provider: hosted
+    defaultHostedProvider: hosted
 providers:
   indexeddb:
     inmem:
@@ -229,16 +229,18 @@ providers:
       indexeddb:
         provider: inmem
         db: agent_state
-      runtime:
-        provider: hosted
-        image: ghcr.io/example/agent:latest
-        pool:
-          minReadyInstances: 1
-          maxReadyInstances: 2
-          startupTimeout: 5m
-          healthCheckInterval: 30s
-          restartPolicy: always
-          drainTimeout: 2m
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          image: ghcr.io/example/agent:latest
+          pool:
+            minReadyInstances: 1
+            maxReadyInstances: 2
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
 runtime:
   providers:
     hosted:

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -920,8 +920,8 @@ func writeProviderLocalBaseConfig(path, dbPath string) error {
 
 func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string, port int, mountPath, uiName, uiManifestPath string) error {
 	pluginEntry := map[string]any{
-		"source":  providerLocalSourceOverride(manifestPath),
-		"runtime": nil,
+		"source":    providerLocalSourceOverride(manifestPath),
+		"execution": nil,
 	}
 	if mountPath != "" || uiName != "" {
 		ui := map[string]any{}
@@ -961,8 +961,8 @@ func writeProviderRemotePluginOverlayConfig(path, pluginKey, manifestPath string
 	cfg := map[string]any{
 		"plugins": map[string]any{
 			pluginKey: map[string]any{
-				"source":  providerLocalSourceOverride(manifestPath),
-				"runtime": nil,
+				"source":    providerLocalSourceOverride(manifestPath),
+				"execution": nil,
 			},
 		},
 	}

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -37,12 +37,14 @@ type agentRuntimeFactoryContextKey struct{}
 
 func testHostedAgentRuntimeConfig() *config.HostedRuntimeConfig {
 	return &config.HostedRuntimeConfig{
-		MinReadyInstances:   1,
-		MaxReadyInstances:   1,
-		StartupTimeout:      "5s",
-		HealthCheckInterval: "1s",
-		RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
-		DrainTimeout:        "1s",
+		Pool: &config.HostedRuntimePoolConfig{
+			MinReadyInstances:   1,
+			MaxReadyInstances:   1,
+			StartupTimeout:      "5s",
+			HealthCheckInterval: "1s",
+			RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+			DrainTimeout:        "1s",
+		},
 	}
 }
 
@@ -211,7 +213,7 @@ func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *tes
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -221,8 +223,8 @@ func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *tes
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command: bin,
-					Runtime: runtimeConfig,
+					Command:   bin,
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
 				},
 			},
 		},
@@ -281,12 +283,12 @@ func TestAgentRuntimeConfigStartsHostedAgentWarmPool(t *testing.T) {
 		return runtimeProvider, nil
 	}
 	runtimeConfig := testHostedAgentRuntimeConfig()
-	runtimeConfig.MinReadyInstances = 2
-	runtimeConfig.MaxReadyInstances = 2
-	runtimeConfig.DrainTimeout = "2s"
+	runtimeConfig.Pool.MinReadyInstances = 2
+	runtimeConfig.Pool.MaxReadyInstances = 2
+	runtimeConfig.Pool.DrainTimeout = "2s"
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -296,8 +298,8 @@ func TestAgentRuntimeConfigStartsHostedAgentWarmPool(t *testing.T) {
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command: bin,
-					Runtime: runtimeConfig,
+					Command:   bin,
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
 				},
 			},
 		},
@@ -421,10 +423,10 @@ func TestAgentRuntimeConfigScalesOutHostedAgentWarmPool(t *testing.T) {
 		return runtimeProvider, nil
 	}
 	runtimeConfig := testHostedAgentRuntimeConfig()
-	runtimeConfig.MaxReadyInstances = 2
+	runtimeConfig.Pool.MaxReadyInstances = 2
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -434,8 +436,8 @@ func TestAgentRuntimeConfigScalesOutHostedAgentWarmPool(t *testing.T) {
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command: bin,
-					Runtime: runtimeConfig,
+					Command:   bin,
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
 				},
 			},
 		},
@@ -526,11 +528,11 @@ func TestAgentRuntimeConfigRestartsUnhealthyHostedAgent(t *testing.T) {
 		return runtimeProvider, nil
 	}
 	runtimeConfig := testHostedAgentRuntimeConfig()
-	runtimeConfig.HealthCheckInterval = "50ms"
-	runtimeConfig.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	runtimeConfig.Pool.HealthCheckInterval = "50ms"
+	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -542,7 +544,7 @@ func TestAgentRuntimeConfigRestartsUnhealthyHostedAgent(t *testing.T) {
 				"simple": {
 					Command:   bin,
 					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
-					Runtime:   runtimeConfig,
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
 				},
 			},
 		},
@@ -609,11 +611,11 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 		return runtimeProvider, nil
 	}
 	runtimeConfig := testHostedAgentRuntimeConfig()
-	runtimeConfig.HealthCheckInterval = "25ms"
-	runtimeConfig.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	runtimeConfig.Pool.HealthCheckInterval = "25ms"
+	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -625,7 +627,7 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 				"simple": {
 					Command:   bin,
 					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
-					Runtime:   runtimeConfig,
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
 				},
 			},
 		},
@@ -674,9 +676,8 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 	}
 }
 
+//nolint:paralleltest // Uses short lifecycle timing assertions that are flaky under parallel package load.
 func TestAgentRuntimeConfigDoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntimeLifetime(t *testing.T) {
-	t.Parallel()
-
 	bin := buildAgentProviderBinary(t)
 	runtimeProvider := newCapturingPluginRuntime()
 	runtimeProvider.lifecycleForSession = func(index int) *pluginruntime.SessionLifecycle {
@@ -690,13 +691,13 @@ func TestAgentRuntimeConfigDoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntim
 		return runtimeProvider, nil
 	}
 	runtimeConfig := testHostedAgentRuntimeConfig()
-	runtimeConfig.StartupTimeout = "5m"
-	runtimeConfig.DrainTimeout = "2m"
-	runtimeConfig.HealthCheckInterval = "25ms"
-	runtimeConfig.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	runtimeConfig.Pool.StartupTimeout = "5m"
+	runtimeConfig.Pool.DrainTimeout = "2m"
+	runtimeConfig.Pool.HealthCheckInterval = "25ms"
+	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -708,7 +709,7 @@ func TestAgentRuntimeConfigDoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntim
 				"simple": {
 					Command:   bin,
 					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
-					Runtime:   runtimeConfig,
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
 				},
 			},
 		},
@@ -759,13 +760,13 @@ func TestAgentRuntimeConfigReplacesExpiresOnlyRuntimeBeforeExpiry(t *testing.T) 
 		return runtimeProvider, nil
 	}
 	runtimeConfig := testHostedAgentRuntimeConfig()
-	runtimeConfig.StartupTimeout = "5m"
-	runtimeConfig.DrainTimeout = "2m"
-	runtimeConfig.HealthCheckInterval = "25ms"
-	runtimeConfig.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	runtimeConfig.Pool.StartupTimeout = "5m"
+	runtimeConfig.Pool.DrainTimeout = "2m"
+	runtimeConfig.Pool.HealthCheckInterval = "25ms"
+	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -777,7 +778,7 @@ func TestAgentRuntimeConfigReplacesExpiresOnlyRuntimeBeforeExpiry(t *testing.T) 
 				"simple": {
 					Command:   bin,
 					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
-					Runtime:   runtimeConfig,
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
 				},
 			},
 		},
@@ -915,7 +916,7 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -925,8 +926,8 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command: bin,
-					Runtime: testHostedAgentRuntimeConfig(),
+					Command:   bin,
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: testHostedAgentRuntimeConfig()},
 				},
 			},
 		},
@@ -1279,7 +1280,7 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -1289,8 +1290,8 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command: bin,
-					Runtime: testHostedAgentRuntimeConfig(),
+					Command:   bin,
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: testHostedAgentRuntimeConfig()},
 				},
 			},
 		},
@@ -1374,7 +1375,7 @@ func TestAgentRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -1384,8 +1385,8 @@ func TestAgentRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command: bin,
-					Runtime: testHostedAgentRuntimeConfig(),
+					Command:   bin,
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: testHostedAgentRuntimeConfig()},
 				},
 			},
 		},

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -406,16 +406,14 @@ func (r *capturingBundlePluginRuntime) BindHostService(ctx context.Context, req 
 func (r *capturingBundlePluginRuntime) StartPlugin(ctx context.Context, req pluginruntime.StartPluginRequest) (*pluginruntime.HostedPlugin, error) {
 	r.mu.Lock()
 	r.startPluginRequests = append(r.startPluginRequests, pluginruntime.StartPluginRequest{
-		SessionID:     req.SessionID,
-		PluginName:    req.PluginName,
-		Command:       req.Command,
-		Args:          slices.Clone(req.Args),
-		Env:           cloneRuntimeMetadata(req.Env),
-		BundleDir:     req.BundleDir,
-		Egress:        cloneRuntimeEgressPolicy(req.Egress),
-		AllowedHosts:  cloneLegacyStartPluginAllowedHosts(req),
-		DefaultAction: legacyStartPluginDefaultAction(req),
-		HostBinary:    req.HostBinary,
+		SessionID:  req.SessionID,
+		PluginName: req.PluginName,
+		Command:    req.Command,
+		Args:       slices.Clone(req.Args),
+		Env:        cloneRuntimeMetadata(req.Env),
+		BundleDir:  req.BundleDir,
+		Egress:     cloneRuntimeEgressPolicy(req.Egress),
+		HostBinary: req.HostBinary,
 	})
 	r.mu.Unlock()
 
@@ -1282,16 +1280,14 @@ func (r *capturingBundlePluginRuntime) startPluginRequestsCopy() []pluginruntime
 	out := make([]pluginruntime.StartPluginRequest, len(r.startPluginRequests))
 	for i, req := range r.startPluginRequests {
 		out[i] = pluginruntime.StartPluginRequest{
-			SessionID:     req.SessionID,
-			PluginName:    req.PluginName,
-			Command:       req.Command,
-			Args:          slices.Clone(req.Args),
-			Env:           cloneRuntimeMetadata(req.Env),
-			BundleDir:     req.BundleDir,
-			Egress:        cloneRuntimeEgressPolicy(req.Egress),
-			AllowedHosts:  cloneLegacyStartPluginAllowedHosts(req),
-			DefaultAction: legacyStartPluginDefaultAction(req),
-			HostBinary:    req.HostBinary,
+			SessionID:  req.SessionID,
+			PluginName: req.PluginName,
+			Command:    req.Command,
+			Args:       slices.Clone(req.Args),
+			Env:        cloneRuntimeMetadata(req.Env),
+			BundleDir:  req.BundleDir,
+			Egress:     cloneRuntimeEgressPolicy(req.Egress),
+			HostBinary: req.HostBinary,
 		}
 	}
 	return out
@@ -1325,12 +1321,11 @@ func cloneRuntimeEgressPolicy(policy pluginruntime.RuntimeEgressPolicy) pluginru
 	}
 }
 
-func cloneLegacyStartPluginAllowedHosts(req pluginruntime.StartPluginRequest) []string {
-	return slices.Clone(req.AllowedHosts) //nolint:staticcheck // Tests assert deprecated runtime compatibility fields remain populated.
-}
-
-func legacyStartPluginDefaultAction(req pluginruntime.StartPluginRequest) pluginruntime.PolicyAction {
-	return req.DefaultAction //nolint:staticcheck // Tests assert deprecated runtime compatibility fields remain populated.
+func hostedExecutionConfig(runtimeCfg *config.HostedRuntimeConfig) *config.ExecutionConfig {
+	return &config.ExecutionConfig{
+		Mode:    config.ExecutionModeHosted,
+		Runtime: runtimeCfg,
+	}
 }
 
 func assertStartPluginEgressPolicy(t *testing.T, req pluginruntime.StartPluginRequest, allowedHosts []string, action pluginruntime.PolicyAction) {
@@ -1340,12 +1335,6 @@ func assertStartPluginEgressPolicy(t *testing.T, req pluginruntime.StartPluginRe
 	}
 	if got := req.Egress.DefaultAction; got != action {
 		t.Fatalf("StartPlugin egress default action = %q, want %q", got, action)
-	}
-	if got := cloneLegacyStartPluginAllowedHosts(req); !slices.Equal(got, allowedHosts) {
-		t.Fatalf("StartPlugin legacy allowed hosts = %#v, want %#v", got, allowedHosts)
-	}
-	if got := legacyStartPluginDefaultAction(req); got != action {
-		t.Fatalf("StartPlugin legacy default action = %q, want %q", got, action)
 	}
 }
 
@@ -3756,7 +3745,7 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 				Invokes: []config.PluginInvocationDependency{{
 					Plugin:    "roadmap",
 					Operation: "sync",
@@ -5355,7 +5344,7 @@ func TestPluginRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *te
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -5480,7 +5469,7 @@ func TestPluginRuntimeStagesBundleForNonHostPathExecution(t *testing.T) {
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -5495,7 +5484,7 @@ func TestPluginRuntimeStagesBundleForNonHostPathExecution(t *testing.T) {
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: manifestPath,
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 			},
 		},
 	}
@@ -5588,7 +5577,7 @@ func TestPluginRuntimeDropsSourceStyleArgsForNonHostPathExecution(t *testing.T) 
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -5602,7 +5591,7 @@ func TestPluginRuntimeDropsSourceStyleArgsForNonHostPathExecution(t *testing.T) 
 				Args:                 []string{"-m", "gestalt._runtime", "/host/source", "pkg.provider", "integration"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: manifestPath,
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 			},
 		},
 	}
@@ -5688,7 +5677,7 @@ func TestPluginRuntimeRewritesHostPathArgsForNonHostPathExecution(t *testing.T) 
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -5703,7 +5692,7 @@ func TestPluginRuntimeRewritesHostPathArgsForNonHostPathExecution(t *testing.T) 
 				Args:                 []string{"--config", configPath, "--name", "example"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: manifestPath,
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 			},
 		},
 	}
@@ -5773,7 +5762,7 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 				S3:                   []string{"main"},
 			},
 		},
@@ -5851,7 +5840,7 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 			t.Fatalf("StartPlugin env should include s3 relay token %s", providerhost.S3SocketTokenEnv(binding))
 		}
 	}
-	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, "gestalt.example.test") {
+	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
 		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", allowedHosts)
 	}
 }
@@ -5959,7 +5948,7 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -5974,7 +5963,7 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: manifestPath,
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 			},
 		},
 	}
@@ -6038,7 +6027,7 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 	if got := startRequests[0].Env[providerhost.AuthorizationSocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the authorization relay token")
 	}
-	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, "gestalt.example.test") {
+	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
 		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", allowedHosts)
 	}
 }
@@ -6064,7 +6053,7 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -6080,7 +6069,7 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 				IndexedDB:            &config.PluginIndexedDBConfig{ObjectStores: []string{"tasks"}},
 			},
 		},
@@ -6153,7 +6142,7 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 	if got := startRequests[0].Env[providerhost.IndexedDBSocketTokenEnv("")]; got == "" {
 		t.Fatal("StartPlugin env should include the IndexedDB relay token")
 	}
-	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, "gestalt.example.test") {
+	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
 		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", allowedHosts)
 	}
 }
@@ -6195,7 +6184,7 @@ func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testi
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -6208,7 +6197,7 @@ func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testi
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 				IndexedDB:            &config.PluginIndexedDBConfig{ObjectStores: []string{"tasks"}},
 			},
 		},
@@ -6304,7 +6293,7 @@ func TestPluginRuntimeConfigUsesPublicCacheRelayWithoutHostServiceTunnelCapabili
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -6320,7 +6309,7 @@ func TestPluginRuntimeConfigUsesPublicCacheRelayWithoutHostServiceTunnelCapabili
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 				Cache:                []string{"session", "rate_limit"},
 			},
 		},
@@ -6398,7 +6387,7 @@ func TestPluginRuntimeConfigUsesPublicCacheRelayWithoutHostServiceTunnelCapabili
 			t.Fatalf("StartPlugin env should include cache relay token %s", providerhost.CacheSocketTokenEnv(binding))
 		}
 	}
-	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, "gestalt.example.test") {
+	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
 		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", allowedHosts)
 	}
 }
@@ -6439,7 +6428,7 @@ func TestPluginRuntimePublicCacheRelayRoundTripsThroughHostedPlugin(t *testing.T
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -6452,7 +6441,7 @@ func TestPluginRuntimePublicCacheRelayRoundTripsThroughHostedPlugin(t *testing.T
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 				Cache:                []string{"session"},
 			},
 		},
@@ -6567,7 +6556,7 @@ func TestPluginRuntimePublicS3RelayRoundTripsThroughHostedPlugin(t *testing.T) {
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -6580,7 +6569,7 @@ func TestPluginRuntimePublicS3RelayRoundTripsThroughHostedPlugin(t *testing.T) {
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 				S3:                   []string{"main"},
 			},
 		},
@@ -6719,7 +6708,7 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	bridge := newLazyInvoker()
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -6732,7 +6721,7 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 				Args:                 []string{"provider"},
 				ResolvedManifest:     callerManifest,
 				ResolvedManifestPath: filepath.Join(callerRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 				Invokes: []config.PluginInvocationDependency{
 					{Plugin: "example", Operation: "request_context"},
 				},
@@ -6839,7 +6828,7 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	if got := startRequests[0].Env[providerhost.PluginInvokerSocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the plugin invoker relay token")
 	}
-	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, relayURL.Hostname()) {
+	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, relayURL.Hostname()) {
 		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host %q", allowedHosts, relayURL.Hostname())
 	}
 	bindRequests := runtimeProvider.bindHostServiceRequests()
@@ -6875,7 +6864,7 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -6891,7 +6880,7 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 			},
 		},
 	}
@@ -6954,7 +6943,7 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 	if got := startRequests[0].Env[providerhost.WorkflowManagerSocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the workflow manager relay token")
 	}
-	if allowedHosts := cloneLegacyStartPluginAllowedHosts(startRequests[0]); !slices.Contains(allowedHosts, "gestalt.example.test") {
+	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
 		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", allowedHosts)
 	}
 }
@@ -6983,7 +6972,7 @@ func TestPluginRuntimeConfigRejectsMissingHostnameEgressCapability(t *testing.T)
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -7036,7 +7025,7 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -7051,7 +7040,7 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 				Cache:                []string{"session"},
 			},
 		},
@@ -7334,7 +7323,7 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -7349,7 +7338,7 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 			},
 		},
 	}
@@ -7483,7 +7472,7 @@ func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *t
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -7498,7 +7487,7 @@ func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *t
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 			},
 		},
 	}
@@ -7603,7 +7592,7 @@ func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapa
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -7619,8 +7608,8 @@ func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapa
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
-				AllowedHosts:         []string{"api.github.com"},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"api.github.com"}},
 			},
 		},
 	}
@@ -7689,7 +7678,7 @@ func TestPluginRuntimeConfigSkipsPublicEgressProxyWhenHostnameEgressIsNotRequire
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyAllow)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -7705,7 +7694,7 @@ func TestPluginRuntimeConfigSkipsPublicEgressProxyWhenHostnameEgressIsNotRequire
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 			},
 		},
 	}
@@ -7756,7 +7745,7 @@ func TestPluginRuntimeConfigUsesDirectHostServiceBindingsAndSkipsPublicEgressPro
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -7772,8 +7761,8 @@ func TestPluginRuntimeConfigUsesDirectHostServiceBindingsAndSkipsPublicEgressPro
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
-				AllowedHosts:         []string{"api.github.com"},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"api.github.com"}},
 				Cache:                []string{"session"},
 			},
 		},
@@ -7858,7 +7847,7 @@ func TestPluginRuntimePublicEgressProxyRoundTripsThroughHostedPlugin(t *testing.
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -7873,8 +7862,8 @@ func TestPluginRuntimePublicEgressProxyRoundTripsThroughHostedPlugin(t *testing.
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
-				AllowedHosts:         []string{"127.0.0.1", "localhost"},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"127.0.0.1", "localhost"}},
 			},
 		},
 	}
@@ -7949,7 +7938,7 @@ func TestPluginRuntimeConfigRejectsDefaultDenyWithoutHostnameEgressCapability(t 
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -7965,7 +7954,7 @@ func TestPluginRuntimeConfigRejectsDefaultDenyWithoutHostnameEgressCapability(t 
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Runtime:              &config.HostedRuntimeConfig{},
+				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
 			},
 		},
 	}

--- a/gestaltd/internal/bootstrap/plugin_runtime_executable.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_executable.go
@@ -35,7 +35,7 @@ func buildExecutablePluginRuntime(ctx context.Context, name string, entry *confi
 		Args:         append([]string(nil), entry.Args...),
 		Env:          maps.Clone(entry.Env),
 		Config:       runtimeConfig,
-		AllowedHosts: entry.EffectiveAllowedHosts(),
+		Egress:       deps.Egress.Policy(entry.EffectiveAllowedHosts()),
 		HostBinary:   entry.HostBinary,
 		HostServices: buildRuntimeProviderHostServices(name, deps),
 		Telemetry:    deps.Telemetry,

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -909,9 +909,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 			AllowedHosts:  egressPlan.RuntimeAllowedHosts,
 			DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
 		},
-		AllowedHosts:  egressPlan.RuntimeAllowedHosts,
-		DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
-		HostBinary:    entry.HostBinary,
+		HostBinary: entry.HostBinary,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("start hosted plugin: %w", err)
@@ -1139,7 +1137,7 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	})
 
 	startEnv := maps.Clone(cfg.Env)
-	agentAllowedHosts := slices.Clone(cfg.AllowedHosts)
+	agentAllowedHosts := cfg.EgressPolicy("").AllowedHosts
 	if len(agentAllowedHosts) == 0 {
 		agentAllowedHosts = slices.Clone(launch.allowedHosts)
 	}
@@ -1193,9 +1191,7 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 			AllowedHosts:  egressPlan.RuntimeAllowedHosts,
 			DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
 		},
-		AllowedHosts:  egressPlan.RuntimeAllowedHosts,
-		DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
-		HostBinary:    cfg.HostBinary,
+		HostBinary: cfg.HostBinary,
 	})
 	recordHostedAgentRuntimeStartPhase(ctx, name, "plugin_start", phaseStarted, err)
 	if err != nil {

--- a/gestaltd/internal/bootstrap/sandbox_test.go
+++ b/gestaltd/internal/bootstrap/sandbox_test.go
@@ -66,7 +66,7 @@ func TestSandboxedPluginCannotReadUnauthorizedFile(t *testing.T) {
 			"sandboxed": {
 				Command:              bin,
 				Args:                 []string{"provider"},
-				AllowedHosts:         []string{"localhost"},
+				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"localhost"}},
 				HostBinary:           hostBin,
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
@@ -110,7 +110,7 @@ func TestSandboxedPluginCanCommunicateViaGRPC(t *testing.T) {
 			"sandboxed": {
 				Command:              bin,
 				Args:                 []string{"provider"},
-				AllowedHosts:         []string{"localhost"},
+				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"localhost"}},
 				HostBinary:           hostBin,
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
@@ -155,7 +155,7 @@ func TestSandboxedSynthesizedSourcePluginCanStart(t *testing.T) {
 	cfg := &config.Config{
 		Plugins: map[string]*config.ProviderEntry{
 			"example": {
-				AllowedHosts:         []string{"localhost"},
+				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"localhost"}},
 				HostBinary:           hostBin,
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: manifestPath,
@@ -256,7 +256,7 @@ func TestSandboxedPluginHTTPProxyAllowsConfiguredHosts(t *testing.T) {
 			"proxied": {
 				Command:              bin,
 				Args:                 []string{"provider"},
-				AllowedHosts:         []string{host},
+				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{host}},
 				HostBinary:           hostBin,
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
@@ -312,7 +312,7 @@ func TestSandboxedPluginHTTPProxyBlocksUnconfiguredHosts(t *testing.T) {
 			"blocked": {
 				Command:              bin,
 				Args:                 []string{"provider"},
-				AllowedHosts:         []string{"not-a-real-host.example.com"},
+				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"not-a-real-host.example.com"}},
 				HostBinary:           hostBin,
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -370,13 +370,11 @@ func (g GitHubReleaseSourceDef) Location() string {
 
 // ProviderEntry is the universal configuration for any provider.
 type ProviderEntry struct {
-	Source  ProviderSource        `yaml:"source"`
-	Config  yaml.Node             `yaml:"config,omitempty"`
-	Default bool                  `yaml:"default,omitempty"`
-	Env     map[string]string     `yaml:"env,omitempty"`
-	Egress  *ProviderEgressConfig `yaml:"egress,omitempty"`
-	// Deprecated: use egress.allowedHosts.
-	AllowedHosts    []string                       `yaml:"allowedHosts,omitempty"`
+	Source          ProviderSource                 `yaml:"source"`
+	Config          yaml.Node                      `yaml:"config,omitempty"`
+	Default         bool                           `yaml:"default,omitempty"`
+	Env             map[string]string              `yaml:"env,omitempty"`
+	Egress          *ProviderEgressConfig          `yaml:"egress,omitempty"`
 	DisplayName     string                         `yaml:"displayName,omitempty"`
 	Description     string                         `yaml:"description,omitempty"`
 	IconFile        string                         `yaml:"iconFile,omitempty"`
@@ -396,10 +394,8 @@ type ProviderEntry struct {
 	Cache             []string                      `yaml:"cache,omitempty"`
 	S3                []string                      `yaml:"s3,omitempty"`
 	Execution         *ExecutionConfig              `yaml:"execution,omitempty"`
-	// Deprecated: use execution.mode=hosted and execution.runtime.
-	Runtime  *HostedRuntimeConfig      `yaml:"runtime,omitempty"`
-	Surfaces *ProviderSurfaceOverrides `yaml:"surfaces,omitempty"`
-	MCP      bool                      `yaml:"mcp,omitempty"`
+	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
+	MCP               bool                          `yaml:"mcp,omitempty"`
 
 	// Runtime-resolved fields (populated during init/bootstrap, not from YAML)
 	Command              string                                `yaml:"-"`
@@ -525,17 +521,11 @@ type ExecutionConfig struct {
 }
 
 type HostedRuntimeConfig struct {
-	Provider            string                     `yaml:"provider,omitempty"`
-	Template            string                     `yaml:"template,omitempty"`
-	Image               string                     `yaml:"image,omitempty"`
-	Metadata            map[string]string          `yaml:"metadata,omitempty"`
-	Pool                *HostedRuntimePoolConfig   `yaml:"pool,omitempty"`
-	MinReadyInstances   int                        `yaml:"-"`
-	MaxReadyInstances   int                        `yaml:"-"`
-	StartupTimeout      string                     `yaml:"-"`
-	HealthCheckInterval string                     `yaml:"-"`
-	RestartPolicy       HostedRuntimeRestartPolicy `yaml:"-"`
-	DrainTimeout        string                     `yaml:"-"`
+	Provider string                   `yaml:"provider,omitempty"`
+	Template string                   `yaml:"template,omitempty"`
+	Image    string                   `yaml:"image,omitempty"`
+	Metadata map[string]string        `yaml:"metadata,omitempty"`
+	Pool     *HostedRuntimePoolConfig `yaml:"pool,omitempty"`
 }
 
 type HostedRuntimePoolConfig struct {
@@ -567,20 +557,7 @@ func (c *HostedRuntimeConfig) LifecyclePolicyFieldsSet() bool {
 	if c == nil {
 		return false
 	}
-	return c.flatLifecyclePolicyFieldsSet() ||
-		(c.Pool != nil && c.Pool.lifecyclePolicyFieldsSet())
-}
-
-func (c *HostedRuntimeConfig) flatLifecyclePolicyFieldsSet() bool {
-	if c == nil {
-		return false
-	}
-	return c.MinReadyInstances != 0 ||
-		c.MaxReadyInstances != 0 ||
-		strings.TrimSpace(c.StartupTimeout) != "" ||
-		strings.TrimSpace(c.HealthCheckInterval) != "" ||
-		strings.TrimSpace(string(c.RestartPolicy)) != "" ||
-		strings.TrimSpace(c.DrainTimeout) != ""
+	return c.Pool != nil && c.Pool.lifecyclePolicyFieldsSet()
 }
 
 func (c *HostedRuntimePoolConfig) lifecyclePolicyFieldsSet() bool {
@@ -629,14 +606,7 @@ func (c *HostedRuntimeConfig) lifecyclePolicyConfig() HostedRuntimePoolConfig {
 	if c.Pool != nil {
 		return *c.Pool
 	}
-	return HostedRuntimePoolConfig{
-		MinReadyInstances:   c.MinReadyInstances,
-		MaxReadyInstances:   c.MaxReadyInstances,
-		StartupTimeout:      c.StartupTimeout,
-		HealthCheckInterval: c.HealthCheckInterval,
-		RestartPolicy:       c.RestartPolicy,
-		DrainTimeout:        c.DrainTimeout,
-	}
+	return HostedRuntimePoolConfig{}
 }
 
 type WorkflowsConfig struct {
@@ -933,14 +903,7 @@ func (f providerEntryFields) toProviderEntry() ProviderEntry {
 func providerEntryFieldsFromEntry(e ProviderEntry) providerEntryFields {
 	e.Egress = cloneProviderEgressConfig(e.Egress)
 	e.Execution = cloneExecutionConfig(e.Execution)
-	e.Runtime = cloneHostedRuntimeConfig(e.Runtime)
 	normalizeProviderEntryAliases(&e)
-	if e.Egress != nil {
-		e.AllowedHosts = nil
-	}
-	if e.Execution != nil {
-		e.Runtime = nil
-	}
 	return providerEntryFields(e)
 }
 
@@ -948,16 +911,11 @@ func normalizeProviderEntryAliases(entry *ProviderEntry) {
 	if entry == nil {
 		return
 	}
-	entry.AllowedHosts = trimStringSlice(entry.AllowedHosts)
 	if entry.Egress != nil {
 		entry.Egress.AllowedHosts = trimStringSlice(entry.Egress.AllowedHosts)
-		entry.AllowedHosts = slices.Clone(entry.Egress.AllowedHosts)
-	} else if len(entry.AllowedHosts) > 0 {
-		entry.Egress = &ProviderEgressConfig{AllowedHosts: slices.Clone(entry.AllowedHosts)}
 	}
 	if entry.Execution != nil {
 		entry.Execution.Mode = ExecutionMode(strings.ToLower(strings.TrimSpace(string(entry.Execution.Mode))))
-		entry.Runtime = entry.Execution.Runtime
 	}
 }
 
@@ -986,7 +944,7 @@ func (e *ProviderEntry) EffectiveAllowedHosts() []string {
 	if e.Egress != nil {
 		return slices.Clone(e.Egress.AllowedHosts)
 	}
-	return slices.Clone(e.AllowedHosts)
+	return nil
 }
 
 func (e *ProviderEntry) UsesHostedExecution() bool {
@@ -1000,7 +958,7 @@ func (e *ProviderEntry) UsesHostedExecution() bool {
 		}
 		return mode == ExecutionModeHosted
 	}
-	return e.Runtime != nil
+	return false
 }
 
 func (e *ProviderEntry) HostedRuntimeConfig() *HostedRuntimeConfig {
@@ -1010,7 +968,7 @@ func (e *ProviderEntry) HostedRuntimeConfig() *HostedRuntimeConfig {
 	if e.Execution != nil {
 		return e.Execution.Runtime
 	}
-	return e.Runtime
+	return nil
 }
 
 func cloneProviderEgressConfig(src *ProviderEgressConfig) *ProviderEgressConfig {
@@ -1035,17 +993,11 @@ func cloneHostedRuntimeConfig(src *HostedRuntimeConfig) *HostedRuntimeConfig {
 		return nil
 	}
 	return &HostedRuntimeConfig{
-		Provider:            src.Provider,
-		Template:            src.Template,
-		Image:               src.Image,
-		Metadata:            maps.Clone(src.Metadata),
-		Pool:                cloneHostedRuntimePoolConfig(src.Pool),
-		MinReadyInstances:   src.MinReadyInstances,
-		MaxReadyInstances:   src.MaxReadyInstances,
-		StartupTimeout:      src.StartupTimeout,
-		HealthCheckInterval: src.HealthCheckInterval,
-		RestartPolicy:       src.RestartPolicy,
-		DrainTimeout:        src.DrainTimeout,
+		Provider: src.Provider,
+		Template: src.Template,
+		Image:    src.Image,
+		Metadata: maps.Clone(src.Metadata),
+		Pool:     cloneHostedRuntimePoolConfig(src.Pool),
 	}
 }
 
@@ -1519,8 +1471,6 @@ type ServerConfig struct {
 
 type ServerRuntimeConfig struct {
 	DefaultHostedProvider string `yaml:"defaultHostedProvider,omitempty"`
-	// Deprecated: use defaultHostedProvider.
-	Provider string `yaml:"provider,omitempty"`
 }
 
 func (s ServerConfig) PublicListener() ListenerConfig {
@@ -1890,11 +1840,7 @@ func normalizeServerRuntimeCompatibility(cfg *Config) {
 	if cfg == nil {
 		return
 	}
-	cfg.Server.Runtime.Provider = strings.TrimSpace(cfg.Server.Runtime.Provider)
 	cfg.Server.Runtime.DefaultHostedProvider = strings.TrimSpace(cfg.Server.Runtime.DefaultHostedProvider)
-	if cfg.Server.Runtime.DefaultHostedProvider == "" {
-		cfg.Server.Runtime.DefaultHostedProvider = cfg.Server.Runtime.Provider
-	}
 }
 
 func normalizeProviderEntryCompatibility(cfg *Config) {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3622,8 +3622,10 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      runtime:
-        provider: missing
+      execution:
+        mode: hosted
+        runtime:
+          provider: missing
 runtime:
   providers:
     hosted:
@@ -3631,7 +3633,7 @@ runtime:
         path: ./providers/runtime/modal
 server:
   runtime:
-    provider: hosted
+    defaultHostedProvider: hosted
   encryptionKey: server-key
 `)
 
@@ -3639,7 +3641,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `providers.agent.simple.runtime.provider references unknown runtime "missing"`) {
+		if !strings.Contains(err.Error(), `providers.agent.simple.execution.runtime.provider references unknown runtime "missing"`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -3655,15 +3657,17 @@ providers:
       source:
         path: ./providers/agent/simple
       indexeddb: agent_state
-      runtime:
-        provider: hosted
-        pool:
-          minReadyInstances: 1
-          maxReadyInstances: 2
-          startupTimeout: 5m
-          healthCheckInterval: 30s
-          restartPolicy: always
-          drainTimeout: 2m
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          pool:
+            minReadyInstances: 1
+            maxReadyInstances: 2
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
   indexeddb:
     agent_state:
       source:
@@ -3676,7 +3680,7 @@ runtime:
 server:
   encryptionKey: server-key
 `
-	t.Run("accepts required lifecycle fields under agent runtime pool", func(t *testing.T) {
+	t.Run("accepts required lifecycle fields under agent execution runtime pool", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, base)
@@ -3684,7 +3688,7 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		runtimeCfg := cfg.Providers.Agent["simple"].Runtime
+		runtimeCfg := cfg.Providers.Agent["simple"].Execution.Runtime
 		if runtimeCfg.Pool == nil {
 			t.Fatal("runtime pool = nil")
 		}
@@ -3758,8 +3762,10 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      runtime:
-        provider: hosted
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
 runtime:
   providers:
     hosted:
@@ -3768,7 +3774,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.runtime.pool.minReadyInstances is required",
+			want: "providers.agent.simple.execution.runtime.pool.minReadyInstances is required",
 		},
 		{
 			name: "rejects missing lifecycle fields",
@@ -3778,14 +3784,16 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      runtime:
-        provider: hosted
-        pool:
-          minReadyInstances: 1
-          startupTimeout: 5m
-          healthCheckInterval: 30s
-          restartPolicy: always
-          drainTimeout: 2m
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          pool:
+            minReadyInstances: 1
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
 runtime:
   providers:
     hosted:
@@ -3794,7 +3802,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.runtime.pool.maxReadyInstances is required",
+			want: "providers.agent.simple.execution.runtime.pool.maxReadyInstances is required",
 		},
 		{
 			name: "rejects missing execution runtime on hosted agent",
@@ -3852,15 +3860,17 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      runtime:
-        provider: hosted
-        pool:
-          minReadyInstances: 2
-          maxReadyInstances: 1
-          startupTimeout: 5m
-          healthCheckInterval: 30s
-          restartPolicy: always
-          drainTimeout: 2m
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          pool:
+            minReadyInstances: 2
+            maxReadyInstances: 1
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
 runtime:
   providers:
     hosted:
@@ -3869,7 +3879,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.runtime.pool.maxReadyInstances must be greater than or equal to minReadyInstances",
+			want: "providers.agent.simple.execution.runtime.pool.maxReadyInstances must be greater than or equal to minReadyInstances",
 		},
 		{
 			name: "rejects unknown restart policy",
@@ -3879,15 +3889,17 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      runtime:
-        provider: hosted
-        pool:
-          minReadyInstances: 1
-          maxReadyInstances: 2
-          startupTimeout: 5m
-          healthCheckInterval: 30s
-          restartPolicy: sometimes
-          drainTimeout: 2m
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          pool:
+            minReadyInstances: 1
+            maxReadyInstances: 2
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: sometimes
+            drainTimeout: 2m
 runtime:
   providers:
     hosted:
@@ -3896,7 +3908,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.runtime.pool.restartPolicy must be one of",
+			want: "providers.agent.simple.execution.runtime.pool.restartPolicy must be one of",
 		},
 		{
 			name: "rejects restart without agent indexeddb",
@@ -3906,6 +3918,36 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          pool:
+            minReadyInstances: 1
+            maxReadyInstances: 2
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: `providers.agent.simple.execution.runtime.pool.restartPolicy "always" requires providers.agent.simple.indexeddb as the provider persistence hook`,
+		},
+		{
+			name: "rejects lifecycle fields on plugin runtime",
+			yaml: `
+plugins:
+  service:
+    source:
+      path: ./plugins/service/manifest.yaml
+    execution:
+      mode: hosted
       runtime:
         provider: hosted
         pool:
@@ -3923,33 +3965,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: `providers.agent.simple.runtime.pool.restartPolicy "always" requires providers.agent.simple.indexeddb as the provider persistence hook`,
-		},
-		{
-			name: "rejects lifecycle fields on plugin runtime",
-			yaml: `
-plugins:
-  service:
-    source:
-      path: ./plugins/service/manifest.yaml
-    runtime:
-      provider: hosted
-      pool:
-        minReadyInstances: 1
-        maxReadyInstances: 2
-        startupTimeout: 5m
-        healthCheckInterval: 30s
-        restartPolicy: always
-        drainTimeout: 2m
-runtime:
-  providers:
-    hosted:
-      source:
-        path: ./providers/runtime/modal
-server:
-  encryptionKey: server-key
-`,
-			want: "plugins.service.runtime lifecycle fields are only supported on providers.agent.*.runtime",
+			want: "plugins.service.execution.runtime lifecycle fields are only supported on providers.agent.*.execution.runtime",
 		},
 	}
 	for _, tc := range cases {
@@ -3968,7 +3984,7 @@ server:
 	}
 }
 
-func TestLoadPathsPreferredProviderEntryAliasesOverrideLegacy(t *testing.T) {
+func TestLoadPathsProviderExecutionAndEgressOverride(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -3981,10 +3997,18 @@ plugins:
   service:
     source:
       path: ./plugins/service/manifest.yaml
-    runtime:
-      provider: missing
-    allowedHosts:
-      - api.github.com
+    execution:
+      mode: hosted
+      runtime:
+        provider: hosted
+    egress:
+      allowedHosts:
+        - api.github.com
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
 `), 0o644); err != nil {
 		t.Fatalf("writing base config: %v", err)
 	}
@@ -3993,6 +4017,7 @@ plugins:
   service:
     execution:
       mode: local
+      runtime: null
     egress:
       allowedHosts: []
 `), 0o644); err != nil {
@@ -4005,13 +4030,10 @@ plugins:
 	}
 	entry := cfg.Plugins["service"]
 	if entry.UsesHostedExecution() {
-		t.Fatal("UsesHostedExecution = true, want preferred execution.mode: local to override legacy runtime")
-	}
-	if entry.Runtime != nil {
-		t.Fatalf("Runtime = %#v, want nil after preferred execution override", entry.Runtime)
+		t.Fatal("UsesHostedExecution = true, want execution.mode: local override")
 	}
 	if got := entry.EffectiveAllowedHosts(); len(got) != 0 {
-		t.Fatalf("EffectiveAllowedHosts = %#v, want empty after preferred egress override", got)
+		t.Fatalf("EffectiveAllowedHosts = %#v, want empty after egress override", got)
 	}
 }
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -415,11 +415,7 @@ func validateRuntimeConfig(cfg *Config) error {
 		return nil
 	}
 	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
-	cfg.Server.Runtime.Provider = strings.TrimSpace(cfg.Server.Runtime.Provider)
 	cfg.Server.Runtime.DefaultHostedProvider = strings.TrimSpace(cfg.Server.Runtime.DefaultHostedProvider)
-	if cfg.Server.Runtime.Provider != "" && cfg.Server.Runtime.DefaultHostedProvider != "" && cfg.Server.Runtime.Provider != cfg.Server.Runtime.DefaultHostedProvider {
-		return fmt.Errorf("config validation: server.runtime.provider and server.runtime.defaultHostedProvider must match when both are set")
-	}
 	for name, entry := range cfg.Runtime.Providers {
 		if entry == nil {
 			return fmt.Errorf("config validation: runtime.providers.%s is required", name)
@@ -484,13 +480,6 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax
 	if entry.Execution != nil {
 		if err := normalizeExecutionConfig("plugins."+name, entry.Execution, false); err != nil {
 			return err
-		}
-	} else if entry.Runtime != nil {
-		if err := normalizeHostedRuntimeConfig("plugins."+name, entry.Runtime); err != nil {
-			return err
-		}
-		if entry.Runtime.LifecyclePolicyFieldsSet() {
-			return fmt.Errorf("config validation: plugins.%s.runtime lifecycle fields are only supported on providers.agent.*.runtime", name)
 		}
 	}
 	seenInvokes := make(map[string]int, len(entry.Invokes))
@@ -674,10 +663,6 @@ func validateAgentConfig(cfg *Config) error {
 			if err := normalizeExecutionConfig("providers.agent."+name, entry.Execution, true); err != nil {
 				return err
 			}
-		} else if entry.Runtime != nil {
-			if err := normalizeHostedRuntimeConfig("providers.agent."+name, entry.Runtime); err != nil {
-				return err
-			}
 		}
 		if err := validateAgentProviderFields(cfg, name, entry); err != nil {
 			return err
@@ -755,9 +740,6 @@ func normalizeHostedRuntimeConfig(subject string, runtimeCfg *HostedRuntimeConfi
 		return nil
 	}
 	if runtimeCfg.Pool != nil {
-		if runtimeCfg.flatLifecyclePolicyFieldsSet() {
-			return fmt.Errorf("config validation: %s.runtime.pool cannot be combined with flat runtime lifecycle fields", subject)
-		}
 		runtimeCfg.Pool.StartupTimeout = strings.TrimSpace(runtimeCfg.Pool.StartupTimeout)
 		runtimeCfg.Pool.HealthCheckInterval = strings.TrimSpace(runtimeCfg.Pool.HealthCheckInterval)
 		runtimeCfg.Pool.RestartPolicy = HostedRuntimeRestartPolicy(strings.TrimSpace(string(runtimeCfg.Pool.RestartPolicy)))
@@ -766,10 +748,6 @@ func normalizeHostedRuntimeConfig(subject string, runtimeCfg *HostedRuntimeConfi
 	runtimeCfg.Provider = strings.TrimSpace(runtimeCfg.Provider)
 	runtimeCfg.Template = strings.TrimSpace(runtimeCfg.Template)
 	runtimeCfg.Image = strings.TrimSpace(runtimeCfg.Image)
-	runtimeCfg.StartupTimeout = strings.TrimSpace(runtimeCfg.StartupTimeout)
-	runtimeCfg.HealthCheckInterval = strings.TrimSpace(runtimeCfg.HealthCheckInterval)
-	runtimeCfg.RestartPolicy = HostedRuntimeRestartPolicy(strings.TrimSpace(string(runtimeCfg.RestartPolicy)))
-	runtimeCfg.DrainTimeout = strings.TrimSpace(runtimeCfg.DrainTimeout)
 	trimmed := make(map[string]string, len(runtimeCfg.Metadata))
 	for key, value := range runtimeCfg.Metadata {
 		trimmedKey := strings.TrimSpace(key)
@@ -830,10 +808,7 @@ func hostedRuntimeConfigAndPath(subject string, entry *ProviderEntry) (*HostedRu
 	if entry != nil && entry.Execution != nil {
 		return entry.Execution.Runtime, subject + ".execution.runtime"
 	}
-	if entry != nil {
-		return entry.Runtime, subject + ".runtime"
-	}
-	return nil, subject + ".runtime"
+	return nil, subject + ".execution.runtime"
 }
 
 func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEntry) error {
@@ -861,9 +836,6 @@ func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEnt
 	}
 	if entry.Execution != nil {
 		return fmt.Errorf("config validation: %s.execution is only supported on plugins.* and providers.agent.*", subject)
-	}
-	if entry.Runtime != nil {
-		return fmt.Errorf("config validation: %s.runtime is only supported on plugins.*", subject)
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
@@ -918,9 +890,6 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	}
 	if entry.Execution != nil {
 		return fmt.Errorf("config validation: %s.execution is only supported on plugins.* and providers.agent.*", subject)
-	}
-	if entry.Runtime != nil {
-		return fmt.Errorf("config validation: %s.runtime is only supported on plugins.*", subject)
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -316,14 +316,10 @@ func ResolveEffectiveExecution(configPath string, entry *ProviderEntry, selected
 	if entry == nil {
 		return EffectiveExecution{Mode: ExecutionModeLocal}, nil
 	}
-	runtimeCfg := entry.Runtime
 	mode := ExecutionModeLocal
-	providerPath := "runtime.provider"
-	if runtimeCfg != nil {
-		mode = ExecutionModeHosted
-	}
+	providerPath := "execution.runtime.provider"
+	var runtimeCfg *HostedRuntimeConfig
 	if entry.Execution != nil {
-		providerPath = "execution.runtime.provider"
 		mode = entry.Execution.Mode
 		if mode == "" {
 			if entry.Execution.Runtime != nil {
@@ -371,10 +367,7 @@ func ResolveEffectiveExecution(configPath string, entry *ProviderEntry, selected
 }
 
 func (s ServerRuntimeConfig) SelectedDefaultHostedProvider() string {
-	if provider := strings.TrimSpace(s.DefaultHostedProvider); provider != "" {
-		return provider
-	}
-	return strings.TrimSpace(s.Provider)
+	return strings.TrimSpace(s.DefaultHostedProvider)
 }
 func ResolveSelectedHostProvider(kind HostProviderKind, explicit string, entries map[string]*ProviderEntry) (string, *ProviderEntry, error) {
 	if len(entries) == 0 {
@@ -421,11 +414,11 @@ func ResolveSelectedRuntimeProvider(explicit string, entries map[string]*Runtime
 	explicit = strings.TrimSpace(explicit)
 	if explicit != "" {
 		if len(entries) == 0 {
-			return "", nil, fmt.Errorf("config validation: server.runtime.provider references unknown runtime %q", explicit)
+			return "", nil, fmt.Errorf("config validation: server.runtime.defaultHostedProvider references unknown runtime %q", explicit)
 		}
 		entry, ok := entries[explicit]
 		if !ok || entry == nil {
-			return "", nil, fmt.Errorf("config validation: server.runtime.provider references unknown runtime %q", explicit)
+			return "", nil, fmt.Errorf("config validation: server.runtime.defaultHostedProvider references unknown runtime %q", explicit)
 		}
 		return explicit, entry, nil
 	}

--- a/gestaltd/internal/config/runtime_config.go
+++ b/gestaltd/internal/config/runtime_config.go
@@ -14,7 +14,6 @@ type componentRuntimeConfig struct {
 	Args         []string              `yaml:"args,omitempty"`
 	Env          map[string]string     `yaml:"env,omitempty"`
 	Egress       *ProviderEgressConfig `yaml:"egress,omitempty"`
-	AllowedHosts []string              `yaml:"allowedHosts,omitempty"`
 	HostBinary   string                `yaml:"hostBinary,omitempty"`
 	ManifestPath string                `yaml:"manifestPath,omitempty"`
 	Config       yaml.Node             `yaml:"config,omitempty"`
@@ -35,7 +34,6 @@ func BuildComponentRuntimeConfigNode(name, kind string, entry *ProviderEntry, pr
 		Args:         append([]string(nil), entry.Args...),
 		Env:          entry.Env,
 		Egress:       cloneProviderEgressConfig(entry.Egress),
-		AllowedHosts: entry.EffectiveAllowedHosts(),
 		HostBinary:   entry.HostBinary,
 		ManifestPath: entry.ResolvedManifestPath,
 		Config:       providerConfig,

--- a/gestaltd/internal/drivers/agent/provider/factory.go
+++ b/gestaltd/internal/drivers/agent/provider/factory.go
@@ -29,15 +29,14 @@ var Factory bootstrap.AgentFactory = func(ctx context.Context, name string, node
 	cfg = prepared.YAMLConfig
 
 	return providerhost.NewExecutableAgent(ctx, providerhost.AgentExecConfig{
-		Command:       cfg.Command,
-		Args:          cfg.Args,
-		Env:           cfg.Env,
-		Config:        cfg.Config,
-		AllowedHosts:  cfg.AllowedHosts,
-		DefaultAction: deps.Egress.DefaultAction,
-		HostBinary:    cfg.HostBinary,
-		Cleanup:       prepared.Cleanup,
-		HostServices:  hostServices,
-		Name:          name,
+		Command:      cfg.Command,
+		Args:         cfg.Args,
+		Env:          cfg.Env,
+		Config:       cfg.Config,
+		Egress:       cfg.EgressPolicy(deps.Egress.DefaultAction),
+		HostBinary:   cfg.HostBinary,
+		Cleanup:      prepared.Cleanup,
+		HostServices: hostServices,
+		Name:         name,
 	})
 }

--- a/gestaltd/internal/drivers/auth/provider/factory.go
+++ b/gestaltd/internal/drivers/auth/provider/factory.go
@@ -39,15 +39,15 @@ var Factory bootstrap.AuthFactory = func(node yaml.Node, deps bootstrap.Deps) (c
 		callbackURL = deps.BaseURL + config.AuthCallbackPath
 	}
 	return providerhost.NewExecutableAuthenticationProvider(context.Background(), providerhost.AuthenticationExecConfig{
-		Command:      cfg.Command,
-		Args:         cfg.Args,
-		Env:          cfg.Env,
-		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
-		HostBinary:   cfg.HostBinary,
-		Cleanup:      prepared.Cleanup,
-		Name:         cfg.Name,
-		CallbackURL:  callbackURL,
-		SessionKey:   deps.EncryptionKey,
+		Command:     cfg.Command,
+		Args:        cfg.Args,
+		Env:         cfg.Env,
+		Config:      cfg.Config,
+		Egress:      cfg.EgressPolicy(""),
+		HostBinary:  cfg.HostBinary,
+		Cleanup:     prepared.Cleanup,
+		Name:        cfg.Name,
+		CallbackURL: callbackURL,
+		SessionKey:  deps.EncryptionKey,
 	})
 }

--- a/gestaltd/internal/drivers/authorization/provider/factory.go
+++ b/gestaltd/internal/drivers/authorization/provider/factory.go
@@ -33,7 +33,7 @@ var Factory bootstrap.AuthorizationFactory = func(node yaml.Node, hostServices [
 		Args:         cfg.Args,
 		Env:          cfg.Env,
 		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
+		Egress:       cfg.EgressPolicy(""),
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      prepared.Cleanup,
 		HostServices: hostServices,

--- a/gestaltd/internal/drivers/cache/provider/factory.go
+++ b/gestaltd/internal/drivers/cache/provider/factory.go
@@ -29,13 +29,13 @@ var Factory bootstrap.CacheFactory = func(node yaml.Node) (corecache.Cache, erro
 	cfg = prepared.YAMLConfig
 
 	return providerhost.NewExecutableCache(context.Background(), providerhost.CacheExecConfig{
-		Command:      cfg.Command,
-		Args:         cfg.Args,
-		Env:          cfg.Env,
-		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
-		HostBinary:   cfg.HostBinary,
-		Cleanup:      prepared.Cleanup,
-		Name:         cfg.Name,
+		Command:    cfg.Command,
+		Args:       cfg.Args,
+		Env:        cfg.Env,
+		Config:     cfg.Config,
+		Egress:     cfg.EgressPolicy(""),
+		HostBinary: cfg.HostBinary,
+		Cleanup:    prepared.Cleanup,
+		Name:       cfg.Name,
 	})
 }

--- a/gestaltd/internal/drivers/componentprovider/factory.go
+++ b/gestaltd/internal/drivers/componentprovider/factory.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"gopkg.in/yaml.v3"
 )
@@ -16,10 +17,14 @@ type YAMLConfig struct {
 	Command      string            `yaml:"command"`
 	Args         []string          `yaml:"args"`
 	Env          map[string]string `yaml:"env"`
-	AllowedHosts []string          `yaml:"allowedHosts"`
+	Egress       *YAMLEgressConfig `yaml:"egress,omitempty"`
 	HostBinary   string            `yaml:"hostBinary"`
 	ManifestPath string            `yaml:"manifestPath"`
 	Config       map[string]any    `yaml:"config"`
+}
+
+type YAMLEgressConfig struct {
+	AllowedHosts []string `yaml:"allowedHosts,omitempty"`
 }
 
 type PreparedConfig struct {
@@ -40,6 +45,16 @@ func DecodeYAMLConfig(node yaml.Node, subject string) (YAMLConfig, error) {
 		return YAMLConfig{}, fmt.Errorf("%s: parsing config: %w", subject, err)
 	}
 	return cfg, nil
+}
+
+func (c YAMLConfig) EgressPolicy(defaultAction egress.PolicyAction) egress.Policy {
+	if c.Egress == nil {
+		return egress.Policy{DefaultAction: defaultAction}
+	}
+	return egress.Policy{
+		AllowedHosts:  append([]string(nil), c.Egress.AllowedHosts...),
+		DefaultAction: defaultAction,
+	}
 }
 
 func PrepareExecution(params PrepareParams) (PreparedConfig, error) {

--- a/gestaltd/internal/drivers/externalcredentials/provider/factory.go
+++ b/gestaltd/internal/drivers/externalcredentials/provider/factory.go
@@ -33,7 +33,7 @@ var Factory bootstrap.ExternalCredentialFactory = func(ctx context.Context, name
 		Args:         cfg.Args,
 		Env:          cfg.Env,
 		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
+		Egress:       cfg.EgressPolicy(""),
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      prepared.Cleanup,
 		HostServices: hostServices,

--- a/gestaltd/internal/drivers/indexeddb/provider/factory.go
+++ b/gestaltd/internal/drivers/indexeddb/provider/factory.go
@@ -29,13 +29,13 @@ var Factory bootstrap.IndexedDBFactory = func(node yaml.Node) (indexeddb.Indexed
 	cfg = prepared.YAMLConfig
 
 	return providerhost.NewExecutableIndexedDB(context.Background(), providerhost.IndexedDBExecConfig{
-		Command:      cfg.Command,
-		Args:         cfg.Args,
-		Env:          cfg.Env,
-		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
-		HostBinary:   cfg.HostBinary,
-		Cleanup:      prepared.Cleanup,
-		Name:         cfg.Name,
+		Command:    cfg.Command,
+		Args:       cfg.Args,
+		Env:        cfg.Env,
+		Config:     cfg.Config,
+		Egress:     cfg.EgressPolicy(""),
+		HostBinary: cfg.HostBinary,
+		Cleanup:    prepared.Cleanup,
+		Name:       cfg.Name,
 	})
 }

--- a/gestaltd/internal/drivers/s3/provider/factory.go
+++ b/gestaltd/internal/drivers/s3/provider/factory.go
@@ -29,13 +29,13 @@ var Factory bootstrap.S3Factory = func(node yaml.Node) (s3store.Client, error) {
 	cfg = prepared.YAMLConfig
 
 	return providerhost.NewExecutableS3(context.Background(), providerhost.S3ExecConfig{
-		Command:      cfg.Command,
-		Args:         cfg.Args,
-		Env:          cfg.Env,
-		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
-		HostBinary:   cfg.HostBinary,
-		Cleanup:      prepared.Cleanup,
-		Name:         cfg.Name,
+		Command:    cfg.Command,
+		Args:       cfg.Args,
+		Env:        cfg.Env,
+		Config:     cfg.Config,
+		Egress:     cfg.EgressPolicy(""),
+		HostBinary: cfg.HostBinary,
+		Cleanup:    prepared.Cleanup,
+		Name:       cfg.Name,
 	})
 }

--- a/gestaltd/internal/drivers/secrets/provider/factory.go
+++ b/gestaltd/internal/drivers/secrets/provider/factory.go
@@ -29,13 +29,13 @@ var Factory bootstrap.SecretManagerFactory = func(node yaml.Node) (core.SecretMa
 	cfg = prepared.YAMLConfig
 
 	return providerhost.NewExecutableSecretManager(context.Background(), providerhost.SecretsExecConfig{
-		Command:      cfg.Command,
-		Args:         cfg.Args,
-		Env:          cfg.Env,
-		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
-		HostBinary:   cfg.HostBinary,
-		Cleanup:      prepared.Cleanup,
-		Name:         cfg.Name,
+		Command:    cfg.Command,
+		Args:       cfg.Args,
+		Env:        cfg.Env,
+		Config:     cfg.Config,
+		Egress:     cfg.EgressPolicy(""),
+		HostBinary: cfg.HostBinary,
+		Cleanup:    prepared.Cleanup,
+		Name:       cfg.Name,
 	})
 }

--- a/gestaltd/internal/drivers/workflow/provider/factory.go
+++ b/gestaltd/internal/drivers/workflow/provider/factory.go
@@ -29,15 +29,14 @@ var Factory bootstrap.WorkflowFactory = func(ctx context.Context, name string, n
 	cfg = prepared.YAMLConfig
 
 	return providerhost.NewExecutableWorkflow(ctx, providerhost.WorkflowExecConfig{
-		Command:       cfg.Command,
-		Args:          cfg.Args,
-		Env:           cfg.Env,
-		Config:        cfg.Config,
-		AllowedHosts:  cfg.AllowedHosts,
-		DefaultAction: deps.Egress.DefaultAction,
-		HostBinary:    cfg.HostBinary,
-		Cleanup:       prepared.Cleanup,
-		HostServices:  hostServices,
-		Name:          name,
+		Command:      cfg.Command,
+		Args:         cfg.Args,
+		Env:          cfg.Env,
+		Config:       cfg.Config,
+		Egress:       cfg.EgressPolicy(deps.Egress.DefaultAction),
+		HostBinary:   cfg.HostBinary,
+		Cleanup:      prepared.Cleanup,
+		HostServices: hostServices,
+		Name:         name,
 	})
 }

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -134,8 +134,9 @@ plugins:
   httpbin:
     displayName: HTTPBin
     source: %s
-    allowedHosts:
-      - httpbin.org
+    egress:
+      allowedHosts:
+        - httpbin.org
 `, encryptionKey,
 		config.DefaultProviderMetadataURL(config.DefaultIndexedDBProvider, config.DefaultIndexedDBVersion),
 		"sqlite://"+dbPath,

--- a/gestaltd/internal/pluginruntime/executable.go
+++ b/gestaltd/internal/pluginruntime/executable.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/runtimelogs"
@@ -25,7 +26,7 @@ type ExecutableConfig struct {
 	Args         []string
 	Env          map[string]string
 	Config       map[string]any
-	AllowedHosts []string
+	Egress       egress.Policy
 	HostBinary   string
 	HostServices []providerhost.HostService
 	Telemetry    metricutil.TelemetryProviders
@@ -49,7 +50,7 @@ func NewExecutableProvider(ctx context.Context, cfg ExecutableConfig) (Provider,
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,
-		AllowedHosts: cfg.AllowedHosts,
+		Egress:       cloneRuntimeEgressPolicy(cfg.Egress),
 		HostBinary:   cfg.HostBinary,
 		HostServices: cfg.HostServices,
 		ProviderName: cfg.Name,
@@ -74,6 +75,13 @@ func NewExecutableProvider(ctx context.Context, cfg ExecutableConfig) (Provider,
 		sessionLogs: cfg.SessionLogs,
 		sessions:    make(map[string]*Session),
 	}, nil
+}
+
+func cloneRuntimeEgressPolicy(policy egress.Policy) egress.Policy {
+	return egress.Policy{
+		AllowedHosts:  append([]string(nil), policy.AllowedHosts...),
+		DefaultAction: policy.DefaultAction,
+	}
 }
 
 func (p *executableProvider) Support(ctx context.Context) (Support, error) {
@@ -227,7 +235,6 @@ func (p *executableProvider) BindHostService(ctx context.Context, req BindHostSe
 }
 
 func (p *executableProvider) StartPlugin(ctx context.Context, req StartPluginRequest) (*HostedPlugin, error) {
-	egressPolicy := req.EgressPolicy()
 	resp, err := p.runtime.StartPlugin(ctx, &proto.StartHostedPluginRequest{
 		SessionId:     req.SessionID,
 		PluginName:    req.PluginName,
@@ -235,8 +242,8 @@ func (p *executableProvider) StartPlugin(ctx context.Context, req StartPluginReq
 		Args:          append([]string(nil), req.Args...),
 		Env:           cloneStringMap(req.Env),
 		BundleDir:     req.BundleDir,
-		AllowedHosts:  append([]string(nil), egressPolicy.AllowedHosts...),
-		DefaultAction: string(egressPolicy.DefaultAction),
+		AllowedHosts:  append([]string(nil), req.Egress.AllowedHosts...),
+		DefaultAction: string(req.Egress.DefaultAction),
 		HostBinary:    req.HostBinary,
 	})
 	if err != nil {

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -292,14 +292,13 @@ func (p *LocalProvider) StartPlugin(ctx context.Context, req StartPluginRequest)
 		}})
 	}
 
-	egressPolicy := req.EgressPolicy()
 	process, err := providerhost.StartPluginProcess(ctx, providerhost.ProcessConfig{
 		Command: req.Command,
 		Args:    req.Args,
 		Env:     env,
 		Egress: egress.Policy{
-			AllowedHosts:  append([]string(nil), egressPolicy.AllowedHosts...),
-			DefaultAction: egress.PolicyAction(egressPolicy.DefaultAction),
+			AllowedHosts:  append([]string(nil), req.Egress.AllowedHosts...),
+			DefaultAction: egress.PolicyAction(req.Egress.DefaultAction),
 		},
 		HostBinary:   req.HostBinary,
 		SocketDir:    rootDir,

--- a/gestaltd/internal/pluginruntime/runtime.go
+++ b/gestaltd/internal/pluginruntime/runtime.go
@@ -123,29 +123,12 @@ type StartPluginRequest struct {
 	Env        map[string]string
 	BundleDir  string
 	Egress     RuntimeEgressPolicy
-	// Deprecated: use Egress.AllowedHosts.
-	AllowedHosts []string
-	// Deprecated: use Egress.DefaultAction.
-	DefaultAction PolicyAction
-	HostBinary    string
+	HostBinary string
 }
 
 type RuntimeEgressPolicy struct {
 	AllowedHosts  []string
 	DefaultAction PolicyAction
-}
-
-func (r StartPluginRequest) EgressPolicy() RuntimeEgressPolicy {
-	if len(r.Egress.AllowedHosts) > 0 || r.Egress.DefaultAction != "" {
-		return RuntimeEgressPolicy{
-			AllowedHosts:  append([]string(nil), r.Egress.AllowedHosts...),
-			DefaultAction: r.Egress.DefaultAction,
-		}
-	}
-	return RuntimeEgressPolicy{
-		AllowedHosts:  append([]string(nil), r.AllowedHosts...),
-		DefaultAction: r.DefaultAction,
-	}
 }
 
 type HostedPlugin struct {

--- a/gestaltd/internal/providerhost/agent_client.go
+++ b/gestaltd/internal/providerhost/agent_client.go
@@ -13,16 +13,15 @@ import (
 )
 
 type AgentExecConfig struct {
-	Command       string
-	Args          []string
-	Env           map[string]string
-	Config        map[string]any
-	AllowedHosts  []string
-	DefaultAction egress.PolicyAction
-	HostBinary    string
-	Cleanup       func()
-	HostServices  []HostService
-	Name          string
+	Command      string
+	Args         []string
+	Env          map[string]string
+	Config       map[string]any
+	Egress       egress.Policy
+	HostBinary   string
+	Cleanup      func()
+	HostServices []HostService
+	Name         string
 }
 
 var startAgentProviderProcess = startProviderProcess
@@ -43,16 +42,15 @@ type RemoteAgentConfig struct {
 
 func NewExecutableAgent(ctx context.Context, cfg AgentExecConfig) (coreagent.Provider, error) {
 	execCfg := ExecConfig{
-		Command:       cfg.Command,
-		Args:          cfg.Args,
-		Env:           cfg.Env,
-		Config:        cfg.Config,
-		AllowedHosts:  cfg.AllowedHosts,
-		DefaultAction: cfg.DefaultAction,
-		HostBinary:    cfg.HostBinary,
-		Cleanup:       cfg.Cleanup,
-		HostServices:  cfg.HostServices,
-		ProviderName:  cfg.Name,
+		Command:      cfg.Command,
+		Args:         cfg.Args,
+		Env:          cfg.Env,
+		Config:       cfg.Config,
+		Egress:       cloneEgressPolicy(cfg.Egress),
+		HostBinary:   cfg.HostBinary,
+		Cleanup:      cfg.Cleanup,
+		HostServices: cfg.HostServices,
+		ProviderName: cfg.Name,
 	}
 	proc, err := startAgentProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {

--- a/gestaltd/internal/providerhost/auth_client.go
+++ b/gestaltd/internal/providerhost/auth_client.go
@@ -12,6 +12,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/session"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -26,16 +27,16 @@ type authenticationRPCClient interface {
 }
 
 type AuthenticationExecConfig struct {
-	Command      string
-	Args         []string
-	Env          map[string]string
-	Config       map[string]any
-	AllowedHosts []string
-	HostBinary   string
-	Cleanup      func()
-	Name         string
-	CallbackURL  string
-	SessionKey   []byte
+	Command     string
+	Args        []string
+	Env         map[string]string
+	Config      map[string]any
+	Egress      egress.Policy
+	HostBinary  string
+	Cleanup     func()
+	Name        string
+	CallbackURL string
+	SessionKey  []byte
 }
 
 const defaultSessionTokenTTL = 24 * time.Hour
@@ -58,7 +59,7 @@ func NewExecutableAuthenticationProvider(ctx context.Context, cfg Authentication
 		Args:         cfg.Args,
 		Env:          cfg.Env,
 		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
+		Egress:       cloneEgressPolicy(cfg.Egress),
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
 		ProviderName: cfg.Name,

--- a/gestaltd/internal/providerhost/authorization_client.go
+++ b/gestaltd/internal/providerhost/authorization_client.go
@@ -6,6 +6,7 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -14,7 +15,7 @@ type AuthorizationExecConfig struct {
 	Args         []string
 	Env          map[string]string
 	Config       map[string]any
-	AllowedHosts []string
+	Egress       egress.Policy
 	HostBinary   string
 	Cleanup      func()
 	HostServices []HostService
@@ -34,7 +35,7 @@ func NewExecutableAuthorizationProvider(ctx context.Context, cfg AuthorizationEx
 		Args:         cfg.Args,
 		Env:          cfg.Env,
 		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
+		Egress:       cloneEgressPolicy(cfg.Egress),
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
 		HostServices: cfg.HostServices,

--- a/gestaltd/internal/providerhost/cache_client.go
+++ b/gestaltd/internal/providerhost/cache_client.go
@@ -8,19 +8,20 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	corecache "github.com/valon-technologies/gestalt/server/core/cache"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type CacheExecConfig struct {
-	Command      string
-	Args         []string
-	Env          map[string]string
-	Config       map[string]any
-	AllowedHosts []string
-	HostBinary   string
-	Cleanup      func()
-	Name         string
+	Command    string
+	Args       []string
+	Env        map[string]string
+	Config     map[string]any
+	Egress     egress.Policy
+	HostBinary string
+	Cleanup    func()
+	Name       string
 }
 
 type remoteCache struct {
@@ -35,7 +36,7 @@ func NewExecutableCache(ctx context.Context, cfg CacheExecConfig) (corecache.Cac
 		Args:         cfg.Args,
 		Env:          cfg.Env,
 		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
+		Egress:       cloneEgressPolicy(cfg.Egress),
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
 		ProviderName: cfg.Name,

--- a/gestaltd/internal/providerhost/external_credential_client.go
+++ b/gestaltd/internal/providerhost/external_credential_client.go
@@ -9,6 +9,7 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -18,7 +19,7 @@ type ExternalCredentialsExecConfig struct {
 	Args         []string
 	Env          map[string]string
 	Config       map[string]any
-	AllowedHosts []string
+	Egress       egress.Policy
 	HostBinary   string
 	Cleanup      func()
 	HostServices []HostService
@@ -36,7 +37,7 @@ func NewExecutableExternalCredentialProvider(ctx context.Context, cfg ExternalCr
 		Args:         cfg.Args,
 		Env:          cfg.Env,
 		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
+		Egress:       cloneEgressPolicy(cfg.Egress),
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
 		HostServices: cfg.HostServices,

--- a/gestaltd/internal/providerhost/indexeddb_client.go
+++ b/gestaltd/internal/providerhost/indexeddb_client.go
@@ -8,20 +8,21 @@ import (
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type IndexedDBExecConfig struct {
-	Command      string
-	Args         []string
-	Env          map[string]string
-	Config       map[string]any
-	AllowedHosts []string
-	HostBinary   string
-	Cleanup      func()
-	Name         string
+	Command    string
+	Args       []string
+	Env        map[string]string
+	Config     map[string]any
+	Egress     egress.Policy
+	HostBinary string
+	Cleanup    func()
+	Name       string
 }
 
 type remoteIndexedDB struct {
@@ -36,7 +37,7 @@ func NewExecutableIndexedDB(ctx context.Context, cfg IndexedDBExecConfig) (index
 		Args:         cfg.Args,
 		Env:          cfg.Env,
 		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
+		Egress:       cloneEgressPolicy(cfg.Egress),
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
 		ProviderName: cfg.Name,

--- a/gestaltd/internal/providerhost/process.go
+++ b/gestaltd/internal/providerhost/process.go
@@ -34,35 +34,27 @@ const (
 )
 
 type ProcessConfig struct {
-	Command string
-	Args    []string
-	Env     map[string]string
-	Egress  egress.Policy
-	// Deprecated: use Egress.AllowedHosts.
-	AllowedHosts []string
-	// Deprecated: use Egress.DefaultAction.
-	DefaultAction egress.PolicyAction
-	HostBinary    string
-	Cleanup       func()
-	HostServices  []HostService
-	SocketDir     string
-	ProviderName  string
-	Telemetry     metricutil.TelemetryProviders
-	Stdout        io.Writer
-	Stderr        io.Writer
+	Command      string
+	Args         []string
+	Env          map[string]string
+	Egress       egress.Policy
+	HostBinary   string
+	Cleanup      func()
+	HostServices []HostService
+	SocketDir    string
+	ProviderName string
+	Telemetry    metricutil.TelemetryProviders
+	Stdout       io.Writer
+	Stderr       io.Writer
 }
 
 type ExecConfig struct {
-	Command    string
-	Args       []string
-	Env        map[string]string
-	StaticSpec StaticProviderSpec
-	Config     map[string]any
-	Egress     egress.Policy
-	// Deprecated: use Egress.AllowedHosts.
-	AllowedHosts []string
-	// Deprecated: use Egress.DefaultAction.
-	DefaultAction    egress.PolicyAction
+	Command          string
+	Args             []string
+	Env              map[string]string
+	StaticSpec       StaticProviderSpec
+	Config           map[string]any
+	Egress           egress.Policy
 	HostBinary       string
 	Cleanup          func()
 	HostServices     []HostService
@@ -127,22 +119,16 @@ func NewExecutableProvider(ctx context.Context, cfg ExecConfig) (core.Provider, 
 
 func (c ExecConfig) processConfig() ProcessConfig {
 	return ProcessConfig{
-		Command:       c.Command,
-		Args:          c.Args,
-		Env:           c.Env,
-		Egress:        c.egressPolicy(),
-		AllowedHosts:  c.AllowedHosts,
-		DefaultAction: c.DefaultAction,
-		HostBinary:    c.HostBinary,
-		Cleanup:       c.Cleanup,
-		HostServices:  c.HostServices,
-		ProviderName:  firstNonBlank(c.ProviderName, c.StaticSpec.Name),
-		Telemetry:     c.Telemetry,
+		Command:      c.Command,
+		Args:         c.Args,
+		Env:          c.Env,
+		Egress:       cloneEgressPolicy(c.Egress),
+		HostBinary:   c.HostBinary,
+		Cleanup:      c.Cleanup,
+		HostServices: c.HostServices,
+		ProviderName: firstNonBlank(c.ProviderName, c.StaticSpec.Name),
+		Telemetry:    c.Telemetry,
 	}
-}
-
-func (c ExecConfig) egressPolicy() egress.Policy {
-	return egressPolicyFromFields(c.Egress, c.AllowedHosts, c.DefaultAction)
 }
 
 func StartPluginProcess(ctx context.Context, cfg ProcessConfig) (*PluginProcess, error) {
@@ -154,19 +140,13 @@ func StartPluginProcess(ctx context.Context, cfg ProcessConfig) (*PluginProcess,
 }
 
 func (c ProcessConfig) egressPolicy() egress.Policy {
-	return egressPolicyFromFields(c.Egress, c.AllowedHosts, c.DefaultAction)
+	return cloneEgressPolicy(c.Egress)
 }
 
-func egressPolicyFromFields(preferred egress.Policy, allowedHosts []string, defaultAction egress.PolicyAction) egress.Policy {
-	if len(preferred.AllowedHosts) > 0 || preferred.DefaultAction != "" {
-		return egress.Policy{
-			AllowedHosts:  append([]string(nil), preferred.AllowedHosts...),
-			DefaultAction: preferred.DefaultAction,
-		}
-	}
+func cloneEgressPolicy(policy egress.Policy) egress.Policy {
 	return egress.Policy{
-		AllowedHosts:  append([]string(nil), allowedHosts...),
-		DefaultAction: defaultAction,
+		AllowedHosts:  append([]string(nil), policy.AllowedHosts...),
+		DefaultAction: policy.DefaultAction,
 	}
 }
 

--- a/gestaltd/internal/providerhost/s3_client.go
+++ b/gestaltd/internal/providerhost/s3_client.go
@@ -8,6 +8,7 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	s3store "github.com/valon-technologies/gestalt/server/core/s3"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -15,14 +16,14 @@ import (
 )
 
 type S3ExecConfig struct {
-	Command      string
-	Args         []string
-	Env          map[string]string
-	Config       map[string]any
-	AllowedHosts []string
-	HostBinary   string
-	Cleanup      func()
-	Name         string
+	Command    string
+	Args       []string
+	Env        map[string]string
+	Config     map[string]any
+	Egress     egress.Policy
+	HostBinary string
+	Cleanup    func()
+	Name       string
 }
 
 type remoteS3 struct {
@@ -37,7 +38,7 @@ func NewExecutableS3(ctx context.Context, cfg S3ExecConfig) (s3store.Client, err
 		Args:         cfg.Args,
 		Env:          cfg.Env,
 		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
+		Egress:       cloneEgressPolicy(cfg.Egress),
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
 		ProviderName: cfg.Name,

--- a/gestaltd/internal/providerhost/secrets_client.go
+++ b/gestaltd/internal/providerhost/secrets_client.go
@@ -7,17 +7,18 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 )
 
 type SecretsExecConfig struct {
-	Command      string
-	Args         []string
-	Env          map[string]string
-	Config       map[string]any
-	AllowedHosts []string
-	HostBinary   string
-	Cleanup      func()
-	Name         string
+	Command    string
+	Args       []string
+	Env        map[string]string
+	Config     map[string]any
+	Egress     egress.Policy
+	HostBinary string
+	Cleanup    func()
+	Name       string
 }
 
 type remoteSecretManager struct {
@@ -31,7 +32,7 @@ func NewExecutableSecretManager(ctx context.Context, cfg SecretsExecConfig) (cor
 		Args:         cfg.Args,
 		Env:          cfg.Env,
 		Config:       cfg.Config,
-		AllowedHosts: cfg.AllowedHosts,
+		Egress:       cloneEgressPolicy(cfg.Egress),
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
 		ProviderName: cfg.Name,

--- a/gestaltd/internal/providerhost/workflow_client.go
+++ b/gestaltd/internal/providerhost/workflow_client.go
@@ -11,16 +11,15 @@ import (
 )
 
 type WorkflowExecConfig struct {
-	Command       string
-	Args          []string
-	Env           map[string]string
-	Config        map[string]any
-	AllowedHosts  []string
-	DefaultAction egress.PolicyAction
-	HostBinary    string
-	Cleanup       func()
-	HostServices  []HostService
-	Name          string
+	Command      string
+	Args         []string
+	Env          map[string]string
+	Config       map[string]any
+	Egress       egress.Policy
+	HostBinary   string
+	Cleanup      func()
+	HostServices []HostService
+	Name         string
 }
 
 var startWorkflowProviderProcess = startProviderProcess
@@ -33,16 +32,15 @@ type remoteWorkflow struct {
 
 func NewExecutableWorkflow(ctx context.Context, cfg WorkflowExecConfig) (coreworkflow.Provider, error) {
 	execCfg := ExecConfig{
-		Command:       cfg.Command,
-		Args:          cfg.Args,
-		Env:           cfg.Env,
-		Config:        cfg.Config,
-		AllowedHosts:  cfg.AllowedHosts,
-		DefaultAction: cfg.DefaultAction,
-		HostBinary:    cfg.HostBinary,
-		Cleanup:       cfg.Cleanup,
-		HostServices:  cfg.HostServices,
-		ProviderName:  cfg.Name,
+		Command:      cfg.Command,
+		Args:         cfg.Args,
+		Env:          cfg.Env,
+		Config:       cfg.Config,
+		Egress:       cloneEgressPolicy(cfg.Egress),
+		HostBinary:   cfg.HostBinary,
+		Cleanup:      cfg.Cleanup,
+		HostServices: cfg.HostServices,
+		ProviderName: cfg.Name,
 	}
 	proc, err := startWorkflowProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {

--- a/gestaltd/internal/providerhost/workflow_client_test.go
+++ b/gestaltd/internal/providerhost/workflow_client_test.go
@@ -22,13 +22,13 @@ func TestNewExecutableWorkflowForwardsDefaultEgressAction(t *testing.T) {
 	}
 
 	_, err := NewExecutableWorkflow(context.Background(), WorkflowExecConfig{
-		Command:       "/bin/true",
-		DefaultAction: egress.PolicyDeny,
+		Command: "/bin/true",
+		Egress:  egress.Policy{DefaultAction: egress.PolicyDeny},
 	})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("NewExecutableWorkflow error = %v, want %v", err, wantErr)
 	}
-	if got.DefaultAction != egress.PolicyDeny {
-		t.Fatalf("default action = %q, want %q", got.DefaultAction, egress.PolicyDeny)
+	if got.Egress.DefaultAction != egress.PolicyDeny {
+		t.Fatalf("default action = %q, want %q", got.Egress.DefaultAction, egress.PolicyDeny)
 	}
 }


### PR DESCRIPTION
## Summary

Removes the legacy runtime and egress compatibility paths now that downstream usage has migrated:

- removes provider-level `allowedHosts` YAML aliases; only `egress.allowedHosts` is accepted
- removes provider-level `runtime` YAML aliases for plugins and agent providers; only `execution.runtime` is accepted
- removes `server.runtime.provider`; only `server.runtime.defaultHostedProvider` is accepted
- removes flat hosted-agent lifecycle fields; lifecycle policy now lives under `execution.runtime.pool`
- removes deprecated Go fallback fields on plugin runtime and provider process launch configs, and routes executable provider constructors through a single `Egress` policy object
- updates docs, generated config, provider-dev overlays, and existing functional/config coverage to use the canonical interfaces

## Interfaces

### Removed YAML

```yaml
server:
  runtime:
    provider: modal

plugins:
  support:
    source: ./plugins/support/manifest.yaml
    runtime:
      image: ghcr.io/example/support:latest
    allowedHosts:
      - api.example.com

providers:
  agent:
    runner:
      source: ./providers/agent/runner
      runtime:
        provider: modal
        minReadyInstances: 1
```

### Canonical YAML

```yaml
server:
  runtime:
    defaultHostedProvider: modal

plugins:
  support:
    source: ./plugins/support/manifest.yaml
    execution:
      mode: hosted
      runtime:
        image: ghcr.io/example/support:latest
    egress:
      allowedHosts:
        - api.example.com

providers:
  agent:
    runner:
      source: ./providers/agent/runner
      execution:
        mode: hosted
        runtime:
          provider: modal
          pool:
            minReadyInstances: 1
            maxReadyInstances: 2
            startupTimeout: 5m
            healthCheckInterval: 30s
            restartPolicy: always
            drainTimeout: 2m
```

### Removed Go

```go
pluginruntime.StartPluginRequest{
    AllowedHosts: hosts,
    DefaultAction: pluginruntime.PolicyDeny,
}

providerhost.ProcessConfig{
    AllowedHosts:  hosts,
    DefaultAction: egress.PolicyDeny,
}

providerhost.WorkflowExecConfig{
    AllowedHosts:  hosts,
    DefaultAction: egress.PolicyDeny,
}
```

### Canonical Go

```go
pluginruntime.StartPluginRequest{
    Egress: pluginruntime.RuntimeEgressPolicy{
        AllowedHosts:  hosts,
        DefaultAction: pluginruntime.PolicyDeny,
    },
}

providerhost.ProcessConfig{
    Egress: egress.Policy{
        AllowedHosts:  hosts,
        DefaultAction: egress.PolicyDeny,
    },
}

providerhost.WorkflowExecConfig{
    Egress: egress.Policy{
        AllowedHosts:  hosts,
        DefaultAction: egress.PolicyDeny,
    },
}
```

## Why This Is Simpler

The config loader no longer materializes duplicate aliases into canonical fields, validation reports only canonical paths, and provider launch code no longer carries parallel `AllowedHosts`/`DefaultAction` fallbacks. Runtime and egress settings now have one YAML shape and one Go policy shape.

## Validation

- `go test ./internal/config ./internal/pluginruntime ./internal/providerhost ./internal/bootstrap ./internal/drivers/... ./internal/operator ./cmd/gestaltd`
- `go test ./internal/config ./cmd/gestaltd ./internal/bootstrap`
- `git diff --check`
- parsed YAML fences in edited docs with Ruby `YAML.safe_load`
