### PR TITLE
Prepare gestalt CLI v0.0.1-alpha.8 release

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.1-alpha.7"
+version = "0.0.1-alpha.8"
 edition = "2024"


### PR DESCRIPTION
## Summary

- Bump the Gestalt CLI workspace package version from `0.0.1-alpha.7` to `0.0.1-alpha.8` so the `gestalt/v0.0.1-alpha.8` release tag passes the release workflow version gate.

## Interfaces

Rust/Cargo:

```toml
[workspace.package]
version = "0.0.1-alpha.8"
```

CLI/stdout:

```console
$ gestalt --version
gestalt 0.0.1-alpha.8
```

Release tag:

```console
git tag -a gestalt/v0.0.1-alpha.8 -m "gestalt v0.0.1-alpha.8"
```

## Verification

```console
$ cd gestalt
$ cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name=="gestalt") | .version'
0.0.1-alpha.8
```

No unit tests: this is a release metadata-only change; the release workflow runs the build/test matrix before publishing.