### PR TITLE
Require IndexedDB provider-dev attach state

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -898,9 +898,9 @@ enough, and this action does not grant normal invocation access:
 ```
 `attachmentState: indexeddb` stores attachment metadata and queued provider/UI
 calls in the selected host IndexedDB, so attach traffic can move across
-`gestaltd` replicas. `attachmentState: processLocal` stores attachment state in
-the accepting process only; reserve it for local demos and single-process
-development servers.
+`gestaltd` replicas. Process-local remote attachment state is not exposed as a
+supported server mode because it is unsafe for load-balanced or multi-replica
+servers.
 Remote provider dev uses `--remote-token` first, then `GESTALT_API_KEY` for
 non-interactive direct attach. Stored CLI credentials are intentionally not used
 for direct attach; without an explicit token, the CLI uses browser approval. An

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -98,8 +98,8 @@ plugin implementations for the authenticated principal that created the session.
 The remote server must opt in with `server.dev.attachmentState`; otherwise the
 command fails before local code is attached. Use `attachmentState: indexeddb` on
 shared or load-balanced servers so attachment metadata and queued provider calls
-are stored in the configured host IndexedDB. `attachmentState: processLocal` is
-available only for local demos and single-process development servers.
+are stored in the configured host IndexedDB. Process-local remote attachment
+state is not a supported server mode.
 For the interactive happy path, `provider dev --remote` creates a short-lived
 attach approval request and opens the remote server in your browser. Approving
 that page with your normal browser session creates an owner-scoped attachment

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -172,7 +172,7 @@ Plugins without `authorizationPolicy` are open to any authenticated subject. Bin
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared artifacts produced by `gestaltd sync --locked`. |
 | `providers.audit` / `providers.authentication` / `providers.authorization` / `providers.indexeddb` / `providers.secrets` / `providers.telemetry` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
-| `dev.attachmentState` | | Enables private remote provider-dev attach routes and selects where attachment state is stored. Use `indexeddb` for shared or load-balanced servers. Use `processLocal` only for local demos and single-process development servers. |
+| `dev.attachmentState` | | Enables private remote provider-dev attach routes and selects where attachment state is stored. The only supported value is `indexeddb`, which stores attachment state in the configured host IndexedDB for shared and load-balanced servers. |
 | `runtime.defaultHostedProvider` | | Default runtime-provider selector for plugins that opt into `execution.mode: hosted`. This does not move plugins into hosted runtimes by itself. |
 | `admin.authorizationPolicy` | | Shared subject access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
@@ -1122,9 +1122,9 @@ URLs.
 `attachmentState: indexeddb` stores attachment metadata and queued provider/UI
 calls in the selected host IndexedDB, so any `gestaltd` replica can accept
 attach creation, CLI poll/complete traffic, provider invocations, and
-provider-owned UI requests. `attachmentState: processLocal` stores the same
-state in this process only; reserve it for local demos and single-process
-development servers.
+provider-owned UI requests. Process-local attachment state is not exposed as a
+server config mode because it is unsafe for load-balanced or multi-replica
+servers.
 
 Interactive attach creation uses a short-lived browser approval page plus a
 verification code shown in the initiating terminal. The approving browser

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1408,10 +1408,7 @@ type DevConfig struct {
 
 type DevAttachmentState string
 
-const (
-	DevAttachmentStateProcessLocal DevAttachmentState = "processLocal"
-	DevAttachmentStateIndexedDB    DevAttachmentState = "indexeddb"
-)
+const DevAttachmentStateIndexedDB DevAttachmentState = "indexeddb"
 
 type ServerRuntimeConfig struct {
 	DefaultHostedProvider string `yaml:"defaultHostedProvider,omitempty"`

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -153,13 +153,13 @@ server:
 			wantErr: `server.dev.attachmentState "sharedRelay" is not supported`,
 		},
 		{
-			name: "process local remote attach",
+			name: "process local attachment state is rejected",
 			yaml: `
 server:
   dev:
     attachmentState: processLocal
 `,
-			wantState: DevAttachmentStateProcessLocal,
+			wantErr: `server.dev.attachmentState "processLocal" is not supported`,
 		},
 		{
 			name: "indexeddb remote attach",

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -156,10 +156,10 @@ func validateProviderDevConfig(cfg *Config) error {
 	state := DevAttachmentState(strings.TrimSpace(string(cfg.Server.Dev.AttachmentState)))
 	cfg.Server.Dev.AttachmentState = state
 	switch state {
-	case "", DevAttachmentStateProcessLocal, DevAttachmentStateIndexedDB:
+	case "", DevAttachmentStateIndexedDB:
 		return nil
 	default:
-		return fmt.Errorf("config validation: server.dev.attachmentState %q is not supported; use %q or %q", state, DevAttachmentStateProcessLocal, DevAttachmentStateIndexedDB)
+		return fmt.Errorf("config validation: server.dev.attachmentState %q is not supported; use %q", state, DevAttachmentStateIndexedDB)
 	}
 }
 

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -484,7 +484,7 @@ func providerRemoteCreateSessionError(err error) error {
 	}
 	return fmt.Errorf(`%w
 
-remote provider-dev attach was denied. The remote plugin must grant providerDev.attach.allowedRoles for your resolved role, and API token callers must use a user token with permissions[].actions including provider_dev.attach for every attached plugin.
+remote provider-dev attach was denied. The remote plugin must grant dev.attach.allowedRoles for your resolved role, and API token callers must use a user token with permissions[].actions including provider_dev.attach for every attached plugin.
 
 provider scopes, operation permissions, and subject-owned API tokens do not grant direct remote attach. Run without --remote-token/%s to use browser approval when the server supports it`, err, gestaltAPIKeyEnv)
 }

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -148,7 +148,7 @@ func TestProviderRemoteCreateSessionErrorAddsAttachPermissionGuidance(t *testing
 	}
 	for _, want := range []string{
 		"remote provider-dev attach was denied",
-		"providerDev.attach.allowedRoles",
+		"dev.attach.allowedRoles",
 		"permissions[].actions including provider_dev.attach",
 		"browser approval",
 	} {


### PR DESCRIPTION
## Summary

Remote provider-dev attach now exposes only one supported server config mode:

```yaml
server:
  dev:
    attachmentState: indexeddb
```

`server.dev.attachmentState: processLocal` is now rejected during config validation instead of being documented as a local-demo/single-process option. This keeps the product surface aligned with the multi-replica requirement: remote attach state must live in the configured host IndexedDB, not in one `gestaltd` process.

This also updates CLI/provider docs and the remote attach denial guidance to point users at the current plugin opt-in surface:

```yaml
plugins:
  slack:
    authorizationPolicy: provider_devs
    dev:
      attach:
        allowedRoles:
          - developer
```

## Examples

Valid server opt-in:

```yaml
server:
  dev:
    attachmentState: indexeddb
```

Invalid server opt-in:

```yaml
server:
  dev:
    attachmentState: processLocal
```

The invalid form now fails with:

```text
server.dev.attachmentState "processLocal" is not supported; use "indexeddb"
```

## Verification

```sh
go test ./internal/config ./internal/daemon ./internal/bootstrap ./internal/server ./internal/providerdev -count=1
golangci-lint run ./...
```