### PR TITLE
[codex] Add S3 service boundary

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -47,6 +47,7 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"github.com/valon-technologies/gestalt/server/services/s3"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
@@ -1930,10 +1931,10 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 		return nil, fmt.Errorf("s3 host services are not available")
 	}
 
-	var accessURLs *providerhost.S3ObjectAccessURLManager
+	var accessURLs *s3.ObjectAccessURLManager
 	if len(deps.EncryptionKey) != 0 {
 		var err error
-		accessURLs, err = providerhost.NewS3ObjectAccessURLManager(deps.EncryptionKey, deps.BaseURL)
+		accessURLs, err = s3.NewObjectAccessURLManager(deps.EncryptionKey, deps.BaseURL)
 		if err != nil {
 			return nil, fmt.Errorf("s3 object access URLs: %w", err)
 		}
@@ -1954,7 +1955,7 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 						BindingName: binding,
 						AccessURLs:  accessURLs,
 					}))
-					proto.RegisterS3ObjectAccessServer(srv, providerhost.NewS3ObjectAccessServer(accessURLs, pluginName, binding))
+					proto.RegisterS3ObjectAccessServer(srv, s3.NewObjectAccessServer(accessURLs, pluginName, binding))
 				}
 			}(client, binding),
 		})
@@ -1970,7 +1971,7 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 					BindingName: binding,
 					AccessURLs:  accessURLs,
 				}))
-				proto.RegisterS3ObjectAccessServer(srv, providerhost.NewS3ObjectAccessServer(accessURLs, pluginName, binding))
+				proto.RegisterS3ObjectAccessServer(srv, s3.NewObjectAccessServer(accessURLs, pluginName, binding))
 			},
 		})
 	}

--- a/gestaltd/internal/server/handlers_s3_object_access.go
+++ b/gestaltd/internal/server/handlers_s3_object_access.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	s3store "github.com/valon-technologies/gestalt/server/core/s3"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/services/s3"
 )
 
 func (s *Server) mountS3ObjectAccessRoutes(r chi.Router) {
-	path := providerhost.S3ObjectAccessPathPrefix + "{token}"
+	path := s3.ObjectAccessPathPrefix + "{token}"
 	r.MethodFunc(http.MethodGet, path, s.handleS3ObjectAccess)
 	r.MethodFunc(http.MethodHead, path, s.handleS3ObjectAccess)
 	r.MethodFunc(http.MethodPut, path, s.handleS3ObjectAccess)
@@ -46,7 +46,7 @@ func (s *Server) handleS3ObjectAccess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ref := target.Ref
-	ref.Key = providerhost.S3PluginObjectKey(target.PluginName, ref.Key)
+	ref.Key = s3.PluginObjectKey(target.PluginName, ref.Key)
 
 	switch target.Method {
 	case s3store.PresignMethodGet:
@@ -99,7 +99,7 @@ func (s *Server) handleS3ObjectAccessHead(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusOK)
 }
 
-func (s *Server) handleS3ObjectAccessPut(w http.ResponseWriter, r *http.Request, client s3store.Client, target providerhost.S3ObjectAccessTarget, ref s3store.ObjectRef) {
+func (s *Server) handleS3ObjectAccessPut(w http.ResponseWriter, r *http.Request, client s3store.Client, target s3.ObjectAccessTarget, ref s3store.ObjectRef) {
 	contentType := target.ContentType
 	if contentType == "" {
 		contentType = r.Header.Get("Content-Type")
@@ -133,7 +133,7 @@ func (s *Server) handleS3ObjectAccessDelete(w http.ResponseWriter, r *http.Reque
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func enforceS3ObjectAccessHeaders(r *http.Request, target providerhost.S3ObjectAccessTarget, enforceContentType bool) error {
+func enforceS3ObjectAccessHeaders(r *http.Request, target s3.ObjectAccessTarget, enforceContentType bool) error {
 	if enforceContentType && target.ContentType != "" && r.Header.Get("Content-Type") != target.ContentType {
 		return fmt.Errorf("Content-Type header must be %q", target.ContentType)
 	}

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -11,8 +11,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/s3"
 )
 
 type contextKey string
@@ -94,7 +94,7 @@ func isProviderDevCompleteCallRequest(r *http.Request) bool {
 }
 
 func isS3ObjectAccessRequest(r *http.Request) bool {
-	return r != nil && r.URL != nil && strings.HasPrefix(r.URL.Path, providerhost.S3ObjectAccessPathPrefix)
+	return r != nil && r.URL != nil && strings.HasPrefix(r.URL.Path, s3.ObjectAccessPathPrefix)
 }
 
 // contentSecurityPolicy is the CSP applied to all responses. script-src and

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -26,6 +26,7 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"github.com/valon-technologies/gestalt/server/services/s3"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -123,7 +124,7 @@ type Server struct {
 	hostServiceVersion     uint64
 	publicHostServices     *runtimehost.PublicHostServiceRegistry
 	s3                     map[string]s3store.Client
-	s3ObjectAccessURLs     *providerhost.S3ObjectAccessURLManager
+	s3ObjectAccessURLs     *s3.ObjectAccessURLManager
 	egressProxyTokens      *providerhost.EgressProxyTokenManager
 	providerDevSessions    *providerdev.Manager
 	providerDevAttach      bool
@@ -291,7 +292,7 @@ func New(cfg Config) (*Server, error) {
 	}
 	var hostServiceRelayTokens *runtimehost.HostServiceRelayTokenManager
 	var egressProxyTokens *providerhost.EgressProxyTokenManager
-	var s3ObjectAccessURLs *providerhost.S3ObjectAccessURLManager
+	var s3ObjectAccessURLs *s3.ObjectAccessURLManager
 	if len(cfg.StateSecret) > 0 {
 		hostServiceRelayTokens, err = runtimehost.NewHostServiceRelayTokenManager(cfg.StateSecret)
 		if err != nil {
@@ -301,7 +302,7 @@ func New(cfg Config) (*Server, error) {
 		if err != nil {
 			return nil, fmt.Errorf("init egress proxy tokens: %w", err)
 		}
-		s3ObjectAccessURLs, err = providerhost.NewS3ObjectAccessURLManager(cfg.StateSecret, cfg.PublicBaseURL)
+		s3ObjectAccessURLs, err = s3.NewObjectAccessURLManager(cfg.StateSecret, cfg.PublicBaseURL)
 		if err != nil {
 			return nil, fmt.Errorf("init s3 object access URLs: %w", err)
 		}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -66,6 +66,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	coreintegration "github.com/valon-technologies/gestalt/server/services/plugins/declarative"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"github.com/valon-technologies/gestalt/server/services/s3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -157,18 +158,18 @@ func TestS3ObjectAccessURLUploadsAndDownloadsPluginScopedObject(t *testing.T) {
 	})
 	defer ts.Close()
 
-	manager, err := providerhost.NewS3ObjectAccessURLManager(
+	manager, err := s3.NewObjectAccessURLManager(
 		[]byte("0123456789abcdef0123456789abcdef"),
 		ts.URL,
 	)
 	if err != nil {
-		t.Fatalf("NewS3ObjectAccessURLManager: %v", err)
+		t.Fatalf("NewObjectAccessURLManager: %v", err)
 	}
 	targetRef := s3store.ObjectRef{
 		Bucket: "brain",
 		Key:    " workspaces/acme/tokens/token-1/content.bin ",
 	}
-	putURL, err := manager.MintURL(providerhost.S3ObjectAccessURLRequest{
+	putURL, err := manager.MintURL(s3.ObjectAccessURLRequest{
 		PluginName:  "brain",
 		BindingName: "brainStorage",
 		Ref:         targetRef,
@@ -199,7 +200,7 @@ func TestS3ObjectAccessURLUploadsAndDownloadsPluginScopedObject(t *testing.T) {
 
 	prefixed := s3store.ObjectRef{
 		Bucket: targetRef.Bucket,
-		Key:    providerhost.S3PluginObjectKey("brain", targetRef.Key),
+		Key:    s3.PluginObjectKey("brain", targetRef.Key),
 	}
 	if _, err := store.HeadObject(context.Background(), prefixed); err != nil {
 		t.Fatalf("HeadObject(prefixed): %v", err)
@@ -208,7 +209,7 @@ func TestS3ObjectAccessURLUploadsAndDownloadsPluginScopedObject(t *testing.T) {
 		t.Fatalf("HeadObject(unprefixed) error = %v, want ErrNotFound", err)
 	}
 
-	getURL, err := manager.MintURL(providerhost.S3ObjectAccessURLRequest{
+	getURL, err := manager.MintURL(s3.ObjectAccessURLRequest{
 		PluginName:  "brain",
 		BindingName: "brainStorage",
 		Ref:         targetRef,
@@ -237,7 +238,7 @@ func TestS3ObjectAccessURLUploadsAndDownloadsPluginScopedObject(t *testing.T) {
 		t.Fatalf("GET Content-Type = %q, want text/plain", getResp.Header.Get("Content-Type"))
 	}
 
-	constrainedGetURL, err := manager.MintURL(providerhost.S3ObjectAccessURLRequest{
+	constrainedGetURL, err := manager.MintURL(s3.ObjectAccessURLRequest{
 		PluginName:  "brain",
 		BindingName: "brainStorage",
 		Ref:         targetRef,

--- a/gestaltd/internal/testutil/s3transport/server.go
+++ b/gestaltd/internal/testutil/s3transport/server.go
@@ -14,6 +14,7 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"github.com/valon-technologies/gestalt/server/services/s3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -47,7 +48,7 @@ func Start(target string, opts Options) (*Server, error) {
 		return nil, err
 	}
 	stub := &coretesting.StubS3{}
-	accessURLs, err := providerhost.NewS3ObjectAccessURLManager(
+	accessURLs, err := s3.NewObjectAccessURLManager(
 		[]byte("0123456789abcdef0123456789abcdef"),
 		"https://gestalt.example.test",
 	)
@@ -60,7 +61,7 @@ func Start(target string, opts Options) (*Server, error) {
 		grpc.ChainStreamInterceptor(requireRelayTokenStream(opts.ExpectRelayToken)),
 	)
 	proto.RegisterS3Server(srv, providerhost.NewS3Server(stub, ""))
-	proto.RegisterS3ObjectAccessServer(srv, providerhost.NewS3ObjectAccessServer(accessURLs, "sdk-test", "default"))
+	proto.RegisterS3ObjectAccessServer(srv, s3.NewObjectAccessServer(accessURLs, "sdk-test", "default"))
 	go func() { _ = srv.Serve(lis) }()
 	return &Server{srv: srv, lis: lis, target: target}, nil
 }

--- a/gestaltd/services/s3/object_access.go
+++ b/gestaltd/services/s3/object_access.go
@@ -1,0 +1,25 @@
+// Package s3 exposes S3 service primitives.
+package s3
+
+import (
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+const ObjectAccessPathPrefix = providerhost.S3ObjectAccessPathPrefix
+
+type ObjectAccessURLManager = providerhost.S3ObjectAccessURLManager
+type ObjectAccessURLRequest = providerhost.S3ObjectAccessURLRequest
+type ObjectAccessTarget = providerhost.S3ObjectAccessTarget
+
+func NewObjectAccessURLManager(secret []byte, baseURL string) (*ObjectAccessURLManager, error) {
+	return providerhost.NewS3ObjectAccessURLManager(secret, baseURL)
+}
+
+func PluginObjectKey(pluginName, key string) string {
+	return providerhost.S3PluginObjectKey(pluginName, key)
+}
+
+func NewObjectAccessServer(manager *ObjectAccessURLManager, pluginName, bindingName string) proto.S3ObjectAccessServer {
+	return providerhost.NewS3ObjectAccessServer(manager, pluginName, bindingName)
+}


### PR DESCRIPTION
## Summary
- Add `gestaltd/services/s3` as the service-facing boundary for S3 signed object-access URL primitives.
- Move server object-access routes, max-body path detection, S3 host-service object-access registration, and S3 transport tests to use `services/s3` rather than `internal/providerhost` for this contract.
- Keep the concrete S3 provider transport and S3 server implementation in `internal/providerhost` for this slice.

## Stack
- Based on `main`; #1574 has been merged.

## New Interfaces
- `s3.ObjectAccessPathPrefix` for public HTTP object-access routing.
- `s3.ObjectAccessURLManager` for minting and resolving signed object access URLs.
- `s3.ObjectAccessURLRequest` and `s3.ObjectAccessTarget` for the signed URL contract.
- `s3.PluginObjectKey` for plugin-scoped object keys.
- `s3.NewObjectAccessServer` for the host-exposed object-access gRPC service.

## Examples
```go
manager, err := s3.NewObjectAccessURLManager(secret, baseURL)
```

```go
result, err := manager.MintURL(s3.ObjectAccessURLRequest{
    PluginName: pluginName,
    BindingName: binding,
    Ref: ref,
    Method: s3store.PresignMethodGet,
})
```

```go
path := s3.ObjectAccessPathPrefix + "{token}"
```

```go
ref.Key = s3.PluginObjectKey(target.PluginName, ref.Key)
```

## Review Pass
- Reviewed with a separate GPT-5.5 xhigh agent after the rename to `services/s3`. No findings.

## Tests
```sh
go test ./services/runtimehost ./services/s3 ./internal/providerhost ./internal/pluginruntime ./internal/bootstrap ./internal/server/... ./internal/testutil/cachetransport ./internal/testutil/indexeddbtransport ./internal/testutil/s3transport ./internal/testutil/cmd/indexeddbtransportd
```