### PR TITLE
Remove legacy credential query aliases

### DIFF
--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -29,8 +29,6 @@ import (
 const defaultTokenInstance = "default"
 const httpInstanceParam = "_instance"
 const httpConnectionParam = "_connection"
-const legacyHTTPInstanceParam = "instance"
-const legacyHTTPConnectionParam = "connection"
 
 const cliStatePrefix = "cli:"
 const maxPort = 65535
@@ -257,8 +255,16 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		auditErr = errors.New("integration not found")
 		return
 	}
+	query := r.URL.Query()
+	for _, param := range []string{"instance", "connection"} {
+		if _, ok := query[param]; ok {
+			auditErr = errors.New("legacy connection parameter")
+			writeError(w, http.StatusBadRequest, "use _connection and _instance query parameters")
+			return
+		}
+	}
 
-	requestedInstance := queryParamValue(r, httpInstanceParam, legacyHTTPInstanceParam)
+	requestedInstance := query.Get(httpInstanceParam)
 	if requestedInstance != "" {
 		var ok bool
 		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
@@ -267,7 +273,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	requestedConnection := queryParamValue(r, httpConnectionParam, legacyHTTPConnectionParam)
+	requestedConnection := query.Get(httpConnectionParam)
 	if requestedConnection != "" {
 		var ok bool
 		requestedConnection, ok = s.resolveRequestedConnection(w, name, requestedConnection)
@@ -369,15 +375,6 @@ func (s *Server) getProvider(w http.ResponseWriter, name string) (core.Provider,
 		return nil, false
 	}
 	return prov, true
-}
-
-func queryParamValue(r *http.Request, names ...string) string {
-	for _, name := range names {
-		if value := r.URL.Query().Get(name); value != "" {
-			return value
-		}
-	}
-	return ""
 }
 
 func (s *Server) requireOAuthHandler(w http.ResponseWriter, integration, connection string) (bootstrap.OAuthHandler, bool) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8666,12 +8666,11 @@ func TestDisconnectIntegration(t *testing.T) {
 		}
 	})
 
-	t.Run("plain parameters are accepted for disconnect", func(t *testing.T) {
+	t.Run("plain parameters are rejected for disconnect", func(t *testing.T) {
 		t.Parallel()
 
 		svc := coretesting.NewStubServices(t)
 		u := seedUser(t, svc, "anonymous@gestalt")
-		var auditBuf bytes.Buffer
 		seedToken(t, svc, &core.ExternalCredential{
 			ID: "tok-b", SubjectID: principal.UserSubjectID(u.ID), Integration: "notion",
 			Connection: "mcp", Instance: "MCP OAuth", AccessToken: "test-token",
@@ -8683,7 +8682,6 @@ func TestDisconnectIntegration(t *testing.T) {
 
 		ts := newTestServer(t, func(cfg *server.Config) {
 			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "notion", DN: "Notion"})
-			cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 			cfg.Services = svc
 		})
 		testutil.CloseOnCleanup(t, ts)
@@ -8695,33 +8693,23 @@ func TestDisconnectIntegration(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode != http.StatusBadRequest {
 			body, _ := io.ReadAll(resp.Body)
-			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+			t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+		}
+		var result map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if !strings.Contains(result["error"], "_connection") || !strings.Contains(result["error"], "_instance") {
+			t.Fatalf("expected canonical parameter error, got %q", result["error"])
 		}
 		tokens, err := svc.ExternalCredentials.ListCredentialsForProvider(context.Background(), principal.UserSubjectID(u.ID), "notion")
 		if err != nil {
 			t.Fatalf("ListCredentialsForProvider: %v", err)
 		}
-		if len(tokens) != 1 {
-			t.Fatalf("expected 1 token after targeted disconnect, got %d", len(tokens))
-		}
-		if tokens[0].Connection != "default" || tokens[0].Instance != "default" {
-			t.Fatalf("unexpected remaining token %+v", tokens[0])
-		}
-
-		var auditRecord map[string]any
-		if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
-			t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
-		}
-		if auditRecord["target_kind"] != "connection" {
-			t.Fatalf("expected audit target_kind connection, got %v", auditRecord["target_kind"])
-		}
-		if auditRecord["target_id"] != "notion/mcp/MCP OAuth" {
-			t.Fatalf("expected audit target_id notion/mcp/MCP OAuth, got %v", auditRecord["target_id"])
-		}
-		if auditRecord["target_name"] != "mcp/MCP OAuth" {
-			t.Fatalf("expected audit target_name mcp/MCP OAuth, got %v", auditRecord["target_name"])
+		if len(tokens) != 2 {
+			t.Fatalf("expected both tokens to remain after rejected disconnect, got %d", len(tokens))
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Remove support for plain `connection` and `instance` query parameters on `DELETE /api/v1/integrations/{name}`.
- Require the canonical `_connection` and `_instance` parameters for targeted disconnects.
- Reject retired plain parameters with a JSON 400 instead of silently treating them as invocation params or disconnecting a broader target.

## Removed interface
```http
DELETE /api/v1/integrations/notion?connection=mcp&instance=MCP%20OAuth
```

## Canonical interface
```http
DELETE /api/v1/integrations/notion?_connection=mcp&_instance=MCP%20OAuth
```

Unsupported plain params now return:
```json
{
  "error": "use _connection and _instance query parameters"
}
```

## Validation
- `go test ./internal/server -run 'TestDisconnectIntegration' -count=1`\n- `golangci-lint run ./internal/server`\n- `git diff --check`\n