### PR TITLE
Remove IndexedDB migration timeout path

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -823,7 +823,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, storeErr)
 	}
 	store = metricutil.InstrumentIndexedDB(store, selectedIndexedDBName)
-	svc, svcErr := coredata.NewWithContext(runtimehost.WithProviderMigrationTimeout(ctx), store)
+	svc, svcErr := coredata.NewWithContext(ctx, store)
 	if svcErr != nil {
 		_ = store.Close()
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, svcErr)

--- a/gestaltd/internal/providerhost/indexeddb_client.go
+++ b/gestaltd/internal/providerhost/indexeddb_client.go
@@ -102,7 +102,7 @@ func (r *remoteIndexedDB) Transaction(ctx context.Context, stores []string, mode
 }
 
 func (r *remoteIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
-	ctx, cancel := providerSchemaChangeContext(ctx)
+	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
 	indexes := make([]*proto.IndexSchema, len(schema.Indexes))
 	for i, idx := range schema.Indexes {
@@ -122,7 +122,7 @@ func (r *remoteIndexedDB) CreateObjectStore(ctx context.Context, name string, sc
 }
 
 func (r *remoteIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
-	ctx, cancel := providerSchemaChangeContext(ctx)
+	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
 	_, err := r.client.DeleteObjectStore(ctx, &proto.DeleteObjectStoreRequest{Name: name})
 	return grpcToDatastoreErr(err)

--- a/gestaltd/internal/providerhost/indexeddb_client_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_client_test.go
@@ -25,48 +25,37 @@ func (c *deadlineIndexedDBClient) DeleteObjectStore(ctx context.Context, req *pr
 	return c.deleteObjectStore(ctx, req, opts...)
 }
 
-func TestRemoteIndexedDBSchemaChangesUseMigrationTimeoutWhenRequested(t *testing.T) {
+func TestRemoteIndexedDBSchemaChangesUseProviderRPCTimeout(t *testing.T) {
 	t.Parallel()
 
-	assertDeadline := func(t *testing.T, ctx context.Context, want time.Duration) {
+	assertDeadline := func(t *testing.T, ctx context.Context) {
 		t.Helper()
 		deadline, ok := ctx.Deadline()
 		if !ok {
 			t.Fatal("schema change context has no deadline")
 		}
 		remaining := time.Until(deadline)
-		if remaining <= want-2*time.Second || remaining > want {
-			t.Fatalf("schema change deadline remaining = %s, want within 2s of %s", remaining, want)
+		if remaining <= providerRPCTimeout-2*time.Second || remaining > providerRPCTimeout {
+			t.Fatalf("schema change deadline remaining = %s, want within 2s of %s", remaining, providerRPCTimeout)
 		}
 	}
 
-	var wantDeadline time.Duration
 	client := &deadlineIndexedDBClient{
 		createObjectStore: func(ctx context.Context, _ *proto.CreateObjectStoreRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-			assertDeadline(t, ctx, wantDeadline)
+			assertDeadline(t, ctx)
 			return &emptypb.Empty{}, nil
 		},
 		deleteObjectStore: func(ctx context.Context, _ *proto.DeleteObjectStoreRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-			assertDeadline(t, ctx, wantDeadline)
+			assertDeadline(t, ctx)
 			return &emptypb.Empty{}, nil
 		},
 	}
 	db := &remoteIndexedDB{client: client}
 
-	wantDeadline = providerRPCTimeout
 	if err := db.CreateObjectStore(context.Background(), "api_tokens", indexeddb.ObjectStoreSchema{}); err != nil {
 		t.Fatalf("CreateObjectStore: %v", err)
 	}
 	if err := db.DeleteObjectStore(context.Background(), "api_tokens"); err != nil {
 		t.Fatalf("DeleteObjectStore: %v", err)
-	}
-
-	migrationCtx := WithProviderMigrationTimeout(context.Background())
-	wantDeadline = providerMigrateTimeout
-	if err := db.CreateObjectStore(migrationCtx, "api_tokens", indexeddb.ObjectStoreSchema{}); err != nil {
-		t.Fatalf("CreateObjectStore with migration context: %v", err)
-	}
-	if err := db.DeleteObjectStore(migrationCtx, "api_tokens"); err != nil {
-		t.Fatalf("DeleteObjectStore with migration context: %v", err)
 	}
 }

--- a/gestaltd/internal/providerhost/indexeddb_server.go
+++ b/gestaltd/internal/providerhost/indexeddb_server.go
@@ -77,7 +77,6 @@ func (s *indexedDBServer) CreateObjectStore(ctx context.Context, req *proto.Crea
 		return nil, indexeddbToGRPCErr(err)
 	}
 	schema := protoToSchema(req.GetSchema())
-	ctx = WithProviderMigrationTimeout(ctx)
 	if err := s.ds.CreateObjectStore(ctx, s.storeName(req.GetName()), schema); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -88,7 +87,6 @@ func (s *indexedDBServer) DeleteObjectStore(ctx context.Context, req *proto.Dele
 	if err := s.ensureAllowedStore(req.GetName()); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
-	ctx = WithProviderMigrationTimeout(ctx)
 	if err := s.ds.DeleteObjectStore(ctx, s.storeName(req.GetName())); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}

--- a/gestaltd/internal/providerhost/indexeddb_server_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_server_test.go
@@ -3,7 +3,6 @@ package providerhost
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
@@ -14,42 +13,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"google.golang.org/grpc"
 )
-
-var errMissingMigrationTimeout = errors.New("missing indexeddb schema migration timeout")
-
-type schemaMigrationContextIndexedDB struct {
-	coretesting.StubIndexedDB
-
-	mu      sync.Mutex
-	created bool
-	deleted bool
-}
-
-func (db *schemaMigrationContextIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
-	if requested, _ := ctx.Value(providerMigrationTimeoutContextKey{}).(bool); !requested {
-		return errMissingMigrationTimeout
-	}
-	if err := db.StubIndexedDB.CreateObjectStore(ctx, name, schema); err != nil {
-		return err
-	}
-	db.mu.Lock()
-	db.created = true
-	db.mu.Unlock()
-	return nil
-}
-
-func (db *schemaMigrationContextIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
-	if requested, _ := ctx.Value(providerMigrationTimeoutContextKey{}).(bool); !requested {
-		return errMissingMigrationTimeout
-	}
-	if err := db.StubIndexedDB.DeleteObjectStore(ctx, name); err != nil {
-		return err
-	}
-	db.mu.Lock()
-	db.deleted = true
-	db.mu.Unlock()
-	return nil
-}
 
 func TestIndexedDBServerUsesStoreNamesAsProvided(t *testing.T) {
 	t.Parallel()
@@ -71,32 +34,6 @@ func TestIndexedDBServerUsesStoreNamesAsProvided(t *testing.T) {
 
 	if _, err := db.ObjectStore("snapshots").Get(ctx, "snap-1"); err != nil {
 		t.Fatalf("expected object store record to exist: %v", err)
-	}
-}
-
-func TestIndexedDBServerSchemaChangesUseMigrationTimeout(t *testing.T) {
-	t.Parallel()
-
-	db := &schemaMigrationContextIndexedDB{}
-	srv := NewIndexedDBServer(db, "workflow", IndexedDBServerOptions{})
-	conn := newBufconnConn(t, func(server *grpc.Server) {
-		proto.RegisterIndexedDBServer(server, srv)
-	})
-	client := proto.NewIndexedDBClient(conn)
-
-	if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{Name: "workflow_runs"}); err != nil {
-		t.Fatalf("CreateObjectStore: %v", err)
-	}
-	if _, err := client.DeleteObjectStore(context.Background(), &proto.DeleteObjectStoreRequest{Name: "workflow_runs"}); err != nil {
-		t.Fatalf("DeleteObjectStore: %v", err)
-	}
-
-	db.mu.Lock()
-	created := db.created
-	deleted := db.deleted
-	db.mu.Unlock()
-	if !created || !deleted {
-		t.Fatalf("schema change calls recorded = created:%v deleted:%v, want both true", created, deleted)
 	}
 }
 

--- a/gestaltd/internal/providerhost/runtime_client.go
+++ b/gestaltd/internal/providerhost/runtime_client.go
@@ -13,8 +13,7 @@ import (
 )
 
 const (
-	providerRPCTimeout     = 10 * time.Second
-	providerMigrateTimeout = 2 * time.Minute
+	providerRPCTimeout = 10 * time.Second
 )
 
 var providerConfigureTimeout = 30 * time.Second
@@ -149,31 +148,6 @@ func providerCallContext(parent context.Context) (context.Context, context.Cance
 	return context.WithTimeout(parent, providerRPCTimeout)
 }
 
-type providerMigrationTimeoutContextKey struct{}
-
-func WithProviderMigrationTimeout(ctx context.Context) context.Context {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	return context.WithValue(ctx, providerMigrationTimeoutContextKey{}, true)
-}
-
-func providerSchemaChangeContext(parent context.Context) (context.Context, context.CancelFunc) {
-	if parent != nil {
-		if useMigrationTimeout, _ := parent.Value(providerMigrationTimeoutContextKey{}).(bool); useMigrationTimeout {
-			return providerMigrationContext(parent)
-		}
-	}
-	return providerCallContext(parent)
-}
-
-func providerMigrationContext(parent context.Context) (context.Context, context.CancelFunc) {
-	if parent == nil {
-		parent = context.Background()
-	}
-	return context.WithTimeout(parent, providerMigrateTimeout)
-}
-
 func providerStreamContext(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent == nil {
 		parent = context.Background()
@@ -184,9 +158,6 @@ func providerStreamContext(parent context.Context) (context.Context, context.Can
 func providerConfigureContext(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent == nil {
 		parent = context.Background()
-	}
-	if useMigrationTimeout, _ := parent.Value(providerMigrationTimeoutContextKey{}).(bool); useMigrationTimeout {
-		return providerMigrationContext(parent)
 	}
 	return context.WithTimeout(parent, providerConfigureTimeout)
 }

--- a/gestaltd/internal/providerhost/runtime_client_test.go
+++ b/gestaltd/internal/providerhost/runtime_client_test.go
@@ -3,7 +3,6 @@ package providerhost
 import (
 	"context"
 	"testing"
-	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc"
@@ -109,53 +108,6 @@ func TestConfigureRuntimeProviderRefreshesMetadataAfterConfigure(t *testing.T) {
 	}
 	if len(meta.Warnings) != 1 || meta.Warnings[0] != "configured" {
 		t.Fatalf("Warnings = %#v, want %#v", meta.Warnings, []string{"configured"})
-	}
-}
-
-func TestConfigureRuntimeProviderUsesMigrationTimeoutWhenRequested(t *testing.T) {
-	t.Parallel()
-
-	assertMigrationDeadline := func(t *testing.T, ctx context.Context) {
-		t.Helper()
-		deadline, ok := ctx.Deadline()
-		if !ok {
-			t.Fatal("provider configure context has no deadline")
-		}
-		remaining := time.Until(deadline)
-		if remaining <= providerConfigureTimeout || remaining > providerMigrateTimeout {
-			t.Fatalf("provider configure deadline remaining = %s, want migration budget above %s", remaining, providerConfigureTimeout)
-		}
-	}
-
-	configureCalled := false
-	client := &fakeProviderLifecycleClient{
-		getProviderIdentity: func(ctx context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (*proto.ProviderIdentity, error) {
-			assertMigrationDeadline(t, ctx)
-			return &proto.ProviderIdentity{
-				Kind:               proto.ProviderKind_PROVIDER_KIND_WORKFLOW,
-				Name:               "indexeddb",
-				MinProtocolVersion: proto.CurrentProtocolVersion,
-				MaxProtocolVersion: proto.CurrentProtocolVersion,
-			}, nil
-		},
-		configureProvider: func(ctx context.Context, _ *proto.ConfigureProviderRequest, _ ...grpc.CallOption) (*proto.ConfigureProviderResponse, error) {
-			assertMigrationDeadline(t, ctx)
-			configureCalled = true
-			return &proto.ConfigureProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
-		},
-	}
-
-	if _, err := ConfigureRuntimeProvider(
-		WithProviderMigrationTimeout(context.Background()),
-		client,
-		proto.ProviderKind_PROVIDER_KIND_WORKFLOW,
-		"indexeddb",
-		nil,
-	); err != nil {
-		t.Fatalf("ConfigureRuntimeProvider: %v", err)
-	}
-	if !configureCalled {
-		t.Fatal("ConfigureProvider was not called")
 	}
 }
 

--- a/gestaltd/internal/providerhost/workflow_client.go
+++ b/gestaltd/internal/providerhost/workflow_client.go
@@ -49,8 +49,7 @@ func NewExecutableWorkflow(ctx context.Context, cfg WorkflowExecConfig) (corewor
 
 	runtimeClient := proto.NewProviderLifecycleClient(proc.conn)
 	workflowClient := proto.NewWorkflowProviderClient(proc.conn)
-	configureCtx := WithProviderMigrationTimeout(ctx)
-	if _, err := ConfigureRuntimeProvider(configureCtx, runtimeClient, proto.ProviderKind_PROVIDER_KIND_WORKFLOW, cfg.Name, cfg.Config); err != nil {
+	if _, err := ConfigureRuntimeProvider(ctx, runtimeClient, proto.ProviderKind_PROVIDER_KIND_WORKFLOW, cfg.Name, cfg.Config); err != nil {
 		_ = proc.Close()
 		return nil, err
 	}

--- a/gestaltd/services/runtimehost/runtimehost.go
+++ b/gestaltd/services/runtimehost/runtimehost.go
@@ -66,10 +66,6 @@ func StartRuntimeProvider(ctx context.Context, client proto.ProviderLifecycleCli
 	return providerhost.StartRuntimeProvider(ctx, client)
 }
 
-func WithProviderMigrationTimeout(ctx context.Context) context.Context {
-	return providerhost.WithProviderMigrationTimeout(ctx)
-}
-
 func NewPublicHostServiceRegistry() *PublicHostServiceRegistry {
 	return providerhost.NewPublicHostServiceRegistry()
 }


### PR DESCRIPTION
## Summary
- removes the core `WithProviderMigrationTimeout` API and the special long-running provider schema-change context
- makes executable IndexedDB `CreateObjectStore`/`DeleteObjectStore` use the ordinary provider RPC timeout
- stops workflow provider configuration and core-data startup from opting into migration-style timeouts

## Product behavior
Schema changes are no longer treated as deploy-time work in gestaltd. Providers may create missing stores through the normal IndexedDB primitive, but existing schema mismatches should fail fast at the provider boundary and be resolved by an explicit/manual migration before rollout.

## Manual migration already run
In `gitlab-peach-street` / CloudSQL `terra-east4`, I manually updated `gestaltd._gestalt_stores` for `local_execution_refs` to remove the obsolete `target_fingerprint` logical column from metadata. No records or index rows were deleted/rebuilt. The live workflow store schemas now match the current `workflow/indexeddb` schemas.

## Interface examples
Normal startup still creates missing stores through the existing IndexedDB API:

```go
err := db.CreateObjectStore(ctx, "local_execution_refs", schema)
```

A schema mismatch now stays provider-owned and should surface as a normal provider error rather than receiving a core migration timeout. The paired provider PR rejects mismatches with `FailedPrecondition` so operators can run an explicit migration first.

## Validation
- `go test ./internal/providerhost ./internal/bootstrap ./services/runtimehost`
- `rg` confirms no remaining `WithProviderMigrationTimeout` / `providerMigrateTimeout` references
- production deploy rerun passed after the manual metadata migration
