### PR TITLE
Dispatch public host services without socket-path relay tokens

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -1483,7 +1483,8 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 
 	bin := buildAgentProviderBinary(t)
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
 	relaySrv.EnableHTTP2 = true
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)
@@ -1520,9 +1521,10 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 	runtimeState := &agentRuntime{providers: map[string]coreagent.Provider{}}
 	runtimeState.SetRunMetadata(services.AgentRunMetadata)
 	deps := Deps{
-		BaseURL:       relaySrv.URL,
-		EncryptionKey: secret,
-		AgentRuntime:  runtimeState,
+		BaseURL:            relaySrv.URL,
+		EncryptionKey:      secret,
+		AgentRuntime:       runtimeState,
+		PublicHostServices: publicHostServices,
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -158,6 +158,7 @@ type Deps struct {
 	PluginInvoker         invocation.Invoker
 	PluginRuntime         pluginruntime.Provider
 	PluginRuntimeRegistry *pluginRuntimeRegistry
+	PublicHostServices    *providerhost.PublicHostServiceRegistry
 	Telemetry             core.TelemetryProvider
 }
 
@@ -222,6 +223,7 @@ type Result struct {
 	Telemetry             core.TelemetryProvider
 	PluginRuntimes        RuntimeInspector
 	ProviderDevSessions   *providerdev.Manager
+	PublicHostServices    *providerhost.PublicHostServiceRegistry
 
 	pluginRuntimeRegistry *pluginRuntimeRegistry
 	auditClose            func(context.Context) error
@@ -951,9 +953,11 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	pluginInvoker := newLazyInvoker()
 	workflowManager := newLazyWorkflowManager()
 	agentManager := newLazyAgentManager()
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
 	prepared.Deps.PluginInvoker = pluginInvoker
 	prepared.Deps.WorkflowManager = workflowManager
 	prepared.Deps.AgentManager = agentManager
+	prepared.Deps.PublicHostServices = publicHostServices
 	prepared.Deps.WorkflowRuntime.SetAgentManager(agentManager)
 
 	providers, providersReady, connAuthResolver, err := buildProviders(ctx, cfg, factories, prepared.Deps)
@@ -1097,6 +1101,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Telemetry:             prepared.Telemetry,
 		PluginRuntimes:        prepared.pluginRuntimeRegistry,
 		ProviderDevSessions:   providerDevSessions,
+		PublicHostServices:    publicHostServices,
 		pluginRuntimeRegistry: prepared.pluginRuntimeRegistry,
 		auditClose:            auditClose,
 	}, nil

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -53,7 +52,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -350,6 +348,7 @@ type capturingBundlePluginRuntime struct {
 	mu                  sync.Mutex
 	bindRequests        []pluginruntime.BindHostServiceRequest
 	startPluginRequests []pluginruntime.StartPluginRequest
+	sessionLifecycles   map[string]*pluginruntime.SessionLifecycle
 	fakePlugins         map[string]*fakeHostedPluginServer
 }
 
@@ -379,15 +378,32 @@ func (r *capturingBundlePluginRuntime) Support(context.Context) (pluginruntime.S
 }
 
 func (r *capturingBundlePluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
-	return r.provider.StartSession(ctx, req)
+	session, err := r.provider.StartSession(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	r.attachSessionLifecycle(session)
+	return session, nil
 }
 
 func (r *capturingBundlePluginRuntime) ListSessions(ctx context.Context) ([]pluginruntime.Session, error) {
-	return r.provider.ListSessions(ctx)
+	sessions, err := r.provider.ListSessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range sessions {
+		r.attachSessionLifecycle(&sessions[i])
+	}
+	return sessions, nil
 }
 
 func (r *capturingBundlePluginRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
-	return r.provider.GetSession(ctx, req)
+	session, err := r.provider.GetSession(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	r.attachSessionLifecycle(session)
+	return session, nil
 }
 
 func (r *capturingBundlePluginRuntime) StopSession(ctx context.Context, req pluginruntime.StopSessionRequest) error {
@@ -1303,6 +1319,25 @@ func (r *capturingBundlePluginRuntime) bindHostServiceRequests() []pluginruntime
 		out[i] = cloneBindHostServiceRequest(req)
 	}
 	return out
+}
+
+func (r *capturingBundlePluginRuntime) setSessionLifecycle(sessionID string, lifecycle *pluginruntime.SessionLifecycle) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.sessionLifecycles == nil {
+		r.sessionLifecycles = make(map[string]*pluginruntime.SessionLifecycle)
+	}
+	r.sessionLifecycles[sessionID] = clonePluginRuntimeSessionLifecycle(lifecycle)
+}
+
+func (r *capturingBundlePluginRuntime) attachSessionLifecycle(session *pluginruntime.Session) {
+	if session == nil || session.ID == "" {
+		return
+	}
+	r.mu.Lock()
+	lifecycle := clonePluginRuntimeSessionLifecycle(r.sessionLifecycles[session.ID])
+	r.mu.Unlock()
+	session.Lifecycle = lifecycle
 }
 
 func cloneRuntimeMetadata(values map[string]string) map[string]string {
@@ -3767,7 +3802,8 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 	t.Parallel()
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
 	relaySrv.EnableHTTP2 = true
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)
@@ -3865,11 +3901,12 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 	}
 
 	deps := Deps{
-		BaseURL:       relaySrv.URL,
-		EncryptionKey: secret,
-		Services:      services,
-		AgentRuntime:  agentRuntime,
-		AgentManager:  manager,
+		BaseURL:            relaySrv.URL,
+		EncryptionKey:      secret,
+		Services:           services,
+		AgentRuntime:       agentRuntime,
+		AgentManager:       manager,
+		PublicHostServices: publicHostServices,
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 
@@ -5906,11 +5943,19 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 func TestProviderDevRuntimeEnvUsesPublicHostServiceRelay(t *testing.T) {
 	t.Parallel()
 
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
+	relaySrv.EnableHTTP2 = true
+	relaySrv.StartTLS()
+	testutil.CloseOnCleanup(t, relaySrv)
+
 	env, err := buildProviderDevRuntimeEnv("echoext", &config.ProviderEntry{
 		S3: []string{"main"},
 	}, Deps{
-		BaseURL:       "https://gestalt.example.test",
-		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		BaseURL:            relaySrv.URL,
+		EncryptionKey:      secret,
+		PublicHostServices: publicHostServices,
 		S3: map[string]s3store.Client{
 			"main": &coretesting.StubS3{},
 		},
@@ -5918,24 +5963,40 @@ func TestProviderDevRuntimeEnvUsesPublicHostServiceRelay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildProviderDevRuntimeEnv: %v", err)
 	}
+	cleanup := env.Cleanup
 	t.Cleanup(func() {
-		if env.Cleanup != nil {
-			env.Cleanup()
+		if cleanup != nil {
+			cleanup()
 		}
 	})
 
 	for _, binding := range []string{"", "main"} {
 		socketEnv := providerhost.S3SocketEnv(binding)
-		if got := env.Env[socketEnv]; got != "tls://gestalt.example.test:443" {
-			t.Fatalf("runtime env %s = %q, want %q", socketEnv, got, "tls://gestalt.example.test:443")
+		if got := env.Env[socketEnv]; !strings.HasPrefix(got, "tls://") {
+			t.Fatalf("runtime env %s = %q, want tls relay target", socketEnv, got)
 		}
 		tokenEnv := providerhost.S3SocketTokenEnv(binding)
 		if got := env.Env[tokenEnv]; got == "" {
 			t.Fatalf("runtime env %s is empty, want relay token", tokenEnv)
 		}
 	}
-	if !slices.Contains(env.AllowedHosts, "gestalt.example.test") {
-		t.Fatalf("allowed hosts = %#v, want gestalt.example.test", env.AllowedHosts)
+	if !slices.Contains(env.AllowedHosts, "127.0.0.1") {
+		t.Fatalf("allowed hosts = %#v, want relay server host", env.AllowedHosts)
+	}
+
+	record, err := fakeHostedS3RoundTrip("assets", "plans/q3.txt", "ship-it", "main", env.Env)
+	if err != nil {
+		t.Fatalf("S3 round trip via provider-dev relay: %v", err)
+	}
+	if got := record["body"]; got != "ship-it" {
+		t.Fatalf("S3 body = %#v, want ship-it", got)
+	}
+	if cleanup != nil {
+		cleanup()
+		cleanup = nil
+	}
+	if _, err := fakeHostedS3RoundTrip("assets", "plans/stale.txt", "stale", "main", env.Env); err == nil {
+		t.Fatalf("S3 round trip after provider-dev cleanup succeeded, want stale relay failure")
 	}
 }
 
@@ -6209,7 +6270,8 @@ func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testi
 	t.Parallel()
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
 	relaySrv.EnableHTTP2 = true
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)
@@ -6275,6 +6337,7 @@ func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testi
 		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) {
 			return boundDB, nil
 		},
+		PublicHostServices: publicHostServices,
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 
@@ -6327,6 +6390,19 @@ func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testi
 	}
 	if got := bindRequests[0].Relay.DialTarget; !strings.HasPrefix(got, "tls://") {
 		t.Fatalf("BindHostService relay target = %q, want tls relay target", got)
+	}
+
+	expiredAt := time.Now().Add(-time.Minute)
+	runtimeProvider.setSessionLifecycle(startRequests[0].SessionID, &pluginruntime.SessionLifecycle{
+		ExpiresAt: &expiredAt,
+	})
+	_, err = prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
+		"store": "tasks",
+		"id":    "task-2",
+		"value": "expired-session",
+	}, "")
+	if err == nil || !strings.Contains(err.Error(), "invalid-host-service-relay-session") {
+		t.Fatalf("Execute indexeddb_roundtrip after runtime expiry error = %v, want relay session rejection", err)
 	}
 }
 
@@ -6454,7 +6530,8 @@ func TestPluginRuntimePublicCacheRelayRoundTripsThroughHostedPlugin(t *testing.T
 	t.Parallel()
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
 	relaySrv.EnableHTTP2 = true
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)
@@ -6515,6 +6592,7 @@ func TestPluginRuntimePublicCacheRelayRoundTripsThroughHostedPlugin(t *testing.T
 		CacheFactory: func(yaml.Node) (corecache.Cache, error) {
 			return boundCache, nil
 		},
+		PublicHostServices: publicHostServices,
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 
@@ -6581,7 +6659,8 @@ func TestPluginRuntimePublicS3RelayRoundTripsThroughHostedPlugin(t *testing.T) {
 	t.Parallel()
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
 	relaySrv.EnableHTTP2 = true
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)
@@ -6640,6 +6719,7 @@ func TestPluginRuntimePublicS3RelayRoundTripsThroughHostedPlugin(t *testing.T) {
 		S3: map[string]s3store.Client{
 			"main": boundS3,
 		},
+		PublicHostServices: publicHostServices,
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 
@@ -6725,7 +6805,8 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	t.Parallel()
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
 	relaySrv.EnableHTTP2 = true
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)
@@ -6799,9 +6880,10 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	}
 
 	deps := Deps{
-		BaseURL:       relaySrv.URL,
-		EncryptionKey: secret,
-		PluginInvoker: bridge,
+		BaseURL:            relaySrv.URL,
+		EncryptionKey:      secret,
+		PluginInvoker:      bridge,
+		PublicHostServices: publicHostServices,
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 
@@ -7120,7 +7202,7 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 	}
 }
 
-func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte) http.Handler {
+func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServices *providerhost.PublicHostServiceRegistry) http.Handler {
 	t.Helper()
 
 	tokenManager, err := providerhost.NewHostServiceRelayTokenManager(stateSecret)
@@ -7138,8 +7220,60 @@ func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte) http.Handler {
 			writeRuntimeRelayGRPCTrailersOnly(w, codes.PermissionDenied, "host-service-relay-method-not-allowed")
 			return
 		}
-		newRuntimeRelayProxy(target.SocketPath).ServeHTTP(w, r)
+		handler, err := runtimeRelayPublicHostServiceHandler(r.Context(), publicHostServices, target)
+		if err != nil {
+			writeRuntimeRelayGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-session")
+			return
+		}
+		if handler == nil {
+			writeRuntimeRelayGRPCTrailersOnly(w, codes.Unavailable, "host-service-relay-unavailable")
+			return
+		}
+		relayReq := r.Clone(r.Context())
+		relayReq.Header = r.Header.Clone()
+		relayReq.Header.Del(providerhost.HostServiceRelayTokenHeader)
+		handler.ServeHTTP(w, relayReq)
 	})
+}
+
+func runtimeRelayPublicHostServiceHandler(ctx context.Context, registry *providerhost.PublicHostServiceRegistry, target providerhost.HostServiceRelayTarget) (http.Handler, error) {
+	handler, err := runtimeRelayPublicHostServiceHandlerForSession(ctx, registry, target, target.SessionID)
+	if handler != nil || err != nil || strings.TrimSpace(target.SessionID) == "" {
+		return handler, err
+	}
+	return runtimeRelayPublicHostServiceHandlerForSession(ctx, registry, target, "")
+}
+
+func runtimeRelayPublicHostServiceHandlerForSession(ctx context.Context, registry *providerhost.PublicHostServiceRegistry, target providerhost.HostServiceRelayTarget, sessionID string) (http.Handler, error) {
+	if registry == nil {
+		return nil, nil
+	}
+	for _, entry := range registry.Services() {
+		if strings.TrimSpace(entry.PluginName) != strings.TrimSpace(target.PluginName) {
+			continue
+		}
+		if strings.TrimSpace(entry.SessionID) != strings.TrimSpace(sessionID) {
+			continue
+		}
+		if strings.TrimSpace(entry.Service.Name) != strings.TrimSpace(target.Service) {
+			continue
+		}
+		if strings.TrimSpace(entry.Service.EnvVar) != strings.TrimSpace(target.EnvVar) {
+			continue
+		}
+		if entry.Service.Register == nil {
+			continue
+		}
+		if entry.SessionVerifier != nil {
+			if err := entry.SessionVerifier.VerifyHostServiceSession(ctx, target.SessionID); err != nil {
+				return nil, err
+			}
+		}
+		srv := grpc.NewServer()
+		entry.Service.Register(srv)
+		return http.HandlerFunc(srv.ServeHTTP), nil
+	}
+	return nil, nil
 }
 
 func newRuntimeEgressProxyTestHandler(t *testing.T, stateSecret []byte) http.Handler {
@@ -7318,31 +7452,6 @@ func runtimeRelayMethodAllowed(path, methodPrefix string) bool {
 	return strings.HasPrefix(path, methodPrefix+"/")
 }
 
-func newRuntimeRelayProxy(socketPath string) *httputil.ReverseProxy {
-	target := &url.URL{
-		Scheme: "http",
-		Host:   "gestalt-test-host-service-relay",
-	}
-	return &httputil.ReverseProxy{
-		Rewrite: func(pr *httputil.ProxyRequest) {
-			pr.SetURL(target)
-			pr.Out.Host = target.Host
-			pr.Out.Header.Del(providerhost.HostServiceRelayTokenHeader)
-		},
-		Transport: &http2.Transport{
-			AllowHTTP: true,
-			DialTLSContext: func(ctx context.Context, _, _ string, _ *tls.Config) (net.Conn, error) {
-				var dialer net.Dialer
-				return dialer.DialContext(ctx, "unix", socketPath)
-			},
-		},
-		FlushInterval: -1,
-		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
-			writeRuntimeRelayGRPCTrailersOnly(w, codes.Unavailable, "host-service-relay-unavailable")
-		},
-	}
-}
-
 func writeRuntimeRelayGRPCTrailersOnly(w http.ResponseWriter, code codes.Code, message string) {
 	headers := w.Header()
 	headers.Set("Content-Type", "application/grpc")
@@ -7358,7 +7467,8 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 	t.Parallel()
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
 	relaySrv.EnableHTTP2 = true
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)
@@ -7403,9 +7513,10 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 
 	manager := newStubWorkflowManager()
 	deps := Deps{
-		BaseURL:         relaySrv.URL,
-		EncryptionKey:   secret,
-		WorkflowManager: manager,
+		BaseURL:            relaySrv.URL,
+		EncryptionKey:      secret,
+		WorkflowManager:    manager,
+		PublicHostServices: publicHostServices,
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 
@@ -7493,7 +7604,8 @@ func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *t
 	t.Parallel()
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
 	relaySrv.EnableHTTP2 = true
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)
@@ -7559,6 +7671,7 @@ func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *t
 		BaseURL:               relaySrv.URL,
 		EncryptionKey:         secret,
 		AuthorizationProvider: authz,
+		PublicHostServices:    publicHostServices,
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -886,7 +886,11 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	if err != nil {
 		return nil, err
 	}
-	cleanup = chainCleanup(cleanup, runtimeCleanup)
+	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps, runtimePlan, runtimeProvider)
+	if err != nil {
+		return nil, err
+	}
+	cleanup = chainCleanup(cleanup, runtimeCleanup, publicHostServicesCleanup)
 	startedHostServices, err := providerhost.StartHostServices(
 		hostServices,
 		providerhost.WithHostServicesProviderName(name),
@@ -990,6 +994,12 @@ func buildHostedAgentProvider(ctx context.Context, name string, entry *config.Pr
 		launch.close()
 		return nil, fmt.Errorf("hosted agent runtime restart policy %q requires indexeddb persistence hook", config.HostedRuntimeRestartPolicyAlways)
 	}
+	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps, launch.runtimePlan, launch.runtimeProvider)
+	if err != nil {
+		launch.close()
+		return nil, err
+	}
+	launch.cleanup = chainCleanup(launch.cleanup, publicHostServicesCleanup)
 	return newHostedAgentProviderPool(ctx, launch, hostServices, deps, policy)
 }
 
@@ -1607,6 +1617,63 @@ func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostSe
 	}, nil, "", nil
 }
 
+type runtimeHostServiceSessionVerifier struct {
+	providerName string
+	provider     pluginruntime.Provider
+}
+
+func (v runtimeHostServiceSessionVerifier) VerifyHostServiceSession(ctx context.Context, sessionID string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return fmt.Errorf("runtime session id is required")
+	}
+	if v.provider == nil {
+		return fmt.Errorf("plugin runtime provider is not configured")
+	}
+	session, err := v.provider.GetSession(ctx, pluginruntime.GetSessionRequest{SessionID: sessionID})
+	if err != nil {
+		return err
+	}
+	if session == nil {
+		return fmt.Errorf("plugin runtime session %q was not found", sessionID)
+	}
+	if expected := strings.TrimSpace(v.providerName); expected != "" {
+		if got := strings.TrimSpace(session.Metadata["provider_name"]); got != "" && got != expected {
+			return fmt.Errorf("plugin runtime session %q belongs to provider %q", sessionID, got)
+		}
+	}
+	if session.Lifecycle != nil && session.Lifecycle.ExpiresAt != nil {
+		expiresAt := session.Lifecycle.ExpiresAt.UTC()
+		if !time.Now().UTC().Before(expiresAt) {
+			return fmt.Errorf("plugin runtime session %q expired at %s", sessionID, expiresAt.Format(time.RFC3339Nano))
+		}
+	}
+	switch session.State {
+	case pluginruntime.SessionStatePending, pluginruntime.SessionStateReady, pluginruntime.SessionStateRunning:
+		return nil
+	default:
+		return fmt.Errorf("plugin runtime session %q is %s", sessionID, session.State)
+	}
+}
+
+func registerPublicRuntimeHostServices(providerName string, hostServices []providerhost.HostService, deps Deps, runtimePlan HostedRuntimePlan, runtimeProvider pluginruntime.Provider) (func(), error) {
+	if runtimePlan.Resolved.HostServiceAccess != RuntimeHostServiceAccessRelay || deps.PublicHostServices == nil {
+		return nil, nil
+	}
+	for _, hostService := range hostServices {
+		if strings.TrimSpace(hostService.Name) == "" {
+			return nil, fmt.Errorf("host service %q requires a service name for public relay", hostService.EnvVar)
+		}
+	}
+	deps.PublicHostServices.RegisterVerified(providerName, runtimeHostServiceSessionVerifier{
+		providerName: providerName,
+		provider:     runtimeProvider,
+	}, hostServices...)
+	return func() {
+		deps.PublicHostServices.Unregister(providerName, hostServices...)
+	}, nil
+}
+
 func buildHostedRuntimePublicEgressProxy(providerName, sessionID string, allowedHosts []string, defaultAction egress.PolicyAction, deps Deps) (map[string]string, error) {
 	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
 		return nil, fmt.Errorf("provider %q requires server.baseURL and server.encryptionKey to enforce hostname-based egress on hosted runtimes without host service tunnels", providerName)
@@ -1653,7 +1720,7 @@ func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, ho
 		PluginName:   providerName,
 		SessionID:    sessionID,
 		Service:      serviceKey,
-		SocketPath:   hostService.SocketPath,
+		EnvVar:       hostService.EnvVar,
 		MethodPrefix: methodPrefix,
 		TTL:          pluginRuntimeHostServiceRelayTokenTTL,
 	})
@@ -1900,6 +1967,7 @@ func buildAgentIndexedDBHostServices(name string, effective config.EffectiveHost
 	}
 
 	hostServices := []providerhost.HostService{{
+		Name:   "indexeddb",
 		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, name, providerhost.IndexedDBServerOptions{

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -157,6 +157,12 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 			cleanup()
 		}
 	}()
+	if deps.PublicHostServices != nil {
+		deps.PublicHostServices.RegisterSession(name, sessionID, hostServices...)
+		cleanup = chainCleanup(cleanup, func() {
+			deps.PublicHostServices.UnregisterSession(name, sessionID, hostServices...)
+		})
+	}
 
 	env := map[string]string{}
 	var allowedHosts []string

--- a/gestaltd/internal/providerhost/host_service_relay_token.go
+++ b/gestaltd/internal/providerhost/host_service_relay_token.go
@@ -3,7 +3,6 @@ package providerhost
 import (
 	"crypto/rand"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -30,7 +29,7 @@ type HostServiceRelayTokenRequest struct {
 	PluginName   string
 	SessionID    string
 	Service      string
-	SocketPath   string
+	EnvVar       string
 	MethodPrefix string
 	TTL          time.Duration
 }
@@ -39,7 +38,7 @@ type HostServiceRelayTarget struct {
 	PluginName   string
 	SessionID    string
 	Service      string
-	SocketPath   string
+	EnvVar       string
 	MethodPrefix string
 }
 
@@ -48,7 +47,7 @@ type hostServiceRelayTokenClaims struct {
 	PluginName   string `json:"plugin,omitempty"`
 	SessionID    string `json:"session_id,omitempty"`
 	Service      string `json:"service,omitempty"`
-	SocketPath   string `json:"socket_path,omitempty"`
+	EnvVar       string `json:"env_var,omitempty"`
 	MethodPrefix string `json:"method_prefix,omitempty"`
 }
 
@@ -71,7 +70,7 @@ func (m *HostServiceRelayTokenManager) MintToken(req HostServiceRelayTokenReques
 	if m == nil {
 		return "", fmt.Errorf("host service relay tokens are not available")
 	}
-	socketPath, methodPrefix, err := normalizeHostServiceRelayTarget(req.SocketPath, req.MethodPrefix)
+	service, envVar, methodPrefix, err := normalizeHostServiceRelayTarget(req.Service, req.EnvVar, req.MethodPrefix)
 	if err != nil {
 		return "", err
 	}
@@ -98,8 +97,8 @@ func (m *HostServiceRelayTokenManager) MintToken(req HostServiceRelayTokenReques
 		},
 		PluginName:   strings.TrimSpace(req.PluginName),
 		SessionID:    strings.TrimSpace(req.SessionID),
-		Service:      strings.TrimSpace(req.Service),
-		SocketPath:   socketPath,
+		Service:      service,
+		EnvVar:       envVar,
 		MethodPrefix: methodPrefix,
 	})
 }
@@ -112,15 +111,15 @@ func (m *HostServiceRelayTokenManager) ResolveToken(token string) (HostServiceRe
 	if err != nil {
 		return HostServiceRelayTarget{}, err
 	}
-	socketPath, methodPrefix, err := normalizeHostServiceRelayTarget(claims.SocketPath, claims.MethodPrefix)
+	service, envVar, methodPrefix, err := normalizeHostServiceRelayTarget(claims.Service, claims.EnvVar, claims.MethodPrefix)
 	if err != nil {
 		return HostServiceRelayTarget{}, fmt.Errorf("host service relay token is invalid or expired")
 	}
 	return HostServiceRelayTarget{
 		PluginName:   strings.TrimSpace(claims.PluginName),
 		SessionID:    strings.TrimSpace(claims.SessionID),
-		Service:      strings.TrimSpace(claims.Service),
-		SocketPath:   socketPath,
+		Service:      service,
+		EnvVar:       envVar,
 		MethodPrefix: methodPrefix,
 	}, nil
 }
@@ -161,17 +160,21 @@ func (m *HostServiceRelayTokenManager) tokenTTL(ttl time.Duration) time.Duration
 	return ttl
 }
 
-func normalizeHostServiceRelayTarget(socketPath, methodPrefix string) (string, string, error) {
-	socketPath = strings.TrimSpace(socketPath)
-	if socketPath == "" {
-		return "", "", fmt.Errorf("host service relay socket path is required")
+func normalizeHostServiceRelayTarget(service, envVar, methodPrefix string) (string, string, string, error) {
+	service = strings.TrimSpace(service)
+	if service == "" {
+		return "", "", "", fmt.Errorf("host service relay service is required")
 	}
-	if !filepath.IsAbs(socketPath) {
-		return "", "", fmt.Errorf("host service relay socket path must be absolute")
+	envVar = strings.TrimSpace(envVar)
+	if envVar == "" {
+		return "", "", "", fmt.Errorf("host service relay env var is required")
 	}
 	methodPrefix = strings.TrimSpace(methodPrefix)
-	if methodPrefix != "" && !strings.HasPrefix(methodPrefix, "/") {
+	if methodPrefix == "" {
+		return "", "", "", fmt.Errorf("host service relay method prefix is required")
+	}
+	if !strings.HasPrefix(methodPrefix, "/") {
 		methodPrefix = "/" + methodPrefix
 	}
-	return socketPath, methodPrefix, nil
+	return service, envVar, methodPrefix, nil
 }

--- a/gestaltd/internal/providerhost/public_host_service.go
+++ b/gestaltd/internal/providerhost/public_host_service.go
@@ -1,0 +1,151 @@
+package providerhost
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+type PublicHostServiceSessionVerifier interface {
+	VerifyHostServiceSession(context.Context, string) error
+}
+
+// PublicHostService describes a host service that can be served by the public
+// gestaltd listener after a host-service relay token has authorized the RPC.
+type PublicHostService struct {
+	PluginName      string
+	SessionID       string
+	SessionVerifier PublicHostServiceSessionVerifier
+	Service         HostService
+}
+
+type PublicHostServiceRegistry struct {
+	mu       sync.Mutex
+	services []PublicHostService
+	version  uint64
+}
+
+func NewPublicHostServiceRegistry() *PublicHostServiceRegistry {
+	return &PublicHostServiceRegistry{}
+}
+
+func (r *PublicHostServiceRegistry) Register(pluginName string, services ...HostService) {
+	r.RegisterVerified(pluginName, nil, services...)
+}
+
+func (r *PublicHostServiceRegistry) RegisterVerified(pluginName string, verifier PublicHostServiceSessionVerifier, services ...HostService) {
+	r.register(pluginName, "", verifier, services...)
+}
+
+func (r *PublicHostServiceRegistry) RegisterSession(pluginName, sessionID string, services ...HostService) {
+	r.register(pluginName, sessionID, nil, services...)
+}
+
+func (r *PublicHostServiceRegistry) register(pluginName, sessionID string, verifier PublicHostServiceSessionVerifier, services ...HostService) {
+	if r == nil {
+		return
+	}
+	pluginName = strings.TrimSpace(pluginName)
+	sessionID = strings.TrimSpace(sessionID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, service := range services {
+		r.services = append(r.services, PublicHostService{
+			PluginName:      pluginName,
+			SessionID:       sessionID,
+			SessionVerifier: verifier,
+			Service:         service,
+		})
+	}
+	if len(services) > 0 {
+		r.version++
+	}
+}
+
+func (r *PublicHostServiceRegistry) Unregister(pluginName string, services ...HostService) {
+	r.unregister(pluginName, "", services...)
+}
+
+func (r *PublicHostServiceRegistry) UnregisterSession(pluginName, sessionID string, services ...HostService) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return
+	}
+	r.unregister(pluginName, sessionID, services...)
+}
+
+func (r *PublicHostServiceRegistry) unregister(pluginName, sessionID string, services ...HostService) {
+	if r == nil {
+		return
+	}
+	pluginName = strings.TrimSpace(pluginName)
+	sessionID = strings.TrimSpace(sessionID)
+	if pluginName == "" {
+		return
+	}
+	removing := make(map[string]struct{}, len(services))
+	for _, service := range services {
+		key := publicHostServiceKey(service)
+		if key != "" {
+			removing[key] = struct{}{}
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	originalLen := len(r.services)
+	filtered := r.services[:0]
+	for _, service := range r.services {
+		if strings.TrimSpace(service.PluginName) == pluginName && strings.TrimSpace(service.SessionID) == sessionID {
+			if len(removing) == 0 {
+				continue
+			}
+			if _, ok := removing[publicHostServiceKey(service.Service)]; ok {
+				continue
+			}
+		}
+		filtered = append(filtered, service)
+	}
+	for i := len(filtered); i < originalLen; i++ {
+		r.services[i] = PublicHostService{}
+	}
+	r.services = filtered
+	if len(r.services) != originalLen {
+		r.version++
+	}
+}
+
+func (r *PublicHostServiceRegistry) Services() []PublicHostService {
+	services, _ := r.Snapshot()
+	return services
+}
+
+func (r *PublicHostServiceRegistry) Snapshot() ([]PublicHostService, uint64) {
+	if r == nil {
+		return nil, 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.services) == 0 {
+		return nil, r.version
+	}
+	return append([]PublicHostService(nil), r.services...), r.version
+}
+
+func (r *PublicHostServiceRegistry) Version() uint64 {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.version
+}
+
+func publicHostServiceKey(service HostService) string {
+	name := strings.TrimSpace(service.Name)
+	envVar := strings.TrimSpace(service.EnvVar)
+	if name == "" || envVar == "" {
+		return ""
+	}
+	return name + "\x00" + envVar
+}

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"google.golang.org/grpc"
+)
+
+type hostServiceHandlerKey struct {
+	pluginName string
+	sessionID  string
+	service    string
+	envVar     string
+}
+
+type hostServiceHandlerEntry struct {
+	handler  http.Handler
+	verifier providerhost.PublicHostServiceSessionVerifier
+}
+
+func newPublicHostServiceHandlers(services []providerhost.PublicHostService) (map[hostServiceHandlerKey]hostServiceHandlerEntry, error) {
+	if len(services) == 0 {
+		return nil, nil
+	}
+	handlers := make(map[hostServiceHandlerKey]hostServiceHandlerEntry, len(services))
+	for _, service := range services {
+		key, entry, ok := newPublicHostServiceHandlerEntry(service)
+		if !ok {
+			continue
+		}
+		if _, ok := handlers[key]; ok {
+			return nil, fmt.Errorf("duplicate public host service %s", key.String())
+		}
+		handlers[key] = entry
+	}
+	if len(handlers) == 0 {
+		return nil, nil
+	}
+	return handlers, nil
+}
+
+func newPublicHostServiceHandlerEntry(service providerhost.PublicHostService) (hostServiceHandlerKey, hostServiceHandlerEntry, bool) {
+	key := hostServiceHandlerKey{
+		pluginName: strings.TrimSpace(service.PluginName),
+		sessionID:  strings.TrimSpace(service.SessionID),
+		service:    strings.TrimSpace(service.Service.Name),
+		envVar:     strings.TrimSpace(service.Service.EnvVar),
+	}
+	if key.pluginName == "" || key.service == "" || key.envVar == "" || service.Service.Register == nil {
+		return hostServiceHandlerKey{}, hostServiceHandlerEntry{}, false
+	}
+	srv := grpc.NewServer()
+	service.Service.Register(srv)
+	return key, hostServiceHandlerEntry{
+		handler:  http.HandlerFunc(srv.ServeHTTP),
+		verifier: service.SessionVerifier,
+	}, true
+}
+
+func (k hostServiceHandlerKey) String() string {
+	parts := []string{k.pluginName, k.service, k.envVar}
+	if k.sessionID != "" {
+		parts = append(parts, "session="+k.sessionID)
+	}
+	return strings.Join(parts, "/")
+}
+
+func (s *Server) hostServiceHandler(ctx context.Context, target providerhost.HostServiceRelayTarget) (http.Handler, error) {
+	if s == nil {
+		return nil, nil
+	}
+	exactKey := hostServiceHandlerKey{
+		pluginName: strings.TrimSpace(target.PluginName),
+		sessionID:  strings.TrimSpace(target.SessionID),
+		service:    strings.TrimSpace(target.Service),
+		envVar:     strings.TrimSpace(target.EnvVar),
+	}
+	providerKey := exactKey
+	providerKey.sessionID = ""
+
+	entry, ok, err := s.hostServiceHandlerEntry(exactKey)
+	if err != nil {
+		return nil, err
+	}
+	if !ok && exactKey.sessionID != "" {
+		entry, ok, err = s.hostServiceHandlerEntry(providerKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !ok {
+		return nil, nil
+	}
+	if entry.verifier != nil {
+		if err := entry.verifier.VerifyHostServiceSession(ctx, exactKey.sessionID); err != nil {
+			return nil, err
+		}
+	}
+	return entry.handler, nil
+}
+
+func (s *Server) hostServiceHandlerEntry(key hostServiceHandlerKey) (hostServiceHandlerEntry, bool, error) {
+	if key.pluginName == "" || key.service == "" || key.envVar == "" {
+		return hostServiceHandlerEntry{}, false, nil
+	}
+
+	for {
+		s.hostServiceMu.Lock()
+		s.refreshHostServiceHandlerCacheLocked()
+		if entry, ok := s.hostServiceHandlers[key]; ok {
+			s.hostServiceMu.Unlock()
+			return entry, true, nil
+		}
+		s.hostServiceMu.Unlock()
+
+		services, snapshotVersion := s.publicHostServices.Snapshot()
+		var found *providerhost.PublicHostService
+		for _, service := range services {
+			serviceKey := hostServiceHandlerKey{
+				pluginName: strings.TrimSpace(service.PluginName),
+				sessionID:  strings.TrimSpace(service.SessionID),
+				service:    strings.TrimSpace(service.Service.Name),
+				envVar:     strings.TrimSpace(service.Service.EnvVar),
+			}
+			if serviceKey != key || service.Service.Register == nil {
+				continue
+			}
+			if found != nil {
+				return hostServiceHandlerEntry{}, false, fmt.Errorf("duplicate public host service %s", key.String())
+			}
+			serviceCopy := service
+			found = &serviceCopy
+		}
+		if found == nil {
+			return hostServiceHandlerEntry{}, false, nil
+		}
+		entryKey, entry, ok := newPublicHostServiceHandlerEntry(*found)
+		if !ok || entryKey != key {
+			return hostServiceHandlerEntry{}, false, nil
+		}
+
+		s.hostServiceMu.Lock()
+		currentVersion := s.publicHostServices.Version()
+		if currentVersion != snapshotVersion {
+			s.hostServiceHandlers = nil
+			s.hostServiceVersion = currentVersion
+			s.hostServiceMu.Unlock()
+			continue
+		}
+		s.hostServiceVersion = snapshotVersion
+		if existing, ok := s.hostServiceHandlers[key]; ok {
+			s.hostServiceMu.Unlock()
+			return existing, true, nil
+		}
+		if s.hostServiceHandlers == nil {
+			s.hostServiceHandlers = make(map[hostServiceHandlerKey]hostServiceHandlerEntry)
+		}
+		s.hostServiceHandlers[key] = entry
+		s.hostServiceMu.Unlock()
+		return entry, true, nil
+	}
+}
+
+func (s *Server) refreshHostServiceHandlerCacheLocked() {
+	version := s.publicHostServices.Version()
+	if version != s.hostServiceVersion {
+		s.hostServiceHandlers = nil
+		s.hostServiceVersion = version
+	}
+}

--- a/gestaltd/internal/server/host_service_relay.go
+++ b/gestaltd/internal/server/host_service_relay.go
@@ -1,21 +1,13 @@
 package server
 
 import (
-	"context"
-	"crypto/tls"
-	"net"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"strconv"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
-	"golang.org/x/net/http2"
 	"google.golang.org/grpc/codes"
 )
-
-const hostServiceRelayBackendHost = "gestalt-host-service-relay"
 
 func (s *Server) hostServiceRelayMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -39,7 +31,19 @@ func (s *Server) hostServiceRelayMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		newHostServiceRelayProxy(target.SocketPath).ServeHTTP(w, r)
+		handler, err := s.hostServiceHandler(r.Context(), target)
+		if err != nil {
+			writeGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-session")
+			return
+		}
+		if handler == nil {
+			writeGRPCTrailersOnly(w, codes.Unavailable, "host-service-relay-unavailable")
+			return
+		}
+		relayReq := r.Clone(r.Context())
+		relayReq.Header = r.Header.Clone()
+		relayReq.Header.Del(providerhost.HostServiceRelayTokenHeader)
+		handler.ServeHTTP(w, relayReq)
 	})
 }
 
@@ -70,31 +74,6 @@ func hostServiceRelayMethodAllowed(path, methodPrefix string) bool {
 		return strings.HasPrefix(path, methodPrefix)
 	}
 	return strings.HasPrefix(path, methodPrefix+"/")
-}
-
-func newHostServiceRelayProxy(socketPath string) *httputil.ReverseProxy {
-	target := &url.URL{
-		Scheme: "http",
-		Host:   hostServiceRelayBackendHost,
-	}
-	return &httputil.ReverseProxy{
-		Rewrite: func(pr *httputil.ProxyRequest) {
-			pr.SetURL(target)
-			pr.Out.Host = hostServiceRelayBackendHost
-			pr.Out.Header.Del(providerhost.HostServiceRelayTokenHeader)
-		},
-		Transport: &http2.Transport{
-			AllowHTTP: true,
-			DialTLSContext: func(ctx context.Context, _, _ string, _ *tls.Config) (net.Conn, error) {
-				var dialer net.Dialer
-				return dialer.DialContext(ctx, "unix", socketPath)
-			},
-		},
-		FlushInterval: -1,
-		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
-			writeGRPCTrailersOnly(w, codes.Unavailable, "host-service-relay-unavailable")
-		},
-	}
 }
 
 func writeGRPCTrailersOnly(w http.ResponseWriter, code codes.Code, message string) {

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -107,6 +107,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		},
 		PrometheusMetrics:   result.Telemetry.PrometheusHandler(),
 		ProviderDevSessions: result.ProviderDevSessions,
+		PublicHostServices:  result.PublicHostServices,
 		Admin: AdminRouteConfig{
 			AuthorizationPolicy: cfg.Server.Admin.AuthorizationPolicy,
 			AllowedRoles:        append([]string(nil), cfg.Server.Admin.AllowedRoles...),

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -56,33 +56,26 @@ func TestNewHTTPServerSupportsH2CHostServiceRelay(t *testing.T) {
 
 	secret := []byte("relay-test-secret-0123456789abcd")
 	cacheSrv := &runtimeTestCacheServer{}
-	hostServices, err := providerhost.StartHostServices([]providerhost.HostService{{
-		EnvVar: "GESTALT_TEST_CACHE_SOCKET",
+	const envVar = "GESTALT_TEST_CACHE_SOCKET"
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	publicHostServices.Register("relay-plugin", providerhost.HostService{
+		Name:   "cache",
+		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterCacheServer(srv, cacheSrv)
 		},
-	}})
-	if err != nil {
-		t.Fatalf("StartHostServices: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = hostServices.Close()
 	})
-
-	bindings := hostServices.Bindings()
-	if len(bindings) != 1 {
-		t.Fatalf("host service bindings len = %d, want 1", len(bindings))
-	}
 
 	reg := registry.New()
 	services := coretesting.NewStubServices(t)
 	handler, err := New(Config{
-		Auth:         &coretesting.StubAuthProvider{N: "none"},
-		Services:     services,
-		Providers:    &reg.Providers,
-		StateSecret:  secret,
-		RouteProfile: RouteProfilePublic,
-		Invoker:      invocation.NewBroker(&reg.Providers, services.Users, services.ExternalCredentials),
+		Auth:               &coretesting.StubAuthProvider{N: "none"},
+		Services:           services,
+		Providers:          &reg.Providers,
+		StateSecret:        secret,
+		RouteProfile:       RouteProfilePublic,
+		Invoker:            invocation.NewBroker(&reg.Providers, services.Users, services.ExternalCredentials),
+		PublicHostServices: publicHostServices,
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -118,7 +111,7 @@ func TestNewHTTPServerSupportsH2CHostServiceRelay(t *testing.T) {
 		PluginName:   "relay-plugin",
 		SessionID:    "session-1",
 		Service:      "cache",
-		SocketPath:   bindings[0].SocketPath,
+		EnvVar:       envVar,
 		MethodPrefix: "/" + proto.Cache_ServiceDesc.ServiceName + "/",
 		TTL:          time.Minute,
 	})

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -113,6 +114,10 @@ type Server struct {
 	prometheusMetrics      http.Handler
 	mcpHandler             http.Handler
 	hostServiceRelayTokens *providerhost.HostServiceRelayTokenManager
+	hostServiceMu          sync.Mutex
+	hostServiceHandlers    map[hostServiceHandlerKey]hostServiceHandlerEntry
+	hostServiceVersion     uint64
+	publicHostServices     *providerhost.PublicHostServiceRegistry
 	egressProxyTokens      *providerhost.EgressProxyTokenManager
 	providerDevSessions    *providerdev.Manager
 	mountedHTTPBindings    []MountedHTTPBinding
@@ -159,6 +164,7 @@ type Config struct {
 	Readiness             ReadinessChecker
 	PrometheusMetrics     http.Handler
 	MCPHandler            http.Handler
+	PublicHostServices    *providerhost.PublicHostServiceRegistry
 	ProviderDevSessions   *providerdev.Manager
 	MountedUIs            []MountedUI
 	Admin                 AdminRouteConfig
@@ -286,6 +292,11 @@ func New(cfg Config) (*Server, error) {
 			return nil, fmt.Errorf("init egress proxy tokens: %w", err)
 		}
 	}
+	publicHostServices, hostServiceVersion := cfg.PublicHostServices.Snapshot()
+	hostServiceHandlers, err := newPublicHostServiceHandlers(publicHostServices)
+	if err != nil {
+		return nil, fmt.Errorf("init public host services: %w", err)
+	}
 	s := &Server{
 		router:                 router,
 		handler:                withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
@@ -322,6 +333,9 @@ func New(cfg Config) (*Server, error) {
 		prometheusMetrics:      cfg.PrometheusMetrics,
 		mcpHandler:             cfg.MCPHandler,
 		hostServiceRelayTokens: hostServiceRelayTokens,
+		hostServiceHandlers:    hostServiceHandlers,
+		hostServiceVersion:     hostServiceVersion,
+		publicHostServices:     cfg.PublicHostServices,
 		egressProxyTokens:      egressProxyTokens,
 		providerDevSessions:    cfg.ProviderDevSessions,
 		mountedHTTPBindings:    mountedHTTPBindings,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -239,12 +239,14 @@ type relayTestCacheServer struct {
 	proto.UnimplementedCacheServer
 
 	mu             sync.Mutex
+	keys           []string
 	receivedTokens []string
 }
 
 func (s *relayTestCacheServer) Get(ctx context.Context, req *proto.CacheGetRequest) (*proto.CacheGetResponse, error) {
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		s.mu.Lock()
+		s.keys = append(s.keys, req.GetKey())
 		s.receivedTokens = append(s.receivedTokens, md.Get(providerhost.HostServiceRelayTokenHeader)...)
 		s.mu.Unlock()
 	}
@@ -260,36 +262,65 @@ func (s *relayTestCacheServer) relayTokens() []string {
 	return append([]string(nil), s.receivedTokens...)
 }
 
+func (s *relayTestCacheServer) calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.keys)
+}
+
+type relayTestSessionVerifier struct {
+	mu     sync.Mutex
+	active map[string]bool
+}
+
+func newRelayTestSessionVerifier(sessionIDs ...string) *relayTestSessionVerifier {
+	verifier := &relayTestSessionVerifier{active: map[string]bool{}}
+	for _, sessionID := range sessionIDs {
+		verifier.active[sessionID] = true
+	}
+	return verifier
+}
+
+func (v *relayTestSessionVerifier) VerifyHostServiceSession(_ context.Context, sessionID string) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.active[strings.TrimSpace(sessionID)] {
+		return nil
+	}
+	return fmt.Errorf("runtime session %q is not active", sessionID)
+}
+
+func (v *relayTestSessionVerifier) setActive(sessionID string, active bool) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.active[sessionID] = active
+}
+
 func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	t.Parallel()
 
 	secret := []byte("relay-test-secret-0123456789abcd")
 	cacheSrv := &relayTestCacheServer{}
-	hostServices, err := providerhost.StartHostServices([]providerhost.HostService{{
-		EnvVar: "GESTALT_TEST_CACHE_SOCKET",
+	const envVar = "GESTALT_TEST_CACHE_SOCKET"
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	sessionVerifier := newRelayTestSessionVerifier("session-1")
+	hostService := providerhost.HostService{
+		Name:   "cache",
+		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterCacheServer(srv, cacheSrv)
 		},
-	}})
-	if err != nil {
-		t.Fatalf("StartHostServices: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = hostServices.Close()
-	})
-
-	bindings := hostServices.Bindings()
-	if len(bindings) != 1 {
-		t.Fatalf("host service bindings len = %d, want 1", len(bindings))
 	}
 
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfilePublic
 		cfg.StateSecret = secret
+		cfg.PublicHostServices = publicHostServices
 	}))
 	ts.EnableHTTP2 = true
 	ts.StartTLS()
 	testutil.CloseOnCleanup(t, ts)
+	publicHostServices.RegisterVerified("support", sessionVerifier, hostService)
 
 	tokenManager, err := providerhost.NewHostServiceRelayTokenManager(secret)
 	if err != nil {
@@ -299,7 +330,7 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 		PluginName:   "support",
 		SessionID:    "session-1",
 		Service:      "cache",
-		SocketPath:   bindings[0].SocketPath,
+		EnvVar:       envVar,
 		MethodPrefix: "/gestalt.provider.v1.Cache/",
 		TTL:          time.Minute,
 	})
@@ -326,6 +357,95 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	}
 	if got := cacheSrv.relayTokens(); len(got) != 0 {
 		t.Fatalf("backend unexpectedly received relay token metadata: %#v", got)
+	}
+
+	sessionVerifier.setActive("session-1", false)
+	staleCtx, staleCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer staleCancel()
+	staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	_, err = proto.NewCacheClient(conn).Get(staleCtx, &proto.CacheGetRequest{Key: "stale"})
+	if grpcstatus.Code(err) != codes.Unauthenticated {
+		t.Fatalf("Cache.Get stale session code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unauthenticated, err)
+	}
+	if got := cacheSrv.calls(); got != 1 {
+		t.Fatalf("backend calls = %d, want only the verified call", got)
+	}
+
+	sessionVerifier.setActive("session-1", true)
+	publicHostServices.Unregister("support", hostService)
+	unregisteredCtx, unregisteredCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer unregisteredCancel()
+	unregisteredCtx = metadata.NewOutgoingContext(unregisteredCtx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	_, err = proto.NewCacheClient(conn).Get(unregisteredCtx, &proto.CacheGetRequest{Key: "unregistered"})
+	if grpcstatus.Code(err) != codes.Unavailable {
+		t.Fatalf("Cache.Get unregistered provider code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
+	}
+	if got := cacheSrv.calls(); got != 1 {
+		t.Fatalf("backend calls = %d, want no calls after unregister", got)
+	}
+}
+
+func TestHostServiceRelayStopsServingUnregisteredSession(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	cacheSrv := &relayTestCacheServer{}
+	const envVar = "GESTALT_TEST_CACHE_SOCKET"
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	hostService := providerhost.HostService{
+		Name:   "cache",
+		EnvVar: envVar,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterCacheServer(srv, cacheSrv)
+		},
+	}
+	publicHostServices.RegisterSession("support", "session-1", hostService)
+
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+		cfg.PublicHostServices = publicHostServices
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := providerhost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	token, err := tokenManager.MintToken(providerhost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-1",
+		Service:      "cache",
+		EnvVar:       envVar,
+		MethodPrefix: "/" + proto.Cache_ServiceDesc.ServiceName + "/",
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	if _, err := proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "active"}); err != nil {
+		t.Fatalf("Cache.Get via session relay: %v", err)
+	}
+
+	publicHostServices.UnregisterSession("support", "session-1", hostService)
+	staleCtx, staleCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer staleCancel()
+	staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	_, err = proto.NewCacheClient(conn).Get(staleCtx, &proto.CacheGetRequest{Key: "stale"})
+	if grpcstatus.Code(err) != codes.Unavailable {
+		t.Fatalf("Cache.Get unregistered session code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
+	}
+	if got := cacheSrv.calls(); got != 1 {
+		t.Fatalf("backend calls = %d, want only the registered call", got)
 	}
 }
 
@@ -359,27 +479,20 @@ func TestHostServiceRelayRejectsMethodOutsideTokenPrefix(t *testing.T) {
 
 	secret := []byte("relay-test-secret-0123456789abcd")
 	cacheSrv := &relayTestCacheServer{}
-	hostServices, err := providerhost.StartHostServices([]providerhost.HostService{{
-		EnvVar: "GESTALT_TEST_CACHE_SOCKET",
+	const envVar = "GESTALT_TEST_CACHE_SOCKET"
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	publicHostServices.Register("support", providerhost.HostService{
+		Name:   "cache",
+		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterCacheServer(srv, cacheSrv)
 		},
-	}})
-	if err != nil {
-		t.Fatalf("StartHostServices: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = hostServices.Close()
 	})
-
-	bindings := hostServices.Bindings()
-	if len(bindings) != 1 {
-		t.Fatalf("host service bindings len = %d, want 1", len(bindings))
-	}
 
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfilePublic
 		cfg.StateSecret = secret
+		cfg.PublicHostServices = publicHostServices
 	}))
 	ts.EnableHTTP2 = true
 	ts.StartTLS()
@@ -393,7 +506,7 @@ func TestHostServiceRelayRejectsMethodOutsideTokenPrefix(t *testing.T) {
 		PluginName:   "support",
 		SessionID:    "session-1",
 		Service:      "cache",
-		SocketPath:   bindings[0].SocketPath,
+		EnvVar:       envVar,
 		MethodPrefix: "/gestalt.provider.v1.IndexedDB/",
 		TTL:          time.Minute,
 	})
@@ -419,29 +532,21 @@ func TestHostServiceRelaySupportsIndexedDBSDKClient(t *testing.T) {
 
 	secret := []byte("relay-test-secret-0123456789abcd")
 	stubDB := &coretesting.StubIndexedDB{}
-	hostServices, err := providerhost.StartHostServices([]providerhost.HostService{{
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	publicHostServices.Register("relay-plugin", providerhost.HostService{
+		Name:   "indexeddb",
 		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(stubDB, "relay-plugin", providerhost.IndexedDBServerOptions{
 				AllowedStores: []string{"tasks"},
 			}))
 		},
-	}})
-	if err != nil {
-		t.Fatalf("StartHostServices: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = hostServices.Close()
 	})
-
-	bindings := hostServices.Bindings()
-	if len(bindings) != 1 {
-		t.Fatalf("host service bindings len = %d, want 1", len(bindings))
-	}
 
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfilePublic
 		cfg.StateSecret = secret
+		cfg.PublicHostServices = publicHostServices
 	}))
 	ts.EnableHTTP2 = true
 	ts.StartTLS()
@@ -455,7 +560,7 @@ func TestHostServiceRelaySupportsIndexedDBSDKClient(t *testing.T) {
 		PluginName:   "relay-plugin",
 		SessionID:    "session-1",
 		Service:      "indexeddb",
-		SocketPath:   bindings[0].SocketPath,
+		EnvVar:       providerhost.DefaultIndexedDBSocketEnv,
 		MethodPrefix: "/" + proto.IndexedDB_ServiceDesc.ServiceName + "/",
 		TTL:          time.Minute,
 	})


### PR DESCRIPTION
## Summary

This removes process-local socket paths from the public host-service relay contract. Hosted runtimes still receive the same `tls://valon.tools:443` host-service dial target and `*_TOKEN` env vars, but the token now identifies the public host-service handler by existing primitives instead of carrying a Unix socket path.

The production public path remains worker-independent: any gestaltd worker can resolve the relay token, find the provider-level host-service registration, and verify the token's `SessionID` through the shared runtime provider before dispatching. Provider-level verification now rejects missing, stopped, failed, wrong-provider, and expired runtime sessions. Provider and provider-dev cleanup unregisters public handlers and bumps the registry version so relay handler caches stop serving stale entries.

## Breaking rollout behavior

This intentionally does not support old public relay tokens that carry `socket_path`. Active hosted runtime sessions launched by the old code should be drained or restarted during rollout. The new public relay token shape is the only supported shape.

## Interface changes

`HostServiceRelayTokenRequest` now uses the existing host-service env var as the binding selector:

```go
type HostServiceRelayTokenRequest struct {
    PluginName   string
    SessionID    string
    Service      string
    EnvVar       string
    MethodPrefix string
    TTL          time.Duration
}
```

`HostServiceRelayTarget` mirrors the validated public target:

```go
type HostServiceRelayTarget struct {
    PluginName   string
    SessionID    string
    Service      string
    EnvVar       string
    MethodPrefix string
}
```

Public host-service registration now exposes provider-level and session-scoped registrations:

```go
type PublicHostServiceSessionVerifier interface {
    VerifyHostServiceSession(context.Context, string) error
}

type PublicHostService struct {
    PluginName      string
    SessionID       string
    SessionVerifier PublicHostServiceSessionVerifier
    Service         HostService
}

type PublicHostServiceRegistry struct { /* internal registry */ }

func (r *PublicHostServiceRegistry) Register(pluginName string, services ...HostService)
func (r *PublicHostServiceRegistry) RegisterVerified(pluginName string, verifier PublicHostServiceSessionVerifier, services ...HostService)
func (r *PublicHostServiceRegistry) RegisterSession(pluginName, sessionID string, services ...HostService)
func (r *PublicHostServiceRegistry) Unregister(pluginName string, services ...HostService)
func (r *PublicHostServiceRegistry) UnregisterSession(pluginName, sessionID string, services ...HostService)
```

## Examples

Token minting for a named cache binding:

```go
token, err := tokenManager.MintToken(providerhost.HostServiceRelayTokenRequest{
    PluginName:   "echoext",
    SessionID:    runtimeSessionID,
    Service:      "cache",
    EnvVar:       providerhost.CacheSocketEnv("session"),
    MethodPrefix: "/gestalt.provider.v1.Cache/",
    TTL:          pluginRuntimeHostServiceRelayTokenTTL,
})
```

Provider-level registration for hosted runtimes:

```go
publicHostServices.RegisterVerified(
    "echoext",
    runtimeHostServiceSessionVerifier{providerName: "echoext", provider: runtimeProvider},
    hostServices...,
)
```

Provider-level cleanup:

```go
publicHostServices.Unregister("echoext", hostServices...)
```

Session-scoped provider-dev registration:

```go
publicHostServices.RegisterSession("echoext", sessionID, hostServices...)
defer publicHostServices.UnregisterSession("echoext", sessionID, hostServices...)
```

Runtime env remains unchanged:

```text
GESTALT_CACHE_SESSION_SOCKET=tls://valon.tools:443
GESTALT_CACHE_SESSION_SOCKET_TOKEN=<relay-token>
```

Direct/local runtimes still use direct `unix://...` `DialTarget` bindings. Public relay tokens no longer carry or route to process-local socket paths.

## Testing

```text
go test -count=1 ./internal/providerhost ./internal/server ./internal/bootstrap
```
