### PR TITLE
Allow config workflows to use internal connections

### DIFF
--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -226,6 +226,9 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 		}
 		principalValue = workflowprincipal.FromExecutionReference(resolvedRef)
 		target = resolvedRef.Target
+		if workflowExecutionRefAllowsInternalConnectionAccess(resolvedRef) {
+			ctx = invocation.WithInternalConnectionAccess(ctx)
+		}
 		if target.Plugin != nil {
 			invokeConnection = strings.TrimSpace(target.Plugin.Connection)
 			invokeInstance = strings.TrimSpace(target.Plugin.Instance)
@@ -297,6 +300,16 @@ func workflowTargetHasMixedKinds(target coreworkflow.Target) bool {
 	return target.Agent != nil && target.Plugin != nil
 }
 
+func workflowExecutionRefAllowsInternalConnectionAccess(ref *coreworkflow.ExecutionReference) bool {
+	if ref == nil {
+		return false
+	}
+	return strings.TrimSpace(ref.AuthSource) == "config" &&
+		strings.TrimSpace(ref.SubjectKind) == "system" &&
+		strings.TrimSpace(ref.SubjectID) == workflowConfigOwnerSubjectID() &&
+		strings.TrimSpace(ref.CredentialSubjectID) == workflowConfigOwnerSubjectID()
+}
+
 func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.InvokeOperationRequest, agentManager agentmanager.Service, invoker invocation.Invoker) (*coreworkflow.InvokeOperationResponse, error) {
 	if agentManager == nil {
 		return nil, fmt.Errorf("workflow runtime agent manager is not configured")
@@ -315,6 +328,9 @@ func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.Invo
 		principalValue = workflowprincipal.FromExecutionReference(resolvedRef)
 		target = resolvedRef.Target
 		callerPluginName = strings.TrimSpace(resolvedRef.CallerPluginName)
+		if workflowExecutionRefAllowsInternalConnectionAccess(resolvedRef) {
+			ctx = invocation.WithInternalConnectionAccess(ctx)
+		}
 	} else if principalValue == nil || strings.TrimSpace(principalValue.SubjectID) == "" {
 		return nil, fmt.Errorf("%w: workflow execution principal is required when execution_ref is omitted", invocation.ErrInternal)
 	}

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -975,6 +975,98 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredSubjectPrincipal(t *testing.
 	}
 }
 
+func TestWorkflowRuntimeInvokeExecutionRefAuthorizesInternalConnections(t *testing.T) {
+	t.Parallel()
+
+	target := testWorkflowPluginTarget("brain", "sources.sync")
+	refProvider := newWorkflowRuntimeExecutionRefProvider()
+	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+		ID:                  "exec-ref-config-source-sync",
+		ProviderName:        "temporal",
+		Target:              target,
+		SubjectID:           "system:config",
+		SubjectKind:         string(principal.Kind("system")),
+		AuthSource:          "config",
+		CredentialSubjectID: "system:config",
+		Permissions: []core.AccessPermission{{
+			Plugin:     "brain",
+			Operations: []string{"sources.sync"},
+		}},
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+
+	runtime := &workflowRuntime{
+		providers: map[string]coreworkflow.Provider{"temporal": refProvider},
+	}
+
+	var gotInternalConnectionAccess bool
+	runtime.SetInvoker(funcInvoker{
+		invoke: func(ctx context.Context, _ *principal.Principal, providerName, _ string, operation string, _ map[string]any) (*core.OperationResult, error) {
+			gotInternalConnectionAccess = invocation.InternalConnectionAccessFromContext(ctx)
+			if providerName != "brain" || operation != "sources.sync" {
+				t.Fatalf("target = %s.%s, want brain.sources.sync", providerName, operation)
+			}
+			return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+		},
+	})
+
+	if _, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		ExecutionRef: "exec-ref-config-source-sync",
+		Target:       target,
+	}); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !gotInternalConnectionAccess {
+		t.Fatal("workflow execution ref did not authorize internal connection access")
+	}
+}
+
+func TestWorkflowRuntimeInvokeUserExecutionRefDoesNotAuthorizeInternalConnections(t *testing.T) {
+	t.Parallel()
+
+	target := testWorkflowPluginTarget("brain", "sources.sync")
+	refProvider := newWorkflowRuntimeExecutionRefProvider()
+	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           "exec-ref-user-source-sync",
+		ProviderName: "temporal",
+		Target:       target,
+		SubjectID:    "user:ada",
+		SubjectKind:  string(principal.KindUser),
+		AuthSource:   "session",
+		Permissions: []core.AccessPermission{{
+			Plugin:     "brain",
+			Operations: []string{"sources.sync"},
+		}},
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+
+	runtime := &workflowRuntime{
+		providers: map[string]coreworkflow.Provider{"temporal": refProvider},
+	}
+
+	var gotInternalConnectionAccess bool
+	runtime.SetInvoker(funcInvoker{
+		invoke: func(ctx context.Context, _ *principal.Principal, _, _, _ string, _ map[string]any) (*core.OperationResult, error) {
+			gotInternalConnectionAccess = invocation.InternalConnectionAccessFromContext(ctx)
+			return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+		},
+	})
+
+	if _, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		ExecutionRef: "exec-ref-user-source-sync",
+		Target:       target,
+	}); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if gotInternalConnectionAccess {
+		t.Fatal("user-owned workflow execution ref unexpectedly authorized internal connection access")
+	}
+}
+
 func TestWorkflowRuntimeInvokeExecutionRefRechecksAuthorizationThroughBroker(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -583,7 +583,10 @@ func (b *Broker) resolveConnectionExposure(providerName, connection string) core
 }
 
 func allowsInternalConnection(ctx context.Context) bool {
-	return InvocationSurfaceFromContext(ctx) == InvocationSurfaceHTTPBinding && HTTPBindingFromContext(ctx) != ""
+	if InvocationSurfaceFromContext(ctx) == InvocationSurfaceHTTPBinding && HTTPBindingFromContext(ctx) != "" {
+		return true
+	}
+	return InternalConnectionAccessFromContext(ctx)
 }
 
 func (b *Broker) ExpandCatalogTargets(ctx context.Context, p *principal.Principal, providerName string, targets []CatalogResolutionTarget) ([]CatalogResolutionTarget, error) {

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -107,6 +107,50 @@ func TestBrokerResolveToken_NonUserSubjectUsesOwnExternalCredential(t *testing.T
 	}
 }
 
+func TestBrokerResolveToken_AllowsInternalConnectionWhenContextAuthorized(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeUser,
+		}),
+		svc.Users,
+		svc.ExternalCredentials,
+		WithConnectionRuntime(ConnectionRuntimeMap{
+			"slack": {
+				"bot": {
+					Mode:     core.ConnectionModePlatform,
+					Exposure: core.ConnectionExposureInternal,
+					Token:    "bot-token",
+				},
+			},
+		}.Resolve),
+	)
+	subject := &principal.Principal{
+		SubjectID: "service_account:workflow-config",
+		Kind:      principal.Kind("service_account"),
+		Source:    principal.SourceAPIToken,
+	}
+
+	_, _, err := broker.ResolveToken(context.Background(), subject, "slack", "bot", "")
+	if err == nil {
+		t.Fatal("ResolveToken without internal connection access succeeded, want denial")
+	}
+
+	ctx, token, err := broker.ResolveToken(WithInternalConnectionAccess(context.Background()), subject, "slack", "bot", "")
+	if err != nil {
+		t.Fatalf("ResolveToken with internal connection access: %v", err)
+	}
+	if token != "bot-token" {
+		t.Fatalf("token = %q, want bot-token", token)
+	}
+	if cred := CredentialContextFromContext(ctx); cred.Mode != core.ConnectionModePlatform || cred.Connection != "bot" {
+		t.Fatalf("credential context = %#v, want platform bot", cred)
+	}
+}
+
 func TestBrokerInvokeProviderOverrideResolvesOperationConnectionFromOverride(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/invocation/context.go
+++ b/gestaltd/services/invocation/context.go
@@ -58,6 +58,7 @@ type httpBindingCtxKey struct{}
 type credentialCtxKey struct{}
 type accessCtxKey struct{}
 type workflowCtxKey struct{}
+type internalConnectionAccessCtxKey struct{}
 
 type InvocationSurface string
 
@@ -173,6 +174,15 @@ func WithHTTPBinding(ctx context.Context, binding string) context.Context {
 func HTTPBindingFromContext(ctx context.Context) string {
 	binding, _ := ctx.Value(httpBindingCtxKey{}).(string)
 	return strings.TrimSpace(binding)
+}
+
+func WithInternalConnectionAccess(ctx context.Context) context.Context {
+	return context.WithValue(ctx, internalConnectionAccessCtxKey{}, true)
+}
+
+func InternalConnectionAccessFromContext(ctx context.Context) bool {
+	allowed, _ := ctx.Value(internalConnectionAccessCtxKey{}).(bool)
+	return allowed
 }
 
 const xForwardedForHeader = "X-Forwarded-For"

--- a/gestaltd/services/plugininvoker/invocation_token.go
+++ b/gestaltd/services/plugininvoker/invocation_token.go
@@ -63,10 +63,11 @@ type credentialClaims struct {
 }
 
 type invocationClaims struct {
-	RequestID string   `json:"request_id,omitempty"`
-	Depth     int      `json:"depth,omitempty"`
-	CallChain []string `json:"call_chain,omitempty"`
-	Surface   string   `json:"surface,omitempty"`
+	RequestID                string   `json:"request_id,omitempty"`
+	Depth                    int      `json:"depth,omitempty"`
+	CallChain                []string `json:"call_chain,omitempty"`
+	Surface                  string   `json:"surface,omitempty"`
+	InternalConnectionAccess bool     `json:"internal_connection_access,omitempty"`
 }
 
 type invocationTokenContext struct {
@@ -76,6 +77,7 @@ type invocationTokenContext struct {
 	credentialModeOverride core.ConnectionMode
 	invocation             *invocation.InvocationMeta
 	surface                invocation.InvocationSurface
+	internalConnection     bool
 	connection             string
 	grants                 InvocationGrants
 }
@@ -169,9 +171,10 @@ func (m *InvocationTokenManager) resolveToken(token, pluginName string) (invocat
 			Depth:     claims.Invocation.Depth,
 			CallChain: append([]string(nil), claims.Invocation.CallChain...),
 		},
-		surface:    invocation.InvocationSurface(strings.TrimSpace(claims.Invocation.Surface)),
-		connection: strings.TrimSpace(claims.Connection),
-		grants:     decodeInvocationGrantClaims(claims.Grants),
+		surface:            invocation.InvocationSurface(strings.TrimSpace(claims.Invocation.Surface)),
+		internalConnection: claims.Invocation.InternalConnectionAccess,
+		connection:         strings.TrimSpace(claims.Connection),
+		grants:             decodeInvocationGrantClaims(claims.Grants),
 	}, nil
 }
 
@@ -295,10 +298,11 @@ func claimsFromContext(ctx context.Context, pluginName string, grants Invocation
 			Instance:   cred.Instance,
 		},
 		Invocation: invocationClaims{
-			RequestID: meta.RequestID,
-			Depth:     meta.Depth,
-			CallChain: append([]string(nil), meta.CallChain...),
-			Surface:   string(invocation.InvocationSurfaceFromContext(ctx)),
+			RequestID:                meta.RequestID,
+			Depth:                    meta.Depth,
+			CallChain:                append([]string(nil), meta.CallChain...),
+			Surface:                  string(invocation.InvocationSurfaceFromContext(ctx)),
+			InternalConnectionAccess: invocation.InternalConnectionAccessFromContext(ctx),
 		},
 		Connection: invocation.ConnectionFromContext(ctx),
 	}
@@ -329,6 +333,9 @@ func restoreInvocationTokenContext(ctx context.Context, tokenCtx invocationToken
 	}
 	if tokenCtx.surface != "" {
 		ctx = invocation.WithInvocationSurface(ctx, tokenCtx.surface)
+	}
+	if tokenCtx.internalConnection {
+		ctx = invocation.WithInternalConnectionAccess(ctx)
 	}
 
 	connection := strings.TrimSpace(connectionOverride)

--- a/gestaltd/services/plugininvoker/plugin_invoker_test.go
+++ b/gestaltd/services/plugininvoker/plugin_invoker_test.go
@@ -14,6 +14,7 @@ import (
 
 type recordingPluginInvoker struct {
 	idempotencyKey        string
+	internalConnection    bool
 	providerName          string
 	instance              string
 	operation             string
@@ -27,11 +28,57 @@ type recordingPluginInvoker struct {
 
 func (i *recordingPluginInvoker) Invoke(ctx context.Context, _ *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	i.idempotencyKey = invocation.IdempotencyKeyFromContext(ctx)
+	i.internalConnection = invocation.InternalConnectionAccessFromContext(ctx)
 	i.providerName = providerName
 	i.instance = instance
 	i.operation = operation
 	i.params = params
 	return &core.OperationResult{Status: 202, Body: "accepted"}, nil
+}
+
+func TestPluginInvokerServerInvokePropagatesInternalConnectionAccess(t *testing.T) {
+	t.Parallel()
+
+	tokens, err := NewInvocationTokenManager([]byte("plugin-invoker-test-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "service_account:workflow-config",
+		Kind:      principal.Kind("service_account"),
+		Source:    principal.SourceAPIToken,
+	})
+	ctx = invocation.WithInternalConnectionAccess(ctx)
+	rootToken, err := tokens.MintRootToken(ctx, "brain", InvocationGrants{
+		"slack": {Operations: map[string]core.ConnectionMode{"conversations.history": ""}},
+	})
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+
+	invoker := &recordingPluginInvoker{}
+	server := NewPluginInvokerServer(
+		"brain",
+		[]invocation.PluginInvocationDependency{
+			{Plugin: "slack", Operation: "conversations.history"},
+		},
+		invoker,
+		tokens,
+	)
+	client := proto.NewPluginInvokerClient(newBufconnConn(t, func(srv *grpc.Server) {
+		proto.RegisterPluginInvokerServer(srv, server)
+	}))
+	if _, err := client.Invoke(context.Background(), &proto.PluginInvokeRequest{
+		InvocationToken: rootToken,
+		Plugin:          "slack",
+		Operation:       "conversations.history",
+		Connection:      "bot",
+	}); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !invoker.internalConnection {
+		t.Fatal("internal connection access was not restored from the invocation token")
+	}
 }
 
 func (i *recordingPluginInvoker) InvokeGraphQL(ctx context.Context, _ *principal.Principal, providerName, instance string, request invocation.GraphQLRequest) (*core.OperationResult, error) {


### PR DESCRIPTION
## Summary

This allows config-owned workflow execution refs to invoke plugin operations that rely on deployment-internal connections, without exposing those connections to user-created workflows or normal user invocations.

The production Brain smoke found that the `brain.sources.sync` schedule was installed and firing, but Slack sync failed when Brain called Slack with `connection: bot`:

```text
[permission_denied] authorization denied: integration "slack" connection "bot" is internal
```

That connection should stay internal. The missing primitive was a host-side capability saying: this invocation is running from a config-owned workflow execution reference, so internal deployment credentials may be used if the execution ref and plugin invocation grants still allow the operation.

## Behavior / interface

Config-owned workflow execution refs are now treated as internal-connection-capable when all of these are true:

```text
auth_source == "config"
subject_kind == "system"
subject_id == "system:config"
credential_subject_id == "system:config"
```

Example config-managed workflow target:

```yaml
workflows:
  schedules:
    - provider: workflow/indexeddb
      cron: '*/15 * * * *'
      timezone: America/New_York
      target:
        plugin:
          pluginName: brain
          operation: sources.sync
          connection: default
          input:
            sourceId: slack-valon-public
      permissions:
        - plugin: brain
          operations: [sources.sync]
        - plugin: slack
          operations:
            - conversations.list
            - conversations.history
            - conversations.replies
            - users.info
```

Brain can then call Slack with its configured internal platform connection:

```yaml
plugins:
  slack:
    connections:
      bot:
        mode: platform
        exposure: internal
```

User-owned workflow execution refs do not receive this capability. HTTP bindings still retain their existing internal-connection access.

## Implementation

- Adds an internal invocation-context bit for internal-connection access.
- Allows the broker to resolve internal connections when that bit is present.
- Sets the bit only for config-owned workflow execution refs.
- Preserves the bit across executable-plugin invocation tokens so a workflow invoking Brain can still allow Brain's nested Slack call.
- Adds regression coverage for broker resolution, workflow runtime capability assignment, and invocation-token propagation.

## Verification

```bash
go test ./services/invocation
go test ./services/plugininvoker
go test ./internal/bootstrap -run 'TestWorkflowRuntimeInvokeExecutionRef|TestWorkflowRuntimeInvokeAgentTargetWithExecutionRef'
```
