### PR TITLE
[codex] Add egress proxy service boundary

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
@@ -7294,9 +7295,9 @@ func runtimeRelayPublicHostServiceHandlerForSession(ctx context.Context, registr
 func newRuntimeEgressProxyTestHandler(t *testing.T, stateSecret []byte) http.Handler {
 	t.Helper()
 
-	tokenManager, err := providerhost.NewEgressProxyTokenManager(stateSecret)
+	tokenManager, err := egressproxy.NewTokenManager(stateSecret)
 	if err != nil {
-		t.Fatalf("NewEgressProxyTokenManager: %v", err)
+		t.Fatalf("NewTokenManager: %v", err)
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := extractRuntimeProxyAuthorizationToken(r.Header.Get("Proxy-Authorization"))

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -45,6 +45,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/s3"
@@ -1710,11 +1711,11 @@ func buildHostedRuntimePublicEgressProxy(providerName, sessionID string, allowed
 	if err != nil {
 		return nil, err
 	}
-	tokenManager, err := providerhost.NewEgressProxyTokenManager(deps.EncryptionKey)
+	tokenManager, err := egressproxy.NewTokenManager(deps.EncryptionKey)
 	if err != nil {
 		return nil, fmt.Errorf("init egress proxy tokens: %w", err)
 	}
-	token, err := tokenManager.MintToken(providerhost.EgressProxyTokenRequest{
+	token, err := tokenManager.MintToken(egressproxy.TokenRequest{
 		PluginName:    providerName,
 		SessionID:     sessionID,
 		AllowedHosts:  slices.Clone(allowedHosts),

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -20,10 +20,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/s3"
@@ -125,7 +125,7 @@ type Server struct {
 	publicHostServices     *runtimehost.PublicHostServiceRegistry
 	s3                     map[string]s3store.Client
 	s3ObjectAccessURLs     *s3.ObjectAccessURLManager
-	egressProxyTokens      *providerhost.EgressProxyTokenManager
+	egressProxyTokens      *egressproxy.TokenManager
 	providerDevSessions    *providerdev.Manager
 	providerDevAttach      bool
 	mountedHTTPBindings    []MountedHTTPBinding
@@ -291,14 +291,14 @@ func New(cfg Config) (*Server, error) {
 		otelOptions = append(otelOptions, otelhttp.WithMeterProvider(cfg.MeterProvider))
 	}
 	var hostServiceRelayTokens *runtimehost.HostServiceRelayTokenManager
-	var egressProxyTokens *providerhost.EgressProxyTokenManager
+	var egressProxyTokens *egressproxy.TokenManager
 	var s3ObjectAccessURLs *s3.ObjectAccessURLManager
 	if len(cfg.StateSecret) > 0 {
 		hostServiceRelayTokens, err = runtimehost.NewHostServiceRelayTokenManager(cfg.StateSecret)
 		if err != nil {
 			return nil, fmt.Errorf("init host service relay tokens: %w", err)
 		}
-		egressProxyTokens, err = providerhost.NewEgressProxyTokenManager(cfg.StateSecret)
+		egressProxyTokens, err = egressproxy.NewTokenManager(cfg.StateSecret)
 		if err != nil {
 			return nil, fmt.Errorf("init egress proxy tokens: %w", err)
 		}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -63,6 +63,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"github.com/valon-technologies/gestalt/server/internal/ui"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	coreintegration "github.com/valon-technologies/gestalt/server/services/plugins/declarative"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
@@ -799,7 +800,7 @@ func TestEgressProxyProxiesHTTPRequest(t *testing.T) {
 	proxy.StartTLS()
 	testutil.CloseOnCleanup(t, proxy)
 
-	proxyURL := mustEgressProxyURL(t, proxy.URL, secret, providerhost.EgressProxyTokenRequest{
+	proxyURL := mustEgressProxyURL(t, proxy.URL, secret, egressproxy.TokenRequest{
 		PluginName:   "support",
 		SessionID:    "session-1",
 		AllowedHosts: []string{"127.0.0.1", "localhost"},
@@ -840,7 +841,7 @@ func TestEgressProxyRejectsDisallowedHost(t *testing.T) {
 	proxy.StartTLS()
 	testutil.CloseOnCleanup(t, proxy)
 
-	proxyURL := mustEgressProxyURL(t, proxy.URL, secret, providerhost.EgressProxyTokenRequest{
+	proxyURL := mustEgressProxyURL(t, proxy.URL, secret, egressproxy.TokenRequest{
 		PluginName:   "support",
 		SessionID:    "session-1",
 		AllowedHosts: []string{"api.github.com"},
@@ -886,7 +887,7 @@ func TestEgressProxySupportsHTTPSConnect(t *testing.T) {
 	proxy.StartTLS()
 	testutil.CloseOnCleanup(t, proxy)
 
-	proxyURL := mustEgressProxyURL(t, proxy.URL, secret, providerhost.EgressProxyTokenRequest{
+	proxyURL := mustEgressProxyURL(t, proxy.URL, secret, egressproxy.TokenRequest{
 		PluginName:   "support",
 		SessionID:    "session-1",
 		AllowedHosts: []string{"127.0.0.1", "localhost"},
@@ -959,11 +960,11 @@ func TestEgressProxyConnectForwardsBufferedClientBytes(t *testing.T) {
 	}))
 	testutil.CloseOnCleanup(t, proxy)
 
-	tokenManager, err := providerhost.NewEgressProxyTokenManager(secret)
+	tokenManager, err := egressproxy.NewTokenManager(secret)
 	if err != nil {
-		t.Fatalf("NewEgressProxyTokenManager: %v", err)
+		t.Fatalf("NewTokenManager: %v", err)
 	}
-	token, err := tokenManager.MintToken(providerhost.EgressProxyTokenRequest{
+	token, err := tokenManager.MintToken(egressproxy.TokenRequest{
 		PluginName:   "support",
 		SessionID:    "session-1",
 		AllowedHosts: []string{"127.0.0.1", "localhost"},
@@ -1036,12 +1037,12 @@ func newRelayGRPCConn(t *testing.T, ts *httptest.Server) *grpc.ClientConn {
 	return conn
 }
 
-func mustEgressProxyURL(t *testing.T, baseURL string, secret []byte, req providerhost.EgressProxyTokenRequest) *url.URL {
+func mustEgressProxyURL(t *testing.T, baseURL string, secret []byte, req egressproxy.TokenRequest) *url.URL {
 	t.Helper()
 
-	tokenManager, err := providerhost.NewEgressProxyTokenManager(secret)
+	tokenManager, err := egressproxy.NewTokenManager(secret)
 	if err != nil {
-		t.Fatalf("NewEgressProxyTokenManager: %v", err)
+		t.Fatalf("NewTokenManager: %v", err)
 	}
 	token, err := tokenManager.MintToken(req)
 	if err != nil {

--- a/gestaltd/services/egressproxy/tokens.go
+++ b/gestaltd/services/egressproxy/tokens.go
@@ -1,0 +1,12 @@
+// Package egressproxy exposes signed egress proxy token primitives.
+package egressproxy
+
+import "github.com/valon-technologies/gestalt/server/internal/providerhost"
+
+type TokenManager = providerhost.EgressProxyTokenManager
+type TokenRequest = providerhost.EgressProxyTokenRequest
+type Target = providerhost.EgressProxyTarget
+
+func NewTokenManager(secret []byte) (*TokenManager, error) {
+	return providerhost.NewEgressProxyTokenManager(secret)
+}


### PR DESCRIPTION
## Summary
- Add `gestaltd/services/egressproxy` as the service-facing boundary for signed egress proxy token primitives.
- Move server initialization, hosted-runtime egress proxy token minting, and related tests to use `egressproxy` rather than `internal/providerhost` for the token contract.
- Keep actual HTTP proxy handling in `internal/server` and token implementation behind the facade for this slice.

## Stack
- Based on `main`; #1575 has been merged.
- This PR is now a single squashable commit on top of `main`.

## New Interfaces
- `egressproxy.TokenManager` for minting and resolving egress proxy tokens.
- `egressproxy.TokenRequest` for allowed-host/default-action proxy grants.
- `egressproxy.Target` for resolved egress proxy authorization.

## Examples
```go
tokenManager, err := egressproxy.NewTokenManager(secret)
```

```go
token, err := tokenManager.MintToken(egressproxy.TokenRequest{
    PluginName: providerName,
    SessionID: sessionID,
    AllowedHosts: allowedHosts,
    DefaultAction: defaultAction,
})
```

```go
target, err := tokenManager.ResolveToken(token)
```

## Review Pass
- Reviewed with a separate GPT-5.5 xhigh agent. No findings.

## Tests
```sh
go test ./services/runtimehost ./services/s3 ./services/egressproxy ./internal/providerhost ./internal/pluginruntime ./internal/bootstrap ./internal/server/... ./internal/testutil/cachetransport ./internal/testutil/indexeddbtransport ./internal/testutil/s3transport ./internal/testutil/cmd/indexeddbtransportd
```