### PR TITLE
Simplify workflow schedule input shapes

### DIFF
--- a/gestaltd/internal/bootstrap/agent_workflow_tools.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools.go
@@ -164,10 +164,10 @@ func (t *workflowSystemTools) ExecuteSystemTool(ctx context.Context, req agentSy
 		}
 		return workflowSystemToolJSONResponse(http.StatusOK, map[string]any{"schedules": items})
 	case workflowSystemToolSchedulesGet:
-		if err := workflowSystemToolRejectUnknownKeys(req.Arguments, "workflow.schedules.get", "scheduleId", "id"); err != nil {
+		if err := workflowSystemToolRejectUnknownKeys(req.Arguments, "workflow.schedules.get", "scheduleId"); err != nil {
 			return nil, err
 		}
-		scheduleID := workflowSystemToolStringArg(req.Arguments, "scheduleId", "id")
+		scheduleID := workflowSystemToolStringArg(req.Arguments, "scheduleId")
 		if scheduleID == "" {
 			return nil, fmt.Errorf("%w: scheduleId is required", invocation.ErrInvalidInvocation)
 		}
@@ -177,10 +177,10 @@ func (t *workflowSystemTools) ExecuteSystemTool(ctx context.Context, req agentSy
 		}
 		return workflowSystemToolJSONResponse(http.StatusOK, map[string]any{"schedule": workflowSystemToolScheduleInfo(schedule)})
 	case workflowSystemToolSchedulesPause:
-		if err := workflowSystemToolRejectUnknownKeys(req.Arguments, "workflow.schedules.pause", "scheduleId", "id"); err != nil {
+		if err := workflowSystemToolRejectUnknownKeys(req.Arguments, "workflow.schedules.pause", "scheduleId"); err != nil {
 			return nil, err
 		}
-		scheduleID := workflowSystemToolStringArg(req.Arguments, "scheduleId", "id")
+		scheduleID := workflowSystemToolStringArg(req.Arguments, "scheduleId")
 		if scheduleID == "" {
 			return nil, fmt.Errorf("%w: scheduleId is required", invocation.ErrInvalidInvocation)
 		}
@@ -190,10 +190,10 @@ func (t *workflowSystemTools) ExecuteSystemTool(ctx context.Context, req agentSy
 		}
 		return workflowSystemToolJSONResponse(http.StatusOK, map[string]any{"schedule": workflowSystemToolScheduleInfo(schedule)})
 	case workflowSystemToolSchedulesResume:
-		if err := workflowSystemToolRejectUnknownKeys(req.Arguments, "workflow.schedules.resume", "scheduleId", "id"); err != nil {
+		if err := workflowSystemToolRejectUnknownKeys(req.Arguments, "workflow.schedules.resume", "scheduleId"); err != nil {
 			return nil, err
 		}
-		scheduleID := workflowSystemToolStringArg(req.Arguments, "scheduleId", "id")
+		scheduleID := workflowSystemToolStringArg(req.Arguments, "scheduleId")
 		if scheduleID == "" {
 			return nil, fmt.Errorf("%w: scheduleId is required", invocation.ErrInvalidInvocation)
 		}
@@ -216,10 +216,10 @@ func (t *workflowSystemTools) ExecuteSystemTool(ctx context.Context, req agentSy
 		}
 		return workflowSystemToolJSONResponse(http.StatusOK, map[string]any{"runs": items})
 	case workflowSystemToolRunsGet:
-		if err := workflowSystemToolRejectUnknownKeys(req.Arguments, "workflow.runs.get", "runId", "id"); err != nil {
+		if err := workflowSystemToolRejectUnknownKeys(req.Arguments, "workflow.runs.get", "runId"); err != nil {
 			return nil, err
 		}
-		runID := workflowSystemToolStringArg(req.Arguments, "runId", "id")
+		runID := workflowSystemToolStringArg(req.Arguments, "runId")
 		if runID == "" {
 			return nil, fmt.Errorf("%w: runId is required", invocation.ErrInvalidInvocation)
 		}
@@ -235,7 +235,7 @@ func (t *workflowSystemTools) ExecuteSystemTool(ctx context.Context, req agentSy
 
 func (t *workflowSystemTools) executeCreateSchedule(ctx context.Context, req agentSystemToolExecutionRequest) (*coreagent.ExecuteToolResponse, error) {
 	args := req.Arguments
-	if err := workflowSystemToolRejectUnknownKeys(args, "workflow.schedules.create", "provider", "providerName", "cron", "timezone", "timeZone", "paused", "target"); err != nil {
+	if err := workflowSystemToolRejectUnknownKeys(args, "workflow.schedules.create", "provider", "cron", "timezone", "paused", "target"); err != nil {
 		return nil, err
 	}
 	cron := workflowSystemToolStringArg(args, "cron")
@@ -259,9 +259,9 @@ func (t *workflowSystemTools) executeCreateSchedule(ctx context.Context, req age
 		return nil, err
 	}
 	schedule, err := t.manager.CreateSchedule(ctx, scopedPrincipal, workflowmanager.ScheduleUpsert{
-		ProviderName: workflowSystemToolStringArg(args, "provider", "providerName"),
+		ProviderName: workflowSystemToolStringArg(args, "provider"),
 		Cron:         cron,
-		Timezone:     workflowSystemToolStringArg(args, "timezone", "timeZone"),
+		Timezone:     workflowSystemToolStringArg(args, "timezone"),
 		Target:       target,
 		Paused:       workflowSystemToolBoolArg(args, "paused"),
 	})
@@ -316,7 +316,6 @@ func workflowSystemToolCreateScheduleSchema() map[string]any {
 			"prompt":          workflowSystemToolStringSchema("Agent prompt."),
 			"messages":        map[string]any{"type": "array", "items": map[string]any{"type": "object"}},
 			"toolRefs":        map[string]any{"type": "array", "items": map[string]any{"type": "object"}},
-			"tools":           map[string]any{"type": "array", "items": map[string]any{"type": "object"}},
 			"responseSchema":  map[string]any{"type": "object"},
 			"metadata":        map[string]any{"type": "object"},
 			"providerOptions": map[string]any{"type": "object"},
@@ -381,10 +380,10 @@ func workflowSystemToolTargetFromValue(value any) (coreworkflow.Target, error) {
 		if !ok {
 			return coreworkflow.Target{}, fmt.Errorf("%w: target.plugin must be an object", invocation.ErrInvalidInvocation)
 		}
-		if err := workflowSystemToolRejectUnknownKeys(pluginMap, "target.plugin", "name", "plugin", "operation", "connection", "instance", "input"); err != nil {
+		if err := workflowSystemToolRejectUnknownKeys(pluginMap, "target.plugin", "name", "operation", "connection", "instance", "input"); err != nil {
 			return coreworkflow.Target{}, err
 		}
-		pluginName := workflowSystemToolStringArg(pluginMap, "name", "plugin")
+		pluginName := workflowSystemToolStringArg(pluginMap, "name")
 		operation := workflowSystemToolStringArg(pluginMap, "operation")
 		if pluginName == "" || operation == "" {
 			return coreworkflow.Target{}, fmt.Errorf("%w: target.plugin.name and target.plugin.operation are required", invocation.ErrInvalidInvocation)
@@ -405,14 +404,10 @@ func workflowSystemToolTargetFromValue(value any) (coreworkflow.Target, error) {
 	if !ok {
 		return coreworkflow.Target{}, fmt.Errorf("%w: target.agent must be an object", invocation.ErrInvalidInvocation)
 	}
-	if err := workflowSystemToolRejectUnknownKeys(agentMap, "target.agent", "provider", "providerName", "model", "prompt", "messages", "toolRefs", "tools", "responseSchema", "metadata", "providerOptions", "timeoutSeconds"); err != nil {
+	if err := workflowSystemToolRejectUnknownKeys(agentMap, "target.agent", "provider", "model", "prompt", "messages", "toolRefs", "responseSchema", "metadata", "providerOptions", "timeoutSeconds"); err != nil {
 		return coreworkflow.Target{}, err
 	}
-	toolRefsValue, ok := agentMap["toolRefs"]
-	if !ok || toolRefsValue == nil {
-		toolRefsValue = agentMap["tools"]
-	}
-	toolRefs, err := workflowSystemToolRefsFromValue(toolRefsValue)
+	toolRefs, err := workflowSystemToolRefsFromValue(agentMap["toolRefs"])
 	if err != nil {
 		return coreworkflow.Target{}, err
 	}
@@ -433,7 +428,7 @@ func workflowSystemToolTargetFromValue(value any) (coreworkflow.Target, error) {
 		return coreworkflow.Target{}, err
 	}
 	return coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
-		ProviderName:    workflowSystemToolStringArg(agentMap, "provider", "providerName"),
+		ProviderName:    workflowSystemToolStringArg(agentMap, "provider"),
 		Model:           workflowSystemToolStringArg(agentMap, "model"),
 		Prompt:          workflowSystemToolStringArg(agentMap, "prompt"),
 		Messages:        messages,
@@ -808,12 +803,10 @@ func workflowSystemToolPutTime(value map[string]any, key string, t *time.Time) {
 	}
 }
 
-func workflowSystemToolStringArg(args map[string]any, keys ...string) string {
-	for _, key := range keys {
-		if value, ok := args[key]; ok {
-			if s, ok := value.(string); ok {
-				return strings.TrimSpace(s)
-			}
+func workflowSystemToolStringArg(args map[string]any, key string) string {
+	if value, ok := args[key]; ok {
+		if s, ok := value.(string); ok {
+			return strings.TrimSpace(s)
 		}
 	}
 	return ""

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
@@ -155,86 +155,60 @@ func TestAgentRuntimeWorkflowSystemToolRejectsUnsupportedScheduleTargetFields(t 
 		Tools: []coreagent.Tool{workflowTool},
 	})
 
-	_, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
-		ProviderName: "managed",
-		SessionID:    "session-1",
-		TurnID:       "turn-1",
-		ToolID:       workflowTool.ID,
-		ToolGrant:    toolGrant,
-		Arguments: map[string]any{
-			"cron": "*/5 * * * *",
-			"target": map[string]any{
-				"agent": map[string]any{
-					"provider": "managed",
-					"prompt":   "Sync roadmap",
-					"toolRefs": []any{
-						map[string]any{
-							"plugin":         "roadmap",
-							"operation":      "sync",
-							"credentialMode": "user",
+	cases := []struct {
+		name      string
+		arguments map[string]any
+	}{
+		{
+			name: "credential mode",
+			arguments: map[string]any{
+				"cron": "*/5 * * * *",
+				"target": map[string]any{
+					"agent": map[string]any{
+						"provider": "managed",
+						"prompt":   "Sync roadmap",
+						"toolRefs": []any{
+							map[string]any{
+								"plugin":         "roadmap",
+								"operation":      "sync",
+								"credentialMode": "user",
+							},
 						},
 					},
 				},
 			},
 		},
-	})
-	if err == nil {
-		t.Fatal("ExecuteTool succeeded, want invalid invocation")
-	}
-	if !errors.Is(err, invocation.ErrInvalidInvocation) {
-		t.Fatalf("ExecuteTool error = %v, want invalid invocation", err)
-	}
-}
-
-func TestAgentRuntimeWorkflowSystemToolCreateScheduleFallsBackFromNullToolRefsToTools(t *testing.T) {
-	t.Parallel()
-
-	runtime, workflowProvider := newWorkflowSystemToolRuntime(t)
-	workflowTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolSchedulesCreate)
-	toolGrant := mustMintWorkflowSystemToolGrant(t, runtime, workflowSystemToolGrantScope{
-		Permissions: []core.AccessPermission{{
-			Plugin:     "roadmap",
-			Operations: []string{"sync"},
-		}},
-		ToolRefs: []coreagent.ToolRef{
-			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolSchedulesCreate},
-			{Plugin: "roadmap", Operation: "sync"},
-		},
-		Tools: []coreagent.Tool{workflowTool},
-	})
-
-	_, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
-		ProviderName: "managed",
-		SessionID:    "session-1",
-		TurnID:       "turn-1",
-		ToolID:       workflowTool.ID,
-		ToolGrant:    toolGrant,
-		Arguments: map[string]any{
-			"cron": "*/5 * * * *",
-			"target": map[string]any{
-				"agent": map[string]any{
-					"provider": "managed",
-					"prompt":   "Sync roadmap",
-					"toolRefs": nil,
-					"tools": []any{
-						map[string]any{
-							"plugin":    "roadmap",
-							"operation": "sync",
+		{
+			name: "agent tools alias",
+			arguments: map[string]any{
+				"cron": "*/5 * * * *",
+				"target": map[string]any{
+					"agent": map[string]any{
+						"provider": "managed",
+						"prompt":   "Sync roadmap",
+						"tools": []any{
+							map[string]any{"plugin": "roadmap", "operation": "sync"},
 						},
 					},
 				},
 			},
 		},
-	})
-	if err != nil {
-		t.Fatalf("ExecuteTool: %v", err)
 	}
-	if len(workflowProvider.upsertedSchedules) != 1 {
-		t.Fatalf("upserted schedules = %d, want 1", len(workflowProvider.upsertedSchedules))
-	}
-	target := workflowProvider.upsertedSchedules[0].Target
-	if target.Agent == nil || len(target.Agent.ToolRefs) != 1 || target.Agent.ToolRefs[0].Plugin != "roadmap" || target.Agent.ToolRefs[0].Operation != "sync" {
-		t.Fatalf("agent target tool refs = %#v", target.Agent)
+	for _, tc := range cases {
+		_, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+			ProviderName: "managed",
+			SessionID:    "session-1",
+			TurnID:       "turn-1",
+			ToolID:       workflowTool.ID,
+			ToolGrant:    toolGrant,
+			Arguments:    tc.arguments,
+		})
+		if err == nil {
+			t.Fatalf("%s: ExecuteTool succeeded, want invalid invocation", tc.name)
+		}
+		if !errors.Is(err, invocation.ErrInvalidInvocation) {
+			t.Fatalf("%s: ExecuteTool error = %v, want invalid invocation", tc.name, err)
+		}
 	}
 }
 

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -16,8 +16,6 @@ import (
 )
 
 type desiredWorkflowConfigEventTrigger struct {
-	ID           string
-	PluginName   string
 	TriggerKey   string
 	ProviderName string
 	TriggerID    string
@@ -36,7 +34,8 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 	for _, rowID := range slices.Sorted(maps.Keys(desired)) {
 		desiredEntry := desired[rowID]
 		trigger := desiredEntry.trigger
-		pluginName := workflowConfigTargetLabel(workflowConfigEventTriggerTarget(trigger))
+		target := workflowConfigTarget(trigger.Target)
+		pluginName := workflowConfigTargetLabel(target)
 		providerName, provider, err := runtime.ResolveProviderSelection(trigger.Provider)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q: %w", desiredEntry.TriggerKey, pluginName, err)
@@ -56,7 +55,7 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 		default:
 			return fmt.Errorf("bootstrap: get workflow event trigger %q for plugin %q: %w", desiredEntry.TriggerID, pluginName, err)
 		}
-		desiredExecutionRef, err := workflowConfigExecutionReference(cfg, providerName, workflowConfigEventTriggerTarget(trigger))
+		desiredExecutionRef, err := workflowConfigExecutionReference(cfg, providerName, target)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q: %w", desiredEntry.TriggerKey, pluginName, err)
 		}
@@ -77,7 +76,7 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 		if _, err := provider.UpsertEventTrigger(providerCtx, coreworkflow.UpsertEventTriggerRequest{
 			TriggerID:    desiredEntry.TriggerID,
 			Match:        workflowConfigEventTriggerMatch(trigger),
-			Target:       workflowConfigEventTriggerTarget(trigger),
+			Target:       target,
 			Paused:       trigger.Paused,
 			RequestedBy:  workflowConfigActor(),
 			ExecutionRef: executionRefID,
@@ -111,10 +110,8 @@ func desiredWorkflowConfigEventTriggers(cfg *config.Config) (map[string]desiredW
 		if err != nil {
 			return nil, err
 		}
-		rowID := workflowConfigEventTriggerStateID(triggerKey)
+		rowID := strings.TrimSpace(triggerKey)
 		desired[rowID] = desiredWorkflowConfigEventTrigger{
-			ID:           rowID,
-			PluginName:   workflowConfigTargetLabel(workflowConfigEventTriggerTarget(trigger)),
 			TriggerKey:   triggerKey,
 			ProviderName: providerName,
 			TriggerID:    workflowConfigEventTriggerID(triggerKey),
@@ -184,14 +181,6 @@ func workflowConfigEventTriggerMatch(trigger config.WorkflowEventTriggerConfig) 
 		Source:  trigger.Match.Source,
 		Subject: trigger.Match.Subject,
 	}
-}
-
-func workflowConfigEventTriggerTarget(trigger config.WorkflowEventTriggerConfig) coreworkflow.Target {
-	return workflowConfigTarget(trigger.Target)
-}
-
-func workflowConfigEventTriggerStateID(triggerKey string) string {
-	return strings.TrimSpace(triggerKey)
 }
 
 func workflowConfigEventTriggerID(triggerKey string) string {

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -24,8 +24,6 @@ import (
 )
 
 type desiredWorkflowConfigSchedule struct {
-	ID           string
-	PluginName   string
 	ScheduleKey  string
 	ProviderName string
 	ScheduleID   string
@@ -44,12 +42,12 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 	for _, rowID := range slices.Sorted(maps.Keys(desired)) {
 		desiredEntry := desired[rowID]
 		schedule := desiredEntry.schedule
-		pluginName := workflowConfigTargetLabel(workflowConfigScheduleTarget(schedule))
+		target := workflowConfigTarget(schedule.Target)
+		pluginName := workflowConfigTargetLabel(target)
 		providerName, provider, err := runtime.ResolveProviderSelection(schedule.Provider)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q: %w", desiredEntry.ScheduleKey, pluginName, err)
 		}
-		target := workflowConfigScheduleTarget(schedule)
 		existingExecutionRef := ""
 		providerCtx := invocation.WithWorkflowContextString(ctx, "plugin", pluginName)
 		existing, err := provider.GetSchedule(providerCtx, coreworkflow.GetScheduleRequest{
@@ -124,10 +122,8 @@ func desiredWorkflowConfigSchedules(cfg *config.Config) (map[string]desiredWorkf
 		if err != nil {
 			return nil, err
 		}
-		rowID := workflowConfigScheduleStateID(scheduleKey)
+		rowID := strings.TrimSpace(scheduleKey)
 		desired[rowID] = desiredWorkflowConfigSchedule{
-			ID:           rowID,
-			PluginName:   workflowConfigTargetLabel(workflowConfigScheduleTarget(schedule)),
 			ScheduleKey:  scheduleKey,
 			ProviderName: providerName,
 			ScheduleID:   workflowConfigScheduleID(scheduleKey),
@@ -199,10 +195,6 @@ func isWorkflowConfigOwnedSchedule(existing *coreworkflow.Schedule, pluginName, 
 		existing.CreatedBy.AuthSource == actor.AuthSource
 }
 
-func workflowTargetsEqual(left, right coreworkflow.Target) bool {
-	return coreworkflow.TargetsEqual(left, right)
-}
-
 func workflowConfigTargetLabel(target coreworkflow.Target) string {
 	if target.Agent != nil {
 		providerName := strings.TrimSpace(target.Agent.ProviderName)
@@ -215,10 +207,6 @@ func workflowConfigTargetLabel(target coreworkflow.Target) string {
 		return ""
 	}
 	return strings.TrimSpace(target.Plugin.PluginName)
-}
-
-func workflowConfigScheduleTarget(schedule config.WorkflowScheduleConfig) coreworkflow.Target {
-	return workflowConfigTarget(schedule.Target)
 }
 
 func workflowConfigTarget(target *config.WorkflowTargetConfig) coreworkflow.Target {
@@ -295,10 +283,6 @@ func workflowConfigActor() coreworkflow.Actor {
 		DisplayName: "Workflow Config",
 		AuthSource:  "config",
 	}
-}
-
-func workflowConfigScheduleStateID(scheduleKey string) string {
-	return strings.TrimSpace(scheduleKey)
 }
 
 func workflowConfigScheduleID(scheduleKey string) string {
@@ -464,7 +448,7 @@ func workflowConfigExecutionRefMatches(existing, desired *coreworkflow.Execution
 	if strings.TrimSpace(existing.AuthSource) != strings.TrimSpace(desired.AuthSource) {
 		return false
 	}
-	if !workflowTargetsEqual(existing.Target, desired.Target) {
+	if !coreworkflow.TargetsEqual(existing.Target, desired.Target) {
 		return false
 	}
 	existingJSON, existingErr := json.Marshal(existing.Permissions)

--- a/gestaltd/internal/server/handlers_workflow.go
+++ b/gestaltd/internal/server/handlers_workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"maps"
 	"net/http"
@@ -39,7 +40,6 @@ type workflowAgentTargetRequest struct {
 	Prompt          string                `json:"prompt,omitempty"`
 	Messages        []agentMessageRequest `json:"messages,omitempty"`
 	ToolRefs        []agentToolRefRequest `json:"toolRefs,omitempty"`
-	Tools           []agentToolRefRequest `json:"tools,omitempty"`
 	ResponseSchema  map[string]any        `json:"responseSchema,omitempty"`
 	Metadata        map[string]any        `json:"metadata,omitempty"`
 	ProviderOptions map[string]any        `json:"providerOptions,omitempty"`
@@ -115,7 +115,7 @@ func (s *Server) createWorkflowSchedule(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var req workflowScheduleUpsertRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeWorkflowJSONBody(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -158,7 +158,7 @@ func (s *Server) updateGlobalWorkflowSchedule(w http.ResponseWriter, r *http.Req
 	scheduleID := chi.URLParam(r, "scheduleID")
 
 	var req workflowScheduleUpsertRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeWorkflowJSONBody(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -252,6 +252,21 @@ func workflowScheduleTargetFromRequest(target workflowScheduleTargetRequest) cor
 	}
 }
 
+func decodeWorkflowJSONBody(r *http.Request, dst any) error {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return fmt.Errorf("invalid trailing JSON body")
+		}
+		return err
+	}
+	return nil
+}
+
 func workflowPluginTargetFromRequest(target *workflowPluginTargetRequest) workflowPluginTargetRequest {
 	if target == nil {
 		return workflowPluginTargetRequest{}
@@ -263,16 +278,12 @@ func workflowAgentTargetFromRequest(target *workflowAgentTargetRequest) corework
 	if target == nil {
 		return coreworkflow.AgentTarget{}
 	}
-	toolRefs := target.ToolRefs
-	if len(toolRefs) == 0 {
-		toolRefs = target.Tools
-	}
 	return coreworkflow.AgentTarget{
 		ProviderName:    strings.TrimSpace(target.ProviderName),
 		Model:           strings.TrimSpace(target.Model),
 		Prompt:          strings.TrimSpace(target.Prompt),
 		Messages:        agentMessagesFromRequest(target.Messages),
-		ToolRefs:        agentToolRefsFromRequest(toolRefs),
+		ToolRefs:        agentToolRefsFromRequest(target.ToolRefs),
 		ToolSource:      coreagent.ToolSourceModeNativeSearch,
 		ResponseSchema:  maps.Clone(target.ResponseSchema),
 		Metadata:        maps.Clone(target.Metadata),

--- a/gestaltd/internal/server/handlers_workflow_event_triggers.go
+++ b/gestaltd/internal/server/handlers_workflow_event_triggers.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -70,7 +69,7 @@ func (s *Server) createGlobalWorkflowEventTrigger(w http.ResponseWriter, r *http
 	}
 
 	var req workflowEventTriggerUpsertRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeWorkflowJSONBody(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -116,7 +115,7 @@ func (s *Server) updateGlobalWorkflowEventTrigger(w http.ResponseWriter, r *http
 	triggerID := chi.URLParam(r, "triggerID")
 
 	var req workflowEventTriggerUpsertRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeWorkflowJSONBody(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -2352,7 +2352,7 @@ func TestGlobalWorkflowEventTriggerCRUDAcrossProviders(t *testing.T) {
 	}
 }
 
-func TestGlobalWorkflowFlatTargetsAreRejected(t *testing.T) {
+func TestGlobalWorkflowLegacyTargetShapesAreRejected(t *testing.T) {
 	t.Parallel()
 
 	services := coretesting.NewStubServices(t)
@@ -2401,9 +2401,27 @@ func TestGlobalWorkflowFlatTargetsAreRejected(t *testing.T) {
 			want: `invalid JSON body`,
 		},
 		{
+			name: "schedule providerName alias",
+			path: "/api/v1/workflow/schedules/",
+			body: `{"providerName":"basic","cron":"*/5 * * * *","timezone":"UTC","target":{"plugin":{"name":"roadmap","operation":"sync"}}}`,
+			want: `invalid JSON body`,
+		},
+		{
 			name: "event trigger",
 			path: "/api/v1/workflow/event-triggers/",
 			body: `{"match":{"type":"roadmap.item.updated","source":"roadmap"},"target":{"plugin":"roadmap","operation":"sync","connection":"analytics","instance":"tenant-a","input":{"mode":"incremental"}}}`,
+			want: `invalid JSON body`,
+		},
+		{
+			name: "schedule agent tools alias",
+			path: "/api/v1/workflow/schedules/",
+			body: `{"cron":"*/5 * * * *","timezone":"UTC","target":{"agent":{"provider":"managed","prompt":"Sync roadmap","tools":[{"plugin":"roadmap","operation":"sync"}]}}}`,
+			want: `invalid JSON body`,
+		},
+		{
+			name: "trailing JSON",
+			path: "/api/v1/workflow/schedules/",
+			body: `{"cron":"*/5 * * * *","timezone":"UTC","target":{"plugin":{"name":"roadmap","operation":"sync"}}} {"timeZone":"UTC"}`,
 			want: `invalid JSON body`,
 		},
 	}


### PR DESCRIPTION
## Summary

This continues the workflow cleanup by deleting live compatibility aliases and dead config-managed reconciliation wrappers while preserving the canonical schedule and event-trigger surfaces.

Removed hidden workflow system tool aliases:
- `id` for schedule/run lookup calls; use `scheduleId` / `runId`
- `providerName`; use `provider`
- `timeZone`; use `timezone`
- `target.plugin.plugin`; use `target.plugin.name`
- `target.agent.providerName`; use `target.agent.provider`
- `target.agent.tools`; use `target.agent.toolRefs`

HTTP schedule and event-trigger upserts now reject unknown JSON fields, so deleted fields fail explicitly instead of being ignored.

## Current Interfaces

Config-managed schedule:

```yaml
workflows:
  schedules:
    nightly_sync:
      provider: temporal
      cron: "*/5 * * * *"
      timezone: UTC
      target:
        plugin:
          name: roadmap
          operation: sync
```

Config-managed event trigger:

```yaml
workflows:
  eventTriggers:
    task_updated:
      provider: temporal
      match:
        type: roadmap.item.updated
      target:
        agent:
          provider: managed
          prompt: Sync the updated item
          tools:
            - plugin: roadmap
              operation: sync
```

Workflow system tool schedule create:

```json
{
  "provider": "temporal",
  "cron": "*/5 * * * *",
  "timezone": "UTC",
  "target": {
    "agent": {
      "provider": "managed",
      "prompt": "Sync roadmap",
      "toolRefs": [
        {"plugin": "roadmap", "operation": "sync"}
      ]
    }
  }
}
```

## Validation

- `go test ./internal/bootstrap ./internal/server`
- `go test ./internal/config ./internal/workflowmanager ./core/workflow`