### PR TITLE
cli: keep agent TUI selectable in normal buffer

### DIFF
--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::crossterm::terminal;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, TextArea};
@@ -58,7 +59,7 @@ pub(super) fn run_shell(
         app.enqueue_or_start(initial_messages);
     }
 
-    let result = app.run(terminal.inner_mut());
+    let result = app.run(&mut terminal);
     terminal.restore()?;
     result
 }
@@ -66,14 +67,17 @@ pub(super) fn run_shell(
 struct TerminalGuard {
     terminal: ratatui::DefaultTerminal,
     restored: bool,
+    viewport_height: u16,
 }
 
 impl TerminalGuard {
     fn start() -> Result<Self> {
-        let terminal = ratatui::try_init().context("failed to initialize terminal UI")?;
+        let viewport_height = current_terminal_height()?;
+        let terminal = inline_terminal(viewport_height)?;
         Ok(Self {
             terminal,
             restored: false,
+            viewport_height,
         })
     }
 
@@ -89,6 +93,22 @@ impl TerminalGuard {
         }
         Ok(())
     }
+
+    fn resize_inline_viewport(&mut self, height: u16) -> Result<()> {
+        let height = height.max(1);
+        if height != self.viewport_height {
+            let backend = ratatui::backend::CrosstermBackend::new(io::stdout());
+            self.terminal = ratatui::Terminal::with_options(
+                backend,
+                ratatui::TerminalOptions {
+                    viewport: ratatui::Viewport::Inline(height),
+                },
+            )
+            .context("failed to resize terminal UI")?;
+            self.viewport_height = height;
+        }
+        Ok(())
+    }
 }
 
 impl Drop for TerminalGuard {
@@ -98,6 +118,19 @@ impl Drop for TerminalGuard {
             self.restored = true;
         }
     }
+}
+
+fn current_terminal_height() -> Result<u16> {
+    terminal::size()
+        .map(|(_, height)| height.max(1))
+        .context("failed to detect terminal size")
+}
+
+fn inline_terminal(viewport_height: u16) -> Result<ratatui::DefaultTerminal> {
+    ratatui::try_init_with_options(ratatui::TerminalOptions {
+        viewport: ratatui::Viewport::Inline(viewport_height),
+    })
+    .context("failed to initialize terminal UI")
 }
 
 struct TuiApp {
@@ -146,12 +179,12 @@ impl TuiApp {
         }
     }
 
-    fn run(&mut self, terminal: &mut ratatui::DefaultTerminal) -> Result<()> {
+    fn run(&mut self, terminal: &mut TerminalGuard) -> Result<()> {
         loop {
             self.drain_worker_events();
             self.start_next_queued_turn();
             self.tick = self.tick.wrapping_add(1);
-            terminal.draw(|frame| self.draw(frame))?;
+            terminal.inner_mut().draw(|frame| self.draw(frame))?;
 
             if self.should_quit {
                 return Ok(());
@@ -160,7 +193,7 @@ impl TuiApp {
             if event::poll(TICK_RATE).context("failed to poll terminal events")? {
                 match event::read().context("failed to read terminal event")? {
                     Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_key(key),
-                    Event::Resize(_, _) => {}
+                    Event::Resize(_, height) => terminal.resize_inline_viewport(height)?,
                     _ => {}
                 }
             }

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -757,7 +757,7 @@ fn test_cli_runs_interactive_agent_session_with_display_events() {
 
 #[cfg(unix)]
 #[test]
-fn test_cli_runs_tty_agent_session_with_full_screen_ui() {
+fn test_cli_runs_tty_agent_session_with_selectable_inline_ui() {
     let server = ScriptedServer::spawn(vec![
         ExpectedRequest::json(
             Method::POST,
@@ -818,7 +818,6 @@ fn test_cli_runs_tty_agent_session_with_full_screen_ui() {
         &["agent", "--provider", "managed", "--model", "gpt-5.4"],
     );
     let mut output = String::new();
-    session.wait_for(&mut output, "\x1b[?1049h");
     session.wait_for(&mut output, "Session");
     session.wait_for(&mut output, "managed/gpt-5.4");
     session.wait_for(&mut output, "footer-branch");
@@ -832,6 +831,10 @@ fn test_cli_runs_tty_agent_session_with_full_screen_ui() {
     assert!(
         output.contains("› hello tui") && output.contains("●"),
         "TTY transcript did not render highlighted user input and assistant bullet:\n{output}"
+    );
+    assert!(
+        !output.contains("\x1b[?1049h"),
+        "TTY entered the alternate screen, which prevents normal terminal scrollback selection:\n{output}"
     );
     assert!(
         !output.contains("**hello**"),
@@ -1396,6 +1399,46 @@ fn test_cli_tty_scrolls_multiline_help_rows() {
     session.write("\x03");
     session.wait_for_exit();
 
+    server.assert_finished();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_tty_resize_expands_selectable_inline_viewport() {
+    let server = ScriptedServer::spawn(vec![ExpectedRequest::json(
+        Method::POST,
+        "/api/v1/agent/sessions",
+        r#"{"provider":"managed","model":"gpt-5.4"}"#,
+        StatusCode::CREATED,
+        http::APPLICATION_JSON,
+        SESSION_JSON,
+    )]);
+
+    let home = tempfile::tempdir().unwrap();
+    let mut session = spawn_tty_cli_with_size(
+        home.path(),
+        server.url(),
+        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        8,
+        100,
+    );
+    let mut output = String::new();
+    session.wait_for(&mut output, "Session");
+
+    session.resize(24, 100);
+    let mut resized_output = String::new();
+    session.wait_for(&mut resized_output, "session session-1");
+
+    let mut help_output = String::new();
+    session.write("/help\r");
+    session.wait_for(&mut help_output, "Ctrl-C cancels, clears input, or exits.");
+    assert!(
+        !help_output.contains("\x1b[?1049h"),
+        "TTY entered the alternate screen after resize:\n{help_output}"
+    );
+
+    session.write("\x03");
+    session.wait_for_exit();
     server.assert_finished();
 }
 
@@ -2586,10 +2629,14 @@ struct ScriptedHttpRequest {
 
 #[cfg(unix)]
 struct TtyCliSession {
+    master: Box<dyn portable_pty::MasterPty + Send>,
     writer: Box<dyn Write + Send>,
     reader: Option<std::thread::JoinHandle<()>>,
     rx: mpsc::Receiver<String>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
+    rows: u16,
+    cols: u16,
+    cursor_query_buffer: Vec<u8>,
 }
 
 #[cfg(unix)]
@@ -2611,7 +2658,10 @@ impl TtyCliSession {
                 .saturating_duration_since(now)
                 .min(Duration::from_millis(100));
             match self.rx.recv_timeout(timeout) {
-                Ok(chunk) => output.push_str(&chunk),
+                Ok(chunk) => {
+                    self.respond_to_cursor_position_requests(&chunk);
+                    output.push_str(&chunk);
+                }
                 Err(mpsc::RecvTimeoutError::Timeout) => {}
                 Err(mpsc::RecvTimeoutError::Disconnected) => {
                     panic!("PTY reader closed before seeing {needle:?}; output was:\n{output}")
@@ -2637,6 +2687,44 @@ impl TtyCliSession {
             std::thread::sleep(Duration::from_millis(50));
         }
     }
+
+    fn resize(&mut self, rows: u16, cols: u16) {
+        self.rows = rows.max(1);
+        self.cols = cols.max(1);
+        self.master
+            .resize(portable_pty::PtySize {
+                rows: self.rows,
+                cols: self.cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .unwrap();
+    }
+
+    fn respond_to_cursor_position_requests(&mut self, chunk: &str) {
+        self.cursor_query_buffer.extend_from_slice(chunk.as_bytes());
+        let query = b"\x1b[6n";
+        while let Some(position) = find_subslice(&self.cursor_query_buffer, query) {
+            let row = self.rows.max(1);
+            let col = self.cols.max(1);
+            self.write(&format!("\x1b[{row};{col}R"));
+            self.cursor_query_buffer
+                .drain(..position.saturating_add(query.len()));
+        }
+
+        let retained = query.len().saturating_sub(1);
+        if self.cursor_query_buffer.len() > retained {
+            let dropped = self.cursor_query_buffer.len() - retained;
+            self.cursor_query_buffer.drain(..dropped);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
 }
 
 #[cfg(unix)]
@@ -2696,10 +2784,14 @@ fn spawn_tty_cli_with_size(
     });
 
     TtyCliSession {
+        master: pair.master,
         writer,
         reader: Some(reader),
         rx,
         child,
+        rows,
+        cols,
+        cursor_query_buffer: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary
- Initialize the agent TUI with a ratatui inline viewport instead of the alternate screen.
- Preserve the existing prompt, slash-command, scroll, resize, and resume behavior while keeping visible transcript text in the normal terminal buffer for selection/copy.
- Rebuild the inline viewport when terminal height changes so newly available rows are used after resize.
- Extend the PTY integration harness to answer standard cursor-position requests, including split escape-sequence reads, so the inline viewport startup and resize paths are tested end to end.

## New interfaces

### Rust
```rust
let viewport_height = terminal::size()?.1.max(1);
let terminal = ratatui::try_init_with_options(ratatui::TerminalOptions {
    viewport: ratatui::Viewport::Inline(viewport_height),
})?;

// On terminal height changes, the TUI rebuilds the inline viewport with
// the new height while preserving the same TUI state.
terminal_guard.resize_inline_viewport(new_height)?;
```

### stdin/stdout
No command syntax changes. The existing interactive interface remains:
```bash
GESTALT_URL=https://valon.tools gestalt agent --provider simple --model gpt-5.5
```

The TUI no longer emits the alternate-screen enter sequence (`ESC[?1049h`), so visible transcript text stays in the normal terminal buffer and can be selected/copied with the terminal mouse. Offscreen transcript is still navigated inside the TUI with PgUp/PgDn. On exit, stdout still prints:
```text
Resume with: gestalt agent resume <session-id>
```

## Verification
```bash
cargo test --manifest-path gestalt/Cargo.toml -p gestalt --test agents_cli
```

33 tests passed.