### PR TITLE
Split plugin runtime provider interfaces

### DIFF
--- a/gestaltd/internal/bootstrap/hosted_agent_pool.go
+++ b/gestaltd/internal/bootstrap/hosted_agent_pool.go
@@ -46,7 +46,7 @@ type hostedAgentProviderPool struct {
 type hostedAgentPoolBackend struct {
 	id               int
 	provider         coreagent.Provider
-	runtimeProvider  pluginruntime.Provider
+	runtimeProvider  pluginruntime.SessionGetter
 	runtimeSessionID string
 	runtimeSession   *pluginruntime.Session
 	startedAt        time.Time

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1016,7 +1016,7 @@ type hostedAgentProviderLaunch struct {
 
 type hostedAgentProviderInstance struct {
 	provider         coreagent.Provider
-	runtimeProvider  pluginruntime.Provider
+	runtimeProvider  pluginruntime.SessionGetter
 	runtimeSessionID string
 	runtimeSession   *pluginruntime.Session
 }
@@ -1424,9 +1424,14 @@ func buildHostedRuntimeEgressLaunchPlan(providerName, sessionID string, policy e
 
 const pluginRuntimeStopTimeout = 3 * time.Second
 
+type runtimeSessionCloser interface {
+	pluginruntime.SessionStopper
+	io.Closer
+}
+
 type runtimeBackedHostedCloser struct {
 	conn         io.Closer
-	runtime      pluginruntime.Provider
+	runtime      runtimeSessionCloser
 	sessionID    string
 	closeRuntime bool
 	cleanup      func()
@@ -1452,7 +1457,7 @@ func (c *runtimeBackedHostedCloser) Close() error {
 	return errors.Join(errs...)
 }
 
-func stopPluginRuntimeSession(runtimeProvider pluginruntime.Provider, sessionID string) error {
+func stopPluginRuntimeSession(runtimeProvider pluginruntime.SessionStopper, sessionID string) error {
 	if runtimeProvider == nil || sessionID == "" {
 		return nil
 	}
@@ -1472,7 +1477,7 @@ func stopPluginRuntimeSession(runtimeProvider pluginruntime.Provider, sessionID 
 	}
 }
 
-func waitForPluginRuntimeSessionReady(ctx context.Context, runtimeProvider pluginruntime.Provider, sessionID string) (*pluginruntime.Session, error) {
+func waitForPluginRuntimeSessionReady(ctx context.Context, runtimeProvider pluginruntime.SessionGetter, sessionID string) (*pluginruntime.Session, error) {
 	for {
 		session, err := runtimeProvider.GetSession(ctx, pluginruntime.GetSessionRequest{SessionID: sessionID})
 		if err != nil {
@@ -1702,7 +1707,7 @@ func buildHostedRuntimeHostServiceEnv(providerName, sessionID string, hostServic
 
 type runtimeHostServiceSessionVerifier struct {
 	providerName string
-	provider     pluginruntime.Provider
+	provider     pluginruntime.SessionGetter
 }
 
 func (v runtimeHostServiceSessionVerifier) VerifyHostServiceSession(ctx context.Context, sessionID string) error {
@@ -1739,7 +1744,7 @@ func (v runtimeHostServiceSessionVerifier) VerifyHostServiceSession(ctx context.
 	}
 }
 
-func registerPublicRuntimeHostServices(providerName string, hostServices []runtimehost.HostService, deps Deps, runtimePlan HostedRuntimePlan, runtimeProvider pluginruntime.Provider) (func(), error) {
+func registerPublicRuntimeHostServices(providerName string, hostServices []runtimehost.HostService, deps Deps, runtimePlan HostedRuntimePlan, runtimeProvider pluginruntime.SessionGetter) (func(), error) {
 	if runtimePlan.Resolved.HostServiceAccess != RuntimeHostServiceAccessRelay || deps.PublicHostServices == nil {
 		return nil, nil
 	}

--- a/gestaltd/services/runtimehost/pluginruntime/runtime.go
+++ b/gestaltd/services/runtimehost/pluginruntime/runtime.go
@@ -2,6 +2,7 @@ package pluginruntime
 
 import (
 	"context"
+	"io"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
@@ -113,12 +114,36 @@ type HostedAgentConn interface {
 	Close() error
 }
 
-type Provider interface {
+type SupportProvider interface {
 	Support(ctx context.Context) (Support, error)
+}
+
+type SessionLister interface {
 	ListSessions(ctx context.Context) ([]Session, error)
+}
+
+type SessionStarter interface {
 	StartSession(ctx context.Context, req StartSessionRequest) (*Session, error)
+}
+
+type SessionGetter interface {
 	GetSession(ctx context.Context, req GetSessionRequest) (*Session, error)
+}
+
+type SessionStopper interface {
 	StopSession(ctx context.Context, req StopSessionRequest) error
+}
+
+type PluginStarter interface {
 	StartPlugin(ctx context.Context, req StartPluginRequest) (*HostedPlugin, error)
-	Close() error
+}
+
+type Provider interface {
+	SupportProvider
+	SessionLister
+	SessionStarter
+	SessionGetter
+	SessionStopper
+	PluginStarter
+	io.Closer
 }


### PR DESCRIPTION
## Summary

Split the plugin runtime `Provider` contract into named behavioral interfaces while preserving the existing full provider contract for factories, registries, and implementations.

## Interface Changes
- New/changed interface: `pluginruntime.Provider` now embeds `SupportProvider`, `SessionLister`, `SessionStarter`, `SessionGetter`, `SessionStopper`, `PluginStarter`, and `io.Closer`.
- Example usage: bootstrap helpers that only poll sessions now accept `pluginruntime.SessionGetter`; stop cleanup accepts `pluginruntime.SessionStopper`; runtime-backed hosted closers accept a local `StopSession` + `Close` composite.

## Functional/Integration Tests
- Tests added or augmented: no new tests; this is an interface-boundary refactor with no runtime behavior changes.
- Contract boundary covered: existing runtimehost and bootstrap runtime/session/host-service tests exercise local/executable runtime providers, hosted runtime startup, session polling/cleanup, and public host-service relay verification.
- Commands run:
  - `go test ./services/runtimehost/pluginruntime`
  - `go test ./services/runtimehost/...`
  - `go test ./internal/bootstrap -run 'PluginRuntime|Hosted|RuntimeSession|HostService'`
  - `go test ./internal/bootstrap -run '^$'`
  - `golangci-lint run ./services/runtimehost/pluginruntime ./internal/bootstrap`
