### PR TITLE
cli: toggle full tool details in agent TUI

### DIFF
--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -293,6 +293,19 @@ fn agent_help_lines() -> Vec<String> {
     ]
 }
 
+fn agent_tui_help_lines() -> Vec<String> {
+    let mut lines = agent_help_lines();
+    let insert_at = lines
+        .iter()
+        .position(|line| line.contains("Ctrl-C cancels"))
+        .unwrap_or(lines.len());
+    lines.insert(
+        insert_at,
+        "  Ctrl-O toggles compact/full tool details.".to_string(),
+    );
+    lines
+}
+
 fn agent_session_lines(shell: &AgentShell) -> Vec<String> {
     vec![
         format!("session {}", shell.session.id),

--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -23,12 +23,12 @@ use crate::cli::AgentTurnCreateArgs;
 mod state;
 mod worker;
 
-use state::{AgentUiState, TranscriptItem, turn_status_label};
+use state::{AgentUiState, ToolDetailMode, TranscriptItem, turn_status_label};
 use worker::{TurnWorker, WorkerCommand, WorkerEvent, spawn_turn_worker};
 
 use super::{
-    AgentInteractionInfo, AgentShell, INTERRUPT_CANCEL_REASON, agent_help_lines, agent_model_lines,
-    agent_session_lines, cancel_turn_silent, compact_json, display_markdown,
+    AgentInteractionInfo, AgentShell, INTERRUPT_CANCEL_REASON, agent_model_lines,
+    agent_session_lines, agent_tui_help_lines, cancel_turn_silent, compact_json, display_markdown,
 };
 
 const TICK_RATE: Duration = Duration::from_millis(50);
@@ -151,6 +151,7 @@ struct TuiApp {
     history_cursor: Option<usize>,
     history_draft: String,
     footer_context: FooterContext,
+    tool_detail_mode: ToolDetailMode,
 }
 
 impl TuiApp {
@@ -176,6 +177,7 @@ impl TuiApp {
             history_cursor: None,
             history_draft: String::new(),
             footer_context: FooterContext::detect(),
+            tool_detail_mode: ToolDetailMode::Compact,
         }
     }
 
@@ -265,7 +267,7 @@ impl TuiApp {
             if index > 0 && item.kind != state::TranscriptKind::Meta {
                 lines.push(Line::from(""));
             }
-            push_transcript_item_lines(&mut lines, item, content_width);
+            push_transcript_item_lines(&mut lines, item, content_width, self.tool_detail_mode);
         }
         lines
     }
@@ -337,6 +339,9 @@ impl TuiApp {
         ];
         if let Some(branch) = self.footer_context.branch.as_deref() {
             footer_parts.push(branch.to_string());
+        }
+        if self.tool_detail_mode == ToolDetailMode::Full {
+            footer_parts.push("tool details full".to_string());
         }
         footer_parts.push(format!(
             "session {}",
@@ -411,6 +416,9 @@ impl TuiApp {
             }
             (KeyCode::End, modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
                 self.state.scroll_to_bottom();
+            }
+            (KeyCode::Char('o'), modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
+                self.toggle_tool_detail_mode();
             }
             (KeyCode::Up, modifiers) if modifiers.is_empty() && self.can_step_history_back() => {
                 self.history_previous();
@@ -522,7 +530,14 @@ impl TuiApp {
     }
 
     fn push_help(&mut self) {
-        self.state.push_system(agent_help_lines().join("\n"));
+        self.state.push_system(agent_tui_help_lines().join("\n"));
+    }
+
+    fn toggle_tool_detail_mode(&mut self) {
+        self.tool_detail_mode = match self.tool_detail_mode {
+            ToolDetailMode::Compact => ToolDetailMode::Full,
+            ToolDetailMode::Full => ToolDetailMode::Compact,
+        };
     }
 
     fn enqueue_or_start(&mut self, messages: Vec<String>) {
@@ -854,6 +869,7 @@ fn push_transcript_item_lines(
     lines: &mut Vec<Line<'static>>,
     item: &TranscriptItem,
     content_width: usize,
+    tool_detail_mode: ToolDetailMode,
 ) {
     match item.kind {
         state::TranscriptKind::User => {
@@ -863,7 +879,7 @@ fn push_transcript_item_lines(
             push_assistant_item_lines(lines, item, content_width);
         }
         state::TranscriptKind::Tool => {
-            push_tool_item_lines(lines, item, content_width);
+            push_tool_item_lines(lines, item, content_width, tool_detail_mode);
         }
         state::TranscriptKind::Meta => {
             push_meta_item_lines(lines, item, content_width);
@@ -878,6 +894,7 @@ fn push_tool_item_lines(
     lines: &mut Vec<Line<'static>>,
     item: &TranscriptItem,
     content_width: usize,
+    detail_mode: ToolDetailMode,
 ) {
     let Some(activity) = item.tool_activity_ref() else {
         push_status_item_lines(lines, item, content_width);
@@ -923,13 +940,13 @@ fn push_tool_item_lines(
     );
 
     let mut detail_rows = Vec::new();
-    if let Some(args) = activity.args() {
+    if let Some(args) = activity.args(detail_mode) {
         detail_rows.push(("input", args, body_style));
     }
-    if let Some(output) = activity.output() {
+    if let Some(output) = activity.output(detail_mode) {
         detail_rows.push(("output", output, body_style));
     }
-    if let Some(error) = activity.error() {
+    if let Some(error) = activity.error(detail_mode) {
         detail_rows.push(("error", error, Style::default().fg(Color::LightRed)));
     }
     let total_rows = detail_rows.len();

--- a/gestalt/cli/src/commands/agents/tui/state.rs
+++ b/gestalt/cli/src/commands/agents/tui/state.rs
@@ -16,6 +16,8 @@ use super::super::{
 const MAX_TRANSCRIPT_ITEMS: usize = 500;
 const TOOL_PREVIEW_MAX_WIDTH: usize = 120;
 const TOOL_PREVIEW_MAX_LINES: usize = 6;
+const TOOL_DETAIL_FULL_MAX_WIDTH: usize = 240;
+const TOOL_DETAIL_FULL_MAX_LINES: usize = 200;
 const LEGACY_ASSISTANT_FORMAT: &str = "markdown";
 
 pub(super) struct AgentUiState {
@@ -33,6 +35,12 @@ pub(super) struct AgentUiState {
     scroll_offset: usize,
     turn_started_at: Option<Instant>,
     turn_elapsed_reported: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ToolDetailMode {
+    Compact,
+    Full,
 }
 
 impl AgentUiState {
@@ -732,9 +740,9 @@ pub(super) struct ToolActivity {
     status: ToolActivityStatus,
     started_at: Option<Instant>,
     elapsed: Option<Duration>,
-    args: Option<String>,
-    output: Option<String>,
-    error: Option<String>,
+    args: Option<ToolDetailValue>,
+    output: Option<ToolDetailValue>,
+    error: Option<ToolDetailValue>,
 }
 
 impl ToolActivity {
@@ -746,7 +754,7 @@ impl ToolActivity {
             status: ToolActivityStatus::Running,
             started_at: Some(Instant::now()),
             elapsed: None,
-            args: preview_value(&event.data, &["arguments", "input", "request"]),
+            args: detail_value(&event.data, &["arguments", "input", "request"]),
             output: None,
             error: None,
         }
@@ -760,7 +768,7 @@ impl ToolActivity {
             status: ToolActivityStatus::Running,
             started_at: Some(Instant::now()),
             elapsed: None,
-            args: preview_display_value(display_tool_input(event, display)),
+            args: display_detail_value(display_tool_input(event, display)),
             output: None,
             error: None,
         }
@@ -857,16 +865,16 @@ impl ToolActivity {
         self.elapsed.map(format_duration)
     }
 
-    pub(super) fn args(&self) -> Option<&str> {
-        self.args.as_deref()
+    pub(super) fn args(&self, mode: ToolDetailMode) -> Option<&str> {
+        self.args.as_ref().map(|value| value.as_str(mode))
     }
 
-    pub(super) fn output(&self) -> Option<&str> {
-        self.output.as_deref()
+    pub(super) fn output(&self, mode: ToolDetailMode) -> Option<&str> {
+        self.output.as_ref().map(|value| value.as_str(mode))
     }
 
-    pub(super) fn error(&self) -> Option<&str> {
-        self.error.as_deref()
+    pub(super) fn error(&self, mode: ToolDetailMode) -> Option<&str> {
+        self.error.as_ref().map(|value| value.as_str(mode))
     }
 
     pub(super) fn is_running(&self) -> bool {
@@ -893,16 +901,42 @@ impl ToolActivity {
         if !meta.is_empty() {
             text.push_str(&format!(" ({})", meta.join(", ")));
         }
-        if let Some(args) = self.args.as_deref() {
+        if let Some(args) = self.args(ToolDetailMode::Compact) {
             text.push_str(&format!("\n  args {args}"));
         }
-        if let Some(output) = self.output.as_deref() {
+        if let Some(output) = self.output(ToolDetailMode::Compact) {
             text.push_str(&format!("\n  output {output}"));
         }
-        if let Some(error) = self.error.as_deref() {
+        if let Some(error) = self.error(ToolDetailMode::Compact) {
             text.push_str(&format!("\n  error {error}"));
         }
         text
+    }
+}
+
+#[derive(Clone)]
+enum ToolDetailValue {
+    Single(String),
+    Truncated { compact: String, full: String },
+}
+
+impl ToolDetailValue {
+    fn from_full(full: String) -> Self {
+        let compact = truncate_multiline_preview(&full);
+        let full = truncate_full_detail(&full);
+        if compact == full {
+            Self::Single(full)
+        } else {
+            Self::Truncated { compact, full }
+        }
+    }
+
+    fn as_str(&self, mode: ToolDetailMode) -> &str {
+        match (self, mode) {
+            (Self::Single(value), _) => value,
+            (Self::Truncated { compact, .. }, ToolDetailMode::Compact) => compact,
+            (Self::Truncated { full, .. }, ToolDetailMode::Full) => full,
+        }
     }
 }
 
@@ -911,14 +945,14 @@ struct ToolTerminalEvent {
     name: String,
     action: Option<String>,
     status: ToolActivityStatus,
-    args: Option<String>,
-    output: Option<String>,
-    error: Option<String>,
+    args: Option<ToolDetailValue>,
+    output: Option<ToolDetailValue>,
+    error: Option<ToolDetailValue>,
 }
 
 impl ToolTerminalEvent {
     fn from_completed(event: &AgentTurnEventInfo) -> Self {
-        let error = string_field(&event.data, "error").map(|value| truncate_preview(&value));
+        let error = string_field(&event.data, "error").map(ToolDetailValue::from_full);
         let status = if error.is_some() {
             ToolActivityStatus::Failed(tool_status(&event.data))
         } else {
@@ -929,8 +963,8 @@ impl ToolTerminalEvent {
             name: event_tool_name(event),
             action: None,
             status,
-            args: preview_value(&event.data, &["arguments", "input", "request"]),
-            output: preview_value(&event.data, &["output", "result", "body"]),
+            args: detail_value(&event.data, &["arguments", "input", "request"]),
+            output: detail_value(&event.data, &["output", "result", "body"]),
             error,
         }
     }
@@ -941,10 +975,10 @@ impl ToolTerminalEvent {
             name: event_tool_name(event),
             action: None,
             status: ToolActivityStatus::Failed(tool_status(&event.data)),
-            args: preview_value(&event.data, &["arguments", "input", "request"]),
-            output: preview_value(&event.data, &["output", "result", "body"]),
+            args: detail_value(&event.data, &["arguments", "input", "request"]),
+            output: detail_value(&event.data, &["output", "result", "body"]),
             error: string_any_field(&event.data, &["error", "message"])
-                .map(|value| truncate_preview(&value)),
+                .map(ToolDetailValue::from_full),
         }
     }
 
@@ -960,8 +994,8 @@ impl ToolTerminalEvent {
             name: display_tool_label(event, display),
             action: display_action(display).map(ToString::to_string),
             status,
-            args: preview_display_value(display_tool_input(event, display)),
-            output: preview_display_value(display_tool_output(event, display)),
+            args: display_detail_value(display_tool_input(event, display)),
+            output: display_detail_value(display_tool_output(event, display)),
             error,
         }
     }
@@ -972,9 +1006,10 @@ impl ToolTerminalEvent {
             name: display_tool_label(event, display),
             action: display_action(display).map(ToString::to_string),
             status: ToolActivityStatus::Running,
-            args: preview_display_value(display_tool_input(event, display)),
-            output: preview_display_value(display_tool_output(event, display))
-                .or_else(|| display_text(display).map(truncate_preview)),
+            args: display_detail_value(display_tool_input(event, display)),
+            output: display_detail_value(display_tool_output(event, display)).or_else(|| {
+                display_text(display).map(|value| ToolDetailValue::from_full(value.to_string()))
+            }),
             error: preview_display_error(display_tool_error(event, display)),
         }
     }
@@ -1053,56 +1088,68 @@ fn tool_status(data: &serde_json::Map<String, Value>) -> Option<String> {
     })
 }
 
-fn preview_value(data: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
-    value_any_field(data, keys).and_then(|value| format_tool_preview(value).ok())
+fn detail_value(data: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<ToolDetailValue> {
+    value_any_field(data, keys).and_then(|value| format_tool_detail(value).ok())
 }
 
-fn preview_display_value(value: Option<&Value>) -> Option<String> {
-    value.and_then(|value| format_tool_preview(value).ok())
+fn display_detail_value(value: Option<&Value>) -> Option<ToolDetailValue> {
+    value.and_then(|value| format_tool_detail(value).ok())
 }
 
-fn preview_display_error(value: Option<&Value>) -> Option<String> {
+fn preview_display_error(value: Option<&Value>) -> Option<ToolDetailValue> {
     value
         .and_then(|value| display_value_text(value).ok())
-        .map(|value| truncate_multiline_preview(&value))
+        .map(ToolDetailValue::from_full)
 }
 
-fn format_tool_preview(value: &Value) -> anyhow::Result<String> {
-    let preview = match value {
+fn format_tool_detail(value: &Value) -> anyhow::Result<ToolDetailValue> {
+    let full = match value {
         Value::Array(_) | Value::Object(_) => pretty_json(value)?,
         _ => compact_json(value)?,
     };
-    Ok(truncate_multiline_preview(&preview))
+    Ok(ToolDetailValue::from_full(full))
 }
 
 fn truncate_multiline_preview(value: &str) -> String {
+    truncate_multiline(value, TOOL_PREVIEW_MAX_LINES, TOOL_PREVIEW_MAX_WIDTH)
+}
+
+fn truncate_full_detail(value: &str) -> String {
+    truncate_multiline(
+        value,
+        TOOL_DETAIL_FULL_MAX_LINES,
+        TOOL_DETAIL_FULL_MAX_WIDTH,
+    )
+}
+
+fn truncate_multiline(value: &str, max_lines: usize, max_width: usize) -> String {
     let total_lines = value.lines().count();
-    let preview_lines = if total_lines > TOOL_PREVIEW_MAX_LINES {
-        TOOL_PREVIEW_MAX_LINES.saturating_sub(1)
+    let preview_lines = if total_lines > max_lines {
+        max_lines.saturating_sub(1)
     } else {
-        TOOL_PREVIEW_MAX_LINES
+        max_lines
     };
     let mut lines = value
         .lines()
         .take(preview_lines)
-        .map(truncate_preview)
+        .map(|line| truncate_to_width_with_marker(line, max_width))
         .collect::<Vec<_>>();
-    if total_lines > TOOL_PREVIEW_MAX_LINES {
+    if total_lines > max_lines {
         lines.push(format!("... +{} lines", total_lines - preview_lines));
     }
     if lines.is_empty() && !value.is_empty() {
-        truncate_preview(value)
+        truncate_to_width_with_marker(value, max_width)
     } else {
         lines.join("\n")
     }
 }
 
-fn truncate_preview(value: &str) -> String {
+fn truncate_to_width_with_marker(value: &str, max_width: usize) -> String {
     let mut preview = String::new();
     let mut width = 0usize;
     for grapheme in UnicodeSegmentation::graphemes(value, true) {
         let grapheme_width = UnicodeWidthStr::width(grapheme);
-        if width > 0 && width.saturating_add(grapheme_width) > TOOL_PREVIEW_MAX_WIDTH {
+        if width > 0 && width.saturating_add(grapheme_width) > max_width {
             preview.push_str("...");
             return preview;
         }

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -1008,35 +1008,47 @@ fn test_cli_tty_renders_display_tool_activity_rows() {
     session.wait_for(&mut output, "suffix");
     session.wait_for(&mut output, "done");
     session.wait_for(&mut output, "fallback");
+    let compact_output = output.clone();
+    let mut full_output = String::new();
+    session.write("\x0f");
+    session.write("\x1b[5~\x1b[5~");
+    session.wait_for(&mut full_output, "\"blue\"");
     session.write("\x03");
     session.wait_for_exit();
 
     assert!(
-        !output.contains("hidden secret"),
-        "unknown private display event was rendered:\n{output}"
+        !compact_output.contains("hidden secret") && !full_output.contains("hidden secret"),
+        "unknown private display event was rendered:\n{compact_output}\n{full_output}"
     );
     assert!(
-        !output.contains("RAW_TUI_INPUT") && !output.contains("RAW_TUI_OUTPUT"),
-        "display tool rendering leaked raw tool payload data:\n{output}"
+        !compact_output.contains("RAW_TUI_INPUT")
+            && !compact_output.contains("RAW_TUI_OUTPUT")
+            && !full_output.contains("RAW_TUI_INPUT")
+            && !full_output.contains("RAW_TUI_OUTPUT"),
+        "display tool rendering leaked raw tool payload data:\n{compact_output}\n{full_output}"
     );
     assert!(
-        output.contains("●")
-            && output.contains("Ran")
-            && output.contains("lookup")
-            && output.contains("input")
-            && output.contains("output")
-            && output.contains("filters")
-            && output.contains("REC-1")
-            && output.contains("... +5 lines")
-            && output.contains("... +4 lines")
-            && output.contains("└─")
-            && !output.contains("Tool")
-            && !output.contains("tool>"),
-        "TTY tool transcript did not render inline activity rows:\n{output}"
+        compact_output.contains("●")
+            && compact_output.contains("Ran")
+            && compact_output.contains("lookup")
+            && compact_output.contains("input")
+            && compact_output.contains("output")
+            && compact_output.contains("filters")
+            && compact_output.contains("REC-1")
+            && compact_output.contains("... +5 lines")
+            && compact_output.contains("... +4 lines")
+            && compact_output.contains("└─")
+            && !compact_output.contains("Tool")
+            && !compact_output.contains("tool>"),
+        "TTY tool transcript did not render inline activity rows:\n{compact_output}"
     );
     assert!(
-        !output.contains("ended"),
-        "tool progress events left duplicate running tool rows:\n{output}"
+        full_output.contains("\"blue\""),
+        "Ctrl-O did not expand full tool detail rows:\n{full_output}"
+    );
+    assert!(
+        !compact_output.contains("ended"),
+        "tool progress events left duplicate running tool rows:\n{compact_output}"
     );
     server.assert_finished();
 }
@@ -1432,6 +1444,10 @@ fn test_cli_tty_resize_expands_selectable_inline_viewport() {
     let mut help_output = String::new();
     session.write("/help\r");
     session.wait_for(&mut help_output, "Ctrl-C cancels, clears input, or exits.");
+    assert!(
+        help_output.contains("Ctrl-O toggles compact/full tool details."),
+        "TTY help did not include tool detail toggle:\n{help_output}"
+    );
     assert!(
         !help_output.contains("\x1b[?1049h"),
         "TTY entered the alternate screen after resize:\n{help_output}"
@@ -2107,6 +2123,7 @@ fn test_cli_agent_help_describes_resume_command() {
         .assert()
         .success()
         .stdout(predicate::str::contains("resume"))
+        .stdout(predicate::str::contains("Ctrl-O").not())
         .stdout(predicate::str::contains("--resume").not())
         .stdout(predicate::str::contains("--continue").not())
         .stdout(predicate::str::contains("--ui").not());


### PR DESCRIPTION
## Summary
- Add an internal compact/full tool-detail mode to the agent TUI.
- Keep the existing compact truncation by default, then let `Ctrl-O` expand tool input/output/error rows to their bounded full formatted display payloads.
- Bound retained/rendered full detail text at 200 lines and 240 display columns per line, and avoid duplicating storage for small values when truncation did not change rendering.
- Keep `Ctrl-O` help TUI-only so fallback non-TUI interactive help stays accurate.
- Extend the existing PTY integration test to verify compact previews, `Ctrl-O` expansion, full nested detail visibility, and continued redaction of raw/private payloads.

## New interfaces

### Rust
```rust
#[derive(Clone, Copy, Debug, Eq, PartialEq)]
pub(super) enum ToolDetailMode {
    Compact,
    Full,
}

// Rendering threads the selected mode into tool rows.
push_transcript_item_lines(&mut lines, item, content_width, self.tool_detail_mode);

// ToolActivity returns the compact or bounded full detail string for the same server payload.
activity.output(ToolDetailMode::Full);
```

### stdin/stdout
No server or wire schema changes. The interactive command remains:
```bash
GESTALT_URL=https://valon.tools gestalt agent --provider simple --model gpt-5.5
```

Inside the TUI:
```text
Ctrl-O  toggles compact/full tool details
PgUp/PgDn scrolls the transcript
Ctrl-C  exits and prints: Resume with: gestalt agent resume <session-id>
```

Example workflow:
```text
● Ran lookup · 200
├─ input { ... +5 lines }
└─ output { ... +4 lines }

# Press Ctrl-O
● Ran lookup · 200
├─ input {
│    "filters": { ... bounded full formatted payload ... }
└─ output {
     ... bounded full formatted payload ...
   }
```

## Verification
```bash
cargo test --manifest-path gestalt/Cargo.toml -p gestalt --test agents_cli
```

33 tests passed.