### PR TITLE
Remove IndexedDB hyphenated provider fallback

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -2362,26 +2362,22 @@ func isIndexedDBProviderEntry(entry *config.ProviderEntry, providerName string) 
 		return false
 	}
 	providerPath := "/indexeddb/" + providerName
-	legacyProviderPath := "/indexeddb-" + providerName
 	if entry.ResolvedManifest != nil {
 		source := strings.TrimSpace(filepath.ToSlash(entry.ResolvedManifest.Source))
-		return strings.HasSuffix(source, providerPath) || strings.HasSuffix(source, legacyProviderPath)
+		return strings.HasSuffix(source, providerPath)
 	}
 	if metadataURL := strings.TrimSpace(entry.SourceMetadataURL()); metadataURL != "" {
 		parsed, err := url.Parse(metadataURL)
 		if err == nil {
 			path := filepath.ToSlash(parsed.Path)
-			return (strings.Contains(path, providerPath+"/") || strings.Contains(path, legacyProviderPath+"/")) &&
-				strings.HasSuffix(path, "/provider-release.yaml")
+			return strings.Contains(path, providerPath+"/") && strings.HasSuffix(path, "/provider-release.yaml")
 		}
 	}
 	if path := strings.TrimSpace(entry.SourcePath()); path != "" {
 		path = filepath.ToSlash(path)
 		return strings.HasSuffix(path, providerPath) ||
-			strings.HasSuffix(path, legacyProviderPath) ||
 			strings.HasSuffix(path, "/"+providerName) ||
 			strings.HasSuffix(path, providerPath+"/manifest.yaml") ||
-			strings.HasSuffix(path, legacyProviderPath+"/manifest.yaml") ||
 			strings.HasSuffix(path, "/"+providerName+"/manifest.yaml")
 	}
 	return false


### PR DESCRIPTION
## Summary
- remove the legacy `indexeddb-<provider>` source-path fallback used when recognizing IndexedDB providers for scoped bindings
- keep support for the canonical provider paths, for example `/indexeddb/relationaldb`, `/indexeddb/mongodb`, and `/indexeddb/dynamodb`

## Interface / Behavior Diff
```diff
- source: github.com/valon-technologies/gestalt-providers/indexeddb-relationaldb
- source: https://.../indexeddb-relationaldb/.../provider-release.yaml
+ source: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+ source: https://.../indexeddb/relationaldb/.../provider-release.yaml
```

Example canonical config remains unchanged:
```yaml
providers:
  indexeddb:
    local:
      source: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
```

## Validation
- `go test ./internal/bootstrap -run 'Test(PluginIndexedDBBuildScopedConfig|PluginIndexedDBInheritsHostSelectionAndDefaultDBName|BootstrapPassesIndexedDBHostSocketToWorkflowProviders|BootstrapPassesIndexedDBHostSocketToAgentProviders|BootstrapPassesIndexedDBHostSocketsToAuthorizationProviders|BootstrapClosesWorkflowIndexedDBAndAppliesScopedConfig|BootstrapRoutesExternalCredentialsIndexedDBHostServices|BootstrapRoutesWorkflowIndexedDBHostServices)$'`\n- `go test ./internal/config -run 'TestLoadConfigPluginIndexedDBBindings$'`\n- `go test ./internal/bootstrap ./internal/config`\n- `git diff --check`