### PR TITLE
Add shared provider-dev attach state

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -848,9 +848,10 @@ gestaltd provider dev --remote "$GESTALT_URL" --path ./slack
 
 The remote URL is environment-agnostic; it can point at any `gestaltd` instance
 that exposes provider-dev attach targets and has opted in with
-`server.providerDev.remoteAttach: true` and
-`server.providerDev.attachmentState: processLocal`. The target plugin must also
-opt into private remote attach with `providerDev.attach.allowedRoles`. The CLI
+`server.dev.attachmentState`. Use `attachmentState: indexeddb` on shared or
+load-balanced servers so attachment metadata and queued provider/UI calls are
+available to every replica. The target plugin must also opt into private remote
+attach with `dev.attach.allowedRoles`. The CLI
 opens a browser approval page for the interactive happy path; approve it with
 your normal browser session and enter the verification code shown in your
 terminal. API-token callers must use a token with the `provider_dev.attach`
@@ -860,9 +861,8 @@ continue to run through the remote server and its existing configuration.
 
 ```yaml
 server:
-  providerDev:
-    remoteAttach: true
-    attachmentState: processLocal
+  dev:
+    attachmentState: indexeddb
 
 authorization:
   policies:
@@ -875,7 +875,7 @@ authorization:
 plugins:
   slack:
     authorizationPolicy: provider_devs
-    providerDev:
+    dev:
       attach:
         allowedRoles:
           - developer
@@ -896,12 +896,11 @@ enough, and this action does not grant normal invocation access:
   ]
 }
 ```
-Remote attach v1 is process-local, and the server requires
-`server.providerDev.attachmentState: processLocal` as an explicit operator
-acknowledgement. On a load-balanced remote, enable it only when the deployment
-is single-replica or sticky-routes attach creation, CLI poll/complete traffic,
-provider invocations, and provider-owned UI requests for the same authenticated
-owner to the same `gestaltd` process.
+`attachmentState: indexeddb` stores attachment metadata and queued provider/UI
+calls in the selected host IndexedDB, so attach traffic can move across
+`gestaltd` replicas. `attachmentState: processLocal` stores attachment state in
+the accepting process only; reserve it for local demos and single-process
+development servers.
 Remote provider dev uses `--remote-token` first, then `GESTALT_API_KEY` for
 non-interactive direct attach. Stored CLI credentials are intentionally not used
 for direct attach; without an explicit token, the CLI uses browser approval. An

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -95,14 +95,11 @@ keeps its existing config-relative behavior for backward compatibility.
 `provider dev --remote` is environment-agnostic: the URL is just the remote
 `gestaltd` instance to attach to. The local command only replaces source-backed
 plugin implementations for the authenticated principal that created the session.
-The remote server must opt in with `server.providerDev.remoteAttach: true` and
-`server.providerDev.attachmentState: processLocal`; otherwise the command fails
-before local code is attached. `attachmentState: processLocal` acknowledges that
-remote attach v1 stores attachments in the `gestaltd` process that accepted the
-create request. Only enable it on a single-replica server or behind sticky
-routing that keeps attach creation, CLI poll/complete traffic, provider
-invocations, and provider-owned UI requests for the same authenticated owner on
-the same `gestaltd` process.
+The remote server must opt in with `server.dev.attachmentState`; otherwise the
+command fails before local code is attached. Use `attachmentState: indexeddb` on
+shared or load-balanced servers so attachment metadata and queued provider calls
+are stored in the configured host IndexedDB. `attachmentState: processLocal` is
+available only for local demos and single-process development servers.
 For the interactive happy path, `provider dev --remote` creates a short-lived
 attach approval request and opens the remote server in your browser. Approving
 that page with your normal browser session creates an owner-scoped attachment

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -172,8 +172,7 @@ Plugins without `authorizationPolicy` are open to any authenticated subject. Bin
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared artifacts produced by `gestaltd sync --locked`. |
 | `providers.audit` / `providers.authentication` / `providers.authorization` / `providers.indexeddb` / `providers.secrets` / `providers.telemetry` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
-| `providerDev.remoteAttach` | `false` | Enables private remote provider-dev attach routes. Requires `providerDev.attachmentState: processLocal`. |
-| `providerDev.attachmentState` | | Required when `providerDev.remoteAttach` is true. Use `processLocal` to acknowledge that remote attach v1 stores attachment state in this `gestaltd` process and therefore requires single-replica operation or sticky routing for provider-dev traffic. |
+| `dev.attachmentState` | | Enables private remote provider-dev attach routes and selects where attachment state is stored. Use `indexeddb` for shared or load-balanced servers. Use `processLocal` only for local demos and single-process development servers. |
 | `runtime.defaultHostedProvider` | | Default runtime-provider selector for plugins that opt into `execution.mode: hosted`. This does not move plugins into hosted runtimes by itself. |
 | `admin.authorizationPolicy` | | Shared subject access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
@@ -1012,7 +1011,7 @@ plugins:
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
-| `providerDev.attach.allowedRoles` | Roles from this plugin's `authorizationPolicy` that may create private remote provider-dev attachments for this plugin. This is denied when omitted, empty, or when the plugin has no `authorizationPolicy`. |
+| `dev.attach.allowedRoles` | Roles from this plugin's `authorizationPolicy` that may create private remote provider-dev attachments for this plugin. This is denied when omitted, empty, or when the plugin has no `authorizationPolicy`. |
 | `execution` | Optional executable-plugin execution config. `execution.mode` is `local` or `hosted`; `execution.runtime` carries the hosted runtime fields. |
 | `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 | `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Supported providers derive plugin scoping from that `db` name using provider-native namespace config; Gestalt does not rewrite object-store names at the SDK transport layer. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
@@ -1093,9 +1092,8 @@ on shared remotes:
 
 ```yaml
 server:
-  providerDev:
-    remoteAttach: true
-    attachmentState: processLocal
+  dev:
+    attachmentState: indexeddb
 
 authorization:
   policies:
@@ -1108,7 +1106,7 @@ authorization:
 plugins:
   slack:
     authorizationPolicy: provider_devs
-    providerDev:
+    dev:
       attach:
         allowedRoles:
           - developer
@@ -1121,19 +1119,19 @@ return redacted attachment metadata and never return dispatcher secrets, runtime
 environment, host-service env, plugin config, access tokens, or browser binding
 URLs.
 
-Remote attach v1 stores attachments in the `gestaltd` process that accepted the
-create request. `attachmentState: processLocal` is required as an explicit
-operator acknowledgement of that model. For load-balanced deployments, treat
-single-replica operation or sticky routing for attach creation, poll/complete
-traffic, provider invocations, and provider-owned UI requests as a hard
-prerequisite before enabling `remoteAttach`.
+`attachmentState: indexeddb` stores attachment metadata and queued provider/UI
+calls in the selected host IndexedDB, so any `gestaltd` replica can accept
+attach creation, CLI poll/complete traffic, provider invocations, and
+provider-owned UI requests. `attachmentState: processLocal` stores the same
+state in this process only; reserve it for local demos and single-process
+development servers.
 
 Interactive attach creation uses a short-lived browser approval page plus a
 verification code shown in the initiating terminal. The approving browser
 session must satisfy the plugin runtime grant. For non-interactive/API-token
 attach, the caller must satisfy both the plugin runtime grant and a token action
 grant. The runtime grant comes from
-`plugins.<name>.providerDev.attach.allowedRoles` on a plugin with an
+`plugins.<name>.dev.attach.allowedRoles` on a plugin with an
 `authorizationPolicy`, or from a runtime authorizer that explicitly grants the
 same action. API tokens must carry `permissions[].actions:
 ["provider_dev.attach"]` for every attached plugin; normal provider scopes and

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -5998,7 +5998,7 @@ func TestProviderDevRuntimeEnvUsesPublicHostServiceRelay(t *testing.T) {
 		S3: map[string]s3store.Client{
 			"main": &coretesting.StubS3{},
 		},
-	}, "provider-dev-session")
+	}, "provider-dev-session", false)
 	if err != nil {
 		t.Fatalf("buildProviderDevRuntimeEnv: %v", err)
 	}

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -22,9 +23,10 @@ func buildProviderDevManager(cfg *config.Config, providers *registry.ProviderMap
 		return nil, nil
 	}
 
+	sharedAttachmentState := cfg.Server.Dev.AttachmentState == config.DevAttachmentStateIndexedDB
 	targets := make([]providerdev.Target, 0, len(cfg.Plugins))
 	for name, entry := range cfg.Plugins {
-		result := deriveProviderDevTarget(name, entry, providers, deps)
+		result := deriveProviderDevTarget(name, entry, providers, deps, sharedAttachmentState)
 		switch result.state {
 		case providerDevTargetAttachable:
 			targets = append(targets, result.target)
@@ -41,7 +43,24 @@ func buildProviderDevManager(cfg *config.Config, providers *registry.ProviderMap
 	if len(targets) == 0 {
 		return nil, nil
 	}
-	return providerdev.NewManager(targets)
+	var opts []providerdev.ManagerOption
+	if sharedAttachmentState {
+		if deps.Services == nil || deps.Services.DB == nil {
+			return nil, fmt.Errorf("provider dev indexeddb attachment state requires core services IndexedDB")
+		}
+		opts = append(opts, providerdev.WithIndexedDBAttachmentState(context.Background(), deps.Services.DB))
+	}
+	manager, err := providerdev.NewManager(targets, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if sharedAttachmentState {
+		if err := registerProviderDevPublicHostServices(cfg, manager, deps, targets); err != nil {
+			_ = manager.Close()
+			return nil, err
+		}
+	}
+	return manager, nil
 }
 
 type providerDevTargetState int
@@ -59,7 +78,7 @@ type providerDevTargetResult struct {
 	err    error
 }
 
-func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers *registry.ProviderMap[core.Provider], deps Deps) providerDevTargetResult {
+func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers *registry.ProviderMap[core.Provider], deps Deps, sharedAttachmentState bool) providerDevTargetResult {
 	if entry == nil {
 		return providerDevTargetResult{state: providerDevTargetUnsupported, reason: "missing config entry"}
 	}
@@ -104,7 +123,7 @@ func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers
 			Config: pluginConfig,
 			UIPath: strings.TrimSpace(entry.MountPath),
 			RuntimeEnv: func(sessionID string) (providerdev.RuntimeEnv, error) {
-				return buildProviderDevRuntimeEnv(targetName, targetEntry, deps, sessionID)
+				return buildProviderDevRuntimeEnv(targetName, targetEntry, deps, sessionID, sharedAttachmentState)
 			},
 		},
 	}
@@ -148,7 +167,7 @@ func providerDevEntryIsLocal(entry *config.ProviderEntry) bool {
 	return entry != nil && (entry.HasLocalSource() || entry.HasLocalReleaseSource())
 }
 
-func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps Deps, sessionID string) (providerdev.RuntimeEnv, error) {
+func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps Deps, sessionID string, sharedAttachmentState bool) (providerdev.RuntimeEnv, error) {
 	hostServices, _, cleanup, err := buildPluginRuntimeHostServices(name, entry, deps, false)
 	if err != nil {
 		return providerdev.RuntimeEnv{}, err
@@ -159,14 +178,41 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 			cleanup()
 		}
 	}()
+	env := map[string]string{}
+	if sharedAttachmentState {
+		for _, hostService := range hostServices {
+			bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, runtimehost.StartedHostService{
+				Name:   hostService.Name,
+				EnvVar: hostService.EnvVar,
+			}, deps, false)
+			if err != nil {
+				return providerdev.RuntimeEnv{}, err
+			}
+			if bindingReq.EnvVar != "" && bindingReq.Relay.DialTarget != "" {
+				env[bindingReq.EnvVar] = bindingReq.Relay.DialTarget
+			}
+			maps.Copy(env, bindingEnv)
+		}
+		if deps.Egress.DefaultAction == egress.PolicyDeny {
+			proxyEnv, err := buildHostedRuntimePublicEgressProxy(name, sessionID, entry.EffectiveAllowedHosts(), deps.Egress.DefaultAction, deps)
+			if err != nil {
+				return providerdev.RuntimeEnv{}, err
+			}
+			maps.Copy(env, proxyEnv)
+		}
+		if cleanup != nil {
+			cleanup()
+			cleanup = nil
+		}
+		cleanupOnError = false
+		return providerdev.RuntimeEnv{Env: env}, nil
+	}
 	if deps.PublicHostServices != nil {
 		deps.PublicHostServices.RegisterSession(name, sessionID, hostServices...)
 		cleanup = chainCleanup(cleanup, func() {
 			deps.PublicHostServices.UnregisterSession(name, sessionID, hostServices...)
 		})
 	}
-
-	env := map[string]string{}
 	startedHostServices, err := runtimehost.StartHostServices(
 		hostServices,
 		runtimehost.WithHostServicesProviderName(name),
@@ -203,4 +249,55 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 		Env:     env,
 		Cleanup: cleanup,
 	}, nil
+}
+
+type providerDevHostServiceVerifier struct {
+	manager  *providerdev.Manager
+	provider string
+}
+
+func (v providerDevHostServiceVerifier) VerifyHostServiceSession(ctx context.Context, sessionID string) error {
+	if v.manager == nil {
+		return fmt.Errorf("provider dev manager is not configured")
+	}
+	return v.manager.VerifyHostServiceSession(ctx, v.provider, sessionID)
+}
+
+func registerProviderDevPublicHostServices(cfg *config.Config, manager *providerdev.Manager, deps Deps, targets []providerdev.Target) error {
+	if cfg == nil || manager == nil || deps.PublicHostServices == nil {
+		return nil
+	}
+	targetNames := make(map[string]struct{}, len(targets))
+	for i := range targets {
+		targetNames[targets[i].Name] = struct{}{}
+	}
+	for name, entry := range cfg.Plugins {
+		if _, ok := targetNames[name]; !ok {
+			continue
+		}
+		if entry == nil || !entry.HasResolvedManifest() {
+			continue
+		}
+		hostServices, _, cleanup, err := buildPluginRuntimeHostServices(name, entry, deps, false)
+		if err != nil {
+			if cleanup != nil {
+				cleanup()
+			}
+			return fmt.Errorf("provider dev public host services %q: %w", name, err)
+		}
+		if len(hostServices) == 0 {
+			if cleanup != nil {
+				cleanup()
+			}
+			continue
+		}
+		deps.PublicHostServices.RegisterVerified(name, providerDevHostServiceVerifier{manager: manager, provider: name}, hostServices...)
+		manager.AddCleanup(func() {
+			deps.PublicHostServices.Unregister(name, hostServices...)
+			if cleanup != nil {
+				cleanup()
+			}
+		})
+	}
+	return nil
 }

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -358,7 +358,7 @@ type ProviderEntry struct {
 	HTTP            map[string]*HTTPBinding        `yaml:"http,omitempty"`
 	// AuthorizationPolicy binds this provider to a shared subject access policy.
 	AuthorizationPolicy string                  `yaml:"authorizationPolicy,omitempty"`
-	ProviderDev         *ProviderEntryDevConfig `yaml:"providerDev,omitempty"`
+	Dev                 *ProviderEntryDevConfig `yaml:"dev,omitempty"`
 
 	// Plugin-specific runtime fields populated from the canonical ui object.
 	MountPath         string                        `yaml:"-"`
@@ -812,7 +812,7 @@ func (f providerEntryFields) toProviderEntry() ProviderEntry {
 func providerEntryFieldsFromEntry(e ProviderEntry) providerEntryFields {
 	e.Egress = cloneProviderEgressConfig(e.Egress)
 	e.Execution = cloneExecutionConfig(e.Execution)
-	e.ProviderDev = cloneProviderEntryDevConfig(e.ProviderDev)
+	e.Dev = cloneProviderEntryDevConfig(e.Dev)
 	normalizeProviderEntryAliases(&e)
 	return providerEntryFields(e)
 }
@@ -836,8 +836,8 @@ func normalizeProviderEntryAliases(entry *ProviderEntry) {
 	if entry.Execution != nil {
 		entry.Execution.Mode = ExecutionMode(strings.ToLower(strings.TrimSpace(string(entry.Execution.Mode))))
 	}
-	if entry.ProviderDev != nil {
-		entry.ProviderDev.Attach.AllowedRoles = trimStringSlice(entry.ProviderDev.Attach.AllowedRoles)
+	if entry.Dev != nil {
+		entry.Dev.Attach.AllowedRoles = trimStringSlice(entry.Dev.Attach.AllowedRoles)
 	}
 }
 
@@ -1396,20 +1396,22 @@ type ServerConfig struct {
 	APITokenTTL   string                   `yaml:"apiTokenTtl"`
 	ArtifactsDir  string                   `yaml:"artifactsDir"`
 	Providers     ServerProvidersConfig    `yaml:"providers,omitempty"`
-	ProviderDev   ProviderDevConfig        `yaml:"providerDev,omitempty"`
+	Dev           DevConfig                `yaml:"dev,omitempty"`
 	Runtime       ServerRuntimeConfig      `yaml:"runtime,omitempty"`
 	Egress        EgressConfig             `yaml:"egress,omitempty"`
 	Admin         AdminConfig              `yaml:"admin,omitempty"`
 }
 
-type ProviderDevConfig struct {
-	RemoteAttach    bool                       `yaml:"remoteAttach,omitempty"`
-	AttachmentState ProviderDevAttachmentState `yaml:"attachmentState,omitempty"`
+type DevConfig struct {
+	AttachmentState DevAttachmentState `yaml:"attachmentState,omitempty"`
 }
 
-type ProviderDevAttachmentState string
+type DevAttachmentState string
 
-const ProviderDevAttachmentStateProcessLocal ProviderDevAttachmentState = "processLocal"
+const (
+	DevAttachmentStateProcessLocal DevAttachmentState = "processLocal"
+	DevAttachmentStateIndexedDB    DevAttachmentState = "indexeddb"
+)
 
 type ServerRuntimeConfig struct {
 	DefaultHostedProvider string `yaml:"defaultHostedProvider,omitempty"`

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -138,46 +138,37 @@ func TestLoadConfigValidatesProviderDevAttachmentState(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name    string
-		yaml    string
-		wantErr string
+		name      string
+		yaml      string
+		wantErr   string
+		wantState DevAttachmentState
 	}{
-		{
-			name: "remote attach requires explicit process local state",
-			yaml: `
-server:
-  providerDev:
-    remoteAttach: true
-`,
-			wantErr: `server.providerDev.remoteAttach requires server.providerDev.attachmentState: "processLocal"`,
-		},
 		{
 			name: "unsupported attachment state",
 			yaml: `
 server:
-  providerDev:
-    remoteAttach: true
+  dev:
     attachmentState: sharedRelay
 `,
-			wantErr: `server.providerDev.attachmentState "sharedRelay" is not supported`,
-		},
-		{
-			name: "attachment state requires remote attach",
-			yaml: `
-server:
-  providerDev:
-    attachmentState: processLocal
-`,
-			wantErr: `server.providerDev.attachmentState requires server.providerDev.remoteAttach`,
+			wantErr: `server.dev.attachmentState "sharedRelay" is not supported`,
 		},
 		{
 			name: "process local remote attach",
 			yaml: `
 server:
-  providerDev:
-    remoteAttach: true
+  dev:
     attachmentState: processLocal
 `,
+			wantState: DevAttachmentStateProcessLocal,
+		},
+		{
+			name: "indexeddb remote attach",
+			yaml: `
+server:
+  dev:
+    attachmentState: indexeddb
+`,
+			wantState: DevAttachmentStateIndexedDB,
 		},
 	}
 
@@ -198,8 +189,8 @@ server:
 			if err != nil {
 				t.Fatalf("Load: %v", err)
 			}
-			if got := cfg.Server.ProviderDev.AttachmentState; got != ProviderDevAttachmentStateProcessLocal {
-				t.Fatalf("providerDev.attachmentState = %q, want %q", got, ProviderDevAttachmentStateProcessLocal)
+			if got := cfg.Server.Dev.AttachmentState; got != tc.wantState {
+				t.Fatalf("dev.attachmentState = %q, want %q", got, tc.wantState)
 			}
 		})
 	}

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -153,22 +153,13 @@ func validateProviderDevConfig(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
-	providerDev := cfg.Server.ProviderDev
-	state := ProviderDevAttachmentState(strings.TrimSpace(string(providerDev.AttachmentState)))
-	cfg.Server.ProviderDev.AttachmentState = state
-	if !providerDev.RemoteAttach {
-		if state != "" {
-			return fmt.Errorf("config validation: server.providerDev.attachmentState requires server.providerDev.remoteAttach")
-		}
-		return nil
-	}
+	state := DevAttachmentState(strings.TrimSpace(string(cfg.Server.Dev.AttachmentState)))
+	cfg.Server.Dev.AttachmentState = state
 	switch state {
-	case ProviderDevAttachmentStateProcessLocal:
+	case "", DevAttachmentStateProcessLocal, DevAttachmentStateIndexedDB:
 		return nil
-	case "":
-		return fmt.Errorf("config validation: server.providerDev.remoteAttach requires server.providerDev.attachmentState: %q because remote attach v1 stores attachments in process memory; enable only on single-replica deployments or deployments with sticky routing for provider-dev traffic", ProviderDevAttachmentStateProcessLocal)
 	default:
-		return fmt.Errorf("config validation: server.providerDev.attachmentState %q is not supported; use %q", state, ProviderDevAttachmentStateProcessLocal)
+		return fmt.Errorf("config validation: server.dev.attachmentState %q is not supported; use %q or %q", state, DevAttachmentStateProcessLocal, DevAttachmentStateIndexedDB)
 	}
 }
 

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -1406,7 +1406,7 @@ func setupIndexedDBProviderDir(t *testing.T, baseDir string) string {
 	artifactRel := filepath.Base(binDest)
 	writeManifestFile(t, providerDir, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb-inmem",
+		Source:      "github.com/test/providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "In-Memory IndexedDB",
 		Spec:        &providermanifestv1.Spec{},
@@ -1589,7 +1589,7 @@ func setupDefaultLocalProvidersDir(t *testing.T, baseDir string) string {
 	}
 	writeManifestFile(t, indexedDBDir, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb-relationaldb",
+		Source:      "github.com/test/providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Relational IndexedDB",
 		Spec:        &providermanifestv1.Spec{},

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -182,7 +182,7 @@ func writeDefaultProvidersDir(baseDir string) (string, error) {
 
 	if err := writeComponentProviderDir(filepath.Join(providersDir, "indexeddb", "relationaldb"), indexedDBBin, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb-relationaldb",
+		Source:      "github.com/test/providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Relational IndexedDB",
 		Spec:        &providermanifestv1.Spec{},

--- a/gestaltd/internal/providerdev/indexeddb_store.go
+++ b/gestaltd/internal/providerdev/indexeddb_store.go
@@ -1,0 +1,1427 @@
+package providerdev
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+const (
+	indexedDBAttachmentStore = "provider_dev_attachments"
+	indexedDBCallStore       = "provider_dev_calls"
+	indexedDBAuthStore       = "provider_dev_attach_authorizations"
+
+	indexedDBCallStatePending  = "pending"
+	indexedDBCallStateLeased   = "leased"
+	indexedDBCallStateComplete = "complete"
+	indexedDBCallStateFailed   = "failed"
+	indexedDBCallStateClosed   = "closed"
+)
+
+var (
+	indexedDBAttachmentSchema = indexeddb.ObjectStoreSchema{
+		Indexes: []indexeddb.IndexSchema{
+			{Name: "by_owner", KeyPath: []string{"owner"}},
+			{Name: "by_owner_created_at", KeyPath: []string{"owner", "created_at"}},
+		},
+		Columns: []indexeddb.ColumnDef{
+			{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+			{Name: "owner", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "dispatcher_secret_hash", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "targets_json", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "created_at", Type: indexeddb.TypeInt},
+			{Name: "last_seen_at", Type: indexeddb.TypeInt},
+			{Name: "closed", Type: indexeddb.TypeBool},
+			{Name: "closed_at", Type: indexeddb.TypeInt},
+		},
+	}
+	indexedDBCallSchema = indexeddb.ObjectStoreSchema{
+		Indexes: []indexeddb.IndexSchema{
+			{Name: "by_attachment_state_created_at", KeyPath: []string{"attachment_id", "state", "created_at"}},
+			{Name: "by_attachment_state", KeyPath: []string{"attachment_id", "state"}},
+			{Name: "by_attachment", KeyPath: []string{"attachment_id"}},
+		},
+		Columns: []indexeddb.ColumnDef{
+			{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+			{Name: "attachment_id", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "owner", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "provider", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "method", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "request_base64", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "response_base64", Type: indexeddb.TypeString},
+			{Name: "error_code", Type: indexeddb.TypeInt},
+			{Name: "error_message", Type: indexeddb.TypeString},
+			{Name: "state", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "created_at", Type: indexeddb.TypeInt},
+			{Name: "leased_at", Type: indexeddb.TypeInt},
+			{Name: "completed_at", Type: indexeddb.TypeInt},
+			{Name: "expires_at", Type: indexeddb.TypeInt},
+		},
+	}
+	indexedDBAuthSchema = indexeddb.ObjectStoreSchema{
+		Indexes: []indexeddb.IndexSchema{
+			{Name: "by_expires_at", KeyPath: []string{"expires_at"}},
+		},
+		Columns: []indexeddb.ColumnDef{
+			{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+			{Name: "client_secret_hash", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "verification_hash", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "request_hash", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "providers_json", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "approved_by_json", Type: indexeddb.TypeString},
+			{Name: "used", Type: indexeddb.TypeBool},
+			{Name: "created_at", Type: indexeddb.TypeInt},
+			{Name: "expires_at", Type: indexeddb.TypeInt},
+		},
+	}
+)
+
+type indexedDBSessionStore struct {
+	db indexeddb.IndexedDB
+}
+
+type indexedDBSessionRecord struct {
+	id                   string
+	owner                string
+	dispatcherSecretHash string
+	targets              []storedTarget
+	createdAt            time.Time
+	lastSeenAt           time.Time
+	closed               bool
+	closedAt             time.Time
+}
+
+type storedTarget struct {
+	Name      string                          `json:"name"`
+	Source    string                          `json:"source,omitempty"`
+	Spec      providerhost.StaticProviderSpec `json:"spec"`
+	Config    map[string]any                  `json:"config,omitempty"`
+	ConfigSet bool                            `json:"configSet,omitempty"`
+	UI        bool                            `json:"ui,omitempty"`
+	UIPath    string                          `json:"uiPath,omitempty"`
+}
+
+type indexedDBCallRecord struct {
+	id           string
+	attachmentID string
+	owner        string
+	provider     string
+	method       string
+	request      []byte
+	response     []byte
+	errorCode    codes.Code
+	errorMessage string
+	state        string
+	createdAt    time.Time
+	leasedAt     time.Time
+	completedAt  time.Time
+	expiresAt    time.Time
+}
+
+type indexedDBAttachAuthorizationRecord struct {
+	id               string
+	clientSecretHash string
+	verificationHash string
+	requestHash      string
+	providers        []string
+	expiresAt        time.Time
+	approvedBy       *principal.Principal
+	used             bool
+	createdAt        time.Time
+}
+
+type sharedSession struct {
+	id    string
+	owner string
+	store *indexedDBSessionStore
+}
+
+func WithIndexedDBAttachmentState(ctx context.Context, db indexeddb.IndexedDB) ManagerOption {
+	return func(m *Manager) error {
+		store, err := newIndexedDBSessionStore(ctx, db)
+		if err != nil {
+			return err
+		}
+		m.shared = store
+		return nil
+	}
+}
+
+func newIndexedDBSessionStore(ctx context.Context, db indexeddb.IndexedDB) (*indexedDBSessionStore, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if db == nil {
+		return nil, fmt.Errorf("provider dev indexeddb attachment state requires an IndexedDB provider")
+	}
+	if err := db.CreateObjectStore(ctx, indexedDBAttachmentStore, indexedDBAttachmentSchema); err != nil {
+		return nil, fmt.Errorf("create provider dev attachment store: %w", err)
+	}
+	if err := db.CreateObjectStore(ctx, indexedDBCallStore, indexedDBCallSchema); err != nil {
+		return nil, fmt.Errorf("create provider dev call store: %w", err)
+	}
+	if err := db.CreateObjectStore(ctx, indexedDBAuthStore, indexedDBAuthSchema); err != nil {
+		return nil, fmt.Errorf("create provider dev attach authorization store: %w", err)
+	}
+	return &indexedDBSessionStore{db: db}, nil
+}
+
+func (s *indexedDBSessionStore) createSession(ctx context.Context, owner, id, dispatcherSecretHash string, targets []Target, now time.Time) error {
+	if s == nil {
+		return status.Error(codes.FailedPrecondition, "provider dev indexeddb attachment state is not configured")
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	_ = s.cleanupExpired(ctx, now)
+	stored := make([]storedTarget, 0, len(targets))
+	for i := range targets {
+		target := targets[i]
+		var storedConfig map[string]any
+		if target.ConfigSet {
+			storedConfig = cloneAnyMap(target.Config)
+		}
+		stored = append(stored, storedTarget{
+			Name:      target.Name,
+			Source:    target.Source,
+			Spec:      target.Spec,
+			Config:    storedConfig,
+			ConfigSet: target.ConfigSet,
+			UI:        target.UI,
+			UIPath:    target.UIPath,
+		})
+	}
+	targetsJSON, err := json.Marshal(stored)
+	if err != nil {
+		return status.Errorf(codes.Internal, "encode provider dev attachment targets: %v", err)
+	}
+	rec := indexeddb.Record{
+		"id":                     id,
+		"owner":                  owner,
+		"dispatcher_secret_hash": dispatcherSecretHash,
+		"targets_json":           string(targetsJSON),
+		"created_at":             unixNano(now),
+		"last_seen_at":           unixNano(now),
+		"closed":                 false,
+	}
+	if err := s.db.ObjectStore(indexedDBAttachmentStore).Add(ctx, rec); err != nil {
+		return status.Errorf(codes.Internal, "record provider dev attachment: %v", err)
+	}
+	return nil
+}
+
+func (s *indexedDBSessionStore) createAttachAuthorization(ctx context.Context, auth AttachAuthorization, now time.Time) (*AttachAuthorizationInfo, error) {
+	if s == nil {
+		return nil, status.Error(codes.FailedPrecondition, "provider dev indexeddb attachment state is not configured")
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	tx, err := s.db.Transaction(ctx, []string{indexedDBAuthStore}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "open provider dev attach authorization transaction: %v", err)
+	}
+	committed := false
+	defer abortIfUncommitted(ctx, tx, &committed)
+	store := tx.ObjectStore(indexedDBAuthStore)
+	records, err := store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list provider dev attach authorizations: %v", err)
+	}
+	active := 0
+	for _, raw := range records {
+		existing, err := attachAuthorizationFromRecord(raw)
+		if err != nil {
+			return nil, err
+		}
+		if existing.used || (!existing.expiresAt.IsZero() && now.After(existing.expiresAt)) {
+			_ = store.Delete(ctx, existing.id)
+			continue
+		}
+		active++
+	}
+	if active >= DefaultMaxAttachAuthorizations {
+		return nil, status.Errorf(codes.ResourceExhausted, "too many pending provider dev attach authorizations; try again later")
+	}
+	if auth.expiresAt.IsZero() {
+		auth.expiresAt = now.Add(5 * time.Minute)
+	}
+	rec, err := attachAuthorizationToRecord(indexedDBAttachAuthorizationRecord{
+		id:               auth.id,
+		clientSecretHash: auth.clientSecretHash,
+		verificationHash: auth.verificationHash,
+		requestHash:      auth.requestHash,
+		providers:        slices.Clone(auth.providers),
+		expiresAt:        auth.expiresAt,
+		createdAt:        now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := store.Add(ctx, rec); err != nil {
+		return nil, status.Errorf(codes.Internal, "record provider dev attach authorization: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, status.Errorf(codes.Internal, "commit provider dev attach authorization: %v", err)
+	}
+	committed = true
+	info := (&AttachAuthorization{
+		id:        auth.id,
+		providers: slices.Clone(auth.providers),
+		expiresAt: auth.expiresAt,
+	}).info()
+	return &info, nil
+}
+
+func (s *indexedDBSessionStore) getAttachAuthorization(ctx context.Context, id string, now time.Time) (*AttachAuthorizationInfo, error) {
+	auth, err := s.loadActiveAttachAuthorization(ctx, id, now)
+	if err != nil {
+		return nil, err
+	}
+	info := auth.info()
+	return &info, nil
+}
+
+func (s *indexedDBSessionStore) approveAttachAuthorization(ctx context.Context, id string, p *principal.Principal, verificationCode string, now time.Time) error {
+	tx, err := s.db.Transaction(ctx, []string{indexedDBAuthStore}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return status.Errorf(codes.Internal, "open provider dev attach authorization approval transaction: %v", err)
+	}
+	committed := false
+	defer abortIfUncommitted(ctx, tx, &committed)
+	store := tx.ObjectStore(indexedDBAuthStore)
+	auth, err := s.attachAuthorizationFromStore(ctx, store, id, now)
+	if err != nil {
+		return err
+	}
+	if subtle.ConstantTimeCompare([]byte(hashAttachAuthorizationSecret(verificationCode)), []byte(auth.verificationHash)) != 1 {
+		return status.Error(codes.PermissionDenied, "provider dev attach verification code is invalid")
+	}
+	if auth.approvedBy != nil {
+		if principalSubjectID(auth.approvedBy) == principalSubjectID(p) {
+			return nil
+		}
+		return status.Error(codes.FailedPrecondition, "provider dev attach authorization is already approved")
+	}
+	auth.approvedBy = clonePrincipal(p)
+	rec, err := attachAuthorizationToRecord(*auth)
+	if err != nil {
+		return err
+	}
+	if err := store.Put(ctx, rec); err != nil {
+		return status.Errorf(codes.Internal, "approve provider dev attach authorization: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return status.Errorf(codes.Internal, "commit provider dev attach authorization approval: %v", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *indexedDBSessionStore) pollAttachAuthorization(ctx context.Context, id, clientSecret string, now time.Time) (*PollAttachAuthorizationResponse, error) {
+	auth, err := s.loadActiveAttachAuthorization(ctx, id, now)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyAttachAuthorizationClientSecret(auth.clientSecretHash, clientSecret); err != nil {
+		return nil, err
+	}
+	return &PollAttachAuthorizationResponse{Approved: auth.approvedBy != nil}, nil
+}
+
+func (s *indexedDBSessionStore) consumeAttachAuthorization(ctx context.Context, id, clientSecret, requestHash string, now time.Time) (*principal.Principal, error) {
+	tx, err := s.db.Transaction(ctx, []string{indexedDBAuthStore}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "open provider dev attach authorization consume transaction: %v", err)
+	}
+	committed := false
+	defer abortIfUncommitted(ctx, tx, &committed)
+	store := tx.ObjectStore(indexedDBAuthStore)
+	auth, err := s.attachAuthorizationFromStore(ctx, store, id, now)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyAttachAuthorizationClientSecret(auth.clientSecretHash, clientSecret); err != nil {
+		return nil, err
+	}
+	if auth.approvedBy == nil {
+		return nil, status.Error(codes.FailedPrecondition, "provider dev attach authorization is not approved")
+	}
+	if subtle.ConstantTimeCompare([]byte(requestHash), []byte(auth.requestHash)) != 1 {
+		return nil, status.Error(codes.PermissionDenied, "provider dev attach authorization request does not match")
+	}
+	auth.used = true
+	rec, err := attachAuthorizationToRecord(*auth)
+	if err != nil {
+		return nil, err
+	}
+	if err := store.Put(ctx, rec); err != nil {
+		return nil, status.Errorf(codes.Internal, "consume provider dev attach authorization: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, status.Errorf(codes.Internal, "commit provider dev attach authorization consume: %v", err)
+	}
+	committed = true
+	return clonePrincipal(auth.approvedBy), nil
+}
+
+func (s *indexedDBSessionStore) poll(ctx context.Context, id, dispatcherSecret string) (*PollResponse, bool, error) {
+	nextHeartbeat := time.Time{}
+	for {
+		now := time.Now()
+		heartbeat := nextHeartbeat.IsZero() || !now.Before(nextHeartbeat)
+		resp, ok, err := s.claimCall(ctx, id, dispatcherSecret, now, heartbeat)
+		if err != nil || ok {
+			return resp, ok, err
+		}
+		if heartbeat {
+			nextHeartbeat = now.Add(DefaultSessionIdleTimeout / 4)
+		}
+		timer := time.NewTimer(100 * time.Millisecond)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) {
+				return nil, false, nil
+			}
+			return nil, false, ctx.Err()
+		}
+	}
+}
+
+func (s *indexedDBSessionStore) claimCall(ctx context.Context, id, dispatcherSecret string, now time.Time, heartbeat bool) (*PollResponse, bool, error) {
+	tx, err := s.db.Transaction(ctx, []string{indexedDBAttachmentStore, indexedDBCallStore}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return nil, false, status.Errorf(codes.Internal, "open provider dev poll transaction: %v", err)
+	}
+	committed := false
+	defer abortIfUncommitted(ctx, tx, &committed)
+
+	attachments := tx.ObjectStore(indexedDBAttachmentStore)
+	calls := tx.ObjectStore(indexedDBCallStore)
+	session, err := s.attachmentFromStore(ctx, attachments, id, now)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := verifyStoredDispatcherSecret(session, dispatcherSecret); err != nil {
+		return nil, false, err
+	}
+	touched := false
+	touchSession := func() error {
+		if touched {
+			return nil
+		}
+		rec, err := attachmentToRecord(session)
+		if err != nil {
+			return err
+		}
+		rec["last_seen_at"] = unixNano(now)
+		if err := attachments.Put(ctx, rec); err != nil {
+			return status.Errorf(codes.Internal, "touch provider dev attachment: %v", err)
+		}
+		touched = true
+		return nil
+	}
+	if heartbeat {
+		if err := touchSession(); err != nil {
+			return nil, false, err
+		}
+	}
+
+	callRecords, err := calls.Index("by_attachment_state").GetAll(ctx, nil, id, indexedDBCallStatePending)
+	if err != nil {
+		return nil, false, status.Errorf(codes.Internal, "list provider dev calls: %v", err)
+	}
+	var claim *indexedDBCallRecord
+	for _, raw := range callRecords {
+		call, err := callFromRecord(raw)
+		if err != nil {
+			return nil, false, err
+		}
+		if call.attachmentID != id || call.state != indexedDBCallStatePending {
+			continue
+		}
+		if !call.expiresAt.IsZero() && now.After(call.expiresAt) {
+			call.state = indexedDBCallStateClosed
+			call.errorCode = codes.DeadlineExceeded
+			call.errorMessage = "provider dev call expired before dispatch"
+			if err := calls.Put(ctx, callToRecord(call)); err != nil {
+				return nil, false, status.Errorf(codes.Internal, "expire provider dev call: %v", err)
+			}
+			continue
+		}
+		if claim == nil || call.createdAt.Before(claim.createdAt) {
+			copy := call
+			claim = &copy
+		}
+	}
+	if claim == nil {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, false, status.Errorf(codes.Internal, "commit provider dev poll heartbeat: %v", err)
+		}
+		committed = true
+		return nil, false, nil
+	}
+	claim.state = indexedDBCallStateLeased
+	claim.leasedAt = now
+	if err := touchSession(); err != nil {
+		return nil, false, err
+	}
+	if err := calls.Put(ctx, callToRecord(*claim)); err != nil {
+		return nil, false, status.Errorf(codes.Internal, "claim provider dev call: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, false, status.Errorf(codes.Internal, "commit provider dev poll: %v", err)
+	}
+	committed = true
+	return &PollResponse{
+		CallID:        claim.id,
+		Provider:      claim.provider,
+		Method:        claim.method,
+		RequestBase64: base64.StdEncoding.EncodeToString(claim.request),
+	}, true, nil
+}
+
+func (s *indexedDBSessionStore) completeCall(ctx context.Context, attachmentID, callID, dispatcherSecret string, req CompleteCallRequest) error {
+	attachmentID = strings.TrimSpace(attachmentID)
+	callID = strings.TrimSpace(callID)
+	if callID == "" {
+		return status.Error(codes.InvalidArgument, "call id is required")
+	}
+	tx, err := s.db.Transaction(ctx, []string{indexedDBAttachmentStore, indexedDBCallStore}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return status.Errorf(codes.Internal, "open provider dev completion transaction: %v", err)
+	}
+	committed := false
+	defer abortIfUncommitted(ctx, tx, &committed)
+
+	attachments := tx.ObjectStore(indexedDBAttachmentStore)
+	calls := tx.ObjectStore(indexedDBCallStore)
+	session, err := s.attachmentFromStore(ctx, attachments, attachmentID, time.Now())
+	if err != nil {
+		return err
+	}
+	if err := verifyStoredDispatcherSecret(session, dispatcherSecret); err != nil {
+		return err
+	}
+	raw, err := calls.Get(ctx, callID)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return status.Errorf(codes.NotFound, "provider dev call %q not found", callID)
+		}
+		return status.Errorf(codes.Internal, "load provider dev call: %v", err)
+	}
+	call, err := callFromRecord(raw)
+	if err != nil {
+		return err
+	}
+	if call.attachmentID != attachmentID {
+		return status.Errorf(codes.NotFound, "provider dev call %q not found", callID)
+	}
+	if call.state != indexedDBCallStateLeased && call.state != indexedDBCallStatePending {
+		return status.Errorf(codes.FailedPrecondition, "provider dev call %q is already completed", callID)
+	}
+
+	switch {
+	case req.Error != nil:
+		call.state = indexedDBCallStateFailed
+		call.errorCode = codes.Code(req.Error.Code)
+		call.errorMessage = req.Error.Message
+		if call.errorCode == codes.OK {
+			call.errorCode = codes.InvalidArgument
+			call.errorMessage = "provider dev error code must be non-OK"
+		}
+	case req.ResponseBase64 != "":
+		payload, err := base64.StdEncoding.DecodeString(req.ResponseBase64)
+		if err != nil {
+			call.state = indexedDBCallStateFailed
+			call.errorCode = codes.InvalidArgument
+			call.errorMessage = fmt.Sprintf("decode provider dev response: %v", err)
+		} else {
+			call.state = indexedDBCallStateComplete
+			call.response = payload
+		}
+	default:
+		call.state = indexedDBCallStateComplete
+	}
+	call.completedAt = time.Now()
+	if err := calls.Put(ctx, callToRecord(call)); err != nil {
+		return status.Errorf(codes.Internal, "record provider dev call completion: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return status.Errorf(codes.Internal, "commit provider dev call completion: %v", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *indexedDBSessionStore) verifyDispatcherSecret(ctx context.Context, id, dispatcherSecret string) error {
+	session, err := s.getActiveAttachment(ctx, id, time.Now())
+	if err != nil {
+		return err
+	}
+	return verifyStoredDispatcherSecret(session, dispatcherSecret)
+}
+
+func (s *indexedDBSessionStore) closeSessionWithDispatcherSecret(ctx context.Context, id, dispatcherSecret string) error {
+	session, err := s.getActiveAttachment(ctx, id, time.Now())
+	if err != nil {
+		return err
+	}
+	if err := verifyStoredDispatcherSecret(session, dispatcherSecret); err != nil {
+		return err
+	}
+	return s.closeAttachment(ctx, id, session.owner)
+}
+
+func (s *indexedDBSessionStore) closeSession(ctx context.Context, owner, id string) error {
+	session, err := s.getActiveAttachment(ctx, id, time.Now())
+	if err != nil {
+		return err
+	}
+	if session.owner != owner {
+		return status.Error(codes.PermissionDenied, "provider dev session belongs to another principal")
+	}
+	return s.closeAttachment(ctx, id, owner)
+}
+
+func (s *indexedDBSessionStore) closeAttachment(ctx context.Context, id, owner string) error {
+	tx, err := s.db.Transaction(ctx, []string{indexedDBAttachmentStore, indexedDBCallStore}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return status.Errorf(codes.Internal, "open provider dev close transaction: %v", err)
+	}
+	committed := false
+	defer abortIfUncommitted(ctx, tx, &committed)
+
+	attachments := tx.ObjectStore(indexedDBAttachmentStore)
+	calls := tx.ObjectStore(indexedDBCallStore)
+	session, err := s.attachmentFromStore(ctx, attachments, id, time.Now())
+	if err != nil {
+		return err
+	}
+	if session.owner != owner {
+		return status.Error(codes.PermissionDenied, "provider dev session belongs to another principal")
+	}
+	session.closed = true
+	session.closedAt = time.Now()
+	rec, err := attachmentToRecord(session)
+	if err != nil {
+		return err
+	}
+	if err := attachments.Put(ctx, rec); err != nil {
+		return status.Errorf(codes.Internal, "close provider dev attachment: %v", err)
+	}
+	callRecords, err := calls.Index("by_attachment").GetAll(ctx, nil, id)
+	if err != nil {
+		return status.Errorf(codes.Internal, "list provider dev calls: %v", err)
+	}
+	for _, raw := range callRecords {
+		call, err := callFromRecord(raw)
+		if err != nil {
+			return err
+		}
+		if call.attachmentID != id || call.state == indexedDBCallStateComplete || call.state == indexedDBCallStateFailed || call.state == indexedDBCallStateClosed {
+			continue
+		}
+		call.state = indexedDBCallStateClosed
+		call.errorCode = codes.Unavailable
+		call.errorMessage = "provider dev session closed"
+		call.completedAt = time.Now()
+		if err := calls.Put(ctx, callToRecord(call)); err != nil {
+			return status.Errorf(codes.Internal, "close provider dev call: %v", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return status.Errorf(codes.Internal, "commit provider dev close: %v", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *indexedDBSessionStore) listSessions(ctx context.Context, owner string) ([]AttachmentInfo, error) {
+	_ = s.cleanupExpired(ctx, time.Now())
+	records, err := s.db.ObjectStore(indexedDBAttachmentStore).Index("by_owner").GetAll(ctx, nil, owner)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list provider dev attachments: %v", err)
+	}
+	now := time.Now()
+	out := make([]AttachmentInfo, 0, len(records))
+	for _, raw := range records {
+		session, err := sessionFromRecord(raw)
+		if err != nil {
+			return nil, err
+		}
+		if session.owner != owner || !attachmentActive(session, now) {
+			continue
+		}
+		out = append(out, session.attachmentInfo())
+	}
+	slices.SortFunc(out, func(a, b AttachmentInfo) int {
+		switch {
+		case a.CreatedAt.Before(b.CreatedAt):
+			return -1
+		case a.CreatedAt.After(b.CreatedAt):
+			return 1
+		case a.AttachID < b.AttachID:
+			return -1
+		case a.AttachID > b.AttachID:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return out, nil
+}
+
+func (s *indexedDBSessionStore) getSession(ctx context.Context, owner, id string) (*AttachmentInfo, error) {
+	session, err := s.getActiveAttachment(ctx, id, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	if session.owner != owner {
+		return nil, status.Error(codes.PermissionDenied, "provider dev session belongs to another principal")
+	}
+	info := session.attachmentInfo()
+	return &info, nil
+}
+
+func (s *indexedDBSessionStore) latestTarget(ctx context.Context, owner, providerName string) (*indexedDBSessionRecord, Target, bool, error) {
+	_ = s.cleanupExpired(ctx, time.Now())
+	records, err := s.db.ObjectStore(indexedDBAttachmentStore).Index("by_owner").GetAll(ctx, nil, owner)
+	if err != nil {
+		return nil, Target{}, false, status.Errorf(codes.Internal, "list provider dev attachments: %v", err)
+	}
+	now := time.Now()
+	var latest *indexedDBSessionRecord
+	var latestTarget Target
+	for _, raw := range records {
+		session, err := sessionFromRecord(raw)
+		if err != nil {
+			return nil, Target{}, false, err
+		}
+		if session.owner != owner || !attachmentActive(session, now) {
+			continue
+		}
+		for i := range session.targets {
+			target := &session.targets[i]
+			if target.Name != providerName {
+				continue
+			}
+			if latest == nil || session.createdAt.After(latest.createdAt) || (session.createdAt.Equal(latest.createdAt) && session.id > latest.id) {
+				copySession := session
+				latest = &copySession
+				latestTarget = target.target()
+			}
+		}
+	}
+	if latest == nil {
+		return nil, Target{}, false, nil
+	}
+	return latest, latestTarget, true, nil
+}
+
+func (s *indexedDBSessionStore) getActiveAttachment(ctx context.Context, id string, now time.Time) (*indexedDBSessionRecord, error) {
+	raw, err := s.db.ObjectStore(indexedDBAttachmentStore).Get(ctx, strings.TrimSpace(id))
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "provider dev session %q not found", id)
+		}
+		return nil, status.Errorf(codes.Internal, "load provider dev attachment: %v", err)
+	}
+	session, err := sessionFromRecord(raw)
+	if err != nil {
+		return nil, err
+	}
+	if !attachmentActive(session, now) {
+		return nil, status.Errorf(codes.NotFound, "provider dev session %q not found", id)
+	}
+	return &session, nil
+}
+
+func (s *indexedDBSessionStore) sessionActive(ctx context.Context, id string, now time.Time) (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return false, nil
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	raw, err := s.db.ObjectStore(indexedDBAttachmentStore).Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return false, nil
+		}
+		return false, status.Errorf(codes.Internal, "load provider dev attachment: %v", err)
+	}
+	session, err := sessionFromRecord(raw)
+	if err != nil {
+		return false, err
+	}
+	return attachmentActive(session, now), nil
+}
+
+func (s *indexedDBSessionStore) attachmentFromStore(ctx context.Context, attachments indexeddb.TransactionObjectStore, id string, now time.Time) (*indexedDBSessionRecord, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, status.Error(codes.InvalidArgument, "session id is required")
+	}
+	raw, err := attachments.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "provider dev session %q not found", id)
+		}
+		return nil, status.Errorf(codes.Internal, "load provider dev attachment: %v", err)
+	}
+	session, err := sessionFromRecord(raw)
+	if err != nil {
+		return nil, err
+	}
+	if !attachmentActive(session, now) {
+		return nil, status.Errorf(codes.NotFound, "provider dev session %q not found", id)
+	}
+	return &session, nil
+}
+
+func attachmentActive(session indexedDBSessionRecord, now time.Time) bool {
+	if session.closed {
+		return false
+	}
+	return session.lastSeenAt.IsZero() || now.Sub(session.lastSeenAt) <= DefaultSessionIdleTimeout
+}
+
+func (s *indexedDBSessionStore) enqueueCall(ctx context.Context, attachmentID, owner, providerName, method string, payload []byte) (string, error) {
+	callID, err := randomID()
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "create provider dev call: %v", err)
+	}
+	now := time.Now()
+	tx, err := s.db.Transaction(ctx, []string{indexedDBAttachmentStore, indexedDBCallStore}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "open provider dev call transaction: %v", err)
+	}
+	committed := false
+	defer abortIfUncommitted(ctx, tx, &committed)
+
+	attachments := tx.ObjectStore(indexedDBAttachmentStore)
+	calls := tx.ObjectStore(indexedDBCallStore)
+	session, err := s.attachmentFromStore(ctx, attachments, attachmentID, now)
+	if err != nil {
+		return "", err
+	}
+	if session.owner != owner {
+		return "", status.Error(codes.PermissionDenied, "provider dev session belongs to another principal")
+	}
+	call := indexedDBCallRecord{
+		id:           callID,
+		attachmentID: attachmentID,
+		owner:        owner,
+		provider:     providerName,
+		method:       method,
+		request:      slices.Clone(payload),
+		state:        indexedDBCallStatePending,
+		createdAt:    now,
+		expiresAt:    now.Add(DefaultCallIdleTimeout),
+	}
+	if err := calls.Add(ctx, callToRecord(call)); err != nil {
+		return "", status.Errorf(codes.Internal, "record provider dev call: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return "", status.Errorf(codes.Internal, "commit provider dev call: %v", err)
+	}
+	committed = true
+	return callID, nil
+}
+
+func (s *indexedDBSessionStore) waitCall(ctx context.Context, attachmentID, callID string) ([]byte, error) {
+	for {
+		raw, err := s.db.ObjectStore(indexedDBCallStore).Get(ctx, callID)
+		if err != nil {
+			if errors.Is(err, indexeddb.ErrNotFound) {
+				return nil, status.Errorf(codes.NotFound, "provider dev call %q not found", callID)
+			}
+			return nil, status.Errorf(codes.Internal, "load provider dev call: %v", err)
+		}
+		call, err := callFromRecord(raw)
+		if err != nil {
+			return nil, err
+		}
+		if call.attachmentID != attachmentID {
+			return nil, status.Errorf(codes.NotFound, "provider dev call %q not found", callID)
+		}
+		switch call.state {
+		case indexedDBCallStateComplete:
+			return call.response, nil
+		case indexedDBCallStateFailed, indexedDBCallStateClosed:
+			if call.errorCode == codes.OK {
+				call.errorCode = codes.Unavailable
+			}
+			if call.errorMessage == "" {
+				call.errorMessage = "provider dev call failed"
+			}
+			return nil, status.Error(call.errorCode, call.errorMessage)
+		}
+		if !call.expiresAt.IsZero() && time.Now().After(call.expiresAt) {
+			_ = s.cancelCall(context.Background(), attachmentID, callID, codes.DeadlineExceeded, "provider dev call timed out")
+			return nil, status.Error(codes.DeadlineExceeded, "provider dev call timed out")
+		}
+		timer := time.NewTimer(100 * time.Millisecond)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			_ = s.cancelCall(context.Background(), attachmentID, callID, status.Code(ctx.Err()), ctx.Err().Error())
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (s *indexedDBSessionStore) cancelCall(ctx context.Context, attachmentID, callID string, code codes.Code, message string) error {
+	tx, err := s.db.Transaction(ctx, []string{indexedDBCallStore}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer abortIfUncommitted(ctx, tx, &committed)
+	calls := tx.ObjectStore(indexedDBCallStore)
+	raw, err := calls.Get(ctx, callID)
+	if err != nil {
+		return err
+	}
+	call, err := callFromRecord(raw)
+	if err != nil {
+		return err
+	}
+	if call.attachmentID != attachmentID || !callOpen(call.state) {
+		return nil
+	}
+	call.state = indexedDBCallStateClosed
+	call.errorCode = code
+	call.errorMessage = message
+	call.completedAt = time.Now()
+	if err := calls.Put(ctx, callToRecord(call)); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+func (s *indexedDBSessionStore) cleanupExpired(ctx context.Context, now time.Time) error {
+	if s == nil {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	tx, err := s.db.Transaction(ctx, []string{indexedDBAttachmentStore, indexedDBCallStore, indexedDBAuthStore}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer abortIfUncommitted(ctx, tx, &committed)
+
+	attachments := tx.ObjectStore(indexedDBAttachmentStore)
+	calls := tx.ObjectStore(indexedDBCallStore)
+	auths := tx.ObjectStore(indexedDBAuthStore)
+
+	callRecords, err := calls.GetAll(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for _, raw := range callRecords {
+		call, err := callFromRecord(raw)
+		if err != nil {
+			return err
+		}
+		switch {
+		case callOpen(call.state) && !call.expiresAt.IsZero() && now.After(call.expiresAt):
+			call.state = indexedDBCallStateClosed
+			call.errorCode = codes.DeadlineExceeded
+			call.errorMessage = "provider dev call timed out"
+			call.completedAt = now
+			if err := calls.Put(ctx, callToRecord(call)); err != nil {
+				return err
+			}
+		case !call.completedAt.IsZero() && now.Sub(call.completedAt) > DefaultSessionIdleTimeout:
+			if err := calls.Delete(ctx, call.id); err != nil {
+				return err
+			}
+		}
+	}
+
+	attachmentRecords, err := attachments.GetAll(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for _, raw := range attachmentRecords {
+		session, err := sessionFromRecord(raw)
+		if err != nil {
+			return err
+		}
+		idleExpired := !session.lastSeenAt.IsZero() && now.Sub(session.lastSeenAt) > DefaultSessionIdleTimeout
+		closedExpired := session.closed && (session.closedAt.IsZero() || now.Sub(session.closedAt) > DefaultSessionIdleTimeout)
+		if !closedExpired && !idleExpired {
+			continue
+		}
+		if err := attachments.Delete(ctx, session.id); err != nil {
+			return err
+		}
+		records, err := calls.Index("by_attachment").GetAll(ctx, nil, session.id)
+		if err != nil {
+			return err
+		}
+		for _, rawCall := range records {
+			call, err := callFromRecord(rawCall)
+			if err != nil {
+				return err
+			}
+			if callOpen(call.state) {
+				call.state = indexedDBCallStateClosed
+				call.errorCode = codes.Unavailable
+				call.errorMessage = "provider dev session expired"
+				call.completedAt = now
+				if err := calls.Put(ctx, callToRecord(call)); err != nil {
+					return err
+				}
+				continue
+			}
+			if !call.completedAt.IsZero() && now.Sub(call.completedAt) > DefaultSessionIdleTimeout {
+				if err := calls.Delete(ctx, call.id); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	authRecords, err := auths.GetAll(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for _, raw := range authRecords {
+		auth, err := attachAuthorizationFromRecord(raw)
+		if err != nil {
+			return err
+		}
+		if auth.used || (!auth.expiresAt.IsZero() && now.After(auth.expiresAt)) {
+			if err := auths.Delete(ctx, auth.id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+func (s *sharedSession) invoke(ctx context.Context, providerName, method string, req gproto.Message, resp gproto.Message) error {
+	if s == nil || s.store == nil {
+		return status.Error(codes.Unavailable, "provider dev session is unavailable")
+	}
+	payload, err := gproto.Marshal(req)
+	if err != nil {
+		return status.Errorf(codes.Internal, "marshal provider dev request: %v", err)
+	}
+	result, err := s.invokeRaw(ctx, providerName, method, payload)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return nil
+	}
+	if err := gproto.Unmarshal(result, resp); err != nil {
+		return status.Errorf(codes.Internal, "unmarshal provider dev response: %v", err)
+	}
+	return nil
+}
+
+func (s *sharedSession) serveUIAsset(ctx context.Context, providerName string, req UIAssetRequest) (*UIAssetResponse, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "marshal provider dev ui request: %v", err)
+	}
+	result, err := s.invokeRaw(ctx, providerName, "ServeUIAsset", payload)
+	if err != nil {
+		return nil, err
+	}
+	var resp UIAssetResponse
+	if err := json.Unmarshal(result, &resp); err != nil {
+		return nil, status.Errorf(codes.Internal, "unmarshal provider dev ui response: %v", err)
+	}
+	return &resp, nil
+}
+
+func (s *sharedSession) invokeRaw(ctx context.Context, providerName, method string, payload []byte) ([]byte, error) {
+	callID, err := s.store.enqueueCall(ctx, s.id, s.owner, providerName, method, payload)
+	if err != nil {
+		return nil, err
+	}
+	return s.store.waitCall(ctx, s.id, callID)
+}
+
+func (m *Manager) VerifyHostServiceSession(ctx context.Context, providerName, sessionID string) error {
+	if m == nil || m.shared == nil {
+		return status.Error(codes.FailedPrecondition, "provider dev indexeddb attachment state is not configured")
+	}
+	session, err := m.shared.getActiveAttachment(ctx, sessionID, time.Now())
+	if err != nil {
+		return err
+	}
+	providerName = strings.TrimSpace(providerName)
+	for i := range session.targets {
+		target := &session.targets[i]
+		if target.Name == providerName {
+			return nil
+		}
+	}
+	return status.Errorf(codes.NotFound, "provider dev session %q does not include provider %q", sessionID, providerName)
+}
+
+func (r indexedDBSessionRecord) attachmentInfo() AttachmentInfo {
+	providers := make([]AttachmentProviderInfo, 0, len(r.targets))
+	for i := range r.targets {
+		target := &r.targets[i]
+		providers = append(providers, AttachmentProviderInfo{
+			Name:   target.Name,
+			Source: target.Source,
+			UI:     target.UI,
+			UIPath: target.UIPath,
+		})
+	}
+	slices.SortFunc(providers, func(a, b AttachmentProviderInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return AttachmentInfo{
+		AttachID:           r.id,
+		CreatedAt:          r.createdAt,
+		LastSeenAt:         r.lastSeenAt,
+		IdleTimeoutSeconds: int(DefaultSessionIdleTimeout / time.Second),
+		Providers:          providers,
+	}
+}
+
+func (t storedTarget) target() Target {
+	return Target{
+		Name:      t.Name,
+		Source:    t.Source,
+		Spec:      t.Spec,
+		Config:    cloneAnyMap(t.Config),
+		ConfigSet: t.ConfigSet,
+		UI:        t.UI,
+		UIPath:    t.UIPath,
+	}
+}
+
+func verifyStoredDispatcherSecret(session *indexedDBSessionRecord, secret string) error {
+	if session == nil {
+		return status.Error(codes.NotFound, "provider dev session not found")
+	}
+	secret = strings.TrimSpace(secret)
+	if secret == "" || session.dispatcherSecretHash == "" {
+		return status.Error(codes.Unauthenticated, "provider dev dispatcher secret is required")
+	}
+	if subtle.ConstantTimeCompare([]byte(hashDispatcherSecret(secret)), []byte(session.dispatcherSecretHash)) == 1 {
+		return nil
+	}
+	return status.Error(codes.PermissionDenied, "provider dev dispatcher secret is invalid")
+}
+
+func verifyAttachAuthorizationClientSecret(hash, secret string) error {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return status.Error(codes.Unauthenticated, "provider dev attach authorization secret is required")
+	}
+	if subtle.ConstantTimeCompare([]byte(hashAttachAuthorizationSecret(secret)), []byte(hash)) != 1 {
+		return status.Error(codes.PermissionDenied, "provider dev attach authorization secret is invalid")
+	}
+	return nil
+}
+
+func (s *indexedDBSessionStore) loadActiveAttachAuthorization(ctx context.Context, id string, now time.Time) (*indexedDBAttachAuthorizationRecord, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, status.Error(codes.InvalidArgument, "provider dev attach authorization id is required")
+	}
+	raw, err := s.db.ObjectStore(indexedDBAuthStore).Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "provider dev attach authorization %q not found", id)
+		}
+		return nil, status.Errorf(codes.Internal, "load provider dev attach authorization: %v", err)
+	}
+	auth, err := attachAuthorizationFromRecord(raw)
+	if err != nil {
+		return nil, err
+	}
+	if auth.used {
+		return nil, status.Errorf(codes.NotFound, "provider dev attach authorization %q not found", id)
+	}
+	if !auth.expiresAt.IsZero() && now.After(auth.expiresAt) {
+		_ = s.db.ObjectStore(indexedDBAuthStore).Delete(ctx, id)
+		return nil, status.Error(codes.DeadlineExceeded, "provider dev attach authorization expired")
+	}
+	return &auth, nil
+}
+
+func (s *indexedDBSessionStore) attachAuthorizationFromStore(ctx context.Context, store indexeddb.TransactionObjectStore, id string, now time.Time) (*indexedDBAttachAuthorizationRecord, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, status.Error(codes.InvalidArgument, "provider dev attach authorization id is required")
+	}
+	raw, err := store.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "provider dev attach authorization %q not found", id)
+		}
+		return nil, status.Errorf(codes.Internal, "load provider dev attach authorization: %v", err)
+	}
+	auth, err := attachAuthorizationFromRecord(raw)
+	if err != nil {
+		return nil, err
+	}
+	if auth.used {
+		return nil, status.Errorf(codes.NotFound, "provider dev attach authorization %q not found", id)
+	}
+	if !auth.expiresAt.IsZero() && now.After(auth.expiresAt) {
+		_ = store.Delete(ctx, id)
+		return nil, status.Error(codes.DeadlineExceeded, "provider dev attach authorization expired")
+	}
+	return &auth, nil
+}
+
+func (a indexedDBAttachAuthorizationRecord) info() AttachAuthorizationInfo {
+	return AttachAuthorizationInfo{
+		AuthorizationID: a.id,
+		Providers:       slices.Clone(a.providers),
+		ExpiresAt:       a.expiresAt,
+	}
+}
+
+func sessionFromRecord(rec indexeddb.Record) (indexedDBSessionRecord, error) {
+	targetsJSON := recordString(rec, "targets_json")
+	var targets []storedTarget
+	if targetsJSON != "" {
+		if err := json.Unmarshal([]byte(targetsJSON), &targets); err != nil {
+			return indexedDBSessionRecord{}, status.Errorf(codes.Internal, "decode provider dev attachment targets: %v", err)
+		}
+	}
+	return indexedDBSessionRecord{
+		id:                   recordString(rec, "id"),
+		owner:                recordString(rec, "owner"),
+		dispatcherSecretHash: recordString(rec, "dispatcher_secret_hash"),
+		targets:              targets,
+		createdAt:            timeFromUnixNano(recordInt64(rec, "created_at")),
+		lastSeenAt:           timeFromUnixNano(recordInt64(rec, "last_seen_at")),
+		closed:               recordBool(rec, "closed"),
+		closedAt:             timeFromUnixNano(recordInt64(rec, "closed_at")),
+	}, nil
+}
+
+func attachmentToRecord(session *indexedDBSessionRecord) (indexeddb.Record, error) {
+	targetsJSON, err := json.Marshal(session.targets)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "encode provider dev attachment targets: %v", err)
+	}
+	return indexeddb.Record{
+		"id":                     session.id,
+		"owner":                  session.owner,
+		"dispatcher_secret_hash": session.dispatcherSecretHash,
+		"targets_json":           string(targetsJSON),
+		"created_at":             unixNano(session.createdAt),
+		"last_seen_at":           unixNano(session.lastSeenAt),
+		"closed":                 session.closed,
+		"closed_at":              unixNano(session.closedAt),
+	}, nil
+}
+
+func attachAuthorizationFromRecord(rec indexeddb.Record) (indexedDBAttachAuthorizationRecord, error) {
+	var providers []string
+	if value := recordString(rec, "providers_json"); value != "" {
+		if err := json.Unmarshal([]byte(value), &providers); err != nil {
+			return indexedDBAttachAuthorizationRecord{}, status.Errorf(codes.Internal, "decode provider dev attach authorization providers: %v", err)
+		}
+	}
+	var approvedBy *principal.Principal
+	if value := recordString(rec, "approved_by_json"); value != "" {
+		var p principal.Principal
+		if err := json.Unmarshal([]byte(value), &p); err != nil {
+			return indexedDBAttachAuthorizationRecord{}, status.Errorf(codes.Internal, "decode provider dev attach authorization principal: %v", err)
+		}
+		approvedBy = &p
+	}
+	return indexedDBAttachAuthorizationRecord{
+		id:               recordString(rec, "id"),
+		clientSecretHash: recordString(rec, "client_secret_hash"),
+		verificationHash: recordString(rec, "verification_hash"),
+		requestHash:      recordString(rec, "request_hash"),
+		providers:        providers,
+		expiresAt:        timeFromUnixNano(recordInt64(rec, "expires_at")),
+		approvedBy:       approvedBy,
+		used:             recordBool(rec, "used"),
+		createdAt:        timeFromUnixNano(recordInt64(rec, "created_at")),
+	}, nil
+}
+
+func attachAuthorizationToRecord(auth indexedDBAttachAuthorizationRecord) (indexeddb.Record, error) {
+	providersJSON, err := json.Marshal(auth.providers)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "encode provider dev attach authorization providers: %v", err)
+	}
+	approvedByJSON := ""
+	if auth.approvedBy != nil {
+		payload, err := json.Marshal(auth.approvedBy)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "encode provider dev attach authorization principal: %v", err)
+		}
+		approvedByJSON = string(payload)
+	}
+	return indexeddb.Record{
+		"id":                 auth.id,
+		"client_secret_hash": auth.clientSecretHash,
+		"verification_hash":  auth.verificationHash,
+		"request_hash":       auth.requestHash,
+		"providers_json":     string(providersJSON),
+		"approved_by_json":   approvedByJSON,
+		"used":               auth.used,
+		"created_at":         unixNano(auth.createdAt),
+		"expires_at":         unixNano(auth.expiresAt),
+	}, nil
+}
+
+func callFromRecord(rec indexeddb.Record) (indexedDBCallRecord, error) {
+	request, err := base64.StdEncoding.DecodeString(recordString(rec, "request_base64"))
+	if err != nil {
+		return indexedDBCallRecord{}, status.Errorf(codes.Internal, "decode provider dev call request: %v", err)
+	}
+	var response []byte
+	if value := recordString(rec, "response_base64"); value != "" {
+		response, err = base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return indexedDBCallRecord{}, status.Errorf(codes.Internal, "decode provider dev call response: %v", err)
+		}
+	}
+	return indexedDBCallRecord{
+		id:           recordString(rec, "id"),
+		attachmentID: recordString(rec, "attachment_id"),
+		owner:        recordString(rec, "owner"),
+		provider:     recordString(rec, "provider"),
+		method:       recordString(rec, "method"),
+		request:      request,
+		response:     response,
+		errorCode:    codes.Code(recordInt64(rec, "error_code")),
+		errorMessage: recordString(rec, "error_message"),
+		state:        recordString(rec, "state"),
+		createdAt:    timeFromUnixNano(recordInt64(rec, "created_at")),
+		leasedAt:     timeFromUnixNano(recordInt64(rec, "leased_at")),
+		completedAt:  timeFromUnixNano(recordInt64(rec, "completed_at")),
+		expiresAt:    timeFromUnixNano(recordInt64(rec, "expires_at")),
+	}, nil
+}
+
+func callToRecord(call indexedDBCallRecord) indexeddb.Record {
+	rec := indexeddb.Record{
+		"id":              call.id,
+		"attachment_id":   call.attachmentID,
+		"owner":           call.owner,
+		"provider":        call.provider,
+		"method":          call.method,
+		"request_base64":  base64.StdEncoding.EncodeToString(call.request),
+		"response_base64": base64.StdEncoding.EncodeToString(call.response),
+		"error_code":      int64(call.errorCode),
+		"error_message":   call.errorMessage,
+		"state":           call.state,
+		"created_at":      unixNano(call.createdAt),
+		"leased_at":       unixNano(call.leasedAt),
+		"completed_at":    unixNano(call.completedAt),
+		"expires_at":      unixNano(call.expiresAt),
+	}
+	return rec
+}
+
+func callOpen(state string) bool {
+	return state == indexedDBCallStatePending || state == indexedDBCallStateLeased
+}
+
+func abortIfUncommitted(ctx context.Context, tx indexeddb.Transaction, committed *bool) {
+	if tx == nil || committed == nil || *committed {
+		return
+	}
+	_ = tx.Abort(ctx)
+}
+
+func recordString(rec indexeddb.Record, key string) string {
+	switch v := rec[key].(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}
+
+func recordBool(rec indexeddb.Record, key string) bool {
+	switch v := rec[key].(type) {
+	case bool:
+		return v
+	case string:
+		return strings.EqualFold(strings.TrimSpace(v), "true")
+	default:
+		return false
+	}
+}
+
+func recordInt64(rec indexeddb.Record, key string) int64 {
+	switch v := rec[key].(type) {
+	case int:
+		return int64(v)
+	case int32:
+		return int64(v)
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	case json.Number:
+		n, _ := v.Int64()
+		return n
+	default:
+		return 0
+	}
+}
+
+func unixNano(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UTC().UnixNano()
+}
+
+func timeFromUnixNano(v int64) time.Time {
+	if v == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, v).UTC()
+}

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -58,6 +58,7 @@ type Target struct {
 	Source     string
 	Spec       pluginservice.StaticProviderSpec
 	Config     map[string]any
+	ConfigSet  bool
 	UI         bool
 	UIPath     string
 	RuntimeEnv RuntimeEnvBuilder
@@ -67,8 +68,13 @@ type Manager struct {
 	mu             sync.RWMutex
 	targets        map[string]Target
 	sessions       map[string]*Session
+	shared         *indexedDBSessionStore
+	sharedTargets  map[string]map[string]*attachedTarget
+	cleanups       []func()
 	authorizations map[string]*AttachAuthorization
 }
+
+type ManagerOption func(*Manager) error
 
 type CreateSessionRequest struct {
 	Providers []AttachProvider `json:"providers"`
@@ -214,10 +220,11 @@ type rpcResponse struct {
 	err     error
 }
 
-func NewManager(targets []Target) (*Manager, error) {
+func NewManager(targets []Target, opts ...ManagerOption) (*Manager, error) {
 	m := &Manager{
 		targets:        make(map[string]Target, len(targets)),
 		sessions:       map[string]*Session{},
+		sharedTargets:  map[string]map[string]*attachedTarget{},
 		authorizations: map[string]*AttachAuthorization{},
 	}
 	for i := range targets {
@@ -229,7 +236,24 @@ func NewManager(targets []Target) (*Manager, error) {
 		target.Name = name
 		m.targets[name] = target
 	}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if err := opt(m); err != nil {
+			return nil, err
+		}
+	}
 	return m, nil
+}
+
+func (m *Manager) AddCleanup(cleanup func()) {
+	if m == nil || cleanup == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cleanups = append(m.cleanups, cleanup)
 }
 
 func (m *Manager) HasTargets() bool {
@@ -271,6 +295,9 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 	dispatcherSecret, dispatcherSecretHash, err := newDispatcherSecret()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "create provider dev dispatcher secret: %v", err)
+	}
+	if m.shared != nil {
+		return m.createSharedSession(ctx, owner, sessionID, dispatcherSecret, dispatcherSecretHash, targets)
 	}
 	session := &Session{
 		id:                   sessionID,
@@ -327,7 +354,61 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 	return resp, nil
 }
 
+func (m *Manager) createSharedSession(ctx context.Context, owner, sessionID, dispatcherSecret, dispatcherSecretHash string, targets []Target) (*CreateSessionResponse, error) {
+	resp := &CreateSessionResponse{
+		AttachID:         sessionID,
+		DispatcherSecret: dispatcherSecret,
+		Providers:        make([]CreateSessionProvider, 0, len(targets)),
+	}
+	var cleanups []func()
+	runCleanups := func() {
+		for _, cleanup := range cleanups {
+			if cleanup != nil {
+				cleanup()
+			}
+		}
+		cleanups = nil
+	}
+	cleanupOnError := true
+	defer func() {
+		if cleanupOnError {
+			runCleanups()
+		}
+	}()
+	for i := range targets {
+		target := targets[i]
+		runtimeEnv := RuntimeEnv{}
+		if target.RuntimeEnv != nil {
+			var err error
+			runtimeEnv, err = target.RuntimeEnv(sessionID)
+			if err != nil {
+				return nil, status.Errorf(codes.FailedPrecondition, "prepare provider %q runtime env: %v", target.Name, err)
+			}
+		}
+		cleanups = append(cleanups, runtimeEnv.Cleanup)
+		targets[i].RuntimeEnv = nil
+		resp.Providers = append(resp.Providers, CreateSessionProvider{
+			Name:   target.Name,
+			Env:    cloneStringMap(runtimeEnv.Env),
+			Source: target.Source,
+			UI:     target.UI,
+			UIPath: target.UIPath,
+		})
+	}
+	if err := m.shared.createSession(ctx, owner, sessionID, dispatcherSecretHash, targets, time.Now()); err != nil {
+		return nil, err
+	}
+	cleanupOnError = false
+	// Shared sessions return durable relay metadata to the local dispatcher. Any
+	// per-replica resources from runtime env synthesis must be released now.
+	runCleanups()
+	return resp, nil
+}
+
 func (m *Manager) PollSessionWithDispatcherSecretOnly(ctx context.Context, sessionID, dispatcherSecret string) (*PollResponse, bool, error) {
+	if m != nil && m.shared != nil {
+		return m.shared.poll(ctx, sessionID, dispatcherSecret)
+	}
 	session, err := m.sessionForDispatcherSecret(sessionID, dispatcherSecret)
 	if err != nil {
 		return nil, false, err
@@ -422,6 +503,20 @@ func (m *Manager) CreateAttachAuthorization(req CreateSessionRequest, now time.T
 	if now.IsZero() {
 		now = time.Now()
 	}
+	if m.shared != nil {
+		info, err := m.shared.createAttachAuthorization(context.Background(), AttachAuthorization{
+			id:               id,
+			clientSecretHash: clientSecretHash,
+			verificationHash: verificationHash,
+			requestHash:      requestHash,
+			providers:        slices.Clone(names),
+			expiresAt:        now.Add(5 * time.Minute),
+		}, now)
+		if err != nil {
+			return nil, "", "", err
+		}
+		return info, clientSecret, verificationCode, nil
+	}
 	auth := &AttachAuthorization{
 		id:               id,
 		clientSecretHash: clientSecretHash,
@@ -443,6 +538,9 @@ func (m *Manager) CreateAttachAuthorization(req CreateSessionRequest, now time.T
 }
 
 func (m *Manager) GetAttachAuthorization(id string) (*AttachAuthorizationInfo, error) {
+	if m != nil && m.shared != nil {
+		return m.shared.getAttachAuthorization(context.Background(), id, time.Now())
+	}
 	auth, err := m.attachAuthorization(id, time.Now())
 	if err != nil {
 		return nil, err
@@ -459,6 +557,9 @@ func (m *Manager) ApproveAttachAuthorization(id string, p *principal.Principal, 
 	verificationCode = normalizeAttachAuthorizationVerificationCode(verificationCode)
 	if verificationCode == "" {
 		return status.Error(codes.InvalidArgument, "provider dev attach verification code is required")
+	}
+	if m != nil && m.shared != nil {
+		return m.shared.approveAttachAuthorization(context.Background(), id, p, verificationCode, time.Now())
 	}
 	auth, err := m.attachAuthorization(id, time.Now())
 	if err != nil {
@@ -483,6 +584,9 @@ func (m *Manager) ApproveAttachAuthorization(id string, p *principal.Principal, 
 }
 
 func (m *Manager) PollAttachAuthorization(id, clientSecret string) (*PollAttachAuthorizationResponse, error) {
+	if m != nil && m.shared != nil {
+		return m.shared.pollAttachAuthorization(context.Background(), id, clientSecret, time.Now())
+	}
 	auth, err := m.attachAuthorizationWithClientSecret(id, clientSecret, time.Now())
 	if err != nil {
 		return nil, err
@@ -495,6 +599,13 @@ func (m *Manager) PollAttachAuthorization(id, clientSecret string) (*PollAttachA
 }
 
 func (m *Manager) ConsumeAttachAuthorization(id, clientSecret string, req CreateSessionRequest) (*principal.Principal, error) {
+	if m != nil && m.shared != nil {
+		requestHash, err := attachAuthorizationRequestHash(req)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "hash provider dev attach authorization request: %v", err)
+		}
+		return m.shared.consumeAttachAuthorization(context.Background(), id, clientSecret, requestHash, time.Now())
+	}
 	auth, err := m.attachAuthorizationWithClientSecret(id, clientSecret, time.Now())
 	if err != nil {
 		return nil, err
@@ -533,6 +644,7 @@ func (m *Manager) resolveAttachTargets(requestedProviders []AttachProvider) ([]T
 		target.Spec = buildAttachSpec(remoteTarget.Spec, requested.Spec)
 		if requested.Config != nil {
 			target.Config = cloneAnyMap(*requested.Config)
+			target.ConfigSet = true
 		}
 		target.UI = requested.UI
 		targets = append(targets, target)
@@ -576,6 +688,9 @@ func (m *Manager) resolveAttachTargetLocked(requested AttachProvider) (Target, e
 }
 
 func (m *Manager) CompleteCallWithDispatcherSecretOnly(sessionID, callID, dispatcherSecret string, req CompleteCallRequest) error {
+	if m != nil && m.shared != nil {
+		return m.shared.completeCall(context.Background(), sessionID, callID, dispatcherSecret, req)
+	}
 	session, err := m.sessionForDispatcherSecret(sessionID, dispatcherSecret)
 	if err != nil {
 		return err
@@ -584,11 +699,20 @@ func (m *Manager) CompleteCallWithDispatcherSecretOnly(sessionID, callID, dispat
 }
 
 func (m *Manager) VerifyDispatcherSecretOnly(sessionID, dispatcherSecret string) error {
+	if m != nil && m.shared != nil {
+		return m.shared.verifyDispatcherSecret(context.Background(), sessionID, dispatcherSecret)
+	}
 	_, err := m.sessionForDispatcherSecret(sessionID, dispatcherSecret)
 	return err
 }
 
 func (m *Manager) CloseSessionWithDispatcherSecret(sessionID, dispatcherSecret string) error {
+	if m != nil && m.shared != nil {
+		if err := m.shared.closeSessionWithDispatcherSecret(context.Background(), sessionID, dispatcherSecret); err != nil {
+			return err
+		}
+		return m.closeSharedTargets(sessionID)
+	}
 	session, err := m.sessionForDispatcherSecret(sessionID, dispatcherSecret)
 	if err != nil {
 		return err
@@ -652,6 +776,10 @@ func (m *Manager) ListSessions(p *principal.Principal) ([]AttachmentInfo, error)
 	if m == nil {
 		return nil, status.Error(codes.FailedPrecondition, "provider dev is not configured")
 	}
+	if m.shared != nil {
+		m.closeInactiveSharedTargets(context.Background(), time.Now())
+		return m.shared.listSessions(context.Background(), owner)
+	}
 	m.closeIdleSessions(time.Now())
 	sessions := m.sessionsForOwner(owner)
 	out := make([]AttachmentInfo, 0, len(sessions))
@@ -665,6 +793,14 @@ func (m *Manager) ListSessions(p *principal.Principal) ([]AttachmentInfo, error)
 }
 
 func (m *Manager) GetSession(p *principal.Principal, sessionID string) (*AttachmentInfo, error) {
+	if m != nil && m.shared != nil {
+		owner := principalSubjectID(p)
+		if owner == "" {
+			return nil, status.Error(codes.Unauthenticated, "provider dev requires an authenticated principal")
+		}
+		m.closeInactiveSharedTargets(context.Background(), time.Now())
+		return m.shared.getSession(context.Background(), owner, sessionID)
+	}
 	session, err := m.sessionForPrincipal(p, sessionID)
 	if err != nil {
 		return nil, err
@@ -674,6 +810,16 @@ func (m *Manager) GetSession(p *principal.Principal, sessionID string) (*Attachm
 }
 
 func (m *Manager) CloseSession(p *principal.Principal, sessionID string) error {
+	if m != nil && m.shared != nil {
+		owner := principalSubjectID(p)
+		if owner == "" {
+			return status.Error(codes.Unauthenticated, "provider dev requires an authenticated principal")
+		}
+		if err := m.shared.closeSession(context.Background(), owner, sessionID); err != nil {
+			return err
+		}
+		return m.closeSharedTargets(sessionID)
+	}
 	session, err := m.sessionForPrincipal(p, sessionID)
 	if err != nil {
 		return err
@@ -698,6 +844,23 @@ func (m *Manager) ResolveProviderOverride(ctx context.Context, p *principal.Prin
 	if providerName == "" {
 		return nil, false, nil
 	}
+	if m.shared != nil {
+		m.closeInactiveSharedTargets(ctx, time.Now())
+		session, target, ok, err := m.shared.latestTarget(ctx, owner, providerName)
+		if err != nil {
+			return nil, false, err
+		}
+		if !ok {
+			return nil, false, nil
+		}
+		target = m.hydrateSharedTarget(target)
+		attached := m.sharedTarget(session.id, target)
+		prov, err := attached.providerForSession(ctx, &sharedSession{id: session.id, owner: owner, store: m.shared}, providerName)
+		if err != nil {
+			return nil, false, err
+		}
+		return prov, true, nil
+	}
 
 	sessions := m.sessionsForOwner(owner)
 
@@ -719,6 +882,28 @@ func (m *Manager) ResolveProviderOverride(ctx context.Context, p *principal.Prin
 	return nil, false, nil
 }
 
+func (m *Manager) hydrateSharedTarget(target Target) Target {
+	if m == nil {
+		return target
+	}
+	m.mu.RLock()
+	base, ok := m.targets[target.Name]
+	m.mu.RUnlock()
+	if !ok {
+		return target
+	}
+	if target.Source == "" {
+		target.Source = base.Source
+	}
+	if target.UIPath == "" {
+		target.UIPath = base.UIPath
+	}
+	if !target.ConfigSet {
+		target.Config = cloneAnyMap(base.Config)
+	}
+	return target
+}
+
 func (m *Manager) ServeUIAsset(ctx context.Context, p *principal.Principal, providerName string, req UIAssetRequest) (*UIAssetResponse, bool, error) {
 	if m == nil {
 		return nil, false, nil
@@ -731,6 +916,24 @@ func (m *Manager) ServeUIAsset(ctx context.Context, p *principal.Principal, prov
 	providerName = strings.TrimSpace(providerName)
 	if providerName == "" {
 		return nil, false, nil
+	}
+	if m.shared != nil {
+		m.closeInactiveSharedTargets(ctx, time.Now())
+		session, target, ok, err := m.shared.latestTarget(ctx, owner, providerName)
+		if err != nil {
+			return nil, false, err
+		}
+		if !ok {
+			return nil, false, nil
+		}
+		if !target.UI {
+			return nil, false, nil
+		}
+		resp, err := (&sharedSession{id: session.id, owner: owner, store: m.shared}).serveUIAsset(ctx, providerName, req)
+		if err != nil {
+			return nil, true, err
+		}
+		return resp, true, nil
 	}
 
 	sessions := m.sessionsForOwner(owner)
@@ -762,15 +965,104 @@ func (m *Manager) Close() error {
 	for _, session := range m.sessions {
 		sessions = append(sessions, session)
 	}
+	sharedTargets := make([]*attachedTarget, 0, len(m.sharedTargets))
+	for _, targets := range m.sharedTargets {
+		for _, target := range targets {
+			sharedTargets = append(sharedTargets, target)
+		}
+	}
 	m.sessions = map[string]*Session{}
+	m.sharedTargets = map[string]map[string]*attachedTarget{}
 	m.authorizations = map[string]*AttachAuthorization{}
+	cleanups := slices.Clone(m.cleanups)
+	m.cleanups = nil
 	m.mu.Unlock()
 
 	var errs []error
 	for _, session := range sessions {
 		errs = append(errs, session.Close())
 	}
+	for _, target := range sharedTargets {
+		errs = append(errs, target.close())
+	}
+	for _, cleanup := range cleanups {
+		if cleanup != nil {
+			cleanup()
+		}
+	}
 	return errors.Join(errs...)
+}
+
+func (m *Manager) sharedTarget(sessionID string, target Target) *attachedTarget {
+	if m == nil {
+		return &attachedTarget{target: target}
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	providerName := strings.TrimSpace(target.Name)
+	if sessionID == "" || providerName == "" {
+		return &attachedTarget{target: target}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sharedTargets == nil {
+		m.sharedTargets = map[string]map[string]*attachedTarget{}
+	}
+	targets := m.sharedTargets[sessionID]
+	if targets == nil {
+		targets = map[string]*attachedTarget{}
+		m.sharedTargets[sessionID] = targets
+	}
+	if existing := targets[providerName]; existing != nil {
+		return existing
+	}
+	target.Name = providerName
+	attached := &attachedTarget{target: target}
+	targets[providerName] = attached
+	return attached
+}
+
+func (m *Manager) closeSharedTargets(sessionID string) error {
+	if m == nil {
+		return nil
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil
+	}
+	m.mu.Lock()
+	targets := m.sharedTargets[sessionID]
+	delete(m.sharedTargets, sessionID)
+	m.mu.Unlock()
+	var errs []error
+	for _, target := range targets {
+		errs = append(errs, target.close())
+	}
+	return errors.Join(errs...)
+}
+
+func (m *Manager) closeInactiveSharedTargets(ctx context.Context, now time.Time) {
+	if m == nil || m.shared == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	m.mu.RLock()
+	sessionIDs := make([]string, 0, len(m.sharedTargets))
+	for sessionID := range m.sharedTargets {
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	m.mu.RUnlock()
+	for _, sessionID := range sessionIDs {
+		active, err := m.shared.sessionActive(ctx, sessionID, now)
+		if err != nil || active {
+			continue
+		}
+		_ = m.closeSharedTargets(sessionID)
+	}
 }
 
 func (m *Manager) closeIdleSessions(now time.Time) {
@@ -1155,7 +1447,11 @@ func (s *Session) invokeRaw(ctx context.Context, providerName, method string, pa
 	}
 }
 
-func (t *attachedTarget) providerForSession(ctx context.Context, session *Session, providerName string) (core.Provider, error) {
+type providerDevSession interface {
+	invoke(ctx context.Context, providerName, method string, req gproto.Message, resp gproto.Message) error
+}
+
+func (t *attachedTarget) providerForSession(ctx context.Context, session providerDevSession, providerName string) (core.Provider, error) {
 	t.providerMu.Lock()
 	defer t.providerMu.Unlock()
 	if t.closed {
@@ -1266,7 +1562,7 @@ func (t *attachedTarget) close() error {
 }
 
 type sessionProviderClient struct {
-	session  *Session
+	session  providerDevSession
 	provider string
 }
 

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -246,6 +246,325 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	}
 }
 
+func TestIndexedDBAttachmentStateDispatchesAcrossManagers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	targets := []Target{{
+		Name: "roadmap",
+		Spec: pluginservice.StaticProviderSpec{
+			Name:           "roadmap",
+			DisplayName:    "Roadmap",
+			ConnectionMode: core.ConnectionModeUser,
+			Catalog: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{{
+					ID:        "echo",
+					Transport: catalog.TransportPlugin,
+				}},
+			},
+		},
+		Config: map[string]any{"remote": true},
+	}}
+	managerA, err := NewManager(targets, WithIndexedDBAttachmentState(ctx, db))
+	if err != nil {
+		t.Fatalf("NewManager A: %v", err)
+	}
+	managerB, err := NewManager(targets, WithIndexedDBAttachmentState(ctx, db))
+	if err != nil {
+		t.Fatalf("NewManager B: %v", err)
+	}
+
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	createTS := httptest.NewServer(providerDevTestHandler(t, managerA, p))
+	t.Cleanup(createTS.Close)
+	dispatchTS := httptest.NewServer(providerDevTestHandler(t, managerB, p))
+	t.Cleanup(dispatchTS.Close)
+
+	createClient := Client{BaseURL: createTS.URL, HTTPClient: createTS.Client()}
+	dispatchClient := Client{BaseURL: dispatchTS.URL, HTTPClient: dispatchTS.Client()}
+	session, err := createClient.CreateSession(context.Background(), CreateSessionRequest{Providers: []AttachProvider{{
+		Name: "roadmap",
+		Spec: pluginservice.StaticProviderSpec{
+			Name: "roadmap",
+			Catalog: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{{
+					ID:        "echo",
+					Transport: catalog.TransportPlugin,
+				}},
+			},
+		},
+	}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	record, err := db.ObjectStore(indexedDBAttachmentStore).Get(ctx, session.AttachID)
+	if err != nil {
+		t.Fatalf("load shared attachment: %v", err)
+	}
+	targetsJSON := fmt.Sprint(record["targets_json"])
+	if strings.Contains(targetsJSON, "remote") {
+		t.Fatalf("shared attachment targets persisted remote config: %s", targetsJSON)
+	}
+	listed, err := dispatchClient.ListAttachments(ctx)
+	if err != nil {
+		t.Fatalf("ListAttachments from second transport: %v", err)
+	}
+	if len(listed) != 1 || listed[0].AttachID != session.AttachID {
+		t.Fatalf("ListAttachments from second transport = %#v, want attachment %q", listed, session.AttachID)
+	}
+	gotInfo, err := dispatchClient.GetAttachment(ctx, session.AttachID)
+	if err != nil {
+		t.Fatalf("GetAttachment from second transport: %v", err)
+	}
+	if gotInfo.AttachID != session.AttachID {
+		t.Fatalf("GetAttachment from second transport = %#v, want %q", gotInfo, session.AttachID)
+	}
+	if err := managerB.VerifyHostServiceSession(context.Background(), "roadmap", session.AttachID); err != nil {
+		t.Fatalf("VerifyHostServiceSession: %v", err)
+	}
+
+	dispatchCtx, dispatchCancel := context.WithCancel(context.Background())
+	defer dispatchCancel()
+	dispatchDone := make(chan error, 1)
+	local := &recordingIntegrationClient{}
+	dispatchClient.DispatcherSecret = session.DispatcherSecret
+	go func() {
+		dispatchDone <- dispatchClient.RunDispatcher(dispatchCtx, session.AttachID, map[string]proto.IntegrationProviderClient{
+			"roadmap": local,
+		})
+	}()
+
+	resolveCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	prov, ok, err := managerB.ResolveProviderOverride(resolveCtx, p, "roadmap")
+	if err != nil {
+		t.Fatalf("ResolveProviderOverride from second manager: %v", err)
+	}
+	if !ok {
+		t.Fatal("ResolveProviderOverride from second manager ok = false, want true")
+	}
+	result, err := prov.Execute(resolveCtx, "echo", map[string]any{"message": "hello"}, "remote-token")
+	if err != nil {
+		t.Fatalf("Execute through shared attachment state: %v", err)
+	}
+	if result.Body != `{"message":"hello","operation":"echo","token":"remote-token"}` {
+		t.Fatalf("Execute body = %s", result.Body)
+	}
+	result, err = prov.Execute(resolveCtx, "echo", map[string]any{"message": "again"}, "remote-token")
+	if err != nil {
+		t.Fatalf("second Execute through shared attachment state: %v", err)
+	}
+	if result.Body != `{"message":"again","operation":"echo","token":"remote-token"}` {
+		t.Fatalf("second Execute body = %s", result.Body)
+	}
+	local.mu.Lock()
+	startCalls := local.startCalls
+	startConfig := fmt.Sprint(local.startConfig)
+	local.mu.Unlock()
+	if startCalls != 1 {
+		t.Fatalf("StartProvider calls = %d, want 1 cached shared provider", startCalls)
+	}
+	if !strings.Contains(startConfig, "remote:true") {
+		t.Fatalf("StartProvider config = %s, want remote:true rehydrated from replica config", startConfig)
+	}
+
+	dispatchCancel()
+	select {
+	case err := <-dispatchDone:
+		if err != nil {
+			t.Fatalf("dispatcher error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatcher did not stop")
+	}
+}
+
+func TestIndexedDBAttachmentStateExpiresIdleAttachmentWithOpenCall(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	manager, err := NewManager([]Target{{Name: "roadmap"}}, WithIndexedDBAttachmentState(ctx, db))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	session, err := manager.CreateSession(ctx, p, CreateSessionRequest{Providers: []AttachProvider{{Name: "roadmap"}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	callID, err := manager.shared.enqueueCall(ctx, session.AttachID, p.SubjectID, "roadmap", "Execute", []byte("payload"))
+	if err != nil {
+		t.Fatalf("enqueueCall: %v", err)
+	}
+	record, err := db.ObjectStore(indexedDBAttachmentStore).Get(ctx, session.AttachID)
+	if err != nil {
+		t.Fatalf("load attachment: %v", err)
+	}
+	record["last_seen_at"] = unixNano(time.Now().Add(-2 * DefaultSessionIdleTimeout))
+	if err := db.ObjectStore(indexedDBAttachmentStore).Put(ctx, record); err != nil {
+		t.Fatalf("expire attachment: %v", err)
+	}
+
+	active, err := manager.shared.sessionActive(ctx, session.AttachID, time.Now())
+	if err != nil {
+		t.Fatalf("sessionActive: %v", err)
+	}
+	if active {
+		t.Fatal("expired attachment stayed active because of an open call")
+	}
+	if err := manager.shared.cleanupExpired(ctx, time.Now()); err != nil {
+		t.Fatalf("cleanupExpired: %v", err)
+	}
+	_, err = manager.shared.waitCall(ctx, session.AttachID, callID)
+	if got := status.Code(err); got != codes.Unavailable {
+		t.Fatalf("waitCall after idle cleanup code = %s, want %s (err=%v)", got, codes.Unavailable, err)
+	}
+}
+
+func TestIndexedDBAttachmentStateClosesCachedSharedTargetsAfterIdleExpiry(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	targets := []Target{{Name: "roadmap"}}
+	managerA, err := NewManager(targets, WithIndexedDBAttachmentState(ctx, db))
+	if err != nil {
+		t.Fatalf("NewManager A: %v", err)
+	}
+	managerB, err := NewManager(targets, WithIndexedDBAttachmentState(ctx, db))
+	if err != nil {
+		t.Fatalf("NewManager B: %v", err)
+	}
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+
+	session, err := managerA.CreateSession(ctx, p, CreateSessionRequest{Providers: []AttachProvider{{Name: "roadmap"}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_ = managerB.sharedTarget(session.AttachID, Target{Name: "roadmap"})
+	managerB.mu.RLock()
+	_, cached := managerB.sharedTargets[session.AttachID]
+	managerB.mu.RUnlock()
+	if !cached {
+		t.Fatal("shared target was not cached")
+	}
+
+	record, err := db.ObjectStore(indexedDBAttachmentStore).Get(ctx, session.AttachID)
+	if err != nil {
+		t.Fatalf("load attachment: %v", err)
+	}
+	record["last_seen_at"] = unixNano(time.Now().Add(-2 * DefaultSessionIdleTimeout))
+	if err := db.ObjectStore(indexedDBAttachmentStore).Put(ctx, record); err != nil {
+		t.Fatalf("expire attachment: %v", err)
+	}
+
+	prov, ok, err := managerB.ResolveProviderOverride(ctx, p, "roadmap")
+	if err != nil {
+		t.Fatalf("ResolveProviderOverride: %v", err)
+	}
+	if ok || prov != nil {
+		t.Fatalf("ResolveProviderOverride = (%v, %v), want no override for expired attachment", prov, ok)
+	}
+	managerB.mu.RLock()
+	_, cached = managerB.sharedTargets[session.AttachID]
+	managerB.mu.RUnlock()
+	if cached {
+		t.Fatal("cached shared target survived attachment idle expiry")
+	}
+}
+
+func TestIndexedDBAttachmentStateRunsRuntimeEnvCleanupAfterCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cleanupCalls := 0
+	manager, err := NewManager([]Target{{
+		Name: "roadmap",
+		RuntimeEnv: func(string) (RuntimeEnv, error) {
+			return RuntimeEnv{
+				Env: map[string]string{"GESTALT_TEST_SOCKET": "relay://example"},
+				Cleanup: func() {
+					cleanupCalls++
+				},
+			}, nil
+		},
+	}}, WithIndexedDBAttachmentState(ctx, &coretesting.StubIndexedDB{}))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	resp, err := manager.CreateSession(ctx, p, CreateSessionRequest{Providers: []AttachProvider{{Name: "roadmap"}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if got := resp.Providers[0].Env["GESTALT_TEST_SOCKET"]; got != "relay://example" {
+		t.Fatalf("runtime env = %q, want relay://example", got)
+	}
+	if cleanupCalls != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", cleanupCalls)
+	}
+	if err := manager.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if cleanupCalls != 1 {
+		t.Fatalf("cleanup calls after manager close = %d, want 1", cleanupCalls)
+	}
+}
+
+func TestIndexedDBAttachAuthorizationApprovesAcrossManagers(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	targets := []Target{{Name: "roadmap"}}
+	managerA, err := NewManager(targets, WithIndexedDBAttachmentState(context.Background(), db))
+	if err != nil {
+		t.Fatalf("NewManager A: %v", err)
+	}
+	managerB, err := NewManager(targets, WithIndexedDBAttachmentState(context.Background(), db))
+	if err != nil {
+		t.Fatalf("NewManager B: %v", err)
+	}
+
+	req := CreateSessionRequest{Providers: []AttachProvider{{Name: "roadmap"}}}
+	info, clientSecret, verificationCode, err := managerA.CreateAttachAuthorization(req, time.Now())
+	if err != nil {
+		t.Fatalf("CreateAttachAuthorization: %v", err)
+	}
+	if info.AuthorizationID == "" || clientSecret == "" || verificationCode == "" {
+		t.Fatalf("authorization response = %#v secret=%q code=%q, want populated values", info, clientSecret, verificationCode)
+	}
+	gotInfo, err := managerB.GetAttachAuthorization(info.AuthorizationID)
+	if err != nil {
+		t.Fatalf("GetAttachAuthorization from second manager: %v", err)
+	}
+	if gotInfo.AuthorizationID != info.AuthorizationID {
+		t.Fatalf("authorization id = %q, want %q", gotInfo.AuthorizationID, info.AuthorizationID)
+	}
+
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	if err := managerB.ApproveAttachAuthorization(info.AuthorizationID, p, verificationCode); err != nil {
+		t.Fatalf("ApproveAttachAuthorization from second manager: %v", err)
+	}
+	poll, err := managerA.PollAttachAuthorization(info.AuthorizationID, clientSecret)
+	if err != nil {
+		t.Fatalf("PollAttachAuthorization from first manager: %v", err)
+	}
+	if poll == nil || !poll.Approved {
+		t.Fatalf("PollAttachAuthorization = %#v, want approved", poll)
+	}
+	approvedBy, err := managerA.ConsumeAttachAuthorization(info.AuthorizationID, clientSecret, req)
+	if err != nil {
+		t.Fatalf("ConsumeAttachAuthorization from first manager: %v", err)
+	}
+	if approvedBy == nil || approvedBy.SubjectID != p.SubjectID {
+		t.Fatalf("approved principal = %#v, want subject %q", approvedBy, p.SubjectID)
+	}
+}
+
 func TestCompleteCallTreatsOKErrorCodeAsProtocolError(t *testing.T) {
 	t.Parallel()
 
@@ -752,6 +1071,8 @@ func writeProviderDevTestError(w http.ResponseWriter, err error) {
 
 type recordingIntegrationClient struct {
 	mu                     sync.Mutex
+	metadataCalls          int
+	startCalls             int
 	startName              string
 	startConfig            map[string]any
 	supportsSessionCatalog bool
@@ -759,11 +1080,15 @@ type recordingIntegrationClient struct {
 }
 
 func (c *recordingIntegrationClient) GetMetadata(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.ProviderMetadata, error) {
+	c.mu.Lock()
+	c.metadataCalls++
+	c.mu.Unlock()
 	return &proto.ProviderMetadata{SupportsSessionCatalog: c.supportsSessionCatalog}, nil
 }
 
 func (c *recordingIntegrationClient) StartProvider(_ context.Context, req *proto.StartProviderRequest, _ ...grpc.CallOption) (*proto.StartProviderResponse, error) {
 	c.mu.Lock()
+	c.startCalls++
 	c.startName = req.GetName()
 	if req.GetConfig() != nil {
 		c.startConfig = req.GetConfig().AsMap()

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -28,7 +28,7 @@ func (s *Server) allowProviderActionContext(ctx context.Context, p *principal.Pr
 		return false
 	}
 	entry := s.pluginDefs[provider]
-	if entry == nil || entry.ProviderDev == nil || len(entry.ProviderDev.Attach.AllowedRoles) == 0 {
+	if entry == nil || entry.Dev == nil || len(entry.Dev.Attach.AllowedRoles) == 0 {
 		return false
 	}
 	if strings.TrimSpace(entry.AuthorizationPolicy) == "" || s.authorizer == nil {
@@ -38,7 +38,7 @@ func (s *Server) allowProviderActionContext(ctx context.Context, p *principal.Pr
 	if !ok || strings.TrimSpace(access.Policy) == "" || strings.TrimSpace(access.Role) == "" {
 		return false
 	}
-	for _, role := range entry.ProviderDev.Attach.AllowedRoles {
+	for _, role := range entry.Dev.Attach.AllowedRoles {
 		if strings.TrimSpace(role) == access.Role {
 			return true
 		}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -471,16 +471,16 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		Surface:        metricutil.InvocationSurfaceHTTP,
 	})
 	p := PrincipalFromContext(r.Context())
+	if !s.allowProviderContext(r.Context(), p, name) {
+		s.auditHTTPEvent(r.Context(), p, name, operation, false, errOperationAccess)
+		writeError(w, http.StatusForbidden, errOperationAccess.Error())
+		return
+	}
 	if override, ok, err := s.providerOverrideForContext(r.Context(), p, name); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	} else if ok {
 		prov = override
-	}
-	if !s.allowProviderContext(r.Context(), p, name) {
-		s.auditHTTPEvent(r.Context(), p, name, operation, false, errOperationAccess)
-		writeError(w, http.StatusForbidden, errOperationAccess.Error())
-		return
 	}
 	requestedConnection := r.URL.Query().Get(httpConnectionParam)
 	if requestedConnection != "" {
@@ -555,13 +555,6 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	surfaceProv := prov
-	if override, ok, err := s.providerOverrideForContext(r.Context(), p, providerName); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	} else if ok {
-		surfaceProv = override
-	}
 	access := s.providerAccessContextWithContext(r.Context(), p, providerName)
 	providerAllowed := s.allowProviderContext(r.Context(), p, providerName)
 	operationAllowed := s.authorizer == nil || s.authorizer.AllowOperation(r.Context(), p, providerName, operationName)
@@ -578,6 +571,13 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		s.auditHTTPAuthorizationEvent(r.Context(), p, providerName, operationName, false, errOperationAccess, authz)
 		writeError(w, http.StatusForbidden, errOperationAccess.Error())
 		return
+	}
+	surfaceProv := prov
+	if override, ok, err := s.providerOverrideForContext(r.Context(), p, providerName); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	} else if ok {
+		surfaceProv = override
 	}
 
 	requestedConnectionInput := r.URL.Query().Get(httpConnectionParam)

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -22,25 +22,45 @@ type hostServiceHandlerEntry struct {
 	verifier runtimehost.PublicHostServiceSessionVerifier
 }
 
-func newPublicHostServiceHandlers(services []runtimehost.PublicHostService) (map[hostServiceHandlerKey]hostServiceHandlerEntry, error) {
+func newPublicHostServiceHandlers(services []runtimehost.PublicHostService) (map[hostServiceHandlerKey][]hostServiceHandlerEntry, error) {
 	if len(services) == 0 {
 		return nil, nil
 	}
-	handlers := make(map[hostServiceHandlerKey]hostServiceHandlerEntry, len(services))
+	handlers := make(map[hostServiceHandlerKey][]hostServiceHandlerEntry, len(services))
 	for _, service := range services {
 		key, entry, ok := newPublicHostServiceHandlerEntry(service)
 		if !ok {
 			continue
 		}
-		if _, ok := handlers[key]; ok {
-			return nil, fmt.Errorf("duplicate public host service %s", key.String())
+		if err := appendHostServiceHandlerEntry(handlers, key, entry); err != nil {
+			return nil, err
 		}
-		handlers[key] = entry
 	}
 	if len(handlers) == 0 {
 		return nil, nil
 	}
 	return handlers, nil
+}
+
+func appendHostServiceHandlerEntry(handlers map[hostServiceHandlerKey][]hostServiceHandlerEntry, key hostServiceHandlerKey, entry hostServiceHandlerEntry) error {
+	if handlers == nil {
+		return nil
+	}
+	entries := handlers[key]
+	if err := checkHostServiceHandlerDuplicate(key, entries, entry); err != nil {
+		return err
+	}
+	handlers[key] = append(entries, entry)
+	return nil
+}
+
+func checkHostServiceHandlerDuplicate(key hostServiceHandlerKey, entries []hostServiceHandlerEntry, entry hostServiceHandlerEntry) error {
+	for _, existing := range entries {
+		if existing.verifier == nil || entry.verifier == nil {
+			return fmt.Errorf("duplicate public host service %s", key.String())
+		}
+	}
+	return nil
 }
 
 func newPublicHostServiceHandlerEntry(service runtimehost.PublicHostService) (hostServiceHandlerKey, hostServiceHandlerEntry, bool) {
@@ -82,28 +102,24 @@ func (s *Server) hostServiceHandler(ctx context.Context, target runtimehost.Host
 	providerKey := exactKey
 	providerKey.sessionID = ""
 
-	entry, ok, err := s.hostServiceHandlerEntry(exactKey)
-	if err != nil {
-		return nil, err
-	}
+	entry, ok, err := s.hostServiceHandlerEntry(ctx, exactKey, exactKey.sessionID)
+	exactErr := err
 	if !ok && exactKey.sessionID != "" {
-		entry, ok, err = s.hostServiceHandlerEntry(providerKey)
+		entry, ok, err = s.hostServiceHandlerEntry(ctx, providerKey, exactKey.sessionID)
 		if err != nil {
 			return nil, err
 		}
 	}
+	if !ok && exactErr != nil {
+		return nil, exactErr
+	}
 	if !ok {
 		return nil, nil
-	}
-	if entry.verifier != nil {
-		if err := entry.verifier.VerifyHostServiceSession(ctx, exactKey.sessionID); err != nil {
-			return nil, err
-		}
 	}
 	return entry.handler, nil
 }
 
-func (s *Server) hostServiceHandlerEntry(key hostServiceHandlerKey) (hostServiceHandlerEntry, bool, error) {
+func (s *Server) hostServiceHandlerEntry(ctx context.Context, key hostServiceHandlerKey, sessionID string) (hostServiceHandlerEntry, bool, error) {
 	if key.pluginName == "" || key.service == "" || key.envVar == "" {
 		return hostServiceHandlerEntry{}, false, nil
 	}
@@ -111,14 +127,14 @@ func (s *Server) hostServiceHandlerEntry(key hostServiceHandlerKey) (hostService
 	for {
 		s.hostServiceMu.Lock()
 		s.refreshHostServiceHandlerCacheLocked()
-		if entry, ok := s.hostServiceHandlers[key]; ok {
+		if entries, ok := s.hostServiceHandlers[key]; ok {
 			s.hostServiceMu.Unlock()
-			return entry, true, nil
+			return selectHostServiceHandlerEntry(ctx, key, sessionID, entries)
 		}
 		s.hostServiceMu.Unlock()
 
 		services, snapshotVersion := s.publicHostServices.Snapshot()
-		var found *runtimehost.PublicHostService
+		var entries []hostServiceHandlerEntry
 		for _, service := range services {
 			serviceKey := hostServiceHandlerKey{
 				pluginName: strings.TrimSpace(service.PluginName),
@@ -129,17 +145,16 @@ func (s *Server) hostServiceHandlerEntry(key hostServiceHandlerKey) (hostService
 			if serviceKey != key || service.Service.Register == nil {
 				continue
 			}
-			if found != nil {
-				return hostServiceHandlerEntry{}, false, fmt.Errorf("duplicate public host service %s", key.String())
+			entryKey, entry, ok := newPublicHostServiceHandlerEntry(service)
+			if !ok || entryKey != key {
+				continue
 			}
-			serviceCopy := service
-			found = &serviceCopy
+			if err := checkHostServiceHandlerDuplicate(key, entries, entry); err != nil {
+				return hostServiceHandlerEntry{}, false, err
+			}
+			entries = append(entries, entry)
 		}
-		if found == nil {
-			return hostServiceHandlerEntry{}, false, nil
-		}
-		entryKey, entry, ok := newPublicHostServiceHandlerEntry(*found)
-		if !ok || entryKey != key {
+		if len(entries) == 0 {
 			return hostServiceHandlerEntry{}, false, nil
 		}
 
@@ -154,15 +169,36 @@ func (s *Server) hostServiceHandlerEntry(key hostServiceHandlerKey) (hostService
 		s.hostServiceVersion = snapshotVersion
 		if existing, ok := s.hostServiceHandlers[key]; ok {
 			s.hostServiceMu.Unlock()
-			return existing, true, nil
+			return selectHostServiceHandlerEntry(ctx, key, sessionID, existing)
 		}
 		if s.hostServiceHandlers == nil {
-			s.hostServiceHandlers = make(map[hostServiceHandlerKey]hostServiceHandlerEntry)
+			s.hostServiceHandlers = make(map[hostServiceHandlerKey][]hostServiceHandlerEntry)
 		}
-		s.hostServiceHandlers[key] = entry
+		s.hostServiceHandlers[key] = entries
 		s.hostServiceMu.Unlock()
+		return selectHostServiceHandlerEntry(ctx, key, sessionID, entries)
+	}
+}
+
+func selectHostServiceHandlerEntry(ctx context.Context, key hostServiceHandlerKey, sessionID string, entries []hostServiceHandlerEntry) (hostServiceHandlerEntry, bool, error) {
+	if len(entries) == 0 {
+		return hostServiceHandlerEntry{}, false, nil
+	}
+	var lastErr error
+	for _, entry := range entries {
+		if entry.verifier == nil {
+			return entry, true, nil
+		}
+		if err := entry.verifier.VerifyHostServiceSession(ctx, sessionID); err != nil {
+			lastErr = err
+			continue
+		}
 		return entry, true, nil
 	}
+	if lastErr != nil {
+		return hostServiceHandlerEntry{}, false, lastErr
+	}
+	return hostServiceHandlerEntry{}, false, nil
 }
 
 func (s *Server) refreshHostServiceHandlerCacheLocked() {

--- a/gestaltd/internal/server/host_service_public_test.go
+++ b/gestaltd/internal/server/host_service_public_test.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"google.golang.org/grpc"
+)
+
+func TestHostServiceHandlerFallsBackWhenExactVerifierRejects(t *testing.T) {
+	t.Parallel()
+
+	exactKey := hostServiceHandlerKey{
+		pluginName: "support",
+		sessionID:  "session-1",
+		service:    "cache",
+		envVar:     "GESTALT_TEST_CACHE_SOCKET",
+	}
+	providerKey := exactKey
+	providerKey.sessionID = ""
+	exactHandler := markerHostServiceHandler("exact")
+	providerHandler := markerHostServiceHandler("provider")
+
+	s := &Server{
+		hostServiceHandlers: map[hostServiceHandlerKey][]hostServiceHandlerEntry{
+			exactKey: {{
+				handler:  exactHandler,
+				verifier: rejectHostServiceSessionVerifier{},
+			}},
+			providerKey: {{
+				handler:  providerHandler,
+				verifier: allowHostServiceSessionVerifier{},
+			}},
+		},
+	}
+
+	handler, err := s.hostServiceHandler(context.Background(), runtimehost.HostServiceRelayTarget{
+		PluginName: "support",
+		SessionID:  "session-1",
+		Service:    "cache",
+		EnvVar:     "GESTALT_TEST_CACHE_SOCKET",
+	})
+	if err != nil {
+		t.Fatalf("hostServiceHandler: %v", err)
+	}
+	if handler != providerHandler {
+		t.Fatalf("handler = %v, want provider-wide fallback", handler)
+	}
+}
+
+func TestNewPublicHostServiceHandlersRejectsDuplicateUnverifiedServices(t *testing.T) {
+	t.Parallel()
+
+	_, err := newPublicHostServiceHandlers([]runtimehost.PublicHostService{
+		testPublicHostService("support", nil),
+		testPublicHostService("support", nil),
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate public host service support/cache/GESTALT_TEST_CACHE_SOCKET") {
+		t.Fatalf("newPublicHostServiceHandlers err = %v, want duplicate public host service", err)
+	}
+}
+
+func TestNewPublicHostServiceHandlersAllowsDuplicateVerifiedServices(t *testing.T) {
+	t.Parallel()
+
+	handlers, err := newPublicHostServiceHandlers([]runtimehost.PublicHostService{
+		testPublicHostService("support", allowHostServiceSessionVerifier{}),
+		testPublicHostService("support", rejectHostServiceSessionVerifier{}),
+	})
+	if err != nil {
+		t.Fatalf("newPublicHostServiceHandlers: %v", err)
+	}
+	key := hostServiceHandlerKey{
+		pluginName: "support",
+		service:    "cache",
+		envVar:     "GESTALT_TEST_CACHE_SOCKET",
+	}
+	if got := len(handlers[key]); got != 2 {
+		t.Fatalf("handlers[%s] = %d, want 2", key.String(), got)
+	}
+}
+
+func TestHostServiceHandlerEntryRejectsDynamicDuplicateUnverifiedServices(t *testing.T) {
+	t.Parallel()
+
+	registry := runtimehost.NewPublicHostServiceRegistry()
+	registry.Register("support", testHostService(), testHostService())
+	s := &Server{publicHostServices: registry}
+	key := hostServiceHandlerKey{
+		pluginName: "support",
+		service:    "cache",
+		envVar:     "GESTALT_TEST_CACHE_SOCKET",
+	}
+	_, _, err := s.hostServiceHandlerEntry(context.Background(), key, "")
+	if err == nil || !strings.Contains(err.Error(), "duplicate public host service support/cache/GESTALT_TEST_CACHE_SOCKET") {
+		t.Fatalf("hostServiceHandlerEntry err = %v, want duplicate public host service", err)
+	}
+}
+
+type markerHostServiceHandler string
+
+func (h markerHostServiceHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
+
+func testPublicHostService(pluginName string, verifier runtimehost.PublicHostServiceSessionVerifier) runtimehost.PublicHostService {
+	return runtimehost.PublicHostService{
+		PluginName:      pluginName,
+		SessionVerifier: verifier,
+		Service:         testHostService(),
+	}
+}
+
+func testHostService() runtimehost.HostService {
+	return runtimehost.HostService{
+		Name:     "cache",
+		EnvVar:   "GESTALT_TEST_CACHE_SOCKET",
+		Register: func(*grpc.Server) {},
+	}
+}
+
+type rejectHostServiceSessionVerifier struct{}
+
+func (rejectHostServiceSessionVerifier) VerifyHostServiceSession(_ context.Context, sessionID string) error {
+	return fmt.Errorf("runtime session %q is not active", strings.TrimSpace(sessionID))
+}
+
+type allowHostServiceSessionVerifier struct{}
+
+func (allowHostServiceSessionVerifier) VerifyHostServiceSession(context.Context, string) error {
+	return nil
+}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -98,7 +98,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		Readiness:             runtimeReadinessStatus(result.ProvidersReady, workflowProvidersReady, result.Services),
 		PrometheusMetrics:     result.Telemetry.PrometheusHandler(),
 		ProviderDevSessions:   result.ProviderDevSessions,
-		ProviderDevAttach:     cfg.Server.ProviderDev.RemoteAttach,
+		ProviderDevAttach:     cfg.Server.Dev.AttachmentState != "",
 		PublicHostServices:    result.PublicHostServices,
 		Admin: AdminRouteConfig{
 			AuthorizationPolicy: cfg.Server.Admin.AuthorizationPolicy,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -120,7 +120,7 @@ type Server struct {
 	mcpHandler             http.Handler
 	hostServiceRelayTokens *runtimehost.HostServiceRelayTokenManager
 	hostServiceMu          sync.Mutex
-	hostServiceHandlers    map[hostServiceHandlerKey]hostServiceHandlerEntry
+	hostServiceHandlers    map[hostServiceHandlerKey][]hostServiceHandlerEntry
 	hostServiceVersion     uint64
 	publicHostServices     *runtimehost.PublicHostServiceRegistry
 	s3                     map[string]s3store.Client

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -568,6 +568,72 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	}
 }
 
+func TestHostServiceRelaySelectsVerifierForDuplicateProviderWideServices(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	const envVar = "GESTALT_TEST_CACHE_SOCKET"
+	cacheSrv1 := &relayTestCacheServer{}
+	cacheSrv2 := &relayTestCacheServer{}
+	publicHostServices := providerhost.NewPublicHostServiceRegistry()
+	hostService1 := providerhost.HostService{
+		Name:   "cache",
+		EnvVar: envVar,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterCacheServer(srv, cacheSrv1)
+		},
+	}
+	hostService2 := providerhost.HostService{
+		Name:   "cache",
+		EnvVar: envVar,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterCacheServer(srv, cacheSrv2)
+		},
+	}
+	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("session-1"), hostService1)
+	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("session-2"), hostService2)
+
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+		cfg.PublicHostServices = publicHostServices
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-2",
+		Service:      "cache",
+		EnvVar:       envVar,
+		MethodPrefix: "/gestalt.provider.v1.Cache/",
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
+	if _, err := proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "selected"}); err != nil {
+		t.Fatalf("Cache.Get via duplicate relay: %v", err)
+	}
+	if got := cacheSrv1.calls(); got != 0 {
+		t.Fatalf("first backend calls = %d, want 0", got)
+	}
+	if got := cacheSrv2.calls(); got != 1 {
+		t.Fatalf("second backend calls = %d, want 1", got)
+	}
+}
+
 func TestHostServiceRelayStopsServingUnregisteredSession(t *testing.T) {
 	t.Parallel()
 
@@ -6164,7 +6230,7 @@ func TestProviderDevAttachmentRoutesEnforceGateDispatcherSecretAndRedaction(t *t
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
 			"roadmap": {
 				AuthorizationPolicy: "provider_devs",
-				ProviderDev: &config.ProviderEntryDevConfig{
+				Dev: &config.ProviderEntryDevConfig{
 					Attach: config.ProviderEntryDevAttachConfig{AllowedRoles: []string{"viewer"}},
 				},
 			},
@@ -6375,7 +6441,7 @@ func TestProviderDevAttachmentCreateRequiresAttachActionPermission(t *testing.T)
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
 			"roadmap": {
 				AuthorizationPolicy: "provider_devs",
-				ProviderDev: &config.ProviderEntryDevConfig{
+				Dev: &config.ProviderEntryDevConfig{
 					Attach: config.ProviderEntryDevAttachConfig{AllowedRoles: []string{"viewer"}},
 				},
 			},
@@ -6457,7 +6523,7 @@ func TestProviderDevAttachAuthorizationBrowserApprovalCreatesDispatcherSession(t
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
 			"roadmap": {
 				AuthorizationPolicy: "provider_devs",
-				ProviderDev: &config.ProviderEntryDevConfig{
+				Dev: &config.ProviderEntryDevConfig{
 					Attach: config.ProviderEntryDevAttachConfig{AllowedRoles: []string{"viewer"}},
 				},
 			},


### PR DESCRIPTION
## Summary

Adds shared provider-dev remote attach state backed by the configured host IndexedDB, and simplifies the config surface so enabling remote attach is a single state-selection field instead of `providerDev.remoteAttach` plus a separate state acknowledgement.

New interfaces:

```yaml
server:
  dev:
    attachmentState: indexeddb # or processLocal for local demos only

plugins:
  slack:
    authorizationPolicy: provider_devs
    dev:
      attach:
        allowedRoles:
          - developer
```

Example usage:

```sh
gestaltd provider dev --remote https://valon.tools --path ./plugins/slack
```

Behavior:

- `server.dev.attachmentState: indexeddb` stores attachment metadata and queued provider/UI calls in host IndexedDB so create, poll/complete, invocation, and UI requests can be handled by different `gestaltd` replicas.
- `server.dev.attachmentState: processLocal` keeps the previous in-process backend for local demos and single-process development servers.
- Plugin attach grants move to `plugins.<name>.dev.attach.allowedRoles`.
- Shared-mode provider-dev host-service relays are registered as provider-wide public services with attachment-session verification, so relay traffic does not depend on the replica that created the attachment.

## Testing

```sh
cd gestaltd
go test ./...
golangci-lint run ./...
go test ./internal/providerdev ./internal/config ./internal/bootstrap ./internal/server
```

The cross-manager provider-dev test covers the shared IndexedDB contract: one manager creates and polls an attachment while another manager resolves and invokes through the same shared attachment state.