### PR TITLE
Simplify provider-dev attach routes

### DIFF
--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -256,9 +256,6 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	}
 	attachID := strings.TrimSpace(session.AttachID)
 	if attachID == "" {
-		attachID = strings.TrimSpace(session.ID)
-	}
-	if attachID == "" {
 		return fmt.Errorf("remote provider dev did not return attachId")
 	}
 	defer func() { _ = client.CloseSession(context.Background(), attachID) }()

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -44,7 +44,6 @@ const (
 
 	PathAttachments          = "/api/v1/provider-dev/attachments"
 	PathAttachAuthorizations = "/api/v1/provider-dev/attach-authorizations"
-	PathSessions             = "/api/v1/provider-dev/sessions"
 )
 
 type RuntimeEnv struct {
@@ -87,7 +86,6 @@ type AttachProvider struct {
 }
 
 type CreateSessionResponse struct {
-	ID               string                  `json:"id,omitempty"`
 	AttachID         string                  `json:"attachId,omitempty"`
 	DispatcherSecret string                  `json:"dispatcherSecret,omitempty"`
 	Providers        []CreateSessionProvider `json:"providers"`
@@ -303,7 +301,6 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 		lastSeen:             now,
 	}
 	resp := &CreateSessionResponse{
-		ID:               sessionID,
 		AttachID:         sessionID,
 		DispatcherSecret: dispatcherSecret,
 		Providers:        make([]CreateSessionProvider, 0, len(targets)),
@@ -350,17 +347,6 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 func (m *Manager) PollSession(ctx context.Context, p *principal.Principal, sessionID string) (*PollResponse, bool, error) {
 	session, err := m.sessionForPrincipal(p, sessionID)
 	if err != nil {
-		return nil, false, err
-	}
-	return session.poll(ctx)
-}
-
-func (m *Manager) PollSessionWithDispatcherSecret(ctx context.Context, p *principal.Principal, sessionID, dispatcherSecret string) (*PollResponse, bool, error) {
-	session, err := m.sessionForPrincipal(p, sessionID)
-	if err != nil {
-		return nil, false, err
-	}
-	if err := session.verifyDispatcherSecret(dispatcherSecret); err != nil {
 		return nil, false, err
 	}
 	return session.poll(ctx)
@@ -638,31 +624,12 @@ func (m *Manager) CompleteCall(p *principal.Principal, sessionID, callID string,
 	return session.completeCall(callID, req)
 }
 
-func (m *Manager) CompleteCallWithDispatcherSecret(p *principal.Principal, sessionID, callID, dispatcherSecret string, req CompleteCallRequest) error {
-	session, err := m.sessionForPrincipal(p, sessionID)
-	if err != nil {
-		return err
-	}
-	if err := session.verifyDispatcherSecret(dispatcherSecret); err != nil {
-		return err
-	}
-	return session.completeCall(callID, req)
-}
-
 func (m *Manager) CompleteCallWithDispatcherSecretOnly(sessionID, callID, dispatcherSecret string, req CompleteCallRequest) error {
 	session, err := m.sessionForDispatcherSecret(sessionID, dispatcherSecret)
 	if err != nil {
 		return err
 	}
 	return session.completeCall(callID, req)
-}
-
-func (m *Manager) VerifyDispatcherSecret(p *principal.Principal, sessionID, dispatcherSecret string) error {
-	session, err := m.sessionForPrincipal(p, sessionID)
-	if err != nil {
-		return err
-	}
-	return session.verifyDispatcherSecret(dispatcherSecret)
 }
 
 func (m *Manager) VerifyDispatcherSecretOnly(sessionID, dispatcherSecret string) error {

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -115,7 +115,7 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	defer dispatchCancel()
 	dispatchDone := make(chan error, 1)
 	go func() {
-		dispatchDone <- client.RunDispatcher(dispatchCtx, session.ID, map[string]proto.IntegrationProviderClient{
+		dispatchDone <- client.RunDispatcher(dispatchCtx, session.AttachID, map[string]proto.IntegrationProviderClient{
 			"roadmap": local,
 		}, WithUIHandlers(map[string]http.Handler{"roadmap": localUI}))
 	}()
@@ -353,10 +353,10 @@ func TestHTTPTransportCreateSessionExplicitConfigOverridesRemoteConfig(t *testin
 	}
 
 	manager.mu.RLock()
-	session := manager.sessions[resp.ID]
+	session := manager.sessions[resp.AttachID]
 	manager.mu.RUnlock()
 	if session == nil {
-		t.Fatalf("session %q was not recorded", resp.ID)
+		t.Fatalf("session %q was not recorded", resp.AttachID)
 	}
 	target := session.targets["roadmap"]
 	if target == nil {
@@ -390,7 +390,7 @@ func TestHTTPTransportRequiresDispatcherSecretForDispatcherTraffic(t *testing.T)
 		t.Fatal("DispatcherSecret is empty")
 	}
 
-	pollReq, err := http.NewRequest(http.MethodGet, ts.URL+PathAttachments+"/"+session.ID+"/poll", nil)
+	pollReq, err := http.NewRequest(http.MethodGet, ts.URL+PathAttachments+"/"+session.AttachID+"/poll", nil)
 	if err != nil {
 		t.Fatalf("build poll request: %v", err)
 	}
@@ -403,7 +403,7 @@ func TestHTTPTransportRequiresDispatcherSecretForDispatcherTraffic(t *testing.T)
 		t.Fatalf("poll status = %d, want 401", pollResp.StatusCode)
 	}
 
-	completeReq, err := http.NewRequest(http.MethodPost, ts.URL+PathAttachments+"/"+session.ID+"/calls/call-1", strings.NewReader(`{}`))
+	completeReq, err := http.NewRequest(http.MethodPost, ts.URL+PathAttachments+"/"+session.AttachID+"/calls/call-1", strings.NewReader(`{}`))
 	if err != nil {
 		t.Fatalf("build complete request: %v", err)
 	}
@@ -417,7 +417,7 @@ func TestHTTPTransportRequiresDispatcherSecretForDispatcherTraffic(t *testing.T)
 		t.Fatalf("complete status = %d, want 401", completeResp.StatusCode)
 	}
 
-	closeReq, err := http.NewRequest(http.MethodDelete, ts.URL+PathAttachments+"/"+session.ID, nil)
+	closeReq, err := http.NewRequest(http.MethodDelete, ts.URL+PathAttachments+"/"+session.AttachID, nil)
 	if err != nil {
 		t.Fatalf("build close request: %v", err)
 	}
@@ -481,7 +481,7 @@ func TestHTTPTransportListsRedactedAttachmentMetadata(t *testing.T) {
 		t.Fatalf("CreateSession: %v", err)
 	}
 
-	for _, path := range []string{PathAttachments, PathAttachments + "/" + session.ID} {
+	for _, path := range []string{PathAttachments, PathAttachments + "/" + session.AttachID} {
 		resp, err := ts.Client().Get(ts.URL + path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
@@ -500,8 +500,8 @@ func TestHTTPTransportListsRedactedAttachmentMetadata(t *testing.T) {
 				t.Fatalf("GET %s leaked %q in %s", path, forbidden, body)
 			}
 		}
-		if !strings.Contains(body, `"attachId":"`+session.ID+`"`) {
-			t.Fatalf("GET %s body missing attachId %q: %s", path, session.ID, body)
+		if !strings.Contains(body, `"attachId":"`+session.AttachID+`"`) {
+			t.Fatalf("GET %s body missing attachId %q: %s", path, session.AttachID, body)
 		}
 	}
 }
@@ -653,7 +653,6 @@ func providerDevTestHandler(t *testing.T, manager *Manager, p *principal.Princip
 		}
 		writeProviderDevTestJSON(w, http.StatusCreated, resp)
 	}
-	mux.HandleFunc(PathSessions, handleCreate)
 	mux.HandleFunc(PathAttachments, func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPost:
@@ -685,7 +684,7 @@ func providerDevTestHandler(t *testing.T, manager *Manager, p *principal.Princip
 			if len(parts) == 2 && parts[1] == "poll" && r.Method == http.MethodGet {
 				ctx, cancel := context.WithTimeout(r.Context(), DefaultPollTimeout)
 				defer cancel()
-				resp, ok, err := manager.PollSessionWithDispatcherSecret(ctx, p, parts[0], r.Header.Get(HeaderDispatcherSecret))
+				resp, ok, err := manager.PollSessionWithDispatcherSecretOnly(ctx, parts[0], r.Header.Get(HeaderDispatcherSecret))
 				if err != nil {
 					writeProviderDevTestError(w, err)
 					return
@@ -703,7 +702,7 @@ func providerDevTestHandler(t *testing.T, manager *Manager, p *principal.Princip
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return
 				}
-				if err := manager.CompleteCallWithDispatcherSecret(p, parts[0], parts[2], r.Header.Get(HeaderDispatcherSecret), req); err != nil {
+				if err := manager.CompleteCallWithDispatcherSecretOnly(parts[0], parts[2], r.Header.Get(HeaderDispatcherSecret), req); err != nil {
 					writeProviderDevTestError(w, err)
 					return
 				}
@@ -721,7 +720,6 @@ func providerDevTestHandler(t *testing.T, manager *Manager, p *principal.Princip
 			http.NotFound(w, r)
 		}
 	}
-	mux.HandleFunc(PathSessions+"/", handleAttachment(PathSessions))
 	mux.HandleFunc(PathAttachments+"/", handleAttachment(PathAttachments))
 	return mux
 }

--- a/gestaltd/internal/server/handlers_provider_dev.go
+++ b/gestaltd/internal/server/handlers_provider_dev.go
@@ -284,25 +284,6 @@ func (s *Server) resolvePublicURLPreserveBasePath(r *http.Request, raw string) (
 	return baseURL.String(), nil
 }
 
-func (s *Server) pollProviderDevSession(w http.ResponseWriter, r *http.Request) {
-	if !s.providerDevAvailable(w) {
-		return
-	}
-	sessionID := providerDevAttachmentID(r)
-	ctx, cancel := context.WithTimeout(r.Context(), providerdev.DefaultPollTimeout)
-	defer cancel()
-	resp, ok, err := s.providerDevSessions.PollSessionWithDispatcherSecret(ctx, PrincipalFromContext(r.Context()), sessionID, providerDevDispatcherSecret(r))
-	if err != nil {
-		writeProviderDevError(w, err)
-		return
-	}
-	if !ok {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-	writeJSON(w, http.StatusOK, resp)
-}
-
 func (s *Server) pollProviderDevSessionByDispatcher(w http.ResponseWriter, r *http.Request) {
 	if !s.providerDevAvailable(w) {
 		return
@@ -320,35 +301,6 @@ func (s *Server) pollProviderDevSessionByDispatcher(w http.ResponseWriter, r *ht
 		return
 	}
 	writeJSON(w, http.StatusOK, resp)
-}
-
-func (s *Server) completeProviderDevCall(w http.ResponseWriter, r *http.Request) {
-	if !s.providerDevAvailable(w) {
-		return
-	}
-	p := PrincipalFromContext(r.Context())
-	sessionID := providerDevAttachmentID(r)
-	dispatcherSecret := providerDevDispatcherSecret(r)
-	if err := s.providerDevSessions.VerifyDispatcherSecret(p, sessionID, dispatcherSecret); err != nil {
-		writeProviderDevError(w, err)
-		return
-	}
-	var req providerdev.CompleteCallRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid provider dev call response")
-		return
-	}
-	err := s.providerDevSessions.CompleteCall(
-		p,
-		sessionID,
-		providerDevCallID(r),
-		req,
-	)
-	if err != nil {
-		writeProviderDevError(w, err)
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 func (s *Server) completeProviderDevCallByDispatcher(w http.ResponseWriter, r *http.Request) {
@@ -375,18 +327,6 @@ func (s *Server) completeProviderDevCallByDispatcher(w http.ResponseWriter, r *h
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
-}
-
-func (s *Server) closeProviderDevSession(w http.ResponseWriter, r *http.Request) {
-	if !s.providerDevAvailable(w) {
-		return
-	}
-	err := s.providerDevSessions.CloseSession(PrincipalFromContext(r.Context()), providerDevAttachmentID(r))
-	if err != nil {
-		writeProviderDevError(w, err)
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "closed"})
 }
 
 func (s *Server) closeProviderDevSessionByDispatcherOrOwner(w http.ResponseWriter, r *http.Request) {
@@ -440,17 +380,11 @@ func providerDevAuthorizationSecret(r *http.Request) string {
 }
 
 func providerDevAttachmentID(r *http.Request) string {
-	if id := chi.URLParam(r, "attachmentID"); id != "" {
-		return id
-	}
-	return chi.URLParam(r, "sessionID")
+	return chi.URLParam(r, "attachmentID")
 }
 
 func providerDevCallID(r *http.Request) string {
-	if id := chi.URLParam(r, "callID"); id != "" {
-		return id
-	}
-	return chi.URLParam(r, "call")
+	return chi.URLParam(r, "callID")
 }
 
 func providerDevDispatcherSecret(r *http.Request) string {

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -85,12 +85,9 @@ func isProviderDevCompleteCallRequest(r *http.Request) bool {
 	if r == nil || r.Method != http.MethodPost || r.URL == nil {
 		return false
 	}
-	rest, ok := strings.CutPrefix(r.URL.Path, providerdev.PathSessions+"/")
+	rest, ok := strings.CutPrefix(r.URL.Path, providerdev.PathAttachments+"/")
 	if !ok {
-		rest, ok = strings.CutPrefix(r.URL.Path, providerdev.PathAttachments+"/")
-		if !ok {
-			return false
-		}
+		return false
 	}
 	sessionID, callID, ok := strings.Cut(rest, "/calls/")
 	return ok && sessionID != "" && callID != "" && !strings.Contains(sessionID, "/") && !strings.Contains(callID, "/")

--- a/gestaltd/internal/server/provider_dev_ui_test.go
+++ b/gestaltd/internal/server/provider_dev_ui_test.go
@@ -40,7 +40,7 @@ func TestProviderDevMountedUIHandlerOverridesFallback(t *testing.T) {
 	defer cancel()
 	dispatchDone := make(chan error, 1)
 	go func() {
-		call, ok, err := manager.PollSession(dispatchCtx, p, session.ID)
+		call, ok, err := manager.PollSession(dispatchCtx, p, session.AttachID)
 		if err != nil || !ok {
 			dispatchDone <- err
 			return
@@ -66,7 +66,7 @@ func TestProviderDevMountedUIHandlerOverridesFallback(t *testing.T) {
 			dispatchDone <- err
 			return
 		}
-		dispatchDone <- manager.CompleteCall(p, session.ID, call.CallID, providerdev.CompleteCallRequest{
+		dispatchDone <- manager.CompleteCall(p, session.AttachID, call.CallID, providerdev.CompleteCallRequest{
 			Response: hex.EncodeToString(respPayload),
 		})
 	}()
@@ -179,7 +179,7 @@ func TestProviderDevMountedUIHandlerUsesMountedAuthRuntime(t *testing.T) {
 
 	dispatchDone := make(chan error, 1)
 	go func() {
-		call, ok, err := manager.PollSession(context.Background(), p, session.ID)
+		call, ok, err := manager.PollSession(context.Background(), p, session.AttachID)
 		if err != nil || !ok {
 			dispatchDone <- err
 			return
@@ -193,7 +193,7 @@ func TestProviderDevMountedUIHandlerUsesMountedAuthRuntime(t *testing.T) {
 			dispatchDone <- err
 			return
 		}
-		dispatchDone <- manager.CompleteCall(p, session.ID, call.CallID, providerdev.CompleteCallRequest{
+		dispatchDone <- manager.CompleteCall(p, session.AttachID, call.CallID, providerdev.CompleteCallRequest{
 			Response: hex.EncodeToString(respPayload),
 		})
 	}()
@@ -271,7 +271,7 @@ func TestProviderDevMountedUIHandlerUsesAnonymousForNoAuthMountedUI(t *testing.T
 
 	dispatchDone := make(chan error, 1)
 	go func() {
-		call, ok, err := manager.PollSession(context.Background(), p, session.ID)
+		call, ok, err := manager.PollSession(context.Background(), p, session.AttachID)
 		if err != nil || !ok {
 			dispatchDone <- err
 			return
@@ -284,7 +284,7 @@ func TestProviderDevMountedUIHandlerUsesAnonymousForNoAuthMountedUI(t *testing.T
 			dispatchDone <- err
 			return
 		}
-		dispatchDone <- manager.CompleteCall(p, session.ID, call.CallID, providerdev.CompleteCallRequest{
+		dispatchDone <- manager.CompleteCall(p, session.AttachID, call.CallID, providerdev.CompleteCallRequest{
 			Response: hex.EncodeToString(respPayload),
 		})
 	}()
@@ -380,13 +380,6 @@ func TestMaxBodyMiddlewareAllowsLargeProviderDevCallCompletions(t *testing.T) {
 	}))
 	largeBody := bytes.Repeat([]byte("x"), defaultMaxBodyBytes+1024)
 
-	providerDevReq := httptest.NewRequest(http.MethodPost, "/api/v1/provider-dev/sessions/session-1/calls/call-1", bytes.NewReader(largeBody))
-	providerDevRec := httptest.NewRecorder()
-	handler.ServeHTTP(providerDevRec, providerDevReq)
-	if providerDevRec.Code != http.StatusNoContent {
-		t.Fatalf("provider dev completion status = %d, want %d", providerDevRec.Code, http.StatusNoContent)
-	}
-
 	providerDevAttachmentReq := httptest.NewRequest(http.MethodPost, "/api/v1/provider-dev/attachments/attach-1/calls/call-1", bytes.NewReader(largeBody))
 	providerDevAttachmentRec := httptest.NewRecorder()
 	handler.ServeHTTP(providerDevAttachmentRec, providerDevAttachmentReq)
@@ -394,7 +387,7 @@ func TestMaxBodyMiddlewareAllowsLargeProviderDevCallCompletions(t *testing.T) {
 		t.Fatalf("provider dev attachment completion status = %d, want %d", providerDevAttachmentRec.Code, http.StatusNoContent)
 	}
 
-	extraPathReq := httptest.NewRequest(http.MethodPost, "/api/v1/provider-dev/sessions/session-1/calls/call-1/extra", bytes.NewReader(largeBody))
+	extraPathReq := httptest.NewRequest(http.MethodPost, "/api/v1/provider-dev/attachments/attach-1/calls/call-1/extra", bytes.NewReader(largeBody))
 	extraPathRec := httptest.NewRecorder()
 	handler.ServeHTTP(extraPathRec, extraPathReq)
 	if extraPathRec.Code != http.StatusRequestEntityTooLarge {

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -61,10 +61,6 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Post("/auth/start-oauth", s.startIntegrationOAuth)
 		r.Post("/auth/connect-manual", s.connectManual)
 
-		r.Post("/provider-dev/sessions", s.createProviderDevSession)
-		r.Get("/provider-dev/sessions/{sessionID}/poll", s.pollProviderDevSession)
-		r.Post("/provider-dev/sessions/{sessionID}/calls/{callID}", s.completeProviderDevCall)
-		r.Delete("/provider-dev/sessions/{sessionID}", s.closeProviderDevSession)
 		r.Post("/provider-dev/attachments", s.createProviderDevSession)
 		r.Get("/provider-dev/attachments", s.listProviderDevAttachments)
 		r.Get("/provider-dev/attachments/{attachmentID}", s.getProviderDevAttachment)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6236,20 +6236,6 @@ func TestProviderDevAttachmentRoutesEnforceGateDispatcherSecretAndRedaction(t *t
 		t.Fatalf("complete without dispatcher secret status = %d, want 401", completeResp.StatusCode)
 	}
 
-	legacyCompleteReq, err := http.NewRequest(http.MethodPost, enabledTS.URL+providerdev.PathSessions+"/"+created.AttachID+"/calls/call-1", strings.NewReader("not-json"))
-	if err != nil {
-		t.Fatalf("new legacy complete request: %v", err)
-	}
-	legacyCompleteReq.Header.Set("Authorization", "Bearer owner-session")
-	legacyCompleteResp, err := enabledTS.Client().Do(legacyCompleteReq)
-	if err != nil {
-		t.Fatalf("legacy complete without dispatcher secret: %v", err)
-	}
-	_ = legacyCompleteResp.Body.Close()
-	if legacyCompleteResp.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("legacy complete without dispatcher secret status = %d, want 401", legacyCompleteResp.StatusCode)
-	}
-
 	pollReq, err := http.NewRequest(http.MethodGet, enabledTS.URL+providerdev.PathAttachments+"/"+created.AttachID+"/poll", nil)
 	if err != nil {
 		t.Fatalf("new poll request: %v", err)
@@ -6262,20 +6248,6 @@ func TestProviderDevAttachmentRoutesEnforceGateDispatcherSecretAndRedaction(t *t
 	_ = pollResp.Body.Close()
 	if pollResp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("poll without dispatcher secret status = %d, want 401", pollResp.StatusCode)
-	}
-
-	legacyPollReq, err := http.NewRequest(http.MethodGet, enabledTS.URL+providerdev.PathSessions+"/"+created.AttachID+"/poll", nil)
-	if err != nil {
-		t.Fatalf("new legacy poll request: %v", err)
-	}
-	legacyPollReq.Header.Set("Authorization", "Bearer owner-session")
-	legacyPollResp, err := enabledTS.Client().Do(legacyPollReq)
-	if err != nil {
-		t.Fatalf("legacy poll without dispatcher secret: %v", err)
-	}
-	_ = legacyPollResp.Body.Close()
-	if legacyPollResp.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("legacy poll without dispatcher secret status = %d, want 401", legacyPollResp.StatusCode)
 	}
 
 	invalidPollReq, err := http.NewRequest(http.MethodGet, enabledTS.URL+providerdev.PathAttachments+"/"+created.AttachID+"/poll", nil)


### PR DESCRIPTION
## Summary

Simplifies the provider-dev remote attach surface by deleting the legacy `/api/v1/provider-dev/sessions` compatibility path and requiring all local-dev dispatcher traffic to use the attachment route family. This keeps the product vocabulary aligned around `attachId` and removes duplicate server/manager code paths.

## Interfaces

Kept public routes:

```bash
POST   /api/v1/provider-dev/attachments
GET    /api/v1/provider-dev/attachments
GET    /api/v1/provider-dev/attachments/{attachId}
GET    /api/v1/provider-dev/attachments/{attachId}/poll
POST   /api/v1/provider-dev/attachments/{attachId}/calls/{callId}
DELETE /api/v1/provider-dev/attachments/{attachId}
```

Removed compatibility routes:

```bash
POST   /api/v1/provider-dev/sessions
GET    /api/v1/provider-dev/sessions/{sessionId}/poll
POST   /api/v1/provider-dev/sessions/{sessionId}/calls/{callId}
DELETE /api/v1/provider-dev/sessions/{sessionId}
```

The create response now relies on `attachId`; the old `id` fallback is removed.

## Examples

```bash
gestaltd provider dev --remote https://valon.tools --path ./plugins/slack
gestaltd provider attach list --remote https://valon.tools
gestaltd provider attach show --remote https://valon.tools att_123
gestaltd provider attach detach --remote https://valon.tools att_123
```

## Validation

```bash
go test ./internal/providerdev ./internal/server ./cmd/gestaltd
golangci-lint run --allow-parallel-runners ./cmd/gestaltd ./internal/providerdev ./internal/server
```