### PR TITLE
[codex] Fail closed for admin and mounted UI auth

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -358,6 +358,7 @@ type ProviderEntry struct {
 	// Plugin-specific runtime fields populated from the canonical ui object.
 	MountPath         string                        `yaml:"-"`
 	UI                string                        `yaml:"-"`
+	UIPublic          bool                          `yaml:"-"`
 	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
 	Invokes           []PluginInvocationDependency  `yaml:"invokes,omitempty"`
@@ -408,11 +409,13 @@ type providerEntryMarshalYAML struct {
 type uiEntryYAML struct {
 	providerEntryYAML `yaml:",inline"`
 	Path              string `yaml:"path,omitempty"`
+	Public            bool   `yaml:"public,omitempty"`
 }
 
 type uiEntryMarshalYAML struct {
 	providerEntryMarshalYAML `yaml:",inline"`
 	Path                     string `yaml:"path,omitempty"`
+	Public                   bool   `yaml:"public,omitempty"`
 }
 
 func (e *ProviderEntry) UnmarshalYAML(value *yaml.Node) error {
@@ -438,6 +441,7 @@ func (e *ProviderEntry) UnmarshalYAML(value *yaml.Node) error {
 		if uiBinding.Path != "" {
 			decoded.MountPath = uiBinding.Path
 		}
+		decoded.UIPublic = uiBinding.Public
 	}
 	*e = decoded
 	return nil
@@ -452,6 +456,7 @@ func (e ProviderEntry) MarshalYAML() (any, error) {
 		raw.UI = &pluginUIBindingConfig{
 			Bundle: strings.TrimSpace(e.UI),
 			Path:   strings.TrimSpace(e.MountPath),
+			Public: e.UIPublic,
 		}
 	}
 	return raw, nil
@@ -476,6 +481,7 @@ type HostIndexedDBBindingConfig struct {
 type pluginUIBindingConfig struct {
 	Path   string `yaml:"path,omitempty"`
 	Bundle string `yaml:"bundle,omitempty"`
+	Public bool   `yaml:"public,omitempty"`
 }
 
 type ProviderEgressConfig struct {
@@ -709,6 +715,7 @@ type ProviderMCPSurfaceOverride struct {
 type UIEntry struct {
 	ProviderEntry `yaml:",inline"`
 	Path          string `yaml:"path,omitempty"`
+	Public        bool   `yaml:"public,omitempty"`
 	OwnerPlugin   string `yaml:"-"`
 }
 
@@ -724,6 +731,7 @@ func (e *UIEntry) UnmarshalYAML(value *yaml.Node) error {
 	*e = UIEntry{
 		ProviderEntry: decoded,
 		Path:          raw.Path,
+		Public:        raw.Public,
 	}
 	return nil
 }
@@ -740,6 +748,7 @@ func (e UIEntry) MarshalYAML() (any, error) {
 	return uiEntryMarshalYAML{
 		providerEntryMarshalYAML: entry,
 		Path:                     e.Path,
+		Public:                   e.Public,
 	}, nil
 }
 
@@ -1399,9 +1408,10 @@ type ManagementListenerConfig struct {
 }
 
 type AdminConfig struct {
-	AuthorizationPolicy string   `yaml:"authorizationPolicy,omitempty"`
-	AllowedRoles        []string `yaml:"allowedRoles,omitempty"`
-	UI                  string   `yaml:"ui,omitempty"`
+	AuthorizationPolicy  string   `yaml:"authorizationPolicy,omitempty"`
+	AllowedRoles         []string `yaml:"allowedRoles,omitempty"`
+	UI                   string   `yaml:"ui,omitempty"`
+	AllowUnauthenticated bool     `yaml:"allowUnauthenticated,omitempty"`
 }
 
 type ServerConfig struct {
@@ -2790,6 +2800,9 @@ func normalizeAdminConfig(cfg *Config) error {
 	admin := cfg.Server.Admin
 	admin.AuthorizationPolicy = strings.TrimSpace(admin.AuthorizationPolicy)
 	admin.UI = strings.TrimSpace(admin.UI)
+	if admin.AuthorizationPolicy != "" && admin.AllowUnauthenticated {
+		return fmt.Errorf("normalize admin config: server.admin.allowUnauthenticated cannot be combined with server.admin.authorizationPolicy")
+	}
 	if len(admin.AllowedRoles) == 0 {
 		if admin.AuthorizationPolicy != "" {
 			admin.AllowedRoles = []string{"admin"}
@@ -2849,6 +2862,9 @@ func applyPluginMountBindings(cfg *Config) error {
 		if err := validateAuthorizationPolicyReference(cfg, "plugin", pluginName, plugin.AuthorizationPolicy); err != nil {
 			return err
 		}
+		if plugin.AuthorizationPolicy != "" && plugin.UIPublic {
+			return fmt.Errorf("config validation: plugins.%s.ui.public cannot be combined with plugins.%s.authorizationPolicy", pluginName, pluginName)
+		}
 		if plugin.UI == "" {
 			continue
 		}
@@ -2862,6 +2878,9 @@ func applyPluginMountBindings(cfg *Config) error {
 		if current := strings.TrimSpace(ui.AuthorizationPolicy); current != "" && current != plugin.AuthorizationPolicy {
 			return fmt.Errorf("config validation: plugins.%s.ui %q conflicts with providers.ui.%s.authorizationPolicy", pluginName, plugin.UI, plugin.UI)
 		}
+		if ui.Public && !plugin.UIPublic {
+			return fmt.Errorf("config validation: plugins.%s.ui %q conflicts with providers.ui.%s.public", pluginName, plugin.UI, plugin.UI)
+		}
 		if current := strings.TrimSpace(ui.Path); current != "" && current != plugin.MountPath {
 			return fmt.Errorf("config validation: plugins.%s.ui %q conflicts with providers.ui.%s.path", pluginName, plugin.UI, plugin.UI)
 		}
@@ -2869,6 +2888,7 @@ func applyPluginMountBindings(cfg *Config) error {
 			return fmt.Errorf("config validation: plugins.%s.ui %q conflicts with providers.ui.%s owner", pluginName, plugin.UI, plugin.UI)
 		}
 		ui.AuthorizationPolicy = plugin.AuthorizationPolicy
+		ui.Public = ui.Public || plugin.UIPublic
 		ui.Path = plugin.MountPath
 		ui.OwnerPlugin = pluginName
 		seenUIs[plugin.UI] = pluginName

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1289,6 +1289,7 @@ providers:
   ui:
     dashboard:
       path: /dashboard
+      public: true
       source: ./providers/ui/dashboard/manifest.yaml
 plugins:
 `)
@@ -1705,6 +1706,7 @@ providers:
       source:
         path: ./ui/default/provider.yaml
       path: /create-customer-roadmap-review
+      public: true
   indexeddb:
     sqlite:
       source:
@@ -1776,6 +1778,7 @@ providers:
       source:
         path: ./web/roadmap/manifest.yaml
       path: /create-customer-roadmap-review/
+      public: true
   indexeddb:
     sqlite:
       source:
@@ -1866,10 +1869,12 @@ providers:
       source:
         path: ./web/docs/manifest.yaml
       path: /docs
+      public: true
     admin:
       source:
         path: ./web/docs-admin/manifest.yaml
       path: /docs/admin
+      public: true
   indexeddb:
     sqlite:
       source:
@@ -1902,6 +1907,7 @@ providers:
       source:
         path: ./web/api/manifest.yaml
       path: /api
+      public: true
   indexeddb:
     sqlite:
       source:
@@ -1931,6 +1937,7 @@ providers:
       source:
         path: ./web/metrics/manifest.yaml
       path: /metrics/dashboard
+      public: true
   indexeddb:
     sqlite:
       source:
@@ -1960,11 +1967,13 @@ plugins:
       path: ./plugin/manifest.yaml
     ui:
       path: /api
+      public: true
 providers:
   ui:
     roadmap:
       source:
         path: ./web/roadmap/manifest.yaml
+      public: true
   indexeddb:
     sqlite:
       source:
@@ -1994,12 +2003,14 @@ plugins:
       path: ./plugin/manifest.yaml
     ui:
       path: /api
+      public: true
 providers:
   ui:
     roadmap:
       source:
         path: ./web/roadmap/manifest.yaml
       path: /roadmap
+      public: true
   indexeddb:
     sqlite:
       source:
@@ -2029,6 +2040,7 @@ providers:
       source:
         path: ./web/docs/manifest.yaml
       path: /tools
+      public: true
   indexeddb:
     sqlite:
       source:
@@ -2039,6 +2051,7 @@ plugins:
       path: ./plugin/manifest.yaml
     ui:
       path: /tools/admin
+      public: true
 server:
   providers:
     indexeddb: sqlite
@@ -2064,6 +2077,7 @@ providers:
       source:
         path: ./web/root/manifest.yaml
       path: /
+      public: true
   indexeddb:
     sqlite:
       source:
@@ -2092,6 +2106,7 @@ providers:
     roadmap:
       source: stdout
       path: /create-customer-roadmap-review
+      public: true
   indexeddb:
     sqlite:
       source:

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -107,6 +107,9 @@ func ValidateCanonicalStructure(cfg *Config) error {
 		if err := validateProviderEntrySource("ui", name, &entry.ProviderEntry); err != nil {
 			return err
 		}
+		if entry.Public && strings.TrimSpace(entry.AuthorizationPolicy) != "" {
+			return fmt.Errorf("config validation: ui.%s.public cannot be combined with ui.%s.authorizationPolicy", name, name)
+		}
 		if err := validateAuthorizationPolicyReference(cfg, "ui", name, entry.AuthorizationPolicy); err != nil {
 			return err
 		}
@@ -1014,6 +1017,9 @@ func validateAdminConfig(cfg *Config) error {
 			return fmt.Errorf("config validation: server.admin.allowedRoles requires server.admin.authorizationPolicy")
 		}
 	} else {
+		if admin.AllowUnauthenticated {
+			return fmt.Errorf("config validation: server.admin.allowUnauthenticated cannot be combined with server.admin.authorizationPolicy")
+		}
 		_, authProvider, err := cfg.SelectedAuthenticationProvider()
 		if err != nil {
 			return err

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -1674,6 +1674,7 @@ func writeServeConfig(t *testing.T, dir string, port int, mountedUI *mountedUITe
       source:
         path: %q
       path: %s
+      public: true
 `, mountedUI.Name, mountedUI.ManifestPath, mountedUI.Path)
 	}
 
@@ -1720,6 +1721,7 @@ func writeServeConfigWithManagement(t *testing.T, dir string, publicPort, manage
       source:
         path: %q
       path: %s
+      public: true
 `, mountedUI.Name, mountedUI.ManifestPath, mountedUI.Path)
 	}
 
@@ -1731,6 +1733,8 @@ server:
   management:
     host: 127.0.0.1
     port: %d
+  admin:
+    allowUnauthenticated: true
   encryptionKey: test-serve-e2e-key
   providers:
     indexeddb: inmem
@@ -2346,6 +2350,7 @@ providers:
     roadmap:
       source:
         path: %s
+      public: true
 plugins:
   example:
     source:
@@ -2353,6 +2358,7 @@ plugins:
     ui:
       bundle: roadmap
       path: /roadmap
+      public: true
 `, publicURL, publicPort, indexedDBManifest, mountedUI.ManifestPath, pluginManifest)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write owned-ui config: %v", err)
@@ -2789,6 +2795,7 @@ plugins:
       path: %s
     ui:
       path: /roadmap
+      public: true
 `, e2eLoopbackBaseURL(0), indexedDBManifest, pluginManifest)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write owned-ui lock/sync config: %v", err)

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -596,7 +596,7 @@ func preparePluginLocalSession(sessionDir, baseConfigPath string, state operator
 	}
 
 	overlayConfigPath := filepath.Join(sessionDir, "provider-target.yaml")
-	if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, "", "", ""); err != nil {
+	if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, "", "", "", false); err != nil {
 		return nil, err
 	}
 
@@ -619,7 +619,8 @@ func preparePluginLocalSession(sessionDir, baseConfigPath string, state operator
 		if err := ensureNoPublicUIPathCollision(loadedCfg, resolvedKey, autoMountPath); err != nil {
 			return nil, err
 		}
-		if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath, "", ""); err != nil {
+		uiPublic := providerLocalPluginOverlayUIPublic(loadedCfg, resolvedKey, "")
+		if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath, "", "", uiPublic); err != nil {
 			return nil, err
 		}
 	case siblingUIManifestPath != "":
@@ -637,7 +638,8 @@ func preparePluginLocalSession(sessionDir, baseConfigPath string, state operator
 				return nil, err
 			}
 		}
-		if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath, uiName, siblingUIManifestPath); err != nil {
+		uiPublic := providerLocalPluginOverlayUIPublic(loadedCfg, resolvedKey, uiName)
+		if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath, uiName, siblingUIManifestPath, uiPublic); err != nil {
 			return nil, err
 		}
 	}
@@ -645,6 +647,10 @@ func preparePluginLocalSession(sessionDir, baseConfigPath string, state operator
 	loadedCfg, err = config.LoadPaths(configPaths)
 	if err != nil {
 		return nil, fmt.Errorf("loading provider dev config with mounted ui: %w", err)
+	}
+	configPaths, loadedCfg, err = ensureProviderLocalAdminOverlay(sessionDir, configPaths, loadedCfg)
+	if err != nil {
+		return nil, err
 	}
 
 	publicURL := providerLocalPublicURL(loadedCfg)
@@ -675,14 +681,16 @@ func prepareUILocalSession(sessionDir, baseConfigPath string, state operator.Sta
 	}
 
 	autoMountPath := defaultProviderLocalMountPath(manifest, targetManifestPath, resolvedKey)
+	uiPublic := true
 	if configuredUIs, err := loadConfiguredUIs(opts.ConfigPaths); err == nil {
 		if entry := configuredUIs[resolvedKey]; entry != nil && strings.TrimSpace(entry.Path) != "" {
 			autoMountPath = strings.TrimSpace(entry.Path)
 		}
+		uiPublic = providerLocalUIOverlayPublic(configuredUIs[resolvedKey])
 	}
 
 	overlayConfigPath := filepath.Join(sessionDir, "provider-target.yaml")
-	if err := writeProviderLocalUIOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath); err != nil {
+	if err := writeProviderLocalUIOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath, uiPublic); err != nil {
 		return nil, err
 	}
 
@@ -692,6 +700,10 @@ func prepareUILocalSession(sessionDir, baseConfigPath string, state operator.Sta
 	loadedCfg, err := config.LoadPaths(configPaths)
 	if err != nil {
 		return nil, fmt.Errorf("loading provider dev config: %w", err)
+	}
+	configPaths, loadedCfg, err = ensureProviderLocalAdminOverlay(sessionDir, configPaths, loadedCfg)
+	if err != nil {
+		return nil, err
 	}
 
 	publicURL := providerLocalPublicURL(loadedCfg)
@@ -1115,7 +1127,7 @@ func writeProviderLocalBaseConfig(path, dbPath string) error {
 	return writeYAMLFile(path, cfg)
 }
 
-func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string, port int, mountPath, uiName, uiManifestPath string) error {
+func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string, port int, mountPath, uiName, uiManifestPath string, uiPublic bool) error {
 	pluginEntry := map[string]any{
 		"source":    providerLocalSourceOverride(manifestPath),
 		"execution": nil,
@@ -1127,6 +1139,9 @@ func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string,
 		}
 		if uiName != "" {
 			ui["bundle"] = uiName
+		}
+		if uiPublic {
+			ui["public"] = true
 		}
 		pluginEntry["ui"] = ui
 	}
@@ -1145,11 +1160,15 @@ func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string,
 		},
 	}
 	if uiName != "" && uiManifestPath != "" {
+		uiProviderEntry := map[string]any{
+			"source": providerLocalSourceOverride(uiManifestPath),
+		}
+		if uiPublic {
+			uiProviderEntry["public"] = true
+		}
 		cfg["providers"] = map[string]any{
 			"ui": map[string]any{
-				uiName: map[string]any{
-					"source": providerLocalSourceOverride(uiManifestPath),
-				},
+				uiName: uiProviderEntry,
 			},
 		}
 	}
@@ -1169,12 +1188,15 @@ func writeProviderRemotePluginOverlayConfig(path, pluginKey, manifestPath string
 	return writeYAMLFile(path, cfg)
 }
 
-func writeProviderLocalUIOverlayConfig(path, uiKey, manifestPath string, port int, mountPath string) error {
+func writeProviderLocalUIOverlayConfig(path, uiKey, manifestPath string, port int, mountPath string, uiPublic bool) error {
 	uiEntry := map[string]any{
 		"source": providerLocalSourceOverride(manifestPath),
 	}
 	if mountPath != "" {
 		uiEntry["path"] = mountPath
+	}
+	if uiPublic {
+		uiEntry["public"] = true
 	}
 
 	cfg := map[string]any{
@@ -1189,6 +1211,53 @@ func writeProviderLocalUIOverlayConfig(path, uiKey, manifestPath string, port in
 		"providers": map[string]any{
 			"ui": map[string]any{
 				uiKey: uiEntry,
+			},
+		},
+	}
+	return writeYAMLFile(path, cfg)
+}
+
+func providerLocalPluginOverlayUIPublic(cfg *config.Config, pluginKey, uiName string) bool {
+	if cfg == nil {
+		return true
+	}
+	if plugin := cfg.Plugins[pluginKey]; plugin != nil && strings.TrimSpace(plugin.AuthorizationPolicy) != "" {
+		return false
+	}
+	if uiName != "" {
+		if ui := cfg.Providers.UI[uiName]; ui != nil && strings.TrimSpace(ui.AuthorizationPolicy) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func providerLocalUIOverlayPublic(entry *config.UIEntry) bool {
+	return entry == nil || strings.TrimSpace(entry.AuthorizationPolicy) == ""
+}
+
+func ensureProviderLocalAdminOverlay(sessionDir string, configPaths []string, loadedCfg *config.Config) ([]string, *config.Config, error) {
+	if loadedCfg == nil || strings.TrimSpace(loadedCfg.Server.Admin.AuthorizationPolicy) != "" || loadedCfg.Server.Admin.AllowUnauthenticated {
+		return configPaths, loadedCfg, nil
+	}
+	overlayConfigPath := filepath.Join(sessionDir, "provider-admin.yaml")
+	if err := writeProviderLocalAdminOverlayConfig(overlayConfigPath); err != nil {
+		return nil, nil, err
+	}
+	configPaths = append(configPaths, overlayConfigPath)
+	reloadedCfg, err := config.LoadPaths(configPaths)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading provider dev config with local admin: %w", err)
+	}
+	return configPaths, reloadedCfg, nil
+}
+
+func writeProviderLocalAdminOverlayConfig(path string) error {
+	cfg := map[string]any{
+		"apiVersion": config.ConfigAPIVersion,
+		"server": map[string]any{
+			"admin": map[string]any{
+				"allowUnauthenticated": true,
 			},
 		},
 	}

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -109,6 +109,106 @@ func TestProviderRemoteConfigPathSynthesizesSourcePlugin(t *testing.T) {
 	}
 }
 
+func TestProviderLocalSessionPreservesProtectedOwnedUI(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+	mountedUI := setupMountedUIDir(t, dir)
+	attachOwnedUIToPluginSource(t, pluginDir, mountedUI.ManifestPath)
+	pluginManifest := componentProviderManifestPath(t, pluginDir)
+	cfgPath := filepath.Join(dir, "protected.yaml")
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
+authorization:
+  policies:
+    dev_policy:
+      default: deny
+plugins:
+  provider:
+    source:
+      path: %s
+    authorizationPolicy: dev_policy
+`, pluginManifest)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	session, err := prepareProviderLocalSession(providerLocalCommandOptions{
+		Path:        pluginManifest,
+		ConfigPaths: []string{cfgPath},
+		Port:        18080,
+	})
+	if err != nil {
+		t.Fatalf("prepareProviderLocalSession: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(session.Dir) }()
+
+	loaded, err := config.LoadPaths(session.ConfigPaths)
+	if err != nil {
+		t.Fatalf("config.LoadPaths: %v", err)
+	}
+	plugin := loaded.Plugins["provider"]
+	if plugin == nil {
+		t.Fatal(`Plugins["provider"] = nil`)
+	}
+	if got := plugin.AuthorizationPolicy; got != "dev_policy" {
+		t.Fatalf("AuthorizationPolicy = %q, want dev_policy", got)
+	}
+	if plugin.UIPublic {
+		t.Fatal("UIPublic = true, want protected provider-dev overlay to preserve policy-bound UI")
+	}
+}
+
+func TestProviderLocalSessionPreservesProtectedSourceUI(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	mountedUI := setupMountedUIDir(t, dir)
+	setUIManifestSource(t, mountedUI.ManifestPath, "github.com/test/ui/roadmap.review")
+	cfgPath := filepath.Join(dir, "protected-ui.yaml")
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
+authorization:
+  policies:
+    dev_policy:
+      default: deny
+providers:
+  ui:
+    roadmap_review:
+      source:
+        path: %s
+      path: /roadmap.review
+      authorizationPolicy: dev_policy
+`, mountedUI.ManifestPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	session, err := prepareProviderLocalSession(providerLocalCommandOptions{
+		Path:        mountedUI.ManifestPath,
+		ConfigPaths: []string{cfgPath},
+		Port:        18080,
+	})
+	if err != nil {
+		t.Fatalf("prepareProviderLocalSession: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(session.Dir) }()
+
+	loaded, err := config.LoadPaths(session.ConfigPaths)
+	if err != nil {
+		t.Fatalf("config.LoadPaths: %v", err)
+	}
+	entry := loaded.Providers.UI["roadmap_review"]
+	if entry == nil {
+		t.Fatal(`Providers.UI["roadmap_review"] = nil`)
+	}
+	if got := entry.AuthorizationPolicy; got != "dev_policy" {
+		t.Fatalf("AuthorizationPolicy = %q, want dev_policy", got)
+	}
+	if entry.Public {
+		t.Fatal("Public = true, want protected provider-dev overlay to preserve policy-bound UI")
+	}
+}
+
 func TestResolveProviderRemoteAttachTokenPrecedence(t *testing.T) {
 	configHome := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", configHome)

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -2374,6 +2374,7 @@ func synthesizePluginOwnedUIEntries(cfg *config.Config) error {
 		}
 		entry.Path = strings.TrimSpace(plugin.MountPath)
 		entry.AuthorizationPolicy = strings.TrimSpace(plugin.AuthorizationPolicy)
+		entry.Public = plugin.UIPublic
 		entry.OwnerPlugin = pluginName
 		if existing := cfg.Providers.UI[pluginName]; existing != nil {
 			if err := validateSynthesizedPluginUIEntry(pluginName, existing, entry); err != nil {
@@ -2384,6 +2385,7 @@ func synthesizePluginOwnedUIEntries(cfg *config.Config) error {
 			}
 			existing.Path = cmp.Or(existing.Path, entry.Path)
 			existing.AuthorizationPolicy = cmp.Or(existing.AuthorizationPolicy, entry.AuthorizationPolicy)
+			existing.Public = existing.Public || entry.Public
 			existing.OwnerPlugin = cmp.Or(existing.OwnerPlugin, entry.OwnerPlugin)
 			continue
 		}
@@ -2429,6 +2431,9 @@ func validateSynthesizedPluginUIEntry(pluginName string, existing, expected *con
 	}
 	if current := strings.TrimSpace(existing.AuthorizationPolicy); current != "" && current != expected.AuthorizationPolicy {
 		return fmt.Errorf("config validation: plugins.%s.authorizationPolicy conflicts with providers.ui.%s.authorizationPolicy", pluginName, pluginName)
+	}
+	if existing.Public && !expected.Public {
+		return fmt.Errorf("config validation: plugins.%s.ui.public conflicts with providers.ui.%s.public", pluginName, pluginName)
 	}
 	if current := strings.TrimSpace(existing.OwnerPlugin); current != "" && current != expected.OwnerPlugin {
 		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with providers.ui.%s owner", pluginName, pluginName)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1184,6 +1184,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalMountedUIWithoutLockfile(t *testing
 		uiKey        string
 		wantPath     string
 		wantPolicy   string
+		wantPublic   bool
 		ownedUIPath  string
 		uiManifest   string
 		wantErr      string
@@ -1298,6 +1299,25 @@ plugins:
 			uiKey:       "roadmap",
 			wantPath:    "/create-customer-roadmap-review",
 			wantPolicy:  "roadmap_policy",
+			ownedUIPath: "../ui/manifest.yaml",
+		},
+		{
+			name: "plugin owned public ui with same-name ui overlay",
+			uiConfigYAML: `  ui:
+    roadmap:
+      source:
+        path: ./ui/manifest.yaml
+plugins:
+    roadmap:
+      source:
+        path: ./plugin/manifest.yaml
+      ui:
+        path: /create-customer-roadmap-review
+        public: true
+`,
+			uiKey:       "roadmap",
+			wantPath:    "/create-customer-roadmap-review",
+			wantPublic:  true,
 			ownedUIPath: "../ui/manifest.yaml",
 		},
 	}
@@ -1428,7 +1448,10 @@ plugins:
 			if got := entry.AuthorizationPolicy; got != tc.wantPolicy {
 				t.Fatalf("AuthorizationPolicy = %q, want %q", got, tc.wantPolicy)
 			}
-			if tc.wantPolicy != "" {
+			if got := entry.Public; got != tc.wantPublic {
+				t.Fatalf("Public = %t, want %t", got, tc.wantPublic)
+			}
+			if tc.wantPolicy != "" || tc.wantPublic {
 				if got := entry.OwnerPlugin; got != "roadmap" {
 					t.Fatalf("OwnerPlugin = %q, want %q", got, "roadmap")
 				}

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -114,6 +114,11 @@ func defaultManagedConfig(dbPath, encryptionKey string) string {
 server:
   public:
     port: 8080
+  management:
+    host: 127.0.0.1
+    port: 8081
+  admin:
+    allowUnauthenticated: true
   encryptionKey: %q
   providers:
     indexeddb: main
@@ -127,6 +132,7 @@ providers:
     root:
       source: %s
       path: /
+      public: true
   secrets:
     env:
       source: env
@@ -149,6 +155,11 @@ func defaultLocalSourceConfig(providersDir, dbPath, encryptionKey string) string
 server:
   public:
     port: 8080
+  management:
+    host: 127.0.0.1
+    port: 8081
+  admin:
+    allowUnauthenticated: true
   encryptionKey: %q
   providers:
     externalCredentials: default
@@ -169,6 +180,7 @@ providers:
       source:
         path: %q
       path: /
+      public: true
   secrets:
     env:
       source: env

--- a/gestaltd/internal/operator/localconfig_test.go
+++ b/gestaltd/internal/operator/localconfig_test.go
@@ -36,6 +36,18 @@ func TestDefaultManagedConfigIncludesRootUI(t *testing.T) {
 	if got := rootUI.Path; got != "/" {
 		t.Fatalf(`Providers.UI["root"].Path = %q, want %q`, got, "/")
 	}
+	if !rootUI.Public {
+		t.Fatal(`Providers.UI["root"].Public = false, want true`)
+	}
+	if !cfg.Server.Admin.AllowUnauthenticated {
+		t.Fatal("Server.Admin.AllowUnauthenticated = false, want true")
+	}
+	if got := cfg.Server.Management.Host; got != "127.0.0.1" {
+		t.Fatalf("Server.Management.Host = %q, want 127.0.0.1", got)
+	}
+	if got := cfg.Server.Management.Port; got != 8081 {
+		t.Fatalf("Server.Management.Port = %d, want 8081", got)
+	}
 
 	indexedDB := cfg.Providers.IndexedDB["main"]
 	if indexedDB == nil {
@@ -76,6 +88,18 @@ func TestDefaultLocalSourceConfigIncludesRootUI(t *testing.T) {
 	}
 	if got := rootUI.Path; got != "/" {
 		t.Fatalf(`Providers.UI["root"].Path = %q, want %q`, got, "/")
+	}
+	if !rootUI.Public {
+		t.Fatal(`Providers.UI["root"].Public = false, want true`)
+	}
+	if !cfg.Server.Admin.AllowUnauthenticated {
+		t.Fatal("Server.Admin.AllowUnauthenticated = false, want true")
+	}
+	if got := cfg.Server.Management.Host; got != "127.0.0.1" {
+		t.Fatalf("Server.Management.Host = %q, want 127.0.0.1", got)
+	}
+	if got := cfg.Server.Management.Port; got != 8081 {
+		t.Fatalf("Server.Management.Port = %d, want 8081", got)
 	}
 
 	externalCredentials := cfg.Providers.ExternalCredentials[config.DefaultProviderInstance]

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -65,7 +65,12 @@ func (s *Server) mountAdminAuthorizationRoutes(r chi.Router) {
 
 func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 	if s.adminRoute.AuthorizationPolicy == "" {
-		return next
+		if s.adminRoute.AllowUnauthenticated {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			writeError(w, http.StatusInternalServerError, "admin authorization is not configured")
+		})
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -67,7 +67,7 @@ func (s *Server) mountedUIForProvider(provider, mountedPath string) (MountedUI, 
 
 func (s *Server) mountedUIRootAccessibleContext(ctx context.Context, p *principal.Principal, mounted MountedUI) bool {
 	if mounted.AuthorizationPolicy == "" {
-		return true
+		return mounted.Public
 	}
 	if s.authorizer == nil || p == nil || principal.IsNonUserPrincipal(p) {
 		return false

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -34,6 +34,9 @@ type protectedUILoginRedirect func(http.ResponseWriter, *http.Request) error
 
 func normalizeAdminRouteConfig(admin AdminRouteConfig) (AdminRouteConfig, error) {
 	admin.AuthorizationPolicy = strings.TrimSpace(admin.AuthorizationPolicy)
+	if admin.AuthorizationPolicy != "" && admin.AllowUnauthenticated {
+		return AdminRouteConfig{}, fmt.Errorf("admin AllowUnauthenticated cannot be combined with AuthorizationPolicy")
+	}
 	if admin.AuthorizationPolicy == "" {
 		if len(admin.AllowedRoles) > 0 {
 			return AdminRouteConfig{}, fmt.Errorf("admin allowedRoles requires AuthorizationPolicy")
@@ -138,6 +141,7 @@ func mountedUIsFromEntries(entries map[string]*config.UIEntry) ([]MountedUI, err
 			Path:                entry.Path,
 			PluginName:          entry.OwnerPlugin,
 			AuthorizationPolicy: entry.AuthorizationPolicy,
+			Public:              entry.Public,
 			Routes:              routes,
 			Handler:             handler,
 		})
@@ -244,6 +248,20 @@ func normalizeMountedUIs(mounted []MountedUI) ([]MountedUI, error) {
 			return nil, fmt.Errorf("normalize mounted ui %q routes: %w", name, err)
 		}
 		normalized[i].Routes = routes
+		if normalized[i].AuthorizationPolicy != "" && normalized[i].Public {
+			name := normalized[i].Name
+			if name == "" {
+				name = normalized[i].Path
+			}
+			return nil, fmt.Errorf("normalize mounted ui %q: Public cannot be combined with AuthorizationPolicy", name)
+		}
+		if normalized[i].AuthorizationPolicy == "" && !normalized[i].Public {
+			name := normalized[i].Name
+			if name == "" {
+				name = normalized[i].Path
+			}
+			return nil, fmt.Errorf("normalize mounted ui %q: AuthorizationPolicy or Public is required", name)
+		}
 		if err := validatePolicyBoundMountedUIRoutes(normalized[i]); err != nil {
 			name := normalized[i].Name
 			if name == "" {
@@ -408,6 +426,7 @@ func (s *Server) adminMountedUI() MountedUI {
 		Name:                "builtin_admin",
 		Path:                "/admin",
 		AuthorizationPolicy: s.adminRoute.AuthorizationPolicy,
+		Public:              s.adminRoute.AllowUnauthenticated,
 		builtInAdmin:        true,
 		Routes: []MountedUIRoute{{
 			Path:         "/*",
@@ -419,7 +438,12 @@ func (s *Server) adminMountedUI() MountedUI {
 
 func (s *Server) protectedUIHandler(mounted MountedUI, inner http.Handler, redirectLogin protectedUILoginRedirect) http.Handler {
 	if mounted.AuthorizationPolicy == "" {
-		return inner
+		if mounted.Public {
+			return inner
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			writeError(w, http.StatusInternalServerError, "ui authorization is not configured")
+		})
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/provider_dev_ui_test.go
+++ b/gestaltd/internal/server/provider_dev_ui_test.go
@@ -78,6 +78,7 @@ func TestProviderDevMountedUIHandlerOverridesFallback(t *testing.T) {
 		Name:       "roadmap",
 		Path:       "/roadmap",
 		PluginName: "roadmap",
+		Public:     true,
 		Handler:    fallback,
 	})
 	req := httptest.NewRequest(http.MethodGet, "/roadmap/sync?tab=preview", nil)
@@ -201,6 +202,7 @@ func TestProviderDevMountedUIHandlerUsesMountedAuthRuntime(t *testing.T) {
 		Name:       "roadmap",
 		Path:       "/roadmap",
 		PluginName: "roadmap",
+		Public:     true,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte("remote fallback"))
 		}),
@@ -292,6 +294,7 @@ func TestProviderDevMountedUIHandlerUsesAnonymousForNoAuthMountedUI(t *testing.T
 		Name:       "roadmap",
 		Path:       "/roadmap",
 		PluginName: "roadmap",
+		Public:     true,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte("remote fallback"))
 		}),

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -91,9 +91,7 @@ func (s *Server) mountAdminUIRoutes(r chi.Router) {
 func (s *Server) mountAdminAPIRoutes(r chi.Router) {
 	r.Route("/admin/api/v1", func(r chi.Router) {
 		r.Use(middleware.Timeout(60 * time.Second))
-		if s.adminRoute.AuthorizationPolicy != "" {
-			r.Use(s.adminAPIAuthMiddleware)
-		}
+		r.Use(s.adminAPIAuthMiddleware)
 		s.mountAdminRuntimeRoutes(r)
 		s.mountAdminAuthorizationRoutes(r)
 	})

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"slices"
 	"strings"
@@ -66,6 +67,11 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 	}
 
 	managementAddr := cfg.Server.ManagementAddr()
+	if cfg.Server.Admin.AuthorizationPolicy == "" && cfg.Server.Admin.AllowUnauthenticated {
+		if !adminUnauthenticatedRouteHostIsLoopback(cfg.Server) {
+			return fmt.Errorf("server.admin.allowUnauthenticated requires admin routes to be served on a loopback listener")
+		}
+	}
 	mcpSlot := &switchableHandler{}
 	workflowProvidersReady := make(chan struct{})
 	baseConfig := Config{
@@ -102,8 +108,9 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		ProviderDevAttach:     cfg.Server.Dev.AttachmentState != "",
 		PublicHostServices:    result.PublicHostServices,
 		Admin: AdminRouteConfig{
-			AuthorizationPolicy: cfg.Server.Admin.AuthorizationPolicy,
-			AllowedRoles:        append([]string(nil), cfg.Server.Admin.AllowedRoles...),
+			AuthorizationPolicy:  cfg.Server.Admin.AuthorizationPolicy,
+			AllowedRoles:         append([]string(nil), cfg.Server.Admin.AllowedRoles...),
+			AllowUnauthenticated: cfg.Server.Admin.AllowUnauthenticated,
 		},
 		AdminUIProvider: strings.TrimSpace(cfg.Server.Admin.UI),
 	}
@@ -253,6 +260,22 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 	case <-ctx.Done():
 		return nil
 	}
+}
+
+func adminManagementHostIsLoopback(host string) bool {
+	host = strings.TrimSpace(host)
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func adminUnauthenticatedRouteHostIsLoopback(cfg config.ServerConfig) bool {
+	if management, ok := cfg.ManagementListener(); ok {
+		return adminManagementHostIsLoopback(management.Host)
+	}
+	return adminManagementHostIsLoopback(cfg.PublicListener().Host)
 }
 
 func newMCPHandler(cfg *config.Config, connMaps bootstrap.ConnectionMaps, result *bootstrap.Result, invoker invocation.Invoker) (http.Handler, error) {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -52,6 +52,7 @@ type MountedUI struct {
 	Path                string
 	PluginName          string
 	AuthorizationPolicy string
+	Public              bool
 	Routes              []MountedUIRoute
 	Handler             http.Handler
 	builtInAdmin        bool
@@ -71,8 +72,9 @@ type MountedHTTPBinding struct {
 }
 
 type AdminRouteConfig struct {
-	AuthorizationPolicy string
-	AllowedRoles        []string
+	AuthorizationPolicy  string
+	AllowedRoles         []string
+	AllowUnauthenticated bool
 }
 
 type BuiltinAdminUIOptions struct {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -117,9 +117,22 @@ func newTestHandler(t *testing.T, opts ...func(*server.Config)) http.Handler {
 			return &reg.Providers
 		}(),
 		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+		Admin: server.AdminRouteConfig{
+			AllowUnauthenticated: true,
+		},
 	}
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+	for i := range cfg.MountedUIs {
+		if cfg.MountedUIs[i].AuthorizationPolicy == "" {
+			cfg.MountedUIs[i].Public = true
+		}
+	}
+	for _, entry := range cfg.ProviderUIs {
+		if entry != nil && entry.AuthorizationPolicy == "" {
+			entry.Public = true
+		}
 	}
 	brokerOpts := []invocation.BrokerOption{}
 	if cfg.DefaultConnection != nil {
@@ -2558,6 +2571,33 @@ func TestNewServerRequiresExternalCredentialsProvider(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "external credentials provider is required") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAdminAPIFailsClosedWithoutAuthorizationPolicy(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	reg := registry.New()
+	s, err := server.New(server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Services:    svc,
+		Providers:   &reg.Providers,
+		Invoker:     invocation.NewBroker(&reg.Providers, svc.Users, svc.ExternalCredentials),
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/api/v1/authorization/plugins", nil)
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d body=%s, want 500", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "admin authorization is not configured") {
+		t.Fatalf("body = %q, want admin authorization error", rec.Body.String())
 	}
 }
 
@@ -6591,6 +6631,29 @@ func TestMountedUIRoutesHiddenOnManagementProfile(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestMountedUIRequiresPolicyOrExplicitPublic(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	reg := registry.New()
+	_, err := server.New(server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Services:    svc,
+		Providers:   &reg.Providers,
+		Invoker:     invocation.NewBroker(&reg.Providers, svc.Users, svc.ExternalCredentials),
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+		Admin:       server.AdminRouteConfig{AllowUnauthenticated: true},
+		MountedUIs: []server.MountedUI{{
+			Name:    "sample_portal",
+			Path:    "/sample-portal",
+			Handler: http.NotFoundHandler(),
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "AuthorizationPolicy or Public is required") {
+		t.Fatalf("server.New error = %v, want mounted ui auth/public requirement", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add explicit `public: true` mounted-UI config and `server.admin.allowUnauthenticated` for intentionally unauthenticated local/admin surfaces.
- Fail closed when admin API/UI or mounted UIs have neither an authorization policy nor an explicit public opt-in.
- Move generated default config to split loopback management for unauthenticated admin access, and keep provider-dev local admin/UI flows explicit.

## Security impact

This addresses the fail-open admin API/default-config and mounted UI findings by making empty authorization policy no longer mean unauthenticated access by default. Default generated configs keep local admin usability by serving admin on `127.0.0.1:8081` with an explicit unauthenticated-management opt-in.

## Validation

- `go test ./internal/daemon -run 'TestE2EProviderDevServesSourceUI|TestE2ELockSyncPluginOwnedUI|TestE2EServeSplitManagementRoutes|TestE2EServePluginOwnedUIWiring|TestE2EProviderDevAutoMountsOwnedUI|TestE2EProviderDevAutoMountsSiblingUIForPlugin|TestE2EProviderDevServesAdminWithoutInjectingRootUI'`
- `go test ./internal/config ./internal/server ./internal/operator ./internal/bootstrap ./internal/daemon`
- `go test ./...` from `gestaltd/` after rebasing onto `origin/main`
