### PR TITLE
Preflight remote provider dev targets

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -851,6 +851,12 @@ a different server URL, including a different path prefix on the same host, is
 not sent; the command exits with the stored credential's server and file path
 plus commands to log in for the requested server or pass an explicit token. Use
 `--remote-token` or `GESTALT_API_KEY` for non-interactive automation.
+After resolving auth, the command runs a remote preflight check before creating
+the session. Preflight confirms that the remote server supports provider-dev,
+shows which remote plugin each local source matched, and includes mounted UI
+paths when the local plugin has bundled UI. If the preflight endpoint is
+missing, upgrade or redeploy the remote `gestaltd` and confirm provider-dev
+attach targets are enabled.
 
 For `--remote --path` without `--config`, Gestalt matches the local manifest
 `source` to a configured plugin on the remote server. The remote plugin's

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -82,6 +82,12 @@ matches `--remote`. Stored CLI tokens are not sent to a different remote URL,
 including a different path prefix on the same host; if the stored credential
 points elsewhere, the command fails with a remediation message instead of
 prompting.
+Before creating the dev session, the command runs a remote preflight check. The
+preflight verifies that the remote `gestaltd` exposes provider-dev endpoints,
+resolves each requested local source to the configured remote plugin name, and
+reports whether locally bundled UI will serve through a mounted remote UI path.
+If the preflight endpoint is missing, the remote server is either too old for
+remote provider dev or provider-dev attach targets are not enabled.
 With `--remote URL --path PATH` and no `--config`, the local command sends the
 manifest `source` and the local implementation only; the remote server chooses
 the configured plugin with the same manifest `source` and preserves that

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -172,6 +172,13 @@ type storedGestaltCLICredential struct {
 	APIToken string `json:"api_token"`
 }
 
+type providerRemoteAuth struct {
+	Token          string
+	Source         string
+	Server         string
+	CredentialPath string
+}
+
 func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	configPaths, cleanup, err := prepareProviderRemoteConfigPaths(opts)
 	if err != nil {
@@ -192,7 +199,7 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		return errors.New("provider dev --remote requires at least one source-backed plugin in --config or --path")
 	}
 
-	token, err := resolveProviderRemoteToken(opts)
+	auth, err := resolveProviderRemoteAuth(opts)
 	if err != nil {
 		return err
 	}
@@ -202,7 +209,7 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 
 	client := providerdev.Client{
 		BaseURL: opts.Remote,
-		Token:   token,
+		Token:   auth.Token,
 	}
 	requestedProviders := make([]providerdev.AttachProvider, 0, len(targets))
 	localUIHandlersByTarget := map[int]http.Handler{}
@@ -240,6 +247,20 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		}
 		requestedProviders = append(requestedProviders, requested)
 	}
+	preflight, err := client.ResolveAttachProviders(ctx, providerdev.ResolveAttachRequest{Providers: requestedProviders})
+	if err != nil {
+		return fmt.Errorf("provider dev remote preflight failed: %w", err)
+	}
+	if err := applyProviderRemotePreflight(targets, preflight, opts); err != nil {
+		return err
+	}
+	slog.Info("provider dev remote preflight ok",
+		append(providerRemoteAuthLogAttrs(auth),
+			"remote", strings.TrimRight(opts.Remote, "/"),
+			"providers", providerRemoteResolvedProviderSummaries(preflight.Providers),
+			"local_ui_providers", providerRemotePreflightUIProviderNames(preflight.Providers),
+		)...,
+	)
 	session, err := client.CreateSession(ctx, providerdev.CreateSessionRequest{Providers: requestedProviders})
 	if err != nil {
 		return err
@@ -297,39 +318,52 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	return client.RunDispatcher(ctx, session.ID, providerClients, providerdev.WithUIHandlers(localUIHandlers))
 }
 
-func resolveProviderRemoteToken(opts providerLocalCommandOptions) (string, error) {
+func resolveProviderRemoteAuth(opts providerLocalCommandOptions) (*providerRemoteAuth, error) {
 	remoteBaseURL, err := providerRemoteBaseURL(opts.Remote)
 	if err != nil {
-		return "", fmt.Errorf("invalid --remote %q: %w", opts.Remote, err)
+		return nil, fmt.Errorf("invalid --remote %q: %w", opts.Remote, err)
 	}
 	if token := strings.TrimSpace(opts.RemoteToken); token != "" {
-		return token, nil
+		return &providerRemoteAuth{
+			Token:  token,
+			Source: "remote-token",
+			Server: remoteBaseURL,
+		}, nil
 	}
 	if token := strings.TrimSpace(os.Getenv(gestaltAPIKeyEnv)); token != "" {
-		return token, nil
+		return &providerRemoteAuth{
+			Token:  token,
+			Source: "env",
+			Server: remoteBaseURL,
+		}, nil
 	}
 
 	credential, credentialPath, ok, err := loadStoredGestaltCLICredential()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if !ok {
-		return "", providerRemoteAuthMissingError(remoteBaseURL)
+		return nil, providerRemoteAuthMissingError(remoteBaseURL)
 	}
 	if strings.TrimSpace(credential.APIURL) == "" {
-		return "", providerRemoteStoredCredentialUnscopedError(remoteBaseURL, credentialPath)
+		return nil, providerRemoteStoredCredentialUnscopedError(remoteBaseURL, credentialPath)
 	}
 	storedBaseURL, err := providerRemoteBaseURL(credential.APIURL)
 	if err != nil {
-		return "", fmt.Errorf("stored Gestalt CLI credential has invalid api_url in %s: %w", credentialPath, err)
+		return nil, fmt.Errorf("stored Gestalt CLI credential has invalid api_url in %s: %w", credentialPath, err)
 	}
 	if storedBaseURL != remoteBaseURL {
-		return "", providerRemoteStoredCredentialMismatchError(remoteBaseURL, storedBaseURL, credentialPath)
+		return nil, providerRemoteStoredCredentialMismatchError(remoteBaseURL, storedBaseURL, credentialPath)
 	}
 	if token := strings.TrimSpace(credential.APIToken); token != "" {
-		return token, nil
+		return &providerRemoteAuth{
+			Token:          token,
+			Source:         "stored-cli",
+			Server:         storedBaseURL,
+			CredentialPath: credentialPath,
+		}, nil
 	}
-	return "", fmt.Errorf("stored Gestalt CLI credential in %s is missing api_token; run 'gestalt auth login --url %s' or pass --remote-token", credentialPath, remoteBaseURL)
+	return nil, fmt.Errorf("stored Gestalt CLI credential in %s is missing api_token; run 'gestalt auth login --url %s' or pass --remote-token", credentialPath, remoteBaseURL)
 }
 
 func loadStoredGestaltCLICredential() (storedGestaltCLICredential, string, bool, error) {
@@ -454,6 +488,69 @@ or pass an explicit token:
   gestaltd provider dev --remote %s --remote-token <token> --path ./plugin
 
 You can also set %s for this command`, remoteOrigin, storedOrigin, credentialPath, remoteOrigin, remoteOrigin, gestaltAPIKeyEnv)
+}
+
+func providerRemoteAuthLogAttrs(auth *providerRemoteAuth) []any {
+	if auth == nil {
+		return nil
+	}
+	attrs := []any{
+		"auth_source", auth.Source,
+		"auth_server", auth.Server,
+	}
+	if auth.CredentialPath != "" {
+		attrs = append(attrs, "credential_file", auth.CredentialPath)
+	}
+	return attrs
+}
+
+func applyProviderRemotePreflight(targets []providerRemoteTarget, preflight *providerdev.ResolveAttachResponse, opts providerLocalCommandOptions) error {
+	if preflight == nil {
+		return errors.New("provider dev remote preflight returned empty response")
+	}
+	if len(preflight.Providers) != len(targets) {
+		return fmt.Errorf("provider dev remote preflight resolved %d providers for %d local targets", len(preflight.Providers), len(targets))
+	}
+	if opts.Path != "" && len(opts.ConfigPaths) == 0 && opts.Name == "" && len(targets) == 1 {
+		targets[0].Name = preflight.Providers[0].Name
+	}
+	return nil
+}
+
+func providerRemoteResolvedProviderSummaries(providers []providerdev.ResolvedAttachProvider) []string {
+	if len(providers) == 0 {
+		return nil
+	}
+	summaries := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		parts := []string{provider.Name}
+		if source := strings.TrimSpace(provider.Source); source != "" {
+			parts = append(parts, "source="+source)
+		}
+		if provider.UI {
+			if uiPath := strings.TrimSpace(provider.UIPath); uiPath != "" {
+				parts = append(parts, "ui="+uiPath)
+			} else {
+				parts = append(parts, "ui=<not-mounted>")
+			}
+		}
+		summaries = append(summaries, strings.Join(parts, " "))
+	}
+	return summaries
+}
+
+func providerRemotePreflightUIProviderNames(providers []providerdev.ResolvedAttachProvider) []string {
+	names := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		if provider.UI {
+			names = append(names, provider.Name)
+		}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	slices.Sort(names)
+	return names
 }
 
 func providerRemoteTargetNames(targets []providerRemoteTarget) []string {
@@ -1608,6 +1705,7 @@ func printProviderDevUsage(w io.Writer) {
 	writeUsageLine(w, "With --remote, source-backed local plugins attach to an authenticated remote gestaltd session")
 	writeUsageLine(w, "while the remote config keeps its normal auth, authorization, connections, host services,")
 	writeUsageLine(w, "and mounted plugin UI routes.")
+	writeUsageLine(w, "Remote mode preflights provider matches and mounted UI paths before creating a session.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --path     Provider manifest path or directory (default: current working directory)")

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -102,48 +102,48 @@ func TestProviderRemoteConfigPathSynthesizesSourcePlugin(t *testing.T) {
 	}
 }
 
-func TestResolveProviderRemoteTokenPrecedence(t *testing.T) {
+func TestResolveProviderRemoteAuthPrecedence(t *testing.T) {
 	configHome := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", configHome)
 	writeStoredGestaltCLICredentialForTest(t, configHome, "https://stored.example.com", "stored-token")
 
 	t.Setenv(gestaltAPIKeyEnv, "env-token")
-	token, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+	auth, err := resolveProviderRemoteAuth(providerLocalCommandOptions{
 		Remote:      "https://remote.example.com",
 		RemoteToken: "flag-token",
 	})
 	if err != nil {
-		t.Fatalf("resolveProviderRemoteToken with explicit token: %v", err)
+		t.Fatalf("resolveProviderRemoteAuth with explicit token: %v", err)
 	}
-	if token != "flag-token" {
-		t.Fatalf("token = %q, want explicit flag token", token)
+	if auth.Token != "flag-token" || auth.Source != "remote-token" || auth.Server != "https://remote.example.com" {
+		t.Fatalf("auth = %+v, want explicit flag token auth", auth)
 	}
 
-	token, err = resolveProviderRemoteToken(providerLocalCommandOptions{
+	auth, err = resolveProviderRemoteAuth(providerLocalCommandOptions{
 		Remote: "https://remote.example.com",
 	})
 	if err != nil {
-		t.Fatalf("resolveProviderRemoteToken with env token: %v", err)
+		t.Fatalf("resolveProviderRemoteAuth with env token: %v", err)
 	}
-	if token != "env-token" {
-		t.Fatalf("token = %q, want env token", token)
+	if auth.Token != "env-token" || auth.Source != "env" || auth.Server != "https://remote.example.com" {
+		t.Fatalf("auth = %+v, want env token auth", auth)
 	}
 }
 
-func TestResolveProviderRemoteTokenUsesMatchingStoredCLICredential(t *testing.T) {
+func TestResolveProviderRemoteAuthUsesMatchingStoredCLICredential(t *testing.T) {
 	configHome := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", configHome)
 	t.Setenv(gestaltAPIKeyEnv, "")
 	writeStoredGestaltCLICredentialForTest(t, configHome, "https://Valon.Tools:443/team-a/", "stored-token")
 
-	token, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+	auth, err := resolveProviderRemoteAuth(providerLocalCommandOptions{
 		Remote: "https://valon.tools/team-a",
 	})
 	if err != nil {
-		t.Fatalf("resolveProviderRemoteToken: %v", err)
+		t.Fatalf("resolveProviderRemoteAuth: %v", err)
 	}
-	if token != "stored-token" {
-		t.Fatalf("token = %q, want stored token", token)
+	if auth.Token != "stored-token" || auth.Source != "stored-cli" || auth.Server != "https://valon.tools/team-a" || auth.CredentialPath == "" {
+		t.Fatalf("auth = %+v, want stored token auth", auth)
 	}
 }
 
@@ -153,7 +153,7 @@ func TestResolveProviderRemoteTokenRejectsDifferentBasePaths(t *testing.T) {
 	t.Setenv(gestaltAPIKeyEnv, "")
 	writeStoredGestaltCLICredentialForTest(t, configHome, "https://valon.tools/team-a", "stored-token")
 
-	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+	_, err := resolveProviderRemoteAuth(providerLocalCommandOptions{
 		Remote: "https://valon.tools/team-b",
 	})
 	if err == nil {
@@ -177,7 +177,7 @@ func TestResolveProviderRemoteTokenRejectsMismatchedStoredCLICredential(t *testi
 	t.Setenv(gestaltAPIKeyEnv, "")
 	writeStoredGestaltCLICredentialForTest(t, configHome, "https://valon.tools", "stored-token")
 
-	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+	_, err := resolveProviderRemoteAuth(providerLocalCommandOptions{
 		Remote: "https://staging.valon.tools",
 	})
 	if err == nil {
@@ -206,7 +206,7 @@ func TestResolveProviderRemoteTokenRejectsUnscopedStoredCLICredential(t *testing
 	t.Setenv(gestaltAPIKeyEnv, "")
 	writeStoredGestaltCLICredentialForTest(t, configHome, "", "legacy-token")
 
-	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+	_, err := resolveProviderRemoteAuth(providerLocalCommandOptions{
 		Remote: "https://valon.tools",
 	})
 	if err == nil {
@@ -229,7 +229,7 @@ func TestResolveProviderRemoteTokenRequiresAuthWhenNoCredentialExists(t *testing
 	t.Setenv("XDG_CONFIG_HOME", configHome)
 	t.Setenv(gestaltAPIKeyEnv, "")
 
-	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+	_, err := resolveProviderRemoteAuth(providerLocalCommandOptions{
 		Remote: "https://valon.tools",
 	})
 	if err == nil {

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -23,7 +23,7 @@ func buildProviderDevManager(cfg *config.Config, providers *registry.ProviderMap
 
 	targets := make([]providerdev.Target, 0, len(cfg.Plugins))
 	for name, entry := range cfg.Plugins {
-		result := deriveProviderDevTarget(name, entry, providers, deps)
+		result := deriveProviderDevTarget(cfg, name, entry, providers, deps)
 		switch result.state {
 		case providerDevTargetAttachable:
 			targets = append(targets, result.target)
@@ -58,7 +58,7 @@ type providerDevTargetResult struct {
 	err    error
 }
 
-func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers *registry.ProviderMap[core.Provider], deps Deps) providerDevTargetResult {
+func deriveProviderDevTarget(cfg *config.Config, name string, entry *config.ProviderEntry, providers *registry.ProviderMap[core.Provider], deps Deps) providerDevTargetResult {
 	if entry == nil {
 		return providerDevTargetResult{state: providerDevTargetUnsupported, reason: "missing config entry"}
 	}
@@ -99,6 +99,7 @@ func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers
 		target: providerdev.Target{
 			Name:   targetName,
 			Source: strings.TrimSpace(entry.ResolvedManifest.Source),
+			UIPath: providerDevTargetUIPath(name, entry, cfg),
 			Spec:   providerDevStaticSpecFromProvider(targetName, entry, provider),
 			Config: pluginConfig,
 			RuntimeEnv: func(sessionID string) (providerdev.RuntimeEnv, error) {
@@ -106,6 +107,24 @@ func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers
 			},
 		},
 	}
+}
+
+func providerDevTargetUIPath(name string, entry *config.ProviderEntry, cfg *config.Config) string {
+	if entry == nil {
+		return ""
+	}
+	uiName := strings.TrimSpace(entry.UI)
+	if uiName == "" {
+		uiName = name
+	}
+	if cfg == nil || cfg.Providers.UI == nil || cfg.Providers.UI[uiName] == nil {
+		return ""
+	}
+	uiEntry := cfg.Providers.UI[uiName]
+	if strings.TrimSpace(uiEntry.OwnerPlugin) != name {
+		return ""
+	}
+	return strings.TrimSpace(uiEntry.Path)
 }
 
 func providerDevStaticSpecFromProvider(name string, entry *config.ProviderEntry, provider core.Provider) providerhost.StaticProviderSpec {

--- a/gestaltd/internal/bootstrap/provider_dev_test.go
+++ b/gestaltd/internal/bootstrap/provider_dev_test.go
@@ -1,0 +1,69 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func TestProviderDevTargetUIPathRequiresPluginOwnedMountedUI(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Providers: config.ProvidersConfig{
+			UI: map[string]*config.UIEntry{
+				"roadmap": {
+					Path: "/standalone",
+				},
+				"owned": {
+					Path:        "/owned",
+					OwnerPlugin: "roadmap",
+				},
+				"other": {
+					Path:        "/other",
+					OwnerPlugin: "other-plugin",
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		name  string
+		entry *config.ProviderEntry
+		want  string
+	}{
+		{
+			name: "standalone ui with same key is not provider-dev interceptable",
+			entry: &config.ProviderEntry{
+				MountPath: "/standalone",
+			},
+			want: "",
+		},
+		{
+			name: "plugin-owned ui with default key",
+			entry: &config.ProviderEntry{
+				MountPath: "/owned",
+				UI:        "owned",
+			},
+			want: "/owned",
+		},
+		{
+			name: "ui owned by another plugin is not provider-dev interceptable",
+			entry: &config.ProviderEntry{
+				MountPath: "/other",
+				UI:        "other",
+			},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := providerDevTargetUIPath("roadmap", tc.entry, cfg); got != tc.want {
+				t.Fatalf("providerDevTargetUIPath = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -35,6 +35,7 @@ const (
 	DefaultSessionIdleTimeout = 2 * time.Minute
 	DefaultCallIdleTimeout    = 30 * time.Minute
 
+	PathResolve  = "/api/v1/provider-dev/resolve"
 	PathSessions = "/api/v1/provider-dev/sessions"
 )
 
@@ -49,6 +50,7 @@ type RuntimeEnvBuilder func(sessionID string) (RuntimeEnv, error)
 type Target struct {
 	Name       string
 	Source     string
+	UIPath     string
 	Spec       providerhost.StaticProviderSpec
 	Config     map[string]any
 	UI         *AttachUI
@@ -66,6 +68,8 @@ type CreateSessionRequest struct {
 	Providers []AttachProvider `json:"providers"`
 }
 
+type ResolveAttachRequest = CreateSessionRequest
+
 type AttachProvider struct {
 	Name   string                          `json:"name"`
 	Source string                          `json:"source,omitempty"`
@@ -77,6 +81,17 @@ type AttachProvider struct {
 type CreateSessionResponse struct {
 	ID        string                  `json:"id"`
 	Providers []CreateSessionProvider `json:"providers"`
+}
+
+type ResolveAttachResponse struct {
+	Providers []ResolvedAttachProvider `json:"providers"`
+}
+
+type ResolvedAttachProvider struct {
+	Name   string `json:"name"`
+	Source string `json:"source,omitempty"`
+	UIPath string `json:"uiPath,omitempty"`
+	UI     bool   `json:"ui,omitempty"`
 }
 
 type CreateSessionProvider struct {
@@ -301,6 +316,19 @@ func (m *Manager) PollSession(ctx context.Context, p *principal.Principal, sessi
 }
 
 func (m *Manager) ResolveAttachProviderNames(req CreateSessionRequest) ([]string, error) {
+	resp, err := m.ResolveAttachProviders(req)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(resp.Providers))
+	for _, provider := range resp.Providers {
+		names = append(names, provider.Name)
+	}
+	slices.Sort(names)
+	return slices.Compact(names), nil
+}
+
+func (m *Manager) ResolveAttachProviders(req ResolveAttachRequest) (*ResolveAttachResponse, error) {
 	if m == nil {
 		return nil, status.Error(codes.FailedPrecondition, "provider dev is not configured")
 	}
@@ -308,17 +336,28 @@ func (m *Manager) ResolveAttachProviderNames(req CreateSessionRequest) ([]string
 	if err != nil {
 		return nil, err
 	}
+	if len(requestedProviders) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "at least one provider is required")
+	}
 	targets, err := m.resolveAttachTargets(requestedProviders)
 	if err != nil {
 		return nil, err
 	}
-	names := make([]string, 0, len(targets))
-	for i := range targets {
-		names = append(names, targets[i].Name)
+	resp := &ResolveAttachResponse{
+		Providers: make([]ResolvedAttachProvider, 0, len(targets)),
 	}
-	slices.Sort(names)
-	names = slices.Compact(names)
-	return names, nil
+	for i := range targets {
+		resp.Providers = append(resp.Providers, ResolvedAttachProvider{
+			Name:   targets[i].Name,
+			Source: strings.TrimSpace(targets[i].Source),
+			UIPath: strings.TrimSpace(targets[i].UIPath),
+			UI:     targets[i].UI != nil,
+		})
+	}
+	slices.SortFunc(resp.Providers, func(a, b ResolvedAttachProvider) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return resp, nil
 }
 
 func (m *Manager) resolveAttachTargets(requestedProviders []AttachProvider) ([]Target, error) {
@@ -961,6 +1000,18 @@ func (c Client) CreateSession(ctx context.Context, req CreateSessionRequest) (*C
 	return &out, nil
 }
 
+func (c Client) ResolveAttachProviders(ctx context.Context, req ResolveAttachRequest) (*ResolveAttachResponse, error) {
+	var out ResolveAttachResponse
+	statusCode, err := c.doJSONStatus(ctx, http.MethodPost, PathResolve, req, &out)
+	if err != nil {
+		if statusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("provider dev preflight endpoint was not found at %s; the remote gestaltd may be too old or provider-dev may not be enabled: %w", c.endpointForLog(PathResolve), err)
+		}
+		return nil, err
+	}
+	return &out, nil
+}
+
 func (c Client) Poll(ctx context.Context, sessionID string) (*PollResponse, bool, error) {
 	path := PathSessions + "/" + url.PathEscape(sessionID) + "/poll"
 	var out PollResponse
@@ -1232,6 +1283,14 @@ func (c Client) endpoint(path string) (string, error) {
 	base.RawQuery = ""
 	base.Fragment = ""
 	return base.String(), nil
+}
+
+func (c Client) endpointForLog(path string) string {
+	endpoint, err := c.endpoint(path)
+	if err != nil {
+		return strings.TrimRight(strings.TrimSpace(c.BaseURL), "/") + path
+	}
+	return endpoint
 }
 
 func encodeRPCError(err error) *RPCError {

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -289,6 +289,7 @@ func TestCreateSessionMatchesProviderBySource(t *testing.T) {
 	manager, err := NewManager([]Target{{
 		Name:   "workplaceHub",
 		Source: "github.com/valon-technologies/valon-tools/plugins/workplace-hub",
+		UIPath: "/workplace",
 		Spec: providerhost.StaticProviderSpec{
 			Name: "workplaceHub",
 		},
@@ -323,6 +324,21 @@ func TestCreateSessionMatchesProviderBySource(t *testing.T) {
 	}
 	if len(names) != 1 || names[0] != "workplaceHub" {
 		t.Fatalf("ResolveAttachProviderNames = %#v, want [workplaceHub]", names)
+	}
+
+	resolved, err := manager.ResolveAttachProviders(ResolveAttachRequest{Providers: []AttachProvider{{
+		Source: "github.com/valon-technologies/valon-tools/plugins/workplace-hub",
+		UI:     &AttachUI{},
+	}}})
+	if err != nil {
+		t.Fatalf("ResolveAttachProviders: %v", err)
+	}
+	if len(resolved.Providers) != 1 {
+		t.Fatalf("ResolveAttachProviders = %#v, want one provider", resolved.Providers)
+	}
+	got := resolved.Providers[0]
+	if got.Name != "workplaceHub" || got.Source != "github.com/valon-technologies/valon-tools/plugins/workplace-hub" || got.UIPath != "/workplace" || !got.UI {
+		t.Fatalf("resolved provider = %+v, want workplaceHub with source and ui path", got)
 	}
 }
 
@@ -366,6 +382,61 @@ func TestHTTPTransportCreateSessionExplicitConfigOverridesRemoteConfig(t *testin
 	}
 	if got := target.target.Config["local"]; got != true {
 		t.Fatalf("attached config local = %#v, want true", got)
+	}
+}
+
+func TestHTTPTransportResolveAttachProviders(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewManager([]Target{{
+		Name:   "roadmap",
+		Source: "github.com/acme/plugins/roadmap",
+		UIPath: "/roadmap",
+	}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	ts := httptest.NewServer(providerDevTestHandler(t, manager, p))
+	t.Cleanup(ts.Close)
+
+	client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	resp, err := client.ResolveAttachProviders(context.Background(), ResolveAttachRequest{Providers: []AttachProvider{{
+		Source: "github.com/acme/plugins/roadmap",
+		UI:     &AttachUI{},
+	}}})
+	if err != nil {
+		t.Fatalf("ResolveAttachProviders: %v", err)
+	}
+	if len(resp.Providers) != 1 {
+		t.Fatalf("resolved providers = %#v, want one", resp.Providers)
+	}
+	if got := resp.Providers[0]; got.Name != "roadmap" || got.Source != "github.com/acme/plugins/roadmap" || got.UIPath != "/roadmap" || !got.UI {
+		t.Fatalf("resolved provider = %+v, want roadmap source/ui metadata", got)
+	}
+}
+
+func TestHTTPTransportResolveAttachProvidersReportsMissingPreflightEndpoint(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(ts.Close)
+
+	client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	_, err := client.ResolveAttachProviders(context.Background(), ResolveAttachRequest{Providers: []AttachProvider{{Name: "roadmap"}}})
+	if err == nil {
+		t.Fatal("expected missing preflight endpoint error")
+	}
+	errText := err.Error()
+	for _, want := range []string{
+		"provider dev preflight endpoint was not found",
+		PathResolve,
+		"remote gestaltd may be too old",
+	} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error missing %q:\n%s", want, errText)
+		}
 	}
 }
 
@@ -499,6 +570,23 @@ func TestSessionCloseReturnsSameErrorToConcurrentCallers(t *testing.T) {
 func providerDevTestHandler(t *testing.T, manager *Manager, p *principal.Principal) http.Handler {
 	t.Helper()
 	mux := http.NewServeMux()
+	mux.HandleFunc(PathResolve, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var req ResolveAttachRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp, err := manager.ResolveAttachProviders(req)
+		if err != nil {
+			writeProviderDevTestError(w, err)
+			return
+		}
+		writeProviderDevTestJSON(w, http.StatusOK, resp)
+	})
 	mux.HandleFunc(PathSessions, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.NotFound(w, r)

--- a/gestaltd/internal/server/handlers_provider_dev.go
+++ b/gestaltd/internal/server/handlers_provider_dev.go
@@ -36,6 +36,28 @@ func (s *Server) createProviderDevSession(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusCreated, resp)
 }
 
+func (s *Server) resolveProviderDevSession(w http.ResponseWriter, r *http.Request) {
+	if s.providerDevSessions == nil {
+		writeError(w, http.StatusNotFound, "provider dev is not configured")
+		return
+	}
+	var req providerdev.ResolveAttachRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid provider dev resolve request")
+		return
+	}
+	p := PrincipalFromContext(r.Context())
+	if err := s.authorizeProviderDevSessionRequest(w, r, p, req); err != nil {
+		return
+	}
+	resp, err := s.providerDevSessions.ResolveAttachProviders(req)
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 func (s *Server) authorizeProviderDevSessionRequest(w http.ResponseWriter, r *http.Request, p *principal.Principal, req providerdev.CreateSessionRequest) error {
 	if err := requireUserCaller(w, p); err != nil {
 		return err

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -60,6 +60,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Post("/auth/start-oauth", s.startIntegrationOAuth)
 		r.Post("/auth/connect-manual", s.connectManual)
 
+		r.Post("/provider-dev/resolve", s.resolveProviderDevSession)
 		r.Post("/provider-dev/sessions", s.createProviderDevSession)
 		r.Get("/provider-dev/sessions/{sessionID}/poll", s.pollProviderDevSession)
 		r.Post("/provider-dev/sessions/{sessionID}/calls/{callID}", s.completeProviderDevCall)


### PR DESCRIPTION
## Summary

Adds a remote provider-dev preflight step so `gestaltd provider dev --remote` explains target matching and remote support before creating a session.

## New Interfaces

- `POST /api/v1/provider-dev/resolve` resolves provider-dev attach targets without creating a session.
- `gestaltd provider dev --remote URL ...` calls that preflight before `POST /api/v1/provider-dev/sessions`.
- Preflight responses include resolved remote provider names, manifest sources, whether local UI is attached, and the remote mounted UI path when available.
- Missing preflight endpoint errors now explicitly say the remote `gestaltd` may be too old or provider-dev may not be enabled.

## Examples

```sh
gestaltd provider dev --remote https://valon.tools --path ./plugin
```

```sh
gestaltd provider dev --remote https://valon.tools --path ./plugin --name workplaceHub
```

```sh
curl -X POST https://valon.tools/api/v1/provider-dev/resolve \
  -H 'Authorization: Bearer <token>' \
  -H 'Content-Type: application/json' \
  -d '{"providers":[{"source":"github.com/acme/plugins/roadmap","ui":{}}]}'
```

Example response:

```json
{
  "providers": [
    {
      "name": "roadmap",
      "source": "github.com/acme/plugins/roadmap",
      "uiPath": "/roadmap",
      "ui": true
    }
  ]
}
```

Docs updated:

- `docs/content/reference/cli.mdx`
- `docs/content/custom-providers/plugins.mdx`

## Verification

```sh
go test ./internal/providerdev -run 'TestCreateSessionMatchesProviderBySource|TestHTTPTransportResolveAttachProviders|TestHTTPTransportResolveAttachProvidersReportsMissingPreflightEndpoint|TestHTTPTransportDispatchesProviderRPCs|TestHTTPTransportCreateSessionExplicitConfigOverridesRemoteConfig'
go test ./cmd/gestaltd -run 'TestResolveProviderRemoteAuth|TestProviderRemoteBaseURL|TestProviderRemoteConfigPathSynthesizesSourcePlugin|TestRun_ProviderCLIUsageAndErrors'
go test ./internal/server -run 'TestProviderDev|TestProviderDevUI'
go test ./internal/bootstrap -run 'Test.*ProviderDev|TestBootstrap'
golangci-lint run ./cmd/gestaltd ./internal/providerdev ./internal/server ./internal/bootstrap
go build -o /tmp/gestaltd-provider-dev-diagnostics ./cmd/gestaltd
cd docs && npm run typecheck && npm run build
```