### PR TITLE
Add typed integration connection status contract

### DIFF
--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -148,7 +148,10 @@ fn execute(
 }
 
 fn should_retry_without_catalog(err: &anyhow::Error, operation: &str) -> bool {
-    !operation.is_empty() && connect_error_kind(err).is_some()
+    matches!(
+        connect_error_kind(err),
+        Some(ConnectErrorKind::NotConnected | ConnectErrorKind::ReconnectRequired)
+    ) && !operation.is_empty()
 }
 
 fn display_operations<'a>(
@@ -217,6 +220,14 @@ fn rewrite_connect_error(
             plugin,
             connect_command,
         ),
+        Some(ConnectErrorKind::AdminConfigurationRequired) => anyhow::anyhow!(
+            "plugin {:?} requires deployment/admin configuration before it can be invoked",
+            plugin,
+        ),
+        Some(ConnectErrorKind::InstanceSelectionRequired) => anyhow::anyhow!(
+            "plugin {:?} has multiple connected instances. Pass --instance to choose one",
+            plugin,
+        ),
         None => err,
     }
 }
@@ -245,6 +256,8 @@ fn invoke_target(plugin: &str, operation: &str) -> String {
 enum ConnectErrorKind {
     NotConnected,
     ReconnectRequired,
+    AdminConfigurationRequired,
+    InstanceSelectionRequired,
 }
 
 fn connect_error_kind(err: &anyhow::Error) -> Option<ConnectErrorKind> {
@@ -253,6 +266,12 @@ fn connect_error_kind(err: &anyhow::Error) -> Option<ConnectErrorKind> {
             match api_error.code() {
                 Some("not_connected") => return Some(ConnectErrorKind::NotConnected),
                 Some("reconnect_required") => return Some(ConnectErrorKind::ReconnectRequired),
+                Some("admin_configuration_required") => {
+                    return Some(ConnectErrorKind::AdminConfigurationRequired);
+                }
+                Some("instance_selection_required") => {
+                    return Some(ConnectErrorKind::InstanceSelectionRequired);
+                }
                 _ => {}
             }
         }
@@ -266,6 +285,14 @@ fn connect_error_kind(err: &anyhow::Error) -> Option<ConnectErrorKind> {
         }
         if message.contains("expired or was revoked") {
             return Some(ConnectErrorKind::ReconnectRequired);
+        }
+        if message.contains("deployment/admin configuration")
+            || message.contains("deployment credential configured")
+        {
+            return Some(ConnectErrorKind::AdminConfigurationRequired);
+        }
+        if message.contains("specify which instance") || message.contains("Pass --instance") {
+            return Some(ConnectErrorKind::InstanceSelectionRequired);
         }
     }
     None

--- a/gestalt/cli/src/commands/plugins.rs
+++ b/gestalt/cli/src/commands/plugins.rs
@@ -58,21 +58,58 @@ pub fn list(client: &ApiClient, format: Format) -> Result<()> {
                 .unwrap_or(&Vec::new())
                 .iter()
                 .map(|item| {
-                    let connected = match item["connected"].as_bool() {
-                        Some(true) => "yes",
-                        _ => "no",
-                    };
                     vec![
                         item["name"].as_str().unwrap_or("-").to_string(),
                         item["description"].as_str().unwrap_or("-").to_string(),
-                        connected.into(),
+                        plugin_status(item),
+                        plugin_connections(item),
                     ]
                 })
                 .collect();
-            output::print_table(&["Name", "Description", "Connected"], &rows);
+            output::print_table(&["Name", "Description", "Status", "Connections"], &rows);
         }
     }
     Ok(())
+}
+
+fn plugin_status(item: &serde_json::Value) -> String {
+    item["status"]
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| match item["connected"].as_bool() {
+            Some(true) => "ready".to_string(),
+            _ => "needs_user_connection".to_string(),
+        })
+}
+
+fn plugin_connections(item: &serde_json::Value) -> String {
+    if let Some(connections) = item["connections"]
+        .as_array()
+        .filter(|connections| !connections.is_empty())
+    {
+        return connections
+            .iter()
+            .map(|connection| {
+                let name = connection["name"].as_str().unwrap_or("-");
+                let status = connection["status"]
+                    .as_str()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| match connection["connected"].as_bool() {
+                        Some(true) => "ready".to_string(),
+                        _ => "needs_user_connection".to_string(),
+                    });
+                format!("{name}: {status}")
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+    }
+
+    let instance_count = item["instances"].as_array().map(Vec::len).unwrap_or(0);
+    match instance_count {
+        0 => "-".to_string(),
+        1 => "1 instance".to_string(),
+        n => format!("{n} instances"),
+    }
 }
 
 pub fn disconnect(

--- a/gestalt/cli/src/commands/plugins/connect.rs
+++ b/gestalt/cli/src/commands/plugins/connect.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::api::ApiClient;
+use crate::api::{ApiClient, ApiError};
 use crate::interactive::{InputPrompt, PromptOption, prompt_input, prompt_select};
 use crate::output;
 
@@ -25,6 +25,8 @@ struct IntegrationInfo {
     connections: Vec<ConnectionDefInfo>,
     #[serde(default)]
     credential_fields: Vec<CredentialFieldInfo>,
+    #[serde(default)]
+    status: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -37,6 +39,10 @@ struct ConnectionDefInfo {
     auth_types: Vec<String>,
     #[serde(default)]
     credential_fields: Vec<CredentialFieldInfo>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    credential_mode: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -168,6 +174,7 @@ impl<'a> ResolvedConnectFlow<'a> {
             .filter(|connection| !connection.credential_fields.is_empty())
             .map(|connection| connection.credential_fields.as_slice())
             .unwrap_or(integration.credential_fields.as_slice());
+        validate_user_connectable(integration, connection.as_ref())?;
 
         Ok(Self {
             integration,
@@ -296,6 +303,7 @@ where
                 connection_params: connection_params.as_ref(),
             },
         )
+        .map_err(rewrite_connect_api_error)
         .context("failed to start OAuth flow")?;
     let url = resp["url"]
         .as_str()
@@ -341,6 +349,7 @@ fn connect_manual(
                     connection_params: connection_params.as_ref(),
                 },
             )
+            .map_err(rewrite_connect_api_error)
             .context("failed to connect plugin")?,
     )
     .context("failed to parse manual connect response")?;
@@ -497,6 +506,61 @@ fn resolve_connect_mode(integration: &str, auth_types: &[String]) -> Result<Conn
         "plugin '{}' does not expose a supported connection flow in the CLI",
         integration
     );
+}
+
+fn validate_user_connectable(
+    integration: &IntegrationInfo,
+    connection: Option<&ResolvedConnection<'_>>,
+) -> Result<()> {
+    if let Some(definition) = connection.and_then(|selected| selected.definition) {
+        match definition.credential_mode.as_deref() {
+            Some("none") => bail!(
+                "plugin '{}' connection '{}' does not require a user connection",
+                integration.name,
+                definition.display_name()
+            ),
+            Some("platform")
+                if definition.status.as_deref() == Some("needs_admin_configuration") =>
+            {
+                bail!(
+                    "plugin '{}' connection '{}' requires deployment/admin configuration",
+                    integration.name,
+                    definition.display_name()
+                )
+            }
+            Some("platform") => bail!(
+                "plugin '{}' connection '{}' is managed by deployment/admin configuration and cannot be connected by a user",
+                integration.name,
+                definition.display_name()
+            ),
+            _ => {}
+        }
+    } else if integration.status.as_deref() == Some("needs_admin_configuration") {
+        bail!(
+            "plugin '{}' requires deployment/admin configuration before users can connect it",
+            integration.name
+        );
+    }
+    Ok(())
+}
+
+fn rewrite_connect_api_error(err: anyhow::Error) -> anyhow::Error {
+    for cause in err.chain() {
+        if let Some(api_error) = cause.downcast_ref::<ApiError>() {
+            match api_error.code() {
+                Some("admin_configuration_required") => {
+                    return anyhow::anyhow!("deployment/admin configuration is required");
+                }
+                Some("instance_selection_required") => {
+                    return anyhow::anyhow!(
+                        "multiple connected instances exist; pass --instance to choose one"
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+    err
 }
 
 fn prompt_connection_params(

--- a/gestalt/cli/tests/invoke_contract.rs
+++ b/gestalt/cli/tests/invoke_contract.rs
@@ -90,6 +90,105 @@ fn test_invoke_reconnect_error_suggests_reconnect_command() {
 }
 
 #[test]
+fn test_invoke_admin_configuration_error_uses_admin_copy() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/platform_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(single_operation_catalog("run"))
+    .create();
+
+    let _invoke_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/platform_svc/run",
+        StatusCode::PRECONDITION_FAILED
+    )
+    .with_body(r#"{"error":"deployment/admin configuration is required for integration \"platform_svc\"","code":"admin_configuration_required","integration":"platform_svc"}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args(["plugin", "invoke", "platform_svc", "run"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "plugin \"platform_svc\" requires deployment/admin configuration before it can be invoked",
+        ))
+        .stderr(predicate::str::contains("gestalt plugin connect").not());
+}
+
+#[test]
+fn test_invoke_instance_selection_error_suggests_instance_flag() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/slack/operations",
+        StatusCode::OK
+    )
+    .with_body(single_operation_catalog("channels"))
+    .create();
+
+    let _invoke_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/slack/channels",
+        StatusCode::CONFLICT
+    )
+    .with_body(r#"{"error":"ambiguous instance: integration \"slack\" has 2 connections ([team-a team-b]); specify which instance to use with the \"_instance\" parameter","code":"instance_selection_required","integration":"slack"}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args(["plugin", "invoke", "slack", "channels"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "plugin \"slack\" has multiple connected instances. Pass --instance to choose one",
+        ))
+        .stderr(predicate::str::contains("gestalt plugin connect").not());
+}
+
+#[test]
+fn test_invoke_error_with_instance_action_name_keeps_original_error() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/slack/operations",
+        StatusCode::OK
+    )
+    .with_body(single_operation_catalog("status"))
+    .create();
+
+    let _invoke_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/slack/status",
+        StatusCode::PRECONDITION_FAILED
+    )
+    .with_body(r#"{"error":"action select_instance is unavailable for this connection"}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args(["plugin", "invoke", "slack", "status"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "action select_instance is unavailable for this connection",
+        ))
+        .stderr(predicate::str::contains("multiple connected instances").not());
+}
+
+#[test]
 fn test_catalog_reconnect_error_suggests_reconnect_command() {
     let mut server = Server::new();
     let home = TempDir::new().unwrap();

--- a/gestalt/cli/tests/plugins_connect.rs
+++ b/gestalt/cli/tests/plugins_connect.rs
@@ -136,6 +136,41 @@ fn test_connect_uses_defined_plugin_connection_name_on_the_wire() {
 }
 
 #[test]
+fn test_connect_platform_connection_uses_admin_copy_without_starting_flow() {
+    let mut server = Server::new();
+    let _integrations =
+        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+            .with_body(
+                r#"[{
+                "name":"platform_svc",
+                "status":"needs_admin_configuration",
+                "connections":[{
+                    "name":"plugin",
+                    "displayName":"Plugin",
+                    "authTypes":[],
+                    "status":"needs_admin_configuration",
+                    "credentialMode":"platform"
+                }]
+            }]"#,
+            )
+            .create();
+
+    let client = create_client(&server);
+    let err = gestalt::commands::plugins::connect_with_browser_opener(
+        &client,
+        "platform_svc",
+        Some("plugin"),
+        None,
+        |_| Ok(()),
+    )
+    .unwrap_err();
+    let message = format!("{err:#}");
+
+    assert!(message.contains("requires deployment/admin configuration"));
+    assert!(!message.contains("OAuth"));
+}
+
+#[test]
 fn test_connect_preserves_requested_plugin_connection_when_no_definitions_exist() {
     let mut server = Server::new();
     let _integrations =
@@ -563,7 +598,7 @@ fn test_cli_plugins_list_table_output() {
     );
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
         .with_body(
-            r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","connected":true}]"#,
+            r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","connected":true,"status":"ready","connections":[{"name":"workspace","status":"ready"}]}]"#,
         )
         .create();
 
@@ -573,11 +608,10 @@ fn test_cli_plugins_list_table_output() {
         .success()
         .stdout(predicate::str::contains("ACME_CRM").or(predicate::str::contains("acme_crm")))
         .stdout(predicate::str::contains("Acme CRM plugin"))
-        .stdout(
-            predicate::str::contains("Connected")
-                .or(predicate::str::contains("CONNECTED"))
-                .or(predicate::str::contains("connected")),
-        );
+        .stdout(predicate::str::contains("Status"))
+        .stdout(predicate::str::contains("Connections"))
+        .stdout(predicate::str::contains("ready"))
+        .stdout(predicate::str::contains("workspace: ready"));
 
     mock.assert();
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -2747,7 +2747,7 @@ func TestE2ELockSyncPluginOwnedUI(t *testing.T) {
 	}
 
 	cfgPath := filepath.Join(dir, "config-owned-ui-lock-sync.yaml")
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   public:
     port: 0

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -88,7 +88,13 @@ func BuildConnectionRuntime(cfg *config.Config) (invocation.ConnectionRuntimeMap
 }
 
 func connectionRuntimeInfo(integration, connection string, conn *config.ConnectionDef) (invocation.ConnectionRuntimeInfo, error) {
-	mode := config.ConnectionModeForConnection(*conn)
+	return StaticConnectionRuntimeInfo(integration, connection, *conn)
+}
+
+// StaticConnectionRuntimeInfo validates and materializes deployment-owned
+// connection material using the same rules as invocation bootstrap.
+func StaticConnectionRuntimeInfo(integration, connection string, conn config.ConnectionDef) (invocation.ConnectionRuntimeInfo, error) {
+	mode := config.ConnectionModeForConnection(conn)
 	info := invocation.ConnectionRuntimeInfo{Mode: mode}
 	if mode != core.ConnectionModePlatform {
 		return info, nil

--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -1,0 +1,377 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+const (
+	connectionStatusReady                   = "ready"
+	connectionStatusDegraded                = "degraded"
+	connectionStatusNeedsUserConnection     = "needs_user_connection"
+	connectionStatusNeedsInstanceSelection  = "needs_instance_selection"
+	connectionStatusNeedsAdminConfiguration = "needs_admin_configuration"
+	connectionStatusUnavailable             = "unavailable"
+	connectionStatusUnknown                 = "unknown"
+
+	credentialStateNotRequired = "not_required"
+	credentialStateConnected   = "connected"
+	credentialStateConfigured  = "configured"
+	credentialStateMissing     = "missing"
+	credentialStateInvalid     = "invalid"
+	credentialStateUnknown     = "unknown"
+
+	healthStateHealthy       = "healthy"
+	healthStateUnhealthy     = "unhealthy"
+	healthStateNotChecked    = "not_checked"
+	healthStateNotApplicable = "not_applicable"
+	healthStateUnknown       = "unknown"
+
+	actionConnect        = "connect"
+	actionDisconnect     = "disconnect"
+	actionAddInstance    = "add_instance"
+	actionSelectInstance = "select_instance"
+	actionReconnect      = "reconnect"
+	actionAdminConfigure = "admin_configure"
+
+	credentialModeNone     = "none"
+	credentialModeSubject  = "subject"
+	credentialModePlatform = "platform"
+
+	ownerKindNone            = "none"
+	ownerKindCurrentUser     = "current_user"
+	ownerKindManagedIdentity = "managed_identity"
+	ownerKindServiceAccount  = "service_account"
+	ownerKindPlatform        = "platform"
+	ownerKindUnknown         = "unknown"
+)
+
+func (s *Server) applyIntegrationConnectionStatus(info *integrationInfo, prov core.Provider, instances []instanceInfo, p *principal.Principal) {
+	status := s.defaultIntegrationStatus(info, prov, instances, p)
+	info.Status = status.Status
+	info.CredentialState = status.CredentialState
+	info.HealthState = status.HealthState
+	info.Actions = status.Actions
+	info.Connected = status.Connected
+}
+
+func (s *Server) defaultIntegrationStatus(info *integrationInfo, prov core.Provider, instances []instanceInfo, p *principal.Principal) connectionStatusInfo {
+	if info == nil {
+		return unknownConnectionStatus()
+	}
+	if conn, ok := info.connectionStatusForDefaultTarget(s.defaultConnectionName(info.Name)); ok {
+		return statusFromConnectionInfo(conn)
+	}
+	if conn, ok := info.singleConnectionStatus(); ok {
+		return statusFromConnectionInfo(conn)
+	}
+	if len(info.Connections) == 0 {
+		return s.implicitIntegrationStatus(info.Name, prov, instances, info.AuthTypes, p)
+	}
+	return summarizeConnectionStatuses(info.Connections)
+}
+
+func (info *integrationInfo) connectionStatusForDefaultTarget(connection string) (*connectionDefInfo, bool) {
+	connection = userFacingConnectionName(config.ResolveConnectionAlias(connection))
+	if connection == "" {
+		return nil, false
+	}
+	for i := range info.Connections {
+		conn := &info.Connections[i]
+		if config.ResolveConnectionAlias(conn.Name) == config.ResolveConnectionAlias(connection) {
+			return conn, true
+		}
+	}
+	return nil, false
+}
+
+func (info *integrationInfo) singleConnectionStatus() (*connectionDefInfo, bool) {
+	if len(info.Connections) != 1 {
+		return nil, false
+	}
+	return &info.Connections[0], true
+}
+
+func (s *Server) defaultConnectionName(integration string) string {
+	if s.defaultConnection != nil {
+		if connection := strings.TrimSpace(s.defaultConnection[integration]); connection != "" {
+			return connection
+		}
+	}
+	entry := s.pluginDefs[integration]
+	if entry == nil {
+		return ""
+	}
+	plan, err := config.BuildStaticConnectionPlan(entry, entry.ManifestSpec())
+	if err != nil {
+		return ""
+	}
+	return plan.AuthDefaultConnection()
+}
+
+func (s *Server) implicitIntegrationStatus(integration string, prov core.Provider, instances []instanceInfo, authTypes []string, p *principal.Principal) connectionStatusInfo {
+	mode := core.ConnectionModeUser
+	if prov != nil {
+		mode = core.NormalizeConnectionMode(prov.ConnectionMode())
+	}
+	switch mode {
+	case core.ConnectionModeNone:
+		return connectionStatusInfo{
+			Status:          connectionStatusReady,
+			CredentialState: credentialStateNotRequired,
+			HealthState:     healthStateNotApplicable,
+			Actions:         []string{},
+			Connected:       true,
+		}
+	case core.ConnectionModePlatform:
+		if s.hasConfiguredPlatformConnection(integration) {
+			return connectionStatusInfo{
+				Status:          connectionStatusReady,
+				CredentialState: credentialStateConfigured,
+				HealthState:     healthStateNotChecked,
+				Actions:         []string{},
+				Connected:       true,
+			}
+		}
+		return connectionStatusInfo{
+			Status:          connectionStatusNeedsAdminConfiguration,
+			CredentialState: credentialStateMissing,
+			HealthState:     healthStateUnknown,
+			Actions:         []string{actionAdminConfigure},
+			Connected:       false,
+			StatusCode:      "admin_configuration_required",
+			StatusReason:    "deployment/admin configuration is required",
+		}
+	default:
+		return subjectConnectionStatus(groupInstancesForConnection(instances, ""), len(authTypes) > 0, ownerKindForPrincipal(p))
+	}
+}
+
+type connectionStatusInfo struct {
+	Status          string
+	CredentialState string
+	HealthState     string
+	Actions         []string
+	CredentialMode  string
+	OwnerKind       string
+	Disconnectable  bool
+	Connected       bool
+	StatusCode      string
+	StatusReason    string
+}
+
+func statusFromConnectionInfo(conn *connectionDefInfo) connectionStatusInfo {
+	return connectionStatusInfo{
+		Status:          conn.Status,
+		CredentialState: conn.CredentialState,
+		HealthState:     conn.HealthState,
+		Actions:         cloneStatusActions(conn.Actions),
+		CredentialMode:  conn.CredentialMode,
+		OwnerKind:       conn.OwnerKind,
+		Disconnectable:  conn.Disconnectable,
+		Connected:       conn.Connected,
+		StatusCode:      conn.StatusCode,
+		StatusReason:    conn.StatusReason,
+	}
+}
+
+func cloneStatusActions(actions []string) []string {
+	if len(actions) == 0 {
+		return []string{}
+	}
+	return append([]string(nil), actions...)
+}
+
+func summarizeConnectionStatuses(connections []connectionDefInfo) connectionStatusInfo {
+	if len(connections) == 0 {
+		return unknownConnectionStatus()
+	}
+	for i := range connections {
+		conn := &connections[i]
+		if conn.Status == connectionStatusNeedsInstanceSelection {
+			return statusFromConnectionInfo(conn)
+		}
+	}
+	allPlatform := true
+	for i := range connections {
+		conn := &connections[i]
+		if conn.CredentialMode != credentialModePlatform {
+			allPlatform = false
+			break
+		}
+	}
+	if allPlatform {
+		for i := range connections {
+			conn := &connections[i]
+			if conn.Status == connectionStatusNeedsAdminConfiguration {
+				return statusFromConnectionInfo(conn)
+			}
+		}
+	}
+	allReady := true
+	for i := range connections {
+		conn := &connections[i]
+		if conn.Status != connectionStatusReady {
+			allReady = false
+			break
+		}
+	}
+	if allReady {
+		status := statusFromConnectionInfo(&connections[0])
+		status.Actions = []string{}
+		status.Connected = true
+		return status
+	}
+	for i := range connections {
+		conn := &connections[i]
+		if conn.Status == connectionStatusNeedsUserConnection {
+			return statusFromConnectionInfo(conn)
+		}
+	}
+	for i := range connections {
+		conn := &connections[i]
+		if conn.Status == connectionStatusNeedsAdminConfiguration {
+			return statusFromConnectionInfo(conn)
+		}
+	}
+	for i := range connections {
+		conn := &connections[i]
+		if conn.Status == connectionStatusUnavailable {
+			return statusFromConnectionInfo(conn)
+		}
+	}
+	return unknownConnectionStatus()
+}
+
+func unknownConnectionStatus() connectionStatusInfo {
+	return connectionStatusInfo{
+		Status:          connectionStatusUnknown,
+		CredentialState: credentialStateUnknown,
+		HealthState:     healthStateUnknown,
+		Actions:         []string{},
+		Connected:       false,
+	}
+}
+
+func noAuthConnectionStatus() connectionStatusInfo {
+	return connectionStatusInfo{
+		Status:          connectionStatusReady,
+		CredentialState: credentialStateNotRequired,
+		HealthState:     healthStateNotApplicable,
+		Actions:         []string{},
+		CredentialMode:  credentialModeNone,
+		OwnerKind:       ownerKindNone,
+		Connected:       true,
+	}
+}
+
+func (s *Server) platformConnectionStatus(integration, connection string, conn config.ConnectionDef) connectionStatusInfo {
+	if _, err := bootstrap.StaticConnectionRuntimeInfo(integration, connection, conn); err != nil {
+		return connectionStatusInfo{
+			Status:          connectionStatusNeedsAdminConfiguration,
+			CredentialState: credentialStateMissing,
+			HealthState:     healthStateUnknown,
+			Actions:         []string{actionAdminConfigure},
+			CredentialMode:  credentialModePlatform,
+			OwnerKind:       ownerKindPlatform,
+			Connected:       false,
+			StatusCode:      "admin_configuration_required",
+			StatusReason:    err.Error(),
+		}
+	}
+	return connectionStatusInfo{
+		Status:          connectionStatusReady,
+		CredentialState: credentialStateConfigured,
+		HealthState:     healthStateNotChecked,
+		Actions:         []string{},
+		CredentialMode:  credentialModePlatform,
+		OwnerKind:       ownerKindPlatform,
+		Connected:       true,
+	}
+}
+
+func subjectConnectionStatus(instances []instanceInfo, connectable bool, ownerKind string) connectionStatusInfo {
+	status := connectionStatusInfo{
+		CredentialMode: credentialModeSubject,
+		OwnerKind:      ownerKind,
+		HealthState:    healthStateNotApplicable,
+		Actions:        []string{},
+		Connected:      false,
+	}
+	switch len(instances) {
+	case 0:
+		status.Status = connectionStatusNeedsUserConnection
+		status.CredentialState = credentialStateMissing
+		if connectable {
+			status.Actions = []string{actionConnect}
+		}
+	case 1:
+		status.Status = connectionStatusReady
+		status.CredentialState = credentialStateConnected
+		status.HealthState = healthStateNotChecked
+		status.Disconnectable = true
+		status.Connected = true
+		status.Actions = subjectConnectionActions(true, connectable, false)
+	default:
+		status.Status = connectionStatusNeedsInstanceSelection
+		status.CredentialState = credentialStateConnected
+		status.HealthState = healthStateNotChecked
+		status.Disconnectable = true
+		status.Connected = true
+		status.Actions = subjectConnectionActions(true, connectable, true)
+		status.StatusCode = "instance_selection_required"
+		status.StatusReason = "multiple connected instances require explicit instance selection"
+	}
+	return status
+}
+
+func subjectConnectionActions(disconnectable, connectable, selectInstance bool) []string {
+	var actions []string
+	if selectInstance {
+		actions = append(actions, actionSelectInstance)
+	}
+	if disconnectable {
+		actions = append(actions, actionDisconnect)
+	}
+	if connectable {
+		actions = append(actions, actionAddInstance)
+	}
+	return actions
+}
+
+func ownerKindForPrincipal(p *principal.Principal) string {
+	subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
+	if subjectID == "" {
+		return ownerKindUnknown
+	}
+	kind, _, ok := core.ParseSubjectID(subjectID)
+	if !ok {
+		return ownerKindUnknown
+	}
+	switch kind {
+	case string(principal.KindUser):
+		return ownerKindCurrentUser
+	case ownerKindManagedIdentity:
+		return ownerKindManagedIdentity
+	case ownerKindServiceAccount:
+		return ownerKindServiceAccount
+	default:
+		return ownerKindUnknown
+	}
+}
+
+func groupInstancesForConnection(instances []instanceInfo, connection string) []instanceInfo {
+	connection = userFacingConnectionName(config.ResolveConnectionAlias(connection))
+	out := make([]instanceInfo, 0, len(instances))
+	for _, instance := range instances {
+		if connection != "" && config.ResolveConnectionAlias(instance.Connection) != config.ResolveConnectionAlias(connection) {
+			continue
+		}
+		out = append(out, instance)
+	}
+	return out
+}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -67,6 +67,16 @@ type connectionDefInfo struct {
 	Connectable      bool                  `json:"connectable"`
 	AuthTypes        []string              `json:"authTypes"`
 	CredentialFields []credentialFieldInfo `json:"credentialFields"`
+	Status           string                `json:"status"`
+	CredentialState  string                `json:"credentialState"`
+	HealthState      string                `json:"healthState"`
+	Actions          []string              `json:"actions"`
+	CredentialMode   string                `json:"credentialMode"`
+	OwnerKind        string                `json:"ownerKind"`
+	Disconnectable   bool                  `json:"disconnectable"`
+	Instances        []instanceInfo        `json:"instances"`
+	StatusCode       string                `json:"statusCode,omitempty"`
+	StatusReason     string                `json:"statusReason,omitempty"`
 }
 
 type integrationInfo struct {
@@ -81,6 +91,10 @@ type integrationInfo struct {
 	ConnectionParams map[string]connectionParamInfo `json:"connectionParams"`
 	Connections      []connectionDefInfo            `json:"connections"`
 	CredentialFields []credentialFieldInfo          `json:"credentialFields"`
+	Status           string                         `json:"status"`
+	CredentialState  string                         `json:"credentialState"`
+	HealthState      string                         `json:"healthState"`
+	Actions          []string                       `json:"actions"`
 }
 
 type connectionParamInfo struct {
@@ -177,6 +191,10 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			ConnectionParams: map[string]connectionParamInfo{},
 			Connections:      []connectionDefInfo{},
 			CredentialFields: []credentialFieldInfo{},
+			Status:           connectionStatusUnknown,
+			CredentialState:  credentialStateUnknown,
+			HealthState:      healthStateUnknown,
+			Actions:          []string{},
 		}
 		if cat := surfaceProv.Catalog(); cat != nil {
 			info.IconSVG = cat.IconSVG
@@ -185,10 +203,9 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
 		}
 		instances := connected[name]
-		providerMode := core.NormalizeConnectionMode(prov.ConnectionMode())
-		info.Connected = len(instances) > 0 || providerMode == core.ConnectionModeNone || s.hasConfiguredPlatformConnection(name)
 		info.Instances = append(make([]instanceInfo, 0, len(instances)), instances...)
-		s.populateIntegrationSettings(&info, prov, instances)
+		s.populateIntegrationSettings(&info, prov, instances, p)
+		s.applyIntegrationConnectionStatus(&info, prov, instances, p)
 		info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, info.MountedPath)
 		if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, surfaceProv, info) {
 			continue
@@ -738,6 +755,16 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 	case errors.Is(err, invocation.ErrScopeDenied):
 		writeError(w, http.StatusForbidden, err.Error())
 	case errors.Is(err, invocation.ErrNoCredential):
+		if deploymentCredentialRequired(err) {
+			writeTypedError(
+				w,
+				http.StatusPreconditionFailed,
+				"admin_configuration_required",
+				providerName,
+				fmt.Sprintf("deployment/admin configuration is required for integration %q", providerName),
+			)
+			return
+		}
 		writeTypedError(
 			w,
 			http.StatusPreconditionFailed,
@@ -754,7 +781,13 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 			fmt.Sprintf("OAuth token for integration %q expired or was revoked; reconnect it", providerName),
 		)
 	case errors.Is(err, invocation.ErrAmbiguousInstance):
-		writeError(w, http.StatusConflict, err.Error())
+		writeTypedError(
+			w,
+			http.StatusConflict,
+			"instance_selection_required",
+			providerName,
+			err.Error(),
+		)
 	case errors.Is(err, invocation.ErrUserResolution):
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
 	case errors.Is(err, invocation.ErrInternal):
@@ -799,6 +832,15 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 		slog.ErrorContext(r.Context(), "operation failed", "provider", providerName, "operation", operationName, "error", err)
 		writeError(w, http.StatusBadGateway, "operation failed")
 	}
+}
+
+func deploymentCredentialRequired(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	return strings.Contains(message, "deployment credential configured") ||
+		strings.Contains(message, "deployment-managed connection")
 }
 
 func httpVisibleCatalogOperations(ops []catalog.CatalogOperation) []catalog.CatalogOperation {

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
@@ -246,7 +248,7 @@ func (s *Server) revokeAllAPITokens(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"status": "revoked", "count": count})
 }
 
-func (s *Server) connectionInfosForPlugin(integration string, plugin *config.ProviderEntry, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) []connectionDefInfo {
+func (s *Server) connectionInfosForPlugin(integration string, plugin *config.ProviderEntry, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, p *principal.Principal) []connectionDefInfo {
 	if plugin == nil {
 		return []connectionDefInfo{}
 	}
@@ -265,7 +267,7 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 		if name == config.PluginConnectionName {
 			conn = displayPluginConnectionDef(plugin, manifestSpec, conn)
 		}
-		if info, ok := s.connectionInfoFromAuth(integration, userFacingConnectionName(name), conn, instances, integrationAuthTypes, defaultCredentialFields, name != config.PluginConnectionName); ok {
+		if info, ok := s.connectionInfoFromAuth(integration, name, userFacingConnectionName(name), conn, instances, integrationAuthTypes, defaultCredentialFields, name != config.PluginConnectionName, p); ok {
 			infos = append(infos, info)
 		}
 	}
@@ -303,17 +305,17 @@ func userFacingConnectionName(name string) string {
 	return name
 }
 
-func (s *Server) populateIntegrationSettings(info *integrationInfo, prov core.Provider, instances []instanceInfo) {
+func (s *Server) populateIntegrationSettings(info *integrationInfo, prov core.Provider, instances []instanceInfo, p *principal.Principal) {
 	authTypes := userFacingAuthTypes(prov.AuthTypes())
 	if core.NormalizeConnectionMode(prov.ConnectionMode()) == core.ConnectionModePlatform {
 		authTypes = nil
 	}
 	info.ConnectionParams = connectionParamInfosFromProvider(prov)
 	info.CredentialFields = credentialFieldInfosFromProvider(prov, authTypes)
-	info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, authTypes, info.CredentialFields)
+	info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, authTypes, info.CredentialFields, p)
 	info.AuthTypes = resolvedIntegrationAuthTypes(prov, authTypes, info.Connections)
 	if len(authTypes) == 0 && len(info.AuthTypes) > 0 {
-		info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, info.AuthTypes, info.CredentialFields)
+		info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, info.AuthTypes, info.CredentialFields, p)
 	}
 }
 
@@ -361,17 +363,29 @@ func credentialFieldInfos[T any](fields []T, mapField func(T) credentialFieldInf
 	return infos
 }
 
-func (s *Server) connectionInfoFromAuth(integration, name string, conn config.ConnectionDef, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, includeWithoutAuth bool) (connectionDefInfo, bool) {
+func (s *Server) connectionInfoFromAuth(integration, internalName, name string, conn config.ConnectionDef, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, includeWithoutAuth bool, p *principal.Principal) (connectionDefInfo, bool) {
 	mode := config.ConnectionModeForConnection(conn)
+	connectionInstances := groupInstancesForConnection(instances, name)
 	if mode == core.ConnectionModePlatform {
+		status := s.platformConnectionStatus(integration, internalName, conn)
 		return connectionDefInfo{
 			DisplayName:      connectionDisplayName(name, conn.DisplayName),
 			Name:             name,
 			Mode:             string(mode),
-			Connected:        strings.TrimSpace(conn.Auth.Token) != "",
+			Connected:        status.Connected,
 			Connectable:      false,
 			AuthTypes:        []string{},
 			CredentialFields: []credentialFieldInfo{},
+			Status:           status.Status,
+			CredentialState:  status.CredentialState,
+			HealthState:      status.HealthState,
+			Actions:          status.Actions,
+			CredentialMode:   status.CredentialMode,
+			OwnerKind:        status.OwnerKind,
+			Disconnectable:   status.Disconnectable,
+			Instances:        []instanceInfo{},
+			StatusCode:       status.StatusCode,
+			StatusReason:     status.StatusReason,
 		}, true
 	}
 	authTypes := connectionAuthTypes(conn.Auth, integrationAuthTypes)
@@ -383,15 +397,29 @@ func (s *Server) connectionInfoFromAuth(integration, name string, conn config.Co
 	if displayMode == core.ConnectionModeNone && len(authTypes) > 0 {
 		displayMode = core.ConnectionModeUser
 	}
+	status := noAuthConnectionStatus()
+	if displayMode != core.ConnectionModeNone {
+		status = subjectConnectionStatus(connectionInstances, len(authTypes) > 0, ownerKindForPrincipal(p))
+	}
 
 	info := connectionDefInfo{
 		DisplayName:      connectionDisplayName(name, conn.DisplayName),
 		Name:             name,
 		Mode:             string(displayMode),
-		Connected:        connectionConnected(instances, name),
+		Connected:        status.Connected,
 		Connectable:      len(authTypes) > 0,
 		AuthTypes:        []string{},
 		CredentialFields: []credentialFieldInfo{},
+		Status:           status.Status,
+		CredentialState:  status.CredentialState,
+		HealthState:      status.HealthState,
+		Actions:          status.Actions,
+		CredentialMode:   status.CredentialMode,
+		OwnerKind:        status.OwnerKind,
+		Disconnectable:   status.Disconnectable,
+		Instances:        connectionInstances,
+		StatusCode:       status.StatusCode,
+		StatusReason:     status.StatusReason,
 	}
 	if len(authTypes) > 0 {
 		info.AuthTypes = authTypes
@@ -412,16 +440,6 @@ func (s *Server) connectionInfoFromAuth(integration, name string, conn config.Co
 	return info, true
 }
 
-func connectionConnected(instances []instanceInfo, connection string) bool {
-	connection = strings.TrimSpace(connection)
-	for _, instance := range instances {
-		if strings.TrimSpace(instance.Connection) == connection {
-			return true
-		}
-	}
-	return false
-}
-
 func (s *Server) hasConfiguredPlatformConnection(integration string) bool {
 	entry := s.pluginDefs[integration]
 	if entry == nil {
@@ -431,20 +449,24 @@ func (s *Server) hasConfiguredPlatformConnection(integration string) bool {
 	if err != nil {
 		return false
 	}
-	if platformConnectionConfigured(plan.PluginConnection()) {
+	if platformConnectionConfiguredForName(integration, config.PluginConnectionName, plan.PluginConnection()) {
 		return true
 	}
 	for _, name := range plan.NamedConnectionNames() {
 		conn, _ := plan.NamedConnectionDef(name)
-		if platformConnectionConfigured(conn) {
+		if platformConnectionConfiguredForName(integration, name, conn) {
 			return true
 		}
 	}
 	return false
 }
 
-func platformConnectionConfigured(conn config.ConnectionDef) bool {
-	return config.ConnectionModeForConnection(conn) == core.ConnectionModePlatform && strings.TrimSpace(conn.Auth.Token) != ""
+func platformConnectionConfiguredForName(integration, connection string, conn config.ConnectionDef) bool {
+	if config.ConnectionModeForConnection(conn) != core.ConnectionModePlatform {
+		return false
+	}
+	_, err := bootstrap.StaticConnectionRuntimeInfo(integration, connection, conn)
+	return err == nil
 }
 
 func (s *Server) invocationConnectionMode(prov core.Provider, integration, connection string) core.ConnectionMode {
@@ -543,7 +565,8 @@ func resolvedIntegrationAuthTypes(prov core.Provider, authTypes []string, connec
 		return authTypes
 	}
 	combined := make([]string, 0, 2)
-	for _, connection := range connections {
+	for i := range connections {
+		connection := &connections[i]
 		combined = append(combined, connection.AuthTypes...)
 	}
 	if authTypes = userFacingAuthTypes(combined); len(authTypes) > 0 {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -7815,6 +7815,181 @@ func TestListIntegrationsShowsConnected(t *testing.T) {
 	}
 }
 
+func TestListIntegrations_ConnectionStatusContract(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	subjectID := principal.UserSubjectID(u.ID)
+	seedSubjectToken(t, svc, subjectID, "manual-connected", testDefaultConnection, "default", "connected-token")
+	seedSubjectToken(t, svc, subjectID, "manual-multi", testDefaultConnection, "team-a", "team-a-token")
+	seedSubjectToken(t, svc, subjectID, "manual-multi", testDefaultConnection, "team-b", "team-b-token")
+
+	providers := testutil.NewProviderRegistry(t,
+		&coretesting.StubIntegration{N: "no-auth", DN: "No Auth", ConnMode: core.ConnectionModeNone},
+		&stubManualProvider{StubIntegration: coretesting.StubIntegration{N: "manual-disconnected", DN: "Manual Disconnected"}},
+		&stubManualProvider{StubIntegration: coretesting.StubIntegration{N: "manual-connected", DN: "Manual Connected"}},
+		&stubManualProvider{StubIntegration: coretesting.StubIntegration{N: "manual-multi", DN: "Manual Multi"}},
+		&coretesting.StubIntegration{N: "platform-bearer", DN: "Platform Bearer", ConnMode: core.ConnectionModePlatform},
+		&coretesting.StubIntegration{N: "platform-manual", DN: "Platform Manual", ConnMode: core.ConnectionModePlatform},
+		&coretesting.StubIntegration{N: "platform-missing", DN: "Platform Missing", ConnMode: core.ConnectionModePlatform},
+	)
+	pluginDefs := map[string]*config.ProviderEntry{
+		"platform-bearer": {
+			ConnectionMode: providermanifestv1.ConnectionModePlatform,
+			Auth: &config.ConnectionAuthDef{
+				Type:  providermanifestv1.AuthTypeBearer,
+				Token: "deployment-token",
+			},
+		},
+		"platform-manual": {
+			ConnectionMode: providermanifestv1.ConnectionModePlatform,
+			Auth: &config.ConnectionAuthDef{
+				Type: providermanifestv1.AuthTypeManual,
+				AuthMapping: &config.AuthMappingDef{
+					Headers: map[string]providermanifestv1.AuthValue{
+						"X-API-Key": {Value: "deployment-api-key"},
+					},
+				},
+			},
+		},
+		"platform-missing": {
+			ConnectionMode: providermanifestv1.ConnectionModePlatform,
+			Auth: &config.ConnectionAuthDef{
+				Type: providermanifestv1.AuthTypeBearer,
+			},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.PluginDefs = pluginDefs
+		cfg.Services = svc
+		cfg.DefaultConnection = map[string]string{
+			"manual-connected": testDefaultConnection,
+			"manual-multi":     testDefaultConnection,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	type statusConnection struct {
+		Name             string           `json:"name"`
+		Mode             string           `json:"mode"`
+		Connected        bool             `json:"connected"`
+		Connectable      bool             `json:"connectable"`
+		Status           string           `json:"status"`
+		CredentialState  string           `json:"credentialState"`
+		HealthState      string           `json:"healthState"`
+		Actions          []string         `json:"actions"`
+		CredentialMode   string           `json:"credentialMode"`
+		OwnerKind        string           `json:"ownerKind"`
+		Disconnectable   bool             `json:"disconnectable"`
+		Instances        []map[string]any `json:"instances"`
+		StatusCode       string           `json:"statusCode"`
+		StatusReason     string           `json:"statusReason"`
+		AuthTypes        []string         `json:"authTypes"`
+		CredentialFields []map[string]any `json:"credentialFields"`
+	}
+	type statusIntegration struct {
+		Name             string                    `json:"name"`
+		Connected        bool                      `json:"connected"`
+		Instances        []map[string]any          `json:"instances"`
+		AuthTypes        []string                  `json:"authTypes"`
+		ConnectionParams map[string]map[string]any `json:"connectionParams"`
+		Connections      []statusConnection        `json:"connections"`
+		CredentialFields []map[string]any          `json:"credentialFields"`
+		Status           string                    `json:"status"`
+		CredentialState  string                    `json:"credentialState"`
+		HealthState      string                    `json:"healthState"`
+		Actions          []string                  `json:"actions"`
+	}
+	var integrations []statusIntegration
+	if err := json.Unmarshal(body, &integrations); err != nil {
+		t.Fatalf("decode integrations: %v (body: %s)", err, body)
+	}
+	got := make(map[string]statusIntegration, len(integrations))
+	for _, integration := range integrations {
+		got[integration.Name] = integration
+		credentialPresent := integration.CredentialState == "not_required" || integration.CredentialState == "connected" || integration.CredentialState == "configured"
+		if integration.Connected != credentialPresent {
+			t.Fatalf("%s legacy connected=%v status=%q violates compatibility invariant", integration.Name, integration.Connected, integration.Status)
+		}
+		if integration.Instances == nil || integration.AuthTypes == nil || integration.ConnectionParams == nil || integration.Connections == nil || integration.CredentialFields == nil {
+			t.Fatalf("%s legacy collections must stay non-nil: %+v", integration.Name, integration)
+		}
+	}
+
+	assertIntegrationStatus := func(name, status, credentialState, healthState string, connected bool, actions []string) statusIntegration {
+		t.Helper()
+		integration, ok := got[name]
+		if !ok {
+			t.Fatalf("integration %q missing from response: %s", name, body)
+		}
+		if integration.Status != status || integration.CredentialState != credentialState || integration.HealthState != healthState || integration.Connected != connected || !reflect.DeepEqual(integration.Actions, actions) {
+			t.Fatalf("%s status = {status:%q credential:%q health:%q connected:%v actions:%v}, want {%q %q %q %v %v}",
+				name, integration.Status, integration.CredentialState, integration.HealthState, integration.Connected, integration.Actions,
+				status, credentialState, healthState, connected, actions)
+		}
+		return integration
+	}
+
+	assertIntegrationStatus("no-auth", "ready", "not_required", "not_applicable", true, []string{})
+	assertIntegrationStatus("manual-disconnected", "needs_user_connection", "missing", "not_applicable", false, []string{"connect"})
+	assertIntegrationStatus("manual-connected", "ready", "connected", "not_checked", true, []string{"disconnect", "add_instance"})
+	assertIntegrationStatus("manual-multi", "needs_instance_selection", "connected", "not_checked", true, []string{"select_instance", "disconnect", "add_instance"})
+
+	platformBearer := assertIntegrationStatus("platform-bearer", "ready", "configured", "not_checked", true, []string{})
+	platformManual := assertIntegrationStatus("platform-manual", "ready", "configured", "not_checked", true, []string{})
+	platformMissing := assertIntegrationStatus("platform-missing", "needs_admin_configuration", "missing", "unknown", false, []string{"admin_configure"})
+
+	for _, tc := range []struct {
+		name        string
+		integration statusIntegration
+		wantStatus  string
+		wantCode    string
+	}{
+		{name: "platform-bearer", integration: platformBearer, wantStatus: "ready"},
+		{name: "platform-manual", integration: platformManual, wantStatus: "ready"},
+		{name: "platform-missing", integration: platformMissing, wantStatus: "needs_admin_configuration", wantCode: "admin_configuration_required"},
+	} {
+		tc := tc
+		t.Run(tc.name+" connection", func(t *testing.T) {
+			t.Parallel()
+			if len(tc.integration.Connections) != 1 {
+				t.Fatalf("connections = %+v, want one platform connection", tc.integration.Connections)
+			}
+			conn := tc.integration.Connections[0]
+			if conn.Mode != string(core.ConnectionModePlatform) || conn.CredentialMode != "platform" || conn.OwnerKind != "platform" || conn.Connectable || conn.Disconnectable {
+				t.Fatalf("platform connection fields = %+v", conn)
+			}
+			if conn.Status != tc.wantStatus {
+				t.Fatalf("connection status = %q, want %q", conn.Status, tc.wantStatus)
+			}
+			if conn.StatusCode != tc.wantCode {
+				t.Fatalf("connection statusCode = %q, want %q", conn.StatusCode, tc.wantCode)
+			}
+			if len(conn.Instances) != 0 {
+				t.Fatalf("platform instances = %+v, want empty", conn.Instances)
+			}
+		})
+	}
+}
+
 func TestListIntegrations_AuthTypes(t *testing.T) {
 	t.Parallel()
 
@@ -10469,6 +10644,9 @@ func TestListOperations_TokenSelectionErrors(t *testing.T) {
 		if !strings.Contains(result["error"], `"_instance"`) {
 			t.Fatalf("expected error to mention _instance, got %q", result["error"])
 		}
+		if result["code"] != "instance_selection_required" {
+			t.Fatalf("expected instance_selection_required code, got %q", result["code"])
+		}
 	})
 
 	t.Run("static_catalog_does_not_fail_open", func(t *testing.T) {
@@ -10871,6 +11049,52 @@ func TestExecuteOperation_AllowsExplicitConnectionAliasForStaticOperation(t *tes
 	}
 	if body["token"] != "plugin-token" {
 		t.Fatalf("token = %q, want plugin-token", body["token"])
+	}
+}
+
+func TestExecuteOperation_PlatformMissingRuntimeMaterialUsesAdminConfigurationError(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "platform-svc",
+			ConnMode: core.ConnectionModePlatform,
+		},
+		ops: []core.Operation{{Name: "do", Method: http.MethodGet}},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/platform-svc/do", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 412, got %d: %s", resp.StatusCode, body)
+	}
+	var errResp struct {
+		Error       string `json:"error"`
+		Code        string `json:"code"`
+		Integration string `json:"integration"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if errResp.Code != "admin_configuration_required" {
+		t.Fatalf("code = %q, want admin_configuration_required", errResp.Code)
+	}
+	if !strings.Contains(errResp.Error, "deployment/admin configuration") {
+		t.Fatalf("error = %q, want deployment/admin copy", errResp.Error)
+	}
+	if errResp.Integration != "platform-svc" {
+		t.Fatalf("integration = %q, want platform-svc", errResp.Integration)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds typed `status`, `credentialState`, `healthState`, and `actions` fields to `/api/v1/integrations` while preserving the legacy top-level and per-connection response fields.
- Adds per-connection `credentialMode`, `ownerKind`, `disconnectable`, grouped `instances`, and optional status code/reason metadata.
- Reuses bootstrap platform-material rules so platform manual direct `authMapping` reports ready even when it uses the synthetic `{}` runtime token.
- Updates CLI list output to show Status and Connections, and updates invoke/connect copy for admin configuration and instance selection errors.
- Rebases onto the current v4 config base and updates the remaining lock-sync e2e fixture to `gestaltd.config/v4`.

Interface examples:

```json
{
  "name": "weather",
  "connected": true,
  "status": "ready",
  "credentialState": "not_required",
  "healthState": "not_applicable",
  "actions": []
}
```

```json
{
  "name": "slack",
  "connected": true,
  "status": "needs_instance_selection",
  "credentialState": "connected",
  "healthState": "not_checked",
  "actions": ["select_instance", "disconnect", "add_instance"],
  "connections": [{
    "name": "default",
    "mode": "user",
    "credentialMode": "subject",
    "ownerKind": "current_user",
    "disconnectable": true,
    "instances": [{"name":"team-a","connection":"default"},{"name":"team-b","connection":"default"}]
  }]
}
```

```json
{
  "name": "platform-svc",
  "connected": false,
  "status": "needs_admin_configuration",
  "credentialState": "missing",
  "healthState": "unknown",
  "actions": ["admin_configure"],
  "connections": [{
    "name": "plugin",
    "mode": "platform",
    "credentialMode": "platform",
    "ownerKind": "platform",
    "statusCode": "admin_configuration_required"
  }]
}
```

## Test plan
- [x] `go test ./internal/server -run 'TestListIntegrations_ConnectionStatusContract|TestExecuteOperation_PlatformMissingRuntimeMaterialUsesAdminConfigurationError|TestListIntegrations'`
- [x] `go test ./internal/bootstrap -run 'TestBuildConnectionRuntime'`
- [x] `go test ./cmd/gestaltd -run TestE2ELockSyncPluginOwnedUI -count=1`
- [x] `golangci-lint run --path-prefix=gestaltd`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --test plugins_connect --test invoke_contract`