### PR TITLE
workflow: write canonical target fingerprints

### DIFF
--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -311,7 +311,7 @@ type Host interface {
 }
 
 func TargetFingerprint(target Target) (string, error) {
-	return legacyTargetFingerprint(target)
+	return canonicalTargetFingerprint(target)
 }
 
 // TargetFingerprintMatches reports whether fingerprint matches the canonical
@@ -321,18 +321,18 @@ func TargetFingerprintMatches(target Target, fingerprint string) (bool, error) {
 	if fingerprint == "" {
 		return false, nil
 	}
-	current, err := TargetFingerprint(target)
+	canonical, err := TargetFingerprint(target)
 	if err != nil {
 		return false, err
 	}
-	if current == fingerprint {
+	if canonical == fingerprint {
 		return true, nil
 	}
-	canonical, err := canonicalTargetFingerprint(target)
+	legacy, err := legacyTargetFingerprint(target)
 	if err != nil {
 		return false, err
 	}
-	return canonical == fingerprint, nil
+	return legacy == fingerprint, nil
 }
 
 func targetFingerprint(payload any) (string, error) {

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -23,6 +23,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 )
 
+const (
+	canonicalSchedulePluginWorkflowTargetFingerprint = "70af38da089061d9dec9094d8c2439074f5f9f860f63f1939a6c48d8796e3818"
+	canonicalScheduleAgentWorkflowTargetFingerprint  = "da243c789ae45205cb83ddcb7fce750a3e6e09cc3d7fac6d037b2b7ba05ce2de"
+)
+
 type stubWorkflowControl struct {
 	defaultProviderName string
 	provider            coreworkflow.Provider
@@ -702,6 +707,9 @@ func TestWorkflowScheduleCRUD(t *testing.T) {
 	if ref.SubjectKind != "user" || ref.DisplayName != "Ada" || ref.AuthSource != "session" {
 		t.Fatalf("execution ref subject metadata = (%q, %q, %q), want user/Ada/session", ref.SubjectKind, ref.DisplayName, ref.AuthSource)
 	}
+	if ref.TargetFingerprint != canonicalSchedulePluginWorkflowTargetFingerprint {
+		t.Fatalf("execution ref target fingerprint = %q, want canonical %q", ref.TargetFingerprint, canonicalSchedulePluginWorkflowTargetFingerprint)
+	}
 
 	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/schedules/", nil)
 	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
@@ -877,6 +885,9 @@ func TestWorkflowScheduleAgentTargetCreateAndList(t *testing.T) {
 	}
 	if ref.Target.Agent == nil || ref.TargetFingerprint == "" {
 		t.Fatalf("execution ref = %#v", ref)
+	}
+	if ref.TargetFingerprint != canonicalScheduleAgentWorkflowTargetFingerprint {
+		t.Fatalf("execution ref target fingerprint = %q, want canonical %q", ref.TargetFingerprint, canonicalScheduleAgentWorkflowTargetFingerprint)
 	}
 
 	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/schedules/", nil)


### PR DESCRIPTION
## Summary

Flip `workflow.TargetFingerprint` to emit the canonical target-nested fingerprint now that `valon-tools/deploy` is pinned to the dual-read Gestalt runtime from #1486/#938.

`TargetFingerprintMatches` still accepts both canonical and legacy stored fingerprints, so existing execution refs remain valid while new execution refs are written in the canonical format.

## New interfaces

```go
fingerprint, err := workflow.TargetFingerprint(target)
matches, err := workflow.TargetFingerprintMatches(target, stored.TargetFingerprint)
```

## Examples

Canonical write:

```go
fingerprint, err := workflow.TargetFingerprint(target)
if err != nil {
    return err
}
ref.TargetFingerprint = fingerprint
```

Compatibility read:

```go
matches, err := workflow.TargetFingerprintMatches(target, ref.TargetFingerprint)
if err != nil {
    return err
}
if !matches {
    return fmt.Errorf("workflow target fingerprint mismatch")
}
```

## Verification

- `git diff --check`
- `go test ./core/workflow ./internal/workflowmanager ./internal/bootstrap ./internal/server -run 'TestSignalRunUsesCurrentPrincipalForTargetValidation|TestSignalOrStartRunExecutionRefInheritsDeclaredAgentToolInvokes|TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefAcceptsStoredFingerprints|TestWorkflowRuntimeInvokeExecutionRefUsesStoredSubjectPrincipal|TestWorkflowScheduleCRUD|TestWorkflowScheduleAgentTargetCreateAndList' -count=1`
