### PR TITLE
Add subject-owned API token admin endpoints

### DIFF
--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -39,7 +39,7 @@ Owned by the configured external credentials provider, not gestaltd core. The de
 | Field | Type | Notes |
 | --- | --- | --- |
 | `id` | string, PK | UUID. |
-| `subject_id` | string | Canonical credential owner such as `user:<id>`, `service_account:<id>`, or a runtime-supplied `system:<id>` subject. |
+| `subject_id` | string | Canonical credential owner such as `user:<id>`, `managed_identity:<id>`, `service_account:<id>`, or a runtime-supplied `system:<id>` subject. |
 | `integration` | string | Provider name from config (e.g., `slack`). |
 | `connection` | string | Named connection within the provider (e.g., `default`, `mcp`). |
 | `instance` | string | User-chosen or discovery-assigned name for multi-account providers. |
@@ -63,7 +63,7 @@ Gestalt API tokens (`gst_api_*`). The plaintext is never stored, only a one-way 
 | --- | --- | --- |
 | `id` | string, PK | UUID. |
 | `owner_kind` | string | Token owner kind (`user` or `subject`). |
-| `owner_id` | string | Owner ID within `owner_kind`; subject-owned tokens use a canonical non-system subject ID. |
+| `owner_id` | string | Owner ID within `owner_kind`; subject-owned tokens use a canonical non-system subject ID such as `managed_identity:<id>` or `service_account:<id>`. |
 | `credential_subject_id` | string | Subject whose upstream credentials the token may use. |
 | `name` | string | Display name (e.g., `automation`, `cli-token`). |
 | `hashed_token` | string, unique | **SHA-256 hash.** Plaintext returned once at creation. |

--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -32,8 +32,8 @@ These fields are emitted when available:
 | Field | Meaning |
 | --- | --- |
 | `auth_source` | Authentication mechanism for the caller: `session`, `api_token`, or `env`. |
-| `subject_id` | Canonical caller subject such as `user:<id>` or `service_account:<id>` |
-| `subject_kind` | Canonical subject type, such as `user` or `service_account` |
+| `subject_id` | Canonical caller subject such as `user:<id>`, `managed_identity:<id>`, or `service_account:<id>` |
+| `subject_kind` | Canonical subject type, such as `user`, `managed_identity`, or `service_account` |
 | `target_kind` | Generic kind for the object the event acted on, such as `api_token` or `connection` |
 | `target_id` | Stable identifier for the affected object when one exists |
 | `target_name` | Human-readable label for the affected object |

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -320,7 +320,7 @@ plugins:
 | Mode | Behavior |
 | --- | --- |
 | `none` | No upstream credential needed. |
-| `user` | Credentials are stored for the calling subject (for example `user:<id>` or `service_account:<id>`). |
+| `user` | Credentials are stored for the calling subject (for example `user:<id>`, `managed_identity:<id>`, or `service_account:<id>`). |
 
 ### Authentication Types
 

--- a/docs/content/providers/authorization.mdx
+++ b/docs/content/providers/authorization.mdx
@@ -25,8 +25,8 @@ provider-backed relationship storage or dynamic subject-grant control plane.
 
 At the product level, authorization is about subjects and runtime surfaces.
 Gestalt resolves each request to a canonical subject such as `user:<id>`,
-`service_account:<id>`, or a system subject, then asks whether that subject may access
-the thing they are trying to use. Static memberships under
+`managed_identity:<id>`, `service_account:<id>`, or a system subject, then asks
+whether that subject may access the thing they are trying to use. Static memberships under
 `authorization.policies` are always available. When you configure an
 authorization provider, Gestalt adds dynamic relationship storage on top so
 those decisions can change without editing YAML.

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -161,7 +161,7 @@ stores credentials per subject.
 | Mode | Behavior |
 | --- | --- |
 | `none` | No upstream credential is required |
-| `user` | The calling subject stores its own credential (`user:<id>`, `service_account:<id>`, or another canonical subject ID) |
+| `user` | The calling subject stores its own credential (`user:<id>`, `managed_identity:<id>`, `service_account:<id>`, or another canonical subject ID) |
 
 Common auth types are `oauth2`, `mcp_oauth`, `bearer`, `manual`, and `none`.
 Operator-supplied app credentials such as `clientId` and `clientSecret` go in

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -152,11 +152,11 @@ authorization:
 
 `admin.ui` optionally pins `/admin` to one named `providers.ui.<name>` bundle. The selected bundle must ship `admin/index.html` inside its prepared asset root. When `admin.ui` is omitted, Gestalt first auto-discovers admin assets from the root-mounted UI bundle (`path: /`) when that bundle contains `admin/index.html`, then falls back to the built-in admin shell.
 
-`authorization.policies` configures shared subject access policies. Each policy resolves a caller to exactly one role by matching canonical `subjectID` values such as `user:<id>` or `service_account:<id>`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
+`authorization.policies` configures shared subject access policies. Each policy resolves a caller to exactly one role by matching canonical `subjectID` values such as `user:<id>`, `managed_identity:<id>`, or `service_account:<id>`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
 
-Dynamic grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, operators can manage additional dynamic members for that plugin from the built-in admin UI at `/admin/?tab=members` or through `/admin/api/v1/authorization/...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for subjects that already have static authorization on that plugin. The `email` write field is a user-only convenience alias; `subjectId` accepts any canonical non-system subject ID, such as `user:<id>`, `service_account:<id>`, or another deployment-defined subject kind.
+Dynamic grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, operators can manage additional dynamic members for that plugin from the built-in admin UI at `/admin/?tab=members` or through `/admin/api/v1/authorization/...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for subjects that already have static authorization on that plugin. The `email` write field is a user-only convenience alias; `subjectId` accepts any canonical non-system subject ID, such as `user:<id>`, `managed_identity:<id>`, `service_account:<id>`, or another deployment-defined subject kind.
 
-Non-human callers are modeled as canonical subjects, typically `service_account:<id>`, and authenticate with Gestalt API tokens whose stored owner is that subject. Grant plugin access with `authorization.policies` or provider-backed dynamic memberships using the canonical subject ID, and store third-party credentials through the configured external credentials provider under the same subject ID.
+Non-human callers are modeled as canonical subjects, typically `managed_identity:<id>` or `service_account:<id>`, and authenticate with Gestalt API tokens whose stored owner is that subject. Grant plugin access with `authorization.policies` or provider-backed dynamic memberships using the canonical subject ID, and store third-party credentials through the configured external credentials provider under the same subject ID.
 
 Plugins without `authorizationPolicy` are open to any authenticated subject. Bind a plugin to a policy when non-human access should be explicit.
 
@@ -1230,7 +1230,7 @@ connection literally named `default`, then the only named connection when there
 is exactly one. If none of those apply, legacy plugin-level auth is exposed as
 the `_plugin` connection.
 
-Connection `mode` determines how credentials are managed: `none` requires no credentials, and `user` stores credentials for the caller's effective subject. For humans that is typically `user:<id>`; for non-human API token callers it can be `service_account:<id>` or another canonical non-system subject ID. Runtime surfaces can also supply system subjects such as `system:http_binding:<plugin>:<binding>` as the effective credential owner. All connections in a single plugin must share the same mode.
+Connection `mode` determines how credentials are managed: `none` requires no credentials, and `user` stores credentials for the caller's effective subject. For humans that is typically `user:<id>`; for non-human API token callers it can be `managed_identity:<id>`, `service_account:<id>`, or another canonical non-system subject ID. Runtime surfaces can also supply system subjects such as `system:http_binding:<plugin>:<binding>` as the effective credential owner. All connections in a single plugin must share the same mode.
 
 #### Authentication Shapes
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -135,10 +135,16 @@ still honor each event's `visibility`.
 | `GET` | `/admin/api/v1/authorization/admins/members` | List merged static and dynamic built-in admin membership rows. |
 | `PUT` | `/admin/api/v1/authorization/admins/members` | Upsert one dynamic built-in admin membership row by canonical `subjectId` or by user-only `email` alias and role. Rejects subjects who already have static built-in admin authorization. |
 | `DELETE` | `/admin/api/v1/authorization/admins/members/{subjectID}` | Remove one dynamic built-in admin membership row. Static rows are read-only and cannot be deleted through the API. |
+| `POST` | `/admin/api/v1/subjects/{subjectID}/tokens` | Create a Gestalt API token owned by a non-user canonical subject. Plaintext is returned once. |
+| `GET` | `/admin/api/v1/subjects/{subjectID}/tokens` | List Gestalt API tokens owned by a non-user canonical subject. |
+| `DELETE` | `/admin/api/v1/subjects/{subjectID}/tokens/{id}` | Revoke one Gestalt API token owned by a non-user canonical subject. |
+| `DELETE` | `/admin/api/v1/subjects/{subjectID}/tokens` | Revoke all Gestalt API tokens owned by a non-user canonical subject. |
 
 `/admin/api/v1/...` mirrors the built-in `/admin` protection model: when `server.admin.authorizationPolicy` is unset, the routes are open wherever `/admin` is open; when it is set, they require the same browser session and role checks as `/admin`, but return JSON `401`/`403` instead of browser redirects.
 
-Mutable membership APIs still list and delete by canonical `subjectId`. User-backed rows use `user:<user_id>` and non-human rows can use `service_account:<id>` or another canonical non-system subject ID. Dynamic membership writes accept either a canonical `subjectId` or an `email` alias. When `email` is used, Gestalt resolves it to the canonical user subject and creates the user record if needed before persisting the provider-backed grant.
+Mutable membership APIs still list and delete by canonical `subjectId`. User-backed rows use `user:<user_id>` and non-human rows can use `managed_identity:<id>`, `service_account:<id>`, or another canonical non-system subject ID. Dynamic membership writes accept either a canonical `subjectId` or an `email` alias. When `email` is used, Gestalt resolves it to the canonical user subject and creates the user record if needed before persisting the provider-backed grant.
+
+Subject token APIs only accept non-user canonical subject IDs. They do not create a managed identity table or registry row; the subject becomes meaningful through the token owner, provider-backed authorization relationships, and any upstream credentials stored by the external credentials provider under the same subject ID.
 
 `PUT` and `DELETE` may return `202 Accepted` with `status: "persisted_pending_reload"` when the dynamic grant was written successfully but the local in-memory authorization snapshot has not reloaded yet. In that case, retry access checks only after the local snapshot converges.
 
@@ -396,4 +402,13 @@ curl -X POST http://localhost:8080/api/v1/agent/turns/turn-123/cancel \
 curl -X PUT http://localhost:9090/admin/api/v1/authorization/plugins/sample_plugin/members \
   -H 'Content-Type: application/json' \
   -d '{"email":"user@example.com","role":"viewer"}'
+
+# Grant a managed identity access, then mint a bearer token for it
+curl -X PUT http://localhost:9090/admin/api/v1/authorization/plugins/sample_plugin/members \
+  -H 'Content-Type: application/json' \
+  -d '{"subjectId":"managed_identity:reporting-bot","role":"viewer"}'
+
+curl -X POST 'http://localhost:9090/admin/api/v1/subjects/managed_identity:reporting-bot/tokens' \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"reporting bot","permissions":[{"plugin":"sample_plugin","operations":["read"]}]}'
 ```

--- a/gestaltd/internal/server/handlers_admin_subject_tokens.go
+++ b/gestaltd/internal/server/handlers_admin_subject_tokens.go
@@ -1,0 +1,173 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+func (s *Server) mountAdminSubjectTokenRoutes(r chi.Router) {
+	r.Get("/subjects/{subjectID}/tokens", s.listAdminSubjectAPITokens)
+	r.Post("/subjects/{subjectID}/tokens", s.createAdminSubjectAPIToken)
+	r.Delete("/subjects/{subjectID}/tokens", s.revokeAllAdminSubjectAPITokens)
+	r.Delete("/subjects/{subjectID}/tokens/{id}", s.revokeAdminSubjectAPIToken)
+}
+
+func (s *Server) createAdminSubjectAPIToken(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("subject api token creation failed")
+	auditTarget := auditTarget{}
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "subject_api_token.create", auditAllowed, auditErr, auditTarget)
+	}()
+
+	subjectID, ok := adminSubjectTokenSubjectID(w, r)
+	if !ok {
+		auditErr = errors.New("invalid subject id")
+		return
+	}
+
+	var req createTokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		auditErr = errors.New("invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.Name) != "" {
+		auditTarget = apiTokenAuditTarget("", req.Name)
+	}
+
+	permissions, err := s.validateCreateAPITokenRequest(req)
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	apiToken, plaintext, err := s.issueOwnedAPIToken(r.Context(), &core.APIToken{
+		OwnerKind:           core.APITokenOwnerKindSubject,
+		OwnerID:             subjectID,
+		CredentialSubjectID: subjectID,
+		Name:                strings.TrimSpace(req.Name),
+		Scopes:              req.Scopes,
+		Permissions:         cloneAccessPermissions(permissions),
+	}, false)
+	if err != nil {
+		auditErr = errors.New("failed to generate token")
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+	auditTarget = apiTokenAuditTarget(apiToken.ID, apiToken.Name)
+
+	auditAllowed = true
+	auditErr = nil
+	writeJSON(w, http.StatusCreated, createTokenResponse{
+		ID:          apiToken.ID,
+		Name:        apiToken.Name,
+		Token:       plaintext,
+		Permissions: cloneAccessPermissions(apiToken.Permissions),
+		ExpiresAt:   apiToken.ExpiresAt,
+	})
+}
+
+func (s *Server) listAdminSubjectAPITokens(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("subject api token list failed")
+	defer func() {
+		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), "", "subject_api_token.list", auditAllowed, auditErr)
+	}()
+
+	subjectID, ok := adminSubjectTokenSubjectID(w, r)
+	if !ok {
+		auditErr = errors.New("invalid subject id")
+		return
+	}
+
+	tokens, err := s.apiTokens.ListAPITokensByOwner(r.Context(), core.APITokenOwnerKindSubject, subjectID)
+	if err != nil {
+		auditErr = errors.New("failed to list tokens")
+		writeError(w, http.StatusInternalServerError, "failed to list tokens")
+		return
+	}
+
+	out := make([]apiTokenInfo, 0, len(tokens))
+	for _, token := range tokens {
+		out = append(out, apiTokenInfoFromCore(token))
+	}
+	auditAllowed = true
+	auditErr = nil
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) revokeAdminSubjectAPIToken(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("subject api token revoke failed")
+	id := chi.URLParam(r, "id")
+	auditTarget := apiTokenAuditTarget(id, "")
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "subject_api_token.revoke", auditAllowed, auditErr, auditTarget)
+	}()
+
+	subjectID, ok := adminSubjectTokenSubjectID(w, r)
+	if !ok {
+		auditErr = errors.New("invalid subject id")
+		return
+	}
+
+	if err := s.apiTokens.RevokeAPITokenByOwner(r.Context(), core.APITokenOwnerKindSubject, subjectID, id); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			auditErr = errors.New("token not found")
+			writeError(w, http.StatusNotFound, "token not found")
+			return
+		}
+		auditErr = errors.New("failed to revoke token")
+		writeError(w, http.StatusInternalServerError, "failed to revoke token")
+		return
+	}
+	auditAllowed = true
+	auditErr = nil
+	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
+}
+
+func (s *Server) revokeAllAdminSubjectAPITokens(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("subject api token revoke all failed")
+	auditTarget := apiTokenCollectionAuditTarget()
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "subject_api_token.revoke_all", auditAllowed, auditErr, auditTarget)
+	}()
+
+	subjectID, ok := adminSubjectTokenSubjectID(w, r)
+	if !ok {
+		auditErr = errors.New("invalid subject id")
+		return
+	}
+
+	count, err := s.apiTokens.RevokeAllAPITokensByOwner(r.Context(), core.APITokenOwnerKindSubject, subjectID)
+	if err != nil {
+		auditErr = errors.New("failed to revoke tokens")
+		writeError(w, http.StatusInternalServerError, "failed to revoke tokens")
+		return
+	}
+	auditAllowed = true
+	auditErr = nil
+	writeJSON(w, http.StatusOK, map[string]any{"status": "revoked", "count": count})
+}
+
+func adminSubjectTokenSubjectID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	subjectID, err := adminAuthorizationSubjectID(chi.URLParam(r, "subjectID"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return "", false
+	}
+	kind, _, ok := core.ParseSubjectID(subjectID)
+	if !ok || kind == core.APITokenOwnerKindUser {
+		writeError(w, http.StatusBadRequest, "subjectID must be a non-user canonical subject ID")
+		return "", false
+	}
+	return subjectID, true
+}

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -58,21 +58,7 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 	}
 	auditTarget = apiTokenAuditTarget("", req.Name)
 
-	if req.Scopes != "" && len(req.Permissions) > 0 {
-		auditErr = errors.New("scopes and permissions are mutually exclusive")
-		writeError(w, http.StatusBadRequest, "scopes and permissions are mutually exclusive")
-		return
-	}
-	if req.Scopes != "" {
-		for _, scope := range strings.Fields(req.Scopes) {
-			if _, err := s.providers.Get(scope); err != nil {
-				auditErr = fmt.Errorf("unknown scope %q", scope)
-				writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown scope %q", scope))
-				return
-			}
-		}
-	}
-	permissions, err := s.normalizeAPITokenPermissions(req.Permissions)
+	permissions, err := s.validateCreateAPITokenRequest(req)
 	if err != nil {
 		auditErr = err
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -96,6 +82,23 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 		Permissions: cloneAccessPermissions(apiToken.Permissions),
 		ExpiresAt:   apiToken.ExpiresAt,
 	})
+}
+
+func (s *Server) validateCreateAPITokenRequest(req createTokenRequest) ([]core.AccessPermission, error) {
+	if strings.TrimSpace(req.Name) == "" {
+		return nil, errors.New("name is required")
+	}
+	if req.Scopes != "" && len(req.Permissions) > 0 {
+		return nil, errors.New("scopes and permissions are mutually exclusive")
+	}
+	if req.Scopes != "" {
+		for _, scope := range strings.Fields(req.Scopes) {
+			if _, err := s.providers.Get(scope); err != nil {
+				return nil, fmt.Errorf("unknown scope %q", scope)
+			}
+		}
+	}
+	return s.normalizeAPITokenPermissions(req.Permissions)
 }
 
 func (s *Server) normalizeAPITokenPermissions(values []core.AccessPermission) ([]core.AccessPermission, error) {

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -96,6 +96,7 @@ func (s *Server) mountAdminAPIRoutes(r chi.Router) {
 		}
 		s.mountAdminRuntimeRoutes(r)
 		s.mountAdminAuthorizationRoutes(r)
+		s.mountAdminSubjectTokenRoutes(r)
 	})
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4088,6 +4088,166 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	}
 }
 
+func TestAdminAPI_SubjectAPITokenCRUD(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	subjectID := "managed_identity:reporting-bot"
+	pluginDefs := map[string]*config.ProviderEntry{
+		"svc": {AuthorizationPolicy: "svc_policy"},
+	}
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.SubjectPolicyDef{
+			"svc_policy": {
+				Default: "deny",
+				Members: []config.SubjectPolicyMemberDef{{
+					SubjectID: subjectID,
+					Role:      "viewer",
+				}},
+			},
+		},
+	}, pluginDefs)
+	stub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "svc",
+				ConnMode: core.ConnectionModeNone,
+				ExecuteFn: func(ctx context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					p := principal.FromContext(ctx)
+					access := invocation.AccessContextFromContext(ctx)
+					body, err := json.Marshal(map[string]string{
+						"operation": op,
+						"subject":   p.SubjectID,
+						"role":      access.Role,
+					})
+					if err != nil {
+						return nil, err
+					}
+					return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+				},
+			},
+		},
+		catalog: &catalog.Catalog{
+			Name: "svc",
+			Operations: []catalog.CatalogOperation{{
+				ID:           "run",
+				Method:       http.MethodGet,
+				Transport:    catalog.TransportREST,
+				AllowedRoles: []string{"viewer"},
+			}},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PluginDefs = pluginDefs
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createBody := bytes.NewBufferString(`{"name":"reporting bot","permissions":[{"plugin":"svc","operations":["run"]}]}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/admin/api/v1/subjects/"+url.PathEscape(subjectID)+"/tokens", createBody)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST subject token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create subject token status = %d, want 201: %s", resp.StatusCode, body)
+	}
+	var createResp struct {
+		ID    string `json:"id"`
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create subject token response: %v", err)
+	}
+	if createResp.ID == "" || createResp.Token == "" {
+		t.Fatalf("create subject token response missing id/token: %+v", createResp)
+	}
+
+	resp, err = http.Get(ts.URL + "/admin/api/v1/subjects/" + url.PathEscape(subjectID) + "/tokens")
+	if err != nil {
+		t.Fatalf("GET subject tokens: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("list subject tokens status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var tokens []struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokens); err != nil {
+		t.Fatalf("decode subject token list: %v", err)
+	}
+	if len(tokens) != 1 || tokens[0].ID != createResp.ID {
+		t.Fatalf("subject tokens = %+v, want token %q", tokens, createResp.ID)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run", nil)
+	req.Header.Set("Authorization", "Bearer "+createResp.Token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("invoke with subject token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("invoke with subject token status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var invokeResp map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&invokeResp); err != nil {
+		t.Fatalf("decode invoke response: %v", err)
+	}
+	if invokeResp["subject"] != subjectID || invokeResp["role"] != "viewer" {
+		t.Fatalf("invoke response = %+v, want subject %q with viewer role", invokeResp, subjectID)
+	}
+
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/subjects/"+url.PathEscape(subjectID)+"/tokens/"+createResp.ID, nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE subject token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("delete subject token status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run", nil)
+	req.Header.Set("Authorization", "Bearer "+createResp.Token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("invoke after subject token revoke: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("invoke after revoke status = %d, want 401: %s", resp.StatusCode, body)
+	}
+
+	userSubjectID := principal.UserSubjectID("user-1")
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/admin/api/v1/subjects/"+url.PathEscape(userSubjectID)+"/tokens", bytes.NewBufferString(`{"name":"bad"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST user subject token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("user subject token status = %d, want 400: %s", resp.StatusCode, body)
+	}
+}
+
 func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add admin subject-token endpoints for non-user canonical subjects such as `managed_identity:<id>` and `service_account:<id>`.
- Keep the data model on existing non-legacy primitives: `api_tokens.owner_kind=subject`, `api_tokens.owner_id=<canonical subject id>`, authorization memberships by canonical `subjectId`, and external credentials keyed by the same subject ID.
- Document managed identities as canonical subjects, not as a restored legacy `/api/v1/identities` API or a new core-owned table.

## Interface Diff

```diff
 # Existing personal token surface remains user-owned only.
 POST   /api/v1/tokens
 GET    /api/v1/tokens
 DELETE /api/v1/tokens/{id}
 DELETE /api/v1/tokens
 
 # Existing authorization surface already accepts canonical subjects.
 PUT    /admin/api/v1/authorization/plugins/{plugin}/members
        { "subjectId": "managed_identity:reporting-bot", "role": "viewer" }
 
+# New non-user subject token surface.
+POST   /admin/api/v1/subjects/{subjectID}/tokens
+GET    /admin/api/v1/subjects/{subjectID}/tokens
+DELETE /admin/api/v1/subjects/{subjectID}/tokens/{id}
+DELETE /admin/api/v1/subjects/{subjectID}/tokens
```

`{subjectID}` must be a canonical, non-user, non-system subject ID. Examples: `managed_identity:reporting-bot`, `service_account:etl-runner`.

## Examples

Grant a managed identity access to a plugin:

```sh
curl -X PUT http://localhost:9090/admin/api/v1/authorization/plugins/sample_plugin/members \
  -H 'Content-Type: application/json' \
  -d '{"subjectId":"managed_identity:reporting-bot","role":"viewer"}'
```

Mint a bearer token for that same subject:

```sh
curl -X POST 'http://localhost:9090/admin/api/v1/subjects/managed_identity:reporting-bot/tokens' \
  -H 'Content-Type: application/json' \
  -d '{"name":"reporting bot","permissions":[{"plugin":"sample_plugin","operations":["read"]}]}'
```

Use the returned `token` with normal invocation:

```sh
curl http://localhost:8080/api/v1/sample_plugin/read \
  -H "Authorization: Bearer $GESTALT_API_KEY"
```

## Verification

- `go test ./internal/server -run 'TestAdminAPI_SubjectAPITokenCRUD|TestAdminAPI_PluginAuthorizationCRUD|TestSubjectAuthorization_ExecuteOperation_UsesSubjectCredentialAndSessionSelectors' -count=1`
- `go test ./internal/server -count=1`
- `go test ./...` still fails in existing bootstrap agent-runtime test `TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartFails`; `internal/server` passed in that run.