### PR TITLE
Move plugin validation behind service boundary

### DIFF
--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -12,10 +12,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/pluginvalidation"
 	"github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
-	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/plugins/registry"
 )
 
@@ -23,7 +23,7 @@ import (
 // starting the server or running migrations. Unlike Bootstrap, provider
 // validation is strict: any provider construction failure is returned.
 func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) ([]string, error) {
-	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(ctx, cfg); err != nil {
+	if err := pluginvalidation.ValidateEffectiveCatalogsAndDependencies(ctx, cfg); err != nil {
 		return nil, err
 	}
 

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -13,11 +13,10 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
+	"github.com/valon-technologies/gestalt/server/internal/pluginvalidation"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"gopkg.in/yaml.v3"
 )
 
@@ -414,10 +413,7 @@ func validateStagedReleaseCatalog(staged *providerpkg.StagedPreparedInstall) err
 	if err != nil {
 		return fmt.Errorf("invalid source in staged manifest: %w", err)
 	}
-	return pluginservice.ValidateEffectiveCatalog(context.Background(), src.PluginName(), &config.ProviderEntry{
-		ResolvedManifestPath: staged.ManifestPath,
-		ResolvedManifest:     staged.Manifest,
-	})
+	return pluginvalidation.ValidateEffectiveManifest(context.Background(), src.PluginName(), staged.ManifestPath, staged.Manifest)
 }
 
 func platformArchiveName(pluginName, version string, plat releasePlatform) string {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginstore"
+	"github.com/valon-technologies/gestalt/server/internal/pluginvalidation"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"gopkg.in/yaml.v3"
 )
 
@@ -283,7 +283,7 @@ func (l *Lifecycle) prepareLockAtPaths(configPaths []string, state StatePaths, d
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
-	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
+	if err := pluginvalidation.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
 	return lock, cfg, paths, nil
@@ -473,7 +473,7 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 		return nil, nil, err
 	}
 	if !secretsValidated && !dependenciesValidated {
-		if err := pluginservice.ValidateDependencies(context.Background(), cfg); err != nil {
+		if err := pluginvalidation.ValidateDependencies(context.Background(), cfg); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -499,7 +499,7 @@ func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string,
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, err
 	}
-	if err := pluginservice.ValidateDependencies(context.Background(), cfg); err != nil {
+	if err := pluginvalidation.ValidateDependencies(context.Background(), cfg); err != nil {
 		return nil, err
 	}
 	return cfg, nil
@@ -536,7 +536,7 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return err
 	}
-	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
+	if err := pluginvalidation.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
 		return err
 	}
 	return nil

--- a/gestaltd/internal/pluginvalidation/validation.go
+++ b/gestaltd/internal/pluginvalidation/validation.go
@@ -1,0 +1,116 @@
+package pluginvalidation
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
+	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
+	"github.com/valon-technologies/gestalt/server/services/plugins/openapi"
+)
+
+func ValidateEffectiveManifest(ctx context.Context, name, manifestPath string, manifest *providermanifestv1.Manifest) error {
+	return pluginservice.ValidateEffectiveCatalog(ctx, name, FromManifest(manifestPath, manifest))
+}
+
+func ValidateEffectiveCatalogsAndDependencies(ctx context.Context, cfg *config.Config) error {
+	return pluginservice.ValidateEffectiveCatalogsAndDependencies(ctx, FromConfig(cfg))
+}
+
+func ValidateDependencies(ctx context.Context, cfg *config.Config) error {
+	return pluginservice.ValidateDependencies(ctx, FromConfig(cfg))
+}
+
+func FromConfig(cfg *config.Config) *pluginservice.ValidationConfig {
+	if cfg == nil {
+		return nil
+	}
+	validation := &pluginservice.ValidationConfig{
+		Plugins: make(map[string]*pluginservice.ValidationPlugin, len(cfg.Plugins)),
+	}
+	for name, entry := range cfg.Plugins {
+		validation.Plugins[name] = FromProviderEntry(entry)
+	}
+	return validation
+}
+
+func FromProviderEntry(entry *config.ProviderEntry) *pluginservice.ValidationPlugin {
+	if entry == nil {
+		return nil
+	}
+	return &pluginservice.ValidationPlugin{
+		Manifest:            entry.ResolvedManifest,
+		ManifestPath:        entry.ResolvedManifestPath,
+		AllowedOperations:   entry.AllowedOperations,
+		Invokes:             invocationDependencies(entry.Invokes),
+		SurfaceURLOverrides: surfaceURLOverrides(entry),
+		ReadStaticCatalog:   staticCatalogReader(entry),
+		LoadAPICatalog:      loadAPICatalog,
+	}
+}
+
+func FromManifest(manifestPath string, manifest *providermanifestv1.Manifest) *pluginservice.ValidationPlugin {
+	return FromProviderEntry(&config.ProviderEntry{
+		ResolvedManifestPath: manifestPath,
+		ResolvedManifest:     manifest,
+	})
+}
+
+func invocationDependencies(dependencies []config.PluginInvocationDependency) []pluginservice.InvocationDependency {
+	if len(dependencies) == 0 {
+		return nil
+	}
+	result := make([]pluginservice.InvocationDependency, 0, len(dependencies))
+	for _, dependency := range dependencies {
+		result = append(result, pluginservice.InvocationDependency{
+			Plugin:    dependency.Plugin,
+			Operation: dependency.Operation,
+			Surface:   pluginservice.SpecSurface(dependency.Surface),
+		})
+	}
+	return result
+}
+
+func surfaceURLOverrides(entry *config.ProviderEntry) map[pluginservice.SpecSurface]string {
+	if entry == nil {
+		return nil
+	}
+	overrides := make(map[pluginservice.SpecSurface]string)
+	for _, surface := range []pluginservice.SpecSurface{pluginservice.SpecSurfaceGraphQL, pluginservice.SpecSurfaceMCP} {
+		if url := config.ProviderSurfaceURLOverride(entry, config.SpecSurface(surface)); url != "" {
+			overrides[surface] = url
+		}
+	}
+	if len(overrides) == 0 {
+		return nil
+	}
+	return overrides
+}
+
+func staticCatalogReader(entry *config.ProviderEntry) pluginservice.StaticCatalogReader {
+	if entry == nil || entry.ResolvedManifestPath == "" {
+		return nil
+	}
+	root := filepath.Dir(entry.ResolvedManifestPath)
+	return func(name string) (*catalog.Catalog, error) {
+		return providerpkg.ReadStaticCatalog(root, name)
+	}
+}
+
+func loadAPICatalog(ctx context.Context, name string, surface pluginservice.SpecSurface, specURL string, allowed map[string]*pluginservice.OperationOverride) (*catalog.Catalog, error) {
+	switch surface {
+	case pluginservice.SpecSurfaceOpenAPI:
+		def, err := openapi.LoadDefinition(ctx, name, specURL, allowed)
+		if err != nil {
+			return nil, err
+		}
+		return declarative.CatalogFromDefinition(def), nil
+	default:
+		return nil, fmt.Errorf("unsupported API catalog surface %q", surface)
+	}
+}

--- a/gestaltd/services/plugins/validation.go
+++ b/gestaltd/services/plugins/validation.go
@@ -4,15 +4,10 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"path/filepath"
 	"slices"
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
-	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
-	"github.com/valon-technologies/gestalt/server/services/plugins/openapi"
 	"github.com/valon-technologies/gestalt/server/services/plugins/operationexposure"
 )
 
@@ -33,7 +28,7 @@ func newCatalogResolutionCache(size int) *catalogResolutionCache {
 	return &catalogResolutionCache{entries: make(map[string]resolvedDependencyCatalog, size)}
 }
 
-func (c *catalogResolutionCache) resolve(ctx context.Context, name string, entry *config.ProviderEntry) resolvedDependencyCatalog {
+func (c *catalogResolutionCache) resolve(ctx context.Context, name string, entry *ValidationPlugin) resolvedDependencyCatalog {
 	if c == nil {
 		resolved := resolvedDependencyCatalog{}
 		resolved.catalog, resolved.sessionOnly, resolved.err = resolveStaticCatalog(ctx, name, entry)
@@ -48,7 +43,7 @@ func (c *catalogResolutionCache) resolve(ctx context.Context, name string, entry
 	return resolved
 }
 
-func ValidateEffectiveCatalog(ctx context.Context, name string, entry *config.ProviderEntry) error {
+func ValidateEffectiveCatalog(ctx context.Context, name string, entry *ValidationPlugin) error {
 	if entry == nil {
 		return nil
 	}
@@ -56,11 +51,17 @@ func ValidateEffectiveCatalog(ctx context.Context, name string, entry *config.Pr
 	return err
 }
 
-func ValidateEffectiveCatalogs(ctx context.Context, cfg *config.Config) error {
+func ValidateEffectiveCatalogs(ctx context.Context, cfg *ValidationConfig) error {
+	if cfg == nil {
+		return nil
+	}
 	return validateEffectiveCatalogs(ctx, cfg, newCatalogResolutionCache(len(cfg.Plugins)))
 }
 
-func ValidateEffectiveCatalogsAndDependencies(ctx context.Context, cfg *config.Config) error {
+func ValidateEffectiveCatalogsAndDependencies(ctx context.Context, cfg *ValidationConfig) error {
+	if cfg == nil {
+		return nil
+	}
 	cache := newCatalogResolutionCache(len(cfg.Plugins))
 	if err := validateEffectiveCatalogs(ctx, cfg, cache); err != nil {
 		return err
@@ -68,7 +69,7 @@ func ValidateEffectiveCatalogsAndDependencies(ctx context.Context, cfg *config.C
 	return validateDependencies(ctx, cfg, cache)
 }
 
-func validateEffectiveCatalogs(ctx context.Context, cfg *config.Config, cache *catalogResolutionCache) error {
+func validateEffectiveCatalogs(ctx context.Context, cfg *ValidationConfig, cache *catalogResolutionCache) error {
 	if cfg == nil {
 		return nil
 	}
@@ -85,11 +86,14 @@ func validateEffectiveCatalogs(ctx context.Context, cfg *config.Config, cache *c
 	return nil
 }
 
-func ValidateDependencies(ctx context.Context, cfg *config.Config) error {
+func ValidateDependencies(ctx context.Context, cfg *ValidationConfig) error {
+	if cfg == nil {
+		return nil
+	}
 	return validateDependencies(ctx, cfg, newCatalogResolutionCache(len(cfg.Plugins)))
 }
 
-func validateDependencies(ctx context.Context, cfg *config.Config, cache *catalogResolutionCache) error {
+func validateDependencies(ctx context.Context, cfg *ValidationConfig, cache *catalogResolutionCache) error {
 	if cfg == nil {
 		return nil
 	}
@@ -106,7 +110,7 @@ func validateDependencies(ctx context.Context, cfg *config.Config, cache *catalo
 				return fmt.Errorf("config validation: plugins.%s.invokes[%d] references unknown plugin %q", callerName, i, dependency.Plugin)
 			}
 			if dependency.Surface != "" {
-				if !pluginSupportsSurface(targetEntry, config.SpecSurface(dependency.Surface)) {
+				if !pluginSupportsSurface(targetEntry, dependency.Surface) {
 					return fmt.Errorf("config validation: plugins.%s.invokes[%d] references plugin %q surface %q, but that surface is not configured", callerName, i, dependency.Plugin, dependency.Surface)
 				}
 				continue
@@ -127,12 +131,12 @@ func validateDependencies(ctx context.Context, cfg *config.Config, cache *catalo
 	return nil
 }
 
-func isExecutablePlugin(entry *config.ProviderEntry) bool {
+func isExecutablePlugin(entry *ValidationPlugin) bool {
 	if entry == nil {
 		return false
 	}
-	manifest := entry.ResolvedManifest
-	spec := entry.ManifestSpec()
+	manifest := entry.Manifest
+	spec := entry.manifestSpec()
 	if manifest == nil || spec == nil {
 		return false
 	}
@@ -145,11 +149,11 @@ func isExecutablePlugin(entry *config.ProviderEntry) bool {
 	return true
 }
 
-func pluginSupportsSurface(entry *config.ProviderEntry, surface config.SpecSurface) bool {
+func pluginSupportsSurface(entry *ValidationPlugin, surface SpecSurface) bool {
 	if entry == nil {
 		return false
 	}
-	spec := entry.ManifestSpec()
+	spec := entry.manifestSpec()
 	if spec == nil {
 		return false
 	}
@@ -157,9 +161,9 @@ func pluginSupportsSurface(entry *config.ProviderEntry, surface config.SpecSurfa
 	return ok
 }
 
-func resolveStaticCatalog(ctx context.Context, name string, entry *config.ProviderEntry) (*catalog.Catalog, bool, error) {
-	manifest := entry.ResolvedManifest
-	spec := entry.ManifestSpec()
+func resolveStaticCatalog(ctx context.Context, name string, entry *ValidationPlugin) (*catalog.Catalog, bool, error) {
+	manifest := entry.Manifest
+	spec := entry.manifestSpec()
 	if manifest == nil || spec == nil {
 		return nil, false, fmt.Errorf("plugin %q does not have a resolved manifest", name)
 	}
@@ -174,16 +178,16 @@ func resolveStaticCatalog(ctx context.Context, name string, entry *config.Provid
 	}
 }
 
-func resolveSpecLoadedCatalog(ctx context.Context, name string, entry *config.ProviderEntry, spec *providermanifestv1.Spec, allowed map[string]*config.OperationOverride) (*catalog.Catalog, bool, error) {
+func resolveSpecLoadedCatalog(ctx context.Context, name string, entry *ValidationPlugin, spec *providermanifestv1.Spec, allowed map[string]*OperationOverride) (*catalog.Catalog, bool, error) {
 	apiCatalog, err := loadConfiguredAPICatalog(ctx, name, entry, spec, allowed)
 	if err != nil {
 		return nil, false, err
 	}
-	_, hasMCP := resolvedSurfaceURL(entry, spec, config.SpecSurfaceMCP)
+	_, hasMCP := resolvedSurfaceURL(entry, spec, SpecSurfaceMCP)
 	return apiCatalog, hasMCP && apiCatalog == nil, nil
 }
 
-func resolveDeclarativeCatalog(name string, manifest *providermanifestv1.Manifest, allowed map[string]*config.OperationOverride) (*catalog.Catalog, bool, error) {
+func resolveDeclarativeCatalog(name string, manifest *providermanifestv1.Manifest, allowed map[string]*OperationOverride) (*catalog.Catalog, bool, error) {
 	rawCatalog, err := loadDeclarativeCatalog(name, manifest)
 	if err != nil {
 		return nil, false, err
@@ -203,7 +207,7 @@ func loadDeclarativeCatalog(name string, manifest *providermanifestv1.Manifest) 
 	return prov.Catalog(), nil
 }
 
-func resolveExecutableCatalog(ctx context.Context, name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, spec *providermanifestv1.Spec, allowed map[string]*config.OperationOverride) (*catalog.Catalog, bool, error) {
+func resolveExecutableCatalog(ctx context.Context, name string, entry *ValidationPlugin, manifest *providermanifestv1.Manifest, spec *providermanifestv1.Spec, allowed map[string]*OperationOverride) (*catalog.Catalog, bool, error) {
 	pluginCatalog, err := readStaticCatalog(name, entry, manifest)
 	if err != nil {
 		return nil, false, err
@@ -252,7 +256,7 @@ func resolveExecutableCatalog(ctx context.Context, name string, entry *config.Pr
 	if err != nil {
 		return nil, false, fmt.Errorf("plugin %q API catalog: %w", name, err)
 	}
-	_, hasMCP := resolvedSurfaceURL(entry, spec, config.SpecSurfaceMCP)
+	_, hasMCP := resolvedSurfaceURL(entry, spec, SpecSurfaceMCP)
 	merged, err := mergeCatalogs(name, filteredPluginCatalog, filteredAPICatalog)
 	if err != nil {
 		return nil, false, err
@@ -260,42 +264,41 @@ func resolveExecutableCatalog(ctx context.Context, name string, entry *config.Pr
 	return merged, hasMCP && merged == nil, nil
 }
 
-func readStaticCatalog(name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest) (*catalog.Catalog, error) {
-	if entry == nil || entry.ResolvedManifestPath == "" {
-		if providerpkg.StaticCatalogRequired(manifest) {
-			return nil, fmt.Errorf("plugin %q requires %s", name, providerpkg.StaticCatalogFile)
+func readStaticCatalog(name string, entry *ValidationPlugin, manifest *providermanifestv1.Manifest) (*catalog.Catalog, error) {
+	if entry == nil || entry.ReadStaticCatalog == nil {
+		if staticCatalogRequired(manifest) {
+			return nil, fmt.Errorf("plugin %q requires %s", name, StaticCatalogFile)
 		}
 		return nil, nil
 	}
-	cat, err := providerpkg.ReadStaticCatalog(filepath.Dir(entry.ResolvedManifestPath), name)
+	cat, err := entry.ReadStaticCatalog(name)
 	if err != nil {
 		return nil, fmt.Errorf("plugin %q static catalog: %w", name, err)
 	}
-	if cat == nil && providerpkg.StaticCatalogRequired(manifest) {
-		return nil, fmt.Errorf("plugin %q requires %s", name, providerpkg.StaticCatalogFile)
+	if cat == nil && staticCatalogRequired(manifest) {
+		return nil, fmt.Errorf("plugin %q requires %s", name, StaticCatalogFile)
 	}
 	return cat, nil
 }
 
-func loadConfiguredAPICatalog(ctx context.Context, name string, entry *config.ProviderEntry, spec *providermanifestv1.Spec, allowed map[string]*config.OperationOverride) (*catalog.Catalog, error) {
+func loadConfiguredAPICatalog(ctx context.Context, name string, entry *ValidationPlugin, spec *providermanifestv1.Spec, allowed map[string]*OperationOverride) (*catalog.Catalog, error) {
 	var merged *catalog.Catalog
-	for _, surface := range []config.SpecSurface{config.SpecSurfaceOpenAPI, config.SpecSurfaceGraphQL} {
+	for _, surface := range []SpecSurface{SpecSurfaceOpenAPI, SpecSurfaceGraphQL} {
 		url, ok := resolvedSurfaceURL(entry, spec, surface)
 		if !ok {
 			continue
 		}
-		if surface == config.SpecSurfaceGraphQL {
+		if surface == SpecSurfaceGraphQL {
 			continue
 		}
-		var (
-			def *declarative.Definition
-			err error
-		)
-		def, err = openapi.LoadDefinition(ctx, name, url, allowed)
+		if entry == nil || entry.LoadAPICatalog == nil {
+			return nil, fmt.Errorf("plugin %q %s catalog loader is not configured", name, surface)
+		}
+		apiCatalog, err := entry.LoadAPICatalog(ctx, name, surface, url, allowed)
 		if err != nil {
 			return nil, fmt.Errorf("plugin %q %s catalog: %w", name, surface, err)
 		}
-		merged, err = mergeCatalogs(name, merged, declarative.CatalogFromDefinition(def))
+		merged, err = mergeCatalogs(name, merged, apiCatalog)
 		if err != nil {
 			return nil, err
 		}
@@ -303,18 +306,11 @@ func loadConfiguredAPICatalog(ctx context.Context, name string, entry *config.Pr
 	return merged, nil
 }
 
-func resolvedSurfaceURL(entry *config.ProviderEntry, spec *providermanifestv1.Spec, surface config.SpecSurface) (string, bool) {
-	if url := config.ProviderSurfaceURLOverride(entry, surface); url != "" {
-		return url, true
-	}
-	url := config.ManifestProviderSurfaceURL(spec, surface)
-	if url == "" {
-		return "", false
-	}
-	return config.ResolveManifestRelativeSpecURL(entry, url), true
+func resolvedSurfaceURL(entry *ValidationPlugin, spec *providermanifestv1.Spec, surface SpecSurface) (string, bool) {
+	return entry.surfaceURL(spec, surface)
 }
 
-func applyOperationExposure(cat *catalog.Catalog, allowed map[string]*config.OperationOverride) (*catalog.Catalog, error) {
+func applyOperationExposure(cat *catalog.Catalog, allowed map[string]*OperationOverride) (*catalog.Catalog, error) {
 	if cat == nil {
 		return nil, nil
 	}
@@ -331,7 +327,7 @@ func applyOperationExposure(cat *catalog.Catalog, allowed map[string]*config.Ope
 	return policy.ApplyCatalog(cat), nil
 }
 
-func validateAllowedOperationCoverage(name string, allowed map[string]*config.OperationOverride, catalogs ...*catalog.Catalog) error {
+func validateAllowedOperationCoverage(name string, allowed map[string]*OperationOverride, catalogs ...*catalog.Catalog) error {
 	if len(allowed) == 0 {
 		return nil
 	}
@@ -388,7 +384,7 @@ func hasCatalogOperation(cat *catalog.Catalog, operation string) bool {
 	return false
 }
 
-func effectiveAllowedOperations(entry *config.ProviderEntry, spec *providermanifestv1.Spec) map[string]*config.OperationOverride {
+func effectiveAllowedOperations(entry *ValidationPlugin, spec *providermanifestv1.Spec) map[string]*OperationOverride {
 	if entry != nil && entry.AllowedOperations != nil {
 		return entry.AllowedOperations
 	}

--- a/gestaltd/services/plugins/validation_types.go
+++ b/gestaltd/services/plugins/validation_types.go
@@ -1,0 +1,107 @@
+package plugins
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/operationexposure"
+)
+
+type OperationOverride = operationexposure.OperationOverride
+
+type SpecSurface string
+
+const (
+	SpecSurfaceOpenAPI SpecSurface = "openapi"
+	SpecSurfaceGraphQL SpecSurface = "graphql"
+	SpecSurfaceMCP     SpecSurface = "mcp"
+
+	StaticCatalogFile = "catalog.yaml"
+)
+
+type InvocationDependency struct {
+	Plugin    string
+	Operation string
+	Surface   SpecSurface
+}
+
+type StaticCatalogReader func(name string) (*catalog.Catalog, error)
+
+type APICatalogLoader func(ctx context.Context, name string, surface SpecSurface, specURL string, allowed map[string]*OperationOverride) (*catalog.Catalog, error)
+
+type ValidationConfig struct {
+	Plugins map[string]*ValidationPlugin
+}
+
+type ValidationPlugin struct {
+	Manifest            *providermanifestv1.Manifest
+	ManifestPath        string
+	AllowedOperations   map[string]*OperationOverride
+	Invokes             []InvocationDependency
+	SurfaceURLOverrides map[SpecSurface]string
+	ReadStaticCatalog   StaticCatalogReader
+	LoadAPICatalog      APICatalogLoader
+}
+
+func (p *ValidationPlugin) manifestSpec() *providermanifestv1.Spec {
+	if p == nil || p.Manifest == nil {
+		return nil
+	}
+	return p.Manifest.Spec
+}
+
+func (p *ValidationPlugin) surfaceURL(spec *providermanifestv1.Spec, surface SpecSurface) (string, bool) {
+	if p == nil {
+		return "", false
+	}
+	if p.SurfaceURLOverrides != nil {
+		if url := strings.TrimSpace(p.SurfaceURLOverrides[surface]); url != "" {
+			return url, true
+		}
+	}
+	url := manifestProviderSurfaceURL(spec, surface)
+	if url == "" {
+		return "", false
+	}
+	return resolveManifestRelativeSpecURL(p.ManifestPath, url), true
+}
+
+func manifestProviderSurfaceURL(provider *providermanifestv1.Spec, surface SpecSurface) string {
+	if provider == nil {
+		return ""
+	}
+	switch surface {
+	case SpecSurfaceOpenAPI:
+		return provider.OpenAPIDocument()
+	case SpecSurfaceGraphQL:
+		return provider.GraphQLURL()
+	case SpecSurfaceMCP:
+		return provider.MCPURL()
+	default:
+		return ""
+	}
+}
+
+func resolveManifestRelativeSpecURL(manifestPath, raw string) string {
+	if manifestPath == "" || raw == "" {
+		return raw
+	}
+	if filepath.IsAbs(raw) || strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		return raw
+	}
+	if strings.HasPrefix(raw, "file://") {
+		path := strings.TrimPrefix(raw, "file://")
+		if filepath.IsAbs(path) {
+			return raw
+		}
+		return "file://" + filepath.Clean(filepath.Join(filepath.Dir(manifestPath), path))
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(manifestPath), raw))
+}
+
+func staticCatalogRequired(manifest *providermanifestv1.Manifest) bool {
+	return manifest != nil && manifest.Kind == providermanifestv1.KindPlugin && manifest.Spec != nil && !manifest.Spec.IsManifestBacked()
+}


### PR DESCRIPTION
## Summary

Moves plugin catalog/dependency validation onto service-owned primitives so `gestaltd/services/plugins/validation.go` no longer imports `server/internal/*`. Internal config, OpenAPI, provider package, and declarative definition conversion concerns live in `internal/pluginvalidation`, which adapts config entries and staged manifests into the service validation contract.

## Interface Changes

- New/changed service interface:
  - `plugins.ValidationConfig{Plugins map[string]*plugins.ValidationPlugin}`
  - `plugins.ValidationPlugin{Manifest, ManifestPath, AllowedOperations, Invokes, SurfaceURLOverrides, ReadStaticCatalog, LoadAPICatalog}`
  - `plugins.ValidateEffectiveCatalog(ctx, name, *ValidationPlugin)`
  - `plugins.ValidateEffectiveCatalogs(ctx, *ValidationConfig)`
  - `plugins.ValidateEffectiveCatalogsAndDependencies(ctx, *ValidationConfig)`
  - `plugins.ValidateDependencies(ctx, *ValidationConfig)`
- New internal adapter:
  - `pluginvalidation.FromConfig(cfg)`
  - `pluginvalidation.FromProviderEntry(entry)`
  - `pluginvalidation.FromManifest(path, manifest)`
  - `pluginvalidation.ValidateEffectiveManifest(ctx, name, path, manifest)`
  - config-facing validation wrappers for bootstrap/operator/daemon call sites

Example service usage:

```go
validator := pluginvalidation.FromConfig(cfg)
err := plugins.ValidateEffectiveCatalogsAndDependencies(ctx, validator)
```

Example staged manifest validation:

```go
err := pluginvalidation.ValidateEffectiveManifest(ctx, pluginName, manifestPath, manifest)
```

## Functional/Integration Tests

- Tests added or augmented: none; this is a boundary refactor covered by existing validation paths.
- Contract boundary covered: config/provider package/OpenAPI adapter -> service-owned plugin validation contract -> bootstrap/operator/daemon validation flows.
- Commands run:
  - `cd gestaltd && rg -n '"github.com/valon-technologies/gestalt/server/internal/' services/plugins/validation.go services/plugins/validation_types.go`
  - `cd gestaltd && go test ./services/plugins ./internal/pluginvalidation ./internal/bootstrap ./internal/operator ./internal/daemon`
  - `cd gestaltd && go test ./internal/operator -run 'TestPrepareAtPath_AllowsInvokesAgainstEffectiveAlias|TestPrepareAtPath_RejectsHybridExecutableStaticOperationByOriginalNameAfterAlias|TestPrepareAtPath_RejectsHybridExecutableDuplicateEffectiveOperation|TestPrepareAtPath_RejectsSessionCatalogOnlyInvokesTarget|TestPrepareAtPath_DoesNotWriteLockfileWhenInvokesValidationFails|TestPrepareAtPath_RejectsHybridMCPTypoAsUnknownOperation'`
  - `cd gestaltd && go test ./internal/bootstrap -run 'TestValidate'`
  - `cd gestaltd && go test ./internal/daemon -run TestE2EValidateRejectsInvalidPluginInvokesDependency`
  - `cd gestaltd && golangci-lint run ./services/plugins/... ./internal/pluginvalidation/... ./internal/bootstrap ./internal/operator ./internal/daemon`

Reviewer agent found no blocking issues. Code review feedback about `FromManifest` is applied by routing staged manifest validation through `ValidateEffectiveManifest`.