### PR TITLE
[codex] Fix pagination aliases

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -2518,7 +2518,14 @@ func applyProviderPagination(def *provider.Definition, manifestPlugin *providerm
 		if pgn == nil {
 			continue
 		}
-		op := def.Operations[opName]
+		exposedName := opName
+		if override.Alias != "" {
+			exposedName = override.Alias
+		}
+		op, ok := def.Operations[exposedName]
+		if !ok {
+			continue
+		}
 		op.Pagination = &provider.PaginationDef{
 			Style:        string(pgn.Style),
 			CursorParam:  pgn.CursorParam,
@@ -2528,7 +2535,7 @@ func applyProviderPagination(def *provider.Definition, manifestPlugin *providerm
 			ResultsPath:  pgn.ResultsPath,
 			MaxPages:     pgn.MaxPages,
 		}
-		def.Operations[opName] = op
+		def.Operations[exposedName] = op
 	}
 }
 

--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -1,0 +1,69 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/provider"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestApplyProviderPaginationUsesExposedAlias(t *testing.T) {
+	t.Parallel()
+
+	def := &provider.Definition{
+		Operations: map[string]provider.OperationDef{
+			"listNotes": {
+				Method: "GET",
+				Path:   "/v1/notes",
+			},
+			"getNote": {
+				Method: "GET",
+				Path:   "/v1/notes/{note_id}",
+			},
+		},
+	}
+	manifestPlugin := &providermanifestv1.Spec{
+		Pagination: &providermanifestv1.ManifestPaginationConfig{
+			Style:        providermanifestv1.PaginationStyleCursor,
+			CursorParam:  "cursor",
+			LimitParam:   "page_size",
+			DefaultLimit: 10,
+			ResultsPath:  "notes",
+		},
+	}
+	allowedOperations := map[string]*config.OperationOverride{
+		"list_notes": {
+			Alias:    "listNotes",
+			Paginate: true,
+		},
+		"mcp_only": {
+			Paginate: true,
+		},
+	}
+
+	applyProviderPagination(def, manifestPlugin, allowedOperations)
+
+	listOp := def.Operations["listNotes"]
+	if listOp.Pagination == nil {
+		t.Fatal("listNotes pagination = nil, want pagination on exposed alias")
+	}
+	if listOp.Pagination.CursorParam != "cursor" {
+		t.Fatalf("CursorParam = %q, want cursor", listOp.Pagination.CursorParam)
+	}
+	if listOp.Pagination.LimitParam != "page_size" {
+		t.Fatalf("LimitParam = %q, want page_size", listOp.Pagination.LimitParam)
+	}
+	if listOp.Pagination.DefaultLimit != 10 {
+		t.Fatalf("DefaultLimit = %d, want 10", listOp.Pagination.DefaultLimit)
+	}
+	if listOp.Pagination.ResultsPath != "notes" {
+		t.Fatalf("ResultsPath = %q, want notes", listOp.Pagination.ResultsPath)
+	}
+	if _, ok := def.Operations["list_notes"]; ok {
+		t.Fatal("applyProviderPagination created original list_notes operation; want only exposed alias")
+	}
+	if _, ok := def.Operations["mcp_only"]; ok {
+		t.Fatal("applyProviderPagination created absent mcp_only operation")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes pagination setup for spec-loaded operations whose `allowedOperations` entry uses an alias. Pagination is now attached to the exposed operation name, and absent operations are skipped instead of creating an empty placeholder operation.

## Root Cause

`applyProviderPagination` iterated allowed operation keys from the original OpenAPI operation IDs. When an operation had both `alias` and `paginate: true`, it wrote the pagination metadata back under the original ID after OpenAPI loading had already renamed the operation to the alias. That created a phantom operation with no method/path, which made calls like `granola.list_notes` appear in the catalog but fail at runtime.

## Validation

- `go test ./internal/bootstrap -run TestApplyProviderPaginationUsesExposedAlias -count=1`
- `go test ./internal/bootstrap -count=1`
- `go test ./internal/openapi ./internal/invocation ./internal/composite ./core/integration -count=1`
- `git diff --check`