### PR TITLE
Simplify provider-dev remote attach auth

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -894,15 +894,13 @@ acknowledgement. On a load-balanced remote, enable it only when the deployment
 is single-replica or sticky-routes attach creation, CLI poll/complete traffic,
 provider invocations, and provider-owned UI requests for the same authenticated
 owner to the same `gestaltd` process.
-Remote provider dev uses `--remote-token` first, then `GESTALT_API_KEY`, then a
-stored CLI token when the stored credential's server base URL matches
-`--remote`. An API token used for direct attach must include
-`permissions[].actions: ["provider_dev.attach"]` for every attached plugin. A
-stored CLI token without that action is not enough for direct attach, so the CLI
-falls back to browser approval when available. A stored credential for a
-different server URL, including a different path prefix on the same host, is not
-sent; the browser approval flow is used instead. Use `--remote-token` or
-`GESTALT_API_KEY` for non-interactive automation.
+Remote provider dev uses `--remote-token` first, then `GESTALT_API_KEY` for
+non-interactive direct attach. Stored CLI credentials are intentionally not used
+for direct attach; without an explicit token, the CLI uses browser approval. An
+API token used for direct attach must include
+`permissions[].actions: ["provider_dev.attach"]` for every attached plugin.
+Stored CLI credentials are not sent on the direct attach path. Use
+`--remote-token` or `GESTALT_API_KEY` for non-interactive automation.
 
 Remote attach creates an owner-scoped attachment. The server returns an
 `attachId` and a one-time dispatcher secret; the CLI uses both for local

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -96,12 +96,11 @@ that page with your normal browser session creates an owner-scoped attachment
 only when your resolved role is allowed by the plugin's provider-dev attach
 configuration. The terminal prints a verification code, and the browser approval
 page requires that code before approval succeeds. `--remote-token` and
-`GESTALT_API_KEY` are the non-interactive path; those API tokens must include
-`permissions[].actions:
-["provider_dev.attach"]` for every attached plugin. If a stored CLI token exists
-for the same server, the CLI first tries it for direct attach and falls back to
-browser approval when it is not attach-scoped. Stored CLI tokens are not sent to
-a different remote URL, including a different path prefix on the same host.
+`GESTALT_API_KEY` are the non-interactive direct-attach path; those API tokens
+must include `permissions[].actions: ["provider_dev.attach"]` for every attached
+plugin. Stored CLI credentials from `gestaltd auth login` are not used for
+direct attach; when no explicit token is provided, `provider dev --remote` uses
+browser approval.
 With `--remote URL --path PATH` and no `--config`, the local command sends the
 manifest `source` and the local implementation only; the remote server chooses
 the configured plugin with the same manifest `source` and preserves that

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -174,11 +174,6 @@ type storedGestaltCLICredential struct {
 	APIToken string `json:"api_token"`
 }
 
-type providerRemoteAuth struct {
-	Token    string
-	Explicit bool
-}
-
 var providerRemoteOpenBrowser = openProviderRemoteBrowser
 
 func runProviderRemoteDev(opts providerLocalCommandOptions) error {
@@ -204,14 +199,14 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	if _, err := providerRemoteBaseURL(opts.Remote); err != nil {
 		return fmt.Errorf("invalid --remote %q: %w", opts.Remote, err)
 	}
-	auth := resolveProviderRemoteAttachAuth(opts)
+	remoteToken := resolveProviderRemoteAttachToken(opts)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	client := providerdev.Client{
 		BaseURL: opts.Remote,
-		Token:   auth.Token,
+		Token:   remoteToken,
 	}
 	requestedProviders := make([]providerdev.AttachProvider, 0, len(targets))
 	localUIHandlersByTarget := map[int]http.Handler{}
@@ -250,7 +245,7 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		requestedProviders = append(requestedProviders, requested)
 	}
 	sessionReq := providerdev.CreateSessionRequest{Providers: requestedProviders}
-	session, err := createProviderRemoteSession(ctx, &client, sessionReq, auth)
+	session, err := createProviderRemoteSession(ctx, &client, sessionReq)
 	if err != nil {
 		return err
 	}
@@ -311,43 +306,25 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 	return client.RunDispatcher(ctx, attachID, providerClients, providerdev.WithUIHandlers(localUIHandlers))
 }
 
-func resolveProviderRemoteAttachAuth(opts providerLocalCommandOptions) providerRemoteAuth {
+func resolveProviderRemoteAttachToken(opts providerLocalCommandOptions) string {
 	if token := strings.TrimSpace(opts.RemoteToken); token != "" {
-		return providerRemoteAuth{Token: token, Explicit: true}
+		return token
 	}
 	if token := strings.TrimSpace(os.Getenv(gestaltAPIKeyEnv)); token != "" {
-		return providerRemoteAuth{Token: token, Explicit: true}
+		return token
 	}
-	token, _ := resolveProviderRemoteToken(opts)
-	if token == "" {
-		return providerRemoteAuth{}
-	}
-	return providerRemoteAuth{Token: token}
+	return ""
 }
 
-func createProviderRemoteSession(ctx context.Context, client *providerdev.Client, req providerdev.CreateSessionRequest, auth providerRemoteAuth) (*providerdev.CreateSessionResponse, error) {
-	if strings.TrimSpace(auth.Token) != "" {
+func createProviderRemoteSession(ctx context.Context, client *providerdev.Client, req providerdev.CreateSessionRequest) (*providerdev.CreateSessionResponse, error) {
+	if strings.TrimSpace(client.Token) != "" {
 		session, err := client.CreateSession(ctx, req)
 		if err == nil {
 			return session, nil
 		}
-		if auth.Explicit || !providerRemoteCreateSessionCanUseBrowserApproval(err) {
-			return nil, providerRemoteCreateSessionError(err)
-		}
-		fmt.Fprintf(os.Stderr, "Stored CLI credentials could not create provider-dev attach directly; opening browser approval instead.\n\n")
-		client.Token = ""
+		return nil, providerRemoteCreateSessionError(err)
 	}
 	return createProviderRemoteSessionWithBrowser(ctx, client, req)
-}
-
-func providerRemoteCreateSessionCanUseBrowserApproval(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "provider dev attach access denied") ||
-		strings.Contains(msg, "401 Unauthorized") ||
-		strings.Contains(msg, "403 Forbidden")
 }
 
 func createProviderRemoteSessionWithBrowser(ctx context.Context, client *providerdev.Client, req providerdev.CreateSessionRequest) (*providerdev.CreateSessionResponse, error) {
@@ -400,17 +377,6 @@ func openProviderRemoteBrowser(rawURL string) error {
 	default:
 		return exec.Command("xdg-open", rawURL).Start()
 	}
-}
-
-func resolveProviderRemoteToken(opts providerLocalCommandOptions) (string, error) {
-	return resolveProviderRemoteTokenWithErrors(opts.Remote, opts.RemoteToken, providerRemoteTokenErrors{
-		AuthMissing:              providerRemoteAuthMissingError,
-		StoredCredentialUnscoped: providerRemoteStoredCredentialUnscopedError,
-		StoredCredentialMismatch: providerRemoteStoredCredentialMismatchError,
-		StoredCredentialMissingToken: func(credentialPath string) error {
-			return fmt.Errorf("stored Gestalt CLI credential in %s is missing api_token; pass --remote-token with a user API token that grants provider_dev.attach for the target plugin", credentialPath)
-		},
-	})
 }
 
 type providerRemoteTokenErrors struct {
@@ -518,57 +484,6 @@ func providerRemoteBaseURL(rawURL string) (string, error) {
 	return baseURL, nil
 }
 
-func providerRemoteAuthMissingError(remoteOrigin string) error {
-	return fmt.Errorf(`provider dev --remote requires authentication.
-
-Remote server:
-  %s
-
-No --remote-token or %s was provided, and no stored Gestalt CLI credential for this server was found.
-
-Create a user API token for this server with permissions[].actions including provider_dev.attach for the target plugin, then pass it explicitly:
-
-  gestaltd provider dev --remote %s --remote-token <token> --path ./plugin
-
-You can also set %s for this command`, remoteOrigin, gestaltAPIKeyEnv, remoteOrigin, gestaltAPIKeyEnv)
-}
-
-func providerRemoteStoredCredentialUnscopedError(remoteOrigin, credentialPath string) error {
-	return fmt.Errorf(`provider dev --remote could not use the stored Gestalt CLI credential.
-
-Remote server:
-  %s
-
-Stored credential:
-  server: <missing>
-  file: %s
-
-The stored credential does not record which Gestalt server it belongs to, so it was not sent.
-
-Create a user API token for this server with permissions[].actions including provider_dev.attach for the target plugin, then pass it explicitly:
-
-  gestaltd provider dev --remote %s --remote-token <token> --path ./plugin`, remoteOrigin, credentialPath, remoteOrigin)
-}
-
-func providerRemoteStoredCredentialMismatchError(remoteOrigin, storedOrigin, credentialPath string) error {
-	return fmt.Errorf(`provider dev --remote could not use the stored Gestalt CLI credential.
-
-Remote server:
-  %s
-
-Stored credential:
-  server: %s
-  file: %s
-
-The stored credential is scoped to a different Gestalt server, so it was not sent.
-
-Create a user API token for this server with permissions[].actions including provider_dev.attach for the target plugin, then pass it explicitly:
-
-  gestaltd provider dev --remote %s --remote-token <token> --path ./plugin
-
-You can also set %s for this command`, remoteOrigin, storedOrigin, credentialPath, remoteOrigin, gestaltAPIKeyEnv)
-}
-
 func providerRemoteCreateSessionError(err error) error {
 	if err == nil {
 		return nil
@@ -580,7 +495,7 @@ func providerRemoteCreateSessionError(err error) error {
 
 remote provider-dev attach was denied. The remote plugin must grant providerDev.attach.allowedRoles for your resolved role, and API token callers must use a user token with permissions[].actions including provider_dev.attach for every attached plugin.
 
-provider scopes, operation permissions, subject-owned API tokens, and stored gestalt auth login API tokens do not grant direct remote attach. Run without --remote-token/%s to use browser approval when the server supports it`, err, gestaltAPIKeyEnv)
+provider scopes, operation permissions, and subject-owned API tokens do not grant direct remote attach. Run without --remote-token/%s to use browser approval when the server supports it`, err, gestaltAPIKeyEnv)
 }
 
 func providerRemoteTargetNames(targets []providerRemoteTarget) []string {

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -104,137 +104,33 @@ func TestProviderRemoteConfigPathSynthesizesSourcePlugin(t *testing.T) {
 	}
 }
 
-func TestResolveProviderRemoteTokenPrecedence(t *testing.T) {
+func TestResolveProviderRemoteAttachTokenPrecedence(t *testing.T) {
 	configHome := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", configHome)
 	writeStoredGestaltCLICredentialForTest(t, configHome, "https://stored.example.com", "stored-token")
 
 	t.Setenv(gestaltAPIKeyEnv, "env-token")
-	token, err := resolveProviderRemoteToken(providerLocalCommandOptions{
+	token := resolveProviderRemoteAttachToken(providerLocalCommandOptions{
 		Remote:      "https://remote.example.com",
 		RemoteToken: "flag-token",
 	})
-	if err != nil {
-		t.Fatalf("resolveProviderRemoteToken with explicit token: %v", err)
-	}
 	if token != "flag-token" {
 		t.Fatalf("token = %q, want explicit flag token", token)
 	}
 
-	token, err = resolveProviderRemoteToken(providerLocalCommandOptions{
+	token = resolveProviderRemoteAttachToken(providerLocalCommandOptions{
 		Remote: "https://remote.example.com",
 	})
-	if err != nil {
-		t.Fatalf("resolveProviderRemoteToken with env token: %v", err)
-	}
 	if token != "env-token" {
 		t.Fatalf("token = %q, want env token", token)
 	}
-}
 
-func TestResolveProviderRemoteTokenUsesMatchingStoredCLICredential(t *testing.T) {
-	configHome := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", configHome)
 	t.Setenv(gestaltAPIKeyEnv, "")
-	writeStoredGestaltCLICredentialForTest(t, configHome, "https://Valon.Tools:443/team-a/", "stored-token")
-
-	token, err := resolveProviderRemoteToken(providerLocalCommandOptions{
-		Remote: "https://valon.tools/team-a",
+	token = resolveProviderRemoteAttachToken(providerLocalCommandOptions{
+		Remote: "https://stored.example.com",
 	})
-	if err != nil {
-		t.Fatalf("resolveProviderRemoteToken: %v", err)
-	}
-	if token != "stored-token" {
-		t.Fatalf("token = %q, want stored token", token)
-	}
-}
-
-func TestResolveProviderRemoteTokenErrors(t *testing.T) {
-	tests := []struct {
-		name         string
-		remote       string
-		storedServer string
-		writeStored  bool
-		want         func(configHome string) []string
-	}{
-		{
-			name:         "different base paths",
-			remote:       "https://valon.tools/team-b",
-			storedServer: "https://valon.tools/team-a",
-			writeStored:  true,
-			want: func(string) []string {
-				return []string{
-					"Remote server:\n  https://valon.tools/team-b",
-					"Stored credential:\n  server: https://valon.tools/team-a",
-					"The stored credential is scoped to a different Gestalt server, so it was not sent.",
-				}
-			},
-		},
-		{
-			name:         "mismatched stored credential",
-			remote:       "https://staging.valon.tools",
-			storedServer: "https://valon.tools",
-			writeStored:  true,
-			want: func(configHome string) []string {
-				return []string{
-					"provider dev --remote could not use the stored Gestalt CLI credential.",
-					"Remote server:\n  https://staging.valon.tools",
-					"Stored credential:\n  server: https://valon.tools",
-					filepath.Join(configHome, "gestalt", "credentials.json"),
-					"The stored credential is scoped to a different Gestalt server, so it was not sent.",
-					"permissions[].actions including provider_dev.attach",
-					"gestaltd provider dev --remote https://staging.valon.tools --remote-token <token> --path ./plugin",
-					"You can also set GESTALT_API_KEY for this command",
-				}
-			},
-		},
-		{
-			name:        "unscoped stored credential",
-			remote:      "https://valon.tools",
-			writeStored: true,
-			want: func(string) []string {
-				return []string{
-					"Stored credential:\n  server: <missing>",
-					"The stored credential does not record which Gestalt server it belongs to, so it was not sent.",
-					"permissions[].actions including provider_dev.attach",
-				}
-			},
-		},
-		{
-			name:   "missing credential",
-			remote: "https://valon.tools",
-			want: func(string) []string {
-				return []string{
-					"provider dev --remote requires authentication.",
-					"Remote server:\n  https://valon.tools",
-					"No --remote-token or GESTALT_API_KEY was provided, and no stored Gestalt CLI credential for this server was found.",
-					"permissions[].actions including provider_dev.attach",
-					"gestaltd provider dev --remote https://valon.tools --remote-token <token> --path ./plugin",
-				}
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			configHome := t.TempDir()
-			t.Setenv("XDG_CONFIG_HOME", configHome)
-			t.Setenv(gestaltAPIKeyEnv, "")
-			if tc.writeStored {
-				writeStoredGestaltCLICredentialForTest(t, configHome, tc.storedServer, "stored-token")
-			}
-
-			_, err := resolveProviderRemoteToken(providerLocalCommandOptions{Remote: tc.remote})
-			if err == nil {
-				t.Fatal("expected remote token resolution error")
-			}
-			errText := err.Error()
-			for _, want := range tc.want(configHome) {
-				if !strings.Contains(errText, want) {
-					t.Fatalf("error missing %q:\n%s", want, errText)
-				}
-			}
-		})
+	if token != "" {
+		t.Fatalf("token = %q, want stored CLI credentials ignored for browser approval", token)
 	}
 }
 
@@ -249,7 +145,6 @@ func TestProviderRemoteCreateSessionErrorAddsAttachPermissionGuidance(t *testing
 		"remote provider-dev attach was denied",
 		"providerDev.attach.allowedRoles",
 		"permissions[].actions including provider_dev.attach",
-		"stored gestalt auth login API tokens do not grant direct remote attach",
 		"browser approval",
 	} {
 		if !strings.Contains(err.Error(), want) {
@@ -263,7 +158,7 @@ func TestProviderRemoteCreateSessionErrorAddsAttachPermissionGuidance(t *testing
 	}
 }
 
-func TestCreateProviderRemoteSessionFallsBackToBrowserApprovalForStoredToken(t *testing.T) {
+func TestCreateProviderRemoteSessionUsesBrowserApprovalWithoutAttachToken(t *testing.T) {
 	t.Parallel()
 
 	var openedURL string
@@ -280,16 +175,9 @@ func TestCreateProviderRemoteSessionFallsBackToBrowserApprovalForStoredToken(t *
 		code         = "pdac_code"
 		dispatcher   = "pda_dispatcher"
 	)
-	var sawDirectToken bool
 	var createdAuthorizedSession bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == providerdev.PathAttachments:
-			if r.Header.Get("Authorization") != "Bearer stored-token" {
-				t.Fatalf("direct attach Authorization = %q, want stored token", r.Header.Get("Authorization"))
-			}
-			sawDirectToken = true
-			http.Error(w, "provider dev attach access denied", http.StatusForbidden)
 		case r.Method == http.MethodPost && r.URL.Path == providerdev.PathAttachAuthorizations:
 			if r.Header.Get("Authorization") != "" {
 				t.Fatalf("browser authorization should not send bearer token, got %q", r.Header.Get("Authorization"))
@@ -321,6 +209,9 @@ func TestCreateProviderRemoteSessionFallsBackToBrowserApprovalForStoredToken(t *
 			if req.AttachAuthorizationCode != code {
 				t.Fatalf("attach authorization code = %q, want %q", req.AttachAuthorizationCode, code)
 			}
+			if len(req.Providers) != 1 || req.Providers[0].Name != "roadmap" {
+				t.Fatalf("authorized attach providers = %#v, want roadmap", req.Providers)
+			}
 			createdAuthorizedSession = true
 			writeJSONForProviderRemoteTest(t, w, http.StatusCreated, providerdev.CreateSessionResponse{
 				AttachID:         "attach-1",
@@ -333,17 +224,14 @@ func TestCreateProviderRemoteSessionFallsBackToBrowserApprovalForStoredToken(t *
 	}))
 	defer ts.Close()
 
-	client := providerdev.Client{BaseURL: ts.URL, Token: "stored-token", HTTPClient: ts.Client()}
+	client := providerdev.Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	session, err := createProviderRemoteSession(ctx, &client, providerdev.CreateSessionRequest{
 		Providers: []providerdev.AttachProvider{{Name: "roadmap"}},
-	}, providerRemoteAuth{Token: "stored-token"})
+	})
 	if err != nil {
 		t.Fatalf("createProviderRemoteSession: %v", err)
-	}
-	if !sawDirectToken {
-		t.Fatal("expected direct attach attempt with stored token")
 	}
 	if openedURL == "" {
 		t.Fatal("expected browser approval URL to be opened")


### PR DESCRIPTION
## Summary

Simplifies provider-dev remote attach auth by removing the stored-credential direct attach branch. Direct attach now only uses an explicit `--remote-token` or `GESTALT_API_KEY`; otherwise the interactive path goes straight to browser approval.

This avoids trying a stored `gestaltd auth login` credential, handling its attach-permission failure, and then falling back to browser approval. Stored CLI credentials still work for `provider attach list/show/detach` owner diagnostics.

## Deleted Interfaces / Code Paths

- Removed `providerRemoteAuth` and its `Explicit` mode.
- Removed provider-dev-specific stored credential mismatch/unscoped/missing error helpers.
- Removed direct attach fallback logic for stored CLI credentials.
- Removed tests that treated stored CLI credentials as direct provider-dev attach tokens.

## Kept Interfaces

```bash
# Interactive happy path: browser approval.
gestaltd provider dev --remote https://valon.tools --path ./plugins/slack

# Non-interactive direct attach with an explicit attach-scoped token.
gestaltd provider dev --remote https://valon.tools --remote-token gst_api_... --path ./plugins/slack

# Env-token direct attach.
GESTALT_API_KEY=gst_api_... gestaltd provider dev --remote https://valon.tools --path ./plugins/slack

# Owner diagnostics still support matching stored CLI credentials.
gestaltd provider attach list --remote https://valon.tools
gestaltd provider attach show --remote https://valon.tools att_123
gestaltd provider attach detach --remote https://valon.tools att_123
```

## Docs

Updated:

- `docs/content/custom-providers/plugins.mdx`
- `docs/content/reference/cli.mdx`

## Validation

- `go test -count=1 ./internal/providerdev ./internal/server`
- `go test -count=1 ./cmd/gestaltd -run 'TestResolveProviderRemoteAttachTokenPrecedence|TestProviderRemoteCreateSessionErrorAddsAttachPermissionGuidance|TestCreateProviderRemoteSessionUsesBrowserApprovalWithoutAttachToken|TestResolveProviderAttachToken|TestProviderAttach'`
- `golangci-lint run --allow-parallel-runners ./internal/providerdev ./internal/server ./cmd/gestaltd`
- `git diff --check`