### PR TITLE
Tune agent tool search ranking

### DIFF
--- a/gestaltd/internal/agentmanager/tool_search.go
+++ b/gestaltd/internal/agentmanager/tool_search.go
@@ -114,12 +114,12 @@ type agentToolSearchRankedCandidate struct {
 
 func agentToolSearchQuery(searchText string) blevequery.Query {
 	queries := []blevequery.Query{
-		agentToolSearchMatchQuery("plugin", searchText, 16),
-		agentToolSearchMatchQuery("operation", searchText, 12),
-		agentToolSearchMatchQuery("aliases", searchText, 10),
+		agentToolSearchMatchQuery("plugin", searchText, 12),
+		agentToolSearchMatchQuery("operation", searchText, 9),
 		agentToolSearchMatchQuery("title", searchText, 8),
 		agentToolSearchMatchQuery("parameters", searchText, 5),
-		agentToolSearchMatchQuery("description", searchText, 1),
+		agentToolSearchMatchQuery("aliases", searchText, 2),
+		agentToolSearchMatchQuery("description", searchText, 4),
 	}
 	return bleve.NewDisjunctionQuery(queries...)
 }
@@ -212,6 +212,8 @@ func agentToolSearchAliases(token string) []string {
 		return []string{"issue", "issues", "task", "tasks"}
 	case "issue", "issues":
 		return []string{"ticket", "tickets", "task", "tasks"}
+	case "task", "tasks":
+		return []string{"issue", "issues", "ticket", "tickets"}
 	case "assigned":
 		return []string{"assignee", "assignees"}
 	case "assignee", "assignees":
@@ -220,10 +222,12 @@ func agentToolSearchAliases(token string) []string {
 		return []string{"direct", "message", "messages", "conversation", "conversations"}
 	case "direct":
 		return []string{"dm", "dms"}
+	case "message", "messages", "conversation", "conversations":
+		return []string{"dm", "dms"}
 	case "pr", "prs":
-		return []string{"pull", "request", "requests", "merge"}
+		return []string{"pull", "request", "requests"}
 	case "pull":
-		return []string{"pr", "prs", "merge"}
+		return []string{"pr", "prs"}
 	case "merge":
 		return []string{"mr", "mrs", "pull", "request", "requests"}
 	case "mr", "mrs":
@@ -260,20 +264,7 @@ func agentToolSearchText(value string) string {
 	if len(tokens) == 0 {
 		return ""
 	}
-	expanded := make([]string, 0, len(tokens)*2)
-	seen := make(map[string]struct{}, len(tokens)*2)
-	for _, token := range tokens {
-		for _, value := range append([]string{token}, agentToolSearchAliases(token)...) {
-			for _, normalized := range uniqueAgentToolSearchTokens(value) {
-				if _, ok := seen[normalized]; ok {
-					continue
-				}
-				seen[normalized] = struct{}{}
-				expanded = append(expanded, normalized)
-			}
-		}
-	}
-	return strings.Join(expanded, " ")
+	return strings.Join(tokens, " ")
 }
 
 func uniqueAgentToolSearchTokens(value string) []string {

--- a/gestaltd/internal/agentmanager/tool_search_test.go
+++ b/gestaltd/internal/agentmanager/tool_search_test.go
@@ -1,0 +1,180 @@
+package agentmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestSearchToolsRanksExactOperationMatchesAheadOfTitleMatches(t *testing.T) {
+	t.Parallel()
+
+	manager := newAgentToolSearchRankingManager(t, "source_control", []catalog.CatalogOperation{
+		{
+			ID:          "reviews.search",
+			Title:       "Pulls List",
+			Description: "Search review metadata.",
+			ReadOnly:    true,
+		},
+		{
+			ID:          "pulls.list",
+			Title:       "Fetch Reviews",
+			Description: "Fetch review branches.",
+			ReadOnly:    true,
+		},
+	})
+	resp := searchAgentToolsForRanking(t, manager, "pulls.list")
+	if got := resp.Tools[0].Target.Operation; got != "pulls.list" {
+		t.Fatalf("top search result = %q, want pulls.list: %#v", got, resp.Tools)
+	}
+}
+
+func TestSearchToolsRanksDescriptionOnlyIntent(t *testing.T) {
+	t.Parallel()
+
+	manager := newAgentToolSearchRankingManager(t, "payments", []catalog.CatalogOperation{
+		{
+			ID:          "accounts.list",
+			Title:       "List Accounts",
+			Description: "List account records.",
+			ReadOnly:    true,
+		},
+		{
+			ID:          "adjustments.create",
+			Title:       "Create Adjustment",
+			Description: "Create a refund for a customer payment.",
+		},
+	})
+	resp := searchAgentToolsForRanking(t, manager, "refund customer payment")
+	if got := resp.Tools[0].Target.Operation; got != "adjustments.create" {
+		t.Fatalf("top search result = %q, want adjustments.create: %#v", got, resp.Tools)
+	}
+}
+
+func TestSearchToolsRanksPullRequestAliasTowardListingIntent(t *testing.T) {
+	t.Parallel()
+
+	manager := newAgentToolSearchRankingManager(t, "codehost", []catalog.CatalogOperation{
+		{
+			ID:          "pulls.merge",
+			Title:       "Merge Pull Request",
+			Description: "Merge a pull request into the base branch.",
+		},
+		{
+			ID:          "pulls.list",
+			Title:       "List Pull Requests",
+			Description: "List open pull requests for a repository.",
+			ReadOnly:    true,
+		},
+	})
+	resp := searchAgentToolsForRanking(t, manager, "open prs")
+	if got := resp.Tools[0].Target.Operation; got != "pulls.list" {
+		t.Fatalf("top search result = %q, want pulls.list: %#v", got, resp.Tools)
+	}
+}
+
+func TestSearchToolsRanksMessageAliasTowardDMIntent(t *testing.T) {
+	t.Parallel()
+
+	manager := newAgentToolSearchRankingManager(t, "chat", []catalog.CatalogOperation{
+		{
+			ID:          "channels.post",
+			Title:       "Post Channel Update",
+			Description: "Post an update to a shared channel.",
+		},
+		{
+			ID:          "messages.send",
+			Title:       "Send Message",
+			Description: "Send a private message to a user.",
+		},
+	})
+	resp := searchAgentToolsForRanking(t, manager, "dm user")
+	if got := resp.Tools[0].Target.Operation; got != "messages.send" {
+		t.Fatalf("top search result = %q, want messages.send: %#v", got, resp.Tools)
+	}
+}
+
+func TestSearchToolsRanksTaskAliasTowardIssueIntent(t *testing.T) {
+	t.Parallel()
+
+	manager := newAgentToolSearchRankingManager(t, "tracker", []catalog.CatalogOperation{
+		{
+			ID:          "projects.list",
+			Title:       "List Projects",
+			Description: "List project workspaces.",
+			ReadOnly:    true,
+		},
+		{
+			ID:          "tasks.search",
+			Title:       "Search Tasks",
+			Description: "Search task records assigned to users.",
+			ReadOnly:    true,
+		},
+	})
+	resp := searchAgentToolsForRanking(t, manager, "assigned issues")
+	if got := resp.Tools[0].Target.Operation; got != "tasks.search" {
+		t.Fatalf("top search result = %q, want tasks.search: %#v", got, resp.Tools)
+	}
+}
+
+func TestSearchToolsDoesNotTreatPullRequestListingAsMergeIntent(t *testing.T) {
+	t.Parallel()
+
+	manager := newAgentToolSearchRankingManager(t, "codehost", []catalog.CatalogOperation{
+		{
+			ID:          "pulls.list",
+			Title:       "List Pull Requests",
+			Description: "List open pull requests for a repository.",
+			ReadOnly:    true,
+		},
+		{
+			ID:          "branches.combine",
+			Title:       "Combine Branches",
+			Description: "Merge branch changes into a repository.",
+		},
+	})
+	resp := searchAgentToolsForRanking(t, manager, "merge")
+	if got := resp.Tools[0].Target.Operation; got != "branches.combine" {
+		t.Fatalf("top search result = %q, want branches.combine: %#v", got, resp.Tools)
+	}
+}
+
+func newAgentToolSearchRankingManager(t *testing.T, name string, ops []catalog.CatalogOperation) *Manager {
+	t.Helper()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        name,
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				DisplayName: name,
+				Operations:  ops,
+			},
+		},
+	}
+	return New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+}
+
+func searchAgentToolsForRanking(t *testing.T, manager *Manager, query string) *coreagent.SearchToolsResponse {
+	t.Helper()
+
+	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query:      query,
+		MaxResults: 1,
+	})
+	if err != nil {
+		t.Fatalf("SearchTools: %v", err)
+	}
+	if len(resp.Tools) != 1 {
+		t.Fatalf("SearchTools returned %d tools, want 1: %#v", len(resp.Tools), resp.Tools)
+	}
+	return resp
+}


### PR DESCRIPTION
## Summary

Tune the general agent tool-search scorer so exact field matches and alias matches stay distinct:

- Normalize `SearchTools` query text without alias expansion.
- Index aliases only in the lower-boost `aliases` field.
- Rebalance ranking boosts to: `plugin=12`, `operation=9`, `title=8`, `parameters=5`, `description=4`, `aliases=2`.
- Keep `pr`/`prs`/`pull` aliases pointed at pull-request synonyms, but stop expanding them to `merge`.
- Keep non-generic alias groups reciprocal for document-side matching, including `task` <-> issue/ticket and `message`/`conversation` <-> DM.

## Interface / Behavior

The `SearchToolsRequest` contract is unchanged. The ranking behavior for existing requests is now:

```go
coreagent.SearchToolsRequest{
    Query:      "open prs",
    MaxResults: 1,
}
```

This prefers a pull-request listing operation over a merge operation when the catalog contains both.

```go
coreagent.SearchToolsRequest{
    Query:      "merge",
    MaxResults: 1,
}
```

This prefers an operation that directly describes merge behavior over a pull-request listing that only matches through aliases.

```go
coreagent.SearchToolsRequest{
    Query:      "dm user",
    MaxResults: 1,
}
```

This can find an operation described as sending a private message.

```go
coreagent.SearchToolsRequest{
    Query:      "assigned issues",
    MaxResults: 1,
}
```

This can find a task-search operation through the issue/task alias.

```go
coreagent.SearchToolsRequest{
    Query:      "refund customer payment",
    MaxResults: 1,
}
```

This can rank a tool whose description carries the user intent, even when the operation name and title are generic.

## Validation

- `go test ./internal/agentmanager -count=1`
- `golangci-lint run ./internal/agentmanager/...`
