### PR TITLE
agent: skip unavailable plugin-scoped tool search providers

### DIFF
--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -882,8 +882,7 @@ func (m *Manager) searchTools(ctx context.Context, p *principal.Principal, req c
 	if err != nil {
 		return nil, err
 	}
-	skipUnavailable := len(refs) == 0
-	candidates, err := m.searchToolCandidates(ctx, p, refs, req.Query, skipUnavailable)
+	candidates, err := m.searchToolCandidates(ctx, p, refs, req.Query, true)
 	if err != nil {
 		return nil, err
 	}
@@ -894,20 +893,22 @@ func (m *Manager) searchTools(ctx context.Context, p *principal.Principal, req c
 	if maxResults > 20 {
 		maxResults = 20
 	}
-	tools, err := m.resolveAgentToolCandidates(ctx, p, candidates, maxResults, skipUnavailable)
+	tools, err := m.resolveAgentToolCandidates(ctx, p, candidates, maxResults, len(refs) > 0)
 	if err != nil {
 		return nil, err
 	}
 	return &coreagent.SearchToolsResponse{Tools: tools}, nil
 }
 
-func (m *Manager) resolveAgentToolCandidates(ctx context.Context, p *principal.Principal, candidates []agentToolSearchCandidate, maxResults int, skipUnavailable bool) ([]coreagent.Tool, error) {
+func (m *Manager) resolveAgentToolCandidates(ctx context.Context, p *principal.Principal, candidates []agentToolSearchCandidate, maxResults int, failIfOnlyUnavailable bool) ([]coreagent.Tool, error) {
 	tools := make([]coreagent.Tool, 0, len(candidates))
 	if maxResults > 0 {
 		tools = make([]coreagent.Tool, 0, min(maxResults, len(candidates)))
 	}
 	seen := map[string]struct{}{}
-	for _, candidate := range candidates {
+	var firstUnavailableErr error
+	for i := range candidates {
+		candidate := &candidates[i]
 		if maxResults > 0 && len(tools) >= maxResults {
 			break
 		}
@@ -916,7 +917,10 @@ func (m *Manager) resolveAgentToolCandidates(ctx context.Context, p *principal.P
 			if errors.Is(err, invocation.ErrAuthorizationDenied) || errors.Is(err, invocation.ErrProviderNotFound) || errors.Is(err, invocation.ErrOperationNotFound) {
 				continue
 			}
-			if skipUnavailable && agentToolSearchUnavailable(err) {
+			if candidate.skipUnavailable && agentToolSearchUnavailable(err) {
+				if firstUnavailableErr == nil {
+					firstUnavailableErr = err
+				}
 				continue
 			}
 			return nil, err
@@ -926,6 +930,9 @@ func (m *Manager) resolveAgentToolCandidates(ctx context.Context, p *principal.P
 		}
 		seen[tool.ID] = struct{}{}
 		tools = append(tools, tool)
+	}
+	if len(tools) == 0 && failIfOnlyUnavailable && firstUnavailableErr != nil {
+		return nil, firstUnavailableErr
 	}
 	return tools, nil
 }
@@ -1061,8 +1068,9 @@ func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref c
 }
 
 type agentToolSearchCandidate struct {
-	ref   coreagent.ToolRef
-	score int
+	ref             coreagent.ToolRef
+	score           int
+	skipUnavailable bool
 }
 
 func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef, query string, skipUnavailable bool) ([]agentToolSearchCandidate, error) {
@@ -1076,6 +1084,7 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 	}
 	query = strings.TrimSpace(query)
 	candidates := make([]agentToolSearchCandidate, 0)
+	var firstUnavailableErr error
 	for _, pluginName := range providerNames {
 		pluginName = strings.TrimSpace(pluginName)
 		if pluginName == "" {
@@ -1094,7 +1103,11 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 		for _, searchRef := range scope.refsForProvider(pluginName) {
 			cat, err := m.catalogForAgentToolSearch(ctx, p, prov, pluginName, searchRef)
 			if err != nil {
-				if skipUnavailable && agentToolSearchUnavailable(err) {
+				refSkipsUnavailable := skipUnavailable && agentToolSearchRefSkipsUnavailable(searchRef)
+				if refSkipsUnavailable && agentToolSearchUnavailable(err) {
+					if firstUnavailableErr == nil {
+						firstUnavailableErr = err
+					}
 					continue
 				}
 				return nil, err
@@ -1128,9 +1141,12 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 				}
 				ref.Plugin = pluginName
 				ref.Operation = operation
-				candidates = append(candidates, agentToolSearchCandidate{ref: ref, score: score})
+				candidates = append(candidates, agentToolSearchCandidate{ref: ref, score: score, skipUnavailable: skipUnavailable && agentToolSearchRefSkipsUnavailable(searchRef)})
 			}
 		}
+	}
+	if len(candidates) == 0 && !scope.all && firstUnavailableErr != nil {
+		return nil, firstUnavailableErr
 	}
 	sort.SliceStable(candidates, func(i, j int) bool {
 		if candidates[i].score != candidates[j].score {
@@ -1150,6 +1166,10 @@ func agentToolSearchUnavailable(err error) bool {
 		errors.Is(err, invocation.ErrReconnectRequired) ||
 		errors.Is(err, invocation.ErrNotAuthenticated) ||
 		errors.Is(err, invocation.ErrScopeDenied)
+}
+
+func agentToolSearchRefSkipsUnavailable(ref coreagent.ToolRef) bool {
+	return strings.TrimSpace(ref.Operation) == ""
 }
 
 func (m *Manager) catalogForAgentToolSearch(ctx context.Context, p *principal.Principal, prov core.Provider, pluginName string, ref coreagent.ToolRef) (*catalog.Catalog, error) {

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -35,6 +35,22 @@ func (p *sessionCatalogProvider) CatalogForRequest(context.Context, string) (*ca
 	return p.sessionCatalog, nil
 }
 
+type tokenErrorInvoker struct {
+	providerName string
+	err          error
+}
+
+func (i tokenErrorInvoker) Invoke(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+	return nil, nil
+}
+
+func (i tokenErrorInvoker) ResolveToken(ctx context.Context, _ *principal.Principal, providerName, _, _ string) (context.Context, string, error) {
+	if i.providerName != "" && providerName != i.providerName {
+		return ctx, "", nil
+	}
+	return ctx, "", i.err
+}
+
 func TestSearchToolsSearchesAuthorizedCatalogWhenNoRefsDefined(t *testing.T) {
 	t.Parallel()
 
@@ -213,6 +229,157 @@ func TestSearchToolsDiscoversSessionCatalogOperations(t *testing.T) {
 	}
 	if resp.Tools[0].Target.Plugin != "docs" || resp.Tools[0].Target.Operation != "dynamic_search" {
 		t.Fatalf("tool target = %#v, want docs.dynamic_search", resp.Tools[0].Target)
+	}
+}
+
+func TestSearchToolsSkipsUnavailablePluginScopedProviders(t *testing.T) {
+	t.Parallel()
+
+	ashby := &sessionCatalogProvider{
+		catalogCountingProvider: catalogCountingProvider{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "ashby",
+				ConnMode: core.ConnectionModeUser,
+			},
+		},
+	}
+	linear := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "linear",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				DisplayName: "Linear",
+				Operations: []catalog.CatalogOperation{{
+					ID:       "searchIssues",
+					Title:    "Search Linear Issues",
+					ReadOnly: true,
+				}},
+			},
+		},
+	}
+	manager := New(Config{
+		Providers: testutil.NewProviderRegistry(t, ashby, linear),
+		Invoker:   tokenErrorInvoker{providerName: "ashby", err: invocation.ErrNoCredential},
+	})
+
+	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query: "Linear",
+		ToolRefs: []coreagent.ToolRef{
+			{Plugin: "ashby"},
+			{Plugin: "linear"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SearchTools: %v", err)
+	}
+	if len(resp.Tools) != 1 {
+		t.Fatalf("SearchTools returned %d tools, want 1", len(resp.Tools))
+	}
+	if resp.Tools[0].Target.Plugin != "linear" || resp.Tools[0].Target.Operation != "searchIssues" {
+		t.Fatalf("tool target = %#v, want linear.searchIssues", resp.Tools[0].Target)
+	}
+}
+
+func TestSearchToolsReturnsUnavailableWhenScopedSearchHasNoCandidates(t *testing.T) {
+	t.Parallel()
+
+	ashby := &sessionCatalogProvider{
+		catalogCountingProvider: catalogCountingProvider{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "ashby",
+				ConnMode: core.ConnectionModeUser,
+			},
+		},
+	}
+	manager := New(Config{
+		Providers: testutil.NewProviderRegistry(t, ashby),
+		Invoker:   tokenErrorInvoker{providerName: "ashby", err: invocation.ErrNoCredential},
+	})
+
+	_, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query:    "Ashby",
+		ToolRefs: []coreagent.ToolRef{{Plugin: "ashby"}},
+	})
+	if !errors.Is(err, invocation.ErrNoCredential) {
+		t.Fatalf("SearchTools error = %v, want ErrNoCredential", err)
+	}
+}
+
+func TestSearchToolsKeepsExactOperationRefsStrict(t *testing.T) {
+	t.Parallel()
+
+	ashby := &sessionCatalogProvider{
+		catalogCountingProvider: catalogCountingProvider{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "ashby",
+				ConnMode: core.ConnectionModeUser,
+			},
+		},
+	}
+	manager := New(Config{
+		Providers: testutil.NewProviderRegistry(t, ashby),
+		Invoker:   tokenErrorInvoker{providerName: "ashby", err: invocation.ErrNoCredential},
+	})
+
+	_, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query: "candidate",
+		ToolRefs: []coreagent.ToolRef{{
+			Plugin:    "ashby",
+			Operation: "candidateSearch",
+		}},
+	})
+	if !errors.Is(err, invocation.ErrNoCredential) {
+		t.Fatalf("SearchTools error = %v, want ErrNoCredential", err)
+	}
+}
+
+func TestSearchToolsKeepsMixedExactOperationRefsStrict(t *testing.T) {
+	t.Parallel()
+
+	ashby := &sessionCatalogProvider{
+		catalogCountingProvider: catalogCountingProvider{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "ashby",
+				ConnMode: core.ConnectionModeUser,
+			},
+		},
+	}
+	linear := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "linear",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				DisplayName: "Linear",
+				Operations: []catalog.CatalogOperation{{
+					ID:       "searchIssues",
+					Title:    "Search Linear Issues",
+					ReadOnly: true,
+				}},
+			},
+		},
+	}
+	manager := New(Config{
+		Providers: testutil.NewProviderRegistry(t, ashby, linear),
+		Invoker:   tokenErrorInvoker{providerName: "ashby", err: invocation.ErrNoCredential},
+	})
+
+	_, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query: "Linear",
+		ToolRefs: []coreagent.ToolRef{
+			{Plugin: "linear"},
+			{Plugin: "ashby", Operation: "candidateSearch"},
+		},
+	})
+	if !errors.Is(err, invocation.ErrNoCredential) {
+		t.Fatalf("SearchTools error = %v, want ErrNoCredential", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes agent native tool discovery when the allowed tool scope includes an unavailable provider. `SearchTools` already skipped unavailable integrations for unconstrained global discovery, but agent turns pass plugin-scoped `toolRefs`, so an unconnected provider such as `ashby` could fail the whole `__gestalt_search_tools__` call before connected providers like `linear` were considered.

## Behavior contract

No proto/interface fields are added. The existing `SearchTools` / `ResolveTools` contract is clarified:

```go
// Discovery is tolerant when another scoped provider can satisfy the search.
SearchTools(query: "Linear", toolRefs: []ToolRef{
  {Plugin: "ashby"},
  {Plugin: "linear"},
})
// If ashby has no stored credential, SearchTools skips ashby and can still
// return tools such as linear.searchIssues.

// A scoped search that only resolves to unavailable providers remains actionable.
SearchTools(query: "Ashby", toolRefs: []ToolRef{
  {Plugin: "ashby"},
})
// Returns the ashby credential error instead of silently returning zero tools.

// Exact operation refs remain strict, even when mixed with plugin-scoped refs.
SearchTools(query: "Linear", toolRefs: []ToolRef{
  {Plugin: "linear"},
  {Plugin: "ashby", Operation: "candidateSearch"},
})
// Returns the ashby credential error because candidateSearch is exact.

// Explicit execution/preflight remains strict.
ResolveTools(toolRefs: []ToolRef{
  {Plugin: "ashby", Operation: "candidateSearch"},
})
// Still returns the provider credential error.
```

## Implementation

- Treat `SearchTools` as discovery-oriented for empty refs or plugin-scoped refs.
- Apply unavailable-provider skipping per ref, not per request.
- Return the first skipped unavailable error when an explicitly scoped search produces no candidates/tools.
- Keep exact-operation refs strict in `SearchTools`, including mixed requests.
- Keep `ResolveTools` strict for invocation/preflight.
- Add focused manager/bootstrap contract coverage for mixed `ashby` / `linear` discovery, exact-operation strictness, mixed-ref strictness, and the no-usable-tools scoped credential error.

## Verification

```bash
cd gestaltd
golangci-lint run ./internal/agentmanager
go test ./internal/agentmanager
go test ./internal/bootstrap -run TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks
go test ./internal/agentmanager ./internal/server -run 'Test(SearchTools|Agent)'
```
