### PR TITLE
gestaltd: require verified public host services

### DIFF
--- a/gestaltd/internal/bootstrap/plugin_runtime.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 )
 
 type pluginRuntimeRegistry struct {
@@ -55,7 +56,7 @@ func (r *pluginRuntimeRegistry) VerifyPluginRuntimeSession(ctx context.Context, 
 		return fmt.Errorf("runtime provider owner is required")
 	}
 	if r == nil || r.cfg == nil {
-		return fmt.Errorf("plugin runtime registry is not configured")
+		return fmt.Errorf("%w: plugin runtime registry is not configured", runtimehost.ErrProviderNotHostedRuntime)
 	}
 
 	effective, err := r.effectiveHostedRuntimeForProvider(providerName)
@@ -63,7 +64,7 @@ func (r *pluginRuntimeRegistry) VerifyPluginRuntimeSession(ctx context.Context, 
 		return err
 	}
 	if !effective.Enabled || strings.TrimSpace(effective.ProviderName) == "" {
-		return fmt.Errorf("provider %q does not use a hosted runtime", providerName)
+		return fmt.Errorf("%w: provider %q", runtimehost.ErrProviderNotHostedRuntime, providerName)
 	}
 
 	r.mu.Lock()
@@ -93,7 +94,7 @@ func (r *pluginRuntimeRegistry) effectiveHostedRuntimeForProvider(providerName s
 	if entry := r.cfg.Providers.Agent[providerName]; entry != nil {
 		return r.cfg.EffectiveHostedRuntime("providers.agent."+providerName, entry)
 	}
-	return config.EffectiveHostedRuntime{}, fmt.Errorf("provider %q does not have a hosted runtime configuration", providerName)
+	return config.EffectiveHostedRuntime{}, fmt.Errorf("%w: provider %q does not have a hosted runtime configuration", runtimehost.ErrProviderNotHostedRuntime, providerName)
 }
 
 func (r *pluginRuntimeRegistry) resolveConfigured(ctx context.Context, effective config.EffectiveHostedRuntime) (pluginruntime.Provider, error) {

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -37,6 +38,9 @@ func validatePublicHostServices(services []runtimehost.PublicHostService) error 
 		key, ok := publicHostServiceHandlerKey(service)
 		if !ok {
 			continue
+		}
+		if key.sessionID == "" && service.SessionVerifier == nil {
+			return fmt.Errorf("public host service %s requires a session verifier", key.String())
 		}
 		entry := hostServiceHandlerEntry{verifier: service.SessionVerifier}
 		if err := appendHostServiceHandlerEntry(handlers, key, entry); err != nil {
@@ -180,16 +184,17 @@ func (s *Server) coreRoutableHostServiceHandlerEntry(ctx context.Context, target
 }
 
 func (s *Server) verifyCoreRoutableHostServiceSession(ctx context.Context, target runtimehost.HostServiceRelayTarget) error {
+	pluginName := strings.TrimSpace(target.PluginName)
+	verifier, ok := s.pluginRuntimes.(pluginRuntimeSessionVerifier)
+	if ok && verifier != nil {
+		if err := verifier.VerifyPluginRuntimeSession(ctx, pluginName, target.SessionID); !errors.Is(err, runtimehost.ErrProviderNotHostedRuntime) {
+			return err
+		}
+	}
 	if ok, err := s.verifyRegisteredCoreRoutableHostServiceSession(ctx, target); ok || err != nil {
 		return err
 	}
-
-	pluginName := strings.TrimSpace(target.PluginName)
-	verifier, ok := s.pluginRuntimes.(pluginRuntimeSessionVerifier)
-	if !ok || verifier == nil {
-		return fmt.Errorf("plugin runtime session verifier is not configured")
-	}
-	return verifier.VerifyPluginRuntimeSession(ctx, pluginName, target.SessionID)
+	return fmt.Errorf("plugin runtime session verifier is not configured")
 }
 
 func (s *Server) verifyRegisteredCoreRoutableHostServiceSession(ctx context.Context, target runtimehost.HostServiceRelayTarget) (bool, error) {
@@ -327,6 +332,9 @@ func (s *Server) hostServiceHandlerEntry(ctx context.Context, key hostServiceHan
 		serviceKey, ok := publicHostServiceHandlerKey(service)
 		if !ok || serviceKey != key {
 			continue
+		}
+		if serviceKey.sessionID == "" && service.SessionVerifier == nil {
+			return hostServiceHandlerEntry{}, true, false, fmt.Errorf("public host service %s requires a session verifier", key.String())
 		}
 		entry, ok := s.publicHostServiceHandlerEntry(service)
 		if !ok {

--- a/gestaltd/internal/server/host_service_public_test.go
+++ b/gestaltd/internal/server/host_service_public_test.go
@@ -32,15 +32,14 @@ func TestHostServiceHandlerDoesNotFallbackWhenExactSessionEntryFails(t *testing.
 	}
 }
 
-func TestValidatePublicHostServicesRejectsDuplicateUnverifiedServices(t *testing.T) {
+func TestValidatePublicHostServicesRejectsProviderWideServiceWithoutVerifier(t *testing.T) {
 	t.Parallel()
 
 	err := validatePublicHostServices([]runtimehost.PublicHostService{
 		testPublicHostService("support", nil),
-		testPublicHostService("support", nil),
 	})
-	if err == nil || !strings.Contains(err.Error(), "duplicate public host service support/cache/GESTALT_TEST_CACHE_SOCKET") {
-		t.Fatalf("validatePublicHostServices err = %v, want duplicate public host service", err)
+	if err == nil || !strings.Contains(err.Error(), "public host service support/cache/GESTALT_TEST_CACHE_SOCKET requires a session verifier") {
+		t.Fatalf("validatePublicHostServices err = %v, want missing verifier failure", err)
 	}
 }
 
@@ -56,20 +55,37 @@ func TestValidatePublicHostServicesAllowsDuplicateVerifiedServices(t *testing.T)
 	}
 }
 
-func TestHostServiceHandlerEntryRejectsDynamicDuplicateUnverifiedServices(t *testing.T) {
+func TestValidatePublicHostServicesAllowsSessionServiceWithoutVerifier(t *testing.T) {
+	t.Parallel()
+
+	err := validatePublicHostServices([]runtimehost.PublicHostService{{
+		PluginName: "support",
+		SessionID:  "session-1",
+		Service:    testHostService(),
+	}})
+	if err != nil {
+		t.Fatalf("validatePublicHostServices: %v", err)
+	}
+}
+
+func TestRegisterSessionRejectsBlankSessionID(t *testing.T) {
 	t.Parallel()
 
 	registry := runtimehost.NewPublicHostServiceRegistry()
-	registry.Register("support", testHostService(), testHostService())
+	registry.RegisterSession("support", "", testHostService())
 	s := &Server{publicHostServices: registry}
 	key := hostServiceHandlerKey{
 		pluginName: "support",
 		service:    "cache",
 		envVar:     "GESTALT_TEST_CACHE_SOCKET",
 	}
-	_, _, _, err := s.hostServiceHandlerEntry(context.Background(), key, "")
-	if err == nil || !strings.Contains(err.Error(), "duplicate public host service support/cache/GESTALT_TEST_CACHE_SOCKET") {
-		t.Fatalf("hostServiceHandlerEntry err = %v, want duplicate public host service", err)
+
+	_, found, ok, err := s.hostServiceHandlerEntry(context.Background(), key, "session-1")
+	if err != nil {
+		t.Fatalf("hostServiceHandlerEntry: %v", err)
+	}
+	if found || ok {
+		t.Fatalf("hostServiceHandlerEntry found=%v ok=%v, want no dynamic provider-wide registration", found, ok)
 	}
 }
 

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -107,7 +107,7 @@ func TestNewHTTPServerSupportsH2CHostServiceRelay(t *testing.T) {
 	cacheSrv := &runtimeTestCacheServer{}
 	const envVar = "GESTALT_TEST_CACHE_SOCKET"
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	publicHostServices.Register("relay-plugin", runtimehost.HostService{
+	publicHostServices.RegisterVerified("relay-plugin", allowHostServiceSessionVerifier{}, runtimehost.HostService{
 		Name:   "cache",
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -623,6 +623,20 @@ func (v *relayTestRuntimeSessionVerifier) ListPluginRuntimeSessionLogs(context.C
 	return nil, nil
 }
 
+type nonHostedRuntimeSessionVerifier struct{}
+
+func (nonHostedRuntimeSessionVerifier) VerifyPluginRuntimeSession(context.Context, string, string) error {
+	return runtimehost.ErrProviderNotHostedRuntime
+}
+
+func (nonHostedRuntimeSessionVerifier) SnapshotPluginRuntimes(context.Context) ([]bootstrap.RuntimeProviderSnapshot, error) {
+	return nil, nil
+}
+
+func (nonHostedRuntimeSessionVerifier) ListPluginRuntimeSessionLogs(context.Context, string, string, int64, int) ([]runtimelogs.Record, error) {
+	return nil, nil
+}
+
 func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	t.Parallel()
 
@@ -868,7 +882,7 @@ func TestHostServiceRelayCoreRoutableTokenDoesNotUseNonCoreRegistry(t *testing.T
 			proto.RegisterCacheServer(srv, cacheSrv)
 		},
 	}
-	publicHostServices.Register("support", hostService)
+	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("session-1"), hostService)
 
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfilePublic
@@ -929,7 +943,7 @@ func TestHostServiceRelayCoreRoutablePluginInvokerIgnoresRegistry(t *testing.T) 
 		t.Fatalf("NewInvocationTokenManager registry: %v", err)
 	}
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	publicHostServices.Register("support", runtimehost.HostService{
+	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("session-core"), runtimehost.HostService{
 		Name:   "plugin_invoker",
 		EnvVar: plugininvokerservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
@@ -1111,6 +1125,89 @@ func TestHostServiceRelayRejectsCoreRoutableWithoutRuntimeVerifier(t *testing.T)
 	}
 }
 
+func TestHostServiceRelayCoreRoutableProviderDevUsesRegisteredSessionVerifier(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	pluginInvoker := &relayTestInvoker{}
+	invokes := []invocation.PluginInvocationDependency{{
+		Plugin:         "slack",
+		Operation:      "events.reply",
+		CredentialMode: core.ConnectionModeNone,
+	}}
+	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
+	publicHostServices.RegisterSession("support", "provider-dev-session", runtimehost.HostService{
+		Name:   "plugin_invoker",
+		EnvVar: plugininvokerservice.DefaultSocketEnv,
+		Register: func(*grpc.Server) {
+		},
+	})
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+		cfg.Invoker = pluginInvoker
+		cfg.PluginInvoker = pluginInvoker
+		cfg.PluginRuntimes = nonHostedRuntimeSessionVerifier{}
+		cfg.PublicHostServices = publicHostServices
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"support": {Invokes: configPluginInvocationDependencies(invokes)},
+		}
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "provider-dev-session",
+		Service:      "plugin_invoker",
+		EnvVar:       plugininvokerservice.DefaultSocketEnv,
+		MethodPrefix: "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/",
+		CoreRoutable: true,
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+	invocationTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "user:test-user",
+		UserID:    "test-user",
+		Kind:      principal.KindUser,
+		Source:    principal.SourceSession,
+	})
+	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "support", plugininvokerservice.InvocationDependencyGrants(invokes))
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+	_, err = proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{
+		InvocationToken: invocationToken,
+		Plugin:          "slack",
+		Operation:       "events.reply",
+		Instance:        "prod",
+		IdempotencyKey:  "provider-dev-call",
+	})
+	if err != nil {
+		t.Fatalf("PluginInvoker.Invoke via provider-dev core relay: %v", err)
+	}
+	if call := pluginInvoker.snapshot(); call.calls != 1 || call.providerName != "slack" || call.operation != "events.reply" {
+		t.Fatalf("plugin invoker call = %+v, want slack events.reply", call)
+	}
+}
+
 func TestHostServiceRelayRejectsRegisteredCoreServiceWithoutCoreRoutableToken(t *testing.T) {
 	t.Parallel()
 
@@ -1126,7 +1223,7 @@ func TestHostServiceRelayRejectsRegisteredCoreServiceWithoutCoreRoutableToken(t 
 		t.Fatalf("NewInvocationTokenManager: %v", err)
 	}
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	publicHostServices.Register("support", runtimehost.HostService{
+	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("provider-dev-session"), runtimehost.HostService{
 		Name:   "plugin_invoker",
 		EnvVar: plugininvokerservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
@@ -1536,7 +1633,7 @@ func TestHostServiceRelayRejectsMethodOutsideTokenPrefix(t *testing.T) {
 	cacheSrv := &relayTestCacheServer{}
 	const envVar = "GESTALT_TEST_CACHE_SOCKET"
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	publicHostServices.Register("support", runtimehost.HostService{
+	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("session-1"), runtimehost.HostService{
 		Name:   "cache",
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
@@ -1588,7 +1685,7 @@ func TestHostServiceRelaySupportsIndexedDBSDKClient(t *testing.T) {
 	secret := []byte("relay-test-secret-0123456789abcd")
 	stubDB := &coretesting.StubIndexedDB{}
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	publicHostServices.Register("relay-plugin", runtimehost.HostService{
+	publicHostServices.RegisterVerified("relay-plugin", newRelayTestSessionVerifier("session-1"), runtimehost.HostService{
 		Name:   "indexeddb",
 		EnvVar: indexeddbservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {

--- a/gestaltd/services/runtimehost/public_host_service.go
+++ b/gestaltd/services/runtimehost/public_host_service.go
@@ -2,9 +2,14 @@ package runtimehost
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 )
+
+// ErrProviderNotHostedRuntime means a public host-service callback did not
+// belong to a provider backed by a hosted runtime.
+var ErrProviderNotHostedRuntime = errors.New("provider does not use a hosted runtime")
 
 type PublicHostServiceSessionVerifier interface {
 	VerifyHostServiceSession(context.Context, string) error
@@ -30,15 +35,18 @@ func NewPublicHostServiceRegistry() *PublicHostServiceRegistry {
 	return &PublicHostServiceRegistry{}
 }
 
-func (r *PublicHostServiceRegistry) Register(pluginName string, services ...HostService) {
-	r.RegisterVerified(pluginName, nil, services...)
-}
-
 func (r *PublicHostServiceRegistry) RegisterVerified(pluginName string, verifier PublicHostServiceSessionVerifier, services ...HostService) {
+	if verifier == nil {
+		return
+	}
 	r.register(pluginName, "", verifier, services...)
 }
 
 func (r *PublicHostServiceRegistry) RegisterSession(pluginName, sessionID string, services ...HostService) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return
+	}
 	r.register(pluginName, sessionID, nil, services...)
 }
 


### PR DESCRIPTION
## Summary
- remove unverified provider-wide public host-service registration
- require provider-wide public host services to carry a session verifier at validation and lookup time
- prefer hosted runtime session verification for core-routable callbacks, falling back to registered provider-dev verification only when the provider is not backed by a hosted runtime
- reject blank exact-session registrations so they cannot become provider-wide entries

## Tests
- `go test ./internal/server ./services/runtimehost -count=1`
- `go test ./internal/bootstrap -run 'TestProviderDevRuntimeEnvUsesPublicHostServiceRelay|TestPluginRuntime|TestHosted|TestAgentRuntime' -count=1`\n- `go test ./internal/server ./internal/bootstrap ./internal/providerdev ./services/runtimehost -count=1` hit existing hosted-agent timing flakes in bootstrap under default parallelism; server/providerdev/runtimehost passed\n- `go test ./internal/bootstrap -count=1 -parallel=1`\n- `go test ./internal/providerdev -count=1`\n- `golangci-lint run ./internal/server ./services/runtimehost ./internal/bootstrap`\n\nReviewer: gpt-5.5 xhigh reviewed the initial diff, I applied both findings, and the follow-up review reported no findings.