### PR TITLE
Fold plugin validation config into plugins service

### DIFF
--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -12,10 +12,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
-	"github.com/valon-technologies/gestalt/server/internal/pluginvalidation"
 	"github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/plugins/registry"
 )
 
@@ -23,7 +23,7 @@ import (
 // starting the server or running migrations. Unlike Bootstrap, provider
 // validation is strict: any provider construction failure is returned.
 func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) ([]string, error) {
-	if err := pluginvalidation.ValidateEffectiveCatalogsAndDependencies(ctx, cfg); err != nil {
+	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(ctx, pluginservice.ValidationConfigFromConfig(cfg)); err != nil {
 		return nil, err
 	}
 

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -13,9 +13,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/valon-technologies/gestalt/server/internal/pluginvalidation"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/plugins/source"
 	"gopkg.in/yaml.v3"
 )
@@ -413,7 +413,7 @@ func validateStagedReleaseCatalog(staged *providerpkg.StagedPreparedInstall) err
 	if err != nil {
 		return fmt.Errorf("invalid source in staged manifest: %w", err)
 	}
-	return pluginvalidation.ValidateEffectiveManifest(context.Background(), src.PluginName(), staged.ManifestPath, staged.Manifest)
+	return pluginservice.ValidateEffectiveManifest(context.Background(), src.PluginName(), staged.ManifestPath, staged.Manifest)
 }
 
 func platformArchiveName(pluginName, version string, plat releasePlatform) string {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -20,9 +20,9 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/pluginvalidation"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/plugins/store"
 	"gopkg.in/yaml.v3"
 )
@@ -283,7 +283,7 @@ func (l *Lifecycle) prepareLockAtPaths(configPaths []string, state StatePaths, d
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
-	if err := pluginvalidation.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
+	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), pluginservice.ValidationConfigFromConfig(cfg)); err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
 	return lock, cfg, paths, nil
@@ -473,7 +473,7 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 		return nil, nil, err
 	}
 	if !secretsValidated && !dependenciesValidated {
-		if err := pluginvalidation.ValidateDependencies(context.Background(), cfg); err != nil {
+		if err := pluginservice.ValidateDependencies(context.Background(), pluginservice.ValidationConfigFromConfig(cfg)); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -499,7 +499,7 @@ func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string,
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, err
 	}
-	if err := pluginvalidation.ValidateDependencies(context.Background(), cfg); err != nil {
+	if err := pluginservice.ValidateDependencies(context.Background(), pluginservice.ValidationConfigFromConfig(cfg)); err != nil {
 		return nil, err
 	}
 	return cfg, nil
@@ -536,7 +536,7 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return err
 	}
-	if err := pluginvalidation.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
+	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), pluginservice.ValidationConfigFromConfig(cfg)); err != nil {
 		return err
 	}
 	return nil

--- a/gestaltd/services/plugins/validation_config.go
+++ b/gestaltd/services/plugins/validation_config.go
@@ -1,4 +1,4 @@
-package pluginvalidation
+package plugins
 
 import (
 	"context"
@@ -9,41 +9,32 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
 	"github.com/valon-technologies/gestalt/server/services/plugins/openapi"
 )
 
 func ValidateEffectiveManifest(ctx context.Context, name, manifestPath string, manifest *providermanifestv1.Manifest) error {
-	return pluginservice.ValidateEffectiveCatalog(ctx, name, FromManifest(manifestPath, manifest))
+	return ValidateEffectiveCatalog(ctx, name, ValidationPluginFromManifest(manifestPath, manifest))
 }
 
-func ValidateEffectiveCatalogsAndDependencies(ctx context.Context, cfg *config.Config) error {
-	return pluginservice.ValidateEffectiveCatalogsAndDependencies(ctx, FromConfig(cfg))
-}
-
-func ValidateDependencies(ctx context.Context, cfg *config.Config) error {
-	return pluginservice.ValidateDependencies(ctx, FromConfig(cfg))
-}
-
-func FromConfig(cfg *config.Config) *pluginservice.ValidationConfig {
+func ValidationConfigFromConfig(cfg *config.Config) *ValidationConfig {
 	if cfg == nil {
 		return nil
 	}
-	validation := &pluginservice.ValidationConfig{
-		Plugins: make(map[string]*pluginservice.ValidationPlugin, len(cfg.Plugins)),
+	validation := &ValidationConfig{
+		Plugins: make(map[string]*ValidationPlugin, len(cfg.Plugins)),
 	}
 	for name, entry := range cfg.Plugins {
-		validation.Plugins[name] = FromProviderEntry(entry)
+		validation.Plugins[name] = ValidationPluginFromProviderEntry(entry)
 	}
 	return validation
 }
 
-func FromProviderEntry(entry *config.ProviderEntry) *pluginservice.ValidationPlugin {
+func ValidationPluginFromProviderEntry(entry *config.ProviderEntry) *ValidationPlugin {
 	if entry == nil {
 		return nil
 	}
-	return &pluginservice.ValidationPlugin{
+	return &ValidationPlugin{
 		Manifest:            entry.ResolvedManifest,
 		ManifestPath:        entry.ResolvedManifestPath,
 		AllowedOperations:   entry.AllowedOperations,
@@ -54,34 +45,34 @@ func FromProviderEntry(entry *config.ProviderEntry) *pluginservice.ValidationPlu
 	}
 }
 
-func FromManifest(manifestPath string, manifest *providermanifestv1.Manifest) *pluginservice.ValidationPlugin {
-	return FromProviderEntry(&config.ProviderEntry{
+func ValidationPluginFromManifest(manifestPath string, manifest *providermanifestv1.Manifest) *ValidationPlugin {
+	return ValidationPluginFromProviderEntry(&config.ProviderEntry{
 		ResolvedManifestPath: manifestPath,
 		ResolvedManifest:     manifest,
 	})
 }
 
-func invocationDependencies(dependencies []config.PluginInvocationDependency) []pluginservice.InvocationDependency {
+func invocationDependencies(dependencies []config.PluginInvocationDependency) []InvocationDependency {
 	if len(dependencies) == 0 {
 		return nil
 	}
-	result := make([]pluginservice.InvocationDependency, 0, len(dependencies))
+	result := make([]InvocationDependency, 0, len(dependencies))
 	for _, dependency := range dependencies {
-		result = append(result, pluginservice.InvocationDependency{
+		result = append(result, InvocationDependency{
 			Plugin:    dependency.Plugin,
 			Operation: dependency.Operation,
-			Surface:   pluginservice.SpecSurface(dependency.Surface),
+			Surface:   SpecSurface(dependency.Surface),
 		})
 	}
 	return result
 }
 
-func surfaceURLOverrides(entry *config.ProviderEntry) map[pluginservice.SpecSurface]string {
+func surfaceURLOverrides(entry *config.ProviderEntry) map[SpecSurface]string {
 	if entry == nil {
 		return nil
 	}
-	overrides := make(map[pluginservice.SpecSurface]string)
-	for _, surface := range []pluginservice.SpecSurface{pluginservice.SpecSurfaceGraphQL, pluginservice.SpecSurfaceMCP} {
+	overrides := make(map[SpecSurface]string)
+	for _, surface := range []SpecSurface{SpecSurfaceGraphQL, SpecSurfaceMCP} {
 		if url := config.ProviderSurfaceURLOverride(entry, config.SpecSurface(surface)); url != "" {
 			overrides[surface] = url
 		}
@@ -92,7 +83,7 @@ func surfaceURLOverrides(entry *config.ProviderEntry) map[pluginservice.SpecSurf
 	return overrides
 }
 
-func staticCatalogReader(entry *config.ProviderEntry) pluginservice.StaticCatalogReader {
+func staticCatalogReader(entry *config.ProviderEntry) StaticCatalogReader {
 	if entry == nil || entry.ResolvedManifestPath == "" {
 		return nil
 	}
@@ -102,9 +93,9 @@ func staticCatalogReader(entry *config.ProviderEntry) pluginservice.StaticCatalo
 	}
 }
 
-func loadAPICatalog(ctx context.Context, name string, surface pluginservice.SpecSurface, specURL string, allowed map[string]*pluginservice.OperationOverride) (*catalog.Catalog, error) {
+func loadAPICatalog(ctx context.Context, name string, surface SpecSurface, specURL string, allowed map[string]*OperationOverride) (*catalog.Catalog, error) {
 	switch surface {
-	case pluginservice.SpecSurfaceOpenAPI:
+	case SpecSurfaceOpenAPI:
 		def, err := openapi.LoadDefinition(ctx, name, specURL, allowed)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

Deletes the standalone `gestaltd/internal/pluginvalidation` adapter package by moving config-to-validation conversion into `gestaltd/services/plugins`.

The plugin service already owns effective catalog/dependency validation. This keeps the server-config adapter next to the validation API instead of leaving a separate internal wrapper package.

## Interface diff

```diff
- import "github.com/valon-technologies/gestalt/server/internal/pluginvalidation"
+ import pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"

- err := pluginvalidation.ValidateEffectiveCatalogsAndDependencies(ctx, cfg)
+ err := pluginservice.ValidateEffectiveCatalogsAndDependencies(
+     ctx,
+     pluginservice.ValidationConfigFromConfig(cfg),
+ )

- err := pluginvalidation.ValidateDependencies(ctx, cfg)
+ err := pluginservice.ValidateDependencies(
+     ctx,
+     pluginservice.ValidationConfigFromConfig(cfg),
+ )
```

```diff
- err := pluginvalidation.ValidateEffectiveManifest(ctx, name, manifestPath, manifest)
+ err := pluginservice.ValidateEffectiveManifest(ctx, name, manifestPath, manifest)
```

## Example

```go
import pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"

validation := pluginservice.ValidationConfigFromConfig(cfg)
if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(ctx, validation); err != nil {
    return err
}
```

## Testing

- `go test ./services/plugins ./internal/bootstrap ./internal/operator`
- `go test ./internal/daemon -run 'TestRun_ProviderRelease|TestE2EProviderValidate|TestRun_ProviderCLIUsageAndErrors' -count=1`
- `go list ./services/plugins ./internal/bootstrap ./internal/operator ./internal/daemon`
- `go list ./...`
- `git diff --check`
