### PR TITLE
workflow: require execution ref fingerprints at provider boundaries

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1372,11 +1372,7 @@ func (p *recordingWorkflowProvider) PutExecutionReference(_ context.Context, ref
 	}
 	stored := cloneBootstrapWorkflowExecutionRef(ref)
 	if strings.TrimSpace(stored.TargetFingerprint) == "" {
-		fingerprint, err := coreworkflow.TargetFingerprint(stored.Target)
-		if err != nil {
-			return nil, err
-		}
-		stored.TargetFingerprint = fingerprint
+		return nil, errors.New("workflow execution reference target fingerprint is required")
 	}
 	p.executionRefs[stored.ID] = stored
 	return cloneBootstrapWorkflowExecutionRef(stored), nil
@@ -4215,11 +4211,17 @@ func TestBootstrapRoutesWorkflowIndexedDBHostServices(t *testing.T) {
 	if !ok {
 		t.Fatal("workflow provider with indexeddb cleanup does not preserve execution reference store")
 	}
+	target := coreWorkflowPluginTarget("roadmap", "sync")
+	targetFingerprint, err := coreworkflow.TargetFingerprint(target)
+	if err != nil {
+		t.Fatalf("workflow target fingerprint: %v", err)
+	}
 	if _, err := executionRefs.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "workflow_schedule:sched-test:ref-test",
-		ProviderName: "basic",
-		Target:       coreWorkflowPluginTarget("roadmap", "sync"),
-		SubjectID:    "user:ada",
+		ID:                "workflow_schedule:sched-test:ref-test",
+		ProviderName:      "basic",
+		Target:            target,
+		TargetFingerprint: targetFingerprint,
+		SubjectID:         "user:ada",
 	}); err != nil {
 		t.Fatalf("PutExecutionReference: %v", err)
 	}

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -48,6 +48,15 @@ func testWorkflowPluginTargetWithInput(pluginName, operation, connection, instan
 	}
 }
 
+func testWorkflowTargetFingerprint(t *testing.T, target coreworkflow.Target) string {
+	t.Helper()
+	fingerprint, err := coreworkflow.TargetFingerprint(target)
+	if err != nil {
+		t.Fatalf("workflow target fingerprint: %v", err)
+	}
+	return fingerprint
+}
+
 const (
 	canonicalAgentWorkflowTargetFingerprint  = "df7c3d7dde92c5807d3268e17d2e2996163442f06624d003c7008e35be508b63"
 	canonicalPluginWorkflowTargetFingerprint = "ba910105b28aa331501c9ec3c34de4c0b67ff58204e0ec4a428122c089bb64a7"
@@ -76,11 +85,7 @@ func (p *workflowRuntimeExecutionRefProvider) PutExecutionReference(_ context.Co
 	}
 	stored := cloneRuntimeExecutionRef(ref)
 	if strings.TrimSpace(stored.TargetFingerprint) == "" {
-		fingerprint, err := coreworkflow.TargetFingerprint(stored.Target)
-		if err != nil {
-			return nil, err
-		}
-		stored.TargetFingerprint = fingerprint
+		return nil, errors.New("workflow execution reference target fingerprint is required")
 	}
 	p.refs[stored.ID] = stored
 	return cloneRuntimeExecutionRef(stored), nil
@@ -621,12 +626,14 @@ func TestWorkflowRuntimeInvokeAgentTargetHandlesMissingTurn(t *testing.T) {
 func TestWorkflowRuntimeRejectsMixedAgentPluginTargetWithExecutionRef(t *testing.T) {
 	t.Parallel()
 
+	target := testWorkflowPluginTarget("roadmap", "sync")
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "plugin-ref",
-		ProviderName: "temporal",
-		Target:       testWorkflowPluginTarget("roadmap", "sync"),
-		SubjectID:    "service_account:scheduler",
+		ID:                "plugin-ref",
+		ProviderName:      "temporal",
+		Target:            target,
+		TargetFingerprint: testWorkflowTargetFingerprint(t, target),
+		SubjectID:         "service_account:scheduler",
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}
@@ -639,7 +646,7 @@ func TestWorkflowRuntimeRejectsMixedAgentPluginTargetWithExecutionRef(t *testing
 		ExecutionRef: "plugin-ref",
 		RunID:        "run-123",
 		Target: coreworkflow.Target{
-			Plugin: testWorkflowPluginTarget("roadmap", "sync").Plugin,
+			Plugin: target.Plugin,
 			Agent: &coreworkflow.AgentTarget{
 				ProviderName:   "managed",
 				Prompt:         "send reminder",
@@ -716,11 +723,13 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 	if err != nil {
 		t.Fatalf("FindOrCreateUser: %v", err)
 	}
+	target := testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", map[string]any{"mode": "full"})
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
 		ID:                  "exec-ref-123",
 		ProviderName:        "temporal",
-		Target:              testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", map[string]any{"mode": "full"}),
+		Target:              target,
+		TargetFingerprint:   testWorkflowTargetFingerprint(t, target),
 		SubjectID:           principal.UserSubjectID(user.ID),
 		SubjectKind:         string(principal.KindUser),
 		DisplayName:         "Ada Lovelace",
@@ -757,15 +766,7 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 	resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
 		ProviderName: "temporal",
 		ExecutionRef: "exec-ref-123",
-		Target: testWorkflowPluginTargetWithInput(
-			"roadmap",
-			"sync",
-			"analytics",
-			"tenant-a",
-			map[string]any{
-				"mode": "full",
-			},
-		),
+		Target:       target,
 		Input: map[string]any{
 			"taskId": "task-123",
 		},
@@ -849,12 +850,14 @@ func TestWorkflowRuntimeInvokeExecutionRefRechecksAuthorizationThroughBroker(t *
 	if err != nil {
 		t.Fatalf("FindOrCreateUser: %v", err)
 	}
+	target := testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", nil)
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "exec-ref-denied",
-		ProviderName: "temporal",
-		Target:       testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", nil),
-		SubjectID:    principal.UserSubjectID(user.ID),
+		ID:                "exec-ref-denied",
+		ProviderName:      "temporal",
+		Target:            target,
+		TargetFingerprint: testWorkflowTargetFingerprint(t, target),
+		SubjectID:         principal.UserSubjectID(user.ID),
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}
@@ -912,7 +915,7 @@ func TestWorkflowRuntimeInvokeExecutionRefRechecksAuthorizationThroughBroker(t *
 	_, err = runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
 		ProviderName: "temporal",
 		ExecutionRef: "exec-ref-denied",
-		Target:       testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", nil),
+		Target:       target,
 	})
 	if err == nil {
 		t.Fatal("expected authorization error, got nil")
@@ -931,12 +934,14 @@ func TestWorkflowRuntimeInvokeExecutionRefPreservesTokenPermissionCeiling(t *tes
 	services := coretesting.NewStubServices(t)
 	ctx := context.Background()
 
+	target := testWorkflowPluginTargetWithInput("roadmap", "export", "analytics", "tenant-a", nil)
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(ctx, &coreworkflow.ExecutionReference{
-		ID:           "exec-ref-123",
-		ProviderName: "basic",
-		Target:       testWorkflowPluginTargetWithInput("roadmap", "export", "analytics", "tenant-a", nil),
-		SubjectID:    principal.UserSubjectID("user-123"),
+		ID:                "exec-ref-123",
+		ProviderName:      "basic",
+		Target:            target,
+		TargetFingerprint: testWorkflowTargetFingerprint(t, target),
+		SubjectID:         principal.UserSubjectID("user-123"),
 		Permissions: []core.AccessPermission{{
 			Plugin:     "roadmap",
 			Operations: []string{"sync"},
@@ -972,7 +977,7 @@ func TestWorkflowRuntimeInvokeExecutionRefPreservesTokenPermissionCeiling(t *tes
 	_, err := runtime.Invoke(ctx, coreworkflow.InvokeOperationRequest{
 		ProviderName: "basic",
 		RunID:        "run-123",
-		Target:       testWorkflowPluginTargetWithInput("roadmap", "export", "analytics", "tenant-a", nil),
+		Target:       target,
 		ExecutionRef: "exec-ref-123",
 	})
 	if !errors.Is(err, invocation.ErrScopeDenied) {

--- a/gestaltd/internal/providerhost/workflow_convert.go
+++ b/gestaltd/internal/providerhost/workflow_convert.go
@@ -224,11 +224,15 @@ func workflowExecutionReferenceFromProto(ref *proto.WorkflowExecutionReference) 
 	if err != nil {
 		return nil, err
 	}
+	targetFingerprint := strings.TrimSpace(ref.GetTargetFingerprint())
+	if targetFingerprint == "" {
+		return nil, fmt.Errorf("workflow execution reference target_fingerprint is required")
+	}
 	return &coreworkflow.ExecutionReference{
 		ID:                  strings.TrimSpace(ref.GetId()),
 		ProviderName:        strings.TrimSpace(ref.GetProviderName()),
 		Target:              target,
-		TargetFingerprint:   strings.TrimSpace(ref.GetTargetFingerprint()),
+		TargetFingerprint:   targetFingerprint,
 		CallerPluginName:    strings.TrimSpace(ref.GetCallerPluginName()),
 		SubjectID:           strings.TrimSpace(ref.GetSubjectId()),
 		SubjectKind:         strings.TrimSpace(ref.GetSubjectKind()),

--- a/gestaltd/internal/providerhost/workflow_convert_test.go
+++ b/gestaltd/internal/providerhost/workflow_convert_test.go
@@ -1,6 +1,7 @@
 package providerhost
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -114,5 +115,26 @@ func TestWorkflowRunTriggerToProtoPrefersScheduleOverManual(t *testing.T) {
 	}
 	if got := trigger.GetManual(); got != nil {
 		t.Fatalf("manual trigger = %#v, want nil", got)
+	}
+}
+
+func TestWorkflowExecutionReferenceFromProtoRequiresTargetFingerprint(t *testing.T) {
+	t.Parallel()
+
+	_, err := workflowExecutionReferenceFromProto(&proto.WorkflowExecutionReference{
+		Id:           "ref-1",
+		ProviderName: "basic",
+		Target: &proto.BoundWorkflowTarget{
+			Plugin: &proto.BoundWorkflowPluginTarget{
+				PluginName: "demo",
+				Operation:  "refresh",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("workflowExecutionReferenceFromProto succeeded, want missing target_fingerprint error")
+	}
+	if !strings.Contains(err.Error(), "target_fingerprint is required") {
+		t.Fatalf("error = %v, want target_fingerprint is required", err)
 	}
 }

--- a/gestaltd/internal/server/workflow_run_test.go
+++ b/gestaltd/internal/server/workflow_run_test.go
@@ -47,6 +47,15 @@ func workflowPluginTargetWithRouting(pluginName, operation, connection, instance
 	}
 }
 
+func workflowTargetFingerprint(t *testing.T, target coreworkflow.Target) string {
+	t.Helper()
+	fingerprint, err := coreworkflow.TargetFingerprint(target)
+	if err != nil {
+		t.Fatalf("workflow target fingerprint: %v", err)
+	}
+	return fingerprint
+}
+
 func TestGlobalWorkflowRunInspectionIncludesHistoricalRevokedRefs(t *testing.T) {
 	t.Parallel()
 
@@ -87,23 +96,26 @@ func TestGlobalWorkflowRunInspectionIncludesHistoricalRevokedRefs(t *testing.T) 
 
 	for _, ref := range []*coreworkflow.ExecutionReference{
 		{
-			ID:           "workflow_schedule:sched-new:ref-active",
-			ProviderName: "basic",
-			Target:       provider.runs["run-new"].Target,
-			SubjectID:    principal.UserSubjectID(user.ID),
+			ID:                "workflow_schedule:sched-new:ref-active",
+			ProviderName:      "basic",
+			Target:            provider.runs["run-new"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, provider.runs["run-new"].Target),
+			SubjectID:         principal.UserSubjectID(user.ID),
 		},
 		{
-			ID:           "workflow_schedule:sched-old:ref-revoked",
-			ProviderName: "basic",
-			Target:       provider.runs["run-old"].Target,
-			SubjectID:    principal.UserSubjectID(user.ID),
-			RevokedAt:    &revokedAt,
+			ID:                "workflow_schedule:sched-old:ref-revoked",
+			ProviderName:      "basic",
+			Target:            provider.runs["run-old"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, provider.runs["run-old"].Target),
+			SubjectID:         principal.UserSubjectID(user.ID),
+			RevokedAt:         &revokedAt,
 		},
 		{
-			ID:           "workflow_schedule:sched-other:ref-other",
-			ProviderName: "basic",
-			Target:       provider.runs["run-other"].Target,
-			SubjectID:    principal.UserSubjectID(other.ID),
+			ID:                "workflow_schedule:sched-other:ref-other",
+			ProviderName:      "basic",
+			Target:            provider.runs["run-other"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, provider.runs["run-other"].Target),
+			SubjectID:         principal.UserSubjectID(other.ID),
 		},
 	} {
 		if _, err := provider.PutExecutionReference(context.Background(), ref); err != nil {
@@ -223,16 +235,18 @@ func TestGlobalWorkflowRunInspectionAPITokenScopeFiltersOperations(t *testing.T)
 	}
 	for _, ref := range []*coreworkflow.ExecutionReference{
 		{
-			ID:           "workflow_schedule:sched-sync:ref-sync",
-			ProviderName: "basic",
-			Target:       provider.runs["run-sync"].Target,
-			SubjectID:    principal.UserSubjectID(user.ID),
+			ID:                "workflow_schedule:sched-sync:ref-sync",
+			ProviderName:      "basic",
+			Target:            provider.runs["run-sync"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, provider.runs["run-sync"].Target),
+			SubjectID:         principal.UserSubjectID(user.ID),
 		},
 		{
-			ID:           "workflow_schedule:sched-export:ref-export",
-			ProviderName: "basic",
-			Target:       provider.runs["run-export"].Target,
-			SubjectID:    principal.UserSubjectID(user.ID),
+			ID:                "workflow_schedule:sched-export:ref-export",
+			ProviderName:      "basic",
+			Target:            provider.runs["run-export"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, provider.runs["run-export"].Target),
+			SubjectID:         principal.UserSubjectID(user.ID),
 		},
 	} {
 		if _, err := provider.PutExecutionReference(context.Background(), ref); err != nil {
@@ -314,10 +328,11 @@ func TestGlobalWorkflowRunCancelUpdatesOwnedRun(t *testing.T) {
 	}
 	provider.runs[run.ID] = run
 	if _, err := provider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           run.ExecutionRef,
-		ProviderName: "basic",
-		Target:       run.Target,
-		SubjectID:    principal.UserSubjectID(user.ID),
+		ID:                run.ExecutionRef,
+		ProviderName:      "basic",
+		Target:            run.Target,
+		TargetFingerprint: workflowTargetFingerprint(t, run.Target),
+		SubjectID:         principal.UserSubjectID(user.ID),
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -362,11 +362,7 @@ func (p *memoryWorkflowProvider) PutExecutionReference(_ context.Context, ref *c
 	}
 	stored := cloneWorkflowExecutionReference(ref)
 	if strings.TrimSpace(stored.TargetFingerprint) == "" {
-		fingerprint, err := coreworkflow.TargetFingerprint(stored.Target)
-		if err != nil {
-			return nil, err
-		}
-		stored.TargetFingerprint = fingerprint
+		return nil, errors.New("workflow execution reference target fingerprint is required")
 	}
 	p.executionRefs[stored.ID] = stored
 	return cloneWorkflowExecutionReference(stored), nil
@@ -950,26 +946,29 @@ func TestWorkflowScheduleListAndMutationsAreOwnerScoped(t *testing.T) {
 		UpdatedAt:    &now,
 	}
 	if _, err := provider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "workflow_schedule:sched-ada:ref-ada",
-		ProviderName: "basic",
-		Target:       provider.schedules["sched-ada"].Target,
-		SubjectID:    principal.UserSubjectID(ada.ID),
+		ID:                "workflow_schedule:sched-ada:ref-ada",
+		ProviderName:      "basic",
+		Target:            provider.schedules["sched-ada"].Target,
+		TargetFingerprint: workflowTargetFingerprint(t, provider.schedules["sched-ada"].Target),
+		SubjectID:         principal.UserSubjectID(ada.ID),
 	}); err != nil {
 		t.Fatalf("Put ada ref: %v", err)
 	}
 	if _, err := provider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "workflow_schedule:sched-grace:ref-grace",
-		ProviderName: "basic",
-		Target:       provider.schedules["sched-grace"].Target,
-		SubjectID:    principal.UserSubjectID(grace.ID),
+		ID:                "workflow_schedule:sched-grace:ref-grace",
+		ProviderName:      "basic",
+		Target:            provider.schedules["sched-grace"].Target,
+		TargetFingerprint: workflowTargetFingerprint(t, provider.schedules["sched-grace"].Target),
+		SubjectID:         principal.UserSubjectID(grace.ID),
 	}); err != nil {
 		t.Fatalf("Put grace ref: %v", err)
 	}
 	if _, err := provider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "workflow_schedule:sched-analytics:ref-analytics",
-		ProviderName: "basic",
-		Target:       provider.schedules["sched-analytics"].Target,
-		SubjectID:    principal.UserSubjectID(ada.ID),
+		ID:                "workflow_schedule:sched-analytics:ref-analytics",
+		ProviderName:      "basic",
+		Target:            provider.schedules["sched-analytics"].Target,
+		TargetFingerprint: workflowTargetFingerprint(t, provider.schedules["sched-analytics"].Target),
+		SubjectID:         principal.UserSubjectID(ada.ID),
 	}); err != nil {
 		t.Fatalf("Put analytics ref: %v", err)
 	}
@@ -1174,16 +1173,18 @@ func TestWorkflowScheduleAPITokenScopeFiltersOperations(t *testing.T) {
 	}
 	for _, ref := range []*coreworkflow.ExecutionReference{
 		{
-			ID:           "workflow_schedule:sched-sync:ref-sync",
-			ProviderName: "basic",
-			Target:       provider.schedules["sched-sync"].Target,
-			SubjectID:    principal.UserSubjectID(user.ID),
+			ID:                "workflow_schedule:sched-sync:ref-sync",
+			ProviderName:      "basic",
+			Target:            provider.schedules["sched-sync"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, provider.schedules["sched-sync"].Target),
+			SubjectID:         principal.UserSubjectID(user.ID),
 		},
 		{
-			ID:           "workflow_schedule:sched-export:ref-export",
-			ProviderName: "basic",
-			Target:       provider.schedules["sched-export"].Target,
-			SubjectID:    principal.UserSubjectID(user.ID),
+			ID:                "workflow_schedule:sched-export:ref-export",
+			ProviderName:      "basic",
+			Target:            provider.schedules["sched-export"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, provider.schedules["sched-export"].Target),
+			SubjectID:         principal.UserSubjectID(user.ID),
 		},
 	} {
 		if _, err := provider.PutExecutionReference(context.Background(), ref); err != nil {
@@ -1299,10 +1300,11 @@ func TestWorkflowScheduleUpdateFailureKeepsExistingExecutionRef(t *testing.T) {
 		UpdatedAt:    &now,
 	}
 	if _, err := provider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "workflow_schedule:sched-ada:ref-old",
-		ProviderName: "basic",
-		Target:       oldTarget,
-		SubjectID:    principal.UserSubjectID(user.ID),
+		ID:                "workflow_schedule:sched-ada:ref-old",
+		ProviderName:      "basic",
+		Target:            oldTarget,
+		TargetFingerprint: workflowTargetFingerprint(t, oldTarget),
+		SubjectID:         principal.UserSubjectID(user.ID),
 	}); err != nil {
 		t.Fatalf("Put old ref: %v", err)
 	}
@@ -1539,10 +1541,11 @@ func TestGlobalWorkflowScheduleLookupIgnoresUnrelatedProviderFailures(t *testing
 		UpdatedAt:    &now,
 	}
 	if _, err := basicProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-		ID:           "workflow_schedule:sched-ada-basic:ref-basic",
-		ProviderName: "basic",
-		Target:       basicProvider.schedules["sched-ada-basic"].Target,
-		SubjectID:    principal.UserSubjectID(user.ID),
+		ID:                "workflow_schedule:sched-ada-basic:ref-basic",
+		ProviderName:      "basic",
+		Target:            basicProvider.schedules["sched-ada-basic"].Target,
+		TargetFingerprint: workflowTargetFingerprint(t, basicProvider.schedules["sched-ada-basic"].Target),
+		SubjectID:         principal.UserSubjectID(user.ID),
 	}); err != nil {
 		t.Fatalf("Put execution ref: %v", err)
 	}
@@ -1640,10 +1643,11 @@ func TestGlobalWorkflowScheduleRejectsDuplicateActiveExecutionRefs(t *testing.T)
 	provider.schedules[schedule.ID] = schedule
 	for _, refID := range []string{"workflow_schedule:sched-ada:active-ref-1", "workflow_schedule:sched-ada:active-ref-2"} {
 		if _, err := provider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
-			ID:           refID,
-			ProviderName: "basic",
-			Target:       schedule.Target,
-			SubjectID:    principal.UserSubjectID(user.ID),
+			ID:                refID,
+			ProviderName:      "basic",
+			Target:            schedule.Target,
+			TargetFingerprint: workflowTargetFingerprint(t, schedule.Target),
+			SubjectID:         principal.UserSubjectID(user.ID),
 		}); err != nil {
 			t.Fatalf("Put execution ref %q: %v", refID, err)
 		}
@@ -1946,22 +1950,25 @@ func TestGlobalWorkflowScheduleListAndMutationsAreOwnerScopedAcrossProviders(t *
 	}
 	for _, ref := range []*coreworkflow.ExecutionReference{
 		{
-			ID:           "workflow_schedule:sched-ada-basic:ref-basic",
-			ProviderName: "basic",
-			Target:       basicProvider.schedules["sched-ada-basic"].Target,
-			SubjectID:    principal.UserSubjectID(ada.ID),
+			ID:                "workflow_schedule:sched-ada-basic:ref-basic",
+			ProviderName:      "basic",
+			Target:            basicProvider.schedules["sched-ada-basic"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, basicProvider.schedules["sched-ada-basic"].Target),
+			SubjectID:         principal.UserSubjectID(ada.ID),
 		},
 		{
-			ID:           "workflow_schedule:sched-ada-advanced:ref-advanced",
-			ProviderName: "advanced",
-			Target:       advancedProvider.schedules["sched-ada-advanced"].Target,
-			SubjectID:    principal.UserSubjectID(ada.ID),
+			ID:                "workflow_schedule:sched-ada-advanced:ref-advanced",
+			ProviderName:      "advanced",
+			Target:            advancedProvider.schedules["sched-ada-advanced"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, advancedProvider.schedules["sched-ada-advanced"].Target),
+			SubjectID:         principal.UserSubjectID(ada.ID),
 		},
 		{
-			ID:           "workflow_schedule:sched-grace-advanced:ref-grace-advanced",
-			ProviderName: "advanced",
-			Target:       advancedProvider.schedules["sched-grace-advanced"].Target,
-			SubjectID:    principal.UserSubjectID(grace.ID),
+			ID:                "workflow_schedule:sched-grace-advanced:ref-grace-advanced",
+			ProviderName:      "advanced",
+			Target:            advancedProvider.schedules["sched-grace-advanced"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, advancedProvider.schedules["sched-grace-advanced"].Target),
+			SubjectID:         principal.UserSubjectID(grace.ID),
 		},
 	} {
 		targetProvider := basicProvider
@@ -2391,22 +2398,25 @@ func TestGlobalWorkflowEventTriggerListAndMutationsAreOwnerScopedAcrossProviders
 	}
 	for _, ref := range []*coreworkflow.ExecutionReference{
 		{
-			ID:           "workflow_event_trigger:trg-ada-basic:ref-basic",
-			ProviderName: "basic",
-			Target:       basicProvider.triggers["trg-ada-basic"].Target,
-			SubjectID:    principal.UserSubjectID(ada.ID),
+			ID:                "workflow_event_trigger:trg-ada-basic:ref-basic",
+			ProviderName:      "basic",
+			Target:            basicProvider.triggers["trg-ada-basic"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, basicProvider.triggers["trg-ada-basic"].Target),
+			SubjectID:         principal.UserSubjectID(ada.ID),
 		},
 		{
-			ID:           "workflow_event_trigger:trg-ada-advanced:ref-advanced",
-			ProviderName: "advanced",
-			Target:       advancedProvider.triggers["trg-ada-advanced"].Target,
-			SubjectID:    principal.UserSubjectID(ada.ID),
+			ID:                "workflow_event_trigger:trg-ada-advanced:ref-advanced",
+			ProviderName:      "advanced",
+			Target:            advancedProvider.triggers["trg-ada-advanced"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, advancedProvider.triggers["trg-ada-advanced"].Target),
+			SubjectID:         principal.UserSubjectID(ada.ID),
 		},
 		{
-			ID:           "workflow_event_trigger:trg-grace-advanced:ref-grace-advanced",
-			ProviderName: "advanced",
-			Target:       advancedProvider.triggers["trg-grace-advanced"].Target,
-			SubjectID:    principal.UserSubjectID(grace.ID),
+			ID:                "workflow_event_trigger:trg-grace-advanced:ref-grace-advanced",
+			ProviderName:      "advanced",
+			Target:            advancedProvider.triggers["trg-grace-advanced"].Target,
+			TargetFingerprint: workflowTargetFingerprint(t, advancedProvider.triggers["trg-grace-advanced"].Target),
+			SubjectID:         principal.UserSubjectID(grace.ID),
 		},
 	} {
 		targetProvider := basicProvider

--- a/gestaltd/internal/workflowmanager/manager_test.go
+++ b/gestaltd/internal/workflowmanager/manager_test.go
@@ -278,6 +278,9 @@ func (p *testWorkflowProvider) SignalRun(_ context.Context, req coreworkflow.Sig
 
 func (p *testWorkflowProvider) PutExecutionReference(_ context.Context, ref *coreworkflow.ExecutionReference) (*coreworkflow.ExecutionReference, error) {
 	copied := *ref
+	if strings.TrimSpace(copied.TargetFingerprint) == "" {
+		return nil, errors.New("workflow execution reference target fingerprint is required")
+	}
 	p.refs[copied.ID] = &copied
 	return &copied, nil
 }


### PR DESCRIPTION
## Summary

- Stop bootstrap/server/workflowmanager workflow test providers from backfilling or accepting missing execution-reference target fingerprints.
- Require inbound providerhost `WorkflowExecutionReference` payloads to include `target_fingerprint`.
- Update workflow runtime/server fixtures to store execution refs using the explicit `TargetFingerprint` contract.

## New interfaces

Go execution-ref fixtures now pass the stored fingerprint explicitly:

```go
&coreworkflow.ExecutionReference{
    ID:                "workflow_schedule:sched-sync:ref-sync",
    ProviderName:      "basic",
    Target:            schedule.Target,
    TargetFingerprint: workflowTargetFingerprint(t, schedule.Target),
    SubjectID:         "user:ada",
}
```

Providerhost inbound proto references now require `target_fingerprint`:

```proto
WorkflowExecutionReference {
  id: "workflow_schedule:sched-sync:ref-sync"
  provider_name: "basic"
  target { plugin { plugin_name: "roadmap" operation: "sync" } }
  target_fingerprint: "70af38da089061d9dec9094d8c2439074f5f9f860f63f1939a6c48d8796e3818"
  subject_id: "user:ada"
}
```

Missing `TargetFingerprint` / `target_fingerprint` is now a boundary error instead of being inferred by test providers or proto conversion.

## Tests

- `go test ./internal/providerhost`
- `go test ./internal/bootstrap -run 'TestWorkflowRuntime|Test.*Workflow.*Execution|Test.*IndexedDB'`
- `go test ./internal/server -run 'TestGlobalWorkflow(Schedule|Run|EventTrigger)'`
- `go test ./internal/bootstrap ./internal/server ./internal/providerhost ./internal/workflowmanager`
- `go test ./...`
