### PR TITLE
Remove v3 config source compatibility

### DIFF
--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -58,7 +58,7 @@ Generate the encryption key once with `openssl rand -hex 32` and use that value 
 Example minimal config:
 
 ```yaml
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   public:
     port: 8080

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -166,7 +166,7 @@ plugins:
   example:
     source:
       path: %s
-`, config.APIVersionV3, tc.source, tc.telemetryBlock, indexedDBManifest, pluginManifest)
+`, config.ConfigAPIVersion, tc.source, tc.telemetryBlock, indexedDBManifest, pluginManifest)
 			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 				t.Fatalf("write config: %v", err)
 			}
@@ -190,7 +190,7 @@ func TestE2EValidateAcceptsCanonicalConfigShapes(t *testing.T) {
 	agentManifest := componentProviderManifestPath(t, setupExecutableProviderDir(t, dir, providermanifestv1.KindAgent, "agent-simple"))
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   encryptionKey: canonical-config-shapes-key
   providers:
@@ -322,7 +322,7 @@ server:
 		},
 		{
 			name: "unknown field",
-			cfg: `apiVersion: gestaltd.config/v3
+			cfg: `apiVersion: gestaltd.config/v4
 server:
   encryptionKey: test-key
   bogus: true
@@ -331,7 +331,7 @@ server:
 		},
 		{
 			name: "ui object requires path",
-			cfg: `apiVersion: gestaltd.config/v3
+			cfg: `apiVersion: gestaltd.config/v4
 plugins:
   roadmap:
     source:
@@ -419,7 +419,7 @@ func TestE2EProviderValidateReusesConfiguredPluginKey(t *testing.T) {
 	providersDir := setupDefaultLocalProvidersDir(t, dir)
 	pluginDir := setupPluginDir(t, dir)
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `apiVersion: gestaltd.config/v3
+	cfg := `apiVersion: gestaltd.config/v4
 plugins:
   provider_go:
     source: https://example.test/provider-release.yaml
@@ -478,7 +478,7 @@ func TestE2EProviderValidateLayeredConfigSupportsNullDeletion(t *testing.T) {
 	}
 
 	baseCfgPath := filepath.Join(dir, "support.yaml")
-	baseCfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	baseCfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 providers:
   ui:
     roadmap:
@@ -498,7 +498,7 @@ plugins:
 	}
 
 	overrideCfgPath := filepath.Join(dir, "support-override.yaml")
-	overrideCfg := `apiVersion: gestaltd.config/v3
+	overrideCfg := `apiVersion: gestaltd.config/v4
 providers:
   ui:
     roadmap: null
@@ -661,7 +661,7 @@ func TestE2EValidateAcceptsLayeredConfigs(t *testing.T) {
 	setupPluginDir(t, overrideDir)
 
 	baseConfigPath := filepath.Join(baseDir, "base.yaml")
-	baseConfig := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	baseConfig := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   encryptionKey: test-key
   providers:
@@ -683,7 +683,7 @@ plugins:
 	}
 
 	overrideConfigPath := filepath.Join(overrideDir, "local.yaml")
-	overrideConfig := `apiVersion: gestaltd.config/v3
+	overrideConfig := `apiVersion: gestaltd.config/v4
 plugins:
   example:
     source:
@@ -709,23 +709,6 @@ plugins:
 		t.Fatalf("expected layered config output to mention success, got: %s", out)
 	}
 
-	mixedOverrideConfigPath := filepath.Join(overrideDir, "v4.yaml")
-	mixedOverrideConfig := `apiVersion: gestaltd.config/v4
-plugins:
-  example:
-    source: ./plugin-src/provider-release.yaml
-`
-	if err := os.WriteFile(mixedOverrideConfigPath, []byte(mixedOverrideConfig), 0o644); err != nil {
-		t.Fatalf("WriteFile mixed override config: %v", err)
-	}
-
-	out, err = exec.Command(gestaltdBin, "validate", "--config", baseConfigPath, "--config", mixedOverrideConfigPath).CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected mixed apiVersion validate to fail, output: %s", out)
-	}
-	if !strings.Contains(string(out), "mixed apiVersion values") {
-		t.Fatalf("expected mixed apiVersion error, got: %s", out)
-	}
 }
 
 func TestE2EValidateUsesScratchPreparedInstallsForLocalSourceConfigs(t *testing.T) {
@@ -736,7 +719,7 @@ func TestE2EValidateUsesScratchPreparedInstallsForLocalSourceConfigs(t *testing.
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   encryptionKey: test-key
   providers:
@@ -798,7 +781,7 @@ func TestE2EValidateRejectsInvalidPluginInvokesDependency(t *testing.T) {
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   encryptionKey: test-key
   providers:
@@ -871,7 +854,7 @@ paths:
 
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   encryptionKey: test-key
   providers:
@@ -1659,7 +1642,7 @@ func writeServeConfig(t *testing.T, dir string, port int, mountedUI *mountedUITe
 `, mountedUI.Name, mountedUI.ManifestPath, mountedUI.Path)
 	}
 
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   public:
     port: %d
@@ -1704,7 +1687,7 @@ func writeServeConfigWithManagement(t *testing.T, dir string, publicPort, manage
 `, mountedUI.Name, mountedUI.ManifestPath, mountedUI.Path)
 	}
 
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   public:
     port: %d
@@ -2295,7 +2278,7 @@ func TestE2EServePluginOwnedUIWiring(t *testing.T) {
 	publicPort, publicHolder := reservePort(t)
 	publicURL := fmt.Sprintf("http://127.0.0.1:%d", publicPort)
 	cfgPath := filepath.Join(dir, "config-owned-ui.yaml")
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   public:
     port: %d
@@ -2385,7 +2368,7 @@ func TestE2EServeStartsWithPluginBoundCacheProvider(t *testing.T) {
 	pluginManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, dir))
 	cfgPath := filepath.Join(dir, "config-cache.yaml")
 
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   public:
     port: 0
@@ -2483,7 +2466,7 @@ func TestE2EHostedHTTPSubjectResolutionUsesAuthorizationAndInheritedInvocation(t
 	port, holder := reservePort(t)
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 	cfgPath := filepath.Join(dir, "config-subject-resolution.yaml")
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   public:
     port: %d
@@ -2793,7 +2776,7 @@ func writeValidValidateConfig(t *testing.T, dir string) string {
 	pluginManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, dir))
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   encryptionKey: valid-config-e2e-key
   providers:
@@ -2825,7 +2808,7 @@ func writeInvalidValidateConfig(t *testing.T, path string) {
 	dir := filepath.Dir(path)
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 	externalCredentialsManifest := componentProviderManifestPath(t, setupExternalCredentialsProviderDir(t, dir))
-	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   encryptionKey: invalid-config-e2e-key
   providers:
@@ -2879,7 +2862,7 @@ func writeLayeredE2EConfigs(t *testing.T, dir string, port int) (string, string,
 
 	basePath := filepath.Join(deployDir, "base.yaml")
 	overridePath := filepath.Join(overrideDir, "local.yaml")
-	baseCfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	baseCfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   public:
     port: %d
@@ -2901,7 +2884,7 @@ plugins:
     source:
       path: %s
 `, port, filepath.ToSlash(externalCredentialsManifest), filepath.ToSlash(indexedDBRel), filepath.ToSlash(pluginRel))
-	overrideCfg := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	overrideCfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   providers:
     authentication: local
@@ -2935,7 +2918,7 @@ func writeE2EConfigWithPaths(t *testing.T, dir, pluginDir, dbPath, artifactsDir 
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	serverBlock := fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	serverBlock := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   public:
     port: %d

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -1083,7 +1083,7 @@ func writeProviderLocalBaseConfig(path, dbPath string) error {
 	}
 
 	cfg := map[string]any{
-		"apiVersion": config.APIVersionV3,
+		"apiVersion": config.ConfigAPIVersion,
 		"server": map[string]any{
 			"encryptionKey": encryptionKey,
 			"providers": map[string]any{
@@ -1132,7 +1132,7 @@ func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string,
 	}
 
 	cfg := map[string]any{
-		"apiVersion": config.APIVersionV3,
+		"apiVersion": config.ConfigAPIVersion,
 		"server": map[string]any{
 			"public": map[string]any{
 				"host": providerDevHost,
@@ -1157,7 +1157,7 @@ func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string,
 
 func writeProviderRemotePluginOverlayConfig(path, pluginKey, manifestPath string) error {
 	cfg := map[string]any{
-		"apiVersion": config.APIVersionV3,
+		"apiVersion": config.ConfigAPIVersion,
 		"plugins": map[string]any{
 			pluginKey: map[string]any{
 				"source":    providerLocalSourceOverride(manifestPath),
@@ -1177,7 +1177,7 @@ func writeProviderLocalUIOverlayConfig(path, uiKey, manifestPath string, port in
 	}
 
 	cfg := map[string]any{
-		"apiVersion": config.APIVersionV3,
+		"apiVersion": config.ConfigAPIVersion,
 		"server": map[string]any{
 			"public": map[string]any{
 				"host": providerDevHost,

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -3212,7 +3212,7 @@ server:
     indexeddb: sqlite
   artifactsDir: %q
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-`, config.APIVersionV3, externalCredentialsManifest, indexedDBManifest, filepath.Join(dir, "gestalt.db"), pluginKey, metadataURL, mountPath, filepath.Join(dir, "prepared-artifacts"))
+`, config.ConfigAPIVersion, externalCredentialsManifest, indexedDBManifest, filepath.Join(dir, "gestalt.db"), pluginKey, metadataURL, mountPath, filepath.Join(dir, "prepared-artifacts"))
 	configPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(configPath, []byte(configData), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -73,7 +73,7 @@ persistence:
 # placeholders at startup, so secrets can be injected via extraEnv when
 # you enable OAuth/OIDC or an external datastore below.
 config:
-  apiVersion: gestaltd.config/v3
+  apiVersion: gestaltd.config/v4
   server:
     public:
       port: 8080

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -48,15 +49,7 @@ const PluginConnectionName = "_plugin"
 // PluginConnectionName. In hybrid integrations, mcp.connection can be set
 // to "plugin" to reuse the plugin's OAuth token.
 const PluginConnectionAlias = "plugin"
-const APIVersionV3 = "gestaltd.config/v3"
-const APIVersionV4 = "gestaltd.config/v4"
-
-type providerSourceSyntaxMode int
-
-const (
-	providerSourceSyntaxV3 providerSourceSyntaxMode = iota
-	providerSourceSyntaxV4
-)
+const ConfigAPIVersion = "gestaltd.config/v4"
 
 type Config struct {
 	APIVersion    string                    `yaml:"apiVersion,omitempty"`
@@ -148,9 +141,9 @@ type ServerProvidersConfig struct {
 //   - Builtin:  recognized host builtins such as source: "env" or "stdout"
 //   - Metadata: source: "https://.../provider-release.yaml"  -> ProviderSource{metadataURL: "..."}
 //   - GitHub:   source: {githubRelease: {repo, tag, asset}}  -> ProviderSource{GitHubRelease: ...}
-//   - Local:    source: {path} or source: "./manifest.yaml"  -> ProviderSource{Path: "..."} in v3
-//   - Local:    source: {path} or source: "./dist/provider-release.yaml"
-//     -> ProviderSource{metadataPath: "..."} in v4
+//   - Local:    source: {path} or source: "./manifest.yaml"  -> ProviderSource{Path: "..."}
+//   - Local metadata: source: {path} or source: "./dist/provider-release.yaml"
+//     -> ProviderSource{metadataPath: "..."}
 type ProviderSource struct {
 	Builtin       string                  `yaml:"-"`
 	scalar        string                  `yaml:"-"`
@@ -2053,22 +2046,11 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 	}
 
 	roots := make([]yaml.Node, len(paths))
-	var sourceSyntax providerSourceSyntaxMode
-	sourceSyntaxSet := false
 	for i, path := range paths {
 		root, err := loadValidatedConfigRoot(path, lookup, mode, sentinelPrefix)
 		if err != nil {
 			return yaml.Node{}, err
 		}
-		rootSyntax, err := configRootSourceSyntax(root)
-		if err != nil {
-			return yaml.Node{}, err
-		}
-		if sourceSyntaxSet && sourceSyntax != rootSyntax {
-			return yaml.Node{}, fmt.Errorf("config validation: mixed apiVersion values are not supported across merged config files")
-		}
-		sourceSyntax = rootSyntax
-		sourceSyntaxSet = true
 		roots[i] = root
 	}
 
@@ -2101,27 +2083,26 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 	return root, nil
 }
 
-func configRootSourceSyntax(root yaml.Node) (providerSourceSyntaxMode, error) {
+func validateConfigRootAPIVersion(root yaml.Node) error {
 	doc := documentValueNode(&root)
 	if doc == nil || doc.Kind == 0 {
-		return providerSourceSyntaxV3, requiredAPIVersionError()
+		return requiredAPIVersionError()
 	}
 	if doc.Kind != yaml.MappingNode {
-		return providerSourceSyntaxV3, fmt.Errorf("parsing config YAML: expected mapping document")
+		return fmt.Errorf("parsing config YAML: expected mapping document")
 	}
 	node := mappingValueNode(doc, "apiVersion")
 	if node == nil {
-		return providerSourceSyntaxV3, requiredAPIVersionError()
+		return requiredAPIVersionError()
 	}
 	value := strings.TrimSpace(node.Value)
 	if value == "" {
-		return providerSourceSyntaxV3, requiredAPIVersionError()
+		return requiredAPIVersionError()
 	}
-	mode, err := providerSourceSyntaxForAPIVersion(value)
-	if err != nil {
-		return providerSourceSyntaxV3, err
+	if value != ConfigAPIVersion {
+		return fmt.Errorf("config validation: unsupported apiVersion %q", value)
 	}
-	return mode, nil
+	return nil
 }
 
 func loadConfigValue(path string, root yaml.Node) (any, error) {
@@ -2166,6 +2147,9 @@ func loadValidatedConfigRoot(path string, lookup func(string) (string, bool), mo
 		return yaml.Node{}, fmt.Errorf("parsing config YAML: %w", err)
 	}
 	if err := normalizeConfigRoot(&root); err != nil {
+		return yaml.Node{}, err
+	}
+	if err := validateConfigRootAPIVersion(root); err != nil {
 		return yaml.Node{}, err
 	}
 
@@ -2564,13 +2548,12 @@ func normalizeProviderSourceShapes(cfg *Config) {
 		return
 	}
 	cfg.APIVersion = strings.TrimSpace(cfg.APIVersion)
-	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 
 	normalizeEntry := func(kind string, entry *ProviderEntry) {
 		if entry == nil {
 			return
 		}
-		normalizeProviderSource(kind, &entry.Source, sourceSyntax)
+		normalizeProviderSource(kind, &entry.Source)
 	}
 
 	for _, entry := range cfg.Plugins {
@@ -2608,7 +2591,7 @@ func normalizeProviderSourceShapes(cfg *Config) {
 	}
 }
 
-func normalizeProviderSource(kind string, source *ProviderSource, sourceSyntax providerSourceSyntaxMode) {
+func normalizeProviderSource(kind string, source *ProviderSource) {
 	if source == nil {
 		return
 	}
@@ -2618,7 +2601,7 @@ func normalizeProviderSource(kind string, source *ProviderSource, sourceSyntax p
 	source.metadataPath = strings.TrimSpace(source.metadataPath)
 	source.unsupported = strings.TrimSpace(source.unsupported)
 	source.Auth = cloneSourceAuthDef(source.Auth)
-	if sourceSyntax == providerSourceSyntaxV4 && source.Path != "" && source.metadataPath == "" {
+	if source.Path != "" && source.metadataPath == "" && isLocalReleaseMetadataPath(source.Path) {
 		source.metadataPath = source.Path
 		source.Path = ""
 	}
@@ -2644,12 +2627,16 @@ func normalizeProviderSource(kind string, source *ProviderSource, sourceSyntax p
 		source.metadataURL = source.scalar
 	case looksLikeUnsupportedScalarSource(source.scalar):
 		source.unsupported = source.scalar
-	case sourceSyntax == providerSourceSyntaxV4:
+	case isLocalReleaseMetadataPath(source.scalar):
 		source.metadataPath = source.scalar
 	default:
 		source.Path = source.scalar
 	}
 	source.scalar = ""
+}
+
+func isLocalReleaseMetadataPath(value string) bool {
+	return path.Base(filepath.ToSlash(strings.TrimSpace(value))) == "provider-release.yaml"
 }
 
 func isBuiltinScalarSource(kind, source string) bool {
@@ -2710,27 +2697,6 @@ func looksLikeUnsupportedScalarSource(value string) bool {
 		}
 	}
 	return false
-}
-
-func providerSourceSyntaxForAPIVersion(apiVersion string) (providerSourceSyntaxMode, error) {
-	switch strings.TrimSpace(apiVersion) {
-	case APIVersionV3:
-		return providerSourceSyntaxV3, nil
-	case APIVersionV4:
-		return providerSourceSyntaxV4, nil
-	case "":
-		return providerSourceSyntaxV3, requiredAPIVersionError()
-	default:
-		return providerSourceSyntaxV3, fmt.Errorf("config validation: unsupported apiVersion %q", strings.TrimSpace(apiVersion))
-	}
-}
-
-func sourceSyntaxForConfig(apiVersion string) providerSourceSyntaxMode {
-	mode, err := providerSourceSyntaxForAPIVersion(apiVersion)
-	if err != nil {
-		return providerSourceSyntaxV3
-	}
-	return mode
 }
 
 func nonNilProviderEntryMap(entries map[string]*ProviderEntry) map[string]*ProviderEntry {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -41,7 +41,7 @@ func withDefaultConfigAPIVersion(content string) string {
 	if strings.HasPrefix(trimmed, "apiVersion:") {
 		return content
 	}
-	return "\napiVersion: " + APIVersionV3 + "\n" + strings.TrimLeft(content, "\r\n")
+	return "\napiVersion: " + ConfigAPIVersion + "\n" + strings.TrimLeft(content, "\r\n")
 }
 
 func mustSelectedProvider(t *testing.T, cfg *Config, kind HostProviderKind) (string, *ProviderEntry) {
@@ -66,7 +66,7 @@ func TestLoadConfigGenericFixture(t *testing.T) {
 	t.Parallel()
 
 	path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   providers:
     authentication: google
@@ -408,7 +408,7 @@ func TestLoadConfigSelectsDefaultProvidersFromNamedMaps(t *testing.T) {
 	t.Parallel()
 
 	path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   encryptionKey: server-key
   providers:
@@ -477,7 +477,7 @@ func TestLoadConfigDefaultsAndEnv(t *testing.T) {
 	}
 
 	path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   providers:
     authentication: local
@@ -536,7 +536,7 @@ func TestLoadConfigAcceptsAuthenticationConfig(t *testing.T) {
 	t.Parallel()
 
 	path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   providers:
     authentication: local
@@ -835,7 +835,7 @@ func TestValidateStructureRejectsDuplicateAuthorizationPolicyMembers(t *testing.
 			t.Parallel()
 
 			cfg := &Config{
-				APIVersion: APIVersionV3,
+				APIVersion: ConfigAPIVersion,
 				Authorization: AuthorizationConfig{
 					Policies: map[string]SubjectPolicyDef{
 						"roadmap": {
@@ -1202,7 +1202,7 @@ plugins:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     custom_tool:
@@ -1213,8 +1213,8 @@ plugins:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		if cfg.APIVersion != APIVersionV3 {
-			t.Fatalf("APIVersion = %q, want %q", cfg.APIVersion, APIVersionV3)
+		if cfg.APIVersion != ConfigAPIVersion {
+			t.Fatalf("APIVersion = %q, want %q", cfg.APIVersion, ConfigAPIVersion)
 		}
 		if got := cfg.Plugins["custom_tool"].SourcePath(); got != filepath.Join(filepath.Dir(path), "manifest.yaml") {
 			t.Fatalf("unexpected plugin source path: %q", got)
@@ -1225,7 +1225,7 @@ plugins:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     custom_tool:
@@ -1256,8 +1256,8 @@ plugins:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		if cfg.APIVersion != APIVersionV4 {
-			t.Fatalf("APIVersion = %q, want %q", cfg.APIVersion, APIVersionV4)
+		if cfg.APIVersion != ConfigAPIVersion {
+			t.Fatalf("APIVersion = %q, want %q", cfg.APIVersion, ConfigAPIVersion)
 		}
 		if got := cfg.Plugins["custom_tool"].SourceReleasePath(); got != filepath.Join(filepath.Dir(path), "dist", "provider-release.yaml") {
 			t.Fatalf("unexpected plugin release metadata path: %q", got)
@@ -1271,7 +1271,7 @@ plugins:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
   workflow:
     demo:
@@ -1292,7 +1292,7 @@ plugins:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
   ui:
     dashboard:
@@ -1314,7 +1314,7 @@ plugins:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     custom_tool:
@@ -1397,7 +1397,7 @@ plugins:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   providers:
     authentication: corporate
@@ -1476,7 +1476,7 @@ plugins:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   providers:
     authentication: corporate
@@ -1537,7 +1537,7 @@ plugins:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     custom_tool:
@@ -1642,7 +1642,7 @@ plugins:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
   secrets:
     default:
@@ -2123,7 +2123,7 @@ server:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
   externalCredentials:
     default:
@@ -3766,7 +3766,7 @@ func TestLoadPathsProviderExecutionAndEgressOverride(t *testing.T) {
 	basePath := filepath.Join(dir, "base.yaml")
 	overridePath := filepath.Join(dir, "override.yaml")
 	if err := os.WriteFile(basePath, []byte(`
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   encryptionKey: server-key
 plugins:
@@ -3789,7 +3789,7 @@ runtime:
 		t.Fatalf("writing base config: %v", err)
 	}
 	if err := os.WriteFile(overridePath, []byte(`
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 plugins:
   service:
     execution:
@@ -3879,7 +3879,7 @@ providers:
 		{
 			name: "external provider source",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
   authentication:
     primary:
@@ -3889,7 +3889,7 @@ providers:
 		{
 			name: "apiVersion scalar local source",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -3899,7 +3899,7 @@ plugins:
 		{
 			name: "apiVersion metadata url with plugin route auth",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   providers:
     authentication: corporate
@@ -3917,7 +3917,7 @@ plugins:
 		{
 			name: "apiVersion metadata url with nested source auth",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -3930,7 +3930,7 @@ plugins:
 		{
 			name: "provider metadata url with nested source auth",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
   authentication:
     primary:
@@ -4007,7 +4007,7 @@ plugins:
 		{
 			name: "provider auth override is rejected outside plugins",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
   cache:
     shared:
@@ -4086,7 +4086,7 @@ func TestLoadPathsRequiresAPIVersionInEveryFile(t *testing.T) {
 	basePath := filepath.Join(dir, "base.yaml")
 	overridePath := filepath.Join(dir, "override.yaml")
 	if err := os.WriteFile(basePath, []byte(`
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
   external:
@@ -4187,7 +4187,7 @@ func TestValidConfigurations(t *testing.T) {
 		{
 			name: "metadata source plugin only",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     custom_tool:
@@ -4268,12 +4268,12 @@ plugins:
     external:
       {}
 `,
-			wantErr: "source.path or metadata URL is required",
+			wantErr: "source.path or provider-release metadata URL is required",
 		},
 		{
 			name: "apiVersion route auth override is valid",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   providers:
     authentication: corporate
@@ -4291,7 +4291,7 @@ plugins:
 		{
 			name: "apiVersion github release source with nested source auth is valid",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4307,7 +4307,7 @@ plugins:
 		{
 			name: "apiVersion github release source requires repo",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4321,7 +4321,7 @@ plugins:
 		{
 			name: "apiVersion github release source requires owner slash name",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4336,7 +4336,7 @@ plugins:
 		{
 			name: "apiVersion nested source auth is valid",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4349,7 +4349,7 @@ plugins:
 		{
 			name: "plugin auth override is valid alongside nested source auth",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   providers:
     authentication: corporate
@@ -4370,7 +4370,7 @@ plugins:
 		{
 			name: "plugin auth override rejects source auth token mix",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4384,7 +4384,7 @@ plugins:
 		{
 			name: "plugin auth override rejects unknown auth provider",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4397,7 +4397,7 @@ plugins:
 		{
 			name: "plugin auth override rejects server alias without configured auth provider",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4410,7 +4410,7 @@ plugins:
 		{
 			name: "apiVersion local source rejects sibling auth",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4454,7 +4454,7 @@ plugins:
 `,
 		},
 		{
-			name: "apiVersion v4 rejects local source manifests",
+			name: "apiVersion accepts local source manifests",
 			yaml: `
 apiVersion: gestaltd.config/v4
 providers:
@@ -4462,12 +4462,11 @@ plugins:
     external:
       source: ./plugins/dummy/manifest.yaml
 `,
-			wantErr: "source.path must reference provider-release.yaml metadata",
 		},
 		{
 			name: "apiVersion accepts absolute http metadata source",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4477,18 +4476,18 @@ plugins:
 		{
 			name: "apiVersion rejects git scalar source",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
       source: git+ssh://git@github.com/example/external.git
 `,
-			wantErr: "git+ sources are not supported in apiVersion v3 configs",
+			wantErr: "git+ sources are not supported",
 		},
 		{
 			name: "apiVersion rejects unsupported ssh scalar source",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4499,7 +4498,7 @@ plugins:
 		{
 			name: "apiVersion rejects unsupported file scalar source",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4510,7 +4509,7 @@ plugins:
 		{
 			name: "apiVersion rejects malformed hostless https metadata source",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     external:
@@ -4521,7 +4520,7 @@ plugins:
 		{
 			name: "apiVersion accepts absolute telemetry metadata source before builtin defaulting",
 			yaml: `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
   telemetry:
     default:
@@ -4647,7 +4646,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 					"sample": {},
 				},
 			},
-			wantErr: "source.path or metadata URL is required",
+			wantErr: "source.path or provider-release metadata URL is required",
 		},
 		{
 			name: "authentication provider valid",
@@ -4668,7 +4667,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 					Authentication: singletonProviderEntry(&ProviderEntry{}),
 				},
 			},
-			wantErr: `source.path or metadata URL is required`,
+			wantErr: `source.path or provider-release metadata URL is required`,
 		},
 		{
 			name: "authentication config requires source",
@@ -4677,7 +4676,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 					Authentication: singletonProviderEntry(&ProviderEntry{Config: yaml.Node{Kind: yaml.MappingNode}}),
 				},
 			},
-			wantErr: `source.path or metadata URL is required`,
+			wantErr: `source.path or provider-release metadata URL is required`,
 		},
 		{
 			name: "plugin auth rejects mcp oauth early",
@@ -4711,7 +4710,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if tc.cfg != nil && strings.TrimSpace(tc.cfg.APIVersion) == "" {
-				tc.cfg.APIVersion = APIVersionV3
+				tc.cfg.APIVersion = ConfigAPIVersion
 			}
 			err := ValidateStructure(tc.cfg)
 			if tc.wantErr == "" {
@@ -4748,7 +4747,7 @@ func TestLoadConfigResolvesRelativePaths(t *testing.T) {
 		t.Fatalf("MkdirAll config dir: %v", err)
 	}
 	if err := os.WriteFile(cfgPath, []byte(`
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
   authentication:
     authentication:
@@ -4799,7 +4798,7 @@ func TestLoadPaths_ResolvesRelativeScalarSourcePathsPerFile(t *testing.T) {
 		t.Fatalf("MkdirAll base: %v", err)
 	}
 	if err := os.WriteFile(basePath, []byte(`
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     sample:
@@ -4813,7 +4812,7 @@ plugins:
 		t.Fatalf("MkdirAll override: %v", err)
 	}
 	if err := os.WriteFile(overridePath, []byte(`
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
 plugins:
     sample:
@@ -4837,7 +4836,7 @@ func TestAuthConfigMap(t *testing.T) {
 	t.Parallel()
 
 	path := mustWriteConfigFile(t, `
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 providers:
   authentication:
     authentication:
@@ -4942,7 +4941,7 @@ func TestLoad_ResolvesRelativePluginSourcePath(t *testing.T) {
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `apiVersion: gestaltd.config/v3
+	cfg := `apiVersion: gestaltd.config/v4
 providers:
 plugins:
     sample:

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -51,7 +51,6 @@ func CanonicalizeStructure(cfg *Config) error {
 // already run on the config.
 func ValidateCanonicalStructure(cfg *Config) error {
 	pluginOwnedUIBindings := pluginOwnedUIBindings(cfg)
-	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	if err := validateAuthorizationPolicies(cfg); err != nil {
 		return err
 	}
@@ -87,7 +86,7 @@ func ValidateCanonicalStructure(cfg *Config) error {
 		{HostProviderKindTelemetry, cfg.Providers.Telemetry},
 		{HostProviderKindAudit, cfg.Providers.Audit},
 	} {
-		if err := validateHostProviderEntries(collection.kind, collection.entries, sourceSyntax); err != nil {
+		if err := validateHostProviderEntries(collection.kind, collection.entries); err != nil {
 			return err
 		}
 		if _, _, err := cfg.SelectedHostProvider(collection.kind); err != nil {
@@ -104,7 +103,7 @@ func ValidateCanonicalStructure(cfg *Config) error {
 		if entry.Source.IsBuiltin() {
 			return fmt.Errorf("config validation: ui %q does not support builtin providers; use a provider source reference", name)
 		}
-		if err := validateProviderEntrySource("ui", name, &entry.ProviderEntry, sourceSyntax); err != nil {
+		if err := validateProviderEntrySource("ui", name, &entry.ProviderEntry); err != nil {
 			return err
 		}
 		if err := validateAuthorizationPolicyReference(cfg, "ui", name, entry.AuthorizationPolicy); err != nil {
@@ -143,7 +142,7 @@ func ValidateCanonicalStructure(cfg *Config) error {
 
 	// Validate plugins
 	for name, entry := range cfg.Plugins {
-		if err := validatePlugin(cfg, name, entry, sourceSyntax); err != nil {
+		if err := validatePlugin(cfg, name, entry); err != nil {
 			return err
 		}
 	}
@@ -178,10 +177,10 @@ func validateAPIVersion(cfg *Config) error {
 		return nil
 	}
 	// YAML roots require apiVersion before this point; direct programmatic
-	// Config values may omit it and use v3 source normalization.
+	// Config values may omit it and use current source normalization.
 	apiVersion := strings.TrimSpace(cfg.APIVersion)
 	switch apiVersion {
-	case "", APIVersionV3, APIVersionV4:
+	case "", ConfigAPIVersion:
 		return nil
 	default:
 		return fmt.Errorf("config validation: unsupported apiVersion %q", apiVersion)
@@ -189,10 +188,10 @@ func validateAPIVersion(cfg *Config) error {
 }
 
 func requiredAPIVersionError() error {
-	return fmt.Errorf("config validation: apiVersion is required; supported values are %q or %q", APIVersionV3, APIVersionV4)
+	return fmt.Errorf("config validation: apiVersion is required; supported value is %q", ConfigAPIVersion)
 }
 
-func validateHostProviderEntries(kind HostProviderKind, entries map[string]*ProviderEntry, sourceSyntax providerSourceSyntaxMode) error {
+func validateHostProviderEntries(kind HostProviderKind, entries map[string]*ProviderEntry) error {
 	for name, entry := range entries {
 		if entry == nil {
 			return fmt.Errorf("config validation: providers.%s.%s is required", kind, name)
@@ -205,26 +204,26 @@ func validateHostProviderEntries(kind HostProviderKind, entries map[string]*Prov
 			if entry.Source.IsBuiltin() {
 				return fmt.Errorf("config validation: authentication provider %q does not support builtin providers; use a provider source reference or omit authentication", name)
 			}
-			if err := validateProviderEntrySource("authentication", name, entry, sourceSyntax); err != nil {
+			if err := validateProviderEntrySource("authentication", name, entry); err != nil {
 				return err
 			}
 		case HostProviderKindAuthorization:
 			if entry.Source.IsBuiltin() {
 				return fmt.Errorf("config validation: authorization provider %q does not support builtin providers; use a provider source reference or omit authorization", name)
 			}
-			if err := validateProviderEntrySource("authorization", name, entry, sourceSyntax); err != nil {
+			if err := validateProviderEntrySource("authorization", name, entry); err != nil {
 				return err
 			}
 		case HostProviderKindExternalCredentials:
 			if entry.Source.IsBuiltin() {
 				return fmt.Errorf("config validation: externalCredentials provider %q does not support builtin providers; use a provider source reference or omit externalCredentials", name)
 			}
-			if err := validateProviderEntrySource("externalCredentials", name, entry, sourceSyntax); err != nil {
+			if err := validateProviderEntrySource("externalCredentials", name, entry); err != nil {
 				return err
 			}
 		case HostProviderKindSecrets, HostProviderKindTelemetry:
 			if !entry.Source.IsBuiltin() {
-				if err := validateProviderEntrySource(string(kind), name, entry, sourceSyntax); err != nil {
+				if err := validateProviderEntrySource(string(kind), name, entry); err != nil {
 					return err
 				}
 			}
@@ -234,7 +233,7 @@ func validateHostProviderEntries(kind HostProviderKind, entries map[string]*Prov
 					return err
 				}
 			} else {
-				if err := validateProviderEntrySource("audit", name, entry, sourceSyntax); err != nil {
+				if err := validateProviderEntrySource("audit", name, entry); err != nil {
 					return err
 				}
 			}
@@ -292,7 +291,7 @@ func validateBuiltinAudit(entry *ProviderEntry) error {
 	}
 }
 
-func validateProviderEntrySource(kind, name string, entry *ProviderEntry, sourceSyntax providerSourceSyntaxMode) error {
+func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error {
 	if entry == nil {
 		return nil
 	}
@@ -306,7 +305,7 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry, source
 	}
 	if src.UnsupportedURL() != "" {
 		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(src.UnsupportedURL())), "git+") {
-			return fmt.Errorf("config validation: %s %q git+ sources are not supported in apiVersion v3 configs", kind, name)
+			return fmt.Errorf("config validation: %s %q git+ sources are not supported", kind, name)
 		}
 		return fmt.Errorf("config validation: %s %q only provider-release.yaml metadata URLs are supported for remote sources", kind, name)
 	}
@@ -324,19 +323,10 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry, source
 		modeCount++
 	}
 	if modeCount == 0 {
-		if sourceSyntax == providerSourceSyntaxV4 {
-			return fmt.Errorf("config validation: %s %q source.path or provider-release metadata URL is required", kind, name)
-		}
-		return fmt.Errorf("config validation: %s %q source.path or metadata URL is required", kind, name)
+		return fmt.Errorf("config validation: %s %q source.path or provider-release metadata URL is required", kind, name)
 	}
 	if modeCount > 1 {
-		if sourceSyntax == providerSourceSyntaxV4 {
-			return fmt.Errorf("config validation: %s %q local and remote provider-release metadata sources are mutually exclusive", kind, name)
-		}
 		return fmt.Errorf("config validation: %s %q source.path and metadata URL sources are mutually exclusive", kind, name)
-	}
-	if src.IsLocal() && sourceSyntax == providerSourceSyntaxV4 {
-		return fmt.Errorf("config validation: %s %q apiVersion v4 source.path must reference provider-release.yaml metadata, not a source manifest", kind, name)
 	}
 	if src.IsLocalMetadataPath() {
 		if path.Base(filepath.ToSlash(src.MetadataPath())) != "provider-release.yaml" {
@@ -444,7 +434,6 @@ func validateRuntimeConfig(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
-	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	cfg.Server.Runtime.DefaultHostedProvider = strings.TrimSpace(cfg.Server.Runtime.DefaultHostedProvider)
 	for name, entry := range cfg.Runtime.Providers {
 		if entry == nil {
@@ -459,7 +448,7 @@ func validateRuntimeConfig(cfg *Config) error {
 			if entry.Source.IsBuiltin() {
 				return fmt.Errorf("config validation: runtime provider %q does not support builtin providers; use a provider source reference or driver: %q", name, RuntimeProviderDriverLocal)
 			}
-			if err := validateProviderEntrySource("runtime", name, &entry.ProviderEntry, sourceSyntax); err != nil {
+			if err := validateProviderEntrySource("runtime", name, &entry.ProviderEntry); err != nil {
 				return err
 			}
 		case RuntimeProviderDriverLocal:
@@ -491,7 +480,7 @@ func runtimeProviderUsesSource(entry *RuntimeProviderEntry) bool {
 		entry.Source.UnsupportedURL() != ""
 }
 
-func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax providerSourceSyntaxMode) error {
+func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 	if entry == nil {
 		return fmt.Errorf("config validation: plugin %q requires a source", name)
 	}
@@ -539,7 +528,7 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax
 	if entry.UI != "" && entry.MountPath == "" {
 		return fmt.Errorf("config validation: plugins.%s.ui.bundle requires plugins.%s.ui.path", name, name)
 	}
-	if err := validateProviderEntrySource("plugin", name, entry, sourceSyntax); err != nil {
+	if err := validateProviderEntrySource("plugin", name, entry); err != nil {
 		return err
 	}
 	if err := validatePluginRouteAuth(cfg, name, entry); err != nil {
@@ -588,7 +577,6 @@ func validatePluginRouteAuth(cfg *Config, name string, entry *ProviderEntry) err
 }
 
 func validateDatastoreConfig(cfg *Config) error {
-	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	for name, entry := range cfg.Providers.IndexedDB {
 		if entry == nil {
 			return fmt.Errorf("config validation: providers.indexeddb.%s is required", name)
@@ -596,7 +584,7 @@ func validateDatastoreConfig(cfg *Config) error {
 		if err := validatePluginOnlyProviderFields("providers.indexeddb."+name, entry); err != nil {
 			return err
 		}
-		if err := validateProviderEntrySource("indexeddb", name, entry, sourceSyntax); err != nil {
+		if err := validateProviderEntrySource("indexeddb", name, entry); err != nil {
 			return err
 		}
 	}
@@ -607,7 +595,6 @@ func validateDatastoreConfig(cfg *Config) error {
 }
 
 func validateCacheConfig(cfg *Config) error {
-	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	for name, entry := range cfg.Providers.Cache {
 		if entry == nil {
 			return fmt.Errorf("config validation: providers.cache.%s is required", name)
@@ -618,7 +605,7 @@ func validateCacheConfig(cfg *Config) error {
 		if err := validatePluginOnlyProviderFields("providers.cache."+name, entry); err != nil {
 			return err
 		}
-		if err := validateProviderEntrySource("cache", name, entry, sourceSyntax); err != nil {
+		if err := validateProviderEntrySource("cache", name, entry); err != nil {
 			return err
 		}
 	}
@@ -626,7 +613,6 @@ func validateCacheConfig(cfg *Config) error {
 }
 
 func validateS3Config(cfg *Config) error {
-	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	for name, entry := range cfg.Providers.S3 {
 		if entry == nil {
 			return fmt.Errorf("config validation: providers.s3.%s is required", name)
@@ -634,7 +620,7 @@ func validateS3Config(cfg *Config) error {
 		if err := validatePluginOnlyProviderFields("providers.s3."+name, entry); err != nil {
 			return err
 		}
-		if err := validateProviderEntrySource("s3", name, entry, sourceSyntax); err != nil {
+		if err := validateProviderEntrySource("s3", name, entry); err != nil {
 			return err
 		}
 	}
@@ -642,7 +628,6 @@ func validateS3Config(cfg *Config) error {
 }
 
 func validateWorkflowConfig(cfg *Config) error {
-	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	defaults := make([]string, 0, len(cfg.Providers.Workflow))
 	for name, entry := range cfg.Providers.Workflow {
 		if entry == nil {
@@ -661,7 +646,7 @@ func validateWorkflowConfig(cfg *Config) error {
 		if err := validateWorkflowProviderFields(cfg, name, entry); err != nil {
 			return err
 		}
-		if err := validateProviderEntrySource("workflow", name, entry, sourceSyntax); err != nil {
+		if err := validateProviderEntrySource("workflow", name, entry); err != nil {
 			return err
 		}
 	}
@@ -673,7 +658,6 @@ func validateWorkflowConfig(cfg *Config) error {
 }
 
 func validateAgentConfig(cfg *Config) error {
-	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	defaults := make([]string, 0, len(cfg.Providers.Agent))
 	for name, entry := range cfg.Providers.Agent {
 		if entry == nil {
@@ -697,7 +681,7 @@ func validateAgentConfig(cfg *Config) error {
 		if err := validateAgentProviderFields(cfg, name, entry); err != nil {
 			return err
 		}
-		if err := validateProviderEntrySource("agent", name, entry, sourceSyntax); err != nil {
+		if err := validateProviderEntrySource("agent", name, entry); err != nil {
 			return err
 		}
 	}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -312,10 +312,10 @@ func TestSourcePluginMetadataURLInitAndLockedLoad(t *testing.T) {
 		remoteArchives     bool
 		tamperLocalArchive bool
 	}{
-		{name: "remote metadata url", apiVersion: config.APIVersionV3},
-		{name: "local metadata file", apiVersion: config.APIVersionV4, localSource: true},
-		{name: "local metadata file with remote archives", apiVersion: config.APIVersionV4, localSource: true, remoteArchives: true},
-		{name: "local metadata file rejects tampered archive", apiVersion: config.APIVersionV4, localSource: true, tamperLocalArchive: true},
+		{name: "remote metadata url", apiVersion: config.ConfigAPIVersion},
+		{name: "local metadata file", apiVersion: config.ConfigAPIVersion, localSource: true},
+		{name: "local metadata file with remote archives", apiVersion: config.ConfigAPIVersion, localSource: true, remoteArchives: true},
+		{name: "local metadata file rejects tampered archive", apiVersion: config.ConfigAPIVersion, localSource: true, tamperLocalArchive: true},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -830,7 +830,7 @@ func TestSourceWorkflowMetadataURLInitAndLockedLoad(t *testing.T) {
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
-	configYAML := "apiVersion: " + config.APIVersionV3 + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+	configYAML := "apiVersion: " + config.ConfigAPIVersion + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"  workflow:",
 		"    runner:",
 		"      source:",
@@ -998,7 +998,7 @@ func TestSourceExternalCredentialsMetadataURLInitAndLockedLoad(t *testing.T) {
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
-	configYAML := "apiVersion: " + config.APIVersionV3 + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+	configYAML := "apiVersion: " + config.ConfigAPIVersion + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"  externalCredentials:",
 		"    runner:",
 		"      source:",
@@ -1177,7 +1177,7 @@ func TestSourceUIMetadataURLInitAndLockedLoad(t *testing.T) {
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
-	configYAML := "apiVersion: " + config.APIVersionV3 + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+	configYAML := "apiVersion: " + config.ConfigAPIVersion + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"  ui:",
 		"    roadmap:",
 		"      source:",
@@ -1327,7 +1327,7 @@ func TestSourcePluginInitRejectsMetadataSourceManifestMismatch(t *testing.T) {
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		"plugins:",
 		"  gadget:",
 		"    source: " + srv.URL + metadataPath,
@@ -1453,7 +1453,7 @@ func TestSourcePluginMetadataURLUsesGenericAuthenticatedFetch(t *testing.T) {
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		"plugins:",
 		"  alpha:",
 		"    source:",
@@ -1654,7 +1654,7 @@ func TestSourcePluginGitHubReleaseSourceUsesResolvedAssetURL(t *testing.T) {
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		"plugins:",
 		"  alpha:",
 		"    source:",
@@ -1781,7 +1781,7 @@ func TestSourcePluginMetadataURLRetriesTransientRemoteMetadataFailure(t *testing
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		"plugins:",
 		"  alpha:",
 		"    source:",
@@ -1856,7 +1856,7 @@ func TestSourcePluginMetadataURLRejectsOversizedRemoteMetadata(t *testing.T) {
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		"plugins:",
 		"  alpha:",
 		"    source:",
@@ -1989,7 +1989,7 @@ func TestSourcePluginMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		"plugins:",
 		"  alpha:",
 		"    source:",
@@ -2189,7 +2189,7 @@ func TestSourcePluginLoadForExecution_RehydratesWhenCachedManifestVersionMismatc
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		"plugins:",
 		"  gadget:",
 		"    source: " + srv.URL + metadataPath,
@@ -2327,7 +2327,7 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
 		"  secrets:",
 		"    secrets:",
@@ -2498,7 +2498,7 @@ func TestSourceAuthPluginInitAllowsMissingEnvPlaceholderInNonStringField(t *test
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
 		"  secrets:",
 		"    secrets:",
@@ -2573,7 +2573,7 @@ func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		"providers:",
 		"  indexeddb:",
 		"    main:",
@@ -2654,7 +2654,7 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	indexedDBManifestPath := writeStubIndexedDBManifest(t, dir)
 	configYAML := strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		"providers:",
 		"  secrets:",
 		"    session:",
@@ -2778,8 +2778,8 @@ func TestManagedCacheSourcesInitAtPathWithPlatformsHashesExtraPlatformArchives(t
 		apiVersion  string
 		localSource bool
 	}{
-		{name: "remote metadata url", apiVersion: config.APIVersionV3},
-		{name: "local metadata file", apiVersion: config.APIVersionV4, localSource: true},
+		{name: "remote metadata url", apiVersion: config.ConfigAPIVersion},
+		{name: "local metadata file", apiVersion: config.ConfigAPIVersion, localSource: true},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -3123,7 +3123,7 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
 		"  secrets:",
 		"    bootstrap:",
@@ -3360,7 +3360,7 @@ func TestLoadForExecutionAtPath_UnlockedBootstrapMetadataInitPreparesOnce(t *tes
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
 		"  secrets:",
 		"    bootstrap:",
@@ -3489,7 +3489,7 @@ func TestLoadForExecutionAtPath_UnlockedMetadataSecretsProviderResolvesConfigSec
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
+		"apiVersion: " + config.ConfigAPIVersion,
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
 		"  secrets:",
 		"    secrets:",

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -130,9 +130,9 @@ func requiredComponentConfigYAML(t *testing.T, dir, dbPath string) string {
 `, manifestPath, dbPath)
 }
 
-func requiredComponentConfigV3YAML(t *testing.T, dir, dbPath string) string {
+func requiredComponentConfigWithAPIVersionYAML(t *testing.T, dir, dbPath string) string {
 	t.Helper()
-	return "apiVersion: " + config.APIVersionV3 + "\n" + requiredComponentConfigYAML(t, dir, dbPath)
+	return "apiVersion: " + config.ConfigAPIVersion + "\n" + requiredComponentConfigYAML(t, dir, dbPath)
 }
 
 func requiredServerDatastoreYAML() string {
@@ -509,7 +509,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -574,7 +574,7 @@ spec:
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     notion:
       source:
         path: ./manifest.yaml
@@ -681,7 +681,7 @@ spec:
 			}
 
 			cfgPath := filepath.Join(dir, "config.yaml")
-			cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+			cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -769,7 +769,7 @@ func TestInitAtPath_RejectsInvalidPluginInvokesShape(t *testing.T) {
 
 			caseDir := t.TempDir()
 			cfgPath := filepath.Join(caseDir, "config.yaml")
-			cfg := requiredComponentConfigV3YAML(t, caseDir, filepath.Join(caseDir, "gestalt.db")) + tc.body + `server:
+			cfg := requiredComponentConfigWithAPIVersionYAML(t, caseDir, filepath.Join(caseDir, "gestalt.db")) + tc.body + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `
 			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -792,7 +792,7 @@ func TestInitAtPath_AllowsInvokesAgainstEffectiveAlias(t *testing.T) {
 	targetManifestPath := writeLocalExecutablePlugin(t, dir, "target", "ping")
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -825,7 +825,7 @@ func TestInitAtPath_RejectsHybridExecutableStaticOperationByOriginalNameAfterAli
 	targetManifestPath := writeLocalExecutableOpenAPIPlugin(t, dir, "target", []string{"ping"}, []string{"status"})
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -860,7 +860,7 @@ func TestInitAtPath_RejectsHybridExecutableDuplicateEffectiveOperation(t *testin
 	targetManifestPath := writeLocalExecutableOpenAPIPlugin(t, dir, "target", []string{"ping"}, []string{"status"})
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     target:
       source:
         path: %q
@@ -937,7 +937,7 @@ func TestInitAtPath_AllowsManagedPluginInvokesOnFirstInit(t *testing.T) {
 	defer srv.Close()
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source: %s/providers/caller/v%s/provider-release.yaml
       invokes:
@@ -970,7 +970,7 @@ func TestInitAtPath_RejectsSessionCatalogOnlyInvokesTarget(t *testing.T) {
 	targetManifestPath := writeLocalMCPSpecPlugin(t, dir, "target")
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -1001,7 +1001,7 @@ func TestInitAtPath_DoesNotWriteLockfileWhenInvokesValidationFails(t *testing.T)
 	targetManifestPath := writeLocalExecutablePlugin(t, dir, "target", "ping")
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -1035,7 +1035,7 @@ func TestInitAtPath_RejectsHybridMCPTypoAsUnknownOperation(t *testing.T) {
 	targetManifestPath := writeLocalOpenAPIAndMCPSpecPlugin(t, dir, "target")
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -1069,7 +1069,7 @@ func TestLoadForExecutionAtPath_RejectsInvalidPluginInvokesDependency(t *testing
 	targetManifestPath := writeLocalExecutablePlugin(t, dir, "target", "ping")
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -1147,7 +1147,7 @@ paths:
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
@@ -1378,7 +1378,7 @@ plugins:
 			}
 
 			cfgPath := filepath.Join(dir, "config.yaml")
-			cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + tc.uiConfigYAML + tc.extraYAML + `server:
+			cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + tc.uiConfigYAML + tc.extraYAML + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `
 			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -1476,7 +1476,7 @@ func TestLoadForExecutionAtPath_RejectsLockedExplicitLocalUIWithoutPreparedUILoc
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
     roadmap:
       source:
         path: ./ui/manifest.yaml
@@ -1617,7 +1617,7 @@ func TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath(t *t
 	defer srv.Close()
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
   roadmap:
     source: ` + srv.URL + `/providers/roadmap-plugin/v` + version + `/provider-release.yaml
     ui:
@@ -1710,7 +1710,7 @@ func TestLoadForExecutionAtPath_ReinitializesManagedPluginWhenGenericArchiveLock
 	defer srv.Close()
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
   roadmap:
     source: ` + srv.URL + `/providers/roadmap-plugin/v` + version + `/provider-release.yaml
 server:
@@ -1851,7 +1851,7 @@ func TestLoadForExecutionAtPath_LockedManagedDeclarativePluginMaterializesBefore
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	writeConfig := func(version string) {
-		cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+		cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
   roadmap:
     source: ` + srv.URL + `/providers/roadmap-plugin/v` + version + `/provider-release.yaml
 server:
@@ -1947,7 +1947,7 @@ server:
   providers:
     indexeddb: main
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-`, config.APIVersionV3, indexedDBManifestPath, filepath.Join(dir, "gestalt.db"), uiManifestPath, pluginManifestPath)
+`, config.ConfigAPIVersion, indexedDBManifestPath, filepath.Join(dir, "gestalt.db"), uiManifestPath, pluginManifestPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
@@ -2110,7 +2110,7 @@ func TestInitAtPath_RejectsManagedPluginOwnedUIPathOutsidePackage(t *testing.T) 
 	defer srv.Close()
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
   roadmap:
     source: ` + srv.URL + `/providers/roadmap-plugin/v` + version + `/provider-release.yaml
     ui:
@@ -2179,7 +2179,7 @@ func TestInitAtPath_RejectsPolicyBoundManagedMountedUIWithoutExplicitRouteCovera
 			defer srv.Close()
 
 			cfgPath := filepath.Join(dir, "config.yaml")
-			cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+			cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
     sample_portal:
       source: ` + srv.URL + `/providers/sample-portal/v0.0.1-alpha.1/provider-release.yaml
       path: /sample-portal
@@ -2356,7 +2356,7 @@ server:
     authentication: auth
     indexeddb: sqlite
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-`, config.APIVersionV3, idbManifestPath, "sqlite://"+dbPath)
+`, config.ConfigAPIVersion, idbManifestPath, "sqlite://"+dbPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
@@ -2445,7 +2445,7 @@ server:
     authentication: auth
     indexeddb: sqlite
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-`, config.APIVersionV3, idbManifestPath, "sqlite://"+dbPath)
+`, config.ConfigAPIVersion, idbManifestPath, "sqlite://"+dbPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
@@ -2507,7 +2507,7 @@ func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalSourceHybridPlugin
 	writeTestFile("manifest.yaml", manifest, 0o644)
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -2692,7 +2692,7 @@ def session_catalog(request: gestalt.Request) -> gestalt.Catalog:
 	}
 	writeTestFile("manifest.yaml", manifest, 0o644)
 
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -3034,7 +3034,7 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+	cfg := requiredComponentConfigWithAPIVersionYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -3065,7 +3065,7 @@ func TestLockMatchesConfig_FalseWithNilLock(t *testing.T) {
 
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(cfgPath, []byte("apiVersion: "+config.APIVersionV3+"\nserver:\n  public:\n    port: 8080\n"), 0644); err != nil {
+	if err := os.WriteFile(cfgPath, []byte("apiVersion: "+config.ConfigAPIVersion+"\nserver:\n  public:\n    port: 8080\n"), 0644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -110,7 +110,7 @@ func GenerateDefaultConfig(configDir string) (string, error) {
 }
 
 func defaultManagedConfig(dbPath, encryptionKey string) string {
-	return fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	return fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   public:
     port: 8080
@@ -145,7 +145,7 @@ plugins:
 }
 
 func defaultLocalSourceConfig(providersDir, dbPath, encryptionKey string) string {
-	return fmt.Sprintf(`apiVersion: gestaltd.config/v3
+	return fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   public:
     port: 8080

--- a/gestaltd/internal/testutil/testdata/provider-go/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-go/config.yaml
@@ -1,4 +1,4 @@
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   encryptionKey: dev-key-for-example-only
   providers:

--- a/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
@@ -1,4 +1,4 @@
-apiVersion: gestaltd.config/v3
+apiVersion: gestaltd.config/v4
 server:
   encryptionKey: dev-key-for-example-only
   providers:


### PR DESCRIPTION
## Summary
- Remove the v3/v4 provider source syntax branch from gestaltd config loading and validation.
- Make `gestaltd.config/v4` the only supported YAML config apiVersion, represented internally as `config.ConfigAPIVersion` instead of version-specific constants.
- Keep provider-dev/local source manifests working by classifying local paths by basename: `provider-release.yaml` is release metadata; other local paths are source manifests.
- Update generated local configs, Helm/docs examples, and config/operator/CLI tests to the single supported contract.

## Interface / Contract Diff
```diff
- const APIVersionV3 = "gestaltd.config/v3"
- const APIVersionV4 = "gestaltd.config/v4"
+ const ConfigAPIVersion = "gestaltd.config/v4"

- apiVersion: gestaltd.config/v3
- apiVersion: gestaltd.config/v4
+ apiVersion: gestaltd.config/v4

- # local source interpretation depended on apiVersion
- # v3: source.path/scalar local paths were source manifests
- # v4: source.path/scalar local paths were provider-release metadata
+ # local source interpretation is path-based
+ # */provider-release.yaml is provider-release metadata
+ # all other local paths are source manifests
```

## Examples
```yaml
apiVersion: gestaltd.config/v4
plugins:
  localDev:
    source: ./manifest.yaml
  localRelease:
    source: ./dist/provider-release.yaml
  remoteRelease:
    source: https://example.com/provider-release.yaml
```

```yaml
apiVersion: gestaltd.config/v4
providers:
  workflow:
    local:
      source:
        path: ./providers/workflow/indexeddb/manifest.yaml
```

## Deployment Check
Latest `valon-tools` deploy configs on `origin/main` are already `gestaltd.config/v4`:
- `valon-tools/deploy/config.yaml`
- `valon-tools/deploy/prod/config.yaml`
- `valon-tools/deploy/brain/prod.config.yaml`
- `valon-tools/deploy/brain/deploy-snippet.yaml`

A local layered `gestaltd validate` reaches provider release resolution after placeholder env expansion, then fails with a 401 for private GitHub release metadata without real deployment credentials. That confirms the config contract clears locally up to credential-gated provider staging.

## Verification
```sh
env GOCACHE=/Users/hugh/src/.codex-worktrees/gestalt-next-legacy-cleanup/.gocache \
  TMPDIR=/Users/hugh/src/.codex-worktrees/gestalt-next-legacy-cleanup/.tmp \
  go test -count=1 ./internal/config ./internal/operator ./cmd/gestaltd
```

```sh
rg -n "APIVersionV3|APIVersionV4|gestaltd\\.config/v3|providerSourceSyntax|sourceSyntaxForConfig|apiVersion v3|v3 configs|mixed apiVersion|v4 rejects local source manifests|sourceSyntax" \
  gestaltd docs sdk gestalt \
  --glob '!gestaltd/internal/adminui/out/**' \
  --glob '!**/gen/**' \
  --glob '!**/generated/**' \
  --glob '!**/node_modules/**' \
  --glob '!**/target/**'
```