### PR TITLE
Remove native search from provider turns

### DIFF
--- a/gestaltd/core/agent/agent.go
+++ b/gestaltd/core/agent/agent.go
@@ -154,9 +154,6 @@ func ValidateMCPCatalogToolRefs(refs []ToolRef, fieldName string) error {
 	if fieldName == "" {
 		fieldName = "toolRefs"
 	}
-	if len(refs) == 0 {
-		return fmt.Errorf("mcp catalog requires explicit %s", fieldName)
-	}
 	for i := range refs {
 		ref := refs[i]
 		system := strings.TrimSpace(ref.System)

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -289,7 +289,7 @@ func (r *agentRuntime) ExecuteTool(ctx context.Context, req coreagent.ExecuteToo
 	if err != nil {
 		return nil, err
 	}
-	if resolvedTool.Hidden && !agentToolMatchesResolvedTools(resolvedTool.Target, resolvedTool.ID, grant.Tools) {
+	if resolvedTool.Hidden && !agentToolHiddenExplicitlyGranted(resolvedTool.Target, resolvedTool.ID, grant.ToolRefs, grant.Tools) {
 		return nil, fmt.Errorf("%w: hidden agent tool %q was not granted to this turn", invocation.ErrAuthorizationDenied, resolvedTool.ID)
 	}
 	if err := validateAgentToolTargetForGrant(grant, principalValue, resolvedTool.Target, resolvedTool.ID); err != nil {
@@ -423,6 +423,9 @@ func (r *agentRuntime) ListTools(ctx context.Context, req coreagent.ListToolsReq
 	if err := validateAgentMCPCatalogToolRefs(grant.ToolRefs); err != nil {
 		return nil, fmt.Errorf("%w: %v", invocation.ErrAuthorizationDenied, err)
 	}
+	if len(grant.ToolRefs) == 0 {
+		return &coreagent.ListToolsResponse{}, nil
+	}
 	resp, err := searcher.ListTools(ctx, principalValue, coreagent.ListToolsRequest{
 		ProviderName: strings.TrimSpace(grant.ProviderName),
 		SessionID:    strings.TrimSpace(grant.SessionID),
@@ -549,6 +552,9 @@ func validateAgentToolTargetForGrant(grant agentgrant.Grant, principalValue *pri
 	if source == coreagent.ToolSourceModeMCPCatalog {
 		if err := validateAgentMCPCatalogToolRefs(grant.ToolRefs); err != nil {
 			return fmt.Errorf("%w: %v", invocation.ErrAuthorizationDenied, err)
+		}
+		if len(grant.ToolRefs) == 0 {
+			return fmt.Errorf("%w: agent tool %q is outside the turn tool scope", invocation.ErrAuthorizationDenied, rawToolID)
 		}
 	}
 	operation := strings.TrimSpace(target.Operation)
@@ -761,6 +767,50 @@ func agentToolMatchesResolvedTools(target coreagent.ToolTarget, rawToolID string
 		if agentToolTargetsEqual(tools[i].Target, target) {
 			return true
 		}
+	}
+	return false
+}
+
+func agentToolHiddenExplicitlyGranted(target coreagent.ToolTarget, rawToolID string, refs []coreagent.ToolRef, tools []coreagent.Tool) bool {
+	if agentToolMatchesResolvedTools(target, rawToolID, tools) {
+		return true
+	}
+	targetOperation := strings.TrimSpace(target.Operation)
+	if targetOperation == "" {
+		return false
+	}
+	if systemName := strings.TrimSpace(target.System); systemName != "" {
+		for i := range refs {
+			if strings.TrimSpace(refs[i].System) != systemName {
+				continue
+			}
+			if strings.TrimSpace(refs[i].Operation) != targetOperation {
+				continue
+			}
+			return true
+		}
+		return false
+	}
+
+	targetConnection := config.ResolveConnectionAlias(strings.TrimSpace(target.Connection))
+	for i := range refs {
+		ref := refs[i]
+		if strings.TrimSpace(ref.Plugin) != strings.TrimSpace(target.Plugin) {
+			continue
+		}
+		if strings.TrimSpace(ref.Operation) != targetOperation {
+			continue
+		}
+		if connection := strings.TrimSpace(ref.Connection); connection != "" && config.ResolveConnectionAlias(connection) != targetConnection {
+			continue
+		}
+		if instance := strings.TrimSpace(ref.Instance); instance != "" && instance != strings.TrimSpace(target.Instance) {
+			continue
+		}
+		if ref.CredentialMode != "" && ref.CredentialMode != target.CredentialMode {
+			continue
+		}
+		return true
 	}
 	return false
 }

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -1869,6 +1869,45 @@ func TestAgentRuntimeExecuteToolRejectsHiddenOperationWithoutExactGrant(t *testi
 		t.Fatalf("invoker idempotency key = %q, want agent-tool:turn-1:call-1", calls[0].idempotencyKey)
 	}
 
+	exactCatalogGrant, err := toolGrants.Mint(agentgrant.Grant{
+		ProviderName: "simple",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		SubjectID:    "user:user-123",
+		SubjectKind:  string(principal.KindUser),
+		Permissions: []core.AccessPermission{{
+			Plugin:     "slack",
+			Operations: []string{"events.reply"},
+		}},
+		ToolRefs: []coreagent.ToolRef{{
+			Plugin:    "slack",
+			Operation: "events.reply",
+		}},
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+	})
+	if err != nil {
+		t.Fatalf("Mint exact catalog grant: %v", err)
+	}
+	resp, err = runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "simple",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolCallID:   "call-2",
+		ToolID:       exactTools[0].ID,
+		ToolGrant:    exactCatalogGrant,
+		Arguments:    map[string]any{"eventId": "evt-2"},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTool exact hidden mcp catalog: %v", err)
+	}
+	if resp == nil || resp.Status != http.StatusAccepted || resp.Body != `{"eventId":"evt-2"}` {
+		t.Fatalf("ExecuteTool exact hidden mcp catalog response = %#v", resp)
+	}
+	calls = invoker.Calls()
+	if len(calls) != 2 || calls[1].providerName != "slack" || calls[1].operation != "events.reply" {
+		t.Fatalf("invoker calls = %#v, want slack events.reply twice", calls)
+	}
+
 	mixedGrant, err := toolGrants.Mint(agentgrant.Grant{
 		ProviderName: "simple",
 		SessionID:    "session-1",
@@ -1907,7 +1946,7 @@ func TestAgentRuntimeExecuteToolRejectsHiddenOperationWithoutExactGrant(t *testi
 		t.Fatalf("ExecuteTool visible wildcard response = %#v", resp)
 	}
 	calls = invoker.Calls()
-	if len(calls) != 2 || calls[1].providerName != "slack" || calls[1].operation != "chat.postMessage" {
+	if len(calls) != 3 || calls[2].providerName != "slack" || calls[2].operation != "chat.postMessage" {
 		t.Fatalf("invoker calls = %#v, want slack events.reply then chat.postMessage", calls)
 	}
 }
@@ -2215,6 +2254,46 @@ func TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn(t *testing.T) {
 	})
 	if !errors.Is(err, invocation.ErrAuthorizationDenied) {
 		t.Fatalf("SearchTools with mcp catalog grant error = %v, want ErrAuthorizationDenied", err)
+	}
+
+	emptyGrant, err := toolGrants.Mint(agentgrant.Grant{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		SubjectID:    "user:user-123",
+		SubjectKind:  string(principal.KindUser),
+		Permissions: []core.AccessPermission{{
+			Plugin:     "roadmap",
+			Operations: []string{"sync"},
+		}},
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+	})
+	if err != nil {
+		t.Fatalf("Mint empty grant: %v", err)
+	}
+	emptyListResp, err := runtime.ListTools(context.Background(), coreagent.ListToolsRequest{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		PageSize:     10,
+		ToolGrant:    emptyGrant,
+	})
+	if err != nil {
+		t.Fatalf("ListTools with empty mcp catalog grant: %v", err)
+	}
+	if len(emptyListResp.Tools) != 0 || emptyListResp.NextPageToken != "" {
+		t.Fatalf("ListTools empty grant = %#v, want no tools", emptyListResp)
+	}
+	_, err = runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolID:       tool.ToolID,
+		ToolGrant:    emptyGrant,
+		Arguments:    map[string]any{"taskId": "task-123"},
+	})
+	if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("ExecuteTool with empty mcp catalog grant error = %v, want ErrAuthorizationDenied", err)
 	}
 
 	broadGrant, err := toolGrants.Mint(agentgrant.Grant{

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -861,12 +861,13 @@ func (p *recordingAgentProvider) ResolveInteraction(_ context.Context, req corea
 
 func (p *recordingAgentProvider) GetCapabilities(context.Context, coreagent.GetCapabilitiesRequest) (*coreagent.ProviderCapabilities, error) {
 	return &coreagent.ProviderCapabilities{
-		StreamingText:    true,
-		ToolCalls:        true,
-		NativeToolSearch: true,
-		Interactions:     true,
-		ResumableTurns:   true,
-		StructuredOutput: true,
+		StreamingText:        true,
+		ToolCalls:            true,
+		Interactions:         true,
+		ResumableTurns:       true,
+		StructuredOutput:     true,
+		BoundedListHydration: true,
+		SupportedToolSources: []coreagent.ToolSourceMode{coreagent.ToolSourceModeMCPCatalog},
 	}, nil
 }
 
@@ -904,6 +905,8 @@ type callbackAgentProvider struct {
 	searchLoadRefs         []*proto.AgentToolRef
 	searchRequests         []*proto.SearchAgentToolsRequest
 	searchResponses        []*proto.SearchAgentToolsResponse
+	listRequests           []*proto.ListAgentToolsRequest
+	listResponses          []*proto.ListAgentToolsResponse
 	toolBodies             []string
 	resolveInteractionHook func(context.Context, coreagent.ResolveInteractionRequest) error
 }
@@ -996,7 +999,7 @@ func (p *callbackAgentProvider) CreateTurn(ctx context.Context, req coreagent.Cr
 	}
 
 	outputBody := ""
-	if req.ToolSource == coreagent.ToolSourceModeNativeSearch || len(req.Tools) > 0 {
+	if req.ToolSource == coreagent.ToolSourceModeMCPCatalog || req.ToolSource == coreagent.ToolSourceModeNativeSearch || len(req.Tools) > 0 {
 		conn, err := grpc.NewClient(
 			"passthrough:///localhost",
 			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
@@ -1012,7 +1015,29 @@ func (p *callbackAgentProvider) CreateTurn(ctx context.Context, req coreagent.Cr
 		defer func() { _ = conn.Close() }()
 		client := proto.NewAgentHostClient(conn)
 		tools := append([]coreagent.Tool(nil), req.Tools...)
-		if len(tools) == 0 {
+		if len(tools) == 0 && req.ToolSource == coreagent.ToolSourceModeMCPCatalog {
+			listReq := &proto.ListAgentToolsRequest{
+				SessionId: req.SessionID,
+				TurnId:    turnID,
+				PageSize:  5,
+				ToolGrant: req.ToolGrant,
+			}
+			listResp, err := client.ListTools(ctx, listReq)
+			if err != nil {
+				cleanupPendingTurn()
+				return nil, err
+			}
+			p.listRequests = append(p.listRequests, gproto.Clone(listReq).(*proto.ListAgentToolsRequest))
+			p.listResponses = append(p.listResponses, gproto.Clone(listResp).(*proto.ListAgentToolsResponse))
+			for _, tool := range listResp.GetTools() {
+				tools = append(tools, coreagent.Tool{
+					ID:          tool.GetId(),
+					Name:        tool.GetMcpName(),
+					Description: tool.GetDescription(),
+				})
+			}
+		}
+		if len(tools) == 0 && req.ToolSource == coreagent.ToolSourceModeNativeSearch {
 			searchQuery := strings.TrimSpace(p.searchQuery)
 			if searchQuery == "" {
 				searchQuery = "roadmap sync"
@@ -1138,12 +1163,13 @@ func (p *callbackAgentProvider) ResolveInteraction(ctx context.Context, req core
 
 func (p *callbackAgentProvider) GetCapabilities(context.Context, coreagent.GetCapabilitiesRequest) (*coreagent.ProviderCapabilities, error) {
 	return &coreagent.ProviderCapabilities{
-		StreamingText:    true,
-		ToolCalls:        true,
-		NativeToolSearch: true,
-		Interactions:     true,
-		ResumableTurns:   true,
-		StructuredOutput: true,
+		StreamingText:        true,
+		ToolCalls:            true,
+		Interactions:         true,
+		ResumableTurns:       true,
+		StructuredOutput:     true,
+		BoundedListHydration: true,
+		SupportedToolSources: []coreagent.ToolSourceMode{coreagent.ToolSourceModeMCPCatalog},
 	}, nil
 }
 
@@ -1214,7 +1240,13 @@ func (p *generatedIDAgentProvider) CancelTurn(_ context.Context, req coreagent.C
 }
 
 func (p *generatedIDAgentProvider) GetCapabilities(context.Context, coreagent.GetCapabilitiesRequest) (*coreagent.ProviderCapabilities, error) {
-	return &coreagent.ProviderCapabilities{StreamingText: true, NativeToolSearch: true, Interactions: true, ResumableTurns: true}, nil
+	return &coreagent.ProviderCapabilities{
+		StreamingText:        true,
+		Interactions:         true,
+		ResumableTurns:       true,
+		BoundedListHydration: true,
+		SupportedToolSources: []coreagent.ToolSourceMode{coreagent.ToolSourceModeMCPCatalog},
+	}, nil
 }
 
 func (p *generatedIDAgentProvider) Ping(context.Context) error { return nil }
@@ -1697,6 +1729,45 @@ func invokeAgentHostCallback(t *testing.T, hostServices []runtimehost.HostServic
 	t.Cleanup(func() { _ = conn.Close() })
 
 	return proto.NewAgentHostClient(conn).ExecuteTool(context.Background(), req)
+}
+
+func invokeAgentHostListTools(t *testing.T, hostServices []runtimehost.HostService, req *proto.ListAgentToolsRequest) *proto.ListAgentToolsResponse {
+	t.Helper()
+
+	if len(hostServices) != 1 {
+		t.Fatalf("agent host services = %d, want 1", len(hostServices))
+	}
+	if hostServices[0].Register == nil {
+		t.Fatal("agent host register func is nil")
+	}
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	hostServices[0].Register(srv)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	resp, err := proto.NewAgentHostClient(conn).ListTools(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	return resp
 }
 
 func withIndexedDBHostClient(t *testing.T, hostService runtimehost.HostService, fn func(proto.IndexedDBClient)) {
@@ -2579,11 +2650,11 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	if createTurnReq.CreatedBy.SubjectID != p.SubjectID {
 		t.Fatalf("CreateTurn created_by.subject_id = %q, want %q", createTurnReq.CreatedBy.SubjectID, p.SubjectID)
 	}
-	if len(createTurnReq.Tools) != 1 || createTurnReq.Tools[0].Target.Plugin != "roadmap" || createTurnReq.Tools[0].Target.Operation != "sync" {
-		t.Fatalf("CreateTurn tools = %#v, want preloaded roadmap.sync", createTurnReq.Tools)
+	if len(createTurnReq.Tools) != 0 {
+		t.Fatalf("CreateTurn tools = %#v, want no preloaded tools", createTurnReq.Tools)
 	}
-	if createTurnReq.ToolSource != coreagent.ToolSourceModeNativeSearch {
-		t.Fatalf("CreateTurn tool source = %q, want native search", createTurnReq.ToolSource)
+	if createTurnReq.ToolSource != coreagent.ToolSourceModeMCPCatalog {
+		t.Fatalf("CreateTurn tool source = %q, want mcp_catalog", createTurnReq.ToolSource)
 	}
 	if len(createTurnReq.ToolRefs) != 1 || createTurnReq.ToolRefs[0].Plugin != "roadmap" || createTurnReq.ToolRefs[0].Operation != "sync" {
 		t.Fatalf("CreateTurn tool refs = %#v", createTurnReq.ToolRefs)
@@ -2607,8 +2678,8 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 	provider.mu.Lock()
 	globalToolBodies := append([]string(nil), provider.toolBodies...)
 	provider.mu.Unlock()
-	if len(globalToolBodies) != 2 || !strings.Contains(globalToolBodies[1], `"subject":"user:user-123"`) || !strings.Contains(globalToolBodies[1], `"taskId":"task-123"`) {
-		t.Fatalf("global tool callback bodies = %#v", globalToolBodies)
+	if len(globalToolBodies) != 1 {
+		t.Fatalf("global tool callback bodies = %#v, want no execution for empty catalog grant", globalToolBodies)
 	}
 
 	_, err = result.AgentManager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
@@ -2616,14 +2687,14 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 		IdempotencyKey: "scoped-unavailable-idempotency-key",
 		Model:          "gpt-test",
 		Messages:       []coreagent.Message{{Role: "user", Text: "sync ashby"}},
-		ToolRefs:       []coreagent.ToolRef{{Plugin: "ashby"}},
+		ToolRefs:       []coreagent.ToolRef{{Plugin: "ashby", Operation: "sync"}},
 	})
 	if err == nil || !strings.Contains(err.Error(), `no external credential stored for integration "ashby"`) {
 		t.Fatalf("AgentManager.CreateTurn(scoped unavailable) error = %v, want ashby credential error", err)
 	}
 }
 
-func TestBootstrapAgentHostToolSearchPrioritizesNamedPluginIssueTools(t *testing.T) {
+func TestBootstrapAgentHostToolCatalogExecutesExactPluginIssueTool(t *testing.T) {
 	t.Parallel()
 
 	cfg := validConfig()
@@ -2825,6 +2896,7 @@ func TestBootstrapAgentHostToolSearchPrioritizesNamedPluginIssueTools(t *testing
 		IdempotencyKey: "linear-search-idempotency-key",
 		Model:          "gpt-test",
 		Messages:       []coreagent.Message{{Role: "user", Text: "get my linear tickets"}},
+		ToolRefs:       []coreagent.ToolRef{{Plugin: "linear", Operation: "list_issues"}},
 	})
 	if err != nil {
 		t.Fatalf("AgentManager.CreateTurn: %v", err)
@@ -2837,7 +2909,7 @@ func TestBootstrapAgentHostToolSearchPrioritizesNamedPluginIssueTools(t *testing
 	toolBodies := append([]string(nil), provider.toolBodies...)
 	provider.mu.Unlock()
 	if len(toolBodies) != 1 || !strings.Contains(toolBodies[0], `"provider":"linear"`) || !strings.Contains(toolBodies[0], `"operation":"list_issues"`) {
-		t.Fatalf("tool callback bodies = %#v, want first searched tool to be linear.list_issues", toolBodies)
+		t.Fatalf("tool callback bodies = %#v, want exact catalog tool linear.list_issues", toolBodies)
 	}
 
 	provider.mu.Lock()
@@ -2848,6 +2920,7 @@ func TestBootstrapAgentHostToolSearchPrioritizesNamedPluginIssueTools(t *testing
 		IdempotencyKey: "linear-search-after-unavailable-idempotency-key",
 		Model:          "gpt-test",
 		Messages:       []coreagent.Message{{Role: "user", Text: "get my assigned tickets"}},
+		ToolRefs:       []coreagent.ToolRef{{Plugin: "linear", Operation: "list_issues"}},
 	})
 	if err != nil {
 		t.Fatalf("AgentManager.CreateTurn(after unavailable hits): %v", err)
@@ -2860,12 +2933,12 @@ func TestBootstrapAgentHostToolSearchPrioritizesNamedPluginIssueTools(t *testing
 	toolBodies = append([]string(nil), provider.toolBodies...)
 	provider.mu.Unlock()
 	if len(toolBodies) != 2 || !strings.Contains(toolBodies[1], `"provider":"linear"`) || !strings.Contains(toolBodies[1], `"operation":"list_issues"`) {
-		t.Fatalf("tool callback bodies after unavailable hits = %#v, want second searched tool to be linear.list_issues", toolBodies)
+		t.Fatalf("tool callback bodies after unavailable hits = %#v, want exact catalog tool linear.list_issues", toolBodies)
 	}
 
 }
 
-func TestBootstrapAgentHostToolSearchReturnsCandidatesAndLoadsRefs(t *testing.T) {
+func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T) {
 	t.Parallel()
 
 	cfg := validConfig()
@@ -2957,6 +3030,12 @@ func TestBootstrapAgentHostToolSearchReturnsCandidatesAndLoadsRefs(t *testing.T)
 		IdempotencyKey: "candidate-search-idempotency-key",
 		Model:          "gpt-test",
 		Messages:       []coreagent.Message{{Role: "user", Text: "search docs"}},
+		ToolRefs: []coreagent.ToolRef{
+			{Plugin: "docs", Operation: "alpha_search"},
+			{Plugin: "docs", Operation: "beta_list"},
+			{Plugin: "docs", Operation: "delta_export"},
+			{Plugin: "docs", Operation: "gamma_get"},
+		},
 	})
 	if err != nil {
 		t.Fatalf("AgentManager.CreateTurn(search): %v", err)
@@ -2966,18 +3045,18 @@ func TestBootstrapAgentHostToolSearchReturnsCandidatesAndLoadsRefs(t *testing.T)
 	}
 
 	provider.mu.Lock()
-	searchResponses := append([]*proto.SearchAgentToolsResponse(nil), provider.searchResponses...)
+	listResponses := append([]*proto.ListAgentToolsResponse(nil), provider.listResponses...)
 	toolBodies := append([]string(nil), provider.toolBodies...)
 	provider.mu.Unlock()
-	if len(searchResponses) != 1 {
-		t.Fatalf("search response count = %d, want 1", len(searchResponses))
+	if len(listResponses) != 1 {
+		t.Fatalf("list response count = %d, want 1", len(listResponses))
 	}
-	searchResp := searchResponses[0]
-	if len(searchResp.GetTools()) != 1 || searchResp.GetTools()[0].GetId() == "" {
-		t.Fatalf("loaded search tools = %#v, want one docs tool", searchResp.GetTools())
+	listResp := listResponses[0]
+	if len(listResp.GetTools()) != 4 {
+		t.Fatalf("listed tools = %#v, want four visible docs tools", listResp.GetTools())
 	}
 	if len(toolBodies) != 1 {
-		t.Fatalf("tool callback bodies = %#v, want one searched tool execution", toolBodies)
+		t.Fatalf("tool callback bodies = %#v, want one listed tool execution", toolBodies)
 	}
 	var loadedBody map[string]string
 	if err := json.Unmarshal([]byte(toolBodies[0]), &loadedBody); err != nil {
@@ -2990,72 +3069,42 @@ func TestBootstrapAgentHostToolSearchReturnsCandidatesAndLoadsRefs(t *testing.T)
 	if loadedOperation == "" || loadedOperation == "hidden_admin" {
 		t.Fatalf("loaded operation = %q, want visible docs operation", loadedOperation)
 	}
-	if len(searchResp.GetCandidates()) != 2 {
-		t.Fatalf("search candidates len = %d, want 2: %#v", len(searchResp.GetCandidates()), searchResp.GetCandidates())
-	}
-	candidateOperations := map[string]bool{}
-	for _, candidate := range searchResp.GetCandidates() {
-		operation := candidate.GetRef().GetOperation()
-		if operation == "" || operation == loadedOperation || operation == "hidden_admin" {
-			t.Fatalf("candidate operation = %q, loaded = %q, candidates = %#v", operation, loadedOperation, searchResp.GetCandidates())
+	var betaOperation string
+	for _, tool := range listResp.GetTools() {
+		ref := tool.GetRef()
+		if ref.GetOperation() == "hidden_admin" {
+			t.Fatalf("listed hidden tool = %#v, want only visible tools for broad catalog", tool)
 		}
-		candidateOperations[operation] = true
+		if ref.GetOperation() == "beta_list" {
+			betaOperation = ref.GetOperation()
+		}
 	}
-	if len(candidateOperations) != 2 {
-		t.Fatalf("candidate operations = %#v, want two distinct operations", candidateOperations)
+	if betaOperation == "" {
+		t.Fatalf("listed tools = %#v, want beta_list", listResp.GetTools())
 	}
-	if !searchResp.GetHasMore() {
-		t.Fatal("search has_more = false, want true after candidate limit")
-	}
-
-	betaRef := gproto.Clone(searchResp.GetCandidates()[0].GetRef()).(*proto.AgentToolRef)
-	betaOperation := betaRef.GetOperation()
-	provider.mu.Lock()
-	provider.searchMaxResults = -1
-	provider.searchCandidateLimit = 0
-	provider.searchLoadRefs = []*proto.AgentToolRef{betaRef}
-	provider.mu.Unlock()
 	exact, err := result.AgentManager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
 		SessionID:      session.ID,
 		IdempotencyKey: "candidate-load-ref-idempotency-key",
 		Model:          "gpt-test",
 		Messages:       []coreagent.Message{{Role: "user", Text: "load beta docs"}},
+		ToolRefs:       []coreagent.ToolRef{{Plugin: "docs", Operation: betaOperation}},
 	})
 	if err != nil {
-		t.Fatalf("AgentManager.CreateTurn(load ref): %v", err)
+		t.Fatalf("AgentManager.CreateTurn(exact ref): %v", err)
 	}
 	if exact == nil {
-		t.Fatal("AgentManager.CreateTurn(load ref) returned nil turn")
+		t.Fatal("AgentManager.CreateTurn(exact ref) returned nil turn")
 	}
 
 	provider.mu.Lock()
 	toolBodies = append([]string(nil), provider.toolBodies...)
 	provider.mu.Unlock()
 	if len(toolBodies) != 2 || !strings.Contains(toolBodies[1], fmt.Sprintf(`"operation":"%s"`, betaOperation)) {
-		t.Fatalf("tool callback bodies after load_ref = %#v, want %s", toolBodies, betaOperation)
-	}
-
-	provider.mu.Lock()
-	provider.searchLoadRefs = []*proto.AgentToolRef{{Plugin: "docs", Operation: "hidden_admin"}}
-	provider.mu.Unlock()
-	_, err = result.AgentManager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
-		SessionID:      session.ID,
-		IdempotencyKey: "candidate-hidden-load-ref-idempotency-key",
-		Model:          "gpt-test",
-		Messages:       []coreagent.Message{{Role: "user", Text: "load hidden docs"}},
-	})
-	if err != nil {
-		t.Fatalf("AgentManager.CreateTurn(hidden load ref): %v", err)
-	}
-	provider.mu.Lock()
-	toolBodies = append([]string(nil), provider.toolBodies...)
-	provider.mu.Unlock()
-	if len(toolBodies) != 2 {
-		t.Fatalf("tool callback bodies after hidden load_ref = %#v, want no hidden execution", toolBodies)
+		t.Fatalf("tool callback bodies after exact ref = %#v, want %s", toolBodies, betaOperation)
 	}
 }
 
-func TestBootstrapHTTPCallerWildcardSearchUsesResolvedUserToolScope(t *testing.T) {
+func TestBootstrapHTTPCallerWildcardCatalogToolRefsAreRejected(t *testing.T) {
 	t.Parallel()
 
 	cfg := validConfig()
@@ -3093,7 +3142,6 @@ func TestBootstrapHTTPCallerWildcardSearchUsesResolvedUserToolScope(t *testing.T
 		},
 	})
 
-	var provider *callbackAgentProvider
 	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, hostServices []runtimehost.HostService, _ bootstrap.Deps) (coreagent.Provider, error) {
 		started, err := runtimehost.StartHostServices(hostServices)
 		if err != nil {
@@ -3105,7 +3153,6 @@ func TestBootstrapHTTPCallerWildcardSearchUsesResolvedUserToolScope(t *testing.T
 			return nil, err
 		}
 		value.searchQuery = "Linear list issues assigned to me"
-		provider = value
 		return value, nil
 	}
 
@@ -3148,18 +3195,11 @@ func TestBootstrapHTTPCallerWildcardSearchUsesResolvedUserToolScope(t *testing.T
 		Messages:         []coreagent.Message{{Role: "user", Text: "get my linear tickets"}},
 		ToolRefs:         []coreagent.ToolRef{{Plugin: "*"}},
 	})
-	if err != nil {
-		t.Fatalf("AgentManager.CreateTurn: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "mcp catalog") {
+		t.Fatalf("AgentManager.CreateTurn wildcard error = %v, want mcp catalog validation error", err)
 	}
-	if turn == nil {
-		t.Fatal("AgentManager.CreateTurn returned nil turn")
-	}
-
-	provider.mu.Lock()
-	toolBodies := append([]string(nil), provider.toolBodies...)
-	provider.mu.Unlock()
-	if len(toolBodies) != 1 || !strings.Contains(toolBodies[0], `"provider":"linear"`) || !strings.Contains(toolBodies[0], `"operation":"issues"`) {
-		t.Fatalf("tool callback bodies = %#v, want searched linear.issues", toolBodies)
+	if turn != nil {
+		t.Fatalf("AgentManager.CreateTurn returned turn %#v, want nil on wildcard rejection", turn)
 	}
 }
 
@@ -6277,10 +6317,19 @@ func TestBootstrapStartsAgentProvidersAfterInvokerIsReady(t *testing.T) {
 	if strings.TrimSpace(createTurnReq.ToolGrant) == "" {
 		t.Fatal("CreateTurn tool_grant is empty")
 	}
-	if len(createTurnReq.Tools) != 1 {
-		t.Fatalf("CreateTurn tools = %#v, want one tool", createTurnReq.Tools)
+	if len(createTurnReq.Tools) != 0 {
+		t.Fatalf("CreateTurn tools = %#v, want no preloaded tools", createTurnReq.Tools)
 	}
-	tool := createTurnReq.Tools[0]
+	listResp := invokeAgentHostListTools(t, capturedHostServices, &proto.ListAgentToolsRequest{
+		SessionId: session.ID,
+		TurnId:    turn.ID,
+		PageSize:  5,
+		ToolGrant: createTurnReq.ToolGrant,
+	})
+	if len(listResp.GetTools()) != 1 {
+		t.Fatalf("ListTools tools = %#v, want one tool", listResp.GetTools())
+	}
+	tool := listResp.GetTools()[0]
 	args, err := structpb.NewStruct(map[string]any{"taskId": "task-123"})
 	if err != nil {
 		t.Fatalf("structpb.NewStruct: %v", err)
@@ -6289,7 +6338,7 @@ func TestBootstrapStartsAgentProvidersAfterInvokerIsReady(t *testing.T) {
 		SessionId:  session.ID,
 		TurnId:     turn.ID,
 		ToolCallId: "tool-call-1",
-		ToolId:     tool.ID,
+		ToolId:     tool.GetId(),
 		Arguments:  args,
 		ToolGrant:  createTurnReq.ToolGrant,
 	})
@@ -6310,7 +6359,7 @@ func TestBootstrapStartsAgentProvidersAfterInvokerIsReady(t *testing.T) {
 		SessionId:  "wrong-session",
 		TurnId:     turn.ID,
 		ToolCallId: "tool-call-mismatch",
-		ToolId:     tool.ID,
+		ToolId:     tool.GetId(),
 		Arguments:  args,
 		ToolGrant:  createTurnReq.ToolGrant,
 	}); status.Code(err) != codes.PermissionDenied {
@@ -6328,7 +6377,7 @@ func TestBootstrapStartsAgentProvidersAfterInvokerIsReady(t *testing.T) {
 		SessionId:  session.ID,
 		TurnId:     turn.ID,
 		ToolCallId: "tool-call-wrong-turn",
-		ToolId:     tool.ID,
+		ToolId:     tool.GetId(),
 		Arguments:  args,
 		ToolGrant:  createTurnReq.ToolGrant,
 	}); status.Code(err) != codes.PermissionDenied {
@@ -6362,7 +6411,7 @@ func TestBootstrapStartsAgentProvidersAfterInvokerIsReady(t *testing.T) {
 		SessionId:  session.ID,
 		TurnId:     turn.ID,
 		ToolCallId: "tool-call-2",
-		ToolId:     tool.ID,
+		ToolId:     tool.GetId(),
 		Arguments:  args,
 		ToolGrant:  createTurnReq.ToolGrant,
 	}); status.Code(err) != codes.PermissionDenied {
@@ -6451,9 +6500,22 @@ func TestBootstrapDoesNotRevokeAgentGrantWhenCancelReturnsLiveTurn(t *testing.T)
 		stored.CompletedAt = nil
 	}
 	providerImpl.mu.Unlock()
-	if strings.TrimSpace(createTurnReq.ToolGrant) == "" || len(createTurnReq.Tools) != 1 {
-		t.Fatalf("CreateTurn request = %#v, want tool grant and one tool", createTurnReq)
+	if strings.TrimSpace(createTurnReq.ToolGrant) == "" {
+		t.Fatal("CreateTurn tool_grant is empty")
 	}
+	if len(createTurnReq.Tools) != 0 {
+		t.Fatalf("CreateTurn tools = %#v, want no preloaded tools", createTurnReq.Tools)
+	}
+	listResp := invokeAgentHostListTools(t, capturedHostServices, &proto.ListAgentToolsRequest{
+		SessionId: session.ID,
+		TurnId:    turn.ID,
+		PageSize:  5,
+		ToolGrant: createTurnReq.ToolGrant,
+	})
+	if len(listResp.GetTools()) != 1 {
+		t.Fatalf("ListTools tools = %#v, want one tool", listResp.GetTools())
+	}
+	tool := listResp.GetTools()[0]
 	args, err := structpb.NewStruct(map[string]any{"taskId": "task-123"})
 	if err != nil {
 		t.Fatalf("structpb.NewStruct: %v", err)
@@ -6462,7 +6524,7 @@ func TestBootstrapDoesNotRevokeAgentGrantWhenCancelReturnsLiveTurn(t *testing.T)
 		SessionId:  session.ID,
 		TurnId:     turn.ID,
 		ToolCallId: "tool-call-before-cancel",
-		ToolId:     createTurnReq.Tools[0].ID,
+		ToolId:     tool.GetId(),
 		Arguments:  args,
 		ToolGrant:  createTurnReq.ToolGrant,
 	}); err != nil {
@@ -6478,7 +6540,7 @@ func TestBootstrapDoesNotRevokeAgentGrantWhenCancelReturnsLiveTurn(t *testing.T)
 		SessionId:  session.ID,
 		TurnId:     turn.ID,
 		ToolCallId: "tool-call-after-live-cancel",
-		ToolId:     createTurnReq.Tools[0].ID,
+		ToolId:     tool.GetId(),
 		Arguments:  args,
 		ToolGrant:  createTurnReq.ToolGrant,
 	}); err != nil {

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -1162,7 +1162,7 @@ func fakeHostedAgentManagerRoundTrip(invocationToken string, env map[string]stri
 		SessionId:       sessionID,
 		Model:           "gpt-test",
 		IdempotencyKey:  "plugin-agent-turn",
-		ToolSource:      proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_NATIVE_SEARCH,
+		ToolSource:      proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_MCP_CATALOG,
 		ToolRefs: []*proto.AgentToolRef{{
 			Plugin:    "roadmap",
 			Operation: "sync",
@@ -1994,12 +1994,13 @@ func (p *stubAgentTurnManagerProvider) ResolveInteraction(_ context.Context, req
 
 func (p *stubAgentTurnManagerProvider) GetCapabilities(context.Context, coreagent.GetCapabilitiesRequest) (*coreagent.ProviderCapabilities, error) {
 	return &coreagent.ProviderCapabilities{
-		StreamingText:    true,
-		ToolCalls:        true,
-		NativeToolSearch: true,
-		Interactions:     true,
-		ResumableTurns:   true,
-		StructuredOutput: true,
+		StreamingText:        true,
+		ToolCalls:            true,
+		Interactions:         true,
+		ResumableTurns:       true,
+		StructuredOutput:     true,
+		BoundedListHydration: true,
+		SupportedToolSources: []coreagent.ToolSourceMode{coreagent.ToolSourceModeMCPCatalog},
 	}, nil
 }
 
@@ -4067,11 +4068,11 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 	if requireInteraction, _ := turnReq.Metadata["requireInteraction"].(bool); !requireInteraction {
 		t.Fatalf("CreateTurn metadata = %#v, want requireInteraction=true", turnReq.Metadata)
 	}
-	if len(turnReq.Tools) != 1 || turnReq.Tools[0].Target.Plugin != "roadmap" || turnReq.Tools[0].Target.Operation != "sync" {
-		t.Fatalf("CreateTurn tools = %#v, want preloaded roadmap.sync", turnReq.Tools)
+	if len(turnReq.Tools) != 0 {
+		t.Fatalf("CreateTurn tools = %#v, want no preloaded tools", turnReq.Tools)
 	}
-	if turnReq.ToolSource != coreagent.ToolSourceModeNativeSearch {
-		t.Fatalf("CreateTurn tool source = %q, want native search", turnReq.ToolSource)
+	if turnReq.ToolSource != coreagent.ToolSourceModeMCPCatalog {
+		t.Fatalf("CreateTurn tool source = %q, want mcp_catalog", turnReq.ToolSource)
 	}
 	if len(turnReq.ToolRefs) != 1 || turnReq.ToolRefs[0].Plugin != "roadmap" || turnReq.ToolRefs[0].Operation != "sync" {
 		t.Fatalf("CreateTurn tool refs = %#v", turnReq.ToolRefs)

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -354,7 +354,6 @@ func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.Invo
 		Model:            agentTarget.Model,
 		Messages:         messages,
 		ToolRefs:         append([]coreagent.ToolRef(nil), agentTarget.ToolRefs...),
-		ToolSource:       coreagent.ToolSourceModeNativeSearch,
 		ResponseSchema:   maps.Clone(agentTarget.ResponseSchema),
 		Metadata:         metadata,
 		ProviderOptions:  maps.Clone(agentTarget.ProviderOptions),

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -612,11 +612,11 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 	if _, ok := metadataPayload["payload"]; ok {
 		t.Fatalf("turn metadata retained raw payload: %#v", metadataPayload)
 	}
-	if len(turnReq.Tools) != 1 || turnReq.Tools[0].Target.Plugin != "roadmap" || turnReq.Tools[0].Target.Operation != "sync" {
-		t.Fatalf("turn tools = %#v, want preloaded roadmap.sync", turnReq.Tools)
+	if len(turnReq.Tools) != 0 {
+		t.Fatalf("turn tools = %#v, want no preloaded tools", turnReq.Tools)
 	}
-	if turnReq.ToolSource != coreagent.ToolSourceModeNativeSearch {
-		t.Fatalf("turn tool source = %q, want native search", turnReq.ToolSource)
+	if turnReq.ToolSource != coreagent.ToolSourceModeMCPCatalog {
+		t.Fatalf("turn tool source = %q, want mcp_catalog", turnReq.ToolSource)
 	}
 	if len(turnReq.ToolRefs) != 1 || turnReq.ToolRefs[0].Plugin != "roadmap" || turnReq.ToolRefs[0].Operation != "sync" {
 		t.Fatalf("turn tool refs = %#v", turnReq.ToolRefs)

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -389,13 +389,11 @@ func (p *memoryAgentProvider) GetCapabilities(context.Context, coreagent.GetCapa
 	return &coreagent.ProviderCapabilities{
 		StreamingText:        true,
 		ToolCalls:            true,
-		NativeToolSearch:     true,
 		Interactions:         true,
 		ResumableTurns:       true,
 		StructuredOutput:     true,
 		BoundedListHydration: true,
 		SupportedToolSources: []coreagent.ToolSourceMode{
-			coreagent.ToolSourceModeNativeSearch,
 			coreagent.ToolSourceModeMCPCatalog,
 		},
 	}, nil
@@ -616,11 +614,11 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	if gotProvider.Name != "managed" || !gotProvider.Default {
 		t.Fatalf("provider = %#v, want managed default", gotProvider)
 	}
-	if !gotProvider.Capabilities.StreamingText || !gotProvider.Capabilities.NativeToolSearch || !gotProvider.Capabilities.BoundedListHydration {
-		t.Fatalf("provider capabilities = %#v, want streaming text, native tool search, and bounded list hydration", gotProvider.Capabilities)
+	if !gotProvider.Capabilities.StreamingText || gotProvider.Capabilities.NativeToolSearch || !gotProvider.Capabilities.BoundedListHydration {
+		t.Fatalf("provider capabilities = %#v, want streaming text, catalog listing, and no native tool search", gotProvider.Capabilities)
 	}
-	if got := gotProvider.Capabilities.SupportedToolSources; strings.Join(got, ",") != "native_search,mcp_catalog" {
-		t.Fatalf("supported tool sources = %#v, want native_search,mcp_catalog", got)
+	if got := gotProvider.Capabilities.SupportedToolSources; strings.Join(got, ",") != "mcp_catalog" {
+		t.Fatalf("supported tool sources = %#v, want mcp_catalog", got)
 	}
 
 	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}],"toolSource":"mcp_catalog","toolRefs":[{"plugin":"docs","operation":"search"}]}`))
@@ -642,8 +640,8 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	if len(turnRequests) != 1 {
 		t.Fatalf("provider turn requests len = %d, want 1", len(turnRequests))
 	}
-	if got := turnRequests[0].Tools; len(got) != 1 || got[0].Target.Plugin != "docs" || got[0].Target.Operation != "search" {
-		t.Fatalf("provider turn tools = %#v, want docs.search", got)
+	if got := turnRequests[0].Tools; len(got) != 0 {
+		t.Fatalf("provider turn tools = %#v, want no preloaded tools", got)
 	}
 	if turnRequests[0].ToolSource != coreagent.ToolSourceModeMCPCatalog {
 		t.Fatalf("provider turn tool source = %q, want mcp_catalog", turnRequests[0].ToolSource)

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -570,7 +570,7 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 		return nil, err
 	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ownedSession.providerName))
-	toolSource, err := validateToolSource(req.ToolSource)
+	toolSource, err := validateProviderTurnToolSource(req.ToolSource)
 	if err != nil {
 		return nil, err
 	}
@@ -582,10 +582,8 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	if err != nil {
 		return nil, err
 	}
-	if toolSource == coreagent.ToolSourceModeMCPCatalog {
-		if err := validateMCPCatalogToolRefs(toolRefs); err != nil {
-			return nil, err
-		}
+	if err := validateMCPCatalogToolRefs(toolRefs); err != nil {
+		return nil, err
 	}
 	if err := m.authorizeToolRefs(ctx, p, toolRefs); err != nil {
 		return nil, err
@@ -595,13 +593,6 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 		return nil, err
 	} else if !supported {
 		return nil, fmt.Errorf("agent provider %q does not support tool source %q", ownedSession.providerName, toolSource)
-	}
-	resolvableToolRefs := resolvableAgentToolRefs(toolRefs)
-	if len(resolvableToolRefs) > 0 {
-		tools, err = m.resolveExactAgentToolRefs(ctx, p, resolvableToolRefs)
-		if err != nil {
-			return nil, err
-		}
 	}
 	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
 	turnID := newAgentTurnID(ownedSession.session.ID, idempotencyKey)
@@ -1219,6 +1210,9 @@ func (m *Manager) listTools(ctx context.Context, p *principal.Principal, req cor
 	if err != nil {
 		return nil, err
 	}
+	if len(refs) == 0 {
+		return &coreagent.ListToolsResponse{}, nil
+	}
 
 	out := make([]coreagent.ListedTool, 0, len(refs))
 	seen := map[agentToolTargetKey]struct{}{}
@@ -1454,30 +1448,6 @@ func agentToolCandidateParameterNames(op catalog.CatalogOperation) []string {
 		out = append(out, name)
 	}
 	return out
-}
-
-func (m *Manager) resolveExactAgentToolRefs(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef) ([]coreagent.Tool, error) {
-	if len(refs) == 0 {
-		return nil, nil
-	}
-	out := make([]coreagent.Tool, 0, len(refs))
-	seen := make(map[agentToolTargetKey]struct{}, len(refs))
-	for i := range refs {
-		if strings.TrimSpace(refs[i].Operation) == "" {
-			return nil, fmt.Errorf("%w: agent tool_refs[%d] requires native tool search", invocation.ErrInternal, i)
-		}
-		tool, err := m.resolveTool(ctx, p, refs[i])
-		if err != nil {
-			return nil, fmt.Errorf("agent tool_refs[%d]: %w", i, err)
-		}
-		key := agentToolTargetKeyFromTarget(tool.Target)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		out = append(out, tool)
-	}
-	return out, nil
 }
 
 func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref coreagent.ToolRef) (coreagent.Tool, error) {
@@ -2476,6 +2446,18 @@ func validateToolSource(source coreagent.ToolSourceMode) (coreagent.ToolSourceMo
 	return source, nil
 }
 
+func validateProviderTurnToolSource(source coreagent.ToolSourceMode) (coreagent.ToolSourceMode, error) {
+	source = coreagent.ToolSourceMode(strings.TrimSpace(string(source)))
+	switch source {
+	case coreagent.ToolSourceModeUnspecified, coreagent.ToolSourceModeMCPCatalog:
+		return coreagent.ToolSourceModeMCPCatalog, nil
+	case coreagent.ToolSourceModeNativeSearch:
+		return "", fmt.Errorf("%w: agent tool source %q is deprecated; use %q", invocation.ErrInvalidInvocation, source, coreagent.ToolSourceModeMCPCatalog)
+	default:
+		return "", fmt.Errorf("%w: unsupported agent tool source %q", invocation.ErrInvalidInvocation, source)
+	}
+}
+
 func agentRunPermissions(ctx context.Context, p *principal.Principal, callerPluginName string, refs []coreagent.ToolRef) []core.AccessPermission {
 	p = principal.Canonicalized(p)
 	if p == nil {
@@ -2558,31 +2540,6 @@ func normalizeToolRefs(refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
 		out = append(out, ref)
 	}
 	return out, nil
-}
-
-func resolvableAgentToolRefs(refs []coreagent.ToolRef) []coreagent.ToolRef {
-	if len(refs) == 0 {
-		return nil
-	}
-	out := make([]coreagent.ToolRef, 0, len(refs))
-	for i := range refs {
-		ref := refs[i]
-		if strings.TrimSpace(ref.System) != "" {
-			if strings.TrimSpace(ref.Operation) == "" {
-				continue
-			}
-			out = append(out, ref)
-			continue
-		}
-		if strings.TrimSpace(ref.Plugin) == agentToolSearchAllPlugin {
-			continue
-		}
-		if strings.TrimSpace(ref.Operation) == "" {
-			continue
-		}
-		out = append(out, ref)
-	}
-	return out
 }
 
 func exactAgentToolRefs(refs []coreagent.ToolRef) []coreagent.ToolRef {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -108,6 +108,7 @@ type routeCountingAgentProvider struct {
 	sessions        map[string]*coreagent.Session
 	turns           map[string]*coreagent.Turn
 	capabilities    *coreagent.ProviderCapabilities
+	createTurnReqs  []coreagent.CreateTurnRequest
 	turnIDOverride  string
 	cancelStatus    coreagent.ExecutionStatus
 	getSessionCalls int
@@ -145,6 +146,7 @@ func (p *routeCountingAgentProvider) GetSession(_ context.Context, req coreagent
 }
 
 func (p *routeCountingAgentProvider) CreateTurn(_ context.Context, req coreagent.CreateTurnRequest) (*coreagent.Turn, error) {
+	p.createTurnReqs = append(p.createTurnReqs, req)
 	turnID := req.TurnID
 	if strings.TrimSpace(p.turnIDOverride) != "" {
 		turnID = p.turnIDOverride
@@ -191,7 +193,12 @@ func (p *routeCountingAgentProvider) GetCapabilities(context.Context, coreagent.
 		caps.SupportedToolSources = append([]coreagent.ToolSourceMode(nil), p.capabilities.SupportedToolSources...)
 		return &caps, nil
 	}
-	return &coreagent.ProviderCapabilities{NativeToolSearch: true}, nil
+	return &coreagent.ProviderCapabilities{
+		BoundedListHydration: true,
+		SupportedToolSources: []coreagent.ToolSourceMode{
+			coreagent.ToolSourceModeMCPCatalog,
+		},
+	}, nil
 }
 
 func cloneRouteSession(session *coreagent.Session) *coreagent.Session {
@@ -238,7 +245,9 @@ func TestManagerCachesProviderRoutesForOwnedSessionAndTurn(t *testing.T) {
 	t.Parallel()
 
 	alpha := newRouteCountingAgentProvider("alpha")
-	alpha.capabilities = &coreagent.ProviderCapabilities{}
+	alpha.capabilities = &coreagent.ProviderCapabilities{
+		SupportedToolSources: []coreagent.ToolSourceMode{coreagent.ToolSourceModeMCPCatalog},
+	}
 	beta := newRouteCountingAgentProvider("beta")
 	manager := newTestManager(t, Config{
 		Agent: &routeCountingAgentControl{
@@ -339,7 +348,7 @@ func TestManagerCreateTurnAcceptsProviderOwnedIDForIdempotentReplay(t *testing.T
 	}
 }
 
-func TestManagerCreateTurnTreatsSupportedToolSourcesAsAuthoritative(t *testing.T) {
+func TestManagerCreateTurnDefaultsToMCPCatalogForProviderTurns(t *testing.T) {
 	t.Parallel()
 
 	alpha := newRouteCountingAgentProvider("alpha")
@@ -372,11 +381,56 @@ func TestManagerCreateTurnTreatsSupportedToolSourcesAsAuthoritative(t *testing.T
 		SessionID: session.ID,
 		Model:     "test-model",
 	})
-	if err == nil {
-		t.Fatal("CreateTurn error = nil, want unsupported native-search tool source")
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
 	}
-	if !strings.Contains(err.Error(), `does not support tool source "native_search"`) {
-		t.Fatalf("CreateTurn error = %v, want unsupported native-search tool source", err)
+	if len(alpha.createTurnReqs) != 1 {
+		t.Fatalf("CreateTurn requests = %d, want 1", len(alpha.createTurnReqs))
+	}
+	if got := alpha.createTurnReqs[0].ToolSource; got != coreagent.ToolSourceModeMCPCatalog {
+		t.Fatalf("CreateTurn tool source = %q, want mcp_catalog", got)
+	}
+	if got := alpha.createTurnReqs[0].Tools; len(got) != 0 {
+		t.Fatalf("CreateTurn tools = %#v, want no preloaded tools", got)
+	}
+}
+
+func TestManagerCreateTurnRejectsNativeSearchToolSource(t *testing.T) {
+	t.Parallel()
+
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		ToolGrants: newAgentManagerTestToolGrants(t),
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID:  session.ID,
+		Model:      "test-model",
+		ToolSource: coreagent.ToolSourceModeNativeSearch,
+	})
+	if err == nil {
+		t.Fatal("CreateTurn error = nil, want deprecated native-search tool source")
+	}
+	if !strings.Contains(err.Error(), "deprecated") || !strings.Contains(err.Error(), string(coreagent.ToolSourceModeNativeSearch)) {
+		t.Fatalf("CreateTurn error = %v, want deprecated native-search tool source", err)
+	}
+	if len(alpha.createTurnReqs) != 0 {
+		t.Fatalf("CreateTurn requests = %d, want 0", len(alpha.createTurnReqs))
 	}
 }
 


### PR DESCRIPTION
## Summary

Provider-facing turns now use the MCP catalog/list contract instead of Gestalt-owned native search:
- default/unspecified turn tool source is normalized to `mcp_catalog` before calling the provider
- `native_search` is rejected for new provider turns as deprecated
- exact refs are no longer preloaded into `CreateTurnRequest.Tools`; providers receive refs plus a tool grant and call `AgentHost.ListTools` / `ExecuteTool`
- empty `toolRefs` is valid and means the provider receives an empty catalog rather than a broad wildcard

## Interface Changes
- New/changed interface: `Manager.CreateTurn` provider requests now carry `ToolSource=mcp_catalog`, empty `Tools`, and the authorized exact `ToolRefs`; `native_search` is no longer accepted for new provider turns.
- Example usage:

```json
{
  "messages": [{"role": "user", "text": "sync roadmap"}],
  "toolRefs": [{"plugin": "roadmap", "operation": "sync"}]
}
```

The provider receives the turn with `toolSource: "mcp_catalog"` and uses `AgentHost.ListTools` with the turn grant to retrieve the current MCP tool IDs before `ExecuteTool`.

## Functional/Integration Tests
- Tests added or augmented: agent manager, HTTP agent session/turn, workflow runtime, plugin-host agent manager, and bootstrap host callback tests now exercise catalog grants and list-then-execute behavior.
- Contract boundary covered: HTTP/workflow/plugin entrypoints -> agent manager -> provider `CreateTurn` -> `AgentHost.ListTools` / `ExecuteTool`.
- Commands run:

```sh
go test ./internal/bootstrap ./internal/server ./services/agents/...
```

Follow-up stack:
- `valon-technologies/gestalt-providers` provider PR updates Claude/simple providers to own tool discovery over `AgentHost.ListTools`.
- `valon-technologies/toolshed` deployment bump is blocked until this PR is merged/pinned and provider releases exist.
