### PR TITLE
Use image-backed hosted runtime launches

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -244,6 +244,17 @@ plugins:
 forwarded to the selected runtime backend. Their meaning is backend-specific: a
 local runtime may ignore them, while a hosted runtime may use them to choose a
 sandbox template, container image, or labels/tags for lifecycle management.
+When `runtime.image` is set, Gestalt expects the image to contain the provider
+package at the image working directory. It starts the executable declared by
+the provider manifest entrypoint and passes the manifest entrypoint args:
+
+```yaml
+execution:
+  mode: hosted
+  runtime:
+    provider: modal
+    image: ghcr.io/example/support-plugin@sha256:...
+```
 
 The built-in `local` runtime handles same-machine execution. Installable
 `kind: runtime` providers such as Modal handle hosted execution.

--- a/docs/content/custom-providers/runtime.mdx
+++ b/docs/content/custom-providers/runtime.mdx
@@ -104,11 +104,6 @@ func (p *Provider) GetSupport(context.Context, *emptypb.Empty) (*proto.PluginRun
 		CanHostPlugins:    true,
 		HostServiceAccess: proto.PluginRuntimeHostServiceAccess_PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT,
 		EgressMode:        proto.PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME,
-		LaunchMode:        proto.PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE,
-		ExecutionTarget: &proto.PluginRuntimeExecutionTarget{
-			Goos:   "linux",
-			Goarch: "amd64",
-		},
 	}, nil
 }
 
@@ -175,11 +170,12 @@ Gestalt's hostname-based `allowedHosts` model. `cidr` is useful metadata, but
 it is not equivalent to hostname-based policy. If your backend can only express
 network controls at firewall or CIDR granularity, advertise `cidr`.
 
-`launch_mode` should be `host_path` only when the backend can execute directly
-from the host paths Gestalt provides. Otherwise advertise `bundle`, which tells
-the host to stage a runtime bundle first. When bundle launch is required,
-`execution_target` must accurately describe the platform the backend will
-actually run so the host can choose or stage the right artifact.
+Hosted runtime providers should run provider images rather than expect Gestalt
+to upload a provider bundle into the session. The `StartSession` request carries
+the selected image, template, and metadata. `StartPlugin` then carries the
+manifest-derived `command` and `args` to execute inside the image. Execute those
+values exactly as provided by the host after applying any environment variables,
+host-service bindings, and egress policy in the request.
 
 New providers should populate `support`. That grouped support shape is the
 runtime contract operators see in inspection.

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -78,8 +78,7 @@ a default selector for providers that already opted into hosted execution.
 Runtime backends are not interchangeable, but the compatibility check is meant
 to read in terms of behavior, not implementation details. Gestalt asks whether
 the runtime can host plugins, how hosted plugins reach Gestalt-owned services,
-whether the runtime can preserve hostname-based `egress.allowedHosts`, and
-whether the plugin should launch from a host path or from a staged bundle.
+and whether the runtime can preserve hostname-based `egress.allowedHosts`.
 
 Host-service access is reported as `none`, `relay`, or `direct`. `direct`
 means the runtime can expose guest-local service sockets inside the session.
@@ -124,18 +123,30 @@ Today there are two main runtime choices:
 | `local` | Built-in driver | Runs the plugin on the same machine as `gestaltd`. Supports host-path execution and the existing host-local runtime behavior. |
 | `modal` | Installable `kind: runtime` provider | Runs the plugin in a hosted Linux sandbox. Requires `runtime.providers.<name>.config.app` and `plugins.<name>.execution.runtime.image`. When the host is configured for the public relay and proxy path, Modal can run plugins that need Gestalt-owned services and hostname-based egress. |
 
-## Bundle staging and host-path execution
+## Provider images
 
-Some runtimes can execute directly from host paths. Others cannot.
+Hosted runtime providers run prebuilt provider images. Gestalt does not upload
+provider bundles into those sessions. Instead, the configured image must contain
+the provider package at the image working directory and preserve the release
+package layout. Gestalt starts the manifest entrypoint path from that working
+directory and passes the manifest entrypoint args.
 
-When a backend advertises a `host_path` launch mode, Gestalt may launch the
-plugin directly from local paths, including synthesized source-provider
-execution. When it advertises `bundle`, Gestalt stages a runtime bundle first
-and asks the backend to start the plugin from that staged bundle instead.
+```yaml
+plugins:
+  support:
+    source: https://artifacts.example.com/support/v0.1.0/provider-release.yaml
+    execution:
+      mode: hosted
+      runtime:
+        provider: modal
+        image: ghcr.io/example/support-plugin@sha256:...
+```
 
 This is why `plugins.<name>.execution.runtime.image`, `template`, and
 `metadata` are forwarded to the runtime backend: they are runtime-specific
-launch hints, not universal plugin semantics.
+session hints, not universal plugin semantics. Keep the manifest release and
+image digest in sync; Gestalt does not inspect the image to prove that the
+manifest entrypoint exists inside it.
 
 ## What to read next
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -253,6 +253,26 @@ means `server.baseURL` and `server.encryptionKey` must be set, and the runtime
 must report a compatible support profile. Without those prerequisites, Gestalt
 will reject Modal for plugins that need relay-backed host services,
 `egress.allowedHosts`, or a server-wide default-deny egress policy.
+
+Hosted runtime images are expected to contain the provider package at the image
+working directory. Gestalt starts the executable declared by the provider
+manifest entrypoint and passes the manifest entrypoint args:
+
+```yaml
+plugins:
+  support:
+    source: https://artifacts.example.com/support/v0.1.0/provider-release.yaml
+    execution:
+      mode: hosted
+      runtime:
+        provider: modal
+        image: ghcr.io/example/support-plugin@sha256:...
+```
+
+There is no separate launch source or runtime command override. If
+`runtime.image` is set, the image must preserve the provider package layout and
+make the manifest entrypoint executable from the image working directory.
+
 ## `providers.authentication`
 
 Platform authentication is optional. Omit the `providers.authentication` block entirely to disable it. When platform authentication is enabled, configure one or more named entries under `providers.authentication`. If more than one entry exists, set `server.providers.authentication` to pick which one the host should use.

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -22,6 +25,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
 )
 
@@ -234,6 +238,19 @@ func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *tes
 	runtimeConfig.Template = "python-dev"
 	runtimeConfig.Image = "ghcr.io/valon/gestalt-python-runtime:latest"
 	runtimeConfig.Metadata = map[string]string{"tenant": "eng"}
+	imageEntrypointDir, err := os.MkdirTemp(".", "agent-image-entrypoint-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(imageEntrypointDir) })
+	imageEntrypoint := filepath.Join(imageEntrypointDir, "agent")
+	agentBytes, err := os.ReadFile(bin)
+	if err != nil {
+		t.Fatalf("ReadFile(agent bin): %v", err)
+	}
+	if err := os.WriteFile(imageEntrypoint, agentBytes, 0o755); err != nil {
+		t.Fatalf("WriteFile(image entrypoint): %v", err)
+	}
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
@@ -249,6 +266,12 @@ func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *tes
 				"simple": {
 					Command:   bin,
 					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+					ResolvedManifest: &providermanifestv1.Manifest{
+						Kind: providermanifestv1.KindAgent,
+						Entrypoint: &providermanifestv1.Entrypoint{
+							ArtifactPath: filepath.ToSlash(imageEntrypoint),
+						},
+					},
 				},
 			},
 		},
@@ -1525,7 +1548,6 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessNone
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -1611,6 +1633,133 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 	}
 }
 
+func TestAgentRuntimeImageLaunchUsesManifestEntrypoint(t *testing.T) {
+	t.Parallel()
+
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessDirect
+	entry := &config.ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Kind: providermanifestv1.KindAgent,
+			Entrypoint: &providermanifestv1.Entrypoint{
+				ArtifactPath: "bin/gestalt-agent-simple",
+				Args:         []string{"--serve"},
+			},
+		},
+		Execution: &config.ExecutionConfig{
+			Mode: config.ExecutionModeHosted,
+			Runtime: &config.HostedRuntimeConfig{
+				Image: "ghcr.io/example/simple-agent@sha256:abc123",
+			},
+		},
+	}
+
+	launch, err := prepareHostedAgentProviderLaunch(context.Background(), "simple", entry, mustNode(t, map[string]any{
+		"name": "simple",
+	}), Deps{PluginRuntime: runtimeProvider})
+	if err != nil {
+		t.Fatalf("prepareHostedAgentProviderLaunch: %v", err)
+	}
+	defer launch.close()
+
+	if launch.launch.command != "./bin/gestalt-agent-simple" {
+		t.Fatalf("agent command = %q, want manifest image entrypoint", launch.launch.command)
+	}
+	if !slices.Equal(launch.launch.args, []string{"--serve"}) {
+		t.Fatalf("agent args = %#v, want manifest image args", launch.launch.args)
+	}
+}
+
+func TestAgentRuntimeTemplateLaunchUsesManifestEntrypoint(t *testing.T) {
+	t.Parallel()
+
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessDirect
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+	}
+	entry := &config.ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Kind: providermanifestv1.KindAgent,
+			Entrypoint: &providermanifestv1.Entrypoint{
+				ArtifactPath: "bin/gestalt-agent-simple",
+				Args:         []string{"--serve"},
+			},
+		},
+		Execution: &config.ExecutionConfig{
+			Mode: config.ExecutionModeHosted,
+			Runtime: &config.HostedRuntimeConfig{
+				Provider: "hosted",
+				Template: "python-runtime",
+			},
+		},
+	}
+
+	launch, err := prepareHostedAgentProviderLaunch(context.Background(), "simple", entry, mustNode(t, map[string]any{
+		"name":    "simple",
+		"command": "/host/only/agent",
+		"args":    []string{"host-arg"},
+	}), Deps{PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{})})
+	if err != nil {
+		t.Fatalf("prepareHostedAgentProviderLaunch: %v", err)
+	}
+	defer launch.close()
+
+	if launch.launch.command != "./bin/gestalt-agent-simple" {
+		t.Fatalf("agent command = %q, want manifest template entrypoint", launch.launch.command)
+	}
+	if !slices.Equal(launch.launch.args, []string{"--serve"}) {
+		t.Fatalf("agent args = %#v, want manifest template args", launch.launch.args)
+	}
+}
+
+func TestAgentRuntimeLocalFallbackImageLaunchUsesConfiguredCommand(t *testing.T) {
+	t.Parallel()
+
+	entry := &config.ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Kind: providermanifestv1.KindAgent,
+			Entrypoint: &providermanifestv1.Entrypoint{
+				ArtifactPath: "bin/gestalt-agent-simple",
+				Args:         []string{"--serve"},
+			},
+		},
+		Execution: &config.ExecutionConfig{
+			Mode: config.ExecutionModeHosted,
+			Runtime: &config.HostedRuntimeConfig{
+				Image: "ghcr.io/example/simple-agent@sha256:abc123",
+			},
+		},
+	}
+
+	launch, err := prepareHostedAgentProviderLaunch(context.Background(), "simple", entry, mustNode(t, map[string]any{
+		"name":    "simple",
+		"command": "/host/only/agent",
+		"args":    []string{"host-arg"},
+	}), Deps{})
+	if err != nil {
+		t.Fatalf("prepareHostedAgentProviderLaunch: %v", err)
+	}
+	defer launch.close()
+
+	if launch.launch.command != "/host/only/agent" {
+		t.Fatalf("agent command = %q, want configured command", launch.launch.command)
+	}
+	if !slices.Equal(launch.launch.args, []string{"host-arg"}) {
+		t.Fatalf("agent args = %#v, want configured args", launch.launch.args)
+	}
+}
+
 func TestAgentRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 	t.Parallel()
 
@@ -1619,7 +1768,6 @@ func TestAgentRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 		inner: newCapturingPluginRuntime(),
 		support: pluginruntime.Support{
 			CanHostPlugins: true,
-			LaunchMode:     pluginruntime.LaunchModeHostPath,
 		},
 	}
 

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -363,11 +363,6 @@ func newCapturingBundlePluginRuntime() *capturingBundlePluginRuntime {
 		provider: pluginruntime.NewLocalProvider(),
 		support: pluginruntime.Support{
 			CanHostPlugins: true,
-			LaunchMode:     pluginruntime.LaunchModeBundle,
-			ExecutionTarget: pluginruntime.ExecutionTarget{
-				GOOS:   runtime.GOOS,
-				GOARCH: runtime.GOARCH,
-			},
 		},
 		fakePlugins: make(map[string]*fakeHostedPluginServer),
 	}
@@ -427,35 +422,15 @@ func (r *capturingBundlePluginRuntime) StartPlugin(ctx context.Context, req plug
 		Command:    req.Command,
 		Args:       slices.Clone(req.Args),
 		Env:        cloneRuntimeMetadata(req.Env),
-		BundleDir:  req.BundleDir,
 		Egress:     cloneRuntimeEgressPolicy(req.Egress),
 		HostBinary: req.HostBinary,
 	})
 	r.mu.Unlock()
 
-	translated := req
-	if req.BundleDir != "" && strings.HasPrefix(req.Command, pluginruntime.HostedPluginBundleRoot+"/") {
-		rel := strings.TrimPrefix(req.Command, pluginruntime.HostedPluginBundleRoot+"/")
-		translated.Command = filepath.Join(req.BundleDir, filepath.FromSlash(rel))
-	}
-	if req.BundleDir != "" {
-		translated.Args = make([]string, len(req.Args))
-		for i, arg := range req.Args {
-			switch {
-			case arg == pluginruntime.HostedPluginBundleRoot:
-				translated.Args[i] = req.BundleDir
-			case strings.HasPrefix(arg, pluginruntime.HostedPluginBundleRoot+"/"):
-				rel := strings.TrimPrefix(arg, pluginruntime.HostedPluginBundleRoot+"/")
-				translated.Args[i] = filepath.Join(req.BundleDir, filepath.FromSlash(rel))
-			default:
-				translated.Args[i] = arg
-			}
-		}
-	}
 	if r.fakeHosted {
 		return r.startFakeHostedPlugin(req)
 	}
-	return r.provider.StartPlugin(ctx, translated)
+	return r.provider.StartPlugin(ctx, req)
 }
 
 func (r *capturingBundlePluginRuntime) Close() error {
@@ -1303,7 +1278,6 @@ func (r *capturingBundlePluginRuntime) startPluginRequestsCopy() []pluginruntime
 			Command:    req.Command,
 			Args:       slices.Clone(req.Args),
 			Env:        cloneRuntimeMetadata(req.Env),
-			BundleDir:  req.BundleDir,
 			Egress:     cloneRuntimeEgressPolicy(req.Egress),
 			HostBinary: req.HostBinary,
 		}
@@ -3306,6 +3280,10 @@ func TestPluginManifestOAuthWiresConnectionAuth(t *testing.T) {
 		},
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	manifest.Entrypoint = &providermanifestv1.Entrypoint{
+		ArtifactPath: "bin/gestalt-plugin-echo",
+		Args:         []string{"--config", "/etc/gestalt/echo.yaml"},
+	}
 	manifest.Spec.Connections = map[string]*providermanifestv1.ManifestConnectionDef{
 		"default": {
 			Auth: &providermanifestv1.ProviderAuth{
@@ -3867,7 +3845,6 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -5429,6 +5406,23 @@ func TestPluginRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *te
 		},
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	imageEntrypointDir, err := os.MkdirTemp(".", "plugin-image-entrypoint-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(imageEntrypointDir) })
+	imageEntrypoint := filepath.Join(imageEntrypointDir, "plugin")
+	pluginBytes, err := os.ReadFile(bin)
+	if err != nil {
+		t.Fatalf("ReadFile(plugin bin): %v", err)
+	}
+	if err := os.WriteFile(imageEntrypoint, pluginBytes, 0o755); err != nil {
+		t.Fatalf("WriteFile(image entrypoint): %v", err)
+	}
+	manifest.Entrypoint = &providermanifestv1.Entrypoint{
+		ArtifactPath: filepath.ToSlash(imageEntrypoint),
+		Args:         []string{"provider"},
+	}
 	runtimeProvider := newCapturingPluginRuntime()
 	ctxSentinel := &struct{}{}
 	var factoryContextValue any
@@ -5514,7 +5508,7 @@ func TestPluginRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *te
 	}
 }
 
-func TestPluginRuntimeStagesBundleForNonHostPathExecution(t *testing.T) {
+func TestPluginRuntimeStartsHostedCommandWithoutBundleStaging(t *testing.T) {
 	t.Parallel()
 
 	bin := buildEchoPluginBinary(t)
@@ -5604,11 +5598,11 @@ func TestPluginRuntimeStagesBundleForNonHostPathExecution(t *testing.T) {
 		t.Fatalf("start plugin requests = %d, want 1", len(requests))
 	}
 	req := requests[0]
-	if req.BundleDir == "" {
-		t.Fatal("StartPlugin BundleDir = empty, want staged bundle")
+	if req.Command != bin {
+		t.Fatalf("StartPlugin Command = %q, want configured command", req.Command)
 	}
-	if !strings.HasPrefix(req.Command, pluginruntime.HostedPluginBundleRoot+"/") {
-		t.Fatalf("StartPlugin Command = %q, want command under %s", req.Command, pluginruntime.HostedPluginBundleRoot)
+	if !slices.Equal(req.Args, []string{"provider"}) {
+		t.Fatalf("StartPlugin Args = %#v, want configured args", req.Args)
 	}
 	if got := runtimeProvider.bindHostCalls.Load(); got != 0 {
 		t.Fatalf("BindHostService calls = %d, want 0", got)
@@ -5617,55 +5611,25 @@ func TestPluginRuntimeStagesBundleForNonHostPathExecution(t *testing.T) {
 	if err := CloseProviders(providers); err != nil {
 		t.Fatalf("CloseProviders: %v", err)
 	}
-	if _, err := os.Stat(req.BundleDir); !os.IsNotExist(err) {
-		t.Fatalf("bundle dir stat after close = %v, want not-exist", err)
-	}
 }
 
-func TestPluginRuntimeDropsSourceStyleArgsForNonHostPathExecution(t *testing.T) {
+func TestPluginRuntimeImageLaunchUsesManifestEntrypoint(t *testing.T) {
 	t.Parallel()
 
-	bin := buildExampleProviderBinary(t)
 	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
-		Name: "example",
+		Name: "echoext",
 		Operations: []catalog.CatalogOperation{
-			{ID: "status", Method: http.MethodGet},
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
 		},
 	})
-	artifactPath := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, filepath.Base(bin)))
-	artifactBytes, err := os.ReadFile(bin)
-	if err != nil {
-		t.Fatalf("ReadFile(binary): %v", err)
-	}
-	artifactFile := filepath.Join(manifestRoot, filepath.FromSlash(artifactPath))
-	if err := os.MkdirAll(filepath.Dir(artifactFile), 0o755); err != nil {
-		t.Fatalf("MkdirAll(artifact dir): %v", err)
-	}
-	if err := os.WriteFile(artifactFile, artifactBytes, 0o755); err != nil {
-		t.Fatalf("WriteFile(artifact): %v", err)
-	}
-	digest, err := providerpkg.FileSHA256(artifactFile)
-	if err != nil {
-		t.Fatalf("FileSHA256(artifact): %v", err)
-	}
-	manifest := newExecutableManifest("Example Provider", "Prepared install artifact")
-	manifest.Artifacts = []providermanifestv1.Artifact{{
-		OS:     runtime.GOOS,
-		Arch:   runtime.GOARCH,
-		Path:   artifactPath,
-		SHA256: digest,
-	}}
-	manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: artifactPath}
-	manifestData, err := providerpkg.EncodeManifestFormat(manifest, providerpkg.ManifestFormatYAML)
-	if err != nil {
-		t.Fatalf("EncodeManifestFormat(manifest): %v", err)
-	}
-	manifestPath := filepath.Join(manifestRoot, "manifest.yaml")
-	if err := os.WriteFile(manifestPath, manifestData, 0o644); err != nil {
-		t.Fatalf("WriteFile(manifest.yaml): %v", err)
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	manifest.Entrypoint = &providermanifestv1.Entrypoint{
+		ArtifactPath: "bin/gestalt-plugin-echo",
+		Args:         []string{"--config", "/etc/gestalt/echo.yaml"},
 	}
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
 		return runtimeProvider, nil
@@ -5682,11 +5646,12 @@ func TestPluginRuntimeDropsSourceStyleArgsForNonHostPathExecution(t *testing.T) 
 			},
 		},
 		Plugins: map[string]*config.ProviderEntry{
-			"example": {
-				Args:                 []string{"-m", "gestalt._runtime", "/host/source", "pkg.provider", "integration"},
+			"echoext": {
 				ResolvedManifest:     manifest,
-				ResolvedManifestPath: manifestPath,
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Execution: hostedExecutionConfig(&config.HostedRuntimeConfig{
+					Image: "ghcr.io/example/echo-plugin@sha256:abc123",
+				}),
 			},
 		},
 	}
@@ -5707,65 +5672,32 @@ func TestPluginRuntimeDropsSourceStyleArgsForNonHostPathExecution(t *testing.T) 
 	if len(requests) != 1 {
 		t.Fatalf("start plugin requests = %d, want 1", len(requests))
 	}
-	if len(requests[0].Args) != 0 {
-		t.Fatalf("StartPlugin Args = %#v, want source-style host args dropped", requests[0].Args)
+	req := requests[0]
+	if req.Command != "./bin/gestalt-plugin-echo" {
+		t.Fatalf("StartPlugin Command = %q, want manifest image entrypoint", req.Command)
 	}
-	if !strings.HasPrefix(requests[0].Command, pluginruntime.HostedPluginBundleRoot+"/") {
-		t.Fatalf("StartPlugin Command = %q, want command under %s", requests[0].Command, pluginruntime.HostedPluginBundleRoot)
+	if !slices.Equal(req.Args, []string{"--config", "/etc/gestalt/echo.yaml"}) {
+		t.Fatalf("StartPlugin Args = %#v, want manifest image args", req.Args)
 	}
 }
 
-func TestPluginRuntimeRewritesHostPathArgsForNonHostPathExecution(t *testing.T) {
+func TestPluginRuntimeTemplateLaunchUsesManifestEntrypoint(t *testing.T) {
 	t.Parallel()
 
-	bin := buildExampleProviderBinary(t)
 	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
-		Name: "example",
+		Name: "echoext",
 		Operations: []catalog.CatalogOperation{
-			{ID: "status", Method: http.MethodGet},
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
 		},
 	})
-	configPath := filepath.Join(manifestRoot, "fixtures", "config.json")
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll(fixtures): %v", err)
-	}
-	if err := os.WriteFile(configPath, []byte(`{"ok":true}`), 0o644); err != nil {
-		t.Fatalf("WriteFile(config.json): %v", err)
-	}
-	artifactPath := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, filepath.Base(bin)))
-	artifactBytes, err := os.ReadFile(bin)
-	if err != nil {
-		t.Fatalf("ReadFile(binary): %v", err)
-	}
-	artifactFile := filepath.Join(manifestRoot, filepath.FromSlash(artifactPath))
-	if err := os.MkdirAll(filepath.Dir(artifactFile), 0o755); err != nil {
-		t.Fatalf("MkdirAll(artifact dir): %v", err)
-	}
-	if err := os.WriteFile(artifactFile, artifactBytes, 0o755); err != nil {
-		t.Fatalf("WriteFile(artifact): %v", err)
-	}
-	digest, err := providerpkg.FileSHA256(artifactFile)
-	if err != nil {
-		t.Fatalf("FileSHA256(artifact): %v", err)
-	}
-	manifest := newExecutableManifest("Example Provider", "Prepared install artifact")
-	manifest.Artifacts = []providermanifestv1.Artifact{{
-		OS:     runtime.GOOS,
-		Arch:   runtime.GOARCH,
-		Path:   artifactPath,
-		SHA256: digest,
-	}}
-	manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: artifactPath}
-	manifestData, err := providerpkg.EncodeManifestFormat(manifest, providerpkg.ManifestFormatYAML)
-	if err != nil {
-		t.Fatalf("EncodeManifestFormat(manifest): %v", err)
-	}
-	manifestPath := filepath.Join(manifestRoot, "manifest.yaml")
-	if err := os.WriteFile(manifestPath, manifestData, 0o644); err != nil {
-		t.Fatalf("WriteFile(manifest.yaml): %v", err)
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	manifest.Entrypoint = &providermanifestv1.Entrypoint{
+		ArtifactPath: "bin/gestalt-plugin-echo",
+		Args:         []string{"--config", "/etc/gestalt/echo.yaml"},
 	}
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
 		return runtimeProvider, nil
@@ -5782,19 +5714,74 @@ func TestPluginRuntimeRewritesHostPathArgsForNonHostPathExecution(t *testing.T) 
 			},
 		},
 		Plugins: map[string]*config.ProviderEntry{
-			"example": {
+			"echoext": {
+				Command:              "/host/only/plugin",
+				Args:                 []string{"host-arg"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Execution: hostedExecutionConfig(&config.HostedRuntimeConfig{
+					Template: "python-runtime",
+				}),
+			},
+		},
+	}
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() {
+		if err := CloseProviders(providers); err != nil {
+			t.Fatalf("CloseProviders: %v", err)
+		}
+	}()
+
+	requests := runtimeProvider.startPluginRequestsCopy()
+	if len(requests) != 1 {
+		t.Fatalf("start plugin requests = %d, want 1", len(requests))
+	}
+	req := requests[0]
+	if req.Command != "./bin/gestalt-plugin-echo" {
+		t.Fatalf("StartPlugin Command = %q, want manifest template entrypoint", req.Command)
+	}
+	if !slices.Equal(req.Args, []string{"--config", "/etc/gestalt/echo.yaml"}) {
+		t.Fatalf("StartPlugin Args = %#v, want manifest template args", req.Args)
+	}
+}
+
+func TestPluginRuntimeLocalFallbackImageLaunchUsesConfiguredCommand(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	manifest.Entrypoint = &providermanifestv1.Entrypoint{
+		ArtifactPath: "bin/gestalt-plugin-echo",
+		Args:         []string{"--config", "/etc/gestalt/echo.yaml"},
+	}
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
 				Command:              bin,
-				Args:                 []string{"--config", configPath, "--name", "example"},
+				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
-				ResolvedManifestPath: manifestPath,
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Execution: hostedExecutionConfig(&config.HostedRuntimeConfig{
+					Image: "ghcr.io/example/echo-plugin@sha256:abc123",
+				}),
 			},
 		},
 	}
 
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
-	})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{})
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -5804,15 +5791,12 @@ func TestPluginRuntimeRewritesHostPathArgsForNonHostPathExecution(t *testing.T) 
 		}
 	}()
 
-	requests := runtimeProvider.startPluginRequestsCopy()
-	if len(requests) != 1 {
-		t.Fatalf("start plugin requests = %d, want 1", len(requests))
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get(echoext): %v", err)
 	}
-	if requests[0].Args[1] != pluginruntime.HostedPluginBundleRoot+"/fixtures/config.json" {
-		t.Fatalf("StartPlugin Args = %#v, want staged bundle config path", requests[0].Args)
-	}
-	if requests[0].Args[3] != "example" {
-		t.Fatalf("StartPlugin Args = %#v, want non-path args preserved", requests[0].Args)
+	if _, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": "PATH"}, ""); err != nil {
+		t.Fatalf("Execute(read_env): %v", err)
 	}
 }
 
@@ -5829,11 +5813,6 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
-	runtimeProvider.fakeHosted = true
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
-	runtimeProvider.fakeHosted = true
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -6059,7 +6038,6 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -6164,7 +6142,6 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -6294,7 +6271,6 @@ func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testi
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 
 	factories := NewFactoryRegistry()
@@ -6419,7 +6395,6 @@ func TestPluginRuntimeConfigUsesPublicCacheRelayWithoutHostServiceTunnelCapabili
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -6553,7 +6528,6 @@ func TestPluginRuntimePublicCacheRelayRoundTripsThroughHostedPlugin(t *testing.T
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 
 	factories := NewFactoryRegistry()
@@ -6683,7 +6657,6 @@ func TestPluginRuntimePublicS3RelayRoundTripsThroughHostedPlugin(t *testing.T) {
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 
 	factories := NewFactoryRegistry()
@@ -6836,7 +6809,6 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 
 	factories := NewFactoryRegistry()
@@ -6996,7 +6968,6 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -7156,7 +7127,6 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 		inner: pluginruntime.NewLocalProvider(),
 		support: pluginruntime.Support{
 			CanHostPlugins: true,
-			LaunchMode:     pluginruntime.LaunchModeHostPath,
 		},
 	}
 	factories := NewFactoryRegistry()
@@ -7483,7 +7453,6 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -7638,7 +7607,6 @@ func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *t
 	}
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -7759,7 +7727,6 @@ func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapa
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -7845,7 +7812,6 @@ func TestPluginRuntimeConfigSkipsPublicEgressProxyWhenHostnameEgressIsNotRequire
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -7912,7 +7878,6 @@ func TestPluginRuntimeConfigUsesDirectHostServiceBindingsAndSkipsPublicEgressPro
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessDirect
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -8014,7 +7979,6 @@ func TestPluginRuntimePublicEgressProxyRoundTripsThroughHostedPlugin(t *testing.
 	manifest := newExecutableManifest("Echo", "Hosted egress proxy roundtrip")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
-	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {

--- a/gestaltd/internal/bootstrap/plugin_runtime_launch.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_launch.go
@@ -2,153 +2,73 @@ package bootstrap
 
 import (
 	"fmt"
-	"os"
 	"path"
-	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
-	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
-type pluginRuntimeLaunch struct {
-	command   string
-	args      []string
-	bundleDir string
-	cleanup   func()
+type hostedProcessLaunch struct {
+	command string
+	args    []string
+	cleanup func()
 }
 
-func prepareHostedRuntimeLaunch(kind, name string, entry *config.ProviderEntry, command string, args []string, cleanup func(), behavior RuntimeBehavior) (pluginRuntimeLaunch, error) {
-	launch := pluginRuntimeLaunch{
-		command: command,
+func prepareHostedProcessLaunch(kind, name string, entry *config.ProviderEntry, command string, args []string, cleanup func(), runtimeConfig config.EffectiveHostedRuntime) (hostedProcessLaunch, error) {
+	if hostedRuntimeUsesImageEntrypoint(runtimeConfig) {
+		command, args, err := hostedRuntimeImageEntrypoint(kind, name, entry)
+		if err != nil {
+			return hostedProcessLaunch{}, err
+		}
+		return hostedProcessLaunch{
+			command: command,
+			args:    args,
+			cleanup: cleanup,
+		}, nil
+	}
+
+	launch := hostedProcessLaunch{
+		command: strings.TrimSpace(command),
 		args:    slices.Clone(args),
 		cleanup: cleanup,
 	}
-	if behavior.LaunchMode == RuntimeLaunchModeHostPath {
-		return launch, nil
+	if launch.command == "" {
+		return hostedProcessLaunch{}, fmt.Errorf("hosted runtime command is required")
 	}
-	if entry == nil {
-		return pluginRuntimeLaunch{}, fmt.Errorf("%s entry is required for non-local hosted runtime", kind)
-	}
-	manifestPath := strings.TrimSpace(entry.ResolvedManifestPath)
-	if manifestPath == "" {
-		return pluginRuntimeLaunch{}, fmt.Errorf("resolved manifest path is required for non-local hosted runtime")
-	}
-	rootDir := filepath.Dir(manifestPath)
-	if !behavior.ExecutionTarget.IsSet() {
-		return pluginRuntimeLaunch{}, fmt.Errorf("non-local hosted runtime must declare execution goos/goarch")
-	}
-
-	bundleDir, err := providerhost.NewPluginTempDir("gestalt-plugin-runtime-bundle-*")
-	if err != nil {
-		return pluginRuntimeLaunch{}, fmt.Errorf("create hosted runtime bundle dir: %w", err)
-	}
-	bundleCleanup := func() {
-		_ = os.RemoveAll(bundleDir)
-	}
-
-	localCommand, err := stageHostedRuntimeBundle(kind, name, manifestPath, bundleDir, behavior.ExecutionTarget.GOOS, behavior.ExecutionTarget.GOARCH)
-	if err != nil {
-		bundleCleanup()
-		return pluginRuntimeLaunch{}, err
-	}
-	rel, err := filepath.Rel(bundleDir, localCommand)
-	if err != nil {
-		bundleCleanup()
-		return pluginRuntimeLaunch{}, fmt.Errorf("resolve hosted runtime bundle command: %w", err)
-	}
-	if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
-		bundleCleanup()
-		return pluginRuntimeLaunch{}, fmt.Errorf("hosted runtime bundle command %q is outside bundle %q", localCommand, bundleDir)
-	}
-
-	launch.command = path.Join(pluginruntime.HostedPluginBundleRoot, filepath.ToSlash(rel))
-	launch.args = rewriteHostedRuntimeBundleArgs(rootDir, launch.args)
-	launch.bundleDir = bundleDir
-	launch.cleanup = chainCleanup(cleanup, bundleCleanup)
 	return launch, nil
 }
 
-func rewriteHostedRuntimeBundleArgs(rootDir string, args []string) []string {
-	if len(args) == 0 {
-		return nil
+func hostedRuntimeUsesImageEntrypoint(runtimeConfig config.EffectiveHostedRuntime) bool {
+	hasRuntimeImageOrTemplate := strings.TrimSpace(runtimeConfig.Image) != "" || strings.TrimSpace(runtimeConfig.Template) != ""
+	if runtimeConfig.Provider != nil {
+		return runtimeConfig.Provider.Driver != config.RuntimeProviderDriverLocal && hasRuntimeImageOrTemplate
 	}
-	rewritten := slices.Clone(args)
-	for i, arg := range rewritten {
-		rewritten[i] = rewriteHostedRuntimeBundleArg(rootDir, arg)
-	}
-	return rewritten
+	return hasRuntimeImageOrTemplate
 }
 
-func rewriteHostedRuntimeBundleArg(rootDir, arg string) string {
-	arg = strings.TrimSpace(arg)
-	if arg == "" || !filepath.IsAbs(arg) {
-		return arg
+func hostedRuntimeImageEntrypoint(kind, name string, entry *config.ProviderEntry) (string, []string, error) {
+	label := strings.TrimSpace(kind)
+	if label == "" {
+		label = "provider"
 	}
-	rel, err := filepath.Rel(rootDir, arg)
-	if err != nil {
-		return arg
+	if trimmedName := strings.TrimSpace(name); trimmedName != "" {
+		label = fmt.Sprintf("%s %q", label, trimmedName)
 	}
-	switch {
-	case rel == ".":
-		return pluginruntime.HostedPluginBundleRoot
-	case rel == "..", strings.HasPrefix(rel, ".."+string(filepath.Separator)):
-		return arg
-	default:
-		return path.Join(pluginruntime.HostedPluginBundleRoot, filepath.ToSlash(rel))
+	if entry == nil || entry.ResolvedManifest == nil {
+		return "", nil, fmt.Errorf("%s manifest is required for hosted runtime image launch", label)
 	}
-}
-
-func stageHostedRuntimeBundle(kind, name, manifestPath, bundleDir, goos, goarch string) (string, error) {
-	rootDir := filepath.Dir(manifestPath)
-	hasSourceReleaseTarget, err := providerpkg.HasSourceReleaseTarget(rootDir, kind)
-	if err != nil {
-		return "", fmt.Errorf("prepare hosted runtime bundle: detect source release target: %w", err)
+	entrypoint := providerpkg.EntrypointForKind(entry.ResolvedManifest, kind)
+	if entrypoint == nil {
+		return "", nil, fmt.Errorf("%s manifest does not define an entrypoint for hosted runtime image launch", label)
 	}
-	if hasSourceReleaseTarget {
-		staged, err := providerpkg.StageSourcePreparedInstallDir(manifestPath, bundleDir, providerpkg.StageSourcePreparedInstallOptions{
-			Kind:       kind,
-			PluginName: name,
-			GOOS:       goos,
-			GOARCH:     goarch,
-		})
-		if err != nil {
-			return "", fmt.Errorf("prepare hosted runtime bundle: stage source install for %s/%s: %w", goos, goarch, err)
-		}
-		entry := providerpkg.EntrypointForKind(staged.Manifest, kind)
-		if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
-			return "", fmt.Errorf("prepare hosted runtime bundle: staged source install has no executable entrypoint")
-		}
-		return filepath.Join(bundleDir, filepath.FromSlash(entry.ArtifactPath)), nil
+	command := path.Clean(strings.TrimSpace(entrypoint.ArtifactPath))
+	if command == "." || command == "" {
+		return "", nil, fmt.Errorf("%s manifest entrypoint artifactPath is required for hosted runtime image launch", label)
 	}
-
-	if err := providerpkg.CopyPackageDir(rootDir, bundleDir); err != nil {
-		return "", fmt.Errorf("prepare hosted runtime bundle: copy package dir: %w", err)
+	if path.IsAbs(command) || command == ".." || strings.HasPrefix(command, "../") {
+		return "", nil, fmt.Errorf("%s manifest entrypoint artifactPath must be relative for hosted runtime image launch", label)
 	}
-	_, manifest, _, err := providerpkg.LoadManifestFromPath(bundleDir)
-	if err != nil {
-		return "", fmt.Errorf("prepare hosted runtime bundle: load staged manifest: %w", err)
-	}
-	artifact, err := artifactForPlatform(manifest, goos, goarch)
-	if err != nil {
-		return "", fmt.Errorf("prepare hosted runtime bundle: %w", err)
-	}
-	return filepath.Join(bundleDir, filepath.FromSlash(artifact.Path)), nil
-}
-
-func artifactForPlatform(manifest *providermanifestv1.Manifest, goos, goarch string) (*providermanifestv1.Artifact, error) {
-	if manifest == nil {
-		return nil, fmt.Errorf("manifest is required")
-	}
-	for i := range manifest.Artifacts {
-		artifact := &manifest.Artifacts[i]
-		if artifact.OS == goos && artifact.Arch == goarch {
-			return artifact, nil
-		}
-	}
-	return nil, fmt.Errorf("no artifact for platform %s/%s", goos, goarch)
+	return "./" + command, slices.Clone(entrypoint.Args), nil
 }

--- a/gestaltd/internal/bootstrap/plugin_runtime_plan.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_plan.go
@@ -2,7 +2,6 @@ package bootstrap
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
@@ -32,28 +31,10 @@ const (
 	RuntimeHostnameEgressDeliveryPublicProxy RuntimeHostnameEgressDelivery = "public_proxy"
 )
 
-type RuntimeLaunchMode string
-
-const (
-	RuntimeLaunchModeHostPath RuntimeLaunchMode = "host_path"
-	RuntimeLaunchModeBundle   RuntimeLaunchMode = "bundle"
-)
-
-type RuntimeExecutionTarget struct {
-	GOOS   string
-	GOARCH string
-}
-
-func (t RuntimeExecutionTarget) IsSet() bool {
-	return strings.TrimSpace(t.GOOS) != "" && strings.TrimSpace(t.GOARCH) != ""
-}
-
 type RuntimeBehavior struct {
 	CanHostPlugins    bool
 	HostServiceAccess RuntimeHostServiceAccess
 	EgressMode        RuntimeEgressMode
-	LaunchMode        RuntimeLaunchMode
-	ExecutionTarget   RuntimeExecutionTarget
 }
 
 type HostedRuntimePlan struct {
@@ -86,11 +67,6 @@ func runtimeAdvertisedBehavior(support pluginruntime.Support) RuntimeBehavior {
 		CanHostPlugins:    support.CanHostPlugins,
 		HostServiceAccess: runtimeHostServiceAccessFromSupport(support.HostServiceAccess),
 		EgressMode:        runtimeEgressModeFromSupport(support.EgressMode),
-		LaunchMode:        runtimeLaunchModeFromSupport(support.LaunchMode),
-		ExecutionTarget: RuntimeExecutionTarget{
-			GOOS:   strings.TrimSpace(support.ExecutionTarget.GOOS),
-			GOARCH: strings.TrimSpace(support.ExecutionTarget.GOARCH),
-		},
 	}
 }
 
@@ -183,9 +159,6 @@ func (p HostedRuntimePlan) Validate(label string) error {
 	if p.RequiresHostnameEgress && p.Resolved.EgressMode != RuntimeEgressModeHostname {
 		return fmt.Errorf("%s cannot preserve hostname-based egress required by this provider", label)
 	}
-	if p.Resolved.LaunchMode == RuntimeLaunchModeBundle && !p.Resolved.ExecutionTarget.IsSet() {
-		return fmt.Errorf("%s cannot stage hosted bundles because it does not declare an execution target", label)
-	}
 	return nil
 }
 
@@ -206,14 +179,5 @@ func runtimeEgressModeFromSupport(src pluginruntime.EgressMode) RuntimeEgressMod
 		return RuntimeEgressModeCIDR
 	default:
 		return RuntimeEgressModeNone
-	}
-}
-
-func runtimeLaunchModeFromSupport(src pluginruntime.LaunchMode) RuntimeLaunchMode {
-	switch src {
-	case pluginruntime.LaunchModeHostPath:
-		return RuntimeLaunchModeHostPath
-	default:
-		return RuntimeLaunchModeBundle
 	}
 }

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -812,7 +812,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		}
 		return nil, err
 	}
-	if command == "" && runtimePlan.Resolved.LaunchMode == RuntimeLaunchModeHostPath {
+	if command == "" && !hostedRuntimeUsesImageEntrypoint(runtimeConfig) {
 		if entry.ResolvedManifestPath == "" {
 			if runtimeOwned {
 				_ = runtimeProvider.Close()
@@ -847,10 +847,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 			maps.Copy(env, execEnv)
 		}
 	}
-	if command == "" && runtimePlan.Resolved.LaunchMode != RuntimeLaunchModeHostPath {
-		args = nil
-	}
-	launch, err := prepareHostedRuntimeLaunch(providermanifestv1.KindPlugin, name, entry, command, args, cleanup, runtimePlan.Resolved)
+	launch, err := prepareHostedProcessLaunch(providermanifestv1.KindPlugin, name, entry, command, args, cleanup, runtimeConfig)
 	if err != nil {
 		if runtimeOwned {
 			_ = runtimeProvider.Close()
@@ -939,7 +936,6 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		Command:    command,
 		Args:       args,
 		Env:        startEnv,
-		BundleDir:  launch.bundleDir,
 		Egress: pluginruntime.RuntimeEgressPolicy{
 			AllowedHosts:  egressPlan.RuntimeAllowedHosts,
 			DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
@@ -1011,7 +1007,7 @@ type hostedAgentProviderLaunch struct {
 	runtimePlan     HostedRuntimePlan
 	cfg             componentprovider.YAMLConfig
 	allowedHosts    []string
-	launch          pluginRuntimeLaunch
+	launch          hostedProcessLaunch
 	cleanup         func()
 }
 
@@ -1072,27 +1068,30 @@ func prepareHostedAgentProviderLaunch(ctx context.Context, name string, entry *c
 		}
 		return nil, err
 	}
-	prepared, err := componentprovider.PrepareExecution(componentprovider.PrepareParams{
-		Kind:                 providermanifestv1.KindAgent,
-		Subject:              "agent provider",
-		SourceMissingMessage: "no Go, Rust, Python, or TypeScript agent provider source package found",
-		Config:               cfg,
-	})
-	if err != nil {
-		if runtimeOwned {
-			_ = runtimeProvider.Close()
+	cleanup := func() {}
+	if !hostedRuntimeUsesImageEntrypoint(runtimeConfig) {
+		prepared, err := componentprovider.PrepareExecution(componentprovider.PrepareParams{
+			Kind:                 providermanifestv1.KindAgent,
+			Subject:              "agent provider",
+			SourceMissingMessage: "no Go, Rust, Python, or TypeScript agent provider source package found",
+			Config:               cfg,
+		})
+		if err != nil {
+			if runtimeOwned {
+				_ = runtimeProvider.Close()
+			}
+			return nil, err
 		}
-		return nil, err
+		cfg = prepared.YAMLConfig
+		cleanup = prepared.Cleanup
 	}
-	cfg = prepared.YAMLConfig
-	cleanup := prepared.Cleanup
 	defer func() {
 		if cleanup != nil {
 			cleanup()
 		}
 	}()
 
-	launch, err := prepareHostedRuntimeLaunch(providermanifestv1.KindAgent, name, entry, cfg.Command, cfg.Args, cleanup, runtimePlan.Resolved)
+	launch, err := prepareHostedProcessLaunch(providermanifestv1.KindAgent, name, entry, cfg.Command, cfg.Args, cleanup, runtimeConfig)
 	if err != nil {
 		if runtimeOwned {
 			_ = runtimeProvider.Close()
@@ -1227,7 +1226,6 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 		Command:    launch.launch.command,
 		Args:       launch.launch.args,
 		Env:        startEnv,
-		BundleDir:  launch.launch.bundleDir,
 		Egress: pluginruntime.RuntimeEgressPolicy{
 			AllowedHosts:  egressPlan.RuntimeAllowedHosts,
 			DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
@@ -1295,10 +1293,10 @@ func effectiveConfiguredHostedRuntime(ctx context.Context, configPath string, en
 			return runtimeConfig, runtimeProvider, false, nil
 		}
 		if runtimeConfig.Enabled {
-			return runtimeConfig, newLocalPluginRuntime(runtimeConfig.ProviderName, deps), true, nil
+			return localHostedRuntimeConfig(runtimeConfig), newLocalPluginRuntime(runtimeConfig.ProviderName, deps), true, nil
 		}
 	}
-	return explicitRuntimeConfig, newLocalPluginRuntime(explicitRuntimeConfig.ProviderName, deps), true, nil
+	return localHostedRuntimeConfig(explicitRuntimeConfig), newLocalPluginRuntime(explicitRuntimeConfig.ProviderName, deps), true, nil
 }
 
 func effectivePluginRuntime(ctx context.Context, name string, entry *config.ProviderEntry, deps Deps) (config.EffectiveHostedRuntime, pluginruntime.Provider, bool, error) {
@@ -1314,10 +1312,10 @@ func effectivePluginRuntime(ctx context.Context, name string, entry *config.Prov
 			return runtimeConfig, runtimeProvider, false, nil
 		}
 		if runtimeConfig.Enabled {
-			return runtimeConfig, newLocalPluginRuntime(runtimeConfig.ProviderName, deps), true, nil
+			return localHostedRuntimeConfig(runtimeConfig), newLocalPluginRuntime(runtimeConfig.ProviderName, deps), true, nil
 		}
 	}
-	return config.EffectiveHostedRuntime{}, newLocalPluginRuntime("", deps), true, nil
+	return localHostedRuntimeConfig(config.EffectiveHostedRuntime{}), newLocalPluginRuntime("", deps), true, nil
 }
 
 func providerEntryHostedRuntimeConfig(entry *config.ProviderEntry) config.EffectiveHostedRuntime {
@@ -1328,13 +1326,21 @@ func providerEntryHostedRuntimeConfig(entry *config.ProviderEntry) config.Effect
 	if runtimeCfg == nil {
 		return config.EffectiveHostedRuntime{Enabled: entry.UsesHostedExecution()}
 	}
-	return config.EffectiveHostedRuntime{
+	effective := config.EffectiveHostedRuntime{
 		Enabled:      entry.UsesHostedExecution(),
 		ProviderName: strings.TrimSpace(runtimeCfg.Provider),
 		Template:     strings.TrimSpace(runtimeCfg.Template),
 		Image:        strings.TrimSpace(runtimeCfg.Image),
 		Metadata:     maps.Clone(runtimeCfg.Metadata),
 	}
+	return effective
+}
+
+func localHostedRuntimeConfig(runtimeConfig config.EffectiveHostedRuntime) config.EffectiveHostedRuntime {
+	if runtimeConfig.Provider == nil {
+		runtimeConfig.Provider = &config.RuntimeProviderEntry{Driver: config.RuntimeProviderDriverLocal}
+	}
+	return runtimeConfig
 }
 
 func newLocalPluginRuntime(runtimeProviderName string, deps Deps) pluginruntime.Provider {

--- a/gestaltd/internal/pluginruntime/executable.go
+++ b/gestaltd/internal/pluginruntime/executable.go
@@ -241,7 +241,6 @@ func (p *executableProvider) StartPlugin(ctx context.Context, req StartPluginReq
 		Command:       req.Command,
 		Args:          append([]string(nil), req.Args...),
 		Env:           cloneStringMap(req.Env),
-		BundleDir:     req.BundleDir,
 		AllowedHosts:  append([]string(nil), req.Egress.AllowedHosts...),
 		DefaultAction: string(req.Egress.DefaultAction),
 		HostBinary:    req.HostBinary,
@@ -309,8 +308,6 @@ func supportFromProto(src *proto.PluginRuntimeSupport) Support {
 		CanHostPlugins:    src.GetCanHostPlugins(),
 		HostServiceAccess: hostServiceAccessFromProto(src.GetHostServiceAccess()),
 		EgressMode:        egressModeFromProto(src.GetEgressMode()),
-		LaunchMode:        launchModeFromProto(src.GetLaunchMode()),
-		ExecutionTarget:   executionTargetFromProto(src.GetExecutionTarget()),
 	}
 }
 
@@ -331,25 +328,6 @@ func egressModeFromProto(src proto.PluginRuntimeEgressMode) EgressMode {
 		return EgressModeCIDR
 	default:
 		return EgressModeNone
-	}
-}
-
-func launchModeFromProto(src proto.PluginRuntimeLaunchMode) LaunchMode {
-	switch src {
-	case proto.PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH:
-		return LaunchModeHostPath
-	default:
-		return LaunchModeBundle
-	}
-}
-
-func executionTargetFromProto(src *proto.PluginRuntimeExecutionTarget) ExecutionTarget {
-	if src == nil {
-		return ExecutionTarget{}
-	}
-	return ExecutionTarget{
-		GOOS:   strings.TrimSpace(src.GetGoos()),
-		GOARCH: strings.TrimSpace(src.GetGoarch()),
 	}
 }
 

--- a/gestaltd/internal/pluginruntime/executable_test.go
+++ b/gestaltd/internal/pluginruntime/executable_test.go
@@ -172,7 +172,6 @@ func (p *runtimeProvider) Configure(context.Context, string, map[string]any) err
 func (p *runtimeProvider) GetSupport(context.Context, *emptypb.Empty) (*proto.PluginRuntimeSupport, error) {
 	return &proto.PluginRuntimeSupport{
 		CanHostPlugins: true,
-		LaunchMode:     proto.PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH,
 	}, nil
 }
 

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -86,11 +85,6 @@ func (p *LocalProvider) Support(context.Context) (Support, error) {
 		CanHostPlugins:    true,
 		HostServiceAccess: HostServiceAccessDirect,
 		EgressMode:        EgressModeHostname,
-		LaunchMode:        LaunchModeHostPath,
-		ExecutionTarget: ExecutionTarget{
-			GOOS:   runtime.GOOS,
-			GOARCH: runtime.GOARCH,
-		},
 	}, nil
 }
 

--- a/gestaltd/internal/pluginruntime/runtime.go
+++ b/gestaltd/internal/pluginruntime/runtime.go
@@ -4,19 +4,17 @@ import (
 	"context"
 	"time"
 
-	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 )
 
 type SessionState string
 
 const (
-	HostedPluginBundleRoot              = gestalt.HostedPluginBundleRoot
-	SessionStatePending    SessionState = "pending"
-	SessionStateReady      SessionState = "ready"
-	SessionStateRunning    SessionState = "running"
-	SessionStateStopped    SessionState = "stopped"
-	SessionStateFailed     SessionState = "failed"
+	SessionStatePending SessionState = "pending"
+	SessionStateReady   SessionState = "ready"
+	SessionStateRunning SessionState = "running"
+	SessionStateStopped SessionState = "stopped"
+	SessionStateFailed  SessionState = "failed"
 )
 
 // PolicyAction mirrors the host egress default for runtime-launched plugins.
@@ -44,24 +42,10 @@ const (
 	EgressModeHostname EgressMode = "hostname"
 )
 
-type LaunchMode string
-
-const (
-	LaunchModeHostPath LaunchMode = "host_path"
-	LaunchModeBundle   LaunchMode = "bundle"
-)
-
-type ExecutionTarget struct {
-	GOOS   string
-	GOARCH string
-}
-
 type Support struct {
 	CanHostPlugins    bool
 	HostServiceAccess HostServiceAccess
 	EgressMode        EgressMode
-	LaunchMode        LaunchMode
-	ExecutionTarget   ExecutionTarget
 }
 
 type Session struct {
@@ -121,7 +105,6 @@ type StartPluginRequest struct {
 	Command    string
 	Args       []string
 	Env        map[string]string
-	BundleDir  string
 	Egress     RuntimeEgressPolicy
 	HostBinary string
 }

--- a/gestaltd/internal/server/handlers_admin_runtime.go
+++ b/gestaltd/internal/server/handlers_admin_runtime.go
@@ -29,16 +29,9 @@ type adminRuntimeProfilePair struct {
 }
 
 type adminRuntimeProfile struct {
-	CanHostPlugins    bool                         `json:"canHostPlugins"`
-	HostServiceAccess string                       `json:"hostServiceAccess"`
-	EgressMode        string                       `json:"egressMode"`
-	LaunchMode        string                       `json:"launchMode"`
-	ExecutionTarget   *adminRuntimeExecutionTarget `json:"executionTarget,omitempty"`
-}
-
-type adminRuntimeExecutionTarget struct {
-	GOOS   string `json:"goos"`
-	GOARCH string `json:"goarch"`
+	CanHostPlugins    bool   `json:"canHostPlugins"`
+	HostServiceAccess string `json:"hostServiceAccess"`
+	EgressMode        string `json:"egressMode"`
 }
 
 type adminRuntimeSessionInfo struct {
@@ -191,19 +184,11 @@ func adminRuntimeProfilePairFromSnapshot(snapshot *bootstrap.RuntimeProviderSnap
 }
 
 func adminRuntimeProfileFromBootstrap(behavior bootstrap.RuntimeBehavior) adminRuntimeProfile {
-	out := adminRuntimeProfile{
+	return adminRuntimeProfile{
 		CanHostPlugins:    behavior.CanHostPlugins,
 		HostServiceAccess: strings.TrimSpace(string(behavior.HostServiceAccess)),
 		EgressMode:        strings.TrimSpace(string(behavior.EgressMode)),
-		LaunchMode:        strings.TrimSpace(string(behavior.LaunchMode)),
 	}
-	if behavior.ExecutionTarget.IsSet() {
-		out.ExecutionTarget = &adminRuntimeExecutionTarget{
-			GOOS:   strings.TrimSpace(behavior.ExecutionTarget.GOOS),
-			GOARCH: strings.TrimSpace(behavior.ExecutionTarget.GOARCH),
-		}
-	}
-	return out
 }
 
 const (

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -3169,21 +3169,11 @@ func TestAdminAPI_RuntimeProviders(t *testing.T) {
 						CanHostPlugins:    true,
 						HostServiceAccess: bootstrap.RuntimeHostServiceAccessNone,
 						EgressMode:        bootstrap.RuntimeEgressModeCIDR,
-						LaunchMode:        bootstrap.RuntimeLaunchModeBundle,
-						ExecutionTarget: bootstrap.RuntimeExecutionTarget{
-							GOOS:   "linux",
-							GOARCH: "amd64",
-						},
 					},
 					Effective: bootstrap.RuntimeBehavior{
 						CanHostPlugins:    true,
 						HostServiceAccess: bootstrap.RuntimeHostServiceAccessRelay,
 						EgressMode:        bootstrap.RuntimeEgressModeCIDR,
-						LaunchMode:        bootstrap.RuntimeLaunchModeBundle,
-						ExecutionTarget: bootstrap.RuntimeExecutionTarget{
-							GOOS:   "linux",
-							GOARCH: "amd64",
-						},
 					},
 					Sessions: []pluginruntime.Session{{
 						ID:    "session-1",
@@ -3249,15 +3239,11 @@ func TestAdminAPI_RuntimeProviders(t *testing.T) {
 	if !ok {
 		t.Fatalf("runtime providers[1].profile.effective = %#v, want object", profile["effective"])
 	}
-	if advertised["canHostPlugins"] != true || advertised["hostServiceAccess"] != "none" || advertised["egressMode"] != "cidr" || advertised["launchMode"] != "bundle" {
+	if advertised["canHostPlugins"] != true || advertised["hostServiceAccess"] != "none" || advertised["egressMode"] != "cidr" {
 		t.Fatalf("runtime providers[1].profile.advertised = %#v", advertised)
 	}
-	if effective["canHostPlugins"] != true || effective["hostServiceAccess"] != "relay" || effective["egressMode"] != "cidr" || effective["launchMode"] != "bundle" {
+	if effective["canHostPlugins"] != true || effective["hostServiceAccess"] != "relay" || effective["egressMode"] != "cidr" {
 		t.Fatalf("runtime providers[1].profile.effective = %#v", effective)
-	}
-	executionTarget, ok := effective["executionTarget"].(map[string]any)
-	if !ok || executionTarget["goos"] != "linux" || executionTarget["goarch"] != "amd64" {
-		t.Fatalf("runtime providers[1].profile.effective.executionTarget = %#v", effective["executionTarget"])
 	}
 }
 
@@ -3384,13 +3370,11 @@ func TestAdminAPI_RuntimeProviderSessionInspectionErrorKeepsProfile(t *testing.T
 					CanHostPlugins:    true,
 					HostServiceAccess: bootstrap.RuntimeHostServiceAccessNone,
 					EgressMode:        bootstrap.RuntimeEgressModeCIDR,
-					LaunchMode:        bootstrap.RuntimeLaunchModeBundle,
 				},
 				Effective: bootstrap.RuntimeBehavior{
 					CanHostPlugins:    true,
 					HostServiceAccess: bootstrap.RuntimeHostServiceAccessRelay,
 					EgressMode:        bootstrap.RuntimeEgressModeCIDR,
-					LaunchMode:        bootstrap.RuntimeLaunchModeBundle,
 				},
 				Error: "list sessions: boom",
 			}},

--- a/sdk/go/gen/v1/pluginruntime.pb.go
+++ b/sdk/go/gen/v1/pluginruntime.pb.go
@@ -124,55 +124,6 @@ func (PluginRuntimeEgressMode) EnumDescriptor() ([]byte, []int) {
 	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{1}
 }
 
-type PluginRuntimeLaunchMode int32
-
-const (
-	PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED PluginRuntimeLaunchMode = 0
-	PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE      PluginRuntimeLaunchMode = 1
-	PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH   PluginRuntimeLaunchMode = 2
-)
-
-// Enum value maps for PluginRuntimeLaunchMode.
-var (
-	PluginRuntimeLaunchMode_name = map[int32]string{
-		0: "PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED",
-		1: "PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE",
-		2: "PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH",
-	}
-	PluginRuntimeLaunchMode_value = map[string]int32{
-		"PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED": 0,
-		"PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE":      1,
-		"PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH":   2,
-	}
-)
-
-func (x PluginRuntimeLaunchMode) Enum() *PluginRuntimeLaunchMode {
-	p := new(PluginRuntimeLaunchMode)
-	*p = x
-	return p
-}
-
-func (x PluginRuntimeLaunchMode) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (PluginRuntimeLaunchMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_v1_pluginruntime_proto_enumTypes[2].Descriptor()
-}
-
-func (PluginRuntimeLaunchMode) Type() protoreflect.EnumType {
-	return &file_v1_pluginruntime_proto_enumTypes[2]
-}
-
-func (x PluginRuntimeLaunchMode) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use PluginRuntimeLaunchMode.Descriptor instead.
-func (PluginRuntimeLaunchMode) EnumDescriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{2}
-}
-
 type PluginRuntimeLogStream int32
 
 const (
@@ -209,11 +160,11 @@ func (x PluginRuntimeLogStream) String() string {
 }
 
 func (PluginRuntimeLogStream) Descriptor() protoreflect.EnumDescriptor {
-	return file_v1_pluginruntime_proto_enumTypes[3].Descriptor()
+	return file_v1_pluginruntime_proto_enumTypes[2].Descriptor()
 }
 
 func (PluginRuntimeLogStream) Type() protoreflect.EnumType {
-	return &file_v1_pluginruntime_proto_enumTypes[3]
+	return &file_v1_pluginruntime_proto_enumTypes[2]
 }
 
 func (x PluginRuntimeLogStream) Number() protoreflect.EnumNumber {
@@ -222,59 +173,7 @@ func (x PluginRuntimeLogStream) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PluginRuntimeLogStream.Descriptor instead.
 func (PluginRuntimeLogStream) EnumDescriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{3}
-}
-
-type PluginRuntimeExecutionTarget struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Goos          string                 `protobuf:"bytes,1,opt,name=goos,proto3" json:"goos,omitempty"`
-	Goarch        string                 `protobuf:"bytes,2,opt,name=goarch,proto3" json:"goarch,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PluginRuntimeExecutionTarget) Reset() {
-	*x = PluginRuntimeExecutionTarget{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[0]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PluginRuntimeExecutionTarget) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PluginRuntimeExecutionTarget) ProtoMessage() {}
-
-func (x *PluginRuntimeExecutionTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[0]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PluginRuntimeExecutionTarget.ProtoReflect.Descriptor instead.
-func (*PluginRuntimeExecutionTarget) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{0}
-}
-
-func (x *PluginRuntimeExecutionTarget) GetGoos() string {
-	if x != nil {
-		return x.Goos
-	}
-	return ""
-}
-
-func (x *PluginRuntimeExecutionTarget) GetGoarch() string {
-	if x != nil {
-		return x.Goarch
-	}
-	return ""
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{2}
 }
 
 type PluginRuntimeSupport struct {
@@ -282,15 +181,13 @@ type PluginRuntimeSupport struct {
 	CanHostPlugins    bool                           `protobuf:"varint,1,opt,name=can_host_plugins,json=canHostPlugins,proto3" json:"can_host_plugins,omitempty"`
 	HostServiceAccess PluginRuntimeHostServiceAccess `protobuf:"varint,2,opt,name=host_service_access,json=hostServiceAccess,proto3,enum=gestalt.provider.v1.PluginRuntimeHostServiceAccess" json:"host_service_access,omitempty"`
 	EgressMode        PluginRuntimeEgressMode        `protobuf:"varint,3,opt,name=egress_mode,json=egressMode,proto3,enum=gestalt.provider.v1.PluginRuntimeEgressMode" json:"egress_mode,omitempty"`
-	LaunchMode        PluginRuntimeLaunchMode        `protobuf:"varint,4,opt,name=launch_mode,json=launchMode,proto3,enum=gestalt.provider.v1.PluginRuntimeLaunchMode" json:"launch_mode,omitempty"`
-	ExecutionTarget   *PluginRuntimeExecutionTarget  `protobuf:"bytes,5,opt,name=execution_target,json=executionTarget,proto3" json:"execution_target,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
 
 func (x *PluginRuntimeSupport) Reset() {
 	*x = PluginRuntimeSupport{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[1]
+	mi := &file_v1_pluginruntime_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -302,7 +199,7 @@ func (x *PluginRuntimeSupport) String() string {
 func (*PluginRuntimeSupport) ProtoMessage() {}
 
 func (x *PluginRuntimeSupport) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[1]
+	mi := &file_v1_pluginruntime_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -315,7 +212,7 @@ func (x *PluginRuntimeSupport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeSupport.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeSupport) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{1}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *PluginRuntimeSupport) GetCanHostPlugins() bool {
@@ -339,20 +236,6 @@ func (x *PluginRuntimeSupport) GetEgressMode() PluginRuntimeEgressMode {
 	return PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_UNSPECIFIED
 }
 
-func (x *PluginRuntimeSupport) GetLaunchMode() PluginRuntimeLaunchMode {
-	if x != nil {
-		return x.LaunchMode
-	}
-	return PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED
-}
-
-func (x *PluginRuntimeSupport) GetExecutionTarget() *PluginRuntimeExecutionTarget {
-	if x != nil {
-		return x.ExecutionTarget
-	}
-	return nil
-}
-
 type PluginRuntimeSession struct {
 	state         protoimpl.MessageState         `protogen:"open.v1"`
 	Id            string                         `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -367,7 +250,7 @@ type PluginRuntimeSession struct {
 
 func (x *PluginRuntimeSession) Reset() {
 	*x = PluginRuntimeSession{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[2]
+	mi := &file_v1_pluginruntime_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -379,7 +262,7 @@ func (x *PluginRuntimeSession) String() string {
 func (*PluginRuntimeSession) ProtoMessage() {}
 
 func (x *PluginRuntimeSession) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[2]
+	mi := &file_v1_pluginruntime_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -392,7 +275,7 @@ func (x *PluginRuntimeSession) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeSession.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeSession) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{2}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *PluginRuntimeSession) GetId() string {
@@ -448,7 +331,7 @@ type PluginRuntimeSessionLifecycle struct {
 
 func (x *PluginRuntimeSessionLifecycle) Reset() {
 	*x = PluginRuntimeSessionLifecycle{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[3]
+	mi := &file_v1_pluginruntime_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -460,7 +343,7 @@ func (x *PluginRuntimeSessionLifecycle) String() string {
 func (*PluginRuntimeSessionLifecycle) ProtoMessage() {}
 
 func (x *PluginRuntimeSessionLifecycle) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[3]
+	mi := &file_v1_pluginruntime_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -473,7 +356,7 @@ func (x *PluginRuntimeSessionLifecycle) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeSessionLifecycle.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeSessionLifecycle) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{3}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *PluginRuntimeSessionLifecycle) GetStartedAt() *timestamppb.Timestamp {
@@ -509,7 +392,7 @@ type StartPluginRuntimeSessionRequest struct {
 
 func (x *StartPluginRuntimeSessionRequest) Reset() {
 	*x = StartPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[4]
+	mi := &file_v1_pluginruntime_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -521,7 +404,7 @@ func (x *StartPluginRuntimeSessionRequest) String() string {
 func (*StartPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *StartPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[4]
+	mi := &file_v1_pluginruntime_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -534,7 +417,7 @@ func (x *StartPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*StartPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{4}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *StartPluginRuntimeSessionRequest) GetPluginName() string {
@@ -574,7 +457,7 @@ type GetPluginRuntimeSessionRequest struct {
 
 func (x *GetPluginRuntimeSessionRequest) Reset() {
 	*x = GetPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[5]
+	mi := &file_v1_pluginruntime_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -586,7 +469,7 @@ func (x *GetPluginRuntimeSessionRequest) String() string {
 func (*GetPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *GetPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[5]
+	mi := &file_v1_pluginruntime_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -599,7 +482,7 @@ func (x *GetPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{5}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *GetPluginRuntimeSessionRequest) GetSessionId() string {
@@ -617,7 +500,7 @@ type ListPluginRuntimeSessionsRequest struct {
 
 func (x *ListPluginRuntimeSessionsRequest) Reset() {
 	*x = ListPluginRuntimeSessionsRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[6]
+	mi := &file_v1_pluginruntime_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -629,7 +512,7 @@ func (x *ListPluginRuntimeSessionsRequest) String() string {
 func (*ListPluginRuntimeSessionsRequest) ProtoMessage() {}
 
 func (x *ListPluginRuntimeSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[6]
+	mi := &file_v1_pluginruntime_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -642,7 +525,7 @@ func (x *ListPluginRuntimeSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPluginRuntimeSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListPluginRuntimeSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{6}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{5}
 }
 
 type ListPluginRuntimeSessionsResponse struct {
@@ -654,7 +537,7 @@ type ListPluginRuntimeSessionsResponse struct {
 
 func (x *ListPluginRuntimeSessionsResponse) Reset() {
 	*x = ListPluginRuntimeSessionsResponse{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[7]
+	mi := &file_v1_pluginruntime_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -666,7 +549,7 @@ func (x *ListPluginRuntimeSessionsResponse) String() string {
 func (*ListPluginRuntimeSessionsResponse) ProtoMessage() {}
 
 func (x *ListPluginRuntimeSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[7]
+	mi := &file_v1_pluginruntime_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -679,7 +562,7 @@ func (x *ListPluginRuntimeSessionsResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ListPluginRuntimeSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListPluginRuntimeSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{7}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListPluginRuntimeSessionsResponse) GetSessions() []*PluginRuntimeSession {
@@ -698,7 +581,7 @@ type StopPluginRuntimeSessionRequest struct {
 
 func (x *StopPluginRuntimeSessionRequest) Reset() {
 	*x = StopPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[8]
+	mi := &file_v1_pluginruntime_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -710,7 +593,7 @@ func (x *StopPluginRuntimeSessionRequest) String() string {
 func (*StopPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *StopPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[8]
+	mi := &file_v1_pluginruntime_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -723,7 +606,7 @@ func (x *StopPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*StopPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{8}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *StopPluginRuntimeSessionRequest) GetSessionId() string {
@@ -742,7 +625,7 @@ type PluginRuntimeHostServiceRelay struct {
 
 func (x *PluginRuntimeHostServiceRelay) Reset() {
 	*x = PluginRuntimeHostServiceRelay{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[9]
+	mi := &file_v1_pluginruntime_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -754,7 +637,7 @@ func (x *PluginRuntimeHostServiceRelay) String() string {
 func (*PluginRuntimeHostServiceRelay) ProtoMessage() {}
 
 func (x *PluginRuntimeHostServiceRelay) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[9]
+	mi := &file_v1_pluginruntime_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -767,7 +650,7 @@ func (x *PluginRuntimeHostServiceRelay) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeHostServiceRelay.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeHostServiceRelay) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{9}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *PluginRuntimeHostServiceRelay) GetDialTarget() string {
@@ -788,7 +671,7 @@ type BindPluginRuntimeHostServiceRequest struct {
 
 func (x *BindPluginRuntimeHostServiceRequest) Reset() {
 	*x = BindPluginRuntimeHostServiceRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[10]
+	mi := &file_v1_pluginruntime_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -800,7 +683,7 @@ func (x *BindPluginRuntimeHostServiceRequest) String() string {
 func (*BindPluginRuntimeHostServiceRequest) ProtoMessage() {}
 
 func (x *BindPluginRuntimeHostServiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[10]
+	mi := &file_v1_pluginruntime_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -813,7 +696,7 @@ func (x *BindPluginRuntimeHostServiceRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use BindPluginRuntimeHostServiceRequest.ProtoReflect.Descriptor instead.
 func (*BindPluginRuntimeHostServiceRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{10}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *BindPluginRuntimeHostServiceRequest) GetSessionId() string {
@@ -849,7 +732,7 @@ type PluginRuntimeHostServiceBinding struct {
 
 func (x *PluginRuntimeHostServiceBinding) Reset() {
 	*x = PluginRuntimeHostServiceBinding{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[11]
+	mi := &file_v1_pluginruntime_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -861,7 +744,7 @@ func (x *PluginRuntimeHostServiceBinding) String() string {
 func (*PluginRuntimeHostServiceBinding) ProtoMessage() {}
 
 func (x *PluginRuntimeHostServiceBinding) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[11]
+	mi := &file_v1_pluginruntime_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -874,7 +757,7 @@ func (x *PluginRuntimeHostServiceBinding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeHostServiceBinding.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeHostServiceBinding) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{11}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *PluginRuntimeHostServiceBinding) GetId() string {
@@ -916,7 +799,6 @@ type StartHostedPluginRequest struct {
 	Command       string                 `protobuf:"bytes,3,opt,name=command,proto3" json:"command,omitempty"`
 	Args          []string               `protobuf:"bytes,4,rep,name=args,proto3" json:"args,omitempty"`
 	Env           map[string]string      `protobuf:"bytes,5,rep,name=env,proto3" json:"env,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	BundleDir     string                 `protobuf:"bytes,6,opt,name=bundle_dir,json=bundleDir,proto3" json:"bundle_dir,omitempty"`
 	AllowedHosts  []string               `protobuf:"bytes,7,rep,name=allowed_hosts,json=allowedHosts,proto3" json:"allowed_hosts,omitempty"`
 	DefaultAction string                 `protobuf:"bytes,8,opt,name=default_action,json=defaultAction,proto3" json:"default_action,omitempty"`
 	HostBinary    string                 `protobuf:"bytes,9,opt,name=host_binary,json=hostBinary,proto3" json:"host_binary,omitempty"`
@@ -926,7 +808,7 @@ type StartHostedPluginRequest struct {
 
 func (x *StartHostedPluginRequest) Reset() {
 	*x = StartHostedPluginRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[12]
+	mi := &file_v1_pluginruntime_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -938,7 +820,7 @@ func (x *StartHostedPluginRequest) String() string {
 func (*StartHostedPluginRequest) ProtoMessage() {}
 
 func (x *StartHostedPluginRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[12]
+	mi := &file_v1_pluginruntime_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -951,7 +833,7 @@ func (x *StartHostedPluginRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartHostedPluginRequest.ProtoReflect.Descriptor instead.
 func (*StartHostedPluginRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{12}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *StartHostedPluginRequest) GetSessionId() string {
@@ -989,13 +871,6 @@ func (x *StartHostedPluginRequest) GetEnv() map[string]string {
 	return nil
 }
 
-func (x *StartHostedPluginRequest) GetBundleDir() string {
-	if x != nil {
-		return x.BundleDir
-	}
-	return ""
-}
-
 func (x *StartHostedPluginRequest) GetAllowedHosts() []string {
 	if x != nil {
 		return x.AllowedHosts
@@ -1029,7 +904,7 @@ type HostedPlugin struct {
 
 func (x *HostedPlugin) Reset() {
 	*x = HostedPlugin{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[13]
+	mi := &file_v1_pluginruntime_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1041,7 +916,7 @@ func (x *HostedPlugin) String() string {
 func (*HostedPlugin) ProtoMessage() {}
 
 func (x *HostedPlugin) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[13]
+	mi := &file_v1_pluginruntime_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1054,7 +929,7 @@ func (x *HostedPlugin) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostedPlugin.ProtoReflect.Descriptor instead.
 func (*HostedPlugin) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{13}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *HostedPlugin) GetId() string {
@@ -1097,7 +972,7 @@ type PluginRuntimeLogEntry struct {
 
 func (x *PluginRuntimeLogEntry) Reset() {
 	*x = PluginRuntimeLogEntry{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[14]
+	mi := &file_v1_pluginruntime_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1109,7 +984,7 @@ func (x *PluginRuntimeLogEntry) String() string {
 func (*PluginRuntimeLogEntry) ProtoMessage() {}
 
 func (x *PluginRuntimeLogEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[14]
+	mi := &file_v1_pluginruntime_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1122,7 +997,7 @@ func (x *PluginRuntimeLogEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeLogEntry.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeLogEntry) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{14}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *PluginRuntimeLogEntry) GetStream() PluginRuntimeLogStream {
@@ -1163,7 +1038,7 @@ type AppendPluginRuntimeLogsRequest struct {
 
 func (x *AppendPluginRuntimeLogsRequest) Reset() {
 	*x = AppendPluginRuntimeLogsRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[15]
+	mi := &file_v1_pluginruntime_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1175,7 +1050,7 @@ func (x *AppendPluginRuntimeLogsRequest) String() string {
 func (*AppendPluginRuntimeLogsRequest) ProtoMessage() {}
 
 func (x *AppendPluginRuntimeLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[15]
+	mi := &file_v1_pluginruntime_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1188,7 +1063,7 @@ func (x *AppendPluginRuntimeLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppendPluginRuntimeLogsRequest.ProtoReflect.Descriptor instead.
 func (*AppendPluginRuntimeLogsRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{15}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *AppendPluginRuntimeLogsRequest) GetSessionId() string {
@@ -1214,7 +1089,7 @@ type AppendPluginRuntimeLogsResponse struct {
 
 func (x *AppendPluginRuntimeLogsResponse) Reset() {
 	*x = AppendPluginRuntimeLogsResponse{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[16]
+	mi := &file_v1_pluginruntime_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1226,7 +1101,7 @@ func (x *AppendPluginRuntimeLogsResponse) String() string {
 func (*AppendPluginRuntimeLogsResponse) ProtoMessage() {}
 
 func (x *AppendPluginRuntimeLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[16]
+	mi := &file_v1_pluginruntime_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1239,7 +1114,7 @@ func (x *AppendPluginRuntimeLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppendPluginRuntimeLogsResponse.ProtoReflect.Descriptor instead.
 func (*AppendPluginRuntimeLogsResponse) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{16}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *AppendPluginRuntimeLogsResponse) GetLastSeq() int64 {
@@ -1253,18 +1128,12 @@ var File_v1_pluginruntime_proto protoreflect.FileDescriptor
 
 const file_v1_pluginruntime_proto_rawDesc = "" +
 	"\n" +
-	"\x16v1/pluginruntime.proto\x12\x13gestalt.provider.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"J\n" +
-	"\x1cPluginRuntimeExecutionTarget\x12\x12\n" +
-	"\x04goos\x18\x01 \x01(\tR\x04goos\x12\x16\n" +
-	"\x06goarch\x18\x02 \x01(\tR\x06goarch\"\xa1\x03\n" +
+	"\x16v1/pluginruntime.proto\x12\x13gestalt.provider.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x86\x02\n" +
 	"\x14PluginRuntimeSupport\x12(\n" +
 	"\x10can_host_plugins\x18\x01 \x01(\bR\x0ecanHostPlugins\x12c\n" +
 	"\x13host_service_access\x18\x02 \x01(\x0e23.gestalt.provider.v1.PluginRuntimeHostServiceAccessR\x11hostServiceAccess\x12M\n" +
 	"\vegress_mode\x18\x03 \x01(\x0e2,.gestalt.provider.v1.PluginRuntimeEgressModeR\n" +
-	"egressMode\x12M\n" +
-	"\vlaunch_mode\x18\x04 \x01(\x0e2,.gestalt.provider.v1.PluginRuntimeLaunchModeR\n" +
-	"launchMode\x12\\\n" +
-	"\x10execution_target\x18\x05 \x01(\v21.gestalt.provider.v1.PluginRuntimeExecutionTargetR\x0fexecutionTarget\"\xe8\x02\n" +
+	"egressModeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\x06\x10\a\"\xe8\x02\n" +
 	"\x14PluginRuntimeSession\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05state\x18\x02 \x01(\tR\x05state\x12S\n" +
@@ -1312,7 +1181,7 @@ const file_v1_pluginruntime_proto_rawDesc = "" +
 	"\n" +
 	"session_id\x18\x02 \x01(\tR\tsessionId\x12\x17\n" +
 	"\aenv_var\x18\x03 \x01(\tR\x06envVar\x12H\n" +
-	"\x05relay\x18\x05 \x01(\v22.gestalt.provider.v1.PluginRuntimeHostServiceRelayR\x05relayJ\x04\b\x04\x10\x05\"\x96\x03\n" +
+	"\x05relay\x18\x05 \x01(\v22.gestalt.provider.v1.PluginRuntimeHostServiceRelayR\x05relayJ\x04\b\x04\x10\x05\"\x83\x03\n" +
 	"\x18StartHostedPluginRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x1f\n" +
@@ -1320,16 +1189,15 @@ const file_v1_pluginruntime_proto_rawDesc = "" +
 	"pluginName\x12\x18\n" +
 	"\acommand\x18\x03 \x01(\tR\acommand\x12\x12\n" +
 	"\x04args\x18\x04 \x03(\tR\x04args\x12H\n" +
-	"\x03env\x18\x05 \x03(\v26.gestalt.provider.v1.StartHostedPluginRequest.EnvEntryR\x03env\x12\x1d\n" +
-	"\n" +
-	"bundle_dir\x18\x06 \x01(\tR\tbundleDir\x12#\n" +
+	"\x03env\x18\x05 \x03(\v26.gestalt.provider.v1.StartHostedPluginRequest.EnvEntryR\x03env\x12#\n" +
 	"\rallowed_hosts\x18\a \x03(\tR\fallowedHosts\x12%\n" +
 	"\x0edefault_action\x18\b \x01(\tR\rdefaultAction\x12\x1f\n" +
 	"\vhost_binary\x18\t \x01(\tR\n" +
 	"hostBinary\x1a6\n" +
 	"\bEnvEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x7f\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x06\x10\aJ\x04\b\n" +
+	"\x10\v\"\x7f\n" +
 	"\fHostedPlugin\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
@@ -1359,11 +1227,7 @@ const file_v1_pluginruntime_proto_rawDesc = "" +
 	"&PLUGIN_RUNTIME_EGRESS_MODE_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fPLUGIN_RUNTIME_EGRESS_MODE_NONE\x10\x01\x12#\n" +
 	"\x1fPLUGIN_RUNTIME_EGRESS_MODE_CIDR\x10\x02\x12'\n" +
-	"#PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME\x10\x03*\x96\x01\n" +
-	"\x17PluginRuntimeLaunchMode\x12*\n" +
-	"&PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED\x10\x00\x12%\n" +
-	"!PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE\x10\x01\x12(\n" +
-	"$PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH\x10\x02*\xb6\x01\n" +
+	"#PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME\x10\x03*\xb6\x01\n" +
 	"\x16PluginRuntimeLogStream\x12)\n" +
 	"%PLUGIN_RUNTIME_LOG_STREAM_UNSPECIFIED\x10\x00\x12$\n" +
 	" PLUGIN_RUNTIME_LOG_STREAM_STDOUT\x10\x01\x12$\n" +
@@ -1396,75 +1260,71 @@ func file_v1_pluginruntime_proto_rawDescGZIP() []byte {
 	return file_v1_pluginruntime_proto_rawDescData
 }
 
-var file_v1_pluginruntime_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_v1_pluginruntime_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_v1_pluginruntime_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_v1_pluginruntime_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_v1_pluginruntime_proto_goTypes = []any{
 	(PluginRuntimeHostServiceAccess)(0),         // 0: gestalt.provider.v1.PluginRuntimeHostServiceAccess
 	(PluginRuntimeEgressMode)(0),                // 1: gestalt.provider.v1.PluginRuntimeEgressMode
-	(PluginRuntimeLaunchMode)(0),                // 2: gestalt.provider.v1.PluginRuntimeLaunchMode
-	(PluginRuntimeLogStream)(0),                 // 3: gestalt.provider.v1.PluginRuntimeLogStream
-	(*PluginRuntimeExecutionTarget)(nil),        // 4: gestalt.provider.v1.PluginRuntimeExecutionTarget
-	(*PluginRuntimeSupport)(nil),                // 5: gestalt.provider.v1.PluginRuntimeSupport
-	(*PluginRuntimeSession)(nil),                // 6: gestalt.provider.v1.PluginRuntimeSession
-	(*PluginRuntimeSessionLifecycle)(nil),       // 7: gestalt.provider.v1.PluginRuntimeSessionLifecycle
-	(*StartPluginRuntimeSessionRequest)(nil),    // 8: gestalt.provider.v1.StartPluginRuntimeSessionRequest
-	(*GetPluginRuntimeSessionRequest)(nil),      // 9: gestalt.provider.v1.GetPluginRuntimeSessionRequest
-	(*ListPluginRuntimeSessionsRequest)(nil),    // 10: gestalt.provider.v1.ListPluginRuntimeSessionsRequest
-	(*ListPluginRuntimeSessionsResponse)(nil),   // 11: gestalt.provider.v1.ListPluginRuntimeSessionsResponse
-	(*StopPluginRuntimeSessionRequest)(nil),     // 12: gestalt.provider.v1.StopPluginRuntimeSessionRequest
-	(*PluginRuntimeHostServiceRelay)(nil),       // 13: gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	(*BindPluginRuntimeHostServiceRequest)(nil), // 14: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
-	(*PluginRuntimeHostServiceBinding)(nil),     // 15: gestalt.provider.v1.PluginRuntimeHostServiceBinding
-	(*StartHostedPluginRequest)(nil),            // 16: gestalt.provider.v1.StartHostedPluginRequest
-	(*HostedPlugin)(nil),                        // 17: gestalt.provider.v1.HostedPlugin
-	(*PluginRuntimeLogEntry)(nil),               // 18: gestalt.provider.v1.PluginRuntimeLogEntry
-	(*AppendPluginRuntimeLogsRequest)(nil),      // 19: gestalt.provider.v1.AppendPluginRuntimeLogsRequest
-	(*AppendPluginRuntimeLogsResponse)(nil),     // 20: gestalt.provider.v1.AppendPluginRuntimeLogsResponse
-	nil,                                         // 21: gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
-	nil,                                         // 22: gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
-	nil,                                         // 23: gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
-	(*timestamppb.Timestamp)(nil),               // 24: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                       // 25: google.protobuf.Empty
+	(PluginRuntimeLogStream)(0),                 // 2: gestalt.provider.v1.PluginRuntimeLogStream
+	(*PluginRuntimeSupport)(nil),                // 3: gestalt.provider.v1.PluginRuntimeSupport
+	(*PluginRuntimeSession)(nil),                // 4: gestalt.provider.v1.PluginRuntimeSession
+	(*PluginRuntimeSessionLifecycle)(nil),       // 5: gestalt.provider.v1.PluginRuntimeSessionLifecycle
+	(*StartPluginRuntimeSessionRequest)(nil),    // 6: gestalt.provider.v1.StartPluginRuntimeSessionRequest
+	(*GetPluginRuntimeSessionRequest)(nil),      // 7: gestalt.provider.v1.GetPluginRuntimeSessionRequest
+	(*ListPluginRuntimeSessionsRequest)(nil),    // 8: gestalt.provider.v1.ListPluginRuntimeSessionsRequest
+	(*ListPluginRuntimeSessionsResponse)(nil),   // 9: gestalt.provider.v1.ListPluginRuntimeSessionsResponse
+	(*StopPluginRuntimeSessionRequest)(nil),     // 10: gestalt.provider.v1.StopPluginRuntimeSessionRequest
+	(*PluginRuntimeHostServiceRelay)(nil),       // 11: gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	(*BindPluginRuntimeHostServiceRequest)(nil), // 12: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
+	(*PluginRuntimeHostServiceBinding)(nil),     // 13: gestalt.provider.v1.PluginRuntimeHostServiceBinding
+	(*StartHostedPluginRequest)(nil),            // 14: gestalt.provider.v1.StartHostedPluginRequest
+	(*HostedPlugin)(nil),                        // 15: gestalt.provider.v1.HostedPlugin
+	(*PluginRuntimeLogEntry)(nil),               // 16: gestalt.provider.v1.PluginRuntimeLogEntry
+	(*AppendPluginRuntimeLogsRequest)(nil),      // 17: gestalt.provider.v1.AppendPluginRuntimeLogsRequest
+	(*AppendPluginRuntimeLogsResponse)(nil),     // 18: gestalt.provider.v1.AppendPluginRuntimeLogsResponse
+	nil,                                         // 19: gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
+	nil,                                         // 20: gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
+	nil,                                         // 21: gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
+	(*timestamppb.Timestamp)(nil),               // 22: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                       // 23: google.protobuf.Empty
 }
 var file_v1_pluginruntime_proto_depIdxs = []int32{
 	0,  // 0: gestalt.provider.v1.PluginRuntimeSupport.host_service_access:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceAccess
 	1,  // 1: gestalt.provider.v1.PluginRuntimeSupport.egress_mode:type_name -> gestalt.provider.v1.PluginRuntimeEgressMode
-	2,  // 2: gestalt.provider.v1.PluginRuntimeSupport.launch_mode:type_name -> gestalt.provider.v1.PluginRuntimeLaunchMode
-	4,  // 3: gestalt.provider.v1.PluginRuntimeSupport.execution_target:type_name -> gestalt.provider.v1.PluginRuntimeExecutionTarget
-	21, // 4: gestalt.provider.v1.PluginRuntimeSession.metadata:type_name -> gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
-	7,  // 5: gestalt.provider.v1.PluginRuntimeSession.lifecycle:type_name -> gestalt.provider.v1.PluginRuntimeSessionLifecycle
-	24, // 6: gestalt.provider.v1.PluginRuntimeSessionLifecycle.started_at:type_name -> google.protobuf.Timestamp
-	24, // 7: gestalt.provider.v1.PluginRuntimeSessionLifecycle.recommended_drain_at:type_name -> google.protobuf.Timestamp
-	24, // 8: gestalt.provider.v1.PluginRuntimeSessionLifecycle.expires_at:type_name -> google.protobuf.Timestamp
-	22, // 9: gestalt.provider.v1.StartPluginRuntimeSessionRequest.metadata:type_name -> gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
-	6,  // 10: gestalt.provider.v1.ListPluginRuntimeSessionsResponse.sessions:type_name -> gestalt.provider.v1.PluginRuntimeSession
-	13, // 11: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	13, // 12: gestalt.provider.v1.PluginRuntimeHostServiceBinding.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	23, // 13: gestalt.provider.v1.StartHostedPluginRequest.env:type_name -> gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
-	3,  // 14: gestalt.provider.v1.PluginRuntimeLogEntry.stream:type_name -> gestalt.provider.v1.PluginRuntimeLogStream
-	24, // 15: gestalt.provider.v1.PluginRuntimeLogEntry.observed_at:type_name -> google.protobuf.Timestamp
-	18, // 16: gestalt.provider.v1.AppendPluginRuntimeLogsRequest.logs:type_name -> gestalt.provider.v1.PluginRuntimeLogEntry
-	19, // 17: gestalt.provider.v1.PluginRuntimeLogHost.AppendLogs:input_type -> gestalt.provider.v1.AppendPluginRuntimeLogsRequest
-	25, // 18: gestalt.provider.v1.PluginRuntimeProvider.GetSupport:input_type -> google.protobuf.Empty
-	8,  // 19: gestalt.provider.v1.PluginRuntimeProvider.StartSession:input_type -> gestalt.provider.v1.StartPluginRuntimeSessionRequest
-	9,  // 20: gestalt.provider.v1.PluginRuntimeProvider.GetSession:input_type -> gestalt.provider.v1.GetPluginRuntimeSessionRequest
-	10, // 21: gestalt.provider.v1.PluginRuntimeProvider.ListSessions:input_type -> gestalt.provider.v1.ListPluginRuntimeSessionsRequest
-	12, // 22: gestalt.provider.v1.PluginRuntimeProvider.StopSession:input_type -> gestalt.provider.v1.StopPluginRuntimeSessionRequest
-	14, // 23: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:input_type -> gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
-	16, // 24: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:input_type -> gestalt.provider.v1.StartHostedPluginRequest
-	20, // 25: gestalt.provider.v1.PluginRuntimeLogHost.AppendLogs:output_type -> gestalt.provider.v1.AppendPluginRuntimeLogsResponse
-	5,  // 26: gestalt.provider.v1.PluginRuntimeProvider.GetSupport:output_type -> gestalt.provider.v1.PluginRuntimeSupport
-	6,  // 27: gestalt.provider.v1.PluginRuntimeProvider.StartSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
-	6,  // 28: gestalt.provider.v1.PluginRuntimeProvider.GetSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
-	11, // 29: gestalt.provider.v1.PluginRuntimeProvider.ListSessions:output_type -> gestalt.provider.v1.ListPluginRuntimeSessionsResponse
-	25, // 30: gestalt.provider.v1.PluginRuntimeProvider.StopSession:output_type -> google.protobuf.Empty
-	15, // 31: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:output_type -> gestalt.provider.v1.PluginRuntimeHostServiceBinding
-	17, // 32: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:output_type -> gestalt.provider.v1.HostedPlugin
-	25, // [25:33] is the sub-list for method output_type
-	17, // [17:25] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	19, // 2: gestalt.provider.v1.PluginRuntimeSession.metadata:type_name -> gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
+	5,  // 3: gestalt.provider.v1.PluginRuntimeSession.lifecycle:type_name -> gestalt.provider.v1.PluginRuntimeSessionLifecycle
+	22, // 4: gestalt.provider.v1.PluginRuntimeSessionLifecycle.started_at:type_name -> google.protobuf.Timestamp
+	22, // 5: gestalt.provider.v1.PluginRuntimeSessionLifecycle.recommended_drain_at:type_name -> google.protobuf.Timestamp
+	22, // 6: gestalt.provider.v1.PluginRuntimeSessionLifecycle.expires_at:type_name -> google.protobuf.Timestamp
+	20, // 7: gestalt.provider.v1.StartPluginRuntimeSessionRequest.metadata:type_name -> gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
+	4,  // 8: gestalt.provider.v1.ListPluginRuntimeSessionsResponse.sessions:type_name -> gestalt.provider.v1.PluginRuntimeSession
+	11, // 9: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	11, // 10: gestalt.provider.v1.PluginRuntimeHostServiceBinding.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	21, // 11: gestalt.provider.v1.StartHostedPluginRequest.env:type_name -> gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
+	2,  // 12: gestalt.provider.v1.PluginRuntimeLogEntry.stream:type_name -> gestalt.provider.v1.PluginRuntimeLogStream
+	22, // 13: gestalt.provider.v1.PluginRuntimeLogEntry.observed_at:type_name -> google.protobuf.Timestamp
+	16, // 14: gestalt.provider.v1.AppendPluginRuntimeLogsRequest.logs:type_name -> gestalt.provider.v1.PluginRuntimeLogEntry
+	17, // 15: gestalt.provider.v1.PluginRuntimeLogHost.AppendLogs:input_type -> gestalt.provider.v1.AppendPluginRuntimeLogsRequest
+	23, // 16: gestalt.provider.v1.PluginRuntimeProvider.GetSupport:input_type -> google.protobuf.Empty
+	6,  // 17: gestalt.provider.v1.PluginRuntimeProvider.StartSession:input_type -> gestalt.provider.v1.StartPluginRuntimeSessionRequest
+	7,  // 18: gestalt.provider.v1.PluginRuntimeProvider.GetSession:input_type -> gestalt.provider.v1.GetPluginRuntimeSessionRequest
+	8,  // 19: gestalt.provider.v1.PluginRuntimeProvider.ListSessions:input_type -> gestalt.provider.v1.ListPluginRuntimeSessionsRequest
+	10, // 20: gestalt.provider.v1.PluginRuntimeProvider.StopSession:input_type -> gestalt.provider.v1.StopPluginRuntimeSessionRequest
+	12, // 21: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:input_type -> gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
+	14, // 22: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:input_type -> gestalt.provider.v1.StartHostedPluginRequest
+	18, // 23: gestalt.provider.v1.PluginRuntimeLogHost.AppendLogs:output_type -> gestalt.provider.v1.AppendPluginRuntimeLogsResponse
+	3,  // 24: gestalt.provider.v1.PluginRuntimeProvider.GetSupport:output_type -> gestalt.provider.v1.PluginRuntimeSupport
+	4,  // 25: gestalt.provider.v1.PluginRuntimeProvider.StartSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
+	4,  // 26: gestalt.provider.v1.PluginRuntimeProvider.GetSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
+	9,  // 27: gestalt.provider.v1.PluginRuntimeProvider.ListSessions:output_type -> gestalt.provider.v1.ListPluginRuntimeSessionsResponse
+	23, // 28: gestalt.provider.v1.PluginRuntimeProvider.StopSession:output_type -> google.protobuf.Empty
+	13, // 29: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:output_type -> gestalt.provider.v1.PluginRuntimeHostServiceBinding
+	15, // 30: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:output_type -> gestalt.provider.v1.HostedPlugin
+	23, // [23:31] is the sub-list for method output_type
+	15, // [15:23] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_v1_pluginruntime_proto_init() }
@@ -1477,8 +1337,8 @@ func file_v1_pluginruntime_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_pluginruntime_proto_rawDesc), len(file_v1_pluginruntime_proto_rawDesc)),
-			NumEnums:      4,
-			NumMessages:   20,
+			NumEnums:      3,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -11,10 +11,6 @@ import (
 type ProviderKind string
 
 const (
-	// HostedPluginBundleRoot is the guest-visible directory where the host stages
-	// bundle-based plugin payloads before a hosted runtime launches them.
-	HostedPluginBundleRoot = "/workspace/plugin"
-
 	// ProviderKindIntegration is the main executable provider surface used by
 	// integration plugins.
 	ProviderKindIntegration ProviderKind = "integration"

--- a/sdk/proto/v1/pluginruntime.proto
+++ b/sdk/proto/v1/pluginruntime.proto
@@ -20,23 +20,11 @@ enum PluginRuntimeEgressMode {
   PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME = 3;
 }
 
-enum PluginRuntimeLaunchMode {
-  PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED = 0;
-  PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE = 1;
-  PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH = 2;
-}
-
-message PluginRuntimeExecutionTarget {
-  string goos = 1;
-  string goarch = 2;
-}
-
 message PluginRuntimeSupport {
+  reserved 4, 5, 6;
   bool can_host_plugins = 1;
   PluginRuntimeHostServiceAccess host_service_access = 2;
   PluginRuntimeEgressMode egress_mode = 3;
-  PluginRuntimeLaunchMode launch_mode = 4;
-  PluginRuntimeExecutionTarget execution_target = 5;
 }
 
 message PluginRuntimeSession {
@@ -99,12 +87,12 @@ message PluginRuntimeHostServiceBinding {
 // plugin's listener endpoint and returns a host-reachable dial target in the
 // HostedPlugin response.
 message StartHostedPluginRequest {
+  reserved 6, 10;
   string session_id = 1;
   string plugin_name = 2;
   string command = 3;
   repeated string args = 4;
   map<string, string> env = 5;
-  string bundle_dir = 6;
   repeated string allowed_hosts = 7;
   string default_action = 8;
   string host_binary = 9;

--- a/sdk/typescript/gen/v1/pluginruntime_pb.ts
+++ b/sdk/typescript/gen/v1/pluginruntime_pb.ts
@@ -12,29 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file v1/pluginruntime.proto.
  */
 export const file_v1_pluginruntime: GenFile = /*@__PURE__*/
-  fileDesc("ChZ2MS9wbHVnaW5ydW50aW1lLnByb3RvEhNnZXN0YWx0LnByb3ZpZGVyLnYxIjwKHFBsdWdpblJ1bnRpbWVFeGVjdXRpb25UYXJnZXQSDAoEZ29vcxgBIAEoCRIOCgZnb2FyY2gYAiABKAki1QIKFFBsdWdpblJ1bnRpbWVTdXBwb3J0EhgKEGNhbl9ob3N0X3BsdWdpbnMYASABKAgSUAoTaG9zdF9zZXJ2aWNlX2FjY2VzcxgCIAEoDjIzLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUhvc3RTZXJ2aWNlQWNjZXNzEkEKC2VncmVzc19tb2RlGAMgASgOMiwuZ2VzdGFsdC5wcm92aWRlci52MS5QbHVnaW5SdW50aW1lRWdyZXNzTW9kZRJBCgtsYXVuY2hfbW9kZRgEIAEoDjIsLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUxhdW5jaE1vZGUSSwoQZXhlY3V0aW9uX3RhcmdldBgFIAEoCzIxLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUV4ZWN1dGlvblRhcmdldCKhAgoUUGx1Z2luUnVudGltZVNlc3Npb24SCgoCaWQYASABKAkSDQoFc3RhdGUYAiABKAkSSQoIbWV0YWRhdGEYAyADKAsyNy5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVTZXNzaW9uLk1ldGFkYXRhRW50cnkSRQoJbGlmZWN5Y2xlGAQgASgLMjIuZ2VzdGFsdC5wcm92aWRlci52MS5QbHVnaW5SdW50aW1lU2Vzc2lvbkxpZmVjeWNsZRIUCgxzdGF0ZV9yZWFzb24YBSABKAkSFQoNc3RhdGVfbWVzc2FnZRgGIAEoCRovCg1NZXRhZGF0YUVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiuQEKHVBsdWdpblJ1bnRpbWVTZXNzaW9uTGlmZWN5Y2xlEi4KCnN0YXJ0ZWRfYXQYASABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEjgKFHJlY29tbWVuZGVkX2RyYWluX2F0GAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIuCgpleHBpcmVzX2F0GAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCLgAQogU3RhcnRQbHVnaW5SdW50aW1lU2Vzc2lvblJlcXVlc3QSEwoLcGx1Z2luX25hbWUYASABKAkSEAoIdGVtcGxhdGUYAiABKAkSDQoFaW1hZ2UYAyABKAkSVQoIbWV0YWRhdGEYBCADKAsyQy5nZXN0YWx0LnByb3ZpZGVyLnYxLlN0YXJ0UGx1Z2luUnVudGltZVNlc3Npb25SZXF1ZXN0Lk1ldGFkYXRhRW50cnkaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIjQKHkdldFBsdWdpblJ1bnRpbWVTZXNzaW9uUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJIiIKIExpc3RQbHVnaW5SdW50aW1lU2Vzc2lvbnNSZXF1ZXN0ImAKIUxpc3RQbHVnaW5SdW50aW1lU2Vzc2lvbnNSZXNwb25zZRI7CghzZXNzaW9ucxgBIAMoCzIpLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZVNlc3Npb24iNQofU3RvcFBsdWdpblJ1bnRpbWVTZXNzaW9uUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJIjQKHVBsdWdpblJ1bnRpbWVIb3N0U2VydmljZVJlbGF5EhMKC2RpYWxfdGFyZ2V0GAEgASgJIpMBCiNCaW5kUGx1Z2luUnVudGltZUhvc3RTZXJ2aWNlUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEg8KB2Vudl92YXIYAiABKAkSQQoFcmVsYXkYBCABKAsyMi5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVIb3N0U2VydmljZVJlbGF5SgQIAxAEIpsBCh9QbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VCaW5kaW5nEgoKAmlkGAEgASgJEhIKCnNlc3Npb25faWQYAiABKAkSDwoHZW52X3ZhchgDIAEoCRJBCgVyZWxheRgFIAEoCzIyLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUhvc3RTZXJ2aWNlUmVsYXlKBAgEEAUiqwIKGFN0YXJ0SG9zdGVkUGx1Z2luUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEhMKC3BsdWdpbl9uYW1lGAIgASgJEg8KB2NvbW1hbmQYAyABKAkSDAoEYXJncxgEIAMoCRJDCgNlbnYYBSADKAsyNi5nZXN0YWx0LnByb3ZpZGVyLnYxLlN0YXJ0SG9zdGVkUGx1Z2luUmVxdWVzdC5FbnZFbnRyeRISCgpidW5kbGVfZGlyGAYgASgJEhUKDWFsbG93ZWRfaG9zdHMYByADKAkSFgoOZGVmYXVsdF9hY3Rpb24YCCABKAkSEwoLaG9zdF9iaW5hcnkYCSABKAkaKgoIRW52RW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASJYCgxIb3N0ZWRQbHVnaW4SCgoCaWQYASABKAkSEgoKc2Vzc2lvbl9pZBgCIAEoCRITCgtwbHVnaW5fbmFtZRgDIAEoCRITCgtkaWFsX3RhcmdldBgEIAEoCSKqAQoVUGx1Z2luUnVudGltZUxvZ0VudHJ5EjsKBnN0cmVhbRgBIAEoDjIrLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUxvZ1N0cmVhbRIPCgdtZXNzYWdlGAIgASgJEi8KC29ic2VydmVkX2F0GAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBISCgpzb3VyY2Vfc2VxGAQgASgDIm4KHkFwcGVuZFBsdWdpblJ1bnRpbWVMb2dzUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEjgKBGxvZ3MYAiADKAsyKi5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVMb2dFbnRyeSIzCh9BcHBlbmRQbHVnaW5SdW50aW1lTG9nc1Jlc3BvbnNlEhAKCGxhc3Rfc2VxGAEgASgDKrABCh5QbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VBY2Nlc3MSMgouUExVR0lOX1JVTlRJTUVfSE9TVF9TRVJWSUNFX0FDQ0VTU19VTlNQRUNJRklFRBAAEisKJ1BMVUdJTl9SVU5USU1FX0hPU1RfU0VSVklDRV9BQ0NFU1NfTk9ORRABEi0KKVBMVUdJTl9SVU5USU1FX0hPU1RfU0VSVklDRV9BQ0NFU1NfRElSRUNUEAIquAEKF1BsdWdpblJ1bnRpbWVFZ3Jlc3NNb2RlEioKJlBMVUdJTl9SVU5USU1FX0VHUkVTU19NT0RFX1VOU1BFQ0lGSUVEEAASIwofUExVR0lOX1JVTlRJTUVfRUdSRVNTX01PREVfTk9ORRABEiMKH1BMVUdJTl9SVU5USU1FX0VHUkVTU19NT0RFX0NJRFIQAhInCiNQTFVHSU5fUlVOVElNRV9FR1JFU1NfTU9ERV9IT1NUTkFNRRADKpYBChdQbHVnaW5SdW50aW1lTGF1bmNoTW9kZRIqCiZQTFVHSU5fUlVOVElNRV9MQVVOQ0hfTU9ERV9VTlNQRUNJRklFRBAAEiUKIVBMVUdJTl9SVU5USU1FX0xBVU5DSF9NT0RFX0JVTkRMRRABEigKJFBMVUdJTl9SVU5USU1FX0xBVU5DSF9NT0RFX0hPU1RfUEFUSBACKrYBChZQbHVnaW5SdW50aW1lTG9nU3RyZWFtEikKJVBMVUdJTl9SVU5USU1FX0xPR19TVFJFQU1fVU5TUEVDSUZJRUQQABIkCiBQTFVHSU5fUlVOVElNRV9MT0dfU1RSRUFNX1NURE9VVBABEiQKIFBMVUdJTl9SVU5USU1FX0xPR19TVFJFQU1fU1RERVJSEAISJQohUExVR0lOX1JVTlRJTUVfTE9HX1NUUkVBTV9SVU5USU1FEAMyjwEKFFBsdWdpblJ1bnRpbWVMb2dIb3N0EncKCkFwcGVuZExvZ3MSMy5nZXN0YWx0LnByb3ZpZGVyLnYxLkFwcGVuZFBsdWdpblJ1bnRpbWVMb2dzUmVxdWVzdBo0Lmdlc3RhbHQucHJvdmlkZXIudjEuQXBwZW5kUGx1Z2luUnVudGltZUxvZ3NSZXNwb25zZTKJBgoVUGx1Z2luUnVudGltZVByb3ZpZGVyEk8KCkdldFN1cHBvcnQSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaKS5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVTdXBwb3J0EnAKDFN0YXJ0U2Vzc2lvbhI1Lmdlc3RhbHQucHJvdmlkZXIudjEuU3RhcnRQbHVnaW5SdW50aW1lU2Vzc2lvblJlcXVlc3QaKS5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVTZXNzaW9uEmwKCkdldFNlc3Npb24SMy5nZXN0YWx0LnByb3ZpZGVyLnYxLkdldFBsdWdpblJ1bnRpbWVTZXNzaW9uUmVxdWVzdBopLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZVNlc3Npb24SfQoMTGlzdFNlc3Npb25zEjUuZ2VzdGFsdC5wcm92aWRlci52MS5MaXN0UGx1Z2luUnVudGltZVNlc3Npb25zUmVxdWVzdBo2Lmdlc3RhbHQucHJvdmlkZXIudjEuTGlzdFBsdWdpblJ1bnRpbWVTZXNzaW9uc1Jlc3BvbnNlElsKC1N0b3BTZXNzaW9uEjQuZ2VzdGFsdC5wcm92aWRlci52MS5TdG9wUGx1Z2luUnVudGltZVNlc3Npb25SZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EoEBCg9CaW5kSG9zdFNlcnZpY2USOC5nZXN0YWx0LnByb3ZpZGVyLnYxLkJpbmRQbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VSZXF1ZXN0GjQuZ2VzdGFsdC5wcm92aWRlci52MS5QbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VCaW5kaW5nEl8KC1N0YXJ0UGx1Z2luEi0uZ2VzdGFsdC5wcm92aWRlci52MS5TdGFydEhvc3RlZFBsdWdpblJlcXVlc3QaIS5nZXN0YWx0LnByb3ZpZGVyLnYxLkhvc3RlZFBsdWdpbkI7WjlnaXRodWIuY29tL3ZhbG9uLXRlY2hub2xvZ2llcy9nZXN0YWx0L3Nkay9nby9nZW4vdjE7cHJvdG9iBnByb3RvMw", [file_google_protobuf_empty, file_google_protobuf_timestamp]);
-
-/**
- * @generated from message gestalt.provider.v1.PluginRuntimeExecutionTarget
- */
-export type PluginRuntimeExecutionTarget = Message<"gestalt.provider.v1.PluginRuntimeExecutionTarget"> & {
-  /**
-   * @generated from field: string goos = 1;
-   */
-  goos: string;
-
-  /**
-   * @generated from field: string goarch = 2;
-   */
-  goarch: string;
-};
-
-/**
- * Describes the message gestalt.provider.v1.PluginRuntimeExecutionTarget.
- * Use `create(PluginRuntimeExecutionTargetSchema)` to create a new message.
- */
-export const PluginRuntimeExecutionTargetSchema: GenMessage<PluginRuntimeExecutionTarget> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 0);
+  fileDesc("ChZ2MS9wbHVnaW5ydW50aW1lLnByb3RvEhNnZXN0YWx0LnByb3ZpZGVyLnYxItcBChRQbHVnaW5SdW50aW1lU3VwcG9ydBIYChBjYW5faG9zdF9wbHVnaW5zGAEgASgIElAKE2hvc3Rfc2VydmljZV9hY2Nlc3MYAiABKA4yMy5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVIb3N0U2VydmljZUFjY2VzcxJBCgtlZ3Jlc3NfbW9kZRgDIAEoDjIsLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUVncmVzc01vZGVKBAgEEAVKBAgFEAZKBAgGEAcioQIKFFBsdWdpblJ1bnRpbWVTZXNzaW9uEgoKAmlkGAEgASgJEg0KBXN0YXRlGAIgASgJEkkKCG1ldGFkYXRhGAMgAygLMjcuZ2VzdGFsdC5wcm92aWRlci52MS5QbHVnaW5SdW50aW1lU2Vzc2lvbi5NZXRhZGF0YUVudHJ5EkUKCWxpZmVjeWNsZRgEIAEoCzIyLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZVNlc3Npb25MaWZlY3ljbGUSFAoMc3RhdGVfcmVhc29uGAUgASgJEhUKDXN0YXRlX21lc3NhZ2UYBiABKAkaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIrkBCh1QbHVnaW5SdW50aW1lU2Vzc2lvbkxpZmVjeWNsZRIuCgpzdGFydGVkX2F0GAEgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBI4ChRyZWNvbW1lbmRlZF9kcmFpbl9hdBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoKZXhwaXJlc19hdBgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAi4AEKIFN0YXJ0UGx1Z2luUnVudGltZVNlc3Npb25SZXF1ZXN0EhMKC3BsdWdpbl9uYW1lGAEgASgJEhAKCHRlbXBsYXRlGAIgASgJEg0KBWltYWdlGAMgASgJElUKCG1ldGFkYXRhGAQgAygLMkMuZ2VzdGFsdC5wcm92aWRlci52MS5TdGFydFBsdWdpblJ1bnRpbWVTZXNzaW9uUmVxdWVzdC5NZXRhZGF0YUVudHJ5Gi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASI0Ch5HZXRQbHVnaW5SdW50aW1lU2Vzc2lvblJlcXVlc3QSEgoKc2Vzc2lvbl9pZBgBIAEoCSIiCiBMaXN0UGx1Z2luUnVudGltZVNlc3Npb25zUmVxdWVzdCJgCiFMaXN0UGx1Z2luUnVudGltZVNlc3Npb25zUmVzcG9uc2USOwoIc2Vzc2lvbnMYASADKAsyKS5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVTZXNzaW9uIjUKH1N0b3BQbHVnaW5SdW50aW1lU2Vzc2lvblJlcXVlc3QSEgoKc2Vzc2lvbl9pZBgBIAEoCSI0Ch1QbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VSZWxheRITCgtkaWFsX3RhcmdldBgBIAEoCSKTAQojQmluZFBsdWdpblJ1bnRpbWVIb3N0U2VydmljZVJlcXVlc3QSEgoKc2Vzc2lvbl9pZBgBIAEoCRIPCgdlbnZfdmFyGAIgASgJEkEKBXJlbGF5GAQgASgLMjIuZ2VzdGFsdC5wcm92aWRlci52MS5QbHVnaW5SdW50aW1lSG9zdFNlcnZpY2VSZWxheUoECAMQBCKbAQofUGx1Z2luUnVudGltZUhvc3RTZXJ2aWNlQmluZGluZxIKCgJpZBgBIAEoCRISCgpzZXNzaW9uX2lkGAIgASgJEg8KB2Vudl92YXIYAyABKAkSQQoFcmVsYXkYBSABKAsyMi5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVIb3N0U2VydmljZVJlbGF5SgQIBBAFIqMCChhTdGFydEhvc3RlZFBsdWdpblJlcXVlc3QSEgoKc2Vzc2lvbl9pZBgBIAEoCRITCgtwbHVnaW5fbmFtZRgCIAEoCRIPCgdjb21tYW5kGAMgASgJEgwKBGFyZ3MYBCADKAkSQwoDZW52GAUgAygLMjYuZ2VzdGFsdC5wcm92aWRlci52MS5TdGFydEhvc3RlZFBsdWdpblJlcXVlc3QuRW52RW50cnkSFQoNYWxsb3dlZF9ob3N0cxgHIAMoCRIWCg5kZWZhdWx0X2FjdGlvbhgIIAEoCRITCgtob3N0X2JpbmFyeRgJIAEoCRoqCghFbnZFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBSgQIBhAHSgQIChALIlgKDEhvc3RlZFBsdWdpbhIKCgJpZBgBIAEoCRISCgpzZXNzaW9uX2lkGAIgASgJEhMKC3BsdWdpbl9uYW1lGAMgASgJEhMKC2RpYWxfdGFyZ2V0GAQgASgJIqoBChVQbHVnaW5SdW50aW1lTG9nRW50cnkSOwoGc3RyZWFtGAEgASgOMisuZ2VzdGFsdC5wcm92aWRlci52MS5QbHVnaW5SdW50aW1lTG9nU3RyZWFtEg8KB21lc3NhZ2UYAiABKAkSLwoLb2JzZXJ2ZWRfYXQYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEhIKCnNvdXJjZV9zZXEYBCABKAMibgoeQXBwZW5kUGx1Z2luUnVudGltZUxvZ3NSZXF1ZXN0EhIKCnNlc3Npb25faWQYASABKAkSOAoEbG9ncxgCIAMoCzIqLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZUxvZ0VudHJ5IjMKH0FwcGVuZFBsdWdpblJ1bnRpbWVMb2dzUmVzcG9uc2USEAoIbGFzdF9zZXEYASABKAMqsAEKHlBsdWdpblJ1bnRpbWVIb3N0U2VydmljZUFjY2VzcxIyCi5QTFVHSU5fUlVOVElNRV9IT1NUX1NFUlZJQ0VfQUNDRVNTX1VOU1BFQ0lGSUVEEAASKwonUExVR0lOX1JVTlRJTUVfSE9TVF9TRVJWSUNFX0FDQ0VTU19OT05FEAESLQopUExVR0lOX1JVTlRJTUVfSE9TVF9TRVJWSUNFX0FDQ0VTU19ESVJFQ1QQAiq4AQoXUGx1Z2luUnVudGltZUVncmVzc01vZGUSKgomUExVR0lOX1JVTlRJTUVfRUdSRVNTX01PREVfVU5TUEVDSUZJRUQQABIjCh9QTFVHSU5fUlVOVElNRV9FR1JFU1NfTU9ERV9OT05FEAESIwofUExVR0lOX1JVTlRJTUVfRUdSRVNTX01PREVfQ0lEUhACEicKI1BMVUdJTl9SVU5USU1FX0VHUkVTU19NT0RFX0hPU1ROQU1FEAMqtgEKFlBsdWdpblJ1bnRpbWVMb2dTdHJlYW0SKQolUExVR0lOX1JVTlRJTUVfTE9HX1NUUkVBTV9VTlNQRUNJRklFRBAAEiQKIFBMVUdJTl9SVU5USU1FX0xPR19TVFJFQU1fU1RET1VUEAESJAogUExVR0lOX1JVTlRJTUVfTE9HX1NUUkVBTV9TVERFUlIQAhIlCiFQTFVHSU5fUlVOVElNRV9MT0dfU1RSRUFNX1JVTlRJTUUQAzKPAQoUUGx1Z2luUnVudGltZUxvZ0hvc3QSdwoKQXBwZW5kTG9ncxIzLmdlc3RhbHQucHJvdmlkZXIudjEuQXBwZW5kUGx1Z2luUnVudGltZUxvZ3NSZXF1ZXN0GjQuZ2VzdGFsdC5wcm92aWRlci52MS5BcHBlbmRQbHVnaW5SdW50aW1lTG9nc1Jlc3BvbnNlMokGChVQbHVnaW5SdW50aW1lUHJvdmlkZXISTwoKR2V0U3VwcG9ydBIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRopLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZVN1cHBvcnQScAoMU3RhcnRTZXNzaW9uEjUuZ2VzdGFsdC5wcm92aWRlci52MS5TdGFydFBsdWdpblJ1bnRpbWVTZXNzaW9uUmVxdWVzdBopLmdlc3RhbHQucHJvdmlkZXIudjEuUGx1Z2luUnVudGltZVNlc3Npb24SbAoKR2V0U2Vzc2lvbhIzLmdlc3RhbHQucHJvdmlkZXIudjEuR2V0UGx1Z2luUnVudGltZVNlc3Npb25SZXF1ZXN0GikuZ2VzdGFsdC5wcm92aWRlci52MS5QbHVnaW5SdW50aW1lU2Vzc2lvbhJ9CgxMaXN0U2Vzc2lvbnMSNS5nZXN0YWx0LnByb3ZpZGVyLnYxLkxpc3RQbHVnaW5SdW50aW1lU2Vzc2lvbnNSZXF1ZXN0GjYuZ2VzdGFsdC5wcm92aWRlci52MS5MaXN0UGx1Z2luUnVudGltZVNlc3Npb25zUmVzcG9uc2USWwoLU3RvcFNlc3Npb24SNC5nZXN0YWx0LnByb3ZpZGVyLnYxLlN0b3BQbHVnaW5SdW50aW1lU2Vzc2lvblJlcXVlc3QaFi5nb29nbGUucHJvdG9idWYuRW1wdHkSgQEKD0JpbmRIb3N0U2VydmljZRI4Lmdlc3RhbHQucHJvdmlkZXIudjEuQmluZFBsdWdpblJ1bnRpbWVIb3N0U2VydmljZVJlcXVlc3QaNC5nZXN0YWx0LnByb3ZpZGVyLnYxLlBsdWdpblJ1bnRpbWVIb3N0U2VydmljZUJpbmRpbmcSXwoLU3RhcnRQbHVnaW4SLS5nZXN0YWx0LnByb3ZpZGVyLnYxLlN0YXJ0SG9zdGVkUGx1Z2luUmVxdWVzdBohLmdlc3RhbHQucHJvdmlkZXIudjEuSG9zdGVkUGx1Z2luQjtaOWdpdGh1Yi5jb20vdmFsb24tdGVjaG5vbG9naWVzL2dlc3RhbHQvc2RrL2dvL2dlbi92MTtwcm90b2IGcHJvdG8z", [file_google_protobuf_empty, file_google_protobuf_timestamp]);
 
 /**
  * @generated from message gestalt.provider.v1.PluginRuntimeSupport
@@ -54,16 +32,6 @@ export type PluginRuntimeSupport = Message<"gestalt.provider.v1.PluginRuntimeSup
    * @generated from field: gestalt.provider.v1.PluginRuntimeEgressMode egress_mode = 3;
    */
   egressMode: PluginRuntimeEgressMode;
-
-  /**
-   * @generated from field: gestalt.provider.v1.PluginRuntimeLaunchMode launch_mode = 4;
-   */
-  launchMode: PluginRuntimeLaunchMode;
-
-  /**
-   * @generated from field: gestalt.provider.v1.PluginRuntimeExecutionTarget execution_target = 5;
-   */
-  executionTarget?: PluginRuntimeExecutionTarget | undefined;
 };
 
 /**
@@ -71,7 +39,7 @@ export type PluginRuntimeSupport = Message<"gestalt.provider.v1.PluginRuntimeSup
  * Use `create(PluginRuntimeSupportSchema)` to create a new message.
  */
 export const PluginRuntimeSupportSchema: GenMessage<PluginRuntimeSupport> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 1);
+  messageDesc(file_v1_pluginruntime, 0);
 
 /**
  * @generated from message gestalt.provider.v1.PluginRuntimeSession
@@ -113,7 +81,7 @@ export type PluginRuntimeSession = Message<"gestalt.provider.v1.PluginRuntimeSes
  * Use `create(PluginRuntimeSessionSchema)` to create a new message.
  */
 export const PluginRuntimeSessionSchema: GenMessage<PluginRuntimeSession> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 2);
+  messageDesc(file_v1_pluginruntime, 1);
 
 /**
  * @generated from message gestalt.provider.v1.PluginRuntimeSessionLifecycle
@@ -140,7 +108,7 @@ export type PluginRuntimeSessionLifecycle = Message<"gestalt.provider.v1.PluginR
  * Use `create(PluginRuntimeSessionLifecycleSchema)` to create a new message.
  */
 export const PluginRuntimeSessionLifecycleSchema: GenMessage<PluginRuntimeSessionLifecycle> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 3);
+  messageDesc(file_v1_pluginruntime, 2);
 
 /**
  * @generated from message gestalt.provider.v1.StartPluginRuntimeSessionRequest
@@ -172,7 +140,7 @@ export type StartPluginRuntimeSessionRequest = Message<"gestalt.provider.v1.Star
  * Use `create(StartPluginRuntimeSessionRequestSchema)` to create a new message.
  */
 export const StartPluginRuntimeSessionRequestSchema: GenMessage<StartPluginRuntimeSessionRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 4);
+  messageDesc(file_v1_pluginruntime, 3);
 
 /**
  * @generated from message gestalt.provider.v1.GetPluginRuntimeSessionRequest
@@ -189,7 +157,7 @@ export type GetPluginRuntimeSessionRequest = Message<"gestalt.provider.v1.GetPlu
  * Use `create(GetPluginRuntimeSessionRequestSchema)` to create a new message.
  */
 export const GetPluginRuntimeSessionRequestSchema: GenMessage<GetPluginRuntimeSessionRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 5);
+  messageDesc(file_v1_pluginruntime, 4);
 
 /**
  * @generated from message gestalt.provider.v1.ListPluginRuntimeSessionsRequest
@@ -202,7 +170,7 @@ export type ListPluginRuntimeSessionsRequest = Message<"gestalt.provider.v1.List
  * Use `create(ListPluginRuntimeSessionsRequestSchema)` to create a new message.
  */
 export const ListPluginRuntimeSessionsRequestSchema: GenMessage<ListPluginRuntimeSessionsRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 6);
+  messageDesc(file_v1_pluginruntime, 5);
 
 /**
  * @generated from message gestalt.provider.v1.ListPluginRuntimeSessionsResponse
@@ -219,7 +187,7 @@ export type ListPluginRuntimeSessionsResponse = Message<"gestalt.provider.v1.Lis
  * Use `create(ListPluginRuntimeSessionsResponseSchema)` to create a new message.
  */
 export const ListPluginRuntimeSessionsResponseSchema: GenMessage<ListPluginRuntimeSessionsResponse> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 7);
+  messageDesc(file_v1_pluginruntime, 6);
 
 /**
  * @generated from message gestalt.provider.v1.StopPluginRuntimeSessionRequest
@@ -236,7 +204,7 @@ export type StopPluginRuntimeSessionRequest = Message<"gestalt.provider.v1.StopP
  * Use `create(StopPluginRuntimeSessionRequestSchema)` to create a new message.
  */
 export const StopPluginRuntimeSessionRequestSchema: GenMessage<StopPluginRuntimeSessionRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 8);
+  messageDesc(file_v1_pluginruntime, 7);
 
 /**
  * @generated from message gestalt.provider.v1.PluginRuntimeHostServiceRelay
@@ -253,7 +221,7 @@ export type PluginRuntimeHostServiceRelay = Message<"gestalt.provider.v1.PluginR
  * Use `create(PluginRuntimeHostServiceRelaySchema)` to create a new message.
  */
 export const PluginRuntimeHostServiceRelaySchema: GenMessage<PluginRuntimeHostServiceRelay> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 9);
+  messageDesc(file_v1_pluginruntime, 8);
 
 /**
  * @generated from message gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
@@ -280,7 +248,7 @@ export type BindPluginRuntimeHostServiceRequest = Message<"gestalt.provider.v1.B
  * Use `create(BindPluginRuntimeHostServiceRequestSchema)` to create a new message.
  */
 export const BindPluginRuntimeHostServiceRequestSchema: GenMessage<BindPluginRuntimeHostServiceRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 10);
+  messageDesc(file_v1_pluginruntime, 9);
 
 /**
  * @generated from message gestalt.provider.v1.PluginRuntimeHostServiceBinding
@@ -312,7 +280,7 @@ export type PluginRuntimeHostServiceBinding = Message<"gestalt.provider.v1.Plugi
  * Use `create(PluginRuntimeHostServiceBindingSchema)` to create a new message.
  */
 export const PluginRuntimeHostServiceBindingSchema: GenMessage<PluginRuntimeHostServiceBinding> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 11);
+  messageDesc(file_v1_pluginruntime, 10);
 
 /**
  * StartHostedPluginRequest describes the plugin process to launch inside a
@@ -349,11 +317,6 @@ export type StartHostedPluginRequest = Message<"gestalt.provider.v1.StartHostedP
   env: { [key: string]: string };
 
   /**
-   * @generated from field: string bundle_dir = 6;
-   */
-  bundleDir: string;
-
-  /**
    * @generated from field: repeated string allowed_hosts = 7;
    */
   allowedHosts: string[];
@@ -374,7 +337,7 @@ export type StartHostedPluginRequest = Message<"gestalt.provider.v1.StartHostedP
  * Use `create(StartHostedPluginRequestSchema)` to create a new message.
  */
 export const StartHostedPluginRequestSchema: GenMessage<StartHostedPluginRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 12);
+  messageDesc(file_v1_pluginruntime, 11);
 
 /**
  * @generated from message gestalt.provider.v1.HostedPlugin
@@ -406,7 +369,7 @@ export type HostedPlugin = Message<"gestalt.provider.v1.HostedPlugin"> & {
  * Use `create(HostedPluginSchema)` to create a new message.
  */
 export const HostedPluginSchema: GenMessage<HostedPlugin> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 13);
+  messageDesc(file_v1_pluginruntime, 12);
 
 /**
  * @generated from message gestalt.provider.v1.PluginRuntimeLogEntry
@@ -438,7 +401,7 @@ export type PluginRuntimeLogEntry = Message<"gestalt.provider.v1.PluginRuntimeLo
  * Use `create(PluginRuntimeLogEntrySchema)` to create a new message.
  */
 export const PluginRuntimeLogEntrySchema: GenMessage<PluginRuntimeLogEntry> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 14);
+  messageDesc(file_v1_pluginruntime, 13);
 
 /**
  * @generated from message gestalt.provider.v1.AppendPluginRuntimeLogsRequest
@@ -460,7 +423,7 @@ export type AppendPluginRuntimeLogsRequest = Message<"gestalt.provider.v1.Append
  * Use `create(AppendPluginRuntimeLogsRequestSchema)` to create a new message.
  */
 export const AppendPluginRuntimeLogsRequestSchema: GenMessage<AppendPluginRuntimeLogsRequest> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 15);
+  messageDesc(file_v1_pluginruntime, 14);
 
 /**
  * @generated from message gestalt.provider.v1.AppendPluginRuntimeLogsResponse
@@ -477,7 +440,7 @@ export type AppendPluginRuntimeLogsResponse = Message<"gestalt.provider.v1.Appen
  * Use `create(AppendPluginRuntimeLogsResponseSchema)` to create a new message.
  */
 export const AppendPluginRuntimeLogsResponseSchema: GenMessage<AppendPluginRuntimeLogsResponse> = /*@__PURE__*/
-  messageDesc(file_v1_pluginruntime, 16);
+  messageDesc(file_v1_pluginruntime, 15);
 
 /**
  * @generated from enum gestalt.provider.v1.PluginRuntimeHostServiceAccess
@@ -537,32 +500,6 @@ export const PluginRuntimeEgressModeSchema: GenEnum<PluginRuntimeEgressMode> = /
   enumDesc(file_v1_pluginruntime, 1);
 
 /**
- * @generated from enum gestalt.provider.v1.PluginRuntimeLaunchMode
- */
-export enum PluginRuntimeLaunchMode {
-  /**
-   * @generated from enum value: PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED = 0;
-   */
-  UNSPECIFIED = 0,
-
-  /**
-   * @generated from enum value: PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE = 1;
-   */
-  BUNDLE = 1,
-
-  /**
-   * @generated from enum value: PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH = 2;
-   */
-  HOST_PATH = 2,
-}
-
-/**
- * Describes the enum gestalt.provider.v1.PluginRuntimeLaunchMode.
- */
-export const PluginRuntimeLaunchModeSchema: GenEnum<PluginRuntimeLaunchMode> = /*@__PURE__*/
-  enumDesc(file_v1_pluginruntime, 2);
-
-/**
  * @generated from enum gestalt.provider.v1.PluginRuntimeLogStream
  */
 export enum PluginRuntimeLogStream {
@@ -591,7 +528,7 @@ export enum PluginRuntimeLogStream {
  * Describes the enum gestalt.provider.v1.PluginRuntimeLogStream.
  */
 export const PluginRuntimeLogStreamSchema: GenEnum<PluginRuntimeLogStream> = /*@__PURE__*/
-  enumDesc(file_v1_pluginruntime, 3);
+  enumDesc(file_v1_pluginruntime, 2);
 
 /**
  * @generated from service gestalt.provider.v1.PluginRuntimeLogHost


### PR DESCRIPTION
## Summary

Simplifies hosted runtime launch to the image/template-backed path only. Legacy bundle staging and launch-mode negotiation are removed from the runtime provider contract.

## Interface Diff

Runtime provider proto support is now capability-only:

```diff
-enum PluginRuntimeLaunchMode {
-  PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED = 0;
-  PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE = 1;
-  PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH = 2;
-}
-
-message PluginRuntimeExecutionTarget {
-  string goos = 1;
-  string goarch = 2;
-}
-
 message PluginRuntimeSupport {
   bool can_host_plugins = 1;
   PluginRuntimeHostServiceAccess host_service_access = 2;
   PluginRuntimeEgressMode egress_mode = 3;
-  PluginRuntimeLaunchMode launch_mode = 4;
-  PluginRuntimeExecutionTarget execution_target = 5;
 }
```

Hosted plugin launch no longer carries a staged bundle root:

```diff
 message StartHostedPluginRequest {
   string session_id = 1;
   string plugin_name = 2;
   string command = 3;
   repeated string args = 4;
   map<string, string> env = 5;
-  string bundle_dir = 6;
   repeated string allowed_hosts = 7;
   string default_action = 8;
   string host_binary = 9;
 }
```

The internal Go runtime provider facade mirrors the same simplification:

```diff
-type LaunchMode string
-
-const (
-  LaunchModeHostPath LaunchMode = "host_path"
-  LaunchModeBundle   LaunchMode = "bundle"
-)
-
-type ExecutionTarget struct {
-  GOOS   string
-  GOARCH string
-}
-
 type Support struct {
   CanHostPlugins    bool
   HostServiceAccess HostServiceAccess
   EgressMode        EgressMode
-  LaunchMode        LaunchMode
-  ExecutionTarget   ExecutionTarget
 }
 
 type StartPluginRequest struct {
   SessionID  string
   PluginName string
   Command    string
   Args       []string
   Env        map[string]string
   Egress     RuntimeEgressPolicy
   HostBinary string
-  BundleDir  string
 }
```

## Config Example Diff

Before, hosted runtime launch needed a provider bundle path or launch-mode behavior outside the image contract:

```diff
 plugins:
   support:
     source: https://artifacts.example.com/support/v0.1.0/provider-release.yaml
     execution:
       mode: hosted
       runtime:
         provider: modal
-        launch:
-          source: bundle
-        command: ./bin/support-plugin
-        args: ["--config", "/etc/gestalt/support.yaml"]
```

Now the image/template is the runtime environment, and `gestaltd` derives `command` and `args` from the provider manifest entrypoint:

```diff
 plugins:
   support:
     source: https://artifacts.example.com/support/v0.1.0/provider-release.yaml
     execution:
       mode: hosted
       runtime:
         provider: modal
+        image: ghcr.io/example/support-plugin@sha256:...
```

Template-backed runtimes use the same generic primitive:

```diff
 providers:
   agent:
     simple:
       execution:
         mode: hosted
         runtime:
           provider: gkeAgentSandbox
+          template: gestalt-plugin-runtime
```

Local development remains host-path based. If the selected runtime provider is `driver: local` or the system falls back to the built-in local runtime, configured host `command` / `args` are preserved even when `runtime.image` is present.

## Changes

- Removed legacy bundle launch fields from proto, Go runtime types, generated Go/TS bindings, admin runtime profiles, and docs.
- Deleted bundle staging/argument rewriting from hosted runtime launch preparation.
- Preserved local runtime host-path execution, including local fallback with image/template config present.
- Added integration-style bootstrap coverage for image/template manifest-entrypoint launch and local fallback command preservation.

## Verification

- `buf generate` in `sdk/proto`
- `npm run build:proto` in `sdk/typescript`
- `go test ./...` in `sdk/go`
- `go test ./...` in `gestaltd`
- `go test ./internal/bootstrap -count=1` after review fixes
- Reviewer agent re-review found no blockers after the template-backed fix.
- Cursor review comments were addressed and resolved.