### PR TITLE
Simplify provider-dev browser approval exchange

### DIFF
--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -354,11 +354,6 @@ func createProviderRemoteSessionWithBrowser(ctx context.Context, client *provide
 			return nil, fmt.Errorf("poll provider dev browser approval: %w", err)
 		}
 		if status.Approved {
-			code := strings.TrimSpace(status.AttachAuthorizationCode)
-			if code == "" {
-				return nil, errors.New("provider dev browser approval did not return an authorization code")
-			}
-			req.AttachAuthorizationCode = code
 			return client.CreateAuthorizedSession(ctx, authorization.AuthorizationID, req)
 		}
 		if !authorization.ExpiresAt.IsZero() && time.Now().After(authorization.ExpiresAt) {

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -172,7 +172,6 @@ func TestCreateProviderRemoteSessionUsesBrowserApprovalWithoutAttachToken(t *tes
 	const (
 		authID       = "auth-1"
 		clientSecret = "pdaa_secret"
-		code         = "pdac_code"
 		dispatcher   = "pda_dispatcher"
 	)
 	var createdAuthorizedSession bool
@@ -195,8 +194,7 @@ func TestCreateProviderRemoteSessionUsesBrowserApprovalWithoutAttachToken(t *tes
 				t.Fatalf("poll authorization secret = %q, want %q", r.Header.Get(providerdev.HeaderAuthorizationSecret), clientSecret)
 			}
 			writeJSONForProviderRemoteTest(t, w, http.StatusOK, providerdev.PollAttachAuthorizationResponse{
-				Approved:                true,
-				AttachAuthorizationCode: code,
+				Approved: true,
 			})
 		case r.Method == http.MethodPost && r.URL.Path == providerdev.PathAttachAuthorizations+"/"+authID+"/attachments":
 			if r.Header.Get(providerdev.HeaderAuthorizationSecret) != clientSecret {
@@ -205,9 +203,6 @@ func TestCreateProviderRemoteSessionUsesBrowserApprovalWithoutAttachToken(t *tes
 			var req providerdev.CreateSessionRequest
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				t.Fatalf("decode authorized attach request: %v", err)
-			}
-			if req.AttachAuthorizationCode != code {
-				t.Fatalf("attach authorization code = %q, want %q", req.AttachAuthorizationCode, code)
 			}
 			if len(req.Providers) != 1 || req.Providers[0].Name != "roadmap" {
 				t.Fatalf("authorized attach providers = %#v, want roadmap", req.Providers)

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -72,8 +72,7 @@ type Manager struct {
 }
 
 type CreateSessionRequest struct {
-	Providers               []AttachProvider `json:"providers"`
-	AttachAuthorizationCode string           `json:"attachAuthorizationCode,omitempty"`
+	Providers []AttachProvider `json:"providers"`
 }
 
 type AttachProvider struct {
@@ -116,8 +115,7 @@ type AttachAuthorizationInfo struct {
 }
 
 type PollAttachAuthorizationResponse struct {
-	Approved                bool   `json:"approved"`
-	AttachAuthorizationCode string `json:"attachAuthorizationCode,omitempty"`
+	Approved bool `json:"approved"`
 }
 
 type AttachmentInfo struct {
@@ -151,8 +149,6 @@ type AttachAuthorization struct {
 	expiresAt        time.Time
 	approvedAt       time.Time
 	approvedBy       *principal.Principal
-	codeHash         string
-	code             string
 	used             bool
 }
 
@@ -492,14 +488,8 @@ func (m *Manager) ApproveAttachAuthorization(id string, p *principal.Principal, 
 		}
 		return status.Error(codes.FailedPrecondition, "provider dev attach authorization is already approved")
 	}
-	code, codeHash, err := newAttachAuthorizationCode()
-	if err != nil {
-		return status.Errorf(codes.Internal, "create provider dev attach authorization code: %v", err)
-	}
 	auth.approvedAt = time.Now()
 	auth.approvedBy = clonePrincipal(p)
-	auth.code = code
-	auth.codeHash = codeHash
 	return nil
 }
 
@@ -511,12 +501,11 @@ func (m *Manager) PollAttachAuthorization(id, clientSecret string) (*PollAttachA
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return &PollAttachAuthorizationResponse{
-		Approved:                !auth.approvedAt.IsZero(),
-		AttachAuthorizationCode: auth.code,
+		Approved: !auth.approvedAt.IsZero(),
 	}, nil
 }
 
-func (m *Manager) ConsumeAttachAuthorization(id, clientSecret, code string, req CreateSessionRequest) (*principal.Principal, error) {
+func (m *Manager) ConsumeAttachAuthorization(id, clientSecret string, req CreateSessionRequest) (*principal.Principal, error) {
 	auth, err := m.attachAuthorizationWithClientSecret(id, clientSecret, time.Now())
 	if err != nil {
 		return nil, err
@@ -525,20 +514,13 @@ func (m *Manager) ConsumeAttachAuthorization(id, clientSecret, code string, req 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "hash provider dev attach authorization request: %v", err)
 	}
-	code = strings.TrimSpace(code)
-	if code == "" {
-		return nil, status.Error(codes.Unauthenticated, "provider dev attach authorization code is required")
-	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if auth.used {
 		return nil, status.Error(codes.FailedPrecondition, "provider dev attach authorization was already used")
 	}
-	if auth.approvedBy == nil || auth.codeHash == "" {
+	if auth.approvedBy == nil {
 		return nil, status.Error(codes.FailedPrecondition, "provider dev attach authorization is not approved")
-	}
-	if subtle.ConstantTimeCompare([]byte(hashAttachAuthorizationSecret(code)), []byte(auth.codeHash)) != 1 {
-		return nil, status.Error(codes.PermissionDenied, "provider dev attach authorization code is invalid")
 	}
 	if subtle.ConstantTimeCompare([]byte(requestHash), []byte(auth.requestHash)) != 1 {
 		return nil, status.Error(codes.PermissionDenied, "provider dev attach authorization request does not match")
@@ -1925,15 +1907,6 @@ func newAttachAuthorizationSecret() (secret string, hash string, err error) {
 	return secret, hashAttachAuthorizationSecret(secret), nil
 }
 
-func newAttachAuthorizationCode() (code string, hash string, err error) {
-	id, err := randomID()
-	if err != nil {
-		return "", "", err
-	}
-	code = "pdac_" + id
-	return code, hashAttachAuthorizationSecret(code), nil
-}
-
 func newAttachAuthorizationVerificationCode() (code string, hash string, err error) {
 	var b [4]byte
 	if _, err := rand.Read(b[:]); err != nil {
@@ -1975,7 +1948,6 @@ func normalizeAttachAuthorizationVerificationCode(code string) string {
 }
 
 func attachAuthorizationRequestHash(req CreateSessionRequest) (string, error) {
-	req.AttachAuthorizationCode = ""
 	payload, err := json.Marshal(req)
 	if err != nil {
 		return "", err

--- a/gestaltd/internal/server/handlers_provider_dev.go
+++ b/gestaltd/internal/server/handlers_provider_dev.go
@@ -198,7 +198,7 @@ func (s *Server) createAuthorizedProviderDevSession(w http.ResponseWriter, r *ht
 		writeError(w, http.StatusBadRequest, "invalid provider dev session request")
 		return
 	}
-	p, err := s.providerDevSessions.ConsumeAttachAuthorization(providerDevAuthorizationID(r), providerDevAuthorizationSecret(r), req.AttachAuthorizationCode, req)
+	p, err := s.providerDevSessions.ConsumeAttachAuthorization(providerDevAuthorizationID(r), providerDevAuthorizationSecret(r), req)
 	if err != nil {
 		writeProviderDevError(w, err)
 		return

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6609,8 +6609,8 @@ func TestProviderDevAttachAuthorizationBrowserApprovalCreatesDispatcherSession(t
 	if err := json.Unmarshal(pollBody, &poll); err != nil {
 		t.Fatalf("decode poll response: %v", err)
 	}
-	if !poll.Approved || poll.AttachAuthorizationCode == "" {
-		t.Fatalf("poll response missing approval/code: %s", pollBody)
+	if !poll.Approved {
+		t.Fatalf("poll response missing approval: %s", pollBody)
 	}
 
 	approveReq, err = http.NewRequest(http.MethodPost, authorization.ApprovalURL+"/approve", strings.NewReader(url.Values{"verificationCode": {authorization.VerificationCode}}.Encode()))
@@ -6645,11 +6645,48 @@ func TestProviderDevAttachAuthorizationBrowserApprovalCreatesDispatcherSession(t
 	if err := json.Unmarshal(pollBody, &secondPoll); err != nil {
 		t.Fatalf("decode second poll response: %v", err)
 	}
-	if secondPoll.AttachAuthorizationCode != poll.AttachAuthorizationCode {
-		t.Fatalf("approval code changed after idempotent approve: got %q want %q", secondPoll.AttachAuthorizationCode, poll.AttachAuthorizationCode)
+	if !secondPoll.Approved {
+		t.Fatalf("second poll response missing approval: %s", pollBody)
 	}
 
-	sessionReq, err := http.NewRequest(http.MethodPost, ts.URL+providerdev.PathAttachAuthorizations+"/"+authorization.AuthorizationID+"/attachments", strings.NewReader(fmt.Sprintf(`{"attachAuthorizationCode":%q,"providers":[{"name":"roadmap"}]}`, poll.AttachAuthorizationCode)))
+	missingSecretReq, err := http.NewRequest(http.MethodPost, ts.URL+providerdev.PathAttachAuthorizations+"/"+authorization.AuthorizationID+"/attachments", strings.NewReader(`{"providers":[{"name":"roadmap"}]}`))
+	if err != nil {
+		t.Fatalf("new missing-secret authorized session request: %v", err)
+	}
+	missingSecretReq.Header.Set("Content-Type", "application/json")
+	missingSecretResp, err := ts.Client().Do(missingSecretReq)
+	if err != nil {
+		t.Fatalf("create authorized session without secret: %v", err)
+	}
+	missingSecretBody, err := io.ReadAll(missingSecretResp.Body)
+	_ = missingSecretResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read missing-secret session response: %v", err)
+	}
+	if missingSecretResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("missing-secret session status = %d, want 401; body = %s", missingSecretResp.StatusCode, missingSecretBody)
+	}
+
+	changedRequestReq, err := http.NewRequest(http.MethodPost, ts.URL+providerdev.PathAttachAuthorizations+"/"+authorization.AuthorizationID+"/attachments", strings.NewReader(`{"providers":[{"name":"other"}]}`))
+	if err != nil {
+		t.Fatalf("new changed-request authorized session request: %v", err)
+	}
+	changedRequestReq.Header.Set("Content-Type", "application/json")
+	changedRequestReq.Header.Set(providerdev.HeaderAuthorizationSecret, authorization.ClientSecret)
+	changedRequestResp, err := ts.Client().Do(changedRequestReq)
+	if err != nil {
+		t.Fatalf("create authorized session with changed request: %v", err)
+	}
+	changedRequestBody, err := io.ReadAll(changedRequestResp.Body)
+	_ = changedRequestResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read changed-request session response: %v", err)
+	}
+	if changedRequestResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("changed-request session status = %d, want 403; body = %s", changedRequestResp.StatusCode, changedRequestBody)
+	}
+
+	sessionReq, err := http.NewRequest(http.MethodPost, ts.URL+providerdev.PathAttachAuthorizations+"/"+authorization.AuthorizationID+"/attachments", strings.NewReader(`{"providers":[{"name":"roadmap"}]}`))
 	if err != nil {
 		t.Fatalf("new authorized session request: %v", err)
 	}


### PR DESCRIPTION
## Summary

Deletes the redundant `attachAuthorizationCode` from provider-dev browser approval. The initiating CLI already authenticates the poll/create path with `X-Gestalt-Provider-Dev-Authorization`, and the server still requires browser approval plus a matching request hash before creating the attachment.

## Interface Changes

Removed:
- `PollAttachAuthorizationResponse.attachAuthorizationCode`
- `CreateSessionRequest.attachAuthorizationCode`
- `pdac_` authorization code generation and validation

Kept:
- `GET /api/v1/provider-dev/attach-authorizations/{authorizationId}/poll` returns `{ "approved": true|false }`
- `POST /api/v1/provider-dev/attach-authorizations/{authorizationId}/attachments` accepts the original `{ "providers": [...] }` request with `X-Gestalt-Provider-Dev-Authorization`

## Examples

```sh
gestaltd provider dev --remote https://valon.tools --path ./plugins/slack
```

Browser-approved create request after approval:

```http
POST /api/v1/provider-dev/attach-authorizations/pdaa_123/attachments
X-Gestalt-Provider-Dev-Authorization: <client-secret>
Content-Type: application/json

{
  "providers": [
    { "name": "slack" }
  ]
}
```

Poll response:

```json
{ "approved": true }
```

## Validation

- `go test -count=1 ./internal/providerdev ./internal/server -run 'ProviderDev|ProviderRemote|ProviderAttach'`
- `go test -count=1 ./cmd/gestaltd -run 'TestResolveProviderRemoteAttachTokenPrecedence|TestProviderRemoteCreateSessionErrorAddsAttachPermissionGuidance|TestCreateProviderRemoteSessionUsesBrowserApprovalWithoutAttachToken|TestResolveProviderAttachToken|TestProviderAttach'`
- `go test -count=1 ./internal/providerdev ./internal/server`
- `golangci-lint run --allow-parallel-runners ./internal/providerdev ./internal/server ./cmd/gestaltd`