### PR TITLE
Stabilize plugin runtime race test startup

### DIFF
--- a/gestaltd/internal/pluginruntime/executable_test.go
+++ b/gestaltd/internal/pluginruntime/executable_test.go
@@ -19,7 +19,7 @@ func TestExecutableProviderIncludesPushedRuntimeLogsInStartupFailures(t *testing
 	t.Parallel()
 
 	services := coretesting.NewStubServices(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	runtimeBin := buildRuntimeLogProviderBinary(t)


### PR DESCRIPTION
The main push build after #1569 exposed a race-suite timeout in `internal/pluginruntime.TestExecutableProviderIncludesPushedRuntimeLogsInStartupFailures`. The test used a 30 second context while provider startup is allowed to wait up to 45 seconds, and the full `go test -race ./...` run on GitHub can be slower under load.

This widens that test context to two minutes while keeping the production startup timeout unchanged.

Validation:
- `go test -race ./internal/pluginruntime`