### PR TITLE
server: remove legacy disconnect selectors

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -30,7 +30,7 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/api/v1/integrations` | List plugins, connection state, authentication types, instances, icons, and connection parameter hints. |
-| `DELETE` | `/api/v1/integrations/{name}` | Disconnect a plugin. Use `?_connection=...` and `?_instance=...` to target one stored connection. Legacy `connection` and `instance` selectors are accepted for compatibility. |
+| `DELETE` | `/api/v1/integrations/{name}` | Disconnect a plugin. Use `?_connection=...` and `?_instance=...` to target one stored connection. |
 | `GET` | `/api/v1/integrations/{name}/operations` | List operations for one plugin. Supports `_connection` and `_instance` selectors. |
 | `GET` or `POST` | `/api/v1/{integration}/{operation}` | Invoke a plugin operation. Supports `_connection` and `_instance`. |
 

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -773,7 +773,7 @@ func TestSearchToolsRanksProviderConfiguredTags(t *testing.T) {
 			}},
 		},
 	}
-	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	manager := newTestManager(t, Config{Providers: testutil.NewProviderRegistry(t, provider)})
 
 	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
 		SubjectID: principal.UserSubjectID("user-1"),
@@ -810,7 +810,7 @@ func TestSearchToolsDoesNotInventSemanticAliases(t *testing.T) {
 				}}},
 			},
 		}
-		manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+		manager := newTestManager(t, Config{Providers: testutil.NewProviderRegistry(t, provider)})
 		resp, err := manager.SearchTools(context.Background(), &principal.Principal{
 			SubjectID: principal.UserSubjectID("user-1"),
 		}, coreagent.SearchToolsRequest{
@@ -852,7 +852,7 @@ func TestSearchToolsDoesNotTreatPullRequestsAsMergeWithoutMetadata(t *testing.T)
 			}}},
 		},
 	}
-	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	manager := newTestManager(t, Config{Providers: testutil.NewProviderRegistry(t, provider)})
 	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
 		SubjectID: principal.UserSubjectID("user-1"),
 	}, coreagent.SearchToolsRequest{
@@ -891,7 +891,7 @@ func TestSearchToolsRanksTitleAheadOfTags(t *testing.T) {
 			}},
 		},
 	}
-	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	manager := newTestManager(t, Config{Providers: testutil.NewProviderRegistry(t, provider)})
 	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
 		SubjectID: principal.UserSubjectID("user-1"),
 	}, coreagent.SearchToolsRequest{

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -261,13 +260,17 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	query := r.URL.Query()
-
-	requestedInstance, err := selectorQueryValue(query, httpInstanceParam, "instance")
-	if err != nil {
-		auditErr = err
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
+	for param := range query {
+		switch param {
+		case httpConnectionParam, httpInstanceParam:
+		default:
+			auditErr = fmt.Errorf("unsupported query parameter %q", param)
+			writeError(w, http.StatusBadRequest, auditErr.Error())
+			return
+		}
 	}
+
+	requestedInstance := query.Get(httpInstanceParam)
 	if requestedInstance != "" {
 		var ok bool
 		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
@@ -276,12 +279,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	requestedConnection, err := selectorQueryValue(query, httpConnectionParam, "connection")
-	if err != nil {
-		auditErr = err
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
+	requestedConnection := query.Get(httpConnectionParam)
 	if requestedConnection != "" {
 		var ok bool
 		requestedConnection, ok = s.resolveRequestedConnection(w, name, requestedConnection)
@@ -370,18 +368,6 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 	auditAllowed = true
 	auditErr = nil
 	writeJSON(w, http.StatusOK, map[string]string{"status": "disconnected"})
-}
-
-func selectorQueryValue(query url.Values, canonical, legacy string) (string, error) {
-	canonicalValue := query.Get(canonical)
-	legacyValue := query.Get(legacy)
-	if canonicalValue != "" && legacyValue != "" && canonicalValue != legacyValue {
-		return "", fmt.Errorf("conflicting %s and %s query parameters", canonical, legacy)
-	}
-	if canonicalValue != "" {
-		return canonicalValue, nil
-	}
-	return legacyValue, nil
 }
 
 func (s *Server) getProvider(w http.ResponseWriter, name string) (core.Provider, bool) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -9580,50 +9580,7 @@ func TestDisconnectIntegration(t *testing.T) {
 		}
 	})
 
-	t.Run("legacy plain parameters are accepted for disconnect", func(t *testing.T) {
-		t.Parallel()
-
-		svc := coretesting.NewStubServices(t)
-		u := seedUser(t, svc, "anonymous@gestalt")
-		seedToken(t, svc, &core.ExternalCredential{
-			ID: "tok-b", SubjectID: principal.UserSubjectID(u.ID), Integration: "notion",
-			Connection: "mcp", Instance: "MCP OAuth", AccessToken: "test-token",
-		})
-		seedToken(t, svc, &core.ExternalCredential{
-			ID: "tok-c", SubjectID: principal.UserSubjectID(u.ID), Integration: "notion",
-			Connection: "default", Instance: "default", AccessToken: "test-token-2",
-		})
-
-		ts := newTestServer(t, func(cfg *server.Config) {
-			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "notion", DN: "Notion"})
-			cfg.Services = svc
-		})
-		testutil.CloseOnCleanup(t, ts)
-
-		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/notion?connection=mcp&instance=MCP%20OAuth", nil)
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("request: %v", err)
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
-		}
-		tokens, err := svc.ExternalCredentials.ListCredentialsForProvider(context.Background(), principal.UserSubjectID(u.ID), "notion")
-		if err != nil {
-			t.Fatalf("ListCredentialsForProvider: %v", err)
-		}
-		if len(tokens) != 1 {
-			t.Fatalf("expected one token to remain after legacy disconnect, got %d", len(tokens))
-		}
-		if tokens[0].Connection != "default" || tokens[0].Instance != "default" {
-			t.Fatalf("unexpected remaining token %+v", tokens[0])
-		}
-	})
-
-	t.Run("conflicting canonical and legacy parameters are rejected for disconnect", func(t *testing.T) {
+	t.Run("plain selectors are rejected for disconnect", func(t *testing.T) {
 		t.Parallel()
 
 		svc := coretesting.NewStubServices(t)
@@ -9639,7 +9596,7 @@ func TestDisconnectIntegration(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/notion?_connection=default&connection=mcp", nil)
+		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/notion?connection=mcp", nil)
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("request: %v", err)
@@ -9654,8 +9611,8 @@ func TestDisconnectIntegration(t *testing.T) {
 		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 			t.Fatalf("decoding: %v", err)
 		}
-		if !strings.Contains(result["error"], "_connection") || !strings.Contains(result["error"], "connection") {
-			t.Fatalf("expected conflict error, got %q", result["error"])
+		if !strings.Contains(result["error"], "unsupported query parameter") {
+			t.Fatalf("expected unsupported query parameter error, got %q", result["error"])
 		}
 	})
 


### PR DESCRIPTION
## Summary
- remove support for legacy `connection` and `instance` query selectors on `DELETE /api/v1/integrations/{name}`
- keep only canonical `_connection` and `_instance` selectors
- reject unsupported disconnect query parameters instead of silently ignoring stale selectors
- update HTTP API docs to describe only the canonical interface
- align agentmanager search-tool tests with the existing test manager helper so latest-main CI has test tool grants configured

## Compatibility
- Gestalt CLI already sends `_connection` / `_instance` for disconnect; the CLI contract tests assert this wire shape.
- `valon-technologies/gestalt-providers#317` updated the default web UI provider to send `_connection` / `_instance` and has been merged.
- The checked-in gestaltd UI bundle no longer contains `URLSearchParams.set("connection"|"instance")` for disconnect.

## Interface changes
```diff
 DELETE /api/v1/integrations/{name}
-  ?connection=<connection>&instance=<instance>
-  ?_connection=<connection>&connection=<other>  # conflict check
+  ?_connection=<connection>&_instance=<instance>
```

Unsupported query parameters now return `400`:
```json
{"error":"unsupported query parameter \"connection\""}
```

## Examples
```bash
# Before: legacy selector alias was accepted
curl -X DELETE '/api/v1/integrations/slack?connection=mcp&instance=workspace-123'

# Now: canonical selectors only
curl -X DELETE '/api/v1/integrations/slack?_connection=mcp&_instance=workspace-123'
```

## Verification
- `go test ./internal/agentmanager`
- `go test ./internal/server -run 'TestDisconnectIntegration'`
- `cargo test --test plugins_connect test_disconnect`
- `git diff --check`