### PR TITLE
[codex] Add plugin provider transport boundary

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -58,6 +58,7 @@ import (
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	s3service "github.com/valon-technologies/gestalt/server/services/s3"
 	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
@@ -487,7 +488,7 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 	}
 	r.mu.Unlock()
 
-	dir, err := providerhost.NewPluginTempDir("gstp-fake-")
+	dir, err := pluginservice.NewPluginTempDir("gstp-fake-")
 	if err != nil {
 		return nil, fmt.Errorf("create fake hosted plugin dir: %w", err)
 	}
@@ -499,7 +500,7 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 	}
 
 	srv := grpc.NewServer()
-	proto.RegisterIntegrationProviderServer(srv, providerhost.NewProviderServer(&coretesting.StubIntegration{
+	proto.RegisterIntegrationProviderServer(srv, pluginservice.NewServer(&coretesting.StubIntegration{
 		N:        req.PluginName,
 		DN:       "Fake Hosted Plugin",
 		Desc:     "test-only fake hosted plugin",

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -52,6 +52,7 @@ import (
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/s3"
 	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
@@ -209,7 +210,7 @@ func validateProviderConnectionMode(provider string, mode core.ConnectionMode) e
 	}
 }
 
-func BuildStartupProviderSpec(name string, entry *config.ProviderEntry) (providerhost.StaticProviderSpec, map[string]string, error) {
+func BuildStartupProviderSpec(name string, entry *config.ProviderEntry) (pluginservice.StaticProviderSpec, map[string]string, error) {
 	spec, routing, err := buildStartupProviderSpec(name, entry)
 	return spec, routing.connections, err
 }
@@ -220,24 +221,24 @@ type startupOperationRouting struct {
 	overridePolicy core.OperationConnectionOverridePolicy
 }
 
-func buildStartupProviderSpec(name string, entry *config.ProviderEntry) (providerhost.StaticProviderSpec, startupOperationRouting, error) {
+func buildStartupProviderSpec(name string, entry *config.ProviderEntry) (pluginservice.StaticProviderSpec, startupOperationRouting, error) {
 	if entry == nil {
-		return providerhost.StaticProviderSpec{}, startupOperationRouting{}, fmt.Errorf("integration %q has no plugin defined", name)
+		return pluginservice.StaticProviderSpec{}, startupOperationRouting{}, fmt.Errorf("integration %q has no plugin defined", name)
 	}
 	manifest := entry.ResolvedManifest
 	manifestPlugin := entry.ManifestSpec()
 	if manifest == nil || manifestPlugin == nil {
-		return providerhost.StaticProviderSpec{}, startupOperationRouting{}, fmt.Errorf("integration %q must resolve to a provider manifest", name)
+		return pluginservice.StaticProviderSpec{}, startupOperationRouting{}, fmt.Errorf("integration %q must resolve to a provider manifest", name)
 	}
 
 	meta := resolveProviderMetadata(entry)
 	spec, plan, err := buildPluginStaticSpec(name, entry, manifest, meta)
 	if err != nil {
-		return providerhost.StaticProviderSpec{}, startupOperationRouting{}, err
+		return pluginservice.StaticProviderSpec{}, startupOperationRouting{}, err
 	}
 	restConnections, restSelectors, restLocks, err := plan.RESTOperationConnectionBindings(manifestPlugin)
 	if err != nil {
-		return providerhost.StaticProviderSpec{}, startupOperationRouting{}, err
+		return pluginservice.StaticProviderSpec{}, startupOperationRouting{}, err
 	}
 	if spec.Catalog != nil {
 		return spec, startupOperationRouting{connections: operationConnectionsForCatalog(spec.Catalog, plan, restConnections)}, nil
@@ -245,15 +246,15 @@ func buildStartupProviderSpec(name string, entry *config.ProviderEntry) (provide
 	if !manifestPlugin.IsDeclarative() && !manifestPlugin.IsSpecLoaded() {
 		return spec, startupOperationRouting{connections: map[string]string{}}, nil
 	}
-	declarative, err := providerhost.NewDeclarativeProvider(
+	declarative, err := pluginservice.NewDeclarativeProvider(
 		manifest,
 		nil,
-		providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
-		providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
-		providerhost.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
+		pluginservice.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+		pluginservice.WithDeclarativeConnectionMode(plan.ConnectionMode()),
+		pluginservice.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
 	)
 	if err != nil {
-		return providerhost.StaticProviderSpec{}, startupOperationRouting{}, err
+		return pluginservice.StaticProviderSpec{}, startupOperationRouting{}, err
 	}
 	spec.Catalog = declarative.Catalog()
 	return spec, startupOperationRouting{
@@ -356,12 +357,12 @@ func buildProvider(ctx context.Context, name string, entry *config.ProviderEntry
 		if err != nil {
 			return nil, fmt.Errorf("build declarative provider %q: %w", name, err)
 		}
-		declarative, err := providerhost.NewDeclarativeProvider(
+		declarative, err := pluginservice.NewDeclarativeProvider(
 			manifest,
 			nil,
-			providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
-			providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
-			providerhost.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
+			pluginservice.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+			pluginservice.WithDeclarativeConnectionMode(plan.ConnectionMode()),
+			pluginservice.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
@@ -409,12 +410,12 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 			return nil, err
 		}
 		pluginProv = filteredPluginProv
-		declarative, err := providerhost.NewDeclarativeProvider(
+		declarative, err := pluginservice.NewDeclarativeProvider(
 			manifest,
 			nil,
-			providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
-			providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
-			providerhost.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
+			pluginservice.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+			pluginservice.WithDeclarativeConnectionMode(plan.ConnectionMode()),
+			pluginservice.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
 		)
 		if err != nil {
 			closeIfPossible(pluginProv)
@@ -787,7 +788,7 @@ func catalogOperationCount(cat *catalog.Catalog) int {
 	return len(cat.Operations)
 }
 
-func buildPluginProvider(ctx context.Context, name string, entry *config.ProviderEntry, pluginConfig map[string]any, spec providerhost.StaticProviderSpec, deps Deps) (core.Provider, error) {
+func buildPluginProvider(ctx context.Context, name string, entry *config.ProviderEntry, pluginConfig map[string]any, spec pluginservice.StaticProviderSpec, deps Deps) (core.Provider, error) {
 	command := entry.Command
 	args := entry.Args
 	env := clonePluginEnv(entry.Env)
@@ -961,7 +962,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	if err != nil {
 		return nil, fmt.Errorf("dial hosted plugin: %w", err)
 	}
-	opts := []providerhost.RemoteProviderOption{providerhost.WithCloser(&runtimeBackedHostedCloser{
+	opts := []pluginservice.RemoteProviderOption{pluginservice.WithCloser(&runtimeBackedHostedCloser{
 		conn:         conn,
 		runtime:      runtimeProvider,
 		sessionID:    sessionID,
@@ -970,11 +971,11 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	})}
 	if invTokens != nil {
 		opts = append(opts,
-			providerhost.WithInvocationTokens(invTokens),
-			providerhost.WithInvocationTokenSubject(name, plugininvokerservice.InvocationDependencyGrants(entry.Invokes)),
+			pluginservice.WithInvocationTokens(invTokens),
+			pluginservice.WithInvocationTokenSubject(name, plugininvokerservice.InvocationDependencyGrants(entry.Invokes)),
 		)
 	}
-	prov, err := providerhost.NewRemoteProvider(ctx, conn.Integration(), spec, pluginConfig, opts...)
+	prov, err := pluginservice.NewRemote(ctx, conn.Integration(), spec, pluginConfig, opts...)
 	if err != nil {
 		_ = conn.Close()
 		return nil, err
@@ -2447,13 +2448,13 @@ func clonePluginEnv(src map[string]string) map[string]string {
 	return dst
 }
 
-func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, meta providerMetadata) (providerhost.StaticProviderSpec, config.StaticConnectionPlan, error) {
+func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, meta providerMetadata) (pluginservice.StaticProviderSpec, config.StaticConnectionPlan, error) {
 	if manifest == nil || manifest.Spec == nil {
-		return providerhost.StaticProviderSpec{}, config.StaticConnectionPlan{}, fmt.Errorf("resolved manifest is required")
+		return pluginservice.StaticProviderSpec{}, config.StaticConnectionPlan{}, fmt.Errorf("resolved manifest is required")
 	}
 	plan, err := config.BuildStaticConnectionPlan(entry, manifest.Spec)
 	if err != nil {
-		return providerhost.StaticProviderSpec{}, config.StaticConnectionPlan{}, err
+		return pluginservice.StaticProviderSpec{}, config.StaticConnectionPlan{}, err
 	}
 
 	displayName := meta.displayNameOr(manifest.DisplayName)
@@ -2479,14 +2480,14 @@ func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *p
 		var err error
 		staticCatalog, err = providerpkg.ReadStaticCatalog(manifestRoot, name)
 		if err != nil {
-			return providerhost.StaticProviderSpec{}, config.StaticConnectionPlan{}, err
+			return pluginservice.StaticProviderSpec{}, config.StaticConnectionPlan{}, err
 		}
 	}
 	if staticCatalog == nil && providerpkg.StaticCatalogRequired(manifest) {
 		if entry.ResolvedManifestPath == "" {
-			return providerhost.StaticProviderSpec{}, config.StaticConnectionPlan{}, fmt.Errorf("resolved manifest path is required for executable provider static catalog")
+			return pluginservice.StaticProviderSpec{}, config.StaticConnectionPlan{}, fmt.Errorf("resolved manifest path is required for executable provider static catalog")
 		}
-		return providerhost.StaticProviderSpec{}, config.StaticConnectionPlan{}, fmt.Errorf("executable providers without declarative or spec surfaces must define %s", providerpkg.StaticCatalogFile)
+		return pluginservice.StaticProviderSpec{}, config.StaticConnectionPlan{}, fmt.Errorf("executable providers without declarative or spec surfaces must define %s", providerpkg.StaticCatalogFile)
 	}
 	if staticCatalog != nil {
 		if displayName != "" {
@@ -2500,7 +2501,7 @@ func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *p
 		}
 	}
 
-	return providerhost.StaticProviderSpec{
+	return pluginservice.StaticProviderSpec{
 		Name:             name,
 		DisplayName:      displayName,
 		Description:      description,
@@ -2508,9 +2509,9 @@ func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *p
 		ConnectionMode:   connMode,
 		Catalog:          staticCatalog,
 		AuthTypes:        staticAuthTypes(conn.Auth.Type),
-		ConnectionParams: providerhost.ConnectionParamDefsFromManifest(conn.ConnectionParams),
-		CredentialFields: providerhost.CredentialFieldsFromManifest(conn.Auth.Credentials),
-		DiscoveryConfig:  providerhost.DiscoveryConfigFromManifest(conn.Discovery),
+		ConnectionParams: pluginservice.ConnectionParamDefsFromManifest(conn.ConnectionParams),
+		CredentialFields: pluginservice.CredentialFieldsFromManifest(conn.Auth.Credentials),
+		DiscoveryConfig:  pluginservice.DiscoveryConfigFromManifest(conn.Discovery),
 	}, plan, nil
 }
 

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -12,8 +12,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 )
 
@@ -110,9 +110,9 @@ func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers
 	}
 }
 
-func providerDevStaticSpecFromProvider(name string, entry *config.ProviderEntry, provider core.Provider) providerhost.StaticProviderSpec {
+func providerDevStaticSpecFromProvider(name string, entry *config.ProviderEntry, provider core.Provider) pluginservice.StaticProviderSpec {
 	meta := resolveProviderMetadata(entry)
-	spec := providerhost.StaticProviderSpec{
+	spec := pluginservice.StaticProviderSpec{
 		Name:             name,
 		DisplayName:      provider.DisplayName(),
 		Description:      provider.Description(),

--- a/gestaltd/internal/bootstrap/startup_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_proxy.go
@@ -12,8 +12,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 )
 
 type startupWaitTracker struct {
@@ -78,7 +78,7 @@ func (t *startupWaitTracker) beginWorkflowWait(providerName, pluginName string) 
 }
 
 type startupProviderProxy struct {
-	spec             providerhost.StaticProviderSpec
+	spec             pluginservice.StaticProviderSpec
 	operationRouting startupOperationRouting
 	tracker          *startupWaitTracker
 
@@ -90,7 +90,7 @@ type startupProviderProxy struct {
 	err      error
 }
 
-func newStartupProviderProxy(spec providerhost.StaticProviderSpec, operationRouting startupOperationRouting, tracker *startupWaitTracker) *startupProviderProxy {
+func newStartupProviderProxy(spec pluginservice.StaticProviderSpec, operationRouting startupOperationRouting, tracker *startupWaitTracker) *startupProviderProxy {
 	operationRouting.connections = maps.Clone(operationRouting.connections)
 	return &startupProviderProxy{
 		spec:             spec,

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -20,9 +20,9 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -275,8 +275,8 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 
 	scheduledFor := time.Date(2026, time.April, 15, 12, 30, 0, 0, time.UTC)
 	roundTripProvider := &workflowRoundTripProvider{}
-	roundTripClient := newWorkflowRoundTripClient(t, providerhost.NewProviderServer(roundTripProvider))
-	roundTripRemote, err := providerhost.NewRemoteProvider(context.Background(), roundTripClient, providerhost.StaticProviderSpec{
+	roundTripClient := newWorkflowRoundTripClient(t, pluginservice.NewServer(roundTripProvider))
+	roundTripRemote, err := pluginservice.NewRemote(context.Background(), roundTripClient, pluginservice.StaticProviderSpec{
 		Name:           "workflow-roundtrip",
 		DisplayName:    "Workflow Round Trip",
 		Description:    "workflow round trip test provider",

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -35,6 +35,7 @@ import (
 	authenticationservice "github.com/valon-technologies/gestalt/server/services/authentication"
 	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	externalcredentialsservice "github.com/valon-technologies/gestalt/server/services/externalcredentials"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	secretsservice "github.com/valon-technologies/gestalt/server/services/secrets"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
@@ -645,15 +646,15 @@ func TestRun_ProviderReleaseBuildsPythonSourcePluginForCurrentPlatform(t *testin
 	}
 
 	ctx := context.Background()
-	prov, err := providerhost.NewExecutableProvider(ctx, providerhost.ExecConfig{
+	prov, err := pluginservice.NewExecutable(ctx, pluginservice.ExecConfig{
 		Command: artifactPath,
-		StaticSpec: providerhost.StaticProviderSpec{
+		StaticSpec: pluginservice.StaticProviderSpec{
 			Name: "python-release",
 		},
 		Config: map[string]any{"greeting": "Hi"},
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableProvider: %v", err)
+		t.Fatalf("pluginservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := prov.(interface{ Close() error }); ok {
@@ -991,15 +992,15 @@ func TestRun_ProviderReleaseBuildsRustSourcePluginForCurrentPlatform(t *testing.
 	}
 
 	ctx := context.Background()
-	prov, err := providerhost.NewExecutableProvider(ctx, providerhost.ExecConfig{
+	prov, err := pluginservice.NewExecutable(ctx, pluginservice.ExecConfig{
 		Command: artifactPath,
-		StaticSpec: providerhost.StaticProviderSpec{
+		StaticSpec: pluginservice.StaticProviderSpec{
 			Name: rustReleasePluginName,
 		},
 		Config: map[string]any{"greeting": "Hi"},
 	})
 	if err != nil {
-		t.Fatalf("NewExecutableProvider: %v", err)
+		t.Fatalf("pluginservice.NewExecutable: %v", err)
 	}
 	defer func() {
 		if closer, ok := prov.(interface{ Close() error }); ok {

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -25,7 +25,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -56,7 +56,7 @@ type RuntimeEnvBuilder func(sessionID string) (RuntimeEnv, error)
 type Target struct {
 	Name       string
 	Source     string
-	Spec       providerhost.StaticProviderSpec
+	Spec       pluginservice.StaticProviderSpec
 	Config     map[string]any
 	UI         bool
 	UIPath     string
@@ -75,11 +75,11 @@ type CreateSessionRequest struct {
 }
 
 type AttachProvider struct {
-	Name   string                          `json:"name"`
-	Source string                          `json:"source,omitempty"`
-	Spec   providerhost.StaticProviderSpec `json:"spec"`
-	Config *map[string]any                 `json:"config,omitempty"`
-	UI     bool                            `json:"ui,omitempty"`
+	Name   string                           `json:"name"`
+	Source string                           `json:"source,omitempty"`
+	Spec   pluginservice.StaticProviderSpec `json:"spec"`
+	Config *map[string]any                  `json:"config,omitempty"`
+	UI     bool                             `json:"ui,omitempty"`
 }
 
 type CreateSessionResponse struct {
@@ -1166,7 +1166,7 @@ func (t *attachedTarget) providerForSession(ctx context.Context, session *Sessio
 	}
 
 	client := &sessionProviderClient{session: session, provider: providerName}
-	prov, err := providerhost.NewRemoteProvider(ctx, client, t.target.Spec, t.target.Config)
+	prov, err := pluginservice.NewRemote(ctx, client, t.target.Spec, t.target.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -1735,7 +1735,7 @@ func normalizeAttachProviders(values []AttachProvider) ([]AttachProvider, error)
 	return requests, nil
 }
 
-func buildAttachSpec(remoteSpec providerhost.StaticProviderSpec, localSpec providerhost.StaticProviderSpec) providerhost.StaticProviderSpec {
+func buildAttachSpec(remoteSpec pluginservice.StaticProviderSpec, localSpec pluginservice.StaticProviderSpec) pluginservice.StaticProviderSpec {
 	spec := cloneStaticProviderSpec(remoteSpec)
 	if spec.Name == "" {
 		spec.Name = localSpec.Name
@@ -1784,7 +1784,7 @@ func buildAttachCatalog(remoteCat, localCat *catalog.Catalog) *catalog.Catalog {
 	return out
 }
 
-func cloneStaticProviderSpec(spec providerhost.StaticProviderSpec) providerhost.StaticProviderSpec {
+func cloneStaticProviderSpec(spec pluginservice.StaticProviderSpec) pluginservice.StaticProviderSpec {
 	out := spec
 	out.AuthTypes = slices.Clone(spec.AuthTypes)
 	if spec.ConnectionParams != nil {

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -41,7 +41,7 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 			}},
 		},
 	}
-	spec := providerhost.StaticProviderSpec{
+	spec := pluginservice.StaticProviderSpec{
 		Name:           "roadmap",
 		DisplayName:    "Roadmap",
 		ConnectionMode: core.ConnectionModeNone,
@@ -55,7 +55,7 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 			}},
 		},
 	}
-	remoteSpec := providerhost.StaticProviderSpec{
+	remoteSpec := pluginservice.StaticProviderSpec{
 		Name:           "roadmap",
 		ConnectionMode: core.ConnectionModeUser,
 		AuthTypes:      []string{"oauth2"},
@@ -290,7 +290,7 @@ func TestCreateSessionMatchesProviderBySource(t *testing.T) {
 	manager, err := NewManager([]Target{{
 		Name:   "workplaceHub",
 		Source: "github.com/valon-technologies/valon-tools/plugins/workplace-hub",
-		Spec: providerhost.StaticProviderSpec{
+		Spec: pluginservice.StaticProviderSpec{
 			Name: "workplaceHub",
 		},
 		Config: map[string]any{"remote": true},
@@ -302,7 +302,7 @@ func TestCreateSessionMatchesProviderBySource(t *testing.T) {
 	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
 	resp, err := manager.CreateSession(context.Background(), p, CreateSessionRequest{Providers: []AttachProvider{{
 		Source: "github.com/valon-technologies/valon-tools/plugins/workplace-hub",
-		Spec: providerhost.StaticProviderSpec{
+		Spec: pluginservice.StaticProviderSpec{
 			Name: "local-workplace-hub",
 		},
 	}}})

--- a/gestaltd/services/plugins/transport.go
+++ b/gestaltd/services/plugins/transport.go
@@ -1,0 +1,75 @@
+package plugins
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
+)
+
+type StaticProviderSpec = providerhost.StaticProviderSpec
+type ExecConfig = providerhost.ExecConfig
+type RemoteProviderOption = providerhost.RemoteProviderOption
+type DeclarativeProvider = providerhost.DeclarativeProvider
+type DeclarativeProviderOption = providerhost.DeclarativeProviderOption
+
+func NewExecutable(ctx context.Context, cfg ExecConfig) (Provider, error) {
+	return providerhost.NewExecutableProvider(ctx, cfg)
+}
+
+func NewRemote(ctx context.Context, client proto.IntegrationProviderClient, spec StaticProviderSpec, config map[string]any, opts ...RemoteProviderOption) (Provider, error) {
+	return providerhost.NewRemoteProvider(ctx, client, spec, config, opts...)
+}
+
+func WithCloser(c io.Closer) RemoteProviderOption {
+	return providerhost.WithCloser(c)
+}
+
+func WithInvocationTokens(tokens *plugininvokerservice.InvocationTokenManager) RemoteProviderOption {
+	return providerhost.WithInvocationTokens(tokens)
+}
+
+func WithInvocationTokenSubject(pluginName string, grants plugininvokerservice.InvocationGrants) RemoteProviderOption {
+	return providerhost.WithInvocationTokenSubject(pluginName, grants)
+}
+
+func NewServer(provider Provider) proto.IntegrationProviderServer {
+	return providerhost.NewProviderServer(provider)
+}
+
+func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *http.Client, opts ...DeclarativeProviderOption) (*DeclarativeProvider, error) {
+	return providerhost.NewDeclarativeProvider(manifest, httpClient, opts...)
+}
+
+func WithDeclarativeMetadataOverrides(displayName, description, iconSVG string) DeclarativeProviderOption {
+	return providerhost.WithDeclarativeMetadataOverrides(displayName, description, iconSVG)
+}
+
+func WithDeclarativeConnectionMode(mode ConnectionMode) DeclarativeProviderOption {
+	return providerhost.WithDeclarativeConnectionMode(mode)
+}
+
+func WithDeclarativeOperationConnections(connections map[string]string, selectors map[string]core.OperationConnectionSelector, locks map[string]bool) DeclarativeProviderOption {
+	return providerhost.WithDeclarativeOperationConnections(connections, selectors, locks)
+}
+
+func ConnectionParamDefsFromManifest(defs map[string]providermanifestv1.ProviderConnectionParam) map[string]ConnectionParamDef {
+	return providerhost.ConnectionParamDefsFromManifest(defs)
+}
+
+func CredentialFieldsFromManifest(fields []providermanifestv1.CredentialField) []CredentialFieldDef {
+	return providerhost.CredentialFieldsFromManifest(fields)
+}
+
+func DiscoveryConfigFromManifest(discovery *providermanifestv1.ProviderDiscovery) *DiscoveryConfig {
+	return providerhost.DiscoveryConfigFromManifest(discovery)
+}
+
+func NewPluginTempDir(pattern string) (string, error) {
+	return providerhost.NewPluginTempDir(pattern)
+}


### PR DESCRIPTION
## Summary
- extend `services/plugins` with the generic provider transport facade
- route bootstrap provider building, provider-dev attach sessions, and startup proxy specs through `services/plugins`
- update existing bootstrap/provider-dev/daemon transport tests to exercise the service-level provider interfaces

## Stack
- based on `main`; #1585 and #1587 have landed, so this PR only contains the generic provider transport boundary slice

## New Interfaces
- `plugins.StaticProviderSpec`
- `plugins.ExecConfig`
- `plugins.NewExecutable(ctx, plugins.ExecConfig{...})`
- `plugins.NewRemote(ctx, client, spec, config, opts...)`
- `plugins.WithCloser(closer)`
- `plugins.WithInvocationTokens(tokens)`
- `plugins.WithInvocationTokenSubject(pluginName, grants)`
- `plugins.NewServer(provider)`
- `plugins.NewDeclarativeProvider(manifest, httpClient, opts...)`
- `plugins.WithDeclarativeMetadataOverrides(displayName, description, iconSVG)`
- `plugins.WithDeclarativeConnectionMode(mode)`
- `plugins.WithDeclarativeOperationConnections(connections, selectors, locks)`
- `plugins.ConnectionParamDefsFromManifest(defs)`
- `plugins.CredentialFieldsFromManifest(fields)`
- `plugins.DiscoveryConfigFromManifest(discovery)`
- `plugins.NewPluginTempDir(pattern)`

## Examples
```go
prov, err := plugins.NewExecutable(ctx, plugins.ExecConfig{
    Command: command,
    StaticSpec: plugins.StaticProviderSpec{Name: name},
})
```

```go
remote, err := plugins.NewRemote(ctx, client, spec, pluginConfig, plugins.WithCloser(closer))
```

```go
proto.RegisterIntegrationProviderServer(srv, plugins.NewServer(provider))
```

```go
declarative, err := plugins.NewDeclarativeProvider(manifest, nil,
    plugins.WithDeclarativeConnectionMode(mode),
)
```

## Review Pass
- separate GPT-5.5 xhigh reviewer found a provider-dev boundary gap
- applied that feedback and reran a separate GPT-5.5 xhigh follow-up review, which found no findings

## Tests
```sh
cd gestaltd && go test ./services/plugins ./internal/bootstrap ./internal/daemon ./internal/providerdev ./services/providerdev/http
```

Follow-up reviewer also ran the providerhost leakage scan, `go list` checks, `git diff --check`, and targeted provider-dev tests.