### PR TITLE
Add browser-approved provider-dev remote attach

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -834,7 +834,6 @@ a path-only attach is enough:
 
 ```sh
 export GESTALT_URL=https://gestalt.example.com
-export GESTALT_API_KEY=<token-with-provider_dev.attach>
 
 gestaltd provider dev --remote "$GESTALT_URL" --path ./slack
 ```
@@ -842,9 +841,11 @@ gestaltd provider dev --remote "$GESTALT_URL" --path ./slack
 The remote URL is environment-agnostic; it can point at any `gestaltd` instance
 that exposes provider-dev attach targets and has opted in with
 `server.providerDev.remoteAttach: true`. The target plugin must also opt into
-private remote attach with `providerDev.attach.allowedRoles`, and API-token
-callers must use a token with the `provider_dev.attach` action for that plugin.
-The local command replaces only the source plugin attached by your
+private remote attach with `providerDev.attach.allowedRoles`. The CLI opens a
+browser approval page for the interactive happy path; approve it with your
+normal browser session and enter the verification code shown in your terminal.
+API-token callers must use a token with the `provider_dev.attach` action for
+that plugin. The local command replaces only the source plugin attached by your
 authenticated session. Providers that are not attached locally continue to run
 through the remote server and its existing configuration.
 
@@ -889,15 +890,15 @@ Remote attach v1 is process-local. On a load-balanced remote, enable it only
 when the deployment is single-replica or sticky-routes attach creation, CLI
 poll/complete traffic, provider invocations, and provider-owned UI requests for
 the same authenticated owner to the same `gestaltd` process.
-Remote provider dev authenticates with `--remote-token` first, then
-`GESTALT_API_KEY`, then a stored CLI token when the stored credential's server
-base URL matches `--remote`. The token must include `permissions[].actions:
-["provider_dev.attach"]` for every attached plugin. Plain `gestalt auth login`
-credentials are not enough unless the stored API token was minted with that
-action. A stored credential for a different server URL, including a different
-path prefix on the same host, is not sent; the command exits with the stored
-credential's server and file path plus commands to pass an explicit token. Use
-`--remote-token` or `GESTALT_API_KEY` for non-interactive automation.
+Remote provider dev uses `--remote-token` first, then `GESTALT_API_KEY`, then a
+stored CLI token when the stored credential's server base URL matches
+`--remote`. An API token used for direct attach must include
+`permissions[].actions: ["provider_dev.attach"]` for every attached plugin. A
+stored CLI token without that action is not enough for direct attach, so the CLI
+falls back to browser approval when available. A stored credential for a
+different server URL, including a different path prefix on the same host, is not
+sent; the browser approval flow is used instead. Use `--remote-token` or
+`GESTALT_API_KEY` for non-interactive automation.
 
 Remote attach creates an owner-scoped attachment. The server returns an
 `attachId` and a one-time dispatcher secret; the CLI uses both for local

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -58,9 +58,9 @@ gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml 
 gestaltd provider dev --path ./plugins/support
 gestaltd provider dev --path ./ui/dashboard
 gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080
-export GESTALT_API_KEY=<token-with-provider_dev.attach>
 gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support
 gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support --name support
+gestaltd provider dev --remote https://gestalt.example.com --remote-token <token-with-provider_dev.attach> --path ./plugins/support
 gestaltd provider dev --remote https://gestalt.example.com --config ./remote.yaml --config ./local-overrides.yaml
 gestaltd provider release --version 0.0.1-alpha.1
 gestaltd provider release --version 0.0.1-alpha.1 --platform all
@@ -82,14 +82,18 @@ Remote attach v1 is also process-local: only enable it on a single-replica
 server or behind sticky routing that keeps attach creation, CLI poll/complete
 traffic, provider invocations, and provider-owned UI requests for the same
 authenticated owner on the same `gestaltd` process.
-Authentication resolves in this order: `--remote-token`, `GESTALT_API_KEY`, then
-the stored CLI token when its recorded server base URL matches `--remote`. The
-token used for remote attach must include `permissions[].actions:
-["provider_dev.attach"]` for every attached plugin. Plain `gestalt auth login`
-credentials are not enough unless the stored API token was minted with that
-action. Stored CLI tokens are not sent to a different remote URL, including a
-different path prefix on the same host; if the stored credential points
-elsewhere, the command fails with a remediation message instead of prompting.
+For the interactive happy path, `provider dev --remote` creates a short-lived
+attach approval request and opens the remote server in your browser. Approving
+that page with your normal browser session creates an owner-scoped attachment
+only when your resolved role is allowed by the plugin's provider-dev attach
+configuration. The terminal prints a verification code, and the browser approval
+page requires that code before approval succeeds. `--remote-token` and
+`GESTALT_API_KEY` are the non-interactive path; those API tokens must include
+`permissions[].actions:
+["provider_dev.attach"]` for every attached plugin. If a stored CLI token exists
+for the same server, the CLI first tries it for direct attach and falls back to
+browser approval when it is not attach-scoped. Stored CLI tokens are not sent to
+a different remote URL, including a different path prefix on the same host.
 With `--remote URL --path PATH` and no `--config`, the local command sends the
 manifest `source` and the local implementation only; the remote server chooses
 the configured plugin with the same manifest `source` and preserves that
@@ -98,11 +102,11 @@ manifest has no source, pass `--name` to choose the configured remote plugin.
 All non-local plugins and remote host services continue to resolve through the
 remote instance.
 
-After the remote creates an attachment, the CLI uses the returned `attachId` plus
-a one-time dispatcher secret for poll/complete traffic. The dispatcher secret is
-not shown by list/get diagnostics and is not needed for owner cleanup detach.
-Attach creation requires a provider-dev attach grant on the remote plugin and,
-when authenticating with an API token, an explicit token action permission:
+After browser approval or attach-token authentication, the remote creates an
+attachment and the CLI uses the returned `attachId` plus a one-time dispatcher
+secret for poll/complete traffic. The dispatcher secret is not shown by list/get
+diagnostics and is not needed for owner cleanup detach. API-token attach
+requires an explicit token action permission:
 
 ```json
 {

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1112,8 +1112,11 @@ sticky routing for attach creation, poll/complete traffic, provider invocations,
 and provider-owned UI requests as a hard prerequisite before enabling
 `remoteAttach`.
 
-Attach creation requires both a plugin runtime grant and, for API-token
-callers, a token action grant. The runtime grant comes from
+Interactive attach creation uses a short-lived browser approval page plus a
+verification code shown in the initiating terminal. The approving browser
+session must satisfy the plugin runtime grant. For non-interactive/API-token
+attach, the caller must satisfy both the plugin runtime grant and a token action
+grant. The runtime grant comes from
 `plugins.<name>.providerDev.attach.allowedRoles` on a plugin with an
 `authorizationPolicy`, or from a runtime authorizer that explicitly grants the
 same action. API tokens must carry `permissions[].actions:

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -14,12 +14,14 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
 	"syscall"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
@@ -172,6 +174,13 @@ type storedGestaltCLICredential struct {
 	APIToken string `json:"api_token"`
 }
 
+type providerRemoteAuth struct {
+	Token    string
+	Explicit bool
+}
+
+var providerRemoteOpenBrowser = openProviderRemoteBrowser
+
 func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	configPaths, cleanup, err := prepareProviderRemoteConfigPaths(opts)
 	if err != nil {
@@ -192,17 +201,17 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		return errors.New("provider dev --remote requires at least one source-backed plugin in --config or --path")
 	}
 
-	token, err := resolveProviderRemoteToken(opts)
-	if err != nil {
-		return err
+	if _, err := providerRemoteBaseURL(opts.Remote); err != nil {
+		return fmt.Errorf("invalid --remote %q: %w", opts.Remote, err)
 	}
+	auth := resolveProviderRemoteAttachAuth(opts)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	client := providerdev.Client{
 		BaseURL: opts.Remote,
-		Token:   token,
+		Token:   auth.Token,
 	}
 	requestedProviders := make([]providerdev.AttachProvider, 0, len(targets))
 	localUIHandlersByTarget := map[int]http.Handler{}
@@ -240,9 +249,10 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		}
 		requestedProviders = append(requestedProviders, requested)
 	}
-	session, err := client.CreateSession(ctx, providerdev.CreateSessionRequest{Providers: requestedProviders})
+	sessionReq := providerdev.CreateSessionRequest{Providers: requestedProviders}
+	session, err := createProviderRemoteSession(ctx, &client, sessionReq, auth)
 	if err != nil {
-		return providerRemoteCreateSessionError(err)
+		return err
 	}
 	attachID := strings.TrimSpace(session.AttachID)
 	if attachID == "" {
@@ -302,6 +312,97 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		"config_files", configPaths,
 	)
 	return client.RunDispatcher(ctx, attachID, providerClients, providerdev.WithUIHandlers(localUIHandlers))
+}
+
+func resolveProviderRemoteAttachAuth(opts providerLocalCommandOptions) providerRemoteAuth {
+	if token := strings.TrimSpace(opts.RemoteToken); token != "" {
+		return providerRemoteAuth{Token: token, Explicit: true}
+	}
+	if token := strings.TrimSpace(os.Getenv(gestaltAPIKeyEnv)); token != "" {
+		return providerRemoteAuth{Token: token, Explicit: true}
+	}
+	token, _ := resolveProviderRemoteToken(opts)
+	if token == "" {
+		return providerRemoteAuth{}
+	}
+	return providerRemoteAuth{Token: token}
+}
+
+func createProviderRemoteSession(ctx context.Context, client *providerdev.Client, req providerdev.CreateSessionRequest, auth providerRemoteAuth) (*providerdev.CreateSessionResponse, error) {
+	if strings.TrimSpace(auth.Token) != "" {
+		session, err := client.CreateSession(ctx, req)
+		if err == nil {
+			return session, nil
+		}
+		if auth.Explicit || !providerRemoteCreateSessionCanUseBrowserApproval(err) {
+			return nil, providerRemoteCreateSessionError(err)
+		}
+		fmt.Fprintf(os.Stderr, "Stored CLI credentials could not create provider-dev attach directly; opening browser approval instead.\n\n")
+		client.Token = ""
+	}
+	return createProviderRemoteSessionWithBrowser(ctx, client, req)
+}
+
+func providerRemoteCreateSessionCanUseBrowserApproval(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "provider dev attach access denied") ||
+		strings.Contains(msg, "401 Unauthorized") ||
+		strings.Contains(msg, "403 Forbidden")
+}
+
+func createProviderRemoteSessionWithBrowser(ctx context.Context, client *providerdev.Client, req providerdev.CreateSessionRequest) (*providerdev.CreateSessionResponse, error) {
+	authorization, err := client.CreateAttachAuthorization(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("create provider dev browser approval: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Approve provider-dev attach in your browser:\n\n  %s\n\nVerification code: %s\n\nOnly approve if the browser asks for this code.\n\n", authorization.ApprovalURL, authorization.VerificationCode)
+	if err := providerRemoteOpenBrowser(authorization.ApprovalURL); err != nil {
+		fmt.Fprintf(os.Stderr, "Could not open browser automatically: %v\nOpen the URL above to continue.\n\n", err)
+	}
+
+	pollInterval := time.Duration(authorization.PollIntervalMillis) * time.Millisecond
+	if pollInterval <= 0 {
+		pollInterval = time.Second
+	}
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+		status, err := client.PollAttachAuthorization(ctx, authorization.AuthorizationID)
+		if err != nil {
+			return nil, fmt.Errorf("poll provider dev browser approval: %w", err)
+		}
+		if status.Approved {
+			code := strings.TrimSpace(status.AttachAuthorizationCode)
+			if code == "" {
+				return nil, errors.New("provider dev browser approval did not return an authorization code")
+			}
+			req.AttachAuthorizationCode = code
+			return client.CreateAuthorizedSession(ctx, authorization.AuthorizationID, req)
+		}
+		if !authorization.ExpiresAt.IsZero() && time.Now().After(authorization.ExpiresAt) {
+			return nil, errors.New("provider dev browser approval expired")
+		}
+		timer.Reset(pollInterval)
+	}
+}
+
+func openProviderRemoteBrowser(rawURL string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", rawURL).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL).Start()
+	default:
+		return exec.Command("xdg-open", rawURL).Start()
+	}
 }
 
 func resolveProviderRemoteToken(opts providerLocalCommandOptions) (string, error) {
@@ -464,7 +565,7 @@ func providerRemoteCreateSessionError(err error) error {
 
 remote provider-dev attach was denied. The remote plugin must grant providerDev.attach.allowedRoles for your resolved role, and API token callers must use a user token with permissions[].actions including provider_dev.attach for every attached plugin.
 
-provider scopes, operation permissions, subject-owned API tokens, and plain gestalt auth login credentials do not grant remote attach`, err)
+provider scopes, operation permissions, subject-owned API tokens, and stored gestalt auth login API tokens do not grant direct remote attach. Run without --remote-token/%s to use browser approval when the server supports it`, err, gestaltAPIKeyEnv)
 }
 
 func providerRemoteTargetNames(targets []providerRemoteTarget) []string {
@@ -1630,5 +1731,5 @@ func printProviderDevUsage(w io.Writer) {
 	writeUsageLine(w, "  --name     Provider key override when the target key is ambiguous")
 	writeUsageLine(w, "  --port     Public port (default: auto-selected free localhost port)")
 	writeUsageLine(w, "  --remote   Remote gestaltd base URL to attach local source plugins to")
-	writeUsageLine(w, "  --remote-token  Bearer token for --remote (default: GESTALT_API_KEY or matching stored CLI credential; must grant provider_dev.attach)")
+	writeUsageLine(w, "  --remote-token  Bearer token for non-interactive --remote attach (must grant provider_dev.attach)")
 }

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
@@ -247,7 +248,8 @@ func TestProviderRemoteCreateSessionErrorAddsAttachPermissionGuidance(t *testing
 		"remote provider-dev attach was denied",
 		"providerDev.attach.allowedRoles",
 		"permissions[].actions including provider_dev.attach",
-		"plain gestalt auth login credentials do not grant remote attach",
+		"stored gestalt auth login API tokens do not grant direct remote attach",
+		"browser approval",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error missing %q:\n%s", want, err)
@@ -258,6 +260,116 @@ func TestProviderRemoteCreateSessionErrorAddsAttachPermissionGuidance(t *testing
 	if got := providerRemoteCreateSessionError(other); got != other {
 		t.Fatalf("unrelated error was wrapped: %v", got)
 	}
+}
+
+func TestCreateProviderRemoteSessionFallsBackToBrowserApprovalForStoredToken(t *testing.T) {
+	t.Parallel()
+
+	var openedURL string
+	previousOpenBrowser := providerRemoteOpenBrowser
+	providerRemoteOpenBrowser = func(rawURL string) error {
+		openedURL = rawURL
+		return nil
+	}
+	t.Cleanup(func() { providerRemoteOpenBrowser = previousOpenBrowser })
+
+	const (
+		authID       = "auth-1"
+		clientSecret = "pdaa_secret"
+		code         = "pdac_code"
+		dispatcher   = "pda_dispatcher"
+	)
+	var sawDirectToken bool
+	var createdAuthorizedSession bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == providerdev.PathAttachments:
+			if r.Header.Get("Authorization") != "Bearer stored-token" {
+				t.Fatalf("direct attach Authorization = %q, want stored token", r.Header.Get("Authorization"))
+			}
+			sawDirectToken = true
+			http.Error(w, "provider dev attach access denied", http.StatusForbidden)
+		case r.Method == http.MethodPost && r.URL.Path == providerdev.PathAttachAuthorizations:
+			if r.Header.Get("Authorization") != "" {
+				t.Fatalf("browser authorization should not send bearer token, got %q", r.Header.Get("Authorization"))
+			}
+			writeJSONForProviderRemoteTest(t, w, http.StatusCreated, providerdev.CreateAttachAuthorizationResponse{
+				AuthorizationID:    authID,
+				ClientSecret:       clientSecret,
+				VerificationCode:   "123-456",
+				ApprovalURL:        tsURL(t, r) + "/approve",
+				ExpiresAt:          time.Now().Add(time.Minute),
+				PollIntervalMillis: 1,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == providerdev.PathAttachAuthorizations+"/"+authID+"/poll":
+			if r.Header.Get(providerdev.HeaderAuthorizationSecret) != clientSecret {
+				t.Fatalf("poll authorization secret = %q, want %q", r.Header.Get(providerdev.HeaderAuthorizationSecret), clientSecret)
+			}
+			writeJSONForProviderRemoteTest(t, w, http.StatusOK, providerdev.PollAttachAuthorizationResponse{
+				Approved:                true,
+				AttachAuthorizationCode: code,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == providerdev.PathAttachAuthorizations+"/"+authID+"/attachments":
+			if r.Header.Get(providerdev.HeaderAuthorizationSecret) != clientSecret {
+				t.Fatalf("authorized attach secret = %q, want %q", r.Header.Get(providerdev.HeaderAuthorizationSecret), clientSecret)
+			}
+			var req providerdev.CreateSessionRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode authorized attach request: %v", err)
+			}
+			if req.AttachAuthorizationCode != code {
+				t.Fatalf("attach authorization code = %q, want %q", req.AttachAuthorizationCode, code)
+			}
+			createdAuthorizedSession = true
+			writeJSONForProviderRemoteTest(t, w, http.StatusCreated, providerdev.CreateSessionResponse{
+				AttachID:         "attach-1",
+				DispatcherSecret: dispatcher,
+				Providers:        []providerdev.CreateSessionProvider{{Name: "roadmap"}},
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+
+	client := providerdev.Client{BaseURL: ts.URL, Token: "stored-token", HTTPClient: ts.Client()}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	session, err := createProviderRemoteSession(ctx, &client, providerdev.CreateSessionRequest{
+		Providers: []providerdev.AttachProvider{{Name: "roadmap"}},
+	}, providerRemoteAuth{Token: "stored-token"})
+	if err != nil {
+		t.Fatalf("createProviderRemoteSession: %v", err)
+	}
+	if !sawDirectToken {
+		t.Fatal("expected direct attach attempt with stored token")
+	}
+	if openedURL == "" {
+		t.Fatal("expected browser approval URL to be opened")
+	}
+	if !createdAuthorizedSession {
+		t.Fatal("expected authorized browser attach session to be created")
+	}
+	if session.AttachID != "attach-1" || client.DispatcherSecret != dispatcher {
+		t.Fatalf("session = %#v, dispatcher secret = %q", session, client.DispatcherSecret)
+	}
+	if client.AuthorizationSecret != "" {
+		t.Fatalf("authorization secret retained after authorized session: %q", client.AuthorizationSecret)
+	}
+}
+
+func writeJSONForProviderRemoteTest(t *testing.T, w http.ResponseWriter, status int, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("encode JSON response: %v", err)
+	}
+}
+
+func tsURL(t *testing.T, r *http.Request) string {
+	t.Helper()
+	return "http://" + r.Host
 }
 
 func TestProviderRemoteBaseURLNormalizesDefaultPortsAndTrailingSlashes(t *testing.T) {

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -33,14 +34,17 @@ import (
 )
 
 const (
-	DefaultPollTimeout        = 30 * time.Second
-	DefaultSessionIdleTimeout = 2 * time.Minute
-	DefaultCallIdleTimeout    = 30 * time.Minute
+	DefaultPollTimeout             = 30 * time.Second
+	DefaultSessionIdleTimeout      = 2 * time.Minute
+	DefaultCallIdleTimeout         = 30 * time.Minute
+	DefaultMaxAttachAuthorizations = 1024
 
-	HeaderDispatcherSecret = "X-Gestalt-Provider-Dev-Dispatcher"
+	HeaderDispatcherSecret    = "X-Gestalt-Provider-Dev-Dispatcher"
+	HeaderAuthorizationSecret = "X-Gestalt-Provider-Dev-Authorization"
 
-	PathAttachments = "/api/v1/provider-dev/attachments"
-	PathSessions    = "/api/v1/provider-dev/sessions"
+	PathAttachments          = "/api/v1/provider-dev/attachments"
+	PathAttachAuthorizations = "/api/v1/provider-dev/attach-authorizations"
+	PathSessions             = "/api/v1/provider-dev/sessions"
 )
 
 type RuntimeEnv struct {
@@ -62,14 +66,16 @@ type Target struct {
 }
 
 type Manager struct {
-	mu         sync.RWMutex
-	targets    map[string]Target
-	sessions   map[string]*Session
-	ownerIndex map[string][]string
+	mu             sync.RWMutex
+	targets        map[string]Target
+	sessions       map[string]*Session
+	ownerIndex     map[string][]string
+	authorizations map[string]*AttachAuthorization
 }
 
 type CreateSessionRequest struct {
-	Providers []AttachProvider `json:"providers"`
+	Providers               []AttachProvider `json:"providers"`
+	AttachAuthorizationCode string           `json:"attachAuthorizationCode,omitempty"`
 }
 
 type AttachProvider struct {
@@ -96,6 +102,27 @@ type CreateSessionProvider struct {
 	UIPath       string            `json:"uiPath,omitempty"`
 }
 
+type CreateAttachAuthorizationResponse struct {
+	AuthorizationID    string    `json:"authorizationId"`
+	ClientSecret       string    `json:"clientSecret"`
+	VerificationCode   string    `json:"verificationCode"`
+	ApprovalURL        string    `json:"approvalUrl"`
+	ExpiresAt          time.Time `json:"expiresAt"`
+	PollIntervalMillis int       `json:"pollIntervalMillis"`
+}
+
+type AttachAuthorizationInfo struct {
+	AuthorizationID string    `json:"authorizationId"`
+	Providers       []string  `json:"providers"`
+	ExpiresAt       time.Time `json:"expiresAt"`
+	Approved        bool      `json:"approved"`
+}
+
+type PollAttachAuthorizationResponse struct {
+	Approved                bool   `json:"approved"`
+	AttachAuthorizationCode string `json:"attachAuthorizationCode,omitempty"`
+}
+
 type AttachmentInfo struct {
 	AttachID           string                   `json:"attachId"`
 	CreatedAt          time.Time                `json:"createdAt"`
@@ -112,6 +139,21 @@ type AttachmentProviderInfo struct {
 }
 
 type AttachUI struct{}
+
+type AttachAuthorization struct {
+	id               string
+	clientSecretHash string
+	verificationHash string
+	requestHash      string
+	providers        []string
+	createdAt        time.Time
+	expiresAt        time.Time
+	approvedAt       time.Time
+	approvedBy       *principal.Principal
+	codeHash         string
+	code             string
+	used             bool
+}
 
 type UIAssetRequest struct {
 	Method   string      `json:"method,omitempty"`
@@ -186,9 +228,10 @@ type rpcResponse struct {
 
 func NewManager(targets []Target) (*Manager, error) {
 	m := &Manager{
-		targets:    make(map[string]Target, len(targets)),
-		sessions:   map[string]*Session{},
-		ownerIndex: map[string][]string{},
+		targets:        make(map[string]Target, len(targets)),
+		sessions:       map[string]*Session{},
+		ownerIndex:     map[string][]string{},
+		authorizations: map[string]*AttachAuthorization{},
 	}
 	for i := range targets {
 		target := targets[i]
@@ -319,6 +362,14 @@ func (m *Manager) PollSessionWithDispatcherSecret(ctx context.Context, p *princi
 	return session.poll(ctx)
 }
 
+func (m *Manager) PollSessionWithDispatcherSecretOnly(ctx context.Context, sessionID, dispatcherSecret string) (*PollResponse, bool, error) {
+	session, err := m.sessionForDispatcherSecret(sessionID, dispatcherSecret)
+	if err != nil {
+		return nil, false, err
+	}
+	return session.poll(ctx)
+}
+
 func (s *Session) poll(ctx context.Context) (*PollResponse, bool, error) {
 	s.touch()
 
@@ -374,6 +425,148 @@ func (m *Manager) ResolveAttachProviderNames(req CreateSessionRequest) ([]string
 	slices.Sort(names)
 	names = slices.Compact(names)
 	return names, nil
+}
+
+func (m *Manager) CreateAttachAuthorization(req CreateSessionRequest, now time.Time) (*AttachAuthorizationInfo, string, string, error) {
+	if m == nil {
+		return nil, "", "", status.Error(codes.FailedPrecondition, "provider dev is not configured")
+	}
+	names, err := m.ResolveAttachProviderNames(req)
+	if err != nil {
+		return nil, "", "", err
+	}
+	if len(names) == 0 {
+		return nil, "", "", status.Error(codes.InvalidArgument, "at least one provider is required")
+	}
+	requestHash, err := attachAuthorizationRequestHash(req)
+	if err != nil {
+		return nil, "", "", status.Errorf(codes.Internal, "hash provider dev attach authorization request: %v", err)
+	}
+	id, err := randomID()
+	if err != nil {
+		return nil, "", "", status.Errorf(codes.Internal, "create provider dev attach authorization id: %v", err)
+	}
+	clientSecret, clientSecretHash, err := newAttachAuthorizationSecret()
+	if err != nil {
+		return nil, "", "", status.Errorf(codes.Internal, "create provider dev attach authorization secret: %v", err)
+	}
+	verificationCode, verificationHash, err := newAttachAuthorizationVerificationCode()
+	if err != nil {
+		return nil, "", "", status.Errorf(codes.Internal, "create provider dev attach verification code: %v", err)
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	auth := &AttachAuthorization{
+		id:               id,
+		clientSecretHash: clientSecretHash,
+		verificationHash: verificationHash,
+		requestHash:      requestHash,
+		providers:        slices.Clone(names),
+		createdAt:        now,
+		expiresAt:        now.Add(5 * time.Minute),
+	}
+	m.mu.Lock()
+	m.closeExpiredAuthorizationsLocked(now)
+	if len(m.authorizations) >= DefaultMaxAttachAuthorizations {
+		m.mu.Unlock()
+		return nil, "", "", status.Errorf(codes.ResourceExhausted, "too many pending provider dev attach authorizations; try again later")
+	}
+	m.authorizations[id] = auth
+	m.mu.Unlock()
+	info := auth.info()
+	return &info, clientSecret, verificationCode, nil
+}
+
+func (m *Manager) GetAttachAuthorization(id string) (*AttachAuthorizationInfo, error) {
+	auth, err := m.attachAuthorization(id, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	info := auth.info()
+	return &info, nil
+}
+
+func (m *Manager) ApproveAttachAuthorization(id string, p *principal.Principal, verificationCode string) error {
+	owner := principalSubjectID(p)
+	if owner == "" {
+		return status.Error(codes.Unauthenticated, "provider dev attach authorization requires an authenticated principal")
+	}
+	verificationCode = normalizeAttachAuthorizationVerificationCode(verificationCode)
+	if verificationCode == "" {
+		return status.Error(codes.InvalidArgument, "provider dev attach verification code is required")
+	}
+	auth, err := m.attachAuthorization(id, time.Now())
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if auth.used {
+		return status.Error(codes.FailedPrecondition, "provider dev attach authorization was already used")
+	}
+	if subtle.ConstantTimeCompare([]byte(hashAttachAuthorizationSecret(verificationCode)), []byte(auth.verificationHash)) != 1 {
+		return status.Error(codes.PermissionDenied, "provider dev attach verification code is invalid")
+	}
+	if auth.approvedBy != nil || !auth.approvedAt.IsZero() {
+		if principalSubjectID(auth.approvedBy) == owner {
+			return nil
+		}
+		return status.Error(codes.FailedPrecondition, "provider dev attach authorization is already approved")
+	}
+	code, codeHash, err := newAttachAuthorizationCode()
+	if err != nil {
+		return status.Errorf(codes.Internal, "create provider dev attach authorization code: %v", err)
+	}
+	auth.approvedAt = time.Now()
+	auth.approvedBy = clonePrincipal(p)
+	auth.code = code
+	auth.codeHash = codeHash
+	return nil
+}
+
+func (m *Manager) PollAttachAuthorization(id, clientSecret string) (*PollAttachAuthorizationResponse, error) {
+	auth, err := m.attachAuthorizationWithClientSecret(id, clientSecret, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return &PollAttachAuthorizationResponse{
+		Approved:                !auth.approvedAt.IsZero(),
+		AttachAuthorizationCode: auth.code,
+	}, nil
+}
+
+func (m *Manager) ConsumeAttachAuthorization(id, clientSecret, code string, req CreateSessionRequest) (*principal.Principal, error) {
+	auth, err := m.attachAuthorizationWithClientSecret(id, clientSecret, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	requestHash, err := attachAuthorizationRequestHash(req)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "hash provider dev attach authorization request: %v", err)
+	}
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return nil, status.Error(codes.Unauthenticated, "provider dev attach authorization code is required")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if auth.used {
+		return nil, status.Error(codes.FailedPrecondition, "provider dev attach authorization was already used")
+	}
+	if auth.approvedBy == nil || auth.codeHash == "" {
+		return nil, status.Error(codes.FailedPrecondition, "provider dev attach authorization is not approved")
+	}
+	if subtle.ConstantTimeCompare([]byte(hashAttachAuthorizationSecret(code)), []byte(auth.codeHash)) != 1 {
+		return nil, status.Error(codes.PermissionDenied, "provider dev attach authorization code is invalid")
+	}
+	if subtle.ConstantTimeCompare([]byte(requestHash), []byte(auth.requestHash)) != 1 {
+		return nil, status.Error(codes.PermissionDenied, "provider dev attach authorization request does not match")
+	}
+	auth.used = true
+	return clonePrincipal(auth.approvedBy), nil
 }
 
 func (m *Manager) resolveAttachTargets(requestedProviders []AttachProvider) ([]Target, error) {
@@ -452,12 +645,37 @@ func (m *Manager) CompleteCallWithDispatcherSecret(p *principal.Principal, sessi
 	return session.completeCall(callID, req)
 }
 
+func (m *Manager) CompleteCallWithDispatcherSecretOnly(sessionID, callID, dispatcherSecret string, req CompleteCallRequest) error {
+	session, err := m.sessionForDispatcherSecret(sessionID, dispatcherSecret)
+	if err != nil {
+		return err
+	}
+	return session.completeCall(callID, req)
+}
+
 func (m *Manager) VerifyDispatcherSecret(p *principal.Principal, sessionID, dispatcherSecret string) error {
 	session, err := m.sessionForPrincipal(p, sessionID)
 	if err != nil {
 		return err
 	}
 	return session.verifyDispatcherSecret(dispatcherSecret)
+}
+
+func (m *Manager) VerifyDispatcherSecretOnly(sessionID, dispatcherSecret string) error {
+	_, err := m.sessionForDispatcherSecret(sessionID, dispatcherSecret)
+	return err
+}
+
+func (m *Manager) CloseSessionWithDispatcherSecret(sessionID, dispatcherSecret string) error {
+	session, err := m.sessionForDispatcherSecret(sessionID, dispatcherSecret)
+	if err != nil {
+		return err
+	}
+	if err := session.Close(); err != nil {
+		return status.Errorf(codes.Internal, "close provider dev session: %v", err)
+	}
+	m.removeSession(sessionID, session.owner)
+	return nil
 }
 
 func (s *Session) completeCall(callID string, req CompleteCallRequest) error {
@@ -651,6 +869,7 @@ func (m *Manager) Close() error {
 	}
 	m.sessions = map[string]*Session{}
 	m.ownerIndex = map[string][]string{}
+	m.authorizations = map[string]*AttachAuthorization{}
 	m.mu.Unlock()
 
 	var errs []error
@@ -678,6 +897,54 @@ func (m *Manager) closeIdleSessions(now time.Time) {
 	}
 }
 
+func (m *Manager) attachAuthorization(id string, now time.Time) (*AttachAuthorization, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, status.Error(codes.InvalidArgument, "provider dev attach authorization id is required")
+	}
+	if m == nil {
+		return nil, status.Error(codes.FailedPrecondition, "provider dev is not configured")
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closeExpiredAuthorizationsLocked(now)
+	auth := m.authorizations[id]
+	if auth == nil {
+		return nil, status.Errorf(codes.NotFound, "provider dev attach authorization %q not found", id)
+	}
+	if !auth.expiresAt.IsZero() && now.After(auth.expiresAt) {
+		delete(m.authorizations, id)
+		return nil, status.Error(codes.DeadlineExceeded, "provider dev attach authorization expired")
+	}
+	return auth, nil
+}
+
+func (m *Manager) attachAuthorizationWithClientSecret(id, clientSecret string, now time.Time) (*AttachAuthorization, error) {
+	auth, err := m.attachAuthorization(id, now)
+	if err != nil {
+		return nil, err
+	}
+	clientSecret = strings.TrimSpace(clientSecret)
+	if clientSecret == "" {
+		return nil, status.Error(codes.Unauthenticated, "provider dev attach authorization secret is required")
+	}
+	if subtle.ConstantTimeCompare([]byte(hashAttachAuthorizationSecret(clientSecret)), []byte(auth.clientSecretHash)) != 1 {
+		return nil, status.Error(codes.PermissionDenied, "provider dev attach authorization secret is invalid")
+	}
+	return auth, nil
+}
+
+func (m *Manager) closeExpiredAuthorizationsLocked(now time.Time) {
+	for id, auth := range m.authorizations {
+		if auth == nil || (!auth.expiresAt.IsZero() && now.After(auth.expiresAt)) || auth.used {
+			delete(m.authorizations, id)
+		}
+	}
+}
+
 func (m *Manager) sessionForPrincipal(p *principal.Principal, sessionID string) (*Session, error) {
 	owner := principalSubjectID(p)
 	if owner == "" {
@@ -699,6 +966,27 @@ func (m *Manager) sessionForPrincipal(p *principal.Principal, sessionID string) 
 	}
 	if session.owner != owner {
 		return nil, status.Error(codes.PermissionDenied, "provider dev session belongs to another principal")
+	}
+	return session, nil
+}
+
+func (m *Manager) sessionForDispatcherSecret(sessionID, dispatcherSecret string) (*Session, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil, status.Error(codes.InvalidArgument, "session id is required")
+	}
+	if m == nil {
+		return nil, status.Error(codes.FailedPrecondition, "provider dev is not configured")
+	}
+	m.closeIdleSessions(time.Now())
+	m.mu.RLock()
+	session := m.sessions[sessionID]
+	m.mu.RUnlock()
+	if session == nil || session.isClosed() {
+		return nil, status.Errorf(codes.NotFound, "provider dev session %q not found", sessionID)
+	}
+	if err := session.verifyDispatcherSecret(dispatcherSecret); err != nil {
+		return nil, err
 	}
 	return session, nil
 }
@@ -839,6 +1127,18 @@ func (s *Session) touch() {
 	defer s.mu.Unlock()
 	if !s.closed {
 		s.lastSeen = time.Now()
+	}
+}
+
+func (a *AttachAuthorization) info() AttachAuthorizationInfo {
+	if a == nil {
+		return AttachAuthorizationInfo{}
+	}
+	return AttachAuthorizationInfo{
+		AuthorizationID: a.id,
+		Providers:       slices.Clone(a.providers),
+		ExpiresAt:       a.expiresAt,
+		Approved:        !a.approvedAt.IsZero(),
 	}
 }
 
@@ -1098,10 +1398,11 @@ func (c *sessionProviderClient) PostConnect(ctx context.Context, req *proto.Post
 }
 
 type Client struct {
-	BaseURL          string
-	Token            string
-	DispatcherSecret string
-	HTTPClient       *http.Client
+	BaseURL             string
+	Token               string
+	DispatcherSecret    string
+	AuthorizationSecret string
+	HTTPClient          *http.Client
 }
 
 type DispatcherOption func(*dispatcherConfig)
@@ -1122,6 +1423,35 @@ func (c *Client) CreateSession(ctx context.Context, req CreateSessionRequest) (*
 		return nil, err
 	}
 	c.DispatcherSecret = out.DispatcherSecret
+	return &out, nil
+}
+
+func (c *Client) CreateAttachAuthorization(ctx context.Context, req CreateSessionRequest) (*CreateAttachAuthorizationResponse, error) {
+	var out CreateAttachAuthorizationResponse
+	if err := c.doJSON(ctx, http.MethodPost, PathAttachAuthorizations, req, &out); err != nil {
+		return nil, err
+	}
+	c.AuthorizationSecret = out.ClientSecret
+	return &out, nil
+}
+
+func (c Client) PollAttachAuthorization(ctx context.Context, authorizationID string) (*PollAttachAuthorizationResponse, error) {
+	path := PathAttachAuthorizations + "/" + url.PathEscape(authorizationID) + "/poll"
+	var out PollAttachAuthorizationResponse
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) CreateAuthorizedSession(ctx context.Context, authorizationID string, req CreateSessionRequest) (*CreateSessionResponse, error) {
+	var out CreateSessionResponse
+	path := PathAttachAuthorizations + "/" + url.PathEscape(authorizationID) + "/attachments"
+	if err := c.doJSON(ctx, http.MethodPost, path, req, &out); err != nil {
+		return nil, err
+	}
+	c.DispatcherSecret = out.DispatcherSecret
+	c.AuthorizationSecret = ""
 	return &out, nil
 }
 
@@ -1362,6 +1692,9 @@ func (c Client) doJSONStatus(ctx context.Context, method, path string, in any, o
 	}
 	if secret := strings.TrimSpace(c.DispatcherSecret); secret != "" {
 		req.Header.Set(HeaderDispatcherSecret, secret)
+	}
+	if secret := strings.TrimSpace(c.AuthorizationSecret); secret != "" {
+		req.Header.Set(HeaderAuthorizationSecret, secret)
 	}
 	httpClient := c.HTTPClient
 	if httpClient == nil {
@@ -1627,7 +1960,85 @@ func newDispatcherSecret() (secret string, hash string, err error) {
 	return secret, hashDispatcherSecret(secret), nil
 }
 
+func newAttachAuthorizationSecret() (secret string, hash string, err error) {
+	id, err := randomID()
+	if err != nil {
+		return "", "", err
+	}
+	secret = "pdaa_" + id
+	return secret, hashAttachAuthorizationSecret(secret), nil
+}
+
+func newAttachAuthorizationCode() (code string, hash string, err error) {
+	id, err := randomID()
+	if err != nil {
+		return "", "", err
+	}
+	code = "pdac_" + id
+	return code, hashAttachAuthorizationSecret(code), nil
+}
+
+func newAttachAuthorizationVerificationCode() (code string, hash string, err error) {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", "", err
+	}
+	n := binary.BigEndian.Uint32(b[:]) % 1000000
+	code = fmt.Sprintf("%03d-%03d", n/1000, n%1000)
+	return code, hashAttachAuthorizationSecret(normalizeAttachAuthorizationVerificationCode(code)), nil
+}
+
 func hashDispatcherSecret(secret string) string {
+	return hashProviderDevSecret(secret)
+}
+
+func hashAttachAuthorizationSecret(secret string) string {
+	return hashProviderDevSecret(secret)
+}
+
+func hashProviderDevSecret(secret string) string {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(secret)))
 	return hex.EncodeToString(sum[:])
+}
+
+func normalizeAttachAuthorizationVerificationCode(code string) string {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range code {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() != 6 {
+		return ""
+	}
+	return b.String()
+}
+
+func attachAuthorizationRequestHash(req CreateSessionRequest) (string, error) {
+	req.AttachAuthorizationCode = ""
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func clonePrincipal(p *principal.Principal) *principal.Principal {
+	if p == nil {
+		return nil
+	}
+	clone := *p
+	if p.Identity != nil {
+		identity := *p.Identity
+		clone.Identity = &identity
+	}
+	clone.Scopes = slices.Clone(p.Scopes)
+	clone.TokenPermissions = nil
+	clone.ActionPermissions = nil
+	return principal.Canonicalized(&clone)
 }

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -431,6 +431,26 @@ func TestHTTPTransportRequiresDispatcherSecretForDispatcherTraffic(t *testing.T)
 	}
 }
 
+func TestCreateAttachAuthorizationRejectsWhenPendingLimitReached(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewManager([]Target{{Name: "roadmap"}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	req := CreateSessionRequest{Providers: []AttachProvider{{Name: "roadmap"}}}
+	now := time.Now()
+	for i := 0; i < DefaultMaxAttachAuthorizations; i++ {
+		if _, _, _, err := manager.CreateAttachAuthorization(req, now); err != nil {
+			t.Fatalf("CreateAttachAuthorization %d: %v", i, err)
+		}
+	}
+	_, _, _, err = manager.CreateAttachAuthorization(req, now)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("CreateAttachAuthorization over limit code = %v, want %v (err=%v)", status.Code(err), codes.ResourceExhausted, err)
+	}
+}
+
 func TestHTTPTransportListsRedactedAttachmentMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers_provider_dev.go
+++ b/gestaltd/internal/server/handlers_provider_dev.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"html"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -62,6 +65,155 @@ func (s *Server) getProviderDevAttachment(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, resp)
 }
 
+func (s *Server) createProviderDevAttachAuthorization(w http.ResponseWriter, r *http.Request) {
+	if !s.providerDevAvailable(w) {
+		return
+	}
+	var req providerdev.CreateSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid provider dev attach authorization request")
+		return
+	}
+	info, clientSecret, verificationCode, err := s.providerDevSessions.CreateAttachAuthorization(req, s.now())
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	approvalPath := providerdev.PathAttachAuthorizations + "/" + url.PathEscape(info.AuthorizationID)
+	approvalURL, err := s.resolvePublicURLPreserveBasePath(r, approvalPath)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve provider dev attach approval URL")
+		return
+	}
+	writeJSON(w, http.StatusCreated, providerdev.CreateAttachAuthorizationResponse{
+		AuthorizationID:    info.AuthorizationID,
+		ClientSecret:       clientSecret,
+		VerificationCode:   verificationCode,
+		ApprovalURL:        approvalURL,
+		ExpiresAt:          info.ExpiresAt,
+		PollIntervalMillis: 1000,
+	})
+}
+
+func (s *Server) showProviderDevAttachAuthorization(w http.ResponseWriter, r *http.Request) {
+	if !s.providerDevAvailable(w) {
+		return
+	}
+	p, ok := s.providerDevBrowserPrincipal(w, r)
+	if !ok {
+		return
+	}
+	info, err := s.providerDevSessions.GetAttachAuthorization(providerDevAuthorizationID(r))
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	for _, name := range info.Providers {
+		if !s.allowProviderActionContext(r.Context(), p, name, core.ProviderActionDevAttach) {
+			writeError(w, http.StatusForbidden, errProviderDevAttachAccess.Error())
+			return
+		}
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	approvalAction := "./" + url.PathEscape(info.AuthorizationID) + "/approve"
+	_, _ = fmt.Fprintf(w, `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Approve provider dev attach</title></head>
+<body>
+<main style="font-family: sans-serif; max-width: 42rem; margin: 3rem auto; line-height: 1.5">
+<h1>Approve local provider development?</h1>
+<p>This allows the requesting local CLI process to handle provider calls for your browser/session only.</p>
+<p>Only approve if you started this request and the provider list matches what you expected.</p>
+<p><strong>Providers:</strong> %s</p>
+<form method="post" action="%s">
+<label for="verificationCode">Enter the verification code shown in your terminal:</label>
+<input id="verificationCode" name="verificationCode" autocomplete="off" inputmode="numeric" pattern="[0-9 -]*" required>
+<button type="submit">Approve attach</button>
+</form>
+</main>
+</body>
+</html>`, html.EscapeString(strings.Join(info.Providers, ", ")), html.EscapeString(approvalAction))
+}
+
+func (s *Server) approveProviderDevAttachAuthorization(w http.ResponseWriter, r *http.Request) {
+	if !s.providerDevAvailable(w) {
+		return
+	}
+	p, ok := s.providerDevBrowserPrincipal(w, r)
+	if !ok {
+		return
+	}
+	info, err := s.providerDevSessions.GetAttachAuthorization(providerDevAuthorizationID(r))
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	for _, name := range info.Providers {
+		if !s.allowProviderActionContext(r.Context(), p, name, core.ProviderActionDevAttach) {
+			writeError(w, http.StatusForbidden, errProviderDevAttachAccess.Error())
+			return
+		}
+	}
+	if err := r.ParseForm(); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid provider dev attach approval request")
+		return
+	}
+	if err := s.providerDevSessions.ApproveAttachAuthorization(info.AuthorizationID, p, r.Form.Get("verificationCode")); err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprint(w, `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Provider dev attach approved</title></head>
+<body>
+<main style="font-family: sans-serif; max-width: 42rem; margin: 3rem auto; line-height: 1.5">
+<h1>Provider dev attach approved</h1>
+<p>You can return to your terminal. Keep the local process running while you develop.</p>
+</main>
+</body>
+</html>`)
+}
+
+func (s *Server) pollProviderDevAttachAuthorization(w http.ResponseWriter, r *http.Request) {
+	if !s.providerDevAvailable(w) {
+		return
+	}
+	resp, err := s.providerDevSessions.PollAttachAuthorization(providerDevAuthorizationID(r), providerDevAuthorizationSecret(r))
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) createAuthorizedProviderDevSession(w http.ResponseWriter, r *http.Request) {
+	if !s.providerDevAvailable(w) {
+		return
+	}
+	var req providerdev.CreateSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid provider dev session request")
+		return
+	}
+	p, err := s.providerDevSessions.ConsumeAttachAuthorization(providerDevAuthorizationID(r), providerDevAuthorizationSecret(r), req.AttachAuthorizationCode, req)
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	if err := s.authorizeProviderDevSessionRequest(w, r, p, req); err != nil {
+		return
+	}
+	resp, err := s.providerDevSessions.CreateSession(r.Context(), p, req)
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, resp)
+}
+
 func (s *Server) authorizeProviderDevSessionRequest(w http.ResponseWriter, r *http.Request, p *principal.Principal, req providerdev.CreateSessionRequest) error {
 	if err := requireUserCaller(w, p); err != nil {
 		return err
@@ -84,6 +236,54 @@ func (s *Server) authorizeProviderDevSessionRequest(w http.ResponseWriter, r *ht
 	return nil
 }
 
+func (s *Server) providerDevBrowserPrincipal(w http.ResponseWriter, r *http.Request) (*principal.Principal, bool) {
+	browserRequest := r.Clone(r.Context())
+	browserRequest.Header = r.Header.Clone()
+	browserRequest.Header.Del("Authorization")
+	p, err := s.resolveRequestPrincipalWithUserID(browserRequest)
+	if err == nil && p != nil && p.Source == principal.SourceSession && !principal.IsNonUserPrincipal(p) {
+		return p, true
+	}
+	if r.Method == http.MethodGet {
+		http.Redirect(w, r, browserLoginPath+"?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusFound)
+		return nil, false
+	}
+	writeError(w, http.StatusUnauthorized, "provider dev attach approval requires browser authentication")
+	return nil, false
+}
+
+func (s *Server) resolvePublicURLPreserveBasePath(r *http.Request, raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if parsed.IsAbs() {
+		return parsed.String(), nil
+	}
+	base := s.publicBaseURL
+	if base == "" {
+		return s.resolvePublicURL(r, raw)
+	}
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	basePath := strings.TrimRight(baseURL.Path, "/")
+	refPath := parsed.EscapedPath()
+	if refPath == "" {
+		refPath = parsed.Path
+	}
+	refPath = "/" + strings.TrimLeft(refPath, "/")
+	baseURL.Path = basePath + refPath
+	baseURL.RawPath = ""
+	baseURL.RawQuery = parsed.RawQuery
+	baseURL.Fragment = parsed.Fragment
+	return baseURL.String(), nil
+}
+
 func (s *Server) pollProviderDevSession(w http.ResponseWriter, r *http.Request) {
 	if !s.providerDevAvailable(w) {
 		return
@@ -92,6 +292,25 @@ func (s *Server) pollProviderDevSession(w http.ResponseWriter, r *http.Request) 
 	ctx, cancel := context.WithTimeout(r.Context(), providerdev.DefaultPollTimeout)
 	defer cancel()
 	resp, ok, err := s.providerDevSessions.PollSessionWithDispatcherSecret(ctx, PrincipalFromContext(r.Context()), sessionID, providerDevDispatcherSecret(r))
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	if !ok {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) pollProviderDevSessionByDispatcher(w http.ResponseWriter, r *http.Request) {
+	if !s.providerDevAvailable(w) {
+		return
+	}
+	sessionID := providerDevAttachmentID(r)
+	ctx, cancel := context.WithTimeout(r.Context(), providerdev.DefaultPollTimeout)
+	defer cancel()
+	resp, ok, err := s.providerDevSessions.PollSessionWithDispatcherSecretOnly(ctx, sessionID, providerDevDispatcherSecret(r))
 	if err != nil {
 		writeProviderDevError(w, err)
 		return
@@ -132,11 +351,63 @@ func (s *Server) completeProviderDevCall(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+func (s *Server) completeProviderDevCallByDispatcher(w http.ResponseWriter, r *http.Request) {
+	if !s.providerDevAvailable(w) {
+		return
+	}
+	if err := s.providerDevSessions.VerifyDispatcherSecretOnly(providerDevAttachmentID(r), providerDevDispatcherSecret(r)); err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	var req providerdev.CompleteCallRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid provider dev call response")
+		return
+	}
+	err := s.providerDevSessions.CompleteCallWithDispatcherSecretOnly(
+		providerDevAttachmentID(r),
+		providerDevCallID(r),
+		providerDevDispatcherSecret(r),
+		req,
+	)
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
 func (s *Server) closeProviderDevSession(w http.ResponseWriter, r *http.Request) {
 	if !s.providerDevAvailable(w) {
 		return
 	}
 	err := s.providerDevSessions.CloseSession(PrincipalFromContext(r.Context()), providerDevAttachmentID(r))
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "closed"})
+}
+
+func (s *Server) closeProviderDevSessionByDispatcherOrOwner(w http.ResponseWriter, r *http.Request) {
+	if !s.providerDevAvailable(w) {
+		return
+	}
+	if strings.TrimSpace(providerDevDispatcherSecret(r)) != "" {
+		err := s.providerDevSessions.CloseSessionWithDispatcherSecret(providerDevAttachmentID(r), providerDevDispatcherSecret(r))
+		if err != nil {
+			writeProviderDevError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "closed"})
+		return
+	}
+	p, err := s.resolveRequestPrincipalWithUserID(r)
+	if err != nil || p == nil {
+		writeError(w, http.StatusUnauthorized, "missing authorization")
+		return
+	}
+	err = s.providerDevSessions.CloseSession(p, providerDevAttachmentID(r))
 	if err != nil {
 		writeProviderDevError(w, err)
 		return
@@ -158,6 +429,14 @@ func (s *Server) providerDevAvailable(w http.ResponseWriter) bool {
 		return false
 	}
 	return true
+}
+
+func providerDevAuthorizationID(r *http.Request) string {
+	return chi.URLParam(r, "authorizationID")
+}
+
+func providerDevAuthorizationSecret(r *http.Request) string {
+	return r.Header.Get(providerdev.HeaderAuthorizationSecret)
 }
 
 func providerDevAttachmentID(r *http.Request) string {

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -169,6 +169,7 @@ func (s *Server) mountAPIRoutes(r chi.Router) {
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(middleware.Timeout(60 * time.Second))
 		s.mountAuthRoutes(r)
+		s.mountProviderDevPublicRoutes(r)
 		s.mountAuthenticatedRoutes(r)
 	})
 }

--- a/gestaltd/internal/server/routes_provider_dev.go
+++ b/gestaltd/internal/server/routes_provider_dev.go
@@ -1,0 +1,15 @@
+package server
+
+import "github.com/go-chi/chi/v5"
+
+func (s *Server) mountProviderDevPublicRoutes(r chi.Router) {
+	r.Post("/provider-dev/attach-authorizations", s.createProviderDevAttachAuthorization)
+	r.Get("/provider-dev/attach-authorizations/{authorizationID}", s.showProviderDevAttachAuthorization)
+	r.Post("/provider-dev/attach-authorizations/{authorizationID}/approve", s.approveProviderDevAttachAuthorization)
+	r.Get("/provider-dev/attach-authorizations/{authorizationID}/poll", s.pollProviderDevAttachAuthorization)
+	r.Post("/provider-dev/attach-authorizations/{authorizationID}/attachments", s.createAuthorizedProviderDevSession)
+
+	r.Get("/provider-dev/attachments/{attachmentID}/poll", s.pollProviderDevSessionByDispatcher)
+	r.Post("/provider-dev/attachments/{attachmentID}/calls/{callID}", s.completeProviderDevCallByDispatcher)
+	r.Delete("/provider-dev/attachments/{attachmentID}", s.closeProviderDevSessionByDispatcherOrOwner)
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -68,9 +68,6 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Post("/provider-dev/attachments", s.createProviderDevSession)
 		r.Get("/provider-dev/attachments", s.listProviderDevAttachments)
 		r.Get("/provider-dev/attachments/{attachmentID}", s.getProviderDevAttachment)
-		r.Get("/provider-dev/attachments/{attachmentID}/poll", s.pollProviderDevSession)
-		r.Post("/provider-dev/attachments/{attachmentID}/calls/{callID}", s.completeProviderDevCall)
-		r.Delete("/provider-dev/attachments/{attachmentID}", s.closeProviderDevSession)
 
 		r.Post("/tokens", s.createAPIToken)
 		r.Get("/tokens", s.listAPITokens)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6476,6 +6476,335 @@ func TestProviderDevAttachmentCreateRequiresAttachActionPermission(t *testing.T)
 	}
 }
 
+func TestProviderDevAttachAuthorizationBrowserApprovalCreatesDispatcherSession(t *testing.T) {
+	t.Parallel()
+
+	manager, err := providerdev.NewManager([]providerdev.Target{{
+		Name:   "roadmap",
+		Source: "github.com/acme/plugins/roadmap",
+		RuntimeEnv: func(string) (providerdev.RuntimeEnv, error) {
+			return providerdev.RuntimeEnv{Env: map[string]string{"SESSION_ENV": "ok"}}, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	auth := &coretesting.StubAuthProvider{
+		N: "test",
+		ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+			if token == "owner-session" {
+				return &core.UserIdentity{Email: "owner@example.test"}, nil
+			}
+			return nil, principal.ErrInvalidToken
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = auth
+		cfg.ProviderDevAttach = true
+		cfg.ProviderDevSessions = manager
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"roadmap": {
+				AuthorizationPolicy: "provider_devs",
+				ProviderDev: &config.ProviderEntryDevConfig{
+					Attach: config.ProviderEntryDevAttachConfig{AllowedRoles: []string{"viewer"}},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{
+			Policies: map[string]config.SubjectPolicyDef{
+				"provider_devs": {Default: "allow"},
+			},
+		}, cfg.PluginDefs)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createReq, err := http.NewRequest(http.MethodPost, ts.URL+providerdev.PathAttachAuthorizations, strings.NewReader(`{"providers":[{"name":"roadmap"}]}`))
+	if err != nil {
+		t.Fatalf("new attach authorization request: %v", err)
+	}
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := ts.Client().Do(createReq)
+	if err != nil {
+		t.Fatalf("create attach authorization: %v", err)
+	}
+	createBody, err := io.ReadAll(createResp.Body)
+	_ = createResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read attach authorization response: %v", err)
+	}
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create attach authorization status = %d, want 201; body = %s", createResp.StatusCode, createBody)
+	}
+	var authorization providerdev.CreateAttachAuthorizationResponse
+	if err := json.Unmarshal(createBody, &authorization); err != nil {
+		t.Fatalf("decode attach authorization response: %v", err)
+	}
+	if authorization.AuthorizationID == "" || authorization.ClientSecret == "" || authorization.VerificationCode == "" || authorization.ApprovalURL == "" {
+		t.Fatalf("attach authorization response missing fields: %s", createBody)
+	}
+
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	showReq, err := http.NewRequest(http.MethodGet, authorization.ApprovalURL, nil)
+	if err != nil {
+		t.Fatalf("new show approval request: %v", err)
+	}
+	showResp, err := noRedirect.Do(showReq)
+	if err != nil {
+		t.Fatalf("show approval without browser session: %v", err)
+	}
+	_ = showResp.Body.Close()
+	if showResp.StatusCode != http.StatusFound {
+		t.Fatalf("show approval without browser session status = %d, want 302", showResp.StatusCode)
+	}
+	if location := showResp.Header.Get("Location"); !strings.HasPrefix(location, "/api/v1/auth/login?next=") {
+		t.Fatalf("show approval redirect = %q, want browser login", location)
+	}
+
+	bearerOnlyReq, err := http.NewRequest(http.MethodGet, authorization.ApprovalURL, nil)
+	if err != nil {
+		t.Fatalf("new bearer-only approval request: %v", err)
+	}
+	bearerOnlyReq.Header.Set("Authorization", "Bearer owner-session")
+	bearerOnlyResp, err := noRedirect.Do(bearerOnlyReq)
+	if err != nil {
+		t.Fatalf("show approval with bearer only: %v", err)
+	}
+	_ = bearerOnlyResp.Body.Close()
+	if bearerOnlyResp.StatusCode != http.StatusFound {
+		t.Fatalf("show approval with bearer only status = %d, want 302", bearerOnlyResp.StatusCode)
+	}
+
+	showReq, err = http.NewRequest(http.MethodGet, authorization.ApprovalURL, nil)
+	if err != nil {
+		t.Fatalf("new authenticated approval request: %v", err)
+	}
+	showReq.AddCookie(&http.Cookie{Name: "session_token", Value: "owner-session"})
+	showResp, err = ts.Client().Do(showReq)
+	if err != nil {
+		t.Fatalf("show approval with browser session: %v", err)
+	}
+	showBody, err := io.ReadAll(showResp.Body)
+	_ = showResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read approval page: %v", err)
+	}
+	if showResp.StatusCode != http.StatusOK {
+		t.Fatalf("show approval with browser session status = %d, want 200; body = %s", showResp.StatusCode, showBody)
+	}
+	if showResp.Header.Get("Cache-Control") != "no-store" || !strings.Contains(string(showBody), "roadmap") {
+		t.Fatalf("approval page missing no-store or provider name: headers=%v body=%s", showResp.Header, showBody)
+	}
+	wantAction := `action="./` + authorization.AuthorizationID + `/approve"`
+	if !strings.Contains(string(showBody), wantAction) {
+		t.Fatalf("approval page action = %s, want relative action %q", showBody, wantAction)
+	}
+	if strings.Contains(string(showBody), authorization.VerificationCode) {
+		t.Fatalf("approval page leaked verification code: %s", showBody)
+	}
+
+	wrongCode := "000-000"
+	if authorization.VerificationCode == wrongCode {
+		wrongCode = "111-111"
+	}
+	approveReq, err := http.NewRequest(http.MethodPost, authorization.ApprovalURL+"/approve", strings.NewReader(url.Values{"verificationCode": {wrongCode}}.Encode()))
+	if err != nil {
+		t.Fatalf("new wrong-code approve request: %v", err)
+	}
+	approveReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	approveReq.AddCookie(&http.Cookie{Name: "session_token", Value: "owner-session"})
+	approveResp, err := ts.Client().Do(approveReq)
+	if err != nil {
+		t.Fatalf("approve attach authorization with wrong code: %v", err)
+	}
+	_ = approveResp.Body.Close()
+	if approveResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("wrong-code approve status = %d, want 403", approveResp.StatusCode)
+	}
+
+	approveReq, err = http.NewRequest(http.MethodPost, authorization.ApprovalURL+"/approve", strings.NewReader(url.Values{"verificationCode": {authorization.VerificationCode}}.Encode()))
+	if err != nil {
+		t.Fatalf("new approve request: %v", err)
+	}
+	approveReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	approveReq.AddCookie(&http.Cookie{Name: "session_token", Value: "owner-session"})
+	approveResp, err = ts.Client().Do(approveReq)
+	if err != nil {
+		t.Fatalf("approve attach authorization: %v", err)
+	}
+	approveBody, err := io.ReadAll(approveResp.Body)
+	_ = approveResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read approve response: %v", err)
+	}
+	if approveResp.StatusCode != http.StatusOK {
+		t.Fatalf("approve status = %d, want 200; body = %s", approveResp.StatusCode, approveBody)
+	}
+	if approveResp.Header.Get("Cache-Control") != "no-store" {
+		t.Fatalf("approve Cache-Control = %q, want no-store", approveResp.Header.Get("Cache-Control"))
+	}
+
+	pollReq, err := http.NewRequest(http.MethodGet, ts.URL+providerdev.PathAttachAuthorizations+"/"+authorization.AuthorizationID+"/poll", nil)
+	if err != nil {
+		t.Fatalf("new poll request: %v", err)
+	}
+	pollResp, err := ts.Client().Do(pollReq)
+	if err != nil {
+		t.Fatalf("poll without authorization secret: %v", err)
+	}
+	_ = pollResp.Body.Close()
+	if pollResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("poll without authorization secret status = %d, want 401", pollResp.StatusCode)
+	}
+
+	pollReq, err = http.NewRequest(http.MethodGet, ts.URL+providerdev.PathAttachAuthorizations+"/"+authorization.AuthorizationID+"/poll", nil)
+	if err != nil {
+		t.Fatalf("new authorized poll request: %v", err)
+	}
+	pollReq.Header.Set(providerdev.HeaderAuthorizationSecret, authorization.ClientSecret)
+	pollResp, err = ts.Client().Do(pollReq)
+	if err != nil {
+		t.Fatalf("poll approval: %v", err)
+	}
+	pollBody, err := io.ReadAll(pollResp.Body)
+	_ = pollResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read poll response: %v", err)
+	}
+	if pollResp.StatusCode != http.StatusOK {
+		t.Fatalf("poll status = %d, want 200; body = %s", pollResp.StatusCode, pollBody)
+	}
+	var poll providerdev.PollAttachAuthorizationResponse
+	if err := json.Unmarshal(pollBody, &poll); err != nil {
+		t.Fatalf("decode poll response: %v", err)
+	}
+	if !poll.Approved || poll.AttachAuthorizationCode == "" {
+		t.Fatalf("poll response missing approval/code: %s", pollBody)
+	}
+
+	approveReq, err = http.NewRequest(http.MethodPost, authorization.ApprovalURL+"/approve", strings.NewReader(url.Values{"verificationCode": {authorization.VerificationCode}}.Encode()))
+	if err != nil {
+		t.Fatalf("new second approve request: %v", err)
+	}
+	approveReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	approveReq.AddCookie(&http.Cookie{Name: "session_token", Value: "owner-session"})
+	approveResp, err = ts.Client().Do(approveReq)
+	if err != nil {
+		t.Fatalf("approve attach authorization again: %v", err)
+	}
+	_ = approveResp.Body.Close()
+	if approveResp.StatusCode != http.StatusOK {
+		t.Fatalf("second approve status = %d, want 200", approveResp.StatusCode)
+	}
+	pollReq, err = http.NewRequest(http.MethodGet, ts.URL+providerdev.PathAttachAuthorizations+"/"+authorization.AuthorizationID+"/poll", nil)
+	if err != nil {
+		t.Fatalf("new second authorized poll request: %v", err)
+	}
+	pollReq.Header.Set(providerdev.HeaderAuthorizationSecret, authorization.ClientSecret)
+	pollResp, err = ts.Client().Do(pollReq)
+	if err != nil {
+		t.Fatalf("poll approval after second approve: %v", err)
+	}
+	pollBody, err = io.ReadAll(pollResp.Body)
+	_ = pollResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read second poll response: %v", err)
+	}
+	var secondPoll providerdev.PollAttachAuthorizationResponse
+	if err := json.Unmarshal(pollBody, &secondPoll); err != nil {
+		t.Fatalf("decode second poll response: %v", err)
+	}
+	if secondPoll.AttachAuthorizationCode != poll.AttachAuthorizationCode {
+		t.Fatalf("approval code changed after idempotent approve: got %q want %q", secondPoll.AttachAuthorizationCode, poll.AttachAuthorizationCode)
+	}
+
+	sessionReq, err := http.NewRequest(http.MethodPost, ts.URL+providerdev.PathAttachAuthorizations+"/"+authorization.AuthorizationID+"/attachments", strings.NewReader(fmt.Sprintf(`{"attachAuthorizationCode":%q,"providers":[{"name":"roadmap"}]}`, poll.AttachAuthorizationCode)))
+	if err != nil {
+		t.Fatalf("new authorized session request: %v", err)
+	}
+	sessionReq.Header.Set("Content-Type", "application/json")
+	sessionReq.Header.Set(providerdev.HeaderAuthorizationSecret, authorization.ClientSecret)
+	sessionResp, err := ts.Client().Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create authorized session: %v", err)
+	}
+	sessionBody, err := io.ReadAll(sessionResp.Body)
+	_ = sessionResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read authorized session response: %v", err)
+	}
+	if sessionResp.StatusCode != http.StatusCreated {
+		t.Fatalf("authorized session status = %d, want 201; body = %s", sessionResp.StatusCode, sessionBody)
+	}
+	var session providerdev.CreateSessionResponse
+	if err := json.Unmarshal(sessionBody, &session); err != nil {
+		t.Fatalf("decode authorized session response: %v", err)
+	}
+	if session.AttachID == "" || session.DispatcherSecret == "" {
+		t.Fatalf("authorized session missing attachId/dispatcherSecret: %s", sessionBody)
+	}
+
+	deleteReq, err := http.NewRequest(http.MethodDelete, ts.URL+providerdev.PathAttachments+"/"+session.AttachID, nil)
+	if err != nil {
+		t.Fatalf("new dispatcher delete request: %v", err)
+	}
+	deleteReq.Header.Set(providerdev.HeaderDispatcherSecret, session.DispatcherSecret)
+	deleteResp, err := ts.Client().Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete by dispatcher secret: %v", err)
+	}
+	deleteBody, err := io.ReadAll(deleteResp.Body)
+	_ = deleteResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read delete response: %v", err)
+	}
+	if deleteResp.StatusCode != http.StatusOK {
+		t.Fatalf("delete by dispatcher secret status = %d, want 200; body = %s", deleteResp.StatusCode, deleteBody)
+	}
+}
+
+func TestProviderDevAttachAuthorizationApprovalURLPreservesPublicBasePath(t *testing.T) {
+	t.Parallel()
+
+	manager, err := providerdev.NewManager([]providerdev.Target{{Name: "roadmap"}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.PublicBaseURL = "https://gestalt.example.test/team-a"
+		cfg.ProviderDevAttach = true
+		cfg.ProviderDevSessions = manager
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createReq, err := http.NewRequest(http.MethodPost, ts.URL+providerdev.PathAttachAuthorizations, strings.NewReader(`{"providers":[{"name":"roadmap"}]}`))
+	if err != nil {
+		t.Fatalf("new attach authorization request: %v", err)
+	}
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := ts.Client().Do(createReq)
+	if err != nil {
+		t.Fatalf("create attach authorization: %v", err)
+	}
+	createBody, err := io.ReadAll(createResp.Body)
+	_ = createResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read attach authorization response: %v", err)
+	}
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create attach authorization status = %d, want 201; body = %s", createResp.StatusCode, createBody)
+	}
+	var authorization providerdev.CreateAttachAuthorizationResponse
+	if err := json.Unmarshal(createBody, &authorization); err != nil {
+		t.Fatalf("decode attach authorization response: %v", err)
+	}
+	if !strings.HasPrefix(authorization.ApprovalURL, "https://gestalt.example.test/team-a/api/v1/provider-dev/attach-authorizations/") {
+		t.Fatalf("approvalUrl = %q, want public base path preserved", authorization.ApprovalURL)
+	}
+}
+
 func TestAuthMiddleware_ValidAPIToken(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds a browser-approved remote attach path for `gestaltd provider dev --remote`, so the interactive happy path no longer requires developers to manually mint/pass an attach-scoped API token. Attach-scoped API tokens still work for non-interactive automation.

## New Interfaces

- `gestaltd provider dev --remote <url> --path <plugin>` now opens a browser approval flow when no attach-scoped API token succeeds.
- `POST /api/v1/provider-dev/attach-authorizations` creates a short-lived approval challenge and returns `authorizationId`, `clientSecret`, `verificationCode`, `approvalUrl`, `expiresAt`, and `pollIntervalMillis`.
- `GET /api/v1/provider-dev/attach-authorizations/{authorizationId}` renders the approval page for an authenticated browser session.
- `POST /api/v1/provider-dev/attach-authorizations/{authorizationId}/approve` approves the local attach request after `providerDev.attach.allowedRoles` passes and the user enters the terminal verification code.
- `GET /api/v1/provider-dev/attach-authorizations/{authorizationId}/poll` returns `attachAuthorizationCode` to the local CLI after approval.
- `POST /api/v1/provider-dev/attach-authorizations/{authorizationId}/attachments` exchanges the approval code for an owner-scoped attachment.
- Dispatcher `poll`, `complete`, and `delete` on `/api/v1/provider-dev/attachments/{attachId}` can now use `X-Gestalt-Provider-Dev-Dispatcher` without a bearer token.

## Examples

Interactive browser-approved attach:

```sh
gestaltd provider dev --remote https://valon.tools --path ./slack
# CLI opens the approval URL and prints a verification code to enter in the browser.
```

Non-interactive attach-token path:

```sh
gestaltd provider dev \
  --remote https://valon.tools \
  --remote-token <token-with-provider_dev.attach> \
  --path ./slack
```

Server/plugin opt-in remains unchanged:

```yaml
server:
  providerDev:
    remoteAttach: true

plugins:
  slack:
    authorizationPolicy: provider_devs
    providerDev:
      attach:
        allowedRoles:
          - developer
```

## Testing

- `golangci-lint run --allow-parallel-runners ./...`
- `go test ./cmd/gestaltd ./internal/providerdev ./internal/server`

## Docs

Updated:

- `docs/content/reference/cli.mdx`
- `docs/content/custom-providers/plugins.mdx`
- `docs/content/reference/config-file.mdx`
