### PR TITLE
Expand agent tool search across credential instances

### DIFF
--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -1105,6 +1105,11 @@ type agentToolSearchCandidate struct {
 	skipUnavailable bool
 }
 
+type agentToolSearchCatalog struct {
+	ref     coreagent.ToolRef
+	catalog *catalog.Catalog
+}
+
 func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef, query string, skipUnavailable bool) ([]agentToolSearchCandidate, error) {
 	scope := newAgentToolSearchScope(refs)
 	providerNames := scope.providerNames()
@@ -1138,7 +1143,7 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 			continue
 		}
 		for _, searchRef := range scope.refsForProvider(pluginName) {
-			cat, err := m.catalogForAgentToolSearch(ctx, p, prov, pluginName, searchRef)
+			searchCatalogs, err := m.catalogsForAgentToolSearch(ctx, p, prov, pluginName, searchRef)
 			if err != nil {
 				refSkipsUnavailable := skipUnavailable && agentToolSearchRefSkipsUnavailable(searchRef)
 				if refSkipsUnavailable && agentToolSearchUnavailable(err) {
@@ -1149,37 +1154,40 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 				}
 				return nil, err
 			}
-			if cat == nil {
-				continue
-			}
-			for i := range cat.Operations {
-				op := cat.Operations[i]
-				operation := strings.TrimSpace(op.ID)
-				if operation == "" || !agentToolSearchRefAllows(searchRef, operation) {
+			for _, searchCatalog := range searchCatalogs {
+				cat := searchCatalog.catalog
+				if cat == nil {
 					continue
 				}
-				if strings.TrimSpace(searchRef.Operation) == "" && !catalog.OperationVisibleByDefault(op) {
-					continue
+				for i := range cat.Operations {
+					op := cat.Operations[i]
+					operation := strings.TrimSpace(op.ID)
+					if operation == "" || !agentToolSearchRefAllows(searchRef, operation) {
+						continue
+					}
+					if strings.TrimSpace(searchRef.Operation) == "" && !catalog.OperationVisibleByDefault(op) {
+						continue
+					}
+					if !m.allowOperation(ctx, p, pluginName, operation) || !principal.AllowsOperationPermission(p, pluginName, operation) {
+						continue
+					}
+					if m.authorizer != nil && !m.authorizer.AllowCatalogOperation(ctx, p, pluginName, op) {
+						continue
+					}
+					ref := searchCatalog.ref
+					if strings.TrimSpace(ref.Operation) == "" {
+						ref.Title = ""
+						ref.Description = ""
+					}
+					ref.Plugin = pluginName
+					ref.Operation = operation
+					candidates = append(candidates, agentToolSearchCandidate{
+						ref:             ref,
+						catalog:         cat,
+						operation:       op,
+						skipUnavailable: skipUnavailable && agentToolSearchRefSkipsUnavailable(searchRef),
+					})
 				}
-				if !m.allowOperation(ctx, p, pluginName, operation) || !principal.AllowsOperationPermission(p, pluginName, operation) {
-					continue
-				}
-				if m.authorizer != nil && !m.authorizer.AllowCatalogOperation(ctx, p, pluginName, op) {
-					continue
-				}
-				ref := searchRef
-				if strings.TrimSpace(ref.Operation) == "" {
-					ref.Title = ""
-					ref.Description = ""
-				}
-				ref.Plugin = pluginName
-				ref.Operation = operation
-				candidates = append(candidates, agentToolSearchCandidate{
-					ref:             ref,
-					catalog:         cat,
-					operation:       op,
-					skipUnavailable: skipUnavailable && agentToolSearchRefSkipsUnavailable(searchRef),
-				})
 			}
 		}
 	}
@@ -1201,7 +1209,7 @@ func agentToolSearchRefSkipsUnavailable(ref coreagent.ToolRef) bool {
 	return strings.TrimSpace(ref.Operation) == ""
 }
 
-func (m *Manager) catalogForAgentToolSearch(ctx context.Context, p *principal.Principal, prov core.Provider, pluginName string, ref coreagent.ToolRef) (*catalog.Catalog, error) {
+func (m *Manager) catalogsForAgentToolSearch(ctx context.Context, p *principal.Principal, prov core.Provider, pluginName string, ref coreagent.ToolRef) ([]agentToolSearchCatalog, error) {
 	connection := strings.TrimSpace(ref.Connection)
 	if connection != "" && !config.SafeConnectionValue(connection) {
 		return nil, fmt.Errorf("connection name contains invalid characters")
@@ -1225,16 +1233,94 @@ func (m *Manager) catalogForAgentToolSearch(ctx context.Context, p *principal.Pr
 		resolver = tr
 	}
 	catalogCtx := invocation.WithAccessContext(ctx, m.providerAccessContext(ctx, p, pluginName))
-	cat, _, err := invocation.ResolveCatalogForTargetsWithMetadata(
-		catalogCtx,
-		prov,
-		pluginName,
-		resolver,
-		p,
-		m.catalogSelectorConfig().SessionCatalogTargets(pluginName, connection, instance),
-		core.SupportsSessionCatalog(prov) || connection != "" || instance != "",
-	)
-	return cat, err
+	targets := m.catalogSelectorConfig().SessionCatalogTargets(pluginName, connection, instance)
+	if !shouldExpandAgentToolSearchCatalogTargets(ref, credentialMode) {
+		cat, _, err := invocation.ResolveCatalogForTargetsWithMetadata(
+			catalogCtx,
+			prov,
+			pluginName,
+			resolver,
+			p,
+			targets,
+			core.SupportsSessionCatalog(prov) || connection != "" || instance != "",
+		)
+		if err != nil || cat == nil {
+			return nil, err
+		}
+		return []agentToolSearchCatalog{{ref: ref, catalog: cat}}, nil
+	}
+
+	expander, ok := m.invoker.(invocation.CatalogTargetExpander)
+	if !ok {
+		cat, _, err := invocation.ResolveCatalogForTargetsWithMetadata(
+			catalogCtx,
+			prov,
+			pluginName,
+			resolver,
+			p,
+			targets,
+			core.SupportsSessionCatalog(prov) || connection != "" || instance != "",
+		)
+		if err != nil || cat == nil {
+			return nil, err
+		}
+		return []agentToolSearchCatalog{{ref: ref, catalog: cat}}, nil
+	}
+	targets, err = expander.ExpandCatalogTargets(catalogCtx, p, pluginName, targets)
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
+		targets = []invocation.CatalogResolutionTarget{{}}
+	}
+
+	out := make([]agentToolSearchCatalog, 0, len(targets))
+	var firstErr error
+	for _, target := range targets {
+		target.Connection = strings.TrimSpace(target.Connection)
+		target.Instance = strings.TrimSpace(target.Instance)
+		if target.Connection != "" && !config.SafeConnectionValue(target.Connection) {
+			return nil, fmt.Errorf("connection name contains invalid characters")
+		}
+		if target.Instance != "" && !config.SafeInstanceValue(target.Instance) {
+			return nil, fmt.Errorf("instance name contains invalid characters")
+		}
+		cat, _, err := invocation.ResolveCatalogForTargetsWithMetadata(
+			catalogCtx,
+			prov,
+			pluginName,
+			resolver,
+			p,
+			[]invocation.CatalogResolutionTarget{target},
+			core.SupportsSessionCatalog(prov) || target.Connection != "" || target.Instance != "",
+		)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if cat == nil {
+			continue
+		}
+		targetRef := ref
+		targetRef.Connection = target.Connection
+		targetRef.Instance = target.Instance
+		out = append(out, agentToolSearchCatalog{
+			ref:     targetRef,
+			catalog: cat,
+		})
+	}
+	if len(out) == 0 {
+		return nil, firstErr
+	}
+	return out, nil
+}
+
+func shouldExpandAgentToolSearchCatalogTargets(ref coreagent.ToolRef, credentialMode core.ConnectionMode) bool {
+	return strings.TrimSpace(ref.Operation) == "" &&
+		strings.TrimSpace(ref.Instance) == "" &&
+		credentialMode != core.ConnectionModeNone
 }
 
 type agentToolSearchScope struct {

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -709,6 +709,75 @@ func TestSearchToolsDiscoversSessionCatalogOperations(t *testing.T) {
 	}
 }
 
+func TestSearchToolsExpandsAmbiguousCredentialInstances(t *testing.T) {
+	t.Parallel()
+
+	provider := &sessionCatalogProvider{
+		catalogCountingProvider: catalogCountingProvider{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "github",
+				ConnMode: core.ConnectionModeUser,
+			},
+		},
+		sessionCatalog: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+			ID:       "list_pull_requests",
+			Title:    "List Pull Requests",
+			ReadOnly: true,
+		}}},
+	}
+	providers := testutil.NewProviderRegistry(t, provider)
+	services := coretesting.NewStubServices(t)
+	subjectID := principal.UserSubjectID("user-1")
+	for _, instance := range []string{"z", "sa"} {
+		if err := services.ExternalCredentials.PutCredential(context.Background(), &core.ExternalCredential{
+			SubjectID:   subjectID,
+			Integration: "github",
+			Connection:  "default",
+			Instance:    instance,
+			AccessToken: "token-" + instance,
+		}); err != nil {
+			t.Fatalf("PutCredential(%s): %v", instance, err)
+		}
+	}
+	broker := invocation.NewBroker(providers, services.Users, services.ExternalCredentials)
+	manager := New(Config{
+		Providers: providers,
+		Invoker:   broker,
+		DefaultConnection: map[string]string{
+			"github": "default",
+		},
+	})
+
+	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: subjectID,
+	}, coreagent.SearchToolsRequest{
+		Query:    "github pull requests",
+		ToolRefs: []coreagent.ToolRef{{Plugin: "*"}},
+	})
+	if err != nil {
+		t.Fatalf("SearchTools: %v", err)
+	}
+	if len(resp.Tools) != 2 {
+		t.Fatalf("SearchTools returned %d tools, want 2: %#v", len(resp.Tools), resp.Tools)
+	}
+	instances := map[string]bool{}
+	for _, tool := range resp.Tools {
+		if tool.Target.Plugin != "github" || tool.Target.Operation != "list_pull_requests" {
+			t.Fatalf("tool target = %#v, want github.list_pull_requests", tool.Target)
+		}
+		if tool.Target.Connection != "default" {
+			t.Fatalf("tool connection = %q, want default", tool.Target.Connection)
+		}
+		instances[tool.Target.Instance] = true
+		if tool.ID == "github/list_pull_requests" {
+			t.Fatalf("tool ID %q is missing credential binding", tool.ID)
+		}
+	}
+	if !instances["z"] || !instances["sa"] {
+		t.Fatalf("tool instances = %#v, want z and sa", instances)
+	}
+}
+
 func TestSearchToolsSkipsUnavailablePluginScopedProviders(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -530,6 +531,92 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 		return ctx, "", fmt.Errorf("%w: looking up provider: %v", ErrInternal, err)
 	}
 	return b.resolveToken(ctx, prov, p, providerName, connection, instance)
+}
+
+func (b *Broker) ExpandCatalogTargets(ctx context.Context, p *principal.Principal, providerName string, targets []CatalogResolutionTarget) ([]CatalogResolutionTarget, error) {
+	if len(targets) == 0 {
+		targets = []CatalogResolutionTarget{{}}
+	}
+	if !principal.AllowsProviderPermission(p, providerName) {
+		return nil, fmt.Errorf("%w: %s", ErrScopeDenied, providerName)
+	}
+	if err := b.resolveUserPrincipal(ctx, p); err != nil {
+		return nil, err
+	}
+	ctx = withResolvedPrincipal(ctx, p)
+	if b.authorizer != nil && !b.authorizer.AllowProvider(ctx, p, providerName) {
+		return nil, fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
+	}
+	prov, err := b.providers.Get(providerName)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return nil, fmt.Errorf("%w: %q", ErrProviderNotFound, providerName)
+		}
+		return nil, fmt.Errorf("%w: looking up provider: %v", ErrInternal, err)
+	}
+	if effectiveConnectionMode(ctx, prov) != core.ConnectionModeUser {
+		return targets, nil
+	}
+	if b == nil || coredata.ExternalCredentialProviderMissing(b.externalCreds) {
+		return nil, fmt.Errorf("%w: external credentials provider is not configured", ErrInternal)
+	}
+	subjectID := principal.EffectiveCredentialSubjectID(p)
+	if subjectID == "" {
+		return nil, fmt.Errorf("%w: principal has no subject ID or email", ErrUserResolution)
+	}
+
+	expanded := make([]CatalogResolutionTarget, 0, len(targets))
+	seen := make(map[CatalogResolutionTarget]struct{}, len(targets))
+	for _, target := range targets {
+		target.Connection = strings.TrimSpace(target.Connection)
+		target.Instance = strings.TrimSpace(target.Instance)
+		if target.Instance != "" {
+			if _, ok := seen[target]; !ok {
+				seen[target] = struct{}{}
+				expanded = append(expanded, target)
+			}
+			continue
+		}
+
+		credentials, listErr := b.externalCreds.ListCredentialsForConnection(ctx, subjectID, providerName, target.Connection)
+		if listErr != nil {
+			return nil, fmt.Errorf("%w: listing external credentials: %v", ErrInternal, listErr)
+		}
+		if len(credentials) == 0 {
+			if _, ok := seen[target]; !ok {
+				seen[target] = struct{}{}
+				expanded = append(expanded, target)
+			}
+			continue
+		}
+		nonNil := credentials[:0]
+		for _, credential := range credentials {
+			if credential != nil {
+				nonNil = append(nonNil, credential)
+			}
+		}
+		sort.Slice(nonNil, func(i, j int) bool {
+			if nonNil[i].Connection != nonNil[j].Connection {
+				return nonNil[i].Connection < nonNil[j].Connection
+			}
+			return nonNil[i].Instance < nonNil[j].Instance
+		})
+		for _, credential := range nonNil {
+			resolved := CatalogResolutionTarget{
+				Connection: strings.TrimSpace(credential.Connection),
+				Instance:   strings.TrimSpace(credential.Instance),
+			}
+			if resolved.Connection == "" {
+				resolved.Connection = target.Connection
+			}
+			if _, ok := seen[resolved]; ok {
+				continue
+			}
+			seen[resolved] = struct{}{}
+			expanded = append(expanded, resolved)
+		}
+	}
+	return expanded, nil
 }
 
 func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -21,6 +21,10 @@ type TokenResolver interface {
 	ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error)
 }
 
+type CatalogTargetExpander interface {
+	ExpandCatalogTargets(ctx context.Context, p *principal.Principal, providerName string, targets []CatalogResolutionTarget) ([]CatalogResolutionTarget, error)
+}
+
 type requestStaticOperationResolver interface {
 	ResolveStaticOperationForRequest(ctx context.Context, operation string) (catalog.CatalogOperation, bool)
 }


### PR DESCRIPTION
## Summary
- expand native agent tool search targets across all matching user credential instances for plugin-only/wildcard refs
- bind discovered tools to the resolved connection/instance so later tool resolution is not ambiguous
- add regression coverage for wildcard GitHub search with two credential instances

## Tests
- go test ./internal/agentmanager ./internal/invocation (from gestaltd/)
- go test ./cmd/gestaltd -run TestE2EDefaultServeAutoGeneratesLocalConfig -count=1 -v (from gestaltd/)

## Notes
- go test ./... (from gestaltd/) passed affected packages but hit existing cmd/gestaltd e2e flakiness around hosted plugin readiness/socket startup when run as a full suite.