### PR TITLE
Normalize OpenAPI parameter names for tool schemas

### DIFF
--- a/gestaltd/core/integration/egress_adapter.go
+++ b/gestaltd/core/integration/egress_adapter.go
@@ -164,7 +164,7 @@ func partitionParams(catOp *catalog.CatalogOperation, params map[string]any, use
 		}
 		switch locations[k] {
 		case "body":
-			body[k] = v
+			body[httpKey] = v
 		case "query":
 			query[httpKey] = v
 		case "header":
@@ -176,14 +176,14 @@ func partitionParams(catOp *catalog.CatalogOperation, params map[string]any, use
 				if useMethodDefault {
 					continue
 				}
-				body[k] = v
+				body[httpKey] = v
 				continue
 			}
 			if defaultLocation == "query" {
 				query[httpKey] = v
 				continue
 			}
-			body[k] = v
+			body[httpKey] = v
 		}
 	}
 	return body, query, headers

--- a/gestaltd/core/integration/param_routing_test.go
+++ b/gestaltd/core/integration/param_routing_test.go
@@ -71,6 +71,33 @@ func TestPartitionParams_NoLocations(t *testing.T) {
 			t.Fatalf("headers = %v, want nil", headers)
 		}
 	})
+
+	t.Run("declared body fallback uses wire names", func(t *testing.T) {
+		t.Parallel()
+		catOp := &catalog.CatalogOperation{
+			ID:     "op1",
+			Method: http.MethodPost,
+			Parameters: []catalog.CatalogParameter{
+				{Name: "at_odata.type", WireName: "@odata.type", Type: "string"},
+			},
+		}
+		body, query, headers := partitionParams(catOp, map[string]any{
+			"at_odata.type": "example.record",
+		}, false)
+
+		if body["@odata.type"] != "example.record" {
+			t.Fatalf("body[@odata.type] = %v, want example.record", body["@odata.type"])
+		}
+		if _, ok := body["at_odata.type"]; ok {
+			t.Fatalf("body should not contain model-facing name: %v", body)
+		}
+		if len(query) != 0 {
+			t.Fatalf("query = %v, want nil", query)
+		}
+		if len(headers) != 0 {
+			t.Fatalf("headers = %v, want nil", headers)
+		}
+	})
 }
 
 func TestPartitionParams_MixedLocations(t *testing.T) {
@@ -333,6 +360,76 @@ func TestExecuteREST_WireNameQueryParam(t *testing.T) {
 	}
 	if parsed.Get(wireName) != pageSizeValue {
 		t.Fatalf("query %s = %q, want %s; raw = %s", wireName, parsed.Get(wireName), pageSizeValue, rawQuery)
+	}
+}
+
+func TestExecuteREST_WireNameBodyParam(t *testing.T) {
+	t.Parallel()
+
+	const (
+		opID       = "create_record"
+		opPath     = "/api/v2/records"
+		schemaName = "at_odata.type"
+		wireName   = "@odata.type"
+		value      = "example.record"
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("io.ReadAll: %v", err)
+		}
+		var body map[string]any
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &body); err != nil {
+				t.Fatalf("json.Unmarshal request body: %v", err)
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"body": body,
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	cat := &catalog.Catalog{
+		Name: "test-svc",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:     opID,
+				Method: http.MethodPost,
+				Path:   opPath,
+				Parameters: []catalog.CatalogParameter{
+					{Name: schemaName, WireName: wireName, Type: "string", Location: "body"},
+				},
+			},
+		},
+	}
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+	}
+	b.SetCatalog(cat)
+
+	result, err := b.Execute(context.Background(), opID, map[string]any{
+		schemaName: value,
+	}, "test-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal response: %v", err)
+	}
+
+	body := resp["body"].(map[string]any)
+	if body[wireName] != value {
+		t.Fatalf("body[%s] = %v, want %s", wireName, body[wireName], value)
+	}
+	if _, ok := body[schemaName]; ok {
+		t.Fatalf("body should not contain schema name %q", schemaName)
 	}
 }
 

--- a/gestaltd/core/toolschema/names.go
+++ b/gestaltd/core/toolschema/names.go
@@ -1,0 +1,136 @@
+package toolschema
+
+import (
+	"fmt"
+	"hash/fnv"
+	"regexp"
+	"strings"
+)
+
+// MaxPropertyNameLength is the maximum model-facing tool input property length
+// accepted by the strictest model provider we currently target.
+const MaxPropertyNameLength = 64
+
+var propertyNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_.-]{1,64}$`)
+
+// NameMapping links a model-facing tool input name to its original wire name.
+type NameMapping struct {
+	Name     string
+	WireName string
+}
+
+// NameAllocator assigns unique model-facing names within one tool schema.
+type NameAllocator struct {
+	used map[string]string
+}
+
+// NewNameAllocator returns an allocator for one operation or tool schema.
+func NewNameAllocator() *NameAllocator {
+	return &NameAllocator{used: make(map[string]string)}
+}
+
+// Allocate returns a safe, unique model-facing name for raw.
+func (a *NameAllocator) Allocate(raw string) NameMapping {
+	if a.used == nil {
+		a.used = make(map[string]string)
+	}
+	baseName, wireName := NormalizePropertyName(raw)
+	name := a.unique(baseName, raw)
+	if name != baseName && wireName == "" {
+		wireName = raw
+	}
+	return NameMapping{Name: name, WireName: wireName}
+}
+
+// NormalizePropertyName converts a raw provider field name into a model-safe
+// tool input property name. It returns a wireName only when callers must retain
+// the original name for execution.
+func NormalizePropertyName(raw string) (name, wireName string) {
+	normalized := safePropertyName(raw)
+	if normalized == raw {
+		return raw, ""
+	}
+	return normalized, raw
+}
+
+// ValidPropertyName reports whether name is safe to expose as a model-facing
+// tool input property.
+func ValidPropertyName(name string) bool {
+	return propertyNamePattern.MatchString(name)
+}
+
+func safePropertyName(raw string) string {
+	var b strings.Builder
+	b.Grow(len(raw))
+	for _, r := range raw {
+		switch {
+		case isPropertyNameChar(r):
+			b.WriteRune(r)
+		case r == '[':
+			b.WriteByte('_')
+		case r == ']':
+			continue
+		case r == '$':
+			writeNamedSeparator(&b, "dollar")
+		case r == '@':
+			writeNamedSeparator(&b, "at")
+		case r == '\'', r == '"', r == '`':
+			continue
+		default:
+			b.WriteByte('_')
+		}
+	}
+	name := b.String()
+	if name == "" {
+		name = "param"
+	}
+	if len(name) <= MaxPropertyNameLength {
+		return name
+	}
+	hash := hashPropertyName(raw)
+	suffix := fmt.Sprintf("_%08x", hash)
+	return name[:MaxPropertyNameLength-len(suffix)] + suffix
+}
+
+func isPropertyNameChar(r rune) bool {
+	return (r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9') ||
+		r == '_' ||
+		r == '.' ||
+		r == '-'
+}
+
+func writeNamedSeparator(b *strings.Builder, name string) {
+	if b.Len() > 0 {
+		b.WriteByte('_')
+	}
+	b.WriteString(name)
+	b.WriteByte('_')
+}
+
+func hashPropertyName(raw string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(raw))
+	return h.Sum32()
+}
+
+func (a *NameAllocator) unique(baseName, rawName string) string {
+	if _, exists := a.used[baseName]; !exists {
+		a.used[baseName] = rawName
+		return baseName
+	}
+	for i := 2; ; i++ {
+		suffix := fmt.Sprintf("_%d", i)
+		prefixLen := MaxPropertyNameLength - len(suffix)
+		name := baseName
+		if len(name) > prefixLen {
+			name = name[:prefixLen]
+		}
+		name += suffix
+		if _, exists := a.used[name]; !exists {
+			a.used[name] = rawName
+			return name
+		}
+	}
+}

--- a/gestaltd/core/toolschema/names_test.go
+++ b/gestaltd/core/toolschema/names_test.go
@@ -1,0 +1,95 @@
+package toolschema
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizePropertyName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw      string
+		wantName string
+		wantWire string
+	}{
+		{raw: "limit", wantName: "limit"},
+		{raw: "$select", wantName: "dollar_select", wantWire: "$select"},
+		{raw: "@odata.type", wantName: "at_odata.type", wantWire: "@odata.type"},
+		{raw: "page[size]", wantName: "page_size", wantWire: "page[size]"},
+		{raw: "'x-Cwd'", wantName: "x-Cwd", wantWire: "'x-Cwd'"},
+		{raw: "", wantName: "param", wantWire: ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Parallel()
+
+			gotName, gotWire := NormalizePropertyName(tc.raw)
+			if gotName != tc.wantName {
+				t.Fatalf("name = %q, want %q", gotName, tc.wantName)
+			}
+			if gotWire != tc.wantWire {
+				t.Fatalf("wireName = %q, want %q", gotWire, tc.wantWire)
+			}
+			if !ValidPropertyName(gotName) {
+				t.Fatalf("normalized name %q is not valid", gotName)
+			}
+		})
+	}
+}
+
+func TestNameAllocatorHandlesCollisions(t *testing.T) {
+	t.Parallel()
+
+	allocator := NewNameAllocator()
+
+	first := allocator.Allocate("$select")
+	if first.Name != "dollar_select" || first.WireName != "$select" {
+		t.Fatalf("first = %#v, want dollar_select with $select wire name", first)
+	}
+
+	second := allocator.Allocate("dollar_select")
+	if second.Name != "dollar_select_2" || second.WireName != "dollar_select" {
+		t.Fatalf("second = %#v, want dollar_select_2 with dollar_select wire name", second)
+	}
+}
+
+func TestNameAllocatorKeepsLongNamesValidAndUnique(t *testing.T) {
+	t.Parallel()
+
+	allocator := NewNameAllocator()
+	raw := strings.Repeat("a", 80)
+
+	first := allocator.Allocate(raw)
+	second := allocator.Allocate(raw)
+
+	if len(first.Name) > MaxPropertyNameLength {
+		t.Fatalf("first name length = %d, want <= %d", len(first.Name), MaxPropertyNameLength)
+	}
+	if len(second.Name) > MaxPropertyNameLength {
+		t.Fatalf("second name length = %d, want <= %d", len(second.Name), MaxPropertyNameLength)
+	}
+	if first.Name == second.Name {
+		t.Fatalf("expected unique names, got %q twice", first.Name)
+	}
+	if !ValidPropertyName(first.Name) || !ValidPropertyName(second.Name) {
+		t.Fatalf("names should be valid: %#v %#v", first, second)
+	}
+}
+
+func TestValidPropertyName(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"limit", "page_size", "at_odata.type", "x-Cwd"} {
+		if !ValidPropertyName(name) {
+			t.Fatalf("%q should be valid", name)
+		}
+	}
+	for _, name := range []string{"", "$select", "@odata.type", strings.Repeat("a", 65)} {
+		if ValidPropertyName(name) {
+			t.Fatalf("%q should be invalid", name)
+		}
+	}
+}

--- a/gestaltd/internal/openapi/loader.go
+++ b/gestaltd/internal/openapi/loader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/orderedmap"
+	"github.com/valon-technologies/gestalt/server/core/toolschema"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 )
@@ -187,16 +188,18 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 				allowedRoles = override.AllowedRoles
 			}
 
-			var params []provider.ParameterDef
+			var (
+				params       []provider.ParameterDef
+				paramNames   = toolschema.NewNameAllocator()
+				seenRawNames = make(map[string]struct{})
+			)
 			for _, p := range op.Parameters {
-				params = append(params, definitionParamFromOpenAPI(p))
+				param := definitionParamFromOpenAPI(p, paramNames)
+				seenRawNames[p.Name] = struct{}{}
+				params = append(params, param)
 			}
 
 			if op.RequestBody != nil && op.RequestBody.Content != nil {
-				seen := make(map[string]struct{}, len(params))
-				for _, p := range params {
-					seen[p.Name] = struct{}{}
-				}
 				for contentPair := op.RequestBody.Content.First(); contentPair != nil; contentPair = contentPair.Next() {
 					mt := contentPair.Value()
 					if mt.Schema == nil || mt.Schema.Schema() == nil {
@@ -211,9 +214,11 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 						requiredSet[r] = true
 					}
 					for propPair := schema.Properties.First(); propPair != nil; propPair = propPair.Next() {
-						if _, exists := seen[propPair.Key()]; exists {
+						rawName := propPair.Key()
+						if _, exists := seenRawNames[rawName]; exists {
 							continue
 						}
+						seenRawNames[rawName] = struct{}{}
 						propSchema := propPair.Value().Schema()
 						if propSchema == nil {
 							continue
@@ -222,12 +227,14 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 						if len(propSchema.Type) > 0 {
 							pType = propSchema.Type[0]
 						}
+						mapping := paramNames.Allocate(rawName)
 						params = append(params, provider.ParameterDef{
-							Name:        propPair.Key(),
+							Name:        mapping.Name,
+							WireName:    mapping.WireName,
 							Type:        pType,
 							Location:    "body",
 							Description: propSchema.Description,
-							Required:    requiredSet[propPair.Key()],
+							Required:    requiredSet[rawName],
 						})
 					}
 					break
@@ -245,28 +252,20 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 	}
 }
 
-func definitionParamFromOpenAPI(p *v3high.Parameter) provider.ParameterDef {
+func definitionParamFromOpenAPI(p *v3high.Parameter, names *toolschema.NameAllocator) provider.ParameterDef {
 	paramType := "string"
 	if p.Schema != nil && p.Schema.Schema() != nil {
 		if types := p.Schema.Schema().Type; len(types) > 0 {
 			paramType = types[0]
 		}
 	}
-	name, wireName := normalizeParamName(p.Name)
+	mapping := names.Allocate(p.Name)
 	return provider.ParameterDef{
-		Name:        name,
-		WireName:    wireName,
+		Name:        mapping.Name,
+		WireName:    mapping.WireName,
 		Type:        paramType,
 		Location:    p.In,
 		Description: p.Description,
 		Required:    p.Required != nil && *p.Required,
 	}
-}
-
-func normalizeParamName(raw string) (name, wireName string) {
-	if !strings.ContainsAny(raw, "[]") {
-		return raw, ""
-	}
-	normalized := strings.ReplaceAll(strings.ReplaceAll(raw, "[", "_"), "]", "")
-	return normalized, raw
 }

--- a/gestaltd/internal/openapi/loader_test.go
+++ b/gestaltd/internal/openapi/loader_test.go
@@ -646,6 +646,89 @@ func TestLoadDefinitionBodyParamDedup(t *testing.T) {
 	}
 }
 
+func TestLoadDefinitionNormalizesModelUnsafeParamNames(t *testing.T) {
+	t.Parallel()
+
+	spec := map[string]any{
+		"openapi": "3.0.0",
+		"info":    map[string]string{"title": "Unsafe Names API"},
+		"servers": []any{map[string]string{"url": "https://api.example.com"}},
+		"paths": map[string]any{
+			"/items": map[string]any{
+				"post": map[string]any{
+					"operationId": "create_item",
+					"summary":     "Create item",
+					"parameters": []any{
+						map[string]any{
+							"name": "$select", "in": "query",
+							"schema": map[string]any{"type": "string"},
+						},
+						map[string]any{
+							"name": "page[size]", "in": "query",
+							"schema": map[string]any{"type": "integer"},
+						},
+						map[string]any{
+							"name": "'x-Cwd'", "in": "header",
+							"schema": map[string]any{"type": "string"},
+						},
+					},
+					"requestBody": map[string]any{
+						"content": map[string]any{
+							"application/json": map[string]any{
+								"schema": map[string]any{
+									"type":     "object",
+									"required": []string{"@odata.type"},
+									"properties": map[string]any{
+										"@odata.type":   map[string]any{"type": "string"},
+										"dollar_select": map[string]any{"type": "string"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv := serveJSON(t, spec)
+	testutil.CloseOnCleanup(t, srv)
+
+	def, err := LoadDefinition(context.Background(), "test", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+
+	op := def.Operations["create_item"]
+	byName := make(map[string]provider.ParameterDef, len(op.Parameters))
+	for _, p := range op.Parameters {
+		byName[p.Name] = p
+	}
+
+	assertParam := func(name, wireName, location string, required bool) {
+		t.Helper()
+		param, ok := byName[name]
+		if !ok {
+			t.Fatalf("missing parameter %q; got %#v", name, byName)
+		}
+		if param.WireName != wireName {
+			t.Errorf("%s wireName = %q, want %q", name, param.WireName, wireName)
+		}
+		if param.Location != location {
+			t.Errorf("%s location = %q, want %q", name, param.Location, location)
+		}
+		if param.Required != required {
+			t.Errorf("%s required = %v, want %v", name, param.Required, required)
+		}
+	}
+
+	assertParam("dollar_select", "$select", "query", false)
+	assertParam("page_size", "page[size]", "query", false)
+	assertParam("x-Cwd", "'x-Cwd'", "header", false)
+	assertParam("at_odata.type", "@odata.type", "body", true)
+	assertParam("dollar_select_2", "dollar_select", "body", false)
+}
+
 func TestLoadDefinitionYAML(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add `core/toolschema` as the small shared primitive for model-safe tool input names.
- Normalize OpenAPI-generated parameter/body property names through that primitive while preserving original HTTP keys in `wireName`.
- Route body parameters through `wireName` the same way query/header params already do.

## Examples
- OpenAPI query parameter `$select` becomes model input `dollar_select` with `wireName: "$select"`.
- OpenAPI query parameter `page[size]` becomes model input `page_size` with `wireName: "page[size]"`.
- OpenAPI body property `@odata.type` becomes model input `at_odata.type` with `wireName: "@odata.type"`.
- If normalization collides, e.g. `$select` and `dollar_select`, the second input becomes `dollar_select_2` and retains `wireName: "dollar_select"`.

## Deliberately not included
- Recursive request-body schema rewriting. The current provider representation only flattens top-level body properties, so recursive rewriting would be larger than this bug requires.
- Agent-side tool filtering. The canonical fix is now at catalog/schema generation; filtering can be added later as a resilience layer if needed.

## Validation
- `GOCACHE=/tmp/gestalt-codex-go-cache go test ./core/toolschema ./internal/openapi ./core/integration`