### PR TITLE
Add authorization managed subject API

### DIFF
--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -1,6 +1,6 @@
 # Data Model
 
-Gestalt stores most persistent state through configured providers. Gestaltd core provisions only the object stores it directly owns through the configured [IndexedDB provider](/providers/indexeddb): users and API tokens. Provider-owned state, such as upstream credentials, workflow state, and agent sessions/turns, is provisioned by those providers instead of by gestaltd core.
+Gestalt stores most persistent state through configured providers. Gestaltd core provisions only the object stores it directly owns through the configured [IndexedDB provider](/providers/indexeddb): users, API tokens, and managed subject metadata. Provider-owned state, such as upstream credentials, workflow state, and agent sessions/turns, is provisioned by those providers instead of by gestaltd core.
 
 MCP OAuth client registrations (`oauth_registrations`) are stored separately in a raw SQL table managed outside the IndexedDB provider.
 
@@ -10,7 +10,7 @@ For encryption mechanics, see [Security Internals](/architecture/security-intern
 
 | Owner | Persistent state |
 | --- | --- |
-| `gestaltd` core | `users`, `api_tokens` |
+| `gestaltd` core | `users`, `managed_subjects`, `api_tokens` |
 | External credentials provider | `external_credentials` |
 | Agent provider | Provider-defined agent session, turn, interaction, event, and idempotency state |
 | Workflow provider | Provider-defined schedule, event trigger, run, execution ref, and idempotency state |
@@ -31,6 +31,24 @@ Created automatically on first login.
 | `updated_at` | time | |
 
 Emails and display names are plaintext. If you need encrypted PII at rest, handle it at the storage layer.
+
+### `managed_subjects`
+
+Metadata for service-account identities managed through `/api/v1/authorization/subjects`. The canonical subject ID is always `service_account:<id>`. Authorization relationships for who can manage the subject live in the configured authorization provider as `managed_subject` resource relationships; plugin runtime grants live as provider-backed dynamic plugin relationships.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string, PK | Same value as `subject_id`; retained for IndexedDB primary-key compatibility. |
+| `subject_id` | string, unique | Canonical service-account subject ID such as `service_account:release-bot`. |
+| `kind` | string | Currently `service_account`. |
+| `display_name` | string | Plaintext. |
+| `description` | string | Plaintext. |
+| `credential_subject_id` | string | Subject whose external credentials and subject-owned API tokens are used; currently matches `subject_id`. |
+| `created_by_subject_id` | string | Canonical user subject that created the managed subject. |
+| `deleted` | bool | Deleted subjects are hidden and their IDs are not reused. |
+| `created_at` | time | |
+| `updated_at` | time | |
+| `deleted_at` | time | Null until deleted. |
 
 ### `external_credentials`
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -121,6 +121,30 @@ still honor each event's `visibility`.
 | `DELETE` | `/api/v1/tokens/{id}` | Revoke an API token. |
 | `DELETE` | `/api/v1/tokens` | Revoke all API tokens for the current user. |
 
+### Managed Subjects
+
+Managed subjects are service-account identities for release bots, service accounts, and shared automation. Their canonical subject ID is always `service_account:<id>`, and their upstream credentials and subject-owned API tokens use that same `credentialSubjectId`. These management routes require a browser session or an unscoped user-owned API token; scoped API tokens and subject-owned API tokens cannot manage managed subjects.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/authorization/subjects` | List managed subjects the current user can view. |
+| `POST` | `/api/v1/authorization/subjects` | Create a managed subject. The creator becomes an `admin` of that managed subject. |
+| `GET` | `/api/v1/authorization/subjects/{subjectID}` | Inspect one managed subject. |
+| `PATCH` | `/api/v1/authorization/subjects/{subjectID}` | Update display metadata. Requires managed subject `admin`. |
+| `DELETE` | `/api/v1/authorization/subjects/{subjectID}` | Delete one managed subject, revoke its API tokens, remove its external credentials, and delete its authorization relationships. Requires managed subject `admin`. |
+| `GET` | `/api/v1/authorization/subjects/{subjectID}/members` | List users or subjects that can manage the managed subject. |
+| `PUT` | `/api/v1/authorization/subjects/{subjectID}/members` | Upsert a managed subject member by canonical `subjectId` or user `email`; role must be `viewer`, `editor`, or `admin`. Requires managed subject `admin`. |
+| `DELETE` | `/api/v1/authorization/subjects/{subjectID}/members/{memberSubjectID}` | Remove a managed subject member. Requires managed subject `admin`. |
+| `GET` | `/api/v1/authorization/subjects/{subjectID}/grants` | List plugin authorization grants for the managed subject. |
+| `PUT` | `/api/v1/authorization/subjects/{subjectID}/grants/{plugin}` | Grant a plugin role to the managed subject. Requires managed subject `admin` and the caller must already hold the requested plugin role, or plugin `admin`. |
+| `DELETE` | `/api/v1/authorization/subjects/{subjectID}/grants/{plugin}` | Remove a plugin authorization grant from the managed subject. Requires managed subject `admin`. |
+| `GET` | `/api/v1/authorization/subjects/{subjectID}/tokens` | List API tokens owned by the managed subject. |
+| `POST` | `/api/v1/authorization/subjects/{subjectID}/tokens` | Create a subject-owned API token. Plaintext is returned once. Requires managed subject `admin`. |
+| `DELETE` | `/api/v1/authorization/subjects/{subjectID}/tokens/{id}` | Revoke one subject-owned API token. Requires managed subject `admin`. |
+| `DELETE` | `/api/v1/authorization/subjects/{subjectID}/tokens` | Revoke all API tokens owned by the managed subject. Requires managed subject `admin`. |
+
+The authorization provider stores managed-subject management as relationships on the `managed_subject` resource type. Plugin runtime access is separate: a managed subject can only invoke a plugin after it has an explicit plugin grant, which is stored as the same provider-backed dynamic plugin relationship used by the admin authorization API. Policy `default: allow` applies to user callers, not to managed subjects.
+
 ### Operator Surfaces
 
 | Method | Path | Purpose |
@@ -396,4 +420,20 @@ curl -X POST http://localhost:8080/api/v1/agent/turns/turn-123/cancel \
 curl -X PUT http://localhost:9090/admin/api/v1/authorization/plugins/sample_plugin/members \
   -H 'Content-Type: application/json' \
   -d '{"email":"user@example.com","role":"viewer"}'
+
+# Create a managed subject and grant it viewer access to a plugin
+curl -X POST http://localhost:8080/api/v1/authorization/subjects \
+  -H 'Authorization: Bearer gst_api_...' \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"release-bot","displayName":"Release Bot"}'
+
+curl -X PUT http://localhost:8080/api/v1/authorization/subjects/service_account:release-bot/grants/github \
+  -H 'Authorization: Bearer gst_api_...' \
+  -H 'Content-Type: application/json' \
+  -d '{"role":"viewer"}'
+
+curl -X POST http://localhost:8080/api/v1/authorization/subjects/service_account:release-bot/tokens \
+  -H 'Authorization: Bearer gst_api_...' \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"release-bot","permissions":[{"plugin":"github","operations":["issues.list"]}]}'
 ```

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -13,6 +13,18 @@ type User struct {
 	UpdatedAt   time.Time
 }
 
+type ManagedSubject struct {
+	SubjectID           string
+	Kind                string
+	DisplayName         string
+	Description         string
+	CredentialSubjectID string
+	CreatedBySubjectID  string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	DeletedAt           *time.Time
+}
+
 type ExternalCredential struct {
 	ID                string
 	SubjectID         string

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -117,7 +117,7 @@ func (a *Authorizer) ResolveAccess(_ context.Context, p *principal.Principal, pr
 		access.Role = role
 		return access, true
 	}
-	if policy.DefaultAllow {
+	if policy.DefaultAllow && defaultAllowAppliesToPrincipal(p) {
 		access.Role = defaultSubjectRole
 		return access, true
 	}
@@ -212,7 +212,7 @@ func (a *Authorizer) ResolvePolicyAccess(_ context.Context, p *principal.Princip
 		access.Role = role
 		return access, true
 	}
-	if policy.DefaultAllow {
+	if policy.DefaultAllow && defaultAllowAppliesToPrincipal(p) {
 		access.Role = defaultSubjectRole
 		return access, true
 	}
@@ -236,7 +236,7 @@ func (a *Authorizer) ResolveAdminAccess(_ context.Context, p *principal.Principa
 		access.Role = role
 		return access, true
 	}
-	if policy.DefaultAllow {
+	if policy.DefaultAllow && defaultAllowAppliesToPrincipal(p) {
 		access.Role = defaultSubjectRole
 		return access, true
 	}
@@ -274,6 +274,10 @@ func (p *SubjectPolicy) roleForPrincipal(pr *principal.Principal) (string, bool)
 		return "", false
 	}
 	return p.staticRoleForIdentity(principal.Canonicalized(pr).SubjectID)
+}
+
+func defaultAllowAppliesToPrincipal(p *principal.Principal) bool {
+	return !principal.IsNonUserPrincipal(p)
 }
 
 func (p *SubjectPolicy) staticRoleForIdentity(subjectID string) (string, bool) {

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -238,7 +238,7 @@ func (a *ProviderBackedAuthorizer) ResolveAccess(ctx context.Context, p *princip
 	role, ok, err := a.resolveProviderRole(ctx, provider, p)
 	if err != nil {
 		a.logProviderEvalError("plugin", provider, err)
-		if policy.DefaultAllow {
+		if policy.DefaultAllow && defaultAllowAppliesToPrincipal(p) {
 			access.Role = defaultSubjectRole
 			return access, true
 		}
@@ -248,7 +248,7 @@ func (a *ProviderBackedAuthorizer) ResolveAccess(ctx context.Context, p *princip
 		access.Role = role
 		return access, true
 	}
-	if policy.DefaultAllow {
+	if policy.DefaultAllow && defaultAllowAppliesToPrincipal(p) {
 		access.Role = defaultSubjectRole
 		return access, true
 	}
@@ -272,7 +272,7 @@ func (a *ProviderBackedAuthorizer) ResolvePolicyAccess(ctx context.Context, p *p
 	role, ok, err := a.resolvePolicyStaticRole(ctx, policyName, p)
 	if err != nil {
 		a.logProviderEvalError("policy", policyName, err)
-		if policy.DefaultAllow {
+		if policy.DefaultAllow && defaultAllowAppliesToPrincipal(p) {
 			access.Role = defaultSubjectRole
 			return access, true
 		}
@@ -282,7 +282,7 @@ func (a *ProviderBackedAuthorizer) ResolvePolicyAccess(ctx context.Context, p *p
 		access.Role = role
 		return access, true
 	}
-	if policy.DefaultAllow {
+	if policy.DefaultAllow && defaultAllowAppliesToPrincipal(p) {
 		access.Role = defaultSubjectRole
 		return access, true
 	}
@@ -306,7 +306,7 @@ func (a *ProviderBackedAuthorizer) ResolveAdminAccess(ctx context.Context, p *pr
 	role, ok, err := a.resolveAdminStaticRole(ctx, policyName, p)
 	if err != nil {
 		a.logProviderEvalError("admin_policy", policyName, err)
-		if policy.DefaultAllow {
+		if policy.DefaultAllow && defaultAllowAppliesToPrincipal(p) {
 			access.Role = defaultSubjectRole
 			return access, true
 		}
@@ -319,7 +319,7 @@ func (a *ProviderBackedAuthorizer) ResolveAdminAccess(ctx context.Context, p *pr
 	role, ok, err = a.resolveAdminDynamicRole(ctx, p)
 	if err != nil {
 		a.logProviderEvalError("admin_dynamic", policyName, err)
-		if policy.DefaultAllow {
+		if policy.DefaultAllow && defaultAllowAppliesToPrincipal(p) {
 			access.Role = defaultSubjectRole
 			return access, true
 		}
@@ -329,7 +329,7 @@ func (a *ProviderBackedAuthorizer) ResolveAdminAccess(ctx context.Context, p *pr
 		access.Role = role
 		return access, true
 	}
-	if policy.DefaultAllow {
+	if policy.DefaultAllow && defaultAllowAppliesToPrincipal(p) {
 		access.Role = defaultSubjectRole
 		return access, true
 	}
@@ -588,6 +588,15 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 				continue
 			}
 			addDesiredRelationship(desired, rel)
+		case resourceTypeManagedSubject:
+			relation := strings.TrimSpace(rel.GetRelation())
+			if !managedSubjectManagementRelation(relation) || rel.GetSubject() == nil || strings.TrimSpace(rel.GetSubject().GetId()) == "" {
+				continue
+			}
+			if strings.TrimSpace(rel.GetSubject().GetType()) != subjectTypeSubject {
+				continue
+			}
+			addDesiredRelationship(desired, rel)
 		}
 	}
 
@@ -699,6 +708,15 @@ func ensureRoleSet(target map[string]map[string]struct{}, key string) map[string
 		target[key] = values
 	}
 	return values
+}
+
+func managedSubjectManagementRelation(relation string) bool {
+	switch strings.TrimSpace(relation) {
+	case relationManagedSubjectViewer, relationManagedSubjectEditor, relationManagedSubjectAdmin:
+		return true
+	default:
+		return false
+	}
 }
 
 func roleSortKey(role string) string {

--- a/gestaltd/internal/authorization/provider_schema.go
+++ b/gestaltd/internal/authorization/provider_schema.go
@@ -8,14 +8,23 @@ import (
 )
 
 const (
-	ProviderResourceTypePolicyStatic       = "policy_static"
-	ProviderResourceTypePluginStatic       = "plugin_static"
-	ProviderResourceTypePluginDynamic      = "plugin_dynamic"
-	ProviderResourceTypeAdminPolicyStatic  = "admin_policy_static"
-	ProviderResourceTypeAdminDynamic       = "admin_dynamic"
-	ProviderResourceTypeExternalIdentity   = "external_identity"
-	ProviderResourceIDAdminDynamicGlobal   = "global"
-	ProviderExternalIdentityRelationAssume = "assume"
+	ProviderResourceTypePolicyStatic        = "policy_static"
+	ProviderResourceTypePluginStatic        = "plugin_static"
+	ProviderResourceTypePluginDynamic       = "plugin_dynamic"
+	ProviderResourceTypeAdminPolicyStatic   = "admin_policy_static"
+	ProviderResourceTypeAdminDynamic        = "admin_dynamic"
+	ProviderResourceTypeExternalIdentity    = "external_identity"
+	ProviderResourceTypeManagedSubject      = "managed_subject"
+	ProviderResourceIDAdminDynamicGlobal    = "global"
+	ProviderExternalIdentityRelationAssume  = "assume"
+	ProviderManagedSubjectRelationViewer    = "viewer"
+	ProviderManagedSubjectRelationEditor    = "editor"
+	ProviderManagedSubjectRelationAdmin     = "admin"
+	ProviderManagedSubjectActionView        = "view"
+	ProviderManagedSubjectActionManage      = "manage"
+	ProviderManagedSubjectActionCreateToken = "create_token"
+	ProviderManagedSubjectActionGrant       = "grant"
+	ProviderManagedSubjectActionConnect     = "connect"
 
 	ProviderSubjectTypeSubject = "subject"
 	ProviderSubjectTypeUser    = "user"
@@ -28,8 +37,12 @@ const (
 	resourceTypeAdminPolicyStatic  = ProviderResourceTypeAdminPolicyStatic
 	resourceTypeAdminDynamic       = ProviderResourceTypeAdminDynamic
 	resourceTypeExternalIdentity   = ProviderResourceTypeExternalIdentity
+	resourceTypeManagedSubject     = ProviderResourceTypeManagedSubject
 	resourceIDAdminDynamicGlobal   = ProviderResourceIDAdminDynamicGlobal
 	relationExternalIdentityAssume = ProviderExternalIdentityRelationAssume
+	relationManagedSubjectViewer   = ProviderManagedSubjectRelationViewer
+	relationManagedSubjectEditor   = ProviderManagedSubjectRelationEditor
+	relationManagedSubjectAdmin    = ProviderManagedSubjectRelationAdmin
 
 	subjectTypeSubject = ProviderSubjectTypeSubject
 	subjectTypeUser    = ProviderSubjectTypeUser
@@ -45,7 +58,8 @@ func IsManagedProviderRelationship(rel *core.Relationship) bool {
 		ProviderResourceTypePluginDynamic,
 		ProviderResourceTypeAdminPolicyStatic,
 		ProviderResourceTypeAdminDynamic,
-		ProviderResourceTypeExternalIdentity:
+		ProviderResourceTypeExternalIdentity,
+		ProviderResourceTypeManagedSubject:
 		return true
 	default:
 		return false
@@ -118,6 +132,26 @@ func buildProviderAuthorizationModel(state providerBackedRoleState) *core.Author
 				Name:      relationExternalIdentityAssume,
 				Relations: []string{relationExternalIdentityAssume},
 			}},
+		},
+	)
+	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
+		&core.AuthorizationModelResourceType{
+			Name: resourceTypeManagedSubject,
+			Relations: []*core.AuthorizationModelRelation{
+				{Name: relationManagedSubjectViewer, SubjectTypes: []string{subjectTypeSubject}},
+				{Name: relationManagedSubjectEditor, SubjectTypes: []string{subjectTypeSubject}},
+				{Name: relationManagedSubjectAdmin, SubjectTypes: []string{subjectTypeSubject}},
+			},
+			Actions: []*core.AuthorizationModelAction{
+				{Name: relationManagedSubjectViewer, Relations: []string{relationManagedSubjectViewer, relationManagedSubjectEditor, relationManagedSubjectAdmin}},
+				{Name: relationManagedSubjectEditor, Relations: []string{relationManagedSubjectEditor, relationManagedSubjectAdmin}},
+				{Name: relationManagedSubjectAdmin, Relations: []string{relationManagedSubjectAdmin}},
+				{Name: ProviderManagedSubjectActionView, Relations: []string{relationManagedSubjectViewer, relationManagedSubjectEditor, relationManagedSubjectAdmin}},
+				{Name: ProviderManagedSubjectActionManage, Relations: []string{relationManagedSubjectAdmin}},
+				{Name: ProviderManagedSubjectActionCreateToken, Relations: []string{relationManagedSubjectAdmin}},
+				{Name: ProviderManagedSubjectActionGrant, Relations: []string{relationManagedSubjectAdmin}},
+				{Name: ProviderManagedSubjectActionConnect, Relations: []string{relationManagedSubjectEditor, relationManagedSubjectAdmin}},
+			},
 		},
 	)
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -2362,21 +2362,26 @@ func isIndexedDBProviderEntry(entry *config.ProviderEntry, providerName string) 
 		return false
 	}
 	providerPath := "/indexeddb/" + providerName
+	legacyProviderPath := "/indexeddb-" + providerName
 	if entry.ResolvedManifest != nil {
-		return strings.HasSuffix(strings.TrimSpace(filepath.ToSlash(entry.ResolvedManifest.Source)), providerPath)
+		source := strings.TrimSpace(filepath.ToSlash(entry.ResolvedManifest.Source))
+		return strings.HasSuffix(source, providerPath) || strings.HasSuffix(source, legacyProviderPath)
 	}
 	if metadataURL := strings.TrimSpace(entry.SourceMetadataURL()); metadataURL != "" {
 		parsed, err := url.Parse(metadataURL)
 		if err == nil {
 			path := filepath.ToSlash(parsed.Path)
-			return strings.Contains(path, providerPath+"/") && strings.HasSuffix(path, "/provider-release.yaml")
+			return (strings.Contains(path, providerPath+"/") || strings.Contains(path, legacyProviderPath+"/")) &&
+				strings.HasSuffix(path, "/provider-release.yaml")
 		}
 	}
 	if path := strings.TrimSpace(entry.SourcePath()); path != "" {
 		path = filepath.ToSlash(path)
 		return strings.HasSuffix(path, providerPath) ||
+			strings.HasSuffix(path, legacyProviderPath) ||
 			strings.HasSuffix(path, "/"+providerName) ||
 			strings.HasSuffix(path, providerPath+"/manifest.yaml") ||
+			strings.HasSuffix(path, legacyProviderPath+"/manifest.yaml") ||
 			strings.HasSuffix(path, "/"+providerName+"/manifest.yaml")
 	}
 	return false

--- a/gestaltd/internal/coredata/managed_subjects.go
+++ b/gestaltd/internal/coredata/managed_subjects.go
@@ -1,0 +1,182 @@
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+const ManagedSubjectKindServiceAccount = "service_account"
+
+type ManagedSubjectService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewManagedSubjectService(ds indexeddb.IndexedDB) *ManagedSubjectService {
+	return &ManagedSubjectService{store: ds.ObjectStore(StoreManagedSubjects)}
+}
+
+func (s *ManagedSubjectService) CreateManagedSubject(ctx context.Context, subject *core.ManagedSubject) (*core.ManagedSubject, error) {
+	if subject == nil {
+		return nil, fmt.Errorf("create managed subject: subject is required")
+	}
+	subjectID := strings.TrimSpace(subject.SubjectID)
+	if subjectID == "" {
+		return nil, fmt.Errorf("create managed subject: subject_id is required")
+	}
+	kind := strings.TrimSpace(subject.Kind)
+	if kind == "" {
+		kind, _, _ = core.ParseSubjectID(subjectID)
+	}
+	if kind != ManagedSubjectKindServiceAccount {
+		return nil, fmt.Errorf("create managed subject: unsupported kind %q", kind)
+	}
+	if parsedKind, _, ok := core.ParseSubjectID(subjectID); !ok || parsedKind != kind {
+		return nil, fmt.Errorf("create managed subject: subject_id must be a canonical %s subject ID", ManagedSubjectKindServiceAccount)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	rec := indexeddb.Record{
+		"id":                    subjectID,
+		"subject_id":            subjectID,
+		"kind":                  kind,
+		"display_name":          strings.TrimSpace(subject.DisplayName),
+		"description":           strings.TrimSpace(subject.Description),
+		"credential_subject_id": subjectID,
+		"created_by_subject_id": strings.TrimSpace(subject.CreatedBySubjectID),
+		"deleted":               false,
+		"created_at":            now,
+		"updated_at":            now,
+	}
+	if err := s.store.Add(ctx, rec); err != nil {
+		if errors.Is(err, indexeddb.ErrAlreadyExists) {
+			return nil, core.ErrAlreadyRegistered
+		}
+		return nil, fmt.Errorf("create managed subject: %w", err)
+	}
+	return recordToManagedSubject(rec), nil
+}
+
+func (s *ManagedSubjectService) GetManagedSubject(ctx context.Context, subjectID string) (*core.ManagedSubject, error) {
+	rec, err := s.store.Get(ctx, strings.TrimSpace(subjectID))
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get managed subject: %w", err)
+	}
+	subject := recordToManagedSubject(rec)
+	if subject.DeletedAt != nil {
+		return nil, core.ErrNotFound
+	}
+	return subject, nil
+}
+
+func (s *ManagedSubjectService) ListManagedSubjects(ctx context.Context, kind string) ([]*core.ManagedSubject, error) {
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		kind = ManagedSubjectKindServiceAccount
+	}
+	if kind != ManagedSubjectKindServiceAccount {
+		return nil, fmt.Errorf("list managed subjects: unsupported kind %q", kind)
+	}
+	recs, err := s.store.Index("by_kind_deleted").GetAll(ctx, nil, kind, false)
+	if err != nil {
+		return nil, fmt.Errorf("list managed subjects: %w", err)
+	}
+	out := make([]*core.ManagedSubject, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToManagedSubject(rec))
+	}
+	return out, nil
+}
+
+func (s *ManagedSubjectService) UpdateManagedSubject(ctx context.Context, subjectID string, update func(*core.ManagedSubject) error) (*core.ManagedSubject, error) {
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID == "" {
+		return nil, fmt.Errorf("update managed subject: subject_id is required")
+	}
+	if update == nil {
+		return nil, fmt.Errorf("update managed subject: update is required")
+	}
+	subject, err := s.GetManagedSubject(ctx, subjectID)
+	if err != nil {
+		return nil, err
+	}
+	if err := update(subject); err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	rec := managedSubjectToRecord(subject)
+	rec["updated_at"] = now
+	rec["deleted"] = subject.DeletedAt != nil
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("update managed subject: %w", err)
+	}
+	return recordToManagedSubject(rec), nil
+}
+
+func (s *ManagedSubjectService) DeleteManagedSubject(ctx context.Context, subjectID string) (*core.ManagedSubject, error) {
+	subjectID = strings.TrimSpace(subjectID)
+	rec, err := s.store.Get(ctx, subjectID)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("delete managed subject: %w", err)
+	}
+	subject := recordToManagedSubject(rec)
+	if subject.DeletedAt != nil {
+		return subject, nil
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	subject.DeletedAt = &now
+	subject.UpdatedAt = now
+	rec = managedSubjectToRecord(subject)
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("delete managed subject: %w", err)
+	}
+	return recordToManagedSubject(rec), nil
+}
+
+func (s *ManagedSubjectService) RemoveManagedSubjectForRollback(ctx context.Context, subjectID string) error {
+	if err := s.store.Delete(ctx, strings.TrimSpace(subjectID)); err != nil {
+		return fmt.Errorf("rollback managed subject: %w", err)
+	}
+	return nil
+}
+
+func recordToManagedSubject(rec indexeddb.Record) *core.ManagedSubject {
+	return &core.ManagedSubject{
+		SubjectID:           recString(rec, "subject_id"),
+		Kind:                recString(rec, "kind"),
+		DisplayName:         recString(rec, "display_name"),
+		Description:         recString(rec, "description"),
+		CredentialSubjectID: recString(rec, "credential_subject_id"),
+		CreatedBySubjectID:  recString(rec, "created_by_subject_id"),
+		CreatedAt:           recTime(rec, "created_at"),
+		UpdatedAt:           recTime(rec, "updated_at"),
+		DeletedAt:           recTimePtr(rec, "deleted_at"),
+	}
+}
+
+func managedSubjectToRecord(subject *core.ManagedSubject) indexeddb.Record {
+	return indexeddb.Record{
+		"id":                    strings.TrimSpace(subject.SubjectID),
+		"subject_id":            strings.TrimSpace(subject.SubjectID),
+		"kind":                  strings.TrimSpace(subject.Kind),
+		"display_name":          strings.TrimSpace(subject.DisplayName),
+		"description":           strings.TrimSpace(subject.Description),
+		"credential_subject_id": strings.TrimSpace(subject.CredentialSubjectID),
+		"created_by_subject_id": strings.TrimSpace(subject.CreatedBySubjectID),
+		"deleted":               subject.DeletedAt != nil,
+		"created_at":            subject.CreatedAt,
+		"updated_at":            subject.UpdatedAt,
+		"deleted_at":            subject.DeletedAt,
+	}
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -5,8 +5,9 @@ import (
 )
 
 const (
-	StoreUsers     = "users"
-	StoreAPITokens = "api_tokens"
+	StoreUsers           = "users"
+	StoreAPITokens       = "api_tokens"
+	StoreManagedSubjects = "managed_subjects"
 )
 
 var UsersSchema = indexeddb.ObjectStoreSchema{
@@ -42,5 +43,26 @@ var APITokensSchema = indexeddb.ObjectStoreSchema{
 		{Name: "expires_at", Type: indexeddb.TypeTime},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var ManagedSubjectsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_kind", KeyPath: []string{"kind"}},
+		{Name: "by_kind_deleted", KeyPath: []string{"kind", "deleted"}},
+		{Name: "by_created_by", KeyPath: []string{"created_by_subject_id"}},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "subject_id", Type: indexeddb.TypeString, NotNull: true, Unique: true},
+		{Name: "kind", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "display_name", Type: indexeddb.TypeString},
+		{Name: "description", Type: indexeddb.TypeString},
+		{Name: "credential_subject_id", Type: indexeddb.TypeString},
+		{Name: "created_by_subject_id", Type: indexeddb.TypeString},
+		{Name: "deleted", Type: indexeddb.TypeBool},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+		{Name: "deleted_at", Type: indexeddb.TypeTime},
 	},
 }

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -13,6 +13,7 @@ type Services struct {
 	Users               *UserService
 	ExternalCredentials core.ExternalCredentialProvider
 	APITokens           *APITokenService
+	ManagedSubjects     *ManagedSubjectService
 	RuntimeSessionLogs  runtimelogs.Store
 	DB                  indexeddb.IndexedDB
 }
@@ -31,15 +32,20 @@ func NewWithContext(ctx context.Context, ds indexeddb.IndexedDB) (*Services, err
 	if err := ds.CreateObjectStore(ctx, StoreAPITokens, APITokensSchema); err != nil {
 		return nil, fmt.Errorf("create api_tokens store: %w", err)
 	}
+	if err := ds.CreateObjectStore(ctx, StoreManagedSubjects, ManagedSubjectsSchema); err != nil {
+		return nil, fmt.Errorf("create managed_subjects store: %w", err)
+	}
 
 	runtimeSessionLogs := runtimelogs.NewMemoryStore()
 
 	users := NewUserService(ds)
 	apiTokens := NewAPITokenService(ds)
+	managedSubjects := NewManagedSubjectService(ds)
 	return &Services{
 		ExternalCredentials: nil,
 		Users:               users,
 		APITokens:           apiTokens,
+		ManagedSubjects:     managedSubjects,
 		RuntimeSessionLogs:  runtimeSessionLogs,
 		DB:                  ds,
 	}, nil

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -1406,7 +1406,7 @@ func setupIndexedDBProviderDir(t *testing.T, baseDir string) string {
 	artifactRel := filepath.Base(binDest)
 	writeManifestFile(t, providerDir, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb-inmem",
+		Source:      "github.com/test/providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "In-Memory IndexedDB",
 		Spec:        &providermanifestv1.Spec{},
@@ -1589,7 +1589,7 @@ func setupDefaultLocalProvidersDir(t *testing.T, baseDir string) string {
 	}
 	writeManifestFile(t, indexedDBDir, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb-relationaldb",
+		Source:      "github.com/test/providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Relational IndexedDB",
 		Spec:        &providermanifestv1.Spec{},

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -182,7 +182,7 @@ func writeDefaultProvidersDir(baseDir string) (string, error) {
 
 	if err := writeComponentProviderDir(filepath.Join(providersDir, "indexeddb", "relationaldb"), indexedDBBin, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb-relationaldb",
+		Source:      "github.com/test/providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Relational IndexedDB",
 		Spec:        &providermanifestv1.Spec{},

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -570,7 +570,7 @@ func TestPollSessionDropsCanceledQueuedCall(t *testing.T) {
 		t.Fatalf("invoke error = %v, want %v", err, context.Canceled)
 	}
 
-	pollCtx, pollCancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), time.Second)
 	defer pollCancel()
 	resp, ok, err := manager.PollSessionWithDispatcherSecretOnly(pollCtx, "session-1", dispatcherSecret)
 	if err != nil {

--- a/gestaltd/internal/server/handlers_authorization_subjects.go
+++ b/gestaltd/internal/server/handlers_authorization_subjects.go
@@ -1,0 +1,932 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+type createManagedSubjectRequest struct {
+	ID          string `json:"id"`
+	SubjectID   string `json:"subjectId"`
+	Kind        string `json:"kind"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+}
+
+type updateManagedSubjectRequest struct {
+	DisplayName *string `json:"displayName"`
+	Description *string `json:"description"`
+}
+
+type managedSubjectInfo struct {
+	ID                  string     `json:"id"`
+	SubjectID           string     `json:"subjectId"`
+	Kind                string     `json:"kind"`
+	DisplayName         string     `json:"displayName"`
+	Description         string     `json:"description,omitempty"`
+	CredentialSubjectID string     `json:"credentialSubjectId"`
+	CreatedBySubjectID  string     `json:"createdBySubjectId,omitempty"`
+	CreatedAt           time.Time  `json:"createdAt"`
+	UpdatedAt           time.Time  `json:"updatedAt"`
+	DeletedAt           *time.Time `json:"deletedAt,omitempty"`
+}
+
+type managedSubjectMemberInfo struct {
+	SubjectID string `json:"subjectId"`
+	Role      string `json:"role"`
+	Email     string `json:"email,omitempty"`
+}
+
+type managedSubjectGrantInfo struct {
+	Plugin  string `json:"plugin"`
+	Role    string `json:"role"`
+	Source  string `json:"source"`
+	Mutable bool   `json:"mutable"`
+}
+
+func (s *Server) mountAuthorizationSubjectRoutes(r chi.Router) {
+	r.Get("/authorization/subjects", s.listManagedSubjects)
+	r.Post("/authorization/subjects", s.createManagedSubject)
+	r.Get("/authorization/subjects/{subjectID}", s.getManagedSubject)
+	r.Patch("/authorization/subjects/{subjectID}", s.updateManagedSubject)
+	r.Delete("/authorization/subjects/{subjectID}", s.deleteManagedSubject)
+
+	r.Get("/authorization/subjects/{subjectID}/members", s.listManagedSubjectMembers)
+	r.Put("/authorization/subjects/{subjectID}/members", s.putManagedSubjectMember)
+	r.Delete("/authorization/subjects/{subjectID}/members/{memberSubjectID}", s.deleteManagedSubjectMember)
+
+	r.Get("/authorization/subjects/{subjectID}/grants", s.listManagedSubjectGrants)
+	r.Put("/authorization/subjects/{subjectID}/grants/{plugin}", s.putManagedSubjectGrant)
+	r.Delete("/authorization/subjects/{subjectID}/grants/{plugin}", s.deleteManagedSubjectGrant)
+
+	r.Get("/authorization/subjects/{subjectID}/tokens", s.listManagedSubjectAPITokens)
+	r.Post("/authorization/subjects/{subjectID}/tokens", s.createManagedSubjectAPIToken)
+	r.Delete("/authorization/subjects/{subjectID}/tokens", s.revokeAllManagedSubjectAPITokens)
+	r.Delete("/authorization/subjects/{subjectID}/tokens/{id}", s.revokeManagedSubjectAPIToken)
+}
+
+func (s *Server) createManagedSubject(w http.ResponseWriter, r *http.Request) {
+	creatorSubjectID, ok := s.currentManagedSubjectUserSubjectID(w, r)
+	if !ok {
+		return
+	}
+	if !s.ensureManagedSubjectsAvailable(w) {
+		return
+	}
+
+	var req createManagedSubjectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	subjectID, err := managedSubjectIDFromCreateRequest(req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	displayName := strings.TrimSpace(req.DisplayName)
+	if displayName == "" {
+		_, id, _ := core.ParseSubjectID(subjectID)
+		displayName = id
+	}
+
+	subject, err := s.managedSubjects.CreateManagedSubject(r.Context(), &core.ManagedSubject{
+		SubjectID:           subjectID,
+		Kind:                coredata.ManagedSubjectKindServiceAccount,
+		DisplayName:         displayName,
+		Description:         req.Description,
+		CredentialSubjectID: subjectID,
+		CreatedBySubjectID:  creatorSubjectID,
+	})
+	if err != nil {
+		if errors.Is(err, core.ErrAlreadyRegistered) {
+			writeError(w, http.StatusConflict, "managed subject already exists")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to create managed subject")
+		return
+	}
+
+	if err := s.writeManagedSubjectMembership(r.Context(), subject.SubjectID, creatorSubjectID, authorization.ProviderManagedSubjectRelationAdmin); err != nil {
+		if rollbackErr := s.managedSubjects.RemoveManagedSubjectForRollback(r.Context(), subject.SubjectID); rollbackErr != nil {
+			writeError(w, http.StatusInternalServerError, "failed to persist managed subject owner and rollback metadata")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to persist managed subject owner")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, managedSubjectInfoFromCore(subject))
+}
+
+func (s *Server) listManagedSubjects(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.currentManagedSubjectUserSubjectID(w, r); !ok {
+		return
+	}
+	if !s.ensureManagedSubjectsAvailable(w) {
+		return
+	}
+	kind := strings.TrimSpace(r.URL.Query().Get("kind"))
+	if kind == "" {
+		kind = coredata.ManagedSubjectKindServiceAccount
+	}
+	subjects, err := s.managedSubjects.ListManagedSubjects(r.Context(), kind)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	out := make([]managedSubjectInfo, 0, len(subjects))
+	for _, subject := range subjects {
+		if subject == nil {
+			continue
+		}
+		allowed, err := s.managedSubjectActionAllowed(r.Context(), subject.SubjectID, authorization.ProviderManagedSubjectActionView)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to evaluate managed subject access")
+			return
+		}
+		if !allowed {
+			continue
+		}
+		out = append(out, managedSubjectInfoFromCore(subject))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].DisplayName != out[j].DisplayName {
+			return out[i].DisplayName < out[j].DisplayName
+		}
+		return out[i].SubjectID < out[j].SubjectID
+	})
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) getManagedSubject(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionView) {
+		return
+	}
+	writeJSON(w, http.StatusOK, managedSubjectInfoFromCore(subject))
+}
+
+func (s *Server) updateManagedSubject(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionManage) {
+		return
+	}
+
+	var req updateManagedSubjectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	updated, err := s.managedSubjects.UpdateManagedSubject(r.Context(), subject.SubjectID, func(subject *core.ManagedSubject) error {
+		if req.DisplayName != nil {
+			subject.DisplayName = strings.TrimSpace(*req.DisplayName)
+		}
+		if req.Description != nil {
+			subject.Description = strings.TrimSpace(*req.Description)
+		}
+		return nil
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update managed subject")
+		return
+	}
+	writeJSON(w, http.StatusOK, managedSubjectInfoFromCore(updated))
+}
+
+func (s *Server) deleteManagedSubject(w http.ResponseWriter, r *http.Request) {
+	subjectID, ok := s.managedSubjectIDFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subjectID, authorization.ProviderManagedSubjectActionManage) {
+		return
+	}
+
+	if _, err := s.apiTokens.RevokeAllAPITokensByOwner(r.Context(), core.APITokenOwnerKindSubject, subjectID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to revoke managed subject tokens")
+		return
+	}
+	if err := s.deleteManagedSubjectCredentials(r.Context(), subjectID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete managed subject credentials")
+		return
+	}
+	if err := s.deleteManagedSubjectSubjectRelationships(r.Context(), subjectID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete managed subject authorization relationships")
+		return
+	}
+	if _, err := s.managedSubjects.DeleteManagedSubject(r.Context(), subjectID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete managed subject")
+		return
+	}
+	if err := s.deleteManagedSubjectResourceRelationships(r.Context(), subjectID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete managed subject authorization relationships")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) listManagedSubjectMembers(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionView) {
+		return
+	}
+	members, err := s.managedSubjectMemberRows(r.Context(), subject.SubjectID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list managed subject members")
+		return
+	}
+	writeJSON(w, http.StatusOK, members)
+}
+
+func (s *Server) putManagedSubjectMember(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionManage) {
+		return
+	}
+	var req putAdminAuthorizationMemberRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if !managedSubjectManagementRole(req.Role) {
+		writeError(w, http.StatusBadRequest, "role must be viewer, editor, or admin")
+		return
+	}
+	member, status, message := s.resolveAdminAuthorizationWriteSubject(r.Context(), req)
+	if status != 0 {
+		writeError(w, status, message)
+		return
+	}
+	if err := s.writeManagedSubjectMembership(r.Context(), subject.SubjectID, member.SubjectID, strings.TrimSpace(req.Role)); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to persist managed subject member")
+		return
+	}
+	writeJSON(w, http.StatusOK, managedSubjectMemberInfo{
+		SubjectID: member.SubjectID,
+		Role:      strings.TrimSpace(req.Role),
+		Email:     adminAuthorizationSubjectEmail(member),
+	})
+}
+
+func (s *Server) deleteManagedSubjectMember(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionManage) {
+		return
+	}
+	memberSubjectID, err := adminAuthorizationSubjectID(strings.TrimSpace(chi.URLParam(r, "memberSubjectID")))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	resource := managedSubjectResource(subject.SubjectID)
+	existing, _, err := s.deleteProviderDynamicMembership(r.Context(), resource, memberSubjectID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete managed subject member")
+		return
+	}
+	if len(existing) == 0 {
+		writeError(w, http.StatusNotFound, "managed subject member not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) listManagedSubjectGrants(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionView) {
+		return
+	}
+	grants, err := s.managedSubjectGrantRows(r.Context(), subject.SubjectID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list managed subject grants")
+		return
+	}
+	writeJSON(w, http.StatusOK, grants)
+}
+
+func (s *Server) putManagedSubjectGrant(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionGrant) {
+		return
+	}
+	plugin, _, err := s.adminAuthorizationPluginEntry(chi.URLParam(r, "plugin"))
+	if err != nil {
+		s.writeAdminAuthorizationPluginError(w, err)
+		return
+	}
+	if access, ok := s.authorizer.StaticRoleForProviderIdentity(plugin, subject.SubjectID); ok && access.Role != "" {
+		writeError(w, http.StatusConflict, "subject already has static authorization for this plugin")
+		return
+	}
+	var req struct {
+		Role string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.Role) == "" {
+		writeError(w, http.StatusBadRequest, "role is required")
+		return
+	}
+	if !s.requireManagedSubjectPluginDelegation(w, r, plugin, req.Role) {
+		return
+	}
+	membership, err := s.upsertProviderPluginAuthorization(r.Context(), &adminAuthorizationWriteSubject{SubjectID: subject.SubjectID}, plugin, req.Role)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to persist managed subject grant")
+		return
+	}
+	if err := s.reloadAuthorizationState(r.Context()); err != nil {
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"status":   "persisted_pending_reload",
+			"grant":    managedSubjectGrantInfo{Plugin: plugin, Role: membership.Role, Source: "dynamic", Mutable: true},
+			"reloaded": false,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, managedSubjectGrantInfo{Plugin: plugin, Role: membership.Role, Source: "dynamic", Mutable: true})
+}
+
+func (s *Server) deleteManagedSubjectGrant(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionGrant) {
+		return
+	}
+	plugin, _, err := s.adminAuthorizationPluginEntry(chi.URLParam(r, "plugin"))
+	if err != nil {
+		s.writeAdminAuthorizationPluginError(w, err)
+		return
+	}
+	if err := s.deleteProviderPluginAuthorization(r.Context(), plugin, subject.SubjectID); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "managed subject grant not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to delete managed subject grant")
+		return
+	}
+	if err := s.reloadAuthorizationState(r.Context()); err != nil {
+		writeJSON(w, http.StatusAccepted, map[string]any{"status": "deleted_pending_reload", "reloaded": false})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) createManagedSubjectAPIToken(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionCreateToken) {
+		return
+	}
+	var req createTokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	permissions, err := s.validateCreateAPITokenRequest(req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	apiToken, plaintext, err := s.issueOwnedAPIToken(r.Context(), &core.APIToken{
+		OwnerKind:           core.APITokenOwnerKindSubject,
+		OwnerID:             subject.SubjectID,
+		CredentialSubjectID: subject.SubjectID,
+		Name:                strings.TrimSpace(req.Name),
+		Scopes:              req.Scopes,
+		Permissions:         cloneAccessPermissions(permissions),
+	}, false)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+	writeJSON(w, http.StatusCreated, createTokenResponse{
+		ID:          apiToken.ID,
+		Name:        apiToken.Name,
+		Token:       plaintext,
+		Permissions: cloneAccessPermissions(apiToken.Permissions),
+		ExpiresAt:   apiToken.ExpiresAt,
+	})
+}
+
+func (s *Server) listManagedSubjectAPITokens(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionView) {
+		return
+	}
+	tokens, err := s.apiTokens.ListAPITokensByOwner(r.Context(), core.APITokenOwnerKindSubject, subject.SubjectID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list managed subject tokens")
+		return
+	}
+	out := make([]apiTokenInfo, 0, len(tokens))
+	for _, token := range tokens {
+		out = append(out, apiTokenInfoFromCore(token))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) revokeManagedSubjectAPIToken(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionManage) {
+		return
+	}
+	id := strings.TrimSpace(chi.URLParam(r, "id"))
+	if err := s.apiTokens.RevokeAPITokenByOwner(r.Context(), core.APITokenOwnerKindSubject, subject.SubjectID, id); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "token not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to revoke token")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
+}
+
+func (s *Server) revokeAllManagedSubjectAPITokens(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionManage) {
+		return
+	}
+	count, err := s.apiTokens.RevokeAllAPITokensByOwner(r.Context(), core.APITokenOwnerKindSubject, subject.SubjectID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to revoke managed subject tokens")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "revoked", "count": count})
+}
+
+func (s *Server) currentUserSubjectID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	userID, err := s.resolveUserID(w, r)
+	if err != nil {
+		return "", false
+	}
+	return principal.UserSubjectID(userID), true
+}
+
+func (s *Server) currentManagedSubjectUserSubjectID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	subjectID, ok := s.currentUserSubjectID(w, r)
+	if !ok {
+		return "", false
+	}
+	if !s.requireUnscopedManagedSubjectCaller(w, r) {
+		return "", false
+	}
+	return subjectID, true
+}
+
+func (s *Server) requireUnscopedManagedSubjectCaller(w http.ResponseWriter, r *http.Request) bool {
+	p := principal.Canonicalized(PrincipalFromContext(r.Context()))
+	if p == nil || p.Source != principal.SourceAPIToken {
+		return true
+	}
+	if p.TokenPermissions == nil && p.ActionPermissions == nil && len(p.Scopes) == 0 {
+		return true
+	}
+	writeError(w, http.StatusForbidden, "scoped API tokens cannot manage managed subjects")
+	return false
+}
+
+func (s *Server) ensureManagedSubjectsAvailable(w http.ResponseWriter) bool {
+	if s.managedSubjects == nil {
+		writeError(w, http.StatusServiceUnavailable, "managed subjects are unavailable")
+		return false
+	}
+	if s.authorizationProvider == nil || s.authorizer == nil {
+		writeError(w, http.StatusServiceUnavailable, "managed subjects require an authorization provider")
+		return false
+	}
+	return true
+}
+
+func (s *Server) managedSubjectFromPath(w http.ResponseWriter, r *http.Request) (*core.ManagedSubject, bool) {
+	subjectID, ok := s.managedSubjectIDFromPath(w, r)
+	if !ok {
+		return nil, false
+	}
+	subject, err := s.managedSubjects.GetManagedSubject(r.Context(), subjectID)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "managed subject not found")
+			return nil, false
+		}
+		writeError(w, http.StatusInternalServerError, "failed to load managed subject")
+		return nil, false
+	}
+	return subject, true
+}
+
+func (s *Server) managedSubjectIDFromPath(w http.ResponseWriter, r *http.Request) (string, bool) {
+	if !s.ensureManagedSubjectsAvailable(w) {
+		return "", false
+	}
+	subjectID, err := canonicalServiceAccountSubjectID(chi.URLParam(r, "subjectID"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return "", false
+	}
+	return subjectID, true
+}
+
+func (s *Server) requireManagedSubjectAction(w http.ResponseWriter, r *http.Request, subjectID, action string) bool {
+	if _, ok := s.currentManagedSubjectUserSubjectID(w, r); !ok {
+		return false
+	}
+	allowed, err := s.managedSubjectActionAllowed(r.Context(), subjectID, action)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to evaluate managed subject access")
+		return false
+	}
+	if !allowed {
+		writeError(w, http.StatusForbidden, "managed subject access denied")
+		return false
+	}
+	return true
+}
+
+func (s *Server) managedSubjectActionAllowed(ctx context.Context, subjectID, action string) (bool, error) {
+	p := PrincipalFromContext(ctx)
+	p = principal.Canonicalized(p)
+	if p == nil || strings.TrimSpace(p.SubjectID) == "" {
+		return false, nil
+	}
+	if s.authorizationProvider == nil {
+		return false, fmt.Errorf("authorization provider is unavailable")
+	}
+	roles := managedSubjectActionRoles(action)
+	reqs := make([]*core.AccessEvaluationRequest, 0, len(roles))
+	for _, role := range roles {
+		reqs = append(reqs, &core.AccessEvaluationRequest{
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: strings.TrimSpace(p.SubjectID)},
+			Action:   &core.ActionRef{Name: role},
+			Resource: managedSubjectResource(subjectID),
+		})
+	}
+	resp, err := s.authorizationProvider.EvaluateMany(ctx, &core.AccessEvaluationsRequest{Requests: reqs})
+	if err != nil {
+		return false, err
+	}
+	for _, decision := range resp.GetDecisions() {
+		if decision.GetAllowed() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *Server) writeManagedSubjectMembership(ctx context.Context, subjectID, memberSubjectID, role string) error {
+	if !managedSubjectManagementRole(role) {
+		return fmt.Errorf("unsupported managed subject role %q", role)
+	}
+	_, _, err := s.replaceProviderDynamicMembership(ctx, managedSubjectResource(subjectID), memberSubjectID, role)
+	return err
+}
+
+func (s *Server) requireManagedSubjectPluginDelegation(w http.ResponseWriter, r *http.Request, plugin, role string) bool {
+	p := principal.Canonicalized(PrincipalFromContext(r.Context()))
+	if p == nil || strings.TrimSpace(p.SubjectID) == "" {
+		writeError(w, http.StatusForbidden, "plugin access denied")
+		return false
+	}
+	access, allowed := s.authorizer.ResolveAccess(r.Context(), p, plugin)
+	if !allowed {
+		writeError(w, http.StatusForbidden, "plugin access denied")
+		return false
+	}
+	requestedRole := strings.TrimSpace(role)
+	callerRole := strings.TrimSpace(access.Role)
+	if access.Policy == "" || managedSubjectPluginRoleCanDelegate(callerRole, requestedRole) {
+		return true
+	}
+	writeError(w, http.StatusForbidden, "plugin role cannot grant requested role")
+	return false
+}
+
+func (s *Server) managedSubjectMemberRows(ctx context.Context, subjectID string) ([]managedSubjectMemberInfo, error) {
+	relationships, err := s.readAllAuthorizationRelationships(ctx, &core.ReadRelationshipsRequest{
+		PageSize: adminAuthorizationProviderReadPageSize,
+		Resource: managedSubjectResource(subjectID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]managedSubjectMemberInfo, 0, len(relationships))
+	for _, rel := range relationships {
+		if rel == nil || rel.GetSubject() == nil || !managedSubjectManagementRole(rel.GetRelation()) {
+			continue
+		}
+		if rel.GetSubject().GetType() != authorization.ProviderSubjectTypeSubject {
+			continue
+		}
+		row := managedSubjectMemberInfo{
+			SubjectID: rel.GetSubject().GetId(),
+			Role:      rel.GetRelation(),
+		}
+		if userID := principal.UserIDFromSubjectID(row.SubjectID); userID != "" {
+			if user, err := s.users.GetUser(ctx, userID); err == nil && user != nil {
+				row.Email = user.Email
+			}
+		}
+		out = append(out, row)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Role != out[j].Role {
+			return managedSubjectRoleSortKey(out[i].Role) < managedSubjectRoleSortKey(out[j].Role)
+		}
+		return out[i].SubjectID < out[j].SubjectID
+	})
+	return out, nil
+}
+
+func (s *Server) managedSubjectGrantRows(ctx context.Context, subjectID string) ([]managedSubjectGrantInfo, error) {
+	byPlugin := map[string]managedSubjectGrantInfo{}
+	for plugin := range s.pluginDefs {
+		if access, ok := s.authorizer.StaticRoleForProviderIdentity(plugin, subjectID); ok && access.Role != "" {
+			byPlugin[plugin] = managedSubjectGrantInfo{Plugin: plugin, Role: access.Role, Source: "static", Mutable: false}
+		}
+	}
+	relationships, err := s.readAllAuthorizationRelationships(ctx, &core.ReadRelationshipsRequest{
+		PageSize: adminAuthorizationProviderReadPageSize,
+		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: subjectID},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, rel := range relationships {
+		if rel == nil || rel.GetResource() == nil || rel.GetResource().GetType() != authorization.ProviderResourceTypePluginDynamic {
+			continue
+		}
+		plugin := strings.TrimSpace(rel.GetResource().GetId())
+		if plugin == "" {
+			continue
+		}
+		if existing, ok := byPlugin[plugin]; ok && existing.Source == "static" {
+			continue
+		}
+		byPlugin[plugin] = managedSubjectGrantInfo{Plugin: plugin, Role: strings.TrimSpace(rel.GetRelation()), Source: "dynamic", Mutable: true}
+	}
+	out := make([]managedSubjectGrantInfo, 0, len(byPlugin))
+	for _, grant := range byPlugin {
+		out = append(out, grant)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Plugin < out[j].Plugin })
+	return out, nil
+}
+
+func (s *Server) deleteManagedSubjectCredentials(ctx context.Context, subjectID string) error {
+	if s.externalCredentials == nil || coredata.ExternalCredentialProviderMissing(s.externalCredentials) {
+		return nil
+	}
+	credentials, err := s.externalCredentials.ListCredentials(ctx, subjectID)
+	if err != nil {
+		return err
+	}
+	for _, credential := range credentials {
+		if credential == nil || strings.TrimSpace(credential.ID) == "" {
+			continue
+		}
+		if err := s.externalCredentials.DeleteCredential(ctx, credential.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) deleteManagedSubjectSubjectRelationships(ctx context.Context, subjectID string) error {
+	if s.authorizationProvider == nil {
+		return errAdminAuthorizationUnavailable
+	}
+	subjectID = strings.TrimSpace(subjectID)
+	subjectRels, err := s.readAllAuthorizationRelationships(ctx, &core.ReadRelationshipsRequest{
+		PageSize: adminAuthorizationProviderReadPageSize,
+		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: subjectID},
+	})
+	if err != nil {
+		return err
+	}
+	return s.deleteAuthorizationRelationships(ctx, subjectRels)
+}
+
+func (s *Server) deleteManagedSubjectResourceRelationships(ctx context.Context, subjectID string) error {
+	if s.authorizationProvider == nil {
+		return errAdminAuthorizationUnavailable
+	}
+	resourceRels, err := s.readAllAuthorizationRelationships(ctx, &core.ReadRelationshipsRequest{
+		PageSize: adminAuthorizationProviderReadPageSize,
+		Resource: managedSubjectResource(subjectID),
+	})
+	if err != nil {
+		return err
+	}
+	return s.deleteAuthorizationRelationships(ctx, resourceRels)
+}
+
+func (s *Server) deleteAuthorizationRelationships(ctx context.Context, relationships []*core.Relationship) error {
+	relationshipsByKey := map[string]*core.Relationship{}
+	for _, rel := range relationships {
+		if rel == nil {
+			continue
+		}
+		relationshipsByKey[providerRelationshipKey(rel)] = rel
+	}
+	if len(relationshipsByKey) == 0 {
+		return nil
+	}
+	rels := make([]*core.Relationship, 0, len(relationshipsByKey))
+	for _, rel := range relationshipsByKey {
+		rels = append(rels, rel)
+	}
+	modelID, err := s.managedAuthorizationModelID(ctx)
+	if err != nil {
+		return err
+	}
+	return s.authorizationProvider.WriteRelationships(ctx, &core.WriteRelationshipsRequest{
+		Deletes: relationshipKeys(rels),
+		ModelId: modelID,
+	})
+}
+
+func managedSubjectResource(subjectID string) *core.ResourceRef {
+	return &core.ResourceRef{Type: authorization.ProviderResourceTypeManagedSubject, Id: strings.TrimSpace(subjectID)}
+}
+
+func managedSubjectInfoFromCore(subject *core.ManagedSubject) managedSubjectInfo {
+	if subject == nil {
+		return managedSubjectInfo{}
+	}
+	_, id, _ := core.ParseSubjectID(subject.SubjectID)
+	return managedSubjectInfo{
+		ID:                  id,
+		SubjectID:           subject.SubjectID,
+		Kind:                subject.Kind,
+		DisplayName:         subject.DisplayName,
+		Description:         subject.Description,
+		CredentialSubjectID: subject.CredentialSubjectID,
+		CreatedBySubjectID:  subject.CreatedBySubjectID,
+		CreatedAt:           subject.CreatedAt,
+		UpdatedAt:           subject.UpdatedAt,
+		DeletedAt:           subject.DeletedAt,
+	}
+}
+
+func managedSubjectIDFromCreateRequest(req createManagedSubjectRequest) (string, error) {
+	kind := strings.TrimSpace(req.Kind)
+	if kind == "" {
+		kind = coredata.ManagedSubjectKindServiceAccount
+	}
+	if kind != coredata.ManagedSubjectKindServiceAccount {
+		return "", fmt.Errorf("kind must be %q", coredata.ManagedSubjectKindServiceAccount)
+	}
+	if subjectID := strings.TrimSpace(req.SubjectID); subjectID != "" {
+		return canonicalServiceAccountSubjectID(subjectID)
+	}
+	id := strings.TrimSpace(req.ID)
+	if !validManagedSubjectLocalID(id) {
+		return "", errors.New("id must contain only letters, numbers, dots, underscores, and hyphens")
+	}
+	return coredata.ManagedSubjectKindServiceAccount + ":" + id, nil
+}
+
+func canonicalServiceAccountSubjectID(subjectID string) (string, error) {
+	kind, id, ok := core.ParseSubjectID(subjectID)
+	if !ok || kind != coredata.ManagedSubjectKindServiceAccount || !validManagedSubjectLocalID(id) {
+		return "", fmt.Errorf("subjectId must be a canonical %s:<id> subject ID", coredata.ManagedSubjectKindServiceAccount)
+	}
+	return kind + ":" + id, nil
+}
+
+func validManagedSubjectLocalID(id string) bool {
+	if id == "" || len(id) > 128 {
+		return false
+	}
+	for _, ch := range id {
+		switch {
+		case ch >= 'a' && ch <= 'z':
+		case ch >= 'A' && ch <= 'Z':
+		case ch >= '0' && ch <= '9':
+		case ch == '.', ch == '_', ch == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func managedSubjectManagementRole(role string) bool {
+	switch strings.TrimSpace(role) {
+	case authorization.ProviderManagedSubjectRelationViewer,
+		authorization.ProviderManagedSubjectRelationEditor,
+		authorization.ProviderManagedSubjectRelationAdmin:
+		return true
+	default:
+		return false
+	}
+}
+
+func managedSubjectPluginRoleCanDelegate(callerRole, requestedRole string) bool {
+	callerRole = strings.TrimSpace(callerRole)
+	requestedRole = strings.TrimSpace(requestedRole)
+	if callerRole == requestedRole {
+		return true
+	}
+	callerRank, callerOK := managedSubjectRoleRank(callerRole)
+	requestedRank, requestedOK := managedSubjectRoleRank(requestedRole)
+	return callerOK && requestedOK && callerRank >= requestedRank
+}
+
+func managedSubjectRoleRank(role string) (int, bool) {
+	switch strings.TrimSpace(role) {
+	case authorization.ProviderManagedSubjectRelationViewer:
+		return 1, true
+	case authorization.ProviderManagedSubjectRelationEditor:
+		return 2, true
+	case authorization.ProviderManagedSubjectRelationAdmin:
+		return 3, true
+	default:
+		return 0, false
+	}
+}
+
+func managedSubjectRoleSortKey(role string) string {
+	switch strings.TrimSpace(role) {
+	case authorization.ProviderManagedSubjectRelationAdmin:
+		return "0:admin"
+	case authorization.ProviderManagedSubjectRelationEditor:
+		return "1:editor"
+	case authorization.ProviderManagedSubjectRelationViewer:
+		return "2:viewer"
+	default:
+		return "9:" + role
+	}
+}
+
+func managedSubjectActionRoles(action string) []string {
+	switch strings.TrimSpace(action) {
+	case authorization.ProviderManagedSubjectActionView:
+		return []string{
+			authorization.ProviderManagedSubjectRelationViewer,
+			authorization.ProviderManagedSubjectRelationEditor,
+			authorization.ProviderManagedSubjectRelationAdmin,
+		}
+	case authorization.ProviderManagedSubjectActionConnect:
+		return []string{
+			authorization.ProviderManagedSubjectRelationEditor,
+			authorization.ProviderManagedSubjectRelationAdmin,
+		}
+	case authorization.ProviderManagedSubjectActionManage,
+		authorization.ProviderManagedSubjectActionCreateToken,
+		authorization.ProviderManagedSubjectActionGrant:
+		return []string{authorization.ProviderManagedSubjectRelationAdmin}
+	default:
+		return []string{strings.TrimSpace(action)}
+	}
+}

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -51,28 +51,9 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Name == "" {
-		auditErr = errors.New("name is required")
-		writeError(w, http.StatusBadRequest, "name is required")
-		return
-	}
 	auditTarget = apiTokenAuditTarget("", req.Name)
 
-	if req.Scopes != "" && len(req.Permissions) > 0 {
-		auditErr = errors.New("scopes and permissions are mutually exclusive")
-		writeError(w, http.StatusBadRequest, "scopes and permissions are mutually exclusive")
-		return
-	}
-	if req.Scopes != "" {
-		for _, scope := range strings.Fields(req.Scopes) {
-			if _, err := s.providers.Get(scope); err != nil {
-				auditErr = fmt.Errorf("unknown scope %q", scope)
-				writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown scope %q", scope))
-				return
-			}
-		}
-	}
-	permissions, err := s.normalizeAPITokenPermissions(req.Permissions)
+	permissions, err := s.validateCreateAPITokenRequest(req)
 	if err != nil {
 		auditErr = err
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -96,6 +77,23 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 		Permissions: cloneAccessPermissions(apiToken.Permissions),
 		ExpiresAt:   apiToken.ExpiresAt,
 	})
+}
+
+func (s *Server) validateCreateAPITokenRequest(req createTokenRequest) ([]core.AccessPermission, error) {
+	if strings.TrimSpace(req.Name) == "" {
+		return nil, errors.New("name is required")
+	}
+	if req.Scopes != "" && len(req.Permissions) > 0 {
+		return nil, errors.New("scopes and permissions are mutually exclusive")
+	}
+	if req.Scopes != "" {
+		for _, scope := range strings.Fields(req.Scopes) {
+			if _, err := s.providers.Get(scope); err != nil {
+				return nil, fmt.Errorf("unknown scope %q", scope)
+			}
+		}
+	}
+	return s.normalizeAPITokenPermissions(req.Permissions)
 }
 
 func (s *Server) normalizeAPITokenPermissions(values []core.AccessPermission) ([]core.AccessPermission, error) {

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -60,6 +60,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			RevokeAllAPITokens: s.revokeAllAPITokens,
 			RevokeAPIToken:     s.revokeAPIToken,
 		})
+		s.mountAuthorizationSubjectRoutes(r)
 		providerdevhttp.Mount(r, providerdevhttp.Handlers{
 			CreateAttachment: s.createProviderDevSession,
 			ListAttachments:  s.listProviderDevAttachments,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -89,6 +89,7 @@ type Server struct {
 	users                  *coredata.UserService
 	externalCredentials    core.ExternalCredentialProvider
 	apiTokens              *coredata.APITokenService
+	managedSubjects        *coredata.ManagedSubjectService
 	agent                  bootstrap.AgentControl
 	workflowSchedules      *workflowmanager.Manager
 	agentRuns              agentmanager.Service
@@ -267,6 +268,7 @@ func New(cfg Config) (*Server, error) {
 		return nil, fmt.Errorf("external credentials provider is required")
 	}
 	apiTokens := cfg.Services.APITokens
+	managedSubjects := cfg.Services.ManagedSubjects
 	resolver := principal.NewResolver(cfg.Auth, users, apiTokens)
 	authProviders := make(map[string]core.AuthenticationProvider, len(cfg.AuthProviders)+1)
 	for name, provider := range cfg.AuthProviders {
@@ -322,6 +324,7 @@ func New(cfg Config) (*Server, error) {
 		users:                  users,
 		externalCredentials:    externalCredentials,
 		apiTokens:              apiTokens,
+		managedSubjects:        managedSubjects,
 		agent:                  cfg.Agent,
 		agentRuns:              cfg.AgentManager,
 		authorizationProvider:  cfg.AuthorizationProvider,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4088,6 +4088,316 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	}
 }
 
+func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	scopedToken, scopedHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	seedAPITokenWithPermissions(t, svc, scopedToken, scopedHash, "scoped-user", []core.AccessPermission{{
+		Plugin:     "svc",
+		Operations: []string{"run"},
+	}})
+
+	pluginDefs := map[string]*config.ProviderEntry{
+		"open-svc": {AuthorizationPolicy: "open_policy"},
+		"svc":      {AuthorizationPolicy: "svc_policy"},
+	}
+	baseAuthz, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.SubjectPolicyDef{
+			"open_policy": {Default: "allow"},
+			"svc_policy":  {Default: "deny"},
+		},
+	}, pluginDefs)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
+	seedProviderPluginAuthorization(t, svc, authz, provider, "svc", "owner@example.test", "editor")
+
+	newStub := func(name string) *stubIntegrationWithSessionCatalog {
+		return &stubIntegrationWithSessionCatalog{
+			stubIntegrationWithOps: stubIntegrationWithOps{
+				StubIntegration: coretesting.StubIntegration{
+					N:        name,
+					ConnMode: core.ConnectionModeNone,
+					ExecuteFn: func(ctx context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+						p := principal.FromContext(ctx)
+						access := invocation.AccessContextFromContext(ctx)
+						body, err := json.Marshal(map[string]string{
+							"operation": op,
+							"subject":   p.SubjectID,
+							"role":      access.Role,
+						})
+						if err != nil {
+							return nil, err
+						}
+						return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+					},
+				},
+			},
+			catalog: &catalog.Catalog{
+				Name: name,
+				Operations: []catalog.CatalogOperation{
+					{ID: "run", Method: http.MethodGet, Transport: catalog.TransportREST, AllowedRoles: []string{"viewer"}},
+					{ID: "admin", Method: http.MethodGet, Transport: catalog.TransportREST, AllowedRoles: []string{"admin"}},
+				},
+			},
+		}
+	}
+	stub := newStub("svc")
+	openStub := newStub("open-svc")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "owner-session":
+					return &core.UserIdentity{Email: "owner@example.test"}, nil
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				case "blocked-session":
+					return &core.UserIdentity{Email: "blocked@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("invalid token")
+				}
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, stub, openStub)
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
+		cfg.PluginDefs = pluginDefs
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	doJSON := func(method, path, session, body string) *http.Response {
+		t.Helper()
+		var reader io.Reader
+		if body != "" {
+			reader = bytes.NewBufferString(body)
+		}
+		req, _ := http.NewRequest(method, ts.URL+path, reader)
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		if session != "" {
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: session})
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", method, path, err)
+		}
+		return resp
+	}
+	expectJSONStatus := func(method, path, session, body string, want int) {
+		t.Helper()
+		resp := doJSON(method, path, session, body)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != want {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want %d: %s", resp.StatusCode, want, body)
+		}
+	}
+
+	expectJSONStatus(http.MethodPost, "/api/v1/authorization/subjects", "owner-session", `{"subjectId":"user:not-a-service-account","displayName":"bad"}`, http.StatusBadRequest)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/authorization/subjects", bytes.NewBufferString(`{"id":"scoped-token-bot"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+scopedToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create with scoped API token: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("scoped API token create status = %d, want 403: %s", resp.StatusCode, body)
+	}
+	_ = resp.Body.Close()
+
+	resp = doJSON(http.MethodPost, "/api/v1/authorization/subjects", "owner-session", `{"id":"reporting-bot","displayName":"Reporting Bot","description":"Nightly reports"}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("create subject status = %d, want 201: %s", resp.StatusCode, body)
+	}
+	var created struct {
+		ID                  string `json:"id"`
+		SubjectID           string `json:"subjectId"`
+		Kind                string `json:"kind"`
+		DisplayName         string `json:"displayName"`
+		CredentialSubjectID string `json:"credentialSubjectId"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode created managed subject: %v", err)
+	}
+	_ = resp.Body.Close()
+	if created.ID != "reporting-bot" || created.SubjectID != "service_account:reporting-bot" || created.Kind != "service_account" || created.CredentialSubjectID != created.SubjectID {
+		t.Fatalf("created managed subject = %+v", created)
+	}
+	if err := svc.ExternalCredentials.PutCredential(context.Background(), &core.ExternalCredential{
+		ID:          "managed-subject-credential",
+		SubjectID:   created.SubjectID,
+		Integration: "svc",
+		Connection:  "default",
+		Instance:    "default",
+		AccessToken: "upstream-token",
+	}); err != nil {
+		t.Fatalf("seed managed subject credential: %v", err)
+	}
+
+	escapedSubjectID := url.PathEscape(created.SubjectID)
+	expectJSONStatus(http.MethodGet, "/api/v1/authorization/subjects/"+escapedSubjectID, "owner-session", "", http.StatusOK)
+
+	expectJSONStatus(http.MethodPut, "/api/v1/authorization/subjects/"+escapedSubjectID+"/members", "owner-session", `{"email":"viewer@example.test","role":"viewer"}`, http.StatusOK)
+
+	expectJSONStatus(http.MethodGet, "/api/v1/authorization/subjects/"+escapedSubjectID, "viewer-session", "", http.StatusOK)
+
+	expectJSONStatus(http.MethodPost, "/api/v1/authorization/subjects/"+escapedSubjectID+"/tokens", "viewer-session", `{"name":"viewer-token"}`, http.StatusForbidden)
+
+	expectJSONStatus(http.MethodPut, "/api/v1/authorization/subjects/"+escapedSubjectID+"/members", "owner-session", `{"email":"blocked@example.test","role":"admin"}`, http.StatusOK)
+
+	expectJSONStatus(http.MethodPut, "/api/v1/authorization/subjects/"+escapedSubjectID+"/grants/svc", "blocked-session", `{"role":"viewer"}`, http.StatusForbidden)
+
+	resp = doJSON(http.MethodPost, "/api/v1/authorization/subjects/"+escapedSubjectID+"/tokens", "owner-session", `{"name":"open-token","permissions":[{"plugin":"open-svc","operations":["run"]}]}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("create open subject token status = %d, want 201: %s", resp.StatusCode, body)
+	}
+	var openTokenResp struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&openTokenResp); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode open token response: %v", err)
+	}
+	_ = resp.Body.Close()
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/open-svc/run", nil)
+	req.Header.Set("Authorization", "Bearer "+openTokenResp.Token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("invoke default-allow plugin without managed subject grant: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("default-allow invocation without grant status = %d, want 403: %s", resp.StatusCode, body)
+	}
+	_ = resp.Body.Close()
+
+	resp = doJSON(http.MethodPut, "/api/v1/authorization/subjects/"+escapedSubjectID+"/grants/svc", "owner-session", `{"role":"viewer"}`)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("grant subject status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var grant struct {
+		Plugin  string `json:"plugin"`
+		Role    string `json:"role"`
+		Source  string `json:"source"`
+		Mutable bool   `json:"mutable"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&grant); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode grant response: %v", err)
+	}
+	_ = resp.Body.Close()
+	if grant.Plugin != "svc" || grant.Role != "viewer" || grant.Source != "dynamic" || !grant.Mutable {
+		t.Fatalf("grant response = %+v", grant)
+	}
+
+	resp = doJSON(http.MethodPost, "/api/v1/authorization/subjects/"+escapedSubjectID+"/tokens", "owner-session", `{"name":"reporting-token","permissions":[{"plugin":"svc","operations":["run"]}]}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("create subject token status = %d, want 201: %s", resp.StatusCode, body)
+	}
+	var tokenResp struct {
+		ID          string                  `json:"id"`
+		Token       string                  `json:"token"`
+		Permissions []core.AccessPermission `json:"permissions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode token response: %v", err)
+	}
+	_ = resp.Body.Close()
+	if tokenResp.ID == "" || tokenResp.Token == "" || len(tokenResp.Permissions) != 1 || tokenResp.Permissions[0].Plugin != "svc" {
+		t.Fatalf("token response = %+v", tokenResp)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenResp.Token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("invoke with subject token: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("invoke status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var invokeResp map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&invokeResp); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode invoke response: %v", err)
+	}
+	_ = resp.Body.Close()
+	if invokeResp["subject"] != created.SubjectID || invokeResp["role"] != "viewer" || invokeResp["operation"] != "run" {
+		t.Fatalf("invoke response = %+v", invokeResp)
+	}
+
+	expectJSONStatus(http.MethodDelete, "/api/v1/authorization/subjects/"+escapedSubjectID, "owner-session", "", http.StatusOK)
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenResp.Token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("invoke after delete: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("invoke after delete status = %d, want 401: %s", resp.StatusCode, body)
+	}
+	_ = resp.Body.Close()
+
+	rels, err := provider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
+		Subject: &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: created.SubjectID},
+	})
+	if err != nil {
+		t.Fatalf("read subject relationships after delete: %v", err)
+	}
+	if len(rels.GetRelationships()) != 0 {
+		t.Fatalf("subject relationships after delete = %+v, want none", rels.GetRelationships())
+	}
+	rels, err = provider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
+		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeManagedSubject, Id: created.SubjectID},
+	})
+	if err != nil {
+		t.Fatalf("read managed subject relationships after delete: %v", err)
+	}
+	if len(rels.GetRelationships()) != 0 {
+		t.Fatalf("managed subject relationships after delete = %+v, want none", rels.GetRelationships())
+	}
+	credentials, err := svc.ExternalCredentials.ListCredentials(context.Background(), created.SubjectID)
+	if err != nil {
+		t.Fatalf("list credentials after delete: %v", err)
+	}
+	if len(credentials) != 0 {
+		t.Fatalf("credentials after delete = %+v, want none", credentials)
+	}
+
+	expectJSONStatus(http.MethodPost, "/api/v1/authorization/subjects", "owner-session", `{"id":"reporting-bot","displayName":"Reporting Bot"}`, http.StatusConflict)
+}
+
 func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds the non-legacy managed subject surface under `/api/v1/authorization/subjects` for service-account style non-user principals.

Managed subjects use canonical subject IDs like `service_account:release-bot`; the backing auth resource is `managed_subject:<subjectId>`. They require explicit runtime plugin grants, and `default: allow` policy access now applies to user principals only.

This also preserves legacy `indexeddb-relationaldb` provider source detection while rebasing over the current IndexedDB scoping change, so daemon E2E fixtures continue to use config-level scoped IndexedDB providers.

## Interfaces

- `POST /api/v1/authorization/subjects` creates a `service_account:<id>` managed subject and assigns the creator `admin` on `managed_subject:<subjectId>`.
- `GET /api/v1/authorization/subjects` lists visible managed subjects.
- `GET /api/v1/authorization/subjects/{subjectID}` reads managed-subject metadata.
- `PATCH /api/v1/authorization/subjects/{subjectID}` updates display metadata.
- `DELETE /api/v1/authorization/subjects/{subjectID}` revokes subject tokens, removes external credentials, deletes subject/resource auth relationships, and tombstones metadata.
- `GET/PUT/DELETE /api/v1/authorization/subjects/{subjectID}/members` manages `viewer` / `editor` / `admin` management relationships.
- `GET/PUT/DELETE /api/v1/authorization/subjects/{subjectID}/grants` manages explicit `plugin_dynamic` runtime grants.
- `GET/POST/DELETE /api/v1/authorization/subjects/{subjectID}/tokens` manages subject-owned API tokens with `credentialSubjectId = service_account:<id>`.

## Examples

```sh
curl -X POST /api/v1/authorization/subjects \
  -d '{"id":"release-bot","displayName":"Release Bot"}'

curl -X PUT /api/v1/authorization/subjects/service_account:release-bot/grants/github \
  -d '{"role":"viewer"}'

curl -X POST /api/v1/authorization/subjects/service_account:release-bot/tokens \
  -d '{"name":"release-bot","permissions":[{"plugin":"github","operations":["issues.list"]}]}'
```

## Verification

- `go test ./internal/server -run TestAuthorizationManagedSubjectsAPI -count=5`
- `go test ./internal/bootstrap -run TestPluginIndexedDBBuildScopedConfig -count=1`
- `go test ./internal/daemon`
- `go test -coverprofile=/tmp/providerdev-coverage.out ./internal/providerdev -run TestPollSessionDropsCanceledQueuedCall -count=20`
- `go test ./internal/providerdev`
- `golangci-lint run`

`go test ./...` now gets past the daemon E2E failure from the current base; the only local remaining failure was the pre-existing flaky `TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartFails`, which also fails isolated under `-count=10`.
