### PR TITLE
[codex] Harden request object and CLI boundaries

### DIFF
--- a/docs/content/architecture/index.mdx
+++ b/docs/content/architecture/index.mdx
@@ -16,7 +16,7 @@ Next, Gestalt initializes the secret managers from `providers.secrets`. The secr
 
 Once the secret managers are ready, Gestalt resolves every structured secret ref across the rest of the config: server settings, auth, indexeddb, telemetry, audit, cache, and all plugin configs. Every ref names its provider explicitly, and each `providers.secrets.<name>.config` block is skipped to avoid a circular dependency.
 
-With secrets resolved, `server.encryptionKey` gets converted into a 32-byte AES key. A 64-character hex string is decoded directly; anything else goes through Argon2id derivation. This derived key protects all stored tokens.
+With secrets resolved, `server.encryptionKey` gets converted into a 32-byte AES key. Use `raw-hex:` for a direct 32-byte hex key and `argon2id:` for passphrases; legacy unprefixed 64-character hex keys are still decoded directly. This derived key protects all stored tokens.
 
 From there, the authentication and datastore providers are spawned as child processes over gRPC, schema migrations run, plugins start, and the HTTP listeners come up. The `/ready` endpoint returns 503 until everything reports ready.
 

--- a/docs/content/architecture/security-internals.mdx
+++ b/docs/content/architecture/security-internals.mdx
@@ -6,9 +6,9 @@ Implementation details of how Gestalt protects credentials. For operator guidanc
 
 `server.encryptionKey` is converted to a 32-byte AES key at startup.
 
-If the key is a 64-character hex string, it's hex-decoded directly into 32 bytes. No derivation, no extra cost. Generate one with `openssl rand -hex 32`.
+Use `raw-hex:` followed by 64 hex characters to hex-decode a direct 32-byte key. No derivation, no extra cost. Generate one with `openssl rand -hex 32`. For compatibility, an unprefixed 64-character hex string is still treated as a raw key.
 
-If the key is anything else (a passphrase, `dev-only-change-me`), Gestalt runs it through Argon2id (3 iterations, 64 MiB, 4 threads). This adds a few hundred milliseconds to startup. A weak passphrase is still a weak passphrase; Argon2id makes brute-forcing harder, not impossible.
+Use `argon2id:` before passphrases, especially passphrases that could be mistaken for hex. Non-hex unprefixed strings also go through Argon2id (3 iterations, 64 MiB, 4 threads). This adds a few hundred milliseconds to startup. A weak passphrase is still a weak passphrase; Argon2id makes brute-forcing harder, not impossible.
 
 The Argon2id path uses a fixed salt (`gestalt-derivekey-v1`), so two deployments with the same passphrase derive the same key. Use a unique random hex key in production.
 

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -216,7 +216,7 @@ spec:
         env: REQUEST_SIGNING_SECRET
       signatureHeader: X-Request-Signature
       signaturePrefix: v0=
-      payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+      payloadTemplate: "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}"
       timestampHeader: X-Request-Timestamp
       maxAgeSeconds: 300
   http:

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -268,9 +268,9 @@ routes that are intentionally unsigned.
 | `description` | string | Optional human-readable description. |
 | `signatureHeader` | string | Header carrying the transmitted HMAC digest for `type: hmac`. |
 | `signaturePrefix` | string | Optional static prefix prepended to the computed digest before comparison. |
-| `payloadTemplate` | string | Template used to build the signed payload for `type: hmac`. Supports `{raw_body}` and `{header:Header-Name}` placeholders. |
-| `timestampHeader` | string | Optional header carrying a Unix-seconds timestamp for freshness and replay checks. |
-| `maxAgeSeconds` | integer | Maximum accepted request age, in seconds, when `timestampHeader` is configured. |
+| `payloadTemplate` | string | Template used to build the signed payload for `type: hmac`. Supports `{raw_body}`, `{request_target}`, and `{header:Header-Name}` placeholders. |
+| `timestampHeader` | string | Required header carrying a Unix-seconds timestamp for freshness and replay checks. |
+| `maxAgeSeconds` | integer | Required maximum accepted request age, in seconds. |
 | `name` | string | Header or query parameter name for `apiKey`. |
 | `in` | string | `header` or `query` for `type: apiKey`. |
 | `scheme` | string | `basic` or `bearer` for `type: http`. |
@@ -279,7 +279,10 @@ routes that are intentionally unsigned.
 Every scheme requires `type`. `hmac`, `apiKey`, and `http` schemes also require
 `secret`. HMAC schemes compare the computed digest against `signatureHeader`,
 optionally prefixed by `signaturePrefix`; `payloadTemplate` supports
-`{raw_body}` and `{header:Header-Name}` placeholders.
+`{raw_body}`, `{request_target}` (path plus query), and
+`{header:Header-Name}` placeholders. Include `{request_target}` when query
+parameters are accepted, and include `{header:Content-Type}` when body parsing
+can vary by content type.
 
 #### `spec.http.<name>`
 
@@ -304,7 +307,7 @@ spec:
         env: REQUEST_SIGNING_SECRET
       signatureHeader: X-Request-Signature
       signaturePrefix: v0=
-      payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+      payloadTemplate: "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}"
       timestampHeader: X-Request-Timestamp
       maxAgeSeconds: 300
   http:

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -15,7 +15,7 @@ Gestalt sits between callers and upstream APIs. It authenticates users, stores e
 
 All plugin tokens are encrypted before storage using AES-256-GCM.
 
-The `server.encryptionKey` is the root deployment secret. If the key is a 64-character hex string, it is decoded directly as a 32-byte AES key. Otherwise, Argon2id derives a 32-byte key from the string (3 iterations, 64 MiB, 4 threads).
+The `server.encryptionKey` is the root deployment secret. Use `raw-hex:` followed by 64 hex characters for a direct 32-byte AES key, or `argon2id:` before a passphrase to force Argon2id derivation. For compatibility, an unprefixed 64-character hex string is still decoded directly; other strings use Argon2id (3 iterations, 64 MiB, 4 threads).
 
 Every encryption operation generates a fresh 12-byte nonce using `crypto/rand`. GCM provides authenticated encryption, so tampering with stored ciphertexts is detected at decryption time.
 
@@ -109,7 +109,7 @@ enforcement.
 
 | Setting | Impact |
 | --- | --- |
-| `server.encryptionKey` | Root deployment secret. If compromised, all stored tokens can be decrypted. Use a strong random string or 64-character hex key. Must be the same across all instances in a cluster. |
+| `server.encryptionKey` | Root deployment secret. If compromised, all stored tokens can be decrypted. Use `raw-hex:` with a random 32-byte hex key, or `argon2id:` with a strong passphrase. Must be the same across all instances in a cluster. |
 | `providers.authentication` | Omitting `providers.authentication` disables all authentication. Do not use in production. |
 | `server.baseUrl` | Must match the public URL exactly. OAuth callbacks are derived from it. |
 | TLS termination | Gestalt does not terminate TLS. Deploy behind a reverse proxy that handles TLS. |

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -264,6 +264,9 @@ impl ApiClient {
                 None => return Err(err),
             },
         };
+        if let Some(creds) = stored_credentials.as_ref() {
+            ensure_stored_credentials_match_url(&base_url, creds)?;
+        }
         let (token, source) = match env_api_key {
             Some(key) => (key, TokenSource::EnvVar),
             None => match stored_credentials.as_ref() {
@@ -510,6 +513,29 @@ impl ApiClient {
         }
         Ok(())
     }
+}
+
+fn ensure_stored_credentials_match_url(
+    base_url: &str,
+    creds: &crate::credentials::Credentials,
+) -> Result<()> {
+    let Some(credentials_url) = creds.api_url().map(normalize_url) else {
+        bail!(
+            "refusing to send stored CLI token without a recorded server URL to {}; run 'gestalt auth login' for this server or set {} for an explicit token override",
+            normalize_url(base_url),
+            ENV_API_KEY
+        );
+    };
+    let target_url = normalize_url(base_url);
+    if credentials_url != target_url {
+        bail!(
+            "refusing to send stored CLI token for {} to {}; run 'gestalt auth login' for this server or set {} for an explicit token override",
+            credentials_url,
+            target_url,
+            ENV_API_KEY
+        );
+    }
+    Ok(())
 }
 
 fn extract_api_error(value: &serde_json::Value) -> Option<ApiError> {

--- a/gestalt/cli/tests/config_resolution.rs
+++ b/gestalt/cli/tests/config_resolution.rs
@@ -26,6 +26,116 @@ fn test_cli_reuses_stored_credentials_api_url() {
 }
 
 #[test]
+fn test_cli_refuses_stored_credentials_when_project_config_points_elsewhere() {
+    let mut credential_server = Server::new();
+    let credential_server_tokens = authed_json_mock!(
+        credential_server,
+        Method::GET,
+        "/api/v1/tokens",
+        StatusCode::OK
+    )
+    .expect(0)
+    .with_body("[]")
+    .create();
+    let mut poisoned_server = Server::new();
+    let poisoned_server_tokens = authed_json_mock!(
+        poisoned_server,
+        Method::GET,
+        "/api/v1/tokens",
+        StatusCode::OK
+    )
+    .expect(0)
+    .with_body("[]")
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "api_url": credential_server.url(),
+            "api_token": TEST_TOKEN,
+            "api_token_id": "tok-123",
+        }),
+    );
+
+    let workspace = TempDir::new().unwrap();
+    let repo_root = workspace.path().join("repo");
+    let nested = repo_root.join("nested");
+    std::fs::create_dir_all(repo_root.join(".gestalt")).unwrap();
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::write(
+        repo_root.join(".gestalt/config.json"),
+        format!("{{\n  \"url\": {:?}\n}}\n", poisoned_server.url()),
+    )
+    .unwrap();
+
+    cli_command(home.path())
+        .current_dir(&nested)
+        .args(["tokens", "list"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "refusing to send stored CLI token",
+        ))
+        .stderr(predicate::str::contains(credential_server.url()))
+        .stderr(predicate::str::contains(poisoned_server.url()));
+
+    credential_server_tokens.assert();
+    poisoned_server_tokens.assert();
+}
+
+#[test]
+fn test_cli_allows_explicit_env_token_for_project_config_url() {
+    let mut credential_server = Server::new();
+    let credential_server_tokens = authed_json_mock!(
+        credential_server,
+        Method::GET,
+        "/api/v1/tokens",
+        StatusCode::OK
+    )
+    .expect(0)
+    .with_body("[]")
+    .create();
+    let mut project_server = Server::new();
+    let project_server_tokens = authed_json_mock!(
+        project_server,
+        Method::GET,
+        "/api/v1/tokens",
+        StatusCode::OK
+    )
+    .with_body("[]")
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "api_url": credential_server.url(),
+            "api_token": "stored-token",
+            "api_token_id": "tok-123",
+        }),
+    );
+
+    let workspace = TempDir::new().unwrap();
+    std::fs::create_dir_all(workspace.path().join(".gestalt")).unwrap();
+    std::fs::write(
+        workspace.path().join(".gestalt/config.json"),
+        format!("{{\n  \"url\": {:?}\n}}\n", project_server.url()),
+    )
+    .unwrap();
+
+    cli_command(home.path())
+        .current_dir(workspace.path())
+        .env(gestalt::api::ENV_API_KEY, TEST_TOKEN)
+        .args(["tokens", "list"])
+        .assert()
+        .success();
+
+    credential_server_tokens.assert();
+    project_server_tokens.assert();
+}
+
+#[test]
 fn test_cli_ignores_blank_stored_credentials_api_url() {
     let home = tempfile::tempdir().unwrap();
     write_cli_credentials(
@@ -41,6 +151,49 @@ fn test_cli_ignores_blank_stored_credentials_api_url() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("no URL configured"));
+}
+
+#[test]
+fn test_cli_refuses_blank_stored_credentials_api_url_for_project_config() {
+    let mut project_server = Server::new();
+    let project_server_tokens = authed_json_mock!(
+        project_server,
+        Method::GET,
+        "/api/v1/tokens",
+        StatusCode::OK
+    )
+    .expect(0)
+    .with_body("[]")
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    write_cli_credentials(
+        home.path(),
+        &format!(
+            r#"{{"api_url":"   ","api_token":"{}","api_token_id":"tok-123"}}"#,
+            TEST_TOKEN
+        ),
+    );
+
+    let workspace = TempDir::new().unwrap();
+    std::fs::create_dir_all(workspace.path().join(".gestalt")).unwrap();
+    std::fs::write(
+        workspace.path().join(".gestalt/config.json"),
+        format!("{{\n  \"url\": {:?}\n}}\n", project_server.url()),
+    )
+    .unwrap();
+
+    cli_command(home.path())
+        .current_dir(workspace.path())
+        .args(["tokens", "list"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "refusing to send stored CLI token without a recorded server URL",
+        ))
+        .stderr(predicate::str::contains(project_server.url()));
+
+    project_server_tokens.assert();
 }
 
 #[test]

--- a/gestaltd/core/crypto/derivekey.go
+++ b/gestaltd/core/crypto/derivekey.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"encoding/hex"
+	"strings"
 
 	"golang.org/x/crypto/argon2"
 )
@@ -11,19 +12,45 @@ const (
 	argonMemory  = 64 * 1024 // 64 MiB
 	argonThreads = 4
 	argonKeyLen  = 32
+
+	rawHexKeyPrefix = "raw-hex:"
+	argon2idPrefix  = "argon2id:"
 )
 
 var argonSalt = []byte("gestalt-derivekey-v1")
 
 // DeriveKey converts an encryption key string to a 32-byte key for AES-256-GCM.
-// If the string is 64 hex characters it is hex-decoded directly; otherwise it is
-// derived using Argon2id. Returns nil for an empty string.
+// Use raw-hex:<64 hex chars> for a raw AES-256 key and argon2id:<passphrase>
+// to force Argon2id derivation. For compatibility, an unprefixed 64-character
+// hex string is still decoded as a raw key; all other strings use Argon2id.
+// Returns nil for an empty string or malformed explicit raw-hex key.
 func DeriveKey(s string) []byte {
 	if s == "" {
 		return nil
 	}
-	if b, err := hex.DecodeString(s); err == nil && len(b) == 32 {
+	if raw, ok := strings.CutPrefix(s, rawHexKeyPrefix); ok {
+		return decodeRawHexKey(raw)
+	}
+	if passphrase, ok := strings.CutPrefix(s, argon2idPrefix); ok {
+		if passphrase == "" {
+			return nil
+		}
+		return deriveArgon2idKey(passphrase)
+	}
+	if b := decodeRawHexKey(s); b != nil {
 		return b
 	}
+	return deriveArgon2idKey(s)
+}
+
+func decodeRawHexKey(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil || len(b) != argonKeyLen {
+		return nil
+	}
+	return b
+}
+
+func deriveArgon2idKey(s string) []byte {
 	return argon2.IDKey([]byte(s), argonSalt, argonTime, argonMemory, argonThreads, argonKeyLen)
 }

--- a/gestaltd/core/crypto/derivekey_test.go
+++ b/gestaltd/core/crypto/derivekey_test.go
@@ -59,6 +59,43 @@ func TestDeriveKeyHexKeyEncryptRoundTrip(t *testing.T) {
 	}
 }
 
+func TestDeriveKeyExplicitRawHexKey(t *testing.T) {
+	t.Parallel()
+	hexKey := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	key := crypto.DeriveKey("raw-hex:" + hexKey)
+	want, _ := hex.DecodeString(hexKey)
+	if !bytes.Equal(key, want) {
+		t.Fatalf("explicit raw hex key not passed through: got %x, want %x", key, want)
+	}
+}
+
+func TestDeriveKeyExplicitArgon2idForHexShapedPassphrase(t *testing.T) {
+	t.Parallel()
+	passphrase := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	key := crypto.DeriveKey("argon2id:" + passphrase)
+	raw, _ := hex.DecodeString(passphrase)
+	if bytes.Equal(key, raw) {
+		t.Fatal("argon2id-prefixed hex-shaped passphrase bypassed KDF")
+	}
+	if len(key) != 32 {
+		t.Fatalf("key length = %d, want 32", len(key))
+	}
+}
+
+func TestDeriveKeyMalformedExplicitRawHexReturnsNil(t *testing.T) {
+	t.Parallel()
+	if key := crypto.DeriveKey("raw-hex:not-a-32-byte-key"); key != nil {
+		t.Fatalf("key = %x, want nil", key)
+	}
+}
+
+func TestDeriveKeyEmptyExplicitArgon2idReturnsNil(t *testing.T) {
+	t.Parallel()
+	if key := crypto.DeriveKey("argon2id:"); key != nil {
+		t.Fatalf("key = %x, want nil", key)
+	}
+}
+
 func TestDeriveKeySamePassphraseProducesSameEncryption(t *testing.T) {
 	t.Parallel()
 	passphrase := "deterministic-dummy-phrase"

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -214,7 +214,7 @@ plugins:
           env: REQUEST_SIGNING_SECRET
         signatureHeader: X-Request-Signature
         signaturePrefix: v0=
-        payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+        payloadTemplate: "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}"
         timestampHeader: X-Request-Timestamp
         maxAgeSeconds: 300
     http:
@@ -253,7 +253,7 @@ plugins:
 	if got, want := scheme.SignatureHeader, "X-Request-Signature"; got != want {
 		t.Fatalf("SecuritySchemes[signed].SignatureHeader = %q, want %q", got, want)
 	}
-	if got, want := scheme.PayloadTemplate, "v0:{header:X-Request-Timestamp}:{raw_body}"; got != want {
+	if got, want := scheme.PayloadTemplate, "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}"; got != want {
 		t.Fatalf("SecuritySchemes[signed].PayloadTemplate = %q, want %q", got, want)
 	}
 	if got, want := scheme.TimestampHeader, "X-Request-Timestamp"; got != want {
@@ -299,7 +299,7 @@ func TestProviderEntryEffectiveHTTPSecuritySchemes_MergesHMACFields(t *testing.T
 			"signed": {
 				SignatureHeader: "X-Request-Signature",
 				SignaturePrefix: "v0=",
-				PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+				PayloadTemplate: "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}",
 				TimestampHeader: "X-Request-Timestamp",
 				MaxAgeSeconds:   300,
 				Secret:          &providermanifestv1.HTTPSecretRef{Env: "REQUEST_SIGNING_SECRET"},
@@ -319,7 +319,7 @@ func TestProviderEntryEffectiveHTTPSecuritySchemes_MergesHMACFields(t *testing.T
 	if got, want := scheme.SignaturePrefix, "v0="; got != want {
 		t.Fatalf("SignaturePrefix = %q, want %q", got, want)
 	}
-	if got, want := scheme.PayloadTemplate, "v0:{header:X-Request-Timestamp}:{raw_body}"; got != want {
+	if got, want := scheme.PayloadTemplate, "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}"; got != want {
 		t.Fatalf("PayloadTemplate = %q, want %q", got, want)
 	}
 	if got, want := scheme.TimestampHeader, "X-Request-Timestamp"; got != want {

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -3104,8 +3104,8 @@ func assertReleasedManifestHasHostedHTTPMetadata(t *testing.T, manifest *provide
 	if scheme.SignaturePrefix != "v0=" {
 		t.Fatalf("scheme.SignaturePrefix = %q, want %q", scheme.SignaturePrefix, "v0=")
 	}
-	if scheme.PayloadTemplate != "v0:{header:X-Request-Timestamp}:{raw_body}" {
-		t.Fatalf("scheme.PayloadTemplate = %q, want %q", scheme.PayloadTemplate, "v0:{header:X-Request-Timestamp}:{raw_body}")
+	if scheme.PayloadTemplate != "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}" {
+		t.Fatalf("scheme.PayloadTemplate = %q, want %q", scheme.PayloadTemplate, "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}")
 	}
 	if scheme.TimestampHeader != "X-Request-Timestamp" {
 		t.Fatalf("scheme.TimestampHeader = %q, want %q", scheme.TimestampHeader, "X-Request-Timestamp")
@@ -3342,7 +3342,7 @@ func hostedHTTPMetadataSpec(target string) *providermanifestv1.Spec {
 				Secret:          &providermanifestv1.HTTPSecretRef{Env: "REQUEST_SIGNING_SECRET"},
 				SignatureHeader: "X-Request-Signature",
 				SignaturePrefix: "v0=",
-				PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+				PayloadTemplate: "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}",
 				TimestampHeader: "X-Request-Timestamp",
 				MaxAgeSeconds:   300,
 			},

--- a/gestaltd/internal/httpbinding/payload_template.go
+++ b/gestaltd/internal/httpbinding/payload_template.go
@@ -20,6 +20,8 @@ func ValidatePayloadTemplate(template, timestampHeader string) error {
 		switch {
 		case token == "raw_body":
 			return nil
+		case token == "request_target":
+			return nil
 		case strings.HasPrefix(strings.ToLower(token), "header:"):
 			headerName := strings.TrimSpace(token[len("header:"):])
 			if headerName == "" {
@@ -42,7 +44,48 @@ func ValidatePayloadTemplate(template, timestampHeader string) error {
 	return nil
 }
 
-func RenderPayloadTemplate(template string, headers http.Header, rawBody []byte) (string, error) {
+func PayloadTemplateReferencesHeader(template, name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	found := false
+	_ = visitPayloadTemplate(strings.TrimSpace(template), func(string) error {
+		return nil
+	}, func(token string) error {
+		if strings.HasPrefix(strings.ToLower(token), "header:") {
+			headerName := strings.TrimSpace(token[len("header:"):])
+			if strings.EqualFold(headerName, name) {
+				found = true
+			}
+		}
+		return nil
+	})
+	return found
+}
+
+func PayloadTemplateReferencesRequestTarget(template string) bool {
+	found := false
+	_ = visitPayloadTemplate(strings.TrimSpace(template), func(string) error {
+		return nil
+	}, func(token string) error {
+		if token == "request_target" {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
+func RenderPayloadTemplate(template string, r *http.Request, rawBody []byte) (string, error) {
+	var headers http.Header
+	var requestTarget string
+	if r != nil {
+		headers = r.Header
+		if r.URL != nil {
+			requestTarget = r.URL.RequestURI()
+		}
+	}
 	var out strings.Builder
 	err := visitPayloadTemplate(strings.TrimSpace(template), func(literal string) error {
 		out.WriteString(literal)
@@ -51,6 +94,9 @@ func RenderPayloadTemplate(template string, headers http.Header, rawBody []byte)
 		switch {
 		case token == "raw_body":
 			_, _ = out.Write(rawBody)
+			return nil
+		case token == "request_target":
+			out.WriteString(requestTarget)
 			return nil
 		case strings.HasPrefix(strings.ToLower(token), "header:"):
 			headerName := strings.TrimSpace(token[len("header:"):])

--- a/gestaltd/internal/httpbinding/security.go
+++ b/gestaltd/internal/httpbinding/security.go
@@ -22,11 +22,11 @@ func ValidateHTTPSecurityScheme(path string, scheme *providermanifestv1.HTTPSecu
 		if scheme.Secret == nil {
 			return fmt.Errorf("%s.secret is required", path)
 		}
-		if strings.TrimSpace(scheme.TimestampHeader) == "" && scheme.MaxAgeSeconds != 0 {
-			return fmt.Errorf("%s.maxAgeSeconds requires %s.timestampHeader to be set", path, path)
+		if strings.TrimSpace(scheme.TimestampHeader) == "" {
+			return fmt.Errorf("%s.timestampHeader is required for replay protection", path)
 		}
-		if strings.TrimSpace(scheme.TimestampHeader) != "" && scheme.MaxAgeSeconds <= 0 {
-			return fmt.Errorf("%s.timestampHeader requires %s.maxAgeSeconds to be greater than zero", path, path)
+		if scheme.MaxAgeSeconds <= 0 {
+			return fmt.Errorf("%s.maxAgeSeconds is required for replay protection", path)
 		}
 		if err := ValidatePayloadTemplate(scheme.PayloadTemplate, scheme.TimestampHeader); err != nil {
 			return fmt.Errorf("%s.payloadTemplate %s", path, err)
@@ -60,4 +60,25 @@ func ValidateHTTPSecurityScheme(path string, scheme *providermanifestv1.HTTPSecu
 		return fmt.Errorf("%s.secret must set env or secret", path)
 	}
 	return nil
+}
+
+func ValidateHTTPBindingHMACCoverage(path string, binding *providermanifestv1.HTTPBinding, scheme *providermanifestv1.HTTPSecurityScheme) error {
+	if binding == nil || scheme == nil || scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeHMAC {
+		return nil
+	}
+	if httpBindingContentTypeAffectsParsing(binding.RequestBody) && !PayloadTemplateReferencesHeader(scheme.PayloadTemplate, "Content-Type") {
+		return fmt.Errorf("%s.security %q uses hmac with content-type-dependent body parsing; payloadTemplate must include {header:Content-Type}", path, binding.Security)
+	}
+	return nil
+}
+
+func httpBindingContentTypeAffectsParsing(requestBody *providermanifestv1.HTTPRequestBody) bool {
+	if requestBody == nil || len(requestBody.Content) == 0 {
+		return true
+	}
+	if len(requestBody.Content) != 1 {
+		return true
+	}
+	_, ok := requestBody.Content["*/*"]
+	return ok
 }

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -508,6 +508,9 @@ func validateHTTPBinding(path string, binding *providermanifestv1.HTTPBinding, s
 		}
 		binding.RequestBody.Content = normalizedContent
 	}
+	if err := httpbinding.ValidateHTTPBindingHMACCoverage(path, binding, schemes[binding.Security]); err != nil {
+		return err
+	}
 	if binding.Ack != nil {
 		if binding.Ack.Status == 0 {
 			binding.Ack.Status = 200

--- a/gestaltd/internal/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/providerpkg/manifest_workflow_test.go
@@ -569,7 +569,7 @@ spec:
         env: REQUEST_SIGNING_SECRET
       signatureHeader: X-Request-Signature
       signaturePrefix: v0=
-      payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+      payloadTemplate: "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}"
       timestampHeader: X-Request-Timestamp
       maxAgeSeconds: 300
   http:
@@ -741,6 +741,46 @@ spec:
 	}
 }
 
+func TestManifestWorkflow_RejectsHMACRequestBodyWithoutSignedContentType(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/bad-http-template
+version: 1.0.0
+spec:
+  securitySchemes:
+    signed:
+      type: hmac
+      secret:
+        env: REQUEST_SIGNING_SECRET
+      signatureHeader: X-Request-Signature
+      signaturePrefix: v0=
+      payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+      timestampHeader: X-Request-Timestamp
+      maxAgeSeconds: 300
+  http:
+    command:
+      path: /command
+      method: POST
+      security: signed
+      target: handle_command
+      requestBody:
+        content:
+          application/json: {}
+          application/x-www-form-urlencoded: {}
+`))
+
+	_, _, err := ReadSourceManifestFile(manifestPath)
+	if err == nil {
+		t.Fatal("expected invalid manifest")
+	}
+	if !strings.Contains(err.Error(), `provider.http.command.security "signed" uses hmac with content-type-dependent body parsing; payloadTemplate must include {header:Content-Type}`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestManifestWorkflow_RejectsInvalidHTTPSecuritySchemes(t *testing.T) {
 	t.Parallel()
 
@@ -805,6 +845,17 @@ func TestManifestWorkflow_RejectsInvalidHTTPSecuritySchemes(t *testing.T) {
       payloadTemplate: "{raw_body}"
 `,
 			wantErrPart: `provider.securitySchemes.bad.signatureHeader is required`,
+		},
+		{
+			name: "missing hmac timestamp replay protection",
+			schemeYAML: `
+      type: hmac
+      secret:
+        secret: shared-key
+      signatureHeader: X-Request-Signature
+      payloadTemplate: "{raw_body}"
+`,
+			wantErrPart: `provider.securitySchemes.bad.timestampHeader is required for replay protection`,
 		},
 	}
 

--- a/gestaltd/internal/server/handlers_provider_dev.go
+++ b/gestaltd/internal/server/handlers_provider_dev.go
@@ -310,6 +310,7 @@ func (s *Server) completeProviderDevCallByDispatcher(w http.ResponseWriter, r *h
 		writeProviderDevError(w, err)
 		return
 	}
+	allowRequestBodyBytes(r, providerDevCallMaxBodyBytes)
 	var req providerdev.CompleteCallRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid provider dev call response")

--- a/gestaltd/internal/server/handlers_s3_object_access.go
+++ b/gestaltd/internal/server/handlers_s3_object_access.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -50,10 +51,11 @@ func (s *Server) handleS3ObjectAccess(w http.ResponseWriter, r *http.Request) {
 
 	switch target.Method {
 	case s3store.PresignMethodGet:
-		s.handleS3ObjectAccessGet(w, r, client, ref)
+		s.handleS3ObjectAccessGet(w, r, client, target, ref)
 	case s3store.PresignMethodHead:
-		s.handleS3ObjectAccessHead(w, r, client, ref)
+		s.handleS3ObjectAccessHead(w, r, client, target, ref)
 	case s3store.PresignMethodPut:
+		allowRequestBodyBytes(r, s3ObjectAccessMaxBodyBytes)
 		s.handleS3ObjectAccessPut(w, r, client, target, ref)
 	case s3store.PresignMethodDelete:
 		s.handleS3ObjectAccessDelete(w, r, client, ref)
@@ -62,7 +64,7 @@ func (s *Server) handleS3ObjectAccess(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) handleS3ObjectAccessGet(w http.ResponseWriter, r *http.Request, client s3store.Client, ref s3store.ObjectRef) {
+func (s *Server) handleS3ObjectAccessGet(w http.ResponseWriter, r *http.Request, client s3store.Client, target s3.ObjectAccessTarget, ref s3store.ObjectRef) {
 	readReq, partial, err := s3ObjectAccessReadRequest(r, client, ref)
 	if err != nil {
 		writeS3ObjectAccessError(w, err)
@@ -74,7 +76,7 @@ func (s *Server) handleS3ObjectAccessGet(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	defer func() { _ = result.Body.Close() }()
-	writeS3ObjectAccessMetaHeaders(w, result.Meta)
+	writeS3ObjectAccessMetaHeaders(w, result.Meta, target)
 	if partial.CoversFullRepresentation(result.Meta.Size) {
 		partial = s3HTTPRange{}
 	}
@@ -89,13 +91,13 @@ func (s *Server) handleS3ObjectAccessGet(w http.ResponseWriter, r *http.Request,
 	_, _ = io.Copy(w, result.Body)
 }
 
-func (s *Server) handleS3ObjectAccessHead(w http.ResponseWriter, r *http.Request, client s3store.Client, ref s3store.ObjectRef) {
+func (s *Server) handleS3ObjectAccessHead(w http.ResponseWriter, r *http.Request, client s3store.Client, target s3.ObjectAccessTarget, ref s3store.ObjectRef) {
 	meta, err := client.HeadObject(r.Context(), ref)
 	if err != nil {
 		writeS3ObjectAccessError(w, err)
 		return
 	}
-	writeS3ObjectAccessMetaHeaders(w, meta)
+	writeS3ObjectAccessMetaHeaders(w, meta, target)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -308,7 +310,9 @@ func parseS3ObjectAccessHTTPRange(value string) (*s3store.ByteRange, s3HTTPRange
 	return out, httpRange, nil
 }
 
-func writeS3ObjectAccessMetaHeaders(w http.ResponseWriter, meta s3store.ObjectMeta) {
+const s3ObjectAccessContentSecurityPolicy = "default-src 'none'; sandbox; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
+
+func writeS3ObjectAccessMetaHeaders(w http.ResponseWriter, meta s3store.ObjectMeta, target s3.ObjectAccessTarget) {
 	if meta.ETag != "" {
 		w.Header().Set("ETag", meta.ETag)
 	}
@@ -322,6 +326,74 @@ func writeS3ObjectAccessMetaHeaders(w http.ResponseWriter, meta s3store.ObjectMe
 	}
 	if !meta.LastModified.IsZero() {
 		w.Header().Set("Last-Modified", meta.LastModified.UTC().Format(http.TimeFormat))
+	}
+	w.Header().Set("Content-Disposition", s3ObjectAccessResponseContentDisposition(target, meta))
+	w.Header().Set("Content-Security-Policy", s3ObjectAccessContentSecurityPolicy)
+}
+
+func s3ObjectAccessResponseContentDisposition(target s3.ObjectAccessTarget, meta s3store.ObjectMeta) string {
+	raw := strings.TrimSpace(target.ContentDisposition)
+	if raw == "" {
+		return "attachment"
+	}
+	disposition, params, err := mime.ParseMediaType(raw)
+	if err != nil {
+		return "attachment"
+	}
+	switch strings.ToLower(disposition) {
+	case "attachment":
+		formatted := mime.FormatMediaType("attachment", params)
+		if formatted == "" {
+			return "attachment"
+		}
+		return formatted
+	case "inline":
+		if !s3ObjectAccessAllowsInline(target.ContentType, meta.ContentType) {
+			return "attachment"
+		}
+		formatted := mime.FormatMediaType("inline", params)
+		if formatted == "" {
+			return "inline"
+		}
+		return formatted
+	default:
+		return "attachment"
+	}
+}
+
+func s3ObjectAccessAllowsInline(targetContentType, metaContentType string) bool {
+	targetMediaType, ok := s3ObjectAccessMediaType(targetContentType)
+	if !ok || !safeS3ObjectAccessInlineMediaType(targetMediaType) {
+		return false
+	}
+	metaMediaType, ok := s3ObjectAccessMediaType(metaContentType)
+	if !ok {
+		return false
+	}
+	return metaMediaType == targetMediaType
+}
+
+func s3ObjectAccessMediaType(value string) (string, bool) {
+	mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(value))
+	if err != nil || mediaType == "" {
+		return "", false
+	}
+	return strings.ToLower(mediaType), true
+}
+
+func safeS3ObjectAccessInlineMediaType(mediaType string) bool {
+	switch mediaType {
+	case "text/plain",
+		"image/avif",
+		"image/bmp",
+		"image/gif",
+		"image/jpeg",
+		"image/png",
+		"image/tiff",
+		"image/webp":
+		return true
+	default:
+		return strings.HasPrefix(mediaType, "audio/") || strings.HasPrefix(mediaType, "video/")
 	}
 }
 

--- a/gestaltd/internal/server/http_binding_replay.go
+++ b/gestaltd/internal/server/http_binding_replay.go
@@ -20,7 +20,7 @@ func newMemoryHTTPBindingReplayStore() httpBindingReplayStore {
 
 func (s *memoryHTTPBindingReplayStore) MarkIfNew(key string, ttl time.Duration) bool {
 	if s == nil || key == "" {
-		return true
+		return false
 	}
 	if ttl <= 0 {
 		ttl = 24 * time.Hour

--- a/gestaltd/internal/server/http_binding_verify.go
+++ b/gestaltd/internal/server/http_binding_verify.go
@@ -99,7 +99,7 @@ func (s *Server) verifyHTTPBindingHMACRequest(r *http.Request, binding MountedHT
 			return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "stale request timestamp", nil)
 		}
 	}
-	payload, err := httpbinding.RenderPayloadTemplate(binding.Security.PayloadTemplate, r.Header, rawBody)
+	payload, err := httpbinding.RenderPayloadTemplate(binding.Security.PayloadTemplate, r, rawBody)
 	if err != nil {
 		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "invalid http binding payload template", err)
 	}
@@ -109,10 +109,20 @@ func (s *Server) verifyHTTPBindingHMACRequest(r *http.Request, binding MountedHT
 	if subtle.ConstantTimeCompare([]byte(expected), []byte(signature)) != 1 {
 		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "invalid request signature", nil)
 	}
-	if binding.Ack != nil && strings.TrimSpace(binding.Security.TimestampHeader) != "" && binding.Security.MaxAgeSeconds > 0 {
+	if r.URL != nil && r.URL.RawQuery != "" && !httpbinding.PayloadTemplateReferencesRequestTarget(binding.Security.PayloadTemplate) {
+		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "request query must be covered by request signature", nil)
+	}
+	if strings.TrimSpace(binding.Security.TimestampHeader) != "" && binding.Security.MaxAgeSeconds > 0 {
+		if s == nil || s.httpBindingReplayStore == nil {
+			return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "http binding replay protection is not configured", nil)
+		}
 		replayKey := binding.PluginName + "\x00" + binding.Name + "\x00" + binding.SecurityName + "\x00sig:" + signature
 		if !s.httpBindingReplayStore.MarkIfNew(replayKey, time.Duration(binding.Security.MaxAgeSeconds)*time.Second) {
-			return nil, newHTTPBindingRequestError(http.StatusOK, "duplicate signed delivery", nil)
+			status := http.StatusUnauthorized
+			if binding.Ack != nil {
+				status = http.StatusOK
+			}
+			return nil, newHTTPBindingRequestError(status, "duplicate signed delivery", nil)
 		}
 	}
 	return &verifiedHTTPBindingSender{

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -218,6 +218,9 @@ func validateMountedHTTPBinding(pluginName, bindingName string, binding *config.
 		}
 		binding.RequestBody.Content = normalizedContent
 	}
+	if err := httpbinding.ValidateHTTPBindingHMACCoverage(path, binding, schemes[binding.Security]); err != nil {
+		return err
+	}
 	if binding.Ack != nil {
 		if binding.Ack.Status == 0 {
 			binding.Ack.Status = http.StatusOK

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -3,16 +3,15 @@ package server
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
-	"github.com/valon-technologies/gestalt/server/services/s3"
 )
 
 type contextKey string
@@ -20,6 +19,7 @@ type contextKey string
 const (
 	userContextKey   contextKey = "user"
 	userIDContextKey contextKey = "userID"
+	bodyLimitKey     contextKey = "bodyLimit"
 
 	anonymousEmail = "anonymous@gestalt"
 )
@@ -65,36 +65,75 @@ const (
 func maxBodyMiddleware(limit int64) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			r.Body = http.MaxBytesReader(w, r.Body, maxBodyLimitForRequest(r, limit))
+			if r.Body == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+			limiter := &requestBodyLimiter{body: r.Body, limit: limit}
+			r.Body = limiter
+			ctx := context.WithValue(r.Context(), bodyLimitKey, limiter)
+			r = r.WithContext(ctx)
 			next.ServeHTTP(w, r)
 		})
 	}
 }
 
-func maxBodyLimitForRequest(r *http.Request, defaultLimit int64) int64 {
-	if isProviderDevCompleteCallRequest(r) {
-		return providerDevCallMaxBodyBytes
-	}
-	if isS3ObjectAccessRequest(r) {
-		return s3ObjectAccessMaxBodyBytes
-	}
-	return defaultLimit
+type requestBodyLimiter struct {
+	body  io.ReadCloser
+	limit int64
+	read  int64
 }
 
-func isProviderDevCompleteCallRequest(r *http.Request) bool {
-	if r == nil || r.Method != http.MethodPost || r.URL == nil {
-		return false
+func (l *requestBodyLimiter) Read(p []byte) (int, error) {
+	if l == nil || l.body == nil {
+		return 0, io.EOF
 	}
-	rest, ok := strings.CutPrefix(r.URL.Path, providerdev.PathAttachments+"/")
-	if !ok {
-		return false
+	limit := l.limit
+	if limit < 0 {
+		return l.body.Read(p)
 	}
-	sessionID, callID, ok := strings.Cut(rest, "/calls/")
-	return ok && sessionID != "" && callID != "" && !strings.Contains(sessionID, "/") && !strings.Contains(callID, "/")
+	if l.read > limit {
+		return 0, &http.MaxBytesError{Limit: limit}
+	}
+	remaining := limit - l.read
+	if int64(len(p)) > remaining {
+		maxRead := remaining + 1
+		if maxRead < 1 {
+			maxRead = 1
+		}
+		if maxRead < int64(len(p)) {
+			p = p[:maxRead]
+		}
+	}
+	n, err := l.body.Read(p)
+	if int64(n) <= remaining {
+		l.read += int64(n)
+		return n, err
+	}
+	l.read += int64(n)
+	return int(remaining), &http.MaxBytesError{Limit: limit}
 }
 
-func isS3ObjectAccessRequest(r *http.Request) bool {
-	return r != nil && r.URL != nil && strings.HasPrefix(r.URL.Path, s3.ObjectAccessPathPrefix)
+func (l *requestBodyLimiter) Close() error {
+	if l == nil || l.body == nil {
+		return nil
+	}
+	return l.body.Close()
+}
+
+func (l *requestBodyLimiter) allow(limit int64) {
+	if l == nil || limit <= l.limit {
+		return
+	}
+	l.limit = limit
+}
+
+func allowRequestBodyBytes(r *http.Request, limit int64) {
+	if r == nil {
+		return
+	}
+	limiter, _ := r.Context().Value(bodyLimitKey).(*requestBodyLimiter)
+	limiter.allow(limit)
 }
 
 // contentSecurityPolicy is the CSP applied to all responses. script-src and

--- a/gestaltd/internal/server/provider_dev_ui_test.go
+++ b/gestaltd/internal/server/provider_dev_ui_test.go
@@ -367,10 +367,13 @@ func TestWriteProviderDevUIAssetReplacesExistingHeaders(t *testing.T) {
 	}
 }
 
-func TestMaxBodyMiddlewareAllowsLargeProviderDevCallCompletions(t *testing.T) {
+func TestMaxBodyMiddlewareRequiresValidatedLargeBodyUpgrade(t *testing.T) {
 	t.Parallel()
 
 	handler := maxBodyMiddleware(defaultMaxBodyBytes)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Validated-Dispatcher") == "yes" {
+			allowRequestBodyBytes(r, providerDevCallMaxBodyBytes)
+		}
 		if _, err := io.ReadAll(r.Body); err != nil {
 			writeError(w, http.StatusRequestEntityTooLarge, err.Error())
 			return
@@ -382,8 +385,16 @@ func TestMaxBodyMiddlewareAllowsLargeProviderDevCallCompletions(t *testing.T) {
 	providerDevAttachmentReq := httptest.NewRequest(http.MethodPost, "/api/v1/provider-dev/attachments/attach-1/calls/call-1", bytes.NewReader(largeBody))
 	providerDevAttachmentRec := httptest.NewRecorder()
 	handler.ServeHTTP(providerDevAttachmentRec, providerDevAttachmentReq)
-	if providerDevAttachmentRec.Code != http.StatusNoContent {
-		t.Fatalf("provider dev attachment completion status = %d, want %d", providerDevAttachmentRec.Code, http.StatusNoContent)
+	if providerDevAttachmentRec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("pre-auth provider dev completion status = %d, want %d", providerDevAttachmentRec.Code, http.StatusRequestEntityTooLarge)
+	}
+
+	validatedProviderDevAttachmentReq := httptest.NewRequest(http.MethodPost, "/api/v1/provider-dev/attachments/attach-1/calls/call-1", bytes.NewReader(largeBody))
+	validatedProviderDevAttachmentReq.Header.Set("X-Validated-Dispatcher", "yes")
+	validatedProviderDevAttachmentRec := httptest.NewRecorder()
+	handler.ServeHTTP(validatedProviderDevAttachmentRec, validatedProviderDevAttachmentReq)
+	if validatedProviderDevAttachmentRec.Code != http.StatusNoContent {
+		t.Fatalf("validated provider dev attachment completion status = %d, want %d", validatedProviderDevAttachmentRec.Code, http.StatusNoContent)
 	}
 
 	extraPathReq := httptest.NewRequest(http.MethodPost, "/api/v1/provider-dev/attachments/attach-1/calls/call-1/extra", bytes.NewReader(largeBody))

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -259,6 +259,54 @@ func TestS3ObjectAccessURLUploadsAndDownloadsPluginScopedObject(t *testing.T) {
 	if getResp.Header.Get("Content-Type") != "text/plain" {
 		t.Fatalf("GET Content-Type = %q, want text/plain", getResp.Header.Get("Content-Type"))
 	}
+	if getResp.Header.Get("Content-Disposition") != "attachment" {
+		t.Fatalf("GET Content-Disposition = %q, want attachment", getResp.Header.Get("Content-Disposition"))
+	}
+	if getResp.Header.Get("Content-Security-Policy") != "default-src 'none'; sandbox; base-uri 'none'; form-action 'none'; frame-ancestors 'none'" {
+		t.Fatalf("GET Content-Security-Policy = %q, want hardened object access policy", getResp.Header.Get("Content-Security-Policy"))
+	}
+
+	inlineGetURL, err := manager.MintURL(s3.ObjectAccessURLRequest{
+		PluginName:         "brain",
+		BindingName:        "brainStorage",
+		Ref:                targetRef,
+		Method:             s3store.PresignMethodGet,
+		Expires:            time.Minute,
+		ContentType:        "text/plain",
+		ContentDisposition: "inline; filename=brain.txt",
+	})
+	if err != nil {
+		t.Fatalf("MintURL(inline get): %v", err)
+	}
+	inlineGetResp, err := ts.Client().Get(inlineGetURL.URL)
+	if err != nil {
+		t.Fatalf("GET inline object access URL: %v", err)
+	}
+	_ = inlineGetResp.Body.Close()
+	if got := inlineGetResp.Header.Get("Content-Disposition"); !strings.HasPrefix(got, "inline") {
+		t.Fatalf("inline GET Content-Disposition = %q, want inline", got)
+	}
+
+	unsafeInlineGetURL, err := manager.MintURL(s3.ObjectAccessURLRequest{
+		PluginName:         "brain",
+		BindingName:        "brainStorage",
+		Ref:                targetRef,
+		Method:             s3store.PresignMethodGet,
+		Expires:            time.Minute,
+		ContentType:        "text/html",
+		ContentDisposition: "inline",
+	})
+	if err != nil {
+		t.Fatalf("MintURL(unsafe inline get): %v", err)
+	}
+	unsafeInlineGetResp, err := ts.Client().Get(unsafeInlineGetURL.URL)
+	if err != nil {
+		t.Fatalf("GET unsafe inline object access URL: %v", err)
+	}
+	_ = unsafeInlineGetResp.Body.Close()
+	if got := unsafeInlineGetResp.Header.Get("Content-Disposition"); got != "attachment" {
+		t.Fatalf("unsafe inline GET Content-Disposition = %q, want attachment", got)
+	}
 
 	constrainedGetURL, err := manager.MintURL(s3.ObjectAccessURLRequest{
 		PluginName:  "brain",
@@ -16537,7 +16585,18 @@ func TestHostedHTTPBinding_HMACAckDispatchesOperationAndRejectsReplay(t *testing
 						},
 						SignatureHeader: "X-Request-Signature",
 						SignaturePrefix: "v0=",
-						PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+						PayloadTemplate: "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{request_target}:{raw_body}",
+						TimestampHeader: "X-Request-Timestamp",
+						MaxAgeSeconds:   300,
+					},
+					"unsignedQuery": {
+						Type: providermanifestv1.HTTPSecuritySchemeTypeHMAC,
+						Secret: &providermanifestv1.HTTPSecretRef{
+							Env: "REQUEST_SIGNING_SECRET",
+						},
+						SignatureHeader: "X-Request-Signature",
+						SignaturePrefix: "v0=",
+						PayloadTemplate: "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}",
 						TimestampHeader: "X-Request-Timestamp",
 						MaxAgeSeconds:   300,
 					},
@@ -16560,6 +16619,18 @@ func TestHostedHTTPBinding_HMACAckDispatchesOperationAndRejectsReplay(t *testing
 							},
 						},
 					},
+					"unsigned-query": {
+						Path:   "/unsigned-query",
+						Method: http.MethodPost,
+						RequestBody: &providermanifestv1.HTTPRequestBody{
+							Required: true,
+							Content: map[string]*providermanifestv1.HTTPMediaType{
+								"application/x-www-form-urlencoded": {},
+							},
+						},
+						Security: "unsignedQuery",
+						Target:   "handle_command",
+					},
 				},
 			},
 		}
@@ -16569,14 +16640,16 @@ func TestHostedHTTPBinding_HMACAckDispatchesOperationAndRejectsReplay(t *testing
 
 	body := "text=hello&callback_url=https%3A%2F%2Fhooks.example.test%2Fresponse"
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+body)
+	contentType := "application/x-www-form-urlencoded"
+	requestTarget := "/api/v1/signed/command?source=query"
+	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+contentType+":"+requestTarget+":"+body)
 
 	makeRequest := func() *http.Request {
-		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/signed/command?source=query", strings.NewReader(body))
+		req, err := http.NewRequest(http.MethodPost, ts.URL+requestTarget, strings.NewReader(body))
 		if err != nil {
 			t.Fatalf("NewRequest: %v", err)
 		}
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Content-Type", contentType)
 		req.Header.Set("X-Request-Timestamp", timestamp)
 		req.Header.Set("X-Request-Signature", signature)
 		return req
@@ -16641,6 +16714,24 @@ func TestHostedHTTPBinding_HMACAckDispatchesOperationAndRejectsReplay(t *testing
 	if got, want := duplicateAck["status"], "accepted"; got != want {
 		t.Fatalf("duplicate status = %#v, want %q", got, want)
 	}
+
+	unsignedQuerySignature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+contentType+":"+body)
+	unsignedQueryReq, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/signed/unsigned-query?source=query", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest(unsigned query): %v", err)
+	}
+	unsignedQueryReq.Header.Set("Content-Type", contentType)
+	unsignedQueryReq.Header.Set("X-Request-Timestamp", timestamp)
+	unsignedQueryReq.Header.Set("X-Request-Signature", unsignedQuerySignature)
+	unsignedQueryResp, err := http.DefaultClient.Do(unsignedQueryReq)
+	if err != nil {
+		t.Fatalf("unsigned query hmac request: %v", err)
+	}
+	_ = unsignedQueryResp.Body.Close()
+	if unsignedQueryResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unsigned query status = %d, want %d", unsignedQueryResp.StatusCode, http.StatusUnauthorized)
+	}
+
 	select {
 	case invocation := <-invocations:
 		t.Fatalf("unexpected duplicate async dispatch: %#v", invocation)
@@ -16678,7 +16769,7 @@ func TestHostedHTTPBinding_MergesManifestAndConfigOverrides(t *testing.T) {
 								Type:            providermanifestv1.HTTPSecuritySchemeTypeHMAC,
 								SignatureHeader: "X-Request-Signature",
 								SignaturePrefix: "v0=",
-								PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+								PayloadTemplate: "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}",
 								TimestampHeader: "X-Request-Timestamp",
 								MaxAgeSeconds:   300,
 							},
@@ -16721,13 +16812,14 @@ func TestHostedHTTPBinding_MergesManifestAndConfigOverrides(t *testing.T) {
 
 	body := "text=hello"
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+body)
+	contentType := "application/x-www-form-urlencoded"
+	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+contentType+":"+body)
 
 	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/signed/command", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("X-Request-Timestamp", timestamp)
 	req.Header.Set("X-Request-Signature", signature)
 
@@ -16757,7 +16849,7 @@ func TestHostedHTTPBinding_MergesManifestAndConfigOverrides(t *testing.T) {
 	}
 }
 
-func TestHostedHTTPBinding_HMACSyncRetriesReinvokeOperation(t *testing.T) {
+func TestHostedHTTPBinding_HMACSyncRejectsReplay(t *testing.T) {
 	t.Setenv("REQUEST_SIGNING_SECRET", "super-secret")
 
 	invocations := make(chan map[string]any, 2)
@@ -16786,7 +16878,7 @@ func TestHostedHTTPBinding_HMACSyncRetriesReinvokeOperation(t *testing.T) {
 						Secret:          &providermanifestv1.HTTPSecretRef{Env: "REQUEST_SIGNING_SECRET"},
 						SignatureHeader: "X-Request-Signature",
 						SignaturePrefix: "v0=",
-						PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+						PayloadTemplate: "v0:{header:X-Request-Timestamp}:{header:Content-Type}:{raw_body}",
 						TimestampHeader: "X-Request-Timestamp",
 						MaxAgeSeconds:   300,
 					},
@@ -16813,47 +16905,58 @@ func TestHostedHTTPBinding_HMACSyncRetriesReinvokeOperation(t *testing.T) {
 
 	body := "text=ping"
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+body)
+	contentType := "application/x-www-form-urlencoded"
+	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+contentType+":"+body)
 
 	makeRequest := func() *http.Request {
 		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/signed/command", strings.NewReader(body))
 		if err != nil {
 			t.Fatalf("NewRequest: %v", err)
 		}
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Content-Type", contentType)
 		req.Header.Set("X-Request-Timestamp", timestamp)
 		req.Header.Set("X-Request-Signature", signature)
 		return req
 	}
 
-	for i := 0; i < 2; i++ {
-		resp, err := http.DefaultClient.Do(makeRequest())
-		if err != nil {
-			t.Fatalf("sync hmac request %d: %v", i, err)
-		}
-		var result map[string]any
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			_ = resp.Body.Close()
-			t.Fatalf("decode sync result %d: %v", i, err)
-		}
+	resp, err := http.DefaultClient.Do(makeRequest())
+	if err != nil {
+		t.Fatalf("sync hmac request: %v", err)
+	}
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		_ = resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("sync status %d = %d, want %d", i, resp.StatusCode, http.StatusOK)
-		}
-		if got, want := result["text"], "pong"; got != want {
-			t.Fatalf("sync result %d text = %#v, want %q", i, got, want)
-		}
+		t.Fatalf("decode sync result: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("sync status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got, want := result["text"], "pong"; got != want {
+		t.Fatalf("sync result text = %#v, want %q", got, want)
 	}
 
-	for i := 0; i < 2; i++ {
-		select {
-		case params := <-invocations:
-			if got, want := params["text"], "ping"; got != want {
-				t.Fatalf("invocation %d text = %#v, want %q", i, got, want)
-			}
-		case <-time.After(2 * time.Second):
-			t.Fatalf("timed out waiting for sync invocation %d", i)
+	resp, err = http.DefaultClient.Do(makeRequest())
+	if err != nil {
+		t.Fatalf("duplicate sync hmac request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("duplicate sync status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	select {
+	case params := <-invocations:
+		if got, want := params["text"], "ping"; got != want {
+			t.Fatalf("invocation text = %#v, want %q", got, want)
 		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for sync invocation")
+	}
+	select {
+	case params := <-invocations:
+		t.Fatalf("unexpected duplicate invocation: %#v", params)
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 
@@ -17765,6 +17868,82 @@ func TestHostedHTTPBinding_RejectsInvalidConfigBindings(t *testing.T) {
 				},
 			},
 			wantErr: "signatureHeader is required",
+		},
+		{
+			name: "missing hmac timestamp replay protection",
+			entry: &config.ProviderEntry{
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type:            providermanifestv1.HTTPSecuritySchemeTypeHMAC,
+						Secret:          &providermanifestv1.HTTPSecretRef{Secret: "shared-key"},
+						SignatureHeader: "X-Request-Signature",
+						PayloadTemplate: "{raw_body}",
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+			wantErr: "timestampHeader is required for replay protection",
+		},
+		{
+			name: "hmac request body content type not signed",
+			entry: &config.ProviderEntry{
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type:            providermanifestv1.HTTPSecuritySchemeTypeHMAC,
+						Secret:          &providermanifestv1.HTTPSecretRef{Secret: "shared-key"},
+						SignatureHeader: "X-Request-Signature",
+						PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+						TimestampHeader: "X-Request-Timestamp",
+						MaxAgeSeconds:   300,
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:   "/event",
+						Method: http.MethodPost,
+						RequestBody: &providermanifestv1.HTTPRequestBody{
+							Content: map[string]*providermanifestv1.HTTPMediaType{
+								"application/json":                  {},
+								"application/x-www-form-urlencoded": {},
+							},
+						},
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+			wantErr: "payloadTemplate must include {header:Content-Type}",
+		},
+		{
+			name: "hmac implicit body parser content type not signed",
+			entry: &config.ProviderEntry{
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type:            providermanifestv1.HTTPSecuritySchemeTypeHMAC,
+						Secret:          &providermanifestv1.HTTPSecretRef{Secret: "shared-key"},
+						SignatureHeader: "X-Request-Signature",
+						PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+						TimestampHeader: "X-Request-Timestamp",
+						MaxAgeSeconds:   300,
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+			wantErr: "payloadTemplate must include {header:Content-Type}",
 		},
 		{
 			name: "duplicate normalized content types",


### PR DESCRIPTION
## Summary
- Serve S3 object-access downloads with attachment-by-default disposition plus a route-specific restrictive CSP, allowing inline only for explicitly requested safe media types that match stored object metadata.
- Move oversized request-body budgets behind validated S3 object-access/provider-dev dispatch paths instead of URL-prefix pre-auth matching.
- Require HMAC HTTP bindings to include replay protection and sign Content-Type when request body parsing is configured; reject sync replays instead of reinvoking.
- Refuse to send stored CLI bearer credentials to a project-config URL that differs from the credential's server URL, while preserving `GESTALT_API_KEY` as an explicit override.
- Add explicit `raw-hex:` and `argon2id:` encryption-key modes and update docs/examples; legacy unprefixed 64-hex keys remain compatible.

## Verification
- `cargo test --manifest-path gestalt/Cargo.toml --package gestalt --test config_resolution`
- `go test ./internal/server ./internal/httpbinding ./internal/providerpkg ./internal/config ./core/crypto`
- `cargo test --manifest-path gestalt/Cargo.toml --package gestalt`
- `go test ./internal/bootstrap -run TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartFails -count=1`
- `go test ./internal/daemon -run 'TestE2EProviderDevAutoMountsOwnedUI|TestE2EProviderDevAutoMountsSiblingUIForPlugin|TestE2EHostedHTTPSubjectResolutionUsesAuthorizationAndInheritedInvocation|TestE2EServeMountsManifestHostedHTTPBindingsForLocalSourcePlugin|TestE2EProviderDevServesAdminWithoutInjectingRootUI' -count=1`

Attempted `go test ./...` from `gestaltd/`; it failed in `internal/bootstrap` and `internal/daemon` readiness/socket-timeout E2E cases while all changed/focused packages passed. The exact failed bootstrap and daemon tests passed on sequential rerun.