### PR TITLE
workflow: accept canonical target fingerprints

### DIFF
--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -311,25 +311,49 @@ type Host interface {
 }
 
 func TargetFingerprint(target Target) (string, error) {
-	if target.Agent != nil && target.Plugin != nil && PluginTargetSet(*target.Plugin) {
-		return "", fmt.Errorf("target cannot include both agent and plugin fields")
+	return legacyTargetFingerprint(target)
+}
+
+// TargetFingerprintMatches reports whether fingerprint matches the canonical
+// target fingerprint or a legacy fingerprint written before target nesting.
+func TargetFingerprintMatches(target Target, fingerprint string) (bool, error) {
+	fingerprint = strings.TrimSpace(fingerprint)
+	if fingerprint == "" {
+		return false, nil
 	}
-	payload, err := json.Marshal(normalizedTargetFingerprintPayload(target))
+	current, err := TargetFingerprint(target)
+	if err != nil {
+		return false, err
+	}
+	if current == fingerprint {
+		return true, nil
+	}
+	canonical, err := canonicalTargetFingerprint(target)
+	if err != nil {
+		return false, err
+	}
+	return canonical == fingerprint, nil
+}
+
+func targetFingerprint(payload any) (string, error) {
+	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
 		return "", err
 	}
-	sum := sha256.Sum256(payload)
+	sum := sha256.Sum256(payloadJSON)
 	return hex.EncodeToString(sum[:]), nil
 }
 
 type targetFingerprintPayload struct {
-	PluginName string
-	Operation  string
-	Connection string
-	Instance   string
-	Input      map[string]any
-	Plugin     *PluginTarget
-	Agent      *AgentTarget
+	Plugin *PluginTarget
+	Agent  *AgentTarget
+}
+
+func canonicalTargetFingerprint(target Target) (string, error) {
+	if target.Agent != nil && target.Plugin != nil && PluginTargetSet(*target.Plugin) {
+		return "", fmt.Errorf("target cannot include both agent and plugin fields")
+	}
+	return targetFingerprint(normalizedTargetFingerprintPayload(target))
 }
 
 func normalizedTargetFingerprintPayload(target Target) targetFingerprintPayload {
@@ -362,6 +386,28 @@ func normalizedTargetFingerprintPayload(target Target) targetFingerprintPayload 
 		out.Plugin = &pluginTarget
 	}
 	return out
+}
+
+func legacyTargetFingerprint(target Target) (string, error) {
+	if target.Agent != nil && target.Plugin != nil && PluginTargetSet(*target.Plugin) {
+		return "", fmt.Errorf("target cannot include both agent and plugin fields")
+	}
+	normalized := normalizedTargetFingerprintPayload(target)
+	payload := legacyTargetFingerprintPayload{
+		Plugin: normalized.Plugin,
+		Agent:  normalized.Agent,
+	}
+	return targetFingerprint(payload)
+}
+
+type legacyTargetFingerprintPayload struct {
+	PluginName string
+	Operation  string
+	Connection string
+	Instance   string
+	Input      map[string]any
+	Plugin     *PluginTarget
+	Agent      *AgentTarget
 }
 
 // PluginTargetSet reports whether a workflow target contains any plugin target field.

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -286,11 +286,11 @@ func (r *workflowRuntime) resolveWorkflowExecutionRef(ctx context.Context, req c
 		return nil, fmt.Errorf("%w: workflow execution ref %q is not valid for provider %q", invocation.ErrAuthorizationDenied, refID, req.ProviderName)
 	}
 	if strings.TrimSpace(ref.TargetFingerprint) != "" {
-		fingerprint, err := coreworkflow.TargetFingerprint(req.Target)
+		matches, err := coreworkflow.TargetFingerprintMatches(req.Target, ref.TargetFingerprint)
 		if err != nil {
 			return nil, fmt.Errorf("%w: workflow execution ref %q target fingerprint failed: %v", invocation.ErrInternal, refID, err)
 		}
-		if fingerprint != strings.TrimSpace(ref.TargetFingerprint) {
+		if !matches {
 			return nil, fmt.Errorf("%w: workflow execution ref %q target does not match the scheduled invocation", invocation.ErrAuthorizationDenied, refID)
 		}
 		return ref, nil

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -49,8 +49,10 @@ func testWorkflowPluginTargetWithInput(pluginName, operation, connection, instan
 }
 
 const (
-	legacyAgentWorkflowTargetFingerprint  = "35e6581a2588dfe3a3885a9e6a98f83fd8444d1408fb22d5d0df08e6811b2c5c"
-	legacyPluginWorkflowTargetFingerprint = "0df33294a540a423e6f3982c190e54505f0415c7856cc3389eb13042415e8796"
+	canonicalAgentWorkflowTargetFingerprint  = "df7c3d7dde92c5807d3268e17d2e2996163442f06624d003c7008e35be508b63"
+	canonicalPluginWorkflowTargetFingerprint = "ba910105b28aa331501c9ec3c34de4c0b67ff58204e0ec4a428122c089bb64a7"
+	legacyAgentWorkflowTargetFingerprint     = "35e6581a2588dfe3a3885a9e6a98f83fd8444d1408fb22d5d0df08e6811b2c5c"
+	legacyPluginWorkflowTargetFingerprint    = "0df33294a540a423e6f3982c190e54505f0415c7856cc3389eb13042415e8796"
 )
 
 func (f funcInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
@@ -517,7 +519,7 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 	}
 }
 
-func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefAcceptsStoredLegacyFingerprint(t *testing.T) {
+func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefAcceptsStoredFingerprints(t *testing.T) {
 	t.Parallel()
 
 	target := coreworkflow.Target{
@@ -529,54 +531,67 @@ func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefAcceptsStoredLegacyFing
 			TimeoutSeconds: 5,
 		},
 	}
-	refProvider := newWorkflowRuntimeExecutionRefProvider()
-	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:                "agent-ref",
-		ProviderName:      "temporal",
-		Target:            target,
-		TargetFingerprint: legacyAgentWorkflowTargetFingerprint,
-		CallerPluginName:  "slack",
-		SubjectID:         "service_account:scheduler",
-	}); err != nil {
-		t.Fatalf("Put execution ref: %v", err)
-	}
-	agentManager := &workflowRuntimeAgentManagerStub{}
-	runtime := &workflowRuntime{
-		providers: map[string]coreworkflow.Provider{"temporal": refProvider},
-	}
-	runtime.SetAgentManager(agentManager)
+	for _, tt := range []struct {
+		name        string
+		fingerprint string
+	}{
+		{name: "legacy", fingerprint: legacyAgentWorkflowTargetFingerprint},
+		{name: "canonical", fingerprint: canonicalAgentWorkflowTargetFingerprint},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
-		ProviderName: "temporal",
-		ExecutionRef: "agent-ref",
-		RunID:        "run-agent-123",
-		Target:       target,
-		Signals: []coreworkflow.Signal{{
-			ID:             "sig-1",
-			Name:           "slack.message",
-			Payload:        map[string]any{"text": "new message"},
-			IdempotencyKey: "evt-1",
-			Sequence:       42,
-		}},
-	})
-	if err != nil {
-		t.Fatalf("Invoke: %v", err)
-	}
-	if resp.Status != http.StatusOK || resp.Body != "turn completed" {
-		t.Fatalf("response = %#v", resp)
-	}
-	if len(agentManager.createTurnRequests) != 1 {
-		t.Fatalf("turn requests = %d, want 1", len(agentManager.createTurnRequests))
-	}
-	turnReq := agentManager.createTurnRequests[0]
-	if turnReq.CallerPluginName != "slack" {
-		t.Fatalf("caller plugin = %q, want slack", turnReq.CallerPluginName)
-	}
-	if !strings.HasPrefix(turnReq.IdempotencyKey, "workflow:temporal:run-agent-123:turn:signal-batch-") {
-		t.Fatalf("turn idempotency key = %q", turnReq.IdempotencyKey)
-	}
-	if len(turnReq.Messages) != 2 || turnReq.Messages[0].Text != "Send the status summary" || !strings.Contains(turnReq.Messages[1].Text, `"name": "slack.message"`) {
-		t.Fatalf("turn messages = %#v", turnReq.Messages)
+			refProvider := newWorkflowRuntimeExecutionRefProvider()
+			if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+				ID:                "agent-ref-" + tt.name,
+				ProviderName:      "temporal",
+				Target:            target,
+				TargetFingerprint: tt.fingerprint,
+				CallerPluginName:  "slack",
+				SubjectID:         "service_account:scheduler",
+			}); err != nil {
+				t.Fatalf("Put execution ref: %v", err)
+			}
+			agentManager := &workflowRuntimeAgentManagerStub{}
+			runtime := &workflowRuntime{
+				providers: map[string]coreworkflow.Provider{"temporal": refProvider},
+			}
+			runtime.SetAgentManager(agentManager)
+
+			resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+				ProviderName: "temporal",
+				ExecutionRef: "agent-ref-" + tt.name,
+				RunID:        "run-agent-123",
+				Target:       target,
+				Signals: []coreworkflow.Signal{{
+					ID:             "sig-1",
+					Name:           "slack.message",
+					Payload:        map[string]any{"text": "new message"},
+					IdempotencyKey: "evt-1",
+					Sequence:       42,
+				}},
+			})
+			if err != nil {
+				t.Fatalf("Invoke: %v", err)
+			}
+			if resp.Status != http.StatusOK || resp.Body != "turn completed" {
+				t.Fatalf("response = %#v", resp)
+			}
+			if len(agentManager.createTurnRequests) != 1 {
+				t.Fatalf("turn requests = %d, want 1", len(agentManager.createTurnRequests))
+			}
+			turnReq := agentManager.createTurnRequests[0]
+			if turnReq.CallerPluginName != "slack" {
+				t.Fatalf("caller plugin = %q, want slack", turnReq.CallerPluginName)
+			}
+			if !strings.HasPrefix(turnReq.IdempotencyKey, "workflow:temporal:run-agent-123:turn:signal-batch-") {
+				t.Fatalf("turn idempotency key = %q", turnReq.IdempotencyKey)
+			}
+			if len(turnReq.Messages) != 2 || turnReq.Messages[0].Text != "Send the status summary" || !strings.Contains(turnReq.Messages[1].Text, `"name": "slack.message"`) {
+				t.Fatalf("turn messages = %#v", turnReq.Messages)
+			}
+		})
 	}
 }
 
@@ -768,45 +783,59 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 func TestWorkflowRuntimeInvokeExecutionRefUsesStoredSubjectPrincipal(t *testing.T) {
 	t.Parallel()
 
-	refProvider := newWorkflowRuntimeExecutionRefProvider()
-	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:                "exec-ref-service-account",
-		ProviderName:      "temporal",
-		Target:            testWorkflowPluginTarget("roadmap", "sync"),
-		TargetFingerprint: legacyPluginWorkflowTargetFingerprint,
-		SubjectID:         "service_account:scheduler",
-	}); err != nil {
-		t.Fatalf("Put execution ref: %v", err)
-	}
+	for _, tt := range []struct {
+		name        string
+		fingerprint string
+	}{
+		{name: "legacy", fingerprint: legacyPluginWorkflowTargetFingerprint},
+		{name: "canonical", fingerprint: canonicalPluginWorkflowTargetFingerprint},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	runtime := &workflowRuntime{
-		providers: map[string]coreworkflow.Provider{"temporal": refProvider},
-	}
+			refID := "exec-ref-service-account-" + tt.name
+			refProvider := newWorkflowRuntimeExecutionRefProvider()
+			if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+				ID:                refID,
+				ProviderName:      "temporal",
+				Target:            testWorkflowPluginTarget("roadmap", "sync"),
+				TargetFingerprint: tt.fingerprint,
+				SubjectID:         "service_account:scheduler",
+			}); err != nil {
+				t.Fatalf("Put execution ref: %v", err)
+			}
 
-	var gotPrincipal *principal.Principal
-	runtime.SetInvoker(funcInvoker{
-		invoke: func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
-			gotPrincipal = p
-			return &core.OperationResult{Status: http.StatusAccepted, Body: `{"ok":true}`}, nil
-		},
-	})
+			runtime := &workflowRuntime{
+				providers: map[string]coreworkflow.Provider{"temporal": refProvider},
+			}
 
-	if _, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
-		ProviderName: "temporal",
-		ExecutionRef: "exec-ref-service-account",
-		Target:       testWorkflowPluginTarget("roadmap", "sync"),
-	}); err != nil {
-		t.Fatalf("Invoke: %v", err)
-	}
+			var gotPrincipal *principal.Principal
+			runtime.SetInvoker(funcInvoker{
+				invoke: func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
+					gotPrincipal = p
+					return &core.OperationResult{Status: http.StatusAccepted, Body: `{"ok":true}`}, nil
+				},
+			})
 
-	if gotPrincipal == nil {
-		t.Fatal("principal = nil")
-	}
-	if gotPrincipal.Kind != principal.Kind("service_account") {
-		t.Fatalf("principal kind = %q, want %q", gotPrincipal.Kind, principal.Kind("service_account"))
-	}
-	if gotPrincipal.SubjectID != "service_account:scheduler" {
-		t.Fatalf("subjectID = %q, want %q", gotPrincipal.SubjectID, "service_account:scheduler")
+			if _, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+				ProviderName: "temporal",
+				ExecutionRef: refID,
+				Target:       testWorkflowPluginTarget("roadmap", "sync"),
+			}); err != nil {
+				t.Fatalf("Invoke: %v", err)
+			}
+
+			if gotPrincipal == nil {
+				t.Fatal("principal = nil")
+			}
+			if gotPrincipal.Kind != principal.Kind("service_account") {
+				t.Fatalf("principal kind = %q, want %q", gotPrincipal.Kind, principal.Kind("service_account"))
+			}
+			if gotPrincipal.SubjectID != "service_account:scheduler" {
+				t.Fatalf("subjectID = %q, want %q", gotPrincipal.SubjectID, "service_account:scheduler")
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -1445,8 +1445,8 @@ func targetMatchesExecutionRef(target coreworkflow.Target, ref *coreworkflow.Exe
 		return false
 	}
 	if strings.TrimSpace(ref.TargetFingerprint) != "" {
-		fingerprint, err := coreworkflow.TargetFingerprint(target)
-		return err == nil && fingerprint == strings.TrimSpace(ref.TargetFingerprint)
+		matches, err := coreworkflow.TargetFingerprintMatches(target, ref.TargetFingerprint)
+		return err == nil && matches
 	}
 	if ref.Target.Agent != nil || target.Agent != nil {
 		return false

--- a/gestaltd/internal/workflowmanager/manager_test.go
+++ b/gestaltd/internal/workflowmanager/manager_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
+const canonicalManagerAgentWorkflowTargetFingerprint = "ad3621e6b034d26e8ef7b542e891eadcbca58a2d663bd998a758d2544204410e"
+
 func TestSignalOrStartRunExecutionRefInheritsDeclaredAgentToolInvokes(t *testing.T) {
 	t.Parallel()
 
@@ -138,15 +140,11 @@ func TestSignalRunUsesCurrentPrincipalForTargetValidation(t *testing.T) {
 			{Plugin: "github", Operation: "bot.openPullRequest"},
 		},
 	}}
-	targetFingerprint, err := coreworkflow.TargetFingerprint(target)
-	if err != nil {
-		t.Fatalf("TargetFingerprint: %v", err)
-	}
 	ref := &coreworkflow.ExecutionReference{
 		ID:                "workflow_run:stale-permissions",
 		ProviderName:      "local",
 		Target:            target,
-		TargetFingerprint: targetFingerprint,
+		TargetFingerprint: canonicalManagerAgentWorkflowTargetFingerprint,
 		SubjectID:         "system:http_binding:github:event",
 		Permissions: []core.AccessPermission{{
 			Plugin:     "github",


### PR DESCRIPTION
## Summary

Adds the compatibility-first read path for workflow target fingerprint migration without changing current writes.

Current writes stay legacy-compatible for rolling deploy safety:

```go
fingerprint, err := workflow.TargetFingerprint(target)
```

Validation can now accept both the current legacy hash and the future canonical nested target hash:

```go
matches, err := workflow.TargetFingerprintMatches(target, stored.TargetFingerprint)
```

Runtime and workflow-manager execution-ref validation now use `TargetFingerprintMatches`. Config-managed workflow reconciliation still reuses existing refs; this PR intentionally does not rotate/revoke refs for fingerprint-only migration. A later PR can flip writes to canonical once this dual-read code is deployed everywhere.

## Verification

```sh
go test ./core/workflow ./internal/bootstrap ./internal/workflowmanager
```
