### PR TITLE
Use stored CLI auth for remote provider dev

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -834,7 +834,7 @@ a path-only attach is enough:
 
 ```sh
 export GESTALT_URL=https://gestalt.example.com
-export GESTALT_API_KEY=vat_...
+gestalt auth login --url "$GESTALT_URL"
 
 gestaltd provider dev --remote "$GESTALT_URL" --path ./slack
 ```
@@ -844,6 +844,13 @@ that exposes provider-dev attach targets. The local command replaces only the
 source plugin attached by your authenticated session. Providers that are not
 attached locally continue to run through the remote server and its existing
 configuration.
+Remote provider dev authenticates with `--remote-token` first, then
+`GESTALT_API_KEY`, then the stored CLI token from `gestalt auth login` when the
+stored credential's server base URL matches `--remote`. A stored credential for
+a different server URL, including a different path prefix on the same host, is
+not sent; the command exits with the stored credential's server and file path
+plus commands to log in for the requested server or pass an explicit token. Use
+`--remote-token` or `GESTALT_API_KEY` for non-interactive automation.
 
 For `--remote --path` without `--config`, Gestalt matches the local manifest
 `source` to a configured plugin on the remote server. The remote plugin's

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -58,9 +58,10 @@ gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml 
 gestaltd provider dev --path ./plugins/support
 gestaltd provider dev --path ./ui/dashboard
 gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080
-GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support
-GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support --name support
-GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --config ./remote.yaml --config ./local-overrides.yaml
+gestalt auth login --url https://gestalt.example.com
+gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support
+gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support --name support
+gestaltd provider dev --remote https://gestalt.example.com --config ./remote.yaml --config ./local-overrides.yaml
 gestaltd provider release --version 0.0.1-alpha.1
 gestaltd provider release --version 0.0.1-alpha.1 --platform all
 gestaltd provider release --version 0.0.1-alpha.1 --platform linux/amd64,linux/arm64
@@ -75,6 +76,12 @@ keeps its existing config-relative behavior for backward compatibility.
 `provider dev --remote` is environment-agnostic: the URL is just the remote
 `gestaltd` instance to attach to. The local command only replaces source-backed
 plugin implementations for the authenticated principal that created the session.
+Authentication resolves in this order: `--remote-token`, `GESTALT_API_KEY`, then
+the stored CLI token from `gestalt auth login` when its recorded server base URL
+matches `--remote`. Stored CLI tokens are not sent to a different remote URL,
+including a different path prefix on the same host; if the stored credential
+points elsewhere, the command fails with a remediation message instead of
+prompting.
 With `--remote URL --path PATH` and no `--config`, the local command sends the
 manifest `source` and the local implementation only; the remote server chooses
 the configured plugin with the same manifest `source` and preserves that

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -38,6 +39,7 @@ const (
 	providerDevIndexedDBName = "main"
 	providerLocalPluginDir   = "plugin"
 	providerLocalSiblingUI   = "ui"
+	gestaltAPIKeyEnv         = "GESTALT_API_KEY"
 )
 
 type providerLocalCommandOptions struct {
@@ -165,6 +167,11 @@ type providerRemoteTarget struct {
 	InheritRemoteConfig bool
 }
 
+type storedGestaltCLICredential struct {
+	APIURL   string `json:"api_url"`
+	APIToken string `json:"api_token"`
+}
+
 func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	configPaths, cleanup, err := prepareProviderRemoteConfigPaths(opts)
 	if err != nil {
@@ -185,12 +192,9 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		return errors.New("provider dev --remote requires at least one source-backed plugin in --config or --path")
 	}
 
-	token := strings.TrimSpace(opts.RemoteToken)
-	if token == "" {
-		token = strings.TrimSpace(os.Getenv("GESTALT_API_KEY"))
-	}
-	if token == "" {
-		return errors.New("provider dev --remote requires --remote-token or GESTALT_API_KEY")
+	token, err := resolveProviderRemoteToken(opts)
+	if err != nil {
+		return err
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -291,6 +295,165 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		"config_files", configPaths,
 	)
 	return client.RunDispatcher(ctx, session.ID, providerClients, providerdev.WithUIHandlers(localUIHandlers))
+}
+
+func resolveProviderRemoteToken(opts providerLocalCommandOptions) (string, error) {
+	remoteBaseURL, err := providerRemoteBaseURL(opts.Remote)
+	if err != nil {
+		return "", fmt.Errorf("invalid --remote %q: %w", opts.Remote, err)
+	}
+	if token := strings.TrimSpace(opts.RemoteToken); token != "" {
+		return token, nil
+	}
+	if token := strings.TrimSpace(os.Getenv(gestaltAPIKeyEnv)); token != "" {
+		return token, nil
+	}
+
+	credential, credentialPath, ok, err := loadStoredGestaltCLICredential()
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", providerRemoteAuthMissingError(remoteBaseURL)
+	}
+	if strings.TrimSpace(credential.APIURL) == "" {
+		return "", providerRemoteStoredCredentialUnscopedError(remoteBaseURL, credentialPath)
+	}
+	storedBaseURL, err := providerRemoteBaseURL(credential.APIURL)
+	if err != nil {
+		return "", fmt.Errorf("stored Gestalt CLI credential has invalid api_url in %s: %w", credentialPath, err)
+	}
+	if storedBaseURL != remoteBaseURL {
+		return "", providerRemoteStoredCredentialMismatchError(remoteBaseURL, storedBaseURL, credentialPath)
+	}
+	if token := strings.TrimSpace(credential.APIToken); token != "" {
+		return token, nil
+	}
+	return "", fmt.Errorf("stored Gestalt CLI credential in %s is missing api_token; run 'gestalt auth login --url %s' or pass --remote-token", credentialPath, remoteBaseURL)
+}
+
+func loadStoredGestaltCLICredential() (storedGestaltCLICredential, string, bool, error) {
+	path, err := storedGestaltCLICredentialPath()
+	if err != nil {
+		return storedGestaltCLICredential{}, "", false, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return storedGestaltCLICredential{}, path, false, nil
+		}
+		return storedGestaltCLICredential{}, path, false, fmt.Errorf("read stored Gestalt CLI credential from %s: %w", path, err)
+	}
+	var credential storedGestaltCLICredential
+	if err := json.Unmarshal(data, &credential); err != nil {
+		return storedGestaltCLICredential{}, path, false, fmt.Errorf("parse stored Gestalt CLI credential from %s: %w", path, err)
+	}
+	return credential, path, true, nil
+}
+
+func storedGestaltCLICredentialPath() (string, error) {
+	if xdgConfigHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdgConfigHome != "" {
+		return filepath.Join(xdgConfigHome, "gestalt", "credentials.json"), nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("locate stored Gestalt CLI credential: %w", err)
+	}
+	return filepath.Join(homeDir, ".config", "gestalt", "credentials.json"), nil
+}
+
+func providerRemoteBaseURL(rawURL string) (string, error) {
+	trimmed := strings.TrimSpace(rawURL)
+	if trimmed == "" {
+		return "", errors.New("URL is required")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", err
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", errors.New("URL scheme must be http or https")
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return "", errors.New("URL must include a host")
+	}
+	port := parsed.Port()
+	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+		port = ""
+	}
+	if port != "" {
+		host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+	baseURL := scheme + "://" + host
+	if path := strings.TrimRight(parsed.EscapedPath(), "/"); path != "" {
+		baseURL += path
+	}
+	return baseURL, nil
+}
+
+func providerRemoteAuthMissingError(remoteOrigin string) error {
+	return fmt.Errorf(`provider dev --remote requires authentication.
+
+Remote server:
+  %s
+
+No --remote-token or %s was provided, and no stored Gestalt CLI credential for this server was found.
+
+Log in for this server:
+
+  gestalt auth login --url %s
+
+or pass an explicit token:
+
+  gestaltd provider dev --remote %s --remote-token <token> --path ./plugin`, remoteOrigin, gestaltAPIKeyEnv, remoteOrigin, remoteOrigin)
+}
+
+func providerRemoteStoredCredentialUnscopedError(remoteOrigin, credentialPath string) error {
+	return fmt.Errorf(`provider dev --remote could not use the stored Gestalt CLI credential.
+
+Remote server:
+  %s
+
+Stored credential:
+  server: <missing>
+  file: %s
+
+The stored credential does not record which Gestalt server it belongs to, so it was not sent.
+
+Log in for this server:
+
+  gestalt auth login --url %s
+
+or pass an explicit token:
+
+  gestaltd provider dev --remote %s --remote-token <token> --path ./plugin`, remoteOrigin, credentialPath, remoteOrigin, remoteOrigin)
+}
+
+func providerRemoteStoredCredentialMismatchError(remoteOrigin, storedOrigin, credentialPath string) error {
+	return fmt.Errorf(`provider dev --remote could not use the stored Gestalt CLI credential.
+
+Remote server:
+  %s
+
+Stored credential:
+  server: %s
+  file: %s
+
+The stored credential is scoped to a different Gestalt server, so it was not sent.
+
+To use this remote server, log in for that server:
+
+  gestalt auth login --url %s
+
+or pass an explicit token:
+
+  gestaltd provider dev --remote %s --remote-token <token> --path ./plugin
+
+You can also set %s for this command`, remoteOrigin, storedOrigin, credentialPath, remoteOrigin, remoteOrigin, gestaltAPIKeyEnv)
 }
 
 func providerRemoteTargetNames(targets []providerRemoteTarget) []string {
@@ -1452,5 +1615,5 @@ func printProviderDevUsage(w io.Writer) {
 	writeUsageLine(w, "  --name     Provider key override when the target key is ambiguous")
 	writeUsageLine(w, "  --port     Public port (default: auto-selected free localhost port)")
 	writeUsageLine(w, "  --remote   Remote gestaltd base URL to attach local source plugins to")
-	writeUsageLine(w, "  --remote-token  Bearer token for --remote (default: GESTALT_API_KEY)")
+	writeUsageLine(w, "  --remote-token  Bearer token for --remote (default: GESTALT_API_KEY or matching gestalt auth login credentials)")
 }

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -98,6 +99,180 @@ func TestProviderRemoteConfigPathSynthesizesSourcePlugin(t *testing.T) {
 	}
 	if !targets[0].InheritRemoteConfig {
 		t.Fatal("target InheritRemoteConfig = false, want true")
+	}
+}
+
+func TestResolveProviderRemoteTokenPrecedence(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeStoredGestaltCLICredentialForTest(t, configHome, "https://stored.example.com", "stored-token")
+
+	t.Setenv(gestaltAPIKeyEnv, "env-token")
+	token, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+		Remote:      "https://remote.example.com",
+		RemoteToken: "flag-token",
+	})
+	if err != nil {
+		t.Fatalf("resolveProviderRemoteToken with explicit token: %v", err)
+	}
+	if token != "flag-token" {
+		t.Fatalf("token = %q, want explicit flag token", token)
+	}
+
+	token, err = resolveProviderRemoteToken(providerLocalCommandOptions{
+		Remote: "https://remote.example.com",
+	})
+	if err != nil {
+		t.Fatalf("resolveProviderRemoteToken with env token: %v", err)
+	}
+	if token != "env-token" {
+		t.Fatalf("token = %q, want env token", token)
+	}
+}
+
+func TestResolveProviderRemoteTokenUsesMatchingStoredCLICredential(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv(gestaltAPIKeyEnv, "")
+	writeStoredGestaltCLICredentialForTest(t, configHome, "https://Valon.Tools:443/team-a/", "stored-token")
+
+	token, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+		Remote: "https://valon.tools/team-a",
+	})
+	if err != nil {
+		t.Fatalf("resolveProviderRemoteToken: %v", err)
+	}
+	if token != "stored-token" {
+		t.Fatalf("token = %q, want stored token", token)
+	}
+}
+
+func TestResolveProviderRemoteTokenRejectsDifferentBasePaths(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv(gestaltAPIKeyEnv, "")
+	writeStoredGestaltCLICredentialForTest(t, configHome, "https://valon.tools/team-a", "stored-token")
+
+	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+		Remote: "https://valon.tools/team-b",
+	})
+	if err == nil {
+		t.Fatal("expected path-scoped stored credential mismatch error")
+	}
+	errText := err.Error()
+	for _, want := range []string{
+		"Remote server:\n  https://valon.tools/team-b",
+		"Stored credential:\n  server: https://valon.tools/team-a",
+		"The stored credential is scoped to a different Gestalt server, so it was not sent.",
+	} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error missing %q:\n%s", want, errText)
+		}
+	}
+}
+
+func TestResolveProviderRemoteTokenRejectsMismatchedStoredCLICredential(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv(gestaltAPIKeyEnv, "")
+	writeStoredGestaltCLICredentialForTest(t, configHome, "https://valon.tools", "stored-token")
+
+	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+		Remote: "https://staging.valon.tools",
+	})
+	if err == nil {
+		t.Fatal("expected stored credential mismatch error")
+	}
+	errText := err.Error()
+	for _, want := range []string{
+		"provider dev --remote could not use the stored Gestalt CLI credential.",
+		"Remote server:\n  https://staging.valon.tools",
+		"Stored credential:\n  server: https://valon.tools",
+		filepath.Join(configHome, "gestalt", "credentials.json"),
+		"The stored credential is scoped to a different Gestalt server, so it was not sent.",
+		"gestalt auth login --url https://staging.valon.tools",
+		"gestaltd provider dev --remote https://staging.valon.tools --remote-token <token> --path ./plugin",
+		"You can also set GESTALT_API_KEY for this command",
+	} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error missing %q:\n%s", want, errText)
+		}
+	}
+}
+
+func TestResolveProviderRemoteTokenRejectsUnscopedStoredCLICredential(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv(gestaltAPIKeyEnv, "")
+	writeStoredGestaltCLICredentialForTest(t, configHome, "", "legacy-token")
+
+	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+		Remote: "https://valon.tools",
+	})
+	if err == nil {
+		t.Fatal("expected unscoped stored credential error")
+	}
+	errText := err.Error()
+	for _, want := range []string{
+		"Stored credential:\n  server: <missing>",
+		"The stored credential does not record which Gestalt server it belongs to, so it was not sent.",
+		"gestalt auth login --url https://valon.tools",
+	} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error missing %q:\n%s", want, errText)
+		}
+	}
+}
+
+func TestResolveProviderRemoteTokenRequiresAuthWhenNoCredentialExists(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv(gestaltAPIKeyEnv, "")
+
+	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+		Remote: "https://valon.tools",
+	})
+	if err == nil {
+		t.Fatal("expected missing auth error")
+	}
+	errText := err.Error()
+	for _, want := range []string{
+		"provider dev --remote requires authentication.",
+		"Remote server:\n  https://valon.tools",
+		"No --remote-token or GESTALT_API_KEY was provided, and no stored Gestalt CLI credential for this server was found.",
+		"gestalt auth login --url https://valon.tools",
+		"gestaltd provider dev --remote https://valon.tools --remote-token <token> --path ./plugin",
+	} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error missing %q:\n%s", want, errText)
+		}
+	}
+}
+
+func TestProviderRemoteBaseURLNormalizesDefaultPortsAndTrailingSlashes(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"https://Valon.Tools":       "https://valon.tools",
+		"https://valon.tools:443/x": "https://valon.tools/x",
+		"http://valon.tools:80":     "http://valon.tools",
+		"http://127.0.0.1:8080/a":   "http://127.0.0.1:8080/a",
+		"https://valon.tools/a///":  "https://valon.tools/a",
+	}
+	for input, want := range cases {
+		input := input
+		want := want
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := providerRemoteBaseURL(input)
+			if err != nil {
+				t.Fatalf("providerRemoteBaseURL(%q): %v", input, err)
+			}
+			if got != want {
+				t.Fatalf("providerRemoteBaseURL(%q) = %q, want %q", input, got, want)
+			}
+		})
 	}
 }
 
@@ -3814,6 +3989,20 @@ func writeTestFile(t *testing.T, dir, rel string, data []byte, mode os.FileMode)
 	if err := os.WriteFile(path, data, mode); err != nil {
 		t.Fatalf("WriteFile(%s): %v", rel, err)
 	}
+}
+
+func writeStoredGestaltCLICredentialForTest(t *testing.T, configHome, apiURL, apiToken string) {
+	t.Helper()
+
+	data, err := json.Marshal(map[string]string{
+		"api_url":      apiURL,
+		"api_token":    apiToken,
+		"api_token_id": "tok-123",
+	})
+	if err != nil {
+		t.Fatalf("Marshal stored CLI credential: %v", err)
+	}
+	writeTestFile(t, configHome, "gestalt/credentials.json", data, 0o600)
 }
 
 func sha256HexForTest(value string) string {


### PR DESCRIPTION
## Summary

`gestaltd provider dev --remote` now reuses the stored `gestalt auth login` credential when it is safe to do so.

## New Interface

Authentication precedence for remote provider dev is now:

1. `--remote-token`
2. `GESTALT_API_KEY`
3. stored `gestalt auth login` credential, but only when the stored `api_url` base URL matches `--remote`

Stored credentials for a different server URL, including a different path prefix on the same host, or legacy stored credentials with no recorded `api_url`, are not sent. The command fails closed and prints the remote server, the stored credential source, and remediation commands.

## Examples

```sh
gestalt auth login --url https://valon.tools
gestaltd provider dev --remote https://valon.tools --path ./plugin
```

```sh
gestaltd provider dev --remote https://staging.valon.tools --remote-token <token> --path ./plugin
```

Docs now show the login-first happy path and explain the precedence/mismatch behavior in:

- `docs/content/reference/cli.mdx`
- `docs/content/custom-providers/plugins.mdx`

## Verification

```sh
go test ./cmd/gestaltd -run 'TestResolveProviderRemoteToken|TestProviderRemoteBaseURL|TestProviderRemoteConfigPathSynthesizesSourcePlugin|TestRun_ProviderCLIUsageAndErrors'
golangci-lint run ./cmd/gestaltd
go build -o /tmp/gestaltd-provider-dev-stored-token ./cmd/gestaltd
cd docs && npm run typecheck && npm run build
```
