### PR TITLE
Centralize SDK Buf generation

### DIFF
--- a/.github/workflows/build-go-sdk.yml
+++ b/.github/workflows/build-go-sdk.yml
@@ -38,15 +38,10 @@ jobs:
           go-version-file: sdk/go/go.mod
           cache-dependency-path: sdk/go/go.sum
 
-      - name: Install Buf
-        run: go install github.com/bufbuild/buf/cmd/buf@v1.66.1
-
       - name: Verify checked-in generated bindings
         run: |
           repo_root="$(git rev-parse --show-toplevel)"
-          cd "$repo_root/sdk/proto"
-          "$(go env GOPATH)/bin/buf" generate --template buf.go.gen.yaml
-          cd "$repo_root"
+          "$repo_root/sdk/proto/scripts/buf_generate.sh" go
           git diff --exit-code -- sdk/go/gen/v1/*.pb.go sdk/go/gen/v1/*_grpc.pb.go
 
       - name: Run Go SDK checks

--- a/.github/workflows/build-rust-sdk.yml
+++ b/.github/workflows/build-rust-sdk.yml
@@ -46,9 +46,6 @@ jobs:
         with:
           go-version-file: sdk/go/go.mod
 
-      - name: Install Buf
-        run: go install github.com/bufbuild/buf/cmd/buf@v1.66.1
-
       - name: Cache cargo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -89,8 +89,6 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: sdk/go/go.mod
-      - name: Install Buf
-        run: go install github.com/bufbuild/buf/cmd/buf@v1.66.1
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |

--- a/sdk/go/gen/v1/doc.go
+++ b/sdk/go/gen/v1/doc.go
@@ -2,6 +2,5 @@
 // by the Go SDK.
 //
 // The source of truth lives under `sdk/proto/v1`. Regenerate this package with
-// `buf generate --template buf.go.gen.yaml` from `sdk/proto` after changing
-// those schema files.
+// `sdk/proto/scripts/buf_generate.sh go` after changing those schema files.
 package proto

--- a/sdk/proto/scripts/buf_generate.sh
+++ b/sdk/proto/scripts/buf_generate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly BUF_VERSION="1.66.1"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+proto_root="$(cd "$script_dir/.." && pwd)"
+
+usage() {
+  echo "usage: $0 <go|python|rust|typescript|template.yaml> [buf generate args...]" >&2
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 2
+fi
+
+target="$1"
+shift
+
+case "$target" in
+  go | python | rust | typescript)
+    template="buf.$target.gen.yaml"
+    ;;
+  *.yaml)
+    template="$target"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+if [[ ! -f "$proto_root/$template" ]]; then
+  echo "Buf template not found: $proto_root/$template" >&2
+  exit 1
+fi
+
+buf_cmd=()
+found_buf_version=""
+if command -v buf >/dev/null 2>&1; then
+  found_buf_version="$(buf --version)"
+fi
+
+if [[ "$found_buf_version" == "$BUF_VERSION" ]]; then
+  buf_cmd=(buf)
+elif command -v go >/dev/null 2>&1; then
+  buf_cmd=(go run "github.com/bufbuild/buf/cmd/buf@v$BUF_VERSION")
+elif [[ -n "$found_buf_version" ]]; then
+  echo "buf $BUF_VERSION or Go is required to run Buf generation; found buf $found_buf_version" >&2
+  exit 1
+else
+  echo "buf $BUF_VERSION or Go is required to run Buf generation" >&2
+  exit 1
+fi
+
+(cd "$proto_root" && "${buf_cmd[@]}" generate --template "$template" "$@")

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -33,10 +33,10 @@ Regenerate them from the repo root with:
 uv run python sdk/python/scripts/generate_stubs.py
 ```
 
-The script uses pinned `buf` remote Python plugins so the generated stubs stay
+The script uses pinned `buf` remote Python plugins through the shared
+`sdk/proto/scripts/buf_generate.sh` driver so the generated stubs stay
 reproducible while `plugin_pb2.py` tracks the protobuf `6.33.1` runtime floor
 used by this SDK package and remains compatible with protobuf 7 runtimes.
-`buf` must be available on `PATH`.
 
 ## API Reference
 

--- a/sdk/python/scripts/generate_stubs.py
+++ b/sdk/python/scripts/generate_stubs.py
@@ -1,6 +1,4 @@
-import shutil
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 
@@ -61,25 +59,18 @@ if _version_not_supported:
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[3]
     proto_dir = repo_root / "sdk/proto"
-    template_path = proto_dir / "buf.python.gen.yaml"
+    buf_generate = proto_dir / "scripts/buf_generate.sh"
     target_dir = repo_root / "sdk/python/gestalt/gen/v1"
-
-    if shutil.which("buf") is None:
-        print("buf is required to regenerate Python protobuf stubs", file=sys.stderr)
-        return 1
 
     with tempfile.TemporaryDirectory(prefix="gestalt-python-stubs-") as work_dir:
         work_path = Path(work_dir)
         subprocess.run(
             [
-                "buf",
-                "generate",
-                "--template",
-                str(template_path),
+                str(buf_generate),
+                "python",
                 "--output",
                 str(work_path),
             ],
-            cwd=proto_dir,
             check=True,
         )
 

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -80,7 +80,8 @@ Maintainers regenerate them from the shared proto definitions in
 [`sdk/proto`](https://github.com/valon-technologies/gestalt/tree/main/sdk/proto)
 with the Buf template in
 [`sdk/proto/buf.rust.gen.yaml`](https://github.com/valon-technologies/gestalt/tree/main/sdk/proto/buf.rust.gen.yaml).
-Use the same Buf CLI version as CI (`v1.66.1`) for deterministic remote-plugin output.
+The script uses the shared `sdk/proto/scripts/buf_generate.sh` driver so local
+and CI regeneration use the same Buf CLI version.
 
 To regenerate the bindings:
 

--- a/sdk/rust/scripts/generate_stubs.sh
+++ b/sdk/rust/scripts/generate_stubs.sh
@@ -6,19 +6,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 proto_root="$repo_root/sdk/proto"
 generated_root="$repo_root/sdk/rust/src/generated"
 
-if ! command -v buf >/dev/null 2>&1; then
-  echo "buf is required to regenerate Rust protobuf stubs" >&2
-  exit 1
-fi
-
-required_buf_version="1.66.1"
-buf_version="$(buf --version)"
-if [[ "$buf_version" != "$required_buf_version" ]]; then
-  echo "buf $required_buf_version is required to regenerate Rust protobuf stubs; found $buf_version" >&2
-  exit 1
-fi
-
-(cd "$proto_root" && buf generate --template buf.rust.gen.yaml)
+"$proto_root/scripts/buf_generate.sh" rust
 
 if command -v rustfmt >/dev/null 2>&1; then
   find "$generated_root" -name '*.rs' -print0 | xargs -0 rustfmt --edition 2024

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -127,7 +127,7 @@ provider source into the result.
 From the repo root:
 
 ```sh
-buf generate --template sdk/proto/buf.typescript.gen.yaml sdk/proto
+sdk/proto/scripts/buf_generate.sh typescript
 ```
 
 ## Local checks

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -29,7 +29,7 @@
     "access": "public"
   },
   "scripts": {
-    "build:proto": "buf generate --template ../proto/buf.typescript.gen.yaml ../proto",
+    "build:proto": "../proto/scripts/buf_generate.sh typescript",
     "docs:lint": "eslint --max-warnings=0 \"src/**/*.ts\" \"docs/entrypoints/**/*.ts\"",
     "docs:build": "typedoc --options typedoc.json --out docs/_build/html",
     "docs:build:deploy": "typedoc --options typedoc.json --out ../../docs/public/api/typescript",


### PR DESCRIPTION
## Summary
- add `sdk/proto/scripts/buf_generate.sh` as the shared SDK Buf generation entrypoint
- route Go, Python, Rust, and TypeScript SDK generation through the shared driver
- remove repeated Buf install/version/invocation logic from SDK workflows and Rust/Python scripts

## Interface Changes
- New/changed interface:
  - SDK protobuf generation can be invoked as `sdk/proto/scripts/buf_generate.sh <go|python|rust|typescript>`.
  - The driver uses Buf `v1.66.1` directly when available, or falls back to `go run github.com/bufbuild/buf/cmd/buf@v1.66.1` when Go is available.
  - Existing language-specific commands continue to work: `sdk/rust/scripts/generate_stubs.sh`, `uv run python sdk/python/scripts/generate_stubs.py`, and `bun run build:proto`.
- Example usage:
  - `sdk/proto/scripts/buf_generate.sh go`
  - `sdk/proto/scripts/buf_generate.sh rust`
  - `sdk/proto/scripts/buf_generate.sh python --output /tmp/python-stubs`

## Functional/Integration Tests
- Tests added or augmented: none; this is SDK codegen orchestration cleanup.
- Contract boundary covered: generated stubs remain unchanged for Go/Rust/Python; TypeScript package script reaches the shared driver but live generation was blocked locally by BSR rate limiting.
- Commands run:
  - `bash -n sdk/proto/scripts/buf_generate.sh sdk/rust/scripts/generate_stubs.sh`
  - `sdk/proto/scripts/buf_generate.sh go && git diff --exit-code -- sdk/go/gen/v1/*.pb.go sdk/go/gen/v1/*_grpc.pb.go`
  - `./scripts/generate_stubs.sh && git diff --exit-code -- src/generated` from `sdk/rust`
  - `python3 sdk/python/scripts/generate_stubs.py && git diff --exit-code -- sdk/python/gestalt/gen`
  - After rebasing onto `main`, additional live Buf generation attempts were blocked by BSR `resource_exhausted`; deleted generated files from the failed clean step were restored from git.
  - `bun run build:proto` from `sdk/typescript` hit BSR `resource_exhausted` after invoking the shared driver
  - `go test ./...` from `sdk/go`
  - `cargo fmt --check`, `cargo test`, `cargo clippy --all-targets -- -D warnings`, `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps` from `sdk/rust`
  - `uv run ruff check scripts/generate_stubs.py`, `uv run ty check scripts/generate_stubs.py`, `uv run python -m unittest discover -s tests` from `sdk/python`
  - `bun install --frozen-lockfile && bun run check`, `bun run docs:lint` from `sdk/typescript`
