### PR TITLE
cli: isolate agent TUI scrollback

### DIFF
--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -9,7 +9,6 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use ratatui::crossterm::terminal;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, TextArea};
@@ -67,17 +66,14 @@ pub(super) fn run_shell(
 struct TerminalGuard {
     terminal: ratatui::DefaultTerminal,
     restored: bool,
-    viewport_height: u16,
 }
 
 impl TerminalGuard {
     fn start() -> Result<Self> {
-        let viewport_height = current_terminal_height()?;
-        let terminal = inline_terminal(viewport_height)?;
+        let terminal = ratatui::try_init().context("failed to initialize terminal UI")?;
         Ok(Self {
             terminal,
             restored: false,
-            viewport_height,
         })
     }
 
@@ -94,20 +90,10 @@ impl TerminalGuard {
         Ok(())
     }
 
-    fn resize_inline_viewport(&mut self, height: u16) -> Result<()> {
-        let height = height.max(1);
-        if height != self.viewport_height {
-            let backend = ratatui::backend::CrosstermBackend::new(io::stdout());
-            self.terminal = ratatui::Terminal::with_options(
-                backend,
-                ratatui::TerminalOptions {
-                    viewport: ratatui::Viewport::Inline(height),
-                },
-            )
-            .context("failed to resize terminal UI")?;
-            self.viewport_height = height;
-        }
-        Ok(())
+    fn resize(&mut self) -> Result<()> {
+        self.terminal
+            .autoresize()
+            .context("failed to resize terminal UI")
     }
 }
 
@@ -118,19 +104,6 @@ impl Drop for TerminalGuard {
             self.restored = true;
         }
     }
-}
-
-fn current_terminal_height() -> Result<u16> {
-    terminal::size()
-        .map(|(_, height)| height.max(1))
-        .context("failed to detect terminal size")
-}
-
-fn inline_terminal(viewport_height: u16) -> Result<ratatui::DefaultTerminal> {
-    ratatui::try_init_with_options(ratatui::TerminalOptions {
-        viewport: ratatui::Viewport::Inline(viewport_height),
-    })
-    .context("failed to initialize terminal UI")
 }
 
 struct TuiApp {
@@ -195,7 +168,7 @@ impl TuiApp {
             if event::poll(TICK_RATE).context("failed to poll terminal events")? {
                 match event::read().context("failed to read terminal event")? {
                     Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_key(key),
-                    Event::Resize(_, height) => terminal.resize_inline_viewport(height)?,
+                    Event::Resize(_, _) => terminal.resize()?,
                     _ => {}
                 }
             }

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -757,7 +757,7 @@ fn test_cli_runs_interactive_agent_session_with_display_events() {
 
 #[cfg(unix)]
 #[test]
-fn test_cli_runs_tty_agent_session_with_selectable_inline_ui() {
+fn test_cli_runs_tty_agent_session_in_isolated_selectable_ui() {
     let server = ScriptedServer::spawn(vec![
         ExpectedRequest::json(
             Method::POST,
@@ -833,8 +833,16 @@ fn test_cli_runs_tty_agent_session_with_selectable_inline_ui() {
         "TTY transcript did not render highlighted user input and assistant bullet:\n{output}"
     );
     assert!(
-        !output.contains("\x1b[?1049h"),
-        "TTY entered the alternate screen, which prevents normal terminal scrollback selection:\n{output}"
+        output.contains("\x1b[?1049h"),
+        "TTY did not enter the alternate screen, so terminal scrollback can include shell output before the session:\n{output}"
+    );
+    assert!(
+        !output.contains("\x1b[?1000h")
+            && !output.contains("\x1b[?1002h")
+            && !output.contains("\x1b[?1003h")
+            && !output.contains("\x1b[?1015h")
+            && !output.contains("\x1b[?1006h"),
+        "TTY enabled mouse capture, which prevents normal drag selection:\n{output}"
     );
     assert!(
         !output.contains("**hello**"),
@@ -1416,7 +1424,7 @@ fn test_cli_tty_scrolls_multiline_help_rows() {
 
 #[cfg(unix)]
 #[test]
-fn test_cli_tty_resize_expands_selectable_inline_viewport() {
+fn test_cli_tty_resize_redraws_isolated_session() {
     let server = ScriptedServer::spawn(vec![ExpectedRequest::json(
         Method::POST,
         "/api/v1/agent/sessions",
@@ -1440,6 +1448,10 @@ fn test_cli_tty_resize_expands_selectable_inline_viewport() {
     session.resize(24, 100);
     let mut resized_output = String::new();
     session.wait_for(&mut resized_output, "session session-1");
+    assert!(
+        resized_output.contains("session session-1"),
+        "TTY did not redraw the resized session after resize:\n{resized_output}"
+    );
 
     let mut help_output = String::new();
     session.write("/help\r");
@@ -1447,10 +1459,6 @@ fn test_cli_tty_resize_expands_selectable_inline_viewport() {
     assert!(
         help_output.contains("Ctrl-O toggles compact/full tool details."),
         "TTY help did not include tool detail toggle:\n{help_output}"
-    );
-    assert!(
-        !help_output.contains("\x1b[?1049h"),
-        "TTY entered the alternate screen after resize:\n{help_output}"
     );
 
     session.write("\x03");


### PR DESCRIPTION
## Summary
- Switch the interactive agent TUI back to ratatui's alternate-screen terminal surface so terminal scrollback before the session cannot mix into transcript scrolling.
- Keep mouse capture disabled, preserving normal drag selection for visible TUI text.
- Keep resize handling through terminal autoresize instead of rebuilding an inline viewport.

## Interfaces
Rust terminal contract:
```rust
let terminal = ratatui::try_init()?; // enters alternate screen, enables raw mode
terminal.autoresize()?;             // resize redraws the isolated TUI surface
```

TUI/stdin/stdout contract:
```text
PgUp / PgDn       scroll the agent transcript only
Ctrl-Home / End   jump transcript top / bottom
Mouse drag        selects visible terminal text; the CLI does not enable mouse capture
```

## Example
```bash
GESTALT_URL=https://valon.tools gestalt agent --provider simple --model gpt-5.5
```

Resume remains unchanged:
```bash
GESTALT_URL=https://valon.tools gestalt agent resume <session-id>
```

## Verification
```bash
cargo test --manifest-path gestalt/Cargo.toml -p gestalt --test agents_cli
git diff --check
```