### PR TITLE
[codex] Add runtime host service boundary

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -36,6 +36,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
@@ -162,19 +163,19 @@ type Deps struct {
 	PluginInvoker         invocation.Invoker
 	PluginRuntime         pluginruntime.Provider
 	PluginRuntimeRegistry *pluginRuntimeRegistry
-	PublicHostServices    *providerhost.PublicHostServiceRegistry
+	PublicHostServices    *runtimehost.PublicHostServiceRegistry
 	Telemetry             core.TelemetryProvider
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthenticationProvider, error)
-type AuthorizationFactory func(node yaml.Node, hostServices []providerhost.HostService, deps Deps) (core.AuthorizationProvider, error)
-type ExternalCredentialFactory func(ctx context.Context, name string, node yaml.Node, hostServices []providerhost.HostService, deps Deps) (core.ExternalCredentialProvider, error)
+type AuthorizationFactory func(node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (core.AuthorizationProvider, error)
+type ExternalCredentialFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (core.ExternalCredentialProvider, error)
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
 type IndexedDBFactory func(node yaml.Node) (indexeddb.IndexedDB, error)
 type CacheFactory func(node yaml.Node) (corecache.Cache, error)
 type S3Factory func(node yaml.Node) (s3store.Client, error)
-type WorkflowFactory func(ctx context.Context, name string, node yaml.Node, hostServices []providerhost.HostService, deps Deps) (coreworkflow.Provider, error)
-type AgentFactory func(ctx context.Context, name string, node yaml.Node, hostServices []providerhost.HostService, deps Deps) (coreagent.Provider, error)
+type WorkflowFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (coreworkflow.Provider, error)
+type AgentFactory func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (coreagent.Provider, error)
 type RuntimeFactory func(ctx context.Context, name string, entry *config.RuntimeProviderEntry, deps Deps) (pluginruntime.Provider, error)
 type TelemetryFactory func(node yaml.Node) (core.TelemetryProvider, error)
 type AuditFactory func(ctx context.Context, cfg config.ProviderEntry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error)
@@ -228,7 +229,7 @@ type Result struct {
 	Telemetry             core.TelemetryProvider
 	PluginRuntimes        RuntimeInspector
 	ProviderDevSessions   *providerdev.Manager
-	PublicHostServices    *providerhost.PublicHostServiceRegistry
+	PublicHostServices    *runtimehost.PublicHostServiceRegistry
 
 	pluginRuntimeRegistry *pluginRuntimeRegistry
 	auditClose            func(context.Context) error
@@ -822,7 +823,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, storeErr)
 	}
 	store = metricutil.InstrumentIndexedDB(store, selectedIndexedDBName)
-	svc, svcErr := coredata.NewWithContext(providerhost.WithProviderMigrationTimeout(ctx), store)
+	svc, svcErr := coredata.NewWithContext(runtimehost.WithProviderMigrationTimeout(ctx), store)
 	if svcErr != nil {
 		_ = store.Close()
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, svcErr)
@@ -971,7 +972,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	workflowManager := newLazyWorkflowManager()
 	agentManager := newLazyAgentManager()
 	workflowTools := newWorkflowSystemTools(workflowManager, prepared.Deps.WorkflowRuntime)
-	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
 	prepared.Deps.PluginInvoker = pluginInvoker
 	prepared.Deps.WorkflowManager = workflowManager
 	prepared.Deps.AgentManager = agentManager
@@ -1384,11 +1385,11 @@ func buildExternalCredentialsRuntimeConfigNode(name string, entry *config.Provid
 	return mapToYAMLNode(cfg)
 }
 
-func buildExternalCredentialsHostServices(name string, deps Deps) ([]providerhost.HostService, error) {
+func buildExternalCredentialsHostServices(name string, deps Deps) ([]runtimehost.HostService, error) {
 	if len(deps.IndexedDBs) == 0 || deps.SelectedIndexedDBName == "" {
 		return nil, fmt.Errorf("indexeddb host services are not available")
 	}
-	hostServices := make([]providerhost.HostService, 0, len(deps.IndexedDBs)+1)
+	hostServices := make([]runtimehost.HostService, 0, len(deps.IndexedDBs)+1)
 	if ds := deps.IndexedDBs[deps.SelectedIndexedDBName]; ds != nil {
 		hostServices = append(hostServices, externalCredentialsIndexedDBHostService(providerhost.DefaultIndexedDBSocketEnv, name, ds))
 	}
@@ -1405,8 +1406,8 @@ func buildExternalCredentialsHostServices(name string, deps Deps) ([]providerhos
 	return hostServices, nil
 }
 
-func externalCredentialsIndexedDBHostService(envVar, providerName string, ds indexeddb.IndexedDB) providerhost.HostService {
-	return providerhost.HostService{
+func externalCredentialsIndexedDBHostService(envVar, providerName string, ds indexeddb.IndexedDB) runtimehost.HostService {
+	return runtimehost.HostService{
 		Name:   "indexeddb",
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
@@ -1571,12 +1572,12 @@ func buildIndexedDB(entry *config.ProviderEntry, factories *FactoryRegistry) (in
 	return ds, nil
 }
 
-func buildHostIndexedDBHostServices(selectedName string, indexeddbs map[string]indexeddb.IndexedDB) []providerhost.HostService {
+func buildHostIndexedDBHostServices(selectedName string, indexeddbs map[string]indexeddb.IndexedDB) []runtimehost.HostService {
 	if len(indexeddbs) == 0 {
 		return nil
 	}
 
-	hostServices := make([]providerhost.HostService, 0, len(indexeddbs)+1)
+	hostServices := make([]runtimehost.HostService, 0, len(indexeddbs)+1)
 	if selected := indexeddbs[selectedName]; strings.TrimSpace(selectedName) != "" && selected != nil {
 		hostServices = append(hostServices, indexedDBHostService(providerhost.DefaultIndexedDBSocketEnv, selectedName, selected))
 	}
@@ -1591,8 +1592,8 @@ func buildHostIndexedDBHostServices(selectedName string, indexeddbs map[string]i
 	return hostServices
 }
 
-func indexedDBHostService(envVar, name string, ds indexeddb.IndexedDB) providerhost.HostService {
-	return providerhost.HostService{
+func indexedDBHostService(envVar, name string, ds indexeddb.IndexedDB) runtimehost.HostService {
+	return runtimehost.HostService{
 		Name:   "indexeddb",
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
@@ -1660,7 +1661,7 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 			return nil, fmt.Errorf("workflow provider: %w", err)
 		}
 	}
-	hostServices := []providerhost.HostService{{
+	hostServices := []runtimehost.HostService{{
 		Name:   "workflow_host",
 		EnvVar: providerhost.DefaultWorkflowHostSocketEnv,
 		Register: func(srv *grpc.Server) {
@@ -1719,7 +1720,7 @@ func buildAgent(ctx context.Context, name string, entry *config.ProviderEntry, f
 			return nil, fmt.Errorf("agent provider: %w", err)
 		}
 	}
-	hostServices := []providerhost.HostService{{
+	hostServices := []runtimehost.HostService{{
 		Name:   "agent_host",
 		EnvVar: providerhost.DefaultAgentHostSocketEnv,
 		Register: func(srv *grpc.Server) {

--- a/gestaltd/internal/bootstrap/hosted_agent_pool.go
+++ b/gestaltd/internal/bootstrap/hosted_agent_pool.go
@@ -14,7 +14,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 )
@@ -24,7 +24,7 @@ const hostedAgentRuntimeLifecycleSafetyMargin = 5 * time.Second
 type hostedAgentProviderPool struct {
 	name         string
 	launch       *hostedAgentProviderLaunch
-	hostServices []providerhost.HostService
+	hostServices []runtimehost.HostService
 	deps         Deps
 	policy       config.HostedRuntimeLifecyclePolicy
 
@@ -60,7 +60,7 @@ type hostedAgentPoolBackend struct {
 	closed           bool
 }
 
-func newHostedAgentProviderPool(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []providerhost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy) (coreagent.Provider, error) {
+func newHostedAgentProviderPool(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []runtimehost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy) (coreagent.Provider, error) {
 	if launch == nil {
 		return nil, fmt.Errorf("hosted agent launch is required")
 	}
@@ -68,7 +68,7 @@ func newHostedAgentProviderPool(ctx context.Context, launch *hostedAgentProvider
 	pool := &hostedAgentProviderPool{
 		name:                launch.name,
 		launch:              launch,
-		hostServices:        append([]providerhost.HostService(nil), hostServices...),
+		hostServices:        append([]runtimehost.HostService(nil), hostServices...),
 		deps:                deps,
 		policy:              policy,
 		ctx:                 poolCtx,

--- a/gestaltd/internal/bootstrap/plugin_runtime_executable.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_executable.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"maps"
 
-	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/runtimelogs"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
@@ -43,15 +42,15 @@ func buildExecutablePluginRuntime(ctx context.Context, name string, entry *confi
 	})
 }
 
-func buildRuntimeProviderHostServices(name string, deps Deps) []providerhost.HostService {
+func buildRuntimeProviderHostServices(name string, deps Deps) []runtimehost.HostService {
 	if deps.Services == nil || deps.Services.RuntimeSessionLogs == nil {
 		return nil
 	}
-	return []providerhost.HostService{{
+	return []runtimehost.HostService{{
 		Name:   "runtime_log_host",
-		EnvVar: providerhost.DefaultRuntimeLogHostSocketEnv,
+		EnvVar: runtimehost.DefaultRuntimeLogHostSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterPluginRuntimeLogHostServer(srv, providerhost.NewRuntimeLogHostServer(name, deps.Services.RuntimeSessionLogs.AppendSessionLogs))
+			runtimehost.RegisterRuntimeLogHostServer(srv, name, deps.Services.RuntimeSessionLogs.AppendSessionLogs)
 		},
 	}}
 }

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -46,6 +46,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
@@ -888,10 +889,10 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		return nil, err
 	}
 	cleanup = chainCleanup(cleanup, runtimeCleanup, publicHostServicesCleanup)
-	startedHostServices, err := providerhost.StartHostServices(
+	startedHostServices, err := runtimehost.StartHostServices(
 		hostServices,
-		providerhost.WithHostServicesProviderName(name),
-		providerhost.WithHostServicesTelemetry(deps.Telemetry),
+		runtimehost.WithHostServicesProviderName(name),
+		runtimehost.WithHostServicesTelemetry(deps.Telemetry),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("start runtime host services: %w", err)
@@ -975,7 +976,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	return prov, nil
 }
 
-func buildHostedAgentProvider(ctx context.Context, name string, entry *config.ProviderEntry, node yaml.Node, hostServices []providerhost.HostService, deps Deps) (coreagent.Provider, error) {
+func buildHostedAgentProvider(ctx context.Context, name string, entry *config.ProviderEntry, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (coreagent.Provider, error) {
 	launch, err := prepareHostedAgentProviderLaunch(ctx, name, entry, node, deps)
 	if err != nil {
 		return nil, err
@@ -1115,7 +1116,7 @@ func prepareHostedAgentProviderLaunch(ctx context.Context, name string, entry *c
 	return preparedLaunch, nil
 }
 
-func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []providerhost.HostService, deps Deps, closeRuntime bool, cleanup func()) (*hostedAgentProviderInstance, error) {
+func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []runtimehost.HostService, deps Deps, closeRuntime bool, cleanup func()) (*hostedAgentProviderInstance, error) {
 	if launch == nil {
 		return nil, fmt.Errorf("hosted agent launch is required")
 	}
@@ -1163,10 +1164,10 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	recordHostedAgentRuntimeStartPhase(ctx, name, "runtime_session_ready", phaseStarted, nil)
 
 	phaseStarted = time.Now()
-	startedHostServices, err := providerhost.StartHostServices(
+	startedHostServices, err := runtimehost.StartHostServices(
 		hostServices,
-		providerhost.WithHostServicesProviderName(name),
-		providerhost.WithHostServicesTelemetry(deps.Telemetry),
+		runtimehost.WithHostServicesProviderName(name),
+		runtimehost.WithHostServicesTelemetry(deps.Telemetry),
 	)
 	recordHostedAgentRuntimeStartPhase(ctx, name, "host_services_start", phaseStarted, err)
 	if err != nil {
@@ -1504,13 +1505,13 @@ func waitForPluginRuntimeSessionReady(ctx context.Context, runtimeProvider plugi
 	}
 }
 
-func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, deps Deps, allowDirectBindings bool) ([]providerhost.HostService, *providerhost.InvocationTokenManager, func(), error) {
+func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, deps Deps, allowDirectBindings bool) ([]runtimehost.HostService, *providerhost.InvocationTokenManager, func(), error) {
 	var (
-		hostServices []providerhost.HostService
+		hostServices []runtimehost.HostService
 		cleanup      func()
 		invTokens    *providerhost.InvocationTokenManager
 	)
-	fail := func(err error) ([]providerhost.HostService, *providerhost.InvocationTokenManager, func(), error) {
+	fail := func(err error) ([]runtimehost.HostService, *providerhost.InvocationTokenManager, func(), error) {
 		if cleanup != nil {
 			cleanup()
 			cleanup = nil
@@ -1578,7 +1579,7 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 	return hostServices, invTokens, cleanup, nil
 }
 
-func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostService providerhost.StartedHostService, deps Deps, allowUnixRelay bool) (pluginruntime.BindHostServiceRequest, map[string]string, string, error) {
+func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostService runtimehost.StartedHostService, deps Deps, allowUnixRelay bool) (pluginruntime.BindHostServiceRequest, map[string]string, string, error) {
 	if !allowUnixRelay {
 		var (
 			serviceKey   string
@@ -1682,7 +1683,7 @@ func (v runtimeHostServiceSessionVerifier) VerifyHostServiceSession(ctx context.
 	}
 }
 
-func registerPublicRuntimeHostServices(providerName string, hostServices []providerhost.HostService, deps Deps, runtimePlan HostedRuntimePlan, runtimeProvider pluginruntime.Provider) (func(), error) {
+func registerPublicRuntimeHostServices(providerName string, hostServices []runtimehost.HostService, deps Deps, runtimePlan HostedRuntimePlan, runtimeProvider pluginruntime.Provider) (func(), error) {
 	if runtimePlan.Resolved.HostServiceAccess != RuntimeHostServiceAccessRelay || deps.PublicHostServices == nil {
 		return nil, nil
 	}
@@ -1730,7 +1731,7 @@ func buildHostedRuntimePublicEgressProxy(providerName, sessionID string, allowed
 	}, nil
 }
 
-func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, hostService providerhost.StartedHostService, deps Deps, serviceKey, serviceLabel, methodPrefix string) (pluginruntime.HostServiceRelay, map[string]string, string, bool, error) {
+func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, hostService runtimehost.StartedHostService, deps Deps, serviceKey, serviceLabel, methodPrefix string) (pluginruntime.HostServiceRelay, map[string]string, string, bool, error) {
 	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
 		return pluginruntime.HostServiceRelay{}, nil, "", false, nil
 	}
@@ -1856,7 +1857,7 @@ func isLoopbackAllowedHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func buildPluginIndexedDBHostServices(pluginName string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]providerhost.HostService, func(), error) {
+func buildPluginIndexedDBHostServices(pluginName string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]runtimehost.HostService, func(), error) {
 	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
 		return nil, nil, fmt.Errorf("indexeddb host services are not available")
 	}
@@ -1866,7 +1867,7 @@ func buildPluginIndexedDBHostServices(pluginName string, effective config.Effect
 		return nil, nil, err
 	}
 
-	hostServices := []providerhost.HostService{{
+	hostServices := []runtimehost.HostService{{
 		Name:   "indexeddb",
 		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
 		Register: func(srv *grpc.Server) {
@@ -1880,12 +1881,12 @@ func buildPluginIndexedDBHostServices(pluginName string, effective config.Effect
 	}, nil
 }
 
-func buildPluginCacheHostServices(pluginName string, entry *config.ProviderEntry, deps Deps) ([]providerhost.HostService, func(), error) {
+func buildPluginCacheHostServices(pluginName string, entry *config.ProviderEntry, deps Deps) ([]runtimehost.HostService, func(), error) {
 	if deps.CacheFactory == nil || len(deps.CacheDefs) == 0 {
 		return nil, nil, fmt.Errorf("cache host services are not available")
 	}
 
-	hostServices := make([]providerhost.HostService, 0, len(entry.Cache)+1)
+	hostServices := make([]runtimehost.HostService, 0, len(entry.Cache)+1)
 	boundCaches := make([]corecache.Cache, 0, len(entry.Cache))
 	for _, bindingName := range entry.Cache {
 		def, ok := deps.CacheDefs[bindingName]
@@ -1899,7 +1900,7 @@ func buildPluginCacheHostServices(pluginName string, entry *config.ProviderEntry
 			return nil, nil, fmt.Errorf("cache %q: %w", bindingName, err)
 		}
 		boundCaches = append(boundCaches, value)
-		hostServices = append(hostServices, providerhost.HostService{
+		hostServices = append(hostServices, runtimehost.HostService{
 			Name:   "cache",
 			EnvVar: providerhost.CacheSocketEnv(bindingName),
 			Register: func(cacheValue corecache.Cache) func(*grpc.Server) {
@@ -1911,7 +1912,7 @@ func buildPluginCacheHostServices(pluginName string, entry *config.ProviderEntry
 	}
 	if len(boundCaches) == 1 {
 		value := boundCaches[0]
-		hostServices = append(hostServices, providerhost.HostService{
+		hostServices = append(hostServices, runtimehost.HostService{
 			Name:   "cache",
 			EnvVar: providerhost.DefaultCacheSocketEnv,
 			Register: func(srv *grpc.Server) {
@@ -1924,7 +1925,7 @@ func buildPluginCacheHostServices(pluginName string, entry *config.ProviderEntry
 	}, nil
 }
 
-func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, deps Deps) ([]providerhost.HostService, error) {
+func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, deps Deps) ([]runtimehost.HostService, error) {
 	if len(deps.S3) == 0 {
 		return nil, fmt.Errorf("s3 host services are not available")
 	}
@@ -1938,13 +1939,13 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 		}
 	}
 
-	hostServices := make([]providerhost.HostService, 0, len(entry.S3)+1)
+	hostServices := make([]runtimehost.HostService, 0, len(entry.S3)+1)
 	for _, binding := range entry.S3 {
 		client, ok := deps.S3[binding]
 		if !ok || client == nil {
 			return nil, fmt.Errorf("s3 %q is not available", binding)
 		}
-		hostServices = append(hostServices, providerhost.HostService{
+		hostServices = append(hostServices, runtimehost.HostService{
 			Name:   "s3",
 			EnvVar: providerhost.S3SocketEnv(binding),
 			Register: func(client s3store.Client, binding string) func(*grpc.Server) {
@@ -1961,7 +1962,7 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 	if len(entry.S3) == 1 {
 		binding := entry.S3[0]
 		client := deps.S3[binding]
-		hostServices = append(hostServices, providerhost.HostService{
+		hostServices = append(hostServices, runtimehost.HostService{
 			Name:   "s3",
 			EnvVar: providerhost.DefaultS3SocketEnv,
 			Register: func(srv *grpc.Server) {
@@ -1976,7 +1977,7 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 	return hostServices, nil
 }
 
-func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]providerhost.HostService, func(), error) {
+func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]runtimehost.HostService, func(), error) {
 	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
 		return nil, nil, fmt.Errorf("indexeddb host services are not available")
 	}
@@ -1986,7 +1987,7 @@ func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveH
 		return nil, nil, err
 	}
 
-	hostServices := []providerhost.HostService{{
+	hostServices := []runtimehost.HostService{{
 		Name:   "indexeddb",
 		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
 		Register: func(srv *grpc.Server) {
@@ -2000,7 +2001,7 @@ func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveH
 	}, nil
 }
 
-func buildAgentIndexedDBHostServices(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]providerhost.HostService, func(), error) {
+func buildAgentIndexedDBHostServices(name string, effective config.EffectiveHostIndexedDBBinding, deps Deps) ([]runtimehost.HostService, func(), error) {
 	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
 		return nil, nil, fmt.Errorf("indexeddb host services are not available")
 	}
@@ -2010,7 +2011,7 @@ func buildAgentIndexedDBHostServices(name string, effective config.EffectiveHost
 		return nil, nil, err
 	}
 
-	hostServices := []providerhost.HostService{{
+	hostServices := []runtimehost.HostService{{
 		Name:   "indexeddb",
 		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
 		Register: func(srv *grpc.Server) {
@@ -2024,12 +2025,12 @@ func buildAgentIndexedDBHostServices(name string, effective config.EffectiveHost
 	}, nil
 }
 
-func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens *providerhost.InvocationTokenManager) providerhost.HostService {
+func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens *providerhost.InvocationTokenManager) runtimehost.HostService {
 	manager := deps.WorkflowManager
 	if manager == nil {
 		manager = unavailableWorkflowManager{}
 	}
-	return providerhost.HostService{
+	return runtimehost.HostService{
 		Name:   "workflow_manager",
 		EnvVar: providerhost.DefaultWorkflowManagerSocketEnv,
 		Register: func(srv *grpc.Server) {
@@ -2038,12 +2039,12 @@ func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens 
 	}
 }
 
-func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *providerhost.InvocationTokenManager) providerhost.HostService {
+func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *providerhost.InvocationTokenManager) runtimehost.HostService {
 	manager := deps.AgentManager
 	if manager == nil {
 		manager = unavailableAgentManager{}
 	}
-	return providerhost.HostService{
+	return runtimehost.HostService{
 		Name:   "agent_manager",
 		EnvVar: providerhost.DefaultAgentManagerSocketEnv,
 		Register: func(srv *grpc.Server) {
@@ -2052,8 +2053,8 @@ func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *pr
 	}
 }
 
-func buildPluginAuthorizationHostService(provider core.AuthorizationProvider) providerhost.HostService {
-	return providerhost.HostService{
+func buildPluginAuthorizationHostService(provider core.AuthorizationProvider) runtimehost.HostService {
+	return runtimehost.HostService{
 		Name:   "authorization",
 		EnvVar: providerhost.DefaultAuthorizationSocketEnv,
 		Register: func(srv *grpc.Server) {
@@ -2062,12 +2063,12 @@ func buildPluginAuthorizationHostService(provider core.AuthorizationProvider) pr
 	}
 }
 
-func buildPluginInvokerHostService(pluginName string, entry *config.ProviderEntry, deps Deps, tokens *providerhost.InvocationTokenManager) providerhost.HostService {
+func buildPluginInvokerHostService(pluginName string, entry *config.ProviderEntry, deps Deps, tokens *providerhost.InvocationTokenManager) runtimehost.HostService {
 	invoker := deps.PluginInvoker
 	if invoker == nil {
 		invoker = unavailablePluginInvoker{}
 	}
-	return providerhost.HostService{
+	return runtimehost.HostService{
 		Name:   "plugin_invoker",
 		EnvVar: providerhost.DefaultPluginInvokerSocketEnv,
 		Register: func(srv *grpc.Server) {

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -14,6 +14,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 )
 
 func buildProviderDevManager(cfg *config.Config, providers *registry.ProviderMap[core.Provider], deps Deps) (*providerdev.Manager, error) {
@@ -166,10 +167,10 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 	}
 
 	env := map[string]string{}
-	startedHostServices, err := providerhost.StartHostServices(
+	startedHostServices, err := runtimehost.StartHostServices(
 		hostServices,
-		providerhost.WithHostServicesProviderName(name),
-		providerhost.WithHostServicesTelemetry(deps.Telemetry),
+		runtimehost.WithHostServicesProviderName(name),
+		runtimehost.WithHostServicesTelemetry(deps.Telemetry),
 	)
 	if err != nil {
 		return providerdev.RuntimeEnv{}, fmt.Errorf("start host services: %w", err)

--- a/gestaltd/internal/drivers/agent/provider/factory.go
+++ b/gestaltd/internal/drivers/agent/provider/factory.go
@@ -9,10 +9,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
 
-var Factory bootstrap.AgentFactory = func(ctx context.Context, name string, node yaml.Node, hostServices []providerhost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
+var Factory bootstrap.AgentFactory = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("agent provider: parsing config: %w", err)

--- a/gestaltd/internal/drivers/authorization/provider/factory.go
+++ b/gestaltd/internal/drivers/authorization/provider/factory.go
@@ -9,10 +9,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
 
-var Factory bootstrap.AuthorizationFactory = func(node yaml.Node, hostServices []providerhost.HostService, _ bootstrap.Deps) (core.AuthorizationProvider, error) {
+var Factory bootstrap.AuthorizationFactory = func(node yaml.Node, hostServices []runtimehost.HostService, _ bootstrap.Deps) (core.AuthorizationProvider, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("authorization provider: parsing config: %w", err)

--- a/gestaltd/internal/drivers/externalcredentials/provider/factory.go
+++ b/gestaltd/internal/drivers/externalcredentials/provider/factory.go
@@ -9,10 +9,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
 
-var Factory bootstrap.ExternalCredentialFactory = func(ctx context.Context, name string, node yaml.Node, hostServices []providerhost.HostService, deps bootstrap.Deps) (core.ExternalCredentialProvider, error) {
+var Factory bootstrap.ExternalCredentialFactory = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (core.ExternalCredentialProvider, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("external credentials provider: parsing config: %w", err)

--- a/gestaltd/internal/drivers/workflow/provider/factory.go
+++ b/gestaltd/internal/drivers/workflow/provider/factory.go
@@ -9,10 +9,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
 
-var Factory bootstrap.WorkflowFactory = func(ctx context.Context, name string, node yaml.Node, hostServices []providerhost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
+var Factory bootstrap.WorkflowFactory = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("workflow provider: parsing config: %w", err)

--- a/gestaltd/internal/pluginruntime/dial_test.go
+++ b/gestaltd/internal/pluginruntime/dial_test.go
@@ -11,6 +11,7 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -21,7 +22,7 @@ func TestDialHostedPluginRecordsRPCClientDurationWithTelemetryAttrs(t *testing.T
 	metrics := metrictest.NewManualMeterProvider(t)
 	const providerName = "hosted-metrics"
 
-	dir, err := providerhost.NewPluginTempDir("grpc-metrics-")
+	dir, err := runtimehost.NewPluginTempDir("grpc-metrics-")
 	if err != nil {
 		t.Fatalf("NewPluginTempDir: %v", err)
 	}

--- a/gestaltd/internal/pluginruntime/executable.go
+++ b/gestaltd/internal/pluginruntime/executable.go
@@ -12,8 +12,8 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/runtimelogs"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -28,13 +28,13 @@ type ExecutableConfig struct {
 	Config       map[string]any
 	Egress       egress.Policy
 	HostBinary   string
-	HostServices []providerhost.HostService
+	HostServices []runtimehost.HostService
 	Telemetry    metricutil.TelemetryProviders
 	SessionLogs  runtimelogs.Store
 }
 
 type executableProvider struct {
-	proc      *providerhost.PluginProcess
+	proc      *runtimehost.PluginProcess
 	runtime   proto.PluginRuntimeProviderClient
 	lifecycle proto.ProviderLifecycleClient
 
@@ -46,7 +46,7 @@ type executableProvider struct {
 }
 
 func NewExecutableProvider(ctx context.Context, cfg ExecutableConfig) (Provider, error) {
-	proc, err := providerhost.StartPluginProcess(ctx, providerhost.ProcessConfig{
+	proc, err := runtimehost.StartPluginProcess(ctx, runtimehost.ProcessConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,
@@ -61,7 +61,7 @@ func NewExecutableProvider(ctx context.Context, cfg ExecutableConfig) (Provider,
 	}
 
 	lifecycle := proto.NewProviderLifecycleClient(proc.Conn())
-	if _, err := providerhost.ConfigureRuntimeProvider(ctx, lifecycle, proto.ProviderKind_PROVIDER_KIND_RUNTIME, cfg.Name, cfg.Config); err != nil {
+	if _, err := runtimehost.ConfigureRuntimeProvider(ctx, lifecycle, proto.ProviderKind_PROVIDER_KIND_RUNTIME, cfg.Name, cfg.Config); err != nil {
 		_ = proc.Close()
 		return nil, err
 	}

--- a/gestaltd/internal/pluginruntime/executable_test.go
+++ b/gestaltd/internal/pluginruntime/executable_test.go
@@ -10,9 +10,8 @@ import (
 	"testing"
 	"time"
 
-	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 )
 
@@ -27,11 +26,11 @@ func TestExecutableProviderIncludesPushedRuntimeLogsInStartupFailures(t *testing
 	runtimeProvider, err := NewExecutableProvider(ctx, ExecutableConfig{
 		Name:    "modal",
 		Command: runtimeBin,
-		HostServices: []providerhost.HostService{{
+		HostServices: []runtimehost.HostService{{
 			Name:   "runtime_logs",
-			EnvVar: providerhost.DefaultRuntimeLogHostSocketEnv,
+			EnvVar: runtimehost.DefaultRuntimeLogHostSocketEnv,
 			Register: func(srv *grpc.Server) {
-				proto.RegisterPluginRuntimeLogHostServer(srv, providerhost.NewRuntimeLogHostServer("modal", services.RuntimeSessionLogs.AppendSessionLogs))
+				runtimehost.RegisterRuntimeLogHostServer(srv, "modal", services.RuntimeSessionLogs.AppendSessionLogs)
 			},
 		}},
 		SessionLogs: services.RuntimeSessionLogs,

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/runtimelogs"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 )
 
 type LocalProvider struct {
@@ -50,7 +50,7 @@ type localBinding struct {
 type localPlugin struct {
 	id      string
 	name    string
-	process *providerhost.PluginProcess
+	process *runtimehost.PluginProcess
 }
 
 type LocalOption func(*LocalProvider)
@@ -93,7 +93,7 @@ func (p *LocalProvider) StartSession(_ context.Context, req StartSessionRequest)
 		return nil, fmt.Errorf("plugin runtime is not configured")
 	}
 
-	rootDir, err := providerhost.NewPluginTempDir("gestalt-plugin-runtime-*")
+	rootDir, err := runtimehost.NewPluginTempDir("gestalt-plugin-runtime-*")
 	if err != nil {
 		return nil, fmt.Errorf("create runtime session dir: %w", err)
 	}
@@ -174,7 +174,7 @@ func (p *LocalProvider) StopSession(_ context.Context, req StopSessionRequest) e
 		return nil
 	}
 
-	var plugin *providerhost.PluginProcess
+	var plugin *runtimehost.PluginProcess
 	var rootDir string
 
 	p.mu.Lock()
@@ -286,7 +286,7 @@ func (p *LocalProvider) StartPlugin(ctx context.Context, req StartPluginRequest)
 		}})
 	}
 
-	process, err := providerhost.StartPluginProcess(ctx, providerhost.ProcessConfig{
+	process, err := runtimehost.StartPluginProcess(ctx, runtimehost.ProcessConfig{
 		Command: req.Command,
 		Args:    req.Args,
 		Env:     env,

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 )
 
@@ -19,10 +20,10 @@ type hostServiceHandlerKey struct {
 
 type hostServiceHandlerEntry struct {
 	handler  http.Handler
-	verifier providerhost.PublicHostServiceSessionVerifier
+	verifier runtimehost.PublicHostServiceSessionVerifier
 }
 
-func newPublicHostServiceHandlers(services []providerhost.PublicHostService) (map[hostServiceHandlerKey]hostServiceHandlerEntry, error) {
+func newPublicHostServiceHandlers(services []runtimehost.PublicHostService) (map[hostServiceHandlerKey]hostServiceHandlerEntry, error) {
 	if len(services) == 0 {
 		return nil, nil
 	}
@@ -43,7 +44,7 @@ func newPublicHostServiceHandlers(services []providerhost.PublicHostService) (ma
 	return handlers, nil
 }
 
-func newPublicHostServiceHandlerEntry(service providerhost.PublicHostService) (hostServiceHandlerKey, hostServiceHandlerEntry, bool) {
+func newPublicHostServiceHandlerEntry(service runtimehost.PublicHostService) (hostServiceHandlerKey, hostServiceHandlerEntry, bool) {
 	key := hostServiceHandlerKey{
 		pluginName: strings.TrimSpace(service.PluginName),
 		sessionID:  strings.TrimSpace(service.SessionID),
@@ -118,7 +119,7 @@ func (s *Server) hostServiceHandlerEntry(key hostServiceHandlerKey) (hostService
 		s.hostServiceMu.Unlock()
 
 		services, snapshotVersion := s.publicHostServices.Snapshot()
-		var found *providerhost.PublicHostService
+		var found *runtimehost.PublicHostService
 		for _, service := range services {
 			serviceKey := hostServiceHandlerKey{
 				pluginName: strings.TrimSpace(service.PluginName),

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -120,7 +121,7 @@ type Server struct {
 	hostServiceMu          sync.Mutex
 	hostServiceHandlers    map[hostServiceHandlerKey]hostServiceHandlerEntry
 	hostServiceVersion     uint64
-	publicHostServices     *providerhost.PublicHostServiceRegistry
+	publicHostServices     *runtimehost.PublicHostServiceRegistry
 	s3                     map[string]s3store.Client
 	s3ObjectAccessURLs     *providerhost.S3ObjectAccessURLManager
 	egressProxyTokens      *providerhost.EgressProxyTokenManager
@@ -170,7 +171,7 @@ type Config struct {
 	Readiness             ReadinessChecker
 	PrometheusMetrics     http.Handler
 	MCPHandler            http.Handler
-	PublicHostServices    *providerhost.PublicHostServiceRegistry
+	PublicHostServices    *runtimehost.PublicHostServiceRegistry
 	S3                    map[string]s3store.Client
 	ProviderDevSessions   *providerdev.Manager
 	ProviderDevAttach     bool

--- a/gestaltd/services/runtimehost/runtimehost.go
+++ b/gestaltd/services/runtimehost/runtimehost.go
@@ -1,0 +1,83 @@
+// Package runtimehost exposes the host-owned runtime process and host-service
+// primitives used by executable and hosted provider runtimes.
+package runtimehost
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/internal/runtimelogs"
+	"google.golang.org/grpc"
+)
+
+// HostService is a host-owned gRPC service exposed to provider runtime
+// processes through a socket and environment variable.
+type HostService = providerhost.HostService
+
+type StartedHostService = providerhost.StartedHostService
+type StartedHostServices = providerhost.StartedHostServices
+type HostServicesOption = providerhost.HostServicesOption
+type TelemetryProviders = metricutil.TelemetryProviders
+
+type ProcessConfig = providerhost.ProcessConfig
+type PluginProcess = providerhost.PluginProcess
+
+type RuntimeProviderMetadata = providerhost.RuntimeProviderMetadata
+
+type AppendRuntimeLogEntry = runtimelogs.AppendEntry
+
+type PublicHostService = providerhost.PublicHostService
+type PublicHostServiceRegistry = providerhost.PublicHostServiceRegistry
+type PublicHostServiceSessionVerifier = providerhost.PublicHostServiceSessionVerifier
+
+const DefaultRuntimeLogHostSocketEnv = providerhost.DefaultRuntimeLogHostSocketEnv
+
+func WithHostServicesProviderName(name string) HostServicesOption {
+	return providerhost.WithHostServicesProviderName(name)
+}
+
+func WithHostServicesTelemetry(telemetry TelemetryProviders) HostServicesOption {
+	return providerhost.WithHostServicesTelemetry(telemetry)
+}
+
+func StartHostServices(services []HostService, opts ...HostServicesOption) (*StartedHostServices, error) {
+	return providerhost.StartHostServices(services, opts...)
+}
+
+func StartPluginProcess(ctx context.Context, cfg ProcessConfig) (*PluginProcess, error) {
+	return providerhost.StartPluginProcess(ctx, cfg)
+}
+
+func NewPluginTempDir(pattern string) (string, error) {
+	return providerhost.NewPluginTempDir(pattern)
+}
+
+func ConfigureRuntimeProvider(ctx context.Context, client proto.ProviderLifecycleClient, expectedKind proto.ProviderKind, name string, config map[string]any) (*RuntimeProviderMetadata, error) {
+	return providerhost.ConfigureRuntimeProvider(ctx, client, expectedKind, name, config)
+}
+
+func CheckRuntimeProviderHealth(ctx context.Context, client proto.ProviderLifecycleClient) error {
+	return providerhost.CheckRuntimeProviderHealth(ctx, client)
+}
+
+func StartRuntimeProvider(ctx context.Context, client proto.ProviderLifecycleClient) error {
+	return providerhost.StartRuntimeProvider(ctx, client)
+}
+
+func WithProviderMigrationTimeout(ctx context.Context) context.Context {
+	return providerhost.WithProviderMigrationTimeout(ctx)
+}
+
+func NewPublicHostServiceRegistry() *PublicHostServiceRegistry {
+	return providerhost.NewPublicHostServiceRegistry()
+}
+
+func NewRuntimeLogHostServer(runtimeProviderName string, appendLogs func(context.Context, string, string, []AppendRuntimeLogEntry) (int64, error)) proto.PluginRuntimeLogHostServer {
+	return providerhost.NewRuntimeLogHostServer(runtimeProviderName, appendLogs)
+}
+
+func RegisterRuntimeLogHostServer(srv *grpc.Server, runtimeProviderName string, appendLogs func(context.Context, string, string, []AppendRuntimeLogEntry) (int64, error)) {
+	proto.RegisterPluginRuntimeLogHostServer(srv, NewRuntimeLogHostServer(runtimeProviderName, appendLogs))
+}


### PR DESCRIPTION
## Summary
- Add `gestaltd/services/runtimehost` as the service-facing boundary for runtime process, runtime lifecycle, host-service, public host-service registry, and runtime-log host primitives.
- Move bootstrap, plugin runtime, server public-host-service, and provider factory signatures to use `runtimehost` for those primitives.
- Keep provider-specific executable adapters, relay token managers, and cache/s3/indexeddb/workflow socket constants in `internal/providerhost` for this slice.

## New interfaces
- `runtimehost.HostService` / `runtimehost.StartHostServices` for host-owned gRPC sockets exposed to runtimes.
- `runtimehost.StartPluginProcess` with `runtimehost.ProcessConfig` for executable runtime sessions.
- `runtimehost.ConfigureRuntimeProvider`, `runtimehost.CheckRuntimeProviderHealth`, `runtimehost.StartRuntimeProvider`, and `runtimehost.RuntimeProviderMetadata` for runtime lifecycle handshakes.
- `runtimehost.PublicHostServiceRegistry` and `runtimehost.RegisterRuntimeLogHostServer` for public host-service relay registration and runtime log hosting.

## Examples
```go
started, err := runtimehost.StartHostServices(
    hostServices,
    runtimehost.WithHostServicesProviderName(name),
    runtimehost.WithHostServicesTelemetry(deps.Telemetry),
)
```

```go
proc, err := runtimehost.StartPluginProcess(ctx, runtimehost.ProcessConfig{
    Command: cfg.Command,
    Args: cfg.Args,
    Env: cfg.Env,
})
```

```go
runtimehost.RegisterRuntimeLogHostServer(
    srv,
    name,
    deps.Services.RuntimeSessionLogs.AppendSessionLogs,
)
```

## Review pass
- Reviewed with a separate GPT-5.5 xhigh agent. Applied the agreed feedback to keep generic executable-provider primitives and daemon remote-dev process launch on `internal/providerhost`.

## Tests
```sh
go test ./services/runtimehost ./internal/pluginruntime ./internal/bootstrap ./internal/server/... ./internal/providerhost ./internal/daemon ./internal/drivers/authorization/provider ./internal/drivers/externalcredentials/provider ./internal/drivers/workflow/provider ./internal/drivers/agent/provider ./cmd/gestaltd
```