### PR TITLE
Harden provider-dev remote attach transport

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -840,10 +840,15 @@ gestaltd provider dev --remote "$GESTALT_URL" --path ./slack
 ```
 
 The remote URL is environment-agnostic; it can point at any `gestaltd` instance
-that exposes provider-dev attach targets. The local command replaces only the
+that exposes provider-dev attach targets and has opted in with
+`server.providerDev.remoteAttach: true`. The local command replaces only the
 source plugin attached by your authenticated session. Providers that are not
 attached locally continue to run through the remote server and its existing
 configuration.
+Remote attach v1 is process-local. On a load-balanced remote, enable it only
+when the deployment is single-replica or sticky-routes attach creation, CLI
+poll/complete traffic, provider invocations, and provider-owned UI requests for
+the same authenticated owner to the same `gestaltd` process.
 Remote provider dev authenticates with `--remote-token` first, then
 `GESTALT_API_KEY`, then the stored CLI token from `gestalt auth login` when the
 stored credential's server base URL matches `--remote`. A stored credential for
@@ -851,6 +856,15 @@ a different server URL, including a different path prefix on the same host, is
 not sent; the command exits with the stored credential's server and file path
 plus commands to log in for the requested server or pass an explicit token. Use
 `--remote-token` or `GESTALT_API_KEY` for non-interactive automation.
+
+Remote attach creates an owner-scoped attachment. The server returns an
+`attachId` and a one-time dispatcher secret; the CLI uses both for local
+poll/complete traffic. Other users keep seeing the deployed provider and UI.
+Owner cleanup can detach a stuck attachment by `attachId`, but diagnostic
+list/get responses never expose dispatcher secrets, host-service env, plugin
+config, access tokens, or browser binding URLs.
+Attach creation currently uses the same provider access checks as normal
+provider use. A dedicated `provider_dev.attach` capability is planned separately.
 
 For `--remote --path` without `--config`, Gestalt matches the local manifest
 `source` to a configured plugin on the remote server. The remote plugin's

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -76,6 +76,12 @@ keeps its existing config-relative behavior for backward compatibility.
 `provider dev --remote` is environment-agnostic: the URL is just the remote
 `gestaltd` instance to attach to. The local command only replaces source-backed
 plugin implementations for the authenticated principal that created the session.
+The remote server must opt in with `server.providerDev.remoteAttach: true`;
+otherwise the command fails before local code is attached.
+Remote attach v1 is also process-local: only enable it on a single-replica
+server or behind sticky routing that keeps attach creation, CLI poll/complete
+traffic, provider invocations, and provider-owned UI requests for the same
+authenticated owner on the same `gestaltd` process.
 Authentication resolves in this order: `--remote-token`, `GESTALT_API_KEY`, then
 the stored CLI token from `gestalt auth login` when its recorded server base URL
 matches `--remote`. Stored CLI tokens are not sent to a different remote URL,
@@ -89,6 +95,13 @@ remote plugin's config. If multiple remote plugins share the same source, or the
 manifest has no source, pass `--name` to choose the configured remote plugin.
 All non-local plugins and remote host services continue to resolve through the
 remote instance.
+
+After the remote creates an attachment, the CLI uses the returned `attachId` plus
+a one-time dispatcher secret for poll/complete traffic. The dispatcher secret is
+not shown by list/get diagnostics and is not needed for owner cleanup detach.
+This version authorizes attach creation with the same provider access checks used
+by the remote server for the target plugin. A narrower `provider_dev.attach`
+capability is not implemented yet.
 
 When `--config` is present, source-backed plugin entries in the layered local
 config are treated as explicit local overrides. Their plugin config is sent to

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1066,6 +1066,32 @@ local manifest `source` to the remote configured plugin and preserves the
 remote plugin config; layered `--config` files are only needed for explicit
 local config overrides or multi-plugin attach sessions.
 
+Remote provider attach is disabled by default on servers. Enable it explicitly
+on shared remotes:
+
+```yaml
+server:
+  providerDev:
+    remoteAttach: true
+```
+
+The attach transport is private to the authenticated owner. The create response
+includes an `attachId` for addressing and a one-time dispatcher secret used only
+by the local CLI for poll/complete traffic. Owner diagnostic list/get routes
+return redacted attachment metadata and never return dispatcher secrets, runtime
+environment, host-service env, plugin config, access tokens, or browser binding
+URLs.
+
+Remote attach v1 stores attachments in the `gestaltd` process that accepted the
+create request. For load-balanced deployments, treat single-replica operation or
+sticky routing for attach creation, poll/complete traffic, provider invocations,
+and provider-owned UI requests as a hard prerequisite before enabling
+`remoteAttach`.
+
+Attach creation currently uses the same provider access checks as normal
+provider use. A dedicated `provider_dev.attach` action permission is planned
+separately and is not part of this transport contract.
+
 Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider`.
 
 <Tabs items={['Go', 'Python', 'Rust']}>

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -244,7 +244,14 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.CloseSession(context.Background(), session.ID) }()
+	attachID := strings.TrimSpace(session.AttachID)
+	if attachID == "" {
+		attachID = strings.TrimSpace(session.ID)
+	}
+	if attachID == "" {
+		return fmt.Errorf("remote provider dev did not return attachId")
+	}
+	defer func() { _ = client.CloseSession(context.Background(), attachID) }()
 
 	sessionProviders := make(map[string]providerdev.CreateSessionProvider, len(session.Providers))
 	for _, provider := range session.Providers {
@@ -289,12 +296,12 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 
 	slog.Info("provider dev attached",
 		"remote", strings.TrimRight(opts.Remote, "/"),
-		"session", session.ID,
+		"attachId", attachID,
 		"providers", providerRemoteTargetNames(targets),
 		"ui_providers", providerRemoteUIProviderNames(localUIHandlers),
 		"config_files", configPaths,
 	)
-	return client.RunDispatcher(ctx, session.ID, providerClients, providerdev.WithUIHandlers(localUIHandlers))
+	return client.RunDispatcher(ctx, attachID, providerClients, providerdev.WithUIHandlers(localUIHandlers))
 }
 
 func resolveProviderRemoteToken(opts providerLocalCommandOptions) (string, error) {

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -101,6 +101,7 @@ func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers
 			Source: strings.TrimSpace(entry.ResolvedManifest.Source),
 			Spec:   providerDevStaticSpecFromProvider(targetName, entry, provider),
 			Config: pluginConfig,
+			UIPath: strings.TrimSpace(entry.MountPath),
 			RuntimeEnv: func(sessionID string) (providerdev.RuntimeEnv, error) {
 				return buildProviderDevRuntimeEnv(targetName, targetEntry, deps, sessionID)
 			},

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1387,9 +1387,14 @@ type ServerConfig struct {
 	APITokenTTL   string                   `yaml:"apiTokenTtl"`
 	ArtifactsDir  string                   `yaml:"artifactsDir"`
 	Providers     ServerProvidersConfig    `yaml:"providers,omitempty"`
+	ProviderDev   ProviderDevConfig        `yaml:"providerDev,omitempty"`
 	Runtime       ServerRuntimeConfig      `yaml:"runtime,omitempty"`
 	Egress        EgressConfig             `yaml:"egress,omitempty"`
 	Admin         AdminConfig              `yaml:"admin,omitempty"`
+}
+
+type ProviderDevConfig struct {
+	RemoteAttach bool `yaml:"remoteAttach,omitempty"`
 }
 
 type ServerRuntimeConfig struct {

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -35,7 +37,10 @@ const (
 	DefaultSessionIdleTimeout = 2 * time.Minute
 	DefaultCallIdleTimeout    = 30 * time.Minute
 
-	PathSessions = "/api/v1/provider-dev/sessions"
+	HeaderDispatcherSecret = "X-Gestalt-Provider-Dev-Dispatcher"
+
+	PathAttachments = "/api/v1/provider-dev/attachments"
+	PathSessions    = "/api/v1/provider-dev/sessions"
 )
 
 type RuntimeEnv struct {
@@ -52,6 +57,7 @@ type Target struct {
 	Spec       providerhost.StaticProviderSpec
 	Config     map[string]any
 	UI         *AttachUI
+	UIPath     string
 	RuntimeEnv RuntimeEnvBuilder
 }
 
@@ -75,14 +81,34 @@ type AttachProvider struct {
 }
 
 type CreateSessionResponse struct {
-	ID        string                  `json:"id"`
-	Providers []CreateSessionProvider `json:"providers"`
+	ID               string                  `json:"id,omitempty"`
+	AttachID         string                  `json:"attachId,omitempty"`
+	DispatcherSecret string                  `json:"dispatcherSecret,omitempty"`
+	Providers        []CreateSessionProvider `json:"providers"`
 }
 
 type CreateSessionProvider struct {
 	Name         string            `json:"name"`
 	Env          map[string]string `json:"env,omitempty"`
 	AllowedHosts []string          `json:"allowedHosts,omitempty"`
+	Source       string            `json:"source,omitempty"`
+	UI           bool              `json:"ui,omitempty"`
+	UIPath       string            `json:"uiPath,omitempty"`
+}
+
+type AttachmentInfo struct {
+	AttachID           string                   `json:"attachId"`
+	CreatedAt          time.Time                `json:"createdAt"`
+	LastSeenAt         time.Time                `json:"lastSeenAt"`
+	IdleTimeoutSeconds int                      `json:"idleTimeoutSeconds"`
+	Providers          []AttachmentProviderInfo `json:"providers"`
+}
+
+type AttachmentProviderInfo struct {
+	Name   string `json:"name"`
+	Source string `json:"source,omitempty"`
+	UI     bool   `json:"ui,omitempty"`
+	UIPath string `json:"uiPath,omitempty"`
 }
 
 type AttachUI struct{}
@@ -119,15 +145,17 @@ type RPCError struct {
 }
 
 type Session struct {
-	id      string
-	owner   string
-	targets map[string]*attachedTarget
+	id                   string
+	dispatcherSecretHash string
+	owner                string
+	targets              map[string]*attachedTarget
 
 	mu        sync.Mutex
 	calls     chan *rpcCall
 	pending   map[string]*rpcCall
 	done      chan struct{}
 	closeDone chan struct{}
+	createdAt time.Time
 	lastSeen  time.Time
 	closeErr  error
 	closed    bool
@@ -210,19 +238,28 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "create provider dev session: %v", err)
 	}
+	dispatcherSecret, dispatcherSecretHash, err := newDispatcherSecret()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "create provider dev dispatcher secret: %v", err)
+	}
+	now := time.Now()
 	session := &Session{
-		id:        sessionID,
-		owner:     owner,
-		targets:   make(map[string]*attachedTarget, len(targets)),
-		calls:     make(chan *rpcCall, 128),
-		pending:   map[string]*rpcCall{},
-		done:      make(chan struct{}),
-		closeDone: make(chan struct{}),
-		lastSeen:  time.Now(),
+		id:                   sessionID,
+		dispatcherSecretHash: dispatcherSecretHash,
+		owner:                owner,
+		targets:              make(map[string]*attachedTarget, len(targets)),
+		calls:                make(chan *rpcCall, 128),
+		pending:              map[string]*rpcCall{},
+		done:                 make(chan struct{}),
+		closeDone:            make(chan struct{}),
+		createdAt:            now,
+		lastSeen:             now,
 	}
 	resp := &CreateSessionResponse{
-		ID:        sessionID,
-		Providers: make([]CreateSessionProvider, 0, len(targets)),
+		ID:               sessionID,
+		AttachID:         sessionID,
+		DispatcherSecret: dispatcherSecret,
+		Providers:        make([]CreateSessionProvider, 0, len(targets)),
 	}
 	cleanupOnError := true
 	defer func() {
@@ -248,6 +285,9 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 			Name:         target.Name,
 			Env:          cloneStringMap(runtimeEnv.Env),
 			AllowedHosts: slices.Clone(runtimeEnv.AllowedHosts),
+			Source:       target.Source,
+			UI:           target.UI != nil,
+			UIPath:       target.UIPath,
 		})
 	}
 
@@ -265,31 +305,46 @@ func (m *Manager) PollSession(ctx context.Context, p *principal.Principal, sessi
 	if err != nil {
 		return nil, false, err
 	}
-	session.touch()
+	return session.poll(ctx)
+}
+
+func (m *Manager) PollSessionWithDispatcherSecret(ctx context.Context, p *principal.Principal, sessionID, dispatcherSecret string) (*PollResponse, bool, error) {
+	session, err := m.sessionForPrincipal(p, sessionID)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := session.verifyDispatcherSecret(dispatcherSecret); err != nil {
+		return nil, false, err
+	}
+	return session.poll(ctx)
+}
+
+func (s *Session) poll(ctx context.Context) (*PollResponse, bool, error) {
+	s.touch()
 
 	for {
 		select {
-		case call := <-session.calls:
-			session.mu.Lock()
-			if session.closed {
-				session.mu.Unlock()
+		case call := <-s.calls:
+			s.mu.Lock()
+			if s.closed {
+				s.mu.Unlock()
 				return nil, false, status.Error(codes.NotFound, "provider dev session is closed")
 			}
 			if call.canceled {
-				session.mu.Unlock()
+				s.mu.Unlock()
 				continue
 			}
 			call.deliveredAt = time.Now()
-			session.pending[call.id] = call
-			session.lastSeen = call.deliveredAt
-			session.mu.Unlock()
+			s.pending[call.id] = call
+			s.lastSeen = call.deliveredAt
+			s.mu.Unlock()
 			return &PollResponse{
 				CallID:   call.id,
 				Provider: call.provider,
 				Method:   call.method,
 				Request:  hex.EncodeToString(call.request),
 			}, true, nil
-		case <-session.done:
+		case <-s.done:
 			return nil, false, status.Error(codes.NotFound, "provider dev session is closed")
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) {
@@ -383,18 +438,41 @@ func (m *Manager) CompleteCall(p *principal.Principal, sessionID, callID string,
 	if err != nil {
 		return err
 	}
-	session.touch()
+	return session.completeCall(callID, req)
+}
+
+func (m *Manager) CompleteCallWithDispatcherSecret(p *principal.Principal, sessionID, callID, dispatcherSecret string, req CompleteCallRequest) error {
+	session, err := m.sessionForPrincipal(p, sessionID)
+	if err != nil {
+		return err
+	}
+	if err := session.verifyDispatcherSecret(dispatcherSecret); err != nil {
+		return err
+	}
+	return session.completeCall(callID, req)
+}
+
+func (m *Manager) VerifyDispatcherSecret(p *principal.Principal, sessionID, dispatcherSecret string) error {
+	session, err := m.sessionForPrincipal(p, sessionID)
+	if err != nil {
+		return err
+	}
+	return session.verifyDispatcherSecret(dispatcherSecret)
+}
+
+func (s *Session) completeCall(callID string, req CompleteCallRequest) error {
+	s.touch()
 	callID = strings.TrimSpace(callID)
 	if callID == "" {
 		return status.Error(codes.InvalidArgument, "call id is required")
 	}
 
-	session.mu.Lock()
-	call, ok := session.pending[callID]
+	s.mu.Lock()
+	call, ok := s.pending[callID]
 	if ok {
-		delete(session.pending, callID)
+		delete(s.pending, callID)
 	}
-	session.mu.Unlock()
+	s.mu.Unlock()
 	if !ok {
 		return status.Errorf(codes.NotFound, "provider dev call %q not found", callID)
 	}
@@ -424,13 +502,50 @@ func (m *Manager) CompleteCall(p *principal.Principal, sessionID, callID string,
 
 	select {
 	case call.response <- resp:
-		session.touch()
+		s.touch()
 		return nil
-	case <-session.done:
+	case <-s.done:
 		return status.Error(codes.NotFound, "provider dev session is closed")
 	default:
 		return status.Error(codes.DeadlineExceeded, "provider dev caller is no longer waiting")
 	}
+}
+
+func (m *Manager) ListSessions(p *principal.Principal) ([]AttachmentInfo, error) {
+	owner := principalSubjectID(p)
+	if owner == "" {
+		return nil, status.Error(codes.Unauthenticated, "provider dev requires an authenticated principal")
+	}
+	if m == nil {
+		return nil, status.Error(codes.FailedPrecondition, "provider dev is not configured")
+	}
+	m.closeIdleSessions(time.Now())
+	m.mu.RLock()
+	sessionIDs := append([]string(nil), m.ownerIndex[owner]...)
+	sessions := make([]*Session, 0, len(sessionIDs))
+	for _, id := range sessionIDs {
+		if session := m.sessions[id]; session != nil {
+			sessions = append(sessions, session)
+		}
+	}
+	m.mu.RUnlock()
+	out := make([]AttachmentInfo, 0, len(sessions))
+	for _, session := range sessions {
+		if session == nil || session.isClosed() {
+			continue
+		}
+		out = append(out, session.attachmentInfo())
+	}
+	return out, nil
+}
+
+func (m *Manager) GetSession(p *principal.Principal, sessionID string) (*AttachmentInfo, error) {
+	session, err := m.sessionForPrincipal(p, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	info := session.attachmentInfo()
+	return &info, nil
 }
 
 func (m *Manager) CloseSession(p *principal.Principal, sessionID string) error {
@@ -667,6 +782,53 @@ func (s *Session) isClosed() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.closed
+}
+
+func (s *Session) verifyDispatcherSecret(secret string) error {
+	if s == nil {
+		return status.Error(codes.NotFound, "provider dev session not found")
+	}
+	secret = strings.TrimSpace(secret)
+	if secret == "" || s.dispatcherSecretHash == "" {
+		return status.Error(codes.Unauthenticated, "provider dev dispatcher secret is required")
+	}
+	if subtle.ConstantTimeCompare([]byte(hashDispatcherSecret(secret)), []byte(s.dispatcherSecretHash)) != 1 {
+		return status.Error(codes.PermissionDenied, "provider dev dispatcher secret is invalid")
+	}
+	return nil
+}
+
+func (s *Session) attachmentInfo() AttachmentInfo {
+	if s == nil {
+		return AttachmentInfo{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	providers := make([]AttachmentProviderInfo, 0, len(s.targets))
+	names := make([]string, 0, len(s.targets))
+	for name := range s.targets {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		target := s.targets[name]
+		if target == nil {
+			continue
+		}
+		providers = append(providers, AttachmentProviderInfo{
+			Name:   name,
+			Source: target.target.Source,
+			UI:     target.target.UI != nil,
+			UIPath: target.target.UIPath,
+		})
+	}
+	return AttachmentInfo{
+		AttachID:           s.id,
+		CreatedAt:          s.createdAt,
+		LastSeenAt:         s.lastSeen,
+		IdleTimeoutSeconds: int(DefaultSessionIdleTimeout / time.Second),
+		Providers:          providers,
+	}
 }
 
 func (s *Session) touch() {
@@ -936,9 +1098,10 @@ func (c *sessionProviderClient) PostConnect(ctx context.Context, req *proto.Post
 }
 
 type Client struct {
-	BaseURL    string
-	Token      string
-	HTTPClient *http.Client
+	BaseURL          string
+	Token            string
+	DispatcherSecret string
+	HTTPClient       *http.Client
 }
 
 type DispatcherOption func(*dispatcherConfig)
@@ -953,16 +1116,17 @@ func WithUIHandlers(handlers map[string]http.Handler) DispatcherOption {
 	}
 }
 
-func (c Client) CreateSession(ctx context.Context, req CreateSessionRequest) (*CreateSessionResponse, error) {
+func (c *Client) CreateSession(ctx context.Context, req CreateSessionRequest) (*CreateSessionResponse, error) {
 	var out CreateSessionResponse
-	if err := c.doJSON(ctx, http.MethodPost, PathSessions, req, &out); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, PathAttachments, req, &out); err != nil {
 		return nil, err
 	}
+	c.DispatcherSecret = out.DispatcherSecret
 	return &out, nil
 }
 
 func (c Client) Poll(ctx context.Context, sessionID string) (*PollResponse, bool, error) {
-	path := PathSessions + "/" + url.PathEscape(sessionID) + "/poll"
+	path := PathAttachments + "/" + url.PathEscape(sessionID) + "/poll"
 	var out PollResponse
 	statusCode, err := c.doJSONStatus(ctx, http.MethodGet, path, nil, &out)
 	if err != nil {
@@ -975,12 +1139,12 @@ func (c Client) Poll(ctx context.Context, sessionID string) (*PollResponse, bool
 }
 
 func (c Client) Complete(ctx context.Context, sessionID, callID string, req CompleteCallRequest) error {
-	path := PathSessions + "/" + url.PathEscape(sessionID) + "/calls/" + url.PathEscape(callID)
+	path := PathAttachments + "/" + url.PathEscape(sessionID) + "/calls/" + url.PathEscape(callID)
 	return c.doJSON(ctx, http.MethodPost, path, req, nil)
 }
 
 func (c Client) CloseSession(ctx context.Context, sessionID string) error {
-	path := PathSessions + "/" + url.PathEscape(sessionID)
+	path := PathAttachments + "/" + url.PathEscape(sessionID)
 	return c.doJSON(ctx, http.MethodDelete, path, nil, nil)
 }
 
@@ -1195,6 +1359,9 @@ func (c Client) doJSONStatus(ctx context.Context, method, path string, in any, o
 	}
 	if token := strings.TrimSpace(c.Token); token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if secret := strings.TrimSpace(c.DispatcherSecret); secret != "" {
+		req.Header.Set(HeaderDispatcherSecret, secret)
 	}
 	httpClient := c.HTTPClient
 	if httpClient == nil {
@@ -1449,4 +1616,18 @@ func randomID() (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(b[:]), nil
+}
+
+func newDispatcherSecret() (secret string, hash string, err error) {
+	id, err := randomID()
+	if err != nil {
+		return "", "", err
+	}
+	secret = "pda_" + id
+	return secret, hashDispatcherSecret(secret), nil
+}
+
+func hashDispatcherSecret(secret string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(secret)))
+	return hex.EncodeToString(sum[:])
 }

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -369,6 +370,122 @@ func TestHTTPTransportCreateSessionExplicitConfigOverridesRemoteConfig(t *testin
 	}
 }
 
+func TestHTTPTransportRequiresDispatcherSecretForDispatcherTraffic(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewManager([]Target{{Name: "roadmap"}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	ts := httptest.NewServer(providerDevTestHandler(t, manager, p))
+	t.Cleanup(ts.Close)
+
+	client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	session, err := client.CreateSession(context.Background(), CreateSessionRequest{Providers: []AttachProvider{{Name: "roadmap"}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if session.DispatcherSecret == "" {
+		t.Fatal("DispatcherSecret is empty")
+	}
+
+	pollReq, err := http.NewRequest(http.MethodGet, ts.URL+PathAttachments+"/"+session.ID+"/poll", nil)
+	if err != nil {
+		t.Fatalf("build poll request: %v", err)
+	}
+	pollResp, err := ts.Client().Do(pollReq)
+	if err != nil {
+		t.Fatalf("poll without dispatcher secret: %v", err)
+	}
+	_ = pollResp.Body.Close()
+	if pollResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("poll status = %d, want 401", pollResp.StatusCode)
+	}
+
+	completeReq, err := http.NewRequest(http.MethodPost, ts.URL+PathAttachments+"/"+session.ID+"/calls/call-1", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("build complete request: %v", err)
+	}
+	completeReq.Header.Set("Content-Type", "application/json")
+	completeResp, err := ts.Client().Do(completeReq)
+	if err != nil {
+		t.Fatalf("complete without dispatcher secret: %v", err)
+	}
+	_ = completeResp.Body.Close()
+	if completeResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("complete status = %d, want 401", completeResp.StatusCode)
+	}
+
+	closeReq, err := http.NewRequest(http.MethodDelete, ts.URL+PathAttachments+"/"+session.ID, nil)
+	if err != nil {
+		t.Fatalf("build close request: %v", err)
+	}
+	closeResp, err := ts.Client().Do(closeReq)
+	if err != nil {
+		t.Fatalf("close without dispatcher secret: %v", err)
+	}
+	_ = closeResp.Body.Close()
+	if closeResp.StatusCode != http.StatusOK {
+		t.Fatalf("close status = %d, want 200", closeResp.StatusCode)
+	}
+}
+
+func TestHTTPTransportListsRedactedAttachmentMetadata(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewManager([]Target{{
+		Name:   "roadmap",
+		Source: "github.com/acme/plugins/roadmap",
+		UIPath: "/roadmap",
+		RuntimeEnv: func(string) (RuntimeEnv, error) {
+			return RuntimeEnv{
+				Env:          map[string]string{"SECRET": "do-not-return"},
+				AllowedHosts: []string{"example.test"},
+			}, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	ts := httptest.NewServer(providerDevTestHandler(t, manager, p))
+	t.Cleanup(ts.Close)
+
+	client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	session, err := client.CreateSession(context.Background(), CreateSessionRequest{Providers: []AttachProvider{{
+		Name: "roadmap",
+		UI:   &AttachUI{},
+	}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	for _, path := range []string{PathAttachments, PathAttachments + "/" + session.ID} {
+		resp, err := ts.Client().Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		payload, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s status = %d, body = %s", path, resp.StatusCode, payload)
+		}
+		body := string(payload)
+		for _, forbidden := range []string{session.DispatcherSecret, "do-not-return", "allowedHosts", "SECRET"} {
+			if forbidden != "" && strings.Contains(body, forbidden) {
+				t.Fatalf("GET %s leaked %q in %s", path, forbidden, body)
+			}
+		}
+		if !strings.Contains(body, `"attachId":"`+session.ID+`"`) {
+			t.Fatalf("GET %s body missing attachId %q: %s", path, session.ID, body)
+		}
+	}
+}
+
 func TestCreateSessionRejectsAmbiguousProviderSource(t *testing.T) {
 	t.Parallel()
 
@@ -499,7 +616,7 @@ func TestSessionCloseReturnsSameErrorToConcurrentCallers(t *testing.T) {
 func providerDevTestHandler(t *testing.T, manager *Manager, p *principal.Principal) http.Handler {
 	t.Helper()
 	mux := http.NewServeMux()
-	mux.HandleFunc(PathSessions, func(w http.ResponseWriter, r *http.Request) {
+	handleCreate := func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.NotFound(w, r)
 			return
@@ -515,48 +632,77 @@ func providerDevTestHandler(t *testing.T, manager *Manager, p *principal.Princip
 			return
 		}
 		writeProviderDevTestJSON(w, http.StatusCreated, resp)
-	})
-	mux.HandleFunc(PathSessions+"/", func(w http.ResponseWriter, r *http.Request) {
-		rest := strings.TrimPrefix(r.URL.Path, PathSessions+"/")
-		parts := strings.Split(rest, "/")
-		if len(parts) == 2 && parts[1] == "poll" && r.Method == http.MethodGet {
-			ctx, cancel := context.WithTimeout(r.Context(), DefaultPollTimeout)
-			defer cancel()
-			resp, ok, err := manager.PollSession(ctx, p, parts[0])
+	}
+	mux.HandleFunc(PathSessions, handleCreate)
+	mux.HandleFunc(PathAttachments, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			handleCreate(w, r)
+		case http.MethodGet:
+			resp, err := manager.ListSessions(p)
 			if err != nil {
 				writeProviderDevTestError(w, err)
 				return
 			}
-			if !ok {
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-			writeProviderDevTestJSON(w, http.StatusOK, resp)
-			return
+			writeProviderDevTestJSON(w, http.StatusOK, map[string]any{"attachments": resp})
+		default:
+			http.NotFound(w, r)
 		}
-		if len(parts) == 3 && parts[1] == "calls" && r.Method == http.MethodPost {
-			var req CompleteCallRequest
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			if err := manager.CompleteCall(p, parts[0], parts[2], req); err != nil {
-				writeProviderDevTestError(w, err)
-				return
-			}
-			writeProviderDevTestJSON(w, http.StatusOK, map[string]string{"status": "ok"})
-			return
-		}
-		if len(parts) == 1 && r.Method == http.MethodDelete {
-			if err := manager.CloseSession(p, parts[0]); err != nil {
-				writeProviderDevTestError(w, err)
-				return
-			}
-			writeProviderDevTestJSON(w, http.StatusOK, map[string]string{"status": "closed"})
-			return
-		}
-		http.NotFound(w, r)
 	})
+	handleAttachment := func(basePath string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			rest := strings.TrimPrefix(r.URL.Path, basePath+"/")
+			parts := strings.Split(rest, "/")
+			if basePath == PathAttachments && len(parts) == 1 && r.Method == http.MethodGet {
+				resp, err := manager.GetSession(p, parts[0])
+				if err != nil {
+					writeProviderDevTestError(w, err)
+					return
+				}
+				writeProviderDevTestJSON(w, http.StatusOK, resp)
+				return
+			}
+			if len(parts) == 2 && parts[1] == "poll" && r.Method == http.MethodGet {
+				ctx, cancel := context.WithTimeout(r.Context(), DefaultPollTimeout)
+				defer cancel()
+				resp, ok, err := manager.PollSessionWithDispatcherSecret(ctx, p, parts[0], r.Header.Get(HeaderDispatcherSecret))
+				if err != nil {
+					writeProviderDevTestError(w, err)
+					return
+				}
+				if !ok {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+				writeProviderDevTestJSON(w, http.StatusOK, resp)
+				return
+			}
+			if len(parts) == 3 && parts[1] == "calls" && r.Method == http.MethodPost {
+				var req CompleteCallRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				if err := manager.CompleteCallWithDispatcherSecret(p, parts[0], parts[2], r.Header.Get(HeaderDispatcherSecret), req); err != nil {
+					writeProviderDevTestError(w, err)
+					return
+				}
+				writeProviderDevTestJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+				return
+			}
+			if len(parts) == 1 && r.Method == http.MethodDelete {
+				if err := manager.CloseSession(p, parts[0]); err != nil {
+					writeProviderDevTestError(w, err)
+					return
+				}
+				writeProviderDevTestJSON(w, http.StatusOK, map[string]string{"status": "closed"})
+				return
+			}
+			http.NotFound(w, r)
+		}
+	}
+	mux.HandleFunc(PathSessions+"/", handleAttachment(PathSessions))
+	mux.HandleFunc(PathAttachments+"/", handleAttachment(PathAttachments))
 	return mux
 }
 

--- a/gestaltd/internal/server/handlers_provider_dev.go
+++ b/gestaltd/internal/server/handlers_provider_dev.go
@@ -15,8 +15,7 @@ import (
 )
 
 func (s *Server) createProviderDevSession(w http.ResponseWriter, r *http.Request) {
-	if s.providerDevSessions == nil {
-		writeError(w, http.StatusNotFound, "provider dev is not configured")
+	if !s.providerDevAvailable(w) {
 		return
 	}
 	var req providerdev.CreateSessionRequest
@@ -34,6 +33,30 @@ func (s *Server) createProviderDevSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (s *Server) listProviderDevAttachments(w http.ResponseWriter, r *http.Request) {
+	if !s.providerDevAvailable(w) {
+		return
+	}
+	resp, err := s.providerDevSessions.ListSessions(PrincipalFromContext(r.Context()))
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"attachments": resp})
+}
+
+func (s *Server) getProviderDevAttachment(w http.ResponseWriter, r *http.Request) {
+	if !s.providerDevAvailable(w) {
+		return
+	}
+	resp, err := s.providerDevSessions.GetSession(PrincipalFromContext(r.Context()), providerDevAttachmentID(r))
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) authorizeProviderDevSessionRequest(w http.ResponseWriter, r *http.Request, p *principal.Principal, req providerdev.CreateSessionRequest) error {
@@ -59,14 +82,13 @@ func (s *Server) authorizeProviderDevSessionRequest(w http.ResponseWriter, r *ht
 }
 
 func (s *Server) pollProviderDevSession(w http.ResponseWriter, r *http.Request) {
-	if s.providerDevSessions == nil {
-		writeError(w, http.StatusNotFound, "provider dev is not configured")
+	if !s.providerDevAvailable(w) {
 		return
 	}
-	sessionID := chi.URLParam(r, "sessionID")
+	sessionID := providerDevAttachmentID(r)
 	ctx, cancel := context.WithTimeout(r.Context(), providerdev.DefaultPollTimeout)
 	defer cancel()
-	resp, ok, err := s.providerDevSessions.PollSession(ctx, PrincipalFromContext(r.Context()), sessionID)
+	resp, ok, err := s.providerDevSessions.PollSessionWithDispatcherSecret(ctx, PrincipalFromContext(r.Context()), sessionID, providerDevDispatcherSecret(r))
 	if err != nil {
 		writeProviderDevError(w, err)
 		return
@@ -79,8 +101,14 @@ func (s *Server) pollProviderDevSession(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) completeProviderDevCall(w http.ResponseWriter, r *http.Request) {
-	if s.providerDevSessions == nil {
-		writeError(w, http.StatusNotFound, "provider dev is not configured")
+	if !s.providerDevAvailable(w) {
+		return
+	}
+	p := PrincipalFromContext(r.Context())
+	sessionID := providerDevAttachmentID(r)
+	dispatcherSecret := providerDevDispatcherSecret(r)
+	if err := s.providerDevSessions.VerifyDispatcherSecret(p, sessionID, dispatcherSecret); err != nil {
+		writeProviderDevError(w, err)
 		return
 	}
 	var req providerdev.CompleteCallRequest
@@ -89,9 +117,9 @@ func (s *Server) completeProviderDevCall(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	err := s.providerDevSessions.CompleteCall(
-		PrincipalFromContext(r.Context()),
-		chi.URLParam(r, "sessionID"),
-		chi.URLParam(r, "callID"),
+		p,
+		sessionID,
+		providerDevCallID(r),
 		req,
 	)
 	if err != nil {
@@ -102,16 +130,49 @@ func (s *Server) completeProviderDevCall(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) closeProviderDevSession(w http.ResponseWriter, r *http.Request) {
-	if s.providerDevSessions == nil {
-		writeError(w, http.StatusNotFound, "provider dev is not configured")
+	if !s.providerDevAvailable(w) {
 		return
 	}
-	err := s.providerDevSessions.CloseSession(PrincipalFromContext(r.Context()), chi.URLParam(r, "sessionID"))
+	err := s.providerDevSessions.CloseSession(PrincipalFromContext(r.Context()), providerDevAttachmentID(r))
 	if err != nil {
 		writeProviderDevError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "closed"})
+}
+
+func (s *Server) providerDevAvailable(w http.ResponseWriter) bool {
+	if s.providerDevSessions == nil {
+		writeError(w, http.StatusNotFound, "provider dev is not configured")
+		return false
+	}
+	if !s.providerDevAttach {
+		writeError(w, http.StatusForbidden, "provider dev remote attach is disabled")
+		return false
+	}
+	if s.noAuth {
+		writeError(w, http.StatusForbidden, "provider dev remote attach requires server authentication")
+		return false
+	}
+	return true
+}
+
+func providerDevAttachmentID(r *http.Request) string {
+	if id := chi.URLParam(r, "attachmentID"); id != "" {
+		return id
+	}
+	return chi.URLParam(r, "sessionID")
+}
+
+func providerDevCallID(r *http.Request) string {
+	if id := chi.URLParam(r, "callID"); id != "" {
+		return id
+	}
+	return chi.URLParam(r, "call")
+}
+
+func providerDevDispatcherSecret(r *http.Request) string {
+	return r.Header.Get(providerdev.HeaderDispatcherSecret)
 }
 
 func writeProviderDevError(w http.ResponseWriter, err error) {

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -82,7 +82,10 @@ func isProviderDevCompleteCallRequest(r *http.Request) bool {
 	}
 	rest, ok := strings.CutPrefix(r.URL.Path, providerdev.PathSessions+"/")
 	if !ok {
-		return false
+		rest, ok = strings.CutPrefix(r.URL.Path, providerdev.PathAttachments+"/")
+		if !ok {
+			return false
+		}
 	}
 	sessionID, callID, ok := strings.Cut(rest, "/calls/")
 	return ok && sessionID != "" && callID != "" && !strings.Contains(sessionID, "/") && !strings.Contains(callID, "/")

--- a/gestaltd/internal/server/provider_dev_ui_test.go
+++ b/gestaltd/internal/server/provider_dev_ui_test.go
@@ -387,6 +387,13 @@ func TestMaxBodyMiddlewareAllowsLargeProviderDevCallCompletions(t *testing.T) {
 		t.Fatalf("provider dev completion status = %d, want %d", providerDevRec.Code, http.StatusNoContent)
 	}
 
+	providerDevAttachmentReq := httptest.NewRequest(http.MethodPost, "/api/v1/provider-dev/attachments/attach-1/calls/call-1", bytes.NewReader(largeBody))
+	providerDevAttachmentRec := httptest.NewRecorder()
+	handler.ServeHTTP(providerDevAttachmentRec, providerDevAttachmentReq)
+	if providerDevAttachmentRec.Code != http.StatusNoContent {
+		t.Fatalf("provider dev attachment completion status = %d, want %d", providerDevAttachmentRec.Code, http.StatusNoContent)
+	}
+
 	extraPathReq := httptest.NewRequest(http.MethodPost, "/api/v1/provider-dev/sessions/session-1/calls/call-1/extra", bytes.NewReader(largeBody))
 	extraPathRec := httptest.NewRecorder()
 	handler.ServeHTTP(extraPathRec, extraPathReq)

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -64,6 +64,12 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Get("/provider-dev/sessions/{sessionID}/poll", s.pollProviderDevSession)
 		r.Post("/provider-dev/sessions/{sessionID}/calls/{callID}", s.completeProviderDevCall)
 		r.Delete("/provider-dev/sessions/{sessionID}", s.closeProviderDevSession)
+		r.Post("/provider-dev/attachments", s.createProviderDevSession)
+		r.Get("/provider-dev/attachments", s.listProviderDevAttachments)
+		r.Get("/provider-dev/attachments/{attachmentID}", s.getProviderDevAttachment)
+		r.Get("/provider-dev/attachments/{attachmentID}/poll", s.pollProviderDevSession)
+		r.Post("/provider-dev/attachments/{attachmentID}/calls/{callID}", s.completeProviderDevCall)
+		r.Delete("/provider-dev/attachments/{attachmentID}", s.closeProviderDevSession)
 
 		r.Post("/tokens", s.createAPIToken)
 		r.Get("/tokens", s.listAPITokens)

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -107,6 +107,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		},
 		PrometheusMetrics:   result.Telemetry.PrometheusHandler(),
 		ProviderDevSessions: result.ProviderDevSessions,
+		ProviderDevAttach:   cfg.Server.ProviderDev.RemoteAttach,
 		PublicHostServices:  result.PublicHostServices,
 		Admin: AdminRouteConfig{
 			AuthorizationPolicy: cfg.Server.Admin.AuthorizationPolicy,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -121,6 +121,7 @@ type Server struct {
 	publicHostServices     *providerhost.PublicHostServiceRegistry
 	egressProxyTokens      *providerhost.EgressProxyTokenManager
 	providerDevSessions    *providerdev.Manager
+	providerDevAttach      bool
 	mountedHTTPBindings    []MountedHTTPBinding
 	mountedUIs             []MountedUI
 	adminRoute             AdminRouteConfig
@@ -167,6 +168,7 @@ type Config struct {
 	MCPHandler            http.Handler
 	PublicHostServices    *providerhost.PublicHostServiceRegistry
 	ProviderDevSessions   *providerdev.Manager
+	ProviderDevAttach     bool
 	MountedUIs            []MountedUI
 	Admin                 AdminRouteConfig
 	AdminUIProvider       string
@@ -340,6 +342,7 @@ func New(cfg Config) (*Server, error) {
 		publicHostServices:     cfg.PublicHostServices,
 		egressProxyTokens:      egressProxyTokens,
 		providerDevSessions:    cfg.ProviderDevSessions,
+		providerDevAttach:      cfg.ProviderDevAttach,
 		mountedHTTPBindings:    mountedHTTPBindings,
 		mountedUIs:             mountedUIs,
 		adminRoute:             adminRoute,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/runtimelogs"
@@ -5902,6 +5903,257 @@ func TestAuthMiddleware_ValidSession(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestProviderDevAttachmentRoutesEnforceGateDispatcherSecretAndRedaction(t *testing.T) {
+	t.Parallel()
+
+	newManager := func(t *testing.T) *providerdev.Manager {
+		t.Helper()
+		manager, err := providerdev.NewManager([]providerdev.Target{{
+			Name:   "roadmap",
+			Source: "github.com/acme/plugins/roadmap",
+			UIPath: "/roadmap",
+			RuntimeEnv: func(string) (providerdev.RuntimeEnv, error) {
+				return providerdev.RuntimeEnv{
+					Env:          map[string]string{"SECRET": "do-not-return"},
+					AllowedHosts: []string{"example.test"},
+				}, nil
+			},
+		}})
+		if err != nil {
+			t.Fatalf("NewManager: %v", err)
+		}
+		return manager
+	}
+	auth := &coretesting.StubAuthProvider{
+		N: "test",
+		ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+			switch token {
+			case "owner-session":
+				return &core.UserIdentity{Email: "owner@example.test"}, nil
+			case "other-session":
+				return &core.UserIdentity{Email: "other@example.test"}, nil
+			default:
+				return nil, principal.ErrInvalidToken
+			}
+		},
+	}
+	createBody := []byte(`{"providers":[{"name":"roadmap","ui":{}}]}`)
+
+	disabledTS := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = auth
+		cfg.ProviderDevSessions = newManager(t)
+	})
+	testutil.CloseOnCleanup(t, disabledTS)
+	req, err := http.NewRequest(http.MethodPost, disabledTS.URL+providerdev.PathAttachments, bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("new disabled request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer owner-session")
+	resp, err := disabledTS.Client().Do(req)
+	if err != nil {
+		t.Fatalf("disabled create request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("disabled create status = %d, want 403", resp.StatusCode)
+	}
+
+	noAuthTS := newTestServer(t, func(cfg *server.Config) {
+		cfg.ProviderDevAttach = true
+		cfg.ProviderDevSessions = newManager(t)
+	})
+	testutil.CloseOnCleanup(t, noAuthTS)
+	resp, err = noAuthTS.Client().Post(noAuthTS.URL+providerdev.PathAttachments, "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("no-auth create request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("no-auth create status = %d, want 403", resp.StatusCode)
+	}
+
+	enabledTS := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = auth
+		cfg.ProviderDevAttach = true
+		cfg.ProviderDevSessions = newManager(t)
+	})
+	testutil.CloseOnCleanup(t, enabledTS)
+	req, err = http.NewRequest(http.MethodPost, enabledTS.URL+providerdev.PathAttachments, bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("new enabled request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer owner-session")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = enabledTS.Client().Do(req)
+	if err != nil {
+		t.Fatalf("enabled create request: %v", err)
+	}
+	payload, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read create response: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("enabled create status = %d, want 201; body = %s", resp.StatusCode, payload)
+	}
+	var created providerdev.CreateSessionResponse
+	if err := json.Unmarshal(payload, &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.AttachID == "" || created.DispatcherSecret == "" {
+		t.Fatalf("create response missing attachId or dispatcherSecret: %s", payload)
+	}
+
+	completeReq, err := http.NewRequest(http.MethodPost, enabledTS.URL+providerdev.PathAttachments+"/"+created.AttachID+"/calls/call-1", strings.NewReader("not-json"))
+	if err != nil {
+		t.Fatalf("new complete request: %v", err)
+	}
+	completeReq.Header.Set("Authorization", "Bearer owner-session")
+	completeResp, err := enabledTS.Client().Do(completeReq)
+	if err != nil {
+		t.Fatalf("complete without dispatcher secret: %v", err)
+	}
+	_ = completeResp.Body.Close()
+	if completeResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("complete without dispatcher secret status = %d, want 401", completeResp.StatusCode)
+	}
+
+	legacyCompleteReq, err := http.NewRequest(http.MethodPost, enabledTS.URL+providerdev.PathSessions+"/"+created.AttachID+"/calls/call-1", strings.NewReader("not-json"))
+	if err != nil {
+		t.Fatalf("new legacy complete request: %v", err)
+	}
+	legacyCompleteReq.Header.Set("Authorization", "Bearer owner-session")
+	legacyCompleteResp, err := enabledTS.Client().Do(legacyCompleteReq)
+	if err != nil {
+		t.Fatalf("legacy complete without dispatcher secret: %v", err)
+	}
+	_ = legacyCompleteResp.Body.Close()
+	if legacyCompleteResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("legacy complete without dispatcher secret status = %d, want 401", legacyCompleteResp.StatusCode)
+	}
+
+	pollReq, err := http.NewRequest(http.MethodGet, enabledTS.URL+providerdev.PathAttachments+"/"+created.AttachID+"/poll", nil)
+	if err != nil {
+		t.Fatalf("new poll request: %v", err)
+	}
+	pollReq.Header.Set("Authorization", "Bearer owner-session")
+	pollResp, err := enabledTS.Client().Do(pollReq)
+	if err != nil {
+		t.Fatalf("poll without dispatcher secret: %v", err)
+	}
+	_ = pollResp.Body.Close()
+	if pollResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("poll without dispatcher secret status = %d, want 401", pollResp.StatusCode)
+	}
+
+	legacyPollReq, err := http.NewRequest(http.MethodGet, enabledTS.URL+providerdev.PathSessions+"/"+created.AttachID+"/poll", nil)
+	if err != nil {
+		t.Fatalf("new legacy poll request: %v", err)
+	}
+	legacyPollReq.Header.Set("Authorization", "Bearer owner-session")
+	legacyPollResp, err := enabledTS.Client().Do(legacyPollReq)
+	if err != nil {
+		t.Fatalf("legacy poll without dispatcher secret: %v", err)
+	}
+	_ = legacyPollResp.Body.Close()
+	if legacyPollResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("legacy poll without dispatcher secret status = %d, want 401", legacyPollResp.StatusCode)
+	}
+
+	invalidPollReq, err := http.NewRequest(http.MethodGet, enabledTS.URL+providerdev.PathAttachments+"/"+created.AttachID+"/poll", nil)
+	if err != nil {
+		t.Fatalf("new invalid-secret poll request: %v", err)
+	}
+	invalidPollReq.Header.Set("Authorization", "Bearer owner-session")
+	invalidPollReq.Header.Set(providerdev.HeaderDispatcherSecret, "wrong")
+	invalidPollResp, err := enabledTS.Client().Do(invalidPollReq)
+	if err != nil {
+		t.Fatalf("poll with invalid dispatcher secret: %v", err)
+	}
+	_ = invalidPollResp.Body.Close()
+	if invalidPollResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("poll with invalid dispatcher secret status = %d, want 403", invalidPollResp.StatusCode)
+	}
+
+	for _, path := range []string{providerdev.PathAttachments, providerdev.PathAttachments + "/" + created.AttachID} {
+		req, err = http.NewRequest(http.MethodGet, enabledTS.URL+path, nil)
+		if err != nil {
+			t.Fatalf("new GET %s request: %v", path, err)
+		}
+		req.Header.Set("Authorization", "Bearer owner-session")
+		resp, err = enabledTS.Client().Do(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		payload, err = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			t.Fatalf("read GET %s response: %v", path, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s status = %d, want 200; body = %s", path, resp.StatusCode, payload)
+		}
+		body := string(payload)
+		if !strings.Contains(body, created.AttachID) {
+			t.Fatalf("GET %s response missing attachId %q: %s", path, created.AttachID, body)
+		}
+		for _, forbidden := range []string{created.DispatcherSecret, "do-not-return", "allowedHosts", "SECRET"} {
+			if forbidden != "" && strings.Contains(body, forbidden) {
+				t.Fatalf("GET %s leaked %q in %s", path, forbidden, body)
+			}
+		}
+	}
+
+	req, err = http.NewRequest(http.MethodGet, enabledTS.URL+providerdev.PathAttachments, nil)
+	if err != nil {
+		t.Fatalf("new other list request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer other-session")
+	resp, err = enabledTS.Client().Do(req)
+	if err != nil {
+		t.Fatalf("other list request: %v", err)
+	}
+	payload, err = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read other list response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("other list status = %d, want 200; body = %s", resp.StatusCode, payload)
+	}
+	if strings.Contains(string(payload), created.AttachID) {
+		t.Fatalf("other principal list leaked attachId %q: %s", created.AttachID, payload)
+	}
+
+	req, err = http.NewRequest(http.MethodGet, enabledTS.URL+providerdev.PathAttachments+"/"+created.AttachID, nil)
+	if err != nil {
+		t.Fatalf("new other get request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer other-session")
+	resp, err = enabledTS.Client().Do(req)
+	if err != nil {
+		t.Fatalf("other get request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("other get status = %d, want 403", resp.StatusCode)
+	}
+
+	req, err = http.NewRequest(http.MethodDelete, enabledTS.URL+providerdev.PathAttachments+"/"+created.AttachID, nil)
+	if err != nil {
+		t.Fatalf("new delete request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer owner-session")
+	resp, err = enabledTS.Client().Do(req)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete status = %d, want 200", resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds a default-off `server.providerDev.remoteAttach` gate and rejects remote attach when the server is running with `auth: none`.
- Adds `/api/v1/provider-dev/attachments` as the public attach route family with `attachId`, one-time `dispatcherSecret`, and redacted owner-scoped diagnostics.
- Requires `X-Gestalt-Provider-Dev-Dispatcher` for poll/complete traffic on both `/attachments` and retained `/sessions` dispatcher aliases.
- Keeps owner-authenticated detach cleanup free of the dispatcher secret so owners can clean up stuck attachments.
- Updates `gestaltd provider dev --remote` to use `attachId` as the primary attachment identifier, with `id` as a response-shape fallback only for `/attachments` responses.
- Documents the server opt-in, attach transport contract, process-local/sticky-routing prerequisite, current auth behavior, and redaction guarantees.

## Interfaces
```yaml
server:
  providerDev:
    remoteAttach: true
```

```http
POST /api/v1/provider-dev/attachments
GET /api/v1/provider-dev/attachments
GET /api/v1/provider-dev/attachments/{attachId}
GET /api/v1/provider-dev/attachments/{attachId}/poll
POST /api/v1/provider-dev/attachments/{attachId}/calls/{callId}
DELETE /api/v1/provider-dev/attachments/{attachId}
X-Gestalt-Provider-Dev-Dispatcher: pda_...
```

```bash
gestaltd provider dev --remote https://valon.tools --path ./slack
```

Create responses include `attachId`, `dispatcherSecret`, and provider runtime env. List/get diagnostics intentionally omit dispatcher secrets, host-service env, plugin config, runtime env, access tokens, and browser-binding URLs.

## Explicit Non-Goals / Follow-Ups
- Attach creation still uses existing provider access checks. A dedicated `provider_dev.attach` capability requires the separate action-permission/token follow-up.
- Attachments are process-local in v1. Load-balanced deployments must use single-replica operation or sticky routing until a shared relay/session store exists.
- The `id` fallback is not old-server route compatibility; new clients use `/attachments`, not old `/sessions`-only servers.

## Review Feedback Applied
- Dispatcher secret is checked before decoding complete-call bodies.
- CLI uses `attachId` first instead of relying on legacy `id`.
- Added routed HTTP coverage for disabled gate, no-auth rejection, legacy alias secret enforcement, missing/invalid dispatcher secrets, redacted list/get, owner isolation, and owner cleanup.
- Clarified process-local deployment requirements and current provider-access attach authorization in docs.

## Tests
- `go test ./internal/providerdev ./internal/server ./internal/config ./cmd/gestaltd`
- `golangci-lint run ./internal/providerdev ./internal/server ./internal/config ./cmd/gestaltd`