### PR TITLE
[codex] Start hosted runtime replacements before drain

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -652,6 +652,8 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 
 	bin := buildAgentProviderBinary(t)
 	runtimeProvider := newCapturingPluginRuntime()
+	var drainMu sync.Mutex
+	var firstDrainAt time.Time
 	runtimeProvider.lifecycleForSession = func(index int) *pluginruntime.SessionLifecycle {
 		startedAt := time.Now().UTC()
 		expiresAt := startedAt.Add(time.Hour)
@@ -660,8 +662,11 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 			ExpiresAt: &expiresAt,
 		}
 		if index == 1 {
-			recommendedDrainAt := startedAt.Add(75 * time.Millisecond)
+			recommendedDrainAt := startedAt.Add(500 * time.Millisecond)
 			lifecycle.RecommendedDrainAt = &recommendedDrainAt
+			drainMu.Lock()
+			firstDrainAt = recommendedDrainAt
+			drainMu.Unlock()
 		}
 		return lifecycle
 	}
@@ -670,6 +675,7 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 		return runtimeProvider, nil
 	}
 	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.Pool.MaxReadyInstances = 2
 	runtimeConfig.Pool.HealthCheckInterval = "25ms"
 	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
 	cfg := &config.Config{
@@ -717,6 +723,19 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 		ready := pool.readyBackends()
 		return len(runtimeProvider.startSessionRequests()) >= 2 && len(ready) == 1 && ready[0] != first
 	})
+	startTimes := runtimeProvider.startSessionTimes()
+	if len(startTimes) < 2 {
+		t.Fatalf("start session times = %d, want at least 2", len(startTimes))
+	}
+	drainMu.Lock()
+	drainAt := firstDrainAt
+	drainMu.Unlock()
+	if drainAt.IsZero() {
+		t.Fatal("first runtime drain deadline was not captured")
+	}
+	if !startTimes[1].Before(drainAt) {
+		t.Fatalf("replacement started at %s, want before first runtime drain deadline %s", startTimes[1].Format(time.RFC3339Nano), drainAt.Format(time.RFC3339Nano))
+	}
 	pool.mu.Lock()
 	firstRetired := first.draining || first.closed
 	pool.mu.Unlock()
@@ -732,6 +751,202 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 	}
 	if session == nil || session.ID != "session-after-runtime-drain" {
 		t.Fatalf("CreateSession(after runtime drain) = %#v, want session-after-runtime-drain", session)
+	}
+}
+
+//nolint:paralleltest // Uses short lifecycle timing assertions that are flaky under parallel package load.
+func TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartFails(t *testing.T) {
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	runtimeProvider.lifecycleForSession = func(index int) *pluginruntime.SessionLifecycle {
+		startedAt := time.Now().UTC()
+		expiresAt := startedAt.Add(time.Hour)
+		lifecycle := &pluginruntime.SessionLifecycle{
+			StartedAt: &startedAt,
+			ExpiresAt: &expiresAt,
+		}
+		if index == 1 {
+			recommendedDrainAt := startedAt.Add(3 * time.Second)
+			lifecycle.RecommendedDrainAt = &recommendedDrainAt
+		}
+		return lifecycle
+	}
+	runtimeProvider.startErrForSession = func(index int) error {
+		if index > 1 {
+			return errors.New("replacement start failed")
+		}
+		return nil
+	}
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.Pool.MaxReadyInstances = 2
+	runtimeConfig.Pool.StartupTimeout = "5s"
+	runtimeConfig.Pool.HealthCheckInterval = "25ms"
+	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command:   bin,
+					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+				},
+			},
+		},
+	}
+	deps := Deps{
+		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:         map[string]*config.ProviderEntry{"agent_state": {}},
+		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+
+	pool := hostedAgentProviderPoolForTest(t, agents[0])
+	backends := pool.readyBackends()
+	if len(backends) != 1 {
+		t.Fatalf("ready backends = %d, want 1", len(backends))
+	}
+	first := backends[0]
+	waitForAgentRuntimeCondition(t, 2*time.Second, func() bool {
+		pool.mu.Lock()
+		defer pool.mu.Unlock()
+		return len(runtimeProvider.startSessionRequests()) >= 2 && !first.replacing
+	})
+	pool.mu.Lock()
+	acceptsNewWork := pool.backendAcceptsNewWorkLocked(first, time.Now().UTC())
+	firstDraining := first.draining
+	pool.mu.Unlock()
+	if !acceptsNewWork || firstDraining {
+		t.Fatalf("first backend acceptsNewWork=%v draining=%v, want serving after failed proactive replacement", acceptsNewWork, firstDraining)
+	}
+	session, err := agents[0].CreateSession(context.Background(), coreagent.CreateSessionRequest{
+		SessionID: "session-after-failed-proactive-replacement",
+		Model:     "gpt-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession(after failed proactive replacement): %v", err)
+	}
+	if session == nil || session.ID != "session-after-failed-proactive-replacement" {
+		t.Fatalf("CreateSession(after failed proactive replacement) = %#v, want session", session)
+	}
+	if backend := pool.sessionBackend("session-after-failed-proactive-replacement"); backend != first {
+		t.Fatalf("session backend = %#v, want first backend after failed proactive replacement", backend)
+	}
+}
+
+//nolint:paralleltest // Uses short lifecycle timing assertions that are flaky under parallel package load.
+func TestAgentRuntimeConfigProactiveReplacementRespectsMaxReadyInstances(t *testing.T) {
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	releaseReplacement := make(chan struct{})
+	replacementStarted := make(chan struct{})
+	var replacementStartedOnce sync.Once
+	runtimeProvider.lifecycleForSession = func(index int) *pluginruntime.SessionLifecycle {
+		startedAt := time.Now().UTC()
+		expiresAt := startedAt.Add(time.Hour)
+		lifecycle := &pluginruntime.SessionLifecycle{
+			StartedAt: &startedAt,
+			ExpiresAt: &expiresAt,
+		}
+		if index <= 2 {
+			recommendedDrainAt := startedAt.Add(500 * time.Millisecond)
+			lifecycle.RecommendedDrainAt = &recommendedDrainAt
+		}
+		return lifecycle
+	}
+	runtimeProvider.startErrForSession = func(index int) error {
+		if index <= 2 {
+			return nil
+		}
+		replacementStartedOnce.Do(func() {
+			close(replacementStarted)
+		})
+		<-releaseReplacement
+		return nil
+	}
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.Pool.MinReadyInstances = 2
+	runtimeConfig.Pool.MaxReadyInstances = 3
+	runtimeConfig.Pool.HealthCheckInterval = "25ms"
+	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command:   bin,
+					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
+					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+				},
+			},
+		},
+	}
+	deps := Deps{
+		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:         map[string]*config.ProviderEntry{"agent_state": {}},
+		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		close(releaseReplacement)
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+
+	pool := hostedAgentProviderPoolForTest(t, agents[0])
+	if ready := pool.readyBackends(); len(ready) != 2 {
+		t.Fatalf("ready backends = %d, want 2", len(ready))
+	}
+	select {
+	case <-replacementStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("proactive replacement did not start")
+	}
+	time.Sleep(150 * time.Millisecond)
+	if got := len(runtimeProvider.startSessionRequests()); got != 3 {
+		t.Fatalf("start session requests while one replacement is starting = %d, want 3", got)
+	}
+	pool.mu.Lock()
+	_, starting, _ := pool.instanceCountsLocked()
+	pool.mu.Unlock()
+	if starting != 1 {
+		t.Fatalf("starting instances = %d, want 1", starting)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -200,6 +200,7 @@ type capturingPluginRuntime struct {
 	bindRequests        []pluginruntime.BindHostServiceRequest
 	sessionLifecycles   map[string]*pluginruntime.SessionLifecycle
 	lifecycleForSession func(index int) *pluginruntime.SessionLifecycle
+	startErrForSession  func(index int) error
 	stopCount           atomic.Int32
 }
 
@@ -223,7 +224,13 @@ func (r *capturingPluginRuntime) StartSession(ctx context.Context, req pluginrun
 	r.startTimes = append(r.startTimes, time.Now().UTC())
 	index := len(r.startRequests)
 	lifecycleForSession := r.lifecycleForSession
+	startErrForSession := r.startErrForSession
 	r.mu.Unlock()
+	if startErrForSession != nil {
+		if err := startErrForSession(index); err != nil {
+			return nil, err
+		}
+	}
 	session, err := r.provider.StartSession(ctx, req)
 	if err != nil {
 		return nil, err

--- a/gestaltd/internal/bootstrap/hosted_agent_pool.go
+++ b/gestaltd/internal/bootstrap/hosted_agent_pool.go
@@ -49,11 +49,13 @@ type hostedAgentPoolBackend struct {
 	runtimeProvider  pluginruntime.Provider
 	runtimeSessionID string
 	runtimeSession   *pluginruntime.Session
+	startedAt        time.Time
 	runtimeDrainAt   *time.Time
 	forceCloseAt     *time.Time
 	active           int
 	liveTurns        map[string]struct{}
 	draining         bool
+	replacing        bool
 	closing          bool
 	closed           bool
 }
@@ -1157,6 +1159,10 @@ func (p *hostedAgentProviderPool) healthLoop() {
 			if err := p.pingBackend(backend); err != nil {
 				slog.Warn("hosted agent runtime instance failed health check", "provider", p.name, "instance", backend.id, "error", err)
 				p.replaceBackend(backend)
+				continue
+			}
+			if reason := p.runtimeSessionProactiveReplacementReason(backend, session, drainAt, time.Now().UTC()); reason != "" {
+				p.startProactiveReplacement(backend, reason)
 			}
 		}
 	}
@@ -1212,6 +1218,48 @@ func (p *hostedAgentProviderPool) runtimeSessionRetirementReason(session *plugin
 		return fmt.Sprintf("runtime session expired at %s", expiresAt.Format(time.RFC3339Nano))
 	}
 	return fmt.Sprintf("runtime session reached drain deadline %s", drainAt.Format(time.RFC3339Nano))
+}
+
+func (p *hostedAgentProviderPool) runtimeSessionProactiveReplacementReason(backend *hostedAgentPoolBackend, session *pluginruntime.Session, drainAt *time.Time, now time.Time) string {
+	if session == nil {
+		return ""
+	}
+	switch session.State {
+	case pluginruntime.SessionStateFailed, pluginruntime.SessionStateStopped:
+		return ""
+	}
+	if drainAt == nil {
+		return ""
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	drainDeadline := drainAt.UTC()
+	if !now.Before(drainDeadline) {
+		return ""
+	}
+	startAt := drainDeadline.Add(-p.runtimeSessionReplacementLeadTime())
+	if backend != nil && !backend.startedAt.IsZero() && backend.startedAt.Before(drainDeadline) {
+		minStartAt := backend.startedAt.UTC().Add(drainDeadline.Sub(backend.startedAt.UTC()) / 2)
+		if startAt.Before(minStartAt) {
+			startAt = minStartAt
+		}
+	}
+	if now.Before(startAt) {
+		return ""
+	}
+	return fmt.Sprintf("runtime session approaching drain deadline %s", drainDeadline.Format(time.RFC3339Nano))
+}
+
+func (p *hostedAgentProviderPool) runtimeSessionReplacementLeadTime() time.Duration {
+	lead := p.policy.StartupTimeout + p.policy.HealthCheckInterval
+	if lead <= 0 {
+		lead = p.policy.HealthCheckInterval
+	}
+	if lead <= 0 {
+		return time.Second
+	}
+	return lead
 }
 
 func (p *hostedAgentProviderPool) runtimeSessionDrainAt(session *pluginruntime.Session, now time.Time) *time.Time {
@@ -1320,6 +1368,50 @@ func (p *hostedAgentProviderPool) replaceBackend(backend *hostedAgentPoolBackend
 	}()
 }
 
+func (p *hostedAgentProviderPool) startProactiveReplacement(backend *hostedAgentPoolBackend, reason string) {
+	if backend == nil || p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever {
+		return
+	}
+	p.mu.Lock()
+	if p.closed || backend.draining || backend.closing || backend.closed || backend.replacing || !p.backendAvailableLocked(backend, false) || !p.canScaleOutLocked() {
+		p.mu.Unlock()
+		return
+	}
+	backend.replacing = true
+	p.starting++
+	ready, starting, draining := p.instanceCountsLocked()
+	p.lifecycleWG.Add(1)
+	p.mu.Unlock()
+	p.recordInstanceCounts(p.ctx, ready, starting, draining)
+
+	go func() {
+		defer p.lifecycleWG.Done()
+		slog.Info("starting proactive hosted agent runtime replacement", "provider", p.name, "instance", backend.id, "reason", reason)
+		_, startErr := p.startBackend(p.ctx)
+		recordHostedAgentRuntimeReplacement(p.ctx, p.name, startErr)
+		p.mu.Lock()
+		p.starting--
+		if p.backendAvailableLocked(backend, true) {
+			if startErr == nil {
+				backend.draining = true
+			}
+			backend.replacing = false
+		}
+		ready, starting, draining := p.instanceCountsLocked()
+		p.mu.Unlock()
+		p.recordInstanceCounts(p.ctx, ready, starting, draining)
+		if startErr != nil {
+			if !errors.Is(startErr, context.Canceled) {
+				slog.Warn("failed to proactively replace hosted agent runtime instance", "provider", p.name, "instance", backend.id, "error", startErr)
+			}
+			return
+		}
+		if err := p.drainAndCloseBackend(backend); err != nil {
+			slog.Warn("failed to close proactively replaced hosted agent runtime instance", "provider", p.name, "instance", backend.id, "error", err)
+		}
+	}()
+}
+
 func (p *hostedAgentProviderPool) addLifecycleWork() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -1380,13 +1472,15 @@ func (p *hostedAgentProviderPool) startBackend(ctx context.Context) (*hostedAgen
 		return nil, fmt.Errorf("hosted agent provider %q is closed", p.name)
 	}
 	p.nextID++
+	now := time.Now().UTC()
 	backend := &hostedAgentPoolBackend{
 		id:               p.nextID,
 		provider:         instance.provider,
 		runtimeProvider:  instance.runtimeProvider,
 		runtimeSessionID: instance.runtimeSessionID,
 		runtimeSession:   instance.runtimeSession,
-		runtimeDrainAt:   p.runtimeSessionDrainAt(instance.runtimeSession, time.Now().UTC()),
+		startedAt:        now,
+		runtimeDrainAt:   p.runtimeSessionDrainAt(instance.runtimeSession, now),
 		forceCloseAt:     runtimeSessionExpiresAt(instance.runtimeSession),
 		liveTurns:        map[string]struct{}{},
 	}


### PR DESCRIPTION
## Summary

Starts healthy hosted agent runtime replacements before their runtime drain deadline, so lifecycle retirement does not remove a ready backend before a replacement has been started.

## Interfaces / Behavior

No public API, proto, provider, or config schema changes.

New internal behavior:

```go
// Healthy runtime with a future runtimeDrainAt and configured pool headroom:
// 1. keep old backend accepting new work
// 2. start one proactive replacement before runtimeDrainAt
// 3. mark the old backend draining under the pool lock after replacement starts
// 4. drain and close the old backend
pool.healthLoop()
```

- Proactive replacement respects `maxReadyInstances`; configure headroom, such as `minReadyInstances: 2` and `maxReadyInstances: 3`, to allow one replacement while preserving the cap.
- Successful proactive start marks the old backend draining under the pool lock before clearing the replacement-in-flight state, preventing duplicate replacement starts.
- Failed/stopped runtime sessions still use the existing immediate drain-and-replace path.
- Health-check failures still use the existing immediate drain-and-replace path.
- A proactive replacement is counted as `starting`, so concurrent min-ready maintenance does not duplicate the start.
- A failed proactive start clears the backend's replacement flag and leaves the old healthy backend serving until the next retry or the actual drain deadline.
- The replacement lead uses `startupTimeout + healthCheckInterval`, capped against the backend's observed lifetime window so short-lived runtimes do not churn immediately.

## Example

```yaml
pool:
  minReadyInstances: 2
  maxReadyInstances: 3
```

With two ready backends approaching `runtimeDrainAt`, only one proactive replacement can be in flight at a time. The other backend remains ready, and the pool stays within the configured max.

## Validation

- `go test ./internal/bootstrap -count=1`
- `go test -race ./internal/bootstrap -run 'TestAgentRuntimeConfig(ProactiveReplacementRespectsMaxReadyInstances|ReplacesHostedAgentBeforeRuntimeDrainDeadline|KeepsHostedAgentServingWhenProactiveReplacementStartFails|RestartsUnhealthyHostedAgent|ReplacesExpiresOnlyRuntimeBeforeExpiry|DoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntimeLifetime)' -count=1`
- `golangci-lint run ./internal/bootstrap`
- `git diff --check`