### PR TITLE
gestaltd: require public host-service relay bindings

### DIFF
--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -406,17 +406,15 @@ func cloneStringMap(values map[string]string) map[string]string {
 
 func normalizeHostServiceBinding(req BindHostServiceRequest) (HostServiceRelay, string, error) {
 	if relay := req.Relay; relay.DialTarget != "" {
-		network, address, err := dialTarget(relay.DialTarget)
+		network, _, err := dialTarget(relay.DialTarget)
 		if err != nil {
 			return HostServiceRelay{}, "", fmt.Errorf("host service relay: %w", err)
 		}
 		switch network {
-		case "unix":
-			return relay, address, nil
 		case "tcp", "tls":
 			return relay, relay.DialTarget, nil
 		default:
-			return HostServiceRelay{}, "", fmt.Errorf("host service relay network %q is not supported", network)
+			return HostServiceRelay{}, "", fmt.Errorf("host service relay network %q is not supported; expected tcp or tls", network)
 		}
 	}
 	return HostServiceRelay{}, "", fmt.Errorf("host service relay is required")

--- a/gestaltd/internal/pluginruntime/local_test.go
+++ b/gestaltd/internal/pluginruntime/local_test.go
@@ -107,3 +107,50 @@ func TestLocalProviderCapturesRuntimeSessionLogsOnPluginStartupFailure(t *testin
 		t.Fatalf("ListSessionLogs after stop len = %d, want %d", len(retained), len(logs))
 	}
 }
+
+func TestLocalProviderBindHostServiceRequiresPublicRelayTarget(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewLocalProvider()
+	t.Cleanup(func() {
+		_ = runtime.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := runtime.StartSession(ctx, StartSessionRequest{PluginName: "relay-target-test"})
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	for _, dialTarget := range []string{"tcp://127.0.0.1:8080", "tls://gestalt.example.test:443"} {
+		binding, err := runtime.BindHostService(ctx, BindHostServiceRequest{
+			SessionID: session.ID,
+			EnvVar:    "GESTALT_TEST_SOCKET",
+			Relay: HostServiceRelay{
+				DialTarget: dialTarget,
+			},
+		})
+		if err != nil {
+			t.Fatalf("BindHostService(%s): %v", dialTarget, err)
+		}
+		if got := binding.Relay.DialTarget; got != dialTarget {
+			t.Fatalf("BindHostService(%s) relay target = %q, want %q", dialTarget, got, dialTarget)
+		}
+	}
+
+	_, err = runtime.BindHostService(ctx, BindHostServiceRequest{
+		SessionID: session.ID,
+		EnvVar:    "GESTALT_TEST_SOCKET",
+		Relay: HostServiceRelay{
+			DialTarget: "unix:///tmp/gestalt-host.sock",
+		},
+	})
+	if err == nil {
+		t.Fatal("BindHostService(unix) succeeded, want rejection")
+	}
+	if !strings.Contains(err.Error(), `host service relay network "unix" is not supported`) {
+		t.Fatalf("BindHostService(unix) error = %q, want unsupported unix relay target", err)
+	}
+}


### PR DESCRIPTION
## Summary
- reject `unix://` host-service relay targets in the local hosted runtime provider
- keep callback bindings on public `tcp://` / `tls://` relay targets so hosted plugins no longer receive raw socket callback endpoints
- add a provider contract test covering accepted public relay targets and rejected Unix relay targets

## Tests
- `go test ./internal/pluginruntime -count=1`
- `go test ./internal/bootstrap ./internal/server -count=1`
- `golangci-lint run ./internal/pluginruntime`
- `go test ./...` (one unrelated bootstrap timing test failed locally; all other packages passed)
- `go test ./internal/bootstrap -run 'TestAgentRuntimeConfig(KeepsHostedAgentServingWhenProactiveReplacementStartFails|ReplacesHostedAgentBeforeRuntimeDrainDeadline)$' -count=1 -v`\n- `go test ./internal/bootstrap -count=1 -parallel=1`