### PR TITLE
Remove core workflow target flat plugin fields

### DIFF
--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -33,13 +33,8 @@ type Actor struct {
 }
 
 type Target struct {
-	PluginName string
-	Operation  string
-	Connection string
-	Instance   string
-	Input      map[string]any
-	Plugin     *PluginTarget
-	Agent      *AgentTarget
+	Plugin *PluginTarget
+	Agent  *AgentTarget
 }
 
 type PluginTarget struct {
@@ -273,28 +268,8 @@ type Host interface {
 	InvokeOperation(ctx context.Context, req InvokeOperationRequest) (*InvokeOperationResponse, error)
 }
 
-func (t Target) PluginTarget() PluginTarget {
-	if t.Plugin != nil {
-		return *t.Plugin
-	}
-	return PluginTarget{
-		PluginName: t.PluginName,
-		Operation:  t.Operation,
-		Connection: t.Connection,
-		Instance:   t.Instance,
-		Input:      t.Input,
-	}
-}
-
-func (t Target) AgentTarget() AgentTarget {
-	if t.Agent != nil {
-		return *t.Agent
-	}
-	return AgentTarget{}
-}
-
 func TargetFingerprint(target Target) (string, error) {
-	if target.Agent != nil && PluginTargetSet(target.PluginTarget()) {
+	if target.Agent != nil && target.Plugin != nil && PluginTargetSet(*target.Plugin) {
 		return "", fmt.Errorf("target cannot include both agent and plugin fields")
 	}
 	payload, err := json.Marshal(normalizedTargetFingerprintPayload(target))
@@ -305,10 +280,20 @@ func TargetFingerprint(target Target) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func normalizedTargetFingerprintPayload(target Target) Target {
-	out := Target{}
+type targetFingerprintPayload struct {
+	PluginName string
+	Operation  string
+	Connection string
+	Instance   string
+	Input      map[string]any
+	Plugin     *PluginTarget
+	Agent      *AgentTarget
+}
+
+func normalizedTargetFingerprintPayload(target Target) targetFingerprintPayload {
+	out := targetFingerprintPayload{}
 	if target.Agent != nil {
-		agentTarget := target.AgentTarget()
+		agentTarget := *target.Agent
 		if len(agentTarget.Messages) == 0 {
 			agentTarget.Messages = nil
 		}
@@ -327,8 +312,8 @@ func normalizedTargetFingerprintPayload(target Target) Target {
 		out.Agent = &agentTarget
 		return out
 	}
-	pluginTarget := target.PluginTarget()
-	if PluginTargetSet(pluginTarget) {
+	if target.Plugin != nil && PluginTargetSet(*target.Plugin) {
+		pluginTarget := *target.Plugin
 		if len(pluginTarget.Input) == 0 {
 			pluginTarget.Input = nil
 		}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -55,6 +56,10 @@ import (
 
 func storeWorkflowExecutionRefForTarget(t *testing.T, deps bootstrap.Deps, providerName string, target coreworkflow.Target) string {
 	t.Helper()
+	pluginTarget := target.Plugin
+	if pluginTarget == nil {
+		t.Fatalf("workflow target plugin is nil: %#v", target)
+	}
 	provider, err := deps.WorkflowRuntime.ResolveProvider(providerName)
 	if err != nil {
 		t.Fatalf("resolve workflow provider %q: %v", providerName, err)
@@ -64,13 +69,13 @@ func storeWorkflowExecutionRefForTarget(t *testing.T, deps bootstrap.Deps, provi
 		t.Fatalf("workflow provider %q does not support execution refs", providerName)
 	}
 	ref, err := store.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           fmt.Sprintf("test:%s:%s:%s", strings.ReplaceAll(t.Name(), "/", "_"), providerName, target.Operation),
+		ID:           fmt.Sprintf("test:%s:%s:%s", strings.ReplaceAll(t.Name(), "/", "_"), providerName, pluginTarget.Operation),
 		ProviderName: providerName,
 		Target:       target,
 		SubjectID:    "system:config",
 		Permissions: []core.AccessPermission{{
-			Plugin:     target.PluginName,
-			Operations: []string{target.Operation},
+			Plugin:     pluginTarget.PluginName,
+			Operations: []string{pluginTarget.Operation},
 		}},
 	})
 	if err != nil {
@@ -1376,9 +1381,7 @@ func cloneBootstrapWorkflowExecutionRef(ref *coreworkflow.ExecutionReference) *c
 		return nil
 	}
 	clone := *ref
-	if ref.Target.Input != nil {
-		clone.Target.Input = maps.Clone(ref.Target.Input)
-	}
+	clone.Target = cloneBootstrapWorkflowTarget(ref.Target)
 	clone.Permissions = append([]core.AccessPermission(nil), ref.Permissions...)
 	for i := range clone.Permissions {
 		clone.Permissions[i].Operations = append([]string(nil), clone.Permissions[i].Operations...)
@@ -1392,6 +1395,25 @@ func cloneBootstrapWorkflowExecutionRef(ref *coreworkflow.ExecutionReference) *c
 		clone.RevokedAt = &revokedAt
 	}
 	return &clone
+}
+
+func cloneBootstrapWorkflowTarget(target coreworkflow.Target) coreworkflow.Target {
+	clone := coreworkflow.Target{}
+	if target.Plugin != nil {
+		plugin := *target.Plugin
+		plugin.Input = maps.Clone(plugin.Input)
+		clone.Plugin = &plugin
+	}
+	if target.Agent != nil {
+		agent := *target.Agent
+		agent.Messages = slices.Clone(agent.Messages)
+		agent.ToolRefs = slices.Clone(agent.ToolRefs)
+		agent.ResponseSchema = maps.Clone(agent.ResponseSchema)
+		agent.ProviderOptions = maps.Clone(agent.ProviderOptions)
+		agent.Metadata = maps.Clone(agent.Metadata)
+		clone.Agent = &agent
+	}
+	return clone
 }
 
 type trackedIndexedDB struct {
@@ -1672,6 +1694,23 @@ func workflowFixtureTarget(plugin, operation string, input map[string]any) *conf
 			Name:      plugin,
 			Operation: operation,
 			Input:     maps.Clone(input),
+		},
+	}
+}
+
+func requireCoreWorkflowPluginTarget(t *testing.T, target coreworkflow.Target) *coreworkflow.PluginTarget {
+	t.Helper()
+	if target.Plugin == nil {
+		t.Fatalf("target plugin is nil: %#v", target)
+	}
+	return target.Plugin
+}
+
+func coreWorkflowPluginTarget(pluginName, operation string) coreworkflow.Target {
+	return coreworkflow.Target{
+		Plugin: &coreworkflow.PluginTarget{
+			PluginName: pluginName,
+			Operation:  operation,
 		},
 	}
 }
@@ -3563,11 +3602,8 @@ func TestBootstrapRoutesWorkflowIndexedDBHostServices(t *testing.T) {
 	if _, err := executionRefs.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
 		ID:           "workflow_schedule:sched-test:ref-test",
 		ProviderName: "basic",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-		},
-		SubjectID: "user:ada",
+		Target:       coreWorkflowPluginTarget("roadmap", "sync"),
+		SubjectID:    "user:ada",
 	}); err != nil {
 		t.Fatalf("PutExecutionReference: %v", err)
 	}
@@ -3674,11 +3710,12 @@ func TestBootstrapAppliesConfiguredWorkflowSchedules(t *testing.T) {
 	if got.Cron != "0 2 * * *" || got.Timezone != "America/New_York" {
 		t.Fatalf("schedule timing = %#v", got)
 	}
-	if got.Target.PluginName != "roadmap" || got.Target.Operation != "sync" {
+	gotPlugin := requireCoreWorkflowPluginTarget(t, got.Target)
+	if gotPlugin.PluginName != "roadmap" || gotPlugin.Operation != "sync" {
 		t.Fatalf("target = %#v", got.Target)
 	}
-	if got.Target.Input["source"] != "yaml" {
-		t.Fatalf("target input = %#v", got.Target.Input)
+	if gotPlugin.Input["source"] != "yaml" {
+		t.Fatalf("target input = %#v", gotPlugin.Input)
 	}
 	if got.RequestedBy.SubjectID != "system:config" || got.RequestedBy.SubjectKind != "system" || got.RequestedBy.AuthSource != "config" {
 		t.Fatalf("requestedBy = %#v", got.RequestedBy)
@@ -4192,7 +4229,7 @@ func TestBootstrapReAdoptsManagedSchedulesWhenOwnershipStateIsMissing(t *testing
 		t.Fatalf("initial upserted schedules = %d, want 1", len(provider.upsertedSchedules))
 	}
 	initialExecutionRef := provider.upsertedSchedules[0].ExecutionRef
-	provider.schedules[workflowConfigScheduleID("nightly_sync")].Target.Input = map[string]any{
+	provider.schedules[workflowConfigScheduleID("nightly_sync")].Target.Plugin.Input = map[string]any{
 		"limit": float64(1),
 	}
 
@@ -4519,11 +4556,12 @@ func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
 	if got.Match.Type != "task.updated" || got.Match.Source != "roadmap" || got.Match.Subject != "" {
 		t.Fatalf("match = %#v", got.Match)
 	}
-	if got.Target.PluginName != "roadmap" || got.Target.Operation != "sync" {
+	gotPlugin := requireCoreWorkflowPluginTarget(t, got.Target)
+	if gotPlugin.PluginName != "roadmap" || gotPlugin.Operation != "sync" {
 		t.Fatalf("target = %#v", got.Target)
 	}
-	if got.Target.Input["source"] != "yaml" {
-		t.Fatalf("target input = %#v", got.Target.Input)
+	if gotPlugin.Input["source"] != "yaml" {
+		t.Fatalf("target input = %#v", gotPlugin.Input)
 	}
 	if got.RequestedBy.SubjectID != "system:config" || got.RequestedBy.SubjectKind != "system" || got.RequestedBy.AuthSource != "config" {
 		t.Fatalf("requestedBy = %#v", got.RequestedBy)
@@ -4885,7 +4923,7 @@ func TestBootstrapReAdoptsManagedEventTriggersWhenOwnershipStateIsMissing(t *tes
 	if len(provider.upsertedEventTriggers) != 1 {
 		t.Fatalf("initial upserted event triggers = %d, want 1", len(provider.upsertedEventTriggers))
 	}
-	provider.eventTriggers[workflowConfigEventTriggerID("task_updated")].Target.Input = map[string]any{
+	provider.eventTriggers[workflowConfigEventTriggerID("task_updated")].Target.Plugin.Input = map[string]any{
 		"limit": float64(1),
 	}
 
@@ -5082,10 +5120,7 @@ func TestBootstrapStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 		}); err != nil {
 			return nil, fmt.Errorf("store startup token: %w", err)
 		}
-		executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-		})
+		executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreWorkflowPluginTarget("roadmap", "sync"))
 		resp, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
 			Target: &proto.BoundWorkflowTarget{
 				Plugin: &proto.BoundWorkflowPluginTarget{
@@ -5143,10 +5178,7 @@ func TestValidateStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 		}); err != nil {
 			return nil, fmt.Errorf("store startup token: %w", err)
 		}
-		executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-		})
+		executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreWorkflowPluginTarget("roadmap", "sync"))
 		resp, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
 			Target: &proto.BoundWorkflowTarget{
 				Plugin: &proto.BoundWorkflowPluginTarget{
@@ -5691,10 +5723,7 @@ func TestValidateManagedWorkflowStartupCallbackUsesPreparedProviderStub(t *testi
 				}); err != nil {
 					return nil, fmt.Errorf("store startup token: %w", err)
 				}
-				executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreworkflow.Target{
-					PluginName: "roadmap",
-					Operation:  "sync",
-				})
+				executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreWorkflowPluginTarget("roadmap", "sync"))
 				resp, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
 					Target: &proto.BoundWorkflowTarget{
 						Plugin: &proto.BoundWorkflowPluginTarget{
@@ -5794,10 +5823,7 @@ func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t 
 		}
 		req := coreworkflow.InvokeOperationRequest{
 			ProviderName: name,
-			Target: coreworkflow.Target{
-				PluginName: "roadmap",
-				Operation:  "sync",
-			},
+			Target:       coreWorkflowPluginTarget("roadmap", "sync"),
 		}
 		configPrincipal := &principal.Principal{
 			SubjectID:           "system:config",

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -2036,13 +2036,22 @@ func cloneManagedEventTrigger(value *workflowmanager.ManagedEventTrigger) *workf
 }
 
 func cloneWorkflowTarget(value coreworkflow.Target) coreworkflow.Target {
-	return coreworkflow.Target{
-		PluginName: value.PluginName,
-		Operation:  value.Operation,
-		Connection: value.Connection,
-		Instance:   value.Instance,
-		Input:      maps.Clone(value.Input),
+	out := coreworkflow.Target{}
+	if value.Plugin != nil {
+		plugin := *value.Plugin
+		plugin.Input = maps.Clone(plugin.Input)
+		out.Plugin = &plugin
 	}
+	if value.Agent != nil {
+		agent := *value.Agent
+		agent.Messages = slices.Clone(agent.Messages)
+		agent.ToolRefs = slices.Clone(agent.ToolRefs)
+		agent.ResponseSchema = maps.Clone(agent.ResponseSchema)
+		agent.ProviderOptions = maps.Clone(agent.ProviderOptions)
+		agent.Metadata = maps.Clone(agent.Metadata)
+		out.Agent = &agent
+	}
+	return out
 }
 
 func cloneWorkflowEventMatch(value coreworkflow.EventMatch) coreworkflow.EventMatch {
@@ -7406,7 +7415,11 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 	if len(schedules) != 1 {
 		t.Fatalf("manager schedules len = %d, want 1", len(schedules))
 	}
-	if got := schedules[0].Schedule.Target.Operation; got != "sync" {
+	scheduleTarget := schedules[0].Schedule.Target.Plugin
+	if scheduleTarget == nil {
+		t.Fatalf("stored target plugin is nil: %#v", schedules[0].Schedule.Target)
+	}
+	if got := scheduleTarget.Operation; got != "sync" {
 		t.Fatalf("stored target operation = %q, want %q", got, "sync")
 	}
 	if got := manager.Subjects(); !slices.Equal(got, []string{"user:user-123", "user:user-123"}) {

--- a/gestaltd/internal/bootstrap/startup_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_proxy.go
@@ -363,7 +363,7 @@ func (p *startupWorkflowProviderProxy) await(ctx context.Context) (coreworkflow.
 }
 
 func (p *startupWorkflowProviderProxy) StartRun(ctx context.Context, req coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
-	provider, err := p.awaitForPlugin(ctx, req.Target.PluginName)
+	provider, err := p.awaitForPlugin(ctx, startupWorkflowTargetPluginName(req.Target))
 	if err != nil {
 		return nil, err
 	}
@@ -395,7 +395,7 @@ func (p *startupWorkflowProviderProxy) CancelRun(ctx context.Context, req corewo
 }
 
 func (p *startupWorkflowProviderProxy) UpsertSchedule(ctx context.Context, req coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
-	provider, err := p.awaitForPlugin(ctx, req.Target.PluginName)
+	provider, err := p.awaitForPlugin(ctx, startupWorkflowTargetPluginName(req.Target))
 	if err != nil {
 		return nil, err
 	}
@@ -443,7 +443,7 @@ func (p *startupWorkflowProviderProxy) ResumeSchedule(ctx context.Context, req c
 }
 
 func (p *startupWorkflowProviderProxy) UpsertEventTrigger(ctx context.Context, req coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
-	provider, err := p.awaitForPlugin(ctx, req.Target.PluginName)
+	provider, err := p.awaitForPlugin(ctx, startupWorkflowTargetPluginName(req.Target))
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +501,7 @@ func (p *startupWorkflowProviderProxy) PublishEvent(ctx context.Context, req cor
 func (p *startupWorkflowProviderProxy) PutExecutionReference(ctx context.Context, ref *coreworkflow.ExecutionReference) (*coreworkflow.ExecutionReference, error) {
 	pluginName := ""
 	if ref != nil {
-		pluginName = ref.Target.PluginName
+		pluginName = startupWorkflowTargetPluginName(ref.Target)
 	}
 	select {
 	case <-p.ready:
@@ -629,6 +629,13 @@ func (p *startupWorkflowProviderProxy) awaitForContextPlugin(ctx context.Context
 	return p.awaitForPlugin(ctx, pluginName)
 }
 
+func startupWorkflowTargetPluginName(target coreworkflow.Target) string {
+	if target.Plugin == nil {
+		return ""
+	}
+	return strings.TrimSpace(target.Plugin.PluginName)
+}
+
 func (p *startupWorkflowProviderProxy) beginPluginWait(pluginName string) (func(), error) {
 	if p == nil || p.tracker == nil {
 		return func() {}, nil
@@ -658,9 +665,7 @@ func cloneStartupWorkflowExecutionRef(ref *coreworkflow.ExecutionReference) *cor
 		return nil
 	}
 	clone := *ref
-	if ref.Target.Input != nil {
-		clone.Target.Input = maps.Clone(ref.Target.Input)
-	}
+	clone.Target = cloneStartupWorkflowTarget(ref.Target)
 	clone.Permissions = append([]core.AccessPermission(nil), ref.Permissions...)
 	for i := range clone.Permissions {
 		clone.Permissions[i].Operations = append([]string(nil), clone.Permissions[i].Operations...)
@@ -674,4 +679,23 @@ func cloneStartupWorkflowExecutionRef(ref *coreworkflow.ExecutionReference) *cor
 		clone.RevokedAt = &revokedAt
 	}
 	return &clone
+}
+
+func cloneStartupWorkflowTarget(target coreworkflow.Target) coreworkflow.Target {
+	clone := coreworkflow.Target{}
+	if target.Plugin != nil {
+		plugin := *target.Plugin
+		plugin.Input = maps.Clone(plugin.Input)
+		clone.Plugin = &plugin
+	}
+	if target.Agent != nil {
+		agent := *target.Agent
+		agent.Messages = slices.Clone(agent.Messages)
+		agent.ToolRefs = slices.Clone(agent.ToolRefs)
+		agent.ResponseSchema = maps.Clone(agent.ResponseSchema)
+		agent.Metadata = maps.Clone(agent.Metadata)
+		agent.ProviderOptions = maps.Clone(agent.ProviderOptions)
+		clone.Agent = &agent
+	}
+	return clone
 }

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -225,7 +225,10 @@ func workflowConfigTargetLabel(target coreworkflow.Target) string {
 		}
 		return "agent:" + providerName
 	}
-	return strings.TrimSpace(target.PluginTarget().PluginName)
+	if target.Plugin == nil {
+		return ""
+	}
+	return strings.TrimSpace(target.Plugin.PluginName)
 }
 
 func workflowConfigScheduleTarget(schedule config.WorkflowScheduleConfig) coreworkflow.Target {
@@ -251,12 +254,7 @@ func workflowConfigTarget(target *config.WorkflowTargetConfig) coreworkflow.Targ
 		Input:      maps.Clone(plugin.Input),
 	}
 	return coreworkflow.Target{
-		PluginName: pluginTarget.PluginName,
-		Operation:  pluginTarget.Operation,
-		Connection: pluginTarget.Connection,
-		Instance:   pluginTarget.Instance,
-		Input:      pluginTarget.Input,
-		Plugin:     &pluginTarget,
+		Plugin: &pluginTarget,
 	}
 }
 
@@ -387,7 +385,10 @@ func workflowExecutionRefPermissionsForTarget(target coreworkflow.Target) []core
 		}
 		return out
 	}
-	pluginTarget := target.PluginTarget()
+	if target.Plugin == nil {
+		return nil
+	}
+	pluginTarget := *target.Plugin
 	pluginName := pluginTarget.PluginName
 	operation := strings.TrimSpace(pluginTarget.Operation)
 	if pluginName == "" || operation == "" {
@@ -420,7 +421,10 @@ func workflowConfigExecutionReference(cfg *config.Config, providerName string, t
 		}
 		return ref, nil
 	}
-	if err := workflowConfigValidateNoUserCredentialTarget(cfg, target.PluginTarget().PluginName); err != nil {
+	if target.Plugin == nil {
+		return nil, fmt.Errorf("workflow target plugin is required")
+	}
+	if err := workflowConfigValidateNoUserCredentialTarget(cfg, target.Plugin.PluginName); err != nil {
 		return nil, err
 	}
 	return ref, nil

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -207,8 +207,7 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 	if invoker == nil {
 		return nil, fmt.Errorf("workflow runtime invoker is not configured")
 	}
-	targetPluginName := strings.TrimSpace(req.Target.PluginTarget().PluginName)
-	if targetPluginName == "" {
+	if req.Target.Plugin == nil || strings.TrimSpace(req.Target.Plugin.PluginName) == "" {
 		return nil, fmt.Errorf("workflow target plugin is required")
 	}
 	principalValue := principal.Canonicalized(principal.FromContext(ctx))
@@ -222,9 +221,10 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 		}
 		principalValue = executionReferencePrincipal(resolvedRef.SubjectID, resolvedRef.CredentialSubjectID, resolvedRef.Permissions)
 		target = resolvedRef.Target
-		pluginTarget := target.PluginTarget()
-		invokeConnection = strings.TrimSpace(pluginTarget.Connection)
-		invokeInstance = strings.TrimSpace(pluginTarget.Instance)
+		if target.Plugin != nil {
+			invokeConnection = strings.TrimSpace(target.Plugin.Connection)
+			invokeInstance = strings.TrimSpace(target.Plugin.Instance)
+		}
 	} else if principalValue == nil || strings.TrimSpace(principalValue.SubjectID) == "" {
 		return nil, fmt.Errorf("%w: workflow execution principal is required when execution_ref is omitted", invocation.ErrInternal)
 	}
@@ -235,7 +235,10 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 		ctx = invocation.WithConnection(ctx, invokeConnection)
 	}
 	params := workflowInvocationParams(req)
-	pluginTarget := target.PluginTarget()
+	if target.Plugin == nil {
+		return nil, fmt.Errorf("workflow target plugin is required")
+	}
+	pluginTarget := target.Plugin
 	result, err := invoker.Invoke(ctx, principalValue, pluginTarget.PluginName, invokeInstance, pluginTarget.Operation, params)
 	if err != nil {
 		return nil, err
@@ -292,8 +295,11 @@ func (r *workflowRuntime) resolveWorkflowExecutionRef(ctx context.Context, req c
 	if ref.Target.Agent != nil || req.Target.Agent != nil {
 		return nil, fmt.Errorf("%w: workflow execution ref %q target fingerprint is required for agent targets", invocation.ErrAuthorizationDenied, refID)
 	}
-	left := ref.Target.PluginTarget()
-	right := req.Target.PluginTarget()
+	if ref.Target.Plugin == nil || req.Target.Plugin == nil {
+		return nil, fmt.Errorf("%w: workflow execution ref %q target does not match the scheduled invocation", invocation.ErrAuthorizationDenied, refID)
+	}
+	left := *ref.Target.Plugin
+	right := *req.Target.Plugin
 	if strings.TrimSpace(left.PluginName) != strings.TrimSpace(right.PluginName) ||
 		strings.TrimSpace(left.Operation) != strings.TrimSpace(right.Operation) ||
 		strings.TrimSpace(left.Connection) != strings.TrimSpace(right.Connection) ||
@@ -304,7 +310,7 @@ func (r *workflowRuntime) resolveWorkflowExecutionRef(ctx context.Context, req c
 }
 
 func workflowTargetHasMixedKinds(target coreworkflow.Target) bool {
-	return target.Agent != nil && coreworkflow.PluginTargetSet(target.PluginTarget())
+	return target.Agent != nil && target.Plugin != nil && coreworkflow.PluginTargetSet(*target.Plugin)
 }
 
 func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.InvokeOperationRequest, agentManager agentmanager.Service) (*coreworkflow.InvokeOperationResponse, error) {
@@ -326,7 +332,10 @@ func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.Invo
 	} else if principalValue == nil || strings.TrimSpace(principalValue.SubjectID) == "" {
 		return nil, fmt.Errorf("%w: workflow execution principal is required when execution_ref is omitted", invocation.ErrInternal)
 	}
-	agentTarget := target.AgentTarget()
+	if target.Agent == nil {
+		return nil, fmt.Errorf("workflow agent target is required")
+	}
+	agentTarget := *target.Agent
 	timeout := workflowAgentTimeout(agentTarget.TimeoutSeconds)
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -429,7 +438,10 @@ func waitForWorkflowAgentTurn(ctx context.Context, agentManager agentmanager.Ser
 }
 
 func workflowInvocationParams(req coreworkflow.InvokeOperationRequest) map[string]any {
-	params := maps.Clone(req.Target.PluginTarget().Input)
+	var params map[string]any
+	if req.Target.Plugin != nil {
+		params = maps.Clone(req.Target.Plugin.Input)
+	}
 	if req.Input != nil {
 		if params == nil {
 			params = map[string]any{}
@@ -473,7 +485,7 @@ func workflowInvocationContext(req coreworkflow.InvokeOperationRequest) map[stri
 func workflowTargetContext(target coreworkflow.Target) map[string]any {
 	value := map[string]any{}
 	if target.Agent != nil {
-		agentTarget := target.AgentTarget()
+		agentTarget := *target.Agent
 		value["kind"] = "agent"
 		if providerName := strings.TrimSpace(agentTarget.ProviderName); providerName != "" {
 			value["agentProvider"] = providerName
@@ -499,7 +511,10 @@ func workflowTargetContext(target coreworkflow.Target) map[string]any {
 		}
 		return value
 	}
-	pluginTarget := target.PluginTarget()
+	if target.Plugin == nil {
+		return value
+	}
+	pluginTarget := *target.Plugin
 	plugin := map[string]any{}
 	if pluginName := strings.TrimSpace(pluginTarget.PluginName); pluginName != "" {
 		value["kind"] = "plugin"

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -30,6 +31,27 @@ import (
 type funcInvoker struct {
 	invoke func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error)
 }
+
+func testWorkflowPluginTarget(pluginName, operation string) coreworkflow.Target {
+	return testWorkflowPluginTargetWithInput(pluginName, operation, "", "", nil)
+}
+
+func testWorkflowPluginTargetWithInput(pluginName, operation, connection, instance string, input map[string]any) coreworkflow.Target {
+	return coreworkflow.Target{
+		Plugin: &coreworkflow.PluginTarget{
+			PluginName: pluginName,
+			Operation:  operation,
+			Connection: connection,
+			Instance:   instance,
+			Input:      input,
+		},
+	}
+}
+
+const (
+	legacyAgentWorkflowTargetFingerprint  = "35e6581a2588dfe3a3885a9e6a98f83fd8444d1408fb22d5d0df08e6811b2c5c"
+	legacyPluginWorkflowTargetFingerprint = "0df33294a540a423e6f3982c190e54505f0415c7856cc3389eb13042415e8796"
+)
 
 func (f funcInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	return f.invoke(ctx, p, providerName, instance, operation, params)
@@ -87,7 +109,7 @@ func cloneRuntimeExecutionRef(ref *coreworkflow.ExecutionReference) *coreworkflo
 		return nil
 	}
 	clone := *ref
-	clone.Target.Input = cloneMapAny(ref.Target.Input)
+	clone.Target = cloneRuntimeTarget(ref.Target)
 	clone.Permissions = append([]core.AccessPermission(nil), ref.Permissions...)
 	for i := range clone.Permissions {
 		clone.Permissions[i].Operations = append([]string(nil), ref.Permissions[i].Operations...)
@@ -101,6 +123,25 @@ func cloneRuntimeExecutionRef(ref *coreworkflow.ExecutionReference) *coreworkflo
 		clone.RevokedAt = &revokedAt
 	}
 	return &clone
+}
+
+func cloneRuntimeTarget(target coreworkflow.Target) coreworkflow.Target {
+	clone := coreworkflow.Target{}
+	if target.Plugin != nil {
+		plugin := *target.Plugin
+		plugin.Input = cloneMapAny(plugin.Input)
+		clone.Plugin = &plugin
+	}
+	if target.Agent != nil {
+		agent := *target.Agent
+		agent.Messages = slices.Clone(agent.Messages)
+		agent.ToolRefs = slices.Clone(agent.ToolRefs)
+		agent.ResponseSchema = cloneMapAny(agent.ResponseSchema)
+		agent.ProviderOptions = cloneMapAny(agent.ProviderOptions)
+		agent.Metadata = cloneMapAny(agent.Metadata)
+		clone.Agent = &agent
+	}
+	return clone
 }
 
 func cloneMapAny(value map[string]any) map[string]any {
@@ -268,16 +309,16 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	req := coreworkflow.InvokeOperationRequest{
 		ProviderName: "temporal",
 		RunID:        "run-123",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-			Connection: "analytics",
-			Instance:   "tenant-a",
-			Input: map[string]any{
+		Target: testWorkflowPluginTargetWithInput(
+			"roadmap",
+			"sync",
+			"analytics",
+			"tenant-a",
+			map[string]any{
 				"mode":   "full",
 				"source": "scheduled",
 			},
-		},
+		),
 		Input: map[string]any{
 			"source": "event",
 			"taskId": "task-456",
@@ -476,14 +517,10 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 	}
 }
 
-func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefIgnoresWhitespaceLegacyPluginFields(t *testing.T) {
+func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefAcceptsStoredLegacyFingerprint(t *testing.T) {
 	t.Parallel()
 
 	target := coreworkflow.Target{
-		PluginName: " \t",
-		Operation:  "\n",
-		Connection: " ",
-		Instance:   "\t",
 		Agent: &coreworkflow.AgentTarget{
 			ProviderName:   "managed",
 			Model:          "deep",
@@ -492,16 +529,12 @@ func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefIgnoresWhitespaceLegacy
 			TimeoutSeconds: 5,
 		},
 	}
-	fingerprint, err := coreworkflow.TargetFingerprint(target)
-	if err != nil {
-		t.Fatalf("TargetFingerprint: %v", err)
-	}
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
 		ID:                "agent-ref",
 		ProviderName:      "temporal",
 		Target:            target,
-		TargetFingerprint: fingerprint,
+		TargetFingerprint: legacyAgentWorkflowTargetFingerprint,
 		SubjectID:         "service_account:scheduler",
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
@@ -559,18 +592,15 @@ func TestWorkflowRuntimeInvokeAgentTargetHandlesMissingTurn(t *testing.T) {
 	}
 }
 
-func TestWorkflowRuntimeRejectsMixedAgentPluginTargetWithLegacyExecutionRef(t *testing.T) {
+func TestWorkflowRuntimeRejectsMixedAgentPluginTargetWithExecutionRef(t *testing.T) {
 	t.Parallel()
 
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "legacy-ref",
+		ID:           "plugin-ref",
 		ProviderName: "temporal",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-		},
-		SubjectID: "service_account:scheduler",
+		Target:       testWorkflowPluginTarget("roadmap", "sync"),
+		SubjectID:    "service_account:scheduler",
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}
@@ -580,11 +610,10 @@ func TestWorkflowRuntimeRejectsMixedAgentPluginTargetWithLegacyExecutionRef(t *t
 	}
 	_, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
 		ProviderName: "temporal",
-		ExecutionRef: "legacy-ref",
+		ExecutionRef: "plugin-ref",
 		RunID:        "run-123",
 		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
+			Plugin: testWorkflowPluginTarget("roadmap", "sync").Plugin,
 			Agent: &coreworkflow.AgentTarget{
 				ProviderName:   "managed",
 				Prompt:         "send reminder",
@@ -640,14 +669,9 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 	}
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "exec-ref-123",
-		ProviderName: "temporal",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-			Connection: "analytics",
-			Instance:   "tenant-a",
-		},
+		ID:                  "exec-ref-123",
+		ProviderName:        "temporal",
+		Target:              testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", nil),
 		SubjectID:           principal.UserSubjectID(user.ID),
 		CredentialSubjectID: "service_account:workflow-credential",
 	}); err != nil {
@@ -681,15 +705,15 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 	resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
 		ProviderName: "temporal",
 		ExecutionRef: "exec-ref-123",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-			Connection: "analytics",
-			Instance:   "tenant-a",
-			Input: map[string]any{
+		Target: testWorkflowPluginTargetWithInput(
+			"roadmap",
+			"sync",
+			"analytics",
+			"tenant-a",
+			map[string]any{
 				"mode": "full",
 			},
-		},
+		),
 		Input: map[string]any{
 			"taskId": "task-123",
 		},
@@ -722,13 +746,11 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredSubjectPrincipal(t *testing.
 
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "exec-ref-service-account",
-		ProviderName: "temporal",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-		},
-		SubjectID: "service_account:scheduler",
+		ID:                "exec-ref-service-account",
+		ProviderName:      "temporal",
+		Target:            testWorkflowPluginTarget("roadmap", "sync"),
+		TargetFingerprint: legacyPluginWorkflowTargetFingerprint,
+		SubjectID:         "service_account:scheduler",
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}
@@ -748,10 +770,7 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredSubjectPrincipal(t *testing.
 	if _, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
 		ProviderName: "temporal",
 		ExecutionRef: "exec-ref-service-account",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-		},
+		Target:       testWorkflowPluginTarget("roadmap", "sync"),
 	}); err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
@@ -779,13 +798,8 @@ func TestWorkflowRuntimeInvokeExecutionRefRechecksAuthorizationThroughBroker(t *
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
 		ID:           "exec-ref-denied",
 		ProviderName: "temporal",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-			Connection: "analytics",
-			Instance:   "tenant-a",
-		},
-		SubjectID: principal.UserSubjectID(user.ID),
+		Target:       testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", nil),
+		SubjectID:    principal.UserSubjectID(user.ID),
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}
@@ -843,12 +857,7 @@ func TestWorkflowRuntimeInvokeExecutionRefRechecksAuthorizationThroughBroker(t *
 	_, err = runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
 		ProviderName: "temporal",
 		ExecutionRef: "exec-ref-denied",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-			Connection: "analytics",
-			Instance:   "tenant-a",
-		},
+		Target:       testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", nil),
 	})
 	if err == nil {
 		t.Fatal("expected authorization error, got nil")
@@ -871,13 +880,8 @@ func TestWorkflowRuntimeInvokeExecutionRefPreservesTokenPermissionCeiling(t *tes
 	if _, err := refProvider.PutExecutionReference(ctx, &coreworkflow.ExecutionReference{
 		ID:           "exec-ref-123",
 		ProviderName: "basic",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "export",
-			Connection: "analytics",
-			Instance:   "tenant-a",
-		},
-		SubjectID: principal.UserSubjectID("user-123"),
+		Target:       testWorkflowPluginTargetWithInput("roadmap", "export", "analytics", "tenant-a", nil),
+		SubjectID:    principal.UserSubjectID("user-123"),
 		Permissions: []core.AccessPermission{{
 			Plugin:     "roadmap",
 			Operations: []string{"sync"},
@@ -913,12 +917,7 @@ func TestWorkflowRuntimeInvokeExecutionRefPreservesTokenPermissionCeiling(t *tes
 	_, err := runtime.Invoke(ctx, coreworkflow.InvokeOperationRequest{
 		ProviderName: "basic",
 		RunID:        "run-123",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "export",
-			Connection: "analytics",
-			Instance:   "tenant-a",
-		},
+		Target:       testWorkflowPluginTargetWithInput("roadmap", "export", "analytics", "tenant-a", nil),
 		ExecutionRef: "exec-ref-123",
 	})
 	if !errors.Is(err, invocation.ErrScopeDenied) {
@@ -948,10 +947,7 @@ func TestWorkflowRuntimeInvokeExecutionRefLookupInfrastructureErrorIsInternal(t 
 	_, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
 		ProviderName: "basic",
 		ExecutionRef: "exec-ref-123",
-		Target: coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "sync",
-		},
+		Target:       testWorkflowPluginTarget("roadmap", "sync"),
 	})
 	if err == nil {
 		t.Fatal("expected internal error, got nil")

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -226,6 +226,10 @@ func invokeWorkflowHostDuringStartup(t *testing.T, hostServices []providerhost.H
 
 func storeStartupExecutionRef(t *testing.T, deps Deps, providerName string, target coreworkflow.Target) string {
 	t.Helper()
+	pluginTarget := target.Plugin
+	if pluginTarget == nil {
+		t.Fatalf("workflow target plugin is nil: %#v", target)
+	}
 	provider, err := deps.WorkflowRuntime.ResolveProvider(providerName)
 	if err != nil {
 		t.Fatalf("resolve workflow provider %q: %v", providerName, err)
@@ -235,7 +239,7 @@ func storeStartupExecutionRef(t *testing.T, deps Deps, providerName string, targ
 		t.Fatalf("workflow provider %q does not support execution refs", providerName)
 	}
 	ref, err := store.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           fmt.Sprintf("startup:%s:%s:%s", strings.ReplaceAll(t.Name(), "/", "_"), providerName, target.Operation),
+		ID:           fmt.Sprintf("startup:%s:%s:%s", strings.ReplaceAll(t.Name(), "/", "_"), providerName, pluginTarget.Operation),
 		ProviderName: providerName,
 		Target:       target,
 		SubjectID:    "system:config",
@@ -286,10 +290,7 @@ func TestBootstrapWorkflowStartupCallbackWaitsForDelayedPluginProvider(t *testin
 		}); err != nil {
 			return nil, fmt.Errorf("store startup token: %w", err)
 		}
-		executionRef := storeStartupExecutionRef(t, deps, name, coreworkflow.Target{
-			PluginName: "roadmap",
-			Operation:  "status",
-		})
+		executionRef := storeStartupExecutionRef(t, deps, name, testWorkflowPluginTarget("roadmap", "status"))
 		resp, err := invokeWorkflowHostDuringStartup(t, hostServices, &proto.InvokeWorkflowOperationRequest{
 			Target: &proto.BoundWorkflowTarget{
 				Plugin: &proto.BoundWorkflowPluginTarget{

--- a/gestaltd/internal/providerhost/workflow_convert.go
+++ b/gestaltd/internal/providerhost/workflow_convert.go
@@ -33,7 +33,11 @@ func workflowRunStatusFromProto(status proto.WorkflowRunStatus) (coreworkflow.Ru
 }
 
 func workflowTargetToProto(target coreworkflow.Target) (*proto.BoundWorkflowTarget, error) {
-	plugin, err := workflowPluginTargetToProto(target.PluginTarget())
+	var pluginTarget coreworkflow.PluginTarget
+	if target.Plugin != nil {
+		pluginTarget = *target.Plugin
+	}
+	plugin, err := workflowPluginTargetToProto(pluginTarget)
 	if err != nil {
 		return nil, err
 	}
@@ -67,12 +71,7 @@ func workflowTargetFromProto(target *proto.BoundWorkflowTarget) coreworkflow.Tar
 		plugin = workflowPluginTargetFromProtoFields(target)
 	}
 	out := coreworkflow.Target{
-		PluginName: plugin.PluginName,
-		Operation:  plugin.Operation,
-		Connection: plugin.Connection,
-		Instance:   plugin.Instance,
-		Input:      plugin.Input,
-		Agent:      workflowAgentTargetFromProto(target.GetAgent()),
+		Agent: workflowAgentTargetFromProto(target.GetAgent()),
 	}
 	if coreworkflow.PluginTargetSet(plugin) {
 		out.Plugin = &plugin

--- a/gestaltd/internal/providerhost/workflow_convert_test.go
+++ b/gestaltd/internal/providerhost/workflow_convert_test.go
@@ -72,16 +72,16 @@ func TestWorkflowTargetFromProtoAcceptsFlatPluginFieldsForProviderCompatibility(
 	if got := target.Plugin.PluginName; got != "demo" {
 		t.Fatalf("plugin name = %q, want %q", got, "demo")
 	}
-	if got := target.Operation; got != "refresh" {
+	if got := target.Plugin.Operation; got != "refresh" {
 		t.Fatalf("operation = %q, want %q", got, "refresh")
 	}
-	if got := target.Connection; got != "workspace" {
+	if got := target.Plugin.Connection; got != "workspace" {
 		t.Fatalf("connection = %q, want %q", got, "workspace")
 	}
-	if got := target.Instance; got != "primary" {
+	if got := target.Plugin.Instance; got != "primary" {
 		t.Fatalf("instance = %q, want %q", got, "primary")
 	}
-	if got := target.Input["customer_id"]; got != "cust_123" {
+	if got := target.Plugin.Input["customer_id"]; got != "cust_123" {
 		t.Fatalf("input customer_id = %#v, want %q", got, "cust_123")
 	}
 }

--- a/gestaltd/internal/providerhost/workflow_host_server.go
+++ b/gestaltd/internal/providerhost/workflow_host_server.go
@@ -36,12 +36,15 @@ func (s *WorkflowHostServer) InvokeOperation(ctx context.Context, req *proto.Inv
 		return nil, status.Errorf(codes.InvalidArgument, "workflow invoke operation: %v", err)
 	}
 	if value.Target.Agent == nil {
-		value.Target.PluginName = strings.TrimSpace(value.Target.PluginTarget().PluginName)
-		if value.Target.PluginName == "" {
+		if value.Target.Plugin == nil {
 			return nil, status.Error(codes.InvalidArgument, "workflow invoke operation: target.plugin.plugin_name is required")
 		}
-		value.Target.Operation = strings.TrimSpace(value.Target.PluginTarget().Operation)
-		if value.Target.Operation == "" {
+		value.Target.Plugin.PluginName = strings.TrimSpace(value.Target.Plugin.PluginName)
+		if value.Target.Plugin.PluginName == "" {
+			return nil, status.Error(codes.InvalidArgument, "workflow invoke operation: target.plugin.plugin_name is required")
+		}
+		value.Target.Plugin.Operation = strings.TrimSpace(value.Target.Plugin.Operation)
+		if value.Target.Plugin.Operation == "" {
 			return nil, status.Error(codes.InvalidArgument, "workflow invoke operation: target.plugin.operation is required")
 		}
 	} else if strings.TrimSpace(value.Target.Agent.ProviderName) == "" {

--- a/gestaltd/internal/providerhost/workflow_manager_server.go
+++ b/gestaltd/internal/providerhost/workflow_manager_server.go
@@ -369,7 +369,10 @@ func workflowManagerScheduleUpsert(
 		return workflowmanager.ScheduleUpsert{}, status.Errorf(codes.InvalidArgument, "target: %v", err)
 	}
 	if target.Agent == nil {
-		pluginTarget := target.PluginTarget()
+		if target.Plugin == nil {
+			return workflowmanager.ScheduleUpsert{}, status.Error(codes.InvalidArgument, "target.plugin.plugin_name is required")
+		}
+		pluginTarget := *target.Plugin
 		if strings.TrimSpace(pluginTarget.PluginName) == "" {
 			return workflowmanager.ScheduleUpsert{}, status.Error(codes.InvalidArgument, "target.plugin.plugin_name is required")
 		}
@@ -399,7 +402,10 @@ func workflowManagerEventTriggerUpsert(
 		return workflowmanager.EventTriggerUpsert{}, status.Errorf(codes.InvalidArgument, "target: %v", err)
 	}
 	if target.Agent == nil {
-		pluginTarget := target.PluginTarget()
+		if target.Plugin == nil {
+			return workflowmanager.EventTriggerUpsert{}, status.Error(codes.InvalidArgument, "target.plugin.plugin_name is required")
+		}
+		pluginTarget := *target.Plugin
 		if strings.TrimSpace(pluginTarget.PluginName) == "" {
 			return workflowmanager.EventTriggerUpsert{}, status.Error(codes.InvalidArgument, "target.plugin.plugin_name is required")
 		}

--- a/gestaltd/internal/server/handlers_workflow.go
+++ b/gestaltd/internal/server/handlers_workflow.go
@@ -283,12 +283,7 @@ func workflowScheduleTargetFromRequest(target workflowScheduleTargetRequest) cor
 		Input:      maps.Clone(plugin.Input),
 	}
 	return coreworkflow.Target{
-		PluginName: pluginTarget.PluginName,
-		Operation:  pluginTarget.Operation,
-		Connection: pluginTarget.Connection,
-		Instance:   pluginTarget.Instance,
-		Input:      pluginTarget.Input,
-		Plugin:     &pluginTarget,
+		Plugin: &pluginTarget,
 	}
 }
 
@@ -380,7 +375,7 @@ func workflowScheduleInfoFromCore(schedule *coreworkflow.Schedule, providerName 
 
 func workflowScheduleTargetInfoFromCore(target coreworkflow.Target) workflowScheduleTargetInfo {
 	if target.Agent != nil {
-		agentTarget := target.AgentTarget()
+		agentTarget := *target.Agent
 		return workflowScheduleTargetInfo{
 			Agent: &workflowAgentTargetInfo{
 				ProviderName:    agentTarget.ProviderName,
@@ -395,7 +390,10 @@ func workflowScheduleTargetInfoFromCore(target coreworkflow.Target) workflowSche
 			},
 		}
 	}
-	pluginTarget := target.PluginTarget()
+	if target.Plugin == nil {
+		return workflowScheduleTargetInfo{}
+	}
+	pluginTarget := *target.Plugin
 	return workflowScheduleTargetInfo{
 		Plugin: &workflowPluginTargetInfo{
 			Name:       pluginTarget.PluginName,

--- a/gestaltd/internal/server/handlers_workflow_runs.go
+++ b/gestaltd/internal/server/handlers_workflow_runs.go
@@ -80,7 +80,7 @@ func (s *Server) listGlobalWorkflowRuns(w http.ResponseWriter, r *http.Request) 
 		if managed == nil || managed.Run == nil {
 			continue
 		}
-		if pluginFilter != "" && strings.TrimSpace(managed.Run.Target.PluginTarget().PluginName) != pluginFilter {
+		if pluginFilter != "" && (managed.Run.Target.Plugin == nil || strings.TrimSpace(managed.Run.Target.Plugin.PluginName) != pluginFilter) {
 			continue
 		}
 		if statusFilter != "" && strings.TrimSpace(string(managed.Run.Status)) != statusFilter {

--- a/gestaltd/internal/server/workflow_run_test.go
+++ b/gestaltd/internal/server/workflow_run_test.go
@@ -32,6 +32,21 @@ type workflowRunResponse struct {
 	} `json:"trigger"`
 }
 
+func workflowPluginTarget(pluginName, operation string) coreworkflow.Target {
+	return workflowPluginTargetWithRouting(pluginName, operation, "", "")
+}
+
+func workflowPluginTargetWithRouting(pluginName, operation, connection, instance string) coreworkflow.Target {
+	return coreworkflow.Target{
+		Plugin: &coreworkflow.PluginTarget{
+			PluginName: pluginName,
+			Operation:  operation,
+			Connection: connection,
+			Instance:   instance,
+		},
+	}
+}
+
 func TestGlobalWorkflowRunInspectionIncludesHistoricalRevokedRefs(t *testing.T) {
 	t.Parallel()
 
@@ -46,7 +61,7 @@ func TestGlobalWorkflowRunInspectionIncludesHistoricalRevokedRefs(t *testing.T) 
 	provider.runs["run-new"] = &coreworkflow.Run{
 		ID:           "run-new",
 		Status:       coreworkflow.RunStatusRunning,
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:       workflowPluginTarget("roadmap", "sync"),
 		Trigger:      coreworkflow.RunTrigger{Schedule: &coreworkflow.ScheduleTrigger{ScheduleID: "sched-new"}},
 		ExecutionRef: "workflow_schedule:sched-new:ref-active",
 		CreatedAt:    &now,
@@ -54,7 +69,7 @@ func TestGlobalWorkflowRunInspectionIncludesHistoricalRevokedRefs(t *testing.T) 
 	provider.runs["run-old"] = &coreworkflow.Run{
 		ID:            "run-old",
 		Status:        coreworkflow.RunStatusSucceeded,
-		Target:        coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:        workflowPluginTarget("roadmap", "sync"),
 		Trigger:       coreworkflow.RunTrigger{Schedule: &coreworkflow.ScheduleTrigger{ScheduleID: "sched-old"}},
 		ExecutionRef:  "workflow_schedule:sched-old:ref-revoked",
 		CreatedAt:     &older,
@@ -65,7 +80,7 @@ func TestGlobalWorkflowRunInspectionIncludesHistoricalRevokedRefs(t *testing.T) 
 	provider.runs["run-other"] = &coreworkflow.Run{
 		ID:           "run-other",
 		Status:       coreworkflow.RunStatusSucceeded,
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:       workflowPluginTarget("roadmap", "sync"),
 		ExecutionRef: "workflow_schedule:sched-other:ref-other",
 		CreatedAt:    &now,
 	}
@@ -195,14 +210,14 @@ func TestGlobalWorkflowRunInspectionAPITokenScopeFiltersOperations(t *testing.T)
 	provider.runs["run-sync"] = &coreworkflow.Run{
 		ID:           "run-sync",
 		Status:       coreworkflow.RunStatusSucceeded,
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:       workflowPluginTarget("roadmap", "sync"),
 		ExecutionRef: "workflow_schedule:sched-sync:ref-sync",
 		CreatedAt:    &now,
 	}
 	provider.runs["run-export"] = &coreworkflow.Run{
 		ID:           "run-export",
 		Status:       coreworkflow.RunStatusFailed,
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "export"},
+		Target:       workflowPluginTarget("roadmap", "export"),
 		ExecutionRef: "workflow_schedule:sched-export:ref-export",
 		CreatedAt:    &now,
 	}
@@ -292,7 +307,7 @@ func TestGlobalWorkflowRunCancelUpdatesOwnedRun(t *testing.T) {
 	run := &coreworkflow.Run{
 		ID:           "run-cancel",
 		Status:       coreworkflow.RunStatusRunning,
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:       workflowPluginTarget("roadmap", "sync"),
 		ExecutionRef: "workflow_schedule:sched-cancel:ref-active",
 		CreatedAt:    &now,
 		StartedAt:    &now,

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -383,7 +383,7 @@ func cloneWorkflowExecutionReference(ref *coreworkflow.ExecutionReference) *core
 		return nil
 	}
 	cloned := *ref
-	cloned.Target.Input = cloneMap(ref.Target.Input)
+	cloned.Target = cloneWorkflowTarget(ref.Target)
 	cloned.Permissions = append([]core.AccessPermission(nil), ref.Permissions...)
 	for i := range cloned.Permissions {
 		cloned.Permissions[i].Operations = append([]string(nil), cloned.Permissions[i].Operations...)
@@ -404,7 +404,7 @@ func cloneWorkflowSchedule(schedule *coreworkflow.Schedule) *coreworkflow.Schedu
 		return nil
 	}
 	cloned := *schedule
-	cloned.Target.Input = cloneMap(schedule.Target.Input)
+	cloned.Target = cloneWorkflowTarget(schedule.Target)
 	if schedule.CreatedAt != nil {
 		value := *schedule.CreatedAt
 		cloned.CreatedAt = &value
@@ -425,7 +425,7 @@ func cloneWorkflowRun(run *coreworkflow.Run) *coreworkflow.Run {
 		return nil
 	}
 	cloned := *run
-	cloned.Target.Input = cloneMap(run.Target.Input)
+	cloned.Target = cloneWorkflowTarget(run.Target)
 	if run.Trigger.Event != nil {
 		event := *run.Trigger.Event
 		event.Event.Data = cloneMap(run.Trigger.Event.Event.Data)
@@ -464,7 +464,7 @@ func cloneWorkflowEventTrigger(trigger *coreworkflow.EventTrigger) *coreworkflow
 		return nil
 	}
 	cloned := *trigger
-	cloned.Target.Input = cloneMap(trigger.Target.Input)
+	cloned.Target = cloneWorkflowTarget(trigger.Target)
 	if trigger.CreatedAt != nil {
 		value := *trigger.CreatedAt
 		cloned.CreatedAt = &value
@@ -474,6 +474,33 @@ func cloneWorkflowEventTrigger(trigger *coreworkflow.EventTrigger) *coreworkflow
 		cloned.UpdatedAt = &value
 	}
 	return &cloned
+}
+
+func cloneWorkflowTarget(target coreworkflow.Target) coreworkflow.Target {
+	cloned := coreworkflow.Target{}
+	if target.Plugin != nil {
+		plugin := *target.Plugin
+		plugin.Input = cloneMap(plugin.Input)
+		cloned.Plugin = &plugin
+	}
+	if target.Agent != nil {
+		agent := *target.Agent
+		agent.Messages = slices.Clone(agent.Messages)
+		agent.ToolRefs = slices.Clone(agent.ToolRefs)
+		agent.ResponseSchema = cloneMap(agent.ResponseSchema)
+		agent.ProviderOptions = cloneMap(agent.ProviderOptions)
+		agent.Metadata = cloneMap(agent.Metadata)
+		cloned.Agent = &agent
+	}
+	return cloned
+}
+
+func requireCoreWorkflowPluginTarget(t *testing.T, target coreworkflow.Target) *coreworkflow.PluginTarget {
+	t.Helper()
+	if target.Plugin == nil {
+		t.Fatalf("target plugin is nil: %#v", target)
+	}
+	return target.Plugin
 }
 
 func cloneWorkflowEvent(event coreworkflow.Event) coreworkflow.Event {
@@ -650,7 +677,8 @@ func TestWorkflowScheduleCRUD(t *testing.T) {
 		t.Fatalf("upsert requests = %d, want 1", len(provider.upsertReqs))
 	}
 	createUpsert := provider.upsertReqs[len(provider.upsertReqs)-1]
-	if createUpsert.Target.PluginName != "roadmap" || createUpsert.Target.Operation != "sync" {
+	createUpsertPlugin := requireCoreWorkflowPluginTarget(t, createUpsert.Target)
+	if createUpsertPlugin.PluginName != "roadmap" || createUpsertPlugin.Operation != "sync" {
 		t.Fatalf("upsert target = %#v", createUpsert.Target)
 	}
 	if createUpsert.ExecutionRef == "" {
@@ -870,7 +898,7 @@ func TestWorkflowScheduleListAndMutationsAreOwnerScoped(t *testing.T) {
 	provider.schedules["sched-ada"] = &coreworkflow.Schedule{
 		ID:           "sched-ada",
 		Cron:         "*/5 * * * *",
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:       workflowPluginTarget("roadmap", "sync"),
 		ExecutionRef: "workflow_schedule:sched-ada:ref-ada",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -878,7 +906,7 @@ func TestWorkflowScheduleListAndMutationsAreOwnerScoped(t *testing.T) {
 	provider.schedules["sched-grace"] = &coreworkflow.Schedule{
 		ID:           "sched-grace",
 		Cron:         "0 * * * *",
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:       workflowPluginTarget("roadmap", "sync"),
 		ExecutionRef: "workflow_schedule:sched-grace:ref-grace",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -886,7 +914,7 @@ func TestWorkflowScheduleListAndMutationsAreOwnerScoped(t *testing.T) {
 	provider.schedules["sched-analytics"] = &coreworkflow.Schedule{
 		ID:           "sched-analytics",
 		Cron:         "15 * * * *",
-		Target:       coreworkflow.Target{PluginName: "analytics", Operation: "sync"},
+		Target:       workflowPluginTarget("analytics", "sync"),
 		ExecutionRef: "workflow_schedule:sched-analytics:ref-analytics",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -1068,7 +1096,7 @@ func TestCreateWorkflowScheduleAllowsAuthorizedCatalogOperation(t *testing.T) {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, body)
 	}
-	if len(provider.upsertReqs) != 1 || provider.upsertReqs[0].Target.Operation != "export" {
+	if len(provider.upsertReqs) != 1 || requireCoreWorkflowPluginTarget(t, provider.upsertReqs[0].Target).Operation != "export" {
 		t.Fatalf("upsert requests = %#v", provider.upsertReqs)
 	}
 }
@@ -1101,7 +1129,7 @@ func TestWorkflowScheduleAPITokenScopeFiltersOperations(t *testing.T) {
 	provider.schedules["sched-sync"] = &coreworkflow.Schedule{
 		ID:           "sched-sync",
 		Cron:         "*/5 * * * *",
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:       workflowPluginTarget("roadmap", "sync"),
 		ExecutionRef: "workflow_schedule:sched-sync:ref-sync",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -1109,7 +1137,7 @@ func TestWorkflowScheduleAPITokenScopeFiltersOperations(t *testing.T) {
 	provider.schedules["sched-export"] = &coreworkflow.Schedule{
 		ID:           "sched-export",
 		Cron:         "0 * * * *",
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "export"},
+		Target:       workflowPluginTarget("roadmap", "export"),
 		ExecutionRef: "workflow_schedule:sched-export:ref-export",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -1223,10 +1251,12 @@ func TestWorkflowScheduleUpdateFailureKeepsExistingExecutionRef(t *testing.T) {
 	user := seedUser(t, services, "ada@example.test")
 	provider := newMemoryWorkflowProvider()
 	oldTarget := coreworkflow.Target{
-		PluginName: "roadmap",
-		Operation:  "sync",
-		Connection: "analytics",
-		Instance:   "tenant-a",
+		Plugin: &coreworkflow.PluginTarget{
+			PluginName: "roadmap",
+			Operation:  "sync",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+		},
 	}
 	now := time.Now().UTC().Truncate(time.Second)
 	provider.schedules["sched-ada"] = &coreworkflow.Schedule{
@@ -1298,7 +1328,7 @@ func TestWorkflowScheduleUpdateFailureKeepsExistingExecutionRef(t *testing.T) {
 	if provider.schedules["sched-ada"].ExecutionRef != "workflow_schedule:sched-ada:ref-old" {
 		t.Fatalf("schedule execution ref = %q, want workflow_schedule:sched-ada:ref-old", provider.schedules["sched-ada"].ExecutionRef)
 	}
-	if provider.schedules["sched-ada"].Target.Instance != "tenant-a" {
+	if requireCoreWorkflowPluginTarget(t, provider.schedules["sched-ada"].Target).Instance != "tenant-a" {
 		t.Fatalf("schedule target after failed update = %#v", provider.schedules["sched-ada"].Target)
 	}
 	oldRef, err := provider.GetExecutionReference(context.Background(), "workflow_schedule:sched-ada:ref-old")
@@ -1454,7 +1484,7 @@ func TestWorkflowScheduleCreatePinsResolvedInstance(t *testing.T) {
 	if len(provider.upsertReqs) != 1 {
 		t.Fatalf("upsert requests = %d, want 1", len(provider.upsertReqs))
 	}
-	if provider.upsertReqs[0].Target.Instance != "tenant-a" {
+	if requireCoreWorkflowPluginTarget(t, provider.upsertReqs[0].Target).Instance != "tenant-a" {
 		t.Fatalf("stored target = %#v, want resolved instance tenant-a", provider.upsertReqs[0].Target)
 	}
 }
@@ -1473,7 +1503,7 @@ func TestGlobalWorkflowScheduleLookupIgnoresUnrelatedProviderFailures(t *testing
 	basicProvider.schedules["sched-ada-basic"] = &coreworkflow.Schedule{
 		ID:           "sched-ada-basic",
 		Cron:         "*/5 * * * *",
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:       workflowPluginTarget("roadmap", "sync"),
 		ExecutionRef: "workflow_schedule:sched-ada-basic:ref-basic",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -1572,7 +1602,7 @@ func TestGlobalWorkflowScheduleRejectsDuplicateActiveExecutionRefs(t *testing.T)
 	schedule := &coreworkflow.Schedule{
 		ID:           "sched-ada",
 		Cron:         "*/5 * * * *",
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:       workflowPluginTarget("roadmap", "sync"),
 		ExecutionRef: "workflow_schedule:sched-ada:active-ref-1",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -1723,7 +1753,7 @@ func TestGlobalWorkflowScheduleCRUDAcrossProviders(t *testing.T) {
 	if len(basicProvider.upsertReqs) != 1 {
 		t.Fatalf("basic upsert requests = %d, want 1", len(basicProvider.upsertReqs))
 	}
-	if basicProvider.upsertReqs[0].Target.PluginName != "roadmap" {
+	if requireCoreWorkflowPluginTarget(t, basicProvider.upsertReqs[0].Target).PluginName != "roadmap" {
 		t.Fatalf("basic create target = %#v", basicProvider.upsertReqs[0].Target)
 	}
 	initialExecutionRef := basicProvider.upsertReqs[0].ExecutionRef
@@ -1863,7 +1893,7 @@ func TestGlobalWorkflowScheduleListAndMutationsAreOwnerScopedAcrossProviders(t *
 	basicProvider.schedules["sched-ada-basic"] = &coreworkflow.Schedule{
 		ID:           "sched-ada-basic",
 		Cron:         "*/5 * * * *",
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:       workflowPluginTarget("roadmap", "sync"),
 		ExecutionRef: "workflow_schedule:sched-ada-basic:ref-basic",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -1871,7 +1901,7 @@ func TestGlobalWorkflowScheduleListAndMutationsAreOwnerScopedAcrossProviders(t *
 	advancedProvider.schedules["sched-ada-advanced"] = &coreworkflow.Schedule{
 		ID:           "sched-ada-advanced",
 		Cron:         "0 * * * *",
-		Target:       coreworkflow.Target{PluginName: "analytics", Operation: "sync"},
+		Target:       workflowPluginTarget("analytics", "sync"),
 		ExecutionRef: "workflow_schedule:sched-ada-advanced:ref-advanced",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -1879,7 +1909,7 @@ func TestGlobalWorkflowScheduleListAndMutationsAreOwnerScopedAcrossProviders(t *
 	advancedProvider.schedules["sched-grace-advanced"] = &coreworkflow.Schedule{
 		ID:           "sched-grace-advanced",
 		Cron:         "15 * * * *",
-		Target:       coreworkflow.Target{PluginName: "analytics", Operation: "sync"},
+		Target:       workflowPluginTarget("analytics", "sync"),
 		ExecutionRef: "workflow_schedule:sched-grace-advanced:ref-grace-advanced",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -2093,7 +2123,7 @@ func TestGlobalWorkflowEventTriggerCRUDAcrossProviders(t *testing.T) {
 	if len(basicProvider.upsertTriggerReqs) != 1 {
 		t.Fatalf("basic trigger upsert requests = %d, want 1", len(basicProvider.upsertTriggerReqs))
 	}
-	if basicProvider.upsertTriggerReqs[0].Target.PluginName != "roadmap" {
+	if requireCoreWorkflowPluginTarget(t, basicProvider.upsertTriggerReqs[0].Target).PluginName != "roadmap" {
 		t.Fatalf("basic create target = %#v", basicProvider.upsertTriggerReqs[0].Target)
 	}
 	initialExecutionRef := basicProvider.upsertTriggerReqs[0].ExecutionRef
@@ -2308,7 +2338,7 @@ func TestGlobalWorkflowEventTriggerListAndMutationsAreOwnerScopedAcrossProviders
 	basicProvider.triggers["trg-ada-basic"] = &coreworkflow.EventTrigger{
 		ID:           "trg-ada-basic",
 		Match:        coreworkflow.EventMatch{Type: "roadmap.item.updated"},
-		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Target:       workflowPluginTarget("roadmap", "sync"),
 		ExecutionRef: "workflow_event_trigger:trg-ada-basic:ref-basic",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -2316,7 +2346,7 @@ func TestGlobalWorkflowEventTriggerListAndMutationsAreOwnerScopedAcrossProviders
 	advancedProvider.triggers["trg-ada-advanced"] = &coreworkflow.EventTrigger{
 		ID:           "trg-ada-advanced",
 		Match:        coreworkflow.EventMatch{Type: "analytics.item.synced"},
-		Target:       coreworkflow.Target{PluginName: "analytics", Operation: "sync"},
+		Target:       workflowPluginTarget("analytics", "sync"),
 		ExecutionRef: "workflow_event_trigger:trg-ada-advanced:ref-advanced",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,
@@ -2324,7 +2354,7 @@ func TestGlobalWorkflowEventTriggerListAndMutationsAreOwnerScopedAcrossProviders
 	advancedProvider.triggers["trg-grace-advanced"] = &coreworkflow.EventTrigger{
 		ID:           "trg-grace-advanced",
 		Match:        coreworkflow.EventMatch{Type: "analytics.item.failed"},
-		Target:       coreworkflow.Target{PluginName: "analytics", Operation: "sync"},
+		Target:       workflowPluginTarget("analytics", "sync"),
 		ExecutionRef: "workflow_event_trigger:trg-grace-advanced:ref-grace-advanced",
 		CreatedAt:    &now,
 		UpdatedAt:    &now,

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -712,14 +712,17 @@ func (m *Manager) resolveProviderByName(providerName string) (coreworkflow.Provi
 }
 
 func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, target coreworkflow.Target) (coreworkflow.Target, error) {
-	pluginTarget := target.PluginTarget()
-	hasPlugin := coreworkflow.PluginTargetSet(pluginTarget)
+	hasPlugin := target.Plugin != nil && coreworkflow.PluginTargetSet(*target.Plugin)
 	hasAgent := target.Agent != nil
 	if hasAgent && hasPlugin {
 		return coreworkflow.Target{}, fmt.Errorf("workflow target must set exactly one of plugin or agent")
 	}
 	if hasAgent {
-		return m.resolveAgentTarget(ctx, p, target.AgentTarget())
+		return m.resolveAgentTarget(ctx, p, *target.Agent)
+	}
+	pluginTarget := coreworkflow.PluginTarget{}
+	if target.Plugin != nil {
+		pluginTarget = *target.Plugin
 	}
 	return m.resolvePluginTarget(ctx, p, pluginTarget)
 }
@@ -798,12 +801,7 @@ func (m *Manager) resolvePluginTarget(ctx context.Context, p *principal.Principa
 		Input:      maps.Clone(target.Input),
 	}
 	return coreworkflow.Target{
-		PluginName: pluginTarget.PluginName,
-		Operation:  pluginTarget.Operation,
-		Connection: pluginTarget.Connection,
-		Instance:   pluginTarget.Instance,
-		Input:      pluginTarget.Input,
-		Plugin:     &pluginTarget,
+		Plugin: &pluginTarget,
 	}, nil
 }
 
@@ -1098,7 +1096,10 @@ func (m *Manager) allowTarget(ctx context.Context, p *principal.Principal, targe
 		}
 		return true
 	}
-	pluginTarget := target.PluginTarget()
+	if target.Plugin == nil {
+		return false
+	}
+	pluginTarget := *target.Plugin
 	pluginName := strings.TrimSpace(pluginTarget.PluginName)
 	operation := strings.TrimSpace(pluginTarget.Operation)
 	if pluginName == "" || operation == "" {
@@ -1203,8 +1204,11 @@ func targetMatchesExecutionRef(target coreworkflow.Target, ref *coreworkflow.Exe
 	if ref.Target.Agent != nil || target.Agent != nil {
 		return false
 	}
-	left := target.PluginTarget()
-	right := ref.Target.PluginTarget()
+	if target.Plugin == nil || ref.Target.Plugin == nil {
+		return false
+	}
+	left := *target.Plugin
+	right := *ref.Target.Plugin
 	return strings.TrimSpace(left.PluginName) == strings.TrimSpace(right.PluginName) &&
 		strings.TrimSpace(left.Operation) == strings.TrimSpace(right.Operation) &&
 		strings.TrimSpace(left.Connection) == strings.TrimSpace(right.Connection) &&


### PR DESCRIPTION
## Summary

Remove the remaining internal `coreworkflow.Target` flat plugin fields and the `PluginTarget()` / `AgentTarget()` compatibility helpers now that config and HTTP workflow targets use nested targets.

## Interface Change

Old internal Go interface:

```go
coreworkflow.Target{
    PluginName: "roadmap",
    Operation:  "sync",
    Connection: "analytics",
    Instance:   "tenant-a",
    Input:      map[string]any{"mode": "full"},
}

target.PluginTarget()
target.AgentTarget()
```

New internal Go interface:

```go
coreworkflow.Target{
    Plugin: &coreworkflow.PluginTarget{
        PluginName: "roadmap",
        Operation:  "sync",
        Connection: "analytics",
        Instance:   "tenant-a",
        Input:      map[string]any{"mode": "full"},
    },
}

target.Plugin

target := coreworkflow.Target{
    Agent: &coreworkflow.AgentTarget{
        ProviderName: "managed",
        Prompt:       "Send the status summary",
    },
}
```

Public YAML/HTTP shape remains nested:

```yaml
target:
  plugin:
    name: roadmap
    operation: sync
    connection: analytics
    instance: tenant-a
    input:
      mode: full
```

```json
{
  "target": {
    "plugin": {
      "name": "roadmap",
      "operation": "sync",
      "connection": "analytics",
      "instance": "tenant-a",
      "input": {"mode": "full"}
    }
  }
}
```

Provider-host protobuf conversion still emits and accepts legacy flat proto fields for wire compatibility, but converts them immediately to nested `Target.Plugin` internally:

```go
// Provider-host wire compatibility only.
proto.BoundWorkflowTarget{
    PluginName: "roadmap",
    Operation:  "sync",
    Plugin: &proto.BoundWorkflowPluginTarget{
        PluginName: "roadmap",
        Operation:  "sync",
    },
}
```

## Why This Improves Things

- Removes duplicated internal plugin state that could drift between `Target.PluginName` and `Target.Plugin.PluginName`.
- Makes plugin versus agent workflow targets explicit through `Target.Plugin` and `Target.Agent`.
- Keeps conversion boundaries responsible for public/wire contract mapping instead of carrying legacy compatibility through core workflow logic.
- Preserves stored execution-reference fingerprints with a private legacy-shaped fingerprint payload, without reintroducing flat fields on `coreworkflow.Target`.

## Validation

- `go test ./...` from `gestaltd`
- `go test ./internal/bootstrap ./internal/server ./internal/providerhost ./internal/workflowmanager ./core/workflow`
