### PR TITLE
workflow: add generic agent progress bridge

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -1723,13 +1723,18 @@ func (m *stubWorkflowManager) Subjects() []string {
 
 type stubAgentTurnManagerProvider struct {
 	coreagent.UnimplementedProvider
-	mu                    sync.Mutex
-	createSessionRequests []coreagent.CreateSessionRequest
-	createTurnRequests    []coreagent.CreateTurnRequest
-	sessions              map[string]*coreagent.Session
-	turns                 map[string]*coreagent.Turn
-	turnEvents            map[string][]*coreagent.TurnEvent
-	interactions          map[string]*coreagent.Interaction
+	mu                     sync.Mutex
+	createSessionRequests  []coreagent.CreateSessionRequest
+	createTurnRequests     []coreagent.CreateTurnRequest
+	createTurnErr          error
+	createTurnStatus       coreagent.ExecutionStatus
+	completeRunningOnGet   bool
+	turnEventsOnCreate     []*coreagent.TurnEvent
+	listTurnEventsRequests []coreagent.ListTurnEventsRequest
+	sessions               map[string]*coreagent.Session
+	turns                  map[string]*coreagent.Turn
+	turnEvents             map[string][]*coreagent.TurnEvent
+	interactions           map[string]*coreagent.Interaction
 }
 
 func newStubAgentTurnManagerProvider() *stubAgentTurnManagerProvider {
@@ -1805,26 +1810,41 @@ func (p *stubAgentTurnManagerProvider) UpdateSession(_ context.Context, req core
 func (p *stubAgentTurnManagerProvider) CreateTurn(_ context.Context, req coreagent.CreateTurnRequest) (*coreagent.Turn, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.createTurnErr != nil {
+		return nil, p.createTurnErr
+	}
 
 	now := time.Now().UTC().Truncate(time.Second)
 	p.createTurnRequests = append(p.createTurnRequests, req)
+	status := p.createTurnStatus
+	if status == "" {
+		status = coreagent.ExecutionStatusSucceeded
+	}
 
 	turn := &coreagent.Turn{
 		ID:           req.TurnID,
 		SessionID:    req.SessionID,
 		ProviderName: "managed",
 		Model:        req.Model,
-		Status:       coreagent.ExecutionStatusSucceeded,
+		Status:       status,
 		Messages:     append([]coreagent.Message(nil), req.Messages...),
 		OutputText:   "turn completed",
 		CreatedBy:    req.CreatedBy,
 		CreatedAt:    &now,
 		StartedAt:    &now,
-		CompletedAt:  &now,
 		ExecutionRef: req.ExecutionRef,
+	}
+	if status == coreagent.ExecutionStatusSucceeded || status == coreagent.ExecutionStatusFailed || status == coreagent.ExecutionStatusCanceled || status == coreagent.ExecutionStatusWaitingForInput {
+		turn.CompletedAt = &now
 	}
 	p.turns[turn.ID] = turn
 	p.appendTurnEventLocked(turn.ID, "turn.started", map[string]any{"session_id": req.SessionID})
+	for _, event := range p.turnEventsOnCreate {
+		if event == nil {
+			continue
+		}
+		p.appendTurnEventLocked(turn.ID, event.Type, event.Data)
+	}
 
 	if requireInteraction, _ := req.Metadata["requireInteraction"].(bool); requireInteraction {
 		turn.Status = coreagent.ExecutionStatusWaitingForInput
@@ -1843,7 +1863,7 @@ func (p *stubAgentTurnManagerProvider) CreateTurn(_ context.Context, req coreage
 			CreatedAt: &now,
 		}
 		p.appendTurnEventLocked(turn.ID, "interaction.requested", map[string]any{"interaction_id": interactionID})
-	} else {
+	} else if turn.Status == coreagent.ExecutionStatusSucceeded {
 		p.appendTurnEventLocked(turn.ID, "assistant.completed", map[string]any{"text": "turn completed"})
 		p.appendTurnEventLocked(turn.ID, "turn.completed", map[string]any{"status": "succeeded"})
 	}
@@ -1861,6 +1881,13 @@ func (p *stubAgentTurnManagerProvider) GetTurn(_ context.Context, req coreagent.
 	turn, ok := p.turns[req.TurnID]
 	if !ok {
 		return nil, core.ErrNotFound
+	}
+	if p.completeRunningOnGet && turn.Status == coreagent.ExecutionStatusRunning {
+		now := time.Now().UTC().Truncate(time.Second)
+		turn.Status = coreagent.ExecutionStatusSucceeded
+		turn.CompletedAt = &now
+		p.appendTurnEventLocked(turn.ID, "assistant.completed", map[string]any{"text": "turn completed"})
+		p.appendTurnEventLocked(turn.ID, "turn.completed", map[string]any{"status": "succeeded"})
 	}
 	return cloneAgentTurn(turn), nil
 }
@@ -1895,6 +1922,7 @@ func (p *stubAgentTurnManagerProvider) CancelTurn(_ context.Context, req coreage
 func (p *stubAgentTurnManagerProvider) ListTurnEvents(_ context.Context, req coreagent.ListTurnEventsRequest) ([]*coreagent.TurnEvent, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.listTurnEventsRequests = append(p.listTurnEventsRequests, req)
 	events := p.turnEvents[req.TurnID]
 	out := make([]*coreagent.TurnEvent, 0, len(events))
 	for _, event := range events {

--- a/gestaltd/internal/bootstrap/workflow_agent_progress_bridge.go
+++ b/gestaltd/internal/bootstrap/workflow_agent_progress_bridge.go
@@ -1,0 +1,525 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+const (
+	workflowAgentProgressMetadataKey       = "gestalt.workflow.agent_progress"
+	workflowAgentProgressUpdateMinInterval = 2 * time.Second
+	workflowAgentProgressUpdateTimeout     = 2 * time.Second
+	workflowAgentProgressClearTimeout      = 5 * time.Second
+)
+
+type workflowAgentProgressBridge struct {
+	invoker           invocation.Invoker
+	principal         *principal.Principal
+	updateTarget      coreagent.ToolTarget
+	clearTarget       coreagent.ToolTarget
+	params            map[string]any
+	updateParams      map[string]any
+	clearParams       map[string]any
+	statusParam       string
+	rules             []workflowAgentProgressRule
+	defaultToolStatus string
+	lastStatus        string
+	lastUpdatedAt     time.Time
+	minInterval       time.Duration
+	cleared           bool
+}
+
+type workflowAgentProgressConfig struct {
+	updateRef         coreagent.ToolRef
+	clearRef          coreagent.ToolRef
+	params            map[string]any
+	updateParams      map[string]any
+	clearParams       map[string]any
+	statusParam       string
+	rules             []workflowAgentProgressRule
+	defaultToolStatus string
+	minInterval       time.Duration
+}
+
+type workflowAgentProgressRule struct {
+	eventType        string
+	identifier       string
+	identifierPrefix string
+	plugin           string
+	pluginPrefix     string
+	operation        string
+	operationPrefix  string
+	status           string
+	ignore           bool
+}
+
+func newWorkflowAgentProgressBridge(ctx context.Context, target coreworkflow.AgentTarget, principalValue *principal.Principal, agentManager agentmanager.Service, invoker invocation.Invoker, callerPluginName string) (*workflowAgentProgressBridge, error) {
+	if agentManager == nil || invoker == nil || principalValue == nil {
+		return nil, nil
+	}
+	cfg, ok, err := workflowAgentProgressConfigFromMetadata(target.Metadata)
+	if err != nil || !ok {
+		return nil, err
+	}
+	cfg.updateRef = workflowAgentProgressRefWithSelectors(cfg.updateRef, target.ToolRefs)
+	cfg.clearRef = workflowAgentProgressRefWithSelectors(cfg.clearRef, target.ToolRefs)
+	tools, err := agentManager.ResolveTools(ctx, principalValue, coreagent.ResolveToolsRequest{
+		ToolRefs:         []coreagent.ToolRef{cfg.updateRef, cfg.clearRef},
+		ToolSource:       target.ToolSource,
+		CallerPluginName: strings.TrimSpace(callerPluginName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	updateTarget, ok := workflowAgentProgressTargetForRef(tools, cfg.updateRef)
+	if !ok {
+		return nil, fmt.Errorf("resolved workflow agent progress update tool is missing")
+	}
+	clearTarget, ok := workflowAgentProgressTargetForRef(tools, cfg.clearRef)
+	if !ok {
+		return nil, fmt.Errorf("resolved workflow agent progress clear tool is missing")
+	}
+	return &workflowAgentProgressBridge{
+		invoker:           invoker,
+		principal:         principalValue,
+		updateTarget:      updateTarget,
+		clearTarget:       clearTarget,
+		params:            cfg.params,
+		updateParams:      cfg.updateParams,
+		clearParams:       cfg.clearParams,
+		statusParam:       cfg.statusParam,
+		rules:             cfg.rules,
+		defaultToolStatus: cfg.defaultToolStatus,
+		minInterval:       cfg.minInterval,
+	}, nil
+}
+
+func workflowAgentProgressConfigFromMetadata(metadata map[string]any) (workflowAgentProgressConfig, bool, error) {
+	raw, ok := metadata[workflowAgentProgressMetadataKey]
+	if !ok || raw == nil {
+		return workflowAgentProgressConfig{}, false, nil
+	}
+	configMap, ok := raw.(map[string]any)
+	if !ok {
+		return workflowAgentProgressConfig{}, false, fmt.Errorf("workflow agent progress metadata must be an object")
+	}
+	updateRef, updateParams, ok := workflowAgentProgressToolRef(configMap, "update")
+	if !ok {
+		return workflowAgentProgressConfig{}, false, fmt.Errorf("workflow agent progress metadata update tool is required")
+	}
+	clearRef, clearParams, ok := workflowAgentProgressToolRef(configMap, "clear")
+	if !ok {
+		return workflowAgentProgressConfig{}, false, fmt.Errorf("workflow agent progress metadata clear tool is required")
+	}
+	statusParam := stringMapValue(configMap, "statusParam", "status_param")
+	if statusParam == "" {
+		statusParam = "status"
+	}
+	minInterval := workflowAgentProgressUpdateMinInterval
+	if parsed, ok := workflowAgentProgressDuration(configMap["minInterval"]); ok {
+		minInterval = parsed
+	} else if parsed, ok := workflowAgentProgressDuration(configMap["min_interval"]); ok {
+		minInterval = parsed
+	}
+	return workflowAgentProgressConfig{
+		updateRef:         updateRef,
+		clearRef:          clearRef,
+		params:            mapValue(configMap, "params"),
+		updateParams:      updateParams,
+		clearParams:       clearParams,
+		statusParam:       statusParam,
+		rules:             workflowAgentProgressRules(configMap["rules"]),
+		defaultToolStatus: stringMapValue(configMap, "defaultToolStatus", "default_tool_status"),
+		minInterval:       minInterval,
+	}, true, nil
+}
+
+func workflowAgentProgressToolRef(configMap map[string]any, key string) (coreagent.ToolRef, map[string]any, bool) {
+	raw := configMap[key]
+	if raw == nil {
+		return coreagent.ToolRef{}, nil, false
+	}
+	toolMap, ok := raw.(map[string]any)
+	if !ok {
+		return coreagent.ToolRef{}, nil, false
+	}
+	ref := coreagent.ToolRef{
+		Plugin:         stringMapValue(toolMap, "plugin"),
+		Operation:      stringMapValue(toolMap, "operation"),
+		Connection:     stringMapValue(toolMap, "connection"),
+		Instance:       stringMapValue(toolMap, "instance"),
+		CredentialMode: core.ConnectionMode(stringMapValue(toolMap, "credentialMode", "credential_mode")),
+	}
+	return ref, mapValue(toolMap, "params"), strings.TrimSpace(ref.Plugin) != "" && strings.TrimSpace(ref.Operation) != ""
+}
+
+func workflowAgentProgressRefWithSelectors(ref coreagent.ToolRef, refs []coreagent.ToolRef) coreagent.ToolRef {
+	var match *coreagent.ToolRef
+	for i := range refs {
+		candidate := &refs[i]
+		if !workflowAgentProgressToolRefMatches(ref, *candidate) {
+			continue
+		}
+		if match != nil {
+			return ref
+		}
+		match = candidate
+	}
+	if match == nil {
+		return ref
+	}
+	if strings.TrimSpace(ref.Connection) == "" {
+		ref.Connection = strings.TrimSpace(match.Connection)
+	}
+	if strings.TrimSpace(ref.Instance) == "" {
+		ref.Instance = strings.TrimSpace(match.Instance)
+	}
+	if ref.CredentialMode == "" {
+		ref.CredentialMode = match.CredentialMode
+	}
+	return ref
+}
+
+func workflowAgentProgressToolRefMatches(ref coreagent.ToolRef, candidate coreagent.ToolRef) bool {
+	if strings.TrimSpace(candidate.Plugin) != strings.TrimSpace(ref.Plugin) || strings.TrimSpace(candidate.Operation) != strings.TrimSpace(ref.Operation) {
+		return false
+	}
+	return workflowAgentProgressSelectorMatches(ref.Connection, candidate.Connection, workflowAgentProgressNormalizeConnection) &&
+		workflowAgentProgressSelectorMatches(ref.Instance, candidate.Instance, workflowAgentProgressNormalizeSelector) &&
+		(ref.CredentialMode == "" || candidate.CredentialMode == ref.CredentialMode)
+}
+
+func workflowAgentProgressDuration(raw any) (time.Duration, bool) {
+	switch value := raw.(type) {
+	case string:
+		parsed, err := time.ParseDuration(strings.TrimSpace(value))
+		return parsed, err == nil
+	case int:
+		return time.Duration(value) * time.Second, true
+	case int64:
+		return time.Duration(value) * time.Second, true
+	case float64:
+		return time.Duration(value * float64(time.Second)), true
+	default:
+		return 0, false
+	}
+}
+
+func workflowAgentProgressRules(raw any) []workflowAgentProgressRule {
+	items, ok := raw.([]any)
+	if !ok || len(items) == 0 {
+		return nil
+	}
+	rules := make([]workflowAgentProgressRule, 0, len(items))
+	for _, item := range items {
+		ruleMap, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		status := stringMapValue(ruleMap, "status")
+		ignore := boolMapValue(ruleMap, "ignore")
+		if status == "" && !ignore {
+			continue
+		}
+		rules = append(rules, workflowAgentProgressRule{
+			eventType:        stringMapValue(ruleMap, "event", "type"),
+			identifier:       stringMapValue(ruleMap, "identifier", "tool"),
+			identifierPrefix: stringMapValue(ruleMap, "identifierPrefix", "identifier_prefix", "toolPrefix", "tool_prefix"),
+			plugin:           stringMapValue(ruleMap, "plugin"),
+			pluginPrefix:     stringMapValue(ruleMap, "pluginPrefix", "plugin_prefix"),
+			operation:        stringMapValue(ruleMap, "operation"),
+			operationPrefix:  stringMapValue(ruleMap, "operationPrefix", "operation_prefix"),
+			status:           status,
+			ignore:           ignore,
+		})
+	}
+	return rules
+}
+
+func workflowAgentProgressTargetForRef(tools []coreagent.Tool, ref coreagent.ToolRef) (coreagent.ToolTarget, bool) {
+	for i := range tools {
+		target := tools[i].Target
+		if workflowAgentProgressTargetMatchesRef(target, ref) {
+			return target, true
+		}
+	}
+	return coreagent.ToolTarget{}, false
+}
+
+func workflowAgentProgressTargetMatchesRef(target coreagent.ToolTarget, ref coreagent.ToolRef) bool {
+	if strings.TrimSpace(target.Plugin) != strings.TrimSpace(ref.Plugin) || strings.TrimSpace(target.Operation) != strings.TrimSpace(ref.Operation) {
+		return false
+	}
+	return workflowAgentProgressSelectorMatches(ref.Connection, target.Connection, workflowAgentProgressNormalizeConnection) &&
+		workflowAgentProgressSelectorMatches(ref.Instance, target.Instance, workflowAgentProgressNormalizeSelector) &&
+		(ref.CredentialMode == "" || target.CredentialMode == ref.CredentialMode)
+}
+
+func (b *workflowAgentProgressBridge) ObserveTurnEvents(ctx context.Context, events []*coreagent.TurnEvent) {
+	if b == nil || len(events) == 0 {
+		return
+	}
+	status := ""
+	for _, event := range events {
+		if next := b.statusForTurnEvent(event); next != "" {
+			status = next
+		}
+	}
+	if status == "" {
+		return
+	}
+	b.update(ctx, status)
+}
+
+func (b *workflowAgentProgressBridge) CompleteTurn(ctx context.Context, _ *coreagent.Turn) {
+	b.clear(ctx)
+}
+
+func (b *workflowAgentProgressBridge) ClearWithDetachedTimeout(ctx context.Context) {
+	if b == nil {
+		return
+	}
+	clearCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), workflowAgentProgressClearTimeout)
+	defer cancel()
+	b.clear(clearCtx)
+}
+
+func (b *workflowAgentProgressBridge) statusForTurnEvent(event *coreagent.TurnEvent) string {
+	if b == nil || event == nil {
+		return ""
+	}
+	for i := range b.rules {
+		if b.rules[i].matches(event) {
+			if b.rules[i].ignore {
+				return ""
+			}
+			return b.rules[i].status
+		}
+	}
+	if strings.TrimSpace(event.Type) == "tool.started" {
+		return strings.TrimSpace(b.defaultToolStatus)
+	}
+	return ""
+}
+
+func (r workflowAgentProgressRule) matches(event *coreagent.TurnEvent) bool {
+	if event == nil {
+		return false
+	}
+	if r.eventType != "" && strings.TrimSpace(event.Type) != r.eventType {
+		return false
+	}
+	if r.identifier == "" && r.identifierPrefix == "" && r.plugin == "" && r.pluginPrefix == "" && r.operation == "" && r.operationPrefix == "" {
+		return true
+	}
+	for _, identifier := range workflowAgentProgressToolIdentifiers(event) {
+		if workflowAgentProgressRuleMatchesIdentifier(r, identifier) {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowAgentProgressRuleMatchesIdentifier(rule workflowAgentProgressRule, identifier string) bool {
+	plugin, operation, normalized := normalizedToolIdentifier(identifier)
+	if normalized == "" {
+		return false
+	}
+	if rule.identifier != "" {
+		_, _, wanted := normalizedToolIdentifier(rule.identifier)
+		if normalized != wanted {
+			return false
+		}
+	}
+	if rule.identifierPrefix != "" && !strings.HasPrefix(normalized, normalizedToolRuleValue(rule.identifierPrefix)) {
+		return false
+	}
+	if rule.plugin != "" && plugin != normalizedToolRuleValue(rule.plugin) {
+		return false
+	}
+	if rule.pluginPrefix != "" && !strings.HasPrefix(plugin, normalizedToolRuleValue(rule.pluginPrefix)) {
+		return false
+	}
+	if rule.operation != "" {
+		_, _, wanted := normalizedToolIdentifier(rule.operation)
+		if operation != wanted && normalized != wanted {
+			return false
+		}
+	}
+	if rule.operationPrefix != "" && !workflowAgentProgressOperationHasPrefix(operation, normalized, rule.operationPrefix) {
+		return false
+	}
+	return true
+}
+
+func workflowAgentProgressToolIdentifiers(event *coreagent.TurnEvent) []string {
+	if event == nil {
+		return nil
+	}
+	identifiers := make([]string, 0, 4)
+	if event.Display != nil {
+		identifiers = append(identifiers, event.Display.Label)
+	}
+	if event.Data != nil {
+		identifiers = append(identifiers,
+			stringMapValue(event.Data, "tool_id", "toolId"),
+			stringMapValue(event.Data, "operation"),
+			stringMapValue(event.Data, "tool_name", "toolName", "name"),
+		)
+	}
+	return identifiers
+}
+
+func (b *workflowAgentProgressBridge) update(ctx context.Context, status string) {
+	status = strings.TrimSpace(status)
+	if b == nil || status == "" || status == b.lastStatus {
+		return
+	}
+	now := time.Now()
+	minInterval := b.minInterval
+	if minInterval <= 0 {
+		minInterval = workflowAgentProgressUpdateMinInterval
+	}
+	if !b.lastUpdatedAt.IsZero() && now.Sub(b.lastUpdatedAt) < minInterval {
+		return
+	}
+	b.lastStatus = status
+	b.lastUpdatedAt = now
+	b.cleared = false
+	params := maps.Clone(b.params)
+	if params == nil {
+		params = map[string]any{}
+	}
+	maps.Copy(params, b.updateParams)
+	params[b.statusParam] = status
+	updateCtx, cancel := context.WithTimeout(ctx, workflowAgentProgressUpdateTimeout)
+	defer cancel()
+	_, _ = invokeResolvedToolTarget(updateCtx, b.invoker, b.principal, b.updateTarget, params)
+}
+
+func (b *workflowAgentProgressBridge) clear(ctx context.Context) {
+	if b == nil || b.cleared {
+		return
+	}
+	params := maps.Clone(b.params)
+	if params == nil {
+		params = map[string]any{}
+	}
+	maps.Copy(params, b.clearParams)
+	if _, err := invokeResolvedToolTarget(ctx, b.invoker, b.principal, b.clearTarget, params); err == nil {
+		b.cleared = true
+	}
+}
+
+func invokeResolvedToolTarget(ctx context.Context, invoker invocation.Invoker, principalValue *principal.Principal, target coreagent.ToolTarget, params map[string]any) (*core.OperationResult, error) {
+	if invoker == nil {
+		return nil, fmt.Errorf("plugin invoker is not available")
+	}
+	if connection := strings.TrimSpace(target.Connection); connection != "" {
+		ctx = invocation.WithConnection(ctx, connection)
+	}
+	if mode := target.CredentialMode; mode != "" {
+		ctx = invocation.WithCredentialModeOverride(ctx, mode)
+	}
+	return invoker.Invoke(ctx, principalValue, target.Plugin, strings.TrimSpace(target.Instance), target.Operation, maps.Clone(params))
+}
+
+func normalizedToolIdentifier(identifier string) (plugin string, operation string, normalized string) {
+	normalized = strings.ToLower(strings.TrimSpace(identifier))
+	if idx := strings.Index(normalized, "?"); idx >= 0 {
+		normalized = normalized[:idx]
+	}
+	if normalized == "" {
+		return "", "", ""
+	}
+	if before, after, ok := strings.Cut(normalized, "/"); ok {
+		return strings.TrimSpace(before), strings.TrimSpace(after), normalized
+	}
+	if before, after, ok := strings.Cut(normalized, "."); ok {
+		return strings.TrimSpace(before), strings.TrimSpace(after), normalized
+	}
+	return "", "", normalized
+}
+
+func normalizedToolRuleValue(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func workflowAgentProgressOperationHasPrefix(operation string, normalized string, prefix string) bool {
+	prefix = normalizedToolRuleValue(prefix)
+	if prefix == "" {
+		return false
+	}
+	return strings.HasPrefix(operation, prefix) || strings.HasPrefix(normalized, prefix)
+}
+
+func workflowAgentProgressSelectorMatches(want string, got string, normalize func(string) string) bool {
+	want = normalize(want)
+	if want == "" {
+		return true
+	}
+	return normalize(got) == want
+}
+
+func workflowAgentProgressNormalizeConnection(value string) string {
+	return config.ResolveConnectionAlias(strings.TrimSpace(value))
+}
+
+func workflowAgentProgressNormalizeSelector(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func mapValue(values map[string]any, key string) map[string]any {
+	if values == nil {
+		return nil
+	}
+	value, ok := values[key]
+	if !ok || value == nil {
+		return nil
+	}
+	if typed, ok := value.(map[string]any); ok {
+		return maps.Clone(typed)
+	}
+	return nil
+}
+
+func stringMapValue(values map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := values[key]; ok && value != nil {
+			text := strings.TrimSpace(fmt.Sprint(value))
+			if text != "" && text != "<nil>" {
+				return text
+			}
+		}
+	}
+	return ""
+}
+
+func boolMapValue(values map[string]any, key string) bool {
+	if values == nil {
+		return false
+	}
+	value, ok := values[key]
+	if !ok {
+		return false
+	}
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return strings.EqualFold(strings.TrimSpace(typed), "true")
+	default:
+		return false
+	}
+}

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -205,7 +205,7 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 		return nil, fmt.Errorf("workflow target cannot include both agent and plugin fields")
 	}
 	if req.Target.Agent != nil {
-		return r.invokeAgent(ctx, req, agentManager)
+		return r.invokeAgent(ctx, req, agentManager, invoker)
 	}
 	if invoker == nil {
 		return nil, fmt.Errorf("workflow runtime invoker is not configured")
@@ -303,7 +303,7 @@ func workflowTargetHasMixedKinds(target coreworkflow.Target) bool {
 	return target.Agent != nil && target.Plugin != nil && coreworkflow.PluginTargetSet(*target.Plugin)
 }
 
-func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.InvokeOperationRequest, agentManager agentmanager.Service) (*coreworkflow.InvokeOperationResponse, error) {
+func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.InvokeOperationRequest, agentManager agentmanager.Service, invoker invocation.Invoker) (*coreworkflow.InvokeOperationResponse, error) {
 	if agentManager == nil {
 		return nil, fmt.Errorf("workflow runtime agent manager is not configured")
 	}
@@ -328,6 +328,13 @@ func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.Invo
 		return nil, fmt.Errorf("workflow agent target is required")
 	}
 	agentTarget := *target.Agent
+	progressBridge, progressBridgeErr := newWorkflowAgentProgressBridge(ctx, agentTarget, principalValue, agentManager, invoker, callerPluginName)
+	if progressBridgeErr != nil {
+		progressBridge = nil
+	}
+	if progressBridge != nil {
+		defer progressBridge.ClearWithDetachedTimeout(ctx)
+	}
 	timeout := workflowAgentTimeout(agentTarget.TimeoutSeconds)
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -369,7 +376,11 @@ func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.Invo
 	if err != nil {
 		return nil, err
 	}
-	turn, err = waitForWorkflowAgentTurn(runCtx, agentManager, principalValue, turn)
+	var observer workflowAgentTurnObserver
+	if progressBridge != nil {
+		observer = progressBridge
+	}
+	turn, err = waitForWorkflowAgentTurn(runCtx, agentManager, principalValue, turn, observer)
 	if err != nil {
 		if turn != nil && strings.TrimSpace(turn.ID) != "" {
 			_, _ = agentManager.CancelTurn(context.WithoutCancel(ctx), principalValue, turn.ID, err.Error())
@@ -387,6 +398,11 @@ func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.Invo
 	default:
 		return nil, fmt.Errorf("workflow agent turn %q finished with status %q: %s", turn.ID, turn.Status, strings.TrimSpace(turn.StatusMessage))
 	}
+}
+
+type workflowAgentTurnObserver interface {
+	ObserveTurnEvents(ctx context.Context, events []*coreagent.TurnEvent)
+	CompleteTurn(ctx context.Context, turn *coreagent.Turn)
 }
 
 func workflowAgentTimeout(seconds int) time.Duration {
@@ -459,11 +475,22 @@ func workflowSignalMessage(signals []coreworkflow.Signal) *coreagent.Message {
 	}
 }
 
-func waitForWorkflowAgentTurn(ctx context.Context, agentManager agentmanager.Service, p *principal.Principal, turn *coreagent.Turn) (*coreagent.Turn, error) {
+func waitForWorkflowAgentTurn(ctx context.Context, agentManager agentmanager.Service, p *principal.Principal, turn *coreagent.Turn, observer workflowAgentTurnObserver) (*coreagent.Turn, error) {
 	if turn == nil || strings.TrimSpace(turn.ID) == "" {
 		return nil, fmt.Errorf("workflow agent turn is missing")
 	}
 	current := turn
+	if observer != nil {
+		defer func() {
+			if current == nil || strings.TrimSpace(current.ID) == "" {
+				return
+			}
+			completeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			defer cancel()
+			observer.CompleteTurn(completeCtx, current)
+		}()
+	}
+	var lastEventSeq int64
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	for {
@@ -475,6 +502,17 @@ func waitForWorkflowAgentTurn(ctx context.Context, agentManager agentmanager.Ser
 		case <-ctx.Done():
 			return current, ctx.Err()
 		case <-ticker.C:
+			if observer != nil {
+				events, err := agentManager.ListTurnEvents(ctx, p, current.ID, lastEventSeq, 50)
+				if err == nil {
+					for _, event := range events {
+						if event != nil && event.Seq > lastEventSeq {
+							lastEventSeq = event.Seq
+						}
+					}
+					observer.ObserveTurnEvents(ctx, events)
+				}
+			}
 			next, err := agentManager.GetTurn(ctx, p, current.ID)
 			if err != nil {
 				return current, err

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"slices"
@@ -30,6 +31,17 @@ import (
 
 type funcInvoker struct {
 	invoke func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error)
+}
+
+type workflowRuntimeRecordedInvoke struct {
+	providerName   string
+	instance       string
+	operation      string
+	connection     string
+	credentialMode core.ConnectionMode
+	params         map[string]any
+	ctxErr         error
+	hasDeadline    bool
 }
 
 func testWorkflowPluginTarget(pluginName, operation string) coreworkflow.Target {
@@ -452,6 +464,8 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 		t.Fatalf("Register roadmap: %v", err)
 	}
 	agentProvider := newStubAgentTurnManagerProvider()
+	agentProvider.createTurnStatus = coreagent.ExecutionStatusRunning
+	agentProvider.completeRunningOnGet = true
 	agentRuntime := &agentRuntime{
 		defaultProviderName: "managed",
 		providers:           map[string]coreagent.Provider{"managed": agentProvider},
@@ -522,6 +536,373 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 	if len(turnReq.ToolRefs) != 1 || turnReq.ToolRefs[0].Plugin != "roadmap" || turnReq.ToolRefs[0].Operation != "sync" {
 		t.Fatalf("turn tool refs = %#v", turnReq.ToolRefs)
 	}
+	if len(agentProvider.listTurnEventsRequests) != 0 {
+		t.Fatalf("list turn events requests = %#v, want none for agent target without progress metadata", agentProvider.listTurnEventsRequests)
+	}
+}
+
+func TestWorkflowRuntimeInvokeAgentTargetUpdatesConfiguredProgressFromTurnEvents(t *testing.T) {
+	t.Parallel()
+
+	agentProvider := newStubAgentTurnManagerProvider()
+	agentProvider.createTurnStatus = coreagent.ExecutionStatusRunning
+	agentProvider.completeRunningOnGet = true
+	agentProvider.turnEventsOnCreate = []*coreagent.TurnEvent{
+		{
+			Type: "tool.started",
+			Data: map[string]any{
+				"operation": "messages.reply",
+				"arguments": map[string]any{"secret": "not for status"},
+			},
+		},
+		{
+			Type: "tool.started",
+			Data: map[string]any{
+				"tool_id": "notifier/activity.update?credentialMode=none",
+			},
+		},
+	}
+	runtime, refProvider, invokes := newProgressWorkflowRuntimeHarness(t, agentProvider)
+	target := testProgressAgentTarget(5)
+	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+		ID:                  "progress-agent-ref",
+		ProviderName:        "temporal",
+		Target:              target,
+		TargetFingerprint:   testWorkflowRuntimeTargetFingerprint(t, target),
+		CallerPluginName:    "notifier",
+		SubjectID:           "service_account:notifier-agent",
+		CredentialSubjectID: "service_account:notifier-agent",
+		Permissions: []core.AccessPermission{{
+			Plugin:     "notifier",
+			Operations: []string{"activity.update", "activity.clear"},
+		}},
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+
+	resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		ExecutionRef: "progress-agent-ref",
+		RunID:        "run-agent-123",
+		Target:       target,
+		Signals: []coreworkflow.Signal{{
+			ID:      "sig-1",
+			Name:    "message.event",
+			Payload: map[string]any{"message": "hello"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != http.StatusOK || resp.Body != "turn completed" {
+		t.Fatalf("response = %#v", resp)
+	}
+	if len(*invokes) != 2 {
+		t.Fatalf("invocations = %#v, want update and clear", *invokes)
+	}
+	updateCall := (*invokes)[0]
+	if updateCall.providerName != "notifier" || updateCall.operation != "activity.update" {
+		t.Fatalf("update invocation = %#v", updateCall)
+	}
+	if updateCall.instance != "tenant-a" || updateCall.connection != "service" || updateCall.credentialMode != core.ConnectionModeNone {
+		t.Fatalf("update target selectors = %#v", updateCall)
+	}
+	if got := updateCall.params["text"]; got != "is sending a reply..." {
+		t.Fatalf("update status = %#v, want configured reply status", got)
+	}
+	if got := updateCall.params["handle"]; got != "opaque-progress-handle" {
+		t.Fatalf("progress handle = %#v, want configured handle", got)
+	}
+	if !updateCall.hasDeadline {
+		t.Fatalf("update invocation missing bounded context: %#v", updateCall)
+	}
+	if strings.Contains(fmt.Sprint(updateCall.params), "not for status") {
+		t.Fatalf("update params leaked tool arguments: %#v", updateCall.params)
+	}
+	clearCall := (*invokes)[1]
+	if clearCall.providerName != "notifier" || clearCall.operation != "activity.clear" {
+		t.Fatalf("clear invocation = %#v", clearCall)
+	}
+	if clearCall.instance != "tenant-a" || clearCall.connection != "service" || clearCall.credentialMode != core.ConnectionModeNone {
+		t.Fatalf("clear target selectors = %#v", clearCall)
+	}
+	if got := clearCall.params["handle"]; got != "opaque-progress-handle" {
+		t.Fatalf("clear progress handle = %#v, want configured handle", got)
+	}
+}
+
+func TestWorkflowRuntimeInvokeAgentTargetUsesDefaultProgressForUnmatchedDottedOperation(t *testing.T) {
+	t.Parallel()
+
+	agentProvider := newStubAgentTurnManagerProvider()
+	agentProvider.createTurnStatus = coreagent.ExecutionStatusRunning
+	agentProvider.completeRunningOnGet = true
+	agentProvider.turnEventsOnCreate = []*coreagent.TurnEvent{{
+		Type: "tool.started",
+		Data: map[string]any{
+			"operation": "other.reply",
+		},
+	}}
+	runtime, refProvider, invokes := newProgressWorkflowRuntimeHarness(t, agentProvider)
+	target := testProgressAgentTarget(5)
+	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+		ID:                  "progress-agent-ref",
+		ProviderName:        "temporal",
+		Target:              target,
+		TargetFingerprint:   testWorkflowRuntimeTargetFingerprint(t, target),
+		CallerPluginName:    "notifier",
+		SubjectID:           "service_account:notifier-agent",
+		CredentialSubjectID: "service_account:notifier-agent",
+		Permissions: []core.AccessPermission{{
+			Plugin:     "notifier",
+			Operations: []string{"activity.update", "activity.clear"},
+		}},
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+
+	resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		ExecutionRef: "progress-agent-ref",
+		RunID:        "run-agent-123",
+		Target:       target,
+		Signals: []coreworkflow.Signal{{
+			ID:      "sig-1",
+			Name:    "message.event",
+			Payload: map[string]any{"message": "hello"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != http.StatusOK || resp.Body != "turn completed" {
+		t.Fatalf("response = %#v", resp)
+	}
+	if len(*invokes) != 2 {
+		t.Fatalf("invocations = %#v, want update and clear", *invokes)
+	}
+	if got := (*invokes)[0].params["text"]; got != "is using a tool..." {
+		t.Fatalf("update status = %#v, want default tool status", got)
+	}
+}
+
+func TestWorkflowRuntimeInvokeAgentTargetClearsConfiguredProgressAfterSetupFailure(t *testing.T) {
+	t.Parallel()
+
+	agentProvider := newStubAgentTurnManagerProvider()
+	agentProvider.createTurnErr = errors.New("create turn failed")
+	runtime, refProvider, invokes := newProgressWorkflowRuntimeHarness(t, agentProvider)
+	target := testProgressAgentTarget(5)
+	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+		ID:                  "progress-agent-ref",
+		ProviderName:        "temporal",
+		Target:              target,
+		TargetFingerprint:   testWorkflowRuntimeTargetFingerprint(t, target),
+		CallerPluginName:    "notifier",
+		SubjectID:           "service_account:notifier-agent",
+		CredentialSubjectID: "service_account:notifier-agent",
+		Permissions: []core.AccessPermission{{
+			Plugin:     "notifier",
+			Operations: []string{"activity.update", "activity.clear"},
+		}},
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+
+	_, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		ExecutionRef: "progress-agent-ref",
+		RunID:        "run-agent-123",
+		Target:       target,
+		Signals: []coreworkflow.Signal{{
+			ID:      "sig-1",
+			Name:    "message.event",
+			Payload: map[string]any{"message": "hello"},
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "create turn failed") {
+		t.Fatalf("Invoke error = %v, want create turn failure", err)
+	}
+	if len(*invokes) != 1 {
+		t.Fatalf("invocations = %#v, want clear only", *invokes)
+	}
+	if (*invokes)[0].operation != "activity.clear" {
+		t.Fatalf("invocation = %#v, want clear", (*invokes)[0])
+	}
+}
+
+func TestWorkflowRuntimeInvokeAgentTargetClearsConfiguredProgressAfterTimeout(t *testing.T) {
+	t.Parallel()
+
+	agentProvider := newStubAgentTurnManagerProvider()
+	agentProvider.createTurnStatus = coreagent.ExecutionStatusRunning
+	runtime, refProvider, invokes := newProgressWorkflowRuntimeHarness(t, agentProvider)
+	target := testProgressAgentTarget(1)
+	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+		ID:                  "progress-agent-ref",
+		ProviderName:        "temporal",
+		Target:              target,
+		TargetFingerprint:   testWorkflowRuntimeTargetFingerprint(t, target),
+		CallerPluginName:    "notifier",
+		SubjectID:           "service_account:notifier-agent",
+		CredentialSubjectID: "service_account:notifier-agent",
+		Permissions: []core.AccessPermission{{
+			Plugin:     "notifier",
+			Operations: []string{"activity.update", "activity.clear"},
+		}},
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+
+	_, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		ExecutionRef: "progress-agent-ref",
+		RunID:        "run-agent-123",
+		Target:       target,
+		Signals: []coreworkflow.Signal{{
+			ID:      "sig-1",
+			Name:    "message.event",
+			Payload: map[string]any{"message": "hello"},
+		}},
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Invoke error = %v, want deadline exceeded", err)
+	}
+	clearCall, ok := lastWorkflowRuntimeInvocationForOperation(*invokes, "activity.clear")
+	if !ok {
+		t.Fatalf("invocations = %#v, want clear", *invokes)
+	}
+	if clearCall.ctxErr != nil {
+		t.Fatalf("clear context err = %v, want detached clear context", clearCall.ctxErr)
+	}
+}
+
+func newProgressWorkflowRuntimeHarness(t *testing.T, agentProvider *stubAgentTurnManagerProvider) (*workflowRuntime, *workflowRuntimeExecutionRefProvider, *[]workflowRuntimeRecordedInvoke) {
+	t.Helper()
+	services := coretesting.NewStubServices(t)
+	reg := registry.New()
+	if err := reg.Providers.Register("notifier", &coretesting.StubIntegration{
+		N:        "notifier",
+		ConnMode: core.ConnectionModeUser,
+		CatalogVal: &catalog.Catalog{
+			Name: "notifier",
+			Operations: []catalog.CatalogOperation{
+				{ID: "activity.update", Method: http.MethodPost},
+				{ID: "activity.clear", Method: http.MethodPost},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Register notifier: %v", err)
+	}
+	agentRuntime := &agentRuntime{
+		defaultProviderName: "managed",
+		providers:           map[string]coreagent.Provider{"managed": agentProvider},
+	}
+	agentRuntime.SetRunMetadata(services.AgentRunMetadata)
+	invokes := []workflowRuntimeRecordedInvoke{}
+	invoker := funcInvoker{
+		invoke: func(ctx context.Context, _ *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
+			_, hasDeadline := ctx.Deadline()
+			invokes = append(invokes, workflowRuntimeRecordedInvoke{
+				providerName:   providerName,
+				instance:       instance,
+				operation:      operation,
+				connection:     invocation.ConnectionFromContext(ctx),
+				credentialMode: invocation.CredentialModeOverrideFromContext(ctx),
+				params:         cloneMapAny(params),
+				ctxErr:         ctx.Err(),
+				hasDeadline:    hasDeadline,
+			})
+			return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+		},
+	}
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:       &reg.Providers,
+		Agent:           agentRuntime,
+		SessionMetadata: services.AgentSessions,
+		RunMetadata:     services.AgentRunMetadata,
+		Invoker:         invoker,
+		PluginInvokes: map[string][]config.PluginInvocationDependency{
+			"notifier": {
+				{Plugin: "notifier", Operation: "activity.update", CredentialMode: "none"},
+				{Plugin: "notifier", Operation: "activity.clear", CredentialMode: "none"},
+			},
+		},
+	})
+	refProvider := newWorkflowRuntimeExecutionRefProvider()
+	runtime := &workflowRuntime{
+		providers: map[string]coreworkflow.Provider{"temporal": refProvider},
+	}
+	runtime.SetAgentManager(manager)
+	runtime.SetInvoker(invoker)
+	return runtime, refProvider, &invokes
+}
+
+func testProgressAgentTarget(timeoutSeconds int) coreworkflow.Target {
+	return coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+		ProviderName: "managed",
+		Model:        "deep",
+		Prompt:       "Handle the message request",
+		ToolSource:   coreagent.ToolSourceModeNativeSearch,
+		ToolRefs: []coreagent.ToolRef{
+			{Plugin: "notifier", Operation: "activity.update", Connection: "other", Instance: "tenant-b", CredentialMode: core.ConnectionModeNone},
+			{Plugin: "notifier", Operation: "activity.clear", Connection: "other", Instance: "tenant-b", CredentialMode: core.ConnectionModeNone},
+			{Plugin: "notifier", Operation: "activity.update", Connection: "service", Instance: "tenant-a", CredentialMode: core.ConnectionModeNone},
+			{Plugin: "notifier", Operation: "activity.clear", Connection: "service", Instance: "tenant-a", CredentialMode: core.ConnectionModeNone},
+		},
+		Metadata:       testProgressAgentMetadata(),
+		TimeoutSeconds: timeoutSeconds,
+	}}
+}
+
+func testProgressAgentMetadata() map[string]any {
+	return map[string]any{
+		workflowAgentProgressMetadataKey: map[string]any{
+			"update": map[string]any{
+				"plugin":         "notifier",
+				"operation":      "activity.update",
+				"connection":     "service",
+				"instance":       "tenant-a",
+				"credentialMode": "none",
+			},
+			"clear": map[string]any{
+				"plugin":         "notifier",
+				"operation":      "activity.clear",
+				"connection":     "service",
+				"instance":       "tenant-a",
+				"credentialMode": "none",
+			},
+			"params": map[string]any{
+				"handle": "opaque-progress-handle",
+			},
+			"statusParam":       "text",
+			"defaultToolStatus": "is using a tool...",
+			"rules": []any{
+				map[string]any{"event": "turn.started", "status": "is getting started..."},
+				map[string]any{"event": "tool.started", "operation": "messages.reply", "status": "is sending a reply..."},
+				map[string]any{"event": "tool.started", "identifier": "notifier/activity.update", "ignore": true},
+				map[string]any{"event": "assistant.completed", "status": "is drafting a response..."},
+			},
+		},
+	}
+}
+
+func testWorkflowRuntimeTargetFingerprint(t *testing.T, target coreworkflow.Target) string {
+	t.Helper()
+	fingerprint, err := coreworkflow.TargetFingerprint(target)
+	if err != nil {
+		t.Fatalf("TargetFingerprint: %v", err)
+	}
+	return fingerprint
+}
+
+func lastWorkflowRuntimeInvocationForOperation(invokes []workflowRuntimeRecordedInvoke, operation string) (workflowRuntimeRecordedInvoke, bool) {
+	for i := len(invokes) - 1; i >= 0; i-- {
+		if invokes[i].operation == operation {
+			return invokes[i], true
+		}
+	}
+	return workflowRuntimeRecordedInvoke{}, false
 }
 
 func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefAcceptsCanonicalFingerprint(t *testing.T) {


### PR DESCRIPTION
## Problem
Workflow-triggered agents can expose progress in a calling surface while the agent is still running, but gestaltd must not know anything about a specific product integration. The runtime should only understand a provider-neutral progress contract.

## New interface
Workflow agent targets may opt in by setting `metadata["gestalt.workflow.agent_progress"]`:

```json
{
  "update": {"plugin": "notifier", "operation": "activity.update"},
  "clear": {"plugin": "notifier", "operation": "activity.clear"},
  "params": {"handle": "opaque-progress-handle"},
  "statusParam": "text",
  "minInterval": "2s",
  "defaultToolStatus": "is using a tool...",
  "rules": [
    {"event": "turn.started", "status": "is getting started..."},
    {"event": "tool.started", "operation": "messages.reply", "status": "is sending a reply..."},
    {"event": "tool.started", "identifier": "notifier/activity.update", "ignore": true},
    {"event": "tool.started", "pluginPrefix": "records", "status": "is checking records..."}
  ]
}
```

`update` and `clear` are resolved through the normal agent tool resolution path, so configured `connection`, `instance`, and `credentialMode` selectors are preserved from the resolved tool target or the matching agent `tool_refs` entry.

## Changes
- Add a generic workflow agent progress bridge in gestaltd.
- Observe turn events only when the metadata opt-in is present.
- Invoke configured update/clear tools without passing tool arguments or provider-specific details through core.
- Clear progress on completion, setup failure, and timeout using a detached short-timeout context.
- Keep product-specific progress strings and tool mappings out of gestaltd.

## Validation
- `go test ./internal/bootstrap -run 'TestWorkflowRuntimeInvokeAgentTarget(CreatesAndSupervisesTurn|UpdatesConfiguredProgressFromTurnEvents|ClearsConfiguredProgressAfterSetupFailure|ClearsConfiguredProgressAfterTimeout)' -count=1`
- `go test ./internal/bootstrap -count=1`
- `go test ./...`
- `golangci-lint run --allow-parallel-runners ./...`
- `go mod tidy && git diff --exit-code go.mod go.sum`
