### PR TITLE
workflow: configure providers with migration budget

### DIFF
--- a/gestaltd/internal/providerhost/runtime_client.go
+++ b/gestaltd/internal/providerhost/runtime_client.go
@@ -185,5 +185,8 @@ func providerConfigureContext(parent context.Context) (context.Context, context.
 	if parent == nil {
 		parent = context.Background()
 	}
+	if useMigrationTimeout, _ := parent.Value(providerMigrationTimeoutContextKey{}).(bool); useMigrationTimeout {
+		return providerMigrationContext(parent)
+	}
 	return context.WithTimeout(parent, providerConfigureTimeout)
 }

--- a/gestaltd/internal/providerhost/runtime_client_test.go
+++ b/gestaltd/internal/providerhost/runtime_client_test.go
@@ -3,6 +3,7 @@ package providerhost
 import (
 	"context"
 	"testing"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc"
@@ -108,6 +109,53 @@ func TestConfigureRuntimeProviderRefreshesMetadataAfterConfigure(t *testing.T) {
 	}
 	if len(meta.Warnings) != 1 || meta.Warnings[0] != "configured" {
 		t.Fatalf("Warnings = %#v, want %#v", meta.Warnings, []string{"configured"})
+	}
+}
+
+func TestConfigureRuntimeProviderUsesMigrationTimeoutWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	assertMigrationDeadline := func(t *testing.T, ctx context.Context) {
+		t.Helper()
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("provider configure context has no deadline")
+		}
+		remaining := time.Until(deadline)
+		if remaining <= providerConfigureTimeout || remaining > providerMigrateTimeout {
+			t.Fatalf("provider configure deadline remaining = %s, want migration budget above %s", remaining, providerConfigureTimeout)
+		}
+	}
+
+	configureCalled := false
+	client := &fakeProviderLifecycleClient{
+		getProviderIdentity: func(ctx context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (*proto.ProviderIdentity, error) {
+			assertMigrationDeadline(t, ctx)
+			return &proto.ProviderIdentity{
+				Kind:               proto.ProviderKind_PROVIDER_KIND_WORKFLOW,
+				Name:               "indexeddb",
+				MinProtocolVersion: proto.CurrentProtocolVersion,
+				MaxProtocolVersion: proto.CurrentProtocolVersion,
+			}, nil
+		},
+		configureProvider: func(ctx context.Context, _ *proto.ConfigureProviderRequest, _ ...grpc.CallOption) (*proto.ConfigureProviderResponse, error) {
+			assertMigrationDeadline(t, ctx)
+			configureCalled = true
+			return &proto.ConfigureProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+		},
+	}
+
+	if _, err := ConfigureRuntimeProvider(
+		WithProviderMigrationTimeout(context.Background()),
+		client,
+		proto.ProviderKind_PROVIDER_KIND_WORKFLOW,
+		"indexeddb",
+		nil,
+	); err != nil {
+		t.Fatalf("ConfigureRuntimeProvider: %v", err)
+	}
+	if !configureCalled {
+		t.Fatal("ConfigureProvider was not called")
 	}
 }
 

--- a/gestaltd/internal/providerhost/workflow_client.go
+++ b/gestaltd/internal/providerhost/workflow_client.go
@@ -49,7 +49,8 @@ func NewExecutableWorkflow(ctx context.Context, cfg WorkflowExecConfig) (corewor
 
 	runtimeClient := proto.NewProviderLifecycleClient(proc.conn)
 	workflowClient := proto.NewWorkflowProviderClient(proc.conn)
-	if _, err := ConfigureRuntimeProvider(ctx, runtimeClient, proto.ProviderKind_PROVIDER_KIND_WORKFLOW, cfg.Name, cfg.Config); err != nil {
+	configureCtx := WithProviderMigrationTimeout(ctx)
+	if _, err := ConfigureRuntimeProvider(configureCtx, runtimeClient, proto.ProviderKind_PROVIDER_KIND_WORKFLOW, cfg.Name, cfg.Config); err != nil {
 		_ = proc.Close()
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- makes `ConfigureRuntimeProvider` honor the existing `WithProviderMigrationTimeout` marker for provider lifecycle configure calls
- configures executable workflow providers under that migration marker
- keeps the normal 30s configure deadline for ordinary providers unless the caller explicitly opts into migration budget

This addresses the next Cloud Run failure after valon-technologies/gestalt#1570: the IndexedDB schema calls no longer surface, but the workflow provider `ConfigureProvider` RPC itself can exceed the 30s configure deadline while doing startup store setup/recovery.

## Interfaces
No public API or config changes.

Existing host primitive:

```go
configureCtx := providerhost.WithProviderMigrationTimeout(ctx)
```

Now affects both schema calls and provider configure calls that are made with that context:

```go
ConfigureRuntimeProvider(configureCtx, runtimeClient, proto.ProviderKind_PROVIDER_KIND_WORKFLOW, name, config)
```

## Example
Workflow providers are durable providers, so the host configures them with the migration budget:

```go
configureCtx := WithProviderMigrationTimeout(ctx)
_, err := ConfigureRuntimeProvider(configureCtx, runtimeClient, proto.ProviderKind_PROVIDER_KIND_WORKFLOW, cfg.Name, cfg.Config)
```

A normal provider configured without the marker still uses the existing 30s configure deadline.

## Verification
- `go test ./internal/providerhost`