### PR TITLE
Inline coredata email normalization

### DIFF
--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -12,7 +13,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
-	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
@@ -47,7 +47,7 @@ func seedUserRecord(t *testing.T, svc *coredata.Services, id, email string, crea
 	rec := indexeddb.Record{
 		"id":               id,
 		"email":            email,
-		"normalized_email": emailutil.Normalize(email),
+		"normalized_email": strings.ToLower(strings.TrimSpace(email)),
 		"display_name":     "",
 		"created_at":       createdAt,
 		"updated_at":       createdAt,

--- a/gestaltd/internal/coredata/users.go
+++ b/gestaltd/internal/coredata/users.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
-	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 )
 
 type UserService struct {
@@ -32,7 +32,7 @@ func (s *UserService) GetUser(ctx context.Context, id string) (*core.User, error
 }
 
 func (s *UserService) FindOrCreateUser(ctx context.Context, email string) (*core.User, error) {
-	email = emailutil.Normalize(email)
+	email = normalizeEmail(email)
 	if email == "" {
 		return nil, fmt.Errorf("find user: email is required")
 	}
@@ -65,7 +65,7 @@ func (s *UserService) FindOrCreateUser(ctx context.Context, email string) (*core
 }
 
 func (s *UserService) FindUserByEmail(ctx context.Context, email string) (*core.User, error) {
-	email = emailutil.Normalize(email)
+	email = normalizeEmail(email)
 	if email == "" {
 		return nil, fmt.Errorf("find user: email is required")
 	}
@@ -84,6 +84,10 @@ func (s *UserService) findUserByNormalizedEmail(ctx context.Context, normalizedE
 		return nil, fmt.Errorf("find user: ambiguous duplicate users for %q", normalizedEmail)
 	}
 	return recordToUser(recs[0]), nil
+}
+
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
 }
 
 func recordToUser(rec indexeddb.Record) *core.User {

--- a/gestaltd/internal/emailutil/email.go
+++ b/gestaltd/internal/emailutil/email.go
@@ -1,7 +1,0 @@
-package emailutil
-
-import "strings"
-
-func Normalize(email string) string {
-	return strings.ToLower(strings.TrimSpace(email))
-}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -46,7 +46,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/composite"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
-	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	gestaltmcp "github.com/valon-technologies/gestalt/server/internal/mcp"
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/server"
@@ -2531,7 +2530,7 @@ func seedUserRecord(t *testing.T, svc *coredata.Services, id, email string, crea
 	rec := indexeddb.Record{
 		"id":               id,
 		"email":            email,
-		"normalized_email": emailutil.Normalize(email),
+		"normalized_email": strings.ToLower(strings.TrimSpace(email)),
 		"display_name":     "",
 		"created_at":       createdAt,
 		"updated_at":       createdAt,


### PR DESCRIPTION
## Summary

Deletes the one-function `gestaltd/internal/emailutil` package and keeps email normalization local to coredata user storage.

No behavior change: email normalization remains `strings.ToLower(strings.TrimSpace(email))`.

Note: PR #1666 is still open and not present on `origin/main`, so this PR is based on latest main and does not stack on it.

## Interface diff

```diff
- import "github.com/valon-technologies/gestalt/server/internal/emailutil"
+ import "strings"

- emailutil.Normalize(email)
+ strings.ToLower(strings.TrimSpace(email))
```

For production user storage:

```diff
- email = emailutil.Normalize(email)
+ email = normalizeEmail(email)
```

## Example

```go
user, err := services.Users.FindOrCreateUser(ctx, email)
```

`FindOrCreateUser` and `FindUserByEmail` still normalize before querying `normalized_email`.

## Testing

- `go test ./internal/coredata`
- `go test ./internal/server -run 'Test.*User|Test.*Subject|Test.*Token|Test.*Auth' -count=1`
- `go list ./internal/coredata ./internal/server`
- `go list ./...`
- `git diff --check`
