### PR TITLE
Recover accepted agent turns after create timeout

### DIFF
--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -53,6 +53,8 @@ const (
 	maxAgentRouteCacheEntries         = 20_000
 	AgentListSummaryDefaultLimit      = 100
 	AgentListMaxLimit                 = 500
+	agentCreateTurnRecoveryTimeout    = 15 * time.Second
+	agentCreateTurnRecoveryInterval   = 250 * time.Millisecond
 )
 
 type AgentProviderNotAvailableError struct {
@@ -621,10 +623,7 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 		ToolGrant:       toolGrant,
 	})
 	if err != nil {
-		fallback, getErr := ownedSession.provider.GetTurn(ctx, coreagent.GetTurnRequest{
-			TurnID:  turnID,
-			Subject: agentSubjectFromPrincipal(p),
-		})
+		fallback, getErr := recoverCreatedTurnAfterError(ctx, ownedSession.provider, turnID, agentSubjectFromPrincipal(p), err)
 		if getErr == nil {
 			turn = fallback
 		} else {
@@ -640,6 +639,82 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	}
 	m.rememberTurnRoute(normalized.ID, ownedSession.providerName)
 	return normalized, nil
+}
+
+func recoverCreatedTurnAfterError(ctx context.Context, provider coreagent.Provider, turnID string, subject coreagent.SubjectContext, createErr error) (*coreagent.Turn, error) {
+	if provider == nil {
+		return nil, createErr
+	}
+	shouldPoll := shouldPollCreateTurnRecovery(createErr)
+	recoveryCtx := ctx
+	cancel := func() {}
+	if shouldPoll {
+		recoveryCtx, cancel = context.WithTimeout(ctx, agentCreateTurnRecoveryTimeout)
+	}
+	defer cancel()
+
+	turn, err := provider.GetTurn(recoveryCtx, coreagent.GetTurnRequest{
+		TurnID:  turnID,
+		Subject: subject,
+	})
+	if err == nil {
+		return turn, nil
+	}
+	if !shouldPoll || !isCreateTurnRecoveryGetRetryable(err) {
+		return nil, err
+	}
+
+	ticker := time.NewTicker(agentCreateTurnRecoveryInterval)
+	defer ticker.Stop()
+	lastErr := err
+	for {
+		select {
+		case <-recoveryCtx.Done():
+			return nil, lastErr
+		case <-ticker.C:
+			turn, err := provider.GetTurn(recoveryCtx, coreagent.GetTurnRequest{
+				TurnID:  turnID,
+				Subject: subject,
+			})
+			if err == nil {
+				return turn, nil
+			}
+			lastErr = err
+			if !isCreateTurnRecoveryGetRetryable(err) {
+				return nil, err
+			}
+		}
+	}
+}
+
+func shouldPollCreateTurnRecovery(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, ErrAgentProviderNotAvailable) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.DeadlineExceeded, codes.Unavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+func isCreateTurnRecoveryGetRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, core.ErrNotFound) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, ErrAgentProviderNotAvailable) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.NotFound, codes.DeadlineExceeded, codes.Unavailable:
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *Manager) GetTurn(ctx context.Context, p *principal.Principal, turnID string) (turn *coreagent.Turn, err error) {

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -111,6 +111,8 @@ type routeCountingAgentProvider struct {
 	turns           map[string]*coreagent.Turn
 	turnIDOverride  string
 	cancelStatus    coreagent.ExecutionStatus
+	createTurnFunc  func(coreagent.CreateTurnRequest) (*coreagent.Turn, error)
+	getTurnFunc     func(coreagent.GetTurnRequest) (*coreagent.Turn, error)
 	getSessionCalls int
 	getTurnCalls    int
 }
@@ -146,6 +148,9 @@ func (p *routeCountingAgentProvider) GetSession(_ context.Context, req coreagent
 }
 
 func (p *routeCountingAgentProvider) CreateTurn(_ context.Context, req coreagent.CreateTurnRequest) (*coreagent.Turn, error) {
+	if p.createTurnFunc != nil {
+		return p.createTurnFunc(req)
+	}
 	turnID := req.TurnID
 	if strings.TrimSpace(p.turnIDOverride) != "" {
 		turnID = p.turnIDOverride
@@ -166,6 +171,9 @@ func (p *routeCountingAgentProvider) CreateTurn(_ context.Context, req coreagent
 
 func (p *routeCountingAgentProvider) GetTurn(_ context.Context, req coreagent.GetTurnRequest) (*coreagent.Turn, error) {
 	p.getTurnCalls++
+	if p.getTurnFunc != nil {
+		return p.getTurnFunc(req)
+	}
 	turn := p.turns[strings.TrimSpace(req.TurnID)]
 	if turn == nil {
 		return nil, core.ErrNotFound
@@ -331,6 +339,74 @@ func TestManagerCreateTurnAcceptsProviderOwnedIDForIdempotentReplay(t *testing.T
 	}
 	if alpha.getTurnCalls != 1 {
 		t.Fatalf("GetTurn calls = %d, want 1 cached provider lookup", alpha.getTurnCalls)
+	}
+}
+
+func TestManagerCreateTurnRecoversLateAcceptedTurnAfterProviderDeadline(t *testing.T) {
+	t.Parallel()
+
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		ToolGrants: newAgentManagerTestToolGrants(t),
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	var accepted *coreagent.Turn
+	getTurnCalls := 0
+	alpha.createTurnFunc = func(req coreagent.CreateTurnRequest) (*coreagent.Turn, error) {
+		accepted = &coreagent.Turn{
+			ID:           req.TurnID,
+			SessionID:    req.SessionID,
+			ProviderName: alpha.name,
+			Model:        req.Model,
+			Status:       coreagent.ExecutionStatusRunning,
+			Messages:     append([]coreagent.Message(nil), req.Messages...),
+			CreatedBy:    req.CreatedBy,
+			ExecutionRef: req.ExecutionRef,
+		}
+		return nil, context.DeadlineExceeded
+	}
+	alpha.getTurnFunc = func(req coreagent.GetTurnRequest) (*coreagent.Turn, error) {
+		getTurnCalls++
+		if getTurnCalls == 1 {
+			return nil, core.ErrNotFound
+		}
+		if accepted == nil || strings.TrimSpace(req.TurnID) != accepted.ID {
+			return nil, core.ErrNotFound
+		}
+		return cloneRouteTurn(accepted), nil
+	}
+
+	turn, err := manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID:        session.ID,
+		IdempotencyKey:   "workflow:provider:run-1:turn:batch-1",
+		Model:            "test-model",
+		Messages:         []coreagent.Message{{Role: "user", Text: "hello"}},
+		CallerPluginName: "slack",
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if turn == nil || accepted == nil || turn.ID != accepted.ID {
+		t.Fatalf("CreateTurn = %#v, want recovered accepted turn %#v", turn, accepted)
+	}
+	if getTurnCalls < 2 {
+		t.Fatalf("GetTurn calls = %d, want retry after initial miss", getTurnCalls)
 	}
 }
 

--- a/gestaltd/internal/providerhost/agent_manager_server_test.go
+++ b/gestaltd/internal/providerhost/agent_manager_server_test.go
@@ -3,11 +3,16 @@ package providerhost
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/internal/agentgrant"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -65,6 +70,134 @@ func (s *recordingAgentManagerService) ListInteractions(context.Context, *princi
 
 func (s *recordingAgentManagerService) ResolveInteraction(context.Context, *principal.Principal, string, string, map[string]any) (*coreagent.Interaction, error) {
 	return nil, errors.New("unexpected ResolveInteraction call")
+}
+
+type lateAcceptedTurnAgentControl struct {
+	provider *lateAcceptedTurnAgentProvider
+}
+
+func (c lateAcceptedTurnAgentControl) ResolveProviderSelection(name string) (string, coreagent.Provider, error) {
+	if strings.TrimSpace(name) == "" || strings.TrimSpace(name) == "managed" {
+		return "managed", c.provider, nil
+	}
+	return "", nil, agentmanager.NewAgentProviderNotAvailableError(name)
+}
+
+func (c lateAcceptedTurnAgentControl) ResolveProvider(name string) (coreagent.Provider, error) {
+	_, provider, err := c.ResolveProviderSelection(name)
+	return provider, err
+}
+
+func (c lateAcceptedTurnAgentControl) ProviderNames() []string {
+	return []string{"managed"}
+}
+
+type lateAcceptedTurnAgentProvider struct {
+	coreagent.UnimplementedProvider
+	session      *coreagent.Session
+	acceptedTurn *coreagent.Turn
+	getTurnCalls int
+}
+
+func (p *lateAcceptedTurnAgentProvider) CreateSession(_ context.Context, req coreagent.CreateSessionRequest) (*coreagent.Session, error) {
+	p.session = &coreagent.Session{
+		ID:           req.SessionID,
+		ProviderName: "managed",
+		Model:        req.Model,
+		State:        coreagent.SessionStateActive,
+		CreatedBy:    req.CreatedBy,
+	}
+	return p.session, nil
+}
+
+func (p *lateAcceptedTurnAgentProvider) GetSession(_ context.Context, req coreagent.GetSessionRequest) (*coreagent.Session, error) {
+	if p.session == nil || strings.TrimSpace(req.SessionID) != p.session.ID {
+		return nil, core.ErrNotFound
+	}
+	return p.session, nil
+}
+
+func (p *lateAcceptedTurnAgentProvider) CreateTurn(_ context.Context, req coreagent.CreateTurnRequest) (*coreagent.Turn, error) {
+	p.acceptedTurn = &coreagent.Turn{
+		ID:           req.TurnID,
+		SessionID:    req.SessionID,
+		ProviderName: "managed",
+		Model:        req.Model,
+		Status:       coreagent.ExecutionStatusRunning,
+		Messages:     append([]coreagent.Message(nil), req.Messages...),
+		CreatedBy:    req.CreatedBy,
+		ExecutionRef: req.ExecutionRef,
+	}
+	return nil, context.DeadlineExceeded
+}
+
+func (p *lateAcceptedTurnAgentProvider) GetTurn(_ context.Context, req coreagent.GetTurnRequest) (*coreagent.Turn, error) {
+	p.getTurnCalls++
+	if p.getTurnCalls == 1 || p.acceptedTurn == nil || strings.TrimSpace(req.TurnID) != p.acceptedTurn.ID {
+		return nil, core.ErrNotFound
+	}
+	return p.acceptedTurn, nil
+}
+
+func (p *lateAcceptedTurnAgentProvider) GetCapabilities(context.Context, coreagent.GetCapabilitiesRequest) (*coreagent.ProviderCapabilities, error) {
+	return &coreagent.ProviderCapabilities{NativeToolSearch: true}, nil
+}
+
+func TestAgentManagerServerCreateTurnRecoversLateAcceptedProviderTurn(t *testing.T) {
+	provider := &lateAcceptedTurnAgentProvider{}
+	grants, err := agentgrant.NewManager([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("agentgrant.NewManager: %v", err)
+	}
+	manager := agentmanager.New(agentmanager.Config{
+		Agent:      lateAcceptedTurnAgentControl{provider: provider},
+		ToolGrants: grants,
+	})
+	tokens, err := NewInvocationTokenManager([]byte("agent-manager-server-test-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+		Kind:      principal.KindUser,
+	})
+	token, err := tokens.MintRootToken(ctx, "caller-plugin", nil)
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+	server := NewAgentManagerServer("caller-plugin", manager, tokens)
+	conn := newBufconnConn(t, func(srv *grpc.Server) {
+		proto.RegisterAgentManagerHostServer(srv, server)
+	})
+	client := proto.NewAgentManagerHostClient(conn)
+
+	session, err := client.CreateSession(context.Background(), &proto.AgentManagerCreateSessionRequest{
+		InvocationToken: token,
+		ProviderName:    "managed",
+		Model:           "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	turn, err := client.CreateTurn(context.Background(), &proto.AgentManagerCreateTurnRequest{
+		InvocationToken: token,
+		SessionId:       session.GetId(),
+		Model:           "test-model",
+		IdempotencyKey:  "workflow:provider:run-1:turn:batch-1",
+		Messages: []*proto.AgentMessage{{
+			Role: "user",
+			Text: "hello",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if provider.acceptedTurn == nil || turn.GetId() != provider.acceptedTurn.ID {
+		t.Fatalf("CreateTurn returned %q, want accepted provider turn %#v", turn.GetId(), provider.acceptedTurn)
+	}
+	if provider.getTurnCalls < 2 {
+		t.Fatalf("GetTurn calls = %d, want retry after initial miss", provider.getTurnCalls)
+	}
 }
 
 func TestAgentManagerServerForwardsBoundedListRequests(t *testing.T) {


### PR DESCRIPTION
## Problem

Slack-triggered workflows can call `Manager.CreateTurn` through a hosted agent provider. If the provider accepts and persists the deterministic turn but the provider RPC returns `DeadlineExceeded`, the workflow currently fails before it can observe the accepted turn. That leaves a valid turn running without the workflow waiting on it.

## Interface

No new public API is required. Callers keep using `Manager.CreateTurn` with a deterministic idempotency key:

```go
turn, err := manager.CreateTurn(ctx, principal, coreagent.ManagerCreateTurnRequest{
    SessionID: session.ID,
    IdempotencyKey: "workflow:slack:run-123:turn:signal-batch",
    Messages: []coreagent.Message{{Role: "user", Text: "..."}},
    CallerPluginName: "slack",
})
```

Providers keep the existing contract: if `CreateTurn` accepted the request before the deadline, `GetTurn` for the deterministic turn ID should return that turn.

## Logic Flow

1. `Manager.CreateTurn` computes the deterministic turn ID from `SessionID + IdempotencyKey`.
2. It calls the provider `CreateTurn` as before.
3. If the provider returns success, behavior is unchanged.
4. If the provider returns an error, the existing immediate `GetTurn` fallback still runs.
5. If the create error is retryable at the provider boundary (`DeadlineExceeded` / `Unavailable`) and `GetTurn` initially misses or hits a transient read error, the manager briefly polls `GetTurn` for the same turn ID.
6. If the turn appears, the manager normalizes and authorizes it exactly like a direct create response. If it does not appear, the original create error is preserved.

## Verification

- `go test -count=1 ./internal/agentmanager`
- `go test -count=1 ./internal/bootstrap -run 'TestHostedAgentProviderPool(GetTurnRetriesAfterPreferredTimeout|GetTurnRetriesAfterStalePreferredMiss|SkipsPastDrainBackendForNewTurn)'`\n\nReviewer agent: no findings; also ran `go test -count=1 ./internal/agentmanager`.