### PR TITLE
Remove internal provider type aliases

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1732,7 +1732,7 @@ func isLoopbackAllowedHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func buildPluginIndexedDBHostServices(pluginName string, effective config.EffectivePluginIndexedDB, deps Deps) ([]providerhost.HostService, func(), error) {
+func buildPluginIndexedDBHostServices(pluginName string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]providerhost.HostService, func(), error) {
 	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
 		return nil, nil, fmt.Errorf("indexeddb host services are not available")
 	}
@@ -1834,7 +1834,7 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 	return hostServices, nil
 }
 
-func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveWorkflowIndexedDB, deps Deps) ([]providerhost.HostService, func(), error) {
+func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]providerhost.HostService, func(), error) {
 	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
 		return nil, nil, fmt.Errorf("indexeddb host services are not available")
 	}
@@ -1858,7 +1858,7 @@ func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveW
 	}, nil
 }
 
-func buildAgentIndexedDBHostServices(name string, effective config.EffectiveAgentIndexedDB, deps Deps) ([]providerhost.HostService, func(), error) {
+func buildAgentIndexedDBHostServices(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]providerhost.HostService, func(), error) {
 	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
 		return nil, nil, fmt.Errorf("indexeddb host services are not available")
 	}
@@ -2075,7 +2075,7 @@ func (unavailableAgentManager) ResolveInteraction(context.Context, *principal.Pr
 	return nil, fmt.Errorf("agent manager is not available")
 }
 
-func buildPluginScopedIndexedDB(pluginName string, effective config.EffectivePluginIndexedDB, deps Deps) (indexeddb.IndexedDB, error) {
+func buildPluginScopedIndexedDB(pluginName string, effective config.EffectiveHostIndexedDBBinding, deps Deps) (indexeddb.IndexedDB, error) {
 	return buildScopedIndexedDB(scopedIndexedDBBuildOptions{
 		MetricsName:        effective.ProviderName,
 		ProviderName:       effective.ProviderName,
@@ -2086,7 +2086,7 @@ func buildPluginScopedIndexedDB(pluginName string, effective config.EffectivePlu
 	}, deps)
 }
 
-func buildWorkflowScopedIndexedDB(name string, effective config.EffectiveWorkflowIndexedDB, deps Deps) (indexeddb.IndexedDB, error) {
+func buildWorkflowScopedIndexedDB(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) (indexeddb.IndexedDB, error) {
 	return buildScopedIndexedDB(scopedIndexedDBBuildOptions{
 		MetricsName:   name,
 		ProviderName:  effective.ProviderName,
@@ -2095,7 +2095,7 @@ func buildWorkflowScopedIndexedDB(name string, effective config.EffectiveWorkflo
 	}, deps)
 }
 
-func buildAgentScopedIndexedDB(name string, effective config.EffectiveAgentIndexedDB, deps Deps) (indexeddb.IndexedDB, error) {
+func buildAgentScopedIndexedDB(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) (indexeddb.IndexedDB, error) {
 	return buildScopedIndexedDB(scopedIndexedDBBuildOptions{
 		MetricsName:   name,
 		ProviderName:  effective.ProviderName,

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -120,10 +120,6 @@ type EffectiveHostIndexedDBBinding struct {
 	ObjectStores []string
 }
 
-type EffectivePluginIndexedDB = EffectiveHostIndexedDBBinding
-type EffectiveWorkflowIndexedDB = EffectiveHostIndexedDBBinding
-type EffectiveAgentIndexedDB = EffectiveHostIndexedDBBinding
-
 type EffectiveHostedRuntime struct {
 	Enabled      bool
 	ProviderName string
@@ -138,10 +134,10 @@ type EffectiveExecution struct {
 	Hosted EffectiveHostedRuntime
 }
 
-func (c *Config) EffectivePluginIndexedDB(pluginName string, entry *ProviderEntry) (EffectivePluginIndexedDB, error) {
+func (c *Config) EffectivePluginIndexedDB(pluginName string, entry *ProviderEntry) (EffectiveHostIndexedDBBinding, error) {
 	selectedName, _, err := c.SelectedIndexedDBProvider()
 	if err != nil {
-		return EffectivePluginIndexedDB{}, err
+		return EffectiveHostIndexedDBBinding{}, err
 	}
 	return ResolveEffectivePluginIndexedDB(pluginName, entry, selectedName, c.Providers.IndexedDB)
 }
@@ -176,11 +172,11 @@ func (c *Config) EffectiveAgentProvider(providerName string) (string, *ProviderE
 	return c.SelectedAgentProvider()
 }
 
-func (c *Config) EffectiveWorkflowIndexedDB(name string, entry *ProviderEntry) (EffectiveWorkflowIndexedDB, error) {
+func (c *Config) EffectiveWorkflowIndexedDB(name string, entry *ProviderEntry) (EffectiveHostIndexedDBBinding, error) {
 	return ResolveEffectiveWorkflowIndexedDB(name, entry, c.Providers.IndexedDB)
 }
 
-func (c *Config) EffectiveAgentIndexedDB(name string, entry *ProviderEntry) (EffectiveAgentIndexedDB, error) {
+func (c *Config) EffectiveAgentIndexedDB(name string, entry *ProviderEntry) (EffectiveHostIndexedDBBinding, error) {
 	return ResolveEffectiveAgentIndexedDB(name, entry, c.Providers.IndexedDB)
 }
 
@@ -203,9 +199,9 @@ func (c *Config) EffectiveExecution(configPath string, entry *ProviderEntry) (Ef
 	return ResolveEffectiveExecution(configPath, entry, selectedName, c.Runtime.Providers)
 }
 
-func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, selectedName string, entries map[string]*ProviderEntry) (EffectivePluginIndexedDB, error) {
+func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, selectedName string, entries map[string]*ProviderEntry) (EffectiveHostIndexedDBBinding, error) {
 	if entry == nil {
-		return EffectivePluginIndexedDB{}, nil
+		return EffectiveHostIndexedDBBinding{}, nil
 	}
 
 	providerName := ""
@@ -217,14 +213,14 @@ func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, se
 	}
 	if providerName == "" {
 		if entry.IndexedDB != nil && (strings.TrimSpace(entry.IndexedDB.DB) != "" || len(entry.IndexedDB.ObjectStores) > 0) {
-			return EffectivePluginIndexedDB{}, fmt.Errorf("config validation: plugins.%s.indexeddb requires indexeddb.provider or an available selected/default host indexeddb", pluginName)
+			return EffectiveHostIndexedDBBinding{}, fmt.Errorf("config validation: plugins.%s.indexeddb requires indexeddb.provider or an available selected/default host indexeddb", pluginName)
 		}
-		return EffectivePluginIndexedDB{}, nil
+		return EffectiveHostIndexedDBBinding{}, nil
 	}
 
 	provider, ok := entries[providerName]
 	if !ok || provider == nil {
-		return EffectivePluginIndexedDB{}, fmt.Errorf("config validation: plugins.%s.indexeddb.provider references unknown indexeddb %q", pluginName, providerName)
+		return EffectiveHostIndexedDBBinding{}, fmt.Errorf("config validation: plugins.%s.indexeddb.provider references unknown indexeddb %q", pluginName, providerName)
 	}
 
 	dbName := pluginName
@@ -237,7 +233,7 @@ func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, se
 		objectStores = slices.Clone(entry.IndexedDB.ObjectStores)
 	}
 
-	return EffectivePluginIndexedDB{
+	return EffectiveHostIndexedDBBinding{
 		Enabled:      true,
 		ProviderName: providerName,
 		Provider:     provider,
@@ -246,19 +242,19 @@ func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, se
 	}, nil
 }
 
-func ResolveEffectiveWorkflowIndexedDB(name string, entry *ProviderEntry, entries map[string]*ProviderEntry) (EffectiveWorkflowIndexedDB, error) {
+func ResolveEffectiveWorkflowIndexedDB(name string, entry *ProviderEntry, entries map[string]*ProviderEntry) (EffectiveHostIndexedDBBinding, error) {
 	if entry == nil || entry.IndexedDB == nil {
-		return EffectiveWorkflowIndexedDB{}, nil
+		return EffectiveHostIndexedDBBinding{}, nil
 	}
 
 	providerName := strings.TrimSpace(entry.IndexedDB.Provider)
 	if providerName == "" {
-		return EffectiveWorkflowIndexedDB{}, fmt.Errorf("config validation: providers.workflow.%s.indexeddb.provider is required", name)
+		return EffectiveHostIndexedDBBinding{}, fmt.Errorf("config validation: providers.workflow.%s.indexeddb.provider is required", name)
 	}
 
 	provider, ok := entries[providerName]
 	if !ok || provider == nil {
-		return EffectiveWorkflowIndexedDB{}, fmt.Errorf("config validation: providers.workflow.%s.indexeddb.provider references unknown indexeddb %q", name, providerName)
+		return EffectiveHostIndexedDBBinding{}, fmt.Errorf("config validation: providers.workflow.%s.indexeddb.provider references unknown indexeddb %q", name, providerName)
 	}
 
 	dbName := strings.TrimSpace(entry.IndexedDB.DB)
@@ -266,7 +262,7 @@ func ResolveEffectiveWorkflowIndexedDB(name string, entry *ProviderEntry, entrie
 		dbName = name
 	}
 
-	return EffectiveWorkflowIndexedDB{
+	return EffectiveHostIndexedDBBinding{
 		Enabled:      true,
 		ProviderName: providerName,
 		Provider:     provider,
@@ -275,19 +271,19 @@ func ResolveEffectiveWorkflowIndexedDB(name string, entry *ProviderEntry, entrie
 	}, nil
 }
 
-func ResolveEffectiveAgentIndexedDB(name string, entry *ProviderEntry, entries map[string]*ProviderEntry) (EffectiveAgentIndexedDB, error) {
+func ResolveEffectiveAgentIndexedDB(name string, entry *ProviderEntry, entries map[string]*ProviderEntry) (EffectiveHostIndexedDBBinding, error) {
 	if entry == nil || entry.IndexedDB == nil {
-		return EffectiveAgentIndexedDB{}, nil
+		return EffectiveHostIndexedDBBinding{}, nil
 	}
 
 	providerName := strings.TrimSpace(entry.IndexedDB.Provider)
 	if providerName == "" {
-		return EffectiveAgentIndexedDB{}, fmt.Errorf("config validation: providers.agent.%s.indexeddb.provider is required", name)
+		return EffectiveHostIndexedDBBinding{}, fmt.Errorf("config validation: providers.agent.%s.indexeddb.provider is required", name)
 	}
 
 	provider, ok := entries[providerName]
 	if !ok || provider == nil {
-		return EffectiveAgentIndexedDB{}, fmt.Errorf("config validation: providers.agent.%s.indexeddb.provider references unknown indexeddb %q", name, providerName)
+		return EffectiveHostIndexedDBBinding{}, fmt.Errorf("config validation: providers.agent.%s.indexeddb.provider references unknown indexeddb %q", name, providerName)
 	}
 
 	dbName := strings.TrimSpace(entry.IndexedDB.DB)
@@ -295,7 +291,7 @@ func ResolveEffectiveAgentIndexedDB(name string, entry *ProviderEntry, entries m
 		dbName = name
 	}
 
-	return EffectiveAgentIndexedDB{
+	return EffectiveHostIndexedDBBinding{
 		Enabled:      true,
 		ProviderName: providerName,
 		Provider:     provider,

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -46,21 +46,21 @@ const (
 )
 
 type Lockfile struct {
-	Version             int                          `json:"version"`
-	Providers           map[string]LockProviderEntry `json:"providers"`
-	Authentication      map[string]LockEntry         `json:"authentication,omitempty"`
-	Authorization       map[string]LockEntry         `json:"authorization,omitempty"`
-	ExternalCredentials map[string]LockEntry         `json:"externalCredentials,omitempty"`
-	IndexedDBs          map[string]LockEntry         `json:"indexeddbs,omitempty"`
-	Caches              map[string]LockEntry         `json:"cache,omitempty"`
-	S3                  map[string]LockEntry         `json:"s3,omitempty"`
-	Workflows           map[string]LockEntry         `json:"workflow,omitempty"`
-	Agents              map[string]LockEntry         `json:"agent,omitempty"`
-	Runtimes            map[string]LockEntry         `json:"runtime,omitempty"`
-	Secrets             map[string]LockEntry         `json:"secrets,omitempty"`
-	Telemetry           map[string]LockEntry         `json:"telemetry,omitempty"`
-	Audit               map[string]LockEntry         `json:"audit,omitempty"`
-	UIs                 map[string]LockUIEntry       `json:"ui,omitempty"`
+	Version             int                  `json:"version"`
+	Providers           map[string]LockEntry `json:"providers"`
+	Authentication      map[string]LockEntry `json:"authentication,omitempty"`
+	Authorization       map[string]LockEntry `json:"authorization,omitempty"`
+	ExternalCredentials map[string]LockEntry `json:"externalCredentials,omitempty"`
+	IndexedDBs          map[string]LockEntry `json:"indexeddbs,omitempty"`
+	Caches              map[string]LockEntry `json:"cache,omitempty"`
+	S3                  map[string]LockEntry `json:"s3,omitempty"`
+	Workflows           map[string]LockEntry `json:"workflow,omitempty"`
+	Agents              map[string]LockEntry `json:"agent,omitempty"`
+	Runtimes            map[string]LockEntry `json:"runtime,omitempty"`
+	Secrets             map[string]LockEntry `json:"secrets,omitempty"`
+	Telemetry           map[string]LockEntry `json:"telemetry,omitempty"`
+	Audit               map[string]LockEntry `json:"audit,omitempty"`
+	UIs                 map[string]LockEntry `json:"ui,omitempty"`
 }
 
 // LockArchive records a platform-specific archive URL and optional integrity hash.
@@ -81,9 +81,6 @@ type LockEntry struct {
 	Executable  string                 `json:"executable,omitempty"`
 	AssetRoot   string                 `json:"assetRoot,omitempty"`
 }
-
-type LockProviderEntry = LockEntry
-type LockUIEntry = LockEntry
 
 type Lifecycle struct {
 	configSecretResolver func(context.Context, *config.Config) error
@@ -1642,20 +1639,20 @@ func localLockEntryFromPreparedInstall(paths initPaths, kind, name string, plugi
 	}, nil
 }
 
-func localUILockEntryFromPreparedInstall(paths initPaths, name string, plugin *config.ProviderEntry, install *preparedInstall) (LockUIEntry, error) {
+func localUILockEntryFromPreparedInstall(paths initPaths, name string, plugin *config.ProviderEntry, install *preparedInstall) (LockEntry, error) {
 	fingerprint, err := NamedUIProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("fingerprinting ui %q: %w", name, err)
+		return LockEntry{}, fmt.Errorf("fingerprinting ui %q: %w", name, err)
 	}
 	manifestPath, err := relativePreparedPath(paths.artifactsDir, install.manifestPath)
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("compute manifest path for ui %q: %w", name, err)
+		return LockEntry{}, fmt.Errorf("compute manifest path for ui %q: %w", name, err)
 	}
 	assetRoot, err := relativePreparedPath(paths.artifactsDir, install.assetRootPath)
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("compute asset root path for ui %q: %w", name, err)
+		return LockEntry{}, fmt.Errorf("compute asset root path for ui %q: %w", name, err)
 	}
-	return LockUIEntry{
+	return LockEntry{
 		Fingerprint: fingerprint,
 		Manifest:    manifestPath,
 		AssetRoot:   assetRoot,
@@ -1730,8 +1727,8 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 	return installed, entry, nil
 }
 
-func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Config, paths initPaths) (map[string]LockProviderEntry, error) {
-	written := make(map[string]LockProviderEntry)
+func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Config, paths initPaths) (map[string]LockEntry, error) {
+	written := make(map[string]LockEntry)
 	for name, entry := range cfg.Plugins {
 		if entry == nil {
 			continue
@@ -1816,17 +1813,17 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 	return entry, nil
 }
 
-func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, configMap map[string]any) (LockProviderEntry, error) {
+func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
 	if plugin != nil && plugin.HasLocalSource() {
 		install, err := prepareLocalSourceInstall(providermanifestv1.KindPlugin, name, plugin.SourcePath(), providerDestDir(paths, name))
 		if err != nil {
-			return LockProviderEntry{}, err
+			return LockEntry{}, err
 		}
 		if err := validateInstalledManifestKind(providermanifestv1.KindPlugin, name, install.manifest); err != nil {
-			return LockProviderEntry{}, err
+			return LockEntry{}, err
 		}
 		if err := providerpkg.ValidateConfigForManifest(install.manifestPath, install.manifest, providermanifestv1.KindPlugin, configMap); err != nil {
-			return LockProviderEntry{}, fmt.Errorf("provider config validation for provider %q: %w", name, err)
+			return LockEntry{}, fmt.Errorf("provider config validation for provider %q: %w", name, err)
 		}
 		return localLockEntryFromPreparedInstall(paths, providermanifestv1.KindPlugin, name, plugin, install)
 	}
@@ -1835,33 +1832,33 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 	destDir := providerDestDir(paths, name)
 	var (
 		installed *pluginstore.InstalledPlugin
-		entry     LockProviderEntry
+		entry     LockEntry
 		err       error
 	)
 	if !plugin.HasReleaseMetadataSource() {
-		return LockProviderEntry{}, fmt.Errorf("provider %q source %q: only provider-release metadata sources and local manifest paths are supported", name, sourceLocation)
+		return LockEntry{}, fmt.Errorf("provider %q source %q: only provider-release metadata sources and local manifest paths are supported", name, sourceLocation)
 	}
 	installed, entry, err = l.installMetadataSourcePackage(ctx, providermanifestv1.KindPlugin, name, fmt.Sprintf("provider %q", name), destDir, plugin, paths.configDir)
 	if err != nil {
-		return LockProviderEntry{}, err
+		return LockEntry{}, err
 	}
 
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindPlugin, configMap); err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider config validation for provider %q: %w", name, err)
+		return LockEntry{}, fmt.Errorf("provider config validation for provider %q: %w", name, err)
 	}
 	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("fingerprinting provider %q: %w", name, err)
+		return LockEntry{}, fmt.Errorf("fingerprinting provider %q: %w", name, err)
 	}
 	manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
 	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("compute manifest path for provider %q: %w", name, err)
+		return LockEntry{}, fmt.Errorf("compute manifest path for provider %q: %w", name, err)
 	}
 	executableRel := ""
 	if installed.ExecutablePath != "" {
 		executableRel, err = filepath.Rel(paths.artifactsDir, installed.ExecutablePath)
 		if err != nil {
-			return LockProviderEntry{}, fmt.Errorf("compute executable path for provider %q: %w", name, err)
+			return LockEntry{}, fmt.Errorf("compute executable path for provider %q: %w", name, err)
 		}
 	}
 	entry.Fingerprint = fingerprint
@@ -1870,32 +1867,32 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 	return entry, nil
 }
 
-func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, destDir string, subject string) (LockUIEntry, error) {
+func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, destDir string, subject string) (LockEntry, error) {
 	if plugin == nil || !sourceBacked(plugin) {
-		return LockUIEntry{}, fmt.Errorf("%s requires source configuration", subject)
+		return LockEntry{}, fmt.Errorf("%s requires source configuration", subject)
 	}
 	configMap, err := config.NodeToMap(plugin.Config)
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("decode %s config: %w", subject, err)
+		return LockEntry{}, fmt.Errorf("decode %s config: %w", subject, err)
 	}
 	fingerprint, err := NamedUIProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("fingerprinting %s: %w", subject, err)
+		return LockEntry{}, fmt.Errorf("fingerprinting %s: %w", subject, err)
 	}
 	if plugin.HasLocalSource() {
 		install, err := prepareLocalSourceInstall(providermanifestv1.KindUI, name, plugin.SourcePath(), destDir)
 		if err != nil {
-			return LockUIEntry{}, err
+			return LockEntry{}, err
 		}
 		if err := validateInstalledManifestKind(providermanifestv1.KindUI, subject, install.manifest); err != nil {
-			return LockUIEntry{}, err
+			return LockEntry{}, err
 		}
 		if err := providerpkg.ValidateConfigForManifest(install.manifestPath, install.manifest, providermanifestv1.KindUI, configMap); err != nil {
-			return LockUIEntry{}, fmt.Errorf("provider config validation for %s: %w", subject, err)
+			return LockEntry{}, fmt.Errorf("provider config validation for %s: %w", subject, err)
 		}
 		entry, err := localUILockEntryFromPreparedInstall(paths, name, plugin, install)
 		if err != nil {
-			return LockUIEntry{}, err
+			return LockEntry{}, err
 		}
 		entry.Fingerprint = fingerprint
 		return entry, nil
@@ -1904,26 +1901,26 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 
 	var (
 		installed *pluginstore.InstalledPlugin
-		entry     LockUIEntry
+		entry     LockEntry
 		opErr     error
 	)
 	if !plugin.HasReleaseMetadataSource() {
-		return LockUIEntry{}, fmt.Errorf("%s source %q: only provider-release metadata sources and local manifest paths are supported", subject, expectedPackage)
+		return LockEntry{}, fmt.Errorf("%s source %q: only provider-release metadata sources and local manifest paths are supported", subject, expectedPackage)
 	}
 	installed, entry, opErr = l.installMetadataSourcePackage(ctx, providermanifestv1.KindUI, name, subject, destDir, plugin, paths.configDir)
 	if opErr != nil {
-		return LockUIEntry{}, opErr
+		return LockEntry{}, opErr
 	}
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindUI, configMap); err != nil {
-		return LockUIEntry{}, fmt.Errorf("provider config validation for %s: %w", subject, err)
+		return LockEntry{}, fmt.Errorf("provider config validation for %s: %w", subject, err)
 	}
 	manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("compute manifest path for %s: %w", subject, err)
+		return LockEntry{}, fmt.Errorf("compute manifest path for %s: %w", subject, err)
 	}
 	assetRoot, err := filepath.Rel(paths.artifactsDir, installed.AssetRoot)
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("compute asset root path for %s: %w", subject, err)
+		return LockEntry{}, fmt.Errorf("compute asset root path for %s: %w", subject, err)
 	}
 	entry.Fingerprint = fingerprint
 	entry.Manifest = filepath.ToSlash(manifestPath)
@@ -2002,7 +1999,7 @@ func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg 
 		if entry == nil {
 			continue
 		}
-		var lockEntry *LockUIEntry
+		var lockEntry *LockEntry
 		if lock != nil {
 			if le, ok := lock.UIs[name]; ok {
 				lockEntry = &le
@@ -2291,7 +2288,7 @@ func equivalentProviderManifestPath(current, expected string) bool {
 		currentManifest.Version == expectedManifest.Version
 }
 
-func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUIEntry, provider *config.ProviderEntry, logicalName, subject, destDir string, locked bool) (string, error) {
+func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockEntry, provider *config.ProviderEntry, logicalName, subject, destDir string, locked bool) (string, error) {
 	if provider == nil {
 		return "", nil
 	}
@@ -2562,7 +2559,7 @@ func bindPathBackedUIManifest(plugin *config.ProviderEntry, configMap map[string
 	return assetRoot, nil
 }
 
-func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, entry LockProviderEntry, locked bool) error {
+func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, entry LockEntry, locked bool) error {
 	platform := providerpkg.CurrentPlatformString()
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
@@ -2679,7 +2676,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 	return nil
 }
 
-func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initPaths, plugin *config.ProviderEntry, entry LockUIEntry, destDir string, locked bool) error {
+func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initPaths, plugin *config.ProviderEntry, entry LockEntry, destDir string, locked bool) error {
 	platform := providerpkg.CurrentPlatformString()
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1779,7 +1779,7 @@ server:
 	paths := initPathsForConfig(cfgPath)
 	staleLock := &Lockfile{
 		Version: LockVersion,
-		Providers: map[string]LockProviderEntry{
+		Providers: map[string]LockEntry{
 			"roadmap": {
 				Fingerprint: mustFingerprint(t, "roadmap", loadedCfg.Plugins["roadmap"], paths.configDir),
 				Source:      srv.URL + "/providers/roadmap-plugin/v" + version + "/provider-release.yaml",
@@ -1923,7 +1923,7 @@ server:
 	}
 	paths := initPathsForConfig(cfgPath)
 	lock := normalizeLockfile(initialLock)
-	lock.Providers = map[string]LockProviderEntry{
+	lock.Providers = map[string]LockEntry{
 		"roadmap": {
 			Fingerprint: mustFingerprint(t, "roadmap", loadedCfg.Plugins["roadmap"], paths.configDir),
 			Source:      srv.URL + "/providers/roadmap-plugin/v" + newVersion + "/provider-release.yaml",
@@ -2003,7 +2003,7 @@ server:
 		t.Fatalf("InitAtPath: %v", err)
 	}
 
-	lock.Providers["example"] = LockProviderEntry{
+	lock.Providers["example"] = LockEntry{
 		Fingerprint: lock.Providers["example"].Fingerprint,
 		Source:      lock.Providers["example"].Source,
 		Version:     lock.Providers["example"].Version,
@@ -2463,7 +2463,7 @@ authorization:
 	}
 }
 
-func TestLockProviderEntryForSource_RejectsManifestWithoutProviderKind(t *testing.T) {
+func TestLockEntryForSource_RejectsManifestWithoutProviderKind(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -2532,7 +2532,7 @@ func TestHashPlatformInEntries_HashesMountedUIAndProviderArchives(t *testing.T) 
 				},
 			},
 		},
-		UIs: map[string]LockUIEntry{
+		UIs: map[string]LockEntry{
 			"roadmap": {
 				Source: "github.com/testowner/web/roadmap",
 				Archives: map[string]LockArchive{
@@ -3814,7 +3814,7 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	lockPath := filepath.Join(dir, InitLockfileName)
 	want := &Lockfile{
 		Version: LockVersion,
-		Providers: map[string]LockProviderEntry{
+		Providers: map[string]LockEntry{
 			"example": {
 				Fingerprint: "provider-fp",
 				Source:      "github.com/test-org/test-repo/test-plugin",
@@ -3896,7 +3896,7 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 				},
 			},
 		},
-		UIs: map[string]LockUIEntry{
+		UIs: map[string]LockEntry{
 			"roadmap": {
 				Fingerprint: "ui-fp",
 				Source:      "github.com/test-org/test-repo/test-ui",

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -61,7 +61,7 @@ type portableLockEntry struct {
 func newLockfile() *Lockfile {
 	return &Lockfile{
 		Version:             LockVersion,
-		Providers:           make(map[string]LockProviderEntry),
+		Providers:           make(map[string]LockEntry),
 		Authentication:      make(map[string]LockEntry),
 		Authorization:       make(map[string]LockEntry),
 		ExternalCredentials: make(map[string]LockEntry),
@@ -74,7 +74,7 @@ func newLockfile() *Lockfile {
 		Secrets:             make(map[string]LockEntry),
 		Telemetry:           make(map[string]LockEntry),
 		Audit:               make(map[string]LockEntry),
-		UIs:                 make(map[string]LockUIEntry),
+		UIs:                 make(map[string]LockEntry),
 	}
 }
 
@@ -86,7 +86,7 @@ func normalizeLockfile(lock *Lockfile) *Lockfile {
 		lock.Version = LockVersion
 	}
 	if lock.Providers == nil {
-		lock.Providers = make(map[string]LockProviderEntry)
+		lock.Providers = make(map[string]LockEntry)
 	}
 	if lock.Authentication == nil {
 		lock.Authentication = make(map[string]LockEntry)
@@ -125,7 +125,7 @@ func normalizeLockfile(lock *Lockfile) *Lockfile {
 		lock.IndexedDBs = make(map[string]LockEntry)
 	}
 	if lock.UIs == nil {
-		lock.UIs = make(map[string]LockUIEntry)
+		lock.UIs = make(map[string]LockEntry)
 	}
 	return lock
 }


### PR DESCRIPTION
## Summary
- remove `operator.LockProviderEntry` and `operator.LockUIEntry`; all lockfile buckets now use `operator.LockEntry` directly
- remove `config.EffectivePluginIndexedDB`, `config.EffectiveWorkflowIndexedDB`, and `config.EffectiveAgentIndexedDB`; the semantic resolver functions now return `config.EffectiveHostIndexedDBBinding` directly
- keep function names like `EffectivePluginIndexedDB` and `ResolveEffectiveWorkflowIndexedDB` so call sites still express the owning provider surface

## Removed interfaces
```go
operator.LockProviderEntry{Manifest: "manifest.yaml"}
operator.LockUIEntry{Manifest: "manifest.yaml", AssetRoot: "ui"}
```

```go
var plugin config.EffectivePluginIndexedDB
var workflow config.EffectiveWorkflowIndexedDB
var agent config.EffectiveAgentIndexedDB
```

## Canonical interfaces
```go
operator.LockEntry{Manifest: "manifest.yaml", AssetRoot: "ui"}
```

```go
effective, err := cfg.EffectivePluginIndexedDB("github", entry)
// effective is config.EffectiveHostIndexedDBBinding
```

## Validation
- `go test ./internal/config -run 'Test.*IndexedDB|TestLoadConfig' -count=1`\n- `go test ./internal/operator -run 'Test.*Lock|Test.*Provider|Test.*UI' -count=1`\n- `go test ./internal/bootstrap -run 'Test.*IndexedDB|Test.*Runtime|Test.*Workflow|Test.*Agent' -count=1`\n- `golangci-lint run ./internal/config ./internal/operator ./internal/bootstrap`\n- `git diff --check`