### PR TITLE
workflow: stabilize signal-or-start execution refs

### DIFF
--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -3,6 +3,8 @@ package workflow
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"time"
 
@@ -334,6 +336,15 @@ func TargetsEqual(left, right Target) bool {
 	}
 	rightJSON, rightErr := json.Marshal(normalizedTargetComparisonPayload(right))
 	return rightErr == nil && bytes.Equal(leftJSON, rightJSON)
+}
+
+func TargetFingerprint(target Target) (string, error) {
+	data, err := json.Marshal(normalizedTargetComparisonPayload(target))
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 type targetComparisonPayload struct {

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -1406,7 +1406,7 @@ func setupIndexedDBProviderDir(t *testing.T, baseDir string) string {
 	artifactRel := filepath.Base(binDest)
 	writeManifestFile(t, providerDir, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb/relationaldb",
+		Source:      "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Relational IndexedDB",
 		Spec:        &providermanifestv1.Spec{},
@@ -1589,7 +1589,7 @@ func setupDefaultLocalProvidersDir(t *testing.T, baseDir string) string {
 	}
 	writeManifestFile(t, indexedDBDir, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb/relationaldb",
+		Source:      "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Relational IndexedDB",
 		Spec:        &providermanifestv1.Spec{},

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -182,7 +182,7 @@ func writeDefaultProvidersDir(baseDir string) (string, error) {
 
 	if err := writeComponentProviderDir(filepath.Join(providersDir, "indexeddb", "relationaldb"), indexedDBBin, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb/relationaldb",
+		Source:      "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Relational IndexedDB",
 		Spec:        &providermanifestv1.Spec{},

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -39,6 +39,7 @@ var (
 const workflowScheduleExecutionRefBasePrefix = "workflow_schedule:"
 const workflowEventTriggerExecutionRefBasePrefix = "workflow_event_trigger:"
 const workflowRunExecutionRefBasePrefix = "workflow_run:"
+const workflowNoProviderPermissionsPlugin = "__gestalt.workflow.no_provider_permissions__"
 const defaultWorkflowEventSpecVersion = "1.0"
 
 type signalTargetPrincipalSource uint8
@@ -400,8 +401,15 @@ func (m *Manager) SignalOrStartRun(ctx context.Context, p *principal.Principal, 
 		return nil, err
 	}
 
-	executionRefID := runExecutionRefID(uuid.NewString())
-	ref, err := m.putExecutionRef(ctx, executionRefID, providerName, provider, target, p, req.CallerPluginName)
+	executionRefPermissions := m.executionRefPermissions(p, target, req.CallerPluginName)
+	if !m.allowTarget(ctx, executionRefPrincipal(p, executionRefPermissions), target) {
+		return nil, core.ErrNotFound
+	}
+	executionRefID, err := signalOrStartExecutionRefID(providerName, workflowKey, target, p, req.CallerPluginName, executionRefPermissions)
+	if err != nil {
+		return nil, err
+	}
+	ref, err := m.putSignalOrStartExecutionRef(ctx, executionRefID, providerName, provider, target, p, req.CallerPluginName, executionRefPermissions)
 	if err != nil {
 		return nil, err
 	}
@@ -414,17 +422,9 @@ func (m *Manager) SignalOrStartRun(ctx context.Context, p *principal.Principal, 
 		Signal:         signal,
 	})
 	if err != nil {
-		m.revokeExecutionRef(ctx, ref)
 		return nil, err
 	}
-	if resp == nil || resp.Run == nil || strings.TrimSpace(resp.Run.ExecutionRef) != executionRefID {
-		m.revokeExecutionRef(ctx, ref)
-	}
-	managed, err := m.managedSignalResponse(ctx, p, providerName, provider, resp, ref, signalTargetPrincipalExecutionRef)
-	if err != nil && resp != nil && resp.Run != nil && strings.TrimSpace(resp.Run.ExecutionRef) == executionRefID {
-		m.revokeExecutionRef(ctx, ref)
-	}
-	return managed, err
+	return m.managedSignalResponse(ctx, p, providerName, provider, resp, ref, signalTargetPrincipalExecutionRef)
 }
 
 func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, event coreworkflow.Event) (coreworkflow.Event, error) {
@@ -1233,6 +1233,31 @@ func (m *Manager) putExecutionRef(ctx context.Context, executionRefID, providerN
 	})
 }
 
+func (m *Manager) putSignalOrStartExecutionRef(ctx context.Context, executionRefID, providerName string, provider coreworkflow.Provider, target coreworkflow.Target, p *principal.Principal, callerPluginName string, permissions []core.AccessPermission) (*coreworkflow.ExecutionReference, error) {
+	store, err := workflowExecutionReferenceStore(providerName, provider)
+	if err != nil {
+		return nil, err
+	}
+	existing, err := store.GetExecutionReference(ctx, executionRefID)
+	if err == nil {
+		existing = workflowExecutionRefForProvider(existing, providerName)
+		if !signalOrStartExecutionRefMatches(existing, executionRefID, providerName, target, p, callerPluginName, permissions) {
+			return nil, fmt.Errorf("%w: %s", ErrDuplicateExecutionRefs, executionRefID)
+		}
+		if executionRefActive(existing) {
+			return existing, nil
+		}
+	} else if !isWorkflowProviderNotFound(err) {
+		return nil, err
+	}
+
+	ref, err := m.putExecutionRef(ctx, executionRefID, providerName, provider, target, p, callerPluginName)
+	if err != nil {
+		return nil, err
+	}
+	return ref, nil
+}
+
 func (m *Manager) executionRefPermissions(p *principal.Principal, target coreworkflow.Target, callerPluginName string) []core.AccessPermission {
 	p = principal.Canonicalized(p)
 	if p == nil || p.TokenPermissions == nil {
@@ -1255,7 +1280,27 @@ func (m *Manager) executionRefPermissions(p *principal.Principal, target corewor
 			addWorkflowPermission(permissions, pluginName, operation)
 		}
 	}
-	return principal.PermissionsToAccessPermissions(permissions)
+	out := principal.PermissionsToAccessPermissions(permissions)
+	if len(out) == 0 {
+		return []core.AccessPermission{{Plugin: workflowNoProviderPermissionsPlugin}}
+	}
+	return out
+}
+
+func executionRefPrincipal(p *principal.Principal, permissions []core.AccessPermission) *principal.Principal {
+	p = principal.Canonicalized(p)
+	if p == nil {
+		return nil
+	}
+	compiled := principal.CompilePermissions(permissions)
+	if permissions != nil && compiled == nil {
+		compiled = principal.PermissionSet{}
+	}
+	next := *p
+	next.TokenPermissions = compiled
+	next.ActionPermissions = nil
+	next.Scopes = principal.PermissionPlugins(compiled)
+	return principal.Canonicalize(&next)
 }
 
 func (m *Manager) callerPluginDeclaresInvoke(callerPluginName, pluginName, operation string) bool {
@@ -1693,6 +1738,28 @@ func targetMatchesExecutionRef(target coreworkflow.Target, ref *coreworkflow.Exe
 	return coreworkflow.TargetsEqual(target, ref.Target)
 }
 
+func signalOrStartExecutionRefMatches(ref *coreworkflow.ExecutionReference, executionRefID, providerName string, target coreworkflow.Target, p *principal.Principal, callerPluginName string, permissions []core.AccessPermission) bool {
+	if ref == nil {
+		return false
+	}
+	if strings.TrimSpace(ref.ID) != strings.TrimSpace(executionRefID) {
+		return false
+	}
+	if providerName = strings.TrimSpace(providerName); providerName != "" && strings.TrimSpace(ref.ProviderName) != providerName {
+		return false
+	}
+	if strings.TrimSpace(ref.CallerPluginName) != strings.TrimSpace(callerPluginName) {
+		return false
+	}
+	if strings.TrimSpace(ref.CredentialSubjectID) != strings.TrimSpace(principal.EffectiveCredentialSubjectID(principal.Canonicalized(p))) {
+		return false
+	}
+	if executionRefPermissionsScope(ref.Permissions) != executionRefPermissionsScope(permissions) {
+		return false
+	}
+	return executionRefOwnedBy(ref, p) && targetMatchesExecutionRef(target, ref)
+}
+
 func normalizeEventMatch(match coreworkflow.EventMatch) coreworkflow.EventMatch {
 	return coreworkflow.EventMatch{
 		Type:    strings.TrimSpace(match.Type),
@@ -1822,6 +1889,71 @@ func runExecutionRefID(value string) string {
 		value = uuid.NewString()
 	}
 	return workflowRunExecutionRefBasePrefix + value
+}
+
+func signalOrStartExecutionRefID(providerName, workflowKey string, target coreworkflow.Target, p *principal.Principal, callerPluginName string, permissions []core.AccessPermission) (string, error) {
+	targetFingerprint, err := coreworkflow.TargetFingerprint(target)
+	if err != nil {
+		return "", fmt.Errorf("workflow target fingerprint: %w", err)
+	}
+	scope := strings.Join([]string{
+		"gestalt.workflow.run.signal_or_start.ref.v2",
+		strings.TrimSpace(providerName),
+		strings.TrimSpace(workflowKey),
+		strings.TrimSpace(principalSubjectID(p)),
+		strings.TrimSpace(principal.EffectiveCredentialSubjectID(p)),
+		strings.TrimSpace(callerPluginName),
+		targetFingerprint,
+		executionRefPermissionsScope(permissions),
+	}, "\x00")
+	return runExecutionRefID(uuid.NewSHA1(uuid.NameSpaceURL, []byte(scope)).String()), nil
+}
+
+func executionRefPermissionsScope(permissions []core.AccessPermission) string {
+	if permissions == nil {
+		return "nil"
+	}
+	if len(permissions) == 0 {
+		return "empty"
+	}
+	var b strings.Builder
+	b.WriteString("set\x1f")
+	wrote := false
+	for _, permission := range permissions {
+		plugin := strings.TrimSpace(permission.Plugin)
+		if plugin == "" {
+			continue
+		}
+		wrote = true
+		b.WriteString(plugin)
+		b.WriteByte('\x1e')
+		operations := append([]string(nil), permission.Operations...)
+		sort.Strings(operations)
+		for _, operation := range operations {
+			operation = strings.TrimSpace(operation)
+			if operation == "" {
+				continue
+			}
+			b.WriteString(operation)
+			b.WriteByte('\x1d')
+		}
+		b.WriteByte('\x1e')
+		actions := append([]string(nil), permission.Actions...)
+		sort.Strings(actions)
+		for _, action := range actions {
+			action = strings.TrimSpace(action)
+			if action == "" {
+				continue
+			}
+			b.WriteString(action)
+			b.WriteByte('\x1d')
+		}
+		b.WriteByte('\x1f')
+	}
+	if !wrote {
+		return "empty"
+	}
+	return b.String()
 }
 
 func (m *Manager) managedSignalResponse(ctx context.Context, p *principal.Principal, providerName string, provider coreworkflow.Provider, resp *coreworkflow.SignalRunResponse, candidateRef *coreworkflow.ExecutionReference, targetPrincipalSource signalTargetPrincipalSource) (*ManagedRunSignal, error) {

--- a/gestaltd/internal/workflowmanager/manager_test.go
+++ b/gestaltd/internal/workflowmanager/manager_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestSignalOrStartRunExecutionRefInheritsDeclaredAgentToolInvokes(t *testing.T) {
@@ -90,6 +92,291 @@ func TestSignalOrStartRunExecutionRefInheritsDeclaredAgentToolInvokes(t *testing
 	}
 	if got := managed.ExecutionRef.Target.Agent.OutputDelivery.CredentialMode; got != core.ConnectionModeNone {
 		t.Fatalf("output delivery credential mode = %q, want %q", got, core.ConnectionModeNone)
+	}
+}
+
+func TestSignalOrStartRunReusesExecutionRefForSameWorkflowKeyAndTarget(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWorkflowProvider()
+	manager := New(Config{
+		Workflow:     testWorkflowControl{provider: provider},
+		Agent:        testAgentControl{},
+		AgentManager: testAgentManager{},
+	})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID: "system:http_binding:github:event",
+	})
+	req := RunSignalOrStart{
+		ProviderName:     "local",
+		WorkflowKey:      "github:99:acme/widgets:7",
+		CallerPluginName: "github",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "simple",
+			Prompt:       "Handle the webhook.",
+		}},
+		Signal: coreworkflow.Signal{Name: "github.app.webhook"},
+	}
+
+	first, err := manager.SignalOrStartRun(context.Background(), caller, req)
+	if err != nil {
+		t.Fatalf("SignalOrStartRun(first): %v", err)
+	}
+	second, err := manager.SignalOrStartRun(context.Background(), caller, req)
+	if err != nil {
+		t.Fatalf("SignalOrStartRun(second): %v", err)
+	}
+	if first.ExecutionRef.ID == "" {
+		t.Fatal("first execution ref ID is empty")
+	}
+	if second.ExecutionRef.ID != first.ExecutionRef.ID {
+		t.Fatalf("execution ref ID changed from %q to %q", first.ExecutionRef.ID, second.ExecutionRef.ID)
+	}
+	if len(provider.refs) != 1 {
+		t.Fatalf("execution refs stored = %d, want 1", len(provider.refs))
+	}
+}
+
+func TestSignalOrStartRunRejectsDeniedExecutionRefPermissionsBeforeEnqueue(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWorkflowProvider()
+	manager := New(Config{
+		Workflow:     testWorkflowControl{provider: provider},
+		Agent:        testAgentControl{},
+		AgentManager: testAgentManager{},
+	})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID: "system:http_binding:github:event",
+	})
+	req := RunSignalOrStart{
+		ProviderName:     "local",
+		WorkflowKey:      "github:99:acme/widgets:7",
+		CallerPluginName: "github",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "simple",
+			Prompt:       "Handle the webhook.",
+			ToolRefs: []coreagent.ToolRef{
+				{Plugin: "github", Operation: "bot.admin"},
+			},
+		}},
+		Signal: coreworkflow.Signal{Name: "github.app.webhook"},
+	}
+
+	if _, err := manager.SignalOrStartRun(context.Background(), caller, req); err != nil {
+		t.Fatalf("SignalOrStartRun(unrestricted): %v", err)
+	}
+	denyAll := principal.Canonicalize(&principal.Principal{
+		SubjectID:        caller.SubjectID,
+		TokenPermissions: principal.PermissionSet{},
+	})
+	_, err := manager.SignalOrStartRun(context.Background(), denyAll, req)
+	if !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("SignalOrStartRun(deny-all) error = %v, want not found from unauthorized target", err)
+	}
+	if provider.signalOrStartCalls != 1 {
+		t.Fatalf("SignalOrStartRun provider calls = %d, want 1", provider.signalOrStartCalls)
+	}
+}
+
+func TestSignalOrStartRunFailureDoesNotRevokeStableExecutionRef(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWorkflowProvider()
+	manager := New(Config{
+		Workflow:     testWorkflowControl{provider: provider},
+		Agent:        testAgentControl{},
+		AgentManager: testAgentManager{},
+	})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID: "system:http_binding:github:event",
+	})
+	req := RunSignalOrStart{
+		ProviderName:     "local",
+		WorkflowKey:      "github:99:acme/widgets:7",
+		CallerPluginName: "github",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "simple",
+			Prompt:       "Handle the webhook.",
+		}},
+		Signal: coreworkflow.Signal{Name: "github.app.webhook"},
+	}
+
+	first, err := manager.SignalOrStartRun(context.Background(), caller, req)
+	if err != nil {
+		t.Fatalf("SignalOrStartRun(first): %v", err)
+	}
+	if first.ExecutionRef == nil || first.ExecutionRef.ID == "" {
+		t.Fatalf("first execution ref = %#v, want stable ref", first.ExecutionRef)
+	}
+
+	provider.signalOrStartErr = errors.New("transient provider failure")
+	_, err = manager.SignalOrStartRun(context.Background(), caller, req)
+	if !errors.Is(err, provider.signalOrStartErr) {
+		t.Fatalf("SignalOrStartRun(second) error = %v, want %v", err, provider.signalOrStartErr)
+	}
+
+	stored := provider.refs[first.ExecutionRef.ID]
+	if stored == nil {
+		t.Fatalf("execution ref %q was removed", first.ExecutionRef.ID)
+	}
+	if stored.RevokedAt != nil {
+		t.Fatalf("execution ref RevokedAt = %v, want nil", stored.RevokedAt)
+	}
+}
+
+func TestSignalOrStartRunFirstFailureKeepsStableExecutionRef(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWorkflowProvider()
+	manager := New(Config{
+		Workflow:     testWorkflowControl{provider: provider},
+		Agent:        testAgentControl{},
+		AgentManager: testAgentManager{},
+	})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID: "system:http_binding:github:event",
+	})
+	req := RunSignalOrStart{
+		ProviderName:     "local",
+		WorkflowKey:      "github:99:acme/widgets:7",
+		CallerPluginName: "github",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "simple",
+			Prompt:       "Handle the webhook.",
+		}},
+		Signal: coreworkflow.Signal{Name: "github.app.webhook"},
+	}
+
+	provider.signalOrStartErr = errors.New("transient provider failure")
+	_, err := manager.SignalOrStartRun(context.Background(), caller, req)
+	if !errors.Is(err, provider.signalOrStartErr) {
+		t.Fatalf("SignalOrStartRun error = %v, want %v", err, provider.signalOrStartErr)
+	}
+	if len(provider.refs) != 1 {
+		t.Fatalf("execution refs stored = %d, want 1", len(provider.refs))
+	}
+	for id, ref := range provider.refs {
+		if ref.RevokedAt != nil {
+			t.Fatalf("execution ref %q RevokedAt = %v, want nil", id, ref.RevokedAt)
+		}
+	}
+}
+
+func TestSignalOrStartRunCreatesExecutionRefAfterGRPCNotFound(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWorkflowProvider()
+	provider.getMissingExecutionReferenceErr = status.Error(codes.NotFound, "missing")
+	manager := New(Config{
+		Workflow:     testWorkflowControl{provider: provider},
+		Agent:        testAgentControl{},
+		AgentManager: testAgentManager{},
+	})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID: "system:http_binding:github:event",
+	})
+
+	managed, err := manager.SignalOrStartRun(context.Background(), caller, RunSignalOrStart{
+		ProviderName:     "local",
+		WorkflowKey:      "github:99:acme/widgets:7",
+		CallerPluginName: "github",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "simple",
+			Prompt:       "Handle the webhook.",
+		}},
+		Signal: coreworkflow.Signal{Name: "github.app.webhook"},
+	})
+	if err != nil {
+		t.Fatalf("SignalOrStartRun: %v", err)
+	}
+	if managed == nil || managed.ExecutionRef == nil {
+		t.Fatalf("managed signal = %#v, want execution ref", managed)
+	}
+	if provider.putExecutionReferenceCalls != 1 {
+		t.Fatalf("PutExecutionReference calls = %d, want 1", provider.putExecutionReferenceCalls)
+	}
+}
+
+func TestSignalOrStartRunDoesNotRewriteExecutionRefForDifferentPermissions(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWorkflowProvider()
+	manager := New(Config{
+		Workflow:     testWorkflowControl{provider: provider},
+		Agent:        testAgentControl{},
+		AgentManager: testAgentManager{},
+	})
+	initialPermissions := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "github",
+		Operations: []string{"events.handle"},
+	}})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID:        "system:http_binding:github:event",
+		TokenPermissions: initialPermissions,
+		Scopes:           principal.PermissionPlugins(initialPermissions),
+	})
+	req := RunSignalOrStart{
+		ProviderName:     "local",
+		WorkflowKey:      "github:99:acme/widgets:7",
+		CallerPluginName: "github",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "simple",
+			Prompt:       "Handle the webhook.",
+		}},
+		Signal: coreworkflow.Signal{Name: "github.app.webhook"},
+	}
+
+	first, err := manager.SignalOrStartRun(context.Background(), caller, req)
+	if err != nil {
+		t.Fatalf("SignalOrStartRun(first): %v", err)
+	}
+	stored := provider.refs[first.ExecutionRef.ID]
+	if stored == nil {
+		t.Fatalf("execution ref %q was not stored", first.ExecutionRef.ID)
+	}
+	initialRefPermissions := stored.Permissions
+	putCalls := provider.putExecutionReferenceCalls
+
+	broaderPermissions := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "github",
+		Operations: []string{"events.handle", "bot.admin"},
+	}})
+	broaderCaller := principal.Canonicalize(&principal.Principal{
+		SubjectID:        caller.SubjectID,
+		TokenPermissions: broaderPermissions,
+		Scopes:           principal.PermissionPlugins(broaderPermissions),
+	})
+	provider.signalOrStartErr = errors.New("transient provider failure")
+	_, err = manager.SignalOrStartRun(context.Background(), broaderCaller, req)
+	if !errors.Is(err, provider.signalOrStartErr) {
+		t.Fatalf("SignalOrStartRun(second) error = %v, want %v", err, provider.signalOrStartErr)
+	}
+	if provider.putExecutionReferenceCalls != putCalls+1 {
+		t.Fatalf("PutExecutionReference calls = %d, want %d", provider.putExecutionReferenceCalls, putCalls+1)
+	}
+	stored = provider.refs[first.ExecutionRef.ID]
+	if !reflect.DeepEqual(stored.Permissions, initialRefPermissions) {
+		t.Fatalf("execution ref permissions = %#v, want original %#v", stored.Permissions, initialRefPermissions)
+	}
+	if stored.RevokedAt != nil {
+		t.Fatalf("execution ref RevokedAt = %v, want nil", stored.RevokedAt)
+	}
+	if len(provider.refs) != 2 {
+		t.Fatalf("execution refs stored = %d, want 2 permission-scoped refs", len(provider.refs))
+	}
+	for id, ref := range provider.refs {
+		if ref.RevokedAt != nil {
+			t.Fatalf("execution ref %q RevokedAt = %v, want nil", id, ref.RevokedAt)
+		}
+	}
+}
+
+func TestExecutionRefPermissionsScopeDistinguishesNilAndEmpty(t *testing.T) {
+	t.Parallel()
+
+	if executionRefPermissionsScope(nil) == executionRefPermissionsScope([]core.AccessPermission{}) {
+		t.Fatal("nil and empty execution ref permissions produced the same scope")
 	}
 }
 
@@ -284,10 +571,14 @@ type testAgentManager struct {
 
 type testWorkflowProvider struct {
 	coreworkflow.Provider
-	refs              map[string]*coreworkflow.ExecutionReference
-	runs              map[string]*coreworkflow.Run
-	schedules         map[string]*coreworkflow.Schedule
-	upsertedSchedules []coreworkflow.UpsertScheduleRequest
+	refs                            map[string]*coreworkflow.ExecutionReference
+	runs                            map[string]*coreworkflow.Run
+	schedules                       map[string]*coreworkflow.Schedule
+	upsertedSchedules               []coreworkflow.UpsertScheduleRequest
+	signalOrStartErr                error
+	signalOrStartCalls              int
+	getMissingExecutionReferenceErr error
+	putExecutionReferenceCalls      int
 }
 
 func newTestWorkflowProvider() *testWorkflowProvider {
@@ -299,6 +590,10 @@ func newTestWorkflowProvider() *testWorkflowProvider {
 }
 
 func (p *testWorkflowProvider) SignalOrStartRun(_ context.Context, req coreworkflow.SignalOrStartRunRequest) (*coreworkflow.SignalRunResponse, error) {
+	p.signalOrStartCalls++
+	if p.signalOrStartErr != nil {
+		return nil, p.signalOrStartErr
+	}
 	run := &coreworkflow.Run{
 		ID:           "run-signaled",
 		Status:       coreworkflow.RunStatusRunning,
@@ -372,6 +667,7 @@ func (p *testWorkflowProvider) GetSchedule(_ context.Context, req coreworkflow.G
 }
 
 func (p *testWorkflowProvider) PutExecutionReference(_ context.Context, ref *coreworkflow.ExecutionReference) (*coreworkflow.ExecutionReference, error) {
+	p.putExecutionReferenceCalls++
 	copied := *ref
 	p.refs[copied.ID] = &copied
 	return &copied, nil
@@ -380,6 +676,9 @@ func (p *testWorkflowProvider) PutExecutionReference(_ context.Context, ref *cor
 func (p *testWorkflowProvider) GetExecutionReference(_ context.Context, id string) (*coreworkflow.ExecutionReference, error) {
 	ref := p.refs[strings.TrimSpace(id)]
 	if ref == nil {
+		if p.getMissingExecutionReferenceErr != nil {
+			return nil, p.getMissingExecutionReferenceErr
+		}
 		return nil, core.ErrNotFound
 	}
 	copied := *ref

--- a/gestaltd/internal/workflowprincipal/principal.go
+++ b/gestaltd/internal/workflowprincipal/principal.go
@@ -12,6 +12,9 @@ func FromExecutionReference(ref *coreworkflow.ExecutionReference) *principal.Pri
 		return nil
 	}
 	compiled := principal.CompilePermissions(ref.Permissions)
+	if ref.Permissions != nil && compiled == nil {
+		compiled = principal.PermissionSet{}
+	}
 	value := &principal.Principal{
 		SubjectID:           strings.TrimSpace(ref.SubjectID),
 		CredentialSubjectID: strings.TrimSpace(ref.CredentialSubjectID),

--- a/gestaltd/internal/workflowprincipal/principal_test.go
+++ b/gestaltd/internal/workflowprincipal/principal_test.go
@@ -1,0 +1,44 @@
+package workflowprincipal
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+func TestFromExecutionReferencePreservesNilPermissionsAsUnrestricted(t *testing.T) {
+	t.Parallel()
+
+	p := FromExecutionReference(&coreworkflow.ExecutionReference{
+		SubjectID: "system:workflow:test",
+	})
+	if p == nil {
+		t.Fatal("principal is nil")
+	}
+	if p.TokenPermissions != nil {
+		t.Fatalf("TokenPermissions = %#v, want nil unrestricted permissions", p.TokenPermissions)
+	}
+	if !principal.AllowsProviderPermission(p, "github") {
+		t.Fatal("nil execution ref permissions should allow provider access")
+	}
+}
+
+func TestFromExecutionReferencePreservesEmptyPermissionsAsDenyAll(t *testing.T) {
+	t.Parallel()
+
+	p := FromExecutionReference(&coreworkflow.ExecutionReference{
+		SubjectID:   "system:workflow:test",
+		Permissions: []core.AccessPermission{},
+	})
+	if p == nil {
+		t.Fatal("principal is nil")
+	}
+	if p.TokenPermissions == nil {
+		t.Fatal("TokenPermissions is nil, want non-nil empty deny-all permissions")
+	}
+	if principal.AllowsProviderPermission(p, "github") {
+		t.Fatal("empty execution ref permissions should deny provider access")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `coreworkflow.TargetFingerprint(target)` for stable target hashes using the same normalized payload as `TargetsEqual`.
- Make `SignalOrStartRun` use deterministic `workflow_run:<sha1>` execution refs scoped by provider, workflow key, principal subject, credential subject, caller plugin, target fingerprint, and computed execution-ref permissions.
- Authorize the resolved target with the computed execution-ref principal before enqueueing, reuse active matching refs without rewriting auth state, and keep SignalOrStart refs durable across enqueue failures instead of revoking shared retry state.
- Preserve nil execution-ref permissions as unrestricted and explicit empty permissions as deny-all in `workflowprincipal.FromExecutionReference`.
- Keep the daemon IndexedDB e2e fixtures aligned with the relational IndexedDB provider source path used by production releases.

## Interfaces

```go
fingerprint, err := coreworkflow.TargetFingerprint(target)
```

```go
managed, err := manager.SignalOrStartRun(ctx, principal, workflowmanager.RunSignalOrStart{
    ProviderName:     "local",
    WorkflowKey:      "github:99:acme/widgets:7",
    CallerPluginName: "github",
    Target:           target,
})
```

`SignalOrStartRun` now reuses the same active execution ref only for the same scoped target and permission set; later signals with different authorization cannot overwrite the active ref permissions or revoked state.

```go
p := workflowprincipal.FromExecutionReference(refWithEmptyPermissions)
// p.TokenPermissions is non-nil and empty, so provider access remains denied.
```

## Validation

- `go test ./internal/workflowmanager ./internal/workflowprincipal`
- `go test ./core/workflow ./internal/workflowmanager ./internal/workflowprincipal`
- `go test ./core/workflow ./internal/workflowmanager ./internal/workflowprincipal ./internal/daemon -run 'TestE2EValidateConfigPathPrecedence|TestE2EValidateAcceptsV3TelemetryBuiltins' -count=1`

## Review

- Addressed Cursor review feedback around preserving stable refs on failed signal enqueue attempts.
- Addressed GPT-5.5 reviewer findings around auth mutation, gRPC NotFound handling, concurrent cleanup races, and nil-vs-empty permission preservation.