### PR TITLE
Adopt provider-authored agent event display

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -1267,6 +1267,19 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 	if len(turnEvents) != 3 || turnEvents[0].Type != "turn.started" || turnEvents[2].Type != "turn.completed" {
 		t.Fatalf("ListTurnEvents = %#v, want started/completed event sequence", turnEvents)
 	}
+	if display := turnEvents[0].Display; display == nil || display.Kind != "status" || display.Phase != "started" || display.Text != "provider turn started" {
+		t.Fatalf("turn.started display = %#v, want provider-authored started status", display)
+	}
+	if display := turnEvents[1].Display; display == nil || display.Kind != "text" || display.Phase != "completed" || display.Text != "provider assistant completed" {
+		t.Fatalf("assistant.completed display = %#v, want provider-authored completed text", display)
+	}
+	if display := turnEvents[2].Display; display == nil || display.Kind != "status" || display.Phase != "completed" || display.Text != "provider turn completed" {
+		t.Fatalf("turn.completed display = %#v, want provider-authored completed status", display)
+	}
+	completedOutput, ok := turnEvents[2].Display.Output.(map[string]any)
+	if !ok || completedOutput["session_id"] != "session-1" {
+		t.Fatalf("turn.completed display output = %#v, want session_id=session-1", turnEvents[2].Display.Output)
+	}
 
 	postTurnSession, err := agents[0].GetSession(context.Background(), coreagent.GetSessionRequest{SessionID: "session-1"})
 	if err != nil {
@@ -1365,6 +1378,9 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 		if event.Data["provider_name"] != "simple" {
 			t.Fatalf("agent.test event data = %#v, want provider_name=simple", event.Data)
 		}
+		if display := event.Display; display == nil || display.Kind != "status" || display.Label != "provider event" || display.Text != "simple" {
+			t.Fatalf("agent.test display = %#v, want provider event display for simple", display)
+		}
 	}
 	if !foundAgentTest {
 		t.Fatalf("events = %#v, want agent.test event", events)
@@ -1419,6 +1435,24 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 	}
 	if interactions[0].Type != coreagent.InteractionTypeApproval || interactions[0].State != coreagent.InteractionStatePending {
 		t.Fatalf("interaction = %#v, want pending approval", interactions[0])
+	}
+	pausedEvents, err := agents[0].ListTurnEvents(context.Background(), coreagent.ListTurnEventsRequest{
+		TurnID:   "turn-2",
+		AfterSeq: 0,
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ListTurnEvents(waiting): %v", err)
+	}
+	if len(pausedEvents) != 2 || pausedEvents[1].Type != "interaction.requested" {
+		t.Fatalf("ListTurnEvents(waiting) = %#v, want interaction.requested", pausedEvents)
+	}
+	if display := pausedEvents[1].Display; display == nil || display.Kind != "interaction" || display.Phase != "requested" || display.Ref != interactions[0].ID {
+		t.Fatalf("interaction.requested display = %#v, want provider-authored interaction ref %q", display, interactions[0].ID)
+	}
+	requestedInput, ok := pausedEvents[1].Display.Input.(map[string]any)
+	if !ok || requestedInput["interaction_id"] != interactions[0].ID || requestedInput["session_id"] != "session-1" {
+		t.Fatalf("interaction.requested display input = %#v, want interaction/session ids", pausedEvents[1].Display.Input)
 	}
 	resolvedInteraction, err := agents[0].ResolveInteraction(context.Background(), coreagent.ResolveInteractionRequest{
 		InteractionID: interactions[0].ID,

--- a/gestaltd/internal/testplugins/agent/main.go
+++ b/gestaltd/internal/testplugins/agent/main.go
@@ -447,9 +447,85 @@ func (p *agentProvider) appendTurnEventLocked(turnID, eventType string, data map
 		Source:     p.providerNameLocked(""),
 		Visibility: "private",
 		Data:       payload,
+		Display:    turnEventDisplay(eventType, data),
 		CreatedAt:  timestamppb.Now(),
 	}
 	p.turnEvents[turnID] = append(events, event)
+}
+
+func turnEventDisplay(eventType string, data map[string]any) *proto.AgentTurnDisplay {
+	switch eventType {
+	case "turn.started":
+		return &proto.AgentTurnDisplay{
+			Kind:  "status",
+			Phase: "started",
+			Label: "turn",
+			Text:  "provider turn started",
+		}
+	case "agent.test":
+		return &proto.AgentTurnDisplay{
+			Kind:  "status",
+			Phase: "completed",
+			Label: "provider event",
+			Text:  displayString(data, "provider_name"),
+		}
+	case "interaction.requested":
+		return &proto.AgentTurnDisplay{
+			Kind:  "interaction",
+			Phase: "requested",
+			Label: "approval",
+			Ref:   displayString(data, "interaction_id"),
+			Input: displayValue(data),
+		}
+	case "interaction.resolved":
+		return &proto.AgentTurnDisplay{
+			Kind:   "interaction",
+			Phase:  "resolved",
+			Label:  "approval",
+			Ref:    displayString(data, "interaction_id"),
+			Output: displayValue(data),
+		}
+	case "assistant.completed":
+		return &proto.AgentTurnDisplay{
+			Kind:  "text",
+			Phase: "completed",
+			Text:  "provider assistant completed",
+		}
+	case "turn.completed":
+		return &proto.AgentTurnDisplay{
+			Kind:   "status",
+			Phase:  "completed",
+			Label:  "turn",
+			Text:   "provider turn completed",
+			Output: displayValue(data),
+		}
+	case "turn.canceled":
+		return &proto.AgentTurnDisplay{
+			Kind:  "status",
+			Phase: "canceled",
+			Label: "turn",
+			Text:  displayString(data, "reason"),
+			Error: displayValue(data),
+		}
+	default:
+		return nil
+	}
+}
+
+func displayString(data map[string]any, key string) string {
+	if data == nil {
+		return ""
+	}
+	value, _ := data[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func displayValue(value any) *structpb.Value {
+	display, err := structpb.NewValue(value)
+	if err != nil {
+		return nil
+	}
+	return display
 }
 
 func (p *agentProvider) providerName() string {

--- a/sdk/typescript/tests/fixtures/agent-provider/agent.ts
+++ b/sdk/typescript/tests/fixtures/agent-provider/agent.ts
@@ -8,21 +8,23 @@ import {
   AgentInteractionType,
   AgentSessionSchema,
   AgentSessionState,
-  AgentTurnEventSchema,
   AgentTurnSchema,
   type AgentInteraction,
   type AgentSession,
   type AgentTurn,
-  type AgentTurnEvent,
   type CreateAgentProviderTurnRequest,
   type GetAgentProviderInteractionRequest,
   type GetAgentProviderSessionRequest,
 } from "../../../gen/v1/agent_pb.ts";
-import { defineAgentProvider } from "../../../src/index.ts";
+import {
+  defineAgentProvider,
+  type AgentTurnDisplayInit,
+  type AgentTurnEventInit,
+} from "../../../src/index.ts";
 
 const sessions = new Map<string, AgentSession>();
 const turns = new Map<string, AgentTurn>();
-const turnEvents = new Map<string, AgentTurnEvent[]>();
+const turnEvents = new Map<string, AgentTurnEventInit[]>();
 const interactions = new Map<string, AgentInteraction>();
 let canceledTurns = 0;
 
@@ -95,7 +97,7 @@ export const provider = defineAgentProvider({
   },
   async listTurnEvents(request) {
     return (turnEvents.get(request.turnId) || [])
-      .filter((event) => event.seq > request.afterSeq)
+      .filter((event) => (event.seq ?? 0n) > request.afterSeq)
       .slice(0, request.limit > 0 ? request.limit : undefined);
   },
   async getInteraction(request) {
@@ -303,19 +305,79 @@ async function resolveCanonicalInteraction(request: {
 
 function appendTurnEvent(turnId: string, type: string, data: JsonObject) {
   const events = turnEvents.get(turnId) || [];
-  events.push(
-    create(AgentTurnEventSchema, {
-      id: `${turnId}-event-${events.length + 1}`,
-      turnId,
-      seq: BigInt(events.length + 1),
-      type,
-      source: "fixture-agent",
-      visibility: "private",
-      data,
-      createdAt: timestampNow(),
-    }),
-  );
+  const display = turnEventDisplay(type, data);
+  events.push({
+    id: `${turnId}-event-${events.length + 1}`,
+    turnId,
+    seq: BigInt(events.length + 1),
+    type,
+    source: "fixture-agent",
+    visibility: "private",
+    data,
+    ...(display !== undefined ? { display } : {}),
+    createdAt: timestampNow(),
+  });
   turnEvents.set(turnId, events);
+}
+
+function turnEventDisplay(
+  type: string,
+  data: JsonObject,
+): AgentTurnDisplayInit | undefined {
+  switch (type) {
+    case "turn.started":
+      return {
+        kind: "status",
+        phase: "started",
+        label: "turn",
+        text: "provider turn started",
+      };
+    case "interaction.requested":
+      return {
+        kind: "interaction",
+        phase: "requested",
+        label: "approval",
+        ref: stringField(data, "interactionId"),
+        input: data,
+      };
+    case "interaction.resolved":
+      return {
+        kind: "interaction",
+        phase: "resolved",
+        label: "approval",
+        ref: stringField(data, "interactionId"),
+        output: data,
+      };
+    case "assistant.completed":
+      return {
+        kind: "text",
+        phase: "completed",
+        text: "provider assistant completed",
+      };
+    case "turn.completed":
+      return {
+        kind: "status",
+        phase: "completed",
+        label: "turn",
+        text: "provider turn completed",
+        output: data,
+      };
+    case "turn.canceled":
+      return {
+        kind: "status",
+        phase: "canceled",
+        label: "turn",
+        text: stringField(data, "reason"),
+        error: data,
+      };
+    default:
+      return undefined;
+  }
+}
+
+function stringField(data: JsonObject, key: string): string {
+  const value = data[key];
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function requireSession(request: GetAgentProviderSessionRequest) {

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { create } from "@bufbuild/protobuf";
+import { create, toJson } from "@bufbuild/protobuf";
 import { EmptySchema } from "@bufbuild/protobuf/wkt";
 import { Code, ConnectError } from "@connectrpc/connect";
 import { expect, test } from "bun:test";
@@ -13,6 +13,7 @@ import {
   AgentInteractionType,
   AgentMessagePartType,
   AgentSessionState,
+  AgentTurnEventSchema,
   CancelAgentProviderTurnRequestSchema,
   CreateAgentProviderSessionRequestSchema,
   CreateAgentProviderTurnRequestSchema,
@@ -1644,6 +1645,31 @@ test("agent provider target resolves and serves runtime metadata plus agent oper
     "assistant.completed",
     "turn.completed",
   ]);
+  expect(listedEvents.events[0]?.display?.kind).toBe("status");
+  expect(listedEvents.events[0]?.display?.phase).toBe("started");
+  expect(listedEvents.events[0]?.display?.text).toBe("provider turn started");
+  expect(listedEvents.events[1]?.display?.kind).toBe("interaction");
+  expect(listedEvents.events[1]?.display?.phase).toBe("requested");
+  expect(listedEvents.events[1]?.display?.ref).toBe(fetchedInteraction.id);
+  expect(listedEvents.events[1]?.display?.input?.kind.case).toBe("structValue");
+  expect(
+    (toJson(AgentTurnEventSchema, listedEvents.events[1]) as any).display.input,
+  ).toEqual({ interactionId: fetchedInteraction.id });
+  expect(listedEvents.events[2]?.display?.kind).toBe("interaction");
+  expect(listedEvents.events[2]?.display?.phase).toBe("resolved");
+  expect(listedEvents.events[2]?.display?.output?.kind.case).toBe("structValue");
+  expect(
+    (toJson(AgentTurnEventSchema, listedEvents.events[2]) as any).display.output,
+  ).toEqual({ interactionId: fetchedInteraction.id });
+  expect(listedEvents.events[3]?.display?.kind).toBe("text");
+  expect(listedEvents.events[3]?.display?.text).toBe(
+    "provider assistant completed",
+  );
+  expect(listedEvents.events[4]?.display?.kind).toBe("status");
+  expect(listedEvents.events[4]?.display?.output?.kind.case).toBe("structValue");
+  expect(
+    (toJson(AgentTurnEventSchema, listedEvents.events[4]) as any).display.output,
+  ).toEqual({ interactionId: fetchedInteraction.id });
 
   const completedTurn = await (agent.createTurn as any)(
     create(CreateAgentProviderTurnRequestSchema, {
@@ -1710,6 +1736,26 @@ test("agent provider target resolves and serves runtime metadata plus agent oper
   );
   expect(canceledTurn.status).toBe(AgentExecutionStatus.CANCELED);
   expect(canceledTurn.statusMessage).toBe("user requested cancellation");
+  const canceledEvents = await (agent.listTurnEvents as any)(
+    create(ListAgentProviderTurnEventsRequestSchema, {
+      turnId: canceledTurn.id,
+      afterSeq: 0n,
+      limit: 10,
+    }),
+  );
+  const canceledEvent = canceledEvents.events.at(-1);
+  expect(canceledEvent).toBeDefined();
+  if (!canceledEvent) {
+    throw new Error("expected turn.canceled event");
+  }
+  expect(canceledEvent?.type).toBe("turn.canceled");
+  expect(canceledEvent?.display?.kind).toBe("status");
+  expect(canceledEvent?.display?.phase).toBe("canceled");
+  expect(canceledEvent?.display?.text).toBe("user requested cancellation");
+  expect(canceledEvent?.display?.error?.kind.case).toBe("structValue");
+  expect(
+    (toJson(AgentTurnEventSchema, canceledEvent) as any).display.error,
+  ).toEqual({ reason: "user requested cancellation" });
 
   const refreshedMetadata = await (runtime.getProviderIdentity as any)(
     create(EmptySchema, {}),


### PR DESCRIPTION
## Summary

Adopts provider-authored `AgentTurnDisplay` in the executable Go agent test plugin and the TypeScript agent-provider fixture. This exercises the existing display envelope from the provider boundary instead of relying only on server-side synthesis.

The patch is intentionally fixture/runtime scoped:
- Go executable agent provider now populates `AgentTurnEvent.Display` for turn, assistant, interaction, cancellation, and provider test events.
- TypeScript fixture provider now returns raw `AgentTurnEventInit` objects with plain JSON `display.input/output/error`, so `createAgentProviderService` must normalize those values into protobuf `Value`s.
- Existing integration/runtime tests now assert provider-authored scalar fields and structured display payloads survive the transport/conversion path.

## Interfaces

No new protocol fields are introduced. This PR uses the existing display envelope added in the prior protocol slice.

Rust/client event display envelope consumed by the CLI:

```rust
#[derive(Debug, Clone, Deserialize)]
#[serde(rename_all = "camelCase")]
struct AgentTurnDisplayInfo {
    #[serde(default)]
    kind: String,
    #[serde(default)]
    phase: String,
    #[serde(default)]
    text: String,
    #[serde(default)]
    label: String,
    #[serde(default, rename = "ref")]
    display_ref: String,
    #[serde(default)]
    parent_ref: String,
    #[serde(default)]
    input: Option<serde_json::Value>,
    #[serde(default)]
    output: Option<serde_json::Value>,
    #[serde(default)]
    error: Option<serde_json::Value>,
}
```

stdin/stdout JSON shape for streamed/listed turn events:

```json
{"type":"interaction.requested","display":{"kind":"interaction","phase":"requested","label":"approval","ref":"interaction-turn-1","input":{"interaction_id":"interaction-turn-1","session_id":"session-1"}}}
{"type":"turn.completed","display":{"kind":"status","phase":"completed","label":"turn","text":"provider turn completed","output":{"session_id":"session-1"}}}
{"type":"turn.canceled","display":{"kind":"status","phase":"canceled","label":"turn","text":"user requested cancellation","error":{"reason":"user requested cancellation"}}}
```

TypeScript fixture/provider usage:

```ts
return {
  id: "turn-1-event-2",
  turnId: "turn-1",
  seq: 2n,
  type: "interaction.requested",
  source: "fixture-agent",
  visibility: "private",
  data: { interactionId: "interaction-1" },
  display: {
    kind: "interaction",
    phase: "requested",
    label: "approval",
    ref: "interaction-1",
    input: { interactionId: "interaction-1" },
  },
};
```

Go executable provider usage:

```go
event := &proto.AgentTurnEvent{
    Type: "turn.completed",
    Data: payload,
    Display: &proto.AgentTurnDisplay{
        Kind: "status",
        Phase: "completed",
        Label: "turn",
        Text: "provider turn completed",
        Output: displayValue(data),
    },
}
```

## Verification

- `git diff --check`
- `go test ./internal/bootstrap -run TestAgentRuntimeConfigUsesDirectAgentHostBinding -count=1`
- `go test ./internal/providerhost ./internal/agentmanager ./internal/server -run 'Display|AgentTurnEvents|ListTurnEvents' -count=1`
- `bunx tsc --noEmit --pretty false`
- `bun test tests/runtime.test.ts`

## Review

Reviewed with separate agents:
- gpt-5.4 xhigh: suggested asserting structured display payload contents, not only protobuf `Value` cases.
- gpt-5.5 xhigh: caught the incorrect Rust field name in the examples and asked for cancellation/error-path coverage. Applied both pieces of feedback.
