### PR TITLE
Start hosted runtime replacements before drain

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -735,6 +735,487 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 	}
 }
 
+//nolint:paralleltest // Exercises short lifecycle deadlines and blocks runtime startup deliberately.
+func TestAgentRuntimeConfigStartsLifecycleReplacementBeforeDraining(t *testing.T) {
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	replacementReady := make(chan struct{})
+	var releaseReplacementOnce sync.Once
+	releaseReplacement := func() { releaseReplacementOnce.Do(func() { close(replacementReady) }) }
+	runtimeProvider.startBlockForSession = func(index int) <-chan struct{} {
+		if index == 2 {
+			return replacementReady
+		}
+		return nil
+	}
+	var lifecycleMu sync.Mutex
+	var firstDrainAt time.Time
+	runtimeProvider.lifecycleForSession = func(index int) *pluginruntime.SessionLifecycle {
+		startedAt := time.Now().UTC()
+		expiresAt := startedAt.Add(time.Hour)
+		lifecycle := &pluginruntime.SessionLifecycle{
+			StartedAt: &startedAt,
+			ExpiresAt: &expiresAt,
+		}
+		if index == 1 {
+			recommendedDrainAt := startedAt.Add(500 * time.Millisecond)
+			lifecycle.RecommendedDrainAt = &recommendedDrainAt
+			lifecycleMu.Lock()
+			firstDrainAt = recommendedDrainAt
+			lifecycleMu.Unlock()
+		}
+		return lifecycle
+	}
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.Pool.HealthCheckInterval = "25ms"
+	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command:   bin,
+					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+				},
+			},
+		},
+	}
+	deps := Deps{
+		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:         map[string]*config.ProviderEntry{"agent_state": {}},
+		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+	defer releaseReplacement()
+
+	pool := hostedAgentProviderPoolForTest(t, agents[0])
+	backends := pool.readyBackends()
+	if len(backends) != 1 {
+		t.Fatalf("ready backends = %d, want 1", len(backends))
+	}
+	first := backends[0]
+
+	waitForAgentRuntimeCondition(t, 3*time.Second, func() bool {
+		lifecycleMu.Lock()
+		drainAt := firstDrainAt
+		lifecycleMu.Unlock()
+		if len(runtimeProvider.startSessionRequests()) < 2 || drainAt.IsZero() || !time.Now().UTC().After(drainAt.Add(25*time.Millisecond)) {
+			return false
+		}
+		pool.mu.Lock()
+		defer pool.mu.Unlock()
+		now := time.Now().UTC()
+		return first.replacementStarting && pool.backendRuntimeDrainDueLocked(first, now) && pool.backendAcceptsNewWorkLocked(first, now) && !first.draining && !first.closing && !first.closed
+	})
+	pool.mu.Lock()
+	replacementStarting := first.replacementStarting
+	runtimeDrainDue := pool.backendRuntimeDrainDueLocked(first, time.Now().UTC())
+	firstAcceptsNewWork := pool.backendAcceptsNewWorkLocked(first, time.Now().UTC())
+	firstDraining := first.draining || first.closing || first.closed
+	pool.mu.Unlock()
+	if !replacementStarting {
+		t.Fatal("first backend was not marked as replacement-starting while replacement was in flight")
+	}
+	if !runtimeDrainDue {
+		t.Fatal("first backend runtime drain deadline was not due")
+	}
+	if firstDraining {
+		t.Fatal("first backend was marked draining before replacement became ready")
+	}
+	if !firstAcceptsNewWork {
+		t.Fatal("first backend did not accept new work while proactive replacement was starting past the drain deadline")
+	}
+
+	session, err := agents[0].CreateSession(context.Background(), coreagent.CreateSessionRequest{
+		SessionID: "session-after-drain-before-replacement",
+		Model:     "gpt-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession(after drain before replacement): %v", err)
+	}
+	if session == nil || session.ID != "session-after-drain-before-replacement" {
+		t.Fatalf("CreateSession(after drain before replacement) = %#v, want session-after-drain-before-replacement", session)
+	}
+	if backend := pool.sessionBackend("session-after-drain-before-replacement"); backend != first {
+		t.Fatalf("session-after-drain-before-replacement backend = %#v, want first backend", backend)
+	}
+
+	releaseReplacement()
+	waitForAgentRuntimeCondition(t, 3*time.Second, func() bool {
+		ready := pool.readyBackends()
+		return len(ready) == 1 && ready[0] != first
+	})
+}
+
+//nolint:paralleltest // Exercises short lifecycle deadlines and retry timing.
+func TestAgentRuntimeConfigRetriesFailedLifecycleReplacementAfterDrain(t *testing.T) {
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	runtimeProvider.startDelay = 50 * time.Millisecond
+	runtimeProvider.startErrForSession = func(index int) error {
+		if index >= 2 {
+			return errors.New("replacement start failed")
+		}
+		return nil
+	}
+	var lifecycleMu sync.Mutex
+	var firstDrainAt time.Time
+	runtimeProvider.lifecycleForSession = func(index int) *pluginruntime.SessionLifecycle {
+		startedAt := time.Now().UTC()
+		expiresAt := startedAt.Add(time.Hour)
+		lifecycle := &pluginruntime.SessionLifecycle{
+			StartedAt: &startedAt,
+			ExpiresAt: &expiresAt,
+		}
+		if index == 1 {
+			recommendedDrainAt := startedAt.Add(75 * time.Millisecond)
+			lifecycle.RecommendedDrainAt = &recommendedDrainAt
+			lifecycleMu.Lock()
+			firstDrainAt = recommendedDrainAt
+			lifecycleMu.Unlock()
+		}
+		return lifecycle
+	}
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.Pool.HealthCheckInterval = "25ms"
+	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command:   bin,
+					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+				},
+			},
+		},
+	}
+	deps := Deps{
+		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:         map[string]*config.ProviderEntry{"agent_state": {}},
+		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+
+	pool := hostedAgentProviderPoolForTest(t, agents[0])
+	backends := pool.readyBackends()
+	if len(backends) != 1 {
+		t.Fatalf("ready backends = %d, want 1", len(backends))
+	}
+	first := backends[0]
+
+	waitForAgentRuntimeCondition(t, 3*time.Second, func() bool {
+		lifecycleMu.Lock()
+		drainAt := firstDrainAt
+		lifecycleMu.Unlock()
+		return len(runtimeProvider.startSessionRequests()) >= 2 && !drainAt.IsZero() && time.Now().UTC().After(drainAt.Add(150*time.Millisecond))
+	})
+	pool.mu.Lock()
+	replacementPending := first.replacementStarting
+	runtimeDrainDue := pool.backendRuntimeDrainDueLocked(first, time.Now().UTC())
+	firstAcceptsNewWork := pool.backendAcceptsNewWorkLocked(first, time.Now().UTC())
+	firstDraining := first.draining || first.closing || first.closed
+	pool.mu.Unlock()
+	if !replacementPending {
+		t.Fatal("first backend was not kept replacement-pending after replacement start failure")
+	}
+	if !runtimeDrainDue {
+		t.Fatal("first backend runtime drain deadline was not due")
+	}
+	if firstDraining {
+		t.Fatal("first backend was marked draining after replacement start failure")
+	}
+	if !firstAcceptsNewWork {
+		t.Fatal("first backend did not accept new work after replacement start failure past the drain deadline")
+	}
+
+	session, err := agents[0].CreateSession(context.Background(), coreagent.CreateSessionRequest{
+		SessionID: "session-after-replacement-failure",
+		Model:     "gpt-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession(after replacement failure): %v", err)
+	}
+	if session == nil || session.ID != "session-after-replacement-failure" {
+		t.Fatalf("CreateSession(after replacement failure) = %#v, want session-after-replacement-failure", session)
+	}
+	if backend := pool.sessionBackend("session-after-replacement-failure"); backend != first {
+		t.Fatalf("session-after-replacement-failure backend = %#v, want first backend", backend)
+	}
+}
+
+//nolint:paralleltest // Exercises short lifecycle deadlines and retry timing.
+func TestAgentRuntimeConfigKeepsReplacementPendingAfterPreDrainFailure(t *testing.T) {
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	runtimeProvider.startDelay = 20 * time.Millisecond
+	runtimeProvider.startErrForSession = func(index int) error {
+		if index >= 2 {
+			return errors.New("replacement start failed before drain")
+		}
+		return nil
+	}
+	var lifecycleMu sync.Mutex
+	var firstDrainAt time.Time
+	runtimeProvider.lifecycleForSession = func(index int) *pluginruntime.SessionLifecycle {
+		startedAt := time.Now().UTC()
+		expiresAt := startedAt.Add(time.Hour)
+		lifecycle := &pluginruntime.SessionLifecycle{
+			StartedAt: &startedAt,
+			ExpiresAt: &expiresAt,
+		}
+		if index == 1 {
+			recommendedDrainAt := startedAt.Add(250 * time.Millisecond)
+			lifecycle.RecommendedDrainAt = &recommendedDrainAt
+			lifecycleMu.Lock()
+			firstDrainAt = recommendedDrainAt
+			lifecycleMu.Unlock()
+		}
+		return lifecycle
+	}
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.Pool.HealthCheckInterval = "25ms"
+	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command:   bin,
+					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+				},
+			},
+		},
+	}
+	deps := Deps{
+		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:         map[string]*config.ProviderEntry{"agent_state": {}},
+		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+
+	pool := hostedAgentProviderPoolForTest(t, agents[0])
+	backends := pool.readyBackends()
+	if len(backends) != 1 {
+		t.Fatalf("ready backends = %d, want 1", len(backends))
+	}
+	first := backends[0]
+
+	waitForAgentRuntimeCondition(t, 3*time.Second, func() bool {
+		return len(runtimeProvider.startSessionRequests()) >= 2
+	})
+	pool.mu.Lock()
+	preDrainPending := first.replacementStarting
+	preDrainDue := pool.backendRuntimeDrainDueLocked(first, time.Now().UTC())
+	pool.mu.Unlock()
+	if !preDrainPending {
+		t.Fatal("first backend was not kept replacement-pending after pre-drain replacement start failure")
+	}
+	if preDrainDue {
+		t.Fatal("first backend runtime drain deadline was already due")
+	}
+
+	waitForAgentRuntimeCondition(t, 3*time.Second, func() bool {
+		lifecycleMu.Lock()
+		drainAt := firstDrainAt
+		lifecycleMu.Unlock()
+		return !drainAt.IsZero() && time.Now().UTC().After(drainAt.Add(25*time.Millisecond))
+	})
+	pool.mu.Lock()
+	postDrainPending := first.replacementStarting
+	firstAcceptsNewWork := pool.backendAcceptsNewWorkLocked(first, time.Now().UTC())
+	firstDraining := first.draining || first.closing || first.closed
+	pool.mu.Unlock()
+	if !postDrainPending {
+		t.Fatal("first backend was not replacement-pending after drain deadline")
+	}
+	if firstDraining {
+		t.Fatal("first backend was marked draining after pre-drain replacement start failure")
+	}
+	if !firstAcceptsNewWork {
+		t.Fatal("first backend did not accept new work after pre-drain replacement start failure crossed drain deadline")
+	}
+}
+
+//nolint:paralleltest // Exercises short lifecycle deadlines and blocks runtime startup deliberately.
+func TestAgentRuntimeConfigLimitsProactiveLifecycleReplacementBurst(t *testing.T) {
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	replacementReady := make(chan struct{})
+	var releaseReplacementOnce sync.Once
+	releaseReplacement := func() { releaseReplacementOnce.Do(func() { close(replacementReady) }) }
+	runtimeProvider.startBlockForSession = func(index int) <-chan struct{} {
+		if index == 3 {
+			return replacementReady
+		}
+		return nil
+	}
+	runtimeProvider.lifecycleForSession = func(index int) *pluginruntime.SessionLifecycle {
+		startedAt := time.Now().UTC()
+		expiresAt := startedAt.Add(time.Hour)
+		lifecycle := &pluginruntime.SessionLifecycle{
+			StartedAt: &startedAt,
+			ExpiresAt: &expiresAt,
+		}
+		if index <= 2 {
+			recommendedDrainAt := startedAt.Add(5 * time.Second)
+			lifecycle.RecommendedDrainAt = &recommendedDrainAt
+		}
+		return lifecycle
+	}
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.Pool.MinReadyInstances = 2
+	runtimeConfig.Pool.MaxReadyInstances = 2
+	runtimeConfig.Pool.HealthCheckInterval = "25ms"
+	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command:   bin,
+					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+				},
+			},
+		},
+	}
+	deps := Deps{
+		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:         map[string]*config.ProviderEntry{"agent_state": {}},
+		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+	defer releaseReplacement()
+
+	pool := hostedAgentProviderPoolForTest(t, agents[0])
+	readyBackends := pool.readyBackends()
+	if ready := len(readyBackends); ready != 2 {
+		t.Fatalf("ready backends = %d, want 2", ready)
+	}
+	first := readyBackends[0]
+	_, releaseFirst, err := pool.acquireBackend(context.Background(), first, false)
+	if err != nil {
+		t.Fatalf("acquire first backend: %v", err)
+	}
+	defer releaseFirst()
+
+	waitForAgentRuntimeCondition(t, 3*time.Second, func() bool {
+		return len(runtimeProvider.startSessionRequests()) >= 3
+	})
+	pool.mu.Lock()
+	inFlight := pool.lifecycleReplacementsActive
+	ready, starting, draining := pool.instanceCountsLocked()
+	pool.mu.Unlock()
+	if inFlight != 1 {
+		t.Fatalf("lifecycle replacements active = %d, want 1", inFlight)
+	}
+	if ready != 2 || starting != 1 || draining != 0 {
+		t.Fatalf("instance counts during proactive replacement = ready:%d starting:%d draining:%d, want ready:2 starting:1 draining:0", ready, starting, draining)
+	}
+
+	releaseReplacement()
+	waitForAgentRuntimeCondition(t, 3*time.Second, func() bool {
+		pool.mu.Lock()
+		defer pool.mu.Unlock()
+		return first.draining && pool.lifecycleReplacementsActive == 1
+	})
+	time.Sleep(150 * time.Millisecond)
+	if got := len(runtimeProvider.startSessionRequests()); got != 3 {
+		t.Fatalf("start session requests while first proactive replacement is draining = %d, want 3", got)
+	}
+	pool.mu.Lock()
+	active := pool.lifecycleReplacementsActive
+	_, _, draining = pool.instanceCountsLocked()
+	pool.mu.Unlock()
+	if active != 1 || draining == 0 {
+		t.Fatalf("lifecycle replacement state while first backend drains = active:%d draining:%d, want active:1 and draining>0", active, draining)
+	}
+}
+
 //nolint:paralleltest // Uses short lifecycle timing assertions that are flaky under parallel package load.
 func TestAgentRuntimeConfigDoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntimeLifetime(t *testing.T) {
 	bin := buildAgentProviderBinary(t)

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -194,13 +194,16 @@ func (p *recordingHostedAuthorizationProvider) Calls() []authorizationSearchCall
 type capturingPluginRuntime struct {
 	provider *pluginruntime.LocalProvider
 
-	mu                  sync.Mutex
-	startRequests       []pluginruntime.StartSessionRequest
-	startTimes          []time.Time
-	bindRequests        []pluginruntime.BindHostServiceRequest
-	sessionLifecycles   map[string]*pluginruntime.SessionLifecycle
-	lifecycleForSession func(index int) *pluginruntime.SessionLifecycle
-	stopCount           atomic.Int32
+	mu                   sync.Mutex
+	startRequests        []pluginruntime.StartSessionRequest
+	startTimes           []time.Time
+	bindRequests         []pluginruntime.BindHostServiceRequest
+	sessionLifecycles    map[string]*pluginruntime.SessionLifecycle
+	lifecycleForSession  func(index int) *pluginruntime.SessionLifecycle
+	startDelay           time.Duration
+	startBlockForSession func(index int) <-chan struct{}
+	startErrForSession   func(index int) error
+	stopCount            atomic.Int32
 }
 
 func newCapturingPluginRuntime() *capturingPluginRuntime {
@@ -223,7 +226,31 @@ func (r *capturingPluginRuntime) StartSession(ctx context.Context, req pluginrun
 	r.startTimes = append(r.startTimes, time.Now().UTC())
 	index := len(r.startRequests)
 	lifecycleForSession := r.lifecycleForSession
+	startBlockForSession := r.startBlockForSession
+	startErrForSession := r.startErrForSession
+	startDelay := r.startDelay
 	r.mu.Unlock()
+	if startDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(startDelay):
+		}
+	}
+	if startBlockForSession != nil {
+		if block := startBlockForSession(index); block != nil {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-block:
+			}
+		}
+	}
+	if startErrForSession != nil {
+		if err := startErrForSession(index); err != nil {
+			return nil, err
+		}
+	}
 	session, err := r.provider.StartSession(ctx, req)
 	if err != nil {
 		return nil, err

--- a/gestaltd/internal/bootstrap/hosted_agent_pool.go
+++ b/gestaltd/internal/bootstrap/hosted_agent_pool.go
@@ -19,7 +19,10 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 )
 
-const hostedAgentRuntimeLifecycleSafetyMargin = 5 * time.Second
+const (
+	hostedAgentRuntimeLifecycleSafetyMargin = 5 * time.Second
+	hostedAgentRuntimeReplacementLeadCap    = 2 * time.Minute
+)
 
 type hostedAgentProviderPool struct {
 	name         string
@@ -32,30 +35,32 @@ type hostedAgentProviderPool struct {
 	cancel      context.CancelFunc
 	lifecycleWG sync.WaitGroup
 
-	mu                  sync.Mutex
-	nextID              int
-	nextPick            int
-	starting            int
-	closed              bool
-	backends            []*hostedAgentPoolBackend
-	sessionBackends     map[string]*hostedAgentPoolBackend
-	turnBackends        map[string]*hostedAgentPoolBackend
-	interactionBackends map[string]*hostedAgentPoolBackend
+	mu                          sync.Mutex
+	nextID                      int
+	nextPick                    int
+	starting                    int
+	lifecycleReplacementsActive int
+	closed                      bool
+	backends                    []*hostedAgentPoolBackend
+	sessionBackends             map[string]*hostedAgentPoolBackend
+	turnBackends                map[string]*hostedAgentPoolBackend
+	interactionBackends         map[string]*hostedAgentPoolBackend
 }
 
 type hostedAgentPoolBackend struct {
-	id               int
-	provider         coreagent.Provider
-	runtimeProvider  pluginruntime.Provider
-	runtimeSessionID string
-	runtimeSession   *pluginruntime.Session
-	runtimeDrainAt   *time.Time
-	forceCloseAt     *time.Time
-	active           int
-	liveTurns        map[string]struct{}
-	draining         bool
-	closing          bool
-	closed           bool
+	id                  int
+	provider            coreagent.Provider
+	runtimeProvider     pluginruntime.Provider
+	runtimeSessionID    string
+	runtimeSession      *pluginruntime.Session
+	runtimeDrainAt      *time.Time
+	forceCloseAt        *time.Time
+	active              int
+	liveTurns           map[string]struct{}
+	draining            bool
+	replacementStarting bool
+	closing             bool
+	closed              bool
 }
 
 func newHostedAgentProviderPool(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []providerhost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy) (coreagent.Provider, error) {
@@ -883,7 +888,13 @@ func (p *hostedAgentProviderPool) backendAvailableLocked(backend *hostedAgentPoo
 }
 
 func (p *hostedAgentProviderPool) backendAcceptsNewWorkLocked(backend *hostedAgentPoolBackend, now time.Time) bool {
-	return p.backendAvailableLocked(backend, false) && !p.backendRuntimeDrainDueLocked(backend, now)
+	if !p.backendAvailableLocked(backend, false) {
+		return false
+	}
+	if !p.backendRuntimeDrainDueLocked(backend, now) {
+		return true
+	}
+	return backend.replacementStarting && !p.backendRuntimeForceCloseDueLocked(backend, now)
 }
 
 func (p *hostedAgentProviderPool) backendRuntimeDrainDueLocked(backend *hostedAgentPoolBackend, now time.Time) bool {
@@ -895,6 +906,17 @@ func (p *hostedAgentProviderPool) backendRuntimeDrainDueLocked(backend *hostedAg
 		now = time.Now().UTC()
 	}
 	return !now.Before(drainAt)
+}
+
+func (p *hostedAgentProviderPool) backendRuntimeForceCloseDueLocked(backend *hostedAgentPoolBackend, now time.Time) bool {
+	if backend == nil || backend.forceCloseAt == nil {
+		return false
+	}
+	forceCloseAt := backend.forceCloseAt.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return !now.Before(forceCloseAt)
 }
 
 func (p *hostedAgentProviderPool) readyBackends() []*hostedAgentPoolBackend {
@@ -940,12 +962,12 @@ func (p *hostedAgentProviderPool) instanceCountsLocked() (ready, starting, drain
 		if backend == nil || backend.closed {
 			continue
 		}
-		if backend.draining || backend.closing || p.backendRuntimeDrainDueLocked(backend, now) {
-			draining++
+		if p.backendAcceptsNewWorkLocked(backend, now) {
+			ready++
 			continue
 		}
-		if backend.provider != nil {
-			ready++
+		if backend.draining || backend.closing || p.backendRuntimeDrainDueLocked(backend, now) {
+			draining++
 		}
 	}
 	return ready, starting, draining
@@ -1141,7 +1163,6 @@ func (p *hostedAgentProviderPool) healthLoop() {
 			return
 		case <-ticker.C:
 		}
-		_ = p.ensureMinReady(p.ctx)
 		for _, backend := range p.readyBackends() {
 			session, drainAt, err := p.refreshBackendRuntimeSession(backend)
 			if err != nil {
@@ -1149,7 +1170,14 @@ func (p *hostedAgentProviderPool) healthLoop() {
 				p.replaceBackend(backend)
 				continue
 			}
-			if reason := p.runtimeSessionRetirementReason(session, drainAt, time.Now().UTC()); reason != "" {
+			now := time.Now().UTC()
+			if p.maybeStartLifecycleReplacementBeforeDrain(backend, drainAt, now) {
+				slog.Info("starting proactive hosted agent runtime replacement", "provider", p.name, "instance", backend.id, "drain_at", drainAt)
+			}
+			if reason := p.runtimeSessionRetirementReason(session, drainAt, now); reason != "" {
+				if p.shouldDeferRuntimeDrainRetirement(backend, session, drainAt, now) {
+					continue
+				}
 				slog.Info("retiring hosted agent runtime instance", "provider", p.name, "instance", backend.id, "reason", reason)
 				p.replaceBackend(backend)
 				continue
@@ -1159,6 +1187,7 @@ func (p *hostedAgentProviderPool) healthLoop() {
 				p.replaceBackend(backend)
 			}
 		}
+		_ = p.ensureMinReady(p.ctx)
 	}
 }
 
@@ -1212,6 +1241,61 @@ func (p *hostedAgentProviderPool) runtimeSessionRetirementReason(session *plugin
 		return fmt.Sprintf("runtime session expired at %s", expiresAt.Format(time.RFC3339Nano))
 	}
 	return fmt.Sprintf("runtime session reached drain deadline %s", drainAt.Format(time.RFC3339Nano))
+}
+
+func (p *hostedAgentProviderPool) maybeStartLifecycleReplacementBeforeDrain(backend *hostedAgentPoolBackend, drainAt *time.Time, now time.Time) bool {
+	if p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever || backend == nil || drainAt == nil {
+		return false
+	}
+	drainAtUTC := drainAt.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if now.Before(p.runtimeSessionReplacementStartAt(drainAtUTC)) {
+		return false
+	}
+	if !now.Before(drainAtUTC) {
+		p.mu.Lock()
+		canReplace := p.backendAvailableLocked(backend, true) && !p.backendRuntimeForceCloseDueLocked(backend, now)
+		p.mu.Unlock()
+		if !canReplace {
+			return false
+		}
+	}
+	return p.startLifecycleReplacementBeforeDrain(backend)
+}
+
+func (p *hostedAgentProviderPool) shouldDeferRuntimeDrainRetirement(backend *hostedAgentPoolBackend, session *pluginruntime.Session, drainAt *time.Time, now time.Time) bool {
+	if session == nil || drainAt == nil {
+		return false
+	}
+	switch session.State {
+	case pluginruntime.SessionStateFailed, pluginruntime.SessionStateStopped:
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if now.Before(drainAt.UTC()) {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.backendAvailableLocked(backend, true) && backend.replacementStarting && !p.backendRuntimeForceCloseDueLocked(backend, now)
+}
+
+func (p *hostedAgentProviderPool) runtimeSessionReplacementStartAt(drainAt time.Time) time.Time {
+	lead := p.policy.StartupTimeout + p.policy.HealthCheckInterval
+	if lead <= 0 {
+		lead = p.policy.HealthCheckInterval
+	}
+	if lead <= 0 {
+		lead = hostedAgentRuntimeReplacementLeadCap
+	}
+	if lead > hostedAgentRuntimeReplacementLeadCap {
+		lead = hostedAgentRuntimeReplacementLeadCap
+	}
+	return drainAt.UTC().Add(-lead)
 }
 
 func (p *hostedAgentProviderPool) runtimeSessionDrainAt(session *pluginruntime.Session, now time.Time) *time.Time {
@@ -1318,6 +1402,79 @@ func (p *hostedAgentProviderPool) replaceBackend(backend *hostedAgentPoolBackend
 			slog.Warn("failed to close unhealthy hosted agent runtime instance", "provider", p.name, "instance", backend.id, "error", err)
 		}
 	}()
+}
+
+func (p *hostedAgentProviderPool) startLifecycleReplacementBeforeDrain(backend *hostedAgentPoolBackend) bool {
+	p.mu.Lock()
+	if p.closed || backend == nil || backend.draining || backend.closing || backend.closed || p.lifecycleReplacementsActive > 0 {
+		p.mu.Unlock()
+		return false
+	}
+	backend.replacementStarting = true
+	p.lifecycleReplacementsActive++
+	p.starting++
+	ready, starting, draining := p.instanceCountsLocked()
+	p.lifecycleWG.Add(1)
+	p.mu.Unlock()
+	p.recordInstanceCounts(p.ctx, ready, starting, draining)
+
+	go func() {
+		defer p.lifecycleWG.Done()
+		startErr := p.startProactiveLifecycleReplacement(backend)
+		recordHostedAgentRuntimeReplacement(p.ctx, p.name, startErr)
+		if startErr != nil && !errors.Is(startErr, context.Canceled) {
+			slog.Warn("failed to proactively replace hosted agent runtime instance", "provider", p.name, "instance", backend.id, "error", startErr)
+		}
+	}()
+	return true
+}
+
+func (p *hostedAgentProviderPool) startProactiveLifecycleReplacement(backend *hostedAgentPoolBackend) error {
+	started, startErr := p.startBackend(p.ctx)
+	p.mu.Lock()
+	p.starting--
+	if startErr != nil {
+		if p.lifecycleReplacementsActive > 0 {
+			p.lifecycleReplacementsActive--
+		}
+		ready, starting, draining := p.instanceCountsLocked()
+		p.mu.Unlock()
+		p.recordInstanceCounts(p.ctx, ready, starting, draining)
+		return startErr
+	}
+	if p.backendAvailableLocked(backend, true) {
+		backend.replacementStarting = false
+	}
+	ready, starting, draining := p.instanceCountsLocked()
+	p.mu.Unlock()
+	p.recordInstanceCounts(p.ctx, ready, starting, draining)
+
+	if started == nil {
+		p.finishProactiveLifecycleReplacement(backend)
+		return fmt.Errorf("replacement runtime instance did not start")
+	}
+	if !p.markBackendDraining(backend) {
+		p.finishProactiveLifecycleReplacement(backend)
+		return nil
+	}
+	if err := p.drainAndCloseBackend(backend); err != nil {
+		slog.Warn("failed to close replaced hosted agent runtime instance", "provider", p.name, "instance", backend.id, "error", err)
+	}
+	p.finishProactiveLifecycleReplacement(backend)
+	return nil
+}
+
+func (p *hostedAgentProviderPool) finishProactiveLifecycleReplacement(backend *hostedAgentPoolBackend) {
+	p.mu.Lock()
+	if p.lifecycleReplacementsActive > 0 {
+		p.lifecycleReplacementsActive--
+	}
+	if p.backendAvailableLocked(backend, true) {
+		backend.replacementStarting = false
+	}
+	ready, starting, draining := p.instanceCountsLocked()
+	p.mu.Unlock()
+	p.recordInstanceCounts(p.ctx, ready, starting, draining)
 }
 
 func (p *hostedAgentProviderPool) addLifecycleWork() bool {


### PR DESCRIPTION
## Summary
- Starts lifecycle replacements before `runtimeDrainAt` instead of waiting until the runtime is already no longer ready.
- Keeps the old backend accepting new work while the replacement backend starts, including when startup crosses `runtimeDrainAt` or transient replacement startup fails before/after drain.
- Marks the old backend draining only after the replacement is ready, allowing one transient lifecycle over-capacity replacement per pool at a time until the replaced backend finishes draining.
- Runs lifecycle refresh before the min-ready refill so drain-deadline backends can enter proactive replacement before the fallback synchronous start path.

## New Interface / Behavior
No public API or proto changes.

Hosted agent pool lifecycle now behaves like:

```text
old runtime: ready, runtimeDrainAt=T
health loop at T-lead: start replacement; old runtime remains ready
if startup crosses T or fails transiently: old runtime remains usable while replacementStarting=true
replacement ready: mark old runtime draining; new work routes to replacement
old runtime closed: release lifecycle replacement budget
```

The proactive replacement lead time is bounded by existing lifecycle policy values and capped at 2 minutes:

```go
lead := min(startupTimeout + healthCheckInterval, 2*time.Minute)
replacementStartAt := runtimeDrainAt.Add(-lead)
```

This avoids using `ensureMinReady` before draining, since that path no-ops or blocks when the pool already has replacement work starting. A runtime that reaches its force-close deadline is still not kept available.

## Functional / Contract Tests
- `go test ./internal/bootstrap -run 'TestAgentRuntimeConfig(ReplacesHostedAgentBeforeRuntimeDrainDeadline|StartsLifecycleReplacementBeforeDraining|RetriesFailedLifecycleReplacementAfterDrain|KeepsReplacementPendingAfterPreDrainFailure|LimitsProactiveLifecycleReplacementBurst|DoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntimeLifetime|ReplacesExpiresOnlyRuntimeBeforeExpiry)$' -count=1`
- `go test ./internal/bootstrap`

The added hosted-runtime tests verify that replacement starts while the old backend is still accepting new work, the old backend is not drained if replacement startup crosses the runtime drain deadline, transient replacement startup failures do not drop the old backend before force-close, new work can still route to the old backend during replacement startup/failure, the min-ready fallback does not preempt proactive replacement at drain time, and the pool only permits one proactive lifecycle replacement through startup plus old-backend drain.