### PR TITLE
[codex] Add agent and workflow service boundaries

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"gopkg.in/yaml.v3"
 )
@@ -1693,8 +1694,8 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 	if len(bindRequests) != 1 {
 		t.Fatalf("bind host service requests = %d, want 1", len(bindRequests))
 	}
-	if bindRequests[0].EnvVar != providerhost.DefaultAgentHostSocketEnv {
-		t.Fatalf("BindHostService EnvVar = %q, want %q", bindRequests[0].EnvVar, providerhost.DefaultAgentHostSocketEnv)
+	if bindRequests[0].EnvVar != agentservice.DefaultHostSocketEnv {
+		t.Fatalf("BindHostService EnvVar = %q, want %q", bindRequests[0].EnvVar, agentservice.DefaultHostSocketEnv)
 	}
 	if got := bindRequests[0].Relay.DialTarget; !strings.HasPrefix(got, "unix://") {
 		t.Fatalf("BindHostService relay target = %q, want unix relay target", got)
@@ -2296,8 +2297,8 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 	if len(bindRequests) != 1 {
 		t.Fatalf("bind host service requests = %d, want 1", len(bindRequests))
 	}
-	if bindRequests[0].EnvVar != providerhost.DefaultAgentHostSocketEnv {
-		t.Fatalf("BindHostService EnvVar = %q, want %q", bindRequests[0].EnvVar, providerhost.DefaultAgentHostSocketEnv)
+	if bindRequests[0].EnvVar != agentservice.DefaultHostSocketEnv {
+		t.Fatalf("BindHostService EnvVar = %q, want %q", bindRequests[0].EnvVar, agentservice.DefaultHostSocketEnv)
 	}
 	if got := bindRequests[0].Relay.DialTarget; got != "tls://"+relaySrv.Listener.Addr().String() {
 		t.Fatalf("BindHostService relay target = %q, want tls relay target", got)
@@ -2307,8 +2308,8 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 	if len(startRequests) != 1 {
 		t.Fatalf("start plugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.DefaultAgentHostSocketEnv+"_TOKEN"]; strings.TrimSpace(got) == "" {
-		t.Fatalf("StartPlugin env missing %s_TOKEN: %#v", providerhost.DefaultAgentHostSocketEnv, startRequests[0].Env)
+	if got := startRequests[0].Env[agentservice.HostSocketTokenEnv()]; strings.TrimSpace(got) == "" {
+		t.Fatalf("StartPlugin env missing %s_TOKEN: %#v", agentservice.DefaultHostSocketEnv, startRequests[0].Env)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -31,13 +31,14 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
@@ -1664,9 +1665,9 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 	}
 	hostServices := []runtimehost.HostService{{
 		Name:   "workflow_host",
-		EnvVar: providerhost.DefaultWorkflowHostSocketEnv,
+		EnvVar: workflowservice.DefaultHostSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterWorkflowHostServer(srv, providerhost.NewWorkflowHostServer(name, deps.WorkflowRuntime.Invoke))
+			proto.RegisterWorkflowHostServer(srv, workflowservice.NewHostServer(name, deps.WorkflowRuntime.Invoke))
 		},
 	}}
 	var cleanup func()
@@ -1723,9 +1724,9 @@ func buildAgent(ctx context.Context, name string, entry *config.ProviderEntry, f
 	}
 	hostServices := []runtimehost.HostService{{
 		Name:   "agent_host",
-		EnvVar: providerhost.DefaultAgentHostSocketEnv,
+		EnvVar: agentservice.DefaultHostSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterAgentHostServer(srv, providerhost.NewAgentHostServer(name, deps.AgentRuntime.SearchTools, deps.AgentRuntime.ExecuteTool))
+			proto.RegisterAgentHostServer(srv, agentservice.NewHostServer(name, deps.AgentRuntime.SearchTools, deps.AgentRuntime.ExecuteTool))
 		},
 	}}
 	var cleanup func()

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -43,8 +43,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -921,7 +923,7 @@ func newCallbackAgentProvider(started *providerhost.StartedHostServices) (*callb
 	}
 	var socketPath string
 	for _, binding := range started.Bindings() {
-		if binding.EnvVar == providerhost.DefaultAgentHostSocketEnv {
+		if binding.EnvVar == agentservice.DefaultHostSocketEnv {
 			socketPath = binding.SocketPath
 			break
 		}
@@ -2325,8 +2327,8 @@ func TestBootstrapPassesConfiguredWorkflowResourceNamesToProviders(t *testing.T)
 		if _, ok := seen[name]; !ok {
 			t.Fatalf("missing workflow runtime name %q in %v", name, seen)
 		}
-		if got := hostSockets[name]; got != providerhost.DefaultWorkflowHostSocketEnv {
-			t.Fatalf("workflow host env for %q = %q, want %q", name, got, providerhost.DefaultWorkflowHostSocketEnv)
+		if got := hostSockets[name]; got != workflowservice.DefaultHostSocketEnv {
+			t.Fatalf("workflow host env for %q = %q, want %q", name, got, workflowservice.DefaultHostSocketEnv)
 		}
 	}
 }
@@ -2375,8 +2377,8 @@ func TestBootstrapPassesConfiguredAgentResourceNamesToProviders(t *testing.T) {
 		if _, ok := seen[name]; !ok {
 			t.Fatalf("missing agent runtime name %q in %v", name, seen)
 		}
-		if got := hostSockets[name]; got != providerhost.DefaultAgentHostSocketEnv {
-			t.Fatalf("agent host env for %q = %q, want %q", name, got, providerhost.DefaultAgentHostSocketEnv)
+		if got := hostSockets[name]; got != agentservice.DefaultHostSocketEnv {
+			t.Fatalf("agent host env for %q = %q, want %q", name, got, agentservice.DefaultHostSocketEnv)
 		}
 	}
 	if got := result.AgentControl.ProviderNames(); !reflect.DeepEqual(got, []string{"cleanup", "reviewer"}) {
@@ -3842,8 +3844,8 @@ func TestBootstrapPassesIndexedDBHostSocketToWorkflowProviders(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("workflow host services = %v, want 2 entries", got)
 	}
-	if got[0] != providerhost.DefaultWorkflowHostSocketEnv {
-		t.Fatalf("workflow host env = %q, want %q", got[0], providerhost.DefaultWorkflowHostSocketEnv)
+	if got[0] != workflowservice.DefaultHostSocketEnv {
+		t.Fatalf("workflow host env = %q, want %q", got[0], workflowservice.DefaultHostSocketEnv)
 	}
 	if got[1] != indexeddbservice.DefaultSocketEnv {
 		t.Fatalf("workflow indexeddb env = %q, want %q", got[1], indexeddbservice.DefaultSocketEnv)
@@ -3890,8 +3892,8 @@ func TestBootstrapPassesIndexedDBHostSocketToAgentProviders(t *testing.T) {
 	if len(hostServices) != 2 {
 		t.Fatalf("agent host services = %d, want 2", len(hostServices))
 	}
-	if hostServices[0].EnvVar != providerhost.DefaultAgentHostSocketEnv {
-		t.Fatalf("agent host env = %q, want %q", hostServices[0].EnvVar, providerhost.DefaultAgentHostSocketEnv)
+	if hostServices[0].EnvVar != agentservice.DefaultHostSocketEnv {
+		t.Fatalf("agent host env = %q, want %q", hostServices[0].EnvVar, agentservice.DefaultHostSocketEnv)
 	}
 	if hostServices[1].EnvVar != indexeddbservice.DefaultSocketEnv {
 		t.Fatalf("agent indexeddb env = %q, want %q", hostServices[1].EnvVar, indexeddbservice.DefaultSocketEnv)

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
@@ -58,6 +59,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	s3service "github.com/valon-technologies/gestalt/server/services/s3"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -971,13 +973,13 @@ func fakeHostedS3RoundTrip(bucket, key, value, binding string, env map[string]st
 }
 
 func fakeHostedWorkflowManagerRoundTrip(invocationToken string, env map[string]string) (map[string]any, error) {
-	target := strings.TrimSpace(env[providerhost.DefaultWorkflowManagerSocketEnv])
+	target := strings.TrimSpace(env[workflowservice.DefaultManagerSocketEnv])
 	if target == "" {
-		return nil, fmt.Errorf("missing workflow manager relay target in %s", providerhost.DefaultWorkflowManagerSocketEnv)
+		return nil, fmt.Errorf("missing workflow manager relay target in %s", workflowservice.DefaultManagerSocketEnv)
 	}
-	token := strings.TrimSpace(env[providerhost.WorkflowManagerSocketTokenEnv()])
+	token := strings.TrimSpace(env[workflowservice.ManagerSocketTokenEnv()])
 	if token == "" {
-		return nil, fmt.Errorf("missing workflow manager relay token in %s", providerhost.WorkflowManagerSocketTokenEnv())
+		return nil, fmt.Errorf("missing workflow manager relay token in %s", workflowservice.ManagerSocketTokenEnv())
 	}
 	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
 	if address == "" || address == target {
@@ -1101,13 +1103,13 @@ func fakeHostedAuthorizationRoundTrip(env map[string]string) (map[string]any, er
 }
 
 func fakeHostedAgentManagerRoundTrip(invocationToken string, env map[string]string) (map[string]any, error) {
-	target := strings.TrimSpace(env[providerhost.DefaultAgentManagerSocketEnv])
+	target := strings.TrimSpace(env[agentservice.DefaultManagerSocketEnv])
 	if target == "" {
-		return nil, fmt.Errorf("missing agent manager relay target in %s", providerhost.DefaultAgentManagerSocketEnv)
+		return nil, fmt.Errorf("missing agent manager relay target in %s", agentservice.DefaultManagerSocketEnv)
 	}
-	token := strings.TrimSpace(env[providerhost.AgentManagerSocketTokenEnv()])
+	token := strings.TrimSpace(env[agentservice.ManagerSocketTokenEnv()])
 	if token == "" {
-		return nil, fmt.Errorf("missing agent manager relay token in %s", providerhost.AgentManagerSocketTokenEnv())
+		return nil, fmt.Errorf("missing agent manager relay token in %s", agentservice.ManagerSocketTokenEnv())
 	}
 	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
 	if address == "" || address == target {
@@ -3760,7 +3762,7 @@ func TestPluginWorkflowManagerExposeHostSocketEnv(t *testing.T) {
 		t.Fatalf("providers.Get(echo): %v", err)
 	}
 
-	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": providerhost.DefaultWorkflowManagerSocketEnv}, "")
+	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": workflowservice.DefaultManagerSocketEnv}, "")
 	if err != nil {
 		t.Fatalf("Execute read_env: %v", err)
 	}
@@ -3773,7 +3775,7 @@ func TestPluginWorkflowManagerExposeHostSocketEnv(t *testing.T) {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
 	if !env.Found || env.Value == "" {
-		t.Fatalf("workflow manager env %q should be set for executable plugins", providerhost.DefaultWorkflowManagerSocketEnv)
+		t.Fatalf("workflow manager env %q should be set for executable plugins", workflowservice.DefaultManagerSocketEnv)
 	}
 }
 
@@ -3813,7 +3815,7 @@ func TestPluginAgentManagerExposeHostSocketEnv(t *testing.T) {
 		t.Fatalf("providers.Get(echo): %v", err)
 	}
 
-	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": providerhost.DefaultAgentManagerSocketEnv}, "")
+	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": agentservice.DefaultManagerSocketEnv}, "")
 	if err != nil {
 		t.Fatalf("Execute read_env: %v", err)
 	}
@@ -3826,7 +3828,7 @@ func TestPluginAgentManagerExposeHostSocketEnv(t *testing.T) {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
 	if !env.Found || env.Value == "" {
-		t.Fatalf("agent manager env %q should be set for executable plugins", providerhost.DefaultAgentManagerSocketEnv)
+		t.Fatalf("agent manager env %q should be set for executable plugins", agentservice.DefaultManagerSocketEnv)
 	}
 }
 
@@ -7079,19 +7081,19 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 		return env.Value, env.Found
 	}
 
-	if got, found := checkEnv(providerhost.DefaultWorkflowManagerSocketEnv); !found || got != "tls://gestalt.example.test:443" {
-		t.Fatalf("plugin workflow manager env %s = (%q, %v), want (%q, true)", providerhost.DefaultWorkflowManagerSocketEnv, got, found, "tls://gestalt.example.test:443")
+	if got, found := checkEnv(workflowservice.DefaultManagerSocketEnv); !found || got != "tls://gestalt.example.test:443" {
+		t.Fatalf("plugin workflow manager env %s = (%q, %v), want (%q, true)", workflowservice.DefaultManagerSocketEnv, got, found, "tls://gestalt.example.test:443")
 	}
-	if got, found := checkEnv(providerhost.WorkflowManagerSocketTokenEnv()); !found || got == "" {
-		t.Fatalf("plugin workflow manager token env %s = (%q, %v), want non-empty token", providerhost.WorkflowManagerSocketTokenEnv(), got, found)
+	if got, found := checkEnv(workflowservice.ManagerSocketTokenEnv()); !found || got == "" {
+		t.Fatalf("plugin workflow manager token env %s = (%q, %v), want non-empty token", workflowservice.ManagerSocketTokenEnv(), got, found)
 	}
 
 	bindRequests := runtimeProvider.bindHostServiceRequests()
 	if len(bindRequests) != 1 {
 		t.Fatalf("BindHostService requests = %d, want 1", len(bindRequests))
 	}
-	if bindRequests[0].EnvVar != providerhost.DefaultWorkflowManagerSocketEnv {
-		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, providerhost.DefaultWorkflowManagerSocketEnv)
+	if bindRequests[0].EnvVar != workflowservice.DefaultManagerSocketEnv {
+		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, workflowservice.DefaultManagerSocketEnv)
 	}
 	if got := bindRequests[0].Relay.DialTarget; got != "tls://gestalt.example.test:443" {
 		t.Fatalf("BindHostService(%s) relay target = %q, want %q", bindRequests[0].EnvVar, got, "tls://gestalt.example.test:443")
@@ -7101,7 +7103,7 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.WorkflowManagerSocketTokenEnv()]; got == "" {
+	if got := startRequests[0].Env[workflowservice.ManagerSocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the workflow manager relay token")
 	}
 	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
@@ -7611,7 +7613,7 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.WorkflowManagerSocketTokenEnv()]; got == "" {
+	if got := startRequests[0].Env[workflowservice.ManagerSocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the workflow manager relay token")
 	}
 	bindRequests := runtimeProvider.bindHostServiceRequests()

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -45,6 +45,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
@@ -52,6 +53,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/s3"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
@@ -1604,15 +1606,15 @@ func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostSe
 			serviceKey = "s3"
 			serviceLabel = "S3"
 			methodPrefix = "/" + proto.S3_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == providerhost.DefaultWorkflowManagerSocketEnv:
+		case hostService.EnvVar == workflowservice.DefaultManagerSocketEnv:
 			serviceKey = "workflow_manager"
 			serviceLabel = "workflow manager"
 			methodPrefix = "/" + proto.WorkflowManagerHost_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == providerhost.DefaultAgentHostSocketEnv:
+		case hostService.EnvVar == agentservice.DefaultHostSocketEnv:
 			serviceKey = "agent_host"
 			serviceLabel = "agent host"
 			methodPrefix = "/" + proto.AgentHost_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == providerhost.DefaultAgentManagerSocketEnv:
+		case hostService.EnvVar == agentservice.DefaultManagerSocketEnv:
 			serviceKey = "agent_manager"
 			serviceLabel = "agent manager"
 			methodPrefix = "/" + proto.AgentManagerHost_ServiceDesc.ServiceName + "/"
@@ -2037,9 +2039,9 @@ func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens 
 	}
 	return runtimehost.HostService{
 		Name:   "workflow_manager",
-		EnvVar: providerhost.DefaultWorkflowManagerSocketEnv,
+		EnvVar: workflowservice.DefaultManagerSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterWorkflowManagerHostServer(srv, providerhost.NewWorkflowManagerServer(pluginName, manager, tokens))
+			proto.RegisterWorkflowManagerHostServer(srv, workflowservice.NewManagerServer(pluginName, manager, tokens))
 		},
 	}
 }
@@ -2051,9 +2053,9 @@ func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *pr
 	}
 	return runtimehost.HostService{
 		Name:   "agent_manager",
-		EnvVar: providerhost.DefaultAgentManagerSocketEnv,
+		EnvVar: agentservice.DefaultManagerSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterAgentManagerHostServer(srv, providerhost.NewAgentManagerServer(pluginName, manager, tokens))
+			proto.RegisterAgentManagerHostServer(srv, agentservice.NewManagerServer(pluginName, manager, tokens))
 		},
 	}
 }

--- a/gestaltd/internal/drivers/agent/provider/factory.go
+++ b/gestaltd/internal/drivers/agent/provider/factory.go
@@ -7,8 +7,8 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
@@ -29,7 +29,7 @@ var Factory bootstrap.AgentFactory = func(ctx context.Context, name string, node
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableAgent(ctx, providerhost.AgentExecConfig{
+	return agentservice.NewExecutable(ctx, agentservice.ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,

--- a/gestaltd/internal/drivers/workflow/provider/factory.go
+++ b/gestaltd/internal/drivers/workflow/provider/factory.go
@@ -7,9 +7,9 @@ import (
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"gopkg.in/yaml.v3"
 )
 
@@ -29,7 +29,7 @@ var Factory bootstrap.WorkflowFactory = func(ctx context.Context, name string, n
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableWorkflow(ctx, providerhost.WorkflowExecConfig{
+	return workflowservice.NewExecutable(ctx, workflowservice.ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,

--- a/gestaltd/services/agents/agents.go
+++ b/gestaltd/services/agents/agents.go
@@ -1,0 +1,41 @@
+// Package agents exposes agent provider transport primitives.
+package agents
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+const DefaultHostSocketEnv = providerhost.DefaultAgentHostSocketEnv
+const DefaultManagerSocketEnv = providerhost.DefaultAgentManagerSocketEnv
+
+type ExecConfig = providerhost.AgentExecConfig
+type InvocationTokenManager = providerhost.InvocationTokenManager
+type ManagerService = providerhost.AgentManagerService
+
+func HostSocketTokenEnv() string {
+	return DefaultHostSocketEnv + "_TOKEN"
+}
+
+func ManagerSocketTokenEnv() string {
+	return providerhost.AgentManagerSocketTokenEnv()
+}
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (coreagent.Provider, error) {
+	return providerhost.NewExecutableAgent(ctx, cfg)
+}
+
+func NewHostServer(
+	providerName string,
+	searchTools func(context.Context, coreagent.SearchToolsRequest) (*coreagent.SearchToolsResponse, error),
+	executeTool func(context.Context, coreagent.ExecuteToolRequest) (*coreagent.ExecuteToolResponse, error),
+) proto.AgentHostServer {
+	return providerhost.NewAgentHostServer(providerName, searchTools, executeTool)
+}
+
+func NewManagerServer(pluginName string, manager ManagerService, tokens *InvocationTokenManager) proto.AgentManagerHostServer {
+	return providerhost.NewAgentManagerServer(pluginName, manager, tokens)
+}

--- a/gestaltd/services/workflows/workflows.go
+++ b/gestaltd/services/workflows/workflows.go
@@ -1,0 +1,41 @@
+// Package workflows exposes workflow provider transport primitives.
+package workflows
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
+)
+
+const DefaultHostSocketEnv = providerhost.DefaultWorkflowHostSocketEnv
+const DefaultManagerSocketEnv = providerhost.DefaultWorkflowManagerSocketEnv
+
+type ExecConfig = providerhost.WorkflowExecConfig
+type InvocationTokenManager = providerhost.InvocationTokenManager
+type ManagerService = workflowmanager.Service
+
+func HostSocketTokenEnv() string {
+	return DefaultHostSocketEnv + "_TOKEN"
+}
+
+func ManagerSocketTokenEnv() string {
+	return providerhost.WorkflowManagerSocketTokenEnv()
+}
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (coreworkflow.Provider, error) {
+	return providerhost.NewExecutableWorkflow(ctx, cfg)
+}
+
+func NewHostServer(
+	providerName string,
+	invoke func(context.Context, coreworkflow.InvokeOperationRequest) (*coreworkflow.InvokeOperationResponse, error),
+) proto.WorkflowHostServer {
+	return providerhost.NewWorkflowHostServer(providerName, invoke)
+}
+
+func NewManagerServer(pluginName string, manager ManagerService, tokens *InvocationTokenManager) proto.WorkflowManagerHostServer {
+	return providerhost.NewWorkflowManagerServer(pluginName, manager, tokens)
+}


### PR DESCRIPTION
## Summary
- add public root service facades for agent and workflow provider transport primitives
- route executable agent/workflow driver factories through those facades
- route bootstrap agent/workflow host-service wiring and existing integration tests through service-level env/server helpers

## Stack
- stacked on #1582 (`codex/gestaltd-security-provider-services`) so this PR only contains the agent/workflow boundary slice

## New Interfaces
- `agents.DefaultHostSocketEnv`
- `agents.HostSocketTokenEnv()`
- `agents.DefaultManagerSocketEnv`
- `agents.ManagerSocketTokenEnv()`
- `agents.NewExecutable(ctx, agents.ExecConfig{...})`
- `agents.NewHostServer(providerName, searchTools, executeTool)`
- `agents.NewManagerServer(pluginName, manager, tokens)`
- `workflows.DefaultHostSocketEnv`
- `workflows.HostSocketTokenEnv()`
- `workflows.DefaultManagerSocketEnv`
- `workflows.ManagerSocketTokenEnv()`
- `workflows.NewExecutable(ctx, workflows.ExecConfig{...})`
- `workflows.NewHostServer(providerName, invoke)`
- `workflows.NewManagerServer(pluginName, manager, tokens)`

## Examples
```go
provider, err := agents.NewExecutable(ctx, agents.ExecConfig{
    Command: command,
    Name:    name,
})
```

```go
hostService := runtimehost.HostService{
    Name:   "workflow_host",
    EnvVar: workflows.DefaultHostSocketEnv,
    Register: func(srv *grpc.Server) {
        proto.RegisterWorkflowHostServer(srv, workflows.NewHostServer(name, deps.WorkflowRuntime.Invoke))
    },
}
```

```go
managerService := runtimehost.HostService{
    Name:   "agent_manager",
    EnvVar: agents.DefaultManagerSocketEnv,
    Register: func(srv *grpc.Server) {
        proto.RegisterAgentManagerHostServer(srv, agents.NewManagerServer(pluginName, manager, tokens))
    },
}
```

## Review Pass
- separate GPT-5.5 xhigh reviewer pass found no findings

## Tests
```sh
cd gestaltd && go test ./services/agents ./services/workflows ./internal/drivers/agent/provider ./internal/drivers/workflow/provider ./internal/bootstrap ./internal/daemon
```

Reviewer also ran targeted bootstrap relay/env tests with `-count=1`, `gofmt -l`, and `git diff --check`.
