### PR TITLE
Remove stale legacy telemetry attr constants

### DIFF
--- a/gestaltd/internal/metricutil/attrs.go
+++ b/gestaltd/internal/metricutil/attrs.go
@@ -19,8 +19,6 @@ const (
 	AttrInvocationSurface = attribute.Key("gestalt.invocation_surface")
 	AttrHTTPBinding       = attribute.Key("gestalt.http_binding")
 	AttrUI                = attribute.Key("gestalt.ui")
-	AttrRPCRole           = attribute.Key("gestalt.rpc.role")
-	AttrHostService       = attribute.Key("gestalt.host_service")
 	AttrResultStatus      = attribute.Key("gestalt.result_status")
 	AttrResultStatusClass = attribute.Key("gestalt.result_status_class")
 	AttrHTTPRoute         = attribute.Key("http.route")


### PR DESCRIPTION
## Summary

Removes the unused exported legacy transport attr constants for `gestalt.rpc.role` and `gestalt.host_service` from `metricutil`. The semconv-aligned helper interfaces remain the only production path for RPC and DB telemetry attributes.

## Interfaces

```go
type RPCMetricDims struct {
    Role            string
    ProviderName    string
    HostServiceName string
}

type DBMetricDims struct {
    SystemName     string
    Namespace      string
    CollectionName string
    OperationName  string
    ProviderName   string
    IndexName      string
    ErrorType      string
}
```

RPC helpers emit `gestaltd.rpc.role`, `gestaltd.provider.name`, and `gestaltd.host_service.name` on `rpc.client.call.duration` / `rpc.server.call.duration`. DB helpers emit OTel DB attributes plus `gestaltd.provider.name`, `gestaltd.indexeddb.index.name`, and `error.type` on `db.client.operation.duration`.

## Examples

```go
metricutil.GRPCMetricOptions(telemetry, metricutil.RPCMetricDims{
    Role:         metricutil.RPCRoleProviderClient,
    ProviderName: providerName,
})

metricutil.DBClientAttrs(metricutil.DBMetricDims{
    SystemName:    metricutil.DBSystemNameGestaltdIndexedDB,
    OperationName: operationName,
    ProviderName:  providerName,
})
```

## Verification

- `git diff --check`
- No unit tests run; this is a dead constant cleanup per the no-unit-tests constraint.
