### PR TITLE
gestaltd: route runtime callbacks through public relay

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -295,9 +295,11 @@ func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *tes
 	}
 
 	deps := Deps{
-		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		AgentRuntime:  &agentRuntime{providers: map[string]coreagent.Provider{}},
 	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 	buildCtx := context.WithValue(context.Background(), agentRuntimeFactoryContextKey{}, ctxSentinel)
 	agents, err := buildAgents(buildCtx, cfg, factories, deps)
 	if err != nil {
@@ -378,10 +380,12 @@ func TestAgentRuntimeConfigStartsHostedAgentWarmPool(t *testing.T) {
 	agentRuntime := &agentRuntime{providers: map[string]coreagent.Provider{}}
 	agentRuntime.SetToolGrants(newTestAgentToolGrants(t))
 	deps := Deps{
-		Services:              services,
-		AgentRuntime:          agentRuntime,
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		Services:      services,
+		AgentRuntime:  agentRuntime,
 	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 	agents, err := buildAgents(context.Background(), cfg, factories, deps)
 	if err != nil {
 		t.Fatalf("buildAgents: %v", err)
@@ -516,10 +520,12 @@ func TestAgentRuntimeConfigScalesOutHostedAgentWarmPool(t *testing.T) {
 	agentRuntime := &agentRuntime{providers: map[string]coreagent.Provider{}}
 	agentRuntime.SetToolGrants(newTestAgentToolGrants(t))
 	deps := Deps{
-		Services:              services,
-		AgentRuntime:          agentRuntime,
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		Services:      services,
+		AgentRuntime:  agentRuntime,
 	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 	agents, err := buildAgents(context.Background(), cfg, factories, deps)
 	if err != nil {
 		t.Fatalf("buildAgents: %v", err)
@@ -620,11 +626,13 @@ func TestAgentRuntimeConfigRestartsUnhealthyHostedAgent(t *testing.T) {
 		},
 	}
 	deps := Deps{
-		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
-		IndexedDBDefs:         testAgentRuntimeIndexedDBDefs(),
-		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+		BaseURL:          "https://gestalt.example.test",
+		EncryptionKey:    []byte("0123456789abcdef0123456789abcdef"),
+		AgentRuntime:     &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:    testAgentRuntimeIndexedDBDefs(),
+		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
 	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 	agents, err := buildAgents(context.Background(), cfg, factories, deps)
 	if err != nil {
 		t.Fatalf("buildAgents: %v", err)
@@ -709,11 +717,13 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 		},
 	}
 	deps := Deps{
-		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
-		IndexedDBDefs:         testAgentRuntimeIndexedDBDefs(),
-		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+		BaseURL:          "https://gestalt.example.test",
+		EncryptionKey:    []byte("0123456789abcdef0123456789abcdef"),
+		AgentRuntime:     &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:    testAgentRuntimeIndexedDBDefs(),
+		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
 	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 	agents, err := buildAgents(context.Background(), cfg, factories, deps)
 	if err != nil {
 		t.Fatalf("buildAgents: %v", err)
@@ -817,11 +827,13 @@ func TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartF
 		},
 	}
 	deps := Deps{
-		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
-		IndexedDBDefs:         testAgentRuntimeIndexedDBDefs(),
-		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+		BaseURL:          "https://gestalt.example.test",
+		EncryptionKey:    []byte("0123456789abcdef0123456789abcdef"),
+		AgentRuntime:     &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:    testAgentRuntimeIndexedDBDefs(),
+		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
 	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 	agents, err := buildAgents(context.Background(), cfg, factories, deps)
 	if err != nil {
 		t.Fatalf("buildAgents: %v", err)
@@ -924,11 +936,13 @@ func TestAgentRuntimeConfigProactiveReplacementRespectsMaxReadyInstances(t *test
 		},
 	}
 	deps := Deps{
-		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
-		IndexedDBDefs:         testAgentRuntimeIndexedDBDefs(),
-		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+		BaseURL:          "https://gestalt.example.test",
+		EncryptionKey:    []byte("0123456789abcdef0123456789abcdef"),
+		AgentRuntime:     &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:    testAgentRuntimeIndexedDBDefs(),
+		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
 	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 	agents, err := buildAgents(context.Background(), cfg, factories, deps)
 	if err != nil {
 		t.Fatalf("buildAgents: %v", err)
@@ -1000,11 +1014,13 @@ func TestAgentRuntimeConfigDoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntim
 		},
 	}
 	deps := Deps{
-		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
-		IndexedDBDefs:         testAgentRuntimeIndexedDBDefs(),
-		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+		BaseURL:          "https://gestalt.example.test",
+		EncryptionKey:    []byte("0123456789abcdef0123456789abcdef"),
+		AgentRuntime:     &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:    testAgentRuntimeIndexedDBDefs(),
+		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
 	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 	agents, err := buildAgents(context.Background(), cfg, factories, deps)
 	if err != nil {
 		t.Fatalf("buildAgents: %v", err)
@@ -1069,11 +1085,13 @@ func TestAgentRuntimeConfigReplacesExpiresOnlyRuntimeBeforeExpiry(t *testing.T) 
 		},
 	}
 	deps := Deps{
-		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
-		IndexedDBDefs:         testAgentRuntimeIndexedDBDefs(),
-		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+		BaseURL:          "https://gestalt.example.test",
+		EncryptionKey:    []byte("0123456789abcdef0123456789abcdef"),
+		AgentRuntime:     &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:    testAgentRuntimeIndexedDBDefs(),
+		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
 	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 	agents, err := buildAgents(context.Background(), cfg, factories, deps)
 	if err != nil {
 		t.Fatalf("buildAgents: %v", err)
@@ -1374,10 +1392,16 @@ func TestHostedAgentProviderPoolListSessionsContinuesAfterTransientBackendFailur
 	}
 }
 
-func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
+func TestAgentRuntimeConfigUsesPublicAgentHostBinding(t *testing.T) {
 	t.Parallel()
 
 	bin := buildAgentProviderBinary(t)
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
+	relaySrv.EnableHTTP2 = true
+	relaySrv.StartTLS()
+	testutil.CloseOnCleanup(t, relaySrv)
 
 	services, err := coredata.New(&coretesting.StubIndexedDB{})
 	if err != nil {
@@ -1431,8 +1455,11 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 	}
 
 	deps := Deps{
-		Services:     services,
-		AgentRuntime: agentRuntime,
+		BaseURL:            relaySrv.URL,
+		EncryptionKey:      secret,
+		Services:           services,
+		AgentRuntime:       agentRuntime,
+		PublicHostServices: publicHostServices,
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 
@@ -1567,152 +1594,21 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 		t.Fatalf("GetSession(after CreateTurn) = %#v, want preserved client_ref cli-session-2", postTurnSession)
 	}
 
-	toolGrant, err := toolGrants.Mint(agentgrant.Grant{
-		ProviderName: "simple",
-		SessionID:    "session-1",
-		TurnID:       "turn-1",
-		SubjectID:    "user:user-123",
-		SubjectKind:  string(principal.KindUser),
-		Permissions: []core.AccessPermission{{
-			Plugin:     "roadmap",
-			Operations: []string{"sync"},
-		}},
-		ToolRefs: []coreagent.ToolRef{{
-			Plugin:         "roadmap",
-			Operation:      "sync",
-			CredentialMode: core.ConnectionModeNone,
-		}},
-		ToolSource: coreagent.ToolSourceModeNativeSearch,
-	})
-	if err != nil {
-		t.Fatalf("Mint tool grant: %v", err)
-	}
-	toolTurn, err := agents[0].CreateTurn(context.Background(), coreagent.CreateTurnRequest{
-		TurnID:       "turn-1",
-		SessionID:    "session-1",
-		Model:        "gpt-test",
-		CreatedBy:    coreagent.Actor{SubjectID: "user:user-123"},
-		ExecutionRef: "exec-turn-1",
-		Messages:     []coreagent.Message{{Role: "user", Text: "Plan it"}},
-		ToolRefs: []coreagent.ToolRef{{
-			Plugin:         "roadmap",
-			Operation:      "sync",
-			CredentialMode: core.ConnectionModeNone,
-		}},
-		ToolSource: coreagent.ToolSourceModeNativeSearch,
-		ToolGrant:  toolGrant,
-		Tools: []coreagent.Tool{{
-			ID: mustMintAgentToolID(t, toolGrants, coreagent.ToolTarget{
-				Plugin:         "roadmap",
-				Operation:      "sync",
-				CredentialMode: core.ConnectionModeNone,
-			}),
-			Name: "Lookup roadmap task",
-			Target: coreagent.ToolTarget{
-				Plugin:         "roadmap",
-				Operation:      "sync",
-				CredentialMode: core.ConnectionModeNone,
-			},
-		}},
-	})
-	if err != nil {
-		t.Fatalf("CreateTurn: %v", err)
-	}
-	if toolTurn == nil {
-		t.Fatal("CreateTurn returned nil turn")
-		return
-	}
-
-	var output struct {
-		ProviderName string `json:"provider_name"`
-		ToolStatus   int    `json:"tool_status"`
-		ToolBody     string `json:"tool_body"`
-		EventEmitted bool   `json:"event_emitted"`
-		HostError    string `json:"host_error"`
-		ToolError    string `json:"tool_error"`
-		EventError   string `json:"event_error"`
-	}
-	if err := json.Unmarshal([]byte(toolTurn.OutputText), &output); err != nil {
-		t.Fatalf("json.Unmarshal(toolTurn.OutputText): %v", err)
-	}
-	if output.ProviderName != "simple" {
-		t.Fatalf("provider_name = %q, want simple", output.ProviderName)
-	}
-	if output.ToolStatus != http.StatusAccepted {
-		t.Fatalf("tool_status = %d, want %d (output=%s)", output.ToolStatus, http.StatusAccepted, toolTurn.OutputText)
-	}
-	if output.ToolBody != `{"taskId":"task-123"}` {
-		t.Fatalf("tool_body = %q, want %q", output.ToolBody, `{"taskId":"task-123"}`)
-	}
-	if !output.EventEmitted {
-		t.Fatal("event_emitted = false, want true")
-	}
-	if output.HostError != "" || output.ToolError != "" || output.EventError != "" {
-		t.Fatalf("runtime callback errors = %+v", output)
-	}
-
-	calls := invoker.Calls()
-	if len(calls) != 1 {
-		t.Fatalf("invoker calls = %d, want 1", len(calls))
-	}
-	if calls[0].providerName != "roadmap" || calls[0].operation != "sync" {
-		t.Fatalf("invoker call = %+v", calls[0])
-	}
-	if calls[0].params["taskId"] != "task-123" {
-		t.Fatalf("invoker params = %#v, want taskId=task-123", calls[0].params)
-	}
-	if calls[0].subjectID != "user:user-123" {
-		t.Fatalf("invoker subject_id = %q, want user:user-123", calls[0].subjectID)
-	}
-	if calls[0].credentialModeOverride != core.ConnectionModeNone {
-		t.Fatalf("invoker credential mode override = %q, want %q", calls[0].credentialModeOverride, core.ConnectionModeNone)
-	}
-	if calls[0].idempotencyKey != "tool-call-key-1" {
-		t.Fatalf("invoker idempotency key = %q, want tool-call-key-1", calls[0].idempotencyKey)
-	}
-
-	events, err := agents[0].ListTurnEvents(context.Background(), coreagent.ListTurnEventsRequest{
-		TurnID:   "turn-1",
-		AfterSeq: 0,
-		Limit:    10,
-	})
-	if err != nil {
-		t.Fatalf("ListTurnEvents: %v", err)
-	}
-	if len(events) == 0 {
-		t.Fatal("ListTurnEvents returned no events")
-	}
-	foundAgentTest := false
-	for _, event := range events {
-		if event.Type != "agent.test" {
-			continue
-		}
-		foundAgentTest = true
-		if event.Data["provider_name"] != "simple" {
-			t.Fatalf("agent.test event data = %#v, want provider_name=simple", event.Data)
-		}
-		if display := event.Display; display == nil || display.Kind != "status" || display.Label != "provider event" || display.Text != "simple" {
-			t.Fatalf("agent.test display = %#v, want provider event display for simple", display)
-		}
-	}
-	if !foundAgentTest {
-		t.Fatalf("events = %#v, want agent.test event", events)
-	}
-
 	bindRequests := capturingRuntime.bindHostServiceRequests()
 	foundAgentHost := false
 	foundRuntimeLogHost := false
+	wantRelayTarget := "tls://" + relaySrv.Listener.Addr().String()
 	for _, req := range bindRequests {
 		switch req.EnvVar {
 		case agentservice.DefaultHostSocketEnv:
 			foundAgentHost = true
-			if got := req.Relay.DialTarget; !strings.HasPrefix(got, "unix://") {
-				t.Fatalf("agent host relay target = %q, want unix relay target", got)
+			if got := req.Relay.DialTarget; got != wantRelayTarget {
+				t.Fatalf("agent host relay target = %q, want %q", got, wantRelayTarget)
 			}
 		case runtimehost.DefaultRuntimeLogHostSocketEnv:
 			foundRuntimeLogHost = true
-			if got := req.Relay.DialTarget; !strings.HasPrefix(got, "unix://") {
-				t.Fatalf("runtime log host relay target = %q, want unix relay target", got)
+			if got := req.Relay.DialTarget; got != wantRelayTarget {
+				t.Fatalf("runtime log host relay target = %q, want %q", got, wantRelayTarget)
 			}
 		}
 	}
@@ -2536,7 +2432,11 @@ func TestAgentRuntimeImageLaunchUsesManifestEntrypoint(t *testing.T) {
 
 	launch, err := prepareHostedAgentProviderLaunch(context.Background(), "simple", entry, mustNode(t, map[string]any{
 		"name": "simple",
-	}), Deps{PluginRuntime: runtimeProvider})
+	}), Deps{
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		PluginRuntime: runtimeProvider,
+	})
 	if err != nil {
 		t.Fatalf("prepareHostedAgentProviderLaunch: %v", err)
 	}
@@ -2615,11 +2515,17 @@ func TestAgentRuntimeTemplateLaunchUsesManifestEntrypoint(t *testing.T) {
 		},
 	}
 
+	deps := Deps{
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
 	launch, err := prepareHostedAgentProviderLaunch(context.Background(), "simple", entry, mustNode(t, map[string]any{
 		"name":    "simple",
 		"command": "/host/only/agent",
 		"args":    []string{"host-arg"},
-	}), Deps{PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{})})
+	}), deps)
 	if err != nil {
 		t.Fatalf("prepareHostedAgentProviderLaunch: %v", err)
 	}
@@ -2656,7 +2562,10 @@ func TestAgentRuntimeLocalFallbackImageLaunchUsesConfiguredCommand(t *testing.T)
 		"name":    "simple",
 		"command": "/host/only/agent",
 		"args":    []string{"host-arg"},
-	}), Deps{})
+	}), Deps{
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+	})
 	if err != nil {
 		t.Fatalf("prepareHostedAgentProviderLaunch: %v", err)
 	}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -166,6 +167,8 @@ type Deps struct {
 	PluginRuntime         pluginruntime.Provider
 	PluginRuntimeRegistry *pluginRuntimeRegistry
 	PublicHostServices    *runtimehost.PublicHostServiceRegistry
+	HostServiceTLSCAFile  string
+	HostServiceTLSCAPEM   string
 	Telemetry             core.TelemetryProvider
 }
 
@@ -780,13 +783,19 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: agent tool grants: %w", err)
 	}
+	hostServiceTLSCAFile, hostServiceTLSCAPEM, err := hostServiceTLSCAFromEnv()
+	if err != nil {
+		return nil, err
+	}
 
 	deps := Deps{
-		EncryptionKey:   encKey,
-		BaseURL:         cfg.Server.BaseURL,
-		SecretManager:   sm,
-		Telemetry:       tp,
-		AgentToolGrants: agentToolGrants,
+		EncryptionKey:        encKey,
+		BaseURL:              cfg.Server.BaseURL,
+		SecretManager:        sm,
+		Telemetry:            tp,
+		AgentToolGrants:      agentToolGrants,
+		HostServiceTLSCAFile: hostServiceTLSCAFile,
+		HostServiceTLSCAPEM:  hostServiceTLSCAPEM,
 	}
 	workflowRuntime, err := newWorkflowRuntime(cfg)
 	if err != nil {
@@ -930,6 +939,24 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		Deps:                  deps,
 		pluginRuntimeRegistry: runtimeRegistry,
 	}, nil
+}
+
+func hostServiceTLSCAFromEnv() (caFile string, caPEM string, err error) {
+	if pemValue := strings.TrimSpace(os.Getenv(hostServiceTLSCAPEMEnv)); pemValue != "" {
+		return "", pemValue, nil
+	}
+	caFile = strings.TrimSpace(os.Getenv(hostServiceTLSCAFileEnv))
+	if caFile == "" {
+		return "", "", nil
+	}
+	data, err := os.ReadFile(caFile)
+	if err != nil {
+		return "", "", fmt.Errorf("bootstrap: read %s %q: %w", hostServiceTLSCAFileEnv, caFile, err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return "", "", fmt.Errorf("bootstrap: %s %q is empty", hostServiceTLSCAFileEnv, caFile)
+	}
+	return "", strings.TrimSpace(string(data)), nil
 }
 
 func (p *preparedCore) Close(ctx context.Context) error {

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -1395,8 +1396,8 @@ func assertHostServiceRelayBindings(t *testing.T, requests []pluginruntime.BindH
 	}
 	foundWantEnv := false
 	for _, req := range requests {
-		if !strings.HasPrefix(req.Relay.DialTarget, "unix://") {
-			t.Fatalf("BindHostService(%s) Relay.DialTarget = %q, want unix:// host relay target", req.EnvVar, req.Relay.DialTarget)
+		if !strings.HasPrefix(req.Relay.DialTarget, "tls://") {
+			t.Fatalf("BindHostService(%s) Relay.DialTarget = %q, want tls:// public relay target", req.EnvVar, req.Relay.DialTarget)
 		}
 		if req.EnvVar == wantEnvVar {
 			foundWantEnv = true
@@ -2976,6 +2977,13 @@ func newNestedInvokeHarness(t *testing.T, brokerOpts ...invocation.BrokerOption)
 	}
 
 	bridge := newLazyInvoker()
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	callerInvokes := []config.PluginInvocationDependency{
+		{Plugin: "example", Operation: "request_context"},
+	}
+	exampleInvokes := []config.PluginInvocationDependency{
+		{Plugin: "example", Operation: "request_context"},
+	}
 	cfg := &config.Config{
 		Plugins: map[string]*config.ProviderEntry{
 			"caller": {
@@ -2983,17 +2991,13 @@ func newNestedInvokeHarness(t *testing.T, brokerOpts ...invocation.BrokerOption)
 				Args:                 []string{"provider"},
 				ResolvedManifest:     callerManifest,
 				ResolvedManifestPath: filepath.Join(callerRoot, "manifest.yaml"),
-				Invokes: []config.PluginInvocationDependency{
-					{Plugin: "example", Operation: "request_context"},
-				},
+				Invokes:              callerInvokes,
 			},
 			"example": {
 				Command:              exampleBin,
 				ResolvedManifest:     exampleManifest,
 				ResolvedManifestPath: filepath.Join(exampleRoot, "manifest.yaml"),
-				Invokes: []config.PluginInvocationDependency{
-					{Plugin: "example", Operation: "request_context"},
-				},
+				Invokes:              exampleInvokes,
 				Config: mustNode(t, map[string]any{
 					"greeting": "Hello from nested invoke",
 				}),
@@ -3001,9 +3005,18 @@ func newNestedInvokeHarness(t *testing.T, brokerOpts ...invocation.BrokerOption)
 		},
 	}
 
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+	pluginInvokerTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager(plugin invoker): %v", err)
+	}
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
+		EncryptionKey: secret,
 		PluginInvoker: bridge,
-	})
+	}, withRuntimeRelayPluginCoreHostService("caller", "plugin_invoker", plugininvokerservice.DefaultSocketEnv, "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
+		proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("caller", pluginInvocationDependencies(callerInvokes), bridge, pluginInvokerTokens))
+	}), withRuntimeRelayPluginCoreHostService("example", "plugin_invoker", plugininvokerservice.DefaultSocketEnv, "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
+		proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("example", pluginInvocationDependencies(exampleInvokes), bridge, pluginInvokerTokens))
+	})))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -3130,9 +3143,17 @@ func newGraphQLSurfaceInvokeHarness(t *testing.T, graphQLURL string, allowSurfac
 		},
 	}
 
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	pluginInvokerTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager(plugin invoker): %v", err)
+	}
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
+		EncryptionKey: secret,
 		PluginInvoker: bridge,
-	})
+	}, withRuntimeRelayCoreHostService("plugin_invoker", plugininvokerservice.DefaultSocketEnv, "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
+		proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("caller", pluginInvocationDependencies(callerInvokes), bridge, pluginInvokerTokens))
+	})))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -3626,13 +3647,13 @@ func TestPluginIndexedDBExposeHostSocketEnv(t *testing.T) {
 
 	checkEnv := func(t *testing.T, indexedDB *config.HostIndexedDBBindingConfig, envName string) bool {
 		t.Helper()
-		providers, _, err := buildProvidersStrict(context.Background(), makeConfig(indexedDB), NewFactoryRegistry(), Deps{
+		providers, _, err := buildProvidersStrict(context.Background(), makeConfig(indexedDB), NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 			SelectedIndexedDBName: "main",
 			IndexedDBDefs:         indexedDBDefs,
 			IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) {
 				return &coretesting.StubIndexedDB{}, nil
 			},
-		})
+		}))
 		if err != nil {
 			t.Fatalf("buildProvidersStrict: %v", err)
 		}
@@ -3700,7 +3721,7 @@ func TestPluginInvokesExposeHostSocketEnv(t *testing.T) {
 		},
 	}
 
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -3751,9 +3772,9 @@ func TestPluginWorkflowManagerExposeHostSocketEnv(t *testing.T) {
 		},
 	}
 
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		WorkflowManager: newStubWorkflowManager(),
-	})
+	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -3804,9 +3825,9 @@ func TestPluginAgentManagerExposeHostSocketEnv(t *testing.T) {
 		},
 	}
 
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		AgentRuntime: &agentRuntime{providers: map[string]coreagent.Provider{}},
-	})
+	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -3960,7 +3981,7 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	defer func() { _ = CloseProviders(providers) }()
-	assertPublicHostServicesExclude(t, publicHostServices, "agent_manager", agentservice.DefaultManagerSocketEnv)
+	assertPublicHostServicesVerified(t, publicHostServices, "agent_manager", agentservice.DefaultManagerSocketEnv)
 
 	prov, err := providers.Get("echoext")
 	if err != nil {
@@ -4098,9 +4119,9 @@ func TestPluginHostedHTTPBindingsExposeAuthorizationSocketEnv(t *testing.T) {
 		},
 	}
 
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		AuthorizationProvider: &hostedHTTPAuthorizationProvider{},
-	})
+	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -4164,9 +4185,17 @@ func TestPluginWorkflowManagerCRUDUsesRequestContext(t *testing.T) {
 		},
 	}
 
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	workflowManagerTokens, err := workflowservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager(workflow manager): %v", err)
+	}
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
+		EncryptionKey:   secret,
 		WorkflowManager: manager,
-	})
+	}, withRuntimeRelayCoreHostService("workflow_manager", workflowservice.DefaultManagerSocketEnv, "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
+		proto.RegisterWorkflowManagerHostServer(srv, workflowservice.NewManagerServer("echo", manager, workflowManagerTokens))
+	})))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -4544,9 +4573,18 @@ func TestPluginWorkflowManagerRejectsInvalidInvocationToken(t *testing.T) {
 		},
 	}
 
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
-		WorkflowManager: newStubWorkflowManager(),
-	})
+	manager := newStubWorkflowManager()
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	workflowManagerTokens, err := workflowservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager(workflow manager): %v", err)
+	}
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
+		EncryptionKey:   secret,
+		WorkflowManager: manager,
+	}, withRuntimeRelayCoreHostService("workflow_manager", workflowservice.DefaultManagerSocketEnv, "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
+		proto.RegisterWorkflowManagerHostServer(srv, workflowservice.NewManagerServer("echo", manager, workflowManagerTokens))
+	})))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -5257,12 +5295,12 @@ func TestPluginCacheBindingsExposeHostSocketEnv(t *testing.T) {
 
 	checkEnv := func(t *testing.T, bindings []string, envName string) bool {
 		t.Helper()
-		providers, _, err := buildProvidersStrict(context.Background(), makeConfig(bindings), NewFactoryRegistry(), Deps{
+		providers, _, err := buildProvidersStrict(context.Background(), makeConfig(bindings), NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 			CacheDefs: cacheBindings,
 			CacheFactory: func(yaml.Node) (corecache.Cache, error) {
 				return coretesting.NewStubCache(), nil
 			},
-		})
+		}))
 		if err != nil {
 			t.Fatalf("buildProvidersStrict: %v", err)
 		}
@@ -5442,9 +5480,9 @@ func TestInjectedPluginRuntimeStopSessionTimeoutDoesNotHangBootstrapFailure(t *t
 
 	done := make(chan error, 1)
 	go func() {
-		_, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+		_, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 			PluginRuntime: runtimeProvider,
-		})
+		}))
 		done <- err
 	}()
 
@@ -5914,6 +5952,7 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 	deps := Deps{
 		BaseURL:       "https://gestalt.example.test",
 		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		Egress:        newEgressDeps(cfg),
 		S3: map[string]s3store.Client{
 			"main":    &coretesting.StubS3{},
 			"archive": &coretesting.StubS3{},
@@ -6189,8 +6228,8 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 	if got := startRequests[0].Env[authorizationservice.SocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the authorization relay token")
 	}
-	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, "gestalt.example.test") {
-		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", allowedHosts)
+	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); len(allowedHosts) != 0 {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want none when hostname egress enforcement is not required", allowedHosts)
 	}
 }
 
@@ -6239,6 +6278,7 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 	deps := Deps{
 		BaseURL:               "https://gestalt.example.test",
 		EncryptionKey:         []byte("0123456789abcdef0123456789abcdef"),
+		Egress:                newEgressDeps(cfg),
 		SelectedIndexedDBName: "memory",
 		IndexedDBDefs: map[string]*config.ProviderEntry{
 			"memory": {
@@ -6492,6 +6532,7 @@ func TestPluginRuntimeConfigUsesPublicCacheRelayWithoutHostServiceTunnelCapabili
 	deps := Deps{
 		BaseURL:       "https://gestalt.example.test",
 		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		Egress:        newEgressDeps(cfg),
 		CacheDefs: map[string]*config.ProviderEntry{
 			"session":    {Config: mustNode(t, map[string]any{"namespace": "session"})},
 			"rate_limit": {Config: mustNode(t, map[string]any{"namespace": "rate_limit"})},
@@ -6942,7 +6983,7 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	t.Cleanup(func() { _ = CloseProviders(providers) })
-	assertPublicHostServicesExclude(t, publicHostServices, "plugin_invoker", plugininvokerservice.DefaultSocketEnv)
+	assertPublicHostServicesVerified(t, publicHostServices, "plugin_invoker", plugininvokerservice.DefaultSocketEnv)
 
 	services, err := coredata.New(&coretesting.StubIndexedDB{})
 	if err != nil {
@@ -7008,10 +7049,6 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 		t.Fatalf("nested credential.instance = %q, want %q", got.Body.Credential.Instance, "default")
 	}
 
-	relayURL, err := url.Parse(relaySrv.URL)
-	if err != nil {
-		t.Fatalf("url.Parse(relay URL): %v", err)
-	}
 	startRequests := runtimeProvider.startPluginRequestsCopy()
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
@@ -7019,8 +7056,8 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	if got := startRequests[0].Env[plugininvokerservice.SocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the plugin invoker relay token")
 	}
-	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); !slices.Contains(allowedHosts, relayURL.Hostname()) {
-		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host %q", allowedHosts, relayURL.Hostname())
+	if allowedHosts := slices.Clone(startRequests[0].Egress.AllowedHosts); len(allowedHosts) != 0 {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want none when hostname egress enforcement is not required", allowedHosts)
 	}
 	bindRequests := runtimeProvider.bindHostServiceRequests()
 	if len(bindRequests) != 1 {
@@ -7078,6 +7115,7 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 	deps := Deps{
 		BaseURL:         "https://gestalt.example.test",
 		EncryptionKey:   []byte("0123456789abcdef0123456789abcdef"),
+		Egress:          newEgressDeps(cfg),
 		WorkflowManager: newStubWorkflowManager(),
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
@@ -7293,7 +7331,11 @@ func TestPluginRuntimeConfigInjectsRuntimeLogSessionAndHostService(t *testing.T)
 		t.Fatalf("coredata.New: %v", err)
 	}
 	t.Cleanup(func() { _ = services.Close() })
-	deps := Deps{Services: services}
+	deps := Deps{
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		Services:      services,
+	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
@@ -7314,8 +7356,11 @@ func TestPluginRuntimeConfigInjectsRuntimeLogSessionAndHostService(t *testing.T)
 		if req.EnvVar != runtimehost.DefaultRuntimeLogHostSocketEnv {
 			continue
 		}
-		if got := req.Relay.DialTarget; !strings.HasPrefix(got, "unix://") {
-			t.Fatalf("runtime log host relay target = %q, want unix direct dial target", got)
+		if got := req.Relay.DialTarget; got != "tls://gestalt.example.test:443" {
+			t.Fatalf("runtime log host relay target = %q, want public relay target", got)
+		}
+		if got := startRequests[0].Env[runtimehost.DefaultRuntimeLogHostSocketEnv+"_TOKEN"]; got == "" {
+			t.Fatalf("StartPlugin env missing %s_TOKEN", runtimehost.DefaultRuntimeLogHostSocketEnv)
 		}
 		return
 	}
@@ -7329,12 +7374,17 @@ type runtimeRelayTestHandlerConfig struct {
 }
 
 type runtimeRelayTestCoreHandlerKey struct {
+	pluginName   string
 	service      string
 	envVar       string
 	methodPrefix string
 }
 
 func withRuntimeRelayCoreHostService(service, envVar, methodPrefix string, register func(*grpc.Server)) runtimeRelayTestHandlerOption {
+	return withRuntimeRelayPluginCoreHostService("", service, envVar, methodPrefix, register)
+}
+
+func withRuntimeRelayPluginCoreHostService(pluginName, service, envVar, methodPrefix string, register func(*grpc.Server)) runtimeRelayTestHandlerOption {
 	return func(cfg *runtimeRelayTestHandlerConfig) {
 		if cfg.coreHandlers == nil {
 			cfg.coreHandlers = make(map[runtimeRelayTestCoreHandlerKey]http.Handler)
@@ -7342,6 +7392,7 @@ func withRuntimeRelayCoreHostService(service, envVar, methodPrefix string, regis
 		srv := grpc.NewServer()
 		register(srv)
 		cfg.coreHandlers[runtimeRelayTestCoreHandlerKey{
+			pluginName:   strings.TrimSpace(pluginName),
 			service:      strings.TrimSpace(service),
 			envVar:       strings.TrimSpace(envVar),
 			methodPrefix: strings.TrimSpace(methodPrefix),
@@ -7349,12 +7400,13 @@ func withRuntimeRelayCoreHostService(service, envVar, methodPrefix string, regis
 	}
 }
 
-func assertPublicHostServicesExclude(t *testing.T, registry *runtimehost.PublicHostServiceRegistry, serviceName, envVar string) {
+func assertPublicHostServicesVerified(t *testing.T, registry *runtimehost.PublicHostServiceRegistry, serviceName, envVar string) {
 	t.Helper()
 
 	if registry == nil {
-		return
+		t.Fatalf("public host services registry is nil, want %s/%s verifier entry", serviceName, envVar)
 	}
+	found := false
 	for _, service := range registry.Services() {
 		if strings.TrimSpace(service.Service.Name) != strings.TrimSpace(serviceName) {
 			continue
@@ -7362,7 +7414,13 @@ func assertPublicHostServicesExclude(t *testing.T, registry *runtimehost.PublicH
 		if strings.TrimSpace(service.Service.EnvVar) != strings.TrimSpace(envVar) {
 			continue
 		}
-		t.Fatalf("public host services = %#v, want no %s/%s registry entry", registry.Services(), serviceName, envVar)
+		found = true
+		if service.SessionVerifier == nil {
+			t.Fatalf("public host services = %#v, want %s/%s verifier entry", registry.Services(), serviceName, envVar)
+		}
+	}
+	if !found {
+		t.Fatalf("public host services = %#v, want %s/%s verifier entry", registry.Services(), serviceName, envVar)
 	}
 }
 
@@ -7393,10 +7451,18 @@ func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServ
 		var handler http.Handler
 		if target.CoreRoutable {
 			handler = cfg.coreHandlers[runtimeRelayTestCoreHandlerKey{
+				pluginName:   strings.TrimSpace(target.PluginName),
 				service:      strings.TrimSpace(target.Service),
 				envVar:       strings.TrimSpace(target.EnvVar),
 				methodPrefix: strings.TrimSpace(target.MethodPrefix),
 			}]
+			if handler == nil {
+				handler = cfg.coreHandlers[runtimeRelayTestCoreHandlerKey{
+					service:      strings.TrimSpace(target.Service),
+					envVar:       strings.TrimSpace(target.EnvVar),
+					methodPrefix: strings.TrimSpace(target.MethodPrefix),
+				}]
+			}
 		} else {
 			handler, err = runtimeRelayPublicHostServiceHandler(r.Context(), publicHostServices, target)
 			if err != nil {
@@ -7413,6 +7479,48 @@ func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServ
 		relayReq.Header.Del(runtimehost.HostServiceRelayTokenHeader)
 		handler.ServeHTTP(w, relayReq)
 	})
+}
+
+func newRuntimePublicEndpointTestServer(t *testing.T, stateSecret []byte, publicHostServices *runtimehost.PublicHostServiceRegistry, opts ...runtimeRelayTestHandlerOption) *httptest.Server {
+	t.Helper()
+
+	relay := newRuntimeRelayTestHandler(t, stateSecret, publicHostServices, opts...)
+	proxy := newRuntimeEgressProxyTestHandler(t, stateSecret)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.TrimSpace(r.Header.Get(runtimehost.HostServiceRelayTokenHeader)) != "" {
+			relay.ServeHTTP(w, r)
+			return
+		}
+		proxy.ServeHTTP(w, r)
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	testutil.CloseOnCleanup(t, srv)
+
+	cert := srv.Certificate()
+	if cert == nil {
+		t.Fatal("runtime public endpoint certificate is nil")
+	}
+	return srv
+}
+
+func testRuntimePublicEndpointDeps(t *testing.T, deps Deps, opts ...runtimeRelayTestHandlerOption) Deps {
+	t.Helper()
+
+	if len(deps.EncryptionKey) == 0 {
+		deps.EncryptionKey = []byte("0123456789abcdef0123456789abcdef")
+	}
+	if deps.PublicHostServices == nil {
+		deps.PublicHostServices = runtimehost.NewPublicHostServiceRegistry()
+	}
+	if strings.TrimSpace(deps.BaseURL) == "" {
+		srv := newRuntimePublicEndpointTestServer(t, deps.EncryptionKey, deps.PublicHostServices, opts...)
+		deps.BaseURL = srv.URL
+		if cert := srv.Certificate(); cert != nil && strings.TrimSpace(deps.HostServiceTLSCAFile) == "" && strings.TrimSpace(deps.HostServiceTLSCAPEM) == "" {
+			deps.HostServiceTLSCAPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+		}
+	}
+	return deps
 }
 
 func runtimeRelayPublicHostServiceHandler(ctx context.Context, registry *runtimehost.PublicHostServiceRegistry, target runtimehost.HostServiceRelayTarget) (http.Handler, error) {
@@ -7715,7 +7823,7 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
 	t.Cleanup(func() { _ = CloseProviders(providers) })
-	assertPublicHostServicesExclude(t, publicHostServices, "workflow_manager", workflowservice.DefaultManagerSocketEnv)
+	assertPublicHostServicesVerified(t, publicHostServices, "workflow_manager", workflowservice.DefaultManagerSocketEnv)
 
 	prov, err := providers.Get("echoext")
 	if err != nil {
@@ -8090,7 +8198,7 @@ func TestPluginRuntimeConfigSkipsPublicEgressProxyWhenHostnameEgressIsNotRequire
 	}
 }
 
-func TestPluginRuntimeConfigUsesDirectHostServiceBindingsAndSkipsPublicEgressProxy(t *testing.T) {
+func TestPluginRuntimeConfigUsesPublicRelayAndEgressProxyWhenRuntimeAdvertisesDirectHostServiceSupport(t *testing.T) {
 	t.Parallel()
 
 	bin := buildEchoPluginBinary(t)
@@ -8156,24 +8264,24 @@ func TestPluginRuntimeConfigUsesDirectHostServiceBindingsAndSkipsPublicEgressPro
 	if len(startRequests) != 1 {
 		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
 	}
-	if got := startRequests[0].Env["HTTP_PROXY"]; got != "" {
-		t.Fatalf("StartPlugin HTTP_PROXY = %q, want empty when direct host service bindings are available", got)
+	if got := startRequests[0].Env["HTTP_PROXY"]; !strings.Contains(got, "@gestalt.example.test") {
+		t.Fatalf("StartPlugin HTTP_PROXY = %q, want public egress proxy on gestalt.example.test", got)
 	}
-	if got := startRequests[0].Env["HTTPS_PROXY"]; got != "" {
-		t.Fatalf("StartPlugin HTTPS_PROXY = %q, want empty when direct host service bindings are available", got)
+	if got := startRequests[0].Env["HTTPS_PROXY"]; !strings.Contains(got, "@gestalt.example.test") {
+		t.Fatalf("StartPlugin HTTPS_PROXY = %q, want public egress proxy on gestalt.example.test", got)
 	}
-	if got := startRequests[0].Env[cacheservice.SocketTokenEnv("session")]; got != "" {
-		t.Fatalf("StartPlugin cache token env = %q, want empty for direct host service bindings", got)
+	if got := startRequests[0].Env[cacheservice.SocketTokenEnv("session")]; got == "" {
+		t.Fatalf("StartPlugin cache token env = %q, want public relay token", got)
 	}
-	assertStartPluginEgressPolicy(t, startRequests[0], []string{"api.github.com"}, pluginruntime.PolicyDeny)
+	assertStartPluginEgressPolicy(t, startRequests[0], []string{"api.github.com", "gestalt.example.test"}, pluginruntime.PolicyDeny)
 
 	bindRequests := runtimeProvider.bindHostServiceRequests()
 	if len(bindRequests) == 0 {
-		t.Fatal("BindHostService requests = 0, want at least one direct host service binding")
+		t.Fatal("BindHostService requests = 0, want at least one public relay binding")
 	}
 	for _, req := range bindRequests {
-		if got := req.Relay.DialTarget; !strings.HasPrefix(got, "unix://") {
-			t.Fatalf("BindHostService(%s) relay target = %q, want unix direct dial target", req.EnvVar, got)
+		if got := req.Relay.DialTarget; got != "tls://gestalt.example.test:443" {
+			t.Fatalf("BindHostService(%s) relay target = %q, want public relay target", req.EnvVar, got)
 		}
 	}
 }
@@ -8359,7 +8467,7 @@ func TestPluginCacheBindingsRejectUnknownCaches(t *testing.T) {
 		},
 	}
 
-	_, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+	_, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		CacheDefs: map[string]*config.ProviderEntry{
 			"session": {
 				Config: mustNode(t, map[string]any{"namespace": "session"}),
@@ -8368,7 +8476,7 @@ func TestPluginCacheBindingsRejectUnknownCaches(t *testing.T) {
 		CacheFactory: func(yaml.Node) (corecache.Cache, error) {
 			return coretesting.NewStubCache(), nil
 		},
-	})
+	}))
 	if err == nil {
 		t.Fatal("buildProvidersStrict: expected error, got nil")
 	}
@@ -8450,7 +8558,7 @@ func TestPluginIndexedDBInheritsHostSelectionAndDefaultDBName(t *testing.T) {
 							IndexedDB:            tc.indexedDB,
 						},
 					},
-				}, NewFactoryRegistry(), deps)
+				}, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, deps))
 				if err != nil {
 					t.Fatalf("buildProvidersStrict: %v", err)
 				}
@@ -8596,7 +8704,7 @@ func TestPluginIndexedDBBuildScopedConfig(t *testing.T) {
 
 			var closeCount atomic.Int32
 			var captured []capturedIndexedDBConfig
-			providers, _, err := buildProvidersStrict(context.Background(), makeConfig(tc.indexedDB), NewFactoryRegistry(), Deps{
+			providers, _, err := buildProvidersStrict(context.Background(), makeConfig(tc.indexedDB), NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 				SelectedIndexedDBName: "postgres",
 				IndexedDBDefs:         indexedDBDefs,
 				IndexedDBFactory: func(node yaml.Node) (indexeddb.IndexedDB, error) {
@@ -8610,7 +8718,7 @@ func TestPluginIndexedDBBuildScopedConfig(t *testing.T) {
 						onClose:       closeCount.Add,
 					}, nil
 				},
-			})
+			}))
 			if err != nil {
 				t.Fatalf("buildProvidersStrict: %v", err)
 			}
@@ -8744,7 +8852,7 @@ func TestPluginIndexedDBRouteObjectStores(t *testing.T) {
 						},
 					},
 				},
-			}, NewFactoryRegistry(), deps)
+			}, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, deps))
 			if err != nil {
 				t.Fatalf("buildProvidersStrict: %v", err)
 			}
@@ -8828,7 +8936,7 @@ func TestPluginIndexedDBProviderOverrideUsesExplicitHostIndexedDB(t *testing.T) 
 				},
 			},
 		},
-	}, NewFactoryRegistry(), Deps{
+	}, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		SelectedIndexedDBName: "main",
 		IndexedDBDefs: map[string]*config.ProviderEntry{
 			"main": {
@@ -8852,7 +8960,7 @@ func TestPluginIndexedDBProviderOverrideUsesExplicitHostIndexedDB(t *testing.T) 
 			boundDBs[bucket] = db
 			return db, nil
 		},
-	})
+	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -8913,7 +9021,7 @@ func TestPluginIndexedDBBindingsCleanupOnS3BindingFailure(t *testing.T) {
 				S3:                   []string{"missing"},
 			},
 		},
-	}, NewFactoryRegistry(), Deps{
+	}, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		SelectedIndexedDBName: "main",
 		IndexedDBDefs: map[string]*config.ProviderEntry{
 			"main": {
@@ -8928,7 +9036,7 @@ func TestPluginIndexedDBBindingsCleanupOnS3BindingFailure(t *testing.T) {
 			}, nil
 		},
 		S3: map[string]s3store.Client{},
-	})
+	}))
 	if err == nil {
 		t.Fatal("expected buildProvidersStrict to fail for missing S3 binding")
 	}
@@ -8968,12 +9076,12 @@ func TestPluginS3BindingsRoundtripAndNamespaceKeys(t *testing.T) {
 				S3:                   []string{"main"},
 			},
 		},
-	}, NewFactoryRegistry(), Deps{
+	}, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		Services: coretesting.NewStubServices(t),
 		S3: map[string]s3store.Client{
 			"main": stubS3,
 		},
-	})
+	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -9069,13 +9177,13 @@ func TestPluginS3BindingsRouteExplicitBinding(t *testing.T) {
 				S3:                   []string{"main", "archive"},
 			},
 		},
-	}, NewFactoryRegistry(), Deps{
+	}, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		Services: coretesting.NewStubServices(t),
 		S3: map[string]s3store.Client{
 			"main":    mainS3,
 			"archive": archiveS3,
 		},
-	})
+	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -9142,10 +9250,10 @@ func TestPluginS3BindingsExposeHostSocketEnv(t *testing.T) {
 
 	checkEnv := func(t *testing.T, bindings []string, envName string) bool {
 		t.Helper()
-		providers, _, err := buildProvidersStrict(context.Background(), makeConfig(bindings), NewFactoryRegistry(), Deps{
+		providers, _, err := buildProvidersStrict(context.Background(), makeConfig(bindings), NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 			Services: services,
 			S3:       s3Bindings,
-		})
+		}))
 		if err != nil {
 			t.Fatalf("buildProvidersStrict: %v", err)
 		}

--- a/gestaltd/internal/bootstrap/host_service_tls_env_test.go
+++ b/gestaltd/internal/bootstrap/host_service_tls_env_test.go
@@ -1,0 +1,87 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"gopkg.in/yaml.v3"
+)
+
+func TestPrepareCoreLoadsHostServiceTLSCAFileForHostedRuntimeEnv(t *testing.T) {
+	certSrv := httptest.NewTLSServer(http.NotFoundHandler())
+	t.Cleanup(certSrv.Close)
+	caPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certSrv.Certificate().Raw}))
+	caFile := filepath.Join(t.TempDir(), "host-service-ca.pem")
+	if err := os.WriteFile(caFile, []byte(caPEM), 0o644); err != nil {
+		t.Fatalf("WriteFile(caFile): %v", err)
+	}
+	t.Setenv(gestalt.EnvHostServiceTLSCAFile, caFile)
+	t.Setenv(gestalt.EnvHostServiceTLSCAPEM, "")
+
+	factories := NewFactoryRegistry()
+	factories.ExternalCredentials = func(context.Context, string, yaml.Node, []runtimehost.HostService, Deps) (core.ExternalCredentialProvider, error) {
+		return coretesting.NewStubExternalCredentialProvider(), nil
+	}
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) {
+		return &coretesting.StubIndexedDB{}, nil
+	}
+	factories.Secrets["stub"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{Secrets: map[string]string{}}, nil
+	}
+	factories.Telemetry["noop"] = func(yaml.Node) (core.TelemetryProvider, error) {
+		return noopTelemetryProvider{}, nil
+	}
+
+	cfg := &config.Config{
+		Providers: config.ProvidersConfig{
+			Secrets: map[string]*config.ProviderEntry{
+				"default": {Source: config.ProviderSource{Builtin: "stub"}},
+			},
+			Telemetry: map[string]*config.ProviderEntry{
+				"default": {Source: config.ProviderSource{Builtin: "noop"}},
+			},
+			IndexedDB: map[string]*config.ProviderEntry{
+				"main": {Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml")},
+			},
+		},
+		Server: config.ServerConfig{
+			BaseURL:       "https://gestalt.example.test",
+			EncryptionKey: "test-encryption-key",
+			Providers:     config.ServerProvidersConfig{IndexedDB: "main"},
+		},
+	}
+
+	prepared, err := prepareCore(context.Background(), cfg, factories, true)
+	if err != nil {
+		t.Fatalf("prepareCore: %v", err)
+	}
+	t.Cleanup(func() { _ = prepared.Close(context.Background()) })
+
+	want := strings.TrimSpace(caPEM)
+	if got := prepared.Deps.HostServiceTLSCAPEM; got != want {
+		t.Fatalf("HostServiceTLSCAPEM = %q, want file contents", got)
+	}
+	if got := prepared.Deps.HostServiceTLSCAFile; got != "" {
+		t.Fatalf("HostServiceTLSCAFile = %q, want omitted after reading file", got)
+	}
+
+	env := withHostServiceTLSCAEnv(nil, prepared.Deps)
+	if got := env[gestalt.EnvHostServiceTLSCAPEM]; got != want {
+		t.Fatalf("host service CA PEM env = %q, want file contents", got)
+	}
+	if got := env[gestalt.EnvHostServiceTLSCAFile]; got != "" {
+		t.Fatalf("host service CA file env = %q, want omitted", got)
+	}
+}

--- a/gestaltd/internal/bootstrap/plugin_runtime_plan.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_plan.go
@@ -10,9 +10,8 @@ import (
 type RuntimeHostServiceAccess string
 
 const (
-	RuntimeHostServiceAccessNone   RuntimeHostServiceAccess = "none"
-	RuntimeHostServiceAccessRelay  RuntimeHostServiceAccess = "relay"
-	RuntimeHostServiceAccessDirect RuntimeHostServiceAccess = "direct"
+	RuntimeHostServiceAccessNone  RuntimeHostServiceAccess = "none"
+	RuntimeHostServiceAccessRelay RuntimeHostServiceAccess = "relay"
 )
 
 type RuntimeEgressMode string
@@ -27,7 +26,6 @@ type RuntimeHostnameEgressDelivery string
 
 const (
 	RuntimeHostnameEgressDeliveryNone        RuntimeHostnameEgressDelivery = "none"
-	RuntimeHostnameEgressDeliveryRuntime     RuntimeHostnameEgressDelivery = "runtime"
 	RuntimeHostnameEgressDeliveryPublicProxy RuntimeHostnameEgressDelivery = "public_proxy"
 )
 
@@ -65,17 +63,19 @@ func buildPluginRuntimePlan(pluginName string, entry *config.ProviderEntry, deps
 func runtimeAdvertisedBehavior(support pluginruntime.Support) RuntimeBehavior {
 	return RuntimeBehavior{
 		CanHostPlugins:    support.CanHostPlugins,
-		HostServiceAccess: runtimeHostServiceAccessFromSupport(support.HostServiceAccess),
+		HostServiceAccess: RuntimeHostServiceAccessNone,
 		EgressMode:        runtimeEgressModeFromSupport(support.EgressMode),
 	}
 }
 
 func runtimeResolvedBehavior(advertised RuntimeBehavior, deps Deps) RuntimeBehavior {
 	resolved := advertised
-	if resolved.HostServiceAccess == RuntimeHostServiceAccessNone && hostCanRelayPluginRuntimeHostServices(deps) {
+	if hostCanRelayPluginRuntimeHostServices(deps) {
 		resolved.HostServiceAccess = RuntimeHostServiceAccessRelay
+	} else {
+		resolved.HostServiceAccess = RuntimeHostServiceAccessNone
 	}
-	if resolved.EgressMode == RuntimeEgressModeHostname && resolved.HostServiceAccess != RuntimeHostServiceAccessDirect && !hostCanProvideHostedHostnameEgress(deps) {
+	if resolved.EgressMode == RuntimeEgressModeHostname && !hostCanProvideHostedHostnameEgress(deps) {
 		resolved.EgressMode = RuntimeEgressModeNone
 	}
 	return resolved
@@ -84,9 +84,6 @@ func runtimeResolvedBehavior(advertised RuntimeBehavior, deps Deps) RuntimeBehav
 func runtimeHostnameEgressDelivery(required bool, resolved RuntimeBehavior) RuntimeHostnameEgressDelivery {
 	if !required || resolved.EgressMode != RuntimeEgressModeHostname {
 		return RuntimeHostnameEgressDeliveryNone
-	}
-	if resolved.HostServiceAccess == RuntimeHostServiceAccessDirect {
-		return RuntimeHostnameEgressDeliveryRuntime
 	}
 	if resolved.HostServiceAccess == RuntimeHostServiceAccessRelay {
 		return RuntimeHostnameEgressDeliveryPublicProxy
@@ -160,15 +157,6 @@ func (p HostedRuntimePlan) Validate(label string) error {
 		return fmt.Errorf("%s cannot preserve hostname-based egress required by this provider", label)
 	}
 	return nil
-}
-
-func runtimeHostServiceAccessFromSupport(src pluginruntime.HostServiceAccess) RuntimeHostServiceAccess {
-	switch src {
-	case pluginruntime.HostServiceAccessDirect:
-		return RuntimeHostServiceAccessDirect
-	default:
-		return RuntimeHostServiceAccessNone
-	}
 }
 
 func runtimeEgressModeFromSupport(src pluginruntime.EgressMode) RuntimeEgressMode {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -890,36 +890,24 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		return nil, fmt.Errorf("wait for plugin runtime session %q ready: %w", sessionID, err)
 	}
 
-	hostServices, invTokens, runtimeCleanup, err := buildPluginRuntimeHostServices(name, entry, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect)
+	hostServices, invTokens, runtimeCleanup, err := buildPluginRuntimeHostServices(name, entry, deps)
 	if err != nil {
 		return nil, err
 	}
 	hostServices = appendRuntimeLogHostService(hostServices, runtimeConfig, deps, runtimePlan)
-	startHostServices, relayOnlyHostServices := splitRelayOnlyCoreHostServices(hostServices, runtimePlan)
 	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps, runtimePlan, runtimeProvider)
 	if err != nil {
 		return nil, err
 	}
 	cleanup = chainCleanup(cleanup, runtimeCleanup, publicHostServicesCleanup)
-	startedHostServices, err := runtimehost.StartHostServices(
-		startHostServices,
-		runtimehost.WithHostServicesProviderName(name),
-		runtimehost.WithHostServicesTelemetry(deps.Telemetry),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("start runtime host services: %w", err)
-	}
-	if startedHostServices != nil {
-		cleanup = chainCleanup(cleanup, func() {
-			_ = startedHostServices.Close()
-		})
-	}
 	startEnv := maps.Clone(env)
 	startEnv = withRuntimeSessionEnv(startEnv, sessionID)
+	startEnv = withHostServiceTLSCAEnv(startEnv, deps)
+	egressPolicy := deps.Egress.ProviderPolicy(entry)
 	allowedHosts := entry.EffectiveAllowedHosts()
-	bindingTargets := append(hostServiceBindingDescriptorsFromStarted(startedHostServices), hostServiceBindingDescriptorsFromConfigured(relayOnlyHostServices)...)
+	bindingTargets := hostServiceBindingDescriptorsFromConfigured(hostServices)
 	for _, hostService := range bindingTargets {
-		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect, true)
+		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, true)
 		if err != nil {
 			return nil, err
 		}
@@ -932,9 +920,11 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 			}
 			maps.Copy(startEnv, bindingEnv)
 		}
-		allowedHosts = appendAllowedHost(allowedHosts, relayHost)
+		if runtimePlan.RequiresHostnameEgress {
+			allowedHosts = appendAllowedHost(allowedHosts, relayHost)
+		}
 	}
-	egressPlan, err := buildHostedRuntimeEgressLaunchPlan(name, sessionID, deps.Egress.ProviderPolicy(entry), allowedHosts, runtimePlan, deps)
+	egressPlan, err := buildHostedRuntimeEgressLaunchPlan(name, sessionID, egressPolicy, allowedHosts, runtimePlan, deps)
 	if err != nil {
 		return nil, err
 	}
@@ -1178,31 +1168,17 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	}
 	recordHostedAgentRuntimeStartPhase(ctx, name, "runtime_session_ready", phaseStarted, nil)
 
-	startHostServices, relayOnlyHostServices := splitRelayOnlyCoreHostServices(hostServices, runtimePlan)
-	phaseStarted = time.Now()
-	startedHostServices, err := runtimehost.StartHostServices(
-		startHostServices,
-		runtimehost.WithHostServicesProviderName(name),
-		runtimehost.WithHostServicesTelemetry(deps.Telemetry),
-	)
-	recordHostedAgentRuntimeStartPhase(ctx, name, "host_services_start", phaseStarted, err)
-	if err != nil {
-		return nil, fmt.Errorf("start agent runtime host services: %w", err)
-	}
-	cleanup = chainCleanup(cleanup, func() {
-		_ = startedHostServices.Close()
-	})
-
 	startEnv := withRuntimeSessionEnv(maps.Clone(cfg.Env), sessionID)
+	startEnv = withHostServiceTLSCAEnv(startEnv, deps)
 	agentAllowedHosts := cfg.EgressPolicy("").AllowedHosts
 	if len(agentAllowedHosts) == 0 {
 		agentAllowedHosts = slices.Clone(launch.allowedHosts)
 	}
 	allowedHosts := hostedAgentAllowedHosts(agentAllowedHosts, runtimePlan)
 	phaseStarted = time.Now()
-	bindingTargets := append(hostServiceBindingDescriptorsFromStarted(startedHostServices), hostServiceBindingDescriptorsFromConfigured(relayOnlyHostServices)...)
+	bindingTargets := hostServiceBindingDescriptorsFromConfigured(hostServices)
 	for _, hostService := range bindingTargets {
-		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect, true)
+		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, true)
 		if err != nil {
 			recordHostedAgentRuntimeStartPhase(ctx, name, "host_services_bind", phaseStarted, err)
 			return nil, err
@@ -1386,6 +1362,8 @@ func newLocalPluginRuntime(runtimeProviderName string, deps Deps) pluginruntime.
 const (
 	pluginRuntimeHostServiceRelayTokenTTL = 30 * 24 * time.Hour
 	pluginRuntimeEgressProxyTokenTTL      = 30 * 24 * time.Hour
+	hostServiceTLSCAFileEnv               = "GESTALT_HOST_SERVICE_TLS_CA_FILE"
+	hostServiceTLSCAPEMEnv                = "GESTALT_HOST_SERVICE_TLS_CA_PEM"
 )
 
 type RuntimeEgressLaunchPlan struct {
@@ -1522,7 +1500,7 @@ func waitForPluginRuntimeSessionReady(ctx context.Context, runtimeProvider plugi
 	}
 }
 
-func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, deps Deps, allowDirectBindings bool) ([]runtimehost.HostService, *plugininvokerservice.InvocationTokenManager, func(), error) {
+func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, deps Deps) ([]runtimehost.HostService, *plugininvokerservice.InvocationTokenManager, func(), error) {
 	var (
 		hostServices []runtimehost.HostService
 		cleanup      func()
@@ -1565,7 +1543,7 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 	}
 	includeWorkflowManager := deps.WorkflowManager != nil || (deps.WorkflowRuntime != nil && deps.WorkflowRuntime.HasConfiguredProviders())
 	includeAgentManager := deps.AgentManager != nil || deps.AgentRuntime != nil
-	needInvocationTokens := allowDirectBindings || len(entry.Invokes) > 0
+	needInvocationTokens := len(entry.Invokes) > 0
 	if includeWorkflowManager || includeAgentManager {
 		needInvocationTokens = true
 	}
@@ -1583,12 +1561,6 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 	}
 	if deps.AuthorizationProvider != nil && len(entry.EffectiveHTTPBindings()) > 0 {
 		hostServices = append(hostServices, buildPluginAuthorizationHostService(deps.AuthorizationProvider))
-	}
-	if !allowDirectBindings {
-		if len(entry.Invokes) > 0 {
-			hostServices = append(hostServices, buildPluginInvokerHostService(name, entry, deps, invTokens))
-		}
-		return hostServices, invTokens, cleanup, nil
 	}
 	if len(entry.Invokes) > 0 {
 		hostServices = append(hostServices, buildPluginInvokerHostService(name, entry, deps, invTokens))
@@ -1629,18 +1601,26 @@ func withRuntimeSessionEnv(env map[string]string, sessionID string) map[string]s
 	return env
 }
 
-type hostServiceBindingDescriptor struct {
-	Name       string
-	EnvVar     string
-	SocketPath string
+func withHostServiceTLSCAEnv(env map[string]string, deps Deps) map[string]string {
+	caPEM := strings.TrimSpace(deps.HostServiceTLSCAPEM)
+	caFile := strings.TrimSpace(deps.HostServiceTLSCAFile)
+	if caPEM == "" && caFile == "" {
+		return env
+	}
+	if env == nil {
+		env = map[string]string{}
+	}
+	if caPEM != "" {
+		env[hostServiceTLSCAPEMEnv] = caPEM
+	} else {
+		env[hostServiceTLSCAFileEnv] = caFile
+	}
+	return env
 }
 
-func hostServiceBindingDescriptorFromStarted(hostService runtimehost.StartedHostService) hostServiceBindingDescriptor {
-	return hostServiceBindingDescriptor{
-		Name:       strings.TrimSpace(hostService.Name),
-		EnvVar:     strings.TrimSpace(hostService.EnvVar),
-		SocketPath: strings.TrimSpace(hostService.SocketPath),
-	}
+type hostServiceBindingDescriptor struct {
+	Name   string
+	EnvVar string
 }
 
 func hostServiceBindingDescriptorFromConfigured(hostService runtimehost.HostService) hostServiceBindingDescriptor {
@@ -1648,18 +1628,6 @@ func hostServiceBindingDescriptorFromConfigured(hostService runtimehost.HostServ
 		Name:   strings.TrimSpace(hostService.Name),
 		EnvVar: strings.TrimSpace(hostService.EnvVar),
 	}
-}
-
-func hostServiceBindingDescriptorsFromStarted(hostServices *runtimehost.StartedHostServices) []hostServiceBindingDescriptor {
-	started := hostServices.Bindings()
-	if len(started) == 0 {
-		return nil
-	}
-	out := make([]hostServiceBindingDescriptor, 0, len(started))
-	for _, hostService := range started {
-		out = append(out, hostServiceBindingDescriptorFromStarted(hostService))
-	}
-	return out
 }
 
 func hostServiceBindingDescriptorsFromConfigured(hostServices []runtimehost.HostService) []hostServiceBindingDescriptor {
@@ -1673,82 +1641,73 @@ func hostServiceBindingDescriptorsFromConfigured(hostServices []runtimehost.Host
 	return out
 }
 
-func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostService hostServiceBindingDescriptor, deps Deps, allowUnixRelay bool, allowCoreRoutable bool) (pluginruntime.BindHostServiceRequest, map[string]string, string, error) {
-	if !allowUnixRelay {
-		var (
-			serviceKey   string
-			serviceLabel string
-			methodPrefix string
-		)
-		switch {
-		case isIndexedDBHostServiceEnv(hostService.EnvVar):
-			serviceKey = "indexeddb"
-			serviceLabel = "IndexedDB"
-			methodPrefix = "/" + proto.IndexedDB_ServiceDesc.ServiceName + "/"
-		case isCacheHostServiceEnv(hostService.EnvVar):
-			serviceKey = "cache"
-			serviceLabel = "cache"
-			methodPrefix = "/" + proto.Cache_ServiceDesc.ServiceName + "/"
-		case isS3HostServiceEnv(hostService.EnvVar):
-			serviceKey = "s3"
-			serviceLabel = "S3"
-			methodPrefix = "/" + proto.S3_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == workflowservice.DefaultManagerSocketEnv:
-			serviceKey = "workflow_manager"
-			serviceLabel = "workflow manager"
-			methodPrefix = "/" + proto.WorkflowManagerHost_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == agentservice.DefaultHostSocketEnv:
-			serviceKey = "agent_host"
-			serviceLabel = "agent host"
-			methodPrefix = "/" + proto.AgentHost_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == agentservice.DefaultManagerSocketEnv:
-			serviceKey = "agent_manager"
-			serviceLabel = "agent manager"
-			methodPrefix = "/" + proto.AgentManagerHost_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == authorizationservice.DefaultSocketEnv:
-			serviceKey = "authorization"
-			serviceLabel = "authorization"
-			methodPrefix = "/" + proto.AuthorizationProvider_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == plugininvokerservice.DefaultSocketEnv:
-			serviceKey = "plugin_invoker"
-			serviceLabel = "plugin invoker"
-			methodPrefix = "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/"
-		case hostService.EnvVar == runtimehost.DefaultRuntimeLogHostSocketEnv:
-			serviceKey = "runtime_log_host"
-			serviceLabel = "runtime log host"
-			methodPrefix = "/" + proto.PluginRuntimeLogHost_ServiceDesc.ServiceName + "/"
-		default:
-			return pluginruntime.BindHostServiceRequest{}, nil, "", fmt.Errorf("host service %q requires host service tunnels", hostService.EnvVar)
-		}
-		relay, relayEnv, relayHost, ok, err := buildHostedRuntimePublicHostServiceRelay(
-			providerName,
-			sessionID,
-			hostService,
-			deps,
-			serviceKey,
-			serviceLabel,
-			methodPrefix,
-			allowCoreRoutable && isCoreRoutableHostedRuntimeHostService(hostService, serviceKey, methodPrefix),
-		)
-		if err != nil {
-			return pluginruntime.BindHostServiceRequest{}, nil, "", err
-		}
-		if !ok {
-			return pluginruntime.BindHostServiceRequest{}, nil, "", fmt.Errorf("provider %q requires server.baseURL and server.encryptionKey to relay %s without host service tunnels", providerName, serviceLabel)
-		}
-		return pluginruntime.BindHostServiceRequest{
-			SessionID: sessionID,
-			EnvVar:    hostService.EnvVar,
-			Relay:     relay,
-		}, relayEnv, relayHost, nil
+func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostService hostServiceBindingDescriptor, deps Deps, allowCoreRoutable bool) (pluginruntime.BindHostServiceRequest, map[string]string, string, error) {
+	var (
+		serviceKey   string
+		serviceLabel string
+		methodPrefix string
+	)
+	switch {
+	case isIndexedDBHostServiceEnv(hostService.EnvVar):
+		serviceKey = "indexeddb"
+		serviceLabel = "IndexedDB"
+		methodPrefix = "/" + proto.IndexedDB_ServiceDesc.ServiceName + "/"
+	case isCacheHostServiceEnv(hostService.EnvVar):
+		serviceKey = "cache"
+		serviceLabel = "cache"
+		methodPrefix = "/" + proto.Cache_ServiceDesc.ServiceName + "/"
+	case isS3HostServiceEnv(hostService.EnvVar):
+		serviceKey = "s3"
+		serviceLabel = "S3"
+		methodPrefix = "/" + proto.S3_ServiceDesc.ServiceName + "/"
+	case hostService.EnvVar == workflowservice.DefaultManagerSocketEnv:
+		serviceKey = "workflow_manager"
+		serviceLabel = "workflow manager"
+		methodPrefix = "/" + proto.WorkflowManagerHost_ServiceDesc.ServiceName + "/"
+	case hostService.EnvVar == agentservice.DefaultHostSocketEnv:
+		serviceKey = "agent_host"
+		serviceLabel = "agent host"
+		methodPrefix = "/" + proto.AgentHost_ServiceDesc.ServiceName + "/"
+	case hostService.EnvVar == agentservice.DefaultManagerSocketEnv:
+		serviceKey = "agent_manager"
+		serviceLabel = "agent manager"
+		methodPrefix = "/" + proto.AgentManagerHost_ServiceDesc.ServiceName + "/"
+	case hostService.EnvVar == authorizationservice.DefaultSocketEnv:
+		serviceKey = "authorization"
+		serviceLabel = "authorization"
+		methodPrefix = "/" + proto.AuthorizationProvider_ServiceDesc.ServiceName + "/"
+	case hostService.EnvVar == plugininvokerservice.DefaultSocketEnv:
+		serviceKey = "plugin_invoker"
+		serviceLabel = "plugin invoker"
+		methodPrefix = "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/"
+	case hostService.EnvVar == runtimehost.DefaultRuntimeLogHostSocketEnv:
+		serviceKey = "runtime_log_host"
+		serviceLabel = "runtime log host"
+		methodPrefix = "/" + proto.PluginRuntimeLogHost_ServiceDesc.ServiceName + "/"
+	default:
+		return pluginruntime.BindHostServiceRequest{}, nil, "", fmt.Errorf("host service %q requires public host service relay support", hostService.EnvVar)
+	}
+	relay, relayEnv, relayHost, ok, err := buildHostedRuntimePublicHostServiceRelay(
+		providerName,
+		sessionID,
+		hostService,
+		deps,
+		serviceKey,
+		serviceLabel,
+		methodPrefix,
+		allowCoreRoutable && isCoreRoutableHostedRuntimeHostService(hostService, serviceKey, methodPrefix),
+	)
+	if err != nil {
+		return pluginruntime.BindHostServiceRequest{}, nil, "", err
+	}
+	if !ok {
+		return pluginruntime.BindHostServiceRequest{}, nil, "", fmt.Errorf("provider %q requires server.baseURL and server.encryptionKey to relay %s through the public host service relay", providerName, serviceLabel)
 	}
 	return pluginruntime.BindHostServiceRequest{
 		SessionID: sessionID,
 		EnvVar:    hostService.EnvVar,
-		Relay: pluginruntime.HostServiceRelay{
-			DialTarget: "unix://" + hostService.SocketPath,
-		},
-	}, nil, "", nil
+		Relay:     relay,
+	}, relayEnv, relayHost, nil
 }
 
 type runtimeHostServiceSessionVerifier struct {
@@ -1794,7 +1753,7 @@ func registerPublicRuntimeHostServices(providerName string, hostServices []runti
 	if runtimePlan.Resolved.HostServiceAccess != RuntimeHostServiceAccessRelay || deps.PublicHostServices == nil {
 		return nil, nil
 	}
-	registerHostServices, _ := splitRelayOnlyCoreHostServices(hostServices, runtimePlan)
+	registerHostServices := publicRuntimeRegistryHostServices(hostServices)
 	if len(registerHostServices) == 0 {
 		return nil, nil
 	}
@@ -1814,7 +1773,7 @@ func registerPublicRuntimeHostServices(providerName string, hostServices []runti
 
 func buildHostedRuntimePublicEgressProxy(providerName, sessionID string, allowedHosts []string, defaultAction egress.PolicyAction, deps Deps) (map[string]string, error) {
 	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
-		return nil, fmt.Errorf("provider %q requires server.baseURL and server.encryptionKey to enforce hostname-based egress on hosted runtimes without host service tunnels", providerName)
+		return nil, fmt.Errorf("provider %q requires server.baseURL and server.encryptionKey to enforce hostname-based egress for hosted runtimes", providerName)
 	}
 	proxyBaseURL, _, err := pluginRuntimePublicProxyBaseURL(deps.BaseURL)
 	if err != nil {
@@ -1862,34 +1821,11 @@ func isCoreRoutableHostedRuntimeHostService(hostService hostServiceBindingDescri
 	}
 }
 
-func splitRelayOnlyCoreHostServices(hostServices []runtimehost.HostService, runtimePlan HostedRuntimePlan) ([]runtimehost.HostService, []runtimehost.HostService) {
-	if len(hostServices) == 0 || runtimePlan.Resolved.HostServiceAccess != RuntimeHostServiceAccessRelay {
-		return hostServices, nil
+func publicRuntimeRegistryHostServices(hostServices []runtimehost.HostService) []runtimehost.HostService {
+	if len(hostServices) == 0 {
+		return nil
 	}
-	startHostServices := make([]runtimehost.HostService, 0, len(hostServices))
-	relayOnlyHostServices := make([]runtimehost.HostService, 0, 3)
-	for _, hostService := range hostServices {
-		if isRelayOnlyCoreHostService(hostService) {
-			relayOnlyHostServices = append(relayOnlyHostServices, hostService)
-			continue
-		}
-		startHostServices = append(startHostServices, hostService)
-	}
-	return startHostServices, relayOnlyHostServices
-}
-
-func isRelayOnlyCoreHostService(hostService runtimehost.HostService) bool {
-	desc := hostServiceBindingDescriptorFromConfigured(hostService)
-	switch desc.EnvVar {
-	case workflowservice.DefaultManagerSocketEnv:
-		return isCoreRoutableHostedRuntimeHostService(desc, "workflow_manager", "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/")
-	case agentservice.DefaultManagerSocketEnv:
-		return isCoreRoutableHostedRuntimeHostService(desc, "agent_manager", "/"+proto.AgentManagerHost_ServiceDesc.ServiceName+"/")
-	case plugininvokerservice.DefaultSocketEnv:
-		return isCoreRoutableHostedRuntimeHostService(desc, "plugin_invoker", "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/")
-	default:
-		return false
-	}
+	return append([]runtimehost.HostService(nil), hostServices...)
 }
 
 func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, hostService hostServiceBindingDescriptor, deps Deps, serviceKey, serviceLabel, methodPrefix string, coreRoutable bool) (pluginruntime.HostServiceRelay, map[string]string, string, bool, error) {
@@ -1930,9 +1866,21 @@ func pluginRuntimePublicRelayTarget(baseURL string) (string, string, error) {
 	}
 	port := parsed.Port()
 	if port == "" {
-		port = "443"
+		if strings.EqualFold(parsed.Scheme, "http") {
+			port = "80"
+		} else {
+			port = "443"
+		}
 	}
-	return "tls://" + net.JoinHostPort(host, port), host, nil
+	target := net.JoinHostPort(host, port)
+	switch strings.ToLower(parsed.Scheme) {
+	case "https":
+		return "tls://" + target, host, nil
+	case "http":
+		return "tcp://" + target, host, nil
+	default:
+		return "", "", fmt.Errorf("server.baseURL %q has unsupported public runtime relay scheme %q", baseURL, parsed.Scheme)
+	}
 }
 
 func pluginRuntimePublicProxyBaseURL(baseURL string) (*url.URL, string, error) {
@@ -1950,7 +1898,13 @@ func pluginRuntimePublicProxyBaseURL(baseURL string) (*url.URL, string, error) {
 	if parsed.RawQuery != "" || parsed.Fragment != "" {
 		return nil, "", fmt.Errorf("server.baseURL %q must not include a query or fragment for public runtime relay", baseURL)
 	}
-	if !strings.EqualFold(parsed.Scheme, "https") {
+	switch strings.ToLower(parsed.Scheme) {
+	case "https":
+	case "http":
+		if !isLoopbackAllowedHost(host) {
+			return nil, "", fmt.Errorf("server.baseURL %q must use https for public runtime relay unless it targets loopback", baseURL)
+		}
+	default:
 		return nil, "", fmt.Errorf("server.baseURL %q must use https for public runtime relay", baseURL)
 	}
 	parsed.Path = ""

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -15,7 +15,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/egress"
 	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/plugins/registry"
-	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 )
 
 func buildProviderDevManager(cfg *config.Config, providers *registry.ProviderMap[core.Provider], deps Deps) (*providerdev.Manager, error) {
@@ -168,7 +167,7 @@ func providerDevEntryIsLocal(entry *config.ProviderEntry) bool {
 }
 
 func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps Deps, sessionID string, sharedAttachmentState bool) (providerdev.RuntimeEnv, error) {
-	hostServices, _, cleanup, err := buildPluginRuntimeHostServices(name, entry, deps, false)
+	hostServices, _, cleanup, err := buildPluginRuntimeHostServices(name, entry, deps)
 	if err != nil {
 		return providerdev.RuntimeEnv{}, err
 	}
@@ -179,9 +178,10 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 		}
 	}()
 	env := withRuntimeSessionEnv(map[string]string{}, sessionID)
+	env = withHostServiceTLSCAEnv(env, deps)
 	if sharedAttachmentState {
 		for _, hostService := range hostServices {
-			bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostServiceBindingDescriptorFromConfigured(hostService), deps, false, false)
+			bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostServiceBindingDescriptorFromConfigured(hostService), deps, true)
 			if err != nil {
 				return providerdev.RuntimeEnv{}, err
 			}
@@ -210,21 +210,8 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 			deps.PublicHostServices.UnregisterSession(name, sessionID, hostServices...)
 		})
 	}
-	startedHostServices, err := runtimehost.StartHostServices(
-		hostServices,
-		runtimehost.WithHostServicesProviderName(name),
-		runtimehost.WithHostServicesTelemetry(deps.Telemetry),
-	)
-	if err != nil {
-		return providerdev.RuntimeEnv{}, fmt.Errorf("start host services: %w", err)
-	}
-	if startedHostServices != nil {
-		cleanup = chainCleanup(cleanup, func() {
-			_ = startedHostServices.Close()
-		})
-	}
-	for _, hostService := range startedHostServices.Bindings() {
-		bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostServiceBindingDescriptorFromStarted(hostService), deps, false, false)
+	for _, hostService := range hostServices {
+		bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostServiceBindingDescriptorFromConfigured(hostService), deps, true)
 		if err != nil {
 			return providerdev.RuntimeEnv{}, err
 		}
@@ -275,7 +262,7 @@ func registerProviderDevPublicHostServices(cfg *config.Config, manager *provider
 		if entry == nil || !entry.HasResolvedManifest() {
 			continue
 		}
-		hostServices, _, cleanup, err := buildPluginRuntimeHostServices(name, entry, deps, false)
+		hostServices, _, cleanup, err := buildPluginRuntimeHostServices(name, entry, deps)
 		if err != nil {
 			if cleanup != nil {
 				cleanup()

--- a/gestaltd/internal/bootstrap/sandbox_test.go
+++ b/gestaltd/internal/bootstrap/sandbox_test.go
@@ -75,7 +75,7 @@ func TestSandboxedPluginCannotReadUnauthorizedFile(t *testing.T) {
 	}
 
 	factories := NewFactoryRegistry()
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, testRuntimePublicEndpointDeps(t, Deps{}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestSandboxedPluginCanCommunicateViaGRPC(t *testing.T) {
 	}
 
 	factories := NewFactoryRegistry()
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, testRuntimePublicEndpointDeps(t, Deps{}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestSandboxedSynthesizedSourcePluginCanStart(t *testing.T) {
 	}
 
 	factories := NewFactoryRegistry()
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, testRuntimePublicEndpointDeps(t, Deps{}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestSandboxDisabledByDefault(t *testing.T) {
 	}
 
 	factories := NewFactoryRegistry()
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, testRuntimePublicEndpointDeps(t, Deps{}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestSandboxedPluginHTTPProxyAllowsConfiguredHosts(t *testing.T) {
 	}
 
 	factories := NewFactoryRegistry()
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, testRuntimePublicEndpointDeps(t, Deps{}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestSandboxedPluginHTTPProxyBlocksUnconfiguredHosts(t *testing.T) {
 	}
 
 	factories := NewFactoryRegistry()
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, testRuntimePublicEndpointDeps(t, Deps{}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -163,6 +163,7 @@ func workflowStartupTestConfig() *config.Config {
 			},
 		},
 		Server: config.ServerConfig{
+			BaseURL:       "https://gestalt.example.test",
 			Public:        config.ListenerConfig{Port: 8080},
 			EncryptionKey: "test-key",
 			Providers:     config.ServerProvidersConfig{IndexedDB: "test"},

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -150,6 +151,7 @@ func TestE2EValidateAcceptsV3TelemetryBuiltins(t *testing.T) {
 			cfgPath := filepath.Join(dir, "config.yaml")
 			cfg := fmt.Sprintf(`apiVersion: %s
 server:
+  baseUrl: %s
   encryptionKey: valid-config-e2e-key
   providers:
     telemetry: primary
@@ -167,7 +169,7 @@ plugins:
   example:
     source:
       path: %s
-`, config.ConfigAPIVersion, tc.source, tc.telemetryBlock, indexedDBManifest, pluginManifest)
+`, config.ConfigAPIVersion, e2eLoopbackBaseURL(8080), tc.source, tc.telemetryBlock, indexedDBManifest, pluginManifest)
 			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 				t.Fatalf("write config: %v", err)
 			}
@@ -193,6 +195,7 @@ func TestE2EValidateAcceptsCanonicalConfigShapes(t *testing.T) {
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   encryptionKey: canonical-config-shapes-key
   providers:
     indexeddb: inmem
@@ -279,7 +282,7 @@ workflows:
           operation: sync
           input:
             mode: event
-`, indexedDBManifest, ui.ManifestPath, workflowManifest, agentManifest, pluginManifest)
+`, e2eLoopbackBaseURL(8080), indexedDBManifest, ui.ManifestPath, workflowManifest, agentManifest, pluginManifest)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -668,6 +671,7 @@ func TestE2EValidateAcceptsLayeredConfigs(t *testing.T) {
 	baseConfigPath := filepath.Join(baseDir, "base.yaml")
 	baseConfig := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   encryptionKey: test-key
   providers:
     indexeddb: sqlite
@@ -682,7 +686,7 @@ plugins:
   example:
     source:
       path: ./missing/manifest.yaml
-`, indexedDBManifest, filepath.Join(rootDir, "gestalt.db"))
+`, e2eLoopbackBaseURL(8080), indexedDBManifest, filepath.Join(rootDir, "gestalt.db"))
 	if err := os.WriteFile(baseConfigPath, []byte(baseConfig), 0o644); err != nil {
 		t.Fatalf("WriteFile base config: %v", err)
 	}
@@ -726,6 +730,7 @@ func TestE2EValidateUsesScratchPreparedInstallsForLocalSourceConfigs(t *testing.
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   encryptionKey: test-key
   providers:
     indexeddb: sqlite
@@ -740,7 +745,7 @@ plugins:
   example:
     source:
       path: %s
-`, indexedDBManifest, filepath.Join(dir, "gestalt.db"), componentProviderManifestPath(t, pluginDir))
+`, e2eLoopbackBaseURL(8080), indexedDBManifest, filepath.Join(dir, "gestalt.db"), componentProviderManifestPath(t, pluginDir))
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
@@ -788,6 +793,7 @@ func TestE2EValidateRejectsInvalidPluginInvokesDependency(t *testing.T) {
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   encryptionKey: test-key
   providers:
     indexeddb: sqlite
@@ -808,7 +814,7 @@ plugins:
   target:
     source:
       path: %s
-`, indexedDBManifest, filepath.Join(dir, "gestalt.db"), componentProviderManifestPath(t, callerDir), componentProviderManifestPath(t, targetDir))
+`, e2eLoopbackBaseURL(8080), indexedDBManifest, filepath.Join(dir, "gestalt.db"), componentProviderManifestPath(t, callerDir), componentProviderManifestPath(t, targetDir))
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
@@ -861,6 +867,7 @@ paths:
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   encryptionKey: test-key
   providers:
     indexeddb: sqlite
@@ -875,7 +882,7 @@ plugins:
   target:
     source:
       path: %s
-`, indexedDBManifest, filepath.Join(dir, "gestalt.db"), manifestPath)
+`, e2eLoopbackBaseURL(8080), indexedDBManifest, filepath.Join(dir, "gestalt.db"), manifestPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
@@ -1672,6 +1679,7 @@ func writeServeConfig(t *testing.T, dir string, port int, mountedUI *mountedUITe
 
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   public:
     port: %d
   encryptionKey: test-serve-e2e-key
@@ -1686,7 +1694,7 @@ providers:
   example:
     source:
       path: %s
-`, port, indexedDBManifest, uiBlock, pluginManifest)
+`, e2eLoopbackBaseURL(port), port, indexedDBManifest, uiBlock, pluginManifest)
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -1717,6 +1725,7 @@ func writeServeConfigWithManagement(t *testing.T, dir string, publicPort, manage
 
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   public:
     port: %d
   management:
@@ -1734,7 +1743,7 @@ providers:
   example:
     source:
       path: %s
-`, publicPort, managementPort, indexedDBManifest, uiBlock, pluginManifest)
+`, e2eLoopbackBaseURL(publicPort), publicPort, managementPort, indexedDBManifest, uiBlock, pluginManifest)
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -1758,6 +1767,10 @@ func startGestaltdWithConfigsAndArgs(t *testing.T, cfgPaths []string, args []str
 		t.Fatalf("read config: %v", err)
 	}
 	cfg := strings.Replace(string(cfgBytes), "port: 0", fmt.Sprintf("port: %d", port), 1)
+	cfg = strings.Replace(cfg, "baseUrl: "+e2eLoopbackBaseURL(0), "baseUrl: "+baseURL, 1)
+	if !strings.Contains(cfg, "server:\n  baseUrl:") {
+		cfg = strings.Replace(cfg, "server:\n", "server:\n  baseUrl: "+baseURL+"\n", 1)
+	}
 	if err := os.WriteFile(primaryCfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -1931,6 +1944,13 @@ func startGestaltdWithConfig(t *testing.T, cfgPath string) string {
 func startGestaltd(t *testing.T, dir string, mountedUI *mountedUITestConfig) string {
 	t.Helper()
 	return startGestaltdWithConfig(t, writeServeConfig(t, dir, 0, mountedUI))
+}
+
+func e2eLoopbackBaseURL(port int) string {
+	return (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort("127.0.0.1", fmt.Sprint(port)),
+	}).String()
 }
 
 func TestE2EServeAndHealthCheck(t *testing.T) {
@@ -2311,6 +2331,7 @@ func TestE2EServePluginOwnedUIWiring(t *testing.T) {
 	cfgPath := filepath.Join(dir, "config-owned-ui.yaml")
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   public:
     port: %d
   encryptionKey: test-plugin-owned-ui-key
@@ -2332,7 +2353,7 @@ plugins:
     ui:
       bundle: roadmap
       path: /roadmap
-`, publicPort, indexedDBManifest, mountedUI.ManifestPath, pluginManifest)
+`, publicURL, publicPort, indexedDBManifest, mountedUI.ManifestPath, pluginManifest)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write owned-ui config: %v", err)
 	}
@@ -2401,6 +2422,7 @@ func TestE2EServeStartsWithPluginBoundCacheProvider(t *testing.T) {
 
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   public:
     port: 0
   encryptionKey: test-cache-serve-e2e-key
@@ -2421,7 +2443,7 @@ plugins:
       path: %s
     cache:
       - session
-`, indexedDBManifest, cacheManifest, pluginManifest)
+`, e2eLoopbackBaseURL(0), indexedDBManifest, cacheManifest, pluginManifest)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -2499,6 +2521,7 @@ func TestE2EHostedHTTPSubjectResolutionUsesAuthorizationAndInheritedInvocation(t
 	cfgPath := filepath.Join(dir, "config-subject-resolution.yaml")
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   public:
     port: %d
   encryptionKey: test-http-subject-resolution-key
@@ -2523,7 +2546,7 @@ plugins:
     invokes:
       - plugin: example
         operation: request_context
-`, port, indexedDBManifest, "sqlite://"+filepath.Join(dir, "gestalt.db"), authorizationManifest, pluginManifest)
+`, baseURL, port, indexedDBManifest, "sqlite://"+filepath.Join(dir, "gestalt.db"), authorizationManifest, pluginManifest)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -2749,6 +2772,7 @@ func TestE2ELockSyncPluginOwnedUI(t *testing.T) {
 	cfgPath := filepath.Join(dir, "config-owned-ui-lock-sync.yaml")
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   public:
     port: 0
   encryptionKey: test-lock-sync-owned-ui-key
@@ -2765,7 +2789,7 @@ plugins:
       path: %s
     ui:
       path: /roadmap
-`, indexedDBManifest, pluginManifest)
+`, e2eLoopbackBaseURL(0), indexedDBManifest, pluginManifest)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write owned-ui lock/sync config: %v", err)
 	}
@@ -3011,6 +3035,7 @@ func writeValidValidateConfig(t *testing.T, dir string) string {
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   encryptionKey: valid-config-e2e-key
   providers:
     indexeddb: inmem
@@ -3028,7 +3053,7 @@ plugins:
   example:
     source:
       path: %s
-`, externalCredentialsManifest, indexedDBManifest, pluginManifest)
+`, e2eLoopbackBaseURL(8080), externalCredentialsManifest, indexedDBManifest, pluginManifest)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write valid config: %v", err)
 	}
@@ -3043,6 +3068,7 @@ func writeInvalidValidateConfig(t *testing.T, path string) {
 	externalCredentialsManifest := componentProviderManifestPath(t, setupExternalCredentialsProviderDir(t, dir))
 	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   encryptionKey: invalid-config-e2e-key
   providers:
     indexeddb: inmem
@@ -3060,7 +3086,7 @@ plugins:
   example:
     source:
       path: %s
-`, externalCredentialsManifest, indexedDBManifest, filepath.Join(dir, "missing-plugin", "manifest.yaml"))
+`, e2eLoopbackBaseURL(8080), externalCredentialsManifest, indexedDBManifest, filepath.Join(dir, "missing-plugin", "manifest.yaml"))
 	if err := os.WriteFile(path, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write invalid config: %v", err)
 	}
@@ -3097,6 +3123,7 @@ func writeLayeredE2EConfigs(t *testing.T, dir string, port int) (string, string,
 	overridePath := filepath.Join(overrideDir, "local.yaml")
 	baseCfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   public:
     port: %d
   encryptionKey: test-layered-e2e-key
@@ -3116,7 +3143,7 @@ plugins:
   example:
     source:
       path: %s
-`, port, filepath.ToSlash(externalCredentialsManifest), filepath.ToSlash(indexedDBRel), filepath.ToSlash(pluginRel))
+`, e2eLoopbackBaseURL(port), port, filepath.ToSlash(externalCredentialsManifest), filepath.ToSlash(indexedDBRel), filepath.ToSlash(pluginRel))
 	overrideCfg := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
   providers:
@@ -3153,10 +3180,11 @@ func writeE2EConfigWithPaths(t *testing.T, dir, pluginDir, dbPath, artifactsDir 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	serverBlock := fmt.Sprintf(`apiVersion: gestaltd.config/v4
 server:
+  baseUrl: %s
   public:
     port: %d
   encryptionKey: test-e2e-key
-`, port)
+`, e2eLoopbackBaseURL(port), port)
 	if artifactsDir != "" {
 		serverBlock += fmt.Sprintf("  artifactsDir: %s\n", artifactsDir)
 	}

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -1134,6 +1134,7 @@ func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string,
 	cfg := map[string]any{
 		"apiVersion": config.ConfigAPIVersion,
 		"server": map[string]any{
+			"baseUrl": providerLocalBaseURL(port),
 			"public": map[string]any{
 				"host": providerDevHost,
 				"port": port,
@@ -1179,6 +1180,7 @@ func writeProviderLocalUIOverlayConfig(path, uiKey, manifestPath string, port in
 	cfg := map[string]any{
 		"apiVersion": config.ConfigAPIVersion,
 		"server": map[string]any{
+			"baseUrl": providerLocalBaseURL(port),
 			"public": map[string]any{
 				"host": providerDevHost,
 				"port": port,
@@ -1315,6 +1317,13 @@ func providerLocalPublicURL(cfg *config.Config) string {
 		return ""
 	}
 	return (&url.URL{Scheme: "http", Host: addr}).String()
+}
+
+func providerLocalBaseURL(port int) string {
+	return (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(providerDevHost, fmt.Sprint(port)),
+	}).String()
 }
 
 func mountedPublicUIPaths(cfg *config.Config) []string {

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -102,6 +102,9 @@ func (s *Server) hostServiceHandler(ctx context.Context, target runtimehost.Host
 		}
 		return entry.handler, nil
 	}
+	if coreRoutableHostServiceTarget(target) {
+		return nil, nil
+	}
 
 	exactKey := hostServiceHandlerKey{
 		pluginName: strings.TrimSpace(target.PluginName),
@@ -147,7 +150,7 @@ func (s *Server) coreRoutableHostServiceHandlerEntry(ctx context.Context, target
 	if !ok {
 		return hostServiceHandlerEntry{}, false, nil
 	}
-	if err := s.verifyCoreRoutableHostServiceSession(ctx, pluginName, target.SessionID); err != nil {
+	if err := s.verifyCoreRoutableHostServiceSession(ctx, target); err != nil {
 		return hostServiceHandlerEntry{}, false, err
 	}
 	s.hostServiceMu.Lock()
@@ -176,12 +179,64 @@ func (s *Server) coreRoutableHostServiceHandlerEntry(ctx context.Context, target
 	return entry, true, nil
 }
 
-func (s *Server) verifyCoreRoutableHostServiceSession(ctx context.Context, pluginName, sessionID string) error {
+func (s *Server) verifyCoreRoutableHostServiceSession(ctx context.Context, target runtimehost.HostServiceRelayTarget) error {
+	if ok, err := s.verifyRegisteredCoreRoutableHostServiceSession(ctx, target); ok || err != nil {
+		return err
+	}
+
+	pluginName := strings.TrimSpace(target.PluginName)
 	verifier, ok := s.pluginRuntimes.(pluginRuntimeSessionVerifier)
 	if !ok || verifier == nil {
 		return fmt.Errorf("plugin runtime session verifier is not configured")
 	}
-	return verifier.VerifyPluginRuntimeSession(ctx, pluginName, sessionID)
+	return verifier.VerifyPluginRuntimeSession(ctx, pluginName, target.SessionID)
+}
+
+func (s *Server) verifyRegisteredCoreRoutableHostServiceSession(ctx context.Context, target runtimehost.HostServiceRelayTarget) (bool, error) {
+	if s == nil || s.publicHostServices == nil {
+		return false, nil
+	}
+	pluginName := strings.TrimSpace(target.PluginName)
+	serviceName := strings.TrimSpace(target.Service)
+	envVar := strings.TrimSpace(target.EnvVar)
+	sessionID := strings.TrimSpace(target.SessionID)
+	if pluginName == "" || serviceName == "" || envVar == "" {
+		return false, nil
+	}
+
+	var lastErr error
+	for _, service := range s.publicHostServices.Snapshot() {
+		key, ok := publicHostServiceHandlerKey(service)
+		if !ok || key.pluginName != pluginName || key.service != serviceName || key.envVar != envVar {
+			continue
+		}
+		if key.sessionID != "" {
+			if key.sessionID != sessionID {
+				continue
+			}
+			if service.SessionVerifier == nil {
+				return true, nil
+			}
+			return true, service.SessionVerifier.VerifyHostServiceSession(ctx, sessionID)
+		}
+		if service.SessionVerifier == nil {
+			continue
+		}
+		if err := service.SessionVerifier.VerifyHostServiceSession(ctx, sessionID); err != nil {
+			lastErr = err
+			continue
+		}
+		return true, nil
+	}
+	if lastErr != nil {
+		return true, lastErr
+	}
+	return false, nil
+}
+
+func coreRoutableHostServiceTarget(target runtimehost.HostServiceRelayTarget) bool {
+	_, ok := coreRoutableHostServiceHandlerKey(strings.TrimSpace(target.PluginName), target)
+	return ok
 }
 
 func coreRoutableHostServiceHandlerKey(pluginName string, target runtimehost.HostServiceRelayTarget) (hostServiceHandlerKey, bool) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1112,7 +1112,7 @@ func TestHostServiceRelayRejectsCoreRoutableWithoutRuntimeVerifier(t *testing.T)
 	}
 }
 
-func TestHostServiceRelayServesRegisteredCoreServiceWithoutCoreRoutableToken(t *testing.T) {
+func TestHostServiceRelayRejectsRegisteredCoreServiceWithoutCoreRoutableToken(t *testing.T) {
 	t.Parallel()
 
 	secret := []byte("relay-test-secret-0123456789abcd")
@@ -1174,21 +1174,18 @@ func TestHostServiceRelayServesRegisteredCoreServiceWithoutCoreRoutableToken(t *
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
-	resp, err := proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{
+	_, err = proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{
 		InvocationToken: invocationToken,
 		Plugin:          "slack",
 		Operation:       "events.reply",
 		Instance:        "prod",
 		IdempotencyKey:  "provider-dev-call",
 	})
-	if err != nil {
-		t.Fatalf("PluginInvoker.Invoke via registered relay: %v", err)
+	if grpcstatus.Code(err) != codes.Unavailable {
+		t.Fatalf("PluginInvoker.Invoke registered non-core relay code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
 	}
-	if resp.GetStatus() != 202 || resp.GetBody() != "relayed" {
-		t.Fatalf("PluginInvoker.Invoke response = %+v, want status=202 body=relayed", resp)
-	}
-	if call := invoker.snapshot(); call.providerName != "slack" || call.operation != "events.reply" || call.idempotencyKey != "provider-dev-call" {
-		t.Fatalf("registry invocation call = %+v, want slack.events.reply provider-dev-call", call)
+	if call := invoker.snapshot(); call.providerName != "" {
+		t.Fatalf("registered core handler was called for non-core relay: %+v", call)
 	}
 }
 

--- a/gestaltd/internal/testplugins/echo/proxy_provider.go
+++ b/gestaltd/internal/testplugins/echo/proxy_provider.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"io"
@@ -645,7 +647,10 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 		if proxyURL := os.Getenv("HTTP_PROXY"); proxyURL != "" {
 			parsed, err := url.Parse(proxyURL)
 			if err == nil {
-				client.Transport = &http.Transport{Proxy: http.ProxyURL(parsed)}
+				client.Transport = &http.Transport{
+					Proxy:           http.ProxyURL(parsed),
+					TLSClientConfig: testTLSConfigFromEnv(),
+				}
 			}
 		}
 		resp, err := client.Get(targetURL)
@@ -985,6 +990,32 @@ func decodeResultBody(body string) any {
 		return decoded
 	}
 	return body
+}
+
+func testTLSConfigFromEnv() *tls.Config {
+	pemBytes := []byte(strings.TrimSpace(os.Getenv(gestalt.EnvHostServiceTLSCAPEM)))
+	caFile := strings.TrimSpace(os.Getenv(gestalt.EnvHostServiceTLSCAFile))
+	if len(pemBytes) == 0 && caFile == "" {
+		return nil
+	}
+	if len(pemBytes) == 0 {
+		var err error
+		pemBytes, err = os.ReadFile(caFile)
+		if err != nil {
+			return nil
+		}
+	}
+	roots, err := x509.SystemCertPool()
+	if err != nil || roots == nil {
+		roots = x509.NewCertPool()
+	}
+	if !roots.AppendCertsFromPEM(pemBytes) {
+		return nil
+	}
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    roots,
+	}
 }
 
 func jsonResult(status int, body any) *core.OperationResult {

--- a/gestaltd/services/runtimehost/process.go
+++ b/gestaltd/services/runtimehost/process.go
@@ -514,6 +514,8 @@ func envSlice(values map[string]string) []string {
 var safeEnvKeys = []string{
 	"PATH", "HOME", "TMPDIR", "LANG", "TZ",
 	"SSL_CERT_FILE", "SSL_CERT_DIR",
+	"GESTALT_HOST_SERVICE_TLS_CA_FILE",
+	"GESTALT_HOST_SERVICE_TLS_CA_PEM",
 }
 
 func safeBaseEnv() []string {

--- a/sdk/go/authorization_client.go
+++ b/sdk/go/authorization_client.go
@@ -2,7 +2,6 @@ package gestalt
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/url"
@@ -91,13 +90,13 @@ func sharedAuthorizationClient(ctx context.Context, target, token string) (proto
 		if splitErr != nil {
 			return nil, fmt.Errorf("authorization: parse tls target %q: %w", address, splitErr)
 		}
+		tlsConfig, tlsErr := hostServiceTLSConfig("authorization", host)
+		if tlsErr != nil {
+			return nil, tlsErr
+		}
 		conn, err = grpc.DialContext(ctx, address,
 			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-					MinVersion: tls.VersionTLS12,
-					ServerName: host,
-					NextProtos: []string{"h2"},
-				})),
+				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 				grpc.WithBlock(),
 			), opts...)...,
 		)

--- a/sdk/go/cache.go
+++ b/sdk/go/cache.go
@@ -2,7 +2,6 @@ package gestalt
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/url"
@@ -115,13 +114,13 @@ func Cache(name ...string) (*CacheClient, error) {
 		if splitErr != nil {
 			return nil, fmt.Errorf("cache: parse tls target %q: %w", address, splitErr)
 		}
+		tlsConfig, tlsErr := hostServiceTLSConfig("cache", host)
+		if tlsErr != nil {
+			return nil, tlsErr
+		}
 		conn, err = grpc.DialContext(ctx, address,
 			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-					MinVersion: tls.VersionTLS12,
-					ServerName: host,
-					NextProtos: []string{"h2"},
-				})),
+				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 				grpc.WithBlock(),
 			), opts...)...,
 		)

--- a/sdk/go/host_service_tls.go
+++ b/sdk/go/host_service_tls.go
@@ -1,0 +1,46 @@
+package gestalt
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// EnvHostServiceTLSCAFile points the SDK at an additional PEM CA bundle for
+// tls:// host-service relay targets.
+const EnvHostServiceTLSCAFile = "GESTALT_HOST_SERVICE_TLS_CA_FILE"
+
+// EnvHostServiceTLSCAPEM provides additional PEM roots directly in the process
+// environment for tls:// host-service relay targets.
+const EnvHostServiceTLSCAPEM = "GESTALT_HOST_SERVICE_TLS_CA_PEM"
+
+func hostServiceTLSConfig(serviceName, serverName string) (*tls.Config, error) {
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		ServerName: serverName,
+		NextProtos: []string{"h2"},
+	}
+	pemBytes := []byte(strings.TrimSpace(os.Getenv(EnvHostServiceTLSCAPEM)))
+	caFile := strings.TrimSpace(os.Getenv(EnvHostServiceTLSCAFile))
+	if len(pemBytes) == 0 && caFile == "" {
+		return cfg, nil
+	}
+	if len(pemBytes) == 0 {
+		var err error
+		pemBytes, err = os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("%s: read %s: %w", serviceName, EnvHostServiceTLSCAFile, err)
+		}
+	}
+	roots, err := x509.SystemCertPool()
+	if err != nil || roots == nil {
+		roots = x509.NewCertPool()
+	}
+	if !roots.AppendCertsFromPEM(pemBytes) {
+		return nil, fmt.Errorf("%s: host service TLS CA did not contain any PEM certificates", serviceName)
+	}
+	cfg.RootCAs = roots
+	return cfg, nil
+}

--- a/sdk/go/indexeddb.go
+++ b/sdk/go/indexeddb.go
@@ -2,7 +2,6 @@ package gestalt
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/url"
@@ -216,13 +215,13 @@ func IndexedDB(name ...string) (*IndexedDBClient, error) {
 		if splitErr != nil {
 			return nil, fmt.Errorf("indexeddb: parse tls target %q: %w", address, splitErr)
 		}
+		tlsConfig, tlsErr := hostServiceTLSConfig("indexeddb", host)
+		if tlsErr != nil {
+			return nil, tlsErr
+		}
 		conn, err = grpc.DialContext(ctx, address,
 			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-					MinVersion: tls.VersionTLS12,
-					ServerName: host,
-					NextProtos: []string{"h2"},
-				})),
+				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 				grpc.WithBlock(),
 			), opts...)...,
 		)

--- a/sdk/go/invoker.go
+++ b/sdk/go/invoker.go
@@ -2,7 +2,6 @@ package gestalt
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/url"
@@ -112,13 +111,13 @@ func sharedPluginInvokerClient(ctx context.Context, target, token string) (proto
 		if splitErr != nil {
 			return nil, fmt.Errorf("plugin invoker: parse tls target %q: %w", address, splitErr)
 		}
+		tlsConfig, tlsErr := hostServiceTLSConfig("plugin invoker", host)
+		if tlsErr != nil {
+			return nil, tlsErr
+		}
 		conn, err = grpc.DialContext(ctx, address,
 			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-					MinVersion: tls.VersionTLS12,
-					ServerName: host,
-					NextProtos: []string{"h2"},
-				})),
+				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 				grpc.WithBlock(),
 			), opts...)...,
 		)

--- a/sdk/go/manager_transport.go
+++ b/sdk/go/manager_transport.go
@@ -2,7 +2,6 @@ package gestalt
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/url"
@@ -92,13 +91,13 @@ func dialManagerTransport(ctx context.Context, serviceName, target, token string
 		if err != nil {
 			return nil, fmt.Errorf("%s: parse tls target %q: %w", serviceName, address, err)
 		}
+		tlsConfig, err := hostServiceTLSConfig(serviceName, host)
+		if err != nil {
+			return nil, err
+		}
 		return grpc.DialContext(ctx, address,
 			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-					MinVersion: tls.VersionTLS12,
-					ServerName: host,
-					NextProtos: []string{"h2"},
-				})),
+				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 				grpc.WithBlock(),
 			), opts...)...,
 		)

--- a/sdk/go/s3.go
+++ b/sdk/go/s3.go
@@ -3,7 +3,6 @@ package gestalt
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -225,13 +224,13 @@ func S3(name ...string) (*S3Client, error) {
 		if splitErr != nil {
 			return nil, fmt.Errorf("s3: parse tls target %q: %w", address, splitErr)
 		}
+		tlsConfig, tlsErr := hostServiceTLSConfig("s3", host)
+		if tlsErr != nil {
+			return nil, tlsErr
+		}
 		conn, err = grpc.DialContext(ctx, address,
 			append(internalHostServiceBaseDialOptions(
-				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-					MinVersion: tls.VersionTLS12,
-					ServerName: host,
-					NextProtos: []string{"h2"},
-				})),
+				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 				grpc.WithBlock(),
 			), opts...)...,
 		)


### PR DESCRIPTION
## Summary
- Remove hosted runtime Unix host-service startup/binding fallback and always bind runtime callbacks through the public host-service relay.
- Register only non-core host services in the public registry; workflow manager, agent manager, and plugin invoker callbacks route through core relay tokens.
- Add SDK support for an explicit host-service TLS CA so integration tests and private-CA deployments can verify tls:// relay targets without disabling TLS verification.

## Testing
- go test ./internal/bootstrap
- go test ./internal/server ./services/runtimehost ./internal/testplugins/echo
- (cd ../sdk/go && go test ./...)
- golangci-lint run --path-prefix=gestaltd ./internal/bootstrap/... ./internal/server/... ./services/runtimehost/... ./internal/testplugins/echo/...
- (cd ../sdk/go && golangci-lint run --new-from-rev=origin/main ./...)

Note: full SDK golangci-lint still reports existing baseline issues; the new-from-main lint run is clean.