### PR TITLE
Agent CLI resume command and model slash command

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -206,7 +206,8 @@ gestalt workflow runs cancel <run-id> --reason "operator requested"
 
 ```sh
 gestalt agent --provider simple --model fast
-gestalt agent --session <session-id>
+gestalt agent resume <session-id>
+gestalt agent resume --provider simple
 
 gestalt agent sessions create --provider simple --model fast
 gestalt agent sessions list --provider simple --state active
@@ -246,16 +247,18 @@ JSON
 ```
 
 `gestalt agent` is the interactive path. It creates a session when you pass
-`--provider` or resumes an existing one with `--session`. The first turn in a
-CLI session can include repeated `--system` messages, repeated `--message`
-prompts, and repeated `--tool plugin:operation` additions. During execution,
-the CLI parses the event stream, renders assistant/tool/interaction events,
-cancels the active turn on Ctrl-C, and resolves pending interactions inline.
-TTY sessions use a full-screen terminal UI with a persistent transcript,
-streaming assistant output, a multiline composer, queued prompts while a turn
-is running, Ctrl-C cancellation, and inline interaction panels. Press Enter to
-send, Alt-Enter to insert a newline, PageUp/PageDown to scroll, `/session` to
-show the active session, and `/quit` to exit. Non-TTY sessions keep the
+`--provider`; `gestalt agent resume [session-id]` resumes either a specific
+session or the most recently updated active session. The first turn in a CLI
+session can include repeated `--system` messages, repeated `--message` prompts,
+and repeated `--tool plugin:operation` additions. During execution, the CLI
+parses the event stream, renders assistant/tool/interaction events, cancels the
+active turn on Ctrl-C, and resolves pending interactions inline. TTY sessions
+use a full-screen terminal UI with a persistent transcript, streaming assistant
+output, a multiline composer, queued prompts while a turn is running, Ctrl-C
+cancellation, and inline interaction panels. Press Enter to send, Alt-Enter to
+insert a newline, PageUp/PageDown to scroll, `/session` to show the active
+session and resume command, and `/model` to show or set the model for future
+turns. Non-TTY sessions keep the
 prompt-and-print fallback used by scripts and tests; there, end an input line
 with `\` to continue the same user message on the next prompt.
 

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -221,15 +221,7 @@ pub struct AgentArgs {
     #[command(subcommand)]
     pub command: Option<AgentCommands>,
 
-    /// Resume an existing agent session
-    #[arg(long)]
-    pub session: Option<String>,
-
-    /// Resume the most recently updated active agent session
-    #[arg(long, visible_alias = "continue", conflicts_with = "session")]
-    pub resume: bool,
-
-    /// Agent provider name for a new session, or provider filter when resuming
+    /// Agent provider name for a new session
     #[arg(long)]
     pub provider: Option<String>,
 
@@ -252,6 +244,8 @@ pub struct AgentArgs {
 
 #[derive(Subcommand)]
 pub enum AgentCommands {
+    /// Resume an interactive agent session
+    Resume(AgentResumeArgs),
     /// Inspect and control agent sessions
     Sessions {
         #[command(subcommand)]
@@ -262,6 +256,32 @@ pub enum AgentCommands {
         #[command(subcommand)]
         command: AgentTurnCommands,
     },
+}
+
+#[derive(Args)]
+pub struct AgentResumeArgs {
+    /// Session ID to resume. Omit to resume the most recently updated active session.
+    pub session_id: Option<String>,
+
+    /// Provider filter when resuming the most recently updated active session
+    #[arg(long, conflicts_with = "session_id")]
+    pub provider: Option<String>,
+
+    /// Model name override for future turns
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// Add a system message to the first turn created in this CLI session
+    #[arg(long = "system")]
+    pub system: Vec<String>,
+
+    /// Start with one or more user messages before entering the prompt loop
+    #[arg(long = "message")]
+    pub messages: Vec<String>,
+
+    /// Add a tool in plugin:operation form to each turn
+    #[arg(long = "tool", value_parser = AgentToolArg::parse)]
+    pub tools: Vec<AgentToolArg>,
 }
 
 #[derive(Subcommand)]

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -13,8 +13,8 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::api::ApiClient;
 use crate::cli::{
-    AgentArgs, AgentSessionCreateArgs, AgentSessionUpdateArgs, AgentToolArg, AgentTurnCreateArgs,
-    AgentTurnEventListArgs, AgentTurnEventStreamArgs,
+    AgentArgs, AgentResumeArgs, AgentSessionCreateArgs, AgentSessionUpdateArgs, AgentToolArg,
+    AgentTurnCreateArgs, AgentTurnEventListArgs, AgentTurnEventStreamArgs,
 };
 use crate::interactive::{
     InputPrompt, InteractiveLineReader, PromptLine, prompt_confirm, prompt_input,
@@ -25,6 +25,7 @@ use crate::params;
 mod tui;
 
 const SESSIONS_PATH: &str = "/api/v1/agent/sessions";
+const PROVIDERS_PATH: &str = "/api/v1/agent/providers";
 const TURNS_PATH: &str = "/api/v1/agent/turns";
 const DEFAULT_EVENT_PAGE_SIZE: u32 = 100;
 const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
@@ -184,41 +185,147 @@ pub fn stream_turn_events(client: &ApiClient, args: &AgentTurnEventStreamArgs) -
 }
 
 pub fn run_interactive(client: &ApiClient, args: &AgentArgs) -> Result<()> {
+    let shell = AgentShell::connect(client, args)?;
+    run_shell_interactive(client, shell, args.messages.clone())
+}
+
+pub fn resume_interactive(client: &ApiClient, args: &AgentResumeArgs) -> Result<()> {
+    let shell = AgentShell::resume(client, args)?;
+    run_shell_interactive(client, shell, args.messages.clone())
+}
+
+fn run_shell_interactive(
+    client: &ApiClient,
+    mut shell: AgentShell,
+    initial_messages: Vec<String>,
+) -> Result<()> {
+    let session_id = shell.session.id.clone();
     if tui::can_run() {
-        return tui::run(client, args);
+        let result = tui::run_shell(client, shell, initial_messages);
+        if result.is_ok() {
+            print_resume_command(&session_id)?;
+        }
+        return result;
     }
 
-    let mut shell = AgentShell::connect(client, args)?;
     shell.print_banner()?;
     let interrupts = InterruptState::install();
     let mut input = InteractiveLineReader::with_history_namespace("agent")?;
 
-    if !args.messages.is_empty() {
-        shell.submit_turn(client, args.messages.clone(), &interrupts)?;
+    if !initial_messages.is_empty() {
+        shell.submit_turn(client, initial_messages, &interrupts)?;
     }
 
     loop {
         let Some(line) = prompt_agent_message(&mut input)? else {
+            print_resume_command(&session_id)?;
             return Ok(());
         };
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
-        match trimmed {
-            "/quit" | "/exit" => return Ok(()),
-            "/help" => {
-                eprintln!("Commands: /help, /session, /quit");
-                continue;
-            }
-            "/session" => {
-                eprintln!("session {}", shell.session.id);
-                continue;
-            }
-            _ => {}
+        if handle_agent_slash_command(client, &mut shell, trimmed)? {
+            continue;
         }
         shell.submit_turn(client, vec![line], &interrupts)?;
     }
+}
+
+fn print_resume_command(session_id: &str) -> Result<()> {
+    let mut stdout = io::stdout().lock();
+    writeln!(stdout, "Resume with: gestalt agent resume {session_id}")?;
+    Ok(())
+}
+
+fn handle_agent_slash_command(
+    client: &ApiClient,
+    shell: &mut AgentShell,
+    trimmed: &str,
+) -> Result<bool> {
+    let Some((command, args)) = parse_agent_slash_command(trimmed) else {
+        return Ok(false);
+    };
+    match command {
+        "help" => {
+            for line in agent_help_lines() {
+                eprintln!("{line}");
+            }
+        }
+        "session" => {
+            for line in agent_session_lines(shell) {
+                eprintln!("{line}");
+            }
+        }
+        "model" => {
+            for line in agent_model_lines(client, shell, args) {
+                eprintln!("{line}");
+            }
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+fn parse_agent_slash_command(input: &str) -> Option<(&str, &str)> {
+    let trimmed = input.trim();
+    let command = trimmed.strip_prefix('/')?;
+    let mut parts = command.splitn(2, char::is_whitespace);
+    let command = parts.next().unwrap_or("");
+    let args = parts.next().unwrap_or("");
+    Some((command, args.trim()))
+}
+
+fn agent_help_lines() -> Vec<String> {
+    vec![
+        "Commands:".to_string(),
+        "  /help     Show commands and keys.".to_string(),
+        "  /session  Show the active session id and resume command.".to_string(),
+        "  /model    Show current model and configured providers.".to_string(),
+        "  /model X  Use model X for future turns in this session.".to_string(),
+        "Keys:".to_string(),
+        "  Enter sends; busy turns queue the prompt.".to_string(),
+        "  Alt-Enter inserts a newline.".to_string(),
+        "  Up/Down recalls prompt history.".to_string(),
+        "  PgUp/PgDn scrolls the transcript.".to_string(),
+        "  Ctrl-C cancels, clears input, or exits.".to_string(),
+    ]
+}
+
+fn agent_session_lines(shell: &AgentShell) -> Vec<String> {
+    vec![
+        format!("session {}", shell.session.id),
+        format!("resume command: gestalt agent resume {}", shell.session.id),
+    ]
+}
+
+fn agent_model_lines(client: &ApiClient, shell: &mut AgentShell, args: &str) -> Vec<String> {
+    let requested = args.trim();
+    if !requested.is_empty() {
+        shell.set_model_override(requested);
+        return vec![format!("model {requested} selected for future turns")];
+    }
+
+    let mut lines = vec![
+        format!("current provider: {}", shell.session.provider),
+        format!("current model: {}", shell.effective_model_label()),
+    ];
+    match list_agent_providers(client) {
+        Ok(providers) if providers.is_empty() => {
+            lines.push("configured providers: none".to_string());
+        }
+        Ok(providers) => {
+            lines.push("configured providers:".to_string());
+            for provider in providers {
+                let suffix = if provider.default { " (default)" } else { "" };
+                lines.push(format!("  {}{}", provider.name, suffix));
+            }
+        }
+        Err(err) => {
+            lines.push(format!("configured providers unavailable: {err}"));
+        }
+    }
+    lines
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -236,6 +343,21 @@ struct AgentSessionInfo {
     created_at: String,
     #[serde(default)]
     updated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentProviderListInfo {
+    #[serde(default)]
+    providers: Vec<AgentProviderInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentProviderInfo {
+    name: String,
+    #[serde(default)]
+    default: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -370,19 +492,28 @@ struct AgentShell {
 
 impl AgentShell {
     fn connect(client: &ApiClient, args: &AgentArgs) -> Result<Self> {
-        let session = match args.session.as_deref() {
+        let session_args = AgentSessionCreateArgs {
+            provider: args.provider.clone(),
+            model: args.model.clone(),
+            client_ref: None,
+            idempotency_key: None,
+            input: None,
+        };
+        let session = create_session_info(client, &session_args)?;
+
+        Ok(Self {
+            session,
+            model_override: args.model.clone(),
+            system_messages: args.system.clone(),
+            tools: args.tools.clone(),
+            applied_system_messages: false,
+        })
+    }
+
+    fn resume(client: &ApiClient, args: &AgentResumeArgs) -> Result<Self> {
+        let session = match args.session_id.as_deref() {
             Some(session_id) => get_session_info(client, session_id)?,
-            None if args.resume => resume_latest_session_info(client, args.provider.as_deref())?,
-            None => {
-                let session_args = AgentSessionCreateArgs {
-                    provider: args.provider.clone(),
-                    model: args.model.clone(),
-                    client_ref: None,
-                    idempotency_key: None,
-                    input: None,
-                };
-                create_session_info(client, &session_args)?
-            }
+            None => resume_latest_session_info(client, args.provider.as_deref())?,
         };
 
         Ok(Self {
@@ -396,18 +527,32 @@ impl AgentShell {
 
     fn print_banner(&self) -> Result<()> {
         let mut stderr = io::stderr().lock();
-        let model = if self.session.model.is_empty() {
-            "<unspecified>"
-        } else {
-            self.session.model.as_str()
-        };
         writeln!(
             stderr,
             "Session {} [{} / {}]",
-            self.session.id, self.session.provider, model
+            self.session.id,
+            self.session.provider,
+            self.effective_model_label()
         )?;
-        writeln!(stderr, "Type /quit to exit.")?;
+        writeln!(stderr, "Press Ctrl-C or send EOF to exit.")?;
         Ok(())
+    }
+
+    fn effective_model_label(&self) -> &str {
+        if let Some(model) = self.model_override.as_deref()
+            && !model.trim().is_empty()
+        {
+            return model;
+        }
+        if self.session.model.trim().is_empty() {
+            "<unspecified>"
+        } else {
+            self.session.model.as_str()
+        }
+    }
+
+    fn set_model_override(&mut self, model: &str) {
+        self.model_override = Some(model.trim().to_string());
     }
 
     fn submit_turn(
@@ -1013,7 +1158,7 @@ fn prompt_agent_message(input: &mut InteractiveLineReader) -> Result<Option<Stri
             }
             PromptLine::Interrupted => {
                 eprintln!("^C");
-                return Ok(Some(String::new()));
+                return Ok(None);
             }
             PromptLine::Eof => return Ok(None),
         }
@@ -1202,6 +1347,15 @@ fn get_session_info(client: &ApiClient, id: &str) -> Result<AgentSessionInfo> {
     )
 }
 
+fn list_agent_providers(client: &ApiClient) -> Result<Vec<AgentProviderInfo>> {
+    let resp: AgentProviderListInfo = decode_json(
+        client
+            .get(PROVIDERS_PATH)
+            .context("failed to list agent providers")?,
+    )?;
+    Ok(resp.providers)
+}
+
 fn resume_latest_session_info(
     client: &ApiClient,
     provider: Option<&str>,
@@ -1217,10 +1371,10 @@ fn resume_latest_session_info(
         .max_by(compare_sessions_for_resume)
         .ok_or_else(|| match provider {
             Some(provider) => anyhow::anyhow!(
-                "no active agent sessions found for provider {provider}; omit --resume to create one"
+                "no active agent sessions found for provider {provider}; use `gestalt agent` to create one"
             ),
             None => anyhow::anyhow!(
-                "no active agent sessions found; omit --resume to create one"
+                "no active agent sessions found; use `gestalt agent` to create one"
             ),
         })
 }

--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -8,13 +8,7 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use ratatui::crossterm::{
-    event::{
-        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
-        KeyModifiers, MouseEventKind,
-    },
-    execute,
-};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, TextArea};
@@ -23,7 +17,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use crate::api::ApiClient;
-use crate::cli::{AgentArgs, AgentTurnCreateArgs};
+use crate::cli::AgentTurnCreateArgs;
 
 mod state;
 mod worker;
@@ -32,7 +26,8 @@ use state::{AgentUiState, TranscriptItem, turn_status_label};
 use worker::{TurnWorker, WorkerCommand, WorkerEvent, spawn_turn_worker};
 
 use super::{
-    AgentInteractionInfo, AgentShell, INTERRUPT_CANCEL_REASON, cancel_turn_silent, compact_json,
+    AgentInteractionInfo, AgentShell, INTERRUPT_CANCEL_REASON, agent_help_lines, agent_model_lines,
+    agent_session_lines, cancel_turn_silent, compact_json,
 };
 
 const TICK_RATE: Duration = Duration::from_millis(50);
@@ -51,13 +46,16 @@ pub(super) fn can_run() -> bool {
     io::stdin().is_terminal() && io::stdout().is_terminal() && io::stderr().is_terminal()
 }
 
-pub(super) fn run(client: &ApiClient, args: &AgentArgs) -> Result<()> {
-    let shell = AgentShell::connect(client, args)?;
+pub(super) fn run_shell(
+    client: &ApiClient,
+    shell: AgentShell,
+    initial_messages: Vec<String>,
+) -> Result<()> {
     let mut app = TuiApp::new(client.clone(), shell);
     let mut terminal = TerminalGuard::start()?;
 
-    if !args.messages.is_empty() {
-        app.enqueue_or_start(args.messages.clone());
+    if !initial_messages.is_empty() {
+        app.enqueue_or_start(initial_messages);
     }
 
     let result = app.run(terminal.inner_mut());
@@ -73,10 +71,6 @@ struct TerminalGuard {
 impl TerminalGuard {
     fn start() -> Result<Self> {
         let terminal = ratatui::try_init().context("failed to initialize terminal UI")?;
-        if let Err(error) = execute!(io::stdout(), EnableMouseCapture) {
-            ratatui::restore();
-            return Err(error).context("failed to enable mouse capture");
-        }
         Ok(Self {
             terminal,
             restored: false,
@@ -89,9 +83,7 @@ impl TerminalGuard {
 
     fn restore(&mut self) -> Result<()> {
         if !self.restored {
-            let mouse_result = execute!(io::stdout(), DisableMouseCapture);
             let restore_result = ratatui::try_restore();
-            mouse_result.context("failed to disable mouse capture")?;
             restore_result.context("failed to restore terminal UI")?;
             self.restored = true;
         }
@@ -102,7 +94,6 @@ impl TerminalGuard {
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
         if !self.restored {
-            let _ = execute!(io::stdout(), DisableMouseCapture);
             ratatui::restore();
             self.restored = true;
         }
@@ -120,7 +111,6 @@ struct TuiApp {
     worker_tx: Sender<WorkerEvent>,
     queued_messages: VecDeque<Vec<String>>,
     should_quit: bool,
-    quit_after_turn: bool,
     transcript_visible_height: usize,
     transcript_content_height: usize,
     tick: usize,
@@ -133,8 +123,10 @@ struct TuiApp {
 impl TuiApp {
     fn new(client: ApiClient, shell: AgentShell) -> Self {
         let (worker_tx, worker_rx) = mpsc::channel();
+        let mut state = AgentUiState::new(&shell.session);
+        state.model = shell.effective_model_label().to_string();
         Self {
-            state: AgentUiState::new(&shell.session),
+            state,
             client,
             shell,
             composer: styled_textarea("Message"),
@@ -144,7 +136,6 @@ impl TuiApp {
             worker_tx,
             queued_messages: VecDeque::new(),
             should_quit: false,
-            quit_after_turn: false,
             transcript_visible_height: 1,
             transcript_content_height: 0,
             tick: 0,
@@ -169,14 +160,6 @@ impl TuiApp {
             if event::poll(TICK_RATE).context("failed to poll terminal events")? {
                 match event::read().context("failed to read terminal event")? {
                     Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_key(key),
-                    Event::Mouse(mouse) => match mouse.kind {
-                        MouseEventKind::ScrollUp => self.state.scroll_up(
-                            self.transcript_visible_height,
-                            self.transcript_content_height,
-                        ),
-                        MouseEventKind::ScrollDown => self.state.scroll_down(),
-                        _ => {}
-                    },
                     Event::Resize(_, _) => {}
                     _ => {}
                 }
@@ -471,22 +454,30 @@ impl TuiApp {
             return;
         }
 
-        match trimmed {
-            "/quit" | "/exit" => {
-                if self.state.busy {
-                    self.quit_after_turn = true;
-                    self.state
-                        .push_system("Will exit after the current turn finishes.");
-                } else {
-                    self.should_quit = true;
-                }
-            }
-            "/help" => {
+        let (command, args) = trimmed
+            .strip_prefix('/')
+            .map(|command| {
+                let mut parts = command.splitn(2, char::is_whitespace);
+                let command = parts.next().unwrap_or("");
+                let args = parts.next().unwrap_or("");
+                (command, args.trim())
+            })
+            .unwrap_or(("", ""));
+
+        match command {
+            "help" => {
                 self.push_help();
             }
-            "/session" => {
+            "session" => {
                 self.state
-                    .push_system(format!("session {}", self.shell.session.id));
+                    .push_system(agent_session_lines(&self.shell).join("\n"));
+            }
+            "model" => {
+                let lines = agent_model_lines(&self.client, &mut self.shell, args);
+                if !args.is_empty() {
+                    self.state.model = self.shell.effective_model_label().to_string();
+                }
+                self.state.push_system(lines.join("\n"));
             }
             _ => {
                 self.record_history(&message);
@@ -498,9 +489,7 @@ impl TuiApp {
     }
 
     fn push_help(&mut self) {
-        self.state.push_system(
-            "Commands\n  /help     Show commands and keys.\n  /session  Show the active session id.\n  /quit     Exit now, or after the active turn.\nKeys\n  Enter sends; busy turns queue the prompt.\n  Alt-Enter inserts a newline.\n  Up/Down recalls prompt history.\n  PgUp/PgDn or mouse wheel scrolls the transcript.\n  Ctrl-C cancels, clears input, or exits.",
-        );
+        self.state.push_system(agent_help_lines().join("\n"));
     }
 
     fn enqueue_or_start(&mut self, messages: Vec<String>) {
@@ -515,10 +504,6 @@ impl TuiApp {
 
     fn start_next_queued_turn(&mut self) {
         if self.state.busy {
-            return;
-        }
-        if self.quit_after_turn {
-            self.should_quit = true;
             return;
         }
         if let Some(messages) = self.queued_messages.pop_front() {

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -130,6 +130,9 @@ fn run() -> anyhow::Result<()> {
             }
             let client = ApiClient::from_env(url)?;
             match args.command {
+                Some(AgentCommands::Resume(resume)) => {
+                    commands::agents::resume_interactive(&client, &resume)
+                }
                 Some(command) => dispatch_agent_command(&client, command, format),
                 None => commands::agents::run_interactive(&client, &args),
             }
@@ -138,28 +141,20 @@ fn run() -> anyhow::Result<()> {
 }
 
 fn reject_agent_interactive_options(args: &AgentArgs) -> anyhow::Result<()> {
-    if args.resume {
-        anyhow::bail!("--resume can only be used with interactive `gestalt agent`");
-    }
-    if args.session.is_some() {
-        anyhow::bail!("--session can only be used with interactive `gestalt agent`");
-    }
     if args.model.is_some() {
-        anyhow::bail!("--model can only be used with interactive `gestalt agent`");
+        anyhow::bail!("--model must be passed before a prompt or after `agent resume`");
     }
     if !args.system.is_empty() {
-        anyhow::bail!("--system can only be used with interactive `gestalt agent`");
+        anyhow::bail!("--system must be passed before a prompt or after `agent resume`");
     }
     if !args.messages.is_empty() {
-        anyhow::bail!("--message can only be used with interactive `gestalt agent`");
+        anyhow::bail!("--message must be passed before a prompt or after `agent resume`");
     }
     if !args.tools.is_empty() {
-        anyhow::bail!("--tool can only be used with interactive `gestalt agent`");
+        anyhow::bail!("--tool must be passed before a prompt or after `agent resume`");
     }
     if args.provider.is_some() {
-        anyhow::bail!(
-            "--provider before an agent subcommand is ignored; pass it after the subcommand if supported"
-        );
+        anyhow::bail!("--provider must be passed before a prompt or after `agent resume`");
     }
     Ok(())
 }
@@ -170,6 +165,7 @@ fn dispatch_agent_command(
     format: gestalt::output::Format,
 ) -> anyhow::Result<()> {
     match command {
+        AgentCommands::Resume(_) => anyhow::bail!("agent resume is interactive"),
         AgentCommands::Sessions { command } => match command {
             AgentSessionCommands::Create(args) => {
                 commands::agents::create_session(client, &args, format)

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -621,7 +621,7 @@ fn test_cli_runs_interactive_agent_session() {
     cli_command_for_server(home.path(), &server)
         .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
         .args(["--tool", "linear:searchIssues"])
-        .write_stdin("hello\\\nthere\n/quit\n")
+        .write_stdin("hello\\\nthere\n")
         .assert()
         .success()
         .stdout(predicate::str::contains("tool> lookup started"))
@@ -632,7 +632,9 @@ fn test_cli_runs_interactive_agent_session() {
         .stderr(predicate::str::contains(
             "Session session-1 [managed / gpt-5.4]",
         ))
-        .stderr(predicate::str::contains("Type /quit to exit."));
+        .stderr(predicate::str::contains(
+            "Press Ctrl-C or send EOF to exit.",
+        ));
 }
 
 #[test]
@@ -706,7 +708,7 @@ fn test_cli_runs_interactive_agent_session_with_display_events() {
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
         .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
-        .write_stdin("display events\n/quit\n")
+        .write_stdin("display events\n")
         .assert()
         .success()
         .stdout(predicate::str::contains(
@@ -798,7 +800,8 @@ fn test_cli_runs_tty_agent_session_with_full_screen_ui() {
     session.write("hello tui\r");
     session.wait_for(&mut output, "hello");
     session.wait_for(&mut output, "Brewed for");
-    session.write("/quit\r");
+    session.write("\x03");
+    session.wait_for(&mut output, "Resume with: gestalt agent resume session-1");
     session.wait_for_exit();
 
     assert!(
@@ -818,6 +821,78 @@ fn test_cli_runs_tty_agent_session_with_full_screen_ui() {
             && !output.contains("you>")
             && !output.contains("assistant>"),
         "TTY transcript still rendered legacy prompt labels:\n{output}"
+    );
+    server.assert_finished();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_tty_resume_model_override_updates_visible_model_and_turn_payload() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/sessions/session-1",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            SESSION_JSON,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-1/turns",
+            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"override model"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-override-model",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.5",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-override-model/events/stream?after=0&limit=100&until=blocked_or_terminal",
+            StatusCode::OK,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"assistant.completed\",\"data\":{\"text\":\"override acknowledged\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-override-model",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-override-model",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.5",
+                "status":"succeeded",
+                "outputText":"override acknowledged"
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    let mut session = spawn_tty_cli(
+        home.path(),
+        server.url(),
+        &["agent", "resume", "session-1", "--model", "gpt-5.5"],
+    );
+    let mut output = String::new();
+    session.wait_for(&mut output, "Session");
+    session.wait_for(&mut output, "managed/gpt-5.5");
+    session.write("override model\r");
+    session.wait_for(&mut output, "override acknowledged");
+    session.wait_for(&mut output, "Brewed for");
+    session.write("\x03");
+    session.wait_for(&mut output, "Resume with: gestalt agent resume session-1");
+    session.wait_for_exit();
+
+    assert!(
+        output.contains("managed/gpt-5.5"),
+        "TTY did not render resumed model override:\n{output}"
     );
     server.assert_finished();
 }
@@ -897,7 +972,7 @@ fn test_cli_tty_renders_display_tool_activity_rows() {
     session.wait_for(&mut output, "suffix");
     session.wait_for(&mut output, "done");
     session.wait_for(&mut output, "fallback");
-    session.write("/quit\r");
+    session.write("\x03");
     session.wait_for_exit();
 
     assert!(
@@ -1001,7 +1076,7 @@ fn test_cli_tty_groups_tool_activity_rows() {
     session.wait_for(&mut output, "denied");
     session.wait_for(&mut output, "contact admin");
     session.wait_for(&mut output, "done");
-    session.write("/quit\r");
+    session.write("\x03");
     session.wait_for_exit();
 
     assert!(
@@ -1090,7 +1165,7 @@ fn test_cli_tty_reconciles_unmatched_tool_activity_rows() {
     session.wait_for(&mut output, "lookup");
     session.wait_for(&mut output, "ended");
     session.wait_for(&mut output, "audit");
-    session.write("/quit\r");
+    session.write("\x03");
     session.wait_for_exit();
 
     assert!(
@@ -1231,7 +1306,7 @@ fn test_cli_tty_help_and_prompt_history() {
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
     session.write("/help\r");
-    session.wait_for(&mut output, "recalls");
+    session.wait_for(&mut output, "Show commands");
     session.write("remember this\r");
     session.wait_for(&mut output, "first");
     output.clear();
@@ -1244,7 +1319,7 @@ fn test_cli_tty_help_and_prompt_history() {
     session.wait_for(&mut output, "working");
     output.clear();
     session.wait_for(&mut output, "ready");
-    session.write("/quit\r");
+    session.write("\x03");
     session.wait_for_exit();
 
     server.assert_finished();
@@ -1273,21 +1348,14 @@ fn test_cli_tty_scrolls_multiline_help_rows() {
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
     session.write("/help\r");
-    session.wait_for(&mut output, "mouse wheel");
-    session.wait_for(&mut output, "cancels");
+    session.wait_for(&mut output, "PgUp/PgDn");
     output.clear();
     session.write("\x1b[5~\x1b[5~");
     session.wait_for(&mut output, "Commands");
     output.clear();
     session.write("\x1b[6~\x1b[6~");
-    session.wait_for(&mut output, "cancels");
-    output.clear();
-    session.write("\x1b[<64;1;1M\x1b[<64;1;1M");
-    session.wait_for(&mut output, "Commands");
-    output.clear();
-    session.write("\x1b[<65;1;1M\x1b[<65;1;1M");
-    session.wait_for(&mut output, "cancels");
-    session.write("/quit\r");
+    session.wait_for(&mut output, "Ctrl-C");
+    session.write("\x03");
     session.wait_for_exit();
 
     server.assert_finished();
@@ -1360,7 +1428,7 @@ fn test_cli_tty_renders_markdown_like_assistant_content() {
     session.wait_for(&mut output, "user_profile_id");
     session.wait_for(&mut output, "__init__");
     session.wait_for(&mut output, "Brewed for");
-    session.write("/quit\r");
+    session.write("\x03");
     session.wait_for_exit();
 
     assert!(
@@ -1435,7 +1503,7 @@ fn test_cli_tty_wraps_wide_transcript_text_by_display_width() {
     session.wait_for(&mut output, "Session");
     session.write("wide text\r");
     session.wait_for(&mut output, "👨‍💻");
-    session.write("/quit\r");
+    session.write("\x03");
     session.wait_for_exit();
 
     server.assert_finished();
@@ -1546,7 +1614,7 @@ fn test_cli_tty_queues_prompt_while_turn_is_running() {
     session.wait_for(&mut output, "› pending turn");
     session.wait_for(&mut output, "done-two");
     session.wait_for(&mut output, "Brewed for");
-    session.write("/quit\r");
+    session.write("\x03");
     session.wait_for_exit();
 
     let done_one = output
@@ -1678,7 +1746,7 @@ fn test_cli_tty_turn_boundary_stops_stale_streaming_transcript_item() {
     session.wait_for(&mut output, "alpha");
     session.write("second turn\r");
     session.wait_for(&mut output, "beta");
-    session.write("/quit\r");
+    session.write("\x03");
     session.wait_for_exit();
 
     assert!(
@@ -1807,7 +1875,7 @@ fn test_cli_tty_secret_interaction_masks_and_requires_input() {
     session.write("supersecret\r");
     session.wait_for(&mut output, "accepted");
     session.wait_for(&mut output, "Brewed for");
-    session.write("/quit\r");
+    session.write("\x03");
     session.wait_for_exit();
 
     assert!(
@@ -1891,16 +1959,18 @@ fn test_cli_resumes_latest_active_agent_session() {
         .arg(server.url())
         .args([
             "agent",
-            "--continue",
+            "resume",
             "--provider",
             "managed",
             "--message",
             "continue plan",
         ])
-        .write_stdin("/quit\n")
         .assert()
         .success()
         .stdout(predicate::str::contains("assistant> continued"))
+        .stdout(predicate::str::contains(
+            "Resume with: gestalt agent resume session-new",
+        ))
         .stderr(predicate::str::contains(
             "Session session-new [managed / gpt-5.4]",
         ));
@@ -1923,11 +1993,11 @@ fn test_cli_resume_fails_without_active_agent_session() {
         .env("GESTALT_API_KEY", TEST_TOKEN)
         .arg("--url")
         .arg(server.url())
-        .args(["agent", "--resume"])
+        .args(["agent", "resume"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "no active agent sessions found; omit --resume to create one",
+            "no active agent sessions found; use `gestalt agent` to create one",
         ));
 
     server.assert_finished();
@@ -1937,25 +2007,143 @@ fn test_cli_resume_fails_without_active_agent_session() {
 fn test_cli_rejects_interactive_agent_flags_with_subcommands() {
     let home = tempfile::tempdir().unwrap();
     cli_command(home.path())
-        .args(["agent", "--resume", "sessions", "list"])
+        .args(["agent", "--model", "gpt-5.5", "sessions", "list"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "--resume can only be used with interactive `gestalt agent`",
+            "--model must be passed before a prompt or after `agent resume`",
         ));
 }
 
 #[test]
-fn test_cli_agent_help_describes_resume_provider_filter() {
+fn test_cli_agent_help_describes_resume_command() {
     let home = tempfile::tempdir().unwrap();
     cli_command(home.path())
         .args(["agent", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("--resume"))
-        .stdout(predicate::str::contains("--continue"))
-        .stdout(predicate::str::contains("provider filter when resuming"))
+        .stdout(predicate::str::contains("resume"))
+        .stdout(predicate::str::contains("--resume").not())
+        .stdout(predicate::str::contains("--continue").not())
         .stdout(predicate::str::contains("--ui").not());
+
+    cli_command(home.path())
+        .args(["agent", "resume", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[SESSION_ID]"))
+        .stdout(predicate::str::contains("Provider filter when resuming"));
+}
+
+#[test]
+fn test_cli_agent_model_slash_lists_configured_providers() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions",
+            r#"{"provider":"managed","model":"gpt-5.4"}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            SESSION_JSON,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/providers",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "providers":[
+                    {"name":"managed","default":true},
+                    {"name":"anthropic"}
+                ]
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
+        .write_stdin("/model\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Resume with: gestalt agent resume session-1",
+        ))
+        .stderr(predicate::str::contains("current provider: managed"))
+        .stderr(predicate::str::contains("current model: gpt-5.4"))
+        .stderr(predicate::str::contains("managed (default)"))
+        .stderr(predicate::str::contains("anthropic"));
+
+    server.assert_finished();
+}
+
+#[test]
+fn test_cli_agent_model_slash_sets_future_turn_model() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions",
+            r#"{"provider":"managed","model":"gpt-5.4"}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            SESSION_JSON,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-1/turns",
+            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"hello"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-model",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.5",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-model/events/stream?after=0&limit=100&until=blocked_or_terminal",
+            StatusCode::OK,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"assistant.completed\",\"data\":{\"text\":\"hello from 5.5\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-model",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-model",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.5",
+                "status":"succeeded",
+                "outputText":"hello from 5.5"
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
+        .write_stdin("/model gpt-5.5\nhello\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("assistant> hello from 5.5"))
+        .stderr(predicate::str::contains(
+            "model gpt-5.5 selected for future turns",
+        ));
+
+    server.assert_finished();
 }
 
 #[test]
@@ -2070,8 +2258,8 @@ fn test_cli_resumes_existing_agent_session_and_resolves_input_interaction() {
         .env("GESTALT_API_KEY", TEST_TOKEN)
         .arg("--url")
         .arg(server.url())
-        .args(["agent", "--session", "session-2"])
-        .write_stdin("need incident context\n\n/quit\n")
+        .args(["agent", "resume", "session-2"])
+        .write_stdin("need incident context\n\n")
         .assert()
         .success()
         .stdout(predicate::str::contains(
@@ -2204,7 +2392,7 @@ fn test_cli_resolves_agent_interaction_in_interactive_mode() {
         .arg("--url")
         .arg(server.url())
         .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
-        .write_stdin("approve deployment\nY\n/quit\n")
+        .write_stdin("approve deployment\nY\n")
         .assert()
         .success()
         .stdout(predicate::str::contains(

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -455,6 +455,7 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	provider := newMemoryAgentProvider()
 	ts := newTestServer(t, func(cfg *server.Config) {
 		services := coretesting.NewStubServices(t)
+		agentControl := &stubAgentControl{defaultProviderName: "managed", provider: provider}
 		cfg.Auth = &coretesting.StubAuthProvider{
 			N: "stub",
 			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
@@ -465,8 +466,9 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 			},
 		}
 		cfg.Services = services
+		cfg.Agent = agentControl
 		cfg.AgentManager = agentmanager.New(agentmanager.Config{
-			Agent: &stubAgentControl{defaultProviderName: "managed", provider: provider},
+			Agent: agentControl,
 			Providers: testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
 				N:        "docs",
 				ConnMode: core.ConnectionModeNone,
@@ -515,6 +517,41 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	}
 	if len(sessions) != 1 || sessions[0]["id"] != sessionID {
 		t.Fatalf("sessions = %#v, want %q", sessions, sessionID)
+	}
+
+	providersReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/providers", nil)
+	providersReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	providersResp, err := http.DefaultClient.Do(providersReq)
+	if err != nil {
+		t.Fatalf("list providers: %v", err)
+	}
+	defer func() { _ = providersResp.Body.Close() }()
+	if providersResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(providersResp.Body)
+		t.Fatalf("list providers status = %d body=%s", providersResp.StatusCode, body)
+	}
+	var providers struct {
+		Providers []struct {
+			Name         string `json:"name"`
+			Default      bool   `json:"default"`
+			Capabilities struct {
+				StreamingText    bool `json:"streamingText"`
+				NativeToolSearch bool `json:"nativeToolSearch"`
+			} `json:"capabilities"`
+		} `json:"providers"`
+	}
+	if err := json.NewDecoder(providersResp.Body).Decode(&providers); err != nil {
+		t.Fatalf("decode providers: %v", err)
+	}
+	if len(providers.Providers) != 1 {
+		t.Fatalf("providers = %#v, want one provider", providers.Providers)
+	}
+	gotProvider := providers.Providers[0]
+	if gotProvider.Name != "managed" || !gotProvider.Default {
+		t.Fatalf("provider = %#v, want managed default", gotProvider)
+	}
+	if !gotProvider.Capabilities.StreamingText || !gotProvider.Capabilities.NativeToolSearch {
+		t.Fatalf("provider capabilities = %#v, want streaming text and native tool search", gotProvider.Capabilities)
 	}
 
 	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}]}`))

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -120,6 +120,27 @@ type agentSessionInfo struct {
 	LastTurnAt *time.Time         `json:"lastTurnAt,omitempty"`
 }
 
+type agentProviderListInfo struct {
+	Providers []agentProviderInfo `json:"providers"`
+}
+
+type agentProviderInfo struct {
+	Name         string                         `json:"name"`
+	Default      bool                           `json:"default,omitempty"`
+	Capabilities *agentProviderCapabilitiesInfo `json:"capabilities,omitempty"`
+}
+
+type agentProviderCapabilitiesInfo struct {
+	StreamingText      bool `json:"streamingText,omitempty"`
+	ToolCalls          bool `json:"toolCalls,omitempty"`
+	ParallelToolCalls  bool `json:"parallelToolCalls,omitempty"`
+	StructuredOutput   bool `json:"structuredOutput,omitempty"`
+	Interactions       bool `json:"interactions,omitempty"`
+	ResumableTurns     bool `json:"resumableTurns,omitempty"`
+	ReasoningSummaries bool `json:"reasoningSummaries,omitempty"`
+	NativeToolSearch   bool `json:"nativeToolSearch,omitempty"`
+}
+
 type agentTurnInfo struct {
 	ID               string                `json:"id"`
 	SessionID        string                `json:"sessionId"`
@@ -227,6 +248,44 @@ func (s *Server) listAgentSessions(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		out = append(out, agentSessionInfoFromCore(session))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) listAgentProviders(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.resolveAgentActor(w, r); !ok {
+		return
+	}
+	if s == nil || s.agent == nil {
+		writeError(w, http.StatusPreconditionFailed, agentmanager.ErrAgentNotConfigured.Error())
+		return
+	}
+
+	defaultProvider := ""
+	if name, _, err := s.agent.ResolveProviderSelection(""); err == nil {
+		defaultProvider = strings.TrimSpace(name)
+	}
+
+	names := s.agent.ProviderNames()
+	out := agentProviderListInfo{Providers: make([]agentProviderInfo, 0, len(names))}
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		info := agentProviderInfo{
+			Name:    name,
+			Default: name == defaultProvider,
+		}
+		provider, err := s.agent.ResolveProvider(name)
+		if err == nil && provider != nil {
+			if caps, err := provider.GetCapabilities(r.Context(), coreagent.GetCapabilitiesRequest{}); err == nil {
+				info.Capabilities = agentProviderCapabilitiesInfoFromCore(caps)
+			} else {
+				slog.WarnContext(r.Context(), "agent provider capabilities unavailable", "provider", name, "error", err)
+			}
+		}
+		out.Providers = append(out.Providers, info)
 	}
 	writeJSON(w, http.StatusOK, out)
 }
@@ -756,6 +815,22 @@ func agentSessionInfoFromCore(session *coreagent.Session) agentSessionInfo {
 	info.UpdatedAt = session.UpdatedAt
 	info.LastTurnAt = session.LastTurnAt
 	return info
+}
+
+func agentProviderCapabilitiesInfoFromCore(caps *coreagent.ProviderCapabilities) *agentProviderCapabilitiesInfo {
+	if caps == nil {
+		return nil
+	}
+	return &agentProviderCapabilitiesInfo{
+		StreamingText:      caps.StreamingText,
+		ToolCalls:          caps.ToolCalls,
+		ParallelToolCalls:  caps.ParallelToolCalls,
+		StructuredOutput:   caps.StructuredOutput,
+		Interactions:       caps.Interactions,
+		ResumableTurns:     caps.ResumableTurns,
+		ReasoningSummaries: caps.ReasoningSummaries,
+		NativeToolSearch:   caps.NativeToolSearch,
+	}
 }
 
 func agentTurnInfoFromCore(turn *coreagent.Turn) agentTurnInfo {

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -40,6 +40,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		})
 		r.Post("/agent/sessions", s.createAgentSession)
 		r.Get("/agent/sessions", s.listAgentSessions)
+		r.Get("/agent/providers", s.listAgentProviders)
 		r.Route("/agent/sessions", func(r chi.Router) {
 			r.Post("/", s.createAgentSession)
 			r.Get("/", s.listAgentSessions)

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -86,6 +86,7 @@ type Server struct {
 	users                  *coredata.UserService
 	externalCredentials    core.ExternalCredentialProvider
 	apiTokens              *coredata.APITokenService
+	agent                  bootstrap.AgentControl
 	workflowSchedules      *workflowmanager.Manager
 	agentRuns              agentmanager.Service
 	authorizationProvider  core.AuthorizationProvider
@@ -308,6 +309,7 @@ func New(cfg Config) (*Server, error) {
 		users:                  users,
 		externalCredentials:    externalCredentials,
 		apiTokens:              apiTokens,
+		agent:                  cfg.Agent,
 		agentRuns:              cfg.AgentManager,
 		authorizationProvider:  cfg.AuthorizationProvider,
 		providers:              cfg.Providers,


### PR DESCRIPTION
## Summary
- Update the CLI docs for the new resume and slash-command surface.
- Replace the interactive resume flags with the explicit `gestalt agent resume [session-id]` command.
- Trim the TUI/stdin slash-command surface to `/help`, `/session`, and `/model`; `/quit`, `/mouse`, `/copy`, `/clear`, and `/status` are not supported.
- Add `GET /api/v1/agent/providers` so clients can display configured agent providers and basic capabilities.
- Print the exact resume command on clean interactive exit.
- Stop capturing mouse input in the TUI so native terminal text selection works.

## Interfaces

### Rust CLI
```rust
pub enum AgentCommands {
    Resume(AgentResumeArgs),
    Sessions { command: AgentSessionCommands },
    Turns { command: AgentTurnCommands },
}

pub struct AgentResumeArgs {
    pub session_id: Option<String>,
    pub provider: Option<String>,
    pub model: Option<String>,
    pub system: Vec<String>,
    pub messages: Vec<String>,
    pub tools: Vec<AgentToolArg>,
}
```

Removed top-level interactive resume flags:
```text
--session
--resume / --continue
```

### stdin/stdout and TUI slash commands
```text
/help       Show commands and keys.
/session    Show the active session id and resume command.
/model      Show current model and configured providers.
/model X    Use model X for future turns in this session.
```

Clean interactive exit prints:
```text
Resume with: gestalt agent resume <session-id>
```

### HTTP
```http
GET /api/v1/agent/providers
```

```json
{
  "providers": [
    {
      "name": "managed",
      "default": true,
      "capabilities": {
        "streamingText": true,
        "nativeToolSearch": true
      }
    }
  ]
}
```

## Examples
```bash
gestalt agent resume <session-id>
gestalt agent resume --provider managed --message "continue plan"
```

Inside the interactive agent:
```text
/model
/model gpt-5.5
/session
```

## Tests
- `cargo clippy --manifest-path gestalt/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo test --manifest-path gestalt/Cargo.toml --test agents_cli test_cli_`
- `go test ./internal/server -run 'TestAgentSessionsAndTurnsRoundTrip'`
