### PR TITLE
[codex] Expose remote agent runtime boundary

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -40,7 +40,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
@@ -1256,7 +1255,7 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 		return nil, fmt.Errorf("dial hosted agent provider: %w", err)
 	}
 	phaseStarted = time.Now()
-	provider, err := providerhost.NewRemoteAgent(ctx, providerhost.RemoteAgentConfig{
+	provider, err := agentservice.NewRemote(ctx, agentservice.RemoteConfig{
 		Client:  conn.Agent(),
 		Runtime: conn.Lifecycle(),
 		Closer: &runtimeBackedHostedCloser{

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -29,10 +29,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/operator"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
-	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"github.com/valon-technologies/gestalt/server/internal/ui"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
 )
 
@@ -274,7 +274,7 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		}
 	}
 
-	processes := make([]*providerhost.PluginProcess, 0, len(targets))
+	processes := make([]*runtimehost.PluginProcess, 0, len(targets))
 	providerClients := make(map[string]proto.IntegrationProviderClient, len(targets))
 	cleanupProcesses := func() {
 		for _, process := range processes {
@@ -845,7 +845,7 @@ func ensureProviderRemoteManifestResolved(name string, entry *config.ProviderEnt
 	return manifestPath, manifest, nil
 }
 
-func startProviderRemoteProcess(ctx context.Context, target providerRemoteTarget, remote providerdev.CreateSessionProvider) (*providerhost.PluginProcess, error) {
+func startProviderRemoteProcess(ctx context.Context, target providerRemoteTarget, remote providerdev.CreateSessionProvider) (*runtimehost.PluginProcess, error) {
 	entry := target.Entry
 	command := entry.Command
 	args := slices.Clone(entry.Args)
@@ -878,7 +878,7 @@ func startProviderRemoteProcess(ctx context.Context, target providerRemoteTarget
 	// Remote dev runs arbitrary local source trees. The plugin sandbox is tuned
 	// for staged executables and can hide source files from TypeScript/Python
 	// runtimes, so v1 leaves local source execution unsandboxed.
-	process, err := providerhost.StartPluginProcess(ctx, providerhost.ProcessConfig{
+	process, err := runtimehost.StartPluginProcess(ctx, runtimehost.ProcessConfig{
 		Command:      command,
 		Args:         args,
 		Env:          env,

--- a/gestaltd/services/agents/agents.go
+++ b/gestaltd/services/agents/agents.go
@@ -13,6 +13,7 @@ const DefaultHostSocketEnv = providerhost.DefaultAgentHostSocketEnv
 const DefaultManagerSocketEnv = providerhost.DefaultAgentManagerSocketEnv
 
 type ExecConfig = providerhost.AgentExecConfig
+type RemoteConfig = providerhost.RemoteAgentConfig
 type InvocationTokenManager = providerhost.InvocationTokenManager
 type ManagerService = providerhost.AgentManagerService
 
@@ -26,6 +27,10 @@ func ManagerSocketTokenEnv() string {
 
 func NewExecutable(ctx context.Context, cfg ExecConfig) (coreagent.Provider, error) {
 	return providerhost.NewExecutableAgent(ctx, cfg)
+}
+
+func NewRemote(ctx context.Context, cfg RemoteConfig) (coreagent.Provider, error) {
+	return providerhost.NewRemoteAgent(ctx, cfg)
 }
 
 func NewHostServer(


### PR DESCRIPTION
## Summary
- add a `services/agents` facade for remote agent provider construction
- route hosted agent provider bootstrap through `agents.NewRemote` instead of importing `internal/providerhost`
- route remaining local plugin process startup callsites through `services/runtimehost` process primitives

## Stack
- based on `main`; follows #1589 and only contains the remote-agent/runtime-process boundary slice

## New Interfaces
- `agents.RemoteConfig`
- `agents.NewRemote(ctx, agents.RemoteConfig{...})`
- `runtimehost.PluginProcess`
- `runtimehost.ProcessConfig`
- `runtimehost.StartPluginProcess(ctx, runtimehost.ProcessConfig{...})`

## Examples
```go
provider, err := agents.NewRemote(ctx, agents.RemoteConfig{
    Client:  conn.Agent(),
    Runtime: conn.Lifecycle(),
    Closer:  closer,
})
```

```go
process, err := runtimehost.StartPluginProcess(ctx, runtimehost.ProcessConfig{
    Command: command,
    Args:    args,
    Env:     env,
})
```

## Review Pass
- separate GPT-5.5 xhigh reviewer pass found no findings

## Tests
```sh
cd gestaltd && go test ./services/agents ./services/runtimehost ./internal/bootstrap ./internal/daemon -count=1
```

Reviewer also ran:
```sh
git diff --check origin/main
go test ./services/agents ./services/runtimehost ./internal/bootstrap ./internal/daemon
```