### PR TITLE
Align gestaltd telemetry metrics with OTel semconv

### DIFF
--- a/gestaltd/internal/invocation/metrics.go
+++ b/gestaltd/internal/invocation/metrics.go
@@ -63,13 +63,28 @@ func recordOperationMetrics(
 		metricutil.AttrResultStatus.String(resultStatusValue),
 		metricutil.AttrResultStatusClass.String(resultStatusClass),
 	}
-	if surface := InvocationSurfaceFromContext(ctx); surface != "" {
+	surface := InvocationSurfaceFromContext(ctx)
+	binding := HTTPBindingFromContext(ctx)
+	if surface != "" {
 		attrs = append(attrs, metricutil.AttrInvocationSurface.String(metricutil.AttrValue(string(surface))))
 	}
-	if binding := HTTPBindingFromContext(ctx); binding != "" {
+	if binding != "" {
 		attrs = append(attrs, metricutil.AttrHTTPBinding.String(metricutil.AttrValue(binding)))
 	}
-	metricutil.AddHTTPAttributes(ctx, attrs...)
+	httpDims := metricutil.HTTPMetricDims{
+		ProviderName:   provider,
+		OperationName:  operation,
+		Transport:      transport,
+		ConnectionMode: connectionMode,
+	}
+	if surface != "" {
+		httpDims.Surface = string(surface)
+	}
+	if binding != "" {
+		httpDims.HTTPBindingName = binding
+		httpDims.Surface = metricutil.InvocationSurfaceHTTPBinding
+	}
+	metricutil.AddHTTPServerMetricDims(ctx, httpDims)
 
 	metrics.count.Add(ctx, 1, metric.WithAttributes(attrs...))
 	duration := time.Since(startedAt)

--- a/gestaltd/internal/metricutil/attrs.go
+++ b/gestaltd/internal/metricutil/attrs.go
@@ -2,6 +2,7 @@ package metricutil
 
 import (
 	"context"
+	"strings"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -23,6 +24,36 @@ const (
 	AttrResultStatus      = attribute.Key("gestalt.result_status")
 	AttrResultStatusClass = attribute.Key("gestalt.result_status_class")
 	AttrHTTPRoute         = attribute.Key("http.route")
+
+	attrGestaltdProviderName       = attribute.Key("gestaltd.provider.name")
+	attrGestaltdOperationName      = attribute.Key("gestaltd.operation.name")
+	attrGestaltdOperationTransport = attribute.Key("gestaltd.operation.transport")
+	attrGestaltdConnectionMode     = attribute.Key("gestaltd.connection.mode")
+	attrGestaltdInvocationSurface  = attribute.Key("gestaltd.invocation.surface")
+	attrGestaltdHTTPBindingName    = attribute.Key("gestaltd.http.binding.name")
+	attrGestaltdUIName             = attribute.Key("gestaltd.ui.name")
+	attrGestaltdRPCRole            = attribute.Key("gestaltd.rpc.role")
+	attrGestaltdHostServiceName    = attribute.Key("gestaltd.host_service.name")
+	attrGestaltdIndexedDBIndexName = attribute.Key("gestaltd.indexeddb.index.name")
+
+	attrDBSystemName     = attribute.Key("db.system.name")
+	attrDBNamespace      = attribute.Key("db.namespace")
+	attrDBCollectionName = attribute.Key("db.collection.name")
+	attrDBOperationName  = attribute.Key("db.operation.name")
+	attrErrorType        = attribute.Key("error.type")
+)
+
+const (
+	InvocationSurfaceHTTP        = "http"
+	InvocationSurfaceHTTPBinding = "http_binding"
+	InvocationSurfaceUI          = "ui"
+
+	RPCRoleProviderClient     = "provider_client"
+	RPCRoleProviderServer     = "provider_server"
+	RPCRoleHostedPluginClient = "hosted_plugin_client"
+	RPCRoleHostServiceServer  = "host_service_server"
+
+	DBSystemNameGestaltdIndexedDB = "gestaltd.indexeddb"
 )
 
 type TelemetryProviders interface {
@@ -30,33 +61,58 @@ type TelemetryProviders interface {
 	TracerProvider() trace.TracerProvider
 }
 
-func AddHTTPAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
-	if len(attrs) == 0 {
-		return
-	}
-	if labeler, ok := otelhttp.LabelerFromContext(ctx); ok {
-		missing := make([]attribute.KeyValue, 0, len(attrs))
-		existing := make(map[attribute.Key]struct{}, len(labeler.Get()))
-		for _, attr := range labeler.Get() {
-			existing[attr.Key] = struct{}{}
-		}
-		for _, attr := range attrs {
-			if _, ok := existing[attr.Key]; ok {
-				continue
-			}
-			missing = append(missing, attr)
-		}
-		if len(missing) > 0 {
-			labeler.Add(missing...)
-		}
-	}
-	span := trace.SpanFromContext(ctx)
-	if span.IsRecording() {
-		span.SetAttributes(attrs...)
-	}
+type HTTPMetricDims struct {
+	ProviderName    string
+	OperationName   string
+	Transport       string
+	ConnectionMode  string
+	Surface         string
+	HTTPBindingName string
+	UIName          string
 }
 
-func GRPCOptions(telemetry TelemetryProviders, attrs ...attribute.KeyValue) []otelgrpc.Option {
+type RPCMetricDims struct {
+	Role            string
+	ProviderName    string
+	HostServiceName string
+}
+
+type DBMetricDims struct {
+	SystemName     string
+	Namespace      string
+	CollectionName string
+	OperationName  string
+	ProviderName   string
+	IndexName      string
+	ErrorType      string
+}
+
+func HTTPServerAttrs(dims HTTPMetricDims) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 7)
+	attrs = appendStringAttr(attrs, attrGestaltdProviderName, dims.ProviderName)
+	attrs = appendStringAttr(attrs, attrGestaltdOperationName, dims.OperationName)
+	attrs = appendStringAttr(attrs, attrGestaltdOperationTransport, dims.Transport)
+	attrs = appendStringAttr(attrs, attrGestaltdConnectionMode, dims.ConnectionMode)
+	attrs = appendStringAttr(attrs, attrGestaltdInvocationSurface, dims.Surface)
+	attrs = appendStringAttr(attrs, attrGestaltdHTTPBindingName, dims.HTTPBindingName)
+	attrs = appendStringAttr(attrs, attrGestaltdUIName, dims.UIName)
+	return attrs
+}
+
+func AddHTTPServerMetricDims(ctx context.Context, dims HTTPMetricDims) {
+	AddHTTPAttributes(ctx, HTTPServerAttrs(dims)...)
+}
+
+func RPCAttrs(dims RPCMetricDims) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 3)
+	attrs = appendStringAttr(attrs, attrGestaltdRPCRole, dims.Role)
+	attrs = appendStringAttr(attrs, attrGestaltdProviderName, dims.ProviderName)
+	attrs = appendStringAttr(attrs, attrGestaltdHostServiceName, dims.HostServiceName)
+	return attrs
+}
+
+func GRPCMetricOptions(telemetry TelemetryProviders, dims RPCMetricDims) []otelgrpc.Option {
+	attrs := RPCAttrs(dims)
 	opts := make([]otelgrpc.Option, 0, 4)
 	if telemetry != nil {
 		if mp := telemetry.MeterProvider(); mp != nil {
@@ -73,4 +129,61 @@ func GRPCOptions(telemetry TelemetryProviders, attrs ...attribute.KeyValue) []ot
 		)
 	}
 	return opts
+}
+
+func DBClientAttrs(dims DBMetricDims) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 7)
+	attrs = appendStringAttr(attrs, attrDBSystemName, dims.SystemName)
+	attrs = appendStringAttr(attrs, attrDBNamespace, dims.Namespace)
+	attrs = appendStringAttr(attrs, attrDBCollectionName, dims.CollectionName)
+	attrs = appendStringAttr(attrs, attrDBOperationName, dims.OperationName)
+	attrs = appendStringAttr(attrs, attrGestaltdProviderName, dims.ProviderName)
+	attrs = appendStringAttr(attrs, attrGestaltdIndexedDBIndexName, dims.IndexName)
+	attrs = appendStringAttr(attrs, attrErrorType, dims.ErrorType)
+	return attrs
+}
+
+func appendStringAttr(attrs []attribute.KeyValue, key attribute.Key, value string) []attribute.KeyValue {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return attrs
+	}
+	return append(attrs, key.String(value))
+}
+
+func AddHTTPAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		return
+	}
+	if labeler, ok := otelhttp.LabelerFromContext(ctx); ok {
+		addMissingHTTPAttributes(labeler, attrs...)
+	}
+	addSpanAttributes(ctx, attrs...)
+}
+
+func addMissingHTTPAttributes(labeler *otelhttp.Labeler, attrs ...attribute.KeyValue) {
+	missing := make([]attribute.KeyValue, 0, len(attrs))
+	existing := make(map[attribute.Key]struct{}, len(labeler.Get()))
+	for _, attr := range labeler.Get() {
+		existing[attr.Key] = struct{}{}
+	}
+	for _, attr := range attrs {
+		if _, ok := existing[attr.Key]; ok {
+			continue
+		}
+		missing = append(missing, attr)
+	}
+	if len(missing) > 0 {
+		labeler.Add(missing...)
+	}
+}
+
+func addSpanAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if span.IsRecording() {
+		span.SetAttributes(attrs...)
+	}
 }

--- a/gestaltd/internal/metricutil/indexeddb.go
+++ b/gestaltd/internal/metricutil/indexeddb.go
@@ -72,88 +72,90 @@ type instrumentedObjectStore struct {
 func (s *instrumentedObjectStore) Get(ctx context.Context, id string) (indexeddb.Record, error) {
 	startedAt := time.Now()
 	rec, err := s.inner.Get(ctx, id)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Get", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Get", err)
 	return rec, err
 }
 
 func (s *instrumentedObjectStore) GetKey(ctx context.Context, id string) (string, error) {
 	startedAt := time.Now()
 	key, err := s.inner.GetKey(ctx, id)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "GetKey", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "GetKey", err)
 	return key, err
 }
 
 func (s *instrumentedObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
 	startedAt := time.Now()
 	err := s.inner.Add(ctx, record)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Add", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Add", err)
 	return err
 }
 
 func (s *instrumentedObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
 	startedAt := time.Now()
 	err := s.inner.Put(ctx, record)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Put", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Put", err)
 	return err
 }
 
 func (s *instrumentedObjectStore) Delete(ctx context.Context, id string) error {
 	startedAt := time.Now()
 	err := s.inner.Delete(ctx, id)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Delete", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Delete", err)
 	return err
 }
 
 func (s *instrumentedObjectStore) Clear(ctx context.Context) error {
 	startedAt := time.Now()
 	err := s.inner.Clear(ctx)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Clear", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Clear", err)
 	return err
 }
 
 func (s *instrumentedObjectStore) GetAll(ctx context.Context, r *indexeddb.KeyRange) ([]indexeddb.Record, error) {
 	startedAt := time.Now()
 	recs, err := s.inner.GetAll(ctx, r)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "GetAll", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "GetAll", err)
 	return recs, err
 }
 
 func (s *instrumentedObjectStore) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange) ([]string, error) {
 	startedAt := time.Now()
 	keys, err := s.inner.GetAllKeys(ctx, r)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "GetAllKeys", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "GetAllKeys", err)
 	return keys, err
 }
 
 func (s *instrumentedObjectStore) Count(ctx context.Context, r *indexeddb.KeyRange) (int64, error) {
 	startedAt := time.Now()
 	n, err := s.inner.Count(ctx, r)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Count", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Count", err)
 	return n, err
 }
 
 func (s *instrumentedObjectStore) DeleteRange(ctx context.Context, r indexeddb.KeyRange) (int64, error) {
 	startedAt := time.Now()
 	n, err := s.inner.DeleteRange(ctx, r)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "DeleteRange", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "DeleteRange", err)
 	return n, err
 }
 
 func (s *instrumentedObjectStore) Index(name string) indexeddb.Index {
-	return &instrumentedIndex{inner: s.inner.Index(name), labels: s.labels}
+	labels := s.labels
+	labels.IndexName = name
+	return &instrumentedIndex{inner: s.inner.Index(name), labels: labels}
 }
 
 func (s *instrumentedObjectStore) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
 	startedAt := time.Now()
 	c, err := s.inner.OpenCursor(ctx, r, dir)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "OpenCursor", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "OpenCursor", err)
 	return c, err
 }
 
 func (s *instrumentedObjectStore) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
 	startedAt := time.Now()
 	c, err := s.inner.OpenKeyCursor(ctx, r, dir)
-	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "OpenKeyCursor", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "OpenKeyCursor", err)
 	return c, err
 }
 
@@ -165,55 +167,55 @@ type instrumentedIndex struct {
 func (i *instrumentedIndex) Get(ctx context.Context, values ...any) (indexeddb.Record, error) {
 	startedAt := time.Now()
 	rec, err := i.inner.Get(ctx, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.Get", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.Get", err)
 	return rec, err
 }
 
 func (i *instrumentedIndex) GetKey(ctx context.Context, values ...any) (string, error) {
 	startedAt := time.Now()
 	key, err := i.inner.GetKey(ctx, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.GetKey", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.GetKey", err)
 	return key, err
 }
 
 func (i *instrumentedIndex) GetAll(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]indexeddb.Record, error) {
 	startedAt := time.Now()
 	recs, err := i.inner.GetAll(ctx, r, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.GetAll", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.GetAll", err)
 	return recs, err
 }
 
 func (i *instrumentedIndex) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]string, error) {
 	startedAt := time.Now()
 	keys, err := i.inner.GetAllKeys(ctx, r, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.GetAllKeys", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.GetAllKeys", err)
 	return keys, err
 }
 
 func (i *instrumentedIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
 	startedAt := time.Now()
 	n, err := i.inner.Count(ctx, r, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.Count", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.Count", err)
 	return n, err
 }
 
 func (i *instrumentedIndex) Delete(ctx context.Context, values ...any) (int64, error) {
 	startedAt := time.Now()
 	n, err := i.inner.Delete(ctx, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.Delete", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.Delete", err)
 	return n, err
 }
 
 func (i *instrumentedIndex) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
 	startedAt := time.Now()
 	c, err := i.inner.OpenCursor(ctx, r, dir, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.OpenCursor", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.OpenCursor", err)
 	return c, err
 }
 
 func (i *instrumentedIndex) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
 	startedAt := time.Now()
 	c, err := i.inner.OpenKeyCursor(ctx, r, dir, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.OpenKeyCursor", err != nil)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.OpenKeyCursor", err)
 	return c, err
 }

--- a/gestaltd/internal/metricutil/indexeddb_test.go
+++ b/gestaltd/internal/metricutil/indexeddb_test.go
@@ -18,15 +18,30 @@ func TestInstrumentIndexedDBRecordsDBAndObjectStoreAttributes(t *testing.T) {
 	if err := db.ObjectStore("users").Put(ctx, map[string]any{"id": "user-1"}); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
+	if _, err := db.ObjectStore("users").Get(ctx, "missing"); err == nil {
+		t.Fatal("Get missing record should fail")
+	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
-	attrs := map[string]string{
-		"gestalt.db":           "system",
-		"gestalt.object_store": "users",
-		"gestalt.method":       "Put",
+	dbAttrs := map[string]string{
+		"db.system.name":     "gestaltd.indexeddb",
+		"db.namespace":       "system",
+		"db.collection.name": "users",
+		"db.operation.name":  "put",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.indexeddb.count", 1, attrs)
-	metrictest.RequireInt64SumOmitsAttr(t, rm, "gestaltd.indexeddb.count", attrs, "gestalt.plugin")
-	metrictest.RequireInt64SumOmitsAttr(t, rm, "gestaltd.indexeddb.count", attrs, "gestalt.store")
-	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.indexeddb.duration", attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "db.client.operation.duration", dbAttrs)
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "db.client.operation.duration", dbAttrs, "gestalt.db")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "db.client.operation.duration", dbAttrs, "gestalt.object_store")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "db.client.operation.duration", dbAttrs, "gestalt.method")
+	metrictest.RequireFloat64Histogram(t, rm, "db.client.operation.duration", map[string]string{
+		"db.system.name":     "gestaltd.indexeddb",
+		"db.namespace":       "system",
+		"db.collection.name": "users",
+		"db.operation.name":  "get",
+		"error.type":         "not_found",
+	})
+
+	metrictest.RequireNoMetric(t, rm, "gestaltd.indexeddb.count")
+	metrictest.RequireNoMetric(t, rm, "gestaltd.indexeddb.error_count")
+	metrictest.RequireNoMetric(t, rm, "gestaltd.indexeddb.duration")
 }

--- a/gestaltd/internal/metricutil/meter.go
+++ b/gestaltd/internal/metricutil/meter.go
@@ -70,11 +70,15 @@ func NewInt64Gauge(meter metric.Meter, name, desc string) metric.Int64Gauge {
 	return gauge
 }
 
-func NewFloat64Histogram(meter metric.Meter, name, desc, unit string) metric.Float64Histogram {
-	histogram, err := meter.Float64Histogram(
-		name,
+func NewFloat64Histogram(meter metric.Meter, name, desc, unit string, opts ...metric.Float64HistogramOption) metric.Float64Histogram {
+	histogramOpts := []metric.Float64HistogramOption{
 		metric.WithDescription(desc),
 		metric.WithUnit(unit),
+	}
+	histogramOpts = append(histogramOpts, opts...)
+	histogram, err := meter.Float64Histogram(
+		name,
+		histogramOpts...,
 	)
 	if err != nil {
 		otel.Handle(err)

--- a/gestaltd/internal/metricutil/semantic_metrics.go
+++ b/gestaltd/internal/metricutil/semantic_metrics.go
@@ -2,8 +2,11 @@ package metricutil
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -13,11 +16,7 @@ const meterName = "gestaltd"
 var (
 	attrProvider       = AttrProvider
 	attrAction         = attribute.Key("gestalt.action")
-	attrDB             = attribute.Key("gestalt.db")
 	attrType           = attribute.Key("gestalt.type")
-	attrMethod         = attribute.Key("gestalt.method")
-	attrObjectStore    = attribute.Key("gestalt.object_store")
-	attrPlugin         = attribute.Key("gestalt.plugin")
 	attrConnectionMode = AttrConnectionMode
 )
 
@@ -52,8 +51,10 @@ var (
 	authMetricsCache           MeterCache[counterMetrics]
 	connectionAuthMetricsCache MeterCache[counterMetrics]
 	discoveryMetricsCache      MeterCache[counterMetrics]
-	indexedDBMetricsCache      MeterCache[counterMetrics]
+	dbClientMetricsCache       MeterCache[metric.Float64Histogram]
 )
+
+var dbClientOperationDurationBuckets = []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10}
 
 func RecordAuthMetrics(ctx context.Context, startedAt time.Time, provider string, action string, failed bool) {
 	metrics := authMetricsCache.Load(ctx, meterName, func(meter metric.Meter) counterMetrics {
@@ -89,24 +90,109 @@ func RecordDiscoveryMetrics(ctx context.Context, startedAt time.Time, provider s
 }
 
 type IndexedDBMetricLabels struct {
-	DB          string
-	Plugin      string
-	ObjectStore string
+	SystemName   string
+	DB           string
+	ProviderName string
+	ObjectStore  string
+	IndexName    string
 }
 
-func RecordIndexedDBMetrics(ctx context.Context, startedAt time.Time, labels IndexedDBMetricLabels, method string, failed bool) {
-	metrics := indexedDBMetricsCache.Load(ctx, meterName, func(meter metric.Meter) counterMetrics {
-		return newCounterMetrics(meter, "gestaltd.indexeddb", "gestaltd indexeddb operations")
+func RecordDBClientOperation(ctx context.Context, startedAt time.Time, dims DBMetricDims) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	duration := dbClientMetricsCache.Load(ctx, meterName, func(meter metric.Meter) metric.Float64Histogram {
+		return NewFloat64Histogram(
+			meter,
+			"db.client.operation.duration",
+			"Measures database client operation duration.",
+			"s",
+			metric.WithExplicitBucketBoundaries(dbClientOperationDurationBuckets...),
+		)
 	})
-	attrs := []attribute.KeyValue{
-		attrDB.String(AttrValue(labels.DB)),
-		attrObjectStore.String(AttrValue(labels.ObjectStore)),
-		attrMethod.String(AttrValue(method)),
+	duration.Record(ctx, time.Since(startedAt).Seconds(), metric.WithAttributes(DBClientAttrs(dims)...))
+}
+
+func RecordIndexedDBOperation(ctx context.Context, startedAt time.Time, labels IndexedDBMetricLabels, method string, err error) {
+	systemName := strings.TrimSpace(labels.SystemName)
+	if systemName == "" {
+		systemName = DBSystemNameGestaltdIndexedDB
 	}
-	if labels.Plugin != "" {
-		attrs = append(attrs, attrPlugin.String(AttrValue(labels.Plugin)))
+	RecordDBClientOperation(ctx, startedAt, DBMetricDims{
+		SystemName:     systemName,
+		Namespace:      labels.DB,
+		CollectionName: labels.ObjectStore,
+		OperationName:  normalizeIndexedDBOperationName(method),
+		ProviderName:   labels.ProviderName,
+		IndexName:      labels.IndexName,
+		ErrorType:      indexedDBErrorType(err),
+	})
+}
+
+func normalizeIndexedDBOperationName(operation string) string {
+	switch strings.TrimSpace(operation) {
+	case "Get":
+		return "get"
+	case "GetKey":
+		return "get_key"
+	case "Add":
+		return "add"
+	case "Put":
+		return "put"
+	case "Delete":
+		return "delete"
+	case "Clear":
+		return "clear"
+	case "GetAll":
+		return "get_all"
+	case "GetAllKeys":
+		return "get_all_keys"
+	case "Count":
+		return "count"
+	case "DeleteRange":
+		return "delete_range"
+	case "OpenCursor":
+		return "open_cursor"
+	case "OpenKeyCursor":
+		return "open_key_cursor"
+	case "Index.Get":
+		return "index_get"
+	case "Index.GetKey":
+		return "index_get_key"
+	case "Index.GetAll":
+		return "index_get_all"
+	case "Index.GetAllKeys":
+		return "index_get_all_keys"
+	case "Index.Count":
+		return "index_count"
+	case "Index.Delete":
+		return "index_delete"
+	case "Index.OpenCursor":
+		return "index_open_cursor"
+	case "Index.OpenKeyCursor":
+		return "index_open_key_cursor"
+	default:
+		return strings.TrimSpace(operation)
 	}
-	recordCounterMetrics(ctx, metrics, startedAt, failed, attrs...)
+}
+
+func indexedDBErrorType(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	case errors.Is(err, indexeddb.ErrNotFound):
+		return "not_found"
+	case errors.Is(err, indexeddb.ErrAlreadyExists):
+		return "already_exists"
+	case errors.Is(err, indexeddb.ErrKeysOnly):
+		return "keys_only"
+	default:
+		return "internal"
+	}
 }
 
 func recordCounterMetrics(ctx context.Context, metrics counterMetrics, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {

--- a/gestaltd/internal/pluginruntime/dial.go
+++ b/gestaltd/internal/pluginruntime/dial.go
@@ -13,7 +13,6 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
@@ -294,13 +293,10 @@ func dialTLSTarget(address string, cfg dialConfig) (*grpc.ClientConn, error) {
 }
 
 func hostedPluginGRPCOptions(cfg dialConfig) []otelgrpc.Option {
-	attrs := []attribute.KeyValue{
-		metricutil.AttrRPCRole.String("hosted_plugin_client"),
-	}
-	if cfg.providerName != "" {
-		attrs = append(attrs, metricutil.AttrProvider.String(metricutil.AttrValue(cfg.providerName)))
-	}
-	return metricutil.GRPCOptions(cfg.telemetryProviders(), attrs...)
+	return metricutil.GRPCMetricOptions(cfg.telemetryProviders(), metricutil.RPCMetricDims{
+		Role:         metricutil.RPCRoleHostedPluginClient,
+		ProviderName: cfg.providerName,
+	})
 }
 
 func (cfg dialConfig) telemetryProviders() metricutil.TelemetryProviders {

--- a/gestaltd/internal/pluginruntime/dial_test.go
+++ b/gestaltd/internal/pluginruntime/dial_test.go
@@ -57,8 +57,11 @@ func TestDialHostedPluginRecordsRPCClientDurationWithTelemetryAttrs(t *testing.T
 	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
-	metrictest.RequireFloat64Histogram(t, rm, "rpc.client.call.duration", map[string]string{
-		"gestalt.rpc.role": "hosted_plugin_client",
-		"gestalt.provider": providerName,
-	})
+	attrs := map[string]string{
+		"gestaltd.rpc.role":      "hosted_plugin_client",
+		"gestaltd.provider.name": providerName,
+	}
+	metrictest.RequireFloat64Histogram(t, rm, "rpc.client.call.duration", attrs)
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.client.call.duration", attrs, "gestalt.rpc.role")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.client.call.duration", attrs, "gestalt.provider")
 }

--- a/gestaltd/internal/providerhost/grpc_telemetry.go
+++ b/gestaltd/internal/providerhost/grpc_telemetry.go
@@ -5,32 +5,26 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 func providerClientGRPCOptions(providerName string, telemetry metricutil.TelemetryProviders) []otelgrpc.Option {
-	return grpcTelemetryOptions("provider_client", providerName, "", telemetry)
+	return grpcTelemetryOptions(metricutil.RPCRoleProviderClient, providerName, "", telemetry)
 }
 
 func providerServerGRPCOptions(providerName string, telemetry metricutil.TelemetryProviders) []otelgrpc.Option {
-	return grpcTelemetryOptions("provider_server", providerName, "", telemetry)
+	return grpcTelemetryOptions(metricutil.RPCRoleProviderServer, providerName, "", telemetry)
 }
 
 func hostServiceServerGRPCOptions(providerName string, service HostService, telemetry metricutil.TelemetryProviders) []otelgrpc.Option {
-	return grpcTelemetryOptions("host_service_server", providerName, hostServiceMetricName(service), telemetry)
+	return grpcTelemetryOptions(metricutil.RPCRoleHostServiceServer, providerName, hostServiceMetricName(service), telemetry)
 }
 
 func grpcTelemetryOptions(role, providerName, hostService string, telemetry metricutil.TelemetryProviders) []otelgrpc.Option {
-	attrs := []attribute.KeyValue{
-		metricutil.AttrRPCRole.String(role),
-	}
-	if providerName != "" {
-		attrs = append(attrs, metricutil.AttrProvider.String(metricutil.AttrValue(providerName)))
-	}
-	if hostService != "" {
-		attrs = append(attrs, metricutil.AttrHostService.String(metricutil.AttrValue(hostService)))
-	}
-	return metricutil.GRPCOptions(telemetry, attrs...)
+	return metricutil.GRPCMetricOptions(telemetry, metricutil.RPCMetricDims{
+		Role:            role,
+		ProviderName:    providerName,
+		HostServiceName: hostService,
+	})
 }
 
 func hostServiceMetricName(service HostService) string {

--- a/gestaltd/internal/providerhost/grpc_test.go
+++ b/gestaltd/internal/providerhost/grpc_test.go
@@ -22,9 +22,14 @@ func newIntegrationProviderClient(t *testing.T, server proto.IntegrationProvider
 
 func newBufconnConn(t *testing.T, register func(*grpc.Server)) *grpc.ClientConn {
 	t.Helper()
+	return newBufconnConnWithOptions(t, nil, nil, register)
+}
+
+func newBufconnConnWithOptions(t *testing.T, serverOpts []grpc.ServerOption, dialOpts []grpc.DialOption, register func(*grpc.Server)) *grpc.ClientConn {
+	t.Helper()
 
 	lis := bufconn.Listen(1024 * 1024)
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(serverOpts...)
 	register(srv)
 	go func() {
 		_ = srv.Serve(lis)
@@ -34,12 +39,14 @@ func newBufconnConn(t *testing.T, register func(*grpc.Server)) *grpc.ClientConn 
 		_ = lis.Close()
 	})
 
-	conn, err := grpc.NewClient("passthrough:///bufnet",
+	dialOptions := []grpc.DialOption{
 		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 			return lis.Dial()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	}
+	dialOptions = append(dialOptions, dialOpts...)
+	conn, err := grpc.NewClient("passthrough:///bufnet", dialOptions...)
 	if err != nil {
 		t.Fatalf("grpc.NewClient: %v", err)
 	}

--- a/gestaltd/internal/providerhost/host_services_test.go
+++ b/gestaltd/internal/providerhost/host_services_test.go
@@ -8,12 +8,15 @@ import (
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type hostServiceMetricsTelemetry struct {
@@ -34,6 +37,43 @@ type metricsCacheServer struct {
 
 func (metricsCacheServer) Get(context.Context, *proto.CacheGetRequest) (*proto.CacheGetResponse, error) {
 	return &proto.CacheGetResponse{Found: true, Value: []byte("ok")}, nil
+}
+
+func TestProviderGRPCOptionsRecordClientAndServerDurationWithTelemetryAttrs(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	const providerName = "provider-rpc-metrics"
+	telemetry := hostServiceMetricsTelemetry{meterProvider: metrics.Provider}
+
+	conn := newBufconnConnWithOptions(t,
+		[]grpc.ServerOption{grpc.StatsHandler(otelgrpc.NewServerHandler(providerServerGRPCOptions(providerName, telemetry)...))},
+		[]grpc.DialOption{grpc.WithStatsHandler(otelgrpc.NewClientHandler(providerClientGRPCOptions(providerName, telemetry)...))},
+		func(srv *grpc.Server) {
+			proto.RegisterIntegrationProviderServer(srv, NewProviderServer(&coretesting.StubIntegration{N: providerName}))
+		},
+	)
+
+	if _, err := proto.NewIntegrationProviderClient(conn).GetMetadata(context.Background(), &emptypb.Empty{}); err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	clientAttrs := map[string]string{
+		"gestaltd.rpc.role":      "provider_client",
+		"gestaltd.provider.name": providerName,
+	}
+	metrictest.RequireFloat64Histogram(t, rm, "rpc.client.call.duration", clientAttrs)
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.client.call.duration", clientAttrs, "gestalt.rpc.role")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.client.call.duration", clientAttrs, "gestalt.provider")
+
+	serverAttrs := map[string]string{
+		"gestaltd.rpc.role":      "provider_server",
+		"gestaltd.provider.name": providerName,
+	}
+	metrictest.RequireFloat64Histogram(t, rm, "rpc.server.call.duration", serverAttrs)
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.server.call.duration", serverAttrs, "gestalt.rpc.role")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.server.call.duration", serverAttrs, "gestalt.provider")
 }
 
 type blockingCacheServer struct {
@@ -99,11 +139,15 @@ func TestStartHostServicesRecordsRPCServerDurationWithTelemetryAttrs(t *testing.
 	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
-	metrictest.RequireFloat64Histogram(t, rm, "rpc.server.call.duration", map[string]string{
-		"gestalt.rpc.role":     "host_service_server",
-		"gestalt.provider":     providerName,
-		"gestalt.host_service": "cache",
-	})
+	attrs := map[string]string{
+		"gestaltd.rpc.role":          "host_service_server",
+		"gestaltd.provider.name":     providerName,
+		"gestaltd.host_service.name": "cache",
+	}
+	metrictest.RequireFloat64Histogram(t, rm, "rpc.server.call.duration", attrs)
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.server.call.duration", attrs, "gestalt.rpc.role")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.server.call.duration", attrs, "gestalt.provider")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.server.call.duration", attrs, "gestalt.host_service")
 }
 
 func TestStartedHostServicesCloseWaitsForInflightRPC(t *testing.T) {

--- a/gestaltd/internal/providerhost/indexeddb_server.go
+++ b/gestaltd/internal/providerhost/indexeddb_server.go
@@ -63,9 +63,9 @@ func (s *indexedDBServer) objectStore(name string) (indexeddb.ObjectStore, error
 	return metricutil.InstrumentObjectStore(
 		metricutil.UnwrapIndexedDB(s.ds).ObjectStore(s.storeName(name)),
 		metricutil.IndexedDBMetricLabels{
-			DB:          s.db,
-			Plugin:      s.plugin,
-			ObjectStore: name,
+			DB:           s.db,
+			ProviderName: s.plugin,
+			ObjectStore:  name,
 		},
 	), nil
 }

--- a/gestaltd/internal/providerhost/indexeddb_server_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_server_test.go
@@ -76,25 +76,31 @@ func TestIndexedDBServerRecordsPluginMetricAttributes(t *testing.T) {
 	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
-	putAttrs := map[string]string{
-		"gestalt.db":           "system",
-		"gestalt.plugin":       "roadmap",
-		"gestalt.object_store": "snapshots",
-		"gestalt.method":       "Put",
+	dbPutAttrs := map[string]string{
+		"db.system.name":         "gestaltd.indexeddb",
+		"db.namespace":           "system",
+		"db.collection.name":     "snapshots",
+		"db.operation.name":      "put",
+		"gestaltd.provider.name": "roadmap",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.indexeddb.count", 1, putAttrs)
-	metrictest.RequireInt64SumOmitsAttr(t, rm, "gestaltd.indexeddb.count", putAttrs, "gestalt.store")
-	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.indexeddb.duration", putAttrs)
+	metrictest.RequireFloat64Histogram(t, rm, "db.client.operation.duration", dbPutAttrs)
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "db.client.operation.duration", dbPutAttrs, "gestalt.db")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "db.client.operation.duration", dbPutAttrs, "gestalt.plugin")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "db.client.operation.duration", dbPutAttrs, "gestalt.object_store")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "db.client.operation.duration", dbPutAttrs, "gestalt.method")
 
-	indexAttrs := map[string]string{
-		"gestalt.db":           "system",
-		"gestalt.plugin":       "roadmap",
-		"gestalt.object_store": "snapshots",
-		"gestalt.method":       "Index.Get",
+	dbIndexAttrs := map[string]string{
+		"db.system.name":                "gestaltd.indexeddb",
+		"db.namespace":                  "system",
+		"db.collection.name":            "snapshots",
+		"db.operation.name":             "index_get",
+		"gestaltd.provider.name":        "roadmap",
+		"gestaltd.indexeddb.index.name": "by_type",
 	}
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.indexeddb.count", 1, indexAttrs)
-	metrictest.RequireInt64SumOmitsAttr(t, rm, "gestaltd.indexeddb.count", indexAttrs, "gestalt.store")
-	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.indexeddb.duration", indexAttrs)
+	metrictest.RequireFloat64Histogram(t, rm, "db.client.operation.duration", dbIndexAttrs)
+	metrictest.RequireNoMetric(t, rm, "gestaltd.indexeddb.count")
+	metrictest.RequireNoMetric(t, rm, "gestaltd.indexeddb.error_count")
+	metrictest.RequireNoMetric(t, rm, "gestaltd.indexeddb.duration")
 }
 
 func TestIndexedDBServerRejectsStoresOutsideAllowlist(t *testing.T) {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -461,12 +461,12 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	metricutil.AddHTTPAttributes(r.Context(),
-		metricutil.AttrProvider.String(metricutil.AttrValue(name)),
-		metricutil.AttrOperation.String(operation),
-		metricutil.AttrConnectionMode.String(metricutil.NormalizeConnectionMode(prov.ConnectionMode())),
-		metricutil.AttrInvocationSurface.String("http"),
-	)
+	metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
+		ProviderName:   name,
+		OperationName:  operation,
+		ConnectionMode: metricutil.NormalizeConnectionMode(prov.ConnectionMode()),
+		Surface:        metricutil.InvocationSurfaceHTTP,
+	})
 	p := PrincipalFromContext(r.Context())
 	if override, ok, err := s.providerOverrideForContext(r.Context(), p, name); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -721,12 +721,12 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		connection = config.ResolveConnectionAlias(connection)
 		ctx = invocation.WithConnection(ctx, connection)
 	}
-	metricutil.AddHTTPAttributes(r.Context(),
-		metricutil.AttrProvider.String(metricutil.AttrValue(providerName)),
-		metricutil.AttrOperation.String(metricutil.AttrValue(opMeta.ID)),
-		metricutil.AttrConnectionMode.String(metricutil.NormalizeConnectionMode(s.invocationConnectionMode(prov, providerName, connection))),
-		metricutil.AttrInvocationSurface.String("http"),
-	)
+	metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
+		ProviderName:   providerName,
+		OperationName:  opMeta.ID,
+		ConnectionMode: metricutil.NormalizeConnectionMode(s.invocationConnectionMode(prov, providerName, connection)),
+		Surface:        metricutil.InvocationSurfaceHTTP,
+	})
 	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTP)
 
 	result, err := s.invoker.Invoke(ctx, p, providerName, instance, operationName, params)

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -262,12 +262,12 @@ func (s *Server) mountHTTPBindingRoutes(r chi.Router) {
 	for i := range s.mountedHTTPBindings {
 		binding := &s.mountedHTTPBindings[i]
 		r.MethodFunc(binding.Method, binding.Path, func(w http.ResponseWriter, r *http.Request) {
-			metricutil.AddHTTPAttributes(r.Context(),
-				metricutil.AttrProvider.String(metricutil.AttrValue(binding.PluginName)),
-				metricutil.AttrOperation.String(metricutil.AttrValue(binding.Target)),
-				metricutil.AttrHTTPBinding.String(metricutil.AttrValue(binding.Name)),
-				metricutil.AttrInvocationSurface.String("http"),
-			)
+			metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
+				ProviderName:    binding.PluginName,
+				OperationName:   binding.Target,
+				HTTPBindingName: binding.Name,
+				Surface:         metricutil.InvocationSurfaceHTTPBinding,
+			})
 			s.handleHTTPBinding(*binding, w, r)
 		})
 	}

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -454,16 +454,19 @@ func TestOperationMetricsDefaultRESTTransportFromCatalogContext(t *testing.T) {
 		"gestalt.result_status":       "404",
 		"gestalt.result_status_class": "4xx",
 	})
-	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", map[string]string{
-		"http.route":                  "/api/v1/{integration}/{operation}",
-		"gestalt.provider":            providerName,
-		"gestalt.operation":           "list",
-		"gestalt.transport":           "rest",
-		"gestalt.connection_mode":     "none",
-		"gestalt.invocation_surface":  "http",
-		"gestalt.result_status":       "200",
-		"gestalt.result_status_class": "2xx",
-	})
+	httpAttrs := map[string]string{
+		"http.route":                   "/api/v1/{integration}/{operation}",
+		"gestaltd.provider.name":       providerName,
+		"gestaltd.operation.name":      "list",
+		"gestaltd.operation.transport": "rest",
+		"gestaltd.connection.mode":     "none",
+		"gestaltd.invocation.surface":  "http",
+	}
+	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", httpAttrs)
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", httpAttrs, "gestalt.provider")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", httpAttrs, "gestalt.operation")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", httpAttrs, "gestalt.result_status")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", httpAttrs, "gestalt.result_status_class")
 }
 
 func TestManualConnectionMetrics(t *testing.T) {
@@ -713,6 +716,8 @@ func TestHTTPMetricsDoNotLabelUnknownPluginRouteParams(t *testing.T) {
 	routeAttrs := map[string]string{"http.route": "/api/v1/{integration}/{operation}"}
 	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", routeAttrs, "gestalt.provider")
 	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", routeAttrs, "gestalt.operation")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", routeAttrs, "gestaltd.provider.name")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", routeAttrs, "gestaltd.operation.name")
 }
 
 func TestHTTPBindingOperationMetricsIncludeBinding(t *testing.T) {
@@ -805,13 +810,17 @@ func TestHTTPBindingOperationMetricsIncludeBinding(t *testing.T) {
 	})
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.count", 1, attrs)
 	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.operation.duration", attrs)
-	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", map[string]string{
-		"http.route":                 "/api/v1/" + providerName + "/delivery",
-		"gestalt.provider":           providerName,
-		"gestalt.operation":          "receive_event",
-		"gestalt.invocation_surface": "http",
-		"gestalt.http_binding":       "delivery",
-	})
+	httpAttrs := map[string]string{
+		"http.route":                  "/api/v1/" + providerName + "/delivery",
+		"gestaltd.provider.name":      providerName,
+		"gestaltd.operation.name":     "receive_event",
+		"gestaltd.invocation.surface": "http_binding",
+		"gestaltd.http.binding.name":  "delivery",
+	}
+	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", httpAttrs)
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", httpAttrs, "gestalt.provider")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", httpAttrs, "gestalt.operation")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", httpAttrs, "gestalt.http_binding")
 }
 
 func TestHTTPDiscoveryMetrics(t *testing.T) {

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -21,7 +21,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"github.com/valon-technologies/gestalt/server/internal/ui"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 const browserLoginPath = "/api/v1/auth/login"
@@ -434,14 +433,11 @@ func (s *Server) protectedUIHandler(mounted MountedUI, inner http.Handler, redir
 
 func mountedUITelemetryHandler(mounted MountedUI, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attrs := []attribute.KeyValue{
-			metricutil.AttrUI.String(metricutil.AttrValue(mounted.Name)),
-			metricutil.AttrInvocationSurface.String("ui"),
-		}
-		if mounted.PluginName != "" {
-			attrs = append(attrs, metricutil.AttrProvider.String(metricutil.AttrValue(mounted.PluginName)))
-		}
-		metricutil.AddHTTPAttributes(r.Context(), attrs...)
+		metricutil.AddHTTPServerMetricDims(r.Context(), metricutil.HTTPMetricDims{
+			ProviderName: mounted.PluginName,
+			Surface:      metricutil.InvocationSurfaceUI,
+			UIName:       mounted.Name,
+		})
 		next.ServeHTTP(w, r)
 	})
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -10505,15 +10505,15 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	httpOperationAttrs := map[string]string{
-		"http.route":                 "/api/v1/{integration}/{operation}",
-		"gestalt.provider":           "slack",
-		"gestalt.operation":          "chat.postMessage",
-		"gestalt.invocation_surface": "http",
+		"http.route":                  "/api/v1/{integration}/{operation}",
+		"gestaltd.provider.name":      "slack",
+		"gestaltd.operation.name":     "chat.postMessage",
+		"gestaltd.invocation.surface": "http",
 	}
 	userAttrs := maps.Clone(httpOperationAttrs)
-	userAttrs["gestalt.connection_mode"] = "user"
+	userAttrs["gestaltd.connection.mode"] = "user"
 	platformAttrs := maps.Clone(httpOperationAttrs)
-	platformAttrs["gestalt.connection_mode"] = "platform"
+	platformAttrs["gestaltd.connection.mode"] = "platform"
 	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", userAttrs)
 	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", platformAttrs)
 

--- a/gestaltd/internal/server/tracing_test.go
+++ b/gestaltd/internal/server/tracing_test.go
@@ -102,6 +102,13 @@ func TestTracing_HTTPAndBrokerSpans(t *testing.T) { //nolint:paralleltest // mut
 	if brokerSpan == nil {
 		t.Fatal("expected broker span named 'broker.invoke'")
 	}
+	assertSpanHasAttr(t, httpSpan, "gestaltd.provider.name", "tracer-prov")
+	assertSpanHasAttr(t, httpSpan, "gestaltd.operation.name", "ping")
+	assertSpanHasAttr(t, httpSpan, "gestaltd.connection.mode", "none")
+	assertSpanHasAttr(t, httpSpan, "gestaltd.invocation.surface", "http")
+	assertSpanLacksAttr(t, httpSpan, "gestalt.provider")
+	assertSpanLacksAttr(t, httpSpan, "gestalt.operation")
+
 	dbUser, err := ds.Users.FindOrCreateUser(context.Background(), "trace@example.com")
 	if err != nil {
 		t.Fatalf("resolve trace user: %v", err)

--- a/gestaltd/internal/testutil/metrictest/metrictest.go
+++ b/gestaltd/internal/testutil/metrictest/metrictest.go
@@ -138,6 +138,18 @@ func RequireFloat64Histogram(t *testing.T, rm metricdata.ResourceMetrics, name s
 	t.Fatalf("metric %q with attrs %v not found", name, attrs)
 }
 
+func RequireNoMetric(t *testing.T, rm metricdata.ResourceMetrics, name string) {
+	t.Helper()
+
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name == name {
+				t.Fatalf("metric %q unexpectedly found", name)
+			}
+		}
+	}
+}
+
 func RequireFloat64HistogramOmitsAttr(t *testing.T, rm metricdata.ResourceMetrics, name string, attrs map[string]string, forbiddenKey string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Adds central metric helper inputs for `gestaltd` HTTP, RPC, and DB dimensions without introducing a policy/interface hierarchy.
- Moves standard HTTP/RPC library metric custom labels from `gestalt.*` to `gestaltd.*` and stops attaching result-status labels to HTTP semconv metrics.
- Deletes the legacy HTTP/RPC span compatibility layer; migrated transport spans now receive the same `gestaltd.*` labels as the standard metrics.
- Replaces legacy `gestaltd.indexeddb.*` metric emission with `db.client.operation.duration` using `db.*` attributes, semconv duration buckets, and bounded `error.type`.
- Keeps the general DB helper explicit: it records caller-provided `db.system.name`, `db.operation.name`, and `error.type`; IndexedDB-specific defaults, operation normalization, and error classification live in the IndexedDB wrapper.

## New Interfaces

```go
type HTTPMetricDims struct {
    ProviderName    string
    OperationName   string
    Transport       string
    ConnectionMode  string
    Surface         string
    HTTPBindingName string
    UIName          string
}

func HTTPServerAttrs(dims HTTPMetricDims) []attribute.KeyValue
func AddHTTPServerMetricDims(ctx context.Context, dims HTTPMetricDims)
```

```go
type RPCMetricDims struct {
    Role            string
    ProviderName    string
    HostServiceName string
}

func RPCAttrs(dims RPCMetricDims) []attribute.KeyValue
func GRPCMetricOptions(telemetry TelemetryProviders, dims RPCMetricDims) []otelgrpc.Option
```

```go
type DBMetricDims struct {
    SystemName     string
    Namespace      string
    CollectionName string
    OperationName  string
    ProviderName   string
    IndexName      string
    ErrorType      string
}

func DBClientAttrs(dims DBMetricDims) []attribute.KeyValue
func RecordDBClientOperation(ctx context.Context, startedAt time.Time, dims DBMetricDims)
```

## Examples

HTTP server metric dimensions:

```go
metricutil.AddHTTPServerMetricDims(ctx, metricutil.HTTPMetricDims{
    ProviderName:   providerName,
    OperationName:  opID,
    ConnectionMode: "user",
    Surface:        metricutil.InvocationSurfaceHTTP,
})
```

RPC metric dimensions:

```go
metricutil.GRPCMetricOptions(telemetry, metricutil.RPCMetricDims{
    Role:            metricutil.RPCRoleHostServiceServer,
    ProviderName:    providerName,
    HostServiceName: "cache",
})
```

DB client metric emission:

```go
metricutil.RecordDBClientOperation(ctx, startedAt, metricutil.DBMetricDims{
    SystemName:     metricutil.DBSystemNameGestaltdIndexedDB,
    Namespace:      "system",
    CollectionName: "users",
    OperationName:  "put",
    ErrorType:      "not_found",
})
```

Emitted metric example:

```text
name: db.client.operation.duration
attrs:
  db.system.name: gestaltd.indexeddb
  db.namespace: system
  db.collection.name: users
  db.operation.name: put
  error.type: not_found
```

## Review Notes

- Removed `InvocationSurfaceMCP` after review because it had no call sites.
- Removed the generic `GRPCOptions` helper after review because callers now use the semconv-specific `GRPCMetricOptions` entry point.
- Moved the IndexedDB `db.system.name` default out of the general DB helper and into the IndexedDB wrapper after review.
- Moved IndexedDB operation normalization and error classification out of the general DB helper and into the IndexedDB wrapper after review.
- Collapsed duplicate invocation surface/binding context reads in operation metric emission after review.
- The earlier legacy span-preservation note is superseded by the requested breaking cleanup: no migrated HTTP/RPC compatibility span attributes are preserved.

## Verification

- `go test -count=1 ./internal/metricutil ./internal/providerhost ./internal/pluginruntime ./internal/server ./internal/invocation`
