### PR TITLE
Route core host service relays across gestaltd instances

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -915,7 +915,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	startEnv := maps.Clone(env)
 	allowedHosts := entry.EffectiveAllowedHosts()
 	for _, hostService := range startedHostServices.Bindings() {
-		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect)
+		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect, true)
 		if err != nil {
 			return nil, err
 		}
@@ -1195,7 +1195,7 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	allowedHosts := hostedAgentAllowedHosts(agentAllowedHosts, runtimePlan)
 	phaseStarted = time.Now()
 	for _, hostService := range startedHostServices.Bindings() {
-		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect)
+		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect, true)
 		if err != nil {
 			recordHostedAgentRuntimeStartPhase(ctx, name, "host_services_bind", phaseStarted, err)
 			return nil, err
@@ -1589,7 +1589,7 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 	return hostServices, invTokens, cleanup, nil
 }
 
-func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostService runtimehost.StartedHostService, deps Deps, allowUnixRelay bool) (pluginruntime.BindHostServiceRequest, map[string]string, string, error) {
+func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostService runtimehost.StartedHostService, deps Deps, allowUnixRelay bool, allowCoreRoutable bool) (pluginruntime.BindHostServiceRequest, map[string]string, string, error) {
 	if !allowUnixRelay {
 		var (
 			serviceKey   string
@@ -1632,7 +1632,16 @@ func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostSe
 		default:
 			return pluginruntime.BindHostServiceRequest{}, nil, "", fmt.Errorf("host service %q requires host service tunnels", hostService.EnvVar)
 		}
-		relay, relayEnv, relayHost, ok, err := buildHostedRuntimePublicHostServiceRelay(providerName, sessionID, hostService, deps, serviceKey, serviceLabel, methodPrefix)
+		relay, relayEnv, relayHost, ok, err := buildHostedRuntimePublicHostServiceRelay(
+			providerName,
+			sessionID,
+			hostService,
+			deps,
+			serviceKey,
+			serviceLabel,
+			methodPrefix,
+			allowCoreRoutable && coreRoutableHostedRuntimeService(serviceKey),
+		)
 		if err != nil {
 			return pluginruntime.BindHostServiceRequest{}, nil, "", err
 		}
@@ -1741,7 +1750,16 @@ func buildHostedRuntimePublicEgressProxy(providerName, sessionID string, allowed
 	}, nil
 }
 
-func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, hostService runtimehost.StartedHostService, deps Deps, serviceKey, serviceLabel, methodPrefix string) (pluginruntime.HostServiceRelay, map[string]string, string, bool, error) {
+func coreRoutableHostedRuntimeService(serviceKey string) bool {
+	switch serviceKey {
+	case "workflow_manager", "agent_manager", "plugin_invoker":
+		return true
+	default:
+		return false
+	}
+}
+
+func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, hostService runtimehost.StartedHostService, deps Deps, serviceKey, serviceLabel, methodPrefix string, coreRoutable bool) (pluginruntime.HostServiceRelay, map[string]string, string, bool, error) {
 	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
 		return pluginruntime.HostServiceRelay{}, nil, "", false, nil
 	}
@@ -1759,6 +1777,7 @@ func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, ho
 		Service:      serviceKey,
 		EnvVar:       hostService.EnvVar,
 		MethodPrefix: methodPrefix,
+		CoreRoutable: coreRoutable,
 		TTL:          pluginRuntimeHostServiceRelayTokenTTL,
 	})
 	if err != nil {

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -184,7 +184,7 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 			bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, runtimehost.StartedHostService{
 				Name:   hostService.Name,
 				EnvVar: hostService.EnvVar,
-			}, deps, false)
+			}, deps, false, false)
 			if err != nil {
 				return providerdev.RuntimeEnv{}, err
 			}
@@ -227,7 +227,7 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 		})
 	}
 	for _, hostService := range startedHostServices.Bindings() {
-		bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, false)
+		bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, false, false)
 		if err != nil {
 			return providerdev.RuntimeEnv{}, err
 		}

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -3,10 +3,16 @@ package server
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
+	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
 )
 
@@ -114,9 +120,126 @@ func (s *Server) hostServiceHandler(ctx context.Context, target runtimehost.Host
 		return nil, exactErr
 	}
 	if !ok {
+		entry, ok = s.coreRoutableHostServiceHandlerEntry(ctx, target)
+	}
+	if !ok {
 		return nil, nil
 	}
 	return entry.handler, nil
+}
+
+func (s *Server) coreRoutableHostServiceHandlerEntry(ctx context.Context, target runtimehost.HostServiceRelayTarget) (hostServiceHandlerEntry, bool) {
+	if s == nil || !target.CoreRoutable || s.invocationTokens == nil {
+		return hostServiceHandlerEntry{}, false
+	}
+	pluginName := strings.TrimSpace(target.PluginName)
+	if pluginName == "" {
+		return hostServiceHandlerEntry{}, false
+	}
+	key, ok := coreRoutableHostServiceHandlerKey(pluginName, target)
+	if !ok {
+		return hostServiceHandlerEntry{}, false
+	}
+	s.hostServiceMu.Lock()
+	if s.coreHostServiceHandlers != nil {
+		if entry, ok := s.coreHostServiceHandlers[key]; ok {
+			s.hostServiceMu.Unlock()
+			return entry, true
+		}
+	}
+	s.hostServiceMu.Unlock()
+
+	entry, ok := s.newCoreRoutableHostServiceHandlerEntry(ctx, pluginName, target)
+	if !ok {
+		return hostServiceHandlerEntry{}, false
+	}
+	s.hostServiceMu.Lock()
+	if s.coreHostServiceHandlers == nil {
+		s.coreHostServiceHandlers = make(map[hostServiceHandlerKey]hostServiceHandlerEntry)
+	}
+	if existing, ok := s.coreHostServiceHandlers[key]; ok {
+		s.hostServiceMu.Unlock()
+		return existing, true
+	}
+	s.coreHostServiceHandlers[key] = entry
+	s.hostServiceMu.Unlock()
+	return entry, true
+}
+
+func coreRoutableHostServiceHandlerKey(pluginName string, target runtimehost.HostServiceRelayTarget) (hostServiceHandlerKey, bool) {
+	methodPrefix := strings.TrimSpace(target.MethodPrefix)
+	switch {
+	case target.Service == "workflow_manager" &&
+		target.EnvVar == workflowservice.DefaultManagerSocketEnv &&
+		methodPrefix == "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/":
+	case target.Service == "agent_manager" &&
+		target.EnvVar == agentservice.DefaultManagerSocketEnv &&
+		methodPrefix == "/"+proto.AgentManagerHost_ServiceDesc.ServiceName+"/":
+	case target.Service == "plugin_invoker" &&
+		target.EnvVar == plugininvokerservice.DefaultSocketEnv &&
+		methodPrefix == "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/":
+	default:
+		return hostServiceHandlerKey{}, false
+	}
+	return hostServiceHandlerKey{
+		pluginName: pluginName,
+		service:    strings.TrimSpace(target.Service),
+		envVar:     strings.TrimSpace(target.EnvVar),
+	}, true
+}
+
+func (s *Server) newCoreRoutableHostServiceHandlerEntry(ctx context.Context, pluginName string, target runtimehost.HostServiceRelayTarget) (hostServiceHandlerEntry, bool) {
+	methodPrefix := strings.TrimSpace(target.MethodPrefix)
+	switch {
+	case target.Service == "workflow_manager" &&
+		target.EnvVar == workflowservice.DefaultManagerSocketEnv &&
+		methodPrefix == "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/":
+		if s.workflowSchedules == nil {
+			return hostServiceHandlerEntry{}, false
+		}
+		slog.DebugContext(ctx, "serving core-routable host service relay", "plugin", pluginName, "service", target.Service)
+		return hostServiceHandlerEntry{
+			handler: newGRPCHostServiceHandler(func(srv *grpc.Server) {
+				proto.RegisterWorkflowManagerHostServer(srv, providerhost.NewWorkflowManagerServer(pluginName, s.workflowSchedules, s.invocationTokens))
+			}),
+		}, true
+	case target.Service == "agent_manager" &&
+		target.EnvVar == agentservice.DefaultManagerSocketEnv &&
+		methodPrefix == "/"+proto.AgentManagerHost_ServiceDesc.ServiceName+"/":
+		if s.agentRuns == nil {
+			return hostServiceHandlerEntry{}, false
+		}
+		slog.DebugContext(ctx, "serving core-routable host service relay", "plugin", pluginName, "service", target.Service)
+		return hostServiceHandlerEntry{
+			handler: newGRPCHostServiceHandler(func(srv *grpc.Server) {
+				proto.RegisterAgentManagerHostServer(srv, providerhost.NewAgentManagerServer(pluginName, s.agentRuns, s.invocationTokens))
+			}),
+		}, true
+	case target.Service == "plugin_invoker" &&
+		target.EnvVar == plugininvokerservice.DefaultSocketEnv &&
+		methodPrefix == "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/":
+		if s.invoker == nil || s.pluginDefs == nil {
+			return hostServiceHandlerEntry{}, false
+		}
+		entry := s.pluginDefs[pluginName]
+		if entry == nil {
+			return hostServiceHandlerEntry{}, false
+		}
+		slog.DebugContext(ctx, "serving core-routable host service relay", "plugin", pluginName, "service", target.Service)
+		return hostServiceHandlerEntry{
+			handler: newGRPCHostServiceHandler(func(srv *grpc.Server) {
+				proto.RegisterPluginInvokerServer(srv, providerhost.NewPluginInvokerServer(pluginName, entry.Invokes, s.invoker, s.invocationTokens))
+			}),
+		}, true
+	default:
+		return hostServiceHandlerEntry{}, false
+	}
+}
+
+func newGRPCHostServiceHandler(register func(*grpc.Server)) http.Handler {
+	srv := grpc.NewServer()
+	register(srv)
+	return http.HandlerFunc(srv.ServeHTTP)
 }
 
 func (s *Server) hostServiceHandlerEntry(ctx context.Context, key hostServiceHandlerKey, sessionID string) (hostServiceHandlerEntry, bool, error) {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -80,61 +81,63 @@ type BuiltinAdminUIOptions struct {
 }
 
 type Server struct {
-	router                 chi.Router
-	handler                http.Handler
-	auth                   core.AuthenticationProvider
-	authProviders          map[string]core.AuthenticationProvider
-	serverAuthProvider     string
-	auditSink              core.AuditSink
-	users                  *coredata.UserService
-	externalCredentials    core.ExternalCredentialProvider
-	apiTokens              *coredata.APITokenService
-	managedSubjects        *coredata.ManagedSubjectService
-	agent                  bootstrap.AgentControl
-	workflowSchedules      *workflowmanager.Manager
-	agentRuns              agentmanager.Service
-	authorizationProvider  core.AuthorizationProvider
-	providers              *registry.ProviderMap[core.Provider]
-	workflow               bootstrap.WorkflowControl
-	pluginRuntimes         bootstrap.RuntimeInspector
-	resolver               *principal.Resolver
-	authResolvers          map[string]*principal.Resolver
-	invoker                invocation.Invoker
-	defaultConnection      map[string]string
-	catalogConnection      map[string]string
-	connectionAuth         func() map[string]map[string]bootstrap.OAuthHandler
-	pluginDefs             map[string]*config.ProviderEntry
-	authorizer             authorization.RuntimeAuthorizer
-	noAuth                 bool
-	anonymousPrincipal     *principal.Principal
-	publicBaseURL          string
-	managementBaseURL      string
-	secureCookies          bool
-	encryptor              *cryptoutil.AESGCMEncryptor
-	sessionIssuer          []byte
-	stateCodec             *integrationOAuthStateCodec
-	apiTokenTTL            time.Duration
-	now                    func() time.Time
-	readiness              ReadinessChecker
-	meterProvider          metric.MeterProvider
-	prometheusMetrics      http.Handler
-	mcpHandler             http.Handler
-	hostServiceRelayTokens *runtimehost.HostServiceRelayTokenManager
-	hostServiceMu          sync.Mutex
-	hostServiceHandlers    map[hostServiceHandlerKey][]hostServiceHandlerEntry
-	hostServiceVersion     uint64
-	publicHostServices     *runtimehost.PublicHostServiceRegistry
-	s3                     map[string]s3store.Client
-	s3ObjectAccessURLs     *s3.ObjectAccessURLManager
-	egressProxyTokens      *egressproxy.TokenManager
-	providerDevSessions    *providerdev.Manager
-	providerDevAttach      bool
-	mountedHTTPBindings    []MountedHTTPBinding
-	mountedUIs             []MountedUI
-	adminRoute             AdminRouteConfig
-	adminUI                http.Handler
-	routeProfile           RouteProfile
-	httpBindingReplayStore httpBindingReplayStore
+	router                  chi.Router
+	handler                 http.Handler
+	auth                    core.AuthenticationProvider
+	authProviders           map[string]core.AuthenticationProvider
+	serverAuthProvider      string
+	auditSink               core.AuditSink
+	users                   *coredata.UserService
+	externalCredentials     core.ExternalCredentialProvider
+	apiTokens               *coredata.APITokenService
+	managedSubjects         *coredata.ManagedSubjectService
+	agent                   bootstrap.AgentControl
+	workflowSchedules       *workflowmanager.Manager
+	agentRuns               agentmanager.Service
+	authorizationProvider   core.AuthorizationProvider
+	providers               *registry.ProviderMap[core.Provider]
+	workflow                bootstrap.WorkflowControl
+	pluginRuntimes          bootstrap.RuntimeInspector
+	resolver                *principal.Resolver
+	authResolvers           map[string]*principal.Resolver
+	invoker                 invocation.Invoker
+	defaultConnection       map[string]string
+	catalogConnection       map[string]string
+	connectionAuth          func() map[string]map[string]bootstrap.OAuthHandler
+	pluginDefs              map[string]*config.ProviderEntry
+	authorizer              authorization.RuntimeAuthorizer
+	noAuth                  bool
+	anonymousPrincipal      *principal.Principal
+	publicBaseURL           string
+	managementBaseURL       string
+	secureCookies           bool
+	encryptor               *cryptoutil.AESGCMEncryptor
+	sessionIssuer           []byte
+	stateCodec              *integrationOAuthStateCodec
+	apiTokenTTL             time.Duration
+	now                     func() time.Time
+	readiness               ReadinessChecker
+	meterProvider           metric.MeterProvider
+	prometheusMetrics       http.Handler
+	mcpHandler              http.Handler
+	hostServiceRelayTokens  *runtimehost.HostServiceRelayTokenManager
+	invocationTokens        *providerhost.InvocationTokenManager
+	hostServiceMu           sync.Mutex
+	hostServiceHandlers     map[hostServiceHandlerKey][]hostServiceHandlerEntry
+	coreHostServiceHandlers map[hostServiceHandlerKey]hostServiceHandlerEntry
+	hostServiceVersion      uint64
+	publicHostServices      *runtimehost.PublicHostServiceRegistry
+	s3                      map[string]s3store.Client
+	s3ObjectAccessURLs      *s3.ObjectAccessURLManager
+	egressProxyTokens       *egressproxy.TokenManager
+	providerDevSessions     *providerdev.Manager
+	providerDevAttach       bool
+	mountedHTTPBindings     []MountedHTTPBinding
+	mountedUIs              []MountedUI
+	adminRoute              AdminRouteConfig
+	adminUI                 http.Handler
+	routeProfile            RouteProfile
+	httpBindingReplayStore  httpBindingReplayStore
 }
 
 func (s *Server) catalogSelectorConfig() invocation.CatalogSelectorConfig {
@@ -293,12 +296,17 @@ func New(cfg Config) (*Server, error) {
 		otelOptions = append(otelOptions, otelhttp.WithMeterProvider(cfg.MeterProvider))
 	}
 	var hostServiceRelayTokens *runtimehost.HostServiceRelayTokenManager
+	var invocationTokens *providerhost.InvocationTokenManager
 	var egressProxyTokens *egressproxy.TokenManager
 	var s3ObjectAccessURLs *s3.ObjectAccessURLManager
 	if len(cfg.StateSecret) > 0 {
 		hostServiceRelayTokens, err = runtimehost.NewHostServiceRelayTokenManager(cfg.StateSecret)
 		if err != nil {
 			return nil, fmt.Errorf("init host service relay tokens: %w", err)
+		}
+		invocationTokens, err = providerhost.NewInvocationTokenManager(cfg.StateSecret)
+		if err != nil {
+			return nil, fmt.Errorf("init invocation tokens: %w", err)
 		}
 		egressProxyTokens, err = egressproxy.NewTokenManager(cfg.StateSecret)
 		if err != nil {
@@ -353,6 +361,7 @@ func New(cfg Config) (*Server, error) {
 		prometheusMetrics:      cfg.PrometheusMetrics,
 		mcpHandler:             cfg.MCPHandler,
 		hostServiceRelayTokens: hostServiceRelayTokens,
+		invocationTokens:       invocationTokens,
 		hostServiceHandlers:    hostServiceHandlers,
 		hostServiceVersion:     hostServiceVersion,
 		publicHostServices:     cfg.PublicHostServices,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -40,6 +40,7 @@ import (
 	s3store "github.com/valon-technologies/gestalt/server/core/s3"
 	"github.com/valon-technologies/gestalt/server/core/session"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/adminui"
 	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/apiexec"
@@ -66,15 +67,18 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
 	coreintegration "github.com/valon-technologies/gestalt/server/services/plugins/declarative"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/s3"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func newTestServer(t *testing.T, opts ...func(*server.Config)) *httptest.Server {
@@ -451,6 +455,90 @@ func (s *relayTestCacheServer) calls() int {
 	return len(s.keys)
 }
 
+type relayTestInvoker struct {
+	mu             sync.Mutex
+	providerName   string
+	instance       string
+	operation      string
+	idempotencyKey string
+	params         map[string]any
+}
+
+func (i *relayTestInvoker) Invoke(ctx context.Context, _ *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.providerName = providerName
+	i.instance = instance
+	i.operation = operation
+	i.idempotencyKey = invocation.IdempotencyKeyFromContext(ctx)
+	i.params = maps.Clone(params)
+	return &core.OperationResult{Status: 202, Body: "relayed"}, nil
+}
+
+type relayTestInvokerCall struct {
+	providerName   string
+	instance       string
+	operation      string
+	idempotencyKey string
+	params         map[string]any
+}
+
+func (i *relayTestInvoker) snapshot() relayTestInvokerCall {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return relayTestInvokerCall{
+		providerName:   i.providerName,
+		instance:       i.instance,
+		operation:      i.operation,
+		idempotencyKey: i.idempotencyKey,
+		params:         maps.Clone(i.params),
+	}
+}
+
+type relayTestWorkflowProvider struct {
+	*memoryWorkflowProvider
+
+	mu               sync.Mutex
+	signalOrStartReq coreworkflow.SignalOrStartRunRequest
+}
+
+func newRelayTestWorkflowProvider() *relayTestWorkflowProvider {
+	return &relayTestWorkflowProvider{
+		memoryWorkflowProvider: newMemoryWorkflowProvider(),
+	}
+}
+
+func (p *relayTestWorkflowProvider) SignalOrStartRun(_ context.Context, req coreworkflow.SignalOrStartRunRequest) (*coreworkflow.SignalRunResponse, error) {
+	p.mu.Lock()
+	p.signalOrStartReq = req
+	p.mu.Unlock()
+	now := time.Now().UTC()
+	signal := req.Signal
+	if signal.ID == "" {
+		signal.ID = "signal-1"
+	}
+	return &coreworkflow.SignalRunResponse{
+		Run: &coreworkflow.Run{
+			ID:           "workflow-run-1",
+			Status:       coreworkflow.RunStatusRunning,
+			WorkflowKey:  req.WorkflowKey,
+			Target:       req.Target,
+			ExecutionRef: req.ExecutionRef,
+			CreatedAt:    &now,
+			StartedAt:    &now,
+		},
+		Signal:      signal,
+		StartedRun:  true,
+		WorkflowKey: req.WorkflowKey,
+	}, nil
+}
+
+func (p *relayTestWorkflowProvider) signalOrStartRequest() coreworkflow.SignalOrStartRunRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.signalOrStartReq
+}
+
 type relayTestSessionVerifier struct {
 	mu     sync.Mutex
 	active map[string]bool
@@ -695,6 +783,241 @@ func TestHostServiceRelayStopsServingUnregisteredSession(t *testing.T) {
 	}
 	if got := cacheSrv.calls(); got != 1 {
 		t.Fatalf("backend calls = %d, want only the registered call", got)
+	}
+}
+
+func TestHostServiceRelayServesCoreRoutablePluginInvokerWithoutRegistry(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	invoker := &relayTestInvoker{}
+	invokes := []config.PluginInvocationDependency{{
+		Plugin:         "slack",
+		Operation:      "events.reply",
+		CredentialMode: providermanifestv1.ConnectionModeNone,
+	}}
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+		cfg.Invoker = invoker
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"support": {Invokes: invokes},
+		}
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-elsewhere",
+		Service:      "plugin_invoker",
+		EnvVar:       plugininvokerservice.DefaultSocketEnv,
+		MethodPrefix: "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/",
+		CoreRoutable: true,
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+	invocationTokens, err := providerhost.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "user:test-user",
+		UserID:    "test-user",
+		Kind:      principal.KindUser,
+		Source:    principal.SourceSession,
+	})
+	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "support", providerhost.InvocationDependencyGrants(invokes))
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+	params, err := structpb.NewStruct(map[string]any{"channel_id": "C123", "thread_ts": "123.456"})
+	if err != nil {
+		t.Fatalf("NewStruct: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+	resp, err := proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{
+		InvocationToken: invocationToken,
+		Plugin:          "slack",
+		Operation:       "events.reply",
+		Instance:        "prod",
+		IdempotencyKey:  "tool-call-1",
+		Params:          params,
+	})
+	if err != nil {
+		t.Fatalf("PluginInvoker.Invoke via relay: %v", err)
+	}
+	if resp.GetStatus() != 202 || resp.GetBody() != "relayed" {
+		t.Fatalf("PluginInvoker.Invoke response = %+v, want status=202 body=relayed", resp)
+	}
+	call := invoker.snapshot()
+	if call.providerName != "slack" || call.operation != "events.reply" || call.instance != "prod" {
+		t.Fatalf("invocation target = %s.%s/%s, want slack.events.reply/prod", call.providerName, call.operation, call.instance)
+	}
+	if call.idempotencyKey != "tool-call-1" {
+		t.Fatalf("idempotency key = %q, want tool-call-1", call.idempotencyKey)
+	}
+	if call.params["channel_id"] != "C123" || call.params["thread_ts"] != "123.456" {
+		t.Fatalf("params = %#v, want Slack reply params", call.params)
+	}
+}
+
+func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	workflowProvider := newRelayTestWorkflowProvider()
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		providers := registry.New()
+		if err := providers.Providers.Register("github", &coretesting.StubIntegration{
+			N:        "github",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: serverTestCatalogFromOperations("github", []core.Operation{{
+				Name:   "events.handle",
+				Method: http.MethodPost,
+			}}),
+		}); err != nil {
+			t.Fatalf("register provider: %v", err)
+		}
+		cfg.Providers = &providers.Providers
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "local",
+			provider:            workflowProvider,
+		}
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "github",
+		SessionID:    "session-elsewhere",
+		Service:      "workflow_manager",
+		EnvVar:       workflowservice.DefaultManagerSocketEnv,
+		MethodPrefix: "/" + proto.WorkflowManagerHost_ServiceDesc.ServiceName + "/",
+		CoreRoutable: true,
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+	invocationTokens, err := providerhost.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "service_account:github_app_installation:99:repo:acme/widgets",
+		Kind:      principal.KindUser,
+		Source:    principal.SourceSession,
+	})
+	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "github", nil)
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+	resp, err := proto.NewWorkflowManagerHostClient(conn).SignalOrStartRun(ctx, &proto.WorkflowManagerSignalOrStartRunRequest{
+		ProviderName:    "local",
+		WorkflowKey:     "github:99:acme/widgets:pull_request:7",
+		IdempotencyKey:  "delivery-1",
+		InvocationToken: invocationToken,
+		Target: &proto.BoundWorkflowTarget{Kind: &proto.BoundWorkflowTarget_Plugin{
+			Plugin: &proto.BoundWorkflowPluginTarget{
+				PluginName: "github",
+				Operation:  "events.handle",
+			},
+		}},
+		Signal: &proto.WorkflowSignal{Name: "github.app.webhook", IdempotencyKey: "delivery-1"},
+	})
+	if err != nil {
+		t.Fatalf("WorkflowManager.SignalOrStartRun via relay: %v", err)
+	}
+	if resp.GetRun().GetId() != "workflow-run-1" || resp.GetWorkflowKey() != "github:99:acme/widgets:pull_request:7" {
+		t.Fatalf("SignalOrStartRun response = %+v, want relayed workflow run", resp)
+	}
+	if !resp.GetStartedRun() || resp.GetSignal().GetId() != "signal-1" {
+		t.Fatalf("SignalOrStartRun signal response = %+v, want started signal-1", resp)
+	}
+	call := workflowProvider.signalOrStartRequest()
+	if call.WorkflowKey != "github:99:acme/widgets:pull_request:7" {
+		t.Fatalf("workflow key = %q, want github:99:acme/widgets:pull_request:7", call.WorkflowKey)
+	}
+	if call.Target.Plugin == nil || call.Target.Plugin.PluginName != "github" || call.Target.Plugin.Operation != "events.handle" {
+		t.Fatalf("workflow target = %#v, want github events.handle target", call.Target)
+	}
+}
+
+func TestHostServiceRelayDoesNotFallbackWithoutCoreRoutableToken(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	invoker := &relayTestInvoker{}
+	invokes := []config.PluginInvocationDependency{{
+		Plugin:         "slack",
+		Operation:      "events.reply",
+		CredentialMode: providermanifestv1.ConnectionModeNone,
+	}}
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+		cfg.Invoker = invoker
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"support": {Invokes: invokes},
+		}
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "provider-dev-session",
+		Service:      "plugin_invoker",
+		EnvVar:       plugininvokerservice.DefaultSocketEnv,
+		MethodPrefix: "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/",
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+	_, err = proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{})
+	if grpcstatus.Code(err) != codes.Unavailable {
+		t.Fatalf("PluginInvoker.Invoke non-core-routable code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
+	}
+	if call := invoker.snapshot(); call.providerName != "" {
+		t.Fatalf("invoker was called for non-core-routable relay: %+v", call)
 	}
 }
 

--- a/gestaltd/services/runtimehost/host_service_relay_token.go
+++ b/gestaltd/services/runtimehost/host_service_relay_token.go
@@ -31,6 +31,7 @@ type HostServiceRelayTokenRequest struct {
 	Service      string
 	EnvVar       string
 	MethodPrefix string
+	CoreRoutable bool
 	TTL          time.Duration
 }
 
@@ -40,6 +41,7 @@ type HostServiceRelayTarget struct {
 	Service      string
 	EnvVar       string
 	MethodPrefix string
+	CoreRoutable bool
 }
 
 type hostServiceRelayTokenClaims struct {
@@ -49,6 +51,7 @@ type hostServiceRelayTokenClaims struct {
 	Service      string `json:"service,omitempty"`
 	EnvVar       string `json:"env_var,omitempty"`
 	MethodPrefix string `json:"method_prefix,omitempty"`
+	CoreRoutable bool   `json:"core_routable,omitempty"`
 }
 
 func NewHostServiceRelayTokenManager(secret []byte) (*HostServiceRelayTokenManager, error) {
@@ -100,6 +103,7 @@ func (m *HostServiceRelayTokenManager) MintToken(req HostServiceRelayTokenReques
 		Service:      service,
 		EnvVar:       envVar,
 		MethodPrefix: methodPrefix,
+		CoreRoutable: req.CoreRoutable,
 	})
 }
 
@@ -121,6 +125,7 @@ func (m *HostServiceRelayTokenManager) ResolveToken(token string) (HostServiceRe
 		Service:      service,
 		EnvVar:       envVar,
 		MethodPrefix: methodPrefix,
+		CoreRoutable: claims.CoreRoutable,
 	}, nil
 }
 


### PR DESCRIPTION
## Problem
Hosted plugin runtimes use public gRPC relay tokens to call gestaltd-owned host services. During multi-instance or revision rollout, a valid runtime can hit an instance that does not have the runtime session in its in-memory `PublicHostServiceRegistry`, causing `host-service-relay-unavailable` for workflow dispatch and agent tool calls.

## Interfaces
- `runtimehost.HostServiceRelayTokenRequest.CoreRoutable bool`
- `runtimehost.HostServiceRelayTarget.CoreRoutable bool`

Only hosted-runtime tokens for these gestaltd-owned services set the signed claim:
- `workflow_manager` / `WorkflowManagerHost`
- `agent_manager` / `AgentManagerHost`
- `plugin_invoker` / `PluginInvoker`

Provider-dev and session-local services do not set it. `authorization`, `agent_host`, `indexeddb`, `cache`, and `s3` remain registry/session scoped.

## Behavior
Registry hits still win. On registry miss, the public relay dynamically serves only exact known `(service, env_var, method_prefix)` tuples and only when the signed token has `CoreRoutable=true`.

## Examples
- A hosted Slack or GitHub runtime can call `WorkflowManagerHost.SignalOrStartRun` through any public gestaltd instance.
- An agent tool call can reach `PluginInvoker.Invoke` through any public gestaltd instance, using the caller plugin from the signed host-service token and invocation grants from `PluginDefs`.

## Verification
- `go test ./internal/server -run 'TestHostServiceRelay'`
- `go test ./services/runtimehost ./internal/server ./internal/bootstrap -run 'TestHostServiceRelay|TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin|TestNonExistent'`