### PR TITLE
Add Vercel deploy page

### DIFF
--- a/docs/content/deploy/_meta.ts
+++ b/docs/content/deploy/_meta.ts
@@ -1,4 +1,5 @@
 export default {
   docker: "Docker",
   helm: "Helm",
+  vercel: "Vercel",
 };

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -66,7 +66,12 @@ See [Configuration](/configuration) for the config model and [Docker](/deploy/do
 
 ## Deployment guides
 
-See [Docker](/deploy/docker) for Docker and Docker Compose, or [Helm](/deploy/helm) for Kubernetes with the published Helm chart.
+Choose the deployment guide that matches your target:
+
+- [Docker](/deploy/docker) for Docker and Docker Compose.
+- [Helm](/deploy/helm) for Kubernetes with the published Helm chart.
+- [Vercel](/deploy/vercel) for static frontend deployment guidance and why the
+  `gestaltd` server itself should run elsewhere.
 
 Gestalt runs on any container platform that supports a Docker image on port `8080` with environment variables. Use the [Docker](/deploy/docker) guide as the base for any of these:
 

--- a/docs/content/deploy/vercel.mdx
+++ b/docs/content/deploy/vercel.mdx
@@ -1,0 +1,78 @@
+import { Callout } from 'nextra/components'
+
+# Vercel
+
+Use Vercel for static documentation, custom frontends, or other web apps that
+talk to a `gestaltd` server running somewhere else. Vercel is not a deployment
+target for the `gestaltd` server itself.
+
+<Callout type="warning">
+  Vercel does not support deploying Docker images directly. `gestaltd` is a
+  long-running server process with a config file, encrypted state, prepared
+  provider artifacts, health endpoints, and a datastore. Deploy it with
+  [Docker](/deploy/docker), [Helm](/deploy/helm), or another container platform,
+  then point Vercel-hosted web apps at that server.
+</Callout>
+
+## Recommended topology
+
+1. Deploy `gestaltd` on container-capable infrastructure such as Kubernetes,
+   Google Cloud Run, Fly.io, Render, Railway, AWS ECS, or another platform that
+   can run the published Docker image.
+2. Set `server.baseUrl` in the Gestalt config to the public HTTPS origin of that
+   server, for example `https://gestalt.example.com`.
+3. Deploy the static frontend or documentation site to Vercel.
+4. Configure the frontend with the Gestalt server URL expected by that app.
+   Keep OAuth callback routes, MCP routes, and API routes on the real Gestalt
+   server unless one transparent reverse-proxy layer owns every route for the
+   public origin.
+
+## Deploying the documentation site
+
+The repository's `docs/` app is a static Next.js export, so it can be deployed
+to Vercel as a frontend-only project.
+
+| Setting | Value |
+| --- | --- |
+| Root Directory | `docs` |
+| Framework Preset | `Next.js` |
+| Install Command | Auto-detected, or override to `npm ci` |
+| Build Command | Auto-detected from `package.json` as `npm run build` |
+| Output Directory | Auto-detected for Next.js. The local static export is `out`. |
+
+If you run the Vercel CLI from the repository root, pass the docs directory as
+the project root:
+
+```sh
+vercel --cwd docs
+vercel --cwd docs --prod
+```
+
+`vercel` creates a Preview Deployment. `vercel --prod` creates a Production
+Deployment for the project's configured production domains.
+
+To check the static export locally before deploying:
+
+```sh
+cd docs
+npm ci
+npm run build
+```
+
+## Environment variables
+
+Set frontend configuration in Vercel Project Settings under Environment
+Variables. Values apply only to new deployments, so redeploy after changing
+them.
+
+Only put browser-safe values in variables that your frontend exposes to the
+client, such as Next.js `NEXT_PUBLIC_*` values. Keep Gestalt secrets such as
+`server.encryptionKey`, database URLs, and provider credentials in the
+`gestaltd` deployment environment, not in the Vercel frontend project.
+
+## References
+
+- [Vercel: Docker deployments](https://vercel.com/guides/does-vercel-support-docker-deployments)
+- [Vercel: Configure a build](https://vercel.com/docs/builds/configure-a-build)
+- [Vercel: Environment variables](https://vercel.com/docs/environment-variables)
+- [Vercel CLI: deploy](https://vercel.com/docs/cli/deploy)


### PR DESCRIPTION
## Summary
- Add a new Vercel deploy page that positions Vercel for static frontend and docs hosting, not for `gestaltd` itself
- Link the page into the deploy nav and update the deploy overview to include it
- Document the recommended split topology, docs-site Vercel settings, and environment variable handling

## Testing
- Not run (not requested)