### PR TITLE
Remove stale provider compatibility aliases

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1046,7 +1046,7 @@ local manifest `source` to the remote configured plugin and preserves the
 remote plugin config; layered `--config` files are only needed for explicit
 local config overrides or multi-plugin attach sessions.
 
-Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider` or the legacy `[tool.gestalt].plugin`.
+Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider`.
 
 <Tabs items={['Go', 'Python', 'Rust']}>
   <Tabs.Tab>

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -60,7 +60,7 @@ Common source-package checks:
     uv run python -c "import provider"
     ```
 
-    Also confirm `[tool.gestalt].provider` or the legacy `[tool.gestalt].plugin` entry in `pyproject.toml` points at the module Gestalt should load.
+    Also confirm the `[tool.gestalt].provider` entry in `pyproject.toml` points at the module Gestalt should load.
 
   </Tabs.Tab>
   <Tabs.Tab>

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -991,7 +991,7 @@ version = "0.0.1-alpha.1"
 dependencies = ["gestalt"]
 
 [tool.gestalt]
-plugin = "os import path\nimport os;os.system('cmd')#:attr"
+provider = "os import path\nimport os;os.system('cmd')#:attr"
 `), 0o644)
 	writeTestFile(t, pluginDir, "provider.py", []byte("plugin = None\n"), 0o644)
 	manifestData, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
@@ -2527,7 +2527,7 @@ version = "0.0.1-alpha.1"
 dependencies = ["gestalt"]
 
 [tool.gestalt]
-plugin = "provider"
+provider = "provider"
 `), 0o644)
 	writeTestFile(t, pluginDir, "provider.py", []byte(`import gestalt
 

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -567,7 +567,7 @@ func TestAgentRuntimeConfigRestartsUnhealthyHostedAgent(t *testing.T) {
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
 					Command:   bin,
-					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
+					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
 					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
 				},
 			},
@@ -650,7 +650,7 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
 					Command:   bin,
-					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
+					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
 					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
 				},
 			},
@@ -732,7 +732,7 @@ func TestAgentRuntimeConfigDoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntim
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
 					Command:   bin,
-					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
+					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
 					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
 				},
 			},
@@ -801,7 +801,7 @@ func TestAgentRuntimeConfigReplacesExpiresOnlyRuntimeBeforeExpiry(t *testing.T) 
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
 					Command:   bin,
-					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
+					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
 					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
 				},
 			},

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2217,7 +2217,7 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 		"managed": {
 			Source:  config.ProviderSource{Path: "stub"},
 			Default: true,
-			IndexedDB: &config.PluginIndexedDBConfig{
+			IndexedDB: &config.HostIndexedDBBindingConfig{
 				Provider:     "test",
 				DB:           "agent_resume",
 				ObjectStores: []string{"provider_state"},
@@ -3174,7 +3174,7 @@ func TestBootstrapPassesIndexedDBHostSocketToWorkflowProviders(t *testing.T) {
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"basic": {
 			Source: config.ProviderSource{Path: "stub"},
-			IndexedDB: &config.PluginIndexedDBConfig{
+			IndexedDB: &config.HostIndexedDBBindingConfig{
 				Provider:     "workflow_state",
 				DB:           "workflow",
 				ObjectStores: []string{"workflow_schedules", "workflow_runs"},
@@ -3229,7 +3229,7 @@ func TestBootstrapPassesIndexedDBHostSocketToAgentProviders(t *testing.T) {
 	cfg.Providers.Agent = map[string]*config.ProviderEntry{
 		"simple": {
 			Source: config.ProviderSource{Path: "stub"},
-			IndexedDB: &config.PluginIndexedDBConfig{
+			IndexedDB: &config.HostIndexedDBBindingConfig{
 				Provider:     "agent_state",
 				DB:           "agent_simple",
 				ObjectStores: []string{"runs"},
@@ -3379,7 +3379,7 @@ func TestBootstrapClosesWorkflowIndexedDBAndAppliesScopedConfig(t *testing.T) {
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"basic": {
 			Source: config.ProviderSource{Path: "stub"},
-			IndexedDB: &config.PluginIndexedDBConfig{
+			IndexedDB: &config.HostIndexedDBBindingConfig{
 				Provider:     "workflow_state",
 				DB:           "workflow",
 				ObjectStores: []string{"workflow_runs"},
@@ -3503,7 +3503,7 @@ func TestBootstrapRoutesWorkflowIndexedDBHostServices(t *testing.T) {
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"basic": {
 			Source: config.ProviderSource{Path: "stub"},
-			IndexedDB: &config.PluginIndexedDBConfig{
+			IndexedDB: &config.HostIndexedDBBindingConfig{
 				Provider:     "workflow_state",
 				DB:           "workflow",
 				ObjectStores: []string{"workflow_runs"},

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -2189,7 +2189,7 @@ func TestPythonSourcePluginFallsBackWithoutGoOnPath(t *testing.T) {
 		t.Fatalf("WriteFile(manifest.yaml): %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
-plugin = "provider"
+provider = "provider"
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(pyproject.toml): %v", err)
 	}
@@ -3422,7 +3422,7 @@ func TestPluginIndexedDBExposeHostSocketEnv(t *testing.T) {
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 
-	makeConfig := func(indexedDB *config.PluginIndexedDBConfig) *config.Config {
+	makeConfig := func(indexedDB *config.HostIndexedDBBindingConfig) *config.Config {
 		return &config.Config{
 			Plugins: map[string]*config.ProviderEntry{
 				"echoext": {
@@ -3445,7 +3445,7 @@ func TestPluginIndexedDBExposeHostSocketEnv(t *testing.T) {
 		},
 	}
 
-	checkEnv := func(t *testing.T, indexedDB *config.PluginIndexedDBConfig, envName string) bool {
+	checkEnv := func(t *testing.T, indexedDB *config.HostIndexedDBBindingConfig, envName string) bool {
 		t.Helper()
 		providers, _, err := buildProvidersStrict(context.Background(), makeConfig(indexedDB), NewFactoryRegistry(), Deps{
 			SelectedIndexedDBName: "main",
@@ -3480,16 +3480,16 @@ func TestPluginIndexedDBExposeHostSocketEnv(t *testing.T) {
 	if got := checkEnv(t, nil, providerhost.DefaultIndexedDBSocketEnv); !got {
 		t.Fatal("default IndexedDB env should be set when plugin omits indexeddb and inherits the host selection")
 	}
-	if got := checkEnv(t, &config.PluginIndexedDBConfig{}, providerhost.DefaultIndexedDBSocketEnv); !got {
+	if got := checkEnv(t, &config.HostIndexedDBBindingConfig{}, providerhost.DefaultIndexedDBSocketEnv); !got {
 		t.Fatal("default IndexedDB env should be set when plugin indexeddb is explicitly empty")
 	}
-	if got := checkEnv(t, &config.PluginIndexedDBConfig{Provider: "archive"}, providerhost.DefaultIndexedDBSocketEnv); !got {
+	if got := checkEnv(t, &config.HostIndexedDBBindingConfig{Provider: "archive"}, providerhost.DefaultIndexedDBSocketEnv); !got {
 		t.Fatal("default IndexedDB env should be set when plugin explicitly selects one indexeddb provider")
 	}
 	if got := checkEnv(t, nil, providerhost.IndexedDBSocketEnv("main")); got {
 		t.Fatal("named IndexedDB env should not be set for inherited plugin indexeddb access")
 	}
-	if got := checkEnv(t, &config.PluginIndexedDBConfig{Provider: "archive"}, providerhost.IndexedDBSocketEnv("archive")); got {
+	if got := checkEnv(t, &config.HostIndexedDBBindingConfig{Provider: "archive"}, providerhost.IndexedDBSocketEnv("archive")); got {
 		t.Fatal("named IndexedDB env should not be set when plugins expose a single indexeddb socket")
 	}
 }
@@ -6072,7 +6072,7 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
-				IndexedDB:            &config.PluginIndexedDBConfig{ObjectStores: []string{"tasks"}},
+				IndexedDB:            &config.HostIndexedDBBindingConfig{ObjectStores: []string{"tasks"}},
 			},
 		},
 	}
@@ -6200,7 +6200,7 @@ func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testi
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
-				IndexedDB:            &config.PluginIndexedDBConfig{ObjectStores: []string{"tasks"}},
+				IndexedDB:            &config.HostIndexedDBBindingConfig{ObjectStores: []string{"tasks"}},
 			},
 		},
 	}
@@ -8036,11 +8036,11 @@ func TestPluginIndexedDBInheritsHostSelectionAndDefaultDBName(t *testing.T) {
 
 	cases := []struct {
 		name      string
-		indexedDB *config.PluginIndexedDBConfig
+		indexedDB *config.HostIndexedDBBindingConfig
 	}{
 		{name: "omitted indexeddb inherits host selection"},
-		{name: "empty indexeddb inherits host selection", indexedDB: &config.PluginIndexedDBConfig{}},
-		{name: "objectStores-only indexeddb inherits host selection", indexedDB: &config.PluginIndexedDBConfig{ObjectStores: []string{"tasks"}}},
+		{name: "empty indexeddb inherits host selection", indexedDB: &config.HostIndexedDBBindingConfig{}},
+		{name: "objectStores-only indexeddb inherits host selection", indexedDB: &config.HostIndexedDBBindingConfig{ObjectStores: []string{"tasks"}}},
 	}
 	runtimeModes := []struct {
 		name   string
@@ -8139,7 +8139,7 @@ func TestPluginIndexedDBBuildScopedConfig(t *testing.T) {
 		Config map[string]any `yaml:"config"`
 	}
 
-	makeConfig := func(indexedDB *config.PluginIndexedDBConfig) *config.Config {
+	makeConfig := func(indexedDB *config.HostIndexedDBBindingConfig) *config.Config {
 		return &config.Config{
 			Plugins: map[string]*config.ProviderEntry{
 				"echoext": {
@@ -8190,26 +8190,26 @@ func TestPluginIndexedDBBuildScopedConfig(t *testing.T) {
 
 	cases := []struct {
 		name       string
-		indexedDB  *config.PluginIndexedDBConfig
+		indexedDB  *config.HostIndexedDBBindingConfig
 		wantDSN    string
 		wantDB     string
 		wantSQLite bool
 	}{
 		{
 			name:      "defaults db to plugin name for postgres",
-			indexedDB: &config.PluginIndexedDBConfig{Provider: "postgres"},
+			indexedDB: &config.HostIndexedDBBindingConfig{Provider: "postgres"},
 			wantDSN:   "postgres://db.example.test/gestalt",
 			wantDB:    "echoext",
 		},
 		{
 			name:      "uses db override for postgres",
-			indexedDB: &config.PluginIndexedDBConfig{Provider: "postgres", DB: "roadmap_state"},
+			indexedDB: &config.HostIndexedDBBindingConfig{Provider: "postgres", DB: "roadmap_state"},
 			wantDSN:   "postgres://db.example.test/gestalt",
 			wantDB:    "roadmap_state",
 		},
 		{
 			name:       "uses db override for sqlite table prefixes",
-			indexedDB:  &config.PluginIndexedDBConfig{Provider: "sqlite", DB: "roadmap_state"},
+			indexedDB:  &config.HostIndexedDBBindingConfig{Provider: "sqlite", DB: "roadmap_state"},
 			wantDSN:    "sqlite://plugin-state.db",
 			wantDB:     "roadmap_state",
 			wantSQLite: true,
@@ -8360,7 +8360,7 @@ func TestPluginIndexedDBRouteObjectStoresAndTransportPrefix(t *testing.T) {
 						Args:                 []string{"provider"},
 						ResolvedManifest:     manifest,
 						ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-						IndexedDB: &config.PluginIndexedDBConfig{
+						IndexedDB: &config.HostIndexedDBBindingConfig{
 							Provider:     "memory",
 							DB:           "roadmap",
 							ObjectStores: []string{"tasks"},
@@ -8451,7 +8451,7 @@ func TestPluginIndexedDBRouteObjectStoresWithoutTransportPrefix(t *testing.T) {
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				IndexedDB: &config.PluginIndexedDBConfig{
+				IndexedDB: &config.HostIndexedDBBindingConfig{
 					Provider:     "postgres",
 					DB:           "roadmap",
 					ObjectStores: []string{"tasks"},
@@ -8556,7 +8556,7 @@ func TestPluginIndexedDBPreserveLegacyTransportPrefixedData(t *testing.T) {
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				IndexedDB: &config.PluginIndexedDBConfig{
+				IndexedDB: &config.HostIndexedDBBindingConfig{
 					Provider:     "memory",
 					DB:           "roadmap",
 					ObjectStores: []string{"tasks"},
@@ -8642,7 +8642,7 @@ func TestPluginIndexedDBProviderOverrideUsesExplicitHostIndexedDB(t *testing.T) 
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				IndexedDB: &config.PluginIndexedDBConfig{
+				IndexedDB: &config.HostIndexedDBBindingConfig{
 					Provider: "archive",
 					DB:       "roadmap",
 				},
@@ -8729,7 +8729,7 @@ func TestPluginIndexedDBBindingsCleanupOnS3BindingFailure(t *testing.T) {
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				IndexedDB:            &config.PluginIndexedDBConfig{Provider: "main"},
+				IndexedDB:            &config.HostIndexedDBBindingConfig{Provider: "main"},
 				S3:                   []string{"missing"},
 			},
 		},

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -494,11 +494,6 @@ type HostIndexedDBBindingConfig struct {
 	ObjectStores []string `yaml:"objectStores,omitempty"`
 }
 
-// PluginIndexedDBConfig is kept as a source-compatible alias for older code and
-// tests. The binding is no longer plugin-specific: plugins, workflow providers,
-// and agent providers all use the same host IndexedDB service shape.
-type PluginIndexedDBConfig = HostIndexedDBBindingConfig
-
 type pluginUIBindingConfig struct {
 	Path   string `yaml:"path,omitempty"`
 	Bundle string `yaml:"bundle,omitempty"`

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -376,7 +376,7 @@ plugins:
 	if authorizationName != "indexeddb" || authorizationEntry == nil {
 		t.Fatalf("SelectedAuthorizationProvider = (%q, %#v), want indexeddb", authorizationName, authorizationEntry)
 	}
-	wantIndexedDB := &PluginIndexedDBConfig{Provider: "archive"}
+	wantIndexedDB := &HostIndexedDBBindingConfig{Provider: "archive"}
 	if got := cfg.Plugins["service-a"].IndexedDB; !reflect.DeepEqual(got, wantIndexedDB) {
 		t.Fatalf("Plugins[service-a].IndexedDB = %#v, want %#v", got, wantIndexedDB)
 	}
@@ -2268,7 +2268,7 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		want := &PluginIndexedDBConfig{
+		want := &HostIndexedDBBindingConfig{
 			Provider:     "archive",
 			DB:           "roadmap_review",
 			ObjectStores: []string{"tasks", "snapshots"},
@@ -2304,7 +2304,7 @@ server:
 			t.Fatalf("Load: %v", err)
 		}
 		got := cfg.Plugins["roadmap"].IndexedDB
-		want := &PluginIndexedDBConfig{
+		want := &HostIndexedDBBindingConfig{
 			Provider: "sqlite",
 		}
 		if !reflect.DeepEqual(got, want) {
@@ -2432,7 +2432,7 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		want := &PluginIndexedDBConfig{DB: "plugin_data"}
+		want := &HostIndexedDBBindingConfig{DB: "plugin_data"}
 		if got := cfg.Plugins["datadog"].IndexedDB; !reflect.DeepEqual(got, want) {
 			t.Fatalf("Plugins[datadog].IndexedDB = %#v, want %#v", got, want)
 		}
@@ -3498,7 +3498,7 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		want := &PluginIndexedDBConfig{
+		want := &HostIndexedDBBindingConfig{
 			Provider:     "workflow_state",
 			DB:           "workflow",
 			ObjectStores: []string{"workflow_schedules", "workflow_runs"},
@@ -3544,7 +3544,7 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		want := &PluginIndexedDBConfig{
+		want := &HostIndexedDBBindingConfig{
 			Provider:     "agent_state",
 			DB:           "agent_simple",
 			ObjectStores: []string{"runs", "run_idempotency"},

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -2828,7 +2828,7 @@ build-backend = "setuptools.build_meta"
 name = "local-python-provider"
 
 [tool.gestalt]
-plugin = "provider"
+provider = "provider"
 	`, "\n")), 0o644)
 	writeTestFile("provider.py", []byte(`from typing import Optional
 

--- a/gestaltd/internal/providerpkg/python_provider.go
+++ b/gestaltd/internal/providerpkg/python_provider.go
@@ -29,7 +29,7 @@ var ErrNoPythonSourceComponentPackage = errors.New("no Python source component p
 var pythonIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 func DetectPythonProviderTarget(root string) (string, error) {
-	target, err := detectPythonProjectTarget(root, "plugin")
+	target, err := detectPythonProjectTarget(root, "provider")
 	if err != nil {
 		if errors.Is(err, ErrNoPythonSourceComponentPackage) {
 			return "", ErrNoPythonProviderPackage
@@ -79,11 +79,7 @@ func detectPythonProjectTarget(root, key string) (string, error) {
 		return "", ErrNoPythonSourceComponentPackage
 	}
 	if _, _, err := SplitPythonProviderTarget(target); err != nil {
-		label := key
-		if key == "plugin" {
-			label = "provider/plugin"
-		}
-		return "", fmt.Errorf("%s tool.gestalt.%s: %w", pythonProjectFile, label, err)
+		return "", fmt.Errorf("%s tool.gestalt.%s: %w", pythonProjectFile, key, err)
 	}
 	return target, nil
 }
@@ -308,12 +304,6 @@ func isPythonIdentifier(value string) bool {
 }
 
 func pythonProjectTarget(data []byte, wantedKey string) (string, error) {
-	if wantedKey == "plugin" {
-		target, err := pythonProjectTargetValue(data, "provider")
-		if err != nil || target != "" {
-			return target, err
-		}
-	}
 	return pythonProjectTargetValue(data, wantedKey)
 }
 

--- a/gestaltd/internal/providerpkg/python_provider_test.go
+++ b/gestaltd/internal/providerpkg/python_provider_test.go
@@ -1,6 +1,7 @@
 package providerpkg
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -62,7 +63,7 @@ func TestDetectPythonComponentTarget(t *testing.T) {
 
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
-plugin = "provider"
+provider = "provider"
 authentication = "provider:auth_provider"
 cache = "provider:cache_provider"
 indexeddb = "provider:indexeddb_provider"
@@ -114,23 +115,19 @@ provider = "provider"
 	}
 }
 
-func TestDetectPythonProviderTarget_PrefersProviderKeyOverLegacyPluginKey(t *testing.T) {
+func TestDetectPythonProviderTarget_IgnoresLegacyPluginKey(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
-provider = "provider"
 plugin = "legacy_provider"
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(pyproject.toml): %v", err)
 	}
 
-	target, err := DetectPythonProviderTarget(root)
-	if err != nil {
-		t.Fatalf("DetectPythonProviderTarget: %v", err)
-	}
-	if target != "provider" {
-		t.Fatalf("target = %q, want %q", target, "provider")
+	_, err := DetectPythonProviderTarget(root)
+	if !errors.Is(err, ErrNoPythonProviderPackage) {
+		t.Fatalf("error = %v, want %v", err, ErrNoPythonProviderPackage)
 	}
 }
 
@@ -139,7 +136,7 @@ func TestDetectPythonComponentTarget_MissingKindReturnsNoSourceComponentPackage(
 
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
-plugin = "provider"
+provider = "provider"
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(pyproject.toml): %v", err)
 	}

--- a/gestaltd/internal/providerpkg/source_provider_test.go
+++ b/gestaltd/internal/providerpkg/source_provider_test.go
@@ -15,7 +15,7 @@ func TestDetectSourceProvider_FallsBackToPythonWhenCargoIsWorkspaceManifest(t *t
 	root := t.TempDir()
 	writeRustWorkspaceCargoToml(t, root)
 	mustWriteFile(t, filepath.Join(root, pythonProjectFile), []byte(`[tool.gestalt]
-plugin = "provider.plugin:plugin"
+provider = "provider.plugin:plugin"
 `), 0o644)
 
 	kind, target, err := detectSourceProvider(root, runtime.GOOS, runtime.GOARCH)

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -7,9 +7,8 @@ It is published to PyPI as `gestalt-sdk` and imported in provider code as
 `gestalt`.
 
 It is intended to be used by source providers discovered through
-`[tool.gestalt].provider` in `pyproject.toml` (or the legacy
-`[tool.gestalt].plugin` key) and by packaged providers built from that
-same source tree.
+`[tool.gestalt].provider` in `pyproject.toml` and by packaged providers
+built from that same source tree.
 
 Python source providers are developed locally via `from.source.path` and
 released through `gestaltd provider release` for the host platform by default,

--- a/sdk/python/gestalt/_bootstrap.py
+++ b/sdk/python/gestalt/_bootstrap.py
@@ -24,9 +24,9 @@ def parse_plugin_target(target: str) -> PluginTarget:
     module_name = module_name.strip()
     attribute_name = attribute_name.strip() or None
     if not module_name:
-        raise RuntimeError("tool.gestalt.provider or tool.gestalt.plugin must be in module or module:attribute form")
+        raise RuntimeError("tool.gestalt.provider must be in module or module:attribute form")
     if sep and attribute_name is None:
-        raise RuntimeError("tool.gestalt.provider or tool.gestalt.plugin attribute is required when ':' is present")
+        raise RuntimeError("tool.gestalt.provider attribute is required when ':' is present")
 
     return PluginTarget(
         module_name=module_name,
@@ -76,5 +76,4 @@ def write_bundled_plugin_config(
         ),
         encoding="utf-8",
     )
-
 


### PR DESCRIPTION
## Summary
- remove the exported `config.PluginIndexedDBConfig` compatibility alias; plugin IndexedDB bindings now use `config.HostIndexedDBBindingConfig` directly
- remove Python source discovery support for the legacy `[tool.gestalt].plugin` key; source providers now use `[tool.gestalt].provider` only
- update docs and test fixtures to use the canonical provider fields

## Removed interfaces
```go
&config.PluginIndexedDBConfig{
    Provider: "default",
    DB: "plugin_data",
    ObjectStores: []string{"tasks"},
}
```

```toml
[tool.gestalt]
plugin = "provider"
```

## Canonical interfaces
```go
&config.HostIndexedDBBindingConfig{
    Provider: "default",
    DB: "plugin_data",
    ObjectStores: []string{"tasks"},
}
```

```toml
[tool.gestalt]
provider = "provider"
```

## Validation
- `go test ./internal/config -count=1`
- `go test ./internal/bootstrap -run 'Test.*IndexedDB|Test.*Agent.*Runtime|Test.*Executable|Test.*PythonSource' -count=1`\n- `go test ./internal/providerpkg -run 'TestDetectPython|TestDetectSourceProvider_FallsBackToPythonWhenCargoIsWorkspaceManifest' -count=1`\n- `go test ./cmd/gestaltd -run 'TestRun_ProviderReleaseRejectsInvalidPythonProviderTarget|TestRun_ProviderRelease.*Python|Test.*PythonSource' -count=1`\n- `go test ./internal/operator -run 'Test.*Python|Test.*ProviderDev' -count=1`\n- `uv run python -m unittest discover -s tests -p '*runtime*.py'`\n- `golangci-lint run ./internal/config ./internal/bootstrap ./internal/providerpkg ./internal/operator ./cmd/gestaltd`\n- `git diff --check`