### PR TITLE
Add connection exposure enforcement

### DIFF
--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -14,6 +14,13 @@ const (
 	ConnectionModePlatform ConnectionMode = "platform"
 )
 
+type ConnectionExposure string
+
+const (
+	ConnectionExposureUser     ConnectionExposure = "user"
+	ConnectionExposureInternal ConnectionExposure = "internal"
+)
+
 func NormalizeConnectionMode(mode ConnectionMode) ConnectionMode {
 	switch mode {
 	case "", ConnectionModeUser:
@@ -24,6 +31,17 @@ func NormalizeConnectionMode(mode ConnectionMode) ConnectionMode {
 		return ConnectionModePlatform
 	default:
 		return mode
+	}
+}
+
+func NormalizeConnectionExposure(exposure ConnectionExposure) ConnectionExposure {
+	switch exposure {
+	case "", ConnectionExposureUser:
+		return ConnectionExposureUser
+	case ConnectionExposureInternal:
+		return ConnectionExposureInternal
+	default:
+		return exposure
 	}
 }
 

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -95,7 +95,10 @@ func connectionRuntimeInfo(integration, connection string, conn *config.Connecti
 // connection material using the same rules as invocation bootstrap.
 func StaticConnectionRuntimeInfo(integration, connection string, conn config.ConnectionDef) (invocation.ConnectionRuntimeInfo, error) {
 	mode := config.ConnectionModeForConnection(conn)
-	info := invocation.ConnectionRuntimeInfo{Mode: mode}
+	info := invocation.ConnectionRuntimeInfo{
+		Mode:     mode,
+		Exposure: config.ConnectionExposureForConnection(conn),
+	}
 	if mode != core.ConnectionModePlatform {
 		return info, nil
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/url"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"slices"
 	"strings"
@@ -316,7 +315,10 @@ func hybridPluginOperationConnection(plan config.StaticConnectionPlan, specConne
 }
 
 func explicitPluginConnection(plan config.StaticConnectionPlan) bool {
-	if !reflect.DeepEqual(plan.PluginConnection(), config.ConnectionDef{}) {
+	pluginConnection := plan.ResolvedPluginConnection()
+	if pluginConnection.Source.ModeSource == config.ConfigSourceDeploy ||
+		pluginConnection.Source.AuthSource == config.ConfigSourceDeploy ||
+		len(pluginConnection.Params) > 0 {
 		return true
 	}
 	return plan.AuthDefaultConnection() == config.PluginConnectionName && len(plan.NamedConnectionNames()) > 0

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1455,6 +1455,7 @@ func (s ServerConfig) ManagementBaseURL() string {
 type ConnectionDef struct {
 	DisplayName      string                                `yaml:"displayName,omitempty"`
 	Mode             providermanifestv1.ConnectionMode     `yaml:"mode"`
+	Exposure         providermanifestv1.ConnectionExposure `yaml:"exposure,omitempty"`
 	Auth             ConnectionAuthDef                     `yaml:"auth"`
 	ConnectionParams map[string]ConnectionParamDef         `yaml:"params"`
 	Discovery        *providermanifestv1.ProviderDiscovery `yaml:"-"`
@@ -1611,6 +1612,9 @@ func MergeConnectionDef(dst *ConnectionDef, src *ConnectionDef) {
 	if src.Mode != "" {
 		dst.Mode = src.Mode
 	}
+	if src.Exposure != "" {
+		dst.Exposure = src.Exposure
+	}
 	MergeConnectionAuth(&dst.Auth, src.Auth)
 	if len(src.ConnectionParams) > 0 {
 		dst.ConnectionParams = maps.Clone(src.ConnectionParams)
@@ -1703,6 +1707,9 @@ func EffectiveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *provider
 			conn.DisplayName = def.DisplayName
 			if def.Mode != "" {
 				conn.Mode = def.Mode
+			}
+			if def.Exposure != "" {
+				conn.Exposure = def.Exposure
 			}
 			if def.Auth != nil {
 				MergeConnectionAuth(&conn.Auth, ManifestAuthToConnectionAuthDef(def.Auth))

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -11,11 +12,51 @@ import (
 
 type StaticConnectionPlan struct {
 	manifestBacked    bool
-	pluginConnection  ConnectionDef
-	namedConnections  map[string]ConnectionDef
+	pluginConnection  ResolvedConnectionDef
+	namedConnections  map[string]ResolvedConnectionDef
 	surfaces          map[SpecSurface]ResolvedSpecSurface
 	restConnection    string
 	defaultConnection string
+}
+
+type ConfigSource string
+
+const (
+	ConfigSourceDefault  ConfigSource = "default"
+	ConfigSourceManifest ConfigSource = "manifest"
+	ConfigSourceDeploy   ConfigSource = "deploy"
+)
+
+type ResolvedConnectionSource struct {
+	DeclaredInManifest bool
+	DeclaredInDeploy   bool
+	ModeSource         ConfigSource
+	ExposureSource     ConfigSource
+	AuthSource         ConfigSource
+	NarrowedByDeploy   bool
+}
+
+type ResolvedConnectionDef struct {
+	Provider    string
+	Name        string
+	DisplayName string
+	Mode        providermanifestv1.ConnectionMode
+	Exposure    providermanifestv1.ConnectionExposure
+	Auth        ConnectionAuthDef
+	Params      map[string]ConnectionParamDef
+	Discovery   *providermanifestv1.ProviderDiscovery
+	Source      ResolvedConnectionSource
+}
+
+func (r ResolvedConnectionDef) ConnectionDef() ConnectionDef {
+	return ConnectionDef{
+		DisplayName:      r.DisplayName,
+		Mode:             r.Mode,
+		Exposure:         r.Exposure,
+		Auth:             r.Auth,
+		ConnectionParams: r.Params,
+		Discovery:        r.Discovery,
+	}
 }
 
 type ResolvedSpecSurface struct {
@@ -30,13 +71,16 @@ func BuildStaticConnectionPlan(plugin *ProviderEntry, manifestPlugin *providerma
 	declaredNames := namedConnectionNames(plugin, manifestPlugin)
 	plan := StaticConnectionPlan{
 		manifestBacked:   manifestPlugin != nil && manifestPlugin.IsManifestBacked(),
-		pluginConnection: EffectivePluginConnectionDef(plugin),
-		namedConnections: make(map[string]ConnectionDef),
+		pluginConnection: ResolvePluginConnectionDef(plugin),
+		namedConnections: make(map[string]ResolvedConnectionDef),
 		surfaces:         make(map[SpecSurface]ResolvedSpecSurface),
 	}
 
 	for name := range declaredNames {
-		conn, ok := EffectiveNamedConnectionDef(plugin, manifestPlugin, name)
+		conn, ok, err := ResolveNamedConnectionDef(plugin, manifestPlugin, name)
+		if err != nil {
+			return StaticConnectionPlan{}, err
+		}
 		if !ok {
 			continue
 		}
@@ -77,7 +121,7 @@ func BuildStaticConnectionPlan(plugin *ProviderEntry, manifestPlugin *providerma
 		if err != nil {
 			return StaticConnectionPlan{}, fmt.Errorf("%s references undeclared connection %q", surface.ConnectionField(), resolved.ConnectionName)
 		}
-		resolved.Connection = conn
+		resolved.Connection = conn.ConnectionDef()
 		plan.surfaces[surface] = resolved
 	}
 	if err := plan.validateConnectionModes(); err != nil {
@@ -91,6 +135,10 @@ func BuildStaticConnectionPlan(plugin *ProviderEntry, manifestPlugin *providerma
 }
 
 func (plan StaticConnectionPlan) PluginConnection() ConnectionDef {
+	return plan.pluginConnection.ConnectionDef()
+}
+
+func (plan StaticConnectionPlan) ResolvedPluginConnection() ResolvedConnectionDef {
 	return plan.pluginConnection
 }
 
@@ -105,6 +153,11 @@ func (plan StaticConnectionPlan) NamedConnectionNames() []string {
 
 func (plan StaticConnectionPlan) NamedConnectionDef(name string) (ConnectionDef, bool) {
 	conn, ok := plan.namedConnections[name]
+	return conn.ConnectionDef(), ok
+}
+
+func (plan StaticConnectionPlan) ResolvedNamedConnectionDef(name string) (ResolvedConnectionDef, bool) {
+	conn, ok := plan.namedConnections[name]
 	return conn, ok
 }
 
@@ -112,6 +165,14 @@ func (plan StaticConnectionPlan) LookupConnection(name string) (ConnectionDef, b
 	conn, err := plan.connectionDef(ResolveConnectionAlias(name))
 	if err != nil {
 		return ConnectionDef{}, false
+	}
+	return conn.ConnectionDef(), true
+}
+
+func (plan StaticConnectionPlan) LookupResolvedConnection(name string) (ResolvedConnectionDef, bool) {
+	conn, err := plan.connectionDef(ResolveConnectionAlias(name))
+	if err != nil {
+		return ResolvedConnectionDef{}, false
 	}
 	return conn, true
 }
@@ -254,12 +315,12 @@ func (plan StaticConnectionPlan) AdvertisedConnectionNames() []string {
 }
 
 func (plan StaticConnectionPlan) ConnectionMode() core.ConnectionMode {
-	if ConnectionModeForConnection(plan.pluginConnection) == core.ConnectionModeUser {
+	if ConnectionModeForConnection(plan.pluginConnection.ConnectionDef()) == core.ConnectionModeUser {
 		return core.ConnectionModeUser
 	}
-	hasPlatform := ConnectionModeForConnection(plan.pluginConnection) == core.ConnectionModePlatform
+	hasPlatform := ConnectionModeForConnection(plan.pluginConnection.ConnectionDef()) == core.ConnectionModePlatform
 	for _, name := range plan.NamedConnectionNames() {
-		mode := ConnectionModeForConnection(plan.namedConnections[name])
+		mode := ConnectionModeForConnection(plan.namedConnections[name].ConnectionDef())
 		if mode == core.ConnectionModeUser {
 			return core.ConnectionModeUser
 		}
@@ -281,11 +342,19 @@ func (plan StaticConnectionPlan) validateConnectionModes() error {
 		}
 	}
 
-	if err := addMode("plugin connection", ConnectionModeForConnection(plan.pluginConnection)); err != nil {
+	if err := addMode("plugin connection", ConnectionModeForConnection(plan.pluginConnection.ConnectionDef())); err != nil {
+		return err
+	}
+	if err := validateConnectionExposure("plugin connection", plan.pluginConnection.ConnectionDef()); err != nil {
 		return err
 	}
 	for _, name := range plan.NamedConnectionNames() {
-		if err := addMode(fmt.Sprintf("connection %q", name), ConnectionModeForConnection(plan.namedConnections[name])); err != nil {
+		scope := fmt.Sprintf("connection %q", name)
+		conn := plan.namedConnections[name].ConnectionDef()
+		if err := addMode(scope, ConnectionModeForConnection(conn)); err != nil {
+			return err
+		}
+		if err := validateConnectionExposure(scope, conn); err != nil {
 			return err
 		}
 	}
@@ -389,13 +458,13 @@ func (plan StaticConnectionPlan) shouldAdvertisePluginConnection() bool {
 	return false
 }
 
-func (plan StaticConnectionPlan) connectionDef(name string) (ConnectionDef, error) {
+func (plan StaticConnectionPlan) connectionDef(name string) (ResolvedConnectionDef, error) {
 	if name == "" || name == PluginConnectionName {
 		return plan.pluginConnection, nil
 	}
 	conn, ok := plan.namedConnections[name]
 	if !ok {
-		return ConnectionDef{}, fmt.Errorf("undeclared connection %q", name)
+		return ResolvedConnectionDef{}, fmt.Errorf("undeclared connection %q", name)
 	}
 	return conn, nil
 }
@@ -446,6 +515,116 @@ func namedConnectionNames(plugin *ProviderEntry, manifestPlugin *providermanifes
 	return names
 }
 
+func ResolvePluginConnectionDef(plugin *ProviderEntry) ResolvedConnectionDef {
+	conn := EffectivePluginConnectionDef(plugin)
+	conn.Mode = providermanifestv1.ConnectionMode(ConnectionModeForConnection(conn))
+	conn.Exposure = providermanifestv1.ConnectionExposure(ConnectionExposureForConnection(conn))
+	source := ResolvedConnectionSource{
+		ModeSource:     ConfigSourceDefault,
+		ExposureSource: ConfigSourceDefault,
+		AuthSource:     ConfigSourceDefault,
+	}
+	if plugin != nil {
+		source.DeclaredInDeploy = true
+		if plugin.ConnectionMode != "" {
+			source.ModeSource = ConfigSourceDeploy
+		}
+		if plugin.Auth != nil {
+			source.AuthSource = ConfigSourceDeploy
+		}
+	}
+	return resolvedConnectionDef(PluginConnectionName, conn, source)
+}
+
+func ResolveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *providermanifestv1.Spec, name string) (ResolvedConnectionDef, bool, error) {
+	conn := ConnectionDef{}
+	source := ResolvedConnectionSource{
+		ModeSource:     ConfigSourceDefault,
+		ExposureSource: ConfigSourceDefault,
+		AuthSource:     ConfigSourceDefault,
+	}
+	found := false
+
+	if manifestPlugin != nil && manifestPlugin.Connections != nil {
+		if def, ok := manifestPlugin.Connections[name]; ok && def != nil {
+			found = true
+			source.DeclaredInManifest = true
+			conn.DisplayName = def.DisplayName
+			if def.Mode != "" {
+				conn.Mode = def.Mode
+				source.ModeSource = ConfigSourceManifest
+			}
+			if def.Exposure != "" {
+				if _, err := ParseConnectionExposure(string(def.Exposure)); err != nil {
+					return ResolvedConnectionDef{}, false, fmt.Errorf("connection %q manifest exposure: %w", name, err)
+				}
+				conn.Exposure = def.Exposure
+				source.ExposureSource = ConfigSourceManifest
+			}
+			if def.Auth != nil {
+				MergeConnectionAuth(&conn.Auth, ManifestAuthToConnectionAuthDef(def.Auth))
+				source.AuthSource = ConfigSourceManifest
+			}
+			if len(def.Params) > 0 {
+				conn.ConnectionParams = maps.Clone(def.Params)
+			}
+			if def.Discovery != nil {
+				conn.Discovery = def.Discovery
+			}
+		}
+	}
+	if plugin != nil {
+		if def, ok := plugin.Connections[name]; ok && def != nil {
+			found = true
+			source.DeclaredInDeploy = true
+			if def.Exposure != "" {
+				if _, err := ParseConnectionExposure(string(def.Exposure)); err != nil {
+					return ResolvedConnectionDef{}, false, fmt.Errorf("connection %q deploy exposure: %w", name, err)
+				}
+				currentExposure := ConnectionExposureForConnection(conn)
+				deployExposure := core.NormalizeConnectionExposure(core.ConnectionExposure(def.Exposure))
+				if currentExposure == core.ConnectionExposureInternal && deployExposure == core.ConnectionExposureUser {
+					return ResolvedConnectionDef{}, false, fmt.Errorf("connection %q deploy exposure %q cannot widen manifest exposure %q", name, def.Exposure, providermanifestv1.ConnectionExposureInternal)
+				}
+				if currentExposure == core.ConnectionExposureUser && deployExposure == core.ConnectionExposureInternal {
+					source.NarrowedByDeploy = true
+				}
+				source.ExposureSource = ConfigSourceDeploy
+			}
+			if def.Mode != "" {
+				source.ModeSource = ConfigSourceDeploy
+			}
+			if def.Auth.Type != "" || def.Auth.Token != "" || def.Auth.AuthMapping != nil || def.Auth.Credentials != nil {
+				source.AuthSource = ConfigSourceDeploy
+			}
+			MergeConnectionDef(&conn, def)
+		}
+	}
+
+	if !found {
+		return ResolvedConnectionDef{}, false, nil
+	}
+	if err := validateConnectionExposure(fmt.Sprintf("connection %q", name), conn); err != nil {
+		return ResolvedConnectionDef{}, false, err
+	}
+	conn.Mode = providermanifestv1.ConnectionMode(ConnectionModeForConnection(conn))
+	conn.Exposure = providermanifestv1.ConnectionExposure(ConnectionExposureForConnection(conn))
+	return resolvedConnectionDef(name, conn, source), true, nil
+}
+
+func resolvedConnectionDef(name string, conn ConnectionDef, source ResolvedConnectionSource) ResolvedConnectionDef {
+	return ResolvedConnectionDef{
+		Name:        name,
+		DisplayName: conn.DisplayName,
+		Mode:        conn.Mode,
+		Exposure:    conn.Exposure,
+		Auth:        conn.Auth,
+		Params:      conn.ConnectionParams,
+		Discovery:   conn.Discovery,
+		Source:      source,
+	}
+}
+
 // ConnectionModeForConnection returns the effective credential mode for a
 // merged connection definition.
 func ConnectionModeForConnection(conn ConnectionDef) core.ConnectionMode {
@@ -458,4 +637,34 @@ func ConnectionModeForConnection(conn ConnectionDef) core.ConnectionMode {
 	default:
 		return core.ConnectionModeUser
 	}
+}
+
+func ParseConnectionExposure(raw string) (core.ConnectionExposure, error) {
+	switch exposure := core.ConnectionExposure(strings.TrimSpace(raw)); exposure {
+	case "", core.ConnectionExposureUser:
+		return core.ConnectionExposureUser, nil
+	case core.ConnectionExposureInternal:
+		return core.ConnectionExposureInternal, nil
+	default:
+		return "", fmt.Errorf("unsupported connection exposure %q", raw)
+	}
+}
+
+func ConnectionExposureForConnection(conn ConnectionDef) core.ConnectionExposure {
+	exposure, err := ParseConnectionExposure(string(conn.Exposure))
+	if err != nil {
+		return core.ConnectionExposure(conn.Exposure)
+	}
+	return exposure
+}
+
+func validateConnectionExposure(scope string, conn ConnectionDef) error {
+	exposure, err := ParseConnectionExposure(string(conn.Exposure))
+	if err != nil {
+		return fmt.Errorf("%s %w", scope, err)
+	}
+	if exposure == core.ConnectionExposureInternal && ConnectionModeForConnection(conn) == core.ConnectionModeUser {
+		return fmt.Errorf("%s exposure %q is not supported for user-owned connections", scope, exposure)
+	}
+	return nil
 }

--- a/gestaltd/internal/config/connection_plan_test.go
+++ b/gestaltd/internal/config/connection_plan_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -32,5 +33,62 @@ func TestBuildStaticConnectionPlan_PrefersNamedDefaultConnection(t *testing.T) {
 	}
 	if got := plan.MCPConnection(); got != "default" {
 		t.Fatalf("MCPConnection() = %q, want %q", got, "default")
+	}
+}
+
+func TestBuildStaticConnectionPlan_ConnectionExposureMergeContract(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Spec{
+		Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+			"user": {
+				Mode:     providermanifestv1.ConnectionModePlatform,
+				Exposure: providermanifestv1.ConnectionExposureUser,
+			},
+			"internal": {
+				Mode:     providermanifestv1.ConnectionModePlatform,
+				Exposure: providermanifestv1.ConnectionExposureInternal,
+			},
+		},
+	}
+	plan, err := BuildStaticConnectionPlan(&ProviderEntry{
+		Connections: map[string]*ConnectionDef{
+			"user": {Exposure: providermanifestv1.ConnectionExposureInternal},
+		},
+	}, manifest)
+	if err != nil {
+		t.Fatalf("BuildStaticConnectionPlan() narrowing error = %v", err)
+	}
+	userConn, ok := plan.ResolvedNamedConnectionDef("user")
+	if !ok {
+		t.Fatal("resolved user connection missing")
+	}
+	if userConn.Exposure != providermanifestv1.ConnectionExposureInternal || !userConn.Source.NarrowedByDeploy {
+		t.Fatalf("resolved user connection = %+v, want deploy-narrowed internal exposure", userConn)
+	}
+
+	_, err = BuildStaticConnectionPlan(&ProviderEntry{
+		Connections: map[string]*ConnectionDef{
+			"internal": {Exposure: providermanifestv1.ConnectionExposureUser},
+		},
+	}, manifest)
+	if err == nil || !strings.Contains(err.Error(), "cannot widen") {
+		t.Fatalf("BuildStaticConnectionPlan() widening error = %v, want cannot widen", err)
+	}
+}
+
+func TestBuildStaticConnectionPlan_RejectsInternalUserConnection(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildStaticConnectionPlan(&ProviderEntry{}, &providermanifestv1.Spec{
+		Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+			"default": {
+				Mode:     providermanifestv1.ConnectionModeUser,
+				Exposure: providermanifestv1.ConnectionExposureInternal,
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not supported for user-owned connections") {
+		t.Fatalf("BuildStaticConnectionPlan() error = %v, want internal user rejection", err)
 	}
 }

--- a/gestaltd/internal/mcp/authorization.go
+++ b/gestaltd/internal/mcp/authorization.go
@@ -89,7 +89,7 @@ func catalogOperationForTool(ctx context.Context, cfg Config, providerName, oper
 		!sessionProviderHydratedFromContext(ctx, providerName, "") {
 		return catalog.CatalogOperation{}, false
 	}
-	if op, ok := invocation.CatalogOperation(prov.Catalog(), operation); ok && catalogOperationProjectedToMCP(cfg, providerName, op) {
+	if op, ok := invocation.CatalogOperation(projectCatalog(cfg, providerName, prov, prov.Catalog()), operation); ok && catalogOperationProjectedToMCP(cfg, providerName, op) {
 		return op, true
 	}
 	if !core.SupportsSessionCatalog(prov) {

--- a/gestaltd/internal/mcp/binding.go
+++ b/gestaltd/internal/mcp/binding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
@@ -19,16 +20,18 @@ const (
 )
 
 type Config struct {
-	Invoker          invocation.Invoker
-	TokenResolver    invocation.TokenResolver
-	AuditSink        core.AuditSink
-	Providers        *registry.ProviderMap[core.Provider]
-	Authorizer       authorization.RuntimeAuthorizer
-	AllowedProviders []string
-	ToolPrefixes     map[string]string
-	ToolTargets      *toolTargetIndex
-	IncludeREST      map[string]bool
-	MCPConnection    map[string]string
+	Invoker             invocation.Invoker
+	TokenResolver       invocation.TokenResolver
+	AuditSink           core.AuditSink
+	Providers           *registry.ProviderMap[core.Provider]
+	Authorizer          authorization.RuntimeAuthorizer
+	AllowedProviders    []string
+	ToolPrefixes        map[string]string
+	ToolTargets         *toolTargetIndex
+	IncludeREST         map[string]bool
+	MCPConnection       map[string]string
+	CatalogProjection   func(provName string, prov core.Provider, cat *catalog.Catalog) *catalog.Catalog
+	InvocationValidator func(ctx context.Context, provName string, prov core.Provider, op catalog.CatalogOperation, params map[string]any, explicitConnection string) error
 }
 
 func NewServer(cfg Config) *mcpserver.MCPServer {
@@ -67,7 +70,7 @@ func NewServer(cfg Config) *mcpserver.MCPServer {
 			dynamicProviders = append(dynamicProviders, provName)
 		}
 
-		if cat := prov.Catalog(); cat != nil {
+		if cat := projectCatalog(cfg, provName, prov, prov.Catalog()); cat != nil {
 			for name := range buildToolMap(cfg, provName, cat) {
 				staticToolNames[name] = struct{}{}
 			}

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -569,6 +569,91 @@ func TestNewServer_ToolCallUsesInjectedInvoker(t *testing.T) {
 	}
 }
 
+func TestNewServer_ToolCallValidatesArgumentsAgainstOriginalOperation(t *testing.T) {
+	t.Parallel()
+
+	cat := &catalog.Catalog{
+		Name: "slack",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:     "chat.postMessage",
+				Method: http.MethodPost,
+				Path:   "/chat.postMessage",
+				Parameters: []catalog.CatalogParameter{
+					{Name: "channel", Type: "string", Required: true},
+					{Name: "actor", Type: "string", Internal: true},
+				},
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"channel":{"type":"string"},"actor":{"type":"string"}}}`),
+			},
+		},
+	}
+	prov := &catalogProvider{
+		StubIntegration: coretesting.StubIntegration{N: "slack"},
+		catalog:         cat,
+	}
+	providers := testutil.NewProviderRegistry(t, prov)
+
+	var invoked bool
+	var validatorSawInternalParam bool
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker: &testutil.StubInvoker{
+			InvokeFn: func(_ context.Context, _ *principal.Principal, _, _, _ string, _ map[string]any) (*core.OperationResult, error) {
+				invoked = true
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		Providers: providers,
+		CatalogProjection: func(_ string, _ core.Provider, source *catalog.Catalog) *catalog.Catalog {
+			projected := source.Clone()
+			projected.Operations[0].Parameters = []catalog.CatalogParameter{
+				{Name: "channel", Type: "string", Required: true},
+			}
+			projected.Operations[0].InputSchema = json.RawMessage(`{"type":"object","properties":{"channel":{"type":"string"}}}`)
+			return projected
+		},
+		InvocationValidator: func(_ context.Context, _ string, _ core.Provider, op catalog.CatalogOperation, params map[string]any, _ string) error {
+			for _, param := range op.Parameters {
+				if param.Name == "actor" && param.Internal {
+					validatorSawInternalParam = true
+					break
+				}
+			}
+			if _, ok := params["actor"]; ok {
+				if !validatorSawInternalParam {
+					return fmt.Errorf("validator saw projected operation metadata")
+				}
+				return fmt.Errorf("%w: parameter %q is not public", invocation.ErrInvalidInvocation, "actor")
+			}
+			return nil
+		},
+	})
+
+	tool := srv.GetTool("slack_chat_postMessage")
+	if tool == nil {
+		t.Fatal("tool not found")
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "slack_chat_postMessage"
+	req.Params.Arguments = map[string]any{
+		"channel": "C123",
+		"actor":   "bot",
+	}
+	result, err := tool.Handler(ctxWithPrincipal("stub-user-id"), req)
+	if err != nil {
+		t.Fatalf("unexpected protocol-level error: %v", err)
+	}
+	if !validatorSawInternalParam {
+		t.Fatal("expected invocation validator to receive original operation metadata")
+	}
+	if invoked {
+		t.Fatal("expected invalid public MCP arguments to be denied before invocation")
+	}
+	if !result.IsError {
+		t.Fatalf("expected error result, got %+v", result)
+	}
+}
+
 func TestNewServer_ErrorResultSetsIsError(t *testing.T) {
 	t.Parallel()
 
@@ -1319,6 +1404,84 @@ func TestNewServer_HumanListToolsUsesHydratedSessionCatalogSnapshot(t *testing.T
 	}
 	if sessionCatalogCalls != 1 {
 		t.Fatalf("sessionCatalogCalls after call = %d, want 1", sessionCatalogCalls)
+	}
+}
+
+func TestNewServer_HumanCallToolRejectsHiddenSessionCatalogArguments(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	sessionCatalog := &catalog.Catalog{
+		Name: "sampledb",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:          "run_query",
+				Description: "run a query",
+				Transport:   catalog.TransportMCPPassthrough,
+				Parameters: []catalog.CatalogParameter{
+					{Name: "sql", Type: "string"},
+					{Name: "actor", Type: "string", Internal: true},
+				},
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"sql":{"type":"string"},"actor":{"type":"string"}}}`),
+			},
+			{
+				ID:          "open_view",
+				Description: "open a view",
+				Transport:   catalog.TransportMCPPassthrough,
+				Parameters: []catalog.CatalogParameter{
+					{Name: "audience", Type: "string"},
+				},
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"audience":{"type":"string","enum":["user","bot"]}}}`),
+			},
+		},
+	}
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{N: "sampledb", ConnMode: core.ConnectionModeNone},
+		sessionCatalogFn: func(_ context.Context, _ string) (*catalog.Catalog, error) {
+			return sessionCatalog, nil
+		},
+	}
+	providers := testutil.NewProviderRegistry(t, prov)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker: &testutil.StubInvoker{
+			InvokeFn: func(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+				invoked = true
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		Providers: providers,
+		CatalogProjection: func(_ string, _ core.Provider, source *catalog.Catalog) *catalog.Catalog {
+			projected := source.Clone()
+			projected.Operations[0].Parameters = []catalog.CatalogParameter{
+				{Name: "sql", Type: "string"},
+			}
+			projected.Operations[0].InputSchema = json.RawMessage(`{"type":"object","properties":{"sql":{"type":"string"}}}`)
+			projected.Operations[1].InputSchema = json.RawMessage(`{"type":"object","properties":{"audience":{"type":"string","enum":["user"]}}}`)
+			return projected
+		},
+	})
+
+	session := newTestSessionWithTools()
+	result := listToolsForSession(t, srv, ctxWithPrincipal("viewer-user"), session)
+	if len(result.Tools) != 2 {
+		t.Fatalf("tools = %+v, want run_query and open_view", result.Tools)
+	}
+
+	hiddenParam := callToolForSession(t, srv, ctxWithPrincipal("viewer-user"), session, "sampledb_run_query", map[string]any{
+		"sql":   "select 1",
+		"actor": "bot",
+	})
+	if !hiddenParam.IsError {
+		t.Fatalf("hidden param call result = %+v, want error", hiddenParam)
+	}
+	hiddenEnum := callToolForSession(t, srv, ctxWithPrincipal("viewer-user"), session, "sampledb_open_view", map[string]any{
+		"audience": "bot",
+	})
+	if !hiddenEnum.IsError {
+		t.Fatalf("hidden enum call result = %+v, want error", hiddenEnum)
+	}
+	if invoked {
+		t.Fatal("expected invalid public MCP arguments to be denied before invocation")
 	}
 }
 

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
@@ -34,12 +35,17 @@ func makeHandler(cfg Config, provName, opName, connection string) mcpserver.Tool
 		if connection != "" {
 			ctx = invocation.WithConnection(ctx, connection)
 		}
+		ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceMCP)
 		if sessionCatalogOperationSuppressedFromContext(ctx, provName, opName, instance) {
 			return mcpgo.NewToolResultError("requested instance is unavailable for this tool"), nil
 		}
+		var validationOp catalog.CatalogOperation
+		var hasValidationOp bool
 		opMeta, sessionConnection, ok := sessionCatalogOperationFromContext(ctx, provName, opName, instance)
 		if ok {
 			ctx = invocation.WithCatalogOperation(ctx, provName, opMeta)
+			validationOp = opMeta
+			hasValidationOp = true
 			if invocation.ConnectionFromContext(ctx) == "" && sessionConnection != "" {
 				ctx = invocation.WithConnection(ctx, sessionConnection)
 			}
@@ -51,6 +57,15 @@ func makeHandler(cfg Config, provName, opName, connection string) mcpserver.Tool
 			}
 		} else if instance != "" {
 			return mcpgo.NewToolResultError("requested instance is unavailable for this tool"), nil
+		}
+		if err := validateSessionCatalogInvocation(ctx, provName, opName, instance, args); err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		if err := validateToolInvocation(ctx, cfg, provName, opName, validationOp, hasValidationOp, args); err != nil {
+			if errors.Is(err, invocation.ErrAuthorizationDenied) || errors.Is(err, invocation.ErrScopeDenied) {
+				return mcpgo.NewToolResultError("operation access denied"), nil
+			}
+			return mcpgo.NewToolResultError(err.Error()), nil
 		}
 		ctx = mcpupstream.WithCallToolMeta(ctx, req.Params.Meta)
 		result, err := cfg.Invoker.Invoke(ctx, p, provName, instance, opName, args)
@@ -73,4 +88,24 @@ func makeHandler(cfg Config, provName, opName, connection string) mcpserver.Tool
 		}
 		return mcpgo.NewToolResultText(result.Body), nil
 	}
+}
+
+func validateToolInvocation(ctx context.Context, cfg Config, provName, opName string, fallbackOp catalog.CatalogOperation, hasFallbackOp bool, args map[string]any) error {
+	if cfg.InvocationValidator == nil || cfg.Providers == nil {
+		return nil
+	}
+	prov, err := cfg.Providers.Get(provName)
+	if err != nil {
+		return err
+	}
+	op := fallbackOp
+	hasOp := hasFallbackOp
+	if staticOp, ok := invocation.CatalogOperation(prov.Catalog(), opName); ok {
+		op = staticOp
+		hasOp = true
+	}
+	if !hasOp {
+		return nil
+	}
+	return cfg.InvocationValidator(ctx, provName, prov, op, args, invocation.ConnectionFromContext(ctx))
 }

--- a/gestaltd/internal/mcp/projection.go
+++ b/gestaltd/internal/mcp/projection.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"strings"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -14,6 +15,13 @@ func addCatalogTools(srv *mcpserver.MCPServer, cfg Config, provName string, cat 
 	for name := range m {
 		srv.AddTool(m[name].Tool, m[name].Handler)
 	}
+}
+
+func projectCatalog(cfg Config, provName string, prov core.Provider, cat *catalog.Catalog) *catalog.Catalog {
+	if cfg.CatalogProjection == nil || cat == nil {
+		return cat
+	}
+	return cfg.CatalogProjection(provName, prov, cat)
 }
 
 func buildToolMap(cfg Config, provName string, cat *catalog.Catalog) map[string]mcpserver.ServerTool {

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -24,10 +25,12 @@ const (
 )
 
 type sessionCatalogOperationMeta struct {
-	AllowedRoles []string `json:"allowedRoles,omitempty"`
-	Transport    string   `json:"transport,omitempty"`
-	Connection   string   `json:"connection,omitempty"`
-	Projected    bool     `json:"projected,omitempty"`
+	AllowedRoles    []string        `json:"allowedRoles,omitempty"`
+	Transport       string          `json:"transport,omitempty"`
+	Connection      string          `json:"connection,omitempty"`
+	Projected       bool            `json:"projected,omitempty"`
+	HiddenArguments []string        `json:"hiddenArguments,omitempty"`
+	InputSchema     json.RawMessage `json:"inputSchema,omitempty"`
 }
 
 func hydrateSessionTools(ctx context.Context, cfg Config, providerNames []string, staticToolNames map[string]struct{}) {
@@ -72,10 +75,11 @@ func hydrateSessionToolsForInstance(ctx context.Context, cfg Config, providerNam
 			continue
 		}
 
-		cat, _, err := core.CatalogForRequest(sessionCtx, prov, token)
+		rawCat, _, err := core.CatalogForRequest(sessionCtx, prov, token)
 		if err != nil {
 			continue
 		}
+		cat := projectCatalog(cfg, provName, prov, rawCat)
 		if deleteSessionProviderHydrationAttempted(tools, provName, instance) {
 			changed = true
 		}
@@ -85,7 +89,7 @@ func hydrateSessionToolsForInstance(ctx context.Context, cfg Config, providerNam
 		if cat == nil {
 			continue
 		}
-		storeSessionCatalogOperationMetadata(tools, cfg, provName, cat, staticToolNames, instance, connection)
+		storeSessionCatalogOperationMetadata(tools, cfg, provName, rawCat, cat, staticToolNames, instance, connection)
 
 		m := buildToolMap(cfg, provName, cat)
 		for name := range m {
@@ -187,14 +191,26 @@ func sessionProviderHydrationAttemptedFromContext(ctx context.Context, provider,
 	return sessionProviderHydrationAttempted(sessionWithTools.GetSessionTools(), provider, instance)
 }
 
-func storeSessionCatalogOperationMetadata(tools map[string]mcpserver.ServerTool, cfg Config, provider string, cat *catalog.Catalog, staticToolNames map[string]struct{}, instance string, connection string) {
+func storeSessionCatalogOperationMetadata(tools map[string]mcpserver.ServerTool, cfg Config, provider string, rawCat *catalog.Catalog, cat *catalog.Catalog, staticToolNames map[string]struct{}, instance string, connection string) {
+	rawOps := map[string]catalog.CatalogOperation{}
+	if rawCat != nil {
+		for i := range rawCat.Operations {
+			rawOps[rawCat.Operations[i].ID] = rawCat.Operations[i]
+		}
+	}
 	for i := range cat.Operations {
 		op := &cat.Operations[i]
+		rawOp := *op
+		if candidate, ok := rawOps[op.ID]; ok {
+			rawOp = candidate
+		}
 		payload, err := json.Marshal(sessionCatalogOperationMeta{
-			AllowedRoles: append([]string(nil), op.AllowedRoles...),
-			Transport:    op.Transport,
-			Connection:   connection,
-			Projected:    catalogOperationProjectedToMCP(cfg, provider, *op),
+			AllowedRoles:    append([]string(nil), op.AllowedRoles...),
+			Transport:       op.Transport,
+			Connection:      connection,
+			Projected:       catalogOperationProjectedToMCP(cfg, provider, *op),
+			HiddenArguments: hiddenSessionCatalogArguments(rawOp, *op),
+			InputSchema:     append(json.RawMessage(nil), op.InputSchema...),
 		})
 		if err != nil {
 			continue
@@ -241,6 +257,112 @@ func sessionCatalogOperationFromContext(ctx context.Context, provider, operation
 		AllowedRoles: meta.AllowedRoles,
 		Transport:    meta.Transport,
 	}, meta.Connection, true
+}
+
+func validateSessionCatalogInvocation(ctx context.Context, provider, operation, instance string, args map[string]any) error {
+	meta, ok := sessionCatalogOperationMetaFromContext(ctx, provider, operation, instance)
+	if !ok || !meta.Projected {
+		return nil
+	}
+	for _, name := range meta.HiddenArguments {
+		if _, ok := args[name]; ok {
+			return fmt.Errorf("%w: parameter %q is not public", invocation.ErrInvalidInvocation, name)
+		}
+	}
+	enums := sessionCatalogSchemaEnums(meta.InputSchema)
+	for name, values := range enums {
+		raw, ok := args[name]
+		if !ok || raw == nil {
+			continue
+		}
+		if _, allowed := values[fmt.Sprint(raw)]; !allowed {
+			return fmt.Errorf("%w: parameter %q value %q is not public", invocation.ErrInvalidInvocation, name, fmt.Sprint(raw))
+		}
+	}
+	return nil
+}
+
+func hiddenSessionCatalogArguments(rawOp catalog.CatalogOperation, projectedOp catalog.CatalogOperation) []string {
+	projected := map[string]struct{}{}
+	for _, param := range projectedOp.Parameters {
+		projected[param.Name] = struct{}{}
+	}
+	for name := range schemaPropertyNames(projectedOp.InputSchema) {
+		projected[name] = struct{}{}
+	}
+
+	hidden := map[string]struct{}{}
+	for _, param := range rawOp.Parameters {
+		if _, ok := projected[param.Name]; !ok {
+			hidden[param.Name] = struct{}{}
+		}
+	}
+	for name := range schemaPropertyNames(rawOp.InputSchema) {
+		if _, ok := projected[name]; !ok {
+			hidden[name] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(hidden))
+	for name := range hidden {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func schemaPropertyNames(raw json.RawMessage) map[string]struct{} {
+	props := schemaProperties(raw)
+	if len(props) == 0 {
+		return nil
+	}
+	names := make(map[string]struct{}, len(props))
+	for name := range props {
+		names[name] = struct{}{}
+	}
+	return names
+}
+
+func sessionCatalogSchemaEnums(raw json.RawMessage) map[string]map[string]struct{} {
+	props := schemaProperties(raw)
+	if len(props) == 0 {
+		return nil
+	}
+	out := map[string]map[string]struct{}{}
+	for name, prop := range props {
+		rawEnum, _ := prop["enum"].([]any)
+		if len(rawEnum) == 0 {
+			continue
+		}
+		values := make(map[string]struct{}, len(rawEnum))
+		for _, value := range rawEnum {
+			values[fmt.Sprint(value)] = struct{}{}
+		}
+		out[name] = values
+	}
+	return out
+}
+
+func schemaProperties(raw json.RawMessage) map[string]map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return nil
+	}
+	rawProps, _ := schema["properties"].(map[string]any)
+	if len(rawProps) == 0 {
+		return nil
+	}
+	props := make(map[string]map[string]any, len(rawProps))
+	for name, rawProp := range rawProps {
+		prop, _ := rawProp.(map[string]any)
+		if prop == nil {
+			continue
+		}
+		props[name] = prop
+	}
+	return props
 }
 
 func sessionCatalogOperationSuppressedFromContext(ctx context.Context, provider, operation, instance string) bool {

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -547,12 +547,22 @@ func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error
 			return fmt.Errorf("provider.connections.%s.auth.type %q requires an MCP surface", name, providermanifestv1.AuthTypeMCPOAuth)
 		}
 		if conn.Mode == "" {
-			continue
+		} else {
+			switch conn.Mode {
+			case providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser, providermanifestv1.ConnectionModePlatform:
+			default:
+				return fmt.Errorf("unsupported provider.connections.%s.mode %q", name, conn.Mode)
+			}
 		}
-		switch conn.Mode {
-		case providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser, providermanifestv1.ConnectionModePlatform:
-		default:
-			return fmt.Errorf("unsupported provider.connections.%s.mode %q", name, conn.Mode)
+		if conn.Exposure != "" {
+			switch conn.Exposure {
+			case providermanifestv1.ConnectionExposureUser, providermanifestv1.ConnectionExposureInternal:
+			default:
+				return fmt.Errorf("unsupported provider.connections.%s.exposure %q", name, conn.Exposure)
+			}
+			if conn.Exposure == providermanifestv1.ConnectionExposureInternal && manifestConnectionMode(conn) == providermanifestv1.ConnectionModeUser {
+				return fmt.Errorf("provider.connections.%s exposure %q is not supported for user-owned connections", name, conn.Exposure)
+			}
 		}
 	}
 	if provider.DefaultConnection != "" {
@@ -580,6 +590,19 @@ func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error
 		}
 	}
 	return nil
+}
+
+func manifestConnectionMode(conn *providermanifestv1.ManifestConnectionDef) providermanifestv1.ConnectionMode {
+	if conn == nil {
+		return providermanifestv1.ConnectionModeNone
+	}
+	if conn.Mode != "" {
+		return conn.Mode
+	}
+	if conn.Auth == nil || conn.Auth.Type == "" || conn.Auth.Type == providermanifestv1.AuthTypeNone {
+		return providermanifestv1.ConnectionModeNone
+	}
+	return providermanifestv1.ConnectionModeUser
 }
 
 var validParamIn = map[string]bool{

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -539,7 +539,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
 	}
 	cat = invocation.FilterCatalogForPrincipal(ctx, cat, name, p, s.authorizer)
-	ops := httpVisibleCatalogOperations(cat.Operations)
+	ops := s.publicHTTPOperations(name, prov, cat.Operations)
 	sort.Slice(ops, func(i, j int) bool {
 		return ops[i].ID < ops[j].ID
 	})
@@ -672,6 +672,10 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	}
 	if !catalog.OperationVisibleByDefault(opMeta) {
 		s.writeInvocationError(w, r, providerName, operationName, invocation.ErrOperationNotFound)
+		return
+	}
+	if err := s.validatePublicOperationInvocation(providerName, surfaceProv, opMeta, params, connection); err != nil {
+		s.writeInvocationError(w, r, providerName, operationName, err)
 		return
 	}
 	if s.authorizer != nil && !s.authorizer.AllowCatalogOperation(ctx, p, providerName, opMeta) {
@@ -841,21 +845,6 @@ func deploymentCredentialRequired(err error) bool {
 	message := err.Error()
 	return strings.Contains(message, "deployment credential configured") ||
 		strings.Contains(message, "deployment-managed connection")
-}
-
-func httpVisibleCatalogOperations(ops []catalog.CatalogOperation) []catalog.CatalogOperation {
-	filtered := make([]catalog.CatalogOperation, 0, len(ops))
-	for i := range ops {
-		op := ops[i]
-		if !catalog.OperationVisibleByDefault(op) {
-			continue
-		}
-		if invocation.OperationTransport(op) == catalog.TransportMCPPassthrough {
-			continue
-		}
-		filtered = append(filtered, op)
-	}
-	return filtered
 }
 
 func staticCatalogOperationVisibleByDefault(prov core.Provider, operation string) (bool, bool) {

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -264,6 +264,9 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 		if !ok || shouldHidePassiveNamedConnection(plan, name, conn, integrationAuthTypes) {
 			continue
 		}
+		if config.ConnectionExposureForConnection(conn) == core.ConnectionExposureInternal {
+			continue
+		}
 		if name == config.PluginConnectionName {
 			conn = displayPluginConnectionDef(plugin, manifestSpec, conn)
 		}
@@ -449,11 +452,14 @@ func (s *Server) hasConfiguredPlatformConnection(integration string) bool {
 	if err != nil {
 		return false
 	}
-	if platformConnectionConfiguredForName(integration, config.PluginConnectionName, plan.PluginConnection()) {
+	if pluginConn := plan.PluginConnection(); config.ConnectionExposureForConnection(pluginConn) != core.ConnectionExposureInternal && platformConnectionConfiguredForName(integration, config.PluginConnectionName, pluginConn) {
 		return true
 	}
 	for _, name := range plan.NamedConnectionNames() {
 		conn, _ := plan.NamedConnectionDef(name)
+		if config.ConnectionExposureForConnection(conn) == core.ConnectionExposureInternal {
+			continue
+		}
 		if platformConnectionConfiguredForName(integration, name, conn) {
 			return true
 		}

--- a/gestaltd/internal/server/http_binding_dispatch.go
+++ b/gestaltd/internal/server/http_binding_dispatch.go
@@ -68,7 +68,7 @@ func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding Mou
 	ctx = principal.WithPrincipal(ctx, p)
 	ctx = invocation.WithAccessContext(ctx, s.providerAccessContextWithContext(ctx, p, binding.PluginName))
 	ctx = invocation.WithWorkflowContext(ctx, httpBindingContextValue(binding, verified, parsed))
-	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTP)
+	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTPBinding)
 	ctx = invocation.WithHTTPBinding(ctx, binding.Name)
 	if binding.CredentialMode != "" {
 		ctx = invocation.WithCredentialModeOverride(ctx, binding.CredentialMode)

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -32,7 +32,7 @@ func (s *Server) integrationHasVisibleHTTPOperationsContext(ctx context.Context,
 		return false
 	}
 	cat = invocation.FilterCatalogForPrincipal(ctx, cat, provider, p, s.authorizer)
-	return len(httpVisibleCatalogOperations(cat.Operations)) > 0
+	return len(s.publicHTTPOperations(provider, prov, cat.Operations)) > 0
 }
 
 func (s *Server) integrationMountedPathForPrincipalContext(ctx context.Context, p *principal.Principal, provider, mountedPath string) string {

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -800,7 +800,7 @@ func TestHTTPBindingOperationMetricsIncludeBinding(t *testing.T) {
 		"gestalt.operation":           "receive_event",
 		"gestalt.transport":           "rest",
 		"gestalt.connection_mode":     "none",
-		"gestalt.invocation_surface":  "http",
+		"gestalt.invocation_surface":  "http_binding",
 		"gestalt.http_binding":        "delivery",
 		"gestalt.result_status":       "200",
 		"gestalt.result_status_class": "2xx",

--- a/gestaltd/internal/server/public_catalog.go
+++ b/gestaltd/internal/server/public_catalog.go
@@ -1,0 +1,300 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+	declarative "github.com/valon-technologies/gestalt/server/services/plugins/declarative"
+)
+
+type operationConnectionProjection struct {
+	plan        config.StaticConnectionPlan
+	connections map[string]string
+	selectors   map[string]core.OperationConnectionSelector
+}
+
+func (s *Server) publicHTTPOperations(integration string, prov core.Provider, ops []catalog.CatalogOperation) []catalog.CatalogOperation {
+	projector, hasProjector := s.operationConnectionProjection(integration)
+	out := make([]catalog.CatalogOperation, 0, len(ops))
+	for i := range ops {
+		op := ops[i]
+		if !catalog.OperationVisibleByDefault(op) {
+			continue
+		}
+		if invocation.OperationTransport(op) == catalog.TransportMCPPassthrough {
+			continue
+		}
+		projected, ok := s.projectPublicOperation(prov, op, projector, hasProjector)
+		if !ok {
+			continue
+		}
+		out = append(out, projected)
+	}
+	return out
+}
+
+func (s *Server) publicMCPCatalog(integration string, prov core.Provider, cat *catalog.Catalog) *catalog.Catalog {
+	if cat == nil {
+		return nil
+	}
+	filtered := cat.Clone()
+	projector, hasProjector := s.operationConnectionProjection(integration)
+	ops := filtered.Operations[:0]
+	for i := range filtered.Operations {
+		op := filtered.Operations[i]
+		if !catalog.OperationVisibleByDefault(op) {
+			continue
+		}
+		projected, ok := s.projectPublicOperation(prov, op, projector, hasProjector)
+		if !ok {
+			continue
+		}
+		ops = append(ops, projected)
+	}
+	filtered.Operations = ops
+	return filtered
+}
+
+func (s *Server) validatePublicOperationInvocation(integration string, prov core.Provider, op catalog.CatalogOperation, params map[string]any, explicitConnection string) error {
+	projector, hasProjector := s.operationConnectionProjection(integration)
+	if _, ok := s.projectPublicOperation(prov, op, projector, hasProjector); !ok {
+		return fmt.Errorf("%w: %s.%s uses an internal connection", invocation.ErrAuthorizationDenied, integration, op.ID)
+	}
+	if explicitConnection != "" && hasProjector && !publicConnection(projector.plan, explicitConnection) {
+		return fmt.Errorf("%w: %s connection %q is internal", invocation.ErrAuthorizationDenied, integration, explicitConnection)
+	}
+	for _, param := range op.Parameters {
+		if !param.Internal {
+			continue
+		}
+		if _, ok := params[param.Name]; ok {
+			return fmt.Errorf("%w: parameter %q is not public", invocation.ErrInvalidInvocation, param.Name)
+		}
+	}
+	if hasProjector {
+		if selector, ok := projector.selectors[op.ID]; ok {
+			if raw, present := params[selector.Parameter]; present && raw != nil {
+				value := strings.TrimSpace(fmt.Sprint(raw))
+				connection := selector.Values[value]
+				if connection != "" && !publicConnection(projector.plan, connection) {
+					return fmt.Errorf("%w: %s.%s selector value %q uses an internal connection", invocation.ErrAuthorizationDenied, integration, op.ID, value)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Server) projectPublicOperation(prov core.Provider, op catalog.CatalogOperation, projector operationConnectionProjection, hasProjector bool) (catalog.CatalogOperation, bool) {
+	if hasProjector {
+		if selector, ok := projector.selectors[op.ID]; ok {
+			selectorParam, selectorParamOK := catalogParameter(op, selector.Parameter)
+			publicValues := make(map[string]string, len(selector.Values))
+			publicSelectorValues := make([]string, 0, len(selector.Values))
+			for value, connection := range selector.Values {
+				if publicConnection(projector.plan, connection) {
+					publicValues[value] = connection
+					publicSelectorValues = append(publicSelectorValues, value)
+				}
+			}
+			if len(publicValues) == 0 {
+				return catalog.CatalogOperation{}, false
+			}
+			if selector.Default != "" {
+				if _, ok := publicValues[selector.Default]; !ok && (!selectorParamOK || selectorParam.Internal || !selectorParam.Required) {
+					return catalog.CatalogOperation{}, false
+				}
+			}
+			if selectorParamOK && selectorParam.Internal {
+				if selector.Default == "" {
+					return catalog.CatalogOperation{}, false
+				}
+				if _, ok := publicValues[selector.Default]; !ok {
+					return catalog.CatalogOperation{}, false
+				}
+			}
+			op = projectSelectorValues(op, selector.Parameter, publicSelectorValues, selector.Default)
+		} else {
+			connection := projector.connections[op.ID]
+			if connection == "" && prov != nil {
+				connection = prov.ConnectionForOperation(op.ID)
+			}
+			if connection != "" && !publicConnection(projector.plan, connection) {
+				return catalog.CatalogOperation{}, false
+			}
+		}
+	}
+	return projectInternalParameters(op), true
+}
+
+func (s *Server) operationConnectionProjection(integration string) (operationConnectionProjection, bool) {
+	entry := s.pluginDefs[integration]
+	if entry == nil {
+		return operationConnectionProjection{}, false
+	}
+	manifest := entry.ManifestSpec()
+	plan, err := config.BuildStaticConnectionPlan(entry, manifest)
+	if err != nil {
+		return operationConnectionProjection{}, false
+	}
+	connections, selectors, _, err := plan.RESTOperationConnectionBindings(manifest)
+	if err != nil {
+		return operationConnectionProjection{}, false
+	}
+	return operationConnectionProjection{
+		plan:        plan,
+		connections: connections,
+		selectors:   selectors,
+	}, true
+}
+
+func publicConnection(plan config.StaticConnectionPlan, connection string) bool {
+	resolved, ok := plan.LookupResolvedConnection(connection)
+	if !ok {
+		return true
+	}
+	return core.NormalizeConnectionExposure(core.ConnectionExposure(resolved.Exposure)) != core.ConnectionExposureInternal
+}
+
+func catalogParameter(op catalog.CatalogOperation, name string) (catalog.CatalogParameter, bool) {
+	for _, param := range op.Parameters {
+		if param.Name == name {
+			return param, true
+		}
+	}
+	return catalog.CatalogParameter{}, false
+}
+
+func projectInternalParameters(op catalog.CatalogOperation) catalog.CatalogOperation {
+	var internal map[string]struct{}
+	publicParams := make([]catalog.CatalogParameter, 0, len(op.Parameters))
+	for _, param := range op.Parameters {
+		if param.Internal {
+			if internal == nil {
+				internal = map[string]struct{}{}
+			}
+			internal[param.Name] = struct{}{}
+			continue
+		}
+		publicParams = append(publicParams, param)
+	}
+	if len(internal) == 0 {
+		return op
+	}
+	op.Parameters = publicParams
+	op.InputSchema = projectInputSchema(op.InputSchema, publicParams, internal)
+	return op
+}
+
+func projectSelectorValues(op catalog.CatalogOperation, paramName string, publicValues []string, defaultValue string) catalog.CatalogOperation {
+	publicSet := make(map[string]struct{}, len(publicValues))
+	for _, value := range publicValues {
+		publicSet[value] = struct{}{}
+	}
+	if len(op.Parameters) > 0 {
+		op.Parameters = append([]catalog.CatalogParameter(nil), op.Parameters...)
+	}
+	for i := range op.Parameters {
+		if op.Parameters[i].Name != paramName {
+			continue
+		}
+		if _, ok := publicSet[fmt.Sprint(op.Parameters[i].Default)]; !ok {
+			op.Parameters[i].Default = nil
+		}
+		if defaultValue != "" {
+			if _, ok := publicSet[defaultValue]; ok {
+				op.Parameters[i].Default = defaultValue
+			}
+		}
+		break
+	}
+	op.InputSchema = projectSelectorInputSchema(op.InputSchema, op.Parameters, paramName, publicValues, defaultValue)
+	return op
+}
+
+func projectSelectorInputSchema(raw json.RawMessage, params []catalog.CatalogParameter, paramName string, publicValues []string, defaultValue string) json.RawMessage {
+	if len(raw) == 0 {
+		raw = declarative.SynthesizeInputSchema(params)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return declarative.SynthesizeInputSchema(params)
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		props = map[string]any{}
+		schema["properties"] = props
+	}
+	prop, _ := props[paramName].(map[string]any)
+	if prop == nil {
+		prop = map[string]any{"type": "string"}
+		props[paramName] = prop
+	}
+	enum := make([]any, 0, len(publicValues))
+	publicSet := make(map[string]struct{}, len(publicValues))
+	for _, value := range publicValues {
+		enum = append(enum, value)
+		publicSet[value] = struct{}{}
+	}
+	prop["enum"] = enum
+	if rawDefault, ok := prop["default"]; ok {
+		if _, public := publicSet[fmt.Sprint(rawDefault)]; !public {
+			delete(prop, "default")
+		}
+	}
+	if defaultValue != "" {
+		if _, ok := publicSet[defaultValue]; ok {
+			prop["default"] = defaultValue
+		} else {
+			delete(prop, "default")
+		}
+	}
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return declarative.SynthesizeInputSchema(params)
+	}
+	return data
+}
+
+func projectInputSchema(raw json.RawMessage, publicParams []catalog.CatalogParameter, internal map[string]struct{}) json.RawMessage {
+	if len(raw) == 0 {
+		return declarative.SynthesizeInputSchema(publicParams)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return declarative.SynthesizeInputSchema(publicParams)
+	}
+	if props, ok := schema["properties"].(map[string]any); ok {
+		for name := range internal {
+			delete(props, name)
+		}
+		if len(props) == 0 {
+			delete(schema, "properties")
+		}
+	}
+	if required, ok := schema["required"].([]any); ok {
+		filtered := required[:0]
+		for _, item := range required {
+			name, _ := item.(string)
+			if _, hidden := internal[name]; hidden {
+				continue
+			}
+			filtered = append(filtered, item)
+		}
+		if len(filtered) == 0 {
+			delete(schema, "required")
+		} else {
+			schema["required"] = filtered
+		}
+	}
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return declarative.SynthesizeInputSchema(publicParams)
+	}
+	return data
+}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -237,6 +239,7 @@ func newMCPHandler(cfg *config.Config, connMaps bootstrap.ConnectionMaps, result
 	if !ok {
 		return nil, fmt.Errorf("MCP token resolution requires *invocation.Broker as invoker")
 	}
+	projectionServer := &Server{pluginDefs: cfg.Plugins}
 
 	names := make([]string, 0, len(cfg.Plugins))
 	for name := range cfg.Plugins {
@@ -269,15 +272,19 @@ func newMCPHandler(cfg *config.Config, connMaps bootstrap.ConnectionMaps, result
 
 	return mcpserver.NewStreamableHTTPServer(
 		gestaltmcp.NewServer(gestaltmcp.Config{
-			Invoker:          invoker,
-			TokenResolver:    broker,
-			AuditSink:        result.AuditSink,
-			Providers:        result.Providers,
-			Authorizer:       result.Authorizer,
-			AllowedProviders: allowedProviders,
-			ToolPrefixes:     toolPrefixes,
-			IncludeREST:      includeREST,
-			MCPConnection:    mcpConnection,
+			Invoker:           invoker,
+			TokenResolver:     broker,
+			AuditSink:         result.AuditSink,
+			Providers:         result.Providers,
+			Authorizer:        result.Authorizer,
+			AllowedProviders:  allowedProviders,
+			ToolPrefixes:      toolPrefixes,
+			IncludeREST:       includeREST,
+			MCPConnection:     mcpConnection,
+			CatalogProjection: projectionServer.publicMCPCatalog,
+			InvocationValidator: func(ctx context.Context, provName string, prov core.Provider, op catalog.CatalogOperation, params map[string]any, explicitConnection string) error {
+				return projectionServer.validatePublicOperationInvocation(provName, prov, op, params, explicitConnection)
+			},
 		}),
 		mcpserver.WithStateLess(true),
 	), nil

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -7515,6 +7515,93 @@ func TestListIntegrations_HumanAuthorizationFiltersByMountedUIAccessAndVisibleOp
 	}
 }
 
+func TestListIntegrations_HidesProviderWithOnlyInternalHTTPOperations(t *testing.T) {
+	t.Parallel()
+
+	manifest := &providermanifestv1.Manifest{
+		Source:      "internal-only",
+		DisplayName: "Internal Only",
+		Spec: &providermanifestv1.Spec{
+			DefaultConnection: "bot",
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"bot": {
+					Mode:     providermanifestv1.ConnectionModePlatform,
+					Exposure: providermanifestv1.ConnectionExposureInternal,
+					Auth:     &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
+				},
+			},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					Connection: "bot",
+					Operations: []providermanifestv1.ProviderOperation{
+						{
+							Name:       "bot.only",
+							Method:     http.MethodGet,
+							Path:       "/bot.only",
+							Connection: "bot",
+						},
+					},
+				},
+			},
+		},
+	}
+	prov := &stubNonOAuthProvider{
+		name: "internal-only",
+		catalog: serverTestCatalog("internal-only", []catalog.CatalogOperation{{
+			ID:        "bot.only",
+			Method:    http.MethodGet,
+			Path:      "/bot.only",
+			Transport: catalog.TransportREST,
+		}}),
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"internal-only": {ResolvedManifest: manifest},
+		}
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/api/v1/integrations")
+	if err != nil {
+		t.Fatalf("list integrations: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("integrations status = %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
+	}
+	var integrations []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decode integrations: %v", err)
+	}
+	for _, integration := range integrations {
+		if integration.Name == "internal-only" {
+			t.Fatalf("internal-only integration leaked in integrations response: %+v", integration)
+		}
+	}
+
+	opsResp, err := http.Get(ts.URL + "/api/v1/integrations/internal-only/operations")
+	if err != nil {
+		t.Fatalf("list operations: %v", err)
+	}
+	defer func() { _ = opsResp.Body.Close() }()
+	if opsResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(opsResp.Body)
+		t.Fatalf("operations status = %d, want %d: %s", opsResp.StatusCode, http.StatusOK, body)
+	}
+	var ops []catalog.CatalogOperation
+	if err := json.NewDecoder(opsResp.Body).Decode(&ops); err != nil {
+		t.Fatalf("decode operations: %v", err)
+	}
+	if len(ops) != 0 {
+		t.Fatalf("operations = %+v, want none", ops)
+	}
+}
+
 func TestSubjectAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t *testing.T) {
 	t.Parallel()
 
@@ -11168,13 +11255,14 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
 				"default": {Mode: providermanifestv1.ConnectionModeUser},
 				"bot": {
-					Mode: providermanifestv1.ConnectionModePlatform,
-					Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
+					Mode:     providermanifestv1.ConnectionModePlatform,
+					Exposure: providermanifestv1.ConnectionExposureInternal,
+					Auth:     &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
 				},
 			},
 			Surfaces: &providermanifestv1.ProviderSurfaces{
 				REST: &providermanifestv1.RESTSurface{
-					Connection: "bot",
+					Connection: "default",
 					BaseURL:    upstream.URL,
 					Operations: []providermanifestv1.ProviderOperation{
 						{
@@ -11184,7 +11272,7 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 							Path:        "/api/chat.postMessage",
 							ConnectionSelector: &providermanifestv1.OperationConnectionSelector{
 								Parameter: "actor",
-								Default:   "bot",
+								Default:   "user",
 								Values: map[string]string{
 									"bot":  "bot",
 									"user": "default",
@@ -11205,6 +11293,18 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 								{Name: "channel", Type: "string", In: "body", Required: true},
 								{Name: "text", Type: "string", In: "body", Required: true},
 								{Name: "post_at", Type: "int", In: "body", Required: true},
+							},
+						},
+						{
+							Name:        "assistant.threads.setStatus",
+							Description: "Set assistant status",
+							Method:      http.MethodPost,
+							Path:        "/api/assistant.threads.setStatus",
+							Connection:  "bot",
+							Parameters: []providermanifestv1.ProviderParameter{
+								{Name: "channel_id", Type: "string", In: "body", Required: true},
+								{Name: "thread_ts", Type: "string", In: "body", Required: true},
+								{Name: "status", Type: "string", In: "body", Required: true},
 							},
 						},
 						{
@@ -11289,8 +11389,12 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 		svc.ExternalCredentials,
 		invocation.WithConnectionRuntime(connectionRuntime.Resolve),
 	)
-	if _, token, err := broker.ResolveToken(context.Background(), &principal.Principal{SubjectID: subjectID}, "slack", "bot", ""); err != nil || token != "bot-slack-token" {
-		t.Fatalf("ResolveToken bot = token %q, err %v; want platform token", token, err)
+	if _, token, err := broker.ResolveToken(context.Background(), &principal.Principal{SubjectID: subjectID}, "slack", "bot", ""); !errors.Is(err, invocation.ErrAuthorizationDenied) || token != "" {
+		t.Fatalf("ResolveToken public bot = token %q, err %v; want authorization denied", token, err)
+	}
+	trustedCtx := invocation.WithHTTPBinding(invocation.WithInvocationSurface(context.Background(), invocation.InvocationSurfaceHTTPBinding), "event")
+	if _, token, err := broker.ResolveToken(trustedCtx, &principal.Principal{SubjectID: subjectID}, "slack", "bot", ""); err != nil || token != "bot-slack-token" {
+		t.Fatalf("ResolveToken trusted bot = token %q, err %v; want platform token", token, err)
 	}
 	metrics := metrictest.NewManualMeterProvider(t)
 
@@ -11337,7 +11441,7 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 	if err := json.NewDecoder(integrationsResp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decode integrations: %v", err)
 	}
-	var botConnection *struct {
+	var defaultConnection *struct {
 		Name        string   `json:"name"`
 		Mode        string   `json:"mode"`
 		Connected   bool     `json:"connected"`
@@ -11351,19 +11455,22 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 		}
 		slackConnected = integrations[i].Connected
 		for j := range integrations[i].Connections {
+			if integrations[i].Connections[j].Name == "default" {
+				defaultConnection = &integrations[i].Connections[j]
+			}
 			if integrations[i].Connections[j].Name == "bot" {
-				botConnection = &integrations[i].Connections[j]
+				t.Fatalf("internal bot connection leaked in integrations response: %+v", integrations[i].Connections[j])
 			}
 		}
 	}
-	if botConnection == nil {
-		t.Fatal("bot connection missing from integrations response")
+	if defaultConnection == nil {
+		t.Fatal("default connection missing from integrations response")
 	}
 	if !slackConnected {
-		t.Fatal("slack integration connected = false, want true when a platform connection is configured")
+		t.Fatal("slack integration connected = false, want true when the user connection is connected")
 	}
-	if botConnection.Mode != "platform" || !botConnection.Connected || botConnection.Connectable || len(botConnection.AuthTypes) != 0 {
-		t.Fatalf("bot connection metadata = %+v, want connected platform non-connectable with no auth types", *botConnection)
+	if defaultConnection.Mode != "user" || !defaultConnection.Connected || !defaultConnection.Connectable {
+		t.Fatalf("default connection metadata = %+v, want connected user connection", *defaultConnection)
 	}
 	for _, tc := range []struct {
 		name string
@@ -11395,6 +11502,69 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 		}
 	}
 
+	opsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/slack/operations", nil)
+	opsReq.Header.Set("Authorization", "Bearer api-token")
+	opsResp, err := http.DefaultClient.Do(opsReq)
+	if err != nil {
+		t.Fatalf("operations request: %v", err)
+	}
+	if opsResp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(opsResp.Body)
+		_ = opsResp.Body.Close()
+		t.Fatalf("operations status = %d: %s", opsResp.StatusCode, payload)
+	}
+	var ops []catalog.CatalogOperation
+	if err := json.NewDecoder(opsResp.Body).Decode(&ops); err != nil {
+		_ = opsResp.Body.Close()
+		t.Fatalf("decode operations: %v", err)
+	}
+	_ = opsResp.Body.Close()
+	seenOps := map[string]catalog.CatalogOperation{}
+	for _, op := range ops {
+		seenOps[op.ID] = op
+	}
+	if _, ok := seenOps["assistant.threads.setStatus"]; ok {
+		t.Fatal("internal bot-only operation leaked in public operations response")
+	}
+	postMessage, ok := seenOps["chat.postMessage"]
+	if !ok {
+		t.Fatal("chat.postMessage missing from public operations response")
+	}
+	for _, param := range postMessage.Parameters {
+		if param.Name == "actor" {
+			t.Fatal("internal actor parameter leaked in public operations response")
+		}
+	}
+	if strings.Contains(string(postMessage.InputSchema), "actor") {
+		t.Fatalf("public chat.postMessage input schema contains internal actor parameter: %s", postMessage.InputSchema)
+	}
+	viewsOpen, ok := seenOps["views.open"]
+	if !ok {
+		t.Fatal("views.open missing from public operations response")
+	}
+	var viewsSchema map[string]any
+	if err := json.Unmarshal(viewsOpen.InputSchema, &viewsSchema); err != nil {
+		t.Fatalf("unmarshal views.open schema: %v", err)
+	}
+	viewsProps, _ := viewsSchema["properties"].(map[string]any)
+	audienceSchema, _ := viewsProps["audience"].(map[string]any)
+	audienceEnum, _ := audienceSchema["enum"].([]any)
+	if len(audienceEnum) != 1 || audienceEnum[0] != "user" {
+		t.Fatalf("views.open audience enum = %#v, want [user]", audienceEnum)
+	}
+	if strings.Contains(string(viewsOpen.InputSchema), "bot") {
+		t.Fatalf("public views.open input schema contains internal selector value: %s", viewsOpen.InputSchema)
+	}
+	cachedViewsOpen, ok := invocation.CatalogOperation(prov.Catalog(), "views.open")
+	if !ok {
+		t.Fatal("views.open missing from provider catalog")
+	}
+	for _, param := range cachedViewsOpen.Parameters {
+		if param.Name == "audience" && param.Default != nil {
+			t.Fatalf("cached views.open audience default mutated = %#v, want nil", param.Default)
+		}
+	}
+
 	doInvoke := func(operation, body string) int {
 		t.Helper()
 		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/slack/"+operation, strings.NewReader(body))
@@ -11415,20 +11585,26 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 		return resp.StatusCode
 	}
 
-	if status := doInvoke("chat.postMessage", `{"channel":"C1","text":"as user","actor":"user"}`); status != http.StatusOK {
-		t.Fatalf("user actor status = %d, want %d", status, http.StatusOK)
+	if status := doInvoke("chat.postMessage", `{"channel":"C1","text":"as user"}`); status != http.StatusOK {
+		t.Fatalf("default user status = %d, want %d", status, http.StatusOK)
 	}
-	if status := doInvoke("chat.postMessage", `{"channel":"C1","text":"as bot"}`); status != http.StatusOK {
-		t.Fatalf("default actor status = %d, want %d", status, http.StatusOK)
+	if status := doInvoke("chat.postMessage", `{"channel":"C1","text":"bad actor","actor":"user"}`); status != http.StatusBadRequest {
+		t.Fatalf("hidden actor status = %d, want %d", status, http.StatusBadRequest)
 	}
 	if status := doInvoke("chat.scheduleMessage?_connection=default", `{"channel":"C1","text":"scheduled","post_at":4102444800}`); status != http.StatusOK {
 		t.Fatalf("surface fallback override status = %d, want %d", status, http.StatusOK)
 	}
+	if status := doInvoke("chat.scheduleMessage?_connection=bot", `{"channel":"C1","text":"scheduled","post_at":4102444800}`); status != http.StatusForbidden {
+		t.Fatalf("internal connection override status = %d, want %d", status, http.StatusForbidden)
+	}
+	if status := doInvoke("assistant.threads.setStatus", `{"channel_id":"C1","thread_ts":"1.0","status":"thinking"}`); status != http.StatusForbidden {
+		t.Fatalf("internal operation status = %d, want %d", status, http.StatusForbidden)
+	}
 	if status := doInvoke("views.open", `{"trigger_id":"T1","audience":"user"}`); status != http.StatusOK {
 		t.Fatalf("non-internal selector status = %d, want %d", status, http.StatusOK)
 	}
-	if status := doInvoke("chat.postMessage", `{"channel":"C1","text":"bad actor","actor":"workspace"}`); status != http.StatusBadRequest {
-		t.Fatalf("invalid actor status = %d, want %d", status, http.StatusBadRequest)
+	if status := doInvoke("views.open", `{"trigger_id":"T1","audience":"bot"}`); status != http.StatusForbidden {
+		t.Fatalf("internal selector status = %d, want %d", status, http.StatusForbidden)
 	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
@@ -11440,15 +11616,12 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 	}
 	userAttrs := maps.Clone(httpOperationAttrs)
 	userAttrs["gestaltd.connection.mode"] = "user"
-	platformAttrs := maps.Clone(httpOperationAttrs)
-	platformAttrs["gestaltd.connection.mode"] = "platform"
 	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", userAttrs)
-	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", platformAttrs)
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(calls) != 4 {
-		t.Fatalf("upstream calls = %d, want 4", len(calls))
+	if len(calls) != 3 {
+		t.Fatalf("upstream calls = %d, want 3", len(calls))
 	}
 	if calls[0].path != "/api/chat.postMessage" {
 		t.Fatalf("first call path = %q, want chat.postMessage", calls[0].path)
@@ -11459,29 +11632,23 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 	if _, ok := calls[0].body["actor"]; ok {
 		t.Fatalf("first upstream body included internal actor param: %+v", calls[0].body)
 	}
-	if calls[1].auth != "Bearer bot-slack-token" {
-		t.Fatalf("second call auth = %q, want bot token", calls[1].auth)
+	if calls[1].path != "/api/chat.scheduleMessage" {
+		t.Fatalf("second call path = %q, want chat.scheduleMessage", calls[1].path)
 	}
-	if _, ok := calls[1].body["actor"]; ok {
-		t.Fatalf("second upstream body included internal actor param: %+v", calls[1].body)
+	if calls[1].auth != "Bearer user-slack-token" {
+		t.Fatalf("second call auth = %q, want user token", calls[1].auth)
 	}
-	if calls[2].path != "/api/chat.scheduleMessage" {
-		t.Fatalf("third call path = %q, want chat.scheduleMessage", calls[2].path)
+	if calls[1].body["text"] != "scheduled" {
+		t.Fatalf("second upstream body text = %#v, want scheduled", calls[1].body["text"])
+	}
+	if calls[2].path != "/api/views.open" {
+		t.Fatalf("third call path = %q, want views.open", calls[2].path)
 	}
 	if calls[2].auth != "Bearer user-slack-token" {
 		t.Fatalf("third call auth = %q, want user token", calls[2].auth)
 	}
-	if calls[2].body["text"] != "scheduled" {
-		t.Fatalf("third upstream body text = %#v, want scheduled", calls[2].body["text"])
-	}
-	if calls[3].path != "/api/views.open" {
-		t.Fatalf("fourth call path = %q, want views.open", calls[3].path)
-	}
-	if calls[3].auth != "Bearer user-slack-token" {
-		t.Fatalf("fourth call auth = %q, want user token", calls[3].auth)
-	}
-	if calls[3].body["audience"] != "user" {
-		t.Fatalf("fourth upstream body audience = %#v, want user", calls[3].body["audience"])
+	if calls[2].body["audience"] != "user" {
+		t.Fatalf("third upstream body audience = %#v, want user", calls[2].body["audience"])
 	}
 }
 

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -380,6 +380,13 @@
             "platform"
           ]
         },
+        "exposure": {
+          "type": "string",
+          "enum": [
+            "user",
+            "internal"
+          ]
+        },
         "auth": {
           "$ref": "#/$defs/providerAuth"
         },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -373,6 +373,7 @@ type ManifestOperationOverride struct {
 type ManifestConnectionDef struct {
 	DisplayName string                             `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	Mode        ConnectionMode                     `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Exposure    ConnectionExposure                 `json:"exposure,omitempty" yaml:"exposure,omitempty"`
 	Auth        *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
 	Params      map[string]ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
 	Discovery   *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
@@ -432,6 +433,13 @@ const (
 	ConnectionModeNone     ConnectionMode = "none"
 	ConnectionModeUser     ConnectionMode = "user"
 	ConnectionModePlatform ConnectionMode = "platform"
+)
+
+type ConnectionExposure string
+
+const (
+	ConnectionExposureUser     ConnectionExposure = "user"
+	ConnectionExposureInternal ConnectionExposure = "internal"
 )
 
 type PaginationStyle string

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -568,6 +568,19 @@ func (b *Broker) resolveConnectionMode(ctx context.Context, prov core.Provider, 
 	return effectiveConnectionMode(ctx, prov)
 }
 
+func (b *Broker) resolveConnectionExposure(providerName, connection string) core.ConnectionExposure {
+	if b != nil && b.connectionRuntime != nil {
+		if info, ok := b.connectionRuntime(providerName, connection); ok && info.Exposure != "" {
+			return core.NormalizeConnectionExposure(info.Exposure)
+		}
+	}
+	return core.ConnectionExposureUser
+}
+
+func allowsInternalConnection(ctx context.Context) bool {
+	return InvocationSurfaceFromContext(ctx) == InvocationSurfaceHTTPBinding && HTTPBindingFromContext(ctx) != ""
+}
+
 func (b *Broker) ExpandCatalogTargets(ctx context.Context, p *principal.Principal, providerName string, targets []CatalogResolutionTarget) ([]CatalogResolutionTarget, error) {
 	if len(targets) == 0 {
 		targets = []CatalogResolutionTarget{{}}
@@ -667,6 +680,9 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 	}
 
 	mode := b.resolveConnectionMode(ctx, prov, providerName, connection)
+	if b.resolveConnectionExposure(providerName, connection) == core.ConnectionExposureInternal && !allowsInternalConnection(ctx) {
+		return ctx, "", fmt.Errorf("%w: integration %q connection %q is internal", ErrAuthorizationDenied, providerName, strings.TrimSpace(connection))
+	}
 	switch mode {
 	case core.ConnectionModeNone:
 		SetCredentialAudit(ctx, core.ConnectionModeNone, "", "", "")

--- a/gestaltd/services/invocation/connection_runtime.go
+++ b/gestaltd/services/invocation/connection_runtime.go
@@ -11,8 +11,9 @@ const runtimePluginConnectionName = "_plugin"
 // ConnectionRuntimeInfo describes deployment-owned connection material that is
 // resolved after an operation selects its concrete connection.
 type ConnectionRuntimeInfo struct {
-	Mode  core.ConnectionMode
-	Token string
+	Mode     core.ConnectionMode
+	Exposure core.ConnectionExposure
+	Token    string
 }
 
 // ConnectionRuntimeResolver resolves runtime metadata for a provider

--- a/gestaltd/services/invocation/context.go
+++ b/gestaltd/services/invocation/context.go
@@ -63,7 +63,11 @@ type InvocationSurface string
 
 type AccessContext = authorization.AccessContext
 
-const InvocationSurfaceHTTP InvocationSurface = "http"
+const (
+	InvocationSurfaceHTTP        InvocationSurface = "http"
+	InvocationSurfaceHTTPBinding InvocationSurface = "http_binding"
+	InvocationSurfaceMCP         InvocationSurface = "mcp"
+)
 
 func WithRequestMeta(ctx context.Context, meta RequestMeta) context.Context {
 	return context.WithValue(ctx, requestMetaCtxKey{}, meta)


### PR DESCRIPTION
## Summary
- Adds a resolved connection exposure contract for provider manifests and deploy config: `exposure: user | internal`.
- Defaults omitted exposure to `user`, allows deploy config to narrow `user -> internal`, and rejects deploy attempts to widen provider-declared `internal -> user`.
- Projects public HTTP and MCP catalogs so internal fixed connections, selector values, and hidden selector params do not appear in public schemas.
- Enforces the same boundary at invocation time: public REST, MCP, service-account, and API-token callers cannot use internal connections; trusted HTTP bindings can.
- Counts user-exposed platform credentials as connected in user-facing integration readiness while hiding internal platform connections from `/integrations`.

## Interfaces and examples

Go manifest/config shape:

```go
type ConnectionExposure string

const (
    ConnectionExposureUser     ConnectionExposure = "user"
    ConnectionExposureInternal ConnectionExposure = "internal"
)

type ManifestConnectionDef struct {
    Mode     ConnectionMode     `json:"mode,omitempty" yaml:"mode,omitempty"`
    Exposure ConnectionExposure `json:"exposure,omitempty" yaml:"exposure,omitempty"`
}
```

YAML example:

```yaml
connections:
  default:
    mode: user
  bot:
    mode: platform
    exposure: internal
    auth:
      type: bearer
```

Public callers can use `default`. Runtime HTTP bindings can use `bot`; public callers posting `_connection=bot` or selector values that resolve to `bot` receive authorization failure.

## Test plan
- [x] `go test ./internal/bootstrap ./internal/config ./internal/server ./internal/mcp ./services/invocation ./internal/providerpkg`