### PR TITLE
Require apiVersion for gestaltd config roots

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -64,14 +64,6 @@ func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
 		wantError string
 	}{
 		{
-			name: "unknown audit provider",
-			auditYAML: `  audit:
-    primary:
-      source: bogus
-`,
-			wantError: "unknown audit provider",
-		},
-		{
 			name: "stdout audit requires mapping config",
 			auditYAML: `  audit:
     primary:
@@ -198,7 +190,8 @@ func TestE2EValidateAcceptsCanonicalConfigShapes(t *testing.T) {
 	agentManifest := componentProviderManifestPath(t, setupExecutableProviderDir(t, dir, providermanifestv1.KindAgent, "agent-simple"))
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`server:
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   encryptionKey: canonical-config-shapes-key
   providers:
     indexeddb: inmem
@@ -313,8 +306,24 @@ func TestE2EValidateRejectsInvalidConfigInput(t *testing.T) {
 			wantError: "parsing config YAML",
 		},
 		{
-			name: "unknown field",
+			name: "missing apiVersion",
 			cfg: `server:
+  encryptionKey: test-key
+`,
+			wantError: "apiVersion is required",
+		},
+		{
+			name: "empty apiVersion",
+			cfg: `apiVersion: ""
+server:
+  encryptionKey: test-key
+`,
+			wantError: "apiVersion is required",
+		},
+		{
+			name: "unknown field",
+			cfg: `apiVersion: gestaltd.config/v3
+server:
   encryptionKey: test-key
   bogus: true
 `,
@@ -322,7 +331,8 @@ func TestE2EValidateRejectsInvalidConfigInput(t *testing.T) {
 		},
 		{
 			name: "ui object requires path",
-			cfg: `plugins:
+			cfg: `apiVersion: gestaltd.config/v3
+plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
@@ -333,7 +343,8 @@ func TestE2EValidateRejectsInvalidConfigInput(t *testing.T) {
 		},
 		{
 			name: "ui object rejects legacy mountPath",
-			cfg: `plugins:
+			cfg: `apiVersion: gestaltd.config/v3
+plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
@@ -421,7 +432,8 @@ func TestE2EProviderValidateReusesConfiguredPluginKey(t *testing.T) {
 	providersDir := setupDefaultLocalProvidersDir(t, dir)
 	pluginDir := setupPluginDir(t, dir)
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `plugins:
+	cfg := `apiVersion: gestaltd.config/v3
+plugins:
   provider_go:
     source: https://example.test/provider-release.yaml
 `
@@ -479,7 +491,8 @@ func TestE2EProviderValidateLayeredConfigSupportsNullDeletion(t *testing.T) {
 	}
 
 	baseCfgPath := filepath.Join(dir, "support.yaml")
-	baseCfg := fmt.Sprintf(`providers:
+	baseCfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+providers:
   ui:
     roadmap:
       source:
@@ -498,7 +511,8 @@ plugins:
 	}
 
 	overrideCfgPath := filepath.Join(dir, "support-override.yaml")
-	overrideCfg := `providers:
+	overrideCfg := `apiVersion: gestaltd.config/v3
+providers:
   ui:
     roadmap: null
 plugins:
@@ -660,7 +674,8 @@ func TestE2EValidateAcceptsLayeredConfigs(t *testing.T) {
 	setupPluginDir(t, overrideDir)
 
 	baseConfigPath := filepath.Join(baseDir, "base.yaml")
-	baseConfig := fmt.Sprintf(`server:
+	baseConfig := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   encryptionKey: test-key
   providers:
     indexeddb: sqlite
@@ -681,7 +696,8 @@ plugins:
 	}
 
 	overrideConfigPath := filepath.Join(overrideDir, "local.yaml")
-	overrideConfig := `plugins:
+	overrideConfig := `apiVersion: gestaltd.config/v3
+plugins:
   example:
     source:
       path: ./plugin-src/manifest.yaml
@@ -705,6 +721,24 @@ plugins:
 	if !strings.Contains(string(out), "config ok") {
 		t.Fatalf("expected layered config output to mention success, got: %s", out)
 	}
+
+	mixedOverrideConfigPath := filepath.Join(overrideDir, "v4.yaml")
+	mixedOverrideConfig := `apiVersion: gestaltd.config/v4
+plugins:
+  example:
+    source: ./plugin-src/provider-release.yaml
+`
+	if err := os.WriteFile(mixedOverrideConfigPath, []byte(mixedOverrideConfig), 0o644); err != nil {
+		t.Fatalf("WriteFile mixed override config: %v", err)
+	}
+
+	out, err = exec.Command(gestaltdBin, "validate", "--config", baseConfigPath, "--config", mixedOverrideConfigPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected mixed apiVersion validate to fail, output: %s", out)
+	}
+	if !strings.Contains(string(out), "mixed apiVersion values") {
+		t.Fatalf("expected mixed apiVersion error, got: %s", out)
+	}
 }
 
 func TestE2EValidateUsesScratchPreparedInstallsForLocalSourceConfigs(t *testing.T) {
@@ -715,7 +749,8 @@ func TestE2EValidateUsesScratchPreparedInstallsForLocalSourceConfigs(t *testing.
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`server:
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   encryptionKey: test-key
   providers:
     indexeddb: sqlite
@@ -776,7 +811,8 @@ func TestE2EValidateRejectsInvalidPluginInvokesDependency(t *testing.T) {
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`server:
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   encryptionKey: test-key
   providers:
     indexeddb: sqlite
@@ -848,7 +884,8 @@ paths:
 
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`server:
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   encryptionKey: test-key
   providers:
     indexeddb: sqlite
@@ -1635,7 +1672,8 @@ func writeServeConfig(t *testing.T, dir string, port int, mountedUI *mountedUITe
 `, mountedUI.Name, mountedUI.ManifestPath, mountedUI.Path)
 	}
 
-	cfg := fmt.Sprintf(`server:
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   public:
     port: %d
   encryptionKey: test-serve-e2e-key
@@ -1679,7 +1717,8 @@ func writeServeConfigWithManagement(t *testing.T, dir string, publicPort, manage
 `, mountedUI.Name, mountedUI.ManifestPath, mountedUI.Path)
 	}
 
-	cfg := fmt.Sprintf(`server:
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   public:
     port: %d
   management:
@@ -2269,7 +2308,8 @@ func TestE2EServePluginOwnedUIWiring(t *testing.T) {
 	publicPort, publicHolder := reservePort(t)
 	publicURL := fmt.Sprintf("http://127.0.0.1:%d", publicPort)
 	cfgPath := filepath.Join(dir, "config-owned-ui.yaml")
-	cfg := fmt.Sprintf(`server:
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   public:
     port: %d
   encryptionKey: test-plugin-owned-ui-key
@@ -2358,7 +2398,8 @@ func TestE2EServeStartsWithPluginBoundCacheProvider(t *testing.T) {
 	pluginManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, dir))
 	cfgPath := filepath.Join(dir, "config-cache.yaml")
 
-	cfg := fmt.Sprintf(`server:
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   public:
     port: 0
   encryptionKey: test-cache-serve-e2e-key
@@ -2455,7 +2496,8 @@ func TestE2EHostedHTTPSubjectResolutionUsesAuthorizationAndInheritedInvocation(t
 	port, holder := reservePort(t)
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 	cfgPath := filepath.Join(dir, "config-subject-resolution.yaml")
-	cfg := fmt.Sprintf(`server:
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   public:
     port: %d
   encryptionKey: test-http-subject-resolution-key
@@ -2764,7 +2806,8 @@ func writeValidValidateConfig(t *testing.T, dir string) string {
 	pluginManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, dir))
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`server:
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   encryptionKey: valid-config-e2e-key
   providers:
     indexeddb: inmem
@@ -2795,7 +2838,8 @@ func writeInvalidValidateConfig(t *testing.T, path string) {
 	dir := filepath.Dir(path)
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 	externalCredentialsManifest := componentProviderManifestPath(t, setupExternalCredentialsProviderDir(t, dir))
-	cfg := fmt.Sprintf(`server:
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   encryptionKey: invalid-config-e2e-key
   providers:
     indexeddb: inmem
@@ -2848,7 +2892,8 @@ func writeLayeredE2EConfigs(t *testing.T, dir string, port int) (string, string,
 
 	basePath := filepath.Join(deployDir, "base.yaml")
 	overridePath := filepath.Join(overrideDir, "local.yaml")
-	baseCfg := fmt.Sprintf(`server:
+	baseCfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   public:
     port: %d
   encryptionKey: test-layered-e2e-key
@@ -2869,7 +2914,8 @@ plugins:
     source:
       path: %s
 `, port, filepath.ToSlash(externalCredentialsManifest), filepath.ToSlash(indexedDBRel), filepath.ToSlash(pluginRel))
-	overrideCfg := fmt.Sprintf(`server:
+	overrideCfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   providers:
     authentication: local
   artifactsDir: ../artifacts/local
@@ -2902,7 +2948,8 @@ func writeE2EConfigWithPaths(t *testing.T, dir, pluginDir, dbPath, artifactsDir 
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	serverBlock := fmt.Sprintf(`server:
+	serverBlock := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   public:
     port: %d
   encryptionKey: test-e2e-key

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -1050,6 +1050,7 @@ func writeProviderLocalBaseConfig(path, dbPath string) error {
 	}
 
 	cfg := map[string]any{
+		"apiVersion": config.APIVersionV3,
 		"server": map[string]any{
 			"encryptionKey": encryptionKey,
 			"providers": map[string]any{
@@ -1098,6 +1099,7 @@ func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string,
 	}
 
 	cfg := map[string]any{
+		"apiVersion": config.APIVersionV3,
 		"server": map[string]any{
 			"public": map[string]any{
 				"host": providerDevHost,
@@ -1122,6 +1124,7 @@ func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string,
 
 func writeProviderRemotePluginOverlayConfig(path, pluginKey, manifestPath string) error {
 	cfg := map[string]any{
+		"apiVersion": config.APIVersionV3,
 		"plugins": map[string]any{
 			pluginKey: map[string]any{
 				"source":    providerLocalSourceOverride(manifestPath),
@@ -1141,6 +1144,7 @@ func writeProviderLocalUIOverlayConfig(path, uiKey, manifestPath string, port in
 	}
 
 	cfg := map[string]any{
+		"apiVersion": config.APIVersionV3,
 		"server": map[string]any{
 			"public": map[string]any{
 				"host": providerDevHost,

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -54,8 +54,7 @@ const APIVersionV4 = "gestaltd.config/v4"
 type providerSourceSyntaxMode int
 
 const (
-	providerSourceSyntaxLegacy providerSourceSyntaxMode = iota
-	providerSourceSyntaxV3
+	providerSourceSyntaxV3 providerSourceSyntaxMode = iota
 	providerSourceSyntaxV4
 )
 
@@ -146,7 +145,7 @@ type ServerProvidersConfig struct {
 
 // ProviderSource supports handwritten config in three forms via custom
 // UnmarshalYAML:
-//   - Builtin:  source: "name"                               -> ProviderSource{Builtin: "name"}
+//   - Builtin:  recognized host builtins such as source: "env" or "stdout"
 //   - Metadata: source: "https://.../provider-release.yaml"  -> ProviderSource{metadataURL: "..."}
 //   - GitHub:   source: {githubRelease: {repo, tag, asset}}  -> ProviderSource{GitHubRelease: ...}
 //   - Local:    source: {path} or source: "./manifest.yaml"  -> ProviderSource{Path: "..."} in v3
@@ -2025,7 +2024,8 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 	}
 
 	roots := make([]yaml.Node, len(paths))
-	sourceSyntax := providerSourceSyntaxLegacy
+	var sourceSyntax providerSourceSyntaxMode
+	sourceSyntaxSet := false
 	for i, path := range paths {
 		root, err := loadValidatedConfigRoot(path, lookup, mode, sentinelPrefix)
 		if err != nil {
@@ -2035,18 +2035,17 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 		if err != nil {
 			return yaml.Node{}, err
 		}
-		if rootSyntax != providerSourceSyntaxLegacy {
-			if sourceSyntax != providerSourceSyntaxLegacy && sourceSyntax != rootSyntax {
-				return yaml.Node{}, fmt.Errorf("config validation: mixed apiVersion values are not supported across merged config files")
-			}
-			sourceSyntax = rootSyntax
+		if sourceSyntaxSet && sourceSyntax != rootSyntax {
+			return yaml.Node{}, fmt.Errorf("config validation: mixed apiVersion values are not supported across merged config files")
 		}
+		sourceSyntax = rootSyntax
+		sourceSyntaxSet = true
 		roots[i] = root
 	}
 
 	var merged any
 	for i, path := range paths {
-		value, err := loadConfigValue(path, roots[i], sourceSyntax)
+		value, err := loadConfigValue(path, roots[i])
 		if err != nil {
 			return yaml.Node{}, err
 		}
@@ -2075,25 +2074,28 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 
 func configRootSourceSyntax(root yaml.Node) (providerSourceSyntaxMode, error) {
 	doc := documentValueNode(&root)
-	if doc == nil || doc.Kind != yaml.MappingNode {
-		return providerSourceSyntaxLegacy, nil
+	if doc == nil || doc.Kind == 0 {
+		return providerSourceSyntaxV3, requiredAPIVersionError()
+	}
+	if doc.Kind != yaml.MappingNode {
+		return providerSourceSyntaxV3, fmt.Errorf("parsing config YAML: expected mapping document")
 	}
 	node := mappingValueNode(doc, "apiVersion")
 	if node == nil {
-		return providerSourceSyntaxLegacy, nil
+		return providerSourceSyntaxV3, requiredAPIVersionError()
 	}
 	value := strings.TrimSpace(node.Value)
 	if value == "" {
-		return providerSourceSyntaxLegacy, nil
+		return providerSourceSyntaxV3, requiredAPIVersionError()
 	}
 	mode, err := providerSourceSyntaxForAPIVersion(value)
 	if err != nil {
-		return providerSourceSyntaxLegacy, err
+		return providerSourceSyntaxV3, err
 	}
 	return mode, nil
 }
 
-func loadConfigValue(path string, root yaml.Node, sourceSyntax providerSourceSyntaxMode) (any, error) {
+func loadConfigValue(path string, root yaml.Node) (any, error) {
 	doc := documentValueNode(&root)
 	if doc == nil || doc.Kind == 0 {
 		return nil, nil
@@ -2113,7 +2115,7 @@ func loadConfigValue(path string, root yaml.Node, sourceSyntax providerSourceSyn
 		if !ok {
 			return nil, fmt.Errorf("expected mapping document")
 		}
-		resolveRelativePathsInValue(path, root, sourceSyntax)
+		resolveRelativePathsInValue(path, root)
 	}
 	return normalized, nil
 }
@@ -2646,8 +2648,6 @@ func normalizeProviderSource(kind string, source *ProviderSource, sourceSyntax p
 		return
 	}
 	switch {
-	case sourceSyntax == providerSourceSyntaxLegacy:
-		source.Builtin = source.scalar
 	case isBuiltinScalarSource(kind, source.scalar):
 		source.Builtin = source.scalar
 	case looksLikeMetadataURL(source.scalar):
@@ -2724,21 +2724,21 @@ func looksLikeUnsupportedScalarSource(value string) bool {
 
 func providerSourceSyntaxForAPIVersion(apiVersion string) (providerSourceSyntaxMode, error) {
 	switch strings.TrimSpace(apiVersion) {
-	case "":
-		return providerSourceSyntaxLegacy, nil
 	case APIVersionV3:
 		return providerSourceSyntaxV3, nil
 	case APIVersionV4:
 		return providerSourceSyntaxV4, nil
+	case "":
+		return providerSourceSyntaxV3, requiredAPIVersionError()
 	default:
-		return providerSourceSyntaxLegacy, fmt.Errorf("config validation: unsupported apiVersion %q", strings.TrimSpace(apiVersion))
+		return providerSourceSyntaxV3, fmt.Errorf("config validation: unsupported apiVersion %q", strings.TrimSpace(apiVersion))
 	}
 }
 
 func sourceSyntaxForConfig(apiVersion string) providerSourceSyntaxMode {
 	mode, err := providerSourceSyntaxForAPIVersion(apiVersion)
 	if err != nil {
-		return providerSourceSyntaxLegacy
+		return providerSourceSyntaxV3
 	}
 	return mode
 }
@@ -2907,7 +2907,7 @@ func resolveBaseURL(cfg *Config) {
 	cfg.Server.Management.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Management.BaseURL), "/")
 }
 
-func resolveRelativePathsInValue(configPath string, root map[string]any, sourceSyntax providerSourceSyntaxMode) {
+func resolveRelativePathsInValue(configPath string, root map[string]any) {
 	baseDir := filepath.Dir(configPath)
 	if absPath, err := filepath.Abs(configPath); err == nil {
 		baseDir = filepath.Dir(absPath)
@@ -2935,31 +2935,28 @@ func resolveRelativePathsInValue(configPath string, root map[string]any, sourceS
 			{key: "agent", kind: string(HostProviderKindAgent)},
 		} {
 			for _, entry := range mapValues(nestedMap(providers, section.key)) {
-				resolveRelativePathsInEntry(section.kind, entry, baseDir, sourceSyntax)
+				resolveRelativePathsInEntry(section.kind, entry, baseDir)
 			}
 		}
 	}
 	if runtimeConfig := nestedMap(root, "runtime"); runtimeConfig != nil {
 		for _, entry := range mapValues(nestedMap(runtimeConfig, "providers")) {
-			resolveRelativePathsInEntry(providermanifestv1.KindRuntime, entry, baseDir, sourceSyntax)
+			resolveRelativePathsInEntry(providermanifestv1.KindRuntime, entry, baseDir)
 		}
 	}
 
 	for _, entry := range mapValues(nestedMap(root, "plugins")) {
-		resolveRelativePathsInEntry(providermanifestv1.KindPlugin, entry, baseDir, sourceSyntax)
+		resolveRelativePathsInEntry(providermanifestv1.KindPlugin, entry, baseDir)
 	}
 }
 
-func resolveRelativePathsInEntry(kind string, entry map[string]any, baseDir string, sourceSyntax providerSourceSyntaxMode) {
+func resolveRelativePathsInEntry(kind string, entry map[string]any, baseDir string) {
 	if entry == nil {
 		return
 	}
 	resolveRelativeStringField(entry, "iconFile", baseDir)
 	if source, ok := entry["source"].(map[string]any); ok {
 		resolveRelativeStringField(source, "path", baseDir)
-		return
-	}
-	if sourceSyntax == providerSourceSyntaxLegacy {
 		return
 	}
 	sourceValue, ok := entry["source"].(string)

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -23,12 +23,25 @@ func mustDecodeNode(t *testing.T, node yaml.Node) map[string]any {
 
 func mustWriteConfigFile(t *testing.T, content string) string {
 	t.Helper()
+	return mustWriteRawConfigFile(t, withDefaultConfigAPIVersion(content))
+}
+
+func mustWriteRawConfigFile(t *testing.T, content string) string {
+	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "gestalt.yaml")
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("writing temp config: %v", err)
 	}
 	return path
+}
+
+func withDefaultConfigAPIVersion(content string) string {
+	trimmed := strings.TrimLeft(content, " \t\r\n")
+	if strings.HasPrefix(trimmed, "apiVersion:") {
+		return content
+	}
+	return "\napiVersion: " + APIVersionV3 + "\n" + strings.TrimLeft(content, "\r\n")
 }
 
 func mustSelectedProvider(t *testing.T, cfg *Config, kind HostProviderKind) (string, *ProviderEntry) {
@@ -830,6 +843,7 @@ func TestValidateStructureRejectsDuplicateAuthorizationPolicyMembers(t *testing.
 			t.Parallel()
 
 			cfg := &Config{
+				APIVersion: APIVersionV3,
 				Authorization: AuthorizationConfig{
 					Policies: map[string]SubjectPolicyDef{
 						"roadmap": {
@@ -2175,7 +2189,7 @@ server:
 		}
 	})
 
-	t.Run("builtin ui source is rejected", func(t *testing.T) {
+	t.Run("ui scalar source is treated as local path", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -2194,12 +2208,12 @@ server:
   encryptionKey: server-key
 `)
 
-		_, err := Load(path)
-		if err == nil {
-			t.Fatal("Load: expected error, got nil")
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
 		}
-		if !strings.Contains(err.Error(), `ui "roadmap" does not support builtin providers`) {
-			t.Fatalf("unexpected error: %v", err)
+		if got := cfg.Providers.UI["roadmap"].SourcePath(); got != filepath.Join(filepath.Dir(path), "stdout") {
+			t.Fatalf("ui source path = %q, want local path", got)
 		}
 	})
 
@@ -3999,6 +4013,7 @@ func TestLoadPathsProviderExecutionAndEgressOverride(t *testing.T) {
 	basePath := filepath.Join(dir, "base.yaml")
 	overridePath := filepath.Join(dir, "override.yaml")
 	if err := os.WriteFile(basePath, []byte(`
+apiVersion: gestaltd.config/v3
 server:
   encryptionKey: server-key
 plugins:
@@ -4021,6 +4036,7 @@ runtime:
 		t.Fatalf("writing base config: %v", err)
 	}
 	if err := os.WriteFile(overridePath, []byte(`
+apiVersion: gestaltd.config/v3
 plugins:
   service:
     execution:
@@ -4287,6 +4303,82 @@ plugins:
 				t.Fatalf("Load error = %v, want substring %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestLoadConfigRequiresAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "missing apiVersion is rejected",
+			yaml: `
+providers:
+plugins:
+  external:
+    source: ./plugins/dummy/manifest.yaml
+`,
+		},
+		{
+			name: "empty apiVersion is rejected",
+			yaml: `
+apiVersion: ""
+providers:
+plugins:
+  external:
+    source: ./plugins/dummy/manifest.yaml
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := mustWriteRawConfigFile(t, tc.yaml)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("Load: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "apiVersion is required") {
+				t.Fatalf("Load error = %v, want apiVersion required error", err)
+			}
+		})
+	}
+}
+
+func TestLoadPathsRequiresAPIVersionInEveryFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.yaml")
+	overridePath := filepath.Join(dir, "override.yaml")
+	if err := os.WriteFile(basePath, []byte(`
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+  external:
+    source: ./plugins/dummy/manifest.yaml
+`), 0o644); err != nil {
+		t.Fatalf("writing base config: %v", err)
+	}
+	if err := os.WriteFile(overridePath, []byte(`
+plugins:
+  external:
+    displayName: External
+`), 0o644); err != nil {
+		t.Fatalf("writing override config: %v", err)
+	}
+
+	_, err := LoadPaths([]string{basePath, overridePath})
+	if err == nil {
+		t.Fatal("LoadPaths: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "apiVersion is required") {
+		t.Fatalf("LoadPaths error = %v, want apiVersion required error", err)
 	}
 }
 
@@ -4937,6 +5029,9 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			if tc.cfg != nil && strings.TrimSpace(tc.cfg.APIVersion) == "" {
+				tc.cfg.APIVersion = APIVersionV3
+			}
 			err := ValidateStructure(tc.cfg)
 			if tc.wantErr == "" {
 				if err != nil {
@@ -4972,6 +5067,7 @@ func TestLoadConfigResolvesRelativePaths(t *testing.T) {
 		t.Fatalf("MkdirAll config dir: %v", err)
 	}
 	if err := os.WriteFile(cfgPath, []byte(`
+apiVersion: gestaltd.config/v3
 providers:
   authentication:
     authentication:
@@ -5036,6 +5132,7 @@ plugins:
 		t.Fatalf("MkdirAll override: %v", err)
 	}
 	if err := os.WriteFile(overridePath, []byte(`
+apiVersion: gestaltd.config/v3
 providers:
 plugins:
     sample:
@@ -5164,7 +5261,8 @@ func TestLoad_ResolvesRelativePluginSourcePath(t *testing.T) {
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `providers:
+	cfg := `apiVersion: gestaltd.config/v3
+providers:
 plugins:
     sample:
       source:

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -150,6 +150,8 @@ func validateAPIVersion(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
+	// YAML roots require apiVersion before this point; direct programmatic
+	// Config values may omit it and use v3 source normalization.
 	apiVersion := strings.TrimSpace(cfg.APIVersion)
 	switch apiVersion {
 	case "", APIVersionV3, APIVersionV4:
@@ -157,6 +159,10 @@ func validateAPIVersion(cfg *Config) error {
 	default:
 		return fmt.Errorf("config validation: unsupported apiVersion %q", apiVersion)
 	}
+}
+
+func requiredAPIVersionError() error {
+	return fmt.Errorf("config validation: apiVersion is required; supported values are %q or %q", APIVersionV3, APIVersionV4)
 }
 
 func validateHostProviderEntries(kind HostProviderKind, entries map[string]*ProviderEntry, sourceSyntax providerSourceSyntaxMode) error {

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -509,7 +509,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -573,7 +573,7 @@ spec:
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     notion:
       source:
         path: ./manifest.yaml
@@ -678,7 +678,7 @@ spec:
 			}
 
 			cfgPath := filepath.Join(dir, "config.yaml")
-			cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+			cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -765,7 +765,7 @@ func TestInitAtPath_RejectsInvalidPluginInvokesShape(t *testing.T) {
 
 			caseDir := t.TempDir()
 			cfgPath := filepath.Join(caseDir, "config.yaml")
-			cfg := requiredComponentConfigYAML(t, caseDir, filepath.Join(caseDir, "gestalt.db")) + tc.body + `server:
+			cfg := requiredComponentConfigV3YAML(t, caseDir, filepath.Join(caseDir, "gestalt.db")) + tc.body + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `
 			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -788,7 +788,7 @@ func TestInitAtPath_AllowsInvokesAgainstEffectiveAlias(t *testing.T) {
 	targetManifestPath := writeLocalExecutablePlugin(t, dir, "target", "ping")
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -821,7 +821,7 @@ func TestInitAtPath_RejectsHybridExecutableStaticOperationByOriginalNameAfterAli
 	targetManifestPath := writeLocalExecutableOpenAPIPlugin(t, dir, "target", []string{"ping"}, []string{"status"})
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -856,7 +856,7 @@ func TestInitAtPath_RejectsHybridExecutableDuplicateEffectiveOperation(t *testin
 	targetManifestPath := writeLocalExecutableOpenAPIPlugin(t, dir, "target", []string{"ping"}, []string{"status"})
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     target:
       source:
         path: %q
@@ -966,7 +966,7 @@ func TestInitAtPath_RejectsSessionCatalogOnlyInvokesTarget(t *testing.T) {
 	targetManifestPath := writeLocalMCPSpecPlugin(t, dir, "target")
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -997,7 +997,7 @@ func TestInitAtPath_DoesNotWriteLockfileWhenInvokesValidationFails(t *testing.T)
 	targetManifestPath := writeLocalExecutablePlugin(t, dir, "target", "ping")
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -1031,7 +1031,7 @@ func TestInitAtPath_RejectsHybridMCPTypoAsUnknownOperation(t *testing.T) {
 	targetManifestPath := writeLocalOpenAPIAndMCPSpecPlugin(t, dir, "target")
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -1065,7 +1065,7 @@ func TestLoadForExecutionAtPath_RejectsInvalidPluginInvokesDependency(t *testing
 	targetManifestPath := writeLocalExecutablePlugin(t, dir, "target", "ping")
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -1143,7 +1143,7 @@ paths:
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -1430,7 +1430,7 @@ plugins:
 			}
 
 			cfgPath := filepath.Join(dir, "config.yaml")
-			cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + tc.uiConfigYAML + tc.extraYAML + `server:
+			cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + tc.uiConfigYAML + tc.extraYAML + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `
 			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -1524,7 +1524,7 @@ func TestLoadForExecutionAtPath_RejectsLockedExplicitLocalUIWithoutPreparedUILoc
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
     roadmap:
       source:
         path: ./ui/manifest.yaml
@@ -1972,7 +1972,8 @@ func TestLoadForExecutionAtPath_UsesDerivedPreparedPathsWhenLockPathsAreStale(t 
 	})
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`providers:
+	cfg := fmt.Sprintf(`apiVersion: %s
+providers:
   indexeddb:
     main:
       source:
@@ -1992,7 +1993,7 @@ server:
   providers:
     indexeddb: main
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-`, indexedDBManifestPath, filepath.Join(dir, "gestalt.db"), uiManifestPath, pluginManifestPath)
+`, config.APIVersionV3, indexedDBManifestPath, filepath.Join(dir, "gestalt.db"), uiManifestPath, pluginManifestPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
@@ -2175,7 +2176,7 @@ func TestLoadForExecutionAtPath_RejectsDisabledLocalMountedUIWithoutLockfile(t *
 
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
     roadmap:
       disabled: true
       source:
@@ -2231,7 +2232,8 @@ func TestInitAtPath_RejectsDisabledManagedHostProvidersWithStructuredSecretRefs(
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	manifestPath := writeStubIndexedDBManifest(t, dir)
-	cfg := `providers:
+	cfg := `apiVersion: ` + config.APIVersionV3 + `
+providers:
   indexeddb:
     sqlite:
       source:
@@ -2592,7 +2594,8 @@ func TestLoadForExecutionAtPath_ResolvesLocalTopLevelPluginsWithoutLockfile(t *t
 	dbPath := filepath.Join(dir, "gestalt.db")
 	idbManifestPath := writeStubIndexedDBManifest(t, dir)
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`providers:
+	cfg := fmt.Sprintf(`apiVersion: %s
+providers:
   authentication:
     auth:
       source:
@@ -2610,7 +2613,7 @@ server:
     authentication: auth
     indexeddb: sqlite
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-`, idbManifestPath, "sqlite://"+dbPath)
+`, config.APIVersionV3, idbManifestPath, "sqlite://"+dbPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
@@ -2681,7 +2684,8 @@ func TestLoadForExecutionAtPath_ResolvesLocalSourceTopLevelPluginsWithoutArtifac
 	dbPath := filepath.Join(dir, "gestalt.db")
 	idbManifestPath := writeStubIndexedDBManifest(t, dir)
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`providers:
+	cfg := fmt.Sprintf(`apiVersion: %s
+providers:
   authentication:
     auth:
       source:
@@ -2697,7 +2701,7 @@ server:
     authentication: auth
     indexeddb: sqlite
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-`, idbManifestPath, "sqlite://"+dbPath)
+`, config.APIVersionV3, idbManifestPath, "sqlite://"+dbPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
@@ -2758,7 +2762,7 @@ func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalSourceHybridPlugin
 	writeTestFile("manifest.yaml", manifest, 0o644)
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -2943,7 +2947,7 @@ def session_catalog(request: gestalt.Request) -> gestalt.Catalog:
 	}
 	writeTestFile("manifest.yaml", manifest, 0o644)
 
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -3285,7 +3289,7 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -3316,7 +3320,7 @@ func TestLockMatchesConfig_FalseWithNilLock(t *testing.T) {
 
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  public:\n    port: 8080\n"), 0644); err != nil {
+	if err := os.WriteFile(cfgPath, []byte("apiVersion: "+config.APIVersionV3+"\nserver:\n  public:\n    port: 8080\n"), 0644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- require every loaded gestaltd YAML config root to declare `apiVersion`
- remove the legacy provider source syntax mode where a missing `apiVersion` made every scalar source a builtin
- update provider-dev generated base/overlay configs and e2e/operator fixtures to emit explicit `gestaltd.config/v3` roots

## New Interface
Every config file passed to `Load`, `LoadPaths`, provider-dev overlays, or daemon commands must include an explicit config API version. Layered override files must declare the same version as the base file.

```yaml
apiVersion: gestaltd.config/v3
providers:
plugins:
  example:
    source: ./plugin/manifest.yaml
```

For v3 configs, scalar local sources point at source manifests:

```yaml
apiVersion: gestaltd.config/v3
plugins:
  example:
    source: ./plugin/manifest.yaml
```

For v4 configs, scalar local sources point at provider-release metadata:

```yaml
apiVersion: gestaltd.config/v4
plugins:
  example:
    source: ./dist/provider-release.yaml
```

Layered config override files must also declare the version:

```yaml
apiVersion: gestaltd.config/v3
plugins:
  example:
    source: ./override-plugin/manifest.yaml
```

Missing or empty `apiVersion` now fails with `config validation: apiVersion is required`. Mixed v3/v4 layered configs continue to fail with the existing mixed-version validation.

## Tests
- `go test ./internal/config`
- `go test ./cmd/gestaltd`
- `go test ./internal/operator`
- `go test ./internal/config ./internal/bootstrap ./internal/providerhost ./internal/server`
- `go test ./...`