### PR TITLE
Collapse static UI helper into UI package

### DIFF
--- a/gestaltd/internal/adminui/adminui.go
+++ b/gestaltd/internal/adminui/adminui.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/valon-technologies/gestalt/server/internal/staticui"
+	"github.com/valon-technologies/gestalt/server/internal/ui"
 )
 
 //go:embed all:out
@@ -26,7 +26,7 @@ func EmbeddedHandler(opts Options) http.Handler {
 	if err != nil {
 		return nil
 	}
-	handler, err := staticui.Handler(staticui.Config{
+	handler, err := ui.StaticHandler(ui.StaticConfig{
 		FS:          sub,
 		RenderIndex: renderFunc(opts),
 	})
@@ -37,7 +37,7 @@ func EmbeddedHandler(opts Options) http.Handler {
 }
 
 func DirHandler(path string, opts Options) (http.Handler, error) {
-	return staticui.Handler(staticui.Config{
+	return ui.StaticHandler(ui.StaticConfig{
 		FS:          os.DirFS(path),
 		RenderIndex: renderFunc(opts),
 	})

--- a/gestaltd/internal/ui/static_handler.go
+++ b/gestaltd/internal/ui/static_handler.go
@@ -1,4 +1,4 @@
-package staticui
+package ui
 
 import (
 	"bytes"
@@ -10,13 +10,13 @@ import (
 	"time"
 )
 
-type Config struct {
+type StaticConfig struct {
 	FS           fs.FS
 	RenderIndex  func([]byte) []byte
 	DynamicIndex bool
 }
 
-func Handler(cfg Config) (http.Handler, error) {
+func StaticHandler(cfg StaticConfig) (http.Handler, error) {
 	if _, err := fs.Stat(cfg.FS, "index.html"); err != nil {
 		return nil, fmt.Errorf("asset root does not contain index.html: %w", err)
 	}

--- a/gestaltd/internal/ui/ui.go
+++ b/gestaltd/internal/ui/ui.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-
-	"github.com/valon-technologies/gestalt/server/internal/staticui"
 )
 
 func DirHandler(path string) (http.Handler, error) {
-	handler, err := staticui.Handler(staticui.Config{
+	handler, err := StaticHandler(StaticConfig{
 		FS:           os.DirFS(path),
 		DynamicIndex: true,
 	})


### PR DESCRIPTION
## Summary

Collapse the standalone `internal/staticui` helper into `internal/ui`. The static asset handler is UI mounting behavior, and the extra internal package only existed as a two-call-site wrapper boundary.

## Simplification

- Removed: `github.com/valon-technologies/gestalt/server/internal/staticui` as a separate package.
- Consolidated: shared static asset routing, SPA fallback, and navigation route resolution now live in `internal/ui`.
- Branching/special-casing reduced: no behavioral branch changes; this removes a package boundary and import indirection.

## Interface Changes

```diff
- import "github.com/valon-technologies/gestalt/server/internal/staticui"
+ import "github.com/valon-technologies/gestalt/server/internal/ui"

- handler, err := staticui.Handler(staticui.Config{
+ handler, err := ui.StaticHandler(ui.StaticConfig{
      FS: fsys,
      RenderIndex: renderIndex,
  })
```

Example usage:

```go
handler, err := ui.StaticHandler(ui.StaticConfig{
    FS:           os.DirFS(path),
    DynamicIndex: true,
})
```

## Functional/Integration Tests

- Tests added or augmented: none; this is a package collapse only.
- Tests consolidated or removed: none.
- Unit tests removed: none.
- Contract boundary covered: UI static file serving and mounted UI route resolution.
- Commands run:
  - `go test ./internal/ui ./internal/adminui -count=1`
  - `go test ./internal/server -run 'TestMountedUI|TestResolveBuiltinAdminUI|TestResolveConfiguredAdminUI|TestUI' -count=1`
  - `go list ./internal/ui ./internal/adminui ./internal/server`
  - `git diff --check`

## Follow-ups

- PR #1666 is still open and not present on `origin/main`; this PR intentionally avoids plugin discovery files.
- PR #1667 is still open while the slower Go checks finish; this PR intentionally avoids coredata/server email normalization files.
