### PR TITLE
Require provider-dev attachment state

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -840,19 +840,21 @@ gestaltd provider dev --remote "$GESTALT_URL" --path ./slack
 
 The remote URL is environment-agnostic; it can point at any `gestaltd` instance
 that exposes provider-dev attach targets and has opted in with
-`server.providerDev.remoteAttach: true`. The target plugin must also opt into
-private remote attach with `providerDev.attach.allowedRoles`. The CLI opens a
-browser approval page for the interactive happy path; approve it with your
-normal browser session and enter the verification code shown in your terminal.
-API-token callers must use a token with the `provider_dev.attach` action for
-that plugin. The local command replaces only the source plugin attached by your
-authenticated session. Providers that are not attached locally continue to run
-through the remote server and its existing configuration.
+`server.providerDev.remoteAttach: true` and
+`server.providerDev.attachmentState: processLocal`. The target plugin must also
+opt into private remote attach with `providerDev.attach.allowedRoles`. The CLI
+opens a browser approval page for the interactive happy path; approve it with
+your normal browser session and enter the verification code shown in your
+terminal. API-token callers must use a token with the `provider_dev.attach`
+action for that plugin. The local command replaces only the source plugin
+attached by your authenticated session. Providers that are not attached locally
+continue to run through the remote server and its existing configuration.
 
 ```yaml
 server:
   providerDev:
     remoteAttach: true
+    attachmentState: processLocal
 
 authorization:
   policies:
@@ -886,10 +888,12 @@ enough, and this action does not grant normal invocation access:
   ]
 }
 ```
-Remote attach v1 is process-local. On a load-balanced remote, enable it only
-when the deployment is single-replica or sticky-routes attach creation, CLI
-poll/complete traffic, provider invocations, and provider-owned UI requests for
-the same authenticated owner to the same `gestaltd` process.
+Remote attach v1 is process-local, and the server requires
+`server.providerDev.attachmentState: processLocal` as an explicit operator
+acknowledgement. On a load-balanced remote, enable it only when the deployment
+is single-replica or sticky-routes attach creation, CLI poll/complete traffic,
+provider invocations, and provider-owned UI requests for the same authenticated
+owner to the same `gestaltd` process.
 Remote provider dev uses `--remote-token` first, then `GESTALT_API_KEY`, then a
 stored CLI token when the stored credential's server base URL matches
 `--remote`. An API token used for direct attach must include

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -76,12 +76,14 @@ keeps its existing config-relative behavior for backward compatibility.
 `provider dev --remote` is environment-agnostic: the URL is just the remote
 `gestaltd` instance to attach to. The local command only replaces source-backed
 plugin implementations for the authenticated principal that created the session.
-The remote server must opt in with `server.providerDev.remoteAttach: true`;
-otherwise the command fails before local code is attached.
-Remote attach v1 is also process-local: only enable it on a single-replica
-server or behind sticky routing that keeps attach creation, CLI poll/complete
-traffic, provider invocations, and provider-owned UI requests for the same
-authenticated owner on the same `gestaltd` process.
+The remote server must opt in with `server.providerDev.remoteAttach: true` and
+`server.providerDev.attachmentState: processLocal`; otherwise the command fails
+before local code is attached. `attachmentState: processLocal` acknowledges that
+remote attach v1 stores attachments in the `gestaltd` process that accepted the
+create request. Only enable it on a single-replica server or behind sticky
+routing that keeps attach creation, CLI poll/complete traffic, provider
+invocations, and provider-owned UI requests for the same authenticated owner on
+the same `gestaltd` process.
 For the interactive happy path, `provider dev --remote` creates a short-lived
 attach approval request and opens the remote server in your browser. Approving
 that page with your normal browser session creates an owner-scoped attachment

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -166,6 +166,8 @@ Plugins without `authorizationPolicy` are open to any authenticated subject. Bin
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared `init` artifacts. |
 | `providers.audit` / `providers.authentication` / `providers.authorization` / `providers.indexeddb` / `providers.secrets` / `providers.telemetry` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
+| `providerDev.remoteAttach` | `false` | Enables private remote provider-dev attach routes. Requires `providerDev.attachmentState: processLocal`. |
+| `providerDev.attachmentState` | | Required when `providerDev.remoteAttach` is true. Use `processLocal` to acknowledge that remote attach v1 stores attachment state in this `gestaltd` process and therefore requires single-replica operation or sticky routing for provider-dev traffic. |
 | `runtime.defaultHostedProvider` | | Default runtime-provider selector for plugins that opt into `execution.mode: hosted`. This does not move plugins into hosted runtimes by itself. |
 | `admin.authorizationPolicy` | | Shared subject access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
@@ -1081,6 +1083,7 @@ on shared remotes:
 server:
   providerDev:
     remoteAttach: true
+    attachmentState: processLocal
 
 authorization:
   policies:
@@ -1107,10 +1110,11 @@ environment, host-service env, plugin config, access tokens, or browser binding
 URLs.
 
 Remote attach v1 stores attachments in the `gestaltd` process that accepted the
-create request. For load-balanced deployments, treat single-replica operation or
-sticky routing for attach creation, poll/complete traffic, provider invocations,
-and provider-owned UI requests as a hard prerequisite before enabling
-`remoteAttach`.
+create request. `attachmentState: processLocal` is required as an explicit
+operator acknowledgement of that model. For load-balanced deployments, treat
+single-replica operation or sticky routing for attach creation, poll/complete
+traffic, provider invocations, and provider-owned UI requests as a hard
+prerequisite before enabling `remoteAttach`.
 
 Interactive attach creation uses a short-lived browser approval page plus a
 verification code shown in the initiating terminal. The approving browser

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1432,8 +1432,13 @@ type ServerConfig struct {
 }
 
 type ProviderDevConfig struct {
-	RemoteAttach bool `yaml:"remoteAttach,omitempty"`
+	RemoteAttach    bool                       `yaml:"remoteAttach,omitempty"`
+	AttachmentState ProviderDevAttachmentState `yaml:"attachmentState,omitempty"`
 }
+
+type ProviderDevAttachmentState string
+
+const ProviderDevAttachmentStateProcessLocal ProviderDevAttachmentState = "processLocal"
 
 type ServerRuntimeConfig struct {
 	DefaultHostedProvider string `yaml:"defaultHostedProvider,omitempty"`

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -134,6 +134,77 @@ plugins:
 	}
 }
 
+func TestLoadConfigValidatesProviderDevAttachmentState(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "remote attach requires explicit process local state",
+			yaml: `
+server:
+  providerDev:
+    remoteAttach: true
+`,
+			wantErr: `server.providerDev.remoteAttach requires server.providerDev.attachmentState: "processLocal"`,
+		},
+		{
+			name: "unsupported attachment state",
+			yaml: `
+server:
+  providerDev:
+    remoteAttach: true
+    attachmentState: sharedRelay
+`,
+			wantErr: `server.providerDev.attachmentState "sharedRelay" is not supported`,
+		},
+		{
+			name: "attachment state requires remote attach",
+			yaml: `
+server:
+  providerDev:
+    attachmentState: processLocal
+`,
+			wantErr: `server.providerDev.attachmentState requires server.providerDev.remoteAttach`,
+		},
+		{
+			name: "process local remote attach",
+			yaml: `
+server:
+  providerDev:
+    remoteAttach: true
+    attachmentState: processLocal
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := mustWriteConfigFile(t, tc.yaml)
+			cfg, err := Load(path)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatal("Load: expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("Load error = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if got := cfg.Server.ProviderDev.AttachmentState; got != ProviderDevAttachmentStateProcessLocal {
+				t.Fatalf("providerDev.attachmentState = %q, want %q", got, ProviderDevAttachmentStateProcessLocal)
+			}
+		})
+	}
+}
+
 func TestLoadConfigParsesPluginHTTPSecuritySchemesAndBindings(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -61,6 +61,9 @@ func ValidateCanonicalStructure(cfg *Config) error {
 	if err := validateAdminConfig(cfg); err != nil {
 		return err
 	}
+	if err := validateProviderDevConfig(cfg); err != nil {
+		return err
+	}
 	if cfg.Server.APITokenTTL != "" {
 		if _, err := ParseDuration(cfg.Server.APITokenTTL); err != nil {
 			return fmt.Errorf("config validation: server.apiTokenTtl: %w", err)
@@ -145,6 +148,29 @@ func ValidateCanonicalStructure(cfg *Config) error {
 		}
 	}
 	return validateWorkflowsConfig(cfg)
+}
+
+func validateProviderDevConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	providerDev := cfg.Server.ProviderDev
+	state := ProviderDevAttachmentState(strings.TrimSpace(string(providerDev.AttachmentState)))
+	cfg.Server.ProviderDev.AttachmentState = state
+	if !providerDev.RemoteAttach {
+		if state != "" {
+			return fmt.Errorf("config validation: server.providerDev.attachmentState requires server.providerDev.remoteAttach")
+		}
+		return nil
+	}
+	switch state {
+	case ProviderDevAttachmentStateProcessLocal:
+		return nil
+	case "":
+		return fmt.Errorf("config validation: server.providerDev.remoteAttach requires server.providerDev.attachmentState: %q because remote attach v1 stores attachments in process memory; enable only on single-replica deployments or deployments with sticky routing for provider-dev traffic", ProviderDevAttachmentStateProcessLocal)
+	default:
+		return fmt.Errorf("config validation: server.providerDev.attachmentState %q is not supported; use %q", state, ProviderDevAttachmentStateProcessLocal)
+	}
 }
 
 func validateAPIVersion(cfg *Config) error {


### PR DESCRIPTION
## Summary

Makes the provider-dev remote attach topology prerequisite enforceable instead of only documented. `server.providerDev.remoteAttach: true` now requires an explicit `server.providerDev.attachmentState: processLocal`, acknowledging that v1 attachment state is stored in the `gestaltd` process that accepted the attach.

## New Interface

```yaml
server:
  providerDev:
    remoteAttach: true
    attachmentState: processLocal
```

Validation now rejects:

- `remoteAttach: true` without `attachmentState: processLocal`
- unsupported attachment state values such as `sharedRelay`
- `attachmentState` when `remoteAttach` is not enabled

## Example

```yaml
server:
  providerDev:
    remoteAttach: true
    attachmentState: processLocal

plugins:
  slack:
    authorizationPolicy: provider_devs
    providerDev:
      attach:
        allowedRoles:
          - developer
```

This means operators must explicitly acknowledge that remote attach v1 is safe only for a single-replica deployment or a deployment that sticky-routes attach creation, dispatcher poll/complete traffic, provider invocations, and provider-owned UI requests to the same `gestaltd` process.

## Testing

- `go test ./internal/config -run 'TestLoadConfigValidatesProviderDevAttachmentState'`
- `go test ./internal/config ./internal/server ./cmd/gestaltd`
- `golangci-lint run --allow-parallel-runners ./...`
- `npm run build` in `docs/`

## Docs

Updated:

- `docs/content/reference/config-file.mdx`
- `docs/content/reference/cli.mdx`
- `docs/content/custom-providers/plugins.mdx`