### PR TITLE
[gestaltd] default httpbin to alpha2 

### DIFF
--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -15,7 +15,7 @@ const (
 	localConfigDirName = ".gestaltd"
 
 	defaultHTTPBinProvider = config.DefaultProviderRepo + "/plugins/httpbin"
-	defaultHTTPBinVersion  = "0.0.1-alpha.1"
+	defaultHTTPBinVersion  = "0.0.1-alpha.2"
 )
 
 func DefaultLocalConfigPath() string {


### PR DESCRIPTION
Updates the generated default gestaltd config to use the republished HTTPBin provider release with current manifest metadata.

