### PR TITLE
[codex] Add HTTP binding labels to operation telemetry

### DIFF
--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -147,7 +147,8 @@ plugin key), `gestalt.operation` (the catalog operation id),
 `gestalt.transport` (how the operation is implemented: `plugin`, `rest`, or
 `mcp-passthrough`), and `gestalt.connection_mode` (the provider auth mode:
 `none` or `user`). When the invocation came from a known surface, they also
-carry `gestalt.invocation_surface`.
+carry `gestalt.invocation_surface`. Hosted HTTP binding invocations also carry
+`gestalt.http_binding`, which is the configured binding name.
 
 Operation metrics also carry `gestalt.result_status` and
 `gestalt.result_status_class`. `gestalt.result_status` is the normalized
@@ -425,7 +426,9 @@ request method, response status, scheme, host, protocol, and route information
 when available. Gestalt also attaches stable dimensions for request surfaces it
 can resolve, including `gestalt.provider`, `gestalt.operation`,
 `gestalt.transport`, `gestalt.connection_mode`, `gestalt.invocation_surface`,
-`gestalt.http_binding`, and `gestalt.ui`.
+`gestalt.http_binding`, and `gestalt.ui`. For hosted HTTP bindings, use
+`gestalt.http_binding` with `gestaltd.operation.*` to correlate the accepted
+HTTP delivery with the provider operation it dispatched.
 
 `http.route` is the framework route template, not the concrete request path. For
 example, a request to `/api/v1/datadog/query_metrics` is grouped under the route

--- a/gestaltd/internal/invocation/context.go
+++ b/gestaltd/internal/invocation/context.go
@@ -54,6 +54,7 @@ type CredentialContext struct {
 }
 
 type invocationSurfaceCtxKey struct{}
+type httpBindingCtxKey struct{}
 type credentialCtxKey struct{}
 type accessCtxKey struct{}
 type workflowCtxKey struct{}
@@ -155,6 +156,19 @@ func WithInvocationSurface(ctx context.Context, surface InvocationSurface) conte
 func InvocationSurfaceFromContext(ctx context.Context) InvocationSurface {
 	surface, _ := ctx.Value(invocationSurfaceCtxKey{}).(InvocationSurface)
 	return surface
+}
+
+func WithHTTPBinding(ctx context.Context, binding string) context.Context {
+	binding = strings.TrimSpace(binding)
+	if binding == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, httpBindingCtxKey{}, binding)
+}
+
+func HTTPBindingFromContext(ctx context.Context) string {
+	binding, _ := ctx.Value(httpBindingCtxKey{}).(string)
+	return strings.TrimSpace(binding)
 }
 
 const xForwardedForHeader = "X-Forwarded-For"

--- a/gestaltd/internal/invocation/metrics.go
+++ b/gestaltd/internal/invocation/metrics.go
@@ -66,6 +66,9 @@ func recordOperationMetrics(
 	if surface := InvocationSurfaceFromContext(ctx); surface != "" {
 		attrs = append(attrs, metricutil.AttrInvocationSurface.String(metricutil.AttrValue(string(surface))))
 	}
+	if binding := HTTPBindingFromContext(ctx); binding != "" {
+		attrs = append(attrs, metricutil.AttrHTTPBinding.String(metricutil.AttrValue(binding)))
+	}
 	metricutil.AddHTTPAttributes(ctx, attrs...)
 
 	metrics.count.Add(ctx, 1, metric.WithAttributes(attrs...))

--- a/gestaltd/internal/server/http_binding_dispatch.go
+++ b/gestaltd/internal/server/http_binding_dispatch.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
@@ -68,6 +69,7 @@ func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding Mou
 	ctx = invocation.WithAccessContext(ctx, s.providerAccessContextWithContext(ctx, p, binding.PluginName))
 	ctx = invocation.WithWorkflowContext(ctx, httpBindingContextValue(binding, verified, parsed))
 	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTP)
+	ctx = invocation.WithHTTPBinding(ctx, binding.Name)
 	if binding.CredentialMode != "" {
 		ctx = invocation.WithCredentialModeOverride(ctx, binding.CredentialMode)
 	}
@@ -76,7 +78,8 @@ func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding Mou
 
 func (s *Server) dispatchHTTPBindingAsync(binding MountedHTTPBinding, p *principal.Principal, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest, requestMeta invocation.RequestMeta) {
 	go func() {
-		ctx := invocation.WithRequestMeta(context.Background(), requestMeta)
+		ctx := metricutil.WithMeterProvider(context.Background(), s.meterProvider)
+		ctx = invocation.WithRequestMeta(ctx, requestMeta)
 		if _, err := s.httpBindingOperationInvocation(ctx, binding, p, verified, parsed); err != nil {
 			slog.Error("http binding async operation failed", "plugin", binding.PluginName, "binding", binding.Name, "operation", binding.Target, "error", err)
 		}

--- a/gestaltd/internal/server/http_binding_subject.go
+++ b/gestaltd/internal/server/http_binding_subject.go
@@ -23,6 +23,7 @@ func (s *Server) resolveHTTPBindingPrincipal(ctx context.Context, binding Mounte
 	resolveCtx = invocation.WithAccessContext(resolveCtx, s.providerAccessContextWithContext(resolveCtx, bindingPrincipal, binding.PluginName))
 	resolveCtx = invocation.WithWorkflowContext(resolveCtx, httpBindingContextValue(binding, verified, parsed))
 	resolveCtx = invocation.WithInvocationSurface(resolveCtx, invocation.InvocationSurfaceHTTP)
+	resolveCtx = invocation.WithHTTPBinding(resolveCtx, binding.Name)
 
 	resolved, supported, err := core.ResolveHTTPSubject(resolveCtx, prov, &core.HTTPSubjectResolveRequest{
 		Binding:         binding.Name,

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -15,11 +15,13 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/session"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
@@ -84,6 +86,45 @@ func hasMetricWithPrefix(rm metricdata.ResourceMetrics, prefix string) bool {
 		}
 	}
 	return false
+}
+
+func hasInt64SumMetric(rm metricdata.ResourceMetrics, name string, want int64, attrs map[string]string) bool {
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, point := range sum.DataPoints {
+				if metrictest.AttrsMatch(point.Attributes, attrs) && point.Value == want {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func collectMetricsUntil(t *testing.T, metrics *metrictest.ManualMeterProvider, ready func(metricdata.ResourceMetrics) bool) metricdata.ResourceMetrics {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var rm metricdata.ResourceMetrics
+		if err := metrics.Reader.Collect(context.Background(), &rm); err != nil {
+			t.Fatalf("collect metrics: %v", err)
+		}
+		if ready(rm) {
+			return rm
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for expected metrics")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func TestConnectionAuthMetrics(t *testing.T) {
@@ -672,6 +713,105 @@ func TestHTTPMetricsDoNotLabelUnknownPluginRouteParams(t *testing.T) {
 	routeAttrs := map[string]string{"http.route": "/api/v1/{integration}/{operation}"}
 	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", routeAttrs, "gestalt.provider")
 	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", routeAttrs, "gestalt.operation")
+}
+
+func TestHTTPBindingOperationMetricsIncludeBinding(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	const providerName = "webhook-metrics"
+	bindingsSeen := make(chan string, 1)
+	operationDone := make(chan struct{}, 1)
+
+	provider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        providerName,
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(ctx context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				defer func() { operationDone <- struct{}{} }()
+				bindingsSeen <- invocation.HTTPBindingFromContext(ctx)
+				if operation == "receive_event" {
+					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+				}
+				return &core.OperationResult{Status: http.StatusNotFound, Body: `{}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "receive_event", Method: http.MethodPost}},
+	}
+
+	srv := newTestServer(t, func(cfg *server.Config) {
+		cfg.MeterProvider = metrics.Provider
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			providerName: {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"public": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"delivery": {
+						Path:     "/delivery",
+						Method:   http.MethodPost,
+						Security: "public",
+						Target:   "receive_event",
+						Ack: &providermanifestv1.HTTPAck{
+							Status: http.StatusAccepted,
+							Body:   map[string]any{"accepted": true},
+						},
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.PluginDefs)
+	})
+	testutil.CloseOnCleanup(t, srv)
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/"+providerName+"/delivery", strings.NewReader(`{"event":"opened"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http binding request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("http binding status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+
+	select {
+	case got := <-bindingsSeen:
+		if got != "delivery" {
+			t.Fatalf("HTTPBindingFromContext = %q, want %q", got, "delivery")
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for http binding invocation")
+	}
+	select {
+	case <-operationDone:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for http binding operation completion")
+	}
+
+	attrs := map[string]string{
+		"gestalt.provider":            providerName,
+		"gestalt.operation":           "receive_event",
+		"gestalt.transport":           "rest",
+		"gestalt.connection_mode":     "none",
+		"gestalt.invocation_surface":  "http",
+		"gestalt.http_binding":        "delivery",
+		"gestalt.result_status":       "200",
+		"gestalt.result_status_class": "2xx",
+	}
+	rm := collectMetricsUntil(t, metrics, func(rm metricdata.ResourceMetrics) bool {
+		return hasInt64SumMetric(rm, "gestaltd.operation.count", 1, attrs)
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.count", 1, attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.operation.duration", attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", map[string]string{
+		"http.route":                 "/api/v1/" + providerName + "/delivery",
+		"gestalt.provider":           providerName,
+		"gestalt.operation":          "receive_event",
+		"gestalt.invocation_surface": "http",
+		"gestalt.http_binding":       "delivery",
+	})
 }
 
 func TestHTTPDiscoveryMetrics(t *testing.T) {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -111,6 +111,7 @@ type Server struct {
 	apiTokenTTL            time.Duration
 	now                    func() time.Time
 	readiness              ReadinessChecker
+	meterProvider          metric.MeterProvider
 	prometheusMetrics      http.Handler
 	mcpHandler             http.Handler
 	hostServiceRelayTokens *providerhost.HostServiceRelayTokenManager
@@ -330,6 +331,7 @@ func New(cfg Config) (*Server, error) {
 		apiTokenTTL:            cfg.APITokenTTL,
 		now:                    now,
 		readiness:              cfg.Readiness,
+		meterProvider:          cfg.MeterProvider,
 		prometheusMetrics:      cfg.PrometheusMetrics,
 		mcpHandler:             cfg.MCPHandler,
 		hostServiceRelayTokens: hostServiceRelayTokens,


### PR DESCRIPTION
## Summary

Adds hosted HTTP binding identity to `gestaltd.operation.*` telemetry so operators can connect an accepted HTTP binding delivery to the provider operation it dispatches.

This keeps the existing telemetry shape intact: inbound HTTP still comes from the server OTel middleware, and provider-operation telemetry still comes from the broker. The change only adds the binding dimension when the invocation came from a hosted HTTP binding.

## New Interfaces

```go
ctx = invocation.WithHTTPBinding(ctx, binding.Name)
bindingName := invocation.HTTPBindingFromContext(ctx)
```

`WithHTTPBinding` stores the configured hosted HTTP binding name on the invocation context. `HTTPBindingFromContext` reads it back for provider dispatch, tests, and broker metric instrumentation.

## Examples

Hosted HTTP binding dispatch now seeds the context before invoking the provider operation:

```go
ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTP)
ctx = invocation.WithHTTPBinding(ctx, binding.Name)
result, err := invoker.Invoke(ctx, principal, binding.PluginName, "", binding.Target, params)
```

Operation telemetry can now be split by binding:

```text
sum:gestaltd.operation.count{gestalt.http_binding:delivery}
  by {gestalt.provider,gestalt.operation,gestalt.result_status}
```

Async acked bindings also retain the configured meter provider when they dispatch from a background context, so their broker metrics land in the server telemetry pipeline.

## Validation

- `go test ./internal/server ./internal/invocation`
- `go test ./cmd/gestaltd -run TestE2EHostedHTTPSubjectResolutionUsesAuthorizationAndInheritedInvocation -count=1`

Note: one full `go test ./...` run initially hit a `cmd/gestaltd` e2e readiness timeout in `TestE2EHostedHTTPSubjectResolutionUsesAuthorizationAndInheritedInvocation`; rerunning that test directly passed.