### PR TITLE
Remove versioned lockfile compatibility

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -40,13 +40,11 @@ const (
 	PreparedAgentDir               = ".gestaltd/agent"
 	PreparedRuntimeDir             = ".gestaltd/runtime"
 	PreparedUIDir                  = ".gestaltd/ui"
-	LockVersion                    = 10
 
 	platformKeyGeneric = "generic"
 )
 
 type Lockfile struct {
-	Version             int                  `json:"version"`
 	Providers           map[string]LockEntry `json:"providers"`
 	Authentication      map[string]LockEntry `json:"authentication,omitempty"`
 	Authorization       map[string]LockEntry `json:"authorization,omitempty"`
@@ -1064,35 +1062,14 @@ func ReadLockfile(path string) (*Lockfile, error) {
 	if err != nil {
 		return nil, err
 	}
-	var header struct {
-		Schema        string `json:"schema"`
-		SchemaVersion int    `json:"schemaVersion"`
-		Version       int    `json:"version"`
-	}
-	if err := json.Unmarshal(data, &header); err != nil {
-		return nil, fmt.Errorf("parsing lockfile %s: %w", path, err)
-	}
-
-	if header.Schema != "" {
-		var lock providerLockfile
-		if err := json.Unmarshal(data, &lock); err != nil {
-			return nil, fmt.Errorf("parsing lockfile %s: %w", path, err)
-		}
-		if err := validateProviderLockfile(&lock); err != nil {
-			return nil, err
-		}
-		return lock.toLockfile(), nil
-	}
-
-	if header.Version != LockVersion {
-		return nil, fmt.Errorf("unsupported lockfile version %d; run `gestaltd init` to upgrade", header.Version)
-	}
-
-	var lock Lockfile
+	var lock providerLockfile
 	if err := json.Unmarshal(data, &lock); err != nil {
 		return nil, fmt.Errorf("parsing lockfile %s: %w", path, err)
 	}
-	return normalizeLockfile(&lock), nil
+	if err := validateProviderLockfile(&lock); err != nil {
+		return nil, err
+	}
+	return lock.toLockfile(), nil
 }
 
 func WriteLockfile(path string, lock *Lockfile) error {
@@ -1106,7 +1083,7 @@ func WriteLockfile(path string, lock *Lockfile) error {
 }
 
 func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool {
-	if lock == nil || lock.Version != LockVersion {
+	if lock == nil {
 		return false
 	}
 	for name, entry := range cfg.Plugins {

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1731,7 +1731,6 @@ server:
 	}
 	paths := initPathsForConfig(cfgPath)
 	staleLock := &Lockfile{
-		Version: LockVersion,
 		Providers: map[string]LockEntry{
 			"roadmap": {
 				Fingerprint: mustFingerprint(t, "roadmap", loadedCfg.Plugins["roadmap"], paths.configDir),
@@ -3114,7 +3113,6 @@ func TestLockMatchesConfig_RemoteS3UsesResourceNameFingerprint(t *testing.T) {
 	}
 
 	lock := &Lockfile{
-		Version: LockVersion,
 		S3: map[string]LockEntry{
 			"assets": lockEntry,
 		},
@@ -3289,7 +3287,7 @@ func TestProviderFingerprint_ChangesWithName(t *testing.T) {
 	}
 }
 
-func TestReadLockfile_RejectsUnsupportedVersion(t *testing.T) {
+func TestReadLockfile_RejectsLockfileWithoutSchema(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -3300,39 +3298,11 @@ func TestReadLockfile_RejectsUnsupportedVersion(t *testing.T) {
 
 	_, err := ReadLockfile(lockPath)
 	if err == nil {
-		t.Fatal("expected error for unsupported lockfile version")
+		t.Fatal("expected error for lockfile without schema")
 		return
 	}
-	if !strings.Contains(err.Error(), "unsupported lockfile version") {
+	if !strings.Contains(err.Error(), "unsupported lockfile schema") {
 		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestReadLockfile_AllowsRuntimeProviderNamedAuth(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	lockPath := filepath.Join(dir, InitLockfileName)
-	if err := os.WriteFile(lockPath, []byte(`{
-  "version": 10,
-  "providers": {
-    "auth": {
-      "fingerprint": "plugin-fp",
-      "source": "github.com/example/auth-plugin",
-      "manifest": ".gestaltd/providers/auth/manifest.yaml"
-    }
-  }
-}
-`), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	lock, err := ReadLockfile(lockPath)
-	if err != nil {
-		t.Fatalf("ReadLockfile: %v", err)
-	}
-	if got := lock.Providers["auth"].Source; got != "github.com/example/auth-plugin" {
-		t.Fatalf("provider auth source = %q, want %q", got, "github.com/example/auth-plugin")
 	}
 }
 
@@ -3433,7 +3403,6 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, InitLockfileName)
 	want := &Lockfile{
-		Version: LockVersion,
 		Providers: map[string]LockEntry{
 			"example": {
 				Fingerprint: "provider-fp",
@@ -3634,9 +3603,6 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	got, err := ReadLockfile(lockPath)
 	if err != nil {
 		t.Fatalf("ReadLockfile: %v", err)
-	}
-	if got.Version != want.Version {
-		t.Fatalf("Version = %d, want %d", got.Version, want.Version)
 	}
 	if got.Providers["example"].Fingerprint != want.Providers["example"].Fingerprint {
 		t.Fatal("provider fingerprint mismatch")

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -11,9 +11,6 @@ import (
 const (
 	providerLockSchemaName         = "gestaltd-provider-lock"
 	providerLockSchemaVersion      = 5
-	providerLockSchemaVersionV4    = 4
-	providerLockSchemaVersionV3    = 3
-	providerLockSchemaVersionV2    = 2
 	providerLockRevision           = 0
 	providerLockKindWorkflow       = "workflow"
 	providerLockKindTelemetry      = "telemetry"
@@ -60,7 +57,6 @@ type portableLockEntry struct {
 
 func newLockfile() *Lockfile {
 	return &Lockfile{
-		Version:             LockVersion,
 		Providers:           make(map[string]LockEntry),
 		Authentication:      make(map[string]LockEntry),
 		Authorization:       make(map[string]LockEntry),
@@ -81,9 +77,6 @@ func newLockfile() *Lockfile {
 func normalizeLockfile(lock *Lockfile) *Lockfile {
 	if lock == nil {
 		return newLockfile()
-	}
-	if lock.Version == 0 {
-		lock.Version = LockVersion
 	}
 	if lock.Providers == nil {
 		lock.Providers = make(map[string]LockEntry)
@@ -241,7 +234,7 @@ func validateProviderLockfile(lock *providerLockfile) error {
 	if lock.Schema != providerLockSchemaName {
 		return fmt.Errorf("unsupported lockfile schema %q; run `gestaltd init` to upgrade", lock.Schema)
 	}
-	if lock.SchemaVersion != providerLockSchemaVersion && lock.SchemaVersion != providerLockSchemaVersionV4 && lock.SchemaVersion != providerLockSchemaVersionV3 && lock.SchemaVersion != providerLockSchemaVersionV2 {
+	if lock.SchemaVersion != providerLockSchemaVersion {
 		return fmt.Errorf("unsupported lockfile schema version %d; run `gestaltd init` to upgrade", lock.SchemaVersion)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Remove the old unstructured `{"version": 10, ...}` lockfile read path.
- Require provider lockfiles to use the current portable schema: `schema: gestaltd-provider-lock`, `schemaVersion: 5`.
- Drop older portable lock schema version acceptance (`2`, `3`, `4`).
- Remove the internal `Lockfile.Version`/`LockVersion` bookkeeping and the test that proved old lockfiles still loaded.

## Interface / Contract Diff
```diff
- ReadLockfile(path) accepted unstructured lockfiles shaped like {"version": 10, "providers": {...}}
+ ReadLockfile(path) requires schema="gestaltd-provider-lock" and schemaVersion=5

- validateProviderLockfile accepted schemaVersion 2, 3, 4, or 5
+ validateProviderLockfile accepts schemaVersion 5 only

- type Lockfile struct { Version int; Providers ... }
+ type Lockfile struct { Providers ... }

- lockMatchesConfig rejected locks by internal Version mismatch
+ lockMatchesConfig validates actual provider entries only
```

## Examples
```json
{
  "schema": "gestaltd-provider-lock",
  "schemaVersion": 5,
  "revision": 0,
  "providers": {
    "plugin": {}
  }
}
```

Regenerate older lockfiles with:
```bash
gestaltd init --config path/to/config.yaml --platform all
```

## Deployment Check
- `valon-tools/deploy/gestalt.lock.json` is already `schemaVersion: 5`.
- The stale local `.gestaltd/local/gestalt.lock.json` is not referenced by the deploy Dockerfile or entrypoint.

## Verification
- `git diff --check`
- `GOCACHE=$PWD/../.gocache TMPDIR=$PWD/../.tmp go test ./internal/operator`
