### PR TITLE
[codex] Harden MCP OAuth token issuance

### DIFF
--- a/gestaltd/core/crypto/aesgcm.go
+++ b/gestaltd/core/crypto/aesgcm.go
@@ -26,22 +26,30 @@ func NewAESGCM(key []byte) (*AESGCMEncryptor, error) {
 }
 
 func (e *AESGCMEncryptor) Encrypt(plaintext string) (string, error) {
-	return e.encrypt(plaintext, base64.StdEncoding)
+	return e.encrypt(plaintext, base64.StdEncoding, nil)
 }
 
 func (e *AESGCMEncryptor) Decrypt(encoded string) (string, error) {
-	return e.decrypt(encoded, base64.StdEncoding)
+	return e.decrypt(encoded, base64.StdEncoding, nil)
 }
 
 func (e *AESGCMEncryptor) EncryptURLSafe(plaintext string) (string, error) {
-	return e.encrypt(plaintext, base64.RawURLEncoding)
+	return e.encrypt(plaintext, base64.RawURLEncoding, nil)
 }
 
 func (e *AESGCMEncryptor) DecryptURLSafe(encoded string) (string, error) {
-	return e.decrypt(encoded, base64.RawURLEncoding)
+	return e.decrypt(encoded, base64.RawURLEncoding, nil)
 }
 
-func (e *AESGCMEncryptor) encrypt(plaintext string, enc *base64.Encoding) (string, error) {
+func (e *AESGCMEncryptor) EncryptURLSafeWithAAD(plaintext string, aad []byte) (string, error) {
+	return e.encrypt(plaintext, base64.RawURLEncoding, aad)
+}
+
+func (e *AESGCMEncryptor) DecryptURLSafeWithAAD(encoded string, aad []byte) (string, error) {
+	return e.decrypt(encoded, base64.RawURLEncoding, aad)
+}
+
+func (e *AESGCMEncryptor) encrypt(plaintext string, enc *base64.Encoding, aad []byte) (string, error) {
 	if plaintext == "" {
 		return "", nil
 	}
@@ -49,11 +57,11 @@ func (e *AESGCMEncryptor) encrypt(plaintext string, enc *base64.Encoding) (strin
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return "", fmt.Errorf("generating nonce: %w", err)
 	}
-	ciphertext := e.gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	ciphertext := e.gcm.Seal(nonce, nonce, []byte(plaintext), aad)
 	return enc.EncodeToString(ciphertext), nil
 }
 
-func (e *AESGCMEncryptor) decrypt(encoded string, enc *base64.Encoding) (string, error) {
+func (e *AESGCMEncryptor) decrypt(encoded string, enc *base64.Encoding, aad []byte) (string, error) {
 	if encoded == "" {
 		return "", nil
 	}
@@ -66,7 +74,7 @@ func (e *AESGCMEncryptor) decrypt(encoded string, enc *base64.Encoding) (string,
 		return "", fmt.Errorf("ciphertext too short")
 	}
 	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
-	plaintext, err := e.gcm.Open(nil, nonce, ciphertext, nil)
+	plaintext, err := e.gcm.Open(nil, nonce, ciphertext, aad)
 	if err != nil {
 		return "", fmt.Errorf("decrypt: %w", err)
 	}

--- a/gestaltd/core/session/session.go
+++ b/gestaltd/core/session/session.go
@@ -11,6 +11,11 @@ import (
 
 var ErrNotJWT = errors.New("not a JWT")
 
+const (
+	Issuer   = "gestaltd"
+	Audience = "gestalt-session"
+)
+
 type claims struct {
 	jwt.RegisteredClaims
 	Email       string `json:"email"`
@@ -21,6 +26,8 @@ type claims struct {
 func IssueToken(identity *core.UserIdentity, secret []byte, ttl time.Duration) (string, error) {
 	c := claims{
 		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    Issuer,
+			Audience:  jwt.ClaimStrings{Audience},
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(ttl)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 		},
@@ -33,12 +40,19 @@ func IssueToken(identity *core.UserIdentity, secret []byte, ttl time.Duration) (
 }
 
 func ValidateToken(tokenStr string, secret []byte) (*core.UserIdentity, error) {
-	token, err := jwt.ParseWithClaims(tokenStr, &claims{}, func(t *jwt.Token) (any, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
-		}
-		return secret, nil
-	})
+	token, err := jwt.ParseWithClaims(
+		tokenStr,
+		&claims{},
+		func(t *jwt.Token) (any, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+			}
+			return secret, nil
+		},
+		jwt.WithIssuer(Issuer),
+		jwt.WithAudience(Audience),
+		jwt.WithExpirationRequired(),
+	)
 	if err != nil {
 		if errors.Is(err, jwt.ErrTokenMalformed) {
 			return nil, ErrNotJWT

--- a/gestaltd/internal/coredata/mcp_oauth_grants.go
+++ b/gestaltd/internal/coredata/mcp_oauth_grants.go
@@ -1,0 +1,333 @@
+package coredata
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+const (
+	MCPOAuthGrantKindAuthorizationCode = "authorization_code"
+	MCPOAuthGrantKindRefreshToken      = "refresh_token"
+)
+
+var (
+	ErrMCPOAuthGrantNotFound = errors.New("mcp oauth grant: not found")
+	ErrMCPOAuthGrantConsumed = errors.New("mcp oauth grant: consumed")
+	ErrMCPOAuthGrantRevoked  = errors.New("mcp oauth grant: revoked")
+	ErrMCPOAuthGrantExpired  = errors.New("mcp oauth grant: expired")
+)
+
+type MCPOAuthGrantService struct {
+	db    indexeddb.IndexedDB
+	store indexeddb.ObjectStore
+	now   func() time.Time
+}
+
+func NewMCPOAuthGrantService(ds indexeddb.IndexedDB) *MCPOAuthGrantService {
+	return &MCPOAuthGrantService{
+		db:    ds,
+		store: ds.ObjectStore(StoreMCPOAuthGrants),
+		now:   time.Now,
+	}
+}
+
+func (s *MCPOAuthGrantService) StoreAuthorizationCode(ctx context.Context, code string, expiresAt time.Time) error {
+	if s == nil {
+		return fmt.Errorf("store mcp oauth authorization code: service is not configured")
+	}
+	return s.addGrant(ctx, mcpOAuthGrantRecord{
+		ID:        hashMCPOAuthGrantToken(code),
+		Kind:      MCPOAuthGrantKindAuthorizationCode,
+		ExpiresAt: expiresAt,
+	})
+}
+
+func (s *MCPOAuthGrantService) ConsumeAuthorizationCode(ctx context.Context, code string) error {
+	if s == nil {
+		return fmt.Errorf("consume mcp oauth authorization code: service is not configured")
+	}
+	return s.consumeGrant(ctx, hashMCPOAuthGrantToken(code), MCPOAuthGrantKindAuthorizationCode)
+}
+
+func (s *MCPOAuthGrantService) ConsumeAuthorizationCodeAndStoreRefreshToken(ctx context.Context, code, refreshToken, familyID string, refreshExpiresAt time.Time) error {
+	if s == nil {
+		return fmt.Errorf("exchange mcp oauth authorization code: service is not configured")
+	}
+	if familyID == "" {
+		return fmt.Errorf("exchange mcp oauth authorization code: refresh token family ID is required")
+	}
+
+	tx, err := s.db.Transaction(ctx, []string{StoreMCPOAuthGrants}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return fmt.Errorf("exchange mcp oauth authorization code: begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Abort(ctx) }()
+
+	store := tx.ObjectStore(StoreMCPOAuthGrants)
+	now := s.now().UTC()
+	codeRec, err := getMCPOAuthGrantRecord(ctx, store, hashMCPOAuthGrantToken(code))
+	if err != nil {
+		return err
+	}
+	if codeRec.Kind != MCPOAuthGrantKindAuthorizationCode {
+		return ErrMCPOAuthGrantNotFound
+	}
+	if !codeRec.RevokedAt.IsZero() {
+		return ErrMCPOAuthGrantRevoked
+	}
+	if !codeRec.ConsumedAt.IsZero() {
+		return ErrMCPOAuthGrantConsumed
+	}
+	if !codeRec.ExpiresAt.IsZero() && now.After(codeRec.ExpiresAt) {
+		return ErrMCPOAuthGrantExpired
+	}
+
+	codeRec.ConsumedAt = now
+	codeRec.UpdatedAt = now
+	if err := store.Put(ctx, codeRec.toIndexedDBRecord()); err != nil {
+		return fmt.Errorf("exchange mcp oauth authorization code: consume code: %w", err)
+	}
+	if err := addMCPOAuthGrantRecord(ctx, store, mcpOAuthGrantRecord{
+		ID:        hashMCPOAuthGrantToken(refreshToken),
+		Kind:      MCPOAuthGrantKindRefreshToken,
+		FamilyID:  familyID,
+		ExpiresAt: refreshExpiresAt,
+	}, now); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("exchange mcp oauth authorization code: commit: %w", err)
+	}
+	return nil
+}
+
+func (s *MCPOAuthGrantService) StoreRefreshToken(ctx context.Context, refreshToken, familyID string, expiresAt time.Time) error {
+	if s == nil {
+		return fmt.Errorf("store mcp oauth refresh token: service is not configured")
+	}
+	if familyID == "" {
+		return fmt.Errorf("store mcp oauth refresh token: family ID is required")
+	}
+	return s.addGrant(ctx, mcpOAuthGrantRecord{
+		ID:        hashMCPOAuthGrantToken(refreshToken),
+		Kind:      MCPOAuthGrantKindRefreshToken,
+		FamilyID:  familyID,
+		ExpiresAt: expiresAt,
+	})
+}
+
+func (s *MCPOAuthGrantService) RotateRefreshToken(ctx context.Context, oldToken, newToken, familyID string, newExpiresAt time.Time) error {
+	if s == nil {
+		return fmt.Errorf("rotate mcp oauth refresh token: service is not configured")
+	}
+	if familyID == "" {
+		return fmt.Errorf("rotate mcp oauth refresh token: family ID is required")
+	}
+
+	tx, err := s.db.Transaction(ctx, []string{StoreMCPOAuthGrants}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return fmt.Errorf("rotate mcp oauth refresh token: begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Abort(ctx) }()
+
+	store := tx.ObjectStore(StoreMCPOAuthGrants)
+	oldID := hashMCPOAuthGrantToken(oldToken)
+	now := s.now().UTC()
+	rec, err := getMCPOAuthGrantRecord(ctx, store, oldID)
+	if err != nil {
+		return err
+	}
+	if rec.Kind != MCPOAuthGrantKindRefreshToken || rec.FamilyID != familyID {
+		return ErrMCPOAuthGrantNotFound
+	}
+	if !rec.RevokedAt.IsZero() {
+		return ErrMCPOAuthGrantRevoked
+	}
+	if !rec.ConsumedAt.IsZero() {
+		if err := revokeMCPOAuthGrantFamily(ctx, store, familyID, now); err != nil {
+			return err
+		}
+		if commitErr := tx.Commit(ctx); commitErr != nil {
+			return fmt.Errorf("rotate mcp oauth refresh token: commit reuse revocation: %w", commitErr)
+		}
+		return ErrMCPOAuthGrantConsumed
+	}
+	if !rec.ExpiresAt.IsZero() && now.After(rec.ExpiresAt) {
+		return ErrMCPOAuthGrantExpired
+	}
+
+	rec.ConsumedAt = now
+	rec.UpdatedAt = now
+	if err := store.Put(ctx, rec.toIndexedDBRecord()); err != nil {
+		return fmt.Errorf("rotate mcp oauth refresh token: consume old token: %w", err)
+	}
+	if err := addMCPOAuthGrantRecord(ctx, store, mcpOAuthGrantRecord{
+		ID:        hashMCPOAuthGrantToken(newToken),
+		Kind:      MCPOAuthGrantKindRefreshToken,
+		FamilyID:  familyID,
+		ExpiresAt: newExpiresAt,
+	}, now); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("rotate mcp oauth refresh token: commit: %w", err)
+	}
+	return nil
+}
+
+func (s *MCPOAuthGrantService) addGrant(ctx context.Context, rec mcpOAuthGrantRecord) error {
+	now := s.now().UTC()
+	if err := addMCPOAuthGrantRecord(ctx, s.store, rec, now); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *MCPOAuthGrantService) consumeGrant(ctx context.Context, id, kind string) error {
+	tx, err := s.db.Transaction(ctx, []string{StoreMCPOAuthGrants}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		return fmt.Errorf("consume mcp oauth grant: begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Abort(ctx) }()
+
+	store := tx.ObjectStore(StoreMCPOAuthGrants)
+	now := s.now().UTC()
+	rec, err := getMCPOAuthGrantRecord(ctx, store, id)
+	if err != nil {
+		return err
+	}
+	if rec.Kind != kind {
+		return ErrMCPOAuthGrantNotFound
+	}
+	if !rec.RevokedAt.IsZero() {
+		return ErrMCPOAuthGrantRevoked
+	}
+	if !rec.ConsumedAt.IsZero() {
+		return ErrMCPOAuthGrantConsumed
+	}
+	if !rec.ExpiresAt.IsZero() && now.After(rec.ExpiresAt) {
+		return ErrMCPOAuthGrantExpired
+	}
+
+	rec.ConsumedAt = now
+	rec.UpdatedAt = now
+	if err := store.Put(ctx, rec.toIndexedDBRecord()); err != nil {
+		return fmt.Errorf("consume mcp oauth grant: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("consume mcp oauth grant: commit: %w", err)
+	}
+	return nil
+}
+
+type mcpOAuthGrantRecord struct {
+	ID         string
+	Kind       string
+	FamilyID   string
+	ExpiresAt  time.Time
+	ConsumedAt time.Time
+	RevokedAt  time.Time
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+func (r mcpOAuthGrantRecord) toIndexedDBRecord() indexeddb.Record {
+	return indexeddb.Record{
+		"id":          r.ID,
+		"kind":        r.Kind,
+		"family_id":   r.FamilyID,
+		"expires_at":  r.ExpiresAt,
+		"consumed_at": zeroTimeToNil(r.ConsumedAt),
+		"revoked_at":  zeroTimeToNil(r.RevokedAt),
+		"created_at":  r.CreatedAt,
+		"updated_at":  r.UpdatedAt,
+	}
+}
+
+func mcpOAuthGrantRecordFromIndexedDB(rec indexeddb.Record) mcpOAuthGrantRecord {
+	return mcpOAuthGrantRecord{
+		ID:         recString(rec, "id"),
+		Kind:       recString(rec, "kind"),
+		FamilyID:   recString(rec, "family_id"),
+		ExpiresAt:  recTime(rec, "expires_at"),
+		ConsumedAt: recTime(rec, "consumed_at"),
+		RevokedAt:  recTime(rec, "revoked_at"),
+		CreatedAt:  recTime(rec, "created_at"),
+		UpdatedAt:  recTime(rec, "updated_at"),
+	}
+}
+
+func addMCPOAuthGrantRecord(ctx context.Context, store interface {
+	Add(context.Context, indexeddb.Record) error
+}, rec mcpOAuthGrantRecord, now time.Time) error {
+	if rec.ID == "" {
+		return fmt.Errorf("add mcp oauth grant: ID is required")
+	}
+	if rec.Kind == "" {
+		return fmt.Errorf("add mcp oauth grant: kind is required")
+	}
+	if rec.ExpiresAt.IsZero() {
+		return fmt.Errorf("add mcp oauth grant: expiration is required")
+	}
+	rec.CreatedAt = now
+	rec.UpdatedAt = now
+	if err := store.Add(ctx, rec.toIndexedDBRecord()); err != nil {
+		if errors.Is(err, indexeddb.ErrAlreadyExists) {
+			return ErrMCPOAuthGrantConsumed
+		}
+		return fmt.Errorf("add mcp oauth grant: %w", err)
+	}
+	return nil
+}
+
+func getMCPOAuthGrantRecord(ctx context.Context, store interface {
+	Get(context.Context, string) (indexeddb.Record, error)
+}, id string) (mcpOAuthGrantRecord, error) {
+	rec, err := store.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return mcpOAuthGrantRecord{}, ErrMCPOAuthGrantNotFound
+		}
+		return mcpOAuthGrantRecord{}, fmt.Errorf("get mcp oauth grant: %w", err)
+	}
+	return mcpOAuthGrantRecordFromIndexedDB(rec), nil
+}
+
+func revokeMCPOAuthGrantFamily(ctx context.Context, store indexeddb.TransactionObjectStore, familyID string, revokedAt time.Time) error {
+	recs, err := store.Index("by_family").GetAll(ctx, nil, familyID)
+	if err != nil {
+		return fmt.Errorf("revoke mcp oauth grant family: %w", err)
+	}
+	for _, raw := range recs {
+		rec := mcpOAuthGrantRecordFromIndexedDB(raw)
+		if rec.Kind != MCPOAuthGrantKindRefreshToken || rec.FamilyID != familyID {
+			continue
+		}
+		if rec.RevokedAt.IsZero() {
+			rec.RevokedAt = revokedAt
+			rec.UpdatedAt = revokedAt
+			if err := store.Put(ctx, rec.toIndexedDBRecord()); err != nil {
+				return fmt.Errorf("revoke mcp oauth grant family: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func hashMCPOAuthGrantToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func zeroTimeToNil(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -8,6 +8,7 @@ const (
 	StoreUsers           = "users"
 	StoreAPITokens       = "api_tokens"
 	StoreManagedSubjects = "managed_subjects"
+	StoreMCPOAuthGrants  = "mcp_oauth_grants"
 )
 
 var UsersSchema = indexeddb.ObjectStoreSchema{
@@ -63,5 +64,22 @@ var ManagedSubjectsSchema = indexeddb.ObjectStoreSchema{
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
 		{Name: "deleted_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var MCPOAuthGrantsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_kind", KeyPath: []string{"kind"}},
+		{Name: "by_family", KeyPath: []string{"family_id"}},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "kind", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "family_id", Type: indexeddb.TypeString},
+		{Name: "expires_at", Type: indexeddb.TypeTime, NotNull: true},
+		{Name: "consumed_at", Type: indexeddb.TypeTime},
+		{Name: "revoked_at", Type: indexeddb.TypeTime},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
 	},
 }

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -14,6 +14,7 @@ type Services struct {
 	ExternalCredentials core.ExternalCredentialProvider
 	APITokens           *APITokenService
 	ManagedSubjects     *ManagedSubjectService
+	MCPOAuthGrants      *MCPOAuthGrantService
 	RuntimeSessionLogs  runtimelogs.Store
 	DB                  indexeddb.IndexedDB
 }
@@ -35,17 +36,22 @@ func NewWithContext(ctx context.Context, ds indexeddb.IndexedDB) (*Services, err
 	if err := ds.CreateObjectStore(ctx, StoreManagedSubjects, ManagedSubjectsSchema); err != nil {
 		return nil, fmt.Errorf("create managed_subjects store: %w", err)
 	}
+	if err := ds.CreateObjectStore(ctx, StoreMCPOAuthGrants, MCPOAuthGrantsSchema); err != nil {
+		return nil, fmt.Errorf("create mcp_oauth_grants store: %w", err)
+	}
 
 	runtimeSessionLogs := runtimelogs.NewMemoryStore()
 
 	users := NewUserService(ds)
 	apiTokens := NewAPITokenService(ds)
 	managedSubjects := NewManagedSubjectService(ds)
+	mcpOAuthGrants := NewMCPOAuthGrantService(ds)
 	return &Services{
 		ExternalCredentials: nil,
 		Users:               users,
 		APITokens:           apiTokens,
 		ManagedSubjects:     managedSubjects,
+		MCPOAuthGrants:      mcpOAuthGrants,
 		RuntimeSessionLogs:  runtimeSessionLogs,
 		DB:                  ds,
 	}, nil

--- a/gestaltd/internal/server/handlers_mcp_authorization_server.go
+++ b/gestaltd/internal/server/handlers_mcp_authorization_server.go
@@ -7,11 +7,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/plugins/oauth"
 )
@@ -20,6 +24,7 @@ const (
 	mcpAuthorizationServerMetadataPath       = "/.well-known/oauth-authorization-server"
 	mcpAuthorizationServerMetadataMCPPath    = "/.well-known/oauth-authorization-server/mcp"
 	mcpAuthorizationEndpointPath             = "/oauth/authorize"
+	mcpAuthorizationConsentEndpointPath      = "/oauth/authorize/consent"
 	mcpTokenEndpointPath                     = "/oauth/token"
 	mcpRegistrationEndpointPath              = "/oauth/register"
 	mcpOAuthTokenAuthMethodNone              = "none"
@@ -258,26 +263,79 @@ func (s *Server) mcpOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/api/v1/auth/login?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusFound)
 		return
 	}
+	if strings.EqualFold(strings.TrimSpace(query.Get("prompt")), "none") {
+		redirectMCPOAuthError(w, r, redirectURI, state, "interaction_required", "user consent is required")
+		return
+	}
 
-	code, err := encodeMCPOAuthAuthorizationCode(s.encryptor, mcpOAuthAuthorizationCodeState{
+	consent, err := encodeMCPOAuthConsentState(s.encryptor, mcpOAuthConsentState{
 		ClientID:            clientID,
 		RedirectURI:         redirectURI,
 		Email:               p.Identity.Email,
 		DisplayName:         p.Identity.DisplayName,
 		AvatarURL:           p.Identity.AvatarURL,
 		Scope:               strings.TrimSpace(query.Get("scope")),
+		State:               state,
 		CodeChallenge:       codeChallenge,
 		CodeChallengeMethod: codeChallengeMethod,
 		ExpiresAt:           s.now().Add(mcpOAuthAuthorizationCodeTTL).Unix(),
 	})
 	if err != nil {
+		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "failed to prepare authorization consent")
+		return
+	}
+
+	writeMCPOAuthConsentPage(w, client.ClientName, strings.TrimSpace(query.Get("scope")), consent)
+}
+
+func (s *Server) mcpOAuthAuthorizeConsent(w http.ResponseWriter, r *http.Request) {
+	auth := s.serverAuthRuntime()
+	if auth.noAuth || auth.provider == nil {
+		writeMCPOAuthError(w, http.StatusNotFound, "server_error", "auth is disabled")
+		return
+	}
+	if s.encryptor == nil {
+		writeMCPOAuthError(w, http.StatusServiceUnavailable, "server_error", "MCP OAuth authorization is unavailable")
+		return
+	}
+	if !s.sameOriginFormPost(r) {
+		writeMCPOAuthError(w, http.StatusForbidden, "invalid_request", "authorization consent origin is invalid")
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_request", "invalid authorization consent body")
+		return
+	}
+	consent := strings.TrimSpace(r.Form.Get("consent"))
+	if consent == "" {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_request", "authorization consent is required")
+		return
+	}
+	state, err := decodeMCPOAuthConsentState(s.encryptor, consent, s.now())
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_request", "authorization consent is invalid")
+		return
+	}
+
+	p, err := s.resolveRequestPrincipalWithResolver(r, auth.resolver)
+	if err != nil || p == nil || p.Identity == nil || p.Identity.Email == "" || principal.IsNonUserPrincipal(p) {
+		writeMCPOAuthError(w, http.StatusUnauthorized, "login_required", "user login is required")
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(p.Identity.Email), strings.TrimSpace(state.Email)) {
+		writeMCPOAuthError(w, http.StatusForbidden, "access_denied", "authorization consent does not match the logged-in user")
+		return
+	}
+
+	code, err := s.issueMCPOAuthAuthorizationCode(r, *state)
+	if err != nil {
 		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue authorization code")
 		return
 	}
 
-	redirectMCPOAuthSuccess(w, r, redirectURI, map[string]string{
+	redirectMCPOAuthSuccess(w, r, state.RedirectURI, map[string]string{
 		"code":  code,
-		"state": state,
+		"state": state.State,
 	})
 }
 
@@ -330,7 +388,33 @@ func (s *Server) mcpOAuthToken(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (s *Server) issueMCPOAuthAuthorizationCode(r *http.Request, consent mcpOAuthConsentState) (string, error) {
+	if s.mcpOAuthGrants == nil {
+		return "", fmt.Errorf("mcp oauth grant store is not configured")
+	}
+	expiresAt := s.now().Add(mcpOAuthAuthorizationCodeTTL)
+	code, err := encodeMCPOAuthAuthorizationCode(s.encryptor, mcpOAuthAuthorizationCodeState{
+		ClientID:            consent.ClientID,
+		RedirectURI:         consent.RedirectURI,
+		Email:               consent.Email,
+		DisplayName:         consent.DisplayName,
+		AvatarURL:           consent.AvatarURL,
+		Scope:               consent.Scope,
+		CodeChallenge:       consent.CodeChallenge,
+		CodeChallengeMethod: consent.CodeChallengeMethod,
+		ExpiresAt:           expiresAt.Unix(),
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := s.mcpOAuthGrants.StoreAuthorizationCode(r.Context(), code, expiresAt); err != nil {
+		return "", err
+	}
+	return code, nil
+}
+
 func (s *Server) mcpOAuthExchangeAuthorizationCode(w http.ResponseWriter, r *http.Request, clientID string) {
+	code := r.Form.Get("code")
 	codeState, err := decodeMCPOAuthAuthorizationCode(s.encryptor, r.Form.Get("code"), s.now())
 	if err != nil {
 		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_grant", "authorization code is invalid")
@@ -365,16 +449,27 @@ func (s *Server) mcpOAuthExchangeAuthorizationCode(w http.ResponseWriter, r *htt
 		return
 	}
 
+	familyID := uuid.NewString()
+	refreshExpiresAt := s.now().Add(mcpOAuthRefreshTokenTTL)
 	refreshToken, err := encodeMCPOAuthRefreshToken(s.encryptor, mcpOAuthRefreshTokenState{
 		ClientID:    clientID,
+		FamilyID:    familyID,
 		Email:       codeState.Email,
 		DisplayName: codeState.DisplayName,
 		AvatarURL:   codeState.AvatarURL,
 		Scope:       codeState.Scope,
-		ExpiresAt:   s.now().Add(mcpOAuthRefreshTokenTTL).Unix(),
+		ExpiresAt:   refreshExpiresAt.Unix(),
 	})
 	if err != nil {
 		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue refresh token")
+		return
+	}
+	if s.mcpOAuthGrants == nil {
+		writeMCPOAuthError(w, http.StatusServiceUnavailable, "server_error", "MCP OAuth grant storage is unavailable")
+		return
+	}
+	if err := s.mcpOAuthGrants.ConsumeAuthorizationCodeAndStoreRefreshToken(r.Context(), code, refreshToken, familyID, refreshExpiresAt); err != nil {
+		writeMCPOAuthGrantError(w, err, "authorization code is invalid")
 		return
 	}
 
@@ -397,16 +492,26 @@ func (s *Server) mcpOAuthRefreshAccessToken(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	if s.mcpOAuthGrants == nil {
+		writeMCPOAuthError(w, http.StatusServiceUnavailable, "server_error", "MCP OAuth grant storage is unavailable")
+		return
+	}
+	refreshExpiresAt := s.now().Add(mcpOAuthRefreshTokenTTL)
 	refreshToken, err := encodeMCPOAuthRefreshToken(s.encryptor, mcpOAuthRefreshTokenState{
 		ClientID:    clientID,
+		FamilyID:    refreshState.FamilyID,
 		Email:       refreshState.Email,
 		DisplayName: refreshState.DisplayName,
 		AvatarURL:   refreshState.AvatarURL,
 		Scope:       refreshState.Scope,
-		ExpiresAt:   s.now().Add(mcpOAuthRefreshTokenTTL).Unix(),
+		ExpiresAt:   refreshExpiresAt.Unix(),
 	})
 	if err != nil {
 		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "failed to rotate refresh token")
+		return
+	}
+	if err := s.mcpOAuthGrants.RotateRefreshToken(r.Context(), r.Form.Get("refresh_token"), refreshToken, refreshState.FamilyID, refreshExpiresAt); err != nil {
+		writeMCPOAuthGrantError(w, err, "refresh token is invalid")
 		return
 	}
 
@@ -420,17 +525,16 @@ func (s *Server) mcpOAuthRefreshAccessToken(w http.ResponseWriter, r *http.Reque
 
 func (s *Server) writeMCPOAuthTokenResponse(w http.ResponseWriter, identity *core.UserIdentity, scope, refreshToken string) {
 	auth := s.serverAuthRuntime()
-	accessToken, err := s.issueSessionToken(auth.provider, identity)
-	if err != nil {
-		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue access token")
-		return
-	}
-
 	ttl := defaultSessionCookieTTL
 	if auth.provider != nil {
 		if providerWithTTL, ok := auth.provider.(SessionTokenTTLProvider); ok {
 			ttl = providerWithTTL.SessionTokenTTL()
 		}
+	}
+	accessToken, err := s.issueMCPOAuthAccessToken(identity, scope, ttl)
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue access token")
+		return
 	}
 
 	setMCPOAuthNoStoreHeaders(w)
@@ -451,9 +555,80 @@ func writeMCPOAuthError(w http.ResponseWriter, status int, code, description str
 	})
 }
 
+func writeMCPOAuthGrantError(w http.ResponseWriter, err error, description string) {
+	switch {
+	case errors.Is(err, coredata.ErrMCPOAuthGrantNotFound),
+		errors.Is(err, coredata.ErrMCPOAuthGrantConsumed),
+		errors.Is(err, coredata.ErrMCPOAuthGrantRevoked),
+		errors.Is(err, coredata.ErrMCPOAuthGrantExpired):
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_grant", description)
+	default:
+		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "MCP OAuth grant storage failed")
+	}
+}
+
 func setMCPOAuthNoStoreHeaders(w http.ResponseWriter) {
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Pragma", "no-cache")
+}
+
+func writeMCPOAuthConsentPage(w http.ResponseWriter, clientName, scope, consent string) {
+	clientName = strings.TrimSpace(clientName)
+	if clientName == "" {
+		clientName = "MCP client"
+	}
+	setMCPOAuthNoStoreHeaders(w)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Authorize MCP Client</title></head>
+<body>
+<main>
+<h1>Authorize %s</h1>
+<p>This client is requesting MCP access%s.</p>
+<form method="post" action="%s">
+<input type="hidden" name="consent" value="%s">
+<button type="submit">Authorize</button>
+</form>
+</main>
+</body>
+</html>`,
+		html.EscapeString(clientName),
+		mcpOAuthConsentScopeText(scope),
+		html.EscapeString(mcpAuthorizationConsentEndpointPath),
+		html.EscapeString(consent),
+	)
+}
+
+func mcpOAuthConsentScopeText(scope string) string {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		return ""
+	}
+	return " for scope " + html.EscapeString(scope)
+}
+
+func (s *Server) sameOriginFormPost(r *http.Request) bool {
+	raw := strings.TrimSpace(r.Header.Get("Origin"))
+	if raw == "" {
+		raw = strings.TrimSpace(r.Header.Get("Referer"))
+	}
+	if raw == "" {
+		return true
+	}
+	got, err := url.Parse(raw)
+	if err != nil || got.Scheme == "" || got.Host == "" {
+		return false
+	}
+	expectedRaw, err := s.resolvePublicURL(r, "/")
+	if err != nil {
+		return false
+	}
+	expected, err := url.Parse(expectedRaw)
+	if err != nil || expected.Scheme == "" || expected.Host == "" {
+		return false
+	}
+	return strings.EqualFold(got.Scheme, expected.Scheme) && strings.EqualFold(got.Host, expected.Host)
 }
 
 func redirectMCPOAuthError(w http.ResponseWriter, r *http.Request, redirectURI, state, code, description string) {
@@ -521,7 +696,25 @@ func validateMCPOAuthRedirectURI(raw string) error {
 	if parsed.Fragment != "" {
 		return errors.New("redirect_uri must not include a fragment")
 	}
+	if parsed.User != nil {
+		return errors.New("redirect_uri must not include userinfo")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return errors.New("redirect_uri scheme must be http or https")
+	}
+	if parsed.Host == "" || !isLoopbackRedirectHost(parsed.Hostname()) {
+		return errors.New("redirect_uri host must be loopback")
+	}
 	return nil
+}
+
+func isLoopbackRedirectHost(host string) bool {
+	host = strings.TrimSpace(strings.Trim(host, "[]"))
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func resolveRegisteredMCPOAuthRedirectURI(registered []string, requested string) (string, error) {

--- a/gestaltd/internal/server/mcp_oauth_access_token.go
+++ b/gestaltd/internal/server/mcp_oauth_access_token.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+const (
+	mcpOAuthAccessTokenIssuer   = "gestaltd"
+	mcpOAuthAccessTokenAudience = "gestalt-mcp"
+)
+
+type mcpOAuthAccessTokenClaims struct {
+	jwt.RegisteredClaims
+	Email       string `json:"email"`
+	DisplayName string `json:"display_name,omitempty"`
+	AvatarURL   string `json:"avatar_url,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+}
+
+func (s *Server) issueMCPOAuthAccessToken(identity *core.UserIdentity, scope string, ttl time.Duration) (string, error) {
+	if len(s.sessionIssuer) == 0 {
+		return "", fmt.Errorf("mcp oauth access token secret is not configured")
+	}
+	claims := mcpOAuthAccessTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    mcpOAuthAccessTokenIssuer,
+			Audience:  jwt.ClaimStrings{mcpOAuthAccessTokenAudience},
+			ExpiresAt: jwt.NewNumericDate(s.now().Add(ttl)),
+			IssuedAt:  jwt.NewNumericDate(s.now()),
+		},
+		Email:       identity.Email,
+		DisplayName: identity.DisplayName,
+		AvatarURL:   identity.AvatarURL,
+		Scope:       scope,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(s.sessionIssuer)
+}
+
+func (s *Server) validateMCPOAuthAccessToken(tokenStr string) (*principal.Principal, error) {
+	if len(s.sessionIssuer) == 0 {
+		return nil, principal.ErrInvalidToken
+	}
+	token, err := jwt.ParseWithClaims(
+		tokenStr,
+		&mcpOAuthAccessTokenClaims{},
+		func(t *jwt.Token) (any, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+			}
+			return s.sessionIssuer, nil
+		},
+		jwt.WithIssuer(mcpOAuthAccessTokenIssuer),
+		jwt.WithAudience(mcpOAuthAccessTokenAudience),
+		jwt.WithExpirationRequired(),
+	)
+	if err != nil {
+		return nil, principal.ErrInvalidToken
+	}
+	claims, ok := token.Claims.(*mcpOAuthAccessTokenClaims)
+	if !ok || claims.Email == "" {
+		return nil, principal.ErrInvalidToken
+	}
+	return &principal.Principal{
+		Identity: &core.UserIdentity{
+			Email:       claims.Email,
+			DisplayName: claims.DisplayName,
+			AvatarURL:   claims.AvatarURL,
+		},
+		Kind:   principal.KindUser,
+		Source: principal.SourceSession,
+	}, nil
+}

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -267,6 +267,76 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+func (s *Server) resolveMCPRequestPrincipal(r *http.Request, auth authRuntime) (*principal.Principal, error) {
+	p, err := s.resolveRequestPrincipalWithResolver(r, auth.resolver)
+	if p != nil {
+		return p, nil
+	}
+	resolverErr := err
+
+	token, err := requestBearerToken(r)
+	if err != nil {
+		return nil, err
+	}
+	if token == "" {
+		return nil, resolverErr
+	}
+
+	p, err = s.validateMCPOAuthAccessToken(token)
+	if err == nil && p != nil {
+		return p, nil
+	}
+	if resolverErr != nil {
+		return nil, resolverErr
+	}
+	return nil, principal.ErrInvalidToken
+}
+
+func (s *Server) mcpAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := s.serverAuthRuntime()
+		if auth.noAuth {
+			s.serveAuthenticated(w, r, next, auth.resolver, auth.noAuth, auth.anonymous, auth.providerName)
+			return
+		}
+
+		p, err := s.resolveMCPRequestPrincipal(r, auth)
+		if err == nil && p != nil {
+			enriched, enrichErr := s.resolvePrincipalUserID(r.Context(), p)
+			switch {
+			case enrichErr == nil && enriched != nil:
+				p = enriched
+			case enrichErr != nil:
+				slog.WarnContext(r.Context(), "auth: unable to resolve user ID", "error", enrichErr)
+			}
+			ctx := principal.WithPrincipal(r.Context(), p)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+
+		authSource := requestedAuthSource(r)
+		switch {
+		case err == nil:
+			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, errors.New("missing authorization"))
+			s.maybeSetMCPResourceMetadataHeader(w, r)
+			writeError(w, http.StatusUnauthorized, "missing authorization")
+		case errors.Is(err, errInvalidAuthorizationHeader):
+			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, errInvalidAuthorizationHeader)
+			s.maybeSetMCPResourceMetadataHeader(w, r)
+			writeError(w, http.StatusUnauthorized, "invalid authorization header format")
+		case errors.Is(err, principal.ErrInvalidToken):
+			slog.InfoContext(r.Context(), "auth: invalid token", "remote_addr", r.RemoteAddr)
+			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, principal.ErrInvalidToken)
+			s.maybeSetMCPResourceMetadataHeader(w, r)
+			writeError(w, http.StatusUnauthorized, "invalid token")
+		default:
+			slog.ErrorContext(r.Context(), "auth: token validation failed", "remote_addr", r.RemoteAddr, "error", err)
+			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, errors.New("token validation failed"))
+			writeError(w, http.StatusInternalServerError, "token validation failed")
+		}
+	})
+}
+
 func (s *Server) pluginRouteAuthMiddleware(pluginParam string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/oauth_state.go
+++ b/gestaltd/internal/server/oauth_state.go
@@ -35,6 +35,12 @@ type integrationOAuthStateCodec struct {
 	encryptor *cryptoutil.AESGCMEncryptor
 }
 
+type encryptedStateEnvelope struct {
+	Type    string          `json:"typ"`
+	Version int             `json:"v"`
+	Payload json.RawMessage `json:"payload"`
+}
+
 func newIntegrationOAuthStateCodec(secret []byte) (*integrationOAuthStateCodec, error) {
 	encryptor, err := cryptoutil.NewAESGCM(secret)
 	if err != nil {
@@ -48,7 +54,15 @@ func encodeEncryptedState[T any](enc *cryptoutil.AESGCMEncryptor, label string, 
 	if err != nil {
 		return "", fmt.Errorf("marshal %s: %w", label, err)
 	}
-	encoded, err := enc.EncryptURLSafe(string(payload))
+	envelope, err := json.Marshal(encryptedStateEnvelope{
+		Type:    label,
+		Version: 1,
+		Payload: payload,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal %s envelope: %w", label, err)
+	}
+	encoded, err := enc.EncryptURLSafeWithAAD(string(envelope), []byte(label))
 	if err != nil {
 		return "", fmt.Errorf("encrypt %s: %w", label, err)
 	}
@@ -56,13 +70,27 @@ func encodeEncryptedState[T any](enc *cryptoutil.AESGCMEncryptor, label string, 
 }
 
 func decodeEncryptedState[T any](enc *cryptoutil.AESGCMEncryptor, label, encoded string) (*T, error) {
-	plaintext, err := enc.DecryptURLSafe(encoded)
+	plaintext, err := enc.DecryptURLSafeWithAAD(encoded, []byte(label))
 	if err != nil {
 		return nil, fmt.Errorf("decrypt %s: %w", label, err)
 	}
 
+	var envelope encryptedStateEnvelope
+	if err := json.Unmarshal([]byte(plaintext), &envelope); err != nil {
+		return nil, fmt.Errorf("unmarshal %s envelope: %w", label, err)
+	}
+	if envelope.Type != label {
+		return nil, fmt.Errorf("%s has unexpected type", label)
+	}
+	if envelope.Version != 1 {
+		return nil, fmt.Errorf("%s has unsupported version", label)
+	}
+	if len(envelope.Payload) == 0 {
+		return nil, fmt.Errorf("%s missing payload", label)
+	}
+
 	var state T
-	if err := json.Unmarshal([]byte(plaintext), &state); err != nil {
+	if err := json.Unmarshal(envelope.Payload, &state); err != nil {
 		return nil, fmt.Errorf("unmarshal %s: %w", label, err)
 	}
 	return &state, nil
@@ -149,8 +177,22 @@ type mcpOAuthAuthorizationCodeState struct {
 	ExpiresAt           int64  `json:"exp"`
 }
 
+type mcpOAuthConsentState struct {
+	ClientID            string `json:"cid"`
+	RedirectURI         string `json:"ru"`
+	Email               string `json:"em"`
+	DisplayName         string `json:"dn,omitempty"`
+	AvatarURL           string `json:"av,omitempty"`
+	Scope               string `json:"sc,omitempty"`
+	State               string `json:"st,omitempty"`
+	CodeChallenge       string `json:"cc"`
+	CodeChallengeMethod string `json:"cm,omitempty"`
+	ExpiresAt           int64  `json:"exp"`
+}
+
 type mcpOAuthRefreshTokenState struct {
 	ClientID    string `json:"cid"`
+	FamilyID    string `json:"fid"`
 	Email       string `json:"em"`
 	DisplayName string `json:"dn,omitempty"`
 	AvatarURL   string `json:"av,omitempty"`
@@ -332,6 +374,44 @@ func decodeMCPOAuthAuthorizationCode(enc *cryptoutil.AESGCMEncryptor, encoded st
 	return state, nil
 }
 
+func encodeMCPOAuthConsentState(enc *cryptoutil.AESGCMEncryptor, state mcpOAuthConsentState) (string, error) {
+	return encodeEncryptedState(enc, "mcp oauth consent", state)
+}
+
+func validateMCPOAuthConsentState(state *mcpOAuthConsentState, now time.Time) error {
+	if state.ClientID == "" {
+		return fmt.Errorf("mcp oauth consent missing client ID")
+	}
+	if state.RedirectURI == "" {
+		return fmt.Errorf("mcp oauth consent missing redirect URI")
+	}
+	if state.Email == "" {
+		return fmt.Errorf("mcp oauth consent missing email")
+	}
+	if state.CodeChallenge == "" {
+		return fmt.Errorf("mcp oauth consent missing code challenge")
+	}
+	if state.ExpiresAt == 0 {
+		return fmt.Errorf("mcp oauth consent missing expiration")
+	}
+	if now.Unix() > state.ExpiresAt {
+		return fmt.Errorf("mcp oauth consent expired")
+	}
+	return nil
+}
+
+func decodeMCPOAuthConsentState(enc *cryptoutil.AESGCMEncryptor, encoded string, now time.Time) (*mcpOAuthConsentState, error) {
+	encoded = strings.TrimSpace(encoded)
+	state, err := decodeEncryptedState[mcpOAuthConsentState](enc, "mcp oauth consent", encoded)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateMCPOAuthConsentState(state, now); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
 func encodeMCPOAuthRefreshToken(enc *cryptoutil.AESGCMEncryptor, state mcpOAuthRefreshTokenState) (string, error) {
 	encoded, err := encodeEncryptedState(enc, "mcp oauth refresh token", state)
 	if err != nil {
@@ -343,6 +423,9 @@ func encodeMCPOAuthRefreshToken(enc *cryptoutil.AESGCMEncryptor, state mcpOAuthR
 func validateMCPOAuthRefreshToken(state *mcpOAuthRefreshTokenState, now time.Time) error {
 	if state.ClientID == "" {
 		return fmt.Errorf("mcp oauth refresh token missing client ID")
+	}
+	if state.FamilyID == "" {
+		return fmt.Errorf("mcp oauth refresh token missing family ID")
 	}
 	if state.Email == "" {
 		return fmt.Errorf("mcp oauth refresh token missing email")

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -159,9 +159,10 @@ func (s *Server) mountMCPRoutes(r chi.Router) {
 	r.Get(mcpAuthorizationServerMetadataMCPPath, s.mcpAuthorizationServerMetadata)
 	r.Post(mcpRegistrationEndpointPath, s.mcpRegisterOAuthClient)
 	r.Get(mcpAuthorizationEndpointPath, s.mcpOAuthAuthorize)
+	r.Post(mcpAuthorizationConsentEndpointPath, s.mcpOAuthAuthorizeConsent)
 	r.Post(mcpTokenEndpointPath, s.mcpOAuthToken)
 	r.Group(func(r chi.Router) {
-		r.Use(s.authMiddleware)
+		r.Use(s.mcpAuthMiddleware)
 		r.Handle(mcpPath, s.mcpHandler)
 	})
 }

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -91,6 +91,7 @@ type Server struct {
 	externalCredentials     core.ExternalCredentialProvider
 	apiTokens               *coredata.APITokenService
 	managedSubjects         *coredata.ManagedSubjectService
+	mcpOAuthGrants          *coredata.MCPOAuthGrantService
 	agent                   bootstrap.AgentControl
 	workflowSchedules       *workflowmanager.Manager
 	agentRuns               agentmanager.Service
@@ -277,6 +278,7 @@ func New(cfg Config) (*Server, error) {
 	}
 	apiTokens := cfg.Services.APITokens
 	managedSubjects := cfg.Services.ManagedSubjects
+	mcpOAuthGrants := cfg.Services.MCPOAuthGrants
 	resolver := principal.NewResolver(cfg.Auth, users, apiTokens)
 	authProviders := make(map[string]core.AuthenticationProvider, len(cfg.AuthProviders)+1)
 	for name, provider := range cfg.AuthProviders {
@@ -336,6 +338,7 @@ func New(cfg Config) (*Server, error) {
 		externalCredentials:    externalCredentials,
 		apiTokens:              apiTokens,
 		managedSubjects:        managedSubjects,
+		mcpOAuthGrants:         mcpOAuthGrants,
 		agent:                  cfg.Agent,
 		agentRuns:              cfg.AgentManager,
 		authorizationProvider:  cfg.AuthorizationProvider,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -20851,10 +20851,27 @@ func TestMCPOAuthAuthorizationCodeFlow(t *testing.T) {
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
 	svc := coretesting.NewStubServices(t)
-	providers := func() *registry.ProviderMap[core.Provider] {
-		reg := registry.New()
-		return &reg.Providers
-	}()
+	var calledTool string
+	prov := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "clickhouse", ConnMode: core.ConnectionModeNone},
+			ops:             []core.Operation{{Name: "run_query", Description: "Execute a SQL query"}},
+		},
+		catalog: &catalog.Catalog{
+			Name: "clickhouse",
+			Operations: []catalog.CatalogOperation{{
+				ID:          "run_query",
+				Description: "Execute a SQL query",
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"sql":{"type":"string"}}}`),
+				Transport:   catalog.TransportMCPPassthrough,
+			}},
+		},
+		callFn: func(_ context.Context, name string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+			calledTool = name
+			return mcpgo.NewToolResultText("query executed"), nil
+		},
+	}
+	providers := testutil.NewProviderRegistry(t, prov)
 	mcpHandler := newMCPHandler(t, providers, svc, nil, nil)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -20972,11 +20989,31 @@ func TestMCPOAuthAuthorizationCodeFlow(t *testing.T) {
 	}
 	defer func() { _ = authorizedResp.Body.Close() }()
 
-	if authorizedResp.StatusCode != http.StatusFound {
+	if authorizedResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(authorizedResp.Body)
-		t.Fatalf("resumed authorize status = %d, want %d: %s", authorizedResp.StatusCode, http.StatusFound, body)
+		t.Fatalf("resumed authorize status = %d, want %d: %s", authorizedResp.StatusCode, http.StatusOK, body)
 	}
-	finalRedirect, err := url.Parse(authorizedResp.Header.Get("Location"))
+	consentBody, err := io.ReadAll(authorizedResp.Body)
+	if err != nil {
+		t.Fatalf("read consent body: %v", err)
+	}
+	consentToken := extractHiddenInputValue(t, string(consentBody), "consent")
+	if consentToken == "" {
+		t.Fatal("consent page missing consent token")
+	}
+
+	consentResp, err := noRedirect.PostForm(ts.URL+"/oauth/authorize/consent", url.Values{
+		"consent": {consentToken},
+	})
+	if err != nil {
+		t.Fatalf("POST /oauth/authorize/consent: %v", err)
+	}
+	defer func() { _ = consentResp.Body.Close() }()
+	if consentResp.StatusCode != http.StatusFound {
+		body, _ := io.ReadAll(consentResp.Body)
+		t.Fatalf("consent status = %d, want %d: %s", consentResp.StatusCode, http.StatusFound, body)
+	}
+	finalRedirect, err := url.Parse(consentResp.Header.Get("Location"))
 	if err != nil {
 		t.Fatalf("parse final redirect: %v", err)
 	}
@@ -21021,6 +21058,22 @@ func TestMCPOAuthAuthorizationCodeFlow(t *testing.T) {
 		t.Fatal("token response missing refresh_token")
 	}
 
+	replayResp, err := http.PostForm(ts.URL+"/oauth/token", url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {clientID},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"code_verifier": {verifier},
+	})
+	if err != nil {
+		t.Fatalf("POST /oauth/token replay: %v", err)
+	}
+	defer func() { _ = replayResp.Body.Close() }()
+	if replayResp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(replayResp.Body)
+		t.Fatalf("replay status = %d, want %d: %s", replayResp.StatusCode, http.StatusBadRequest, body)
+	}
+
 	status, _ := mcpJSONRPC(t, ts, map[string]string{"Authorization": "Bearer " + accessToken}, map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -21033,6 +21086,33 @@ func TestMCPOAuthAuthorizationCodeFlow(t *testing.T) {
 	})
 	if status != http.StatusOK {
 		t.Fatalf("initialize with access token: expected 200, got %d", status)
+	}
+	status, toolResp := mcpJSONRPC(t, ts, map[string]string{"Authorization": "Bearer " + accessToken}, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "clickhouse_run_query",
+			"arguments": map[string]any{"sql": "SELECT 1"},
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("tools/call with scoped OAuth access token: expected 200, got %d: %+v", status, toolResp)
+	}
+	if calledTool != "run_query" {
+		t.Fatalf("tools/call invoked %q, want run_query", calledTool)
+	}
+
+	apiReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	apiReq.Header.Set("Authorization", "Bearer "+accessToken)
+	apiResp, err := http.DefaultClient.Do(apiReq)
+	if err != nil {
+		t.Fatalf("GET /api/v1/integrations with MCP token: %v", err)
+	}
+	defer func() { _ = apiResp.Body.Close() }()
+	if apiResp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(apiResp.Body)
+		t.Fatalf("MCP access token API status = %d, want %d: %s", apiResp.StatusCode, http.StatusUnauthorized, body)
 	}
 
 	refreshResp, err := http.PostForm(ts.URL+"/oauth/token", url.Values{
@@ -21058,6 +21138,10 @@ func TestMCPOAuthAuthorizationCodeFlow(t *testing.T) {
 	if refreshedAccessToken == "" {
 		t.Fatal("refresh response missing access_token")
 	}
+	rotatedRefreshToken, _ := refreshBody["refresh_token"].(string)
+	if rotatedRefreshToken == "" || rotatedRefreshToken == refreshToken {
+		t.Fatalf("refresh response did not rotate refresh_token")
+	}
 
 	status, _ = mcpJSONRPC(t, ts, map[string]string{"Authorization": "Bearer " + refreshedAccessToken}, map[string]any{
 		"jsonrpc": "2.0",
@@ -21071,6 +21155,68 @@ func TestMCPOAuthAuthorizationCodeFlow(t *testing.T) {
 	})
 	if status != http.StatusOK {
 		t.Fatalf("initialize with refreshed access token: expected 200, got %d", status)
+	}
+
+	reusedRefreshResp, err := http.PostForm(ts.URL+"/oauth/token", url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {clientID},
+		"refresh_token": {refreshToken},
+	})
+	if err != nil {
+		t.Fatalf("POST /oauth/token reused refresh_token: %v", err)
+	}
+	defer func() { _ = reusedRefreshResp.Body.Close() }()
+	if reusedRefreshResp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(reusedRefreshResp.Body)
+		t.Fatalf("reused refresh status = %d, want %d: %s", reusedRefreshResp.StatusCode, http.StatusBadRequest, body)
+	}
+
+	revokedFamilyResp, err := http.PostForm(ts.URL+"/oauth/token", url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {clientID},
+		"refresh_token": {rotatedRefreshToken},
+	})
+	if err != nil {
+		t.Fatalf("POST /oauth/token after refresh family revocation: %v", err)
+	}
+	defer func() { _ = revokedFamilyResp.Body.Close() }()
+	if revokedFamilyResp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(revokedFamilyResp.Body)
+		t.Fatalf("revoked family refresh status = %d, want %d: %s", revokedFamilyResp.StatusCode, http.StatusBadRequest, body)
+	}
+}
+
+func TestMCPOAuthDynamicClientRegistrationRejectsNonLoopbackRedirect(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	svc := coretesting.NewStubServices(t)
+	providers := func() *registry.ProviderMap[core.Provider] {
+		reg := registry.New()
+		return &reg.Providers
+	}()
+	mcpHandler := newMCPHandler(t, providers, svc, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubHostIssuedSessionAuth{secret: secret, name: "oidc"}
+		cfg.StateSecret = secret
+		cfg.MCPHandler = mcpHandler
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Post(ts.URL+"/oauth/register", "application/json", strings.NewReader(`{
+		"client_name":"Evil",
+		"redirect_uris":["https://evil.example/callback"]
+	}`))
+	if err != nil {
+		t.Fatalf("POST /oauth/register: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("register status = %d, want %d: %s", resp.StatusCode, http.StatusBadRequest, body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Hardens the MCP OAuth and session-token boundary so OAuth grants cannot mint general Gestalt session JWTs or be replayed across token classes.

- Adds issuer/audience/expiration enforcement to session JWT validation.
- Binds encrypted state blobs to typed envelopes and AES-GCM AAD so code/refresh/login state cannot be type-confused by swapping prefixes.
- Adds an MCP OAuth grant ledger for single-use authorization codes and rotating refresh tokens with refresh-family revocation on reuse.
- Changes MCP OAuth token responses to return an MCP-scoped JWT (`aud=gestalt-mcp`) instead of the general session JWT (`aud=gestalt-session`).
- Adds MCP-specific route auth so scoped MCP tokens work for `/mcp` but are rejected by normal `/api/v1` routes.
- Requires explicit user consent before issuing an MCP authorization code.
- Restricts dynamic client registration redirect URIs to loopback HTTP(S) clients.

## Compatibility / rollout notes

This intentionally invalidates credentials and transient state minted by the previous unsafe formats. Existing session cookies, login/OAuth state cookies, MCP dynamic client registrations, MCP authorization codes, and MCP refresh tokens will need to be recreated after deployment. Users should re-login and MCP clients should re-register/re-authorize.

Dynamic client registration now accepts loopback redirect URIs only. Non-loopback MCP clients will need a future explicit allowlist/config path rather than unauthenticated arbitrary redirect registration.

## Validation

- `go test ./internal/server -run 'TestMCPOAuthAuthorizationCodeFlow|TestMCPOAuthDynamicClientRegistrationRejectsNonLoopbackRedirect'`
- `go test ./internal/server ./internal/coredata ./core/session ./core/crypto`
- `go test ./...` from `gestaltd`

A separate gpt-5.5 xhigh reviewer pass flagged scope mapping, grant atomicity, and refresh-family assertion gaps; those were addressed before opening this PR.