### PR TITLE
Collapse remote provider capability wrappers

### DIFF
--- a/gestaltd/core/provider_capabilities.go
+++ b/gestaltd/core/provider_capabilities.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 )
@@ -63,8 +64,23 @@ func WrapSessionCatalogUnsupported(err error) error {
 	}
 }
 
+type sessionCatalogSupporter interface {
+	SupportsSessionCatalog() bool
+}
+
+type postConnectSupporter interface {
+	SupportsPostConnect() bool
+}
+
+type httpSubjectSupporter interface {
+	SupportsHTTPSubject() bool
+}
+
 func SupportsSessionCatalog(prov Provider) bool {
-	if aware, ok := prov.(interface{ SupportsSessionCatalog() bool }); ok {
+	if prov == nil {
+		return false
+	}
+	if aware, ok := prov.(sessionCatalogSupporter); ok {
 		return aware.SupportsSessionCatalog()
 	}
 	_, ok := prov.(SessionCatalogProvider)
@@ -72,16 +88,22 @@ func SupportsSessionCatalog(prov Provider) bool {
 }
 
 func CatalogForRequest(ctx context.Context, prov Provider, token string) (*catalog.Catalog, bool, error) {
+	if !SupportsSessionCatalog(prov) {
+		return nil, false, nil
+	}
 	scp, ok := prov.(SessionCatalogProvider)
 	if !ok {
-		return nil, false, nil
+		return nil, true, WrapSessionCatalogUnsupported(fmt.Errorf("provider %q advertises session catalog support but does not implement session catalogs", prov.Name()))
 	}
 	cat, err := scp.CatalogForRequest(ctx, token)
 	return cat, true, wrapSessionCatalogUnavailable(err)
 }
 
 func SupportsPostConnect(prov Provider) bool {
-	if aware, ok := prov.(interface{ SupportsPostConnect() bool }); ok {
+	if prov == nil {
+		return false
+	}
+	if aware, ok := prov.(postConnectSupporter); ok {
 		return aware.SupportsPostConnect()
 	}
 	_, ok := prov.(PostConnectCapable)
@@ -94,7 +116,7 @@ func PostConnect(ctx context.Context, prov Provider, token *ExternalCredential) 
 	}
 	pcp, ok := prov.(PostConnectCapable)
 	if !ok {
-		return nil, false, nil
+		return nil, true, fmt.Errorf("%w: provider %q advertises post-connect support but does not implement post-connect", ErrPostConnectUnsupported, prov.Name())
 	}
 	metadata, err := pcp.PostConnect(ctx, token)
 	if err != nil {
@@ -107,7 +129,10 @@ func PostConnect(ctx context.Context, prov Provider, token *ExternalCredential) 
 }
 
 func SupportsHTTPSubject(prov Provider) bool {
-	if aware, ok := prov.(interface{ SupportsHTTPSubject() bool }); ok {
+	if prov == nil {
+		return false
+	}
+	if aware, ok := prov.(httpSubjectSupporter); ok {
 		return aware.SupportsHTTPSubject()
 	}
 	_, ok := prov.(HTTPSubjectResolver)

--- a/gestaltd/core/provider_capabilities_test.go
+++ b/gestaltd/core/provider_capabilities_test.go
@@ -1,0 +1,119 @@
+package core_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+)
+
+type sessionCatalogProbeProvider struct {
+	coretesting.StubIntegration
+	supports bool
+	called   bool
+}
+
+func (p *sessionCatalogProbeProvider) SupportsSessionCatalog() bool {
+	return p.supports
+}
+
+func (p *sessionCatalogProbeProvider) CatalogForRequest(context.Context, string) (*catalog.Catalog, error) {
+	p.called = true
+	return &catalog.Catalog{Name: "probe"}, nil
+}
+
+type sessionCatalogSupportOnlyProvider struct {
+	coretesting.StubIntegration
+}
+
+func (p *sessionCatalogSupportOnlyProvider) SupportsSessionCatalog() bool {
+	return true
+}
+
+type postConnectProbeProvider struct {
+	coretesting.StubIntegration
+	supports bool
+	called   bool
+}
+
+func (p *postConnectProbeProvider) SupportsPostConnect() bool {
+	return p.supports
+}
+
+func (p *postConnectProbeProvider) PostConnect(context.Context, *core.ExternalCredential) (map[string]string, error) {
+	p.called = true
+	return map[string]string{"ok": "true"}, nil
+}
+
+type postConnectSupportOnlyProvider struct {
+	coretesting.StubIntegration
+}
+
+func (p *postConnectSupportOnlyProvider) SupportsPostConnect() bool {
+	return true
+}
+
+func TestCapabilityHelpersRespectExplicitSupportFlags(t *testing.T) {
+	t.Parallel()
+
+	session := &sessionCatalogProbeProvider{
+		StubIntegration: coretesting.StubIntegration{N: "session"},
+	}
+	cat, attempted, err := core.CatalogForRequest(context.Background(), session, "token")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if attempted {
+		t.Fatal("expected session catalog attempt to be skipped")
+	}
+	if cat != nil {
+		t.Fatalf("expected nil catalog, got %#v", cat)
+	}
+	if session.called {
+		t.Fatal("explicit false support should prevent CatalogForRequest from being called")
+	}
+
+	postConnect := &postConnectProbeProvider{
+		StubIntegration: coretesting.StubIntegration{N: "post-connect"},
+	}
+	metadata, supported, err := core.PostConnect(context.Background(), postConnect, &core.ExternalCredential{})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if supported {
+		t.Fatal("expected post-connect support to be skipped")
+	}
+	if metadata != nil {
+		t.Fatalf("expected nil metadata, got %#v", metadata)
+	}
+	if postConnect.called {
+		t.Fatal("explicit false support should prevent PostConnect from being called")
+	}
+}
+
+func TestCapabilityHelpersReportAdvertisedSupportWithoutMethod(t *testing.T) {
+	t.Parallel()
+
+	_, attempted, err := core.CatalogForRequest(context.Background(), &sessionCatalogSupportOnlyProvider{
+		StubIntegration: coretesting.StubIntegration{N: "session"},
+	}, "token")
+	if !attempted {
+		t.Fatal("expected advertised session catalog support to be attempted")
+	}
+	if !errors.Is(err, core.ErrSessionCatalogUnsupported) {
+		t.Fatalf("expected ErrSessionCatalogUnsupported, got %v", err)
+	}
+
+	_, supported, err := core.PostConnect(context.Background(), &postConnectSupportOnlyProvider{
+		StubIntegration: coretesting.StubIntegration{N: "post-connect"},
+	}, &core.ExternalCredential{})
+	if !supported {
+		t.Fatal("expected advertised post-connect support")
+	}
+	if !errors.Is(err, core.ErrPostConnectUnsupported) {
+		t.Fatalf("expected ErrPostConnectUnsupported, got %v", err)
+	}
+}

--- a/gestaltd/internal/bootstrap/connected_provider.go
+++ b/gestaltd/internal/bootstrap/connected_provider.go
@@ -18,10 +18,10 @@ func bindProviderConnection(prov core.Provider, connection string) core.Provider
 		inner:      prov,
 		connection: connection,
 	}
-	if session, ok := prov.(core.SessionCatalogProvider); ok {
+	if core.SupportsSessionCatalog(prov) {
 		wrapped = &connectedSessionCatalogProvider{
-			Provider: wrapped,
-			session:  session,
+			Provider:      wrapped,
+			sessionSource: prov,
 		}
 	}
 	if graphQL, ok := prov.(core.GraphQLSurfaceInvoker); ok {
@@ -83,6 +83,9 @@ func (p *connectedProvider) OperationConnectionOverrideAllowed(operation string,
 	return false
 }
 func (p *connectedProvider) Catalog() *catalog.Catalog { return p.inner.Catalog() }
+func (p *connectedProvider) SupportsSessionCatalog() bool {
+	return core.SupportsSessionCatalog(p.inner)
+}
 func (p *connectedProvider) SupportsPostConnect() bool { return core.SupportsPostConnect(p.inner) }
 func (p *connectedProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
 	return p.inner.Execute(ctx, operation, params, token)
@@ -108,7 +111,11 @@ func (p *connectedProvider) Close() error {
 
 type connectedSessionCatalogProvider struct {
 	core.Provider
-	session core.SessionCatalogProvider
+	sessionSource core.Provider
+}
+
+func (p *connectedSessionCatalogProvider) SupportsSessionCatalog() bool {
+	return core.SupportsSessionCatalog(p.sessionSource)
 }
 
 func (p *connectedSessionCatalogProvider) SupportsPostConnect() bool {
@@ -141,7 +148,11 @@ func (p *connectedSessionCatalogProvider) OperationConnectionOverrideAllowed(ope
 }
 
 func (p *connectedSessionCatalogProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	return p.session.CatalogForRequest(ctx, token)
+	cat, scoped, err := core.CatalogForRequest(ctx, p.sessionSource, token)
+	if !scoped {
+		return nil, core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", p.Name()))
+	}
+	return cat, err
 }
 
 func (p *connectedSessionCatalogProvider) Close() error {
@@ -154,6 +165,10 @@ func (p *connectedSessionCatalogProvider) Close() error {
 type connectedGraphQLProvider struct {
 	core.Provider
 	graphQL core.GraphQLSurfaceInvoker
+}
+
+func (p *connectedGraphQLProvider) SupportsSessionCatalog() bool {
+	return core.SupportsSessionCatalog(p.Provider)
 }
 
 func (p *connectedGraphQLProvider) SupportsPostConnect() bool {
@@ -190,11 +205,11 @@ func (p *connectedGraphQLProvider) InvokeGraphQL(ctx context.Context, request co
 }
 
 func (p *connectedGraphQLProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	session, ok := p.Provider.(core.SessionCatalogProvider)
-	if !ok {
+	cat, scoped, err := core.CatalogForRequest(ctx, p.Provider, token)
+	if !scoped {
 		return nil, core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", p.Name()))
 	}
-	return session.CatalogForRequest(ctx, token)
+	return cat, err
 }
 
 func (p *connectedGraphQLProvider) Close() error {
@@ -207,6 +222,10 @@ func (p *connectedGraphQLProvider) Close() error {
 type connectedOAuthProvider struct {
 	core.Provider
 	auth core.OAuthProvider
+}
+
+func (p *connectedOAuthProvider) SupportsSessionCatalog() bool {
+	return core.SupportsSessionCatalog(p.Provider)
 }
 
 func (p *connectedOAuthProvider) SupportsPostConnect() bool {
@@ -251,11 +270,11 @@ func (p *connectedOAuthProvider) RefreshToken(ctx context.Context, refreshToken 
 }
 
 func (p *connectedOAuthProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	session, ok := p.Provider.(core.SessionCatalogProvider)
-	if !ok {
+	cat, scoped, err := core.CatalogForRequest(ctx, p.Provider, token)
+	if !scoped {
 		return nil, core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", p.Name()))
 	}
-	return session.CatalogForRequest(ctx, token)
+	return cat, err
 }
 
 func (p *connectedOAuthProvider) InvokeGraphQL(ctx context.Context, request core.GraphQLRequest, token string) (*core.OperationResult, error) {

--- a/gestaltd/internal/bootstrap/connected_provider_test.go
+++ b/gestaltd/internal/bootstrap/connected_provider_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"reflect"
 	"testing"
@@ -237,5 +238,55 @@ func TestBindProviderConnectionDoesNotFalsePositivePostConnectSupport(t *testing
 	}
 	if got != nil {
 		t.Fatalf("PostConnect metadata = %#v, want nil", got)
+	}
+}
+
+type connectedNoSessionCatalogProvider struct {
+	connectedNoPostConnectProvider
+	catalogCalls int
+}
+
+func (p *connectedNoSessionCatalogProvider) SupportsSessionCatalog() bool {
+	return false
+}
+
+func (p *connectedNoSessionCatalogProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
+	p.catalogCalls++
+	return p.connectedNoPostConnectProvider.CatalogForRequest(ctx, token)
+}
+
+func TestBindProviderConnectionDoesNotFalsePositiveSessionCatalogSupport(t *testing.T) {
+	t.Parallel()
+
+	inner := &connectedNoSessionCatalogProvider{}
+	prov := bindProviderConnection(inner, "default")
+	if core.SupportsSessionCatalog(prov) {
+		t.Fatal("expected bound provider to report no session catalog support")
+	}
+
+	cat, attempted, err := core.CatalogForRequest(context.Background(), prov, "tok")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if attempted {
+		t.Fatal("expected core.CatalogForRequest to report no attempt")
+	}
+	if cat != nil {
+		t.Fatalf("CatalogForRequest catalog = %#v, want nil", cat)
+	}
+	if inner.catalogCalls != 0 {
+		t.Fatalf("CatalogForRequest calls = %d, want 0", inner.catalogCalls)
+	}
+
+	scp, ok := prov.(core.SessionCatalogProvider)
+	if !ok {
+		t.Fatal("expected outer OAuth/GraphQL wrapper to still have direct CatalogForRequest method")
+	}
+	_, err = scp.CatalogForRequest(context.Background(), "tok")
+	if !errors.Is(err, core.ErrSessionCatalogUnsupported) {
+		t.Fatalf("direct CatalogForRequest error = %v, want ErrSessionCatalogUnsupported", err)
+	}
+	if inner.catalogCalls != 0 {
+		t.Fatalf("direct CatalogForRequest calls = %d, want 0", inner.catalogCalls)
 	}
 }

--- a/gestaltd/services/plugins/composite/provider.go
+++ b/gestaltd/services/plugins/composite/provider.go
@@ -148,10 +148,11 @@ func (p *Provider) SupportsPostConnect() bool {
 }
 
 func (p *Provider) PostConnect(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
-	if pcp, ok := p.api.(core.PostConnectCapable); ok {
-		return pcp.PostConnect(ctx, token)
+	metadata, supported, err := core.PostConnect(ctx, p.api, token)
+	if !supported {
+		return nil, core.ErrPostConnectUnsupported
 	}
-	return nil, core.ErrPostConnectUnsupported
+	return metadata, err
 }
 
 func (p *Provider) SupportsHTTPSubject() bool {

--- a/gestaltd/services/plugins/composite/provider_session_test.go
+++ b/gestaltd/services/plugins/composite/provider_session_test.go
@@ -2,6 +2,7 @@ package composite_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"reflect"
 	"testing"
@@ -155,5 +156,68 @@ func TestCompositePreservesPostConnectCapability(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, api.metadata) {
 		t.Fatalf("PostConnect metadata = %#v, want %#v", got, api.metadata)
+	}
+}
+
+type falseSupportPostConnectProvider struct {
+	*fakeProvider
+	called bool
+}
+
+func (p *falseSupportPostConnectProvider) SupportsPostConnect() bool {
+	return false
+}
+
+func (p *falseSupportPostConnectProvider) PostConnect(context.Context, *core.ExternalCredential) (map[string]string, error) {
+	p.called = true
+	return map[string]string{"unexpected": "true"}, nil
+}
+
+func TestCompositeSkipsPostConnectWhenProviderAdvertisesNoSupport(t *testing.T) {
+	t.Parallel()
+
+	api := &falseSupportPostConnectProvider{
+		fakeProvider: &fakeProvider{name: "api"},
+	}
+	mcp := &fakeMCPUpstream{
+		fakeSessionProvider: &fakeSessionProvider{
+			fakeProvider: &fakeProvider{name: "mcp", connMode: core.ConnectionModeUser},
+			sessionCat:   &catalog.Catalog{Name: "test"},
+		},
+	}
+
+	prov := composite.New("test", api, mcp)
+	if core.SupportsPostConnect(prov) {
+		t.Fatal("expected composite provider to report no post-connect support")
+	}
+
+	metadata, supported, err := core.PostConnect(context.Background(), prov, &core.ExternalCredential{
+		Integration: "slack",
+		Connection:  "default",
+		AccessToken: "tok",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if supported {
+		t.Fatal("expected core.PostConnect to report unsupported")
+	}
+	if metadata != nil {
+		t.Fatalf("PostConnect metadata = %#v, want nil", metadata)
+	}
+	if api.called {
+		t.Fatal("explicit false support should prevent API PostConnect from being called")
+	}
+
+	pcp, ok := prov.(core.PostConnectCapable)
+	if !ok {
+		t.Fatal("expected composite provider to keep direct PostConnect method")
+	}
+	_, err = pcp.PostConnect(context.Background(), &core.ExternalCredential{})
+	if !errors.Is(err, core.ErrPostConnectUnsupported) {
+		t.Fatalf("direct PostConnect error = %v, want ErrPostConnectUnsupported", err)
+	}
+	if api.called {
+		t.Fatal("direct composite PostConnect should not call API provider with false support")
 	}
 }

--- a/gestaltd/services/plugins/declarative/restricted_test.go
+++ b/gestaltd/services/plugins/declarative/restricted_test.go
@@ -2,6 +2,7 @@ package declarative_test
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -389,5 +390,40 @@ func TestRestrictedPreservesPostConnectCapability(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("PostConnect metadata = %#v, want %#v", got, want)
+	}
+}
+
+func TestRestrictedOAuthDoesNotFalsePositiveSessionCatalogSupport(t *testing.T) {
+	t.Parallel()
+
+	inner := &stubOAuth{
+		stubWithOps: stubWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			ops:             sampleOps(),
+		},
+	}
+
+	prov := coreintegration.NewRestricted(inner, map[string]string{"list_channels": ""})
+	if core.SupportsSessionCatalog(prov) {
+		t.Fatal("expected restricted OAuth wrapper to report no session catalog support")
+	}
+	cat, attempted, err := core.CatalogForRequest(context.Background(), prov, "tok")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if attempted {
+		t.Fatal("expected core.CatalogForRequest to report no attempt")
+	}
+	if cat != nil {
+		t.Fatalf("CatalogForRequest catalog = %#v, want nil", cat)
+	}
+
+	scp, ok := prov.(core.SessionCatalogProvider)
+	if !ok {
+		t.Fatal("expected OAuth wrapper to still have direct CatalogForRequest method")
+	}
+	_, err = scp.CatalogForRequest(context.Background(), "tok")
+	if !errors.Is(err, core.ErrSessionCatalogUnsupported) {
+		t.Fatalf("direct CatalogForRequest error = %v, want ErrSessionCatalogUnsupported", err)
 	}
 }

--- a/gestaltd/services/plugins/operationexposure/restricted.go
+++ b/gestaltd/services/plugins/operationexposure/restricted.go
@@ -74,8 +74,8 @@ func NewRestricted(inner core.Provider, ops map[string]string, opts ...Restricte
 	for _, opt := range opts {
 		opt(r)
 	}
-	if scp, ok := inner.(core.SessionCatalogProvider); ok {
-		rs := &restrictedSession{Restricted: r, scp: scp}
+	if core.SupportsSessionCatalog(inner) {
+		rs := &restrictedSession{Restricted: r, sessionSource: inner}
 		if oauth, ok := inner.(core.OAuthProvider); ok {
 			return &restrictedOAuth{Restricted: rs.Restricted, inner: oauth, session: rs}
 		}
@@ -173,15 +173,22 @@ func (r *Restricted) Inner() core.Provider {
 	return r.inner
 }
 
+func (r *Restricted) SupportsSessionCatalog() bool {
+	return core.SupportsSessionCatalog(r.inner)
+}
+
 // restrictedSession wraps a Restricted provider and adds SessionCatalogProvider
-// support. Only returned when the inner provider actually implements it.
+// support. Only returned when the inner provider reports support for it.
 type restrictedSession struct {
 	*Restricted
-	scp core.SessionCatalogProvider
+	sessionSource core.Provider
 }
 
 func (rs *restrictedSession) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	cat, err := rs.scp.CatalogForRequest(ctx, token)
+	cat, scoped, err := core.CatalogForRequest(ctx, rs.sessionSource, token)
+	if !scoped {
+		return nil, core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", rs.Name()))
+	}
 	if err != nil || cat == nil {
 		return cat, err
 	}
@@ -208,11 +215,15 @@ func (r *restrictedOAuth) RefreshToken(ctx context.Context, refreshToken string)
 	return r.inner.RefreshToken(ctx, refreshToken)
 }
 
+func (r *restrictedOAuth) SupportsSessionCatalog() bool {
+	return r.session != nil && core.SupportsSessionCatalog(r.Restricted.inner)
+}
+
 func (r *restrictedOAuth) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
 	if r.session != nil {
 		return r.session.CatalogForRequest(ctx, token)
 	}
-	return nil, nil
+	return nil, core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", r.Name()))
 }
 
 func (r *Restricted) AuthTypes() []string {
@@ -236,10 +247,11 @@ func (r *Restricted) SupportsPostConnect() bool {
 }
 
 func (r *Restricted) PostConnect(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
-	if pcp, ok := r.inner.(core.PostConnectCapable); ok {
-		return pcp.PostConnect(ctx, token)
+	metadata, supported, err := core.PostConnect(ctx, r.inner, token)
+	if !supported {
+		return nil, core.ErrPostConnectUnsupported
 	}
-	return nil, core.ErrPostConnectUnsupported
+	return metadata, err
 }
 
 func (r *Restricted) SupportsHTTPSubject() bool {

--- a/gestaltd/services/plugins/provider_client.go
+++ b/gestaltd/services/plugins/provider_client.go
@@ -34,6 +34,7 @@ type StaticProviderSpec struct {
 
 type remoteProviderBase struct {
 	client       proto.IntegrationProviderClient
+	support      integrationProviderSupport
 	name         string
 	displayName  string
 	description  string
@@ -49,6 +50,11 @@ type remoteProviderBase struct {
 	callerPlugin string
 	invokeGrants plugininvokerservice.InvocationGrants
 }
+
+var (
+	_ core.SessionCatalogProvider = (*remoteProviderBase)(nil)
+	_ core.PostConnectCapable     = (*remoteProviderBase)(nil)
+)
 
 type integrationProviderSupport struct {
 	sessionCatalog bool
@@ -86,6 +92,7 @@ func NewRemote(ctx context.Context, client proto.IntegrationProviderClient, spec
 
 	base := &remoteProviderBase{
 		client:      client,
+		support:     *support,
 		name:        spec.Name,
 		displayName: spec.DisplayName,
 		description: spec.Description,
@@ -101,14 +108,6 @@ func NewRemote(ctx context.Context, client proto.IntegrationProviderClient, spec
 		opt(base)
 	}
 
-	switch {
-	case support.sessionCatalog && support.postConnect:
-		return &remoteProviderWithSessionCatalogAndPostConnect{remoteProviderBase: base}, nil
-	case support.sessionCatalog:
-		return &remoteProviderWithSessionCatalog{remoteProviderBase: base}, nil
-	case support.postConnect:
-		return &remoteProviderWithPostConnect{remoteProviderBase: base}, nil
-	}
 	return base, nil
 }
 
@@ -218,6 +217,17 @@ func (p *remoteProviderBase) DiscoveryConfig() *core.DiscoveryConfig {
 
 func (p *remoteProviderBase) ConnectionForOperation(string) string { return "" }
 
+func (p *remoteProviderBase) SupportsSessionCatalog() bool {
+	return p != nil && p.support.sessionCatalog
+}
+
+func (p *remoteProviderBase) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
+	if !p.SupportsSessionCatalog() {
+		return nil, core.WrapSessionCatalogUnsupported(core.ErrSessionCatalogUnsupported)
+	}
+	return p.sessionCatalog(ctx, token)
+}
+
 func (p *remoteProviderBase) sessionCatalog(ctx context.Context, token string) (*catalog.Catalog, error) {
 	reqCtx, err := requestContextProto(ctx)
 	if err != nil {
@@ -239,6 +249,17 @@ func (p *remoteProviderBase) sessionCatalog(ctx context.Context, token string) (
 	return p.decorateCatalog(cat), nil
 }
 
+func (p *remoteProviderBase) SupportsPostConnect() bool {
+	return p != nil && p.support.postConnect
+}
+
+func (p *remoteProviderBase) PostConnect(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
+	if !p.SupportsPostConnect() {
+		return nil, core.ErrPostConnectUnsupported
+	}
+	return p.postConnect(ctx, token)
+}
+
 func (p *remoteProviderBase) postConnect(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
 	resp, err := p.client.PostConnect(ctx, &proto.PostConnectRequest{
 		Token: postConnectCredentialToProto(token),
@@ -255,28 +276,6 @@ func (p *remoteProviderBase) postConnect(ctx context.Context, token *core.Extern
 		out[key] = value
 	}
 	return out, nil
-}
-
-type remoteProviderWithSessionCatalog struct{ *remoteProviderBase }
-
-func (p *remoteProviderWithSessionCatalog) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	return p.sessionCatalog(ctx, token)
-}
-
-type remoteProviderWithPostConnect struct{ *remoteProviderBase }
-
-func (p *remoteProviderWithPostConnect) PostConnect(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
-	return p.postConnect(ctx, token)
-}
-
-type remoteProviderWithSessionCatalogAndPostConnect struct{ *remoteProviderBase }
-
-func (p *remoteProviderWithSessionCatalogAndPostConnect) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	return p.sessionCatalog(ctx, token)
-}
-
-func (p *remoteProviderWithSessionCatalogAndPostConnect) PostConnect(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
-	return p.postConnect(ctx, token)
 }
 
 func (p *remoteProviderBase) decorateCatalog(cat *catalog.Catalog) *catalog.Catalog {

--- a/gestaltd/services/plugins/provider_test.go
+++ b/gestaltd/services/plugins/provider_test.go
@@ -2,9 +2,11 @@ package plugins
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	sdkgestalt "github.com/valon-technologies/gestalt/sdk/go"
@@ -191,8 +193,14 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	if _, ok := prov.(core.SessionCatalogProvider); !ok {
 		t.Fatal("expected remote provider to implement SessionCatalogProvider")
 	}
+	if !core.SupportsSessionCatalog(prov) {
+		t.Fatal("expected remote provider to support session catalogs")
+	}
 	if _, ok := prov.(core.PostConnectCapable); !ok {
 		t.Fatal("expected remote provider to implement PostConnectCapable")
+	}
+	if !core.SupportsPostConnect(prov) {
+		t.Fatal("expected remote provider to support post-connect")
 	}
 	if got := prov.AuthTypes(); len(got) != 1 || got[0] != "manual" {
 		t.Fatalf("unexpected auth types: %#v", got)
@@ -266,10 +274,12 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 				t.Fatalf("unexpected static catalog allowedRoles: %#v", got)
 			}
 
-			scp := prov.(core.SessionCatalogProvider)
-			sessionCat, err := scp.CatalogForRequest(ctx, "token-123")
+			sessionCat, attempted, err := core.CatalogForRequest(ctx, prov, "token-123")
 			if err != nil {
 				t.Fatalf("CatalogForRequest: %v", err)
+			}
+			if !attempted {
+				t.Fatal("expected core.CatalogForRequest to report attempted")
 			}
 			if sessionCat.Name != "roundtrip-session" || sessionCat.DisplayName != tc.wantSessionCatalog {
 				t.Fatalf("unexpected session catalog: %+v", sessionCat)
@@ -281,14 +291,16 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 				t.Fatalf("unexpected session catalog tags: %#v", got)
 			}
 
-			pcp := prov.(core.PostConnectCapable)
-			metadata, err := pcp.PostConnect(ctx, &core.ExternalCredential{
+			metadata, supported, err := core.PostConnect(ctx, prov, &core.ExternalCredential{
 				SubjectID:  principal.EffectiveCredentialSubjectID(tc.principal),
 				Connection: "workspace",
 				Instance:   "default",
 			})
 			if err != nil {
 				t.Fatalf("PostConnect: %v", err)
+			}
+			if !supported {
+				t.Fatal("expected core.PostConnect to report support")
 			}
 			if !reflect.DeepEqual(metadata, map[string]string{
 				"subject":    principal.EffectiveCredentialSubjectID(tc.principal),
@@ -447,6 +459,38 @@ func (s *metadataFailureProviderServer) GetMetadata(context.Context, *emptypb.Em
 	return nil, status.Error(codes.Unknown, "provider metadata: metadata exploded")
 }
 
+type unsupportedCapabilityProviderServer struct {
+	proto.UnimplementedIntegrationProviderServer
+	metadataErr         error
+	sessionCatalogCalls atomic.Int32
+	postConnectCalls    atomic.Int32
+}
+
+func (s *unsupportedCapabilityProviderServer) GetMetadata(context.Context, *emptypb.Empty) (*proto.ProviderMetadata, error) {
+	if s.metadataErr != nil {
+		return nil, s.metadataErr
+	}
+	return &proto.ProviderMetadata{}, nil
+}
+
+func (s *unsupportedCapabilityProviderServer) StartProvider(context.Context, *proto.StartProviderRequest) (*proto.StartProviderResponse, error) {
+	return &proto.StartProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+}
+
+func (s *unsupportedCapabilityProviderServer) Execute(context.Context, *proto.ExecuteRequest) (*proto.OperationResult, error) {
+	return &proto.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
+}
+
+func (s *unsupportedCapabilityProviderServer) GetSessionCatalog(context.Context, *proto.GetSessionCatalogRequest) (*proto.GetSessionCatalogResponse, error) {
+	s.sessionCatalogCalls.Add(1)
+	return nil, status.Error(codes.Unimplemented, "session catalog is not implemented")
+}
+
+func (s *unsupportedCapabilityProviderServer) PostConnect(context.Context, *proto.PostConnectRequest) (*proto.PostConnectResponse, error) {
+	s.postConnectCalls.Add(1)
+	return nil, status.Error(codes.Unimplemented, "post connect is not implemented")
+}
+
 type unavailableMetadataProviderServer struct {
 	cancel context.CancelFunc
 }
@@ -476,6 +520,84 @@ func (*unavailableMetadataProviderServer) GetSessionCatalog(context.Context, *pr
 
 func (*unavailableMetadataProviderServer) PostConnect(context.Context, *proto.PostConnectRequest, ...grpc.CallOption) (*proto.PostConnectResponse, error) {
 	panic("unexpected PostConnect call")
+}
+
+func TestRemoteProviderUnsupportedCapabilitiesDoNotDispatchRPCs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		metadataErr error
+	}{
+		{name: "metadata false"},
+		{name: "metadata unimplemented", metadataErr: status.Error(codes.Unimplemented, "metadata is not implemented")},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := &unsupportedCapabilityProviderServer{metadataErr: tc.metadataErr}
+			prov, err := NewRemoteProvider(context.Background(), newIntegrationProviderClient(t, server), manualOnlyStaticSpec(), nil)
+			if err != nil {
+				t.Fatalf("NewRemoteProvider: %v", err)
+			}
+			if _, ok := prov.(core.SessionCatalogProvider); !ok {
+				t.Fatal("expected remote provider to implement SessionCatalogProvider")
+			}
+			if _, ok := prov.(core.PostConnectCapable); !ok {
+				t.Fatal("expected remote provider to implement PostConnectCapable")
+			}
+
+			if core.SupportsSessionCatalog(prov) {
+				t.Fatal("expected remote provider to report no session catalog support")
+			}
+			cat, attempted, err := core.CatalogForRequest(context.Background(), prov, "tok")
+			if err != nil {
+				t.Fatalf("CatalogForRequest: %v", err)
+			}
+			if attempted {
+				t.Fatal("expected core.CatalogForRequest to report no attempt")
+			}
+			if cat != nil {
+				t.Fatalf("CatalogForRequest catalog = %#v, want nil", cat)
+			}
+
+			scp := prov.(core.SessionCatalogProvider)
+			_, err = scp.CatalogForRequest(context.Background(), "tok")
+			if !errors.Is(err, core.ErrSessionCatalogUnsupported) {
+				t.Fatalf("direct CatalogForRequest error = %v, want ErrSessionCatalogUnsupported", err)
+			}
+
+			if core.SupportsPostConnect(prov) {
+				t.Fatal("expected remote provider to report no post-connect support")
+			}
+			metadata, supported, err := core.PostConnect(context.Background(), prov, &core.ExternalCredential{})
+			if err != nil {
+				t.Fatalf("PostConnect: %v", err)
+			}
+			if supported {
+				t.Fatal("expected core.PostConnect to report unsupported")
+			}
+			if metadata != nil {
+				t.Fatalf("PostConnect metadata = %#v, want nil", metadata)
+			}
+
+			pcp := prov.(core.PostConnectCapable)
+			_, err = pcp.PostConnect(context.Background(), &core.ExternalCredential{})
+			if !errors.Is(err, core.ErrPostConnectUnsupported) {
+				t.Fatalf("direct PostConnect error = %v, want ErrPostConnectUnsupported", err)
+			}
+
+			if got := server.sessionCatalogCalls.Load(); got != 0 {
+				t.Fatalf("GetSessionCatalog calls = %d, want 0", got)
+			}
+			if got := server.postConnectCalls.Load(); got != 0 {
+				t.Fatalf("PostConnect calls = %d, want 0", got)
+			}
+		})
+	}
 }
 
 func TestNewRemoteProviderLabelsMetadataFailures(t *testing.T) {

--- a/gestaltd/services/providerdev/session.go
+++ b/gestaltd/services/providerdev/session.go
@@ -1552,11 +1552,10 @@ func (p *attachProvider) CatalogForRequest(ctx context.Context, token string) (*
 	if p == nil || p.Provider == nil {
 		return nil, core.ErrSessionCatalogUnsupported
 	}
-	scp, ok := p.Provider.(core.SessionCatalogProvider)
-	if !ok {
-		return nil, core.ErrSessionCatalogUnsupported
+	cat, scoped, err := core.CatalogForRequest(ctx, p.Provider, token)
+	if !scoped {
+		return nil, core.WrapSessionCatalogUnsupported(core.ErrSessionCatalogUnsupported)
 	}
-	cat, err := scp.CatalogForRequest(ctx, token)
 	if err != nil {
 		return nil, err
 	}
@@ -1574,11 +1573,11 @@ func (p *attachProvider) PostConnect(ctx context.Context, token *core.ExternalCr
 	if p == nil || p.Provider == nil {
 		return nil, core.ErrPostConnectUnsupported
 	}
-	pcp, ok := p.Provider.(core.PostConnectCapable)
-	if !ok {
+	metadata, supported, err := core.PostConnect(ctx, p.Provider, token)
+	if !supported {
 		return nil, core.ErrPostConnectUnsupported
 	}
-	return pcp.PostConnect(ctx, token)
+	return metadata, err
 }
 
 func (p *attachProvider) SupportsHTTPSubject() bool {

--- a/gestaltd/services/providerdev/session_test.go
+++ b/gestaltd/services/providerdev/session_test.go
@@ -246,6 +246,61 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	}
 }
 
+func TestAttachProviderSkipsSessionCatalogWhenRemoteMetadataReportsNoSupport(t *testing.T) {
+	t.Parallel()
+
+	local := &recordingIntegrationClient{
+		sessionCatalog: &proto.Catalog{
+			Name: "roadmap",
+			Operations: []*proto.CatalogOperation{{
+				Id:        "echo",
+				Transport: catalog.TransportPlugin,
+			}},
+		},
+	}
+	spec := pluginservice.StaticProviderSpec{
+		Name:           "roadmap",
+		DisplayName:    "Roadmap",
+		ConnectionMode: core.ConnectionModeUser,
+		Catalog: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{{
+				ID:        "echo",
+				Transport: catalog.TransportPlugin,
+			}},
+		},
+	}
+	remote, err := pluginservice.NewRemote(context.Background(), local, spec, nil)
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+	prov := &attachProvider{
+		Provider:      remote,
+		policyCatalog: spec.Catalog,
+	}
+
+	if core.SupportsSessionCatalog(prov) {
+		t.Fatal("expected attach provider to report no session catalog support")
+	}
+	cat, attempted, err := core.CatalogForRequest(context.Background(), prov, "tok")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if attempted {
+		t.Fatal("expected core.CatalogForRequest to report no attempt")
+	}
+	if cat != nil {
+		t.Fatalf("CatalogForRequest catalog = %#v, want nil", cat)
+	}
+
+	local.mu.Lock()
+	calls := local.sessionCatalogCalls
+	local.mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("GetSessionCatalog calls = %d, want 0", calls)
+	}
+}
+
 func TestVerifyHostServiceSessionUsesActiveMemorySession(t *testing.T) {
 	t.Parallel()
 
@@ -1104,6 +1159,7 @@ type recordingIntegrationClient struct {
 	mu                     sync.Mutex
 	metadataCalls          int
 	startCalls             int
+	sessionCatalogCalls    int
 	startName              string
 	startConfig            map[string]any
 	supportsSessionCatalog bool
@@ -1139,6 +1195,9 @@ func (c *recordingIntegrationClient) ResolveHTTPSubject(context.Context, *proto.
 }
 
 func (c *recordingIntegrationClient) GetSessionCatalog(context.Context, *proto.GetSessionCatalogRequest, ...grpc.CallOption) (*proto.GetSessionCatalogResponse, error) {
+	c.mu.Lock()
+	c.sessionCatalogCalls++
+	c.mu.Unlock()
 	if !c.supportsSessionCatalog {
 		return nil, status.Error(codes.Unimplemented, "session catalog is not implemented")
 	}


### PR DESCRIPTION
## Summary

Collapses the remote provider session/post-connect wrapper matrix into `remoteProviderBase`, now that #1675 makes explicit `Supports*` flags authoritative.

## Interface Changes
- New/changed interface: `remoteProviderBase` now implements `SessionCatalogProvider`, `PostConnectCapable`, `SupportsSessionCatalog`, and `SupportsPostConnect` directly.
- Example usage: callers should continue using `core.SupportsSessionCatalog(prov)` / `core.SupportsPostConnect(prov)` before invoking optional capabilities; direct calls on unsupported remote providers return unsupported errors without dispatching RPCs.

## Functional/Integration Tests
- Tests added or augmented: `services/plugins/provider_test.go` now verifies supported remote calls through core helpers and unsupported metadata/unimplemented-metadata cases without `GetSessionCatalog` or `PostConnect` RPC dispatch.
- Contract boundary covered: in-process gRPC provider server/client transport plus remote metadata support flags.
- Commands run:
  - `go test ./services/plugins`
  - `go test ./services/providerdev ./internal/bootstrap ./services/plugins/composite ./services/plugins/declarative`
  - `go test ./services/invocation ./internal/server -run '^$'`
  - `go test ./services/plugins/...`
  - `golangci-lint run ./services/plugins ./services/providerdev ./internal/bootstrap ./services/plugins/composite ./services/plugins/declarative`

Stacking: depends on #1675.
