### PR TITLE
agent: preload exact refs during native search

### DIFF
--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -43,6 +43,7 @@ var (
 const (
 	agentSessionCreationWaitTimeout  = 5 * time.Second
 	agentSessionCreationPollInterval = 100 * time.Millisecond
+	agentToolSearchAllPlugin         = "*"
 )
 
 type AgentProviderNotAvailableError struct {
@@ -449,12 +450,12 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 		return nil, err
 	}
 	var tools []coreagent.Tool
-	nativeToolSearch, err := agentProviderSupportsNativeToolSearch(ctx, provider)
-	if err != nil {
+	if _, err := agentProviderSupportsNativeToolSearch(ctx, provider); err != nil {
 		return nil, err
 	}
-	if !nativeToolSearch && len(toolRefs) > 0 {
-		tools, err = m.resolveExactAgentToolRefs(ctx, p, toolRefs)
+	exactToolRefs := exactAgentToolRefs(toolRefs)
+	if len(exactToolRefs) > 0 {
+		tools, err = m.resolveExactAgentToolRefs(ctx, p, exactToolRefs)
 		if err != nil {
 			return nil, err
 		}
@@ -1253,6 +1254,10 @@ func newAgentToolSearchScope(refs []coreagent.ToolRef) agentToolSearchScope {
 		}
 		ref.Plugin = pluginName
 		ref.Operation = strings.TrimSpace(ref.Operation)
+		if ref.Plugin == agentToolSearchAllPlugin {
+			scope.all = true
+			continue
+		}
 		if ref.Operation == "" {
 			scope.plugins[pluginName] = ref
 			continue
@@ -1317,6 +1322,9 @@ func (m *Manager) authorizeToolRefs(ctx context.Context, p *principal.Principal,
 	for _, ref := range refs {
 		pluginName := strings.TrimSpace(ref.Plugin)
 		if pluginName == "" {
+			continue
+		}
+		if pluginName == agentToolSearchAllPlugin {
 			continue
 		}
 		if strings.TrimSpace(ref.Operation) != "" {
@@ -1693,9 +1701,31 @@ func normalizeToolRefs(refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
 		if ref.Plugin == "" {
 			return nil, fmt.Errorf("%w: agent tool_refs[%d].plugin is required", invocation.ErrProviderNotFound, idx)
 		}
+		if ref.Plugin == agentToolSearchAllPlugin {
+			if ref.Operation != "" || ref.Connection != "" || ref.Instance != "" || ref.Title != "" || ref.Description != "" || ref.CredentialMode != "" {
+				return nil, fmt.Errorf("%w: agent tool_refs[%d] global search ref cannot include operation, connection, instance, credential mode, title, or description", invocation.ErrProviderNotFound, idx)
+			}
+		}
 		out = append(out, ref)
 	}
 	return out, nil
+}
+
+func exactAgentToolRefs(refs []coreagent.ToolRef) []coreagent.ToolRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]coreagent.ToolRef, 0, len(refs))
+	for _, ref := range refs {
+		if strings.TrimSpace(ref.Plugin) == agentToolSearchAllPlugin {
+			continue
+		}
+		if strings.TrimSpace(ref.Operation) == "" {
+			continue
+		}
+		out = append(out, ref)
+	}
+	return out
 }
 
 func (m *Manager) applyCallerInvokeCredentialModes(callerPluginName string, refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -499,6 +499,54 @@ func TestSearchToolsOmitsHiddenOperationsUnlessExplicitlyScoped(t *testing.T) {
 	}
 }
 
+func TestSearchToolsGlobalWildcardKeepsSearchOpenWithExactRefs(t *testing.T) {
+	t.Parallel()
+
+	hidden := false
+	slack := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:      "events.reply",
+				Title:   "Reply to Event",
+				Visible: &hidden,
+			}}},
+		},
+	}
+	linear := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "linear",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:       "list_issues",
+				Title:    "List Linear Issues",
+				ReadOnly: true,
+			}}},
+		},
+	}
+	manager := New(Config{Providers: testutil.NewProviderRegistry(t, slack, linear)})
+
+	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query: "linear issues",
+		ToolRefs: []coreagent.ToolRef{
+			{Plugin: "*"},
+			{Plugin: "slack", Operation: "events.reply"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SearchTools: %v", err)
+	}
+	if len(resp.Tools) != 1 {
+		t.Fatalf("SearchTools returned %d tools, want 1", len(resp.Tools))
+	}
+	if resp.Tools[0].Target.Plugin != "linear" || resp.Tools[0].Target.Operation != "list_issues" {
+		t.Fatalf("tool target = %#v, want linear.list_issues", resp.Tools[0].Target)
+	}
+}
+
 func TestSearchToolsRejectsBlankToolRefPlugin(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -560,6 +560,9 @@ func validateAgentToolSearchResults(p *principal.Principal, refs []coreagent.Too
 func agentToolMatchesRefs(target coreagent.ToolTarget, refs []coreagent.ToolRef) bool {
 	targetConnection := config.ResolveConnectionAlias(strings.TrimSpace(target.Connection))
 	for _, ref := range refs {
+		if strings.TrimSpace(ref.Plugin) == "*" && strings.TrimSpace(ref.Operation) == "" {
+			return true
+		}
 		if strings.TrimSpace(ref.Plugin) != strings.TrimSpace(target.Plugin) {
 			continue
 		}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2430,8 +2430,8 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	if createTurnReq.CreatedBy.SubjectID != p.SubjectID {
 		t.Fatalf("CreateTurn created_by.subject_id = %q, want %q", createTurnReq.CreatedBy.SubjectID, p.SubjectID)
 	}
-	if len(createTurnReq.Tools) != 0 {
-		t.Fatalf("CreateTurn tools = %#v, want no preloaded tools", createTurnReq.Tools)
+	if len(createTurnReq.Tools) != 1 || createTurnReq.Tools[0].Target.Plugin != "roadmap" || createTurnReq.Tools[0].Target.Operation != "sync" {
+		t.Fatalf("CreateTurn tools = %#v, want preloaded roadmap.sync", createTurnReq.Tools)
 	}
 	if createTurnReq.ToolSource != coreagent.ToolSourceModeNativeSearch {
 		t.Fatalf("CreateTurn tool source = %q, want native search", createTurnReq.ToolSource)

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -3951,8 +3951,8 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 	if requireInteraction, _ := turnReq.Metadata["requireInteraction"].(bool); !requireInteraction {
 		t.Fatalf("CreateTurn metadata = %#v, want requireInteraction=true", turnReq.Metadata)
 	}
-	if len(turnReq.Tools) != 0 {
-		t.Fatalf("CreateTurn tools = %#v, want no preloaded tools", turnReq.Tools)
+	if len(turnReq.Tools) != 1 || turnReq.Tools[0].Target.Plugin != "roadmap" || turnReq.Tools[0].Target.Operation != "sync" {
+		t.Fatalf("CreateTurn tools = %#v, want preloaded roadmap.sync", turnReq.Tools)
 	}
 	if turnReq.ToolSource != coreagent.ToolSourceModeNativeSearch {
 		t.Fatalf("CreateTurn tool source = %q, want native search", turnReq.ToolSource)

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -506,8 +506,8 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 	if len(turnReq.Messages) != 1 || turnReq.Messages[0].Text != "Send the status summary" {
 		t.Fatalf("turn messages = %#v", turnReq.Messages)
 	}
-	if len(turnReq.Tools) != 0 {
-		t.Fatalf("turn tools = %#v, want no preloaded tools", turnReq.Tools)
+	if len(turnReq.Tools) != 1 || turnReq.Tools[0].Target.Plugin != "roadmap" || turnReq.Tools[0].Target.Operation != "sync" {
+		t.Fatalf("turn tools = %#v, want preloaded roadmap.sync", turnReq.Tools)
 	}
 	if turnReq.ToolSource != coreagent.ToolSourceModeNativeSearch {
 		t.Fatalf("turn tool source = %q, want native search", turnReq.ToolSource)


### PR DESCRIPTION
## Summary
- preload exact agent tool refs even when the provider uses native tool search
- add a `*` tool ref convention so callers can preload delivery tools without narrowing native search
- allow runtime tool-search validation to accept wildcard-scoped runs

## Tests
- `go test ./internal/agentmanager ./internal/bootstrap`