### PR TITLE
[codex] Cache dynamic MCP catalog discovery

### DIFF
--- a/gestaltd/internal/mcpupstream/upstream.go
+++ b/gestaltd/internal/mcpupstream/upstream.go
@@ -2,24 +2,36 @@ package mcpupstream
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	neturl "net/url"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
+	"github.com/valon-technologies/gestalt/server/internal/observability"
 	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sync/singleflight"
 )
 
-const httpTimeout = 30 * time.Second
+const (
+	httpTimeout                 = 30 * time.Second
+	defaultCatalogCacheTTL      = 5 * time.Minute
+	defaultCatalogCacheMaxItems = 128
+)
 
 var (
 	_ core.Provider               = (*Upstream)(nil)
@@ -48,12 +60,25 @@ type Upstream struct {
 	connMode    core.ConnectionMode
 	headers     map[string]string
 	cat         *catalog.Catalog
+	catMu       sync.RWMutex
 	client      mcpclient.MCPClient
-	exposure    *operationexposure.Policy
+	exposure    atomic.Pointer[operationexposure.Policy]
 	checkEgress func(string) error
+
+	catalogCacheMu       sync.Mutex
+	catalogCache         map[string]cachedCatalog
+	catalogCacheGroup    singleflight.Group
+	catalogCacheTTL      time.Duration
+	catalogCacheMaxItems int
+	catalogCacheGen      uint64
 }
 
 type Option func(*Upstream)
+
+type cachedCatalog struct {
+	cat       *catalog.Catalog
+	expiresAt time.Time
+}
 
 func WithMetadataOverrides(displayName, description, iconSVG string) Option {
 	return func(u *Upstream) {
@@ -82,6 +107,9 @@ func New(_ context.Context, name string, url string, connMode core.ConnectionMod
 		connMode:    connMode,
 		headers:     config.NormalizeHeaders(headers),
 		checkEgress: checkEgress,
+
+		catalogCacheTTL:      defaultCatalogCacheTTL,
+		catalogCacheMaxItems: defaultCatalogCacheMaxItems,
 	}
 	for _, opt := range opts {
 		opt(u)
@@ -98,6 +126,9 @@ func newFromClient(name string, client mcpclient.MCPClient, connMode core.Connec
 		connMode: connMode,
 		cat:      cat,
 		client:   client,
+
+		catalogCacheTTL:      defaultCatalogCacheTTL,
+		catalogCacheMaxItems: defaultCatalogCacheMaxItems,
 	}
 }
 
@@ -112,7 +143,7 @@ func (u *Upstream) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 func (u *Upstream) CredentialFields() []core.CredentialFieldDef { return nil }
 func (u *Upstream) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
 func (u *Upstream) ConnectionForOperation(string) string        { return "" }
-func (u *Upstream) Catalog() *catalog.Catalog                   { return u.decorateCatalog(u.cat) }
+func (u *Upstream) Catalog() *catalog.Catalog                   { return u.decorateCatalog(u.staticCatalog()) }
 
 func (u *Upstream) SetDisplayName(s string) { u.display = s }
 func (u *Upstream) SetDescription(s string) { u.desc = s }
@@ -123,7 +154,52 @@ func (u *Upstream) Execute(_ context.Context, _ string, _ map[string]any, _ stri
 }
 
 func (u *Upstream) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	return u.discover(ctx, token)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if u.client != nil && u.hasStaticCatalog() {
+		return u.discover(ctx, token)
+	}
+
+	cacheKey := mcpCatalogCacheKey(token)
+	if cat := u.cachedCatalog(cacheKey); cat != nil {
+		observability.RecordMCPCatalogCacheHit(ctx, u.catalogMetricAttrs("hit")...)
+		return u.decorateCatalog(cat), nil
+	}
+	observability.RecordMCPCatalogCacheMiss(ctx, u.catalogMetricAttrs("miss")...)
+
+	cacheGen := u.catalogCacheGeneration()
+	flightKey := fmt.Sprintf("%s:%d", cacheKey, cacheGen)
+	result := u.catalogCacheGroup.DoChan(flightKey, func() (any, error) {
+		if cat := u.cachedCatalog(cacheKey); cat != nil {
+			return cat, nil
+		}
+
+		discoverCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), httpTimeout)
+		defer cancel()
+		startedAt := time.Now()
+		cat, err := u.discoverCatalog(discoverCtx, token)
+		observability.RecordMCPCatalogDiscover(discoverCtx, startedAt, err != nil, u.catalogMetricAttrs("")...)
+		if err != nil {
+			return nil, err
+		}
+		u.storeCachedCatalog(cacheKey, cacheGen, cat)
+		return cat, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-result:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		cat, ok := res.Val.(*catalog.Catalog)
+		if !ok || cat == nil {
+			return nil, fmt.Errorf("mcpupstream %s: catalog discovery returned no catalog", u.name)
+		}
+		return u.decorateCatalog(cat), nil
+	}
 }
 
 func (u *Upstream) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
@@ -161,18 +237,21 @@ func (u *Upstream) FilterOperations(allowed map[string]*config.OperationOverride
 	if err != nil {
 		return err
 	}
+
+	u.catMu.Lock()
 	if u.cat != nil {
 		if err := policy.ValidateCatalog(u.cat); err != nil {
+			u.catMu.Unlock()
 			return err
 		}
+		if policy != nil {
+			u.cat = policy.ApplyCatalog(u.cat)
+		}
 	}
-	u.exposure = policy
+	u.catMu.Unlock()
 
-	if u.cat == nil || policy == nil {
-		return nil
-	}
-
-	u.cat = policy.ApplyCatalog(u.cat)
+	u.exposure.Store(policy)
+	u.clearCatalogCache()
 	return nil
 }
 
@@ -232,8 +311,18 @@ func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClie
 }
 
 func (u *Upstream) discover(ctx context.Context, token string) (*catalog.Catalog, error) {
-	if u.client != nil && u.cat != nil {
-		return u.decorateCatalog(u.cat), nil
+	cat, err := u.discoverCatalog(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	return u.decorateCatalog(cat), nil
+}
+
+func (u *Upstream) discoverCatalog(ctx context.Context, token string) (*catalog.Catalog, error) {
+	if u.client != nil {
+		if cat := u.staticCatalog(); cat != nil {
+			return cat, nil
+		}
 	}
 
 	client, err := u.connect(ctx, token)
@@ -248,14 +337,15 @@ func (u *Upstream) discover(ctx context.Context, token string) (*catalog.Catalog
 	}
 
 	cat := buildCatalog(u.name, toolsResult.Tools)
-	if err := u.exposure.ValidateCatalog(cat); err != nil {
+	exposure := u.exposure.Load()
+	if err := exposure.ValidateCatalog(cat); err != nil {
 		return nil, err
 	}
-	return u.decorateCatalog(u.exposure.ApplyCatalog(cat)), nil
+	return exposure.ApplyCatalog(cat), nil
 }
 
 func (u *Upstream) resolveInnerName(name string) (string, bool) {
-	return u.exposure.Resolve(name)
+	return u.exposure.Load().Resolve(name)
 }
 
 func buildCatalog(name string, tools []mcpgo.Tool) *catalog.Catalog {
@@ -311,4 +401,103 @@ func (u *Upstream) decorateCatalog(cat *catalog.Catalog) *catalog.Catalog {
 		decorated.IconSVG = u.iconSVG
 	}
 	return decorated
+}
+
+func (u *Upstream) staticCatalog() *catalog.Catalog {
+	u.catMu.RLock()
+	defer u.catMu.RUnlock()
+	if u.cat == nil {
+		return nil
+	}
+	return u.cat.Clone()
+}
+
+func (u *Upstream) hasStaticCatalog() bool {
+	u.catMu.RLock()
+	defer u.catMu.RUnlock()
+	return u.cat != nil
+}
+
+func (u *Upstream) cachedCatalog(key string) *catalog.Catalog {
+	if u.catalogCacheTTL <= 0 {
+		return nil
+	}
+
+	now := time.Now()
+	u.catalogCacheMu.Lock()
+	defer u.catalogCacheMu.Unlock()
+	cached, ok := u.catalogCache[key]
+	if !ok {
+		return nil
+	}
+	if !cached.expiresAt.After(now) {
+		delete(u.catalogCache, key)
+		return nil
+	}
+	return cached.cat.Clone()
+}
+
+func (u *Upstream) storeCachedCatalog(key string, generation uint64, cat *catalog.Catalog) {
+	if u.catalogCacheTTL <= 0 || cat == nil {
+		return
+	}
+
+	u.catalogCacheMu.Lock()
+	defer u.catalogCacheMu.Unlock()
+	if u.catalogCacheGen != generation {
+		return
+	}
+	if u.catalogCache == nil {
+		u.catalogCache = make(map[string]cachedCatalog)
+	}
+	u.pruneCatalogCacheLocked(time.Now())
+	if maxItems := u.catalogCacheMaxItems; maxItems > 0 && len(u.catalogCache) >= maxItems {
+		for existingKey := range u.catalogCache {
+			delete(u.catalogCache, existingKey)
+			break
+		}
+	}
+	u.catalogCache[key] = cachedCatalog{
+		cat:       cat.Clone(),
+		expiresAt: time.Now().Add(u.catalogCacheTTL),
+	}
+}
+
+func (u *Upstream) clearCatalogCache() {
+	u.catalogCacheMu.Lock()
+	defer u.catalogCacheMu.Unlock()
+	u.catalogCacheGen++
+	clear(u.catalogCache)
+}
+
+func (u *Upstream) catalogCacheGeneration() uint64 {
+	u.catalogCacheMu.Lock()
+	defer u.catalogCacheMu.Unlock()
+	return u.catalogCacheGen
+}
+
+func (u *Upstream) pruneCatalogCacheLocked(now time.Time) {
+	for key, cached := range u.catalogCache {
+		if !cached.expiresAt.After(now) {
+			delete(u.catalogCache, key)
+		}
+	}
+}
+
+func (u *Upstream) catalogMetricAttrs(cacheResult string) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		metricutil.AttrProvider.String(metricutil.AttrValue(u.name)),
+	}
+	if cacheResult != "" {
+		attrs = append(attrs, observability.AttrMCPCatalogCacheResult.String(cacheResult))
+	}
+	return attrs
+}
+
+func mcpCatalogCacheKey(token string) string {
+	if token == "" {
+		return "no-token"
+	}
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
 }

--- a/gestaltd/internal/mcpupstream/upstream_test.go
+++ b/gestaltd/internal/mcpupstream/upstream_test.go
@@ -8,7 +8,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -19,8 +23,8 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
-func newTestServer() *mcpserver.MCPServer {
-	srv := mcpserver.NewMCPServer("test-remote", "1.0.0")
+func newTestServer(opts ...mcpserver.ServerOption) *mcpserver.MCPServer {
+	srv := mcpserver.NewMCPServer("test-remote", "1.0.0", opts...)
 
 	srv.AddTool(
 		mcpgo.NewToolWithRawSchema("run_query", "Execute a SQL query",
@@ -94,6 +98,21 @@ func newHeaderAuthenticatedHTTPTestServer(t *testing.T, expectedHeaders map[stri
 		}
 		handler.ServeHTTP(w, r)
 	}))
+}
+
+func newCountingHTTPTestServer(t *testing.T, listToolsCount *atomic.Int32, opts ...mcpserver.ServerOption) *httptest.Server {
+	t.Helper()
+
+	hooks := &mcpserver.Hooks{}
+	hooks.AddBeforeListTools(func(context.Context, any, *mcpgo.ListToolsRequest) {
+		listToolsCount.Add(1)
+	})
+	opts = append(opts, mcpserver.WithHooks(hooks))
+	handler := mcpserver.NewStreamableHTTPServer(
+		newTestServer(opts...),
+		mcpserver.WithStateLess(true),
+	)
+	return httptest.NewServer(handler)
 }
 
 func TestUpstream_DiscoverTools(t *testing.T) {
@@ -374,6 +393,335 @@ func TestUpstream_LazyDiscoveryUsesRequestToken(t *testing.T) {
 	}
 	if result.IsError {
 		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+}
+
+func TestUpstream_CatalogForRequestCachesByToken(t *testing.T) {
+	t.Parallel()
+
+	var listToolsCount atomic.Int32
+	ts := newCountingHTTPTestServer(t, &listToolsCount)
+	t.Cleanup(ts.Close)
+
+	u, err := New(context.Background(), "clickhouse", ts.URL, core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	first, err := u.CatalogForRequest(context.Background(), "secret-token")
+	if err != nil {
+		t.Fatalf("first CatalogForRequest: %v", err)
+	}
+	first.Operations[0].ID = "mutated-by-caller"
+
+	second, err := u.CatalogForRequest(context.Background(), "secret-token")
+	if err != nil {
+		t.Fatalf("second CatalogForRequest: %v", err)
+	}
+	if got := listToolsCount.Load(); got != 1 {
+		t.Fatalf("ListTools count = %d, want 1", got)
+	}
+	if second.Operations[0].ID == "mutated-by-caller" {
+		t.Fatalf("cached catalog was mutated by caller: %#v", second.Operations)
+	}
+}
+
+func TestUpstream_CatalogForRequestCacheExpires(t *testing.T) {
+	t.Parallel()
+
+	var listToolsCount atomic.Int32
+	ts := newCountingHTTPTestServer(t, &listToolsCount)
+	t.Cleanup(ts.Close)
+
+	u, err := New(context.Background(), "clickhouse", ts.URL, core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	u.catalogCacheTTL = 10 * time.Millisecond
+
+	if _, err := u.CatalogForRequest(context.Background(), "secret-token"); err != nil {
+		t.Fatalf("first CatalogForRequest: %v", err)
+	}
+	time.Sleep(25 * time.Millisecond)
+	if _, err := u.CatalogForRequest(context.Background(), "secret-token"); err != nil {
+		t.Fatalf("second CatalogForRequest: %v", err)
+	}
+	if got := listToolsCount.Load(); got != 2 {
+		t.Fatalf("ListTools count = %d, want 2 after expiry", got)
+	}
+}
+
+func TestUpstream_CatalogForRequestCacheSeparatesTokens(t *testing.T) {
+	t.Parallel()
+
+	var listToolsCount atomic.Int32
+	ts := newCountingHTTPTestServer(t, &listToolsCount)
+	t.Cleanup(ts.Close)
+
+	u, err := New(context.Background(), "clickhouse", ts.URL, core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	for _, token := range []string{"token-a", "token-a", "token-b", "token-a"} {
+		if _, err := u.CatalogForRequest(context.Background(), token); err != nil {
+			t.Fatalf("CatalogForRequest(%q): %v", token, err)
+		}
+	}
+	if got := listToolsCount.Load(); got != 2 {
+		t.Fatalf("ListTools count = %d, want 2 for two distinct tokens", got)
+	}
+}
+
+func TestUpstream_CatalogForRequestSingleflightsConcurrentDiscovery(t *testing.T) {
+	t.Parallel()
+
+	var listToolsCount atomic.Int32
+	firstListStarted := make(chan struct{})
+	releaseFirstList := make(chan struct{})
+	hooks := &mcpserver.Hooks{}
+	hooks.AddBeforeListTools(func(context.Context, any, *mcpgo.ListToolsRequest) {
+		if listToolsCount.Add(1) == 1 {
+			close(firstListStarted)
+			<-releaseFirstList
+		}
+	})
+	handler := mcpserver.NewStreamableHTTPServer(
+		newTestServer(mcpserver.WithHooks(hooks)),
+		mcpserver.WithStateLess(true),
+	)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	u, err := New(context.Background(), "clickhouse", ts.URL, core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := u.CatalogForRequest(context.Background(), "secret-token")
+		errs <- err
+	}()
+
+	<-firstListStarted
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := u.CatalogForRequest(context.Background(), "secret-token")
+		errs <- err
+	}()
+	time.Sleep(25 * time.Millisecond)
+	close(releaseFirstList)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("CatalogForRequest: %v", err)
+		}
+	}
+	if got := listToolsCount.Load(); got != 1 {
+		t.Fatalf("ListTools count = %d, want 1 for concurrent same-token discovery", got)
+	}
+}
+
+func TestUpstream_CatalogForRequestSingleflightIgnoresLeaderCancellation(t *testing.T) {
+	t.Parallel()
+
+	var listToolsCount atomic.Int32
+	firstListStarted := make(chan struct{})
+	releaseFirstList := make(chan struct{})
+	hooks := &mcpserver.Hooks{}
+	hooks.AddBeforeListTools(func(context.Context, any, *mcpgo.ListToolsRequest) {
+		if listToolsCount.Add(1) == 1 {
+			close(firstListStarted)
+			<-releaseFirstList
+		}
+	})
+	handler := mcpserver.NewStreamableHTTPServer(
+		newTestServer(mcpserver.WithHooks(hooks)),
+		mcpserver.WithStateLess(true),
+	)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	u, err := New(context.Background(), "clickhouse", ts.URL, core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderErr := make(chan error, 1)
+	go func() {
+		_, err := u.CatalogForRequest(leaderCtx, "secret-token")
+		leaderErr <- err
+	}()
+
+	<-firstListStarted
+	cancelLeader()
+	if err := <-leaderErr; !errors.Is(err, context.Canceled) {
+		t.Fatalf("leader error = %v, want context.Canceled", err)
+	}
+
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := u.CatalogForRequest(context.Background(), "secret-token")
+		waiterErr <- err
+	}()
+	time.Sleep(25 * time.Millisecond)
+	close(releaseFirstList)
+	if err := <-waiterErr; err != nil {
+		t.Fatalf("waiter CatalogForRequest: %v", err)
+	}
+	if got := listToolsCount.Load(); got != 1 {
+		t.Fatalf("ListTools count = %d, want 1 despite leader cancellation", got)
+	}
+}
+
+func TestUpstream_FilterOperationsClearsDynamicCatalogCache(t *testing.T) {
+	t.Parallel()
+
+	var listToolsCount atomic.Int32
+	ts := newCountingHTTPTestServer(t, &listToolsCount)
+	t.Cleanup(ts.Close)
+
+	u, err := New(context.Background(), "clickhouse", ts.URL, core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	full, err := u.CatalogForRequest(context.Background(), "secret-token")
+	if err != nil {
+		t.Fatalf("initial CatalogForRequest: %v", err)
+	}
+	if len(full.Operations) != 2 {
+		t.Fatalf("initial operations len = %d, want 2", len(full.Operations))
+	}
+
+	if err := u.FilterOperations(map[string]*config.OperationOverride{
+		"run_query": {Alias: "query"},
+	}); err != nil {
+		t.Fatalf("FilterOperations: %v", err)
+	}
+
+	filtered, err := u.CatalogForRequest(context.Background(), "secret-token")
+	if err != nil {
+		t.Fatalf("filtered CatalogForRequest: %v", err)
+	}
+	if got := listToolsCount.Load(); got != 2 {
+		t.Fatalf("ListTools count = %d, want 2 after filter invalidation", got)
+	}
+	if len(filtered.Operations) != 1 || filtered.Operations[0].ID != "query" {
+		t.Fatalf("filtered operations = %#v, want only aliased query", filtered.Operations)
+	}
+}
+
+func TestUpstream_FilterOperationsConcurrentWithCatalogAndCallTool(t *testing.T) {
+	t.Parallel()
+
+	var listToolsCount atomic.Int32
+	ts := newCountingHTTPTestServer(t, &listToolsCount)
+	t.Cleanup(ts.Close)
+
+	u, err := New(context.Background(), "clickhouse", ts.URL, core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 90)
+	for i := 0; i < 30; i++ {
+		wg.Add(3)
+		go func(i int) {
+			defer wg.Done()
+			allowed := map[string]*config.OperationOverride{"run_query": nil}
+			if i%2 == 0 {
+				allowed = map[string]*config.OperationOverride{"list_databases": nil}
+			}
+			if err := u.FilterOperations(allowed); err != nil {
+				errs <- err
+			}
+		}(i)
+		go func() {
+			defer wg.Done()
+			if _, err := u.CatalogForRequest(context.Background(), "secret-token"); err != nil {
+				errs <- err
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if _, err := u.CallTool(context.Background(), "run_query", map[string]any{"sql": "SELECT 1"}); err != nil && !strings.Contains(err.Error(), "not allowed") {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent operation failed: %v", err)
+	}
+}
+
+func TestUpstream_CallToolRemainsLiveAfterCatalogCache(t *testing.T) {
+	t.Parallel()
+
+	var (
+		listToolsCount atomic.Int32
+		callToolCount  atomic.Int32
+	)
+	hooks := &mcpserver.Hooks{}
+	hooks.AddBeforeListTools(func(context.Context, any, *mcpgo.ListToolsRequest) {
+		listToolsCount.Add(1)
+	})
+	srv := mcpserver.NewMCPServer("live-tool-test", "1.0.0", mcpserver.WithHooks(hooks))
+	srv.AddTool(
+		mcpgo.NewTool("run_query", mcpgo.WithDescription("Execute a SQL query")),
+		func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			return mcpgo.NewToolResultText(fmt.Sprintf("call-%d", callToolCount.Add(1))), nil
+		},
+	)
+	handler := mcpserver.NewStreamableHTTPServer(srv, mcpserver.WithStateLess(true))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	u, err := New(context.Background(), "clickhouse", ts.URL, core.ConnectionModeUser, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := u.CatalogForRequest(context.Background(), "secret-token"); err != nil {
+		t.Fatalf("first CatalogForRequest: %v", err)
+	}
+	if _, err := u.CatalogForRequest(context.Background(), "secret-token"); err != nil {
+		t.Fatalf("second CatalogForRequest: %v", err)
+	}
+	if got := listToolsCount.Load(); got != 1 {
+		t.Fatalf("ListTools count = %d, want cached catalog discovery", got)
+	}
+
+	for i, want := range []string{"call-1", "call-2"} {
+		result, err := u.CallTool(context.Background(), "run_query", nil)
+		if err != nil {
+			t.Fatalf("CallTool #%d: %v", i+1, err)
+		}
+		if result.IsError {
+			t.Fatalf("CallTool #%d returned tool error: %v", i+1, result.Content)
+		}
+		text, ok := result.Content[0].(mcpgo.TextContent)
+		if !ok {
+			t.Fatalf("CallTool #%d content = %T, want TextContent", i+1, result.Content[0])
+		}
+		if text.Text != want {
+			t.Fatalf("CallTool #%d text = %q, want %q", i+1, text.Text, want)
+		}
+	}
+	if got := callToolCount.Load(); got != 2 {
+		t.Fatalf("CallTool count = %d, want 2 live calls", got)
 	}
 }
 

--- a/gestaltd/internal/observability/observability.go
+++ b/gestaltd/internal/observability/observability.go
@@ -26,6 +26,7 @@ var (
 	AttrCredentialProvider     = attribute.Key("gestalt.credential.provider")
 	AttrCredentialOperation    = attribute.Key("gestalt.credential.operation")
 	AttrCatalogSource          = attribute.Key("gestalt.catalog.source")
+	AttrMCPCatalogCacheResult  = attribute.Key("gestalt.mcp.catalog.cache.result")
 )
 
 type metricSet struct {
@@ -57,6 +58,9 @@ var (
 	authorizationProviderEvaluateMetrics metricutil.MeterCache[metricSet]
 	catalogOperationResolveMetrics       metricutil.MeterCache[metricSet]
 	credentialProviderOperationMetrics   metricutil.MeterCache[metricSet]
+	mcpCatalogCacheHitMetrics            metricutil.MeterCache[countMetricSet]
+	mcpCatalogCacheMissMetrics           metricutil.MeterCache[countMetricSet]
+	mcpCatalogDiscoverMetrics            metricutil.MeterCache[metricSet]
 )
 
 func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
@@ -157,6 +161,18 @@ func RecordCatalogOperationResolve(ctx context.Context, startedAt time.Time, fai
 
 func RecordCredentialProviderOperation(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
 	record(ctx, &credentialProviderOperationMetrics, "gestaltd.credential.provider.operation", "gestaltd credential provider operations", startedAt, failed, attrs...)
+}
+
+func RecordMCPCatalogCacheHit(ctx context.Context, attrs ...attribute.KeyValue) {
+	recordCount(ctx, &mcpCatalogCacheHitMetrics, "gestaltd.mcp.catalog.cache.hit", "gestaltd MCP catalog cache hits", false, attrs...)
+}
+
+func RecordMCPCatalogCacheMiss(ctx context.Context, attrs ...attribute.KeyValue) {
+	recordCount(ctx, &mcpCatalogCacheMissMetrics, "gestaltd.mcp.catalog.cache.miss", "gestaltd MCP catalog cache misses", false, attrs...)
+}
+
+func RecordMCPCatalogDiscover(ctx context.Context, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {
+	record(ctx, &mcpCatalogDiscoverMetrics, "gestaltd.mcp.catalog.discover", "gestaltd MCP catalog discoveries", startedAt, failed, attrs...)
 }
 
 func record(ctx context.Context, cache *metricutil.MeterCache[metricSet], prefix, desc string, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {


### PR DESCRIPTION
## Summary

Adds a short-lived cache around dynamic MCP catalog discovery so repeated native tool searches do not reconnect, initialize MCP, and list tools for the same upstream/token on every search.

## Interfaces / Behavior

No public API or proto changes.

Internal behavior is now:

```go
// Same upstream + same token hash: second call reuses the discovered catalog.
cat1, _ := upstream.CatalogForRequest(ctx, "user-token")
cat2, _ := upstream.CatalogForRequest(ctx, "user-token")

// Different token: separate cache entry and separate discovery.
cat3, _ := upstream.CatalogForRequest(ctx, "other-token")
```

- Cache TTL: 5 minutes.
- Max entries per upstream: 128.
- Cache key: token SHA-256 hash, or explicit no-token key. Raw tokens are never stored in cache keys.
- Concurrent same-token cache misses are singleflighted so only one MCP list-tools discovery runs.
- Shared discovery is decoupled from the leader request cancellation; each caller's context still controls how long that caller waits.
- Exposure policy is published through an atomic snapshot, static catalogs are protected by a lock, and policy changes increment a cache generation so in-flight discoveries cannot repopulate stale cache entries.
- Cached catalogs are cloned on store/load so callers cannot mutate cached state.
- `CallTool` remains live passthrough and is not cached.

## Observability

Adds low-cardinality metrics:

- `gestaltd.mcp.catalog.cache.hit.count`
- `gestaltd.mcp.catalog.cache.miss.count`
- `gestaltd.mcp.catalog.discover.duration`

Attributes include provider name and cache result where applicable; no token, query, or user data is recorded.

## Validation

- `go test ./internal/mcpupstream ./internal/observability -count=1`
- `go test -race ./internal/mcpupstream -count=1`
- `go test ./internal/mcpupstream ./internal/agentmanager ./internal/bootstrap ./internal/observability -count=1`
- `golangci-lint run ./internal/mcpupstream ./internal/observability`