### PR TITLE
cli: render formatted display text in stdout transcripts

### DIFF
--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -22,6 +22,7 @@ use crate::interactive::{
 use crate::output::{self, Format};
 use crate::params;
 
+mod display_markdown;
 mod tui;
 
 const SESSIONS_PATH: &str = "/api/v1/agent/sessions";
@@ -933,11 +934,16 @@ impl AgentTurnRenderer {
     }
 
     fn render_display_text(&mut self, display: &AgentTurnDisplayInfo, label: &str) -> Result<bool> {
-        let text = display_text(display);
+        let raw_text = display_text(display);
+        let rendered_text = if label == "assistant>" {
+            rendered_display_text(display)
+        } else {
+            raw_text.map(ToString::to_string)
+        };
         if label == "assistant>" {
             match display.phase.trim() {
                 "delta" => {
-                    if let Some(text) = text {
+                    if let Some(text) = raw_text {
                         self.start_assistant_line()?;
                         print!("{text}");
                         io::stdout().flush().context("failed to flush stdout")?;
@@ -948,7 +954,7 @@ impl AgentTurnRenderer {
                 }
                 "completed" => {
                     if self.assistant_line_open {
-                        let Some(text) = text else {
+                        let Some(text) = raw_text else {
                             return Ok(false);
                         };
                         if self.delta_buffer.is_empty() {
@@ -960,16 +966,16 @@ impl AgentTurnRenderer {
                         self.assistant_line_open = false;
                         self.delta_buffer.clear();
                         return Ok(true);
-                    } else if let Some(text) = text {
+                    } else if let Some(text) = rendered_text.as_deref() {
                         println!("{} {text}", self.label(label));
                         self.saw_assistant_output = true;
                         self.delta_buffer.clear();
                         return Ok(true);
                     }
                 }
-                _ if text.is_some() => {
+                _ if rendered_text.is_some() => {
                     self.finish_assistant_line();
-                    let text = text.expect("checked is_some");
+                    let text = rendered_text.as_deref().expect("checked is_some");
                     println!("{} {text}", self.label(label));
                     self.saw_assistant_output = true;
                     return Ok(true);
@@ -980,7 +986,7 @@ impl AgentTurnRenderer {
         }
 
         self.finish_assistant_line();
-        if let Some(text) = text {
+        if let Some(text) = rendered_text.as_deref() {
             println!("{} {text}", self.label(label));
             return Ok(true);
         }
@@ -1642,6 +1648,15 @@ fn display_text(display: &AgentTurnDisplayInfo) -> Option<&str> {
     } else {
         Some(&display.text)
     }
+}
+
+fn rendered_display_text(display: &AgentTurnDisplayInfo) -> Option<String> {
+    let text = display_text(display)?;
+    Some(display_markdown::plain_text_for_format(
+        text,
+        display_format(display),
+        display_language(display),
+    ))
 }
 
 fn display_label(display: &AgentTurnDisplayInfo) -> Option<&str> {

--- a/gestalt/cli/src/commands/agents/display_markdown.rs
+++ b/gestalt/cli/src/commands/agents/display_markdown.rs
@@ -1,0 +1,179 @@
+pub(super) fn effective_format<'a>(format: Option<&'a str>, language: Option<&str>) -> &'a str {
+    match format {
+        Some(format) => format,
+        None if language.is_some() => "code",
+        None => "plain",
+    }
+}
+
+pub(super) fn plain_text_for_format(
+    text: &str,
+    format: Option<&str>,
+    language: Option<&str>,
+) -> String {
+    if is_markdown_format(effective_format(format, language)) {
+        markdown_to_plain_text(text)
+    } else {
+        text.to_string()
+    }
+}
+
+pub(super) fn is_markdown_format(format: &str) -> bool {
+    matches!(format.trim(), "markdown" | "md")
+}
+
+pub(super) fn is_code_like_format(format: &str) -> bool {
+    matches!(format.trim(), "code" | "json" | "diff")
+}
+
+pub(super) fn code_fence_language(text: &str) -> Option<&str> {
+    text.trim_start().strip_prefix("```").map(str::trim)
+}
+
+pub(super) fn markdown_link(rest: &str) -> Option<(&str, &str, usize)> {
+    if !rest.starts_with('[') {
+        return None;
+    }
+    let label_end = 1 + rest[1..].find("](")?;
+    let url_start = label_end + 2;
+    let url_end = url_start + rest[url_start..].find(')')?;
+    let label = &rest[1..label_end];
+    if label.is_empty() {
+        return None;
+    }
+    let url = &rest[url_start..url_end];
+    if url.is_empty() {
+        return None;
+    }
+    Some((label, url, url_end + 1))
+}
+
+pub(super) fn raw_url(rest: &str) -> Option<(&str, usize)> {
+    if !(rest.starts_with("https://") || rest.starts_with("http://")) {
+        return None;
+    }
+    let end = rest
+        .char_indices()
+        .find_map(|(index, ch)| ch.is_whitespace().then_some(index))
+        .unwrap_or(rest.len());
+    Some((&rest[..end], end))
+}
+
+pub(super) fn delimited<'a>(
+    text: &'a str,
+    index: usize,
+    delimiter: &str,
+) -> Option<(&'a str, usize)> {
+    let rest = &text[index..];
+    if !rest.starts_with(delimiter) {
+        return None;
+    }
+    if delimiter != "`" && !delimiter_boundary_before(text, index) {
+        return None;
+    }
+    let after_open = &rest[delimiter.len()..];
+    if after_open.chars().next().is_none_or(char::is_whitespace) {
+        return None;
+    }
+    let close = after_open.find(delimiter)?;
+    if close == 0 {
+        return None;
+    }
+    let inner = &after_open[..close];
+    if inner.chars().last().is_none_or(char::is_whitespace) {
+        return None;
+    }
+    let consumed = delimiter.len() + close + delimiter.len();
+    if delimiter != "`" && !delimiter_boundary_after(text, index + consumed) {
+        return None;
+    }
+    Some((inner, consumed))
+}
+
+fn markdown_to_plain_text(text: &str) -> String {
+    let mut rendered = String::new();
+    let mut in_code_fence = false;
+    for line in text.split('\n') {
+        if code_fence_language(line).is_some() {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if !rendered.is_empty() {
+            rendered.push('\n');
+        }
+        if in_code_fence {
+            rendered.push_str(line);
+        } else {
+            rendered.push_str(&markdown_inline_to_plain_text(line));
+        }
+    }
+    rendered
+}
+
+fn markdown_inline_to_plain_text(text: &str) -> String {
+    let mut rendered = String::new();
+    let mut index = 0usize;
+    while index < text.len() {
+        let rest = &text[index..];
+
+        if let Some((label, url, consumed)) = markdown_link(rest) {
+            rendered.push_str(&markdown_inline_to_plain_text(label));
+            rendered.push_str(" (");
+            rendered.push_str(url);
+            rendered.push(')');
+            index += consumed;
+            continue;
+        }
+
+        if let Some((url, consumed)) = raw_url(rest) {
+            rendered.push_str(url);
+            index += consumed;
+            continue;
+        }
+
+        if let Some((inner, consumed)) = delimited(text, index, "`") {
+            rendered.push_str(inner);
+            index += consumed;
+            continue;
+        }
+
+        if let Some((inner, consumed)) = delimited(text, index, "**") {
+            rendered.push_str(&markdown_inline_to_plain_text(inner));
+            index += consumed;
+            continue;
+        }
+
+        if let Some((inner, consumed)) =
+            delimited(text, index, "*").or_else(|| delimited(text, index, "_"))
+        {
+            rendered.push_str(&markdown_inline_to_plain_text(inner));
+            index += consumed;
+            continue;
+        }
+
+        let Some(ch) = rest.chars().next() else {
+            break;
+        };
+        rendered.push(ch);
+        index += ch.len_utf8();
+    }
+    rendered
+}
+
+fn delimiter_boundary_before(text: &str, index: usize) -> bool {
+    text[..index]
+        .chars()
+        .next_back()
+        .is_none_or(|ch| !is_identifier_char(ch))
+}
+
+fn delimiter_boundary_after(text: &str, index: usize) -> bool {
+    text[index..]
+        .chars()
+        .next()
+        .is_none_or(|ch| !is_identifier_char(ch))
+}
+
+fn is_identifier_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_'
+}

--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -27,7 +27,7 @@ use worker::{TurnWorker, WorkerCommand, WorkerEvent, spawn_turn_worker};
 
 use super::{
     AgentInteractionInfo, AgentShell, INTERRUPT_CANCEL_REASON, agent_help_lines, agent_model_lines,
-    agent_session_lines, cancel_turn_silent, compact_json,
+    agent_session_lines, cancel_turn_silent, compact_json, display_markdown,
 };
 
 const TICK_RATE: Duration = Duration::from_millis(50);
@@ -1059,18 +1059,14 @@ fn push_assistant_item_lines(
     let bullet_style = Style::default()
         .fg(Color::Green)
         .add_modifier(Modifier::BOLD);
-    let format = item
-        .format
-        .as_deref()
-        .unwrap_or(if item.language.is_some() {
-            "code"
-        } else {
-            "plain"
-        });
+    let format =
+        display_markdown::effective_format(item.format.as_deref(), item.language.as_deref());
     let mut in_markdown_code_block = false;
     let mut visible_line_index = 0usize;
     for text_line in item.text.split('\n') {
-        if is_markdown_format(format) && markdown_code_fence_language(text_line).is_some() {
+        if display_markdown::is_markdown_format(format)
+            && display_markdown::code_fence_language(text_line).is_some()
+        {
             in_markdown_code_block = !in_markdown_code_block;
             continue;
         }
@@ -1106,28 +1102,16 @@ fn assistant_segments_for_format(
     body_style: Style,
     in_markdown_code_block: bool,
 ) -> Vec<StyledSegment> {
-    if in_markdown_code_block || is_code_like_format(format) {
+    if in_markdown_code_block || display_markdown::is_code_like_format(format) {
         return vec![StyledSegment::new(
             text.to_string(),
             body_style.fg(Color::Cyan),
         )];
     }
-    if is_markdown_format(format) {
+    if display_markdown::is_markdown_format(format) {
         return markdown_segments(text, body_style);
     }
     vec![StyledSegment::new(text.to_string(), body_style)]
-}
-
-fn is_markdown_format(format: &str) -> bool {
-    matches!(format.trim(), "markdown" | "md")
-}
-
-fn is_code_like_format(format: &str) -> bool {
-    matches!(format.trim(), "code" | "json" | "diff")
-}
-
-fn markdown_code_fence_language(text: &str) -> Option<&str> {
-    text.trim_start().strip_prefix("```").map(str::trim)
 }
 
 fn push_meta_item_lines(
@@ -1259,7 +1243,7 @@ fn markdown_segments_with_depth(text: &str, base_style: Style, depth: usize) -> 
     while index < text.len() {
         let rest = &text[index..];
 
-        if let Some((label, url, consumed)) = markdown_link(rest) {
+        if let Some((label, url, consumed)) = display_markdown::markdown_link(rest) {
             let link_style = base_style
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::UNDERLINED);
@@ -1274,7 +1258,7 @@ fn markdown_segments_with_depth(text: &str, base_style: Style, depth: usize) -> 
             continue;
         }
 
-        if let Some((url, consumed)) = raw_url(rest) {
+        if let Some((url, consumed)) = display_markdown::raw_url(rest) {
             push_segment(
                 &mut segments,
                 url,
@@ -1286,7 +1270,7 @@ fn markdown_segments_with_depth(text: &str, base_style: Style, depth: usize) -> 
             continue;
         }
 
-        if let Some((inner, consumed)) = delimited(text, index, "`") {
+        if let Some((inner, consumed)) = display_markdown::delimited(text, index, "`") {
             push_segment(
                 &mut segments,
                 inner,
@@ -1296,7 +1280,7 @@ fn markdown_segments_with_depth(text: &str, base_style: Style, depth: usize) -> 
             continue;
         }
 
-        if let Some((inner, consumed)) = delimited(text, index, "**") {
+        if let Some((inner, consumed)) = display_markdown::delimited(text, index, "**") {
             append_segments(
                 &mut segments,
                 markdown_segments_with_depth(
@@ -1309,8 +1293,8 @@ fn markdown_segments_with_depth(text: &str, base_style: Style, depth: usize) -> 
             continue;
         }
 
-        if let Some((inner, consumed)) =
-            delimited(text, index, "*").or_else(|| delimited(text, index, "_"))
+        if let Some((inner, consumed)) = display_markdown::delimited(text, index, "*")
+            .or_else(|| display_markdown::delimited(text, index, "_"))
         {
             append_segments(
                 &mut segments,
@@ -1350,80 +1334,6 @@ fn push_segment(segments: &mut Vec<StyledSegment>, text: &str, style: Style) {
         return;
     }
     segments.push(StyledSegment::new(text.to_string(), style));
-}
-
-fn markdown_link(rest: &str) -> Option<(&str, &str, usize)> {
-    if !rest.starts_with('[') {
-        return None;
-    }
-    let label_end = 1 + rest[1..].find("](")?;
-    let url_start = label_end + 2;
-    let url_end = url_start + rest[url_start..].find(')')?;
-    let label = &rest[1..label_end];
-    if label.is_empty() {
-        return None;
-    }
-    let url = &rest[url_start..url_end];
-    if url.is_empty() {
-        return None;
-    }
-    Some((label, url, url_end + 1))
-}
-
-fn raw_url(rest: &str) -> Option<(&str, usize)> {
-    if !(rest.starts_with("https://") || rest.starts_with("http://")) {
-        return None;
-    }
-    let end = rest
-        .char_indices()
-        .find_map(|(index, ch)| ch.is_whitespace().then_some(index))
-        .unwrap_or(rest.len());
-    Some((&rest[..end], end))
-}
-
-fn delimited<'a>(text: &'a str, index: usize, delimiter: &str) -> Option<(&'a str, usize)> {
-    let rest = &text[index..];
-    if !rest.starts_with(delimiter) {
-        return None;
-    }
-    if delimiter != "`" && !delimiter_boundary_before(text, index) {
-        return None;
-    }
-    let after_open = &rest[delimiter.len()..];
-    if after_open.chars().next().is_none_or(char::is_whitespace) {
-        return None;
-    }
-    let close = after_open.find(delimiter)?;
-    if close == 0 {
-        return None;
-    }
-    let inner = &after_open[..close];
-    if inner.chars().last().is_none_or(char::is_whitespace) {
-        return None;
-    }
-    let consumed = delimiter.len() + close + delimiter.len();
-    if delimiter != "`" && !delimiter_boundary_after(text, index + consumed) {
-        return None;
-    }
-    Some((inner, consumed))
-}
-
-fn delimiter_boundary_before(text: &str, index: usize) -> bool {
-    text[..index]
-        .chars()
-        .next_back()
-        .is_none_or(|ch| !is_identifier_char(ch))
-}
-
-fn delimiter_boundary_after(text: &str, index: usize) -> bool {
-    text[index..]
-        .chars()
-        .next()
-        .is_none_or(|ch| !is_identifier_char(ch))
-}
-
-fn is_identifier_char(ch: char) -> bool {
-    ch.is_alphanumeric() || ch == '_'
 }
 
 fn textarea_with_text(title: &'static str, text: &str) -> TextArea<'static> {

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -176,7 +176,7 @@ const TURN_TRANSCRIPT_EVENTS_PAGE_2_JSON: &str = r#"[
         "source":"managed",
         "visibility":"public",
         "data":{"text":"RAW_TRANSCRIPT_TEXT"},
-        "display":{"kind":"text","phase":"completed","text":"historical answer"},
+        "display":{"kind":"text","phase":"completed","format":"markdown","text":"**Historical Answer**\nUse `lookupItems` with _active_ filters and [Reference](https://example.test).\n```json\n{\"ok\":true}\n```\nKeep record_id and __init__ literal."},
         "createdAt":"2026-04-22T00:00:03Z"
     },
     {
@@ -529,10 +529,20 @@ fn test_cli_renders_agent_turn_transcript_from_display_events() {
         .stdout(predicate::str::contains(
             r#"tool> lookup completed (200) {"ok":true}"#,
         ))
-        .stdout(predicate::str::contains("assistant> historical answer"))
+        .stdout(predicate::str::contains("assistant> Historical Answer"))
+        .stdout(predicate::str::contains("Use lookupItems"))
+        .stdout(predicate::str::contains("Reference (https://example.test)"))
+        .stdout(predicate::str::contains(r#"{"ok":true}"#))
+        .stdout(predicate::str::contains("record_id"))
+        .stdout(predicate::str::contains("__init__"))
         .stdout(predicate::str::contains("turn> completed (done)"))
         .stdout(predicate::str::contains("structured>"))
         .stdout(predicate::str::contains(r#""summary": "done""#))
+        .stdout(predicate::str::contains("**Historical Answer**").not())
+        .stdout(predicate::str::contains("`lookupItems`").not())
+        .stdout(predicate::str::contains("_active_").not())
+        .stdout(predicate::str::contains("[Reference]").not())
+        .stdout(predicate::str::contains("```").not())
         .stdout(predicate::str::contains("RAW_TRANSCRIPT_INPUT").not())
         .stdout(predicate::str::contains("RAW_TRANSCRIPT_OUTPUT").not())
         .stdout(predicate::str::contains("RAW_TRANSCRIPT_TEXT").not())
@@ -689,14 +699,15 @@ fn test_cli_runs_interactive_agent_session_with_display_events() {
              data: {\"seq\":3,\"type\":\"provider.tool\",\"visibility\":\"public\",\"display\":{\"kind\":\"tool\",\"phase\":\"completed\",\"label\":\"lookup\",\"ref\":\"call-lookup\",\"text\":\"200\",\"output\":{\"ok\":true}}}\n\n\
              data: {\"seq\":4,\"type\":\"provider.tool\",\"visibility\":\"public\",\"data\":{\"arguments\":{\"secret\":\"RAW_INPUT_SENTINEL\"}},\"display\":{\"kind\":\"tool\",\"phase\":\"started\",\"label\":\"redacted\",\"ref\":\"call-redacted\"}}\n\n\
              data: {\"seq\":5,\"type\":\"provider.tool\",\"visibility\":\"public\",\"data\":{\"output\":{\"secret\":\"RAW_OUTPUT_SENTINEL\"}},\"display\":{\"kind\":\"tool\",\"phase\":\"completed\",\"label\":\"redacted\",\"ref\":\"call-redacted\",\"text\":\"done\"}}\n\n\
-             data: {\"seq\":6,\"type\":\"provider.text\",\"visibility\":\"public\",\"display\":{\"kind\":\"text\",\"phase\":\"delta\",\"text\":\"hello\"}}\n\n\
-             data: {\"seq\":7,\"type\":\"provider.text\",\"visibility\":\"public\",\"display\":{\"kind\":\"text\",\"phase\":\"delta\",\"text\":\"\\n  display\"}}\n\n\
-             data: {\"seq\":8,\"type\":\"assistant.completed\",\"visibility\":\"public\",\"data\":{\"text\":\"hello\\n  display\"},\"display\":{\"kind\":\"text\",\"phase\":\"completed\"}}\n\n\
+             data: {\"seq\":6,\"type\":\"provider.text\",\"visibility\":\"public\",\"display\":{\"kind\":\"text\",\"phase\":\"delta\",\"format\":\"markdown\",\"text\":\"**hello\"}}\n\n\
+             data: {\"seq\":7,\"type\":\"provider.text\",\"visibility\":\"public\",\"display\":{\"kind\":\"text\",\"phase\":\"delta\",\"format\":\"markdown\",\"text\":\"**\\n  display\"}}\n\n\
+             data: {\"seq\":8,\"type\":\"assistant.completed\",\"visibility\":\"public\",\"data\":{\"text\":\"**hello**\\n  display\"},\"display\":{\"kind\":\"text\",\"phase\":\"completed\",\"format\":\"markdown\",\"text\":\"**hello**\\n  display\"}}\n\n\
              data: {\"seq\":9,\"type\":\"assistant.completed\",\"visibility\":\"public\",\"data\":{\"text\":\"raw fallback\"},\"display\":{\"kind\":123,\"text\":42}}\n\n\
              data: {\"seq\":10,\"type\":\"assistant.completed\",\"visibility\":\"public\",\"data\":{\"text\":\"missing display text fallback\"},\"display\":{\"kind\":\"text\",\"phase\":\"completed\"}}\n\n\
-             data: {\"seq\":11,\"type\":\"provider.status\",\"visibility\":\"public\",\"display\":{\"kind\":\"status\",\"phase\":\"completed\",\"text\":\"tools synced\"}}\n\n\
-             data: {\"seq\":12,\"type\":\"provider.secret\",\"visibility\":\"private\",\"display\":{\"kind\":\"error\",\"phase\":\"failed\",\"text\":\"hidden secret\"}}\n\n\
-             data: {\"seq\":13,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+             data: {\"seq\":11,\"type\":\"provider.reasoning\",\"visibility\":\"public\",\"display\":{\"kind\":\"reasoning\",\"phase\":\"completed\",\"format\":\"markdown\",\"text\":\"**thinking**\"}}\n\n\
+             data: {\"seq\":12,\"type\":\"provider.status\",\"visibility\":\"public\",\"display\":{\"kind\":\"status\",\"phase\":\"completed\",\"text\":\"tools synced\"}}\n\n\
+             data: {\"seq\":13,\"type\":\"provider.secret\",\"visibility\":\"private\",\"display\":{\"kind\":\"error\",\"phase\":\"failed\",\"text\":\"hidden secret\"}}\n\n\
+             data: {\"seq\":14,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
         )
         .create();
     let _get_turn = authed_json_mock!(
@@ -712,7 +723,7 @@ fn test_cli_runs_interactive_agent_session_with_display_events() {
             "provider":"managed",
             "model":"gpt-5.4",
             "status":"succeeded",
-            "outputText":"hello\n  display"
+            "outputText":"**hello**\n  display"
         }"#,
     )
     .create();
@@ -732,11 +743,12 @@ fn test_cli_runs_interactive_agent_session_with_display_events() {
         ))
         .stdout(predicate::str::contains("tool> redacted started"))
         .stdout(predicate::str::contains("tool> redacted completed (done)"))
-        .stdout(predicate::str::contains("assistant> hello\n  display"))
+        .stdout(predicate::str::contains("assistant> **hello**\n  display"))
         .stdout(predicate::str::contains("assistant> raw fallback"))
         .stdout(predicate::str::contains(
             "assistant> missing display text fallback",
         ))
+        .stdout(predicate::str::contains("reasoning> **thinking**"))
         .stdout(predicate::str::contains("turn> completed (tools synced)"))
         .stdout(predicate::str::contains("RAW_INPUT_SENTINEL").not())
         .stdout(predicate::str::contains("RAW_OUTPUT_SENTINEL").not())


### PR DESCRIPTION
## Summary

Render completed, non-streamed agent text display events according to the existing `display.format` / `display.language` metadata in stdout/table transcript mode. This makes `gestalt agent turns transcript ...` match the TUI behavior more closely instead of printing markdown syntax and code fences verbatim.

This also moves the terminal markdown parsing helpers into one shared CLI module so the TUI and stdout paths use the same markdown/link/fence/token handling.

## Interfaces

Existing agent event display metadata:

```json
{
  "display": {
    "kind": "text",
    "phase": "completed",
    "format": "markdown",
    "language": "json",
    "text": "**Result**\nUse `lookupItems` and [Docs](https://example.test)."
  }
}
```

Stdout/table transcript rendering now consumes:

```rust
AgentTurnDisplayInfo {
    kind: "text".into(),
    phase: "completed".into(),
    format: "markdown".into(),
    language: "".into(),
    text: "**Result**\nUse `lookupItems` and [Docs](https://example.test).".into(),
    ..
}
```

Example output:

```text
assistant> Result
Use lookupItems and Docs (https://example.test).
```

Streaming deltas remain raw while an assistant line is open so partial markdown tokens are not rewritten mid-stream.

## Verification

```bash
cargo test --manifest-path gestalt/Cargo.toml -p gestalt --test agents_cli
git diff --check
```