### PR TITLE
Improve agent TUI resume and copy behavior

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -319,6 +319,10 @@ impl ApiClient {
         })
     }
 
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
     pub fn get(&self, path: &str) -> Result<serde_json::Value> {
         self.send(Method::GET, path)
     }

--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -54,6 +54,7 @@ pub(super) fn can_run() -> bool {
 pub(super) fn run(client: &ApiClient, args: &AgentArgs) -> Result<()> {
     let shell = AgentShell::connect(client, args)?;
     let mut app = TuiApp::new(client.clone(), shell);
+    let resume_command = resume_command(client.base_url(), &app.shell.session.id);
     let mut terminal = TerminalGuard::start()?;
 
     if !args.messages.is_empty() {
@@ -62,6 +63,9 @@ pub(super) fn run(client: &ApiClient, args: &AgentArgs) -> Result<()> {
 
     let result = app.run(terminal.inner_mut());
     terminal.restore()?;
+    if result.is_ok() {
+        println!("Resume this session:\n  {resume_command}");
+    }
     result
 }
 
@@ -73,10 +77,6 @@ struct TerminalGuard {
 impl TerminalGuard {
     fn start() -> Result<Self> {
         let terminal = ratatui::try_init().context("failed to initialize terminal UI")?;
-        if let Err(error) = execute!(io::stdout(), EnableMouseCapture) {
-            ratatui::restore();
-            return Err(error).context("failed to enable mouse capture");
-        }
         Ok(Self {
             terminal,
             restored: false,
@@ -128,6 +128,7 @@ struct TuiApp {
     history_cursor: Option<usize>,
     history_draft: String,
     footer_context: FooterContext,
+    mouse_capture_enabled: bool,
 }
 
 impl TuiApp {
@@ -152,6 +153,7 @@ impl TuiApp {
             history_cursor: None,
             history_draft: String::new(),
             footer_context: FooterContext::detect(),
+            mouse_capture_enabled: false,
         }
     }
 
@@ -488,6 +490,15 @@ impl TuiApp {
                 self.state
                     .push_system(format!("session {}", self.shell.session.id));
             }
+            "/mouse" => {
+                self.toggle_mouse_capture();
+            }
+            "/mouse on" => {
+                self.set_mouse_capture_enabled(true);
+            }
+            "/mouse off" => {
+                self.set_mouse_capture_enabled(false);
+            }
             _ => {
                 self.record_history(&message);
                 self.enqueue_or_start(vec![message]);
@@ -499,8 +510,39 @@ impl TuiApp {
 
     fn push_help(&mut self) {
         self.state.push_system(
-            "Commands\n  /help     Show commands and keys.\n  /session  Show the active session id.\n  /quit     Exit now, or after the active turn.\nKeys\n  Enter sends; busy turns queue the prompt.\n  Alt-Enter inserts a newline.\n  Up/Down recalls prompt history.\n  PgUp/PgDn or mouse wheel scrolls the transcript.\n  Ctrl-C cancels, clears input, or exits.",
+            "Commands\n  /help       Show commands and keys.\n  /session    Show the active session id.\n  /mouse      Toggle mouse wheel capture; leave off for native text selection.\n  /mouse on   Enable mouse wheel transcript scrolling.\n  /mouse off  Disable mouse capture so drag selection works.\n  /quit       Exit now, or after the active turn.\nKeys\n  Enter sends; busy turns queue the prompt.\n  Alt-Enter inserts a newline.\n  Up/Down recalls prompt history.\n  PgUp/PgDn scrolls the transcript.\n  Ctrl-C cancels, clears input, or exits.",
         );
+    }
+
+    fn toggle_mouse_capture(&mut self) {
+        self.set_mouse_capture_enabled(!self.mouse_capture_enabled);
+    }
+
+    fn set_mouse_capture_enabled(&mut self, enabled: bool) {
+        let result = if enabled {
+            execute!(io::stdout(), EnableMouseCapture)
+        } else {
+            execute!(io::stdout(), DisableMouseCapture)
+        };
+        match result {
+            Ok(()) => {
+                self.mouse_capture_enabled = enabled;
+                if enabled {
+                    self.state.push_system(
+                        "mouse wheel capture enabled; drag selection may require your terminal modifier key",
+                    );
+                    self.state.status = "mouse capture enabled".to_string();
+                } else {
+                    self.state
+                        .push_system("mouse capture disabled; native drag selection is available");
+                    self.state.status = "mouse capture disabled".to_string();
+                }
+            }
+            Err(error) => {
+                self.state
+                    .push_error(format!("failed to update mouse capture: {error}"));
+            }
+        }
     }
 
     fn enqueue_or_start(&mut self, messages: Vec<String>) {
@@ -723,6 +765,25 @@ fn visible_lines(
     let end = lines.len().saturating_sub(scroll_offset);
     let start = end.saturating_sub(visible_height.max(1));
     lines.into_iter().skip(start).take(end - start).collect()
+}
+
+fn resume_command(base_url: &str, session_id: &str) -> String {
+    format!(
+        "gestalt --url {} agent --session {}",
+        shell_word(base_url),
+        shell_word(session_id)
+    )
+}
+
+fn shell_word(value: &str) -> String {
+    if !value.is_empty()
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 struct FooterContext {

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -799,6 +799,10 @@ fn test_cli_runs_tty_agent_session_with_full_screen_ui() {
     session.wait_for(&mut output, "hello");
     session.wait_for(&mut output, "Brewed for");
     session.write("/quit\r");
+    session.wait_for(&mut output, "\x1b[?1049l");
+    session.wait_for(&mut output, "Resume this session:");
+    session.wait_for(&mut output, "gestalt --url");
+    session.wait_for(&mut output, "agent --session session-1");
     session.wait_for_exit();
 
     assert!(
@@ -811,6 +815,20 @@ fn test_cli_runs_tty_agent_session_with_full_screen_ui() {
             && output.contains("footer-branch")
             && output.contains("session session-1"),
         "TTY footer did not render local model/session/path/branch metadata:\n{output}"
+    );
+    assert!(
+        !output.contains("\x1b[?1000h"),
+        "TTY enabled mouse capture by default, preventing native drag selection:\n{output}"
+    );
+    assert!(
+        output.contains("Resume this session:")
+            && output.contains("gestalt --url")
+            && output.contains("agent --session session-1"),
+        "TTY exit did not print a resume command after restoring the terminal:\n{output}"
+    );
+    assert!(
+        output.find("\x1b[?1049l").unwrap() < output.find("Resume this session:").unwrap(),
+        "TTY printed the resume command before restoring the alternate screen:\n{output}"
     );
     assert!(
         !output.contains("You")
@@ -1273,19 +1291,29 @@ fn test_cli_tty_scrolls_multiline_help_rows() {
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
     session.write("/help\r");
-    session.wait_for(&mut output, "mouse wheel");
+    session.wait_for(&mut output, "PgUp/PgDn scrolls");
     session.wait_for(&mut output, "cancels");
     output.clear();
     session.write("\x1b[5~\x1b[5~");
-    session.wait_for(&mut output, "Commands");
+    session.wait_for(&mut output, "native text selection");
     output.clear();
     session.write("\x1b[6~\x1b[6~");
     session.wait_for(&mut output, "cancels");
     output.clear();
-    session.write("\x1b[<64;1;1M\x1b[<64;1;1M");
-    session.wait_for(&mut output, "Commands");
+    session.write("/mouse on\r");
+    session.wait_for(&mut output, "\x1b[?1000h");
     output.clear();
-    session.write("\x1b[<65;1;1M\x1b[<65;1;1M");
+    session.write("/mouse off\r");
+    session.wait_for(&mut output, "\x1b[?1000l");
+    session.wait_for(&mut output, "selection is");
+    output.clear();
+    session.write("/mouse on\r");
+    session.wait_for(&mut output, "\x1b[?1000h");
+    output.clear();
+    session.write("\x1b[<64;1;1M\x1b[<64;1;1M\x1b[<64;1;1M\x1b[<64;1;1M");
+    session.wait_for(&mut output, "PgUp/PgDn");
+    output.clear();
+    session.write("\x1b[<65;1;1M\x1b[<65;1;1M\x1b[<65;1;1M\x1b[<65;1;1M");
     session.wait_for(&mut output, "cancels");
     session.write("/quit\r");
     session.wait_for_exit();


### PR DESCRIPTION
## Summary

- Prints a concrete resume command to stdout after a normal full-screen agent TUI exit.
- Stops enabling terminal mouse capture by default so native drag/highlight selection works in the TUI.
- Adds `/mouse`, `/mouse on`, and `/mouse off` as client-only TUI controls for users who still want mouse-wheel transcript scrolling.

## New Interfaces

Rust:

```rust
impl ApiClient {
    pub fn base_url(&self) -> &str;
}
```

Client-side helpers:

```rust
resume_command(base_url, session_id) -> "gestalt --url <url> agent --session <id>"
```

TUI slash commands:

```text
/mouse      Toggle mouse wheel capture; leave off for native text selection.
/mouse on   Enable mouse wheel transcript scrolling.
/mouse off  Disable mouse capture so drag selection works.
```

Stdout after normal TUI exit:

```text
Resume this session:
  gestalt --url https://valon.tools agent --session 01d4f9a6-2ef4-4acf-ae69-586859faa0fa
```

## Examples

Run against production and later resume from the printed command:

```bash
gestalt --url https://valon.tools agent --provider managed --model gpt-5.4
# ... /quit ...
# stdout:
# Resume this session:
#   gestalt --url https://valon.tools agent --session <session-id>
```

Keep drag selection available by default; opt into mouse-wheel scrolling only when needed:

```text
/mouse on
/mouse off
```

## Validation

- `cargo fmt --manifest-path gestalt/Cargo.toml --package gestalt --check`
- `cargo test --manifest-path gestalt/Cargo.toml --test agents_cli -- --nocapture`
- `cargo clippy --manifest-path gestalt/Cargo.toml --all-targets -- -D warnings`

The TTY coverage exercises the stdout resume command, verifies mouse capture is not enabled by default, and covers the opt-in `/mouse on` path for mouse-wheel transcript scrolling.
