### PR TITLE
Remove stale legacy provider naming

### DIFF
--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -31,7 +31,7 @@ These fields are emitted when available:
 
 | Field | Meaning |
 | --- | --- |
-| `auth_source` | Authentication mechanism for the caller: `session`, `api_token`, or `env`. Rejected retired workload bearer tokens are audit-tagged as `retired_workload_token`. |
+| `auth_source` | Authentication mechanism for the caller: `session`, `api_token`, or `env`. |
 | `subject_id` | Canonical caller subject such as `user:<id>` or `service_account:<id>` |
 | `subject_kind` | Canonical subject type, such as `user` or `service_account` |
 | `target_kind` | Generic kind for the object the event acted on, such as `api_token` or `connection` |

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -258,7 +258,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	for _, param := range []string{"instance", "connection"} {
 		if _, ok := query[param]; ok {
-			auditErr = errors.New("legacy connection parameter")
+			auditErr = errors.New("unsupported connection parameter")
 			writeError(w, http.StatusBadRequest, "use _connection and _instance query parameters")
 			return
 		}

--- a/sdk/go/auth.go
+++ b/sdk/go/auth.go
@@ -23,7 +23,7 @@ type CompleteLoginRequest = proto.CompleteLoginRequest
 
 // AuthenticationProvider serves the Gestalt authentication protocol.
 type AuthenticationProvider interface {
-	PluginProvider
+	Provider
 	BeginLogin(ctx context.Context, req *BeginLoginRequest) (*BeginLoginResponse, error)
 	CompleteLogin(ctx context.Context, req *CompleteLoginRequest) (*AuthenticatedUser, error)
 }

--- a/sdk/go/authorization.go
+++ b/sdk/go/authorization.go
@@ -40,7 +40,7 @@ type ListModelsResponse = proto.ListModelsResponse
 type WriteModelRequest = proto.WriteModelRequest
 
 type AuthorizationProvider interface {
-	PluginProvider
+	Provider
 	Evaluate(ctx context.Context, req *AccessEvaluationRequest) (*AccessDecision, error)
 	EvaluateMany(ctx context.Context, req *AccessEvaluationsRequest) (*AccessEvaluationsResponse, error)
 	SearchResources(ctx context.Context, req *ResourceSearchRequest) (*ResourceSearchResponse, error)

--- a/sdk/go/external_credential.go
+++ b/sdk/go/external_credential.go
@@ -17,7 +17,7 @@ type DeleteExternalCredentialRequest = proto.DeleteExternalCredentialRequest
 // ExternalCredentialProvider serves CRUD operations for host-managed external
 // credentials.
 type ExternalCredentialProvider interface {
-	PluginProvider
+	Provider
 	UpsertCredential(ctx context.Context, req *UpsertExternalCredentialRequest) (*ExternalCredential, error)
 	GetCredential(ctx context.Context, req *GetExternalCredentialRequest) (*ExternalCredential, error)
 	ListCredentials(ctx context.Context, req *ListExternalCredentialsRequest) (*ListExternalCredentialsResponse, error)

--- a/sdk/go/secrets.go
+++ b/sdk/go/secrets.go
@@ -7,6 +7,6 @@ import (
 // SecretsProvider serves secret lookups for providers that need host-managed
 // secret material.
 type SecretsProvider interface {
-	PluginProvider
+	Provider
 	GetSecret(ctx context.Context, name string) (string, error)
 }

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -56,9 +56,6 @@ type Provider interface {
 	Configure(ctx context.Context, name string, config map[string]any) error
 }
 
-// PluginProvider is a deprecated alias for Provider.
-type PluginProvider = Provider
-
 // MetadataProvider is implemented by providers that can describe themselves
 // without consulting the manifest or host-side configuration.
 type MetadataProvider interface {


### PR DESCRIPTION
## Summary
- Remove the deprecated Go SDK `PluginProvider` alias.
- Embed `Provider` directly in typed Go provider interfaces.
- Remove stale retired workload-token audit documentation and the remaining legacy connection audit label.

## Interface change
Before:

```go
type PluginProvider = Provider

type AuthenticationProvider interface {
    PluginProvider
    BeginLogin(ctx context.Context, req *BeginLoginRequest) (*BeginLoginResponse, error)
    CompleteLogin(ctx context.Context, req *CompleteLoginRequest) (*AuthenticatedUser, error)
}
```

After:

```go
type Provider interface {
    Configure(ctx context.Context, name string, config map[string]any) error
}

type AuthenticationProvider interface {
    Provider
    BeginLogin(ctx context.Context, req *BeginLoginRequest) (*BeginLoginResponse, error)
    CompleteLogin(ctx context.Context, req *CompleteLoginRequest) (*AuthenticatedUser, error)
}
```

The same direct `Provider` embedding now applies to `AuthorizationProvider`, `ExternalCredentialProvider`, and `SecretsProvider`.

## Example
```go
type myProvider struct{}

func (p *myProvider) Configure(ctx context.Context, name string, config map[string]any) error {
    return nil
}

var _ gestalt.Provider = (*myProvider)(nil)
```

## Validation
- `go test ./...` from `sdk/go`
- `go test ./internal/server` from `gestaltd`
