### PR TITLE
workflow: stop adopting unmanaged config objects

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -4794,7 +4794,12 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowScheduleID(t *testing.T) {
 	}
 
 	recorder := &recordingWorkflowProvider{
-		getSchedule: &coreworkflow.Schedule{ID: workflowConfigScheduleID("nightly_sync")},
+		getSchedule: &coreworkflow.Schedule{
+			ID:       workflowConfigScheduleID("nightly_sync"),
+			Cron:     "0 2 * * *",
+			Timezone: "UTC",
+			Target:   coreWorkflowPluginTarget("roadmap", "sync"),
+		},
 	}
 	factories := validFactories()
 	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
@@ -4807,71 +4812,6 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowScheduleID(t *testing.T) {
 	}
 	if len(recorder.upsertedSchedules) != 0 {
 		t.Fatalf("upserted schedules = %d, want 0", len(recorder.upsertedSchedules))
-	}
-}
-
-func TestBootstrapReAdoptsManagedSchedulesWhenOwnershipStateIsMissing(t *testing.T) {
-	t.Parallel()
-
-	provider := &recordingWorkflowProvider{}
-	db1 := &coretesting.StubIndexedDB{}
-	db2 := &coretesting.StubIndexedDB{}
-	factories := validFactories()
-	currentDB := db1
-	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return currentDB, nil }
-	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
-		return provider, nil
-	}
-
-	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
-		Provider: "temporal",
-		Schedules: map[string]workflowFixtureSchedule{
-			"nightly_sync": {
-				Cron:      "0 2 * * *",
-				Timezone:  "UTC",
-				Operation: "sync",
-			},
-		},
-	})
-	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
-		"temporal": {Source: config.ProviderSource{Path: "stub"}},
-	}
-
-	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
-	if err != nil {
-		t.Fatalf("Bootstrap initial: %v", err)
-	}
-	_ = result.Close(context.Background())
-	if len(provider.upsertedSchedules) != 1 {
-		t.Fatalf("initial upserted schedules = %d, want 1", len(provider.upsertedSchedules))
-	}
-	initialExecutionRef := provider.upsertedSchedules[0].ExecutionRef
-	provider.schedules[workflowConfigScheduleID("nightly_sync")].Target.Plugin.Input = map[string]any{
-		"limit": float64(1),
-	}
-
-	currentDB = db2
-	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
-	if err != nil {
-		t.Fatalf("Bootstrap re-adopt: %v", err)
-	}
-	defer func() { _ = result.Close(context.Background()) }()
-	<-result.ProvidersReady
-
-	if len(provider.upsertedSchedules) != 2 {
-		t.Fatalf("upserted schedules = %d, want 2", len(provider.upsertedSchedules))
-	}
-	rotatedExecutionRef := provider.upsertedSchedules[1].ExecutionRef
-	if rotatedExecutionRef != initialExecutionRef {
-		t.Fatalf("execution ref = %q, want reuse of %q", rotatedExecutionRef, initialExecutionRef)
-	}
-	newRef, err := provider.GetExecutionReference(context.Background(), rotatedExecutionRef)
-	if err != nil {
-		t.Fatalf("Get rotated execution ref: %v", err)
-	}
-	if newRef.RevokedAt != nil {
-		t.Fatalf("rotated revokedAt = %#v, want nil", newRef.RevokedAt)
 	}
 }
 
@@ -5641,7 +5581,13 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerID(t *testing.T) {
 	}
 
 	recorder := &recordingWorkflowProvider{
-		getEventTrigger: &coreworkflow.EventTrigger{ID: workflowConfigEventTriggerID("task_updated")},
+		getEventTrigger: &coreworkflow.EventTrigger{
+			ID: workflowConfigEventTriggerID("task_updated"),
+			Match: coreworkflow.EventMatch{
+				Type: "task.updated",
+			},
+			Target: coreWorkflowPluginTarget("roadmap", "sync"),
+		},
 	}
 	factories := validFactories()
 	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
@@ -5654,68 +5600,6 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerID(t *testing.T) {
 	}
 	if len(recorder.upsertedEventTriggers) != 0 {
 		t.Fatalf("upserted event triggers = %d, want 0", len(recorder.upsertedEventTriggers))
-	}
-}
-
-func TestBootstrapReAdoptsManagedEventTriggersWhenOwnershipStateIsMissing(t *testing.T) {
-	t.Parallel()
-
-	provider := &recordingWorkflowProvider{}
-	db1 := &coretesting.StubIndexedDB{}
-	db2 := &coretesting.StubIndexedDB{}
-	factories := validFactories()
-	currentDB := db1
-	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return currentDB, nil }
-	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
-		return provider, nil
-	}
-
-	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
-		Provider: "temporal",
-		EventTriggers: map[string]workflowFixtureEventTrigger{
-			"task_updated": {
-				Match: workflowFixtureEventMatch{
-					Type: "task.updated",
-				},
-				Operation: "sync",
-			},
-		},
-	})
-	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
-		"temporal": {Source: config.ProviderSource{Path: "stub"}},
-	}
-
-	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
-	if err != nil {
-		t.Fatalf("Bootstrap initial: %v", err)
-	}
-	_ = result.Close(context.Background())
-	if len(provider.upsertedEventTriggers) != 1 {
-		t.Fatalf("initial upserted event triggers = %d, want 1", len(provider.upsertedEventTriggers))
-	}
-	provider.eventTriggers[workflowConfigEventTriggerID("task_updated")].Target.Plugin.Input = map[string]any{
-		"limit": float64(1),
-	}
-
-	currentDB = db2
-	cfg.Workflows.EventTriggers["task_updated"] = config.WorkflowEventTriggerConfig{
-		Target: workflowFixtureTarget("roadmap", "sync", map[string]any{
-			"limit": 1,
-		}),
-		Match: config.WorkflowEventMatch{
-			Type: "task.updated",
-		},
-	}
-	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
-	if err != nil {
-		t.Fatalf("Bootstrap re-adopt: %v", err)
-	}
-	defer func() { _ = result.Close(context.Background()) }()
-	<-result.ProvidersReady
-
-	if len(provider.upsertedEventTriggers) != 2 {
-		t.Fatalf("upserted event triggers = %d, want 2", len(provider.upsertedEventTriggers))
 	}
 }
 

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -48,11 +48,10 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 		})
 		switch {
 		case err == nil:
-			if !isWorkflowConfigOwnedEventTrigger(existing, pluginName, desiredEntry.TriggerID) &&
-				!isAdoptableWorkflowEventTrigger(existing, trigger, desiredEntry.TriggerID) {
+			if !isWorkflowConfigOwnedEventTrigger(existing, pluginName, desiredEntry.TriggerID) {
 				return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q conflicts with existing unmanaged trigger id %q", desiredEntry.TriggerKey, pluginName, desiredEntry.TriggerID)
 			}
-			existingExecutionRef = workflowEventTriggerExecutionRef(existing, "")
+			existingExecutionRef = strings.TrimSpace(existing.ExecutionRef)
 		case isWorkflowObjectNotFound(err):
 		default:
 			return fmt.Errorf("bootstrap: get workflow event trigger %q for plugin %q: %w", desiredEntry.TriggerID, pluginName, err)
@@ -167,16 +166,6 @@ func cleanupRemovedWorkflowConfigEventTriggers(ctx context.Context, runtime *wor
 	return nil
 }
 
-func isAdoptableWorkflowEventTrigger(existing *coreworkflow.EventTrigger, trigger config.WorkflowEventTriggerConfig, triggerID string) bool {
-	if existing == nil {
-		return false
-	}
-	return existing.ID == triggerID &&
-		existing.Match == workflowConfigEventTriggerMatch(trigger) &&
-		existing.Paused == trigger.Paused &&
-		workflowTargetsEqual(existing.Target, workflowConfigEventTriggerTarget(trigger))
-}
-
 func isWorkflowConfigOwnedEventTrigger(existing *coreworkflow.EventTrigger, pluginName, triggerID string) bool {
 	if existing == nil {
 		return false
@@ -212,13 +201,4 @@ func workflowConfigEventTriggerID(triggerKey string) string {
 
 func workflowConfigEventTriggerExecutionRefID(triggerID string) string {
 	return "workflow_event_trigger:" + strings.TrimSpace(triggerID) + ":" + uuid.NewString()
-}
-
-func workflowEventTriggerExecutionRef(existing *coreworkflow.EventTrigger, fallback string) string {
-	if existing != nil {
-		if refID := strings.TrimSpace(existing.ExecutionRef); refID != "" {
-			return refID
-		}
-	}
-	return strings.TrimSpace(fallback)
 }

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -57,8 +57,7 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 		})
 		switch {
 		case err == nil:
-			if !isWorkflowConfigOwnedSchedule(existing, pluginName, desiredEntry.ScheduleID) &&
-				!isAdoptableWorkflowSchedule(existing, schedule, desiredEntry.ScheduleID) {
+			if !isWorkflowConfigOwnedSchedule(existing, pluginName, desiredEntry.ScheduleID) {
 				return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q conflicts with existing unmanaged schedule id %q", desiredEntry.ScheduleKey, pluginName, desiredEntry.ScheduleID)
 			}
 		case isWorkflowObjectNotFound(err):
@@ -67,7 +66,7 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 			return fmt.Errorf("bootstrap: get workflow schedule %q for plugin %q: %w", desiredEntry.ScheduleID, pluginName, err)
 		}
 		if existing != nil {
-			existingExecutionRef = workflowScheduleExecutionRef(existing, "")
+			existingExecutionRef = strings.TrimSpace(existing.ExecutionRef)
 		}
 		desiredExecutionRef, err := workflowConfigExecutionReference(cfg, providerName, target)
 		if err != nil {
@@ -186,17 +185,6 @@ func cleanupRemovedWorkflowConfigSchedules(ctx context.Context, runtime *workflo
 
 func workflowConfigProviderObjectKey(providerName, objectID string) string {
 	return strings.TrimSpace(providerName) + "\x00" + strings.TrimSpace(objectID)
-}
-
-func isAdoptableWorkflowSchedule(existing *coreworkflow.Schedule, schedule config.WorkflowScheduleConfig, scheduleID string) bool {
-	if existing == nil {
-		return false
-	}
-	return existing.ID == scheduleID &&
-		existing.Cron == schedule.Cron &&
-		existing.Timezone == schedule.Timezone &&
-		existing.Paused == schedule.Paused &&
-		workflowTargetsEqual(existing.Target, workflowConfigScheduleTarget(schedule))
 }
 
 func isWorkflowConfigOwnedSchedule(existing *coreworkflow.Schedule, pluginName, scheduleID string) bool {
@@ -322,15 +310,6 @@ func workflowConfigScheduleID(scheduleKey string) string {
 
 func workflowConfigScheduleExecutionRefID(scheduleID string) string {
 	return "workflow_schedule:" + scheduleID + ":" + uuid.NewString()
-}
-
-func workflowScheduleExecutionRef(existing *coreworkflow.Schedule, fallback string) string {
-	if existing != nil {
-		if refID := strings.TrimSpace(existing.ExecutionRef); refID != "" {
-			return refID
-		}
-	}
-	return strings.TrimSpace(fallback)
 }
 
 func workflowEnsureConfigExecutionRef(


### PR DESCRIPTION
## Summary

- Remove the config-workflow compatibility path that re-adopted existing unmanaged schedules when their cron/target shape matched YAML.
- Remove the equivalent event-trigger re-adoption path.
- Delete the missing-ownership re-adoption tests and tighten the existing unmanaged-id tests so matching unmanaged objects are still rejected.

## Supported YAML

Cron schedules are still supported. The config shape for creating or updating a config-managed schedule is unchanged:

```yaml
workflows:
  schedules:
    nightly_sync:
      provider: local
      cron: "0 2 * * *"
      timezone: UTC
      target:
        plugin:
          name: roadmap
          operation: sync
```

Event triggers are also still supported:

```yaml
workflows:
  eventTriggers:
    item_updated:
      provider: local
      match:
        type: roadmap.item.updated
      target:
        plugin:
          name: roadmap
          operation: sync
```

## Removed Compatibility

The removed path is not YAML cron support. It is provider-object adoption based on shape matching.

Before, bootstrap could claim this existing provider object if it matched YAML, even though it was not marked as config-owned:

```go
existing := &coreworkflow.Schedule{
    ID:       workflowConfigScheduleID("nightly_sync"),
    Cron:     "0 2 * * *",
    Timezone: "UTC",
    Target:   coreWorkflowPluginTarget("roadmap", "sync"),
    // CreatedBy missing or not system:config
}
// Bootstrap re-adopted this schedule if the YAML shape matched.
```

After, matching cron/target shape is not enough. An existing provider object is config-owned only when it carries the config actor metadata:

```go
existing := &coreworkflow.Schedule{
    ID:        workflowConfigScheduleID("nightly_sync"),
    CreatedBy: coreworkflow.Actor{SubjectID: "system:config", SubjectKind: "system", AuthSource: "config"},
}
// Bootstrap treats only this as config-owned. Matching unmanaged objects conflict.
```

The same ownership rule applies to `coreworkflow.EventTrigger`.

## Tests

- `go test ./internal/bootstrap -run 'TestBootstrap.*ConfiguredWorkflow|TestBootstrapRejectsExistingUnmanagedWorkflow|TestBootstrapMovesConfiguredWorkflow|TestBootstrapDeletesRemovedConfiguredWorkflow'`
- `go test ./internal/bootstrap`
- `go test ./internal/config`
- `go test ./cmd/gestaltd`

Also ran `go test ./...`; all packages passed except `cmd/gestaltd` hit E2E readiness timeouts during the initial cold Rust CLI rebuild. Rerunning `go test ./cmd/gestaltd` immediately afterward passed.
