### PR TITLE
Support config workflow execution permissions

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -545,6 +545,11 @@ workflows:
         plugin:
           name: roadmap
           operation: sync_items
+      permissions:
+        - plugin: slack
+          operations:
+            - conversations.list
+            - conversations.history
   eventTriggers:
     item_updated:
       provider: local
@@ -558,8 +563,12 @@ workflows:
 
 Workflow targets are always explicit through `target.plugin` or `target.agent`.
 For plugin targets, set `name`, `operation`, and optional `connection`,
-`instance`, and `input`. Config-managed schedules and event triggers are
-reconciled into the provider at startup. See [Workflow](/providers/workflow)
+`instance`, and `input`. `permissions` can grant additional plugin operations
+to the config-owned execution principal for nested calls made by the target;
+the direct target operation is always granted. These scopes do not select or
+grant credentials; nested calls still resolve credentials through the invoked
+plugin operation's normal connection. Config-managed schedules and event
+triggers are reconciled into the provider at startup. See [Workflow](/providers/workflow)
 for the user-facing and provider model.
 
 ## Configuring agent providers

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -117,10 +117,20 @@ workflows:
           input:
             mode: incremental
             includeArchived: false
+      permissions:
+        - plugin: slack
+          operations:
+            - conversations.list
+            - conversations.history
 ```
 
 This creates a durable schedule named `nightly_sync` that invokes
-`roadmap.sync` every day at 3:00 AM New York time.
+`roadmap.sync` every day at 3:00 AM New York time. `permissions` grants the
+config-owned execution principal additional plugin operations the target may
+invoke while it runs; Gestalt always includes the direct target operation.
+The extra scopes do not grant credentials. The invoked plugin still resolves
+its own connection, and config-owned workflow targets must resolve to non-user
+credentials.
 
 ### Triggers
 
@@ -142,6 +152,10 @@ workflows:
           input:
             channel: C123456
             text: "A roadmap item changed."
+      permissions:
+        - plugin: roadmap
+          operations:
+            - items.get
 ```
 
 This creates a durable trigger that listens for published events with:

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -582,6 +582,11 @@ workflows:
           instance: tenant-a
           input:
             mode: incremental
+      permissions:
+        - plugin: slack
+          operations:
+            - conversations.list
+            - conversations.history
       paused: false
 
   eventTriggers:
@@ -596,6 +601,10 @@ workflows:
           operation: sync_items
           input:
             reason: sync
+      permissions:
+        - plugin: slack
+          operations:
+            - chat.postMessage
       paused: false
 ```
 
@@ -610,6 +619,7 @@ workflows:
 | `target.plugin.instance` | Optional target instance name. |
 | `target.plugin.input` | Optional static input merged into the invocation payload. |
 | `target.agent` | Optional agent target using the same shape as workflow agent requests: `provider`, `model`, `prompt`, `messages`, `tools`, `responseSchema`, `metadata`, `providerOptions`, and `timeout`. |
+| `permissions` | Optional additional plugin-operation permissions granted to the config-owned execution principal. The direct target operation is always included. These scopes do not grant credentials; invoked operations still resolve credentials through their configured connection. |
 | `cron` | **Required.** Five-field cron expression. |
 | `timezone` | IANA timezone name. Defaults to `UTC`. |
 | `paused` | When `true`, Gestalt reconciles the schedule in a paused state. |
@@ -624,6 +634,7 @@ workflows:
 | `target.plugin.connection` | Optional target connection name. |
 | `target.plugin.instance` | Optional target instance name. |
 | `target.plugin.input` | Optional static input merged into the invocation payload. |
+| `permissions` | Optional additional plugin-operation permissions granted to the config-owned execution principal. The direct target operation is always included. These scopes do not grant credentials; invoked operations still resolve credentials through their configured connection. |
 | `target.agent` | Optional agent target using the same shape as workflow agent requests. |
 | `match.type` | **Required.** Event type matcher. |
 | `match.source` | Optional event source matcher. |

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -4257,6 +4257,26 @@ func TestBootstrapAppliesConfiguredWorkflowSchedules(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["slack"] = &config.ProviderEntry{
+		ConnectionMode: providermanifestv1.ConnectionModePlatform,
+		Auth: &config.ConnectionAuthDef{
+			Type:  providermanifestv1.AuthTypeBearer,
+			Token: "platform-token",
+		},
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Spec: &providermanifestv1.Spec{
+				Surfaces: &providermanifestv1.ProviderSurfaces{
+					REST: &providermanifestv1.RESTSurface{
+						BaseURL: "https://slack.example.invalid",
+						Operations: []providermanifestv1.ProviderOperation{
+							{Name: "conversations.list", Method: http.MethodPost, Path: "/conversations.list"},
+							{Name: "conversations.history", Method: http.MethodPost, Path: "/conversations.history"},
+						},
+					},
+				},
+			},
+		},
+	}
 	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider: "temporal",
 		Schedules: map[string]workflowFixtureSchedule{
@@ -4270,6 +4290,15 @@ func TestBootstrapAppliesConfiguredWorkflowSchedules(t *testing.T) {
 			},
 		},
 	})
+	nightly := cfg.Workflows.Schedules["nightly_sync"]
+	nightly.Permissions = []core.AccessPermission{{
+		Plugin: "slack",
+		Operations: []string{
+			"conversations.list",
+			"conversations.history",
+		},
+	}}
+	cfg.Workflows.Schedules["nightly_sync"] = nightly
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -4324,8 +4353,125 @@ func TestBootstrapAppliesConfiguredWorkflowSchedules(t *testing.T) {
 	if ref.SubjectID != "system:config" {
 		t.Fatalf("subjectID = %q, want %q", ref.SubjectID, "system:config")
 	}
-	if len(ref.Permissions) != 1 || ref.Permissions[0].Plugin != "roadmap" || len(ref.Permissions[0].Operations) != 1 || ref.Permissions[0].Operations[0] != "sync" {
-		t.Fatalf("permissions = %#v", ref.Permissions)
+	wantPermissions := []core.AccessPermission{
+		{Plugin: "roadmap", Operations: []string{"sync"}},
+		{Plugin: "slack", Operations: []string{"conversations.list", "conversations.history"}},
+	}
+	if !reflect.DeepEqual(ref.Permissions, wantPermissions) {
+		t.Fatalf("permissions = %#v, want %#v", ref.Permissions, wantPermissions)
+	}
+}
+
+func TestBootstrapRecreatesConfiguredWorkflowScheduleExecutionRefWhenPermissionsChange(t *testing.T) {
+	t.Parallel()
+
+	factories := validFactories()
+	recorders := []*recordingWorkflowProvider{}
+	sharedSchedules := map[string]*coreworkflow.Schedule{}
+	sharedExecutionRefs := map[string]*coreworkflow.ExecutionReference{}
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{
+			schedules:     sharedSchedules,
+			executionRefs: sharedExecutionRefs,
+		}
+		recorders = append(recorders, recorder)
+		return recorder, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		Schedules: map[string]workflowFixtureSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	})
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	<-result.ProvidersReady
+	if len(recorders) != 1 || len(recorders[0].upsertedSchedules) != 1 {
+		t.Fatalf("initial upserts = %#v", recorders)
+	}
+	initialExecutionRef := recorders[0].upsertedSchedules[0].ExecutionRef
+	if strings.TrimSpace(initialExecutionRef) == "" {
+		t.Fatal("initial execution ref = empty")
+	}
+	_ = result.Close(context.Background())
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["slack"] = &config.ProviderEntry{
+		ConnectionMode: providermanifestv1.ConnectionModePlatform,
+		Auth: &config.ConnectionAuthDef{
+			Type:  providermanifestv1.AuthTypeBearer,
+			Token: "platform-token",
+		},
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Spec: &providermanifestv1.Spec{
+				Surfaces: &providermanifestv1.ProviderSurfaces{
+					REST: &providermanifestv1.RESTSurface{
+						BaseURL: "https://slack.example.invalid",
+						Operations: []providermanifestv1.ProviderOperation{
+							{Name: "conversations.history", Method: http.MethodPost, Path: "/conversations.history"},
+						},
+					},
+				},
+			},
+		},
+	}
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		Schedules: map[string]workflowFixtureSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	})
+	nightly := cfg.Workflows.Schedules["nightly_sync"]
+	nightly.Permissions = []core.AccessPermission{{
+		Plugin:     "slack",
+		Operations: []string{"conversations.history"},
+	}}
+	cfg.Workflows.Schedules["nightly_sync"] = nightly
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap with permissions: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(recorders) != 2 || len(recorders[1].upsertedSchedules) != 1 {
+		t.Fatalf("second upserts = %#v", recorders)
+	}
+	nextExecutionRef := recorders[1].upsertedSchedules[0].ExecutionRef
+	if nextExecutionRef == initialExecutionRef {
+		t.Fatalf("execution ref = %q, want recreated after permissions change", nextExecutionRef)
+	}
+	oldRef, err := recorders[1].GetExecutionReference(context.Background(), initialExecutionRef)
+	if err != nil {
+		t.Fatalf("Get old execution ref: %v", err)
+	}
+	if oldRef.RevokedAt == nil || oldRef.RevokedAt.IsZero() {
+		t.Fatalf("old execution ref revokedAt = %#v, want set", oldRef.RevokedAt)
+	}
+	nextRef, err := recorders[1].GetExecutionReference(context.Background(), nextExecutionRef)
+	if err != nil {
+		t.Fatalf("Get new execution ref: %v", err)
+	}
+	wantPermissions := []core.AccessPermission{
+		{Plugin: "roadmap", Operations: []string{"sync"}},
+		{Plugin: "slack", Operations: []string{"conversations.history"}},
+	}
+	if !reflect.DeepEqual(nextRef.Permissions, wantPermissions) {
+		t.Fatalf("permissions = %#v, want %#v", nextRef.Permissions, wantPermissions)
 	}
 }
 
@@ -4400,6 +4546,127 @@ func TestBootstrapRejectsConfiguredWorkflowSchedulesForUserCredentialedPlugins(t
 	}
 	if !strings.Contains(err.Error(), `config-managed workflows do not support user-credentialed plugin "roadmap"`) {
 		t.Fatalf("Bootstrap error = %v", err)
+	}
+}
+
+func TestBootstrapAppliesConfiguredWorkflowSchedulesForPlatformConnectionOnUserDefaultPlugin(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].ConnectionMode = providermanifestv1.ConnectionModeUser
+	cfg.Plugins["roadmap"].Connections = map[string]*config.ConnectionDef{
+		"bot": {
+			Mode: providermanifestv1.ConnectionModePlatform,
+			Auth: config.ConnectionAuthDef{
+				Type:  providermanifestv1.AuthTypeBearer,
+				Token: "platform-token",
+			},
+		},
+	}
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		Schedules: map[string]workflowFixtureSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	})
+	nightly := cfg.Workflows.Schedules["nightly_sync"]
+	nightly.Target.Plugin.Connection = "bot"
+	cfg.Workflows.Schedules["nightly_sync"] = nightly
+
+	factories := validFactories()
+	recorders := map[string]*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		recorders[name] = recorder
+		return recorder, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	recorder := recorders["temporal"]
+	if recorder == nil || len(recorder.upsertedSchedules) != 1 {
+		t.Fatalf("recorded schedules = %#v", recorders)
+	}
+	gotPlugin := requireCoreWorkflowPluginTarget(t, recorder.upsertedSchedules[0].Target)
+	if gotPlugin.Connection != "bot" {
+		t.Fatalf("target connection = %q, want bot", gotPlugin.Connection)
+	}
+}
+
+func TestBootstrapAllowsConfiguredWorkflowSchedulePermissionScopesForUserCredentialedPlugins(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["slack"] = &config.ProviderEntry{
+		ConnectionMode: providermanifestv1.ConnectionModeUser,
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Spec: &providermanifestv1.Spec{
+				Surfaces: &providermanifestv1.ProviderSurfaces{
+					REST: &providermanifestv1.RESTSurface{
+						BaseURL: "https://slack.example.invalid",
+						Operations: []providermanifestv1.ProviderOperation{
+							{Name: "conversations.list", Method: http.MethodPost, Path: "/conversations.list"},
+						},
+					},
+				},
+			},
+		},
+	}
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		Schedules: map[string]workflowFixtureSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	})
+	nightly := cfg.Workflows.Schedules["nightly_sync"]
+	nightly.Permissions = []core.AccessPermission{{
+		Plugin:     "slack",
+		Operations: []string{"conversations.list"},
+	}}
+	cfg.Workflows.Schedules["nightly_sync"] = nightly
+
+	factories := validFactories()
+	recorders := map[string]*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		recorders[name] = recorder
+		return recorder, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	recorder := recorders["temporal"]
+	if recorder == nil || len(recorder.upsertedSchedules) != 1 {
+		t.Fatalf("recorded schedules = %#v", recorders)
+	}
+	ref, err := recorder.GetExecutionReference(context.Background(), recorder.upsertedSchedules[0].ExecutionRef)
+	if err != nil {
+		t.Fatalf("Get execution ref: %v", err)
+	}
+	wantPermissions := []core.AccessPermission{
+		{Plugin: "roadmap", Operations: []string{"sync"}},
+		{Plugin: "slack", Operations: []string{"conversations.list"}},
+	}
+	if !reflect.DeepEqual(ref.Permissions, wantPermissions) {
+		t.Fatalf("permissions = %#v, want %#v", ref.Permissions, wantPermissions)
 	}
 }
 
@@ -5109,6 +5376,25 @@ func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["slack"] = &config.ProviderEntry{
+		ConnectionMode: providermanifestv1.ConnectionModePlatform,
+		Auth: &config.ConnectionAuthDef{
+			Type:  providermanifestv1.AuthTypeBearer,
+			Token: "platform-token",
+		},
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Spec: &providermanifestv1.Spec{
+				Surfaces: &providermanifestv1.ProviderSurfaces{
+					REST: &providermanifestv1.RESTSurface{
+						BaseURL: "https://slack.example.invalid",
+						Operations: []providermanifestv1.ProviderOperation{
+							{Name: "conversations.history", Method: http.MethodPost, Path: "/conversations.history"},
+						},
+					},
+				},
+			},
+		},
+	}
 	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider: "temporal",
 		EventTriggers: map[string]workflowFixtureEventTrigger{
@@ -5124,6 +5410,12 @@ func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
 			},
 		},
 	})
+	taskUpdated := cfg.Workflows.EventTriggers["task_updated"]
+	taskUpdated.Permissions = []core.AccessPermission{{
+		Plugin:     "slack",
+		Operations: []string{"conversations.history"},
+	}}
+	cfg.Workflows.EventTriggers["task_updated"] = taskUpdated
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -5177,6 +5469,13 @@ func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
 	}
 	if ref.SubjectID != "system:config" {
 		t.Fatalf("subjectID = %q, want %q", ref.SubjectID, "system:config")
+	}
+	wantPermissions := []core.AccessPermission{
+		{Plugin: "roadmap", Operations: []string{"sync"}},
+		{Plugin: "slack", Operations: []string{"conversations.history"}},
+	}
+	if !reflect.DeepEqual(ref.Permissions, wantPermissions) {
+		t.Fatalf("permissions = %#v, want %#v", ref.Permissions, wantPermissions)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -55,7 +55,7 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 		default:
 			return fmt.Errorf("bootstrap: get workflow event trigger %q for plugin %q: %w", desiredEntry.TriggerID, pluginName, err)
 		}
-		desiredExecutionRef, err := workflowConfigExecutionReference(cfg, providerName, target)
+		desiredExecutionRef, err := workflowConfigExecutionReference(cfg, providerName, target, trigger.Permissions)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q: %w", desiredEntry.TriggerKey, pluginName, err)
 		}

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -18,6 +18,7 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -66,7 +67,7 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 		if existing != nil {
 			existingExecutionRef = strings.TrimSpace(existing.ExecutionRef)
 		}
-		desiredExecutionRef, err := workflowConfigExecutionReference(cfg, providerName, target)
+		desiredExecutionRef, err := workflowConfigExecutionReference(cfg, providerName, target, schedule.Permissions)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q: %w", desiredEntry.ScheduleKey, pluginName, err)
 		}
@@ -360,9 +361,10 @@ func workflowEnsureConfigExecutionRef(
 	return refID, true, nil
 }
 
-func workflowExecutionRefPermissionsForTarget(target coreworkflow.Target) []core.AccessPermission {
+func workflowExecutionRefPermissionsForTarget(target coreworkflow.Target, explicit ...[]core.AccessPermission) []core.AccessPermission {
+	var base []core.AccessPermission
 	if target.Agent != nil {
-		out := make([]core.AccessPermission, 0, len(target.Agent.ToolRefs))
+		base = make([]core.AccessPermission, 0, len(target.Agent.ToolRefs)+1)
 		for i := range target.Agent.ToolRefs {
 			tool := target.Agent.ToolRefs[i]
 			pluginName := strings.TrimSpace(tool.Plugin)
@@ -370,7 +372,7 @@ func workflowExecutionRefPermissionsForTarget(target coreworkflow.Target) []core
 			if pluginName == "" || operation == "" {
 				continue
 			}
-			out = append(out, core.AccessPermission{
+			base = append(base, core.AccessPermission{
 				Plugin:     pluginName,
 				Operations: []string{operation},
 			})
@@ -379,30 +381,72 @@ func workflowExecutionRefPermissionsForTarget(target coreworkflow.Target) []core
 			pluginName := strings.TrimSpace(delivery.Target.PluginName)
 			operation := strings.TrimSpace(delivery.Target.Operation)
 			if pluginName != "" && operation != "" {
-				out = append(out, core.AccessPermission{
+				base = append(base, core.AccessPermission{
 					Plugin:     pluginName,
 					Operations: []string{operation},
 				})
 			}
 		}
-		return out
+		return workflowMergeExecutionRefPermissions(append([][]core.AccessPermission{base}, explicit...)...)
 	}
 	if target.Plugin == nil {
-		return nil
+		return workflowMergeExecutionRefPermissions(explicit...)
 	}
 	pluginTarget := *target.Plugin
 	pluginName := pluginTarget.PluginName
 	operation := strings.TrimSpace(pluginTarget.Operation)
-	if pluginName == "" || operation == "" {
-		return nil
+	if pluginName != "" && operation != "" {
+		base = []core.AccessPermission{{
+			Plugin:     pluginName,
+			Operations: []string{operation},
+		}}
 	}
-	return []core.AccessPermission{{
-		Plugin:     pluginName,
-		Operations: []string{operation},
-	}}
+	return workflowMergeExecutionRefPermissions(append([][]core.AccessPermission{base}, explicit...)...)
 }
 
-func workflowConfigExecutionReference(cfg *config.Config, providerName string, target coreworkflow.Target) (*coreworkflow.ExecutionReference, error) {
+func workflowMergeExecutionRefPermissions(groups ...[]core.AccessPermission) []core.AccessPermission {
+	out := make([]core.AccessPermission, 0)
+	pluginIndexes := map[string]int{}
+	seenOperations := map[string]map[string]struct{}{}
+	for _, group := range groups {
+		for _, value := range group {
+			plugin := strings.TrimSpace(value.Plugin)
+			if plugin == "" {
+				continue
+			}
+			operations := make([]string, 0, len(value.Operations))
+			for _, operation := range value.Operations {
+				operation = strings.TrimSpace(operation)
+				if operation != "" {
+					operations = append(operations, operation)
+				}
+			}
+			if len(operations) == 0 {
+				continue
+			}
+			idx, ok := pluginIndexes[plugin]
+			if !ok {
+				idx = len(out)
+				pluginIndexes[plugin] = idx
+				seenOperations[plugin] = map[string]struct{}{}
+				out = append(out, core.AccessPermission{Plugin: plugin})
+			}
+			for _, operation := range operations {
+				if _, exists := seenOperations[plugin][operation]; exists {
+					continue
+				}
+				seenOperations[plugin][operation] = struct{}{}
+				out[idx].Operations = append(out[idx].Operations, operation)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func workflowConfigExecutionReference(cfg *config.Config, providerName string, target coreworkflow.Target, permissions []core.AccessPermission) (*coreworkflow.ExecutionReference, error) {
 	ref := &coreworkflow.ExecutionReference{
 		ProviderName:        providerName,
 		Target:              target,
@@ -411,7 +455,7 @@ func workflowConfigExecutionReference(cfg *config.Config, providerName string, t
 		DisplayName:         "Gestalt config",
 		AuthSource:          "config",
 		CredentialSubjectID: workflowConfigOwnerSubjectID(),
-		Permissions:         workflowExecutionRefPermissionsForTarget(target),
+		Permissions:         workflowExecutionRefPermissionsForTarget(target, permissions),
 	}
 	if target.Agent != nil {
 		for i := range target.Agent.ToolRefs {
@@ -419,12 +463,17 @@ func workflowConfigExecutionReference(cfg *config.Config, providerName string, t
 			if strings.TrimSpace(tool.System) != "" {
 				continue
 			}
-			if err := workflowConfigValidateNoUserCredentialTarget(cfg, tool.Plugin); err != nil {
+			if err := workflowConfigValidateNoUserCredentialTarget(cfg, coreworkflow.PluginTarget{
+				PluginName: strings.TrimSpace(tool.Plugin),
+				Operation:  strings.TrimSpace(tool.Operation),
+				Connection: strings.TrimSpace(tool.Connection),
+				Instance:   strings.TrimSpace(tool.Instance),
+			}); err != nil {
 				return nil, err
 			}
 		}
 		if delivery := target.Agent.OutputDelivery; delivery != nil {
-			if err := workflowConfigValidateNoUserCredentialTarget(cfg, delivery.Target.PluginName); err != nil {
+			if err := workflowConfigValidateNoUserCredentialTarget(cfg, delivery.Target); err != nil {
 				return nil, err
 			}
 		}
@@ -433,37 +482,126 @@ func workflowConfigExecutionReference(cfg *config.Config, providerName string, t
 	if target.Plugin == nil {
 		return nil, fmt.Errorf("workflow target plugin is required")
 	}
-	if err := workflowConfigValidateNoUserCredentialTarget(cfg, target.Plugin.PluginName); err != nil {
+	if err := workflowConfigValidateNoUserCredentialTarget(cfg, *target.Plugin); err != nil {
 		return nil, err
 	}
 	return ref, nil
 }
 
-func workflowConfigValidateNoUserCredentialTarget(cfg *config.Config, pluginName string) error {
-	mode, err := workflowConfigTargetConnectionMode(cfg, pluginName)
+func workflowConfigValidateNoUserCredentialTarget(cfg *config.Config, target coreworkflow.PluginTarget) error {
+	mode, err := workflowConfigTargetConnectionMode(cfg, target)
 	if err != nil {
 		return err
 	}
+	pluginName := strings.TrimSpace(target.PluginName)
 	switch mode {
 	case core.ConnectionModeNone, core.ConnectionModePlatform:
 		return nil
 	case core.ConnectionModeUser:
-		return fmt.Errorf("config-managed workflows do not support user-credentialed plugin %q", strings.TrimSpace(pluginName))
+		return fmt.Errorf("config-managed workflows do not support user-credentialed plugin %q", pluginName)
 	default:
-		return fmt.Errorf("unsupported connection mode %q for config-managed workflow target %q", mode, strings.TrimSpace(pluginName))
+		return fmt.Errorf("unsupported connection mode %q for config-managed workflow target %q", mode, pluginName)
 	}
 }
 
-func workflowConfigTargetConnectionMode(cfg *config.Config, pluginName string) (core.ConnectionMode, error) {
+func workflowConfigTargetConnectionMode(cfg *config.Config, target coreworkflow.PluginTarget) (core.ConnectionMode, error) {
 	if cfg == nil {
 		return core.ConnectionModeNone, fmt.Errorf("workflow config is not available")
 	}
-	pluginName = strings.TrimSpace(pluginName)
+	pluginName := strings.TrimSpace(target.PluginName)
 	entry := cfg.Plugins[pluginName]
 	if entry == nil {
 		return core.ConnectionModeNone, fmt.Errorf("workflow target plugin %q is not configured", pluginName)
 	}
+	plan, err := config.BuildStaticConnectionPlan(entry, entry.ManifestSpec())
+	if err != nil {
+		return core.ConnectionModeNone, fmt.Errorf("workflow target plugin %q connection plan: %w", pluginName, err)
+	}
+
+	if connection := strings.TrimSpace(target.Connection); connection != "" {
+		return workflowConfigConnectionModeForName(plan, pluginName, connection)
+	}
+	if operation := strings.TrimSpace(target.Operation); operation != "" {
+		mode, ok, err := workflowConfigOperationConnectionMode(plan, entry.ManifestSpec(), target)
+		if err != nil {
+			return core.ConnectionModeNone, fmt.Errorf("workflow target plugin %q operation %q connection plan: %w", pluginName, operation, err)
+		}
+		if ok {
+			return mode, nil
+		}
+	}
 	return core.NormalizeConnectionMode(core.ConnectionMode(entry.ConnectionMode)), nil
+}
+
+func workflowConfigOperationConnectionMode(plan config.StaticConnectionPlan, manifestPlugin *providermanifestv1.Spec, target coreworkflow.PluginTarget) (core.ConnectionMode, bool, error) {
+	connections, selectors, _, err := plan.RESTOperationConnectionBindings(manifestPlugin)
+	if err != nil {
+		return core.ConnectionModeNone, false, err
+	}
+	operation := strings.TrimSpace(target.Operation)
+	if selector, ok := selectors[operation]; ok {
+		connectionName, resolved := workflowConfigConnectionSelectorTargetConnection(selector, target.Input)
+		if resolved {
+			mode, err := workflowConfigConnectionModeForName(plan, target.PluginName, connectionName)
+			return mode, true, err
+		}
+		if connectionName := strings.TrimSpace(connections[operation]); connectionName != "" {
+			mode, err := workflowConfigConnectionModeForName(plan, target.PluginName, connectionName)
+			return mode, true, err
+		}
+		mode, err := workflowConfigConnectionSelectorMode(plan, target.PluginName, selector)
+		return mode, true, err
+	}
+	if connectionName := strings.TrimSpace(connections[operation]); connectionName != "" {
+		mode, err := workflowConfigConnectionModeForName(plan, target.PluginName, connectionName)
+		return mode, true, err
+	}
+	return core.ConnectionModeNone, false, nil
+}
+
+func workflowConfigConnectionSelectorTargetConnection(selector core.OperationConnectionSelector, input map[string]any) (string, bool) {
+	parameter := strings.TrimSpace(selector.Parameter)
+	if parameter == "" || len(input) == 0 {
+		return "", false
+	}
+	value, ok := input[parameter]
+	if !ok {
+		return "", false
+	}
+	selectorValue, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	connectionName := selector.Values[strings.TrimSpace(selectorValue)]
+	return strings.TrimSpace(connectionName), strings.TrimSpace(connectionName) != ""
+}
+
+func workflowConfigConnectionSelectorMode(plan config.StaticConnectionPlan, pluginName string, selector core.OperationConnectionSelector) (core.ConnectionMode, error) {
+	hasPlatform := false
+	for _, connectionName := range selector.Values {
+		mode, err := workflowConfigConnectionModeForName(plan, pluginName, connectionName)
+		if err != nil {
+			return core.ConnectionModeNone, err
+		}
+		switch mode {
+		case core.ConnectionModeUser:
+			return core.ConnectionModeUser, nil
+		case core.ConnectionModePlatform:
+			hasPlatform = true
+		}
+	}
+	if hasPlatform {
+		return core.ConnectionModePlatform, nil
+	}
+	return core.ConnectionModeNone, nil
+}
+
+func workflowConfigConnectionModeForName(plan config.StaticConnectionPlan, pluginName, connectionName string) (core.ConnectionMode, error) {
+	conn, ok := plan.LookupConnection(connectionName)
+	if !ok {
+		return core.ConnectionModeNone, fmt.Errorf("workflow target plugin %q connection %q is not configured", strings.TrimSpace(pluginName), strings.TrimSpace(connectionName))
+	}
+	return config.ConnectionModeForConnection(conn), nil
 }
 
 func workflowConfigOwnerSubjectID() string {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
@@ -599,18 +600,20 @@ type WorkflowsConfig struct {
 }
 
 type WorkflowScheduleConfig struct {
-	Provider string                `yaml:"provider,omitempty"`
-	Target   *WorkflowTargetConfig `yaml:"target,omitempty"`
-	Cron     string                `yaml:"cron,omitempty"`
-	Timezone string                `yaml:"timezone,omitempty"`
-	Paused   bool                  `yaml:"paused,omitempty"`
+	Provider    string                  `yaml:"provider,omitempty"`
+	Target      *WorkflowTargetConfig   `yaml:"target,omitempty"`
+	Permissions []core.AccessPermission `yaml:"permissions,omitempty"`
+	Cron        string                  `yaml:"cron,omitempty"`
+	Timezone    string                  `yaml:"timezone,omitempty"`
+	Paused      bool                    `yaml:"paused,omitempty"`
 }
 
 type WorkflowEventTriggerConfig struct {
-	Provider string                `yaml:"provider,omitempty"`
-	Target   *WorkflowTargetConfig `yaml:"target,omitempty"`
-	Match    WorkflowEventMatch    `yaml:"match,omitempty"`
-	Paused   bool                  `yaml:"paused,omitempty"`
+	Provider    string                  `yaml:"provider,omitempty"`
+	Target      *WorkflowTargetConfig   `yaml:"target,omitempty"`
+	Permissions []core.AccessPermission `yaml:"permissions,omitempty"`
+	Match       WorkflowEventMatch      `yaml:"match,omitempty"`
+	Paused      bool                    `yaml:"paused,omitempty"`
 }
 
 type WorkflowTargetConfig struct {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -2623,6 +2624,9 @@ plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
+  slack:
+    source:
+      path: ./providers/slack/manifest.yaml
 workflows:
   schedules:
     nightly:
@@ -2634,6 +2638,11 @@ workflows:
           operation: nightly_sync
           input:
             source: yaml
+      permissions:
+        - plugin: slack
+          operations:
+            - conversations.list
+            - conversations.history
   eventTriggers:
     task_updated:
       provider: temporal
@@ -2646,6 +2655,10 @@ workflows:
           operation: backfill_items
           input:
             source: event
+      permissions:
+        - plugin: slack
+          operations:
+            - chat.postMessage
       paused: true
 providers:
   workflow:
@@ -2677,6 +2690,13 @@ server:
 					},
 				},
 			},
+			Permissions: []core.AccessPermission{{
+				Plugin: "slack",
+				Operations: []string{
+					"conversations.list",
+					"conversations.history",
+				},
+			}},
 			Cron:     "0 2 * * *",
 			Timezone: "UTC",
 		}
@@ -2694,6 +2714,10 @@ server:
 					},
 				},
 			},
+			Permissions: []core.AccessPermission{{
+				Plugin:     "slack",
+				Operations: []string{"chat.postMessage"},
+			}},
 			Match: WorkflowEventMatch{
 				Type:   "roadmap.task.updated",
 				Source: "roadmap",
@@ -2734,6 +2758,66 @@ server:
   encryptionKey: server-key
 `,
 				want: `workflows.schedules.nightly.target.plugin.name references unknown plugin "missing"`,
+			},
+			{
+				name: "unknown schedule permission plugin",
+				yaml: `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+workflows:
+  schedules:
+    nightly:
+      provider: temporal
+      cron: "0 2 * * *"
+      target:
+        plugin:
+          name: roadmap
+          operation: nightly_sync
+      permissions:
+        - plugin: missing
+          operations: [conversations.list]
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+server:
+  encryptionKey: server-key
+`,
+				want: `workflows.schedules.nightly.permissions[0].plugin references unknown plugin "missing"`,
+			},
+			{
+				name: "schedule permission requires operations",
+				yaml: `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+  slack:
+    source:
+      path: ./providers/slack/manifest.yaml
+workflows:
+  schedules:
+    nightly:
+      provider: temporal
+      cron: "0 2 * * *"
+      target:
+        plugin:
+          name: roadmap
+          operation: nightly_sync
+      permissions:
+        - plugin: slack
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+server:
+  encryptionKey: server-key
+`,
+				want: `workflows.schedules.nightly.permissions[0].operations is required`,
 			},
 			{
 				name: "event trigger agent missing provider",

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	cronv3 "github.com/robfig/cron/v3"
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/s3"
@@ -1157,6 +1158,11 @@ func validateWorkflowsConfig(cfg *Config) error {
 			if err := validateWorkflowScheduleTarget(cfg, key, &schedule); err != nil {
 				return err
 			}
+			permissions, err := normalizeWorkflowExecutionPermissions(cfg, "workflows.schedules."+key+".permissions", schedule.Permissions)
+			if err != nil {
+				return err
+			}
+			schedule.Permissions = permissions
 			schedule.Provider = strings.TrimSpace(schedule.Provider)
 			providerName, _, err := cfg.EffectiveWorkflowProvider(schedule.Provider)
 			if err != nil {
@@ -1198,6 +1204,11 @@ func validateWorkflowsConfig(cfg *Config) error {
 			if err := validateWorkflowEventTriggerTarget(cfg, key, &trigger); err != nil {
 				return err
 			}
+			permissions, err := normalizeWorkflowExecutionPermissions(cfg, "workflows.eventTriggers."+key+".permissions", trigger.Permissions)
+			if err != nil {
+				return err
+			}
+			trigger.Permissions = permissions
 			trigger.Provider = strings.TrimSpace(trigger.Provider)
 			providerName, _, err := cfg.EffectiveWorkflowProvider(trigger.Provider)
 			if err != nil {
@@ -1251,6 +1262,64 @@ func validateWorkflowEventTriggerTarget(cfg *Config, key string, trigger *Workfl
 		return nil
 	}
 	return validateWorkflowAgentConfig(cfg, targetPath+".agent", trigger.Target.Agent)
+}
+
+func normalizeWorkflowExecutionPermissions(cfg *Config, path string, values []core.AccessPermission) ([]core.AccessPermission, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make([]core.AccessPermission, 0, len(values))
+	pluginIndexes := make(map[string]int, len(values))
+	seenOperations := make(map[string]map[string]struct{}, len(values))
+	for i, value := range values {
+		plugin := strings.TrimSpace(value.Plugin)
+		if plugin == "" {
+			return nil, fmt.Errorf("config validation: %s[%d].plugin is required", path, i)
+		}
+		if _, ok := cfg.Plugins[plugin]; !ok {
+			return nil, fmt.Errorf("config validation: %s[%d].plugin references unknown plugin %q", path, i, plugin)
+		}
+		if len(value.Actions) > 0 {
+			return nil, fmt.Errorf("config validation: %s[%d].actions is not supported", path, i)
+		}
+		operations, err := normalizeWorkflowExecutionPermissionNames(fmt.Sprintf("%s[%d].operations", path, i), value.Operations)
+		if err != nil {
+			return nil, err
+		}
+		if len(operations) == 0 {
+			return nil, fmt.Errorf("config validation: %s[%d].operations is required", path, i)
+		}
+		idx, ok := pluginIndexes[plugin]
+		if !ok {
+			idx = len(out)
+			pluginIndexes[plugin] = idx
+			seenOperations[plugin] = map[string]struct{}{}
+			out = append(out, core.AccessPermission{Plugin: plugin})
+		}
+		for _, operation := range operations {
+			if _, exists := seenOperations[plugin][operation]; exists {
+				continue
+			}
+			seenOperations[plugin][operation] = struct{}{}
+			out[idx].Operations = append(out[idx].Operations, operation)
+		}
+	}
+	return out, nil
+}
+
+func normalizeWorkflowExecutionPermissionNames(path string, values []string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(values))
+	for i, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil, fmt.Errorf("config validation: %s[%d] is required", path, i)
+		}
+		out = append(out, value)
+	}
+	return out, nil
 }
 
 func normalizeWorkflowTarget(path string, target *WorkflowTargetConfig) error {


### PR DESCRIPTION
## Summary

Adds first-class execution permissions for config-managed workflows:

```yaml
workflows:
  schedules:
    brain_slack_sync:
      provider: local
      cron: "*/15 * * * *"
      target:
        plugin:
          name: brain
          operation: sources.sync
          input:
            sourceId: slack-valon-public
      permissions:
        - plugin: slack
          operations:
            - conversations.list
            - conversations.history
            - conversations.replies
            - users.info

  eventTriggers:
    brain_event_sync:
      provider: local
      match:
        type: brain.source.requested
      target:
        plugin:
          name: brain
          operation: sources.sync
      permissions:
        - plugin: gong
          operations:
            - calls.list
            - calls.transcript
```

Behavior:

- Gestalt still grants the direct target operation automatically, e.g. `brain.sources.sync`.
- `permissions` grants additional plugin-operation scopes to the config-owned execution principal for nested calls made by the target.
- `permissions` does not select or grant credentials. Nested calls still resolve credentials through the invoked plugin operation's normal connection.
- Config-owned direct targets, agent tools, and output delivery targets must resolve to non-user credentials. Explicit platform connections on mixed/user-default plugins are supported.
- Config validation normalizes/dedupes permissions, rejects unknown plugins, rejects empty operation grants, and rejects action grants for workflow execution permissions.
- Execution refs are reconciled when these permissions change, so workflow providers pick up the new scope set and stale refs are revoked.

## Why

A config-owned cron targeting `brain.sources.sync` currently receives only `brain.sources.sync`. When Brain invokes Slack or Gong through the plugin invoker, the broker evaluates the same execution principal and denies `slack.*`/`gong.*` before credential resolution. Platform-backed credentials are therefore not enough; the execution principal needs explicit operation scope for nested plugin calls.

This PR avoids the unsafe alternative of auto-granting every operation listed in `plugins.brain.invokes`. A Slack sync cron can grant only Slack operations, while a Gong sync cron can grant only Gong operations. Credential selection stays owned by the provider connection model.

## Validation

```sh
go test ./internal/config ./internal/bootstrap ./services/workflows/...
git diff --check
```
