### PR TITLE
Remove legacy auth lockfile bucket support

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -49,7 +49,6 @@ type Lockfile struct {
 	Version             int                          `json:"version"`
 	Providers           map[string]LockProviderEntry `json:"providers"`
 	Authentication      map[string]LockEntry         `json:"authentication,omitempty"`
-	LegacyAuth          map[string]LockEntry         `json:"auth,omitempty"`
 	Authorization       map[string]LockEntry         `json:"authorization,omitempty"`
 	ExternalCredentials map[string]LockEntry         `json:"externalCredentials,omitempty"`
 	IndexedDBs          map[string]LockEntry         `json:"indexeddbs,omitempty"`
@@ -1076,6 +1075,9 @@ func ReadLockfile(path string) (*Lockfile, error) {
 	if err := json.Unmarshal(data, &header); err != nil {
 		return nil, fmt.Errorf("parsing lockfile %s: %w", path, err)
 	}
+	if err := rejectLegacyAuthLockBucket(data, header.Schema != ""); err != nil {
+		return nil, err
+	}
 
 	if header.Schema != "" {
 		var lock providerLockfile
@@ -1097,6 +1099,26 @@ func ReadLockfile(path string) (*Lockfile, error) {
 		return nil, fmt.Errorf("parsing lockfile %s: %w", path, err)
 	}
 	return normalizeLockfile(&lock), nil
+}
+
+func rejectLegacyAuthLockBucket(data []byte, rejectProviderAuthBucket bool) error {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("parsing lockfile fields: %w", err)
+	}
+	if _, ok := raw["auth"]; ok {
+		return fmt.Errorf(`unsupported lockfile field "auth"; run ` + "`gestaltd init`" + ` to rewrite authentication providers under "authentication"`)
+	}
+	if rejectProviderAuthBucket {
+		providers, ok := raw["providers"].(map[string]any)
+		if !ok {
+			return nil
+		}
+		if _, ok := providers["auth"]; ok {
+			return fmt.Errorf(`unsupported lockfile field "providers.auth"; run ` + "`gestaltd init`" + ` to rewrite authentication providers under "providers.authentication"`)
+		}
+	}
+	return nil
 }
 
 func WriteLockfile(path string, lock *Lockfile) error {

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3557,6 +3557,102 @@ func TestReadLockfile_RejectsUnsupportedVersion(t *testing.T) {
 	}
 }
 
+func TestReadLockfile_RejectsLegacyAuthLockBuckets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		lock    string
+		wantErr string
+	}{
+		{
+			name: "runtime lockfile",
+			lock: `{
+  "version": 10,
+  "providers": {},
+  "auth": {
+    "oauth": {
+      "fingerprint": "auth-fp",
+      "source": "github.com/example/auth",
+      "manifest": ".gestaltd/auth/oauth/manifest.yaml"
+    }
+  }
+}
+`,
+			wantErr: `unsupported lockfile field "auth"`,
+		},
+		{
+			name: "provider lockfile",
+			lock: `{
+  "schema": "gestaltd-provider-lock",
+  "schemaVersion": 5,
+  "revision": 0,
+  "providers": {
+    "auth": {
+      "oauth": {
+        "inputDigest": "auth-fp",
+        "package": "github.com/example/auth",
+        "kind": "authentication",
+        "runtime": "executable"
+      }
+    }
+  }
+}
+`,
+			wantErr: `unsupported lockfile field "providers.auth"`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			lockPath := filepath.Join(dir, InitLockfileName)
+			if err := os.WriteFile(lockPath, []byte(tt.lock), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			_, err := ReadLockfile(lockPath)
+			if err == nil {
+				t.Fatal("expected error for legacy auth lock bucket")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestReadLockfile_AllowsRuntimeProviderNamedAuth(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, InitLockfileName)
+	if err := os.WriteFile(lockPath, []byte(`{
+  "version": 10,
+  "providers": {
+    "auth": {
+      "fingerprint": "plugin-fp",
+      "source": "github.com/example/auth-plugin",
+      "manifest": ".gestaltd/providers/auth/manifest.yaml"
+    }
+  }
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	lock, err := ReadLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if got := lock.Providers["auth"].Source; got != "github.com/example/auth-plugin" {
+		t.Fatalf("provider auth source = %q, want %q", got, "github.com/example/auth-plugin")
+	}
+}
+
 func TestReadLockfile_RejectsLegacyUILockShapeBeforeUnmarshal(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -34,7 +34,6 @@ type providerLockfile struct {
 type providerLockBuckets struct {
 	Plugin              map[string]portableLockEntry `json:"plugin,omitempty"`
 	Authentication      map[string]portableLockEntry `json:"authentication,omitempty"`
-	LegacyAuth          map[string]portableLockEntry `json:"auth,omitempty"`
 	Authorization       map[string]portableLockEntry `json:"authorization,omitempty"`
 	ExternalCredentials map[string]portableLockEntry `json:"externalCredentials,omitempty"`
 	IndexedDB           map[string]portableLockEntry `json:"indexeddb,omitempty"`
@@ -83,8 +82,6 @@ func normalizeLockfile(lock *Lockfile) *Lockfile {
 	if lock == nil {
 		return newLockfile()
 	}
-	lock.Authentication = mergeLockEntries(lock.Authentication, lock.LegacyAuth)
-	lock.LegacyAuth = nil
 	if lock.Version == 0 {
 		lock.Version = LockVersion
 	}
@@ -131,44 +128,6 @@ func normalizeLockfile(lock *Lockfile) *Lockfile {
 		lock.UIs = make(map[string]LockUIEntry)
 	}
 	return lock
-}
-
-func mergeLockEntries(primary, legacy map[string]LockEntry) map[string]LockEntry {
-	switch {
-	case primary == nil && legacy == nil:
-		return nil
-	case primary == nil:
-		return maps.Clone(legacy)
-	case legacy == nil:
-		return primary
-	default:
-		for name := range legacy {
-			if _, exists := primary[name]; exists {
-				continue
-			}
-			primary[name] = legacy[name]
-		}
-		return primary
-	}
-}
-
-func mergePortableLockEntries(primary, legacy map[string]portableLockEntry) map[string]portableLockEntry {
-	switch {
-	case primary == nil && legacy == nil:
-		return nil
-	case primary == nil:
-		return maps.Clone(legacy)
-	case legacy == nil:
-		return primary
-	default:
-		for name, entry := range legacy {
-			if _, exists := primary[name]; exists {
-				continue
-			}
-			primary[name] = entry
-		}
-		return primary
-	}
 }
 
 func providerLockKinds() []string {
@@ -259,7 +218,7 @@ func (lock *providerLockfile) toLockfile() *Lockfile {
 		return runtimeLock
 	}
 	runtimeLock.Providers = lockEntriesFromPortableEntries(lock.Providers.Plugin)
-	runtimeLock.Authentication = lockEntriesFromPortableEntries(mergePortableLockEntries(lock.Providers.Authentication, lock.Providers.LegacyAuth))
+	runtimeLock.Authentication = lockEntriesFromPortableEntries(lock.Providers.Authentication)
 	runtimeLock.Authorization = lockEntriesFromPortableEntries(lock.Providers.Authorization)
 	runtimeLock.ExternalCredentials = lockEntriesFromPortableEntries(lock.Providers.ExternalCredentials)
 	runtimeLock.IndexedDBs = lockEntriesFromPortableEntries(lock.Providers.IndexedDB)


### PR DESCRIPTION
## Summary

Remove support for the legacy lockfile `auth` bucket. Lockfiles must now use canonical authentication buckets only.

Removed interface:
- top-level runtime lockfile `auth`
- schema lockfile `providers.auth`
- automatic merging from `auth` into `authentication`

Legacy `auth` buckets now fail fast with a `gestaltd init` rewrite hint instead of being silently normalized.

## Canonical Runtime Lockfile Example

```json
{
  "version": 10,
  "authentication": {
    "oidc": {
      "fingerprint": "...",
      "manifest": ".gestaltd/auth/oidc/manifest.yaml"
    }
  }
}
```

## Canonical Provider Lockfile Example

```json
{
  "schema": "gestaltd-provider-lock",
  "schemaVersion": 5,
  "providers": {
    "authentication": {
      "oidc": {
        "inputDigest": "...",
        "package": "github.com/example/auth",
        "kind": "authentication",
        "runtime": "executable"
      }
    }
  }
}
```

## Validation

- `go test ./internal/operator -run 'TestReadLockfile|TestLifecycle|TestInit|TestLoadForExecution' -count=1`
- `go test ./internal/operator ./cmd/gestaltd -count=1`
- `git diff --check HEAD~1..HEAD`
