### PR TITLE
gestaltd: support platform manual auth mappings

### DIFF
--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -93,17 +93,57 @@ func connectionRuntimeInfo(integration, connection string, conn *config.Connecti
 	if mode != core.ConnectionModePlatform {
 		return info, nil
 	}
-	if conn.Auth.Type != providermanifestv1.AuthTypeBearer {
-		return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q mode platform requires auth.type bearer", integration, connection)
-	}
-	if strings.TrimSpace(conn.Auth.Token) == "" {
-		return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q mode platform requires auth.token in deployment config", integration, connection)
-	}
-	if len(conn.Auth.Credentials) > 0 || conn.Auth.AuthMapping != nil {
+	if len(conn.Auth.Credentials) > 0 {
 		return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q mode platform does not support user credential fields", integration, connection)
 	}
-	info.Token = strings.TrimSpace(conn.Auth.Token)
-	return info, nil
+	switch conn.Auth.Type {
+	case providermanifestv1.AuthTypeBearer:
+		if strings.TrimSpace(conn.Auth.Token) == "" {
+			return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q mode platform requires auth.token in deployment config", integration, connection)
+		}
+		if conn.Auth.AuthMapping != nil {
+			return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q mode platform bearer auth does not support authMapping", integration, connection)
+		}
+		info.Token = strings.TrimSpace(conn.Auth.Token)
+		return info, nil
+	case providermanifestv1.AuthTypeManual:
+		token := strings.TrimSpace(conn.Auth.Token)
+		if token == "" {
+			if authMappingNeedsToken(conn.Auth.AuthMapping) {
+				return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q mode platform manual auth with credential refs requires auth.token in deployment config", integration, connection)
+			}
+			token = "{}"
+		}
+		info.Token = token
+		return info, nil
+	default:
+		return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q mode platform requires auth.type bearer or manual", integration, connection)
+	}
+}
+
+func authMappingNeedsToken(mapping *config.AuthMappingDef) bool {
+	if mapping == nil {
+		return true
+	}
+	hasMaterialization := len(mapping.Headers) > 0 || mapping.Basic != nil
+	if !hasMaterialization {
+		return true
+	}
+	for _, value := range mapping.Headers {
+		if authValueNeedsToken(value) {
+			return true
+		}
+	}
+	if mapping.Basic != nil {
+		if authValueNeedsToken(mapping.Basic.Username) || authValueNeedsToken(mapping.Basic.Password) {
+			return true
+		}
+	}
+	return false
+}
+
+func authValueNeedsToken(value config.AuthValueDef) bool {
+	return value.ValueFrom != nil
 }
 
 func buildConnectionAuthMap(name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, pluginConfig map[string]any, authFallback *specAuthFallback, deps Deps) (map[string]OAuthHandler, error) {

--- a/gestaltd/internal/bootstrap/connections_test.go
+++ b/gestaltd/internal/bootstrap/connections_test.go
@@ -1,0 +1,117 @@
+package bootstrap
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestBuildConnectionRuntimePlatformManualDirectAuthMapping(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"gong": {
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{
+						Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+							"default": {
+								Mode: providermanifestv1.ConnectionModeUser,
+								Auth: &providermanifestv1.ProviderAuth{
+									Type: providermanifestv1.AuthTypeManual,
+									Credentials: []providermanifestv1.CredentialField{
+										{Name: "access_key_id"},
+										{Name: "secret_key"},
+									},
+									AuthMapping: &providermanifestv1.AuthMapping{
+										Basic: &providermanifestv1.BasicAuthMapping{
+											Username: providermanifestv1.AuthValue{
+												ValueFrom: &providermanifestv1.AuthValueFrom{
+													CredentialFieldRef: &providermanifestv1.CredentialFieldRef{Name: "access_key_id"},
+												},
+											},
+											Password: providermanifestv1.AuthValue{
+												ValueFrom: &providermanifestv1.AuthValueFrom{
+													CredentialFieldRef: &providermanifestv1.CredentialFieldRef{Name: "secret_key"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Connections: map[string]*config.ConnectionDef{
+					"default": {
+						Mode: providermanifestv1.ConnectionModePlatform,
+						Auth: config.ConnectionAuthDef{
+							Type:        providermanifestv1.AuthTypeManual,
+							Credentials: []config.CredentialFieldDef{},
+							AuthMapping: &config.AuthMappingDef{
+								Basic: &config.BasicAuthMappingDef{
+									Username: config.AuthValueDef{Value: "access-key-id"},
+									Password: config.AuthValueDef{Value: "access-key-secret"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runtime, err := BuildConnectionRuntime(cfg)
+	if err != nil {
+		t.Fatalf("BuildConnectionRuntime() error = %v", err)
+	}
+	info, ok := runtime.Resolve("gong", "default")
+	if !ok {
+		t.Fatal("runtime.Resolve(gong, default) not found")
+	}
+	if info.Mode != core.ConnectionModePlatform {
+		t.Fatalf("Mode = %q, want %q", info.Mode, core.ConnectionModePlatform)
+	}
+	if info.Token != "{}" {
+		t.Fatalf("Token = %q, want placeholder JSON token", info.Token)
+	}
+}
+
+func TestBuildConnectionRuntimePlatformManualCredentialRefsRequireToken(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"sample": {
+				Connections: map[string]*config.ConnectionDef{
+					"default": {
+						Mode: providermanifestv1.ConnectionModePlatform,
+						Auth: config.ConnectionAuthDef{
+							Type: providermanifestv1.AuthTypeManual,
+							AuthMapping: &config.AuthMappingDef{
+								Headers: map[string]config.AuthValueDef{
+									"X-API-Key": {
+										ValueFrom: &config.AuthValueFromDef{
+											CredentialFieldRef: &config.CredentialFieldRefDef{Name: "api_key"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := BuildConnectionRuntime(cfg)
+	if err == nil {
+		t.Fatal("BuildConnectionRuntime() error = nil, want credential ref error")
+	}
+	if !strings.Contains(err.Error(), "manual auth with credential refs requires auth.token") {
+		t.Fatalf("BuildConnectionRuntime() error = %v, want credential ref token error", err)
+	}
+}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1576,8 +1576,12 @@ func MergeConnectionAuth(dst *ConnectionAuthDef, src ConnectionAuthDef) {
 	if src.TokenMetadata != nil {
 		dst.TokenMetadata = src.TokenMetadata
 	}
-	if len(src.Credentials) > 0 {
-		dst.Credentials = mergeCredentialFields(dst.Credentials, src.Credentials)
+	if src.Credentials != nil {
+		if len(src.Credentials) == 0 {
+			dst.Credentials = nil
+		} else {
+			dst.Credentials = mergeCredentialFields(dst.Credentials, src.Credentials)
+		}
 	}
 	if src.AuthMapping != nil {
 		dst.AuthMapping = src.AuthMapping

--- a/gestaltd/internal/config/connection_auth_test.go
+++ b/gestaltd/internal/config/connection_auth_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"testing"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestMergeConnectionAuthExplicitEmptyCredentialsClearsInherited(t *testing.T) {
+	t.Parallel()
+
+	dst := &ConnectionAuthDef{
+		Type: providermanifestv1.AuthTypeManual,
+		Credentials: []CredentialFieldDef{
+			{Name: "api_key"},
+			{Name: "api_secret"},
+		},
+	}
+
+	MergeConnectionAuth(dst, ConnectionAuthDef{
+		Type:        providermanifestv1.AuthTypeManual,
+		Credentials: []CredentialFieldDef{},
+	})
+
+	if len(dst.Credentials) != 0 {
+		t.Fatalf("Credentials len = %d, want 0: %#v", len(dst.Credentials), dst.Credentials)
+	}
+}


### PR DESCRIPTION
## Summary

- allow platform connections to use manual auth mappings when credentials are provided entirely by config
- preserve the existing platform bearer path and reject unresolved manual credential refs without a token
- let explicit empty credentials clear provider-inherited credential fields during auth merge

## Test plan

- [x] go test ./internal/bootstrap -run 'TestBuildConnectionRuntimePlatformManual|TestValidate'\n- [x] go test ./internal/config -run 'TestMergeConnectionAuthExplicitEmptyCredentialsClearsInherited|TestBuildStaticConnectionPlan'\n- [x] go test ./internal/provider ./internal/egress\n- [x] go test ./internal/invocation