### PR TITLE
Move plugin source parsing into plugins service

### DIFF
--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -13,10 +13,10 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	"github.com/valon-technologies/gestalt/server/internal/pluginvalidation"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/source"
 	"gopkg.in/yaml.v3"
 )
 
@@ -109,7 +109,7 @@ func runProviderRelease(args []string) (err error) {
 		return fmt.Errorf("--version is required")
 	}
 
-	if err := pluginsource.ValidateVersion(*version); err != nil {
+	if err := source.ValidateVersion(*version); err != nil {
 		return fmt.Errorf("invalid --version: %w", err)
 	}
 
@@ -148,7 +148,7 @@ func runProviderRelease(args []string) (err error) {
 	if err := providerpkg.EnsureSourceStaticCatalog(manifestPath, releaseManifest); err != nil {
 		return err
 	}
-	src, err := pluginsource.Parse(releaseManifest.Source)
+	src, err := source.Parse(releaseManifest.Source)
 	if err != nil {
 		return fmt.Errorf("invalid source in manifest: %w", err)
 	}
@@ -409,7 +409,7 @@ func validateStagedReleaseCatalog(staged *providerpkg.StagedPreparedInstall) err
 	if staged == nil || staged.Manifest == nil || staged.Manifest.Kind != providermanifestv1.KindPlugin {
 		return nil
 	}
-	src, err := pluginsource.Parse(staged.Manifest.Source)
+	src, err := source.Parse(staged.Manifest.Source)
 	if err != nil {
 		return fmt.Errorf("invalid source in staged manifest: %w", err)
 	}

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -27,10 +27,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
-	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"github.com/valon-technologies/gestalt/server/internal/ui"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/source"
 	"github.com/valon-technologies/gestalt/server/services/providerdev"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"gopkg.in/yaml.v3"
@@ -1429,7 +1429,7 @@ func canonicalPath(path string) (string, error) {
 
 func derivedPluginKey(manifest *providermanifestv1.Manifest, manifestPath string) string {
 	if manifest != nil {
-		if src, err := pluginsource.Parse(manifest.Source); err == nil {
+		if src, err := source.Parse(manifest.Source); err == nil {
 			if name := sanitizeDerivedPluginKey(src.PluginName()); name != "" {
 				return name
 			}
@@ -1473,7 +1473,7 @@ func defaultProviderLocalMountPath(manifest *providermanifestv1.Manifest, manife
 
 func derivedProviderLocalMountSlug(manifest *providermanifestv1.Manifest, manifestPath string) string {
 	if manifest != nil {
-		if src, err := pluginsource.Parse(manifest.Source); err == nil {
+		if src, err := source.Parse(manifest.Source); err == nil {
 			if slug := strings.TrimSpace(src.PluginName()); slug != "" {
 				return slug
 			}

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -17,9 +17,9 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/source"
 	"gopkg.in/yaml.v3"
 )
 
@@ -105,10 +105,10 @@ func validateProviderReleaseMetadata(metadata *providerReleaseMetadata) error {
 	if metadata.SchemaVersion != providerReleaseSchemaVersion {
 		return fmt.Errorf("unsupported provider release schema version %d", metadata.SchemaVersion)
 	}
-	if _, err := pluginsource.Parse(strings.TrimSpace(metadata.Package)); err != nil {
+	if _, err := source.Parse(strings.TrimSpace(metadata.Package)); err != nil {
 		return fmt.Errorf("provider release package: %w", err)
 	}
-	if err := pluginsource.ValidateVersion(strings.TrimSpace(metadata.Version)); err != nil {
+	if err := source.ValidateVersion(strings.TrimSpace(metadata.Version)); err != nil {
 		return fmt.Errorf("provider release version: %w", err)
 	}
 	switch metadata.Kind {

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/httpbinding"
-	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/source"
 	"gopkg.in/yaml.v3"
 )
 
@@ -126,10 +126,10 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 	if manifest.Source == "" {
 		return fmt.Errorf("manifest source is required")
 	}
-	if _, err := pluginsource.Parse(manifest.Source); err != nil {
+	if _, err := source.Parse(manifest.Source); err != nil {
 		return fmt.Errorf("manifest source: %w", err)
 	}
-	if err := pluginsource.ValidateVersion(manifest.Version); err != nil {
+	if err := source.ValidateVersion(manifest.Version); err != nil {
 		return fmt.Errorf("manifest version: %w", err)
 	}
 	if manifest.IconFile != "" {

--- a/gestaltd/internal/providerpkg/prepared_stage.go
+++ b/gestaltd/internal/providerpkg/prepared_stage.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/source"
 )
 
 const (
@@ -115,7 +115,7 @@ func StagePreparedInstallDir(manifestPath, stagingDir string, opts StagePrepared
 	}
 	pluginName := strings.TrimSpace(opts.PluginName)
 	if pluginName == "" {
-		src, err := pluginsource.Parse(srcManifest.Source)
+		src, err := source.Parse(srcManifest.Source)
 		if err != nil {
 			return nil, fmt.Errorf("invalid source in manifest: %w", err)
 		}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -17,8 +17,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	gestaltmcp "github.com/valon-technologies/gestalt/server/internal/mcp"
-	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/plugins/source"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
@@ -285,7 +285,7 @@ func newMCPHandler(cfg *config.Config, connMaps bootstrap.ConnectionMaps, result
 			continue
 		}
 		if entry.ResolvedManifest != nil {
-			if src, err := pluginsource.Parse(strings.TrimSpace(entry.ResolvedManifest.Source)); err == nil {
+			if src, err := source.Parse(strings.TrimSpace(entry.ResolvedManifest.Source)); err == nil {
 				toolPrefixes[name] = src.PluginName() + "_"
 			}
 		}

--- a/gestaltd/services/plugins/source/source.go
+++ b/gestaltd/services/plugins/source/source.go
@@ -1,4 +1,4 @@
-package pluginsource
+package source
 
 import (
 	"fmt"
@@ -27,23 +27,23 @@ type Source struct {
 
 func Parse(raw string) (Source, error) {
 	if raw != strings.TrimSpace(raw) {
-		return Source{}, fmt.Errorf("pluginsource: input contains leading or trailing whitespace")
+		return Source{}, fmt.Errorf("plugin source: input contains leading or trailing whitespace")
 	}
 
 	parts := strings.Split(raw, "/")
 	if len(parts) < minSegmentCount {
-		return Source{}, fmt.Errorf("pluginsource: expected at least %d segments, got %d", minSegmentCount, len(parts))
+		return Source{}, fmt.Errorf("plugin source: expected at least %d segments, got %d", minSegmentCount, len(parts))
 	}
 
 	host, owner, repo := parts[0], parts[1], parts[2]
 
 	if host != HostGitHub {
-		return Source{}, fmt.Errorf("pluginsource: unsupported host %q (only %s is supported)", host, HostGitHub)
+		return Source{}, fmt.Errorf("plugin source: unsupported host %q (only %s is supported)", host, HostGitHub)
 	}
 
 	for _, seg := range parts[1:] {
 		if !segmentRe.MatchString(seg) {
-			return Source{}, fmt.Errorf("pluginsource: invalid segment %q", seg)
+			return Source{}, fmt.Errorf("plugin source: invalid segment %q", seg)
 		}
 	}
 

--- a/gestaltd/services/plugins/source/source_test.go
+++ b/gestaltd/services/plugins/source/source_test.go
@@ -1,4 +1,4 @@
-package pluginsource
+package source
 
 import (
 	"testing"

--- a/gestaltd/services/plugins/source/version.go
+++ b/gestaltd/services/plugins/source/version.go
@@ -1,4 +1,4 @@
-package pluginsource
+package source
 
 import (
 	"fmt"
@@ -10,14 +10,14 @@ import (
 func ValidateVersion(version string) error {
 	canonical := versionPrefix + version
 	if !semver.IsValid(canonical) {
-		return fmt.Errorf("pluginsource: invalid semver %q", version)
+		return fmt.Errorf("plugin source: invalid semver %q", version)
 	}
 	base := canonical
 	if i := strings.IndexByte(base, '+'); i != -1 {
 		base = base[:i]
 	}
 	if semver.Canonical(canonical) != base {
-		return fmt.Errorf("pluginsource: invalid semver %q", version)
+		return fmt.Errorf("plugin source: invalid semver %q", version)
 	}
 	return nil
 }

--- a/gestaltd/services/plugins/source/version_test.go
+++ b/gestaltd/services/plugins/source/version_test.go
@@ -1,4 +1,4 @@
-package pluginsource
+package source
 
 import (
 	"testing"


### PR DESCRIPTION
## Summary

Moves plugin source parsing and release version validation out of `gestaltd/internal/pluginsource` and into `gestaltd/services/plugins/source`.

This keeps source-coordinate parsing with the plugin service-owned code rather than leaving it as a standalone internal package.

## Interface diff

```diff
- import "github.com/valon-technologies/gestalt/server/internal/pluginsource"
+ import "github.com/valon-technologies/gestalt/server/services/plugins/source"

- src, err := pluginsource.Parse(manifest.Source)
+ src, err := source.Parse(manifest.Source)

- err := pluginsource.ValidateVersion(version)
+ err := source.ValidateVersion(version)
```

## Example

```go
import "github.com/valon-technologies/gestalt/server/services/plugins/source"

src, err := source.Parse(manifest.Source)
if err != nil {
    return err
}

if err := source.ValidateVersion(version); err != nil {
    return err
}
```

## Testing

- `go test ./services/plugins/source ./internal/providerpkg ./internal/operator ./internal/pluginvalidation`
- `go test ./internal/server -run 'Test.*Runtime|Test.*Catalog|Test.*Composite|Test.*Connect' -count=1`
- `go test ./internal/daemon -run 'TestRun_ProviderRelease|TestProviderRemoteConfigPathSynthesizesSourcePlugin|TestE2EProviderValidate' -count=1`
- `go list ./...`
- `git diff --check HEAD`
