### PR TITLE
Remove core-routable host service relay fallback

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -2961,18 +2961,10 @@ func newNestedInvokeHarness(t *testing.T, brokerOpts ...invocation.BrokerOption)
 		},
 	}
 
-	pluginInvokerTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager(plugin invoker): %v", err)
-	}
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		EncryptionKey: secret,
 		PluginInvoker: bridge,
-	}, withRuntimeRelayPluginCoreHostService("caller", "plugin_invoker", plugininvokerservice.DefaultSocketEnv, "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
-		proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("caller", pluginInvocationDependencies(callerInvokes), bridge, pluginInvokerTokens))
-	}), withRuntimeRelayPluginCoreHostService("example", "plugin_invoker", plugininvokerservice.DefaultSocketEnv, "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
-		proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("example", pluginInvocationDependencies(exampleInvokes), bridge, pluginInvokerTokens))
-	})))
+	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -3100,16 +3092,10 @@ func newGraphQLSurfaceInvokeHarness(t *testing.T, graphQLURL string, allowSurfac
 	}
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	pluginInvokerTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager(plugin invoker): %v", err)
-	}
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		EncryptionKey: secret,
 		PluginInvoker: bridge,
-	}, withRuntimeRelayCoreHostService("plugin_invoker", plugininvokerservice.DefaultSocketEnv, "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
-		proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("caller", pluginInvocationDependencies(callerInvokes), bridge, pluginInvokerTokens))
-	})))
+	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -3872,18 +3858,7 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 			}},
 		},
 	})
-	agentManagerTokens, err := agentservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager(agent manager): %v", err)
-	}
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(
-		t,
-		secret,
-		publicHostServices,
-		withRuntimeRelayCoreHostService("agent_manager", agentservice.DefaultManagerSocketEnv, "/"+proto.AgentManagerHost_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
-			proto.RegisterAgentManagerHostServer(srv, agentservice.NewManagerServer("echoext", manager, agentManagerTokens))
-		}),
-	))
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
 	relaySrv.EnableHTTP2 = true
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)
@@ -4144,16 +4119,10 @@ func TestPluginWorkflowManagerCRUDUsesRequestContext(t *testing.T) {
 	}
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	workflowManagerTokens, err := workflowservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager(workflow manager): %v", err)
-	}
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		EncryptionKey:   secret,
 		WorkflowManager: manager,
-	}, withRuntimeRelayCoreHostService("workflow_manager", workflowservice.DefaultManagerSocketEnv, "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
-		proto.RegisterWorkflowManagerHostServer(srv, workflowservice.NewManagerServer("echo", manager, workflowManagerTokens))
-	})))
+	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -4533,16 +4502,10 @@ func TestPluginWorkflowManagerRejectsInvalidInvocationToken(t *testing.T) {
 
 	manager := newStubWorkflowManager()
 	secret := []byte("0123456789abcdef0123456789abcdef")
-	workflowManagerTokens, err := workflowservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager(workflow manager): %v", err)
-	}
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
 		EncryptionKey:   secret,
 		WorkflowManager: manager,
-	}, withRuntimeRelayCoreHostService("workflow_manager", workflowservice.DefaultManagerSocketEnv, "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
-		proto.RegisterWorkflowManagerHostServer(srv, workflowservice.NewManagerServer("echo", manager, workflowManagerTokens))
-	})))
+	}))
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -6915,18 +6878,7 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	callerInvokes := []config.PluginInvocationDependency{
 		{Plugin: "example", Operation: "request_context"},
 	}
-	pluginInvokerTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager(plugin invoker): %v", err)
-	}
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(
-		t,
-		secret,
-		publicHostServices,
-		withRuntimeRelayCoreHostService("plugin_invoker", plugininvokerservice.DefaultSocketEnv, "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
-			proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("caller", pluginInvocationDependencies(callerInvokes), bridge, pluginInvokerTokens))
-		}),
-	))
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
 	relaySrv.EnableHTTP2 = true
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)
@@ -7325,39 +7277,6 @@ func TestPluginRuntimeConfigInjectsRuntimeLogSessionAndHostService(t *testing.T)
 	}
 }
 
-type runtimeRelayTestHandlerOption func(*runtimeRelayTestHandlerConfig)
-
-type runtimeRelayTestHandlerConfig struct {
-	coreHandlers map[runtimeRelayTestCoreHandlerKey]http.Handler
-}
-
-type runtimeRelayTestCoreHandlerKey struct {
-	pluginName   string
-	service      string
-	envVar       string
-	methodPrefix string
-}
-
-func withRuntimeRelayCoreHostService(service, envVar, methodPrefix string, register func(*grpc.Server)) runtimeRelayTestHandlerOption {
-	return withRuntimeRelayPluginCoreHostService("", service, envVar, methodPrefix, register)
-}
-
-func withRuntimeRelayPluginCoreHostService(pluginName, service, envVar, methodPrefix string, register func(*grpc.Server)) runtimeRelayTestHandlerOption {
-	return func(cfg *runtimeRelayTestHandlerConfig) {
-		if cfg.coreHandlers == nil {
-			cfg.coreHandlers = make(map[runtimeRelayTestCoreHandlerKey]http.Handler)
-		}
-		srv := grpc.NewServer()
-		register(srv)
-		cfg.coreHandlers[runtimeRelayTestCoreHandlerKey{
-			pluginName:   strings.TrimSpace(pluginName),
-			service:      strings.TrimSpace(service),
-			envVar:       strings.TrimSpace(envVar),
-			methodPrefix: strings.TrimSpace(methodPrefix),
-		}] = http.HandlerFunc(srv.ServeHTTP)
-	}
-}
-
 func assertPublicHostServicesVerified(t *testing.T, registry *runtimehost.PublicHostServiceRegistry, serviceName, envVar string) {
 	t.Helper()
 
@@ -7382,18 +7301,12 @@ func assertPublicHostServicesVerified(t *testing.T, registry *runtimehost.Public
 	}
 }
 
-func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServices *runtimehost.PublicHostServiceRegistry, opts ...runtimeRelayTestHandlerOption) http.Handler {
+func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServices *runtimehost.PublicHostServiceRegistry) http.Handler {
 	t.Helper()
 
 	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(stateSecret)
 	if err != nil {
 		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
-	}
-	var cfg runtimeRelayTestHandlerConfig
-	for _, opt := range opts {
-		if opt != nil {
-			opt(&cfg)
-		}
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := strings.TrimSpace(r.Header.Get(runtimehost.HostServiceRelayTokenHeader))
@@ -7406,27 +7319,10 @@ func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServ
 			writeRuntimeRelayGRPCTrailersOnly(w, codes.PermissionDenied, "host-service-relay-method-not-allowed")
 			return
 		}
-		var handler http.Handler
-		if target.CoreRoutable {
-			handler = cfg.coreHandlers[runtimeRelayTestCoreHandlerKey{
-				pluginName:   strings.TrimSpace(target.PluginName),
-				service:      strings.TrimSpace(target.Service),
-				envVar:       strings.TrimSpace(target.EnvVar),
-				methodPrefix: strings.TrimSpace(target.MethodPrefix),
-			}]
-			if handler == nil {
-				handler = cfg.coreHandlers[runtimeRelayTestCoreHandlerKey{
-					service:      strings.TrimSpace(target.Service),
-					envVar:       strings.TrimSpace(target.EnvVar),
-					methodPrefix: strings.TrimSpace(target.MethodPrefix),
-				}]
-			}
-		} else {
-			handler, err = runtimeRelayPublicHostServiceHandler(r.Context(), publicHostServices, target)
-			if err != nil {
-				writeRuntimeRelayGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-session")
-				return
-			}
+		handler, err := runtimeRelayPublicHostServiceHandler(r.Context(), publicHostServices, target)
+		if err != nil {
+			writeRuntimeRelayGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-session")
+			return
 		}
 		if handler == nil {
 			writeRuntimeRelayGRPCTrailersOnly(w, codes.Unavailable, "host-service-relay-unavailable")
@@ -7439,10 +7335,10 @@ func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte, publicHostServ
 	})
 }
 
-func newRuntimePublicEndpointTestServer(t *testing.T, stateSecret []byte, publicHostServices *runtimehost.PublicHostServiceRegistry, opts ...runtimeRelayTestHandlerOption) *httptest.Server {
+func newRuntimePublicEndpointTestServer(t *testing.T, stateSecret []byte, publicHostServices *runtimehost.PublicHostServiceRegistry) *httptest.Server {
 	t.Helper()
 
-	relay := newRuntimeRelayTestHandler(t, stateSecret, publicHostServices, opts...)
+	relay := newRuntimeRelayTestHandler(t, stateSecret, publicHostServices)
 	proxy := newRuntimeEgressProxyTestHandler(t, stateSecret)
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.TrimSpace(r.Header.Get(runtimehost.HostServiceRelayTokenHeader)) != "" {
@@ -7462,7 +7358,7 @@ func newRuntimePublicEndpointTestServer(t *testing.T, stateSecret []byte, public
 	return srv
 }
 
-func testRuntimePublicEndpointDeps(t *testing.T, deps Deps, opts ...runtimeRelayTestHandlerOption) Deps {
+func testRuntimePublicEndpointDeps(t *testing.T, deps Deps) Deps {
 	t.Helper()
 
 	if len(deps.EncryptionKey) == 0 {
@@ -7472,7 +7368,7 @@ func testRuntimePublicEndpointDeps(t *testing.T, deps Deps, opts ...runtimeRelay
 		deps.PublicHostServices = runtimehost.NewPublicHostServiceRegistry()
 	}
 	if strings.TrimSpace(deps.BaseURL) == "" {
-		srv := newRuntimePublicEndpointTestServer(t, deps.EncryptionKey, deps.PublicHostServices, opts...)
+		srv := newRuntimePublicEndpointTestServer(t, deps.EncryptionKey, deps.PublicHostServices)
 		deps.BaseURL = srv.URL
 		if cert := srv.Certificate(); cert != nil && strings.TrimSpace(deps.HostServiceTLSCAFile) == "" && strings.TrimSpace(deps.HostServiceTLSCAPEM) == "" {
 			deps.HostServiceTLSCAPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
@@ -7742,18 +7638,7 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 	}
 
 	manager := newStubWorkflowManager()
-	workflowManagerTokens, err := workflowservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager(workflow manager): %v", err)
-	}
-	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(
-		t,
-		secret,
-		publicHostServices,
-		withRuntimeRelayCoreHostService("workflow_manager", workflowservice.DefaultManagerSocketEnv, "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/", func(srv *grpc.Server) {
-			proto.RegisterWorkflowManagerHostServer(srv, workflowservice.NewManagerServer("echoext", manager, workflowManagerTokens))
-		}),
-	))
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret, publicHostServices))
 	relaySrv.EnableHTTP2 = true
 	relaySrv.StartTLS()
 	testutil.CloseOnCleanup(t, relaySrv)

--- a/gestaltd/internal/bootstrap/plugin_runtime.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime.go
@@ -3,11 +3,9 @@ package bootstrap
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost/pluginruntime"
 )
 
@@ -48,53 +46,6 @@ func (r *pluginRuntimeRegistry) Resolve(ctx context.Context, configPath string, 
 
 	provider, err := r.resolveConfigured(ctx, effective)
 	return effective, provider, err
-}
-
-func (r *pluginRuntimeRegistry) VerifyPluginRuntimeSession(ctx context.Context, providerName, sessionID string) error {
-	providerName = strings.TrimSpace(providerName)
-	if providerName == "" {
-		return fmt.Errorf("runtime provider owner is required")
-	}
-	if r == nil || r.cfg == nil {
-		return fmt.Errorf("%w: plugin runtime registry is not configured", runtimehost.ErrProviderNotHostedRuntime)
-	}
-
-	effective, err := r.effectiveHostedRuntimeForProvider(providerName)
-	if err != nil {
-		return err
-	}
-	if !effective.Enabled || strings.TrimSpace(effective.ProviderName) == "" {
-		return fmt.Errorf("%w: provider %q", runtimehost.ErrProviderNotHostedRuntime, providerName)
-	}
-
-	r.mu.Lock()
-	if r.closed {
-		r.mu.Unlock()
-		return fmt.Errorf("plugin runtime registry is closed")
-	}
-	runtimeProvider := r.providers[effective.ProviderName]
-	r.mu.Unlock()
-	if runtimeProvider == nil {
-		return fmt.Errorf("runtime provider %q is not loaded", effective.ProviderName)
-	}
-
-	return runtimeHostServiceSessionVerifier{
-		providerName: providerName,
-		provider:     runtimeProvider,
-	}.VerifyHostServiceSession(ctx, sessionID)
-}
-
-func (r *pluginRuntimeRegistry) effectiveHostedRuntimeForProvider(providerName string) (config.EffectiveHostedRuntime, error) {
-	if r == nil || r.cfg == nil {
-		return config.EffectiveHostedRuntime{}, fmt.Errorf("plugin runtime registry is not configured")
-	}
-	if entry := r.cfg.Plugins[providerName]; entry != nil {
-		return r.cfg.EffectiveHostedRuntime("plugins."+providerName, entry)
-	}
-	if entry := r.cfg.Providers.Agent[providerName]; entry != nil {
-		return r.cfg.EffectiveHostedRuntime("providers.agent."+providerName, entry)
-	}
-	return config.EffectiveHostedRuntime{}, fmt.Errorf("%w: provider %q does not have a hosted runtime configuration", runtimehost.ErrProviderNotHostedRuntime, providerName)
 }
 
 func (r *pluginRuntimeRegistry) resolveConfigured(ctx context.Context, effective config.EffectiveHostedRuntime) (pluginruntime.Provider, error) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -907,7 +907,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	allowedHosts := entry.EffectiveAllowedHosts()
 	bindingTargets := hostServiceBindingDescriptorsFromConfigured(hostServices)
 	for _, hostService := range bindingTargets {
-		bindingEnv, relayHost, err := buildHostedRuntimeHostServiceEnv(name, sessionID, hostService, deps, true)
+		bindingEnv, relayHost, err := buildHostedRuntimeHostServiceEnv(name, sessionID, hostService, deps)
 		if err != nil {
 			return nil, err
 		}
@@ -1175,7 +1175,7 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	phaseStarted = time.Now()
 	bindingTargets := hostServiceBindingDescriptorsFromConfigured(hostServices)
 	for _, hostService := range bindingTargets {
-		bindingEnv, relayHost, err := buildHostedRuntimeHostServiceEnv(name, sessionID, hostService, deps, true)
+		bindingEnv, relayHost, err := buildHostedRuntimeHostServiceEnv(name, sessionID, hostService, deps)
 		if err != nil {
 			recordHostedAgentRuntimeStartPhase(ctx, name, "host_services_relay", phaseStarted, err)
 			return nil, err
@@ -1634,7 +1634,7 @@ func hostServiceBindingDescriptorsFromConfigured(hostServices []runtimehost.Host
 	return out
 }
 
-func buildHostedRuntimeHostServiceEnv(providerName, sessionID string, hostService hostServiceBindingDescriptor, deps Deps, allowCoreRoutable bool) (map[string]string, string, error) {
+func buildHostedRuntimeHostServiceEnv(providerName, sessionID string, hostService hostServiceBindingDescriptor, deps Deps) (map[string]string, string, error) {
 	var (
 		serviceKey   string
 		serviceLabel string
@@ -1688,7 +1688,6 @@ func buildHostedRuntimeHostServiceEnv(providerName, sessionID string, hostServic
 		serviceKey,
 		serviceLabel,
 		methodPrefix,
-		allowCoreRoutable && isCoreRoutableHostedRuntimeHostService(hostService, serviceKey, methodPrefix),
 	)
 	if err != nil {
 		return nil, "", err
@@ -1791,26 +1790,6 @@ func buildHostedRuntimePublicEgressProxy(providerName, sessionID string, allowed
 	}, nil
 }
 
-func isCoreRoutableHostedRuntimeHostService(hostService hostServiceBindingDescriptor, serviceKey, methodPrefix string) bool {
-	methodPrefix = strings.TrimSpace(methodPrefix)
-	switch serviceKey {
-	case "workflow_manager":
-		return hostService.Name == "workflow_manager" &&
-			hostService.EnvVar == workflowservice.DefaultManagerSocketEnv &&
-			methodPrefix == "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/"
-	case "agent_manager":
-		return hostService.Name == "agent_manager" &&
-			hostService.EnvVar == agentservice.DefaultManagerSocketEnv &&
-			methodPrefix == "/"+proto.AgentManagerHost_ServiceDesc.ServiceName+"/"
-	case "plugin_invoker":
-		return hostService.Name == "plugin_invoker" &&
-			hostService.EnvVar == plugininvokerservice.DefaultSocketEnv &&
-			methodPrefix == "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/"
-	default:
-		return false
-	}
-}
-
 func publicRuntimeRegistryHostServices(hostServices []runtimehost.HostService) []runtimehost.HostService {
 	if len(hostServices) == 0 {
 		return nil
@@ -1818,7 +1797,7 @@ func publicRuntimeRegistryHostServices(hostServices []runtimehost.HostService) [
 	return append([]runtimehost.HostService(nil), hostServices...)
 }
 
-func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, hostService hostServiceBindingDescriptor, deps Deps, serviceKey, serviceLabel, methodPrefix string, coreRoutable bool) (string, map[string]string, string, bool, error) {
+func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, hostService hostServiceBindingDescriptor, deps Deps, serviceKey, serviceLabel, methodPrefix string) (string, map[string]string, string, bool, error) {
 	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
 		return "", nil, "", false, nil
 	}
@@ -1836,7 +1815,6 @@ func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, ho
 		Service:      serviceKey,
 		EnvVar:       hostService.EnvVar,
 		MethodPrefix: methodPrefix,
-		CoreRoutable: coreRoutable,
 		TTL:          pluginRuntimeHostServiceRelayTokenTTL,
 	})
 	if err != nil {

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -169,7 +169,7 @@ func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps D
 	env := withRuntimeSessionEnv(map[string]string{}, sessionID)
 	env = withHostServiceTLSCAEnv(env, deps)
 	for _, hostService := range hostServices {
-		bindingEnv, _, err := buildHostedRuntimeHostServiceEnv(name, sessionID, hostService, deps, true)
+		bindingEnv, _, err := buildHostedRuntimeHostServiceEnv(name, sessionID, hostService, deps)
 		if err != nil {
 			return providerdev.RuntimeEnv{}, err
 		}

--- a/gestaltd/internal/server/host_service_public.go
+++ b/gestaltd/internal/server/host_service_public.go
@@ -2,17 +2,11 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strings"
 
-	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
-	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
-	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
-	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"google.golang.org/grpc"
 )
 
@@ -25,10 +19,6 @@ type hostServiceHandlerKey struct {
 type hostServiceHandlerEntry struct {
 	handler  http.Handler
 	verifier runtimehost.PublicHostServiceSessionVerifier
-}
-
-type pluginRuntimeSessionVerifier interface {
-	VerifyPluginRuntimeSession(context.Context, string, string) error
 }
 
 func validatePublicHostServices(services []runtimehost.PublicHostService) error {
@@ -90,20 +80,6 @@ func (s *Server) hostServiceHandler(ctx context.Context, target runtimehost.Host
 	if s == nil {
 		return nil, nil
 	}
-	if target.CoreRoutable {
-		entry, ok, err := s.coreRoutableHostServiceHandlerEntry(ctx, target)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			return nil, nil
-		}
-		return entry.handler, nil
-	}
-	if coreRoutableHostServiceTarget(target) {
-		return nil, nil
-	}
-
 	key := hostServiceHandlerKey{
 		pluginName: strings.TrimSpace(target.PluginName),
 		service:    strings.TrimSpace(target.Service),
@@ -118,175 +94,6 @@ func (s *Server) hostServiceHandler(ctx context.Context, target runtimehost.Host
 		return nil, nil
 	}
 	return entry.handler, nil
-}
-
-func (s *Server) coreRoutableHostServiceHandlerEntry(ctx context.Context, target runtimehost.HostServiceRelayTarget) (hostServiceHandlerEntry, bool, error) {
-	if s == nil || !target.CoreRoutable || s.invocationTokens == nil {
-		return hostServiceHandlerEntry{}, false, nil
-	}
-	pluginName := strings.TrimSpace(target.PluginName)
-	if pluginName == "" {
-		return hostServiceHandlerEntry{}, false, nil
-	}
-	key, ok := coreRoutableHostServiceHandlerKey(pluginName, target)
-	if !ok {
-		return hostServiceHandlerEntry{}, false, nil
-	}
-	if err := s.verifyCoreRoutableHostServiceSession(ctx, target); err != nil {
-		return hostServiceHandlerEntry{}, false, err
-	}
-	s.hostServiceMu.Lock()
-	if s.coreHostServiceHandlers != nil {
-		if entry, ok := s.coreHostServiceHandlers[key]; ok {
-			s.hostServiceMu.Unlock()
-			return entry, true, nil
-		}
-	}
-	s.hostServiceMu.Unlock()
-
-	entry, ok := s.newCoreRoutableHostServiceHandlerEntry(ctx, pluginName, target)
-	if !ok {
-		return hostServiceHandlerEntry{}, false, nil
-	}
-	s.hostServiceMu.Lock()
-	if s.coreHostServiceHandlers == nil {
-		s.coreHostServiceHandlers = make(map[hostServiceHandlerKey]hostServiceHandlerEntry)
-	}
-	if existing, ok := s.coreHostServiceHandlers[key]; ok {
-		s.hostServiceMu.Unlock()
-		return existing, true, nil
-	}
-	s.coreHostServiceHandlers[key] = entry
-	s.hostServiceMu.Unlock()
-	return entry, true, nil
-}
-
-func (s *Server) verifyCoreRoutableHostServiceSession(ctx context.Context, target runtimehost.HostServiceRelayTarget) error {
-	pluginName := strings.TrimSpace(target.PluginName)
-	verifier, ok := s.pluginRuntimes.(pluginRuntimeSessionVerifier)
-	if ok && verifier != nil {
-		if err := verifier.VerifyPluginRuntimeSession(ctx, pluginName, target.SessionID); !errors.Is(err, runtimehost.ErrProviderNotHostedRuntime) {
-			return err
-		}
-	}
-	if ok, err := s.verifyRegisteredCoreRoutableHostServiceSession(ctx, target); ok || err != nil {
-		return err
-	}
-	return fmt.Errorf("plugin runtime session verifier is not configured")
-}
-
-func (s *Server) verifyRegisteredCoreRoutableHostServiceSession(ctx context.Context, target runtimehost.HostServiceRelayTarget) (bool, error) {
-	if s == nil || s.publicHostServices == nil {
-		return false, nil
-	}
-	pluginName := strings.TrimSpace(target.PluginName)
-	serviceName := strings.TrimSpace(target.Service)
-	envVar := strings.TrimSpace(target.EnvVar)
-	sessionID := strings.TrimSpace(target.SessionID)
-	if pluginName == "" || serviceName == "" || envVar == "" {
-		return false, nil
-	}
-
-	var lastErr error
-	for _, service := range s.publicHostServices.Snapshot() {
-		key, ok := publicHostServiceHandlerKey(service)
-		if !ok || key.pluginName != pluginName || key.service != serviceName || key.envVar != envVar {
-			continue
-		}
-		if service.SessionVerifier == nil {
-			continue
-		}
-		if err := service.SessionVerifier.VerifyHostServiceSession(ctx, sessionID); err != nil {
-			lastErr = err
-			continue
-		}
-		return true, nil
-	}
-	if lastErr != nil {
-		return true, lastErr
-	}
-	return false, nil
-}
-
-func coreRoutableHostServiceTarget(target runtimehost.HostServiceRelayTarget) bool {
-	_, ok := coreRoutableHostServiceHandlerKey(strings.TrimSpace(target.PluginName), target)
-	return ok
-}
-
-func coreRoutableHostServiceHandlerKey(pluginName string, target runtimehost.HostServiceRelayTarget) (hostServiceHandlerKey, bool) {
-	methodPrefix := strings.TrimSpace(target.MethodPrefix)
-	switch {
-	case target.Service == "workflow_manager" &&
-		target.EnvVar == workflowservice.DefaultManagerSocketEnv &&
-		methodPrefix == "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/":
-	case target.Service == "agent_manager" &&
-		target.EnvVar == agentservice.DefaultManagerSocketEnv &&
-		methodPrefix == "/"+proto.AgentManagerHost_ServiceDesc.ServiceName+"/":
-	case target.Service == "plugin_invoker" &&
-		target.EnvVar == plugininvokerservice.DefaultSocketEnv &&
-		methodPrefix == "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/":
-	default:
-		return hostServiceHandlerKey{}, false
-	}
-	return hostServiceHandlerKey{
-		pluginName: pluginName,
-		service:    strings.TrimSpace(target.Service),
-		envVar:     strings.TrimSpace(target.EnvVar),
-	}, true
-}
-
-func (s *Server) newCoreRoutableHostServiceHandlerEntry(ctx context.Context, pluginName string, target runtimehost.HostServiceRelayTarget) (hostServiceHandlerEntry, bool) {
-	methodPrefix := strings.TrimSpace(target.MethodPrefix)
-	switch {
-	case target.Service == "workflow_manager" &&
-		target.EnvVar == workflowservice.DefaultManagerSocketEnv &&
-		methodPrefix == "/"+proto.WorkflowManagerHost_ServiceDesc.ServiceName+"/":
-		if s.workflowSchedules == nil {
-			return hostServiceHandlerEntry{}, false
-		}
-		slog.DebugContext(ctx, "serving core-routable host service relay", "plugin", pluginName, "service", target.Service)
-		return hostServiceHandlerEntry{
-			handler: newGRPCHostServiceHandler(func(srv *grpc.Server) {
-				proto.RegisterWorkflowManagerHostServer(srv, workflowservice.NewManagerServer(pluginName, s.workflowSchedules, s.invocationTokens))
-			}),
-		}, true
-	case target.Service == "agent_manager" &&
-		target.EnvVar == agentservice.DefaultManagerSocketEnv &&
-		methodPrefix == "/"+proto.AgentManagerHost_ServiceDesc.ServiceName+"/":
-		if s.agentRuns == nil {
-			return hostServiceHandlerEntry{}, false
-		}
-		slog.DebugContext(ctx, "serving core-routable host service relay", "plugin", pluginName, "service", target.Service)
-		return hostServiceHandlerEntry{
-			handler: newGRPCHostServiceHandler(func(srv *grpc.Server) {
-				proto.RegisterAgentManagerHostServer(srv, agentservice.NewManagerServer(pluginName, s.agentRuns, s.invocationTokens))
-			}),
-		}, true
-	case target.Service == "plugin_invoker" &&
-		target.EnvVar == plugininvokerservice.DefaultSocketEnv &&
-		methodPrefix == "/"+proto.PluginInvoker_ServiceDesc.ServiceName+"/":
-		if s.pluginInvoker == nil || s.pluginDefs == nil {
-			return hostServiceHandlerEntry{}, false
-		}
-		entry := s.pluginDefs[pluginName]
-		if entry == nil {
-			return hostServiceHandlerEntry{}, false
-		}
-		slog.DebugContext(ctx, "serving core-routable host service relay", "plugin", pluginName, "service", target.Service)
-		return hostServiceHandlerEntry{
-			handler: newGRPCHostServiceHandler(func(srv *grpc.Server) {
-				proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewPluginInvokerServer(pluginName, pluginInvocationDependencies(entry.Invokes), s.pluginInvoker, s.invocationTokens))
-			}),
-		}, true
-	default:
-		return hostServiceHandlerEntry{}, false
-	}
-}
-
-func newGRPCHostServiceHandler(register func(*grpc.Server)) http.Handler {
-	srv := grpc.NewServer()
-	register(srv)
-	return http.HandlerFunc(srv.ServeHTTP)
 }
 
 func (s *Server) hostServiceHandlerEntry(ctx context.Context, key hostServiceHandlerKey, sessionID string) (hostServiceHandlerEntry, bool, bool, error) {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -22,7 +22,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
-	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
 	"github.com/valon-technologies/gestalt/server/services/plugins/registry"
 	"github.com/valon-technologies/gestalt/server/services/providerdev"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
@@ -81,63 +80,61 @@ type BuiltinAdminUIOptions struct {
 }
 
 type Server struct {
-	router                  chi.Router
-	handler                 http.Handler
-	auth                    core.AuthenticationProvider
-	authProviders           map[string]core.AuthenticationProvider
-	serverAuthProvider      string
-	auditSink               core.AuditSink
-	users                   *coredata.UserService
-	externalCredentials     core.ExternalCredentialProvider
-	apiTokens               *coredata.APITokenService
-	managedSubjects         *coredata.ManagedSubjectService
-	agent                   bootstrap.AgentControl
-	workflowSchedules       *workflowmanager.Manager
-	agentRuns               agentmanager.Service
-	authorizationProvider   core.AuthorizationProvider
-	providers               *registry.ProviderMap[core.Provider]
-	workflow                bootstrap.WorkflowControl
-	pluginRuntimes          bootstrap.RuntimeInspector
-	resolver                *principal.Resolver
-	authResolvers           map[string]*principal.Resolver
-	invoker                 invocation.Invoker
-	pluginInvoker           invocation.Invoker
-	defaultConnection       map[string]string
-	catalogConnection       map[string]string
-	connectionAuth          func() map[string]map[string]bootstrap.OAuthHandler
-	pluginDefs              map[string]*config.ProviderEntry
-	authorizer              authorization.RuntimeAuthorizer
-	noAuth                  bool
-	anonymousPrincipal      *principal.Principal
-	publicBaseURL           string
-	managementBaseURL       string
-	secureCookies           bool
-	encryptor               *cryptoutil.AESGCMEncryptor
-	sessionIssuer           []byte
-	stateCodec              *integrationOAuthStateCodec
-	apiTokenTTL             time.Duration
-	now                     func() time.Time
-	readiness               ReadinessChecker
-	meterProvider           metric.MeterProvider
-	prometheusMetrics       http.Handler
-	mcpHandler              http.Handler
-	hostServiceRelayTokens  *runtimehost.HostServiceRelayTokenManager
-	invocationTokens        *plugininvokerservice.InvocationTokenManager
-	hostServiceMu           sync.Mutex
-	coreHostServiceHandlers map[hostServiceHandlerKey]hostServiceHandlerEntry
-	hostServiceHandlers     map[uint64]http.Handler
-	publicHostServices      *runtimehost.PublicHostServiceRegistry
-	s3                      map[string]s3store.Client
-	s3ObjectAccessURLs      *s3.ObjectAccessURLManager
-	egressProxyTokens       *egressproxy.TokenManager
-	providerDevSessions     *providerdev.Manager
-	providerDevAttach       bool
-	mountedHTTPBindings     []MountedHTTPBinding
-	mountedUIs              []MountedUI
-	adminRoute              AdminRouteConfig
-	adminUI                 http.Handler
-	routeProfile            RouteProfile
-	httpBindingReplayStore  httpBindingReplayStore
+	router                 chi.Router
+	handler                http.Handler
+	auth                   core.AuthenticationProvider
+	authProviders          map[string]core.AuthenticationProvider
+	serverAuthProvider     string
+	auditSink              core.AuditSink
+	users                  *coredata.UserService
+	externalCredentials    core.ExternalCredentialProvider
+	apiTokens              *coredata.APITokenService
+	managedSubjects        *coredata.ManagedSubjectService
+	agent                  bootstrap.AgentControl
+	workflowSchedules      *workflowmanager.Manager
+	agentRuns              agentmanager.Service
+	authorizationProvider  core.AuthorizationProvider
+	providers              *registry.ProviderMap[core.Provider]
+	workflow               bootstrap.WorkflowControl
+	pluginRuntimes         bootstrap.RuntimeInspector
+	resolver               *principal.Resolver
+	authResolvers          map[string]*principal.Resolver
+	invoker                invocation.Invoker
+	pluginInvoker          invocation.Invoker
+	defaultConnection      map[string]string
+	catalogConnection      map[string]string
+	connectionAuth         func() map[string]map[string]bootstrap.OAuthHandler
+	pluginDefs             map[string]*config.ProviderEntry
+	authorizer             authorization.RuntimeAuthorizer
+	noAuth                 bool
+	anonymousPrincipal     *principal.Principal
+	publicBaseURL          string
+	managementBaseURL      string
+	secureCookies          bool
+	encryptor              *cryptoutil.AESGCMEncryptor
+	sessionIssuer          []byte
+	stateCodec             *integrationOAuthStateCodec
+	apiTokenTTL            time.Duration
+	now                    func() time.Time
+	readiness              ReadinessChecker
+	meterProvider          metric.MeterProvider
+	prometheusMetrics      http.Handler
+	mcpHandler             http.Handler
+	hostServiceRelayTokens *runtimehost.HostServiceRelayTokenManager
+	hostServiceMu          sync.Mutex
+	hostServiceHandlers    map[uint64]http.Handler
+	publicHostServices     *runtimehost.PublicHostServiceRegistry
+	s3                     map[string]s3store.Client
+	s3ObjectAccessURLs     *s3.ObjectAccessURLManager
+	egressProxyTokens      *egressproxy.TokenManager
+	providerDevSessions    *providerdev.Manager
+	providerDevAttach      bool
+	mountedHTTPBindings    []MountedHTTPBinding
+	mountedUIs             []MountedUI
+	adminRoute             AdminRouteConfig
+	adminUI                http.Handler
+	routeProfile           RouteProfile
+	httpBindingReplayStore httpBindingReplayStore
 }
 
 func (s *Server) catalogSelectorConfig() invocation.CatalogSelectorConfig {
@@ -301,17 +298,12 @@ func New(cfg Config) (*Server, error) {
 		otelOptions = append(otelOptions, otelhttp.WithMeterProvider(cfg.MeterProvider))
 	}
 	var hostServiceRelayTokens *runtimehost.HostServiceRelayTokenManager
-	var invocationTokens *plugininvokerservice.InvocationTokenManager
 	var egressProxyTokens *egressproxy.TokenManager
 	var s3ObjectAccessURLs *s3.ObjectAccessURLManager
 	if len(cfg.StateSecret) > 0 {
 		hostServiceRelayTokens, err = runtimehost.NewHostServiceRelayTokenManager(cfg.StateSecret)
 		if err != nil {
 			return nil, fmt.Errorf("init host service relay tokens: %w", err)
-		}
-		invocationTokens, err = plugininvokerservice.NewInvocationTokenManager(cfg.StateSecret)
-		if err != nil {
-			return nil, fmt.Errorf("init invocation tokens: %w", err)
 		}
 		egressProxyTokens, err = egressproxy.NewTokenManager(cfg.StateSecret)
 		if err != nil {
@@ -365,7 +357,6 @@ func New(cfg Config) (*Server, error) {
 		prometheusMetrics:      cfg.PrometheusMetrics,
 		mcpHandler:             cfg.MCPHandler,
 		hostServiceRelayTokens: hostServiceRelayTokens,
-		invocationTokens:       invocationTokens,
 		publicHostServices:     cfg.PublicHostServices,
 		s3:                     cfg.S3,
 		s3ObjectAccessURLs:     s3ObjectAccessURLs,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -78,7 +78,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func configPluginInvocationDependencies(deps []invocation.PluginInvocationDependency) []config.PluginInvocationDependency {
@@ -587,54 +586,49 @@ func (v *relayTestSessionVerifier) setActive(sessionID string, active bool) {
 	v.active[sessionID] = active
 }
 
-type relayTestRuntimeSessionVerifier struct {
-	mu     sync.Mutex
-	active map[string]bool
+type relayTestWorkflowManagerHostServer struct {
+	proto.UnimplementedWorkflowManagerHostServer
+	calls *atomic.Int64
 }
 
-func newRelayTestRuntimeSessionVerifier(providerName, sessionID string) *relayTestRuntimeSessionVerifier {
-	verifier := &relayTestRuntimeSessionVerifier{active: map[string]bool{}}
-	verifier.setActive(providerName, sessionID, true)
-	return verifier
-}
-
-func (v *relayTestRuntimeSessionVerifier) VerifyPluginRuntimeSession(_ context.Context, providerName, sessionID string) error {
-	key := strings.TrimSpace(providerName) + "\x00" + strings.TrimSpace(sessionID)
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	if v.active[key] {
-		return nil
+func (s relayTestWorkflowManagerHostServer) GetSchedule(_ context.Context, req *proto.WorkflowManagerGetScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+	if s.calls != nil {
+		s.calls.Add(1)
 	}
-	return fmt.Errorf("runtime session %q is not active", sessionID)
+	return &proto.ManagedWorkflowSchedule{
+		ProviderName: "registered",
+		Schedule: &proto.BoundWorkflowSchedule{
+			Id: req.GetScheduleId(),
+		},
+	}, nil
 }
 
-func (v *relayTestRuntimeSessionVerifier) setActive(providerName, sessionID string, active bool) {
-	key := strings.TrimSpace(providerName) + "\x00" + strings.TrimSpace(sessionID)
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	v.active[key] = active
+type relayTestAgentManagerHostServer struct {
+	proto.UnimplementedAgentManagerHostServer
+	calls *atomic.Int64
 }
 
-func (v *relayTestRuntimeSessionVerifier) SnapshotPluginRuntimes(context.Context) ([]bootstrap.RuntimeProviderSnapshot, error) {
-	return nil, nil
+func (s relayTestAgentManagerHostServer) GetSession(_ context.Context, req *proto.AgentManagerGetSessionRequest) (*proto.AgentSession, error) {
+	if s.calls != nil {
+		s.calls.Add(1)
+	}
+	return &proto.AgentSession{
+		Id:           req.GetSessionId(),
+		ProviderName: "registered",
+		Model:        "test-model",
+	}, nil
 }
 
-func (v *relayTestRuntimeSessionVerifier) ListPluginRuntimeSessionLogs(context.Context, string, string, int64, int) ([]runtimelogs.Record, error) {
-	return nil, nil
+type relayTestRuntimeLogHostServer struct {
+	proto.UnimplementedPluginRuntimeLogHostServer
+	calls *atomic.Int64
 }
 
-type nonHostedRuntimeSessionVerifier struct{}
-
-func (nonHostedRuntimeSessionVerifier) VerifyPluginRuntimeSession(context.Context, string, string) error {
-	return runtimehost.ErrProviderNotHostedRuntime
-}
-
-func (nonHostedRuntimeSessionVerifier) SnapshotPluginRuntimes(context.Context) ([]bootstrap.RuntimeProviderSnapshot, error) {
-	return nil, nil
-}
-
-func (nonHostedRuntimeSessionVerifier) ListPluginRuntimeSessionLogs(context.Context, string, string, int64, int) ([]runtimelogs.Record, error) {
-	return nil, nil
+func (s relayTestRuntimeLogHostServer) AppendLogs(_ context.Context, req *proto.AppendPluginRuntimeLogsRequest) (*proto.AppendPluginRuntimeLogsResponse, error) {
+	if s.calls != nil {
+		s.calls.Add(1)
+	}
+	return &proto.AppendPluginRuntimeLogsResponse{LastSeq: int64(len(req.GetLogs()))}, nil
 }
 
 func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
@@ -663,7 +657,7 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	ts.EnableHTTP2 = true
 	ts.StartTLS()
 	testutil.CloseOnCleanup(t, ts)
-	publicHostServices.RegisterVerified("support", sessionVerifier, hostService)
+	registration := publicHostServices.RegisterVerified("support", sessionVerifier, hostService)
 
 	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
 	if err != nil {
@@ -725,7 +719,7 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	}
 
 	sessionVerifier.setActive("session-1", true)
-	publicHostServices.Unregister("support", hostService)
+	registration.Unregister()
 	unregisteredCtx, unregisteredCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer unregisteredCancel()
 	unregisteredCtx = metadata.NewOutgoingContext(unregisteredCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
@@ -852,7 +846,7 @@ func TestHostServiceRelayStopsServingUnregisteredProviderService(t *testing.T) {
 			proto.RegisterCacheServer(srv, cacheSrv)
 		},
 	}
-	publicHostServices.RegisterVerified("support", sessionVerifier, hostService)
+	registration := publicHostServices.RegisterVerified("support", sessionVerifier, hostService)
 
 	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfilePublic
@@ -889,7 +883,7 @@ func TestHostServiceRelayStopsServingUnregisteredProviderService(t *testing.T) {
 		t.Fatalf("Cache.Get via relay: %v", err)
 	}
 
-	publicHostServices.Unregister("support", hostService)
+	registration.Unregister()
 	staleCtx, staleCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer staleCancel()
 	staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
@@ -902,347 +896,7 @@ func TestHostServiceRelayStopsServingUnregisteredProviderService(t *testing.T) {
 	}
 }
 
-func TestHostServiceRelayCoreRoutableTokenDoesNotUseNonCoreRegistry(t *testing.T) {
-	t.Parallel()
-
-	secret := []byte("relay-test-secret-0123456789abcd")
-	cacheSrv := &relayTestCacheServer{}
-	const envVar = "GESTALT_TEST_CACHE_SOCKET"
-	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	hostService := runtimehost.HostService{
-		Name:   "cache",
-		EnvVar: envVar,
-		Register: func(srv *grpc.Server) {
-			proto.RegisterCacheServer(srv, cacheSrv)
-		},
-	}
-	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("session-1"), hostService)
-
-	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
-		cfg.RouteProfile = server.RouteProfilePublic
-		cfg.StateSecret = secret
-		cfg.PublicHostServices = publicHostServices
-	}))
-	ts.EnableHTTP2 = true
-	ts.StartTLS()
-	testutil.CloseOnCleanup(t, ts)
-
-	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
-	}
-	token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
-		PluginName:   "support",
-		SessionID:    "session-1",
-		Service:      "cache",
-		EnvVar:       envVar,
-		MethodPrefix: "/" + proto.Cache_ServiceDesc.ServiceName + "/",
-		CoreRoutable: true,
-		TTL:          time.Minute,
-	})
-	if err != nil {
-		t.Fatalf("MintToken: %v", err)
-	}
-
-	conn := newRelayGRPCConn(t, ts)
-	defer func() { _ = conn.Close() }()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
-	_, err = proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "core-routable-cache"})
-	if grpcstatus.Code(err) != codes.Unavailable {
-		t.Fatalf("Cache.Get core-routable non-core code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
-	}
-	if got := cacheSrv.calls(); got != 0 {
-		t.Fatalf("backend calls = %d, want 0", got)
-	}
-}
-
-func TestHostServiceRelayCoreRoutablePluginInvokerIgnoresRegistry(t *testing.T) {
-	t.Parallel()
-
-	secret := []byte("relay-test-secret-0123456789abcd")
-	httpInvoker := &relayTestInvoker{}
-	pluginInvoker := &relayTestInvoker{}
-	registryInvoker := &relayTestInvoker{}
-	runtimeSessions := newRelayTestRuntimeSessionVerifier("support", "session-core")
-	invokes := []invocation.PluginInvocationDependency{{
-		Plugin:         "slack",
-		Operation:      "events.reply",
-		CredentialMode: core.ConnectionModeNone,
-	}}
-	registryTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager registry: %v", err)
-	}
-	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("session-core"), runtimehost.HostService{
-		Name:   "plugin_invoker",
-		EnvVar: plugininvokerservice.DefaultSocketEnv,
-		Register: func(srv *grpc.Server) {
-			proto.RegisterPluginInvokerServer(srv, plugininvokerservice.NewServer("support", invokes, registryInvoker, registryTokens))
-		},
-	})
-	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
-		cfg.RouteProfile = server.RouteProfilePublic
-		cfg.StateSecret = secret
-		cfg.Invoker = httpInvoker
-		cfg.PluginInvoker = pluginInvoker
-		cfg.PluginRuntimes = runtimeSessions
-		cfg.PublicHostServices = publicHostServices
-		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"support": {Invokes: configPluginInvocationDependencies(invokes)},
-		}
-	}))
-	ts.EnableHTTP2 = true
-	ts.StartTLS()
-	testutil.CloseOnCleanup(t, ts)
-
-	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
-	}
-	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
-		PluginName:   "support",
-		SessionID:    "session-core",
-		Service:      "plugin_invoker",
-		EnvVar:       plugininvokerservice.DefaultSocketEnv,
-		MethodPrefix: "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/",
-		CoreRoutable: true,
-		TTL:          time.Minute,
-	})
-	if err != nil {
-		t.Fatalf("MintToken: %v", err)
-	}
-	invocationTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager: %v", err)
-	}
-	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
-		SubjectID: "user:test-user",
-		UserID:    "test-user",
-		Kind:      principal.KindUser,
-		Source:    principal.SourceSession,
-	})
-	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "support", plugininvokerservice.InvocationDependencyGrants(invokes))
-	if err != nil {
-		t.Fatalf("MintRootToken: %v", err)
-	}
-	params, err := structpb.NewStruct(map[string]any{"channel_id": "C123", "thread_ts": "123.456"})
-	if err != nil {
-		t.Fatalf("NewStruct: %v", err)
-	}
-
-	conn := newRelayGRPCConn(t, ts)
-	defer func() { _ = conn.Close() }()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
-	resp, err := proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{
-		InvocationToken: invocationToken,
-		Plugin:          "slack",
-		Operation:       "events.reply",
-		Instance:        "prod",
-		IdempotencyKey:  "tool-call-1",
-		Params:          params,
-	})
-	if err != nil {
-		t.Fatalf("PluginInvoker.Invoke via relay: %v", err)
-	}
-	if resp.GetStatus() != 202 || resp.GetBody() != "relayed" {
-		t.Fatalf("PluginInvoker.Invoke response = %+v, want status=202 body=relayed", resp)
-	}
-	call := pluginInvoker.snapshot()
-	if call.providerName != "slack" || call.operation != "events.reply" || call.instance != "prod" {
-		t.Fatalf("invocation target = %s.%s/%s, want slack.events.reply/prod", call.providerName, call.operation, call.instance)
-	}
-	if call.idempotencyKey != "tool-call-1" {
-		t.Fatalf("idempotency key = %q, want tool-call-1", call.idempotencyKey)
-	}
-	if call.params["channel_id"] != "C123" || call.params["thread_ts"] != "123.456" {
-		t.Fatalf("params = %#v, want Slack reply params", call.params)
-	}
-	if httpCall := httpInvoker.snapshot(); httpCall.providerName != "" {
-		t.Fatalf("http invoker was called for plugin relay: %+v", httpCall)
-	}
-	if registryCall := registryInvoker.snapshot(); registryCall.providerName != "" {
-		t.Fatalf("registry invoker was called for core-routable relay: %+v", registryCall)
-	}
-
-	runtimeSessions.setActive("support", "session-core", false)
-	staleCtx, staleCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer staleCancel()
-	staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
-	_, err = proto.NewPluginInvokerClient(conn).Invoke(staleCtx, &proto.PluginInvokeRequest{
-		InvocationToken: invocationToken,
-		Plugin:          "slack",
-		Operation:       "events.reply",
-		Params:          params,
-	})
-	if grpcstatus.Code(err) != codes.Unauthenticated {
-		t.Fatalf("PluginInvoker.Invoke stale runtime session code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unauthenticated, err)
-	}
-	if call := pluginInvoker.snapshot(); call.calls != 1 {
-		t.Fatalf("plugin invoker calls = %d, want 1 after stale runtime session", call.calls)
-	}
-}
-
-func TestHostServiceRelayRejectsCoreRoutableWithoutRuntimeVerifier(t *testing.T) {
-	t.Parallel()
-
-	secret := []byte("relay-test-secret-0123456789abcd")
-	pluginInvoker := &relayTestInvoker{}
-	invokes := []invocation.PluginInvocationDependency{{
-		Plugin:         "slack",
-		Operation:      "events.reply",
-		CredentialMode: core.ConnectionModeNone,
-	}}
-	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
-		cfg.RouteProfile = server.RouteProfilePublic
-		cfg.StateSecret = secret
-		cfg.PluginInvoker = pluginInvoker
-		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"support": {Invokes: configPluginInvocationDependencies(invokes)},
-		}
-	}))
-	ts.EnableHTTP2 = true
-	ts.StartTLS()
-	testutil.CloseOnCleanup(t, ts)
-
-	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
-	}
-	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
-		PluginName:   "support",
-		SessionID:    "session-no-verifier",
-		Service:      "plugin_invoker",
-		EnvVar:       plugininvokerservice.DefaultSocketEnv,
-		MethodPrefix: "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/",
-		CoreRoutable: true,
-		TTL:          time.Minute,
-	})
-	if err != nil {
-		t.Fatalf("MintToken: %v", err)
-	}
-	invocationTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager: %v", err)
-	}
-	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
-		SubjectID: "user:test-user",
-		UserID:    "test-user",
-		Kind:      principal.KindUser,
-		Source:    principal.SourceSession,
-	})
-	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "support", plugininvokerservice.InvocationDependencyGrants(invokes))
-	if err != nil {
-		t.Fatalf("MintRootToken: %v", err)
-	}
-
-	conn := newRelayGRPCConn(t, ts)
-	defer func() { _ = conn.Close() }()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
-	_, err = proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{
-		InvocationToken: invocationToken,
-		Plugin:          "slack",
-		Operation:       "events.reply",
-	})
-	if grpcstatus.Code(err) != codes.Unauthenticated {
-		t.Fatalf("PluginInvoker.Invoke without runtime verifier code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unauthenticated, err)
-	}
-	if call := pluginInvoker.snapshot(); call.calls != 0 {
-		t.Fatalf("plugin invoker calls = %d, want 0 without runtime verifier", call.calls)
-	}
-}
-
-func TestHostServiceRelayCoreRoutableProviderDevUsesRegisteredSessionVerifier(t *testing.T) {
-	t.Parallel()
-
-	secret := []byte("relay-test-secret-0123456789abcd")
-	pluginInvoker := &relayTestInvoker{}
-	invokes := []invocation.PluginInvocationDependency{{
-		Plugin:         "slack",
-		Operation:      "events.reply",
-		CredentialMode: core.ConnectionModeNone,
-	}}
-	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("provider-dev-session"), runtimehost.HostService{
-		Name:   "plugin_invoker",
-		EnvVar: plugininvokerservice.DefaultSocketEnv,
-		Register: func(*grpc.Server) {
-		},
-	})
-	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
-		cfg.RouteProfile = server.RouteProfilePublic
-		cfg.StateSecret = secret
-		cfg.Invoker = pluginInvoker
-		cfg.PluginInvoker = pluginInvoker
-		cfg.PluginRuntimes = nonHostedRuntimeSessionVerifier{}
-		cfg.PublicHostServices = publicHostServices
-		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"support": {Invokes: configPluginInvocationDependencies(invokes)},
-		}
-	}))
-	ts.EnableHTTP2 = true
-	ts.StartTLS()
-	testutil.CloseOnCleanup(t, ts)
-
-	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
-	}
-	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
-		PluginName:   "support",
-		SessionID:    "provider-dev-session",
-		Service:      "plugin_invoker",
-		EnvVar:       plugininvokerservice.DefaultSocketEnv,
-		MethodPrefix: "/" + proto.PluginInvoker_ServiceDesc.ServiceName + "/",
-		CoreRoutable: true,
-		TTL:          time.Minute,
-	})
-	if err != nil {
-		t.Fatalf("MintToken: %v", err)
-	}
-	invocationTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager: %v", err)
-	}
-	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
-		SubjectID: "user:test-user",
-		UserID:    "test-user",
-		Kind:      principal.KindUser,
-		Source:    principal.SourceSession,
-	})
-	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "support", plugininvokerservice.InvocationDependencyGrants(invokes))
-	if err != nil {
-		t.Fatalf("MintRootToken: %v", err)
-	}
-
-	conn := newRelayGRPCConn(t, ts)
-	defer func() { _ = conn.Close() }()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
-	_, err = proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{
-		InvocationToken: invocationToken,
-		Plugin:          "slack",
-		Operation:       "events.reply",
-		Instance:        "prod",
-		IdempotencyKey:  "provider-dev-call",
-	})
-	if err != nil {
-		t.Fatalf("PluginInvoker.Invoke via provider-dev core relay: %v", err)
-	}
-	if call := pluginInvoker.snapshot(); call.calls != 1 || call.providerName != "slack" || call.operation != "events.reply" {
-		t.Fatalf("plugin invoker call = %+v, want slack events.reply", call)
-	}
-}
-
-func TestHostServiceRelayRejectsRegisteredCoreServiceWithoutCoreRoutableToken(t *testing.T) {
+func TestHostServiceRelayRoutesRegisteredPluginInvokerService(t *testing.T) {
 	t.Parallel()
 
 	secret := []byte("relay-test-secret-0123456789abcd")
@@ -1257,7 +911,8 @@ func TestHostServiceRelayRejectsRegisteredCoreServiceWithoutCoreRoutableToken(t 
 		t.Fatalf("NewInvocationTokenManager: %v", err)
 	}
 	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
-	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("provider-dev-session"), runtimehost.HostService{
+	sessionVerifier := newRelayTestSessionVerifier("provider-dev-session")
+	publicHostServices.RegisterVerified("support", sessionVerifier, runtimehost.HostService{
 		Name:   "plugin_invoker",
 		EnvVar: plugininvokerservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
@@ -1311,228 +966,185 @@ func TestHostServiceRelayRejectsRegisteredCoreServiceWithoutCoreRoutableToken(t 
 		Instance:        "prod",
 		IdempotencyKey:  "provider-dev-call",
 	})
-	if grpcstatus.Code(err) != codes.Unavailable {
-		t.Fatalf("PluginInvoker.Invoke registered non-core relay code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
+	if err != nil {
+		t.Fatalf("PluginInvoker.Invoke via registered relay: %v", err)
 	}
-	if call := invoker.snapshot(); call.providerName != "" {
-		t.Fatalf("registered core handler was called for non-core relay: %+v", call)
+	if call := invoker.snapshot(); call.calls != 1 || call.providerName != "slack" || call.operation != "events.reply" || call.instance != "prod" {
+		t.Fatalf("plugin invoker call = %+v, want slack events.reply/prod", call)
+	}
+
+	sessionVerifier.setActive("provider-dev-session", false)
+	staleCtx, staleCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer staleCancel()
+	staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+	_, err = proto.NewPluginInvokerClient(conn).Invoke(staleCtx, &proto.PluginInvokeRequest{
+		InvocationToken: invocationToken,
+		Plugin:          "slack",
+		Operation:       "events.reply",
+	})
+	if grpcstatus.Code(err) != codes.Unauthenticated {
+		t.Fatalf("PluginInvoker.Invoke stale session code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unauthenticated, err)
+	}
+	if call := invoker.snapshot(); call.calls != 1 {
+		t.Fatalf("plugin invoker calls = %d, want only the verified call", call.calls)
 	}
 }
 
-func TestHostServiceRelayServesCoreRoutableWorkflowManagerWithoutRegistry(t *testing.T) {
+func TestHostServiceRelayRoutesRegisteredRuntimeCoreServices(t *testing.T) {
 	t.Parallel()
 
-	secret := []byte("relay-test-secret-0123456789abcd")
-	workflowProvider := newRelayTestWorkflowProvider()
-	agentProvider := newMemoryAgentProvider()
-	runtimeSessions := newRelayTestRuntimeSessionVerifier("github", "session-workflow")
-	invokes := []invocation.PluginInvocationDependency{{
-		Plugin:         "github",
-		Operation:      "bot.commentFinal",
-		CredentialMode: core.ConnectionModeNone,
-	}}
-	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
-		providers := registry.New()
-		if err := providers.Providers.Register("github", &coretesting.StubIntegration{
-			N:        "github",
-			ConnMode: core.ConnectionModeNone,
-			CatalogVal: serverTestCatalogFromOperations("github", []core.Operation{{
-				Name:   "events.handle",
-				Method: http.MethodPost,
-			}, {
-				Name:   "bot.commentFinal",
-				Method: http.MethodPost,
-			}}),
-		}); err != nil {
-			t.Fatalf("register provider: %v", err)
-		}
-		cfg.Providers = &providers.Providers
-		cfg.RouteProfile = server.RouteProfilePublic
-		cfg.StateSecret = secret
-		cfg.PluginRuntimes = runtimeSessions
-		cfg.Workflow = &stubWorkflowControl{
-			defaultProviderName: "local",
-			provider:            workflowProvider,
-		}
-		cfg.Agent = &stubAgentControl{
-			defaultProviderName: "managed",
-			provider:            agentProvider,
-		}
-		cfg.AgentManager = agentmanager.New(agentmanager.Config{Agent: cfg.Agent})
-		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"github": {Invokes: configPluginInvocationDependencies(invokes)},
-		}
-	}))
-	ts.EnableHTTP2 = true
-	ts.StartTLS()
-	testutil.CloseOnCleanup(t, ts)
-
-	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
-	}
-	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
-		PluginName:   "github",
-		SessionID:    "session-workflow",
-		Service:      "workflow_manager",
-		EnvVar:       workflowservice.DefaultManagerSocketEnv,
-		MethodPrefix: "/" + proto.WorkflowManagerHost_ServiceDesc.ServiceName + "/",
-		CoreRoutable: true,
-		TTL:          time.Minute,
-	})
-	if err != nil {
-		t.Fatalf("MintToken: %v", err)
-	}
-	invocationTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager: %v", err)
-	}
-	permissions := principal.CompilePermissions([]core.AccessPermission{{
-		Plugin:     "github",
-		Operations: []string{"events.handle"},
-	}, {
-		Plugin: "managed",
-	}})
-	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
-		SubjectID:        "service_account:github_app_installation:99:repo:acme/widgets",
-		Kind:             principal.KindUser,
-		Source:           principal.SourceSession,
-		TokenPermissions: permissions,
-		Scopes:           principal.PermissionPlugins(permissions),
-	})
-	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "github", nil)
-	if err != nil {
-		t.Fatalf("MintRootToken: %v", err)
-	}
-
-	conn := newRelayGRPCConn(t, ts)
-	defer func() { _ = conn.Close() }()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
-	resp, err := proto.NewWorkflowManagerHostClient(conn).SignalOrStartRun(ctx, &proto.WorkflowManagerSignalOrStartRunRequest{
-		ProviderName:    "local",
-		WorkflowKey:     "github:99:acme/widgets:pull_request:7",
-		IdempotencyKey:  "delivery-1",
-		InvocationToken: invocationToken,
-		Target: &proto.BoundWorkflowTarget{Kind: &proto.BoundWorkflowTarget_Agent{
-			Agent: &proto.BoundWorkflowAgentTarget{
-				ProviderName: "managed",
-				Prompt:       "Handle the webhook.",
-				OutputDelivery: &proto.WorkflowOutputDelivery{
-					Target: &proto.BoundWorkflowPluginTarget{
-						PluginName: "github",
-						Operation:  "bot.commentFinal",
-					},
-					CredentialMode: string(core.ConnectionModeNone),
-					InputBindings: []*proto.WorkflowOutputBinding{{
-						InputField: "body",
-						Value: &proto.WorkflowOutputValueSource{
-							Kind: &proto.WorkflowOutputValueSource_AgentOutput{AgentOutput: "text"},
-						},
+	cases := []struct {
+		name         string
+		service      string
+		envVar       string
+		methodPrefix string
+		register     func(*grpc.Server, *atomic.Int64)
+		call         func(*testing.T, context.Context, *grpc.ClientConn)
+	}{
+		{
+			name:         "workflow manager",
+			service:      "workflow_manager",
+			envVar:       workflowservice.DefaultManagerSocketEnv,
+			methodPrefix: "/" + proto.WorkflowManagerHost_ServiceDesc.ServiceName + "/",
+			register: func(srv *grpc.Server, calls *atomic.Int64) {
+				proto.RegisterWorkflowManagerHostServer(srv, relayTestWorkflowManagerHostServer{calls: calls})
+			},
+			call: func(t *testing.T, ctx context.Context, conn *grpc.ClientConn) {
+				t.Helper()
+				resp, err := proto.NewWorkflowManagerHostClient(conn).GetSchedule(ctx, &proto.WorkflowManagerGetScheduleRequest{ScheduleId: "schedule-1"})
+				if err != nil {
+					t.Fatalf("WorkflowManager.GetSchedule via relay: %v", err)
+				}
+				if resp.GetProviderName() != "registered" || resp.GetSchedule().GetId() != "schedule-1" {
+					t.Fatalf("WorkflowManager.GetSchedule response = %+v, want registered schedule-1", resp)
+				}
+			},
+		},
+		{
+			name:         "agent manager",
+			service:      "agent_manager",
+			envVar:       agentservice.DefaultManagerSocketEnv,
+			methodPrefix: "/" + proto.AgentManagerHost_ServiceDesc.ServiceName + "/",
+			register: func(srv *grpc.Server, calls *atomic.Int64) {
+				proto.RegisterAgentManagerHostServer(srv, relayTestAgentManagerHostServer{calls: calls})
+			},
+			call: func(t *testing.T, ctx context.Context, conn *grpc.ClientConn) {
+				t.Helper()
+				resp, err := proto.NewAgentManagerHostClient(conn).GetSession(ctx, &proto.AgentManagerGetSessionRequest{SessionId: "agent-session-1"})
+				if err != nil {
+					t.Fatalf("AgentManager.GetSession via relay: %v", err)
+				}
+				if resp.GetProviderName() != "registered" || resp.GetId() != "agent-session-1" {
+					t.Fatalf("AgentManager.GetSession response = %+v, want registered agent-session-1", resp)
+				}
+			},
+		},
+		{
+			name:         "runtime log host",
+			service:      "runtime_log_host",
+			envVar:       runtimehost.DefaultRuntimeLogHostSocketEnv,
+			methodPrefix: "/" + proto.PluginRuntimeLogHost_ServiceDesc.ServiceName + "/",
+			register: func(srv *grpc.Server, calls *atomic.Int64) {
+				proto.RegisterPluginRuntimeLogHostServer(srv, relayTestRuntimeLogHostServer{calls: calls})
+			},
+			call: func(t *testing.T, ctx context.Context, conn *grpc.ClientConn) {
+				t.Helper()
+				resp, err := proto.NewPluginRuntimeLogHostClient(conn).AppendLogs(ctx, &proto.AppendPluginRuntimeLogsRequest{
+					SessionId: "runtime-session-1",
+					Logs: []*proto.PluginRuntimeLogEntry{{
+						Stream:    proto.PluginRuntimeLogStream_PLUGIN_RUNTIME_LOG_STREAM_STDOUT,
+						Message:   "hello",
+						SourceSeq: 1,
 					}},
+				})
+				if err != nil {
+					t.Fatalf("PluginRuntimeLogHost.AppendLogs via relay: %v", err)
+				}
+				if resp.GetLastSeq() != 1 {
+					t.Fatalf("PluginRuntimeLogHost.AppendLogs last_seq = %d, want 1", resp.GetLastSeq())
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			secret := []byte("relay-test-secret-0123456789abcd")
+			var calls atomic.Int64
+			publicHostServices := runtimehost.NewPublicHostServiceRegistry()
+			sessionVerifier := newRelayTestSessionVerifier("session-1")
+			publicHostServices.RegisterVerified("support", sessionVerifier, runtimehost.HostService{
+				Name:   tc.service,
+				EnvVar: tc.envVar,
+				Register: func(srv *grpc.Server) {
+					tc.register(srv, &calls)
 				},
-			},
-		}},
-		Signal: &proto.WorkflowSignal{Name: "github.app.webhook", IdempotencyKey: "delivery-1"},
-	})
-	if err != nil {
-		t.Fatalf("WorkflowManager.SignalOrStartRun via relay: %v", err)
-	}
-	if resp.GetRun().GetId() != "workflow-run-1" || resp.GetWorkflowKey() != "github:99:acme/widgets:pull_request:7" {
-		t.Fatalf("SignalOrStartRun response = %+v, want relayed workflow run", resp)
-	}
-	if !resp.GetStartedRun() || resp.GetSignal().GetId() != "signal-1" {
-		t.Fatalf("SignalOrStartRun signal response = %+v, want started signal-1", resp)
-	}
-	call := workflowProvider.signalOrStartRequest()
-	if call.WorkflowKey != "github:99:acme/widgets:pull_request:7" {
-		t.Fatalf("workflow key = %q, want github:99:acme/widgets:pull_request:7", call.WorkflowKey)
-	}
-	if call.Target.Agent == nil || call.Target.Agent.ProviderName != "managed" {
-		t.Fatalf("workflow target = %#v, want managed agent target", call.Target)
-	}
-	if delivery := call.Target.Agent.OutputDelivery; delivery == nil || delivery.Target.PluginName != "github" || delivery.Target.Operation != "bot.commentFinal" || delivery.CredentialMode != core.ConnectionModeNone {
-		t.Fatalf("workflow output delivery = %#v, want github bot.commentFinal with credential mode none", delivery)
-	}
-}
+			})
 
-func TestHostServiceRelayServesCoreRoutableAgentManagerWithoutRegistry(t *testing.T) {
-	t.Parallel()
+			ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+				cfg.RouteProfile = server.RouteProfilePublic
+				cfg.StateSecret = secret
+				cfg.PublicHostServices = publicHostServices
+			}))
+			ts.EnableHTTP2 = true
+			ts.StartTLS()
+			testutil.CloseOnCleanup(t, ts)
 
-	secret := []byte("relay-test-secret-0123456789abcd")
-	agentProvider := newMemoryAgentProvider()
-	runtimeSessions := newRelayTestRuntimeSessionVerifier("support", "session-agent")
-	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
-		cfg.RouteProfile = server.RouteProfilePublic
-		cfg.StateSecret = secret
-		cfg.PluginRuntimes = runtimeSessions
-		cfg.AgentManager = agentmanager.New(agentmanager.Config{
-			Agent: &stubAgentControl{
-				defaultProviderName: "managed",
-				provider:            agentProvider,
-			},
+			tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+			if err != nil {
+				t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+			}
+			relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+				PluginName:   "support",
+				SessionID:    "session-1",
+				Service:      tc.service,
+				EnvVar:       tc.envVar,
+				MethodPrefix: tc.methodPrefix,
+				TTL:          time.Minute,
+			})
+			if err != nil {
+				t.Fatalf("MintToken: %v", err)
+			}
+
+			conn := newRelayGRPCConn(t, ts)
+			defer func() { _ = conn.Close() }()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+			tc.call(t, ctx, conn)
+			if got := calls.Load(); got != 1 {
+				t.Fatalf("registered handler calls = %d, want 1", got)
+			}
+
+			sessionVerifier.setActive("session-1", false)
+			staleCtx, staleCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer staleCancel()
+			staleCtx = metadata.NewOutgoingContext(staleCtx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
+			switch tc.service {
+			case "workflow_manager":
+				_, err = proto.NewWorkflowManagerHostClient(conn).GetSchedule(staleCtx, &proto.WorkflowManagerGetScheduleRequest{ScheduleId: "schedule-1"})
+			case "agent_manager":
+				_, err = proto.NewAgentManagerHostClient(conn).GetSession(staleCtx, &proto.AgentManagerGetSessionRequest{SessionId: "agent-session-1"})
+			case "runtime_log_host":
+				_, err = proto.NewPluginRuntimeLogHostClient(conn).AppendLogs(staleCtx, &proto.AppendPluginRuntimeLogsRequest{
+					SessionId: "runtime-session-1",
+					Logs:      []*proto.PluginRuntimeLogEntry{{Message: "stale"}},
+				})
+			}
+			if grpcstatus.Code(err) != codes.Unauthenticated {
+				t.Fatalf("stale %s relay code = %v, want %v (err=%v)", tc.service, grpcstatus.Code(err), codes.Unauthenticated, err)
+			}
+			if got := calls.Load(); got != 1 {
+				t.Fatalf("registered handler calls after stale session = %d, want 1", got)
+			}
 		})
-	}))
-	ts.EnableHTTP2 = true
-	ts.StartTLS()
-	testutil.CloseOnCleanup(t, ts)
-
-	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
-	}
-	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
-		PluginName:   "support",
-		SessionID:    "session-agent",
-		Service:      "agent_manager",
-		EnvVar:       agentservice.DefaultManagerSocketEnv,
-		MethodPrefix: "/" + proto.AgentManagerHost_ServiceDesc.ServiceName + "/",
-		CoreRoutable: true,
-		TTL:          time.Minute,
-	})
-	if err != nil {
-		t.Fatalf("MintToken: %v", err)
-	}
-	invocationTokens, err := plugininvokerservice.NewInvocationTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewInvocationTokenManager: %v", err)
-	}
-	principalCtx := principal.WithPrincipal(context.Background(), &principal.Principal{
-		SubjectID: "user:test-user",
-		UserID:    "test-user",
-		Kind:      principal.KindUser,
-		Source:    principal.SourceSession,
-	})
-	invocationToken, err := invocationTokens.MintRootToken(principalCtx, "support", nil)
-	if err != nil {
-		t.Fatalf("MintRootToken: %v", err)
-	}
-
-	conn := newRelayGRPCConn(t, ts)
-	defer func() { _ = conn.Close() }()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
-	resp, err := proto.NewAgentManagerHostClient(conn).CreateSession(ctx, &proto.AgentManagerCreateSessionRequest{
-		InvocationToken: invocationToken,
-		ProviderName:    "managed",
-		Model:           "gpt-test",
-		ClientRef:       "client-1",
-		IdempotencyKey:  "agent-session-1",
-	})
-	if err != nil {
-		t.Fatalf("AgentManager.CreateSession via relay: %v", err)
-	}
-	if resp.GetProviderName() != "managed" || resp.GetModel() != "gpt-test" || resp.GetClientRef() != "client-1" {
-		t.Fatalf("AgentManager.CreateSession response = %+v, want managed gpt-test client-1", resp)
-	}
-	if resp.GetId() == "" {
-		t.Fatalf("AgentManager.CreateSession id is empty: %+v", resp)
 	}
 }
 
-func TestHostServiceRelayDoesNotFallbackWithoutCoreRoutableToken(t *testing.T) {
+func TestHostServiceRelayDoesNotFallbackWithoutRegisteredService(t *testing.T) {
 	t.Parallel()
 
 	secret := []byte("relay-test-secret-0123456789abcd")
@@ -1577,63 +1189,10 @@ func TestHostServiceRelayDoesNotFallbackWithoutCoreRoutableToken(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
 	_, err = proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{})
 	if grpcstatus.Code(err) != codes.Unavailable {
-		t.Fatalf("PluginInvoker.Invoke non-core-routable code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
+		t.Fatalf("PluginInvoker.Invoke without registered service code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
 	}
 	if call := invoker.snapshot(); call.providerName != "" {
-		t.Fatalf("invoker was called for non-core-routable relay: %+v", call)
-	}
-}
-
-func TestHostServiceRelayRejectsCoreRoutableWithWrongCoreMethodPrefix(t *testing.T) {
-	t.Parallel()
-
-	secret := []byte("relay-test-secret-0123456789abcd")
-	invoker := &relayTestInvoker{}
-	invokes := []invocation.PluginInvocationDependency{{
-		Plugin:         "slack",
-		Operation:      "events.reply",
-		CredentialMode: core.ConnectionModeNone,
-	}}
-	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
-		cfg.RouteProfile = server.RouteProfilePublic
-		cfg.StateSecret = secret
-		cfg.Invoker = invoker
-		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"support": {Invokes: configPluginInvocationDependencies(invokes)},
-		}
-	}))
-	ts.EnableHTTP2 = true
-	ts.StartTLS()
-	testutil.CloseOnCleanup(t, ts)
-
-	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
-	if err != nil {
-		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
-	}
-	relayToken, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
-		PluginName:   "support",
-		SessionID:    "session-elsewhere",
-		Service:      "plugin_invoker",
-		EnvVar:       plugininvokerservice.DefaultSocketEnv,
-		MethodPrefix: "/",
-		CoreRoutable: true,
-		TTL:          time.Minute,
-	})
-	if err != nil {
-		t.Fatalf("MintToken: %v", err)
-	}
-
-	conn := newRelayGRPCConn(t, ts)
-	defer func() { _ = conn.Close() }()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, relayToken))
-	_, err = proto.NewPluginInvokerClient(conn).Invoke(ctx, &proto.PluginInvokeRequest{})
-	if grpcstatus.Code(err) != codes.Unavailable {
-		t.Fatalf("PluginInvoker.Invoke wrong-prefix code = %v, want %v (err=%v)", grpcstatus.Code(err), codes.Unavailable, err)
-	}
-	if call := invoker.snapshot(); call.providerName != "" {
-		t.Fatalf("invoker was called for wrong-prefix core relay: %+v", call)
+		t.Fatalf("invoker was called without registered relay service: %+v", call)
 	}
 }
 

--- a/gestaltd/services/runtimehost/host_service_relay_token.go
+++ b/gestaltd/services/runtimehost/host_service_relay_token.go
@@ -31,7 +31,6 @@ type HostServiceRelayTokenRequest struct {
 	Service      string
 	EnvVar       string
 	MethodPrefix string
-	CoreRoutable bool
 	TTL          time.Duration
 }
 
@@ -41,7 +40,6 @@ type HostServiceRelayTarget struct {
 	Service      string
 	EnvVar       string
 	MethodPrefix string
-	CoreRoutable bool
 }
 
 type hostServiceRelayTokenClaims struct {
@@ -51,7 +49,6 @@ type hostServiceRelayTokenClaims struct {
 	Service      string `json:"service,omitempty"`
 	EnvVar       string `json:"env_var,omitempty"`
 	MethodPrefix string `json:"method_prefix,omitempty"`
-	CoreRoutable bool   `json:"core_routable,omitempty"`
 }
 
 func NewHostServiceRelayTokenManager(secret []byte) (*HostServiceRelayTokenManager, error) {
@@ -103,7 +100,6 @@ func (m *HostServiceRelayTokenManager) MintToken(req HostServiceRelayTokenReques
 		Service:      service,
 		EnvVar:       envVar,
 		MethodPrefix: methodPrefix,
-		CoreRoutable: req.CoreRoutable,
 	})
 }
 
@@ -125,7 +121,6 @@ func (m *HostServiceRelayTokenManager) ResolveToken(token string) (HostServiceRe
 		Service:      service,
 		EnvVar:       envVar,
 		MethodPrefix: methodPrefix,
-		CoreRoutable: claims.CoreRoutable,
 	}, nil
 }
 

--- a/gestaltd/services/runtimehost/public_host_service.go
+++ b/gestaltd/services/runtimehost/public_host_service.go
@@ -9,6 +9,9 @@ import (
 
 // ErrProviderNotHostedRuntime means a public host-service callback did not
 // belong to a provider backed by a hosted runtime.
+//
+// Deprecated: public host-service relay callbacks now resolve exclusively
+// through registered PublicHostService entries and their session verifiers.
 var ErrProviderNotHostedRuntime = errors.New("provider does not use a hosted runtime")
 
 type PublicHostServiceSessionVerifier interface {


### PR DESCRIPTION
## Summary

Remove the core-routable host-service relay fallback so plugin runtime callbacks always resolve through registered public host-service entries and their session verifiers.

This deletes the `CoreRoutable` relay-token field and the server-side direct routing path that could synthesize built-in workflow manager, agent manager, and plugin invoker handlers outside `PublicHostServiceRegistry`. Hosted runtime bootstrap already registers those services for public relay, so the relay path now has one routing model.

## Behavioral notes

- Existing relay tokens with the old `core_routable` claim are parsed as normal relay tokens, but they no longer get special fallback routing.
- A callback succeeds only when its `(plugin, service, env var)` target is registered in `PublicHostServiceRegistry` and the registered session verifier accepts the session.
- The exported provider-wide `PublicHostServiceRegistry.Unregister` method remains for compatibility. `ErrProviderNotHostedRuntime` remains exported as deprecated compatibility surface.

## Tests

- `cd gestaltd && go test ./services/runtimehost ./internal/server ./internal/bootstrap -count=1`
- `git diff --check origin/main...HEAD`

## Review

Reviewed by two gpt-5.5 xhigh agents. Applied feedback to add server-level transport coverage for registered `workflow_manager`, `agent_manager`, and `runtime_log_host`, and restored the exported unregister compatibility API.
