### PR TITLE
Prepare gestalt CLI v0.0.1-alpha.10 release

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.1-alpha.9"
+version = "0.0.1-alpha.10"
 edition = "2024"


### PR DESCRIPTION
## Summary

Prepares the `gestalt` CLI `0.0.1-alpha.10` release so the merged live TUI rendering polish is installable.

This release packages #1488:

- highlighted `› ...` user prompt rows
- `● ...` assistant rows
- lightweight inline markdown rendering
- visible Markdown link URLs as `label (url)`
- mouse-wheel transcript scrolling
- muted `* Brewed for ...` completion rows

## Interfaces

### Rust

```toml
[workspace.package]
version = "0.0.1-alpha.10"
```

No Rust API or runtime behavior changes are introduced by this release commit itself; it only changes the workspace package version.

### stdin/stdout

```bash
gestalt --version
# gestalt 0.0.1-alpha.10
```

Release tag command after merge:

```bash
git tag -a gestalt/v0.0.1-alpha.10 <merge-sha> -m "gestalt v0.0.1-alpha.10"
git push origin gestalt/v0.0.1-alpha.10
```

The released TUI rendering changes from:

```text
You
  what are my linear tasks?

Assistant
  **Data Platform**
```

to:

```text
› what are my linear tasks?

● Data Platform
* Brewed for 1s
```

## Tests

- `cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name=="gestalt") | .version'`

No unit tests added. This is a release version bump; functional coverage for the TUI behavior is in #1488.
