### PR TITLE
indexeddb: give host-service schema changes migration budget

### DIFF
--- a/gestaltd/internal/providerhost/indexeddb_server.go
+++ b/gestaltd/internal/providerhost/indexeddb_server.go
@@ -77,6 +77,7 @@ func (s *indexedDBServer) CreateObjectStore(ctx context.Context, req *proto.Crea
 		return nil, indexeddbToGRPCErr(err)
 	}
 	schema := protoToSchema(req.GetSchema())
+	ctx = WithProviderMigrationTimeout(ctx)
 	if err := s.ds.CreateObjectStore(ctx, s.storeName(req.GetName()), schema); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -87,6 +88,7 @@ func (s *indexedDBServer) DeleteObjectStore(ctx context.Context, req *proto.Dele
 	if err := s.ensureAllowedStore(req.GetName()); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
+	ctx = WithProviderMigrationTimeout(ctx)
 	if err := s.ds.DeleteObjectStore(ctx, s.storeName(req.GetName())); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}

--- a/gestaltd/internal/providerhost/indexeddb_server_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_server_test.go
@@ -3,6 +3,7 @@ package providerhost
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
@@ -13,6 +14,42 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"google.golang.org/grpc"
 )
+
+var errMissingMigrationTimeout = errors.New("missing indexeddb schema migration timeout")
+
+type schemaMigrationContextIndexedDB struct {
+	coretesting.StubIndexedDB
+
+	mu      sync.Mutex
+	created bool
+	deleted bool
+}
+
+func (db *schemaMigrationContextIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	if requested, _ := ctx.Value(providerMigrationTimeoutContextKey{}).(bool); !requested {
+		return errMissingMigrationTimeout
+	}
+	if err := db.StubIndexedDB.CreateObjectStore(ctx, name, schema); err != nil {
+		return err
+	}
+	db.mu.Lock()
+	db.created = true
+	db.mu.Unlock()
+	return nil
+}
+
+func (db *schemaMigrationContextIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
+	if requested, _ := ctx.Value(providerMigrationTimeoutContextKey{}).(bool); !requested {
+		return errMissingMigrationTimeout
+	}
+	if err := db.StubIndexedDB.DeleteObjectStore(ctx, name); err != nil {
+		return err
+	}
+	db.mu.Lock()
+	db.deleted = true
+	db.mu.Unlock()
+	return nil
+}
 
 func TestIndexedDBServerUsesStoreNamesAsProvided(t *testing.T) {
 	t.Parallel()
@@ -34,6 +71,32 @@ func TestIndexedDBServerUsesStoreNamesAsProvided(t *testing.T) {
 
 	if _, err := db.ObjectStore("snapshots").Get(ctx, "snap-1"); err != nil {
 		t.Fatalf("expected object store record to exist: %v", err)
+	}
+}
+
+func TestIndexedDBServerSchemaChangesUseMigrationTimeout(t *testing.T) {
+	t.Parallel()
+
+	db := &schemaMigrationContextIndexedDB{}
+	srv := NewIndexedDBServer(db, "workflow", IndexedDBServerOptions{})
+	conn := newBufconnConn(t, func(server *grpc.Server) {
+		proto.RegisterIndexedDBServer(server, srv)
+	})
+	client := proto.NewIndexedDBClient(conn)
+
+	if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{Name: "workflow_runs"}); err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+	if _, err := client.DeleteObjectStore(context.Background(), &proto.DeleteObjectStoreRequest{Name: "workflow_runs"}); err != nil {
+		t.Fatalf("DeleteObjectStore: %v", err)
+	}
+
+	db.mu.Lock()
+	created := db.created
+	deleted := db.deleted
+	db.mu.Unlock()
+	if !created || !deleted {
+		t.Fatalf("schema change calls recorded = created:%v deleted:%v, want both true", created, deleted)
 	}
 }
 


### PR DESCRIPTION
## Problem

Cloud Run deployment of the workflow provider can fail at startup while `workflow/indexeddb` creates or validates its object stores through the IndexedDB host-service socket:

```text
indexeddb workflow: ensure stores: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

Gestalt already has a longer IndexedDB schema migration timeout for host-side schema changes, but executable providers call `CreateObjectStore`/`DeleteObjectStore` over the host-service gRPC socket. The in-process context marker is not present on the server side of that socket, so the host forwards those schema changes through the normal provider RPC budget.

## Changes

- `IndexedDBServer.CreateObjectStore` wraps the forwarded call with `WithProviderMigrationTimeout`.
- `IndexedDBServer.DeleteObjectStore` does the same for schema deletion.
- Adds a host-service transport contract test proving provider-originated schema changes receive the migration timeout marker before reaching the underlying IndexedDB provider.

## Interfaces

No public API or config changes.

Existing provider-facing IndexedDB host-service calls stay the same:

```go
client.CreateObjectStore(ctx, &proto.CreateObjectStoreRequest{Name: "workflow_runs"})
client.DeleteObjectStore(ctx, &proto.DeleteObjectStoreRequest{Name: "workflow_runs"})
```

The host now treats those calls as schema migration work internally before proxying to the configured IndexedDB provider.

## Verification

```sh
cd gestaltd
go test ./internal/providerhost
```