### PR TITLE
Rename Helm preparation values

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -198,11 +198,11 @@ jobs:
       - name: Validate Kubernetes schemas (ingress)
         run: kubeconform -strict -summary /tmp/rendered-ingress.yaml
 
-      - name: Helm template (plugin-init)
+      - name: Helm template (preparation)
         run: |
           helm template test-release gestaltd/deploy/helm/gestalt \
-            -f gestaltd/deploy/helm/gestalt/ci-values-plugin-init.yaml \
-            > /tmp/rendered-plugin-init.yaml
+            -f gestaltd/deploy/helm/gestalt/ci-values-preparation.yaml \
+            > /tmp/rendered-preparation.yaml
 
-      - name: Validate Kubernetes schemas (plugin-init)
-        run: kubeconform -strict -summary /tmp/rendered-plugin-init.yaml
+      - name: Validate Kubernetes schemas (preparation)
+        run: kubeconform -strict -summary /tmp/rendered-preparation.yaml

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -71,7 +71,7 @@ extraEnv:
         name: gestalt-secrets
         key: database-url
 
-pluginInit:
+preparation:
   enabled: true
 ```
 
@@ -92,8 +92,8 @@ helm upgrade --install gestalt \
 | `config` | Rendered as `/etc/gestalt/config.yaml`. |
 | `extraEnv` | Environment variables used by `${VAR}` placeholders in `config`. |
 | `persistence` | PVC settings for SQLite or other local state. |
-| `pluginInit.enabled` | Runs `gestaltd lock` and `gestaltd sync --locked` in an init container before the main server starts. Use it when the chart should prepare locked state for published provider packages or packaged UI bundles. |
-| `lockedServe.enabled` | Adds `--locked` to the main container without enabling the chart init container. Use it when lock state and prepared artifacts are baked into the image or mounted by external automation. |
+| `preparation.enabled` | Runs `gestaltd lock` and `gestaltd sync --locked` in a preparation container before the main server starts. Use it when the chart should prepare locked state for published provider packages or packaged UI bundles. |
+| `lockedServe.enabled` | Adds `--locked` to the main container without enabling the chart preparation container. Use it when lock state and prepared artifacts are baked into the image or mounted by external automation. |
 | `ingress` | Standard ingress settings. |
 | `ingress.hosts[].paths` | Per-host ingress paths and path types. |
 | `managementService` | Optional internal Service for a separate management listener. |
@@ -165,7 +165,7 @@ extraEnv:
         name: gestalt-secrets
         key: database-url
 
-pluginInit:
+preparation:
   enabled: true
 ```
 
@@ -175,15 +175,15 @@ on port `9090`. If operators need browser access to `/admin`, place an
 internal-only ingress, VPN, or identity-aware proxy in front of that management
 Service rather than exposing it on the public ingress.
 
-## When to enable `pluginInit`
+## When to enable `preparation`
 
-Enable the init container when your config uses published provider metadata URLs under `plugins.*.source`, `providers.authentication.*.source`, `providers.indexeddb.*.source`, or `providers.ui.*.source` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
+Enable the preparation container when your config uses published provider metadata URLs under `plugins.*.source`, `providers.authentication.*.source`, `providers.indexeddb.*.source`, or `providers.ui.*.source` and you want that state prepared before the main container starts. The preparation container copies the rendered config and runs:
 
 `/gestaltd lock --config /etc/gestalt/config.yaml && /gestaltd sync --locked --config /etc/gestalt/config.yaml`
 
 The main container then starts in locked mode against the prepared state.
 
-If you prepare lock state outside the chart, leave `pluginInit.enabled: false`
+If you prepare lock state outside the chart, leave `preparation.enabled: false`
 and set `lockedServe.enabled: true` so the main container still starts with
 `serve --locked`.
 

--- a/gestaltd/deploy/helm/gestalt/ci-values-preparation.yaml
+++ b/gestaltd/deploy/helm/gestalt/ci-values-preparation.yaml
@@ -10,5 +10,5 @@ config:
 image:
   tag: "ci-test"
 
-pluginInit:
+preparation:
   enabled: true

--- a/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
+++ b/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
@@ -66,7 +66,7 @@ For Google OAuth:
   GOOGLE_CLIENT_SECRET     Google OAuth client secret
 
 For OIDC, override config.auth.plugin in your values file.
-{{- if .Values.pluginInit.enabled }}
+{{- if .Values.preparation.enabled }}
 
 Plugin preparation is enabled. A preparation container runs `gestaltd lock` followed by
 `gestaltd sync --locked` before the main server starts, preparing locked state

--- a/gestaltd/deploy/helm/gestalt/templates/deployment.yaml
+++ b/gestaltd/deploy/helm/gestalt/templates/deployment.yaml
@@ -37,9 +37,9 @@ spec:
         fsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
-      {{- if .Values.pluginInit.enabled }}
+      {{- if .Values.preparation.enabled }}
       initContainers:
-        - name: plugin-init
+        - name: prepare-state
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true
@@ -82,7 +82,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - serve
-            {{- if or .Values.pluginInit.enabled .Values.lockedServe.enabled }}
+            {{- if or .Values.preparation.enabled .Values.lockedServe.enabled }}
             - --locked
             {{- end }}
             - --config
@@ -113,7 +113,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if .Values.pluginInit.enabled }}
+            {{- if .Values.preparation.enabled }}
             - name: gestalt-state
               mountPath: /etc/gestalt
               readOnly: true
@@ -140,7 +140,7 @@ spec:
           {{- end }}
         - name: tmp
           emptyDir: {}
-        {{- if .Values.pluginInit.enabled }}
+        {{- if .Values.preparation.enabled }}
         - name: gestalt-state
           emptyDir: {}
         {{- end }}

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -149,7 +149,7 @@ extraEnv: []
 #       name: gestalt-secrets
 #       key: oidc-session-secret
 
-pluginInit:
+preparation:
   # Enable this when your config uses remote REST/GraphQL upstreams or
   # packaged plugins and you want the chart to lock and sync prepared artifacts
   # before the main container starts in locked mode.
@@ -157,8 +157,8 @@ pluginInit:
 
 lockedServe:
   # Enable this when lock state and prepared artifacts are baked into the image
-  # or mounted by external automation, without using the chart's pluginInit
-  # init container.
+  # or mounted by external automation, without using the chart's preparation
+  # container.
   enabled: false
 
 livenessProbe:


### PR DESCRIPTION
## Summary
- Rename the Helm chart preparation switch from `pluginInit.enabled` to `preparation.enabled`.
- Rename the rendered preparation container from `plugin-init` to `prepare-state`.
- Rename the chart CI values fixture and workflow labels from plugin-init to preparation.
- Update Helm deployment docs and NOTES to use preparation terminology.

## Interface / Contract Diff
```diff
- pluginInit:
-   enabled: true
+ preparation:
+   enabled: true

- initContainers:
-   - name: plugin-init
+ initContainers:
+   - name: prepare-state
```

`lockedServe.enabled` is unchanged and still means the main container runs with `serve --locked` while lock state and prepared artifacts come from the image or external mounts.

## Examples
```yaml
preparation:
  enabled: true
```

```yaml
lockedServe:
  enabled: true
```

## Verification
```sh
helm lint gestaltd/deploy/helm/gestalt
helm template test-release gestaltd/deploy/helm/gestalt > /tmp/rendered-default.yaml
helm template test-release gestaltd/deploy/helm/gestalt \
  -f gestaltd/deploy/helm/gestalt/ci-values-preparation.yaml \
  > /tmp/rendered-preparation.yaml
rg -n 'prepare-state|plugin-init|--locked|/gestaltd lock|/gestaltd sync|initContainers' \
  /tmp/rendered-preparation.yaml /tmp/rendered-default.yaml
```

```sh
rg -n 'pluginInit|plugin-init|ci-values-plugin-init|rendered-plugin-init|Plugin init|gestaltd init|`init`, `validate`, `serve`|gestaltd\.config/v3|init container' \
  .github gestaltd/deploy/helm docs
```

Local note: `kubeconform` is not installed in this environment, so Kubernetes schema validation is left to CI.