### PR TITLE
Render agent event tables from display metadata

### DIFF
--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1613,7 +1613,7 @@ fn event_headers() -> [&'static str; 7] {
         "Visibility",
         "Turn",
         "Created",
-        "Data",
+        "Display",
     ]
 }
 
@@ -1640,6 +1640,8 @@ fn turn_row(value: &Value) -> Vec<String> {
 }
 
 fn turn_event_row(value: &Value) -> Vec<String> {
+    let display = turn_event_display_summary(value)
+        .unwrap_or_else(|| fallback_turn_event_data_summary(value));
     vec![
         value["seq"]
             .as_i64()
@@ -1650,6 +1652,177 @@ fn turn_event_row(value: &Value) -> Vec<String> {
         value["visibility"].as_str().unwrap_or("-").to_string(),
         value["turnId"].as_str().unwrap_or("-").to_string(),
         value["createdAt"].as_str().unwrap_or("-").to_string(),
-        serde_json::to_string(&value["data"]).unwrap_or_else(|_| "-".to_string()),
+        display,
     ]
+}
+
+fn fallback_turn_event_data_summary(value: &Value) -> String {
+    if let Ok(event) = serde_json::from_value::<AgentTurnEventInfo>(value.clone()) {
+        if let Some(summary) = turn_event_data_summary(&event) {
+            return summary;
+        }
+        if event.visibility == "private" {
+            return String::new();
+        }
+    } else if value["visibility"].as_str() == Some("private") {
+        return String::new();
+    }
+    serde_json::to_string(&value["data"]).unwrap_or_else(|_| "-".to_string())
+}
+
+fn turn_event_data_summary(event: &AgentTurnEventInfo) -> Option<String> {
+    match event.event_type.as_str() {
+        "agent.message.delta" | "assistant.delta" => {
+            string_any_field(&event.data, &["text", "delta", "content"])
+                .map(|text| format!("assistant delta: {text}"))
+        }
+        "assistant.completed" => {
+            string_field(&event.data, "text").map(|text| format!("assistant completed: {text}"))
+        }
+        "turn.started" => string_any_field(&event.data, &["status", "state"])
+            .map(|status| format!("turn started: {status}"))
+            .or_else(|| Some("turn started".to_string())),
+        "turn.completed" => string_any_field(&event.data, &["status", "state"])
+            .map(|status| format!("turn completed: {status}"))
+            .or_else(|| Some("turn completed".to_string())),
+        "turn.failed" => string_field(&event.data, "error")
+            .map(|error| format!("turn failed: {error}"))
+            .or_else(|| Some("turn failed".to_string())),
+        "turn.canceled" => string_field(&event.data, "reason")
+            .map(|reason| format!("turn canceled: {reason}"))
+            .or_else(|| Some("turn canceled".to_string())),
+        "tool.started" => Some(tool_data_summary(event, "started")?),
+        "tool.completed" => Some(tool_data_summary(event, "completed")?),
+        "tool.failed" => Some(tool_data_summary(event, "failed")?),
+        "interaction.requested" => {
+            let id = string_any_field(&event.data, &["interaction_id", "interactionId"])
+                .unwrap_or_else(|| "interaction".to_string());
+            Some(format!("interaction requested ({id})"))
+        }
+        "interaction.resolved" => {
+            let id = string_any_field(&event.data, &["interaction_id", "interactionId"])
+                .unwrap_or_else(|| "interaction".to_string());
+            Some(format!("interaction resolved ({id})"))
+        }
+        _ => None,
+    }
+}
+
+fn tool_data_summary(event: &AgentTurnEventInfo, phase: &str) -> Option<String> {
+    let tool = string_any_field(
+        &event.data,
+        &[
+            "tool_name",
+            "toolName",
+            "name",
+            "operation",
+            "tool_id",
+            "toolId",
+        ],
+    )
+    .unwrap_or_else(|| "tool".to_string());
+    let mut summary = format!("{tool} {phase}");
+    if let Some(status) = string_any_field(&event.data, &["status", "state"]).or_else(|| {
+        number_any_field(&event.data, &["status", "statusCode"]).map(|status| status.to_string())
+    }) {
+        summary.push_str(&format!(" ({status})"));
+    }
+    if let Some(error) = string_field(&event.data, "error") {
+        summary.push_str(&format!(": {error}"));
+    } else if let Some(output) = value_any_field(&event.data, &["output", "result", "body"]) {
+        summary.push(' ');
+        summary.push_str(&compact_json(output).ok()?);
+    } else if let Some(input) = value_any_field(&event.data, &["arguments", "input", "request"]) {
+        summary.push(' ');
+        summary.push_str(&compact_json(input).ok()?);
+    }
+    Some(summary)
+}
+
+fn turn_event_display_summary(value: &Value) -> Option<String> {
+    let event: AgentTurnEventInfo = serde_json::from_value(value.clone()).ok()?;
+    let display = turn_event_display(&event)?;
+    match display.kind.trim() {
+        "text" => display_text(display).map(|text| match display.phase.trim() {
+            "delta" => format!("assistant delta: {text}"),
+            "completed" => format!("assistant completed: {text}"),
+            phase if !phase.is_empty() => format!("assistant {phase}: {text}"),
+            _ => format!("assistant: {text}"),
+        }),
+        "reasoning" => display_text(display).map(|text| format!("reasoning: {text}")),
+        "tool" => Some(tool_display_summary(&event, display)?),
+        "interaction" => {
+            let label = display_label(display).unwrap_or("interaction");
+            let reference = display_ref(display).unwrap_or(label);
+            match display.phase.trim() {
+                "requested" => Some(format!("{label} requested ({reference})")),
+                "resolved" => Some(format!("{label} resolved ({reference})")),
+                phase if !phase.is_empty() => Some(format!("{label} {phase} ({reference})")),
+                _ => Some(label.to_string()),
+            }
+        }
+        "status" => {
+            let label = display_label(display).unwrap_or("turn");
+            match (display.phase.trim(), display_text(display)) {
+                ("started", Some(text)) => Some(format!("{label} started: {text}")),
+                ("started", None) => Some(format!("{label} started")),
+                ("completed", Some(text)) => Some(format!("{label} completed: {text}")),
+                ("completed", None) => Some(format!("{label} completed")),
+                ("canceled", Some(text)) => Some(format!("{label} canceled: {text}")),
+                ("canceled", None) => Some(format!("{label} canceled")),
+                ("progress", Some(text)) => Some(format!("{label}: {text}")),
+                (phase, Some(text)) if !phase.is_empty() => {
+                    Some(format!("{label} {phase}: {text}"))
+                }
+                _ => None,
+            }
+        }
+        "error" => {
+            let text = display_text(display).map(ToString::to_string).or_else(|| {
+                display
+                    .error
+                    .as_ref()
+                    .and_then(|value| display_value_text(value).ok())
+            })?;
+            let label = display_label(display).unwrap_or("error");
+            match display.phase.trim() {
+                "failed" if label == "turn" => Some(format!("turn failed: {text}")),
+                "failed" => Some(format!("{label} failed: {text}")),
+                _ => Some(format!("{label}: {text}")),
+            }
+        }
+        _ => None,
+    }
+}
+
+fn tool_display_summary(
+    event: &AgentTurnEventInfo,
+    display: &AgentTurnDisplayInfo,
+) -> Option<String> {
+    let tool = display_tool_label(event, display);
+    let mut summary = match display.phase.trim() {
+        "started" => format!("{tool} started"),
+        "completed" => format!("{tool} completed"),
+        "failed" => format!("{tool} failed"),
+        "progress" => display_text(display)
+            .map(|text| format!("{tool} {text}"))
+            .unwrap_or_else(|| format!("{tool} progress")),
+        phase if !phase.is_empty() => format!("{tool} {phase}"),
+        _ => tool,
+    };
+    if matches!(display.phase.trim(), "completed" | "failed")
+        && let Some(status) = display_status(event, display)
+    {
+        summary.push_str(&format!(" ({status})"));
+    }
+    if let Some(error) = display_tool_error(event, display) {
+        summary.push_str(&format!(": {}", display_value_text(error).ok()?));
+    } else if let Some(output) = display_tool_output(event, display) {
+        summary.push(' ');
+        summary.push_str(&compact_json(output).ok()?);
+    } else if let Some(input) = display_tool_input(event, display) {
+        summary.push(' ');
+        summary.push_str(&compact_json(input).ok()?);
+    }
+    Some(summary)
 }

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -41,6 +41,7 @@ const TURN_EVENTS_JSON: &str = r#"[
         "source":"managed",
         "visibility":"public",
         "data":{"status":"running"},
+        "display":{"kind":"status","phase":"started","label":"turn","text":"running"},
         "createdAt":"2026-04-22T00:00:01Z"
     },
     {
@@ -51,7 +52,63 @@ const TURN_EVENTS_JSON: &str = r#"[
         "source":"managed",
         "visibility":"public",
         "data":{"text":"risk is dependency churn"},
+        "display":{"kind":"text","phase":"delta","text":"risk is dependency churn"},
         "createdAt":"2026-04-22T00:00:02Z"
+    },
+    {
+        "id":"evt-3",
+        "turnId":"turn-1",
+        "seq":3,
+        "type":"tool.completed",
+        "source":"managed",
+        "visibility":"public",
+        "data":{"output":{"secret":"RAW_OUTPUT_SENTINEL"}},
+        "display":{"kind":"tool","phase":"completed","label":"lookup","ref":"call-lookup","text":"200","output":{"ok":true}},
+        "createdAt":"2026-04-22T00:00:03Z"
+    },
+    {
+        "id":"evt-4",
+        "turnId":"turn-1",
+        "seq":4,
+        "type":"turn.failed",
+        "source":"managed",
+        "visibility":"public",
+        "data":{"error":"fallback failure"},
+        "display":{"kind":"error","phase":"failed","label":"turn","error":"display failure"},
+        "createdAt":"2026-04-22T00:00:04Z"
+    },
+    {
+        "id":"evt-5",
+        "turnId":"turn-1",
+        "seq":5,
+        "type":"turn.failed",
+        "source":"managed",
+        "visibility":"public",
+        "data":{"debug":"RAW_FAILED_SENTINEL"},
+        "display":{"kind":123,"text":"bad failure display"},
+        "createdAt":"2026-04-22T00:00:05Z"
+    },
+    {
+        "id":"evt-6",
+        "turnId":"turn-1",
+        "seq":6,
+        "type":"provider.secret",
+        "source":"managed",
+        "visibility":"private",
+        "data":{"secret":"RAW_PRIVATE_SENTINEL"},
+        "display":{"kind":123,"text":"hidden"},
+        "createdAt":"2026-04-22T00:00:06Z"
+    },
+    {
+        "id":"evt-7",
+        "turnId":"turn-1",
+        "seq":7,
+        "type":"assistant.completed",
+        "source":"managed",
+        "visibility":"private",
+        "data":{"text":"private known fallback"},
+        "display":{"kind":123,"text":"bad display"},
+        "createdAt":"2026-04-22T00:00:07Z"
     }
 ]"#;
 
@@ -284,6 +341,48 @@ fn test_cli_lists_agent_turn_events() {
         .success()
         .stdout(predicate::str::contains("agent.message.delta"))
         .stdout(predicate::str::contains("risk is dependency churn"));
+}
+
+#[test]
+fn test_cli_lists_agent_turn_events_table_uses_display_summary() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/agent/turns/turn-1/events?after=0&limit=10",
+        StatusCode::OK
+    )
+    .with_body(TURN_EVENTS_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "agent", "turns", "events", "list", "turn-1", "--after", "0", "--limit", "10",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Display"))
+        .stdout(predicate::str::contains("started:"))
+        .stdout(predicate::str::contains("running"))
+        .stdout(predicate::str::contains("assistant"))
+        .stdout(predicate::str::contains("dependency"))
+        .stdout(predicate::str::contains("lookup"))
+        .stdout(predicate::str::contains("completed"))
+        .stdout(predicate::str::contains(r#"{"ok"#))
+        .stdout(predicate::str::contains("failed:"))
+        .stdout(predicate::str::contains("display"))
+        .stdout(predicate::str::contains("failure"))
+        .stdout(predicate::str::contains("turn.failed"))
+        .stdout(predicate::str::contains("private"))
+        .stdout(predicate::str::contains("known"))
+        .stdout(predicate::str::contains("fallback"))
+        .stdout(predicate::str::contains("RAW_OUTPUT_SENTINEL").not())
+        .stdout(predicate::str::contains("RAW_FAILED_SENTINEL").not())
+        .stdout(predicate::str::contains("RAW_PRIVATE_SENTINEL").not())
+        .stdout(predicate::str::contains("bad display").not())
+        .stdout(predicate::str::contains("bad failure display").not())
+        .stdout(predicate::str::contains("fallback failure").not());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Updates `agent turns events list` table output to render a display-oriented summary column instead of dumping raw `data` by default.

Behavior:
- If `display` is present and valid, the table derives a compact summary from `kind`, `phase`, labels, refs, text, and display-safe input/output/error fields.
- If `display` is missing or malformed, known event types fall back to typed event summaries, matching the interactive renderer’s behavior.
- Private unknown events render an empty summary rather than raw payload data.
- `turn.failed` always gets a typed fallback summary, even if `data.error` is absent.

## Interfaces

No protocol fields are added. This PR consumes the existing display envelope.

Rust/client display envelope used by table rendering:

```rust
#[derive(Debug, Clone, Deserialize)]
#[serde(rename_all = "camelCase")]
struct AgentTurnDisplayInfo {
    #[serde(default)]
    kind: String,
    #[serde(default)]
    phase: String,
    #[serde(default)]
    text: String,
    #[serde(default)]
    label: String,
    #[serde(default, rename = "ref")]
    display_ref: String,
    #[serde(default)]
    parent_ref: String,
    #[serde(default)]
    input: Option<serde_json::Value>,
    #[serde(default)]
    output: Option<serde_json::Value>,
    #[serde(default)]
    error: Option<serde_json::Value>,
}
```

stdin/stdout JSON event shapes rendered by `agent turns events list`:

```json
{"seq":1,"type":"tool.completed","visibility":"public","data":{"output":{"secret":"RAW_OUTPUT_SENTINEL"}},"display":{"kind":"tool","phase":"completed","label":"lookup","ref":"call-lookup","text":"200","output":{"ok":true}}}
{"seq":2,"type":"turn.failed","visibility":"public","display":{"kind":"error","phase":"failed","label":"turn","error":"display failure"}}
{"seq":3,"type":"provider.secret","visibility":"private","data":{"secret":"RAW_PRIVATE_SENTINEL"},"display":{"kind":123,"text":"hidden"}}
```

Example table summaries:

```text
lookup completed (200) {"ok":true}
turn failed: display failure
turn failed
<empty display cell for private unknown event>
```

## Verification

- `cargo test test_cli_lists_agent_turn_events --test agents_cli`
- `cargo test --test agents_cli`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

## Review

Reviewed with separate agents:
- gpt-5.4 xhigh caught private raw-data fallback and failed-error phrasing. Applied both fixes.
- gpt-5.4 xhigh follow-up caught known private event fallback consistency. Applied that fix.
- Cursor Bugbot caught `turn.failed` without `data.error` falling through to raw JSON. Applied that fix.
- gpt-5.5 xhigh final review found no issues after the Cursor fix.
