### PR TITLE
Fix daemon IndexedDB fixture namespace metadata

### DIFF
--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -1406,9 +1406,9 @@ func setupIndexedDBProviderDir(t *testing.T, baseDir string) string {
 	artifactRel := filepath.Base(binDest)
 	writeManifestFile(t, providerDir, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb-inmem",
+		Source:      "github.com/test/providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
-		DisplayName: "In-Memory IndexedDB",
+		DisplayName: "Relational IndexedDB",
 		Spec:        &providermanifestv1.Spec{},
 		Artifacts: []providermanifestv1.Artifact{
 			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: artifactRel},
@@ -1589,7 +1589,7 @@ func setupDefaultLocalProvidersDir(t *testing.T, baseDir string) string {
 	}
 	writeManifestFile(t, indexedDBDir, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb-relationaldb",
+		Source:      "github.com/test/providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Relational IndexedDB",
 		Spec:        &providermanifestv1.Spec{},

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -182,7 +182,7 @@ func writeDefaultProvidersDir(baseDir string) (string, error) {
 
 	if err := writeComponentProviderDir(filepath.Join(providersDir, "indexeddb", "relationaldb"), indexedDBBin, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindIndexedDB,
-		Source:      "github.com/test/providers/indexeddb-relationaldb",
+		Source:      "github.com/test/providers/indexeddb/relationaldb",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Relational IndexedDB",
 		Spec:        &providermanifestv1.Spec{},


### PR DESCRIPTION
## Summary

Fixes daemon E2E fixture metadata so local IndexedDB provider manifests advertise the namespaceable relational provider source shape expected by scoped IndexedDB bindings.

This unblocks the current `main` daemon E2E failures where workflow/agent scoped bindings fail with:

```text
scoped indexeddb bindings require a provider with config-level namespace support
```

## Interface / Contract

`bootstrap.newScopedIndexedDBDef` recognizes namespace support from provider manifest source paths like:

```go
"github.com/test/providers/indexeddb/relationaldb"
```

The daemon E2E helpers now emit that source while preserving existing config names:

```yaml
server:
  providers:
    indexeddb: inmem
providers:
  indexeddb:
    inmem:
      source:
        path: /tmp/.../manifest.yaml
```

For sqlite-named fixtures, the logical resource name can also stay unchanged:

```yaml
providers:
  indexeddb:
    sqlite:
      source:
        path: /tmp/.../manifest.yaml
      config:
        path: /tmp/.../gestalt.db
```

## Code References

- `gestaltd/internal/daemon/e2e_test.go`: local daemon E2E IndexedDB fixture manifest source
- `gestaltd/internal/daemon/testmain_test.go`: default local providers fixture source
- `gestaltd/internal/bootstrap/provider_build.go`: scoped IndexedDB namespace support detection

## Verification

```bash
go test ./internal/daemon -run 'TestE2EValidateAcceptsV3TelemetryBuiltins/noop' -count=1
go test ./internal/daemon -run 'TestE2EValidateAcceptsV3TelemetryBuiltins|TestE2EValidateAcceptsCanonicalConfigShapes|TestE2EProviderValidateLayeredConfigSupportsNullDeletion|TestE2EServePluginOwnedUIWiring|TestE2EHostedHTTPSubjectResolutionUsesAuthorizationAndInheritedInvocation|TestE2EServeStartsWithPluginBoundCacheProvider' -count=1
go test ./internal/daemon -count=1
git diff --check
```

Reviewed by a separate `gpt-5.5` xhigh agent; no concrete issues were found.