### PR TITLE
operator: retry transient release metadata fetches

### DIFF
--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1697,6 +1697,116 @@ func TestSourcePluginGitHubReleaseSourceUsesResolvedAssetURL(t *testing.T) {
 	}
 }
 
+func TestSourcePluginMetadataURLRetriesTransientRemoteMetadataFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	archivePath := buildV2Archive(t, dir, testSource, testVersion, testBinary)
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSHA := sha256.Sum256(archiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+
+	const metadataPath = "/providers/alpha/provider-release.yaml"
+	const archivePathURL = "/providers/alpha/alpha-current.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			count := metadataCount.Add(1)
+			if count <= 2 {
+				http.Error(w, "bad gateway", http.StatusBadGateway)
+				return
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+				handlerErrs <- fmt.Errorf("metadata accept = %q, want %q", got, "application/octet-stream")
+				http.Error(w, "bad metadata accept", http.StatusBadRequest)
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       testSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       testVersion,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   "./alpha-current.tar.gz",
+						SHA256: hex.EncodeToString(archiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case archivePathURL:
+			archiveCount.Add(1)
+			_, _ = w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		"plugins:",
+		"  alpha:",
+		"    source:",
+		"      url: " + srv.URL + metadataPath,
+		"      auth:",
+		"        token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle()
+	if _, err := lc.InitAtPath(configPath); err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got != 3 {
+		t.Fatalf("metadata request count = %d, want 3", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive request count = %d, want 1", got)
+	}
+}
+
 func TestSourcePluginMetadataURLRejectsOversizedRemoteMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
@@ -35,6 +36,12 @@ const (
 	httpAuthorizationHeader           = "Authorization"
 	httpBearerAuthorizationPrefix     = "Bearer "
 )
+
+var providerReleaseFetchRetryDelays = []time.Duration{
+	200 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
+}
 
 type gitHubReleaseLocation struct {
 	Repo  string
@@ -165,11 +172,9 @@ func fetchProviderReleaseMetadata(ctx context.Context, client *http.Client, meta
 	if client == nil {
 		client = http.DefaultClient
 	}
-	req, err := newAuthenticatedFetchRequest(ctx, resolvedMetadataLocation, token)
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("create provider release metadata request: %w", err)
-	}
-	resp, err := client.Do(req)
+	resp, err := doProviderReleaseHTTPRequestWithRetry(ctx, client, func(ctx context.Context) (*http.Request, error) {
+		return newAuthenticatedFetchRequest(ctx, resolvedMetadataLocation, token)
+	})
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("fetch provider release metadata: %w", err)
 	}
@@ -189,6 +194,49 @@ func fetchProviderReleaseMetadata(ctx context.Context, client *http.Client, meta
 		return nil, "", nil, err
 	}
 	return metadata, resolvedMetadataLocation, gitHubReleaseAssets, nil
+}
+
+func doProviderReleaseHTTPRequestWithRetry(ctx context.Context, client *http.Client, newRequest func(context.Context) (*http.Request, error)) (*http.Response, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		req, err := newRequest(ctx)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := client.Do(req)
+		if err == nil && !isTransientProviderReleaseHTTPStatus(resp.StatusCode) {
+			return resp, nil
+		}
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = nil
+		}
+		if attempt >= len(providerReleaseFetchRetryDelays) {
+			return resp, lastErr
+		}
+		if resp != nil && resp.Body != nil {
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+			_ = resp.Body.Close()
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		timer := time.NewTimer(providerReleaseFetchRetryDelays[attempt])
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func isTransientProviderReleaseHTTPStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
 }
 
 func newAuthenticatedFetchRequest(ctx context.Context, requestURL, token string) (*http.Request, error) {
@@ -256,15 +304,18 @@ func resolveGitHubReleaseAssetURL(ctx context.Context, client *http.Client, ref 
 		client = http.DefaultClient
 	}
 	endpoint := "https://api.github.com/repos/" + strings.TrimSpace(ref.Repo) + "/releases/tags/" + url.PathEscape(strings.TrimSpace(ref.Tag))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return "", nil, fmt.Errorf("create github release lookup request: %w", err)
-	}
-	req.Header.Set(httpAcceptHeader, httpAcceptGitHubAPI)
-	if token = strings.TrimSpace(token); token != "" {
-		req.Header.Set(httpAuthorizationHeader, httpBearerAuthorizationPrefix+token)
-	}
-	resp, err := client.Do(req)
+	token = strings.TrimSpace(token)
+	resp, err := doProviderReleaseHTTPRequestWithRetry(ctx, client, func(ctx context.Context) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set(httpAcceptHeader, httpAcceptGitHubAPI)
+		if token != "" {
+			req.Header.Set(httpAuthorizationHeader, httpBearerAuthorizationPrefix+token)
+		}
+		return req, nil
+	})
 	if err != nil {
 		return "", nil, fmt.Errorf("resolve github release %s@%s: %w", ref.Repo, ref.Tag, err)
 	}


### PR DESCRIPTION
## Summary

Retry transient remote `provider-release.yaml` fetch failures during lifecycle initialization.

The toolshed deploy for `55191af4` failed because startup fetched Hex provider metadata from GitHub releases and GitHub returned a transient `502`:

```text
provider "hex" fetch metadata "https://github.com/valon-technologies/gestalt-providers/releases/download/plugins/hex/v0.0.1-alpha.7/provider-release.yaml": unexpected status 502 fetching provider release metadata
```

This keeps deterministic errors fail-fast, but retries transient HTTP statuses and transport failures:

- retries: `429`, `5xx`, request transport errors
- does not retry: `4xx` other than `429`, invalid YAML, oversized metadata, missing artifacts, integrity errors

## Interface

No config or API change. Existing provider metadata source configuration stays the same:

```yaml
plugins:
  hex:
    source: https://github.com/valon-technologies/gestalt-providers/releases/download/plugins/hex/v0.0.1-alpha.7/provider-release.yaml
```

The same retry path also covers `githubRelease` source lookups before downloading the selected metadata asset:

```yaml
plugins:
  workplaceHub:
    source:
      githubRelease:
        repo: valon-technologies/toolshed
        tag: plugins/workplace-hub/v0.0.1-alpha.1
        asset: provider-release.yaml
```

## Verification

```bash
GOCACHE=/tmp/gestalt-provider-retry-gocache go test ./internal/operator -run 'TestSourcePluginMetadataURLRetriesTransientRemoteMetadataFailure|TestSourcePluginGitHubReleaseSourceUsesResolvedAssetURL|TestSourcePluginMetadataURLRejectsOversizedRemoteMetadata'
```

The new lifecycle-style test returns two `502` responses for remote release metadata, then valid metadata, and verifies initialization succeeds with three metadata requests and one archive fetch.