### PR TITLE
Harden browser auth CSRF flows

### DIFF
--- a/gestaltd/internal/server/csrf.go
+++ b/gestaltd/internal/server/csrf.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+)
+
+var (
+	errCSRFValidationFailed        = errors.New("CSRF validation failed")
+	errUnsupportedLoginContentType = errors.New("login initiation requires application/json")
+)
+
+func (s *Server) cookieCSRFMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := s.validateCookieAuthenticatedMutation(r); err != nil {
+			writeError(w, http.StatusForbidden, errCSRFValidationFailed.Error())
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) validateCookieAuthenticatedMutation(r *http.Request) error {
+	if !isMutatingMethod(r.Method) {
+		return nil
+	}
+	p := PrincipalFromContext(r.Context())
+	if p == nil || p.Source != principal.SourceSession {
+		return nil
+	}
+	if c, err := r.Cookie(sessionCookieName); err != nil || c.Value == "" {
+		return nil
+	}
+	return s.validateSameOriginRequestHeaders(r)
+}
+
+func isMutatingMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Server) validateLoginInitiation(r *http.Request, extraAllowedOrigins ...requestOrigin) error {
+	if r.Method == http.MethodPost && !hasJSONContentType(r) {
+		return errUnsupportedLoginContentType
+	}
+	return s.validateSameOriginRequestHeaders(r, extraAllowedOrigins...)
+}
+
+func hasJSONContentType(r *http.Request) bool {
+	contentType := strings.TrimSpace(r.Header.Get("Content-Type"))
+	if contentType == "" {
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(mediaType, "application/json")
+}
+
+func (s *Server) validateSameOriginRequestHeaders(r *http.Request, extraAllowedOrigins ...requestOrigin) error {
+	if site := strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site"))); site != "" {
+		switch site {
+		case "same-origin", "none":
+		case "same-site":
+			if !s.hasAllowedOriginEvidence(r, extraAllowedOrigins...) {
+				return fmt.Errorf("%w: same-site fetch metadata without allowed origin", errCSRFValidationFailed)
+			}
+		case "cross-site":
+			return fmt.Errorf("%w: cross-site fetch metadata", errCSRFValidationFailed)
+		default:
+			return fmt.Errorf("%w: invalid fetch metadata", errCSRFValidationFailed)
+		}
+	}
+	if origin := strings.TrimSpace(r.Header.Get("Origin")); origin != "" {
+		if !s.requestOriginAllowed(r, origin, extraAllowedOrigins...) {
+			return fmt.Errorf("%w: origin mismatch", errCSRFValidationFailed)
+		}
+	}
+	if referer := strings.TrimSpace(r.Header.Get("Referer")); referer != "" {
+		if !s.requestRefererAllowed(r, referer, extraAllowedOrigins...) {
+			return fmt.Errorf("%w: referer mismatch", errCSRFValidationFailed)
+		}
+	}
+	return nil
+}
+
+func (s *Server) hasAllowedOriginEvidence(r *http.Request, extraAllowedOrigins ...requestOrigin) bool {
+	if origin := strings.TrimSpace(r.Header.Get("Origin")); origin != "" {
+		return s.requestOriginAllowed(r, origin, extraAllowedOrigins...)
+	}
+	if referer := strings.TrimSpace(r.Header.Get("Referer")); referer != "" {
+		return s.requestRefererAllowed(r, referer, extraAllowedOrigins...)
+	}
+	return false
+}
+
+func (s *Server) requestOriginAllowed(r *http.Request, rawOrigin string, extraAllowedOrigins ...requestOrigin) bool {
+	if strings.EqualFold(rawOrigin, "null") {
+		return false
+	}
+	origin, err := url.Parse(rawOrigin)
+	if err != nil || origin.Scheme == "" || origin.Host == "" || origin.Path != "" {
+		return false
+	}
+	return s.originAllowed(r, origin.Scheme, origin.Host, extraAllowedOrigins...)
+}
+
+func (s *Server) requestRefererAllowed(r *http.Request, rawReferer string, extraAllowedOrigins ...requestOrigin) bool {
+	referer, err := url.Parse(rawReferer)
+	if err != nil || referer.Scheme == "" || referer.Host == "" {
+		return false
+	}
+	return s.originAllowed(r, referer.Scheme, referer.Host, extraAllowedOrigins...)
+}
+
+func (s *Server) originAllowed(r *http.Request, scheme, host string, extraAllowedOrigins ...requestOrigin) bool {
+	for _, allowed := range s.allowedRequestOrigins(r, extraAllowedOrigins...) {
+		if strings.EqualFold(allowed.Scheme, scheme) && strings.EqualFold(allowed.Host, host) {
+			return true
+		}
+	}
+	return false
+}
+
+type requestOrigin struct {
+	Scheme string
+	Host   string
+}
+
+func (s *Server) allowedRequestOrigins(r *http.Request, extraAllowedOrigins ...requestOrigin) []requestOrigin {
+	origins := append([]requestOrigin(nil), extraAllowedOrigins...)
+	if s.publicBaseURL != "" {
+		if parsed, err := url.Parse(s.publicBaseURL); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+			origins = append(origins, requestOrigin{Scheme: parsed.Scheme, Host: parsed.Host})
+		}
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if r.Host != "" {
+		origins = append(origins, requestOrigin{Scheme: scheme, Host: r.Host})
+	}
+	return origins
+}

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -80,6 +80,16 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 		s.auditHTTPEvent(r.Context(), nil, auth.providerName, "auth.login.start", auditAllowed, auditErr)
 	}()
 
+	if err := s.validateLoginInitiation(r); err != nil {
+		auditErr = err
+		status := http.StatusForbidden
+		if errors.Is(err, errUnsupportedLoginContentType) {
+			status = http.StatusUnsupportedMediaType
+		}
+		writeError(w, status, err.Error())
+		return
+	}
+
 	var req loginRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		auditErr = errors.New("invalid JSON body")
@@ -87,15 +97,17 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	state := req.State
+	mode := loginModeBrowser
 	if req.CallbackPort > 0 && req.CallbackPort <= maxPort {
 		state = fmt.Sprintf("%s%d:%s", cliStatePrefix, req.CallbackPort, req.State)
+		mode = loginModeCLI
 	}
 	if auth.noAuth || auth.provider == nil {
 		auditErr = errors.New("auth is disabled")
 		writeError(w, http.StatusNotFound, "auth is disabled")
 		return
 	}
-	loginURL, err := s.beginLogin(w, r, auth, state, "")
+	loginURL, err := s.beginLogin(w, r, auth, state, "", mode)
 	if err != nil {
 		auditErr = err
 		status := http.StatusInternalServerError
@@ -128,6 +140,11 @@ func (s *Server) startBrowserLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if err := s.validateLoginInitiation(r, s.allowedLoginInitiationOrigins(nextPath)...); err != nil {
+		auditErr = err
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 	auth, err = s.loginAuthRuntimeForNextPath(nextPath)
 	if err != nil {
 		auditErr = err
@@ -140,7 +157,7 @@ func (s *Server) startBrowserLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	loginURL, err := s.beginLogin(w, r, auth, browserLoginStateForNextPath(nextPath), nextPath)
+	loginURL, err := s.beginLogin(w, r, auth, browserLoginStateForNextPath(nextPath), nextPath, loginModeBrowser)
 	if err != nil {
 		auditErr = err
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -152,7 +169,7 @@ func (s *Server) startBrowserLogin(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, loginURL, http.StatusFound)
 }
 
-func (s *Server) beginLogin(w http.ResponseWriter, r *http.Request, auth authRuntime, state, nextPath string) (string, error) {
+func (s *Server) beginLogin(w http.ResponseWriter, r *http.Request, auth authRuntime, state, nextPath, mode string) (string, error) {
 	loginURLRaw, err := loginURLForRequest(r.Context(), auth.provider, state)
 	if err != nil {
 		return "", errors.New("failed to generate login URL")
@@ -166,6 +183,7 @@ func (s *Server) beginLogin(w http.ResponseWriter, r *http.Request, auth authRun
 			State:     state,
 			Provider:  auth.providerRef,
 			NextPath:  nextPath,
+			Mode:      normalizeLoginMode(mode, state),
 			ExpiresAt: s.now().Add(loginStateTTL).Unix(),
 		})
 		if encErr != nil {
@@ -189,6 +207,19 @@ func (s *Server) allowedLoginRedirectBaseURLs() []string {
 		return nil
 	}
 	return []string{strings.TrimRight(s.managementBaseURL, "/") + "/admin"}
+}
+
+func (s *Server) allowedLoginInitiationOrigins(nextPath string) []requestOrigin {
+	parsed, err := url.Parse(strings.TrimSpace(nextPath))
+	if err != nil || !parsed.IsAbs() || parsed.Scheme == "" || parsed.Host == "" {
+		return nil
+	}
+	for _, base := range s.allowedLoginRedirectBaseURLs() {
+		if absoluteLoginRedirectAllowed(nextPath, base) {
+			return []requestOrigin{{Scheme: parsed.Scheme, Host: parsed.Host}}
+		}
+	}
+	return nil
 }
 
 func resolveLoginRedirectPath(raw string, allowedBaseURLs []string) (string, error) {
@@ -402,6 +433,12 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, "login state validation failed")
 		return
 	}
+	if !loginCallbackModeMatches(loginState.Mode, r.URL.Query().Get("cli")) {
+		auditErr = errors.New("login mode validation failed")
+		slog.ErrorContext(r.Context(), "login mode validation failed", "expected", loginState.Mode)
+		writeError(w, http.StatusForbidden, "login mode validation failed")
+		return
+	}
 
 	auth, err = s.authRuntimeForProvider(loginState.Provider)
 	if err != nil {
@@ -445,7 +482,7 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		s.clearLoginStateCookie(w)
 	}
 
-	if r.URL.Query().Get("cli") == "1" {
+	if loginState.Mode == loginModeCLI {
 		dbUser, dbErr := s.users.FindOrCreateUser(r.Context(), identity.Email)
 		if dbErr != nil || dbUser == nil || dbUser.ID == "" {
 			auditErr = errors.New("failed to resolve user")
@@ -453,7 +490,7 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		auditSubjectID = principal.UserSubjectID(dbUser.ID)
-		apiToken, plaintext, issueErr := s.issueAPIToken(r.Context(), dbUser.ID, cliLoginTokenName, "", true)
+		apiToken, plaintext, issueErr := s.issueAPIToken(r.Context(), dbUser.ID, cliLoginTokenName, "", false)
 		if issueErr != nil {
 			auditErr = errors.New("failed to issue CLI API token")
 			writeError(w, http.StatusInternalServerError, "failed to issue CLI API token")
@@ -510,6 +547,7 @@ func (s *Server) loginStateForCallback(r *http.Request) (*loginState, error) {
 		return &loginState{
 			State:    r.URL.Query().Get("state"),
 			Provider: "server",
+			Mode:     loginModeBrowser,
 		}, nil
 	}
 	cookie, err := r.Cookie(loginStateCookieName)
@@ -523,7 +561,16 @@ func (s *Server) loginStateForCallback(r *http.Request) (*loginState, error) {
 	if strings.TrimSpace(state.Provider) == "" {
 		state.Provider = "server"
 	}
+	state.Mode = normalizeLoginMode(state.Mode, state.State)
 	return state, nil
+}
+
+func loginCallbackModeMatches(expectedMode, cliQuery string) bool {
+	requestedMode := loginModeBrowser
+	if cliQuery == "1" {
+		requestedMode = loginModeCLI
+	}
+	return normalizeLoginMode(expectedMode, "") == requestedMode
 }
 
 func loginStatesMatch(expectedState, originalState string) bool {

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -79,6 +79,12 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "oauth state encryption is not configured")
 		return
 	}
+	browserNonce, err := newIntegrationOAuthBrowserNonce()
+	if err != nil {
+		auditErr = errors.New("failed to generate oauth nonce")
+		writeError(w, http.StatusInternalServerError, "failed to generate oauth nonce")
+		return
+	}
 
 	subjectID, instance, err := s.resolveCredentialConnectionSetup(w, r, req.Instance)
 	if err != nil {
@@ -121,6 +127,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		Connection:       connection,
 		Instance:         instance,
 		Verifier:         verifier,
+		BrowserNonce:     browserNonce,
 		ConnectionParams: connParams,
 		ExpiresAt:        s.now().Add(integrationOAuthStateTTL).Unix(),
 	})
@@ -134,6 +141,12 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		auditErr = errors.New("failed to prepare oauth URL")
 		writeError(w, http.StatusInternalServerError, "failed to prepare oauth URL")
+		return
+	}
+
+	if err := s.setIntegrationOAuthNonceCookie(w, browserNonce); err != nil {
+		auditErr = errors.New("failed to encode oauth nonce")
+		writeError(w, http.StatusInternalServerError, "failed to encode oauth nonce")
 		return
 	}
 
@@ -212,6 +225,17 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	auditSubjectID = state.SubjectID
 	stateAuthSource = state.AuthSource
 	auditTarget = connectionAuditTarget(state.Integration, state.Connection, state.Instance)
+	if err := s.validateIntegrationOAuthNonceCookie(r, state); err != nil {
+		auditErr = errors.New("oauth callback validation failed")
+		writeCallbackError(
+			http.StatusForbidden,
+			"oauth callback validation failed",
+			"Connection failed",
+			"Gestalt could not validate this connection attempt. Start the connection again from Integrations.",
+		)
+		return
+	}
+	s.clearIntegrationOAuthNonceCookie(w, state.BrowserNonce)
 	handler, ok := s.requireOAuthHandler(w, providerName, state.Connection)
 	if !ok {
 		auditErr = errors.New("oauth is not configured")
@@ -314,4 +338,55 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	auditAllowed = true
 	auditErr = nil
 	http.Redirect(w, r, "/integrations?connected="+url.QueryEscape(providerName), http.StatusSeeOther)
+}
+
+func (s *Server) setIntegrationOAuthNonceCookie(w http.ResponseWriter, nonce string) error {
+	if s.encryptor == nil {
+		return errors.New("oauth nonce encryption is not configured")
+	}
+	expiresAt := s.now().Add(integrationOAuthStateTTL).Unix()
+	encoded, err := encodeIntegrationOAuthNonceCookie(s.encryptor, integrationOAuthNonceCookieState{
+		Nonce:     nonce,
+		ExpiresAt: expiresAt,
+	})
+	if err != nil {
+		return err
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     integrationOAuthNonceCookieName(nonce),
+		Value:    encoded,
+		Path:     "/api/v1/auth",
+		MaxAge:   int(integrationOAuthStateTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
+	return nil
+}
+
+func (s *Server) validateIntegrationOAuthNonceCookie(r *http.Request, state *integrationOAuthState) error {
+	if s.encryptor == nil {
+		return errors.New("oauth nonce encryption is not configured")
+	}
+	if state == nil || state.BrowserNonce == "" {
+		return errors.New("oauth state missing browser nonce")
+	}
+	cookie, err := r.Cookie(integrationOAuthNonceCookieName(state.BrowserNonce))
+	if err != nil {
+		return errors.New("missing oauth nonce cookie")
+	}
+	_, err = decodeIntegrationOAuthNonceCookie(s.encryptor, cookie.Value, state.BrowserNonce, s.now())
+	return err
+}
+
+func (s *Server) clearIntegrationOAuthNonceCookie(w http.ResponseWriter, nonce string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     integrationOAuthNonceCookieName(nonce),
+		Value:    "",
+		Path:     "/api/v1/auth",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
 }

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -158,10 +158,18 @@ func TestConnectionAuthMetrics(t *testing.T) {
 	startOAuth := func(code string) int {
 		t.Helper()
 
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("cookie jar: %v", err)
+		}
+		noRedirect := &http.Client{
+			Jar:           jar,
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		}
 		body := bytes.NewBufferString(`{"integration":"` + providerName + `"}`)
 		startReq, _ := http.NewRequest(http.MethodPost, oauthServer.URL+"/api/v1/auth/start-oauth", body)
 		startReq.Header.Set("Content-Type", "application/json")
-		startResp, err := http.DefaultClient.Do(startReq)
+		startResp, err := noRedirect.Do(startReq)
 		if err != nil {
 			t.Fatalf("start oauth request: %v", err)
 		}
@@ -176,9 +184,6 @@ func TestConnectionAuthMetrics(t *testing.T) {
 			t.Fatalf("decode start oauth response: %v", err)
 		}
 
-		noRedirect := &http.Client{
-			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
-		}
 		req, _ := http.NewRequest(http.MethodGet, oauthServer.URL+"/api/v1/auth/callback?code="+url.QueryEscape(code)+"&state="+url.QueryEscape(startResult["state"]), nil)
 		resp, err := noRedirect.Do(req)
 		if err != nil {

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -269,11 +269,12 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 
 func (s *Server) pluginRouteAuthMiddleware(pluginParam string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
+		protectedNext := s.cookieCSRFMiddleware(next)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			pluginName := strings.TrimSpace(chi.URLParam(r, pluginParam))
 			if pluginName == "" {
 				auth := s.serverAuthRuntime()
-				s.serveAuthenticated(w, r, next, auth.resolver, auth.noAuth, auth.anonymous, auth.providerName)
+				s.serveAuthenticated(w, r, protectedNext, auth.resolver, auth.noAuth, auth.anonymous, auth.providerName)
 				return
 			}
 
@@ -284,7 +285,7 @@ func (s *Server) pluginRouteAuthMiddleware(pluginParam string) func(http.Handler
 				return
 			}
 
-			s.serveAuthenticated(w, r, next, auth.resolver, auth.noAuth, auth.anonymous, auth.providerName)
+			s.serveAuthenticated(w, r, protectedNext, auth.resolver, auth.noAuth, auth.anonymous, auth.providerName)
 		})
 	}
 }

--- a/gestaltd/internal/server/oauth_state.go
+++ b/gestaltd/internal/server/oauth_state.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +16,7 @@ import (
 
 const integrationOAuthStateTTL = 10 * time.Minute
 const pendingConnectionTTL = 30 * time.Minute
+const integrationOAuthNonceCookiePrefix = "oauth_state_"
 
 var errPendingConnectionExpired = errors.New("pending connection expired")
 
@@ -27,6 +30,7 @@ type integrationOAuthState struct {
 	Connection       string            `json:"con,omitempty"`
 	Instance         string            `json:"ins,omitempty"`
 	Verifier         string            `json:"ver,omitempty"`
+	BrowserNonce     string            `json:"bn,omitempty"`
 	ConnectionParams map[string]string `json:"cp,omitempty"`
 	ExpiresAt        int64             `json:"exp"`
 }
@@ -75,6 +79,9 @@ func validateIntegrationOAuthState(state *integrationOAuthState, now time.Time) 
 	if state.Integration == "" {
 		return fmt.Errorf("oauth state missing integration")
 	}
+	if state.BrowserNonce == "" {
+		return fmt.Errorf("oauth state missing browser nonce")
+	}
 	if state.ExpiresAt == 0 {
 		return fmt.Errorf("oauth state missing expiration")
 	}
@@ -101,6 +108,8 @@ func (c *integrationOAuthStateCodec) Decode(encoded string, now time.Time) (*int
 
 const loginStateTTL = 10 * time.Minute
 const loginStateCookieName = "login_state"
+const loginModeBrowser = "browser"
+const loginModeCLI = "cli"
 const mcpOAuthClientRegistrationTTL = 365 * 24 * time.Hour
 const mcpOAuthAuthorizationCodeTTL = 5 * time.Minute
 const mcpOAuthRefreshTokenTTL = 30 * 24 * time.Hour
@@ -115,6 +124,12 @@ type loginState struct {
 	State     string `json:"s"`
 	Provider  string `json:"p,omitempty"`
 	NextPath  string `json:"n,omitempty"`
+	Mode      string `json:"m,omitempty"`
+	ExpiresAt int64  `json:"exp"`
+}
+
+type integrationOAuthNonceCookieState struct {
+	Nonce     string `json:"n"`
 	ExpiresAt int64  `json:"exp"`
 }
 
@@ -166,6 +181,11 @@ func validateLoginState(state *loginState, now time.Time) error {
 	if state.State == "" {
 		return fmt.Errorf("login state missing state value")
 	}
+	switch strings.TrimSpace(state.Mode) {
+	case "", loginModeBrowser, loginModeCLI:
+	default:
+		return fmt.Errorf("login state has invalid mode")
+	}
 	if state.ExpiresAt == 0 {
 		return fmt.Errorf("login state missing expiration")
 	}
@@ -181,6 +201,68 @@ func decodeLoginState(enc *cryptoutil.AESGCMEncryptor, encoded string, now time.
 		return nil, err
 	}
 	if err := validateLoginState(state, now); err != nil {
+		return nil, err
+	}
+	state.Mode = normalizeLoginMode(state.Mode, state.State)
+	return state, nil
+}
+
+func normalizeLoginMode(mode, state string) string {
+	switch strings.TrimSpace(mode) {
+	case loginModeCLI:
+		return loginModeCLI
+	case loginModeBrowser:
+		return loginModeBrowser
+	case "":
+		if _, ok := stripCLIStatePrefix(state); ok {
+			return loginModeCLI
+		}
+	}
+	return loginModeBrowser
+}
+
+func newIntegrationOAuthBrowserNonce() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+}
+
+func integrationOAuthNonceCookieName(nonce string) string {
+	nonce = strings.TrimSpace(nonce)
+	if nonce == "" {
+		return integrationOAuthNonceCookiePrefix
+	}
+	return integrationOAuthNonceCookiePrefix + nonce
+}
+
+func encodeIntegrationOAuthNonceCookie(enc *cryptoutil.AESGCMEncryptor, state integrationOAuthNonceCookieState) (string, error) {
+	return encodeEncryptedState(enc, "oauth nonce cookie", state)
+}
+
+func validateIntegrationOAuthNonceCookieState(state *integrationOAuthNonceCookieState, expectedNonce string, now time.Time) error {
+	if state.Nonce == "" {
+		return fmt.Errorf("oauth nonce cookie missing nonce")
+	}
+	if state.Nonce != expectedNonce {
+		return fmt.Errorf("oauth nonce cookie mismatch")
+	}
+	if state.ExpiresAt == 0 {
+		return fmt.Errorf("oauth nonce cookie missing expiration")
+	}
+	if now.Unix() > state.ExpiresAt {
+		return fmt.Errorf("oauth nonce cookie expired")
+	}
+	return nil
+}
+
+func decodeIntegrationOAuthNonceCookie(enc *cryptoutil.AESGCMEncryptor, encoded, expectedNonce string, now time.Time) (*integrationOAuthNonceCookieState, error) {
+	state, err := decodeEncryptedState[integrationOAuthNonceCookieState](enc, "oauth nonce cookie", encoded)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateIntegrationOAuthNonceCookieState(state, expectedNonce, now); err != nil {
 		return nil, err
 	}
 	return state, nil

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -162,6 +162,7 @@ func (s *Server) mountMCPRoutes(r chi.Router) {
 	r.Post(mcpTokenEndpointPath, s.mcpOAuthToken)
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMiddleware)
+		r.Use(s.cookieCSRFMiddleware)
 		r.Handle(mcpPath, s.mcpHandler)
 	})
 }

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -12,6 +12,7 @@ import (
 func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMiddleware)
+		r.Use(s.cookieCSRFMiddleware)
 
 		pluginshttp.MountAuthenticated(r, pluginshttp.AuthenticatedHandlers{
 			ListIntegrations:      s.listIntegrations,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -3750,7 +3750,10 @@ func TestBuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow(t *testing
 		t.Fatalf("initial admin redirect = %q, want %q", got, want)
 	}
 
-	loginStartResp, err := client.Get(loginStartURL)
+	loginStartReq, _ := http.NewRequest(http.MethodGet, loginStartURL, nil)
+	loginStartReq.Header.Set("Sec-Fetch-Site", "same-site")
+	loginStartReq.Header.Set("Referer", managementURL+"/admin/?tab=members")
+	loginStartResp, err := client.Do(loginStartReq)
 	if err != nil {
 		t.Fatalf("GET browser login start: %v", err)
 	}
@@ -5362,7 +5365,11 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 	if oauthStart.State == "" || !strings.Contains(oauthStart.URL, url.QueryEscape(oauthStart.State)) {
 		t.Fatalf("oauth start response = %+v", oauthStart)
 	}
+	oauthNonceCookies := resp.Cookies()
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(oauthStart.State), nil)
+	for _, cookie := range oauthNonceCookies {
+		req.AddCookie(cookie)
+	}
 	resp, err = noRedirect.Do(req)
 	if err != nil {
 		t.Fatalf("managed subject oauth callback: %v", err)
@@ -14563,6 +14570,53 @@ func TestStartLoginWithInvalidCallbackPort(t *testing.T) {
 	}
 }
 
+func TestStartLoginRejectsUnsafeInitiation(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubAuthWithLoginURL{
+			StubAuthProvider: coretesting.StubAuthProvider{N: "test"},
+			loginURL:         "https://auth.example.com/login",
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/login", strings.NewReader(`{"state":"abc"}`))
+	req.Header.Set("Content-Type", "text/plain")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request with text/plain: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnsupportedMediaType {
+		t.Fatalf("text/plain status = %d, want %d", resp.StatusCode, http.StatusUnsupportedMediaType)
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/login", strings.NewReader(`{"state":"abc"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "https://evil.example")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request with cross-origin header: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-origin status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/login?next="+url.QueryEscape("/"), nil)
+	req.Header.Set("Sec-Fetch-Site", "same-site")
+	req.Header.Set("Referer", "https://evil.example/start")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request with same-site evil referer: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("same-site evil referer status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
 func TestStartLogin_NoAuthInvalidJSON(t *testing.T) {
 	t.Parallel()
 
@@ -14821,10 +14875,12 @@ func TestLoginCallback_MissingPluginRouteAuthProviderAuditsAttemptedProvider(t *
 func TestLoginCallbackForCLI(t *testing.T) {
 	t.Parallel()
 
+	fixedNow := time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC)
 	svc := coretesting.NewStubServices(t)
 	u := seedUser(t, svc, "user@example.com")
 	var auditBuf bytes.Buffer
 	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Now = func() time.Time { return fixedNow }
 		cfg.Auth = &coretesting.StubAuthProvider{
 			N: "test",
 			HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
@@ -14842,7 +14898,7 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	jar, _ := cookiejar.New(nil)
 	client := &http.Client{Jar: jar}
 
-	body := bytes.NewBufferString(`{"state":"test-state"}`)
+	body := bytes.NewBufferString(`{"state":"test-state","callbackPort":54305}`)
 	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
 	if err != nil {
 		t.Fatalf("start login: %v", err)
@@ -14872,6 +14928,17 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	if result["name"] != "cli-token" {
 		t.Fatalf("expected cli-token name in CLI login response, got %v", result["name"])
 	}
+	expiresAtStr, ok := result["expiresAt"].(string)
+	if !ok {
+		t.Fatal("expected CLI token response to include expiresAt")
+	}
+	expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
+	if err != nil {
+		t.Fatalf("parse expiresAt: %v", err)
+	}
+	if expected := fixedNow.Add(30 * 24 * time.Hour).UTC().Truncate(time.Second); !expiresAt.Equal(expected) {
+		t.Fatalf("expected CLI token expiry %v, got %v", expected, expiresAt)
+	}
 
 	tokens, err := svc.APITokens.ListAPITokens(context.Background(), u.ID)
 	if err != nil {
@@ -14882,6 +14949,9 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	}
 	if tokens[0].Name != "cli-token" {
 		t.Fatalf("expected cli token name, got %q", tokens[0].Name)
+	}
+	if tokens[0].ExpiresAt == nil {
+		t.Fatal("expected stored CLI token to expire")
 	}
 
 	for _, cookie := range resp.Cookies() {
@@ -14930,6 +15000,51 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	}
 	if _, ok := loginAudit["user_id"]; ok {
 		t.Fatalf("expected emitted login audit record to omit user_id, got %v", loginAudit["user_id"])
+	}
+}
+
+func TestLoginCallbackRejectsBrowserToCLIModeSwitch(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
+				if code == "good-code" {
+					return &core.UserIdentity{Email: "user@example.com", DisplayName: "User"}, nil
+				}
+				return nil, fmt.Errorf("bad code")
+			},
+		}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	body := bytes.NewBufferString(`{"state":"test-state"}`)
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+
+	resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state&cli=1")
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+	tokens, err := svc.APITokens.ListAPITokens(context.Background(), "")
+	if err != nil {
+		t.Fatalf("list api tokens: %v", err)
+	}
+	if len(tokens) != 0 {
+		t.Fatalf("expected no API tokens to be issued, got %d", len(tokens))
 	}
 }
 
@@ -15303,6 +15418,62 @@ func TestStartIntegrationOAuth_ServiceAccountDeniedByPolicy(t *testing.T) {
 	}
 }
 
+func TestIntegrationOAuthCallbackRequiresNonceCookie(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubIntegrationWithAuthURL{
+		StubIntegration: coretesting.StubIntegration{N: "slack"},
+		authURL:         "https://slack.com/oauth/v2/authorize",
+	}
+	handler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+		exchangeCodeFn: func(context.Context, string) (*core.TokenResponse, error) {
+			t.Fatal("token exchange should not run without the oauth nonce cookie")
+			return nil, nil
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"slack"}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+	if startResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(startResp.Body)
+		t.Fatalf("start status = %d, want 200: %s", startResp.StatusCode, body)
+	}
+	var startResult map[string]string
+	if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("callback status = %d, want 403: %s", resp.StatusCode, body)
+	}
+}
+
 func TestIntegrationOAuthCallback(t *testing.T) {
 	t.Parallel()
 
@@ -15377,11 +15548,21 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("cookie jar: %v", err)
+		}
+		noRedirect := &http.Client{
+			Jar: jar,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
 		startBody := bytes.NewBufferString(`{"integration":"slack"}`)
 		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
 		startReq.Header.Set("Content-Type", "application/json")
 		startReq.Header.Set("Authorization", "Bearer session-token")
-		startResp, err := http.DefaultClient.Do(startReq)
+		startResp, err := noRedirect.Do(startReq)
 		if err != nil {
 			t.Fatalf("start request: %v", err)
 		}
@@ -15396,11 +15577,6 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			t.Fatalf("decoding start response: %v", err)
 		}
 
-		noRedirect := &http.Client{
-			CheckRedirect: func(*http.Request, []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
 		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
 		resp, err := noRedirect.Do(req)
 		if err != nil {
@@ -15584,21 +15760,6 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		startBody := bytes.NewBufferString(`{"integration":"slack"}`)
-		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
-		startReq.Header.Set("Content-Type", "application/json")
-		startReq.Header.Set("Authorization", "Bearer cli-api-token")
-		startResp, err := http.DefaultClient.Do(startReq)
-		if err != nil {
-			t.Fatalf("start request: %v", err)
-		}
-		defer func() { _ = startResp.Body.Close() }()
-
-		var startResult map[string]string
-		if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
-			t.Fatalf("decoding start response: %v", err)
-		}
-
 		jar, err := cookiejar.New(nil)
 		if err != nil {
 			t.Fatalf("cookie jar: %v", err)
@@ -15609,6 +15770,21 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 				return http.ErrUseLastResponse
 			},
 		}
+		startBody := bytes.NewBufferString(`{"integration":"slack"}`)
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+		startReq.Header.Set("Content-Type", "application/json")
+		startReq.Header.Set("Authorization", "Bearer cli-api-token")
+		startResp, err := noRedirect.Do(startReq)
+		if err != nil {
+			t.Fatalf("start request: %v", err)
+		}
+		defer func() { _ = startResp.Body.Close() }()
+
+		var startResult map[string]string
+		if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+			t.Fatalf("decoding start response: %v", err)
+		}
+
 		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
 		resp, err := noRedirect.Do(req)
 		if err != nil {
@@ -15794,11 +15970,21 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 
 		runConnect := func(session string) *http.Response {
 			t.Helper()
+			jar, err := cookiejar.New(nil)
+			if err != nil {
+				t.Fatalf("cookie jar: %v", err)
+			}
+			noRedirect := &http.Client{
+				Jar: jar,
+				CheckRedirect: func(*http.Request, []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			}
 			startBody := bytes.NewBufferString(`{"integration":"slack"}`)
 			startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
 			startReq.Header.Set("Content-Type", "application/json")
 			startReq.Header.Set("Authorization", "Bearer "+session)
-			startResp, err := http.DefaultClient.Do(startReq)
+			startResp, err := noRedirect.Do(startReq)
 			if err != nil {
 				t.Fatalf("start request: %v", err)
 			}
@@ -15810,11 +15996,6 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			var startResult map[string]string
 			if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
 				t.Fatalf("decoding start response: %v", err)
-			}
-			noRedirect := &http.Client{
-				CheckRedirect: func(*http.Request, []*http.Request) error {
-					return http.ErrUseLastResponse
-				},
 			}
 			req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
 			resp, err := noRedirect.Do(req)
@@ -15966,6 +16147,88 @@ func TestCreateAndListAPITokens(t *testing.T) {
 	}
 	if result["name"] != "my-token" {
 		t.Fatalf("expected name my-token, got %q", result["name"])
+	}
+}
+
+func TestCookieAuthenticatedMutationCSRFGate(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	apiToken, apiTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	seedAPIToken(t, svc, apiToken, apiTokenHash, "api-user")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "cookie-user@test.local"}, nil
+			},
+		}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"blocked-token"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "https://evil.example")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("cross-origin cookie request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-origin cookie status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	body = bytes.NewBufferString(`{"name":"blocked-token-with-header"}`)
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "https://evil.example")
+	req.Header.Set("Authorization", "Bearer not-a-real-token")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("cross-origin cookie request with authorization header: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-origin cookie plus authorization status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	body = bytes.NewBufferString(`{"name":"same-origin-token"}`)
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", ts.URL)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("same-origin cookie request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("same-origin cookie status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	body = bytes.NewBufferString(`{"name":"bearer-token"}`)
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "https://evil.example")
+	req.Header.Set("Authorization", "Bearer "+apiToken)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("bearer request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("bearer status = %d, want %d", resp.StatusCode, http.StatusCreated)
 	}
 }
 
@@ -18119,10 +18382,20 @@ func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	noRedirect := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	startBody := bytes.NewBufferString(`{"integration":"gitlab"}`)
 	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
 	startReq.Header.Set("Content-Type", "application/json")
-	startResp, err := http.DefaultClient.Do(startReq)
+	startResp, err := noRedirect.Do(startReq)
 	if err != nil {
 		t.Fatalf("start request: %v", err)
 	}
@@ -18137,11 +18410,6 @@ func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 		t.Fatalf("decoding start response: %v", err)
 	}
 
-	noRedirect := &http.Client{
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
 	resp, err := noRedirect.Do(req)
 	if err != nil {
@@ -20250,11 +20518,21 @@ func TestOAuthCallback_UsesStateConnection(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	noRedirect := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	startBody := bytes.NewBufferString(`{"integration":"multi","connection":"conn-b"}`)
 	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
 	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
 	startReq.Header.Set("Content-Type", "application/json")
-	startResp, err := http.DefaultClient.Do(startReq)
+	startResp, err := noRedirect.Do(startReq)
 	if err != nil {
 		t.Fatalf("start request: %v", err)
 	}
@@ -20267,11 +20545,6 @@ func TestOAuthCallback_UsesStateConnection(t *testing.T) {
 		t.Fatalf("decoding start response: %v", err)
 	}
 
-	noRedirect := &http.Client{
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=ok&state="+url.QueryEscape(startResult["state"]), nil)
 	resp, err := noRedirect.Do(req)
 	if err != nil {
@@ -20619,6 +20892,49 @@ func TestMCPEndpoint_RequiresAuth(t *testing.T) {
 	wantAuth := `Bearer resource_metadata="` + ts.URL + `/.well-known/oauth-protected-resource/mcp"`
 	if got := resp.Header.Get("WWW-Authenticate"); got != wantAuth {
 		t.Fatalf("WWW-Authenticate = %q, want %q", got, wantAuth)
+	}
+}
+
+func TestMCPEndpointRejectsCookieAuthenticatedCrossOriginPost(t *testing.T) {
+	t.Parallel()
+
+	providers := func() *registry.ProviderMap[core.Provider] {
+		reg := registry.New()
+		return &reg.Providers
+	}()
+	svc := coretesting.NewStubServices(t)
+	mcpHandler := newMCPHandler(t, providers, svc, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "mcp-user@example.com"}, nil
+			},
+		}
+		cfg.MCPHandler = mcpHandler
+		cfg.Services = svc
+	})
+	defer ts.Close()
+
+	status, _, _ := mcpJSONRPCWithHeaders(t, ts, map[string]string{
+		"Cookie": "session_token=session-token",
+		"Origin": "https://evil.example",
+	}, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	})
+	if status != http.StatusForbidden {
+		t.Fatalf("cross-origin cookie-authenticated /mcp status = %d, want %d", status, http.StatusForbidden)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add cookie-auth CSRF checks for state-changing authenticated user routes and plugin operation routes.
- Harden login initiation with same-origin/content-type checks, bind browser-vs-CLI mode into login state, and stop issuing non-expiring CLI login tokens.
- Bind integration OAuth callbacks to a browser nonce cookie so attacker-originated state cannot pre-hijack a victim callback.

## Verification
- `go test ./internal/server`
- `git diff --check`

## Notes
- Requests without browser origin/fetch metadata continue to work to avoid breaking non-browser API clients.
- In-flight integration OAuth states minted before this change will not have a nonce and must be restarted.