### PR TITLE
[codex] Extract gestaltd daemon entrypoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ Thanks for contributing. Before opening a PR, run the checks that match the part
 
 | Path | Purpose |
 | --- | --- |
-| `gestaltd/cmd/gestaltd` | Server entrypoint, command handling, and built-in registration. |
+| `gestaltd/cmd/gestaltd` | Thin server executable entrypoint. |
+| `gestaltd/internal/daemon` | Server command handling, runtime composition, and built-in registration. |
 | `gestaltd/core` | Public Go interfaces for auth, datastore, secrets, cache, telemetry, and providers. |
 | `gestaltd/internal` | Bootstrap, config loading, invocation, HTTP and MCP serving, operator lifecycle, and other server internals. |
 | `gestaltd/internal/ui` | Embedded admin UI asset serving and related tests. |
@@ -23,7 +24,7 @@ Thanks for contributing. Before opening a PR, run the checks that match the part
 When you update docs, keep them aligned with:
 
 - config structs in `gestaltd/internal/config`
-- bootstrap wiring in `gestaltd/cmd/gestaltd` and `gestaltd/internal/bootstrap`
+- bootstrap wiring in `gestaltd/internal/daemon` and `gestaltd/internal/bootstrap`
 - HTTP and MCP behavior in `gestaltd/internal/server` and `gestaltd/internal/mcp`
 - admin and mounted UI behavior in `gestaltd/internal/ui` and `gestaltd/internal/server/mounted_ui.go`
 - deployment assets in `gestaltd/Dockerfile` and `gestaltd/deploy/helm`
@@ -128,7 +129,7 @@ Keep the bare semantic version aligned across artifacts when they are meant to s
 
 If you add a new built-in auth provider, datastore, secret manager, telemetry sink, audit sink, or named provider:
 
-1. Register it in the relevant `gestaltd/cmd/gestaltd` file.
+1. Register it in the relevant `gestaltd/internal/daemon` file.
 2. Add or update tests.
 3. Update [First-Party Providers](https://gestaltd.ai/reference/built-in-providers).
 4. Update any docs or examples that describe the supported inventory.

--- a/gestaltd/cmd/gestaltd/main.go
+++ b/gestaltd/cmd/gestaltd/main.go
@@ -6,12 +6,17 @@ import (
 	"log/slog"
 	"os"
 	_ "time/tzdata"
+
+	"github.com/valon-technologies/gestalt/server/internal/daemon"
 )
 
 var version = "dev"
 
 func main() {
-	if err := run(os.Args[1:]); err != nil {
+	if err := daemon.Run(daemon.Options{
+		Version: version,
+		Args:    os.Args[1:],
+	}); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return
 		}

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"context"

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"context"

--- a/gestaltd/internal/daemon/init.go
+++ b/gestaltd/internal/daemon/init.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"context"

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"os/exec"

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"bytes"

--- a/gestaltd/internal/daemon/provider_attach.go
+++ b/gestaltd/internal/daemon/provider_attach.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"context"

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"context"

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"context"

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"flag"
@@ -16,6 +16,11 @@ import (
 
 type repeatedStringFlag []string
 
+type Options struct {
+	Version string
+	Args    []string
+}
+
 func (f *repeatedStringFlag) String() string {
 	return strings.Join(*f, ",")
 }
@@ -25,7 +30,15 @@ func (f *repeatedStringFlag) Set(value string) error {
 	return nil
 }
 
-func run(args []string) error {
+func Run(opts Options) error {
+	version := opts.Version
+	if version == "" {
+		version = "dev"
+	}
+	return run(opts.Args, version)
+}
+
+func run(args []string, version string) error {
 	if len(args) > 0 {
 		switch args[0] {
 		case "-h", "--help", "help":

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"crypto/sha256"
@@ -47,7 +47,10 @@ func TestMain(m *testing.M) {
 	var wg sync.WaitGroup
 	errs := make([]error, 4)
 	wg.Add(4)
-	go func() { defer wg.Done(); errs[0] = buildTarget(".", ".", gestaltdBin) }()
+	go func() {
+		defer wg.Done()
+		errs[0] = buildTarget(".", "github.com/valon-technologies/gestalt/server/cmd/gestaltd", gestaltdBin)
+	}()
 	go func() {
 		defer wg.Done()
 		errs[1] = providerpkg.BuildGoProviderBinary(testutil.MustExampleProviderPluginPath(), pluginBin, "provider-go", runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
## Summary

This PR starts the `gestaltd` service-boundary migration by keeping the executable package as a thin wrapper and moving command/runtime composition into a private daemon package.

New daemon interface:

```go
package daemon

type Options struct {
    Version string
    Args    []string
}

func Run(opts Options) error
```

Example usage from `cmd/gestaltd`:

```go
if err := daemon.Run(daemon.Options{
    Version: version,
    Args:    os.Args[1:],
}); err != nil {
    // existing flag.ErrHelp, slog, and exit behavior is preserved
}
```

## What Changed

- Moved the command implementation from `gestaltd/cmd/gestaltd` to `gestaltd/internal/daemon`.
- Kept `gestaltd/cmd/gestaltd/main.go` as the binary wrapper, preserving the `time/tzdata` import and `-ldflags -X main.version=...` version path.
- Preserved the hidden `__sandbox` command dispatch inside the daemon runner.
- Moved the existing command/provider integration tests with the daemon package and updated their binary build target so they still execute the real `cmd/gestaltd` binary.
- Updated CONTRIBUTING path references from `gestaltd/app/gestaltd` to `gestaltd/internal/daemon`.

## Interface Diff

```diff
- gestaltd/cmd/gestaltd/*.go        # package main owned command/runtime composition
- gestaltd/app/gestaltd/*.go        # package gestaltd application runner
+ gestaltd/cmd/gestaltd/main.go     # package main binary wrapper only
+ gestaltd/internal/daemon/*.go     # package daemon private command/runtime composition
```

No `docs/` changes are included in this PR.

## Validation

```bash
cd gestaltd
go test -p 1 ./cmd/gestaltd ./internal/daemon ./internal/bootstrap/... -count=1 -parallel=1
```
