### PR TITLE
operator: retry transient provider package fetches

### DIFF
--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -38,9 +38,10 @@ const (
 )
 
 var providerReleaseFetchRetryDelays = []time.Duration{
-	200 * time.Millisecond,
-	500 * time.Millisecond,
 	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
 }
 
 type gitHubReleaseLocation struct {

--- a/gestaltd/internal/providerpkg/fetch.go
+++ b/gestaltd/internal/providerpkg/fetch.go
@@ -8,9 +8,17 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 )
 
 const MaxPackageBytes = 512 << 20 // 512 MB
+
+var packageFetchRetryDelays = []time.Duration{
+	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+}
 
 type DownloadResult struct {
 	LocalPath string
@@ -19,19 +27,44 @@ type DownloadResult struct {
 }
 
 func DownloadRequest(client *http.Client, req *http.Request) (*DownloadResult, error) {
-	resp, err := client.Do(req)
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if req == nil {
+		return nil, fmt.Errorf("request is required")
+	}
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		result, retry, err := downloadRequestOnce(client, req)
+		if !retry {
+			return result, err
+		}
+		lastErr = err
+		if attempt >= len(packageFetchRetryDelays) {
+			return nil, lastErr
+		}
+		if err := waitPackageFetchRetry(req.Context(), packageFetchRetryDelays[attempt]); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func downloadRequestOnce(client *http.Client, req *http.Request) (*DownloadResult, bool, error) {
+	attemptReq := req.Clone(req.Context())
+	resp, err := client.Do(attemptReq)
 	if err != nil {
-		return nil, fmt.Errorf("execute request: %w", err)
+		return nil, true, fmt.Errorf("execute request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, req.URL)
+		err := fmt.Errorf("unexpected status %d from %s", resp.StatusCode, req.URL)
+		return nil, isTransientPackageFetchHTTPStatus(resp.StatusCode), err
 	}
 
 	tmp, err := createPackageTempFile("gestalt-plugin-*.tar.gz")
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	tmpPath := tmp.Name()
 	removeTmp := func() { _ = os.Remove(tmpPath) }
@@ -41,28 +74,49 @@ func DownloadRequest(client *http.Client, req *http.Request) (*DownloadResult, e
 	if _, err := io.Copy(w, io.LimitReader(resp.Body, MaxPackageBytes+1)); err != nil {
 		_ = tmp.Close()
 		removeTmp()
-		return nil, fmt.Errorf("download body: %w", err)
+		return nil, true, fmt.Errorf("download body: %w", err)
 	}
 	info, err := tmp.Stat()
 	if err != nil {
 		_ = tmp.Close()
 		removeTmp()
-		return nil, fmt.Errorf("stat temp file: %w", err)
+		return nil, false, fmt.Errorf("stat temp file: %w", err)
 	}
 	if info.Size() > MaxPackageBytes {
 		_ = tmp.Close()
 		removeTmp()
-		return nil, fmt.Errorf("download exceeds %d byte limit", MaxPackageBytes)
+		return nil, false, fmt.Errorf("download exceeds %d byte limit", MaxPackageBytes)
 	}
 	if err := tmp.Close(); err != nil {
 		removeTmp()
-		return nil, fmt.Errorf("close temp file: %w", err)
+		return nil, false, fmt.Errorf("close temp file: %w", err)
 	}
 	return &DownloadResult{
 		LocalPath: tmpPath,
 		Cleanup:   removeTmp,
 		SHA256Hex: hex.EncodeToString(h.Sum(nil)),
-	}, nil
+	}, false, nil
+}
+
+func waitPackageFetchRetry(ctx context.Context, delay time.Duration) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func isTransientPackageFetchHTTPStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
 }
 
 func FetchPackage(ctx context.Context, url string) (localPath string, cleanup func(), err error) {


### PR DESCRIPTION
## Summary
- Retries transient provider archive download failures (`429` and `5xx`) in `providerpkg.DownloadRequest`.
- Extends the existing provider release metadata retry window so short GitHub release outages do not fail `gestaltd init` / Cloud Run startup immediately.
- Keeps deterministic failures like `404` non-retried, so bad config pins still fail fast.

## Why
The toolshed Cloud Run deploy failed during `gestaltd init` because provider release fetches from GitHub returned transient `502`s. After fixing an unpublished GitHub provider version in toolshed, local init still hit different release assets with `502`, so the fetch path needs to tolerate short upstream release/CDN failures.

## Interface / Usage
No public interface change. Existing config continues to use provider release metadata and archive URLs:

```yaml
plugins:
  google_sheets:
    source: https://github.com/valon-technologies/gestalt-providers/releases/download/plugins/google_sheets/v0.0.1-alpha.1/provider-release.yaml
```

The behavior change is in the fetch contract:

```diff
- DownloadRequest(client, req) fails immediately on 429/5xx or transient read errors.
+ DownloadRequest(client, req) retries transient request/status/body failures with backoff.
+ DownloadRequest(client, req) still fails immediately on deterministic statuses like 404.
```

## Verification
- `go test ./internal/providerpkg ./internal/operator`
- Built patched `gestaltd` locally and ran `gestaltd init` against the full `toolshed/valon-tools` deploy config stack with `--platform linux/amd64`; it prepared all locked artifacts successfully.