### PR TITLE
Require provider-dev attach action permission

### DIFF
--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -58,7 +58,7 @@ Gestalt API tokens (`gst_api_*`). The plaintext is never stored, only a one-way 
 | `name` | string | Display name (e.g., `automation`, `cli-token`). |
 | `hashed_token` | string, unique | **SHA-256 hash.** Plaintext returned once at creation. |
 | `scopes` | string | Plaintext. Space-separated provider names. |
-| `permissions_json` | string | JSON-encoded provider access permissions. |
+| `permissions_json` | string | JSON-encoded provider operation permissions and provider-scoped action permissions such as `provider_dev.attach`. |
 | `expires_at` | time | Null for non-expiring tokens. |
 | `created_at` | time | |
 | `updated_at` | time | |

--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -834,27 +834,69 @@ a path-only attach is enough:
 
 ```sh
 export GESTALT_URL=https://gestalt.example.com
-gestalt auth login --url "$GESTALT_URL"
+export GESTALT_API_KEY=<token-with-provider_dev.attach>
 
 gestaltd provider dev --remote "$GESTALT_URL" --path ./slack
 ```
 
 The remote URL is environment-agnostic; it can point at any `gestaltd` instance
 that exposes provider-dev attach targets and has opted in with
-`server.providerDev.remoteAttach: true`. The local command replaces only the
-source plugin attached by your authenticated session. Providers that are not
-attached locally continue to run through the remote server and its existing
-configuration.
+`server.providerDev.remoteAttach: true`. The target plugin must also opt into
+private remote attach with `providerDev.attach.allowedRoles`, and API-token
+callers must use a token with the `provider_dev.attach` action for that plugin.
+The local command replaces only the source plugin attached by your
+authenticated session. Providers that are not attached locally continue to run
+through the remote server and its existing configuration.
+
+```yaml
+server:
+  providerDev:
+    remoteAttach: true
+
+authorization:
+  policies:
+    provider_devs:
+      default: deny
+      members:
+        - subjectID: user:usr_123
+          role: developer
+
+plugins:
+  slack:
+    authorizationPolicy: provider_devs
+    providerDev:
+      attach:
+        allowedRoles:
+          - developer
+```
+
+For non-interactive attach, create or supply an API token with an action
+permission. Provider scopes and operation permissions are intentionally not
+enough, and this action does not grant normal invocation access:
+
+```json
+{
+  "name": "slack local dev",
+  "permissions": [
+    {
+      "plugin": "slack",
+      "actions": ["provider_dev.attach"]
+    }
+  ]
+}
+```
 Remote attach v1 is process-local. On a load-balanced remote, enable it only
 when the deployment is single-replica or sticky-routes attach creation, CLI
 poll/complete traffic, provider invocations, and provider-owned UI requests for
 the same authenticated owner to the same `gestaltd` process.
 Remote provider dev authenticates with `--remote-token` first, then
-`GESTALT_API_KEY`, then the stored CLI token from `gestalt auth login` when the
-stored credential's server base URL matches `--remote`. A stored credential for
-a different server URL, including a different path prefix on the same host, is
-not sent; the command exits with the stored credential's server and file path
-plus commands to log in for the requested server or pass an explicit token. Use
+`GESTALT_API_KEY`, then a stored CLI token when the stored credential's server
+base URL matches `--remote`. The token must include `permissions[].actions:
+["provider_dev.attach"]` for every attached plugin. Plain `gestalt auth login`
+credentials are not enough unless the stored API token was minted with that
+action. A stored credential for a different server URL, including a different
+path prefix on the same host, is not sent; the command exits with the stored
+credential's server and file path plus commands to pass an explicit token. Use
 `--remote-token` or `GESTALT_API_KEY` for non-interactive automation.
 
 Remote attach creates an owner-scoped attachment. The server returns an
@@ -863,8 +905,6 @@ poll/complete traffic. Other users keep seeing the deployed provider and UI.
 Owner cleanup can detach a stuck attachment by `attachId`, but diagnostic
 list/get responses never expose dispatcher secrets, host-service env, plugin
 config, access tokens, or browser binding URLs.
-Attach creation currently uses the same provider access checks as normal
-provider use. A dedicated `provider_dev.attach` capability is planned separately.
 
 For `--remote --path` without `--config`, Gestalt matches the local manifest
 `source` to a configured plugin on the remote server. The remote plugin's

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -58,7 +58,7 @@ gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml 
 gestaltd provider dev --path ./plugins/support
 gestaltd provider dev --path ./ui/dashboard
 gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080
-gestalt auth login --url https://gestalt.example.com
+export GESTALT_API_KEY=<token-with-provider_dev.attach>
 gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support
 gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support --name support
 gestaltd provider dev --remote https://gestalt.example.com --config ./remote.yaml --config ./local-overrides.yaml
@@ -83,11 +83,13 @@ server or behind sticky routing that keeps attach creation, CLI poll/complete
 traffic, provider invocations, and provider-owned UI requests for the same
 authenticated owner on the same `gestaltd` process.
 Authentication resolves in this order: `--remote-token`, `GESTALT_API_KEY`, then
-the stored CLI token from `gestalt auth login` when its recorded server base URL
-matches `--remote`. Stored CLI tokens are not sent to a different remote URL,
-including a different path prefix on the same host; if the stored credential
-points elsewhere, the command fails with a remediation message instead of
-prompting.
+the stored CLI token when its recorded server base URL matches `--remote`. The
+token used for remote attach must include `permissions[].actions:
+["provider_dev.attach"]` for every attached plugin. Plain `gestalt auth login`
+credentials are not enough unless the stored API token was minted with that
+action. Stored CLI tokens are not sent to a different remote URL, including a
+different path prefix on the same host; if the stored credential points
+elsewhere, the command fails with a remediation message instead of prompting.
 With `--remote URL --path PATH` and no `--config`, the local command sends the
 manifest `source` and the local implementation only; the remote server chooses
 the configured plugin with the same manifest `source` and preserves that
@@ -99,9 +101,24 @@ remote instance.
 After the remote creates an attachment, the CLI uses the returned `attachId` plus
 a one-time dispatcher secret for poll/complete traffic. The dispatcher secret is
 not shown by list/get diagnostics and is not needed for owner cleanup detach.
-This version authorizes attach creation with the same provider access checks used
-by the remote server for the target plugin. A narrower `provider_dev.attach`
-capability is not implemented yet.
+Attach creation requires a provider-dev attach grant on the remote plugin and,
+when authenticating with an API token, an explicit token action permission:
+
+```json
+{
+  "name": "slack local dev",
+  "permissions": [
+    {
+      "plugin": "slack",
+      "actions": ["provider_dev.attach"]
+    }
+  ]
+}
+```
+
+Normal provider scopes and operation permissions do not grant remote attach, and
+`provider_dev.attach` does not grant normal invocation access. Subject-owned API
+tokens are not accepted for remote attach v1.
 
 When `--config` is present, source-backed plugin entries in the layered local
 config are treated as explicit local overrides. Their plugin config is sent to

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1004,6 +1004,7 @@ plugins:
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
+| `providerDev.attach.allowedRoles` | Roles from this plugin's `authorizationPolicy` that may create private remote provider-dev attachments for this plugin. This is denied when omitted, empty, or when the plugin has no `authorizationPolicy`. |
 | `execution` | Optional executable-plugin execution config. `execution.mode` is `local` or `hosted`; `execution.runtime` carries the hosted runtime fields. |
 | `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 | `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Schema-capable backends derive plugin scoping from that `db` name. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
@@ -1080,6 +1081,22 @@ on shared remotes:
 server:
   providerDev:
     remoteAttach: true
+
+authorization:
+  policies:
+    provider_devs:
+      default: deny
+      members:
+        - subjectID: user:usr_123
+          role: developer
+
+plugins:
+  slack:
+    authorizationPolicy: provider_devs
+    providerDev:
+      attach:
+        allowedRoles:
+          - developer
 ```
 
 The attach transport is private to the authenticated owner. The create response
@@ -1095,9 +1112,14 @@ sticky routing for attach creation, poll/complete traffic, provider invocations,
 and provider-owned UI requests as a hard prerequisite before enabling
 `remoteAttach`.
 
-Attach creation currently uses the same provider access checks as normal
-provider use. A dedicated `provider_dev.attach` action permission is planned
-separately and is not part of this transport contract.
+Attach creation requires both a plugin runtime grant and, for API-token
+callers, a token action grant. The runtime grant comes from
+`plugins.<name>.providerDev.attach.allowedRoles` on a plugin with an
+`authorizationPolicy`, or from a runtime authorizer that explicitly grants the
+same action. API tokens must carry `permissions[].actions:
+["provider_dev.attach"]` for every attached plugin; normal provider scopes and
+operation permissions do not grant attach, and the attach action does not grant
+operation invocation.
 
 Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider`.
 

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -242,7 +242,7 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	}
 	session, err := client.CreateSession(ctx, providerdev.CreateSessionRequest{Providers: requestedProviders})
 	if err != nil {
-		return err
+		return providerRemoteCreateSessionError(err)
 	}
 	attachID := strings.TrimSpace(session.AttachID)
 	if attachID == "" {
@@ -336,7 +336,7 @@ func resolveProviderRemoteToken(opts providerLocalCommandOptions) (string, error
 	if token := strings.TrimSpace(credential.APIToken); token != "" {
 		return token, nil
 	}
-	return "", fmt.Errorf("stored Gestalt CLI credential in %s is missing api_token; run 'gestalt auth login --url %s' or pass --remote-token", credentialPath, remoteBaseURL)
+	return "", fmt.Errorf("stored Gestalt CLI credential in %s is missing api_token; pass --remote-token with a user API token that grants provider_dev.attach for the target plugin", credentialPath)
 }
 
 func loadStoredGestaltCLICredential() (storedGestaltCLICredential, string, bool, error) {
@@ -410,13 +410,11 @@ Remote server:
 
 No --remote-token or %s was provided, and no stored Gestalt CLI credential for this server was found.
 
-Log in for this server:
+Create a user API token for this server with permissions[].actions including provider_dev.attach for the target plugin, then pass it explicitly:
 
-  gestalt auth login --url %s
+  gestaltd provider dev --remote %s --remote-token <token> --path ./plugin
 
-or pass an explicit token:
-
-  gestaltd provider dev --remote %s --remote-token <token> --path ./plugin`, remoteOrigin, gestaltAPIKeyEnv, remoteOrigin, remoteOrigin)
+You can also set %s for this command`, remoteOrigin, gestaltAPIKeyEnv, remoteOrigin, gestaltAPIKeyEnv)
 }
 
 func providerRemoteStoredCredentialUnscopedError(remoteOrigin, credentialPath string) error {
@@ -431,13 +429,9 @@ Stored credential:
 
 The stored credential does not record which Gestalt server it belongs to, so it was not sent.
 
-Log in for this server:
+Create a user API token for this server with permissions[].actions including provider_dev.attach for the target plugin, then pass it explicitly:
 
-  gestalt auth login --url %s
-
-or pass an explicit token:
-
-  gestaltd provider dev --remote %s --remote-token <token> --path ./plugin`, remoteOrigin, credentialPath, remoteOrigin, remoteOrigin)
+  gestaltd provider dev --remote %s --remote-token <token> --path ./plugin`, remoteOrigin, credentialPath, remoteOrigin)
 }
 
 func providerRemoteStoredCredentialMismatchError(remoteOrigin, storedOrigin, credentialPath string) error {
@@ -452,15 +446,25 @@ Stored credential:
 
 The stored credential is scoped to a different Gestalt server, so it was not sent.
 
-To use this remote server, log in for that server:
-
-  gestalt auth login --url %s
-
-or pass an explicit token:
+Create a user API token for this server with permissions[].actions including provider_dev.attach for the target plugin, then pass it explicitly:
 
   gestaltd provider dev --remote %s --remote-token <token> --path ./plugin
 
-You can also set %s for this command`, remoteOrigin, storedOrigin, credentialPath, remoteOrigin, remoteOrigin, gestaltAPIKeyEnv)
+You can also set %s for this command`, remoteOrigin, storedOrigin, credentialPath, remoteOrigin, gestaltAPIKeyEnv)
+}
+
+func providerRemoteCreateSessionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if !strings.Contains(err.Error(), "provider dev attach access denied") {
+		return err
+	}
+	return fmt.Errorf(`%w
+
+remote provider-dev attach was denied. The remote plugin must grant providerDev.attach.allowedRoles for your resolved role, and API token callers must use a user token with permissions[].actions including provider_dev.attach for every attached plugin.
+
+provider scopes, operation permissions, subject-owned API tokens, and plain gestalt auth login credentials do not grant remote attach`, err)
 }
 
 func providerRemoteTargetNames(targets []providerRemoteTarget) []string {
@@ -1626,5 +1630,5 @@ func printProviderDevUsage(w io.Writer) {
 	writeUsageLine(w, "  --name     Provider key override when the target key is ambiguous")
 	writeUsageLine(w, "  --port     Public port (default: auto-selected free localhost port)")
 	writeUsageLine(w, "  --remote   Remote gestaltd base URL to attach local source plugins to")
-	writeUsageLine(w, "  --remote-token  Bearer token for --remote (default: GESTALT_API_KEY or matching gestalt auth login credentials)")
+	writeUsageLine(w, "  --remote-token  Bearer token for --remote (default: GESTALT_API_KEY or matching stored CLI credential; must grant provider_dev.attach)")
 }

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -180,7 +180,7 @@ func TestResolveProviderRemoteTokenErrors(t *testing.T) {
 					"Stored credential:\n  server: https://valon.tools",
 					filepath.Join(configHome, "gestalt", "credentials.json"),
 					"The stored credential is scoped to a different Gestalt server, so it was not sent.",
-					"gestalt auth login --url https://staging.valon.tools",
+					"permissions[].actions including provider_dev.attach",
 					"gestaltd provider dev --remote https://staging.valon.tools --remote-token <token> --path ./plugin",
 					"You can also set GESTALT_API_KEY for this command",
 				}
@@ -194,7 +194,7 @@ func TestResolveProviderRemoteTokenErrors(t *testing.T) {
 				return []string{
 					"Stored credential:\n  server: <missing>",
 					"The stored credential does not record which Gestalt server it belongs to, so it was not sent.",
-					"gestalt auth login --url https://valon.tools",
+					"permissions[].actions including provider_dev.attach",
 				}
 			},
 		},
@@ -206,7 +206,7 @@ func TestResolveProviderRemoteTokenErrors(t *testing.T) {
 					"provider dev --remote requires authentication.",
 					"Remote server:\n  https://valon.tools",
 					"No --remote-token or GESTALT_API_KEY was provided, and no stored Gestalt CLI credential for this server was found.",
-					"gestalt auth login --url https://valon.tools",
+					"permissions[].actions including provider_dev.attach",
 					"gestaltd provider dev --remote https://valon.tools --remote-token <token> --path ./plugin",
 				}
 			},
@@ -233,6 +233,30 @@ func TestResolveProviderRemoteTokenErrors(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestProviderRemoteCreateSessionErrorAddsAttachPermissionGuidance(t *testing.T) {
+	t.Parallel()
+
+	err := providerRemoteCreateSessionError(errors.New("provider dev remote POST /api/v1/provider-dev/attachments: 403 Forbidden: provider dev attach access denied"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{
+		"remote provider-dev attach was denied",
+		"providerDev.attach.allowedRoles",
+		"permissions[].actions including provider_dev.attach",
+		"plain gestalt auth login credentials do not grant remote attach",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q:\n%s", want, err)
+		}
+	}
+
+	other := errors.New("network unavailable")
+	if got := providerRemoteCreateSessionError(other); got != other {
+		t.Fatalf("unrelated error was wrapped: %v", got)
 	}
 }
 

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -33,7 +33,10 @@ type ExternalCredential struct {
 type AccessPermission struct {
 	Plugin     string   `json:"plugin"`
 	Operations []string `json:"operations,omitempty"`
+	Actions    []string `json:"actions,omitempty"`
 }
+
+const ProviderActionDevAttach = "provider_dev.attach"
 
 type APIToken struct {
 	ID                  string

--- a/gestaltd/internal/authorization/runtime.go
+++ b/gestaltd/internal/authorization/runtime.go
@@ -31,6 +31,12 @@ type RuntimeAuthorizer interface {
 	StaticMembersForProvider(provider string) (string, []StaticSubjectMember, bool)
 }
 
+// ProviderActionAuthorizer optionally grants provider-scoped actions that are
+// not operation invocations, such as provider-dev remote attach.
+type ProviderActionAuthorizer interface {
+	AllowProviderAction(ctx context.Context, p *principal.Principal, provider, action string) bool
+}
+
 // ManagedAuthorizationModelResolver exposes the authorization model managed by
 // the current runtime authorizer when one exists.
 type ManagedAuthorizationModelResolver interface {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1424,6 +1424,7 @@ func cloneBootstrapWorkflowExecutionRef(ref *coreworkflow.ExecutionReference) *c
 	clone.Permissions = append([]core.AccessPermission(nil), ref.Permissions...)
 	for i := range clone.Permissions {
 		clone.Permissions[i].Operations = append([]string(nil), clone.Permissions[i].Operations...)
+		clone.Permissions[i].Actions = append([]string(nil), clone.Permissions[i].Actions...)
 	}
 	if ref.CreatedAt != nil {
 		createdAt := ref.CreatedAt.UTC()

--- a/gestaltd/internal/bootstrap/startup_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_proxy.go
@@ -721,6 +721,7 @@ func cloneStartupWorkflowExecutionRef(ref *coreworkflow.ExecutionReference) *cor
 	clone.Permissions = append([]core.AccessPermission(nil), ref.Permissions...)
 	for i := range clone.Permissions {
 		clone.Permissions[i].Operations = append([]string(nil), clone.Permissions[i].Operations...)
+		clone.Permissions[i].Actions = append([]string(nil), clone.Permissions[i].Actions...)
 	}
 	if ref.CreatedAt != nil {
 		createdAt := ref.CreatedAt.UTC()

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -120,6 +120,7 @@ func cloneRuntimeExecutionRef(ref *coreworkflow.ExecutionReference) *coreworkflo
 	clone.Permissions = append([]core.AccessPermission(nil), ref.Permissions...)
 	for i := range clone.Permissions {
 		clone.Permissions[i].Operations = append([]string(nil), ref.Permissions[i].Operations...)
+		clone.Permissions[i].Actions = append([]string(nil), ref.Permissions[i].Actions...)
 	}
 	if ref.CreatedAt != nil {
 		createdAt := ref.CreatedAt.UTC()

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -381,7 +381,8 @@ type ProviderEntry struct {
 	SecuritySchemes map[string]*HTTPSecurityScheme `yaml:"securitySchemes,omitempty"`
 	HTTP            map[string]*HTTPBinding        `yaml:"http,omitempty"`
 	// AuthorizationPolicy binds this provider to a shared subject access policy.
-	AuthorizationPolicy string `yaml:"authorizationPolicy,omitempty"`
+	AuthorizationPolicy string                  `yaml:"authorizationPolicy,omitempty"`
+	ProviderDev         *ProviderEntryDevConfig `yaml:"providerDev,omitempty"`
 
 	// Plugin-specific runtime fields populated from the canonical ui object.
 	MountPath         string                        `yaml:"-"`
@@ -413,6 +414,14 @@ type ProviderEntry struct {
 }
 
 type providerEntryFields ProviderEntry
+
+type ProviderEntryDevConfig struct {
+	Attach ProviderEntryDevAttachConfig `yaml:"attach,omitempty"`
+}
+
+type ProviderEntryDevAttachConfig struct {
+	AllowedRoles []string `yaml:"allowedRoles,omitempty"`
+}
 
 type providerEntryYAML struct {
 	providerEntryFields `yaml:",inline"`
@@ -826,8 +835,18 @@ func (f providerEntryFields) toProviderEntry() ProviderEntry {
 func providerEntryFieldsFromEntry(e ProviderEntry) providerEntryFields {
 	e.Egress = cloneProviderEgressConfig(e.Egress)
 	e.Execution = cloneExecutionConfig(e.Execution)
+	e.ProviderDev = cloneProviderEntryDevConfig(e.ProviderDev)
 	normalizeProviderEntryAliases(&e)
 	return providerEntryFields(e)
+}
+
+func cloneProviderEntryDevConfig(src *ProviderEntryDevConfig) *ProviderEntryDevConfig {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	dst.Attach.AllowedRoles = slices.Clone(src.Attach.AllowedRoles)
+	return &dst
 }
 
 func normalizeProviderEntryAliases(entry *ProviderEntry) {
@@ -839,6 +858,9 @@ func normalizeProviderEntryAliases(entry *ProviderEntry) {
 	}
 	if entry.Execution != nil {
 		entry.Execution.Mode = ExecutionMode(strings.ToLower(strings.TrimSpace(string(entry.Execution.Mode))))
+	}
+	if entry.ProviderDev != nil {
+		entry.ProviderDev.Attach.AllowedRoles = trimStringSlice(entry.ProviderDev.Attach.AllowedRoles)
 	}
 }
 

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -34,9 +34,11 @@ type Principal struct {
 	AuthSourceOverride  string
 	Scopes              []string
 	TokenPermissions    PermissionSet
+	ActionPermissions   ActionPermissionSet
 }
 
 type PermissionSet map[string]map[string]struct{}
+type ActionPermissionSet map[string]map[string]struct{}
 
 func (s Source) String() string {
 	switch s {
@@ -71,7 +73,7 @@ func (p *Principal) AuthSource() string {
 	if authSource := strings.TrimSpace(p.AuthSourceOverride); authSource != "" {
 		return authSource
 	}
-	if p.Identity == nil && p.UserID == "" && p.SubjectID == "" && p.Kind == "" && len(p.Scopes) == 0 && p.TokenPermissions == nil {
+	if p.Identity == nil && p.UserID == "" && p.SubjectID == "" && p.Kind == "" && len(p.Scopes) == 0 && p.TokenPermissions == nil && p.ActionPermissions == nil {
 		return ""
 	}
 	return p.Source.String()
@@ -152,6 +154,9 @@ func CompilePermissions(perms []core.AccessPermission) PermissionSet {
 			continue
 		}
 		if len(perm.Operations) == 0 {
+			if len(perm.Actions) > 0 {
+				continue
+			}
 			set[plugin] = nil
 			continue
 		}
@@ -172,7 +177,36 @@ func CompilePermissions(perms []core.AccessPermission) PermissionSet {
 		}
 	}
 	if len(set) == 0 {
+		return PermissionSet{}
+	}
+	return set
+}
+
+func CompileActionPermissions(perms []core.AccessPermission) ActionPermissionSet {
+	if len(perms) == 0 {
 		return nil
+	}
+	set := make(ActionPermissionSet, len(perms))
+	for _, perm := range perms {
+		plugin := strings.TrimSpace(perm.Plugin)
+		if plugin == "" {
+			continue
+		}
+		for _, action := range perm.Actions {
+			action = strings.TrimSpace(action)
+			if action == "" {
+				continue
+			}
+			actions := set[plugin]
+			if actions == nil {
+				actions = map[string]struct{}{}
+				set[plugin] = actions
+			}
+			actions[action] = struct{}{}
+		}
+	}
+	if len(set) == 0 {
+		return ActionPermissionSet{}
 	}
 	return set
 }
@@ -300,6 +334,21 @@ func AllowsOperationPermission(p *Principal, provider, operation string) bool {
 		return ok
 	}
 	return AllowsProviderPermission(p, provider)
+}
+
+func AllowsActionPermission(p *Principal, provider, action string) bool {
+	if p == nil {
+		return false
+	}
+	if p.ActionPermissions != nil {
+		actions, ok := p.ActionPermissions[provider]
+		if !ok {
+			return false
+		}
+		_, ok = actions[action]
+		return ok
+	}
+	return p.Source != SourceAPIToken
 }
 
 func clonePermissionOps(src map[string]struct{}) map[string]struct{} {

--- a/gestaltd/internal/principal/resolver.go
+++ b/gestaltd/internal/principal/resolver.go
@@ -149,8 +149,9 @@ func (r *Resolver) resolveUserAPIToken(ctx context.Context, apiToken *core.APITo
 		Kind:                KindUser,
 		Source:              SourceAPIToken,
 	}
-	if perms := permissionsForAPIToken(apiToken); perms != nil {
+	if perms, actionPerms, ok := permissionsForAPIToken(apiToken); ok {
 		p.TokenPermissions = perms
+		p.ActionPermissions = actionPerms
 		p.Scopes = PermissionPlugins(perms)
 	}
 	return p, nil
@@ -179,8 +180,9 @@ func resolveSubjectAPIToken(apiToken *core.APIToken) (*Principal, error) {
 		DisplayName:         strings.TrimSpace(apiToken.Name),
 		Source:              SourceAPIToken,
 	}
-	if perms := permissionsForAPIToken(apiToken); perms != nil {
+	if perms, actionPerms, ok := permissionsForAPIToken(apiToken); ok {
 		p.TokenPermissions = perms
+		p.ActionPermissions = actionPerms
 		p.Scopes = PermissionPlugins(perms)
 	}
 	return Canonicalize(p), nil
@@ -199,14 +201,17 @@ func HashToken(token string) string {
 	return hex.EncodeToString(h[:])
 }
 
-func permissionsForAPIToken(apiToken *core.APIToken) PermissionSet {
+func permissionsForAPIToken(apiToken *core.APIToken) (PermissionSet, ActionPermissionSet, bool) {
 	if apiToken == nil {
-		return nil
+		return nil, nil, false
 	}
-	if perms := CompilePermissions(apiToken.Permissions); perms != nil {
-		return perms
+	if len(apiToken.Permissions) > 0 {
+		return CompilePermissions(apiToken.Permissions), CompileActionPermissions(apiToken.Permissions), true
 	}
-	return PermissionsFromScopeString(apiToken.Scopes)
+	if perms := PermissionsFromScopeString(apiToken.Scopes); perms != nil {
+		return perms, nil, true
+	}
+	return nil, nil, false
 }
 
 func (r *Resolver) apiTokenOwnerKind(apiToken *core.APIToken) string {

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
@@ -14,6 +16,34 @@ func (s *Server) allowProviderContext(ctx context.Context, p *principal.Principa
 		return true
 	}
 	return s.authorizer.AllowProvider(ctx, p, provider)
+}
+
+func (s *Server) allowProviderActionContext(ctx context.Context, p *principal.Principal, provider, action string) bool {
+	if s.authorizer != nil {
+		if actionAuthorizer, ok := s.authorizer.(authorization.ProviderActionAuthorizer); ok && actionAuthorizer.AllowProviderAction(ctx, p, provider, action) {
+			return true
+		}
+	}
+	if action != core.ProviderActionDevAttach {
+		return false
+	}
+	entry := s.pluginDefs[provider]
+	if entry == nil || entry.ProviderDev == nil || len(entry.ProviderDev.Attach.AllowedRoles) == 0 {
+		return false
+	}
+	if strings.TrimSpace(entry.AuthorizationPolicy) == "" || s.authorizer == nil {
+		return false
+	}
+	access, ok := s.authorizer.ResolveAccess(ctx, p, provider)
+	if !ok || strings.TrimSpace(access.Policy) == "" || strings.TrimSpace(access.Role) == "" {
+		return false
+	}
+	for _, role := range entry.ProviderDev.Attach.AllowedRoles {
+		if strings.TrimSpace(role) == access.Role {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) providerAccessContextWithContext(ctx context.Context, p *principal.Principal, provider string) invocation.AccessContext {

--- a/gestaltd/internal/server/handlers_provider_dev.go
+++ b/gestaltd/internal/server/handlers_provider_dev.go
@@ -8,11 +8,14 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+var errProviderDevAttachAccess = errors.New("provider dev attach access denied")
 
 func (s *Server) createProviderDevSession(w http.ResponseWriter, r *http.Request) {
 	if !s.providerDevAvailable(w) {
@@ -73,9 +76,9 @@ func (s *Server) authorizeProviderDevSessionRequest(w http.ResponseWriter, r *ht
 		if name == "" {
 			continue
 		}
-		if !principal.AllowsProviderPermission(p, name) || !s.allowProviderContext(r.Context(), p, name) {
-			writeError(w, http.StatusForbidden, errOperationAccess.Error())
-			return errOperationAccess
+		if !principal.AllowsActionPermission(p, name, core.ProviderActionDevAttach) || !s.allowProviderActionContext(r.Context(), p, name, core.ProviderActionDevAttach) {
+			writeError(w, http.StatusForbidden, errProviderDevAttachAccess.Error())
+			return errProviderDevAttachAccess
 		}
 	}
 	return nil

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -15,8 +15,9 @@ import (
 )
 
 type createTokenRequest struct {
-	Name   string `json:"name"`
-	Scopes string `json:"scopes"`
+	Name        string                  `json:"name"`
+	Scopes      string                  `json:"scopes"`
+	Permissions []core.AccessPermission `json:"permissions,omitempty"`
 }
 
 type createTokenResponse struct {
@@ -55,6 +56,11 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 	}
 	auditTarget = apiTokenAuditTarget("", req.Name)
 
+	if req.Scopes != "" && len(req.Permissions) > 0 {
+		auditErr = errors.New("scopes and permissions are mutually exclusive")
+		writeError(w, http.StatusBadRequest, "scopes and permissions are mutually exclusive")
+		return
+	}
 	if req.Scopes != "" {
 		for _, scope := range strings.Fields(req.Scopes) {
 			if _, err := s.providers.Get(scope); err != nil {
@@ -64,8 +70,14 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	permissions, err := s.normalizeAPITokenPermissions(req.Permissions)
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
-	apiToken, plaintext, err := s.issueAPIToken(r.Context(), userID, req.Name, req.Scopes, false)
+	apiToken, plaintext, err := s.issueAPITokenWithPermissions(r.Context(), userID, req.Name, req.Scopes, permissions, false)
 	if err != nil {
 		auditErr = errors.New("failed to generate token")
 		writeError(w, http.StatusInternalServerError, "failed to generate token")
@@ -79,9 +91,66 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 		ID:          apiToken.ID,
 		Name:        apiToken.Name,
 		Token:       plaintext,
-		Permissions: append([]core.AccessPermission(nil), apiToken.Permissions...),
+		Permissions: cloneAccessPermissions(apiToken.Permissions),
 		ExpiresAt:   apiToken.ExpiresAt,
 	})
+}
+
+func (s *Server) normalizeAPITokenPermissions(values []core.AccessPermission) ([]core.AccessPermission, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make([]core.AccessPermission, 0, len(values))
+	for i, value := range values {
+		plugin := strings.TrimSpace(value.Plugin)
+		if plugin == "" {
+			return nil, fmt.Errorf("permissions[%d].plugin is required", i)
+		}
+		if _, err := s.providers.Get(plugin); err != nil {
+			return nil, fmt.Errorf("unknown permission plugin %q", plugin)
+		}
+		operations, err := normalizeAPITokenPermissionNames(fmt.Sprintf("permissions[%d].operations", i), value.Operations, nil)
+		if err != nil {
+			return nil, err
+		}
+		actions, err := normalizeAPITokenPermissionNames(fmt.Sprintf("permissions[%d].actions", i), value.Actions, map[string]struct{}{
+			core.ProviderActionDevAttach: {},
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, core.AccessPermission{
+			Plugin:     plugin,
+			Operations: operations,
+			Actions:    actions,
+		})
+	}
+	return out, nil
+}
+
+func normalizeAPITokenPermissionNames(label string, values []string, allowed map[string]struct{}) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := values[:0]
+	seen := make(map[string]struct{}, len(values))
+	for i, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil, fmt.Errorf("%s[%d] is required", label, i)
+		}
+		if allowed != nil {
+			if _, ok := allowed[value]; !ok {
+				return nil, fmt.Errorf("%s[%d] has unsupported action %q", label, i, value)
+			}
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out, nil
 }
 
 type apiTokenInfo struct {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1480,6 +1480,11 @@ func oauthRefreshConnectionAuth(integration string, refreshFn func(context.Conte
 
 func seedAPIToken(t *testing.T, svc *coredata.Services, plaintext, hashed, userID string) {
 	t.Helper()
+	seedAPITokenWithPermissions(t, svc, plaintext, hashed, userID, nil)
+}
+
+func seedAPITokenWithPermissions(t *testing.T, svc *coredata.Services, plaintext, hashed, userID string, permissions []core.AccessPermission) *core.User {
+	t.Helper()
 	ctx := context.Background()
 	user, err := svc.Users.FindOrCreateUser(ctx, userID+"@test.local")
 	if err != nil {
@@ -1494,12 +1499,19 @@ func seedAPIToken(t *testing.T, svc *coredata.Services, plaintext, hashed, userI
 		Name:                "test-token",
 		HashedToken:         hashed,
 		ExpiresAt:           &exp,
+		Permissions:         cloneAccessPermissionsForTest(permissions),
 	}); err != nil {
 		t.Fatalf("seedAPIToken: StoreAPIToken: %v", err)
 	}
+	return user
 }
 
 func seedSubjectAPIToken(t *testing.T, svc *coredata.Services, hashed, subjectID, name string) {
+	t.Helper()
+	seedSubjectAPITokenWithPermissions(t, svc, hashed, subjectID, name, nil)
+}
+
+func seedSubjectAPITokenWithPermissions(t *testing.T, svc *coredata.Services, hashed, subjectID, name string, permissions []core.AccessPermission) {
 	t.Helper()
 	exp := time.Now().Add(24 * time.Hour)
 	if err := svc.APITokens.StoreAPIToken(context.Background(), &core.APIToken{
@@ -1510,9 +1522,22 @@ func seedSubjectAPIToken(t *testing.T, svc *coredata.Services, hashed, subjectID
 		Name:                name,
 		HashedToken:         hashed,
 		ExpiresAt:           &exp,
+		Permissions:         cloneAccessPermissionsForTest(permissions),
 	}); err != nil {
 		t.Fatalf("seedSubjectAPIToken: StoreAPIToken: %v", err)
 	}
+}
+
+func cloneAccessPermissionsForTest(src []core.AccessPermission) []core.AccessPermission {
+	if len(src) == 0 {
+		return nil
+	}
+	out := append([]core.AccessPermission(nil), src...)
+	for i := range out {
+		out[i].Operations = append([]string(nil), out[i].Operations...)
+		out[i].Actions = append([]string(nil), out[i].Actions...)
+	}
+	return out
 }
 
 func seedUser(t *testing.T, svc *coredata.Services, email string) *core.User {
@@ -6156,6 +6181,19 @@ func TestProviderDevAttachmentRoutesEnforceGateDispatcherSecretAndRedaction(t *t
 		cfg.Auth = auth
 		cfg.ProviderDevAttach = true
 		cfg.ProviderDevSessions = newManager(t)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"roadmap": {
+				AuthorizationPolicy: "provider_devs",
+				ProviderDev: &config.ProviderEntryDevConfig{
+					Attach: config.ProviderEntryDevAttachConfig{AllowedRoles: []string{"viewer"}},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{
+			Policies: map[string]config.SubjectPolicyDef{
+				"provider_devs": {Default: "allow"},
+			},
+		}, cfg.PluginDefs)
 	})
 	testutil.CloseOnCleanup(t, enabledTS)
 	req, err = http.NewRequest(http.MethodPost, enabledTS.URL+providerdev.PathAttachments, bytes.NewReader(createBody))
@@ -6331,6 +6369,110 @@ func TestProviderDevAttachmentRoutesEnforceGateDispatcherSecretAndRedaction(t *t
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("delete status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestProviderDevAttachmentCreateRequiresAttachActionPermission(t *testing.T) {
+	t.Parallel()
+
+	newManager := func(t *testing.T) *providerdev.Manager {
+		t.Helper()
+		manager, err := providerdev.NewManager([]providerdev.Target{{
+			Name:   "roadmap",
+			Source: "github.com/acme/plugins/roadmap",
+		}})
+		if err != nil {
+			t.Fatalf("NewManager: %v", err)
+		}
+		return manager
+	}
+	newToken := func(t *testing.T) (string, string) {
+		t.Helper()
+		plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+		if err != nil {
+			t.Fatalf("GenerateToken: %v", err)
+		}
+		return plaintext, hashed
+	}
+	svc := coretesting.NewStubServices(t)
+	broadToken, broadHash := newToken(t)
+	seedAPIToken(t, svc, broadToken, broadHash, "broad-user")
+	invokeToken, invokeHash := newToken(t)
+	seedAPITokenWithPermissions(t, svc, invokeToken, invokeHash, "invoke-user", []core.AccessPermission{{Plugin: "roadmap"}})
+	attachToken, attachHash := newToken(t)
+	seedAPITokenWithPermissions(t, svc, attachToken, attachHash, "attach-user", []core.AccessPermission{{
+		Plugin:  "roadmap",
+		Actions: []string{core.ProviderActionDevAttach},
+	}})
+	subjectToken, subjectHash := newToken(t)
+	seedSubjectAPITokenWithPermissions(t, svc, subjectHash, "service_account:roadmap-dev", "roadmap-dev", []core.AccessPermission{{
+		Plugin:  "roadmap",
+		Actions: []string{core.ProviderActionDevAttach},
+	}})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(context.Context, string) (*core.UserIdentity, error) {
+				return nil, fmt.Errorf("not a session token")
+			},
+		}
+		cfg.Services = svc
+		cfg.ProviderDevAttach = true
+		cfg.ProviderDevSessions = newManager(t)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"roadmap": {
+				AuthorizationPolicy: "provider_devs",
+				ProviderDev: &config.ProviderEntryDevConfig{
+					Attach: config.ProviderEntryDevAttachConfig{AllowedRoles: []string{"viewer"}},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{
+			Policies: map[string]config.SubjectPolicyDef{
+				"provider_devs": {Default: "allow"},
+			},
+		}, cfg.PluginDefs)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	create := func(t *testing.T, token string) (int, string) {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, ts.URL+providerdev.PathAttachments, strings.NewReader(`{"providers":[{"name":"roadmap"}]}`))
+		if err != nil {
+			t.Fatalf("new create request: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := ts.Client().Do(req)
+		if err != nil {
+			t.Fatalf("create request: %v", err)
+		}
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			t.Fatalf("read create response: %v", err)
+		}
+		return resp.StatusCode, string(body)
+	}
+
+	for name, token := range map[string]string{
+		"legacy broad token": broadToken,
+		"invoke permission":  invokeToken,
+		"subject token":      subjectToken,
+	} {
+		status, body := create(t, token)
+		if status != http.StatusForbidden {
+			t.Fatalf("%s create status = %d, want 403; body = %s", name, status, body)
+		}
+	}
+
+	status, body := create(t, attachToken)
+	if status != http.StatusCreated {
+		t.Fatalf("attach action create status = %d, want 201; body = %s", status, body)
+	}
+	if !strings.Contains(body, `"attachId"`) || !strings.Contains(body, `"dispatcherSecret"`) {
+		t.Fatalf("attach action create response missing attachId/dispatcherSecret: %s", body)
 	}
 }
 
@@ -13837,6 +13979,68 @@ func TestCreateAndListAPITokens(t *testing.T) {
 	}
 	if result["name"] != "my-token" {
 		t.Fatalf("expected name my-token, got %q", result["name"])
+	}
+}
+
+func TestCreateAPIToken_WithActionPermissions(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeNone,
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"attach-token","permissions":[{"plugin":"roadmap","actions":["provider_dev.attach"]}]}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create status = %d, want 201: %s", resp.StatusCode, respBody)
+	}
+	var created struct {
+		ID          string                  `json:"id"`
+		Token       string                  `json:"token"`
+		Permissions []core.AccessPermission `json:"permissions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.ID == "" || created.Token == "" {
+		t.Fatalf("create response missing id/token: %+v", created)
+	}
+	if len(created.Permissions) != 1 || created.Permissions[0].Plugin != "roadmap" || len(created.Permissions[0].Actions) != 1 || created.Permissions[0].Actions[0] != core.ProviderActionDevAttach || len(created.Permissions[0].Operations) != 0 {
+		t.Fatalf("created permissions = %#v", created.Permissions)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/tokens", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("list status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+	var listed []struct {
+		ID          string                  `json:"id"`
+		Permissions []core.AccessPermission `json:"permissions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != created.ID || len(listed[0].Permissions) != 1 || len(listed[0].Permissions[0].Actions) != 1 || listed[0].Permissions[0].Actions[0] != core.ProviderActionDevAttach {
+		t.Fatalf("listed tokens = %#v", listed)
 	}
 }
 

--- a/gestaltd/internal/server/token_helpers.go
+++ b/gestaltd/internal/server/token_helpers.go
@@ -17,12 +17,17 @@ func (s *Server) nowUTCSecond() time.Time {
 }
 
 func (s *Server) issueAPIToken(ctx context.Context, userID, name, scopes string, nonExpiring bool) (*core.APIToken, string, error) {
+	return s.issueAPITokenWithPermissions(ctx, userID, name, scopes, nil, nonExpiring)
+}
+
+func (s *Server) issueAPITokenWithPermissions(ctx context.Context, userID, name, scopes string, permissions []core.AccessPermission, nonExpiring bool) (*core.APIToken, string, error) {
 	return s.issueOwnedAPIToken(ctx, &core.APIToken{
 		OwnerKind:           core.APITokenOwnerKindUser,
 		OwnerID:             userID,
 		CredentialSubjectID: principal.UserSubjectID(userID),
 		Name:                name,
 		Scopes:              scopes,
+		Permissions:         cloneAccessPermissions(permissions),
 	}, nonExpiring)
 }
 
@@ -61,8 +66,20 @@ func apiTokenInfoFromCore(token *core.APIToken) apiTokenInfo {
 		ID:          token.ID,
 		Name:        token.Name,
 		Scopes:      token.Scopes,
-		Permissions: append([]core.AccessPermission(nil), token.Permissions...),
+		Permissions: cloneAccessPermissions(token.Permissions),
 		CreatedAt:   token.CreatedAt,
 		ExpiresAt:   token.ExpiresAt,
 	}
+}
+
+func cloneAccessPermissions(src []core.AccessPermission) []core.AccessPermission {
+	if len(src) == 0 {
+		return nil
+	}
+	out := append([]core.AccessPermission(nil), src...)
+	for i := range out {
+		out[i].Operations = append([]string(nil), out[i].Operations...)
+		out[i].Actions = append([]string(nil), out[i].Actions...)
+	}
+	return out
 }

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -407,6 +407,7 @@ func cloneWorkflowExecutionReference(ref *coreworkflow.ExecutionReference) *core
 	cloned.Permissions = append([]core.AccessPermission(nil), ref.Permissions...)
 	for i := range cloned.Permissions {
 		cloned.Permissions[i].Operations = append([]string(nil), cloned.Permissions[i].Operations...)
+		cloned.Permissions[i].Actions = append([]string(nil), cloned.Permissions[i].Actions...)
 	}
 	if ref.CreatedAt != nil {
 		value := *ref.CreatedAt


### PR DESCRIPTION
## Summary

Requires remote provider-dev attach creation to use an explicit provider-scoped action instead of ordinary provider invoke access.

## New interfaces

API token permissions now support provider actions:

```json
{
  "name": "slack local dev",
  "permissions": [
    {
      "plugin": "slack",
      "actions": ["provider_dev.attach"]
    }
  ]
}
```

Plugin config can grant attach by resolved role:

```yaml
plugins:
  slack:
    authorizationPolicy: provider_devs
    providerDev:
      attach:
        allowedRoles:
          - developer
```

Usage stays the same, but the token must now include the attach action and the remote plugin must grant attach:

```sh
gestaltd provider dev --remote https://valon.tools --remote-token <token> --path ./slack
```

## Behavior

- `permissions[].actions:["provider_dev.attach"]` does not grant normal operation invocation.
- Existing provider scopes and `permissions[].operations` do not grant provider-dev remote attach.
- Subject-owned API tokens remain denied for remote attach v1.
- Static attach grants require `plugins.<name>.authorizationPolicy` plus `plugins.<name>.providerDev.attach.allowedRoles`.
- Docs now cover the config, token payload, and local development flow.

## Verification

- `go test ./...`
- `golangci-lint run --allow-parallel-runners ./...`