### PR TITLE
Move declarative auth mapping into plugins service

### DIFF
--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -129,7 +128,7 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 				return nil, fmt.Errorf("%s: authMapping.basic requires authStyle basic", def.Provider)
 			}
 		}
-		base.TokenParser = MappedCredentialParser(def.AuthMapping)
+		base.TokenParser = coreintegration.MappedCredentialParser(def.AuthMapping)
 	case def.AuthHeader != "":
 		headerName := def.AuthHeader
 		base.TokenParser = func(token string) (string, map[string]string, error) {
@@ -254,77 +253,6 @@ func clearManualAuthMaterialization(def *Definition) {
 	def.TokenPrefix = ""
 	def.AuthMapping = nil
 	def.CredentialFields = nil
-}
-
-func parseMappedToken(token string) (map[string]any, error) {
-	var tokenData map[string]any
-	if err := json.Unmarshal([]byte(token), &tokenData); err != nil {
-		return nil, fmt.Errorf("parsing token as JSON for authMapping: %w", err)
-	}
-	return tokenData, nil
-}
-
-func MappedCredentialParser(mapping *AuthMappingDef) func(string) (string, map[string]string, error) {
-	return func(token string) (string, map[string]string, error) {
-		var (
-			tokenData map[string]any
-			headers   map[string]string
-		)
-		if len(mapping.Headers) > 0 {
-			headers = make(map[string]string, len(mapping.Headers))
-			for headerName, value := range mapping.Headers {
-				resolved, err := resolveAuthValue(value, token, &tokenData)
-				if err != nil {
-					return "", nil, fmt.Errorf("authMapping.headers[%q]: %w", headerName, err)
-				}
-				headers[headerName] = resolved
-			}
-		}
-		authToken := ""
-		if mapping.Basic != nil {
-			username, err := resolveAuthValue(mapping.Basic.Username, token, &tokenData)
-			if err != nil {
-				return "", nil, fmt.Errorf("authMapping.basic.username: %w", err)
-			}
-			password, err := resolveAuthValue(mapping.Basic.Password, token, &tokenData)
-			if err != nil {
-				return "", nil, fmt.Errorf("authMapping.basic.password: %w", err)
-			}
-			credential := fmt.Sprintf("%s:%s", username, password)
-			authToken = "Basic " + base64.StdEncoding.EncodeToString([]byte(credential))
-		}
-		if len(headers) == 0 {
-			headers = nil
-		}
-		return authToken, headers, nil
-	}
-}
-
-func resolveAuthValue(value AuthValueDef, token string, tokenData *map[string]any) (string, error) {
-	hasValue := value.Value != ""
-	hasValueFrom := value.ValueFrom != nil
-	if hasValue == hasValueFrom {
-		return "", fmt.Errorf("must set exactly one of value or valueFrom.credentialFieldRef")
-	}
-	if hasValue {
-		return value.Value, nil
-	}
-	if value.ValueFrom == nil || value.ValueFrom.CredentialFieldRef == nil {
-		return "", fmt.Errorf("must set exactly one of value or valueFrom.credentialFieldRef")
-	}
-	if *tokenData == nil {
-		parsed, err := parseMappedToken(token)
-		if err != nil {
-			return "", err
-		}
-		*tokenData = parsed
-	}
-	fieldName := value.ValueFrom.CredentialFieldRef.Name
-	val, ok := (*tokenData)[fieldName]
-	if !ok || val == nil {
-		return "", fmt.Errorf("token field %q is missing or null", fieldName)
-	}
-	return fmt.Sprintf("%v", val), nil
 }
 
 func setStr(dst *string, val string) {

--- a/gestaltd/services/plugins/declarative/auth_mapping.go
+++ b/gestaltd/services/plugins/declarative/auth_mapping.go
@@ -1,0 +1,85 @@
+package declarative
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+type AuthMappingDef = providermanifestv1.AuthMapping
+type AuthValueDef = providermanifestv1.AuthValue
+
+// MappedCredentialParser maps a structured credential JSON token into request
+// auth material according to an authMapping definition.
+func MappedCredentialParser(mapping *AuthMappingDef) func(string) (string, map[string]string, error) {
+	return func(token string) (string, map[string]string, error) {
+		var (
+			tokenData map[string]any
+			headers   map[string]string
+		)
+		if len(mapping.Headers) > 0 {
+			headers = make(map[string]string, len(mapping.Headers))
+			for headerName, value := range mapping.Headers {
+				resolved, err := resolveAuthValue(value, token, &tokenData)
+				if err != nil {
+					return "", nil, fmt.Errorf("authMapping.headers[%q]: %w", headerName, err)
+				}
+				headers[headerName] = resolved
+			}
+		}
+		authToken := ""
+		if mapping.Basic != nil {
+			username, err := resolveAuthValue(mapping.Basic.Username, token, &tokenData)
+			if err != nil {
+				return "", nil, fmt.Errorf("authMapping.basic.username: %w", err)
+			}
+			password, err := resolveAuthValue(mapping.Basic.Password, token, &tokenData)
+			if err != nil {
+				return "", nil, fmt.Errorf("authMapping.basic.password: %w", err)
+			}
+			credential := fmt.Sprintf("%s:%s", username, password)
+			authToken = "Basic " + base64.StdEncoding.EncodeToString([]byte(credential))
+		}
+		if len(headers) == 0 {
+			headers = nil
+		}
+		return authToken, headers, nil
+	}
+}
+
+func resolveAuthValue(value AuthValueDef, token string, tokenData *map[string]any) (string, error) {
+	hasValue := value.Value != ""
+	hasValueFrom := value.ValueFrom != nil
+	if hasValue == hasValueFrom {
+		return "", fmt.Errorf("must set exactly one of value or valueFrom.credentialFieldRef")
+	}
+	if hasValue {
+		return value.Value, nil
+	}
+	if value.ValueFrom == nil || value.ValueFrom.CredentialFieldRef == nil {
+		return "", fmt.Errorf("must set exactly one of value or valueFrom.credentialFieldRef")
+	}
+	if *tokenData == nil {
+		parsed, err := parseMappedToken(token)
+		if err != nil {
+			return "", err
+		}
+		*tokenData = parsed
+	}
+	fieldName := value.ValueFrom.CredentialFieldRef.Name
+	val, ok := (*tokenData)[fieldName]
+	if !ok || val == nil {
+		return "", fmt.Errorf("token field %q is missing or null", fieldName)
+	}
+	return fmt.Sprintf("%v", val), nil
+}
+
+func parseMappedToken(token string) (map[string]any, error) {
+	var tokenData map[string]any
+	if err := json.Unmarshal([]byte(token), &tokenData); err != nil {
+		return nil, fmt.Errorf("parsing token as JSON for authMapping: %w", err)
+	}
+	return tokenData, nil
+}

--- a/gestaltd/services/plugins/declarative_provider.go
+++ b/gestaltd/services/plugins/declarative_provider.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
-	"github.com/valon-technologies/gestalt/server/internal/provider"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	integration "github.com/valon-technologies/gestalt/server/services/plugins/declarative"
 )
@@ -116,7 +115,7 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 		authType = auth.Type
 		authorizationURL = auth.AuthorizationURL
 		if auth.AuthMapping != nil && (len(auth.AuthMapping.Headers) > 0 || auth.AuthMapping.Basic != nil) {
-			base.TokenParser = provider.MappedCredentialParser(auth.AuthMapping)
+			base.TokenParser = integration.MappedCredentialParser(auth.AuthMapping)
 		}
 	}
 	base.SetCatalog(cat)


### PR DESCRIPTION
## Summary
- Move auth-mapping credential parsing into `services/plugins/declarative`.
- Update the manifest-backed declarative provider to use the service-owned parser instead of importing `internal/provider`.
- Update the legacy internal provider builder to consume the same service-owned parser.

## New Interface
```go
func declarative.MappedCredentialParser(mapping *declarative.AuthMappingDef) func(token string) (authHeader string, extraHeaders map[string]string, err error)
```

## Example
```go
base.TokenParser = declarative.MappedCredentialParser(&providermanifestv1.AuthMapping{
    Headers: map[string]providermanifestv1.AuthValue{
        "X-Api-Key": {
            ValueFrom: &providermanifestv1.AuthValueFrom{
                CredentialFieldRef: &providermanifestv1.CredentialFieldRef{Name: "api_key"},
            },
        },
    },
})
```

`MappedCredentialParser` preserves existing behavior: JSON credential tokens can populate mapped headers, and basic auth mappings still produce a `Basic ...` authorization header.

## Verification
- `go test ./services/plugins ./services/plugins/declarative ./internal/provider ./internal/bootstrap ./internal/server`
- `go test ./... -run '^$'`
- `golangci-lint run` returned `0 issues` (local cache emitted no-space warnings only)
- `git diff --check`
- `git grep -n 'github.com/valon-technologies/gestalt/server/internal/' -- 'gestaltd/services/**/*.go' ':!**/*_test.go'` returned no output