### PR TITLE
workflow: require execution ref target fingerprints

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -68,11 +68,16 @@ func storeWorkflowExecutionRefForTarget(t *testing.T, deps bootstrap.Deps, provi
 	if !ok {
 		t.Fatalf("workflow provider %q does not support execution refs", providerName)
 	}
+	targetFingerprint, err := coreworkflow.TargetFingerprint(target)
+	if err != nil {
+		t.Fatalf("workflow target fingerprint: %v", err)
+	}
 	ref, err := store.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           fmt.Sprintf("test:%s:%s:%s", strings.ReplaceAll(t.Name(), "/", "_"), providerName, pluginTarget.Operation),
-		ProviderName: providerName,
-		Target:       target,
-		SubjectID:    "system:config",
+		ID:                fmt.Sprintf("test:%s:%s:%s", strings.ReplaceAll(t.Name(), "/", "_"), providerName, pluginTarget.Operation),
+		ProviderName:      providerName,
+		Target:            target,
+		TargetFingerprint: targetFingerprint,
+		SubjectID:         "system:config",
 		Permissions: []core.AccessPermission{{
 			Plugin:     pluginTarget.PluginName,
 			Operations: []string{pluginTarget.Operation},
@@ -4920,67 +4925,6 @@ func TestBootstrapReusesConfiguredWorkflowExecutionRefAcrossUnchangedBootstrap(t
 	}
 	if ref.RevokedAt != nil {
 		t.Fatalf("revokedAt = %#v, want nil", ref.RevokedAt)
-	}
-}
-
-func TestBootstrapRefreshesConfiguredWorkflowExecutionRefWhenFingerprintMissing(t *testing.T) {
-	t.Parallel()
-
-	db := &coretesting.StubIndexedDB{}
-	provider := &recordingWorkflowProvider{}
-	factories := validFactories()
-	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
-	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
-		return provider, nil
-	}
-
-	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
-		Provider: "temporal",
-		Schedules: map[string]workflowFixtureSchedule{
-			"nightly_sync": {
-				Cron:      "0 2 * * *",
-				Timezone:  "UTC",
-				Operation: "sync",
-			},
-		},
-	})
-	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
-		"temporal": {Source: config.ProviderSource{Path: "stub"}},
-	}
-
-	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
-	if err != nil {
-		t.Fatalf("Bootstrap initial: %v", err)
-	}
-	initialExecutionRef := provider.upsertedSchedules[0].ExecutionRef
-	_ = result.Close(context.Background())
-	provider.executionRefs[initialExecutionRef].TargetFingerprint = ""
-
-	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
-	if err != nil {
-		t.Fatalf("Bootstrap replay: %v", err)
-	}
-	defer func() { _ = result.Close(context.Background()) }()
-	<-result.ProvidersReady
-
-	refreshedExecutionRef := provider.upsertedSchedules[1].ExecutionRef
-	if refreshedExecutionRef == initialExecutionRef {
-		t.Fatalf("execution ref = %q, want refreshed ref after missing target fingerprint", refreshedExecutionRef)
-	}
-	oldRef, err := provider.GetExecutionReference(context.Background(), initialExecutionRef)
-	if err != nil {
-		t.Fatalf("Get old execution ref: %v", err)
-	}
-	if oldRef.RevokedAt == nil {
-		t.Fatal("old execution ref revokedAt = nil, want revoked")
-	}
-	newRef, err := provider.GetExecutionReference(context.Background(), refreshedExecutionRef)
-	if err != nil {
-		t.Fatalf("Get refreshed execution ref: %v", err)
-	}
-	if strings.TrimSpace(newRef.TargetFingerprint) == "" {
-		t.Fatal("refreshed execution ref target fingerprint is empty")
 	}
 }
 

--- a/gestaltd/internal/bootstrap/startup_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_proxy.go
@@ -556,11 +556,7 @@ func (p *startupWorkflowProviderProxy) PutExecutionReference(ctx context.Context
 			return nil, fmt.Errorf("workflow execution reference id is required")
 		}
 		if strings.TrimSpace(stored.TargetFingerprint) == "" {
-			fingerprint, err := coreworkflow.TargetFingerprint(stored.Target)
-			if err != nil {
-				return nil, fmt.Errorf("workflow execution reference target fingerprint: %w", err)
-			}
-			stored.TargetFingerprint = fingerprint
+			return nil, fmt.Errorf("workflow execution reference target fingerprint is required")
 		}
 		p.mu.Lock()
 		p.pendingExecutionRefs[stored.ID] = stored

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -246,12 +246,17 @@ func storeStartupExecutionRef(t *testing.T, deps Deps, providerName string, targ
 	if !ok {
 		t.Fatalf("workflow provider %q does not support execution refs", providerName)
 	}
+	targetFingerprint, err := coreworkflow.TargetFingerprint(target)
+	if err != nil {
+		t.Fatalf("workflow target fingerprint: %v", err)
+	}
 	ref, err := store.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           fmt.Sprintf("startup:%s:%s:%s", strings.ReplaceAll(t.Name(), "/", "_"), providerName, pluginTarget.Operation),
-		ProviderName: providerName,
-		Target:       target,
-		SubjectID:    "system:config",
-		Permissions:  workflowExecutionRefPermissionsForTarget(target),
+		ID:                fmt.Sprintf("startup:%s:%s:%s", strings.ReplaceAll(t.Name(), "/", "_"), providerName, pluginTarget.Operation),
+		ProviderName:      providerName,
+		Target:            target,
+		TargetFingerprint: targetFingerprint,
+		SubjectID:         "system:config",
+		Permissions:       workflowExecutionRefPermissionsForTarget(target),
 	})
 	if err != nil {
 		t.Fatalf("store workflow execution ref: %v", err)

--- a/gestaltd/internal/providerhost/workflow_convert.go
+++ b/gestaltd/internal/providerhost/workflow_convert.go
@@ -195,11 +195,15 @@ func workflowExecutionReferenceToProto(ref *coreworkflow.ExecutionReference) (*p
 	if err != nil {
 		return nil, err
 	}
+	targetFingerprint := strings.TrimSpace(ref.TargetFingerprint)
+	if targetFingerprint == "" {
+		return nil, fmt.Errorf("workflow execution reference target_fingerprint is required")
+	}
 	return &proto.WorkflowExecutionReference{
 		Id:                  ref.ID,
 		ProviderName:        ref.ProviderName,
 		Target:              target,
-		TargetFingerprint:   ref.TargetFingerprint,
+		TargetFingerprint:   targetFingerprint,
 		CallerPluginName:    ref.CallerPluginName,
 		SubjectId:           ref.SubjectID,
 		SubjectKind:         ref.SubjectKind,


### PR DESCRIPTION
## Summary
- delete the bootstrap compatibility repair path for workflow execution refs missing target fingerprints
- make startup workflow refs fail fast when `TargetFingerprint` is omitted
- make provider-host transport reject outbound execution refs without `target_fingerprint`
- remove the old bootstrap test that kept missing-fingerprint repair behavior alive

## New interface

Execution refs must now carry the canonical target fingerprint when they are written:

```go
target := coreworkflow.Target{Plugin: &coreworkflow.PluginTarget{PluginName: "roadmap", Operation: "sync"}}
targetFingerprint, err := coreworkflow.TargetFingerprint(target)
if err != nil {
    return err
}
_, err = store.PutExecutionReference(ctx, &coreworkflow.ExecutionReference{
    ID:                "workflow_schedule:cfg_123:ref_123",
    ProviderName:      "temporal",
    Target:            target,
    TargetFingerprint: targetFingerprint,
    SubjectID:         "system:config",
})
```

Wire shape:

```proto
reference {
  id: "workflow_schedule:cfg_123:ref_123"
  provider_name: "temporal"
  target { plugin { plugin_name: "roadmap" operation: "sync" } }
  target_fingerprint: "<canonical target fingerprint>"
}
```

Missing `target_fingerprint` now fails at the startup proxy/provider-host boundary instead of being repaired.

## Validation
- `go test ./internal/bootstrap ./internal/providerhost ./internal/workflowmanager`
- `go test ./internal/server -run 'Test.*Workflow(Schedule|Run|EventTrigger)'`\n- `git diff --check`\n