### PR TITLE
[codex] Add plugin invoker service boundary

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"gopkg.in/yaml.v3"
 )
@@ -1693,8 +1694,8 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 	if len(bindRequests) != 1 {
 		t.Fatalf("bind host service requests = %d, want 1", len(bindRequests))
 	}
-	if bindRequests[0].EnvVar != providerhost.DefaultAgentHostSocketEnv {
-		t.Fatalf("BindHostService EnvVar = %q, want %q", bindRequests[0].EnvVar, providerhost.DefaultAgentHostSocketEnv)
+	if bindRequests[0].EnvVar != agentservice.DefaultHostSocketEnv {
+		t.Fatalf("BindHostService EnvVar = %q, want %q", bindRequests[0].EnvVar, agentservice.DefaultHostSocketEnv)
 	}
 	if got := bindRequests[0].Relay.DialTarget; !strings.HasPrefix(got, "unix://") {
 		t.Fatalf("BindHostService relay target = %q, want unix relay target", got)
@@ -2296,8 +2297,8 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 	if len(bindRequests) != 1 {
 		t.Fatalf("bind host service requests = %d, want 1", len(bindRequests))
 	}
-	if bindRequests[0].EnvVar != providerhost.DefaultAgentHostSocketEnv {
-		t.Fatalf("BindHostService EnvVar = %q, want %q", bindRequests[0].EnvVar, providerhost.DefaultAgentHostSocketEnv)
+	if bindRequests[0].EnvVar != agentservice.DefaultHostSocketEnv {
+		t.Fatalf("BindHostService EnvVar = %q, want %q", bindRequests[0].EnvVar, agentservice.DefaultHostSocketEnv)
 	}
 	if got := bindRequests[0].Relay.DialTarget; got != "tls://"+relaySrv.Listener.Addr().String() {
 		t.Fatalf("BindHostService relay target = %q, want tls relay target", got)
@@ -2307,8 +2308,8 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 	if len(startRequests) != 1 {
 		t.Fatalf("start plugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.DefaultAgentHostSocketEnv+"_TOKEN"]; strings.TrimSpace(got) == "" {
-		t.Fatalf("StartPlugin env missing %s_TOKEN: %#v", providerhost.DefaultAgentHostSocketEnv, startRequests[0].Env)
+	if got := startRequests[0].Env[agentservice.HostSocketTokenEnv()]; strings.TrimSpace(got) == "" {
+		t.Fatalf("StartPlugin env missing %s_TOKEN: %#v", agentservice.DefaultHostSocketEnv, startRequests[0].Env)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -31,13 +31,14 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
@@ -1664,9 +1665,9 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 	}
 	hostServices := []runtimehost.HostService{{
 		Name:   "workflow_host",
-		EnvVar: providerhost.DefaultWorkflowHostSocketEnv,
+		EnvVar: workflowservice.DefaultHostSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterWorkflowHostServer(srv, providerhost.NewWorkflowHostServer(name, deps.WorkflowRuntime.Invoke))
+			proto.RegisterWorkflowHostServer(srv, workflowservice.NewHostServer(name, deps.WorkflowRuntime.Invoke))
 		},
 	}}
 	var cleanup func()
@@ -1723,9 +1724,9 @@ func buildAgent(ctx context.Context, name string, entry *config.ProviderEntry, f
 	}
 	hostServices := []runtimehost.HostService{{
 		Name:   "agent_host",
-		EnvVar: providerhost.DefaultAgentHostSocketEnv,
+		EnvVar: agentservice.DefaultHostSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterAgentHostServer(srv, providerhost.NewAgentHostServer(name, deps.AgentRuntime.SearchTools, deps.AgentRuntime.ExecuteTool))
+			proto.RegisterAgentHostServer(srv, agentservice.NewHostServer(name, deps.AgentRuntime.SearchTools, deps.AgentRuntime.ExecuteTool))
 		},
 	}}
 	var cleanup func()

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -43,8 +43,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -921,7 +923,7 @@ func newCallbackAgentProvider(started *providerhost.StartedHostServices) (*callb
 	}
 	var socketPath string
 	for _, binding := range started.Bindings() {
-		if binding.EnvVar == providerhost.DefaultAgentHostSocketEnv {
+		if binding.EnvVar == agentservice.DefaultHostSocketEnv {
 			socketPath = binding.SocketPath
 			break
 		}
@@ -2325,8 +2327,8 @@ func TestBootstrapPassesConfiguredWorkflowResourceNamesToProviders(t *testing.T)
 		if _, ok := seen[name]; !ok {
 			t.Fatalf("missing workflow runtime name %q in %v", name, seen)
 		}
-		if got := hostSockets[name]; got != providerhost.DefaultWorkflowHostSocketEnv {
-			t.Fatalf("workflow host env for %q = %q, want %q", name, got, providerhost.DefaultWorkflowHostSocketEnv)
+		if got := hostSockets[name]; got != workflowservice.DefaultHostSocketEnv {
+			t.Fatalf("workflow host env for %q = %q, want %q", name, got, workflowservice.DefaultHostSocketEnv)
 		}
 	}
 }
@@ -2375,8 +2377,8 @@ func TestBootstrapPassesConfiguredAgentResourceNamesToProviders(t *testing.T) {
 		if _, ok := seen[name]; !ok {
 			t.Fatalf("missing agent runtime name %q in %v", name, seen)
 		}
-		if got := hostSockets[name]; got != providerhost.DefaultAgentHostSocketEnv {
-			t.Fatalf("agent host env for %q = %q, want %q", name, got, providerhost.DefaultAgentHostSocketEnv)
+		if got := hostSockets[name]; got != agentservice.DefaultHostSocketEnv {
+			t.Fatalf("agent host env for %q = %q, want %q", name, got, agentservice.DefaultHostSocketEnv)
 		}
 	}
 	if got := result.AgentControl.ProviderNames(); !reflect.DeepEqual(got, []string{"cleanup", "reviewer"}) {
@@ -3842,8 +3844,8 @@ func TestBootstrapPassesIndexedDBHostSocketToWorkflowProviders(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("workflow host services = %v, want 2 entries", got)
 	}
-	if got[0] != providerhost.DefaultWorkflowHostSocketEnv {
-		t.Fatalf("workflow host env = %q, want %q", got[0], providerhost.DefaultWorkflowHostSocketEnv)
+	if got[0] != workflowservice.DefaultHostSocketEnv {
+		t.Fatalf("workflow host env = %q, want %q", got[0], workflowservice.DefaultHostSocketEnv)
 	}
 	if got[1] != indexeddbservice.DefaultSocketEnv {
 		t.Fatalf("workflow indexeddb env = %q, want %q", got[1], indexeddbservice.DefaultSocketEnv)
@@ -3890,8 +3892,8 @@ func TestBootstrapPassesIndexedDBHostSocketToAgentProviders(t *testing.T) {
 	if len(hostServices) != 2 {
 		t.Fatalf("agent host services = %d, want 2", len(hostServices))
 	}
-	if hostServices[0].EnvVar != providerhost.DefaultAgentHostSocketEnv {
-		t.Fatalf("agent host env = %q, want %q", hostServices[0].EnvVar, providerhost.DefaultAgentHostSocketEnv)
+	if hostServices[0].EnvVar != agentservice.DefaultHostSocketEnv {
+		t.Fatalf("agent host env = %q, want %q", hostServices[0].EnvVar, agentservice.DefaultHostSocketEnv)
 	}
 	if hostServices[1].EnvVar != indexeddbservice.DefaultSocketEnv {
 		t.Fatalf("agent indexeddb env = %q, want %q", hostServices[1].EnvVar, indexeddbservice.DefaultSocketEnv)

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	s3service "github.com/valon-technologies/gestalt/server/services/s3"
 	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
@@ -622,7 +623,7 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 			case "invoke_plugin":
 				targetPlugin, _ := params["plugin"].(string)
 				targetOperation, _ := params["operation"].(string)
-				envelope, err := fakeHostedInvokePlugin(targetPlugin, targetOperation, providerhost.InvocationTokenFromContext(ctx), env)
+				envelope, err := fakeHostedInvokePlugin(targetPlugin, targetOperation, plugininvokerservice.InvocationTokenFromContext(ctx), env)
 				if err != nil {
 					envelope = invokePluginEnvelope{
 						OK:              false,
@@ -637,7 +638,7 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 				}
 				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 			case "workflow_manager_roundtrip":
-				record, err := fakeHostedWorkflowManagerRoundTrip(providerhost.InvocationTokenFromContext(ctx), env)
+				record, err := fakeHostedWorkflowManagerRoundTrip(plugininvokerservice.InvocationTokenFromContext(ctx), env)
 				if err != nil {
 					return nil, err
 				}
@@ -647,7 +648,7 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 				}
 				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 			case "agent_manager_roundtrip":
-				record, err := fakeHostedAgentManagerRoundTrip(providerhost.InvocationTokenFromContext(ctx), env)
+				record, err := fakeHostedAgentManagerRoundTrip(plugininvokerservice.InvocationTokenFromContext(ctx), env)
 				if err != nil {
 					return nil, err
 				}
@@ -1249,13 +1250,13 @@ func fakeHostedInvokePlugin(targetPlugin, targetOperation, invocationToken strin
 		TargetPlugin:    targetPlugin,
 		TargetOperation: targetOperation,
 	}
-	target := strings.TrimSpace(env[providerhost.DefaultPluginInvokerSocketEnv])
+	target := strings.TrimSpace(env[plugininvokerservice.DefaultSocketEnv])
 	if target == "" {
-		return envelope, fmt.Errorf("missing plugin invoker relay target in %s", providerhost.DefaultPluginInvokerSocketEnv)
+		return envelope, fmt.Errorf("missing plugin invoker relay target in %s", plugininvokerservice.DefaultSocketEnv)
 	}
-	token := strings.TrimSpace(env[providerhost.PluginInvokerSocketTokenEnv()])
+	token := strings.TrimSpace(env[plugininvokerservice.SocketTokenEnv()])
 	if token == "" {
-		return envelope, fmt.Errorf("missing plugin invoker relay token in %s", providerhost.PluginInvokerSocketTokenEnv())
+		return envelope, fmt.Errorf("missing plugin invoker relay token in %s", plugininvokerservice.SocketTokenEnv())
 	}
 	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
 	if address == "" || address == target {
@@ -3709,7 +3710,7 @@ func TestPluginInvokesExposeHostSocketEnv(t *testing.T) {
 		t.Fatalf("providers.Get(caller): %v", err)
 	}
 
-	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": providerhost.DefaultPluginInvokerSocketEnv}, "")
+	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": plugininvokerservice.DefaultSocketEnv}, "")
 	if err != nil {
 		t.Fatalf("Execute read_env: %v", err)
 	}
@@ -3722,7 +3723,7 @@ func TestPluginInvokesExposeHostSocketEnv(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if !env.Found || env.Value == "" {
-		t.Fatalf("plugin invoker env %q should be set when plugin declares invokes", providerhost.DefaultPluginInvokerSocketEnv)
+		t.Fatalf("plugin invoker env %q should be set when plugin declares invokes", plugininvokerservice.DefaultSocketEnv)
 	}
 }
 
@@ -6989,7 +6990,7 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.PluginInvokerSocketTokenEnv()]; got == "" {
+	if got := startRequests[0].Env[plugininvokerservice.SocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the plugin invoker relay token")
 	}
 	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, relayURL.Hostname()) {
@@ -6999,8 +7000,8 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	if len(bindRequests) != 1 {
 		t.Fatalf("BindHostService requests = %d, want 1", len(bindRequests))
 	}
-	if bindRequests[0].EnvVar != providerhost.DefaultPluginInvokerSocketEnv {
-		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, providerhost.DefaultPluginInvokerSocketEnv)
+	if bindRequests[0].EnvVar != plugininvokerservice.DefaultSocketEnv {
+		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, plugininvokerservice.DefaultSocketEnv)
 	}
 	if got := bindRequests[0].Relay.DialTarget; !strings.HasPrefix(got, "tls://") {
 		t.Fatalf("BindHostService relay target = %q, want tls relay target", got)

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
@@ -58,6 +59,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	s3service "github.com/valon-technologies/gestalt/server/services/s3"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -971,13 +973,13 @@ func fakeHostedS3RoundTrip(bucket, key, value, binding string, env map[string]st
 }
 
 func fakeHostedWorkflowManagerRoundTrip(invocationToken string, env map[string]string) (map[string]any, error) {
-	target := strings.TrimSpace(env[providerhost.DefaultWorkflowManagerSocketEnv])
+	target := strings.TrimSpace(env[workflowservice.DefaultManagerSocketEnv])
 	if target == "" {
-		return nil, fmt.Errorf("missing workflow manager relay target in %s", providerhost.DefaultWorkflowManagerSocketEnv)
+		return nil, fmt.Errorf("missing workflow manager relay target in %s", workflowservice.DefaultManagerSocketEnv)
 	}
-	token := strings.TrimSpace(env[providerhost.WorkflowManagerSocketTokenEnv()])
+	token := strings.TrimSpace(env[workflowservice.ManagerSocketTokenEnv()])
 	if token == "" {
-		return nil, fmt.Errorf("missing workflow manager relay token in %s", providerhost.WorkflowManagerSocketTokenEnv())
+		return nil, fmt.Errorf("missing workflow manager relay token in %s", workflowservice.ManagerSocketTokenEnv())
 	}
 	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
 	if address == "" || address == target {
@@ -1101,13 +1103,13 @@ func fakeHostedAuthorizationRoundTrip(env map[string]string) (map[string]any, er
 }
 
 func fakeHostedAgentManagerRoundTrip(invocationToken string, env map[string]string) (map[string]any, error) {
-	target := strings.TrimSpace(env[providerhost.DefaultAgentManagerSocketEnv])
+	target := strings.TrimSpace(env[agentservice.DefaultManagerSocketEnv])
 	if target == "" {
-		return nil, fmt.Errorf("missing agent manager relay target in %s", providerhost.DefaultAgentManagerSocketEnv)
+		return nil, fmt.Errorf("missing agent manager relay target in %s", agentservice.DefaultManagerSocketEnv)
 	}
-	token := strings.TrimSpace(env[providerhost.AgentManagerSocketTokenEnv()])
+	token := strings.TrimSpace(env[agentservice.ManagerSocketTokenEnv()])
 	if token == "" {
-		return nil, fmt.Errorf("missing agent manager relay token in %s", providerhost.AgentManagerSocketTokenEnv())
+		return nil, fmt.Errorf("missing agent manager relay token in %s", agentservice.ManagerSocketTokenEnv())
 	}
 	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
 	if address == "" || address == target {
@@ -3760,7 +3762,7 @@ func TestPluginWorkflowManagerExposeHostSocketEnv(t *testing.T) {
 		t.Fatalf("providers.Get(echo): %v", err)
 	}
 
-	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": providerhost.DefaultWorkflowManagerSocketEnv}, "")
+	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": workflowservice.DefaultManagerSocketEnv}, "")
 	if err != nil {
 		t.Fatalf("Execute read_env: %v", err)
 	}
@@ -3773,7 +3775,7 @@ func TestPluginWorkflowManagerExposeHostSocketEnv(t *testing.T) {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
 	if !env.Found || env.Value == "" {
-		t.Fatalf("workflow manager env %q should be set for executable plugins", providerhost.DefaultWorkflowManagerSocketEnv)
+		t.Fatalf("workflow manager env %q should be set for executable plugins", workflowservice.DefaultManagerSocketEnv)
 	}
 }
 
@@ -3813,7 +3815,7 @@ func TestPluginAgentManagerExposeHostSocketEnv(t *testing.T) {
 		t.Fatalf("providers.Get(echo): %v", err)
 	}
 
-	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": providerhost.DefaultAgentManagerSocketEnv}, "")
+	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": agentservice.DefaultManagerSocketEnv}, "")
 	if err != nil {
 		t.Fatalf("Execute read_env: %v", err)
 	}
@@ -3826,7 +3828,7 @@ func TestPluginAgentManagerExposeHostSocketEnv(t *testing.T) {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
 	if !env.Found || env.Value == "" {
-		t.Fatalf("agent manager env %q should be set for executable plugins", providerhost.DefaultAgentManagerSocketEnv)
+		t.Fatalf("agent manager env %q should be set for executable plugins", agentservice.DefaultManagerSocketEnv)
 	}
 }
 
@@ -7079,19 +7081,19 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 		return env.Value, env.Found
 	}
 
-	if got, found := checkEnv(providerhost.DefaultWorkflowManagerSocketEnv); !found || got != "tls://gestalt.example.test:443" {
-		t.Fatalf("plugin workflow manager env %s = (%q, %v), want (%q, true)", providerhost.DefaultWorkflowManagerSocketEnv, got, found, "tls://gestalt.example.test:443")
+	if got, found := checkEnv(workflowservice.DefaultManagerSocketEnv); !found || got != "tls://gestalt.example.test:443" {
+		t.Fatalf("plugin workflow manager env %s = (%q, %v), want (%q, true)", workflowservice.DefaultManagerSocketEnv, got, found, "tls://gestalt.example.test:443")
 	}
-	if got, found := checkEnv(providerhost.WorkflowManagerSocketTokenEnv()); !found || got == "" {
-		t.Fatalf("plugin workflow manager token env %s = (%q, %v), want non-empty token", providerhost.WorkflowManagerSocketTokenEnv(), got, found)
+	if got, found := checkEnv(workflowservice.ManagerSocketTokenEnv()); !found || got == "" {
+		t.Fatalf("plugin workflow manager token env %s = (%q, %v), want non-empty token", workflowservice.ManagerSocketTokenEnv(), got, found)
 	}
 
 	bindRequests := runtimeProvider.bindHostServiceRequests()
 	if len(bindRequests) != 1 {
 		t.Fatalf("BindHostService requests = %d, want 1", len(bindRequests))
 	}
-	if bindRequests[0].EnvVar != providerhost.DefaultWorkflowManagerSocketEnv {
-		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, providerhost.DefaultWorkflowManagerSocketEnv)
+	if bindRequests[0].EnvVar != workflowservice.DefaultManagerSocketEnv {
+		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, workflowservice.DefaultManagerSocketEnv)
 	}
 	if got := bindRequests[0].Relay.DialTarget; got != "tls://gestalt.example.test:443" {
 		t.Fatalf("BindHostService(%s) relay target = %q, want %q", bindRequests[0].EnvVar, got, "tls://gestalt.example.test:443")
@@ -7101,7 +7103,7 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.WorkflowManagerSocketTokenEnv()]; got == "" {
+	if got := startRequests[0].Env[workflowservice.ManagerSocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the workflow manager relay token")
 	}
 	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
@@ -7611,7 +7613,7 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env[providerhost.WorkflowManagerSocketTokenEnv()]; got == "" {
+	if got := startRequests[0].Env[workflowservice.ManagerSocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the workflow manager relay token")
 	}
 	bindRequests := runtimeProvider.bindHostServiceRequests()

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -45,6 +45,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
@@ -52,6 +53,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/s3"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
@@ -1604,15 +1606,15 @@ func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostSe
 			serviceKey = "s3"
 			serviceLabel = "S3"
 			methodPrefix = "/" + proto.S3_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == providerhost.DefaultWorkflowManagerSocketEnv:
+		case hostService.EnvVar == workflowservice.DefaultManagerSocketEnv:
 			serviceKey = "workflow_manager"
 			serviceLabel = "workflow manager"
 			methodPrefix = "/" + proto.WorkflowManagerHost_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == providerhost.DefaultAgentHostSocketEnv:
+		case hostService.EnvVar == agentservice.DefaultHostSocketEnv:
 			serviceKey = "agent_host"
 			serviceLabel = "agent host"
 			methodPrefix = "/" + proto.AgentHost_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == providerhost.DefaultAgentManagerSocketEnv:
+		case hostService.EnvVar == agentservice.DefaultManagerSocketEnv:
 			serviceKey = "agent_manager"
 			serviceLabel = "agent manager"
 			methodPrefix = "/" + proto.AgentManagerHost_ServiceDesc.ServiceName + "/"
@@ -2037,9 +2039,9 @@ func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens 
 	}
 	return runtimehost.HostService{
 		Name:   "workflow_manager",
-		EnvVar: providerhost.DefaultWorkflowManagerSocketEnv,
+		EnvVar: workflowservice.DefaultManagerSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterWorkflowManagerHostServer(srv, providerhost.NewWorkflowManagerServer(pluginName, manager, tokens))
+			proto.RegisterWorkflowManagerHostServer(srv, workflowservice.NewManagerServer(pluginName, manager, tokens))
 		},
 	}
 }
@@ -2051,9 +2053,9 @@ func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *pr
 	}
 	return runtimehost.HostService{
 		Name:   "agent_manager",
-		EnvVar: providerhost.DefaultAgentManagerSocketEnv,
+		EnvVar: agentservice.DefaultManagerSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterAgentManagerHostServer(srv, providerhost.NewAgentManagerServer(pluginName, manager, tokens))
+			proto.RegisterAgentManagerHostServer(srv, agentservice.NewManagerServer(pluginName, manager, tokens))
 		},
 	}
 }

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -51,6 +51,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/s3"
 	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
@@ -970,7 +971,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	if invTokens != nil {
 		opts = append(opts,
 			providerhost.WithInvocationTokens(invTokens),
-			providerhost.WithInvocationTokenSubject(name, providerhost.InvocationDependencyGrants(entry.Invokes)),
+			providerhost.WithInvocationTokenSubject(name, plugininvokerservice.InvocationDependencyGrants(entry.Invokes)),
 		)
 	}
 	prov, err := providerhost.NewRemoteProvider(ctx, conn.Integration(), spec, pluginConfig, opts...)
@@ -1512,13 +1513,13 @@ func waitForPluginRuntimeSessionReady(ctx context.Context, runtimeProvider plugi
 	}
 }
 
-func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, deps Deps, allowDirectBindings bool) ([]runtimehost.HostService, *providerhost.InvocationTokenManager, func(), error) {
+func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, deps Deps, allowDirectBindings bool) ([]runtimehost.HostService, *plugininvokerservice.InvocationTokenManager, func(), error) {
 	var (
 		hostServices []runtimehost.HostService
 		cleanup      func()
-		invTokens    *providerhost.InvocationTokenManager
+		invTokens    *plugininvokerservice.InvocationTokenManager
 	)
-	fail := func(err error) ([]runtimehost.HostService, *providerhost.InvocationTokenManager, func(), error) {
+	fail := func(err error) ([]runtimehost.HostService, *plugininvokerservice.InvocationTokenManager, func(), error) {
 		if cleanup != nil {
 			cleanup()
 			cleanup = nil
@@ -1560,7 +1561,7 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 		needInvocationTokens = true
 	}
 	if needInvocationTokens {
-		invTokens, err = providerhost.NewInvocationTokenManager(deps.EncryptionKey)
+		invTokens, err = plugininvokerservice.NewInvocationTokenManager(deps.EncryptionKey)
 		if err != nil {
 			return fail(err)
 		}
@@ -1622,7 +1623,7 @@ func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostSe
 			serviceKey = "authorization"
 			serviceLabel = "authorization"
 			methodPrefix = "/" + proto.AuthorizationProvider_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == providerhost.DefaultPluginInvokerSocketEnv:
+		case hostService.EnvVar == plugininvokerservice.DefaultSocketEnv:
 			serviceKey = "plugin_invoker"
 			serviceLabel = "plugin invoker"
 			methodPrefix = "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/"
@@ -2032,7 +2033,7 @@ func buildAgentIndexedDBHostServices(name string, effective config.EffectiveHost
 	}, nil
 }
 
-func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens *providerhost.InvocationTokenManager) runtimehost.HostService {
+func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens *plugininvokerservice.InvocationTokenManager) runtimehost.HostService {
 	manager := deps.WorkflowManager
 	if manager == nil {
 		manager = unavailableWorkflowManager{}
@@ -2046,7 +2047,7 @@ func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens 
 	}
 }
 
-func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *providerhost.InvocationTokenManager) runtimehost.HostService {
+func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *plugininvokerservice.InvocationTokenManager) runtimehost.HostService {
 	manager := deps.AgentManager
 	if manager == nil {
 		manager = unavailableAgentManager{}
@@ -2070,16 +2071,16 @@ func buildPluginAuthorizationHostService(provider core.AuthorizationProvider) ru
 	}
 }
 
-func buildPluginInvokerHostService(pluginName string, entry *config.ProviderEntry, deps Deps, tokens *providerhost.InvocationTokenManager) runtimehost.HostService {
+func buildPluginInvokerHostService(pluginName string, entry *config.ProviderEntry, deps Deps, tokens *plugininvokerservice.InvocationTokenManager) runtimehost.HostService {
 	invoker := deps.PluginInvoker
 	if invoker == nil {
 		invoker = unavailablePluginInvoker{}
 	}
 	return runtimehost.HostService{
 		Name:   "plugin_invoker",
-		EnvVar: providerhost.DefaultPluginInvokerSocketEnv,
+		EnvVar: plugininvokerservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterPluginInvokerServer(srv, providerhost.NewPluginInvokerServer(pluginName, entry.Invokes, invoker, tokens))
+			proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer(pluginName, entry.Invokes, invoker, tokens))
 		},
 	}
 }

--- a/gestaltd/internal/drivers/agent/provider/factory.go
+++ b/gestaltd/internal/drivers/agent/provider/factory.go
@@ -7,8 +7,8 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
@@ -29,7 +29,7 @@ var Factory bootstrap.AgentFactory = func(ctx context.Context, name string, node
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableAgent(ctx, providerhost.AgentExecConfig{
+	return agentservice.NewExecutable(ctx, agentservice.ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,

--- a/gestaltd/internal/drivers/workflow/provider/factory.go
+++ b/gestaltd/internal/drivers/workflow/provider/factory.go
@@ -7,9 +7,9 @@ import (
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"gopkg.in/yaml.v3"
 )
 
@@ -29,7 +29,7 @@ var Factory bootstrap.WorkflowFactory = func(ctx context.Context, name string, n
 	}
 	cfg = prepared.YAMLConfig
 
-	return providerhost.NewExecutableWorkflow(ctx, providerhost.WorkflowExecConfig{
+	return workflowservice.NewExecutable(ctx, workflowservice.ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,

--- a/gestaltd/services/agents/agents.go
+++ b/gestaltd/services/agents/agents.go
@@ -1,0 +1,41 @@
+// Package agents exposes agent provider transport primitives.
+package agents
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+const DefaultHostSocketEnv = providerhost.DefaultAgentHostSocketEnv
+const DefaultManagerSocketEnv = providerhost.DefaultAgentManagerSocketEnv
+
+type ExecConfig = providerhost.AgentExecConfig
+type InvocationTokenManager = providerhost.InvocationTokenManager
+type ManagerService = providerhost.AgentManagerService
+
+func HostSocketTokenEnv() string {
+	return DefaultHostSocketEnv + "_TOKEN"
+}
+
+func ManagerSocketTokenEnv() string {
+	return providerhost.AgentManagerSocketTokenEnv()
+}
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (coreagent.Provider, error) {
+	return providerhost.NewExecutableAgent(ctx, cfg)
+}
+
+func NewHostServer(
+	providerName string,
+	searchTools func(context.Context, coreagent.SearchToolsRequest) (*coreagent.SearchToolsResponse, error),
+	executeTool func(context.Context, coreagent.ExecuteToolRequest) (*coreagent.ExecuteToolResponse, error),
+) proto.AgentHostServer {
+	return providerhost.NewAgentHostServer(providerName, searchTools, executeTool)
+}
+
+func NewManagerServer(pluginName string, manager ManagerService, tokens *InvocationTokenManager) proto.AgentManagerHostServer {
+	return providerhost.NewAgentManagerServer(pluginName, manager, tokens)
+}

--- a/gestaltd/services/plugininvoker/plugininvoker.go
+++ b/gestaltd/services/plugininvoker/plugininvoker.go
@@ -1,0 +1,37 @@
+// Package plugininvoker exposes plugin invocation host-service primitives.
+package plugininvoker
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+const DefaultSocketEnv = providerhost.DefaultPluginInvokerSocketEnv
+
+type InvocationGrant = providerhost.InvocationGrant
+type InvocationGrants = providerhost.InvocationGrants
+type InvocationTokenManager = providerhost.InvocationTokenManager
+
+func SocketTokenEnv() string {
+	return providerhost.PluginInvokerSocketTokenEnv()
+}
+
+func NewInvocationTokenManager(secret []byte) (*InvocationTokenManager, error) {
+	return providerhost.NewInvocationTokenManager(secret)
+}
+
+func InvocationDependencyGrants(deps []config.PluginInvocationDependency) InvocationGrants {
+	return providerhost.InvocationDependencyGrants(deps)
+}
+
+func InvocationTokenFromContext(ctx context.Context) string {
+	return providerhost.InvocationTokenFromContext(ctx)
+}
+
+func NewServer(pluginName string, deps []config.PluginInvocationDependency, invoker invocation.Invoker, tokens *InvocationTokenManager) proto.PluginInvokerServer {
+	return providerhost.NewPluginInvokerServer(pluginName, deps, invoker, tokens)
+}

--- a/gestaltd/services/workflows/workflows.go
+++ b/gestaltd/services/workflows/workflows.go
@@ -1,0 +1,41 @@
+// Package workflows exposes workflow provider transport primitives.
+package workflows
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
+)
+
+const DefaultHostSocketEnv = providerhost.DefaultWorkflowHostSocketEnv
+const DefaultManagerSocketEnv = providerhost.DefaultWorkflowManagerSocketEnv
+
+type ExecConfig = providerhost.WorkflowExecConfig
+type InvocationTokenManager = providerhost.InvocationTokenManager
+type ManagerService = workflowmanager.Service
+
+func HostSocketTokenEnv() string {
+	return DefaultHostSocketEnv + "_TOKEN"
+}
+
+func ManagerSocketTokenEnv() string {
+	return providerhost.WorkflowManagerSocketTokenEnv()
+}
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (coreworkflow.Provider, error) {
+	return providerhost.NewExecutableWorkflow(ctx, cfg)
+}
+
+func NewHostServer(
+	providerName string,
+	invoke func(context.Context, coreworkflow.InvokeOperationRequest) (*coreworkflow.InvokeOperationResponse, error),
+) proto.WorkflowHostServer {
+	return providerhost.NewWorkflowHostServer(providerName, invoke)
+}
+
+func NewManagerServer(pluginName string, manager ManagerService, tokens *InvocationTokenManager) proto.WorkflowManagerHostServer {
+	return providerhost.NewWorkflowManagerServer(pluginName, manager, tokens)
+}


### PR DESCRIPTION
## Summary
- add a `services/plugininvoker` facade for plugin invocation host-service primitives
- route plugin runtime host-service setup through service-level token/env/server helpers
- update hosted plugin invocation transport tests to assert through the service boundary

## Stack
- stacked on #1585 (`codex/gestaltd-agent-workflow-services`) so this PR only contains the plugin-invoker boundary slice

## New Interfaces
- `plugininvoker.DefaultSocketEnv`
- `plugininvoker.SocketTokenEnv()`
- `plugininvoker.NewInvocationTokenManager(secret)`
- `plugininvoker.InvocationDependencyGrants(deps)`
- `plugininvoker.InvocationTokenFromContext(ctx)`
- `plugininvoker.NewServer(pluginName, deps, invoker, tokens)`

## Examples
```go
tokens, err := plugininvoker.NewInvocationTokenManager(deps.EncryptionKey)
```

```go
hostService := runtimehost.HostService{
    Name:   "plugin_invoker",
    EnvVar: plugininvoker.DefaultSocketEnv,
    Register: func(srv *grpc.Server) {
        proto.RegisterPluginInvokerServer(srv, plugininvoker.NewServer(pluginName, entry.Invokes, invoker, tokens))
    },
}
```

```go
invocationToken := plugininvoker.InvocationTokenFromContext(ctx)
```

## Review Pass
- separate GPT-5.5 xhigh reviewer pass found no findings

## Tests
```sh
cd gestaltd && go test ./services/plugininvoker ./internal/bootstrap
```

Reviewer also ran `go test ./services/plugininvoker ./internal/bootstrap -count=1`, `go test ./internal/providerhost -count=1`, `go list ./services/...`, `gofmt -l`, and `git diff --check`.
