### PR TITLE
agent: wait for idempotent session metadata

### DIFF
--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -40,6 +40,11 @@ var (
 	ErrAgentInteractionNotFound          = errors.New("agent interaction is not found")
 )
 
+const (
+	agentSessionCreationWaitTimeout  = 5 * time.Second
+	agentSessionCreationPollInterval = 100 * time.Millisecond
+)
+
 type AgentProviderNotAvailableError struct {
 	Name string
 }
@@ -217,9 +222,13 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 			existing, err := m.sessionMetadata.Get(ctx, claimedSessionID)
 			if err != nil {
 				if errors.Is(err, indexeddb.ErrNotFound) {
-					return nil, ErrAgentSessionCreationInProgress
+					existing, err = m.waitForClaimedSessionMetadata(ctx, subjectID, providerName, idempotencyKey, claimedSessionID)
+					if err != nil {
+						return nil, err
+					}
+				} else {
+					return nil, err
 				}
-				return nil, err
 			}
 			if !sessionRefOwnedBy(existing, p) {
 				return nil, core.ErrNotFound
@@ -1394,6 +1403,37 @@ func (m *Manager) catalogSelectorConfig() invocation.CatalogSelectorConfig {
 		Invoker:           m.invoker,
 		CatalogConnection: m.catalogConnection,
 		DefaultConnection: m.defaultConnection,
+	}
+}
+
+func (m *Manager) waitForClaimedSessionMetadata(ctx context.Context, subjectID, providerName, idempotencyKey, sessionID string) (*coreagent.SessionReference, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, agentSessionCreationWaitTimeout)
+	defer cancel()
+	ticker := time.NewTicker(agentSessionCreationPollInterval)
+	defer ticker.Stop()
+	currentSessionID := strings.TrimSpace(sessionID)
+	for {
+		select {
+		case <-waitCtx.Done():
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return nil, ErrAgentSessionCreationInProgress
+		case <-ticker.C:
+			refreshedSessionID, err := m.sessionMetadata.SessionIDForIdempotency(ctx, subjectID, providerName, idempotencyKey)
+			if err == nil && strings.TrimSpace(refreshedSessionID) != "" {
+				currentSessionID = strings.TrimSpace(refreshedSessionID)
+			} else if err != nil && !errors.Is(err, indexeddb.ErrNotFound) {
+				return nil, err
+			}
+			existing, err := m.sessionMetadata.Get(ctx, currentSessionID)
+			if err == nil {
+				return existing, nil
+			}
+			if !errors.Is(err, indexeddb.ErrNotFound) {
+				return nil, err
+			}
+		}
 	}
 }
 

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -220,6 +220,126 @@ func TestCreateSessionPreservesExistingMetadataWhenReconcilingProviderSession(t 
 	}
 }
 
+func TestCreateSessionWaitsForClaimedIdempotentSessionMetadata(t *testing.T) {
+	t.Parallel()
+
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	subjectID := principal.UserSubjectID("user-1")
+	provider := &idempotentSessionProvider{
+		session: &coreagent.Session{
+			ID:        "provider-session-1",
+			State:     coreagent.SessionStateActive,
+			CreatedBy: coreagent.Actor{SubjectID: subjectID},
+		},
+	}
+	manager := New(Config{
+		Agent:           singleAgentControl{name: "simple", provider: provider},
+		SessionMetadata: services.AgentSessions,
+		RunMetadata:     services.AgentRunMetadata,
+	})
+	const idempotencyKey = "workflow:github:run-1:session"
+	claimedSessionID, claimed, err := services.AgentSessions.ClaimIdempotency(context.Background(), subjectID, "simple", idempotencyKey, "provider-session-1", time.Now())
+	if err != nil {
+		t.Fatalf("ClaimIdempotency: %v", err)
+	}
+	if !claimed || claimedSessionID != "provider-session-1" {
+		t.Fatalf("ClaimIdempotency = (%q, %t), want (provider-session-1, true)", claimedSessionID, claimed)
+	}
+	putErr := make(chan error, 1)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		_, err := services.AgentSessions.Put(context.Background(), &coreagent.SessionReference{
+			ID:             "provider-session-1",
+			ProviderName:   "simple",
+			SubjectID:      subjectID,
+			IdempotencyKey: idempotencyKey,
+		})
+		putErr <- err
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	session, err := manager.CreateSession(ctx, &principal.Principal{SubjectID: subjectID}, coreagent.ManagerCreateSessionRequest{
+		ProviderName:   "simple",
+		IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := <-putErr; err != nil {
+		t.Fatalf("AgentSessions.Put: %v", err)
+	}
+	if session.ID != "provider-session-1" {
+		t.Fatalf("CreateSession ID = %q, want provider-session-1", session.ID)
+	}
+	if len(provider.createRequests) != 0 {
+		t.Fatalf("provider CreateSession calls = %d, want 0", len(provider.createRequests))
+	}
+}
+
+func TestCreateSessionWaitsForReconciledIdempotentSessionMetadata(t *testing.T) {
+	t.Parallel()
+
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	subjectID := principal.UserSubjectID("user-1")
+	provider := &idempotentSessionProvider{
+		session: &coreagent.Session{
+			ID:        "provider-session-1",
+			State:     coreagent.SessionStateActive,
+			CreatedBy: coreagent.Actor{SubjectID: subjectID},
+		},
+	}
+	manager := New(Config{
+		Agent:           singleAgentControl{name: "simple", provider: provider},
+		SessionMetadata: services.AgentSessions,
+		RunMetadata:     services.AgentRunMetadata,
+	})
+	const idempotencyKey = "workflow:github:run-1:session"
+	claimedSessionID, claimed, err := services.AgentSessions.ClaimIdempotency(context.Background(), subjectID, "simple", idempotencyKey, "generated-session-1", time.Now())
+	if err != nil {
+		t.Fatalf("ClaimIdempotency: %v", err)
+	}
+	if !claimed || claimedSessionID != "generated-session-1" {
+		t.Fatalf("ClaimIdempotency = (%q, %t), want (generated-session-1, true)", claimedSessionID, claimed)
+	}
+	putErr := make(chan error, 1)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		_, err := services.AgentSessions.Put(context.Background(), &coreagent.SessionReference{
+			ID:             "provider-session-1",
+			ProviderName:   "simple",
+			SubjectID:      subjectID,
+			IdempotencyKey: idempotencyKey,
+		})
+		putErr <- err
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	session, err := manager.CreateSession(ctx, &principal.Principal{SubjectID: subjectID}, coreagent.ManagerCreateSessionRequest{
+		ProviderName:   "simple",
+		IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := <-putErr; err != nil {
+		t.Fatalf("AgentSessions.Put: %v", err)
+	}
+	if session.ID != "provider-session-1" {
+		t.Fatalf("CreateSession ID = %q, want provider-session-1", session.ID)
+	}
+	if len(provider.createRequests) != 0 {
+		t.Fatalf("provider CreateSession calls = %d, want 0", len(provider.createRequests))
+	}
+}
+
 func TestCreateSessionRejectsIdempotentProviderSessionForDifferentSubject(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/coredata/agent_session_metadata.go
+++ b/gestaltd/internal/coredata/agent_session_metadata.go
@@ -165,6 +165,21 @@ func (s *AgentSessionMetadataService) ReleaseIdempotency(ctx context.Context, su
 	return nil
 }
 
+func (s *AgentSessionMetadataService) SessionIDForIdempotency(ctx context.Context, subjectID, providerName, idempotencyKey string) (string, error) {
+	recordID := agentSessionIdempotencyRecordID(subjectID, providerName, idempotencyKey)
+	if recordID == "" {
+		return "", indexeddb.ErrNotFound
+	}
+	rec, err := s.idempotencyStore.Get(ctx, recordID)
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return "", indexeddb.ErrNotFound
+		}
+		return "", fmt.Errorf("get agent session idempotency: %w", err)
+	}
+	return recString(rec, "session_id"), nil
+}
+
 func (s *AgentSessionMetadataService) putIdempotencyRecord(ctx context.Context, ref *coreagent.SessionReference) error {
 	if s == nil || s.idempotencyStore == nil || ref == nil {
 		return nil


### PR DESCRIPTION
## Summary
- wait briefly when a CreateSession idempotency key is claimed but session metadata is not visible yet
- refresh the idempotency mapping while waiting so reconciled provider session IDs are handled
- expose a coredata helper for reading the session ID currently mapped to an agent session idempotency key

## Interface / Behavior
```go
session, err := manager.CreateSession(ctx, principal, coreagent.ManagerCreateSessionRequest{
    ProviderName:   "simple",
    IdempotencyKey: "workflow:github:<run-id>:session",
})
```

Before:
```text
concurrent GitHub webhook -> agent session creation is already in progress for this idempotency key -> 500
```

After:
```text
concurrent GitHub webhook -> poll idempotency mapping -> SessionReference{ID: "<provider-session>"} -> replay existing session
```

This covers both the normal path where the claim points at the final session ID and the reconciled path where #1444 moves the mapping from the generated request ID to the provider-returned session ID.

## Tests
- go test ./internal/agentmanager
- go test ./internal/bootstrap
- go test ./internal/coredata