### PR TITLE
Use source slugs for provider-dev UI mounts

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -793,6 +793,12 @@ that owned UI automatically. For the common `plugin/` + sibling `ui/` layout,
 the local commands also detect `../ui/manifest.yaml` and wire it in
 automatically during local development.
 
+When no config file supplies an explicit `plugins.<name>.ui.path`, the inferred
+local UI path comes from the manifest `source` slug. For example,
+`github.com/acme/tools/plugins/vm-style-guide` mounts at `/vm-style-guide`.
+The plugin key remains API-safe, so the same plugin may still be addressed as
+`vm_style_guide` in local integration APIs.
+
 Validate the plugin in isolation:
 
 ```sh

--- a/docs/content/custom-providers/ui.mdx
+++ b/docs/content/custom-providers/ui.mdx
@@ -22,6 +22,14 @@ When the UI is part of a `plugin/` + sibling `ui/` package layout, running
 `gestaltd provider dev` from the plugin side also picks up that sibling UI
 automatically for the local session.
 
+Without an explicit config mount, the local UI path is derived from the
+manifest `source` slug. A UI source ending in `vm-style-guide` is served at
+`/vm-style-guide`, which lets bundles that contain absolute asset URLs work in
+the config-free local loop. When developing a UI bundle directly, configured
+`providers.ui.<name>.path` values still take precedence. When developing from a
+plugin with owned or sibling UI, configure `plugins.<name>.ui.path` to override
+the inferred mount.
+
 A UI bundle is not a plugin in the executable sense. It contains no server-side
 code. Gestalt simply serves the static files from the asset root directory. The
 bundle talks to Gestalt through the same HTTP API and MCP endpoints that any

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -43,6 +43,14 @@ import { Callout } from 'nextra/components'
 | `gestaltd provider release --version VERSION` | Build and package a provider release. Go, Python, Rust, and TypeScript source plugins default to the host platform. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
 | `gestaltd provider release --output DIR` | Output directory for the release archive. Defaults to `dist/`. |
 
+For config-free local development, inferred UI mount paths use the manifest
+`source` slug rather than the API-safe provider key. A source ending in
+`vm-style-guide` mounts at `/vm-style-guide`, while the local integration key
+may still be `vm_style_guide`. Explicit `plugins.<name>.ui.path` values take
+precedence for plugin-owned or sibling UI, and explicit
+`providers.ui.<name>.path` values take precedence when developing a UI bundle
+directly.
+
 ## Examples
 
 ```sh

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -394,6 +394,7 @@ func TestE2EProviderValidateSourceUI(t *testing.T) {
 	dir := t.TempDir()
 	providersDir := setupDefaultLocalProvidersDir(t, dir)
 	mountedUI := setupMountedUIDir(t, dir)
+	setUIManifestSource(t, mountedUI.ManifestPath, "github.com/test/ui/roadmap.review")
 
 	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", mountedUI.ManifestPath)
 	cmd.Env = append(os.Environ(),
@@ -409,6 +410,9 @@ func TestE2EProviderValidateSourceUI(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "ui=roadmap_review") {
 		t.Fatalf("expected ui validation summary, got: %s", out)
+	}
+	if !strings.Contains(string(out), "mounted_ui_paths=[/roadmap.review]") {
+		t.Fatalf("expected source-slug ui mount path in output, got: %s", out)
 	}
 }
 
@@ -1033,6 +1037,29 @@ func setupPluginDirWithVersion(t *testing.T, baseDir, version string) string {
 	}
 	writeManifestFile(t, pluginDir, manifest)
 	return pluginDir
+}
+
+func setPluginManifestSource(t *testing.T, pluginDir, source string) {
+	t.Helper()
+
+	manifestPath := componentProviderManifestPath(t, pluginDir)
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile(%s): %v", manifestPath, err)
+	}
+	manifest.Source = source
+	writeManifestFile(t, pluginDir, manifest)
+}
+
+func setUIManifestSource(t *testing.T, manifestPath, source string) {
+	t.Helper()
+
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile(%s): %v", manifestPath, err)
+	}
+	manifest.Source = source
+	writeManifestFile(t, filepath.Dir(manifestPath), manifest)
 }
 
 func setupAuthProviderDir(t *testing.T, baseDir, name string) string {
@@ -2086,6 +2113,7 @@ func TestE2EProviderDevServesSourceUI(t *testing.T) {
 	dir := t.TempDir()
 	providersDir := setupDefaultLocalProvidersDir(t, dir)
 	mountedUI := setupMountedUIDir(t, dir)
+	setUIManifestSource(t, mountedUI.ManifestPath, "github.com/test/ui/roadmap.review")
 	port, holder := reservePort(t)
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 	_ = holder.Close()
@@ -2098,7 +2126,7 @@ func TestE2EProviderDevServesSourceUI(t *testing.T) {
 	startCommandAndWaitReady(t, cmd, baseURL)
 
 	client := &http.Client{Timeout: 2 * time.Second}
-	_ = waitForHTTPBody(t, client, baseURL+"/roadmap_review/sync", "Roadmap Review UI")
+	_ = waitForHTTPBody(t, client, baseURL+"/roadmap.review/sync", "Roadmap Review UI")
 }
 
 func TestE2EProviderDevAutoMountsSiblingUIForPlugin(t *testing.T) {
@@ -2112,6 +2140,7 @@ func TestE2EProviderDevAutoMountsSiblingUIForPlugin(t *testing.T) {
 	providersDir := setupDefaultLocalProvidersDir(t, dir)
 	rootDir := filepath.Join(dir, "package")
 	pluginDir := setupPluginDir(t, filepath.Join(rootDir, "plugin"))
+	setPluginManifestSource(t, pluginDir, "github.com/test/plugins/vm-style-guide")
 	_ = setupMountedUIDirAt(t, filepath.Join(rootDir, "ui"), nil)
 	port, holder := reservePort(t)
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
@@ -2125,7 +2154,8 @@ func TestE2EProviderDevAutoMountsSiblingUIForPlugin(t *testing.T) {
 	startCommandAndWaitReady(t, cmd, baseURL)
 
 	client := &http.Client{Timeout: 2 * time.Second}
-	_ = waitForHTTPBody(t, client, baseURL+"/provider/sync", "Roadmap Review UI")
+	_ = waitForHTTPBody(t, client, baseURL+"/vm-style-guide/sync", "Roadmap Review UI")
+	_ = waitForHTTPBody(t, client, baseURL+"/vm-style-guide/assets/app.js", "ready")
 }
 
 //nolint:paralleltest // Uses the default 8080 startup path intentionally.

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -615,7 +615,7 @@ func preparePluginLocalSession(sessionDir, baseConfigPath string, state operator
 	}
 	switch {
 	case shouldAutoMountOwnedUI(loadedCfg, resolvedKey, manifest):
-		autoMountPath = "/" + resolvedKey
+		autoMountPath = defaultProviderLocalMountPath(manifest, targetManifestPath, resolvedKey)
 		if err := ensureNoPublicUIPathCollision(loadedCfg, resolvedKey, autoMountPath); err != nil {
 			return nil, err
 		}
@@ -632,7 +632,7 @@ func preparePluginLocalSession(sessionDir, baseConfigPath string, state operator
 			uiName = resolvedKey
 		}
 		if autoMountPath == "" {
-			autoMountPath = "/" + resolvedKey
+			autoMountPath = defaultProviderLocalMountPath(manifest, targetManifestPath, resolvedKey)
 			if err := ensureNoPublicUIPathCollision(loadedCfg, resolvedKey, autoMountPath); err != nil {
 				return nil, err
 			}
@@ -674,7 +674,7 @@ func prepareUILocalSession(sessionDir, baseConfigPath string, state operator.Sta
 		return nil, err
 	}
 
-	autoMountPath := "/" + resolvedKey
+	autoMountPath := defaultProviderLocalMountPath(manifest, targetManifestPath, resolvedKey)
 	if configuredUIs, err := loadConfiguredUIs(opts.ConfigPaths); err == nil {
 		if entry := configuredUIs[resolvedKey]; entry != nil && strings.TrimSpace(entry.Path) != "" {
 			autoMountPath = strings.TrimSpace(entry.Path)
@@ -1450,6 +1450,56 @@ func sanitizeDerivedPluginKey(value string) string {
 		}
 	}
 	return strings.Trim(b.String(), "_")
+}
+
+func defaultProviderLocalMountPath(manifest *providermanifestv1.Manifest, manifestPath, fallbackKey string) string {
+	if slug := derivedProviderLocalMountSlug(manifest, manifestPath); slug != "" {
+		return "/" + slug
+	}
+	if slug := sanitizeProviderLocalMountSlug(fallbackKey); slug != "" {
+		return "/" + slug
+	}
+	return "/" + fallbackKey
+}
+
+func derivedProviderLocalMountSlug(manifest *providermanifestv1.Manifest, manifestPath string) string {
+	if manifest != nil {
+		if src, err := pluginsource.Parse(manifest.Source); err == nil {
+			if slug := strings.TrimSpace(src.PluginName()); slug != "" {
+				return slug
+			}
+		}
+	}
+	return sanitizeProviderLocalMountSlug(filepath.Base(filepath.Dir(manifestPath)))
+}
+
+func sanitizeProviderLocalMountSlug(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	var b strings.Builder
+	previousSeparator := false
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+			previousSeparator = false
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			previousSeparator = false
+		case r == '-' || r == '_' || r == '.':
+			if previousSeparator || b.Len() == 0 {
+				continue
+			}
+			b.WriteRune(r)
+			previousSeparator = true
+		default:
+			if previousSeparator || b.Len() == 0 {
+				continue
+			}
+			b.WriteByte('-')
+			previousSeparator = true
+		}
+	}
+	return strings.Trim(b.String(), "-_.")
 }
 
 func isValidExplicitPluginKey(value string) bool {


### PR DESCRIPTION
## Summary
- Dogfooding `gestaltd provider dev --path /Users/hugh/src/toolshed/valon-tools/deploy/vm-style-guide/plugin` showed that config-free local dev mounted the sibling UI at `/vm_style_guide`, while the UI bundle referenced absolute assets under `/vm-style-guide`.
- Keep local provider keys API-safe, but derive inferred browser-facing UI mount paths from the manifest `source` slug so hyphenated UI bundles work without a config overlay.
- Document the source-slug mount behavior and keep configured `plugins.<name>.ui.path` / `providers.ui.<name>.path` values as the explicit override.

## Interface change
Config-free provider-local UI mount inference now uses the manifest source slug for the URL path.

```sh
gestaltd provider dev --path ./vm-style-guide/plugin
```

Now serves the sibling UI at:

```text
/vm-style-guide
```

The provider key remains API-safe:

```http
GET /api/v1/vm_style_guide/get_site_metadata
```

Explicit config still wins:

```yaml
plugins:
  vmStyleGuide:
    ui:
      path: /custom-style-guide
```

## Dogfood
From latest `origin/main` before this fix:

```sh
/tmp/gestaltd-dogfood provider dev --remote https://valon.tools --path /Users/hugh/src/toolshed/valon-tools/deploy/vm-style-guide/plugin
```

Result: remote attach reached `valon.tools`, but the server returned `403 {"error":"provider dev remote attach is disabled"}`. That is an operational/config gate, not a CLI transport failure.

Local dogfood before this fix:

```sh
/tmp/gestaltd-dogfood provider dev --path /Users/hugh/src/toolshed/valon-tools/deploy/vm-style-guide/plugin
curl http://127.0.0.1:<port>/vm_style_guide/
curl http://127.0.0.1:<port>/vm-style-guide/assets/fonts.css
```

Result: HTML returned 200 from `/vm_style_guide/`, but the bundle's absolute asset URL `/vm-style-guide/assets/fonts.css` returned 404.

Local dogfood after this fix:

```sh
/tmp/gestaltd-dogfood-fixed provider dev --path /Users/hugh/src/toolshed/valon-tools/deploy/vm-style-guide/plugin
curl http://127.0.0.1:53013/vm-style-guide/
curl http://127.0.0.1:53013/vm-style-guide/assets/fonts.css
curl http://127.0.0.1:53013/api/v1/integrations
curl http://127.0.0.1:53013/api/v1/vm_style_guide/get_site_metadata
```

Result: all returned 200. `/api/v1/integrations` reported `mountedPath: /vm-style-guide`, while the provider API remained `vm_style_guide`.

## Validation
- `go test -count=1 -parallel=1 ./cmd/gestaltd -run 'TestE2EProviderValidateSourceUI|TestE2EProviderDevServesSourceUI|TestE2EProviderDevAutoMountsSiblingUIForPlugin|TestE2EProviderDevAutoMountsOwnedUI'`
- `golangci-lint run --allow-parallel-runners ./cmd/gestaltd`
- `npm run typecheck` in `docs/`
- `npm run build` in `docs/`
- `git diff --check HEAD~1..HEAD`

Note: a full local `go test -count=1 ./cmd/gestaltd` attempt hit unrelated e2e readiness timeouts while other worktree tests were running. The focused e2e set for this behavior passes consistently with `-parallel=1`.