### PR TITLE
Use provider tags for agent tool search metadata

### DIFF
--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -683,6 +683,166 @@ func TestSearchToolsGlobalWildcardFindsProviderQualifiedCatalogOperation(t *test
 	}
 }
 
+func TestSearchToolsRanksProviderConfiguredTags(t *testing.T) {
+	t.Parallel()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "codehost",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
+				{
+					ID:          "pulls.list",
+					Title:       "List Pull Requests",
+					Description: "List pull requests for a repository.",
+					Tags:        []string{"pr", "prs"},
+					ReadOnly:    true,
+				},
+				{
+					ID:          "pulls.merge",
+					Title:       "Merge Pull Request",
+					Description: "Merge a pull request into the base branch.",
+					Tags:        []string{"merge"},
+				},
+			}},
+		},
+	}
+	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+
+	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query:      "prs",
+		MaxResults: 1,
+	})
+	if err != nil {
+		t.Fatalf("SearchTools: %v", err)
+	}
+	if len(resp.Tools) != 1 {
+		t.Fatalf("SearchTools returned %d tools, want 1: %#v", len(resp.Tools), resp.Tools)
+	}
+	if resp.Tools[0].Target.Plugin != "codehost" || resp.Tools[0].Target.Operation != "pulls.list" {
+		t.Fatalf("tool target = %#v, want codehost.pulls.list", resp.Tools[0].Target)
+	}
+}
+
+func TestSearchToolsDoesNotInventSemanticAliases(t *testing.T) {
+	t.Parallel()
+
+	search := func(t *testing.T, tags []string) *coreagent.SearchToolsResponse {
+		t.Helper()
+
+		provider := &catalogCountingProvider{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "chat",
+				ConnMode: core.ConnectionModeNone,
+				CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+					ID:          "messages.send",
+					Title:       "Send Message",
+					Description: "Send a private message.",
+					Tags:        tags,
+				}}},
+			},
+		}
+		manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+		resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+			SubjectID: principal.UserSubjectID("user-1"),
+		}, coreagent.SearchToolsRequest{
+			Query:      "dm",
+			MaxResults: 1,
+		})
+		if err != nil {
+			t.Fatalf("SearchTools: %v", err)
+		}
+		return resp
+	}
+
+	withoutTags := search(t, nil)
+	if len(withoutTags.Tools) != 0 {
+		t.Fatalf("SearchTools without dm tags returned %#v, want no tools", withoutTags.Tools)
+	}
+
+	withTags := search(t, []string{"dm", "direct message"})
+	if len(withTags.Tools) != 1 {
+		t.Fatalf("SearchTools with dm tags returned %d tools, want 1: %#v", len(withTags.Tools), withTags.Tools)
+	}
+	if withTags.Tools[0].Target.Plugin != "chat" || withTags.Tools[0].Target.Operation != "messages.send" {
+		t.Fatalf("tool target = %#v, want chat.messages.send", withTags.Tools[0].Target)
+	}
+}
+
+func TestSearchToolsDoesNotTreatPullRequestsAsMergeWithoutMetadata(t *testing.T) {
+	t.Parallel()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "codehost",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:          "pulls.list",
+				Title:       "List Pull Requests",
+				Description: "List open pull requests for a repository.",
+				ReadOnly:    true,
+			}}},
+		},
+	}
+	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query:      "merge",
+		MaxResults: 1,
+	})
+	if err != nil {
+		t.Fatalf("SearchTools: %v", err)
+	}
+	if len(resp.Tools) != 0 {
+		t.Fatalf("SearchTools returned %#v, want no tools without merge metadata", resp.Tools)
+	}
+}
+
+func TestSearchToolsRanksTitleAheadOfTags(t *testing.T) {
+	t.Parallel()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "records",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
+				{
+					ID:          "records.lookup",
+					Title:       "Lookup Records",
+					Description: "Lookup records by ID.",
+					Tags:        []string{"audit"},
+					ReadOnly:    true,
+				},
+				{
+					ID:          "logs.list",
+					Title:       "Audit Logs",
+					Description: "List log entries.",
+					ReadOnly:    true,
+				},
+			}},
+		},
+	}
+	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.SearchToolsRequest{
+		Query:      "audit",
+		MaxResults: 1,
+	})
+	if err != nil {
+		t.Fatalf("SearchTools: %v", err)
+	}
+	if len(resp.Tools) != 1 {
+		t.Fatalf("SearchTools returned %d tools, want 1: %#v", len(resp.Tools), resp.Tools)
+	}
+	if resp.Tools[0].Target.Plugin != "records" || resp.Tools[0].Target.Operation != "logs.list" {
+		t.Fatalf("tool target = %#v, want records.logs.list", resp.Tools[0].Target)
+	}
+}
+
 func TestAgentRunPermissionsKeepsAPITokenRestrictionsForHTTPWildcard(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/agentmanager/tool_search.go
+++ b/gestaltd/internal/agentmanager/tool_search.go
@@ -18,7 +18,7 @@ type agentToolSearchDocument struct {
 	Title       string `json:"title"`
 	Description string `json:"description"`
 	Parameters  string `json:"parameters"`
-	Aliases     string `json:"aliases"`
+	Tags        string `json:"tags"`
 }
 
 func mentionedAgentToolSearchProviders(query string, providerNames []string) []string {
@@ -114,12 +114,12 @@ type agentToolSearchRankedCandidate struct {
 
 func agentToolSearchQuery(searchText string) blevequery.Query {
 	queries := []blevequery.Query{
-		agentToolSearchMatchQuery("plugin", searchText, 16),
-		agentToolSearchMatchQuery("operation", searchText, 12),
-		agentToolSearchMatchQuery("aliases", searchText, 10),
+		agentToolSearchMatchQuery("plugin", searchText, 12),
+		agentToolSearchMatchQuery("operation", searchText, 9),
 		agentToolSearchMatchQuery("title", searchText, 8),
 		agentToolSearchMatchQuery("parameters", searchText, 5),
-		agentToolSearchMatchQuery("description", searchText, 1),
+		agentToolSearchMatchQuery("description", searchText, 4),
+		agentToolSearchMatchQuery("tags", searchText, 3),
 	}
 	return bleve.NewDisjunctionQuery(queries...)
 }
@@ -142,11 +142,11 @@ func agentToolSearchDoc(candidate agentToolSearchCandidate) agentToolSearchDocum
 	}
 	return agentToolSearchDocument{
 		Plugin:      agentToolSearchText(candidate.ref.Plugin + " " + catalogName + " " + catalogDisplayName),
-		Operation:   agentToolSearchText(candidate.ref.Operation + " " + op.ID + " " + op.ProviderID + " " + op.Path + " " + strings.Join(op.Tags, " ")),
+		Operation:   agentToolSearchText(candidate.ref.Operation + " " + op.ID + " " + op.ProviderID + " " + op.Path),
 		Title:       agentToolSearchText(op.Title),
 		Description: agentToolSearchText(catalogDescription + " " + op.Description),
 		Parameters:  agentToolSearchText(agentToolSearchParameterText(op)),
-		Aliases:     agentToolSearchText(agentToolSearchAliasText(candidate.ref.Plugin, op)),
+		Tags:        agentToolSearchText(strings.Join(op.Tags, " ")),
 	}
 }
 
@@ -188,51 +188,6 @@ func agentToolSearchSchemaText(raw json.RawMessage) string {
 	return strings.Join(parts, " ")
 }
 
-func agentToolSearchAliasText(pluginName string, op catalog.CatalogOperation) string {
-	tokens := agentToolSearchTokenSet(strings.Join([]string{
-		pluginName,
-		op.ID,
-		op.ProviderID,
-		op.Title,
-		op.Description,
-		strings.Join(op.Tags, " "),
-		agentToolSearchParameterText(op),
-	}, " "))
-	aliases := make([]string, 0, len(tokens)*2)
-	for token := range tokens {
-		aliases = append(aliases, agentToolSearchAliases(token)...)
-	}
-	sort.Strings(aliases)
-	return strings.Join(aliases, " ")
-}
-
-func agentToolSearchAliases(token string) []string {
-	switch token {
-	case "ticket", "tickets":
-		return []string{"issue", "issues", "task", "tasks"}
-	case "issue", "issues":
-		return []string{"ticket", "tickets", "task", "tasks"}
-	case "assigned":
-		return []string{"assignee", "assignees"}
-	case "assignee", "assignees":
-		return []string{"assigned"}
-	case "dm", "dms":
-		return []string{"direct", "message", "messages", "conversation", "conversations"}
-	case "direct":
-		return []string{"dm", "dms"}
-	case "pr", "prs":
-		return []string{"pull", "request", "requests", "merge"}
-	case "pull":
-		return []string{"pr", "prs", "merge"}
-	case "merge":
-		return []string{"mr", "mrs", "pull", "request", "requests"}
-	case "mr", "mrs":
-		return []string{"merge", "request", "requests"}
-	default:
-		return nil
-	}
-}
-
 func sortAgentToolSearchCandidates(candidates []agentToolSearchCandidate) {
 	sort.SliceStable(candidates, func(i, j int) bool {
 		return compareAgentToolSearchCandidates(candidates[i], candidates[j]) < 0
@@ -256,24 +211,7 @@ func compareAgentToolSearchCandidates(a, b agentToolSearchCandidate) int {
 }
 
 func agentToolSearchText(value string) string {
-	tokens := uniqueAgentToolSearchTokens(value)
-	if len(tokens) == 0 {
-		return ""
-	}
-	expanded := make([]string, 0, len(tokens)*2)
-	seen := make(map[string]struct{}, len(tokens)*2)
-	for _, token := range tokens {
-		for _, value := range append([]string{token}, agentToolSearchAliases(token)...) {
-			for _, normalized := range uniqueAgentToolSearchTokens(value) {
-				if _, ok := seen[normalized]; ok {
-					continue
-				}
-				seen[normalized] = struct{}{}
-				expanded = append(expanded, normalized)
-			}
-		}
-	}
-	return strings.Join(expanded, " ")
+	return strings.Join(uniqueAgentToolSearchTokens(value), " ")
 }
 
 func uniqueAgentToolSearchTokens(value string) []string {
@@ -294,15 +232,6 @@ func uniqueAgentToolSearchTokens(value string) []string {
 			seen[normalized] = struct{}{}
 			out = append(out, normalized)
 		}
-	}
-	return out
-}
-
-func agentToolSearchTokenSet(value string) map[string]bool {
-	tokens := uniqueAgentToolSearchTokens(value)
-	out := make(map[string]bool, len(tokens))
-	for _, token := range tokens {
-		out[token] = true
 	}
 	return out
 }

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -95,7 +95,7 @@ func (p *roundTripProvider) CatalogForRequest(ctx context.Context, token string)
 		DisplayName: fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s|%s", token, subjectID, subjectKind, displayName, identityPresent, authSource, credential.Mode, access.Policy, access.Role),
 		Description: "session catalog",
 		Operations: []catalog.CatalogOperation{
-			{ID: "echo", Method: http.MethodPost, AllowedRoles: []string{"viewer"}},
+			{ID: "echo", Method: http.MethodPost, AllowedRoles: []string{"viewer"}, Tags: []string{"roundtrip", "session"}},
 		},
 	}, nil
 }
@@ -274,6 +274,9 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 			}
 			if got := sessionCat.Operations[0].AllowedRoles; len(got) != 1 || got[0] != "viewer" {
 				t.Fatalf("unexpected session catalog allowedRoles: %#v", got)
+			}
+			if got := sessionCat.Operations[0].Tags; len(got) != 2 || got[0] != "roundtrip" || got[1] != "session" {
+				t.Fatalf("unexpected session catalog tags: %#v", got)
 			}
 
 			pcp := prov.(core.PostConnectCapable)


### PR DESCRIPTION
## Summary

Move agent tool search semantics out of `gestaltd` core and into provider-owned catalog metadata:

- remove the hard-coded semantic alias table from core tool search
- stop expanding every query/document token through core aliases
- index `CatalogOperation.Tags` as a separate low-positive `tags` field
- keep tags distinct from operation IDs so provider metadata does not masquerade as exact operation text
- keep the existing `SearchToolsRequest` / `SearchToolsResponse` contract unchanged
- assert tags round-trip through the provider-host session catalog proto path

## Interface / Behavior

No proto, SDK, or catalog schema field is added. Existing `CatalogOperation.Tags` is now the provider-owned search metadata surface for agent tool search.

```go
catalog.CatalogOperation{
    ID:          "pulls.list",
    Title:       "List Pull Requests",
    Description: "List pull requests for a repository.",
    Tags:        []string{"pr", "prs"},
    ReadOnly:    true,
}
```

```go
coreagent.SearchToolsRequest{
    Query:      "prs",
    MaxResults: 1,
}
```

This can find `pulls.list` because the provider supplied `pr`/`prs` tags.

```go
coreagent.SearchToolsRequest{
    Query:      "dm",
    MaxResults: 1,
}
```

This only finds a message operation if the provider catalog supplies tags such as `dm` or `direct message`. Core no longer knows that synonym.

```go
coreagent.SearchToolsRequest{
    Query:      "merge",
    MaxResults: 1,
}
```

This no longer finds a pull-request listing operation unless the provider metadata directly includes merge-related text.

Current generic field boosts are:

```text
plugin=12, operation=9, title=8, parameters=5, description=4, tags=3
```

## Validation

- `go test ./internal/agentmanager ./internal/providerhost -count=1`
- `go test -race ./internal/agentmanager -run TestSearchToolsRanksProviderConfiguredTags -count=1`
- `golangci-lint run ./internal/agentmanager/... ./internal/providerhost/...`
