### PR TITLE
Polish live agent TUI message rendering

### DIFF
--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -5,7 +5,13 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::crossterm::{
+    event::{
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
+        KeyModifiers, MouseEventKind,
+    },
+    execute,
+};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, TextArea};
@@ -29,6 +35,9 @@ use super::{
 const TICK_RATE: Duration = Duration::from_millis(50);
 const HISTORY_LIMIT: usize = 100;
 const SPINNER_FRAMES: [&str; 4] = ["|", "/", "-", "\\"];
+const USER_PROMPT: &str = "› ";
+const ASSISTANT_BULLET: &str = "● ";
+const META_PREFIX: &str = "* ";
 
 pub(super) fn can_run() -> bool {
     io::stdin().is_terminal() && io::stdout().is_terminal() && io::stderr().is_terminal()
@@ -55,8 +64,13 @@ struct TerminalGuard {
 
 impl TerminalGuard {
     fn start() -> Result<Self> {
+        let terminal = ratatui::try_init().context("failed to initialize terminal UI")?;
+        if let Err(error) = execute!(io::stdout(), EnableMouseCapture) {
+            ratatui::restore();
+            return Err(error).context("failed to enable mouse capture");
+        }
         Ok(Self {
-            terminal: ratatui::try_init().context("failed to initialize terminal UI")?,
+            terminal,
             restored: false,
         })
     }
@@ -67,7 +81,10 @@ impl TerminalGuard {
 
     fn restore(&mut self) -> Result<()> {
         if !self.restored {
-            ratatui::try_restore().context("failed to restore terminal UI")?;
+            let mouse_result = execute!(io::stdout(), DisableMouseCapture);
+            let restore_result = ratatui::try_restore();
+            mouse_result.context("failed to disable mouse capture")?;
+            restore_result.context("failed to restore terminal UI")?;
             self.restored = true;
         }
         Ok(())
@@ -77,6 +94,7 @@ impl TerminalGuard {
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
         if !self.restored {
+            let _ = execute!(io::stdout(), DisableMouseCapture);
             ratatui::restore();
             self.restored = true;
         }
@@ -141,6 +159,14 @@ impl TuiApp {
             if event::poll(TICK_RATE).context("failed to poll terminal events")? {
                 match event::read().context("failed to read terminal event")? {
                     Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_key(key),
+                    Event::Mouse(mouse) => match mouse.kind {
+                        MouseEventKind::ScrollUp => self.state.scroll_up(
+                            self.transcript_visible_height,
+                            self.transcript_content_height,
+                        ),
+                        MouseEventKind::ScrollDown => self.state.scroll_down(),
+                        _ => {}
+                    },
                     Event::Resize(_, _) => {}
                     _ => {}
                 }
@@ -201,7 +227,7 @@ impl TuiApp {
         let content_width = area.width.saturating_sub(2).max(1) as usize;
         let mut lines = Vec::new();
         for (index, item) in self.state.transcript().iter().enumerate() {
-            if index > 0 {
+            if index > 0 && item.kind != state::TranscriptKind::Meta {
                 lines.push(Line::from(""));
             }
             push_transcript_item_lines(&mut lines, item, content_width);
@@ -276,14 +302,14 @@ impl TuiApp {
                 format!(" | queued {}", self.queued_messages.len())
             };
             format!(
-                "{} {}{} | Enter queue | Alt-Enter newline | Up/Down history | PgUp/PgDn scroll | Ctrl-C cancel",
+                "{} {}{} | Enter queue | Alt-Enter newline | Up/Down history | PgUp/PgDn/wheel scroll | Ctrl-C cancel",
                 self.activity_indicator(),
                 self.state.status,
                 queued
             )
         } else {
             format!(
-                "{} | Enter send | Alt-Enter newline | Up/Down history | PgUp/PgDn scroll | Ctrl-C clear/exit",
+                "{} | Enter send | Alt-Enter newline | Up/Down history | PgUp/PgDn/wheel scroll | Ctrl-C clear/exit",
                 self.state.status
             )
         };
@@ -429,17 +455,17 @@ impl TuiApp {
 
     fn push_help(&mut self) {
         self.state.push_system(
-            "Commands\n  /help     Show commands and keys.\n  /session  Show the active session id.\n  /quit     Exit now, or after the active turn.\nKeys\n  Enter sends; busy turns queue the prompt.\n  Alt-Enter inserts a newline.\n  Up/Down recalls prompt history.\n  PgUp/PgDn scrolls the transcript.\n  Ctrl-C cancels, clears input, or exits.",
+            "Commands\n  /help     Show commands and keys.\n  /session  Show the active session id.\n  /quit     Exit now, or after the active turn.\nKeys\n  Enter sends; busy turns queue the prompt.\n  Alt-Enter inserts a newline.\n  Up/Down recalls prompt history.\n  PgUp/PgDn or mouse wheel scrolls the transcript.\n  Ctrl-C cancels, clears input, or exits.",
         );
     }
 
     fn enqueue_or_start(&mut self, messages: Vec<String>) {
-        self.state.push_user(messages.join("\n"));
         if self.state.busy {
             self.queued_messages.push_back(messages);
             self.state.status = "queued".to_string();
             return;
         }
+        self.state.push_user(messages.join("\n"));
         self.start_turn(messages);
     }
 
@@ -452,6 +478,7 @@ impl TuiApp {
             return;
         }
         if let Some(messages) = self.queued_messages.pop_front() {
+            self.state.push_user(messages.join("\n"));
             self.start_turn(messages);
         }
     }
@@ -659,6 +686,22 @@ fn push_transcript_item_lines(
     item: &TranscriptItem,
     content_width: usize,
 ) {
+    match item.kind {
+        state::TranscriptKind::User => {
+            push_user_item_lines(lines, item, content_width);
+            return;
+        }
+        state::TranscriptKind::Assistant => {
+            push_assistant_item_lines(lines, item, content_width);
+            return;
+        }
+        state::TranscriptKind::Meta => {
+            push_meta_item_lines(lines, item, content_width);
+            return;
+        }
+        _ => {}
+    }
+
     let header_style = item.kind.header_style().add_modifier(Modifier::BOLD);
     lines.push(Line::from(Span::styled(
         item.kind.header().to_string(),
@@ -677,6 +720,133 @@ fn push_transcript_item_lines(
             )));
         }
     }
+}
+
+fn push_user_item_lines(
+    lines: &mut Vec<Line<'static>>,
+    item: &TranscriptItem,
+    content_width: usize,
+) {
+    let style = Style::default().fg(Color::Black).bg(Color::Gray);
+    let body_width = content_width
+        .saturating_sub(UnicodeWidthStr::width(USER_PROMPT))
+        .max(1);
+    for (line_index, text_line) in item.text.split('\n').enumerate() {
+        let chunks = text_chunks(text_line, body_width);
+        for (chunk_index, chunk) in chunks.into_iter().enumerate() {
+            let prefix = if line_index == 0 && chunk_index == 0 {
+                USER_PROMPT
+            } else {
+                "  "
+            };
+            let line = pad_to_width(format!("{prefix}{chunk}"), content_width);
+            lines.push(Line::from(Span::styled(line, style)));
+        }
+    }
+}
+
+fn push_assistant_item_lines(
+    lines: &mut Vec<Line<'static>>,
+    item: &TranscriptItem,
+    content_width: usize,
+) {
+    let body_style = item.kind.body_style();
+    let bullet_style = Style::default()
+        .fg(Color::Green)
+        .add_modifier(Modifier::BOLD);
+    for (line_index, text_line) in item.text.split('\n').enumerate() {
+        let prefix = if line_index == 0 {
+            ASSISTANT_BULLET
+        } else {
+            "  "
+        };
+        let prefix_style = if line_index == 0 {
+            bullet_style
+        } else {
+            body_style
+        };
+        push_wrapped_segments(
+            lines,
+            markdown_segments(text_line, body_style),
+            prefix,
+            "  ",
+            prefix_style,
+            body_style,
+            content_width,
+        );
+    }
+}
+
+fn push_meta_item_lines(
+    lines: &mut Vec<Line<'static>>,
+    item: &TranscriptItem,
+    content_width: usize,
+) {
+    let style = item.kind.body_style();
+    for (line_index, text_line) in item.text.split('\n').enumerate() {
+        let prefix = if line_index == 0 { META_PREFIX } else { "  " };
+        push_wrapped_segments(
+            lines,
+            vec![StyledSegment::new(text_line.to_string(), style)],
+            prefix,
+            "  ",
+            style,
+            style,
+            content_width,
+        );
+    }
+}
+
+fn push_wrapped_segments(
+    lines: &mut Vec<Line<'static>>,
+    segments: Vec<StyledSegment>,
+    first_prefix: &str,
+    continuation_prefix: &str,
+    first_prefix_style: Style,
+    continuation_prefix_style: Style,
+    content_width: usize,
+) {
+    let mut spans = vec![Span::styled(first_prefix.to_string(), first_prefix_style)];
+    let mut line_width = UnicodeWidthStr::width(first_prefix);
+    let mut prefix_width = line_width;
+    let mut wrote_text = false;
+
+    for segment in segments {
+        for grapheme in UnicodeSegmentation::graphemes(segment.text.as_str(), true) {
+            let grapheme_width = UnicodeWidthStr::width(grapheme);
+            if line_width > prefix_width
+                && line_width.saturating_add(grapheme_width) > content_width
+            {
+                lines.push(Line::from(spans));
+                spans = vec![Span::styled(
+                    continuation_prefix.to_string(),
+                    continuation_prefix_style,
+                )];
+                line_width = UnicodeWidthStr::width(continuation_prefix);
+                prefix_width = line_width;
+            }
+            push_span(&mut spans, grapheme, segment.style);
+            line_width = line_width.saturating_add(grapheme_width);
+            wrote_text = true;
+        }
+    }
+
+    if wrote_text || !first_prefix.is_empty() {
+        lines.push(Line::from(spans));
+    }
+}
+
+fn push_span(spans: &mut Vec<Span<'static>>, text: &str, style: Style) {
+    if text.is_empty() {
+        return;
+    }
+    if let Some(last) = spans.last_mut()
+        && last.style == style
+    {
+        last.content.to_mut().push_str(text);
+        return;
+    }
+    spans.push(Span::styled(text.to_string(), style));
 }
 
 fn text_chunks(text: &str, width: usize) -> Vec<String> {
@@ -700,6 +870,207 @@ fn text_chunks(text: &str, width: usize) -> Vec<String> {
         chunks.push(chunk);
     }
     chunks
+}
+
+fn pad_to_width(mut text: String, width: usize) -> String {
+    let text_width = UnicodeWidthStr::width(text.as_str());
+    if text_width < width {
+        text.push_str(&" ".repeat(width - text_width));
+    }
+    text
+}
+
+#[derive(Clone)]
+struct StyledSegment {
+    text: String,
+    style: Style,
+}
+
+impl StyledSegment {
+    fn new(text: String, style: Style) -> Self {
+        Self { text, style }
+    }
+}
+
+fn markdown_segments(text: &str, base_style: Style) -> Vec<StyledSegment> {
+    markdown_segments_with_depth(text, base_style, 0)
+}
+
+fn markdown_segments_with_depth(text: &str, base_style: Style, depth: usize) -> Vec<StyledSegment> {
+    if depth > 6 {
+        return vec![StyledSegment::new(text.to_string(), base_style)];
+    }
+
+    let mut segments = Vec::new();
+    let mut index = 0usize;
+    while index < text.len() {
+        let rest = &text[index..];
+
+        if let Some((label, url, consumed)) = markdown_link(rest) {
+            let link_style = base_style
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::UNDERLINED);
+            append_segments(
+                &mut segments,
+                markdown_segments_with_depth(label, link_style, depth + 1),
+            );
+            push_segment(&mut segments, " (", base_style);
+            push_segment(&mut segments, url, link_style);
+            push_segment(&mut segments, ")", base_style);
+            index += consumed;
+            continue;
+        }
+
+        if let Some((url, consumed)) = raw_url(rest) {
+            push_segment(
+                &mut segments,
+                url,
+                base_style
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::UNDERLINED),
+            );
+            index += consumed;
+            continue;
+        }
+
+        if let Some((inner, consumed)) = delimited(text, index, "`") {
+            push_segment(
+                &mut segments,
+                inner,
+                base_style.fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            );
+            index += consumed;
+            continue;
+        }
+
+        if let Some((inner, consumed)) = delimited(text, index, "**") {
+            append_segments(
+                &mut segments,
+                markdown_segments_with_depth(
+                    inner,
+                    base_style.add_modifier(Modifier::BOLD),
+                    depth + 1,
+                ),
+            );
+            index += consumed;
+            continue;
+        }
+
+        if let Some((inner, consumed)) =
+            delimited(text, index, "*").or_else(|| delimited(text, index, "_"))
+        {
+            append_segments(
+                &mut segments,
+                markdown_segments_with_depth(
+                    inner,
+                    base_style.add_modifier(Modifier::ITALIC),
+                    depth + 1,
+                ),
+            );
+            index += consumed;
+            continue;
+        }
+
+        let Some(ch) = rest.chars().next() else {
+            break;
+        };
+        push_segment(&mut segments, &ch.to_string(), base_style);
+        index += ch.len_utf8();
+    }
+    segments
+}
+
+fn append_segments(target: &mut Vec<StyledSegment>, segments: Vec<StyledSegment>) {
+    for segment in segments {
+        push_segment(target, &segment.text, segment.style);
+    }
+}
+
+fn push_segment(segments: &mut Vec<StyledSegment>, text: &str, style: Style) {
+    if text.is_empty() {
+        return;
+    }
+    if let Some(last) = segments.last_mut()
+        && last.style == style
+    {
+        last.text.push_str(text);
+        return;
+    }
+    segments.push(StyledSegment::new(text.to_string(), style));
+}
+
+fn markdown_link(rest: &str) -> Option<(&str, &str, usize)> {
+    if !rest.starts_with('[') {
+        return None;
+    }
+    let label_end = 1 + rest[1..].find("](")?;
+    let url_start = label_end + 2;
+    let url_end = url_start + rest[url_start..].find(')')?;
+    let label = &rest[1..label_end];
+    if label.is_empty() {
+        return None;
+    }
+    let url = &rest[url_start..url_end];
+    if url.is_empty() {
+        return None;
+    }
+    Some((label, url, url_end + 1))
+}
+
+fn raw_url(rest: &str) -> Option<(&str, usize)> {
+    if !(rest.starts_with("https://") || rest.starts_with("http://")) {
+        return None;
+    }
+    let end = rest
+        .char_indices()
+        .find_map(|(index, ch)| ch.is_whitespace().then_some(index))
+        .unwrap_or(rest.len());
+    Some((&rest[..end], end))
+}
+
+fn delimited<'a>(text: &'a str, index: usize, delimiter: &str) -> Option<(&'a str, usize)> {
+    let rest = &text[index..];
+    if !rest.starts_with(delimiter) {
+        return None;
+    }
+    if delimiter != "`" && !delimiter_boundary_before(text, index) {
+        return None;
+    }
+    let after_open = &rest[delimiter.len()..];
+    if after_open.chars().next().is_none_or(char::is_whitespace) {
+        return None;
+    }
+    let close = after_open.find(delimiter)?;
+    if close == 0 {
+        return None;
+    }
+    let inner = &after_open[..close];
+    if inner.chars().last().is_none_or(char::is_whitespace) {
+        return None;
+    }
+    let consumed = delimiter.len() + close + delimiter.len();
+    if delimiter != "`" && !delimiter_boundary_after(text, index + consumed) {
+        return None;
+    }
+    Some((inner, consumed))
+}
+
+fn delimiter_boundary_before(text: &str, index: usize) -> bool {
+    text[..index]
+        .chars()
+        .next_back()
+        .is_none_or(|ch| !is_identifier_char(ch))
+}
+
+fn delimiter_boundary_after(text: &str, index: usize) -> bool {
+    text[index..]
+        .chars()
+        .next()
+        .is_none_or(|ch| !is_identifier_char(ch))
+}
+
+fn is_identifier_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_'
 }
 
 fn textarea_with_text(title: &'static str, text: &str) -> TextArea<'static> {

--- a/gestalt/cli/src/commands/agents/tui/state.rs
+++ b/gestalt/cli/src/commands/agents/tui/state.rs
@@ -29,6 +29,8 @@ pub(super) struct AgentUiState {
     saw_assistant_output: bool,
     saw_structured_output: bool,
     scroll_offset: usize,
+    turn_started_at: Option<Instant>,
+    turn_elapsed_reported: bool,
 }
 
 impl AgentUiState {
@@ -51,6 +53,8 @@ impl AgentUiState {
             saw_assistant_output: false,
             saw_structured_output: false,
             scroll_offset: 0,
+            turn_started_at: None,
+            turn_elapsed_reported: false,
         }
     }
 
@@ -63,6 +67,8 @@ impl AgentUiState {
         self.status = "starting turn".to_string();
         self.saw_assistant_output = false;
         self.saw_structured_output = false;
+        self.turn_started_at = Some(Instant::now());
+        self.turn_elapsed_reported = false;
     }
 
     pub(super) fn finish_worker(&mut self) {
@@ -298,6 +304,9 @@ impl AgentUiState {
             self.push_system(format!("structured output\n{text}"));
             self.saw_structured_output = true;
         }
+        if terminal {
+            self.push_turn_elapsed();
+        }
         self.status = turn_status_label(turn);
     }
 
@@ -449,6 +458,24 @@ impl AgentUiState {
         self.push(TranscriptKind::Error, text);
     }
 
+    fn push_meta(&mut self, text: impl Into<String>) {
+        self.push(TranscriptKind::Meta, text.into());
+    }
+
+    fn push_turn_elapsed(&mut self) {
+        if self.turn_elapsed_reported {
+            return;
+        }
+        self.turn_elapsed_reported = true;
+        let Some(started_at) = self.turn_started_at.take() else {
+            return;
+        };
+        self.push_meta(format!(
+            "Brewed for {}",
+            format_brewed_duration(started_at.elapsed())
+        ));
+    }
+
     fn push(&mut self, kind: TranscriptKind, text: String) {
         self.transcript.push(TranscriptItem {
             kind,
@@ -535,6 +562,7 @@ pub(super) enum TranscriptKind {
     Interaction,
     System,
     Error,
+    Meta,
 }
 
 impl TranscriptKind {
@@ -546,6 +574,7 @@ impl TranscriptKind {
             Self::Interaction => "Interaction",
             Self::System => "System",
             Self::Error => "Error",
+            Self::Meta => "",
         }
     }
 
@@ -557,6 +586,7 @@ impl TranscriptKind {
             Self::Interaction => Color::Magenta,
             Self::System => Color::Blue,
             Self::Error => Color::Red,
+            Self::Meta => Color::DarkGray,
         })
     }
 
@@ -568,6 +598,7 @@ impl TranscriptKind {
             Self::Interaction => Color::Gray,
             Self::System => Color::Gray,
             Self::Error => Color::LightRed,
+            Self::Meta => Color::DarkGray,
         })
     }
 }
@@ -901,6 +932,23 @@ fn truncate_preview(value: &str) -> String {
 fn format_duration(duration: Duration) -> String {
     if duration.as_secs() > 0 {
         format!("{:.1}s", duration.as_secs_f64())
+    } else {
+        format!("{}ms", duration.as_millis())
+    }
+}
+
+fn format_brewed_duration(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if seconds >= 60 {
+        let minutes = seconds / 60;
+        let remaining_seconds = seconds % 60;
+        if remaining_seconds == 0 {
+            format!("{minutes}m")
+        } else {
+            format!("{minutes}m {remaining_seconds}s")
+        }
+    } else if seconds > 0 {
+        format!("{seconds}s")
     } else {
         format!("{}ms", duration.as_millis())
     }

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -788,17 +788,20 @@ fn test_cli_runs_tty_agent_session_with_full_screen_ui() {
     session.wait_for(&mut output, "\x1b[?1049h");
     session.wait_for(&mut output, "Session");
     session.write("hello tui\r");
-    session.wait_for(&mut output, "Assistant");
     session.wait_for(&mut output, "hello");
+    session.wait_for(&mut output, "Brewed for");
     session.write("/quit\r");
     session.wait_for_exit();
 
     assert!(
-        output.contains("You") && output.contains("Assistant"),
-        "TTY transcript did not render grouped message headers:\n{output}"
+        output.contains("› hello tui") && output.contains("●"),
+        "TTY transcript did not render highlighted user input and assistant bullet:\n{output}"
     );
     assert!(
-        !output.contains("you>") && !output.contains("assistant>"),
+        !output.contains("You")
+            && !output.contains("Assistant")
+            && !output.contains("you>")
+            && !output.contains("assistant>"),
         "TTY transcript still rendered legacy prompt labels:\n{output}"
     );
     server.assert_finished();
@@ -1049,7 +1052,6 @@ fn test_cli_tty_reconciles_unmatched_tool_activity_rows() {
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
     session.write("ambiguous tools\r");
-    session.wait_for(&mut output, "query");
     session.wait_for(&mut output, "completed");
     session.wait_for(&mut output, "lookup");
     session.wait_for(&mut output, "ended");
@@ -1237,12 +1239,103 @@ fn test_cli_tty_scrolls_multiline_help_rows() {
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
     session.write("/help\r");
+    session.wait_for(&mut output, "mouse wheel");
     session.wait_for(&mut output, "cancels");
+    output.clear();
     session.write("\x1b[5~\x1b[5~");
     session.wait_for(&mut output, "Commands");
+    output.clear();
+    session.write("\x1b[6~\x1b[6~");
+    session.wait_for(&mut output, "cancels");
+    output.clear();
+    session.write("\x1b[<64;1;1M\x1b[<64;1;1M");
+    session.wait_for(&mut output, "Commands");
+    output.clear();
+    session.write("\x1b[<65;1;1M\x1b[<65;1;1M");
+    session.wait_for(&mut output, "cancels");
     session.write("/quit\r");
     session.wait_for_exit();
 
+    server.assert_finished();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_tty_renders_markdown_like_assistant_content() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions",
+            r#"{"provider":"managed","model":"gpt-5.4"}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            SESSION_JSON,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-1/turns",
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"render markdown"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-markdown",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-markdown/events/stream?after=0&limit=100&until=blocked_or_terminal",
+            StatusCode::OK,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"assistant.completed\",\"data\":{\"text\":\"**Data Platform**\\nUse `searchIssues` with _active_ filters and [Linear](https://linear.app).\\nKeep user_profile_id and __init__ literal.\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-markdown",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-markdown",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"succeeded",
+                "outputText":"**Data Platform**\nUse `searchIssues` with _active_ filters and [Linear](https://linear.app).\nKeep user_profile_id and __init__ literal."
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    let mut session = spawn_tty_cli(
+        home.path(),
+        server.url(),
+        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+    );
+    let mut output = String::new();
+    session.wait_for(&mut output, "Session");
+    session.write("render markdown\r");
+    session.wait_for(&mut output, "Data Platform");
+    session.wait_for(&mut output, "searchIssues");
+    session.wait_for(&mut output, "active");
+    session.wait_for(&mut output, "Linear");
+    session.wait_for(&mut output, "https://linear.app");
+    session.wait_for(&mut output, "user_profile_id");
+    session.wait_for(&mut output, "__init__");
+    session.wait_for(&mut output, "Brewed for");
+    session.write("/quit\r");
+    session.wait_for_exit();
+
+    assert!(
+        !output.contains("**Data Platform**")
+            && !output.contains("`searchIssues`")
+            && !output.contains("_active_")
+            && !output.contains("[Linear]"),
+        "TTY assistant markdown syntax was not rendered away:\n{output}"
+    );
     server.assert_finished();
 }
 
@@ -1413,11 +1506,44 @@ fn test_cli_tty_queues_prompt_while_turn_is_running() {
     session.wait_for(&mut output, "working");
     session.write("pending turn\r");
     session.wait_for(&mut output, "queued");
+    output.clear();
     session.wait_for(&mut output, "done-one");
+    session.wait_for(&mut output, "Brewed for");
+    session.wait_for(&mut output, "› pending turn");
     session.wait_for(&mut output, "done-two");
+    session.wait_for(&mut output, "Brewed for");
     session.write("/quit\r");
     session.wait_for_exit();
 
+    let done_one = output
+        .find("done-one")
+        .unwrap_or_else(|| panic!("queued TTY output did not include first response:\n{output}"));
+    let first_elapsed = output[done_one..]
+        .find("Brewed for")
+        .map(|index| done_one + index)
+        .unwrap_or_else(|| {
+            panic!("queued TTY output did not include first elapsed row:\n{output}")
+        });
+    let queued_prompt = output
+        .find("› pending turn")
+        .unwrap_or_else(|| panic!("queued TTY output did not include queued prompt:\n{output}"));
+    let done_two = output
+        .find("done-two")
+        .unwrap_or_else(|| panic!("queued TTY output did not include second response:\n{output}"));
+    let second_elapsed = output[done_two..]
+        .find("Brewed for")
+        .map(|index| done_two + index)
+        .unwrap_or_else(|| {
+            panic!("queued TTY output did not include second elapsed row:\n{output}")
+        });
+    assert!(
+        done_one < first_elapsed && first_elapsed < queued_prompt && queued_prompt < done_two,
+        "queued prompt rendered before the active turn completion marker:\n{output}"
+    );
+    assert!(
+        done_two < second_elapsed,
+        "second turn completion marker did not follow second response:\n{output}"
+    );
     server.assert_finished();
 }
 
@@ -1645,8 +1771,8 @@ fn test_cli_tty_secret_interaction_masks_and_requires_input() {
     session.write("\r");
     session.wait_for(&mut output, "A value is required.");
     session.write("supersecret\r");
-    session.wait_for(&mut output, "Assistant");
     session.wait_for(&mut output, "accepted");
+    session.wait_for(&mut output, "Brewed for");
     session.write("/quit\r");
     session.wait_for_exit();
 


### PR DESCRIPTION
## Summary

Polishes the live `gestalt agent` TUI transcript so it moves closer to the Claude/Hermes-style terminal presentation:

- renders user messages as highlighted prompt rows instead of `You` headers
- renders assistant messages with a bullet marker instead of an `Assistant` header
- renders lightweight inline markdown for assistant text: bold, italic, inline code, raw URLs, and Markdown links
- preserves Markdown link destinations in terminal text as `label (url)` for copyability
- avoids treating identifier-like text such as `user_profile_id` and `__init__` as emphasis
- emits a muted `Brewed for ...` completion row based on client-side turn elapsed time
- keeps queued prompt transcript rows attached to the queued turn when it starts, so completion metadata stays with the turn that produced it
- supports mouse-wheel transcript scrolling in addition to existing PgUp/PgDn scrolling

## Interfaces

### Rust

```rust
// Existing transcript item primitive, with one new client-only kind.
enum TranscriptKind {
    User,
    Assistant,
    Tool,
    Interaction,
    System,
    Error,
    Meta,
}

// Existing TUI state now tracks local elapsed time for the active turn.
struct AgentUiState {
    turn_started_at: Option<Instant>,
    turn_elapsed_reported: bool,
    // existing fields unchanged
}
```

Renderer behavior is still entirely client-side:

```rust
TranscriptKind::User      -> highlighted `› ...` prompt row
TranscriptKind::Assistant -> `● ...` row with inline markdown spans
TranscriptKind::Meta      -> muted `* Brewed for ...` row
```

Mouse scrolling reuses the existing scroll primitives:

```rust
MouseEventKind::ScrollUp   -> AgentUiState::scroll_up(...)
MouseEventKind::ScrollDown -> AgentUiState::scroll_down()
```

### stdin/stdout

No transport, API, or upstream model contract changes. The TUI still submits the same stdin/user messages and consumes the same streamed turn events.

Before:

```text
You
  what are my linear tasks?

Assistant
  **Data Platform**
  Use [Linear](https://linear.app)
```

After:

```text
› what are my linear tasks?

● Data Platform
  Use Linear (https://linear.app)
* Brewed for 1s
```

Inline markdown now renders away presentation syntax in the live TUI:

```text
**Data Platform**
Use `searchIssues` with _active_ filters and [Linear](https://linear.app).
Keep user_profile_id and __init__ literal.
```

renders as bold `Data Platform`, colored `searchIssues`, italic `active`, colored/underlined `Linear`, visible `https://linear.app`, and literal identifier text.

## Tests

- `cargo test --locked --test agents_cli -- --nocapture`
- `cargo build --locked --release`
- `git diff --check`

No unit tests added. Coverage extends the existing PTY integration tests for the live TUI rendering contract, including mouse-wheel escape input and queued-turn elapsed row ordering.
