### PR TITLE
Fold health readiness checks into serve E2E

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1907,6 +1907,37 @@ func TestE2EServeAndHealthCheck(t *testing.T) {
 	baseURL := startGestaltd(t, dir, nil)
 
 	client := &http.Client{Timeout: 2 * time.Second}
+	for _, tc := range []struct {
+		path string
+		want string
+	}{
+		{path: "/health", want: "ok"},
+		{path: "/ready", want: "ok"},
+	} {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+
+			resp, err := client.Get(baseURL + tc.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", tc.path, err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("expected %s 200, got %d: %s", tc.path, resp.StatusCode, body)
+			}
+
+			var body map[string]string
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode %s response: %v", tc.path, err)
+			}
+			if body["status"] != tc.want {
+				t.Fatalf("%s status = %q, want %q", tc.path, body["status"], tc.want)
+			}
+		})
+	}
+
 	intResp, err := client.Get(baseURL + "/api/v1/integrations")
 	if err != nil {
 		t.Fatalf("GET /api/v1/integrations: %v", err)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1498,30 +1498,6 @@ func TestNewServerAdminAuthorizationRequiresValidSplitBaseURLs(t *testing.T) {
 	}
 }
 
-func TestHealthCheck(t *testing.T) {
-	t.Parallel()
-	ts := newTestServer(t)
-	testutil.CloseOnCleanup(t, ts)
-
-	resp, err := http.Get(ts.URL + "/health")
-	if err != nil {
-		t.Fatalf("GET /health: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-
-	var body map[string]string
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		t.Fatalf("decoding response: %v", err)
-	}
-	if body["status"] != "ok" {
-		t.Fatalf("expected status ok, got %q", body["status"])
-	}
-}
-
 func TestMountedUIRoutes(t *testing.T) {
 	t.Parallel()
 
@@ -5737,30 +5713,6 @@ func TestSecurityHeaders(t *testing.T) {
 			t.Errorf("Strict-Transport-Security = %q, want %q", got, wantHSTS)
 		}
 	})
-}
-
-func TestReadinessCheck(t *testing.T) {
-	t.Parallel()
-	ts := newTestServer(t)
-	testutil.CloseOnCleanup(t, ts)
-
-	resp, err := http.Get(ts.URL + "/ready")
-	if err != nil {
-		t.Fatalf("GET /ready: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-
-	var body map[string]string
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		t.Fatalf("decoding response: %v", err)
-	}
-	if body["status"] != "ok" {
-		t.Fatalf("expected status ok, got %q", body["status"])
-	}
 }
 
 func TestReadinessCheck_NotReady(t *testing.T) {


### PR DESCRIPTION
## Summary

Folds the duplicated happy-path `/health` and `/ready` handler checks into the existing `gestaltd serve` E2E. The internal server package still keeps the readiness failure-mode unit coverage where injected readiness state is useful, but the successful status endpoint contract now runs over the real serve transport path.

## New Test Interface

- `TestE2EServeAndHealthCheck` now checks status endpoints with rows shaped as `{path, want}`.
- `/health` and `/ready` both assert HTTP 200 and JSON `{"status": "ok"}` through the running `gestaltd` binary.

## Example

```go
{path: "/health", want: "ok"}
{path: "/ready", want: "ok"}
```

Add another status endpoint contract by appending a `{path, want}` row to the E2E status table.

## Validation

- `TMPDIR=/Users/hugh/src/gestalt-test-folding/.tmp-test go test ./cmd/gestaltd ./internal/server -run 'TestE2EServeAndHealthCheck|TestReadinessCheck_NotReady|TestReadinessCheck_DatastoreDown' -count=1`
- `git diff --check`

Note: `gh pr create` is currently blocked by the authenticated user GraphQL rate limit, so this PR was opened via the GitHub connector.