### PR TITLE
Close IndexedDB cursor after update transport check

### DIFF
--- a/sdk/typescript/tests/indexeddb.transport.test.ts
+++ b/sdk/typescript/tests/indexeddb.transport.test.ts
@@ -523,6 +523,7 @@ describe("IndexedDB transport", () => {
     expect(cursor!.value).toEqual({ id: "u1", status: "inactive" });
     const got = await os.get("u1");
     expect(got).toEqual({ id: "u1", status: "inactive" });
+    cursor!.close();
   });
 
   test("error mapping: get missing throws NotFoundError", async () => {


### PR DESCRIPTION
## Summary
- Closes the cursor stream in the TypeScript IndexedDB cursor-update transport case after validating the mutation.
- Keeps the existing W3C IndexedDB API contract unchanged; this is a test lifecycle cleanup only.

## Interfaces
None.

## Example
```ts
await cursor.update({ id: "u1", status: "inactive" });
expect(cursor.value).toEqual({ id: "u1", status: "inactive" });
cursor.close();
```

## Validation
- `bun test tests/indexeddb.transport.test.ts && bun run typecheck` from `sdk/typescript`