### PR TITLE
Remove provider-dev session relay registrations

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -57,6 +57,7 @@ import (
 	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	graphqlschema "github.com/valon-technologies/gestalt/server/services/plugins/graphql"
 	"github.com/valon-technologies/gestalt/server/services/plugins/registry"
+	"github.com/valon-technologies/gestalt/server/services/providerdev"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	s3service "github.com/valon-technologies/gestalt/server/services/s3"
 	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
@@ -65,6 +66,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v3"
@@ -6039,50 +6041,163 @@ func TestProviderDevRuntimeEnvUsesPublicHostServiceRelay(t *testing.T) {
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)
 
-	env, err := buildProviderDevRuntimeEnv("echoext", &config.ProviderEntry{
+	entry := &config.ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Source: "local://echoext",
+		},
 		S3: []string{"main"},
-	}, Deps{
+	}
+	deps := Deps{
 		BaseURL:            relaySrv.URL,
 		EncryptionKey:      secret,
 		PublicHostServices: publicHostServices,
 		S3: map[string]s3store.Client{
 			"main": &coretesting.StubS3{},
 		},
-	}, "provider-dev-session", false)
-	if err != nil {
-		t.Fatalf("buildProviderDevRuntimeEnv: %v", err)
 	}
-	cleanup := env.Cleanup
+	runtimeHostServiceDescriptors := map[string][]hostServiceBindingDescriptor{}
+	manager, err := providerdev.NewManager([]providerdev.Target{{
+		Name: "echoext",
+		RuntimeEnv: func(sessionID string) (providerdev.RuntimeEnv, error) {
+			return buildProviderDevRuntimeEnv("echoext", entry, deps, sessionID, runtimeHostServiceDescriptors["echoext"])
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
 	t.Cleanup(func() {
-		if cleanup != nil {
-			cleanup()
+		if err := manager.Close(); err != nil {
+			t.Fatalf("provider dev manager close: %v", err)
 		}
 	})
+	targets := []providerdev.Target{{Name: "echoext"}}
+	if err := registerProviderDevPublicHostServices(&config.Config{
+		Plugins: map[string]*config.ProviderEntry{"echoext": entry},
+	}, manager, deps, targets, runtimeHostServiceDescriptors); err != nil {
+		t.Fatalf("registerProviderDevPublicHostServices: %v", err)
+	}
+	session, err := manager.CreateSession(context.Background(), &principal.Principal{
+		SubjectID: "user:test-user",
+		UserID:    "test-user",
+		Kind:      principal.KindUser,
+	}, providerdev.CreateSessionRequest{
+		Providers: []providerdev.AttachProvider{{Name: "echoext"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if len(session.Providers) != 1 {
+		t.Fatalf("session providers = %#v, want one", session.Providers)
+	}
+	env := session.Providers[0].Env
 
 	for _, binding := range []string{"", "main"} {
 		socketEnv := s3service.SocketEnv(binding)
-		if got := env.Env[socketEnv]; !strings.HasPrefix(got, "tls://") {
+		if got := env[socketEnv]; !strings.HasPrefix(got, "tls://") {
 			t.Fatalf("runtime env %s = %q, want tls relay target", socketEnv, got)
 		}
 		tokenEnv := s3service.SocketTokenEnv(binding)
-		if got := env.Env[tokenEnv]; got == "" {
+		if got := env[tokenEnv]; got == "" {
 			t.Fatalf("runtime env %s is empty, want relay token", tokenEnv)
 		}
 	}
-	record, err := fakeHostedS3RoundTrip("assets", "plans/q3.txt", "ship-it", "main", env.Env)
+	record, err := fakeHostedS3RoundTrip("assets", "plans/q3.txt", "ship-it", "main", env)
 	if err != nil {
 		t.Fatalf("S3 round trip via provider-dev relay: %v", err)
 	}
 	if got := record["body"]; got != "ship-it" {
 		t.Fatalf("S3 body = %#v, want ship-it", got)
 	}
-	if cleanup != nil {
-		cleanup()
-		cleanup = nil
+	if err := manager.CloseSession(&principal.Principal{
+		SubjectID: "user:test-user",
+		UserID:    "test-user",
+		Kind:      principal.KindUser,
+	}, session.AttachID); err != nil {
+		t.Fatalf("CloseSession: %v", err)
 	}
-	if _, err := fakeHostedS3RoundTrip("assets", "plans/stale.txt", "stale", "main", env.Env); err == nil {
-		t.Fatalf("S3 round trip after provider-dev cleanup succeeded, want stale relay failure")
+	if _, err := fakeHostedS3RoundTrip("assets", "plans/stale.txt", "stale", "main", env); err == nil {
+		t.Fatalf("S3 round trip after provider-dev session close succeeded, want stale relay failure")
 	}
+}
+
+func TestBuildProviderDevManagerRegistersMemoryModePublicHostServiceVerifiers(t *testing.T) {
+	t.Parallel()
+
+	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
+	providers := registry.New()
+	if err := providers.Providers.Register("echoext", &connectedCapabilityProvider{}); err != nil {
+		t.Fatalf("Register provider: %v", err)
+	}
+	entry := &config.ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Source: "local://echoext",
+		},
+		Cache: []string{"main"},
+		S3:    []string{"main"},
+	}
+	var cacheFactoryCalls atomic.Int64
+	manager, err := buildProviderDevManager(&config.Config{
+		Plugins: map[string]*config.ProviderEntry{"echoext": entry},
+	}, &providers.Providers, Deps{
+		BaseURL:            "https://gestalt.example.test",
+		EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
+		PublicHostServices: publicHostServices,
+		CacheDefs: map[string]*config.ProviderEntry{
+			"main": {},
+		},
+		CacheFactory: func(yaml.Node) (corecache.Cache, error) {
+			if cacheFactoryCalls.Add(1) > 1 {
+				return nil, fmt.Errorf("cache factory opened more than once")
+			}
+			return coretesting.NewStubCache(), nil
+		},
+		S3: map[string]s3store.Client{
+			"main": &coretesting.StubS3{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildProviderDevManager: %v", err)
+	}
+	if manager == nil {
+		t.Fatal("buildProviderDevManager returned nil manager")
+	}
+	t.Cleanup(func() {
+		if err := manager.Close(); err != nil {
+			t.Fatalf("provider dev manager close: %v", err)
+		}
+	})
+	assertPublicHostServicesVerified(t, publicHostServices, "s3", s3service.SocketEnv("main"))
+	assertPublicHostServicesVerified(t, publicHostServices, "cache", cacheservice.SocketEnv("main"))
+
+	p := &principal.Principal{SubjectID: "user:test-user", UserID: "test-user", Kind: principal.KindUser}
+	session, err := manager.CreateSession(context.Background(), p, providerdev.CreateSessionRequest{
+		Providers: []providerdev.AttachProvider{{Name: "echoext"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if calls := cacheFactoryCalls.Load(); calls != 1 {
+		t.Fatalf("cache factory calls after CreateSession = %d, want startup-only open", calls)
+	}
+	for _, service := range publicHostServices.Services() {
+		if strings.TrimSpace(service.Service.Name) != "s3" || strings.TrimSpace(service.Service.EnvVar) != s3service.SocketEnv("main") {
+			continue
+		}
+		if service.SessionVerifier == nil {
+			t.Fatal("S3 public host service verifier is nil")
+		}
+		if err := service.SessionVerifier.VerifyHostServiceSession(context.Background(), session.AttachID); err != nil {
+			t.Fatalf("VerifyHostServiceSession(active memory session): %v", err)
+		}
+		if err := manager.CloseSession(p, session.AttachID); err != nil {
+			t.Fatalf("CloseSession: %v", err)
+		}
+		if err := service.SessionVerifier.VerifyHostServiceSession(context.Background(), session.AttachID); grpcstatus.Code(err) != codes.NotFound {
+			t.Fatalf("VerifyHostServiceSession(closed memory session) code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.NotFound, err)
+		}
+		return
+	}
+	t.Fatalf("public host services = %#v, want s3/%s", publicHostServices.Services(), s3service.SocketEnv("main"))
 }
 
 func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnelCapability(t *testing.T) {
@@ -7524,22 +7639,11 @@ func testRuntimePublicEndpointDeps(t *testing.T, deps Deps, opts ...runtimeRelay
 }
 
 func runtimeRelayPublicHostServiceHandler(ctx context.Context, registry *runtimehost.PublicHostServiceRegistry, target runtimehost.HostServiceRelayTarget) (http.Handler, error) {
-	handler, err := runtimeRelayPublicHostServiceHandlerForSession(ctx, registry, target, target.SessionID)
-	if handler != nil || err != nil || strings.TrimSpace(target.SessionID) == "" {
-		return handler, err
-	}
-	return runtimeRelayPublicHostServiceHandlerForSession(ctx, registry, target, "")
-}
-
-func runtimeRelayPublicHostServiceHandlerForSession(ctx context.Context, registry *runtimehost.PublicHostServiceRegistry, target runtimehost.HostServiceRelayTarget, sessionID string) (http.Handler, error) {
 	if registry == nil {
 		return nil, nil
 	}
 	for _, entry := range registry.Services() {
 		if strings.TrimSpace(entry.PluginName) != strings.TrimSpace(target.PluginName) {
-			continue
-		}
-		if strings.TrimSpace(entry.SessionID) != strings.TrimSpace(sessionID) {
 			continue
 		}
 		if strings.TrimSpace(entry.Service.Name) != strings.TrimSpace(target.Service) {
@@ -7551,10 +7655,11 @@ func runtimeRelayPublicHostServiceHandlerForSession(ctx context.Context, registr
 		if entry.Service.Register == nil {
 			continue
 		}
-		if entry.SessionVerifier != nil {
-			if err := entry.SessionVerifier.VerifyHostServiceSession(ctx, target.SessionID); err != nil {
-				return nil, err
-			}
+		if entry.SessionVerifier == nil {
+			return nil, fmt.Errorf("public host service %s/%s/%s requires a session verifier", strings.TrimSpace(target.PluginName), strings.TrimSpace(target.Service), strings.TrimSpace(target.EnvVar))
+		}
+		if err := entry.SessionVerifier.VerifyHostServiceSession(ctx, target.SessionID); err != nil {
+			return nil, err
 		}
 		srv := grpc.NewServer()
 		entry.Service.Register(srv)

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1762,12 +1762,12 @@ func registerPublicRuntimeHostServices(providerName string, hostServices []runti
 			return nil, fmt.Errorf("host service %q requires a service name for public relay", hostService.EnvVar)
 		}
 	}
-	deps.PublicHostServices.RegisterVerified(providerName, runtimeHostServiceSessionVerifier{
+	registration := deps.PublicHostServices.RegisterVerified(providerName, runtimeHostServiceSessionVerifier{
 		providerName: providerName,
 		provider:     runtimeProvider,
 	}, registerHostServices...)
 	return func() {
-		deps.PublicHostServices.Unregister(providerName, registerHostServices...)
+		registration.Unregister()
 	}, nil
 }
 

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -23,9 +23,10 @@ func buildProviderDevManager(cfg *config.Config, providers *registry.ProviderMap
 	}
 
 	sharedAttachmentState := cfg.Server.Dev.AttachmentState == config.DevAttachmentStateIndexedDB
+	runtimeHostServiceDescriptors := map[string][]hostServiceBindingDescriptor{}
 	targets := make([]providerdev.Target, 0, len(cfg.Plugins))
 	for name, entry := range cfg.Plugins {
-		result := deriveProviderDevTarget(name, entry, providers, deps, sharedAttachmentState)
+		result := deriveProviderDevTarget(name, entry, providers, deps, runtimeHostServiceDescriptors)
 		switch result.state {
 		case providerDevTargetAttachable:
 			targets = append(targets, result.target)
@@ -53,11 +54,9 @@ func buildProviderDevManager(cfg *config.Config, providers *registry.ProviderMap
 	if err != nil {
 		return nil, err
 	}
-	if sharedAttachmentState {
-		if err := registerProviderDevPublicHostServices(cfg, manager, deps, targets); err != nil {
-			_ = manager.Close()
-			return nil, err
-		}
+	if err := registerProviderDevPublicHostServices(cfg, manager, deps, targets, runtimeHostServiceDescriptors); err != nil {
+		_ = manager.Close()
+		return nil, err
 	}
 	return manager, nil
 }
@@ -77,7 +76,7 @@ type providerDevTargetResult struct {
 	err    error
 }
 
-func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers *registry.ProviderMap[core.Provider], deps Deps, sharedAttachmentState bool) providerDevTargetResult {
+func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers *registry.ProviderMap[core.Provider], deps Deps, runtimeHostServiceDescriptors map[string][]hostServiceBindingDescriptor) providerDevTargetResult {
 	if entry == nil {
 		return providerDevTargetResult{state: providerDevTargetUnsupported, reason: "missing config entry"}
 	}
@@ -122,7 +121,7 @@ func deriveProviderDevTarget(name string, entry *config.ProviderEntry, providers
 			Config: pluginConfig,
 			UIPath: strings.TrimSpace(entry.MountPath),
 			RuntimeEnv: func(sessionID string) (providerdev.RuntimeEnv, error) {
-				return buildProviderDevRuntimeEnv(targetName, targetEntry, deps, sessionID, sharedAttachmentState)
+				return buildProviderDevRuntimeEnv(targetName, targetEntry, deps, sessionID, runtimeHostServiceDescriptors[targetName])
 			},
 		},
 	}
@@ -166,52 +165,11 @@ func providerDevEntryIsLocal(entry *config.ProviderEntry) bool {
 	return entry != nil && (entry.HasLocalSource() || entry.HasLocalReleaseSource())
 }
 
-func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps Deps, sessionID string, sharedAttachmentState bool) (providerdev.RuntimeEnv, error) {
-	hostServices, _, cleanup, err := buildPluginRuntimeHostServices(name, entry, deps)
-	if err != nil {
-		return providerdev.RuntimeEnv{}, err
-	}
-	cleanupOnError := true
-	defer func() {
-		if cleanupOnError && cleanup != nil {
-			cleanup()
-		}
-	}()
+func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps Deps, sessionID string, hostServices []hostServiceBindingDescriptor) (providerdev.RuntimeEnv, error) {
 	env := withRuntimeSessionEnv(map[string]string{}, sessionID)
 	env = withHostServiceTLSCAEnv(env, deps)
-	if sharedAttachmentState {
-		for _, hostService := range hostServices {
-			bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostServiceBindingDescriptorFromConfigured(hostService), deps, true)
-			if err != nil {
-				return providerdev.RuntimeEnv{}, err
-			}
-			if bindingReq.EnvVar != "" && bindingReq.Relay.DialTarget != "" {
-				env[bindingReq.EnvVar] = bindingReq.Relay.DialTarget
-			}
-			maps.Copy(env, bindingEnv)
-		}
-		if deps.Egress.DefaultAction == egress.PolicyDeny {
-			proxyEnv, err := buildHostedRuntimePublicEgressProxy(name, sessionID, entry.EffectiveAllowedHosts(), deps.Egress.DefaultAction, deps)
-			if err != nil {
-				return providerdev.RuntimeEnv{}, err
-			}
-			maps.Copy(env, proxyEnv)
-		}
-		if cleanup != nil {
-			cleanup()
-			cleanup = nil
-		}
-		cleanupOnError = false
-		return providerdev.RuntimeEnv{Env: env}, nil
-	}
-	if deps.PublicHostServices != nil {
-		deps.PublicHostServices.RegisterSession(name, sessionID, hostServices...)
-		cleanup = chainCleanup(cleanup, func() {
-			deps.PublicHostServices.UnregisterSession(name, sessionID, hostServices...)
-		})
-	}
 	for _, hostService := range hostServices {
-		bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostServiceBindingDescriptorFromConfigured(hostService), deps, true)
+		bindingReq, bindingEnv, _, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, true)
 		if err != nil {
 			return providerdev.RuntimeEnv{}, err
 		}
@@ -228,11 +186,7 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 		maps.Copy(env, proxyEnv)
 	}
 
-	cleanupOnError = false
-	return providerdev.RuntimeEnv{
-		Env:     env,
-		Cleanup: cleanup,
-	}, nil
+	return providerdev.RuntimeEnv{Env: env}, nil
 }
 
 type providerDevHostServiceVerifier struct {
@@ -247,7 +201,7 @@ func (v providerDevHostServiceVerifier) VerifyHostServiceSession(ctx context.Con
 	return v.manager.VerifyHostServiceSession(ctx, v.provider, sessionID)
 }
 
-func registerProviderDevPublicHostServices(cfg *config.Config, manager *providerdev.Manager, deps Deps, targets []providerdev.Target) error {
+func registerProviderDevPublicHostServices(cfg *config.Config, manager *providerdev.Manager, deps Deps, targets []providerdev.Target, runtimeHostServiceDescriptors map[string][]hostServiceBindingDescriptor) error {
 	if cfg == nil || manager == nil || deps.PublicHostServices == nil {
 		return nil
 	}
@@ -275,9 +229,12 @@ func registerProviderDevPublicHostServices(cfg *config.Config, manager *provider
 			}
 			continue
 		}
-		deps.PublicHostServices.RegisterVerified(name, providerDevHostServiceVerifier{manager: manager, provider: name}, hostServices...)
+		if runtimeHostServiceDescriptors != nil {
+			runtimeHostServiceDescriptors[name] = hostServiceBindingDescriptorsFromConfigured(hostServices)
+		}
+		registration := deps.PublicHostServices.RegisterVerified(name, providerDevHostServiceVerifier{manager: manager, provider: name}, hostServices...)
 		manager.AddCleanup(func() {
-			deps.PublicHostServices.Unregister(name, hostServices...)
+			registration.Unregister()
 			if cleanup != nil {
 				cleanup()
 			}

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -18,7 +18,6 @@ import (
 
 type hostServiceHandlerKey struct {
 	pluginName string
-	sessionID  string
 	service    string
 	envVar     string
 }
@@ -39,7 +38,7 @@ func validatePublicHostServices(services []runtimehost.PublicHostService) error 
 		if !ok {
 			continue
 		}
-		if key.sessionID == "" && service.SessionVerifier == nil {
+		if service.SessionVerifier == nil {
 			return fmt.Errorf("public host service %s requires a session verifier", key.String())
 		}
 		entry := hostServiceHandlerEntry{verifier: service.SessionVerifier}
@@ -74,7 +73,6 @@ func checkHostServiceHandlerDuplicate(key hostServiceHandlerKey, entries []hostS
 func publicHostServiceHandlerKey(service runtimehost.PublicHostService) (hostServiceHandlerKey, bool) {
 	key := hostServiceHandlerKey{
 		pluginName: strings.TrimSpace(service.PluginName),
-		sessionID:  strings.TrimSpace(service.SessionID),
 		service:    strings.TrimSpace(service.Service.Name),
 		envVar:     strings.TrimSpace(service.Service.EnvVar),
 	}
@@ -85,11 +83,7 @@ func publicHostServiceHandlerKey(service runtimehost.PublicHostService) (hostSer
 }
 
 func (k hostServiceHandlerKey) String() string {
-	parts := []string{k.pluginName, k.service, k.envVar}
-	if k.sessionID != "" {
-		parts = append(parts, "session="+k.sessionID)
-	}
-	return strings.Join(parts, "/")
+	return strings.Join([]string{k.pluginName, k.service, k.envVar}, "/")
 }
 
 func (s *Server) hostServiceHandler(ctx context.Context, target runtimehost.HostServiceRelayTarget) (http.Handler, error) {
@@ -110,29 +104,13 @@ func (s *Server) hostServiceHandler(ctx context.Context, target runtimehost.Host
 		return nil, nil
 	}
 
-	exactKey := hostServiceHandlerKey{
+	key := hostServiceHandlerKey{
 		pluginName: strings.TrimSpace(target.PluginName),
-		sessionID:  strings.TrimSpace(target.SessionID),
 		service:    strings.TrimSpace(target.Service),
 		envVar:     strings.TrimSpace(target.EnvVar),
 	}
-	providerKey := exactKey
-	providerKey.sessionID = ""
 
-	if exactKey.sessionID != "" {
-		entry, found, ok, err := s.hostServiceHandlerEntry(ctx, exactKey, exactKey.sessionID)
-		if err != nil {
-			return nil, err
-		}
-		if found {
-			if !ok {
-				return nil, nil
-			}
-			return entry.handler, nil
-		}
-	}
-
-	entry, _, ok, err := s.hostServiceHandlerEntry(ctx, providerKey, exactKey.sessionID)
+	entry, _, ok, err := s.hostServiceHandlerEntry(ctx, key, target.SessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -214,15 +192,6 @@ func (s *Server) verifyRegisteredCoreRoutableHostServiceSession(ctx context.Cont
 		key, ok := publicHostServiceHandlerKey(service)
 		if !ok || key.pluginName != pluginName || key.service != serviceName || key.envVar != envVar {
 			continue
-		}
-		if key.sessionID != "" {
-			if key.sessionID != sessionID {
-				continue
-			}
-			if service.SessionVerifier == nil {
-				return true, nil
-			}
-			return true, service.SessionVerifier.VerifyHostServiceSession(ctx, sessionID)
 		}
 		if service.SessionVerifier == nil {
 			continue
@@ -333,7 +302,7 @@ func (s *Server) hostServiceHandlerEntry(ctx context.Context, key hostServiceHan
 		if !ok || serviceKey != key {
 			continue
 		}
-		if serviceKey.sessionID == "" && service.SessionVerifier == nil {
+		if service.SessionVerifier == nil {
 			return hostServiceHandlerEntry{}, true, false, fmt.Errorf("public host service %s requires a session verifier", key.String())
 		}
 		entry, ok := s.publicHostServiceHandlerEntry(service)
@@ -427,7 +396,7 @@ func selectHostServiceHandlerEntry(ctx context.Context, key hostServiceHandlerKe
 	var lastErr error
 	for _, entry := range entries {
 		if entry.verifier == nil {
-			return entry, true, nil
+			return hostServiceHandlerEntry{}, false, fmt.Errorf("public host service %s requires a session verifier", key.String())
 		}
 		if err := entry.verifier.VerifyHostServiceSession(ctx, sessionID); err != nil {
 			lastErr = err

--- a/gestaltd/internal/server/host_service_public_test.go
+++ b/gestaltd/internal/server/host_service_public_test.go
@@ -10,12 +10,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-func TestHostServiceHandlerDoesNotFallbackWhenExactSessionEntryFails(t *testing.T) {
+func TestHostServiceHandlerReturnsVerifierError(t *testing.T) {
 	t.Parallel()
 
 	registry := runtimehost.NewPublicHostServiceRegistry()
-	registry.RegisterSession("support", "session-1", testHostService(), testHostService())
-	registry.RegisterVerified("support", allowHostServiceSessionVerifier{}, testHostService())
+	registry.RegisterVerified("support", rejectHostServiceSessionVerifier{}, testHostService())
 	s := &Server{publicHostServices: registry}
 
 	handler, err := s.hostServiceHandler(context.Background(), runtimehost.HostServiceRelayTarget{
@@ -24,11 +23,11 @@ func TestHostServiceHandlerDoesNotFallbackWhenExactSessionEntryFails(t *testing.
 		Service:    "cache",
 		EnvVar:     "GESTALT_TEST_CACHE_SOCKET",
 	})
-	if err == nil || !strings.Contains(err.Error(), "duplicate public host service support/cache/GESTALT_TEST_CACHE_SOCKET/session=session-1") {
-		t.Fatalf("hostServiceHandler err = %v, want exact session duplicate failure", err)
+	if err == nil || !strings.Contains(err.Error(), `runtime session "session-1" is not active`) {
+		t.Fatalf("hostServiceHandler err = %v, want verifier failure", err)
 	}
 	if handler != nil {
-		t.Fatalf("handler = %v, want no provider-wide fallback", handler)
+		t.Fatalf("handler = %v, want no handler", handler)
 	}
 }
 
@@ -52,40 +51,6 @@ func TestValidatePublicHostServicesAllowsDuplicateVerifiedServices(t *testing.T)
 	})
 	if err != nil {
 		t.Fatalf("validatePublicHostServices: %v", err)
-	}
-}
-
-func TestValidatePublicHostServicesAllowsSessionServiceWithoutVerifier(t *testing.T) {
-	t.Parallel()
-
-	err := validatePublicHostServices([]runtimehost.PublicHostService{{
-		PluginName: "support",
-		SessionID:  "session-1",
-		Service:    testHostService(),
-	}})
-	if err != nil {
-		t.Fatalf("validatePublicHostServices: %v", err)
-	}
-}
-
-func TestRegisterSessionRejectsBlankSessionID(t *testing.T) {
-	t.Parallel()
-
-	registry := runtimehost.NewPublicHostServiceRegistry()
-	registry.RegisterSession("support", "", testHostService())
-	s := &Server{publicHostServices: registry}
-	key := hostServiceHandlerKey{
-		pluginName: "support",
-		service:    "cache",
-		envVar:     "GESTALT_TEST_CACHE_SOCKET",
-	}
-
-	_, found, ok, err := s.hostServiceHandlerEntry(context.Background(), key, "session-1")
-	if err != nil {
-		t.Fatalf("hostServiceHandlerEntry: %v", err)
-	}
-	if found || ok {
-		t.Fatalf("hostServiceHandlerEntry found=%v ok=%v, want no dynamic provider-wide registration", found, ok)
 	}
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -761,7 +761,7 @@ func TestHostServiceRelaySelectsVerifierForDuplicateProviderWideServices(t *test
 		},
 	}
 	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("session-1"), hostService1)
-	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("session-2"), hostService2)
+	session2Registration := publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("session-2"), hostService2)
 
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfilePublic
@@ -802,15 +802,49 @@ func TestHostServiceRelaySelectsVerifierForDuplicateProviderWideServices(t *test
 	if got := cacheSrv2.calls(); got != 1 {
 		t.Fatalf("second backend calls = %d, want 1", got)
 	}
+
+	session2Registration.Unregister()
+	session1Token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-1",
+		Service:      "cache",
+		EnvVar:       envVar,
+		MethodPrefix: "/gestalt.provider.v1.Cache/",
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken(session-1): %v", err)
+	}
+	session1Ctx, session1Cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer session1Cancel()
+	session1Ctx = metadata.NewOutgoingContext(session1Ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, session1Token))
+	if _, err := proto.NewCacheClient(conn).Get(session1Ctx, &proto.CacheGetRequest{Key: "still-active"}); err != nil {
+		t.Fatalf("Cache.Get via remaining duplicate relay: %v", err)
+	}
+	if got := cacheSrv1.calls(); got != 1 {
+		t.Fatalf("first backend calls after unregistering second registration = %d, want 1", got)
+	}
+
+	removedCtx, removedCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer removedCancel()
+	removedCtx = metadata.NewOutgoingContext(removedCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
+	_, err = proto.NewCacheClient(conn).Get(removedCtx, &proto.CacheGetRequest{Key: "removed"})
+	if grpcstatus.Code(err) != codes.Unauthenticated {
+		t.Fatalf("Cache.Get removed duplicate code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unauthenticated, err)
+	}
+	if got := cacheSrv2.calls(); got != 1 {
+		t.Fatalf("second backend calls after unregister = %d, want 1", got)
+	}
 }
 
-func TestHostServiceRelayStopsServingUnregisteredSession(t *testing.T) {
+func TestHostServiceRelayStopsServingUnregisteredProviderService(t *testing.T) {
 	t.Parallel()
 
 	secret := []byte("relay-test-secret-0123456789abcd")
 	cacheSrv := &relayTestCacheServer{}
 	const envVar = "GESTALT_TEST_CACHE_SOCKET"
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
+	sessionVerifier := newRelayTestSessionVerifier("session-1")
 	hostService := runtimehost.HostService{
 		Name:   "cache",
 		EnvVar: envVar,
@@ -818,7 +852,7 @@ func TestHostServiceRelayStopsServingUnregisteredSession(t *testing.T) {
 			proto.RegisterCacheServer(srv, cacheSrv)
 		},
 	}
-	publicHostServices.RegisterSession("support", "session-1", hostService)
+	publicHostServices.RegisterVerified("support", sessionVerifier, hostService)
 
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfilePublic
@@ -852,16 +886,16 @@ func TestHostServiceRelayStopsServingUnregisteredSession(t *testing.T) {
 	defer cancel()
 	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 	if _, err := proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "active"}); err != nil {
-		t.Fatalf("Cache.Get via session relay: %v", err)
+		t.Fatalf("Cache.Get via relay: %v", err)
 	}
 
-	publicHostServices.UnregisterSession("support", "session-1", hostService)
+	publicHostServices.Unregister("support", hostService)
 	staleCtx, staleCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer staleCancel()
 	staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
 	_, err = proto.NewCacheClient(conn).Get(staleCtx, &proto.CacheGetRequest{Key: "stale"})
 	if grpcstatus.Code(err) != codes.Unavailable {
-		t.Fatalf("Cache.Get unregistered session code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
+		t.Fatalf("Cache.Get unregistered service code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
 	}
 	if got := cacheSrv.calls(); got != 1 {
 		t.Fatalf("backend calls = %d, want only the registered call", got)
@@ -1136,7 +1170,7 @@ func TestHostServiceRelayCoreRoutableProviderDevUsesRegisteredSessionVerifier(t 
 		CredentialMode: core.ConnectionModeNone,
 	}}
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	publicHostServices.RegisterSession("support", "provider-dev-session", runtimehost.HostService{
+	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("provider-dev-session"), runtimehost.HostService{
 		Name:   "plugin_invoker",
 		EnvVar: plugininvokerservice.DefaultSocketEnv,
 		Register: func(*grpc.Server) {

--- a/gestaltd/services/providerdev/indexeddb_store.go
+++ b/gestaltd/services/providerdev/indexeddb_store.go
@@ -1080,24 +1080,6 @@ func (s *sharedSession) invokeRaw(ctx context.Context, providerName, method stri
 	return s.store.waitCall(ctx, s.id, callID)
 }
 
-func (m *Manager) VerifyHostServiceSession(ctx context.Context, providerName, sessionID string) error {
-	if m == nil || m.shared == nil {
-		return status.Error(codes.FailedPrecondition, "provider dev indexeddb attachment state is not configured")
-	}
-	session, err := m.shared.getActiveAttachment(ctx, sessionID, time.Now())
-	if err != nil {
-		return err
-	}
-	providerName = strings.TrimSpace(providerName)
-	for i := range session.targets {
-		target := &session.targets[i]
-		if target.Name == providerName {
-			return nil
-		}
-	}
-	return status.Errorf(codes.NotFound, "provider dev session %q does not include provider %q", sessionID, providerName)
-}
-
 func (r indexedDBSessionRecord) attachmentInfo() AttachmentInfo {
 	providers := make([]AttachmentProviderInfo, 0, len(r.targets))
 	for i := range r.targets {

--- a/gestaltd/services/providerdev/session.go
+++ b/gestaltd/services/providerdev/session.go
@@ -706,6 +706,49 @@ func (m *Manager) VerifyDispatcherSecretOnly(sessionID, dispatcherSecret string)
 	return err
 }
 
+func (m *Manager) VerifyHostServiceSession(ctx context.Context, providerName, sessionID string) error {
+	if m == nil {
+		return status.Error(codes.FailedPrecondition, "provider dev is not configured")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return status.Error(codes.InvalidArgument, "provider name is required")
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return status.Error(codes.InvalidArgument, "session id is required")
+	}
+	if m.shared != nil {
+		session, err := m.shared.getActiveAttachment(ctx, sessionID, time.Now())
+		if err != nil {
+			return err
+		}
+		for i := range session.targets {
+			target := &session.targets[i]
+			if target.Name == providerName {
+				return nil
+			}
+		}
+		return status.Errorf(codes.NotFound, "provider dev session %q does not include provider %q", sessionID, providerName)
+	}
+	m.closeIdleSessions(time.Now())
+	m.mu.RLock()
+	session := m.sessions[sessionID]
+	m.mu.RUnlock()
+	if session == nil {
+		return status.Errorf(codes.NotFound, "provider dev session %q not found", sessionID)
+	}
+	return session.verifyHostServiceProvider(providerName)
+}
+
 func (m *Manager) CloseSessionWithDispatcherSecret(sessionID, dispatcherSecret string) error {
 	if m != nil && m.shared != nil {
 		if err := m.shared.closeSessionWithDispatcherSecret(context.Background(), sessionID, dispatcherSecret); err != nil {
@@ -1284,6 +1327,25 @@ func (s *Session) verifyDispatcherSecret(secret string) error {
 	}
 	if subtle.ConstantTimeCompare([]byte(hashDispatcherSecret(secret)), []byte(s.dispatcherSecretHash)) != 1 {
 		return status.Error(codes.PermissionDenied, "provider dev dispatcher secret is invalid")
+	}
+	return nil
+}
+
+func (s *Session) verifyHostServiceProvider(providerName string) error {
+	if s == nil {
+		return status.Error(codes.NotFound, "provider dev session not found")
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return status.Error(codes.InvalidArgument, "provider name is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return status.Errorf(codes.NotFound, "provider dev session %q not found", s.id)
+	}
+	if _, ok := s.targets[providerName]; !ok {
+		return status.Errorf(codes.NotFound, "provider dev session %q does not include provider %q", s.id, providerName)
 	}
 	return nil
 }

--- a/gestaltd/services/providerdev/session_test.go
+++ b/gestaltd/services/providerdev/session_test.go
@@ -246,6 +246,37 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	}
 }
 
+func TestVerifyHostServiceSessionUsesActiveMemorySession(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewManager([]Target{{Name: "roadmap"}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := manager.Close(); err != nil {
+			t.Fatalf("manager close: %v", err)
+		}
+	})
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	session, err := manager.CreateSession(context.Background(), p, CreateSessionRequest{Providers: []AttachProvider{{Name: "roadmap"}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := manager.VerifyHostServiceSession(context.Background(), "roadmap", session.AttachID); err != nil {
+		t.Fatalf("VerifyHostServiceSession active session: %v", err)
+	}
+	if err := manager.VerifyHostServiceSession(context.Background(), "billing", session.AttachID); status.Code(err) != codes.NotFound {
+		t.Fatalf("VerifyHostServiceSession missing provider code = %v, want %v (err=%v)", status.Code(err), codes.NotFound, err)
+	}
+	if err := manager.CloseSession(p, session.AttachID); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+	if err := manager.VerifyHostServiceSession(context.Background(), "roadmap", session.AttachID); status.Code(err) != codes.NotFound {
+		t.Fatalf("VerifyHostServiceSession closed session code = %v, want %v (err=%v)", status.Code(err), codes.NotFound, err)
+	}
+}
+
 func TestIndexedDBAttachmentStateDispatchesAcrossManagers(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/runtimehost/public_host_service.go
+++ b/gestaltd/services/runtimehost/public_host_service.go
@@ -19,7 +19,6 @@ type PublicHostServiceSessionVerifier interface {
 // gestaltd listener after a host-service relay token has authorized the RPC.
 type PublicHostService struct {
 	PluginName      string
-	SessionID       string
 	SessionVerifier PublicHostServiceSessionVerifier
 	Service         HostService
 	registrationID  uint64
@@ -31,63 +30,85 @@ type PublicHostServiceRegistry struct {
 	nextID   uint64
 }
 
+type PublicHostServiceRegistration struct {
+	registry *PublicHostServiceRegistry
+	ids      []uint64
+}
+
 func NewPublicHostServiceRegistry() *PublicHostServiceRegistry {
 	return &PublicHostServiceRegistry{}
 }
 
-func (r *PublicHostServiceRegistry) RegisterVerified(pluginName string, verifier PublicHostServiceSessionVerifier, services ...HostService) {
+func (r *PublicHostServiceRegistry) RegisterVerified(pluginName string, verifier PublicHostServiceSessionVerifier, services ...HostService) PublicHostServiceRegistration {
 	if verifier == nil {
-		return
+		return PublicHostServiceRegistration{}
 	}
-	r.register(pluginName, "", verifier, services...)
+	return r.register(pluginName, verifier, services...)
 }
 
-func (r *PublicHostServiceRegistry) RegisterSession(pluginName, sessionID string, services ...HostService) {
-	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" {
-		return
-	}
-	r.register(pluginName, sessionID, nil, services...)
-}
-
-func (r *PublicHostServiceRegistry) register(pluginName, sessionID string, verifier PublicHostServiceSessionVerifier, services ...HostService) {
+func (r *PublicHostServiceRegistry) register(pluginName string, verifier PublicHostServiceSessionVerifier, services ...HostService) PublicHostServiceRegistration {
 	if r == nil {
-		return
+		return PublicHostServiceRegistration{}
 	}
 	pluginName = strings.TrimSpace(pluginName)
-	sessionID = strings.TrimSpace(sessionID)
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	ids := make([]uint64, 0, len(services))
 	for _, service := range services {
 		r.nextID++
+		ids = append(ids, r.nextID)
 		r.services = append(r.services, PublicHostService{
 			PluginName:      pluginName,
-			SessionID:       sessionID,
 			SessionVerifier: verifier,
 			Service:         service,
 			registrationID:  r.nextID,
 		})
 	}
+	return PublicHostServiceRegistration{registry: r, ids: ids}
+}
+
+func (r PublicHostServiceRegistration) Unregister() {
+	if r.registry == nil || len(r.ids) == 0 {
+		return
+	}
+	r.registry.unregisterIDs(r.ids...)
+}
+
+func (r *PublicHostServiceRegistry) unregisterIDs(ids ...uint64) {
+	if r == nil || len(ids) == 0 {
+		return
+	}
+	removing := make(map[uint64]struct{}, len(ids))
+	for _, id := range ids {
+		if id != 0 {
+			removing[id] = struct{}{}
+		}
+	}
+	if len(removing) == 0 {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	originalLen := len(r.services)
+	filtered := r.services[:0]
+	for _, service := range r.services {
+		if _, ok := removing[service.registrationID]; ok {
+			continue
+		}
+		filtered = append(filtered, service)
+	}
+	for i := len(filtered); i < originalLen; i++ {
+		r.services[i] = PublicHostService{}
+	}
+	r.services = filtered
 }
 
 func (r *PublicHostServiceRegistry) Unregister(pluginName string, services ...HostService) {
-	r.unregister(pluginName, "", services...)
-}
-
-func (r *PublicHostServiceRegistry) UnregisterSession(pluginName, sessionID string, services ...HostService) {
-	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" {
-		return
-	}
-	r.unregister(pluginName, sessionID, services...)
-}
-
-func (r *PublicHostServiceRegistry) unregister(pluginName, sessionID string, services ...HostService) {
 	if r == nil {
 		return
 	}
 	pluginName = strings.TrimSpace(pluginName)
-	sessionID = strings.TrimSpace(sessionID)
 	if pluginName == "" {
 		return
 	}
@@ -104,7 +125,7 @@ func (r *PublicHostServiceRegistry) unregister(pluginName, sessionID string, ser
 	originalLen := len(r.services)
 	filtered := r.services[:0]
 	for _, service := range r.services {
-		if strings.TrimSpace(service.PluginName) == pluginName && strings.TrimSpace(service.SessionID) == sessionID {
+		if strings.TrimSpace(service.PluginName) == pluginName {
 			if len(removing) == 0 {
 				continue
 			}


### PR DESCRIPTION
## Summary
- remove session-specific public host-service registrations and route all public host-service callbacks through provider-wide verified registrations
- register provider-dev public host services at manager startup for both memory and IndexedDB attachment state
- verify provider-dev public relay sessions against active in-memory sessions as well as IndexedDB sessions
- add registration handles so cleanup removes only the exact provider-wide entries it owns

## Tests
- go test ./internal/server ./services/providerdev ./services/runtimehost -count=1
- go test ./internal/bootstrap -count=1
- golangci-lint run ./internal/bootstrap ./internal/server ./services/providerdev ./services/runtimehost