### PR TITLE
agent: reconcile idempotent provider sessions

### DIFF
--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -256,20 +256,37 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 		}
 		session = fallback
 	}
-	normalized, err := normalizeProviderSession(providerName, sessionID, session)
+	normalized, err := normalizeProviderSessionForCreate(providerName, sessionID, idempotencyKey, session)
 	if err != nil {
 		if idempotencyKey != "" {
 			_ = m.sessionMetadata.ReleaseIdempotency(ctx, subjectID, providerName, idempotencyKey)
 		}
 		return nil, err
 	}
-	if _, err := m.sessionMetadata.Put(ctx, &coreagent.SessionReference{
+	var existingRef *coreagent.SessionReference
+	if strings.TrimSpace(normalized.ID) != strings.TrimSpace(sessionID) {
+		existingRef, err = m.validateIdempotentProviderSession(ctx, p, providerName, idempotencyKey, normalized)
+		if err != nil {
+			if idempotencyKey != "" {
+				_ = m.sessionMetadata.ReleaseIdempotency(ctx, subjectID, providerName, idempotencyKey)
+			}
+			return nil, err
+		}
+	}
+	sessionRef := &coreagent.SessionReference{
 		ID:                  normalized.ID,
 		ProviderName:        providerName,
 		SubjectID:           subjectID,
 		CredentialSubjectID: strings.TrimSpace(principal.EffectiveCredentialSubjectID(p)),
 		IdempotencyKey:      idempotencyKey,
-	}); err != nil {
+	}
+	if existingRef != nil {
+		sessionRef = cloneSessionReference(existingRef)
+		if strings.TrimSpace(sessionRef.IdempotencyKey) == "" {
+			sessionRef.IdempotencyKey = idempotencyKey
+		}
+	}
+	if _, err := m.sessionMetadata.Put(ctx, sessionRef); err != nil {
 		if idempotencyKey != "" {
 			_ = m.sessionMetadata.ReleaseIdempotency(ctx, subjectID, providerName, idempotencyKey)
 		}
@@ -1380,6 +1397,34 @@ func (m *Manager) catalogSelectorConfig() invocation.CatalogSelectorConfig {
 	}
 }
 
+func (m *Manager) validateIdempotentProviderSession(ctx context.Context, p *principal.Principal, providerName, idempotencyKey string, session *coreagent.Session) (*coreagent.SessionReference, error) {
+	if session == nil {
+		return nil, core.ErrNotFound
+	}
+	sessionID := strings.TrimSpace(session.ID)
+	if sessionID == "" {
+		return nil, fmt.Errorf("agent provider returned session without id")
+	}
+	ref, err := m.sessionMetadata.Get(ctx, sessionID)
+	if err == nil {
+		if strings.TrimSpace(ref.ProviderName) != strings.TrimSpace(providerName) || !sessionRefOwnedBy(ref, p) {
+			return nil, core.ErrNotFound
+		}
+		refIdempotencyKey := strings.TrimSpace(ref.IdempotencyKey)
+		if refIdempotencyKey != "" && refIdempotencyKey != strings.TrimSpace(idempotencyKey) {
+			return nil, fmt.Errorf("%w: agent provider returned session %q for idempotency key %q, but existing metadata uses idempotency key %q", invocation.ErrInternal, sessionID, strings.TrimSpace(idempotencyKey), refIdempotencyKey)
+		}
+		return ref, nil
+	}
+	if !errors.Is(err, indexeddb.ErrNotFound) {
+		return nil, err
+	}
+	if !providerSessionOwnedBy(session, p) {
+		return nil, core.ErrNotFound
+	}
+	return nil, nil
+}
+
 func executionRefOwnedBy(ref *coreagent.ExecutionReference, p *principal.Principal) bool {
 	if ref == nil || p == nil {
 		return false
@@ -1394,6 +1439,22 @@ func sessionRefOwnedBy(ref *coreagent.SessionReference, p *principal.Principal) 
 	}
 	subjectID := strings.TrimSpace(principalSubjectID(principal.Canonicalized(p)))
 	return subjectID != "" && strings.TrimSpace(ref.SubjectID) == subjectID
+}
+
+func cloneSessionReference(ref *coreagent.SessionReference) *coreagent.SessionReference {
+	if ref == nil {
+		return nil
+	}
+	cloned := *ref
+	return &cloned
+}
+
+func providerSessionOwnedBy(session *coreagent.Session, p *principal.Principal) bool {
+	if session == nil || p == nil {
+		return false
+	}
+	subjectID := strings.TrimSpace(principalSubjectID(principal.Canonicalized(p)))
+	return subjectID != "" && strings.TrimSpace(session.CreatedBy.SubjectID) == subjectID
 }
 
 func executionRefActive(ref *coreagent.ExecutionReference) bool {
@@ -1464,6 +1525,23 @@ func normalizeProviderSession(providerName, sessionID string, session *coreagent
 	}
 	if strings.TrimSpace(cloned.ID) != strings.TrimSpace(sessionID) {
 		return nil, fmt.Errorf("agent provider returned session id %q, want %q", cloned.ID, sessionID)
+	}
+	if strings.TrimSpace(cloned.ProviderName) == "" {
+		cloned.ProviderName = strings.TrimSpace(providerName)
+	}
+	return &cloned, nil
+}
+
+func normalizeProviderSessionForCreate(providerName, sessionID, idempotencyKey string, session *coreagent.Session) (*coreagent.Session, error) {
+	if strings.TrimSpace(idempotencyKey) == "" {
+		return normalizeProviderSession(providerName, sessionID, session)
+	}
+	if session == nil {
+		return nil, core.ErrNotFound
+	}
+	cloned := *session
+	if strings.TrimSpace(cloned.ID) == "" {
+		return nil, fmt.Errorf("agent provider returned session without id")
 	}
 	if strings.TrimSpace(cloned.ProviderName) == "" {
 		cloned.ProviderName = strings.TrimSpace(providerName)

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
@@ -49,6 +51,218 @@ func (i tokenErrorInvoker) ResolveToken(ctx context.Context, _ *principal.Princi
 		return ctx, "", nil
 	}
 	return ctx, "", i.err
+}
+
+type singleAgentControl struct {
+	name     string
+	provider coreagent.Provider
+}
+
+func (c singleAgentControl) ResolveProvider(name string) (coreagent.Provider, error) {
+	if name != "" && name != c.name {
+		return nil, NewAgentProviderNotAvailableError(name)
+	}
+	return c.provider, nil
+}
+
+func (c singleAgentControl) ResolveProviderSelection(name string) (string, coreagent.Provider, error) {
+	if name != "" && name != c.name {
+		return "", nil, NewAgentProviderNotAvailableError(name)
+	}
+	return c.name, c.provider, nil
+}
+
+func (c singleAgentControl) ProviderNames() []string {
+	return []string{c.name}
+}
+
+type idempotentSessionProvider struct {
+	coreagent.UnimplementedProvider
+	session        *coreagent.Session
+	createRequests []coreagent.CreateSessionRequest
+}
+
+func (p *idempotentSessionProvider) CreateSession(_ context.Context, req coreagent.CreateSessionRequest) (*coreagent.Session, error) {
+	p.createRequests = append(p.createRequests, req)
+	return cloneAgentManagerSession(p.session), nil
+}
+
+func (p *idempotentSessionProvider) GetSession(_ context.Context, req coreagent.GetSessionRequest) (*coreagent.Session, error) {
+	if p.session == nil || req.SessionID != p.session.ID {
+		return nil, core.ErrNotFound
+	}
+	return cloneAgentManagerSession(p.session), nil
+}
+
+func cloneAgentManagerSession(src *coreagent.Session) *coreagent.Session {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	return &dst
+}
+
+func TestCreateSessionReconcilesIdempotentProviderSessionID(t *testing.T) {
+	t.Parallel()
+
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	provider := &idempotentSessionProvider{
+		session: &coreagent.Session{
+			ID:        "provider-session-1",
+			State:     coreagent.SessionStateActive,
+			CreatedBy: coreagent.Actor{SubjectID: principal.UserSubjectID("user-1")},
+		},
+	}
+	manager := New(Config{
+		Agent:           singleAgentControl{name: "simple", provider: provider},
+		SessionMetadata: services.AgentSessions,
+		RunMetadata:     services.AgentRunMetadata,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName:    "simple",
+		IdempotencyKey:  "workflow:github:run-1:session",
+		ProviderOptions: map[string]any{"temperature": 0},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if session.ID != "provider-session-1" {
+		t.Fatalf("CreateSession session ID = %q, want provider-session-1", session.ID)
+	}
+	if len(provider.createRequests) != 1 {
+		t.Fatalf("CreateSession calls = %d, want 1", len(provider.createRequests))
+	}
+	if provider.createRequests[0].SessionID == session.ID {
+		t.Fatalf("provider request session ID = returned session ID %q, want generated requested ID", session.ID)
+	}
+
+	ref, err := services.AgentSessions.Get(context.Background(), "provider-session-1")
+	if err != nil {
+		t.Fatalf("AgentSessions.Get: %v", err)
+	}
+	if ref.IdempotencyKey != "workflow:github:run-1:session" {
+		t.Fatalf("metadata idempotency key = %q, want workflow key", ref.IdempotencyKey)
+	}
+
+	replayed, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName:   "simple",
+		IdempotencyKey: "workflow:github:run-1:session",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession replay: %v", err)
+	}
+	if replayed.ID != "provider-session-1" {
+		t.Fatalf("CreateSession replay ID = %q, want provider-session-1", replayed.ID)
+	}
+	if len(provider.createRequests) != 1 {
+		t.Fatalf("CreateSession calls after replay = %d, want 1", len(provider.createRequests))
+	}
+}
+
+func TestCreateSessionPreservesExistingMetadataWhenReconcilingProviderSession(t *testing.T) {
+	t.Parallel()
+
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	archivedAt := time.Date(2026, time.April, 27, 12, 0, 0, 0, time.UTC)
+	if _, err := services.AgentSessions.Put(context.Background(), &coreagent.SessionReference{
+		ID:                  "provider-session-1",
+		ProviderName:        "simple",
+		SubjectID:           principal.UserSubjectID("user-1"),
+		CredentialSubjectID: "credential:old",
+		ArchivedAt:          &archivedAt,
+	}); err != nil {
+		t.Fatalf("AgentSessions.Put: %v", err)
+	}
+	provider := &idempotentSessionProvider{
+		session: &coreagent.Session{
+			ID:    "provider-session-1",
+			State: coreagent.SessionStateArchived,
+		},
+	}
+	manager := New(Config{
+		Agent:           singleAgentControl{name: "simple", provider: provider},
+		SessionMetadata: services.AgentSessions,
+		RunMetadata:     services.AgentRunMetadata,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName:   "simple",
+		IdempotencyKey: "workflow:github:run-1:session",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if session.ID != "provider-session-1" {
+		t.Fatalf("CreateSession session ID = %q, want provider-session-1", session.ID)
+	}
+
+	ref, err := services.AgentSessions.Get(context.Background(), "provider-session-1")
+	if err != nil {
+		t.Fatalf("AgentSessions.Get: %v", err)
+	}
+	if ref.ArchivedAt == nil || !ref.ArchivedAt.Equal(archivedAt) {
+		t.Fatalf("metadata archived_at = %v, want %v", ref.ArchivedAt, archivedAt)
+	}
+	if ref.CredentialSubjectID != "credential:old" {
+		t.Fatalf("metadata credential_subject_id = %q, want credential:old", ref.CredentialSubjectID)
+	}
+	if ref.IdempotencyKey != "workflow:github:run-1:session" {
+		t.Fatalf("metadata idempotency key = %q, want workflow key", ref.IdempotencyKey)
+	}
+}
+
+func TestCreateSessionRejectsIdempotentProviderSessionForDifferentSubject(t *testing.T) {
+	t.Parallel()
+
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	provider := &idempotentSessionProvider{
+		session: &coreagent.Session{
+			ID:        "provider-session-1",
+			State:     coreagent.SessionStateActive,
+			CreatedBy: coreagent.Actor{SubjectID: principal.UserSubjectID("user-2")},
+		},
+	}
+	manager := New(Config{
+		Agent:           singleAgentControl{name: "simple", provider: provider},
+		SessionMetadata: services.AgentSessions,
+		RunMetadata:     services.AgentRunMetadata,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	_, err = manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName:   "simple",
+		IdempotencyKey: "workflow:github:run-1:session",
+	})
+	if !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("CreateSession error = %v, want not found", err)
+	}
+	if _, err := services.AgentSessions.Get(context.Background(), "provider-session-1"); err == nil {
+		t.Fatal("AgentSessions.Get error = nil, want not found")
+	}
+
+	provider.session.CreatedBy = coreagent.Actor{SubjectID: principal.UserSubjectID("user-1")}
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName:   "simple",
+		IdempotencyKey: "workflow:github:run-1:session",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession after rejected replay: %v", err)
+	}
+	if session.ID != "provider-session-1" {
+		t.Fatalf("CreateSession after rejected replay ID = %q, want provider-session-1", session.ID)
+	}
 }
 
 func TestSearchToolsSearchesAuthorizedCatalogWhenNoRefsDefined(t *testing.T) {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -425,7 +425,7 @@ func (p *agentProviderWithTracking) CreateSession(ctx context.Context, req corea
 	requestedID := strings.TrimSpace(req.SessionID)
 	if requestedID != "" && session != nil {
 		actualID := strings.TrimSpace(session.ID)
-		if actualID != "" && actualID != requestedID {
+		if actualID != "" && actualID != requestedID && strings.TrimSpace(req.IdempotencyKey) == "" {
 			return nil, fmt.Errorf("%w: agent provider %q returned session id %q for requested session id %q", invocation.ErrInternal, p.providerName, actualID, requestedID)
 		}
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -5801,6 +5801,18 @@ func TestBootstrapAgentProviderRejectsMismatchedRequestedSessionOrTurnID(t *test
 		t.Fatalf("CreateSession error = %v, want mismatched session id failure", err)
 	}
 
+	replayedSession, err := provider.CreateSession(startCtx, coreagent.CreateSessionRequest{
+		SessionID:      "agent-session-1",
+		IdempotencyKey: "workflow:github:run-1:session",
+		Model:          "gpt-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession idempotent replay: %v", err)
+	}
+	if replayedSession.ID != "generated-session-1" {
+		t.Fatalf("CreateSession idempotent replay ID = %q, want generated-session-1", replayedSession.ID)
+	}
+
 	if _, err := provider.CreateTurn(startCtx, coreagent.CreateTurnRequest{
 		TurnID:    "agent-turn-1",
 		SessionID: "agent-session-1",


### PR DESCRIPTION
## Summary
- allow idempotent agent CreateSession replays to return an existing provider-owned session ID
- adopt the replayed ID only when same-subject ownership is proven by existing session metadata or provider CreatedBy metadata
- preserve existing SessionReference fields such as CreatedAt, ArchivedAt, and CredentialSubjectID when existing metadata proves ownership

## Interface / Behavior
```go
session, err := manager.CreateSession(ctx, principal, coreagent.ManagerCreateSessionRequest{
    ProviderName:   "simple",
    IdempotencyKey: "workflow:github:<run-id>:session",
})
```

Before:
```text
provider returned session 16bcc601-... for requested session 72685850-... -> internal error
```

After:
```text
SessionReference{ID: "16bcc601-...", IdempotencyKey: "workflow:github:<run-id>:session"}
```

The reconciled session is accepted only for the same subject. If existing metadata proves ownership, its archived state and credential subject are preserved.

## Tests
- go test ./internal/agentmanager
- go test ./internal/bootstrap