### PR TITLE
cli: bump gestalt release to alpha.11

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.1-alpha.10"
+version = "0.0.1-alpha.11"
 edition = "2024"


### PR DESCRIPTION
## Summary
- Bump the Gestalt CLI workspace version from `0.0.1-alpha.10` to `0.0.1-alpha.11`.
- Prepares the repository for the matching release tag `gestalt/v0.0.1-alpha.11`.

## Interfaces
Rust package metadata:
```toml
[workspace.package]
version = "0.0.1-alpha.11"
```

Release/tag contract:
```bash
git tag gestalt/v0.0.1-alpha.11
git push origin gestalt/v0.0.1-alpha.11
```

The release workflow verifies:
```bash
cargo metadata --format-version 1 --no-deps \
  | jq -r '.packages[] | select(.name=="gestalt") | .version'
# 0.0.1-alpha.11
```

## Usage after release
```bash
brew upgrade valon-technologies/gestalt/gestalt
GESTALT_URL=https://valon.tools gestalt agent --provider simple --model gpt-5.5
```

Resume remains:
```bash
GESTALT_URL=https://valon.tools gestalt agent resume <session-id>
```

## Verification
```bash
cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name=="gestalt") | .version'
cargo test --manifest-path gestalt/Cargo.toml -p gestalt --test agents_cli
git diff --check
```