### PR TITLE
Drop provider-dev approval poll interval field

### DIFF
--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -337,10 +337,6 @@ func createProviderRemoteSessionWithBrowser(ctx context.Context, client *provide
 		fmt.Fprintf(os.Stderr, "Could not open browser automatically: %v\nOpen the URL above to continue.\n\n", err)
 	}
 
-	pollInterval := time.Duration(authorization.PollIntervalMillis) * time.Millisecond
-	if pollInterval <= 0 {
-		pollInterval = time.Second
-	}
 	timer := time.NewTimer(0)
 	defer timer.Stop()
 	for {
@@ -359,7 +355,7 @@ func createProviderRemoteSessionWithBrowser(ctx context.Context, client *provide
 		if !authorization.ExpiresAt.IsZero() && time.Now().After(authorization.ExpiresAt) {
 			return nil, errors.New("provider dev browser approval expired")
 		}
-		timer.Reset(pollInterval)
+		timer.Reset(time.Second)
 	}
 }
 

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -182,12 +182,11 @@ func TestCreateProviderRemoteSessionUsesBrowserApprovalWithoutAttachToken(t *tes
 				t.Fatalf("browser authorization should not send bearer token, got %q", r.Header.Get("Authorization"))
 			}
 			writeJSONForProviderRemoteTest(t, w, http.StatusCreated, providerdev.CreateAttachAuthorizationResponse{
-				AuthorizationID:    authID,
-				ClientSecret:       clientSecret,
-				VerificationCode:   "123-456",
-				ApprovalURL:        tsURL(t, r) + "/approve",
-				ExpiresAt:          time.Now().Add(time.Minute),
-				PollIntervalMillis: 1,
+				AuthorizationID:  authID,
+				ClientSecret:     clientSecret,
+				VerificationCode: "123-456",
+				ApprovalURL:      tsURL(t, r) + "/approve",
+				ExpiresAt:        time.Now().Add(time.Minute),
 			})
 		case r.Method == http.MethodGet && r.URL.Path == providerdev.PathAttachAuthorizations+"/"+authID+"/poll":
 			if r.Header.Get(providerdev.HeaderAuthorizationSecret) != clientSecret {

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -97,12 +97,11 @@ type CreateSessionProvider struct {
 }
 
 type CreateAttachAuthorizationResponse struct {
-	AuthorizationID    string    `json:"authorizationId"`
-	ClientSecret       string    `json:"clientSecret"`
-	VerificationCode   string    `json:"verificationCode"`
-	ApprovalURL        string    `json:"approvalUrl"`
-	ExpiresAt          time.Time `json:"expiresAt"`
-	PollIntervalMillis int       `json:"pollIntervalMillis"`
+	AuthorizationID  string    `json:"authorizationId"`
+	ClientSecret     string    `json:"clientSecret"`
+	VerificationCode string    `json:"verificationCode"`
+	ApprovalURL      string    `json:"approvalUrl"`
+	ExpiresAt        time.Time `json:"expiresAt"`
 }
 
 type AttachAuthorizationInfo struct {

--- a/gestaltd/internal/server/handlers_provider_dev.go
+++ b/gestaltd/internal/server/handlers_provider_dev.go
@@ -86,12 +86,11 @@ func (s *Server) createProviderDevAttachAuthorization(w http.ResponseWriter, r *
 		return
 	}
 	writeJSON(w, http.StatusCreated, providerdev.CreateAttachAuthorizationResponse{
-		AuthorizationID:    info.AuthorizationID,
-		ClientSecret:       clientSecret,
-		VerificationCode:   verificationCode,
-		ApprovalURL:        approvalURL,
-		ExpiresAt:          info.ExpiresAt,
-		PollIntervalMillis: 1000,
+		AuthorizationID:  info.AuthorizationID,
+		ClientSecret:     clientSecret,
+		VerificationCode: verificationCode,
+		ApprovalURL:      approvalURL,
+		ExpiresAt:        info.ExpiresAt,
 	})
 }
 


### PR DESCRIPTION
## Summary
- Remove the hard-coded `pollIntervalMillis` field from provider-dev browser approval responses.
- Keep the CLI polling behavior fixed at once per second, which is what the server already required.
- Update the existing browser approval test fixture to match the smaller contract.

## Interface change
`CreateAttachAuthorizationResponse` no longer includes `pollIntervalMillis`.

The supported flow is unchanged:

```sh
gestaltd provider dev --remote https://valon.tools --path ./plugins/slack
```

The approval poll endpoint is unchanged:

```http
GET /api/v1/provider-dev/attach-authorizations/{authorizationId}/poll
```

Example poll response remains:

```json
{"approved": true}
```

## Validation
- `go test -count=1 ./internal/providerdev ./internal/server -run 'ProviderDev|ProviderRemote|ProviderAttach'`
- `go test -count=1 ./cmd/gestaltd -run 'ProviderRemote|ProviderDev|ProviderAttach'`
- `go test -count=1 ./internal/providerdev ./internal/server ./cmd/gestaltd`
- `golangci-lint run --allow-parallel-runners ./internal/providerdev ./internal/server ./cmd/gestaltd`
- `git diff --check`