### PR TITLE
providerhost: relax workflow provider deadlines

### DIFF
--- a/gestaltd/internal/providerhost/runtime_client.go
+++ b/gestaltd/internal/providerhost/runtime_client.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	providerRPCTimeout = 10 * time.Second
+	providerRPCTimeout     = 10 * time.Second
+	providerMigrateTimeout = 2 * time.Minute
 )
 
 var providerConfigureTimeout = 30 * time.Second
@@ -48,7 +49,7 @@ func ConfigureRuntimeProvider(ctx context.Context, client proto.ProviderLifecycl
 	if err != nil {
 		return nil, fmt.Errorf("encode provider config: %w", err)
 	}
-	configureCtx, configureCancel := providerConfigureContext(ctx)
+	configureCtx, configureCancel := providerConfigureOperationContext(ctx)
 	defer configureCancel()
 	resp, err := client.ConfigureProvider(configureCtx, &proto.ConfigureProviderRequest{
 		Name:            name,
@@ -148,6 +149,22 @@ func providerCallContext(parent context.Context) (context.Context, context.Cance
 	return context.WithTimeout(parent, providerRPCTimeout)
 }
 
+type providerMigrationTimeoutContextKey struct{}
+
+func WithProviderMigrationTimeout(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, providerMigrationTimeoutContextKey{}, true)
+}
+
+func providerMigrationContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, providerMigrateTimeout)
+}
+
 func providerStreamContext(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent == nil {
 		parent = context.Background()
@@ -160,4 +177,13 @@ func providerConfigureContext(parent context.Context) (context.Context, context.
 		parent = context.Background()
 	}
 	return context.WithTimeout(parent, providerConfigureTimeout)
+}
+
+func providerConfigureOperationContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent != nil {
+		if useMigrationTimeout, _ := parent.Value(providerMigrationTimeoutContextKey{}).(bool); useMigrationTimeout {
+			return providerMigrationContext(parent)
+		}
+	}
+	return providerConfigureContext(parent)
 }

--- a/gestaltd/internal/providerhost/runtime_client_test.go
+++ b/gestaltd/internal/providerhost/runtime_client_test.go
@@ -3,6 +3,7 @@ package providerhost
 import (
 	"context"
 	"testing"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc"
@@ -108,6 +109,56 @@ func TestConfigureRuntimeProviderRefreshesMetadataAfterConfigure(t *testing.T) {
 	}
 	if len(meta.Warnings) != 1 || meta.Warnings[0] != "configured" {
 		t.Fatalf("Warnings = %#v, want %#v", meta.Warnings, []string{"configured"})
+	}
+}
+
+func TestConfigureRuntimeProviderUsesMigrationTimeoutForConfigureProvider(t *testing.T) {
+	t.Parallel()
+
+	var configureRemaining time.Duration
+	client := &fakeProviderLifecycleClient{
+		getProviderIdentity: func(_ context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (*proto.ProviderIdentity, error) {
+			return &proto.ProviderIdentity{
+				Kind:               proto.ProviderKind_PROVIDER_KIND_WORKFLOW,
+				Name:               "indexeddb",
+				MinProtocolVersion: proto.CurrentProtocolVersion,
+				MaxProtocolVersion: proto.CurrentProtocolVersion,
+			}, nil
+		},
+		configureProvider: func(ctx context.Context, _ *proto.ConfigureProviderRequest, _ ...grpc.CallOption) (*proto.ConfigureProviderResponse, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("ConfigureProvider context has no deadline")
+			}
+			configureRemaining = time.Until(deadline)
+			return &proto.ConfigureProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+		},
+	}
+
+	_, err := ConfigureRuntimeProvider(
+		WithProviderMigrationTimeout(context.Background()),
+		client,
+		proto.ProviderKind_PROVIDER_KIND_WORKFLOW,
+		"indexeddb",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ConfigureRuntimeProvider: %v", err)
+	}
+
+	if configureRemaining <= providerConfigureTimeout {
+		t.Fatalf(
+			"ConfigureProvider remaining deadline = %s, want migration timeout above %s",
+			configureRemaining,
+			providerConfigureTimeout,
+		)
+	}
+	if configureRemaining > providerMigrateTimeout {
+		t.Fatalf(
+			"ConfigureProvider remaining deadline = %s, want at most %s",
+			configureRemaining,
+			providerMigrateTimeout,
+		)
 	}
 }
 

--- a/gestaltd/internal/providerhost/workflow_client.go
+++ b/gestaltd/internal/providerhost/workflow_client.go
@@ -3,12 +3,15 @@ package providerhost
 import (
 	"context"
 	"io"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+const workflowListRunsTimeout = 30 * time.Second
 
 type WorkflowExecConfig struct {
 	Command      string
@@ -49,7 +52,8 @@ func NewExecutableWorkflow(ctx context.Context, cfg WorkflowExecConfig) (corewor
 
 	runtimeClient := proto.NewProviderLifecycleClient(proc.conn)
 	workflowClient := proto.NewWorkflowProviderClient(proc.conn)
-	if _, err := ConfigureRuntimeProvider(ctx, runtimeClient, proto.ProviderKind_PROVIDER_KIND_WORKFLOW, cfg.Name, cfg.Config); err != nil {
+	configureCtx := WithProviderMigrationTimeout(ctx)
+	if _, err := ConfigureRuntimeProvider(configureCtx, runtimeClient, proto.ProviderKind_PROVIDER_KIND_WORKFLOW, cfg.Name, cfg.Config); err != nil {
 		_ = proc.Close()
 		return nil, err
 	}
@@ -89,7 +93,7 @@ func (r *remoteWorkflow) GetRun(ctx context.Context, req coreworkflow.GetRunRequ
 }
 
 func (r *remoteWorkflow) ListRuns(ctx context.Context, req coreworkflow.ListRunsRequest) ([]*coreworkflow.Run, error) {
-	ctx, cancel := providerCallContext(ctx)
+	ctx, cancel := workflowListRunsContext(ctx)
 	defer cancel()
 	resp, err := r.client.ListRuns(ctx, &proto.ListWorkflowProviderRunsRequest{})
 	if err != nil {
@@ -104,6 +108,13 @@ func (r *remoteWorkflow) ListRuns(ctx context.Context, req coreworkflow.ListRuns
 		runs = append(runs, value)
 	}
 	return runs, nil
+}
+
+func workflowListRunsContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, workflowListRunsTimeout)
 }
 
 func (r *remoteWorkflow) CancelRun(ctx context.Context, req coreworkflow.CancelRunRequest) (*coreworkflow.Run, error) {


### PR DESCRIPTION
## Summary
- Let workflow provider `ConfigureProvider` calls opt into the longer migration timeout during bootstrap.
- Give workflow `ListRuns` a 30s provider RPC budget instead of the generic 10s call timeout.
- Add providerhost coverage for the configure timeout behavior.

## Context
`valon.tools` Cloud Run logs showed `/api/v1/workflow/runs` returning 500 after provider `DeadlineExceeded`/cancel errors, and the latest revision failing startup while configuring the indexeddb workflow provider.

## Tests
- `go test ./internal/providerhost`