### PR TITLE
agent: skip unavailable providers in global tool search

### DIFF
--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -174,11 +174,11 @@ func (m *Manager) ResolveTools(ctx context.Context, p *principal.Principal, req 
 	if err != nil {
 		return nil, err
 	}
-	candidates, err := m.searchToolCandidates(ctx, p, refs, "")
+	candidates, err := m.searchToolCandidates(ctx, p, refs, "", false)
 	if err != nil {
 		return nil, err
 	}
-	tools, err = m.resolveAgentToolCandidates(ctx, p, candidates, 0)
+	tools, err = m.resolveAgentToolCandidates(ctx, p, candidates, 0, false)
 	if err != nil {
 		return nil, err
 	}
@@ -882,7 +882,8 @@ func (m *Manager) searchTools(ctx context.Context, p *principal.Principal, req c
 	if err != nil {
 		return nil, err
 	}
-	candidates, err := m.searchToolCandidates(ctx, p, refs, req.Query)
+	skipUnavailable := len(refs) == 0
+	candidates, err := m.searchToolCandidates(ctx, p, refs, req.Query, skipUnavailable)
 	if err != nil {
 		return nil, err
 	}
@@ -893,14 +894,14 @@ func (m *Manager) searchTools(ctx context.Context, p *principal.Principal, req c
 	if maxResults > 20 {
 		maxResults = 20
 	}
-	tools, err := m.resolveAgentToolCandidates(ctx, p, candidates, maxResults)
+	tools, err := m.resolveAgentToolCandidates(ctx, p, candidates, maxResults, skipUnavailable)
 	if err != nil {
 		return nil, err
 	}
 	return &coreagent.SearchToolsResponse{Tools: tools}, nil
 }
 
-func (m *Manager) resolveAgentToolCandidates(ctx context.Context, p *principal.Principal, candidates []agentToolSearchCandidate, maxResults int) ([]coreagent.Tool, error) {
+func (m *Manager) resolveAgentToolCandidates(ctx context.Context, p *principal.Principal, candidates []agentToolSearchCandidate, maxResults int, skipUnavailable bool) ([]coreagent.Tool, error) {
 	tools := make([]coreagent.Tool, 0, len(candidates))
 	if maxResults > 0 {
 		tools = make([]coreagent.Tool, 0, min(maxResults, len(candidates)))
@@ -913,6 +914,9 @@ func (m *Manager) resolveAgentToolCandidates(ctx context.Context, p *principal.P
 		tool, err := m.resolveTool(ctx, p, candidate.ref)
 		if err != nil {
 			if errors.Is(err, invocation.ErrAuthorizationDenied) || errors.Is(err, invocation.ErrProviderNotFound) || errors.Is(err, invocation.ErrOperationNotFound) {
+				continue
+			}
+			if skipUnavailable && agentToolSearchUnavailable(err) {
 				continue
 			}
 			return nil, err
@@ -1061,7 +1065,7 @@ type agentToolSearchCandidate struct {
 	score int
 }
 
-func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef, query string) ([]agentToolSearchCandidate, error) {
+func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef, query string, skipUnavailable bool) ([]agentToolSearchCandidate, error) {
 	scope := newAgentToolSearchScope(refs)
 	providerNames := scope.providerNames()
 	if len(providerNames) == 0 {
@@ -1090,6 +1094,9 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 		for _, searchRef := range scope.refsForProvider(pluginName) {
 			cat, err := m.catalogForAgentToolSearch(ctx, p, prov, pluginName, searchRef)
 			if err != nil {
+				if skipUnavailable && agentToolSearchUnavailable(err) {
+					continue
+				}
 				return nil, err
 			}
 			if cat == nil {
@@ -1135,6 +1142,14 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 		return candidates[i].ref.Operation < candidates[j].ref.Operation
 	})
 	return candidates, nil
+}
+
+func agentToolSearchUnavailable(err error) bool {
+	return errors.Is(err, invocation.ErrNoCredential) ||
+		errors.Is(err, invocation.ErrAmbiguousInstance) ||
+		errors.Is(err, invocation.ErrReconnectRequired) ||
+		errors.Is(err, invocation.ErrNotAuthenticated) ||
+		errors.Is(err, invocation.ErrScopeDenied)
 }
 
 func (m *Manager) catalogForAgentToolSearch(ctx context.Context, p *principal.Principal, prov core.Provider, pluginName string, ref coreagent.ToolRef) (*catalog.Catalog, error) {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -814,6 +814,15 @@ type callbackAgentProvider struct {
 	resolveInteractionHook func(context.Context, coreagent.ResolveInteractionRequest) error
 }
 
+type callbackSessionCatalogIntegration struct {
+	coretesting.StubIntegration
+	sessionCatalog *catalog.Catalog
+}
+
+func (p *callbackSessionCatalogIntegration) CatalogForRequest(context.Context, string) (*catalog.Catalog, error) {
+	return p.sessionCatalog, nil
+}
+
 func newCallbackAgentProvider(started *providerhost.StartedHostServices) (*callbackAgentProvider, error) {
 	if started == nil {
 		return nil, fmt.Errorf("started host services are required")
@@ -2204,31 +2213,62 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	}
 
 	factories := validFactories()
-	factories.Builtins = append(factories.Builtins, &coretesting.StubIntegration{
-		N:        "roadmap",
-		ConnMode: core.ConnectionModeNone,
-		CatalogVal: &catalog.Catalog{
-			Name: "roadmap",
-			Operations: []catalog.CatalogOperation{{
-				ID:          "sync",
-				Method:      http.MethodPost,
-				Title:       "Sync roadmap",
-				Description: "Sync the roadmap state",
-				InputSchema: json.RawMessage(`{"type":"object","properties":{"taskId":{"type":"string"}}}`),
-			}},
+	factories.Builtins = append(
+		factories.Builtins,
+		&coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{{
+					ID:          "sync",
+					Method:      http.MethodPost,
+					Title:       "Sync roadmap",
+					Description: "Sync the roadmap state",
+					InputSchema: json.RawMessage(`{"type":"object","properties":{"taskId":{"type":"string"}}}`),
+				}},
+			},
+			ExecuteFn: func(ctx context.Context, operation string, params map[string]any, _ string) (*core.OperationResult, error) {
+				body, err := json.Marshal(map[string]any{
+					"operation": operation,
+					"subject":   principal.FromContext(ctx).SubjectID,
+					"taskId":    params["taskId"],
+				})
+				if err != nil {
+					return nil, err
+				}
+				return &core.OperationResult{Status: http.StatusAccepted, Body: string(body)}, nil
+			},
 		},
-		ExecuteFn: func(ctx context.Context, operation string, params map[string]any, _ string) (*core.OperationResult, error) {
-			body, err := json.Marshal(map[string]any{
-				"operation": operation,
-				"subject":   principal.FromContext(ctx).SubjectID,
-				"taskId":    params["taskId"],
-			})
-			if err != nil {
-				return nil, err
-			}
-			return &core.OperationResult{Status: http.StatusAccepted, Body: string(body)}, nil
+		&coretesting.StubIntegration{
+			N:        "lever",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name: "lever",
+				Operations: []catalog.CatalogOperation{{
+					ID:          "sync",
+					Method:      http.MethodPost,
+					Title:       "Roadmap sync",
+					Description: "Unavailable static integration that should not fail global agent tool search",
+				}},
+			},
 		},
-	})
+		&callbackSessionCatalogIntegration{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "ashby",
+				ConnMode: core.ConnectionModeUser,
+			},
+			sessionCatalog: &catalog.Catalog{
+				Name: "ashby",
+				Operations: []catalog.CatalogOperation{{
+					ID:          "sync",
+					Method:      http.MethodPost,
+					Title:       "Roadmap sync",
+					Description: "Unavailable session-catalog integration that should not fail global agent tool search",
+				}},
+			},
+		},
+	)
 
 	var provider *callbackAgentProvider
 	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, hostServices []providerhost.HostService, _ bootstrap.Deps) (coreagent.Provider, error) {
@@ -2252,10 +2292,20 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	defer func() { _ = result.Close(context.Background()) }()
 	<-result.ProvidersReady
 
-	perms := principal.CompilePermissions([]core.AccessPermission{{
-		Plugin:     "roadmap",
-		Operations: []string{"sync"},
-	}})
+	perms := principal.CompilePermissions([]core.AccessPermission{
+		{
+			Plugin:     "roadmap",
+			Operations: []string{"sync"},
+		},
+		{
+			Plugin:     "lever",
+			Operations: []string{"sync"},
+		},
+		{
+			Plugin:     "ashby",
+			Operations: []string{"sync"},
+		},
+	})
 	p := &principal.Principal{
 		SubjectID:           "user:user-123",
 		UserID:              "user-123",
@@ -2354,6 +2404,43 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	}
 	if ref.CredentialSubjectID != principal.WorkloadSubjectID("agent-credential") {
 		t.Fatalf("stored credential subject = %q, want %q", ref.CredentialSubjectID, principal.WorkloadSubjectID("agent-credential"))
+	}
+
+	global, err := result.AgentManager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
+		SessionID:      session.ID,
+		IdempotencyKey: "global-search-idempotency-key",
+		Model:          "gpt-test",
+		Messages:       []coreagent.Message{{Role: "user", Text: "sync it without explicit tools"}},
+	})
+	if err != nil {
+		t.Fatalf("AgentManager.CreateTurn(global search): %v", err)
+	}
+	provider.mu.Lock()
+	globalToolBodies := append([]string(nil), provider.toolBodies...)
+	provider.mu.Unlock()
+	if len(globalToolBodies) != 2 || !strings.Contains(globalToolBodies[1], `"subject":"user:user-123"`) || !strings.Contains(globalToolBodies[1], `"taskId":"task-123"`) {
+		t.Fatalf("global tool callback bodies = %#v", globalToolBodies)
+	}
+	globalRef, err := result.Services.AgentRunMetadata.Get(context.Background(), global.ID)
+	if err != nil {
+		t.Fatalf("AgentRunMetadata.Get(global): %v", err)
+	}
+	if len(globalRef.ToolRefs) != 0 || globalRef.ToolSource != coreagent.ToolSourceModeNativeSearch {
+		t.Fatalf("global stored tool source/refs = %q %#v", globalRef.ToolSource, globalRef.ToolRefs)
+	}
+	if len(globalRef.Tools) != 1 || globalRef.Tools[0].Target.Plugin != "roadmap" || globalRef.Tools[0].Target.Operation != "sync" {
+		t.Fatalf("global stored searched tools = %#v", globalRef.Tools)
+	}
+
+	_, err = result.AgentManager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
+		SessionID:      session.ID,
+		IdempotencyKey: "scoped-unavailable-idempotency-key",
+		Model:          "gpt-test",
+		Messages:       []coreagent.Message{{Role: "user", Text: "sync ashby"}},
+		ToolRefs:       []coreagent.ToolRef{{Plugin: "ashby"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), `no external credential stored for integration "ashby"`) {
+		t.Fatalf("AgentManager.CreateTurn(scoped unavailable) error = %v, want ashby credential error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Treat no-`tool_refs` agent tool search as a search over authorized and currently usable tools.
- Skip provider-specific unavailable credential/configuration errors during global search so one disconnected integration does not fail the whole agent search.
- Preserve explicit scoping behavior: scoped `tool_refs` still return the credential/configuration error.

## Interfaces / Behavior
```yaml
# Global search: searches across usable tools only; disconnected providers are omitted.
tool_refs: []
```

```yaml
# Scoped search: still fails clearly if the scoped provider is unavailable.
tool_refs:
  - plugin: ashby
```

Go behavior:
```go
SearchTools(ctx, p, SearchToolsRequest{Query: "Linear list tickets"})
SearchTools(ctx, p, SearchToolsRequest{Query: "search", ToolRefs: []ToolRef{{Plugin: "ashby"}}})
```

## Verification
- `go test ./internal/bootstrap -run TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks -count=1`
- `go test ./internal/agentmanager -count=1`

## Review Follow-up
- Applied reviewer feedback by moving coverage into the existing bootstrap agent-host callback path, so the behavior is tested through persisted run metadata, AgentHost `SearchTools`, tool merge, and `ExecuteTool`.