### PR TITLE
Remove workload subject primitive

### DIFF
--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -29,7 +29,7 @@ Owned by the configured external credentials provider, not gestaltd core. The de
 | Field | Type | Notes |
 | --- | --- | --- |
 | `id` | string, PK | UUID. |
-| `subject_id` | string | Canonical credential owner such as `user:<id>`, `workload:<id>`, or `service_account:<id>`. |
+| `subject_id` | string | Canonical credential owner such as `user:<id>`, `service_account:<id>`, or a runtime-supplied `system:<id>` subject. |
 | `integration` | string | Provider name from config (e.g., `slack`). |
 | `connection` | string | Named connection within the provider (e.g., `default`, `mcp`). |
 | `instance` | string | User-chosen or discovery-assigned name for multi-account providers. |

--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -31,9 +31,9 @@ These fields are emitted when available:
 
 | Field | Meaning |
 | --- | --- |
-| `auth_source` | Authentication mechanism for the caller: `session`, `api_token`, or `env` |
-| `subject_id` | Canonical caller subject such as `user:<id>` or `workload:<id>` |
-| `subject_kind` | Canonical subject type, such as `user` or `workload` |
+| `auth_source` | Authentication mechanism for the caller: `session`, `api_token`, or `env`. Rejected retired workload bearer tokens are audit-tagged as `retired_workload_token`. |
+| `subject_id` | Canonical caller subject such as `user:<id>` or `service_account:<id>` |
+| `subject_kind` | Canonical subject type, such as `user` or `service_account` |
 | `target_kind` | Generic kind for the object the event acted on, such as `api_token` or `connection` |
 | `target_id` | Stable identifier for the affected object when one exists |
 | `target_name` | Human-readable label for the affected object |

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -309,7 +309,7 @@ plugins:
 | Mode | Behavior |
 | --- | --- |
 | `none` | No upstream credential needed. |
-| `user` | Credentials are stored for the calling subject (for example `user:<id>` or `workload:<id>`). |
+| `user` | Credentials are stored for the calling subject (for example `user:<id>` or `service_account:<id>`). |
 
 ### Authentication Types
 

--- a/docs/content/providers/authorization.mdx
+++ b/docs/content/providers/authorization.mdx
@@ -25,7 +25,7 @@ provider-backed relationship storage or dynamic subject-grant control plane.
 
 At the product level, authorization is about subjects and runtime surfaces.
 Gestalt resolves each request to a canonical subject such as `user:<id>`,
-`workload:<id>`, or a system subject, then asks whether that subject may access
+`service_account:<id>`, or a system subject, then asks whether that subject may access
 the thing they are trying to use. Static memberships under
 `authorization.policies` are always available. When you configure an
 authorization provider, Gestalt adds dynamic relationship storage on top so

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -161,7 +161,7 @@ stores credentials per subject.
 | Mode | Behavior |
 | --- | --- |
 | `none` | No upstream credential is required |
-| `user` | The calling subject stores its own credential (`user:<id>` or `workload:<id>`) |
+| `user` | The calling subject stores its own credential (`user:<id>`, `service_account:<id>`, or another canonical subject ID) |
 
 Common auth types are `oauth2`, `mcp_oauth`, `bearer`, `manual`, and `none`.
 Operator-supplied app credentials such as `clientId` and `clientSecret` go in

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -166,7 +166,7 @@ omitted, that field is ignored during matching.
 User-owned schedules are global resources exposed through
 `POST /api/v1/workflow/schedules` and `gestalt workflow schedules ...`.
 These schedules execute as the creating subject, not as a plugin-local or
-synthetic workflow workload.
+synthetic workflow subject.
 
 <Tabs items={['CLI', 'HTTP']}>
   <Tabs.Tab>
@@ -258,7 +258,7 @@ workflow backend.
 User-owned triggers are global resources exposed through
 `POST /api/v1/workflow/event-triggers` and
 `gestalt workflow triggers ...`. These triggers execute as the creating
-subject, not as a plugin-local or synthetic workflow workload.
+subject, not as a plugin-local or synthetic workflow subject.
 
 <Tabs items={['CLI', 'HTTP']}>
   <Tabs.Tab>

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -126,7 +126,7 @@ authorization:
           role: viewer
         - subjectID: user:admin-user
           role: admin
-        - subjectID: workload:triage-bot
+        - subjectID: service_account:triage-bot
           role: viewer
 ```
 
@@ -146,11 +146,11 @@ authorization:
 
 `admin.ui` optionally pins `/admin` to one named `providers.ui.<name>` bundle. The selected bundle must ship `admin/index.html` inside its prepared asset root. When `admin.ui` is omitted, Gestalt first auto-discovers admin assets from the root-mounted UI bundle (`path: /`) when that bundle contains `admin/index.html`, then falls back to the built-in admin shell.
 
-`authorization.policies` configures shared subject access policies. Each policy resolves a caller to exactly one role by matching canonical `subjectID` values such as `user:<id>` or `workload:<id>`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
+`authorization.policies` configures shared subject access policies. Each policy resolves a caller to exactly one role by matching canonical `subjectID` values such as `user:<id>` or `service_account:<id>`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
 
-Dynamic grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, operators can manage additional dynamic members for that plugin from the built-in admin UI at `/admin/?tab=members` or through `/admin/api/v1/authorization/...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for subjects that already have static authorization on that plugin. The `email` write field is a user-only convenience alias; `subjectId` accepts any canonical non-system subject ID, such as `user:<id>`, `workload:<id>`, or `service_account:<id>`.
+Dynamic grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, operators can manage additional dynamic members for that plugin from the built-in admin UI at `/admin/?tab=members` or through `/admin/api/v1/authorization/...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for subjects that already have static authorization on that plugin. The `email` write field is a user-only convenience alias; `subjectId` accepts any canonical non-system subject ID, such as `user:<id>`, `service_account:<id>`, or another deployment-defined subject kind.
 
-Non-human callers are modeled as canonical subjects, typically `workload:<id>` or `service_account:<id>`, and authenticate with Gestalt API tokens whose stored owner is that subject. Grant plugin access with `authorization.policies` or provider-backed dynamic memberships using the canonical subject ID, and store third-party credentials through the configured external credentials provider under the same subject ID.
+Non-human callers are modeled as canonical subjects, typically `service_account:<id>`, and authenticate with Gestalt API tokens whose stored owner is that subject. Grant plugin access with `authorization.policies` or provider-backed dynamic memberships using the canonical subject ID, and store third-party credentials through the configured external credentials provider under the same subject ID.
 
 Plugins without `authorizationPolicy` are open to any authenticated subject. Bind a plugin to a policy when non-human access should be explicit.
 
@@ -1126,7 +1126,7 @@ connections:
       type: mcp_oauth
 ```
 
-Connection `mode` determines how credentials are managed: `none` requires no credentials, and `user` stores credentials for the caller's effective subject. For humans that is typically `user:<id>`; for non-human subjects it can be `workload:<id>`, `service_account:<id>`, or another canonical non-system subject ID. All connections in a single plugin must share the same mode.
+Connection `mode` determines how credentials are managed: `none` requires no credentials, and `user` stores credentials for the caller's effective subject. For humans that is typically `user:<id>`; for non-human API token callers it can be `service_account:<id>` or another canonical non-system subject ID. Runtime surfaces can also supply system subjects such as `system:http_binding:<plugin>:<binding>` as the effective credential owner. All connections in a single plugin must share the same mode.
 
 #### Authentication Shapes
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -128,7 +128,7 @@ tool_result | image_ref` plus the corresponding `text`, `json`, `toolCall`,
 
 `/admin/api/v1/...` mirrors the built-in `/admin` protection model: when `server.admin.authorizationPolicy` is unset, the routes are open wherever `/admin` is open; when it is set, they require the same browser session and role checks as `/admin`, but return JSON `401`/`403` instead of browser redirects.
 
-Mutable membership APIs still list and delete by canonical `subjectId`. User-backed rows use `user:<user_id>` and non-human rows can use `workload:<workload_id>`, `service_account:<id>`, or another canonical non-system subject ID. Dynamic membership writes accept either a canonical `subjectId` or an `email` alias. When `email` is used, Gestalt resolves it to the canonical user subject and creates the user record if needed before persisting the provider-backed grant.
+Mutable membership APIs still list and delete by canonical `subjectId`. User-backed rows use `user:<user_id>` and non-human rows can use `service_account:<id>` or another canonical non-system subject ID. Dynamic membership writes accept either a canonical `subjectId` or an `email` alias. When `email` is used, Gestalt resolves it to the canonical user subject and creates the user record if needed before persisting the provider-backed grant.
 
 `PUT` and `DELETE` may return `202 Accepted` with `status: "persisted_pending_reload"` when the dynamic grant was written successfully but the local in-memory authorization snapshot has not reloaded yet. In that case, retry access checks only after the local snapshot converges.
 

--- a/gestaltd/core/external_credentials.go
+++ b/gestaltd/core/external_credentials.go
@@ -3,7 +3,7 @@ package core
 import "context"
 
 // ExternalCredentialProvider manages subject-scoped third-party credentials
-// used to invoke integrations on behalf of users, workloads, or system
+// used to invoke integrations on behalf of users or other canonical subjects.
 // subjects.
 type ExternalCredentialProvider interface {
 	PutCredential(ctx context.Context, credential *ExternalCredential) error

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2259,7 +2259,7 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	p := &principal.Principal{
 		SubjectID:           "user:user-123",
 		UserID:              "user-123",
-		CredentialSubjectID: principal.WorkloadSubjectID("agent-credential"),
+		CredentialSubjectID: "service_account:agent-credential",
 		Kind:                principal.KindUser,
 		Source:              principal.SourceSession,
 		TokenPermissions:    perms,
@@ -2352,8 +2352,8 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	if len(ref.Tools) != 1 || ref.Tools[0].Target.Plugin != "roadmap" || ref.Tools[0].Target.Operation != "sync" {
 		t.Fatalf("stored searched tools = %#v", ref.Tools)
 	}
-	if ref.CredentialSubjectID != principal.WorkloadSubjectID("agent-credential") {
-		t.Fatalf("stored credential subject = %q, want %q", ref.CredentialSubjectID, principal.WorkloadSubjectID("agent-credential"))
+	if ref.CredentialSubjectID != "service_account:agent-credential" {
+		t.Fatalf("stored credential subject = %q, want %q", ref.CredentialSubjectID, "service_account:agent-credential")
 	}
 }
 
@@ -6094,7 +6094,7 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
-	t.Run("workflow managed workloads allow normalized credentialed providers", func(t *testing.T) {
+	t.Run("workflow managed subjects allow normalized credentialed providers", func(t *testing.T) {
 		t.Parallel()
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -6135,7 +6135,7 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
-	t.Run("workflow managed workload subjects stay unique across similar plugin names", func(t *testing.T) {
+	t.Run("workflow managed service account subjects stay unique across similar plugin names", func(t *testing.T) {
 		t.Parallel()
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -325,10 +325,10 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 		t.Fatalf("provider = %q, want %q", gotProvider, "roadmap")
 	}
 	if gotInstance != "" {
-		t.Fatalf("instance = %q, want empty instance for workload invocations", gotInstance)
+		t.Fatalf("instance = %q, want empty instance for non-user invocations", gotInstance)
 	}
 	if gotConnection != "" {
-		t.Fatalf("connection = %q, want empty connection for workload invocations", gotConnection)
+		t.Fatalf("connection = %q, want empty connection for non-user invocations", gotConnection)
 	}
 	if gotOperation != "sync" {
 		t.Fatalf("operation = %q, want %q", gotOperation, "sync")
@@ -494,7 +494,7 @@ func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefIgnoresWhitespaceLegacy
 		ProviderName:      "temporal",
 		Target:            target,
 		TargetFingerprint: fingerprint,
-		SubjectID:         principal.WorkloadSubjectID("scheduler"),
+		SubjectID:         "service_account:scheduler",
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}
@@ -562,7 +562,7 @@ func TestWorkflowRuntimeRejectsMixedAgentPluginTargetWithLegacyExecutionRef(t *t
 			PluginName: "roadmap",
 			Operation:  "sync",
 		},
-		SubjectID: principal.WorkloadSubjectID("scheduler"),
+		SubjectID: "service_account:scheduler",
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}
@@ -603,7 +603,7 @@ func TestWorkflowRuntimeRejectsAgentExecutionRefWithoutFingerprint(t *testing.T)
 		ID:           "agent-ref-without-fingerprint",
 		ProviderName: "temporal",
 		Target:       target,
-		SubjectID:    principal.WorkloadSubjectID("scheduler"),
+		SubjectID:    "service_account:scheduler",
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}
@@ -641,7 +641,7 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 			Instance:   "tenant-a",
 		},
 		SubjectID:           principal.UserSubjectID(user.ID),
-		CredentialSubjectID: principal.WorkloadSubjectID("workflow-credential"),
+		CredentialSubjectID: "service_account:workflow-credential",
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}
@@ -695,8 +695,8 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 	if gotPrincipal == nil || gotPrincipal.Kind != principal.KindUser || gotPrincipal.UserID != user.ID || gotPrincipal.SubjectID != principal.UserSubjectID(user.ID) {
 		t.Fatalf("principal = %#v", gotPrincipal)
 	}
-	if gotPrincipal.CredentialSubjectID != principal.WorkloadSubjectID("workflow-credential") {
-		t.Fatalf("credential subject = %q, want %q", gotPrincipal.CredentialSubjectID, principal.WorkloadSubjectID("workflow-credential"))
+	if gotPrincipal.CredentialSubjectID != "service_account:workflow-credential" {
+		t.Fatalf("credential subject = %q, want %q", gotPrincipal.CredentialSubjectID, "service_account:workflow-credential")
 	}
 	if gotProvider != "roadmap" {
 		t.Fatalf("provider = %q, want %q", gotProvider, "roadmap")
@@ -709,18 +709,18 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 	}
 }
 
-func TestWorkflowRuntimeInvokeExecutionRefUsesStoredWorkloadPrincipal(t *testing.T) {
+func TestWorkflowRuntimeInvokeExecutionRefUsesStoredSubjectPrincipal(t *testing.T) {
 	t.Parallel()
 
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "exec-ref-workload",
+		ID:           "exec-ref-service-account",
 		ProviderName: "temporal",
 		Target: coreworkflow.Target{
 			PluginName: "roadmap",
 			Operation:  "sync",
 		},
-		SubjectID: principal.WorkloadSubjectID("scheduler"),
+		SubjectID: "service_account:scheduler",
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}
@@ -739,7 +739,7 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredWorkloadPrincipal(t *testing
 
 	if _, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
 		ProviderName: "temporal",
-		ExecutionRef: "exec-ref-workload",
+		ExecutionRef: "exec-ref-service-account",
 		Target: coreworkflow.Target{
 			PluginName: "roadmap",
 			Operation:  "sync",
@@ -751,11 +751,11 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredWorkloadPrincipal(t *testing
 	if gotPrincipal == nil {
 		t.Fatal("principal = nil")
 	}
-	if gotPrincipal.Kind != principal.KindWorkload {
-		t.Fatalf("principal kind = %q, want %q", gotPrincipal.Kind, principal.KindWorkload)
+	if gotPrincipal.Kind != principal.Kind("service_account") {
+		t.Fatalf("principal kind = %q, want %q", gotPrincipal.Kind, principal.Kind("service_account"))
 	}
-	if gotPrincipal.SubjectID != principal.WorkloadSubjectID("scheduler") {
-		t.Fatalf("subjectID = %q, want %q", gotPrincipal.SubjectID, principal.WorkloadSubjectID("scheduler"))
+	if gotPrincipal.SubjectID != "service_account:scheduler" {
+		t.Fatalf("subjectID = %q, want %q", gotPrincipal.SubjectID, "service_account:scheduler")
 	}
 }
 

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -757,7 +757,7 @@ func TestAPITokenService(t *testing.T) {
 		if err := svc.APITokens.StoreAPIToken(ctx, &core.APIToken{
 			ID:          "api-subject",
 			OwnerKind:   core.APITokenOwnerKindSubject,
-			OwnerID:     principal.WorkloadSubjectID("triage-bot"),
+			OwnerID:     "service_account:triage-bot",
 			Name:        "triage-bot",
 			HashedToken: "sha256:subject",
 		}); err != nil {
@@ -768,10 +768,10 @@ func TestAPITokenService(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ValidateAPIToken: %v", err)
 		}
-		if got.OwnerKind != core.APITokenOwnerKindSubject || got.OwnerID != principal.WorkloadSubjectID("triage-bot") {
-			t.Fatalf("owner = (%q, %q), want (%q, %q)", got.OwnerKind, got.OwnerID, core.APITokenOwnerKindSubject, principal.WorkloadSubjectID("triage-bot"))
+		if got.OwnerKind != core.APITokenOwnerKindSubject || got.OwnerID != "service_account:triage-bot" {
+			t.Fatalf("owner = (%q, %q), want (%q, %q)", got.OwnerKind, got.OwnerID, core.APITokenOwnerKindSubject, "service_account:triage-bot")
 		}
-		if got.CredentialSubjectID != principal.WorkloadSubjectID("triage-bot") {
+		if got.CredentialSubjectID != "service_account:triage-bot" {
 			t.Fatalf("CredentialSubjectID = %q, want owner subject", got.CredentialSubjectID)
 		}
 	})
@@ -786,8 +786,8 @@ func TestAPITokenService(t *testing.T) {
 		}{
 			{name: "user subject", ownerID: principal.UserSubjectID("user-123")},
 			{name: "system subject", ownerID: "system:config"},
-			{name: "mismatched credential subject", ownerID: principal.WorkloadSubjectID("triage-bot"), credentialSubjectID: principal.WorkloadSubjectID("other-bot")},
-			{name: "borrowed user credential subject", ownerID: principal.WorkloadSubjectID("triage-bot"), credentialSubjectID: principal.UserSubjectID("user-123")},
+			{name: "mismatched credential subject", ownerID: "service_account:triage-bot", credentialSubjectID: "service_account:other-bot"},
+			{name: "borrowed user credential subject", ownerID: "service_account:triage-bot", credentialSubjectID: principal.UserSubjectID("user-123")},
 		} {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -137,10 +137,10 @@ func ctxWithIdentityPrincipal(email, userID string) context.Context {
 	return principal.WithPrincipal(context.Background(), p)
 }
 
-func ctxWithWorkloadPrincipal(workloadID string) context.Context {
+func ctxWithServiceAccountPrincipal(accountID string) context.Context {
 	p := &principal.Principal{
-		Kind:      principal.KindWorkload,
-		SubjectID: principal.WorkloadSubjectID(workloadID),
+		Kind:      principal.Kind("service_account"),
+		SubjectID: "service_account:" + accountID,
 		Source:    principal.SourceAPIToken,
 	}
 	return principal.WithPrincipal(context.Background(), p)
@@ -971,7 +971,7 @@ func TestNewServer_SessionCatalogConnectionModeNoneSetsCredentialContext(t *test
 	}
 }
 
-func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
+func TestNewServer_ServiceAccountListToolsFiltersStaticAndSessionTools(t *testing.T) {
 	t.Parallel()
 
 	staticCat := &catalog.Catalog{
@@ -1032,7 +1032,7 @@ func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
 		Policies: map[string]config.SubjectPolicyDef{
 			"clickhouse_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
-					SubjectID: principal.WorkloadSubjectID("triage-bot"),
+					SubjectID: "service_account:triage-bot",
 					Role:      "viewer",
 				}},
 			},
@@ -1047,8 +1047,8 @@ func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
 		},
 		TokenResolver: &stubTokenResolver{
 			resolveFn: func(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
-				if p == nil || p.Kind != principal.KindWorkload {
-					t.Fatalf("expected workload principal, got %+v", p)
+				if p == nil || p.Kind != principal.Kind("service_account") {
+					t.Fatalf("expected service account principal, got %+v", p)
 				}
 				if providerName != "clickhouse" {
 					t.Fatalf("providerName = %q, want %q", providerName, "clickhouse")
@@ -1065,7 +1065,7 @@ func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
 	})
 
 	session := newTestSessionWithTools()
-	result := listToolsForSession(t, srv, ctxWithWorkloadPrincipal("triage-bot"), session)
+	result := listToolsForSession(t, srv, ctxWithServiceAccountPrincipal("triage-bot"), session)
 
 	names := make([]string, 0, len(result.Tools))
 	descriptions := map[string]string{}
@@ -1702,7 +1702,7 @@ func TestNewServer_HumanCallToolDeniedWhenAllowedRolesAreMissing(t *testing.T) {
 	}
 }
 
-func TestNewServer_WorkloadCallToolDeniedReturnsErrorResult(t *testing.T) {
+func TestNewServer_ServiceAccountCallToolDeniedReturnsErrorResult(t *testing.T) {
 	t.Parallel()
 
 	var sessionCatalogCalls int
@@ -1744,7 +1744,7 @@ func TestNewServer_WorkloadCallToolDeniedReturnsErrorResult(t *testing.T) {
 		Policies: map[string]config.SubjectPolicyDef{
 			"clickhouse_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
-					SubjectID: principal.WorkloadSubjectID("triage-bot"),
+					SubjectID: "service_account:triage-bot",
 					Role:      "viewer",
 				}},
 			},
@@ -1758,7 +1758,7 @@ func TestNewServer_WorkloadCallToolDeniedReturnsErrorResult(t *testing.T) {
 		Authorizer: authz,
 	})
 
-	result := callToolForSession(t, srv, ctxWithWorkloadPrincipal("triage-bot"), newTestSessionWithTools(), "clickhouse_delete_table", map[string]any{"table": "users"})
+	result := callToolForSession(t, srv, ctxWithServiceAccountPrincipal("triage-bot"), newTestSessionWithTools(), "clickhouse_delete_table", map[string]any{"table": "users"})
 	if !result.IsError {
 		t.Fatalf("expected MCP error result, got %+v", result)
 	}
@@ -1774,7 +1774,7 @@ func TestNewServer_WorkloadCallToolDeniedReturnsErrorResult(t *testing.T) {
 	}
 }
 
-func TestNewServer_WorkloadCallToolDeniedForUnboundSessionOnlyProvider(t *testing.T) {
+func TestNewServer_ServiceAccountCallToolDeniedForUnboundSessionOnlyProvider(t *testing.T) {
 	t.Parallel()
 
 	var sessionCatalogCalls int
@@ -1820,7 +1820,7 @@ func TestNewServer_WorkloadCallToolDeniedForUnboundSessionOnlyProvider(t *testin
 	})
 
 	session := newTestSessionWithTools()
-	result := callToolForSession(t, srv, ctxWithWorkloadPrincipal("triage-bot"), session, "clickhouse_run_query", map[string]any{"sql": "select 1"})
+	result := callToolForSession(t, srv, ctxWithServiceAccountPrincipal("triage-bot"), session, "clickhouse_run_query", map[string]any{"sql": "select 1"})
 	if !result.IsError {
 		t.Fatalf("expected MCP error result, got %+v", result)
 	}
@@ -1839,7 +1839,7 @@ func TestNewServer_WorkloadCallToolDeniedForUnboundSessionOnlyProvider(t *testin
 	}
 }
 
-func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *testing.T) {
+func TestNewServer_ServiceAccountCallToolUsesBoundConnectionForSessionOnlyProvider(t *testing.T) {
 	t.Parallel()
 
 	var sessionCatalogCalls int
@@ -1851,8 +1851,8 @@ func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *
 		},
 		sessionCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
 			sessionCatalogCalls++
-			if token != "workload-token" {
-				t.Fatalf("session catalog token = %q, want %q", token, "workload-token")
+			if token != "service-account-token" {
+				t.Fatalf("session catalog token = %q, want %q", token, "service-account-token")
 			}
 			return &catalog.Catalog{
 				Name: "clickhouse",
@@ -1871,8 +1871,8 @@ func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *
 			if name != "run_query" {
 				t.Fatalf("name = %q, want %q", name, "run_query")
 			}
-			if token := mcpupstream.UpstreamTokenFromContext(ctx); token != "workload-token" {
-				t.Fatalf("upstream token = %q, want %q", token, "workload-token")
+			if token := mcpupstream.UpstreamTokenFromContext(ctx); token != "service-account-token" {
+				t.Fatalf("upstream token = %q, want %q", token, "service-account-token")
 			}
 			if sql, _ := args["sql"].(string); sql != "select 1" {
 				t.Fatalf("sql = %q, want %q", sql, "select 1")
@@ -1885,12 +1885,12 @@ func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *
 	ds := coretesting.NewStubServices(t)
 	ctx := context.Background()
 	if err := ds.ExternalCredentials.PutCredential(ctx, &core.ExternalCredential{
-		ID:          "tok-workload",
-		SubjectID:   principal.WorkloadSubjectID("triage-bot"),
+		ID:          "tok-service-account",
+		SubjectID:   "service_account:triage-bot",
 		Integration: "clickhouse",
 		Connection:  "workspace",
 		Instance:    "team-a",
-		AccessToken: "workload-token",
+		AccessToken: "service-account-token",
 	}); err != nil {
 		t.Fatalf("PutCredential: %v", err)
 	}
@@ -1899,7 +1899,7 @@ func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *
 		Policies: map[string]config.SubjectPolicyDef{
 			"clickhouse_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
-					SubjectID: principal.WorkloadSubjectID("triage-bot"),
+					SubjectID: "service_account:triage-bot",
 					Role:      "viewer",
 				}},
 			},
@@ -1915,7 +1915,7 @@ func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *
 		MCPConnection: map[string]string{"clickhouse": "workspace"},
 	})
 
-	result := callToolForSession(t, srv, ctxWithWorkloadPrincipal("triage-bot"), newTestSessionWithTools(), "clickhouse_run_query", map[string]any{"sql": "select 1"})
+	result := callToolForSession(t, srv, ctxWithServiceAccountPrincipal("triage-bot"), newTestSessionWithTools(), "clickhouse_run_query", map[string]any{"sql": "select 1"})
 	if result.IsError {
 		t.Fatalf("expected success result, got %+v", result)
 	}
@@ -1924,14 +1924,14 @@ func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *
 		t.Fatalf("unexpected MCP success content: %+v", result.Content)
 	}
 	if !called {
-		t.Fatal("expected workload tool call to reach provider")
+		t.Fatal("expected service account tool call to reach provider")
 	}
 	if sessionCatalogCalls != 1 {
 		t.Fatalf("session catalog calls = %d, want %d", sessionCatalogCalls, 1)
 	}
 }
 
-func TestNewServer_WorkloadCallToolUsesRequestedInstance(t *testing.T) {
+func TestNewServer_ServiceAccountCallToolUsesRequestedInstance(t *testing.T) {
 	t.Parallel()
 
 	var sessionCatalogCalls int
@@ -1988,8 +1988,8 @@ func TestNewServer_WorkloadCallToolUsesRequestedInstance(t *testing.T) {
 	ds := coretesting.NewStubServices(t)
 	ctx := context.Background()
 	if err := ds.ExternalCredentials.PutCredential(ctx, &core.ExternalCredential{
-		ID:          "tok-workload",
-		SubjectID:   principal.WorkloadSubjectID("triage-bot"),
+		ID:          "tok-service-account",
+		SubjectID:   "service_account:triage-bot",
 		Integration: "sampledb",
 		Connection:  "workspace",
 		Instance:    "team-b",
@@ -1998,12 +1998,12 @@ func TestNewServer_WorkloadCallToolUsesRequestedInstance(t *testing.T) {
 		t.Fatalf("PutCredential: %v", err)
 	}
 	if err := ds.ExternalCredentials.PutCredential(ctx, &core.ExternalCredential{
-		ID:          "tok-workload-default",
-		SubjectID:   principal.WorkloadSubjectID("triage-bot"),
+		ID:          "tok-service-account-default",
+		SubjectID:   "service_account:triage-bot",
 		Integration: "sampledb",
 		Connection:  "workspace",
 		Instance:    "team-a",
-		AccessToken: "workload-token",
+		AccessToken: "service-account-token",
 	}); err != nil {
 		t.Fatalf("PutCredential: %v", err)
 	}
@@ -2012,7 +2012,7 @@ func TestNewServer_WorkloadCallToolUsesRequestedInstance(t *testing.T) {
 		Policies: map[string]config.SubjectPolicyDef{
 			"sampledb_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
-					SubjectID: principal.WorkloadSubjectID("triage-bot"),
+					SubjectID: "service_account:triage-bot",
 					Role:      "viewer",
 				}},
 			},
@@ -2028,7 +2028,7 @@ func TestNewServer_WorkloadCallToolUsesRequestedInstance(t *testing.T) {
 		MCPConnection: map[string]string{"sampledb": "workspace"},
 	})
 
-	result := callToolForSession(t, srv, ctxWithWorkloadPrincipal("triage-bot"), newTestSessionWithTools(), "sampledb_run_query", map[string]any{
+	result := callToolForSession(t, srv, ctxWithServiceAccountPrincipal("triage-bot"), newTestSessionWithTools(), "sampledb_run_query", map[string]any{
 		"sql":       "select 1",
 		"_instance": "team-b",
 	})
@@ -2037,7 +2037,7 @@ func TestNewServer_WorkloadCallToolUsesRequestedInstance(t *testing.T) {
 		t.Fatalf("unexpected MCP success content: %+v", result.Content)
 	}
 	if !called {
-		t.Fatal("expected workload tool call to reach provider")
+		t.Fatal("expected service account tool call to reach provider")
 	}
 	if sessionCatalogCalls != 1 {
 		t.Fatalf("session catalog calls = %d, want %d", sessionCatalogCalls, 1)

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -20,8 +20,7 @@ const (
 type Kind string
 
 const (
-	KindUser     Kind = "user"
-	KindWorkload Kind = "workload"
+	KindUser Kind = "user"
 )
 
 type Principal struct {
@@ -86,13 +85,6 @@ func UserIDFromSubjectID(subjectID string) string {
 		return ""
 	}
 	return strings.TrimPrefix(subjectID, string(KindUser)+":")
-}
-
-func WorkloadSubjectID(workloadID string) string {
-	if workloadID == "" {
-		return ""
-	}
-	return string(KindWorkload) + ":" + workloadID
 }
 
 func KindFromSubjectID(subjectID string) Kind {

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -220,15 +220,15 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 			wantSessionCatalog: "token-123|user:user-123|user|Ada|true|api_token|user|roadmap|admin",
 		},
 		{
-			name: "workload subject",
+			name: "service account subject",
 			principal: &principal.Principal{
-				SubjectID:   principal.WorkloadSubjectID("triage-bot"),
+				SubjectID:   "service_account:triage-bot",
 				DisplayName: "Triage Bot",
-				Kind:        principal.KindWorkload,
+				Kind:        principal.Kind("service_account"),
 				Source:      principal.SourceAPIToken,
 			},
-			wantExecuteBody:    "echo|secret-token|hi|acme|workload:triage-bot|workload|Triage Bot|false|api_token|user|workload:triage-bot|roadmap|admin",
-			wantSessionCatalog: "token-123|workload:triage-bot|workload|Triage Bot|false|api_token|user|roadmap|admin",
+			wantExecuteBody:    "echo|secret-token|hi|acme|service_account:triage-bot|service_account|Triage Bot|false|api_token|user|service_account:triage-bot|roadmap|admin",
+			wantSessionCatalog: "token-123|service_account:triage-bot|service_account|Triage Bot|false|api_token|user|roadmap|admin",
 		},
 	}
 
@@ -314,13 +314,13 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	}
 }
 
-func TestRequestContextProto_PreservesWorkloadDisplayName(t *testing.T) {
+func TestRequestContextProto_PreservesServiceAccountDisplayName(t *testing.T) {
 	t.Parallel()
 
 	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
-		SubjectID:   principal.WorkloadSubjectID("triage-bot"),
+		SubjectID:   "service_account:triage-bot",
 		DisplayName: "Triage Bot",
-		Kind:        principal.KindWorkload,
+		Kind:        principal.Kind("service_account"),
 		Source:      principal.SourceAPIToken,
 	})
 	ctx = invocation.WithAccessContext(ctx, invocation.AccessContext{

--- a/gestaltd/internal/server/audit_metadata_test.go
+++ b/gestaltd/internal/server/audit_metadata_test.go
@@ -349,20 +349,20 @@ func TestAuditMetadata_AuthMiddlewareFailures(t *testing.T) {
 	}
 }
 
-func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
+func TestAuditMetadata_ServiceAccountSubjectAndCredentialPath(t *testing.T) {
 	t.Parallel()
 
 	var auditBuf bytes.Buffer
 	auditSink := invocation.NewSlogAuditSink(&auditBuf)
 
-	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
-			N:        "audit-workload-prov",
+			N:        "audit-subject-prov",
 			ConnMode: core.ConnectionModeUser,
 			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
 				if token != "identity-token" {
@@ -382,11 +382,11 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
+	seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
 	if err := svc.ExternalCredentials.PutCredential(t.Context(), &core.ExternalCredential{
 		ID:          "identity-audit-token",
-		SubjectID:   principal.WorkloadSubjectID("triage-bot"),
-		Integration: "audit-workload-prov",
+		SubjectID:   "service_account:triage-bot",
+		Integration: "audit-subject-prov",
 		Connection:  "workspace",
 		Instance:    "team-a",
 		AccessToken: "identity-token",
@@ -412,8 +412,8 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
 
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/audit-workload-prov/ping?_connection=workspace&_instance=team-a", bytes.NewBufferString(`{}`))
-	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/audit-subject-prov/ping?_connection=workspace&_instance=team-a", bytes.NewBufferString(`{}`))
+	req.Header.Set("Authorization", "Bearer "+subjectToken)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -431,17 +431,17 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 		t.Fatalf("failed to parse audit JSON: %v\nraw: %s", err, auditBuf.String())
 	}
 
-	if record["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected workload subject_id, got %v", record["subject_id"])
+	if record["subject_id"] != "service_account:triage-bot" {
+		t.Fatalf("expected service account subject_id, got %v", record["subject_id"])
 	}
-	if record["subject_kind"] != "workload" {
-		t.Fatalf("expected subject_kind=workload, got %v", record["subject_kind"])
+	if record["subject_kind"] != "service_account" {
+		t.Fatalf("expected subject_kind=service_account, got %v", record["subject_kind"])
 	}
 	if record["credential_mode"] != "user" {
 		t.Fatalf("expected credential_mode=user, got %v", record["credential_mode"])
 	}
-	if record["credential_subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected credential_subject_id workload principal, got %v", record["credential_subject_id"])
+	if record["credential_subject_id"] != "service_account:triage-bot" {
+		t.Fatalf("expected credential_subject_id service account principal, got %v", record["credential_subject_id"])
 	}
 	if record["credential_connection"] != "workspace" {
 		t.Fatalf("expected credential_connection=workspace, got %v", record["credential_connection"])

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -293,7 +293,7 @@ func TestResolveCatalog_ModeNonePrincipalUsesRequestedSelectors(t *testing.T) {
 		prov,
 		"bound-none-api",
 		resolver,
-		&principal.Principal{Kind: principal.KindWorkload, SubjectID: principal.WorkloadSubjectID("triage-bot")},
+		&principal.Principal{Kind: principal.Kind("service_account"), SubjectID: "service_account:triage-bot"},
 		"workspace",
 		"team-a",
 	)
@@ -684,7 +684,7 @@ func TestFilterCatalogForPrincipal_HumanUnboundProviderKeepsRoleAnnotatedOperati
 	}
 }
 
-func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing.T) {
+func TestFilterCatalogForPrincipal_SubjectFilteringUsesMergedCatalog(t *testing.T) {
 	t.Parallel()
 
 	prov := &stubSessionProvider{
@@ -714,7 +714,7 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 		Policies: map[string]config.SubjectPolicyDef{
 			"clash_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
-					SubjectID: principal.WorkloadSubjectID("triage-bot"),
+					SubjectID: "service_account:triage-bot",
 					Role:      "viewer",
 				}},
 			},
@@ -728,8 +728,8 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 	}
 
 	p := &principal.Principal{
-		Kind:      principal.KindWorkload,
-		SubjectID: principal.WorkloadSubjectID("triage-bot"),
+		Kind:      principal.Kind("service_account"),
+		SubjectID: "service_account:triage-bot",
 	}
 	cat, err := invocation.ResolveCatalog(context.Background(), prov, "clash-api", &stubTokenResolver{token: "tok_456"}, p, "default", "")
 	if err != nil {
@@ -738,7 +738,7 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 
 	filtered := invocation.FilterCatalogForPrincipal(context.Background(), cat, "clash-api", p, authz)
 	if len(filtered.Operations) != 2 {
-		t.Fatalf("expected 2 operations after workload filtering, got %d", len(filtered.Operations))
+		t.Fatalf("expected 2 operations after subject filtering, got %d", len(filtered.Operations))
 	}
 	if filtered.Operations[0].ID != "shared_op" {
 		t.Fatalf("expected first filtered op shared_op, got %q", filtered.Operations[0].ID)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -5906,7 +5906,7 @@ func TestAuthMiddleware_ValidSubjectOwnedAPIToken(t *testing.T) {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 	svc := coretesting.NewStubServices(t)
-	seedSubjectAPIToken(t, svc, hashed, principal.WorkloadSubjectID("weather-bot"), "weather-bot")
+	seedSubjectAPIToken(t, svc, hashed, "service_account:weather-bot", "weather-bot")
 
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
@@ -5954,7 +5954,7 @@ func TestAuthMiddleware_SubjectOwnedAPITokenRejectsBorrowedCredentialSubject(t *
 	if err := svc.DB.ObjectStore(coredata.StoreAPITokens).Add(context.Background(), indexeddb.Record{
 		"id":                    "api-tok-borrowed-credential",
 		"owner_kind":            core.APITokenOwnerKindSubject,
-		"owner_id":              principal.WorkloadSubjectID("triage-bot"),
+		"owner_id":              "service_account:triage-bot",
 		"credential_subject_id": principal.UserSubjectID("other-user"),
 		"name":                  "triage-bot",
 		"hashed_token":          hashed,
@@ -6251,7 +6251,7 @@ func TestAuthMiddleware_LegacyWorkloadPrefixRejectedBeforeOAuth(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
-	req.Header.Set("Authorization", "Bearer gst_wld_legacy-workload-token")
+	req.Header.Set("Authorization", "Bearer gst_wld_legacy-service-account-token")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -6612,17 +6612,17 @@ func TestListIntegrations_HumanAuthorizationFiltersByMountedUIAccessAndVisibleOp
 	}
 }
 
-func TestWorkloadAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t *testing.T) {
+func TestSubjectAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
-	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "svc", "workspace", "default", "identity-svc-token")
+	seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
+	seedSubjectToken(t, svc, "service_account:triage-bot", "svc", "workspace", "default", "identity-svc-token")
 
 	svcProvider := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "svc", DN: "Service", ConnMode: core.ConnectionModeUser},
@@ -6647,19 +6647,19 @@ func TestWorkloadAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t
 	providers := testutil.NewProviderRegistry(t, svcProvider, weatherProvider, mcpOnlyProvider, secretProvider)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.SubjectPolicyDef{
-			"workload_policy": {
+			"subject_policy": {
 				Default: "allow",
 				Members: []config.SubjectPolicyMemberDef{{
-					SubjectID: principal.WorkloadSubjectID("triage-bot"),
+					SubjectID: "service_account:triage-bot",
 					Role:      "viewer",
 				}},
 			},
 			"secret_policy": {},
 		},
 	}, map[string]*config.ProviderEntry{
-		"svc":      {AuthorizationPolicy: "workload_policy"},
-		"weather":  {AuthorizationPolicy: "workload_policy"},
-		"mcp-only": {AuthorizationPolicy: "workload_policy"},
+		"svc":      {AuthorizationPolicy: "subject_policy"},
+		"weather":  {AuthorizationPolicy: "subject_policy"},
+		"mcp-only": {AuthorizationPolicy: "subject_policy"},
 		"secret":   {AuthorizationPolicy: "secret_policy"},
 	})
 
@@ -6673,7 +6673,7 @@ func TestWorkloadAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t
 	testutil.CloseOnCleanup(t, ts)
 
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
-	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	req.Header.Set("Authorization", "Bearer "+subjectToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -6733,13 +6733,13 @@ func TestWorkloadAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t
 		t.Fatalf("mcp-only integration should not be visible over HTTP: %+v", integrations)
 	}
 	if !got["svc"].Connected {
-		t.Fatalf("expected workload integration to be connected, got %+v", got["svc"])
+		t.Fatalf("expected service account integration to be connected, got %+v", got["svc"])
 	}
 	if !got["weather"].Connected {
 		t.Fatalf("expected connection-mode none integration to be connected, got %+v", got["weather"])
 	}
 	if len(got["svc"].Instances) != 1 {
-		t.Fatalf("expected workload-owned svc instance to be listed, got %+v", got["svc"].Instances)
+		t.Fatalf("expected service-account-owned svc instance to be listed, got %+v", got["svc"].Instances)
 	}
 
 	provider := svc.ExternalCredentials.(*coretesting.StubExternalCredentialProvider)
@@ -6751,7 +6751,7 @@ func TestWorkloadAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t
 	})
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
-	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	req.Header.Set("Authorization", "Bearer "+subjectToken)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request with token store outage: %v", err)
@@ -6760,19 +6760,19 @@ func TestWorkloadAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t
 
 	if resp.StatusCode != http.StatusInternalServerError {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 500 when workload credential lookup fails, got %d: %s", resp.StatusCode, body)
+		t.Fatalf("expected 500 when service account credential lookup fails, got %d: %s", resp.StatusCode, body)
 	}
 }
 
-func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelectors(t *testing.T) {
+func TestSubjectAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelectors(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 	authSvc := coretesting.NewStubServices(t)
-	seedSubjectAPIToken(t, authSvc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
+	seedSubjectAPIToken(t, authSvc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
 
 	provider := &stubIntegrationWithCatalog{
 		StubIntegration: coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionModeUser},
@@ -6787,7 +6787,7 @@ func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelector
 			"svc_policy": {
 				Default: "allow",
 				Members: []config.SubjectPolicyMemberDef{{
-					SubjectID: principal.WorkloadSubjectID("triage-bot"),
+					SubjectID: "service_account:triage-bot",
 					Role:      "viewer",
 				}},
 			},
@@ -6805,7 +6805,7 @@ func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelector
 	testutil.CloseOnCleanup(t, ts)
 
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/svc/operations", nil)
-	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	req.Header.Set("Authorization", "Bearer "+subjectToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -6828,8 +6828,8 @@ func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelector
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
-	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "svc-session", testDefaultConnection, "team-a", "session-bound-token")
+	seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
+	seedSubjectToken(t, svc, "service_account:triage-bot", "svc-session", testDefaultConnection, "team-a", "session-bound-token")
 
 	var sessionCatalogToken string
 	sessionProvider := &stubIntegrationWithSessionCatalog{
@@ -6851,7 +6851,7 @@ func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelector
 		Policies: map[string]config.SubjectPolicyDef{
 			"svc_session_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
-					SubjectID: principal.WorkloadSubjectID("triage-bot"),
+					SubjectID: "service_account:triage-bot",
 					Role:      "viewer",
 				}},
 			},
@@ -6868,7 +6868,7 @@ func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelector
 	testutil.CloseOnCleanup(t, sessionTS)
 
 	req, _ = http.NewRequest(http.MethodGet, sessionTS.URL+"/api/v1/integrations/svc-session/operations", nil)
-	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	req.Header.Set("Authorization", "Bearer "+subjectToken)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("session catalog request: %v", err)
@@ -6877,7 +6877,7 @@ func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelector
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 200 for session-catalog workload discovery, got %d: %s", resp.StatusCode, body)
+		t.Fatalf("expected 200 for session-catalog service account discovery, got %d: %s", resp.StatusCode, body)
 	}
 
 	ops = nil
@@ -6888,7 +6888,7 @@ func TestWorkloadAuthorization_ListOperationsUsesSubjectPolicyAndSessionSelector
 		t.Fatalf("session operations = %+v, want only run", ops)
 	}
 	if sessionCatalogToken != "session-bound-token" {
-		t.Fatalf("expected session catalog to use workload credential token, got %q", sessionCatalogToken)
+		t.Fatalf("expected session catalog to use service account credential token, got %q", sessionCatalogToken)
 	}
 }
 
@@ -10273,17 +10273,17 @@ func TestExecuteOperation_NoStoredToken(t *testing.T) {
 
 }
 
-func TestWorkloadAuthorization_ExecuteOperation_UsesSubjectCredentialAndSessionSelectors(t *testing.T) {
+func TestSubjectAuthorization_ExecuteOperation_UsesSubjectCredentialAndSessionSelectors(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
-	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "svc", "workspace", "team-a", "identity-bound-token")
+	seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
+	seedSubjectToken(t, svc, "service_account:triage-bot", "svc", "workspace", "team-a", "identity-bound-token")
 
 	stub := &stubIntegrationWithCatalog{
 		StubIntegration: coretesting.StubIntegration{
@@ -10304,7 +10304,7 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesSubjectCredentialAndSessionS
 			"svc_policy": {
 				Default: "allow",
 				Members: []config.SubjectPolicyMemberDef{{
-					SubjectID: principal.WorkloadSubjectID("triage-bot"),
+					SubjectID: "service_account:triage-bot",
 					Role:      "viewer",
 				}},
 			},
@@ -10323,7 +10323,7 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesSubjectCredentialAndSessionS
 	testutil.CloseOnCleanup(t, ts)
 
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run", nil)
-	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	req.Header.Set("Authorization", "Bearer "+subjectToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -10338,11 +10338,11 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesSubjectCredentialAndSessionS
 		t.Fatalf("decoding: %v", err)
 	}
 	if result["token"] != "identity-bound-token" {
-		t.Fatalf("expected workload credential token, got %v", result["token"])
+		t.Fatalf("expected service account credential token, got %v", result["token"])
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/admin", nil)
-	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	req.Header.Set("Authorization", "Bearer "+subjectToken)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("unauthorized request: %v", err)
@@ -10354,7 +10354,7 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesSubjectCredentialAndSessionS
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run?_instance=team-a", nil)
-	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	req.Header.Set("Authorization", "Bearer "+subjectToken)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("selector request: %v", err)
@@ -10367,15 +10367,15 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesSubjectCredentialAndSessionS
 
 }
 
-func TestWorkloadAuthorization_ExecuteOperation_AllowsPolicylessPlugin(t *testing.T) {
+func TestSubjectAuthorization_ExecuteOperation_AllowsPolicylessPlugin(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 	svc := coretesting.NewStubServices(t)
-	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
+	seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
 			N:        "svc",
@@ -10396,7 +10396,7 @@ func TestWorkloadAuthorization_ExecuteOperation_AllowsPolicylessPlugin(t *testin
 	testutil.CloseOnCleanup(t, ts)
 
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run", nil)
-	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	req.Header.Set("Authorization", "Bearer "+subjectToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -10404,7 +10404,7 @@ func TestWorkloadAuthorization_ExecuteOperation_AllowsPolicylessPlugin(t *testin
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 200 for policyless workload plugin, got %d: %s", resp.StatusCode, body)
+		t.Fatalf("expected 200 for policyless service account plugin, got %d: %s", resp.StatusCode, body)
 	}
 }
 
@@ -10813,10 +10813,10 @@ func TestHumanAuthorization_ExecuteOperation_UsesResolvedRoleAndRejectsDisallowe
 	}
 }
 
-func TestWorkloadAuthorization_ExecuteOperation_MissingSubjectCredentialReturns412(t *testing.T) {
+func TestSubjectAuthorization_ExecuteOperation_MissingSubjectCredentialReturns412(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -10837,7 +10837,7 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingSubjectCredentialReturns4
 			"svc_policy": {
 				Default: "allow",
 				Members: []config.SubjectPolicyMemberDef{{
-					SubjectID: principal.WorkloadSubjectID("triage-bot"),
+					SubjectID: "service_account:triage-bot",
 					Role:      "viewer",
 				}},
 			},
@@ -10845,7 +10845,7 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingSubjectCredentialReturns4
 	}, map[string]*config.ProviderEntry{"svc": {AuthorizationPolicy: "svc_policy"}})
 
 	svc := coretesting.NewStubServices(t)
-	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
+	seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
 	broker := invocation.NewBroker(providers, svc.Users, svc.ExternalCredentials, invocation.WithAuthorizer(authz))
 	guarded := invocation.NewGuarded(broker, broker, "http", auditSink, invocation.WithoutRateLimit())
 
@@ -10861,7 +10861,7 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingSubjectCredentialReturns4
 	testutil.CloseOnCleanup(t, ts)
 
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run", nil)
-	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	req.Header.Set("Authorization", "Bearer "+subjectToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -10876,8 +10876,8 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingSubjectCredentialReturns4
 	if err := json.Unmarshal(auditBuf.Bytes(), &record); err != nil {
 		t.Fatalf("failed to parse audit JSON: %v\nraw: %s", err, auditBuf.String())
 	}
-	if record["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected workload subject_id, got %v", record["subject_id"])
+	if record["subject_id"] != "service_account:triage-bot" {
+		t.Fatalf("expected service account subject_id, got %v", record["subject_id"])
 	}
 }
 
@@ -12299,15 +12299,15 @@ func TestStartIntegrationOAuth(t *testing.T) {
 	}
 }
 
-func TestStartIntegrationOAuth_WorkloadDeniedByPolicy(t *testing.T) {
+func TestStartIntegrationOAuth_ServiceAccountDeniedByPolicy(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 	svc := coretesting.NewStubServices(t)
-	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
+	seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
 	stub := &stubIntegrationWithAuthURL{
 		StubIntegration: coretesting.StubIntegration{N: "slack"},
 		authURL:         "https://slack.com/oauth/v2/authorize",
@@ -12334,7 +12334,7 @@ func TestStartIntegrationOAuth_WorkloadDeniedByPolicy(t *testing.T) {
 
 	body := bytes.NewBufferString(`{"integration":"slack","scopes":["channels:read"]}`)
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
-	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	req.Header.Set("Authorization", "Bearer "+subjectToken)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -16048,15 +16048,15 @@ func TestConnectManual(t *testing.T) {
 		}
 	})
 
-	t.Run("workload denied by policy cannot connect", func(t *testing.T) {
+	t.Run("service account denied by policy cannot connect", func(t *testing.T) {
 		t.Parallel()
 
-		workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+		subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 		if err != nil {
 			t.Fatalf("GenerateToken: %v", err)
 		}
 		svc := coretesting.NewStubServices(t)
-		seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
+		seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
 		authz := mustAuthorizer(t, config.AuthorizationConfig{
 			Policies: map[string]config.SubjectPolicyDef{
 				"manual_policy": {
@@ -16077,7 +16077,7 @@ func TestConnectManual(t *testing.T) {
 
 		body := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key"}`)
 		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
-		req.Header.Set("Authorization", "Bearer "+workloadToken)
+		req.Header.Set("Authorization", "Bearer "+subjectToken)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -16088,30 +16088,30 @@ func TestConnectManual(t *testing.T) {
 			body, _ := io.ReadAll(resp.Body)
 			t.Fatalf("expected 403, got %d: %s", resp.StatusCode, body)
 		}
-		tokens, err := svc.ExternalCredentials.ListCredentials(context.Background(), principal.WorkloadSubjectID("triage-bot"))
+		tokens, err := svc.ExternalCredentials.ListCredentials(context.Background(), "service_account:triage-bot")
 		if err != nil {
 			t.Fatalf("ListCredentials: %v", err)
 		}
 		if len(tokens) != 0 {
-			t.Fatalf("expected denied workload connect not to store credentials, got %d", len(tokens))
+			t.Fatalf("expected denied service account connect not to store credentials, got %d", len(tokens))
 		}
 	})
 
-	t.Run("workload external identity writes subject relationship", func(t *testing.T) {
+	t.Run("service account external identity writes subject relationship", func(t *testing.T) {
 		t.Parallel()
 
-		workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+		subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 		if err != nil {
 			t.Fatalf("GenerateToken: %v", err)
 		}
 		svc := coretesting.NewStubServices(t)
-		seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
+		seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
 		authzProvider := newMemoryAuthorizationProvider("memory-authorization")
 		base, err := authorization.New(config.AuthorizationConfig{
 			Policies: map[string]config.SubjectPolicyDef{
 				"manual_policy": {
 					Members: []config.SubjectPolicyMemberDef{{
-						SubjectID: principal.WorkloadSubjectID("triage-bot"),
+						SubjectID: "service_account:triage-bot",
 						Role:      "viewer",
 					}},
 				},
@@ -16142,7 +16142,7 @@ func TestConnectManual(t *testing.T) {
 
 		body := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key","connectionParams":{"team_id":"T123","user_id":"U456"}}`)
 		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
-		req.Header.Set("Authorization", "Bearer "+workloadToken)
+		req.Header.Set("Authorization", "Bearer "+subjectToken)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -16169,8 +16169,8 @@ func TestConnectManual(t *testing.T) {
 			t.Fatalf("expected one external identity relationship, got %+v", relationships)
 		}
 		subject := relationships[0].GetSubject()
-		if subject.GetType() != authorization.ProviderSubjectTypeSubject || subject.GetId() != principal.WorkloadSubjectID("triage-bot") {
-			t.Fatalf("expected subject workload relationship, got %+v", subject)
+		if subject.GetType() != authorization.ProviderSubjectTypeSubject || subject.GetId() != "service_account:triage-bot" {
+			t.Fatalf("expected subject service account relationship, got %+v", subject)
 		}
 	})
 
@@ -18134,7 +18134,7 @@ func TestMCPEndpoint_DirectPassthrough(t *testing.T) {
 	}
 }
 
-func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
+func TestMCPEndpoint_ServiceAccountAuthorizationAndAudit(t *testing.T) {
 	t.Parallel()
 
 	staticCat := &catalog.Catalog{
@@ -18174,19 +18174,19 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	}
 
 	svc := coretesting.NewStubServices(t)
-	workloadToken, workloadTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	subjectToken, subjectTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
-	seedSubjectAPIToken(t, svc, workloadTokenHash, principal.WorkloadSubjectID("triage-bot"), "triage-bot")
-	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "clickhouse", "default", "default", "identity-token")
+	seedSubjectAPIToken(t, svc, subjectTokenHash, "service_account:triage-bot", "triage-bot")
+	seedSubjectToken(t, svc, "service_account:triage-bot", "clickhouse", "default", "default", "identity-token")
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.SubjectPolicyDef{
 			"clickhouse_policy": {
 				Members: []config.SubjectPolicyMemberDef{{
-					SubjectID: principal.WorkloadSubjectID("triage-bot"),
+					SubjectID: "service_account:triage-bot",
 					Role:      "viewer",
 				}},
 			},
@@ -18205,7 +18205,7 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	defer ts.Close()
 
 	headers := map[string]string{
-		"Authorization": "Bearer " + workloadToken,
+		"Authorization": "Bearer " + subjectToken,
 	}
 
 	_, _, initHeaders := mcpJSONRPCWithHeaders(t, ts, headers, map[string]any{
@@ -18300,11 +18300,11 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	if auditRecord["auth_source"] != "api_token" {
 		t.Fatalf("expected audit auth_source api_token, got %v", auditRecord["auth_source"])
 	}
-	if auditRecord["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected subject_id workload:triage-bot, got %v", auditRecord["subject_id"])
+	if auditRecord["subject_id"] != "service_account:triage-bot" {
+		t.Fatalf("expected subject_id service_account:triage-bot, got %v", auditRecord["subject_id"])
 	}
-	if auditRecord["subject_kind"] != "workload" {
-		t.Fatalf("expected subject_kind workload, got %v", auditRecord["subject_kind"])
+	if auditRecord["subject_kind"] != "service_account" {
+		t.Fatalf("expected subject_kind service_account, got %v", auditRecord["subject_kind"])
 	}
 }
 

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -768,7 +768,7 @@ test("integration provider service resolves hosted HTTP subjects through the plu
       context: create(RequestContextSchema, {
         subject: create(SubjectContextSchema, {
           id: "system:http_binding:agent:command",
-          kind: "workload",
+          kind: "system",
           authSource: "http_binding",
         }),
         credential: create(CredentialContextSchema, {
@@ -817,7 +817,7 @@ test("integration provider service resolves hosted HTTP subjects through the plu
   expect(seenContext).toEqual({
     subject: {
       id: "system:http_binding:agent:command",
-      kind: "workload",
+      kind: "system",
       displayName: "",
       authSource: "http_binding",
     },
@@ -1438,8 +1438,8 @@ test("workflow provider target resolves and serves runtime metadata plus workflo
       cron: "*/5 * * * *",
       timezone: "UTC",
       requestedBy: {
-        subjectId: "workload:planner",
-        subjectKind: "workload",
+        subjectId: "service_account:planner",
+        subjectKind: "service_account",
         displayName: "Planner",
         authSource: "api_token",
       },
@@ -1451,7 +1451,7 @@ test("workflow provider target resolves and serves runtime metadata plus workflo
   );
   expect(schedule.id).toBe("nightly");
   expect(schedule.target?.pluginName).toBe("roadmap");
-  expect(schedule.createdBy?.subjectId).toBe("workload:planner");
+  expect(schedule.createdBy?.subjectId).toBe("service_account:planner");
 
   const updatedSchedule = await (workflow.upsertSchedule as any)(
     create(UpsertWorkflowProviderScheduleRequestSchema, {
@@ -1470,7 +1470,7 @@ test("workflow provider target resolves and serves runtime metadata plus workflo
       },
     }),
   );
-  expect(updatedSchedule.createdBy?.subjectId).toBe("workload:planner");
+  expect(updatedSchedule.createdBy?.subjectId).toBe("service_account:planner");
 
   await (workflow.publishEvent as any)(
     create(PublishWorkflowProviderEventRequestSchema, {


### PR DESCRIPTION
## Summary

Remove the remaining active workload-specific subject primitive from gestaltd. Non-human callers now use the same generic canonical subject model as every other non-user subject.

Removed interface:
- `principal.KindWorkload`
- `principal.WorkloadSubjectID(id)`

The retired `gst_wld_` bearer prefix remains only as a rejection/audit guard so those old tokens cannot fall through into OAuth session validation.

## Canonical Subject Example

```go
p := &principal.Principal{
    Kind:      principal.Kind("service_account"),
    SubjectID: "service_account:triage-bot",
    Source:    principal.SourceAPIToken,
}
```

## Authorization Example

```go
config.SubjectPolicyMemberDef{
    SubjectID: "service_account:triage-bot",
    Role:      "viewer",
}
```

## External Credential Example

```go
&core.ExternalCredential{
    SubjectID:   "service_account:triage-bot",
    Integration: "slack",
    Connection:  "default",
    Instance:    "default",
}
```

## Validation

- `go test ./internal/principal ./internal/coredata ./internal/providerhost ./internal/mcp ./internal/server ./internal/bootstrap -count=1`
- `bun test tests/runtime.test.ts` in `sdk/typescript`
- `bun run typecheck` in `sdk/typescript`
- `git diff --check HEAD~1..HEAD`
