### PR TITLE
Generalize non-user subject handling

### DIFF
--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -29,7 +29,7 @@ Owned by the configured external credentials provider, not gestaltd core. The de
 | Field | Type | Notes |
 | --- | --- | --- |
 | `id` | string, PK | UUID. |
-| `subject_id` | string | Canonical credential owner such as `user:<id>` or `workload:<id>`. |
+| `subject_id` | string | Canonical credential owner such as `user:<id>`, `workload:<id>`, or `service_account:<id>`. |
 | `integration` | string | Provider name from config (e.g., `slack`). |
 | `connection` | string | Named connection within the provider (e.g., `default`, `mcp`). |
 | `instance` | string | User-chosen or discovery-assigned name for multi-account providers. |
@@ -52,8 +52,8 @@ Gestalt API tokens (`gst_api_*`). The plaintext is never stored, only a one-way 
 | Field | Type | Notes |
 | --- | --- | --- |
 | `id` | string, PK | UUID. |
-| `owner_kind` | string | Token owner kind (`user`). |
-| `owner_id` | string | Owner ID within `owner_kind`. |
+| `owner_kind` | string | Token owner kind (`user` or `subject`). |
+| `owner_id` | string | Owner ID within `owner_kind`; subject-owned tokens use a canonical non-system subject ID. |
 | `credential_subject_id` | string | Subject whose upstream credentials the token may use. |
 | `name` | string | Display name (e.g., `automation`, `cli-token`). |
 | `hashed_token` | string, unique | **SHA-256 hash.** Plaintext returned once at creation. |

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -148,9 +148,9 @@ authorization:
 
 `authorization.policies` configures shared subject access policies. Each policy resolves a caller to exactly one role by matching canonical `subjectID` values such as `user:<id>` or `workload:<id>`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
 
-Dynamic grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, operators can manage additional dynamic members for that plugin from the built-in admin UI at `/admin/?tab=members` or through `/admin/api/v1/authorization/...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for subjects that already have static authorization on that plugin. The `email` write field is a user-only convenience alias; `subjectId` accepts both `user:<id>` and `workload:<id>`.
+Dynamic grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, operators can manage additional dynamic members for that plugin from the built-in admin UI at `/admin/?tab=members` or through `/admin/api/v1/authorization/...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for subjects that already have static authorization on that plugin. The `email` write field is a user-only convenience alias; `subjectId` accepts any canonical non-system subject ID, such as `user:<id>`, `workload:<id>`, or `service_account:<id>`.
 
-Non-human callers are modeled as canonical subjects, typically `workload:<id>`, and authenticate with Gestalt API tokens whose stored owner is that subject. Grant plugin access with `authorization.policies` or provider-backed dynamic memberships using the workload subject ID, and store third-party credentials through the configured external credentials provider under the same subject ID.
+Non-human callers are modeled as canonical subjects, typically `workload:<id>` or `service_account:<id>`, and authenticate with Gestalt API tokens whose stored owner is that subject. Grant plugin access with `authorization.policies` or provider-backed dynamic memberships using the canonical subject ID, and store third-party credentials through the configured external credentials provider under the same subject ID.
 
 Plugins without `authorizationPolicy` are open to any authenticated subject. Bind a plugin to a policy when non-human access should be explicit.
 
@@ -1126,7 +1126,7 @@ connections:
       type: mcp_oauth
 ```
 
-Connection `mode` determines how credentials are managed: `none` requires no credentials, and `user` stores credentials for the caller's effective subject. For humans that is typically `user:<id>`; for workloads it is `workload:<id>`. All connections in a single plugin must share the same mode.
+Connection `mode` determines how credentials are managed: `none` requires no credentials, and `user` stores credentials for the caller's effective subject. For humans that is typically `user:<id>`; for non-human subjects it can be `workload:<id>`, `service_account:<id>`, or another canonical non-system subject ID. All connections in a single plugin must share the same mode.
 
 #### Authentication Shapes
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -128,7 +128,7 @@ tool_result | image_ref` plus the corresponding `text`, `json`, `toolCall`,
 
 `/admin/api/v1/...` mirrors the built-in `/admin` protection model: when `server.admin.authorizationPolicy` is unset, the routes are open wherever `/admin` is open; when it is set, they require the same browser session and role checks as `/admin`, but return JSON `401`/`403` instead of browser redirects.
 
-Mutable membership APIs still list and delete by canonical `subjectId`. User-backed rows use `user:<user_id>` and workload-backed rows use `workload:<workload_id>`. Dynamic membership writes accept either a canonical `subjectId` or an `email` alias. When `email` is used, Gestalt resolves it to the canonical user subject and creates the user record if needed before persisting the provider-backed grant.
+Mutable membership APIs still list and delete by canonical `subjectId`. User-backed rows use `user:<user_id>` and non-human rows can use `workload:<workload_id>`, `service_account:<id>`, or another canonical non-system subject ID. Dynamic membership writes accept either a canonical `subjectId` or an `email` alias. When `email` is used, Gestalt resolves it to the canonical user subject and creates the user record if needed before persisting the provider-backed grant.
 
 `PUT` and `DELETE` may return `202 Accepted` with `status: "persisted_pending_reload"` when the dynamic grant was written successfully but the local in-memory authorization snapshot has not reloaded yet. In that case, retry access checks only after the local snapshot converges.
 

--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -988,8 +988,8 @@ func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref c
 	if credentialMode != "" {
 		ctx = invocation.WithCredentialModeOverride(ctx, credentialMode)
 	}
-	if m.authorizer != nil && principal.IsWorkloadPrincipal(p) && (connection != "" || instance != "") {
-		return coreagent.Tool{}, fmt.Errorf("%w: workloads may not override connection or instance bindings", invocation.ErrAuthorizationDenied)
+	if m.authorizer != nil && principal.IsNonUserPrincipal(p) && (connection != "" || instance != "") {
+		return coreagent.Tool{}, fmt.Errorf("%w: non-user subjects may not override connection or instance bindings", invocation.ErrAuthorizationDenied)
 	}
 
 	ctx = invocation.WithAccessContext(ctx, m.providerAccessContext(ctx, p, pluginName))
@@ -1153,8 +1153,8 @@ func (m *Manager) catalogForAgentToolSearch(ctx context.Context, p *principal.Pr
 	if credentialMode != "" {
 		ctx = invocation.WithCredentialModeOverride(ctx, credentialMode)
 	}
-	if m.authorizer != nil && principal.IsWorkloadPrincipal(p) && (connection != "" || instance != "") {
-		return nil, fmt.Errorf("%w: workloads may not override connection or instance bindings", invocation.ErrAuthorizationDenied)
+	if m.authorizer != nil && principal.IsNonUserPrincipal(p) && (connection != "" || instance != "") {
+		return nil, fmt.Errorf("%w: non-user subjects may not override connection or instance bindings", invocation.ErrAuthorizationDenied)
 	}
 	var resolver invocation.TokenResolver
 	if tr, ok := m.invoker.(invocation.TokenResolver); ok {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -7038,8 +7038,9 @@ func TestBootstrapSecretResolution(t *testing.T) {
 
 	})
 
-	t.Run("workload resolve access uses subject policy membership", func(t *testing.T) {
+	t.Run("non-user resolve access uses subject policy membership", func(t *testing.T) {
 		t.Parallel()
+		subjectID := "service_account:triage-bot"
 
 		cfg := validConfig()
 		cfg.Authorization = config.AuthorizationConfig{
@@ -7047,7 +7048,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 				"roadmap-policy": {
 					Default: "deny",
 					Members: []config.SubjectPolicyMemberDef{{
-						SubjectID: principal.WorkloadSubjectID("triage-bot"),
+						SubjectID: subjectID,
 						Role:      "viewer",
 					}},
 				},
@@ -7070,22 +7071,22 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		t.Cleanup(func() { _ = result.Close(context.Background()) })
 		<-result.ProvidersReady
 
-		workloadPrincipal := &principal.Principal{
-			SubjectID: principal.WorkloadSubjectID("triage-bot"),
-			Kind:      principal.KindWorkload,
+		subjectPrincipal := &principal.Principal{
+			SubjectID: subjectID,
+			Kind:      principal.Kind("service_account"),
 		}
-		access, allowed := result.Authorizer.ResolveAccess(ctx, workloadPrincipal, "roadmap")
+		access, allowed := result.Authorizer.ResolveAccess(ctx, subjectPrincipal, "roadmap")
 		if !allowed {
-			t.Fatal("expected workload ResolveAccess to use subject policy membership")
+			t.Fatal("expected non-user ResolveAccess to use subject policy membership")
 		}
 		if access.Policy != "roadmap-policy" {
-			t.Fatalf("workload access policy = %q, want %q", access.Policy, "roadmap-policy")
+			t.Fatalf("subject access policy = %q, want %q", access.Policy, "roadmap-policy")
 		}
 		if access.Role != "viewer" {
-			t.Fatalf("workload access role = %q, want viewer", access.Role)
+			t.Fatalf("subject access role = %q, want viewer", access.Role)
 		}
-		if !result.Authorizer.AllowProvider(ctx, workloadPrincipal, "roadmap") {
-			t.Fatal("expected workload subject to be allowed for roadmap provider")
+		if !result.Authorizer.AllowProvider(ctx, subjectPrincipal, "roadmap") {
+			t.Fatal("expected non-user subject to be allowed for roadmap provider")
 		}
 	})
 

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -561,7 +561,7 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 
 func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principal) error {
 	p = principal.Canonicalize(p)
-	if p == nil || p.UserID != "" || p.Kind == principal.KindWorkload || p.Identity == nil || p.Identity.Email == "" {
+	if p == nil || p.UserID != "" || principal.IsNonUserPrincipal(p) || p.Identity == nil || p.Identity.Email == "" {
 		return nil
 	}
 	if b.users == nil {

--- a/gestaltd/internal/invocation/broker_test.go
+++ b/gestaltd/internal/invocation/broker_test.go
@@ -48,7 +48,7 @@ func TestBrokerResolveToken_ConnectionModeNoneResolvesSessionUserSubject(t *test
 	}
 }
 
-func TestBrokerResolveToken_WorkloadUsesOwnExternalCredential(t *testing.T) {
+func TestBrokerResolveToken_NonUserSubjectUsesOwnExternalCredential(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
@@ -57,10 +57,11 @@ func TestBrokerResolveToken_WorkloadUsesOwnExternalCredential(t *testing.T) {
 		ConnMode: core.ConnectionModeUser,
 	})
 	broker := NewBroker(providers, svc.Users, svc.ExternalCredentials)
+	subjectID := "service_account:workflow-roadmap"
 
 	if err := svc.ExternalCredentials.PutCredential(context.Background(), &core.ExternalCredential{
-		ID:          "workload-workspace-team-a",
-		SubjectID:   principal.WorkloadSubjectID("workflow.roadmap"),
+		ID:          "subject-workspace-team-a",
+		SubjectID:   subjectID,
 		Integration: "slack",
 		Connection:  "workspace",
 		Instance:    "team-a",
@@ -69,8 +70,8 @@ func TestBrokerResolveToken_WorkloadUsesOwnExternalCredential(t *testing.T) {
 		t.Fatalf("PutCredential team-a: %v", err)
 	}
 	if err := svc.ExternalCredentials.PutCredential(context.Background(), &core.ExternalCredential{
-		ID:          "workload-workspace-team-b",
-		SubjectID:   principal.WorkloadSubjectID("workflow.roadmap"),
+		ID:          "subject-workspace-team-b",
+		SubjectID:   subjectID,
 		Integration: "slack",
 		Connection:  "workspace",
 		Instance:    "team-b",
@@ -79,16 +80,16 @@ func TestBrokerResolveToken_WorkloadUsesOwnExternalCredential(t *testing.T) {
 		t.Fatalf("PutCredential team-b: %v", err)
 	}
 
-	workload := &principal.Principal{
-		SubjectID: principal.WorkloadSubjectID("workflow.roadmap"),
-		Kind:      principal.KindWorkload,
+	subject := &principal.Principal{
+		SubjectID: subjectID,
+		Kind:      principal.Kind("service_account"),
 		Source:    principal.SourceAPIToken,
 	}
 	ctx := WithWorkflowContext(context.Background(), map[string]any{
 		"runId": "run-123",
 	})
 
-	ctx, token, err := broker.ResolveToken(ctx, workload, "slack", "workspace", "team-b")
+	ctx, token, err := broker.ResolveToken(ctx, subject, "slack", "workspace", "team-b")
 	if err != nil {
 		t.Fatalf("ResolveToken: %v", err)
 	}
@@ -96,8 +97,8 @@ func TestBrokerResolveToken_WorkloadUsesOwnExternalCredential(t *testing.T) {
 		t.Fatalf("token = %q, want team-b-token", token)
 	}
 	cred := CredentialContextFromContext(ctx)
-	if cred.SubjectID != principal.WorkloadSubjectID("workflow.roadmap") {
-		t.Fatalf("credential subject = %q, want workload subject", cred.SubjectID)
+	if cred.SubjectID != subjectID {
+		t.Fatalf("credential subject = %q, want %q", cred.SubjectID, subjectID)
 	}
 	if cred.Connection != "workspace" || cred.Instance != "team-b" {
 		t.Fatalf("credential selectors = %q/%q, want workspace/team-b", cred.Connection, cred.Instance)

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -111,11 +111,6 @@ func IsSystemPrincipal(p *Principal) bool {
 	return p != nil && IsSystemSubjectID(p.SubjectID)
 }
 
-func IsWorkloadPrincipal(p *Principal) bool {
-	p = Canonicalized(p)
-	return p != nil && p.Kind == KindWorkload
-}
-
 func IsNonUserPrincipal(p *Principal) bool {
 	p = Canonicalized(p)
 	return p != nil && p.Kind != "" && p.Kind != KindUser

--- a/gestaltd/internal/providerhost/provider_server.go
+++ b/gestaltd/internal/providerhost/provider_server.go
@@ -2,6 +2,7 @@ package providerhost
 
 import (
 	"context"
+	"strings"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
@@ -120,11 +121,8 @@ func principalFromProto(subject *proto.SubjectContext) *principal.Principal {
 		DisplayName: subject.GetDisplayName(),
 		Source:      sourceFromString(subject.GetAuthSource()),
 	}
-	switch subject.GetKind() {
-	case string(principal.KindUser):
-		p.Kind = principal.KindUser
-	case string(principal.KindWorkload):
-		p.Kind = principal.KindWorkload
+	if kind := strings.TrimSpace(subject.GetKind()); kind != "" {
+		p.Kind = principal.Kind(kind)
 	}
 	p.UserID = principal.UserIDFromSubjectID(p.SubjectID)
 	p = principal.Canonicalized(p)

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -370,12 +370,12 @@ func TestRequestContextProto_PreservesWorkflowContext(t *testing.T) {
 	}
 }
 
-func TestPrincipalFromProto_WorkloadDisplayNameDoesNotCreateIdentity(t *testing.T) {
+func TestPrincipalFromProto_NonUserDisplayNameDoesNotCreateIdentity(t *testing.T) {
 	t.Parallel()
 
 	p := principalFromProto(&proto.SubjectContext{
-		Id:          principal.WorkloadSubjectID("triage-bot"),
-		Kind:        string(principal.KindWorkload),
+		Id:          "service_account:triage-bot",
+		Kind:        "service_account",
 		DisplayName: "Triage Bot",
 		AuthSource:  principal.SourceAPIToken.String(),
 	})
@@ -385,8 +385,11 @@ func TestPrincipalFromProto_WorkloadDisplayNameDoesNotCreateIdentity(t *testing.
 	if p.DisplayName != "Triage Bot" {
 		t.Fatalf("display name = %q, want %q", p.DisplayName, "Triage Bot")
 	}
+	if p.Kind != principal.Kind("service_account") {
+		t.Fatalf("kind = %q, want service_account", p.Kind)
+	}
 	if p.Identity != nil {
-		t.Fatalf("expected workload identity to remain nil, got %#v", p.Identity)
+		t.Fatalf("expected non-user identity to remain nil, got %#v", p.Identity)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -565,16 +565,15 @@ func adminAuthorizationSubjectID(subjectID string) (string, error) {
 	if subjectID == "" {
 		return "", errors.New("subjectID is required")
 	}
-	if principal.IsSystemSubjectID(subjectID) {
+	kind, id, ok := core.ParseSubjectID(subjectID)
+	if !ok {
+		return "", errors.New("subjectID must be a canonical subject ID")
+	}
+	subjectID = kind + ":" + id
+	if kind == "system" {
 		return "", errors.New("subjectID must not use system:<id>")
 	}
-	if strings.TrimSpace(principal.UserIDFromSubjectID(subjectID)) != "" {
-		return subjectID, nil
-	}
-	if strings.HasPrefix(subjectID, string(principal.KindWorkload)+":") && strings.TrimPrefix(subjectID, string(principal.KindWorkload)+":") != "" {
-		return subjectID, nil
-	}
-	return "", errors.New("subjectID must use user:<id> or workload:<id>")
+	return subjectID, nil
 }
 
 func adminAuthorizationValidSubjectID(subjectID string) bool {

--- a/gestaltd/internal/server/http_binding_subject.go
+++ b/gestaltd/internal/server/http_binding_subject.go
@@ -63,11 +63,8 @@ func (s *Server) resolveHTTPBindingPrincipal(ctx context.Context, binding Mounte
 		DisplayName: strings.TrimSpace(resolved.DisplayName),
 		Source:      principal.ParseSource(strings.TrimSpace(resolved.AuthSource)),
 	})
-	switch strings.TrimSpace(resolved.Kind) {
-	case string(principal.KindUser):
-		p.Kind = principal.KindUser
-	case string(principal.KindWorkload):
-		p.Kind = principal.KindWorkload
+	if kind := strings.TrimSpace(resolved.Kind); kind != "" {
+		p.Kind = principal.Kind(kind)
 	}
 	return p, nil
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -3723,6 +3723,40 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("plugin membership email = %q, want %q", putPluginMembershipResp.Membership.Email, dynamicEmail)
 	}
 
+	serviceAccountSubjectID := "service_account:reporting-bot"
+	body = bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, serviceAccountSubjectID))
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT service account member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put service account member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+	var putServiceAccountMembershipResp struct {
+		Membership struct {
+			SelectorKind  string `json:"selectorKind"`
+			SelectorValue string `json:"selectorValue"`
+			Email         string `json:"email"`
+			Role          string `json:"role"`
+		} `json:"membership"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&putServiceAccountMembershipResp); err != nil {
+		t.Fatalf("decode service account membership response: %v", err)
+	}
+	if putServiceAccountMembershipResp.Membership.SelectorKind != "subject_id" {
+		t.Fatalf("service account membership selectorKind = %q, want subject_id", putServiceAccountMembershipResp.Membership.SelectorKind)
+	}
+	if putServiceAccountMembershipResp.Membership.SelectorValue != serviceAccountSubjectID {
+		t.Fatalf("service account membership selectorValue = %q, want %q", putServiceAccountMembershipResp.Membership.SelectorValue, serviceAccountSubjectID)
+	}
+	if putServiceAccountMembershipResp.Membership.Email != "" {
+		t.Fatalf("service account membership email = %q, want empty", putServiceAccountMembershipResp.Membership.Email)
+	}
+
 	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
 	if err != nil {
 		t.Fatalf("GET members: %v", err)
@@ -3736,27 +3770,39 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
 		t.Fatalf("decoding members: %v", err)
 	}
-	if len(members) != 2 {
-		t.Fatalf("expected 2 merged members, got %d (%+v)", len(members), members)
+	if len(members) != 3 {
+		t.Fatalf("expected 3 merged members, got %d (%+v)", len(members), members)
 	}
 	foundDynamicPluginMember := false
+	foundDynamicServiceAccountMember := false
 	for _, member := range members {
 		if member["source"] != "dynamic" {
 			continue
 		}
-		foundDynamicPluginMember = true
-		if got := member["selectorKind"]; got != "subject_id" {
-			t.Fatalf("dynamic plugin member selectorKind = %v, want subject_id", got)
-		}
-		if member["selectorValue"] != principal.UserSubjectID(dynamicUser.ID) {
-			t.Fatalf("dynamic plugin member selector metadata = %+v, want canonical subject_id selectorValue", member)
-		}
-		if member["email"] != dynamicEmail {
-			t.Fatalf("dynamic plugin member email = %v, want %q", member["email"], dynamicEmail)
+		switch member["selectorValue"] {
+		case principal.UserSubjectID(dynamicUser.ID):
+			foundDynamicPluginMember = true
+			if got := member["selectorKind"]; got != "subject_id" {
+				t.Fatalf("dynamic plugin member selectorKind = %v, want subject_id", got)
+			}
+			if member["email"] != dynamicEmail {
+				t.Fatalf("dynamic plugin member email = %v, want %q", member["email"], dynamicEmail)
+			}
+		case serviceAccountSubjectID:
+			foundDynamicServiceAccountMember = true
+			if got := member["selectorKind"]; got != "subject_id" {
+				t.Fatalf("dynamic service account member selectorKind = %v, want subject_id", got)
+			}
+			if member["email"] != nil {
+				t.Fatalf("dynamic service account member email = %v, want omitted", member["email"])
+			}
 		}
 	}
 	if !foundDynamicPluginMember {
 		t.Fatalf("expected one dynamic plugin member, got %+v", members)
+	}
+	if !foundDynamicServiceAccountMember {
+		t.Fatalf("expected one dynamic service account member, got %+v", members)
 	}
 
 	body = bytes.NewBufferString(`{"email":"static@example.test","role":"viewer"}`)
@@ -3781,6 +3827,17 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		t.Fatalf("delete dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members/"+url.PathEscape(serviceAccountSubjectID), nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE service account member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("delete service account member status = %d, want 200: %s", resp.StatusCode, respBody)
 	}
 
 	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")


### PR DESCRIPTION
## Summary
- replace the remaining workload-only runtime checks with generic non-user subject checks
- allow dynamic authorization writes for any canonical non-system `subjectId`, such as `service_account:<id>`
- preserve arbitrary subject kinds through provider-host and HTTP binding subject contexts
- remove the now-unused `principal.IsWorkloadPrincipal` helper
- update docs so API tokens, dynamic memberships, and external credentials describe subject-owned non-human callers generically

## New interface
```go
func principal.IsNonUserPrincipal(p *principal.Principal) bool
```

## Examples
```go
// Dynamic authorization membership can target any canonical non-system subject.
subjectId := "service_account:reporting-bot"
```

```go
// Non-human API tokens resolve credentials under their own subject ID.
core.APIToken{
    OwnerKind: core.APITokenOwnerKindSubject,
    OwnerID: "service_account:workflow-roadmap",
    CredentialSubjectID: "service_account:workflow-roadmap",
}
```

## Validation
- `go test ./internal/invocation ./internal/agentmanager ./internal/server ./internal/bootstrap ./internal/providerhost -run 'TestBrokerResolveToken_NonUserSubjectUsesOwnExternalCredential|TestAdminAPI_PluginAuthorizationCRUD|TestSubjectAuthorization_UserOnlyRoutesReturn403ForNonUserSubjects|TestPrincipalFromProto_NonUserDisplayNameDoesNotCreateIdentity|TestBootstrap/.+subject policy membership' -count=1`
- `go test ./internal/principal ./internal/invocation ./internal/agentmanager ./internal/server ./internal/bootstrap ./internal/providerhost ./internal/mcp ./internal/authorization -count=1`