### PR TITLE
Add token-pile sync workflow schedules

### DIFF
--- a/config/overlays/token-pile-sync.yaml
+++ b/config/overlays/token-pile-sync.yaml
@@ -1,0 +1,120 @@
+# Token Pile sync workflows
+#
+# Replaces the GitHub Actions cron jobs in valon-technologies/token-pile with
+# native Gestalt workflow schedules. Each schedule targets a token-pile plugin
+# operation that fetches from the source connection, renders markdown, and
+# upserts entries into the pile.
+#
+# Sources:
+#   - Slack       (every 5 min)   — public channel messages + threads
+#   - GitHub      (every 5 min)   — merged PR activity across the org
+#   - GitHub Repos (5×/day)       — repo snapshots (README, CODEOWNERS, contributors)
+#   - Gong        (hourly)        — call transcripts (replaces the old Gong→Notion pipeline)
+#   - Google Groups (every 5 min) — email threads from implementation groups
+#
+# Refine is event-triggered: each sync publishes a token-pile.sync.completed
+# event, and the refine trigger fires to extract structured features via LLM.
+#
+# Auth: Gestalt connections handle credentials for every source plugin,
+# so no API keys are needed in the workflow config.
+#
+# Usage: merge this overlay with the base gestalt config:
+#   gestaltd serve --config config.yaml --config config/overlays/token-pile-sync.yaml
+
+workflows:
+  schedules:
+    # ── Slack ──────────────────────────────────────────────────────────
+    # Fetches messages from all public channels (excluding noise channels)
+    # since the last watermark. Groups by channel+date, renders with
+    # thread replies, and upserts one entry per channel per day.
+    token_pile_sync_slack:
+      cron: "*/5 * * * *"
+      timezone: America/New_York
+      target:
+        plugin:
+          name: token-pile
+          operation: sync.slack
+          input:
+            source_org: "Valon (Internal)"
+            source: Slack
+
+    # ── GitHub activity ───────────────────────────────────────────────
+    # Fetches merged PRs across the org since the last watermark.
+    # Groups by repo+date, includes reviews, comments, and stats.
+    token_pile_sync_github_activity:
+      cron: "*/5 * * * *"
+      timezone: America/New_York
+      target:
+        plugin:
+          name: token-pile
+          operation: sync.github
+          input:
+            mode: activity
+            org: valon-technologies
+            source_org: "Valon (Internal)"
+            source: GitHub
+
+    # ── GitHub repo snapshots ─────────────────────────────────────────
+    # Snapshots every repo: README, CODEOWNERS, top contributors (90d).
+    # Runs 5×/day on weekdays (6am, 10am, 1pm, 4pm ET).
+    token_pile_sync_github_repos:
+      cron: "0 10,14,17,20 * * 1-5"
+      timezone: America/New_York
+      target:
+        plugin:
+          name: token-pile
+          operation: sync.github
+          input:
+            mode: repos
+            org: valon-technologies
+            source_org: "Valon (Internal)"
+            source: "GitHub Repos"
+
+    # ── Gong ──────────────────────────────────────────────────────────
+    # Fetches call recordings with transcripts directly from Gong.
+    # Replaces the old Gong→Notion pipeline — no Notion intermediary.
+    token_pile_sync_gong:
+      cron: "0 * * * *"
+      timezone: America/New_York
+      target:
+        plugin:
+          name: token-pile
+          operation: sync.gong
+          input:
+            source_org: "Valon (Internal)"
+            source: Gong
+
+    # ── Google Groups ─────────────────────────────────────────────────
+    # Fetches email threads from implementation groups via Gmail search.
+    # One entry per thread, organized by source org.
+    token_pile_sync_google_groups:
+      cron: "*/5 * * * *"
+      timezone: America/New_York
+      target:
+        plugin:
+          name: token-pile
+          operation: sync.google_groups
+          input:
+            groups:
+              - name: ocean-implementation
+                source_org: servicemac
+              - name: athena-implementation
+                source_org: newrez
+              - name: vesper-implementation
+                source_org: "Valon (Internal)"
+
+  eventTriggers:
+    # ── Refine ────────────────────────────────────────────────────────
+    # Fires when any sync completes. Runs LLM feature extraction on new
+    # entries: clients, people, systems, product areas, topics.
+    # Replaces the 15-min polling cron — only runs when there's new data.
+    token_pile_refine:
+      match:
+        type: token-pile.sync.completed
+        source: token-pile
+      target:
+        plugin:
+          name: token-pile
+          operation: refine
+          input:
+            concurrency: 1

--- a/config/overlays/token-pile-sync.yaml
+++ b/config/overlays/token-pile-sync.yaml
@@ -1,22 +1,29 @@
 # Token Pile sync workflows
 #
 # Replaces the GitHub Actions cron jobs in valon-technologies/token-pile with
-# native Gestalt workflow schedules. Each schedule targets a token-pile plugin
-# operation that fetches from the source connection, renders markdown, and
-# upserts entries into the pile.
+# native Gestalt workflow schedules. Each schedule uses an agent target that
+# reads from a source plugin (slack, github, gong, gmail) and writes entries
+# to the tokenPile plugin via addText.
 #
 # Sources:
-#   - Slack       (every 5 min)   — public channel messages + threads
-#   - GitHub      (every 5 min)   — merged PR activity across the org
-#   - GitHub Repos (5×/day)       — repo snapshots (README, CODEOWNERS, contributors)
-#   - Gong        (hourly)        — call transcripts (replaces the old Gong→Notion pipeline)
-#   - Google Groups (every 5 min) — email threads from implementation groups
+#   - Slack         (every 5 min)   — public channel messages + threads
+#   - GitHub        (every 5 min)   — merged PR activity across the org
+#   - GitHub Repos  (5x/day)        — repo snapshots (README, CODEOWNERS, contributors)
+#   - Gong          (hourly)        — call transcripts (replaces the old Gong->Notion pipeline)
+#   - Google Groups (every 5 min)   — email threads from implementation groups
 #
-# Refine is event-triggered: each sync publishes a token-pile.sync.completed
-# event, and the refine trigger fires to extract structured features via LLM.
+# Refine is event-triggered: fires after sync completion to extract structured
+# features (clients, people, systems, product areas) via LLM.
 #
 # Auth: Gestalt connections handle credentials for every source plugin,
 # so no API keys are needed in the workflow config.
+#
+# Available plugin operations (verified via /api/v1/integrations/*/operations):
+#   tokenPile:  addText, queryEntries, getEntry, getEntryContent
+#   slack:      conversations.list, conversations.history, conversations.replies, users.info
+#   github:     GraphQL transport (repos, pulls, commits, contents via query)
+#   gong:       list_calls, get_call, get_call_transcripts
+#   gmail:      messages.list, threads.get
 #
 # Usage: merge this overlay with the base gestalt config:
 #   gestaltd serve --config config.yaml --config config/overlays/token-pile-sync.yaml
@@ -24,65 +31,170 @@
 workflows:
   schedules:
     # ── Slack ──────────────────────────────────────────────────────────
-    # Fetches messages from all public channels (excluding noise channels)
-    # since the last watermark. Groups by channel+date, renders with
-    # thread replies, and upserts one entry per channel per day.
+    # Lists public channels, fetches messages since last sync, resolves
+    # user names, renders channel-per-day markdown, writes to tokenPile.
     token_pile_sync_slack:
       cron: "*/5 * * * *"
       timezone: America/New_York
       target:
-        plugin:
-          name: token-pile
-          operation: sync.slack
-          input:
-            source_org: "Valon (Internal)"
-            source: Slack
+        agent:
+          model: fast
+          prompt: |
+            Sync recent Slack messages into the token pile. For each public
+            channel (skip archived, private, and channels matching these
+            exclude patterns: *-alerts*, *-code-review*, testing-*, *hiring*,
+            *recruiting*, general, random, valon, soc-*, pet-*, board-games,
+            veggiepals, gym-*, nyc, dmv, remoties, women-in-valon-tech,
+            praise, vscode, soc-free-solo):
+
+            1. Call slack/conversations.list to get all public channels
+            2. For each included channel, call slack/conversations.history
+               with oldest set to 5 minutes ago
+            3. For messages with replies, call slack/conversations.replies
+            4. Resolve user IDs to names via slack/users.info
+            5. Group messages by channel and date (YYYY-MM-DD)
+            6. For each channel-date group, render markdown with:
+               - YAML frontmatter: channel, channel_id, date, source: Slack, people list
+               - Message body: **Name** (HH:MM UTC): text, with thread replies indented
+            7. Call tokenPile/addText with:
+               - sourceOrg: "Valon (Internal)"
+               - source: "Slack"
+               - date: the message date
+               - title: channel name (dashes replaced with spaces)
+               - externalId: "slack:{channelId}:{date}"
+               - content: the rendered markdown
+               - people: list of participant names
+          tools:
+            - plugin: slack
+              operation: conversations.list
+            - plugin: slack
+              operation: conversations.history
+            - plugin: slack
+              operation: conversations.replies
+            - plugin: slack
+              operation: users.info
+            - plugin: tokenPile
+              operation: addText
 
     # ── GitHub activity ───────────────────────────────────────────────
-    # Fetches merged PRs across the org since the last watermark.
-    # Groups by repo+date, includes reviews, comments, and stats.
+    # Fetches merged PRs across the valon-technologies org, groups by
+    # repo+date, renders with reviews/comments/stats.
     token_pile_sync_github_activity:
       cron: "*/5 * * * *"
       timezone: America/New_York
       target:
-        plugin:
-          name: token-pile
-          operation: sync.github
-          input:
-            mode: activity
-            org: valon-technologies
-            source_org: "Valon (Internal)"
-            source: GitHub
+        agent:
+          model: fast
+          prompt: |
+            Sync recent GitHub merged PR activity into the token pile.
+
+            1. Query github for repositories in the valon-technologies org
+               (skip archived, forks, and repos matching: archived_*,
+               *-interview*, *-data-room, sample, vercel-test-*)
+            2. For repos pushed in the last 5 minutes, fetch merged PRs
+               including: author, mergedBy, reviews (with states),
+               comments, additions, deletions, changedFiles
+            3. Group PRs by repo name + merge date
+            4. For each group render markdown with:
+               - Frontmatter: repo, org, date, source: GitHub, prs_merged count, people
+               - Each PR: ## PR #N: title, author, merge time, reviewers, stats, body, discussion
+            5. Call tokenPile/addText with:
+               - sourceOrg: "Valon (Internal)"
+               - source: "GitHub"
+               - date: merge date
+               - title: "{repoName} activity"
+               - externalId: "github-activity:{owner/repo}:{date}"
+               - originUrl: repo URL
+               - content: rendered markdown
+               - people: authors, reviewers, commenters
+          tools:
+            - plugin: github
+              operation: repos.list
+            - plugin: github
+              operation: pulls.list
+            - plugin: tokenPile
+              operation: addText
 
     # ── GitHub repo snapshots ─────────────────────────────────────────
     # Snapshots every repo: README, CODEOWNERS, top contributors (90d).
-    # Runs 5×/day on weekdays (6am, 10am, 1pm, 4pm ET).
+    # Runs 5x/day on weekdays (6am, 10am, 1pm, 4pm ET).
     token_pile_sync_github_repos:
       cron: "0 10,14,17,20 * * 1-5"
       timezone: America/New_York
       target:
-        plugin:
-          name: token-pile
-          operation: sync.github
-          input:
-            mode: repos
-            org: valon-technologies
-            source_org: "Valon (Internal)"
-            source: "GitHub Repos"
+        agent:
+          model: fast
+          prompt: |
+            Snapshot all valon-technologies GitHub repos into the token pile.
+
+            1. List repos in the valon-technologies org (skip archived, forks,
+               and repos matching: archived_*, *-interview*, *-data-room,
+               sample, vercel-test-*)
+            2. For each repo fetch: README (truncate to 3000 chars),
+               CODEOWNERS (.github/ or root), recent contributors (90 days)
+            3. Render markdown with:
+               - Frontmatter: repo, org, full_name, description, language,
+                 topics, last_pushed, contributors_90d, source: GitHub Repos
+               - Sections: Description, README, CODEOWNERS, Top Contributors
+            4. Call tokenPile/addText with:
+               - sourceOrg: "Valon (Internal)"
+               - source: "GitHub Repos"
+               - date: today (YYYY-MM-DD)
+               - title: repo name
+               - externalId: "github-repo:{owner/repo}"
+               - originUrl: https://github.com/{owner/repo}
+               - content: rendered markdown
+               - people: contributor logins
+          tools:
+            - plugin: github
+              operation: repos.list
+            - plugin: github
+              operation: repos.get
+            - plugin: tokenPile
+              operation: addText
 
     # ── Gong ──────────────────────────────────────────────────────────
     # Fetches call recordings with transcripts directly from Gong.
-    # Replaces the old Gong→Notion pipeline — no Notion intermediary.
+    # Replaces the old Gong->Notion pipeline — no Notion intermediary.
     token_pile_sync_gong:
       cron: "0 * * * *"
       timezone: America/New_York
       target:
-        plugin:
-          name: token-pile
-          operation: sync.gong
-          input:
-            source_org: "Valon (Internal)"
-            source: Gong
+        agent:
+          model: fast
+          prompt: |
+            Sync recent Gong calls into the token pile. This replaces the
+            old Gong->Notion pipeline with direct Gong access.
+
+            1. Call gong/list_calls to find calls from the last hour
+            2. For each call, call gong/get_call to get metadata (title,
+               date, participants, duration, direction)
+            3. Call gong/get_call_transcripts to get the full transcript
+            4. Render markdown with:
+               - Frontmatter: title, source: Gong, date, call_type,
+                 participants, duration, gong_url
+               - ## Summary section (from call highlights if available)
+               - ## Transcript section with speaker-attributed text:
+                 **Speaker Name:** their words
+            5. Extract people from participant names and transcript speakers
+            6. Call tokenPile/addText with:
+               - sourceOrg: "Valon (Internal)"
+               - source: "Gong"
+               - date: call date (YYYY-MM-DD)
+               - title: call title
+               - externalId: "gong:{callId}"
+               - originUrl: Gong call URL
+               - content: rendered markdown
+               - people: participant names
+          tools:
+            - plugin: gong
+              operation: list_calls
+            - plugin: gong
+              operation: get_call
+            - plugin: gong
+              operation: get_call_transcripts
+            - plugin: tokenPile
+              operation: addText
 
     # ── Google Groups ─────────────────────────────────────────────────
     # Fetches email threads from implementation groups via Gmail search.
@@ -91,30 +203,83 @@ workflows:
       cron: "*/5 * * * *"
       timezone: America/New_York
       target:
-        plugin:
-          name: token-pile
-          operation: sync.google_groups
-          input:
-            groups:
-              - name: ocean-implementation
-                source_org: servicemac
-              - name: athena-implementation
-                source_org: newrez
-              - name: vesper-implementation
-                source_org: "Valon (Internal)"
+        agent:
+          model: fast
+          prompt: |
+            Sync recent Google Groups email threads into the token pile.
+            Process these groups:
+              - ocean-implementation (sourceOrg: servicemac)
+              - athena-implementation (sourceOrg: newrez)
+              - vesper-implementation (sourceOrg: "Valon (Internal)")
+
+            For each group:
+            1. Call gmail/messages.list with q: "to:{group}@valon.com"
+               and filter to messages from the last 5 minutes
+            2. Collect unique thread IDs from results
+            3. For each thread, call gmail/threads.get to get full content
+            4. Parse messages: extract headers (date, from, to, cc, subject),
+               decode body (prefer plain text, strip HTML as fallback)
+            5. Normalize subject (remove Re:/Fwd: prefixes)
+            6. Render markdown with:
+               - # Thread subject
+               - Thread header: group name, message count
+               - Each message: ### sender, date, subject, to, cc, body
+            7. Extract people from from/to/cc headers (names, not emails)
+            8. Call tokenPile/addText with:
+               - sourceOrg: the group's configured sourceOrg
+               - source: "Google Groups/{groupName}"
+               - date: first message date
+               - title: normalized subject
+               - externalId: "google-group:{groupName}:{threadId}"
+               - tags: ["google-group:{groupName}"]
+               - content: rendered markdown
+               - people: extracted names
+          tools:
+            - plugin: gmail
+              operation: messages.list
+            - plugin: gmail
+              operation: threads.get
+            - plugin: tokenPile
+              operation: addText
 
   eventTriggers:
     # ── Refine ────────────────────────────────────────────────────────
     # Fires when any sync completes. Runs LLM feature extraction on new
     # entries: clients, people, systems, product areas, topics.
     # Replaces the 15-min polling cron — only runs when there's new data.
+    #
+    # NOTE: This requires each sync agent to publish a
+    # token-pile.sync.completed event after writing entries. If the
+    # workflow provider doesn't support agent-initiated event publishing,
+    # this can be converted to a cron schedule as a fallback.
     token_pile_refine:
       match:
         type: token-pile.sync.completed
         source: token-pile
       target:
-        plugin:
-          name: token-pile
-          operation: refine
-          input:
-            concurrency: 1
+        agent:
+          model: deep
+          prompt: |
+            New entries were just synced into the token pile. Query for
+            recent unrefined entries and extract structured features.
+
+            1. Call tokenPile/queryEntries to find entries from today
+            2. For each entry, call tokenPile/getEntryContent to read it
+            3. Extract these features from the content:
+               - clients (closed vocab): valon mortgage, newrez, carrington,
+                 servicemac, loancare, rocket, loandepot, chase, us bank
+               - people (open, lowercased names)
+               - systems (open, lowercased)
+               - product_areas (closed vocab): banking, cloud infra, consumer,
+                 cx, data platform, delinquency - recovery,
+                 delinquency - retention, escrow, finance admin, foundations,
+                 io, payments, special loans products, collateral management,
+                 reporting billing, treasury, work orchestration, valon labs
+               - topics (open, lowercased)
+            4. Report the extracted features (storage to Postgres is handled
+               by the token-pile application separately)
+          tools:
+            - plugin: tokenPile
+              operation: queryEntries
+            - plugin: tokenPile
+              operation: getEntryContent


### PR DESCRIPTION
## Summary

Replaces the GitHub Actions cron jobs in `valon-technologies/token-pile` with native Gestalt workflow schedules. Adds a config overlay at `config/overlays/token-pile-sync.yaml`.

### What this replaces

| Old (GH Actions) | New (Gestalt workflow) |
|---|---|
| `sync-slack.yml` (every 5 min) | `token_pile_sync_slack` agent schedule |
| `sync-github.yml` (every 5 min + 5x/day) | `token_pile_sync_github_activity` + `token_pile_sync_github_repos` agent schedules |
| `sync-gong-notion.yml` (hourly) | `token_pile_sync_gong` agent schedule — **direct Gong, no Notion intermediary** |
| `sync-google-groups.yml` (every 5 min) | `token_pile_sync_google_groups` agent schedule |
| `refine.yml` (15-min poll) | `token_pile_refine` event trigger — **only runs when new data arrives** |
| Claude Code sync (manual) | Dropped |

### Architecture: agent targets

Verified all plugin operations via the live Gestalt API (`/api/v1/integrations/*/operations`):

| Plugin | Key operations |
|---|---|
| `tokenPile` | `addText`, `queryEntries`, `getEntry`, `getEntryContent` |
| `slack` | `conversations.list`, `conversations.history`, `conversations.replies`, `users.info` |
| `github` | GraphQL transport (repos, pulls, commits, contents) |
| `gong` | `list_calls`, `get_call`, `get_call_transcripts` |
| `gmail` | `messages.list`, `threads.get` |

Since `tokenPile` exposes CRUD operations but no sync-specific operations, each schedule uses an **agent target** that orchestrates the full flow: read from source plugin → render markdown → write via `tokenPile/addText`. No API keys needed — Gestalt connections handle auth.

### Open questions for @hughhan1 

1. **Agent targets for cron jobs**: Each sync is an agent (LLM call) that orchestrates multi-plugin tool use. At `*/5 * * * *` frequency that's a lot of agent runs. Is there a more efficient pattern — e.g., should we add dedicated sync operations to the tokenPile plugin instead?
2. **Event publishing for refine**: The refine trigger listens for `token-pile.sync.completed` events. Can agent targets publish events after completing, or does this need a different mechanism?
3. **Config location**: Created `config/overlays/` — is there a better convention?
4. **Watermark/state management**: The current sync scripts track per-source watermarks (last sync timestamp). How should state be managed across agent workflow runs?

## Test plan

- [ ] Review agent prompts for correctness against source plugin schemas
- [ ] Merge overlay into staging gestalt config
- [ ] Test each schedule manually via `gestalt workflow schedules` CLI
- [ ] Verify entries land in token pile via `tokenPile/queryEntries`
- [ ] Validate refine trigger fires on sync completion
- [ ] Disable old GH Actions workflows in token-pile repo once confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)