### PR TITLE
gestaltd: route core host service relays without registry fallback

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -225,6 +225,7 @@ type Result struct {
 	Authorizer            authorization.RuntimeAuthorizer
 	ConnectionAuth        func() map[string]map[string]OAuthHandler
 	Invoker               invocation.Invoker
+	PluginInvoker         invocation.Invoker
 	CapabilityLister      invocation.CapabilityLister
 	AuditSink             core.AuditSink
 	SecretManager         core.SecretManager
@@ -1124,6 +1125,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Authorizer:            authz,
 		ConnectionAuth:        connAuthResolver,
 		Invoker:               sharedInvoker,
+		PluginInvoker:         pluginInvoker,
 		CapabilityLister:      sharedInvoker,
 		AuditSink:             audit,
 		SecretManager:         prepared.SecretManager,

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -3840,11 +3840,6 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
-	relaySrv.EnableHTTP2 = true
-	relaySrv.StartTLS()
-	testutil.CloseOnCleanup(t, relaySrv)
-
 	bin := buildEchoPluginBinary(t)
 	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
 		Name: "echoext",
@@ -3901,6 +3896,21 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 			}},
 		},
 	})
+	agentManagerTokens, err := agentservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager(agent manager): %v", err)
+	}
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(
+		t,
+		secret,
+		publicHostServices,
+		withRuntimeRelayCoreHostService("agent_manager", agentservice.DefaultManagerSocketEnv, "/"+proto.AgentManagerHost_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
+			proto.RegisterAgentManagerHostServer(srv, agentservice.NewManagerServer("echoext", manager, agentManagerTokens))
+		}),
+	))
+	relaySrv.EnableHTTP2 = true
+	relaySrv.StartTLS()
+	testutil.CloseOnCleanup(t, relaySrv)
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
@@ -3951,6 +3961,7 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	defer func() { _ = CloseProviders(providers) }()
+	assertPublicHostServicesExclude(t, publicHostServices, "agent_manager", agentservice.DefaultManagerSocketEnv)
 
 	prov, err := providers.Get("echoext")
 	if err != nil {
@@ -6834,10 +6845,6 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
-	relaySrv.EnableHTTP2 = true
-	relaySrv.StartTLS()
-	testutil.CloseOnCleanup(t, relaySrv)
 
 	callerBin := buildEchoPluginBinary(t)
 	callerRoot := writeStaticCatalog(t, &catalog.Catalog{
@@ -6872,6 +6879,25 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	}
 
 	bridge := newLazyInvoker()
+	callerInvokes := []config.PluginInvocationDependency{
+		{Plugin: "example", Operation: "request_context"},
+	}
+	pluginInvokerTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager(plugin invoker): %v", err)
+	}
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(
+		t,
+		secret,
+		publicHostServices,
+		withRuntimeRelayCoreHostService("plugin_invoker", plugininvokerservice.DefaultSocketEnv, "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
+			proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("caller", callerInvokes, bridge, pluginInvokerTokens))
+		}),
+	))
+	relaySrv.EnableHTTP2 = true
+	relaySrv.StartTLS()
+	testutil.CloseOnCleanup(t, relaySrv)
+
 	cfg := &config.Config{
 		Server: config.ServerConfig{
 			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
@@ -6888,9 +6914,7 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 				ResolvedManifest:     callerManifest,
 				ResolvedManifestPath: filepath.Join(callerRoot, "manifest.yaml"),
 				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
-				Invokes: []config.PluginInvocationDependency{
-					{Plugin: "example", Operation: "request_context"},
-				},
+				Invokes:              callerInvokes,
 			},
 			"example": {
 				Command:              exampleBin,
@@ -6919,6 +6943,7 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	t.Cleanup(func() { _ = CloseProviders(providers) })
+	assertPublicHostServicesExclude(t, publicHostServices, "plugin_invoker", plugininvokerservice.DefaultSocketEnv)
 
 	services, err := coredata.New(&coretesting.StubIndexedDB{})
 	if err != nil {
@@ -7298,12 +7323,62 @@ func TestPluginRuntimeConfigInjectsRuntimeLogSessionAndHostService(t *testing.T)
 	t.Fatalf("BindHostService requests missing %s: %#v", runtimehost.DefaultRuntimeLogHostSocketEnv, bindRequests)
 }
 
-func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServices *runtimehost.PublicHostServiceRegistry) http.Handler {
+type runtimeRelayTestHandlerOption func(*runtimeRelayTestHandlerConfig)
+
+type runtimeRelayTestHandlerConfig struct {
+	coreHandlers map[runtimeRelayTestCoreHandlerKey]http.Handler
+}
+
+type runtimeRelayTestCoreHandlerKey struct {
+	service      string
+	envVar       string
+	methodPrefix string
+}
+
+func withRuntimeRelayCoreHostService(service, envVar, methodPrefix string, register func(*grpc.Server)) runtimeRelayTestHandlerOption {
+	return func(cfg *runtimeRelayTestHandlerConfig) {
+		if cfg.coreHandlers == nil {
+			cfg.coreHandlers = make(map[runtimeRelayTestCoreHandlerKey]http.Handler)
+		}
+		srv := grpc.NewServer()
+		register(srv)
+		cfg.coreHandlers[runtimeRelayTestCoreHandlerKey{
+			service:      strings.TrimSpace(service),
+			envVar:       strings.TrimSpace(envVar),
+			methodPrefix: strings.TrimSpace(methodPrefix),
+		}] = http.HandlerFunc(srv.ServeHTTP)
+	}
+}
+
+func assertPublicHostServicesExclude(t *testing.T, registry *runtimehost.PublicHostServiceRegistry, serviceName, envVar string) {
+	t.Helper()
+
+	if registry == nil {
+		return
+	}
+	for _, service := range registry.Services() {
+		if strings.TrimSpace(service.Service.Name) != strings.TrimSpace(serviceName) {
+			continue
+		}
+		if strings.TrimSpace(service.Service.EnvVar) != strings.TrimSpace(envVar) {
+			continue
+		}
+		t.Fatalf("public host services = %#v, want no %s/%s registry entry", registry.Services(), serviceName, envVar)
+	}
+}
+
+func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServices *runtimehost.PublicHostServiceRegistry, opts ...runtimeRelayTestHandlerOption) http.Handler {
 	t.Helper()
 
 	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(stateSecret)
 	if err != nil {
 		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	var cfg runtimeRelayTestHandlerConfig
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := strings.TrimSpace(r.Header.Get(runtimehost.HostServiceRelayTokenHeader))
@@ -7316,10 +7391,19 @@ func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServ
 			writeRuntimeRelayGRPCTrailersOnly(w, codes.PermissionDenied, "host-service-relay-method-not-allowed")
 			return
 		}
-		handler, err := runtimeRelayPublicHostServiceHandler(r.Context(), publicHostServices, target)
-		if err != nil {
-			writeRuntimeRelayGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-session")
-			return
+		var handler http.Handler
+		if target.CoreRoutable {
+			handler = cfg.coreHandlers[runtimeRelayTestCoreHandlerKey{
+				service:      strings.TrimSpace(target.Service),
+				envVar:       strings.TrimSpace(target.EnvVar),
+				methodPrefix: strings.TrimSpace(target.MethodPrefix),
+			}]
+		} else {
+			handler, err = runtimeRelayPublicHostServiceHandler(r.Context(), publicHostServices, target)
+			if err != nil {
+				writeRuntimeRelayGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-session")
+				return
+			}
 		}
 		if handler == nil {
 			writeRuntimeRelayGRPCTrailersOnly(w, codes.Unavailable, "host-service-relay-unavailable")
@@ -7564,10 +7648,6 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
-	relaySrv.EnableHTTP2 = true
-	relaySrv.StartTLS()
-	testutil.CloseOnCleanup(t, relaySrv)
 
 	bin := buildEchoPluginBinary(t)
 	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
@@ -7607,6 +7687,22 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 	}
 
 	manager := newStubWorkflowManager()
+	workflowManagerTokens, err := workflowservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager(workflow manager): %v", err)
+	}
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(
+		t,
+		secret,
+		publicHostServices,
+		withRuntimeRelayCoreHostService("workflow_manager", workflowservice.DefaultManagerSocketEnv, "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
+			proto.RegisterWorkflowManagerHostServer(srv, workflowservice.NewManagerServer("echoext", manager, workflowManagerTokens))
+		}),
+	))
+	relaySrv.EnableHTTP2 = true
+	relaySrv.StartTLS()
+	testutil.CloseOnCleanup(t, relaySrv)
+
 	deps := Deps{
 		BaseURL:            relaySrv.URL,
 		EncryptionKey:      secret,
@@ -7620,6 +7716,7 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	t.Cleanup(func() { _ = CloseProviders(providers) })
+	assertPublicHostServicesExclude(t, publicHostServices, "workflow_manager", workflowservice.DefaultManagerSocketEnv)
 
 	prov, err := providers.Get("echoext")
 	if err != nil {

--- a/gestaltd/internal/bootstrap/plugin_runtime.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -46,6 +47,53 @@ func (r *pluginRuntimeRegistry) Resolve(ctx context.Context, configPath string, 
 
 	provider, err := r.resolveConfigured(ctx, effective)
 	return effective, provider, err
+}
+
+func (r *pluginRuntimeRegistry) VerifyPluginRuntimeSession(ctx context.Context, providerName, sessionID string) error {
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return fmt.Errorf("runtime provider owner is required")
+	}
+	if r == nil || r.cfg == nil {
+		return fmt.Errorf("plugin runtime registry is not configured")
+	}
+
+	effective, err := r.effectiveHostedRuntimeForProvider(providerName)
+	if err != nil {
+		return err
+	}
+	if !effective.Enabled || strings.TrimSpace(effective.ProviderName) == "" {
+		return fmt.Errorf("provider %q does not use a hosted runtime", providerName)
+	}
+
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return fmt.Errorf("plugin runtime registry is closed")
+	}
+	runtimeProvider := r.providers[effective.ProviderName]
+	r.mu.Unlock()
+	if runtimeProvider == nil {
+		return fmt.Errorf("runtime provider %q is not loaded", effective.ProviderName)
+	}
+
+	return runtimeHostServiceSessionVerifier{
+		providerName: providerName,
+		provider:     runtimeProvider,
+	}.VerifyHostServiceSession(ctx, sessionID)
+}
+
+func (r *pluginRuntimeRegistry) effectiveHostedRuntimeForProvider(providerName string) (config.EffectiveHostedRuntime, error) {
+	if r == nil || r.cfg == nil {
+		return config.EffectiveHostedRuntime{}, fmt.Errorf("plugin runtime registry is not configured")
+	}
+	if entry := r.cfg.Plugins[providerName]; entry != nil {
+		return r.cfg.EffectiveHostedRuntime("plugins."+providerName, entry)
+	}
+	if entry := r.cfg.Providers.Agent[providerName]; entry != nil {
+		return r.cfg.EffectiveHostedRuntime("providers.agent."+providerName, entry)
+	}
+	return config.EffectiveHostedRuntime{}, fmt.Errorf("provider %q does not have a hosted runtime configuration", providerName)
 }
 
 func (r *pluginRuntimeRegistry) resolveConfigured(ctx context.Context, effective config.EffectiveHostedRuntime) (pluginruntime.Provider, error) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -895,13 +895,14 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		return nil, err
 	}
 	hostServices = appendRuntimeLogHostService(hostServices, runtimeConfig, deps, runtimePlan)
+	startHostServices, relayOnlyHostServices := splitRelayOnlyCoreHostServices(hostServices, runtimePlan)
 	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps, runtimePlan, runtimeProvider)
 	if err != nil {
 		return nil, err
 	}
 	cleanup = chainCleanup(cleanup, runtimeCleanup, publicHostServicesCleanup)
 	startedHostServices, err := runtimehost.StartHostServices(
-		hostServices,
+		startHostServices,
 		runtimehost.WithHostServicesProviderName(name),
 		runtimehost.WithHostServicesTelemetry(deps.Telemetry),
 	)
@@ -916,7 +917,8 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	startEnv := maps.Clone(env)
 	startEnv = withRuntimeSessionEnv(startEnv, sessionID)
 	allowedHosts := entry.EffectiveAllowedHosts()
-	for _, hostService := range startedHostServices.Bindings() {
+	bindingTargets := append(hostServiceBindingDescriptorsFromStarted(startedHostServices), hostServiceBindingDescriptorsFromConfigured(relayOnlyHostServices)...)
+	for _, hostService := range bindingTargets {
 		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect, true)
 		if err != nil {
 			return nil, err
@@ -1176,9 +1178,10 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	}
 	recordHostedAgentRuntimeStartPhase(ctx, name, "runtime_session_ready", phaseStarted, nil)
 
+	startHostServices, relayOnlyHostServices := splitRelayOnlyCoreHostServices(hostServices, runtimePlan)
 	phaseStarted = time.Now()
 	startedHostServices, err := runtimehost.StartHostServices(
-		hostServices,
+		startHostServices,
 		runtimehost.WithHostServicesProviderName(name),
 		runtimehost.WithHostServicesTelemetry(deps.Telemetry),
 	)
@@ -1197,7 +1200,8 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	}
 	allowedHosts := hostedAgentAllowedHosts(agentAllowedHosts, runtimePlan)
 	phaseStarted = time.Now()
-	for _, hostService := range startedHostServices.Bindings() {
+	bindingTargets := append(hostServiceBindingDescriptorsFromStarted(startedHostServices), hostServiceBindingDescriptorsFromConfigured(relayOnlyHostServices)...)
+	for _, hostService := range bindingTargets {
 		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect, true)
 		if err != nil {
 			recordHostedAgentRuntimeStartPhase(ctx, name, "host_services_bind", phaseStarted, err)
@@ -1625,7 +1629,51 @@ func withRuntimeSessionEnv(env map[string]string, sessionID string) map[string]s
 	return env
 }
 
-func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostService runtimehost.StartedHostService, deps Deps, allowUnixRelay bool, allowCoreRoutable bool) (pluginruntime.BindHostServiceRequest, map[string]string, string, error) {
+type hostServiceBindingDescriptor struct {
+	Name       string
+	EnvVar     string
+	SocketPath string
+}
+
+func hostServiceBindingDescriptorFromStarted(hostService runtimehost.StartedHostService) hostServiceBindingDescriptor {
+	return hostServiceBindingDescriptor{
+		Name:       strings.TrimSpace(hostService.Name),
+		EnvVar:     strings.TrimSpace(hostService.EnvVar),
+		SocketPath: strings.TrimSpace(hostService.SocketPath),
+	}
+}
+
+func hostServiceBindingDescriptorFromConfigured(hostService runtimehost.HostService) hostServiceBindingDescriptor {
+	return hostServiceBindingDescriptor{
+		Name:   strings.TrimSpace(hostService.Name),
+		EnvVar: strings.TrimSpace(hostService.EnvVar),
+	}
+}
+
+func hostServiceBindingDescriptorsFromStarted(hostServices *runtimehost.StartedHostServices) []hostServiceBindingDescriptor {
+	started := hostServices.Bindings()
+	if len(started) == 0 {
+		return nil
+	}
+	out := make([]hostServiceBindingDescriptor, 0, len(started))
+	for _, hostService := range started {
+		out = append(out, hostServiceBindingDescriptorFromStarted(hostService))
+	}
+	return out
+}
+
+func hostServiceBindingDescriptorsFromConfigured(hostServices []runtimehost.HostService) []hostServiceBindingDescriptor {
+	if len(hostServices) == 0 {
+		return nil
+	}
+	out := make([]hostServiceBindingDescriptor, 0, len(hostServices))
+	for _, hostService := range hostServices {
+		out = append(out, hostServiceBindingDescriptorFromConfigured(hostService))
+	}
+	return out
+}
+
+func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostService hostServiceBindingDescriptor, deps Deps, allowUnixRelay bool, allowCoreRoutable bool) (pluginruntime.BindHostServiceRequest, map[string]string, string, error) {
 	if !allowUnixRelay {
 		var (
 			serviceKey   string
@@ -1680,7 +1728,7 @@ func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostSe
 			serviceKey,
 			serviceLabel,
 			methodPrefix,
-			allowCoreRoutable && coreRoutableHostedRuntimeService(serviceKey),
+			allowCoreRoutable && isCoreRoutableHostedRuntimeHostService(hostService, serviceKey, methodPrefix),
 		)
 		if err != nil {
 			return pluginruntime.BindHostServiceRequest{}, nil, "", err
@@ -1746,7 +1794,11 @@ func registerPublicRuntimeHostServices(providerName string, hostServices []runti
 	if runtimePlan.Resolved.HostServiceAccess != RuntimeHostServiceAccessRelay || deps.PublicHostServices == nil {
 		return nil, nil
 	}
-	for _, hostService := range hostServices {
+	registerHostServices, _ := splitRelayOnlyCoreHostServices(hostServices, runtimePlan)
+	if len(registerHostServices) == 0 {
+		return nil, nil
+	}
+	for _, hostService := range registerHostServices {
 		if strings.TrimSpace(hostService.Name) == "" {
 			return nil, fmt.Errorf("host service %q requires a service name for public relay", hostService.EnvVar)
 		}
@@ -1754,9 +1806,9 @@ func registerPublicRuntimeHostServices(providerName string, hostServices []runti
 	deps.PublicHostServices.RegisterVerified(providerName, runtimeHostServiceSessionVerifier{
 		providerName: providerName,
 		provider:     runtimeProvider,
-	}, hostServices...)
+	}, registerHostServices...)
 	return func() {
-		deps.PublicHostServices.Unregister(providerName, hostServices...)
+		deps.PublicHostServices.Unregister(providerName, registerHostServices...)
 	}, nil
 }
 
@@ -1790,16 +1842,57 @@ func buildHostedRuntimePublicEgressProxy(providerName, sessionID string, allowed
 	}, nil
 }
 
-func coreRoutableHostedRuntimeService(serviceKey string) bool {
+func isCoreRoutableHostedRuntimeHostService(hostService hostServiceBindingDescriptor, serviceKey, methodPrefix string) bool {
+	methodPrefix = strings.TrimSpace(methodPrefix)
 	switch serviceKey {
-	case "workflow_manager", "agent_manager", "plugin_invoker":
-		return true
+	case "workflow_manager":
+		return hostService.Name == "workflow_manager" &&
+			hostService.EnvVar == workflowservice.DefaultManagerSocketEnv &&
+			methodPrefix == "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/"
+	case "agent_manager":
+		return hostService.Name == "agent_manager" &&
+			hostService.EnvVar == agentservice.DefaultManagerSocketEnv &&
+			methodPrefix == "/"+proto.AgentManagerHost_ServiceDesc.ServiceName+"/"
+	case "plugin_invoker":
+		return hostService.Name == "plugin_invoker" &&
+			hostService.EnvVar == plugininvokerservice.DefaultSocketEnv &&
+			methodPrefix == "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/"
 	default:
 		return false
 	}
 }
 
-func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, hostService runtimehost.StartedHostService, deps Deps, serviceKey, serviceLabel, methodPrefix string, coreRoutable bool) (pluginruntime.HostServiceRelay, map[string]string, string, bool, error) {
+func splitRelayOnlyCoreHostServices(hostServices []runtimehost.HostService, runtimePlan HostedRuntimePlan) ([]runtimehost.HostService, []runtimehost.HostService) {
+	if len(hostServices) == 0 || runtimePlan.Resolved.HostServiceAccess != RuntimeHostServiceAccessRelay {
+		return hostServices, nil
+	}
+	startHostServices := make([]runtimehost.HostService, 0, len(hostServices))
+	relayOnlyHostServices := make([]runtimehost.HostService, 0, 3)
+	for _, hostService := range hostServices {
+		if isRelayOnlyCoreHostService(hostService) {
+			relayOnlyHostServices = append(relayOnlyHostServices, hostService)
+			continue
+		}
+		startHostServices = append(startHostServices, hostService)
+	}
+	return startHostServices, relayOnlyHostServices
+}
+
+func isRelayOnlyCoreHostService(hostService runtimehost.HostService) bool {
+	desc := hostServiceBindingDescriptorFromConfigured(hostService)
+	switch desc.EnvVar {
+	case workflowservice.DefaultManagerSocketEnv:
+		return isCoreRoutableHostedRuntimeHostService(desc, "workflow_manager", "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/")
+	case agentservice.DefaultManagerSocketEnv:
+		return isCoreRoutableHostedRuntimeHostService(desc, "agent_manager", "/"+proto.AgentManagerHost_ServiceDesc.ServiceName+"/")
+	case plugininvokerservice.DefaultSocketEnv:
+		return isCoreRoutableHostedRuntimeHostService(desc, "plugin_invoker", "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/")
+	default:
+		return false
+	}
+}
+
+func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, hostService hostServiceBindingDescriptor, deps Deps, serviceKey, serviceLabel, methodPrefix string, coreRoutable bool) (pluginruntime.HostServiceRelay, map[string]string, string, bool, error) {
 	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
 		return pluginruntime.HostServiceRelay{}, nil, "", false, nil
 	}

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -181,10 +181,7 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 	env := withRuntimeSessionEnv(map[string]string{}, sessionID)
 	if sharedAttachmentState {
 		for _, hostService := range hostServices {
-			bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, runtimehost.StartedHostService{
-				Name:   hostService.Name,
-				EnvVar: hostService.EnvVar,
-			}, deps, false, false)
+			bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostServiceBindingDescriptorFromConfigured(hostService), deps, false, false)
 			if err != nil {
 				return providerdev.RuntimeEnv{}, err
 			}
@@ -227,7 +224,7 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 		})
 	}
 	for _, hostService := range startedHostServices.Bindings() {
-		bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, false, false)
+		bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostServiceBindingDescriptorFromStarted(hostService), deps, false, false)
 		if err != nil {
 			return providerdev.RuntimeEnv{}, err
 		}

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -27,24 +27,23 @@ type hostServiceHandlerEntry struct {
 	verifier runtimehost.PublicHostServiceSessionVerifier
 }
 
-func newPublicHostServiceHandlers(services []runtimehost.PublicHostService) (map[hostServiceHandlerKey][]hostServiceHandlerEntry, error) {
-	if len(services) == 0 {
-		return nil, nil
-	}
-	handlers := make(map[hostServiceHandlerKey][]hostServiceHandlerEntry, len(services))
+type pluginRuntimeSessionVerifier interface {
+	VerifyPluginRuntimeSession(context.Context, string, string) error
+}
+
+func validatePublicHostServices(services []runtimehost.PublicHostService) error {
+	handlers := make(map[hostServiceHandlerKey][]hostServiceHandlerEntry)
 	for _, service := range services {
-		key, entry, ok := newPublicHostServiceHandlerEntry(service)
+		key, ok := publicHostServiceHandlerKey(service)
 		if !ok {
 			continue
 		}
+		entry := hostServiceHandlerEntry{verifier: service.SessionVerifier}
 		if err := appendHostServiceHandlerEntry(handlers, key, entry); err != nil {
-			return nil, err
+			return err
 		}
 	}
-	if len(handlers) == 0 {
-		return nil, nil
-	}
-	return handlers, nil
+	return nil
 }
 
 func appendHostServiceHandlerEntry(handlers map[hostServiceHandlerKey][]hostServiceHandlerEntry, key hostServiceHandlerKey, entry hostServiceHandlerEntry) error {
@@ -68,7 +67,7 @@ func checkHostServiceHandlerDuplicate(key hostServiceHandlerKey, entries []hostS
 	return nil
 }
 
-func newPublicHostServiceHandlerEntry(service runtimehost.PublicHostService) (hostServiceHandlerKey, hostServiceHandlerEntry, bool) {
+func publicHostServiceHandlerKey(service runtimehost.PublicHostService) (hostServiceHandlerKey, bool) {
 	key := hostServiceHandlerKey{
 		pluginName: strings.TrimSpace(service.PluginName),
 		sessionID:  strings.TrimSpace(service.SessionID),
@@ -76,14 +75,9 @@ func newPublicHostServiceHandlerEntry(service runtimehost.PublicHostService) (ho
 		envVar:     strings.TrimSpace(service.Service.EnvVar),
 	}
 	if key.pluginName == "" || key.service == "" || key.envVar == "" || service.Service.Register == nil {
-		return hostServiceHandlerKey{}, hostServiceHandlerEntry{}, false
+		return hostServiceHandlerKey{}, false
 	}
-	srv := grpc.NewServer()
-	service.Service.Register(srv)
-	return key, hostServiceHandlerEntry{
-		handler:  http.HandlerFunc(srv.ServeHTTP),
-		verifier: service.SessionVerifier,
-	}, true
+	return key, true
 }
 
 func (k hostServiceHandlerKey) String() string {
@@ -98,6 +92,17 @@ func (s *Server) hostServiceHandler(ctx context.Context, target runtimehost.Host
 	if s == nil {
 		return nil, nil
 	}
+	if target.CoreRoutable {
+		entry, ok, err := s.coreRoutableHostServiceHandlerEntry(ctx, target)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, nil
+		}
+		return entry.handler, nil
+	}
+
 	exactKey := hostServiceHandlerKey{
 		pluginName: strings.TrimSpace(target.PluginName),
 		sessionID:  strings.TrimSpace(target.SessionID),
@@ -107,19 +112,22 @@ func (s *Server) hostServiceHandler(ctx context.Context, target runtimehost.Host
 	providerKey := exactKey
 	providerKey.sessionID = ""
 
-	entry, ok, err := s.hostServiceHandlerEntry(ctx, exactKey, exactKey.sessionID)
-	exactErr := err
-	if !ok && exactKey.sessionID != "" {
-		entry, ok, err = s.hostServiceHandlerEntry(ctx, providerKey, exactKey.sessionID)
+	if exactKey.sessionID != "" {
+		entry, found, ok, err := s.hostServiceHandlerEntry(ctx, exactKey, exactKey.sessionID)
 		if err != nil {
 			return nil, err
 		}
+		if found {
+			if !ok {
+				return nil, nil
+			}
+			return entry.handler, nil
+		}
 	}
-	if !ok && exactErr != nil {
-		return nil, exactErr
-	}
-	if !ok {
-		entry, ok = s.coreRoutableHostServiceHandlerEntry(ctx, target)
+
+	entry, _, ok, err := s.hostServiceHandlerEntry(ctx, providerKey, exactKey.sessionID)
+	if err != nil {
+		return nil, err
 	}
 	if !ok {
 		return nil, nil
@@ -127,30 +135,33 @@ func (s *Server) hostServiceHandler(ctx context.Context, target runtimehost.Host
 	return entry.handler, nil
 }
 
-func (s *Server) coreRoutableHostServiceHandlerEntry(ctx context.Context, target runtimehost.HostServiceRelayTarget) (hostServiceHandlerEntry, bool) {
+func (s *Server) coreRoutableHostServiceHandlerEntry(ctx context.Context, target runtimehost.HostServiceRelayTarget) (hostServiceHandlerEntry, bool, error) {
 	if s == nil || !target.CoreRoutable || s.invocationTokens == nil {
-		return hostServiceHandlerEntry{}, false
+		return hostServiceHandlerEntry{}, false, nil
 	}
 	pluginName := strings.TrimSpace(target.PluginName)
 	if pluginName == "" {
-		return hostServiceHandlerEntry{}, false
+		return hostServiceHandlerEntry{}, false, nil
 	}
 	key, ok := coreRoutableHostServiceHandlerKey(pluginName, target)
 	if !ok {
-		return hostServiceHandlerEntry{}, false
+		return hostServiceHandlerEntry{}, false, nil
+	}
+	if err := s.verifyCoreRoutableHostServiceSession(ctx, pluginName, target.SessionID); err != nil {
+		return hostServiceHandlerEntry{}, false, err
 	}
 	s.hostServiceMu.Lock()
 	if s.coreHostServiceHandlers != nil {
 		if entry, ok := s.coreHostServiceHandlers[key]; ok {
 			s.hostServiceMu.Unlock()
-			return entry, true
+			return entry, true, nil
 		}
 	}
 	s.hostServiceMu.Unlock()
 
 	entry, ok := s.newCoreRoutableHostServiceHandlerEntry(ctx, pluginName, target)
 	if !ok {
-		return hostServiceHandlerEntry{}, false
+		return hostServiceHandlerEntry{}, false, nil
 	}
 	s.hostServiceMu.Lock()
 	if s.coreHostServiceHandlers == nil {
@@ -158,11 +169,19 @@ func (s *Server) coreRoutableHostServiceHandlerEntry(ctx context.Context, target
 	}
 	if existing, ok := s.coreHostServiceHandlers[key]; ok {
 		s.hostServiceMu.Unlock()
-		return existing, true
+		return existing, true, nil
 	}
 	s.coreHostServiceHandlers[key] = entry
 	s.hostServiceMu.Unlock()
-	return entry, true
+	return entry, true, nil
+}
+
+func (s *Server) verifyCoreRoutableHostServiceSession(ctx context.Context, pluginName, sessionID string) error {
+	verifier, ok := s.pluginRuntimes.(pluginRuntimeSessionVerifier)
+	if !ok || verifier == nil {
+		return fmt.Errorf("plugin runtime session verifier is not configured")
+	}
+	return verifier.VerifyPluginRuntimeSession(ctx, pluginName, sessionID)
 }
 
 func coreRoutableHostServiceHandlerKey(pluginName string, target runtimehost.HostServiceRelayTarget) (hostServiceHandlerKey, bool) {
@@ -217,7 +236,7 @@ func (s *Server) newCoreRoutableHostServiceHandlerEntry(ctx context.Context, plu
 	case target.Service == "plugin_invoker" &&
 		target.EnvVar == plugininvokerservice.DefaultSocketEnv &&
 		methodPrefix == "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/":
-		if s.invoker == nil || s.pluginDefs == nil {
+		if s.pluginInvoker == nil || s.pluginDefs == nil {
 			return hostServiceHandlerEntry{}, false
 		}
 		entry := s.pluginDefs[pluginName]
@@ -227,7 +246,7 @@ func (s *Server) newCoreRoutableHostServiceHandlerEntry(ctx context.Context, plu
 		slog.DebugContext(ctx, "serving core-routable host service relay", "plugin", pluginName, "service", target.Service)
 		return hostServiceHandlerEntry{
 			handler: newGRPCHostServiceHandler(func(srv *grpc.Server) {
-				proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewPluginInvokerServer(pluginName, entry.Invokes, s.invoker, s.invocationTokens))
+				proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewPluginInvokerServer(pluginName, entry.Invokes, s.pluginInvoker, s.invocationTokens))
 			}),
 		}, true
 	default:
@@ -241,65 +260,101 @@ func newGRPCHostServiceHandler(register func(*grpc.Server)) http.Handler {
 	return http.HandlerFunc(srv.ServeHTTP)
 }
 
-func (s *Server) hostServiceHandlerEntry(ctx context.Context, key hostServiceHandlerKey, sessionID string) (hostServiceHandlerEntry, bool, error) {
-	if key.pluginName == "" || key.service == "" || key.envVar == "" {
-		return hostServiceHandlerEntry{}, false, nil
+func (s *Server) hostServiceHandlerEntry(ctx context.Context, key hostServiceHandlerKey, sessionID string) (hostServiceHandlerEntry, bool, bool, error) {
+	if s == nil || key.pluginName == "" || key.service == "" || key.envVar == "" {
+		return hostServiceHandlerEntry{}, false, false, nil
 	}
 
-	for {
-		s.hostServiceMu.Lock()
-		s.refreshHostServiceHandlerCacheLocked()
-		if entries, ok := s.hostServiceHandlers[key]; ok {
-			s.hostServiceMu.Unlock()
-			return selectHostServiceHandlerEntry(ctx, key, sessionID, entries)
-		}
-		s.hostServiceMu.Unlock()
-
-		services, snapshotVersion := s.publicHostServices.Snapshot()
-		var entries []hostServiceHandlerEntry
-		for _, service := range services {
-			serviceKey := hostServiceHandlerKey{
-				pluginName: strings.TrimSpace(service.PluginName),
-				sessionID:  strings.TrimSpace(service.SessionID),
-				service:    strings.TrimSpace(service.Service.Name),
-				envVar:     strings.TrimSpace(service.Service.EnvVar),
-			}
-			if serviceKey != key || service.Service.Register == nil {
-				continue
-			}
-			entryKey, entry, ok := newPublicHostServiceHandlerEntry(service)
-			if !ok || entryKey != key {
-				continue
-			}
-			if err := checkHostServiceHandlerDuplicate(key, entries, entry); err != nil {
-				return hostServiceHandlerEntry{}, false, err
-			}
-			entries = append(entries, entry)
-		}
-		if len(entries) == 0 {
-			return hostServiceHandlerEntry{}, false, nil
-		}
-
-		s.hostServiceMu.Lock()
-		currentVersion := s.publicHostServices.Version()
-		if currentVersion != snapshotVersion {
-			s.hostServiceHandlers = nil
-			s.hostServiceVersion = currentVersion
-			s.hostServiceMu.Unlock()
+	var entries []hostServiceHandlerEntry
+	services := s.publicHostServices.Snapshot()
+	s.prunePublicHostServiceHandlerCache(services)
+	for _, service := range services {
+		serviceKey, ok := publicHostServiceHandlerKey(service)
+		if !ok || serviceKey != key {
 			continue
 		}
-		s.hostServiceVersion = snapshotVersion
-		if existing, ok := s.hostServiceHandlers[key]; ok {
-			s.hostServiceMu.Unlock()
-			return selectHostServiceHandlerEntry(ctx, key, sessionID, existing)
+		entry, ok := s.publicHostServiceHandlerEntry(service)
+		if !ok {
+			continue
 		}
-		if s.hostServiceHandlers == nil {
-			s.hostServiceHandlers = make(map[hostServiceHandlerKey][]hostServiceHandlerEntry)
+		if err := checkHostServiceHandlerDuplicate(key, entries, entry); err != nil {
+			return hostServiceHandlerEntry{}, true, false, err
 		}
-		s.hostServiceHandlers[key] = entries
-		s.hostServiceMu.Unlock()
-		return selectHostServiceHandlerEntry(ctx, key, sessionID, entries)
+		entries = append(entries, entry)
 	}
+	if len(entries) == 0 {
+		return hostServiceHandlerEntry{}, false, false, nil
+	}
+	entry, ok, err := selectHostServiceHandlerEntry(ctx, key, sessionID, entries)
+	return entry, true, ok, err
+}
+
+func (s *Server) publicHostServiceHandlerEntry(service runtimehost.PublicHostService) (hostServiceHandlerEntry, bool) {
+	_, ok := publicHostServiceHandlerKey(service)
+	if !ok {
+		return hostServiceHandlerEntry{}, false
+	}
+	return hostServiceHandlerEntry{
+		handler:  s.cachedPublicHostServiceHandler(service),
+		verifier: service.SessionVerifier,
+	}, true
+}
+
+func (s *Server) cachedPublicHostServiceHandler(service runtimehost.PublicHostService) http.Handler {
+	registrationID := service.RegistrationID()
+	if registrationID == 0 {
+		srv := grpc.NewServer()
+		service.Service.Register(srv)
+		return http.HandlerFunc(srv.ServeHTTP)
+	}
+
+	s.hostServiceMu.Lock()
+	if handler := s.hostServiceHandlers[registrationID]; handler != nil {
+		s.hostServiceMu.Unlock()
+		return handler
+	}
+	s.hostServiceMu.Unlock()
+
+	srv := grpc.NewServer()
+	service.Service.Register(srv)
+	handler := http.HandlerFunc(srv.ServeHTTP)
+
+	s.hostServiceMu.Lock()
+	if s.hostServiceHandlers == nil {
+		s.hostServiceHandlers = make(map[uint64]http.Handler)
+	}
+	if existing := s.hostServiceHandlers[registrationID]; existing != nil {
+		s.hostServiceMu.Unlock()
+		return existing
+	}
+	s.hostServiceHandlers[registrationID] = handler
+	s.hostServiceMu.Unlock()
+	return handler
+}
+
+func (s *Server) prunePublicHostServiceHandlerCache(services []runtimehost.PublicHostService) {
+	if s == nil {
+		return
+	}
+	if len(services) == 0 {
+		s.hostServiceMu.Lock()
+		clear(s.hostServiceHandlers)
+		s.hostServiceMu.Unlock()
+		return
+	}
+	active := make(map[uint64]struct{}, len(services))
+	for _, service := range services {
+		if id := service.RegistrationID(); id != 0 {
+			active[id] = struct{}{}
+		}
+	}
+	s.hostServiceMu.Lock()
+	for id := range s.hostServiceHandlers {
+		if _, ok := active[id]; !ok {
+			delete(s.hostServiceHandlers, id)
+		}
+	}
+	s.hostServiceMu.Unlock()
 }
 
 func selectHostServiceHandlerEntry(ctx context.Context, key hostServiceHandlerKey, sessionID string, entries []hostServiceHandlerEntry) (hostServiceHandlerEntry, bool, error) {
@@ -321,12 +376,4 @@ func selectHostServiceHandlerEntry(ctx context.Context, key hostServiceHandlerKe
 		return hostServiceHandlerEntry{}, false, lastErr
 	}
 	return hostServiceHandlerEntry{}, false, nil
-}
-
-func (s *Server) refreshHostServiceHandlerCacheLocked() {
-	version := s.publicHostServices.Version()
-	if version != s.hostServiceVersion {
-		s.hostServiceHandlers = nil
-		s.hostServiceVersion = version
-	}
 }

--- a/gestaltd/internal/server/host_service_public_test.go
+++ b/gestaltd/internal/server/host_service_public_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -11,32 +10,13 @@ import (
 	"google.golang.org/grpc"
 )
 
-func TestHostServiceHandlerFallsBackWhenExactVerifierRejects(t *testing.T) {
+func TestHostServiceHandlerDoesNotFallbackWhenExactSessionEntryFails(t *testing.T) {
 	t.Parallel()
 
-	exactKey := hostServiceHandlerKey{
-		pluginName: "support",
-		sessionID:  "session-1",
-		service:    "cache",
-		envVar:     "GESTALT_TEST_CACHE_SOCKET",
-	}
-	providerKey := exactKey
-	providerKey.sessionID = ""
-	exactHandler := markerHostServiceHandler("exact")
-	providerHandler := markerHostServiceHandler("provider")
-
-	s := &Server{
-		hostServiceHandlers: map[hostServiceHandlerKey][]hostServiceHandlerEntry{
-			exactKey: {{
-				handler:  exactHandler,
-				verifier: rejectHostServiceSessionVerifier{},
-			}},
-			providerKey: {{
-				handler:  providerHandler,
-				verifier: allowHostServiceSessionVerifier{},
-			}},
-		},
-	}
+	registry := runtimehost.NewPublicHostServiceRegistry()
+	registry.RegisterSession("support", "session-1", testHostService(), testHostService())
+	registry.RegisterVerified("support", allowHostServiceSessionVerifier{}, testHostService())
+	s := &Server{publicHostServices: registry}
 
 	handler, err := s.hostServiceHandler(context.Background(), runtimehost.HostServiceRelayTarget{
 		PluginName: "support",
@@ -44,43 +24,35 @@ func TestHostServiceHandlerFallsBackWhenExactVerifierRejects(t *testing.T) {
 		Service:    "cache",
 		EnvVar:     "GESTALT_TEST_CACHE_SOCKET",
 	})
-	if err != nil {
-		t.Fatalf("hostServiceHandler: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "duplicate public host service support/cache/GESTALT_TEST_CACHE_SOCKET/session=session-1") {
+		t.Fatalf("hostServiceHandler err = %v, want exact session duplicate failure", err)
 	}
-	if handler != providerHandler {
-		t.Fatalf("handler = %v, want provider-wide fallback", handler)
+	if handler != nil {
+		t.Fatalf("handler = %v, want no provider-wide fallback", handler)
 	}
 }
 
-func TestNewPublicHostServiceHandlersRejectsDuplicateUnverifiedServices(t *testing.T) {
+func TestValidatePublicHostServicesRejectsDuplicateUnverifiedServices(t *testing.T) {
 	t.Parallel()
 
-	_, err := newPublicHostServiceHandlers([]runtimehost.PublicHostService{
+	err := validatePublicHostServices([]runtimehost.PublicHostService{
 		testPublicHostService("support", nil),
 		testPublicHostService("support", nil),
 	})
 	if err == nil || !strings.Contains(err.Error(), "duplicate public host service support/cache/GESTALT_TEST_CACHE_SOCKET") {
-		t.Fatalf("newPublicHostServiceHandlers err = %v, want duplicate public host service", err)
+		t.Fatalf("validatePublicHostServices err = %v, want duplicate public host service", err)
 	}
 }
 
-func TestNewPublicHostServiceHandlersAllowsDuplicateVerifiedServices(t *testing.T) {
+func TestValidatePublicHostServicesAllowsDuplicateVerifiedServices(t *testing.T) {
 	t.Parallel()
 
-	handlers, err := newPublicHostServiceHandlers([]runtimehost.PublicHostService{
+	err := validatePublicHostServices([]runtimehost.PublicHostService{
 		testPublicHostService("support", allowHostServiceSessionVerifier{}),
 		testPublicHostService("support", rejectHostServiceSessionVerifier{}),
 	})
 	if err != nil {
-		t.Fatalf("newPublicHostServiceHandlers: %v", err)
-	}
-	key := hostServiceHandlerKey{
-		pluginName: "support",
-		service:    "cache",
-		envVar:     "GESTALT_TEST_CACHE_SOCKET",
-	}
-	if got := len(handlers[key]); got != 2 {
-		t.Fatalf("handlers[%s] = %d, want 2", key.String(), got)
+		t.Fatalf("validatePublicHostServices: %v", err)
 	}
 }
 
@@ -95,15 +67,11 @@ func TestHostServiceHandlerEntryRejectsDynamicDuplicateUnverifiedServices(t *tes
 		service:    "cache",
 		envVar:     "GESTALT_TEST_CACHE_SOCKET",
 	}
-	_, _, err := s.hostServiceHandlerEntry(context.Background(), key, "")
+	_, _, _, err := s.hostServiceHandlerEntry(context.Background(), key, "")
 	if err == nil || !strings.Contains(err.Error(), "duplicate public host service support/cache/GESTALT_TEST_CACHE_SOCKET") {
 		t.Fatalf("hostServiceHandlerEntry err = %v, want duplicate public host service", err)
 	}
 }
-
-type markerHostServiceHandler string
-
-func (h markerHostServiceHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
 
 func testPublicHostService(pluginName string, verifier runtimehost.PublicHostServiceSessionVerifier) runtimehost.PublicHostService {
 	return runtimehost.PublicHostService{

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -80,6 +80,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		Workflow:             result.WorkflowControl,
 		PluginRuntimes:       result.PluginRuntimes,
 		Invoker:              httpInvoker,
+		PluginInvoker:        result.PluginInvoker,
 		DefaultConnection:    connMaps.DefaultConnection,
 		// HTTP routes expose REST-visible operations, so unqualified session-catalog
 		// resolution should follow the API surface by default. The MCP server keeps

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -101,6 +101,7 @@ type Server struct {
 	resolver                *principal.Resolver
 	authResolvers           map[string]*principal.Resolver
 	invoker                 invocation.Invoker
+	pluginInvoker           invocation.Invoker
 	defaultConnection       map[string]string
 	catalogConnection       map[string]string
 	connectionAuth          func() map[string]map[string]bootstrap.OAuthHandler
@@ -123,9 +124,8 @@ type Server struct {
 	hostServiceRelayTokens  *runtimehost.HostServiceRelayTokenManager
 	invocationTokens        *plugininvokerservice.InvocationTokenManager
 	hostServiceMu           sync.Mutex
-	hostServiceHandlers     map[hostServiceHandlerKey][]hostServiceHandlerEntry
 	coreHostServiceHandlers map[hostServiceHandlerKey]hostServiceHandlerEntry
-	hostServiceVersion      uint64
+	hostServiceHandlers     map[uint64]http.Handler
 	publicHostServices      *runtimehost.PublicHostServiceRegistry
 	s3                      map[string]s3store.Client
 	s3ObjectAccessURLs      *s3.ObjectAccessURLManager
@@ -160,6 +160,7 @@ type Config struct {
 	Workflow              bootstrap.WorkflowControl
 	PluginRuntimes        bootstrap.RuntimeInspector
 	Invoker               invocation.Invoker
+	PluginInvoker         invocation.Invoker
 	DefaultConnection     map[string]string
 	CatalogConnection     map[string]string
 	ConnectionAuth        func() map[string]map[string]bootstrap.OAuthHandler
@@ -192,6 +193,10 @@ type Config struct {
 func New(cfg Config) (*Server, error) {
 	if cfg.Invoker == nil {
 		return nil, fmt.Errorf("invoker is required")
+	}
+	pluginInvoker := cfg.PluginInvoker
+	if pluginInvoker == nil {
+		pluginInvoker = cfg.Invoker
 	}
 	noAuth := cfg.Auth == nil || cfg.Auth.Name() == "none"
 	serverAuthProvider := strings.TrimSpace(cfg.SelectedAuthProvider)
@@ -317,9 +322,7 @@ func New(cfg Config) (*Server, error) {
 			return nil, fmt.Errorf("init s3 object access URLs: %w", err)
 		}
 	}
-	publicHostServices, hostServiceVersion := cfg.PublicHostServices.Snapshot()
-	hostServiceHandlers, err := newPublicHostServiceHandlers(publicHostServices)
-	if err != nil {
+	if err := validatePublicHostServices(cfg.PublicHostServices.Snapshot()); err != nil {
 		return nil, fmt.Errorf("init public host services: %w", err)
 	}
 	s := &Server{
@@ -342,6 +345,7 @@ func New(cfg Config) (*Server, error) {
 		resolver:               resolver,
 		authResolvers:          authResolvers,
 		invoker:                cfg.Invoker,
+		pluginInvoker:          pluginInvoker,
 		defaultConnection:      cfg.DefaultConnection,
 		catalogConnection:      cfg.CatalogConnection,
 		connectionAuth:         cfg.ConnectionAuth,
@@ -362,8 +366,6 @@ func New(cfg Config) (*Server, error) {
 		mcpHandler:             cfg.MCPHandler,
 		hostServiceRelayTokens: hostServiceRelayTokens,
 		invocationTokens:       invocationTokens,
-		hostServiceHandlers:    hostServiceHandlers,
-		hostServiceVersion:     hostServiceVersion,
 		publicHostServices:     cfg.PublicHostServices,
 		s3:                     cfg.S3,
 		s3ObjectAccessURLs:     s3ObjectAccessURLs,
@@ -386,6 +388,7 @@ func New(cfg Config) (*Server, error) {
 		Authorizer:        cfg.Authorizer,
 		DefaultConnection: cfg.DefaultConnection,
 		CatalogConnection: cfg.CatalogConnection,
+		PluginInvokes:     pluginInvokesFromProviderEntries(cfg.PluginDefs),
 		Now:               now,
 	})
 	if noAuth || hasAnonymousAuthProvider(authProviders) {
@@ -417,6 +420,23 @@ func hasAnonymousAuthProvider(providers map[string]core.AuthenticationProvider) 
 		}
 	}
 	return false
+}
+
+func pluginInvokesFromProviderEntries(entries map[string]*config.ProviderEntry) map[string][]config.PluginInvocationDependency {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make(map[string][]config.PluginInvocationDependency, len(entries))
+	for pluginName, entry := range entries {
+		if entry == nil || len(entry.Invokes) == 0 {
+			continue
+		}
+		out[pluginName] = append([]config.PluginInvocationDependency(nil), entry.Invokes...)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"github.com/valon-technologies/gestalt/server/internal/ui"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
 	"github.com/valon-technologies/gestalt/server/services/egressproxy"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
@@ -457,6 +458,7 @@ func (s *relayTestCacheServer) calls() int {
 
 type relayTestInvoker struct {
 	mu             sync.Mutex
+	calls          int
 	providerName   string
 	instance       string
 	operation      string
@@ -467,6 +469,7 @@ type relayTestInvoker struct {
 func (i *relayTestInvoker) Invoke(ctx context.Context, _ *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	i.calls++
 	i.providerName = providerName
 	i.instance = instance
 	i.operation = operation
@@ -476,6 +479,7 @@ func (i *relayTestInvoker) Invoke(ctx context.Context, _ *principal.Principal, p
 }
 
 type relayTestInvokerCall struct {
+	calls          int
 	providerName   string
 	instance       string
 	operation      string
@@ -487,6 +491,7 @@ func (i *relayTestInvoker) snapshot() relayTestInvokerCall {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	return relayTestInvokerCall{
+		calls:          i.calls,
 		providerName:   i.providerName,
 		instance:       i.instance,
 		operation:      i.operation,
@@ -567,6 +572,42 @@ func (v *relayTestSessionVerifier) setActive(sessionID string, active bool) {
 	v.active[sessionID] = active
 }
 
+type relayTestRuntimeSessionVerifier struct {
+	mu     sync.Mutex
+	active map[string]bool
+}
+
+func newRelayTestRuntimeSessionVerifier(providerName, sessionID string) *relayTestRuntimeSessionVerifier {
+	verifier := &relayTestRuntimeSessionVerifier{active: map[string]bool{}}
+	verifier.setActive(providerName, sessionID, true)
+	return verifier
+}
+
+func (v *relayTestRuntimeSessionVerifier) VerifyPluginRuntimeSession(_ context.Context, providerName, sessionID string) error {
+	key := strings.TrimSpace(providerName) + "\x00" + strings.TrimSpace(sessionID)
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.active[key] {
+		return nil
+	}
+	return fmt.Errorf("runtime session %q is not active", sessionID)
+}
+
+func (v *relayTestRuntimeSessionVerifier) setActive(providerName, sessionID string, active bool) {
+	key := strings.TrimSpace(providerName) + "\x00" + strings.TrimSpace(sessionID)
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.active[key] = active
+}
+
+func (v *relayTestRuntimeSessionVerifier) SnapshotPluginRuntimes(context.Context) ([]bootstrap.RuntimeProviderSnapshot, error) {
+	return nil, nil
+}
+
+func (v *relayTestRuntimeSessionVerifier) ListPluginRuntimeSessionLogs(context.Context, string, string, int64, int) ([]runtimelogs.Record, error) {
+	return nil, nil
+}
+
 func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	t.Parallel()
 
@@ -575,10 +616,12 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	const envVar = "GESTALT_TEST_CACHE_SOCKET"
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
 	sessionVerifier := newRelayTestSessionVerifier("session-1")
+	var registerCalls atomic.Int64
 	hostService := runtimehost.HostService{
 		Name:   "cache",
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
+			registerCalls.Add(1)
 			proto.RegisterCacheServer(srv, cacheSrv)
 		},
 	}
@@ -630,6 +673,16 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 		t.Fatalf("backend unexpectedly received relay token metadata: %#v", got)
 	}
 
+	secondCtx, secondCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer secondCancel()
+	secondCtx = metadata.NewOutgoingContext(secondCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
+	if _, err := proto.NewCacheClient(conn).Get(secondCtx, &proto.CacheGetRequest{Key: "again"}); err != nil {
+		t.Fatalf("second Cache.Get via relay: %v", err)
+	}
+	if got := registerCalls.Load(); got != 1 {
+		t.Fatalf("host service registrations = %d, want cached handler registered once", got)
+	}
+
 	sessionVerifier.setActive("session-1", false)
 	staleCtx, staleCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer staleCancel()
@@ -638,8 +691,8 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	if grpcstatus.Code(err) != codes.Unauthenticated {
 		t.Fatalf("Cache.Get stale session code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unauthenticated, err)
 	}
-	if got := cacheSrv.calls(); got != 1 {
-		t.Fatalf("backend calls = %d, want only the verified call", got)
+	if got := cacheSrv.calls(); got != 2 {
+		t.Fatalf("backend calls = %d, want only the verified calls", got)
 	}
 
 	sessionVerifier.setActive("session-1", true)
@@ -651,7 +704,7 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	if grpcstatus.Code(err) != codes.Unavailable {
 		t.Fatalf("Cache.Get unregistered provider code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
 	}
-	if got := cacheSrv.calls(); got != 1 {
+	if got := cacheSrv.calls(); got != 2 {
 		t.Fatalf("backend calls = %d, want no calls after unregister", got)
 	}
 }
@@ -786,20 +839,95 @@ func TestHostServiceRelayStopsServingUnregisteredSession(t *testing.T) {
 	}
 }
 
-func TestHostServiceRelayServesCoreRoutablePluginInvokerWithoutRegistry(t *testing.T) {
+func TestHostServiceRelayCoreRoutableTokenDoesNotUseNonCoreRegistry(t *testing.T) {
 	t.Parallel()
 
 	secret := []byte("relay-test-secret-0123456789abcd")
-	invoker := &relayTestInvoker{}
+	cacheSrv := &relayTestCacheServer{}
+	const envVar = "GESTALT_TEST_CACHE_SOCKET"
+	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
+	hostService := runtimehost.HostService{
+		Name:   "cache",
+		EnvVar: envVar,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterCacheServer(srv, cacheSrv)
+		},
+	}
+	publicHostServices.Register("support", hostService)
+
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+		cfg.PublicHostServices = publicHostServices
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-1",
+		Service:      "cache",
+		EnvVar:       envVar,
+		MethodPrefix: "/" + proto.Cache_ServiceDesc.ServiceName + "/",
+		CoreRoutable: true,
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
+	_, err = proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "core-routable-cache"})
+	if grpcstatus.Code(err) != codes.Unavailable {
+		t.Fatalf("Cache.Get core-routable non-core code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
+	}
+	if got := cacheSrv.calls(); got != 0 {
+		t.Fatalf("backend calls = %d, want 0", got)
+	}
+}
+
+func TestHostServiceRelayCoreRoutablePluginInvokerIgnoresRegistry(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	httpInvoker := &relayTestInvoker{}
+	pluginInvoker := &relayTestInvoker{}
+	registryInvoker := &relayTestInvoker{}
+	runtimeSessions := newRelayTestRuntimeSessionVerifier("support", "session-core")
 	invokes := []config.PluginInvocationDependency{{
 		Plugin:         "slack",
 		Operation:      "events.reply",
 		CredentialMode: providermanifestv1.ConnectionModeNone,
 	}}
+	registryTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager registry: %v", err)
+	}
+	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
+	publicHostServices.Register("support", runtimehost.HostService{
+		Name:   "plugin_invoker",
+		EnvVar: plugininvokerservice.DefaultSocketEnv,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("support", invokes, registryInvoker, registryTokens))
+		},
+	})
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfilePublic
 		cfg.StateSecret = secret
-		cfg.Invoker = invoker
+		cfg.Invoker = httpInvoker
+		cfg.PluginInvoker = pluginInvoker
+		cfg.PluginRuntimes = runtimeSessions
+		cfg.PublicHostServices = publicHostServices
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
 			"support": {Invokes: invokes},
 		}
@@ -814,7 +942,7 @@ func TestHostServiceRelayServesCoreRoutablePluginInvokerWithoutRegistry(t *testi
 	}
 	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
 		PluginName:   "support",
-		SessionID:    "session-elsewhere",
+		SessionID:    "session-core",
 		Service:      "plugin_invoker",
 		EnvVar:       plugininvokerservice.DefaultSocketEnv,
 		MethodPrefix: "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/",
@@ -862,7 +990,7 @@ func TestHostServiceRelayServesCoreRoutablePluginInvokerWithoutRegistry(t *testi
 	if resp.GetStatus() != 202 || resp.GetBody() != "relayed" {
 		t.Fatalf("PluginInvoker.Invoke response = %+v, want status=202 body=relayed", resp)
 	}
-	call := invoker.snapshot()
+	call := pluginInvoker.snapshot()
 	if call.providerName != "slack" || call.operation != "events.reply" || call.instance != "prod" {
 		t.Fatalf("invocation target = %s.%s/%s, want slack.events.reply/prod", call.providerName, call.operation, call.instance)
 	}
@@ -872,6 +1000,180 @@ func TestHostServiceRelayServesCoreRoutablePluginInvokerWithoutRegistry(t *testi
 	if call.params["channel_id"] != "C123" || call.params["thread_ts"] != "123.456" {
 		t.Fatalf("params = %#v, want Slack reply params", call.params)
 	}
+	if httpCall := httpInvoker.snapshot(); httpCall.providerName != "" {
+		t.Fatalf("http invoker was called for plugin relay: %+v", httpCall)
+	}
+	if registryCall := registryInvoker.snapshot(); registryCall.providerName != "" {
+		t.Fatalf("registry invoker was called for core-routable relay: %+v", registryCall)
+	}
+
+	runtimeSessions.setActive("support", "session-core", false)
+	staleCtx, staleCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer staleCancel()
+	staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+	_, err = proto.NewPluginInvokerClient(conn).Invoke(staleCtx, &proto.PluginInvokeRequest{
+		InvocationToken: invocationToken,
+		Plugin:          "slack",
+		Operation:       "events.reply",
+		Params:          params,
+	})
+	if grpcstatus.Code(err) != codes.Unauthenticated {
+		t.Fatalf("PluginInvoker.Invoke stale runtime session code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unauthenticated, err)
+	}
+	if call := pluginInvoker.snapshot(); call.calls != 1 {
+		t.Fatalf("plugin invoker calls = %d, want 1 after stale runtime session", call.calls)
+	}
+}
+
+func TestHostServiceRelayRejectsCoreRoutableWithoutRuntimeVerifier(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	pluginInvoker := &relayTestInvoker{}
+	invokes := []config.PluginInvocationDependency{{
+		Plugin:         "slack",
+		Operation:      "events.reply",
+		CredentialMode: providermanifestv1.ConnectionModeNone,
+	}}
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+		cfg.PluginInvoker = pluginInvoker
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"support": {Invokes: invokes},
+		}
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-no-verifier",
+		Service:      "plugin_invoker",
+		EnvVar:       plugininvokerservice.DefaultSocketEnv,
+		MethodPrefix: "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/",
+		CoreRoutable: true,
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+	invocationTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "user:test-user",
+		UserID:    "test-user",
+		Kind:      principal.KindUser,
+		Source:    principal.SourceSession,
+	})
+	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "support", plugininvokerservice.InvocationDependencyGrants(invokes))
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+	_, err = proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{
+		InvocationToken: invocationToken,
+		Plugin:          "slack",
+		Operation:       "events.reply",
+	})
+	if grpcstatus.Code(err) != codes.Unauthenticated {
+		t.Fatalf("PluginInvoker.Invoke without runtime verifier code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unauthenticated, err)
+	}
+	if call := pluginInvoker.snapshot(); call.calls != 0 {
+		t.Fatalf("plugin invoker calls = %d, want 0 without runtime verifier", call.calls)
+	}
+}
+
+func TestHostServiceRelayServesRegisteredCoreServiceWithoutCoreRoutableToken(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	invoker := &relayTestInvoker{}
+	invokes := []config.PluginInvocationDependency{{
+		Plugin:         "slack",
+		Operation:      "events.reply",
+		CredentialMode: providermanifestv1.ConnectionModeNone,
+	}}
+	invocationTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
+	publicHostServices.Register("support", runtimehost.HostService{
+		Name:   "plugin_invoker",
+		EnvVar: plugininvokerservice.DefaultSocketEnv,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("support", invokes, invoker, invocationTokens))
+		},
+	})
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+		cfg.PublicHostServices = publicHostServices
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "provider-dev-session",
+		Service:      "plugin_invoker",
+		EnvVar:       plugininvokerservice.DefaultSocketEnv,
+		MethodPrefix: "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/",
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "user:test-user",
+		UserID:    "test-user",
+		Kind:      principal.KindUser,
+		Source:    principal.SourceSession,
+	})
+	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "support", plugininvokerservice.InvocationDependencyGrants(invokes))
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+	resp, err := proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{
+		InvocationToken: invocationToken,
+		Plugin:          "slack",
+		Operation:       "events.reply",
+		Instance:        "prod",
+		IdempotencyKey:  "provider-dev-call",
+	})
+	if err != nil {
+		t.Fatalf("PluginInvoker.Invoke via registered relay: %v", err)
+	}
+	if resp.GetStatus() != 202 || resp.GetBody() != "relayed" {
+		t.Fatalf("PluginInvoker.Invoke response = %+v, want status=202 body=relayed", resp)
+	}
+	if call := invoker.snapshot(); call.providerName != "slack" || call.operation != "events.reply" || call.idempotencyKey != "provider-dev-call" {
+		t.Fatalf("registry invocation call = %+v, want slack.events.reply provider-dev-call", call)
+	}
 }
 
 func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *testing.T) {
@@ -879,6 +1181,13 @@ func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *tes
 
 	secret := []byte("relay-test-secret-0123456789abcd")
 	workflowProvider := newRelayTestWorkflowProvider()
+	agentProvider := newMemoryAgentProvider()
+	runtimeSessions := newRelayTestRuntimeSessionVerifier("github", "session-workflow")
+	invokes := []config.PluginInvocationDependency{{
+		Plugin:         "github",
+		Operation:      "bot.commentFinal",
+		CredentialMode: providermanifestv1.ConnectionModeNone,
+	}}
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		providers := registry.New()
 		if err := providers.Providers.Register("github", &coretesting.StubIntegration{
@@ -887,6 +1196,9 @@ func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *tes
 			CatalogVal: serverTestCatalogFromOperations("github", []core.Operation{{
 				Name:   "events.handle",
 				Method: http.MethodPost,
+			}, {
+				Name:   "bot.commentFinal",
+				Method: http.MethodPost,
 			}}),
 		}); err != nil {
 			t.Fatalf("register provider: %v", err)
@@ -894,9 +1206,18 @@ func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *tes
 		cfg.Providers = &providers.Providers
 		cfg.RouteProfile = server.RouteProfilePublic
 		cfg.StateSecret = secret
+		cfg.PluginRuntimes = runtimeSessions
 		cfg.Workflow = &stubWorkflowControl{
 			defaultProviderName: "local",
 			provider:            workflowProvider,
+		}
+		cfg.Agent = &stubAgentControl{
+			defaultProviderName: "managed",
+			provider:            agentProvider,
+		}
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{Agent: cfg.Agent})
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"github": {Invokes: invokes},
 		}
 	}))
 	ts.EnableHTTP2 = true
@@ -909,7 +1230,7 @@ func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *tes
 	}
 	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
 		PluginName:   "github",
-		SessionID:    "session-elsewhere",
+		SessionID:    "session-workflow",
 		Service:      "workflow_manager",
 		EnvVar:       workflowservice.DefaultManagerSocketEnv,
 		MethodPrefix: "/" + proto.WorkflowManagerHost_ServiceDesc.ServiceName + "/",
@@ -923,10 +1244,16 @@ func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *tes
 	if err != nil {
 		t.Fatalf("NewInvocationTokenManager: %v", err)
 	}
+	permissions := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "github",
+		Operations: []string{"events.handle"},
+	}})
 	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
-		SubjectID: "service_account:github_app_installation:99:repo:acme/widgets",
-		Kind:      principal.KindUser,
-		Source:    principal.SourceSession,
+		SubjectID:        "service_account:github_app_installation:99:repo:acme/widgets",
+		Kind:             principal.KindUser,
+		Source:           principal.SourceSession,
+		TokenPermissions: permissions,
+		Scopes:           principal.PermissionPlugins(permissions),
 	})
 	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "github", nil)
 	if err != nil {
@@ -943,10 +1270,23 @@ func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *tes
 		WorkflowKey:     "github:99:acme/widgets:pull_request:7",
 		IdempotencyKey:  "delivery-1",
 		InvocationToken: invocationToken,
-		Target: &proto.BoundWorkflowTarget{Kind: &proto.BoundWorkflowTarget_Plugin{
-			Plugin: &proto.BoundWorkflowPluginTarget{
-				PluginName: "github",
-				Operation:  "events.handle",
+		Target: &proto.BoundWorkflowTarget{Kind: &proto.BoundWorkflowTarget_Agent{
+			Agent: &proto.BoundWorkflowAgentTarget{
+				ProviderName: "managed",
+				Prompt:       "Handle the webhook.",
+				OutputDelivery: &proto.WorkflowOutputDelivery{
+					Target: &proto.BoundWorkflowPluginTarget{
+						PluginName: "github",
+						Operation:  "bot.commentFinal",
+					},
+					CredentialMode: string(core.ConnectionModeNone),
+					InputBindings: []*proto.WorkflowOutputBinding{{
+						InputField: "body",
+						Value: &proto.WorkflowOutputValueSource{
+							Kind: &proto.WorkflowOutputValueSource_AgentOutput{AgentOutput: "text"},
+						},
+					}},
+				},
 			},
 		}},
 		Signal: &proto.WorkflowSignal{Name: "github.app.webhook", IdempotencyKey: "delivery-1"},
@@ -964,8 +1304,86 @@ func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *tes
 	if call.WorkflowKey != "github:99:acme/widgets:pull_request:7" {
 		t.Fatalf("workflow key = %q, want github:99:acme/widgets:pull_request:7", call.WorkflowKey)
 	}
-	if call.Target.Plugin == nil || call.Target.Plugin.PluginName != "github" || call.Target.Plugin.Operation != "events.handle" {
-		t.Fatalf("workflow target = %#v, want github events.handle target", call.Target)
+	if call.Target.Agent == nil || call.Target.Agent.ProviderName != "managed" {
+		t.Fatalf("workflow target = %#v, want managed agent target", call.Target)
+	}
+	if delivery := call.Target.Agent.OutputDelivery; delivery == nil || delivery.Target.PluginName != "github" || delivery.Target.Operation != "bot.commentFinal" || delivery.CredentialMode != core.ConnectionModeNone {
+		t.Fatalf("workflow output delivery = %#v, want github bot.commentFinal with credential mode none", delivery)
+	}
+}
+
+func TestHostServiceRelayServesCoreRoutableAgentManagerWithoutRegistry(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	agentProvider := newMemoryAgentProvider()
+	runtimeSessions := newRelayTestRuntimeSessionVerifier("support", "session-agent")
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+		cfg.PluginRuntimes = runtimeSessions
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent: &stubAgentControl{
+				defaultProviderName: "managed",
+				provider:            agentProvider,
+			},
+		})
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-agent",
+		Service:      "agent_manager",
+		EnvVar:       agentservice.DefaultManagerSocketEnv,
+		MethodPrefix: "/" + proto.AgentManagerHost_ServiceDesc.ServiceName + "/",
+		CoreRoutable: true,
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+	invocationTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "user:test-user",
+		UserID:    "test-user",
+		Kind:      principal.KindUser,
+		Source:    principal.SourceSession,
+	})
+	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "support", nil)
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+	resp, err := proto.NewAgentManagerHostClient(conn).CreateSession(ctx, &proto.AgentManagerCreateSessionRequest{
+		InvocationToken: invocationToken,
+		ProviderName:    "managed",
+		Model:           "gpt-test",
+		ClientRef:       "client-1",
+		IdempotencyKey:  "agent-session-1",
+	})
+	if err != nil {
+		t.Fatalf("AgentManager.CreateSession via relay: %v", err)
+	}
+	if resp.GetProviderName() != "managed" || resp.GetModel() != "gpt-test" || resp.GetClientRef() != "client-1" {
+		t.Fatalf("AgentManager.CreateSession response = %+v, want managed gpt-test client-1", resp)
+	}
+	if resp.GetId() == "" {
+		t.Fatalf("AgentManager.CreateSession id is empty: %+v", resp)
 	}
 }
 
@@ -1018,6 +1436,59 @@ func TestHostServiceRelayDoesNotFallbackWithoutCoreRoutableToken(t *testing.T) {
 	}
 	if call := invoker.snapshot(); call.providerName != "" {
 		t.Fatalf("invoker was called for non-core-routable relay: %+v", call)
+	}
+}
+
+func TestHostServiceRelayRejectsCoreRoutableWithWrongCoreMethodPrefix(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	invoker := &relayTestInvoker{}
+	invokes := []config.PluginInvocationDependency{{
+		Plugin:         "slack",
+		Operation:      "events.reply",
+		CredentialMode: providermanifestv1.ConnectionModeNone,
+	}}
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+		cfg.Invoker = invoker
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"support": {Invokes: invokes},
+		}
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-elsewhere",
+		Service:      "plugin_invoker",
+		EnvVar:       plugininvokerservice.DefaultSocketEnv,
+		MethodPrefix: "/",
+		CoreRoutable: true,
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+	_, err = proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{})
+	if grpcstatus.Code(err) != codes.Unavailable {
+		t.Fatalf("PluginInvoker.Invoke wrong-prefix code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
+	}
+	if call := invoker.snapshot(); call.providerName != "" {
+		t.Fatalf("invoker was called for wrong-prefix core relay: %+v", call)
 	}
 }
 

--- a/gestaltd/services/runtimehost/public_host_service.go
+++ b/gestaltd/services/runtimehost/public_host_service.go
@@ -17,12 +17,13 @@ type PublicHostService struct {
 	SessionID       string
 	SessionVerifier PublicHostServiceSessionVerifier
 	Service         HostService
+	registrationID  uint64
 }
 
 type PublicHostServiceRegistry struct {
 	mu       sync.Mutex
 	services []PublicHostService
-	version  uint64
+	nextID   uint64
 }
 
 func NewPublicHostServiceRegistry() *PublicHostServiceRegistry {
@@ -50,15 +51,14 @@ func (r *PublicHostServiceRegistry) register(pluginName, sessionID string, verif
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, service := range services {
+		r.nextID++
 		r.services = append(r.services, PublicHostService{
 			PluginName:      pluginName,
 			SessionID:       sessionID,
 			SessionVerifier: verifier,
 			Service:         service,
+			registrationID:  r.nextID,
 		})
-	}
-	if len(services) > 0 {
-		r.version++
 	}
 }
 
@@ -110,35 +110,22 @@ func (r *PublicHostServiceRegistry) unregister(pluginName, sessionID string, ser
 		r.services[i] = PublicHostService{}
 	}
 	r.services = filtered
-	if len(r.services) != originalLen {
-		r.version++
-	}
 }
 
 func (r *PublicHostServiceRegistry) Services() []PublicHostService {
-	services, _ := r.Snapshot()
-	return services
+	return r.Snapshot()
 }
 
-func (r *PublicHostServiceRegistry) Snapshot() ([]PublicHostService, uint64) {
+func (r *PublicHostServiceRegistry) Snapshot() []PublicHostService {
 	if r == nil {
-		return nil, 0
+		return nil
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if len(r.services) == 0 {
-		return nil, r.version
+		return nil
 	}
-	return append([]PublicHostService(nil), r.services...), r.version
-}
-
-func (r *PublicHostServiceRegistry) Version() uint64 {
-	if r == nil {
-		return 0
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.version
+	return append([]PublicHostService(nil), r.services...)
 }
 
 func publicHostServiceKey(service HostService) string {
@@ -148,4 +135,8 @@ func publicHostServiceKey(service HostService) string {
 		return ""
 	}
 	return name + "\x00" + envVar
+}
+
+func (s PublicHostService) RegistrationID() uint64 {
+	return s.registrationID
 }


### PR DESCRIPTION
## Summary
- Routes `core_routable` host-service relay tokens exclusively through deterministic core handlers for workflow manager, agent manager, and plugin invoker.
- Stops relay-mode hosted runtimes from registering or locally starting those core services, while still binding relay tokens for them.
- Simplifies `PublicHostServiceRegistry` by removing version/cache coupling and keeps registry dispatch for non-core/provider-dev services.

## Interface changes
- `runtimehost.PublicHostServiceRegistry.Snapshot()` now returns only `[]PublicHostService`; the server no longer uses registry versions for handler caching.
- Internal hosted-runtime binding now uses a private descriptor so relay-only core services can be bound without being started as local Unix host services.

## Tests
- `go test ./internal/server -run 'TestHostServiceRelay|TestHostServiceHandler|TestValidatePublicHostServices'`
- `go test ./internal/bootstrap -run 'TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext|TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin|TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin|TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin|TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding|TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunnelCapability|TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin|TestPluginRuntimePublicCacheRelayRoundTripsThroughHostedPlugin|TestPluginRuntimePublicS3RelayRoundTripsThroughHostedPlugin|TestProviderDevRuntimeEnvUsesPublicHostServiceRelay'`
- `go test ./internal/server ./services/runtimehost`
- `go test ./internal/bootstrap -skip TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartFails`

Note: full `go test ./internal/bootstrap` currently fails on `TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartFails`; rerunning that test alone reproduces the same unrelated proactive-replacement timing failure.