### PR TITLE
Emit canonical workflow target JSON

### DIFF
--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -209,14 +209,16 @@ synthetic workflow workload.
         "cron": "0 */6 * * *",
         "timezone": "America/New_York",
         "target": {
-          "plugin": "github",
-          "operation": "issues.list",
-          "connection": "default",
-          "instance": "acme-org",
-          "input": {
-            "owner": "valon-technologies",
-            "repo": "gestalt",
-            "state": "open"
+          "plugin": {
+            "name": "github",
+            "operation": "issues.list",
+            "connection": "default",
+            "instance": "acme-org",
+            "input": {
+              "owner": "valon-technologies",
+              "repo": "gestalt",
+              "state": "open"
+            }
           }
         }
       }'
@@ -301,12 +303,14 @@ subject, not as a plugin-local or synthetic workflow workload.
           "subject": "item"
         },
         "target": {
-          "plugin": "slack",
-          "operation": "chat.postMessage",
-          "connection": "default",
-          "input": {
-            "channel": "C123",
-            "text": "Roadmap item updated"
+          "plugin": {
+            "name": "slack",
+            "operation": "chat.postMessage",
+            "connection": "default",
+            "input": {
+              "channel": "C123",
+              "text": "Roadmap item updated"
+            }
           }
         }
       }'

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -64,6 +64,12 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `GET` | `/api/v1/workflow/runs/{runID}` | Inspect one workflow run. |
 | `POST` | `/api/v1/workflow/runs/{runID}/cancel` | Cancel one workflow run. The request body may include an optional `reason`. |
 
+Schedule, event-trigger, and run responses return target plugin details under
+`target.plugin` as an object with `name`, `operation`, and optional
+`connection`, `instance`, and `input` fields. Schedule and trigger create/update
+requests use the same nested shape; legacy flat plugin request fields remain
+accepted during migration.
+
 ### Agents
 
 | Method | Path | Purpose |
@@ -173,11 +179,13 @@ curl -X POST http://localhost:8080/api/v1/workflow/schedules \
     "cron": "0 */6 * * *",
     "timezone": "America/New_York",
     "target": {
-      "plugin": "github",
-      "operation": "issues.list",
-      "input": {
-        "owner": "valon-technologies",
-        "repo": "gestalt"
+      "plugin": {
+        "name": "github",
+        "operation": "issues.list",
+        "input": {
+          "owner": "valon-technologies",
+          "repo": "gestalt"
+        }
       }
     }
   }'
@@ -193,11 +201,13 @@ curl -X POST http://localhost:8080/api/v1/workflow/event-triggers \
       "subject": "item"
     },
     "target": {
-      "plugin": "slack",
-      "operation": "chat.postMessage",
-      "input": {
-        "channel": "C123",
-        "text": "Roadmap item updated"
+      "plugin": {
+        "name": "slack",
+        "operation": "chat.postMessage",
+        "input": {
+          "channel": "C123",
+          "text": "Roadmap item updated"
+        }
       }
     }
   }'

--- a/gestalt/cli/src/commands/workflows.rs
+++ b/gestalt/cli/src/commands/workflows.rs
@@ -251,7 +251,7 @@ fn filter_by_plugin(value: Value, plugin: Option<&str>) -> Value {
     Value::Array(
         items
             .into_iter()
-            .filter(|item| item["target"]["plugin"].as_str() == Some(plugin))
+            .filter(|item| target_plugin(item) == Some(plugin))
             .collect(),
     )
 }
@@ -265,7 +265,7 @@ fn filter_runs(value: Value, plugin: Option<&str>, status: Option<&str>) -> Valu
             .into_iter()
             .filter(|item| {
                 plugin
-                    .map(|plugin| item["target"]["plugin"].as_str() == Some(plugin))
+                    .map(|plugin| target_plugin(item) == Some(plugin))
                     .unwrap_or(true)
                     && status
                         .map(|status| item["status"].as_str() == Some(status))
@@ -284,7 +284,7 @@ fn filter_triggers(value: Value, plugin: Option<&str>, event_type: Option<&str>)
             .into_iter()
             .filter(|item| {
                 plugin
-                    .map(|plugin| item["target"]["plugin"].as_str() == Some(plugin))
+                    .map(|plugin| target_plugin(item) == Some(plugin))
                     .unwrap_or(true)
                     && event_type
                         .map(|event_type| item["match"]["type"].as_str() == Some(event_type))
@@ -424,35 +424,28 @@ fn merge_update(args: &WorkflowScheduleUpdateArgs, existing: &Value) -> Result<V
 
     let plugin = match args.plugin.as_deref() {
         Some(value) => value.to_string(),
-        None => existing["target"]["plugin"]
-            .as_str()
+        None => target_plugin(existing)
             .ok_or_else(|| anyhow!("existing schedule is missing target.plugin; pass --plugin"))?
             .to_string(),
     };
     let operation = match args.operation.as_deref() {
         Some(value) => value.to_string(),
-        None => existing["target"]["operation"]
-            .as_str()
+        None => target_operation(existing)
             .ok_or_else(|| {
                 anyhow!("existing schedule is missing target.operation; pass --operation")
             })?
             .to_string(),
     };
-    let connection = resolve_optional_string(
-        args.connection.as_deref(),
-        existing["target"]["connection"].as_str(),
-    );
-    let instance = resolve_optional_string(
-        args.instance.as_deref(),
-        existing["target"]["instance"].as_str(),
-    );
+    let connection =
+        resolve_optional_string(args.connection.as_deref(), target_connection(existing));
+    let instance = resolve_optional_string(args.instance.as_deref(), target_instance(existing));
 
     let input = if args.clear_input {
         None
     } else if !args.params.is_empty() || args.input_file.is_some() {
         build_optional_map(&args.params, args.input_file.as_deref())?
     } else {
-        existing["target"]["input"].as_object().cloned()
+        target_input(existing).cloned()
     };
 
     let paused = if args.paused {
@@ -491,35 +484,28 @@ fn merge_trigger_update(args: &WorkflowTriggerUpdateArgs, existing: &Value) -> R
     );
     let plugin = match args.plugin.as_deref() {
         Some(value) => value.to_string(),
-        None => existing["target"]["plugin"]
-            .as_str()
+        None => target_plugin(existing)
             .ok_or_else(|| anyhow!("existing trigger is missing target.plugin; pass --plugin"))?
             .to_string(),
     };
     let operation = match args.operation.as_deref() {
         Some(value) => value.to_string(),
-        None => existing["target"]["operation"]
-            .as_str()
+        None => target_operation(existing)
             .ok_or_else(|| {
                 anyhow!("existing trigger is missing target.operation; pass --operation")
             })?
             .to_string(),
     };
-    let connection = resolve_optional_string(
-        args.connection.as_deref(),
-        existing["target"]["connection"].as_str(),
-    );
-    let instance = resolve_optional_string(
-        args.instance.as_deref(),
-        existing["target"]["instance"].as_str(),
-    );
+    let connection =
+        resolve_optional_string(args.connection.as_deref(), target_connection(existing));
+    let instance = resolve_optional_string(args.instance.as_deref(), target_instance(existing));
 
     let input = if args.clear_input {
         None
     } else if !args.params.is_empty() || args.input_file.is_some() {
         build_optional_map(&args.params, args.input_file.as_deref())?
     } else {
-        existing["target"]["input"].as_object().cloned()
+        target_input(existing).cloned()
     };
 
     let paused = if args.paused {
@@ -559,25 +545,79 @@ fn build_target_object(
     instance: Option<&str>,
     input: Option<&Map<String, Value>>,
 ) -> Value {
-    let mut target = Map::new();
-    target.insert("plugin".to_string(), Value::String(plugin.to_string()));
-    target.insert(
+    let mut plugin_target = Map::new();
+    plugin_target.insert("name".to_string(), Value::String(plugin.to_string()));
+    plugin_target.insert(
         "operation".to_string(),
         Value::String(operation.to_string()),
     );
     if let Some(connection) = connection {
-        target.insert(
+        plugin_target.insert(
             "connection".to_string(),
             Value::String(connection.to_string()),
         );
     }
     if let Some(instance) = instance {
-        target.insert("instance".to_string(), Value::String(instance.to_string()));
+        plugin_target.insert("instance".to_string(), Value::String(instance.to_string()));
     }
     if let Some(input) = input {
-        target.insert("input".to_string(), Value::Object(input.clone()));
+        plugin_target.insert("input".to_string(), Value::Object(input.clone()));
     }
+    let mut target = Map::new();
+    target.insert("plugin".to_string(), Value::Object(plugin_target));
     Value::Object(target)
+}
+
+fn target_plugin(value: &Value) -> Option<&str> {
+    match value.get("target")?.get("plugin")? {
+        Value::String(plugin) => Some(plugin.as_str()),
+        Value::Object(plugin) => plugin.get("name").and_then(Value::as_str),
+        _ => None,
+    }
+}
+
+fn target_operation(value: &Value) -> Option<&str> {
+    let target = value.get("target")?;
+    target
+        .get("plugin")
+        .and_then(|plugin| plugin.get("operation"))
+        .and_then(Value::as_str)
+        .or_else(|| target.get("operation").and_then(Value::as_str))
+}
+
+fn target_connection(value: &Value) -> Option<&str> {
+    target_plugin_field(value, "connection").or_else(|| {
+        value
+            .get("target")
+            .and_then(|target| target.get("connection"))
+            .and_then(Value::as_str)
+    })
+}
+
+fn target_instance(value: &Value) -> Option<&str> {
+    target_plugin_field(value, "instance").or_else(|| {
+        value
+            .get("target")
+            .and_then(|target| target.get("instance"))
+            .and_then(Value::as_str)
+    })
+}
+
+fn target_input(value: &Value) -> Option<&Map<String, Value>> {
+    let target = value.get("target")?;
+    target
+        .get("plugin")
+        .and_then(|plugin| plugin.get("input"))
+        .and_then(Value::as_object)
+        .or_else(|| target.get("input").and_then(Value::as_object))
+}
+
+fn target_plugin_field<'a>(value: &'a Value, field: &str) -> Option<&'a str> {
+    value
+        .get("target")?
+        .get("plugin")?
+        .get(field)
+        .and_then(Value::as_str)
 }
 
 fn build_event_match(event_type: &str, source: Option<&str>, subject: Option<&str>) -> Value {
@@ -688,14 +728,8 @@ fn trigger_row(value: &Value) -> Vec<String> {
             .as_str()
             .unwrap_or("-")
             .to_string(),
-        value["target"]["plugin"]
-            .as_str()
-            .unwrap_or("-")
-            .to_string(),
-        value["target"]["operation"]
-            .as_str()
-            .unwrap_or("-")
-            .to_string(),
+        target_plugin(value).unwrap_or("-").to_string(),
+        target_operation(value).unwrap_or("-").to_string(),
         format_bool(value["paused"].as_bool()),
         value["createdAt"].as_str().unwrap_or("-").to_string(),
     ]
@@ -717,14 +751,8 @@ fn schedule_headers() -> [&'static str; 8] {
 fn schedule_row(value: &Value) -> Vec<String> {
     vec![
         value["id"].as_str().unwrap_or("-").to_string(),
-        value["target"]["plugin"]
-            .as_str()
-            .unwrap_or("-")
-            .to_string(),
-        value["target"]["operation"]
-            .as_str()
-            .unwrap_or("-")
-            .to_string(),
+        target_plugin(value).unwrap_or("-").to_string(),
+        target_operation(value).unwrap_or("-").to_string(),
         value["cron"].as_str().unwrap_or("-").to_string(),
         value["timezone"].as_str().unwrap_or("-").to_string(),
         format_bool(value["paused"].as_bool()),
@@ -762,14 +790,8 @@ fn published_event_row(value: &Value) -> Vec<String> {
 fn run_row(value: &Value) -> Vec<String> {
     vec![
         value["id"].as_str().unwrap_or("-").to_string(),
-        value["target"]["plugin"]
-            .as_str()
-            .unwrap_or("-")
-            .to_string(),
-        value["target"]["operation"]
-            .as_str()
-            .unwrap_or("-")
-            .to_string(),
+        target_plugin(value).unwrap_or("-").to_string(),
+        target_operation(value).unwrap_or("-").to_string(),
         value["status"].as_str().unwrap_or("-").to_string(),
         run_trigger_label(value),
         value["startedAt"]

--- a/gestalt/cli/tests/workflows_cli.rs
+++ b/gestalt/cli/tests/workflows_cli.rs
@@ -8,9 +8,11 @@ const SCHEDULE_JSON: &str = r#"{
     "cron":"0 0 * * *",
     "timezone":"UTC",
     "target":{
-        "plugin":"dummy",
-        "operation":"doit",
-        "input":{"k":"v"}
+        "plugin":{
+            "name":"dummy",
+            "operation":"doit",
+            "input":{"k":"v"}
+        }
     },
     "paused":false,
     "createdAt":"2026-04-20T00:00:00Z",
@@ -23,9 +25,11 @@ const TRIGGER_JSON: &str = r#"{
     "provider":"test-provider",
     "match":{"type":"dummy.event","source":"dummy","subject":"item"},
     "target":{
-        "plugin":"dummy",
-        "operation":"doit",
-        "input":{"k":"v"}
+        "plugin":{
+            "name":"dummy",
+            "operation":"doit",
+            "input":{"k":"v"}
+        }
     },
     "paused":false,
     "createdAt":"2026-04-20T00:00:00Z",
@@ -37,9 +41,11 @@ const RUN_JSON: &str = r#"{
     "provider":"test-provider",
     "status":"succeeded",
     "target":{
-        "plugin":"dummy",
-        "operation":"doit",
-        "input":{"k":"v"}
+        "plugin":{
+            "name":"dummy",
+            "operation":"doit",
+            "input":{"k":"v"}
+        }
     },
     "trigger":{"kind":"schedule","scheduleId":"sched-1"},
     "createdAt":"2026-04-20T00:00:00Z",
@@ -103,8 +109,8 @@ fn test_cli_lists_schedules() {
 #[test]
 fn test_cli_list_schedules_filters_by_plugin() {
     let body = r#"[
-        {"id":"sched-a","provider":"p","cron":"* * * * *","target":{"plugin":"alpha","operation":"x"},"paused":false},
-        {"id":"sched-b","provider":"p","cron":"* * * * *","target":{"plugin":"beta","operation":"y"},"paused":false}
+        {"id":"sched-a","provider":"p","cron":"* * * * *","target":{"plugin":{"name":"alpha","operation":"x"}},"paused":false},
+        {"id":"sched-b","provider":"p","cron":"* * * * *","target":{"plugin":{"name":"beta","operation":"y"}},"paused":false}
     ]"#;
     let mut server = Server::new();
     let _mock = authed_json_mock!(
@@ -123,6 +129,31 @@ fn test_cli_list_schedules_filters_by_plugin() {
         .success()
         .stdout(predicate::str::contains("sched-b"))
         .stdout(predicate::str::contains("sched-a").not());
+}
+
+#[test]
+fn test_cli_list_schedules_accepts_legacy_flat_response_target() {
+    let body = r#"[
+        {"id":"sched1","provider":"p","cron":"* * * * *","target":{"plugin":"legacy","operation":"sync"},"paused":false}
+    ]"#;
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/schedules",
+        StatusCode::OK
+    )
+    .with_body(body)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflow", "schedules", "list", "--plugin", "legacy"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sched1"))
+        .stdout(predicate::str::contains("legacy"))
+        .stdout(predicate::str::contains("sync"));
 }
 
 #[test]
@@ -160,7 +191,7 @@ fn test_cli_creates_schedule() {
         r#"{
             "cron":"0 */5 * * *",
             "timezone":"UTC",
-            "target":{"plugin":"dummy","operation":"doit","input":{"channel":"C1","text":"hi"}},
+            "target":{"plugin":{"name":"dummy","operation":"doit","input":{"channel":"C1","text":"hi"}}},
             "paused":false
         }"#
         .to_string(),
@@ -215,7 +246,7 @@ fn test_cli_updates_schedule_merges_existing_fields() {
         r#"{
             "cron":"15 * * * *",
             "timezone":"UTC",
-            "target":{"plugin":"dummy","operation":"doit","input":{"k":"v"}},
+            "target":{"plugin":{"name":"dummy","operation":"doit","input":{"k":"v"}}},
             "paused":true
         }"#
         .to_string(),
@@ -233,6 +264,65 @@ fn test_cli_updates_schedule_merges_existing_fields() {
             "--cron",
             "15 * * * *",
             "--paused",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_cli_updates_schedule_merges_legacy_flat_existing_target() {
+    let legacy_schedule = r#"{
+        "id":"sched-legacy",
+        "provider":"test-provider",
+        "cron":"0 0 * * *",
+        "timezone":"UTC",
+        "target":{
+            "plugin":"legacy",
+            "operation":"sync",
+            "connection":"analytics",
+            "instance":"tenant-a",
+            "input":{"k":"v"}
+        },
+        "paused":false
+    }"#;
+    let mut server = Server::new();
+    let _get = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/schedules/sched-legacy",
+        StatusCode::OK
+    )
+    .with_body(legacy_schedule)
+    .create();
+
+    let _put = authed_json_mock!(
+        server,
+        Method::PUT,
+        "/api/v1/workflow/schedules/sched-legacy",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{
+            "cron":"15 * * * *",
+            "timezone":"UTC",
+            "target":{"plugin":{"name":"legacy","operation":"sync","connection":"analytics","instance":"tenant-a","input":{"k":"v"}}},
+            "paused":false
+        }"#
+        .to_string(),
+    ))
+    .with_body(SCHEDULE_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "workflow",
+            "schedules",
+            "update",
+            "sched-legacy",
+            "--cron",
+            "15 * * * *",
         ])
         .assert()
         .success();
@@ -318,7 +408,7 @@ fn test_cli_list_schedules_json_format() {
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""id": "sched-1""#))
-        .stdout(predicate::str::contains(r#""plugin": "dummy""#));
+        .stdout(predicate::str::contains(r#""name": "dummy""#));
 }
 
 #[test]
@@ -346,8 +436,8 @@ fn test_cli_lists_event_triggers() {
 #[test]
 fn test_cli_list_event_triggers_filters() {
     let body = r#"[
-        {"id":"trg-a","match":{"type":"alpha.created"},"target":{"plugin":"alpha","operation":"x"},"paused":false},
-        {"id":"trg-b","match":{"type":"beta.failed"},"target":{"plugin":"beta","operation":"y"},"paused":false}
+        {"id":"trg-a","match":{"type":"alpha.created"},"target":{"plugin":{"name":"alpha","operation":"x"}},"paused":false},
+        {"id":"trg-b","match":{"type":"beta.failed"},"target":{"plugin":{"name":"beta","operation":"y"}},"paused":false}
     ]"#;
     let mut server = Server::new();
     let _mock = authed_json_mock!(
@@ -410,7 +500,7 @@ fn test_cli_creates_event_trigger() {
     .match_body(Matcher::JsonString(
         r#"{
             "match":{"type":"dummy.event","source":"dummy","subject":"item"},
-            "target":{"plugin":"dummy","operation":"doit","input":{"channel":"C1","text":"hi"}},
+            "target":{"plugin":{"name":"dummy","operation":"doit","input":{"channel":"C1","text":"hi"}}},
             "paused":false
         }"#
         .to_string(),
@@ -467,7 +557,7 @@ fn test_cli_updates_event_trigger_merges_existing_fields() {
         r#"{
             "provider":"test-provider",
             "match":{"type":"dummy.event.updated","source":"dummy","subject":"item"},
-            "target":{"plugin":"dummy","operation":"doit","input":{"k":"v"}},
+            "target":{"plugin":{"name":"dummy","operation":"doit","input":{"k":"v"}}},
             "paused":true
         }"#
         .to_string(),
@@ -570,8 +660,8 @@ fn test_cli_lists_runs() {
 #[test]
 fn test_cli_list_runs_filters() {
     let body = r#"[
-        {"id":"run-a","status":"running","target":{"plugin":"alpha","operation":"x"},"trigger":{"kind":"manual"}},
-        {"id":"run-b","status":"failed","target":{"plugin":"beta","operation":"y"},"trigger":{"kind":"event","triggerId":"evt-1"}}
+        {"id":"run-a","status":"running","target":{"plugin":{"name":"alpha","operation":"x"}},"trigger":{"kind":"manual"}},
+        {"id":"run-b","status":"failed","target":{"plugin":{"name":"beta","operation":"y"}},"trigger":{"kind":"event","triggerId":"evt-1"}}
     ]"#;
     let mut server = Server::new();
     let _mock = authed_json_mock!(server, Method::GET, "/api/v1/workflow/runs", StatusCode::OK)
@@ -628,7 +718,7 @@ fn test_cli_cancels_run() {
             "id":"run-1",
             "provider":"test-provider",
             "status":"canceled",
-            "target":{"plugin":"dummy","operation":"doit"},
+            "target":{"plugin":{"name":"dummy","operation":"doit"}},
             "statusMessage":"operator requested"
         }"#,
     )

--- a/gestaltd/internal/server/handlers_workflow.go
+++ b/gestaltd/internal/server/handlers_workflow.go
@@ -95,12 +95,16 @@ type workflowScheduleUpsertRequest struct {
 }
 
 type workflowScheduleTargetInfo struct {
-	Plugin     string                   `json:"plugin,omitempty"`
-	Operation  string                   `json:"operation"`
-	Connection string                   `json:"connection,omitempty"`
-	Instance   string                   `json:"instance,omitempty"`
-	Input      map[string]any           `json:"input,omitempty"`
-	Agent      *workflowAgentTargetInfo `json:"agent,omitempty"`
+	Plugin *workflowPluginTargetInfo `json:"plugin,omitempty"`
+	Agent  *workflowAgentTargetInfo  `json:"agent,omitempty"`
+}
+
+type workflowPluginTargetInfo struct {
+	Name       string         `json:"name"`
+	Operation  string         `json:"operation"`
+	Connection string         `json:"connection,omitempty"`
+	Instance   string         `json:"instance,omitempty"`
+	Input      map[string]any `json:"input,omitempty"`
 }
 
 type workflowAgentTargetInfo struct {
@@ -398,11 +402,13 @@ func workflowScheduleTargetInfoFromCore(target coreworkflow.Target) workflowSche
 	}
 	pluginTarget := target.PluginTarget()
 	return workflowScheduleTargetInfo{
-		Plugin:     pluginTarget.PluginName,
-		Operation:  pluginTarget.Operation,
-		Connection: userFacingConnectionName(pluginTarget.Connection),
-		Instance:   pluginTarget.Instance,
-		Input:      maps.Clone(pluginTarget.Input),
+		Plugin: &workflowPluginTargetInfo{
+			Name:       pluginTarget.PluginName,
+			Operation:  pluginTarget.Operation,
+			Connection: userFacingConnectionName(pluginTarget.Connection),
+			Instance:   pluginTarget.Instance,
+			Input:      maps.Clone(pluginTarget.Input),
+		},
 	}
 }
 

--- a/gestaltd/internal/server/workflow_run_test.go
+++ b/gestaltd/internal/server/workflow_run_test.go
@@ -21,8 +21,10 @@ type workflowRunResponse struct {
 	ID     string `json:"id"`
 	Status string `json:"status"`
 	Target struct {
-		Plugin    string `json:"plugin"`
-		Operation string `json:"operation"`
+		Plugin *struct {
+			Name      string `json:"name"`
+			Operation string `json:"operation"`
+		} `json:"plugin"`
 	} `json:"target"`
 	Trigger struct {
 		Kind       string `json:"kind"`

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -499,28 +499,12 @@ func cloneMap(src map[string]any) map[string]any {
 }
 
 type workflowScheduleResponse struct {
-	ID       string `json:"id"`
-	Provider string `json:"provider"`
-	Cron     string `json:"cron"`
-	Timezone string `json:"timezone"`
-	Target   struct {
-		Plugin     string         `json:"plugin"`
-		Operation  string         `json:"operation"`
-		Connection string         `json:"connection"`
-		Instance   string         `json:"instance"`
-		Input      map[string]any `json:"input"`
-		Agent      *struct {
-			ProviderName   string `json:"provider"`
-			Model          string `json:"model"`
-			Prompt         string `json:"prompt"`
-			TimeoutSeconds int    `json:"timeoutSeconds"`
-			ToolRefs       []struct {
-				Plugin    string `json:"plugin"`
-				Operation string `json:"operation"`
-			} `json:"toolRefs"`
-		} `json:"agent"`
-	} `json:"target"`
-	Paused bool `json:"paused"`
+	ID       string                 `json:"id"`
+	Provider string                 `json:"provider"`
+	Cron     string                 `json:"cron"`
+	Timezone string                 `json:"timezone"`
+	Target   workflowTargetResponse `json:"target"`
+	Paused   bool                   `json:"paused"`
 }
 
 type workflowEventTriggerResponse struct {
@@ -531,23 +515,71 @@ type workflowEventTriggerResponse struct {
 		Source  string `json:"source"`
 		Subject string `json:"subject"`
 	} `json:"match"`
-	Target struct {
-		Plugin     string         `json:"plugin"`
-		Operation  string         `json:"operation"`
-		Connection string         `json:"connection"`
-		Instance   string         `json:"instance"`
-		Input      map[string]any `json:"input"`
-		Agent      *struct {
-			ProviderName string `json:"provider"`
-			Model        string `json:"model"`
-			Prompt       string `json:"prompt"`
-			ToolRefs     []struct {
-				Plugin    string `json:"plugin"`
-				Operation string `json:"operation"`
-			} `json:"toolRefs"`
-		} `json:"agent"`
-	} `json:"target"`
-	Paused bool `json:"paused"`
+	Target workflowTargetResponse `json:"target"`
+	Paused bool                   `json:"paused"`
+}
+
+type workflowTargetResponse struct {
+	Plugin *workflowPluginTargetResponse `json:"plugin"`
+	Agent  *workflowAgentTargetResponse  `json:"agent"`
+}
+
+type workflowPluginTargetResponse struct {
+	Name       string         `json:"name"`
+	Operation  string         `json:"operation"`
+	Connection string         `json:"connection"`
+	Instance   string         `json:"instance"`
+	Input      map[string]any `json:"input"`
+}
+
+type workflowAgentTargetResponse struct {
+	ProviderName   string `json:"provider"`
+	Model          string `json:"model"`
+	Prompt         string `json:"prompt"`
+	TimeoutSeconds int    `json:"timeoutSeconds"`
+	ToolRefs       []struct {
+		Plugin    string `json:"plugin"`
+		Operation string `json:"operation"`
+	} `json:"toolRefs"`
+}
+
+func requireWorkflowPluginTarget(t *testing.T, target workflowTargetResponse) *workflowPluginTargetResponse {
+	t.Helper()
+	if target.Plugin == nil {
+		t.Fatalf("target plugin is nil: %#v", target)
+	}
+	return target.Plugin
+}
+
+func requireCanonicalPluginTargetJSON(t *testing.T, body []byte) workflowPluginTargetResponse {
+	t.Helper()
+
+	var envelope struct {
+		Target map[string]json.RawMessage `json:"target"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode response envelope: %v", err)
+	}
+	if len(envelope.Target) == 0 {
+		t.Fatalf("response target is empty: %s", body)
+	}
+	for _, field := range []string{"operation", "connection", "instance", "input"} {
+		if _, ok := envelope.Target[field]; ok {
+			t.Fatalf("response target contains legacy flat field %q: %s", field, body)
+		}
+	}
+	rawPlugin, ok := envelope.Target["plugin"]
+	if !ok {
+		t.Fatalf("response target missing plugin object: %s", body)
+	}
+	var plugin workflowPluginTargetResponse
+	if err := json.Unmarshal(rawPlugin, &plugin); err != nil {
+		t.Fatalf("decode response target plugin: %v", err)
+	}
+	if plugin.Name == "" || plugin.Operation == "" {
+		t.Fatalf("response target plugin = %#v, want name and operation", plugin)
+	}
+	return plugin
 }
 
 func TestWorkflowScheduleCRUD(t *testing.T) {
@@ -598,15 +630,21 @@ func TestWorkflowScheduleCRUD(t *testing.T) {
 		t.Fatalf("expected 201, got %d: %s", createResp.StatusCode, body)
 	}
 
+	createRespBody, err := io.ReadAll(createResp.Body)
+	if err != nil {
+		t.Fatalf("read create response: %v", err)
+	}
+	requireCanonicalPluginTargetJSON(t, createRespBody)
 	var created workflowScheduleResponse
-	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+	if err := json.Unmarshal(createRespBody, &created); err != nil {
 		t.Fatalf("decode create response: %v", err)
 	}
-	if created.Provider != "basic" || created.Target.Operation != "sync" || created.Target.Connection != "analytics" || created.Target.Instance != "tenant-a" {
+	createdPlugin := requireWorkflowPluginTarget(t, created.Target)
+	if created.Provider != "basic" || createdPlugin.Operation != "sync" || createdPlugin.Connection != "analytics" || createdPlugin.Instance != "tenant-a" {
 		t.Fatalf("created schedule = %#v", created)
 	}
-	if created.Target.Plugin != "roadmap" {
-		t.Fatalf("created target plugin = %q, want roadmap", created.Target.Plugin)
+	if createdPlugin.Name != "roadmap" {
+		t.Fatalf("created target plugin = %q, want roadmap", createdPlugin.Name)
 	}
 	if len(provider.upsertReqs) != 1 {
 		t.Fatalf("upsert requests = %d, want 1", len(provider.upsertReqs))
@@ -643,8 +681,9 @@ func TestWorkflowScheduleCRUD(t *testing.T) {
 	if len(listed) != 1 || listed[0].ID != created.ID {
 		t.Fatalf("listed schedules = %#v", listed)
 	}
-	if listed[0].Target.Plugin != "roadmap" {
-		t.Fatalf("listed target plugin = %q, want roadmap", listed[0].Target.Plugin)
+	listedPlugin := requireWorkflowPluginTarget(t, listed[0].Target)
+	if listedPlugin.Name != "roadmap" {
+		t.Fatalf("listed target plugin = %q, want roadmap", listedPlugin.Name)
 	}
 
 	updateBody := bytes.NewBufferString(`{"cron":"0 * * * *","timezone":"UTC","target":{"plugin":{"name":"roadmap","operation":"sync","connection":"analytics","instance":"tenant-a","input":{"mode":"full"}}},"paused":true}`)
@@ -1408,8 +1447,9 @@ func TestWorkflowScheduleCreatePinsResolvedInstance(t *testing.T) {
 	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
 		t.Fatalf("decode create response: %v", err)
 	}
-	if created.Target.Instance != "tenant-a" {
-		t.Fatalf("created schedule target instance = %q, want tenant-a", created.Target.Instance)
+	createdPlugin := requireWorkflowPluginTarget(t, created.Target)
+	if createdPlugin.Instance != "tenant-a" {
+		t.Fatalf("created schedule target instance = %q, want tenant-a", createdPlugin.Instance)
 	}
 	if len(provider.upsertReqs) != 1 {
 		t.Fatalf("upsert requests = %d, want 1", len(provider.upsertReqs))
@@ -1676,7 +1716,8 @@ func TestGlobalWorkflowScheduleCRUDAcrossProviders(t *testing.T) {
 	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
 		t.Fatalf("decode create response: %v", err)
 	}
-	if created.Provider != "basic" || created.Target.Plugin != "roadmap" || created.Target.Operation != "sync" {
+	createdPlugin := requireWorkflowPluginTarget(t, created.Target)
+	if created.Provider != "basic" || createdPlugin.Name != "roadmap" || createdPlugin.Operation != "sync" {
 		t.Fatalf("created schedule = %#v", created)
 	}
 	if len(basicProvider.upsertReqs) != 1 {
@@ -1702,7 +1743,11 @@ func TestGlobalWorkflowScheduleCRUDAcrossProviders(t *testing.T) {
 	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
 		t.Fatalf("decode list response: %v", err)
 	}
-	if len(listed) != 1 || listed[0].ID != created.ID || listed[0].Provider != "basic" || listed[0].Target.Plugin != "roadmap" {
+	if len(listed) != 1 || listed[0].ID != created.ID || listed[0].Provider != "basic" {
+		t.Fatalf("listed schedules = %#v", listed)
+	}
+	listedPlugin := requireWorkflowPluginTarget(t, listed[0].Target)
+	if listedPlugin.Name != "roadmap" {
 		t.Fatalf("listed schedules = %#v", listed)
 	}
 
@@ -1727,7 +1772,8 @@ func TestGlobalWorkflowScheduleCRUDAcrossProviders(t *testing.T) {
 	if err := json.NewDecoder(updateResp.Body).Decode(&updated); err != nil {
 		t.Fatalf("decode update response: %v", err)
 	}
-	if updated.Provider != "advanced" || updated.Target.Plugin != "analytics" || !updated.Paused {
+	updatedPlugin := requireWorkflowPluginTarget(t, updated.Target)
+	if updated.Provider != "advanced" || updatedPlugin.Name != "analytics" || !updated.Paused {
 		t.Fatalf("updated schedule = %#v", updated)
 	}
 	if len(advancedProvider.upsertReqs) != 1 {
@@ -2031,11 +2077,17 @@ func TestGlobalWorkflowEventTriggerCRUDAcrossProviders(t *testing.T) {
 		t.Fatalf("expected 201, got %d: %s", createResp.StatusCode, body)
 	}
 
+	createRespBody, err := io.ReadAll(createResp.Body)
+	if err != nil {
+		t.Fatalf("read create response: %v", err)
+	}
+	requireCanonicalPluginTargetJSON(t, createRespBody)
 	var created workflowEventTriggerResponse
-	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+	if err := json.Unmarshal(createRespBody, &created); err != nil {
 		t.Fatalf("decode create response: %v", err)
 	}
-	if created.Provider != "basic" || created.Match.Type != "roadmap.item.updated" || created.Target.Plugin != "roadmap" || created.Target.Operation != "sync" {
+	createdPlugin := requireWorkflowPluginTarget(t, created.Target)
+	if created.Provider != "basic" || created.Match.Type != "roadmap.item.updated" || createdPlugin.Name != "roadmap" || createdPlugin.Operation != "sync" {
 		t.Fatalf("created trigger = %#v", created)
 	}
 	if len(basicProvider.upsertTriggerReqs) != 1 {
@@ -2086,7 +2138,8 @@ func TestGlobalWorkflowEventTriggerCRUDAcrossProviders(t *testing.T) {
 	if err := json.NewDecoder(updateResp.Body).Decode(&updated); err != nil {
 		t.Fatalf("decode update response: %v", err)
 	}
-	if updated.Provider != "advanced" || updated.Match.Type != "analytics.item.synced" || updated.Target.Plugin != "analytics" || !updated.Paused {
+	updatedPlugin := requireWorkflowPluginTarget(t, updated.Target)
+	if updated.Provider != "advanced" || updated.Match.Type != "analytics.item.synced" || updatedPlugin.Name != "analytics" || !updated.Paused {
 		t.Fatalf("updated trigger = %#v", updated)
 	}
 	if len(advancedProvider.upsertTriggerReqs) != 1 {
@@ -2215,11 +2268,17 @@ func TestGlobalWorkflowEventTriggerLegacyFlatTargetStillAccepted(t *testing.T) {
 		body, _ := io.ReadAll(createResp.Body)
 		t.Fatalf("expected 201, got %d: %s", createResp.StatusCode, body)
 	}
+	createRespBody, err := io.ReadAll(createResp.Body)
+	if err != nil {
+		t.Fatalf("read create response: %v", err)
+	}
+	requireCanonicalPluginTargetJSON(t, createRespBody)
 	var created workflowEventTriggerResponse
-	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+	if err := json.Unmarshal(createRespBody, &created); err != nil {
 		t.Fatalf("decode create response: %v", err)
 	}
-	if created.Target.Plugin != "roadmap" || created.Target.Operation != "sync" {
+	createdPlugin := requireWorkflowPluginTarget(t, created.Target)
+	if createdPlugin.Name != "roadmap" || createdPlugin.Operation != "sync" {
 		t.Fatalf("created trigger = %#v", created)
 	}
 	if len(provider.upsertTriggerReqs) != 1 {


### PR DESCRIPTION
## Summary

Emit workflow plugin targets in the canonical nested JSON shape for schedule, event-trigger, and run responses.

New response interface:

```json
{
  "target": {
    "plugin": {
      "name": "roadmap",
      "operation": "sync",
      "connection": "analytics",
      "instance": "tenant-a",
      "input": {"mode": "incremental"}
    }
  }
}
```

Canonical schedule/event-trigger create and update requests use the same nested target shape. The CLI now sends that shape too:

```json
{
  "target": {
    "plugin": {
      "name": "roadmap",
      "operation": "sync",
      "connection": "analytics"
    }
  }
}
```

Legacy flat response fields are no longer emitted by `gestaltd`:

```json
{
  "target": {
    "plugin": "roadmap",
    "operation": "sync",
    "connection": "analytics",
    "instance": "tenant-a",
    "input": {"mode": "incremental"}
  }
}
```

Legacy flat plugin requests remain accepted during the migration, and the CLI still tolerates legacy flat responses while older servers are in circulation:

```json
{
  "target": {
    "plugin": "roadmap",
    "operation": "sync",
    "connection": "analytics"
  }
}
```

## Tests

```sh
go test ./internal/server -run 'TestWorkflowScheduleCRUD|TestWorkflowScheduleCreatePinsResolvedInstance|TestGlobalWorkflowScheduleCRUDAcrossProviders|TestGlobalWorkflowEventTriggerCRUDAcrossProviders|TestGlobalWorkflowEventTriggerLegacyFlatTargetStillAccepted|TestGlobalWorkflowRunInspection'
go test ./internal/server
cargo test --manifest-path gestalt/cli/Cargo.toml --test workflows_cli
```
