### PR TITLE
Remove unused provider-dev allowed hosts handoff

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -5996,10 +5996,6 @@ func TestProviderDevRuntimeEnvUsesPublicHostServiceRelay(t *testing.T) {
 			t.Fatalf("runtime env %s is empty, want relay token", tokenEnv)
 		}
 	}
-	if !slices.Contains(env.AllowedHosts, "127.0.0.1") {
-		t.Fatalf("allowed hosts = %#v, want relay server host", env.AllowedHosts)
-	}
-
 	record, err := fakeHostedS3RoundTrip("assets", "plans/q3.txt", "ship-it", "main", env.Env)
 	if err != nil {
 		t.Fatalf("S3 round trip via provider-dev relay: %v", err)

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -166,7 +166,6 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 	}
 
 	env := map[string]string{}
-	var allowedHosts []string
 	startedHostServices, err := providerhost.StartHostServices(
 		hostServices,
 		providerhost.WithHostServicesProviderName(name),
@@ -181,7 +180,7 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 		})
 	}
 	for _, hostService := range startedHostServices.Bindings() {
-		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, false)
+		bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, false)
 		if err != nil {
 			return providerdev.RuntimeEnv{}, err
 		}
@@ -189,7 +188,6 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 			env[bindingReq.EnvVar] = bindingReq.Relay.DialTarget
 		}
 		maps.Copy(env, bindingEnv)
-		allowedHosts = appendAllowedHost(allowedHosts, relayHost)
 	}
 	if deps.Egress.DefaultAction == egress.PolicyDeny {
 		proxyEnv, err := buildHostedRuntimePublicEgressProxy(name, sessionID, entry.EffectiveAllowedHosts(), deps.Egress.DefaultAction, deps)
@@ -197,15 +195,11 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 			return providerdev.RuntimeEnv{}, err
 		}
 		maps.Copy(env, proxyEnv)
-		if _, proxyHost, err := pluginRuntimePublicProxyBaseURL(deps.BaseURL); err == nil {
-			allowedHosts = appendAllowedHost(allowedHosts, proxyHost)
-		}
 	}
 
 	cleanupOnError = false
 	return providerdev.RuntimeEnv{
-		Env:          env,
-		AllowedHosts: slices.Clone(allowedHosts),
-		Cleanup:      cleanup,
+		Env:     env,
+		Cleanup: cleanup,
 	}, nil
 }

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -47,9 +47,8 @@ const (
 )
 
 type RuntimeEnv struct {
-	Env          map[string]string
-	AllowedHosts []string
-	Cleanup      func()
+	Env     map[string]string
+	Cleanup func()
 }
 
 type RuntimeEnvBuilder func(sessionID string) (RuntimeEnv, error)
@@ -90,12 +89,11 @@ type CreateSessionResponse struct {
 }
 
 type CreateSessionProvider struct {
-	Name         string            `json:"name"`
-	Env          map[string]string `json:"env,omitempty"`
-	AllowedHosts []string          `json:"allowedHosts,omitempty"`
-	Source       string            `json:"source,omitempty"`
-	UI           bool              `json:"ui,omitempty"`
-	UIPath       string            `json:"uiPath,omitempty"`
+	Name   string            `json:"name"`
+	Env    map[string]string `json:"env,omitempty"`
+	Source string            `json:"source,omitempty"`
+	UI     bool              `json:"ui,omitempty"`
+	UIPath string            `json:"uiPath,omitempty"`
 }
 
 type CreateAttachAuthorizationResponse struct {
@@ -316,12 +314,11 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 			env:    runtimeEnv,
 		}
 		resp.Providers = append(resp.Providers, CreateSessionProvider{
-			Name:         target.Name,
-			Env:          cloneStringMap(runtimeEnv.Env),
-			AllowedHosts: slices.Clone(runtimeEnv.AllowedHosts),
-			Source:       target.Source,
-			UI:           target.UI != nil,
-			UIPath:       target.UIPath,
+			Name:   target.Name,
+			Env:    cloneStringMap(runtimeEnv.Env),
+			Source: target.Source,
+			UI:     target.UI != nil,
+			UIPath: target.UIPath,
 		})
 	}
 

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -77,8 +77,7 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 		},
 		RuntimeEnv: func(string) (RuntimeEnv, error) {
 			return RuntimeEnv{
-				Env:          map[string]string{"GESTALT_PLUGIN_INVOKER_SOCKET": "tls://gestalt.example.test:443"},
-				AllowedHosts: []string{"gestalt.example.test"},
+				Env: map[string]string{"GESTALT_PLUGIN_INVOKER_SOCKET": "tls://gestalt.example.test:443"},
 			}, nil
 		},
 	}})
@@ -461,8 +460,7 @@ func TestHTTPTransportListsRedactedAttachmentMetadata(t *testing.T) {
 		UIPath: "/roadmap",
 		RuntimeEnv: func(string) (RuntimeEnv, error) {
 			return RuntimeEnv{
-				Env:          map[string]string{"SECRET": "do-not-return"},
-				AllowedHosts: []string{"example.test"},
+				Env: map[string]string{"SECRET": "do-not-return"},
 			}, nil
 		},
 	}})

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6077,8 +6077,7 @@ func TestProviderDevAttachmentRoutesEnforceGateDispatcherSecretAndRedaction(t *t
 			UIPath: "/roadmap",
 			RuntimeEnv: func(string) (providerdev.RuntimeEnv, error) {
 				return providerdev.RuntimeEnv{
-					Env:          map[string]string{"SECRET": "do-not-return"},
-					AllowedHosts: []string{"example.test"},
+					Env: map[string]string{"SECRET": "do-not-return"},
 				}, nil
 			},
 		}})


### PR DESCRIPTION
## Summary

Deletes the unused provider-dev `allowedHosts` handoff from remote attach runtime env and create-session provider responses. The local dispatcher never consumed this field, and remote provider-dev source execution is intentionally unsandboxed; the actual runtime behavior is carried by the env vars returned in `providers[].env`.

## Interface Changes

Removed:
- `providerdev.RuntimeEnv.AllowedHosts`
- `CreateSessionProvider.allowedHosts`

Kept:
- `POST /api/v1/provider-dev/attachments` returns `attachId`, `dispatcherSecret`, and `providers[]` entries with `name`, `env`, `source`, `ui`, and `uiPath`.
- `gestaltd provider dev --remote` continues to start the local provider with host-service and egress proxy env vars from the remote server.

## Examples

```sh
gestaltd provider dev --remote https://valon.tools --path ./plugins/slack
```

Attach-create response shape after this cleanup:

```json
{
  "attachId": "att_123",
  "dispatcherSecret": "pdd_...",
  "providers": [
    {
      "name": "slack",
      "env": {
        "GESTALT_PLUGIN_INVOKER_SOCKET": "tls://..."
      },
      "source": "github.com/example/plugins/slack",
      "ui": true,
      "uiPath": "/slack"
    }
  ]
}
```

## Validation

- `go test -count=1 ./internal/providerdev ./internal/server -run 'ProviderDev|ProviderRemote|ProviderAttach'`
- `go test -count=1 ./internal/bootstrap -run 'ProviderDev|Remote|Egress|HostService'`
- `go test -count=1 ./internal/providerdev ./internal/bootstrap ./internal/server`
- `golangci-lint run --allow-parallel-runners ./internal/providerdev ./internal/bootstrap ./internal/server ./cmd/gestaltd`