### PR TITLE
gestaltd: gate readiness on workflow startup

### DIFF
--- a/gestaltd/internal/providerhost/runtime_client.go
+++ b/gestaltd/internal/providerhost/runtime_client.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	providerRPCTimeout = 10 * time.Second
+	providerRPCTimeout   = 10 * time.Second
+	providerStartTimeout = 2 * time.Minute
 )
 
 var providerConfigureTimeout = 30 * time.Second
@@ -108,7 +109,7 @@ func StartRuntimeProvider(ctx context.Context, client proto.ProviderLifecycleCli
 	if client == nil {
 		return fmt.Errorf("runtime client is required")
 	}
-	startCtx, cancel := providerCallContext(ctx)
+	startCtx, cancel := providerStartContext(ctx)
 	defer cancel()
 	resp, err := client.StartProvider(startCtx, &emptypb.Empty{})
 	if err != nil {
@@ -146,6 +147,13 @@ func providerCallContext(parent context.Context) (context.Context, context.Cance
 		parent = context.Background()
 	}
 	return context.WithTimeout(parent, providerRPCTimeout)
+}
+
+func providerStartContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, providerStartTimeout)
 }
 
 func providerStreamContext(parent context.Context) (context.Context, context.CancelFunc) {

--- a/gestaltd/internal/providerhost/runtime_client_test.go
+++ b/gestaltd/internal/providerhost/runtime_client_test.go
@@ -3,6 +3,7 @@ package providerhost
 import (
 	"context"
 	"testing"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc"
@@ -121,6 +122,31 @@ func TestStartRuntimeProviderTreatsUnimplementedAsNoop(t *testing.T) {
 	}
 	if err := StartRuntimeProvider(context.Background(), client); err != nil {
 		t.Fatalf("StartRuntimeProvider: %v", err)
+	}
+}
+
+func TestStartRuntimeProviderUsesStartupTimeout(t *testing.T) {
+	t.Parallel()
+
+	var remaining time.Duration
+	client := &fakeProviderLifecycleClient{
+		startProvider: func(ctx context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (*proto.StartRuntimeProviderResponse, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("StartProvider context has no deadline")
+			}
+			remaining = time.Until(deadline)
+			return &proto.StartRuntimeProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+		},
+	}
+	if err := StartRuntimeProvider(context.Background(), client); err != nil {
+		t.Fatalf("StartRuntimeProvider: %v", err)
+	}
+	if remaining <= providerRPCTimeout {
+		t.Fatalf("StartProvider remaining deadline = %s, want above request timeout %s", remaining, providerRPCTimeout)
+	}
+	if remaining > providerStartTimeout {
+		t.Fatalf("StartProvider remaining deadline = %s, want at most startup timeout %s", remaining, providerStartTimeout)
 	}
 }
 

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -65,6 +65,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 
 	managementAddr := cfg.Server.ManagementAddr()
 	mcpSlot := &switchableHandler{}
+	workflowProvidersReady := make(chan struct{})
 	baseConfig := Config{
 		Auth:                 result.Auth,
 		SelectedAuthProvider: result.SelectedAuthProvider,
@@ -92,24 +93,11 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		StateSecret:           crypto.DeriveKey(cfg.Server.EncryptionKey),
 		S3:                    result.S3,
 		APITokenTTL:           apiTokenTTL,
-		Readiness: func() string {
-			select {
-			case <-result.ProvidersReady:
-			default:
-				return "providers loading"
-			}
-
-			pingCtx, cancel := context.WithTimeout(context.Background(), readinessDatastorePingTimeout)
-			defer cancel()
-			if err := result.Services.Ping(pingCtx); err != nil {
-				return "datastore unavailable"
-			}
-			return ""
-		},
-		PrometheusMetrics:   result.Telemetry.PrometheusHandler(),
-		ProviderDevSessions: result.ProviderDevSessions,
-		ProviderDevAttach:   cfg.Server.ProviderDev.RemoteAttach,
-		PublicHostServices:  result.PublicHostServices,
+		Readiness:             runtimeReadinessStatus(result.ProvidersReady, workflowProvidersReady, result.Services),
+		PrometheusMetrics:     result.Telemetry.PrometheusHandler(),
+		ProviderDevSessions:   result.ProviderDevSessions,
+		ProviderDevAttach:     cfg.Server.ProviderDev.RemoteAttach,
+		PublicHostServices:    result.PublicHostServices,
 		Admin: AdminRouteConfig{
 			AuthorizationPolicy: cfg.Server.Admin.AuthorizationPolicy,
 			AllowedRoles:        append([]string(nil), cfg.Server.Admin.AllowedRoles...),
@@ -179,10 +167,40 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		})
 	}
 
-	return serveRuntime(ctx, cfg, connMaps, result, mcpInvoker, servers, mcpSlot)
+	return serveRuntime(ctx, cfg, connMaps, result, mcpInvoker, servers, mcpSlot, workflowProvidersReady)
 }
 
-func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.ConnectionMaps, result *bootstrap.Result, mcpInvoker invocation.Invoker, servers []namedHTTPServer, mcpSlot *switchableHandler) error {
+type datastorePinger interface {
+	Ping(context.Context) error
+}
+
+func runtimeReadinessStatus(providersReady, workflowProvidersReady <-chan struct{}, services datastorePinger) ReadinessChecker {
+	return func() string {
+		select {
+		case <-providersReady:
+		default:
+			return "providers loading"
+		}
+
+		select {
+		case <-workflowProvidersReady:
+		default:
+			return "workflow providers loading"
+		}
+
+		if services == nil {
+			return "datastore unavailable"
+		}
+		pingCtx, cancel := context.WithTimeout(context.Background(), readinessDatastorePingTimeout)
+		defer cancel()
+		if err := services.Ping(pingCtx); err != nil {
+			return "datastore unavailable"
+		}
+		return ""
+	}
+}
+
+func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.ConnectionMaps, result *bootstrap.Result, mcpInvoker invocation.Invoker, servers []namedHTTPServer, mcpSlot *switchableHandler, workflowProvidersReady chan<- struct{}) error {
 	listenErr := make(chan namedListenFailure, len(servers))
 	for _, entry := range servers {
 		entry := entry
@@ -216,6 +234,8 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 	if err := result.StartWorkflowProviders(ctx); err != nil {
 		return err
 	}
+	close(workflowProvidersReady)
+	slog.Info("workflow providers ready", "count", len(result.ExtraWorkflows))
 
 	mcpHandler, err := newMCPHandler(cfg, connMaps, result, mcpInvoker)
 	if err != nil {

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"sync"
@@ -32,6 +33,54 @@ func TestHTTPCatalogConnectionMapUsesAPIConnection(t *testing.T) {
 	got := httpCatalogConnectionMap(connMaps)
 	if got["notion"] != "OAuth" {
 		t.Fatalf("catalog connection = %q, want %q", got["notion"], "OAuth")
+	}
+}
+
+type fakeDatastorePinger struct {
+	err error
+}
+
+func (p fakeDatastorePinger) Ping(context.Context) error {
+	return p.err
+}
+
+func TestRuntimeReadinessStatusWaitsForWorkflowProviders(t *testing.T) {
+	t.Parallel()
+
+	providersReady := make(chan struct{})
+	workflowProvidersReady := make(chan struct{})
+	check := runtimeReadinessStatus(providersReady, workflowProvidersReady, fakeDatastorePinger{})
+
+	if got := check(); got != "providers loading" {
+		t.Fatalf("readiness before providers = %q, want %q", got, "providers loading")
+	}
+
+	close(providersReady)
+	if got := check(); got != "workflow providers loading" {
+		t.Fatalf("readiness before workflow providers = %q, want %q", got, "workflow providers loading")
+	}
+
+	close(workflowProvidersReady)
+	if got := check(); got != "" {
+		t.Fatalf("readiness after workflow providers = %q, want ready", got)
+	}
+}
+
+func TestRuntimeReadinessStatusChecksDatastoreAfterProviders(t *testing.T) {
+	t.Parallel()
+
+	providersReady := make(chan struct{})
+	close(providersReady)
+	workflowProvidersReady := make(chan struct{})
+	close(workflowProvidersReady)
+	check := runtimeReadinessStatus(
+		providersReady,
+		workflowProvidersReady,
+		fakeDatastorePinger{err: errors.New("down")},
+	)
+
+	if got := check(); got != "datastore unavailable" {
+		t.Fatalf("readiness with datastore error = %q, want %q", got, "datastore unavailable")
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep /ready unavailable until workflow providers finish startup
- give provider StartProvider calls a startup-scale timeout instead of the normal 10s request timeout
- add unit coverage for readiness sequencing and startup timeout selection

## Verification
- go test ./internal/server ./internal/providerhost

## Production context
Cloud Run logs in gitlab-peach-street show instances passing /ready and receiving traffic before workflow provider StartProvider finishes. Those instances then exit around the provider start deadline with `gestaltd exited error="start provider: rpc error: code = DeadlineExceeded"`, causing 500/503s on API and webhook routes. CloudSQL CPU after the 4 CPU upgrade is around 45-51%, so this is not supported as a CPU-sizing issue.