### PR TITLE
Move plugin validation into plugins service

### DIFF
--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -12,10 +12,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
-	"github.com/valon-technologies/gestalt/server/internal/plugininvocation"
 	"github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/plugins/registry"
 )
 
@@ -23,7 +23,7 @@ import (
 // starting the server or running migrations. Unlike Bootstrap, provider
 // validation is strict: any provider construction failure is returned.
 func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) ([]string, error) {
-	if err := plugininvocation.ValidateEffectiveCatalogsAndDependencies(ctx, cfg); err != nil {
+	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(ctx, cfg); err != nil {
 		return nil, err
 	}
 

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -14,10 +14,10 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/plugininvocation"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"gopkg.in/yaml.v3"
 )
 
@@ -414,7 +414,7 @@ func validateStagedReleaseCatalog(staged *providerpkg.StagedPreparedInstall) err
 	if err != nil {
 		return fmt.Errorf("invalid source in staged manifest: %w", err)
 	}
-	return plugininvocation.ValidateEffectiveCatalog(context.Background(), src.PluginName(), &config.ProviderEntry{
+	return pluginservice.ValidateEffectiveCatalog(context.Background(), src.PluginName(), &config.ProviderEntry{
 		ResolvedManifestPath: staged.ManifestPath,
 		ResolvedManifest:     staged.Manifest,
 	})

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -20,10 +20,10 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/plugininvocation"
 	"github.com/valon-technologies/gestalt/server/internal/pluginstore"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"gopkg.in/yaml.v3"
 )
 
@@ -283,7 +283,7 @@ func (l *Lifecycle) prepareLockAtPaths(configPaths []string, state StatePaths, d
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
-	if err := plugininvocation.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
+	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
 	return lock, cfg, paths, nil
@@ -473,7 +473,7 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 		return nil, nil, err
 	}
 	if !secretsValidated && !dependenciesValidated {
-		if err := plugininvocation.ValidateDependencies(context.Background(), cfg); err != nil {
+		if err := pluginservice.ValidateDependencies(context.Background(), cfg); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -499,7 +499,7 @@ func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string,
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, err
 	}
-	if err := plugininvocation.ValidateDependencies(context.Background(), cfg); err != nil {
+	if err := pluginservice.ValidateDependencies(context.Background(), cfg); err != nil {
 		return nil, err
 	}
 	return cfg, nil
@@ -536,7 +536,7 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return err
 	}
-	if err := plugininvocation.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
+	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
 		return err
 	}
 	return nil

--- a/gestaltd/services/plugins/validation.go
+++ b/gestaltd/services/plugins/validation.go
@@ -1,4 +1,4 @@
-package plugininvocation
+package plugins
 
 import (
 	"context"
@@ -13,7 +13,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/plugins/operationexposure"
 )
 
@@ -197,7 +196,7 @@ func resolveDeclarativeCatalog(name string, manifest *providermanifestv1.Manifes
 }
 
 func loadDeclarativeCatalog(name string, manifest *providermanifestv1.Manifest) (*catalog.Catalog, error) {
-	prov, err := pluginservice.NewDeclarativeProvider(manifest, nil)
+	prov, err := NewDeclarativeProvider(manifest, nil)
 	if err != nil {
 		return nil, fmt.Errorf("plugin %q declarative catalog: %w", name, err)
 	}


### PR DESCRIPTION
## Summary
- deletes the stale `gestaltd/internal/plugininvocation` package
- moves plugin catalog/dependency validation into `gestaltd/services/plugins`
- updates bootstrap, daemon, and operator callers to use the plugins service package directly

## Interface diff
```diff
- plugininvocation.ValidateEffectiveCatalog(ctx, name, entry)
- plugininvocation.ValidateEffectiveCatalogs(ctx, cfg)
- plugininvocation.ValidateEffectiveCatalogsAndDependencies(ctx, cfg)
- plugininvocation.ValidateDependencies(ctx, cfg)
+ pluginservice.ValidateEffectiveCatalog(ctx, name, entry)
+ pluginservice.ValidateEffectiveCatalogs(ctx, cfg)
+ pluginservice.ValidateEffectiveCatalogsAndDependencies(ctx, cfg)
+ pluginservice.ValidateDependencies(ctx, cfg)
```

## Example
```go
import pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"

if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(ctx, cfg); err != nil {
    return err
}
```

## Testing
- `go test ./services/plugins ./internal/bootstrap ./internal/operator ./internal/daemon`
