### PR TITLE
Add operation-level connection routing

### DIFF
--- a/gestaltd/core/catalog/catalog.go
+++ b/gestaltd/core/catalog/catalog.go
@@ -126,6 +126,7 @@ type CatalogParameter struct {
 	Location    string `yaml:"location,omitempty"    json:"location,omitempty"`
 	Description string `yaml:"description,omitempty"  json:"description,omitempty"`
 	Required    bool   `yaml:"required,omitempty"    json:"required,omitempty"`
+	Internal    bool   `yaml:"internal,omitempty"    json:"internal,omitempty"`
 	Default     any    `yaml:"default,omitempty"     json:"default,omitempty"`
 }
 

--- a/gestaltd/core/integration/egress_adapter.go
+++ b/gestaltd/core/integration/egress_adapter.go
@@ -134,9 +134,13 @@ func partitionParams(catOp *catalog.CatalogOperation, params map[string]any, use
 
 	declared := make(map[string]struct{}, len(catOp.Parameters))
 	locations := make(map[string]string, len(catOp.Parameters))
+	internal := make(map[string]struct{})
 	var wireNames map[string]string
 	for _, p := range catOp.Parameters {
 		declared[p.Name] = struct{}{}
+		if p.Internal {
+			internal[p.Name] = struct{}{}
+		}
 		if p.Location != "" {
 			locations[p.Name] = p.Location
 		}
@@ -151,6 +155,9 @@ func partitionParams(catOp *catalog.CatalogOperation, params map[string]any, use
 	query = make(map[string]any)
 	headers = make(map[string]string)
 	for k, v := range params {
+		if _, ok := internal[k]; ok {
+			continue
+		}
 		httpKey := k
 		if wn, ok := wireNames[k]; ok {
 			httpKey = wn

--- a/gestaltd/core/integration/restricted.go
+++ b/gestaltd/core/integration/restricted.go
@@ -252,3 +252,31 @@ func (r *Restricted) ConnectionForOperation(operation string) string {
 	}
 	return r.inner.ConnectionForOperation(innerOperation)
 }
+
+func (r *Restricted) ResolveConnectionForOperation(operation string, params map[string]any) (string, error) {
+	if _, ok := r.allowed[operation]; !ok {
+		return "", nil
+	}
+	innerOperation := operation
+	if alias, ok := r.aliases[operation]; ok {
+		innerOperation = alias
+	}
+	if resolver, ok := r.inner.(core.OperationConnectionResolver); ok {
+		return resolver.ResolveConnectionForOperation(innerOperation, params)
+	}
+	return r.inner.ConnectionForOperation(innerOperation), nil
+}
+
+func (r *Restricted) OperationConnectionOverrideAllowed(operation string, params map[string]any) bool {
+	if _, ok := r.allowed[operation]; !ok {
+		return true
+	}
+	innerOperation := operation
+	if alias, ok := r.aliases[operation]; ok {
+		innerOperation = alias
+	}
+	if policy, ok := r.inner.(core.OperationConnectionOverridePolicy); ok {
+		return policy.OperationConnectionOverrideAllowed(innerOperation, params)
+	}
+	return false
+}

--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -38,6 +38,26 @@ type Provider interface {
 	Execute(ctx context.Context, operation string, params map[string]any, token string) (*OperationResult, error)
 }
 
+// OperationConnectionSelector maps a caller-supplied parameter value to the
+// named connection Gestalt should use for an operation invocation.
+type OperationConnectionSelector struct {
+	Parameter string
+	Default   string
+	Values    map[string]string
+}
+
+// OperationConnectionResolver is implemented by providers that choose an
+// operation connection from invocation parameters before credential lookup.
+type OperationConnectionResolver interface {
+	ResolveConnectionForOperation(operation string, params map[string]any) (string, error)
+}
+
+// OperationConnectionOverridePolicy is implemented by providers that can tell
+// whether a caller-supplied connection may override the operation connection.
+type OperationConnectionOverridePolicy interface {
+	OperationConnectionOverrideAllowed(operation string, params map[string]any) bool
+}
+
 // GraphQLSurfaceInvoker is an optional interface for providers that expose a
 // raw GraphQL surface in addition to cataloged operations.
 type GraphQLSurfaceInvoker interface {

--- a/gestaltd/internal/bootstrap/connected_provider.go
+++ b/gestaltd/internal/bootstrap/connected_provider.go
@@ -58,9 +58,32 @@ func (p *connectedProvider) CredentialFields() []core.CredentialFieldDef {
 func (p *connectedProvider) DiscoveryConfig() *core.DiscoveryConfig {
 	return p.inner.DiscoveryConfig()
 }
-func (p *connectedProvider) ConnectionForOperation(string) string { return p.connection }
-func (p *connectedProvider) Catalog() *catalog.Catalog            { return p.inner.Catalog() }
-func (p *connectedProvider) SupportsPostConnect() bool            { return core.SupportsPostConnect(p.inner) }
+func (p *connectedProvider) ConnectionForOperation(operation string) string {
+	if connection := p.inner.ConnectionForOperation(operation); connection != "" {
+		return connection
+	}
+	return p.connection
+}
+func (p *connectedProvider) ResolveConnectionForOperation(operation string, params map[string]any) (string, error) {
+	if resolver, ok := p.inner.(core.OperationConnectionResolver); ok {
+		connection, err := resolver.ResolveConnectionForOperation(operation, params)
+		if err != nil || connection != "" {
+			return connection, err
+		}
+	}
+	if connection := p.inner.ConnectionForOperation(operation); connection != "" {
+		return connection, nil
+	}
+	return p.connection, nil
+}
+func (p *connectedProvider) OperationConnectionOverrideAllowed(operation string, params map[string]any) bool {
+	if policy, ok := p.inner.(core.OperationConnectionOverridePolicy); ok {
+		return policy.OperationConnectionOverrideAllowed(operation, params)
+	}
+	return false
+}
+func (p *connectedProvider) Catalog() *catalog.Catalog { return p.inner.Catalog() }
+func (p *connectedProvider) SupportsPostConnect() bool { return core.SupportsPostConnect(p.inner) }
 func (p *connectedProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
 	return p.inner.Execute(ctx, operation, params, token)
 }
@@ -109,6 +132,14 @@ func (p *connectedSessionCatalogProvider) ResolveHTTPSubject(ctx context.Context
 	return subject, err
 }
 
+func (p *connectedSessionCatalogProvider) ResolveConnectionForOperation(operation string, params map[string]any) (string, error) {
+	return resolveProviderConnectionForOperation(p.Provider, operation, params)
+}
+
+func (p *connectedSessionCatalogProvider) OperationConnectionOverrideAllowed(operation string, params map[string]any) bool {
+	return providerOperationConnectionOverrideAllowed(p.Provider, operation, params)
+}
+
 func (p *connectedSessionCatalogProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
 	return p.session.CatalogForRequest(ctx, token)
 }
@@ -144,6 +175,14 @@ func (p *connectedGraphQLProvider) SupportsHTTPSubject() bool {
 func (p *connectedGraphQLProvider) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
 	subject, _, err := core.ResolveHTTPSubject(ctx, p.Provider, req)
 	return subject, err
+}
+
+func (p *connectedGraphQLProvider) ResolveConnectionForOperation(operation string, params map[string]any) (string, error) {
+	return resolveProviderConnectionForOperation(p.Provider, operation, params)
+}
+
+func (p *connectedGraphQLProvider) OperationConnectionOverrideAllowed(operation string, params map[string]any) bool {
+	return providerOperationConnectionOverrideAllowed(p.Provider, operation, params)
 }
 
 func (p *connectedGraphQLProvider) InvokeGraphQL(ctx context.Context, request core.GraphQLRequest, token string) (*core.OperationResult, error) {
@@ -191,6 +230,14 @@ func (p *connectedOAuthProvider) ResolveHTTPSubject(ctx context.Context, req *co
 	return subject, err
 }
 
+func (p *connectedOAuthProvider) ResolveConnectionForOperation(operation string, params map[string]any) (string, error) {
+	return resolveProviderConnectionForOperation(p.Provider, operation, params)
+}
+
+func (p *connectedOAuthProvider) OperationConnectionOverrideAllowed(operation string, params map[string]any) bool {
+	return providerOperationConnectionOverrideAllowed(p.Provider, operation, params)
+}
+
 func (p *connectedOAuthProvider) AuthorizationURL(state string, scopes []string) string {
 	return p.auth.AuthorizationURL(state, scopes)
 }
@@ -224,4 +271,18 @@ func (p *connectedOAuthProvider) Close() error {
 		return closer.Close()
 	}
 	return nil
+}
+
+func resolveProviderConnectionForOperation(prov core.Provider, operation string, params map[string]any) (string, error) {
+	if resolver, ok := prov.(core.OperationConnectionResolver); ok {
+		return resolver.ResolveConnectionForOperation(operation, params)
+	}
+	return prov.ConnectionForOperation(operation), nil
+}
+
+func providerOperationConnectionOverrideAllowed(prov core.Provider, operation string, params map[string]any) bool {
+	if policy, ok := prov.(core.OperationConnectionOverridePolicy); ok {
+		return policy.OperationConnectionOverrideAllowed(operation, params)
+	}
+	return false
 }

--- a/gestaltd/internal/bootstrap/connected_provider_test.go
+++ b/gestaltd/internal/bootstrap/connected_provider_test.go
@@ -8,10 +8,14 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
 )
 
 type connectedCapabilityProvider struct {
 	postConnectMetadata map[string]string
+	operationConnection map[string]string
+	resolveConnection   func(operation string, params map[string]any) (string, error)
+	overrideAllowed     func(operation string, params map[string]any) bool
 }
 
 func (p *connectedCapabilityProvider) Name() string        { return "slack" }
@@ -26,7 +30,21 @@ func (p *connectedCapabilityProvider) ConnectionParamDefs() map[string]core.Conn
 }
 func (p *connectedCapabilityProvider) CredentialFields() []core.CredentialFieldDef { return nil }
 func (p *connectedCapabilityProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
-func (p *connectedCapabilityProvider) ConnectionForOperation(string) string        { return "" }
+func (p *connectedCapabilityProvider) ConnectionForOperation(operation string) string {
+	return p.operationConnection[operation]
+}
+func (p *connectedCapabilityProvider) ResolveConnectionForOperation(operation string, params map[string]any) (string, error) {
+	if p.resolveConnection != nil {
+		return p.resolveConnection(operation, params)
+	}
+	return p.ConnectionForOperation(operation), nil
+}
+func (p *connectedCapabilityProvider) OperationConnectionOverrideAllowed(operation string, params map[string]any) bool {
+	if p.overrideAllowed != nil {
+		return p.overrideAllowed(operation, params)
+	}
+	return false
+}
 func (p *connectedCapabilityProvider) Catalog() *catalog.Catalog {
 	return &catalog.Catalog{
 		Name: "slack",
@@ -96,6 +114,62 @@ func TestBindProviderConnectionPreservesPostConnectCapability(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("PostConnect metadata = %#v, want %#v", got, want)
+	}
+}
+
+func TestBindProviderConnectionResolvesInnerStaticOperationConnection(t *testing.T) {
+	t.Parallel()
+
+	prov := bindProviderConnection(&connectedCapabilityProvider{
+		operationConnection: map[string]string{"viewer": "bot"},
+	}, "default")
+
+	if got := prov.ConnectionForOperation("viewer"); got != "bot" {
+		t.Fatalf("ConnectionForOperation(viewer) = %q, want %q", got, "bot")
+	}
+	got, err := invocation.ResolveOperationConnection(prov, "viewer", nil)
+	if err != nil {
+		t.Fatalf("ResolveOperationConnection(viewer): %v", err)
+	}
+	if got != "bot" {
+		t.Fatalf("ResolveOperationConnection(viewer) = %q, want %q", got, "bot")
+	}
+}
+
+func TestBindProviderConnectionPreservesOperationConnectionInterfacesThroughCapabilityWrappers(t *testing.T) {
+	t.Parallel()
+
+	prov := bindProviderConnection(&connectedCapabilityProvider{
+		operationConnection: map[string]string{"viewer": "default"},
+		resolveConnection: func(operation string, params map[string]any) (string, error) {
+			if params["actor"] == "bot" {
+				return "bot", nil
+			}
+			return "default", nil
+		},
+		overrideAllowed: func(operation string, params map[string]any) bool {
+			return params["allow_override"] == true
+		},
+	}, "default")
+
+	resolver, ok := prov.(core.OperationConnectionResolver)
+	if !ok {
+		t.Fatal("expected bound provider to preserve operation connection resolver")
+	}
+	got, err := resolver.ResolveConnectionForOperation("viewer", map[string]any{"actor": "bot"})
+	if err != nil {
+		t.Fatalf("ResolveConnectionForOperation(viewer): %v", err)
+	}
+	if got != "bot" {
+		t.Fatalf("ResolveConnectionForOperation(viewer) = %q, want %q", got, "bot")
+	}
+
+	policy, ok := prov.(core.OperationConnectionOverridePolicy)
+	if !ok {
+		t.Fatal("expected bound provider to preserve operation connection override policy")
+	}
+	if !policy.OperationConnectionOverrideAllowed("viewer", map[string]any{"allow_override": true}) {
+		t.Fatal("expected operation connection override policy to be forwarded")
 	}
 }
 

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -2508,14 +2508,14 @@ paths:
 		t.Fatalf("status connection = %q, want %q", got, "default")
 	}
 
-	_, operationConnections, err := buildStartupProviderSpec("hybrid", entry)
+	_, operationRouting, err := buildStartupProviderSpec("hybrid", entry)
 	if err != nil {
 		t.Fatalf("buildStartupProviderSpec: %v", err)
 	}
-	if got := operationConnections["echo"]; got != "default" {
+	if got := operationRouting.connections["echo"]; got != "default" {
 		t.Fatalf("startup echo connection = %q, want %q", got, "default")
 	}
-	if _, ok := operationConnections["status"]; ok {
+	if _, ok := operationRouting.connections["status"]; ok {
 		t.Fatalf("startup catalog unexpectedly exposed spec-loaded status operation")
 	}
 }
@@ -2538,15 +2538,19 @@ func TestHybridDeclarativeExecutableProviderUsesNamedDefaultConnectionForPluginO
 			BaseURL: "https://example.invalid",
 			Operations: []providermanifestv1.ProviderOperation{
 				{
-					Name:   "status",
-					Method: http.MethodGet,
-					Path:   "/status",
+					Name:       "status",
+					Method:     http.MethodGet,
+					Path:       "/status",
+					Connection: "bot",
 				},
 			},
 		},
 	}
 	manifest.Spec.Connections = map[string]*providermanifestv1.ManifestConnectionDef{
 		"default": {
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
+		},
+		"bot": {
 			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
 		},
 	}
@@ -2578,8 +2582,8 @@ func TestHybridDeclarativeExecutableProviderUsesNamedDefaultConnectionForPluginO
 	if got := prov.ConnectionForOperation("echo"); got != "default" {
 		t.Fatalf("echo connection = %q, want %q", got, "default")
 	}
-	if got := prov.ConnectionForOperation("status"); got != "default" {
-		t.Fatalf("status connection = %q, want %q", got, "default")
+	if got := prov.ConnectionForOperation("status"); got != "bot" {
+		t.Fatalf("status connection = %q, want %q", got, "bot")
 	}
 
 	services := coretesting.NewStubServices(t)
@@ -3118,17 +3122,22 @@ func TestBuildStartupProviderSpecPreservesStaticCatalogConnectionRouting(t *test
 			Mode: providermanifestv1.ConnectionModeUser,
 			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
 		},
+		"openapi": {
+			Mode: providermanifestv1.ConnectionModeUser,
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
+		},
 		"mcp": {
 			Mode: providermanifestv1.ConnectionModeUser,
 			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
 		},
 	}
 	manifest.Spec.Surfaces = &providermanifestv1.ProviderSurfaces{
-		REST: &providermanifestv1.RESTSurface{Connection: "api"},
-		MCP:  &providermanifestv1.MCPSurface{URL: "https://example.invalid/mcp", Connection: "mcp"},
+		OpenAPI: &providermanifestv1.OpenAPISurface{Document: "openapi.yaml", Connection: "openapi"},
+		REST:    &providermanifestv1.RESTSurface{Connection: "api"},
+		MCP:     &providermanifestv1.MCPSurface{URL: "https://example.invalid/mcp", Connection: "mcp"},
 	}
 
-	spec, operationConnections, err := buildStartupProviderSpec("roadmap", &config.ProviderEntry{
+	spec, operationRouting, err := buildStartupProviderSpec("roadmap", &config.ProviderEntry{
 		ResolvedManifest:     manifest,
 		ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 	})
@@ -3138,14 +3147,92 @@ func TestBuildStartupProviderSpecPreservesStaticCatalogConnectionRouting(t *test
 	if spec.Catalog == nil || len(spec.Catalog.Operations) != 3 {
 		t.Fatalf("unexpected startup catalog: %+v", spec.Catalog)
 	}
-	if got := operationConnections["status"]; got != "api" {
+	if got := operationRouting.connections["status"]; got != "api" {
 		t.Fatalf("status connection = %q, want %q", got, "api")
 	}
-	if got := operationConnections["search"]; got != "mcp" {
+	if got := operationRouting.connections["search"]; got != "mcp" {
 		t.Fatalf("search connection = %q, want %q", got, "mcp")
 	}
-	if got := operationConnections["echo"]; got != config.PluginConnectionName {
+	if got := operationRouting.connections["echo"]; got != config.PluginConnectionName {
 		t.Fatalf("echo connection = %q, want %q", got, config.PluginConnectionName)
+	}
+}
+
+func TestStartupProviderProxyResolvesDeclarativeConnectionSelectorBeforeProviderReady(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Source:      "slack",
+		DisplayName: "Slack",
+		Spec: &providermanifestv1.Spec{
+			DefaultConnection: "default",
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"default": {Mode: providermanifestv1.ConnectionModeUser},
+				"bot":     {Mode: providermanifestv1.ConnectionModeUser},
+			},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					Connection: "bot",
+					BaseURL:    "https://slack.com",
+					Operations: []providermanifestv1.ProviderOperation{
+						{
+							Name:   "chat.postMessage",
+							Method: http.MethodPost,
+							Path:   "/api/chat.postMessage",
+							ConnectionSelector: &providermanifestv1.OperationConnectionSelector{
+								Parameter: "actor",
+								Default:   "bot",
+								Values: map[string]string{
+									"bot":  "bot",
+									"user": "default",
+								},
+							},
+							Parameters: []providermanifestv1.ProviderParameter{
+								{Name: "actor", Type: "string", In: "body", Internal: true},
+								{Name: "channel", Type: "string", In: "body", Required: true},
+								{Name: "text", Type: "string", In: "body", Required: true},
+							},
+						},
+						{
+							Name:   "chat.scheduleMessage",
+							Method: http.MethodPost,
+							Path:   "/api/chat.scheduleMessage",
+							Parameters: []providermanifestv1.ProviderParameter{
+								{Name: "channel", Type: "string", In: "body", Required: true},
+								{Name: "text", Type: "string", In: "body", Required: true},
+								{Name: "post_at", Type: "int", In: "body", Required: true},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	spec, operationRouting, err := buildStartupProviderSpec("slack", &config.ProviderEntry{ResolvedManifest: manifest})
+	if err != nil {
+		t.Fatalf("buildStartupProviderSpec: %v", err)
+	}
+	proxy := newStartupProviderProxy(spec, operationRouting, nil)
+
+	conn, err := proxy.ResolveConnectionForOperation("chat.postMessage", map[string]any{"actor": "user"})
+	if err != nil {
+		t.Fatalf("ResolveConnectionForOperation(user): %v", err)
+	}
+	if conn != "default" {
+		t.Fatalf("user actor connection = %q, want default", conn)
+	}
+	conn, err = proxy.ResolveConnectionForOperation("chat.postMessage", nil)
+	if err != nil {
+		t.Fatalf("ResolveConnectionForOperation(default): %v", err)
+	}
+	if conn != "bot" {
+		t.Fatalf("default actor connection = %q, want bot", conn)
+	}
+	if proxy.OperationConnectionOverrideAllowed("chat.postMessage", map[string]any{"actor": "user"}) {
+		t.Fatal("selector-selected operation allowed explicit override")
+	}
+	if !proxy.OperationConnectionOverrideAllowed("chat.scheduleMessage", nil) {
+		t.Fatal("surface fallback operation rejected explicit override before provider ready")
 	}
 }
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -101,11 +101,11 @@ func buildProvidersAsync(
 		intgDef := cfg.Plugins[name]
 		var proxy *startupProviderProxy
 		if deps.WorkflowRuntime != nil {
-			spec, operationConnections, err := buildStartupProviderSpec(name, intgDef)
+			spec, operationRouting, err := buildStartupProviderSpec(name, intgDef)
 			if err != nil {
 				slog.Warn("building startup provider proxy metadata failed", "provider", name, "error", err)
 			} else {
-				proxy = newStartupProviderProxy(spec, operationConnections, deps.WorkflowRuntime.StartupWaitTracker())
+				proxy = newStartupProviderProxy(spec, operationRouting, deps.WorkflowRuntime.StartupWaitTracker())
 				if err := reg.Providers.Register(name, proxy); err != nil {
 					errMu.Lock()
 					buildErrs = append(buildErrs, fmt.Errorf("integration %q: %w", name, err))
@@ -201,44 +201,60 @@ func validateProviderConnectionMode(provider string, mode core.ConnectionMode) e
 }
 
 func BuildStartupProviderSpec(name string, entry *config.ProviderEntry) (providerhost.StaticProviderSpec, map[string]string, error) {
-	return buildStartupProviderSpec(name, entry)
+	spec, routing, err := buildStartupProviderSpec(name, entry)
+	return spec, routing.connections, err
 }
 
-func buildStartupProviderSpec(name string, entry *config.ProviderEntry) (providerhost.StaticProviderSpec, map[string]string, error) {
+type startupOperationRouting struct {
+	connections    map[string]string
+	resolver       core.OperationConnectionResolver
+	overridePolicy core.OperationConnectionOverridePolicy
+}
+
+func buildStartupProviderSpec(name string, entry *config.ProviderEntry) (providerhost.StaticProviderSpec, startupOperationRouting, error) {
 	if entry == nil {
-		return providerhost.StaticProviderSpec{}, nil, fmt.Errorf("integration %q has no plugin defined", name)
+		return providerhost.StaticProviderSpec{}, startupOperationRouting{}, fmt.Errorf("integration %q has no plugin defined", name)
 	}
 	manifest := entry.ResolvedManifest
 	manifestPlugin := entry.ManifestSpec()
 	if manifest == nil || manifestPlugin == nil {
-		return providerhost.StaticProviderSpec{}, nil, fmt.Errorf("integration %q must resolve to a provider manifest", name)
+		return providerhost.StaticProviderSpec{}, startupOperationRouting{}, fmt.Errorf("integration %q must resolve to a provider manifest", name)
 	}
 
 	meta := resolveProviderMetadata(entry)
 	spec, plan, err := buildPluginStaticSpec(name, entry, manifest, meta)
 	if err != nil {
-		return providerhost.StaticProviderSpec{}, nil, err
+		return providerhost.StaticProviderSpec{}, startupOperationRouting{}, err
+	}
+	restConnections, restSelectors, restLocks, err := plan.RESTOperationConnectionBindings(manifestPlugin)
+	if err != nil {
+		return providerhost.StaticProviderSpec{}, startupOperationRouting{}, err
 	}
 	if spec.Catalog != nil {
-		return spec, operationConnectionsForCatalog(spec.Catalog, plan), nil
+		return spec, startupOperationRouting{connections: operationConnectionsForCatalog(spec.Catalog, plan, restConnections)}, nil
 	}
 	if !manifestPlugin.IsDeclarative() && !manifestPlugin.IsSpecLoaded() {
-		return spec, map[string]string{}, nil
+		return spec, startupOperationRouting{connections: map[string]string{}}, nil
 	}
 	declarative, err := providerhost.NewDeclarativeProvider(
 		manifest,
 		nil,
 		providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
 		providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
+		providerhost.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
 	)
 	if err != nil {
-		return providerhost.StaticProviderSpec{}, nil, err
+		return providerhost.StaticProviderSpec{}, startupOperationRouting{}, err
 	}
 	spec.Catalog = declarative.Catalog()
-	return spec, operationConnectionsForCatalog(spec.Catalog, plan), nil
+	return spec, startupOperationRouting{
+		connections:    operationConnectionsForCatalog(spec.Catalog, plan, restConnections),
+		resolver:       declarative,
+		overridePolicy: declarative,
+	}, nil
 }
 
-func operationConnectionsForCatalog(cat *catalog.Catalog, plan config.StaticConnectionPlan) map[string]string {
+func operationConnectionsForCatalog(cat *catalog.Catalog, plan config.StaticConnectionPlan, restConnections map[string]string) map[string]string {
 	if cat == nil {
 		return map[string]string{}
 	}
@@ -249,7 +265,11 @@ func operationConnectionsForCatalog(cat *catalog.Catalog, plan config.StaticConn
 		connection := pluginConnection
 		switch operation.Transport {
 		case catalog.TransportREST:
-			connection = plan.APIConnection()
+			if resolved := restConnections[operation.ID]; resolved != "" {
+				connection = resolved
+			} else {
+				connection = plan.RESTConnection()
+			}
 		case "graphql":
 			if resolved, ok := plan.ResolvedSurface(config.SpecSurfaceGraphQL); ok {
 				connection = resolved.ConnectionName
@@ -323,11 +343,16 @@ func buildProvider(ctx context.Context, name string, entry *config.ProviderEntry
 		if err != nil {
 			return nil, fmt.Errorf("build declarative provider %q: %w", name, err)
 		}
+		restConnections, restSelectors, restLocks, err := plan.RESTOperationConnectionBindings(manifestPlugin)
+		if err != nil {
+			return nil, fmt.Errorf("build declarative provider %q: %w", name, err)
+		}
 		declarative, err := providerhost.NewDeclarativeProvider(
 			manifest,
 			nil,
 			providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
 			providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
+			providerhost.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
@@ -364,6 +389,11 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 	staticAllowedOperations := operationexposure.MatchingAllowedOperations(allowedOperations, pluginProv.Catalog())
 
 	if manifestPlugin.IsDeclarative() {
+		restConnections, restSelectors, restLocks, err := plan.RESTOperationConnectionBindings(manifestPlugin)
+		if err != nil {
+			closeIfPossible(pluginProv)
+			return nil, fmt.Errorf("build declarative provider %q: %w", name, err)
+		}
 		filteredPluginProv, err := applyAllowedOperations(name, staticAllowedOperations, pluginProv)
 		if err != nil {
 			closeIfPossible(pluginProv)
@@ -375,6 +405,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 			nil,
 			providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
 			providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
+			providerhost.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
 		)
 		if err != nil {
 			closeIfPossible(pluginProv)
@@ -392,7 +423,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 			pluginProv.Description(),
 			firstProviderIconSVG(pluginProv, apiProv),
 			composite.BoundProvider{Provider: pluginProv, Connection: hybridPluginOperationConnection(plan, plan.APIConnection())},
-			composite.BoundProvider{Provider: apiProv, Connection: plan.APIConnection()},
+			composite.BoundProvider{Provider: apiProv, FallbackConnection: plan.RESTConnection()},
 		)
 		if err != nil {
 			closeIfPossible(apiProv, pluginProv)

--- a/gestaltd/internal/bootstrap/startup_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_proxy.go
@@ -78,9 +78,9 @@ func (t *startupWaitTracker) beginWorkflowWait(providerName, pluginName string) 
 }
 
 type startupProviderProxy struct {
-	spec                 providerhost.StaticProviderSpec
-	operationConnections map[string]string
-	tracker              *startupWaitTracker
+	spec             providerhost.StaticProviderSpec
+	operationRouting startupOperationRouting
+	tracker          *startupWaitTracker
 
 	ready chan struct{}
 	once  sync.Once
@@ -90,12 +90,13 @@ type startupProviderProxy struct {
 	err      error
 }
 
-func newStartupProviderProxy(spec providerhost.StaticProviderSpec, operationConnections map[string]string, tracker *startupWaitTracker) *startupProviderProxy {
+func newStartupProviderProxy(spec providerhost.StaticProviderSpec, operationRouting startupOperationRouting, tracker *startupWaitTracker) *startupProviderProxy {
+	operationRouting.connections = maps.Clone(operationRouting.connections)
 	return &startupProviderProxy{
-		spec:                 spec,
-		operationConnections: maps.Clone(operationConnections),
-		tracker:              tracker,
-		ready:                make(chan struct{}),
+		spec:             spec,
+		operationRouting: operationRouting,
+		tracker:          tracker,
+		ready:            make(chan struct{}),
 	}
 }
 
@@ -247,7 +248,35 @@ func (p *startupProviderProxy) ConnectionForOperation(operation string) string {
 	if provider != nil {
 		return provider.ConnectionForOperation(operation)
 	}
-	return p.operationConnections[operation]
+	return p.operationRouting.connections[operation]
+}
+
+func (p *startupProviderProxy) ResolveConnectionForOperation(operation string, params map[string]any) (string, error) {
+	provider := p.resolved()
+	if provider != nil {
+		if resolver, ok := provider.(core.OperationConnectionResolver); ok {
+			return resolver.ResolveConnectionForOperation(operation, params)
+		}
+		return provider.ConnectionForOperation(operation), nil
+	}
+	if p.operationRouting.resolver != nil {
+		return p.operationRouting.resolver.ResolveConnectionForOperation(operation, params)
+	}
+	return p.operationRouting.connections[operation], nil
+}
+
+func (p *startupProviderProxy) OperationConnectionOverrideAllowed(operation string, params map[string]any) bool {
+	provider := p.resolved()
+	if provider != nil {
+		if policy, ok := provider.(core.OperationConnectionOverridePolicy); ok {
+			return policy.OperationConnectionOverrideAllowed(operation, params)
+		}
+		return false
+	}
+	if p.operationRouting.overridePolicy != nil {
+		return p.operationRouting.overridePolicy.OperationConnectionOverrideAllowed(operation, params)
+	}
+	return false
 }
 
 func (p *startupProviderProxy) ConnectionParamDefs() map[string]core.ConnectionParamDef {

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -180,7 +180,7 @@ func newPreparedProviderStub(name string, entry *config.ProviderEntry) (core.Pro
 	if entry == nil || entry.ResolvedManifest == nil {
 		return nil, fmt.Errorf("prepared manifest is not resolved")
 	}
-	spec, operationConnections, err := buildStartupProviderSpec(name, entry)
+	spec, operationRouting, err := buildStartupProviderSpec(name, entry)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func newPreparedProviderStub(name string, entry *config.ProviderEntry) (core.Pro
 		description:    description,
 		connectionMode: spec.ConnectionMode,
 		catalog:        cat,
-		connections:    operationConnections,
+		connections:    operationRouting.connections,
 	}, nil
 }
 

--- a/gestaltd/internal/composite/merged.go
+++ b/gestaltd/internal/composite/merged.go
@@ -18,12 +18,18 @@ type MergedProvider struct {
 	connMode core.ConnectionMode
 	opConn   map[string]string
 	route    map[string]core.Provider
+	binding  map[string]BoundProvider
 	owned    []core.Provider
 }
 
 type BoundProvider struct {
-	Provider   core.Provider
-	Connection string
+	Provider core.Provider
+
+	// Connection forces every operation from this provider to use the named
+	// connection. FallbackConnection only applies when the provider does not
+	// report or resolve a more specific operation connection.
+	Connection         string
+	FallbackConnection string
 }
 
 var (
@@ -45,9 +51,10 @@ func NewMergedWithConnections(name, displayName, desc, iconSVG string, providers
 			IconSVG:     iconSVG,
 			Operations:  make([]catalog.CatalogOperation, 0),
 		},
-		opConn: make(map[string]string),
-		route:  make(map[string]core.Provider),
-		owned:  owned,
+		opConn:  make(map[string]string),
+		route:   make(map[string]core.Provider),
+		binding: make(map[string]BoundProvider),
+		owned:   owned,
 	}
 	for i, bound := range providers {
 		p := bound.Provider
@@ -66,12 +73,15 @@ func NewMergedWithConnections(name, displayName, desc, iconSVG string, providers
 				return nil, fmt.Errorf("operation %q provided by both %q and %q", op.ID, owner.Name(), p.Name())
 			}
 			m.route[op.ID] = p
+			m.binding[op.ID] = bound
 			m.catalog.Operations = append(m.catalog.Operations, *op)
-			switch {
+			switch operationConnection := p.ConnectionForOperation(op.ID); {
 			case bound.Connection != "":
 				m.opConn[op.ID] = bound.Connection
-			case p.ConnectionForOperation(op.ID) != "":
-				m.opConn[op.ID] = p.ConnectionForOperation(op.ID)
+			case operationConnection != "":
+				m.opConn[op.ID] = operationConnection
+			case bound.FallbackConnection != "":
+				m.opConn[op.ID] = bound.FallbackConnection
 			}
 		}
 	}
@@ -126,6 +136,37 @@ func (m *MergedProvider) DiscoveryConfig() *core.DiscoveryConfig {
 
 func (m *MergedProvider) ConnectionForOperation(op string) string {
 	return m.opConn[op]
+}
+
+func (m *MergedProvider) ResolveConnectionForOperation(op string, params map[string]any) (string, error) {
+	if bound, ok := m.binding[op]; ok {
+		if bound.Connection != "" {
+			return bound.Connection, nil
+		}
+		if resolver, ok := bound.Provider.(core.OperationConnectionResolver); ok {
+			connection, err := resolver.ResolveConnectionForOperation(op, params)
+			if err != nil || connection != "" {
+				return connection, err
+			}
+		}
+		if bound.FallbackConnection != "" {
+			return bound.FallbackConnection, nil
+		}
+	}
+	return m.ConnectionForOperation(op), nil
+}
+
+func (m *MergedProvider) OperationConnectionOverrideAllowed(op string, params map[string]any) bool {
+	if bound, ok := m.binding[op]; ok {
+		if bound.Connection != "" {
+			return false
+		}
+		if policy, ok := bound.Provider.(core.OperationConnectionOverridePolicy); ok {
+			return policy.OperationConnectionOverrideAllowed(op, params)
+		}
+		return bound.FallbackConnection != ""
+	}
+	return false
 }
 
 func (m *MergedProvider) Catalog() *catalog.Catalog { return m.catalog.Clone() }

--- a/gestaltd/internal/composite/merged_test.go
+++ b/gestaltd/internal/composite/merged_test.go
@@ -15,6 +15,7 @@ type fakeProvider struct {
 	name     string
 	connMode core.ConnectionMode
 	ops      []core.Operation
+	opConn   map[string]string
 	execFn   func(ctx context.Context, op string, params map[string]any, token string) (*core.OperationResult, error)
 	closed   bool
 }
@@ -29,7 +30,12 @@ func (p *fakeProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef 
 }
 func (p *fakeProvider) CredentialFields() []core.CredentialFieldDef { return nil }
 func (p *fakeProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
-func (p *fakeProvider) ConnectionForOperation(string) string        { return "" }
+func (p *fakeProvider) ConnectionForOperation(operation string) string {
+	return p.opConn[operation]
+}
+func (p *fakeProvider) ResolveConnectionForOperation(operation string, _ map[string]any) (string, error) {
+	return p.ConnectionForOperation(operation), nil
+}
 func (p *fakeProvider) Catalog() *catalog.Catalog {
 	cat := &catalog.Catalog{
 		Name:       p.name,
@@ -174,6 +180,70 @@ func TestMergedCatalogIncludesConstructorMetadata(t *testing.T) {
 	}
 	if cat.IconSVG != "<svg/>" {
 		t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, "<svg/>")
+	}
+}
+
+func TestMergedConnectionBindingPrecedence(t *testing.T) {
+	t.Parallel()
+
+	forced, err := composite.NewMergedWithConnections("test", "Test", "desc", "",
+		composite.BoundProvider{
+			Provider: &fakeProvider{
+				name:   "api",
+				ops:    []core.Operation{{Name: "list_items"}},
+				opConn: map[string]string{"list_items": "reported"},
+			},
+			Connection: "forced",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := forced.ConnectionForOperation("list_items"); got != "forced" {
+		t.Fatalf("forced ConnectionForOperation = %q, want %q", got, "forced")
+	}
+	resolved, err := forced.ResolveConnectionForOperation("list_items", nil)
+	if err != nil {
+		t.Fatalf("forced ResolveConnectionForOperation: %v", err)
+	}
+	if resolved != "forced" {
+		t.Fatalf("forced ResolveConnectionForOperation = %q, want %q", resolved, "forced")
+	}
+	if forced.OperationConnectionOverrideAllowed("list_items", nil) {
+		t.Fatal("forced binding should not allow explicit connection override")
+	}
+
+	fallback, err := composite.NewMergedWithConnections("test", "Test", "desc", "",
+		composite.BoundProvider{
+			Provider: &fakeProvider{
+				name: "api",
+				ops: []core.Operation{
+					{Name: "list_items"},
+					{Name: "get_item"},
+				},
+				opConn: map[string]string{"list_items": "reported"},
+			},
+			FallbackConnection: "fallback",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fallback.ConnectionForOperation("list_items"); got != "reported" {
+		t.Fatalf("fallback reported ConnectionForOperation = %q, want %q", got, "reported")
+	}
+	if got := fallback.ConnectionForOperation("get_item"); got != "fallback" {
+		t.Fatalf("fallback default ConnectionForOperation = %q, want %q", got, "fallback")
+	}
+	resolved, err = fallback.ResolveConnectionForOperation("get_item", nil)
+	if err != nil {
+		t.Fatalf("fallback ResolveConnectionForOperation: %v", err)
+	}
+	if resolved != "fallback" {
+		t.Fatalf("fallback ResolveConnectionForOperation = %q, want %q", resolved, "fallback")
+	}
+	if !fallback.OperationConnectionOverrideAllowed("get_item", nil) {
+		t.Fatal("fallback binding should allow explicit connection override")
 	}
 }
 

--- a/gestaltd/internal/composite/provider.go
+++ b/gestaltd/internal/composite/provider.go
@@ -106,6 +106,20 @@ func (p *Provider) ConnectionForOperation(operation string) string {
 	return p.api.ConnectionForOperation(operation)
 }
 
+func (p *Provider) ResolveConnectionForOperation(operation string, params map[string]any) (string, error) {
+	if resolver, ok := p.api.(core.OperationConnectionResolver); ok {
+		return resolver.ResolveConnectionForOperation(operation, params)
+	}
+	return p.api.ConnectionForOperation(operation), nil
+}
+
+func (p *Provider) OperationConnectionOverrideAllowed(operation string, params map[string]any) bool {
+	if policy, ok := p.api.(core.OperationConnectionOverridePolicy); ok {
+		return policy.OperationConnectionOverrideAllowed(operation, params)
+	}
+	return false
+}
+
 func (p *Provider) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
 	return p.mcp.CallTool(ctx, name, args)
 }

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -82,6 +83,9 @@ func BuildStaticConnectionPlan(plugin *ProviderEntry, manifestPlugin *providerma
 	if err := plan.validateConnectionModes(); err != nil {
 		return StaticConnectionPlan{}, err
 	}
+	if _, _, _, err := plan.RESTOperationConnectionBindings(manifestPlugin); err != nil {
+		return StaticConnectionPlan{}, err
+	}
 
 	return plan, nil
 }
@@ -156,6 +160,84 @@ func (plan StaticConnectionPlan) APIConnection() string {
 	return plan.fallbackConnection()
 }
 
+func (plan StaticConnectionPlan) RESTConnection() string {
+	if plan.restConnection != "" {
+		return plan.restConnection
+	}
+	return plan.fallbackConnection()
+}
+
+// RESTOperationConnectionBindings returns the effective static connection and
+// optional selector for each declarative REST operation in the manifest.
+func (plan StaticConnectionPlan) RESTOperationConnectionBindings(manifestPlugin *providermanifestv1.Spec) (map[string]string, map[string]core.OperationConnectionSelector, map[string]bool, error) {
+	if manifestPlugin == nil || manifestPlugin.Surfaces == nil || manifestPlugin.Surfaces.REST == nil {
+		return nil, nil, nil, nil
+	}
+	operations := manifestPlugin.Surfaces.REST.Operations
+	if len(operations) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	connections := make(map[string]string, len(operations))
+	selectors := make(map[string]core.OperationConnectionSelector)
+	locked := make(map[string]bool)
+	defaultConnection := plan.RESTConnection()
+	for i := range operations {
+		op := &operations[i]
+		operationName := strings.TrimSpace(op.Name)
+		if operationName == "" {
+			continue
+		}
+
+		parameterNames := make(map[string]struct{}, len(op.Parameters))
+		for j := range op.Parameters {
+			if name := strings.TrimSpace(op.Parameters[j].Name); name != "" {
+				parameterNames[name] = struct{}{}
+			}
+		}
+
+		connection := defaultConnection
+		operationConnection := strings.TrimSpace(op.Connection)
+		if operationConnection != "" {
+			connection = ResolveConnectionAlias(operationConnection)
+			locked[operationName] = true
+		}
+		if connection != "" {
+			if _, err := plan.connectionDef(connection); err != nil {
+				return nil, nil, nil, fmt.Errorf("operation %q connection references %w", operationName, err)
+			}
+			connections[operationName] = connection
+		}
+
+		selector, err := plan.resolveOperationConnectionSelector(operationName, op.ConnectionSelector)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if selector.Parameter != "" {
+			if _, ok := parameterNames[selector.Parameter]; !ok {
+				return nil, nil, nil, fmt.Errorf("operation %q connectionSelector.parameter %q must be declared in parameters", operationName, selector.Parameter)
+			}
+			if operationConnection != "" && selector.Default != "" {
+				return nil, nil, nil, fmt.Errorf("operation %q cannot declare both connection and connectionSelector.default", operationName)
+			}
+			selectors[operationName] = selector
+			if selector.Default != "" {
+				connections[operationName] = selector.Values[selector.Default]
+			}
+		}
+	}
+	if len(connections) == 0 {
+		connections = nil
+	}
+	if len(selectors) == 0 {
+		selectors = nil
+	}
+	if len(locked) == 0 {
+		locked = nil
+	}
+	return connections, selectors, locked, nil
+}
+
 func (plan StaticConnectionPlan) MCPConnection() string {
 	if resolved, ok := plan.ResolvedSurface(SpecSurfaceMCP); ok {
 		return resolved.ConnectionName
@@ -206,6 +288,45 @@ func (plan StaticConnectionPlan) validateConnectionModes() error {
 	return nil
 }
 
+func (plan StaticConnectionPlan) resolveOperationConnectionSelector(operationName string, raw *providermanifestv1.OperationConnectionSelector) (core.OperationConnectionSelector, error) {
+	if raw == nil {
+		return core.OperationConnectionSelector{}, nil
+	}
+	parameter := strings.TrimSpace(raw.Parameter)
+	if parameter == "" {
+		return core.OperationConnectionSelector{}, fmt.Errorf("operation %q connectionSelector.parameter is required", operationName)
+	}
+	if len(raw.Values) == 0 {
+		return core.OperationConnectionSelector{}, fmt.Errorf("operation %q connectionSelector.values is required", operationName)
+	}
+	values := make(map[string]string, len(raw.Values))
+	for value, rawConnection := range raw.Values {
+		selectorValue := strings.TrimSpace(value)
+		if selectorValue == "" {
+			return core.OperationConnectionSelector{}, fmt.Errorf("operation %q connectionSelector.values contains an empty value", operationName)
+		}
+		connection := ResolveConnectionAlias(strings.TrimSpace(rawConnection))
+		if connection == "" {
+			return core.OperationConnectionSelector{}, fmt.Errorf("operation %q connectionSelector value %q references an empty connection", operationName, selectorValue)
+		}
+		if _, err := plan.connectionDef(connection); err != nil {
+			return core.OperationConnectionSelector{}, fmt.Errorf("operation %q connectionSelector value %q references %w", operationName, selectorValue, err)
+		}
+		values[selectorValue] = connection
+	}
+	defaultValue := strings.TrimSpace(raw.Default)
+	if defaultValue != "" {
+		if _, ok := values[defaultValue]; !ok {
+			return core.OperationConnectionSelector{}, fmt.Errorf("operation %q connectionSelector.default %q is not declared in values", operationName, defaultValue)
+		}
+	}
+	return core.OperationConnectionSelector{
+		Parameter: parameter,
+		Default:   defaultValue,
+		Values:    values,
+	}, nil
+}
+
 func (plan StaticConnectionPlan) fallbackConnection() string {
 	if plan.defaultConnection != "" {
 		return plan.defaultConnection
@@ -253,6 +374,9 @@ func (plan StaticConnectionPlan) shouldAdvertisePluginConnection() bool {
 		return true
 	}
 	if plan.APIConnection() == PluginConnectionName {
+		return true
+	}
+	if plan.RESTConnection() == PluginConnectionName {
 		return true
 	}
 	if plan.MCPConnection() == PluginConnectionName {

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -287,7 +287,11 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		if transport == catalog.TransportMCPPassthrough {
 			conn = b.mcpConnection(providerName)
 		} else {
-			conn = prov.ConnectionForOperation(operation)
+			var err error
+			conn, err = ResolveOperationConnection(execProv, opMeta.ID, params)
+			if err != nil {
+				return fail(err)
+			}
 		}
 	}
 	if conn == "" && b.connMapper != nil {

--- a/gestaltd/internal/invocation/broker_test.go
+++ b/gestaltd/internal/invocation/broker_test.go
@@ -2,9 +2,11 @@ package invocation
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
@@ -103,4 +105,118 @@ func TestBrokerResolveToken_NonUserSubjectUsesOwnExternalCredential(t *testing.T
 	if cred.Connection != "workspace" || cred.Instance != "team-b" {
 		t.Fatalf("credential selectors = %q/%q, want workspace/team-b", cred.Connection, cred.Instance)
 	}
+}
+
+func TestBrokerInvokeProviderOverrideResolvesOperationConnectionFromOverride(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	cat := &catalog.Catalog{
+		Name: "slack",
+		Operations: []catalog.CatalogOperation{{
+			ID:     "send",
+			Method: "POST",
+		}},
+	}
+	baseProvider := &brokerOperationConnectionProvider{
+		StubIntegration: &coretesting.StubIntegration{
+			N:          "slack",
+			ConnMode:   core.ConnectionModeUser,
+			CatalogVal: cat,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: 200, Body: token}, nil
+			},
+		},
+		operationConnections: map[string]string{"send": "default"},
+	}
+	overrideProvider := &brokerOperationConnectionProvider{
+		StubIntegration: &coretesting.StubIntegration{
+			N:          "slack",
+			ConnMode:   core.ConnectionModeUser,
+			CatalogVal: cat,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: 200, Body: token}, nil
+			},
+		},
+		operationConnections: map[string]string{"send": "default"},
+		selector: core.OperationConnectionSelector{
+			Parameter: "actor",
+			Default:   "user",
+			Values: map[string]string{
+				"bot":  "bot",
+				"user": "default",
+			},
+		},
+	}
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, baseProvider),
+		svc.Users,
+		svc.ExternalCredentials,
+		WithProviderOverrides(staticProviderOverrideResolver{provider: overrideProvider}),
+	)
+	subjectID := principal.UserSubjectID("u-override")
+	for connection, token := range map[string]string{
+		"default": "user-token",
+		"bot":     "bot-token",
+	} {
+		if err := svc.ExternalCredentials.PutCredential(context.Background(), &core.ExternalCredential{
+			SubjectID:   subjectID,
+			Integration: "slack",
+			Connection:  connection,
+			Instance:    "default",
+			AccessToken: token,
+		}); err != nil {
+			t.Fatalf("PutCredential(%s): %v", connection, err)
+		}
+	}
+
+	result, err := broker.Invoke(
+		context.Background(),
+		&principal.Principal{SubjectID: subjectID, UserID: "u-override", Kind: principal.KindUser},
+		"slack",
+		"",
+		"send",
+		map[string]any{"actor": "bot"},
+	)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if result.Body != "bot-token" {
+		t.Fatalf("token = %q, want bot-token", result.Body)
+	}
+}
+
+type staticProviderOverrideResolver struct {
+	provider core.Provider
+}
+
+func (r staticProviderOverrideResolver) ResolveProviderOverride(context.Context, *principal.Principal, string) (core.Provider, bool, error) {
+	return r.provider, r.provider != nil, nil
+}
+
+type brokerOperationConnectionProvider struct {
+	*coretesting.StubIntegration
+	operationConnections map[string]string
+	selector             core.OperationConnectionSelector
+}
+
+func (p *brokerOperationConnectionProvider) ConnectionForOperation(operation string) string {
+	return p.operationConnections[operation]
+}
+
+func (p *brokerOperationConnectionProvider) ResolveConnectionForOperation(operation string, params map[string]any) (string, error) {
+	if p.selector.Parameter == "" {
+		return p.ConnectionForOperation(operation), nil
+	}
+	selected := p.selector.Default
+	if params != nil {
+		if raw, ok := params[p.selector.Parameter]; ok {
+			selected = fmt.Sprint(raw)
+		}
+	}
+	connection, ok := p.selector.Values[selected]
+	if !ok {
+		return "", fmt.Errorf("unsupported selector value %q", selected)
+	}
+	return connection, nil
 }

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -158,6 +158,30 @@ func sessionCatalogUnsupported(err error) bool {
 	return err != nil && errors.Is(err, core.ErrSessionCatalogUnsupported)
 }
 
+func ResolveOperationConnection(prov core.Provider, operation string, params map[string]any) (string, error) {
+	if prov == nil {
+		return "", nil
+	}
+	if resolver, ok := prov.(core.OperationConnectionResolver); ok {
+		connection, err := resolver.ResolveConnectionForOperation(operation, params)
+		if err != nil {
+			return "", fmt.Errorf("%w: %v", ErrInvalidInvocation, err)
+		}
+		return connection, nil
+	}
+	return prov.ConnectionForOperation(operation), nil
+}
+
+func OperationConnectionOverrideAllowed(prov core.Provider, operation string, params map[string]any) bool {
+	if prov == nil {
+		return true
+	}
+	if policy, ok := prov.(core.OperationConnectionOverridePolicy); ok {
+		return policy.OperationConnectionOverrideAllowed(operation, params)
+	}
+	return false
+}
+
 func resolveCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string, strictSession bool) (*catalog.Catalog, CatalogResolutionMetadata, error) {
 	meta := CatalogResolutionMetadata{}
 	staticCat := prov.Catalog()

--- a/gestaltd/internal/invocation/errors.go
+++ b/gestaltd/internal/invocation/errors.go
@@ -13,4 +13,5 @@ var (
 	ErrUserResolution      = errors.New("user resolution failed")
 	ErrInternal            = errors.New("internal error")
 	ErrScopeDenied         = errors.New("token scope denied")
+	ErrInvalidInvocation   = errors.New("invalid invocation")
 )

--- a/gestaltd/internal/invocation/metrics.go
+++ b/gestaltd/internal/invocation/metrics.go
@@ -98,7 +98,7 @@ func operationResultStatus(result *core.OperationResult, err error) int {
 		return http.StatusConflict
 	case errors.Is(err, ErrUserResolution), errors.Is(err, ErrInternal):
 		return http.StatusInternalServerError
-	case errors.Is(err, core.ErrMCPOnly), errors.Is(err, apiexec.ErrMissingPathParam):
+	case errors.Is(err, ErrInvalidInvocation), errors.Is(err, core.ErrMCPOnly), errors.Is(err, apiexec.ErrMissingPathParam):
 		return http.StatusBadRequest
 	case errors.As(err, &upstreamErr) && validHTTPStatus(upstreamErr.Status):
 		return upstreamErr.Status

--- a/gestaltd/internal/providerhost/declarative.go
+++ b/gestaltd/internal/providerhost/declarative.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -18,10 +20,13 @@ const declarativeHTTPTimeout = 30 * time.Second
 const declarativeJSONContentType = "application/json; charset=utf-8"
 
 type declarativeOptions struct {
-	displayName    string
-	description    string
-	iconSVG        string
-	connectionMode core.ConnectionMode
+	displayName          string
+	description          string
+	iconSVG              string
+	connectionMode       core.ConnectionMode
+	operationConnections map[string]string
+	connectionSelectors  map[string]core.OperationConnectionSelector
+	operationLocks       map[string]bool
 }
 
 type DeclarativeProviderOption func(*declarativeOptions)
@@ -44,10 +49,23 @@ func WithDeclarativeConnectionMode(mode core.ConnectionMode) DeclarativeProvider
 	return func(opts *declarativeOptions) { opts.connectionMode = mode }
 }
 
+// WithDeclarativeOperationConnections binds declarative REST operations to
+// effective connection names and optional parameter-based selectors.
+func WithDeclarativeOperationConnections(connections map[string]string, selectors map[string]core.OperationConnectionSelector, locks map[string]bool) DeclarativeProviderOption {
+	return func(opts *declarativeOptions) {
+		opts.operationConnections = maps.Clone(connections)
+		opts.connectionSelectors = cloneOperationConnectionSelectors(selectors)
+		opts.operationLocks = maps.Clone(locks)
+	}
+}
+
 type DeclarativeProvider struct {
 	*integration.Base
-	authType         providermanifestv1.AuthType
-	authorizationURL string
+	authType             providermanifestv1.AuthType
+	authorizationURL     string
+	operationConnections map[string]string
+	connectionSelectors  map[string]core.OperationConnectionSelector
+	operationLocks       map[string]bool
 }
 
 func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *http.Client, opts ...DeclarativeProviderOption) (*DeclarativeProvider, error) {
@@ -104,9 +122,12 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 	base.SetCatalog(cat)
 
 	return &DeclarativeProvider{
-		Base:             base,
-		authType:         authType,
-		authorizationURL: authorizationURL,
+		Base:                 base,
+		authType:             authType,
+		authorizationURL:     authorizationURL,
+		operationConnections: maps.Clone(options.operationConnections),
+		connectionSelectors:  cloneOperationConnectionSelectors(options.connectionSelectors),
+		operationLocks:       maps.Clone(options.operationLocks),
 	}, nil
 }
 
@@ -119,6 +140,55 @@ func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, par
 		return &core.OperationResult{Status: http.StatusNotFound, Body: `{"error":"unknown operation"}`}, nil
 	}
 	return p.Base.Execute(ctx, operation, params, token)
+}
+
+func (p *DeclarativeProvider) ConnectionForOperation(operation string) string {
+	return p.operationConnections[operation]
+}
+
+func (p *DeclarativeProvider) ResolveConnectionForOperation(operation string, params map[string]any) (string, error) {
+	selector, ok := p.connectionSelectors[operation]
+	if !ok {
+		return p.ConnectionForOperation(operation), nil
+	}
+	if connection, selected, err := selectorConnection(selector, params); selected || err != nil {
+		return connection, err
+	}
+	return p.ConnectionForOperation(operation), nil
+}
+
+func (p *DeclarativeProvider) OperationConnectionOverrideAllowed(operation string, params map[string]any) bool {
+	if selector, ok := p.connectionSelectors[operation]; ok {
+		if _, selected, _ := selectorConnection(selector, params); selected {
+			return false
+		}
+	}
+	return !p.operationLocks[operation]
+}
+
+func selectorConnection(selector core.OperationConnectionSelector, params map[string]any) (string, bool, error) {
+	selected := ""
+	if params != nil {
+		if value, ok := params[selector.Parameter]; ok && value != nil {
+			selected = strings.TrimSpace(fmt.Sprint(value))
+		}
+	}
+	if selected == "" {
+		selected = strings.TrimSpace(selector.Default)
+	}
+	if selected == "" {
+		return "", false, nil
+	}
+	connection, ok := selector.Values[selected]
+	if !ok {
+		values := make([]string, 0, len(selector.Values))
+		for value := range selector.Values {
+			values = append(values, value)
+		}
+		slices.Sort(values)
+		return "", true, fmt.Errorf("connection selector parameter %q must be one of [%s]", selector.Parameter, strings.Join(values, ", "))
+	}
+	return connection, true, nil
 }
 
 func (p *DeclarativeProvider) AuthTypes() []string {
@@ -191,12 +261,25 @@ func declarativeCatalog(manifest *providermanifestv1.Manifest, opts declarativeO
 				Location:    mp.In,
 				Description: mp.Description,
 				Required:    mp.Required,
+				Internal:    mp.Internal,
 			})
 		}
 		cat.Operations = append(cat.Operations, catOp)
 	}
 	integration.CompileSchemas(cat)
 	return cat
+}
+
+func cloneOperationConnectionSelectors(src map[string]core.OperationConnectionSelector) map[string]core.OperationConnectionSelector {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]core.OperationConnectionSelector, len(src))
+	for operation, selector := range src {
+		selector.Values = maps.Clone(selector.Values)
+		cloned[operation] = selector
+	}
+	return cloned
 }
 
 func declarativeConnectionMode(override core.ConnectionMode, auth *providermanifestv1.ProviderAuth) core.ConnectionMode {

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -591,7 +591,8 @@ func validateDeclarativeProvider(provider *providermanifestv1.Spec) error {
 	}
 	ops := provider.RESTOperations()
 	seen := make(map[string]struct{}, len(ops))
-	for i, op := range ops {
+	for i := range ops {
+		op := &ops[i]
 		if op.Name == "" {
 			return fmt.Errorf("provider.operations[%d].name is required", i)
 		}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -669,13 +669,18 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, "operation access denied")
 		return
 	}
+	operationConnection, err := invocation.ResolveOperationConnection(surfaceProv, opMeta.ID, params)
+	if err != nil {
+		s.writeInvocationError(w, r, providerName, operationName, err)
+		return
+	}
 	explicitConnection := connectionInput
 	if explicitConnection != "" {
 		if !safeParamValue.MatchString(explicitConnection) {
 			writeError(w, http.StatusBadRequest, "connection name contains invalid characters")
 			return
 		}
-		if operationConnection := config.ResolveConnectionAlias(prov.ConnectionForOperation(opMeta.ID)); operationConnection != "" && operationConnection != connection {
+		if operationConnection := config.ResolveConnectionAlias(operationConnection); operationConnection != "" && operationConnection != connection && !invocation.OperationConnectionOverrideAllowed(surfaceProv, opMeta.ID, params) {
 			writeError(
 				w,
 				http.StatusBadRequest,
@@ -692,7 +697,10 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx = invocation.WithCatalogOperation(ctx, providerName, opMeta)
 	if connection == "" {
-		connection = resolvedConnection
+		connection = operationConnection
+		if connection == "" {
+			connection = resolvedConnection
+		}
 	}
 	if connection != "" {
 		if !safeParamValue.MatchString(connection) {
@@ -748,6 +756,8 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
 	case errors.Is(err, invocation.ErrInternal):
 		writeError(w, http.StatusInternalServerError, "internal error")
+	case errors.Is(err, invocation.ErrInvalidInvocation):
+		writeError(w, http.StatusBadRequest, err.Error())
 	case errors.Is(err, core.ErrMCPOnly):
 		writeError(w, http.StatusBadRequest, "this integration is accessible only via MCP")
 	case errors.Is(err, apiexec.ErrMissingPathParam):

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -10143,6 +10143,242 @@ func TestExecuteOperation_AllowsExplicitConnectionAliasForStaticOperation(t *tes
 	}
 }
 
+func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOmitsInternalParam(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu    sync.Mutex
+		calls []struct {
+			path string
+			auth string
+			body map[string]any
+		}
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/chat.postMessage", "/api/chat.scheduleMessage", "/api/views.open":
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		calls = append(calls, struct {
+			path string
+			auth string
+			body map[string]any
+		}{
+			path: r.URL.Path,
+			auth: r.Header.Get("Authorization"),
+			body: body,
+		})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	manifest := &providermanifestv1.Manifest{
+		Source:      "slack",
+		DisplayName: "Slack",
+		Spec: &providermanifestv1.Spec{
+			DefaultConnection: "default",
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"default": {Mode: providermanifestv1.ConnectionModeUser},
+				"bot":     {Mode: providermanifestv1.ConnectionModeUser},
+			},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					Connection: "bot",
+					BaseURL:    upstream.URL,
+					Operations: []providermanifestv1.ProviderOperation{
+						{
+							Name:        "chat.postMessage",
+							Description: "Send a Slack message",
+							Method:      http.MethodPost,
+							Path:        "/api/chat.postMessage",
+							ConnectionSelector: &providermanifestv1.OperationConnectionSelector{
+								Parameter: "actor",
+								Default:   "bot",
+								Values: map[string]string{
+									"bot":  "bot",
+									"user": "default",
+								},
+							},
+							Parameters: []providermanifestv1.ProviderParameter{
+								{Name: "channel", Type: "string", In: "body", Required: true},
+								{Name: "text", Type: "string", In: "body", Required: true},
+								{Name: "actor", Type: "string", In: "body", Internal: true},
+							},
+						},
+						{
+							Name:        "chat.scheduleMessage",
+							Description: "Schedule a Slack message",
+							Method:      http.MethodPost,
+							Path:        "/api/chat.scheduleMessage",
+							Parameters: []providermanifestv1.ProviderParameter{
+								{Name: "channel", Type: "string", In: "body", Required: true},
+								{Name: "text", Type: "string", In: "body", Required: true},
+								{Name: "post_at", Type: "int", In: "body", Required: true},
+							},
+						},
+						{
+							Name:        "views.open",
+							Description: "Open a Slack view",
+							Method:      http.MethodPost,
+							Path:        "/api/views.open",
+							ConnectionSelector: &providermanifestv1.OperationConnectionSelector{
+								Parameter: "audience",
+								Default:   "user",
+								Values: map[string]string{
+									"bot":  "bot",
+									"user": "default",
+								},
+							},
+							Parameters: []providermanifestv1.ProviderParameter{
+								{Name: "trigger_id", Type: "string", In: "body", Required: true},
+								{Name: "audience", Type: "string", In: "body"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	entry := &config.ProviderEntry{ResolvedManifest: manifest}
+	plan, err := config.BuildStaticConnectionPlan(entry, manifest.Spec)
+	if err != nil {
+		t.Fatalf("BuildStaticConnectionPlan: %v", err)
+	}
+	restConnections, restSelectors, restLocks, err := plan.RESTOperationConnectionBindings(manifest.Spec)
+	if err != nil {
+		t.Fatalf("RESTOperationConnectionBindings: %v", err)
+	}
+	prov, err := providerhost.NewDeclarativeProvider(
+		manifest,
+		upstream.Client(),
+		providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
+		providerhost.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
+	)
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	user, err := svc.Users.FindOrCreateUser(context.Background(), "selector@test.local")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	subjectID := principal.UserSubjectID(user.ID)
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:          "slack-default",
+		SubjectID:   subjectID,
+		Integration: "slack",
+		Connection:  "default",
+		Instance:    "default",
+		AccessToken: "user-slack-token",
+	})
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:          "slack-bot",
+		SubjectID:   subjectID,
+		Integration: "slack",
+		Connection:  "bot",
+		Instance:    "default",
+		AccessToken: "bot-slack-token",
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "api-token" {
+					return nil, fmt.Errorf("bad token")
+				}
+				return &core.UserIdentity{Email: "selector@test.local"}, nil
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	doInvoke := func(operation, body string) int {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/slack/"+operation, strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer api-token")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode >= 500 {
+			payload, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d: %s", resp.StatusCode, payload)
+		}
+		return resp.StatusCode
+	}
+
+	if status := doInvoke("chat.postMessage", `{"channel":"C1","text":"as user","actor":"user"}`); status != http.StatusOK {
+		t.Fatalf("user actor status = %d, want %d", status, http.StatusOK)
+	}
+	if status := doInvoke("chat.postMessage", `{"channel":"C1","text":"as bot"}`); status != http.StatusOK {
+		t.Fatalf("default actor status = %d, want %d", status, http.StatusOK)
+	}
+	if status := doInvoke("chat.scheduleMessage?_connection=default", `{"channel":"C1","text":"scheduled","post_at":4102444800}`); status != http.StatusOK {
+		t.Fatalf("surface fallback override status = %d, want %d", status, http.StatusOK)
+	}
+	if status := doInvoke("views.open", `{"trigger_id":"T1","audience":"user"}`); status != http.StatusOK {
+		t.Fatalf("non-internal selector status = %d, want %d", status, http.StatusOK)
+	}
+	if status := doInvoke("chat.postMessage", `{"channel":"C1","text":"bad actor","actor":"workspace"}`); status != http.StatusBadRequest {
+		t.Fatalf("invalid actor status = %d, want %d", status, http.StatusBadRequest)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 4 {
+		t.Fatalf("upstream calls = %d, want 4", len(calls))
+	}
+	if calls[0].path != "/api/chat.postMessage" {
+		t.Fatalf("first call path = %q, want chat.postMessage", calls[0].path)
+	}
+	if calls[0].auth != "Bearer user-slack-token" {
+		t.Fatalf("first call auth = %q, want user token", calls[0].auth)
+	}
+	if _, ok := calls[0].body["actor"]; ok {
+		t.Fatalf("first upstream body included internal actor param: %+v", calls[0].body)
+	}
+	if calls[1].auth != "Bearer bot-slack-token" {
+		t.Fatalf("second call auth = %q, want bot token", calls[1].auth)
+	}
+	if _, ok := calls[1].body["actor"]; ok {
+		t.Fatalf("second upstream body included internal actor param: %+v", calls[1].body)
+	}
+	if calls[2].path != "/api/chat.scheduleMessage" {
+		t.Fatalf("third call path = %q, want chat.scheduleMessage", calls[2].path)
+	}
+	if calls[2].auth != "Bearer user-slack-token" {
+		t.Fatalf("third call auth = %q, want user token", calls[2].auth)
+	}
+	if calls[2].body["text"] != "scheduled" {
+		t.Fatalf("third upstream body text = %#v, want scheduled", calls[2].body["text"])
+	}
+	if calls[3].path != "/api/views.open" {
+		t.Fatalf("fourth call path = %q, want views.open", calls[3].path)
+	}
+	if calls[3].auth != "Bearer user-slack-token" {
+		t.Fatalf("fourth call auth = %q, want user token", calls[3].auth)
+	}
+	if calls[3].body["audience"] != "user" {
+		t.Fatalf("fourth upstream body audience = %#v, want user", calls[3].body["audience"])
+	}
+}
+
 func TestExecuteOperation_UnknownIntegration(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t, func(cfg *server.Config) {

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -846,6 +846,13 @@
           "type": "string",
           "minLength": 1
         },
+        "connection": {
+          "type": "string",
+          "minLength": 1
+        },
+        "connectionSelector": {
+          "$ref": "#/$defs/operationConnectionSelector"
+        },
         "allowedRoles": {
           "type": "array",
           "items": {
@@ -857,6 +864,32 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/providerParameter"
+          }
+        }
+      }
+    },
+    "operationConnectionSelector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "parameter",
+        "values"
+      ],
+      "properties": {
+        "parameter": {
+          "type": "string",
+          "minLength": 1
+        },
+        "default": {
+          "type": "string",
+          "minLength": 1
+        },
+        "values": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
           }
         }
       }
@@ -916,6 +949,9 @@
           "type": "string"
         },
         "required": {
+          "type": "boolean"
+        },
+        "internal": {
           "type": "boolean"
         }
       }

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -383,12 +383,20 @@ type UIRoute struct {
 }
 
 type ProviderOperation struct {
-	Name         string              `json:"name" yaml:"name"`
-	Description  string              `json:"description,omitempty" yaml:"description,omitempty"`
-	Method       string              `json:"method" yaml:"method"`
-	Path         string              `json:"path" yaml:"path"`
-	AllowedRoles []string            `json:"allowedRoles,omitempty" yaml:"allowedRoles,omitempty"`
-	Parameters   []ProviderParameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Name               string                       `json:"name" yaml:"name"`
+	Description        string                       `json:"description,omitempty" yaml:"description,omitempty"`
+	Method             string                       `json:"method" yaml:"method"`
+	Path               string                       `json:"path" yaml:"path"`
+	Connection         string                       `json:"connection,omitempty" yaml:"connection,omitempty"`
+	ConnectionSelector *OperationConnectionSelector `json:"connectionSelector,omitempty" yaml:"connectionSelector,omitempty"`
+	AllowedRoles       []string                     `json:"allowedRoles,omitempty" yaml:"allowedRoles,omitempty"`
+	Parameters         []ProviderParameter          `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+}
+
+type OperationConnectionSelector struct {
+	Parameter string            `json:"parameter" yaml:"parameter"`
+	Default   string            `json:"default,omitempty" yaml:"default,omitempty"`
+	Values    map[string]string `json:"values" yaml:"values"`
 }
 
 type ProviderParameter struct {
@@ -397,6 +405,7 @@ type ProviderParameter struct {
 	In          string `json:"in" yaml:"in"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
+	Internal    bool   `json:"internal,omitempty" yaml:"internal,omitempty"`
 }
 
 type ManagedParameter struct {


### PR DESCRIPTION
## Summary

Adds manifest and runtime support for routing declarative REST operations to named connections without splitting a plugin. The server resolves operation connection bindings before credential lookup, preserves operation routing through provider wrappers, provider overrides, startup proxies, and hybrid executable/declarative providers, and supports internal selector-only parameters that are not sent upstream.

REST surface fallback connections remain overrideable at invocation time with `_connection`. Static operation bindings and selector-selected/defaulted bindings reject conflicting `_connection` values, so operations that require one credential cannot be silently run with another.

## Old Interfaces

Before this PR, declarative REST auth was only selectable at the plugin/default connection or whole REST surface level. Every operation on the surface inherited the same effective connection unless the caller supplied an explicit `_connection` override at invocation time.

Single REST surface connection:

```yaml
spec:
  defaultConnection: default
  surfaces:
    rest:
      connection: default
      baseUrl: https://slack.com
      operations:
        - name: search.messages
          method: GET
          path: /api/search.messages
        - name: chat.postMessage
          method: POST
          path: /api/chat.postMessage
```

Invocation-time override only:

```bash
# Uses the REST surface/default connection.
gestalt invoke slack chat.postMessage -p channel=C123 -p text=hello

# Caller must know and pass the alternate connection explicitly.
gestalt invoke slack chat.postMessage -p _connection=bot -p channel=C123 -p text=hello
```

For operations that needed different credentials by default, the practical alternative was exposing a separate operation/plugin surface or baking credential choice into provider code instead of the manifest contract.

## New Interfaces

Static operation binding:

```yaml
spec:
  defaultConnection: default
  surfaces:
    rest:
      connection: default
      baseUrl: https://slack.com
      operations:
        - name: search.messages
          method: GET
          path: /api/search.messages
          connection: default
```

Parameter selector binding:

```yaml
spec:
  surfaces:
    rest:
      connection: bot
      baseUrl: https://slack.com
      operations:
        - name: chat.postMessage
          method: POST
          path: /api/chat.postMessage
          connectionSelector:
            parameter: actor
            default: bot
            values:
              bot: bot
              user: default
          parameters:
            - name: actor
              type: string
              in: body
              internal: true
            - name: channel
              type: string
              in: body
              required: true
            - name: text
              type: string
              in: body
              required: true
```

Invocation examples:

```bash
# Uses the selector default, which maps bot -> bot.
gestalt invoke slack chat.postMessage -p channel=C123 -p text=hello

# Selects the user OAuth credential, and actor is omitted from the Slack HTTP request.
gestalt invoke slack chat.postMessage -p actor=user -p channel=C123 -p text=hello

# Uses an explicit user credential for an operation that only inherited the REST surface fallback.
gestalt invoke slack chat.scheduleMessage -p _connection=default -p channel=C123 -p text=hello -p post_at:=1770000000
```

`connectionSelector.default` is a selector value, not a connection name. The selected value maps through `values` to the concrete connection. Selector parameters are normal invocation parameters and are forwarded upstream unless the parameter is marked `internal: true`.

An operation may use `connection` as a static binding, or use `connectionSelector.default` as the default dynamic selection. It cannot declare both `connection` and `connectionSelector.default`, because the selector default would make the explicit operation connection unreachable. Selector parameters must be declared in the operation parameter list.

## Validation

- `go test ./internal/bootstrap ./internal/invocation ./internal/server ./internal/composite ./internal/providerhost ./internal/config ./core/integration`
- `golangci-lint run`
- `git diff --check`
- `python3 -m json.tool sdk/providermanifest/v1/manifest.jsonschema.json >/dev/null`
