### PR TITLE
Remove three-part platform compatibility

### DIFF
--- a/gestaltd/cmd/gestaltd/init.go
+++ b/gestaltd/cmd/gestaltd/init.go
@@ -30,9 +30,9 @@ func initConfigWithStatePaths(configFlags []string, state operator.StatePaths, p
 		return err
 	}
 
-	platArgs := make([]struct{ GOOS, GOARCH, LibC string }, len(platforms))
+	platArgs := make([]struct{ GOOS, GOARCH string }, len(platforms))
 	for i, p := range platforms {
-		platArgs[i] = struct{ GOOS, GOARCH, LibC string }{p.GOOS, p.GOARCH, ""}
+		platArgs[i] = struct{ GOOS, GOARCH string }{p.GOOS, p.GOARCH}
 	}
 
 	_, err = operatorLifecycle().InitAtPathsWithPlatforms(configPaths, state, platArgs)

--- a/gestaltd/cmd/gestaltd/provider.go
+++ b/gestaltd/cmd/gestaltd/provider.go
@@ -93,7 +93,7 @@ func runProviderRelease(args []string) (err error) {
 	fs.Usage = func() { printProviderReleaseUsage(fs.Output()) }
 	version := fs.String("version", "", "semantic version string (required)")
 	outputDir := fs.String("output", defaultReleaseOutputDir, "output directory")
-	platforms := fs.String("platform", "", "comma-separated platforms (os/arch[/libc]) or 'all'")
+	platforms := fs.String("platform", "", "comma-separated platforms (os/arch) or 'all'")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -332,7 +332,7 @@ func expandReleasePlatformValue(value string) (string, error) {
 	trimmed := strings.TrimSpace(value)
 	switch {
 	case trimmed == "":
-		return "", fmt.Errorf("--platform requires a comma-separated os/arch[/libc] list or %q", allPlatformsValue)
+		return "", fmt.Errorf("--platform requires a comma-separated os/arch list or %q", allPlatformsValue)
 	case strings.EqualFold(trimmed, allPlatformsValue):
 		return defaultPlatforms, nil
 	default:
@@ -620,7 +620,7 @@ func printProviderReleaseUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd provider release --version VERSION [--output DIR] [--platform PLATFORMS]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Build a provider release archive for the host platform by default.")
-	writeUsageLine(w, "Pass --platform with a comma-separated os/arch[/libc] list or --platform all")
+	writeUsageLine(w, "Pass --platform with a comma-separated os/arch list or --platform all")
 	writeUsageLine(w, "to build multiple per-platform tar.gz archives plus a checksums file.")
 	writeUsageLine(w, "Run from the provider source directory.")
 	writeUsageLine(w, "For apiVersion v4 local deploy configs, point source.path at dist/provider-release.yaml.")
@@ -628,5 +628,5 @@ func printProviderReleaseUsage(w io.Writer) {
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --version    Semantic version string (required)")
 	writeUsageLine(w, "  --output     Output directory (default: dist/)")
-	writeUsageLine(w, "  --platform   Comma-separated platforms (os/arch[/libc]) or all (default: host platform only)")
+	writeUsageLine(w, "  --platform   Comma-separated platforms (os/arch) or all (default: host platform only)")
 }

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -933,7 +933,7 @@ func TestRun_ProviderReleaseBuildsRustSourcePluginForCurrentPlatform(t *testing.
 		t.Skip("fake cargo test fixture is POSIX-only")
 	}
 
-	hostTarget, _, err := providerpkgRustTargetTriple(runtime.GOOS, runtime.GOARCH, "")
+	hostTarget, err := providerpkgRustTargetTriple(runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		t.Fatalf("providerpkgRustTargetTriple(host): %v", err)
 	}
@@ -959,7 +959,7 @@ func TestRun_ProviderReleaseBuildsRustSourcePluginForCurrentPlatform(t *testing.
 		"--output", outputDir,
 	)
 
-	archiveName := expectedRustArchiveName(testVersion, runtime.GOOS, runtime.GOARCH, "")
+	archiveName := expectedRustArchiveName(testVersion, runtime.GOOS, runtime.GOARCH)
 	extractDir := extractReleasedArchive(t, outputDir, archiveName)
 	manifest := readReleasedManifest(t, outputDir, archiveName)
 	assertReleasedManifestHasHostedHTTPMetadata(t, manifest, "greet")
@@ -968,7 +968,7 @@ func TestRun_ProviderReleaseBuildsRustSourcePluginForCurrentPlatform(t *testing.
 	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
 		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
 	}
-	assertExpectedRustArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH, "")
+	assertExpectedRustArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH)
 	if manifest.Entrypoint == nil || manifest.Entrypoint.ArtifactPath != binaryName {
 		t.Fatalf("provider entrypoint = %+v, want artifact path %q", manifest.Entrypoint, binaryName)
 	}
@@ -1013,51 +1013,6 @@ func TestRun_ProviderReleaseBuildsRustSourcePluginForCurrentPlatform(t *testing.
 	if !strings.Contains(result.Body, "Hi, Ada!") {
 		t.Fatalf("body = %q, want greeting", result.Body)
 	}
-}
-
-func TestRun_ProviderReleaseBuildsRustSourcePluginForExplicitLinuxTarget(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake cargo test fixture is POSIX-only")
-	}
-
-	hostTarget, _, err := providerpkgRustTargetTriple(runtime.GOOS, runtime.GOARCH, "")
-	if err != nil {
-		t.Fatalf("providerpkgRustTargetTriple(host): %v", err)
-	}
-	explicitTarget, _, err := providerpkgRustTargetTriple("linux", "amd64", "musl")
-	if err != nil {
-		t.Fatalf("providerpkgRustTargetTriple(linux/amd64/musl): %v", err)
-	}
-
-	fakeCargoDir := t.TempDir()
-	writeFakeRustReleaseCargo(t, filepath.Join(fakeCargoDir, "cargo"), fakeRustCargoConfig{
-		ExpectedPluginName:   rustReleasePluginName,
-		ExpectedServeExport:  "__gestalt_serve",
-		ExpectedCatalogWrite: true,
-		GeneratedCatalog:     rustReleasePluginName,
-		DelegateBinary:       pluginBin,
-		AllowedTargets:       []string{hostTarget, explicitTarget},
-	})
-	t.Setenv("PATH", fakeCargoDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-
-	pluginDir := newRustSourceReleaseFixture(t, t.TempDir())
-	outputDir := t.TempDir()
-	const testVersion = "0.0.12-rust-musl"
-
-	runProviderReleaseCommand(t, pluginDir,
-		"--version", testVersion,
-		"--platform", "linux/amd64/musl",
-		"--output", outputDir,
-	)
-
-	archiveName := expectedRustArchiveName(testVersion, "linux", "amd64", "musl")
-	manifest := readReleasedManifest(t, outputDir, archiveName)
-	binaryName := releaseBinaryName(rustReleasePluginName, "linux")
-
-	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
-		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
-	}
-	assertExpectedRustArtifactPlatform(t, manifest.Artifacts[0], "linux", "amd64", "musl")
 }
 
 func TestRun_ProviderReleaseRejectsMissingCrossTargetInterpreterForPythonSourcePlugin(t *testing.T) {
@@ -1651,7 +1606,7 @@ func TestRun_ProviderReleaseBuildsExecutableAuthProviders(t *testing.T) {
 			prepare: func(t *testing.T) string {
 				t.Helper()
 
-				hostTarget, _, err := providerpkgRustTargetTriple(runtime.GOOS, runtime.GOARCH, "")
+				hostTarget, err := providerpkgRustTargetTriple(runtime.GOOS, runtime.GOARCH)
 				if err != nil {
 					t.Fatalf("providerpkgRustTargetTriple(host): %v", err)
 				}
@@ -1671,7 +1626,7 @@ func TestRun_ProviderReleaseBuildsExecutableAuthProviders(t *testing.T) {
 			},
 			assertArtifact: func(t *testing.T, artifact providermanifestv1.Artifact) {
 				t.Helper()
-				assertExpectedRustArtifactPlatform(t, artifact, runtime.GOOS, runtime.GOARCH, "")
+				assertExpectedRustArtifactPlatform(t, artifact, runtime.GOOS, runtime.GOARCH)
 			},
 			assertSessionTTL: true,
 		},
@@ -3012,7 +2967,7 @@ func expectedPythonArchiveName(version, goos, goarch string) string {
 	return expectedPythonArchiveNameFor("python-release", version, goos, goarch)
 }
 
-func expectedRustArchiveName(version, goos, goarch, _ string) string {
+func expectedRustArchiveName(version, goos, goarch string) string {
 	return platformArchiveNameForTest(rustReleasePluginName, version, goos, goarch)
 }
 
@@ -3026,7 +2981,7 @@ func assertExpectedGoArtifactPlatform(t *testing.T, artifact providermanifestv1.
 	assertArtifactPlatform(t, artifact, goos, goarch)
 }
 
-func assertExpectedRustArtifactPlatform(t *testing.T, artifact providermanifestv1.Artifact, goos, goarch, _ string) {
+func assertExpectedRustArtifactPlatform(t *testing.T, artifact providermanifestv1.Artifact, goos, goarch string) {
 	t.Helper()
 	assertArtifactPlatform(t, artifact, goos, goarch)
 }
@@ -3750,29 +3705,29 @@ fi`
 fi`
 }
 
-func providerpkgRustTargetTriple(goos, goarch, _ string) (string, string, error) {
+func providerpkgRustTargetTriple(goos, goarch string) (string, error) {
 	switch goos {
 	case "darwin":
 		switch goarch {
 		case "amd64":
-			return "x86_64-apple-darwin", "", nil
+			return "x86_64-apple-darwin", nil
 		case "arm64":
-			return "aarch64-apple-darwin", "", nil
+			return "aarch64-apple-darwin", nil
 		}
 	case "linux":
 		switch goarch {
 		case "amd64":
-			return "x86_64-unknown-linux-musl", "", nil
+			return "x86_64-unknown-linux-musl", nil
 		case "arm64":
-			return "aarch64-unknown-linux-musl", "", nil
+			return "aarch64-unknown-linux-musl", nil
 		}
 	case "windows":
 		switch goarch {
 		case "amd64":
-			return "x86_64-pc-windows-gnu", "", nil
+			return "x86_64-pc-windows-gnu", nil
 		}
 	}
-	return "", "", fmt.Errorf("unsupported Rust target platform %s/%s", goos, goarch)
+	return "", fmt.Errorf("unsupported Rust target platform %s/%s", goos, goarch)
 }
 
 func shellSingleQuoted(value string) string {

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -123,7 +123,7 @@ func runInit(args []string) error {
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
-	platformFlag := fs.String("platform", "", "additional platforms to verify hashes for (comma-separated os/arch[/libc] or \"all\")")
+	platformFlag := fs.String("platform", "", "additional platforms to verify hashes for (comma-separated os/arch or \"all\")")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -282,7 +282,7 @@ func printInitUsage(w io.Writer) {
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
 	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory")
 	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
-	writeUsageLine(w, "  --platform        Additional platforms to verify (comma-separated os/arch[/libc] or \"all\")")
+	writeUsageLine(w, "  --platform        Additional platforms to verify (comma-separated os/arch or \"all\")")
 }
 
 func printValidateUsage(w io.Writer) {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -130,13 +130,13 @@ func (l *Lifecycle) InitAtPathsWithStatePaths(configPaths []string, state StateP
 
 // InitAtPathWithPlatforms runs init and additionally downloads and hashes
 // archives for the specified extra platforms.
-func (l *Lifecycle) InitAtPathWithPlatforms(configPath, artifactsDir string, platforms []struct{ GOOS, GOARCH, LibC string }) (*Lockfile, error) {
+func (l *Lifecycle) InitAtPathWithPlatforms(configPath, artifactsDir string, platforms []struct{ GOOS, GOARCH string }) (*Lockfile, error) {
 	return l.InitAtPathsWithPlatforms([]string{configPath}, StatePaths{ArtifactsDir: artifactsDir}, platforms)
 }
 
 // InitAtPathsWithPlatforms runs init and additionally downloads and hashes
 // archives for the specified extra platforms.
-func (l *Lifecycle) InitAtPathsWithPlatforms(configPaths []string, state StatePaths, platforms []struct{ GOOS, GOARCH, LibC string }) (*Lockfile, error) {
+func (l *Lifecycle) InitAtPathsWithPlatforms(configPaths []string, state StatePaths, platforms []struct{ GOOS, GOARCH string }) (*Lockfile, error) {
 	lock, cfg, paths, err := l.initAtPaths(configPaths, state)
 	if err != nil {
 		return nil, err
@@ -1489,19 +1489,10 @@ func preparedManifestMatchesLock(entry LockEntry, manifest *providermanifestv1.M
 }
 
 // resolveArchiveForPlatform looks up a LockArchive for the given platform
-// string using a fallback chain: exact match → without libc → generic.
+// string using a fallback chain: exact match → generic.
 func resolveArchiveForPlatform(entry LockEntry, platform string) (LockArchive, string, bool) {
 	if a, ok := entry.Archives[platform]; ok {
 		return a, platform, true
-	}
-	goos, goarch, err := providerpkg.ParsePlatformString(platform)
-	if err == nil {
-		key := providerpkg.PlatformString(goos, goarch)
-		if key != platform {
-			if a, ok := entry.Archives[key]; ok {
-				return a, key, true
-			}
-		}
 	}
 	if a, ok := entry.Archives[platformKeyGeneric]; ok {
 		return a, platformKeyGeneric, true
@@ -2707,7 +2698,7 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initP
 	return nil
 }
 
-func (l *Lifecycle) downloadPlatformArchives(ctx context.Context, lock *Lockfile, paths initPaths, platforms []struct{ GOOS, GOARCH, LibC string }, tokenForSource map[string]string) error {
+func (l *Lifecycle) downloadPlatformArchives(ctx context.Context, lock *Lockfile, paths initPaths, platforms []struct{ GOOS, GOARCH string }, tokenForSource map[string]string) error {
 	for _, plat := range platforms {
 		platformKey := providerpkg.PlatformString(plat.GOOS, plat.GOARCH)
 		if err := l.hashPlatformInEntries(ctx, lock, paths, platformKey, tokenForSource); err != nil {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -602,7 +602,7 @@ func TestSourcePluginMetadataURLInitAndLockedLoad(t *testing.T) {
 			}
 
 			lc := NewLifecycle()
-			lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{
+			lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH string }{
 				{GOOS: extraPlatform.goos, GOARCH: extraPlatform.goarch},
 			})
 			if err == nil {
@@ -2789,9 +2789,9 @@ func TestManagedCacheSourcesInitAtPathWithPlatformsHashesExtraPlatformArchives(t
 			cacheSource := "github.com/acme/tools/cache-session"
 			version := "1.0.0"
 
-			extraPlatform := struct{ GOOS, GOARCH, LibC string }{GOOS: "linux", GOARCH: "amd64"}
+			extraPlatform := struct{ GOOS, GOARCH string }{GOOS: "linux", GOARCH: "amd64"}
 			if runtime.GOOS == extraPlatform.GOOS && runtime.GOARCH == extraPlatform.GOARCH {
-				extraPlatform = struct{ GOOS, GOARCH, LibC string }{GOOS: "darwin", GOARCH: "arm64"}
+				extraPlatform = struct{ GOOS, GOARCH string }{GOOS: "darwin", GOARCH: "arm64"}
 			}
 			extraPlatformKey := providerpkg.PlatformString(extraPlatform.GOOS, extraPlatform.GOARCH)
 			currentArchivePath := buildExecutableArchive(t, dir, "cache-src", cacheSource, version, providermanifestv1.KindCache, "cache-plugin", "fake-cache-binary")
@@ -2918,7 +2918,7 @@ func TestManagedCacheSourcesInitAtPathWithPlatformsHashesExtraPlatformArchives(t
 			if client != nil {
 				lc = lc.WithHTTPClient(client)
 			}
-			lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{extraPlatform})
+			lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH string }{extraPlatform})
 			if err != nil {
 				t.Fatalf("InitAtPathWithPlatforms: %v", err)
 			}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3691,7 +3691,7 @@ func TestResolveArchiveForPlatform(t *testing.T) {
 		wantOK   bool
 	}{
 		{"exact match", "darwin/arm64", "https://example.com/darwin-arm64", true},
-		{"fallback without libc", "linux/amd64", "https://example.com/linux-amd64", true},
+		{"linux match", "linux/amd64", "https://example.com/linux-amd64", true},
 		{"no match falls to generic", "windows/amd64", "https://example.com/generic", true},
 	}
 	for _, tt := range tests {

--- a/gestaltd/internal/providerpkg/platform.go
+++ b/gestaltd/internal/providerpkg/platform.go
@@ -21,22 +21,13 @@ func CurrentPlatformString() string {
 }
 
 // ParsePlatformString parses "darwin/arm64" or "linux/amd64" into (goos, goarch).
-// A trailing third component (e.g. "linux/amd64/musl") is accepted and ignored
-// for backwards compatibility with older platform strings.
 func ParsePlatformString(s string) (goos, goarch string, err error) {
 	parts := strings.Split(s, "/")
-	switch len(parts) {
-	case 2:
-		if parts[0] == "" || parts[1] == "" {
-			return "", "", fmt.Errorf("invalid platform string %q: empty component", s)
-		}
-		return parts[0], parts[1], nil
-	case 3:
-		if parts[0] == "" || parts[1] == "" {
-			return "", "", fmt.Errorf("invalid platform string %q: empty component", s)
-		}
-		return parts[0], parts[1], nil
-	default:
+	if len(parts) != 2 {
 		return "", "", fmt.Errorf("invalid platform string %q: expected os/arch", s)
 	}
+	if parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid platform string %q: empty component", s)
+	}
+	return parts[0], parts[1], nil
 }

--- a/gestaltd/internal/providerpkg/platform_test.go
+++ b/gestaltd/internal/providerpkg/platform_test.go
@@ -16,17 +16,6 @@ func TestParsePlatformString_TwoComponents(t *testing.T) {
 	}
 }
 
-func TestParsePlatformString_ThreeComponentsIgnoresLibC(t *testing.T) {
-	t.Parallel()
-	goos, goarch, err := ParsePlatformString("linux/amd64/musl")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if goos != "linux" || goarch != "amd64" {
-		t.Fatalf("got (%q, %q), want (linux, amd64)", goos, goarch)
-	}
-}
-
 func TestParsePlatformString_RoundTrip(t *testing.T) {
 	t.Parallel()
 	for _, input := range []string{"darwin/arm64", "linux/amd64", "windows/amd64"} {
@@ -43,7 +32,7 @@ func TestParsePlatformString_RoundTrip(t *testing.T) {
 
 func TestParsePlatformString_RejectsInvalid(t *testing.T) {
 	t.Parallel()
-	for _, input := range []string{"", "darwin", "a/b/c/d", "/arm64", "darwin/"} {
+	for _, input := range []string{"", "darwin", "linux/amd64/musl", "a/b/c/d", "/arm64", "darwin/"} {
 		_, _, err := ParsePlatformString(input)
 		if err == nil {
 			t.Errorf("ParsePlatformString(%q) should fail", input)


### PR DESCRIPTION
## Summary
- Require provider release and lock platform keys to use the canonical `os/arch` form.
- Remove the `os/arch/libc` parser compatibility path and archive fallback from `resolveArchiveForPlatform`.
- Drop the ignored `LibC` field from the internal init platform contract.
- Delete the release test that only existed to prove `linux/amd64/musl` worked.

## Interface / Contract Diff
```diff
- ParsePlatformString("linux/amd64/musl") => ("linux", "amd64", nil)
+ ParsePlatformString("linux/amd64/musl") => error

- InitAtPathsWithPlatforms(configPaths, state, []struct{ GOOS, GOARCH, LibC string }{...})
+ InitAtPathsWithPlatforms(configPaths, state, []struct{ GOOS, GOARCH string }{...})

- resolveArchiveForPlatform: exact platform -> os/arch fallback -> generic
+ resolveArchiveForPlatform: exact platform -> generic

- gestaltd provider release --platform os/arch[/libc]
+ gestaltd provider release --platform os/arch

- gestaltd init --platform os/arch[/libc]
+ gestaltd init --platform os/arch
```

## Examples
```bash
# Valid
gestaltd provider release --version 1.2.3 --platform darwin/arm64
gestaltd provider release --version 1.2.3 --platform linux/amd64

# Invalid
gestaltd provider release --version 1.2.3 --platform linux/amd64/musl

# Lock archive fallback still supports generic archives
archives:
  generic:
    url: https://example.com/provider.tar.gz
```

## Verification
- `git diff --check`
- `GOCACHE=$PWD/../.gocache TMPDIR=$PWD/../.tmp go test ./internal/providerpkg -run 'Test(ParsePlatformString|CurrentPlatformString)'`
- `GOCACHE=$PWD/../.gocache TMPDIR=$PWD/../.tmp go test ./internal/operator -run 'TestResolveArchiveForPlatform|TestSourcePluginMetadataURLInitAndLockedLoad|TestManagedCacheSourcesInitAtPathWithPlatformsHashesExtraPlatformArchives'`
- `GOCACHE=$PWD/../.gocache TMPDIR=$PWD/../.tmp go test ./cmd/gestaltd -run TestRun_ProviderReleaseBuildsRustSourcePluginForCurrentPlatform`