### PR TITLE
Polish agent TUI tool detail previews

### DIFF
--- a/gestalt/cli/src/commands/agents/tui/state.rs
+++ b/gestalt/cli/src/commands/agents/tui/state.rs
@@ -15,6 +15,7 @@ use super::super::{
 
 const MAX_TRANSCRIPT_ITEMS: usize = 500;
 const TOOL_PREVIEW_MAX_WIDTH: usize = 120;
+const TOOL_PREVIEW_MAX_LINES: usize = 6;
 const LEGACY_ASSISTANT_FORMAT: &str = "markdown";
 
 pub(super) struct AgentUiState {
@@ -1053,21 +1054,47 @@ fn tool_status(data: &serde_json::Map<String, Value>) -> Option<String> {
 }
 
 fn preview_value(data: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
-    value_any_field(data, keys)
-        .and_then(|value| compact_json(value).ok())
-        .map(|value| truncate_preview(&value))
+    value_any_field(data, keys).and_then(|value| format_tool_preview(value).ok())
 }
 
 fn preview_display_value(value: Option<&Value>) -> Option<String> {
-    value
-        .and_then(|value| compact_json(value).ok())
-        .map(|value| truncate_preview(&value))
+    value.and_then(|value| format_tool_preview(value).ok())
 }
 
 fn preview_display_error(value: Option<&Value>) -> Option<String> {
     value
         .and_then(|value| display_value_text(value).ok())
-        .map(|value| truncate_preview(&value))
+        .map(|value| truncate_multiline_preview(&value))
+}
+
+fn format_tool_preview(value: &Value) -> anyhow::Result<String> {
+    let preview = match value {
+        Value::Array(_) | Value::Object(_) => pretty_json(value)?,
+        _ => compact_json(value)?,
+    };
+    Ok(truncate_multiline_preview(&preview))
+}
+
+fn truncate_multiline_preview(value: &str) -> String {
+    let total_lines = value.lines().count();
+    let preview_lines = if total_lines > TOOL_PREVIEW_MAX_LINES {
+        TOOL_PREVIEW_MAX_LINES.saturating_sub(1)
+    } else {
+        TOOL_PREVIEW_MAX_LINES
+    };
+    let mut lines = value
+        .lines()
+        .take(preview_lines)
+        .map(truncate_preview)
+        .collect::<Vec<_>>();
+    if total_lines > TOOL_PREVIEW_MAX_LINES {
+        lines.push(format!("... +{} lines", total_lines - preview_lines));
+    }
+    if lines.is_empty() && !value.is_empty() {
+        truncate_preview(value)
+    } else {
+        lines.join("\n")
+    }
 }
 
 fn truncate_preview(value: &str) -> String {

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -945,10 +945,10 @@ fn test_cli_tty_renders_display_tool_activity_rows() {
             "/api/v1/agent/turns/turn-display-tools/events/stream?after=0&limit=100&until=blocked_or_terminal",
             StatusCode::OK,
             "text/event-stream",
-            "data: {\"seq\":1,\"type\":\"provider.tool\",\"visibility\":\"public\",\"data\":{\"arguments\":{\"secret\":\"RAW_TUI_INPUT\"}},\"display\":{\"kind\":\"tool\",\"phase\":\"started\",\"action\":\"Running\",\"label\":\"lookup\",\"ref\":\"call-lookup\",\"input\":{\"query\":\"sample\"}}}\n\n\
+            "data: {\"seq\":1,\"type\":\"provider.tool\",\"visibility\":\"public\",\"data\":{\"arguments\":{\"secret\":\"RAW_TUI_INPUT\"}},\"display\":{\"kind\":\"tool\",\"phase\":\"started\",\"action\":\"Running\",\"label\":\"lookup\",\"ref\":\"call-lookup\",\"input\":{\"query\":\"sample\",\"filters\":{\"status\":\"open\",\"tags\":[\"red\",\"blue\"]}}}}\n\n\
              data: {\"seq\":2,\"type\":\"provider.tool\",\"visibility\":\"public\",\"display\":{\"kind\":\"tool\",\"phase\":\"progress\",\"label\":\"lookup\",\"ref\":\"call-lookup\",\"text\":\"halfway\"}}\n\n\
              data: {\"seq\":3,\"type\":\"provider.tool\",\"visibility\":\"public\",\"display\":{\"kind\":\"tool\",\"phase\":\"progress\",\"label\":\"lookup\",\"ref\":\"call-lookup\",\"text\":\"almost done\"}}\n\n\
-             data: {\"seq\":4,\"type\":\"provider.tool\",\"visibility\":\"public\",\"data\":{\"output\":{\"secret\":\"RAW_TUI_OUTPUT\"}},\"display\":{\"kind\":\"tool\",\"phase\":\"completed\",\"action\":\"Ran\",\"label\":\"lookup\",\"ref\":\"call-lookup\",\"text\":\"200\",\"output\":{\"count\":1}}}\n\n\
+             data: {\"seq\":4,\"type\":\"provider.tool\",\"visibility\":\"public\",\"data\":{\"output\":{\"secret\":\"RAW_TUI_OUTPUT\"}},\"display\":{\"kind\":\"tool\",\"phase\":\"completed\",\"action\":\"Ran\",\"label\":\"lookup\",\"ref\":\"call-lookup\",\"text\":\"200\",\"output\":{\"count\":1,\"items\":[{\"id\":\"REC-1\",\"status\":\"open\"}]}}}\n\n\
              data: {\"seq\":5,\"type\":\"provider.status\",\"visibility\":\"public\",\"display\":{\"kind\":\"status\",\"phase\":\"completed\",\"text\":\"sync complete\"}}\n\n\
              data: {\"seq\":6,\"type\":\"provider.text\",\"visibility\":\"public\",\"display\":{\"kind\":\"text\",\"phase\":\"delta\",\"text\":\"tui\"}}\n\n\
              data: {\"seq\":7,\"type\":\"assistant.completed\",\"visibility\":\"public\",\"data\":{\"text\":\"tui suffix\"},\"display\":{\"kind\":\"text\",\"phase\":\"completed\"}}\n\n\
@@ -986,6 +986,10 @@ fn test_cli_tty_renders_display_tool_activity_rows() {
     session.wait_for(&mut output, "Ran");
     session.wait_for(&mut output, "200");
     session.wait_for(&mut output, "count");
+    session.wait_for(&mut output, "filters");
+    session.wait_for(&mut output, "REC-1");
+    session.wait_for(&mut output, "... +5 lines");
+    session.wait_for(&mut output, "... +4 lines");
     session.wait_for(&mut output, "suffix");
     session.wait_for(&mut output, "done");
     session.wait_for(&mut output, "fallback");
@@ -1006,6 +1010,10 @@ fn test_cli_tty_renders_display_tool_activity_rows() {
             && output.contains("lookup")
             && output.contains("input")
             && output.contains("output")
+            && output.contains("filters")
+            && output.contains("REC-1")
+            && output.contains("... +5 lines")
+            && output.contains("... +4 lines")
             && output.contains("└─")
             && !output.contains("Tool")
             && !output.contains("tool>"),


### PR DESCRIPTION
## Summary
- Pretty-print structured tool input/output display values in the agent TUI instead of collapsing them to compact JSON.
- Keep previews bounded by width and line count, with an omitted-line marker for large values.
- Augment the existing TTY integration test to cover nested display metadata, bounded previews, and raw payload non-leakage.

## New Interfaces
No new Rust API, protobuf, HTTP, or stdin/stdout contract is introduced.

The TUI continues to consume the existing display metadata interface:
```json
{
  "display": {
    "kind": "tool",
    "phase": "completed",
    "action": "Ran",
    "label": "lookup",
    "output": {
      "count": 1,
      "items": [{ "id": "REC-1" }]
    }
  }
}
```

Example TUI rendering:
```text
● Ran lookup
└─ output {
   "count": 1,
   "items": [
   ... +4 lines
```

## Testing
- `cargo test --manifest-path gestalt/Cargo.toml --test agents_cli`
- `cargo clippy --manifest-path gestalt/Cargo.toml --workspace --all-targets -- -D warnings`
- `git diff --check`
- `if rg -n "Linear|linear|Data Platform|AIT-|DATA-|DP-|hugh|peach|Hermes|Claude|slack|Search docs|linear\\.app" gestalt/cli/tests/agents_cli.rs; then exit 1; fi`

## Review
- Reviewed by separate `gpt-5.5` xhigh agent. Applied its truncation-count feedback and added marker assertions to the integration test.