### PR TITLE
Allow platform provider manifest connections

### DIFF
--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -539,7 +539,7 @@ func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error
 			continue
 		}
 		switch conn.Mode {
-		case "none", "user":
+		case providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser, providermanifestv1.ConnectionModePlatform:
 		default:
 			return fmt.Errorf("unsupported provider.connections.%s.mode %q", name, conn.Mode)
 		}

--- a/gestaltd/internal/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/providerpkg/manifest_workflow_test.go
@@ -497,6 +497,54 @@ spec:
 	}
 }
 
+func TestManifestWorkflow_AcceptsPlatformProviderConnection(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/platform-connection
+version: 1.0.0
+spec:
+  defaultConnection: default
+  connections:
+    default:
+      mode: user
+      auth:
+        type: oauth2
+        authorizationUrl: https://auth.example.com/authorize
+        tokenUrl: https://auth.example.com/token
+    bot:
+      displayName: Bot
+      mode: platform
+      auth:
+        type: bearer
+`))
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if manifest.Spec == nil {
+		t.Fatal("expected plugin metadata")
+	}
+	if got := manifest.Spec.Connections["bot"].Mode; got != providermanifestv1.ConnectionModePlatform {
+		t.Fatalf("bot connection mode = %q, want %q", got, providermanifestv1.ConnectionModePlatform)
+	}
+	if got := manifest.Spec.Connections["bot"].Auth.Type; got != providermanifestv1.AuthTypeBearer {
+		t.Fatalf("bot auth type = %q, want %q", got, providermanifestv1.AuthTypeBearer)
+	}
+
+	encoded, err := EncodeSourceManifestFormat(manifest, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+	rendered := string(encoded)
+	if !strings.Contains(rendered, "mode: platform") || !strings.Contains(rendered, "type: bearer") {
+		t.Fatalf("expected canonical platform bearer connection in output:\n%s", rendered)
+	}
+}
+
 func TestManifestWorkflow_AcceptsHostedHTTPBindingsAndSecuritySchemes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes provider package validation so `gestaltd provider release` accepts provider manifests that declare deployment-owned platform connections.

This is the follow-up needed for `valon-technologies/gestalt-providers#279`; its CI currently fails while packaging Slack because the provider-release validator rejects `provider.connections.bot.mode: platform`.

## Old Provider Interface

```yaml
connections:
  bot:
    mode: user
    auth:
      type: oauth2
```

## New Provider Interface

```yaml
connections:
  bot:
    mode: platform
    auth:
      type: bearer
```

## Deployment Example

```yaml
plugins:
  slack:
    connections:
      bot:
        mode: platform
        auth:
          type: bearer
          token:
            secret:
              provider: secrets
              name: slack-bot-token
```

## Details

- Allows `provider.connections.<name>.mode: platform` in provider package manifest validation.
- Keeps HTTP binding `credentialMode` validation unchanged; `credentialMode: platform` is still not a supported override.
- Adds manifest workflow coverage for a Slack-like mixed provider with `default` user OAuth and `bot` platform bearer.

## Validation

```bash
git diff --check
go test ./internal/providerpkg -run 'TestManifestWorkflow_AcceptsPlatformProviderConnection|TestManifestWorkflow_RejectsInvalidManifests' -count=1
go test ./internal/providerpkg -count=1
go build -o /tmp/gestaltd-providerpkg-platform ./cmd/gestaltd
(cd /Users/hugh/src/.worktrees/gestalt-providers-slack-platform-20260428/plugins/slack && /tmp/gestaltd-providerpkg-platform provider release --version 0.0.1-alpha.1 --output /tmp/slack-provider-release-test)
```