### PR TITLE
Simplify managed subject credential ownership

### DIFF
--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -43,7 +43,6 @@ Metadata for service-account identities managed through `/api/v1/authorization/s
 | `kind` | string | Currently `service_account`. |
 | `display_name` | string | Plaintext. |
 | `description` | string | Plaintext. |
-| `credential_subject_id` | string | Subject whose external credentials and subject-owned API tokens are used; currently matches `subject_id`. |
 | `created_by_subject_id` | string | Canonical user subject that created the managed subject. |
 | `deleted` | bool | Deleted subjects are hidden and their IDs are not reused. |
 | `created_at` | time | |

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -123,7 +123,7 @@ still honor each event's `visibility`.
 
 ### Managed Subjects
 
-Managed subjects are service-account identities for release bots, service accounts, and shared automation. Their canonical subject ID is always `service_account:<id>`, and their upstream credentials and subject-owned API tokens use that same `credentialSubjectId`. These management routes require a browser session or an unscoped user-owned API token; scoped API tokens and subject-owned API tokens cannot manage managed subjects.
+Managed subjects are service-account identities for release bots, service accounts, and shared automation. Their canonical subject ID is always `service_account:<id>`, and their upstream credentials and subject-owned API tokens use that same subject ID. These management routes require a browser session or an unscoped user-owned API token; scoped API tokens and subject-owned API tokens cannot manage managed subjects.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
@@ -147,7 +147,7 @@ Managed subjects are service-account identities for release bots, service accoun
 | `DELETE` | `/api/v1/authorization/subjects/{subjectID}/tokens/{id}` | Revoke one subject-owned API token. Requires managed subject `admin`. |
 | `DELETE` | `/api/v1/authorization/subjects/{subjectID}/tokens` | Revoke all API tokens owned by the managed subject. Requires managed subject `admin`. |
 
-The authorization provider stores managed-subject management as relationships on the `managed_subject` resource type. Plugin runtime access is separate: a managed subject can only invoke a plugin after it has an explicit plugin grant, which is stored as the same provider-backed dynamic plugin relationship used by the admin authorization API. Policy `default: allow` applies to user callers, not to managed subjects. Credential connection management is also subject-scoped: OAuth, manual credentials, pending connection selection, and disconnects store or remove credentials under the managed subject's `credentialSubjectId`.
+The authorization provider stores managed-subject management as relationships on the `managed_subject` resource type. Plugin runtime access is separate: a managed subject can only invoke a plugin after it has an explicit plugin grant, which is stored as the same provider-backed dynamic plugin relationship used by the admin authorization API. Policy `default: allow` applies to user callers, not to managed subjects. Credential connection management is also subject-scoped: OAuth, manual credentials, pending connection selection, and disconnects store or remove credentials under the managed subject's canonical subject ID.
 
 ### Operator Surfaces
 

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -14,15 +14,14 @@ type User struct {
 }
 
 type ManagedSubject struct {
-	SubjectID           string
-	Kind                string
-	DisplayName         string
-	Description         string
-	CredentialSubjectID string
-	CreatedBySubjectID  string
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
-	DeletedAt           *time.Time
+	SubjectID          string
+	Kind               string
+	DisplayName        string
+	Description        string
+	CreatedBySubjectID string
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+	DeletedAt          *time.Time
 }
 
 type ExternalCredential struct {

--- a/gestaltd/internal/coredata/managed_subjects.go
+++ b/gestaltd/internal/coredata/managed_subjects.go
@@ -47,7 +47,6 @@ func (s *ManagedSubjectService) CreateManagedSubject(ctx context.Context, subjec
 		"kind":                  kind,
 		"display_name":          strings.TrimSpace(subject.DisplayName),
 		"description":           strings.TrimSpace(subject.Description),
-		"credential_subject_id": subjectID,
 		"created_by_subject_id": strings.TrimSpace(subject.CreatedBySubjectID),
 		"deleted":               false,
 		"created_at":            now,
@@ -153,15 +152,14 @@ func (s *ManagedSubjectService) RemoveManagedSubjectForRollback(ctx context.Cont
 
 func recordToManagedSubject(rec indexeddb.Record) *core.ManagedSubject {
 	return &core.ManagedSubject{
-		SubjectID:           recString(rec, "subject_id"),
-		Kind:                recString(rec, "kind"),
-		DisplayName:         recString(rec, "display_name"),
-		Description:         recString(rec, "description"),
-		CredentialSubjectID: recString(rec, "credential_subject_id"),
-		CreatedBySubjectID:  recString(rec, "created_by_subject_id"),
-		CreatedAt:           recTime(rec, "created_at"),
-		UpdatedAt:           recTime(rec, "updated_at"),
-		DeletedAt:           recTimePtr(rec, "deleted_at"),
+		SubjectID:          recString(rec, "subject_id"),
+		Kind:               recString(rec, "kind"),
+		DisplayName:        recString(rec, "display_name"),
+		Description:        recString(rec, "description"),
+		CreatedBySubjectID: recString(rec, "created_by_subject_id"),
+		CreatedAt:          recTime(rec, "created_at"),
+		UpdatedAt:          recTime(rec, "updated_at"),
+		DeletedAt:          recTimePtr(rec, "deleted_at"),
 	}
 }
 
@@ -172,7 +170,6 @@ func managedSubjectToRecord(subject *core.ManagedSubject) indexeddb.Record {
 		"kind":                  strings.TrimSpace(subject.Kind),
 		"display_name":          strings.TrimSpace(subject.DisplayName),
 		"description":           strings.TrimSpace(subject.Description),
-		"credential_subject_id": strings.TrimSpace(subject.CredentialSubjectID),
 		"created_by_subject_id": strings.TrimSpace(subject.CreatedBySubjectID),
 		"deleted":               subject.DeletedAt != nil,
 		"created_at":            subject.CreatedAt,

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -58,7 +58,6 @@ var ManagedSubjectsSchema = indexeddb.ObjectStoreSchema{
 		{Name: "kind", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "display_name", Type: indexeddb.TypeString},
 		{Name: "description", Type: indexeddb.TypeString},
-		{Name: "credential_subject_id", Type: indexeddb.TypeString},
 		{Name: "created_by_subject_id", Type: indexeddb.TypeString},
 		{Name: "deleted", Type: indexeddb.TypeBool},
 		{Name: "created_at", Type: indexeddb.TypeTime},

--- a/gestaltd/internal/server/handlers_authorization_subjects.go
+++ b/gestaltd/internal/server/handlers_authorization_subjects.go
@@ -31,16 +31,15 @@ type updateManagedSubjectRequest struct {
 }
 
 type managedSubjectInfo struct {
-	ID                  string     `json:"id"`
-	SubjectID           string     `json:"subjectId"`
-	Kind                string     `json:"kind"`
-	DisplayName         string     `json:"displayName"`
-	Description         string     `json:"description,omitempty"`
-	CredentialSubjectID string     `json:"credentialSubjectId"`
-	CreatedBySubjectID  string     `json:"createdBySubjectId,omitempty"`
-	CreatedAt           time.Time  `json:"createdAt"`
-	UpdatedAt           time.Time  `json:"updatedAt"`
-	DeletedAt           *time.Time `json:"deletedAt,omitempty"`
+	ID                 string     `json:"id"`
+	SubjectID          string     `json:"subjectId"`
+	Kind               string     `json:"kind"`
+	DisplayName        string     `json:"displayName"`
+	Description        string     `json:"description,omitempty"`
+	CreatedBySubjectID string     `json:"createdBySubjectId,omitempty"`
+	CreatedAt          time.Time  `json:"createdAt"`
+	UpdatedAt          time.Time  `json:"updatedAt"`
+	DeletedAt          *time.Time `json:"deletedAt,omitempty"`
 }
 
 type managedSubjectMemberInfo struct {
@@ -108,12 +107,11 @@ func (s *Server) createManagedSubject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	subject, err := s.managedSubjects.CreateManagedSubject(r.Context(), &core.ManagedSubject{
-		SubjectID:           subjectID,
-		Kind:                coredata.ManagedSubjectKindServiceAccount,
-		DisplayName:         displayName,
-		Description:         req.Description,
-		CredentialSubjectID: subjectID,
-		CreatedBySubjectID:  creatorSubjectID,
+		SubjectID:          subjectID,
+		Kind:               coredata.ManagedSubjectKindServiceAccount,
+		DisplayName:        displayName,
+		Description:        req.Description,
+		CreatedBySubjectID: creatorSubjectID,
 	})
 	if err != nil {
 		if errors.Is(err, core.ErrAlreadyRegistered) {
@@ -177,22 +175,16 @@ func (s *Server) listManagedSubjects(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getManagedSubject(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionView)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionView) {
 		return
 	}
 	writeJSON(w, http.StatusOK, managedSubjectInfoFromCore(subject))
 }
 
 func (s *Server) updateManagedSubject(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionManage)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionManage) {
 		return
 	}
 
@@ -250,11 +242,8 @@ func (s *Server) deleteManagedSubject(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listManagedSubjectMembers(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionView)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionView) {
 		return
 	}
 	members, err := s.managedSubjectMemberRows(r.Context(), subject.SubjectID)
@@ -266,11 +255,8 @@ func (s *Server) listManagedSubjectMembers(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) putManagedSubjectMember(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionManage)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionManage) {
 		return
 	}
 	var req putAdminAuthorizationMemberRequest
@@ -299,11 +285,8 @@ func (s *Server) putManagedSubjectMember(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) deleteManagedSubjectMember(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionManage)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionManage) {
 		return
 	}
 	memberSubjectID, err := adminAuthorizationSubjectID(strings.TrimSpace(chi.URLParam(r, "memberSubjectID")))
@@ -325,11 +308,8 @@ func (s *Server) deleteManagedSubjectMember(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *Server) listManagedSubjectGrants(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionView)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionView) {
 		return
 	}
 	grants, err := s.managedSubjectGrantRows(r.Context(), subject.SubjectID)
@@ -341,11 +321,8 @@ func (s *Server) listManagedSubjectGrants(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) putManagedSubjectGrant(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionGrant)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionGrant) {
 		return
 	}
 	plugin, _, err := s.adminAuthorizationPluginEntry(chi.URLParam(r, "plugin"))
@@ -388,11 +365,8 @@ func (s *Server) putManagedSubjectGrant(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) deleteManagedSubjectGrant(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionGrant)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionGrant) {
 		return
 	}
 	plugin, _, err := s.adminAuthorizationPluginEntry(chi.URLParam(r, "plugin"))
@@ -416,55 +390,24 @@ func (s *Server) deleteManagedSubjectGrant(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) listManagedSubjectIntegrations(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
-	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionView) {
-		return
-	}
-	s.listIntegrations(w, r.WithContext(managedSubjectCredentialContext(r.Context(), subject.SubjectID)))
+	s.withManagedSubjectCredential(w, r, authorization.ProviderManagedSubjectActionView, s.listIntegrations)
 }
 
 func (s *Server) startManagedSubjectIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
-	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionConnect) {
-		return
-	}
-	s.startIntegrationOAuth(w, r.WithContext(managedSubjectCredentialContext(r.Context(), subject.SubjectID)))
+	s.withManagedSubjectCredential(w, r, authorization.ProviderManagedSubjectActionConnect, s.startIntegrationOAuth)
 }
 
 func (s *Server) connectManagedSubjectManual(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
-	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionConnect) {
-		return
-	}
-	s.connectManual(w, r.WithContext(managedSubjectCredentialContext(r.Context(), subject.SubjectID)))
+	s.withManagedSubjectCredential(w, r, authorization.ProviderManagedSubjectActionConnect, s.connectManual)
 }
 
 func (s *Server) disconnectManagedSubjectIntegration(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
-	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionConnect) {
-		return
-	}
-	s.disconnectIntegration(w, r.WithContext(managedSubjectCredentialContext(r.Context(), subject.SubjectID)))
+	s.withManagedSubjectCredential(w, r, authorization.ProviderManagedSubjectActionConnect, s.disconnectIntegration)
 }
 
 func (s *Server) createManagedSubjectAPIToken(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionCreateToken)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionCreateToken) {
 		return
 	}
 	var req createTokenRequest
@@ -499,11 +442,8 @@ func (s *Server) createManagedSubjectAPIToken(w http.ResponseWriter, r *http.Req
 }
 
 func (s *Server) listManagedSubjectAPITokens(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionView)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionView) {
 		return
 	}
 	tokens, err := s.apiTokens.ListAPITokensByOwner(r.Context(), core.APITokenOwnerKindSubject, subject.SubjectID)
@@ -519,11 +459,8 @@ func (s *Server) listManagedSubjectAPITokens(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *Server) revokeManagedSubjectAPIToken(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionManage)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionManage) {
 		return
 	}
 	id := strings.TrimSpace(chi.URLParam(r, "id"))
@@ -539,11 +476,8 @@ func (s *Server) revokeManagedSubjectAPIToken(w http.ResponseWriter, r *http.Req
 }
 
 func (s *Server) revokeAllManagedSubjectAPITokens(w http.ResponseWriter, r *http.Request) {
-	subject, ok := s.managedSubjectFromPath(w, r)
+	subject, ok := s.managedSubjectForAction(w, r, authorization.ProviderManagedSubjectActionManage)
 	if !ok {
-		return
-	}
-	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, authorization.ProviderManagedSubjectActionManage) {
 		return
 	}
 	count, err := s.apiTokens.RevokeAllAPITokensByOwner(r.Context(), core.APITokenOwnerKindSubject, subject.SubjectID)
@@ -618,6 +552,17 @@ func (s *Server) managedSubjectFromPath(w http.ResponseWriter, r *http.Request) 
 	return subject, true
 }
 
+func (s *Server) managedSubjectForAction(w http.ResponseWriter, r *http.Request, action string) (*core.ManagedSubject, bool) {
+	subject, ok := s.managedSubjectFromPath(w, r)
+	if !ok {
+		return nil, false
+	}
+	if !s.requireManagedSubjectAction(w, r, subject.SubjectID, action) {
+		return nil, false
+	}
+	return subject, true
+}
+
 func (s *Server) managedSubjectIDFromPath(w http.ResponseWriter, r *http.Request) (string, bool) {
 	if !s.ensureManagedSubjectsAvailable(w) {
 		return "", false
@@ -683,6 +628,14 @@ func managedSubjectCredentialContext(ctx context.Context, subjectID string) cont
 	}
 	p.CredentialSubjectID = strings.TrimSpace(subjectID)
 	return principal.WithPrincipal(ctx, p)
+}
+
+func (s *Server) withManagedSubjectCredential(w http.ResponseWriter, r *http.Request, action string, handler http.HandlerFunc) {
+	subject, ok := s.managedSubjectForAction(w, r, action)
+	if !ok {
+		return
+	}
+	handler(w, r.WithContext(managedSubjectCredentialContext(r.Context(), subject.SubjectID)))
 }
 
 func (s *Server) writeManagedSubjectMembership(ctx context.Context, subjectID, memberSubjectID, role string) error {
@@ -867,16 +820,15 @@ func managedSubjectInfoFromCore(subject *core.ManagedSubject) managedSubjectInfo
 	}
 	_, id, _ := core.ParseSubjectID(subject.SubjectID)
 	return managedSubjectInfo{
-		ID:                  id,
-		SubjectID:           subject.SubjectID,
-		Kind:                subject.Kind,
-		DisplayName:         subject.DisplayName,
-		Description:         subject.Description,
-		CredentialSubjectID: subject.CredentialSubjectID,
-		CreatedBySubjectID:  subject.CreatedBySubjectID,
-		CreatedAt:           subject.CreatedAt,
-		UpdatedAt:           subject.UpdatedAt,
-		DeletedAt:           subject.DeletedAt,
+		ID:                 id,
+		SubjectID:          subject.SubjectID,
+		Kind:               subject.Kind,
+		DisplayName:        subject.DisplayName,
+		Description:        subject.Description,
+		CreatedBySubjectID: subject.CreatedBySubjectID,
+		CreatedAt:          subject.CreatedAt,
+		UpdatedAt:          subject.UpdatedAt,
+		DeletedAt:          subject.DeletedAt,
 	}
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4227,11 +4227,10 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 	stub := newStub("svc")
 	openStub := newStub("open-svc")
 	var created struct {
-		ID                  string `json:"id"`
-		SubjectID           string `json:"subjectId"`
-		Kind                string `json:"kind"`
-		DisplayName         string `json:"displayName"`
-		CredentialSubjectID string `json:"credentialSubjectId"`
+		ID          string `json:"id"`
+		SubjectID   string `json:"subjectId"`
+		Kind        string `json:"kind"`
+		DisplayName string `json:"displayName"`
 	}
 	assertManagedSubjectCredentialContext := func(label string) func(context.Context, *core.ExternalCredential) (map[string]string, error) {
 		return func(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
@@ -4375,7 +4374,7 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 		t.Fatalf("decode created managed subject: %v", err)
 	}
 	_ = resp.Body.Close()
-	if created.ID != "reporting-bot" || created.SubjectID != "service_account:reporting-bot" || created.Kind != "service_account" || created.CredentialSubjectID != created.SubjectID {
+	if created.ID != "reporting-bot" || created.SubjectID != "service_account:reporting-bot" || created.Kind != "service_account" {
 		t.Fatalf("created managed subject = %+v", created)
 	}
 	if err := svc.ExternalCredentials.PutCredential(context.Background(), &core.ExternalCredential{


### PR DESCRIPTION
## Summary

This removes the redundant managed-subject credential owner field. Managed subjects now have one canonical identity value: `subjectId`. External credentials and subject-owned API tokens both use that same canonical subject ID.

It also folds repeated managed-subject handler boilerplate into shared helpers before delegating to the existing credential-scoped integration handlers.

## Interface diff

```diff
 type ManagedSubject struct {
     SubjectID string
     Kind string
     DisplayName string
     Description string
-    CredentialSubjectID string
     CreatedBySubjectID string
     CreatedAt time.Time
     UpdatedAt time.Time
     DeletedAt *time.Time
 }
```

```diff
 {
   "id": "release-bot",
   "subjectId": "service_account:release-bot",
   "kind": "service_account",
   "displayName": "Release Bot",
-  "credentialSubjectId": "service_account:release-bot",
   "createdAt": "...",
   "updatedAt": "..."
 }
```

## Examples

Create a managed subject:

```sh
curl -X POST http://localhost:8080/api/v1/authorization/subjects \
  -H "Authorization: Bearer gst_api_..." \
  -H "Content-Type: application/json" \
  -d '{"id":"release-bot","displayName":"Release Bot"}'
```

Connect a provider credential for that subject. The credential is stored under `subject_id = service_account:release-bot`:

```sh
curl -X POST http://localhost:8080/api/v1/authorization/subjects/service_account:release-bot/auth/connect-manual \
  -H "Authorization: Bearer gst_api_..." \
  -H "Content-Type: application/json" \
  -d '{"integration":"github","credential":"ghp_..."}'
```

Create a subject-owned API token. The token owner and credential subject are both `service_account:release-bot`:

```sh
curl -X POST http://localhost:8080/api/v1/authorization/subjects/service_account:release-bot/tokens \
  -H "Authorization: Bearer gst_api_..." \
  -H "Content-Type: application/json" \
  -d '{"name":"release-bot","permissions":[{"plugin":"github","operations":["issues.list"]}]}'
```

## Validation

- `go test ./internal/coredata -count=1`
- `go test ./internal/server -run TestAuthorizationManagedSubjectsAPI -count=1`
- `go test ./internal/server -count=1`
- `go test ./internal/agentmanager ./internal/providerhost -run TestNonExistent -count=0`
- `go test ./internal/bootstrap -run TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline -count=1`

Note: `go test ./...` failed once on `TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline` timing in `internal/bootstrap`; that exact test passed on rerun.