### PR TITLE
Use bearer auth for OAuth connection overrides

### DIFF
--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -209,6 +209,9 @@ func ReadIconFile(path string) (string, error) {
 // ApplyConnectionAuth merges connection auth overrides into the Definition.
 func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 	o := conn.Auth
+	if o.Type == providermanifestv1.AuthTypeOAuth2 && def.Auth.Type != string(providermanifestv1.AuthTypeOAuth2) {
+		clearManualAuthMaterialization(def)
+	}
 	setStr(&def.Auth.Type, string(o.Type))
 	setStr(&def.Auth.AuthorizationURL, o.AuthorizationURL)
 	setStr(&def.Auth.TokenURL, o.TokenURL)
@@ -243,6 +246,14 @@ func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 	if o.AuthMapping != nil {
 		def.AuthMapping = config.CloneAuthMapping(o.AuthMapping)
 	}
+}
+
+func clearManualAuthMaterialization(def *Definition) {
+	def.AuthStyle = ""
+	def.AuthHeader = ""
+	def.TokenPrefix = ""
+	def.AuthMapping = nil
+	def.CredentialFields = nil
 }
 
 func parseMappedToken(token string) (map[string]any, error) {

--- a/gestaltd/internal/provider/build_test.go
+++ b/gestaltd/internal/provider/build_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
 func testDefinition(name string) *Definition {
@@ -383,6 +384,63 @@ func TestBuildAuthHeader(t *testing.T) {
 	}
 	if resp["auth"] != "" {
 		t.Errorf("Authorization should be empty, got %v", resp["auth"])
+	}
+}
+
+func TestBuildOAuthConnectionOverrideClearsOpenAPIManualAuth(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"authorization": r.Header.Get("Authorization"),
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	def := &Definition{
+		Provider:    "oauth_override",
+		DisplayName: "OAuth Override API",
+		BaseURL:     srv.URL,
+		Auth:        AuthDef{Type: "manual"},
+		AuthStyle:   "raw",
+		AuthHeader:  "Authorization",
+		CredentialFields: []CredentialFieldDef{
+			{Name: "api_key", Label: "API Key"},
+		},
+		Operations: map[string]OperationDef{
+			"list": {Description: "List items", Method: http.MethodGet, Path: "/items"},
+		},
+	}
+
+	prov, err := Build(def, config.ConnectionDef{
+		Auth: config.ConnectionAuthDef{
+			Type:             providermanifestv1.AuthTypeOAuth2,
+			AuthorizationURL: "https://identity.example.com/oauth/authorize",
+			TokenURL:         "https://identity.example.com/oauth/token",
+			ClientID:         "client-id",
+			ClientSecret:     "client-secret",
+			RedirectURL:      "https://gestalt.example.com/api/v1/auth/callback",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	result, err := prov.Execute(context.Background(), "list", nil, "oauth-access-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if resp["authorization"] != "Bearer oauth-access-token" {
+		t.Errorf("Authorization = %v, want Bearer oauth-access-token", resp["authorization"])
+	}
+	if fields := prov.CredentialFields(); len(fields) != 0 {
+		t.Fatalf("CredentialFields len = %d, want 0: %+v", len(fields), fields)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Clear OpenAPI-derived manual auth materialization when a connection explicitly overrides the provider to OAuth2.
- This makes OAuth-backed declarative providers send `Authorization: Bearer <access-token>` instead of reusing stale API-key/raw header injection from the OpenAPI spec.
- Add a regression test matching the PagerDuty shape: OpenAPI declares `Authorization` API key auth, deployment config supplies OAuth2 connection auth.

## Validation
- `go test ./internal/provider`
- `go test ./internal/openapi`
- `go test ./internal/bootstrap`
- `go test ./internal/server`
- `git diff --check`