### PR TITLE
Generalize non-user subject route guards

### DIFF
--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -91,7 +91,7 @@ rejects the request before invocation.
 | Provider operation invocation | Yes: `gestaltd.operation.*` | Yes | Guarded invocations are both metered and audited. |
 | Platform login start and completion | Yes: `gestaltd.auth.*` | Yes | Login is both operational telemetry and a security event. |
 | Platform token validation | Yes: `gestaltd.auth.*` with `action=validate_token` | Partially | Successful per-request validation is metrics-only; denied auth in shared middleware emits `auth.authenticate`. |
-| HTTP pre-invoker authorization denials | No dedicated semantic metric family | Yes | Denied workload access before invocation dispatch is audited with the attempted operation or `operations.list`. |
+| HTTP pre-invoker authorization denials | No dedicated semantic metric family | Yes | Denied subject access before invocation dispatch is audited with the attempted operation or `operations.list`. |
 | Connection auth start and completion | Yes: `gestaltd.connection.auth.*` | Yes | Covers OAuth start and completion plus manual connect completion. |
 | Connection credential refresh | Yes: `gestaltd.connection.auth.*` with `action=refresh` | No | Refresh remains metrics-only to avoid audit noise. |
 | Credentialed HTTP catalog discovery | Yes: `gestaltd.discovery.*` with `action=list_operations` | No | Operation listing that resolves a session catalog stays metrics-only to avoid audit spam. |

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -375,7 +375,7 @@ need actor, target, and outcome details.
 | Provider operation invocation | Yes: `gestaltd.operation.*` | Yes | Every guarded HTTP and MCP invocation is audited. |
 | Platform login start and completion | Yes: `gestaltd.auth.*` | Yes | `begin_login` and `complete_login` are both operational and security events. |
 | Platform token validation | Yes: `gestaltd.auth.*` with `action=validate_token` | Partially | Successful per-request validation is metrics-only; shared-middleware denials emit `auth.authenticate`. |
-| Pre-invoker authorization denials | No dedicated semantic metric family | Yes | Denied workload access before guarded invocation dispatch is audited with the attempted operation or `operations.list`. |
+| Pre-invoker authorization denials | No dedicated semantic metric family | Yes | Denied subject access before guarded invocation dispatch is audited with the attempted operation or `operations.list`. |
 | Connection auth start and completion | Yes: `gestaltd.connection.auth.*` | Yes | Covers OAuth start and completion plus manual connect completion. |
 | Connection credential refresh | Yes: `gestaltd.connection.auth.*` with `action=refresh` | No | Refresh is system maintenance behavior, not a user-facing audit event. |
 | Credentialed HTTP catalog discovery | Yes: `gestaltd.discovery.*` with `action=list_operations` | No | Operation listing stays metrics-only even when it resolves session catalogs. |

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -116,6 +116,11 @@ func IsWorkloadPrincipal(p *Principal) bool {
 	return p != nil && p.Kind == KindWorkload
 }
 
+func IsNonUserPrincipal(p *Principal) bool {
+	p = Canonicalized(p)
+	return p != nil && p.Kind != "" && p.Kind != KindUser
+}
+
 func EffectiveCredentialSubjectID(p *Principal) string {
 	if p == nil {
 		return ""

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -37,7 +37,7 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	if p == nil {
 		return nil, nil
 	}
-	if principal.IsWorkloadPrincipal(p) {
+	if principal.IsNonUserPrincipal(p) {
 		return p, nil
 	}
 	if p.UserID != "" {

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -31,10 +31,10 @@ func (s *Server) providerOverrideForContext(ctx context.Context, p *principal.Pr
 	return s.providerDevSessions.ResolveProviderOverride(ctx, p, provider)
 }
 
-func rejectWorkloadCaller(w http.ResponseWriter, p *principal.Principal) error {
-	if !principal.IsWorkloadPrincipal(p) {
+func requireUserCaller(w http.ResponseWriter, p *principal.Principal) error {
+	if !principal.IsNonUserPrincipal(p) {
 		return nil
 	}
-	writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
-	return errWorkloadForbidden
+	writeError(w, http.StatusForbidden, errUserRequired.Error())
+	return errUserRequired
 }

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -39,10 +39,10 @@ const sessionCookieName = "session_token"
 const defaultSessionCookieTTL = 24 * time.Hour
 
 var (
-	errNotAuthenticated  = errors.New("not authenticated")
-	errResolveUser       = errors.New("failed to resolve user")
-	errWorkloadForbidden = errors.New("workload callers are not allowed on this route")
-	errOperationAccess   = errors.New("operation access denied")
+	errNotAuthenticated = errors.New("not authenticated")
+	errResolveUser      = errors.New("failed to resolve user")
+	errUserRequired     = errors.New("user caller is required on this route")
+	errOperationAccess  = errors.New("operation access denied")
 )
 
 var (
@@ -89,8 +89,8 @@ type connectionParamInfo struct {
 }
 
 func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, error) {
-	if err := rejectWorkloadCaller(w, PrincipalFromContext(r.Context())); err != nil {
-		return "", errWorkloadForbidden
+	if err := requireUserCaller(w, PrincipalFromContext(r.Context())); err != nil {
+		return "", errUserRequired
 	}
 	user := UserFromContext(r.Context())
 	if user == nil || user.Email == "" {
@@ -110,7 +110,7 @@ func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, 
 
 func (s *Server) resolveCredentialSubjectID(w http.ResponseWriter, r *http.Request) (string, error) {
 	p := PrincipalFromContext(r.Context())
-	if principal.IsWorkloadPrincipal(p) {
+	if principal.IsNonUserPrincipal(p) {
 		subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
 		if subjectID == "" {
 			writeError(w, http.StatusUnauthorized, "not authenticated")
@@ -198,7 +198,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) subjectConnectedIntegrations(r *http.Request) (map[string][]instanceInfo, error) {
 	p := PrincipalFromContext(r.Context())
-	if principal.IsWorkloadPrincipal(p) {
+	if principal.IsNonUserPrincipal(p) {
 		subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
 		if subjectID == "" {
 			return nil, nil

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -83,7 +83,7 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
-		if err := rejectWorkloadCaller(w, p); err != nil {
+		if err := requireUserCaller(w, p); err != nil {
 			return
 		}
 

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -585,7 +585,7 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		s.auditHTTPEvent(r.Context(), auditPrincipal, s.authProviderName(), "auth.logout", auditAllowed, auditErr)
 	}()
-	if err := rejectWorkloadCaller(w, auditPrincipal); err != nil {
+	if err := requireUserCaller(w, auditPrincipal); err != nil {
 		auditErr = err
 		return
 	}

--- a/gestaltd/internal/server/handlers_mcp_authorization_server.go
+++ b/gestaltd/internal/server/handlers_mcp_authorization_server.go
@@ -250,7 +250,7 @@ func (s *Server) mcpOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	p, err := s.resolveRequestPrincipalWithResolver(r, auth.resolver)
-	if err != nil || p == nil || p.Identity == nil || p.Identity.Email == "" || principal.IsWorkloadPrincipal(p) {
+	if err != nil || p == nil || p.Identity == nil || p.Identity.Email == "" || principal.IsNonUserPrincipal(p) {
 		if strings.EqualFold(strings.TrimSpace(query.Get("prompt")), "none") {
 			redirectMCPOAuthError(w, r, redirectURI, state, "login_required", "user login is required")
 			return

--- a/gestaltd/internal/server/handlers_provider_dev.go
+++ b/gestaltd/internal/server/handlers_provider_dev.go
@@ -37,7 +37,7 @@ func (s *Server) createProviderDevSession(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) authorizeProviderDevSessionRequest(w http.ResponseWriter, r *http.Request, p *principal.Principal, req providerdev.CreateSessionRequest) error {
-	if err := rejectWorkloadCaller(w, p); err != nil {
+	if err := requireUserCaller(w, p); err != nil {
 		return err
 	}
 	names, err := s.providerDevSessions.ResolveAttachProviderNames(req)

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -20,7 +20,7 @@ func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *prin
 }
 
 func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
-	if principal.IsWorkloadPrincipal(p) {
+	if principal.IsNonUserPrincipal(p) {
 		return false
 	}
 	return info.Connected || len(info.AuthTypes) > 0 || len(info.Connections) > 0
@@ -69,7 +69,7 @@ func (s *Server) mountedUIRootAccessibleContext(ctx context.Context, p *principa
 	if mounted.AuthorizationPolicy == "" {
 		return true
 	}
-	if s.authorizer == nil || p == nil || principal.IsWorkloadPrincipal(p) {
+	if s.authorizer == nil || p == nil || principal.IsNonUserPrincipal(p) {
 		return false
 	}
 

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -158,10 +158,10 @@ func (s *Server) resolveRequestPrincipalWithResolver(r *http.Request, resolver *
 
 	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
 		p, err := resolver.ResolveToken(r.Context(), c.Value)
-		if p != nil && !principal.IsWorkloadPrincipal(p) {
+		if p != nil && !principal.IsNonUserPrincipal(p) {
 			return p, nil
 		}
-		if principal.IsWorkloadPrincipal(p) {
+		if principal.IsNonUserPrincipal(p) {
 			lastErr = principal.ErrInvalidToken
 		} else {
 			lastErr = err

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -465,7 +465,7 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		}
 		return nil, false
 	}
-	if err := rejectWorkloadCaller(w, p); err != nil {
+	if err := requireUserCaller(w, p); err != nil {
 		return nil, false
 	}
 

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -257,8 +257,8 @@ func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, 
 	if p == nil {
 		return "", false, nil
 	}
-	if principal.IsWorkloadPrincipal(p) {
-		return "", true, errWorkloadForbidden
+	if principal.IsNonUserPrincipal(p) {
+		return "", true, errUserRequired
 	}
 	subjectID := strings.TrimSpace(p.SubjectID)
 	if subjectID == "" && strings.TrimSpace(p.UserID) != "" {
@@ -294,8 +294,8 @@ func (s *Server) authorizePendingConnectionByCookie(r *http.Request, state *pend
 func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Request, state *pendingConnectionState) bool {
 	subjectID, authenticated, err := s.resolvePendingConnectionUserID(r)
 	if err != nil {
-		if errors.Is(err, errWorkloadForbidden) {
-			writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
+		if errors.Is(err, errUserRequired) {
+			writeError(w, http.StatusForbidden, errUserRequired.Error())
 			return false
 		}
 		if errors.Is(err, principal.ErrInvalidToken) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -10824,15 +10824,15 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingSubjectCredentialReturns4
 	}
 }
 
-func TestWorkloadAuthorization_HumanRoutesReturn403(t *testing.T) {
+func TestSubjectAuthorization_UserOnlyRoutesReturn403ForNonUserSubjects(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 	svc := coretesting.NewStubServices(t)
-	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
+	seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
 
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
@@ -10858,7 +10858,7 @@ func TestWorkloadAuthorization_HumanRoutesReturn403(t *testing.T) {
 		{method: http.MethodPost, path: "/api/v1/auth/logout"},
 	} {
 		req, _ := http.NewRequest(request.method, ts.URL+request.path, bytes.NewBufferString(request.body))
-		req.Header.Set("Authorization", "Bearer "+workloadToken)
+		req.Header.Set("Authorization", "Bearer "+subjectToken)
 		if request.body != "" {
 			req.Header.Set("Content-Type", "application/json")
 		}


### PR DESCRIPTION
## Summary
- replace workload-specific user-route rejection with a generic non-user subject guard
- let credential listing and credential-subject resolution use any non-user canonical subject, not only `workload:<id>`
- keep browser/session-only surfaces user-only without introducing a separate service-account path
- update audit/observability docs from workload access to subject access

## New interface
```go
func principal.IsNonUserPrincipal(p *principal.Principal) bool
```

## Examples
```go
if principal.IsNonUserPrincipal(p) {
    return errUserRequired
}
```

```go
// service_account:triage-bot now follows the same user-only route rejection
// as workload:triage-bot while still using subject-owned API tokens.
core.APIToken{
    OwnerKind: core.APITokenOwnerKindSubject,
    OwnerID: "service_account:triage-bot",
    CredentialSubjectID: "service_account:triage-bot",
}
```

## Validation
- `go test ./internal/principal ./internal/server -run 'TestSubjectAuthorization_UserOnlyRoutesReturn403ForNonUserSubjects|TestWorkloadAuthorization|TestAuditMetadata_WorkloadSubjectAndCredentialPath|TestAuthMiddleware_LegacyWorkloadPrefixRejectedBeforeOAuth' -count=1`
- `go test ./internal/principal ./internal/server`
- `go test ./internal/authorization ./internal/invocation ./internal/mcp`
- `go test ./internal/principal ./internal/server ./internal/authorization ./internal/invocation ./internal/mcp ./internal/bootstrap -count=1`