### PR TITLE
Cache MCP session catalog discovery

### DIFF
--- a/gestaltd/internal/mcpupstream/upstream.go
+++ b/gestaltd/internal/mcpupstream/upstream.go
@@ -2,24 +2,34 @@ package mcpupstream
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	neturl "net/url"
+	"sync"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
+	"github.com/valon-technologies/gestalt/server/internal/observability"
 	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sync/singleflight"
 )
 
-const httpTimeout = 30 * time.Second
+const (
+	httpTimeout            = 30 * time.Second
+	defaultCatalogCacheTTL = 5 * time.Minute
+	maxCatalogCacheEntries = 128
+)
 
 var (
 	_ core.Provider               = (*Upstream)(nil)
@@ -51,6 +61,18 @@ type Upstream struct {
 	client      mcpclient.MCPClient
 	exposure    *operationexposure.Policy
 	checkEgress func(string) error
+
+	catalogCacheMu  sync.Mutex
+	catalogCache    map[string]catalogCacheEntry
+	catalogRequests singleflight.Group
+	catalogCacheTTL time.Duration
+	clock           func() time.Time
+}
+
+type catalogCacheEntry struct {
+	catalog  *catalog.Catalog
+	expires  time.Time
+	lastUsed time.Time
 }
 
 type Option func(*Upstream)
@@ -75,13 +97,14 @@ func New(_ context.Context, name string, url string, connMode core.ConnectionMod
 	}
 
 	u := &Upstream{
-		name:        name,
-		display:     name,
-		desc:        fmt.Sprintf("MCP upstream: %s", url),
-		url:         url,
-		connMode:    connMode,
-		headers:     config.NormalizeHeaders(headers),
-		checkEgress: checkEgress,
+		name:            name,
+		display:         name,
+		desc:            fmt.Sprintf("MCP upstream: %s", url),
+		url:             url,
+		connMode:        connMode,
+		headers:         config.NormalizeHeaders(headers),
+		checkEgress:     checkEgress,
+		catalogCacheTTL: defaultCatalogCacheTTL,
 	}
 	for _, opt := range opts {
 		opt(u)
@@ -92,12 +115,13 @@ func New(_ context.Context, name string, url string, connMode core.ConnectionMod
 func newFromClient(name string, client mcpclient.MCPClient, connMode core.ConnectionMode, tools []mcpgo.Tool) *Upstream {
 	cat := buildCatalog(name, tools)
 	return &Upstream{
-		name:     name,
-		display:  name,
-		desc:     fmt.Sprintf("MCP upstream: %s", name),
-		connMode: connMode,
-		cat:      cat,
-		client:   client,
+		name:            name,
+		display:         name,
+		desc:            fmt.Sprintf("MCP upstream: %s", name),
+		connMode:        connMode,
+		cat:             cat,
+		client:          client,
+		catalogCacheTTL: defaultCatalogCacheTTL,
 	}
 }
 
@@ -114,16 +138,25 @@ func (u *Upstream) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
 func (u *Upstream) ConnectionForOperation(string) string        { return "" }
 func (u *Upstream) Catalog() *catalog.Catalog                   { return u.decorateCatalog(u.cat) }
 
-func (u *Upstream) SetDisplayName(s string) { u.display = s }
-func (u *Upstream) SetDescription(s string) { u.desc = s }
-func (u *Upstream) SetIconSVG(svg string)   { u.iconSVG = svg }
+func (u *Upstream) SetDisplayName(s string) {
+	u.display = s
+	u.clearCatalogCache()
+}
+func (u *Upstream) SetDescription(s string) {
+	u.desc = s
+	u.clearCatalogCache()
+}
+func (u *Upstream) SetIconSVG(svg string) {
+	u.iconSVG = svg
+	u.clearCatalogCache()
+}
 
 func (u *Upstream) Execute(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
 	return nil, core.ErrMCPOnly
 }
 
 func (u *Upstream) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	return u.discover(ctx, token)
+	return u.cachedCatalog(ctx, token)
 }
 
 func (u *Upstream) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
@@ -169,11 +202,158 @@ func (u *Upstream) FilterOperations(allowed map[string]*config.OperationOverride
 	u.exposure = policy
 
 	if u.cat == nil || policy == nil {
+		u.clearCatalogCache()
 		return nil
 	}
 
 	u.cat = policy.ApplyCatalog(u.cat)
+	u.clearCatalogCache()
 	return nil
+}
+
+func (u *Upstream) cachedCatalog(ctx context.Context, token string) (*catalog.Catalog, error) {
+	if u.client != nil && u.cat != nil {
+		return u.discover(ctx, token)
+	}
+
+	key := catalogCacheKey(token)
+	if cat, ok := u.catalogCacheGet(key); ok {
+		observability.RecordMCPCatalogCache(ctx, true, u.catalogMetricAttrs()...)
+		return cat, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	observability.RecordMCPCatalogCache(ctx, false, u.catalogMetricAttrs()...)
+
+	ch := u.catalogRequests.DoChan(key, func() (any, error) {
+		if cat, ok := u.catalogCacheGet(key); ok {
+			return cat, nil
+		}
+
+		discoverCtx, cancel := context.WithTimeout(context.Background(), httpTimeout)
+		defer cancel()
+
+		startedAt := time.Now()
+		cat, err := u.discover(discoverCtx, token)
+		observability.RecordMCPCatalogDiscover(ctx, startedAt, err != nil, u.catalogMetricAttrs()...)
+		if err != nil {
+			return nil, err
+		}
+		u.catalogCacheSet(key, cat)
+		if cat == nil {
+			return nil, nil
+		}
+		return cat.Clone(), nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-ch:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		cat, _ := result.Val.(*catalog.Catalog)
+		if cat == nil {
+			return nil, nil
+		}
+		return cat.Clone(), nil
+	}
+}
+
+func (u *Upstream) catalogCacheGet(key string) (*catalog.Catalog, bool) {
+	now := u.catalogCacheNow()
+	u.catalogCacheMu.Lock()
+	defer u.catalogCacheMu.Unlock()
+	entry, ok := u.catalogCache[key]
+	if !ok {
+		return nil, false
+	}
+	if !entry.expires.After(now) {
+		delete(u.catalogCache, key)
+		return nil, false
+	}
+	entry.lastUsed = now
+	u.catalogCache[key] = entry
+	return entry.catalog.Clone(), true
+}
+
+func (u *Upstream) catalogCacheSet(key string, cat *catalog.Catalog) {
+	if cat == nil {
+		return
+	}
+	ttl := u.catalogCacheTTL
+	if ttl <= 0 {
+		ttl = defaultCatalogCacheTTL
+	}
+	now := u.catalogCacheNow()
+	u.catalogCacheMu.Lock()
+	defer u.catalogCacheMu.Unlock()
+	if u.catalogCache == nil {
+		u.catalogCache = make(map[string]catalogCacheEntry)
+	}
+	u.evictCatalogCacheLocked(now, key)
+	u.catalogCache[key] = catalogCacheEntry{
+		catalog:  cat.Clone(),
+		expires:  now.Add(ttl),
+		lastUsed: now,
+	}
+}
+
+func (u *Upstream) evictCatalogCacheLocked(now time.Time, preserveKey string) {
+	for key, entry := range u.catalogCache {
+		if key == preserveKey {
+			continue
+		}
+		if !entry.expires.After(now) {
+			delete(u.catalogCache, key)
+		}
+	}
+	for len(u.catalogCache) >= maxCatalogCacheEntries {
+		var oldestKey string
+		var oldestTime time.Time
+		for key, entry := range u.catalogCache {
+			if key == preserveKey {
+				continue
+			}
+			if oldestKey == "" || entry.lastUsed.Before(oldestTime) {
+				oldestKey = key
+				oldestTime = entry.lastUsed
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(u.catalogCache, oldestKey)
+	}
+}
+
+func (u *Upstream) clearCatalogCache() {
+	u.catalogCacheMu.Lock()
+	defer u.catalogCacheMu.Unlock()
+	u.catalogCache = nil
+}
+
+func (u *Upstream) catalogCacheNow() time.Time {
+	if u.clock != nil {
+		return u.clock()
+	}
+	return time.Now()
+}
+
+func (u *Upstream) catalogMetricAttrs() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("gestalt.provider", u.name),
+	}
+}
+
+func catalogCacheKey(token string) string {
+	if token == "" {
+		return "no-token"
+	}
+	sum := sha256.Sum256([]byte(token))
+	return "token:" + hex.EncodeToString(sum[:])
 }
 
 func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClient, error) {

--- a/gestaltd/internal/mcpupstream/upstream_test.go
+++ b/gestaltd/internal/mcpupstream/upstream_test.go
@@ -1,22 +1,35 @@
 package mcpupstream
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
+
+type countingMCPHTTPServer struct {
+	server *httptest.Server
+	mu     sync.Mutex
+	lists  map[string]int
+}
 
 func newTestServer() *mcpserver.MCPServer {
 	srv := mcpserver.NewMCPServer("test-remote", "1.0.0")
@@ -93,6 +106,45 @@ func newHeaderAuthenticatedHTTPTestServer(t *testing.T, expectedHeaders map[stri
 		}
 		handler.ServeHTTP(w, r)
 	}))
+}
+
+func newCountingMCPHTTPTestServer(t *testing.T, listDelay time.Duration) *countingMCPHTTPServer {
+	t.Helper()
+
+	handler := mcpserver.NewStreamableHTTPServer(
+		newTestServer(),
+		mcpserver.WithStateLess(true),
+	)
+	out := &countingMCPHTTPServer{lists: map[string]int{}}
+	out.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		if strings.Contains(string(body), "tools/list") {
+			out.mu.Lock()
+			out.lists[r.Header.Get("Authorization")]++
+			out.mu.Unlock()
+			if listDelay > 0 {
+				time.Sleep(listDelay)
+			}
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(out.server.Close)
+	return out
+}
+
+func (s *countingMCPHTTPServer) URL() string {
+	return s.server.URL
+}
+
+func (s *countingMCPHTTPServer) listCalls(auth string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lists[auth]
 }
 
 func TestUpstream_DiscoverTools(t *testing.T) {
@@ -370,6 +422,238 @@ func TestUpstream_LazyDiscoveryUsesRequestToken(t *testing.T) {
 	}
 	if result.IsError {
 		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+}
+
+func TestUpstream_CatalogForRequestCachesDiscoveryByToken(t *testing.T) {
+	t.Parallel()
+
+	ts := newCountingMCPHTTPTestServer(t, 0)
+	u, err := New(context.Background(), "clickhouse", ts.URL(), core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	u.clock = func() time.Time { return now }
+	u.catalogCacheTTL = time.Hour
+
+	first, err := u.CatalogForRequest(ctx, "secret-token")
+	if err != nil {
+		t.Fatalf("CatalogForRequest first: %v", err)
+	}
+	if len(first.Operations) == 0 {
+		t.Fatal("expected first catalog operations")
+	}
+	first.Operations[0].ID = "mutated"
+
+	second, err := u.CatalogForRequest(ctx, "secret-token")
+	if err != nil {
+		t.Fatalf("CatalogForRequest second: %v", err)
+	}
+	if got := ts.listCalls("Bearer secret-token"); got != 1 {
+		t.Fatalf("tools/list calls for secret-token = %d, want 1", got)
+	}
+	if second.Operations[0].ID == "mutated" {
+		t.Fatal("cached catalog was returned without cloning")
+	}
+
+	if _, err := u.CatalogForRequest(ctx, "other-token"); err != nil {
+		t.Fatalf("CatalogForRequest other token: %v", err)
+	}
+	if got := ts.listCalls("Bearer other-token"); got != 1 {
+		t.Fatalf("tools/list calls for other-token = %d, want 1", got)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.mcp.catalog.cache.hit.count", 1, map[string]string{
+		"gestalt.provider": "clickhouse",
+		"gestalt.result":   "hit",
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.mcp.catalog.cache.miss.count", 2, map[string]string{
+		"gestalt.provider": "clickhouse",
+		"gestalt.result":   "miss",
+	})
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.mcp.catalog.discover.duration", map[string]string{
+		"gestalt.provider": "clickhouse",
+		"gestalt.result":   "success",
+	})
+}
+
+func TestUpstream_CatalogForRequestCacheExpires(t *testing.T) {
+	t.Parallel()
+
+	ts := newCountingMCPHTTPTestServer(t, 0)
+	u, err := New(context.Background(), "clickhouse", ts.URL(), core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	u.clock = func() time.Time { return now }
+	u.catalogCacheTTL = time.Minute
+
+	if _, err := u.CatalogForRequest(context.Background(), "secret-token"); err != nil {
+		t.Fatalf("CatalogForRequest first: %v", err)
+	}
+	now = now.Add(time.Minute + time.Second)
+	if _, err := u.CatalogForRequest(context.Background(), "secret-token"); err != nil {
+		t.Fatalf("CatalogForRequest after expiry: %v", err)
+	}
+	if got := ts.listCalls("Bearer secret-token"); got != 2 {
+		t.Fatalf("tools/list calls after expiry = %d, want 2", got)
+	}
+}
+
+func TestUpstream_CatalogForRequestCoalescesConcurrentDiscovery(t *testing.T) {
+	t.Parallel()
+
+	ts := newCountingMCPHTTPTestServer(t, 50*time.Millisecond)
+	u, err := New(context.Background(), "clickhouse", ts.URL(), core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	u.clock = func() time.Time { return now }
+	u.catalogCacheTTL = time.Hour
+
+	const callers = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, callers)
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			cat, err := u.CatalogForRequest(context.Background(), "secret-token")
+			if err != nil {
+				errs <- err
+				return
+			}
+			if len(cat.Operations) != 2 {
+				errs <- fmt.Errorf("operations = %d, want 2", len(cat.Operations))
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := ts.listCalls("Bearer secret-token"); got != 1 {
+		t.Fatalf("tools/list calls = %d, want 1", got)
+	}
+}
+
+func TestUpstream_CatalogForRequestCallerCancellationDoesNotCancelSharedDiscovery(t *testing.T) {
+	t.Parallel()
+
+	ts := newCountingMCPHTTPTestServer(t, 100*time.Millisecond)
+	u, err := New(context.Background(), "clickhouse", ts.URL(), core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	u.clock = func() time.Time { return now }
+	u.catalogCacheTTL = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errs := make(chan error, 1)
+	go func() {
+		_, err := u.CatalogForRequest(ctx, "secret-token")
+		errs <- err
+	}()
+
+	deadline := time.After(time.Second)
+	for ts.listCalls("Bearer secret-token") == 0 {
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatal("timed out waiting for tools/list to start")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	cancel()
+	select {
+	case err := <-errs:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("CatalogForRequest after caller cancellation = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for canceled caller")
+	}
+
+	cat, err := u.CatalogForRequest(context.Background(), "secret-token")
+	if err != nil {
+		t.Fatalf("CatalogForRequest after cancellation: %v", err)
+	}
+	if len(cat.Operations) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(cat.Operations))
+	}
+	if got := ts.listCalls("Bearer secret-token"); got != 1 {
+		t.Fatalf("tools/list calls after canceled caller = %d, want 1", got)
+	}
+}
+
+func TestUpstream_CatalogForRequestCanceledCallerDoesNotStartDiscovery(t *testing.T) {
+	t.Parallel()
+
+	ts := newCountingMCPHTTPTestServer(t, 0)
+	u, err := New(context.Background(), "clickhouse", ts.URL(), core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = u.CatalogForRequest(ctx, "secret-token")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("CatalogForRequest with canceled context = %v, want context.Canceled", err)
+	}
+	if got := ts.listCalls("Bearer secret-token"); got != 0 {
+		t.Fatalf("tools/list calls for canceled caller = %d, want 0", got)
+	}
+}
+
+func TestUpstream_CatalogForRequestCacheClearedAfterMetadataOverride(t *testing.T) {
+	t.Parallel()
+
+	ts := newCountingMCPHTTPTestServer(t, 0)
+	u, err := New(context.Background(), "clickhouse", ts.URL(), core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	u.clock = func() time.Time { return now }
+	u.catalogCacheTTL = time.Hour
+
+	if _, err := u.CatalogForRequest(context.Background(), "secret-token"); err != nil {
+		t.Fatalf("CatalogForRequest first: %v", err)
+	}
+
+	u.SetDisplayName("Renamed")
+
+	cat, err := u.CatalogForRequest(context.Background(), "secret-token")
+	if err != nil {
+		t.Fatalf("CatalogForRequest after metadata override: %v", err)
+	}
+	if cat.DisplayName != "Renamed" {
+		t.Fatalf("DisplayName = %q, want %q", cat.DisplayName, "Renamed")
+	}
+	if got := ts.listCalls("Bearer secret-token"); got != 2 {
+		t.Fatalf("tools/list calls after metadata override = %d, want 2", got)
 	}
 }
 

--- a/gestaltd/internal/observability/observability.go
+++ b/gestaltd/internal/observability/observability.go
@@ -45,6 +45,12 @@ type countMetricSet struct {
 	errorCount metric.Int64Counter
 }
 
+type mcpCatalogMetricSet struct {
+	cacheHit         metric.Int64Counter
+	cacheMiss        metric.Int64Counter
+	discoverDuration metric.Float64Histogram
+}
+
 var (
 	agentOperationMetrics                metricutil.MeterCache[metricSet]
 	agentProviderOperationMetrics        metricutil.MeterCache[metricSet]
@@ -58,6 +64,7 @@ var (
 	authorizationProviderEvaluateMetrics metricutil.MeterCache[metricSet]
 	catalogOperationResolveMetrics       metricutil.MeterCache[metricSet]
 	credentialProviderOperationMetrics   metricutil.MeterCache[metricSet]
+	mcpCatalogMetrics                    metricutil.MeterCache[mcpCatalogMetricSet]
 )
 
 func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
@@ -160,8 +167,52 @@ func RecordCatalogOperationResolve(ctx context.Context, startedAt time.Time, fai
 	record(ctx, &catalogOperationResolveMetrics, "gestaltd.catalog.operation.resolve", "gestaltd catalog operation resolution", startedAt, failed, attrs...)
 }
 
+func RecordMCPCatalogCache(ctx context.Context, hit bool, attrs ...attribute.KeyValue) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	metrics := mcpCatalogMetrics.Load(ctx, tracerName, newMCPCatalogMetrics)
+	if hit {
+		attrs = append(attrs, attribute.String("gestalt.result", "hit"))
+		metrics.cacheHit.Add(ctx, 1, metric.WithAttributes(attrs...))
+		return
+	}
+	attrs = append(attrs, attribute.String("gestalt.result", "miss"))
+	metrics.cacheMiss.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+func RecordMCPCatalogDiscover(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	metrics := mcpCatalogMetrics.Load(ctx, tracerName, newMCPCatalogMetrics)
+	attrs = append(attrs, attribute.String("gestalt.result", metricutil.ResultValue(failed)))
+	metrics.discoverDuration.Record(ctx, time.Since(startedAt).Seconds(), metric.WithAttributes(attrs...))
+}
+
 func RecordCredentialProviderOperation(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
 	record(ctx, &credentialProviderOperationMetrics, "gestaltd.credential.provider.operation", "gestaltd credential provider operations", startedAt, failed, attrs...)
+}
+
+func newMCPCatalogMetrics(meter metric.Meter) mcpCatalogMetricSet {
+	return mcpCatalogMetricSet{
+		cacheHit: metricutil.NewInt64Counter(
+			meter,
+			"gestaltd.mcp.catalog.cache.hit.count",
+			"Counts successful gestaltd MCP catalog cache hits.",
+		),
+		cacheMiss: metricutil.NewInt64Counter(
+			meter,
+			"gestaltd.mcp.catalog.cache.miss.count",
+			"Counts gestaltd MCP catalog cache misses.",
+		),
+		discoverDuration: metricutil.NewFloat64Histogram(
+			meter,
+			"gestaltd.mcp.catalog.discover.duration",
+			"Measures gestaltd MCP catalog discovery duration.",
+			"s",
+		),
+	}
 }
 
 func record(ctx context.Context, cache *metricutil.MeterCache[metricSet], prefix, desc string, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {


### PR DESCRIPTION
## Summary
- Adds a per-upstream MCP catalog cache for dynamic `CatalogForRequest(ctx, token)` discovery.
- Keys cache entries by hashed auth token so different users/tokens stay isolated.
- Clones cached catalogs before returning and clears cached catalogs when metadata/filter overrides change.
- Coalesces concurrent discovery with a bounded shared context while preserving per-caller cancellation.
- Avoids starting upstream discovery for an already-canceled caller.
- Emits low-cardinality MCP catalog cache/discovery metrics.

## New Interface / Behavior
`CatalogForRequest(ctx, token)` keeps the same public signature. For dynamic upstreams, successful catalog discovery is now cached for 5 minutes, with a max of 128 entries per upstream. In-process persistent upstreams keep the existing static-catalog path.

```go
cat, err := upstream.CatalogForRequest(ctx, userToken)
catAgain, err := upstream.CatalogForRequest(ctx, userToken) // reuses cached tools/list
other, err := upstream.CatalogForRequest(ctx, otherToken)   // separate cache entry
```

Metadata/filter mutation still behaves as before from the caller perspective, but now invalidates cached catalogs:

```go
upstream.SetDisplayName("Custom name")
upstream.FilterOperations([]string{"tool_a"})
cat, err := upstream.CatalogForRequest(ctx, userToken) // rediscovers with new overrides
```

A canceled caller no longer cancels the shared discovery for other callers; an already-canceled caller does not start discovery:

```go
ctx, cancel := context.WithCancel(parent)
cancel()
_, err := upstream.CatalogForRequest(ctx, userToken) // returns ctx cancellation without tools/list
```

## Metrics
```text
gestaltd.mcp.catalog.cache.hit.count{gestalt.provider, gestalt.result=hit}
gestaltd.mcp.catalog.cache.miss.count{gestalt.provider, gestalt.result=miss}
gestaltd.mcp.catalog.discover.duration{gestalt.provider, gestalt.result=success|error}
```

## Tests
- `go test ./internal/mcpupstream`
- `go test -race ./internal/mcpupstream`

The added coverage uses the existing HTTP MCP transport path to verify per-token caching, TTL expiry, concurrent request coalescing, caller cancellation behavior, already-canceled caller behavior, cache invalidation after metadata changes, clone-on-return behavior, and emitted metric attributes.