### PR TITLE
gestaltd: ignore runtime host service access support

### DIFF
--- a/docs/content/custom-providers/runtime.mdx
+++ b/docs/content/custom-providers/runtime.mdx
@@ -111,13 +111,12 @@ the exported provider for the selected language.
         return nil
     }
 
-    func (p *Provider) GetSupport(context.Context, *emptypb.Empty) (*proto.PluginRuntimeSupport, error) {
-        return &proto.PluginRuntimeSupport{
-            CanHostPlugins:    true,
-            HostServiceAccess: proto.PluginRuntimeHostServiceAccess_PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT,
-            EgressMode:        proto.PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME,
-        }, nil
-    }
+	    func (p *Provider) GetSupport(context.Context, *emptypb.Empty) (*proto.PluginRuntimeSupport, error) {
+	        return &proto.PluginRuntimeSupport{
+	            CanHostPlugins: true,
+	            EgressMode:     proto.PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME,
+	        }, nil
+	    }
 
     func (p *Provider) StartSession(context.Context, *proto.StartPluginRuntimeSessionRequest) (*proto.PluginRuntimeSession, error) {
         return &proto.PluginRuntimeSession{
@@ -173,12 +172,11 @@ the exported provider for the selected language.
 
 
     class ExampleRuntime(gestalt.PluginRuntimeProvider):
-        def GetSupport(self, request, context):
-            return pb.PluginRuntimeSupport(
-                can_host_plugins=True,
-                host_service_access=pb.PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT,
-                egress_mode=pb.PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME,
-            )
+	        def GetSupport(self, request, context):
+	            return pb.PluginRuntimeSupport(
+	                can_host_plugins=True,
+	                egress_mode=pb.PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME,
+	            )
 
         def StartSession(self, request, context):
             return pb.PluginRuntimeSession(id="session-1", state="ready")
@@ -229,11 +227,10 @@ the exported provider for the selected language.
             &self,
             _request: Request<()>,
         ) -> Result<Response<proto::PluginRuntimeSupport>, Status> {
-            Ok(Response::new(proto::PluginRuntimeSupport {
-                can_host_plugins: true,
-                host_service_access: proto::PluginRuntimeHostServiceAccess::Direct as i32,
-                egress_mode: proto::PluginRuntimeEgressMode::Hostname as i32,
-            }))
+	            Ok(Response::new(proto::PluginRuntimeSupport {
+	                can_host_plugins: true,
+	                egress_mode: proto::PluginRuntimeEgressMode::Hostname as i32,
+	            }))
         }
 
         async fn start_session(
@@ -313,19 +310,17 @@ the exported provider for the selected language.
   </Tabs.Tab>
   <Tabs.Tab>
     ```ts
-    import {
-      PluginRuntimeEgressMode,
-      PluginRuntimeHostServiceAccess,
-      definePluginRuntimeProvider,
-    } from "@valon-technologies/gestalt";
+	    import {
+	      PluginRuntimeEgressMode,
+	      definePluginRuntimeProvider,
+	    } from "@valon-technologies/gestalt";
 
     export const runtime = definePluginRuntimeProvider({
       getSupport() {
-        return {
-          canHostPlugins: true,
-          hostServiceAccess: PluginRuntimeHostServiceAccess.DIRECT,
-          egressMode: PluginRuntimeEgressMode.HOSTNAME,
-        };
+	        return {
+	          canHostPlugins: true,
+	          egressMode: PluginRuntimeEgressMode.HOSTNAME,
+	        };
       },
 
       startSession() {
@@ -373,11 +368,10 @@ host-reachable executable plugin session. If that is false, Gestalt will reject
 hosted execution for that runtime immediately instead of failing later during
 bootstrap.
 
-`host_service_access` should be `direct` only when the backend can expose
-guest-local host-service sockets inside the runtime session. Most hosted
-runtimes should report `none` and let Gestalt decide whether the current
-deployment can provide relay-backed host services through the public relay
-path. That relay path is host-provided behavior, not runtime-owned behavior.
+	`host_service_access` is a legacy support field kept on the wire for older
+	runtime SDKs. New providers should omit it or leave it unspecified. Gestalt
+	ignores runtime-advertised host-service access and derives effective
+	host-service access from its own public relay configuration.
 
 `egress_mode` should be `hostname` only when the runtime can preserve
 Gestalt's hostname-based `allowedHosts` model. `cidr` is useful metadata, but
@@ -402,10 +396,9 @@ API. Gestalt needs an explicit session lifecycle because it may need to create
 the session, wait until it is ready, bind host-local services into it, and only
 then start the plugin.
 
-That is why `BindHostService` exists separately from `StartPlugin`. A binding
-may be direct, using a guest-local socket path, or relay-backed, in which case
-the provider receives a public dial target and the hosted plugin talks back to
-`gestaltd` through the host-service relay.
+	That is why `BindHostService` exists separately from `StartPlugin`. A binding
+	is relay-backed: the provider receives a scoped dial target and the hosted
+	plugin talks back to `gestaltd` through the host-service relay.
 
 ## Dial targets
 

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -80,12 +80,13 @@ to read in terms of behavior, not implementation details. Gestalt asks whether
 the runtime can host plugins, how hosted plugins reach Gestalt-owned services,
 and whether the runtime can preserve hostname-based `egress.allowedHosts`.
 
-Host-service access is reported as `none`, `relay`, or `direct`. `direct`
-means the runtime can expose guest-local service sockets inside the session.
-`relay` means the current host deployment can provide those services through
-Gestalt's public relay path. Egress support is separate: a runtime must preserve
-Gestalt's hostname-based policy model before plugins with `egress.allowedHosts`
-or a default-deny egress policy can run there.
+Host-service access is derived by Gestalt from the current host deployment.
+`none` means host services are unavailable for that runtime, while `relay`
+means Gestalt can provide those services through the public relay path. The
+legacy runtime-reported `host_service_access` field is ignored. Egress support
+is separate: a runtime must preserve Gestalt's hostname-based policy model
+before plugins with `egress.allowedHosts` or a default-deny egress policy can
+run there.
 
 The admin inspection API exposes both sides of that decision. `GET
 /admin/api/v1/runtime/providers` includes `profile.advertised`, which is what
@@ -96,12 +97,9 @@ considered.
 ## Host services and hosted plugins
 
 Plugins do not talk directly to host-local services over the public network.
-`gestaltd` starts those services on the host and then gives the runtime one of
-two integration paths. A runtime with direct host-service access can bind
-guest-local sockets straight into the session. A runtime without that direct
-path can still use relay-backed bindings, in which case the hosted plugin talks
-back to `gestaltd` over a scoped public relay target and `gestaltd` forwards
-the request to the real host-local service.
+`gestaltd` starts those services on the host and gives the runtime relay-backed
+bindings. The hosted plugin talks back to `gestaltd` over a scoped public relay
+target, and `gestaltd` forwards the request to the real host-local service.
 
 That same split shows up in hostname-based egress. A runtime may preserve
 `egress.allowedHosts` internally, or it may preserve it by routing hosted

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -2321,7 +2321,6 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 	testutil.CloseOnCleanup(t, relaySrv)
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessNone
 
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -2410,7 +2409,6 @@ func TestAgentRuntimeImageLaunchUsesManifestEntrypoint(t *testing.T) {
 	t.Parallel()
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessDirect
 	entry := &config.ProviderEntry{
 		ResolvedManifest: &providermanifestv1.Manifest{
 			Kind: providermanifestv1.KindAgent,
@@ -2484,7 +2482,6 @@ func TestAgentRuntimeTemplateLaunchUsesManifestEntrypoint(t *testing.T) {
 	t.Parallel()
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessDirect
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
 		return runtimeProvider, nil

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -7190,8 +7190,7 @@ func TestPluginRuntimeConfigRejectsMissingHostnameEgressCapability(t *testing.T)
 	runtimeProvider := &staticCapabilityPluginRuntime{
 		inner: pluginruntime.NewLocalProvider(),
 		support: pluginruntime.Support{
-			CanHostPlugins:    true,
-			HostServiceAccess: pluginruntime.HostServiceAccessDirect,
+			CanHostPlugins: true,
 		},
 	}
 	factories := NewFactoryRegistry()
@@ -7301,7 +7300,6 @@ func TestPluginRuntimeConfigInjectsRuntimeLogSessionAndHostService(t *testing.T)
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessDirect
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -8198,7 +8196,7 @@ func TestPluginRuntimeConfigSkipsPublicEgressProxyWhenHostnameEgressIsNotRequire
 	}
 }
 
-func TestPluginRuntimeConfigUsesPublicRelayAndEgressProxyWhenRuntimeAdvertisesDirectHostServiceSupport(t *testing.T) {
+func TestPluginRuntimeConfigUsesPublicRelayAndEgressProxyWhenHostCanRelay(t *testing.T) {
 	t.Parallel()
 
 	bin := buildEchoPluginBinary(t)
@@ -8210,7 +8208,6 @@ func TestPluginRuntimeConfigUsesPublicRelayAndEgressProxyWhenRuntimeAdvertisesDi
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessDirect
 	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
@@ -8401,8 +8398,7 @@ func TestPluginRuntimeConfigRejectsDefaultDenyWithoutHostnameEgressCapability(t 
 	runtimeProvider := &staticCapabilityPluginRuntime{
 		inner: pluginruntime.NewLocalProvider(),
 		support: pluginruntime.Support{
-			CanHostPlugins:    true,
-			HostServiceAccess: pluginruntime.HostServiceAccessDirect,
+			CanHostPlugins: true,
 		},
 	}
 	factories := NewFactoryRegistry()

--- a/gestaltd/internal/pluginruntime/executable.go
+++ b/gestaltd/internal/pluginruntime/executable.go
@@ -314,19 +314,11 @@ func supportFromProto(src *proto.PluginRuntimeSupport) Support {
 	if src == nil {
 		return Support{}
 	}
+	// host_service_access is a legacy runtime-advertised capability. gestaltd
+	// now derives host-service access from its own public relay configuration.
 	return Support{
-		CanHostPlugins:    src.GetCanHostPlugins(),
-		HostServiceAccess: hostServiceAccessFromProto(src.GetHostServiceAccess()),
-		EgressMode:        egressModeFromProto(src.GetEgressMode()),
-	}
-}
-
-func hostServiceAccessFromProto(src proto.PluginRuntimeHostServiceAccess) HostServiceAccess {
-	switch src {
-	case proto.PluginRuntimeHostServiceAccess_PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT:
-		return HostServiceAccessDirect
-	default:
-		return HostServiceAccessNone
+		CanHostPlugins: src.GetCanHostPlugins(),
+		EgressMode:     egressModeFromProto(src.GetEgressMode()),
 	}
 }
 

--- a/gestaltd/internal/pluginruntime/executable_test.go
+++ b/gestaltd/internal/pluginruntime/executable_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -14,6 +15,34 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 )
+
+func TestExecutableProviderIgnoresLegacyDirectHostServiceAccess(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	runtimeBin := buildRuntimeLogProviderBinary(t)
+	runtimeProvider, err := NewExecutableProvider(ctx, ExecutableConfig{
+		Name:    "modal",
+		Command: runtimeBin,
+	})
+	if err != nil {
+		t.Fatalf("NewExecutableProvider: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = runtimeProvider.Close()
+	})
+
+	support, err := runtimeProvider.Support(ctx)
+	if err != nil {
+		t.Fatalf("Support: %v", err)
+	}
+	want := Support{CanHostPlugins: true, EgressMode: EgressModeNone}
+	if !reflect.DeepEqual(support, want) {
+		t.Fatalf("Support = %#v, want %#v", support, want)
+	}
+}
 
 func TestExecutableProviderIncludesPushedRuntimeLogsInStartupFailures(t *testing.T) {
 	t.Parallel()
@@ -171,6 +200,7 @@ func (p *runtimeProvider) Configure(context.Context, string, map[string]any) err
 func (p *runtimeProvider) GetSupport(context.Context, *emptypb.Empty) (*proto.PluginRuntimeSupport, error) {
 	return &proto.PluginRuntimeSupport{
 		CanHostPlugins: true,
+		HostServiceAccess: proto.PluginRuntimeHostServiceAccess_PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT,
 	}, nil
 }
 

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -82,9 +82,8 @@ func NewLocalProvider(opts ...LocalOption) *LocalProvider {
 
 func (p *LocalProvider) Support(context.Context) (Support, error) {
 	return Support{
-		CanHostPlugins:    true,
-		HostServiceAccess: HostServiceAccessDirect,
-		EgressMode:        EgressModeHostname,
+		CanHostPlugins: true,
+		EgressMode:     EgressModeHostname,
 	}, nil
 }
 

--- a/gestaltd/internal/pluginruntime/runtime.go
+++ b/gestaltd/internal/pluginruntime/runtime.go
@@ -27,13 +27,6 @@ const (
 	PolicyDeny  PolicyAction = "deny"
 )
 
-type HostServiceAccess string
-
-const (
-	HostServiceAccessNone   HostServiceAccess = "none"
-	HostServiceAccessDirect HostServiceAccess = "direct"
-)
-
 type EgressMode string
 
 const (
@@ -43,9 +36,8 @@ const (
 )
 
 type Support struct {
-	CanHostPlugins    bool
-	HostServiceAccess HostServiceAccess
-	EgressMode        EgressMode
+	CanHostPlugins bool
+	EgressMode     EgressMode
 }
 
 type Session struct {

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -96,7 +96,6 @@ import {
   httpSubjectError,
   PresignMethod,
   PluginRuntimeEgressMode,
-  PluginRuntimeHostServiceAccess,
   S3,
   WorkflowRunStatus,
   defineCacheProvider,
@@ -1427,7 +1426,6 @@ test("plugin runtime provider serves runtime metadata plus sessions", async () =
     getSupport() {
       return {
         canHostPlugins: true,
-        hostServiceAccess: PluginRuntimeHostServiceAccess.DIRECT,
         egressMode: PluginRuntimeEgressMode.HOSTNAME,
       };
     },
@@ -1477,7 +1475,6 @@ test("plugin runtime provider serves runtime metadata plus sessions", async () =
 
   const support = await (service.getSupport as any)(create(EmptySchema));
   expect(support.canHostPlugins).toBe(true);
-  expect(support.hostServiceAccess).toBe(PluginRuntimeHostServiceAccess.DIRECT);
   expect(support.egressMode).toBe(PluginRuntimeEgressMode.HOSTNAME);
 
   const session = await (service.startSession as any)(


### PR DESCRIPTION
## Summary
- remove the internal runtime-advertised host-service access capability from `pluginruntime.Support`
- keep accepting the legacy proto field but ignore it; effective host-service access is derived from gestaltd public relay configuration
- update runtime docs/examples to omit `host_service_access=direct` and describe relay-only callback flow
- add an executable-runtime contract test where a real provider advertises legacy `DIRECT` over gRPC and gestaltd ignores it

## Tests
- `go test ./internal/pluginruntime ./internal/bootstrap ./internal/server -count=1`
- `golangci-lint run --new-from-rev=origin/main ./internal/pluginruntime/... ./internal/bootstrap/... ./internal/server/...`
- `bun test --max-concurrency 1 tests/runtime.test.ts`
- `bun run typecheck`