### PR TITLE
Add managed subject connection APIs

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -138,12 +138,16 @@ Managed subjects are service-account identities for release bots, service accoun
 | `GET` | `/api/v1/authorization/subjects/{subjectID}/grants` | List plugin authorization grants for the managed subject. |
 | `PUT` | `/api/v1/authorization/subjects/{subjectID}/grants/{plugin}` | Grant a plugin role to the managed subject. Requires managed subject `admin` and the caller must already hold the requested plugin role, or plugin `admin`. |
 | `DELETE` | `/api/v1/authorization/subjects/{subjectID}/grants/{plugin}` | Remove a plugin authorization grant from the managed subject. Requires managed subject `admin`. |
+| `GET` | `/api/v1/authorization/subjects/{subjectID}/integrations` | List plugins with connection state resolved against the managed subject's credential subject. Requires managed subject `viewer`. |
+| `POST` | `/api/v1/authorization/subjects/{subjectID}/auth/start-oauth` | Start a plugin OAuth flow that stores credentials on the managed subject. Requires managed subject `editor`. |
+| `POST` | `/api/v1/authorization/subjects/{subjectID}/auth/connect-manual` | Submit manual plugin credentials for the managed subject. Requires managed subject `editor`. |
+| `DELETE` | `/api/v1/authorization/subjects/{subjectID}/integrations/{name}` | Disconnect one plugin credential from the managed subject. Requires managed subject `editor`. |
 | `GET` | `/api/v1/authorization/subjects/{subjectID}/tokens` | List API tokens owned by the managed subject. |
 | `POST` | `/api/v1/authorization/subjects/{subjectID}/tokens` | Create a subject-owned API token. Plaintext is returned once. Requires managed subject `admin`. |
 | `DELETE` | `/api/v1/authorization/subjects/{subjectID}/tokens/{id}` | Revoke one subject-owned API token. Requires managed subject `admin`. |
 | `DELETE` | `/api/v1/authorization/subjects/{subjectID}/tokens` | Revoke all API tokens owned by the managed subject. Requires managed subject `admin`. |
 
-The authorization provider stores managed-subject management as relationships on the `managed_subject` resource type. Plugin runtime access is separate: a managed subject can only invoke a plugin after it has an explicit plugin grant, which is stored as the same provider-backed dynamic plugin relationship used by the admin authorization API. Policy `default: allow` applies to user callers, not to managed subjects.
+The authorization provider stores managed-subject management as relationships on the `managed_subject` resource type. Plugin runtime access is separate: a managed subject can only invoke a plugin after it has an explicit plugin grant, which is stored as the same provider-backed dynamic plugin relationship used by the admin authorization API. Policy `default: allow` applies to user callers, not to managed subjects. Credential connection management is also subject-scoped: OAuth, manual credentials, pending connection selection, and disconnects store or remove credentials under the managed subject's `credentialSubjectId`.
 
 ### Operator Surfaces
 
@@ -431,6 +435,14 @@ curl -X PUT http://localhost:8080/api/v1/authorization/subjects/service_account:
   -H 'Authorization: Bearer gst_api_...' \
   -H 'Content-Type: application/json' \
   -d '{"role":"viewer"}'
+
+curl -X POST http://localhost:8080/api/v1/authorization/subjects/service_account:release-bot/auth/connect-manual \
+  -H 'Authorization: Bearer gst_api_...' \
+  -H 'Content-Type: application/json' \
+  -d '{"integration":"github","credential":"ghp_..."}'
+
+curl http://localhost:8080/api/v1/authorization/subjects/service_account:release-bot/integrations \
+  -H 'Authorization: Bearer gst_api_...'
 
 curl -X POST http://localhost:8080/api/v1/authorization/subjects/service_account:release-bot/tokens \
   -H 'Authorization: Bearer gst_api_...' \

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -125,6 +125,11 @@ func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, 
 
 func (s *Server) resolveCredentialSubjectID(w http.ResponseWriter, r *http.Request) (string, error) {
 	p := PrincipalFromContext(r.Context())
+	if p != nil {
+		if subjectID := strings.TrimSpace(p.CredentialSubjectID); subjectID != "" {
+			return subjectID, nil
+		}
+	}
 	if principal.IsNonUserPrincipal(p) {
 		subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
 		if subjectID == "" {
@@ -217,6 +222,11 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) subjectConnectedIntegrations(r *http.Request) (map[string][]instanceInfo, error) {
 	p := PrincipalFromContext(r.Context())
+	if p != nil {
+		if subjectID := strings.TrimSpace(p.CredentialSubjectID); subjectID != "" {
+			return s.connectedIntegrationsForSubject(r.Context(), subjectID)
+		}
+	}
 	if principal.IsNonUserPrincipal(p) {
 		subjectID := strings.TrimSpace(principal.EffectiveCredentialSubjectID(p))
 		if subjectID == "" {

--- a/gestaltd/internal/server/handlers_authorization_subjects.go
+++ b/gestaltd/internal/server/handlers_authorization_subjects.go
@@ -71,6 +71,11 @@ func (s *Server) mountAuthorizationSubjectRoutes(r chi.Router) {
 	r.Put("/authorization/subjects/{subjectID}/grants/{plugin}", s.putManagedSubjectGrant)
 	r.Delete("/authorization/subjects/{subjectID}/grants/{plugin}", s.deleteManagedSubjectGrant)
 
+	r.Get("/authorization/subjects/{subjectID}/integrations", s.listManagedSubjectIntegrations)
+	r.Post("/authorization/subjects/{subjectID}/auth/start-oauth", s.startManagedSubjectIntegrationOAuth)
+	r.Post("/authorization/subjects/{subjectID}/auth/connect-manual", s.connectManagedSubjectManual)
+	r.Delete("/authorization/subjects/{subjectID}/integrations/{name}", s.disconnectManagedSubjectIntegration)
+
 	r.Get("/authorization/subjects/{subjectID}/tokens", s.listManagedSubjectAPITokens)
 	r.Post("/authorization/subjects/{subjectID}/tokens", s.createManagedSubjectAPIToken)
 	r.Delete("/authorization/subjects/{subjectID}/tokens", s.revokeAllManagedSubjectAPITokens)
@@ -410,6 +415,50 @@ func (s *Server) deleteManagedSubjectGrant(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
 
+func (s *Server) listManagedSubjectIntegrations(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionView) {
+		return
+	}
+	s.listIntegrations(w, r.WithContext(managedSubjectCredentialContext(r.Context(), subject.SubjectID)))
+}
+
+func (s *Server) startManagedSubjectIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionConnect) {
+		return
+	}
+	s.startIntegrationOAuth(w, r.WithContext(managedSubjectCredentialContext(r.Context(), subject.SubjectID)))
+}
+
+func (s *Server) connectManagedSubjectManual(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionConnect) {
+		return
+	}
+	s.connectManual(w, r.WithContext(managedSubjectCredentialContext(r.Context(), subject.SubjectID)))
+}
+
+func (s *Server) disconnectManagedSubjectIntegration(w http.ResponseWriter, r *http.Request) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionConnect) {
+		return
+	}
+	s.disconnectIntegration(w, r.WithContext(managedSubjectCredentialContext(r.Context(), subject.SubjectID)))
+}
+
 func (s *Server) createManagedSubjectAPIToken(w http.ResponseWriter, r *http.Request) {
 	subject, ok := s.managedSubjectFromPath(w, r)
 	if !ok {
@@ -525,15 +574,19 @@ func (s *Server) currentManagedSubjectUserSubjectID(w http.ResponseWriter, r *ht
 }
 
 func (s *Server) requireUnscopedManagedSubjectCaller(w http.ResponseWriter, r *http.Request) bool {
-	p := principal.Canonicalized(PrincipalFromContext(r.Context()))
-	if p == nil || p.Source != principal.SourceAPIToken {
-		return true
-	}
-	if p.TokenPermissions == nil && p.ActionPermissions == nil && len(p.Scopes) == 0 {
+	if managedSubjectCallerIsUnscoped(PrincipalFromContext(r.Context())) {
 		return true
 	}
 	writeError(w, http.StatusForbidden, "scoped API tokens cannot manage managed subjects")
 	return false
+}
+
+func managedSubjectCallerIsUnscoped(p *principal.Principal) bool {
+	p = principal.Canonicalized(p)
+	if p == nil || p.Source != principal.SourceAPIToken {
+		return true
+	}
+	return p.TokenPermissions == nil && p.ActionPermissions == nil && len(p.Scopes) == 0
 }
 
 func (s *Server) ensureManagedSubjectsAvailable(w http.ResponseWriter) bool {
@@ -621,6 +674,15 @@ func (s *Server) managedSubjectActionAllowed(ctx context.Context, subjectID, act
 		}
 	}
 	return false, nil
+}
+
+func managedSubjectCredentialContext(ctx context.Context, subjectID string) context.Context {
+	p := principal.Canonicalized(PrincipalFromContext(ctx))
+	if p == nil {
+		return ctx
+	}
+	p.CredentialSubjectID = strings.TrimSpace(subjectID)
+	return principal.WithPrincipal(ctx, p)
 }
 
 func (s *Server) writeManagedSubjectMembership(ctx context.Context, subjectID, memberSubjectID, role string) error {

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -16,6 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/discovery"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 type connectManualRequest struct {
@@ -129,6 +130,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		AccessToken:  effectiveCredential,
 		MetadataJSON: manualMeta,
 	}
+	credentialActorFromPrincipal(p, subjectID).applyTo(&tm)
 
 	result, err := s.runPostConnect(r.Context(), prov, tm)
 	if err != nil {
@@ -248,15 +250,69 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 type credentialMaterial struct {
-	SubjectID      string
-	AuthSource     string
-	Integration    string
-	Connection     string
-	Instance       string
-	AccessToken    string
-	RefreshToken   string
-	TokenExpiresAt *time.Time
-	MetadataJSON   string
+	SubjectID       string
+	AuthSource      string
+	Integration     string
+	Connection      string
+	Instance        string
+	AccessToken     string
+	RefreshToken    string
+	TokenExpiresAt  *time.Time
+	MetadataJSON    string
+	ActorSubjectID  string
+	ActorUserID     string
+	ActorAuthSource string
+}
+
+type credentialActor struct {
+	SubjectID  string
+	UserID     string
+	AuthSource string
+}
+
+func credentialActorFromPrincipal(p *principal.Principal, credentialSubjectID string) credentialActor {
+	p = principal.Canonicalized(p)
+	if p == nil {
+		return credentialActor{}
+	}
+	actorSubjectID := strings.TrimSpace(p.SubjectID)
+	if actorSubjectID == "" || actorSubjectID == strings.TrimSpace(credentialSubjectID) {
+		return credentialActor{}
+	}
+	return credentialActor{
+		SubjectID:  actorSubjectID,
+		UserID:     strings.TrimSpace(p.UserID),
+		AuthSource: p.AuthSource(),
+	}
+}
+
+func (a credentialActor) applyTo(tm *credentialMaterial) {
+	if tm == nil {
+		return
+	}
+	tm.ActorSubjectID = strings.TrimSpace(a.SubjectID)
+	tm.ActorUserID = strings.TrimSpace(a.UserID)
+	tm.ActorAuthSource = strings.TrimSpace(a.AuthSource)
+}
+
+func credentialMaterialContext(ctx context.Context, p *principal.Principal, tm credentialMaterial) context.Context {
+	if p != nil {
+		p = principal.Canonicalized(p)
+		if p != nil {
+			p.CredentialSubjectID = strings.TrimSpace(tm.SubjectID)
+			return principal.WithPrincipal(ctx, p)
+		}
+	}
+	if strings.TrimSpace(tm.ActorSubjectID) == "" {
+		return ctx
+	}
+	actor := &principal.Principal{
+		SubjectID:           strings.TrimSpace(tm.ActorSubjectID),
+		UserID:              strings.TrimSpace(tm.ActorUserID),
+		CredentialSubjectID: strings.TrimSpace(tm.SubjectID),
+	}
+	principal.SetAuthSource(actor, strings.TrimSpace(tm.ActorAuthSource))
+	return principal.WithPrincipal(ctx, actor)
 }
 
 type postConnectResult struct {

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -110,9 +110,13 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	if p != nil {
 		authSource = p.AuthSource()
 	}
+	actor := credentialActorFromPrincipal(p, subjectID)
 	state, err := s.stateCodec.Encode(integrationOAuthState{
 		SubjectID:        subjectID,
 		AuthSource:       authSource,
+		ActorSubjectID:   actor.SubjectID,
+		ActorUserID:      actor.UserID,
+		ActorAuthSource:  actor.AuthSource,
 		Integration:      req.Integration,
 		Connection:       connection,
 		Instance:         instance,
@@ -278,8 +282,11 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		TokenExpiresAt: tokenExpiresAt,
 		MetadataJSON:   metadata,
 	}
+	tm.ActorSubjectID = state.ActorSubjectID
+	tm.ActorUserID = state.ActorUserID
+	tm.ActorAuthSource = state.ActorAuthSource
 
-	result, err := s.runPostConnect(r.Context(), prov, tm)
+	result, err := s.runPostConnect(credentialMaterialContext(r.Context(), nil, tm), prov, tm)
 	if err != nil {
 		auditErr = errors.New("connection setup failed")
 		slog.ErrorContext(r.Context(), "post_connect failed", "provider", providerName, "error", err)

--- a/gestaltd/internal/server/oauth_state.go
+++ b/gestaltd/internal/server/oauth_state.go
@@ -20,6 +20,9 @@ var errPendingConnectionExpired = errors.New("pending connection expired")
 type integrationOAuthState struct {
 	SubjectID        string            `json:"sid"`
 	AuthSource       string            `json:"src,omitempty"`
+	ActorSubjectID   string            `json:"asid,omitempty"`
+	ActorUserID      string            `json:"auid,omitempty"`
+	ActorAuthSource  string            `json:"asrc,omitempty"`
 	Integration      string            `json:"int"`
 	Connection       string            `json:"con,omitempty"`
 	Instance         string            `json:"ins,omitempty"`

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"html/template"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
@@ -243,31 +245,27 @@ func (s *Server) writePendingConnectionSuccessPage(w http.ResponseWriter, integr
 	}, "failed to render success page")
 }
 
-func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, error) {
+func (s *Server) resolvePendingConnectionPrincipal(r *http.Request) (*principal.Principal, bool, error) {
 	if s.noAuth {
-		return "", false, nil
+		return nil, false, nil
 	}
 	p, err := s.resolveRequestPrincipalWithUserID(r)
 	if err != nil {
 		if errors.Is(err, errInvalidAuthorizationHeader) {
-			return "", true, principal.ErrInvalidToken
+			return nil, true, principal.ErrInvalidToken
 		}
-		return "", true, err
+		return nil, true, err
 	}
 	if p == nil {
-		return "", false, nil
+		return nil, false, nil
 	}
 	if principal.IsNonUserPrincipal(p) {
-		return "", true, errUserRequired
+		return nil, true, errUserRequired
 	}
-	subjectID := strings.TrimSpace(p.SubjectID)
-	if subjectID == "" && strings.TrimSpace(p.UserID) != "" {
-		subjectID = principal.UserSubjectID(p.UserID)
+	if strings.TrimSpace(p.SubjectID) == "" && strings.TrimSpace(p.UserID) == "" {
+		return nil, true, fmt.Errorf("authenticated principal missing subject ID")
 	}
-	if subjectID == "" {
-		return "", true, fmt.Errorf("authenticated principal missing subject ID")
-	}
-	return subjectID, true, nil
+	return principal.Canonicalized(p), true, nil
 }
 
 func (s *Server) authorizePendingConnectionByCookie(r *http.Request, state *pendingConnectionState) error {
@@ -291,31 +289,61 @@ func (s *Server) authorizePendingConnectionByCookie(r *http.Request, state *pend
 	return nil
 }
 
-func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Request, state *pendingConnectionState) bool {
-	subjectID, authenticated, err := s.resolvePendingConnectionUserID(r)
+func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Request, state *pendingConnectionState) (*principal.Principal, bool) {
+	p, authenticated, err := s.resolvePendingConnectionPrincipal(r)
 	if err != nil {
 		if errors.Is(err, errUserRequired) {
 			writeError(w, http.StatusForbidden, errUserRequired.Error())
-			return false
+			return nil, false
 		}
 		if errors.Is(err, principal.ErrInvalidToken) {
 			writeError(w, http.StatusUnauthorized, "invalid token")
-			return false
+			return nil, false
 		}
 		writeError(w, http.StatusInternalServerError, "failed to validate pending connection")
-		return false
+		return nil, false
 	}
-	if authenticated && subjectID != state.Credential.SubjectID {
-		writeError(w, http.StatusNotFound, "pending connection not found")
-		return false
+	if authenticated {
+		subjectID := strings.TrimSpace(p.SubjectID)
+		if subjectID == "" && strings.TrimSpace(p.UserID) != "" {
+			subjectID = principal.UserSubjectID(p.UserID)
+		}
+		if subjectID != state.Credential.SubjectID {
+			if !s.authorizeManagedSubjectPendingConnection(r.Context(), p, state.Credential.SubjectID) {
+				writeError(w, http.StatusNotFound, "pending connection not found")
+				return nil, false
+			}
+		}
+		return p, true
 	}
 	if !authenticated {
+		if _, err := canonicalServiceAccountSubjectID(state.Credential.SubjectID); err == nil {
+			writeError(w, http.StatusUnauthorized, "pending connection authorization required")
+			return nil, false
+		}
 		if err := s.authorizePendingConnectionByCookie(r, state); err != nil {
 			writeError(w, http.StatusUnauthorized, "pending connection authorization required")
-			return false
+			return nil, false
 		}
 	}
-	return true
+	return nil, true
+}
+
+func (s *Server) authorizeManagedSubjectPendingConnection(ctx context.Context, p *principal.Principal, subjectID string) bool {
+	if _, err := canonicalServiceAccountSubjectID(subjectID); err != nil {
+		return false
+	}
+	if !managedSubjectCallerIsUnscoped(p) {
+		return false
+	}
+	if s.managedSubjects == nil || s.authorizationProvider == nil || s.authorizer == nil {
+		return false
+	}
+	if _, err := s.managedSubjects.GetManagedSubject(ctx, subjectID); err != nil {
+		return false
+	}
+	allowed, err := s.managedSubjectActionAllowed(principal.WithPrincipal(ctx, p), subjectID, authorization.ProviderManagedSubjectActionConnect)
+	return err == nil && allowed
 }
 
 func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request) {
@@ -360,7 +388,8 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 	}
 	providerName = state.Credential.Integration
 	auditTarget = connectionAuditTarget(state.Credential.Integration, state.Credential.Connection, state.Credential.Instance)
-	if !s.authorizePendingConnection(w, r, state) {
+	completionPrincipal, ok := s.authorizePendingConnection(w, r, state)
+	if !ok {
 		auditErr = errors.New("pending connection authorization required")
 		return
 	}
@@ -413,7 +442,7 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 		auditErr = errors.New("integration not found")
 		return
 	}
-	if _, err := s.completeConnection(r.Context(), prov, tm); err != nil {
+	if _, err := s.completeConnection(credentialMaterialContext(r.Context(), completionPrincipal, tm), prov, tm); err != nil {
 		auditErr = errors.New("failed to store connection")
 		writeError(w, http.StatusInternalServerError, "failed to store connection")
 		return

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4168,13 +4168,19 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 	}})
 
 	pluginDefs := map[string]*config.ProviderEntry{
-		"open-svc": {AuthorizationPolicy: "open_policy"},
-		"svc":      {AuthorizationPolicy: "svc_policy"},
+		"discover-manual-svc": {AuthorizationPolicy: "discover_manual_policy"},
+		"manual-svc":          {AuthorizationPolicy: "manual_policy"},
+		"oauth-svc":           {AuthorizationPolicy: "oauth_policy"},
+		"open-svc":            {AuthorizationPolicy: "open_policy"},
+		"svc":                 {AuthorizationPolicy: "svc_policy"},
 	}
 	baseAuthz, err := authorization.New(config.AuthorizationConfig{
 		Policies: map[string]config.SubjectPolicyDef{
-			"open_policy": {Default: "allow"},
-			"svc_policy":  {Default: "deny"},
+			"discover_manual_policy": {Default: "deny"},
+			"manual_policy":          {Default: "deny"},
+			"oauth_policy":           {Default: "deny"},
+			"open_policy":            {Default: "allow"},
+			"svc_policy":             {Default: "deny"},
 		},
 	}, pluginDefs)
 	if err != nil {
@@ -4182,7 +4188,11 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 	}
 	provider := newMemoryAuthorizationProvider("memory-authorization")
 	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
-	seedProviderPluginAuthorization(t, svc, authz, provider, "svc", "owner@example.test", "editor")
+	ownerUser := seedProviderPluginAuthorization(t, svc, authz, provider, "svc", "owner@example.test", "editor")
+	seedProviderPluginAuthorization(t, svc, authz, provider, "manual-svc", "owner@example.test", "viewer")
+	seedProviderPluginAuthorization(t, svc, authz, provider, "discover-manual-svc", "owner@example.test", "viewer")
+	seedProviderPluginAuthorization(t, svc, authz, provider, "oauth-svc", "owner@example.test", "viewer")
+	ownerSubjectID := principal.UserSubjectID(ownerUser.ID)
 
 	newStub := func(name string) *stubIntegrationWithSessionCatalog {
 		return &stubIntegrationWithSessionCatalog{
@@ -4216,6 +4226,68 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 	}
 	stub := newStub("svc")
 	openStub := newStub("open-svc")
+	var created struct {
+		ID                  string `json:"id"`
+		SubjectID           string `json:"subjectId"`
+		Kind                string `json:"kind"`
+		DisplayName         string `json:"displayName"`
+		CredentialSubjectID string `json:"credentialSubjectId"`
+	}
+	assertManagedSubjectCredentialContext := func(label string) func(context.Context, *core.ExternalCredential) (map[string]string, error) {
+		return func(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
+			p := principal.FromContext(ctx)
+			if p == nil {
+				return nil, fmt.Errorf("%s post-connect principal missing", label)
+			}
+			if p.SubjectID != ownerSubjectID {
+				return nil, fmt.Errorf("%s post-connect subject = %q, want %q", label, p.SubjectID, ownerSubjectID)
+			}
+			if p.CredentialSubjectID != created.SubjectID {
+				return nil, fmt.Errorf("%s post-connect credential subject = %q, want %q", label, p.CredentialSubjectID, created.SubjectID)
+			}
+			if token.SubjectID != created.SubjectID {
+				return nil, fmt.Errorf("%s stored subject = %q, want %q", label, token.SubjectID, created.SubjectID)
+			}
+			return nil, nil
+		}
+	}
+	managedDiscoverySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"id":"site-a","name":"Site A","workspace":"alpha"},{"id":"site-b","name":"Site B","workspace":"beta"}]`)
+	}))
+	testutil.CloseOnCleanup(t, managedDiscoverySrv)
+	manualStub := &stubPostConnectManualProvider{
+		stubManualProvider: stubManualProvider{
+			StubIntegration: coretesting.StubIntegration{N: "manual-svc", DN: "Manual Service"},
+		},
+		postConnect: assertManagedSubjectCredentialContext("manual"),
+	}
+	discoverManualStub := &stubDiscoveringManualProvider{
+		stubManualProvider: stubManualProvider{
+			StubIntegration: coretesting.StubIntegration{N: "discover-manual-svc", DN: "Discover Manual Service"},
+		},
+		discovery: &core.DiscoveryConfig{
+			URL:      managedDiscoverySrv.URL,
+			IDPath:   "id",
+			NamePath: "name",
+			Metadata: map[string]string{"workspace": "workspace"},
+		},
+		postConnect: assertManagedSubjectCredentialContext("discovery"),
+	}
+	oauthStub := &stubIntegrationWithAuthURL{
+		StubIntegration: coretesting.StubIntegration{N: "oauth-svc", DN: "OAuth Service"},
+		authURL:         "https://oauth.example/authorize",
+		postConnect:     assertManagedSubjectCredentialContext("oauth"),
+	}
+	oauthHandler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://oauth.example/authorize",
+		exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+			if code != "good-code" {
+				return nil, fmt.Errorf("bad code")
+			}
+			return &core.TokenResponse{AccessToken: "oauth-upstream-token"}, nil
+		},
+	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -4233,7 +4305,13 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 				}
 			},
 		}
-		cfg.Providers = testutil.NewProviderRegistry(t, stub, openStub)
+		cfg.Providers = testutil.NewProviderRegistry(t, stub, openStub, manualStub, discoverManualStub, oauthStub)
+		cfg.DefaultConnection = map[string]string{
+			"manual-svc":          config.PluginConnectionName,
+			"discover-manual-svc": config.PluginConnectionName,
+			"oauth-svc":           testDefaultConnection,
+		}
+		cfg.ConnectionAuth = testConnectionAuth("oauth-svc", oauthHandler)
 		cfg.Services = svc
 		cfg.Authorizer = authz
 		cfg.AuthorizationProvider = provider
@@ -4292,13 +4370,6 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 		_ = resp.Body.Close()
 		t.Fatalf("create subject status = %d, want 201: %s", resp.StatusCode, body)
 	}
-	var created struct {
-		ID                  string `json:"id"`
-		SubjectID           string `json:"subjectId"`
-		Kind                string `json:"kind"`
-		DisplayName         string `json:"displayName"`
-		CredentialSubjectID string `json:"credentialSubjectId"`
-	}
 	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
 		_ = resp.Body.Close()
 		t.Fatalf("decode created managed subject: %v", err)
@@ -4326,6 +4397,197 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 	expectJSONStatus(http.MethodGet, "/api/v1/authorization/subjects/"+escapedSubjectID, "viewer-session", "", http.StatusOK)
 
 	expectJSONStatus(http.MethodPost, "/api/v1/authorization/subjects/"+escapedSubjectID+"/tokens", "viewer-session", `{"name":"viewer-token"}`, http.StatusForbidden)
+
+	expectJSONStatus(http.MethodPost, "/api/v1/authorization/subjects/"+escapedSubjectID+"/auth/connect-manual", "viewer-session", `{"integration":"manual-svc","credential":"viewer-key"}`, http.StatusForbidden)
+
+	resp = doJSON(http.MethodPost, "/api/v1/authorization/subjects/"+escapedSubjectID+"/auth/connect-manual", "owner-session", `{"integration":"manual-svc","credential":"managed-key"}`)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("managed subject manual connect status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var connectResp struct {
+		Status      string `json:"status"`
+		Integration string `json:"integration"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&connectResp); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode managed subject manual connect: %v", err)
+	}
+	_ = resp.Body.Close()
+	if connectResp.Status != "connected" || connectResp.Integration != "manual-svc" {
+		t.Fatalf("manual connect response = %+v", connectResp)
+	}
+	managedCredentials, err := svc.ExternalCredentials.ListCredentialsForProvider(context.Background(), created.SubjectID, "manual-svc")
+	if err != nil {
+		t.Fatalf("list managed subject manual credentials: %v", err)
+	}
+	if len(managedCredentials) != 1 || managedCredentials[0].AccessToken != "managed-key" {
+		t.Fatalf("managed subject manual credentials = %+v", managedCredentials)
+	}
+
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp = doJSON(http.MethodPost, "/api/v1/authorization/subjects/"+escapedSubjectID+"/auth/connect-manual", "owner-session", `{"integration":"discover-manual-svc","credential":"managed-discovery-key"}`)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("managed subject discovery connect status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var discoveryConnectResp struct {
+		Status       string `json:"status"`
+		Integration  string `json:"integration"`
+		SelectionURL string `json:"selectionUrl"`
+		PendingToken string `json:"pendingToken"`
+		Candidates   []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"candidates"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&discoveryConnectResp); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode managed subject discovery connect: %v", err)
+	}
+	_ = resp.Body.Close()
+	if discoveryConnectResp.Status != "selection_required" || discoveryConnectResp.Integration != "discover-manual-svc" || discoveryConnectResp.SelectionURL != "/api/v1/auth/pending-connection" || discoveryConnectResp.PendingToken == "" || len(discoveryConnectResp.Candidates) != 2 {
+		t.Fatalf("managed subject discovery connect response = %+v", discoveryConnectResp)
+	}
+
+	discoveryForm := url.Values{
+		"pending_token":   {discoveryConnectResp.PendingToken},
+		"candidate_index": {"1"},
+	}
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+discoveryConnectResp.SelectionURL, strings.NewReader(discoveryForm.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err = noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("managed subject discovery unauthenticated select: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("managed subject discovery unauthenticated select status = %d, want 401: %s", resp.StatusCode, body)
+	}
+	_ = resp.Body.Close()
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+discoveryConnectResp.SelectionURL, strings.NewReader(discoveryForm.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "owner-session"})
+	resp, err = noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("managed subject discovery select: %v", err)
+	}
+	if resp.StatusCode != http.StatusSeeOther {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("managed subject discovery select status = %d, want 303: %s", resp.StatusCode, body)
+	}
+	_ = resp.Body.Close()
+	managedCredentials, err = svc.ExternalCredentials.ListCredentialsForProvider(context.Background(), created.SubjectID, "discover-manual-svc")
+	if err != nil {
+		t.Fatalf("list managed subject discovery credentials: %v", err)
+	}
+	if len(managedCredentials) != 1 || managedCredentials[0].AccessToken != "managed-discovery-key" {
+		t.Fatalf("managed subject discovery credentials = %+v", managedCredentials)
+	}
+	var discoveryMetadata map[string]string
+	if err := json.Unmarshal([]byte(managedCredentials[0].MetadataJSON), &discoveryMetadata); err != nil {
+		t.Fatalf("unmarshal managed subject discovery metadata: %v", err)
+	}
+	if discoveryMetadata["workspace"] != "beta" {
+		t.Fatalf("managed subject discovery workspace = %q, want beta", discoveryMetadata["workspace"])
+	}
+
+	resp = doJSON(http.MethodGet, "/api/v1/authorization/subjects/"+escapedSubjectID+"/integrations", "owner-session", "")
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("managed subject integrations status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var integrations []struct {
+		Name            string `json:"name"`
+		Connected       bool   `json:"connected"`
+		Status          string `json:"status"`
+		CredentialState string `json:"credentialState"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode managed subject integrations: %v", err)
+	}
+	_ = resp.Body.Close()
+	var manualIntegration *struct {
+		Name            string `json:"name"`
+		Connected       bool   `json:"connected"`
+		Status          string `json:"status"`
+		CredentialState string `json:"credentialState"`
+	}
+	for i := range integrations {
+		if integrations[i].Name == "manual-svc" {
+			manualIntegration = &integrations[i]
+			break
+		}
+	}
+	if manualIntegration == nil {
+		t.Fatalf("manual-svc missing from managed subject integrations: %+v", integrations)
+	}
+	if !manualIntegration.Connected || manualIntegration.Status != "ready" || manualIntegration.CredentialState != "connected" {
+		t.Fatalf("manual-svc status = %+v, want connected ready", *manualIntegration)
+	}
+
+	resp = doJSON(http.MethodPost, "/api/v1/authorization/subjects/"+escapedSubjectID+"/auth/start-oauth", "owner-session", `{"integration":"oauth-svc","scopes":["read"]}`)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("managed subject oauth start status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var oauthStart struct {
+		URL   string `json:"url"`
+		State string `json:"state"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&oauthStart); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode managed subject oauth start: %v", err)
+	}
+	_ = resp.Body.Close()
+	if oauthStart.State == "" || !strings.Contains(oauthStart.URL, url.QueryEscape(oauthStart.State)) {
+		t.Fatalf("oauth start response = %+v", oauthStart)
+	}
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(oauthStart.State), nil)
+	resp, err = noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("managed subject oauth callback: %v", err)
+	}
+	if resp.StatusCode != http.StatusSeeOther {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("managed subject oauth callback status = %d, want 303: %s", resp.StatusCode, body)
+	}
+	_ = resp.Body.Close()
+	managedCredentials, err = svc.ExternalCredentials.ListCredentialsForProvider(context.Background(), created.SubjectID, "oauth-svc")
+	if err != nil {
+		t.Fatalf("list managed subject oauth credentials: %v", err)
+	}
+	if len(managedCredentials) != 1 || managedCredentials[0].AccessToken != "oauth-upstream-token" {
+		t.Fatalf("managed subject oauth credentials = %+v", managedCredentials)
+	}
+
+	expectJSONStatus(http.MethodDelete, "/api/v1/authorization/subjects/"+escapedSubjectID+"/integrations/manual-svc", "viewer-session", "", http.StatusForbidden)
+
+	resp = doJSON(http.MethodDelete, "/api/v1/authorization/subjects/"+escapedSubjectID+"/integrations/manual-svc", "owner-session", "")
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("managed subject disconnect status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	_ = resp.Body.Close()
+	managedCredentials, err = svc.ExternalCredentials.ListCredentialsForProvider(context.Background(), created.SubjectID, "manual-svc")
+	if err != nil {
+		t.Fatalf("list managed subject manual credentials after disconnect: %v", err)
+	}
+	if len(managedCredentials) != 0 {
+		t.Fatalf("managed subject manual credentials after disconnect = %+v, want none", managedCredentials)
+	}
 
 	expectJSONStatus(http.MethodPut, "/api/v1/authorization/subjects/"+escapedSubjectID+"/members", "owner-session", `{"email":"blocked@example.test","role":"admin"}`, http.StatusOK)
 
@@ -17934,11 +18196,19 @@ func (s *stubNilAuthTypesProvider) AuthTypes() []string { return nil }
 
 type stubDiscoveringManualProvider struct {
 	stubManualProvider
-	discovery *core.DiscoveryConfig
+	discovery   *core.DiscoveryConfig
+	postConnect func(context.Context, *core.ExternalCredential) (map[string]string, error)
 }
 
 func (s *stubDiscoveringManualProvider) DiscoveryConfig() *core.DiscoveryConfig {
 	return s.discovery
+}
+
+func (s *stubDiscoveringManualProvider) PostConnect(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
+	if s.postConnect != nil {
+		return s.postConnect(ctx, token)
+	}
+	return nil, nil
 }
 
 type stubDiscoveringProvider struct {


### PR DESCRIPTION
## Summary

Adds subject-scoped connection management APIs for service-account managed subjects:

- `GET /api/v1/authorization/subjects/{subjectID}/integrations`
- `POST /api/v1/authorization/subjects/{subjectID}/auth/start-oauth`
- `POST /api/v1/authorization/subjects/{subjectID}/auth/connect-manual`
- `DELETE /api/v1/authorization/subjects/{subjectID}/integrations/{name}`

These routes authorize against the managed subject (`viewer` for listing, `editor`/`admin` for connect/disconnect), reuse the existing integration connection handlers, and store credentials under the managed subject `credentialSubjectId`.

Deferred completion paths preserve the human manager principal:

- manual connect with discovery encodes actor context into pending connection state and rehydrates it when the user selects a candidate
- OAuth start encodes actor context into encrypted OAuth state and rehydrates it on callback
- provider post-connect hooks see the human actor as `SubjectID` and the managed subject as `CredentialSubjectID`

## Examples

Manual credential connect:

```sh
curl -X POST /api/v1/authorization/subjects/service_account:release-bot/auth/connect-manual \
  -H 'Authorization: Bearer gst_api_...' \
  -H 'Content-Type: application/json' \
  -d '{"integration":"github","credential":"ghp_..."}'
```

Start OAuth:

```sh
curl -X POST /api/v1/authorization/subjects/service_account:release-bot/auth/start-oauth \
  -H 'Authorization: Bearer gst_api_...' \
  -H 'Content-Type: application/json' \
  -d '{"integration":"slack","scopes":["channels:read"]}'
```

List managed subject integrations:

```sh
curl /api/v1/authorization/subjects/service_account:release-bot/integrations \
  -H 'Authorization: Bearer gst_api_...'
```

Disconnect:

```sh
curl -X DELETE /api/v1/authorization/subjects/service_account:release-bot/integrations/github \
  -H 'Authorization: Bearer gst_api_...'
```

## Testing

No unit tests added. Augmented the existing server integration-style managed-subject API test to cover:

- viewer cannot connect/disconnect
- editor/admin can manually connect credentials for the managed subject
- discovery pending selection requires an authenticated managed-subject editor/admin and stores selected metadata
- OAuth start/callback stores credentials on the managed subject
- managed-subject integrations list resolves connection state against the managed subject
- disconnect removes the managed subject credential
- post-connect hooks observe the human manager principal while credentials are stored under the service account subject

Ran:

```sh
go test ./internal/server -run 'TestAuthorizationManagedSubjectsAPI|TestConnectManual|TestStartIntegrationOAuth|TestIntegrationOAuthCallback' -count=1
go test ./internal/server -run 'TestListIntegrations|TestDisconnectIntegration|TestSubjectAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials' -count=1
go test ./internal/server -count=1
```
