### PR TITLE
[codex] Add storage service boundaries

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -35,6 +35,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
@@ -1391,14 +1392,14 @@ func buildExternalCredentialsHostServices(name string, deps Deps) ([]runtimehost
 	}
 	hostServices := make([]runtimehost.HostService, 0, len(deps.IndexedDBs)+1)
 	if ds := deps.IndexedDBs[deps.SelectedIndexedDBName]; ds != nil {
-		hostServices = append(hostServices, externalCredentialsIndexedDBHostService(providerhost.DefaultIndexedDBSocketEnv, name, ds))
+		hostServices = append(hostServices, externalCredentialsIndexedDBHostService(indexeddbservice.DefaultSocketEnv, name, ds))
 	}
 	for _, indexedDBName := range slices.Sorted(maps.Keys(deps.IndexedDBs)) {
 		ds := deps.IndexedDBs[indexedDBName]
 		if ds == nil {
 			continue
 		}
-		hostServices = append(hostServices, externalCredentialsIndexedDBHostService(providerhost.IndexedDBSocketEnv(indexedDBName), name, ds))
+		hostServices = append(hostServices, externalCredentialsIndexedDBHostService(indexeddbservice.SocketEnv(indexedDBName), name, ds))
 	}
 	if len(hostServices) == 0 {
 		return nil, fmt.Errorf("indexeddb %q is not available", deps.SelectedIndexedDBName)
@@ -1411,7 +1412,7 @@ func externalCredentialsIndexedDBHostService(envVar, providerName string, ds ind
 		Name:   "indexeddb",
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, providerName, providerhost.IndexedDBServerOptions{
+			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, providerName, indexeddbservice.ServerOptions{
 				AllowedStores: []string{"external_credentials"},
 			}))
 		},
@@ -1579,7 +1580,7 @@ func buildHostIndexedDBHostServices(selectedName string, indexeddbs map[string]i
 
 	hostServices := make([]runtimehost.HostService, 0, len(indexeddbs)+1)
 	if selected := indexeddbs[selectedName]; strings.TrimSpace(selectedName) != "" && selected != nil {
-		hostServices = append(hostServices, indexedDBHostService(providerhost.DefaultIndexedDBSocketEnv, selectedName, selected))
+		hostServices = append(hostServices, indexedDBHostService(indexeddbservice.DefaultSocketEnv, selectedName, selected))
 	}
 
 	for _, name := range slices.Sorted(maps.Keys(indexeddbs)) {
@@ -1587,7 +1588,7 @@ func buildHostIndexedDBHostServices(selectedName string, indexeddbs map[string]i
 		if ds == nil {
 			continue
 		}
-		hostServices = append(hostServices, indexedDBHostService(providerhost.IndexedDBSocketEnv(name), name, ds))
+		hostServices = append(hostServices, indexedDBHostService(indexeddbservice.SocketEnv(name), name, ds))
 	}
 	return hostServices
 }
@@ -1597,7 +1598,7 @@ func indexedDBHostService(envVar, name string, ds indexeddb.IndexedDB) runtimeho
 		Name:   "indexeddb",
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, name, providerhost.IndexedDBServerOptions{}))
+			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, name, indexeddbservice.ServerOptions{}))
 		},
 	}
 }

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -3844,8 +3845,8 @@ func TestBootstrapPassesIndexedDBHostSocketToWorkflowProviders(t *testing.T) {
 	if got[0] != providerhost.DefaultWorkflowHostSocketEnv {
 		t.Fatalf("workflow host env = %q, want %q", got[0], providerhost.DefaultWorkflowHostSocketEnv)
 	}
-	if got[1] != providerhost.DefaultIndexedDBSocketEnv {
-		t.Fatalf("workflow indexeddb env = %q, want %q", got[1], providerhost.DefaultIndexedDBSocketEnv)
+	if got[1] != indexeddbservice.DefaultSocketEnv {
+		t.Fatalf("workflow indexeddb env = %q, want %q", got[1], indexeddbservice.DefaultSocketEnv)
 	}
 }
 
@@ -3892,8 +3893,8 @@ func TestBootstrapPassesIndexedDBHostSocketToAgentProviders(t *testing.T) {
 	if hostServices[0].EnvVar != providerhost.DefaultAgentHostSocketEnv {
 		t.Fatalf("agent host env = %q, want %q", hostServices[0].EnvVar, providerhost.DefaultAgentHostSocketEnv)
 	}
-	if hostServices[1].EnvVar != providerhost.DefaultIndexedDBSocketEnv {
-		t.Fatalf("agent indexeddb env = %q, want %q", hostServices[1].EnvVar, providerhost.DefaultIndexedDBSocketEnv)
+	if hostServices[1].EnvVar != indexeddbservice.DefaultSocketEnv {
+		t.Fatalf("agent indexeddb env = %q, want %q", hostServices[1].EnvVar, indexeddbservice.DefaultSocketEnv)
 	}
 
 	withIndexedDBHostClient(t, hostServices[1], func(client proto.IndexedDBClient) {
@@ -3976,12 +3977,12 @@ func TestBootstrapPassesIndexedDBHostSocketsToAuthorizationProviders(t *testing.
 	if len(hostServices) != 3 {
 		t.Fatalf("authorization host services = %d, want 3", len(hostServices))
 	}
-	if hostServices[0].EnvVar != providerhost.DefaultIndexedDBSocketEnv {
-		t.Fatalf("authorization default indexeddb env = %q, want %q", hostServices[0].EnvVar, providerhost.DefaultIndexedDBSocketEnv)
+	if hostServices[0].EnvVar != indexeddbservice.DefaultSocketEnv {
+		t.Fatalf("authorization default indexeddb env = %q, want %q", hostServices[0].EnvVar, indexeddbservice.DefaultSocketEnv)
 	}
 	wantNamed := []string{
-		providerhost.IndexedDBSocketEnv("archive"),
-		providerhost.IndexedDBSocketEnv("test"),
+		indexeddbservice.SocketEnv("archive"),
+		indexeddbservice.SocketEnv("test"),
 	}
 	for i, want := range wantNamed {
 		if got := hostServices[i+1].EnvVar; got != want {
@@ -4101,12 +4102,12 @@ func TestBootstrapRoutesExternalCredentialsIndexedDBHostServices(t *testing.T) {
 	if len(hostServices) != 3 {
 		t.Fatalf("external credentials host services = %d, want 3", len(hostServices))
 	}
-	if hostServices[0].EnvVar != providerhost.DefaultIndexedDBSocketEnv {
-		t.Fatalf("external credentials default indexeddb env = %q, want %q", hostServices[0].EnvVar, providerhost.DefaultIndexedDBSocketEnv)
+	if hostServices[0].EnvVar != indexeddbservice.DefaultSocketEnv {
+		t.Fatalf("external credentials default indexeddb env = %q, want %q", hostServices[0].EnvVar, indexeddbservice.DefaultSocketEnv)
 	}
 	wantNamed := []string{
-		providerhost.IndexedDBSocketEnv("archive"),
-		providerhost.IndexedDBSocketEnv("test"),
+		indexeddbservice.SocketEnv("archive"),
+		indexeddbservice.SocketEnv("test"),
 	}
 	for i, want := range wantNamed {
 		if got := hostServices[i+1].EnvVar; got != want {
@@ -4166,7 +4167,7 @@ func TestBootstrapRoutesWorkflowIndexedDBHostServices(t *testing.T) {
 
 	var indexedDBHost providerhost.HostService
 	for _, hostService := range hostEnv {
-		if hostService.EnvVar == providerhost.DefaultIndexedDBSocketEnv {
+		if hostService.EnvVar == indexeddbservice.DefaultSocketEnv {
 			indexedDBHost = hostService
 			break
 		}

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -51,9 +51,12 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
+	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	s3service "github.com/valon-technologies/gestalt/server/services/s3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -709,11 +712,11 @@ func (r *capturingBundlePluginRuntime) cleanupFakeHostedPlugin(sessionID string)
 }
 
 func fakeHostedIndexedDBRoundTrip(store, id, value, binding string, env map[string]string) (map[string]any, error) {
-	envName := providerhost.DefaultIndexedDBSocketEnv
-	tokenEnvName := providerhost.IndexedDBSocketTokenEnv("")
+	envName := indexeddbservice.DefaultSocketEnv
+	tokenEnvName := indexeddbservice.SocketTokenEnv("")
 	if strings.TrimSpace(binding) != "" {
-		envName = providerhost.IndexedDBSocketEnv(binding)
-		tokenEnvName = providerhost.IndexedDBSocketTokenEnv(binding)
+		envName = indexeddbservice.SocketEnv(binding)
+		tokenEnvName = indexeddbservice.SocketTokenEnv(binding)
 	}
 	target := strings.TrimSpace(env[envName])
 	if target == "" {
@@ -768,11 +771,11 @@ func fakeHostedIndexedDBRoundTrip(store, id, value, binding string, env map[stri
 }
 
 func fakeHostedCacheRoundTrip(key, value, binding string, env map[string]string) (map[string]any, error) {
-	envName := providerhost.DefaultCacheSocketEnv
-	tokenEnvName := providerhost.CacheSocketTokenEnv("")
+	envName := cacheservice.DefaultSocketEnv
+	tokenEnvName := cacheservice.SocketTokenEnv("")
 	if strings.TrimSpace(binding) != "" {
-		envName = providerhost.CacheSocketEnv(binding)
-		tokenEnvName = providerhost.CacheSocketTokenEnv(binding)
+		envName = cacheservice.SocketEnv(binding)
+		tokenEnvName = cacheservice.SocketTokenEnv(binding)
 	}
 	target := strings.TrimSpace(env[envName])
 	if target == "" {
@@ -849,11 +852,11 @@ func fakeHostedMakeHTTPRequest(targetURL string, env map[string]string) (map[str
 }
 
 func fakeHostedS3RoundTrip(bucket, key, value, binding string, env map[string]string) (map[string]any, error) {
-	envName := providerhost.DefaultS3SocketEnv
-	tokenEnvName := providerhost.S3SocketTokenEnv("")
+	envName := s3service.DefaultSocketEnv
+	tokenEnvName := s3service.SocketTokenEnv("")
 	if strings.TrimSpace(binding) != "" {
-		envName = providerhost.S3SocketEnv(binding)
-		tokenEnvName = providerhost.S3SocketTokenEnv(binding)
+		envName = s3service.SocketEnv(binding)
+		tokenEnvName = s3service.SocketTokenEnv(binding)
 	}
 	target := strings.TrimSpace(env[envName])
 	if target == "" {
@@ -3648,19 +3651,19 @@ func TestPluginIndexedDBExposeHostSocketEnv(t *testing.T) {
 		return env.Found && env.Value != ""
 	}
 
-	if got := checkEnv(t, nil, providerhost.DefaultIndexedDBSocketEnv); !got {
+	if got := checkEnv(t, nil, indexeddbservice.DefaultSocketEnv); !got {
 		t.Fatal("default IndexedDB env should be set when plugin omits indexeddb and inherits the host selection")
 	}
-	if got := checkEnv(t, &config.HostIndexedDBBindingConfig{}, providerhost.DefaultIndexedDBSocketEnv); !got {
+	if got := checkEnv(t, &config.HostIndexedDBBindingConfig{}, indexeddbservice.DefaultSocketEnv); !got {
 		t.Fatal("default IndexedDB env should be set when plugin indexeddb is explicitly empty")
 	}
-	if got := checkEnv(t, &config.HostIndexedDBBindingConfig{Provider: "archive"}, providerhost.DefaultIndexedDBSocketEnv); !got {
+	if got := checkEnv(t, &config.HostIndexedDBBindingConfig{Provider: "archive"}, indexeddbservice.DefaultSocketEnv); !got {
 		t.Fatal("default IndexedDB env should be set when plugin explicitly selects one indexeddb provider")
 	}
-	if got := checkEnv(t, nil, providerhost.IndexedDBSocketEnv("main")); got {
+	if got := checkEnv(t, nil, indexeddbservice.SocketEnv("main")); got {
 		t.Fatal("named IndexedDB env should not be set for inherited plugin indexeddb access")
 	}
-	if got := checkEnv(t, &config.HostIndexedDBBindingConfig{Provider: "archive"}, providerhost.IndexedDBSocketEnv("archive")); got {
+	if got := checkEnv(t, &config.HostIndexedDBBindingConfig{Provider: "archive"}, indexeddbservice.SocketEnv("archive")); got {
 		t.Fatal("named IndexedDB env should not be set when plugins expose a single indexeddb socket")
 	}
 }
@@ -5267,22 +5270,22 @@ func TestPluginCacheBindingsExposeHostSocketEnv(t *testing.T) {
 		return env.Found && env.Value != ""
 	}
 
-	if got := checkEnv(t, nil, providerhost.DefaultCacheSocketEnv); got {
+	if got := checkEnv(t, nil, cacheservice.DefaultSocketEnv); got {
 		t.Fatal("default cache env should not be set without plugin cache bindings")
 	}
-	if got := checkEnv(t, []string{"session"}, providerhost.DefaultCacheSocketEnv); !got {
+	if got := checkEnv(t, []string{"session"}, cacheservice.DefaultSocketEnv); !got {
 		t.Fatal("default cache env should be set with a single plugin cache binding")
 	}
-	if got := checkEnv(t, []string{"session"}, providerhost.CacheSocketEnv("session")); !got {
+	if got := checkEnv(t, []string{"session"}, cacheservice.SocketEnv("session")); !got {
 		t.Fatal("named cache env should be set with a single plugin cache binding")
 	}
-	if got := checkEnv(t, []string{"session", "rate_limit"}, providerhost.DefaultCacheSocketEnv); got {
+	if got := checkEnv(t, []string{"session", "rate_limit"}, cacheservice.DefaultSocketEnv); got {
 		t.Fatal("default cache env should not be set with multiple plugin cache bindings")
 	}
-	if got := checkEnv(t, []string{"session", "rate_limit"}, providerhost.CacheSocketEnv("session")); !got {
+	if got := checkEnv(t, []string{"session", "rate_limit"}, cacheservice.SocketEnv("session")); !got {
 		t.Fatal(`named cache env for "session" should be set with multiple plugin cache bindings`)
 	}
-	if got := checkEnv(t, []string{"session", "rate_limit"}, providerhost.CacheSocketEnv("rate_limit")); !got {
+	if got := checkEnv(t, []string{"session", "rate_limit"}, cacheservice.SocketEnv("rate_limit")); !got {
 		t.Fatal(`named cache env for "rate_limit" should be set with multiple plugin cache bindings`)
 	}
 }
@@ -5928,21 +5931,21 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 		return env.Value, env.Found
 	}
 
-	if got, found := checkEnv(providerhost.DefaultS3SocketEnv); !found || got != "tls://gestalt.example.test:443" {
-		t.Fatalf("plugin s3 env %s = (%q, %v), want (%q, true)", providerhost.DefaultS3SocketEnv, got, found, "tls://gestalt.example.test:443")
+	if got, found := checkEnv(s3service.DefaultSocketEnv); !found || got != "tls://gestalt.example.test:443" {
+		t.Fatalf("plugin s3 env %s = (%q, %v), want (%q, true)", s3service.DefaultSocketEnv, got, found, "tls://gestalt.example.test:443")
 	}
 	for _, binding := range []string{"main"} {
-		envName := providerhost.S3SocketEnv(binding)
+		envName := s3service.SocketEnv(binding)
 		if got, found := checkEnv(envName); !found || got != "tls://gestalt.example.test:443" {
 			t.Fatalf("plugin s3 env %s = (%q, %v), want (%q, true)", envName, got, found, "tls://gestalt.example.test:443")
 		}
-		tokenEnvName := providerhost.S3SocketTokenEnv(binding)
+		tokenEnvName := s3service.SocketTokenEnv(binding)
 		if got, found := checkEnv(tokenEnvName); !found || got == "" {
 			t.Fatalf("plugin s3 token env %s = (%q, %v), want non-empty token", tokenEnvName, got, found)
 		}
 	}
-	if got, found := checkEnv(providerhost.S3SocketTokenEnv("")); !found || got == "" {
-		t.Fatalf("plugin s3 token env %s = (%q, %v), want non-empty token", providerhost.S3SocketTokenEnv(""), got, found)
+	if got, found := checkEnv(s3service.SocketTokenEnv("")); !found || got == "" {
+		t.Fatalf("plugin s3 token env %s = (%q, %v), want non-empty token", s3service.SocketTokenEnv(""), got, found)
 	}
 
 	bindRequests := runtimeProvider.bindHostServiceRequests()
@@ -5960,8 +5963,8 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
 	for _, binding := range []string{"", "main"} {
-		if got := startRequests[0].Env[providerhost.S3SocketTokenEnv(binding)]; got == "" {
-			t.Fatalf("StartPlugin env should include s3 relay token %s", providerhost.S3SocketTokenEnv(binding))
+		if got := startRequests[0].Env[s3service.SocketTokenEnv(binding)]; got == "" {
+			t.Fatalf("StartPlugin env should include s3 relay token %s", s3service.SocketTokenEnv(binding))
 		}
 	}
 	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
@@ -6000,11 +6003,11 @@ func TestProviderDevRuntimeEnvUsesPublicHostServiceRelay(t *testing.T) {
 	})
 
 	for _, binding := range []string{"", "main"} {
-		socketEnv := providerhost.S3SocketEnv(binding)
+		socketEnv := s3service.SocketEnv(binding)
 		if got := env.Env[socketEnv]; !strings.HasPrefix(got, "tls://") {
 			t.Fatalf("runtime env %s = %q, want tls relay target", socketEnv, got)
 		}
-		tokenEnv := providerhost.S3SocketTokenEnv(binding)
+		tokenEnv := s3service.SocketTokenEnv(binding)
 		if got := env.Env[tokenEnv]; got == "" {
 			t.Fatalf("runtime env %s is empty, want relay token", tokenEnv)
 		}
@@ -6262,10 +6265,10 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 		return env.Value
 	}
 
-	if got := checkEnv(providerhost.DefaultIndexedDBSocketEnv); got != "tls://gestalt.example.test:443" {
+	if got := checkEnv(indexeddbservice.DefaultSocketEnv); got != "tls://gestalt.example.test:443" {
 		t.Fatalf("plugin indexeddb socket env = %q, want %q", got, "tls://gestalt.example.test:443")
 	}
-	if got := checkEnv(providerhost.IndexedDBSocketTokenEnv("")); got == "" {
+	if got := checkEnv(indexeddbservice.SocketTokenEnv("")); got == "" {
 		t.Fatal("plugin indexeddb socket token env should be set for the public relay")
 	}
 
@@ -6281,7 +6284,7 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.IndexedDBSocketTokenEnv("")]; got == "" {
+	if got := startRequests[0].Env[indexeddbservice.SocketTokenEnv("")]; got == "" {
 		t.Fatal("StartPlugin env should include the IndexedDB relay token")
 	}
 	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
@@ -6403,7 +6406,7 @@ func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testi
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.IndexedDBSocketTokenEnv("")]; got == "" {
+	if got := startRequests[0].Env[indexeddbservice.SocketTokenEnv("")]; got == "" {
 		t.Fatal("StartPlugin env should include the IndexedDB relay token")
 	}
 	bindRequests := runtimeProvider.bindHostServiceRequests()
@@ -6509,15 +6512,15 @@ func TestPluginRuntimeConfigUsesPublicCacheRelayWithoutHostServiceTunnelCapabili
 		return env.Value, env.Found
 	}
 
-	if _, found := checkEnv(providerhost.DefaultCacheSocketEnv); found {
-		t.Fatalf("env %s should not be set with multiple cache bindings", providerhost.DefaultCacheSocketEnv)
+	if _, found := checkEnv(cacheservice.DefaultSocketEnv); found {
+		t.Fatalf("env %s should not be set with multiple cache bindings", cacheservice.DefaultSocketEnv)
 	}
 	for _, binding := range []string{"session", "rate_limit"} {
-		envName := providerhost.CacheSocketEnv(binding)
+		envName := cacheservice.SocketEnv(binding)
 		if got, found := checkEnv(envName); !found || got != "tls://gestalt.example.test:443" {
 			t.Fatalf("plugin cache env %s = (%q, %v), want (%q, true)", envName, got, found, "tls://gestalt.example.test:443")
 		}
-		tokenEnvName := providerhost.CacheSocketTokenEnv(binding)
+		tokenEnvName := cacheservice.SocketTokenEnv(binding)
 		if got, found := checkEnv(tokenEnvName); !found || got == "" {
 			t.Fatalf("plugin cache token env %s = (%q, %v), want non-empty token", tokenEnvName, got, found)
 		}
@@ -6538,8 +6541,8 @@ func TestPluginRuntimeConfigUsesPublicCacheRelayWithoutHostServiceTunnelCapabili
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
 	for _, binding := range []string{"session", "rate_limit"} {
-		if got := startRequests[0].Env[providerhost.CacheSocketTokenEnv(binding)]; got == "" {
-			t.Fatalf("StartPlugin env should include cache relay token %s", providerhost.CacheSocketTokenEnv(binding))
+		if got := startRequests[0].Env[cacheservice.SocketTokenEnv(binding)]; got == "" {
+			t.Fatalf("StartPlugin env should include cache relay token %s", cacheservice.SocketTokenEnv(binding))
 		}
 	}
 	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
@@ -6661,7 +6664,7 @@ func TestPluginRuntimePublicCacheRelayRoundTripsThroughHostedPlugin(t *testing.T
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.CacheSocketTokenEnv("")]; got == "" {
+	if got := startRequests[0].Env[cacheservice.SocketTokenEnv("")]; got == "" {
 		t.Fatal("StartPlugin env should include the cache relay token")
 	}
 	bindRequests := runtimeProvider.bindHostServiceRequests()
@@ -6803,10 +6806,10 @@ func TestPluginRuntimePublicS3RelayRoundTripsThroughHostedPlugin(t *testing.T) {
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.S3SocketTokenEnv("")]; got == "" {
+	if got := startRequests[0].Env[s3service.SocketTokenEnv("")]; got == "" {
 		t.Fatal("StartPlugin env should include the default s3 relay token")
 	}
-	if got := startRequests[0].Env[providerhost.S3SocketTokenEnv("main")]; got == "" {
+	if got := startRequests[0].Env[s3service.SocketTokenEnv("main")]; got == "" {
 		t.Fatal("StartPlugin env should include the named s3 relay token")
 	}
 	bindRequests := runtimeProvider.bindHostServiceRequests()
@@ -7986,7 +7989,7 @@ func TestPluginRuntimeConfigUsesDirectHostServiceBindingsAndSkipsPublicEgressPro
 	if got := startRequests[0].Env["HTTPS_PROXY"]; got != "" {
 		t.Fatalf("StartPlugin HTTPS_PROXY = %q, want empty when direct host service bindings are available", got)
 	}
-	if got := startRequests[0].Env[providerhost.CacheSocketTokenEnv("session")]; got != "" {
+	if got := startRequests[0].Env[cacheservice.SocketTokenEnv("session")]; got != "" {
 		t.Fatalf("StartPlugin cache token env = %q, want empty for direct host service bindings", got)
 	}
 	assertStartPluginEgressPolicy(t, startRequests[0], []string{"api.github.com"}, pluginruntime.PolicyDeny)
@@ -8303,7 +8306,7 @@ func TestPluginIndexedDBInheritsHostSelectionAndDefaultDBName(t *testing.T) {
 					t.Fatalf("inherited host indexeddb should use plugin-name default db prefix: %v", err)
 				}
 				if runtimeProvider != nil {
-					assertHostServiceRelayBindings(t, runtimeProvider.bindHostServiceRequests(), providerhost.DefaultIndexedDBSocketEnv)
+					assertHostServiceRelayBindings(t, runtimeProvider.bindHostServiceRequests(), indexeddbservice.DefaultSocketEnv)
 				}
 			})
 		}
@@ -8576,7 +8579,7 @@ func TestPluginIndexedDBRouteObjectStoresAndTransportPrefix(t *testing.T) {
 				t.Fatal("indexeddb_roundtrip on disallowed object store should fail")
 			}
 			if runtimeProvider != nil {
-				assertHostServiceRelayBindings(t, runtimeProvider.bindHostServiceRequests(), providerhost.DefaultIndexedDBSocketEnv)
+				assertHostServiceRelayBindings(t, runtimeProvider.bindHostServiceRequests(), indexeddbservice.DefaultSocketEnv)
 			}
 
 			_ = CloseProviders(providers)
@@ -9067,22 +9070,22 @@ func TestPluginS3BindingsExposeHostSocketEnv(t *testing.T) {
 		return env.Found && env.Value != ""
 	}
 
-	if got := checkEnv(t, nil, providerhost.DefaultS3SocketEnv); got {
+	if got := checkEnv(t, nil, s3service.DefaultSocketEnv); got {
 		t.Fatal("default S3 env should not be set without plugin s3 bindings")
 	}
-	if got := checkEnv(t, []string{"main"}, providerhost.DefaultS3SocketEnv); !got {
+	if got := checkEnv(t, []string{"main"}, s3service.DefaultSocketEnv); !got {
 		t.Fatal("default S3 env should be set with a single plugin s3 binding")
 	}
-	if got := checkEnv(t, []string{"main"}, providerhost.S3SocketEnv("main")); !got {
+	if got := checkEnv(t, []string{"main"}, s3service.SocketEnv("main")); !got {
 		t.Fatal("named S3 env should be set with a single plugin s3 binding")
 	}
-	if got := checkEnv(t, []string{"main", "archive"}, providerhost.DefaultS3SocketEnv); got {
+	if got := checkEnv(t, []string{"main", "archive"}, s3service.DefaultSocketEnv); got {
 		t.Fatal("default S3 env should not be set with multiple plugin s3 bindings")
 	}
-	if got := checkEnv(t, []string{"main", "archive"}, providerhost.S3SocketEnv("main")); !got {
+	if got := checkEnv(t, []string{"main", "archive"}, s3service.SocketEnv("main")); !got {
 		t.Fatal(`named S3 env for "main" should be set with multiple plugin s3 bindings`)
 	}
-	if got := checkEnv(t, []string{"main", "archive"}, providerhost.S3SocketEnv("archive")); !got {
+	if got := checkEnv(t, []string{"main", "archive"}, s3service.SocketEnv("archive")); !got {
 		t.Fatal(`named S3 env for "archive" should be set with multiple plugin s3 bindings`)
 	}
 }

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
@@ -1040,13 +1041,13 @@ func fakeHostedWorkflowManagerRoundTrip(invocationToken string, env map[string]s
 }
 
 func fakeHostedAuthorizationRoundTrip(env map[string]string) (map[string]any, error) {
-	target := strings.TrimSpace(env[providerhost.DefaultAuthorizationSocketEnv])
+	target := strings.TrimSpace(env[authorizationservice.DefaultSocketEnv])
 	if target == "" {
-		return nil, fmt.Errorf("missing authorization relay target in %s", providerhost.DefaultAuthorizationSocketEnv)
+		return nil, fmt.Errorf("missing authorization relay target in %s", authorizationservice.DefaultSocketEnv)
 	}
-	token := strings.TrimSpace(env[providerhost.AuthorizationSocketTokenEnv()])
+	token := strings.TrimSpace(env[authorizationservice.SocketTokenEnv()])
 	if token == "" {
-		return nil, fmt.Errorf("missing authorization relay token in %s", providerhost.AuthorizationSocketTokenEnv())
+		return nil, fmt.Errorf("missing authorization relay token in %s", authorizationservice.SocketTokenEnv())
 	}
 	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
 	if address == "" || address == target {
@@ -4095,7 +4096,7 @@ func TestPluginHostedHTTPBindingsExposeAuthorizationSocketEnv(t *testing.T) {
 		t.Fatalf("providers.Get(echo): %v", err)
 	}
 
-	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": providerhost.DefaultAuthorizationSocketEnv}, "")
+	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": authorizationservice.DefaultSocketEnv}, "")
 	if err != nil {
 		t.Fatalf("Execute read_env: %v", err)
 	}
@@ -4108,7 +4109,7 @@ func TestPluginHostedHTTPBindingsExposeAuthorizationSocketEnv(t *testing.T) {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
 	if !env.Found || env.Value == "" {
-		t.Fatalf("authorization env %q should be set for executable plugins with hosted HTTP bindings", providerhost.DefaultAuthorizationSocketEnv)
+		t.Fatalf("authorization env %q should be set for executable plugins with hosted HTTP bindings", authorizationservice.DefaultSocketEnv)
 	}
 }
 
@@ -6148,19 +6149,19 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 		return env.Value, env.Found
 	}
 
-	if got, found := checkEnv(providerhost.DefaultAuthorizationSocketEnv); !found || got != "tls://gestalt.example.test:443" {
-		t.Fatalf("plugin authorization env %s = (%q, %v), want (%q, true)", providerhost.DefaultAuthorizationSocketEnv, got, found, "tls://gestalt.example.test:443")
+	if got, found := checkEnv(authorizationservice.DefaultSocketEnv); !found || got != "tls://gestalt.example.test:443" {
+		t.Fatalf("plugin authorization env %s = (%q, %v), want (%q, true)", authorizationservice.DefaultSocketEnv, got, found, "tls://gestalt.example.test:443")
 	}
-	if got, found := checkEnv(providerhost.AuthorizationSocketTokenEnv()); !found || got == "" {
-		t.Fatalf("plugin authorization token env %s = (%q, %v), want non-empty token", providerhost.AuthorizationSocketTokenEnv(), got, found)
+	if got, found := checkEnv(authorizationservice.SocketTokenEnv()); !found || got == "" {
+		t.Fatalf("plugin authorization token env %s = (%q, %v), want non-empty token", authorizationservice.SocketTokenEnv(), got, found)
 	}
 
 	bindRequests := runtimeProvider.bindHostServiceRequests()
 	if len(bindRequests) != 1 {
 		t.Fatalf("BindHostService requests = %d, want 1", len(bindRequests))
 	}
-	if bindRequests[0].EnvVar != providerhost.DefaultAuthorizationSocketEnv {
-		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, providerhost.DefaultAuthorizationSocketEnv)
+	if bindRequests[0].EnvVar != authorizationservice.DefaultSocketEnv {
+		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, authorizationservice.DefaultSocketEnv)
 	}
 	if got := bindRequests[0].Relay.DialTarget; got != "tls://gestalt.example.test:443" {
 		t.Fatalf("BindHostService(%s) relay target = %q, want %q", bindRequests[0].EnvVar, got, "tls://gestalt.example.test:443")
@@ -6170,7 +6171,7 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.AuthorizationSocketTokenEnv()]; got == "" {
+	if got := startRequests[0].Env[authorizationservice.SocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the authorization relay token")
 	}
 	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
@@ -7755,7 +7756,7 @@ func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *t
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.AuthorizationSocketTokenEnv()]; got == "" {
+	if got := startRequests[0].Env[authorizationservice.SocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the authorization relay token")
 	}
 	bindRequests := runtimeProvider.bindHostServiceRequests()

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -45,7 +45,9 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
+	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/s3"
@@ -1802,17 +1804,17 @@ func pluginRuntimePublicProxyBaseURL(baseURL string) (*url.URL, string, error) {
 
 func isIndexedDBHostServiceEnv(envVar string) bool {
 	envVar = strings.TrimSpace(envVar)
-	return envVar == providerhost.DefaultIndexedDBSocketEnv || strings.HasPrefix(envVar, providerhost.DefaultIndexedDBSocketEnv+"_")
+	return envVar == indexeddbservice.DefaultSocketEnv || strings.HasPrefix(envVar, indexeddbservice.DefaultSocketEnv+"_")
 }
 
 func isCacheHostServiceEnv(envVar string) bool {
 	envVar = strings.TrimSpace(envVar)
-	return envVar == providerhost.DefaultCacheSocketEnv || strings.HasPrefix(envVar, providerhost.DefaultCacheSocketEnv+"_")
+	return envVar == cacheservice.DefaultSocketEnv || strings.HasPrefix(envVar, cacheservice.DefaultSocketEnv+"_")
 }
 
 func isS3HostServiceEnv(envVar string) bool {
 	envVar = strings.TrimSpace(envVar)
-	return envVar == providerhost.DefaultS3SocketEnv || strings.HasPrefix(envVar, providerhost.DefaultS3SocketEnv+"_")
+	return envVar == s3.DefaultSocketEnv || strings.HasPrefix(envVar, s3.DefaultSocketEnv+"_")
 }
 
 func appendAllowedHost(allowedHosts []string, host string) []string {
@@ -1871,9 +1873,9 @@ func buildPluginIndexedDBHostServices(pluginName string, effective config.Effect
 
 	hostServices := []runtimehost.HostService{{
 		Name:   "indexeddb",
-		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
+		EnvVar: indexeddbservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, pluginName, providerhost.IndexedDBServerOptions{
+			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, pluginName, indexeddbservice.ServerOptions{
 				AllowedStores: effective.ObjectStores,
 			}))
 		},
@@ -1904,10 +1906,10 @@ func buildPluginCacheHostServices(pluginName string, entry *config.ProviderEntry
 		boundCaches = append(boundCaches, value)
 		hostServices = append(hostServices, runtimehost.HostService{
 			Name:   "cache",
-			EnvVar: providerhost.CacheSocketEnv(bindingName),
+			EnvVar: cacheservice.SocketEnv(bindingName),
 			Register: func(cacheValue corecache.Cache) func(*grpc.Server) {
 				return func(srv *grpc.Server) {
-					proto.RegisterCacheServer(srv, providerhost.NewCacheServer(cacheValue, pluginName))
+					proto.RegisterCacheServer(srv, cacheservice.NewServer(cacheValue, pluginName))
 				}
 			}(value),
 		})
@@ -1916,9 +1918,9 @@ func buildPluginCacheHostServices(pluginName string, entry *config.ProviderEntry
 		value := boundCaches[0]
 		hostServices = append(hostServices, runtimehost.HostService{
 			Name:   "cache",
-			EnvVar: providerhost.DefaultCacheSocketEnv,
+			EnvVar: cacheservice.DefaultSocketEnv,
 			Register: func(srv *grpc.Server) {
-				proto.RegisterCacheServer(srv, providerhost.NewCacheServer(value, pluginName))
+				proto.RegisterCacheServer(srv, cacheservice.NewServer(value, pluginName))
 			},
 		})
 	}
@@ -1949,10 +1951,10 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 		}
 		hostServices = append(hostServices, runtimehost.HostService{
 			Name:   "s3",
-			EnvVar: providerhost.S3SocketEnv(binding),
+			EnvVar: s3.SocketEnv(binding),
 			Register: func(client s3store.Client, binding string) func(*grpc.Server) {
 				return func(srv *grpc.Server) {
-					proto.RegisterS3Server(srv, providerhost.NewS3ServerWithOptions(client, pluginName, providerhost.S3ServerOptions{
+					proto.RegisterS3Server(srv, s3.NewServerWithOptions(client, pluginName, s3.ServerOptions{
 						BindingName: binding,
 						AccessURLs:  accessURLs,
 					}))
@@ -1966,9 +1968,9 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 		client := deps.S3[binding]
 		hostServices = append(hostServices, runtimehost.HostService{
 			Name:   "s3",
-			EnvVar: providerhost.DefaultS3SocketEnv,
+			EnvVar: s3.DefaultSocketEnv,
 			Register: func(srv *grpc.Server) {
-				proto.RegisterS3Server(srv, providerhost.NewS3ServerWithOptions(client, pluginName, providerhost.S3ServerOptions{
+				proto.RegisterS3Server(srv, s3.NewServerWithOptions(client, pluginName, s3.ServerOptions{
 					BindingName: binding,
 					AccessURLs:  accessURLs,
 				}))
@@ -1991,9 +1993,9 @@ func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveH
 
 	hostServices := []runtimehost.HostService{{
 		Name:   "indexeddb",
-		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
+		EnvVar: indexeddbservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, name, providerhost.IndexedDBServerOptions{
+			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, name, indexeddbservice.ServerOptions{
 				AllowedStores: effective.ObjectStores,
 			}))
 		},
@@ -2015,9 +2017,9 @@ func buildAgentIndexedDBHostServices(name string, effective config.EffectiveHost
 
 	hostServices := []runtimehost.HostService{{
 		Name:   "indexeddb",
-		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
+		EnvVar: indexeddbservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, name, providerhost.IndexedDBServerOptions{
+			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, name, indexeddbservice.ServerOptions{
 				AllowedStores: effective.ObjectStores,
 			}))
 		},

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -45,6 +45,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
@@ -1615,7 +1616,7 @@ func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostSe
 			serviceKey = "agent_manager"
 			serviceLabel = "agent manager"
 			methodPrefix = "/" + proto.AgentManagerHost_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == providerhost.DefaultAuthorizationSocketEnv:
+		case hostService.EnvVar == authorizationservice.DefaultSocketEnv:
 			serviceKey = "authorization"
 			serviceLabel = "authorization"
 			methodPrefix = "/" + proto.AuthorizationProvider_ServiceDesc.ServiceName + "/"
@@ -2060,9 +2061,9 @@ func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *pr
 func buildPluginAuthorizationHostService(provider core.AuthorizationProvider) runtimehost.HostService {
 	return runtimehost.HostService{
 		Name:   "authorization",
-		EnvVar: providerhost.DefaultAuthorizationSocketEnv,
+		EnvVar: authorizationservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterAuthorizationProviderServer(srv, providerhost.NewAuthorizationProviderServer(provider))
+			proto.RegisterAuthorizationProviderServer(srv, authorizationservice.NewProviderServer(provider))
 		},
 	}
 }

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -32,6 +32,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/fakebun"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	authenticationservice "github.com/valon-technologies/gestalt/server/services/authentication"
+	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
+	externalcredentialsservice "github.com/valon-technologies/gestalt/server/services/externalcredentials"
+	secretsservice "github.com/valon-technologies/gestalt/server/services/secrets"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
@@ -1146,14 +1150,14 @@ func TestRun_ProviderReleaseBuildsGoSourceAuthPlugin(t *testing.T) {
 		t.Fatalf("release metadata auth artifact = %+v, want path %q sha %q", authArtifact, archiveName, authDigest)
 	}
 
-	auth, err := providerhost.NewExecutableAuthenticationProvider(context.Background(), providerhost.AuthenticationExecConfig{
+	auth, err := authenticationservice.NewExecutable(context.Background(), authenticationservice.ExecConfig{
 		Command:     filepath.Join(extractDir, binaryName),
 		Name:        "auth-release",
 		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
 		SessionKey:  []byte("0123456789abcdef0123456789abcdef"),
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableAuthenticationProvider: %v", err)
+		t.Fatalf("authenticationservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := auth.(interface{ Close() error }); ok {
@@ -1261,12 +1265,12 @@ func TestRun_ProviderReleaseBuildsGoSourceAuthorizationProvider(t *testing.T) {
 		t.Fatalf("release metadata runtime = %q, want %q", metadata.Runtime, providerReleaseRuntimeKindExecutable)
 	}
 
-	authz, err := providerhost.NewExecutableAuthorizationProvider(context.Background(), providerhost.AuthorizationExecConfig{
+	authz, err := authorizationservice.NewExecutable(context.Background(), authorizationservice.ExecConfig{
 		Command: filepath.Join(extractDir, binaryName),
 		Name:    "authorization-release",
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableAuthorizationProvider: %v", err)
+		t.Fatalf("authorizationservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := authz.(interface{ Close() error }); ok {
@@ -1350,12 +1354,12 @@ func TestRun_ProviderReleaseBuildsGoSourceSecretsPlugin(t *testing.T) {
 		t.Fatalf("expected %s in archive: %v", secretsReleaseSchemaPath, err)
 	}
 
-	sm, err := providerhost.NewExecutableSecretManager(context.Background(), providerhost.SecretsExecConfig{
+	sm, err := secretsservice.NewExecutable(context.Background(), secretsservice.ExecConfig{
 		Command: filepath.Join(extractDir, binaryName),
 		Name:    secretsReleasePluginName,
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableSecretManager: %v", err)
+		t.Fatalf("secretsservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := sm.(interface{ Close() error }); ok {
@@ -1487,19 +1491,19 @@ func TestRun_ProviderReleaseBuildsGoSourceExternalCredentialsPlugin(t *testing.T
 	}
 	coretesting.AttachStubExternalCredentials(services)
 
-	provider, err := providerhost.NewExecutableExternalCredentialProvider(context.Background(), providerhost.ExternalCredentialsExecConfig{
+	provider, err := externalcredentialsservice.NewExecutable(context.Background(), externalcredentialsservice.ExecConfig{
 		Command: filepath.Join(extractDir, binaryName),
 		Name:    externalCredentialReleasePluginName,
 		HostServices: []providerhost.HostService{{
 			Name:   "external-credentials",
-			EnvVar: providerhost.DefaultExternalCredentialSocketEnv,
+			EnvVar: externalcredentialsservice.DefaultSocketEnv,
 			Register: func(srv *grpc.Server) {
-				proto.RegisterExternalCredentialProviderServer(srv, providerhost.NewExternalCredentialProviderServer(services.ExternalCredentials))
+				proto.RegisterExternalCredentialProviderServer(srv, externalcredentialsservice.NewProviderServer(services.ExternalCredentials))
 			},
 		}},
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableExternalCredentialProvider: %v", err)
+		t.Fatalf("externalcredentialsservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := provider.(interface{ Close() error }); ok {
@@ -2996,14 +3000,14 @@ func assertArtifactPlatform(t *testing.T, artifact providermanifestv1.Artifact, 
 func assertExecutableAuthProviderWorks(t *testing.T, command, providerName string, assertSessionTTL, assertExternalJWT bool) {
 	t.Helper()
 
-	auth, err := providerhost.NewExecutableAuthenticationProvider(context.Background(), providerhost.AuthenticationExecConfig{
+	auth, err := authenticationservice.NewExecutable(context.Background(), authenticationservice.ExecConfig{
 		Command:     command,
 		Name:        providerName,
 		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
 		SessionKey:  []byte("0123456789abcdef0123456789abcdef"),
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableAuthenticationProvider: %v", err)
+		t.Fatalf("authenticationservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := auth.(interface{ Close() error }); ok {

--- a/gestaltd/internal/drivers/auth/provider/factory.go
+++ b/gestaltd/internal/drivers/auth/provider/factory.go
@@ -8,8 +8,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	authenticationservice "github.com/valon-technologies/gestalt/server/services/authentication"
 	"gopkg.in/yaml.v3"
 )
 
@@ -38,7 +38,7 @@ var Factory bootstrap.AuthFactory = func(node yaml.Node, deps bootstrap.Deps) (c
 	if callbackURL == "" && deps.BaseURL != "" {
 		callbackURL = deps.BaseURL + config.AuthCallbackPath
 	}
-	return providerhost.NewExecutableAuthenticationProvider(context.Background(), providerhost.AuthenticationExecConfig{
+	return authenticationservice.NewExecutable(context.Background(), authenticationservice.ExecConfig{
 		Command:     cfg.Command,
 		Args:        cfg.Args,
 		Env:         cfg.Env,

--- a/gestaltd/internal/drivers/authorization/provider/factory.go
+++ b/gestaltd/internal/drivers/authorization/provider/factory.go
@@ -7,8 +7,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
@@ -29,7 +29,7 @@ var Factory bootstrap.AuthorizationFactory = func(node yaml.Node, hostServices [
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableAuthorizationProvider(context.Background(), providerhost.AuthorizationExecConfig{
+	return authorizationservice.NewExecutable(context.Background(), authorizationservice.ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,

--- a/gestaltd/internal/drivers/cache/provider/factory.go
+++ b/gestaltd/internal/drivers/cache/provider/factory.go
@@ -7,8 +7,8 @@ import (
 	corecache "github.com/valon-technologies/gestalt/server/core/cache"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"gopkg.in/yaml.v3"
 )
 
@@ -28,7 +28,7 @@ var Factory bootstrap.CacheFactory = func(node yaml.Node) (corecache.Cache, erro
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableCache(context.Background(), providerhost.CacheExecConfig{
+	return cacheservice.NewExecutable(context.Background(), cacheservice.ExecConfig{
 		Command:    cfg.Command,
 		Args:       cfg.Args,
 		Env:        cfg.Env,

--- a/gestaltd/internal/drivers/externalcredentials/provider/factory.go
+++ b/gestaltd/internal/drivers/externalcredentials/provider/factory.go
@@ -7,8 +7,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	externalcredentialsservice "github.com/valon-technologies/gestalt/server/services/externalcredentials"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
@@ -29,7 +29,7 @@ var Factory bootstrap.ExternalCredentialFactory = func(ctx context.Context, name
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableExternalCredentialProvider(ctx, providerhost.ExternalCredentialsExecConfig{
+	return externalcredentialsservice.NewExecutable(ctx, externalcredentialsservice.ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,

--- a/gestaltd/internal/drivers/indexeddb/provider/factory.go
+++ b/gestaltd/internal/drivers/indexeddb/provider/factory.go
@@ -7,8 +7,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"gopkg.in/yaml.v3"
 )
 
@@ -28,7 +28,7 @@ var Factory bootstrap.IndexedDBFactory = func(node yaml.Node) (indexeddb.Indexed
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableIndexedDB(context.Background(), providerhost.IndexedDBExecConfig{
+	return indexeddbservice.NewExecutable(context.Background(), indexeddbservice.ExecConfig{
 		Command:    cfg.Command,
 		Args:       cfg.Args,
 		Env:        cfg.Env,

--- a/gestaltd/internal/drivers/s3/provider/factory.go
+++ b/gestaltd/internal/drivers/s3/provider/factory.go
@@ -7,8 +7,8 @@ import (
 	s3store "github.com/valon-technologies/gestalt/server/core/s3"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	s3service "github.com/valon-technologies/gestalt/server/services/s3"
 	"gopkg.in/yaml.v3"
 )
 
@@ -28,7 +28,7 @@ var Factory bootstrap.S3Factory = func(node yaml.Node) (s3store.Client, error) {
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableS3(context.Background(), providerhost.S3ExecConfig{
+	return s3service.NewExecutable(context.Background(), s3service.ExecConfig{
 		Command:    cfg.Command,
 		Args:       cfg.Args,
 		Env:        cfg.Env,

--- a/gestaltd/internal/drivers/secrets/provider/factory.go
+++ b/gestaltd/internal/drivers/secrets/provider/factory.go
@@ -7,8 +7,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	secretsservice "github.com/valon-technologies/gestalt/server/services/secrets"
 	"gopkg.in/yaml.v3"
 )
 
@@ -28,7 +28,7 @@ var Factory bootstrap.SecretManagerFactory = func(node yaml.Node) (core.SecretMa
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableSecretManager(context.Background(), providerhost.SecretsExecConfig{
+	return secretsservice.NewExecutable(context.Background(), secretsservice.ExecConfig{
 		Command:    cfg.Command,
 		Args:       cfg.Args,
 		Env:        cfg.Env,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -64,6 +64,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/ui"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
+	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	coreintegration "github.com/valon-technologies/gestalt/server/services/plugins/declarative"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
@@ -717,9 +718,9 @@ func TestHostServiceRelaySupportsIndexedDBSDKClient(t *testing.T) {
 	publicHostServices := providerhost.NewPublicHostServiceRegistry()
 	publicHostServices.Register("relay-plugin", providerhost.HostService{
 		Name:   "indexeddb",
-		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
+		EnvVar: indexeddbservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(stubDB, "relay-plugin", providerhost.IndexedDBServerOptions{
+			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(stubDB, "relay-plugin", indexeddbservice.ServerOptions{
 				AllowedStores: []string{"tasks"},
 			}))
 		},
@@ -742,7 +743,7 @@ func TestHostServiceRelaySupportsIndexedDBSDKClient(t *testing.T) {
 		PluginName:   "relay-plugin",
 		SessionID:    "session-1",
 		Service:      "indexeddb",
-		EnvVar:       providerhost.DefaultIndexedDBSocketEnv,
+		EnvVar:       indexeddbservice.DefaultSocketEnv,
 		MethodPrefix: "/" + proto.IndexedDB_ServiceDesc.ServiceName + "/",
 		TTL:          time.Minute,
 	})

--- a/gestaltd/internal/testutil/cachetransport/server.go
+++ b/gestaltd/internal/testutil/cachetransport/server.go
@@ -12,7 +12,7 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -49,7 +49,7 @@ func Start(target string, opts Options) (*Server, error) {
 	srv := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(requireRelayTokenUnary(opts.ExpectRelayToken)),
 	)
-	proto.RegisterCacheServer(srv, providerhost.NewCacheServer(stub, ""))
+	proto.RegisterCacheServer(srv, cacheservice.NewServer(stub, ""))
 	go func() { _ = srv.Serve(lis) }()
 	return &Server{srv: srv, lis: lis, target: target}, nil
 }

--- a/gestaltd/internal/testutil/indexeddbtransport/server.go
+++ b/gestaltd/internal/testutil/indexeddbtransport/server.go
@@ -12,7 +12,7 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -51,7 +51,7 @@ func Start(target string, opts Options) (*Server, error) {
 		grpc.ChainUnaryInterceptor(requireRelayTokenUnary(opts.ExpectRelayToken)),
 		grpc.ChainStreamInterceptor(requireRelayTokenStream(opts.ExpectRelayToken)),
 	)
-	proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(stub, "", providerhost.IndexedDBServerOptions{}))
+	proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(stub, "", indexeddbservice.ServerOptions{}))
 	go func() { _ = srv.Serve(lis) }()
 	return &Server{srv: srv, lis: lis, target: target}, nil
 }

--- a/gestaltd/internal/testutil/s3transport/server.go
+++ b/gestaltd/internal/testutil/s3transport/server.go
@@ -12,7 +12,6 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/s3"
 	"google.golang.org/grpc"
@@ -60,7 +59,7 @@ func Start(target string, opts Options) (*Server, error) {
 		grpc.ChainUnaryInterceptor(requireRelayTokenUnary(opts.ExpectRelayToken)),
 		grpc.ChainStreamInterceptor(requireRelayTokenStream(opts.ExpectRelayToken)),
 	)
-	proto.RegisterS3Server(srv, providerhost.NewS3Server(stub, ""))
+	proto.RegisterS3Server(srv, s3.NewServer(stub, ""))
 	proto.RegisterS3ObjectAccessServer(srv, s3.NewObjectAccessServer(accessURLs, "sdk-test", "default"))
 	go func() { _ = srv.Serve(lis) }()
 	return &Server{srv: srv, lis: lis, target: target}, nil

--- a/gestaltd/services/authentication/authentication.go
+++ b/gestaltd/services/authentication/authentication.go
@@ -1,0 +1,15 @@
+// Package authentication exposes authentication provider transport primitives.
+package authentication
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+type ExecConfig = providerhost.AuthenticationExecConfig
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthenticationProvider, error) {
+	return providerhost.NewExecutableAuthenticationProvider(ctx, cfg)
+}

--- a/gestaltd/services/authorization/authorization.go
+++ b/gestaltd/services/authorization/authorization.go
@@ -1,0 +1,26 @@
+// Package authorization exposes authorization provider transport primitives.
+package authorization
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+const DefaultSocketEnv = providerhost.DefaultAuthorizationSocketEnv
+
+type ExecConfig = providerhost.AuthorizationExecConfig
+
+func SocketTokenEnv() string {
+	return providerhost.AuthorizationSocketTokenEnv()
+}
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthorizationProvider, error) {
+	return providerhost.NewExecutableAuthorizationProvider(ctx, cfg)
+}
+
+func NewProviderServer(provider core.AuthorizationProvider) proto.AuthorizationProviderServer {
+	return providerhost.NewAuthorizationProviderServer(provider)
+}

--- a/gestaltd/services/cache/cache.go
+++ b/gestaltd/services/cache/cache.go
@@ -1,0 +1,30 @@
+// Package cache exposes cache provider transport primitives.
+package cache
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	corecache "github.com/valon-technologies/gestalt/server/core/cache"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+const DefaultSocketEnv = providerhost.DefaultCacheSocketEnv
+
+type ExecConfig = providerhost.CacheExecConfig
+
+func SocketEnv(name string) string {
+	return providerhost.CacheSocketEnv(name)
+}
+
+func SocketTokenEnv(name string) string {
+	return providerhost.CacheSocketTokenEnv(name)
+}
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (corecache.Cache, error) {
+	return providerhost.NewExecutableCache(ctx, cfg)
+}
+
+func NewServer(cache corecache.Cache, pluginName string) proto.CacheServer {
+	return providerhost.NewCacheServer(cache, pluginName)
+}

--- a/gestaltd/services/externalcredentials/externalcredentials.go
+++ b/gestaltd/services/externalcredentials/externalcredentials.go
@@ -1,0 +1,22 @@
+// Package externalcredentials exposes external credential provider transport primitives.
+package externalcredentials
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+const DefaultSocketEnv = providerhost.DefaultExternalCredentialSocketEnv
+
+type ExecConfig = providerhost.ExternalCredentialsExecConfig
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (core.ExternalCredentialProvider, error) {
+	return providerhost.NewExecutableExternalCredentialProvider(ctx, cfg)
+}
+
+func NewProviderServer(provider core.ExternalCredentialProvider) proto.ExternalCredentialProviderServer {
+	return providerhost.NewExternalCredentialProviderServer(provider)
+}

--- a/gestaltd/services/indexeddb/indexeddb.go
+++ b/gestaltd/services/indexeddb/indexeddb.go
@@ -1,0 +1,31 @@
+// Package indexeddb exposes IndexedDB provider transport primitives.
+package indexeddb
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	coreindexeddb "github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+const DefaultSocketEnv = providerhost.DefaultIndexedDBSocketEnv
+
+type ExecConfig = providerhost.IndexedDBExecConfig
+type ServerOptions = providerhost.IndexedDBServerOptions
+
+func SocketEnv(name string) string {
+	return providerhost.IndexedDBSocketEnv(name)
+}
+
+func SocketTokenEnv(name string) string {
+	return providerhost.IndexedDBSocketTokenEnv(name)
+}
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (coreindexeddb.IndexedDB, error) {
+	return providerhost.NewExecutableIndexedDB(ctx, cfg)
+}
+
+func NewServer(ds coreindexeddb.IndexedDB, pluginName string, opts ServerOptions) proto.IndexedDBServer {
+	return providerhost.NewIndexedDBServer(ds, pluginName, opts)
+}

--- a/gestaltd/services/s3/object_access.go
+++ b/gestaltd/services/s3/object_access.go
@@ -1,16 +1,42 @@
-// Package s3 exposes S3 service primitives.
+// Package s3 exposes S3 provider transport and object-access primitives.
 package s3
 
 import (
+	"context"
+
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	s3store "github.com/valon-technologies/gestalt/server/core/s3"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 )
 
+const DefaultSocketEnv = providerhost.DefaultS3SocketEnv
 const ObjectAccessPathPrefix = providerhost.S3ObjectAccessPathPrefix
 
+type ExecConfig = providerhost.S3ExecConfig
+type ServerOptions = providerhost.S3ServerOptions
 type ObjectAccessURLManager = providerhost.S3ObjectAccessURLManager
 type ObjectAccessURLRequest = providerhost.S3ObjectAccessURLRequest
 type ObjectAccessTarget = providerhost.S3ObjectAccessTarget
+
+func SocketEnv(name string) string {
+	return providerhost.S3SocketEnv(name)
+}
+
+func SocketTokenEnv(name string) string {
+	return providerhost.S3SocketTokenEnv(name)
+}
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (s3store.Client, error) {
+	return providerhost.NewExecutableS3(ctx, cfg)
+}
+
+func NewServer(client s3store.Client, pluginName string) proto.S3Server {
+	return providerhost.NewS3Server(client, pluginName)
+}
+
+func NewServerWithOptions(client s3store.Client, pluginName string, opts ServerOptions) proto.S3Server {
+	return providerhost.NewS3ServerWithOptions(client, pluginName, opts)
+}
 
 func NewObjectAccessURLManager(secret []byte, baseURL string) (*ObjectAccessURLManager, error) {
 	return providerhost.NewS3ObjectAccessURLManager(secret, baseURL)

--- a/gestaltd/services/secrets/secrets.go
+++ b/gestaltd/services/secrets/secrets.go
@@ -1,0 +1,15 @@
+// Package secrets exposes secret manager provider transport primitives.
+package secrets
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+type ExecConfig = providerhost.SecretsExecConfig
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (core.SecretManager, error) {
+	return providerhost.NewExecutableSecretManager(ctx, cfg)
+}


### PR DESCRIPTION
## Summary
- Add `gestaltd/services/cache` as the service-facing boundary for cache provider transport primitives.
- Add `gestaltd/services/indexeddb` as the service-facing boundary for IndexedDB provider transport primitives.
- Extend `gestaltd/services/s3` so S3 owns socket env names, executable provider construction, and S3 gRPC server registration alongside object-access URLs.
- Move bootstrap storage host-service wiring, storage provider factories, and SDK transport test servers to use the service packages instead of importing `internal/providerhost` for these contracts.

## Stack
- Based on `main`; #1576 has been merged.
- This PR is a single squashable commit on top of `main`.

## New Interfaces
- `cache.DefaultSocketEnv`, `cache.SocketEnv`, and `cache.SocketTokenEnv` for cache host-service env names.
- `cache.ExecConfig`, `cache.NewExecutable`, and `cache.NewServer` for executable cache providers and host gRPC registration.
- `indexeddb.DefaultSocketEnv`, `indexeddb.SocketEnv`, and `indexeddb.SocketTokenEnv` for IndexedDB host-service env names.
- `indexeddb.ExecConfig`, `indexeddb.ServerOptions`, `indexeddb.NewExecutable`, and `indexeddb.NewServer` for executable IndexedDB providers and host gRPC registration.
- `s3.DefaultSocketEnv`, `s3.SocketEnv`, and `s3.SocketTokenEnv` for S3 host-service env names.
- `s3.ExecConfig`, `s3.ServerOptions`, `s3.NewExecutable`, `s3.NewServer`, and `s3.NewServerWithOptions` for executable S3 providers and host gRPC registration.

## Examples
```go
cacheProvider, err := cache.NewExecutable(ctx, cache.ExecConfig{
    Command: cfg.Command,
    Args: cfg.Args,
    Env: cfg.Env,
    Config: cfg.Config,
    Name: cfg.Name,
})
```

```go
proto.RegisterIndexedDBServer(
    srv,
    indexeddb.NewServer(db, providerName, indexeddb.ServerOptions{
        AllowedStores: stores,
    }),
)
```

```go
proto.RegisterS3Server(
    srv,
    s3.NewServerWithOptions(client, pluginName, s3.ServerOptions{
        BindingName: binding,
        AccessURLs: accessURLs,
    }),
)
```

## Review Pass
- Reviewed with a separate GPT-5.5 xhigh agent. No findings.

## Tests
```sh
go test ./services/cache ./services/indexeddb ./services/s3 ./internal/bootstrap ./internal/server/... ./internal/testutil/cachetransport ./internal/testutil/indexeddbtransport ./internal/testutil/s3transport ./internal/drivers/cache/provider ./internal/drivers/indexeddb/provider ./internal/drivers/s3/provider
```

gpt-5.5 reviewer additionally ran:
```sh
go test ./services/cache ./services/indexeddb ./services/s3 ./internal/drivers/cache/provider ./internal/drivers/indexeddb/provider ./internal/drivers/s3/provider ./internal/testutil/cachetransport ./internal/testutil/indexeddbtransport ./internal/testutil/s3transport
```