### PR TITLE
[codex] Expose runtime host relay primitives

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -741,7 +742,7 @@ func fakeHostedIndexedDBRoundTrip(store, id, value, binding string, env map[stri
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 
 	client := proto.NewIndexedDBClient(conn)
 	if _, err := client.CreateObjectStore(ctx, &proto.CreateObjectStoreRequest{Name: store}); err != nil {
@@ -800,7 +801,7 @@ func fakeHostedCacheRoundTrip(key, value, binding string, env map[string]string)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 
 	client := proto.NewCacheClient(conn)
 	if _, err := client.Set(ctx, &proto.CacheSetRequest{
@@ -881,7 +882,7 @@ func fakeHostedS3RoundTrip(bucket, key, value, binding string, env map[string]st
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 
 	client := proto.NewS3Client(conn)
 	writeStream, err := client.WriteObject(ctx)
@@ -993,7 +994,7 @@ func fakeHostedWorkflowManagerRoundTrip(invocationToken string, env map[string]s
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 
 	client := proto.NewWorkflowManagerHostClient(conn)
 	created, err := client.CreateSchedule(ctx, &proto.WorkflowManagerCreateScheduleRequest{
@@ -1063,7 +1064,7 @@ func fakeHostedAuthorizationRoundTrip(env map[string]string) (map[string]any, er
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 
 	client := proto.NewAuthorizationProviderClient(conn)
 	meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
@@ -1123,7 +1124,7 @@ func fakeHostedAgentManagerRoundTrip(invocationToken string, env map[string]stri
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 
 	client := proto.NewAgentManagerHostClient(conn)
 	session, err := client.CreateSession(ctx, &proto.AgentManagerCreateSessionRequest{
@@ -1269,7 +1270,7 @@ func fakeHostedInvokePlugin(targetPlugin, targetOperation, invocationToken strin
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 
 	resp, err := proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{
 		InvocationToken: invocationToken,
@@ -7219,12 +7220,12 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServices *providerhost.PublicHostServiceRegistry) http.Handler {
 	t.Helper()
 
-	tokenManager, err := providerhost.NewHostServiceRelayTokenManager(stateSecret)
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(stateSecret)
 	if err != nil {
 		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		token := strings.TrimSpace(r.Header.Get(providerhost.HostServiceRelayTokenHeader))
+		token := strings.TrimSpace(r.Header.Get(runtimehost.HostServiceRelayTokenHeader))
 		target, err := tokenManager.ResolveToken(token)
 		if err != nil {
 			writeRuntimeRelayGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-token")
@@ -7245,12 +7246,12 @@ func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServ
 		}
 		relayReq := r.Clone(r.Context())
 		relayReq.Header = r.Header.Clone()
-		relayReq.Header.Del(providerhost.HostServiceRelayTokenHeader)
+		relayReq.Header.Del(runtimehost.HostServiceRelayTokenHeader)
 		handler.ServeHTTP(w, relayReq)
 	})
 }
 
-func runtimeRelayPublicHostServiceHandler(ctx context.Context, registry *providerhost.PublicHostServiceRegistry, target providerhost.HostServiceRelayTarget) (http.Handler, error) {
+func runtimeRelayPublicHostServiceHandler(ctx context.Context, registry *providerhost.PublicHostServiceRegistry, target runtimehost.HostServiceRelayTarget) (http.Handler, error) {
 	handler, err := runtimeRelayPublicHostServiceHandlerForSession(ctx, registry, target, target.SessionID)
 	if handler != nil || err != nil || strings.TrimSpace(target.SessionID) == "" {
 		return handler, err
@@ -7258,7 +7259,7 @@ func runtimeRelayPublicHostServiceHandler(ctx context.Context, registry *provide
 	return runtimeRelayPublicHostServiceHandlerForSession(ctx, registry, target, "")
 }
 
-func runtimeRelayPublicHostServiceHandlerForSession(ctx context.Context, registry *providerhost.PublicHostServiceRegistry, target providerhost.HostServiceRelayTarget, sessionID string) (http.Handler, error) {
+func runtimeRelayPublicHostServiceHandlerForSession(ctx context.Context, registry *providerhost.PublicHostServiceRegistry, target runtimehost.HostServiceRelayTarget, sessionID string) (http.Handler, error) {
 	if registry == nil {
 		return nil, nil
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1739,11 +1739,11 @@ func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, ho
 	if err != nil {
 		return pluginruntime.HostServiceRelay{}, nil, "", false, err
 	}
-	tokenManager, err := providerhost.NewHostServiceRelayTokenManager(deps.EncryptionKey)
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(deps.EncryptionKey)
 	if err != nil {
 		return pluginruntime.HostServiceRelay{}, nil, "", false, fmt.Errorf("init host service relay tokens: %w", err)
 	}
-	token, err := tokenManager.MintToken(providerhost.HostServiceRelayTokenRequest{
+	token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
 		PluginName:   providerName,
 		SessionID:    sessionID,
 		Service:      serviceKey,

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 )
@@ -70,7 +69,7 @@ func (k hostServiceHandlerKey) String() string {
 	return strings.Join(parts, "/")
 }
 
-func (s *Server) hostServiceHandler(ctx context.Context, target providerhost.HostServiceRelayTarget) (http.Handler, error) {
+func (s *Server) hostServiceHandler(ctx context.Context, target runtimehost.HostServiceRelayTarget) (http.Handler, error) {
 	if s == nil {
 		return nil, nil
 	}

--- a/gestaltd/internal/server/host_service_relay.go
+++ b/gestaltd/internal/server/host_service_relay.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc/codes"
 )
 
@@ -42,7 +42,7 @@ func (s *Server) hostServiceRelayMiddleware(next http.Handler) http.Handler {
 		}
 		relayReq := r.Clone(r.Context())
 		relayReq.Header = r.Header.Clone()
-		relayReq.Header.Del(providerhost.HostServiceRelayTokenHeader)
+		relayReq.Header.Del(runtimehost.HostServiceRelayTokenHeader)
 		handler.ServeHTTP(w, relayReq)
 	})
 }
@@ -51,7 +51,7 @@ func (s *Server) hostServiceRelayToken(r *http.Request) string {
 	if s == nil || r == nil {
 		return ""
 	}
-	return strings.TrimSpace(r.Header.Get(providerhost.HostServiceRelayTokenHeader))
+	return strings.TrimSpace(r.Header.Get(runtimehost.HostServiceRelayTokenHeader))
 }
 
 func isGRPCRequest(r *http.Request) bool {

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
@@ -103,11 +104,11 @@ func TestNewHTTPServerSupportsH2CHostServiceRelay(t *testing.T) {
 		}
 	})
 
-	tokenManager, err := providerhost.NewHostServiceRelayTokenManager(secret)
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
 	if err != nil {
 		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
 	}
-	token, err := tokenManager.MintToken(providerhost.HostServiceRelayTokenRequest{
+	token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
 		PluginName:   "relay-plugin",
 		SessionID:    "session-1",
 		Service:      "cache",
@@ -129,7 +130,7 @@ func TestNewHTTPServerSupportsH2CHostServiceRelay(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 
 	resp, err := proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "hello"})
 	if err != nil {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -117,7 +117,7 @@ type Server struct {
 	meterProvider          metric.MeterProvider
 	prometheusMetrics      http.Handler
 	mcpHandler             http.Handler
-	hostServiceRelayTokens *providerhost.HostServiceRelayTokenManager
+	hostServiceRelayTokens *runtimehost.HostServiceRelayTokenManager
 	hostServiceMu          sync.Mutex
 	hostServiceHandlers    map[hostServiceHandlerKey]hostServiceHandlerEntry
 	hostServiceVersion     uint64
@@ -289,11 +289,11 @@ func New(cfg Config) (*Server, error) {
 	if cfg.MeterProvider != nil {
 		otelOptions = append(otelOptions, otelhttp.WithMeterProvider(cfg.MeterProvider))
 	}
-	var hostServiceRelayTokens *providerhost.HostServiceRelayTokenManager
+	var hostServiceRelayTokens *runtimehost.HostServiceRelayTokenManager
 	var egressProxyTokens *providerhost.EgressProxyTokenManager
 	var s3ObjectAccessURLs *providerhost.S3ObjectAccessURLManager
 	if len(cfg.StateSecret) > 0 {
-		hostServiceRelayTokens, err = providerhost.NewHostServiceRelayTokenManager(cfg.StateSecret)
+		hostServiceRelayTokens, err = runtimehost.NewHostServiceRelayTokenManager(cfg.StateSecret)
 		if err != nil {
 			return nil, fmt.Errorf("init host service relay tokens: %w", err)
 		}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -65,6 +65,7 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	coreintegration "github.com/valon-technologies/gestalt/server/services/plugins/declarative"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -426,7 +427,7 @@ func (s *relayTestCacheServer) Get(ctx context.Context, req *proto.CacheGetReque
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		s.mu.Lock()
 		s.keys = append(s.keys, req.GetKey())
-		s.receivedTokens = append(s.receivedTokens, md.Get(providerhost.HostServiceRelayTokenHeader)...)
+		s.receivedTokens = append(s.receivedTokens, md.Get(runtimehost.HostServiceRelayTokenHeader)...)
 		s.mu.Unlock()
 	}
 	return &proto.CacheGetResponse{
@@ -501,11 +502,11 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 	publicHostServices.RegisterVerified("support", sessionVerifier, hostService)
 
-	tokenManager, err := providerhost.NewHostServiceRelayTokenManager(secret)
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
 	if err != nil {
 		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
 	}
-	token, err := tokenManager.MintToken(providerhost.HostServiceRelayTokenRequest{
+	token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
 		PluginName:   "support",
 		SessionID:    "session-1",
 		Service:      "cache",
@@ -522,7 +523,7 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 
 	resp, err := proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "hello"})
 	if err != nil {
@@ -541,7 +542,7 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	sessionVerifier.setActive("session-1", false)
 	staleCtx, staleCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer staleCancel()
-	staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 	_, err = proto.NewCacheClient(conn).Get(staleCtx, &proto.CacheGetRequest{Key: "stale"})
 	if grpcstatus.Code(err) != codes.Unauthenticated {
 		t.Fatalf("Cache.Get stale session code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unauthenticated, err)
@@ -554,7 +555,7 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	publicHostServices.Unregister("support", hostService)
 	unregisteredCtx, unregisteredCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer unregisteredCancel()
-	unregisteredCtx = metadata.NewOutgoingContext(unregisteredCtx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	unregisteredCtx = metadata.NewOutgoingContext(unregisteredCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 	_, err = proto.NewCacheClient(conn).Get(unregisteredCtx, &proto.CacheGetRequest{Key: "unregistered"})
 	if grpcstatus.Code(err) != codes.Unavailable {
 		t.Fatalf("Cache.Get unregistered provider code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
@@ -589,11 +590,11 @@ func TestHostServiceRelayStopsServingUnregisteredSession(t *testing.T) {
 	ts.StartTLS()
 	testutil.CloseOnCleanup(t, ts)
 
-	tokenManager, err := providerhost.NewHostServiceRelayTokenManager(secret)
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
 	if err != nil {
 		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
 	}
-	token, err := tokenManager.MintToken(providerhost.HostServiceRelayTokenRequest{
+	token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
 		PluginName:   "support",
 		SessionID:    "session-1",
 		Service:      "cache",
@@ -610,7 +611,7 @@ func TestHostServiceRelayStopsServingUnregisteredSession(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 	if _, err := proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "active"}); err != nil {
 		t.Fatalf("Cache.Get via session relay: %v", err)
 	}
@@ -618,7 +619,7 @@ func TestHostServiceRelayStopsServingUnregisteredSession(t *testing.T) {
 	publicHostServices.UnregisterSession("support", "session-1", hostService)
 	staleCtx, staleCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer staleCancel()
-	staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 	_, err = proto.NewCacheClient(conn).Get(staleCtx, &proto.CacheGetRequest{Key: "stale"})
 	if grpcstatus.Code(err) != codes.Unavailable {
 		t.Fatalf("Cache.Get unregistered session code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
@@ -645,7 +646,7 @@ func TestHostServiceRelayRejectsInvalidToken(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, "not-a-valid-token"))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, "not-a-valid-token"))
 
 	_, err := proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "hello"})
 	if grpcstatus.Code(err) != codes.Unauthenticated {
@@ -677,11 +678,11 @@ func TestHostServiceRelayRejectsMethodOutsideTokenPrefix(t *testing.T) {
 	ts.StartTLS()
 	testutil.CloseOnCleanup(t, ts)
 
-	tokenManager, err := providerhost.NewHostServiceRelayTokenManager(secret)
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
 	if err != nil {
 		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
 	}
-	token, err := tokenManager.MintToken(providerhost.HostServiceRelayTokenRequest{
+	token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
 		PluginName:   "support",
 		SessionID:    "session-1",
 		Service:      "cache",
@@ -698,7 +699,7 @@ func TestHostServiceRelayRejectsMethodOutsideTokenPrefix(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 
 	_, err = proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "hello"})
 	if grpcstatus.Code(err) != codes.PermissionDenied {
@@ -731,11 +732,11 @@ func TestHostServiceRelaySupportsIndexedDBSDKClient(t *testing.T) {
 	ts.StartTLS()
 	testutil.CloseOnCleanup(t, ts)
 
-	tokenManager, err := providerhost.NewHostServiceRelayTokenManager(secret)
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
 	if err != nil {
 		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
 	}
-	token, err := tokenManager.MintToken(providerhost.HostServiceRelayTokenRequest{
+	token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
 		PluginName:   "relay-plugin",
 		SessionID:    "session-1",
 		Service:      "indexeddb",
@@ -749,7 +750,7 @@ func TestHostServiceRelaySupportsIndexedDBSDKClient(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 
 	recordValue, err := gestaltsdk.RecordToProto(gestaltsdk.Record{"id": "task-1", "value": "ship-it"})
 	if err != nil {

--- a/gestaltd/internal/testutil/cachetransport/server.go
+++ b/gestaltd/internal/testutil/cachetransport/server.go
@@ -13,6 +13,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -71,7 +72,7 @@ func validateRelayToken(ctx context.Context, expected string) error {
 	if !ok {
 		return status.Error(codes.Unauthenticated, "missing relay token metadata")
 	}
-	values := md.Get(providerhost.HostServiceRelayTokenHeader)
+	values := md.Get(runtimehost.HostServiceRelayTokenHeader)
 	if len(values) == 0 || strings.TrimSpace(values[0]) != expected {
 		return status.Error(codes.Unauthenticated, "invalid relay token metadata")
 	}

--- a/gestaltd/internal/testutil/cmd/indexeddbtransportd/main.go
+++ b/gestaltd/internal/testutil/cmd/indexeddbtransportd/main.go
@@ -19,8 +19,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/indexeddbtransport"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc/codes"
 )
@@ -125,7 +125,7 @@ func startTLSRelay(address string, certFile string, keyFile string, expectToken 
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if expectToken != "" {
-				token := strings.TrimSpace(r.Header.Get(providerhost.HostServiceRelayTokenHeader))
+				token := strings.TrimSpace(r.Header.Get(runtimehost.HostServiceRelayTokenHeader))
 				if token != expectToken {
 					writeGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-token")
 					return
@@ -166,7 +166,7 @@ func newRuntimeRelayProxy(socketPath string) *httputil.ReverseProxy {
 			pr.Out.URL.Scheme = "http"
 			pr.Out.URL.Host = target
 			pr.Out.Host = target
-			pr.Out.Header.Del(providerhost.HostServiceRelayTokenHeader)
+			pr.Out.Header.Del(runtimehost.HostServiceRelayTokenHeader)
 		},
 		Transport: &http2.Transport{
 			AllowHTTP: true,

--- a/gestaltd/internal/testutil/indexeddbtransport/server.go
+++ b/gestaltd/internal/testutil/indexeddbtransport/server.go
@@ -13,6 +13,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -83,7 +84,7 @@ func validateRelayToken(ctx context.Context, expected string) error {
 	if !ok {
 		return status.Error(codes.Unauthenticated, "missing relay token metadata")
 	}
-	values := md.Get(providerhost.HostServiceRelayTokenHeader)
+	values := md.Get(runtimehost.HostServiceRelayTokenHeader)
 	if len(values) == 0 || strings.TrimSpace(values[0]) != expected {
 		return status.Error(codes.Unauthenticated, "invalid relay token metadata")
 	}

--- a/gestaltd/internal/testutil/s3transport/server.go
+++ b/gestaltd/internal/testutil/s3transport/server.go
@@ -13,6 +13,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -92,7 +93,7 @@ func validateRelayToken(ctx context.Context, expected string) error {
 	if !ok {
 		return status.Error(codes.Unauthenticated, "missing relay token metadata")
 	}
-	values := md.Get(providerhost.HostServiceRelayTokenHeader)
+	values := md.Get(runtimehost.HostServiceRelayTokenHeader)
 	if len(values) == 0 || strings.TrimSpace(values[0]) != expected {
 		return status.Error(codes.Unauthenticated, "invalid relay token metadata")
 	}

--- a/gestaltd/services/runtimehost/relay.go
+++ b/gestaltd/services/runtimehost/relay.go
@@ -1,0 +1,13 @@
+package runtimehost
+
+import "github.com/valon-technologies/gestalt/server/internal/providerhost"
+
+const HostServiceRelayTokenHeader = providerhost.HostServiceRelayTokenHeader
+
+type HostServiceRelayTokenManager = providerhost.HostServiceRelayTokenManager
+type HostServiceRelayTokenRequest = providerhost.HostServiceRelayTokenRequest
+type HostServiceRelayTarget = providerhost.HostServiceRelayTarget
+
+func NewHostServiceRelayTokenManager(secret []byte) (*HostServiceRelayTokenManager, error) {
+	return providerhost.NewHostServiceRelayTokenManager(secret)
+}


### PR DESCRIPTION
## Summary
- Add `runtimehost` facade exports for host-service relay token/header/target primitives.
- Move runtime-host relay minting and server relay handling to use `services/runtimehost` rather than `internal/providerhost`.
- Update existing server/bootstrap/test transport relay coverage to exercise the new service-facing surface.

## New interfaces
- `runtimehost.HostServiceRelayTokenHeader` for relay gRPC metadata/header forwarding.
- `runtimehost.HostServiceRelayTokenManager` for minting and resolving relay tokens.
- `runtimehost.HostServiceRelayTokenRequest` and `runtimehost.HostServiceRelayTarget` for the relay contract.

## Examples
```go
tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
```

```go
token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
    PluginName: providerName,
    SessionID: sessionID,
    Service: serviceKey,
    EnvVar: hostService.EnvVar,
    MethodPrefix: methodPrefix,
})
```

```go
ctx = metadata.NewOutgoingContext(
    ctx,
    metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token),
)
```

## Boundary
Provider-specific host service servers, egress tokens, S3 object access, and concrete socket env constants intentionally remain in `internal/providerhost` for this slice.

## Review pass
- Reviewed with a separate GPT-5.5 xhigh agent. The only finding was to ensure `services/runtimehost/relay.go` was tracked; it is included in the commit.

## Tests
```sh
go test ./services/runtimehost ./internal/providerhost ./internal/pluginruntime ./internal/bootstrap ./internal/server/... ./internal/testutil/cachetransport ./internal/testutil/indexeddbtransport ./internal/testutil/s3transport ./internal/testutil/cmd/indexeddbtransportd
```