### PR TITLE
Move invocation config primitives into services

### DIFF
--- a/gestaltd/core/connection.go
+++ b/gestaltd/core/connection.go
@@ -1,8 +1,42 @@
 package core
 
-import "context"
+import (
+	"context"
+	"regexp"
+)
 
 type connectionParamsKey struct{}
+
+// PluginConnectionName is the implicit connection name used when storing
+// tokens for plugin-only integrations that do not declare YAML connections.
+const PluginConnectionName = "_plugin"
+
+// PluginConnectionAlias is the user-facing alias that maps to
+// PluginConnectionName. In hybrid integrations, mcp.connection can be set
+// to "plugin" to reuse the plugin's OAuth token.
+const PluginConnectionAlias = "plugin"
+
+var (
+	safeConnectionValue = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	safeInstanceValue   = regexp.MustCompile(`^[a-zA-Z0-9._ -]+$`)
+)
+
+// ResolveConnectionAlias maps the user-facing "plugin" alias to the internal
+// PluginConnectionName. All other names pass through unchanged.
+func ResolveConnectionAlias(name string) string {
+	if name == PluginConnectionAlias {
+		return PluginConnectionName
+	}
+	return name
+}
+
+func SafeConnectionValue(value string) bool {
+	return safeConnectionValue.MatchString(value)
+}
+
+func SafeInstanceValue(value string) bool {
+	return safeInstanceValue.MatchString(value)
+}
 
 func WithConnectionParams(ctx context.Context, params map[string]string) context.Context {
 	return context.WithValue(ctx, connectionParamsKey{}, params)

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1183,16 +1183,32 @@ func buildAgents(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	return extraAgents, nil
 }
 
-func agentPluginInvokes(cfg *config.Config) map[string][]config.PluginInvocationDependency {
+func agentPluginInvokes(cfg *config.Config) map[string][]invocation.PluginInvocationDependency {
 	if cfg == nil || len(cfg.Plugins) == 0 {
 		return nil
 	}
-	out := make(map[string][]config.PluginInvocationDependency, len(cfg.Plugins))
+	out := make(map[string][]invocation.PluginInvocationDependency, len(cfg.Plugins))
 	for pluginName, entry := range cfg.Plugins {
 		if entry == nil || len(entry.Invokes) == 0 {
 			continue
 		}
-		out[pluginName] = append([]config.PluginInvocationDependency(nil), entry.Invokes...)
+		out[pluginName] = pluginInvocationDependencies(entry.Invokes)
+	}
+	return out
+}
+
+func pluginInvocationDependencies(deps []config.PluginInvocationDependency) []invocation.PluginInvocationDependency {
+	if len(deps) == 0 {
+		return nil
+	}
+	out := make([]invocation.PluginInvocationDependency, 0, len(deps))
+	for _, dep := range deps {
+		out = append(out, invocation.PluginInvocationDependency{
+			Plugin:         dep.Plugin,
+			Operation:      dep.Operation,
+			Surface:        dep.Surface,
+			CredentialMode: core.ConnectionMode(dep.CredentialMode),
+		})
 	}
 	return out
 }

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -3889,7 +3889,7 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 		Agent:      agentRuntime,
 		ToolGrants: toolGrants,
 		Invoker:    broker,
-		PluginInvokes: map[string][]config.PluginInvocationDependency{
+		PluginInvokes: map[string][]invocation.PluginInvocationDependency{
 			"echoext": {{
 				Plugin:    "roadmap",
 				Operation: "sync",
@@ -6891,7 +6891,7 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 		secret,
 		publicHostServices,
 		withRuntimeRelayCoreHostService("plugin_invoker", plugininvokerservice.DefaultSocketEnv, "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
-			proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("caller", callerInvokes, bridge, pluginInvokerTokens))
+			proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("caller", pluginInvocationDependencies(callerInvokes), bridge, pluginInvokerTokens))
 		}),
 	))
 	relaySrv.EnableHTTP2 = true

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -977,7 +977,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	if invTokens != nil {
 		opts = append(opts,
 			pluginservice.WithInvocationTokens(invTokens),
-			pluginservice.WithInvocationTokenSubject(name, plugininvokerservice.InvocationDependencyGrants(entry.Invokes)),
+			pluginservice.WithInvocationTokenSubject(name, plugininvokerservice.InvocationDependencyGrants(pluginInvocationDependencies(entry.Invokes))),
 		)
 	}
 	prov, err := pluginservice.NewRemote(ctx, conn.Integration(), spec, pluginConfig, opts...)
@@ -2234,7 +2234,7 @@ func buildPluginInvokerHostService(pluginName string, entry *config.ProviderEntr
 		Name:   "plugin_invoker",
 		EnvVar: plugininvokerservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer(pluginName, entry.Invokes, invoker, tokens))
+			proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer(pluginName, pluginInvocationDependencies(entry.Invokes), invoker, tokens))
 		},
 	}
 }

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -42,14 +42,8 @@ const (
 	DefaultProviderInstance            = "default"
 )
 
-// PluginConnectionName is the implicit connection name used when storing
-// tokens for plugin-only integrations that do not declare YAML connections.
-const PluginConnectionName = "_plugin"
-
-// PluginConnectionAlias is the user-facing alias that maps to
-// PluginConnectionName. In hybrid integrations, mcp.connection can be set
-// to "plugin" to reuse the plugin's OAuth token.
-const PluginConnectionAlias = "plugin"
+const PluginConnectionName = core.PluginConnectionName
+const PluginConnectionAlias = core.PluginConnectionAlias
 const ConfigAPIVersion = "gestaltd.config/v4"
 
 type Config struct {
@@ -1518,10 +1512,7 @@ type ConnectionParamDef = providermanifestv1.ProviderConnectionParam
 // ResolveConnectionAlias maps the user-facing "plugin" alias to the
 // internal PluginConnectionName. All other names pass through unchanged.
 func ResolveConnectionAlias(name string) string {
-	if name == PluginConnectionAlias {
-		return PluginConnectionName
-	}
-	return name
+	return core.ResolveConnectionAlias(name)
 }
 
 func MergeConnectionAuth(dst *ConnectionAuthDef, src ConnectionAuthDef) {

--- a/gestaltd/internal/config/selector_values.go
+++ b/gestaltd/internal/config/selector_values.go
@@ -1,16 +1,11 @@
 package config
 
-import "regexp"
-
-var (
-	safeConnectionValue = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
-	safeInstanceValue   = regexp.MustCompile(`^[a-zA-Z0-9._ -]+$`)
-)
+import "github.com/valon-technologies/gestalt/server/core"
 
 func SafeConnectionValue(value string) bool {
-	return safeConnectionValue.MatchString(value)
+	return core.SafeConnectionValue(value)
 }
 
 func SafeInstanceValue(value string) bool {
-	return safeInstanceValue.MatchString(value)
+	return core.SafeInstanceValue(value)
 }

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -246,7 +246,7 @@ func (s *Server) newCoreRoutableHostServiceHandlerEntry(ctx context.Context, plu
 		slog.DebugContext(ctx, "serving core-routable host service relay", "plugin", pluginName, "service", target.Service)
 		return hostServiceHandlerEntry{
 			handler: newGRPCHostServiceHandler(func(srv *grpc.Server) {
-				proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewPluginInvokerServer(pluginName, entry.Invokes, s.pluginInvoker, s.invocationTokens))
+				proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewPluginInvokerServer(pluginName, pluginInvocationDependencies(entry.Invokes), s.pluginInvoker, s.invocationTokens))
 			}),
 		}, true
 	default:

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -422,19 +422,35 @@ func hasAnonymousAuthProvider(providers map[string]core.AuthenticationProvider) 
 	return false
 }
 
-func pluginInvokesFromProviderEntries(entries map[string]*config.ProviderEntry) map[string][]config.PluginInvocationDependency {
+func pluginInvokesFromProviderEntries(entries map[string]*config.ProviderEntry) map[string][]invocation.PluginInvocationDependency {
 	if len(entries) == 0 {
 		return nil
 	}
-	out := make(map[string][]config.PluginInvocationDependency, len(entries))
+	out := make(map[string][]invocation.PluginInvocationDependency, len(entries))
 	for pluginName, entry := range entries {
 		if entry == nil || len(entry.Invokes) == 0 {
 			continue
 		}
-		out[pluginName] = append([]config.PluginInvocationDependency(nil), entry.Invokes...)
+		out[pluginName] = pluginInvocationDependencies(entry.Invokes)
 	}
 	if len(out) == 0 {
 		return nil
+	}
+	return out
+}
+
+func pluginInvocationDependencies(deps []config.PluginInvocationDependency) []invocation.PluginInvocationDependency {
+	if len(deps) == 0 {
+		return nil
+	}
+	out := make([]invocation.PluginInvocationDependency, 0, len(deps))
+	for _, dep := range deps {
+		out = append(out, invocation.PluginInvocationDependency{
+			Plugin:         dep.Plugin,
+			Operation:      dep.Operation,
+			Surface:        dep.Surface,
+			CredentialMode: core.ConnectionMode(dep.CredentialMode),
+		})
 	}
 	return out
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -82,6 +82,22 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+func configPluginInvocationDependencies(deps []invocation.PluginInvocationDependency) []config.PluginInvocationDependency {
+	if len(deps) == 0 {
+		return nil
+	}
+	out := make([]config.PluginInvocationDependency, 0, len(deps))
+	for _, dep := range deps {
+		out = append(out, config.PluginInvocationDependency{
+			Plugin:         dep.Plugin,
+			Operation:      dep.Operation,
+			Surface:        dep.Surface,
+			CredentialMode: providermanifestv1.ConnectionMode(dep.CredentialMode),
+		})
+	}
+	return out
+}
+
 func newTestServer(t *testing.T, opts ...func(*server.Config)) *httptest.Server {
 	t.Helper()
 	return newTestHTTPServer(t, httptest.NewServer, opts...)
@@ -904,10 +920,10 @@ func TestHostServiceRelayCoreRoutablePluginInvokerIgnoresRegistry(t *testing.T) 
 	pluginInvoker := &relayTestInvoker{}
 	registryInvoker := &relayTestInvoker{}
 	runtimeSessions := newRelayTestRuntimeSessionVerifier("support", "session-core")
-	invokes := []config.PluginInvocationDependency{{
+	invokes := []invocation.PluginInvocationDependency{{
 		Plugin:         "slack",
 		Operation:      "events.reply",
-		CredentialMode: providermanifestv1.ConnectionModeNone,
+		CredentialMode: core.ConnectionModeNone,
 	}}
 	registryTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
 	if err != nil {
@@ -929,7 +945,7 @@ func TestHostServiceRelayCoreRoutablePluginInvokerIgnoresRegistry(t *testing.T) 
 		cfg.PluginRuntimes = runtimeSessions
 		cfg.PublicHostServices = publicHostServices
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"support": {Invokes: invokes},
+			"support": {Invokes: configPluginInvocationDependencies(invokes)},
 		}
 	}))
 	ts.EnableHTTP2 = true
@@ -1030,17 +1046,17 @@ func TestHostServiceRelayRejectsCoreRoutableWithoutRuntimeVerifier(t *testing.T)
 
 	secret := []byte("relay-test-secret-0123456789abcd")
 	pluginInvoker := &relayTestInvoker{}
-	invokes := []config.PluginInvocationDependency{{
+	invokes := []invocation.PluginInvocationDependency{{
 		Plugin:         "slack",
 		Operation:      "events.reply",
-		CredentialMode: providermanifestv1.ConnectionModeNone,
+		CredentialMode: core.ConnectionModeNone,
 	}}
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfilePublic
 		cfg.StateSecret = secret
 		cfg.PluginInvoker = pluginInvoker
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"support": {Invokes: invokes},
+			"support": {Invokes: configPluginInvocationDependencies(invokes)},
 		}
 	}))
 	ts.EnableHTTP2 = true
@@ -1101,10 +1117,10 @@ func TestHostServiceRelayServesRegisteredCoreServiceWithoutCoreRoutableToken(t *
 
 	secret := []byte("relay-test-secret-0123456789abcd")
 	invoker := &relayTestInvoker{}
-	invokes := []config.PluginInvocationDependency{{
+	invokes := []invocation.PluginInvocationDependency{{
 		Plugin:         "slack",
 		Operation:      "events.reply",
-		CredentialMode: providermanifestv1.ConnectionModeNone,
+		CredentialMode: core.ConnectionModeNone,
 	}}
 	invocationTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
 	if err != nil {
@@ -1183,10 +1199,10 @@ func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *tes
 	workflowProvider := newRelayTestWorkflowProvider()
 	agentProvider := newMemoryAgentProvider()
 	runtimeSessions := newRelayTestRuntimeSessionVerifier("github", "session-workflow")
-	invokes := []config.PluginInvocationDependency{{
+	invokes := []invocation.PluginInvocationDependency{{
 		Plugin:         "github",
 		Operation:      "bot.commentFinal",
-		CredentialMode: providermanifestv1.ConnectionModeNone,
+		CredentialMode: core.ConnectionModeNone,
 	}}
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		providers := registry.New()
@@ -1217,7 +1233,7 @@ func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *tes
 		}
 		cfg.AgentManager = agentmanager.New(agentmanager.Config{Agent: cfg.Agent})
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"github": {Invokes: invokes},
+			"github": {Invokes: configPluginInvocationDependencies(invokes)},
 		}
 	}))
 	ts.EnableHTTP2 = true
@@ -1392,17 +1408,17 @@ func TestHostServiceRelayDoesNotFallbackWithoutCoreRoutableToken(t *testing.T) {
 
 	secret := []byte("relay-test-secret-0123456789abcd")
 	invoker := &relayTestInvoker{}
-	invokes := []config.PluginInvocationDependency{{
+	invokes := []invocation.PluginInvocationDependency{{
 		Plugin:         "slack",
 		Operation:      "events.reply",
-		CredentialMode: providermanifestv1.ConnectionModeNone,
+		CredentialMode: core.ConnectionModeNone,
 	}}
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfilePublic
 		cfg.StateSecret = secret
 		cfg.Invoker = invoker
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"support": {Invokes: invokes},
+			"support": {Invokes: configPluginInvocationDependencies(invokes)},
 		}
 	}))
 	ts.EnableHTTP2 = true
@@ -1444,17 +1460,17 @@ func TestHostServiceRelayRejectsCoreRoutableWithWrongCoreMethodPrefix(t *testing
 
 	secret := []byte("relay-test-secret-0123456789abcd")
 	invoker := &relayTestInvoker{}
-	invokes := []config.PluginInvocationDependency{{
+	invokes := []invocation.PluginInvocationDependency{{
 		Plugin:         "slack",
 		Operation:      "events.reply",
-		CredentialMode: providermanifestv1.ConnectionModeNone,
+		CredentialMode: core.ConnectionModeNone,
 	}}
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfilePublic
 		cfg.StateSecret = secret
 		cfg.Invoker = invoker
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"support": {Invokes: invokes},
+			"support": {Invokes: configPluginInvocationDependencies(invokes)},
 		}
 	}))
 	ts.EnableHTTP2 = true

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -17,7 +17,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentgrant"
 	"github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
@@ -119,7 +118,7 @@ type Config struct {
 	Authorizer        authorization.RuntimeAuthorizer
 	DefaultConnection map[string]string
 	CatalogConnection map[string]string
-	PluginInvokes     map[string][]config.PluginInvocationDependency
+	PluginInvokes     map[string][]invocation.PluginInvocationDependency
 }
 
 type Manager struct {
@@ -131,7 +130,7 @@ type Manager struct {
 	authorizer        authorization.RuntimeAuthorizer
 	defaultConnection map[string]string
 	catalogConnection map[string]string
-	pluginInvokes     map[string][]config.PluginInvocationDependency
+	pluginInvokes     map[string][]invocation.PluginInvocationDependency
 	// Route caches are process-local accelerators; providers remain the durable source of truth.
 	routeMu       sync.Mutex
 	sessionRoutes agentRouteCache
@@ -139,10 +138,6 @@ type Manager struct {
 }
 
 func New(cfg Config) *Manager {
-	pluginInvokes := make(map[string][]config.PluginInvocationDependency, len(cfg.PluginInvokes))
-	for pluginName, deps := range cfg.PluginInvokes {
-		pluginInvokes[pluginName] = append([]config.PluginInvocationDependency(nil), deps...)
-	}
 	return &Manager{
 		providers:         cfg.Providers,
 		agent:             cfg.Agent,
@@ -152,7 +147,7 @@ func New(cfg Config) *Manager {
 		authorizer:        cfg.Authorizer,
 		defaultConnection: maps.Clone(cfg.DefaultConnection),
 		catalogConnection: maps.Clone(cfg.CatalogConnection),
-		pluginInvokes:     pluginInvokes,
+		pluginInvokes:     invocation.ClonePluginInvocationDependencyMap(cfg.PluginInvokes),
 		sessionRoutes:     newAgentRouteCache(),
 		turnRoutes:        newAgentRouteCache(),
 	}
@@ -1524,12 +1519,12 @@ func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref c
 	}
 
 	connection := strings.TrimSpace(ref.Connection)
-	if connection != "" && !config.SafeConnectionValue(connection) {
+	if connection != "" && !core.SafeConnectionValue(connection) {
 		return coreagent.Tool{}, fmt.Errorf("connection name contains invalid characters")
 	}
-	connection = config.ResolveConnectionAlias(connection)
+	connection = core.ResolveConnectionAlias(connection)
 	instance := strings.TrimSpace(ref.Instance)
-	if instance != "" && !config.SafeInstanceValue(instance) {
+	if instance != "" && !core.SafeInstanceValue(instance) {
 		return coreagent.Tool{}, fmt.Errorf("instance name contains invalid characters")
 	}
 	credentialMode, err := normalizeAgentToolCredentialMode(ref.CredentialMode)
@@ -1640,7 +1635,7 @@ func agentToolTargetKeyFromRef(ref coreagent.ToolRef) agentToolTargetKey {
 		system:         strings.TrimSpace(ref.System),
 		plugin:         strings.TrimSpace(ref.Plugin),
 		operation:      strings.TrimSpace(ref.Operation),
-		connection:     config.ResolveConnectionAlias(strings.TrimSpace(ref.Connection)),
+		connection:     core.ResolveConnectionAlias(strings.TrimSpace(ref.Connection)),
 		instance:       strings.TrimSpace(ref.Instance),
 		credentialMode: ref.CredentialMode,
 	}
@@ -1651,7 +1646,7 @@ func agentToolTargetKeyFromTarget(target coreagent.ToolTarget) agentToolTargetKe
 		system:         strings.TrimSpace(target.System),
 		plugin:         strings.TrimSpace(target.Plugin),
 		operation:      strings.TrimSpace(target.Operation),
-		connection:     config.ResolveConnectionAlias(strings.TrimSpace(target.Connection)),
+		connection:     core.ResolveConnectionAlias(strings.TrimSpace(target.Connection)),
 		instance:       strings.TrimSpace(target.Instance),
 		credentialMode: target.CredentialMode,
 	}
@@ -1812,7 +1807,7 @@ func (m *Manager) searchToolCandidatesForLoadRefs(ctx context.Context, p *princi
 func configuredExactAgentLoadRef(loadRef coreagent.ToolRef, refs []coreagent.ToolRef) (coreagent.ToolRef, bool) {
 	loadPlugin := strings.TrimSpace(loadRef.Plugin)
 	loadOperation := strings.TrimSpace(loadRef.Operation)
-	loadConnection := config.ResolveConnectionAlias(strings.TrimSpace(loadRef.Connection))
+	loadConnection := core.ResolveConnectionAlias(strings.TrimSpace(loadRef.Connection))
 	loadInstance := strings.TrimSpace(loadRef.Instance)
 	exactRefs := exactAgentToolRefs(refs)
 	for i := range exactRefs {
@@ -1820,7 +1815,7 @@ func configuredExactAgentLoadRef(loadRef coreagent.ToolRef, refs []coreagent.Too
 		if strings.TrimSpace(ref.Plugin) != loadPlugin || strings.TrimSpace(ref.Operation) != loadOperation {
 			continue
 		}
-		if loadConnection != "" && config.ResolveConnectionAlias(strings.TrimSpace(ref.Connection)) != loadConnection {
+		if loadConnection != "" && core.ResolveConnectionAlias(strings.TrimSpace(ref.Connection)) != loadConnection {
 			continue
 		}
 		if loadInstance != "" && strings.TrimSpace(ref.Instance) != loadInstance {
@@ -1852,11 +1847,11 @@ func agentToolSearchRefSkipsUnavailable(ref coreagent.ToolRef) bool {
 
 func (m *Manager) catalogsForAgentToolSearch(ctx context.Context, p *principal.Principal, prov core.Provider, pluginName string, ref coreagent.ToolRef) ([]agentToolSearchCatalog, error) {
 	connection := strings.TrimSpace(ref.Connection)
-	if connection != "" && !config.SafeConnectionValue(connection) {
+	if connection != "" && !core.SafeConnectionValue(connection) {
 		return nil, fmt.Errorf("connection name contains invalid characters")
 	}
 	instance := strings.TrimSpace(ref.Instance)
-	if instance != "" && !config.SafeInstanceValue(instance) {
+	if instance != "" && !core.SafeInstanceValue(instance) {
 		return nil, fmt.Errorf("instance name contains invalid characters")
 	}
 	credentialMode, err := normalizeAgentToolCredentialMode(ref.CredentialMode)
@@ -1920,10 +1915,10 @@ func (m *Manager) catalogsForAgentToolSearch(ctx context.Context, p *principal.P
 	for _, target := range targets {
 		target.Connection = strings.TrimSpace(target.Connection)
 		target.Instance = strings.TrimSpace(target.Instance)
-		if target.Connection != "" && !config.SafeConnectionValue(target.Connection) {
+		if target.Connection != "" && !core.SafeConnectionValue(target.Connection) {
 			return nil, fmt.Errorf("connection name contains invalid characters")
 		}
-		if target.Instance != "" && !config.SafeInstanceValue(target.Instance) {
+		if target.Instance != "" && !core.SafeInstanceValue(target.Instance) {
 			return nil, fmt.Errorf("instance name contains invalid characters")
 		}
 		cat, _, err := invocation.ResolveCatalogForTargetsWithMetadata(
@@ -2085,11 +2080,11 @@ func (m *Manager) authorizeToolRefs(ctx context.Context, p *principal.Principal,
 			return fmt.Errorf("%w: %s", invocation.ErrAuthorizationDenied, pluginName)
 		}
 		connection := strings.TrimSpace(ref.Connection)
-		if connection != "" && !config.SafeConnectionValue(connection) {
+		if connection != "" && !core.SafeConnectionValue(connection) {
 			return fmt.Errorf("connection name contains invalid characters")
 		}
 		instance := strings.TrimSpace(ref.Instance)
-		if instance != "" && !config.SafeInstanceValue(instance) {
+		if instance != "" && !core.SafeInstanceValue(instance) {
 			return fmt.Errorf("instance name contains invalid characters")
 		}
 	}
@@ -2627,7 +2622,7 @@ func (m *Manager) applyCallerInvokeCredentialModes(callerPluginName string, refs
 			if pluginName == "" || operation == "" {
 				continue
 			}
-			mode, err := normalizeAgentToolCredentialMode(core.ConnectionMode(invoke.CredentialMode))
+			mode, err := normalizeAgentToolCredentialMode(invoke.CredentialMode)
 			if err != nil {
 				return nil, err
 			}

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -10,9 +10,7 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
-	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentgrant"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
@@ -1429,11 +1427,11 @@ func TestResolveToolsAppliesDeclaredInvokeCredentialMode(t *testing.T) {
 	}
 	manager := newTestManager(t, Config{
 		Providers: testutil.NewProviderRegistry(t, provider),
-		PluginInvokes: map[string][]config.PluginInvocationDependency{
+		PluginInvokes: map[string][]invocation.PluginInvocationDependency{
 			"slackbot": {{
 				Plugin:         "slack",
 				Operation:      "events.reply",
-				CredentialMode: providermanifestv1.ConnectionModeNone,
+				CredentialMode: core.ConnectionModeNone,
 			}},
 		},
 	})
@@ -1476,11 +1474,11 @@ func TestResolveToolsRejectsUndeclaredCredentialMode(t *testing.T) {
 	}
 	manager := newTestManager(t, Config{
 		Providers: testutil.NewProviderRegistry(t, provider),
-		PluginInvokes: map[string][]config.PluginInvocationDependency{
+		PluginInvokes: map[string][]invocation.PluginInvocationDependency{
 			"slackbot": {{
 				Plugin:         "slack",
 				Operation:      "chat.postMessage",
-				CredentialMode: providermanifestv1.ConnectionModeNone,
+				CredentialMode: core.ConnectionModeNone,
 			}},
 		},
 	})

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -719,7 +719,7 @@ func (b *Broker) resolvePlatformCredential(ctx context.Context, providerName, co
 	}
 	connection = strings.TrimSpace(connection)
 	if connection == "" {
-		connection = runtimePluginConnectionName
+		connection = core.PluginConnectionName
 	}
 	info, ok := b.connectionRuntime(providerName, connection)
 	token := strings.TrimSpace(info.Token)

--- a/gestaltd/services/invocation/catalog_selectors.go
+++ b/gestaltd/services/invocation/catalog_selectors.go
@@ -1,6 +1,6 @@
 package invocation
 
-import "github.com/valon-technologies/gestalt/server/internal/config"
+import "github.com/valon-technologies/gestalt/server/core"
 
 type CatalogSelectorConfig struct {
 	Invoker           any
@@ -10,7 +10,7 @@ type CatalogSelectorConfig struct {
 
 func (cfg CatalogSelectorConfig) SessionCatalogConnections(providerName string, explicit string) []string {
 	if explicit != "" {
-		return []string{config.ResolveConnectionAlias(explicit)}
+		return []string{core.ResolveConnectionAlias(explicit)}
 	}
 
 	connections := make([]string, 0, 2)

--- a/gestaltd/services/invocation/connection_runtime.go
+++ b/gestaltd/services/invocation/connection_runtime.go
@@ -6,8 +6,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 )
 
-const runtimePluginConnectionName = "_plugin"
-
 // ConnectionRuntimeInfo describes deployment-owned connection material that is
 // resolved after an operation selects its concrete connection.
 type ConnectionRuntimeInfo struct {
@@ -35,7 +33,7 @@ func (m ConnectionRuntimeMap) Resolve(provider, connection string) (ConnectionRu
 	}
 	connection = strings.TrimSpace(connection)
 	if connection == "" {
-		connection = runtimePluginConnectionName
+		connection = core.PluginConnectionName
 	}
 	info, ok := connections[connection]
 	return info, ok

--- a/gestaltd/services/invocation/plugin_invocation_dependency.go
+++ b/gestaltd/services/invocation/plugin_invocation_dependency.go
@@ -1,0 +1,30 @@
+package invocation
+
+import "github.com/valon-technologies/gestalt/server/core"
+
+// PluginInvocationDependency describes one plugin-to-plugin invocation grant.
+// It is the service-level form of the config "invokes" entry.
+type PluginInvocationDependency struct {
+	Plugin         string
+	Operation      string
+	Surface        string
+	CredentialMode core.ConnectionMode
+}
+
+func ClonePluginInvocationDependencies(src []PluginInvocationDependency) []PluginInvocationDependency {
+	if len(src) == 0 {
+		return nil
+	}
+	return append([]PluginInvocationDependency(nil), src...)
+}
+
+func ClonePluginInvocationDependencyMap(src map[string][]PluginInvocationDependency) map[string][]PluginInvocationDependency {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string][]PluginInvocationDependency, len(src))
+	for pluginName, deps := range src {
+		out[pluginName] = ClonePluginInvocationDependencies(deps)
+	}
+	return out
+}

--- a/gestaltd/services/plugininvoker/invocation_grants.go
+++ b/gestaltd/services/plugininvoker/invocation_grants.go
@@ -7,7 +7,7 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
 type InvocationGrant struct {
@@ -25,7 +25,7 @@ type invocationGrantClaims struct {
 	Surfaces       []string          `json:"surfaces,omitempty"`
 }
 
-func InvocationDependencyGrants(deps []config.PluginInvocationDependency) InvocationGrants {
+func InvocationDependencyGrants(deps []invocation.PluginInvocationDependency) InvocationGrants {
 	if len(deps) == 0 {
 		return nil
 	}
@@ -42,7 +42,7 @@ func InvocationDependencyGrants(deps []config.PluginInvocationDependency) Invoca
 			if grant.Operations == nil {
 				grant.Operations = make(map[string]core.ConnectionMode)
 			}
-			grant.Operations[operation] = core.ConnectionMode(dep.CredentialMode)
+			grant.Operations[operation] = dep.CredentialMode
 		}
 		if surface != "" {
 			if grant.Surfaces == nil {

--- a/gestaltd/services/plugininvoker/invocation_token_test.go
+++ b/gestaltd/services/plugininvoker/invocation_token_test.go
@@ -7,7 +7,6 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc/codes"
@@ -141,7 +140,7 @@ func TestPluginInvokerExchangeRequiresExplicitGrantScope(t *testing.T) {
 		t.Fatalf("MintRootToken: %v", err)
 	}
 
-	server := NewPluginInvokerServer("caller", []config.PluginInvocationDependency{{
+	server := NewPluginInvokerServer("caller", []invocation.PluginInvocationDependency{{
 		Plugin:    "example",
 		Operation: "request_context",
 	}}, nil, manager)

--- a/gestaltd/services/plugininvoker/plugin_invoker_server.go
+++ b/gestaltd/services/plugininvoker/plugin_invoker_server.go
@@ -9,7 +9,6 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc/codes"
@@ -25,7 +24,7 @@ type PluginInvokerServer struct {
 	allowed    InvocationGrants
 }
 
-func NewPluginInvokerServer(pluginName string, deps []config.PluginInvocationDependency, invoker invocation.Invoker, tokens *InvocationTokenManager) *PluginInvokerServer {
+func NewPluginInvokerServer(pluginName string, deps []invocation.PluginInvocationDependency, invoker invocation.Invoker, tokens *InvocationTokenManager) *PluginInvokerServer {
 	return &PluginInvokerServer{
 		pluginName: pluginName,
 		invoker:    invoker,
@@ -34,7 +33,7 @@ func NewPluginInvokerServer(pluginName string, deps []config.PluginInvocationDep
 	}
 }
 
-func NewServer(pluginName string, deps []config.PluginInvocationDependency, invoker invocation.Invoker, tokens *InvocationTokenManager) proto.PluginInvokerServer {
+func NewServer(pluginName string, deps []invocation.PluginInvocationDependency, invoker invocation.Invoker, tokens *InvocationTokenManager) proto.PluginInvokerServer {
 	return NewPluginInvokerServer(pluginName, deps, invoker, tokens)
 }
 

--- a/gestaltd/services/plugininvoker/plugin_invoker_test.go
+++ b/gestaltd/services/plugininvoker/plugin_invoker_test.go
@@ -6,7 +6,6 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"google.golang.org/grpc"
@@ -68,7 +67,7 @@ func TestPluginInvokerServerInvokePropagatesIdempotencyKey(t *testing.T) {
 	invoker := &recordingPluginInvoker{}
 	server := NewPluginInvokerServer(
 		"caller",
-		[]config.PluginInvocationDependency{
+		[]invocation.PluginInvocationDependency{
 			{Plugin: "github", Operation: "issues.create"},
 			{Plugin: "linear", Surface: "graphql"},
 		},

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -13,7 +13,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
 	"github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
@@ -92,7 +91,7 @@ type Config struct {
 	Authorizer        authorization.RuntimeAuthorizer
 	DefaultConnection map[string]string
 	CatalogConnection map[string]string
-	PluginInvokes     map[string][]config.PluginInvocationDependency
+	PluginInvokes     map[string][]invocation.PluginInvocationDependency
 	Now               func() time.Time
 }
 
@@ -105,7 +104,7 @@ type Manager struct {
 	authorizer        authorization.RuntimeAuthorizer
 	defaultConnection map[string]string
 	catalogConnection map[string]string
-	pluginInvokes     map[string][]config.PluginInvocationDependency
+	pluginInvokes     map[string][]invocation.PluginInvocationDependency
 	now               func() time.Time
 }
 
@@ -186,10 +185,6 @@ func New(cfg Config) *Manager {
 	if now == nil {
 		now = time.Now
 	}
-	pluginInvokes := make(map[string][]config.PluginInvocationDependency, len(cfg.PluginInvokes))
-	for pluginName, deps := range cfg.PluginInvokes {
-		pluginInvokes[pluginName] = append([]config.PluginInvocationDependency(nil), deps...)
-	}
 	return &Manager{
 		providers:         cfg.Providers,
 		workflow:          cfg.Workflow,
@@ -199,7 +194,7 @@ func New(cfg Config) *Manager {
 		authorizer:        cfg.Authorizer,
 		defaultConnection: maps.Clone(cfg.DefaultConnection),
 		catalogConnection: maps.Clone(cfg.CatalogConnection),
-		pluginInvokes:     pluginInvokes,
+		pluginInvokes:     invocation.ClonePluginInvocationDependencyMap(cfg.PluginInvokes),
 		now:               now,
 	}
 }
@@ -983,12 +978,12 @@ func (m *Manager) resolvePluginTarget(ctx context.Context, p *principal.Principa
 	}
 
 	connection := strings.TrimSpace(target.Connection)
-	if connection != "" && !config.SafeConnectionValue(connection) {
+	if connection != "" && !core.SafeConnectionValue(connection) {
 		return coreworkflow.Target{}, fmt.Errorf("connection name contains invalid characters")
 	}
-	connection = config.ResolveConnectionAlias(connection)
+	connection = core.ResolveConnectionAlias(connection)
 	instance := strings.TrimSpace(target.Instance)
-	if instance != "" && !config.SafeInstanceValue(instance) {
+	if instance != "" && !core.SafeInstanceValue(instance) {
 		return coreworkflow.Target{}, fmt.Errorf("instance name contains invalid characters")
 	}
 

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
-	"github.com/valon-technologies/gestalt/server/internal/config"
-	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
@@ -27,10 +25,10 @@ func TestSignalOrStartRunExecutionRefInheritsDeclaredAgentToolInvokes(t *testing
 		Workflow:     testWorkflowControl{provider: provider},
 		Agent:        testAgentControl{},
 		AgentManager: testAgentManager{},
-		PluginInvokes: map[string][]config.PluginInvocationDependency{
+		PluginInvokes: map[string][]invocation.PluginInvocationDependency{
 			"github": {
 				{Plugin: "github", Operation: "bot.commitFiles"},
-				{Plugin: "github", Operation: "bot.commentFinal", CredentialMode: providermanifestv1.ConnectionModeNone},
+				{Plugin: "github", Operation: "bot.commentFinal", CredentialMode: core.ConnectionModeNone},
 				{Plugin: "github", Operation: "bot.openPullRequest"},
 			},
 		},
@@ -388,7 +386,7 @@ func TestSignalOrStartRunExecutionRefDoesNotInheritSurfaceInvokes(t *testing.T) 
 		Workflow:     testWorkflowControl{provider: provider},
 		Agent:        testAgentControl{},
 		AgentManager: testAgentManager{},
-		PluginInvokes: map[string][]config.PluginInvocationDependency{
+		PluginInvokes: map[string][]invocation.PluginInvocationDependency{
 			"github": {
 				{Plugin: "github", Surface: "graphql"},
 			},


### PR DESCRIPTION
## Summary
- Move connection selector primitives (`PluginConnectionName`, `PluginConnectionAlias`, `ResolveConnectionAlias`, `SafeConnectionValue`, `SafeInstanceValue`) into `core` and keep `internal/config` as a compatibility wrapper.
- Add service-owned `invocation.PluginInvocationDependency` plus clone helpers so `plugininvoker`, `agentmanager`, and `workflowmanager` no longer depend on `internal/config`.
- Convert YAML `config.PluginInvocationDependency` entries only at composition boundaries in `internal/bootstrap` and `internal/server`.

## New Interfaces
```go
core.PluginConnectionName
core.PluginConnectionAlias
core.ResolveConnectionAlias(name)
core.SafeConnectionValue(value)
core.SafeInstanceValue(value)
```

```go
type invocation.PluginInvocationDependency struct {
    Plugin         string
    Operation      string
    Surface        string
    CredentialMode core.ConnectionMode
}

invocation.ClonePluginInvocationDependencies(deps)
invocation.ClonePluginInvocationDependencyMap(depsByPlugin)
```

## Examples
```go
plugininvokerservice.NewServer("caller", []invocation.PluginInvocationDependency{{
    Plugin:         "github",
    Operation:      "issues.create",
    CredentialMode: core.ConnectionModeNone,
}}, invoker, tokens)
```

```go
agentmanager.New(agentmanager.Config{
    PluginInvokes: map[string][]invocation.PluginInvocationDependency{
        "caller": {{
            Plugin:         "github",
            Operation:      "issues.create",
            CredentialMode: core.ConnectionModeNone,
        }},
    },
})
```

## Verification
- `go test ./services/invocation ./services/plugininvoker ./services/agents/agentmanager ./services/workflows/workflowmanager ./internal/bootstrap ./internal/server`
- `go test ./... -run '^$'`
- `go test ./internal/config`
- `git diff --check`
- `git grep -n 'github.com/valon-technologies/gestalt/server/internal/config' -- 'gestaltd/services/**/*.go' ':!**/*_test.go'` returned no output