### PR TITLE
Add provider-dev attachment CLI

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -907,9 +907,20 @@ sent; the browser approval flow is used instead. Use `--remote-token` or
 Remote attach creates an owner-scoped attachment. The server returns an
 `attachId` and a one-time dispatcher secret; the CLI uses both for local
 poll/complete traffic. Other users keep seeing the deployed provider and UI.
-Owner cleanup can detach a stuck attachment by `attachId`, but diagnostic
-list/get responses never expose dispatcher secrets, host-service env, plugin
-config, access tokens, or browser binding URLs.
+Owner cleanup can detach a stuck attachment by `attachId`:
+
+```sh
+gestaltd provider attach list --remote "$GESTALT_URL"
+gestaltd provider attach show --remote "$GESTALT_URL" att_123
+gestaltd provider attach detach --remote "$GESTALT_URL" att_123
+```
+
+These diagnostic commands use `--remote-token`, `GESTALT_API_KEY`, or a matching
+stored Gestalt CLI credential for the same remote URL. They do not require
+`provider_dev.attach` because they only list, inspect, or detach attachments
+owned by the authenticated principal. Diagnostic list/get responses never expose
+dispatcher secrets, host-service env, plugin config, access tokens, or browser
+binding URLs.
 
 For `--remote --path` without `--config`, Gestalt matches the local manifest
 `source` to a configured plugin on the remote server. The remote plugin's

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -35,6 +35,9 @@ import { Callout } from 'nextra/components'
 | `gestaltd provider dev --config PATH` | Layer supporting providers, plugins, and UI mounts on top of the synthesized local baseline. Repeat `--config` to merge left-to-right. |
 | `gestaltd provider dev --remote URL --path PATH` | Attach one local source plugin to an authenticated remote `gestaltd` session. The remote server matches by manifest `source` and keeps its configured auth, authorization, connections, plugin config, and host services. |
 | `gestaltd provider dev --remote URL --config PATH` | Attach every source-backed plugin in the layered config. Use repeated `--config` files when you need explicit local config overrides or multiple local plugins. |
+| `gestaltd provider attach list --remote URL` | List your active remote provider-dev attachments on that server. |
+| `gestaltd provider attach show --remote URL ATTACH_ID` | Inspect one active remote provider-dev attachment. |
+| `gestaltd provider attach detach --remote URL ATTACH_ID` | Detach a stuck remote provider-dev attachment owned by your authenticated principal. |
 | `gestaltd provider validate --path PATH` | Validate a local source plugin or UI bundle inside the same synthesized Gestalt config used by `provider dev`. |
 | `gestaltd provider validate --config PATH` | Validate the target provider together with selected supporting providers and `null` deletions from layered config overlays. |
 | `gestaltd provider release --version VERSION` | Build and package a provider release. Go, Python, Rust, and TypeScript source plugins default to the host platform. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
@@ -62,6 +65,9 @@ gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/supp
 gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support --name support
 gestaltd provider dev --remote https://gestalt.example.com --remote-token <token-with-provider_dev.attach> --path ./plugins/support
 gestaltd provider dev --remote https://gestalt.example.com --config ./remote.yaml --config ./local-overrides.yaml
+gestaltd provider attach list --remote https://gestalt.example.com
+gestaltd provider attach show --remote https://gestalt.example.com att_123
+gestaltd provider attach detach --remote https://gestalt.example.com att_123
 gestaltd provider release --version 0.0.1-alpha.1
 gestaltd provider release --version 0.0.1-alpha.1 --platform all
 gestaltd provider release --version 0.0.1-alpha.1 --platform linux/amd64,linux/arm64
@@ -107,8 +113,16 @@ remote instance.
 After browser approval or attach-token authentication, the remote creates an
 attachment and the CLI uses the returned `attachId` plus a one-time dispatcher
 secret for poll/complete traffic. The dispatcher secret is not shown by list/get
-diagnostics and is not needed for owner cleanup detach. API-token attach
-requires an explicit token action permission:
+diagnostics and is not needed for owner cleanup detach. Use
+`gestaltd provider attach list --remote URL`,
+`gestaltd provider attach show --remote URL ATTACH_ID`, and
+`gestaltd provider attach detach --remote URL ATTACH_ID` to inspect or clean up
+attachments owned by your authenticated principal. These diagnostic commands use
+`--remote-token`, `GESTALT_API_KEY`, or a matching stored Gestalt CLI
+credential, and they do not require `provider_dev.attach` because they cannot
+create a new attachment.
+
+API-token attach creation requires an explicit token action permission:
 
 ```json
 {

--- a/gestaltd/cmd/gestaltd/main_test.go
+++ b/gestaltd/cmd/gestaltd/main_test.go
@@ -34,7 +34,12 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "provider",
 			args:      []string{"provider", "--help"},
-			wantParts: []string{"gestaltd provider <command> [flags]", "dev", "validate", "release"},
+			wantParts: []string{"gestaltd provider <command> [flags]", "attach", "dev", "validate", "release"},
+		},
+		{
+			name:      "provider attach",
+			args:      []string{"provider", "attach", "--help"},
+			wantParts: []string{"gestaltd provider attach <command> [flags]", "list", "show", "detach"},
 		},
 		{
 			name:      "provider validate",

--- a/gestaltd/cmd/gestaltd/provider.go
+++ b/gestaltd/cmd/gestaltd/provider.go
@@ -31,6 +31,8 @@ func runProvider(args []string) error {
 	case "-h", "--help", "help":
 		printProviderUsage(os.Stderr)
 		return flag.ErrHelp
+	case "attach":
+		return runProviderAttach(args[1:])
 	case "dev":
 		return runProviderDev(args[1:])
 	case "validate":
@@ -607,6 +609,7 @@ func printProviderUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  attach      List, inspect, or detach remote provider-dev attachments")
 	writeUsageLine(w, "  dev         Run a local source plugin inside a synthesized Gestalt config")
 	writeUsageLine(w, "  release     Build provider release archives")
 	writeUsageLine(w, "  validate    Validate a local source plugin inside a synthesized Gestalt config")

--- a/gestaltd/cmd/gestaltd/provider_attach.go
+++ b/gestaltd/cmd/gestaltd/provider_attach.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
+)
+
+type providerAttachCommandOptions struct {
+	Remote      string
+	RemoteToken string
+}
+
+func runProviderAttach(args []string) error {
+	if len(args) == 0 {
+		printProviderAttachUsage(os.Stderr)
+		return flag.ErrHelp
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		printProviderAttachUsage(os.Stderr)
+		return flag.ErrHelp
+	case "list":
+		return runProviderAttachList(args[1:])
+	case "show":
+		return runProviderAttachShow(args[1:])
+	case "detach":
+		return runProviderAttachDetach(args[1:])
+	default:
+		return fmt.Errorf("unknown provider attach command %q", args[0])
+	}
+}
+
+func runProviderAttachList(args []string) error {
+	opts, remaining, err := parseProviderAttachFlags("list", args, printProviderAttachListUsage)
+	if err != nil {
+		return err
+	}
+	if len(remaining) > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(remaining, " "))
+	}
+	client, err := providerAttachClient(opts)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	attachments, err := client.ListAttachments(ctx)
+	if err != nil {
+		return err
+	}
+	printProviderAttachList(os.Stdout, attachments)
+	return nil
+}
+
+func runProviderAttachShow(args []string) error {
+	opts, remaining, err := parseProviderAttachFlags("show", args, printProviderAttachShowUsage)
+	if err != nil {
+		return err
+	}
+	if len(remaining) != 1 {
+		return errorsForProviderAttachID("show", remaining)
+	}
+	client, err := providerAttachClient(opts)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	attachment, err := client.GetAttachment(ctx, remaining[0])
+	if err != nil {
+		return err
+	}
+	printProviderAttachShow(os.Stdout, attachment)
+	return nil
+}
+
+func runProviderAttachDetach(args []string) error {
+	opts, remaining, err := parseProviderAttachFlags("detach", args, printProviderAttachDetachUsage)
+	if err != nil {
+		return err
+	}
+	if len(remaining) != 1 {
+		return errorsForProviderAttachID("detach", remaining)
+	}
+	client, err := providerAttachClient(opts)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := client.CloseSession(ctx, remaining[0]); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "Detached provider-dev attachment %s\n", remaining[0])
+	return nil
+}
+
+func parseProviderAttachFlags(command string, args []string, usage func(io.Writer)) (providerAttachCommandOptions, []string, error) {
+	fs := flag.NewFlagSet("gestaltd provider attach "+command, flag.ContinueOnError)
+	fs.Usage = func() { usage(fs.Output()) }
+	remoteFlag := fs.String("remote", "", "remote gestaltd base URL")
+	remoteTokenFlag := fs.String("remote-token", "", "bearer token for the remote server")
+	if err := fs.Parse(args); err != nil {
+		return providerAttachCommandOptions{}, nil, err
+	}
+	opts := providerAttachCommandOptions{
+		Remote:      *remoteFlag,
+		RemoteToken: *remoteTokenFlag,
+	}
+	if strings.TrimSpace(opts.Remote) == "" {
+		return providerAttachCommandOptions{}, nil, errorsForProviderAttachRemote(command)
+	}
+	return opts, fs.Args(), nil
+}
+
+func providerAttachClient(opts providerAttachCommandOptions) (providerdev.Client, error) {
+	token, err := resolveProviderAttachToken(opts)
+	if err != nil {
+		return providerdev.Client{}, err
+	}
+	return providerdev.Client{
+		BaseURL: opts.Remote,
+		Token:   token,
+	}, nil
+}
+
+func resolveProviderAttachToken(opts providerAttachCommandOptions) (string, error) {
+	return resolveProviderRemoteTokenWithErrors(opts.Remote, opts.RemoteToken, providerRemoteTokenErrors{
+		AuthMissing:              providerAttachAuthMissingError,
+		StoredCredentialUnscoped: providerAttachStoredCredentialUnscopedError,
+		StoredCredentialMismatch: providerAttachStoredCredentialMismatchError,
+		StoredCredentialMissingToken: func(credentialPath string) error {
+			return fmt.Errorf("stored Gestalt CLI credential in %s is missing api_token; pass --remote-token with a user API token for this server", credentialPath)
+		},
+	})
+}
+
+func printProviderAttachList(w io.Writer, attachments []providerdev.AttachmentInfo) {
+	if len(attachments) == 0 {
+		_, _ = fmt.Fprintln(w, "No provider-dev attachments found.")
+		return
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "ATTACH ID\tPROVIDERS\tUI\tLAST SEEN\tIDLE TIMEOUT")
+	for _, attachment := range attachments {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%ds\n",
+			attachment.AttachID,
+			providerAttachProviderNames(attachment.Providers),
+			providerAttachUIProviders(attachment.Providers),
+			formatProviderAttachTime(attachment.LastSeenAt),
+			attachment.IdleTimeoutSeconds,
+		)
+	}
+	_ = tw.Flush()
+}
+
+func printProviderAttachShow(w io.Writer, attachment *providerdev.AttachmentInfo) {
+	if attachment == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "Attach ID: %s\n", attachment.AttachID)
+	_, _ = fmt.Fprintf(w, "Created: %s\n", formatProviderAttachTime(attachment.CreatedAt))
+	_, _ = fmt.Fprintf(w, "Last seen: %s\n", formatProviderAttachTime(attachment.LastSeenAt))
+	_, _ = fmt.Fprintf(w, "Idle timeout: %ds\n", attachment.IdleTimeoutSeconds)
+	_, _ = fmt.Fprintln(w, "Providers:")
+	if len(attachment.Providers) == 0 {
+		_, _ = fmt.Fprintln(w, "  - none")
+		return
+	}
+	for _, provider := range attachment.Providers {
+		_, _ = fmt.Fprintf(w, "  - %s", provider.Name)
+		if strings.TrimSpace(provider.Source) != "" {
+			_, _ = fmt.Fprintf(w, " source=%s", provider.Source)
+		}
+		if provider.UI {
+			uiPath := strings.TrimSpace(provider.UIPath)
+			if uiPath == "" {
+				uiPath = "<mounted>"
+			}
+			_, _ = fmt.Fprintf(w, " ui=%s", uiPath)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+}
+
+func providerAttachProviderNames(providers []providerdev.AttachmentProviderInfo) string {
+	names := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		if name := strings.TrimSpace(provider.Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return "-"
+	}
+	slices.Sort(names)
+	return strings.Join(names, ",")
+}
+
+func providerAttachUIProviders(providers []providerdev.AttachmentProviderInfo) string {
+	names := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		if !provider.UI {
+			continue
+		}
+		name := strings.TrimSpace(provider.Name)
+		if name == "" {
+			continue
+		}
+		if path := strings.TrimSpace(provider.UIPath); path != "" {
+			name += ":" + path
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return "-"
+	}
+	slices.Sort(names)
+	return strings.Join(names, ",")
+}
+
+func formatProviderAttachTime(value time.Time) string {
+	if value.IsZero() {
+		return "-"
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func errorsForProviderAttachID(command string, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("gestaltd provider attach %s requires ATTACH_ID", command)
+	}
+	return fmt.Errorf("unexpected arguments: %s", strings.Join(args[1:], " "))
+}
+
+func errorsForProviderAttachRemote(command string) error {
+	return fmt.Errorf("gestaltd provider attach %s requires --remote URL", command)
+}
+
+func providerAttachAuthMissingError(remoteOrigin string) error {
+	return fmt.Errorf(`provider attach requires authentication.
+
+Remote server:
+  %s
+
+No --remote-token or %s was provided, and no stored Gestalt CLI credential for this server was found.
+
+Pass a user API token for this server:
+
+  gestaltd provider attach list --remote %s --remote-token <token>
+
+You can also set %s for this command`, remoteOrigin, gestaltAPIKeyEnv, remoteOrigin, gestaltAPIKeyEnv)
+}
+
+func providerAttachStoredCredentialUnscopedError(remoteOrigin, credentialPath string) error {
+	return fmt.Errorf(`provider attach could not use the stored Gestalt CLI credential.
+
+Remote server:
+  %s
+
+Stored credential:
+  server: <missing>
+  file: %s
+
+The stored credential does not record which Gestalt server it belongs to, so it was not sent.
+
+Pass a user API token for this server:
+
+  gestaltd provider attach list --remote %s --remote-token <token>`, remoteOrigin, credentialPath, remoteOrigin)
+}
+
+func providerAttachStoredCredentialMismatchError(remoteOrigin, storedOrigin, credentialPath string) error {
+	return fmt.Errorf(`provider attach could not use the stored Gestalt CLI credential.
+
+Remote server:
+  %s
+
+Stored credential:
+  server: %s
+  file: %s
+
+The stored credential is scoped to a different Gestalt server, so it was not sent.
+
+Pass a user API token for this server:
+
+  gestaltd provider attach list --remote %s --remote-token <token>
+
+You can also set %s for this command`, remoteOrigin, storedOrigin, credentialPath, remoteOrigin, gestaltAPIKeyEnv)
+}
+
+func printProviderAttachUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd provider attach <command> [flags]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  list       List your remote provider-dev attachments")
+	writeUsageLine(w, "  show       Show one remote provider-dev attachment")
+	writeUsageLine(w, "  detach     Detach one remote provider-dev attachment")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Run these against the same remote gestaltd URL used by provider dev --remote.")
+}
+
+func printProviderAttachListUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd provider attach list --remote URL [--remote-token TOKEN]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "List remote provider-dev attachments owned by the authenticated caller.")
+	writeProviderAttachFlagsUsage(w)
+}
+
+func printProviderAttachShowUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd provider attach show --remote URL [--remote-token TOKEN] ATTACH_ID")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Show one remote provider-dev attachment owned by the authenticated caller.")
+	writeProviderAttachFlagsUsage(w)
+}
+
+func printProviderAttachDetachUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd provider attach detach --remote URL [--remote-token TOKEN] ATTACH_ID")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Detach one remote provider-dev attachment owned by the authenticated caller.")
+	writeProviderAttachFlagsUsage(w)
+}
+
+func writeProviderAttachFlagsUsage(w io.Writer) {
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --remote        Remote gestaltd base URL")
+	writeUsageLine(w, "  --remote-token  Bearer token for the remote server (defaults to GESTALT_API_KEY or matching stored Gestalt CLI credential)")
+}

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -406,11 +406,29 @@ func openProviderRemoteBrowser(rawURL string) error {
 }
 
 func resolveProviderRemoteToken(opts providerLocalCommandOptions) (string, error) {
-	remoteBaseURL, err := providerRemoteBaseURL(opts.Remote)
+	return resolveProviderRemoteTokenWithErrors(opts.Remote, opts.RemoteToken, providerRemoteTokenErrors{
+		AuthMissing:              providerRemoteAuthMissingError,
+		StoredCredentialUnscoped: providerRemoteStoredCredentialUnscopedError,
+		StoredCredentialMismatch: providerRemoteStoredCredentialMismatchError,
+		StoredCredentialMissingToken: func(credentialPath string) error {
+			return fmt.Errorf("stored Gestalt CLI credential in %s is missing api_token; pass --remote-token with a user API token that grants provider_dev.attach for the target plugin", credentialPath)
+		},
+	})
+}
+
+type providerRemoteTokenErrors struct {
+	AuthMissing                  func(remoteOrigin string) error
+	StoredCredentialUnscoped     func(remoteOrigin, credentialPath string) error
+	StoredCredentialMismatch     func(remoteOrigin, storedOrigin, credentialPath string) error
+	StoredCredentialMissingToken func(credentialPath string) error
+}
+
+func resolveProviderRemoteTokenWithErrors(remote, explicitToken string, tokenErrors providerRemoteTokenErrors) (string, error) {
+	remoteBaseURL, err := providerRemoteBaseURL(remote)
 	if err != nil {
-		return "", fmt.Errorf("invalid --remote %q: %w", opts.Remote, err)
+		return "", fmt.Errorf("invalid --remote %q: %w", remote, err)
 	}
-	if token := strings.TrimSpace(opts.RemoteToken); token != "" {
+	if token := strings.TrimSpace(explicitToken); token != "" {
 		return token, nil
 	}
 	if token := strings.TrimSpace(os.Getenv(gestaltAPIKeyEnv)); token != "" {
@@ -422,22 +440,22 @@ func resolveProviderRemoteToken(opts providerLocalCommandOptions) (string, error
 		return "", err
 	}
 	if !ok {
-		return "", providerRemoteAuthMissingError(remoteBaseURL)
+		return "", tokenErrors.AuthMissing(remoteBaseURL)
 	}
 	if strings.TrimSpace(credential.APIURL) == "" {
-		return "", providerRemoteStoredCredentialUnscopedError(remoteBaseURL, credentialPath)
+		return "", tokenErrors.StoredCredentialUnscoped(remoteBaseURL, credentialPath)
 	}
 	storedBaseURL, err := providerRemoteBaseURL(credential.APIURL)
 	if err != nil {
 		return "", fmt.Errorf("stored Gestalt CLI credential has invalid api_url in %s: %w", credentialPath, err)
 	}
 	if storedBaseURL != remoteBaseURL {
-		return "", providerRemoteStoredCredentialMismatchError(remoteBaseURL, storedBaseURL, credentialPath)
+		return "", tokenErrors.StoredCredentialMismatch(remoteBaseURL, storedBaseURL, credentialPath)
 	}
 	if token := strings.TrimSpace(credential.APIToken); token != "" {
 		return token, nil
 	}
-	return "", fmt.Errorf("stored Gestalt CLI credential in %s is missing api_token; pass --remote-token with a user API token that grants provider_dev.attach for the target plugin", credentialPath)
+	return "", tokenErrors.StoredCredentialMissingToken(credentialPath)
 }
 
 func loadStoredGestaltCLICredential() (storedGestaltCLICredential, string, bool, error) {

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -358,6 +359,104 @@ func TestCreateProviderRemoteSessionFallsBackToBrowserApprovalForStoredToken(t *
 	}
 }
 
+func TestResolveProviderAttachTokenUsesMatchingStoredCLICredential(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv(gestaltAPIKeyEnv, "")
+	writeStoredGestaltCLICredentialForTest(t, configHome, "https://Valon.Tools/team-a/", "stored-token")
+
+	token, err := resolveProviderAttachToken(providerAttachCommandOptions{
+		Remote: "https://valon.tools/team-a",
+	})
+	if err != nil {
+		t.Fatalf("resolveProviderAttachToken: %v", err)
+	}
+	if token != "stored-token" {
+		t.Fatalf("token = %q, want stored-token", token)
+	}
+}
+
+func TestProviderAttachCommandsUseOwnerAttachmentRoutes(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	var sawDelete atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer owner-token" {
+			http.Error(w, "missing owner token", http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/team-a"+providerdev.PathAttachments:
+			writeJSONForProviderRemoteTest(t, w, http.StatusOK, providerdev.ListAttachmentsResponse{
+				Attachments: []providerdev.AttachmentInfo{{
+					AttachID:           "attach-1",
+					CreatedAt:          now.Add(-time.Minute),
+					LastSeenAt:         now,
+					IdleTimeoutSeconds: 120,
+					Providers: []providerdev.AttachmentProviderInfo{{
+						Name:   "roadmap",
+						Source: "github.com/test/plugins/roadmap",
+						UI:     true,
+						UIPath: "/roadmap",
+					}},
+				}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/team-a"+providerdev.PathAttachments+"/attach-1":
+			writeJSONForProviderRemoteTest(t, w, http.StatusOK, providerdev.AttachmentInfo{
+				AttachID:           "attach-1",
+				CreatedAt:          now.Add(-time.Minute),
+				LastSeenAt:         now,
+				IdleTimeoutSeconds: 120,
+				Providers: []providerdev.AttachmentProviderInfo{{
+					Name:   "roadmap",
+					Source: "github.com/test/plugins/roadmap",
+					UI:     true,
+					UIPath: "/roadmap",
+				}},
+			})
+		case r.Method == http.MethodDelete && r.URL.Path == "/team-a"+providerdev.PathAttachments+"/attach-1":
+			sawDelete.Store(true)
+			writeJSONForProviderRemoteTest(t, w, http.StatusOK, map[string]string{"status": "closed"})
+		default:
+			http.Error(w, "unexpected request "+r.Method+" "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+	remote := ts.URL + "/team-a"
+
+	listOut, err := runProviderCommandResult("", "attach", "list", "--remote", remote, "--remote-token", "owner-token")
+	if err != nil {
+		t.Fatalf("provider attach list: %v\n%s", err, listOut)
+	}
+	for _, want := range []string{"ATTACH ID", "attach-1", "roadmap", "roadmap:/roadmap", "120s"} {
+		if !strings.Contains(string(listOut), want) {
+			t.Fatalf("list output missing %q:\n%s", want, listOut)
+		}
+	}
+
+	showOut, err := runProviderCommandResult("", "attach", "show", "--remote", remote, "--remote-token", "owner-token", "attach-1")
+	if err != nil {
+		t.Fatalf("provider attach show: %v\n%s", err, showOut)
+	}
+	for _, want := range []string{"Attach ID: attach-1", "Providers:", "roadmap", "source=github.com/test/plugins/roadmap", "ui=/roadmap"} {
+		if !strings.Contains(string(showOut), want) {
+			t.Fatalf("show output missing %q:\n%s", want, showOut)
+		}
+	}
+
+	detachOut, err := runProviderCommandResult("", "attach", "detach", "--remote", remote, "--remote-token", "owner-token", "attach-1")
+	if err != nil {
+		t.Fatalf("provider attach detach: %v\n%s", err, detachOut)
+	}
+	if !strings.Contains(string(detachOut), "Detached provider-dev attachment attach-1") {
+		t.Fatalf("unexpected detach output: %s", detachOut)
+	}
+	if !sawDelete.Load() {
+		t.Fatal("expected owner detach request")
+	}
+}
+
 func writeJSONForProviderRemoteTest(t *testing.T, w http.ResponseWriter, status int, value any) {
 	t.Helper()
 	w.Header().Set("Content-Type", "application/json")
@@ -412,8 +511,13 @@ func TestRun_ProviderCLIUsageAndErrors(t *testing.T) {
 		{
 			name:      "root help",
 			args:      []string{"--help"},
-			wantParts: []string{"gestaltd provider <command> [flags]", "release"},
+			wantParts: []string{"gestaltd provider <command> [flags]", "attach", "release"},
 			notWant:   []string{"\n  install", "\n  inspect", "\n  list", "\n  init", "\n  package"},
+		},
+		{
+			name:      "attach help",
+			args:      []string{"attach", "--help"},
+			wantParts: []string{"gestaltd provider attach <command> [flags]", "detach"},
 		},
 		{
 			name:      "release help",

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -773,7 +773,7 @@ func TestSearchToolsRanksProviderConfiguredTags(t *testing.T) {
 			}},
 		},
 	}
-	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	manager := newTestManager(t, Config{Providers: testutil.NewProviderRegistry(t, provider)})
 
 	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
 		SubjectID: principal.UserSubjectID("user-1"),
@@ -810,7 +810,7 @@ func TestSearchToolsDoesNotInventSemanticAliases(t *testing.T) {
 				}}},
 			},
 		}
-		manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+		manager := newTestManager(t, Config{Providers: testutil.NewProviderRegistry(t, provider)})
 		resp, err := manager.SearchTools(context.Background(), &principal.Principal{
 			SubjectID: principal.UserSubjectID("user-1"),
 		}, coreagent.SearchToolsRequest{
@@ -852,7 +852,7 @@ func TestSearchToolsDoesNotTreatPullRequestsAsMergeWithoutMetadata(t *testing.T)
 			}}},
 		},
 	}
-	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	manager := newTestManager(t, Config{Providers: testutil.NewProviderRegistry(t, provider)})
 	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
 		SubjectID: principal.UserSubjectID("user-1"),
 	}, coreagent.SearchToolsRequest{
@@ -891,7 +891,7 @@ func TestSearchToolsRanksTitleAheadOfTags(t *testing.T) {
 			}},
 		},
 	}
-	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	manager := newTestManager(t, Config{Providers: testutil.NewProviderRegistry(t, provider)})
 	resp, err := manager.SearchTools(context.Background(), &principal.Principal{
 		SubjectID: principal.UserSubjectID("user-1"),
 	}, coreagent.SearchToolsRequest{

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -131,6 +131,10 @@ type AttachmentInfo struct {
 	Providers          []AttachmentProviderInfo `json:"providers"`
 }
 
+type ListAttachmentsResponse struct {
+	Attachments []AttachmentInfo `json:"attachments"`
+}
+
 type AttachmentProviderInfo struct {
 	Name   string `json:"name"`
 	Source string `json:"source,omitempty"`
@@ -1452,6 +1456,23 @@ func (c *Client) CreateAuthorizedSession(ctx context.Context, authorizationID st
 	}
 	c.DispatcherSecret = out.DispatcherSecret
 	c.AuthorizationSecret = ""
+	return &out, nil
+}
+
+func (c Client) ListAttachments(ctx context.Context) ([]AttachmentInfo, error) {
+	var out ListAttachmentsResponse
+	if err := c.doJSON(ctx, http.MethodGet, PathAttachments, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Attachments, nil
+}
+
+func (c Client) GetAttachment(ctx context.Context, attachID string) (*AttachmentInfo, error) {
+	path := PathAttachments + "/" + url.PathEscape(attachID)
+	var out AttachmentInfo
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
 	return &out, nil
 }
 


### PR DESCRIPTION
## Summary

Adds owner-facing CLI commands for remote provider-dev attachment diagnostics and cleanup. This closes the gap where the server already exposed redacted list/get and owner detach routes, but users had to hand-write curl to inspect or clean up stuck attachments.

## New Interfaces

```sh
gestaltd provider attach list --remote URL [--remote-token TOKEN]
gestaltd provider attach show --remote URL [--remote-token TOKEN] ATTACH_ID
gestaltd provider attach detach --remote URL [--remote-token TOKEN] ATTACH_ID
```

The commands authenticate with `--remote-token`, `GESTALT_API_KEY`, or a matching stored Gestalt CLI credential for the same remote URL. They do not require `provider_dev.attach` because they only list, inspect, or detach attachments owned by the authenticated principal; they cannot create new attachments.

## Examples

```sh
gestaltd provider attach list --remote https://valon.tools
gestaltd provider attach show --remote https://valon.tools att_123
gestaltd provider attach detach --remote https://valon.tools att_123
```

Example output:

```text
ATTACH ID  PROVIDERS  UI                LAST SEEN             IDLE TIMEOUT
att_123    slack      slack:/slack-dev  2026-04-29T12:00:00Z  120s
```

## Testing

- `go test ./cmd/gestaltd -run 'TestProviderAttach|TestResolveProviderAttach|TestE2ECLIHelp|TestRun_ProviderCLIUsageAndErrors'`
- `go test ./cmd/gestaltd ./internal/providerdev ./internal/server -count=1`
- `golangci-lint run --allow-parallel-runners ./...`
- `npm run build` in `docs/`

Note: the first broad `go test ./cmd/gestaltd ./internal/providerdev ./internal/server` run hit an existing port-bind flake in `TestE2EHostedHTTPSubjectResolutionUsesAuthorizationAndInheritedInvocation`; rerunning that test and then the same package set with `-count=1` passed.

## Docs

Updated:

- `docs/content/reference/cli.mdx`
- `docs/content/custom-providers/plugins.mdx`