### PR TITLE
[codex] Plumb provider-owned tool search tags

### DIFF
--- a/gestaltd/core/catalog/catalog.go
+++ b/gestaltd/core/catalog/catalog.go
@@ -55,6 +55,28 @@ func OperationVisibleByDefault(op CatalogOperation) bool {
 	return op.Visible == nil || *op.Visible
 }
 
+// MergeTags returns provider-owned search tags with empty values removed and
+// case-insensitive duplicates collapsed while preserving the first spelling.
+func MergeTags(groups ...[]string) []string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, group := range groups {
+		for _, tag := range group {
+			tag = strings.TrimSpace(tag)
+			if tag == "" {
+				continue
+			}
+			key := strings.ToLower(tag)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, tag)
+		}
+	}
+	return out
+}
+
 func (o *CatalogOperation) UnmarshalYAML(value *yaml.Node) error {
 	type catalogOperationYAML struct {
 		ID             string               `yaml:"id"`

--- a/gestaltd/core/integration/restricted.go
+++ b/gestaltd/core/integration/restricted.go
@@ -18,6 +18,7 @@ type Restricted struct {
 	allowedInner map[string]struct{}
 	descriptions map[string]string
 	allowedRoles map[string][]string
+	tags         map[string][]string
 }
 
 // RestrictedOption configures a Restricted provider.
@@ -31,6 +32,11 @@ func WithDescriptions(descs map[string]string) RestrictedOption {
 // WithAllowedRoles sets allowedRoles overrides keyed by exposed operation name.
 func WithAllowedRoles(roles map[string][]string) RestrictedOption {
 	return func(r *Restricted) { r.allowedRoles = roles }
+}
+
+// WithTags adds provider-owned search tags keyed by exposed operation name.
+func WithTags(tags map[string][]string) RestrictedOption {
+	return func(r *Restricted) { r.tags = tags }
 }
 
 // Compile-time interface checks.
@@ -145,6 +151,9 @@ func (r *Restricted) filterCatalog(cat *catalog.Catalog) *catalog.Catalog {
 			}
 			if roles, ok := r.allowedRoles[op.ID]; ok {
 				op.AllowedRoles = append([]string(nil), roles...)
+			}
+			if tags, ok := r.tags[op.ID]; ok {
+				op.Tags = catalog.MergeTags(op.Tags, tags)
 			}
 			filtered.Operations = append(filtered.Operations, op)
 		}

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -2413,7 +2413,7 @@ func TestHybridExecutableProviderAppliesAllowedOperationsToStaticAndOpenAPICatal
 	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
 		Name: "hybrid",
 		Operations: []catalog.CatalogOperation{
-			{ID: "echo", Method: http.MethodPost, Parameters: []catalog.CatalogParameter{{Name: "message", Type: "string", Required: true}}},
+			{ID: "echo", Method: http.MethodPost, Tags: []string{"static-source"}, Parameters: []catalog.CatalogParameter{{Name: "message", Type: "string", Required: true}}},
 		},
 	})
 	openapiDoc := `openapi: "3.1.0"
@@ -2424,6 +2424,8 @@ paths:
   /status:
     get:
       operationId: status
+      tags:
+        - openapi-source
       responses:
         "200":
           description: OK
@@ -2447,8 +2449,8 @@ paths:
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: manifestPath,
 				AllowedOperations: map[string]*config.OperationOverride{
-					"echo":   {Alias: "renamed_echo"},
-					"status": {Alias: "renamed_status"},
+					"echo":   {Alias: "renamed_echo", Tags: []string{"static-override"}},
+					"status": {Alias: "renamed_status", Tags: []string{"status-override"}},
 				},
 			},
 		},
@@ -2480,6 +2482,21 @@ paths:
 	}
 	if hasOperation("echo") || hasOperation("status") {
 		t.Fatalf("catalog operations = %+v, want original operation ids hidden", cat.Operations)
+	}
+	operationTags := func(id string) []string {
+		for _, op := range cat.Operations {
+			if op.ID == id {
+				return op.Tags
+			}
+		}
+		t.Fatalf("operation %q not found in catalog: %+v", id, cat.Operations)
+		return nil
+	}
+	if got, want := operationTags("renamed_echo"), []string{"static-source", "static-override"}; !slices.Equal(got, want) {
+		t.Fatalf("renamed_echo tags = %#v, want %#v", got, want)
+	}
+	if got, want := operationTags("renamed_status"), []string{"openapi-source", "status-override"}; !slices.Equal(got, want) {
+		t.Fatalf("renamed_status tags = %#v, want %#v", got, want)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/graphql_session_provider_test.go
+++ b/gestaltd/internal/bootstrap/graphql_session_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -82,7 +83,9 @@ func TestGraphQLSessionCatalogProviderLoadsCatalogOnDemand(t *testing.T) {
 		t.Fatalf("provider.Build: %v", err)
 	}
 
-	wrapped := wrapGraphQLSessionCatalogProvider(base, "linear", srv.URL, nil, map[string]string{
+	wrapped := wrapGraphQLSessionCatalogProvider(base, "linear", srv.URL, map[string]*config.OperationOverride{
+		"viewer": {Tags: []string{"profile"}},
+	}, map[string]string{
 		"viewer": "id",
 	})
 	if got := len(wrapped.Catalog().Operations); got != 0 {
@@ -109,6 +112,9 @@ func TestGraphQLSessionCatalogProviderLoadsCatalogOnDemand(t *testing.T) {
 	}
 	if viewer.Transport != "graphql" {
 		t.Fatalf("viewer transport = %q, want %q", viewer.Transport, "graphql")
+	}
+	if got, want := viewer.Tags, []string{"profile"}; !slices.Equal(got, want) {
+		t.Fatalf("viewer tags = %#v, want %#v", got, want)
 	}
 
 	result, err := wrapped.Execute(context.Background(), "viewer", nil, "test-token")

--- a/gestaltd/internal/graphql/loader.go
+++ b/gestaltd/internal/graphql/loader.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 )
@@ -92,6 +93,7 @@ func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isM
 		desc := field.Description
 		opName := field.Name
 		var allowedRoles []string
+		var tags []string
 		if override := allowedOps[field.Name]; override != nil {
 			if override.Description != "" {
 				desc = override.Description
@@ -100,6 +102,7 @@ func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isM
 				opName = override.Alias
 			}
 			allowedRoles = override.AllowedRoles
+			tags = catalog.MergeTags(override.Tags)
 		}
 
 		query := generateQuery(schema, field, isMutation, selectionOverrides[field.Name])
@@ -107,6 +110,7 @@ func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isM
 		opDef := provider.OperationDef{
 			Description:  provider.TruncateDescription(desc),
 			AllowedRoles: allowedRoles,
+			Tags:         tags,
 			Transport:    "graphql",
 			Query:        query,
 		}

--- a/gestaltd/internal/graphql/loader_test.go
+++ b/gestaltd/internal/graphql/loader_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -141,7 +142,7 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 	defer srv.Close()
 
 	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*config.OperationOverride{
-		"teams": {Description: "My custom description"},
+		"teams": {Description: "My custom description", Tags: []string{"workspace"}},
 	}, nil)
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)
@@ -154,6 +155,9 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 	teams := def.Operations["teams"]
 	if teams.Description != "My custom description" {
 		t.Errorf("teams.Description: got %q, want custom override", teams.Description)
+	}
+	if got, want := teams.Tags, []string{"workspace"}; !slices.Equal(got, want) {
+		t.Errorf("teams.Tags: got %#v, want %#v", got, want)
 	}
 }
 

--- a/gestaltd/internal/mcpupstream/upstream_test.go
+++ b/gestaltd/internal/mcpupstream/upstream_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -242,7 +243,7 @@ func TestUpstream_DiscoverAfterFilterWithAlias(t *testing.T) {
 	t.Cleanup(func() { _ = u.Close() })
 
 	err := u.FilterOperations(map[string]*config.OperationOverride{
-		"run_query": {Alias: "query"},
+		"run_query": {Alias: "query", Tags: []string{"sql"}},
 	})
 	if err != nil {
 		t.Fatalf("FilterOperations: %v", err)
@@ -257,6 +258,9 @@ func TestUpstream_DiscoverAfterFilterWithAlias(t *testing.T) {
 	}
 	if cat.Operations[0].ID != "query" {
 		t.Errorf("expected aliased ID %q, got %q", "query", cat.Operations[0].ID)
+	}
+	if got, want := cat.Operations[0].Tags, []string{"sql"}; !slices.Equal(got, want) {
+		t.Errorf("expected tags %#v, got %#v", want, got)
 	}
 }
 

--- a/gestaltd/internal/openapi/loader.go
+++ b/gestaltd/internal/openapi/loader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/orderedmap"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/toolschema"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
@@ -178,6 +179,7 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 			}
 			opID := op.OperationId
 			var allowedRoles []string
+			tags := catalog.MergeTags(op.Tags)
 			if override := allowedOps[op.OperationId]; override != nil {
 				if override.Description != "" {
 					desc = override.Description
@@ -186,6 +188,7 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 					opID = override.Alias
 				}
 				allowedRoles = override.AllowedRoles
+				tags = catalog.MergeTags(tags, override.Tags)
 			}
 
 			var (
@@ -246,6 +249,7 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 				Method:       strings.ToUpper(method),
 				Path:         path,
 				AllowedRoles: allowedRoles,
+				Tags:         tags,
 				Parameters:   params,
 			}
 		}

--- a/gestaltd/internal/openapi/loader_test.go
+++ b/gestaltd/internal/openapi/loader_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -50,6 +51,7 @@ func testSpec() map[string]any {
 				"get": map[string]any{
 					"operationId": "list_items",
 					"summary":     "List all items",
+					"tags":        []any{"inventory"},
 					"parameters": []any{
 						map[string]any{
 							"name": "limit", "in": "query",
@@ -81,7 +83,7 @@ func TestLoadDefinition(t *testing.T) {
 	testutil.CloseOnCleanup(t, srv)
 
 	allowed := map[string]*config.OperationOverride{
-		"list_items": {Description: "List items with pagination"},
+		"list_items": {Description: "List items with pagination", Tags: []string{"pagination"}},
 		"get_item":   nil,
 	}
 
@@ -112,6 +114,9 @@ func TestLoadDefinition(t *testing.T) {
 	listOp := def.Operations["list_items"]
 	if listOp.Description != "List items with pagination" {
 		t.Errorf("list_items description = %q, want override", listOp.Description)
+	}
+	if got, want := listOp.Tags, []string{"inventory", "pagination"}; !slices.Equal(got, want) {
+		t.Errorf("list_items tags = %#v, want %#v", got, want)
 	}
 	if len(listOp.Parameters) != 1 {
 		t.Fatalf("list_items params = %d, want 1", len(listOp.Parameters))

--- a/gestaltd/internal/operationexposure/policy.go
+++ b/gestaltd/internal/operationexposure/policy.go
@@ -18,6 +18,7 @@ type Policy struct {
 	originalToExposed map[string]string
 	descriptions      map[string]string
 	allowedRoles      map[string][]string
+	tags              map[string][]string
 }
 
 func New(allowed map[string]*config.OperationOverride) (*Policy, error) {
@@ -57,6 +58,15 @@ func New(allowed map[string]*config.OperationOverride) (*Policy, error) {
 				policy.allowedRoles = make(map[string][]string)
 			}
 			policy.allowedRoles[exposed] = append([]string(nil), override.AllowedRoles...)
+		}
+		if override != nil {
+			tags := catalog.MergeTags(override.Tags)
+			if len(tags) > 0 {
+				if policy.tags == nil {
+					policy.tags = make(map[string][]string)
+				}
+				policy.tags[exposed] = tags
+			}
 		}
 	}
 
@@ -112,6 +122,9 @@ func (p *Policy) Wrap(prov core.Provider) core.Provider {
 	if len(p.allowedRoles) > 0 {
 		opts = append(opts, coreintegration.WithAllowedRoles(p.AllowedRoles()))
 	}
+	if len(p.tags) > 0 {
+		opts = append(opts, coreintegration.WithTags(p.Tags()))
+	}
 	return coreintegration.NewRestricted(prov, p.RestrictedMap(), opts...)
 }
 
@@ -153,6 +166,18 @@ func (p *Policy) AllowedRoles() map[string][]string {
 		roles[exposed] = append([]string(nil), allowed...)
 	}
 	return roles
+}
+
+func (p *Policy) Tags() map[string][]string {
+	if len(p.tags) == 0 {
+		return nil
+	}
+
+	tags := make(map[string][]string, len(p.tags))
+	for exposed, values := range p.tags {
+		tags[exposed] = append([]string(nil), values...)
+	}
+	return tags
 }
 
 func (p *Policy) ApplyOperations(ops []core.Operation) []core.Operation {
@@ -197,6 +222,9 @@ func (p *Policy) ApplyCatalog(cat *catalog.Catalog) *catalog.Catalog {
 		}
 		if roles, ok := p.allowedRoles[exposed]; ok {
 			op.AllowedRoles = append([]string(nil), roles...)
+		}
+		if tags, ok := p.tags[exposed]; ok {
+			op.Tags = catalog.MergeTags(op.Tags, tags)
 		}
 		filtered.Operations = append(filtered.Operations, op)
 	}

--- a/gestaltd/internal/provider/catalog_metadata.go
+++ b/gestaltd/internal/provider/catalog_metadata.go
@@ -28,6 +28,7 @@ func CatalogFromDefinition(def *Definition) *catalog.Catalog {
 			Path:         opDef.Path,
 			Description:  opDef.Description,
 			AllowedRoles: opDef.AllowedRoles,
+			Tags:         catalog.MergeTags(opDef.Tags),
 			Transport:    opDef.Transport,
 			Query:        opDef.Query,
 			InputSchema:  opDef.InputSchema,

--- a/gestaltd/internal/provider/definition.go
+++ b/gestaltd/internal/provider/definition.go
@@ -88,6 +88,7 @@ type OperationDef struct {
 	Method       string          `yaml:"method" json:"method"`
 	Path         string          `yaml:"path" json:"path"`
 	AllowedRoles []string        `yaml:"allowedRoles,omitempty" json:"allowedRoles,omitempty"`
+	Tags         []string        `yaml:"tags,omitempty" json:"tags,omitempty"`
 	Parameters   []ParameterDef  `yaml:"parameters" json:"parameters"`
 	Query        string          `yaml:"query" json:"query"`                       // GraphQL query/mutation template
 	Transport    string          `yaml:"transport" json:"transport"`               // "rest" (default) or "graphql"

--- a/gestaltd/internal/providerhost/declarative.go
+++ b/gestaltd/internal/providerhost/declarative.go
@@ -251,6 +251,7 @@ func declarativeCatalog(manifest *providermanifestv1.Manifest, opts declarativeO
 			Path:         mop.Path,
 			Description:  mop.Description,
 			AllowedRoles: mop.AllowedRoles,
+			Tags:         catalog.MergeTags(mop.Tags),
 			Transport:    catalog.TransportREST,
 			Parameters:   make([]catalog.CatalogParameter, 0, len(mop.Parameters)),
 		}

--- a/gestaltd/internal/providerhost/declarative_test.go
+++ b/gestaltd/internal/providerhost/declarative_test.go
@@ -43,6 +43,7 @@ func TestDeclarativeProvider_POSTUsesExplicitJSONContentType(t *testing.T) {
 						Name:   "chat.postMessage",
 						Method: http.MethodPost,
 						Path:   "/api/chat.postMessage",
+						Tags:   []string{"chat", "message"},
 						Parameters: []providermanifestv1.ProviderParameter{
 							{Name: "channel", Type: "string", In: "body", Required: true},
 							{Name: "text", Type: "string", In: "body", Required: true},
@@ -77,5 +78,8 @@ func TestDeclarativeProvider_POSTUsesExplicitJSONContentType(t *testing.T) {
 	}
 	if gotBody["text"] != "hello" {
 		t.Fatalf("body[text] = %v, want hello", gotBody["text"])
+	}
+	if got := prov.Catalog().Operations[0].Tags; len(got) != 2 || got[0] != "chat" || got[1] != "message" {
+		t.Fatalf("catalog operation tags = %#v, want chat/message", got)
 	}
 }

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -862,6 +862,13 @@
             "minLength": 1
           }
         },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
         "parameters": {
           "type": "array",
           "items": {
@@ -1053,6 +1060,13 @@
           "type": "string"
         },
         "allowedRoles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "tags": {
           "type": "array",
           "items": {
             "type": "string",

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -365,6 +365,7 @@ type ManifestOperationOverride struct {
 	Alias        string                    `json:"alias,omitempty" yaml:"alias,omitempty"`
 	Description  string                    `json:"description,omitempty" yaml:"description,omitempty"`
 	AllowedRoles []string                  `json:"allowedRoles,omitempty" yaml:"allowedRoles,omitempty"`
+	Tags         []string                  `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Paginate     bool                      `json:"paginate,omitempty" yaml:"paginate,omitempty"`
 	Pagination   *ManifestPaginationConfig `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 }
@@ -390,6 +391,7 @@ type ProviderOperation struct {
 	Connection         string                       `json:"connection,omitempty" yaml:"connection,omitempty"`
 	ConnectionSelector *OperationConnectionSelector `json:"connectionSelector,omitempty" yaml:"connectionSelector,omitempty"`
 	AllowedRoles       []string                     `json:"allowedRoles,omitempty" yaml:"allowedRoles,omitempty"`
+	Tags               []string                     `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Parameters         []ProviderParameter          `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Plumbs provider-owned tool search tags from provider configuration into normalized catalogs so adaptive tool search can rank against metadata defined by the provider, not hard-coded gestaltd aliases.

## Interfaces

Manifest operation overrides can now add search tags to an exposed operation:

```yaml
allowedOperations:
  pull_requests.list:
    alias: list_pull_requests
    tags: [pr, prs]
```

Declarative REST operations can define source tags directly:

```yaml
surfaces:
  rest:
    operations:
      - name: messages.send
        method: POST
        path: /messages
        tags: [dm, direct message]
```

OpenAPI operation `tags` are preserved and augmented by `allowedOperations[].tags` before catalog generation:

```yaml
paths:
  /issues:
    get:
      operationId: issues.list
      tags: [issue-tracking]
allowedOperations:
  issues.list:
    tags: [tickets]
```

## Implementation Notes

- Adds `tags` to `ManifestOperationOverride`, declarative `ProviderOperation`, and internal `provider.OperationDef`.
- Carries tags through OpenAPI, GraphQL override metadata, declarative catalogs, provider definition catalogs, operation exposure, restricted provider catalogs, GraphQL session catalogs, and MCP rediscovery after filtering.
- Adds `catalog.MergeTags` to trim empty tags and dedupe case-insensitively while preserving first spelling.
- Tag behavior is additive: source tags are kept and override tags are appended/deduped.

## Validation

- `go test ./core/catalog ./core/integration ./internal/operationexposure ./internal/openapi ./internal/graphql ./internal/provider ./internal/providerhost ./internal/bootstrap ./internal/mcpupstream ./sdk/providermanifest/v1 -count=1`
- `golangci-lint run ./core/catalog ./core/integration ./internal/operationexposure ./internal/openapi ./internal/graphql ./internal/provider ./internal/providerhost ./internal/bootstrap ./internal/mcpupstream ./sdk/providermanifest/v1`
