### PR TITLE
Move plugin config inputs behind service boundary

### DIFF
--- a/gestaltd/internal/bootstrap/declarative_connection.go
+++ b/gestaltd/internal/bootstrap/declarative_connection.go
@@ -1,0 +1,59 @@
+package bootstrap
+
+import (
+	"maps"
+	"slices"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
+)
+
+func declarativeConnectionDef(conn config.ConnectionDef) declarative.ConnectionDef {
+	return declarative.ConnectionDef{
+		Mode:             conn.Mode,
+		Auth:             declarativeConnectionAuthDef(conn.Auth),
+		ConnectionParams: declarativeConnectionParamDefs(conn.ConnectionParams),
+	}
+}
+
+func declarativeConnectionAuthDef(auth config.ConnectionAuthDef) declarative.ConnectionAuthDef {
+	return declarative.ConnectionAuthDef{
+		Type:                auth.Type,
+		Token:               auth.Token,
+		AuthorizationURL:    auth.AuthorizationURL,
+		TokenURL:            auth.TokenURL,
+		ClientID:            auth.ClientID,
+		ClientSecret:        auth.ClientSecret,
+		RedirectURL:         auth.RedirectURL,
+		ClientAuth:          auth.ClientAuth,
+		TokenExchange:       auth.TokenExchange,
+		Scopes:              slices.Clone(auth.Scopes),
+		ScopeParam:          auth.ScopeParam,
+		ScopeSeparator:      auth.ScopeSeparator,
+		PKCE:                auth.PKCE,
+		AuthorizationParams: maps.Clone(auth.AuthorizationParams),
+		TokenParams:         maps.Clone(auth.TokenParams),
+		RefreshParams:       maps.Clone(auth.RefreshParams),
+		AcceptHeader:        auth.AcceptHeader,
+		AccessTokenPath:     auth.AccessTokenPath,
+		TokenMetadata:       slices.Clone(auth.TokenMetadata),
+		Credentials:         slices.Clone(auth.Credentials),
+		AuthMapping:         config.CloneAuthMapping(auth.AuthMapping),
+	}
+}
+
+func declarativeConnectionParamDefs(params map[string]config.ConnectionParamDef) map[string]declarative.ConnectionParamDef {
+	if len(params) == 0 {
+		return nil
+	}
+	out := make(map[string]declarative.ConnectionParamDef, len(params))
+	for name, param := range params {
+		out[name] = declarative.ConnectionParamDef{
+			Required:    param.Required,
+			Description: param.Description,
+			From:        param.From,
+			Field:       param.Field,
+		}
+	}
+	return out
+}

--- a/gestaltd/internal/bootstrap/graphql_session_provider_test.go
+++ b/gestaltd/internal/bootstrap/graphql_session_provider_test.go
@@ -78,7 +78,7 @@ func TestGraphQLSessionCatalogProviderLoadsCatalogOnDemand(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	base, err := declarative.Build(graphql.StaticDefinition("linear", srv.URL), config.ConnectionDef{})
+	base, err := declarative.Build(graphql.StaticDefinition("linear", srv.URL), declarative.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("declarative.Build: %v", err)
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -720,7 +720,7 @@ func buildConfiguredSpecProvider(ctx context.Context, name string, resolved conf
 		if err != nil {
 			return nil, nil, err
 		}
-		prov, err := declarative.Build(def, resolved.Connection, buildOpts...)
+		prov, err := declarative.Build(def, declarativeConnectionDef(resolved.Connection), buildOpts...)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -2921,8 +2921,9 @@ func buildOAuthHandlerFromDefinition(def *declarative.Definition, conn config.Co
 	}
 
 	defCopy := *def
-	declarative.ApplyConnectionAuth(&defCopy, effectiveConn)
-	upstream, err := declarative.BuildOAuthUpstream(&defCopy, effectiveConn, defCopy.BaseURL, nil)
+	serviceConn := declarativeConnectionDef(effectiveConn)
+	declarative.ApplyConnectionAuth(&defCopy, serviceConn)
+	upstream, err := declarative.BuildOAuthUpstream(&defCopy, serviceConn, defCopy.BaseURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -10580,7 +10580,7 @@ func TestListIntegrations_ConnectionInfosIncludeProviderManualAuth(t *testing.T)
 					Operations: map[string]declarative.OperationDef{
 						"list_items": {Method: http.MethodGet, Path: "/items"},
 					},
-				}, config.ConnectionDef{})
+				}, declarative.ConnectionDef{})
 				if err != nil {
 					t.Fatalf("Build: %v", err)
 				}
@@ -10706,7 +10706,7 @@ func TestListIntegrationsWithIcon(t *testing.T) {
 			Operations: map[string]declarative.OperationDef{
 				"op": {Description: "An op", Method: http.MethodGet, Path: "/op"},
 			},
-		}, config.ConnectionDef{})
+		}, declarative.ConnectionDef{})
 		if err != nil {
 			t.Fatalf("Build: %v", err)
 		}
@@ -21675,7 +21675,7 @@ func TestUpstreamHTTPErrorPassthrough(t *testing.T) {
 		Operations: map[string]declarative.OperationDef{
 			"do_thing": {Description: "Do a thing", Method: http.MethodGet, Path: "/do_thing"},
 		},
-	}, config.ConnectionDef{})
+	}, declarative.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}

--- a/gestaltd/services/plugins/declarative/build.go
+++ b/gestaltd/services/plugins/declarative/build.go
@@ -3,13 +3,14 @@ package declarative
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/plugins/apiexec"
 	"github.com/valon-technologies/gestalt/server/services/plugins/oauth"
@@ -35,7 +36,7 @@ func WithEgressCheck(fn func(string) error) BuildOption {
 
 // Build constructs a provider from a spec Definition and a ConnectionDef that
 // owns auth configuration.
-func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (core.Provider, error) {
+func Build(def *Definition, conn ConnectionDef, opts ...BuildOption) (core.Provider, error) {
 	var bo buildOptions
 	for _, opt := range opts {
 		opt(&bo)
@@ -176,7 +177,9 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 			base.ConnectionDefs[name] = core.ConnectionParamDef{
 				Required:    cpd.Required,
 				Description: cpd.Description,
+				Default:     cpd.Default,
 				From:        cpd.From,
+				Field:       cpd.Field,
 			}
 		}
 	} else if len(def.Connection) > 0 {
@@ -205,7 +208,7 @@ func ReadIconFile(path string) (string, error) {
 }
 
 // ApplyConnectionAuth merges connection auth overrides into the Definition.
-func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
+func ApplyConnectionAuth(def *Definition, conn ConnectionDef) {
 	o := conn.Auth
 	if o.Type == providermanifestv1.AuthTypeOAuth2 && def.Auth.Type != string(providermanifestv1.AuthTypeOAuth2) {
 		clearManualAuthMaterialization(def)
@@ -216,7 +219,7 @@ func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 	setStr(&def.Auth.ClientAuth, o.ClientAuth)
 	setStr(&def.Auth.TokenExchange, o.TokenExchange)
 	if o.Scopes != nil {
-		def.Auth.Scopes = o.Scopes
+		def.Auth.Scopes = slices.Clone(o.Scopes)
 	}
 	setStr(&def.Auth.ScopeParam, o.ScopeParam)
 	setStr(&def.Auth.ScopeSeparator, o.ScopeSeparator)
@@ -226,23 +229,22 @@ func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 		def.Auth.PKCE = true
 	}
 	if o.AuthorizationParams != nil {
-		def.Auth.AuthorizationParams = o.AuthorizationParams
+		def.Auth.AuthorizationParams = maps.Clone(o.AuthorizationParams)
 	}
 	if o.TokenParams != nil {
-		def.Auth.TokenParams = o.TokenParams
+		def.Auth.TokenParams = maps.Clone(o.TokenParams)
 	}
 	if o.RefreshParams != nil {
-		def.Auth.RefreshParams = o.RefreshParams
+		def.Auth.RefreshParams = maps.Clone(o.RefreshParams)
 	}
 	if o.TokenMetadata != nil {
-		def.Auth.TokenMetadata = o.TokenMetadata
+		def.Auth.TokenMetadata = slices.Clone(o.TokenMetadata)
 	}
 	if len(o.Credentials) > 0 {
-		def.CredentialFields = make([]CredentialFieldDef, len(o.Credentials))
-		copy(def.CredentialFields, o.Credentials)
+		def.CredentialFields = slices.Clone(o.Credentials)
 	}
 	if o.AuthMapping != nil {
-		def.AuthMapping = config.CloneAuthMapping(o.AuthMapping)
+		def.AuthMapping = cloneAuthMapping(o.AuthMapping)
 	}
 }
 
@@ -260,7 +262,7 @@ func setStr(dst *string, val string) {
 	}
 }
 
-func buildAuth(def *Definition, conn config.ConnectionDef, baseURL string, client *http.Client) (AuthHandler, error) {
+func buildAuth(def *Definition, conn ConnectionDef, baseURL string, client *http.Client) (AuthHandler, error) {
 	if def.Auth.Type == "manual" || (def.Auth.Type == "" && def.Auth.AuthorizationURL == "") {
 		return oauth.ManualAuthHandler{}, nil
 	}
@@ -277,19 +279,21 @@ func buildAuth(def *Definition, conn config.ConnectionDef, baseURL string, clien
 // token_params, refresh_params, scope_separator, accept_header, and response
 // hooks. Callers outside the provider build pipeline (e.g. the factory building
 // per-connection OAuth handlers) use this to get a standalone handler.
-func BuildOAuthUpstream(def *Definition, conn config.ConnectionDef, baseURL string, client *http.Client) (*oauth.UpstreamHandler, error) {
+func BuildOAuthUpstream(def *Definition, conn ConnectionDef, baseURL string, client *http.Client) (*oauth.UpstreamHandler, error) {
+	auth := cloneAuthDef(def.Auth)
+
 	var tokenExchange oauth.TokenExchangeFormat
-	switch def.Auth.TokenExchange {
+	switch auth.TokenExchange {
 	case "", "form":
 		tokenExchange = oauth.TokenExchangeForm
 	case "json":
 		tokenExchange = oauth.TokenExchangeJSON
 	default:
-		return nil, fmt.Errorf("unknown tokenExchange %q", def.Auth.TokenExchange)
+		return nil, fmt.Errorf("unknown tokenExchange %q", auth.TokenExchange)
 	}
 
-	authURL := resolveURL(baseURL, def.Auth.AuthorizationURL)
-	tokenURL := resolveURL(baseURL, def.Auth.TokenURL)
+	authURL := resolveURL(baseURL, auth.AuthorizationURL)
+	tokenURL := resolveURL(baseURL, auth.TokenURL)
 
 	oauthCfg := oauth.UpstreamConfig{
 		ClientID:            conn.Auth.ClientID,
@@ -297,19 +301,19 @@ func BuildOAuthUpstream(def *Definition, conn config.ConnectionDef, baseURL stri
 		AuthorizationURL:    authURL,
 		TokenURL:            tokenURL,
 		RedirectURL:         conn.Auth.RedirectURL,
-		PKCE:                def.Auth.PKCE,
-		DefaultScopes:       def.Auth.Scopes,
-		ScopeParam:          def.Auth.ScopeParam,
-		ScopeSeparator:      def.Auth.ScopeSeparator,
-		AuthorizationParams: def.Auth.AuthorizationParams,
-		TokenParams:         def.Auth.TokenParams,
-		RefreshParams:       def.Auth.RefreshParams,
+		PKCE:                auth.PKCE,
+		DefaultScopes:       auth.Scopes,
+		ScopeParam:          auth.ScopeParam,
+		ScopeSeparator:      auth.ScopeSeparator,
+		AuthorizationParams: auth.AuthorizationParams,
+		TokenParams:         auth.TokenParams,
+		RefreshParams:       auth.RefreshParams,
 		TokenExchange:       tokenExchange,
-		AcceptHeader:        def.Auth.AcceptHeader,
-		AccessTokenPath:     def.Auth.AccessTokenPath,
+		AcceptHeader:        auth.AcceptHeader,
+		AccessTokenPath:     auth.AccessTokenPath,
 	}
 
-	if def.Auth.ClientAuth == "header" {
+	if auth.ClientAuth == "header" {
 		oauthCfg.ClientAuthMethod = oauth.ClientAuthHeader
 	}
 
@@ -318,8 +322,8 @@ func BuildOAuthUpstream(def *Definition, conn config.ConnectionDef, baseURL stri
 		opts = append(opts, oauth.WithHTTPClient(client))
 	}
 
-	if def.Auth.ResponseCheck != nil {
-		rcd := def.Auth.ResponseCheck
+	if auth.ResponseCheck != nil {
+		rcd := auth.ResponseCheck
 		opts = append(opts, oauth.WithResponseHook(func(body []byte) error {
 			var data map[string]any
 			if err := json.Unmarshal(body, &data); err != nil {

--- a/gestaltd/services/plugins/declarative/build_test.go
+++ b/gestaltd/services/plugins/declarative/build_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
@@ -34,8 +33,8 @@ func testDefinition(name string) *Definition {
 	}
 }
 
-func testCreds() config.ConnectionDef {
-	return config.ConnectionDef{Auth: config.ConnectionAuthDef{
+func testCreds() ConnectionDef {
+	return ConnectionDef{Auth: ConnectionAuthDef{
 		ClientID:     "test",
 		ClientSecret: "test",
 		RedirectURL:  "http://localhost/callback",
@@ -70,7 +69,7 @@ func TestBuildManualAuth(t *testing.T) {
 			"list": {Description: "List", Method: http.MethodGet, Path: "/list"},
 		},
 	}
-	intg, err := Build(def, config.ConnectionDef{})
+	intg, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -83,7 +82,7 @@ func TestBuildDoesNotMutateDefinition(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("original")
-	_, err := Build(def, config.ConnectionDef{Auth: config.ConnectionAuthDef{
+	_, err := Build(def, ConnectionDef{Auth: ConnectionAuthDef{
 		ClientID: "test",
 		TokenURL: "https://override.example.com/token",
 	}})
@@ -119,7 +118,7 @@ func TestBuildBasicAuthStyle(t *testing.T) {
 			"list": {Description: "List", Method: http.MethodGet, Path: "/list"},
 		},
 	}
-	intg, err := Build(def, config.ConnectionDef{})
+	intg, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -159,7 +158,7 @@ func TestBuildExposesCatalog(t *testing.T) {
 		},
 	}
 
-	provider, err := Build(def, config.ConnectionDef{})
+	provider, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -245,7 +244,7 @@ func TestBuildExecuteRoutesQueryParamsUsingCatalogMetadata(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -304,7 +303,7 @@ func TestBuildAppliesIconFile(t *testing.T) {
 		t.Fatalf("ReadIconFile: %v", err)
 	}
 	def.IconSVG = iconSVG
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -334,7 +333,7 @@ func TestBuildIconFileMissing(t *testing.T) {
 	if _, err := ReadIconFile("/nonexistent/icon.svg"); err == nil {
 		t.Fatal("expected ReadIconFile to fail for missing icon")
 	}
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build should succeed with missing icon: %v", err)
 	}
@@ -365,7 +364,7 @@ func TestBuildAuthHeader(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -413,8 +412,8 @@ func TestBuildOAuthConnectionOverrideClearsOpenAPIManualAuth(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{
-		Auth: config.ConnectionAuthDef{
+	prov, err := Build(def, ConnectionDef{
+		Auth: ConnectionAuthDef{
 			Type:             providermanifestv1.AuthTypeOAuth2,
 			AuthorizationURL: "https://identity.example.com/oauth/authorize",
 			TokenURL:         "https://identity.example.com/oauth/token",
@@ -481,7 +480,7 @@ func TestBuildAuthMapping(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -534,7 +533,7 @@ func TestBuildAuthMappingMissingField(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -573,7 +572,7 @@ func TestBuildErrorMessagePath(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -610,7 +609,7 @@ func TestBuildErrorMessagePathSuccessPassthrough(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -649,7 +648,7 @@ func TestBuildConfigOverridesAuthHeader(t *testing.T) {
 
 	def.AuthHeader = "X-Override-Key"
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -691,7 +690,7 @@ func TestBuildConnectionParams(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -730,7 +729,7 @@ func TestBuildConnectionParamsBaseURLInterpolation(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -770,7 +769,7 @@ func TestBuildResponseCheck_SuccessMatch(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -813,7 +812,7 @@ func TestBuildResponseCheck_FailureMatch(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -851,7 +850,7 @@ func TestBuildResponseCheck_NonJSON200(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -888,7 +887,7 @@ func TestBuildResponseCheck_NonJSON500(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -915,7 +914,7 @@ func TestBuildResponseCheck_SuccessMatchOnly(t *testing.T) {
 		},
 	}
 
-	_, err := Build(def, config.ConnectionDef{})
+	_, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build should succeed with structured response check: %v", err)
 	}
@@ -949,7 +948,7 @@ func TestBuildResponseCheck_ErrorMessagePathOnly(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -980,7 +979,7 @@ func TestBuildCredentialFields(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{})
+	prov, err := Build(def, ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -1010,9 +1009,9 @@ func TestBuildCredentialFieldsFromConfig(t *testing.T) {
 		},
 	}
 
-	conn := config.ConnectionDef{
-		Auth: config.ConnectionAuthDef{
-			Credentials: []config.CredentialFieldDef{
+	conn := ConnectionDef{
+		Auth: ConnectionAuthDef{
+			Credentials: []CredentialFieldDef{
 				{Name: "token", Label: "Access Token"},
 			},
 		},
@@ -1054,18 +1053,18 @@ func TestBuildAuthMappingFromConfig(t *testing.T) {
 		},
 	}
 
-	conn := config.ConnectionDef{
-		Auth: config.ConnectionAuthDef{
-			AuthMapping: &config.AuthMappingDef{
-				Headers: map[string]config.AuthValueDef{
+	conn := ConnectionDef{
+		Auth: ConnectionAuthDef{
+			AuthMapping: &AuthMappingDef{
+				Headers: map[string]AuthValueDef{
 					"X-Api-Key": {
-						ValueFrom: &config.AuthValueFromDef{
-							CredentialFieldRef: &config.CredentialFieldRefDef{Name: "api_key"},
+						ValueFrom: &AuthValueFromDef{
+							CredentialFieldRef: &CredentialFieldRefDef{Name: "api_key"},
 						},
 					},
 					"X-App-Key": {
-						ValueFrom: &config.AuthValueFromDef{
-							CredentialFieldRef: &config.CredentialFieldRefDef{Name: "app_key"},
+						ValueFrom: &AuthValueFromDef{
+							CredentialFieldRef: &CredentialFieldRefDef{Name: "app_key"},
 						},
 					},
 				},

--- a/gestaltd/services/plugins/declarative/catalog_metadata.go
+++ b/gestaltd/services/plugins/declarative/catalog_metadata.go
@@ -1,6 +1,7 @@
 package declarative
 
 import (
+	"slices"
 	"sort"
 	"strings"
 
@@ -27,7 +28,7 @@ func CatalogFromDefinition(def *Definition) *catalog.Catalog {
 			Method:       strings.ToUpper(opDef.Method),
 			Path:         opDef.Path,
 			Description:  opDef.Description,
-			AllowedRoles: opDef.AllowedRoles,
+			AllowedRoles: slices.Clone(opDef.AllowedRoles),
 			Tags:         catalog.MergeTags(opDef.Tags),
 			Transport:    opDef.Transport,
 			Query:        opDef.Query,

--- a/gestaltd/services/plugins/declarative/connection.go
+++ b/gestaltd/services/plugins/declarative/connection.go
@@ -1,0 +1,96 @@
+package declarative
+
+import (
+	"maps"
+	"slices"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+// ConnectionDef is the service-owned provider construction input for a
+// resolved connection.
+type ConnectionDef struct {
+	Mode             providermanifestv1.ConnectionMode
+	Auth             ConnectionAuthDef
+	ConnectionParams map[string]ConnectionParamDef
+}
+
+// ConnectionAuthDef is the auth material needed to construct a declarative
+// provider or OAuth upstream.
+type ConnectionAuthDef struct {
+	Type                providermanifestv1.AuthType
+	Token               string
+	AuthorizationURL    string
+	TokenURL            string
+	ClientID            string
+	ClientSecret        string
+	RedirectURL         string
+	ClientAuth          string
+	TokenExchange       string
+	Scopes              []string
+	ScopeParam          string
+	ScopeSeparator      string
+	PKCE                bool
+	AuthorizationParams map[string]string
+	TokenParams         map[string]string
+	RefreshParams       map[string]string
+	AcceptHeader        string
+	AccessTokenPath     string
+	TokenMetadata       []string
+	Credentials         []CredentialFieldDef
+	AuthMapping         *AuthMappingDef
+}
+
+func cloneAuthMapping(src *AuthMappingDef) *AuthMappingDef {
+	if src == nil {
+		return nil
+	}
+	dst := &AuthMappingDef{}
+	if len(src.Headers) > 0 {
+		dst.Headers = make(map[string]AuthValueDef, len(src.Headers))
+		for name, value := range src.Headers {
+			dst.Headers[name] = cloneAuthValue(value)
+		}
+	}
+	if src.Basic != nil {
+		dst.Basic = &BasicAuthMappingDef{
+			Username: cloneAuthValue(src.Basic.Username),
+			Password: cloneAuthValue(src.Basic.Password),
+		}
+	}
+	return dst
+}
+
+func cloneAuthValue(src AuthValueDef) AuthValueDef {
+	dst := src
+	if src.ValueFrom != nil {
+		dst.ValueFrom = &AuthValueFromDef{}
+		if src.ValueFrom.CredentialFieldRef != nil {
+			dst.ValueFrom.CredentialFieldRef = &CredentialFieldRefDef{
+				Name: src.ValueFrom.CredentialFieldRef.Name,
+			}
+		}
+	}
+	return dst
+}
+
+func cloneAuthDef(src AuthDef) AuthDef {
+	dst := src
+	dst.Scopes = slices.Clone(src.Scopes)
+	dst.AuthorizationParams = maps.Clone(src.AuthorizationParams)
+	dst.TokenParams = maps.Clone(src.TokenParams)
+	dst.RefreshParams = maps.Clone(src.RefreshParams)
+	dst.TokenMetadata = slices.Clone(src.TokenMetadata)
+	dst.ResponseCheck = cloneResponseCheckDef(src.ResponseCheck)
+	return dst
+}
+
+func cloneResponseCheckDef(src *ResponseCheckDef) *ResponseCheckDef {
+	if src == nil {
+		return nil
+	}
+	return &ResponseCheckDef{
+		SuccessBodyMatch: maps.Clone(src.SuccessBodyMatch),
+		ErrorMessagePath: src.ErrorMessagePath,
+	}
+}

--- a/gestaltd/services/plugins/graphql/loader.go
+++ b/gestaltd/services/plugins/graphql/loader.go
@@ -5,15 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
+	"github.com/valon-technologies/gestalt/server/services/plugins/operationexposure"
 )
 
-func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[string]*config.OperationOverride, selectionOverrides map[string]string) (*declarative.Definition, error) {
+func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) (*declarative.Definition, error) {
 	schema, err := introspect(ctx, endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("introspecting %s: %w", endpoint, err)
@@ -31,7 +32,7 @@ func StaticDefinition(name, endpoint string) *declarative.Definition {
 	return def
 }
 
-func DefinitionFromSchema(name, endpoint string, schema *Schema, allowedOps map[string]*config.OperationOverride, selectionOverrides map[string]string) (*declarative.Definition, error) {
+func DefinitionFromSchema(name, endpoint string, schema *Schema, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) (*declarative.Definition, error) {
 	def := StaticDefinition(name, endpoint)
 	def.Operations = make(map[string]declarative.OperationDef)
 	addOperations(schema, def, schema.QueryType, false, allowedOps, selectionOverrides)
@@ -70,7 +71,7 @@ func SchemaFromResult(result *core.OperationResult) (*Schema, error) {
 	return SchemaFromBody([]byte(result.Body))
 }
 
-func addOperations(schema *Schema, def *declarative.Definition, root *TypeName, isMutation bool, allowedOps map[string]*config.OperationOverride, selectionOverrides map[string]string) {
+func addOperations(schema *Schema, def *declarative.Definition, root *TypeName, isMutation bool, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) {
 	if root == nil {
 		return
 	}
@@ -101,7 +102,7 @@ func addOperations(schema *Schema, def *declarative.Definition, root *TypeName, 
 			if override.Alias != "" {
 				opName = override.Alias
 			}
-			allowedRoles = override.AllowedRoles
+			allowedRoles = slices.Clone(override.AllowedRoles)
 			tags = catalog.MergeTags(override.Tags)
 		}
 

--- a/gestaltd/services/plugins/graphql/loader_test.go
+++ b/gestaltd/services/plugins/graphql/loader_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/plugins/operationexposure"
 )
 
 func strPtr(s string) *string { return &s }
@@ -141,8 +141,8 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 	srv := startIntrospectionServer(t, newTestSchema())
 	defer srv.Close()
 
-	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*config.OperationOverride{
-		"teams": {Description: "My custom description", Tags: []string{"workspace"}},
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"teams": {Description: "My custom description", AllowedRoles: []string{"workspace-admin"}, Tags: []string{"workspace"}},
 	}, nil)
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)
@@ -158,6 +158,9 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 	}
 	if got, want := teams.Tags, []string{"workspace"}; !slices.Equal(got, want) {
 		t.Errorf("teams.Tags: got %#v, want %#v", got, want)
+	}
+	if got, want := teams.AllowedRoles, []string{"workspace-admin"}; !slices.Equal(got, want) {
+		t.Errorf("teams.AllowedRoles: got %#v, want %#v", got, want)
 	}
 }
 

--- a/gestaltd/services/plugins/openapi/loader.go
+++ b/gestaltd/services/plugins/openapi/loader.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -16,15 +17,15 @@ import (
 	"github.com/pb33f/libopenapi/orderedmap"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/toolschema"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
+	"github.com/valon-technologies/gestalt/server/services/plugins/operationexposure"
 )
 
 const maxSpecSize = 100 << 20 // 100 MB
 
 var defaultClient = &http.Client{Timeout: 30 * time.Second}
 
-func LoadDefinition(ctx context.Context, name, specURL string, allowedOps map[string]*config.OperationOverride) (*declarative.Definition, error) {
+func LoadDefinition(ctx context.Context, name, specURL string, allowedOps map[string]*operationexposure.OperationOverride) (*declarative.Definition, error) {
 	body, err := fetch(ctx, specURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetching %s: %w", specURL, err)
@@ -108,7 +109,7 @@ func extractScopes(scopes *orderedmap.Map[string, string]) []string {
 	return result
 }
 
-func collectOperationScopes(model *v3high.Document, allowedOps map[string]*config.OperationOverride) []string {
+func collectOperationScopes(model *v3high.Document, allowedOps map[string]*operationexposure.OperationOverride) []string {
 	seen := make(map[string]struct{})
 	collect := func(reqs []*base.SecurityRequirement) {
 		for _, req := range reqs {
@@ -151,7 +152,7 @@ func collectOperationScopes(model *v3high.Document, allowedOps map[string]*confi
 	return result
 }
 
-func extractOperations(model *v3high.Document, def *declarative.Definition, allowedOps map[string]*config.OperationOverride) {
+func extractOperations(model *v3high.Document, def *declarative.Definition, allowedOps map[string]*operationexposure.OperationOverride) {
 	def.Operations = make(map[string]declarative.OperationDef)
 
 	if model.Paths == nil || model.Paths.PathItems == nil {
@@ -187,7 +188,7 @@ func extractOperations(model *v3high.Document, def *declarative.Definition, allo
 				if override.Alias != "" {
 					opID = override.Alias
 				}
-				allowedRoles = override.AllowedRoles
+				allowedRoles = slices.Clone(override.AllowedRoles)
 				tags = catalog.MergeTags(tags, override.Tags)
 			}
 

--- a/gestaltd/services/plugins/openapi/loader_test.go
+++ b/gestaltd/services/plugins/openapi/loader_test.go
@@ -8,9 +8,9 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
+	"github.com/valon-technologies/gestalt/server/services/plugins/operationexposure"
 )
 
 func serveJSON(t *testing.T, spec any) *httptest.Server {
@@ -82,8 +82,8 @@ func TestLoadDefinition(t *testing.T) {
 	srv := serveJSON(t, testSpec())
 	testutil.CloseOnCleanup(t, srv)
 
-	allowed := map[string]*config.OperationOverride{
-		"list_items": {Description: "List items with pagination", Tags: []string{"pagination"}},
+	allowed := map[string]*operationexposure.OperationOverride{
+		"list_items": {Description: "List items with pagination", AllowedRoles: []string{"reader"}, Tags: []string{"pagination"}},
 		"get_item":   nil,
 	}
 
@@ -117,6 +117,9 @@ func TestLoadDefinition(t *testing.T) {
 	}
 	if got, want := listOp.Tags, []string{"inventory", "pagination"}; !slices.Equal(got, want) {
 		t.Errorf("list_items tags = %#v, want %#v", got, want)
+	}
+	if got, want := listOp.AllowedRoles, []string{"reader"}; !slices.Equal(got, want) {
+		t.Errorf("list_items allowed roles = %#v, want %#v", got, want)
 	}
 	if len(listOp.Parameters) != 1 {
 		t.Fatalf("list_items params = %d, want 1", len(listOp.Parameters))
@@ -154,7 +157,7 @@ func TestLoadDefinitionFiltersOperations(t *testing.T) {
 	srv := serveJSON(t, spec)
 	testutil.CloseOnCleanup(t, srv)
 
-	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]*config.OperationOverride{"op_a": nil, "op_c": nil})
+	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]*operationexposure.OperationOverride{"op_a": nil, "op_c": nil})
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)
 	}
@@ -347,7 +350,7 @@ func TestCollectScopesRespectsAllowedOps(t *testing.T) {
 	srv := serveJSON(t, spec)
 	testutil.CloseOnCleanup(t, srv)
 
-	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]*config.OperationOverride{"read_op": nil})
+	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]*operationexposure.OperationOverride{"read_op": nil})
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)
 	}


### PR DESCRIPTION
## Summary

Remove the remaining production `server/internal/config` imports from `gestaltd/services/plugins/**` by giving plugin service packages their own provider-building input contracts.

This PR:
- Adds service-owned `declarative.ConnectionDef` and `declarative.ConnectionAuthDef`.
- Keeps config resolution inside bootstrap with an internal adapter from `config.ConnectionDef` to `declarative.ConnectionDef`.
- Changes OpenAPI and GraphQL loaders to accept `operationexposure.OperationOverride` instead of `config.OperationOverride`.
- Clones mutable auth/operation role slices and maps at service boundaries.

## Interface Changes

- New declarative provider construction input:

```go
conn := declarative.ConnectionDef{
    Mode: providermanifestv1.ConnectionModeUser,
    Auth: declarative.ConnectionAuthDef{
        Type:         providermanifestv1.AuthTypeOAuth2,
        ClientID:     "client-id",
        ClientSecret: "client-secret",
        RedirectURL:  "https://app.example.com/oauth/callback",
    },
    ConnectionParams: map[string]declarative.ConnectionParamDef{
        "subdomain": {Required: true, Description: "Store subdomain"},
    },
}

provider, err := declarative.Build(def, conn, declarative.WithEgressCheck(checkHost))
```

- OpenAPI and GraphQL loaders now take service-owned operation exposure overrides:

```go
allowed := map[string]*operationexposure.OperationOverride{
    "list_items": {
        Alias:        "list",
        Description:  "List visible items",
        AllowedRoles: []string{"reader"},
        Tags:         []string{"inventory"},
    },
}

def, err := openapi.LoadDefinition(ctx, "shop", specURL, allowed)
```

## Functional/Integration Tests

- Tests added or augmented:
  - Augmented existing OpenAPI and GraphQL loader tests to assert `AllowedRoles` preservation through operation overrides.
  - Updated existing declarative/server/bootstrap tests for the new service-owned connection input.

- Contract boundary covered:
  - Config/manifest resolved connection definitions flow through bootstrap into declarative provider construction.
  - OpenAPI and lazy GraphQL surfaces still load and execute through bootstrap.
  - OAuth connection auth from manifest/deploy config still produces connection auth handlers.
  - `services/plugins` no longer imports `server/internal/config`.

- Commands run from `gestaltd/`:

```sh
go test ./services/plugins/...
go test ./internal/bootstrap -run 'TestBootstrapAllowsPluginConfiguredWithBothOpenAPIAndGraphQLAPISurfaces|TestPluginManifestOAuthWiresConnectionAuth|TestPluginManifestNamedOAuthKeepsProviderTokenMode|TestHybridExecutableProviderAppliesAllowedOperationsToStaticAndOpenAPICatalogs'
go test ./internal/pluginvalidation
go test ./internal/server -run 'TestListIntegrations|TestUpstreamHTTPErrorPassthrough'
```

## Stack

Standalone PR against `main`.