### PR TITLE
Prepare gestalt CLI v0.0.1-alpha.9 release

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.1-alpha.8"
+version = "0.0.1-alpha.9"
 edition = "2024"


### PR DESCRIPTION
## Summary

- Bump the Gestalt CLI workspace package version from `0.0.1-alpha.8` to `0.0.1-alpha.9` so the `gestalt/v0.0.1-alpha.9` release tag passes the release workflow version gate.

## Interfaces

Rust/Cargo:

```toml
[workspace.package]
version = "0.0.1-alpha.9"
```

CLI/stdout:

```console
$ gestalt --version
gestalt 0.0.1-alpha.9
```

Release tag:

```console
git tag -a gestalt/v0.0.1-alpha.9 -m "gestalt v0.0.1-alpha.9"
```

## Verification

```console
$ cd gestalt
$ cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name=="gestalt") | .version'
0.0.1-alpha.9
```

No unit tests: this is a release metadata-only change; the release workflow runs the build/test matrix before publishing.