### PR TITLE
gestaltd: route merged static operations before sessions

### DIFF
--- a/gestaltd/internal/composite/operation_resolution.go
+++ b/gestaltd/internal/composite/operation_resolution.go
@@ -13,6 +13,14 @@ func (p *Provider) ResolveStaticOperationForRequest(_ context.Context, operation
 	return taggedCatalogOperation(p.api.Catalog(), operation, "")
 }
 
+// ResolveStaticOperationForRequest marks statically merged operations as
+// authoritative for request execution. Merged providers can combine source
+// plugin operations with providers that expose session catalogs; static
+// operations should still route directly to their owning provider.
+func (m *MergedProvider) ResolveStaticOperationForRequest(_ context.Context, operation string) (catalog.CatalogOperation, bool) {
+	return taggedCatalogOperation(m.catalog, operation, "")
+}
+
 func taggedCatalogOperation(cat *catalog.Catalog, operation, transport string) (catalog.CatalogOperation, bool) {
 	if cat == nil {
 		return catalog.CatalogOperation{}, false

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -14424,6 +14424,103 @@ func TestHostedHTTPBinding_CredentialModeNoneBypassesProviderTokenLookup(t *test
 	}
 }
 
+func TestHostedHTTPBinding_MergedStaticOperationSkipsSessionCatalogResolution(t *testing.T) {
+	t.Parallel()
+
+	hidden := false
+	invocations := make(chan string, 1)
+	sourceProvider := &stubIntegrationWithCatalog{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "github",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
+				if token != "" {
+					t.Fatalf("token = %q, want empty", token)
+				}
+				invocations <- op
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true,"ignored":"ping"}`}, nil
+			},
+		},
+		catalog: serverTestCatalog("github", []catalog.CatalogOperation{{
+			ID:        "events.handle",
+			Method:    http.MethodPost,
+			Transport: catalog.TransportPlugin,
+			Visible:   &hidden,
+		}}),
+	}
+
+	var sessionCatalogCalls atomic.Int64
+	sessionProvider := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "github",
+				ConnMode: core.ConnectionModeUser,
+			},
+		},
+		catalogForRequestFn: func(context.Context, string) (*catalog.Catalog, error) {
+			sessionCatalogCalls.Add(1)
+			return nil, fmt.Errorf("session catalog should not be resolved for static http binding operation")
+		},
+	}
+	merged, err := composite.NewMergedWithConnections("github", "GitHub", "", "",
+		composite.BoundProvider{Provider: sourceProvider},
+		composite.BoundProvider{Provider: sessionProvider},
+	)
+	if err != nil {
+		t.Fatalf("NewMergedWithConnections: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, merged)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"github": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"github_app": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:           "/event",
+						Method:         http.MethodPost,
+						CredentialMode: providermanifestv1.ConnectionModeNone,
+						Security:       "github_app",
+						Target:         "events.handle",
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.PluginDefs)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/github/event", strings.NewReader(`{"zen":"Keep it logically awesome.","hook":{}}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http binding request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
+	}
+
+	select {
+	case op := <-invocations:
+		if op != "events.handle" {
+			t.Fatalf("operation = %q, want events.handle", op)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for http binding invocation")
+	}
+	if got := sessionCatalogCalls.Load(); got != 0 {
+		t.Fatalf("session catalog calls = %d, want 0", got)
+	}
+}
+
 func TestHostedHTTPBinding_RejectsGenericOperationRouteConflicts(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Interfaces
- No public config shape changes.
- Merged providers now resolve static operations before attempting session catalog lookup.
- This applies to source-plugin operations merged with REST/GraphQL/MCP surfaces, including hidden HTTP-binding targets such as `github.events.handle`.

## Examples
```yaml
http:
  event:
    path: /event
    method: POST
    credentialMode: none
    target: events.handle
```

With this shape, `POST /api/v1/github/event` executes the source-plugin `events.handle` operation directly instead of first trying to initialize the GitHub REST/GraphQL session catalog with an empty token.

```text
POST /api/v1/github/event
X-Hub-Signature-256: sha256=...

{"zen":"...","hook":{...}}
```

Expected result: the hidden source-plugin handler returns the webhook response, for example `{"ok":true,"ignored":"ping"}` for GitHub ping deliveries.

## Tests
- `go test ./internal/composite`
- `go test ./internal/invocation`
- `go test ./internal/server -run 'TestVisibleFalseGenericRouteSkipsSessionCatalogCredentialResolution|TestExecuteOperation_CompositeStaticRESTBypassesMCPSessionResolution|TestHostedHTTPBinding_'`