### PR TITLE
server: return JSON for unknown API routes

### DIFF
--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -171,7 +172,17 @@ func (s *Server) mountAPIRoutes(r chi.Router) {
 		s.mountAuthRoutes(r)
 		s.mountProviderDevPublicRoutes(r)
 		s.mountAuthenticatedRoutes(r)
+		r.NotFound(apiNotFound)
+		r.MethodNotAllowed(apiMethodNotAllowed)
 	})
+}
+
+func apiNotFound(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusNotFound, fmt.Sprintf("API route %q not found", r.URL.Path))
+}
+
+func apiMethodNotAllowed(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusMethodNotAllowed, fmt.Sprintf("method %s is not allowed for API route %q", r.Method, r.URL.Path))
 }
 
 func (s *Server) servePrometheusMetrics(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -5843,6 +5843,25 @@ func TestMountedRootUIRoutes(t *testing.T) {
 	if strings.Contains(string(body), "root-shell") {
 		t.Fatalf("health body unexpectedly served root UI: %q", body)
 	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/identities")
+	if err != nil {
+		t.Fatalf("GET unknown API route: %v", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll unknown API route: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown API route status = %d, want 404", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("unknown API route content-type = %q, want application/json", ct)
+	}
+	if strings.Contains(string(body), "root-shell") {
+		t.Fatalf("unknown API route unexpectedly served root UI: %q", body)
+	}
 }
 
 func TestMountedRootUIRoutesHiddenOnManagementProfile(t *testing.T) {


### PR DESCRIPTION
## Summary
- ensure unknown /api/v1 routes return JSON 404s instead of falling through to a mounted root UI
- add coverage for /api/v1/identities with a mounted root UI

## Validation
- go test ./internal/server -run TestMountedRootUIRoutes -count=1
