### PR TITLE
docs: clarify core data ownership

### DIFF
--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -1,10 +1,20 @@
 # Data Model
 
-Gestalt stores most persistent state through configured providers. Gestaltd core provisions only the object stores it directly owns through the configured [IndexedDB provider](/providers/indexeddb): users, API tokens, agent metadata/idempotency, runtime sessions, and runtime session logs. Provider-owned state, such as upstream credentials, is provisioned by that provider instead of by gestaltd core.
+Gestalt stores most persistent state through configured providers. Gestaltd core provisions only the object stores it directly owns through the configured [IndexedDB provider](/providers/indexeddb): users and API tokens. Provider-owned state, such as upstream credentials, workflow state, and agent sessions/turns, is provisioned by those providers instead of by gestaltd core.
 
 MCP OAuth client registrations (`oauth_registrations`) are stored separately in a raw SQL table managed outside the IndexedDB provider.
 
 For encryption mechanics, see [Security Internals](/architecture/security-internals). For choosing a provider, see [Configuration](/configuration).
+
+## Ownership summary
+
+| Owner | Persistent state |
+| --- | --- |
+| `gestaltd` core | `users`, `api_tokens` |
+| External credentials provider | `external_credentials` |
+| Agent provider | Provider-defined agent session, turn, interaction, event, and idempotency state |
+| Workflow provider | Provider-defined schedule, event trigger, run, execution ref, and idempotency state |
+| MCP OAuth support | `oauth_registrations` raw SQL table |
 
 ## Object stores
 

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -338,7 +338,7 @@ These metrics are recorded around every ObjectStore and Index operation on the
 system IndexedDB instance. They use the OpenTelemetry
 `db.client.operation.duration` histogram instead of a Gestalt-specific metric
 family. The instrumentation is applied once at the interface level in bootstrap,
-so both core services (tokens, users, API tokens) and plugin host traffic are
+so both core services (users and API tokens) and provider-hosted traffic are
 covered.
 
 <Tabs items={['OpenTelemetry', 'Prometheus']}>


### PR DESCRIPTION
## Summary
- document that gestaltd core currently provisions only `users` and `api_tokens`
- call out provider-owned state for external credentials, workflow, and agent sessions/turns/idempotency
- update IndexedDB observability wording now that the old core token/external-credential paths are gone

## Interface changes
None. Documentation-only cleanup.

## Examples
Core-owned stores:
```text
users
api_tokens
```

Provider-owned state examples:
```text
external_credentials              # ExternalCredentialsProvider
agent sessions/turns/idempotency  # AgentProvider
workflow schedules/runs/refs      # WorkflowProvider
```

## Verification
- `git diff --check`
- `rg -n "integration_tokens|IntegrationToken|integration token" . -g'!*node_modules*' -g'!*dist*' -g'!*vendor*'`
- `rg -n "Store[A-Za-z]+\\s*=|CreateObjectStore\\(ctx, Store" gestaltd/internal/coredata gestaltd/internal -g'*.go'`