### PR TITLE
[codex] Add security provider service boundaries

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
@@ -1040,13 +1041,13 @@ func fakeHostedWorkflowManagerRoundTrip(invocationToken string, env map[string]s
 }
 
 func fakeHostedAuthorizationRoundTrip(env map[string]string) (map[string]any, error) {
-	target := strings.TrimSpace(env[providerhost.DefaultAuthorizationSocketEnv])
+	target := strings.TrimSpace(env[authorizationservice.DefaultSocketEnv])
 	if target == "" {
-		return nil, fmt.Errorf("missing authorization relay target in %s", providerhost.DefaultAuthorizationSocketEnv)
+		return nil, fmt.Errorf("missing authorization relay target in %s", authorizationservice.DefaultSocketEnv)
 	}
-	token := strings.TrimSpace(env[providerhost.AuthorizationSocketTokenEnv()])
+	token := strings.TrimSpace(env[authorizationservice.SocketTokenEnv()])
 	if token == "" {
-		return nil, fmt.Errorf("missing authorization relay token in %s", providerhost.AuthorizationSocketTokenEnv())
+		return nil, fmt.Errorf("missing authorization relay token in %s", authorizationservice.SocketTokenEnv())
 	}
 	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
 	if address == "" || address == target {
@@ -4095,7 +4096,7 @@ func TestPluginHostedHTTPBindingsExposeAuthorizationSocketEnv(t *testing.T) {
 		t.Fatalf("providers.Get(echo): %v", err)
 	}
 
-	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": providerhost.DefaultAuthorizationSocketEnv}, "")
+	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": authorizationservice.DefaultSocketEnv}, "")
 	if err != nil {
 		t.Fatalf("Execute read_env: %v", err)
 	}
@@ -4108,7 +4109,7 @@ func TestPluginHostedHTTPBindingsExposeAuthorizationSocketEnv(t *testing.T) {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
 	if !env.Found || env.Value == "" {
-		t.Fatalf("authorization env %q should be set for executable plugins with hosted HTTP bindings", providerhost.DefaultAuthorizationSocketEnv)
+		t.Fatalf("authorization env %q should be set for executable plugins with hosted HTTP bindings", authorizationservice.DefaultSocketEnv)
 	}
 }
 
@@ -6148,19 +6149,19 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 		return env.Value, env.Found
 	}
 
-	if got, found := checkEnv(providerhost.DefaultAuthorizationSocketEnv); !found || got != "tls://gestalt.example.test:443" {
-		t.Fatalf("plugin authorization env %s = (%q, %v), want (%q, true)", providerhost.DefaultAuthorizationSocketEnv, got, found, "tls://gestalt.example.test:443")
+	if got, found := checkEnv(authorizationservice.DefaultSocketEnv); !found || got != "tls://gestalt.example.test:443" {
+		t.Fatalf("plugin authorization env %s = (%q, %v), want (%q, true)", authorizationservice.DefaultSocketEnv, got, found, "tls://gestalt.example.test:443")
 	}
-	if got, found := checkEnv(providerhost.AuthorizationSocketTokenEnv()); !found || got == "" {
-		t.Fatalf("plugin authorization token env %s = (%q, %v), want non-empty token", providerhost.AuthorizationSocketTokenEnv(), got, found)
+	if got, found := checkEnv(authorizationservice.SocketTokenEnv()); !found || got == "" {
+		t.Fatalf("plugin authorization token env %s = (%q, %v), want non-empty token", authorizationservice.SocketTokenEnv(), got, found)
 	}
 
 	bindRequests := runtimeProvider.bindHostServiceRequests()
 	if len(bindRequests) != 1 {
 		t.Fatalf("BindHostService requests = %d, want 1", len(bindRequests))
 	}
-	if bindRequests[0].EnvVar != providerhost.DefaultAuthorizationSocketEnv {
-		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, providerhost.DefaultAuthorizationSocketEnv)
+	if bindRequests[0].EnvVar != authorizationservice.DefaultSocketEnv {
+		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, authorizationservice.DefaultSocketEnv)
 	}
 	if got := bindRequests[0].Relay.DialTarget; got != "tls://gestalt.example.test:443" {
 		t.Fatalf("BindHostService(%s) relay target = %q, want %q", bindRequests[0].EnvVar, got, "tls://gestalt.example.test:443")
@@ -6170,7 +6171,7 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.AuthorizationSocketTokenEnv()]; got == "" {
+	if got := startRequests[0].Env[authorizationservice.SocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the authorization relay token")
 	}
 	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
@@ -7755,7 +7756,7 @@ func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *t
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.AuthorizationSocketTokenEnv()]; got == "" {
+	if got := startRequests[0].Env[authorizationservice.SocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the authorization relay token")
 	}
 	bindRequests := runtimeProvider.bindHostServiceRequests()

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -45,6 +45,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
@@ -1615,7 +1616,7 @@ func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostSe
 			serviceKey = "agent_manager"
 			serviceLabel = "agent manager"
 			methodPrefix = "/" + proto.AgentManagerHost_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == providerhost.DefaultAuthorizationSocketEnv:
+		case hostService.EnvVar == authorizationservice.DefaultSocketEnv:
 			serviceKey = "authorization"
 			serviceLabel = "authorization"
 			methodPrefix = "/" + proto.AuthorizationProvider_ServiceDesc.ServiceName + "/"
@@ -2060,9 +2061,9 @@ func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *pr
 func buildPluginAuthorizationHostService(provider core.AuthorizationProvider) runtimehost.HostService {
 	return runtimehost.HostService{
 		Name:   "authorization",
-		EnvVar: providerhost.DefaultAuthorizationSocketEnv,
+		EnvVar: authorizationservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterAuthorizationProviderServer(srv, providerhost.NewAuthorizationProviderServer(provider))
+			proto.RegisterAuthorizationProviderServer(srv, authorizationservice.NewProviderServer(provider))
 		},
 	}
 }

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -32,6 +32,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/fakebun"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	authenticationservice "github.com/valon-technologies/gestalt/server/services/authentication"
+	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
+	externalcredentialsservice "github.com/valon-technologies/gestalt/server/services/externalcredentials"
+	secretsservice "github.com/valon-technologies/gestalt/server/services/secrets"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
@@ -1146,14 +1150,14 @@ func TestRun_ProviderReleaseBuildsGoSourceAuthPlugin(t *testing.T) {
 		t.Fatalf("release metadata auth artifact = %+v, want path %q sha %q", authArtifact, archiveName, authDigest)
 	}
 
-	auth, err := providerhost.NewExecutableAuthenticationProvider(context.Background(), providerhost.AuthenticationExecConfig{
+	auth, err := authenticationservice.NewExecutable(context.Background(), authenticationservice.ExecConfig{
 		Command:     filepath.Join(extractDir, binaryName),
 		Name:        "auth-release",
 		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
 		SessionKey:  []byte("0123456789abcdef0123456789abcdef"),
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableAuthenticationProvider: %v", err)
+		t.Fatalf("authenticationservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := auth.(interface{ Close() error }); ok {
@@ -1261,12 +1265,12 @@ func TestRun_ProviderReleaseBuildsGoSourceAuthorizationProvider(t *testing.T) {
 		t.Fatalf("release metadata runtime = %q, want %q", metadata.Runtime, providerReleaseRuntimeKindExecutable)
 	}
 
-	authz, err := providerhost.NewExecutableAuthorizationProvider(context.Background(), providerhost.AuthorizationExecConfig{
+	authz, err := authorizationservice.NewExecutable(context.Background(), authorizationservice.ExecConfig{
 		Command: filepath.Join(extractDir, binaryName),
 		Name:    "authorization-release",
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableAuthorizationProvider: %v", err)
+		t.Fatalf("authorizationservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := authz.(interface{ Close() error }); ok {
@@ -1350,12 +1354,12 @@ func TestRun_ProviderReleaseBuildsGoSourceSecretsPlugin(t *testing.T) {
 		t.Fatalf("expected %s in archive: %v", secretsReleaseSchemaPath, err)
 	}
 
-	sm, err := providerhost.NewExecutableSecretManager(context.Background(), providerhost.SecretsExecConfig{
+	sm, err := secretsservice.NewExecutable(context.Background(), secretsservice.ExecConfig{
 		Command: filepath.Join(extractDir, binaryName),
 		Name:    secretsReleasePluginName,
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableSecretManager: %v", err)
+		t.Fatalf("secretsservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := sm.(interface{ Close() error }); ok {
@@ -1487,19 +1491,19 @@ func TestRun_ProviderReleaseBuildsGoSourceExternalCredentialsPlugin(t *testing.T
 	}
 	coretesting.AttachStubExternalCredentials(services)
 
-	provider, err := providerhost.NewExecutableExternalCredentialProvider(context.Background(), providerhost.ExternalCredentialsExecConfig{
+	provider, err := externalcredentialsservice.NewExecutable(context.Background(), externalcredentialsservice.ExecConfig{
 		Command: filepath.Join(extractDir, binaryName),
 		Name:    externalCredentialReleasePluginName,
 		HostServices: []providerhost.HostService{{
 			Name:   "external-credentials",
-			EnvVar: providerhost.DefaultExternalCredentialSocketEnv,
+			EnvVar: externalcredentialsservice.DefaultSocketEnv,
 			Register: func(srv *grpc.Server) {
-				proto.RegisterExternalCredentialProviderServer(srv, providerhost.NewExternalCredentialProviderServer(services.ExternalCredentials))
+				proto.RegisterExternalCredentialProviderServer(srv, externalcredentialsservice.NewProviderServer(services.ExternalCredentials))
 			},
 		}},
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableExternalCredentialProvider: %v", err)
+		t.Fatalf("externalcredentialsservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := provider.(interface{ Close() error }); ok {
@@ -2996,14 +3000,14 @@ func assertArtifactPlatform(t *testing.T, artifact providermanifestv1.Artifact, 
 func assertExecutableAuthProviderWorks(t *testing.T, command, providerName string, assertSessionTTL, assertExternalJWT bool) {
 	t.Helper()
 
-	auth, err := providerhost.NewExecutableAuthenticationProvider(context.Background(), providerhost.AuthenticationExecConfig{
+	auth, err := authenticationservice.NewExecutable(context.Background(), authenticationservice.ExecConfig{
 		Command:     command,
 		Name:        providerName,
 		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
 		SessionKey:  []byte("0123456789abcdef0123456789abcdef"),
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableAuthenticationProvider: %v", err)
+		t.Fatalf("authenticationservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := auth.(interface{ Close() error }); ok {

--- a/gestaltd/internal/drivers/auth/provider/factory.go
+++ b/gestaltd/internal/drivers/auth/provider/factory.go
@@ -8,8 +8,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	authenticationservice "github.com/valon-technologies/gestalt/server/services/authentication"
 	"gopkg.in/yaml.v3"
 )
 
@@ -38,7 +38,7 @@ var Factory bootstrap.AuthFactory = func(node yaml.Node, deps bootstrap.Deps) (c
 	if callbackURL == "" && deps.BaseURL != "" {
 		callbackURL = deps.BaseURL + config.AuthCallbackPath
 	}
-	return providerhost.NewExecutableAuthenticationProvider(context.Background(), providerhost.AuthenticationExecConfig{
+	return authenticationservice.NewExecutable(context.Background(), authenticationservice.ExecConfig{
 		Command:     cfg.Command,
 		Args:        cfg.Args,
 		Env:         cfg.Env,

--- a/gestaltd/internal/drivers/authorization/provider/factory.go
+++ b/gestaltd/internal/drivers/authorization/provider/factory.go
@@ -7,8 +7,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
@@ -29,7 +29,7 @@ var Factory bootstrap.AuthorizationFactory = func(node yaml.Node, hostServices [
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableAuthorizationProvider(context.Background(), providerhost.AuthorizationExecConfig{
+	return authorizationservice.NewExecutable(context.Background(), authorizationservice.ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,

--- a/gestaltd/internal/drivers/externalcredentials/provider/factory.go
+++ b/gestaltd/internal/drivers/externalcredentials/provider/factory.go
@@ -7,8 +7,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	externalcredentialsservice "github.com/valon-technologies/gestalt/server/services/externalcredentials"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
@@ -29,7 +29,7 @@ var Factory bootstrap.ExternalCredentialFactory = func(ctx context.Context, name
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableExternalCredentialProvider(ctx, providerhost.ExternalCredentialsExecConfig{
+	return externalcredentialsservice.NewExecutable(ctx, externalcredentialsservice.ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,

--- a/gestaltd/internal/drivers/secrets/provider/factory.go
+++ b/gestaltd/internal/drivers/secrets/provider/factory.go
@@ -7,8 +7,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	secretsservice "github.com/valon-technologies/gestalt/server/services/secrets"
 	"gopkg.in/yaml.v3"
 )
 
@@ -28,7 +28,7 @@ var Factory bootstrap.SecretManagerFactory = func(node yaml.Node) (core.SecretMa
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableSecretManager(context.Background(), providerhost.SecretsExecConfig{
+	return secretsservice.NewExecutable(context.Background(), secretsservice.ExecConfig{
 		Command:    cfg.Command,
 		Args:       cfg.Args,
 		Env:        cfg.Env,

--- a/gestaltd/services/authentication/authentication.go
+++ b/gestaltd/services/authentication/authentication.go
@@ -1,0 +1,15 @@
+// Package authentication exposes authentication provider transport primitives.
+package authentication
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+type ExecConfig = providerhost.AuthenticationExecConfig
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthenticationProvider, error) {
+	return providerhost.NewExecutableAuthenticationProvider(ctx, cfg)
+}

--- a/gestaltd/services/authorization/authorization.go
+++ b/gestaltd/services/authorization/authorization.go
@@ -1,0 +1,26 @@
+// Package authorization exposes authorization provider transport primitives.
+package authorization
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+const DefaultSocketEnv = providerhost.DefaultAuthorizationSocketEnv
+
+type ExecConfig = providerhost.AuthorizationExecConfig
+
+func SocketTokenEnv() string {
+	return providerhost.AuthorizationSocketTokenEnv()
+}
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (core.AuthorizationProvider, error) {
+	return providerhost.NewExecutableAuthorizationProvider(ctx, cfg)
+}
+
+func NewProviderServer(provider core.AuthorizationProvider) proto.AuthorizationProviderServer {
+	return providerhost.NewAuthorizationProviderServer(provider)
+}

--- a/gestaltd/services/externalcredentials/externalcredentials.go
+++ b/gestaltd/services/externalcredentials/externalcredentials.go
@@ -1,0 +1,22 @@
+// Package externalcredentials exposes external credential provider transport primitives.
+package externalcredentials
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+const DefaultSocketEnv = providerhost.DefaultExternalCredentialSocketEnv
+
+type ExecConfig = providerhost.ExternalCredentialsExecConfig
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (core.ExternalCredentialProvider, error) {
+	return providerhost.NewExecutableExternalCredentialProvider(ctx, cfg)
+}
+
+func NewProviderServer(provider core.ExternalCredentialProvider) proto.ExternalCredentialProviderServer {
+	return providerhost.NewExternalCredentialProviderServer(provider)
+}

--- a/gestaltd/services/secrets/secrets.go
+++ b/gestaltd/services/secrets/secrets.go
@@ -1,0 +1,15 @@
+// Package secrets exposes secret manager provider transport primitives.
+package secrets
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+type ExecConfig = providerhost.SecretsExecConfig
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (core.SecretManager, error) {
+	return providerhost.NewExecutableSecretManager(ctx, cfg)
+}


### PR DESCRIPTION
## Summary
- add public service facades for executable authentication, authorization, external credential, and secrets providers
- route driver factories and bootstrap authorization host-service wiring through those facades
- update daemon release-flow integration tests to consume the service interfaces rather than `internal/providerhost` constructors

## Stack
- stacked on #1579 (`codex/gestaltd-cache-indexeddb-services`) so this PR only contains the security-provider boundary slice

## New Interfaces
- `authentication.NewExecutable(ctx, authentication.ExecConfig{...})`
- `authorization.DefaultSocketEnv`
- `authorization.SocketTokenEnv()`
- `authorization.NewExecutable(ctx, authorization.ExecConfig{...})`
- `authorization.NewProviderServer(provider)`
- `externalcredentials.DefaultSocketEnv`
- `externalcredentials.NewExecutable(ctx, externalcredentials.ExecConfig{...})`
- `externalcredentials.NewProviderServer(provider)`
- `secrets.NewExecutable(ctx, secrets.ExecConfig{...})`

## Examples
```go
provider, err := authentication.NewExecutable(ctx, authentication.ExecConfig{
    Command: command,
    Name:    name,
})
```

```go
hostService := runtimehost.HostService{
    Name:   "authorization",
    EnvVar: authorization.DefaultSocketEnv,
    Register: func(srv *grpc.Server) {
        proto.RegisterAuthorizationProviderServer(srv, authorization.NewProviderServer(provider))
    },
}
```

```go
manager, err := secrets.NewExecutable(ctx, secrets.ExecConfig{
    Command: command,
    Name:    name,
})
```

## Review Pass
- separate GPT-5.5 xhigh reviewer pass found no findings

## Tests
```sh
cd gestaltd && go test ./services/authentication ./services/authorization ./services/externalcredentials ./services/secrets ./internal/drivers/auth/provider ./internal/drivers/authorization/provider ./internal/drivers/externalcredentials/provider ./internal/drivers/secrets/provider ./internal/bootstrap ./internal/daemon
```

Reviewer also ran the same focused suite with `-count=1`.
