### PR TITLE
Name GuardedInvoker optional interfaces

### DIFF
--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -100,9 +100,11 @@ type UserStore interface {
 }
 
 var (
-	_ Invoker          = (*Broker)(nil)
-	_ GraphQLInvoker   = (*Broker)(nil)
-	_ CapabilityLister = (*Broker)(nil)
+	_ Invoker              = (*Broker)(nil)
+	_ GraphQLInvoker       = (*Broker)(nil)
+	_ CapabilityLister     = (*Broker)(nil)
+	_ TokenResolver        = (*Broker)(nil)
+	_ subjectTokenResolver = (*Broker)(nil)
 )
 
 type ConnectionMapper interface {

--- a/gestaltd/services/invocation/catalog.go
+++ b/gestaltd/services/invocation/catalog.go
@@ -21,6 +21,10 @@ type TokenResolver interface {
 	ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error)
 }
 
+type subjectTokenResolver interface {
+	ResolveSubjectToken(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string) (context.Context, string, error)
+}
+
 type CatalogTargetExpander interface {
 	ExpandCatalogTargets(ctx context.Context, p *principal.Principal, providerName string, targets []CatalogResolutionTarget) ([]CatalogResolutionTarget, error)
 }

--- a/gestaltd/services/invocation/guarded.go
+++ b/gestaltd/services/invocation/guarded.go
@@ -16,9 +16,11 @@ const (
 )
 
 var (
-	_ Invoker          = (*GuardedInvoker)(nil)
-	_ GraphQLInvoker   = (*GuardedInvoker)(nil)
-	_ CapabilityLister = (*GuardedInvoker)(nil)
+	_ Invoker              = (*GuardedInvoker)(nil)
+	_ GraphQLInvoker       = (*GuardedInvoker)(nil)
+	_ CapabilityLister     = (*GuardedInvoker)(nil)
+	_ TokenResolver        = (*GuardedInvoker)(nil)
+	_ subjectTokenResolver = (*GuardedInvoker)(nil)
 )
 
 type GuardedInvoker struct {
@@ -217,20 +219,14 @@ func (g *GuardedInvoker) check(meta *InvocationMeta, providerName, instance, ope
 }
 
 func (g *GuardedInvoker) ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
-	type resolver interface {
-		ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error)
-	}
-	if r, ok := g.inner.(resolver); ok {
+	if r, ok := g.inner.(TokenResolver); ok {
 		return r.ResolveToken(ctx, p, providerName, connection, instance)
 	}
 	return ctx, "", fmt.Errorf("token resolution not supported")
 }
 
 func (g *GuardedInvoker) ResolveSubjectToken(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string) (context.Context, string, error) {
-	type resolver interface {
-		ResolveSubjectToken(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string) (context.Context, string, error)
-	}
-	if r, ok := g.inner.(resolver); ok {
+	if r, ok := g.inner.(subjectTokenResolver); ok {
 		return r.ResolveSubjectToken(ctx, prov, subjectID, providerName, connection, instance)
 	}
 	return ctx, "", fmt.Errorf("subject token resolution not supported")

--- a/gestaltd/services/invocation/guarded_test.go
+++ b/gestaltd/services/invocation/guarded_test.go
@@ -65,6 +65,34 @@ func (f funcInvoker) Invoke(ctx context.Context, p *principal.Principal, provide
 	return f.invoke(ctx, p, providerName, instance, operation, params)
 }
 
+type optionalInvoker struct {
+	invoke              func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error)
+	invokeGraphQL       func(ctx context.Context, p *principal.Principal, providerName, instance string, request invocation.GraphQLRequest) (*core.OperationResult, error)
+	resolveToken        func(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error)
+	resolveSubjectToken func(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string) (context.Context, string, error)
+}
+
+func (o *optionalInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
+	if o.invoke != nil {
+		return o.invoke(ctx, p, providerName, instance, operation, params)
+	}
+	return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+}
+
+func (o *optionalInvoker) InvokeGraphQL(ctx context.Context, p *principal.Principal, providerName, instance string, request invocation.GraphQLRequest) (*core.OperationResult, error) {
+	return o.invokeGraphQL(ctx, p, providerName, instance, request)
+}
+
+func (o *optionalInvoker) ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
+	return o.resolveToken(ctx, p, providerName, connection, instance)
+}
+
+func (o *optionalInvoker) ResolveSubjectToken(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string) (context.Context, string, error) {
+	return o.resolveSubjectToken(ctx, prov, subjectID, providerName, connection, instance)
+}
+
+type contextMarkerKey struct{}
+
 func guardTestProvider(name string) *stubProviderWithOps {
 	return &stubProviderWithOps{
 		StubIntegration: coretesting.StubIntegration{
@@ -322,4 +350,165 @@ func TestGuardedInvoker_ListCapabilities(t *testing.T) {
 			t.Fatalf("expected 3 capabilities, got %d", len(caps))
 		}
 	})
+}
+
+func TestGuardedInvoker_OptionalGraphQLDelegates(t *testing.T) {
+	t.Parallel()
+
+	sink := &capturingSink{}
+	base := &optionalInvoker{
+		invokeGraphQL: func(ctx context.Context, p *principal.Principal, providerName, instance string, request invocation.GraphQLRequest) (*core.OperationResult, error) {
+			if p.SubjectID != "subject-1" {
+				t.Fatalf("expected subject-1, got %q", p.SubjectID)
+			}
+			if providerName != "alpha" {
+				t.Fatalf("expected provider alpha, got %q", providerName)
+			}
+			if instance != "team-a" {
+				t.Fatalf("expected instance team-a, got %q", instance)
+			}
+			if request.Document != "query Test { viewer { id } }" {
+				t.Fatalf("unexpected document: %q", request.Document)
+			}
+			if request.Variables["limit"] != 3 {
+				t.Fatalf("unexpected variables: %#v", request.Variables)
+			}
+			meta := invocation.MetaFromContext(ctx)
+			if meta == nil {
+				t.Fatal("expected invocation metadata")
+			}
+			if meta.RequestID != "req-1" {
+				t.Fatalf("expected request req-1, got %q", meta.RequestID)
+			}
+			if meta.Depth != 2 {
+				t.Fatalf("expected depth 2, got %d", meta.Depth)
+			}
+			wantChain := []string{"root/default/ping", "alpha/team-a/graphql"}
+			if strings.Join(meta.CallChain, ",") != strings.Join(wantChain, ",") {
+				t.Fatalf("expected call chain %v, got %v", wantChain, meta.CallChain)
+			}
+			return &core.OperationResult{Status: http.StatusAccepted, Body: `{"graphql":true}`}, nil
+		},
+	}
+	guarded := invocation.NewGuarded(base, nil, "test", sink, invocation.WithAllowedProviders([]string{"alpha"}), invocation.WithoutRateLimit())
+
+	ctx := invocation.ContextWithMeta(context.Background(), &invocation.InvocationMeta{
+		RequestID: "req-1",
+		Depth:     1,
+		CallChain: []string{"root/default/ping"},
+	})
+	result, err := guarded.InvokeGraphQL(ctx, &principal.Principal{SubjectID: "subject-1"}, "alpha", "team-a", invocation.GraphQLRequest{
+		Document:  "query Test { viewer { id } }",
+		Variables: map[string]any{"limit": 3},
+	})
+	if err != nil {
+		t.Fatalf("InvokeGraphQL: %v", err)
+	}
+	if result.Status != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", result.Status)
+	}
+	if len(sink.entries) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(sink.entries))
+	}
+	entry := sink.entries[0]
+	if entry.Provider != "alpha" || entry.Operation != "graphql" || !entry.Allowed {
+		t.Fatalf("unexpected audit entry: %#v", entry)
+	}
+}
+
+func TestGuardedInvoker_OptionalTokenResolversDelegateOutsideGuardChecks(t *testing.T) {
+	t.Parallel()
+
+	prov := guardTestProvider("alpha")
+	base := &optionalInvoker{
+		resolveToken: func(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
+			if p.SubjectID != "subject-1" {
+				t.Fatalf("expected subject-1, got %q", p.SubjectID)
+			}
+			if providerName != "alpha" || connection != "workspace" || instance != "team-a" {
+				t.Fatalf("unexpected token target: %s/%s/%s", providerName, connection, instance)
+			}
+			return context.WithValue(ctx, contextMarkerKey{}, "token"), "token-123", nil
+		},
+		resolveSubjectToken: func(ctx context.Context, gotProv core.Provider, subjectID, providerName, connection, instance string) (context.Context, string, error) {
+			if gotProv != prov {
+				t.Fatal("expected provider to be forwarded")
+			}
+			if subjectID != "subject-2" || providerName != "alpha" || connection != "workspace" || instance != "team-b" {
+				t.Fatalf("unexpected subject token target: %s/%s/%s/%s", subjectID, providerName, connection, instance)
+			}
+			return context.WithValue(ctx, contextMarkerKey{}, "subject-token"), "subject-token-456", nil
+		},
+	}
+	guarded := invocation.NewGuarded(base, nil, "test", &capturingSink{}, invocation.WithAllowedProviders([]string{"other"}), invocation.WithoutRateLimit())
+
+	tokenCtx, token, err := guarded.ResolveToken(context.Background(), &principal.Principal{SubjectID: "subject-1"}, "alpha", "workspace", "team-a")
+	if err != nil {
+		t.Fatalf("ResolveToken: %v", err)
+	}
+	if token != "token-123" {
+		t.Fatalf("expected token-123, got %q", token)
+	}
+	if tokenCtx.Value(contextMarkerKey{}) != "token" {
+		t.Fatalf("expected token context marker, got %#v", tokenCtx.Value(contextMarkerKey{}))
+	}
+
+	subjectCtx, subjectToken, err := guarded.ResolveSubjectToken(context.Background(), prov, "subject-2", "alpha", "workspace", "team-b")
+	if err != nil {
+		t.Fatalf("ResolveSubjectToken: %v", err)
+	}
+	if subjectToken != "subject-token-456" {
+		t.Fatalf("expected subject-token-456, got %q", subjectToken)
+	}
+	if subjectCtx.Value(contextMarkerKey{}) != "subject-token" {
+		t.Fatalf("expected subject-token context marker, got %#v", subjectCtx.Value(contextMarkerKey{}))
+	}
+}
+
+func TestGuardedInvoker_OptionalDependenciesUnsupported(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	sink := &capturingSink{}
+	base := funcInvoker{
+		invoke: func(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+			invoked = true
+			return &core.OperationResult{Status: http.StatusOK}, nil
+		},
+	}
+	guarded := invocation.NewGuarded(base, nil, "test", sink, invocation.WithAllowedProviders([]string{"other"}), invocation.WithoutRateLimit())
+
+	_, err := guarded.InvokeGraphQL(context.Background(), &principal.Principal{}, "alpha", "", invocation.GraphQLRequest{})
+	if err == nil || err.Error() != "plugin invoker is not available" {
+		t.Fatalf("expected plugin invoker unavailable error, got %v", err)
+	}
+	if invoked {
+		t.Fatal("plain invoker should not be called for unsupported GraphQL")
+	}
+	if len(sink.entries) != 0 {
+		t.Fatalf("expected no audit entries for unsupported GraphQL, got %d", len(sink.entries))
+	}
+
+	ctx := context.WithValue(context.Background(), contextMarkerKey{}, "original")
+	tokenCtx, token, err := guarded.ResolveToken(ctx, &principal.Principal{}, "alpha", "workspace", "team-a")
+	if err == nil || err.Error() != "token resolution not supported" {
+		t.Fatalf("expected token unsupported error, got %v", err)
+	}
+	if token != "" {
+		t.Fatalf("expected empty token, got %q", token)
+	}
+	if tokenCtx != ctx {
+		t.Fatal("expected unsupported token resolution to return original context")
+	}
+
+	subjectCtx, subjectToken, err := guarded.ResolveSubjectToken(ctx, guardTestProvider("alpha"), "subject-1", "alpha", "workspace", "team-a")
+	if err == nil || err.Error() != "subject token resolution not supported" {
+		t.Fatalf("expected subject token unsupported error, got %v", err)
+	}
+	if subjectToken != "" {
+		t.Fatalf("expected empty subject token, got %q", subjectToken)
+	}
+	if subjectCtx != ctx {
+		t.Fatal("expected unsupported subject token resolution to return original context")
+	}
 }


### PR DESCRIPTION
## Summary

Make GuardedInvoker optional dependencies explicit through named interfaces instead of anonymous local resolver interfaces, while keeping the constructor and runtime behavior unchanged.

## Interface Changes
- New/changed interface: add an internal `subjectTokenResolver` interface alongside `TokenResolver`; `GuardedInvoker` now delegates token and subject-token behavior through named interfaces instead of anonymous per-call interface declarations.
- Example usage: existing calls like `invocation.NewGuarded(broker, broker, "http", audit, invocation.WithoutRateLimit())` continue to work; if `broker` implements the optional interfaces, guarded calls delegate through those interfaces.

## Functional/Integration Tests
- Tests added or augmented: `services/invocation/guarded_test.go` now covers optional GraphQL delegation, token delegation, subject-token delegation, unsupported optional behavior, unchanged unsupported-token contexts, and early unsupported GraphQL behavior without audit logging.
- Contract boundary covered: guarded invocation wrapper behavior across optional GraphQL/token interfaces and major consumer runtime assertions.
- Commands run:
  - `go test ./services/invocation`
  - `go test ./internal/bootstrap -run '^TestPluginInvokesGraphQLSurface$'`
  - `go test ./internal/server ./services/agents/agentmanager ./services/workflows/workflowmanager -run '^$'`
  - `golangci-lint run ./services/invocation`

Follow-up PRs: provider capability semantics/wrapper reduction, then plugin runtime consumer-owned subset interfaces.
