### PR TITLE
workflow: inherit agent tool invokes

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1020,6 +1020,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Authorizer:        authz,
 		DefaultConnection: connMaps.DefaultConnection,
 		CatalogConnection: connMaps.APIConnection,
+		PluginInvokes:     agentPluginInvokes(cfg),
 	}))
 	agentManager.SetTarget(agentmanager.New(agentmanager.Config{
 		Providers:         providers,

--- a/gestaltd/internal/bootstrap/execution_principal.go
+++ b/gestaltd/internal/bootstrap/execution_principal.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
@@ -16,26 +15,6 @@ func executionReferencePrincipal(subjectID, credentialSubjectID string, permissi
 		Scopes:              principal.PermissionPlugins(compiled),
 		TokenPermissions:    compiled,
 	}
-	if value.CredentialSubjectID == "" && principal.IsSystemSubjectID(value.SubjectID) {
-		value.CredentialSubjectID = value.SubjectID
-	}
-	return principal.Canonicalize(value)
-}
-
-func workflowExecutionReferencePrincipal(ref *coreworkflow.ExecutionReference) *principal.Principal {
-	if ref == nil {
-		return nil
-	}
-	compiled := principal.CompilePermissions(ref.Permissions)
-	value := &principal.Principal{
-		SubjectID:           strings.TrimSpace(ref.SubjectID),
-		CredentialSubjectID: strings.TrimSpace(ref.CredentialSubjectID),
-		DisplayName:         strings.TrimSpace(ref.DisplayName),
-		Kind:                principal.Kind(strings.TrimSpace(ref.SubjectKind)),
-		Scopes:              principal.PermissionPlugins(compiled),
-		TokenPermissions:    compiled,
-	}
-	principal.SetAuthSource(value, ref.AuthSource)
 	if value.CredentialSubjectID == "" && principal.IsSystemSubjectID(value.SubjectID) {
 		value.CredentialSubjectID = value.SubjectID
 	}

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -19,6 +19,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/workflowprincipal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -221,7 +222,7 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 		if err != nil {
 			return nil, err
 		}
-		principalValue = workflowExecutionReferencePrincipal(resolvedRef)
+		principalValue = workflowprincipal.FromExecutionReference(resolvedRef)
 		target = resolvedRef.Target
 		if target.Plugin != nil {
 			invokeConnection = strings.TrimSpace(target.Plugin.Connection)
@@ -330,7 +331,7 @@ func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.Invo
 		if err != nil {
 			return nil, err
 		}
-		principalValue = workflowExecutionReferencePrincipal(resolvedRef)
+		principalValue = workflowprincipal.FromExecutionReference(resolvedRef)
 		target = resolvedRef.Target
 		callerPluginName = strings.TrimSpace(resolvedRef.CallerPluginName)
 	} else if principalValue == nil || strings.TrimSpace(principalValue.SubjectID) == "" {

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
+	"github.com/valon-technologies/gestalt/server/internal/workflowprincipal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -39,6 +40,13 @@ const workflowScheduleExecutionRefBasePrefix = "workflow_schedule:"
 const workflowEventTriggerExecutionRefBasePrefix = "workflow_event_trigger:"
 const workflowRunExecutionRefBasePrefix = "workflow_run:"
 const defaultWorkflowEventSpecVersion = "1.0"
+
+type signalTargetPrincipalSource uint8
+
+const (
+	signalTargetPrincipalCaller signalTargetPrincipalSource = iota
+	signalTargetPrincipalExecutionRef
+)
 
 type WorkflowControl interface {
 	ResolveProvider(name string) (coreworkflow.Provider, error)
@@ -83,6 +91,7 @@ type Config struct {
 	Authorizer        authorization.RuntimeAuthorizer
 	DefaultConnection map[string]string
 	CatalogConnection map[string]string
+	PluginInvokes     map[string][]config.PluginInvocationDependency
 	Now               func() time.Time
 }
 
@@ -95,6 +104,7 @@ type Manager struct {
 	authorizer        authorization.RuntimeAuthorizer
 	defaultConnection map[string]string
 	catalogConnection map[string]string
+	pluginInvokes     map[string][]config.PluginInvocationDependency
 	now               func() time.Time
 }
 
@@ -173,6 +183,10 @@ func New(cfg Config) *Manager {
 	if now == nil {
 		now = time.Now
 	}
+	pluginInvokes := make(map[string][]config.PluginInvocationDependency, len(cfg.PluginInvokes))
+	for pluginName, deps := range cfg.PluginInvokes {
+		pluginInvokes[pluginName] = append([]config.PluginInvocationDependency(nil), deps...)
+	}
 	return &Manager{
 		providers:         cfg.Providers,
 		workflow:          cfg.Workflow,
@@ -182,6 +196,7 @@ func New(cfg Config) *Manager {
 		authorizer:        cfg.Authorizer,
 		defaultConnection: maps.Clone(cfg.DefaultConnection),
 		catalogConnection: maps.Clone(cfg.CatalogConnection),
+		pluginInvokes:     pluginInvokes,
 		now:               now,
 	}
 }
@@ -358,7 +373,7 @@ func (m *Manager) SignalRun(ctx context.Context, p *principal.Principal, req Run
 	if err != nil {
 		return nil, err
 	}
-	return m.managedSignalResponse(ctx, p, value.ProviderName, existingRunProvider(value), resp, value.ExecutionRef)
+	return m.managedSignalResponse(ctx, p, value.ProviderName, existingRunProvider(value), resp, value.ExecutionRef, signalTargetPrincipalCaller)
 }
 
 func (m *Manager) SignalOrStartRun(ctx context.Context, p *principal.Principal, req RunSignalOrStart) (*ManagedRunSignal, error) {
@@ -403,7 +418,7 @@ func (m *Manager) SignalOrStartRun(ctx context.Context, p *principal.Principal, 
 	if resp == nil || resp.Run == nil || strings.TrimSpace(resp.Run.ExecutionRef) != executionRefID {
 		m.revokeExecutionRef(ctx, ref)
 	}
-	managed, err := m.managedSignalResponse(ctx, p, providerName, provider, resp, ref)
+	managed, err := m.managedSignalResponse(ctx, p, providerName, provider, resp, ref, signalTargetPrincipalExecutionRef)
 	if err != nil && resp != nil && resp.Run != nil && strings.TrimSpace(resp.Run.ExecutionRef) == executionRefID {
 		m.revokeExecutionRef(ctx, ref)
 	}
@@ -1153,8 +1168,83 @@ func (m *Manager) putExecutionRef(ctx context.Context, executionRefID, providerN
 		DisplayName:         actor.DisplayName,
 		AuthSource:          actor.AuthSource,
 		CredentialSubjectID: strings.TrimSpace(principal.EffectiveCredentialSubjectID(p)),
-		Permissions:         principal.PermissionsToAccessPermissions(p.TokenPermissions),
+		Permissions:         m.executionRefPermissions(p, target, callerPluginName),
 	})
+}
+
+func (m *Manager) executionRefPermissions(p *principal.Principal, target coreworkflow.Target, callerPluginName string) []core.AccessPermission {
+	p = principal.Canonicalized(p)
+	if p == nil || p.TokenPermissions == nil {
+		return principal.PermissionsToAccessPermissions(nil)
+	}
+	permissions := cloneWorkflowPermissionSet(p.TokenPermissions)
+	if target.Agent != nil {
+		for _, tool := range target.Agent.ToolRefs {
+			pluginName := strings.TrimSpace(tool.Plugin)
+			operation := strings.TrimSpace(tool.Operation)
+			if pluginName == "" || pluginName == "*" || operation == "" {
+				continue
+			}
+			if m.callerPluginDeclaresInvoke(callerPluginName, pluginName, operation) {
+				addWorkflowPermission(permissions, pluginName, operation)
+			}
+		}
+	}
+	return principal.PermissionsToAccessPermissions(permissions)
+}
+
+func (m *Manager) callerPluginDeclaresInvoke(callerPluginName, pluginName, operation string) bool {
+	callerPluginName = strings.TrimSpace(callerPluginName)
+	pluginName = strings.TrimSpace(pluginName)
+	operation = strings.TrimSpace(operation)
+	if callerPluginName == "" || pluginName == "" || operation == "" || m == nil {
+		return false
+	}
+	for _, invoke := range m.pluginInvokes[callerPluginName] {
+		if strings.TrimSpace(invoke.Surface) != "" {
+			continue
+		}
+		if strings.TrimSpace(invoke.Plugin) == pluginName && strings.TrimSpace(invoke.Operation) == operation {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneWorkflowPermissionSet(src principal.PermissionSet) principal.PermissionSet {
+	if src == nil {
+		return nil
+	}
+	out := make(principal.PermissionSet, len(src))
+	for pluginName, operations := range src {
+		if operations == nil {
+			out[pluginName] = nil
+			continue
+		}
+		copied := make(map[string]struct{}, len(operations))
+		for operation := range operations {
+			copied[operation] = struct{}{}
+		}
+		out[pluginName] = copied
+	}
+	return out
+}
+
+func addWorkflowPermission(permissions principal.PermissionSet, pluginName, operation string) {
+	pluginName = strings.TrimSpace(pluginName)
+	operation = strings.TrimSpace(operation)
+	if permissions == nil || pluginName == "" || operation == "" {
+		return
+	}
+	if operations, ok := permissions[pluginName]; ok && operations == nil {
+		return
+	}
+	operations := permissions[pluginName]
+	if operations == nil {
+		operations = map[string]struct{}{}
+		permissions[pluginName] = operations
+	}
+	operations[operation] = struct{}{}
 }
 
 func (m *Manager) revokeExecutionRef(ctx context.Context, ref *coreworkflow.ExecutionReference) {
@@ -1463,7 +1553,7 @@ func runExecutionRefID(value string) string {
 	return workflowRunExecutionRefBasePrefix + value
 }
 
-func (m *Manager) managedSignalResponse(ctx context.Context, p *principal.Principal, providerName string, provider coreworkflow.Provider, resp *coreworkflow.SignalRunResponse, candidateRef *coreworkflow.ExecutionReference) (*ManagedRunSignal, error) {
+func (m *Manager) managedSignalResponse(ctx context.Context, p *principal.Principal, providerName string, provider coreworkflow.Provider, resp *coreworkflow.SignalRunResponse, candidateRef *coreworkflow.ExecutionReference, targetPrincipalSource signalTargetPrincipalSource) (*ManagedRunSignal, error) {
 	if resp == nil || resp.Run == nil {
 		return nil, core.ErrNotFound
 	}
@@ -1483,7 +1573,11 @@ func (m *Manager) managedSignalResponse(ctx context.Context, p *principal.Princi
 		}
 		ref = workflowExecutionRefForProvider(ref, providerName)
 	}
-	if !executionRefOwnedBy(ref, p) || !executionRefActive(ref) || !m.allowTarget(ctx, p, ref.Target) || !runMatchesExecutionRef(providerName, resp.Run, ref) {
+	targetPrincipal := p
+	if targetPrincipalSource == signalTargetPrincipalExecutionRef {
+		targetPrincipal = workflowprincipal.FromExecutionReference(ref)
+	}
+	if !executionRefOwnedBy(ref, p) || !executionRefActive(ref) || !m.allowTarget(ctx, targetPrincipal, ref.Target) || !runMatchesExecutionRef(providerName, resp.Run, ref) {
 		return nil, core.ErrNotFound
 	}
 	workflowKey := strings.TrimSpace(resp.WorkflowKey)

--- a/gestaltd/internal/workflowmanager/manager_test.go
+++ b/gestaltd/internal/workflowmanager/manager_test.go
@@ -1,0 +1,306 @@
+package workflowmanager
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+func TestSignalOrStartRunExecutionRefInheritsDeclaredAgentToolInvokes(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWorkflowProvider()
+	manager := New(Config{
+		Workflow:     testWorkflowControl{provider: provider},
+		Agent:        testAgentControl{},
+		AgentManager: testAgentManager{},
+		PluginInvokes: map[string][]config.PluginInvocationDependency{
+			"github": {
+				{Plugin: "github", Operation: "bot.commitFiles"},
+				{Plugin: "github", Operation: "bot.openPullRequest"},
+			},
+		},
+	})
+	callerPermissions := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "github",
+		Operations: []string{"events.handle"},
+	}})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID:        "system:http_binding:github:event",
+		TokenPermissions: callerPermissions,
+		Scopes:           principal.PermissionPlugins(callerPermissions),
+	})
+
+	managed, err := manager.SignalOrStartRun(context.Background(), caller, RunSignalOrStart{
+		ProviderName:     "local",
+		WorkflowKey:      "github:99:acme/widgets:7",
+		CallerPluginName: "github",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "simple",
+			Prompt:       "Handle the webhook.",
+			ToolSource:   coreagent.ToolSourceModeNativeSearch,
+			ToolRefs: []coreagent.ToolRef{
+				{Plugin: "github", Operation: "bot.commitFiles"},
+				{Plugin: "github", Operation: "bot.openPullRequest"},
+			},
+		}},
+		Signal: coreworkflow.Signal{Name: "github.app.webhook"},
+	})
+	if err != nil {
+		t.Fatalf("SignalOrStartRun: %v", err)
+	}
+	if managed == nil || managed.ExecutionRef == nil {
+		t.Fatalf("managed signal = %#v, want execution ref", managed)
+	}
+
+	wantPermissions := []core.AccessPermission{{
+		Plugin: "github",
+		Operations: []string{
+			"bot.commitFiles",
+			"bot.openPullRequest",
+			"events.handle",
+		},
+	}}
+	if !reflect.DeepEqual(managed.ExecutionRef.Permissions, wantPermissions) {
+		t.Fatalf("execution ref permissions = %#v, want %#v", managed.ExecutionRef.Permissions, wantPermissions)
+	}
+	if managed.ExecutionRef.CallerPluginName != "github" {
+		t.Fatalf("caller plugin = %q, want github", managed.ExecutionRef.CallerPluginName)
+	}
+}
+
+func TestSignalOrStartRunExecutionRefDoesNotInheritSurfaceInvokes(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWorkflowProvider()
+	manager := New(Config{
+		Workflow:     testWorkflowControl{provider: provider},
+		Agent:        testAgentControl{},
+		AgentManager: testAgentManager{},
+		PluginInvokes: map[string][]config.PluginInvocationDependency{
+			"github": {
+				{Plugin: "github", Surface: "graphql"},
+			},
+		},
+	})
+	callerPermissions := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "github",
+		Operations: []string{"events.handle"},
+	}})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID:        "system:http_binding:github:event",
+		TokenPermissions: callerPermissions,
+		Scopes:           principal.PermissionPlugins(callerPermissions),
+	})
+
+	_, err := manager.SignalOrStartRun(context.Background(), caller, RunSignalOrStart{
+		ProviderName:     "local",
+		WorkflowKey:      "github:99:acme/widgets:7",
+		CallerPluginName: "github",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "simple",
+			Prompt:       "Handle the webhook.",
+			ToolSource:   coreagent.ToolSourceModeNativeSearch,
+			ToolRefs: []coreagent.ToolRef{
+				{Plugin: "github", Operation: "bot.createPullRequest"},
+			},
+		}},
+		Signal: coreworkflow.Signal{Name: "github.app.webhook"},
+	})
+	if !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("SignalOrStartRun error = %v, want not found from unauthorized target", err)
+	}
+}
+
+func TestSignalRunUsesCurrentPrincipalForTargetValidation(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWorkflowProvider()
+	manager := New(Config{
+		Workflow:     testWorkflowControl{provider: provider},
+		Agent:        testAgentControl{},
+		AgentManager: testAgentManager{},
+	})
+	target := coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+		ProviderName: "simple",
+		Prompt:       "Handle the webhook.",
+		ToolSource:   coreagent.ToolSourceModeNativeSearch,
+		ToolRefs: []coreagent.ToolRef{
+			{Plugin: "github", Operation: "bot.openPullRequest"},
+		},
+	}}
+	targetFingerprint, err := coreworkflow.TargetFingerprint(target)
+	if err != nil {
+		t.Fatalf("TargetFingerprint: %v", err)
+	}
+	ref := &coreworkflow.ExecutionReference{
+		ID:                "workflow_run:stale-permissions",
+		ProviderName:      "local",
+		Target:            target,
+		TargetFingerprint: targetFingerprint,
+		SubjectID:         "system:http_binding:github:event",
+		Permissions: []core.AccessPermission{{
+			Plugin:     "github",
+			Operations: []string{"events.handle"},
+		}},
+	}
+	provider.refs[ref.ID] = ref
+	provider.runs["run-stale-permissions"] = &coreworkflow.Run{
+		ID:           "run-stale-permissions",
+		Status:       coreworkflow.RunStatusRunning,
+		WorkflowKey:  "github:99:acme/widgets:7",
+		Target:       target,
+		ExecutionRef: ref.ID,
+	}
+	callerPermissions := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "github",
+		Operations: []string{"events.handle", "bot.openPullRequest"},
+	}})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID:        "system:http_binding:github:event",
+		TokenPermissions: callerPermissions,
+		Scopes:           principal.PermissionPlugins(callerPermissions),
+	})
+
+	managed, err := manager.SignalRun(context.Background(), caller, RunSignal{
+		RunID:  "run-stale-permissions",
+		Signal: coreworkflow.Signal{Name: "github.app.webhook"},
+	})
+	if err != nil {
+		t.Fatalf("SignalRun: %v", err)
+	}
+	if managed == nil || managed.Run == nil || managed.Run.ID != "run-stale-permissions" {
+		t.Fatalf("managed signal = %#v, want stale run", managed)
+	}
+}
+
+type testWorkflowControl struct {
+	provider coreworkflow.Provider
+}
+
+func (c testWorkflowControl) ResolveProvider(name string) (coreworkflow.Provider, error) {
+	return c.provider, nil
+}
+
+func (c testWorkflowControl) ResolveProviderSelection(name string) (string, coreworkflow.Provider, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = "local"
+	}
+	return name, c.provider, nil
+}
+
+func (c testWorkflowControl) ProviderNames() []string {
+	return []string{"local"}
+}
+
+type testAgentControl struct{}
+
+func (testAgentControl) ResolveProviderSelection(name string) (string, coreagent.Provider, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = "simple"
+	}
+	return name, nil, nil
+}
+
+type testAgentManager struct {
+	agentmanager.Service
+}
+
+type testWorkflowProvider struct {
+	coreworkflow.Provider
+	refs map[string]*coreworkflow.ExecutionReference
+	runs map[string]*coreworkflow.Run
+}
+
+func newTestWorkflowProvider() *testWorkflowProvider {
+	return &testWorkflowProvider{
+		refs: map[string]*coreworkflow.ExecutionReference{},
+		runs: map[string]*coreworkflow.Run{},
+	}
+}
+
+func (p *testWorkflowProvider) SignalOrStartRun(_ context.Context, req coreworkflow.SignalOrStartRunRequest) (*coreworkflow.SignalRunResponse, error) {
+	run := &coreworkflow.Run{
+		ID:           "run-signaled",
+		Status:       coreworkflow.RunStatusRunning,
+		WorkflowKey:  req.WorkflowKey,
+		Target:       req.Target,
+		ExecutionRef: req.ExecutionRef,
+		CreatedBy:    req.CreatedBy,
+	}
+	p.runs[run.ID] = run
+	signal := req.Signal
+	if strings.TrimSpace(signal.ID) == "" {
+		signal.ID = "signal-1"
+	}
+	return &coreworkflow.SignalRunResponse{
+		Run:         run,
+		Signal:      signal,
+		StartedRun:  true,
+		WorkflowKey: req.WorkflowKey,
+	}, nil
+}
+
+func (p *testWorkflowProvider) GetRun(_ context.Context, req coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
+	run := p.runs[strings.TrimSpace(req.RunID)]
+	if run == nil {
+		return nil, core.ErrNotFound
+	}
+	copied := *run
+	return &copied, nil
+}
+
+func (p *testWorkflowProvider) SignalRun(_ context.Context, req coreworkflow.SignalRunRequest) (*coreworkflow.SignalRunResponse, error) {
+	run := p.runs[strings.TrimSpace(req.RunID)]
+	if run == nil {
+		return nil, core.ErrNotFound
+	}
+	copiedRun := *run
+	signal := req.Signal
+	if strings.TrimSpace(signal.ID) == "" {
+		signal.ID = "signal-1"
+	}
+	return &coreworkflow.SignalRunResponse{
+		Run:         &copiedRun,
+		Signal:      signal,
+		WorkflowKey: copiedRun.WorkflowKey,
+	}, nil
+}
+
+func (p *testWorkflowProvider) PutExecutionReference(_ context.Context, ref *coreworkflow.ExecutionReference) (*coreworkflow.ExecutionReference, error) {
+	copied := *ref
+	p.refs[copied.ID] = &copied
+	return &copied, nil
+}
+
+func (p *testWorkflowProvider) GetExecutionReference(_ context.Context, id string) (*coreworkflow.ExecutionReference, error) {
+	ref := p.refs[strings.TrimSpace(id)]
+	if ref == nil {
+		return nil, core.ErrNotFound
+	}
+	copied := *ref
+	return &copied, nil
+}
+
+func (p *testWorkflowProvider) ListExecutionReferences(_ context.Context, subjectID string) ([]*coreworkflow.ExecutionReference, error) {
+	out := []*coreworkflow.ExecutionReference{}
+	for _, ref := range p.refs {
+		if strings.TrimSpace(ref.SubjectID) != strings.TrimSpace(subjectID) {
+			continue
+		}
+		copied := *ref
+		out = append(out, &copied)
+	}
+	return out, nil
+}

--- a/gestaltd/internal/workflowprincipal/principal.go
+++ b/gestaltd/internal/workflowprincipal/principal.go
@@ -1,0 +1,28 @@
+package workflowprincipal
+
+import (
+	"strings"
+
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+func FromExecutionReference(ref *coreworkflow.ExecutionReference) *principal.Principal {
+	if ref == nil {
+		return nil
+	}
+	compiled := principal.CompilePermissions(ref.Permissions)
+	value := &principal.Principal{
+		SubjectID:           strings.TrimSpace(ref.SubjectID),
+		CredentialSubjectID: strings.TrimSpace(ref.CredentialSubjectID),
+		DisplayName:         strings.TrimSpace(ref.DisplayName),
+		Kind:                principal.Kind(strings.TrimSpace(ref.SubjectKind)),
+		Scopes:              principal.PermissionPlugins(compiled),
+		TokenPermissions:    compiled,
+	}
+	principal.SetAuthSource(value, ref.AuthSource)
+	if value.CredentialSubjectID == "" && principal.IsSystemSubjectID(value.SubjectID) {
+		value.CredentialSubjectID = value.SubjectID
+	}
+	return principal.Canonicalize(value)
+}


### PR DESCRIPTION
## Summary

Fix provider-started workflow agent runs so their execution refs can authorize the agent target's exact tool refs when those refs are declared by the calling plugin's `invokes`.

This is the follow-up for the GitHub workflow-only webhook path: the GitHub provider calls `WorkflowManager.SignalOrStartRun` from `events.handle`, but the HTTP binding caller only has permission for `github.events.handle`. The workflow execution ref now inherits the exact bot operations declared by the `github` plugin config.

## New Interfaces

Workflow manager config now accepts plugin invocation declarations:

```go
workflowmanager.Config{
  PluginInvokes: map[string][]config.PluginInvocationDependency{
    "github": {
      {Plugin: "github", Operation: "bot.commitFiles"},
      {Plugin: "github", Operation: "bot.openPullRequest"},
      {Plugin: "github", Operation: "bot.createPullRequest"},
    },
  },
}
```

Bootstrap wires this from existing plugin config:

```yaml
plugins:
  github:
    invokes:
      - plugin: github
        operation: bot.commitFiles
        credentialMode: none
      - plugin: github
        operation: bot.openPullRequest
        credentialMode: none
      - plugin: github
        operation: bot.createPullRequest
        credentialMode: none
```

Runtime effect:

```text
WorkflowManager.SignalOrStartRun(
  callerPluginName="github",
  target.agent.tool_refs=[github.bot.commitFiles, github.bot.openPullRequest],
)
```

stores a workflow execution ref with:

```yaml
permissions:
  - plugin: github
    operations:
      - bot.commitFiles
      - bot.openPullRequest
      - events.handle
```

Only exact REST operation invokes are inherited. Surface invokes such as `surface: graphql` are ignored for agent tool permission inheritance.

## Validation

`SignalOrStartRun` now validates the returned run using the execution-ref principal rather than the original HTTP binding principal, so provider-started workflow agents can pass target validation with inherited tool refs.

## Tests

```text
go test -count=1 ./internal/workflowmanager ./internal/bootstrap ./internal/server
```