### PR TITLE
Split gestaltd lock and sync lifecycle

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -287,7 +287,8 @@ cd /path/to/gestalt-providers/agent/simple
 uv sync --group dev
 
 cd /path/to/gestalt
-go run ./cmd/gestaltd init --config ./config.yaml
+go run ./cmd/gestaltd lock --config ./config.yaml
+go run ./cmd/gestaltd sync --locked --config ./config.yaml
 go run ./cmd/gestaltd serve --locked --config ./config.yaml
 
 gestalt --url http://localhost:18080 agent --provider simple --model fast
@@ -295,6 +296,6 @@ gestalt --url http://localhost:18080 agent --provider simple --model fast
 
 Notes:
 
-- `uv sync --group dev` matters for source-backed Python providers. `gestaltd init` prefers the provider-local `.venv` when it builds locked artifacts.
+- `uv sync --group dev` matters for source-backed Python providers. `gestaltd sync --locked` prefers the provider-local `.venv` when it builds locked artifacts.
 - If your local server has no platform auth configured, the CLI can connect without `GESTALT_API_KEY`.
 - Successful turns still need the upstream model credentials expected by your configured provider, such as `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` for `agent/simple`.

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -137,7 +137,7 @@ plugins:
       bundle: github_console
 ```
 
-For published providers, `source` usually points at a `provider-release.yaml` metadata URL. When the release is hosted in GitHub and you want checked-in config to stay readable, use `source.githubRelease` instead. Gestalt resolves the matching platform archive during `init` and records the exact release in the lockfile. First-party providers are published from `github.com/valon-technologies/gestalt-providers/`.
+For published providers, `source` usually points at a `provider-release.yaml` metadata URL. When the release is hosted in GitHub and you want checked-in config to stay readable, use `source.githubRelease` instead. Gestalt resolves the matching platform archive during `gestaltd lock` and records the exact release in the lockfile. First-party providers are published from `github.com/valon-technologies/gestalt-providers/`.
 
 For a private GitHub release, pair `source.githubRelease` with inline source auth:
 

--- a/docs/content/custom-providers/cache.mdx
+++ b/docs/content/custom-providers/cache.mdx
@@ -235,6 +235,7 @@ When a plugin binds multiple caches, only the named env vars are set.
 
 ## Release flow
 
-Managed cache providers follow the same `gestaltd init` / lockfile / release
-flow as other source-backed provider kinds. Point a manifest at a published
-source ref, run `gestaltd init`, and package releases with `gestaltd provider release`.
+Managed cache providers follow the same `gestaltd lock` /
+`gestaltd sync --locked` / release flow as other source-backed provider kinds.
+Point a manifest at a published source ref, run `gestaltd lock`, sync locked
+artifacts, and package releases with `gestaltd provider release`.

--- a/docs/content/custom-providers/index.mdx
+++ b/docs/content/custom-providers/index.mdx
@@ -32,8 +32,8 @@ providers:
   session or sandbox and bridge those plugins back to the host.
 - UI providers are static asset bundles served under configured public path
   prefixes.
-- Published packages are prepared with `gestaltd init` and referenced from
-  `gestalt.lock.json`.
+- Published packages are locked with `gestaltd lock`, prepared with
+  `gestaltd sync --locked`, and referenced from `gestalt.lock.json`.
 
 ## Choose a starting point
 

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -180,7 +180,7 @@ spec:
   configSchemaPath: schemas/ui-config.schema.json
 ```
 
-`gestaltd init` prepares the released UI and records it in `gestalt.lock.json`. `gestaltd serve --locked` then serves the prepared asset root at whatever public path the deployment config binds for that UI bundle. Omit `providers.ui` to run headless with no public UI bundles. The built-in admin UI remains available at `/admin` regardless.
+`gestaltd lock` records the released UI in `gestalt.lock.json`, and `gestaltd sync --locked` prepares its assets. `gestaltd serve --locked` then serves the prepared asset root at whatever public path the deployment config binds for that UI bundle. Omit `providers.ui` to run headless with no public UI bundles. The built-in admin UI remains available at `/admin` regardless.
 
 ## Build a release
 
@@ -287,13 +287,14 @@ providers:
         brand_name: Acme
 ```
 
-When a config references published releases, run `gestaltd init` to resolve and prepare them:
+When a config references published releases, lock and sync them before locked runtime:
 
 ```sh
-gestaltd init --config ./config.yaml
+gestaltd lock --config ./config.yaml
+gestaltd sync --locked --config ./config.yaml
 ```
 
-This writes lock state (`gestalt.lock.json`) and extracts prepared artifacts under `.gestaltd/`. After init, `gestaltd serve --locked` starts the server from that lock state. If the prepared files are already present, Gestalt uses them directly. If they are missing, Gestalt can materialize them from the lockfile at runtime. See [Configuration](/configuration) for the full startup model and the tradeoffs between vendored artifacts and lockfile-only startup.
+This writes lock state (`gestalt.lock.json`) and extracts prepared artifacts under `.gestaltd/`. After sync, `gestaltd serve --locked` starts the server from that prepared state without resolving or writing artifacts at runtime. See [Configuration](/configuration) for the full startup model.
 
 ## Release archive layout
 
@@ -321,4 +322,4 @@ reference.
 
 - [Provider Manifests](/reference/plugin-manifests): full manifest field reference
 - [Helm Deployment](/deploy/helm): deploying with Helm and referencing published releases
-- [Configuration](/configuration): `gestaltd init`, lock state, and the full startup model
+- [Configuration](/configuration): `gestaltd lock`, `gestaltd sync --locked`, lock state, and the full startup model

--- a/docs/content/custom-providers/ui.mdx
+++ b/docs/content/custom-providers/ui.mdx
@@ -106,12 +106,11 @@ providers:
       authorizationPolicy: dashboard_users
 ```
 
-When a config references a published UI bundle, run `gestaltd init` to resolve
-and prepare it. This writes lock state to `gestalt.lock.json` and extracts the
-assets under `.gestaltd/`. After init, `gestaltd serve --locked` serves the
-locked UI bundle from its configured path prefix. If the prepared UI files are
-already present, Gestalt uses them directly; if they are missing, Gestalt can
-materialize them from the lockfile at startup.
+When a config references a published UI bundle, run `gestaltd lock` to resolve
+it and `gestaltd sync --locked` to prepare it. This writes lock state to
+`gestalt.lock.json` and extracts the assets under `.gestaltd/`. After sync,
+`gestaltd serve --locked` serves the locked UI bundle from its configured path
+prefix and refuses to repair missing artifacts at runtime.
 
 If `providers.ui` is omitted entirely, Gestalt runs headless with no public UI
 bundles.

--- a/docs/content/deploy/docker.mdx
+++ b/docs/content/deploy/docker.mdx
@@ -44,7 +44,7 @@ volumes:
 | Variants | `:latest-alpine` (Alpine, has shell) |
 | Port | `8080` |
 | Entrypoint | `/gestaltd` |
-| Default command | `serve --locked --config /etc/gestalt/config.yaml --artifacts-dir /data` |
+| Default command | `serve --config /etc/gestalt/config.yaml --artifacts-dir /data` |
 | Config path | `/etc/gestalt/config.yaml` |
 | Data directory | `/data` |
 
@@ -52,7 +52,7 @@ For the CLI client image, see [Client Docker Image](/client/cli/docker).
 
 ## Production image
 
-For deterministic production deployments, run `gestaltd init` locally to resolve plugins and write lock state, then bake the result into a derived image:
+For deterministic production deployments, run `gestaltd lock` and `gestaltd sync --locked` during image build, then bake the lockfile and prepared artifacts into a derived image:
 
 ```
 deploy/
@@ -68,7 +68,7 @@ COPY deploy/ /app/
 CMD ["serve", "--locked", "--config", "/app/config.yaml"]
 ```
 
-This produces a self-contained image that starts without fetching or resolving anything at runtime.
+This produces a self-contained image that starts without fetching, resolving, or writing provider artifacts at runtime.
 
 See [Configuration](/configuration) for what `gestalt.lock.json` records and
 why `serve --locked` depends on it.

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -92,7 +92,8 @@ helm upgrade --install gestalt \
 | `config` | Rendered as `/etc/gestalt/config.yaml`. |
 | `extraEnv` | Environment variables used by `${VAR}` placeholders in `config`. |
 | `persistence` | PVC settings for SQLite or other local state. |
-| `pluginInit.enabled` | Runs `gestaltd init` in an init container before the main server starts. Use it when the chart should prepare locked state for published provider packages or packaged UI bundles. |
+| `pluginInit.enabled` | Runs `gestaltd lock` and `gestaltd sync --locked` in an init container before the main server starts. Use it when the chart should prepare locked state for published provider packages or packaged UI bundles. |
+| `lockedServe.enabled` | Adds `--locked` to the main container without enabling the chart init container. Use it when lock state and prepared artifacts are baked into the image or mounted by external automation. |
 | `ingress` | Standard ingress settings. |
 | `ingress.hosts[].paths` | Per-host ingress paths and path types. |
 | `managementService` | Optional internal Service for a separate management listener. |
@@ -178,9 +179,13 @@ Service rather than exposing it on the public ingress.
 
 Enable the init container when your config uses published provider metadata URLs under `plugins.*.source`, `providers.authentication.*.source`, `providers.indexeddb.*.source`, or `providers.ui.*.source` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
 
-`/gestaltd init --config /etc/gestalt/config.yaml`
+`/gestaltd lock --config /etc/gestalt/config.yaml && /gestaltd sync --locked --config /etc/gestalt/config.yaml`
 
 The main container then starts in locked mode against the prepared state.
+
+If you prepare lock state outside the chart, leave `pluginInit.enabled: false`
+and set `lockedServe.enabled: true` so the main container still starts with
+`serve --locked`.
 
 See [Configuration](/configuration) for how the lockfile and prepared artifacts
 fit together.

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -16,51 +16,57 @@ The server image `valontechnologies/gestaltd:latest` is published for `linux/amd
 
 **TLS.** Gestalt does not terminate TLS. Deploy behind a reverse proxy or load balancer that handles TLS termination. Set `server.baseUrl` to the public HTTPS URL so that OAuth callback URLs are derived correctly.
 
-**Startup workflows.** `gestaltd serve` resolves providers on first boot and is suitable for development and single-instance deployments. For deterministic, reproducible deployments, split startup into two phases:
+**Startup workflows.** `gestaltd serve` resolves providers on first boot and is suitable for development and single-instance deployments. For deterministic, reproducible deployments, split startup into three phases:
 
-1. **Prepare** -- run `gestaltd init` locally (or in CI) to resolve every provider and write a lock file.
-2. **Serve** -- run `gestaltd serve --locked` in production. The server reads the lock file and refuses to start if any provider is missing or has drifted.
+1. **Lock** -- run `gestaltd lock` locally or in CI to resolve every provider and write a lock file.
+2. **Sync** -- run `gestaltd sync --locked` during image build or release preparation to materialize prepared artifacts from the lock file.
+3. **Serve** -- run `gestaltd serve --locked` in production. The server reads the lock file and prepared artifacts and refuses to start if either is missing or stale.
 
 This guarantees that the image you test is byte-for-byte the image you deploy.
 
 <Callout type="warning">
-  For production, strongly prefer `gestaltd init` plus
-  `gestaltd serve --locked`. Without a lockfile, startup can resolve newly
-  published provider artifacts or changed registry metadata, which weakens
-  reproducibility and integrity checks. Lockfiles pin the resolved artifacts and
-  verified hashes that the deployment was tested with.
+  For production, strongly prefer `gestaltd lock`, `gestaltd sync --locked`,
+  and then `gestaltd serve --locked`. Without a lockfile, startup can resolve
+  newly published provider artifacts or changed registry metadata, which weakens
+  reproducibility and integrity checks. Locked serve is read-only and will not
+  repair missing artifacts at runtime.
 </Callout>
 
-**Prepared state and lockfiles.** `gestaltd init` writes a `deploy/` directory next to your config file:
+**Prepared state and lockfiles.** `gestaltd lock` writes `gestalt.lock.json`; `gestaltd sync --locked` writes prepared artifacts under `.gestaltd/`:
 
 ```
 deploy/
   gestalt.lock.json    # pinned provider refs and checksums
-  .gestaltd/providers/ # vendored provider artifacts (optional)
-  .gestaltd/ui/        # vendored UI assets (optional)
+  .gestaltd/providers/ # prepared provider artifacts
+  .gestaltd/ui/        # prepared UI assets
 ```
 
 The lock file is a JSON document that records resolved plugins and host-scoped providers in separate maps:
 
 ```json
 {
-  "version": 1,
-  "indexeddbs": {
-    "main": {
-      "fingerprint": "ab12cd...",
-      "source": "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb",
-      "version": "0.0.1-alpha.1",
-      "manifest": ".gestaltd/providers/main/manifest.json",
-      "executable": ".gestaltd/providers/main/artifacts/linux/amd64/provider"
+  "schema": "gestaltd-provider-lock",
+  "schemaVersion": 5,
+  "revision": 0,
+  "providers": {
+    "indexeddb": {
+      "main": {
+        "inputDigest": "ab12cd...",
+        "package": "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb",
+        "kind": "indexeddb",
+        "runtime": "executable",
+        "source": "https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.4/provider-release.yaml",
+        "version": "0.0.1-alpha.4"
+      }
     }
   }
 }
 ```
 
-You can choose between two patterns:
-
-- **Vendored** -- commit the full `deploy/` directory (including `providers/`). The server loads artifacts directly with no network calls at boot. Best for air-gapped or latency-sensitive environments.
-- **Lockfile-only** -- commit only `gestalt.lock.json`. The server fetches providers on first boot but verifies each artifact against the recorded checksum. Keeps your repo lightweight while still guaranteeing integrity.
+For production, bake or mount both the lockfile and the prepared `.gestaltd/`
+directory before starting with `serve --locked`. For development and local
+single-instance deployments, omit `--locked` and let `gestaltd serve` resolve
+and prepare providers at startup.
 
 See [Configuration](/configuration) for the config model and [Docker](/deploy/docker) for the recommended production image pattern.
 

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -126,8 +126,9 @@ plugins:
       - assets
 ```
 
-Run `gestaltd init` when you want to resolve and pin published releases ahead
-of time, then `gestaltd serve --locked` to start from that prepared state.
+Run `gestaltd lock` when you want to resolve and pin published releases ahead
+of time, then `gestaltd sync --locked` to prepare artifacts before
+`gestaltd serve --locked` starts from that prepared state.
 
 ## Building custom providers
 

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -221,8 +221,9 @@ providers:
 ## Operational notes
 
 Gestalt needs exactly one active datastore selected by
-`server.providers.indexeddb`. Published datastore packages can be prepared with
-`gestaltd init` just like other provider types. Plugins still go through the
+`server.providers.indexeddb`. Published datastore packages can be locked and
+prepared with `gestaltd lock` and `gestaltd sync --locked` just like other
+provider types. Plugins still go through the
 host's request and auth model, so they do not talk to the datastore provider
 directly.
 

--- a/docs/content/providers/s3.mdx
+++ b/docs/content/providers/s3.mdx
@@ -207,8 +207,9 @@ limit instead of exposing provider-specific multipart controls through the
 portable provider contract. Browser uploads that need direct client transport
 should use hosted object access URLs; product-specific multipart state still
 belongs in the plugin that owns that workflow. Published S3 provider packages
-can still be prepared with `gestaltd init`, just like auth, indexeddb, cache,
-and secrets providers.
+can still be locked and prepared with `gestaltd lock` and
+`gestaltd sync --locked`, just like auth, indexeddb, cache, and secrets
+providers.
 
 ## Building your own S3 provider
 

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -8,7 +8,8 @@ regardless of whether public UI bundles are configured.
 ## How UI providers work
 
 Unlike executable providers, a UI provider is just a packaged asset root.
-`gestaltd` resolves the bundle, prepares it during `gestaltd init`, and then
+`gestaltd` resolves the bundle during `gestaltd lock`, prepares it during
+`gestaltd sync --locked`, and then
 serves the pinned assets from the configured public path prefix when the server
 starts.
 
@@ -114,7 +115,8 @@ associated static assets.
 When a published UI bundle is referenced from `providers.ui`, run:
 
 ```sh
-gestaltd init --config ./config.yaml
+gestaltd lock --config ./config.yaml
+gestaltd sync --locked --config ./config.yaml
 ```
 
 That writes `gestalt.lock.json` and prepares the bundle under `.gestaltd/`.

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -10,21 +10,24 @@ import { Callout } from 'nextra/components'
 | --- | --- |
 | `gestaltd` | Local-friendly startup. Generates a config if needed and serves. |
 | `gestaltd serve --config PATH` | Start the server. Repeat `--config` to layer overrides. |
-| `gestaltd serve --locked --config PATH` | Start from lock state. Uses prepared artifacts when present and can materialize missing artifacts from the lockfile. Repeat `--config` to layer overrides. |
+| `gestaltd serve --locked --config PATH` | Start read-only from an existing lockfile and prepared artifacts. Repeat `--config` to layer overrides. |
 | `gestaltd serve --artifacts-dir DIR` | Directory for prepared provider artifacts. |
 | `gestaltd serve --lockfile PATH` | Override the lockfile location. `PATH` resolves like a normal CLI path. |
-| `gestaltd init --config PATH` | Resolve published plugin sources and write lock state. Repeat `--config` to layer overrides. |
-| `gestaltd init --artifacts-dir DIR` | Directory for prepared provider artifacts. |
-| `gestaltd init --lockfile PATH` | Override the lockfile location. `PATH` resolves like a normal CLI path. |
+| `gestaltd lock --config PATH` | Resolve published provider sources and write canonical lock metadata. Repeat `--config` to layer overrides. |
+| `gestaltd lock --check --config PATH` | Verify that the checked-in lockfile matches the current config without rewriting it. |
+| `gestaltd sync --locked --config PATH` | Materialize prepared provider artifacts from an existing lockfile. |
+| `gestaltd sync --locked --check --config PATH` | Verify that prepared artifacts exist and match the lockfile without rewriting them. |
+| `gestaltd init --config PATH` | Legacy alias for `gestaltd lock`; writes lock metadata only. |
 | `gestaltd validate --config PATH` | Validate config without serving. Repeat `--config` to layer overrides. |
-| `gestaltd validate --lockfile PATH` | Accept the same explicit lockfile path used by `init` and `serve` without mutating it. |
+| `gestaltd validate --lockfile PATH` | Accept the same explicit lockfile path used by `lock`, `sync`, and `serve` without mutating it. |
 | `gestaltd --version` | Print the server version. |
 
 <Callout type="warning">
-  For production deployments, strongly prefer `gestaltd init` followed by
-  `gestaltd serve --locked`. The lockfile pins resolved provider artifacts and
-  verified hashes so startup cannot silently pick up new artifacts or mutate
-  deployment state.
+  For production deployments, strongly prefer `gestaltd lock`, then
+  `gestaltd sync --locked` during image build or release preparation, then
+  `gestaltd serve --locked` at runtime. The lockfile pins resolved provider
+  artifacts and verified hashes, and locked serve refuses to mutate deployment
+  state.
 </Callout>
 
 ## Provider commands
@@ -47,13 +50,16 @@ import { Callout } from 'nextra/components'
 
 ```sh
 gestaltd
-gestaltd init --config ./config.yaml
+gestaltd lock --config ./config.yaml
+gestaltd sync --locked --config ./config.yaml
 gestaltd serve --locked --config ./config.yaml
 gestaltd validate --config ./config.yaml
-gestaltd init --config ./config.yaml --lockfile ./local/gestalt.lock.json
+gestaltd lock --config ./config.yaml --lockfile ./local/gestalt.lock.json
+gestaltd sync --locked --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd serve --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd serve --locked --config ./config.yaml --lockfile ./local/gestalt.lock.json
-gestaltd init --config ./base.yaml --config ./overrides/local.yaml
+gestaltd lock --config ./base.yaml --config ./overrides/prod.yaml
+gestaltd sync --locked --config ./base.yaml --config ./overrides/prod.yaml
 gestaltd serve --locked --config ./base.yaml --config ./overrides/prod.yaml
 gestaltd provider validate --path ./plugins/support
 gestaltd provider validate --path ./ui/dashboard
@@ -156,4 +162,4 @@ For TypeScript source plugins, `provider dev` installs dependencies with
 Source UI release builds use the same bootstrap for Bun-managed build workdirs
 before `release.build.command` when dependencies are missing.
 
-See [Configuration](/configuration) for the relationship between `init`, `serve --locked`, and `validate`.
+See [Configuration](/configuration) for the relationship between `lock`, `sync --locked`, `serve --locked`, and `validate`.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -140,7 +140,7 @@ authorization:
 
 `encryptionKey` is the only required server field. It is the root deployment secret, used for encryption and derived session material.
 
-`apiTokenTtl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifactsDir` is a writable directory for prepared artifacts produced by `init` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `init`/`serve` lifecycle.
+`apiTokenTtl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifactsDir` is a writable directory for prepared artifacts produced by `gestaltd sync --locked` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `lock`/`sync`/`serve` lifecycle.
 
 `admin.authorizationPolicy` binds the built-in `/admin` route to one shared subject access policy from `authorization.policies`. `admin.allowedRoles` controls which roles may load the built-in admin UI, defaulting to `[admin]`.
 
@@ -164,7 +164,7 @@ Plugins without `authorizationPolicy` are open to any authenticated subject. Bin
 | `baseUrl` | | Public origin URL used for OAuth callbacks and admin UI links. |
 | `encryptionKey` | | **Required.** Root encryption key. Typically a structured secret ref. |
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
-| `artifactsDir` | config directory | Directory for prepared `init` artifacts. |
+| `artifactsDir` | config directory | Directory for prepared artifacts produced by `gestaltd sync --locked`. |
 | `providers.audit` / `providers.authentication` / `providers.authorization` / `providers.indexeddb` / `providers.secrets` / `providers.telemetry` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
 | `providerDev.remoteAttach` | `false` | Enables private remote provider-dev attach routes. Requires `providerDev.attachmentState: processLocal`. |
 | `providerDev.attachmentState` | | Required when `providerDev.remoteAttach` is true. Use `processLocal` to acknowledge that remote attach v1 stores attachment state in this `gestaltd` process and therefore requires single-replica operation or sticky routing for provider-dev traffic. |

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -183,7 +183,7 @@ Surfaces load operation catalogs from external specifications. They are configur
 | `url`        | string | URL of the upstream GraphQL endpoint.   |
 | `connection` | string | Connection name used for GraphQL calls. |
 
-GraphQL surfaces expose a raw GraphQL passthrough immediately. Generated GraphQL operation catalogs are resolved lazily from the upstream schema when a real request runs under that surface's connection. Gestalt does not introspect GraphQL endpoints during package build, `gestaltd init`, or config validation.
+GraphQL surfaces expose a raw GraphQL passthrough immediately. Generated GraphQL operation catalogs are resolved lazily from the upstream schema when a real request runs under that surface's connection. Gestalt does not introspect GraphQL endpoints during package build, `gestaltd lock`, or config validation.
 
 #### `spec.surfaces.mcp`
 

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -4,7 +4,7 @@ import { Tabs } from "nextra/components";
 
 ## Startup
 
-When `gestaltd serve --locked` reports that prepared artifacts are missing or stale, the lock state has drifted from the current config. Run `gestaltd init --config ./config.yaml` to re-resolve and re-prepare all references, then start the server again with `gestaltd serve --locked --config ./config.yaml`.
+When `gestaltd serve --locked` reports that lock metadata is missing or stale, run `gestaltd lock --config ./config.yaml` and commit or bake the updated lockfile. When it reports that prepared artifacts are missing or stale, run `gestaltd sync --locked --config ./config.yaml`, then start the server again with `gestaltd serve --locked --config ./config.yaml`.
 
 The validation error `server.encryptionKey is required` means the config is missing its root deployment secret. Set `server.encryptionKey` to a structured secret ref or other secret-backed value. The encryption key is used for token encryption and derived session material, so the server refuses to start without it.
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -13,7 +13,7 @@
 - Default command:
 
   ```sh
-  /gestaltd serve --locked --config /etc/gestalt/config.yaml --artifacts-dir /data
+  /gestaltd serve --config /etc/gestalt/config.yaml --artifacts-dir /data
   ```
 
 - Default config path: `/etc/gestalt/config.yaml`
@@ -96,9 +96,9 @@ volumes:
 
 ## Production images
 
-For deterministic production deployments, run `gestaltd init` locally to
-resolve providers and write `gestalt.lock.json`, then bake the result into a
-derived image:
+For deterministic production deployments, run `gestaltd lock` and
+`gestaltd sync --locked` before runtime, then bake the lockfile and prepared
+artifacts into a derived image:
 
 ```dockerfile
 FROM valontechnologies/gestaltd:latest-alpine
@@ -107,7 +107,7 @@ CMD ["serve", "--locked", "--config", "/app/config.yaml"]
 ```
 
 See the [deployment documentation](https://gestaltd.ai/deploy) for the full
-vendored-artifacts vs lockfile-only workflow and recommended patterns.
+lock/sync/serve workflow and recommended patterns.
 
 ## Configuration and environment variables
 
@@ -166,9 +166,9 @@ docker run --rm valontechnologies/gestaltd:latest --help
 
 ## Caveats
 
-- The published image defaults to locked startup. A missing config file,
-  missing lockfile, or unwritable artifacts directory causes startup to fail
-  fast.
+- The published image defaults to unlocked startup for local usability. For
+  production, bake locked state and override the command to
+  `serve --locked --config ...`.
 - `docker run valontechnologies/gestaltd:latest` by itself fails because the
   image does not auto-generate config in-container.
 - The default image does not include a shell. Use `-alpine` for debugging.

--- a/gestaltd/Dockerfile
+++ b/gestaltd/Dockerfile
@@ -39,7 +39,7 @@ LABEL org.opencontainers.image.title="gestaltd" \
       org.opencontainers.image.created="${GESTALT_CREATED}"
 EXPOSE 8080
 ENTRYPOINT ["/gestaltd"]
-CMD ["serve", "--locked", "--config", "/etc/gestalt/config.yaml", "--artifacts-dir", "/data"]
+CMD ["serve", "--config", "/etc/gestalt/config.yaml", "--artifacts-dir", "/data"]
 
 # --- Alpine ---
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS alpine
@@ -63,4 +63,4 @@ LABEL org.opencontainers.image.title="gestaltd" \
 USER nobody:nobody
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/gestaltd"]
-CMD ["serve", "--locked", "--config", "/etc/gestalt/config.yaml", "--artifacts-dir", "/data"]
+CMD ["serve", "--config", "/etc/gestalt/config.yaml", "--artifacts-dir", "/data"]

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -2584,6 +2585,200 @@ func TestE2EInitLocalProviders(t *testing.T) {
 	if _, ok := lock["version"]; ok {
 		t.Fatalf("expected schema-based lockfile without version field, got %v", lock["version"])
 	}
+	if _, err := os.Stat(filepath.Join(dir, ".gestaltd")); !os.IsNotExist(err) {
+		t.Fatalf("init is a lock-only alias and should not prepare artifacts, got err=%v", err)
+	}
+}
+
+func TestE2ELockSyncLocalProviders(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping E2E lock/sync test in short mode")
+	}
+
+	dir := t.TempDir()
+	cfgPath := writeServeConfig(t, dir, 0, nil)
+	lockPath := filepath.Join(dir, "gestalt.lock.json")
+
+	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd lock failed: %v\noutput: %s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gestaltd")); !os.IsNotExist(err) {
+		t.Fatalf("lock should not prepare final artifacts, got err=%v", err)
+	}
+	out, err = exec.Command(gestaltdBin, "lock", "--check", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd lock --check failed: %v\noutput: %s", err, out)
+	}
+
+	staleCfgPath := filepath.Join(dir, "config-stale.yaml")
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	staleCfg := strings.Replace(string(cfgBytes), "  example:\n    source:", "  renamed:\n    source:", 1)
+	if staleCfg == string(cfgBytes) {
+		t.Fatal("failed to create stale config")
+	}
+	if err := os.WriteFile(staleCfgPath, []byte(staleCfg), 0o644); err != nil {
+		t.Fatalf("write stale config: %v", err)
+	}
+	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--check", "--config", staleCfgPath, "--artifacts-dir", filepath.Join(dir, "prepared")).CombinedOutput()
+	if err == nil {
+		t.Fatalf("gestaltd sync --check with stale lock unexpectedly succeeded\noutput: %s", out)
+	}
+	if !strings.Contains(string(out), "gestaltd lock") {
+		t.Fatalf("stale lock output should point at lock, got: %s", out)
+	}
+	if strings.Contains(string(out), "--artifacts-dir") {
+		t.Fatalf("lock remediation should not include --artifacts-dir, got: %s", out)
+	}
+	if strings.Contains(string(out), "--lockfile") {
+		t.Fatalf("lock remediation should not include default --lockfile, got: %s", out)
+	}
+	staleArtifactsDir := filepath.Join(dir, "prepared-stale")
+	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--config", staleCfgPath, "--artifacts-dir", staleArtifactsDir).CombinedOutput()
+	if err == nil {
+		t.Fatalf("gestaltd sync with stale lock unexpectedly succeeded\noutput: %s", out)
+	}
+	if !strings.Contains(string(out), "lockfile is out of date") || !strings.Contains(string(out), "gestaltd lock") {
+		t.Fatalf("stale lock materialize output should point at lock, got: %s", out)
+	}
+	if strings.Contains(string(out), "lock entry for provider") {
+		t.Fatalf("stale lock materialize should fail before per-provider materialization, got: %s", out)
+	}
+	if _, err := os.Stat(staleArtifactsDir); !os.IsNotExist(err) {
+		t.Fatalf("stale sync should not create artifacts dir, stat err=%v", err)
+	}
+
+	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--check", "--config", staleCfgPath, "--lockfile", lockPath, "--artifacts-dir", filepath.Join(dir, "prepared")).CombinedOutput()
+	if err == nil {
+		t.Fatalf("gestaltd sync --check with stale lock unexpectedly succeeded\noutput: %s", out)
+	}
+	if !strings.Contains(string(out), "--lockfile "+lockPath) {
+		t.Fatalf("lock remediation should preserve explicit --lockfile, got: %s", out)
+	}
+	if strings.Contains(string(out), "--artifacts-dir") {
+		t.Fatalf("lock remediation should not include --artifacts-dir, got: %s", out)
+	}
+
+	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--check", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("gestaltd sync --check before sync unexpectedly succeeded\noutput: %s", out)
+	}
+	if !strings.Contains(string(out), "gestaltd sync --locked") {
+		t.Fatalf("sync --check output should point at sync, got: %s", out)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err = exec.CommandContext(ctx, gestaltdBin, "serve", "--locked", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("gestaltd serve --locked before sync unexpectedly succeeded\noutput: %s", out)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("gestaltd serve --locked before sync timed out\noutput: %s", out)
+	}
+	if !strings.Contains(string(out), "gestaltd sync --locked") {
+		t.Fatalf("locked serve output should point at sync, got: %s", out)
+	}
+
+	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd sync failed: %v\noutput: %s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gestaltd", "providers", "example")); err != nil {
+		t.Fatalf("expected synced plugin artifact: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "indexeddb", "inmem")); err != nil {
+		t.Fatalf("expected synced indexeddb artifact: %v", err)
+	}
+
+	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--check", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd sync --check after sync failed: %v\noutput: %s", err, out)
+	}
+
+	baseURL := startGestaltdWithConfigs(t, []string{cfgPath}, true)
+	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(baseURL + "/api/v1/integrations")
+	if err != nil {
+		t.Fatalf("GET /api/v1/integrations: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected /api/v1/integrations 200, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestE2ELockSyncPluginOwnedUI(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping E2E lock/sync plugin-owned UI test in short mode")
+	}
+
+	dir := t.TempDir()
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+	pluginDir := setupPrebuiltPluginDir(t, dir)
+	mountedUI := setupMountedUIDirWithRoutes(t, dir, []providermanifestv1.UIRoute{{
+		Path:         "/*",
+		AllowedRoles: []string{"viewer"},
+	}})
+	attachOwnedUIToPluginSource(t, pluginDir, mountedUI.ManifestPath)
+	pluginManifest, err := providerpkg.FindManifestFile(pluginDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile(%s): %v", pluginDir, err)
+	}
+
+	cfgPath := filepath.Join(dir, "config-owned-ui-lock-sync.yaml")
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
+  public:
+    port: 0
+  encryptionKey: test-lock-sync-owned-ui-key
+  providers:
+    indexeddb: inmem
+providers:
+  indexeddb:
+    inmem:
+      source:
+        path: %s
+plugins:
+  example:
+    source:
+      path: %s
+    ui:
+      path: /roadmap
+`, indexedDBManifest, pluginManifest)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write owned-ui lock/sync config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd lock failed: %v\noutput: %s", err, out)
+	}
+	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd sync failed: %v\noutput: %s", err, out)
+	}
+
+	baseURL := startGestaltdWithConfigs(t, []string{cfgPath}, true)
+	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(baseURL + "/roadmap/sync")
+	if err != nil {
+		t.Fatalf("GET /roadmap/sync: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected /roadmap/sync 200, got %d: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "Roadmap Review UI") {
+		t.Fatalf("expected mounted ui body to contain marker, got: %s", body)
+	}
 }
 
 func TestE2EInitWritesOverrideLockfile(t *testing.T) {
@@ -2619,12 +2814,16 @@ func TestE2EInitAndServeLayeredConfigs(t *testing.T) {
 	dir := t.TempDir()
 	basePath, overridePath, lockPath, _ := writeLayeredE2EConfigs(t, dir, 0)
 
-	out, err := exec.Command(gestaltdBin, "init", "--config", basePath, "--config", overridePath).CombinedOutput()
+	out, err := exec.Command(gestaltdBin, "lock", "--config", basePath, "--config", overridePath).CombinedOutput()
 	if err != nil {
-		t.Fatalf("gestaltd init with layered configs failed: %v\noutput: %s", err, out)
+		t.Fatalf("gestaltd lock with layered configs failed: %v\noutput: %s", err, out)
 	}
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatalf("expected lock file at %s: %v", lockPath, err)
+	}
+	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--config", basePath, "--config", overridePath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd sync with layered configs failed: %v\noutput: %s", err, out)
 	}
 
 	baseURL := startGestaltdWithConfigs(t, []string{basePath, overridePath}, true)
@@ -2651,11 +2850,11 @@ func TestE2EServeUsesOverrideLockfile(t *testing.T) {
 		name       string
 		lockDir    string
 		args       func(lockPath string) []string
-		preInit    bool
+		preSync    bool
 		waitForNew bool
 	}{
 		{
-			name:    "serve auto init",
+			name:    "serve auto prepare",
 			lockDir: "serve",
 			args: func(lockPath string) []string {
 				return []string{"serve", "--lockfile", lockPath}
@@ -2663,7 +2862,7 @@ func TestE2EServeUsesOverrideLockfile(t *testing.T) {
 			waitForNew: true,
 		},
 		{
-			name:    "default serve auto init",
+			name:    "default serve auto prepare",
 			lockDir: "default-serve",
 			args: func(lockPath string) []string {
 				return []string{"--lockfile", lockPath}
@@ -2676,7 +2875,7 @@ func TestE2EServeUsesOverrideLockfile(t *testing.T) {
 			args: func(lockPath string) []string {
 				return []string{"serve", "--locked", "--lockfile", lockPath}
 			},
-			preInit: true,
+			preSync: true,
 		},
 	}
 
@@ -2688,10 +2887,14 @@ func TestE2EServeUsesOverrideLockfile(t *testing.T) {
 			dir := t.TempDir()
 			cfgPath := writeServeConfig(t, dir, 0, nil)
 			lockPath := filepath.Join(dir, "state", tc.lockDir, "gestalt.lock.json")
-			if tc.preInit {
-				out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+			if tc.preSync {
+				out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 				if err != nil {
-					t.Fatalf("gestaltd init with --lockfile failed: %v\noutput: %s", err, out)
+					t.Fatalf("gestaltd lock with --lockfile failed: %v\noutput: %s", err, out)
+				}
+				out, err = exec.Command(gestaltdBin, "sync", "--locked", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+				if err != nil {
+					t.Fatalf("gestaltd sync with --lockfile failed: %v\noutput: %s", err, out)
 				}
 			}
 

--- a/gestaltd/cmd/gestaltd/init.go
+++ b/gestaltd/cmd/gestaltd/init.go
@@ -14,10 +14,13 @@ func operatorLifecycle() *operator.Lifecycle {
 	})
 }
 
-func initConfigWithStatePaths(configFlags []string, state operator.StatePaths, platformFlag string) error {
+func lockConfigWithStatePaths(configFlags []string, state operator.StatePaths, platformFlag string, check bool) error {
 	configPaths := operator.ResolveConfigPaths(configFlags)
+	if platformFlag == "" && check {
+		return operatorLifecycle().CheckLockAtPathsWithStatePaths(configPaths, state, nil)
+	}
 	if platformFlag == "" {
-		_, err := operatorLifecycle().InitAtPathsWithStatePaths(configPaths, state)
+		_, err := operatorLifecycle().LockAtPathsWithStatePaths(configPaths, state)
 		return err
 	}
 
@@ -35,8 +38,19 @@ func initConfigWithStatePaths(configFlags []string, state operator.StatePaths, p
 		platArgs[i] = struct{ GOOS, GOARCH string }{p.GOOS, p.GOARCH}
 	}
 
-	_, err = operatorLifecycle().InitAtPathsWithPlatforms(configPaths, state, platArgs)
+	if check {
+		return operatorLifecycle().CheckLockAtPathsWithStatePaths(configPaths, state, platArgs)
+	}
+	_, err = operatorLifecycle().LockAtPathsWithPlatforms(configPaths, state, platArgs)
 	return err
+}
+
+func syncConfigWithStatePaths(configFlags []string, state operator.StatePaths, check bool) error {
+	configPaths := operator.ResolveConfigPaths(configFlags)
+	if check {
+		return operatorLifecycle().CheckSyncAtPathsWithStatePaths(configPaths, state)
+	}
+	return operatorLifecycle().SyncAtPathsWithStatePaths(configPaths, state)
 }
 
 func loadConfigForExecutionAtPathsWithStatePaths(configPaths []string, state operator.StatePaths, locked bool) (*config.Config, error) {

--- a/gestaltd/cmd/gestaltd/main_test.go
+++ b/gestaltd/cmd/gestaltd/main_test.go
@@ -18,7 +18,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "root",
 			args:      []string{"--help"},
-			wantParts: []string{"gestaltd validate", "gestaltd init", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "[--config PATH]...", "--lockfile PATH"},
+			wantParts: []string{"gestaltd validate", "gestaltd lock", "gestaltd sync --locked", "gestaltd init", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "[--config PATH]...", "--lockfile PATH"},
 			notWant:   []string{"gestaltd bundle", "gestaltd dev"},
 		},
 		{
@@ -29,7 +29,17 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "init",
 			args:      []string{"init", "--help"},
-			wantParts: []string{"gestaltd init", "When repeated, --config files merge left-to-right.", "--lockfile PATH"},
+			wantParts: []string{"gestaltd init", "Legacy alias for `gestaltd lock`", "When repeated, --config files merge left-to-right.", "--lockfile PATH"},
+		},
+		{
+			name:      "lock",
+			args:      []string{"lock", "--help"},
+			wantParts: []string{"gestaltd lock", "write canonical lock metadata", "--platform", "--check"},
+		},
+		{
+			name:      "sync",
+			args:      []string{"sync", "--help"},
+			wantParts: []string{"gestaltd sync --locked", "Materialize prepared artifacts", "--artifacts-dir", "--check"},
 		},
 		{
 			name:      "provider",
@@ -103,6 +113,11 @@ func TestE2ECLIRejectsBadArgs(t *testing.T) {
 			name:     "validate trailing args",
 			args:     []string{"validate", "--config", "foo.yaml", "extra"},
 			wantPart: "unexpected arguments: extra",
+		},
+		{
+			name:     "init artifacts dir rejected",
+			args:     []string{"init", "--artifacts-dir", "/tmp/gestaltd-artifacts"},
+			wantPart: "gestaltd init no longer accepts --artifacts-dir",
 		},
 		{
 			name:     "missing validate config",

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -38,6 +38,10 @@ func run(args []string) error {
 			return runProvider(args[1:])
 		case "serve":
 			return runServe(args[1:])
+		case "lock":
+			return runLock(args[1:])
+		case "sync":
+			return runSync(args[1:])
 		case "init":
 			return runInit(args[1:])
 		case "validate":
@@ -76,7 +80,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
 	var lockedFlag *bool
 	if opts.allowLocked {
-		lockedFlag = fs.Bool("locked", false, "require exact lock state; do not auto-init")
+		lockedFlag = fs.Bool("locked", false, "require exact lock state; do not auto lock/sync")
 	}
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -124,6 +128,30 @@ func runInit(args []string) error {
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
 	platformFlag := fs.String("platform", "", "additional platforms to verify hashes for (comma-separated os/arch or \"all\")")
+	check := fs.Bool("check", false, "fail if the lockfile would change")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if strings.TrimSpace(*artifactsDir) != "" {
+		return fmt.Errorf("gestaltd init no longer accepts --artifacts-dir because it only writes lock metadata; run `gestaltd lock` followed by `gestaltd sync --locked --artifacts-dir %s`", *artifactsDir)
+	}
+
+	return lockConfigWithStatePaths(configPaths, operator.StatePaths{
+		LockfilePath: *lockfilePath,
+	}, *platformFlag, *check)
+}
+
+func runLock(args []string) error {
+	fs := flag.NewFlagSet("gestaltd lock", flag.ContinueOnError)
+	fs.Usage = func() { printLockUsage(fs.Output()) }
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	platformFlag := fs.String("platform", "", "additional platforms to verify hashes for (comma-separated os/arch or \"all\")")
+	check := fs.Bool("check", false, "fail if the lockfile would change")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -131,10 +159,34 @@ func runInit(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	return initConfigWithStatePaths(configPaths, operator.StatePaths{
+	return lockConfigWithStatePaths(configPaths, operator.StatePaths{
+		LockfilePath: *lockfilePath,
+	}, *platformFlag, *check)
+}
+
+func runSync(args []string) error {
+	fs := flag.NewFlagSet("gestaltd sync", flag.ContinueOnError)
+	fs.Usage = func() { printSyncUsage(fs.Output()) }
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
+	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	locked := fs.Bool("locked", false, "require an existing lockfile; do not resolve new metadata")
+	check := fs.Bool("check", false, "fail if artifacts would need to be materialized")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if !*locked {
+		return fmt.Errorf("gestaltd sync currently requires --locked")
+	}
+
+	return syncConfigWithStatePaths(configPaths, operator.StatePaths{
 		ArtifactsDir: *artifactsDir,
 		LockfilePath: *lockfilePath,
-	}, *platformFlag)
+	}, *check)
 }
 
 func runValidate(args []string) error {
@@ -236,13 +288,17 @@ func maskEmpty(s string) string {
 func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]")
-	writeUsageLine(w, "  gestaltd init [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--platform PLATFORMS]")
+	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
+	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--check]")
 	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
+	writeUsageLine(w, "  gestaltd init [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
-	writeUsageLine(w, "  init        Resolve providers and plugins and write lock state")
+	writeUsageLine(w, "  lock        Resolve provider metadata and write lock state")
+	writeUsageLine(w, "  sync        Materialize prepared artifacts from lock state")
+	writeUsageLine(w, "  init        Legacy alias for lock")
 	writeUsageLine(w, "  provider    Develop, validate, or build provider release archives")
 	writeUsageLine(w, "  serve       Start the server (use --locked for production)")
 	writeUsageLine(w, "  validate    Load and validate configuration without starting the server")
@@ -250,7 +306,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
-	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory for init/serve")
+	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory for sync/serve")
 	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
 }
 
@@ -258,31 +314,58 @@ func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
 	writeUsageLine(w, "")
-	writeUsageLine(w, "Start the server. Auto-inits if lock state is missing or stale.")
+	writeUsageLine(w, "Start the server. Without --locked, auto lock/syncs if state is missing or stale.")
 	writeUsageLine(w, "For production, strongly prefer --locked so startup uses the pinned")
-	writeUsageLine(w, "lockfile state instead of resolving new artifacts or mutating state.")
-	writeUsageLine(w, "When locked, run `gestaltd init` first to prepare artifacts.")
+	writeUsageLine(w, "lockfile and prepared artifacts instead of resolving or mutating state.")
+	writeUsageLine(w, "When locked, run `gestaltd lock` before deploy and `gestaltd sync --locked` during build.")
 	writeUsageLine(w, "When repeated, --config files merge left-to-right. Maps deep-merge,")
 	writeUsageLine(w, "later scalars win, lists replace, and null deletes inherited keys.")
 }
 
 func printInitUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd init [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--platform PLATFORMS]")
+	writeUsageLine(w, "  gestaltd init [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
 	writeUsageLine(w, "")
-	writeUsageLine(w, "Resolve remote plugin sources and write lock state.")
-	writeUsageLine(w, "By default, creates gestalt.lock.json in the config directory and prepared artifacts")
-	writeUsageLine(w, "in the artifacts directory. The lockfile records archive URLs for all")
-	writeUsageLine(w, "discovered platforms and verified SHA256 hashes for the current platform.")
-	writeUsageLine(w, "Use --platform to pre-verify hashes for additional deploy targets.")
-	writeUsageLine(w, "Use this before `gestaltd serve --locked` for production deployments.")
+	writeUsageLine(w, "Legacy alias for `gestaltd lock`; writes lock metadata only.")
+	writeUsageLine(w, "Use `gestaltd sync --locked` to materialize prepared artifacts.")
+	writeUsageLine(w, "When repeated, --config files merge left-to-right.")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
+	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	writeUsageLine(w, "  --platform        Additional platforms to verify (comma-separated os/arch or \"all\")")
+	writeUsageLine(w, "  --check           Fail if the lockfile would change")
+}
+
+func printLockUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Resolve provider metadata, validate config against staged scratch artifacts,")
+	writeUsageLine(w, "and write canonical lock metadata without preparing final artifacts.")
+	writeUsageLine(w, "When repeated, --config files merge left-to-right.")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
+	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	writeUsageLine(w, "  --platform        Additional platforms to verify (comma-separated os/arch or \"all\")")
+	writeUsageLine(w, "  --check           Fail if the lockfile would change")
+}
+
+func printSyncUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--check]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Materialize prepared artifacts from the existing lockfile.")
+	writeUsageLine(w, "Does not resolve new metadata or rewrite the lockfile.")
 	writeUsageLine(w, "When repeated, --config files merge left-to-right.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
 	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory")
 	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
-	writeUsageLine(w, "  --platform        Additional platforms to verify (comma-separated os/arch or \"all\")")
+	writeUsageLine(w, "  --locked          Require an existing lockfile")
+	writeUsageLine(w, "  --check           Fail if artifacts would need to be materialized")
 }
 
 func printValidateUsage(w io.Writer) {
@@ -293,7 +376,7 @@ func printValidateUsage(w io.Writer) {
 	writeUsageLine(w, "Validation always stages source-backed providers in a temporary scratch dir.")
 	writeUsageLine(w, "Repeated --config flags merge left-to-right.")
 	writeUsageLine(w, "The --lockfile path follows normal CLI path resolution; --artifacts-dir keeps")
-	writeUsageLine(w, "its existing config-relative behavior on init/serve.")
+	writeUsageLine(w, "its existing config-relative behavior on sync/serve paths for compatibility.")
 }
 
 func writeUsageLine(w io.Writer, line string) {

--- a/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
+++ b/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
@@ -68,7 +68,13 @@ For Google OAuth:
 For OIDC, override config.auth.plugin in your values file.
 {{- if .Values.pluginInit.enabled }}
 
-Plugin init is enabled. An init container runs `gestaltd init` before
-the main server starts, preparing locked state in a shared volume.
+Plugin init is enabled. An init container runs `gestaltd lock` followed by
+`gestaltd sync --locked` before the main server starts, preparing locked state
+in a shared volume.
 The main container runs with --locked to prevent mutation at startup.
+{{- else if .Values.lockedServe.enabled }}
+
+Locked serve is enabled. The main container runs with --locked and expects
+lock state plus prepared artifacts to be present from the image or external
+mounts before startup.
 {{- end }}

--- a/gestaltd/deploy/helm/gestalt/templates/deployment.yaml
+++ b/gestaltd/deploy/helm/gestalt/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args:
-            - cp -r /etc/gestalt-config/. /etc/gestalt/ && /gestaltd init --config /etc/gestalt/config.yaml
+            - cp -r /etc/gestalt-config/. /etc/gestalt/ && /gestaltd lock --config /etc/gestalt/config.yaml && /gestaltd sync --locked --config /etc/gestalt/config.yaml
           {{- with .Values.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -82,7 +82,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - serve
+            {{- if or .Values.pluginInit.enabled .Values.lockedServe.enabled }}
             - --locked
+            {{- end }}
             - --config
             - /etc/gestalt/config.yaml
           ports:

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -151,7 +151,14 @@ extraEnv: []
 
 pluginInit:
   # Enable this when your config uses remote REST/GraphQL upstreams or
-  # packaged plugins and you want the chart to prepare locked state for you.
+  # packaged plugins and you want the chart to lock and sync prepared artifacts
+  # before the main container starts in locked mode.
+  enabled: false
+
+lockedServe:
+  # Enable this when lock state and prepared artifacts are baked into the image
+  # or mounted by external automation, without using the chart's pluginInit
+  # init container.
   enabled: false
 
 livenessProbe:

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"crypto/sha256"
@@ -90,6 +91,18 @@ type StatePaths struct {
 	LockfilePath string
 }
 
+type artifactMode int
+
+const (
+	artifactModeMaterialize artifactMode = iota
+	artifactModeCheck
+	artifactModeReadOnly
+)
+
+func (m artifactMode) canMaterialize() bool {
+	return m == artifactModeMaterialize
+}
+
 func NewLifecycle() *Lifecycle {
 	return &Lifecycle{}
 }
@@ -126,6 +139,71 @@ func (l *Lifecycle) InitAtPathsWithStatePaths(configPaths []string, state StateP
 	return lock, err
 }
 
+func (l *Lifecycle) LockAtPathsWithStatePaths(configPaths []string, state StatePaths) (*Lockfile, error) {
+	return l.LockAtPathsWithPlatforms(configPaths, state, nil)
+}
+
+func (l *Lifecycle) LockAtPathsWithPlatforms(configPaths []string, state StatePaths, platforms []struct{ GOOS, GOARCH string }) (*Lockfile, error) {
+	lock, cfg, paths, cleanup, err := l.prepareLockAtPathsInScratch(configPaths, state)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(platforms) > 0 {
+		tokenForSource := buildSourceTokenMap(cfg)
+		if err := l.downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
+			return nil, err
+		}
+	}
+	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
+		return nil, err
+	}
+	slog.Info("wrote lockfile", "path", paths.lockfilePath)
+	return providerLockfileFromLockfile(lock).toLockfile(), nil
+}
+
+func (l *Lifecycle) CheckLockAtPathsWithStatePaths(configPaths []string, state StatePaths, platforms []struct{ GOOS, GOARCH string }) error {
+	lock, cfg, paths, cleanup, err := l.prepareLockAtPathsInScratch(configPaths, state)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return err
+	}
+	if len(platforms) > 0 {
+		tokenForSource := buildSourceTokenMap(cfg)
+		if err := l.downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
+			return err
+		}
+	}
+	expected, err := canonicalLockfileJSON(lock)
+	if err != nil {
+		return err
+	}
+	currentLock, err := ReadLockfile(paths.lockfilePath)
+	if err != nil {
+		return fmt.Errorf("lockfile is missing or unreadable; run `%s`: %w", formatLockCommand(paths), err)
+	}
+	current, err := canonicalLockfileJSON(currentLock)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(current, expected) {
+		return fmt.Errorf("lockfile is out of date; run `%s`", formatLockCommand(paths))
+	}
+	return nil
+}
+
+func (l *Lifecycle) SyncAtPathsWithStatePaths(configPaths []string, state StatePaths) error {
+	return l.syncAtPathsWithStatePaths(configPaths, state, artifactModeMaterialize)
+}
+
+func (l *Lifecycle) CheckSyncAtPathsWithStatePaths(configPaths []string, state StatePaths) error {
+	return l.syncAtPathsWithStatePaths(configPaths, state, artifactModeCheck)
+}
+
 // InitAtPathWithPlatforms runs init and additionally downloads and hashes
 // archives for the specified extra platforms.
 func (l *Lifecycle) InitAtPathWithPlatforms(configPath, artifactsDir string, platforms []struct{ GOOS, GOARCH string }) (*Lockfile, error) {
@@ -155,25 +233,8 @@ func (l *Lifecycle) InitAtPathsWithPlatforms(configPaths []string, state StatePa
 }
 
 func (l *Lifecycle) initAtPaths(configPaths []string, state StatePaths) (*Lockfile, *config.Config, initPaths, error) {
-	cfg, err := config.LoadAllowMissingEnvPaths(configPaths)
+	lock, cfg, paths, err := l.prepareLockAtPaths(configPaths, state)
 	if err != nil {
-		return nil, nil, initPaths{}, fmt.Errorf("loading config: %v", err)
-	}
-	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
-		return nil, nil, initPaths{}, fmt.Errorf("loading config: %v", err)
-	}
-	paths := resolveInitPaths(configPaths, cfg, state)
-	lock, err := l.prepareRuntimeLockFromLoadedConfig(context.Background(), paths, cfg)
-	if err != nil {
-		return nil, nil, initPaths{}, err
-	}
-	if err := l.applyPreparedProviders(paths, lock, cfg, true); err != nil {
-		return nil, nil, initPaths{}, err
-	}
-	if err := config.ValidateResolvedStructure(cfg); err != nil {
-		return nil, nil, initPaths{}, err
-	}
-	if err := plugininvocation.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
 		return nil, nil, initPaths{}, err
 	}
 	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
@@ -185,8 +246,51 @@ func (l *Lifecycle) initAtPaths(configPaths []string, state StatePaths) (*Lockfi
 	return lock, cfg, paths, nil
 }
 
+func (l *Lifecycle) prepareLockAtPathsInScratch(configPaths []string, state StatePaths) (*Lockfile, *config.Config, initPaths, func(), error) {
+	scratchDir, err := os.MkdirTemp("", "gestaltd-lock-*")
+	if err != nil {
+		return nil, nil, initPaths{}, nil, fmt.Errorf("create lock scratch dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(scratchDir) }
+	scratchState := state
+	scratchState.ArtifactsDir = scratchDir
+	lock, cfg, paths, err := l.prepareLockAtPaths(configPaths, scratchState, state)
+	if err != nil {
+		return nil, nil, initPaths{}, cleanup, err
+	}
+	return lock, cfg, paths, cleanup, nil
+}
+
+func (l *Lifecycle) prepareLockAtPaths(configPaths []string, state StatePaths, displayState ...StatePaths) (*Lockfile, *config.Config, initPaths, error) {
+	cfg, err := config.LoadAllowMissingEnvPaths(configPaths)
+	if err != nil {
+		return nil, nil, initPaths{}, fmt.Errorf("loading config: %v", err)
+	}
+	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
+		return nil, nil, initPaths{}, fmt.Errorf("loading config: %v", err)
+	}
+	paths := resolveInitPaths(configPaths, cfg, state)
+	if len(displayState) > 0 {
+		paths.configFlags = formatInitFlags(configPaths, displayState[0])
+	}
+	lock, err := l.prepareRuntimeLockFromLoadedConfig(context.Background(), paths, cfg)
+	if err != nil {
+		return nil, nil, initPaths{}, err
+	}
+	if err := l.applyPreparedProviders(paths, lock, cfg, artifactModeMaterialize); err != nil {
+		return nil, nil, initPaths{}, err
+	}
+	if err := config.ValidateResolvedStructure(cfg); err != nil {
+		return nil, nil, initPaths{}, err
+	}
+	if err := plugininvocation.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
+		return nil, nil, initPaths{}, err
+	}
+	return lock, cfg, paths, nil
+}
+
 func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, paths initPaths, cfg *config.Config) (*Lockfile, error) {
-	secretsEntries, err := l.primeSecretsProviderForConfigResolution(ctx, paths, cfg, nil)
+	secretsEntries, err := l.primeSecretsProviderForConfigResolution(ctx, paths, cfg, nil, artifactModeMaterialize)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +338,7 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 		}
 		lock.Runtimes[name] = lockEntry
 	}
-	if err := l.resolveConfiguredPlugins(paths, lock, cfg, true); err != nil {
+	if err := l.resolveConfiguredPlugins(paths, lock, cfg, artifactModeMaterialize); err != nil {
 		return nil, err
 	}
 	existingUIEntries := make(map[string]struct{}, len(cfg.Providers.UI))
@@ -343,11 +447,15 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
 	paths := resolveInitPaths(configPaths, cfg, state)
+	mode := artifactModeMaterialize
+	if locked {
+		mode = artifactModeReadOnly
+	}
 	secretsLock, secretsValidated, err := l.lockForSecretsBootstrap(configPaths, state, paths, cfg, locked)
 	if err != nil {
 		return nil, nil, err
 	}
-	if _, err := l.primeSecretsProviderForConfigResolution(context.Background(), paths, cfg, secretsLock); err != nil {
+	if _, err := l.primeSecretsProviderForConfigResolution(context.Background(), paths, cfg, secretsLock, mode); err != nil {
 		return nil, nil, err
 	}
 	if err := l.resolveConfigSecrets(context.Background(), cfg); err != nil {
@@ -357,7 +465,7 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 		return nil, nil, err
 	}
 
-	dependenciesValidated, err := l.applyLockedProviders(configPaths, state, cfg, locked, secretsLock)
+	dependenciesValidated, err := l.applyLockedProviders(configPaths, state, cfg, locked, secretsLock, mode)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -385,7 +493,7 @@ func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string,
 	if err := config.ValidateRuntime(cfg); err != nil {
 		return nil, err
 	}
-	if err := l.applyPreparedProviders(paths, lock, cfg, true); err != nil {
+	if err := l.applyPreparedProviders(paths, lock, cfg, artifactModeMaterialize); err != nil {
 		return nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -395,6 +503,43 @@ func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string,
 		return nil, err
 	}
 	return cfg, nil
+}
+
+func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StatePaths, mode artifactMode) error {
+	cfg, err := config.LoadAllowMissingEnvPaths(configPaths)
+	if err != nil {
+		return fmt.Errorf("loading config: %v", err)
+	}
+	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
+		return fmt.Errorf("loading config: %v", err)
+	}
+	paths := resolveInitPaths(configPaths, cfg, state)
+	lock, err := ReadLockfile(paths.lockfilePath)
+	if err != nil {
+		return fmt.Errorf("source-backed providers require lock metadata; run `%s`: %w", formatLockCommand(paths), err)
+	}
+	if !lockMetadataMatchesConfig(cfg, paths, lock) {
+		return fmt.Errorf("lockfile is out of date; run `%s`", formatLockCommand(paths))
+	}
+	if _, err := l.primeSecretsProviderForConfigResolution(context.Background(), paths, cfg, lock, mode); err != nil {
+		return err
+	}
+	if err := l.resolveConfigSecrets(context.Background(), cfg); err != nil {
+		return err
+	}
+	if err := config.ValidateRuntime(cfg); err != nil {
+		return err
+	}
+	if err := l.applyPreparedProviders(paths, lock, cfg, mode); err != nil {
+		return err
+	}
+	if err := config.ValidateResolvedStructure(cfg); err != nil {
+		return err
+	}
+	if err := plugininvocation.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (l *Lifecycle) resolveConfigSecrets(ctx context.Context, cfg *config.Config) error {
@@ -493,12 +638,12 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, state StatePat
 		validatedDuringInit = err == nil
 	}
 	if err != nil {
-		return nil, false, fmt.Errorf("source-backed providers require prepared artifacts; run `gestaltd init %s`: %w", paths.configFlags, err)
+		return nil, false, fmt.Errorf("source-backed providers require lock metadata; run `%s` then `%s`: %w", formatLockCommand(paths), formatSyncLockedCommand(paths), err)
 	}
 	return lock, validatedDuringInit, nil
 }
 
-func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context, paths initPaths, cfg *config.Config, lock *Lockfile) (map[string]LockEntry, error) {
+func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context, paths initPaths, cfg *config.Config, lock *Lockfile, mode artifactMode) (map[string]LockEntry, error) {
 	if cfg == nil {
 		return nil, nil
 	}
@@ -560,9 +705,9 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 				if lock != nil {
 					lockEntry, ok := lock.Secrets[name]
 					if !ok {
-						return nil, fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", providermanifestv1.KindSecrets, name, paths.configFlags)
+						return nil, lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", providermanifestv1.KindSecrets, name)
 					}
-					if err := l.applyLockedComponentEntry(paths, &lockEntry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), false); err != nil {
+					if err := l.applyLockedComponentEntry(paths, &lockEntry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), mode); err != nil {
 						return nil, err
 					}
 				} else {
@@ -570,7 +715,7 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 					if err != nil {
 						return nil, err
 					}
-					if err := l.applyLockedComponentEntry(paths, &entry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), false); err != nil {
+					if err := l.applyLockedComponentEntry(paths, &entry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), artifactModeMaterialize); err != nil {
 						return nil, err
 					}
 					prepared[name] = entry
@@ -610,6 +755,7 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 type initPaths struct {
 	configPaths            []string
 	configFlags            string
+	lockFlags              string
 	configPath             string
 	configDir              string
 	artifactsDir           string
@@ -652,15 +798,42 @@ func formatInitFlags(paths []string, state StatePaths) string {
 	return strings.Join(args, " ")
 }
 
-func formatPlatformInitFlags(paths initPaths, platform string) string {
-	args := strings.TrimSpace(paths.configFlags)
-	if platform == "" {
-		return args
+func formatLockFlags(paths []string, state StatePaths) string {
+	if len(paths) == 0 && state.LockfilePath == "" {
+		return ""
 	}
+	args := make([]string, 0, len(paths)*2+2)
+	for _, path := range paths {
+		args = append(args, "--config", path)
+	}
+	if state.LockfilePath != "" {
+		args = append(args, "--lockfile", state.LockfilePath)
+	}
+	return strings.Join(args, " ")
+}
+
+func formatLockCommand(paths initPaths) string {
+	args := strings.TrimSpace(paths.lockFlags)
 	if args == "" {
-		return "--platform " + platform
+		return "gestaltd lock"
 	}
-	return args + " --platform " + platform
+	return "gestaltd lock " + args
+}
+
+func formatSyncLockedCommand(paths initPaths) string {
+	args := strings.TrimSpace(paths.configFlags)
+	if args == "" {
+		return "gestaltd sync --locked"
+	}
+	return "gestaltd sync --locked " + args
+}
+
+func preparedArtifactStaleError(paths initPaths, format string, args ...any) error {
+	return fmt.Errorf(format+"; run `%s`", append(args, formatSyncLockedCommand(paths))...)
+}
+
+func lockMetadataStaleError(paths initPaths, format string, args ...any) error {
+	return fmt.Errorf(format+"; run `%s`", append(args, formatLockCommand(paths))...)
 }
 
 type providerFingerprintInput struct {
@@ -880,6 +1053,7 @@ func resolveInitPaths(configPaths []string, cfg *config.Config, state StatePaths
 	return initPaths{
 		configPaths:            append([]string(nil), configPaths...),
 		configFlags:            formatInitFlags(configPaths, state),
+		lockFlags:              formatLockFlags(configPaths, state),
 		configPath:             configPath,
 		configDir:              configDir,
 		artifactsDir:           artifactsDir,
@@ -1057,6 +1231,14 @@ func writeJSONFile(path string, v any) error {
 	return os.WriteFile(path, data, 0o644)
 }
 
+func canonicalLockfileJSON(lock *Lockfile) ([]byte, error) {
+	data, err := json.MarshalIndent(providerLockfileFromLockfile(lock), "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
 func ReadLockfile(path string) (*Lockfile, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -1157,6 +1339,70 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			return false
 		}
 		if _, err := os.Stat(install.assetRootPath); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func lockMetadataMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool {
+	if lock == nil {
+		return false
+	}
+	for name, entry := range cfg.Plugins {
+		if !sourceBacked(entry) {
+			continue
+		}
+		lockEntry, found := lock.Providers[name]
+		if !lockEntryMetadataMatches(paths, providermanifestv1.KindPlugin, name, entry, lockEntry, found) {
+			return false
+		}
+	}
+	for _, collection := range hostProviderCollections(cfg) {
+		lockEntries := lockEntriesForKind(lock, collection.kind)
+		for name, entry := range collection.entries {
+			if entry == nil || !sourceBacked(entry) {
+				continue
+			}
+			lockEntry, found := lockEntries[name]
+			if !lockEntryMetadataMatches(paths, providerManifestKind(collection.kind), name, entry, lockEntry, found) {
+				return false
+			}
+		}
+	}
+	for name, entry := range cfg.Runtime.Providers {
+		if !runtimeSourceBacked(entry) {
+			continue
+		}
+		lockEntry, found := lock.Runtimes[name]
+		if !lockEntryMetadataMatches(paths, providermanifestv1.KindRuntime, name, &entry.ProviderEntry, lockEntry, found) {
+			return false
+		}
+	}
+	for name, entry := range cfg.Providers.IndexedDB {
+		if !sourceBacked(entry) {
+			continue
+		}
+		lockEntry, found := lock.IndexedDBs[name]
+		if !lockEntryMetadataMatches(paths, providermanifestv1.KindIndexedDB, name, entry, lockEntry, found) {
+			return false
+		}
+	}
+	for name, entry := range cfg.Providers.S3 {
+		if !sourceBacked(entry) {
+			continue
+		}
+		lockEntry, found := lock.S3[name]
+		if !lockEntryMetadataMatches(paths, providermanifestv1.KindS3, name, entry, lockEntry, found) {
+			return false
+		}
+	}
+	for name, entry := range cfg.Providers.UI {
+		if entry == nil || !sourceBacked(&entry.ProviderEntry) {
+			continue
+		}
+		lockEntry, found := lock.UIs[name]
+		if !uiLockEntryMetadataMatches(paths, name, &entry.ProviderEntry, lockEntry, found) {
 			return false
 		}
 	}
@@ -1397,14 +1643,7 @@ func readLockEntryManifest(paths initPaths, entry LockEntry, destDir string) (*p
 }
 
 func lockEntryMatches(paths initPaths, kind, name string, providerEntry *config.ProviderEntry, entry LockEntry, found bool, destDir string) bool {
-	if !found {
-		return false
-	}
-	fingerprint, err := ProviderFingerprint(name, providerEntry, paths.configDir)
-	if err != nil || entry.Fingerprint != fingerprint {
-		return false
-	}
-	if entry.Source != providerSourceLockLocation(providerEntry, paths.configDir) {
+	if !lockEntryMetadataMatches(paths, kind, name, providerEntry, entry, found) {
 		return false
 	}
 	if len(entry.Archives) > 0 {
@@ -1415,6 +1654,7 @@ func lockEntryMatches(paths initPaths, kind, name string, providerEntry *config.
 		}
 		policyKind := archivePolicyKind(kind)
 		var manifest *providermanifestv1.Manifest
+		var err error
 		if policyKind == providermanifestv1.KindPlugin {
 			manifest, err = readLockEntryManifest(paths, entry, destDir)
 			if err != nil {
@@ -1452,6 +1692,40 @@ func lockEntryMatches(paths initPaths, kind, name string, providerEntry *config.
 	return true
 }
 
+func lockEntryMetadataMatches(paths initPaths, kind, name string, providerEntry *config.ProviderEntry, entry LockEntry, found bool) bool {
+	if !found {
+		return false
+	}
+	fingerprint, err := ProviderFingerprint(name, providerEntry, paths.configDir)
+	if err != nil || entry.Fingerprint != fingerprint {
+		return false
+	}
+	if entry.Source != providerSourceLockLocation(providerEntry, paths.configDir) {
+		return false
+	}
+	if entry.Kind != "" && entry.Kind != kind {
+		return false
+	}
+	return true
+}
+
+func uiLockEntryMetadataMatches(paths initPaths, name string, providerEntry *config.ProviderEntry, entry LockEntry, found bool) bool {
+	if !found {
+		return false
+	}
+	fingerprint, err := NamedUIProviderFingerprint(name, providerEntry, paths.configDir)
+	if err != nil || entry.Fingerprint != fingerprint {
+		return false
+	}
+	if entry.Source != providerSourceLockLocation(providerEntry, paths.configDir) {
+		return false
+	}
+	if entry.Kind != "" && entry.Kind != providermanifestv1.KindUI {
+		return false
+	}
+	return true
+}
+
 func preparedManifestMatchesLock(entry LockEntry, manifest *providermanifestv1.Manifest) bool {
 	if manifest == nil {
 		return false
@@ -1478,26 +1752,43 @@ func resolveArchiveForPlatform(entry LockEntry, platform string) (LockArchive, s
 }
 
 func prepareLocalSourceInstall(kind, name, manifestPath, destDir string) (*preparedInstall, error) {
+	_, cleanupInstall, commitInstall, err := stageLocalSourceInstall(kind, name, manifestPath, destDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cleanupInstall() }()
+	if err := commitInstall(); err != nil {
+		return nil, err
+	}
+	install, err := inspectPreparedInstall(destDir)
+	if err != nil {
+		return nil, fmt.Errorf("inspect prepared install for %s %q: %w", kind, name, err)
+	}
+	return install, nil
+}
+
+func stageLocalSourceInstall(kind, name, manifestPath, destDir string) (*preparedInstall, func() error, func() error, error) {
 	if strings.TrimSpace(manifestPath) == "" {
-		return nil, fmt.Errorf("manifest path for %s %q is required", kind, name)
+		return nil, nil, nil, fmt.Errorf("manifest path for %s %q is required", kind, name)
 	}
 	if _, err := os.Stat(manifestPath); err != nil {
-		return nil, fmt.Errorf("manifest for %s %q not found at %s: %w", kind, name, manifestPath, err)
+		return nil, nil, nil, fmt.Errorf("manifest for %s %q not found at %s: %w", kind, name, manifestPath, err)
 	}
 	parentDir := filepath.Dir(destDir)
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
-		return nil, fmt.Errorf("create destination parent directory: %w", err)
+		return nil, nil, nil, fmt.Errorf("create destination parent directory: %w", err)
 	}
 	tempDir, err := os.MkdirTemp(parentDir, filepath.Base(destDir)+".tmp-*")
 	if err != nil {
-		return nil, fmt.Errorf("create temp install directory: %w", err)
+		return nil, nil, nil, fmt.Errorf("create temp install directory: %w", err)
 	}
 	cleanupDir := tempDir
-	defer func() {
-		if cleanupDir != "" {
-			_ = os.RemoveAll(cleanupDir)
+	cleanupInstall := func() error {
+		if cleanupDir == "" {
+			return nil
 		}
-	}()
+		return os.RemoveAll(cleanupDir)
+	}
 
 	stageKind := kind
 	if stageKind == providerLockKindTelemetry || stageKind == providerLockKindAudit {
@@ -1509,37 +1800,43 @@ func prepareLocalSourceInstall(kind, name, manifestPath, destDir string) (*prepa
 		GOOS:       runtime.GOOS,
 		GOARCH:     runtime.GOARCH,
 	}); err != nil {
-		return nil, fmt.Errorf("prepare manifest for %s %q: %w", kind, name, err)
+		_ = cleanupInstall()
+		return nil, nil, nil, fmt.Errorf("prepare manifest for %s %q: %w", kind, name, err)
+	}
+	install, err := inspectPreparedInstall(tempDir)
+	if err != nil {
+		_ = cleanupInstall()
+		return nil, nil, nil, fmt.Errorf("inspect prepared install for %s %q: %w", kind, name, err)
 	}
 
-	backupDir := ""
-	if _, err := os.Stat(destDir); err == nil {
-		backupDir = destDir + ".backup-" + strconv.FormatInt(time.Now().UnixNano(), 10)
-		if err := os.Rename(destDir, backupDir); err != nil {
-			return nil, fmt.Errorf("stage existing provider cache at %s: %w", destDir, err)
+	commitInstall := func() error {
+		backupDir := ""
+		if _, err := os.Stat(destDir); err == nil {
+			backupDir = destDir + ".backup-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+			if err := os.Rename(destDir, backupDir); err != nil {
+				return fmt.Errorf("stage existing provider cache at %s: %w", destDir, err)
+			}
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect existing provider cache at %s: %w", destDir, err)
 		}
-	} else if !os.IsNotExist(err) {
-		return nil, fmt.Errorf("inspect existing provider cache at %s: %w", destDir, err)
-	}
-	if err := os.Rename(tempDir, destDir); err != nil {
+		if err := os.Rename(tempDir, destDir); err != nil {
+			if backupDir != "" {
+				if restoreErr := os.Rename(backupDir, destDir); restoreErr != nil {
+					return fmt.Errorf("activate prepared install at %s: %w (rollback failed: %v)", destDir, err, restoreErr)
+				}
+			}
+			return fmt.Errorf("activate prepared install at %s: %w", destDir, err)
+		}
+		cleanupDir = ""
 		if backupDir != "" {
-			if restoreErr := os.Rename(backupDir, destDir); restoreErr != nil {
-				return nil, fmt.Errorf("activate prepared install at %s: %w (rollback failed: %v)", destDir, err, restoreErr)
+			if err := os.RemoveAll(backupDir); err != nil {
+				return fmt.Errorf("remove staged provider cache backup at %s: %w", backupDir, err)
 			}
 		}
-		return nil, fmt.Errorf("activate prepared install at %s: %w", destDir, err)
+		return nil
 	}
-	cleanupDir = ""
-	if backupDir != "" {
-		if err := os.RemoveAll(backupDir); err != nil {
-			return nil, fmt.Errorf("remove staged provider cache backup at %s: %w", backupDir, err)
-		}
-	}
-	install, err := inspectPreparedInstall(destDir)
-	if err != nil {
-		return nil, fmt.Errorf("inspect prepared install for %s %q: %w", kind, name, err)
-	}
-	return install, nil
+
+	return install, cleanupInstall, commitInstall, nil
 }
 
 func relativePreparedPath(artifactsDir, path string) (string, error) {
@@ -1873,22 +2170,15 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	return entry, nil
 }
 
-func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg *config.Config, locked bool) error {
+func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg *config.Config, mode artifactMode) error {
 	if !configHasProviderLoading(cfg) {
 		return nil
 	}
 
-	synthesizedPluginUIs, err := synthesizeLockedSourcePluginOwnedUIEntries(cfg, paths, lock)
-	if err != nil {
-		return err
-	}
-
-	if err := l.resolveConfiguredPlugins(paths, lock, cfg, locked); err != nil {
-		clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
+	if err := l.resolveConfiguredPlugins(paths, lock, cfg, mode); err != nil {
 		return err
 	}
 	if err := synthesizePluginOwnedUIEntries(cfg); err != nil {
-		clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
 		return err
 	}
 	for _, collection := range hostProviderCollections(cfg) {
@@ -1897,8 +2187,7 @@ func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg 
 			if entry == nil {
 				continue
 			}
-			if err := l.applyComponentProvider(paths, lockEntries, providerManifestKind(collection.kind), name, entry, entry.Config, &entry.Config, componentDestDir(paths, collection.kind, name), locked); err != nil {
-				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
+			if err := l.applyComponentProvider(paths, lockEntries, providerManifestKind(collection.kind), name, entry, entry.Config, &entry.Config, componentDestDir(paths, collection.kind, name), mode); err != nil {
 				return err
 			}
 		}
@@ -1911,8 +2200,7 @@ func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg 
 		if entry == nil {
 			continue
 		}
-		if err := l.applyComponentProvider(paths, runtimeLocks, providermanifestv1.KindRuntime, name, &entry.ProviderEntry, entry.Config, &entry.Config, runtimeDestDir(paths, name), locked); err != nil {
-			clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
+		if err := l.applyComponentProvider(paths, runtimeLocks, providermanifestv1.KindRuntime, name, &entry.ProviderEntry, entry.Config, &entry.Config, runtimeDestDir(paths, name), mode); err != nil {
 			return err
 		}
 	}
@@ -1922,8 +2210,7 @@ func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg 
 	}
 	for name, def := range cfg.Providers.IndexedDB {
 		if def != nil {
-			if err := l.applyComponentProvider(paths, indexedDBLocks, providermanifestv1.KindIndexedDB, name, def, def.Config, &def.Config, indexeddbDestDir(paths, name), locked); err != nil {
-				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
+			if err := l.applyComponentProvider(paths, indexedDBLocks, providermanifestv1.KindIndexedDB, name, def, def.Config, &def.Config, indexeddbDestDir(paths, name), mode); err != nil {
 				return err
 			}
 		}
@@ -1934,8 +2221,7 @@ func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg 
 	}
 	for name, def := range cfg.Providers.S3 {
 		if def != nil {
-			if err := l.applyComponentProvider(paths, s3Locks, providermanifestv1.KindS3, name, def, def.Config, &def.Config, s3DestDir(paths, name), locked); err != nil {
-				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
+			if err := l.applyComponentProvider(paths, s3Locks, providermanifestv1.KindS3, name, def, def.Config, &def.Config, s3DestDir(paths, name), mode); err != nil {
 				return err
 			}
 		}
@@ -1950,9 +2236,8 @@ func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg 
 				lockEntry = &le
 			}
 		}
-		resolvedAssetRoot, err := l.applyConfiguredUIProvider(paths, lockEntry, &entry.ProviderEntry, name, "ui "+strconv.Quote(name), uiDestDir(paths, name), locked)
+		resolvedAssetRoot, err := l.applyConfiguredUIProvider(paths, lockEntry, &entry.ProviderEntry, name, "ui "+strconv.Quote(name), uiDestDir(paths, name), mode)
 		if err != nil {
-			clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
 			return err
 		}
 		entry.ResolvedAssetRoot = resolvedAssetRoot
@@ -1961,7 +2246,7 @@ func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg 
 	return nil
 }
 
-func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths, cfg *config.Config, locked bool, bootstrapLock *Lockfile) (bool, error) {
+func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths, cfg *config.Config, locked bool, bootstrapLock *Lockfile, mode artifactMode) (bool, error) {
 	if !configHasProviderLoading(cfg) {
 		return false, nil
 	}
@@ -1978,9 +2263,9 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths,
 		validatedDuringInit = err == nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("source-backed providers require prepared artifacts; run `gestaltd init %s`: %w", paths.configFlags, err)
+		return false, fmt.Errorf("source-backed providers require lock metadata; run `%s` then `%s`: %w", formatLockCommand(paths), formatSyncLockedCommand(paths), err)
 	}
-	if err := l.applyPreparedProviders(paths, lock, cfg, locked); err != nil {
+	if err := l.applyPreparedProviders(paths, lock, cfg, mode); err != nil {
 		return false, err
 	}
 	return validatedDuringInit, nil
@@ -2038,7 +2323,7 @@ func installLockedPackageAtomic(packagePath, destDir string) (*pluginstore.Insta
 	}, commit, nil
 }
 
-func (l *Lifecycle) resolveConfiguredPlugins(paths initPaths, lock *Lockfile, cfg *config.Config, locked bool) error {
+func (l *Lifecycle) resolveConfiguredPlugins(paths initPaths, lock *Lockfile, cfg *config.Config, mode artifactMode) error {
 	for name, entry := range cfg.Plugins {
 		if entry == nil {
 			continue
@@ -2049,7 +2334,7 @@ func (l *Lifecycle) resolveConfiguredPlugins(paths initPaths, lock *Lockfile, cf
 		}
 		switch {
 		case sourceBacked(entry):
-			if err := l.applyLockedProviderEntry(paths, lock, name, entry, configMap, locked); err != nil {
+			if err := l.applyLockedProviderEntry(paths, lock, name, entry, configMap, mode); err != nil {
 				return err
 			}
 		default:
@@ -2105,68 +2390,6 @@ func synthesizePluginOwnedUIEntries(cfg *config.Config) error {
 		cfg.Providers.UI[pluginName] = entry
 	}
 	return nil
-}
-
-func synthesizeLockedSourcePluginOwnedUIEntries(cfg *config.Config, paths initPaths, lock *Lockfile) (map[string]struct{}, error) {
-	added := map[string]struct{}{}
-	if cfg == nil || len(cfg.Plugins) == 0 || lock == nil {
-		return added, nil
-	}
-	if cfg.Providers.UI == nil {
-		cfg.Providers.UI = map[string]*config.UIEntry{}
-	}
-	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
-	for _, pluginName := range pluginNames {
-		plugin := cfg.Plugins[pluginName]
-		if plugin == nil || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !sourceBacked(plugin) {
-			continue
-		}
-		lockEntry, ok := lock.Providers[pluginName]
-		if !ok {
-			continue
-		}
-		install, err := inspectPreparedInstall(providerDestDir(paths, pluginName))
-		if err != nil {
-			return added, fmt.Errorf("prepare manifest for provider %q: %w", pluginName, err)
-		}
-		if !preparedManifestMatchesLock(lockEntry, install.manifest) {
-			return added, fmt.Errorf("prepared manifest for provider %q is missing or stale", pluginName)
-		}
-		if install.manifest == nil || install.manifest.Spec == nil || install.manifest.Spec.UI == nil {
-			continue
-		}
-		entry, err := ownedUIEntryFromManifest(install.manifestPath, install.manifest.Spec.UI)
-		if err != nil {
-			return added, fmt.Errorf("plugin %q ui: %w", pluginName, err)
-		}
-		entry.Path = strings.TrimSpace(plugin.MountPath)
-		entry.AuthorizationPolicy = strings.TrimSpace(plugin.AuthorizationPolicy)
-		entry.OwnerPlugin = pluginName
-		if existing := cfg.Providers.UI[pluginName]; existing != nil {
-			if err := validateSynthesizedPluginUIEntry(pluginName, existing, entry); err != nil {
-				return added, err
-			}
-			if existing.Source.Auth == nil && entry.Source.Auth != nil {
-				existing.Source.Auth = entry.Source.Auth
-			}
-			existing.Path = cmp.Or(existing.Path, entry.Path)
-			existing.AuthorizationPolicy = cmp.Or(existing.AuthorizationPolicy, entry.AuthorizationPolicy)
-			existing.OwnerPlugin = cmp.Or(existing.OwnerPlugin, entry.OwnerPlugin)
-			continue
-		}
-		cfg.Providers.UI[pluginName] = entry
-		added[pluginName] = struct{}{}
-	}
-	return added, nil
-}
-
-func clearSynthesizedPluginOwnedUIEntries(cfg *config.Config, added map[string]struct{}) {
-	if cfg == nil || len(added) == 0 || cfg.Providers.UI == nil {
-		return
-	}
-	for name := range added {
-		delete(cfg.Providers.UI, name)
-	}
 }
 
 func ownedUIEntryForPlugin(plugin *config.ProviderEntry, ownedUI *providermanifestv1.OwnedUI) (*config.UIEntry, error) {
@@ -2233,7 +2456,7 @@ func equivalentProviderManifestPath(current, expected string) bool {
 		currentManifest.Version == expectedManifest.Version
 }
 
-func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockEntry, provider *config.ProviderEntry, logicalName, subject, destDir string, locked bool) (string, error) {
+func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockEntry, provider *config.ProviderEntry, logicalName, subject, destDir string, mode artifactMode) (string, error) {
 	if provider == nil {
 		return "", nil
 	}
@@ -2247,11 +2470,25 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockEn
 			if provider.HasLocalSource() && pathWithinRoot(filepath.Join(paths.artifactsDir, ".gestaltd"), provider.SourcePath()) {
 				return bindPathBackedUIManifest(provider, configMap)
 			}
-			return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init %s`", subject, paths.configFlags)
+			return "", lockMetadataStaleError(paths, "lock entry for %s is missing or stale", subject)
+		}
+		if lockEntry.Source != providerSourceLockLocation(provider, paths.configDir) {
+			return "", lockMetadataStaleError(paths, "lock entry for %s is stale", subject)
 		}
 		fingerprint, err := NamedUIProviderFingerprint(logicalName, provider, paths.configDir)
-		if err != nil || lockEntry.Fingerprint != fingerprint {
-			return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init %s`", subject, paths.configFlags)
+		if err != nil {
+			return "", fmt.Errorf("fingerprinting %s: %w", subject, err)
+		}
+		var stagedInstall *preparedInstall
+		var cleanupStaged func() error
+		var commitStaged func() error
+		defer func() {
+			if cleanupStaged != nil {
+				_ = cleanupStaged()
+			}
+		}()
+		if lockEntry.Fingerprint != fingerprint {
+			return "", lockMetadataStaleError(paths, "lock entry for %s is stale", subject)
 		}
 		install, err := inspectPreparedInstall(destDir)
 		needMaterialize := err != nil || !preparedManifestMatchesLock(*lockEntry, install.manifest)
@@ -2264,11 +2501,36 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockEn
 			}
 		}
 		if needMaterialize {
-			if len(lockEntry.Archives) == 0 {
-				return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init %s`", subject, paths.configFlags)
+			if !mode.canMaterialize() {
+				return "", preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
 			}
-			if err := l.materializeLockedUIProvider(context.Background(), paths, provider, *lockEntry, destDir, locked); err != nil {
-				return "", err
+			if len(lockEntry.Archives) == 0 {
+				if !provider.HasLocalSource() {
+					return "", preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
+				}
+				if stagedInstall == nil {
+					stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindUI, logicalName, provider.SourcePath(), destDir)
+					if err != nil {
+						return "", err
+					}
+					fingerprint, err = NamedUIProviderFingerprint(logicalName, provider, paths.configDir)
+					if err != nil {
+						return "", fmt.Errorf("fingerprinting %s: %w", subject, err)
+					}
+					if lockEntry.Fingerprint != fingerprint {
+						return "", lockMetadataStaleError(paths, "lock entry for %s is stale", subject)
+					}
+				}
+				if !preparedManifestMatchesLock(*lockEntry, stagedInstall.manifest) {
+					return "", lockMetadataStaleError(paths, "lock entry for %s is stale", subject)
+				}
+				if err := commitStaged(); err != nil {
+					return "", err
+				}
+			} else {
+				if err := l.materializeLockedUIProvider(context.Background(), paths, provider, *lockEntry, destDir); err != nil {
+					return "", err
+				}
 			}
 			install, err = inspectPreparedInstall(destDir)
 			if err != nil {
@@ -2290,7 +2552,7 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockEn
 	}
 }
 
-func (l *Lifecycle) applyComponentProvider(paths initPaths, lockEntries map[string]LockEntry, kind, name string, provider *config.ProviderEntry, providerConfig yaml.Node, targetNode *yaml.Node, destDir string, locked bool) error {
+func (l *Lifecycle) applyComponentProvider(paths initPaths, lockEntries map[string]LockEntry, kind, name string, provider *config.ProviderEntry, providerConfig yaml.Node, targetNode *yaml.Node, destDir string, mode artifactMode) error {
 	if provider == nil {
 		return nil
 	}
@@ -2301,13 +2563,13 @@ func (l *Lifecycle) applyComponentProvider(paths initPaths, lockEntries map[stri
 	switch {
 	case sourceBacked(provider):
 		if lockEntries == nil {
-			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
+			return lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", kind, name)
 		}
 		lockEntry, ok := lockEntries[name]
 		if !ok {
-			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
+			return lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", kind, name)
 		}
-		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, provider, configMap, destDir, locked); err != nil {
+		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, provider, configMap, destDir, mode); err != nil {
 			return err
 		}
 	default:
@@ -2322,20 +2584,35 @@ func (l *Lifecycle) applyComponentProvider(paths initPaths, lockEntries map[stri
 	return nil
 }
 
-func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, name string, plugin *config.ProviderEntry, configMap map[string]any, locked bool) error {
+func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, name string, plugin *config.ProviderEntry, configMap map[string]any, mode artifactMode) error {
+	if lock == nil {
+		return lockMetadataStaleError(paths, "lock entry for provider %q is missing or stale", name)
+	}
 	entry, ok := lock.Providers[name]
 	if !ok {
-		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init %s`", name, paths.configFlags)
+		return lockMetadataStaleError(paths, "lock entry for provider %q is missing or stale", name)
+	}
+	if entry.Source != providerSourceLockLocation(plugin, paths.configDir) {
+		return lockMetadataStaleError(paths, "lock entry for provider %q is stale", name)
 	}
 	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return fmt.Errorf("fingerprinting provider %q: %w", name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != providerSourceLockLocation(plugin, paths.configDir) {
-		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init %s`", name, paths.configFlags)
-	}
 
 	destDir := providerDestDir(paths, name)
+	var stagedInstall *preparedInstall
+	var cleanupStaged func() error
+	var commitStaged func() error
+	defer func() {
+		if cleanupStaged != nil {
+			_ = cleanupStaged()
+		}
+	}()
+	if entry.Fingerprint != fingerprint {
+		return lockMetadataStaleError(paths, "lock entry for provider %q is stale", name)
+	}
+
 	install, err := inspectPreparedInstall(destDir)
 	needMaterialize := err != nil || !preparedManifestMatchesLock(entry, install.manifest)
 	if err == nil && !needMaterialize {
@@ -2352,11 +2629,36 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 		}
 	}
 	if needMaterialize {
-		if len(entry.Archives) == 0 {
-			return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init %s`", name, paths.configFlags)
+		if !mode.canMaterialize() {
+			return preparedArtifactStaleError(paths, "prepared artifact for provider %q is missing or stale", name)
 		}
-		if err := l.materializeLockedProvider(context.Background(), paths, name, plugin, entry, locked); err != nil {
-			return err
+		if len(entry.Archives) == 0 {
+			if !plugin.HasLocalSource() {
+				return preparedArtifactStaleError(paths, "prepared artifact for provider %q is missing or stale", name)
+			}
+			if stagedInstall == nil {
+				stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindPlugin, name, plugin.SourcePath(), destDir)
+				if err != nil {
+					return err
+				}
+				fingerprint, err = ProviderFingerprint(name, plugin, paths.configDir)
+				if err != nil {
+					return fmt.Errorf("fingerprinting provider %q: %w", name, err)
+				}
+				if entry.Fingerprint != fingerprint {
+					return lockMetadataStaleError(paths, "lock entry for provider %q is stale", name)
+				}
+			}
+			if !preparedManifestMatchesLock(entry, stagedInstall.manifest) {
+				return lockMetadataStaleError(paths, "lock entry for provider %q is stale", name)
+			}
+			if err := commitStaged(); err != nil {
+				return err
+			}
+		} else {
+			if err := l.materializeLockedProvider(context.Background(), paths, name, plugin, entry); err != nil {
+				return err
+			}
 		}
 		install, err = inspectPreparedInstall(destDir)
 		if err != nil {
@@ -2368,7 +2670,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	}
 	if install.executablePath != "" {
 		if _, err := os.Stat(install.executablePath); err != nil {
-			return fmt.Errorf("prepared executable for provider %q not found at %s; run `gestaltd init %s`", name, install.executablePath, paths.configFlags)
+			return preparedArtifactStaleError(paths, "prepared executable for provider %q not found at %s", name, install.executablePath)
 		}
 		args, err := providerEntrypointArgs(install.manifest)
 		if err != nil {
@@ -2380,16 +2682,28 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	return nil
 }
 
-func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry, kind, name string, plugin *config.ProviderEntry, configMap map[string]any, destDir string, locked bool) error {
+func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry, kind, name string, plugin *config.ProviderEntry, configMap map[string]any, destDir string, mode artifactMode) error {
 	if entry == nil {
-		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
+		return lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", kind, name)
+	}
+	if entry.Source != providerSourceLockLocation(plugin, paths.configDir) {
+		return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
 	}
 	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != providerSourceLockLocation(plugin, paths.configDir) {
-		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
+
+	var stagedInstall *preparedInstall
+	var cleanupStaged func() error
+	var commitStaged func() error
+	defer func() {
+		if cleanupStaged != nil {
+			_ = cleanupStaged()
+		}
+	}()
+	if entry.Fingerprint != fingerprint {
+		return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
 	}
 
 	install, err := inspectPreparedInstall(destDir)
@@ -2411,11 +2725,36 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 		}
 	}
 	if needMaterialize {
-		if len(entry.Archives) == 0 {
-			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
+		if !mode.canMaterialize() {
+			return preparedArtifactStaleError(paths, "prepared artifact for %s %q is missing or stale", kind, name)
 		}
-		if err := l.materializeLockedComponent(context.Background(), paths, kind, name, plugin, *entry, destDir, locked); err != nil {
-			return err
+		if len(entry.Archives) == 0 {
+			if !plugin.HasLocalSource() {
+				return preparedArtifactStaleError(paths, "prepared artifact for %s %q is missing or stale", kind, name)
+			}
+			if stagedInstall == nil {
+				stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(kind, name, plugin.SourcePath(), destDir)
+				if err != nil {
+					return err
+				}
+				fingerprint, err = ProviderFingerprint(name, plugin, paths.configDir)
+				if err != nil {
+					return fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
+				}
+				if entry.Fingerprint != fingerprint {
+					return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
+				}
+			}
+			if !preparedManifestMatchesLock(*entry, stagedInstall.manifest) {
+				return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
+			}
+			if err := commitStaged(); err != nil {
+				return err
+			}
+		} else {
+			if err := l.materializeLockedComponent(context.Background(), paths, kind, name, plugin, *entry, destDir); err != nil {
+				return err
+			}
 		}
 		install, err = inspectPreparedInstall(destDir)
 		if err != nil {
@@ -2423,13 +2762,13 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 		}
 	}
 	if install.executablePath == "" {
-		return fmt.Errorf("prepared executable for %s %q not found in %s; run `gestaltd init %s`", kind, name, destDir, paths.configFlags)
+		return preparedArtifactStaleError(paths, "prepared executable for %s %q not found in %s", kind, name, destDir)
 	}
 	if err := bindResolvedComponentManifest(kind, name, plugin, install.manifestPath, install.manifest, configMap); err != nil {
 		return err
 	}
 	if _, err := os.Stat(install.executablePath); err != nil {
-		return fmt.Errorf("prepared executable for %s %q not found at %s; run `gestaltd init %s`", kind, name, install.executablePath, paths.configFlags)
+		return preparedArtifactStaleError(paths, "prepared executable for %s %q not found at %s", kind, name, install.executablePath)
 	}
 	args, err := componentEntrypointArgs(install.manifest, kind)
 	if err != nil {
@@ -2504,18 +2843,18 @@ func bindPathBackedUIManifest(plugin *config.ProviderEntry, configMap map[string
 	return assetRoot, nil
 }
 
-func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, entry LockEntry, locked bool) error {
+func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, entry LockEntry) error {
 	platform := providerpkg.CurrentPlatformString()
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
-		return fmt.Errorf("no archive for platform %s for provider %q; run `gestaltd init %s`", platform, name, paths.configFlags)
+		return fmt.Errorf("no archive for platform %s for provider %q; run `%s --platform %s`", platform, name, formatLockCommand(paths), platform)
 	}
 	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
 	if err != nil {
 		return fmt.Errorf("resolve locked source provider for provider %q: %w", name, err)
 	}
-	if locked && archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
-		return fmt.Errorf("no verified hash for platform %s for provider %q; run `gestaltd init %s`", platform, name, formatPlatformInitFlags(paths, platform))
+	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
+		return fmt.Errorf("no verified hash for platform %s for provider %q; run `%s --platform %s`", platform, name, formatLockCommand(paths), platform)
 	}
 	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archiveLocation)
 	if err != nil {
@@ -2560,18 +2899,18 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 	return nil
 }
 
-func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPaths, kind, name string, plugin *config.ProviderEntry, entry LockEntry, destDir string, locked bool) error {
+func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPaths, kind, name string, plugin *config.ProviderEntry, entry LockEntry, destDir string) error {
 	platform := providerpkg.CurrentPlatformString()
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
-		return fmt.Errorf("no archive for platform %s for %s %q; run `gestaltd init %s`", platform, kind, name, paths.configFlags)
+		return fmt.Errorf("no archive for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
 	}
 	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
 	if err != nil {
 		return fmt.Errorf("resolve locked source provider for %s %q: %w", kind, name, err)
 	}
-	if locked && archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
-		return fmt.Errorf("no verified hash for platform %s for %s %q; run `gestaltd init %s`", platform, kind, name, formatPlatformInitFlags(paths, platform))
+	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
+		return fmt.Errorf("no verified hash for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
 	}
 	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archiveLocation)
 	if err != nil {
@@ -2621,18 +2960,18 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 	return nil
 }
 
-func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initPaths, plugin *config.ProviderEntry, entry LockEntry, destDir string, locked bool) error {
+func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initPaths, plugin *config.ProviderEntry, entry LockEntry, destDir string) error {
 	platform := providerpkg.CurrentPlatformString()
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
-		return fmt.Errorf("no archive for platform %s for ui provider; run `gestaltd init %s`", platform, paths.configFlags)
+		return fmt.Errorf("no archive for platform %s for ui provider; run `%s --platform %s`", platform, formatLockCommand(paths), platform)
 	}
 	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
 	if err != nil {
 		return fmt.Errorf("resolve locked source for ui provider: %w", err)
 	}
-	if locked && archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
-		return fmt.Errorf("no verified hash for platform %s for ui provider; run `gestaltd init %s`", platform, formatPlatformInitFlags(paths, platform))
+	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
+		return fmt.Errorf("no verified hash for platform %s for ui provider; run `%s --platform %s`", platform, formatLockCommand(paths), platform)
 	}
 	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archiveLocation)
 	if err != nil {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -705,13 +705,13 @@ func TestSourcePluginMetadataURLInitAndLockedLoad(t *testing.T) {
 
 			metadataBefore := metadataCount.Load()
 			currentBefore := currentArchiveCount.Load()
-			cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+			err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
 			if tc.tamperLocalArchive {
 				if handlerErr := nextHandlerErr(); handlerErr != nil {
 					t.Fatal(handlerErr)
 				}
 				if err == nil || !strings.Contains(err.Error(), "digest mismatch") {
-					t.Fatalf("LoadForExecutionAtPath(locked=true) error = %v, want digest mismatch", err)
+					t.Fatalf("SyncAtPathsWithStatePaths error = %v, want digest mismatch", err)
 				}
 				return
 			}
@@ -719,21 +719,25 @@ func TestSourcePluginMetadataURLInitAndLockedLoad(t *testing.T) {
 				if handlerErr := nextHandlerErr(); handlerErr != nil {
 					t.Fatal(handlerErr)
 				}
-				t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+				t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 			}
 			if handlerErr := nextHandlerErr(); handlerErr != nil {
 				t.Fatal(handlerErr)
 			}
 			if !tc.localSource || tc.remoteArchives {
 				if got := metadataCount.Load(); got != metadataBefore {
-					t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+					t.Fatalf("metadata request count during sync = %d, want %d", got, metadataBefore)
 				}
 				if got := currentArchiveCount.Load() - currentBefore; got != 1 {
-					t.Fatalf("current archive request count during locked load = %d, want 1", got)
+					t.Fatalf("current archive request count during sync = %d, want 1", got)
 				}
 				if got := extraArchiveCount.Load(); got != 0 {
-					t.Fatalf("extra archive request count after locked load = %d, want 0", got)
+					t.Fatalf("extra archive request count after sync = %d, want 0", got)
 				}
+			}
+			cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+			if err != nil {
+				t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 			}
 			if cfg.Plugins["alpha"] == nil {
 				t.Fatal(`cfg.Plugins["alpha"] = nil`)
@@ -891,23 +895,22 @@ func TestSourceWorkflowMetadataURLInitAndLockedLoad(t *testing.T) {
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
-	if err == nil {
-		if handlerErr := nextHandlerErr(); handlerErr != nil {
-			t.Fatal(handlerErr)
-		}
-	}
+	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
 	if err != nil {
-		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
 	}
 	if got := metadataCount.Load(); got != metadataBefore {
-		t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+		t.Fatalf("metadata request count during sync = %d, want %d", got, metadataBefore)
 	}
 	if got := archiveCount.Load() - archiveBefore; got != 1 {
-		t.Fatalf("archive request count during locked load = %d, want 1", got)
+		t.Fatalf("archive request count during sync = %d, want 1", got)
+	}
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
 	workflow := cfg.Providers.Workflow["runner"]
 	if workflow == nil || workflow.ResolvedManifest == nil {
@@ -1060,23 +1063,22 @@ func TestSourceExternalCredentialsMetadataURLInitAndLockedLoad(t *testing.T) {
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
-	if err == nil {
-		if handlerErr := nextHandlerErr(); handlerErr != nil {
-			t.Fatal(handlerErr)
-		}
-	}
+	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
 	if err != nil {
-		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
 	}
 	if got := metadataCount.Load(); got != metadataBefore {
-		t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+		t.Fatalf("metadata request count during sync = %d, want %d", got, metadataBefore)
 	}
 	if got := archiveCount.Load() - archiveBefore; got != 1 {
-		t.Fatalf("archive request count during locked load = %d, want 1", got)
+		t.Fatalf("archive request count during sync = %d, want 1", got)
+	}
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
 	externalCredentials := cfg.Providers.ExternalCredentials["runner"]
 	if externalCredentials == nil || externalCredentials.ResolvedManifest == nil {
@@ -1242,23 +1244,22 @@ func TestSourceUIMetadataURLInitAndLockedLoad(t *testing.T) {
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
-	if err == nil {
-		if handlerErr := nextHandlerErr(); handlerErr != nil {
-			t.Fatal(handlerErr)
-		}
-	}
+	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
 	if err != nil {
-		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
 	}
 	if got := metadataCount.Load(); got != metadataBefore {
-		t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+		t.Fatalf("metadata request count during sync = %d, want %d", got, metadataBefore)
 	}
 	if got := archiveCount.Load() - archiveBefore; got != 1 {
-		t.Fatalf("archive request count during locked load = %d, want 1", got)
+		t.Fatalf("archive request count during sync = %d, want 1", got)
+	}
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
 	ui := cfg.Providers.UI["roadmap"]
 	if ui == nil || ui.ResolvedManifest == nil {
@@ -1505,23 +1506,22 @@ func TestSourcePluginMetadataURLUsesGenericAuthenticatedFetch(t *testing.T) {
 
 	metadataBefore := metadataCount.Load()
 	archiveBefore := archiveCount.Load()
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
-	if err == nil {
-		if handlerErr := nextHandlerErr(); handlerErr != nil {
-			t.Fatal(handlerErr)
-		}
-	}
+	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
 	if err != nil {
-		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
 	}
 	if handlerErr := nextHandlerErr(); handlerErr != nil {
 		t.Fatal(handlerErr)
 	}
 	if got := metadataCount.Load(); got != metadataBefore {
-		t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+		t.Fatalf("metadata request count during sync = %d, want %d", got, metadataBefore)
 	}
 	if got := archiveCount.Load() - archiveBefore; got != 1 {
-		t.Fatalf("archive request count during locked load = %d, want 1", got)
+		t.Fatalf("archive request count during sync = %d, want 1", got)
+	}
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
 	if cfg.Plugins["alpha"] == nil || cfg.Plugins["alpha"].ResolvedManifest == nil {
 		t.Fatal("resolved metadata plugin manifest missing after locked load")
@@ -2121,7 +2121,7 @@ func TestMaterializeLockedComponent_AllowsGenericDeclarativeTelemetryAndAuditPac
 				Source: config.NewMetadataSource("https://example.invalid/github-com-acme-providers-declarative/v1.0.0/provider-release.yaml"),
 			}
 			destDir := filepath.Join(dir, kind)
-			if err := lc.materializeLockedComponent(context.Background(), initPaths{}, kind, "default", providerEntry, entry, destDir, true); err != nil {
+			if err := lc.materializeLockedComponent(context.Background(), initPaths{}, kind, "default", providerEntry, entry, destDir); err != nil {
 				t.Fatalf("materializeLockedComponent: %v", err)
 			}
 			install, err := inspectPreparedInstall(destDir)
@@ -2237,12 +2237,15 @@ func TestSourcePluginLoadForExecution_RehydratesWhenCachedManifestVersionMismatc
 	}
 
 	downloadsBefore := downloadCount.Load()
+	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+	}
 	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
 	if got := downloadCount.Load() - downloadsBefore; got != 1 {
-		t.Fatalf("download count during locked rehydration = %d, want 1", got)
+		t.Fatalf("download count during sync = %d, want 1", got)
 	}
 
 	gotManifest := cfg.Plugins["gadget"].ResolvedManifest
@@ -2396,15 +2399,19 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 	}
 
 	downloadsBefore := downloadCount.Load()
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
 	if err != nil {
-		t.Fatalf("LoadForExecutionAtPath after cache removal: %v", err)
+		t.Fatalf("SyncAtPathsWithStatePaths after cache removal: %v", err)
 	}
 	if got := metadataCount.Load(); got != metadataBefore {
-		t.Fatalf("metadata request count during locked rehydration = %d, want %d", got, metadataBefore)
+		t.Fatalf("metadata request count during sync = %d, want %d", got, metadataBefore)
 	}
 	if got := downloadCount.Load() - downloadsBefore; got != 1 {
-		t.Fatalf("download count during locked rehydration = %d, want 1", got)
+		t.Fatalf("download count during sync = %d, want 1", got)
+	}
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath after sync: %v", err)
 	}
 
 	authProvider := mustSelectedHostProviderEntry(t, cfg, config.HostProviderKindAuthentication)
@@ -3196,21 +3203,25 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 	authMetadataBefore := authMetadataCount.Load()
 	secretsDownloadsBefore := secretsDownloads.Load()
 	authDownloadsBefore := authDownloads.Load()
+	err = lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	if err != nil {
+		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+	}
+	if got := secretsMetadataCount.Load(); got != secretsMetadataBefore {
+		t.Fatalf("secrets metadata requests during sync = %d, want %d", got, secretsMetadataBefore)
+	}
+	if got := authMetadataCount.Load(); got != authMetadataBefore {
+		t.Fatalf("auth metadata requests during sync = %d, want %d", got, authMetadataBefore)
+	}
+	if got := secretsDownloads.Load() - secretsDownloadsBefore; got != 1 {
+		t.Fatalf("secrets download count during sync = %d, want 1", got)
+	}
+	if got := authDownloads.Load() - authDownloadsBefore; got != 1 {
+		t.Fatalf("auth download count during sync = %d, want 1", got)
+	}
 	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
-	}
-	if got := secretsMetadataCount.Load(); got != secretsMetadataBefore {
-		t.Fatalf("secrets metadata requests during locked load = %d, want %d", got, secretsMetadataBefore)
-	}
-	if got := authMetadataCount.Load(); got != authMetadataBefore {
-		t.Fatalf("auth metadata requests during locked load = %d, want %d", got, authMetadataBefore)
-	}
-	if got := secretsDownloads.Load() - secretsDownloadsBefore; got != 1 {
-		t.Fatalf("secrets download count during locked load = %d, want 1", got)
-	}
-	if got := authDownloads.Load() - authDownloadsBefore; got != 1 {
-		t.Fatalf("auth download count during locked load = %d, want 1", got)
 	}
 	authProvider := mustSelectedHostProviderEntry(t, cfg, config.HostProviderKindAuthentication)
 	if authProvider == nil || authProvider.Source.Auth == nil {

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1502,8 +1502,8 @@ server:
 		t.Fatalf("WriteLockfile: %v", err)
 	}
 
-	if _, _, err := lc.LoadForExecutionAtPath(cfgPath, true); err == nil || !strings.Contains(err.Error(), `prepared artifact for ui "roadmap" is missing or stale`) {
-		t.Fatalf("LoadForExecutionAtPath locked error = %v, want missing prepared artifact", err)
+	if _, _, err := lc.LoadForExecutionAtPath(cfgPath, true); err == nil || !strings.Contains(err.Error(), `lock entry for ui "roadmap" is missing or stale`) {
+		t.Fatalf("LoadForExecutionAtPath locked error = %v, want missing lock entry", err)
 	}
 }
 
@@ -1893,6 +1893,9 @@ server:
 		t.Fatalf("WriteLockfile: %v", err)
 	}
 
+	if err := lc.SyncAtPathsWithStatePaths([]string{cfgPath}, StatePaths{}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+	}
 	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, true)
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
@@ -3052,7 +3055,7 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 	loaded.Plugins["missing"] = &config.ProviderEntry{}
 
 	lc := NewLifecycle()
-	if _, err := lc.applyLockedProviders([]string{cfgPath}, StatePaths{}, loaded, false, nil); err != nil {
+	if _, err := lc.applyLockedProviders([]string{cfgPath}, StatePaths{}, loaded, false, nil, artifactModeMaterialize); err != nil {
 		t.Fatalf("applyLockedProviders: %v", err)
 	}
 	if loaded.Plugins["example"] == nil || loaded.Plugins["example"].ResolvedManifest == nil {

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -229,13 +229,13 @@ func (lock *providerLockfile) toLockfile() *Lockfile {
 
 func validateProviderLockfile(lock *providerLockfile) error {
 	if lock == nil {
-		return fmt.Errorf("unsupported lockfile schema; run `gestaltd init` to upgrade")
+		return fmt.Errorf("unsupported lockfile schema; run `gestaltd lock` to upgrade")
 	}
 	if lock.Schema != providerLockSchemaName {
-		return fmt.Errorf("unsupported lockfile schema %q; run `gestaltd init` to upgrade", lock.Schema)
+		return fmt.Errorf("unsupported lockfile schema %q; run `gestaltd lock` to upgrade", lock.Schema)
 	}
 	if lock.SchemaVersion != providerLockSchemaVersion {
-		return fmt.Errorf("unsupported lockfile schema version %d; run `gestaltd init` to upgrade", lock.SchemaVersion)
+		return fmt.Errorf("unsupported lockfile schema version %d; run `gestaltd lock` to upgrade", lock.SchemaVersion)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Splits the overloaded `gestaltd init` lifecycle into explicit lock/sync phases:

- `gestaltd lock` writes canonical portable lock metadata using scratch-staged artifacts for validation.
- `gestaltd sync --locked` materializes or checks prepared artifacts from an existing lock without rewriting it.
- `gestaltd serve --locked` is read-only for lock/artifact state and points missing artifacts at `sync`.
- `gestaltd init` remains only as a deprecated lock-only alias.

## Interface Diff

```diff
- gestaltd init [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--platform PLATFORMS]
- gestaltd serve --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]
- # locked serve could materialize missing artifacts from the lockfile
+ gestaltd lock [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]
+ gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--check]
+ gestaltd serve --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]
+ # locked serve only reads already-prepared artifacts
+ gestaltd init [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]
+ # legacy alias for gestaltd lock; no final artifact materialization
```

Old deployment shape:

```sh
gestaltd init \
  --config deploy/config.yaml \
  --config deploy/prod/config.yaml \
  --artifacts-dir /data

gestaltd serve --locked \
  --config deploy/config.yaml \
  --config deploy/prod/config.yaml \
  --artifacts-dir /data
```

New deployment shape:

```sh
gestaltd lock \
  --config deploy/config.yaml \
  --config deploy/prod/config.yaml \
  --platform all

gestaltd sync --locked \
  --config deploy/config.yaml \
  --config deploy/prod/config.yaml \
  --artifacts-dir /data

gestaltd serve --locked \
  --config deploy/config.yaml \
  --config deploy/prod/config.yaml \
  --artifacts-dir /data
```

CI/check examples:

```sh
gestaltd lock --check \
  --config deploy/config.yaml \
  --config deploy/prod/config.yaml \
  --platform all

gestaltd sync --locked --check \
  --config deploy/config.yaml \
  --config deploy/prod/config.yaml \
  --artifacts-dir /data
```

## Contract Notes

- `lock` stages into a temporary artifact root so manifest/config/catalog validation still runs, but final `--artifacts-dir` remains untouched.
- `sync --locked` verifies lock fingerprint/source agreement before materializing artifacts.
- Local `source.path` providers are re-staged from config during sync after lock verification.
- Plugin-owned UI is covered by the owning plugin lock; sync/serve synthesize it after the plugin has been materialized/read, so scratch paths do not enter the portable lock.
- Unlocked `serve` and bare `gestaltd` preserve local-dev auto-prepare behavior.
- Helm defaults to unlocked serve for local usability; set `pluginInit.enabled: true` to run chart-managed `lock`/`sync`, or set `lockedServe.enabled: true` when lock state and prepared artifacts are supplied by a baked image or external init flow.

## Tests

```sh
cd gestaltd && go test ./internal/operator
cd gestaltd && go test ./cmd/gestaltd -run 'TestE2ECLIHelp|TestE2ELockSyncLocalProviders|TestE2ELockSyncPluginOwnedUI|TestE2EInitAndServeLayeredConfigs|TestE2EServeUsesOverrideLockfile'
cd gestaltd && go test ./cmd/gestaltd -run TestE2EProviderDevAutoMountsSiblingUIForPlugin -count=1
helm lint gestaltd/deploy/helm/gestalt
helm template gestalt gestaltd/deploy/helm/gestalt --set lockedServe.enabled=true
npm --prefix docs run build
```