### PR TITLE
workflow: remove legacy execution ref target matching

### DIFF
--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -311,28 +311,10 @@ type Host interface {
 }
 
 func TargetFingerprint(target Target) (string, error) {
-	return canonicalTargetFingerprint(target)
-}
-
-// TargetFingerprintMatches reports whether fingerprint matches the canonical
-// target fingerprint or a legacy fingerprint written before target nesting.
-func TargetFingerprintMatches(target Target, fingerprint string) (bool, error) {
-	fingerprint = strings.TrimSpace(fingerprint)
-	if fingerprint == "" {
-		return false, nil
+	if target.Agent != nil && target.Plugin != nil && PluginTargetSet(*target.Plugin) {
+		return "", fmt.Errorf("target cannot include both agent and plugin fields")
 	}
-	canonical, err := TargetFingerprint(target)
-	if err != nil {
-		return false, err
-	}
-	if canonical == fingerprint {
-		return true, nil
-	}
-	legacy, err := legacyTargetFingerprint(target)
-	if err != nil {
-		return false, err
-	}
-	return legacy == fingerprint, nil
+	return targetFingerprint(normalizedTargetFingerprintPayload(target))
 }
 
 func targetFingerprint(payload any) (string, error) {
@@ -347,13 +329,6 @@ func targetFingerprint(payload any) (string, error) {
 type targetFingerprintPayload struct {
 	Plugin *PluginTarget
 	Agent  *AgentTarget
-}
-
-func canonicalTargetFingerprint(target Target) (string, error) {
-	if target.Agent != nil && target.Plugin != nil && PluginTargetSet(*target.Plugin) {
-		return "", fmt.Errorf("target cannot include both agent and plugin fields")
-	}
-	return targetFingerprint(normalizedTargetFingerprintPayload(target))
 }
 
 func normalizedTargetFingerprintPayload(target Target) targetFingerprintPayload {
@@ -386,28 +361,6 @@ func normalizedTargetFingerprintPayload(target Target) targetFingerprintPayload 
 		out.Plugin = &pluginTarget
 	}
 	return out
-}
-
-func legacyTargetFingerprint(target Target) (string, error) {
-	if target.Agent != nil && target.Plugin != nil && PluginTargetSet(*target.Plugin) {
-		return "", fmt.Errorf("target cannot include both agent and plugin fields")
-	}
-	normalized := normalizedTargetFingerprintPayload(target)
-	payload := legacyTargetFingerprintPayload{
-		Plugin: normalized.Plugin,
-		Agent:  normalized.Agent,
-	}
-	return targetFingerprint(payload)
-}
-
-type legacyTargetFingerprintPayload struct {
-	PluginName string
-	Operation  string
-	Connection string
-	Instance   string
-	Input      map[string]any
-	Plugin     *PluginTarget
-	Agent      *AgentTarget
 }
 
 // PluginTargetSet reports whether a workflow target contains any plugin target field.

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1351,6 +1351,13 @@ func (p *recordingWorkflowProvider) PutExecutionReference(_ context.Context, ref
 		p.executionRefs = map[string]*coreworkflow.ExecutionReference{}
 	}
 	stored := cloneBootstrapWorkflowExecutionRef(ref)
+	if strings.TrimSpace(stored.TargetFingerprint) == "" {
+		fingerprint, err := coreworkflow.TargetFingerprint(stored.Target)
+		if err != nil {
+			return nil, err
+		}
+		stored.TargetFingerprint = fingerprint
+	}
 	p.executionRefs[stored.ID] = stored
 	return cloneBootstrapWorkflowExecutionRef(stored), nil
 }
@@ -4701,6 +4708,67 @@ func TestBootstrapReusesConfiguredWorkflowExecutionRefAcrossUnchangedBootstrap(t
 	}
 	if ref.RevokedAt != nil {
 		t.Fatalf("revokedAt = %#v, want nil", ref.RevokedAt)
+	}
+}
+
+func TestBootstrapRefreshesConfiguredWorkflowExecutionRefWhenFingerprintMissing(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	provider := &recordingWorkflowProvider{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return provider, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		Schedules: map[string]workflowFixtureSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	})
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	initialExecutionRef := provider.upsertedSchedules[0].ExecutionRef
+	_ = result.Close(context.Background())
+	provider.executionRefs[initialExecutionRef].TargetFingerprint = ""
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap replay: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	refreshedExecutionRef := provider.upsertedSchedules[1].ExecutionRef
+	if refreshedExecutionRef == initialExecutionRef {
+		t.Fatalf("execution ref = %q, want refreshed ref after missing target fingerprint", refreshedExecutionRef)
+	}
+	oldRef, err := provider.GetExecutionReference(context.Background(), initialExecutionRef)
+	if err != nil {
+		t.Fatalf("Get old execution ref: %v", err)
+	}
+	if oldRef.RevokedAt == nil {
+		t.Fatal("old execution ref revokedAt = nil, want revoked")
+	}
+	newRef, err := provider.GetExecutionReference(context.Background(), refreshedExecutionRef)
+	if err != nil {
+		t.Fatalf("Get refreshed execution ref: %v", err)
+	}
+	if strings.TrimSpace(newRef.TargetFingerprint) == "" {
+		t.Fatal("refreshed execution ref target fingerprint is empty")
 	}
 }
 

--- a/gestaltd/internal/bootstrap/startup_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_proxy.go
@@ -555,6 +555,13 @@ func (p *startupWorkflowProviderProxy) PutExecutionReference(ctx context.Context
 		if stored == nil || strings.TrimSpace(stored.ID) == "" {
 			return nil, fmt.Errorf("workflow execution reference id is required")
 		}
+		if strings.TrimSpace(stored.TargetFingerprint) == "" {
+			fingerprint, err := coreworkflow.TargetFingerprint(stored.Target)
+			if err != nil {
+				return nil, fmt.Errorf("workflow execution reference target fingerprint: %w", err)
+			}
+			stored.TargetFingerprint = fingerprint
+		}
 		p.mu.Lock()
 		p.pendingExecutionRefs[stored.ID] = stored
 		p.mu.Unlock()

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -486,6 +486,9 @@ func workflowConfigExecutionRefMatches(existing, desired *coreworkflow.Execution
 	if strings.TrimSpace(existing.AuthSource) != strings.TrimSpace(desired.AuthSource) {
 		return false
 	}
+	if strings.TrimSpace(existing.TargetFingerprint) != strings.TrimSpace(desired.TargetFingerprint) {
+		return false
+	}
 	if !workflowTargetsEqual(existing.Target, desired.Target) {
 		return false
 	}

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -285,28 +285,15 @@ func (r *workflowRuntime) resolveWorkflowExecutionRef(ctx context.Context, req c
 	if strings.TrimSpace(ref.ProviderName) != strings.TrimSpace(req.ProviderName) {
 		return nil, fmt.Errorf("%w: workflow execution ref %q is not valid for provider %q", invocation.ErrAuthorizationDenied, refID, req.ProviderName)
 	}
-	if strings.TrimSpace(ref.TargetFingerprint) != "" {
-		matches, err := coreworkflow.TargetFingerprintMatches(req.Target, ref.TargetFingerprint)
-		if err != nil {
-			return nil, fmt.Errorf("%w: workflow execution ref %q target fingerprint failed: %v", invocation.ErrInternal, refID, err)
-		}
-		if !matches {
-			return nil, fmt.Errorf("%w: workflow execution ref %q target does not match the scheduled invocation", invocation.ErrAuthorizationDenied, refID)
-		}
-		return ref, nil
+	refFingerprint := strings.TrimSpace(ref.TargetFingerprint)
+	if refFingerprint == "" {
+		return nil, fmt.Errorf("%w: workflow execution ref %q target fingerprint is required", invocation.ErrAuthorizationDenied, refID)
 	}
-	if ref.Target.Agent != nil || req.Target.Agent != nil {
-		return nil, fmt.Errorf("%w: workflow execution ref %q target fingerprint is required for agent targets", invocation.ErrAuthorizationDenied, refID)
+	targetFingerprint, err := coreworkflow.TargetFingerprint(req.Target)
+	if err != nil {
+		return nil, fmt.Errorf("%w: workflow execution ref %q target fingerprint failed: %v", invocation.ErrInternal, refID, err)
 	}
-	if ref.Target.Plugin == nil || req.Target.Plugin == nil {
-		return nil, fmt.Errorf("%w: workflow execution ref %q target does not match the scheduled invocation", invocation.ErrAuthorizationDenied, refID)
-	}
-	left := *ref.Target.Plugin
-	right := *req.Target.Plugin
-	if strings.TrimSpace(left.PluginName) != strings.TrimSpace(right.PluginName) ||
-		strings.TrimSpace(left.Operation) != strings.TrimSpace(right.Operation) ||
-		strings.TrimSpace(left.Connection) != strings.TrimSpace(right.Connection) ||
-		strings.TrimSpace(left.Instance) != strings.TrimSpace(right.Instance) {
+	if targetFingerprint != refFingerprint {
 		return nil, fmt.Errorf("%w: workflow execution ref %q target does not match the scheduled invocation", invocation.ErrAuthorizationDenied, refID)
 	}
 	return ref, nil

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -51,8 +51,6 @@ func testWorkflowPluginTargetWithInput(pluginName, operation, connection, instan
 const (
 	canonicalAgentWorkflowTargetFingerprint  = "df7c3d7dde92c5807d3268e17d2e2996163442f06624d003c7008e35be508b63"
 	canonicalPluginWorkflowTargetFingerprint = "ba910105b28aa331501c9ec3c34de4c0b67ff58204e0ec4a428122c089bb64a7"
-	legacyAgentWorkflowTargetFingerprint     = "35e6581a2588dfe3a3885a9e6a98f83fd8444d1408fb22d5d0df08e6811b2c5c"
-	legacyPluginWorkflowTargetFingerprint    = "0df33294a540a423e6f3982c190e54505f0415c7856cc3389eb13042415e8796"
 )
 
 func (f funcInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
@@ -77,6 +75,13 @@ func (p *workflowRuntimeExecutionRefProvider) PutExecutionReference(_ context.Co
 		p.refs = map[string]*coreworkflow.ExecutionReference{}
 	}
 	stored := cloneRuntimeExecutionRef(ref)
+	if strings.TrimSpace(stored.TargetFingerprint) == "" {
+		fingerprint, err := coreworkflow.TargetFingerprint(stored.Target)
+		if err != nil {
+			return nil, err
+		}
+		stored.TargetFingerprint = fingerprint
+	}
 	p.refs[stored.ID] = stored
 	return cloneRuntimeExecutionRef(stored), nil
 }
@@ -519,7 +524,7 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 	}
 }
 
-func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefAcceptsStoredFingerprints(t *testing.T) {
+func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefAcceptsCanonicalFingerprint(t *testing.T) {
 	t.Parallel()
 
 	target := coreworkflow.Target{
@@ -531,67 +536,54 @@ func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefAcceptsStoredFingerprin
 			TimeoutSeconds: 5,
 		},
 	}
-	for _, tt := range []struct {
-		name        string
-		fingerprint string
-	}{
-		{name: "legacy", fingerprint: legacyAgentWorkflowTargetFingerprint},
-		{name: "canonical", fingerprint: canonicalAgentWorkflowTargetFingerprint},
-	} {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	refProvider := newWorkflowRuntimeExecutionRefProvider()
+	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+		ID:                "agent-ref",
+		ProviderName:      "temporal",
+		Target:            target,
+		TargetFingerprint: canonicalAgentWorkflowTargetFingerprint,
+		CallerPluginName:  "slack",
+		SubjectID:         "service_account:scheduler",
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+	agentManager := &workflowRuntimeAgentManagerStub{}
+	runtime := &workflowRuntime{
+		providers: map[string]coreworkflow.Provider{"temporal": refProvider},
+	}
+	runtime.SetAgentManager(agentManager)
 
-			refProvider := newWorkflowRuntimeExecutionRefProvider()
-			if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-				ID:                "agent-ref-" + tt.name,
-				ProviderName:      "temporal",
-				Target:            target,
-				TargetFingerprint: tt.fingerprint,
-				CallerPluginName:  "slack",
-				SubjectID:         "service_account:scheduler",
-			}); err != nil {
-				t.Fatalf("Put execution ref: %v", err)
-			}
-			agentManager := &workflowRuntimeAgentManagerStub{}
-			runtime := &workflowRuntime{
-				providers: map[string]coreworkflow.Provider{"temporal": refProvider},
-			}
-			runtime.SetAgentManager(agentManager)
-
-			resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
-				ProviderName: "temporal",
-				ExecutionRef: "agent-ref-" + tt.name,
-				RunID:        "run-agent-123",
-				Target:       target,
-				Signals: []coreworkflow.Signal{{
-					ID:             "sig-1",
-					Name:           "slack.message",
-					Payload:        map[string]any{"text": "new message"},
-					IdempotencyKey: "evt-1",
-					Sequence:       42,
-				}},
-			})
-			if err != nil {
-				t.Fatalf("Invoke: %v", err)
-			}
-			if resp.Status != http.StatusOK || resp.Body != "turn completed" {
-				t.Fatalf("response = %#v", resp)
-			}
-			if len(agentManager.createTurnRequests) != 1 {
-				t.Fatalf("turn requests = %d, want 1", len(agentManager.createTurnRequests))
-			}
-			turnReq := agentManager.createTurnRequests[0]
-			if turnReq.CallerPluginName != "slack" {
-				t.Fatalf("caller plugin = %q, want slack", turnReq.CallerPluginName)
-			}
-			if !strings.HasPrefix(turnReq.IdempotencyKey, "workflow:temporal:run-agent-123:turn:signal-batch-") {
-				t.Fatalf("turn idempotency key = %q", turnReq.IdempotencyKey)
-			}
-			if len(turnReq.Messages) != 2 || turnReq.Messages[0].Text != "Send the status summary" || !strings.Contains(turnReq.Messages[1].Text, `"name": "slack.message"`) {
-				t.Fatalf("turn messages = %#v", turnReq.Messages)
-			}
-		})
+	resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		ExecutionRef: "agent-ref",
+		RunID:        "run-agent-123",
+		Target:       target,
+		Signals: []coreworkflow.Signal{{
+			ID:             "sig-1",
+			Name:           "slack.message",
+			Payload:        map[string]any{"text": "new message"},
+			IdempotencyKey: "evt-1",
+			Sequence:       42,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != http.StatusOK || resp.Body != "turn completed" {
+		t.Fatalf("response = %#v", resp)
+	}
+	if len(agentManager.createTurnRequests) != 1 {
+		t.Fatalf("turn requests = %d, want 1", len(agentManager.createTurnRequests))
+	}
+	turnReq := agentManager.createTurnRequests[0]
+	if turnReq.CallerPluginName != "slack" {
+		t.Fatalf("caller plugin = %q, want slack", turnReq.CallerPluginName)
+	}
+	if !strings.HasPrefix(turnReq.IdempotencyKey, "workflow:temporal:run-agent-123:turn:signal-batch-") {
+		t.Fatalf("turn idempotency key = %q", turnReq.IdempotencyKey)
+	}
+	if len(turnReq.Messages) != 2 || turnReq.Messages[0].Text != "Send the status summary" || !strings.Contains(turnReq.Messages[1].Text, `"name": "slack.message"`) {
+		t.Fatalf("turn messages = %#v", turnReq.Messages)
 	}
 }
 
@@ -660,35 +652,58 @@ func TestWorkflowRuntimeRejectsMixedAgentPluginTargetWithExecutionRef(t *testing
 	}
 }
 
-func TestWorkflowRuntimeRejectsAgentExecutionRefWithoutFingerprint(t *testing.T) {
+func TestWorkflowRuntimeRejectsExecutionRefWithoutFingerprint(t *testing.T) {
 	t.Parallel()
 
-	refProvider := newWorkflowRuntimeExecutionRefProvider()
-	target := coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
-		ProviderName: "managed",
-		Prompt:       "send reminder",
-		ToolSource:   coreagent.ToolSourceModeNativeSearch,
-	}}
-	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "agent-ref-without-fingerprint",
-		ProviderName: "temporal",
-		Target:       target,
-		SubjectID:    "service_account:scheduler",
-	}); err != nil {
-		t.Fatalf("Put execution ref: %v", err)
-	}
+	for _, tt := range []struct {
+		name   string
+		target coreworkflow.Target
+	}{
+		{name: "plugin", target: testWorkflowPluginTarget("roadmap", "sync")},
+		{name: "agent", target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "managed",
+			Prompt:       "send reminder",
+			ToolSource:   coreagent.ToolSourceModeNativeSearch,
+		}}},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	runtime := &workflowRuntime{
-		providers: map[string]coreworkflow.Provider{"temporal": refProvider},
-	}
-	_, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
-		ProviderName: "temporal",
-		ExecutionRef: "agent-ref-without-fingerprint",
-		RunID:        "run-123",
-		Target:       target,
-	})
-	if err == nil {
-		t.Fatal("Invoke agent target without execution-ref fingerprint succeeded, want error")
+			refProvider := newWorkflowRuntimeExecutionRefProvider()
+			refID := tt.name + "-ref-without-fingerprint"
+			refProvider.refs[refID] = &coreworkflow.ExecutionReference{
+				ID:           refID,
+				ProviderName: "temporal",
+				Target:       tt.target,
+				SubjectID:    "service_account:scheduler",
+			}
+
+			runtime := &workflowRuntime{
+				providers: map[string]coreworkflow.Provider{"temporal": refProvider},
+			}
+			if tt.target.Agent != nil {
+				runtime.SetAgentManager(&workflowRuntimeAgentManagerStub{})
+			} else {
+				runtime.SetInvoker(funcInvoker{
+					invoke: func(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+						return &core.OperationResult{Status: http.StatusAccepted, Body: `{"ok":true}`}, nil
+					},
+				})
+			}
+			_, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+				ProviderName: "temporal",
+				ExecutionRef: refID,
+				RunID:        "run-123",
+				Target:       tt.target,
+			})
+			if err == nil {
+				t.Fatal("Invoke target without execution-ref fingerprint succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), "target fingerprint is required") {
+				t.Fatalf("error = %v, want target fingerprint is required", err)
+			}
+		})
 	}
 }
 
@@ -704,7 +719,7 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
 		ID:                  "exec-ref-123",
 		ProviderName:        "temporal",
-		Target:              testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", nil),
+		Target:              testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", map[string]any{"mode": "full"}),
 		SubjectID:           principal.UserSubjectID(user.ID),
 		SubjectKind:         string(principal.KindUser),
 		DisplayName:         "Ada Lovelace",
@@ -783,59 +798,45 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 func TestWorkflowRuntimeInvokeExecutionRefUsesStoredSubjectPrincipal(t *testing.T) {
 	t.Parallel()
 
-	for _, tt := range []struct {
-		name        string
-		fingerprint string
-	}{
-		{name: "legacy", fingerprint: legacyPluginWorkflowTargetFingerprint},
-		{name: "canonical", fingerprint: canonicalPluginWorkflowTargetFingerprint},
-	} {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	refProvider := newWorkflowRuntimeExecutionRefProvider()
+	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+		ID:                "exec-ref-service-account",
+		ProviderName:      "temporal",
+		Target:            testWorkflowPluginTarget("roadmap", "sync"),
+		TargetFingerprint: canonicalPluginWorkflowTargetFingerprint,
+		SubjectID:         "service_account:scheduler",
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
 
-			refID := "exec-ref-service-account-" + tt.name
-			refProvider := newWorkflowRuntimeExecutionRefProvider()
-			if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-				ID:                refID,
-				ProviderName:      "temporal",
-				Target:            testWorkflowPluginTarget("roadmap", "sync"),
-				TargetFingerprint: tt.fingerprint,
-				SubjectID:         "service_account:scheduler",
-			}); err != nil {
-				t.Fatalf("Put execution ref: %v", err)
-			}
+	runtime := &workflowRuntime{
+		providers: map[string]coreworkflow.Provider{"temporal": refProvider},
+	}
 
-			runtime := &workflowRuntime{
-				providers: map[string]coreworkflow.Provider{"temporal": refProvider},
-			}
+	var gotPrincipal *principal.Principal
+	runtime.SetInvoker(funcInvoker{
+		invoke: func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
+			gotPrincipal = p
+			return &core.OperationResult{Status: http.StatusAccepted, Body: `{"ok":true}`}, nil
+		},
+	})
 
-			var gotPrincipal *principal.Principal
-			runtime.SetInvoker(funcInvoker{
-				invoke: func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
-					gotPrincipal = p
-					return &core.OperationResult{Status: http.StatusAccepted, Body: `{"ok":true}`}, nil
-				},
-			})
+	if _, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		ExecutionRef: "exec-ref-service-account",
+		Target:       testWorkflowPluginTarget("roadmap", "sync"),
+	}); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
 
-			if _, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
-				ProviderName: "temporal",
-				ExecutionRef: refID,
-				Target:       testWorkflowPluginTarget("roadmap", "sync"),
-			}); err != nil {
-				t.Fatalf("Invoke: %v", err)
-			}
-
-			if gotPrincipal == nil {
-				t.Fatal("principal = nil")
-			}
-			if gotPrincipal.Kind != principal.Kind("service_account") {
-				t.Fatalf("principal kind = %q, want %q", gotPrincipal.Kind, principal.Kind("service_account"))
-			}
-			if gotPrincipal.SubjectID != "service_account:scheduler" {
-				t.Fatalf("subjectID = %q, want %q", gotPrincipal.SubjectID, "service_account:scheduler")
-			}
-		})
+	if gotPrincipal == nil {
+		t.Fatal("principal = nil")
+	}
+	if gotPrincipal.Kind != principal.Kind("service_account") {
+		t.Fatalf("principal kind = %q, want %q", gotPrincipal.Kind, principal.Kind("service_account"))
+	}
+	if gotPrincipal.SubjectID != "service_account:scheduler" {
+		t.Fatalf("subjectID = %q, want %q", gotPrincipal.SubjectID, "service_account:scheduler")
 	}
 }
 

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -361,6 +361,13 @@ func (p *memoryWorkflowProvider) PutExecutionReference(_ context.Context, ref *c
 		p.executionRefs = map[string]*coreworkflow.ExecutionReference{}
 	}
 	stored := cloneWorkflowExecutionReference(ref)
+	if strings.TrimSpace(stored.TargetFingerprint) == "" {
+		fingerprint, err := coreworkflow.TargetFingerprint(stored.Target)
+		if err != nil {
+			return nil, err
+		}
+		stored.TargetFingerprint = fingerprint
+	}
 	p.executionRefs[stored.ID] = stored
 	return cloneWorkflowExecutionReference(stored), nil
 }

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -1444,22 +1444,12 @@ func targetMatchesExecutionRef(target coreworkflow.Target, ref *coreworkflow.Exe
 	if ref == nil {
 		return false
 	}
-	if strings.TrimSpace(ref.TargetFingerprint) != "" {
-		matches, err := coreworkflow.TargetFingerprintMatches(target, ref.TargetFingerprint)
-		return err == nil && matches
-	}
-	if ref.Target.Agent != nil || target.Agent != nil {
+	refFingerprint := strings.TrimSpace(ref.TargetFingerprint)
+	if refFingerprint == "" {
 		return false
 	}
-	if target.Plugin == nil || ref.Target.Plugin == nil {
-		return false
-	}
-	left := *target.Plugin
-	right := *ref.Target.Plugin
-	return strings.TrimSpace(left.PluginName) == strings.TrimSpace(right.PluginName) &&
-		strings.TrimSpace(left.Operation) == strings.TrimSpace(right.Operation) &&
-		strings.TrimSpace(left.Connection) == strings.TrimSpace(right.Connection) &&
-		strings.TrimSpace(left.Instance) == strings.TrimSpace(right.Instance)
+	targetFingerprint, err := coreworkflow.TargetFingerprint(target)
+	return err == nil && targetFingerprint == refFingerprint
 }
 
 func normalizeEventMatch(match coreworkflow.EventMatch) coreworkflow.EventMatch {


### PR DESCRIPTION
## Summary

This is the first deletion-oriented cleanup after downstream providers moved to canonical workflow target fingerprints.

## New interface

```go
fingerprint, err := workflow.TargetFingerprint(target)
ref.TargetFingerprint = fingerprint
```

## Runtime example

```go
fingerprint, err := workflow.TargetFingerprint(req.Target)
if err != nil {
    return err
}
if ref.TargetFingerprint != fingerprint {
    return invocation.ErrAuthorizationDenied
}
```

## Deleted behavior

- Removed `workflow.TargetFingerprintMatches`.
- Removed the legacy flat target fingerprint payload and fallback matcher.
- Removed plugin execution-ref fallback matching by `plugin/operation/connection/instance` when `target_fingerprint` is missing.
- Updated workflow runtime and manager paths to require exact canonical target fingerprints.

## Kept behavior

- `workflow.TargetFingerprint(target)` remains the single way to compute the canonical target fingerprint.
- Startup workflow provider proxy derives `target_fingerprint` for pending refs before the actual provider is ready.
- Test providers derive fingerprints on `PutExecutionReference`, matching real provider behavior.
- Config-managed schedule/event refs with missing or stale `target_fingerprint` are treated as drift and rotated.

## Compatibility

This is intentionally backward incompatible for old workflow execution refs. Workflows do not have active users yet, and this removes fallback behavior instead of preserving legacy shapes.

## Verification

```sh
cd gestaltd
go test ./core/workflow ./internal/workflowmanager ./internal/bootstrap ./internal/server -count=1
go test ./internal/providerhost -count=1
```

I also ran:

```sh
go test ./... -count=1
```

That full run passed the changed workflow packages and then hit a flaky/unrelated `internal/providerhost` telemetry metric assertion; rerunning `go test ./internal/providerhost -count=1` passed.
