### PR TITLE
[codex] Harden network egress boundaries

### DIFF
--- a/gestaltd/internal/mcpoauth/discovery.go
+++ b/gestaltd/internal/mcpoauth/discovery.go
@@ -15,6 +15,14 @@ import (
 
 const discoveryTimeout = 10 * time.Second
 
+type DiscoverOption func(*discoveryPolicy)
+
+func withInsecureLocalDiscovery() DiscoverOption {
+	return func(policy *discoveryPolicy) {
+		policy.allowInsecureLocal = true
+	}
+}
+
 type DiscoveredMetadata struct {
 	AuthServerURL                 string
 	AuthorizationEndpoint         string
@@ -65,27 +73,36 @@ func (m *DiscoveredMetadata) PreferredAuthMethod() string {
 // Discover probes an MCP server to find its OAuth endpoints. Handles both
 // RFC 9728 indirection (authorization_servers) and servers that embed
 // endpoints directly in resource metadata (ClickHouse).
-func Discover(ctx context.Context, mcpURL string) (*DiscoveredMetadata, error) {
-	client, closeIdleConnections := newHTTPClient(discoveryTimeout)
+func Discover(ctx context.Context, mcpURL string, opts ...DiscoverOption) (*DiscoveredMetadata, error) {
+	var policy discoveryPolicy
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&policy)
+		}
+	}
+	client, closeIdleConnections := newHTTPClient(discoveryTimeout, policy)
 	defer closeIdleConnections()
 
-	resourceMetadataURL, err := probeForResourceMetadata(ctx, client, mcpURL)
+	resourceMetadataURL, err := probeForResourceMetadata(ctx, client, mcpURL, policy)
 	if err != nil {
 		return nil, fmt.Errorf("mcpoauth discovery: probing %s: %w", mcpURL, err)
 	}
 
-	resourceMeta, err := fetchJSON(ctx, client, resourceMetadataURL)
+	resourceMeta, err := fetchJSON(ctx, client, resourceMetadataURL, policy)
 	if err != nil {
 		return nil, fmt.Errorf("mcpoauth discovery: fetching resource metadata from %s: %w", resourceMetadataURL, err)
 	}
 
-	return resolveMetadata(ctx, client, resourceMeta)
+	return resolveMetadata(ctx, client, resourceMeta, policy)
 }
 
 // probeForResourceMetadata sends an unauthenticated request to the MCP URL and
 // looks for a resource_metadata URL in the WWW-Authenticate header. Falls back
 // to constructing the .well-known URL from the MCP URL's origin.
-func probeForResourceMetadata(ctx context.Context, client *http.Client, mcpURL string) (string, error) {
+func probeForResourceMetadata(ctx context.Context, client *http.Client, mcpURL string, policy discoveryPolicy) (string, error) {
+	if err := validateDiscoveryURL(ctx, mcpURL, policy); err != nil {
+		return "", err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, mcpURL, strings.NewReader(`{"jsonrpc":"2.0","method":"initialize","id":1}`))
 	if err != nil {
 		return "", fmt.Errorf("creating probe request: %w", err)
@@ -138,7 +155,7 @@ func wellKnownResourceMetadataURL(mcpURL string) (string, error) {
 	return wellKnown.String(), nil
 }
 
-func resolveMetadata(ctx context.Context, client *http.Client, resourceMeta map[string]any) (*DiscoveredMetadata, error) {
+func resolveMetadata(ctx context.Context, client *http.Client, resourceMeta map[string]any, policy discoveryPolicy) (*DiscoveredMetadata, error) {
 	md := &DiscoveredMetadata{}
 
 	// Try RFC 9728 indirection: authorization_servers -> AS metadata
@@ -146,7 +163,7 @@ func resolveMetadata(ctx context.Context, client *http.Client, resourceMeta map[
 		serverURL, _ := servers[0].(string)
 		if serverURL != "" {
 			md.AuthServerURL = serverURL
-			asMeta, err := fetchASMetadata(ctx, client, serverURL)
+			asMeta, err := fetchASMetadata(ctx, client, serverURL, policy)
 			if err != nil {
 				return nil, fmt.Errorf("fetching AS metadata from %s: %w", serverURL, err)
 			}
@@ -184,6 +201,18 @@ func resolveMetadata(ctx context.Context, client *http.Client, resourceMeta map[
 	if md.AuthorizationEndpoint == "" || md.TokenEndpoint == "" {
 		return nil, fmt.Errorf("discovery did not find authorization_endpoint and token_endpoint")
 	}
+	for name, endpoint := range map[string]string{
+		"authorization_endpoint": md.AuthorizationEndpoint,
+		"token_endpoint":         md.TokenEndpoint,
+		"registration_endpoint":  md.RegistrationEndpoint,
+	} {
+		if endpoint == "" {
+			continue
+		}
+		if err := validateDiscoveryURL(ctx, endpoint, policy); err != nil {
+			return nil, fmt.Errorf("%s is not a safe discovery URL: %w", name, err)
+		}
+	}
 
 	// Derive AuthServerURL from the authorization endpoint origin when not
 	// set via the authorization_servers field.
@@ -196,7 +225,7 @@ func resolveMetadata(ctx context.Context, client *http.Client, resourceMeta map[
 	return md, nil
 }
 
-func fetchASMetadata(ctx context.Context, client *http.Client, serverURL string) (map[string]any, error) {
+func fetchASMetadata(ctx context.Context, client *http.Client, serverURL string, policy discoveryPolicy) (map[string]any, error) {
 	u, err := url.Parse(serverURL)
 	if err != nil {
 		return nil, fmt.Errorf("parsing AS URL: %w", err)
@@ -207,7 +236,7 @@ func fetchASMetadata(ctx context.Context, client *http.Client, serverURL string)
 		Host:   u.Host,
 		Path:   "/.well-known/oauth-authorization-server" + u.Path,
 	}
-	return fetchJSON(ctx, client, wellKnown.String())
+	return fetchJSON(ctx, client, wellKnown.String(), policy)
 }
 
 func populateFromASMetadata(md *DiscoveredMetadata, asMeta map[string]any) {
@@ -225,7 +254,10 @@ func populateFromASMetadata(md *DiscoveredMetadata, asMeta map[string]any) {
 	md.TokenEndpointAuthMethods = stringSlice(asMeta, "token_endpoint_auth_methods_supported")
 }
 
-func fetchJSON(ctx context.Context, client *http.Client, rawURL string) (map[string]any, error) {
+func fetchJSON(ctx context.Context, client *http.Client, rawURL string, policy discoveryPolicy) (map[string]any, error) {
+	if err := validateDiscoveryURL(ctx, rawURL, policy); err != nil {
+		return nil, err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request for %s: %w", rawURL, err)

--- a/gestaltd/internal/mcpoauth/discovery_test.go
+++ b/gestaltd/internal/mcpoauth/discovery_test.go
@@ -1,0 +1,67 @@
+package mcpoauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/services/egress"
+)
+
+func TestDiscoverRejectsHTTPWithoutLocalOptIn(t *testing.T) {
+	t.Parallel()
+
+	_, err := Discover(context.Background(), "http://example.com/mcp")
+	if err == nil {
+		t.Fatal("expected HTTP discovery to be rejected")
+	}
+	if !strings.Contains(err.Error(), "must use https") {
+		t.Fatalf("Discover error = %v, want HTTPS requirement", err)
+	}
+}
+
+func TestDiscoverRejectsUnsafeAdvertisedMetadataURL(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="https://169.254.169.254/.well-known/oauth-protected-resource/mcp"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	_, err := Discover(context.Background(), srv.URL+"/mcp", withInsecureLocalDiscovery())
+	if !errors.Is(err, egress.ErrUnsafeDestination) {
+		t.Fatalf("Discover error = %v, want ErrUnsafeDestination", err)
+	}
+}
+
+func TestDiscoverRejectsUnsafeAuthorizationServerURL(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /mcp", func(w http.ResponseWriter, r *http.Request) {
+		baseURL := "http://" + r.Host
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(
+			`Bearer resource_metadata="%s/.well-known/oauth-protected-resource/mcp"`, baseURL))
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"authorization_servers": []string{"https://169.254.169.254"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	testutil.CloseOnCleanup(t, srv)
+
+	_, err := Discover(context.Background(), srv.URL+"/mcp", withInsecureLocalDiscovery())
+	if !errors.Is(err, egress.ErrUnsafeDestination) {
+		t.Fatalf("Discover error = %v, want ErrUnsafeDestination", err)
+	}
+}

--- a/gestaltd/internal/mcpoauth/handler.go
+++ b/gestaltd/internal/mcpoauth/handler.go
@@ -18,6 +18,10 @@ type HandlerConfig struct {
 	MCPURL      string
 	Store       RegistrationStore // nil for non-SQL deployments
 	RedirectURL string
+	// AllowInsecureLocalDiscovery permits http:// loopback MCP OAuth discovery
+	// for local development and tests. Production discovery remains HTTPS-only
+	// and public-address-only by default.
+	AllowInsecureLocalDiscovery bool
 
 	// Static overrides: if set, skip DCR and use these directly.
 	ClientID     string
@@ -50,7 +54,11 @@ func (h *Handler) ensure() (*oauth.UpstreamHandler, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	md, err := Discover(ctx, h.cfg.MCPURL)
+	var discoverOpts []DiscoverOption
+	if h.cfg.AllowInsecureLocalDiscovery {
+		discoverOpts = append(discoverOpts, withInsecureLocalDiscovery())
+	}
+	md, err := Discover(ctx, h.cfg.MCPURL, discoverOpts...)
 	if err != nil {
 		if h.upstream != nil {
 			return h.upstream, nil
@@ -97,6 +105,7 @@ func (h *Handler) ensure() (*oauth.UpstreamHandler, error) {
 		authMethod = oauth.ClientAuthBody
 	}
 
+	oauthClient, _ := newHTTPClient(discoveryTimeout, h.discoveryPolicy())
 	upstream := oauth.NewUpstream(oauth.UpstreamConfig{
 		ClientID:         clientID,
 		ClientSecret:     clientSecret,
@@ -106,7 +115,7 @@ func (h *Handler) ensure() (*oauth.UpstreamHandler, error) {
 		ClientAuthMethod: authMethod,
 		PKCE:             md.SupportsPKCE(),
 		DefaultScopes:    md.ScopesSupported,
-	})
+	}, oauth.WithHTTPClient(oauthClient))
 
 	h.upstream = upstream
 	h.metadata = md
@@ -140,7 +149,7 @@ func (h *Handler) resolveRegistration(ctx context.Context, md *DiscoveredMetadat
 		slog.Info("mcpoauth: re-registering (expired)", "auth_server", authServerURL)
 	}
 
-	reg, err := RegisterClient(ctx, md.RegistrationEndpoint, h.cfg.RedirectURL, "Gestalt", md.PreferredAuthMethod())
+	reg, err := registerClient(ctx, md.RegistrationEndpoint, h.cfg.RedirectURL, "Gestalt", md.PreferredAuthMethod(), h.discoveryPolicy())
 	if err != nil {
 		if existing != nil {
 			slog.Warn("mcpoauth: re-registration failed, using existing", "auth_server", authServerURL, "error", err)
@@ -165,6 +174,10 @@ func (h *Handler) resolveRegistration(ctx context.Context, md *DiscoveredMetadat
 	}
 
 	return reg, nil
+}
+
+func (h *Handler) discoveryPolicy() discoveryPolicy {
+	return discoveryPolicy{allowInsecureLocal: h.cfg.AllowInsecureLocalDiscovery}
 }
 
 func (h *Handler) ClearRegistration() {

--- a/gestaltd/internal/mcpoauth/http_client.go
+++ b/gestaltd/internal/mcpoauth/http_client.go
@@ -1,16 +1,75 @@
 package mcpoauth
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/services/egress"
 )
 
-func newHTTPClient(timeout time.Duration) (*http.Client, func()) {
+type discoveryPolicy struct {
+	allowInsecureLocal bool
+}
+
+func newHTTPClient(timeout time.Duration, policy discoveryPolicy) (*http.Client, func()) {
 	transport := egress.CloneDefaultTransport()
+	transport.Proxy = nil
+	transport.DialContext = egress.SafeDialContext(destinationPolicy(policy))
+	checkRedirect := func(req *http.Request, via []*http.Request) error {
+		if req == nil || req.URL == nil {
+			return nil
+		}
+		if err := validateDiscoveryURL(req.Context(), req.URL.String(), policy); err != nil {
+			return err
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		return nil
+	}
 	return &http.Client{
-		Timeout:   timeout,
-		Transport: transport,
+		Timeout:       timeout,
+		Transport:     transport,
+		CheckRedirect: checkRedirect,
 	}, transport.CloseIdleConnections
+}
+
+func destinationPolicy(policy discoveryPolicy) egress.DestinationPolicy {
+	return egress.DestinationPolicy{AllowLoopback: policy.allowInsecureLocal}
+}
+
+func validateDiscoveryURL(ctx context.Context, rawURL string, policy discoveryPolicy) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parsing discovery URL: %w", err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("discovery URL %q is missing host", rawURL)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https":
+	case "http":
+		if !policy.allowInsecureLocal || !egress.IsLocalhostName(u.Hostname()) {
+			return fmt.Errorf("discovery URL %q must use https", rawURL)
+		}
+	default:
+		return fmt.Errorf("discovery URL %q must use https", rawURL)
+	}
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "http" {
+			port = "80"
+		} else {
+			port = "443"
+		}
+	}
+	if _, err := egress.ResolveSafeTCPAddr(ctx, "tcp", net.JoinHostPort(u.Hostname(), port), destinationPolicy(policy)); err != nil {
+		return err
+	}
+	return nil
 }

--- a/gestaltd/internal/mcpoauth/mcpoauth_test.go
+++ b/gestaltd/internal/mcpoauth/mcpoauth_test.go
@@ -117,9 +117,10 @@ func TestMCPOAuthFlow(t *testing.T) {
 
 		store := &memStore{regs: make(map[string]*mcpoauth.Registration)}
 		handler := mcpoauth.NewHandler(mcpoauth.HandlerConfig{
-			MCPURL:      srv.URL + "/mcp",
-			Store:       store,
-			RedirectURL: "http://localhost:9999/callback",
+			MCPURL:                      srv.URL + "/mcp",
+			Store:                       store,
+			RedirectURL:                 "http://localhost:9999/callback",
+			AllowInsecureLocalDiscovery: true,
 		})
 
 		authURL, verifier := handler.StartOAuth("test-state", nil)
@@ -219,9 +220,10 @@ func TestMCPOAuthFlow(t *testing.T) {
 
 		store := &memStore{regs: make(map[string]*mcpoauth.Registration)}
 		handler := mcpoauth.NewHandler(mcpoauth.HandlerConfig{
-			MCPURL:      srv.URL + "/mcp",
-			Store:       store,
-			RedirectURL: "http://localhost:9999/callback",
+			MCPURL:                      srv.URL + "/mcp",
+			Store:                       store,
+			RedirectURL:                 "http://localhost:9999/callback",
+			AllowInsecureLocalDiscovery: true,
 		})
 
 		authURL, verifier := handler.StartOAuth("test-state", nil)
@@ -289,8 +291,9 @@ func TestMCPOAuthFlow(t *testing.T) {
 		testutil.CloseOnCleanup(t, srv)
 
 		handler := mcpoauth.NewHandler(mcpoauth.HandlerConfig{
-			MCPURL:      srv.URL + "/mcp",
-			RedirectURL: "http://localhost:9999/callback",
+			MCPURL:                      srv.URL + "/mcp",
+			RedirectURL:                 "http://localhost:9999/callback",
+			AllowInsecureLocalDiscovery: true,
 		})
 
 		authURL, verifier := handler.StartOAuth("test-state", nil)
@@ -365,9 +368,10 @@ func TestMCPOAuthFlow(t *testing.T) {
 
 		store := &memStore{regs: make(map[string]*mcpoauth.Registration)}
 		handler := mcpoauth.NewHandler(mcpoauth.HandlerConfig{
-			MCPURL:      srv.URL + "/mcp",
-			Store:       store,
-			RedirectURL: "http://localhost:9999/callback",
+			MCPURL:                      srv.URL + "/mcp",
+			Store:                       store,
+			RedirectURL:                 "http://localhost:9999/callback",
+			AllowInsecureLocalDiscovery: true,
 		})
 
 		authURL1, _ := handler.StartOAuth("s1", nil)
@@ -427,8 +431,9 @@ func TestMCPOAuthFlow(t *testing.T) {
 		testutil.CloseOnCleanup(t, srv)
 
 		handler := mcpoauth.NewHandler(mcpoauth.HandlerConfig{
-			MCPURL:      srv.URL + "/mcp",
-			RedirectURL: "http://localhost:9999/callback",
+			MCPURL:                      srv.URL + "/mcp",
+			RedirectURL:                 "http://localhost:9999/callback",
+			AllowInsecureLocalDiscovery: true,
 		})
 
 		defaultTransport, ok := http.DefaultTransport.(*http.Transport)

--- a/gestaltd/internal/mcpoauth/registration.go
+++ b/gestaltd/internal/mcpoauth/registration.go
@@ -30,6 +30,10 @@ func (r *Registration) Expired() bool {
 }
 
 func RegisterClient(ctx context.Context, endpoint, redirectURI, clientName, tokenAuthMethod string) (*Registration, error) {
+	return registerClient(ctx, endpoint, redirectURI, clientName, tokenAuthMethod, discoveryPolicy{})
+}
+
+func registerClient(ctx context.Context, endpoint, redirectURI, clientName, tokenAuthMethod string, policy discoveryPolicy) (*Registration, error) {
 	if tokenAuthMethod == "" {
 		tokenAuthMethod = "none"
 	}
@@ -46,13 +50,16 @@ func RegisterClient(ctx context.Context, endpoint, redirectURI, clientName, toke
 		return nil, fmt.Errorf("encoding DCR request: %w", err)
 	}
 
+	if err := validateDiscoveryURL(ctx, endpoint, policy); err != nil {
+		return nil, err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("creating DCR request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client, closeIdleConnections := newHTTPClient(discoveryTimeout)
+	client, closeIdleConnections := newHTTPClient(discoveryTimeout, policy)
 	defer closeIdleConnections()
 	resp, err := client.Do(req)
 	if err != nil {

--- a/gestaltd/internal/pluginruntime/dial.go
+++ b/gestaltd/internal/pluginruntime/dial.go
@@ -5,7 +5,9 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"net/netip"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -20,6 +22,8 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+const allowInsecureRemotePluginTCPEnv = "GESTALTD_ALLOW_INSECURE_REMOTE_PLUGIN_TCP"
 
 type dialedHostedPluginConn struct {
 	conn      *grpc.ClientConn
@@ -259,6 +263,9 @@ func dialUnixTarget(ctx context.Context, socket string, cfg dialConfig) (*grpc.C
 }
 
 func dialTCPTarget(address string, cfg dialConfig) (*grpc.ClientConn, error) {
+	if err := validatePlaintextTCPTarget(address); err != nil {
+		return nil, err
+	}
 	conn, err := grpc.NewClient(
 		address,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -269,6 +276,31 @@ func dialTCPTarget(address string, cfg dialConfig) (*grpc.ClientConn, error) {
 	}
 	conn.Connect()
 	return conn, nil
+}
+
+func validatePlaintextTCPTarget(address string) error {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(address))
+	if err != nil {
+		return fmt.Errorf("parse hosted plugin tcp dial target %q: %w", address, err)
+	}
+	if isLoopbackDialHost(host) {
+		return nil
+	}
+	if strings.EqualFold(strings.TrimSpace(os.Getenv(allowInsecureRemotePluginTCPEnv)), "true") || os.Getenv(allowInsecureRemotePluginTCPEnv) == "1" {
+		return nil
+	}
+	return fmt.Errorf("hosted plugin tcp dial target %q uses plaintext TCP for a non-loopback host; use tls:// or set %s=1 for local development", address, allowInsecureRemotePluginTCPEnv)
+}
+
+func isLoopbackDialHost(host string) bool {
+	host = strings.TrimSpace(host)
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
+	if strings.EqualFold(strings.TrimSuffix(host, "."), "localhost") {
+		return true
+	}
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.Unmap().IsLoopback()
 }
 
 func dialTLSTarget(address string, cfg dialConfig) (*grpc.ClientConn, error) {

--- a/gestaltd/internal/pluginruntime/dial_test.go
+++ b/gestaltd/internal/pluginruntime/dial_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
@@ -15,6 +16,37 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+func TestValidatePlaintextTCPTargetRefusesNonLoopback(t *testing.T) {
+	t.Setenv(allowInsecureRemotePluginTCPEnv, "")
+
+	err := validatePlaintextTCPTarget("192.0.2.10:443")
+	if err == nil {
+		t.Fatal("expected non-loopback plaintext TCP target to be refused")
+	}
+	if want := allowInsecureRemotePluginTCPEnv; !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want opt-in env %s", err, want)
+	}
+}
+
+func TestValidatePlaintextTCPTargetAllowsLoopback(t *testing.T) {
+	t.Parallel()
+
+	if err := validatePlaintextTCPTarget("127.0.0.1:50051"); err != nil {
+		t.Fatalf("validatePlaintextTCPTarget loopback: %v", err)
+	}
+	if err := validatePlaintextTCPTarget("[::1]:50051"); err != nil {
+		t.Fatalf("validatePlaintextTCPTarget IPv6 loopback: %v", err)
+	}
+}
+
+func TestValidatePlaintextTCPTargetAllowsExplicitDevOptIn(t *testing.T) {
+	t.Setenv(allowInsecureRemotePluginTCPEnv, "1")
+
+	if err := validatePlaintextTCPTarget("192.0.2.10:443"); err != nil {
+		t.Fatalf("validatePlaintextTCPTarget with opt-in: %v", err)
+	}
+}
 
 func TestDialHostedPluginRecordsRPCClientDurationWithTelemetryAttrs(t *testing.T) {
 	t.Parallel()

--- a/gestaltd/internal/server/egress_proxy.go
+++ b/gestaltd/internal/server/egress_proxy.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"context"
 	"encoding/base64"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -15,6 +17,10 @@ const (
 	proxyAuthorizationHeader = "Proxy-Authorization"
 	egressProxyDialTimeout   = 10 * time.Second
 )
+
+type egressProxyRequestPolicy struct {
+	destination egress.DestinationPolicy
+}
 
 func (s *Server) egressProxyMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -33,17 +39,30 @@ func (s *Server) egressProxyMiddleware(next http.Handler) http.Handler {
 			http.Error(w, "invalid egress proxy token", http.StatusProxyAuthRequired)
 			return
 		}
-		host := proxyTargetHost(r)
-		if host == "" {
+		endpoint, err := proxyTargetEndpoint(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if endpoint.host == "" {
 			http.Error(w, "proxy target host is required", http.StatusBadRequest)
 			return
 		}
-		if err := egress.CheckHost(target.AllowedHosts, host, target.DefaultAction); err != nil {
+		if err := egress.CheckEndpoint(target.AllowedHosts, endpoint.hostport(), target.DefaultAction, endpoint.defaultPort); err != nil {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
+		requestPolicy := egressProxyRequestPolicy{
+			destination: egress.DestinationPolicy{
+				AllowLoopback: proxyTargetAllowsExplicitLoopback(target.AllowedHosts, endpoint.host),
+			},
+		}
+		if err := egress.RejectUnsafeHostLiteral(endpoint.host, requestPolicy.destination); err != nil {
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 
-		newEgressProxyHandler().ServeHTTP(w, r)
+		newEgressProxyHandler(requestPolicy).ServeHTTP(w, r)
 	})
 }
 
@@ -64,26 +83,54 @@ func isEgressProxyRequest(r *http.Request) bool {
 	return r.URL != nil && r.URL.IsAbs()
 }
 
-func proxyTargetHost(r *http.Request) string {
-	if r == nil {
-		return ""
+type proxyEndpoint struct {
+	host        string
+	port        string
+	defaultPort string
+}
+
+func (e proxyEndpoint) hostport() string {
+	if e.port == "" {
+		return e.host
 	}
-	var host string
+	return net.JoinHostPort(e.host, e.port)
+}
+
+func proxyTargetEndpoint(r *http.Request) (proxyEndpoint, error) {
+	if r == nil {
+		return proxyEndpoint{}, nil
+	}
+	var host, port, defaultPort string
 	switch {
 	case r.Method == http.MethodConnect:
-		host = strings.TrimSpace(r.Host)
+		host, port = splitProxyHostPort(strings.TrimSpace(r.Host))
+		defaultPort = "443"
 	case r.URL != nil && r.URL.Host != "":
 		host = strings.TrimSpace(r.URL.Hostname())
+		port = strings.TrimSpace(r.URL.Port())
+		defaultPort = defaultPortForScheme(r.URL.Scheme)
 	default:
-		host = strings.TrimSpace(r.Host)
+		host, port = splitProxyHostPort(strings.TrimSpace(r.Host))
+		defaultPort = "80"
 	}
 	if host == "" {
-		return ""
+		return proxyEndpoint{}, nil
 	}
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		return h
+	if port == "" {
+		resolvedHost, resolvedPort, err := egress.SplitHostPortDefault(host, defaultPort)
+		if err != nil {
+			return proxyEndpoint{}, err
+		}
+		host, port = resolvedHost, resolvedPort
 	}
-	return host
+	if _, _, err := egress.SplitHostPortDefault(net.JoinHostPort(host, port), defaultPort); err != nil {
+		return proxyEndpoint{}, err
+	}
+	return proxyEndpoint{
+		host:        strings.TrimSpace(host),
+		port:        port,
+		defaultPort: defaultPort,
+	}, nil
 }
 
 func extractProxyAuthorizationToken(header string) string {
@@ -108,18 +155,65 @@ func extractProxyAuthorizationToken(header string) string {
 	return ""
 }
 
-func newEgressProxyHandler() http.Handler {
+func splitProxyHostPort(hostport string) (string, string) {
+	if h, p, err := net.SplitHostPort(hostport); err == nil {
+		return h, p
+	}
+	return hostport, ""
+}
+
+func defaultPortForScheme(scheme string) string {
+	switch strings.ToLower(strings.TrimSpace(scheme)) {
+	case "https":
+		return "443"
+	default:
+		return "80"
+	}
+}
+
+func proxyTargetAllowsExplicitLoopback(allowedHosts []string, host string) bool {
+	if !egress.IsLocalhostName(host) {
+		return false
+	}
+	for _, allowed := range allowedHosts {
+		allowedHost, _, _, err := splitAllowedProxyHost(allowed)
+		if err == nil && egress.IsLocalhostName(allowedHost) {
+			return true
+		}
+	}
+	return false
+}
+
+func splitAllowedProxyHost(pattern string) (string, string, bool, error) {
+	u := &url.URL{Host: strings.TrimSpace(pattern)}
+	host := u.Hostname()
+	port := u.Port()
+	if host == "" {
+		host, port = splitProxyHostPort(pattern)
+	}
+	if port == "" {
+		return host, "", false, nil
+	}
+	if _, _, err := egress.SplitHostPortDefault(net.JoinHostPort(host, port), ""); err != nil {
+		return "", "", false, err
+	}
+	return host, port, true, nil
+}
+
+func newEgressProxyHandler(policy egressProxyRequestPolicy) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodConnect {
-			handleEgressProxyConnect(w, r)
+			handleEgressProxyConnect(w, r, policy)
 			return
 		}
-		handleEgressProxyHTTP(w, r)
+		handleEgressProxyHTTP(w, r, policy)
 	})
 }
 
-func handleEgressProxyHTTP(w http.ResponseWriter, r *http.Request) {
-	transport := &http.Transport{}
+func handleEgressProxyHTTP(w http.ResponseWriter, r *http.Request, policy egressProxyRequestPolicy) {
+	transport := egress.CloneDefaultTransport()
+	transport.Proxy = nil
+	transport.DialContext = egress.SafeDialContext(policy.destination)
 	defer transport.CloseIdleConnections()
 
 	out := r.Clone(r.Context())
@@ -148,7 +242,7 @@ func handleEgressProxyHTTP(w http.ResponseWriter, r *http.Request) {
 	_, _ = io.Copy(w, resp.Body)
 }
 
-func handleEgressProxyConnect(w http.ResponseWriter, r *http.Request) {
+func handleEgressProxyConnect(w http.ResponseWriter, r *http.Request, policy egressProxyRequestPolicy) {
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
 		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
@@ -164,8 +258,15 @@ func handleEgressProxyConnect(w http.ResponseWriter, r *http.Request) {
 		targetAddr = net.JoinHostPort(targetAddr, "443")
 	}
 
+	ctx, cancel := context.WithTimeout(r.Context(), egressProxyDialTimeout)
+	defer cancel()
+	safeTargetAddr, err := egress.ResolveSafeTCPAddr(ctx, "tcp", targetAddr, policy.destination)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
 	var dialer net.Dialer
-	targetConn, err := dialer.DialContext(r.Context(), "tcp", targetAddr)
+	targetConn, err := dialer.DialContext(ctx, "tcp", safeTargetAddr)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1743,6 +1743,107 @@ func TestEgressProxyRejectsDisallowedHost(t *testing.T) {
 	}
 }
 
+func TestEgressProxyRejectsDisallowedConnectPort(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	proxy := httptest.NewTLSServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+	}))
+	testutil.CloseOnCleanup(t, proxy)
+
+	tokenManager, err := egressproxy.NewTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	token, err := tokenManager.MintToken(egressproxy.TokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-1",
+		AllowedHosts: []string{"api.github.com"},
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("Parse proxy URL: %v", err)
+	}
+	conn, err := tls.Dial("tcp", proxyURL.Host, &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12})
+	if err != nil {
+		t.Fatalf("Dial proxy: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	authHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte("gestalt-egress-proxy:"+token))
+	targetAddr := "api.github.com:22"
+	request := fmt.Sprintf(
+		"CONNECT %s HTTP/1.1\r\nHost: %s\r\nProxy-Authorization: %s\r\n\r\n",
+		targetAddr,
+		targetAddr,
+		authHeader,
+	)
+	if _, err := conn.Write([]byte(request)); err != nil {
+		t.Fatalf("Write CONNECT request: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("ReadResponse: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("proxy status = %d, want %d (body=%s)", resp.StatusCode, http.StatusForbidden, string(body))
+	}
+	if !strings.Contains(string(body), "egress denied") {
+		t.Fatalf("proxy body = %q, want egress denied", string(body))
+	}
+}
+
+func TestEgressProxyRejectsUnsafeIPLiteral(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	proxy := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+	}))
+	proxy.EnableHTTP2 = true
+	proxy.StartTLS()
+	testutil.CloseOnCleanup(t, proxy)
+
+	proxyURL := mustEgressProxyURL(t, proxy.URL, secret, egressproxy.TokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-1",
+		AllowedHosts: []string{"169.254.169.254"},
+	})
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
+		},
+	}
+	resp, err := client.Get("http://169.254.169.254/latest/meta-data")
+	if err != nil {
+		t.Fatalf("GET unsafe IP via egress proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("proxy status = %d, want %d (body=%s)", resp.StatusCode, http.StatusForbidden, string(body))
+	}
+	if !strings.Contains(string(body), "egress unsafe destination") {
+		t.Fatalf("proxy body = %q, want unsafe destination", string(body))
+	}
+}
+
 func TestEgressProxySupportsHTTPSConnect(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/egress/destination.go
+++ b/gestaltd/services/egress/destination.go
@@ -1,0 +1,177 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+)
+
+// DestinationPolicy controls the narrow local-development exceptions allowed
+// by safe outbound dialing. Metadata addresses are always denied.
+type DestinationPolicy struct {
+	AllowLoopback  bool
+	AllowPrivate   bool
+	AllowLinkLocal bool
+}
+
+var (
+	// ErrUnsafeDestination is returned when a destination resolves to an
+	// internal, loopback, link-local, metadata, or otherwise unroutable address.
+	ErrUnsafeDestination = errors.New("egress unsafe destination")
+
+	awsMetadataIPv4     = netip.MustParseAddr("169.254.169.254")
+	awsMetadataIPv6     = netip.MustParseAddr("fd00:ec2::254")
+	alibabaMetadataIPv4 = netip.MustParseAddr("100.100.100.200")
+	carrierGradeNATIPv4 = netip.MustParsePrefix("100.64.0.0/10")
+)
+
+// IsLocalhostName reports whether host is an explicit localhost or loopback
+// literal. It intentionally does not resolve arbitrary names.
+func IsLocalhostName(host string) bool {
+	host = normalizeHost(host)
+	if host == "localhost" {
+		return true
+	}
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.Unmap().IsLoopback()
+}
+
+// RejectUnsafeHostLiteral rejects unsafe IP literals without resolving names.
+func RejectUnsafeHostLiteral(host string, policy DestinationPolicy) error {
+	addr, err := netip.ParseAddr(normalizeHost(host))
+	if err != nil {
+		return nil
+	}
+	return CheckAddrAllowed(addr, policy)
+}
+
+// CheckAddrAllowed rejects internal and metadata destinations according to
+// policy. Metadata addresses remain denied even when a local-dev exception is
+// enabled.
+func CheckAddrAllowed(addr netip.Addr, policy DestinationPolicy) error {
+	addr = addr.Unmap()
+	switch {
+	case !addr.IsValid():
+		return fmt.Errorf("%w: invalid IP address", ErrUnsafeDestination)
+	case isMetadataAddr(addr):
+		return fmt.Errorf("%w: metadata IP %s is not allowed", ErrUnsafeDestination, addr)
+	case addr.IsLoopback() && !policy.AllowLoopback:
+		return fmt.Errorf("%w: loopback IP %s is not allowed", ErrUnsafeDestination, addr)
+	case addr.IsPrivate() && !policy.AllowPrivate:
+		return fmt.Errorf("%w: private IP %s is not allowed", ErrUnsafeDestination, addr)
+	case carrierGradeNATIPv4.Contains(addr) && !policy.AllowPrivate:
+		return fmt.Errorf("%w: shared/private IP %s is not allowed", ErrUnsafeDestination, addr)
+	case (addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast()) && !policy.AllowLinkLocal:
+		return fmt.Errorf("%w: link-local IP %s is not allowed", ErrUnsafeDestination, addr)
+	case addr.IsUnspecified():
+		return fmt.Errorf("%w: unspecified IP %s is not allowed", ErrUnsafeDestination, addr)
+	case addr.IsMulticast() || addr.IsInterfaceLocalMulticast():
+		return fmt.Errorf("%w: multicast IP %s is not allowed", ErrUnsafeDestination, addr)
+	}
+	return nil
+}
+
+func isMetadataAddr(addr netip.Addr) bool {
+	return addr == awsMetadataIPv4 || addr == awsMetadataIPv6 || addr == alibabaMetadataIPv4
+}
+
+// ResolveSafeTCPAddr resolves address, rejects unsafe answers, and returns a
+// host:port string pinned to the selected safe IP.
+func ResolveSafeTCPAddr(ctx context.Context, network, address string, policy DestinationPolicy) (string, error) {
+	addrs, err := ResolveSafeTCPAddrs(ctx, network, address, policy)
+	if err != nil {
+		return "", err
+	}
+	return addrs[0], nil
+}
+
+// ResolveSafeTCPAddrs resolves address, rejects unsafe answers, and returns
+// host:port strings pinned to safe IPs.
+func ResolveSafeTCPAddrs(ctx context.Context, network, address string, policy DestinationPolicy) ([]string, error) {
+	host, port, err := SplitHostPortDefault(address, "")
+	if err != nil {
+		return nil, err
+	}
+	if addr, err := netip.ParseAddr(host); err == nil {
+		addr = addr.Unmap()
+		if !addrMatchesNetwork(addr, network) {
+			return nil, fmt.Errorf("%w: IP %s does not match %s", ErrUnsafeDestination, addr, network)
+		}
+		if err := CheckAddrAllowed(addr, policy); err != nil {
+			return nil, err
+		}
+		return []string{net.JoinHostPort(addr.String(), port)}, nil
+	}
+
+	resolverNetwork := "ip"
+	switch network {
+	case "tcp4":
+		resolverNetwork = "ip4"
+	case "tcp6":
+		resolverNetwork = "ip6"
+	}
+	ips, err := net.DefaultResolver.LookupNetIP(ctx, resolverNetwork, host)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s: %w", host, err)
+	}
+	var denied []error
+	safeAddrs := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		ip = ip.Unmap()
+		if !addrMatchesNetwork(ip, network) {
+			continue
+		}
+		if err := CheckAddrAllowed(ip, policy); err != nil {
+			denied = append(denied, err)
+			continue
+		}
+		safeAddrs = append(safeAddrs, net.JoinHostPort(ip.String(), port))
+	}
+	if len(safeAddrs) > 0 {
+		return safeAddrs, nil
+	}
+	if len(denied) > 0 {
+		return nil, denied[0]
+	}
+	return nil, fmt.Errorf("%w: %s resolved to no usable IPs", ErrUnsafeDestination, host)
+}
+
+// SafeDialContext resolves through ResolveSafeTCPAddrs before dialing so DNS
+// rebinding cannot swap in an unsafe address after policy checks.
+func SafeDialContext(policy DestinationPolicy) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		if strings.HasPrefix(network, "tcp") {
+			safeAddrs, err := ResolveSafeTCPAddrs(ctx, network, address, policy)
+			if err != nil {
+				return nil, err
+			}
+			var errs []error
+			var dialer net.Dialer
+			for _, safeAddr := range safeAddrs {
+				conn, err := dialer.DialContext(ctx, network, safeAddr)
+				if err == nil {
+					return conn, nil
+				}
+				errs = append(errs, err)
+			}
+			return nil, fmt.Errorf("dial safe destination %s: %w", address, errors.Join(errs...))
+		}
+		var dialer net.Dialer
+		return dialer.DialContext(ctx, network, address)
+	}
+}
+
+func addrMatchesNetwork(addr netip.Addr, network string) bool {
+	addr = addr.Unmap()
+	switch network {
+	case "tcp4":
+		return addr.Is4()
+	case "tcp6":
+		return addr.Is6() && !addr.Is4()
+	default:
+		return true
+	}
+}

--- a/gestaltd/services/egress/destination_test.go
+++ b/gestaltd/services/egress/destination_test.go
@@ -1,0 +1,51 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+)
+
+func TestCheckAddrAllowedRejectsUnsafeRanges(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		ip   string
+	}{
+		{name: "loopback", ip: "127.0.0.1"},
+		{name: "private", ip: "10.0.0.8"},
+		{name: "link-local", ip: "169.254.1.2"},
+		{name: "metadata", ip: "169.254.169.254"},
+		{name: "shared", ip: "100.100.100.200"},
+		{name: "unspecified", ip: "0.0.0.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := CheckAddrAllowed(netip.MustParseAddr(tt.ip), DestinationPolicy{})
+			if !errors.Is(err, ErrUnsafeDestination) {
+				t.Fatalf("CheckAddrAllowed(%s) = %v, want ErrUnsafeDestination", tt.ip, err)
+			}
+		})
+	}
+}
+
+func TestResolveSafeTCPAddrRejectsLocalhostByDefault(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveSafeTCPAddr(context.Background(), "tcp", "localhost:80", DestinationPolicy{})
+	if !errors.Is(err, ErrUnsafeDestination) {
+		t.Fatalf("ResolveSafeTCPAddr localhost = %v, want ErrUnsafeDestination", err)
+	}
+}
+
+func TestResolveSafeTCPAddrAllowsLoopbackWhenExplicitlyEnabled(t *testing.T) {
+	t.Parallel()
+	addr, err := ResolveSafeTCPAddr(context.Background(), "tcp", "127.0.0.1:80", DestinationPolicy{AllowLoopback: true})
+	if err != nil {
+		t.Fatalf("ResolveSafeTCPAddr: %v", err)
+	}
+	if addr != "127.0.0.1:80" {
+		t.Fatalf("addr = %q, want 127.0.0.1:80", addr)
+	}
+}

--- a/gestaltd/services/egress/host_check.go
+++ b/gestaltd/services/egress/host_check.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -22,6 +23,10 @@ type Policy struct {
 
 func (p Policy) CheckHost(host string) error {
 	return CheckHost(p.AllowedHosts, host, p.DefaultAction)
+}
+
+func (p Policy) CheckEndpoint(hostport, defaultPort string) error {
+	return CheckEndpoint(p.AllowedHosts, hostport, p.DefaultAction, defaultPort)
 }
 
 func (p Policy) RequiresHostnameEnforcement() bool {
@@ -52,6 +57,28 @@ func CheckHost(allowedHosts []string, host string, defaultAction PolicyAction) e
 	return nil
 }
 
+// CheckEndpoint reports whether an outbound request to hostport is permitted
+// by the host allowlist and port policy. Allowlist entries may include an
+// explicit port. Entries without a port permit only the request's default port,
+// except explicit localhost/loopback entries which keep local development
+// compatibility and allow any loopback port.
+func CheckEndpoint(allowedHosts []string, hostport string, defaultAction PolicyAction, defaultPort string) error {
+	host, port, err := SplitHostPortDefault(hostport, defaultPort)
+	if err != nil {
+		return err
+	}
+	if len(allowedHosts) > 0 {
+		if matchEndpoint(allowedHosts, host, port, defaultPort) {
+			return nil
+		}
+		return fmt.Errorf("%w: endpoint %q is not in the allowed list", ErrEgressDenied, net.JoinHostPort(host, port))
+	}
+	if defaultAction == PolicyDeny {
+		return fmt.Errorf("%w: host %q denied by default policy", ErrEgressDenied, host)
+	}
+	return nil
+}
+
 // matchHost checks host against patterns supporting exact and *.suffix forms.
 func matchHost(patterns []string, host string) bool {
 	lower := strings.ToLower(host)
@@ -65,4 +92,81 @@ func matchHost(patterns []string, host string) bool {
 		}
 	}
 	return false
+}
+
+func matchEndpoint(patterns []string, host, port, defaultPort string) bool {
+	for _, pattern := range patterns {
+		patternHost, patternPort, hasPort, err := splitAllowedHostPattern(pattern)
+		if err != nil {
+			continue
+		}
+		if !matchHost([]string{patternHost}, host) {
+			continue
+		}
+		if hasPort {
+			if port == patternPort {
+				return true
+			}
+			continue
+		}
+		if defaultPort != "" && port == defaultPort {
+			return true
+		}
+		if IsLocalhostName(patternHost) && IsLocalhostName(host) {
+			return true
+		}
+	}
+	return false
+}
+
+func splitAllowedHostPattern(pattern string) (host string, port string, hasPort bool, err error) {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return "", "", false, fmt.Errorf("allowed host pattern is empty")
+	}
+	if h, p, splitErr := net.SplitHostPort(pattern); splitErr == nil {
+		if err := validatePort(p); err != nil {
+			return "", "", false, err
+		}
+		return normalizeHost(h), p, true, nil
+	}
+	return normalizeHost(pattern), "", false, nil
+}
+
+// SplitHostPortDefault splits hostport, applying defaultPort when the port is
+// absent. The returned host is normalized for matching and dialing.
+func SplitHostPortDefault(hostport, defaultPort string) (host string, port string, err error) {
+	hostport = strings.TrimSpace(hostport)
+	if hostport == "" {
+		return "", "", fmt.Errorf("%w: target host is required", ErrEgressDenied)
+	}
+	if h, p, splitErr := net.SplitHostPort(hostport); splitErr == nil {
+		if err := validatePort(p); err != nil {
+			return "", "", err
+		}
+		return normalizeHost(h), p, nil
+	}
+	if defaultPort == "" {
+		return "", "", fmt.Errorf("%w: endpoint %q is missing a port", ErrEgressDenied, hostport)
+	}
+	if err := validatePort(defaultPort); err != nil {
+		return "", "", err
+	}
+	return normalizeHost(hostport), defaultPort, nil
+}
+
+func validatePort(port string) error {
+	n, err := strconv.Atoi(port)
+	if err != nil || n < 1 || n > 65535 {
+		return fmt.Errorf("%w: invalid port %q", ErrEgressDenied, port)
+	}
+	return nil
+}
+
+func normalizeHost(host string) string {
+	host = strings.TrimSpace(host)
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
+	host = strings.TrimSuffix(host, ".")
+	return strings.ToLower(host)
 }

--- a/gestaltd/services/egress/host_check_test.go
+++ b/gestaltd/services/egress/host_check_test.go
@@ -64,6 +64,35 @@ func TestCheckHost_StripsPort(t *testing.T) {
 	}
 }
 
+func TestCheckEndpoint_DefaultPortAllowsHostnamePattern(t *testing.T) {
+	t.Parallel()
+	if err := CheckEndpoint([]string{"api.example.com"}, "api.example.com:443", PolicyAllow, "443"); err != nil {
+		t.Fatalf("expected default port allow, got %v", err)
+	}
+}
+
+func TestCheckEndpoint_DeniesNonDefaultPortWithoutExplicitAllow(t *testing.T) {
+	t.Parallel()
+	err := CheckEndpoint([]string{"api.example.com"}, "api.example.com:22", PolicyAllow, "443")
+	if !errors.Is(err, ErrEgressDenied) {
+		t.Fatalf("expected deny for non-default port, got %v", err)
+	}
+}
+
+func TestCheckEndpoint_AllowsExplicitPort(t *testing.T) {
+	t.Parallel()
+	if err := CheckEndpoint([]string{"api.example.com:8443"}, "api.example.com:8443", PolicyAllow, "443"); err != nil {
+		t.Fatalf("expected explicit port allow, got %v", err)
+	}
+}
+
+func TestCheckEndpoint_LocalhostPatternAllowsEphemeralLocalPort(t *testing.T) {
+	t.Parallel()
+	if err := CheckEndpoint([]string{"localhost"}, "localhost:49152", PolicyAllow, "80"); err != nil {
+		t.Fatalf("expected localhost dev port allow, got %v", err)
+	}
+}
+
 func TestCheckHost_EmptyDefaultActionIsAllow(t *testing.T) {
 	t.Parallel()
 	if err := CheckHost(nil, "anything.com", ""); err != nil {

--- a/gestaltd/services/plugins/declarative/base.go
+++ b/gestaltd/services/plugins/declarative/base.go
@@ -2,9 +2,12 @@ package declarative
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -146,6 +149,59 @@ func (b *Base) httpClient() *http.Client {
 		return b.HTTPClient
 	}
 	return &http.Client{Timeout: 10 * time.Second}
+}
+
+func (b *Base) httpClientForEgress() *http.Client {
+	client := b.httpClient()
+	if b.CheckEgress == nil {
+		return client
+	}
+	cloned := *client
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if client.Transport != nil {
+		if parent, ok := client.Transport.(*http.Transport); ok {
+			transport = parent.Clone()
+		}
+	}
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, _, err := egress.SplitHostPortDefault(address, "")
+		if err != nil {
+			return nil, err
+		}
+		policy := egress.DestinationPolicy{
+			AllowLoopback: egress.IsLocalhostName(host),
+		}
+		return egress.SafeDialContext(policy)(ctx, network, address)
+	}
+	transport.Proxy = nil
+	cloned.Transport = transport
+	parentCheckRedirect := client.CheckRedirect
+	cloned.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req == nil || req.URL == nil {
+			return nil
+		}
+		if err := b.checkRedirectEgress(req.URL); err != nil {
+			return err
+		}
+		if parentCheckRedirect != nil {
+			return parentCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &cloned
+}
+
+func (b *Base) checkRedirectEgress(u *url.URL) error {
+	if b.CheckEgress == nil || u == nil {
+		return nil
+	}
+	if err := egress.RejectUnsafeHostLiteral(u.Hostname(), egress.DestinationPolicy{}); err != nil {
+		return err
+	}
+	return b.CheckEgress(u.Host)
 }
 
 func (b *Base) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {

--- a/gestaltd/services/plugins/declarative/base_test.go
+++ b/gestaltd/services/plugins/declarative/base_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -232,6 +233,79 @@ func TestBaseExecuteRESTEgressDenyBlocksRequest(t *testing.T) {
 	_, err := b.Execute(context.Background(), "op", nil, "tok")
 	if !errors.Is(err, egress.ErrEgressDenied) {
 		t.Fatalf("expected ErrEgressDenied, got %v", err)
+	}
+}
+
+func TestBaseExecuteRESTRedirectRechecksEgress(t *testing.T) {
+	t.Parallel()
+
+	var allowedHost string
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://blocked.example.test/blocked", http.StatusFound)
+	}))
+	t.Cleanup(func() { origin.Close() })
+	originURL, err := url.Parse(origin.URL)
+	if err != nil {
+		t.Fatalf("parse origin URL: %v", err)
+	}
+	allowedHost = originURL.Host
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: origin.URL,
+		CheckEgress: func(host string) error {
+			if host == allowedHost {
+				return nil
+			}
+			return egress.ErrEgressDenied
+		},
+	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/start"))
+
+	_, err = b.Execute(context.Background(), "op", nil, "tok")
+	if !errors.Is(err, egress.ErrEgressDenied) {
+		t.Fatalf("expected redirect egress deny, got %v", err)
+	}
+}
+
+func TestBaseExecuteRESTRedirectRejectsUnsafeIPLiteral(t *testing.T) {
+	t.Parallel()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data", http.StatusFound)
+	}))
+	t.Cleanup(func() { origin.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: origin.URL,
+		CheckEgress: func(string) error {
+			return nil
+		},
+	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/start"))
+
+	_, err := b.Execute(context.Background(), "op", nil, "tok")
+	if !errors.Is(err, egress.ErrUnsafeDestination) {
+		t.Fatalf("expected unsafe redirect deny, got %v", err)
+	}
+}
+
+func TestBaseHTTPClientForEgressDisablesEnvironmentProxy(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:1")
+
+	b := &Base{
+		CheckEgress: func(string) error {
+			return nil
+		},
+	}
+	client := b.httpClientForEgress()
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport = %T, want *http.Transport", client.Transport)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("expected egress client to disable ambient proxy configuration")
 	}
 }
 

--- a/gestaltd/services/plugins/declarative/egress_adapter.go
+++ b/gestaltd/services/plugins/declarative/egress_adapter.go
@@ -58,10 +58,10 @@ func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog
 	}
 
 	if pgn, ok := b.Pagination[operation]; ok {
-		return apiexec.DoPaginated(ctx, b.httpClient(), req, pgn)
+		return apiexec.DoPaginated(ctx, b.httpClientForEgress(), req, pgn)
 	}
 
-	result, err := apiexec.Do(ctx, b.httpClient(), req)
+	result, err := apiexec.Do(ctx, b.httpClientForEgress(), req)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (b *Base) executeGraphQL(ctx context.Context, operation string, query strin
 		CustomHeaders: headers,
 	}
 
-	return apiexec.DoGraphQL(ctx, b.httpClient(), gqlReq)
+	return apiexec.DoGraphQL(ctx, b.httpClientForEgress(), gqlReq)
 }
 
 func (b *Base) checkEgressHost(rawURL string) error {

--- a/gestaltd/services/runtimehost/internal/sandbox/sandbox_darwin.go
+++ b/gestaltd/services/runtimehost/internal/sandbox/sandbox_darwin.go
@@ -80,7 +80,7 @@ func buildSBPLProfile(policy *Policy) string {
 	}
 
 	if policy.ProxyPort > 0 {
-		b.WriteString("(allow network-outbound (remote ip \"localhost:*\"))\n")
+		fmt.Fprintf(&b, "(allow network-outbound (remote tcp %s))\n", sbplQuote(fmt.Sprintf("localhost:%d", policy.ProxyPort)))
 		b.WriteString("(allow network* (local unix-socket))\n")
 	} else {
 		b.WriteString("(allow network*)\n")

--- a/gestaltd/services/runtimehost/internal/sandbox/sandbox_darwin_test.go
+++ b/gestaltd/services/runtimehost/internal/sandbox/sandbox_darwin_test.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildSBPLProfileConstrainsProxyPort(t *testing.T) {
+	t.Parallel()
+
+	profile := buildSBPLProfile(&Policy{ProxyPort: 3128})
+	if !strings.Contains(profile, `(remote tcp "localhost:3128")`) {
+		t.Fatalf("profile = %s, want tcp-scoped proxy port", profile)
+	}
+	if !strings.Contains(profile, `"localhost:3128"`) {
+		t.Fatalf("profile = %s, want exact proxy port", profile)
+	}
+	if strings.Contains(profile, "localhost:*") {
+		t.Fatalf("profile = %s, must not allow localhost wildcard port", profile)
+	}
+}

--- a/gestaltd/services/runtimehost/internal/sandbox/sandbox_linux.go
+++ b/gestaltd/services/runtimehost/internal/sandbox/sandbox_linux.go
@@ -15,6 +15,8 @@ import (
 	"github.com/landlock-lsm/go-landlock/landlock"
 )
 
+const allowNetworkRestrictionUnavailableEnv = "GESTALTD_SANDBOX_ALLOW_NETWORK_RESTRICTION_UNAVAILABLE"
+
 func Wrap(policy *Policy, cmd *exec.Cmd) (*exec.Cmd, func(), error) {
 	hostBin := policy.HostBinary
 	if hostBin == "" {
@@ -39,7 +41,7 @@ func Wrap(policy *Policy, cmd *exec.Cmd) (*exec.Cmd, func(), error) {
 	args = append(args, remaining...)
 
 	wrapped := exec.Command(args[0], args[1:]...)
-	wrapped.Env = cmd.Env
+	wrapped.Env = sandboxWrapperEnv(cmd.Env)
 	wrapped.Dir = cmd.Dir
 	wrapped.Stdout = cmd.Stdout
 	wrapped.Stderr = cmd.Stderr
@@ -101,11 +103,17 @@ func RunSubcommand(args []string) error {
 
 	if proxyPort > 0 {
 		if err := landlock.V4.RestrictNet(landlock.ConnectTCP(uint16(proxyPort))); err != nil {
-			slog.Warn("sandbox: landlock network restriction unavailable", "error", err)
+			if !allowNetworkRestrictionUnavailable() {
+				return fmt.Errorf("landlock restrict network to proxy port %d: %w", proxyPort, err)
+			}
+			slog.Warn("sandbox: landlock network restriction unavailable",
+				"error", err,
+				"override_env", allowNetworkRestrictionUnavailableEnv,
+			)
 		}
 	}
 
-	return syscall.Exec(binary, remaining, os.Environ())
+	return syscall.Exec(binary, remaining, sandboxExecEnv())
 }
 
 func DefaultReadOnlyPaths() []string {
@@ -139,4 +147,37 @@ func (f *multiFlag) String() string { return strings.Join(*f, ",") }
 func (f *multiFlag) Set(v string) error {
 	*f = append(*f, v)
 	return nil
+}
+
+func allowNetworkRestrictionUnavailable() bool {
+	value := strings.TrimSpace(os.Getenv(allowNetworkRestrictionUnavailableEnv))
+	return value == "1" || strings.EqualFold(value, "true")
+}
+
+func sandboxWrapperEnv(pluginEnv []string) []string {
+	baseEnv := pluginEnv
+	if baseEnv == nil {
+		baseEnv = os.Environ()
+	}
+	env := filterEnvKey(baseEnv, allowNetworkRestrictionUnavailableEnv)
+	if allowNetworkRestrictionUnavailable() {
+		env = append(env, allowNetworkRestrictionUnavailableEnv+"="+os.Getenv(allowNetworkRestrictionUnavailableEnv))
+	}
+	return env
+}
+
+func sandboxExecEnv() []string {
+	return filterEnvKey(os.Environ(), allowNetworkRestrictionUnavailableEnv)
+}
+
+func filterEnvKey(env []string, key string) []string {
+	prefix := key + "="
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }

--- a/gestaltd/services/runtimehost/internal/sandbox/sandbox_linux_test.go
+++ b/gestaltd/services/runtimehost/internal/sandbox/sandbox_linux_test.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+package sandbox
+
+import "testing"
+
+func TestAllowNetworkRestrictionUnavailableRequiresExplicitEnv(t *testing.T) {
+	t.Setenv(allowNetworkRestrictionUnavailableEnv, "")
+	if allowNetworkRestrictionUnavailable() {
+		t.Fatal("expected network restriction opt-out to default false")
+	}
+
+	t.Setenv(allowNetworkRestrictionUnavailableEnv, "1")
+	if !allowNetworkRestrictionUnavailable() {
+		t.Fatal("expected network restriction opt-out to accept 1")
+	}
+
+	t.Setenv(allowNetworkRestrictionUnavailableEnv, "true")
+	if !allowNetworkRestrictionUnavailable() {
+		t.Fatal("expected network restriction opt-out to accept true")
+	}
+}
+
+func TestSandboxWrapperEnvFiltersPluginOptOut(t *testing.T) {
+	t.Setenv(allowNetworkRestrictionUnavailableEnv, "")
+
+	env := sandboxWrapperEnv([]string{
+		"KEEP=value",
+		allowNetworkRestrictionUnavailableEnv + "=1",
+	})
+
+	if envValue(env, allowNetworkRestrictionUnavailableEnv) != "" {
+		t.Fatal("expected plugin-supplied sandbox opt-out to be filtered")
+	}
+	if got := envValue(env, "KEEP"); got != "value" {
+		t.Fatalf("KEEP = %q, want value", got)
+	}
+}
+
+func TestSandboxWrapperEnvPropagatesParentOptOut(t *testing.T) {
+	t.Setenv(allowNetworkRestrictionUnavailableEnv, "true")
+
+	env := sandboxWrapperEnv([]string{
+		"KEEP=value",
+		allowNetworkRestrictionUnavailableEnv + "=0",
+	})
+
+	if got := envValue(env, allowNetworkRestrictionUnavailableEnv); got != "true" {
+		t.Fatalf("%s = %q, want true", allowNetworkRestrictionUnavailableEnv, got)
+	}
+}
+
+func TestSandboxExecEnvRemovesOptOut(t *testing.T) {
+	t.Setenv(allowNetworkRestrictionUnavailableEnv, "true")
+
+	env := sandboxExecEnv()
+	if envValue(env, allowNetworkRestrictionUnavailableEnv) != "" {
+		t.Fatal("expected sandbox control env to be removed before executing plugin")
+	}
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if len(entry) > len(prefix) && entry[:len(prefix)] == prefix {
+			return entry[len(prefix):]
+		}
+		if entry == prefix {
+			return ""
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

- Add shared egress destination safety helpers for port-aware endpoint checks, unsafe IP classification, DNS resolution, and pinned safe dialing.
- Harden the egress proxy so CONNECT and absolute-form HTTP requests enforce host+port policy and reject loopback/private/link-local/metadata destinations unless explicitly local.
- Harden declarative HTTP clients and MCP OAuth discovery/DCR/token clients against unsafe redirects and DNS rebinding.
- Refuse plaintext remote `tcp://` plugin runtime gRPC by default for non-loopback targets; add `tls://` support for remote hosted plugins.
- Tighten runtimehost sandbox network behavior: macOS proxy rules bind the exact TCP port and Linux Landlock network failures fail closed unless explicitly opted out.

## Security impact

This addresses the network hardening findings around egress proxy port scope and DNS rebinding, declarative HTTP redirect SSRF, MCP OAuth discovery SSRF, plaintext remote plugin-runtime gRPC, macOS sandbox overbroad localhost access, and Linux network sandbox fail-open behavior.

## Validation

- `go test ./services/egress ./services/plugins/declarative ./internal/mcpoauth ./internal/pluginruntime ./services/runtimehost/internal/sandbox ./internal/server ./services/runtimehost`
- `go test ./internal/daemon -run TestE2EProviderDevAutoMountsOwnedUI -count=1`
- `go test ./internal/bootstrap -run TestAgentRuntimeConfigRestartsUnhealthyHostedAgent -count=1`
- `go test ./internal/bootstrap`
- `go test ./...` from `gestaltd/` after rebasing onto current `origin/main`

Note: one full-suite run after rebase hit a known-style hosted-agent bootstrap cleanup flake in `TestAgentRuntimeConfigRestartsUnhealthyHostedAgent`; the exact test and full `internal/bootstrap` package passed on rerun.
