### PR TITLE
Remove gestaltd init alias

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -17,7 +17,6 @@ import { Callout } from 'nextra/components'
 | `gestaltd lock --check --config PATH` | Verify that the checked-in lockfile matches the current config without rewriting it. |
 | `gestaltd sync --locked --config PATH` | Materialize prepared provider artifacts from an existing lockfile. |
 | `gestaltd sync --locked --check --config PATH` | Verify that prepared artifacts exist and match the lockfile without rewriting them. |
-| `gestaltd init --config PATH` | Legacy alias for `gestaltd lock`; writes lock metadata only. |
 | `gestaltd validate --config PATH` | Validate config without serving. Repeat `--config` to layer overrides. |
 | `gestaltd validate --lockfile PATH` | Accept the same explicit lockfile path used by `lock`, `sync`, and `serve` without mutating it. |
 | `gestaltd --version` | Print the server version. |

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1401,7 +1401,7 @@ When `authorizationPolicy` is set on a mounted UI, the referenced UI manifest mu
 
 ## Validation rules
 
-Structural validation runs at config load time (`init`, `validate`, `serve`). Runtime validation runs only at `serve` time.
+Structural validation runs at config load time (`lock`, `sync`, `validate`, `serve`). Runtime validation runs only at `serve` time.
 
 ### Structural
 

--- a/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
+++ b/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
@@ -68,7 +68,7 @@ For Google OAuth:
 For OIDC, override config.auth.plugin in your values file.
 {{- if .Values.pluginInit.enabled }}
 
-Plugin init is enabled. An init container runs `gestaltd lock` followed by
+Plugin preparation is enabled. A preparation container runs `gestaltd lock` followed by
 `gestaltd sync --locked` before the main server starts, preparing locked state
 in a shared volume.
 The main container runs with --locked to prevent mutation at startup.

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -2564,19 +2564,19 @@ plugins:
 	}
 }
 
-func TestE2EInitLocalProviders(t *testing.T) {
+func TestE2ELockLocalProviders(t *testing.T) {
 	t.Parallel()
 
 	if testing.Short() {
-		t.Skip("skipping E2E init test in short mode")
+		t.Skip("skipping E2E lock test in short mode")
 	}
 
 	dir := t.TempDir()
 	cfgPath := writeServeConfig(t, dir, 0, nil)
 
-	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath).CombinedOutput()
 	if err != nil {
-		t.Fatalf("gestaltd init failed: %v\noutput: %s", err, out)
+		t.Fatalf("gestaltd lock failed: %v\noutput: %s", err, out)
 	}
 
 	lockPath := filepath.Join(dir, "gestalt.lock.json")
@@ -2599,7 +2599,7 @@ func TestE2EInitLocalProviders(t *testing.T) {
 		t.Fatalf("expected schema-based lockfile without version field, got %v", lock["version"])
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".gestaltd")); !os.IsNotExist(err) {
-		t.Fatalf("init is a lock-only alias and should not prepare artifacts, got err=%v", err)
+		t.Fatalf("lock should not prepare artifacts, got err=%v", err)
 	}
 }
 
@@ -2794,20 +2794,20 @@ plugins:
 	}
 }
 
-func TestE2EInitWritesOverrideLockfile(t *testing.T) {
+func TestE2ELockWritesOverrideLockfile(t *testing.T) {
 	t.Parallel()
 
 	if testing.Short() {
-		t.Skip("skipping E2E init lockfile override test in short mode")
+		t.Skip("skipping E2E lockfile override test in short mode")
 	}
 
 	dir := t.TempDir()
 	cfgPath := writeServeConfig(t, dir, 0, nil)
 	lockPath := filepath.Join(dir, "state", "local", "gestalt.lock.json")
 
-	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {
-		t.Fatalf("gestaltd init with --lockfile failed: %v\noutput: %s", err, out)
+		t.Fatalf("gestaltd lock with --lockfile failed: %v\noutput: %s", err, out)
 	}
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatalf("expected override lockfile at %s: %v", lockPath, err)
@@ -2817,7 +2817,7 @@ func TestE2EInitWritesOverrideLockfile(t *testing.T) {
 	}
 }
 
-func TestE2EInitAndServeLayeredConfigs(t *testing.T) {
+func TestE2ELockAndServeLayeredConfigs(t *testing.T) {
 	t.Parallel()
 
 	if testing.Short() {

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -18,18 +18,13 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "root",
 			args:      []string{"--help"},
-			wantParts: []string{"gestaltd validate", "gestaltd lock", "gestaltd sync --locked", "gestaltd init", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "[--config PATH]...", "--lockfile PATH"},
-			notWant:   []string{"gestaltd bundle", "gestaltd dev"},
+			wantParts: []string{"gestaltd validate", "gestaltd lock", "gestaltd sync --locked", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "[--config PATH]...", "--lockfile PATH"},
+			notWant:   []string{"gestaltd bundle", "gestaltd dev", "gestaltd init", "\n  init"},
 		},
 		{
 			name:      "validate",
 			args:      []string{"validate", "--help"},
 			wantParts: []string{"gestaltd validate", "Repeated --config flags merge left-to-right.", "--lockfile PATH"},
-		},
-		{
-			name:      "init",
-			args:      []string{"init", "--help"},
-			wantParts: []string{"gestaltd init", "Legacy alias for `gestaltd lock`", "When repeated, --config files merge left-to-right.", "--lockfile PATH"},
 		},
 		{
 			name:      "lock",
@@ -113,11 +108,6 @@ func TestE2ECLIRejectsBadArgs(t *testing.T) {
 			name:     "validate trailing args",
 			args:     []string{"validate", "--config", "foo.yaml", "extra"},
 			wantPart: "unexpected arguments: extra",
-		},
-		{
-			name:     "init artifacts dir rejected",
-			args:     []string{"init", "--artifacts-dir", "/tmp/gestaltd-artifacts"},
-			wantPart: "gestaltd init no longer accepts --artifacts-dir",
 		},
 		{
 			name:     "missing validate config",

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -55,8 +55,6 @@ func run(args []string, version string) error {
 			return runLock(args[1:])
 		case "sync":
 			return runSync(args[1:])
-		case "init":
-			return runInit(args[1:])
 		case "validate":
 			return runValidate(args[1:])
 		case "__sandbox":
@@ -131,30 +129,6 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 func runServer(env *bootstrapEnv) error {
 	defer env.Close()
 	return server.Run(env.Ctx, env.Config, env.Result)
-}
-
-func runInit(args []string) error {
-	fs := flag.NewFlagSet("gestaltd init", flag.ContinueOnError)
-	fs.Usage = func() { printInitUsage(fs.Output()) }
-	var configPaths repeatedStringFlag
-	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
-	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
-	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
-	platformFlag := fs.String("platform", "", "additional platforms to verify hashes for (comma-separated os/arch or \"all\")")
-	check := fs.Bool("check", false, "fail if the lockfile would change")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	if fs.NArg() > 0 {
-		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
-	}
-	if strings.TrimSpace(*artifactsDir) != "" {
-		return fmt.Errorf("gestaltd init no longer accepts --artifacts-dir because it only writes lock metadata; run `gestaltd lock` followed by `gestaltd sync --locked --artifacts-dir %s`", *artifactsDir)
-	}
-
-	return lockConfigWithStatePaths(configPaths, operator.StatePaths{
-		LockfilePath: *lockfilePath,
-	}, *platformFlag, *check)
 }
 
 func runLock(args []string) error {
@@ -304,14 +278,12 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
 	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--check]")
 	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
-	writeUsageLine(w, "  gestaltd init [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
 	writeUsageLine(w, "  lock        Resolve provider metadata and write lock state")
 	writeUsageLine(w, "  sync        Materialize prepared artifacts from lock state")
-	writeUsageLine(w, "  init        Legacy alias for lock")
 	writeUsageLine(w, "  provider    Develop, validate, or build provider release archives")
 	writeUsageLine(w, "  serve       Start the server (use --locked for production)")
 	writeUsageLine(w, "  validate    Load and validate configuration without starting the server")
@@ -333,21 +305,6 @@ func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "When locked, run `gestaltd lock` before deploy and `gestaltd sync --locked` during build.")
 	writeUsageLine(w, "When repeated, --config files merge left-to-right. Maps deep-merge,")
 	writeUsageLine(w, "later scalars win, lists replace, and null deletes inherited keys.")
-}
-
-func printInitUsage(w io.Writer) {
-	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd init [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
-	writeUsageLine(w, "")
-	writeUsageLine(w, "Legacy alias for `gestaltd lock`; writes lock metadata only.")
-	writeUsageLine(w, "Use `gestaltd sync --locked` to materialize prepared artifacts.")
-	writeUsageLine(w, "When repeated, --config files merge left-to-right.")
-	writeUsageLine(w, "")
-	writeUsageLine(w, "Flags:")
-	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
-	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
-	writeUsageLine(w, "  --platform        Additional platforms to verify (comma-separated os/arch or \"all\")")
-	writeUsageLine(w, "  --check           Fail if the lockfile would change")
 }
 
 func printLockUsage(w io.Writer) {


### PR DESCRIPTION
## Summary
- Remove the legacy `gestaltd init` command alias.
- Keep `gestaltd lock` as the single lock-writing CLI command.
- Move the existing lockfile e2e coverage from `init` to `lock` and remove alias-specific help/error tests.
- Update CLI and config-file docs so they no longer advertise or reference the alias.
- Update Helm notes to describe lock/sync preparation instead of “plugin init”.
- Bring the remaining lock/sync plugin-owned UI fixture onto the current v4 config contract.

## Interface / Contract Diff
```diff
- gestaltd init [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]
+ gestaltd lock [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]

- root help listed `init        Legacy alias for lock`
+ root help only lists `lock`, `sync`, `provider`, `serve`, `validate`, and `version`
```

## Examples
```sh
gestaltd lock --config ./config.yaml
gestaltd lock --config ./config.yaml --lockfile ./state/gestalt.lock.json
gestaltd sync --locked --config ./config.yaml
gestaltd serve --locked --config ./config.yaml
```

## Verification
```sh
cd gestaltd
mkdir -p ../.tmp ../.gocache
env GOCACHE=$PWD/../.gocache \
  TMPDIR=$PWD/../.tmp \
  go test -count=1 ./internal/daemon -run 'TestE2ELockSyncPluginOwnedUI|TestE2ECLIHelp|TestE2ECLIRejectsBadArgs|TestE2ELockLocalProviders|TestE2ELockWritesOverrideLockfile|TestE2ELockAndServeLayeredConfigs'
```

```sh
rg -n 'case "init"|runInit|printInitUsage|gestaltd init|Plugin init|Legacy alias for lock|Legacy alias for `gestaltd lock`|gestaltd\.config/v3|`init`, `validate`, `serve`' \
  gestaltd docs
```
