### PR TITLE
Consolidate duplicative gestaltd tests

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -2580,85 +2580,79 @@ func TestE2EInitAndServeLayeredConfigs(t *testing.T) {
 	}
 }
 
-func TestE2EServeAutoInitUsesOverrideLockfile(t *testing.T) {
+func TestE2EServeUsesOverrideLockfile(t *testing.T) {
 	t.Parallel()
 
 	if testing.Short() {
-		t.Skip("skipping E2E serve lockfile override test in short mode")
+		t.Skip("skipping E2E serve lockfile override tests in short mode")
 	}
 
-	dir := t.TempDir()
-	cfgPath := writeServeConfig(t, dir, 0, nil)
-	lockPath := filepath.Join(dir, "state", "serve", "gestalt.lock.json")
-
-	baseURL := startGestaltdWithConfigsAndArgs(t, []string{cfgPath}, []string{"serve", "--lockfile", lockPath}, lockPath)
-	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(baseURL + "/api/v1/integrations")
-	if err != nil {
-		t.Fatalf("GET /api/v1/integrations: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected /api/v1/integrations 200, got %d: %s", resp.StatusCode, body)
-	}
-	if _, err := os.Stat(filepath.Join(dir, "gestalt.lock.json")); !os.IsNotExist(err) {
-		t.Fatalf("default lockfile should not be written, got err=%v", err)
-	}
-}
-
-func TestE2EDefaultServeAutoInitUsesOverrideLockfile(t *testing.T) {
-	t.Parallel()
-
-	if testing.Short() {
-		t.Skip("skipping default serve lockfile override test in short mode")
-	}
-
-	dir := t.TempDir()
-	cfgPath := writeServeConfig(t, dir, 0, nil)
-	lockPath := filepath.Join(dir, "state", "default-serve", "gestalt.lock.json")
-
-	baseURL := startGestaltdWithConfigsAndArgs(t, []string{cfgPath}, []string{"--lockfile", lockPath}, lockPath)
-	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(baseURL + "/api/v1/integrations")
-	if err != nil {
-		t.Fatalf("GET /api/v1/integrations: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected /api/v1/integrations 200, got %d: %s", resp.StatusCode, body)
-	}
-	if _, err := os.Stat(filepath.Join(dir, "gestalt.lock.json")); !os.IsNotExist(err) {
-		t.Fatalf("default lockfile should not be written, got err=%v", err)
-	}
-}
-
-func TestE2EServeLockedUsesOverrideLockfile(t *testing.T) {
-	t.Parallel()
-
-	if testing.Short() {
-		t.Skip("skipping locked serve lockfile override test in short mode")
+	tests := []struct {
+		name       string
+		lockDir    string
+		args       func(lockPath string) []string
+		preInit    bool
+		waitForNew bool
+	}{
+		{
+			name:    "serve auto init",
+			lockDir: "serve",
+			args: func(lockPath string) []string {
+				return []string{"serve", "--lockfile", lockPath}
+			},
+			waitForNew: true,
+		},
+		{
+			name:    "default serve auto init",
+			lockDir: "default-serve",
+			args: func(lockPath string) []string {
+				return []string{"--lockfile", lockPath}
+			},
+			waitForNew: true,
+		},
+		{
+			name:    "locked serve",
+			lockDir: "locked-serve",
+			args: func(lockPath string) []string {
+				return []string{"serve", "--locked", "--lockfile", lockPath}
+			},
+			preInit: true,
+		},
 	}
 
-	dir := t.TempDir()
-	cfgPath := writeServeConfig(t, dir, 0, nil)
-	lockPath := filepath.Join(dir, "state", "locked-serve", "gestalt.lock.json")
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
-	if err != nil {
-		t.Fatalf("gestaltd init with --lockfile failed: %v\noutput: %s", err, out)
-	}
-	baseURL := startGestaltdWithConfigsAndArgs(t, []string{cfgPath}, []string{"serve", "--locked", "--lockfile", lockPath}, "")
-	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(baseURL + "/api/v1/integrations")
-	if err != nil {
-		t.Fatalf("GET /api/v1/integrations: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected /api/v1/integrations 200, got %d: %s", resp.StatusCode, body)
-	}
-	if _, err := os.Stat(filepath.Join(dir, "gestalt.lock.json")); !os.IsNotExist(err) {
-		t.Fatalf("default lockfile should not be written, got err=%v", err)
+			dir := t.TempDir()
+			cfgPath := writeServeConfig(t, dir, 0, nil)
+			lockPath := filepath.Join(dir, "state", tc.lockDir, "gestalt.lock.json")
+			if tc.preInit {
+				out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+				if err != nil {
+					t.Fatalf("gestaltd init with --lockfile failed: %v\noutput: %s", err, out)
+				}
+			}
+
+			requiredPath := ""
+			if tc.waitForNew {
+				requiredPath = lockPath
+			}
+			baseURL := startGestaltdWithConfigsAndArgs(t, []string{cfgPath}, tc.args(lockPath), requiredPath)
+			resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(baseURL + "/api/v1/integrations")
+			if err != nil {
+				t.Fatalf("GET /api/v1/integrations: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("expected /api/v1/integrations 200, got %d: %s", resp.StatusCode, body)
+			}
+			if _, err := os.Stat(filepath.Join(dir, "gestalt.lock.json")); !os.IsNotExist(err) {
+				t.Fatalf("default lockfile should not be written, got err=%v", err)
+			}
+		})
 	}
 }
 

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -147,105 +147,92 @@ func TestResolveProviderRemoteTokenUsesMatchingStoredCLICredential(t *testing.T)
 	}
 }
 
-func TestResolveProviderRemoteTokenRejectsDifferentBasePaths(t *testing.T) {
-	configHome := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", configHome)
-	t.Setenv(gestaltAPIKeyEnv, "")
-	writeStoredGestaltCLICredentialForTest(t, configHome, "https://valon.tools/team-a", "stored-token")
-
-	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
-		Remote: "https://valon.tools/team-b",
-	})
-	if err == nil {
-		t.Fatal("expected path-scoped stored credential mismatch error")
+func TestResolveProviderRemoteTokenErrors(t *testing.T) {
+	tests := []struct {
+		name         string
+		remote       string
+		storedServer string
+		writeStored  bool
+		want         func(configHome string) []string
+	}{
+		{
+			name:         "different base paths",
+			remote:       "https://valon.tools/team-b",
+			storedServer: "https://valon.tools/team-a",
+			writeStored:  true,
+			want: func(string) []string {
+				return []string{
+					"Remote server:\n  https://valon.tools/team-b",
+					"Stored credential:\n  server: https://valon.tools/team-a",
+					"The stored credential is scoped to a different Gestalt server, so it was not sent.",
+				}
+			},
+		},
+		{
+			name:         "mismatched stored credential",
+			remote:       "https://staging.valon.tools",
+			storedServer: "https://valon.tools",
+			writeStored:  true,
+			want: func(configHome string) []string {
+				return []string{
+					"provider dev --remote could not use the stored Gestalt CLI credential.",
+					"Remote server:\n  https://staging.valon.tools",
+					"Stored credential:\n  server: https://valon.tools",
+					filepath.Join(configHome, "gestalt", "credentials.json"),
+					"The stored credential is scoped to a different Gestalt server, so it was not sent.",
+					"gestalt auth login --url https://staging.valon.tools",
+					"gestaltd provider dev --remote https://staging.valon.tools --remote-token <token> --path ./plugin",
+					"You can also set GESTALT_API_KEY for this command",
+				}
+			},
+		},
+		{
+			name:        "unscoped stored credential",
+			remote:      "https://valon.tools",
+			writeStored: true,
+			want: func(string) []string {
+				return []string{
+					"Stored credential:\n  server: <missing>",
+					"The stored credential does not record which Gestalt server it belongs to, so it was not sent.",
+					"gestalt auth login --url https://valon.tools",
+				}
+			},
+		},
+		{
+			name:   "missing credential",
+			remote: "https://valon.tools",
+			want: func(string) []string {
+				return []string{
+					"provider dev --remote requires authentication.",
+					"Remote server:\n  https://valon.tools",
+					"No --remote-token or GESTALT_API_KEY was provided, and no stored Gestalt CLI credential for this server was found.",
+					"gestalt auth login --url https://valon.tools",
+					"gestaltd provider dev --remote https://valon.tools --remote-token <token> --path ./plugin",
+				}
+			},
+		},
 	}
-	errText := err.Error()
-	for _, want := range []string{
-		"Remote server:\n  https://valon.tools/team-b",
-		"Stored credential:\n  server: https://valon.tools/team-a",
-		"The stored credential is scoped to a different Gestalt server, so it was not sent.",
-	} {
-		if !strings.Contains(errText, want) {
-			t.Fatalf("error missing %q:\n%s", want, errText)
-		}
-	}
-}
 
-func TestResolveProviderRemoteTokenRejectsMismatchedStoredCLICredential(t *testing.T) {
-	configHome := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", configHome)
-	t.Setenv(gestaltAPIKeyEnv, "")
-	writeStoredGestaltCLICredentialForTest(t, configHome, "https://valon.tools", "stored-token")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configHome := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", configHome)
+			t.Setenv(gestaltAPIKeyEnv, "")
+			if tc.writeStored {
+				writeStoredGestaltCLICredentialForTest(t, configHome, tc.storedServer, "stored-token")
+			}
 
-	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
-		Remote: "https://staging.valon.tools",
-	})
-	if err == nil {
-		t.Fatal("expected stored credential mismatch error")
-	}
-	errText := err.Error()
-	for _, want := range []string{
-		"provider dev --remote could not use the stored Gestalt CLI credential.",
-		"Remote server:\n  https://staging.valon.tools",
-		"Stored credential:\n  server: https://valon.tools",
-		filepath.Join(configHome, "gestalt", "credentials.json"),
-		"The stored credential is scoped to a different Gestalt server, so it was not sent.",
-		"gestalt auth login --url https://staging.valon.tools",
-		"gestaltd provider dev --remote https://staging.valon.tools --remote-token <token> --path ./plugin",
-		"You can also set GESTALT_API_KEY for this command",
-	} {
-		if !strings.Contains(errText, want) {
-			t.Fatalf("error missing %q:\n%s", want, errText)
-		}
-	}
-}
-
-func TestResolveProviderRemoteTokenRejectsUnscopedStoredCLICredential(t *testing.T) {
-	configHome := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", configHome)
-	t.Setenv(gestaltAPIKeyEnv, "")
-	writeStoredGestaltCLICredentialForTest(t, configHome, "", "legacy-token")
-
-	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
-		Remote: "https://valon.tools",
-	})
-	if err == nil {
-		t.Fatal("expected unscoped stored credential error")
-	}
-	errText := err.Error()
-	for _, want := range []string{
-		"Stored credential:\n  server: <missing>",
-		"The stored credential does not record which Gestalt server it belongs to, so it was not sent.",
-		"gestalt auth login --url https://valon.tools",
-	} {
-		if !strings.Contains(errText, want) {
-			t.Fatalf("error missing %q:\n%s", want, errText)
-		}
-	}
-}
-
-func TestResolveProviderRemoteTokenRequiresAuthWhenNoCredentialExists(t *testing.T) {
-	configHome := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", configHome)
-	t.Setenv(gestaltAPIKeyEnv, "")
-
-	_, err := resolveProviderRemoteToken(providerLocalCommandOptions{
-		Remote: "https://valon.tools",
-	})
-	if err == nil {
-		t.Fatal("expected missing auth error")
-	}
-	errText := err.Error()
-	for _, want := range []string{
-		"provider dev --remote requires authentication.",
-		"Remote server:\n  https://valon.tools",
-		"No --remote-token or GESTALT_API_KEY was provided, and no stored Gestalt CLI credential for this server was found.",
-		"gestalt auth login --url https://valon.tools",
-		"gestaltd provider dev --remote https://valon.tools --remote-token <token> --path ./plugin",
-	} {
-		if !strings.Contains(errText, want) {
-			t.Fatalf("error missing %q:\n%s", want, errText)
-		}
+			_, err := resolveProviderRemoteToken(providerLocalCommandOptions{Remote: tc.remote})
+			if err == nil {
+				t.Fatal("expected remote token resolution error")
+			}
+			errText := err.Error()
+			for _, want := range tc.want(configHome) {
+				if !strings.Contains(errText, want) {
+					t.Fatalf("error missing %q:\n%s", want, errText)
+				}
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -4917,169 +4917,117 @@ func TestPluginInvokesDoNotLeakCallerAccessToPolicylessTargets(t *testing.T) {
 	}
 }
 
-func TestPluginInvokesRejectUndeclaredTargets(t *testing.T) {
+func TestPluginInvokesRejectInvalidTargetRequests(t *testing.T) {
 	t.Parallel()
 
-	harness := newNestedInvokeHarness(t)
-	ctx := context.Background()
-	user := newNestedInvokeUser(t, harness, ctx, "nested-declared@test.com")
-	storeNestedInvokeToken(t, harness, ctx, user.ID, "caller", "work", "default")
-	storeNestedInvokeToken(t, harness, ctx, user.ID, "example", "work", "default")
-
-	result, err := harness.invoker.Invoke(
-		invocation.WithConnection(context.Background(), "work"),
-		&principal.Principal{
-			UserID: user.ID,
-			Kind:   principal.KindUser,
-			Source: principal.SourceSession,
-			Scopes: []string{"caller", "example"},
+	type tokenSpec struct {
+		plugin     string
+		connection string
+		instance   string
+	}
+	tests := []struct {
+		name      string
+		email     string
+		tokens    []tokenSpec
+		params    map[string]any
+		wantError string
+	}{
+		{
+			name:  "undeclared target",
+			email: "nested-declared@test.com",
+			tokens: []tokenSpec{
+				{plugin: "caller", connection: "work", instance: "default"},
+				{plugin: "example", connection: "work", instance: "default"},
+			},
+			params: map[string]any{
+				"plugin":    "example",
+				"operation": "status",
+			},
+			wantError: `may not invoke example.status`,
 		},
-		"caller",
-		"",
-		"invoke_plugin",
-		map[string]any{
-			"plugin":    "example",
-			"operation": "status",
+		{
+			name:  "invalid invocation token",
+			email: "nested-invalid-handle@test.com",
+			tokens: []tokenSpec{
+				{plugin: "caller", connection: "work", instance: "default"},
+				{plugin: "example", connection: "work", instance: "default"},
+			},
+			params: map[string]any{
+				"plugin":           "example",
+				"operation":        "request_context",
+				"invocation_token": "forged-token",
+			},
+			wantError: "invalid or expired",
 		},
-	)
-	if err != nil {
-		t.Fatalf("Invoke(caller.invoke_plugin): %v", err)
-	}
-
-	var got invokePluginEnvelope
-	if err := json.Unmarshal([]byte(result.Body), &got); err != nil {
-		t.Fatalf("json.Unmarshal: %v", err)
-	}
-	if got.OK {
-		t.Fatalf("expected undeclared target rejection, got success: %+v", got)
-	}
-	if !strings.Contains(got.Error, `may not invoke example.status`) {
-		t.Fatalf("undeclared target error = %q, want target rejection", got.Error)
-	}
-}
-
-func TestPluginInvokesRejectInvalidInvocationToken(t *testing.T) {
-	t.Parallel()
-
-	harness := newNestedInvokeHarness(t)
-	ctx := context.Background()
-	user := newNestedInvokeUser(t, harness, ctx, "nested-invalid-handle@test.com")
-	storeNestedInvokeToken(t, harness, ctx, user.ID, "caller", "work", "default")
-	storeNestedInvokeToken(t, harness, ctx, user.ID, "example", "work", "default")
-
-	result, err := harness.invoker.Invoke(
-		invocation.WithConnection(context.Background(), "work"),
-		&principal.Principal{
-			UserID: user.ID,
-			Kind:   principal.KindUser,
-			Source: principal.SourceSession,
-			Scopes: []string{"caller", "example"},
+		{
+			name:  "missing target token",
+			email: "nested-no-target-token@test.com",
+			tokens: []tokenSpec{
+				{plugin: "caller", connection: "work", instance: "default"},
+			},
+			params: map[string]any{
+				"plugin":    "example",
+				"operation": "request_context",
+			},
+			wantError: "code = FailedPrecondition",
 		},
-		"caller",
-		"",
-		"invoke_plugin",
-		map[string]any{
-			"plugin":           "example",
-			"operation":        "request_context",
-			"invocation_token": "forged-token",
+		{
+			name:  "ambiguous target instance",
+			email: "nested-ambiguous-target@test.com",
+			tokens: []tokenSpec{
+				{plugin: "caller", connection: "work", instance: "default"},
+				{plugin: "example", connection: "work", instance: "primary"},
+				{plugin: "example", connection: "work", instance: "secondary"},
+			},
+			params: map[string]any{
+				"plugin":     "example",
+				"operation":  "request_context",
+				"connection": "work",
+			},
+			wantError: "code = Aborted",
 		},
-	)
-	if err != nil {
-		t.Fatalf("Invoke(caller.invoke_plugin): %v", err)
 	}
 
-	var got invokePluginEnvelope
-	if err := json.Unmarshal([]byte(result.Body), &got); err != nil {
-		t.Fatalf("json.Unmarshal: %v", err)
-	}
-	if got.OK {
-		t.Fatalf("expected invalid invocation token rejection, got success: %+v", got)
-	}
-	if !strings.Contains(got.Error, "invalid or expired") {
-		t.Fatalf("invalid invocation token error = %q, want invalid or expired", got.Error)
-	}
-}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-func TestPluginInvokesMissingTargetTokenReturnsFailedPrecondition(t *testing.T) {
-	t.Parallel()
+			harness := newNestedInvokeHarness(t)
+			ctx := context.Background()
+			user := newNestedInvokeUser(t, harness, ctx, tc.email)
+			for _, token := range tc.tokens {
+				storeNestedInvokeToken(t, harness, ctx, user.ID, token.plugin, token.connection, token.instance)
+			}
 
-	harness := newNestedInvokeHarness(t)
-	ctx := context.Background()
-	user := newNestedInvokeUser(t, harness, ctx, "nested-no-target-token@test.com")
-	storeNestedInvokeToken(t, harness, ctx, user.ID, "caller", "work", "default")
+			result, err := harness.invoker.Invoke(
+				invocation.WithConnection(context.Background(), "work"),
+				&principal.Principal{
+					UserID: user.ID,
+					Kind:   principal.KindUser,
+					Source: principal.SourceSession,
+					Scopes: []string{"caller", "example"},
+				},
+				"caller",
+				"",
+				"invoke_plugin",
+				tc.params,
+			)
+			if err != nil {
+				t.Fatalf("Invoke(caller.invoke_plugin): %v", err)
+			}
 
-	result, err := harness.invoker.Invoke(
-		invocation.WithConnection(context.Background(), "work"),
-		&principal.Principal{
-			UserID: user.ID,
-			Kind:   principal.KindUser,
-			Source: principal.SourceSession,
-			Scopes: []string{"caller", "example"},
-		},
-		"caller",
-		"",
-		"invoke_plugin",
-		map[string]any{
-			"plugin":    "example",
-			"operation": "request_context",
-		},
-	)
-	if err != nil {
-		t.Fatalf("Invoke(caller.invoke_plugin): %v", err)
-	}
-
-	var got invokePluginEnvelope
-	if err := json.Unmarshal([]byte(result.Body), &got); err != nil {
-		t.Fatalf("json.Unmarshal: %v", err)
-	}
-	if got.OK {
-		t.Fatalf("expected missing target token envelope, got success: %+v", got)
-	}
-	if !strings.Contains(got.Error, "code = FailedPrecondition") {
-		t.Fatalf("missing target token error = %q, want FailedPrecondition", got.Error)
-	}
-}
-
-func TestPluginInvokesAmbiguousTargetInstanceReturnsAborted(t *testing.T) {
-	t.Parallel()
-
-	harness := newNestedInvokeHarness(t)
-	ctx := context.Background()
-	user := newNestedInvokeUser(t, harness, ctx, "nested-ambiguous-target@test.com")
-	storeNestedInvokeToken(t, harness, ctx, user.ID, "caller", "work", "default")
-	storeNestedInvokeToken(t, harness, ctx, user.ID, "example", "work", "primary")
-	storeNestedInvokeToken(t, harness, ctx, user.ID, "example", "work", "secondary")
-
-	result, err := harness.invoker.Invoke(
-		invocation.WithConnection(context.Background(), "work"),
-		&principal.Principal{
-			UserID: user.ID,
-			Kind:   principal.KindUser,
-			Source: principal.SourceSession,
-			Scopes: []string{"caller", "example"},
-		},
-		"caller",
-		"",
-		"invoke_plugin",
-		map[string]any{
-			"plugin":     "example",
-			"operation":  "request_context",
-			"connection": "work",
-		},
-	)
-	if err != nil {
-		t.Fatalf("Invoke(caller.invoke_plugin): %v", err)
-	}
-
-	var got invokePluginEnvelope
-	if err := json.Unmarshal([]byte(result.Body), &got); err != nil {
-		t.Fatalf("json.Unmarshal: %v", err)
-	}
-	if got.OK {
-		t.Fatalf("expected ambiguous target instance envelope, got success: %+v", got)
-	}
-	if !strings.Contains(got.Error, "code = Aborted") {
-		t.Fatalf("ambiguous target instance error = %q, want Aborted", got.Error)
+			var got invokePluginEnvelope
+			if err := json.Unmarshal([]byte(result.Body), &got); err != nil {
+				t.Fatalf("json.Unmarshal: %v", err)
+			}
+			if got.OK {
+				t.Fatalf("expected error envelope, got success: %+v", got)
+			}
+			if !strings.Contains(got.Error, tc.wantError) {
+				t.Fatalf("error = %q, want substring %q", got.Error, tc.wantError)
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/oauth/upstream_test.go
+++ b/gestaltd/internal/oauth/upstream_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 )
 
@@ -284,177 +285,160 @@ func TestPKCEExchangeCode(t *testing.T) {
 func TestClientAuthHeader(t *testing.T) {
 	t.Parallel()
 
-	var gotAuth string
-	var formHasClientID bool
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
-		if err := r.ParseForm(); err != nil {
-			http.Error(w, "bad form", http.StatusBadRequest)
-			return
-		}
-		formHasClientID = r.FormValue("client_id") != ""
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token": "header-token",
-			"token_type":   "Bearer",
+	tests := []struct {
+		name      string
+		call      func(*UpstreamHandler) (*core.TokenResponse, error)
+		wantToken string
+	}{
+		{
+			name: "authorization code",
+			call: func(h *UpstreamHandler) (*core.TokenResponse, error) {
+				return h.ExchangeCode(context.Background(), "code")
+			},
+			wantToken: "header-token",
+		},
+		{
+			name: "refresh token",
+			call: func(h *UpstreamHandler) (*core.TokenResponse, error) {
+				return h.RefreshToken(context.Background(), "rt")
+			},
+			wantToken: "refreshed",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotAuth string
+			var formHasClientID bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotAuth = r.Header.Get("Authorization")
+				if err := r.ParseForm(); err != nil {
+					http.Error(w, "bad form", http.StatusBadRequest)
+					return
+				}
+				formHasClientID = r.FormValue("client_id") != ""
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token": tc.wantToken,
+					"token_type":   "Bearer",
+				})
+			}))
+			testutil.CloseOnCleanup(t, srv)
+
+			h := NewUpstream(UpstreamConfig{
+				ClientID:         "my-id",
+				ClientSecret:     "my-secret",
+				TokenURL:         srv.URL + "/token",
+				RedirectURL:      srv.URL + "/callback",
+				ClientAuthMethod: ClientAuthHeader,
+			})
+
+			tok, err := tc.call(h)
+			if err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if tok.AccessToken != tc.wantToken {
+				t.Errorf("AccessToken = %q, want %q", tok.AccessToken, tc.wantToken)
+			}
+			if !strings.HasPrefix(gotAuth, "Basic ") {
+				t.Errorf("expected Basic auth header, got %q", gotAuth)
+			}
+			if formHasClientID {
+				t.Error("client_id should not appear in form body with ClientAuthHeader")
+			}
 		})
-	}))
-	testutil.CloseOnCleanup(t, srv)
-
-	h := NewUpstream(UpstreamConfig{
-		ClientID:         "my-id",
-		ClientSecret:     "my-secret",
-		TokenURL:         srv.URL + "/token",
-		RedirectURL:      srv.URL + "/callback",
-		ClientAuthMethod: ClientAuthHeader,
-	})
-
-	tok, err := h.ExchangeCode(context.Background(), "code")
-	if err != nil {
-		t.Fatalf("ExchangeCode: %v", err)
-	}
-	if tok.AccessToken != "header-token" {
-		t.Errorf("AccessToken = %q, want %q", tok.AccessToken, "header-token")
-	}
-	if !strings.HasPrefix(gotAuth, "Basic ") {
-		t.Errorf("expected Basic auth header, got %q", gotAuth)
-	}
-	if formHasClientID {
-		t.Error("client_id should not appear in form body with ClientAuthHeader")
-	}
-}
-
-func TestClientAuthHeaderRefresh(t *testing.T) {
-	t.Parallel()
-
-	var gotAuth string
-	var formHasClientID bool
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
-		if err := r.ParseForm(); err != nil {
-			http.Error(w, "bad form", http.StatusBadRequest)
-			return
-		}
-		formHasClientID = r.FormValue("client_id") != ""
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token": "refreshed",
-			"token_type":   "Bearer",
-		})
-	}))
-	testutil.CloseOnCleanup(t, srv)
-
-	h := NewUpstream(UpstreamConfig{
-		ClientID:         "my-id",
-		ClientSecret:     "my-secret",
-		TokenURL:         srv.URL + "/token",
-		ClientAuthMethod: ClientAuthHeader,
-	})
-
-	tok, err := h.RefreshToken(context.Background(), "rt")
-	if err != nil {
-		t.Fatalf("RefreshToken: %v", err)
-	}
-	if tok.AccessToken != "refreshed" {
-		t.Errorf("AccessToken = %q, want %q", tok.AccessToken, "refreshed")
-	}
-	if !strings.HasPrefix(gotAuth, "Basic ") {
-		t.Errorf("expected Basic auth header, got %q", gotAuth)
-	}
-	if formHasClientID {
-		t.Error("client_id should not appear in form body with ClientAuthHeader")
 	}
 }
 
 func TestTokenExchangeJSON(t *testing.T) {
 	t.Parallel()
 
-	var gotContentType string
-	var gotBody map[string]string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotContentType = r.Header.Get("Content-Type")
-		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			http.Error(w, "bad json", http.StatusBadRequest)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token": "json-token",
-			"token_type":   "Bearer",
+	tests := []struct {
+		name       string
+		call       func(*UpstreamHandler) (*core.TokenResponse, error)
+		wantToken  string
+		wantGrant  string
+		wantField  string
+		wantValue  string
+		redirect   string
+		wantClient bool
+	}{
+		{
+			name: "authorization code",
+			call: func(h *UpstreamHandler) (*core.TokenResponse, error) {
+				return h.ExchangeCode(context.Background(), "code-123")
+			},
+			wantToken:  "json-token",
+			wantGrant:  "authorization_code",
+			wantField:  "code",
+			wantValue:  "code-123",
+			redirect:   "http://localhost/callback",
+			wantClient: true,
+		},
+		{
+			name: "refresh token",
+			call: func(h *UpstreamHandler) (*core.TokenResponse, error) {
+				return h.RefreshToken(context.Background(), "rt-123")
+			},
+			wantToken: "json-refreshed",
+			wantGrant: "refresh_token",
+			wantField: "refresh_token",
+			wantValue: "rt-123",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotContentType string
+			var gotBody map[string]string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotContentType = r.Header.Get("Content-Type")
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					http.Error(w, "bad json", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token": tc.wantToken,
+					"token_type":   "Bearer",
+				})
+			}))
+			testutil.CloseOnCleanup(t, srv)
+
+			h := NewUpstream(UpstreamConfig{
+				ClientID:      "cid",
+				ClientSecret:  "csecret",
+				TokenURL:      srv.URL + "/token",
+				RedirectURL:   tc.redirect,
+				TokenExchange: TokenExchangeJSON,
+			})
+
+			tok, err := tc.call(h)
+			if err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if tok.AccessToken != tc.wantToken {
+				t.Errorf("AccessToken = %q, want %q", tok.AccessToken, tc.wantToken)
+			}
+			if gotContentType != "application/json" {
+				t.Errorf("Content-Type = %q, want %q", gotContentType, "application/json")
+			}
+			if gotBody["grant_type"] != tc.wantGrant {
+				t.Errorf("grant_type = %q, want %q", gotBody["grant_type"], tc.wantGrant)
+			}
+			if gotBody[tc.wantField] != tc.wantValue {
+				t.Errorf("%s = %q, want %q", tc.wantField, gotBody[tc.wantField], tc.wantValue)
+			}
+			if tc.wantClient && gotBody["client_id"] != "cid" {
+				t.Errorf("client_id = %q, want %q", gotBody["client_id"], "cid")
+			}
 		})
-	}))
-	testutil.CloseOnCleanup(t, srv)
-
-	h := NewUpstream(UpstreamConfig{
-		ClientID:      "cid",
-		ClientSecret:  "csecret",
-		TokenURL:      srv.URL + "/token",
-		RedirectURL:   srv.URL + "/callback",
-		TokenExchange: TokenExchangeJSON,
-	})
-
-	tok, err := h.ExchangeCode(context.Background(), "code-123")
-	if err != nil {
-		t.Fatalf("ExchangeCode: %v", err)
-	}
-	if tok.AccessToken != "json-token" {
-		t.Errorf("AccessToken = %q, want %q", tok.AccessToken, "json-token")
-	}
-	if gotContentType != "application/json" {
-		t.Errorf("Content-Type = %q, want %q", gotContentType, "application/json")
-	}
-	if gotBody["grant_type"] != "authorization_code" {
-		t.Errorf("grant_type = %q, want %q", gotBody["grant_type"], "authorization_code")
-	}
-	if gotBody["code"] != "code-123" {
-		t.Errorf("code = %q, want %q", gotBody["code"], "code-123")
-	}
-	if gotBody["client_id"] != "cid" {
-		t.Errorf("client_id = %q, want %q", gotBody["client_id"], "cid")
-	}
-}
-
-func TestTokenExchangeJSONRefresh(t *testing.T) {
-	t.Parallel()
-
-	var gotContentType string
-	var gotBody map[string]string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotContentType = r.Header.Get("Content-Type")
-		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			http.Error(w, "bad json", http.StatusBadRequest)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token": "json-refreshed",
-			"token_type":   "Bearer",
-		})
-	}))
-	testutil.CloseOnCleanup(t, srv)
-
-	h := NewUpstream(UpstreamConfig{
-		ClientID:      "cid",
-		ClientSecret:  "csecret",
-		TokenURL:      srv.URL + "/token",
-		TokenExchange: TokenExchangeJSON,
-	})
-
-	tok, err := h.RefreshToken(context.Background(), "rt-123")
-	if err != nil {
-		t.Fatalf("RefreshToken: %v", err)
-	}
-	if tok.AccessToken != "json-refreshed" {
-		t.Errorf("AccessToken = %q, want %q", tok.AccessToken, "json-refreshed")
-	}
-	if gotContentType != "application/json" {
-		t.Errorf("Content-Type = %q, want %q", gotContentType, "application/json")
-	}
-	if gotBody["grant_type"] != "refresh_token" {
-		t.Errorf("grant_type = %q, want %q", gotBody["grant_type"], "refresh_token")
-	}
-	if gotBody["refresh_token"] != "rt-123" {
-		t.Errorf("refresh_token = %q, want %q", gotBody["refresh_token"], "rt-123")
 	}
 }
 
@@ -593,88 +577,64 @@ func TestGenerateVerifier(t *testing.T) {
 	}
 }
 
-func TestDefaultScopesUsedWhenCallerProvidesNone(t *testing.T) {
+func TestAuthorizationURLScopes(t *testing.T) {
 	t.Parallel()
 
-	h := NewUpstream(UpstreamConfig{
-		ClientID:         "client-id",
-		AuthorizationURL: "https://example.com/authorize",
-		RedirectURL:      "https://app.com/callback",
-		DefaultScopes:    []string{"read:data"},
-	})
-
-	authURL := h.AuthorizationURL("state-1", nil)
-	parsed, err := url.Parse(authURL)
-	if err != nil {
-		t.Fatalf("parsing URL: %v", err)
+	tests := []struct {
+		name                string
+		defaultScopes       []string
+		requestScopes       []string
+		authorizationParams map[string]string
+		wantScope           string
+	}{
+		{
+			name:          "default scopes when caller provides none",
+			defaultScopes: []string{"read:data"},
+			wantScope:     "read:data",
+		},
+		{
+			name:          "default scopes when caller provides empty",
+			defaultScopes: []string{"read", "write"},
+			requestScopes: []string{},
+			wantScope:     "read write",
+		},
+		{
+			name:          "explicit scopes override defaults",
+			defaultScopes: []string{"default-scope"},
+			requestScopes: []string{"explicit-scope"},
+			wantScope:     "explicit-scope",
+		},
+		{
+			name:                "authorization params override defaults",
+			defaultScopes:       []string{"from-spec"},
+			authorizationParams: map[string]string{"scope": "from-config"},
+			wantScope:           "from-config",
+		},
 	}
-	scope := parsed.Query().Get("scope")
-	if scope != "read:data" {
-		t.Errorf("scope = %q, want %q", scope, "read:data")
-	}
-}
 
-func TestDefaultScopesUsedWhenCallerProvidesEmpty(t *testing.T) {
-	t.Parallel()
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	h := NewUpstream(UpstreamConfig{
-		ClientID:         "client-id",
-		AuthorizationURL: "https://example.com/authorize",
-		RedirectURL:      "https://app.com/callback",
-		DefaultScopes:    []string{"read", "write"},
-	})
+			h := NewUpstream(UpstreamConfig{
+				ClientID:            "client-id",
+				AuthorizationURL:    "https://example.com/authorize",
+				RedirectURL:         "https://app.com/callback",
+				DefaultScopes:       tc.defaultScopes,
+				AuthorizationParams: tc.authorizationParams,
+			})
 
-	authURL := h.AuthorizationURL("state-1", []string{})
-	parsed, err := url.Parse(authURL)
-	if err != nil {
-		t.Fatalf("parsing URL: %v", err)
-	}
-	scope := parsed.Query().Get("scope")
-	if scope != "read write" {
-		t.Errorf("scope = %q, want %q", scope, "read write")
-	}
-}
-
-func TestExplicitScopesOverrideDefaults(t *testing.T) {
-	t.Parallel()
-
-	h := NewUpstream(UpstreamConfig{
-		ClientID:         "client-id",
-		AuthorizationURL: "https://example.com/authorize",
-		RedirectURL:      "https://app.com/callback",
-		DefaultScopes:    []string{"default-scope"},
-	})
-
-	authURL := h.AuthorizationURL("state-1", []string{"explicit-scope"})
-	parsed, err := url.Parse(authURL)
-	if err != nil {
-		t.Fatalf("parsing URL: %v", err)
-	}
-	scope := parsed.Query().Get("scope")
-	if scope != "explicit-scope" {
-		t.Errorf("scope = %q, want %q", scope, "explicit-scope")
-	}
-}
-
-func TestAuthorizationParamsOverrideDefaultScopes(t *testing.T) {
-	t.Parallel()
-
-	h := NewUpstream(UpstreamConfig{
-		ClientID:            "client-id",
-		AuthorizationURL:    "https://example.com/authorize",
-		RedirectURL:         "https://app.com/callback",
-		DefaultScopes:       []string{"from-spec"},
-		AuthorizationParams: map[string]string{"scope": "from-config"},
-	})
-
-	authURL := h.AuthorizationURL("state-1", nil)
-	parsed, err := url.Parse(authURL)
-	if err != nil {
-		t.Fatalf("parsing URL: %v", err)
-	}
-	scope := parsed.Query().Get("scope")
-	if scope != "from-config" {
-		t.Errorf("scope = %q, want %q (authorization_params should override default scopes)", scope, "from-config")
+			authURL := h.AuthorizationURL("state-1", tc.requestScopes)
+			parsed, err := url.Parse(authURL)
+			if err != nil {
+				t.Fatalf("parsing URL: %v", err)
+			}
+			scope := parsed.Query().Get("scope")
+			if scope != tc.wantScope {
+				t.Errorf("scope = %q, want %q", scope, tc.wantScope)
+			}
+		})
 	}
 }
 
@@ -764,63 +724,64 @@ func TestTokenResponseExtra(t *testing.T) {
 	}
 }
 
-func TestAccessTokenPathExtractsNestedToken(t *testing.T) {
+func TestAccessTokenPath(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"ok": true,
-			"access_token": "xoxb-bot-token",
-			"token_type": "bot",
-			"authed_user": {
-				"id": "U12345",
-				"access_token": "xoxp-user-token",
-				"token_type": "user",
-				"scope": "chat:write"
+	tests := []struct {
+		name            string
+		responseBody    string
+		accessTokenPath string
+		wantToken       string
+	}{
+		{
+			name: "extracts nested token",
+			responseBody: `{
+				"ok": true,
+				"access_token": "xoxb-bot-token",
+				"token_type": "bot",
+				"authed_user": {
+					"id": "U12345",
+					"access_token": "xoxp-user-token",
+					"token_type": "user",
+					"scope": "chat:write"
+				}
+			}`,
+			accessTokenPath: "authed_user.access_token",
+			wantToken:       "xoxp-user-token",
+		},
+		{
+			name:         "falls back to top level",
+			responseBody: `{"access_token": "standard-token", "token_type": "Bearer"}`,
+			wantToken:    "standard-token",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.responseBody))
+			}))
+			t.Cleanup(srv.Close)
+
+			h := NewUpstream(UpstreamConfig{
+				ClientID:        "cid",
+				ClientSecret:    "csec",
+				TokenURL:        srv.URL + "/token",
+				RedirectURL:     "http://localhost/cb",
+				AccessTokenPath: tc.accessTokenPath,
+			})
+
+			resp, err := h.ExchangeCode(context.Background(), "code")
+			if err != nil {
+				t.Fatalf("ExchangeCode: %v", err)
 			}
-		}`))
-	}))
-	t.Cleanup(srv.Close)
-
-	h := NewUpstream(UpstreamConfig{
-		ClientID:        "cid",
-		ClientSecret:    "csec",
-		TokenURL:        srv.URL + "/token",
-		RedirectURL:     "http://localhost/cb",
-		AccessTokenPath: "authed_user.access_token",
-	})
-
-	resp, err := h.ExchangeCode(context.Background(), "code")
-	if err != nil {
-		t.Fatalf("ExchangeCode: %v", err)
-	}
-	if resp.AccessToken != "xoxp-user-token" {
-		t.Errorf("AccessToken = %q, want xoxp-user-token", resp.AccessToken)
-	}
-}
-
-func TestAccessTokenPathFallsBackToTopLevel(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token": "standard-token", "token_type": "Bearer"}`))
-	}))
-	t.Cleanup(srv.Close)
-
-	h := NewUpstream(UpstreamConfig{
-		ClientID:     "cid",
-		ClientSecret: "csec",
-		TokenURL:     srv.URL + "/token",
-		RedirectURL:  "http://localhost/cb",
-	})
-
-	resp, err := h.ExchangeCode(context.Background(), "code")
-	if err != nil {
-		t.Fatalf("ExchangeCode: %v", err)
-	}
-	if resp.AccessToken != "standard-token" {
-		t.Errorf("AccessToken = %q, want standard-token", resp.AccessToken)
+			if resp.AccessToken != tc.wantToken {
+				t.Errorf("AccessToken = %q, want %q", resp.AccessToken, tc.wantToken)
+			}
+		})
 	}
 }

--- a/gestaltd/internal/openapi/loader_test.go
+++ b/gestaltd/internal/openapi/loader_test.go
@@ -355,159 +355,92 @@ func TestCollectScopesRespectsAllowedOps(t *testing.T) {
 	}
 }
 
-func TestExtractAuthAPIKeyHeader(t *testing.T) {
+func TestExtractAuth(t *testing.T) {
 	t.Parallel()
 
-	spec := map[string]any{
-		"openapi": "3.0.0",
-		"info":    map[string]string{"title": "API Key API"},
-		"servers": []any{map[string]string{"url": "https://api.example.com"}},
-		"components": map[string]any{
-			"securitySchemes": map[string]any{
-				"apiKey": map[string]any{
-					"type": "apiKey",
-					"in":   "header",
-					"name": "X-API-Key",
+	tests := []struct {
+		name       string
+		schemeName string
+		scheme     map[string]any
+		wantStyle  string
+		wantHeader string
+	}{
+		{
+			name:       "api key header",
+			schemeName: "apiKey",
+			scheme: map[string]any{
+				"type": "apiKey",
+				"in":   "header",
+				"name": "X-API-Key",
+			},
+			wantStyle:  "raw",
+			wantHeader: "X-API-Key",
+		},
+		{
+			name:       "api key query",
+			schemeName: "apiKey",
+			scheme: map[string]any{
+				"type": "apiKey",
+				"in":   "query",
+				"name": "api_key",
+			},
+			wantStyle: "raw",
+		},
+		{
+			name:       "http bearer",
+			schemeName: "bearerAuth",
+			scheme: map[string]any{
+				"type":   "http",
+				"scheme": "bearer",
+			},
+		},
+		{
+			name:       "http basic",
+			schemeName: "basicAuth",
+			scheme: map[string]any{
+				"type":   "http",
+				"scheme": "basic",
+			},
+			wantStyle: "basic",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := map[string]any{
+				"openapi": "3.0.0",
+				"info":    map[string]string{"title": tc.name},
+				"servers": []any{map[string]string{"url": "https://api.example.com"}},
+				"components": map[string]any{
+					"securitySchemes": map[string]any{tc.schemeName: tc.scheme},
 				},
-			},
-		},
-		"paths": map[string]any{
-			"/items": map[string]any{
-				"get": map[string]any{"operationId": "list_items", "summary": "List items"},
-			},
-		},
-	}
-
-	srv := serveJSON(t, spec)
-	testutil.CloseOnCleanup(t, srv)
-
-	def, err := LoadDefinition(context.Background(), "test", srv.URL, nil)
-	if err != nil {
-		t.Fatalf("LoadDefinition: %v", err)
-	}
-	if def.Auth.Type != "manual" {
-		t.Errorf("Auth.Type = %q, want manual", def.Auth.Type)
-	}
-	if def.AuthStyle != "raw" {
-		t.Errorf("AuthStyle = %q, want raw", def.AuthStyle)
-	}
-	if def.AuthHeader != "X-API-Key" {
-		t.Errorf("AuthHeader = %q, want X-API-Key", def.AuthHeader)
-	}
-}
-
-func TestExtractAuthAPIKeyQuery(t *testing.T) {
-	t.Parallel()
-
-	spec := map[string]any{
-		"openapi": "3.0.0",
-		"info":    map[string]string{"title": "Query Key API"},
-		"servers": []any{map[string]string{"url": "https://api.example.com"}},
-		"components": map[string]any{
-			"securitySchemes": map[string]any{
-				"apiKey": map[string]any{
-					"type": "apiKey",
-					"in":   "query",
-					"name": "api_key",
+				"paths": map[string]any{
+					"/items": map[string]any{
+						"get": map[string]any{"operationId": "list_items", "summary": "List items"},
+					},
 				},
-			},
-		},
-		"paths": map[string]any{
-			"/items": map[string]any{
-				"get": map[string]any{"operationId": "list_items", "summary": "List items"},
-			},
-		},
-	}
+			}
 
-	srv := serveJSON(t, spec)
-	testutil.CloseOnCleanup(t, srv)
+			srv := serveJSON(t, spec)
+			testutil.CloseOnCleanup(t, srv)
 
-	def, err := LoadDefinition(context.Background(), "test", srv.URL, nil)
-	if err != nil {
-		t.Fatalf("LoadDefinition: %v", err)
-	}
-	if def.Auth.Type != "manual" {
-		t.Errorf("Auth.Type = %q, want manual", def.Auth.Type)
-	}
-	if def.AuthStyle != "raw" {
-		t.Errorf("AuthStyle = %q, want raw", def.AuthStyle)
-	}
-	if def.AuthHeader != "" {
-		t.Errorf("AuthHeader = %q, want empty for query auth", def.AuthHeader)
-	}
-}
-
-func TestExtractAuthHTTPBearer(t *testing.T) {
-	t.Parallel()
-
-	spec := map[string]any{
-		"openapi": "3.0.0",
-		"info":    map[string]string{"title": "Bearer API"},
-		"servers": []any{map[string]string{"url": "https://api.example.com"}},
-		"components": map[string]any{
-			"securitySchemes": map[string]any{
-				"bearerAuth": map[string]any{
-					"type":   "http",
-					"scheme": "bearer",
-				},
-			},
-		},
-		"paths": map[string]any{
-			"/items": map[string]any{
-				"get": map[string]any{"operationId": "list_items", "summary": "List items"},
-			},
-		},
-	}
-
-	srv := serveJSON(t, spec)
-	testutil.CloseOnCleanup(t, srv)
-
-	def, err := LoadDefinition(context.Background(), "test", srv.URL, nil)
-	if err != nil {
-		t.Fatalf("LoadDefinition: %v", err)
-	}
-	if def.Auth.Type != "manual" {
-		t.Errorf("Auth.Type = %q, want manual", def.Auth.Type)
-	}
-	if def.AuthStyle != "" {
-		t.Errorf("AuthStyle = %q, want empty (bearer is default)", def.AuthStyle)
-	}
-}
-
-func TestExtractAuthHTTPBasic(t *testing.T) {
-	t.Parallel()
-
-	spec := map[string]any{
-		"openapi": "3.0.0",
-		"info":    map[string]string{"title": "Basic API"},
-		"servers": []any{map[string]string{"url": "https://api.example.com"}},
-		"components": map[string]any{
-			"securitySchemes": map[string]any{
-				"basicAuth": map[string]any{
-					"type":   "http",
-					"scheme": "basic",
-				},
-			},
-		},
-		"paths": map[string]any{
-			"/items": map[string]any{
-				"get": map[string]any{"operationId": "list_items", "summary": "List items"},
-			},
-		},
-	}
-
-	srv := serveJSON(t, spec)
-	testutil.CloseOnCleanup(t, srv)
-
-	def, err := LoadDefinition(context.Background(), "test", srv.URL, nil)
-	if err != nil {
-		t.Fatalf("LoadDefinition: %v", err)
-	}
-	if def.Auth.Type != "manual" {
-		t.Errorf("Auth.Type = %q, want manual", def.Auth.Type)
-	}
-	if def.AuthStyle != "basic" {
-		t.Errorf("AuthStyle = %q, want basic", def.AuthStyle)
+			def, err := LoadDefinition(context.Background(), "test", srv.URL, nil)
+			if err != nil {
+				t.Fatalf("LoadDefinition: %v", err)
+			}
+			if def.Auth.Type != "manual" {
+				t.Errorf("Auth.Type = %q, want manual", def.Auth.Type)
+			}
+			if def.AuthStyle != tc.wantStyle {
+				t.Errorf("AuthStyle = %q, want %q", def.AuthStyle, tc.wantStyle)
+			}
+			if def.AuthHeader != tc.wantHeader {
+				t.Errorf("AuthHeader = %q, want %q", def.AuthHeader, tc.wantHeader)
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/ui/ui_test.go
+++ b/gestaltd/internal/ui/ui_test.go
@@ -38,142 +38,98 @@ func mustServe(t *testing.T, handler http.Handler, path string) (int, string) {
 	return resp.StatusCode, string(body)
 }
 
-func TestDirHandler_ServesIndexHTML(t *testing.T) {
+func TestDirHandler_ServesFilesAndFallbacks(t *testing.T) {
 	t.Parallel()
-	dir := t.TempDir()
-	mustWriteFile(t, dir, "index.html", "<html>home</html>")
 
-	handler, err := DirHandler(dir)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name  string
+		files map[string]string
+		path  string
+		want  string
+	}{
+		{
+			name:  "serves index html",
+			files: map[string]string{"index.html": "<html>home</html>"},
+			path:  "/",
+			want:  "home",
+		},
+		{
+			name: "serves exact file",
+			files: map[string]string{
+				"index.html": "<html>home</html>",
+				"style.css":  "body { color: red; }",
+			},
+			path: "/style.css",
+			want: "color: red",
+		},
+		{
+			name: "html suffix fallback",
+			files: map[string]string{
+				"index.html": "<html>home</html>",
+				"about.html": "<html>about page</html>",
+			},
+			path: "/about",
+			want: "about page",
+		},
+		{
+			name:  "spa fallback for unknown path",
+			files: map[string]string{"index.html": "<html>spa-root</html>"},
+			path:  "/nonexistent",
+			want:  "spa-root",
+		},
+		{
+			name: "static asset in subdirectory",
+			files: map[string]string{
+				"index.html":    "<html>home</html>",
+				"assets/app.js": "console.log('app');",
+			},
+			path: "/assets/app.js",
+			want: "console.log",
+		},
+		{
+			name: "html fallback preferred over spa",
+			files: map[string]string{
+				"index.html":    "<html>home</html>",
+				"settings.html": "<html>settings</html>",
+			},
+			path: "/settings",
+			want: "settings",
+		},
+		{
+			name: "html fallback preferred over directory",
+			files: map[string]string{
+				"index.html":                    "<html>home</html>",
+				"integrations.html":             "<html>integrations</html>",
+				"integrations/__next._full.txt": "metadata",
+			},
+			path: "/integrations",
+			want: "integrations",
+		},
 	}
 
-	code, body := mustServe(t, handler, "/")
-	if code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", code, http.StatusOK)
-	}
-	if !strings.Contains(body, "home") {
-		t.Fatalf("body = %q, want home content", body)
-	}
-}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-func TestDirHandler_ServesExactFile(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	mustWriteFile(t, dir, "index.html", "<html>home</html>")
-	mustWriteFile(t, dir, "style.css", "body { color: red; }")
+			dir := t.TempDir()
+			for rel, content := range tc.files {
+				mustWriteFile(t, dir, rel, content)
+			}
 
-	handler, err := DirHandler(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+			handler, err := DirHandler(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	code, body := mustServe(t, handler, "/style.css")
-	if code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", code, http.StatusOK)
-	}
-	if !strings.Contains(body, "color: red") {
-		t.Fatalf("body = %q, want CSS content", body)
-	}
-}
-
-func TestDirHandler_HTMLSuffixFallback(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	mustWriteFile(t, dir, "index.html", "<html>home</html>")
-	mustWriteFile(t, dir, "about.html", "<html>about page</html>")
-
-	handler, err := DirHandler(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	code, body := mustServe(t, handler, "/about")
-	if code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", code, http.StatusOK)
-	}
-	if !strings.Contains(body, "about page") {
-		t.Fatalf("body = %q, want about page content", body)
-	}
-}
-
-func TestDirHandler_SPAFallbackForUnknownPath(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	mustWriteFile(t, dir, "index.html", "<html>spa-root</html>")
-
-	handler, err := DirHandler(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	code, body := mustServe(t, handler, "/nonexistent")
-	if code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", code, http.StatusOK)
-	}
-	if !strings.Contains(body, "spa-root") {
-		t.Fatalf("body = %q, want SPA fallback", body)
-	}
-}
-
-func TestDirHandler_StaticAssetInSubdirectory(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	mustWriteFile(t, dir, "index.html", "<html>home</html>")
-	mustWriteFile(t, dir, "assets/app.js", "console.log('app');")
-
-	handler, err := DirHandler(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	code, body := mustServe(t, handler, "/assets/app.js")
-	if code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", code, http.StatusOK)
-	}
-	if !strings.Contains(body, "console.log") {
-		t.Fatalf("body = %q, want JS content", body)
-	}
-}
-
-func TestDirHandler_HTMLFallbackPreferredOverSPA(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	mustWriteFile(t, dir, "index.html", "<html>home</html>")
-	mustWriteFile(t, dir, "settings.html", "<html>settings</html>")
-
-	handler, err := DirHandler(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	code, body := mustServe(t, handler, "/settings")
-	if code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", code, http.StatusOK)
-	}
-	if !strings.Contains(body, "settings") {
-		t.Fatalf("body = %q, want settings content", body)
-	}
-}
-
-func TestDirHandler_HTMLFallbackPreferredOverDirectory(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	mustWriteFile(t, dir, "index.html", "<html>home</html>")
-	mustWriteFile(t, dir, "integrations.html", "<html>integrations</html>")
-	mustWriteFile(t, dir, "integrations/__next._full.txt", "metadata")
-
-	handler, err := DirHandler(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	code, body := mustServe(t, handler, "/integrations")
-	if code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", code, http.StatusOK)
-	}
-	if !strings.Contains(body, "integrations") {
-		t.Fatalf("body = %q, want integrations content", body)
+			code, body := mustServe(t, handler, tc.path)
+			if code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", code, http.StatusOK)
+			}
+			if !strings.Contains(body, tc.want) {
+				t.Fatalf("body = %q, want content containing %q", body, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Consolidates duplicative gestaltd coverage into table-driven cases without changing production behavior or adding unit-test-only coverage. The PR keeps the same assertions while reducing repeated harness setup across static UI serving, OpenAPI auth extraction, OAuth upstream request variants, nested plugin invoke rejection paths, serve lockfile E2E modes, and provider remote token error cases.

## New Test Interfaces

- `TestDirHandler_ServesFilesAndFallbacks` rows: `{files, path, want}`.
- `TestExtractAuth` rows: `{schemeName, scheme, wantStyle, wantHeader}`.
- OAuth upstream rows: `{call func(*UpstreamHandler), wantToken, wantGrant, wantField, wantValue}` for exchange/refresh transport variants.
- Nested invoke rejection rows: `{tokens []tokenSpec, params, wantError}`.
- `TestE2EServeUsesOverrideLockfile` rows: `{args(lockPath), preInit, waitForNew}`.
- Provider remote token error rows: `{remote, storedServer, writeStored, want(configHome)}`.

## Examples

```go
// Add a new static serving fallback case.
{
    name: "serves nested html fallback",
    files: map[string]string{"index.html": "<html>home</html>", "docs/start.html": "docs"},
    path: "/docs/start",
    want: "docs",
}

// Add a new OAuth JSON token request variant.
{
    name: "refresh token",
    call: func(h *UpstreamHandler) (*core.TokenResponse, error) {
        return h.RefreshToken(context.Background(), "rt-123")
    },
    wantGrant: "refresh_token",
    wantField: "refresh_token",
    wantValue: "rt-123",
}
```

## Validation

- `TMPDIR=/Users/hugh/src/gestalt-test-coverage-cleanup/.tmp-test go test ./internal/ui ./internal/openapi ./internal/oauth ./internal/bootstrap ./cmd/gestaltd -run 'TestDirHandler_ServesFilesAndFallbacks|TestExtractAuth|TestClientAuthHeader|TestTokenExchangeJSON|TestAuthorizationURLScopes|TestAccessTokenPath|TestPluginInvokesRejectInvalidTargetRequests|TestE2EServeUsesOverrideLockfile|TestResolveProviderRemoteTokenErrors' -count=1`\n- `git diff --check`\n\nNote: a broader `go test ./internal/ui ./internal/openapi ./internal/oauth ./internal/bootstrap ./cmd/gestaltd` run passed the non-`cmd/gestaltd` packages, then the full `cmd/gestaltd` suite exhausted the local macOS temp volume (`no space left on device`). The targeted consolidated `cmd/gestaltd` cases passed after rerunning with a worktree-local `TMPDIR`.\n