### PR TITLE
Render stored agent turn transcripts

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -218,6 +218,7 @@ gestalt agent turns create <session-id> \
   --tool roadmap:sync
 gestalt agent turns list <session-id> --status succeeded
 gestalt agent turns get <turn-id>
+gestalt agent turns transcript <turn-id>
 gestalt agent turns cancel <turn-id> --reason "operator requested"
 gestalt agent turns events list <turn-id> --after 0 --limit 100
 gestalt agent turns events stream <turn-id> --after 100
@@ -260,11 +261,15 @@ with `\` to continue the same user message on the next prompt.
 
 `gestalt agent turns create` is the non-interactive equivalent. It supports
 repeated `--system`, repeated `--message`, repeated `--tool plugin:operation`,
-`--idempotency-key`, and `--input`. `gestalt agent turns events list` reads
-stored events from `GET /api/v1/agent/turns/{turnID}/events`. `--after` is an
-event sequence cursor and `--limit` controls the page size. `gestalt agent
-turns events stream` reads `GET /api/v1/agent/turns/{turnID}/events/stream`
-and writes the raw server-sent event stream to stdout.
+`--idempotency-key`, and `--input`. `gestalt agent turns transcript` renders a
+stored turn by combining the turn's messages from
+`GET /api/v1/agent/turns/{turnID}` with stored display-projected events from
+`GET /api/v1/agent/turns/{turnID}/events`. `gestalt agent turns events list`
+reads stored events from `GET /api/v1/agent/turns/{turnID}/events`. `--after`
+is an event sequence cursor and `--limit` controls the page size. `gestalt
+agent turns events stream` reads
+`GET /api/v1/agent/turns/{turnID}/events/stream` and writes the raw
+server-sent event stream to stdout.
 
 Interactive sessions use `GET /api/v1/agent/turns/{turnID}/events/stream`
 with `until=blocked_or_terminal`, which lets the CLI switch immediately from

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -400,6 +400,11 @@ pub enum AgentTurnCommands {
         /// Turn ID
         id: String,
     },
+    /// Render a stored turn as a transcript
+    Transcript {
+        /// Turn ID
+        id: String,
+    },
     /// Cancel an agent turn
     Cancel {
         /// Turn ID

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -108,6 +108,28 @@ pub fn get_turn(client: &ApiClient, id: &str, format: Format) -> Result<()> {
     Ok(())
 }
 
+pub fn transcript_turn(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let turn = client
+        .get(&format!("{TURNS_PATH}/{id}"))
+        .with_context(|| format!("failed to get agent turn {id}"))?;
+    let event_values = list_turn_event_values(client, id)?;
+    match format {
+        Format::Json => output::print_json(&json!({
+            "turn": turn,
+            "events": event_values,
+        })),
+        Format::Table => {
+            let turn = decode_json::<AgentTurnInfo>(turn)?;
+            let events: Vec<AgentTurnEventInfo> = event_values
+                .into_iter()
+                .map(decode_json)
+                .collect::<Result<_>>()?;
+            render_turn_transcript(&turn, &events)?;
+        }
+    }
+    Ok(())
+}
+
 pub fn cancel_turn(
     client: &ApiClient,
     id: &str,
@@ -221,6 +243,8 @@ struct AgentSessionInfo {
 struct AgentTurnInfo {
     id: String,
     #[serde(default)]
+    messages: Vec<AgentMessageInfo>,
+    #[serde(default)]
     status: String,
     #[serde(default)]
     output_text: String,
@@ -228,6 +252,32 @@ struct AgentTurnInfo {
     structured_output: Option<Value>,
     #[serde(default)]
     status_message: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentMessageInfo {
+    #[serde(default)]
+    role: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    parts: Vec<AgentMessagePartInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentMessagePartInfo {
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    json: Option<Value>,
+    #[serde(default)]
+    tool_call: Option<Value>,
+    #[serde(default)]
+    tool_result: Option<Value>,
+    #[serde(default)]
+    image_ref: Option<Value>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -515,6 +565,20 @@ impl AgentTurnRenderer {
 
     fn after_seq(&self) -> u64 {
         self.after_seq
+    }
+
+    fn render_messages(&mut self, messages: &[AgentMessageInfo]) -> Result<()> {
+        self.finish_assistant_line();
+        for message in messages {
+            let Some(label) = message_label(message) else {
+                continue;
+            };
+            let Some(text) = message_text(message) else {
+                continue;
+            };
+            println!("{} {text}", self.label(&label));
+        }
+        Ok(())
     }
 
     fn render_events(&mut self, events: &[AgentTurnEventInfo]) -> Result<()> {
@@ -1224,6 +1288,45 @@ fn resolve_interaction_info(
     )
 }
 
+fn list_turn_event_values(client: &ApiClient, turn_id: &str) -> Result<Vec<Value>> {
+    let mut events = Vec::new();
+    let mut after_seq = 0u64;
+    loop {
+        let page: Vec<Value> = decode_json(
+            client
+                .get(&turn_events_path(
+                    turn_id,
+                    false,
+                    Some(after_seq),
+                    Some(DEFAULT_EVENT_PAGE_SIZE),
+                    None,
+                ))
+                .with_context(|| format!("failed to list events for agent turn {turn_id}"))?,
+        )?;
+        if page.is_empty() {
+            return Ok(events);
+        }
+
+        let next_after_seq = page
+            .iter()
+            .filter_map(|event| event.get("seq").and_then(Value::as_u64))
+            .max()
+            .unwrap_or(after_seq);
+        events.extend(page);
+        if next_after_seq <= after_seq {
+            return Ok(events);
+        }
+        after_seq = next_after_seq;
+    }
+}
+
+fn render_turn_transcript(turn: &AgentTurnInfo, events: &[AgentTurnEventInfo]) -> Result<()> {
+    let mut renderer = AgentTurnRenderer::new();
+    renderer.render_messages(&turn.messages)?;
+    renderer.render_events(events)?;
+    renderer.finish_turn(turn)
+}
+
 fn decode_json<T>(value: Value) -> Result<T>
 where
     T: DeserializeOwned,
@@ -1293,6 +1396,55 @@ fn known_turn_event_type(event_type: &str) -> bool {
             | "interaction.requested"
             | "interaction.resolved"
     )
+}
+
+fn message_label(message: &AgentMessageInfo) -> Option<String> {
+    let role = non_empty_str(&message.role)?;
+    Some(match role {
+        "user" => "you>".to_string(),
+        "system" => "system>".to_string(),
+        "assistant" => "assistant>".to_string(),
+        "tool" => "tool>".to_string(),
+        other => format!("{other}>"),
+    })
+}
+
+fn message_text(message: &AgentMessageInfo) -> Option<String> {
+    if !message.text.is_empty() {
+        return Some(message.text.clone());
+    }
+    let text = message
+        .parts
+        .iter()
+        .filter_map(message_part_text)
+        .collect::<Vec<_>>()
+        .join("");
+    if text.is_empty() { None } else { Some(text) }
+}
+
+fn message_part_text(part: &AgentMessagePartInfo) -> Option<String> {
+    if !part.text.trim().is_empty() {
+        return Some(part.text.clone());
+    }
+    if let Some(json) = part.json.as_ref() {
+        return compact_json(json).ok();
+    }
+    if let Some(tool_call) = part.tool_call.as_ref() {
+        return compact_json(tool_call)
+            .ok()
+            .map(|value| format!("tool call {value}"));
+    }
+    if let Some(tool_result) = part.tool_result.as_ref() {
+        return compact_json(tool_result)
+            .ok()
+            .map(|value| format!("tool result {value}"));
+    }
+    if let Some(image_ref) = part.image_ref.as_ref() {
+        return compact_json(image_ref)
+            .ok()
+            .map(|value| format!("image {value}"));
+    }
+    None
 }
 
 fn display_text(display: &AgentTurnDisplayInfo) -> Option<&str> {

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -191,6 +191,9 @@ fn dispatch_agent_command(
                 commands::agents::list_turns(client, &session_id, status.as_deref(), format)
             }
             AgentTurnCommands::Get { id } => commands::agents::get_turn(client, &id, format),
+            AgentTurnCommands::Transcript { id } => {
+                commands::agents::transcript_turn(client, &id, format)
+            }
             AgentTurnCommands::Cancel { id, reason } => {
                 commands::agents::cancel_turn(client, &id, reason.as_deref(), format)
             }

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -112,6 +112,87 @@ const TURN_EVENTS_JSON: &str = r#"[
     }
 ]"#;
 
+const TURN_TRANSCRIPT_JSON: &str = r#"{
+    "id":"turn-1",
+    "sessionId":"session-1",
+    "provider":"managed",
+    "model":"gpt-5.4",
+    "status":"succeeded",
+    "messages":[
+        {"role":"system","text":"Be concise."},
+        {"role":"user","text":"Summarize the roadmap risk."},
+        {"role":"user","parts":[
+            {"text":"Include filter "},
+            {"json":{"priority":"high"}}
+        ]}
+    ],
+    "outputText":"historical answer",
+    "structuredOutput":{"summary":"done"},
+    "createdAt":"2026-04-22T00:00:00Z",
+    "executionRef":"turn-1"
+}"#;
+
+const TURN_TRANSCRIPT_EVENTS_PAGE_1_JSON: &str = r#"[
+    {
+        "id":"evt-t1",
+        "turnId":"turn-1",
+        "seq":1,
+        "type":"provider.tool",
+        "source":"managed",
+        "visibility":"public",
+        "data":{"arguments":{"secret":"RAW_TRANSCRIPT_INPUT"}},
+        "display":{"kind":"tool","phase":"started","label":"lookup","ref":"call-lookup","input":{"ticket":"INC-42"}},
+        "createdAt":"2026-04-22T00:00:01Z"
+    },
+    {
+        "id":"evt-t2",
+        "turnId":"turn-1",
+        "seq":2,
+        "type":"provider.tool",
+        "source":"managed",
+        "visibility":"public",
+        "data":{"output":{"secret":"RAW_TRANSCRIPT_OUTPUT"}},
+        "display":{"kind":"tool","phase":"completed","label":"lookup","ref":"call-lookup","text":"200","output":{"ok":true}},
+        "createdAt":"2026-04-22T00:00:02Z"
+    }
+]"#;
+
+const TURN_TRANSCRIPT_EVENTS_PAGE_2_JSON: &str = r#"[
+    {
+        "id":"evt-t3",
+        "turnId":"turn-1",
+        "seq":3,
+        "type":"provider.text",
+        "source":"managed",
+        "visibility":"public",
+        "data":{"text":"RAW_TRANSCRIPT_TEXT"},
+        "display":{"kind":"text","phase":"completed","text":"historical answer"},
+        "createdAt":"2026-04-22T00:00:03Z"
+    },
+    {
+        "id":"evt-t4",
+        "turnId":"turn-1",
+        "seq":4,
+        "type":"provider.secret",
+        "source":"managed",
+        "visibility":"private",
+        "data":{"secret":"RAW_TRANSCRIPT_PRIVATE"},
+        "display":{"kind":"error","phase":"failed","text":"hidden private display"},
+        "createdAt":"2026-04-22T00:00:04Z"
+    },
+    {
+        "id":"evt-t5",
+        "turnId":"turn-1",
+        "seq":5,
+        "type":"turn.completed",
+        "source":"managed",
+        "visibility":"public",
+        "data":{"status":"succeeded"},
+        "display":{"kind":"status","phase":"completed","text":"done"},
+        "createdAt":"2026-04-22T00:00:05Z"
+    }
+]"#;
+
 #[test]
 fn test_cli_creates_agent_session() {
     let mut server = Server::new();
@@ -383,6 +464,69 @@ fn test_cli_lists_agent_turn_events_table_uses_display_summary() {
         .stdout(predicate::str::contains("bad display").not())
         .stdout(predicate::str::contains("bad failure display").not())
         .stdout(predicate::str::contains("fallback failure").not());
+}
+
+#[test]
+fn test_cli_renders_agent_turn_transcript_from_display_events() {
+    let mut server = Server::new();
+    let _turn = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/agent/turns/turn-1",
+        StatusCode::OK
+    )
+    .with_body(TURN_TRANSCRIPT_JSON)
+    .create();
+    let _events = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/agent/turns/turn-1/events?after=0&limit=100",
+        StatusCode::OK
+    )
+    .with_body(TURN_TRANSCRIPT_EVENTS_PAGE_1_JSON)
+    .create();
+    let _events_page_2 = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/agent/turns/turn-1/events?after=2&limit=100",
+        StatusCode::OK
+    )
+    .with_body(TURN_TRANSCRIPT_EVENTS_PAGE_2_JSON)
+    .create();
+    let _events_done = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/agent/turns/turn-1/events?after=5&limit=100",
+        StatusCode::OK
+    )
+    .with_body("[]")
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["agent", "turns", "transcript", "turn-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("system> Be concise."))
+        .stdout(predicate::str::contains("you> Summarize the roadmap risk."))
+        .stdout(predicate::str::contains(
+            r#"you> Include filter {"priority":"high"}"#,
+        ))
+        .stdout(predicate::str::contains(
+            r#"tool> lookup started {"ticket":"INC-42"}"#,
+        ))
+        .stdout(predicate::str::contains(
+            r#"tool> lookup completed (200) {"ok":true}"#,
+        ))
+        .stdout(predicate::str::contains("assistant> historical answer"))
+        .stdout(predicate::str::contains("turn> completed (done)"))
+        .stdout(predicate::str::contains("structured>"))
+        .stdout(predicate::str::contains(r#""summary": "done""#))
+        .stdout(predicate::str::contains("RAW_TRANSCRIPT_INPUT").not())
+        .stdout(predicate::str::contains("RAW_TRANSCRIPT_OUTPUT").not())
+        .stdout(predicate::str::contains("RAW_TRANSCRIPT_TEXT").not())
+        .stdout(predicate::str::contains("RAW_TRANSCRIPT_PRIVATE").not())
+        .stdout(predicate::str::contains("hidden private display").not());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a historical transcript view for stored agent turns:

- Adds `gestalt agent turns transcript <turn-id>`.
- Fetches `GET /api/v1/agent/turns/{turnID}` for turn messages and final output metadata.
- Fetches stored turn events from `GET /api/v1/agent/turns/{turnID}/events?after=<seq>&limit=100` until the event page is exhausted.
- Reuses the display-aware agent turn renderer, so provider-authored `display` metadata drives tool/status/interaction/assistant rendering and raw/private sentinels do not leak into the transcript.
- Documents the new CLI command.

## Interfaces

### Rust

```rust
pub enum AgentTurnCommands {
    Get { id: String },
    Transcript { id: String },
    Cancel { id: String, reason: Option<String> },
    Events { command: AgentTurnEventCommands },
}

pub fn transcript_turn(client: &ApiClient, id: &str, format: Format) -> Result<()>;
```

`transcript_turn` reads the existing HTTP contract:

```text
GET /api/v1/agent/turns/{turnID}
GET /api/v1/agent/turns/{turnID}/events?after=0&limit=100
GET /api/v1/agent/turns/{turnID}/events?after=<lastSeq>&limit=100
```

No new server endpoint or provider primitive is added.

### stdin/stdout

Human transcript rendering:

```sh
gestalt agent turns transcript turn-123
```

Example output:

```text
system> Be concise.
you> Summarize the roadmap risk.
tool> lookup started {"ticket":"INC-42"}
tool> lookup completed (200) {"ok":true}
assistant> historical answer
turn> completed (done)
structured> {
  "summary": "done"
}
```

Raw transport envelope for scripts:

```sh
gestalt --format json agent turns transcript turn-123
```

Example JSON shape:

```json
{
  "turn": {
    "id": "turn-123",
    "messages": [
      {"role": "user", "text": "Summarize the roadmap risk."}
    ],
    "status": "succeeded",
    "outputText": "historical answer"
  },
  "events": [
    {
      "seq": 1,
      "type": "provider.tool",
      "display": {
        "kind": "tool",
        "phase": "completed",
        "label": "lookup",
        "output": {"ok": true}
      }
    }
  ]
}
```

## Verification

- `cargo fmt --check`
- `cargo test test_cli_renders_agent_turn_transcript_from_display_events --test agents_cli`
- `cargo test --test agents_cli`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- `npm run build` in `docs/` after `npm ci` (build passes; Nextra reports existing Git timestamp warnings in this worktree)
