### PR TITLE
[codex] Fix integration disconnect selectors

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -30,7 +30,7 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/api/v1/integrations` | List plugins, connection state, authentication types, instances, icons, and connection parameter hints. |
-| `DELETE` | `/api/v1/integrations/{name}` | Disconnect a plugin. Use `?connection=...` and `?instance=...` to target one stored connection. |
+| `DELETE` | `/api/v1/integrations/{name}` | Disconnect a plugin. Use `?_connection=...` and `?_instance=...` to target one stored connection. Legacy `connection` and `instance` selectors are accepted for compatibility. |
 | `GET` | `/api/v1/integrations/{name}/operations` | List operations for one plugin. Supports `_connection` and `_instance` selectors. |
 | `GET` or `POST` | `/api/v1/{integration}/{operation}` | Invoke a plugin operation. Supports `_connection` and `_instance`. |
 

--- a/gestalt/cli/src/commands/plugins.rs
+++ b/gestalt/cli/src/commands/plugins.rs
@@ -84,8 +84,8 @@ pub fn disconnect(
     let normalized_connection = connection.map(|value| ConnectionName::new(value).canonical());
     let mut path = format!("/api/v1/integrations/{name}");
     let params: Vec<(&str, &str)> = [
-        ("connection", normalized_connection),
-        ("instance", instance),
+        ("_connection", normalized_connection),
+        ("_instance", instance),
     ]
     .into_iter()
     .filter_map(|(key, value)| value.map(|v| (key, v)))

--- a/gestalt/cli/tests/plugins_connect.rs
+++ b/gestalt/cli/tests/plugins_connect.rs
@@ -174,7 +174,7 @@ fn test_disconnect_sends_delete_with_connection_and_instance() {
     let mock = authed_json_mock!(
         server,
         Method::DELETE,
-        "/api/v1/integrations/widget_metrics?connection=oauth&instance=prod",
+        "/api/v1/integrations/widget_metrics?_connection=oauth&_instance=prod",
         StatusCode::OK
     )
     .with_body(r#"{"status":"disconnected"}"#)
@@ -198,7 +198,7 @@ fn test_disconnect_normalizes_plugin_connection_name() {
     let mock = authed_json_mock!(
         server,
         Method::DELETE,
-        "/api/v1/integrations/acme_crm?connection=_plugin",
+        "/api/v1/integrations/acme_crm?_connection=_plugin",
         StatusCode::OK
     )
     .with_body(r#"{"status":"disconnected"}"#)

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -256,15 +257,13 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	query := r.URL.Query()
-	for _, param := range []string{"instance", "connection"} {
-		if _, ok := query[param]; ok {
-			auditErr = errors.New("unsupported connection parameter")
-			writeError(w, http.StatusBadRequest, "use _connection and _instance query parameters")
-			return
-		}
-	}
 
-	requestedInstance := query.Get(httpInstanceParam)
+	requestedInstance, err := selectorQueryValue(query, httpInstanceParam, "instance")
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	if requestedInstance != "" {
 		var ok bool
 		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
@@ -273,7 +272,12 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	requestedConnection := query.Get(httpConnectionParam)
+	requestedConnection, err := selectorQueryValue(query, httpConnectionParam, "connection")
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	if requestedConnection != "" {
 		var ok bool
 		requestedConnection, ok = s.resolveRequestedConnection(w, name, requestedConnection)
@@ -362,6 +366,18 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 	auditAllowed = true
 	auditErr = nil
 	writeJSON(w, http.StatusOK, map[string]string{"status": "disconnected"})
+}
+
+func selectorQueryValue(query url.Values, canonical, legacy string) (string, error) {
+	canonicalValue := query.Get(canonical)
+	legacyValue := query.Get(legacy)
+	if canonicalValue != "" && legacyValue != "" && canonicalValue != legacyValue {
+		return "", fmt.Errorf("conflicting %s and %s query parameters", canonical, legacy)
+	}
+	if canonicalValue != "" {
+		return canonicalValue, nil
+	}
+	return legacyValue, nil
 }
 
 func (s *Server) getProvider(w http.ResponseWriter, name string) (core.Provider, bool) {
@@ -760,6 +776,16 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 	case errors.Is(err, apiexec.ErrMissingPathParam):
 		writeError(w, http.StatusBadRequest, err.Error())
 	case errors.As(err, &upstreamErr):
+		if upstreamErr.Status == http.StatusUnauthorized {
+			writeTypedError(
+				w,
+				http.StatusPreconditionFailed,
+				"reconnect_required",
+				providerName,
+				fmt.Sprintf("stored credential for integration %q was rejected by upstream; reconnect it", providerName),
+			)
+			return
+		}
 		writeOperationResult(w, &core.OperationResult{
 			Status:  upstreamErr.Status,
 			Headers: upstreamErr.Headers,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8590,7 +8590,7 @@ func TestDisconnectIntegration(t *testing.T) {
 		}
 	})
 
-	t.Run("plain parameters are rejected for disconnect", func(t *testing.T) {
+	t.Run("legacy plain parameters are accepted for disconnect", func(t *testing.T) {
 		t.Parallel()
 
 		svc := coretesting.NewStubServices(t)
@@ -8617,6 +8617,45 @@ func TestDisconnectIntegration(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+		tokens, err := svc.ExternalCredentials.ListCredentialsForProvider(context.Background(), principal.UserSubjectID(u.ID), "notion")
+		if err != nil {
+			t.Fatalf("ListCredentialsForProvider: %v", err)
+		}
+		if len(tokens) != 1 {
+			t.Fatalf("expected one token to remain after legacy disconnect, got %d", len(tokens))
+		}
+		if tokens[0].Connection != "default" || tokens[0].Instance != "default" {
+			t.Fatalf("unexpected remaining token %+v", tokens[0])
+		}
+	})
+
+	t.Run("conflicting canonical and legacy parameters are rejected for disconnect", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		u := seedUser(t, svc, "anonymous@gestalt")
+		seedToken(t, svc, &core.ExternalCredential{
+			ID: "tok-b", SubjectID: principal.UserSubjectID(u.ID), Integration: "notion",
+			Connection: "mcp", Instance: "MCP OAuth", AccessToken: "test-token",
+		})
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "notion", DN: "Notion"})
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/notion?_connection=default&connection=mcp", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
 		if resp.StatusCode != http.StatusBadRequest {
 			body, _ := io.ReadAll(resp.Body)
 			t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
@@ -8625,15 +8664,8 @@ func TestDisconnectIntegration(t *testing.T) {
 		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 			t.Fatalf("decoding: %v", err)
 		}
-		if !strings.Contains(result["error"], "_connection") || !strings.Contains(result["error"], "_instance") {
-			t.Fatalf("expected canonical parameter error, got %q", result["error"])
-		}
-		tokens, err := svc.ExternalCredentials.ListCredentialsForProvider(context.Background(), principal.UserSubjectID(u.ID), "notion")
-		if err != nil {
-			t.Fatalf("ListCredentialsForProvider: %v", err)
-		}
-		if len(tokens) != 2 {
-			t.Fatalf("expected both tokens to remain after rejected disconnect, got %d", len(tokens))
+		if !strings.Contains(result["error"], "_connection") || !strings.Contains(result["error"], "connection") {
+			t.Fatalf("expected conflict error, got %q", result["error"])
 		}
 	})
 
@@ -18729,6 +18761,59 @@ func TestUpstreamHTTPErrorPassthrough(t *testing.T) {
 	}
 	if errObj["message"] != "invalid parameter: limit" {
 		t.Fatalf("message = %v, want %q", errObj["message"], "invalid parameter: limit")
+	}
+}
+
+func TestExecuteOperation_UpstreamUnauthorizedRequiresReconnect(t *testing.T) {
+	t.Parallel()
+
+	fullStub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "test-int"},
+		ops: []core.Operation{
+			{Name: "do_thing", Description: "Do a thing", Method: http.MethodGet},
+		},
+	}
+	invoker := &testutil.StubInvoker{
+		Err: &apiexec.UpstreamHTTPError{
+			Status: http.StatusUnauthorized,
+			Body:   "",
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, fullStub)
+		cfg.Invoker = invoker
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/test-int/do_thing", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 412: %s", resp.StatusCode, body)
+	}
+
+	var errResp struct {
+		Error       string `json:"error"`
+		Code        string `json:"code"`
+		Integration string `json:"integration"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decoding error response: %v", err)
+	}
+	if errResp.Code != "reconnect_required" {
+		t.Fatalf("expected reconnect_required code, got %q", errResp.Code)
+	}
+	if errResp.Integration != "test-int" {
+		t.Fatalf("expected integration test-int, got %q", errResp.Integration)
+	}
+	if !strings.Contains(errResp.Error, "reconnect it") {
+		t.Fatalf("expected reconnect hint, got %q", errResp.Error)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the integration disconnect flow for the new Gestalt deployment by making the server accept both canonical selector query parameters and legacy client parameters.

## What changed

- Keep `_connection` and `_instance` as the canonical disconnect selectors.
- Allow legacy `connection` and `instance` selectors on disconnect so older deployed UI/CLI clients do not trap users with stale connections.
- Reject conflicting canonical and legacy selector values explicitly.
- Update the CLI disconnect command to send `_connection` and `_instance`.
- Convert upstream integration `401` responses into typed `reconnect_required` errors so the CLI points users at reconnecting the integration instead of `gestalt auth login`.
- Update HTTP API docs and tests for the selector contract.

## Root cause

The server had moved disconnect targeting to `_connection` / `_instance`, while the UI and CLI were still sending `connection` / `instance`. That prevented users from disconnecting stale PagerDuty credentials. Separately, upstream integration `401`s were passed through as bare HTTP 401s, which the CLI misreported as expired Gestalt CLI auth.

## Validation

- `go test ./internal/server`
- `cargo test --test plugins_connect --test invoke_contract`
- `git diff --check`