### PR TITLE
Simplify provider-dev UI attach flag

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -112,7 +112,10 @@ remote instance.
 After browser approval or attach-token authentication, the remote creates an
 attachment and the CLI uses the returned `attachId` plus a one-time dispatcher
 secret for poll/complete traffic. The dispatcher secret is not shown by list/get
-diagnostics and is not needed for owner cleanup detach. Use
+diagnostics and is not needed for owner cleanup detach. Remote attach requests
+mark an attached provider with `ui: true` when the local dispatcher will serve
+that provider's mounted UI assets; diagnostic responses report the mounted
+`uiPath` but never return local UI contents. Use
 `gestaltd provider attach list --remote URL`,
 `gestaltd provider attach show --remote URL ATTACH_ID`, and
 `gestaltd provider attach detach --remote URL ATTACH_ID` to inspect or clean up

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -239,7 +239,7 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 			return fmt.Errorf("prepare provider dev remote ui for plugins.%s: %w", target.Name, err)
 		}
 		if hasUI {
-			requested.UI = &providerdev.AttachUI{}
+			requested.UI = true
 			localUIHandlersByTarget[i] = uiHandler
 		}
 		requestedProviders = append(requestedProviders, requested)

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -58,7 +58,7 @@ type Target struct {
 	Source     string
 	Spec       providerhost.StaticProviderSpec
 	Config     map[string]any
-	UI         *AttachUI
+	UI         bool
 	UIPath     string
 	RuntimeEnv RuntimeEnvBuilder
 }
@@ -79,7 +79,7 @@ type AttachProvider struct {
 	Source string                          `json:"source,omitempty"`
 	Spec   providerhost.StaticProviderSpec `json:"spec"`
 	Config *map[string]any                 `json:"config,omitempty"`
-	UI     *AttachUI                       `json:"ui,omitempty"`
+	UI     bool                            `json:"ui,omitempty"`
 }
 
 type CreateSessionResponse struct {
@@ -134,8 +134,6 @@ type AttachmentProviderInfo struct {
 	UI     bool   `json:"ui,omitempty"`
 	UIPath string `json:"uiPath,omitempty"`
 }
-
-type AttachUI struct{}
 
 type AttachAuthorization struct {
 	id               string
@@ -317,7 +315,7 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 			Name:   target.Name,
 			Env:    cloneStringMap(runtimeEnv.Env),
 			Source: target.Source,
-			UI:     target.UI != nil,
+			UI:     target.UI,
 			UIPath: target.UIPath,
 		})
 	}
@@ -542,7 +540,7 @@ func (m *Manager) resolveAttachTargets(requestedProviders []AttachProvider) ([]T
 		if requested.Config != nil {
 			target.Config = cloneAnyMap(*requested.Config)
 		}
-		target.UI = cloneAttachUI(requested.UI)
+		target.UI = requested.UI
 		targets = append(targets, target)
 	}
 	return targets, nil
@@ -749,7 +747,7 @@ func (m *Manager) ServeUIAsset(ctx context.Context, p *principal.Principal, prov
 			continue
 		}
 		target := session.targets[providerName]
-		if target == nil || target.target.UI == nil {
+		if target == nil || !target.target.UI {
 			continue
 		}
 		resp, err := session.serveUIAsset(ctx, providerName, req)
@@ -1024,7 +1022,7 @@ func (s *Session) attachmentInfo() AttachmentInfo {
 		providers = append(providers, AttachmentProviderInfo{
 			Name:   name,
 			Source: target.target.Source,
-			UI:     target.target.UI != nil,
+			UI:     target.target.UI,
 			UIPath: target.target.UIPath,
 		})
 	}
@@ -1811,14 +1809,6 @@ func cloneStaticProviderSpec(spec providerhost.StaticProviderSpec) providerhost.
 		out.DiscoveryConfig = &discovery
 	}
 	return out
-}
-
-func cloneAttachUI(ui *AttachUI) *AttachUI {
-	if ui == nil {
-		return nil
-	}
-	out := *ui
-	return &out
 }
 
 func cloneHTTPHeader(header http.Header) http.Header {

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -98,7 +98,7 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	session, err := client.CreateSession(context.Background(), CreateSessionRequest{Providers: []AttachProvider{{
 		Name: "roadmap",
 		Spec: spec,
-		UI:   &AttachUI{},
+		UI:   true,
 	}}})
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
@@ -474,7 +474,7 @@ func TestHTTPTransportListsRedactedAttachmentMetadata(t *testing.T) {
 	client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
 	session, err := client.CreateSession(context.Background(), CreateSessionRequest{Providers: []AttachProvider{{
 		Name: "roadmap",
-		UI:   &AttachUI{},
+		UI:   true,
 	}}})
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)

--- a/gestaltd/internal/server/provider_dev_ui_test.go
+++ b/gestaltd/internal/server/provider_dev_ui_test.go
@@ -29,7 +29,7 @@ func TestProviderDevMountedUIHandlerOverridesFallback(t *testing.T) {
 	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
 	session, err := manager.CreateSession(context.Background(), p, providerdev.CreateSessionRequest{Providers: []providerdev.AttachProvider{{
 		Name: "roadmap",
-		UI:   &providerdev.AttachUI{},
+		UI:   true,
 	}}})
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
@@ -169,7 +169,7 @@ func TestProviderDevMountedUIHandlerUsesMountedAuthRuntime(t *testing.T) {
 	}
 	session, err := manager.CreateSession(context.Background(), p, providerdev.CreateSessionRequest{Providers: []providerdev.AttachProvider{{
 		Name: "roadmap",
-		UI:   &providerdev.AttachUI{},
+		UI:   true,
 	}}})
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
@@ -261,7 +261,7 @@ func TestProviderDevMountedUIHandlerUsesAnonymousForNoAuthMountedUI(t *testing.T
 	}
 	session, err := manager.CreateSession(context.Background(), p, providerdev.CreateSessionRequest{Providers: []providerdev.AttachProvider{{
 		Name: "roadmap",
-		UI:   &providerdev.AttachUI{},
+		UI:   true,
 	}}})
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6099,7 +6099,7 @@ func TestProviderDevAttachmentRoutesEnforceGateDispatcherSecretAndRedaction(t *t
 			}
 		},
 	}
-	createBody := []byte(`{"providers":[{"name":"roadmap","ui":{}}]}`)
+	createBody := []byte(`{"providers":[{"name":"roadmap","ui":true}]}`)
 
 	disabledTS := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = auth


### PR DESCRIPTION
## Summary

Replaces the empty provider-dev `AttachUI` marker object with a boolean `ui` flag. Remote attach only needs to know whether the local dispatcher will serve UI assets, so the request now uses `ui: true` instead of `ui: {}` and the empty `AttachUI` type/clone helper are removed.

## Interface Changes

Changed:
- `providers[].ui` in provider-dev attach requests is now a boolean.

Removed:
- `providerdev.AttachUI`

Kept:
- `CreateSessionProvider.ui` and attachment diagnostics still report whether a provider has local UI attached.
- `uiPath` remains the mounted remote UI path reported by create/list/get responses.

## Examples

```sh
gestaltd provider dev --remote https://valon.tools --path ./plugins/slack
```

Attach-create request when local UI assets are attached:

```http
POST /api/v1/provider-dev/attachments
Authorization: Bearer <token-with-provider_dev.attach>
Content-Type: application/json

{
  "providers": [
    {
      "name": "slack",
      "ui": true
    }
  ]
}
```

Browser-approved attach uses the same provider request body against:

```http
POST /api/v1/provider-dev/attach-authorizations/{authorizationId}/attachments
X-Gestalt-Provider-Dev-Authorization: <client-secret>
```

## Validation

- `go test -count=1 ./internal/providerdev ./internal/server -run 'ProviderDev|ProviderRemote|ProviderAttach'`
- `go test -count=1 ./cmd/gestaltd -run 'ProviderRemote|ProviderDev|ProviderAttach'`
- `go test -count=1 ./internal/providerdev ./internal/server ./cmd/gestaltd`
- `golangci-lint run --allow-parallel-runners ./internal/providerdev ./internal/server ./cmd/gestaltd`