### PR TITLE
provider release: resolve source manifests absolutely

### DIFF
--- a/gestaltd/cmd/gestaltd/provider.go
+++ b/gestaltd/cmd/gestaltd/provider.go
@@ -116,6 +116,10 @@ func runProviderRelease(args []string) (err error) {
 	if err != nil {
 		return err
 	}
+	manifestPath, err = filepath.Abs(manifestPath)
+	if err != nil {
+		return fmt.Errorf("resolve manifest path: %w", err)
+	}
 	sourceDir := filepath.Dir(manifestPath)
 	catalogSnapshot, err := snapshotSourceStaticCatalog(sourceDir)
 	if err != nil {

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -604,6 +604,7 @@ func TestRun_ProviderReleaseBuildsTypeScriptSourcePluginForCurrentPlatform(t *te
 	t.Setenv("GESTALT_TYPESCRIPT_SDK_DIR", sdkDir)
 	bunPath := writeFakeTypeScriptProviderReleaseBun(
 		t,
+		pluginDir,
 		typeScriptReleasePluginName,
 		typeScriptReleaseTarget,
 		runtime.GOOS,
@@ -789,6 +790,7 @@ func TestRun_ProviderReleaseBuildsRequestedPlatformSets(t *testing.T) {
 		defaultPlatforms := defaultReleasePlatformsForTest(t)
 		bunPath := writeFakeTypeScriptComponentReleaseBunForPlatforms(
 			t,
+			pluginDir,
 			authReleaseTypeScriptTarget,
 			authReleasePluginName,
 			defaultPlatforms,
@@ -1597,7 +1599,7 @@ func TestRun_ProviderReleaseBuildsExecutableAuthProviders(t *testing.T) {
 				pluginDir := newTypeScriptSourceAuthReleaseFixture(t, t.TempDir())
 				sdkDir := writeFakeTypeScriptReleaseSDKDir(t, t.TempDir())
 				t.Setenv("GESTALT_TYPESCRIPT_SDK_DIR", sdkDir)
-				bunPath := writeFakeTypeScriptComponentReleaseBun(t, authReleaseTypeScriptTarget, authReleasePluginName, runtime.GOOS, runtime.GOARCH, builtBinary)
+				bunPath := writeFakeTypeScriptComponentReleaseBun(t, pluginDir, authReleaseTypeScriptTarget, authReleasePluginName, runtime.GOOS, runtime.GOARCH, builtBinary)
 				t.Setenv("PATH", pathWithoutGo(t))
 				t.Setenv("GESTALT_BUN", bunPath)
 				return pluginDir
@@ -2675,15 +2677,15 @@ authentication = "provider:auth_provider"
 	return pluginDir
 }
 
-func writeFakeTypeScriptComponentReleaseBun(t *testing.T, expectedTarget, expectedPluginName, expectedGOOS, expectedGOARCH, builtBinaryPath string) string {
+func writeFakeTypeScriptComponentReleaseBun(t *testing.T, sourceDir, expectedTarget, expectedPluginName, expectedGOOS, expectedGOARCH, builtBinaryPath string) string {
 	t.Helper()
-	return writeFakeTypeScriptComponentReleaseBunForPlatforms(t, expectedTarget, expectedPluginName, []releasePlatform{{
+	return writeFakeTypeScriptComponentReleaseBunForPlatforms(t, sourceDir, expectedTarget, expectedPluginName, []releasePlatform{{
 		GOOS:   expectedGOOS,
 		GOARCH: expectedGOARCH,
 	}}, builtBinaryPath)
 }
 
-func writeFakeTypeScriptComponentReleaseBunForPlatforms(t *testing.T, expectedTarget, expectedPluginName string, expectedPlatforms []releasePlatform, builtBinaryPath string) string {
+func writeFakeTypeScriptComponentReleaseBunForPlatforms(t *testing.T, sourceDir, expectedTarget, expectedPluginName string, expectedPlatforms []releasePlatform, builtBinaryPath string) string {
 	t.Helper()
 
 	allowedPlatforms := make([]fakebun.Platform, 0, len(expectedPlatforms))
@@ -2699,7 +2701,6 @@ func writeFakeTypeScriptComponentReleaseBunForPlatforms(t *testing.T, expectedTa
 		t.Fatal("GESTALT_TYPESCRIPT_SDK_DIR must be set for TypeScript release tests")
 	}
 
-	sourceDir := "."
 	return fakebun.NewExecutable(t, fakebun.Config{
 		Install: &fakebun.InstallConfig{
 			ExpectedCwds:          []string{sourceDir, sdkPath},
@@ -2730,7 +2731,7 @@ func writeFakeTypeScriptReleaseSDKDir(t *testing.T, root string) string {
 	return root
 }
 
-func writeFakeTypeScriptProviderReleaseBun(t *testing.T, expectedPluginName, expectedTarget, expectedGOOS, expectedGOARCH string) string {
+func writeFakeTypeScriptProviderReleaseBun(t *testing.T, sourceDir, expectedPluginName, expectedTarget, expectedGOOS, expectedGOARCH string) string {
 	t.Helper()
 
 	sdkPath := strings.TrimSpace(os.Getenv("GESTALT_TYPESCRIPT_SDK_DIR"))
@@ -2738,7 +2739,6 @@ func writeFakeTypeScriptProviderReleaseBun(t *testing.T, expectedPluginName, exp
 		t.Fatal("GESTALT_TYPESCRIPT_SDK_DIR must be set for TypeScript release tests")
 	}
 
-	sourceDir := "."
 	return fakebun.NewExecutable(t, fakebun.Config{
 		Install: &fakebun.InstallConfig{
 			ExpectedCwds:          []string{sourceDir, sdkPath},

--- a/gestaltd/internal/providerpkg/prepared_stage.go
+++ b/gestaltd/internal/providerpkg/prepared_stage.go
@@ -91,11 +91,17 @@ func StagePreparedInstallDir(manifestPath, stagingDir string, opts StagePrepared
 		return nil, fmt.Errorf("staging directory is required")
 	}
 
+	absoluteManifestPath, err := filepath.Abs(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve manifest path: %w", err)
+	}
+	manifestPath = absoluteManifestPath
+
 	sourceDir := filepath.Dir(manifestPath)
 	manifestFormat := ManifestFormatFromPath(manifestPath)
 	manifestFile := preparedManifestFileName(manifestFormat)
 
-	_, _, err := ReadSourceManifestFile(manifestPath)
+	_, _, err = ReadSourceManifestFile(manifestPath)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", manifestPath, err)
 	}

--- a/gestaltd/internal/providerpkg/source_prepare.go
+++ b/gestaltd/internal/providerpkg/source_prepare.go
@@ -15,6 +15,12 @@ import (
 const envWriteCatalog = "GESTALT_PLUGIN_WRITE_CATALOG"
 
 func PrepareSourceManifest(manifestPath string) ([]byte, *providermanifestv1.Manifest, error) {
+	absoluteManifestPath, err := filepath.Abs(manifestPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve manifest path: %w", err)
+	}
+	manifestPath = absoluteManifestPath
+
 	data, manifest, err := ReadSourceManifestFile(manifestPath)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary

Make `gestaltd provider release` normalize provider source manifest paths to absolute paths before static catalog generation, source preparation, and release staging.

This fixes TypeScript provider packaging with a local SDK checkout: Bun runs SDK helpers with the SDK as cwd, so relative provider roots like `.` were being interpreted as the SDK directory instead of the provider directory. With absolute source roots, the canonical packager works for TypeScript the same way it already does for Go/Rust/Python.

## Interface

No new interface. This keeps the existing canonical release interface:

```bash
gestaltd provider release \
  --version 0.0.1-alpha.test \
  --platform darwin/arm64 \
  --output /tmp/provider-release
```

For local TypeScript SDK development:

```bash
GESTALT_TYPESCRIPT_SDK_DIR=/path/to/gestalt/sdk/typescript \
  gestaltd provider release \
    --version 0.0.1-alpha.test \
    --platform darwin/arm64 \
    --output /tmp/provider-release
```

The generated archive contains the provider binary, `manifest.yaml` with `artifacts` and `entrypoint`, and `catalog.yaml`.

## Verification

```bash
GOCACHE=/tmp/gestalt-packager-gocache go test ./cmd/gestaltd -run 'TestRun_ProviderReleaseBuildsTypeScriptSourcePluginForCurrentPlatform|TestRun_ProviderReleaseBuildsRequestedPlatformSets|TestRun_ProviderReleaseBuildsExecutableAuthProviders'
```

```bash
go build -o /tmp/gestaltd-packager-test ./cmd/gestaltd
GESTALT_TYPESCRIPT_SDK_DIR=/private/tmp/gestalt-main-packager/sdk/typescript \
  /tmp/gestaltd-packager-test provider release \
    --version 0.0.1-alpha.test \
    --platform darwin/arm64 \
    --output /tmp/brain-gestaltd-release
```

Validated the Brain archive manifest includes `artifacts` and `entrypoint` generated by `gestaltd provider release`.