### PR TITLE
Simplify provider-dev dispatcher state

### DIFF
--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -68,7 +68,6 @@ type Manager struct {
 	mu             sync.RWMutex
 	targets        map[string]Target
 	sessions       map[string]*Session
-	ownerIndex     map[string][]string
 	authorizations map[string]*AttachAuthorization
 }
 
@@ -171,14 +170,13 @@ type UIAssetResponse struct {
 }
 
 type PollResponse struct {
-	CallID   string `json:"callId"`
-	Provider string `json:"provider"`
-	Method   string `json:"method"`
-	Request  string `json:"request"`
+	CallID        string `json:"callId"`
+	Provider      string `json:"provider"`
+	Method        string `json:"method"`
+	RequestBase64 string `json:"requestBase64"`
 }
 
 type CompleteCallRequest struct {
-	Response       string    `json:"response,omitempty"`
 	ResponseBase64 string    `json:"responseBase64,omitempty"`
 	Error          *RPCError `json:"error,omitempty"`
 }
@@ -232,7 +230,6 @@ func NewManager(targets []Target) (*Manager, error) {
 	m := &Manager{
 		targets:        make(map[string]Target, len(targets)),
 		sessions:       map[string]*Session{},
-		ownerIndex:     map[string][]string{},
 		authorizations: map[string]*AttachAuthorization{},
 	}
 	for i := range targets {
@@ -287,7 +284,6 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "create provider dev dispatcher secret: %v", err)
 	}
-	now := time.Now()
 	session := &Session{
 		id:                   sessionID,
 		dispatcherSecretHash: dispatcherSecretHash,
@@ -297,8 +293,6 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 		pending:              map[string]*rpcCall{},
 		done:                 make(chan struct{}),
 		closeDone:            make(chan struct{}),
-		createdAt:            now,
-		lastSeen:             now,
 	}
 	resp := &CreateSessionResponse{
 		AttachID:         sessionID,
@@ -336,20 +330,14 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 	}
 
 	m.mu.Lock()
+	insertedAt := time.Now()
+	session.createdAt = insertedAt
+	session.lastSeen = insertedAt
 	m.sessions[sessionID] = session
-	m.ownerIndex[owner] = append(m.ownerIndex[owner], sessionID)
 	m.mu.Unlock()
 	cleanupOnError = false
 
 	return resp, nil
-}
-
-func (m *Manager) PollSession(ctx context.Context, p *principal.Principal, sessionID string) (*PollResponse, bool, error) {
-	session, err := m.sessionForPrincipal(p, sessionID)
-	if err != nil {
-		return nil, false, err
-	}
-	return session.poll(ctx)
 }
 
 func (m *Manager) PollSessionWithDispatcherSecretOnly(ctx context.Context, sessionID, dispatcherSecret string) (*PollResponse, bool, error) {
@@ -380,10 +368,10 @@ func (s *Session) poll(ctx context.Context) (*PollResponse, bool, error) {
 			s.lastSeen = call.deliveredAt
 			s.mu.Unlock()
 			return &PollResponse{
-				CallID:   call.id,
-				Provider: call.provider,
-				Method:   call.method,
-				Request:  hex.EncodeToString(call.request),
+				CallID:        call.id,
+				Provider:      call.provider,
+				Method:        call.method,
+				RequestBase64: base64.StdEncoding.EncodeToString(call.request),
 			}, true, nil
 		case <-s.done:
 			return nil, false, status.Error(codes.NotFound, "provider dev session is closed")
@@ -616,14 +604,6 @@ func (m *Manager) resolveAttachTargetLocked(requested AttachProvider) (Target, e
 	return matches[0], nil
 }
 
-func (m *Manager) CompleteCall(p *principal.Principal, sessionID, callID string, req CompleteCallRequest) error {
-	session, err := m.sessionForPrincipal(p, sessionID)
-	if err != nil {
-		return err
-	}
-	return session.completeCall(callID, req)
-}
-
 func (m *Manager) CompleteCallWithDispatcherSecretOnly(sessionID, callID, dispatcherSecret string, req CompleteCallRequest) error {
 	session, err := m.sessionForDispatcherSecret(sessionID, dispatcherSecret)
 	if err != nil {
@@ -645,7 +625,7 @@ func (m *Manager) CloseSessionWithDispatcherSecret(sessionID, dispatcherSecret s
 	if err := session.Close(); err != nil {
 		return status.Errorf(codes.Internal, "close provider dev session: %v", err)
 	}
-	m.removeSession(sessionID, session.owner)
+	m.removeSession(sessionID)
 	return nil
 }
 
@@ -680,13 +660,6 @@ func (s *Session) completeCall(callID string, req CompleteCallRequest) error {
 		} else {
 			resp.payload = payload
 		}
-	case req.Response != "":
-		payload, err := hex.DecodeString(req.Response)
-		if err != nil {
-			resp.err = status.Errorf(codes.InvalidArgument, "decode provider dev response: %v", err)
-		} else {
-			resp.payload = payload
-		}
 	}
 
 	select {
@@ -709,15 +682,7 @@ func (m *Manager) ListSessions(p *principal.Principal) ([]AttachmentInfo, error)
 		return nil, status.Error(codes.FailedPrecondition, "provider dev is not configured")
 	}
 	m.closeIdleSessions(time.Now())
-	m.mu.RLock()
-	sessionIDs := append([]string(nil), m.ownerIndex[owner]...)
-	sessions := make([]*Session, 0, len(sessionIDs))
-	for _, id := range sessionIDs {
-		if session := m.sessions[id]; session != nil {
-			sessions = append(sessions, session)
-		}
-	}
-	m.mu.RUnlock()
+	sessions := m.sessionsForOwner(owner)
 	out := make([]AttachmentInfo, 0, len(sessions))
 	for _, session := range sessions {
 		if session == nil || session.isClosed() {
@@ -745,7 +710,7 @@ func (m *Manager) CloseSession(p *principal.Principal, sessionID string) error {
 	if err := session.Close(); err != nil {
 		return status.Errorf(codes.Internal, "close provider dev session: %v", err)
 	}
-	m.removeSession(sessionID, session.owner)
+	m.removeSession(sessionID)
 	return nil
 }
 
@@ -763,16 +728,10 @@ func (m *Manager) ResolveProviderOverride(ctx context.Context, p *principal.Prin
 		return nil, false, nil
 	}
 
-	m.mu.RLock()
-	sessionIDs := append([]string(nil), m.ownerIndex[owner]...)
-	sessions := make(map[string]*Session, len(sessionIDs))
-	for _, id := range sessionIDs {
-		sessions[id] = m.sessions[id]
-	}
-	m.mu.RUnlock()
+	sessions := m.sessionsForOwner(owner)
 
-	for i := len(sessionIDs) - 1; i >= 0; i-- {
-		session := sessions[sessionIDs[i]]
+	for i := len(sessions) - 1; i >= 0; i-- {
+		session := sessions[i]
 		if session == nil || session.isClosed() {
 			continue
 		}
@@ -803,16 +762,10 @@ func (m *Manager) ServeUIAsset(ctx context.Context, p *principal.Principal, prov
 		return nil, false, nil
 	}
 
-	m.mu.RLock()
-	sessionIDs := append([]string(nil), m.ownerIndex[owner]...)
-	sessions := make(map[string]*Session, len(sessionIDs))
-	for _, id := range sessionIDs {
-		sessions[id] = m.sessions[id]
-	}
-	m.mu.RUnlock()
+	sessions := m.sessionsForOwner(owner)
 
-	for i := len(sessionIDs) - 1; i >= 0; i-- {
-		session := sessions[sessionIDs[i]]
+	for i := len(sessions) - 1; i >= 0; i-- {
+		session := sessions[i]
 		if session == nil || session.isClosed() {
 			continue
 		}
@@ -839,7 +792,6 @@ func (m *Manager) Close() error {
 		sessions = append(sessions, session)
 	}
 	m.sessions = map[string]*Session{}
-	m.ownerIndex = map[string][]string{}
 	m.authorizations = map[string]*AttachAuthorization{}
 	m.mu.Unlock()
 
@@ -864,7 +816,7 @@ func (m *Manager) closeIdleSessions(now time.Time) {
 	m.mu.RUnlock()
 	for _, session := range expired {
 		_ = session.Close()
-		m.removeSession(session.id, session.owner)
+		m.removeSession(session.id)
 	}
 }
 
@@ -962,26 +914,42 @@ func (m *Manager) sessionForDispatcherSecret(sessionID, dispatcherSecret string)
 	return session, nil
 }
 
-func (m *Manager) removeSession(sessionID, owner string) {
+func (m *Manager) sessionsForOwner(owner string) []*Session {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	sessions := make([]*Session, 0, len(m.sessions))
+	for _, session := range m.sessions {
+		if session != nil && session.owner == owner {
+			sessions = append(sessions, session)
+		}
+	}
+	m.mu.RUnlock()
+	slices.SortFunc(sessions, func(a, b *Session) int {
+		switch {
+		case a.createdAt.Before(b.createdAt):
+			return -1
+		case a.createdAt.After(b.createdAt):
+			return 1
+		case a.id < b.id:
+			return -1
+		case a.id > b.id:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return sessions
+}
+
+func (m *Manager) removeSession(sessionID string) {
 	if m == nil {
 		return
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.sessions, sessionID)
-	ids := m.ownerIndex[owner]
-	for i, id := range ids {
-		if id != sessionID {
-			continue
-		}
-		ids = append(ids[:i], ids[i+1:]...)
-		break
-	}
-	if len(ids) == 0 {
-		delete(m.ownerIndex, owner)
-		return
-	}
-	m.ownerIndex[owner] = ids
 }
 
 func (s *Session) Close() error {
@@ -1506,7 +1474,7 @@ func (c Client) dispatchCall(ctx context.Context, call *PollResponse, providers 
 	if client == nil {
 		return CompleteCallRequest{Error: encodeRPCError(status.Errorf(codes.NotFound, "local provider %q is not running", call.Provider))}
 	}
-	payload, err := hex.DecodeString(call.Request)
+	payload, err := base64.StdEncoding.DecodeString(call.RequestBase64)
 	if err != nil {
 		return CompleteCallRequest{Error: encodeRPCError(status.Errorf(codes.InvalidArgument, "decode request: %v", err))}
 	}
@@ -1522,7 +1490,7 @@ func dispatchProviderDevUI(ctx context.Context, call *PollResponse, handlers map
 	if handler == nil {
 		return CompleteCallRequest{Error: encodeRPCError(status.Errorf(codes.NotFound, "local ui for provider %q is not running", call.Provider))}
 	}
-	payload, err := hex.DecodeString(call.Request)
+	payload, err := base64.StdEncoding.DecodeString(call.RequestBase64)
 	if err != nil {
 		return CompleteCallRequest{Error: encodeRPCError(status.Errorf(codes.InvalidArgument, "decode ui request: %v", err))}
 	}

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -251,24 +251,25 @@ func TestCompleteCallTreatsOKErrorCodeAsProtocolError(t *testing.T) {
 	t.Parallel()
 
 	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	dispatcherSecret := "dispatcher-secret"
 	call := &rpcCall{id: "call-1", response: make(chan rpcResponse, 1)}
 	session := &Session{
-		id:        "session-1",
-		owner:     p.SubjectID,
-		pending:   map[string]*rpcCall{"call-1": call},
-		done:      make(chan struct{}),
-		closeDone: make(chan struct{}),
-		lastSeen:  time.Now(),
+		id:                   "session-1",
+		dispatcherSecretHash: hashDispatcherSecret(dispatcherSecret),
+		owner:                p.SubjectID,
+		pending:              map[string]*rpcCall{"call-1": call},
+		done:                 make(chan struct{}),
+		closeDone:            make(chan struct{}),
+		lastSeen:             time.Now(),
 	}
 	manager := &Manager{
-		sessions:   map[string]*Session{"session-1": session},
-		ownerIndex: map[string][]string{p.SubjectID: {"session-1"}},
+		sessions: map[string]*Session{"session-1": session},
 	}
 
-	if err := manager.CompleteCall(p, "session-1", "call-1", CompleteCallRequest{
+	if err := manager.CompleteCallWithDispatcherSecretOnly("session-1", "call-1", dispatcherSecret, CompleteCallRequest{
 		Error: &RPCError{Code: int32(codes.OK), Message: "unexpected ok"},
 	}); err != nil {
-		t.Fatalf("CompleteCall: %v", err)
+		t.Fatalf("CompleteCallWithDispatcherSecretOnly: %v", err)
 	}
 
 	select {
@@ -537,18 +538,19 @@ func TestPollSessionDropsCanceledQueuedCall(t *testing.T) {
 	t.Parallel()
 
 	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	dispatcherSecret := "dispatcher-secret"
 	session := &Session{
-		id:        "session-1",
-		owner:     p.SubjectID,
-		calls:     make(chan *rpcCall, 1),
-		pending:   map[string]*rpcCall{},
-		done:      make(chan struct{}),
-		closeDone: make(chan struct{}),
-		lastSeen:  time.Now(),
+		id:                   "session-1",
+		dispatcherSecretHash: hashDispatcherSecret(dispatcherSecret),
+		owner:                p.SubjectID,
+		calls:                make(chan *rpcCall, 1),
+		pending:              map[string]*rpcCall{},
+		done:                 make(chan struct{}),
+		closeDone:            make(chan struct{}),
+		lastSeen:             time.Now(),
 	}
 	manager := &Manager{
-		sessions:   map[string]*Session{"session-1": session},
-		ownerIndex: map[string][]string{p.SubjectID: {"session-1"}},
+		sessions: map[string]*Session{"session-1": session},
 	}
 
 	invokeCtx, cancel := context.WithCancel(context.Background())
@@ -572,9 +574,9 @@ func TestPollSessionDropsCanceledQueuedCall(t *testing.T) {
 
 	pollCtx, pollCancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
 	defer pollCancel()
-	resp, ok, err := manager.PollSession(pollCtx, p, "session-1")
+	resp, ok, err := manager.PollSessionWithDispatcherSecretOnly(pollCtx, "session-1", dispatcherSecret)
 	if err != nil {
-		t.Fatalf("PollSession: %v", err)
+		t.Fatalf("PollSessionWithDispatcherSecretOnly: %v", err)
 	}
 	if ok || resp != nil {
 		t.Fatalf("PollSession = (%#v, %t), want no call", resp, ok)

--- a/gestaltd/internal/server/provider_dev_ui_test.go
+++ b/gestaltd/internal/server/provider_dev_ui_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -40,13 +39,13 @@ func TestProviderDevMountedUIHandlerOverridesFallback(t *testing.T) {
 	defer cancel()
 	dispatchDone := make(chan error, 1)
 	go func() {
-		call, ok, err := manager.PollSession(dispatchCtx, p, session.AttachID)
+		call, ok, err := manager.PollSessionWithDispatcherSecretOnly(dispatchCtx, session.AttachID, session.DispatcherSecret)
 		if err != nil || !ok {
 			dispatchDone <- err
 			return
 		}
 		var assetReq providerdev.UIAssetRequest
-		payload, err := hex.DecodeString(call.Request)
+		payload, err := base64.StdEncoding.DecodeString(call.RequestBase64)
 		if err == nil {
 			err = json.Unmarshal(payload, &assetReq)
 		}
@@ -66,8 +65,8 @@ func TestProviderDevMountedUIHandlerOverridesFallback(t *testing.T) {
 			dispatchDone <- err
 			return
 		}
-		dispatchDone <- manager.CompleteCall(p, session.AttachID, call.CallID, providerdev.CompleteCallRequest{
-			Response: hex.EncodeToString(respPayload),
+		dispatchDone <- manager.CompleteCallWithDispatcherSecretOnly(session.AttachID, call.CallID, session.DispatcherSecret, providerdev.CompleteCallRequest{
+			ResponseBase64: base64.StdEncoding.EncodeToString(respPayload),
 		})
 	}()
 
@@ -179,7 +178,7 @@ func TestProviderDevMountedUIHandlerUsesMountedAuthRuntime(t *testing.T) {
 
 	dispatchDone := make(chan error, 1)
 	go func() {
-		call, ok, err := manager.PollSession(context.Background(), p, session.AttachID)
+		call, ok, err := manager.PollSessionWithDispatcherSecretOnly(context.Background(), session.AttachID, session.DispatcherSecret)
 		if err != nil || !ok {
 			dispatchDone <- err
 			return
@@ -193,8 +192,8 @@ func TestProviderDevMountedUIHandlerUsesMountedAuthRuntime(t *testing.T) {
 			dispatchDone <- err
 			return
 		}
-		dispatchDone <- manager.CompleteCall(p, session.AttachID, call.CallID, providerdev.CompleteCallRequest{
-			Response: hex.EncodeToString(respPayload),
+		dispatchDone <- manager.CompleteCallWithDispatcherSecretOnly(session.AttachID, call.CallID, session.DispatcherSecret, providerdev.CompleteCallRequest{
+			ResponseBase64: base64.StdEncoding.EncodeToString(respPayload),
 		})
 	}()
 
@@ -271,7 +270,7 @@ func TestProviderDevMountedUIHandlerUsesAnonymousForNoAuthMountedUI(t *testing.T
 
 	dispatchDone := make(chan error, 1)
 	go func() {
-		call, ok, err := manager.PollSession(context.Background(), p, session.AttachID)
+		call, ok, err := manager.PollSessionWithDispatcherSecretOnly(context.Background(), session.AttachID, session.DispatcherSecret)
 		if err != nil || !ok {
 			dispatchDone <- err
 			return
@@ -284,8 +283,8 @@ func TestProviderDevMountedUIHandlerUsesAnonymousForNoAuthMountedUI(t *testing.T
 			dispatchDone <- err
 			return
 		}
-		dispatchDone <- manager.CompleteCall(p, session.AttachID, call.CallID, providerdev.CompleteCallRequest{
-			Response: hex.EncodeToString(respPayload),
+		dispatchDone <- manager.CompleteCallWithDispatcherSecretOnly(session.AttachID, call.CallID, session.DispatcherSecret, providerdev.CompleteCallRequest{
+			ResponseBase64: base64.StdEncoding.EncodeToString(respPayload),
 		})
 	}()
 


### PR DESCRIPTION
## Summary

Simplifies provider-dev remote attach internals now that there are no compatibility requirements:

- Deletes the `ownerIndex` side table; owner-scoped lookups scan the in-memory attachment map and preserve latest-successful-attach precedence by timestamping under the manager lock.
- Deletes the direct owner poll/complete manager helpers; dispatcher traffic uses the dispatcher-secret path everywhere in production code and tests.
- Simplifies the dispatcher wire payload to one binary encoding: poll responses return `requestBase64`, and call completions accept `responseBase64`. The old hex `response` completion field is removed.

## Kept Interfaces

- `POST /api/v1/provider-dev/attachments` returns `attachId`, `dispatcherSecret`, and provider runtime env.
- `GET /api/v1/provider-dev/attachments` lists owner-scoped, redacted attachments.
- `GET /api/v1/provider-dev/attachments/{attachId}` shows one owner-scoped, redacted attachment.
- `GET /api/v1/provider-dev/attachments/{attachId}/poll` requires `X-Gestalt-Provider-Dev-Dispatcher` and returns calls with `requestBase64`.
- `POST /api/v1/provider-dev/attachments/{attachId}/calls/{callId}` requires `X-Gestalt-Provider-Dev-Dispatcher` and accepts `responseBase64` or `error`.
- `DELETE /api/v1/provider-dev/attachments/{attachId}` works with either the dispatcher secret or owner authentication.

## Examples

```bash
gestaltd provider dev --remote https://valon.tools --path ./plugins/slack
gestaltd provider attach list --remote https://valon.tools
gestaltd provider attach show --remote https://valon.tools att_123
gestaltd provider attach detach --remote https://valon.tools att_123
```

Dispatcher completion payload:

```json
{ "responseBase64": "CgJvaw==" }
```

Dispatcher poll payload:

```json
{ "callId": "call_123", "provider": "slack", "method": "Execute", "requestBase64": "Cg..." }
```

## Validation

- `go test ./internal/providerdev ./internal/server ./cmd/gestaltd`
- `golangci-lint run --allow-parallel-runners ./internal/providerdev ./internal/server ./cmd/gestaltd`
- `git diff --check`