### PR TITLE
Compact oversized agent tool schemas

### DIFF
--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -15,6 +15,7 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
@@ -44,6 +45,7 @@ const (
 	agentSessionCreationWaitTimeout  = 5 * time.Second
 	agentSessionCreationPollInterval = 100 * time.Millisecond
 	agentToolSearchAllPlugin         = "*"
+	agentToolInputSchemaMaxBytes     = 128 * 1024
 )
 
 type AgentProviderNotAvailableError struct {
@@ -1724,14 +1726,25 @@ func sessionSortTime(session *coreagent.Session) *time.Time {
 }
 
 func operationInputSchema(op catalog.CatalogOperation) (map[string]any, error) {
-	if len(op.InputSchema) == 0 {
+	raw := agentToolInputSchema(op)
+	if len(raw) == 0 {
 		return nil, nil
 	}
 	var out map[string]any
-	if err := json.Unmarshal(op.InputSchema, &out); err != nil {
+	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil, fmt.Errorf("decode %s input schema: %w", op.ID, err)
 	}
 	return out, nil
+}
+
+func agentToolInputSchema(op catalog.CatalogOperation) json.RawMessage {
+	if len(op.InputSchema) <= agentToolInputSchemaMaxBytes {
+		return op.InputSchema
+	}
+	if synthesized := integration.SynthesizeInputSchema(op.Parameters); len(synthesized) > 0 {
+		return synthesized
+	}
+	return json.RawMessage(`{"type":"object","additionalProperties":true}`)
 }
 
 func agentToolID(pluginName, operation, connection, instance string, credentialMode core.ConnectionMode) string {

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -3,6 +3,7 @@ package agentmanager
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -448,6 +449,90 @@ func TestSearchToolsRestrictsToDefinedRefs(t *testing.T) {
 	}
 	if resp.Tools[0].Target.Plugin != "docs" || resp.Tools[0].Target.Operation != "search" {
 		t.Fatalf("tool target = %#v, want docs.search", resp.Tools[0].Target)
+	}
+}
+
+func TestSearchToolsCompactsOversizedInputSchemaFromParameters(t *testing.T) {
+	t.Parallel()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "github",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:          "pulls.list",
+				Title:       "List Pull Requests",
+				Description: "List pull requests for a repository.",
+				InputSchema: []byte(`{"type":"object","properties":{"payload":{"type":"string","description":"` + strings.Repeat("x", agentToolInputSchemaMaxBytes) + `"}}}`),
+				Parameters: []catalog.CatalogParameter{
+					{Name: "owner", Type: "string", Description: "Repository owner.", Required: true},
+					{Name: "repo", Type: "string", Description: "Repository name.", Required: true},
+					{Name: "state", Type: "string", Description: "Pull request state."},
+				},
+				ReadOnly: true,
+			}}},
+		},
+	}
+	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query: "github pull requests",
+	})
+	if err != nil {
+		t.Fatalf("SearchTools: %v", err)
+	}
+	if len(resp.Tools) != 1 {
+		t.Fatalf("SearchTools returned %d tools, want 1", len(resp.Tools))
+	}
+	schema := resp.Tools[0].ParametersSchema
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema properties = %#v, want object", schema["properties"])
+	}
+	if _, ok := properties["payload"]; ok {
+		t.Fatalf("schema properties include oversized raw payload: %#v", properties)
+	}
+	if _, ok := properties["owner"]; !ok {
+		t.Fatalf("schema properties = %#v, want owner", properties)
+	}
+	required, ok := schema["required"].([]any)
+	if !ok || len(required) != 2 || required[0] != "owner" || required[1] != "repo" {
+		t.Fatalf("schema required = %#v, want owner and repo", schema["required"])
+	}
+}
+
+func TestSearchToolsUsesOpenObjectSchemaForOversizedInputSchemaWithoutParameters(t *testing.T) {
+	t.Parallel()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "github",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:          "search.code",
+				Title:       "Search Code",
+				Description: "Search code.",
+				InputSchema: []byte(`{"type":"object","properties":{"payload":{"type":"string","description":"` + strings.Repeat("x", agentToolInputSchemaMaxBytes) + `"}}}`),
+				ReadOnly:    true,
+			}}},
+		},
+	}
+	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query: "github code",
+	})
+	if err != nil {
+		t.Fatalf("SearchTools: %v", err)
+	}
+	if len(resp.Tools) != 1 {
+		t.Fatalf("SearchTools returned %d tools, want 1", len(resp.Tools))
+	}
+	schema := resp.Tools[0].ParametersSchema
+	if schema["type"] != "object" || schema["additionalProperties"] != true {
+		t.Fatalf("schema = %#v, want open object fallback", schema)
 	}
 }
 


### PR DESCRIPTION
## Summary
- compact oversized agent tool input schemas before returning tools to agent providers
- synthesize a small schema from catalog parameters when available
- fall back to an open object schema when an oversized schema has no parameters

## Testing
- go test ./internal/agentmanager
- go test ./internal/bootstrap ./internal/providerhost