### PR TITLE
Avoid mutating provider manifests while encoding

### DIFF
--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -74,6 +74,9 @@ func decodeManifest(data []byte, format string, sourceMode bool) (*providermanif
 	if err := validateManifest(&manifest, sourceMode); err != nil {
 		return nil, err
 	}
+	if _, err := normalizeManifestKind(&manifest); err != nil {
+		return nil, err
+	}
 	return &manifest, nil
 }
 
@@ -102,6 +105,14 @@ func ManifestKind(manifest *providermanifestv1.Manifest) (string, error) {
 	kind := providermanifestv1.NormalizeKind(manifest.Kind)
 	if !validManifestKinds[manifest.Kind] && !validManifestKinds[kind] {
 		return "", fmt.Errorf("manifest kind %q is not valid; expected one of plugin, authentication, authorization, external_credentials, indexeddb, cache, s3, workflow, agent, secrets, runtime, or ui", manifest.Kind)
+	}
+	return kind, nil
+}
+
+func normalizeManifestKind(manifest *providermanifestv1.Manifest) (string, error) {
+	kind, err := ManifestKind(manifest)
+	if err != nil {
+		return "", err
 	}
 	manifest.Kind = kind
 	return kind, nil
@@ -639,17 +650,41 @@ func EncodeSourceManifestFormat(manifest *providermanifestv1.Manifest, format st
 }
 
 func encodeManifestFormat(manifest *providermanifestv1.Manifest, format string, sourceMode bool) ([]byte, error) {
-	if err := validateManifest(manifest, sourceMode); err != nil {
+	encodedManifest, err := cloneManifest(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("clone manifest: %w", err)
+	}
+	if err := validateManifest(encodedManifest, sourceMode); err != nil {
+		return nil, err
+	}
+	if _, err := normalizeManifestKind(encodedManifest); err != nil {
 		return nil, err
 	}
 	switch format {
 	case ManifestFormatJSON:
-		return encodeManifestJSON(manifest)
+		return encodeManifestJSON(encodedManifest)
 	case ManifestFormatYAML:
-		return encodeManifestYAML(manifest)
+		return encodeManifestYAML(encodedManifest)
 	default:
 		return nil, fmt.Errorf("unsupported manifest format %q", format)
 	}
+}
+
+func cloneManifest(manifest *providermanifestv1.Manifest) (*providermanifestv1.Manifest, error) {
+	if manifest == nil {
+		return nil, nil
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	var cloned providermanifestv1.Manifest
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return nil, err
+	}
+	return &cloned, nil
 }
 
 func encodeManifestJSON(manifest *providermanifestv1.Manifest) ([]byte, error) {

--- a/gestaltd/internal/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/providerpkg/manifest_workflow_test.go
@@ -70,6 +70,46 @@ func TestManifestWorkflow_RoundTripsProviderPackagesAcrossDirectoryAndArchive(t 
 
 }
 
+func TestManifestKindNormalizationDoesNotMutateCallerManifest(t *testing.T) {
+	t.Parallel()
+
+	artifactPath := testArtifactPath("auth")
+	manifest := &providermanifestv1.Manifest{
+		Kind:    "auth",
+		Source:  "github.com/acme/plugins/auth",
+		Version: "1.0.0",
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:     testArtifactOS,
+			Arch:   testArtifactArch,
+			Path:   artifactPath,
+			SHA256: sha256Hex("auth"),
+		}},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactPath},
+	}
+
+	kind, err := ManifestKind(manifest)
+	if err != nil {
+		t.Fatalf("ManifestKind: %v", err)
+	}
+	if kind != providermanifestv1.KindAuthentication {
+		t.Fatalf("ManifestKind = %q, want %q", kind, providermanifestv1.KindAuthentication)
+	}
+	if manifest.Kind != "auth" {
+		t.Fatalf("ManifestKind mutated manifest kind to %q", manifest.Kind)
+	}
+
+	encoded, err := EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if manifest.Kind != "auth" {
+		t.Fatalf("EncodeManifest mutated manifest kind to %q", manifest.Kind)
+	}
+	if !strings.Contains(string(encoded), `"kind": "authentication"`) {
+		t.Fatalf("encoded manifest did not normalize kind:\n%s", encoded)
+	}
+}
+
 func TestManifestWorkflow_RoundTripsUIPackage(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/providerpkg/prepared_stage.go
+++ b/gestaltd/internal/providerpkg/prepared_stage.go
@@ -1,7 +1,6 @@
 package providerpkg
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -326,23 +325,6 @@ func writePreparedManifestFile(path, manifestFormat string, manifest *providerma
 		return fmt.Errorf("encode manifest: %w", err)
 	}
 	return os.WriteFile(path, data, 0o644)
-}
-
-func cloneManifest(manifest *providermanifestv1.Manifest) (*providermanifestv1.Manifest, error) {
-	if manifest == nil {
-		return nil, nil
-	}
-
-	data, err := json.Marshal(manifest)
-	if err != nil {
-		return nil, err
-	}
-
-	var cloned providermanifestv1.Manifest
-	if err := json.Unmarshal(data, &cloned); err != nil {
-		return nil, err
-	}
-	return &cloned, nil
 }
 
 func copyPreparedInstallDir(src, dst string) error {


### PR DESCRIPTION
## Summary

This fixes the providerpkg race from the latest main Build Gestaltd run by removing the shared-pointer mutation in manifest kind normalization.

Encode paths now clone the manifest before validation and output normalization. `ManifestKind` now returns the normalized kind without mutating the caller's manifest, while decode still normalizes its owned manifest before returning it.

## Validation

- `go test -race ./internal/providerpkg`
- `go test -race ./internal/pluginruntime ./internal/providerpkg`