### PR TITLE
[codex] Enforce agent provider authorization

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2511,6 +2511,9 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 			Plugin:     "ashby",
 			Operations: []string{"sync"},
 		},
+		{
+			Plugin: "managed",
+		},
 	})
 	p := &principal.Principal{
 		SubjectID:           "user:user-123",
@@ -2792,6 +2795,9 @@ func TestBootstrapAgentHostToolSearchPrioritizesNamedPluginIssueTools(t *testing
 
 	permissions := []core.AccessPermission{
 		{
+			Plugin: "managed",
+		},
+		{
 			Plugin:     "linear",
 			Operations: []string{"list_issues", "list_comments", "list_customers", "list_documents"},
 		},
@@ -2933,6 +2939,8 @@ func TestBootstrapAgentHostToolSearchReturnsCandidatesAndLoadsRefs(t *testing.T)
 	perms := principal.CompilePermissions([]core.AccessPermission{{
 		Plugin:     "docs",
 		Operations: []string{"alpha_search", "beta_list", "delta_export", "gamma_get", "hidden_admin"},
+	}, {
+		Plugin: "managed",
 	}})
 	p := &principal.Principal{
 		SubjectID:        "user:user-123",
@@ -3122,6 +3130,8 @@ func TestBootstrapHTTPCallerWildcardSearchUsesResolvedUserToolScope(t *testing.T
 			"events.reply",
 			"events.setStatus",
 		},
+	}, {
+		Plugin: "managed",
 	}})
 	p := &principal.Principal{
 		SubjectID:        "user:user-123",
@@ -3729,6 +3739,8 @@ func TestBootstrapAgentManagerIdempotentTurnReplayRequiresCurrentToolAccess(t *t
 	perms := principal.CompilePermissions([]core.AccessPermission{{
 		Plugin:     "roadmap",
 		Operations: []string{"sync"},
+	}, {
+		Plugin: "managed",
 	}})
 	full := &principal.Principal{
 		SubjectID:        "user:user-123",
@@ -3770,8 +3782,8 @@ func TestBootstrapAgentManagerIdempotentTurnReplayRequiresCurrentToolAccess(t *t
 		UserID:           "user-123",
 		Kind:             principal.KindUser,
 		Source:           principal.SourceSession,
-		TokenPermissions: principal.PermissionSet{},
-		Scopes:           []string{},
+		TokenPermissions: principal.CompilePermissions([]core.AccessPermission{{Plugin: "managed"}}),
+		Scopes:           []string{"managed"},
 	}
 	restrictedCtx := principal.WithPrincipal(context.Background(), restricted)
 

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -3991,6 +3991,8 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 	perms := principal.CompilePermissions([]core.AccessPermission{{
 		Plugin:     "roadmap",
 		Operations: []string{"sync"},
+	}, {
+		Plugin: "managed",
 	}})
 	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
 		SubjectID:        "user:user-123",

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -562,6 +562,8 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 		TokenPermissions: principal.CompilePermissions([]core.AccessPermission{{
 			Plugin:     "roadmap",
 			Operations: []string{"sync"},
+		}, {
+			Plugin: "managed",
 		}}),
 	})
 

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,11 +18,14 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentgrant"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
+	"github.com/valon-technologies/gestalt/server/services/authorization"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 )
 
@@ -32,6 +36,261 @@ func newServerTestAgentToolGrants(t testing.TB) *agentgrant.Manager {
 		t.Fatalf("agentgrant.NewManager: %v", err)
 	}
 	return grants
+}
+
+type dynamicProviderAuthorizer struct {
+	allowed atomic.Bool
+}
+
+func (a *dynamicProviderAuthorizer) Start(context.Context) error                    { return nil }
+func (a *dynamicProviderAuthorizer) Close() error                                   { return nil }
+func (a *dynamicProviderAuthorizer) ReloadAuthorizationState(context.Context) error { return nil }
+
+func (a *dynamicProviderAuthorizer) AllowProvider(context.Context, *principal.Principal, string) bool {
+	return a.allowed.Load()
+}
+
+func (a *dynamicProviderAuthorizer) AllowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool {
+	return a.AllowProvider(ctx, p, provider)
+}
+
+func (a *dynamicProviderAuthorizer) ResolveAccess(context.Context, *principal.Principal, string) (authorization.AccessContext, bool) {
+	return authorization.AccessContext{}, a.allowed.Load()
+}
+
+func (a *dynamicProviderAuthorizer) ResolvePolicyAccess(context.Context, *principal.Principal, string) (authorization.AccessContext, bool) {
+	return authorization.AccessContext{}, a.allowed.Load()
+}
+
+func (a *dynamicProviderAuthorizer) ResolveAdminAccess(context.Context, *principal.Principal, string) (authorization.AccessContext, bool) {
+	return authorization.AccessContext{}, a.allowed.Load()
+}
+
+func (a *dynamicProviderAuthorizer) AllowCatalogOperation(context.Context, *principal.Principal, string, catalog.CatalogOperation) bool {
+	return a.allowed.Load()
+}
+
+func (a *dynamicProviderAuthorizer) PolicyNameForProvider(string) string { return "agent_policy" }
+
+func (a *dynamicProviderAuthorizer) StaticRoleForPolicyIdentity(string, string) (authorization.AccessContext, bool) {
+	return authorization.AccessContext{}, false
+}
+
+func (a *dynamicProviderAuthorizer) StaticRoleForProviderIdentity(string, string) (authorization.AccessContext, bool) {
+	return authorization.AccessContext{}, false
+}
+
+func (a *dynamicProviderAuthorizer) StaticMembersForPolicy(string) ([]authorization.StaticSubjectMember, bool) {
+	return nil, false
+}
+
+func (a *dynamicProviderAuthorizer) StaticMembersForProvider(string) (string, []authorization.StaticSubjectMember, bool) {
+	return "", nil, false
+}
+
+func TestAgentSessionRejectsUnauthorizedProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAgentProvider()
+	var createSessionCalled atomic.Bool
+	ts := newTestServer(t, func(cfg *server.Config) {
+		services := coretesting.NewStubServices(t)
+		agentControl := &stubAgentControl{defaultProviderName: "managed", provider: provider}
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "ada@example.com", DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Agent = agentControl
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"managed": {AuthorizationPolicy: "agent_policy"},
+		}
+		authz := mustAuthorizer(t, config.AuthorizationConfig{
+			Policies: map[string]config.SubjectPolicyDef{
+				"agent_policy": {Default: "deny"},
+			},
+		}, cfg.PluginDefs)
+		cfg.Authorizer = authz
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:      agentControl,
+			Authorizer: authz,
+			ToolGrants: newServerTestAgentToolGrants(t),
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	provider.createSessionHook = func() {
+		createSessionCalled.Store(true)
+	}
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions", bytes.NewBufferString(`{"provider":"managed","model":"gpt-5.4"}`))
+	sessionReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	sessionResp, err := http.DefaultClient.Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(sessionResp.Body)
+		t.Fatalf("create session status = %d body=%s, want 403", sessionResp.StatusCode, body)
+	}
+	if createSessionCalled.Load() {
+		t.Fatal("agent provider CreateSession was called despite authorization denial")
+	}
+}
+
+func TestAgentTurnRechecksProviderAuthorization(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAgentProvider()
+	authz := &dynamicProviderAuthorizer{}
+	authz.allowed.Store(true)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		services := coretesting.NewStubServices(t)
+		agentControl := &stubAgentControl{defaultProviderName: "managed", provider: provider}
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "ada@example.com", DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Agent = agentControl
+		cfg.Authorizer = authz
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:      agentControl,
+			Authorizer: authz,
+			ToolGrants: newServerTestAgentToolGrants(t),
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions", bytes.NewBufferString(`{"provider":"managed","model":"gpt-5.4"}`))
+	sessionReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	sessionResp, err := http.DefaultClient.Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(sessionResp.Body)
+		t.Fatalf("create session status = %d body=%s, want 201", sessionResp.StatusCode, body)
+	}
+	var session map[string]any
+	if err := json.NewDecoder(sessionResp.Body).Decode(&session); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	sessionID := session["id"].(string)
+
+	authz.allowed.Store(false)
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	turnResp, err := http.DefaultClient.Do(turnReq)
+	if err != nil {
+		t.Fatalf("create turn: %v", err)
+	}
+	defer func() { _ = turnResp.Body.Close() }()
+	if turnResp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(turnResp.Body)
+		t.Fatalf("create turn status = %d body=%s, want 403", turnResp.StatusCode, body)
+	}
+	if got := len(provider.capturedGetSessionRequests()); got != 0 {
+		t.Fatalf("provider get session requests len = %d, want 0", got)
+	}
+	if got := len(provider.capturedTurnRequests()); got != 0 {
+		t.Fatalf("provider turn requests len = %d, want 0", got)
+	}
+}
+
+func TestAgentRequestsRejectMissingProviderTokenPermission(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAgentProvider()
+	services := coretesting.NewStubServices(t)
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	user := seedAPITokenWithPermissions(t, services, plaintext, hashed, "agent-user", []core.AccessPermission{{
+		Plugin:     "roadmap",
+		Operations: []string{"sync"},
+	}})
+	ts := newTestServer(t, func(cfg *server.Config) {
+		agentControl := &stubAgentControl{defaultProviderName: "managed", provider: provider}
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(context.Context, string) (*core.UserIdentity, error) {
+				return nil, core.ErrNotFound
+			},
+		}
+		cfg.Services = services
+		cfg.Agent = agentControl
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:      agentControl,
+			ToolGrants: newServerTestAgentToolGrants(t),
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	var createSessionCalled atomic.Bool
+	provider.createSessionHook = func() {
+		createSessionCalled.Store(true)
+	}
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions", bytes.NewBufferString(`{"provider":"managed","model":"gpt-5.4"}`))
+	sessionReq.Header.Set("Authorization", "Bearer "+plaintext)
+	sessionResp, err := http.DefaultClient.Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(sessionResp.Body)
+		t.Fatalf("create session status = %d body=%s, want 403", sessionResp.StatusCode, body)
+	}
+	if createSessionCalled.Load() {
+		t.Fatal("agent provider CreateSession was called despite missing provider token permission")
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	provider.mu.Lock()
+	provider.sessions["session-managed"] = &coreagent.Session{
+		ID:           "session-managed",
+		ProviderName: "managed",
+		Model:        "gpt-5.4",
+		State:        coreagent.SessionStateActive,
+		CreatedBy: coreagent.Actor{
+			SubjectID:   principal.UserSubjectID(user.ID),
+			SubjectKind: string(principal.KindUser),
+		},
+		CreatedAt: &now,
+		UpdatedAt: &now,
+	}
+	provider.mu.Unlock()
+
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/session-managed/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq.Header.Set("Authorization", "Bearer "+plaintext)
+	turnResp, err := http.DefaultClient.Do(turnReq)
+	if err != nil {
+		t.Fatalf("create turn: %v", err)
+	}
+	defer func() { _ = turnResp.Body.Close() }()
+	if turnResp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(turnResp.Body)
+		t.Fatalf("create turn status = %d body=%s, want 403", turnResp.StatusCode, body)
+	}
+	if got := len(provider.capturedGetSessionRequests()); got != 0 {
+		t.Fatalf("provider get session requests len = %d, want 0", got)
+	}
+	if got := len(provider.capturedTurnRequests()); got != 0 {
+		t.Fatalf("provider turn requests len = %d, want 0", got)
+	}
 }
 
 type stubAgentControl struct {
@@ -74,8 +333,10 @@ type memoryAgentProvider struct {
 	turnEvents          map[string][]*coreagent.TurnEvent
 	interactions        map[string]*coreagent.Interaction
 	turnRequests        []coreagent.CreateTurnRequest
+	getSessionRequests  []coreagent.GetSessionRequest
 	listSessionRequests []coreagent.ListSessionsRequest
 	listTurnRequests    []coreagent.ListTurnsRequest
+	createSessionHook   func()
 }
 
 func newMemoryAgentProvider() *memoryAgentProvider {
@@ -90,6 +351,9 @@ func newMemoryAgentProvider() *memoryAgentProvider {
 func (p *memoryAgentProvider) CreateSession(_ context.Context, req coreagent.CreateSessionRequest) (*coreagent.Session, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.createSessionHook != nil {
+		p.createSessionHook()
+	}
 
 	now := time.Now().UTC().Truncate(time.Second)
 	session := &coreagent.Session{
@@ -111,6 +375,7 @@ func (p *memoryAgentProvider) GetSession(_ context.Context, req coreagent.GetSes
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	p.getSessionRequests = append(p.getSessionRequests, req)
 	session, ok := p.sessions[req.SessionID]
 	if !ok {
 		return nil, core.ErrNotFound
@@ -239,6 +504,13 @@ func (p *memoryAgentProvider) CreateTurn(_ context.Context, req coreagent.Create
 		session.UpdatedAt = &now
 	}
 	return cloneTurn(turn), nil
+}
+
+func (p *memoryAgentProvider) capturedGetSessionRequests() []coreagent.GetSessionRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return append([]coreagent.GetSessionRequest(nil), p.getSessionRequests...)
 }
 
 func (p *memoryAgentProvider) capturedTurnRequests() []coreagent.CreateTurnRequest {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1356,6 +1356,8 @@ func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *tes
 	permissions := principal.CompilePermissions([]core.AccessPermission{{
 		Plugin:     "github",
 		Operations: []string{"events.handle"},
+	}, {
+		Plugin: "managed",
 	}})
 	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
 		SubjectID:        "service_account:github_app_installation:99:repo:acme/widgets",

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -411,6 +411,9 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 		return nil, err
 	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(providerName))
+	if !m.allowsAgentProvider(ctx, p, providerName) {
+		return nil, fmt.Errorf("%w: %s", invocation.ErrAuthorizationDenied, providerName)
+	}
 	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
 	sessionID := uuid.NewString()
 	session, err = provider.CreateSession(ctx, coreagent.CreateSessionRequest{
@@ -464,7 +467,7 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 	if providerName != "" {
 		observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(providerName))
 	}
-	candidates, err := m.providerCandidates(providerName)
+	candidates, err := m.authorizedProviderCandidates(ctx, p, providerName)
 	if err != nil {
 		return nil, err
 	}
@@ -917,6 +920,26 @@ func (m *Manager) providerCandidates(providerName string) ([]namedAgentProvider,
 	return candidates, nil
 }
 
+func (m *Manager) authorizedProviderCandidates(ctx context.Context, p *principal.Principal, providerName string) ([]namedAgentProvider, error) {
+	candidates, err := m.providerCandidates(providerName)
+	if err != nil {
+		return nil, err
+	}
+	authorized := make([]namedAgentProvider, 0, len(candidates))
+	for _, candidate := range candidates {
+		if m.allowsAgentProvider(ctx, p, candidate.name) {
+			authorized = append(authorized, candidate)
+		}
+	}
+	if len(authorized) == 0 {
+		if providerName = strings.TrimSpace(providerName); providerName != "" {
+			return nil, fmt.Errorf("%w: %s", invocation.ErrAuthorizationDenied, providerName)
+		}
+		return nil, invocation.ErrAuthorizationDenied
+	}
+	return authorized, nil
+}
+
 func (m *Manager) findOwnedSession(ctx context.Context, p *principal.Principal, sessionID, providerName string) (*ownedAgentSession, error) {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {
@@ -951,7 +974,7 @@ func (m *Manager) findOwnedSession(ctx context.Context, p *principal.Principal, 
 }
 
 func (m *Manager) findOwnedSessionInProviders(ctx context.Context, p *principal.Principal, sessionID, providerName string) (*ownedAgentSession, error) {
-	candidates, err := m.providerCandidates(providerName)
+	candidates, err := m.authorizedProviderCandidates(ctx, p, providerName)
 	if err != nil {
 		return nil, err
 	}
@@ -1023,7 +1046,7 @@ func (m *Manager) findOwnedTurn(ctx context.Context, p *principal.Principal, tur
 }
 
 func (m *Manager) findOwnedTurnInProviders(ctx context.Context, p *principal.Principal, turnID, providerName string) (*ownedAgentTurn, error) {
-	candidates, err := m.providerCandidates(providerName)
+	candidates, err := m.authorizedProviderCandidates(ctx, p, providerName)
 	if err != nil {
 		return nil, err
 	}
@@ -2076,7 +2099,7 @@ func (m *Manager) authorizeToolRefs(ctx context.Context, p *principal.Principal,
 			}
 			return fmt.Errorf("%w: looking up provider: %v", invocation.ErrInternal, err)
 		}
-		if !m.allowProvider(ctx, p, pluginName) || !principal.AllowsProviderPermission(p, pluginName) {
+		if !m.allowsAgentProvider(ctx, p, pluginName) {
 			return fmt.Errorf("%w: %s", invocation.ErrAuthorizationDenied, pluginName)
 		}
 		connection := strings.TrimSpace(ref.Connection)
@@ -2096,6 +2119,10 @@ func (m *Manager) allowProvider(ctx context.Context, p *principal.Principal, pro
 		return true
 	}
 	return m.authorizer.AllowProvider(ctx, p, provider)
+}
+
+func (m *Manager) allowsAgentProvider(ctx context.Context, p *principal.Principal, provider string) bool {
+	return m.allowProvider(ctx, p, provider) && principal.AllowsProviderPermission(p, provider)
 }
 
 func (m *Manager) allowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool {

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -1041,6 +1041,9 @@ func (m *Manager) resolveAgentTarget(ctx context.Context, p *principal.Principal
 		return coreworkflow.Target{}, err
 	}
 	target.ProviderName = strings.TrimSpace(providerName)
+	if !m.allowProvider(ctx, p, target.ProviderName) || !principal.AllowsProviderPermission(p, target.ProviderName) {
+		return coreworkflow.Target{}, fmt.Errorf("%w: %s", invocation.ErrAuthorizationDenied, target.ProviderName)
+	}
 	target.Model = strings.TrimSpace(target.Model)
 	target.Prompt = strings.TrimSpace(target.Prompt)
 	if strings.TrimSpace(target.Prompt) == "" && len(target.Messages) == 0 {
@@ -1427,6 +1430,10 @@ func (m *Manager) providerAccessContext(ctx context.Context, p *principal.Princi
 
 func (m *Manager) allowTarget(ctx context.Context, p *principal.Principal, target coreworkflow.Target) bool {
 	if target.Agent != nil {
+		agentProviderName := strings.TrimSpace(target.Agent.ProviderName)
+		if agentProviderName == "" || !m.allowProvider(ctx, p, agentProviderName) || !principal.AllowsProviderPermission(p, agentProviderName) {
+			return false
+		}
 		hasSystemTools := workflowAgentToolRefsContainSystem(target.Agent.ToolRefs)
 		for i := range target.Agent.ToolRefs {
 			tool := target.Agent.ToolRefs[i]

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -11,6 +11,7 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
+	"github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc/codes"
@@ -36,9 +37,13 @@ func TestSignalOrStartRunExecutionRefInheritsDeclaredAgentToolInvokes(t *testing
 	callerPermissions := principal.CompilePermissions([]core.AccessPermission{{
 		Plugin:     "github",
 		Operations: []string{"events.handle"},
+	}, {
+		Plugin: "simple",
 	}})
 	caller := principal.Canonicalize(&principal.Principal{
-		SubjectID:        "system:http_binding:github:event",
+		SubjectID:        principal.UserSubjectID("ada"),
+		UserID:           "ada",
+		Kind:             principal.KindUser,
 		TokenPermissions: callerPermissions,
 		Scopes:           principal.PermissionPlugins(callerPermissions),
 	})
@@ -81,6 +86,8 @@ func TestSignalOrStartRunExecutionRefInheritsDeclaredAgentToolInvokes(t *testing
 			"bot.openPullRequest",
 			"events.handle",
 		},
+	}, {
+		Plugin: "simple",
 	}}
 	if !reflect.DeepEqual(managed.ExecutionRef.Permissions, wantPermissions) {
 		t.Fatalf("execution ref permissions = %#v, want %#v", managed.ExecutionRef.Permissions, wantPermissions)
@@ -169,8 +176,8 @@ func TestSignalOrStartRunRejectsDeniedExecutionRefPermissionsBeforeEnqueue(t *te
 		TokenPermissions: principal.PermissionSet{},
 	})
 	_, err := manager.SignalOrStartRun(context.Background(), denyAll, req)
-	if !errors.Is(err, core.ErrNotFound) {
-		t.Fatalf("SignalOrStartRun(deny-all) error = %v, want not found from unauthorized target", err)
+	if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("SignalOrStartRun(deny-all) error = %v, want authorization denied from unauthorized target", err)
 	}
 	if provider.signalOrStartCalls != 1 {
 		t.Fatalf("SignalOrStartRun provider calls = %d, want 1", provider.signalOrStartCalls)
@@ -308,6 +315,8 @@ func TestSignalOrStartRunDoesNotRewriteExecutionRefForDifferentPermissions(t *te
 	initialPermissions := principal.CompilePermissions([]core.AccessPermission{{
 		Plugin:     "github",
 		Operations: []string{"events.handle"},
+	}, {
+		Plugin: "simple",
 	}})
 	caller := principal.Canonicalize(&principal.Principal{
 		SubjectID:        "system:http_binding:github:event",
@@ -339,6 +348,8 @@ func TestSignalOrStartRunDoesNotRewriteExecutionRefForDifferentPermissions(t *te
 	broaderPermissions := principal.CompilePermissions([]core.AccessPermission{{
 		Plugin:     "github",
 		Operations: []string{"events.handle", "bot.admin"},
+	}, {
+		Plugin: "simple",
 	}})
 	broaderCaller := principal.Canonicalize(&principal.Principal{
 		SubjectID:        caller.SubjectID,
@@ -395,9 +406,13 @@ func TestSignalOrStartRunExecutionRefDoesNotInheritSurfaceInvokes(t *testing.T) 
 	callerPermissions := principal.CompilePermissions([]core.AccessPermission{{
 		Plugin:     "github",
 		Operations: []string{"events.handle"},
+	}, {
+		Plugin: "simple",
 	}})
 	caller := principal.Canonicalize(&principal.Principal{
-		SubjectID:        "system:http_binding:github:event",
+		SubjectID:        principal.UserSubjectID("ada"),
+		UserID:           "ada",
+		Kind:             principal.KindUser,
 		TokenPermissions: callerPermissions,
 		Scopes:           principal.PermissionPlugins(callerPermissions),
 	})
@@ -417,6 +432,94 @@ func TestSignalOrStartRunExecutionRefDoesNotInheritSurfaceInvokes(t *testing.T) 
 	})
 	if !errors.Is(err, core.ErrNotFound) {
 		t.Fatalf("SignalOrStartRun error = %v, want not found from unauthorized target", err)
+	}
+}
+
+func TestSignalOrStartRunRejectsUnauthorizedAgentProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWorkflowProvider()
+	manager := New(Config{
+		Workflow:     testWorkflowControl{provider: provider},
+		Agent:        testAgentControl{},
+		AgentManager: testAgentManager{},
+	})
+	callerPermissions := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "github",
+		Operations: []string{"events.handle"},
+	}})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID:        "system:http_binding:github:event",
+		TokenPermissions: callerPermissions,
+		Scopes:           principal.PermissionPlugins(callerPermissions),
+	})
+
+	_, err := manager.SignalOrStartRun(context.Background(), caller, RunSignalOrStart{
+		ProviderName:     "local",
+		WorkflowKey:      "github:99:acme/widgets:7",
+		CallerPluginName: "github",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "simple",
+			Prompt:       "Handle the webhook.",
+		}},
+		Signal: coreworkflow.Signal{Name: "github.app.webhook"},
+	})
+	if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("SignalOrStartRun error = %v, want authorization denied from unauthorized agent provider", err)
+	}
+	if provider.signalOrStartCalls != 0 {
+		t.Fatalf("SignalOrStartRun provider calls = %d, want 0", provider.signalOrStartCalls)
+	}
+}
+
+func TestSignalOrStartRunRejectsRuntimeDeniedAgentProvider(t *testing.T) {
+	t.Parallel()
+
+	authz, err := authorization.New(authorization.StaticConfig{
+		Policies: map[string]authorization.StaticSubjectPolicy{
+			"agent_policy": {Default: "deny"},
+		},
+		ProviderPolicies: map[string]string{"simple": "agent_policy"},
+	})
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	provider := newTestWorkflowProvider()
+	manager := New(Config{
+		Workflow:     testWorkflowControl{provider: provider},
+		Agent:        testAgentControl{},
+		AgentManager: testAgentManager{},
+		Authorizer:   authz,
+	})
+	callerPermissions := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "github",
+		Operations: []string{"events.handle"},
+	}, {
+		Plugin: "simple",
+	}})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID:        principal.UserSubjectID("ada"),
+		UserID:           "ada",
+		Kind:             principal.KindUser,
+		TokenPermissions: callerPermissions,
+		Scopes:           principal.PermissionPlugins(callerPermissions),
+	})
+
+	_, err = manager.SignalOrStartRun(context.Background(), caller, RunSignalOrStart{
+		ProviderName:     "local",
+		WorkflowKey:      "github:99:acme/widgets:7",
+		CallerPluginName: "github",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "simple",
+			Prompt:       "Handle the webhook.",
+		}},
+		Signal: coreworkflow.Signal{Name: "github.app.webhook"},
+	})
+	if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("SignalOrStartRun error = %v, want authorization denied from runtime-denied agent provider", err)
+	}
+	if provider.signalOrStartCalls != 0 {
+		t.Fatalf("SignalOrStartRun provider calls = %d, want 0", provider.signalOrStartCalls)
 	}
 }
 
@@ -444,6 +547,8 @@ func TestSignalRunUsesCurrentPrincipalForTargetValidation(t *testing.T) {
 		Permissions: []core.AccessPermission{{
 			Plugin:     "github",
 			Operations: []string{"events.handle"},
+		}, {
+			Plugin: "simple",
 		}},
 	}
 	provider.refs[ref.ID] = ref
@@ -457,6 +562,8 @@ func TestSignalRunUsesCurrentPrincipalForTargetValidation(t *testing.T) {
 	callerPermissions := principal.CompilePermissions([]core.AccessPermission{{
 		Plugin:     "github",
 		Operations: []string{"events.handle", "bot.openPullRequest"},
+	}, {
+		Plugin: "simple",
 	}})
 	caller := principal.Canonicalize(&principal.Principal{
 		SubjectID:        "system:http_binding:github:event",


### PR DESCRIPTION
## Summary
- Require runtime authorizer and token/provider permission checks before creating agent sessions and before each agent turn.
- Apply the same provider authorization to workflow agent targets before resolving or signaling runs.
- Extend existing server, workflow, and bootstrap integration-style tests so successful agent flows explicitly carry agent-provider permission, and unauthorized provider access is denied before provider invocation.

## Tests
- `go test ./internal/server -run 'TestAgentSessionRejectsUnauthorizedProvider|TestAgentTurnRechecksProviderAuthorization'`
- `go test ./internal/workflowmanager ./internal/agentmanager`
- `go test ./internal/bootstrap -run 'TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext|TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn|TestBootstrapHTTPCallerWildcardSearchUsesResolvedUserToolScope|TestBootstrapAgentManagerIdempotentTurnReplayRequiresCurrentToolAccess|TestBootstrapAgentHostToolSearchPrioritizesNamedPluginIssueTools|TestBootstrapAgentHostToolSearchReturnsCandidatesAndLoadsRefs|TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks'`
- `go test ./...`