### PR TITLE
agent: preserve resolved user tool search scope

### DIFF
--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -510,7 +510,7 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 		SubjectID:           subjectID,
 		CredentialSubjectID: strings.TrimSpace(principal.EffectiveCredentialSubjectID(p)),
 		IdempotencyKey:      idempotencyKey,
-		Permissions:         principal.PermissionsToAccessPermissions(p.TokenPermissions),
+		Permissions:         agentRunPermissions(ctx, p, req.CallerPluginName, toolRefs),
 		ToolRefs:            append([]coreagent.ToolRef(nil), toolRefs...),
 		ToolSource:          toolSource,
 		Tools:               tools,
@@ -1676,6 +1676,35 @@ func validateToolSource(source coreagent.ToolSourceMode) (coreagent.ToolSourceMo
 		return "", fmt.Errorf("unsupported agent tool source %q", source)
 	}
 	return source, nil
+}
+
+func agentRunPermissions(ctx context.Context, p *principal.Principal, callerPluginName string, refs []coreagent.ToolRef) []core.AccessPermission {
+	p = principal.Canonicalized(p)
+	if p == nil {
+		return nil
+	}
+	if shouldUseResolvedUserToolScope(ctx, p, callerPluginName, refs) {
+		return nil
+	}
+	return principal.PermissionsToAccessPermissions(p.TokenPermissions)
+}
+
+func shouldUseResolvedUserToolScope(ctx context.Context, p *principal.Principal, callerPluginName string, refs []coreagent.ToolRef) bool {
+	if strings.TrimSpace(callerPluginName) == "" {
+		return false
+	}
+	if invocation.InvocationSurfaceFromContext(ctx) != invocation.InvocationSurfaceHTTP {
+		return false
+	}
+	if p == nil || p.Kind != principal.KindUser || p.Source == principal.SourceAPIToken {
+		return false
+	}
+	for _, ref := range refs {
+		if strings.TrimSpace(ref.Plugin) == agentToolSearchAllPlugin && strings.TrimSpace(ref.Operation) == "" {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeToolSource(source coreagent.ToolSourceMode) coreagent.ToolSourceMode {

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -547,6 +547,101 @@ func TestSearchToolsGlobalWildcardKeepsSearchOpenWithExactRefs(t *testing.T) {
 	}
 }
 
+func TestSearchToolsGlobalWildcardFindsProviderQualifiedCatalogOperation(t *testing.T) {
+	t.Parallel()
+
+	hidden := false
+	slack := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:      "events.reply",
+				Title:   "Reply to Event",
+				Visible: &hidden,
+			}}},
+		},
+	}
+	linear := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "linear",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				DisplayName: "Linear",
+				Operations: []catalog.CatalogOperation{{
+					ID:          "issues",
+					Description: "All issues. Returns a paginated list of issues visible to the authenticated user.",
+					ReadOnly:    true,
+				}},
+			},
+		},
+	}
+	manager := New(Config{Providers: testutil.NewProviderRegistry(t, slack, linear)})
+
+	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query: "Linear list issues assigned to me",
+		ToolRefs: []coreagent.ToolRef{
+			{Plugin: "*"},
+			{Plugin: "slack", Operation: "events.reply"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SearchTools: %v", err)
+	}
+	if len(resp.Tools) != 1 {
+		t.Fatalf("SearchTools returned %d tools, want 1", len(resp.Tools))
+	}
+	if resp.Tools[0].Target.Plugin != "linear" || resp.Tools[0].Target.Operation != "issues" {
+		t.Fatalf("tool target = %#v, want linear.issues", resp.Tools[0].Target)
+	}
+}
+
+func TestAgentRunPermissionsKeepsAPITokenRestrictionsForHTTPWildcard(t *testing.T) {
+	t.Parallel()
+
+	perms := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "linear",
+		Operations: []string{"issues"},
+	}})
+	p := &principal.Principal{
+		SubjectID:        principal.UserSubjectID("user-1"),
+		UserID:           "user-1",
+		Kind:             principal.KindUser,
+		Source:           principal.SourceAPIToken,
+		TokenPermissions: perms,
+		Scopes:           principal.PermissionPlugins(perms),
+	}
+	ctx := invocation.WithInvocationSurface(context.Background(), invocation.InvocationSurfaceHTTP)
+
+	got := agentRunPermissions(ctx, p, "slack", []coreagent.ToolRef{{Plugin: "*"}})
+	if len(got) != 1 || got[0].Plugin != "linear" || len(got[0].Operations) != 1 || got[0].Operations[0] != "issues" {
+		t.Fatalf("agentRunPermissions = %#v, want API token permissions preserved", got)
+	}
+}
+
+func TestAgentRunPermissionsClearsHTTPResolvedUserWildcardRestrictions(t *testing.T) {
+	t.Parallel()
+
+	perms := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "slack",
+		Operations: []string{"events.reply"},
+	}})
+	p := &principal.Principal{
+		SubjectID:        principal.UserSubjectID("user-1"),
+		UserID:           "user-1",
+		Kind:             principal.KindUser,
+		TokenPermissions: perms,
+		Scopes:           principal.PermissionPlugins(perms),
+	}
+	ctx := invocation.WithInvocationSurface(context.Background(), invocation.InvocationSurfaceHTTP)
+
+	if got := agentRunPermissions(ctx, p, "slack", []coreagent.ToolRef{{Plugin: "*"}}); got != nil {
+		t.Fatalf("agentRunPermissions = %#v, want nil permissions for resolved user wildcard search", got)
+	}
+}
+
 func TestSearchToolsRejectsBlankToolRefPlugin(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -148,6 +148,13 @@ func (r *agentRuntime) TrackTurn(ctx context.Context, providerName string, req c
 		}
 		return fmt.Errorf("%w: agent execution principal is required", invocation.ErrInternal)
 	}
+	var existingRef *coreagent.ExecutionReference
+	existing, err := runMetadata.Get(ctx, turnID)
+	if err == nil {
+		existingRef = existing
+	} else if !errors.Is(err, indexeddb.ErrNotFound) {
+		return fmt.Errorf("%w: agent turn %q metadata lookup failed: %v", invocation.ErrInternal, turnID, err)
+	}
 	principalValue := principal.Canonicalized(principal.FromContext(ctx))
 	var permissions []core.AccessPermission
 	if principalValue != nil {
@@ -156,13 +163,16 @@ func (r *agentRuntime) TrackTurn(ctx context.Context, providerName string, req c
 	if permissions == nil && len(req.Tools) > 0 {
 		permissions = permissionsForAgentTools(req.Tools)
 	}
+	if existingRef != nil {
+		permissions = append([]core.AccessPermission(nil), existingRef.Permissions...)
+	}
 	startedAt := time.Now()
 	attrs := []attribute.KeyValue{
 		observability.AttrAgentProvider.String(strings.TrimSpace(providerName)),
 		observability.AttrAgentOperation.String("track_turn"),
 	}
 	metadataCtx, span := observability.StartSpan(ctx, "agent.run_metadata.write", attrs...)
-	_, err := runMetadata.Put(metadataCtx, &coreagent.ExecutionReference{
+	_, err = runMetadata.Put(metadataCtx, &coreagent.ExecutionReference{
 		ID:                  turnID,
 		SessionID:           strings.TrimSpace(req.SessionID),
 		ProviderName:        strings.TrimSpace(providerName),

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2758,6 +2758,128 @@ func TestBootstrapAgentHostToolSearchPrioritizesNamedPluginIssueTools(t *testing
 	}
 }
 
+func TestBootstrapHTTPCallerWildcardSearchUsesResolvedUserToolScope(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.Agent = map[string]*config.ProviderEntry{
+		"managed": {
+			Source:  config.ProviderSource{Path: "stub"},
+			Default: true,
+		},
+	}
+
+	factories := validFactories()
+	factories.Builtins = append(factories.Builtins, &coretesting.StubIntegration{
+		N:        "linear",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name:        "linear",
+			DisplayName: "Linear",
+			Description: "Manage issues, projects, and teams.",
+			Operations: []catalog.CatalogOperation{{
+				ID:          "issues",
+				Method:      http.MethodGet,
+				Description: "All issues visible to the authenticated user. Can be filtered by assignee.",
+				ReadOnly:    true,
+			}},
+		},
+		ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+			body, err := json.Marshal(map[string]any{
+				"provider":  "linear",
+				"operation": operation,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+		},
+	})
+
+	var provider *callbackAgentProvider
+	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, hostServices []providerhost.HostService, _ bootstrap.Deps) (coreagent.Provider, error) {
+		started, err := providerhost.StartHostServices(hostServices)
+		if err != nil {
+			return nil, err
+		}
+		value, err := newCallbackAgentProvider(started)
+		if err != nil {
+			_ = started.Close()
+			return nil, err
+		}
+		value.searchQuery = "Linear list issues assigned to me"
+		provider = value
+		return value, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	slackOnly := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin: "slack",
+		Operations: []string{
+			"events.reply",
+			"events.setStatus",
+		},
+	}})
+	p := &principal.Principal{
+		SubjectID:        "user:user-123",
+		UserID:           "user-123",
+		Kind:             principal.KindUser,
+		TokenPermissions: slackOnly,
+		Scopes:           principal.PermissionPlugins(slackOnly),
+	}
+	ctx := invocation.WithInvocationSurface(principal.WithPrincipal(context.Background(), p), invocation.InvocationSurfaceHTTP)
+
+	session, err := result.AgentManager.CreateSession(ctx, p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "managed",
+		Model:        "gpt-test",
+		ClientRef:    "cli-session-http-slack-search",
+	})
+	if err != nil {
+		t.Fatalf("AgentManager.CreateSession: %v", err)
+	}
+	turn, err := result.AgentManager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
+		CallerPluginName: "slack",
+		SessionID:        session.ID,
+		IdempotencyKey:   "http-slack-linear-search",
+		Model:            "gpt-test",
+		Messages:         []coreagent.Message{{Role: "user", Text: "get my linear tickets"}},
+		ToolRefs:         []coreagent.ToolRef{{Plugin: "*"}},
+	})
+	if err != nil {
+		t.Fatalf("AgentManager.CreateTurn: %v", err)
+	}
+	if turn == nil {
+		t.Fatal("AgentManager.CreateTurn returned nil turn")
+	}
+
+	ref, err := result.Services.AgentRunMetadata.Get(context.Background(), turn.ID)
+	if err != nil {
+		t.Fatalf("AgentRunMetadata.Get: %v", err)
+	}
+
+	provider.mu.Lock()
+	toolBodies := append([]string(nil), provider.toolBodies...)
+	provider.mu.Unlock()
+	if len(toolBodies) != 1 || !strings.Contains(toolBodies[0], `"provider":"linear"`) || !strings.Contains(toolBodies[0], `"operation":"issues"`) {
+		t.Fatalf("tool callback bodies = %#v, ref permissions = %#v, ref tools = %#v, want searched linear.issues", toolBodies, ref.Permissions, ref.Tools)
+	}
+	if ref.Permissions != nil {
+		t.Fatalf("stored permissions = %#v, want unrestricted resolved user scope", ref.Permissions)
+	}
+	if len(ref.ToolRefs) != 1 || ref.ToolRefs[0].Plugin != "*" {
+		t.Fatalf("stored tool refs = %#v, want global search ref", ref.ToolRefs)
+	}
+	if len(ref.Tools) == 0 || ref.Tools[0].Target.Plugin != "linear" || ref.Tools[0].Target.Operation != "issues" {
+		t.Fatalf("stored searched tools = %#v, want linear.issues", ref.Tools)
+	}
+}
+
 func TestBootstrapAgentProviderSupportsDirectTurnInteractionLifecycle(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- do not persist caller-plugin invoke permissions as the agent run scope when an HTTP webhook resolved a user and requested global native tool search
- preserve existing manager-written execution-reference permissions when the agent tracking wrapper records the turn
- add regressions for Slack-scoped webhook turns discovering Linear and for API token restrictions staying scoped

## Tests
- `go test ./internal/agentmanager -count=1`
- `go test ./internal/bootstrap -count=1`