### PR TITLE
Retry stale hosted agent read mappings

### DIFF
--- a/gestalt/cli/src/commands/agents/tui/worker.rs
+++ b/gestalt/cli/src/commands/agents/tui/worker.rs
@@ -46,7 +46,7 @@ pub(super) fn spawn_turn_worker(
     thread::spawn(move || {
         let result = run_turn_worker(&client, turn_args, &event_tx, &command_rx);
         if let Err(err) = result {
-            let _ = event_tx.send(WorkerEvent::Error(err.to_string()));
+            let _ = event_tx.send(WorkerEvent::Error(format!("{err:#}")));
         }
         let _ = event_tx.send(WorkerEvent::Done);
     })

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -1027,6 +1027,58 @@ func TestHostedAgentProviderPoolGetTurnRetriesAfterPreferredTimeout(t *testing.T
 	}
 }
 
+func TestHostedAgentProviderPoolGetTurnRetriesAfterStalePreferredMiss(t *testing.T) {
+	t.Parallel()
+
+	firstCalls := 0
+	secondCalls := 0
+	first := &hostedAgentPoolBackend{
+		id: 1,
+		provider: &routingAgentProvider{
+			getTurn: func(context.Context, coreagent.GetTurnRequest) (*coreagent.Turn, error) {
+				firstCalls++
+				return nil, core.ErrNotFound
+			},
+		},
+		liveTurns: map[string]struct{}{"turn-1": {}},
+	}
+	second := &hostedAgentPoolBackend{
+		id: 2,
+		provider: &routingAgentProvider{
+			getTurn: func(_ context.Context, req coreagent.GetTurnRequest) (*coreagent.Turn, error) {
+				secondCalls++
+				return &coreagent.Turn{
+					ID:        req.TurnID,
+					SessionID: "session-1",
+					Status:    coreagent.ExecutionStatusSucceeded,
+				}, nil
+			},
+		},
+		liveTurns: map[string]struct{}{},
+	}
+	pool := &hostedAgentProviderPool{
+		name:            "simple",
+		ctx:             context.Background(),
+		sessionBackends: map[string]*hostedAgentPoolBackend{},
+		turnBackends:    map[string]*hostedAgentPoolBackend{"turn-1": first},
+		backends:        []*hostedAgentPoolBackend{first, second},
+	}
+
+	turn, err := pool.GetTurn(context.Background(), coreagent.GetTurnRequest{TurnID: "turn-1"})
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if turn == nil || turn.ID != "turn-1" || turn.Status != coreagent.ExecutionStatusSucceeded {
+		t.Fatalf("GetTurn = %#v, want succeeded turn-1", turn)
+	}
+	if firstCalls != 1 || secondCalls != 1 {
+		t.Fatalf("GetTurn calls: first=%d second=%d, want first=1 second=1", firstCalls, secondCalls)
+	}
+	if backend := pool.turnBackend("turn-1"); backend != nil {
+		t.Fatalf("terminal turn backend = %#v, want no sticky backend after success", backend)
+	}
+}
+
 func TestHostedAgentProviderPoolListSessionsContinuesAfterTransientBackendFailure(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/hosted_agent_pool.go
+++ b/gestaltd/internal/bootstrap/hosted_agent_pool.go
@@ -113,6 +113,7 @@ func (p *hostedAgentProviderPool) CreateSession(ctx context.Context, req coreage
 
 func (p *hostedAgentProviderPool) GetSession(ctx context.Context, req coreagent.GetSessionRequest) (*coreagent.Session, error) {
 	var retryableErr error
+	var lastNotFound error
 	tried := map[*hostedAgentPoolBackend]struct{}{}
 	if backend := p.sessionBackend(req.SessionID); backend != nil {
 		tried[backend] = struct{}{}
@@ -123,14 +124,13 @@ func (p *hostedAgentProviderPool) GetSession(ctx context.Context, req coreagent.
 			return session, nil
 		case errors.Is(err, core.ErrNotFound):
 			p.deleteSessionBackend(req.SessionID)
-			return nil, err
+			lastNotFound = err
 		case isHostedAgentReadRetryableError(err):
 			retryableErr = err
 		default:
 			return nil, err
 		}
 	}
-	var lastNotFound error
 	for _, backend := range p.availableBackends(true) {
 		if _, ok := tried[backend]; ok {
 			continue
@@ -253,6 +253,7 @@ func (p *hostedAgentProviderPool) CreateTurn(ctx context.Context, req coreagent.
 
 func (p *hostedAgentProviderPool) GetTurn(ctx context.Context, req coreagent.GetTurnRequest) (*coreagent.Turn, error) {
 	var retryableErr error
+	var lastNotFound error
 	tried := map[*hostedAgentPoolBackend]struct{}{}
 	if backend := p.turnBackend(req.TurnID); backend != nil {
 		tried[backend] = struct{}{}
@@ -263,14 +264,13 @@ func (p *hostedAgentProviderPool) GetTurn(ctx context.Context, req coreagent.Get
 			return turn, nil
 		case errors.Is(err, core.ErrNotFound):
 			p.deleteTurnBackend(req.TurnID)
-			return nil, err
+			lastNotFound = err
 		case isHostedAgentReadRetryableError(err):
 			retryableErr = err
 		default:
 			return nil, err
 		}
 	}
-	var lastNotFound error
 	for _, backend := range p.availableBackends(true) {
 		if _, ok := tried[backend]; ok {
 			continue
@@ -301,6 +301,7 @@ func (p *hostedAgentProviderPool) GetTurn(ctx context.Context, req coreagent.Get
 
 func (p *hostedAgentProviderPool) ListTurns(ctx context.Context, req coreagent.ListTurnsRequest) ([]*coreagent.Turn, error) {
 	var retryableErr error
+	var lastNotFound error
 	succeeded := false
 	tried := map[*hostedAgentPoolBackend]struct{}{}
 	if backend := p.sessionBackend(req.SessionID); backend != nil {
@@ -309,10 +310,15 @@ func (p *hostedAgentProviderPool) ListTurns(ctx context.Context, req coreagent.L
 		if err == nil {
 			return turns, nil
 		}
-		if !isHostedAgentReadRetryableError(err) {
+		switch {
+		case errors.Is(err, core.ErrNotFound):
+			p.deleteSessionBackend(req.SessionID)
+			lastNotFound = err
+		case isHostedAgentReadRetryableError(err):
+			retryableErr = err
+		default:
 			return nil, err
 		}
-		retryableErr = err
 	}
 	var out []*coreagent.Turn
 	for _, backend := range p.availableBackends(true) {
@@ -321,6 +327,10 @@ func (p *hostedAgentProviderPool) ListTurns(ctx context.Context, req coreagent.L
 		}
 		turns, err := p.listTurnsFromBackend(ctx, backend, req)
 		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				lastNotFound = err
+				continue
+			}
 			if isHostedAgentReadRetryableError(err) {
 				retryableErr = err
 				continue
@@ -332,6 +342,9 @@ func (p *hostedAgentProviderPool) ListTurns(ctx context.Context, req coreagent.L
 	}
 	if !succeeded && retryableErr != nil {
 		return nil, retryableErr
+	}
+	if !succeeded && lastNotFound != nil {
+		return nil, lastNotFound
 	}
 	return out, nil
 }
@@ -363,6 +376,7 @@ func (p *hostedAgentProviderPool) CancelTurn(ctx context.Context, req coreagent.
 
 func (p *hostedAgentProviderPool) ListTurnEvents(ctx context.Context, req coreagent.ListTurnEventsRequest) ([]*coreagent.TurnEvent, error) {
 	var retryableErr error
+	var lastNotFound error
 	tried := map[*hostedAgentPoolBackend]struct{}{}
 	if backend := p.turnBackend(req.TurnID); backend != nil {
 		tried[backend] = struct{}{}
@@ -370,12 +384,16 @@ func (p *hostedAgentProviderPool) ListTurnEvents(ctx context.Context, req coreag
 		if err == nil {
 			return events, nil
 		}
-		if !isHostedAgentReadRetryableError(err) {
+		switch {
+		case errors.Is(err, core.ErrNotFound):
+			p.deleteTurnBackend(req.TurnID)
+			lastNotFound = err
+		case isHostedAgentReadRetryableError(err):
+			retryableErr = err
+		default:
 			return nil, err
 		}
-		retryableErr = err
 	}
-	var lastNotFound error
 	for _, backend := range p.availableBackends(true) {
 		if _, ok := tried[backend]; ok {
 			continue
@@ -405,6 +423,7 @@ func (p *hostedAgentProviderPool) ListTurnEvents(ctx context.Context, req coreag
 
 func (p *hostedAgentProviderPool) GetInteraction(ctx context.Context, req coreagent.GetInteractionRequest) (*coreagent.Interaction, error) {
 	var retryableErr error
+	var lastNotFound error
 	tried := map[*hostedAgentPoolBackend]struct{}{}
 	if backend := p.interactionBackend(req.InteractionID); backend != nil {
 		tried[backend] = struct{}{}
@@ -415,14 +434,13 @@ func (p *hostedAgentProviderPool) GetInteraction(ctx context.Context, req coreag
 			return interaction, nil
 		case errors.Is(err, core.ErrNotFound):
 			p.deleteInteractionBackend(req.InteractionID)
-			return nil, err
+			lastNotFound = err
 		case isHostedAgentReadRetryableError(err):
 			retryableErr = err
 		default:
 			return nil, err
 		}
 	}
-	var lastNotFound error
 	for _, backend := range p.availableBackends(true) {
 		if _, ok := tried[backend]; ok {
 			continue
@@ -453,6 +471,7 @@ func (p *hostedAgentProviderPool) GetInteraction(ctx context.Context, req coreag
 
 func (p *hostedAgentProviderPool) ListInteractions(ctx context.Context, req coreagent.ListInteractionsRequest) ([]*coreagent.Interaction, error) {
 	var retryableErr error
+	var lastNotFound error
 	succeeded := false
 	tried := map[*hostedAgentPoolBackend]struct{}{}
 	if backend := p.turnBackend(req.TurnID); backend != nil {
@@ -461,10 +480,15 @@ func (p *hostedAgentProviderPool) ListInteractions(ctx context.Context, req core
 		if err == nil {
 			return interactions, nil
 		}
-		if !isHostedAgentReadRetryableError(err) {
+		switch {
+		case errors.Is(err, core.ErrNotFound):
+			p.deleteTurnBackend(req.TurnID)
+			lastNotFound = err
+		case isHostedAgentReadRetryableError(err):
+			retryableErr = err
+		default:
 			return nil, err
 		}
-		retryableErr = err
 	}
 	var out []*coreagent.Interaction
 	for _, backend := range p.availableBackends(true) {
@@ -473,6 +497,10 @@ func (p *hostedAgentProviderPool) ListInteractions(ctx context.Context, req core
 		}
 		interactions, err := p.listInteractionsFromBackend(ctx, backend, req)
 		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				lastNotFound = err
+				continue
+			}
 			if isHostedAgentReadRetryableError(err) {
 				retryableErr = err
 				continue
@@ -484,6 +512,9 @@ func (p *hostedAgentProviderPool) ListInteractions(ctx context.Context, req core
 	}
 	if !succeeded && retryableErr != nil {
 		return nil, retryableErr
+	}
+	if !succeeded && lastNotFound != nil {
+		return nil, lastNotFound
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Summary
- Retry hosted agent provider read paths when a remembered backend returns `not found`, treating that as a stale host-side routing hint instead of an authoritative provider result.
- Apply the same stale-mapping behavior to session, turn, turn-event, and interaction read paths.
- Preserve full anyhow cause chains in the interactive agent TUI so future `error>` rows include the underlying HTTP/status/timeout cause.

## Interface / Usage
No API, proto, YAML, or CLI invocation changes. Existing calls continue to work:

```bash
GESTALT_URL=https://valon.tools gestalt agent
GESTALT_URL=https://valon.tools gestalt agent turns get <turn-id> --format json
```

Existing REST contract is unchanged:

```http
GET /api/v1/agent/turns/{turnId}
GET /api/v1/agent/turns/{turnId}/events?stream=true&until=blocked_or_terminal
```

Provider implementations do not need new methods. This only changes host routing semantics: backend affinity maps are cache hints; provider read results across available hosted backends remain the source of truth.

## Verification
- `go test ./internal/bootstrap -run 'TestHostedAgentProviderPoolGetTurnRetriesAfter(StalePreferredMiss|PreferredTimeout)'`
- `go test ./internal/bootstrap`
- `cargo check -p gestalt`
- `cargo clippy --workspace --all-targets -- -D warnings`
