### PR TITLE
providerpkg: avoid manifest kind races

### DIFF
--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -74,6 +74,11 @@ func decodeManifest(data []byte, format string, sourceMode bool) (*providermanif
 	if err := validateManifest(&manifest, sourceMode); err != nil {
 		return nil, err
 	}
+	kind, err := ManifestKind(&manifest)
+	if err != nil {
+		return nil, err
+	}
+	manifest.Kind = kind
 	return &manifest, nil
 }
 
@@ -103,7 +108,6 @@ func ManifestKind(manifest *providermanifestv1.Manifest) (string, error) {
 	if !validManifestKinds[manifest.Kind] && !validManifestKinds[kind] {
 		return "", fmt.Errorf("manifest kind %q is not valid; expected one of plugin, authentication, authorization, external_credentials, indexeddb, cache, s3, workflow, agent, secrets, runtime, or ui", manifest.Kind)
 	}
-	manifest.Kind = kind
 	return kind, nil
 }
 


### PR DESCRIPTION
## Summary

Fix the race-detector failure on current `main` by making provider manifest kind normalization happen at the decode ownership boundary instead of inside `ManifestKind` / validation paths used by manifest comparison.

## Old Interface

```go
kind, err := providerpkg.ManifestKind(manifest)
// Returned the normalized kind and also wrote manifest.Kind = kind.
```

`EncodeManifest` and `ManifestEqual` call validation before encoding, so the old `ManifestKind` mutation could race when multiple tests compared or encoded a shared manifest pointer.

## New Interface

```go
kind, err := providerpkg.ManifestKind(manifest)
// Returns the normalized kind without mutating manifest.Kind.
```

Decoded manifests are still normalized at the ownership boundary:

```go
var manifest providermanifestv1.Manifest
// decodeStrict fills manifest
if err := validateManifest(&manifest, sourceMode); err != nil {
    return nil, err
}
kind, err := ManifestKind(&manifest)
if err != nil {
    return nil, err
}
manifest.Kind = kind
```

Example:

```go
manifest.Kind = "externalCredentials"
kind, _ := providerpkg.ManifestKind(manifest) // "external_credentials"
// manifest.Kind is unchanged for ManifestKind callers and encode/compare validation.

decoded, _ := providerpkg.DecodeManifestFormat(data, providerpkg.ManifestFormatYAML)
// decoded.Kind is normalized because decodeManifest owns the fresh decoded value.
```

## Why This Improves Things

- Removes the data race reported by `go test -race ./...` in `internal/providerpkg`.
- Keeps source/release manifest loading behavior normalized.
- Stops `ManifestEqual` / `EncodeManifest` from racing specifically on `manifest.Kind` for shared manifest pointers.
- Lets toolshed safely bump `GESTALT_REF` to a current green main SHA after this merges.

Note: this PR only removes the `manifest.Kind` mutation from compare/encode validation. It does not claim every validation path is completely read-only; some nested manifest fields are still normalized elsewhere by existing validation code.

## Verification

```text
go test -race -run TestLoadManifestFromPath_DirectoryManifestFileAndArchive -count=100 ./internal/providerpkg
go test ./internal/providerpkg
go test -race ./internal/providerpkg
git diff --check HEAD~1..HEAD
```
