### PR TITLE
agent: render display-projected CLI events

### DIFF
--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
-use serde::{Deserialize, de::DeserializeOwned};
+use serde::{Deserialize, Deserializer, de::DeserializeOwned};
 use serde_json::{Map, Value, json};
 use std::io::{self, BufRead, BufReader, IsTerminal, Write};
 use std::sync::{
@@ -247,6 +247,51 @@ struct AgentTurnEventInfo {
     visibility: String,
     #[serde(default)]
     data: Map<String, Value>,
+    #[serde(default, deserialize_with = "deserialize_turn_display")]
+    display: Option<AgentTurnDisplayInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentTurnDisplayInfo {
+    #[serde(default)]
+    kind: String,
+    #[serde(default)]
+    phase: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    label: String,
+    #[serde(default, rename = "ref")]
+    display_ref: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    parent_ref: String,
+    #[serde(default)]
+    input: Option<Value>,
+    #[serde(default)]
+    output: Option<Value>,
+    #[serde(default)]
+    error: Option<Value>,
+}
+
+impl AgentTurnDisplayInfo {
+    fn from_value(value: Value) -> Option<Self> {
+        let Value::Object(mut data) = value else {
+            return None;
+        };
+        Some(Self {
+            kind: take_string_field(&mut data, "kind"),
+            phase: take_string_field(&mut data, "phase"),
+            text: take_string_field(&mut data, "text"),
+            label: take_string_field(&mut data, "label"),
+            display_ref: take_string_field(&mut data, "ref"),
+            parent_ref: take_string_field(&mut data, "parentRef"),
+            input: data.remove("input"),
+            output: data.remove("output"),
+            error: data.remove("error"),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -477,6 +522,9 @@ impl AgentTurnRenderer {
             if event.seq > 0 {
                 self.after_seq = self.after_seq.max(event.seq as u64);
             }
+            if self.render_display_event(event)? {
+                continue;
+            }
             match event.event_type.as_str() {
                 "agent.message.delta" | "assistant.delta" => {
                     if let Some(text) = string_any_field(&event.data, &["text", "delta", "content"])
@@ -649,6 +697,198 @@ impl AgentTurnRenderer {
             println!();
             self.assistant_line_open = false;
         }
+    }
+
+    fn render_display_event(&mut self, event: &AgentTurnEventInfo) -> Result<bool> {
+        let Some(display) = turn_event_display(event) else {
+            return Ok(false);
+        };
+        match display.kind.trim() {
+            "text" => self.render_display_text(display, "assistant>"),
+            "reasoning" => self.render_display_text(display, "reasoning>"),
+            "tool" => self.render_display_tool(event, display),
+            "interaction" => Ok(self.render_display_interaction(event, display)),
+            "status" => Ok(self.render_display_status(display)),
+            "error" => Ok(self.render_display_error(display)),
+            _ => Ok(false),
+        }
+    }
+
+    fn render_display_text(&mut self, display: &AgentTurnDisplayInfo, label: &str) -> Result<bool> {
+        let text = display_text(display);
+        if label == "assistant>" {
+            match display.phase.trim() {
+                "delta" => {
+                    if let Some(text) = text {
+                        self.start_assistant_line()?;
+                        print!("{text}");
+                        io::stdout().flush().context("failed to flush stdout")?;
+                        self.saw_assistant_output = true;
+                        self.delta_buffer.push_str(text);
+                        return Ok(true);
+                    }
+                }
+                "completed" => {
+                    if self.assistant_line_open {
+                        let Some(text) = text else {
+                            return Ok(false);
+                        };
+                        if self.delta_buffer.is_empty() {
+                            print!("{text}");
+                        } else if let Some(suffix) = text.strip_prefix(&self.delta_buffer) {
+                            print!("{suffix}");
+                        }
+                        println!();
+                        self.assistant_line_open = false;
+                        self.delta_buffer.clear();
+                        return Ok(true);
+                    } else if let Some(text) = text {
+                        println!("{} {text}", self.label(label));
+                        self.saw_assistant_output = true;
+                        self.delta_buffer.clear();
+                        return Ok(true);
+                    }
+                }
+                _ if text.is_some() => {
+                    self.finish_assistant_line();
+                    let text = text.expect("checked is_some");
+                    println!("{} {text}", self.label(label));
+                    self.saw_assistant_output = true;
+                    return Ok(true);
+                }
+                _ => {}
+            }
+            return Ok(false);
+        }
+
+        self.finish_assistant_line();
+        if let Some(text) = text {
+            println!("{} {text}", self.label(label));
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn render_display_tool(
+        &mut self,
+        event: &AgentTurnEventInfo,
+        display: &AgentTurnDisplayInfo,
+    ) -> Result<bool> {
+        self.finish_assistant_line();
+        let tool = display_tool_label(event, display);
+        match display.phase.trim() {
+            "started" => {
+                print!("{} {tool} started", self.label("tool>"));
+                if let Some(input) = display_tool_input(event, display) {
+                    print!(" {}", compact_json(input)?);
+                }
+                println!();
+            }
+            "completed" => {
+                print!("{} {tool} completed", self.label("tool>"));
+                if let Some(status) = display_status(event, display) {
+                    print!(" ({status})");
+                }
+                if let Some(error) = display_tool_error(event, display) {
+                    print!(": {}", display_value_text(error)?);
+                } else if let Some(output) = display_tool_output(event, display) {
+                    print!(" {}", compact_json(output)?);
+                }
+                println!();
+            }
+            "failed" => {
+                print!("{} {tool} failed", self.label("tool>"));
+                if let Some(status) = display_status(event, display) {
+                    print!(" ({status})");
+                }
+                if let Some(error) = display_tool_error(event, display) {
+                    print!(": {}", display_value_text(error)?);
+                }
+                println!();
+            }
+            "progress" => {
+                if let Some(text) = display_text(display) {
+                    println!("{} {tool} {text}", self.label("tool>"));
+                } else {
+                    println!("{} {tool} progress", self.label("tool>"));
+                }
+            }
+            _ => return Ok(false),
+        }
+        Ok(true)
+    }
+
+    fn render_display_interaction(
+        &mut self,
+        _event: &AgentTurnEventInfo,
+        display: &AgentTurnDisplayInfo,
+    ) -> bool {
+        self.finish_assistant_line();
+        let interaction_ref = display_ref(display)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| "interaction".to_string());
+        match display.phase.trim() {
+            "requested" => println!(
+                "{} requested ({interaction_ref})",
+                self.label("interaction>")
+            ),
+            "resolved" => println!(
+                "{} resolved ({interaction_ref})",
+                self.label("interaction>")
+            ),
+            _ => return false,
+        }
+        true
+    }
+
+    fn render_display_status(&mut self, display: &AgentTurnDisplayInfo) -> bool {
+        self.finish_assistant_line();
+        let text = display_text(display);
+        match display.phase.trim() {
+            "started" => match text {
+                Some(text) => println!("{} started ({text})", self.label("turn>")),
+                None => println!("{} started", self.label("turn>")),
+            },
+            "canceled" => match text {
+                Some(text) => println!("{} canceled: {text}", self.label("turn>")),
+                None => println!("{} canceled", self.label("turn>")),
+            },
+            "completed" => {
+                if let Some(text) = text {
+                    println!("{} completed ({text})", self.label("turn>"));
+                }
+            }
+            "progress" => {
+                if let Some(text) = text {
+                    println!("{} {text}", self.label("turn>"));
+                }
+            }
+            _ => return false,
+        }
+        true
+    }
+
+    fn render_display_error(&mut self, display: &AgentTurnDisplayInfo) -> bool {
+        self.finish_assistant_line();
+        let label = if display_label(display) == Some("turn") {
+            "turn>"
+        } else {
+            "error>"
+        };
+        let text = display_text(display).map(ToString::to_string).or_else(|| {
+            display
+                .error
+                .as_ref()
+                .and_then(|value| display_value_text(value).ok())
+        });
+        let Some(text) = text else {
+            return false;
+        };
+        match display.phase.trim() {
+            "failed" => println!("{} failed: {text}", self.label(label)),
+            _ => println!("{} {text}", self.label(label)),
+        }
+        true
     }
 
     fn render_generic_event(&mut self, event: &AgentTurnEventInfo) -> Result<()> {
@@ -991,6 +1231,23 @@ where
     serde_json::from_value(value).context("failed to decode agent response")
 }
 
+fn deserialize_turn_display<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<AgentTurnDisplayInfo>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    Ok(value.and_then(AgentTurnDisplayInfo::from_value))
+}
+
+fn take_string_field(data: &mut Map<String, Value>, key: &str) -> String {
+    match data.remove(key) {
+        Some(Value::String(value)) => value,
+        _ => String::new(),
+    }
+}
+
 fn string_field(data: &Map<String, Value>, key: &str) -> Option<String> {
     data.get(key)
         .and_then(Value::as_str)
@@ -1007,6 +1264,103 @@ fn value_any_field<'a>(data: &'a Map<String, Value>, keys: &[&str]) -> Option<&'
 
 fn number_any_field(data: &Map<String, Value>, keys: &[&str]) -> Option<i64> {
     keys.iter().find_map(|key| data.get(*key)?.as_i64())
+}
+
+fn turn_event_display(event: &AgentTurnEventInfo) -> Option<&AgentTurnDisplayInfo> {
+    let display = event.display.as_ref()?;
+    if display.kind.trim().is_empty() {
+        return None;
+    }
+    if event.visibility == "private" && !known_turn_event_type(&event.event_type) {
+        return None;
+    }
+    Some(display)
+}
+
+fn known_turn_event_type(event_type: &str) -> bool {
+    matches!(
+        event_type,
+        "agent.message.delta"
+            | "assistant.delta"
+            | "assistant.completed"
+            | "turn.started"
+            | "turn.completed"
+            | "turn.failed"
+            | "turn.canceled"
+            | "tool.started"
+            | "tool.completed"
+            | "tool.failed"
+            | "interaction.requested"
+            | "interaction.resolved"
+    )
+}
+
+fn display_text(display: &AgentTurnDisplayInfo) -> Option<&str> {
+    if display.text.is_empty() {
+        None
+    } else {
+        Some(&display.text)
+    }
+}
+
+fn display_label(display: &AgentTurnDisplayInfo) -> Option<&str> {
+    non_empty_str(&display.label)
+}
+
+fn display_ref(display: &AgentTurnDisplayInfo) -> Option<&str> {
+    non_empty_str(&display.display_ref)
+}
+
+fn display_tool_label(_event: &AgentTurnEventInfo, display: &AgentTurnDisplayInfo) -> String {
+    display_label(display)
+        .or_else(|| display_ref(display))
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "tool".to_string())
+}
+
+fn display_tool_ref(_event: &AgentTurnEventInfo, display: &AgentTurnDisplayInfo) -> Option<String> {
+    display_ref(display).map(ToString::to_string)
+}
+
+fn display_tool_input<'a>(
+    _event: &'a AgentTurnEventInfo,
+    display: &'a AgentTurnDisplayInfo,
+) -> Option<&'a Value> {
+    display.input.as_ref()
+}
+
+fn display_tool_output<'a>(
+    _event: &'a AgentTurnEventInfo,
+    display: &'a AgentTurnDisplayInfo,
+) -> Option<&'a Value> {
+    display.output.as_ref()
+}
+
+fn display_tool_error<'a>(
+    _event: &'a AgentTurnEventInfo,
+    display: &'a AgentTurnDisplayInfo,
+) -> Option<&'a Value> {
+    display.error.as_ref()
+}
+
+fn display_status(_event: &AgentTurnEventInfo, display: &AgentTurnDisplayInfo) -> Option<String> {
+    display_text(display).map(ToString::to_string)
+}
+
+fn display_value_text(value: &Value) -> Result<String> {
+    match value {
+        Value::String(text) => Ok(text.clone()),
+        _ => compact_json(value),
+    }
+}
+
+fn non_empty_str(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
 }
 
 fn compact_json(value: &Value) -> Result<String> {

--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -521,7 +521,7 @@ impl TuiApp {
                 self.state.current_turn_id = Some(turn.id.clone());
                 self.state.status = turn_status_label(&turn);
             }
-            WorkerEvent::TurnEvent(event) => self.state.apply_turn_event(event),
+            WorkerEvent::TurnEvent(event) => self.state.apply_turn_event(*event),
             WorkerEvent::TurnSnapshot(turn) => self.state.finish_turn(&turn),
             WorkerEvent::WaitingForInput(interaction) => {
                 self.interaction_input = InteractionInput::for_interaction(&interaction);

--- a/gestalt/cli/src/commands/agents/tui/state.rs
+++ b/gestalt/cli/src/commands/agents/tui/state.rs
@@ -5,8 +5,11 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use super::super::{
-    AgentInteractionInfo, AgentSessionInfo, AgentTurnEventInfo, AgentTurnInfo, compact_json,
-    number_any_field, pretty_json, string_any_field, string_field, value_any_field,
+    AgentInteractionInfo, AgentSessionInfo, AgentTurnDisplayInfo, AgentTurnEventInfo,
+    AgentTurnInfo, compact_json, display_status, display_text, display_tool_error,
+    display_tool_input, display_tool_label, display_tool_output, display_tool_ref,
+    display_value_text, number_any_field, pretty_json, string_any_field, string_field,
+    turn_event_display, value_any_field,
 };
 
 const MAX_TRANSCRIPT_ITEMS: usize = 500;
@@ -72,6 +75,9 @@ impl AgentUiState {
     }
 
     pub(super) fn apply_turn_event(&mut self, event: AgentTurnEventInfo) {
+        if self.apply_display_turn_event(&event) {
+            return;
+        }
         match event.event_type.as_str() {
             "agent.message.delta" | "assistant.delta" => {
                 if let Some(text) = string_any_field(&event.data, &["text", "delta", "content"]) {
@@ -131,6 +137,132 @@ impl AgentUiState {
             "turn.completed" => {}
             _ if event.visibility == "private" => {}
             _ => self.push_system(generic_event_text(&event)),
+        }
+    }
+
+    fn apply_display_turn_event(&mut self, event: &AgentTurnEventInfo) -> bool {
+        let Some(display) = turn_event_display(event) else {
+            return false;
+        };
+        match display.kind.trim() {
+            "text" => {
+                match display.phase.trim() {
+                    "delta" => {
+                        if let Some(text) = display_text(display) {
+                            self.push_assistant_delta(text);
+                        } else {
+                            return false;
+                        }
+                    }
+                    "completed" => {
+                        if let Some(text) = display_text(display) {
+                            self.complete_assistant(text);
+                        } else {
+                            return false;
+                        }
+                    }
+                    _ => {
+                        if let Some(text) = display_text(display) {
+                            self.push_assistant(text.to_string());
+                        } else {
+                            return false;
+                        }
+                    }
+                }
+                true
+            }
+            "reasoning" => {
+                if let Some(text) = display_text(display) {
+                    self.push_system(format!("reasoning: {text}"));
+                } else {
+                    return false;
+                }
+                true
+            }
+            "tool" => {
+                match display.phase.trim() {
+                    "started" => {
+                        let activity = ToolActivity::started_display(event, display);
+                        let tool = activity.name.clone();
+                        self.push_tool_activity(activity);
+                        self.status = format!("{tool} running");
+                    }
+                    "progress" => {
+                        self.apply_tool_progress(event, display);
+                    }
+                    "completed" | "failed" => {
+                        let info = ToolTerminalEvent::from_display(event, display);
+                        self.finish_tool_activity(info);
+                    }
+                    _ => return false,
+                }
+                true
+            }
+            "interaction" => {
+                let id = if display.display_ref.trim().is_empty() {
+                    "interaction".to_string()
+                } else {
+                    display.display_ref.trim().to_string()
+                };
+                match display.phase.trim() {
+                    "requested" => {
+                        self.push_interaction(format!("requested {id}"));
+                        self.status = "waiting for input".to_string();
+                    }
+                    "resolved" => {
+                        self.push_interaction(format!("resolved {id}"));
+                        self.status = "interaction resolved".to_string();
+                    }
+                    _ => return false,
+                }
+                true
+            }
+            "status" => {
+                match display.phase.trim() {
+                    "started" => {
+                        self.status = display_text(display)
+                            .map(|status| format!("turn {status}"))
+                            .unwrap_or_else(|| "turn started".to_string());
+                    }
+                    "canceled" => {
+                        if let Some(reason) = display_text(display) {
+                            self.push_system(format!("turn canceled: {reason}"));
+                        } else {
+                            self.push_system("turn canceled");
+                        }
+                    }
+                    "progress" => {
+                        if let Some(text) = display_text(display) {
+                            self.status = text.to_string();
+                        }
+                    }
+                    "completed" => {
+                        self.status = display_text(display)
+                            .map(ToString::to_string)
+                            .unwrap_or_else(|| "completed".to_string());
+                    }
+                    _ => return false,
+                }
+                true
+            }
+            "error" => {
+                let text = display_text(display).map(ToString::to_string).or_else(|| {
+                    display
+                        .error
+                        .as_ref()
+                        .and_then(|value| display_value_text(value).ok())
+                });
+                let Some(text) = text else {
+                    return false;
+                };
+                if display.label.trim() == "turn" || display.phase.trim() == "failed" {
+                    self.push_error(format!("turn failed: {text}"));
+                } else {
+                    self.push_error(text.to_string());
+                }
+                true
+            }
+            _ => false,
         }
     }
 
@@ -241,6 +373,20 @@ impl AgentUiState {
             self.push_tool_activity(ToolActivity::terminal(terminal));
         }
         self.status = terminal_status.unwrap_or_else(|| format!("{tool} completed"));
+    }
+
+    fn apply_tool_progress(&mut self, event: &AgentTurnEventInfo, display: &AgentTurnDisplayInfo) {
+        let progress = ToolTerminalEvent::from_display_progress(event, display);
+        let tool = progress.name.clone();
+        if let Some(item) = self.find_running_tool_activity_mut(&progress) {
+            if let Some(activity) = item.tool_activity.as_mut() {
+                activity.update_progress(progress);
+                item.text = activity.render_text();
+            }
+        } else {
+            self.push_tool_activity(ToolActivity::progress(progress));
+        }
+        self.status = format!("{tool} running");
     }
 
     fn find_running_tool_activity_mut(
@@ -453,6 +599,32 @@ impl ToolActivity {
         }
     }
 
+    fn started_display(event: &AgentTurnEventInfo, display: &AgentTurnDisplayInfo) -> Self {
+        Self {
+            key: display_tool_ref(event, display),
+            name: display_tool_label(event, display),
+            status: ToolActivityStatus::Running,
+            started_at: Some(Instant::now()),
+            elapsed: None,
+            args: preview_display_value(display_tool_input(event, display)),
+            output: None,
+            error: None,
+        }
+    }
+
+    fn progress(progress: ToolTerminalEvent) -> Self {
+        Self {
+            key: progress.key.clone(),
+            name: progress.name.clone(),
+            status: ToolActivityStatus::Running,
+            started_at: Some(Instant::now()),
+            elapsed: None,
+            args: progress.args.clone(),
+            output: progress.output.clone(),
+            error: progress.error.clone(),
+        }
+    }
+
     fn terminal(terminal: ToolTerminalEvent) -> Self {
         let mut activity = Self {
             key: terminal.key.clone(),
@@ -476,6 +648,18 @@ impl ToolActivity {
         self.output = terminal.output;
         self.error = terminal.error;
         self.elapsed = self.started_at.map(|started_at| started_at.elapsed());
+    }
+
+    fn update_progress(&mut self, progress: ToolTerminalEvent) {
+        if self.args.is_none() {
+            self.args = progress.args;
+        }
+        if progress.output.is_some() {
+            self.output = progress.output;
+        }
+        if progress.error.is_some() {
+            self.error = progress.error;
+        }
     }
 
     fn end(&mut self, reason: &str) {
@@ -552,6 +736,35 @@ impl ToolTerminalEvent {
             output: preview_value(&event.data, &["output", "result", "body"]),
             error: string_any_field(&event.data, &["error", "message"])
                 .map(|value| truncate_preview(&value)),
+        }
+    }
+
+    fn from_display(event: &AgentTurnEventInfo, display: &AgentTurnDisplayInfo) -> Self {
+        let error = preview_display_error(display_tool_error(event, display));
+        let status = if display.phase.trim() == "failed" || error.is_some() {
+            ToolActivityStatus::Failed(display_status(event, display))
+        } else {
+            ToolActivityStatus::Completed(display_status(event, display))
+        };
+        Self {
+            key: display_tool_ref(event, display),
+            name: display_tool_label(event, display),
+            status,
+            args: preview_display_value(display_tool_input(event, display)),
+            output: preview_display_value(display_tool_output(event, display)),
+            error,
+        }
+    }
+
+    fn from_display_progress(event: &AgentTurnEventInfo, display: &AgentTurnDisplayInfo) -> Self {
+        Self {
+            key: display_tool_ref(event, display),
+            name: display_tool_label(event, display),
+            status: ToolActivityStatus::Running,
+            args: preview_display_value(display_tool_input(event, display)),
+            output: preview_display_value(display_tool_output(event, display))
+                .or_else(|| display_text(display).map(truncate_preview)),
+            error: preview_display_error(display_tool_error(event, display)),
         }
     }
 
@@ -632,6 +845,18 @@ fn tool_status(data: &serde_json::Map<String, Value>) -> Option<String> {
 fn preview_value(data: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
     value_any_field(data, keys)
         .and_then(|value| compact_json(value).ok())
+        .map(|value| truncate_preview(&value))
+}
+
+fn preview_display_value(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(|value| compact_json(value).ok())
+        .map(|value| truncate_preview(&value))
+}
+
+fn preview_display_error(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(|value| display_value_text(value).ok())
         .map(|value| truncate_preview(&value))
 }
 

--- a/gestalt/cli/src/commands/agents/tui/worker.rs
+++ b/gestalt/cli/src/commands/agents/tui/worker.rs
@@ -29,7 +29,7 @@ pub(super) enum WorkerCommand {
 
 pub(super) enum WorkerEvent {
     TurnCreated(AgentTurnInfo),
-    TurnEvent(AgentTurnEventInfo),
+    TurnEvent(Box<AgentTurnEventInfo>),
     TurnSnapshot(AgentTurnInfo),
     WaitingForInput(AgentInteractionInfo),
     InteractionResolved(AgentInteractionInfo),
@@ -74,7 +74,7 @@ fn run_turn_worker(
                 after_seq = after_seq.max(event.seq as u64);
             }
             event_tx
-                .send(WorkerEvent::TurnEvent(event))
+                .send(WorkerEvent::TurnEvent(Box::new(event)))
                 .context("terminal UI closed while streaming events")
         })?;
 

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -392,6 +392,99 @@ fn test_cli_runs_interactive_agent_session() {
         .stderr(predicate::str::contains("Type /quit to exit."));
 }
 
+#[test]
+fn test_cli_runs_interactive_agent_session_with_display_events() {
+    let mut server = Server::new();
+    let _session = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/sessions",
+        StatusCode::CREATED
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"provider":"managed","model":"gpt-5.4"}"#.to_string(),
+    ))
+    .with_body(SESSION_JSON)
+    .create();
+    let _turn = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/sessions/session-1/turns",
+        StatusCode::CREATED
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display events"}]}"#.to_string(),
+    ))
+    .with_body(TURN_JSON)
+    .create();
+    let _events = server
+        .mock(
+            Method::GET.as_str(),
+            "/api/v1/agent/turns/turn-1/events/stream?after=0&limit=100&until=blocked_or_terminal",
+        )
+        .match_header(header::AUTHORIZATION.as_str(), Matcher::Exact(test_bearer()))
+        .with_status(usize::from(StatusCode::OK.as_u16()))
+        .with_header(header::CONTENT_TYPE.as_str(), "text/event-stream")
+        .with_body(
+            "data: {\"seq\":1,\"type\":\"provider.tool\",\"visibility\":\"public\",\"display\":{\"kind\":\"tool\",\"phase\":\"started\",\"label\":\"lookup\",\"ref\":\"call-lookup\",\"input\":{\"ticket\":\"INC-42\"}}}\n\n\
+             data: {\"seq\":2,\"type\":\"provider.tool\",\"visibility\":\"public\",\"display\":{\"kind\":\"tool\",\"phase\":\"completed\",\"label\":\"lookup\",\"ref\":\"call-lookup\",\"text\":\"200\",\"output\":{\"ok\":true}}}\n\n\
+             data: {\"seq\":3,\"type\":\"provider.tool\",\"visibility\":\"public\",\"data\":{\"arguments\":{\"secret\":\"RAW_INPUT_SENTINEL\"}},\"display\":{\"kind\":\"tool\",\"phase\":\"started\",\"label\":\"redacted\",\"ref\":\"call-redacted\"}}\n\n\
+             data: {\"seq\":4,\"type\":\"provider.tool\",\"visibility\":\"public\",\"data\":{\"output\":{\"secret\":\"RAW_OUTPUT_SENTINEL\"}},\"display\":{\"kind\":\"tool\",\"phase\":\"completed\",\"label\":\"redacted\",\"ref\":\"call-redacted\",\"text\":\"done\"}}\n\n\
+             data: {\"seq\":5,\"type\":\"provider.text\",\"visibility\":\"public\",\"display\":{\"kind\":\"text\",\"phase\":\"delta\",\"text\":\"hello\"}}\n\n\
+             data: {\"seq\":6,\"type\":\"provider.text\",\"visibility\":\"public\",\"display\":{\"kind\":\"text\",\"phase\":\"delta\",\"text\":\"\\n  display\"}}\n\n\
+             data: {\"seq\":7,\"type\":\"assistant.completed\",\"visibility\":\"public\",\"data\":{\"text\":\"hello\\n  display\"},\"display\":{\"kind\":\"text\",\"phase\":\"completed\"}}\n\n\
+             data: {\"seq\":8,\"type\":\"assistant.completed\",\"visibility\":\"public\",\"data\":{\"text\":\"raw fallback\"},\"display\":{\"kind\":123,\"text\":42}}\n\n\
+             data: {\"seq\":9,\"type\":\"assistant.completed\",\"visibility\":\"public\",\"data\":{\"text\":\"missing display text fallback\"},\"display\":{\"kind\":\"text\",\"phase\":\"completed\"}}\n\n\
+             data: {\"seq\":10,\"type\":\"provider.status\",\"visibility\":\"public\",\"display\":{\"kind\":\"status\",\"phase\":\"completed\",\"text\":\"tools synced\"}}\n\n\
+             data: {\"seq\":11,\"type\":\"provider.secret\",\"visibility\":\"private\",\"display\":{\"kind\":\"error\",\"phase\":\"failed\",\"text\":\"hidden secret\"}}\n\n\
+             data: {\"seq\":12,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        )
+        .create();
+    let _get_turn = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/agent/turns/turn-1",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"{
+            "id":"turn-1",
+            "sessionId":"session-1",
+            "provider":"managed",
+            "model":"gpt-5.4",
+            "status":"succeeded",
+            "outputText":"hello\n  display"
+        }"#,
+    )
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
+        .write_stdin("display events\n/quit\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r#"tool> lookup started {"ticket":"INC-42"}"#,
+        ))
+        .stdout(predicate::str::contains(
+            r#"tool> lookup completed (200) {"ok":true}"#,
+        ))
+        .stdout(predicate::str::contains("tool> redacted started"))
+        .stdout(predicate::str::contains("tool> redacted completed (done)"))
+        .stdout(predicate::str::contains("assistant> hello\n  display"))
+        .stdout(predicate::str::contains("assistant> raw fallback"))
+        .stdout(predicate::str::contains(
+            "assistant> missing display text fallback",
+        ))
+        .stdout(predicate::str::contains("turn> completed (tools synced)"))
+        .stdout(predicate::str::contains("RAW_INPUT_SENTINEL").not())
+        .stdout(predicate::str::contains("RAW_OUTPUT_SENTINEL").not())
+        .stdout(predicate::str::contains("hidden secret").not());
+}
+
 #[cfg(unix)]
 #[test]
 fn test_cli_runs_tty_agent_session_with_full_screen_ui() {
@@ -457,6 +550,99 @@ fn test_cli_runs_tty_agent_session_with_full_screen_ui() {
     session.write("/quit\r");
     session.wait_for_exit();
 
+    server.assert_finished();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_tty_renders_display_tool_activity_rows() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions",
+            r#"{"provider":"managed","model":"gpt-5.4"}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            SESSION_JSON,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-1/turns",
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display tools"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-display-tools",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-display-tools/events/stream?after=0&limit=100&until=blocked_or_terminal",
+            StatusCode::OK,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"provider.tool\",\"visibility\":\"public\",\"data\":{\"arguments\":{\"secret\":\"RAW_TUI_INPUT\"}},\"display\":{\"kind\":\"tool\",\"phase\":\"started\",\"label\":\"search\",\"ref\":\"call-search\",\"input\":{\"query\":\"roadmap\"}}}\n\n\
+             data: {\"seq\":2,\"type\":\"provider.tool\",\"visibility\":\"public\",\"display\":{\"kind\":\"tool\",\"phase\":\"progress\",\"label\":\"search\",\"ref\":\"call-search\",\"text\":\"halfway\"}}\n\n\
+             data: {\"seq\":3,\"type\":\"provider.tool\",\"visibility\":\"public\",\"display\":{\"kind\":\"tool\",\"phase\":\"progress\",\"label\":\"search\",\"ref\":\"call-search\",\"text\":\"almost done\"}}\n\n\
+             data: {\"seq\":4,\"type\":\"provider.tool\",\"visibility\":\"public\",\"data\":{\"output\":{\"secret\":\"RAW_TUI_OUTPUT\"}},\"display\":{\"kind\":\"tool\",\"phase\":\"completed\",\"label\":\"search\",\"ref\":\"call-search\",\"text\":\"200\",\"output\":{\"matches\":1}}}\n\n\
+             data: {\"seq\":5,\"type\":\"provider.status\",\"visibility\":\"public\",\"display\":{\"kind\":\"status\",\"phase\":\"completed\",\"text\":\"sync complete\"}}\n\n\
+             data: {\"seq\":6,\"type\":\"provider.text\",\"visibility\":\"public\",\"display\":{\"kind\":\"text\",\"phase\":\"delta\",\"text\":\"tui\"}}\n\n\
+             data: {\"seq\":7,\"type\":\"assistant.completed\",\"visibility\":\"public\",\"data\":{\"text\":\"tui suffix\"},\"display\":{\"kind\":\"text\",\"phase\":\"completed\"}}\n\n\
+             data: {\"seq\":8,\"type\":\"provider.text\",\"visibility\":\"public\",\"display\":{\"kind\":\"text\",\"phase\":\"completed\",\"text\":\"display done\"}}\n\n\
+             data: {\"seq\":9,\"type\":\"assistant.completed\",\"visibility\":\"public\",\"data\":{\"text\":\"raw tui fallback\"},\"display\":{\"kind\":123,\"text\":42}}\n\n\
+             data: {\"seq\":10,\"type\":\"provider.secret\",\"visibility\":\"private\",\"display\":{\"kind\":\"text\",\"phase\":\"completed\",\"text\":\"hidden secret\"}}\n\n\
+             data: {\"seq\":11,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-display-tools",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-display-tools",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"succeeded",
+                "outputText":"display done"
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    let mut session = spawn_tty_cli(
+        home.path(),
+        server.url(),
+        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+    );
+    let mut output = String::new();
+    session.wait_for(&mut output, "Session");
+    session.write("display tools\r");
+    session.wait_for(&mut output, "search");
+    session.wait_for(&mut output, "completed");
+    session.wait_for(&mut output, "200");
+    session.wait_for(&mut output, "matches");
+    session.wait_for(&mut output, "suffix");
+    session.wait_for(&mut output, "done");
+    session.wait_for(&mut output, "fallback");
+    session.write("/quit\r");
+    session.wait_for_exit();
+
+    assert!(
+        !output.contains("hidden secret"),
+        "unknown private display event was rendered:\n{output}"
+    );
+    assert!(
+        !output.contains("RAW_TUI_INPUT") && !output.contains("RAW_TUI_OUTPUT"),
+        "display tool rendering leaked raw tool payload data:\n{output}"
+    );
+    assert!(
+        !output.contains("ended"),
+        "tool progress events left duplicate running tool rows:\n{output}"
+    );
     server.assert_finished();
 }
 


### PR DESCRIPTION
## Summary

This PR teaches the Rust agent CLI to consume the optional agent turn-event `display` projection. It is standalone: when `display` is absent, malformed, or unsupported, the existing raw `type`/`data` rendering remains the fallback.

## Rust interface

```rust
#[derive(Debug, Clone, Deserialize)]
#[serde(rename_all = "camelCase")]
struct AgentTurnEventInfo {
    #[serde(rename = "type")]
    event_type: String,
    #[serde(default)]
    visibility: String,
    #[serde(default)]
    data: Map<String, Value>,
    #[serde(default)]
    display: Option<AgentTurnDisplayInfo>,
}

#[derive(Debug, Clone, Deserialize)]
#[serde(rename_all = "camelCase")]
struct AgentTurnDisplayInfo {
    kind: String,
    phase: String,
    text: String,
    label: String,
    #[serde(rename = "ref")]
    display_ref: String,
    parent_ref: String,
    input: Option<Value>,
    output: Option<Value>,
    error: Option<Value>,
}
```

The non-TTY `AgentTurnRenderer` and full-screen `AgentUiState` both prefer `display` for `text`, `reasoning`, `tool`, `interaction`, `status`, and `error` events, then fall back to the previous raw event rendering. Unknown private events remain hidden even when they include `display`.

## stdin/stdout example

Input SSE frames:

```text
data: {"seq":1,"type":"provider.tool","visibility":"public","display":{"kind":"tool","phase":"started","label":"lookup","ref":"call-lookup","input":{"ticket":"INC-42"}}}

data: {"seq":2,"type":"provider.tool","visibility":"public","display":{"kind":"tool","phase":"completed","label":"lookup","text":"200","output":{"ok":true}}}

data: {"seq":3,"type":"provider.text","visibility":"public","display":{"kind":"text","phase":"completed","text":"hello display"}}}
```

Rendered non-TTY output:

```text
tool> lookup started {"ticket":"INC-42"}
tool> lookup completed (200) {"ok":true}
assistant> hello display
```

## Validation

```text
cargo test --test agents_cli
```

The added tests exercise the display projection over the fake HTTP/SSE transport for both stdin/stdout mode and the full-screen TUI path.