### PR TITLE
Split plugin package IO from provider build internals

### DIFF
--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -23,7 +23,7 @@ import (
 // starting the server or running migrations. Unlike Bootstrap, provider
 // validation is strict: any provider construction failure is returned.
 func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) ([]string, error) {
-	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(ctx, pluginservice.ValidationConfigFromConfig(cfg)); err != nil {
+	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(ctx, config.PluginValidationConfig(cfg)); err != nil {
 		return nil, err
 	}
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	"github.com/valon-technologies/gestalt/server/services/plugins/providerpkg"
+	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 	"gopkg.in/yaml.v3"
 )
 
@@ -2800,7 +2800,7 @@ func normalizeAdminConfig(cfg *Config) error {
 		return nil
 	}
 
-	roles, err := providerpkg.NormalizeUIAllowedRoles("server.admin.allowedRoles", admin.AllowedRoles)
+	roles, err := packageio.NormalizeUIAllowedRoles("server.admin.allowedRoles", admin.AllowedRoles)
 	if err != nil {
 		if admin.AuthorizationPolicy == "" {
 			return fmt.Errorf("normalize admin config: server.admin.allowedRoles requires server.admin.authorizationPolicy")

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -17,7 +17,7 @@ import (
 	cronv3 "github.com/robfig/cron/v3"
 	"github.com/valon-technologies/gestalt/server/core"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	"github.com/valon-technologies/gestalt/server/services/plugins/providerpkg"
+	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 	"github.com/valon-technologies/gestalt/server/services/s3"
 )
 
@@ -399,7 +399,7 @@ func ValidateResolvedStructure(cfg *Config) error {
 		if entry.ResolvedManifest == nil || entry.ManifestSpec() == nil {
 			return fmt.Errorf("config validation: ui %q authorizationPolicy requires a resolved ui manifest", name)
 		}
-		if err := providerpkg.ValidatePolicyBoundUIRoutes(entry.ManifestSpec().Routes); err != nil {
+		if err := packageio.ValidatePolicyBoundUIRoutes(entry.ManifestSpec().Routes); err != nil {
 			return fmt.Errorf("config validation: ui %q authorizationPolicy: %w", name, err)
 		}
 	}

--- a/gestaltd/internal/config/plugin_validation.go
+++ b/gestaltd/internal/config/plugin_validation.go
@@ -1,0 +1,62 @@
+package config
+
+import pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
+
+func PluginValidationConfig(cfg *Config) *pluginservice.ValidationConfig {
+	if cfg == nil {
+		return nil
+	}
+	validation := &pluginservice.ValidationConfig{
+		Plugins: make(map[string]*pluginservice.ValidationPlugin, len(cfg.Plugins)),
+	}
+	for name, entry := range cfg.Plugins {
+		validation.Plugins[name] = PluginValidationEntry(entry)
+	}
+	return validation
+}
+
+func PluginValidationEntry(entry *ProviderEntry) *pluginservice.ValidationPlugin {
+	if entry == nil {
+		return nil
+	}
+	return &pluginservice.ValidationPlugin{
+		Manifest:            entry.ResolvedManifest,
+		ManifestPath:        entry.ResolvedManifestPath,
+		AllowedOperations:   entry.AllowedOperations,
+		Invokes:             pluginInvocationDependencies(entry.Invokes),
+		SurfaceURLOverrides: pluginSurfaceURLOverrides(entry),
+		ReadStaticCatalog:   pluginservice.StaticCatalogReaderForManifest(entry.ResolvedManifestPath),
+		LoadAPICatalog:      pluginservice.DefaultAPICatalogLoader,
+	}
+}
+
+func pluginInvocationDependencies(dependencies []PluginInvocationDependency) []pluginservice.InvocationDependency {
+	if len(dependencies) == 0 {
+		return nil
+	}
+	result := make([]pluginservice.InvocationDependency, 0, len(dependencies))
+	for _, dependency := range dependencies {
+		result = append(result, pluginservice.InvocationDependency{
+			Plugin:    dependency.Plugin,
+			Operation: dependency.Operation,
+			Surface:   pluginservice.SpecSurface(dependency.Surface),
+		})
+	}
+	return result
+}
+
+func pluginSurfaceURLOverrides(entry *ProviderEntry) map[pluginservice.SpecSurface]string {
+	if entry == nil {
+		return nil
+	}
+	overrides := make(map[pluginservice.SpecSurface]string)
+	for _, surface := range []pluginservice.SpecSurface{pluginservice.SpecSurfaceGraphQL, pluginservice.SpecSurfaceMCP} {
+		if url := ProviderSurfaceURLOverride(entry, SpecSurface(surface)); url != "" {
+			overrides[surface] = url
+		}
+	}
+	if len(overrides) == 0 {
+		return nil
+	}
+	return overrides
+}

--- a/gestaltd/services/operator/lifecycle.go
+++ b/gestaltd/services/operator/lifecycle.go
@@ -283,7 +283,7 @@ func (l *Lifecycle) prepareLockAtPaths(configPaths []string, state StatePaths, d
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
-	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), pluginservice.ValidationConfigFromConfig(cfg)); err != nil {
+	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), config.PluginValidationConfig(cfg)); err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
 	return lock, cfg, paths, nil
@@ -473,7 +473,7 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, 
 		return nil, nil, err
 	}
 	if !secretsValidated && !dependenciesValidated {
-		if err := pluginservice.ValidateDependencies(context.Background(), pluginservice.ValidationConfigFromConfig(cfg)); err != nil {
+		if err := pluginservice.ValidateDependencies(context.Background(), config.PluginValidationConfig(cfg)); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -499,7 +499,7 @@ func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string,
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, err
 	}
-	if err := pluginservice.ValidateDependencies(context.Background(), pluginservice.ValidationConfigFromConfig(cfg)); err != nil {
+	if err := pluginservice.ValidateDependencies(context.Background(), config.PluginValidationConfig(cfg)); err != nil {
 		return nil, err
 	}
 	return cfg, nil
@@ -536,7 +536,7 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return err
 	}
-	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), pluginservice.ValidationConfigFromConfig(cfg)); err != nil {
+	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), config.PluginValidationConfig(cfg)); err != nil {
 		return err
 	}
 	return nil

--- a/gestaltd/services/plugins/packageio/archive.go
+++ b/gestaltd/services/plugins/packageio/archive.go
@@ -1,0 +1,410 @@
+package packageio
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func ReadPackageManifest(packagePath string) (_ []byte, _ *providermanifestv1.Manifest, err error) {
+	return ReadPackageManifestIn(packagePath, ManifestFiles)
+}
+
+func ReadPackageManifestIn(packagePath string, names []string) (_ []byte, _ *providermanifestv1.Manifest, err error) {
+	var firstErr error
+	for _, name := range names {
+		data, err := ReadArchiveEntry(packagePath, name)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		format := ManifestFormatFromPath(name)
+		manifest, err := DecodeManifestFormat(data, format)
+		if err != nil {
+			return nil, nil, err
+		}
+		return data, manifest, nil
+	}
+	return nil, nil, firstErr
+}
+
+func ReadManifestFile(p string) ([]byte, *providermanifestv1.Manifest, error) {
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read manifest %q: %w", p, err)
+	}
+	format := ManifestFormatFromPath(p)
+	manifest, err := DecodeManifestFormat(data, format)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, manifest, nil
+}
+
+func ReadSourceManifestFile(p string) ([]byte, *providermanifestv1.Manifest, error) {
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read manifest %q: %w", p, err)
+	}
+	format := ManifestFormatFromPath(p)
+	manifest, err := DecodeSourceManifestFormat(data, format)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, manifest, nil
+}
+
+func LoadManifestFromPath(inputPath string) ([]byte, *providermanifestv1.Manifest, string, error) {
+	return LoadManifestFromPathIn(inputPath, ManifestFiles)
+}
+
+func LoadManifestFromPathIn(inputPath string, names []string) ([]byte, *providermanifestv1.Manifest, string, error) {
+	info, err := os.Stat(inputPath)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("stat %q: %w", inputPath, err)
+	}
+	if info.IsDir() {
+		manifestPath, err := FindManifestFileIn(inputPath, names)
+		if err != nil {
+			return nil, nil, "", err
+		}
+		data, manifest, err := ReadManifestFile(manifestPath)
+		return data, manifest, manifestPath, err
+	}
+	if IsManifestFileIn(inputPath, names) {
+		data, manifest, err := ReadManifestFile(inputPath)
+		return data, manifest, inputPath, err
+	}
+	data, manifest, err := ReadPackageManifestIn(inputPath, names)
+	return data, manifest, inputPath, err
+}
+
+func CopyPackageDir(sourceDir, destDir string) error {
+	sourceDir = filepath.Clean(sourceDir)
+	if _, err := ValidatePackageDir(sourceDir); err != nil {
+		return err
+	}
+	destDir = filepath.Clean(destDir)
+	if isPathWithinDir(sourceDir, destDir) {
+		return fmt.Errorf("output directory %q must not be inside source directory %q", destDir, sourceDir)
+	}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	return filepath.WalkDir(sourceDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(sourceDir, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		src, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = src.Close() }()
+		dst, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(dst, src); err != nil {
+			_ = dst.Close()
+			return err
+		}
+		return dst.Close()
+	})
+}
+
+func CreatePackageFromDir(sourceDir, outputPath string) (err error) {
+	sourceDir = filepath.Clean(sourceDir)
+	if _, err := ValidatePackageDir(sourceDir); err != nil {
+		return err
+	}
+	outputPath = filepath.Clean(outputPath)
+	if isPathWithinDir(sourceDir, outputPath) {
+		return fmt.Errorf("output archive %q must not be inside source directory %q", outputPath, sourceDir)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	out, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("create package %q: %w", outputPath, err)
+	}
+	defer joinCloseError(&err, fmt.Sprintf("close package %q", outputPath), out)
+
+	gzw := gzip.NewWriter(out)
+	gzw.ModTime = time.Unix(0, 0)
+	defer joinCloseError(&err, "close gzip stream", gzw)
+
+	tw := tar.NewWriter(gzw)
+	defer joinCloseError(&err, "close tar stream", tw)
+
+	var files []string
+	err = filepath.WalkDir(sourceDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(sourceDir, p)
+		if err != nil {
+			return err
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walk source dir: %w", err)
+	}
+	slices.Sort(files)
+
+	for _, rel := range files {
+		absPath := filepath.Join(sourceDir, filepath.FromSlash(rel))
+		info, err := os.Stat(absPath)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", rel, err)
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return fmt.Errorf("build tar header for %s: %w", rel, err)
+		}
+		hdr.Name = rel
+		hdr.ModTime = time.Unix(0, 0)
+		hdr.AccessTime = time.Unix(0, 0)
+		hdr.ChangeTime = time.Unix(0, 0)
+		hdr.Uid = 0
+		hdr.Gid = 0
+		hdr.Uname = ""
+		hdr.Gname = ""
+		if err := tw.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("write tar header for %s: %w", rel, err)
+		}
+		f, err := os.Open(absPath)
+		if err != nil {
+			return fmt.Errorf("open %s: %w", rel, err)
+		}
+		if _, err := io.Copy(tw, f); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("write %s: %w", rel, err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", rel, err)
+		}
+	}
+
+	return nil
+}
+
+func isPathWithinDir(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func ExtractPackage(packagePath, destDir string) (err error) {
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("create destination dir: %w", err)
+	}
+
+	file, err := os.Open(packagePath)
+	if err != nil {
+		return fmt.Errorf("open package %q: %w", packagePath, err)
+	}
+	defer joinCloseError(&err, fmt.Sprintf("close package %q", packagePath), file)
+
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("open gzip stream: %w", err)
+	}
+	defer joinCloseError(&err, "close gzip stream", gzr)
+
+	tr := tar.NewReader(gzr)
+	seen := make(map[string]struct{})
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read tar stream: %w", err)
+		}
+
+		rel, err := archiveEntryPath(hdr.Name)
+		if err != nil {
+			return err
+		}
+		if _, ok := seen[rel]; ok {
+			return fmt.Errorf("archive entry %q appears more than once", rel)
+		}
+		seen[rel] = struct{}{}
+		target := filepath.Join(destDir, filepath.FromSlash(rel))
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
+				return fmt.Errorf("create directory %s: %w", rel, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return fmt.Errorf("create parent dir for %s: %w", rel, err)
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode))
+			if err != nil {
+				return fmt.Errorf("create file %s: %w", rel, err)
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				_ = f.Close()
+				return fmt.Errorf("extract file %s: %w", rel, err)
+			}
+			if err := f.Close(); err != nil {
+				return fmt.Errorf("close file %s: %w", rel, err)
+			}
+		default:
+			return fmt.Errorf("unsupported tar entry type for %s", rel)
+		}
+	}
+}
+
+func ReadArchiveEntry(packagePath, wanted string) (_ []byte, err error) {
+	file, err := os.Open(packagePath)
+	if err != nil {
+		return nil, fmt.Errorf("open package %q: %w", packagePath, err)
+	}
+	defer joinCloseError(&err, fmt.Sprintf("close package %q", packagePath), file)
+
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, fmt.Errorf("open gzip stream: %w", err)
+	}
+	defer joinCloseError(&err, "close gzip stream", gzr)
+
+	tr := tar.NewReader(gzr)
+	var found []byte
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tar stream: %w", err)
+		}
+		if hdr.FileInfo().IsDir() {
+			continue
+		}
+		name, err := archiveEntryPath(hdr.Name)
+		if err != nil {
+			return nil, err
+		}
+		if name != wanted {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("archive entry %q appears more than once", wanted)
+		}
+		found, err = io.ReadAll(tr)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", wanted, err)
+		}
+	}
+	if found == nil {
+		return nil, fmt.Errorf("package %q does not contain %s", packagePath, wanted)
+	}
+	return found, nil
+}
+
+func ValidatePackageDir(sourceDir string) (*providermanifestv1.Manifest, error) {
+	_, manifest, err := loadManifestFromDir(sourceDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, artifact := range manifest.Artifacts {
+		path := filepath.Join(sourceDir, filepath.FromSlash(artifact.Path))
+		sum, err := fileSHA256(path)
+		if err != nil {
+			return nil, fmt.Errorf("validate artifact %s: %w", artifact.Path, err)
+		}
+		if sum != artifact.SHA256 {
+			return nil, fmt.Errorf("artifact %s sha256 %s does not match manifest %s", artifact.Path, sum, artifact.SHA256)
+		}
+	}
+	for _, ref := range LocalPackageReferences(manifest) {
+		refPath := filepath.Join(sourceDir, filepath.FromSlash(ref.Path))
+		if _, err := os.Stat(refPath); err != nil {
+			return nil, fmt.Errorf("validate %s %s: %w", ref.Description, ref.Path, err)
+		}
+	}
+	staticCatalog, err := ReadStaticCatalog(sourceDir, "")
+	if err != nil {
+		return nil, err
+	}
+	if staticCatalog == nil && StaticCatalogRequired(manifest) {
+		return nil, fmt.Errorf("validate provider static catalog %s: file does not exist", StaticCatalogFile)
+	}
+	return manifest, nil
+}
+
+func loadManifestFromDir(sourceDir string) ([]byte, *providermanifestv1.Manifest, error) {
+	p, err := FindManifestFile(sourceDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ReadManifestFile(p)
+}
+
+func archiveEntryPath(name string) (string, error) {
+	if strings.Contains(name, "\\") {
+		return "", fmt.Errorf("archive entry %q must use forward slashes", name)
+	}
+	cleaned := path.Clean(strings.TrimPrefix(name, "./"))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("archive entry %q escapes the package root", name)
+	}
+	return cleaned, nil
+}
+
+func fileSHA256(path string) (_ string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer joinCloseError(&err, fmt.Sprintf("close %q", path), f)
+	sum := sha256.New()
+	if _, err := io.Copy(sum, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(sum.Sum(nil)), nil
+}
+
+func joinCloseError(errp *error, label string, closer io.Closer) {
+	if closeErr := closer.Close(); closeErr != nil {
+		*errp = errors.Join(*errp, fmt.Errorf("%s: %w", label, closeErr))
+	}
+}

--- a/gestaltd/services/plugins/packageio/catalog.go
+++ b/gestaltd/services/plugins/packageio/catalog.go
@@ -1,0 +1,47 @@
+package packageio
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+const StaticCatalogFile = "catalog.yaml"
+
+func StaticCatalogPath(rootDir string) string {
+	if rootDir == "" {
+		return StaticCatalogFile
+	}
+	return filepath.Join(rootDir, StaticCatalogFile)
+}
+
+func StaticCatalogRequired(manifest *providermanifestv1.Manifest) bool {
+	return manifest != nil && manifest.Kind == providermanifestv1.KindPlugin && manifest.Spec != nil && !manifest.Spec.IsManifestBacked()
+}
+
+func ReadStaticCatalog(rootDir, name string) (*catalog.Catalog, error) {
+	catalogPath := StaticCatalogPath(rootDir)
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read static catalog %q: %w", catalogPath, err)
+	}
+
+	var cat catalog.Catalog
+	if err := decodeStrict(data, ManifestFormatFromPath(catalogPath), "static catalog", &cat); err != nil {
+		return nil, err
+	}
+
+	if cat.Name == "" && name != "" {
+		cat.Name = name
+	}
+	if err := cat.Validate(); err != nil {
+		return nil, fmt.Errorf("validate static catalog %q: %w", catalogPath, err)
+	}
+	return &cat, nil
+}

--- a/gestaltd/services/plugins/packageio/digest.go
+++ b/gestaltd/services/plugins/packageio/digest.go
@@ -1,0 +1,94 @@
+package packageio
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func ArchiveDigest(archivePath string) (string, error) {
+	sum, err := FileSHA256(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("digest archive: %w", err)
+	}
+	return sum, nil
+}
+
+func FileSHA256(path string) (string, error) {
+	return fileSHA256(path)
+}
+
+func DirectoryDigest(dirPath, manifestPath string, manifest *providermanifestv1.Manifest) (string, error) {
+	if manifest == nil {
+		return "", fmt.Errorf("manifest is required")
+	}
+
+	var digests []string
+
+	if manifestPath == "" {
+		var err error
+		manifestPath, err = FindManifestFile(dirPath)
+		if err != nil {
+			return "", fmt.Errorf("digest manifest: %w", err)
+		}
+	}
+	manifestSum, err := FileSHA256(manifestPath)
+	if err != nil {
+		return "", fmt.Errorf("digest manifest: %w", err)
+	}
+	digests = append(digests, manifestSum)
+
+	for _, artifact := range manifest.Artifacts {
+		sum, err := FileSHA256(filepath.Join(dirPath, filepath.FromSlash(artifact.Path)))
+		if err != nil {
+			return "", fmt.Errorf("digest artifact %s: %w", artifact.Path, err)
+		}
+		digests = append(digests, sum)
+	}
+
+	for _, ref := range LocalPackageReferences(manifest) {
+		sum, err := FileSHA256(filepath.Join(dirPath, filepath.FromSlash(ref.Path)))
+		if err != nil {
+			return "", fmt.Errorf("digest %s: %w", ref.Description, err)
+		}
+		digests = append(digests, sum)
+	}
+	staticCatalogPath := StaticCatalogPath(dirPath)
+	if _, err := os.Stat(staticCatalogPath); err == nil {
+		sum, err := FileSHA256(staticCatalogPath)
+		if err != nil {
+			return "", fmt.Errorf("digest provider static catalog: %w", err)
+		}
+		digests = append(digests, sum)
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("digest provider static catalog: %w", err)
+	} else if StaticCatalogRequired(manifest) {
+		return "", fmt.Errorf("digest provider static catalog: %s does not exist", StaticCatalogFile)
+	}
+
+	if manifest.Spec != nil && manifest.Spec.AssetRoot != "" {
+		assetDir := filepath.Join(dirPath, filepath.FromSlash(manifest.Spec.AssetRoot))
+		if err := filepath.WalkDir(assetDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return err
+			}
+			sum, err := FileSHA256(path)
+			if err != nil {
+				return fmt.Errorf("digest asset %s: %w", path, err)
+			}
+			rel, _ := filepath.Rel(assetDir, path)
+			digests = append(digests, rel+"="+sum)
+			return nil
+		}); err != nil {
+			return "", fmt.Errorf("digest ui assets: %w", err)
+		}
+	}
+
+	combined := sha256.Sum256([]byte(strings.Join(digests, "\n")))
+	return hex.EncodeToString(combined[:]), nil
+}

--- a/gestaltd/services/plugins/packageio/manifest.go
+++ b/gestaltd/services/plugins/packageio/manifest.go
@@ -1,0 +1,771 @@
+package packageio
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"mime"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/httpbinding"
+	"github.com/valon-technologies/gestalt/server/services/plugins/source"
+	"gopkg.in/yaml.v3"
+)
+
+const ManifestFile = "manifest.json"
+
+var ManifestFiles = []string{"manifest.json", "manifest.yaml", "manifest.yml"}
+
+const (
+	ManifestFormatJSON = "json"
+	ManifestFormatYAML = "yaml"
+)
+
+func FindManifestFile(dir string) (string, error) {
+	return FindManifestFileIn(dir, ManifestFiles)
+}
+
+func FindManifestFileIn(dir string, names []string) (string, error) {
+	for _, name := range names {
+		p := filepath.Join(dir, name)
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("no manifest file found in %s (tried %s)", dir, strings.Join(names, ", "))
+}
+
+func IsManifestFile(path string) bool {
+	return IsManifestFileIn(path, ManifestFiles)
+}
+
+func IsManifestFileIn(path string, names []string) bool {
+	base := filepath.Base(path)
+	return slices.Contains(names, base)
+}
+
+func ManifestFormatFromPath(path string) string {
+	if isYAMLFile(path) {
+		return ManifestFormatYAML
+	}
+	return ManifestFormatJSON
+}
+
+func isYAMLFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+func DecodeManifest(data []byte) (*providermanifestv1.Manifest, error) {
+	return DecodeManifestFormat(data, ManifestFormatJSON)
+}
+
+func DecodeSourceManifestFormat(data []byte, format string) (*providermanifestv1.Manifest, error) {
+	return decodeManifest(data, format, true)
+}
+
+func DecodeManifestFormat(data []byte, format string) (*providermanifestv1.Manifest, error) {
+	return decodeManifest(data, format, false)
+}
+
+func decodeManifest(data []byte, format string, sourceMode bool) (*providermanifestv1.Manifest, error) {
+	var manifest providermanifestv1.Manifest
+	if err := decodeStrict(data, format, "manifest", &manifest); err != nil {
+		return nil, err
+	}
+	if err := validateManifest(&manifest, sourceMode); err != nil {
+		return nil, err
+	}
+	if _, err := normalizeManifestKind(&manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+var validManifestKinds = map[string]bool{
+	providermanifestv1.KindPlugin:              true,
+	providermanifestv1.KindAuthentication:      true,
+	providermanifestv1.KindAuthorization:       true,
+	providermanifestv1.KindExternalCredentials: true,
+	providermanifestv1.KindIndexedDB:           true,
+	providermanifestv1.KindCache:               true,
+	providermanifestv1.KindS3:                  true,
+	providermanifestv1.KindWorkflow:            true,
+	providermanifestv1.KindAgent:               true,
+	providermanifestv1.KindSecrets:             true,
+	providermanifestv1.KindUI:                  true,
+	providermanifestv1.KindRuntime:             true,
+}
+
+func ManifestKind(manifest *providermanifestv1.Manifest) (string, error) {
+	if manifest == nil {
+		return "", fmt.Errorf("manifest is required")
+	}
+	if manifest.Kind == "" {
+		return "", fmt.Errorf("manifest kind is required")
+	}
+	kind := providermanifestv1.NormalizeKind(manifest.Kind)
+	if !validManifestKinds[manifest.Kind] && !validManifestKinds[kind] {
+		return "", fmt.Errorf("manifest kind %q is not valid; expected one of plugin, authentication, authorization, external_credentials, indexeddb, cache, s3, workflow, agent, secrets, runtime, or ui", manifest.Kind)
+	}
+	return kind, nil
+}
+
+func normalizeManifestKind(manifest *providermanifestv1.Manifest) (string, error) {
+	kind, err := ManifestKind(manifest)
+	if err != nil {
+		return "", err
+	}
+	manifest.Kind = kind
+	return kind, nil
+}
+
+func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) error {
+	if manifest == nil {
+		return fmt.Errorf("manifest is required")
+	}
+
+	if manifest.Source == "" {
+		return fmt.Errorf("manifest source is required")
+	}
+	if _, err := source.Parse(manifest.Source); err != nil {
+		return fmt.Errorf("manifest source: %w", err)
+	}
+	if err := source.ValidateVersion(manifest.Version); err != nil {
+		return fmt.Errorf("manifest version: %w", err)
+	}
+	if manifest.IconFile != "" {
+		if err := validateRelativePackagePath(manifest.IconFile, "iconFile"); err != nil {
+			return err
+		}
+	}
+	if manifest.Release != nil {
+		if !sourceMode {
+			return fmt.Errorf("release metadata is only allowed in source manifests")
+		}
+		if err := validateReleaseMetadata(manifest.Release); err != nil {
+			return err
+		}
+	}
+	kind, err := ManifestKind(manifest)
+	if err != nil {
+		return err
+	}
+
+	allowsSourceEntrypointOmission := sourceMode && manifest.Entrypoint == nil
+
+	needsArtifacts := len(manifest.Artifacts) > 0
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		needsArtifacts = needsArtifacts || manifest.Entrypoint != nil
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		needsArtifacts = needsArtifacts || !allowsSourceEntrypointOmission
+	}
+
+	var artifactPaths map[string]struct{}
+	if needsArtifacts {
+		artifactPaths = make(map[string]struct{}, len(manifest.Artifacts))
+		artifactPlatforms := make(map[string]struct{}, len(manifest.Artifacts))
+		for _, artifact := range manifest.Artifacts {
+			if err := validateRelativePackagePath(artifact.Path, "artifact path"); err != nil {
+				return err
+			}
+			if artifact.SHA256 == "" && !sourceMode {
+				return fmt.Errorf("artifact %s sha256 is required", artifact.Path)
+			}
+			if _, exists := artifactPaths[artifact.Path]; exists {
+				return fmt.Errorf("duplicate artifact path %q", artifact.Path)
+			}
+			artifactPaths[artifact.Path] = struct{}{}
+
+			key := PlatformString(artifact.OS, artifact.Arch)
+			if _, exists := artifactPlatforms[key]; exists {
+				return fmt.Errorf("duplicate artifact platform %q", key)
+			}
+			artifactPlatforms[key] = struct{}{}
+		}
+	}
+
+	spec := manifest.Spec
+	if spec != nil && spec.ConfigSchemaPath != "" {
+		if err := validateRelativePackagePath(spec.ConfigSchemaPath, "spec config schema path"); err != nil {
+			return err
+		}
+	}
+
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		if spec == nil {
+			return fmt.Errorf("spec is required for plugin manifests")
+		}
+		if err := validateExecutableProviderMetadata(spec); err != nil {
+			return err
+		}
+		if err := validateOwnedUI(spec.UI, sourceMode); err != nil {
+			return err
+		}
+		if spec != nil && spec.IsDeclarative() {
+			if err := validateDeclarativeProvider(spec); err != nil {
+				return err
+			}
+		}
+		switch {
+		case manifest.Entrypoint != nil:
+			if err := validateEntrypoint(kind, manifest.Entrypoint, artifactPaths); err != nil {
+				return err
+			}
+		case manifest.IsDeclarativeOnlyProvider():
+		case spec != nil && spec.IsSpecLoaded():
+		case allowsSourceEntrypointOmission:
+		default:
+			return fmt.Errorf("entrypoint is required")
+		}
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		if manifest.Entrypoint == nil && !allowsSourceEntrypointOmission {
+			return fmt.Errorf("entrypoint is required")
+		}
+		if manifest.Entrypoint != nil {
+			if err := validateEntrypoint(kind, manifest.Entrypoint, artifactPaths); err != nil {
+				return err
+			}
+		}
+	case providermanifestv1.KindUI:
+		if manifest.Entrypoint != nil {
+			return fmt.Errorf("ui manifests may not define entrypoints")
+		}
+		if spec == nil || spec.AssetRoot == "" {
+			return fmt.Errorf("spec.assetRoot is required for ui manifests")
+		}
+		if err := validateRelativePackagePath(spec.AssetRoot, "spec.assetRoot"); err != nil {
+			return err
+		}
+		if err := validateUIRoutes(spec.Routes); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported manifest kind %q", kind)
+	}
+
+	return nil
+}
+
+func validateOwnedUI(ownedUI *providermanifestv1.OwnedUI, sourceMode bool) error {
+	if ownedUI == nil {
+		return nil
+	}
+	pathValue := strings.TrimSpace(ownedUI.Path)
+	if pathValue != "" {
+		if !sourceMode {
+			if err := validateRelativePackagePath(pathValue, "spec.ui.path"); err != nil {
+				return err
+			}
+			ownedUI.Path = pathValue
+		} else {
+			if filepath.IsAbs(pathValue) {
+				return fmt.Errorf("spec.ui.path must be relative")
+			}
+			cleaned := path.Clean(filepath.ToSlash(pathValue))
+			if cleaned == "." || cleaned == "" {
+				return fmt.Errorf("spec.ui.path must not be empty")
+			}
+			ownedUI.Path = cleaned
+		}
+		return nil
+	}
+	return fmt.Errorf("spec.ui.path is required when spec.ui is set")
+}
+
+func validateUIRoutes(routes []providermanifestv1.UIRoute) error {
+	seenPaths := make(map[string]struct{}, len(routes))
+	for i := range routes {
+		normalized, err := NormalizeUIRoutePath(fmt.Sprintf("spec.routes[%d].path", i), routes[i].Path)
+		if err != nil {
+			return err
+		}
+		routes[i].Path = normalized
+		if _, exists := seenPaths[normalized]; exists {
+			return fmt.Errorf("spec.routes[%d].path %q duplicates another route", i, normalized)
+		}
+		seenPaths[normalized] = struct{}{}
+
+		roles, err := NormalizeUIAllowedRoles(fmt.Sprintf("spec.routes[%d].allowedRoles", i), routes[i].AllowedRoles)
+		if err != nil {
+			return err
+		}
+		routes[i].AllowedRoles = roles
+	}
+	return nil
+}
+
+func ValidatePolicyBoundUIRoutes(routes []providermanifestv1.UIRoute) error {
+	if len(routes) == 0 {
+		return fmt.Errorf("policy-bound UIs must declare at least one route")
+	}
+	coversRoot := false
+	for i := range routes {
+		if len(routes[i].AllowedRoles) == 0 {
+			return fmt.Errorf("spec.routes[%d].allowedRoles must not be empty", i)
+		}
+		if UIRouteMatches(routes[i].Path, "/") {
+			coversRoot = true
+		}
+	}
+	if !coversRoot {
+		return fmt.Errorf("policy-bound UIs must declare a route covering /")
+	}
+	return nil
+}
+
+func CurrentPlatformArtifact(manifest *providermanifestv1.Manifest) (*providermanifestv1.Artifact, error) {
+	if manifest == nil {
+		return nil, fmt.Errorf("manifest is required")
+	}
+	for i := range manifest.Artifacts {
+		a := &manifest.Artifacts[i]
+		if a.OS == runtime.GOOS && a.Arch == runtime.GOARCH {
+			return a, nil
+		}
+	}
+	return nil, fmt.Errorf("no artifact for current platform %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+func EntrypointForKind(manifest *providermanifestv1.Manifest, _ string) *providermanifestv1.Entrypoint {
+	if manifest == nil {
+		return nil
+	}
+	return manifest.Entrypoint
+}
+
+func EnsureEntrypoint(manifest *providermanifestv1.Manifest) *providermanifestv1.Entrypoint {
+	if manifest.Entrypoint == nil {
+		manifest.Entrypoint = &providermanifestv1.Entrypoint{}
+	}
+	return manifest.Entrypoint
+}
+
+func validateEntrypoint(_ string, entry *providermanifestv1.Entrypoint, artifactPaths map[string]struct{}) error {
+	if entry == nil {
+		return fmt.Errorf("entrypoint is required")
+	}
+	if entry.ArtifactPath == "" {
+		return fmt.Errorf("entrypoint.artifactPath is required")
+	}
+	if err := validateRelativePackagePath(entry.ArtifactPath, "entrypoint.artifactPath"); err != nil {
+		return err
+	}
+	if len(artifactPaths) == 0 {
+		return fmt.Errorf("entrypoint references unknown artifact %q", entry.ArtifactPath)
+	}
+	if _, ok := artifactPaths[entry.ArtifactPath]; !ok {
+		return fmt.Errorf("entrypoint references unknown artifact %q", entry.ArtifactPath)
+	}
+	return nil
+}
+
+func validateRelativePackagePath(value, label string) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", label)
+	}
+	if strings.HasPrefix(value, "/") {
+		return fmt.Errorf("%s must be relative", label)
+	}
+	cleaned := path.Clean(value)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return fmt.Errorf("%s must stay within the package", label)
+	}
+	if strings.Contains(value, "\\") {
+		return fmt.Errorf("%s must use forward slashes", label)
+	}
+	if cleaned != value {
+		return fmt.Errorf("%s must be normalized", label)
+	}
+	return nil
+}
+
+func validateReleaseMetadata(release *providermanifestv1.ReleaseMetadata) error {
+	if release == nil || release.Build == nil {
+		return nil
+	}
+	if release.Build.Workdir != "" {
+		if err := validateRelativePackagePath(release.Build.Workdir, "release.build.workdir"); err != nil {
+			return err
+		}
+	}
+	if len(release.Build.Command) == 0 {
+		return fmt.Errorf("release.build.command is required")
+	}
+	for i, arg := range release.Build.Command {
+		if strings.TrimSpace(arg) == "" {
+			return fmt.Errorf("release.build.command[%d] is required", i)
+		}
+	}
+	return nil
+}
+
+func validateProviderAuth(path string, auth *providermanifestv1.ProviderAuth) error {
+	if auth == nil {
+		return nil
+	}
+	switch auth.Type {
+	case providermanifestv1.AuthTypeOAuth2:
+		if auth.AuthorizationURL == "" {
+			return fmt.Errorf("%s.authorizationUrl is required for oauth2", path)
+		}
+		if auth.TokenURL == "" {
+			return fmt.Errorf("%s.tokenUrl is required for oauth2", path)
+		}
+	case providermanifestv1.AuthTypeMCPOAuth, providermanifestv1.AuthTypeBearer, providermanifestv1.AuthTypeManual, providermanifestv1.AuthTypeNone:
+	default:
+		return fmt.Errorf("unsupported %s.type %q", path, auth.Type)
+	}
+	return nil
+}
+
+func validateRouteAuthRef(path string, auth *providermanifestv1.RouteAuthRef) error {
+	if auth == nil {
+		return nil
+	}
+	if strings.TrimSpace(auth.Provider) == "" {
+		return fmt.Errorf("%s.provider is required", path)
+	}
+	return nil
+}
+
+func normalizeHTTPBindingPath(field, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s is required", field)
+	}
+	if strings.Contains(value, "*") {
+		return "", fmt.Errorf("%s must not contain wildcards", field)
+	}
+	cleaned := path.Clean(strings.ReplaceAll(value, "\\", "/"))
+	if cleaned == "." {
+		cleaned = "/"
+	}
+	if !strings.HasPrefix(cleaned, "/") {
+		cleaned = "/" + cleaned
+	}
+	return cleaned, nil
+}
+
+func normalizeHTTPContentType(field, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s must not be empty", field)
+	}
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return "", fmt.Errorf("%s must be a valid media type", field)
+	}
+	return strings.ToLower(mediaType), nil
+}
+
+func validateHTTPSecurityScheme(path string, scheme *providermanifestv1.HTTPSecurityScheme) error {
+	return httpbinding.ValidateHTTPSecurityScheme(path, scheme)
+}
+
+func validateHTTPBinding(path string, binding *providermanifestv1.HTTPBinding, schemes map[string]*providermanifestv1.HTTPSecurityScheme) error {
+	if binding == nil {
+		return fmt.Errorf("%s is required", path)
+	}
+	normalizedPath, err := normalizeHTTPBindingPath(path+".path", binding.Path)
+	if err != nil {
+		return err
+	}
+	binding.Path = normalizedPath
+	method := strings.ToUpper(strings.TrimSpace(binding.Method))
+	if !validHTTPMethods[method] {
+		return fmt.Errorf("%s.method %q is not a valid HTTP method", path, binding.Method)
+	}
+	binding.Method = method
+	binding.CredentialMode = providermanifestv1.ConnectionMode(strings.TrimSpace(string(binding.CredentialMode)))
+	switch binding.CredentialMode {
+	case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser:
+	default:
+		return fmt.Errorf("%s.credentialMode %q is not supported", path, binding.CredentialMode)
+	}
+	if strings.TrimSpace(binding.Target) == "" {
+		return fmt.Errorf("%s.target is required", path)
+	}
+	binding.Target = strings.TrimSpace(binding.Target)
+	binding.Security = strings.TrimSpace(binding.Security)
+	if binding.Security == "" {
+		return fmt.Errorf("%s.security is required", path)
+	}
+	if schemes == nil || schemes[binding.Security] == nil {
+		return fmt.Errorf("%s.security %q references an undefined security scheme", path, binding.Security)
+	}
+	if binding.RequestBody != nil {
+		normalizedContent := make(map[string]*providermanifestv1.HTTPMediaType, len(binding.RequestBody.Content))
+		for mediaType := range binding.RequestBody.Content {
+			normalizedMediaType, err := normalizeHTTPContentType(path+".requestBody.content", mediaType)
+			if err != nil {
+				return err
+			}
+			if _, exists := normalizedContent[normalizedMediaType]; exists {
+				return fmt.Errorf("%s.requestBody.content %q is duplicated after normalization", path, normalizedMediaType)
+			}
+			normalizedContent[normalizedMediaType] = binding.RequestBody.Content[mediaType]
+		}
+		binding.RequestBody.Content = normalizedContent
+	}
+	if binding.Ack != nil {
+		if binding.Ack.Status == 0 {
+			binding.Ack.Status = 200
+		}
+		if binding.Ack.Status < 200 || binding.Ack.Status > 299 {
+			return fmt.Errorf("%s.ack.status must be a 2xx status", path)
+		}
+	}
+	return nil
+}
+
+func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error {
+	if provider == nil {
+		return nil
+	}
+	if err := validateRouteAuthRef("provider.auth", provider.RouteAuth); err != nil {
+		return err
+	}
+	for name, scheme := range provider.SecuritySchemes {
+		if err := validateHTTPSecurityScheme(fmt.Sprintf("provider.securitySchemes.%s", name), scheme); err != nil {
+			return err
+		}
+	}
+	for name, binding := range provider.HTTP {
+		if err := validateHTTPBinding(fmt.Sprintf("provider.http.%s", name), binding, provider.SecuritySchemes); err != nil {
+			return err
+		}
+	}
+	for name, conn := range provider.Connections {
+		if conn == nil {
+			continue
+		}
+		if err := validateProviderAuth(fmt.Sprintf("provider.connections.%s.auth", name), conn.Auth); err != nil {
+			return err
+		}
+		if conn.Auth != nil && conn.Auth.Type == providermanifestv1.AuthTypeMCPOAuth && provider.MCPURL() == "" {
+			return fmt.Errorf("provider.connections.%s.auth.type %q requires an MCP surface", name, providermanifestv1.AuthTypeMCPOAuth)
+		}
+		if conn.Mode == "" {
+		} else {
+			switch conn.Mode {
+			case providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser, providermanifestv1.ConnectionModePlatform:
+			default:
+				return fmt.Errorf("unsupported provider.connections.%s.mode %q", name, conn.Mode)
+			}
+		}
+		if conn.Exposure != "" {
+			switch conn.Exposure {
+			case providermanifestv1.ConnectionExposureUser, providermanifestv1.ConnectionExposureInternal:
+			default:
+				return fmt.Errorf("unsupported provider.connections.%s.exposure %q", name, conn.Exposure)
+			}
+			if conn.Exposure == providermanifestv1.ConnectionExposureInternal && manifestConnectionMode(conn) == providermanifestv1.ConnectionModeUser {
+				return fmt.Errorf("provider.connections.%s exposure %q is not supported for user-owned connections", name, conn.Exposure)
+			}
+		}
+	}
+	if provider.DefaultConnection != "" {
+		if _, ok := provider.Connections[provider.DefaultConnection]; !ok {
+			return fmt.Errorf("provider.defaultConnection %q references undefined provider.connections entry", provider.DefaultConnection)
+		}
+	}
+	if len(provider.Connections) > 0 {
+		for name := range provider.Connections {
+			if strings.TrimSpace(name) == "" {
+				return fmt.Errorf("provider.connections keys must be non-empty")
+			}
+		}
+	}
+	checks := []struct {
+		field   string
+		present bool
+	}{
+		{field: "provider.baseUrl", present: provider.RESTBaseURL() != "" && !provider.IsDeclarative() && provider.OpenAPIDocument() == ""},
+		{field: "provider.operations", present: len(provider.RESTOperations()) > 0 && !provider.IsDeclarative()},
+	}
+	for _, check := range checks {
+		if check.present {
+			return fmt.Errorf("%s is no longer supported for executable providers", check.field)
+		}
+	}
+	return nil
+}
+
+func manifestConnectionMode(conn *providermanifestv1.ManifestConnectionDef) providermanifestv1.ConnectionMode {
+	if conn == nil {
+		return providermanifestv1.ConnectionModeNone
+	}
+	if conn.Mode != "" {
+		return conn.Mode
+	}
+	if conn.Auth == nil || conn.Auth.Type == "" || conn.Auth.Type == providermanifestv1.AuthTypeNone {
+		return providermanifestv1.ConnectionModeNone
+	}
+	return providermanifestv1.ConnectionModeUser
+}
+
+var validParamIn = map[string]bool{
+	"query": true,
+	"body":  true,
+	"path":  true,
+}
+
+var validHTTPMethods = map[string]bool{
+	"GET":    true,
+	"POST":   true,
+	"PUT":    true,
+	"PATCH":  true,
+	"DELETE": true,
+}
+
+func validateDeclarativeProvider(provider *providermanifestv1.Spec) error {
+	if provider.RESTBaseURL() == "" {
+		return fmt.Errorf("provider.baseUrl is required for declarative providers")
+	}
+	ops := provider.RESTOperations()
+	seen := make(map[string]struct{}, len(ops))
+	for i := range ops {
+		op := &ops[i]
+		if op.Name == "" {
+			return fmt.Errorf("provider.operations[%d].name is required", i)
+		}
+		if _, exists := seen[op.Name]; exists {
+			return fmt.Errorf("duplicate operation name %q", op.Name)
+		}
+		seen[op.Name] = struct{}{}
+		if !validHTTPMethods[op.Method] {
+			return fmt.Errorf("provider.operations[%d].method %q is not a valid HTTP method", i, op.Method)
+		}
+		if op.Path == "" {
+			return fmt.Errorf("provider.operations[%d].path is required", i)
+		}
+		seenParams := make(map[string]struct{}, len(op.Parameters))
+		for j, param := range op.Parameters {
+			if param.Name == "" {
+				return fmt.Errorf("provider.operations[%d].parameters[%d].name is required", i, j)
+			}
+			if _, dup := seenParams[param.Name]; dup {
+				return fmt.Errorf("provider.operations[%d] has duplicate parameter name %q", i, param.Name)
+			}
+			seenParams[param.Name] = struct{}{}
+			if !validParamIn[param.In] {
+				return fmt.Errorf("provider.operations[%d].parameters[%d].in %q must be query, body, or path", i, j, param.In)
+			}
+			if param.In == "path" && !strings.Contains(op.Path, "{"+param.Name+"}") {
+				return fmt.Errorf("provider.operations[%d].parameters[%d] %q declared as path param but %q has no {%s} placeholder", i, j, param.Name, op.Path, param.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func EncodeManifest(manifest *providermanifestv1.Manifest) ([]byte, error) {
+	return EncodeManifestFormat(manifest, ManifestFormatJSON)
+}
+
+func EncodeManifestFormat(manifest *providermanifestv1.Manifest, format string) ([]byte, error) {
+	return encodeManifestFormat(manifest, format, false)
+}
+
+func EncodeSourceManifestFormat(manifest *providermanifestv1.Manifest, format string) ([]byte, error) {
+	return encodeManifestFormat(manifest, format, true)
+}
+
+func encodeManifestFormat(manifest *providermanifestv1.Manifest, format string, sourceMode bool) ([]byte, error) {
+	encodedManifest, err := CloneManifest(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("clone manifest: %w", err)
+	}
+	if err := validateManifest(encodedManifest, sourceMode); err != nil {
+		return nil, err
+	}
+	if _, err := normalizeManifestKind(encodedManifest); err != nil {
+		return nil, err
+	}
+	switch format {
+	case ManifestFormatJSON:
+		return encodeManifestJSON(encodedManifest)
+	case ManifestFormatYAML:
+		return encodeManifestYAML(encodedManifest)
+	default:
+		return nil, fmt.Errorf("unsupported manifest format %q", format)
+	}
+}
+
+func CloneManifest(manifest *providermanifestv1.Manifest) (*providermanifestv1.Manifest, error) {
+	if manifest == nil {
+		return nil, nil
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	var cloned providermanifestv1.Manifest
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return nil, err
+	}
+	return &cloned, nil
+}
+
+func encodeManifestJSON(manifest *providermanifestv1.Manifest) ([]byte, error) {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal manifest: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func encodeManifestYAML(manifest *providermanifestv1.Manifest) ([]byte, error) {
+	data, err := yaml.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("marshal manifest YAML: %w", err)
+	}
+	return data, nil
+}
+
+func decodeStrict(data []byte, format, subject string, target any) error {
+	switch format {
+	case ManifestFormatJSON:
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(target); err != nil {
+			return fmt.Errorf("parse %s JSON: %w", subject, err)
+		}
+		return nil
+	case ManifestFormatYAML:
+		dec := yaml.NewDecoder(bytes.NewReader(data))
+		dec.KnownFields(true)
+		if err := dec.Decode(target); err != nil {
+			return fmt.Errorf("parse %s YAML: %w", subject, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported %s format %q", subject, format)
+	}
+}
+
+func ManifestEqual(a, b *providermanifestv1.Manifest) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	aj, err := EncodeManifest(a)
+	if err != nil {
+		return false
+	}
+	bj, err := EncodeManifest(b)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(aj, bj)
+}

--- a/gestaltd/services/plugins/packageio/platform.go
+++ b/gestaltd/services/plugins/packageio/platform.go
@@ -1,0 +1,33 @@
+package packageio
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+func PlatformString(goos, goarch string) string {
+	return fmt.Sprintf("%s/%s", goos, goarch)
+}
+
+func PlatformArchiveSuffix(goos, goarch string) string {
+	return fmt.Sprintf("%s_%s", goos, goarch)
+}
+
+// CurrentPlatformString returns the platform string for the host running
+// this process (e.g. "darwin/arm64", "linux/amd64").
+func CurrentPlatformString() string {
+	return PlatformString(runtime.GOOS, runtime.GOARCH)
+}
+
+// ParsePlatformString parses "darwin/arm64" or "linux/amd64" into (goos, goarch).
+func ParsePlatformString(s string) (goos, goarch string, err error) {
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid platform string %q: expected os/arch", s)
+	}
+	if parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid platform string %q: empty component", s)
+	}
+	return parts[0], parts[1], nil
+}

--- a/gestaltd/services/plugins/packageio/references.go
+++ b/gestaltd/services/plugins/packageio/references.go
@@ -1,0 +1,104 @@
+package packageio
+
+import (
+	"path/filepath"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+type LocalPackageReference struct {
+	Path        string
+	Description string
+}
+
+func LocalPackageReferences(manifest *providermanifestv1.Manifest) []LocalPackageReference {
+	if manifest == nil {
+		return nil
+	}
+
+	refs := make([]LocalPackageReference, 0, 3)
+	seen := make(map[string]struct{}, 3)
+	add := func(path, description string) {
+		if path == "" {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		refs = append(refs, LocalPackageReference{
+			Path:        path,
+			Description: description,
+		})
+	}
+
+	if manifest.Spec != nil {
+		add(manifest.Spec.ConfigSchemaPath, "provider config schema")
+		if doc := manifest.Spec.OpenAPIDocument(); doc != "" && !strings.Contains(doc, "://") {
+			add(doc, "provider openapi document")
+		}
+		if url := manifest.Spec.GraphQLURL(); url != "" && !strings.Contains(url, "://") {
+			add(url, "provider graphql document")
+		}
+		if url := manifest.Spec.MCPURL(); url != "" && !strings.Contains(url, "://") {
+			add(url, "provider mcp document")
+		}
+	}
+	add(manifest.IconFile, "icon_file")
+	return refs
+}
+
+func ResolveManifestLocalReferences(manifest *providermanifestv1.Manifest, manifestPath string) *providermanifestv1.Manifest {
+	if manifest == nil || manifest.Spec == nil || manifestPath == "" {
+		return manifest
+	}
+	if manifest.Spec.Surfaces == nil {
+		return manifest
+	}
+
+	resolve := func(value string) string {
+		if value == "" || filepath.IsAbs(value) || strings.Contains(value, "://") {
+			return value
+		}
+		return filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(value))
+	}
+
+	provider := *manifest.Spec
+	surfaces := *provider.Surfaces
+	changed := false
+
+	if surfaces.OpenAPI != nil {
+		s := *surfaces.OpenAPI
+		if resolved := resolve(s.Document); resolved != s.Document {
+			s.Document = resolved
+			surfaces.OpenAPI = &s
+			changed = true
+		}
+	}
+	if surfaces.GraphQL != nil {
+		s := *surfaces.GraphQL
+		if resolved := resolve(s.URL); resolved != s.URL {
+			s.URL = resolved
+			surfaces.GraphQL = &s
+			changed = true
+		}
+	}
+	if surfaces.MCP != nil {
+		s := *surfaces.MCP
+		if resolved := resolve(s.URL); resolved != s.URL {
+			s.URL = resolved
+			surfaces.MCP = &s
+			changed = true
+		}
+	}
+
+	if !changed {
+		return manifest
+	}
+
+	provider.Surfaces = &surfaces
+	cloned := *manifest
+	cloned.Spec = &provider
+	return &cloned
+}

--- a/gestaltd/services/plugins/packageio/ui_routes.go
+++ b/gestaltd/services/plugins/packageio/ui_routes.go
@@ -1,0 +1,81 @@
+package packageio
+
+import (
+	"fmt"
+	stdpath "path"
+	"strings"
+)
+
+func NormalizeUIRoutePath(label, routePath string) (string, error) {
+	routePath = strings.TrimSpace(routePath)
+	if routePath == "" {
+		return "", fmt.Errorf("%s is required", label)
+	}
+	if !strings.HasPrefix(routePath, "/") {
+		return "", fmt.Errorf("%s must start with /", label)
+	}
+	if strings.ContainsAny(routePath, "{}") {
+		return "", fmt.Errorf("%s route patterns are not supported", label)
+	}
+	if strings.Contains(routePath, "*") {
+		if routePath != "/*" && (!strings.HasSuffix(routePath, "/*") || strings.Count(routePath, "*") != 1) {
+			return "", fmt.Errorf("%s wildcards are only supported as a terminal /*", label)
+		}
+		base := strings.TrimSuffix(routePath, "/*")
+		if base == "" {
+			return "/*", nil
+		}
+		base = stdpath.Clean(base)
+		if base == "." {
+			base = "/"
+		}
+		if base == "/" {
+			return "/*", nil
+		}
+		base = strings.TrimRight(base, "/")
+		return base + "/*", nil
+	}
+
+	routePath = stdpath.Clean(routePath)
+	if routePath == "." {
+		routePath = "/"
+	}
+	if routePath != "/" {
+		routePath = strings.TrimRight(routePath, "/")
+	}
+	return routePath, nil
+}
+
+func NormalizeUIAllowedRoles(label string, allowedRoles []string) ([]string, error) {
+	if len(allowedRoles) == 0 {
+		return nil, fmt.Errorf("%s must not be empty", label)
+	}
+	roles := allowedRoles[:0]
+	seenRoles := make(map[string]struct{}, len(allowedRoles))
+	for i, role := range allowedRoles {
+		role = strings.TrimSpace(role)
+		if role == "" {
+			return nil, fmt.Errorf("%s[%d] is required", label, i)
+		}
+		if _, exists := seenRoles[role]; exists {
+			continue
+		}
+		seenRoles[role] = struct{}{}
+		roles = append(roles, role)
+	}
+	return roles, nil
+}
+
+func UIRouteMatches(routePath, requestPath string) bool {
+	if routePath == "/*" {
+		return true
+	}
+	if strings.HasSuffix(routePath, "/*") {
+		base := strings.TrimSuffix(routePath, "/*")
+		return requestPath == base || strings.HasPrefix(requestPath, base+"/")
+	}
+	if routePath == "/" {
+		return requestPath == "/"
+	}
+	return requestPath == routePath
+}

--- a/gestaltd/services/plugins/providerpkg/archive.go
+++ b/gestaltd/services/plugins/providerpkg/archive.go
@@ -1,402 +1,42 @@
 package providerpkg
 
 import (
-	"archive/tar"
-	"compress/gzip"
-	"crypto/sha256"
-	"encoding/hex"
-	"errors"
-	"fmt"
-	"io"
-	"io/fs"
-	"os"
-	"path"
-	"path/filepath"
-	"slices"
-	"strings"
-	"time"
-
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 )
 
-func ReadPackageManifest(packagePath string) (_ []byte, _ *providermanifestv1.Manifest, err error) {
-	var firstErr error
-	for _, name := range ManifestFiles {
-		data, err := ReadArchiveEntry(packagePath, name)
-		if err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-		format := ManifestFormatFromPath(name)
-		manifest, err := DecodeManifestFormat(data, format)
-		if err != nil {
-			return nil, nil, err
-		}
-		return data, manifest, nil
-	}
-	return nil, nil, firstErr
+func ReadPackageManifest(packagePath string) ([]byte, *providermanifestv1.Manifest, error) {
+	return packageio.ReadPackageManifestIn(packagePath, ManifestFiles)
 }
 
 func ReadManifestFile(p string) ([]byte, *providermanifestv1.Manifest, error) {
-	data, err := os.ReadFile(p)
-	if err != nil {
-		return nil, nil, fmt.Errorf("read manifest %q: %w", p, err)
-	}
-	format := ManifestFormatFromPath(p)
-	manifest, err := DecodeManifestFormat(data, format)
-	if err != nil {
-		return nil, nil, err
-	}
-	return data, manifest, nil
+	return packageio.ReadManifestFile(p)
 }
 
 func ReadSourceManifestFile(p string) ([]byte, *providermanifestv1.Manifest, error) {
-	data, err := os.ReadFile(p)
-	if err != nil {
-		return nil, nil, fmt.Errorf("read manifest %q: %w", p, err)
-	}
-	format := ManifestFormatFromPath(p)
-	manifest, err := DecodeSourceManifestFormat(data, format)
-	if err != nil {
-		return nil, nil, err
-	}
-	return data, manifest, nil
+	return packageio.ReadSourceManifestFile(p)
 }
 
 func LoadManifestFromPath(inputPath string) ([]byte, *providermanifestv1.Manifest, string, error) {
-	info, err := os.Stat(inputPath)
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("stat %q: %w", inputPath, err)
-	}
-	if info.IsDir() {
-		manifestPath, err := FindManifestFile(inputPath)
-		if err != nil {
-			return nil, nil, "", err
-		}
-		data, manifest, err := ReadManifestFile(manifestPath)
-		return data, manifest, manifestPath, err
-	}
-	if IsManifestFile(inputPath) {
-		data, manifest, err := ReadManifestFile(inputPath)
-		return data, manifest, inputPath, err
-	}
-	data, manifest, err := ReadPackageManifest(inputPath)
-	return data, manifest, inputPath, err
+	return packageio.LoadManifestFromPathIn(inputPath, ManifestFiles)
 }
 
 func CopyPackageDir(sourceDir, destDir string) error {
-	sourceDir = filepath.Clean(sourceDir)
-	if _, err := ValidatePackageDir(sourceDir); err != nil {
-		return err
-	}
-	destDir = filepath.Clean(destDir)
-	if isPathWithinDir(sourceDir, destDir) {
-		return fmt.Errorf("output directory %q must not be inside source directory %q", destDir, sourceDir)
-	}
-	if err := os.MkdirAll(destDir, 0755); err != nil {
-		return fmt.Errorf("create output dir: %w", err)
-	}
-	return filepath.WalkDir(sourceDir, func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(sourceDir, p)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(destDir, rel)
-		if d.IsDir() {
-			return os.MkdirAll(target, 0755)
-		}
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-		src, err := os.Open(p)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = src.Close() }()
-		dst, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
-		if err != nil {
-			return err
-		}
-		if _, err := io.Copy(dst, src); err != nil {
-			_ = dst.Close()
-			return err
-		}
-		return dst.Close()
-	})
+	return packageio.CopyPackageDir(sourceDir, destDir)
 }
 
-func CreatePackageFromDir(sourceDir, outputPath string) (err error) {
-	sourceDir = filepath.Clean(sourceDir)
-	if _, err := ValidatePackageDir(sourceDir); err != nil {
-		return err
-	}
-	outputPath = filepath.Clean(outputPath)
-	if isPathWithinDir(sourceDir, outputPath) {
-		return fmt.Errorf("output archive %q must not be inside source directory %q", outputPath, sourceDir)
-	}
-
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
-		return fmt.Errorf("create output dir: %w", err)
-	}
-	out, err := os.Create(outputPath)
-	if err != nil {
-		return fmt.Errorf("create package %q: %w", outputPath, err)
-	}
-	defer joinCloseError(&err, fmt.Sprintf("close package %q", outputPath), out)
-
-	gzw := gzip.NewWriter(out)
-	gzw.ModTime = time.Unix(0, 0)
-	defer joinCloseError(&err, "close gzip stream", gzw)
-
-	tw := tar.NewWriter(gzw)
-	defer joinCloseError(&err, "close tar stream", tw)
-
-	var files []string
-	err = filepath.WalkDir(sourceDir, func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(sourceDir, p)
-		if err != nil {
-			return err
-		}
-		files = append(files, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("walk source dir: %w", err)
-	}
-	slices.Sort(files)
-
-	for _, rel := range files {
-		absPath := filepath.Join(sourceDir, filepath.FromSlash(rel))
-		info, err := os.Stat(absPath)
-		if err != nil {
-			return fmt.Errorf("stat %s: %w", rel, err)
-		}
-		hdr, err := tar.FileInfoHeader(info, "")
-		if err != nil {
-			return fmt.Errorf("build tar header for %s: %w", rel, err)
-		}
-		hdr.Name = rel
-		hdr.ModTime = time.Unix(0, 0)
-		hdr.AccessTime = time.Unix(0, 0)
-		hdr.ChangeTime = time.Unix(0, 0)
-		hdr.Uid = 0
-		hdr.Gid = 0
-		hdr.Uname = ""
-		hdr.Gname = ""
-		if err := tw.WriteHeader(hdr); err != nil {
-			return fmt.Errorf("write tar header for %s: %w", rel, err)
-		}
-		f, err := os.Open(absPath)
-		if err != nil {
-			return fmt.Errorf("open %s: %w", rel, err)
-		}
-		if _, err := io.Copy(tw, f); err != nil {
-			_ = f.Close()
-			return fmt.Errorf("write %s: %w", rel, err)
-		}
-		if err := f.Close(); err != nil {
-			return fmt.Errorf("close %s: %w", rel, err)
-		}
-	}
-
-	return nil
+func CreatePackageFromDir(sourceDir, outputPath string) error {
+	return packageio.CreatePackageFromDir(sourceDir, outputPath)
 }
 
-func isPathWithinDir(root, target string) bool {
-	rel, err := filepath.Rel(root, target)
-	if err != nil {
-		return false
-	}
-	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+func ExtractPackage(packagePath, destDir string) error {
+	return packageio.ExtractPackage(packagePath, destDir)
 }
 
-func ExtractPackage(packagePath, destDir string) (err error) {
-	if err := os.MkdirAll(destDir, 0755); err != nil {
-		return fmt.Errorf("create destination dir: %w", err)
-	}
-
-	file, err := os.Open(packagePath)
-	if err != nil {
-		return fmt.Errorf("open package %q: %w", packagePath, err)
-	}
-	defer joinCloseError(&err, fmt.Sprintf("close package %q", packagePath), file)
-
-	gzr, err := gzip.NewReader(file)
-	if err != nil {
-		return fmt.Errorf("open gzip stream: %w", err)
-	}
-	defer joinCloseError(&err, "close gzip stream", gzr)
-
-	tr := tar.NewReader(gzr)
-	seen := make(map[string]struct{})
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("read tar stream: %w", err)
-		}
-
-		rel, err := archiveEntryPath(hdr.Name)
-		if err != nil {
-			return err
-		}
-		if _, ok := seen[rel]; ok {
-			return fmt.Errorf("archive entry %q appears more than once", rel)
-		}
-		seen[rel] = struct{}{}
-		target := filepath.Join(destDir, filepath.FromSlash(rel))
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
-				return fmt.Errorf("create directory %s: %w", rel, err)
-			}
-		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-				return fmt.Errorf("create parent dir for %s: %w", rel, err)
-			}
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode))
-			if err != nil {
-				return fmt.Errorf("create file %s: %w", rel, err)
-			}
-			if _, err := io.Copy(f, tr); err != nil {
-				_ = f.Close()
-				return fmt.Errorf("extract file %s: %w", rel, err)
-			}
-			if err := f.Close(); err != nil {
-				return fmt.Errorf("close file %s: %w", rel, err)
-			}
-		default:
-			return fmt.Errorf("unsupported tar entry type for %s", rel)
-		}
-	}
-}
-
-func ReadArchiveEntry(packagePath, wanted string) (_ []byte, err error) {
-	file, err := os.Open(packagePath)
-	if err != nil {
-		return nil, fmt.Errorf("open package %q: %w", packagePath, err)
-	}
-	defer joinCloseError(&err, fmt.Sprintf("close package %q", packagePath), file)
-
-	gzr, err := gzip.NewReader(file)
-	if err != nil {
-		return nil, fmt.Errorf("open gzip stream: %w", err)
-	}
-	defer joinCloseError(&err, "close gzip stream", gzr)
-
-	tr := tar.NewReader(gzr)
-	var found []byte
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("read tar stream: %w", err)
-		}
-		if hdr.FileInfo().IsDir() {
-			continue
-		}
-		name, err := archiveEntryPath(hdr.Name)
-		if err != nil {
-			return nil, err
-		}
-		if name != wanted {
-			continue
-		}
-		if found != nil {
-			return nil, fmt.Errorf("archive entry %q appears more than once", wanted)
-		}
-		found, err = io.ReadAll(tr)
-		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", wanted, err)
-		}
-	}
-	if found == nil {
-		return nil, fmt.Errorf("package %q does not contain %s", packagePath, wanted)
-	}
-	return found, nil
+func ReadArchiveEntry(packagePath, wanted string) ([]byte, error) {
+	return packageio.ReadArchiveEntry(packagePath, wanted)
 }
 
 func ValidatePackageDir(sourceDir string) (*providermanifestv1.Manifest, error) {
-	_, manifest, err := loadManifestFromDir(sourceDir)
-	if err != nil {
-		return nil, err
-	}
-	for _, artifact := range manifest.Artifacts {
-		path := filepath.Join(sourceDir, filepath.FromSlash(artifact.Path))
-		sum, err := fileSHA256(path)
-		if err != nil {
-			return nil, fmt.Errorf("validate artifact %s: %w", artifact.Path, err)
-		}
-		if sum != artifact.SHA256 {
-			return nil, fmt.Errorf("artifact %s sha256 %s does not match manifest %s", artifact.Path, sum, artifact.SHA256)
-		}
-	}
-	for _, ref := range LocalPackageReferences(manifest) {
-		refPath := filepath.Join(sourceDir, filepath.FromSlash(ref.Path))
-		if _, err := os.Stat(refPath); err != nil {
-			return nil, fmt.Errorf("validate %s %s: %w", ref.Description, ref.Path, err)
-		}
-	}
-	staticCatalog, err := ReadStaticCatalog(sourceDir, "")
-	if err != nil {
-		return nil, err
-	}
-	if staticCatalog == nil && StaticCatalogRequired(manifest) {
-		return nil, fmt.Errorf("validate provider static catalog %s: file does not exist", StaticCatalogFile)
-	}
-	return manifest, nil
-}
-
-func loadManifestFromDir(sourceDir string) ([]byte, *providermanifestv1.Manifest, error) {
-	p, err := FindManifestFile(sourceDir)
-	if err != nil {
-		return nil, nil, err
-	}
-	return ReadManifestFile(p)
-}
-
-func archiveEntryPath(name string) (string, error) {
-	if strings.Contains(name, "\\") {
-		return "", fmt.Errorf("archive entry %q must use forward slashes", name)
-	}
-	cleaned := path.Clean(strings.TrimPrefix(name, "./"))
-	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
-		return "", fmt.Errorf("archive entry %q escapes the package root", name)
-	}
-	return cleaned, nil
-}
-
-func fileSHA256(path string) (_ string, err error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer joinCloseError(&err, fmt.Sprintf("close %q", path), f)
-	sum := sha256.New()
-	if _, err := io.Copy(sum, f); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(sum.Sum(nil)), nil
-}
-
-func joinCloseError(errp *error, label string, closer io.Closer) {
-	if closeErr := closer.Close(); closeErr != nil {
-		*errp = errors.Join(*errp, fmt.Errorf("%s: %w", label, closeErr))
-	}
+	return packageio.ValidatePackageDir(sourceDir)
 }

--- a/gestaltd/services/plugins/providerpkg/archive_boundary_test.go
+++ b/gestaltd/services/plugins/providerpkg/archive_boundary_test.go
@@ -1,6 +1,7 @@
 package providerpkg
 
 import (
+	"archive/tar"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -124,6 +125,40 @@ func TestExtractPackageRejectsEscapingEntry(t *testing.T) {
 		t.Fatal("expected escaping archive entry error")
 	}
 	if !strings.Contains(err.Error(), "escapes the package root") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReadArchiveEntryRejectsBackslashEntry(t *testing.T) {
+	t.Parallel()
+
+	archivePath := filepath.Join(t.TempDir(), "backslash-entry.tar.gz")
+	mustCreateArchive(t, archivePath,
+		archiveTestFile{name: `dir\evil.txt`, data: []byte("oops"), mode: 0644},
+	)
+
+	_, err := ReadArchiveEntry(archivePath, "dir/evil.txt")
+	if err == nil {
+		t.Fatal("expected backslash archive entry error")
+	}
+	if !strings.Contains(err.Error(), "must use forward slashes") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExtractPackageRejectsUnsupportedEntry(t *testing.T) {
+	t.Parallel()
+
+	archivePath := filepath.Join(t.TempDir(), "unsupported-entry.tar.gz")
+	mustCreateArchive(t, archivePath,
+		archiveTestFile{name: "link", mode: 0777, typeflag: tar.TypeSymlink, linkname: "target"},
+	)
+
+	err := ExtractPackage(archivePath, filepath.Join(t.TempDir(), "out"))
+	if err == nil {
+		t.Fatal("expected unsupported tar entry error")
+	}
+	if !strings.Contains(err.Error(), "unsupported tar entry type") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/gestaltd/services/plugins/providerpkg/catalog.go
+++ b/gestaltd/services/plugins/providerpkg/catalog.go
@@ -1,47 +1,21 @@
 package providerpkg
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 )
 
-const StaticCatalogFile = "catalog.yaml"
+const StaticCatalogFile = packageio.StaticCatalogFile
 
 func StaticCatalogPath(rootDir string) string {
-	if rootDir == "" {
-		return StaticCatalogFile
-	}
-	return filepath.Join(rootDir, StaticCatalogFile)
+	return packageio.StaticCatalogPath(rootDir)
 }
 
 func StaticCatalogRequired(manifest *providermanifestv1.Manifest) bool {
-	return manifest != nil && manifest.Kind == providermanifestv1.KindPlugin && manifest.Spec != nil && !manifest.Spec.IsManifestBacked()
+	return packageio.StaticCatalogRequired(manifest)
 }
 
 func ReadStaticCatalog(rootDir, name string) (*catalog.Catalog, error) {
-	catalogPath := StaticCatalogPath(rootDir)
-	data, err := os.ReadFile(catalogPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read static catalog %q: %w", catalogPath, err)
-	}
-
-	var cat catalog.Catalog
-	if err := decodeStrict(data, ManifestFormatFromPath(catalogPath), "static catalog", &cat); err != nil {
-		return nil, err
-	}
-
-	if cat.Name == "" && name != "" {
-		cat.Name = name
-	}
-	if err := cat.Validate(); err != nil {
-		return nil, fmt.Errorf("validate static catalog %q: %w", catalogPath, err)
-	}
-	return &cat, nil
+	return packageio.ReadStaticCatalog(rootDir, name)
 }

--- a/gestaltd/services/plugins/providerpkg/digest.go
+++ b/gestaltd/services/plugins/providerpkg/digest.go
@@ -1,94 +1,18 @@
 package providerpkg
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 )
 
 func ArchiveDigest(archivePath string) (string, error) {
-	sum, err := FileSHA256(archivePath)
-	if err != nil {
-		return "", fmt.Errorf("digest archive: %w", err)
-	}
-	return sum, nil
+	return packageio.ArchiveDigest(archivePath)
 }
 
 func FileSHA256(path string) (string, error) {
-	return fileSHA256(path)
+	return packageio.FileSHA256(path)
 }
 
 func DirectoryDigest(dirPath, manifestPath string, manifest *providermanifestv1.Manifest) (string, error) {
-	if manifest == nil {
-		return "", fmt.Errorf("manifest is required")
-	}
-
-	var digests []string
-
-	if manifestPath == "" {
-		var err error
-		manifestPath, err = FindManifestFile(dirPath)
-		if err != nil {
-			return "", fmt.Errorf("digest manifest: %w", err)
-		}
-	}
-	manifestSum, err := FileSHA256(manifestPath)
-	if err != nil {
-		return "", fmt.Errorf("digest manifest: %w", err)
-	}
-	digests = append(digests, manifestSum)
-
-	for _, artifact := range manifest.Artifacts {
-		sum, err := FileSHA256(filepath.Join(dirPath, filepath.FromSlash(artifact.Path)))
-		if err != nil {
-			return "", fmt.Errorf("digest artifact %s: %w", artifact.Path, err)
-		}
-		digests = append(digests, sum)
-	}
-
-	for _, ref := range LocalPackageReferences(manifest) {
-		sum, err := FileSHA256(filepath.Join(dirPath, filepath.FromSlash(ref.Path)))
-		if err != nil {
-			return "", fmt.Errorf("digest %s: %w", ref.Description, err)
-		}
-		digests = append(digests, sum)
-	}
-	staticCatalogPath := StaticCatalogPath(dirPath)
-	if _, err := os.Stat(staticCatalogPath); err == nil {
-		sum, err := FileSHA256(staticCatalogPath)
-		if err != nil {
-			return "", fmt.Errorf("digest provider static catalog: %w", err)
-		}
-		digests = append(digests, sum)
-	} else if !os.IsNotExist(err) {
-		return "", fmt.Errorf("digest provider static catalog: %w", err)
-	} else if StaticCatalogRequired(manifest) {
-		return "", fmt.Errorf("digest provider static catalog: %s does not exist", StaticCatalogFile)
-	}
-
-	if manifest.Spec != nil && manifest.Spec.AssetRoot != "" {
-		assetDir := filepath.Join(dirPath, filepath.FromSlash(manifest.Spec.AssetRoot))
-		if err := filepath.WalkDir(assetDir, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
-				return err
-			}
-			sum, err := FileSHA256(path)
-			if err != nil {
-				return fmt.Errorf("digest asset %s: %w", path, err)
-			}
-			rel, _ := filepath.Rel(assetDir, path)
-			digests = append(digests, rel+"="+sum)
-			return nil
-		}); err != nil {
-			return "", fmt.Errorf("digest ui assets: %w", err)
-		}
-	}
-
-	combined := sha256.Sum256([]byte(strings.Join(digests, "\n")))
-	return hex.EncodeToString(combined[:]), nil
+	return packageio.DirectoryDigest(dirPath, manifestPath, manifest)
 }

--- a/gestaltd/services/plugins/providerpkg/manifest.go
+++ b/gestaltd/services/plugins/providerpkg/manifest.go
@@ -1,763 +1,79 @@
 package providerpkg
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"mime"
-	"os"
-	"path"
-	"path/filepath"
-	"runtime"
-	"slices"
-	"strings"
-
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	"github.com/valon-technologies/gestalt/server/services/plugins/httpbinding"
-	"github.com/valon-technologies/gestalt/server/services/plugins/source"
-	"gopkg.in/yaml.v3"
+	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 )
 
-const ManifestFile = "manifest.json"
+const ManifestFile = packageio.ManifestFile
 
-var ManifestFiles = []string{"manifest.json", "manifest.yaml", "manifest.yml"}
+var ManifestFiles = packageio.ManifestFiles
 
 const (
-	ManifestFormatJSON = "json"
-	ManifestFormatYAML = "yaml"
+	ManifestFormatJSON = packageio.ManifestFormatJSON
+	ManifestFormatYAML = packageio.ManifestFormatYAML
 )
 
 func FindManifestFile(dir string) (string, error) {
-	for _, name := range ManifestFiles {
-		p := filepath.Join(dir, name)
-		if _, err := os.Stat(p); err == nil {
-			return p, nil
-		}
-	}
-	return "", fmt.Errorf("no manifest file found in %s (tried %s)", dir, strings.Join(ManifestFiles, ", "))
+	return packageio.FindManifestFileIn(dir, ManifestFiles)
 }
 
 func IsManifestFile(path string) bool {
-	base := filepath.Base(path)
-	return slices.Contains(ManifestFiles, base)
+	return packageio.IsManifestFileIn(path, ManifestFiles)
 }
 
 func ManifestFormatFromPath(path string) string {
-	if isYAMLFile(path) {
-		return ManifestFormatYAML
-	}
-	return ManifestFormatJSON
-}
-
-func isYAMLFile(path string) bool {
-	ext := strings.ToLower(filepath.Ext(path))
-	return ext == ".yaml" || ext == ".yml"
+	return packageio.ManifestFormatFromPath(path)
 }
 
 func DecodeManifest(data []byte) (*providermanifestv1.Manifest, error) {
-	return DecodeManifestFormat(data, ManifestFormatJSON)
+	return packageio.DecodeManifest(data)
 }
 
 func DecodeSourceManifestFormat(data []byte, format string) (*providermanifestv1.Manifest, error) {
-	return decodeManifest(data, format, true)
+	return packageio.DecodeSourceManifestFormat(data, format)
 }
 
 func DecodeManifestFormat(data []byte, format string) (*providermanifestv1.Manifest, error) {
-	return decodeManifest(data, format, false)
-}
-
-func decodeManifest(data []byte, format string, sourceMode bool) (*providermanifestv1.Manifest, error) {
-	var manifest providermanifestv1.Manifest
-	if err := decodeStrict(data, format, "manifest", &manifest); err != nil {
-		return nil, err
-	}
-	if err := validateManifest(&manifest, sourceMode); err != nil {
-		return nil, err
-	}
-	if _, err := normalizeManifestKind(&manifest); err != nil {
-		return nil, err
-	}
-	return &manifest, nil
-}
-
-var validManifestKinds = map[string]bool{
-	providermanifestv1.KindPlugin:              true,
-	providermanifestv1.KindAuthentication:      true,
-	providermanifestv1.KindAuthorization:       true,
-	providermanifestv1.KindExternalCredentials: true,
-	providermanifestv1.KindIndexedDB:           true,
-	providermanifestv1.KindCache:               true,
-	providermanifestv1.KindS3:                  true,
-	providermanifestv1.KindWorkflow:            true,
-	providermanifestv1.KindAgent:               true,
-	providermanifestv1.KindSecrets:             true,
-	providermanifestv1.KindUI:                  true,
-	providermanifestv1.KindRuntime:             true,
+	return packageio.DecodeManifestFormat(data, format)
 }
 
 func ManifestKind(manifest *providermanifestv1.Manifest) (string, error) {
-	if manifest == nil {
-		return "", fmt.Errorf("manifest is required")
-	}
-	if manifest.Kind == "" {
-		return "", fmt.Errorf("manifest kind is required")
-	}
-	kind := providermanifestv1.NormalizeKind(manifest.Kind)
-	if !validManifestKinds[manifest.Kind] && !validManifestKinds[kind] {
-		return "", fmt.Errorf("manifest kind %q is not valid; expected one of plugin, authentication, authorization, external_credentials, indexeddb, cache, s3, workflow, agent, secrets, runtime, or ui", manifest.Kind)
-	}
-	return kind, nil
-}
-
-func normalizeManifestKind(manifest *providermanifestv1.Manifest) (string, error) {
-	kind, err := ManifestKind(manifest)
-	if err != nil {
-		return "", err
-	}
-	manifest.Kind = kind
-	return kind, nil
-}
-
-func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) error {
-	if manifest == nil {
-		return fmt.Errorf("manifest is required")
-	}
-
-	if manifest.Source == "" {
-		return fmt.Errorf("manifest source is required")
-	}
-	if _, err := source.Parse(manifest.Source); err != nil {
-		return fmt.Errorf("manifest source: %w", err)
-	}
-	if err := source.ValidateVersion(manifest.Version); err != nil {
-		return fmt.Errorf("manifest version: %w", err)
-	}
-	if manifest.IconFile != "" {
-		if err := validateRelativePackagePath(manifest.IconFile, "iconFile"); err != nil {
-			return err
-		}
-	}
-	if manifest.Release != nil {
-		if !sourceMode {
-			return fmt.Errorf("release metadata is only allowed in source manifests")
-		}
-		if err := validateReleaseMetadata(manifest.Release); err != nil {
-			return err
-		}
-	}
-	kind, err := ManifestKind(manifest)
-	if err != nil {
-		return err
-	}
-
-	allowsSourceEntrypointOmission := sourceMode && manifest.Entrypoint == nil
-
-	needsArtifacts := len(manifest.Artifacts) > 0
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		needsArtifacts = needsArtifacts || manifest.Entrypoint != nil
-	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
-		needsArtifacts = needsArtifacts || !allowsSourceEntrypointOmission
-	}
-
-	var artifactPaths map[string]struct{}
-	if needsArtifacts {
-		artifactPaths = make(map[string]struct{}, len(manifest.Artifacts))
-		artifactPlatforms := make(map[string]struct{}, len(manifest.Artifacts))
-		for _, artifact := range manifest.Artifacts {
-			if err := validateRelativePackagePath(artifact.Path, "artifact path"); err != nil {
-				return err
-			}
-			if artifact.SHA256 == "" && !sourceMode {
-				return fmt.Errorf("artifact %s sha256 is required", artifact.Path)
-			}
-			if _, exists := artifactPaths[artifact.Path]; exists {
-				return fmt.Errorf("duplicate artifact path %q", artifact.Path)
-			}
-			artifactPaths[artifact.Path] = struct{}{}
-
-			key := PlatformString(artifact.OS, artifact.Arch)
-			if _, exists := artifactPlatforms[key]; exists {
-				return fmt.Errorf("duplicate artifact platform %q", key)
-			}
-			artifactPlatforms[key] = struct{}{}
-		}
-	}
-
-	spec := manifest.Spec
-	if spec != nil && spec.ConfigSchemaPath != "" {
-		if err := validateRelativePackagePath(spec.ConfigSchemaPath, "spec config schema path"); err != nil {
-			return err
-		}
-	}
-
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		if spec == nil {
-			return fmt.Errorf("spec is required for plugin manifests")
-		}
-		if err := validateExecutableProviderMetadata(spec); err != nil {
-			return err
-		}
-		if err := validateOwnedUI(spec.UI, sourceMode); err != nil {
-			return err
-		}
-		if spec != nil && spec.IsDeclarative() {
-			if err := validateDeclarativeProvider(spec); err != nil {
-				return err
-			}
-		}
-		switch {
-		case manifest.Entrypoint != nil:
-			if err := validateEntrypoint(kind, manifest.Entrypoint, artifactPaths); err != nil {
-				return err
-			}
-		case manifest.IsDeclarativeOnlyProvider():
-		case spec != nil && spec.IsSpecLoaded():
-		case allowsSourceEntrypointOmission:
-		default:
-			return fmt.Errorf("entrypoint is required")
-		}
-	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
-		if manifest.Entrypoint == nil && !allowsSourceEntrypointOmission {
-			return fmt.Errorf("entrypoint is required")
-		}
-		if manifest.Entrypoint != nil {
-			if err := validateEntrypoint(kind, manifest.Entrypoint, artifactPaths); err != nil {
-				return err
-			}
-		}
-	case providermanifestv1.KindUI:
-		if manifest.Entrypoint != nil {
-			return fmt.Errorf("ui manifests may not define entrypoints")
-		}
-		if spec == nil || spec.AssetRoot == "" {
-			return fmt.Errorf("spec.assetRoot is required for ui manifests")
-		}
-		if err := validateRelativePackagePath(spec.AssetRoot, "spec.assetRoot"); err != nil {
-			return err
-		}
-		if err := validateUIRoutes(spec.Routes); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("unsupported manifest kind %q", kind)
-	}
-
-	return nil
-}
-
-func validateOwnedUI(ownedUI *providermanifestv1.OwnedUI, sourceMode bool) error {
-	if ownedUI == nil {
-		return nil
-	}
-	pathValue := strings.TrimSpace(ownedUI.Path)
-	if pathValue != "" {
-		if !sourceMode {
-			if err := validateRelativePackagePath(pathValue, "spec.ui.path"); err != nil {
-				return err
-			}
-			ownedUI.Path = pathValue
-		} else {
-			if filepath.IsAbs(pathValue) {
-				return fmt.Errorf("spec.ui.path must be relative")
-			}
-			cleaned := path.Clean(filepath.ToSlash(pathValue))
-			if cleaned == "." || cleaned == "" {
-				return fmt.Errorf("spec.ui.path must not be empty")
-			}
-			ownedUI.Path = cleaned
-		}
-		return nil
-	}
-	return fmt.Errorf("spec.ui.path is required when spec.ui is set")
-}
-
-func validateUIRoutes(routes []providermanifestv1.UIRoute) error {
-	seenPaths := make(map[string]struct{}, len(routes))
-	for i := range routes {
-		normalized, err := NormalizeUIRoutePath(fmt.Sprintf("spec.routes[%d].path", i), routes[i].Path)
-		if err != nil {
-			return err
-		}
-		routes[i].Path = normalized
-		if _, exists := seenPaths[normalized]; exists {
-			return fmt.Errorf("spec.routes[%d].path %q duplicates another route", i, normalized)
-		}
-		seenPaths[normalized] = struct{}{}
-
-		roles, err := NormalizeUIAllowedRoles(fmt.Sprintf("spec.routes[%d].allowedRoles", i), routes[i].AllowedRoles)
-		if err != nil {
-			return err
-		}
-		routes[i].AllowedRoles = roles
-	}
-	return nil
+	return packageio.ManifestKind(manifest)
 }
 
 func ValidatePolicyBoundUIRoutes(routes []providermanifestv1.UIRoute) error {
-	if len(routes) == 0 {
-		return fmt.Errorf("policy-bound UIs must declare at least one route")
-	}
-	coversRoot := false
-	for i := range routes {
-		if len(routes[i].AllowedRoles) == 0 {
-			return fmt.Errorf("spec.routes[%d].allowedRoles must not be empty", i)
-		}
-		if UIRouteMatches(routes[i].Path, "/") {
-			coversRoot = true
-		}
-	}
-	if !coversRoot {
-		return fmt.Errorf("policy-bound UIs must declare a route covering /")
-	}
-	return nil
+	return packageio.ValidatePolicyBoundUIRoutes(routes)
 }
 
 func CurrentPlatformArtifact(manifest *providermanifestv1.Manifest) (*providermanifestv1.Artifact, error) {
-	if manifest == nil {
-		return nil, fmt.Errorf("manifest is required")
-	}
-	for i := range manifest.Artifacts {
-		a := &manifest.Artifacts[i]
-		if a.OS == runtime.GOOS && a.Arch == runtime.GOARCH {
-			return a, nil
-		}
-	}
-	return nil, fmt.Errorf("no artifact for current platform %s/%s", runtime.GOOS, runtime.GOARCH)
+	return packageio.CurrentPlatformArtifact(manifest)
 }
 
-func EntrypointForKind(manifest *providermanifestv1.Manifest, _ string) *providermanifestv1.Entrypoint {
-	if manifest == nil {
-		return nil
-	}
-	return manifest.Entrypoint
+func EntrypointForKind(manifest *providermanifestv1.Manifest, kind string) *providermanifestv1.Entrypoint {
+	return packageio.EntrypointForKind(manifest, kind)
 }
 
 func EnsureEntrypoint(manifest *providermanifestv1.Manifest) *providermanifestv1.Entrypoint {
-	if manifest.Entrypoint == nil {
-		manifest.Entrypoint = &providermanifestv1.Entrypoint{}
-	}
-	return manifest.Entrypoint
-}
-
-func validateEntrypoint(_ string, entry *providermanifestv1.Entrypoint, artifactPaths map[string]struct{}) error {
-	if entry == nil {
-		return fmt.Errorf("entrypoint is required")
-	}
-	if entry.ArtifactPath == "" {
-		return fmt.Errorf("entrypoint.artifactPath is required")
-	}
-	if err := validateRelativePackagePath(entry.ArtifactPath, "entrypoint.artifactPath"); err != nil {
-		return err
-	}
-	if len(artifactPaths) == 0 {
-		return fmt.Errorf("entrypoint references unknown artifact %q", entry.ArtifactPath)
-	}
-	if _, ok := artifactPaths[entry.ArtifactPath]; !ok {
-		return fmt.Errorf("entrypoint references unknown artifact %q", entry.ArtifactPath)
-	}
-	return nil
-}
-
-func validateRelativePackagePath(value, label string) error {
-	if value == "" {
-		return fmt.Errorf("%s is required", label)
-	}
-	if strings.HasPrefix(value, "/") {
-		return fmt.Errorf("%s must be relative", label)
-	}
-	cleaned := path.Clean(value)
-	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
-		return fmt.Errorf("%s must stay within the package", label)
-	}
-	if strings.Contains(value, "\\") {
-		return fmt.Errorf("%s must use forward slashes", label)
-	}
-	if cleaned != value {
-		return fmt.Errorf("%s must be normalized", label)
-	}
-	return nil
-}
-
-func validateReleaseMetadata(release *providermanifestv1.ReleaseMetadata) error {
-	if release == nil || release.Build == nil {
-		return nil
-	}
-	if release.Build.Workdir != "" {
-		if err := validateRelativePackagePath(release.Build.Workdir, "release.build.workdir"); err != nil {
-			return err
-		}
-	}
-	if len(release.Build.Command) == 0 {
-		return fmt.Errorf("release.build.command is required")
-	}
-	for i, arg := range release.Build.Command {
-		if strings.TrimSpace(arg) == "" {
-			return fmt.Errorf("release.build.command[%d] is required", i)
-		}
-	}
-	return nil
-}
-
-func validateProviderAuth(path string, auth *providermanifestv1.ProviderAuth) error {
-	if auth == nil {
-		return nil
-	}
-	switch auth.Type {
-	case providermanifestv1.AuthTypeOAuth2:
-		if auth.AuthorizationURL == "" {
-			return fmt.Errorf("%s.authorizationUrl is required for oauth2", path)
-		}
-		if auth.TokenURL == "" {
-			return fmt.Errorf("%s.tokenUrl is required for oauth2", path)
-		}
-	case providermanifestv1.AuthTypeMCPOAuth, providermanifestv1.AuthTypeBearer, providermanifestv1.AuthTypeManual, providermanifestv1.AuthTypeNone:
-	default:
-		return fmt.Errorf("unsupported %s.type %q", path, auth.Type)
-	}
-	return nil
-}
-
-func validateRouteAuthRef(path string, auth *providermanifestv1.RouteAuthRef) error {
-	if auth == nil {
-		return nil
-	}
-	if strings.TrimSpace(auth.Provider) == "" {
-		return fmt.Errorf("%s.provider is required", path)
-	}
-	return nil
-}
-
-func normalizeHTTPBindingPath(field, value string) (string, error) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "", fmt.Errorf("%s is required", field)
-	}
-	if strings.Contains(value, "*") {
-		return "", fmt.Errorf("%s must not contain wildcards", field)
-	}
-	cleaned := path.Clean(strings.ReplaceAll(value, "\\", "/"))
-	if cleaned == "." {
-		cleaned = "/"
-	}
-	if !strings.HasPrefix(cleaned, "/") {
-		cleaned = "/" + cleaned
-	}
-	return cleaned, nil
-}
-
-func normalizeHTTPContentType(field, value string) (string, error) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "", fmt.Errorf("%s must not be empty", field)
-	}
-	mediaType, _, err := mime.ParseMediaType(value)
-	if err != nil {
-		return "", fmt.Errorf("%s must be a valid media type", field)
-	}
-	return strings.ToLower(mediaType), nil
-}
-
-func validateHTTPSecurityScheme(path string, scheme *providermanifestv1.HTTPSecurityScheme) error {
-	return httpbinding.ValidateHTTPSecurityScheme(path, scheme)
-}
-
-func validateHTTPBinding(path string, binding *providermanifestv1.HTTPBinding, schemes map[string]*providermanifestv1.HTTPSecurityScheme) error {
-	if binding == nil {
-		return fmt.Errorf("%s is required", path)
-	}
-	normalizedPath, err := normalizeHTTPBindingPath(path+".path", binding.Path)
-	if err != nil {
-		return err
-	}
-	binding.Path = normalizedPath
-	method := strings.ToUpper(strings.TrimSpace(binding.Method))
-	if !validHTTPMethods[method] {
-		return fmt.Errorf("%s.method %q is not a valid HTTP method", path, binding.Method)
-	}
-	binding.Method = method
-	binding.CredentialMode = providermanifestv1.ConnectionMode(strings.TrimSpace(string(binding.CredentialMode)))
-	switch binding.CredentialMode {
-	case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser:
-	default:
-		return fmt.Errorf("%s.credentialMode %q is not supported", path, binding.CredentialMode)
-	}
-	if strings.TrimSpace(binding.Target) == "" {
-		return fmt.Errorf("%s.target is required", path)
-	}
-	binding.Target = strings.TrimSpace(binding.Target)
-	binding.Security = strings.TrimSpace(binding.Security)
-	if binding.Security == "" {
-		return fmt.Errorf("%s.security is required", path)
-	}
-	if schemes == nil || schemes[binding.Security] == nil {
-		return fmt.Errorf("%s.security %q references an undefined security scheme", path, binding.Security)
-	}
-	if binding.RequestBody != nil {
-		normalizedContent := make(map[string]*providermanifestv1.HTTPMediaType, len(binding.RequestBody.Content))
-		for mediaType := range binding.RequestBody.Content {
-			normalizedMediaType, err := normalizeHTTPContentType(path+".requestBody.content", mediaType)
-			if err != nil {
-				return err
-			}
-			if _, exists := normalizedContent[normalizedMediaType]; exists {
-				return fmt.Errorf("%s.requestBody.content %q is duplicated after normalization", path, normalizedMediaType)
-			}
-			normalizedContent[normalizedMediaType] = binding.RequestBody.Content[mediaType]
-		}
-		binding.RequestBody.Content = normalizedContent
-	}
-	if binding.Ack != nil {
-		if binding.Ack.Status == 0 {
-			binding.Ack.Status = 200
-		}
-		if binding.Ack.Status < 200 || binding.Ack.Status > 299 {
-			return fmt.Errorf("%s.ack.status must be a 2xx status", path)
-		}
-	}
-	return nil
-}
-
-func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error {
-	if provider == nil {
-		return nil
-	}
-	if err := validateRouteAuthRef("provider.auth", provider.RouteAuth); err != nil {
-		return err
-	}
-	for name, scheme := range provider.SecuritySchemes {
-		if err := validateHTTPSecurityScheme(fmt.Sprintf("provider.securitySchemes.%s", name), scheme); err != nil {
-			return err
-		}
-	}
-	for name, binding := range provider.HTTP {
-		if err := validateHTTPBinding(fmt.Sprintf("provider.http.%s", name), binding, provider.SecuritySchemes); err != nil {
-			return err
-		}
-	}
-	for name, conn := range provider.Connections {
-		if conn == nil {
-			continue
-		}
-		if err := validateProviderAuth(fmt.Sprintf("provider.connections.%s.auth", name), conn.Auth); err != nil {
-			return err
-		}
-		if conn.Auth != nil && conn.Auth.Type == providermanifestv1.AuthTypeMCPOAuth && provider.MCPURL() == "" {
-			return fmt.Errorf("provider.connections.%s.auth.type %q requires an MCP surface", name, providermanifestv1.AuthTypeMCPOAuth)
-		}
-		if conn.Mode == "" {
-		} else {
-			switch conn.Mode {
-			case providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser, providermanifestv1.ConnectionModePlatform:
-			default:
-				return fmt.Errorf("unsupported provider.connections.%s.mode %q", name, conn.Mode)
-			}
-		}
-		if conn.Exposure != "" {
-			switch conn.Exposure {
-			case providermanifestv1.ConnectionExposureUser, providermanifestv1.ConnectionExposureInternal:
-			default:
-				return fmt.Errorf("unsupported provider.connections.%s.exposure %q", name, conn.Exposure)
-			}
-			if conn.Exposure == providermanifestv1.ConnectionExposureInternal && manifestConnectionMode(conn) == providermanifestv1.ConnectionModeUser {
-				return fmt.Errorf("provider.connections.%s exposure %q is not supported for user-owned connections", name, conn.Exposure)
-			}
-		}
-	}
-	if provider.DefaultConnection != "" {
-		if _, ok := provider.Connections[provider.DefaultConnection]; !ok {
-			return fmt.Errorf("provider.defaultConnection %q references undefined provider.connections entry", provider.DefaultConnection)
-		}
-	}
-	if len(provider.Connections) > 0 {
-		for name := range provider.Connections {
-			if strings.TrimSpace(name) == "" {
-				return fmt.Errorf("provider.connections keys must be non-empty")
-			}
-		}
-	}
-	checks := []struct {
-		field   string
-		present bool
-	}{
-		{field: "provider.baseUrl", present: provider.RESTBaseURL() != "" && !provider.IsDeclarative() && provider.OpenAPIDocument() == ""},
-		{field: "provider.operations", present: len(provider.RESTOperations()) > 0 && !provider.IsDeclarative()},
-	}
-	for _, check := range checks {
-		if check.present {
-			return fmt.Errorf("%s is no longer supported for executable providers", check.field)
-		}
-	}
-	return nil
-}
-
-func manifestConnectionMode(conn *providermanifestv1.ManifestConnectionDef) providermanifestv1.ConnectionMode {
-	if conn == nil {
-		return providermanifestv1.ConnectionModeNone
-	}
-	if conn.Mode != "" {
-		return conn.Mode
-	}
-	if conn.Auth == nil || conn.Auth.Type == "" || conn.Auth.Type == providermanifestv1.AuthTypeNone {
-		return providermanifestv1.ConnectionModeNone
-	}
-	return providermanifestv1.ConnectionModeUser
-}
-
-var validParamIn = map[string]bool{
-	"query": true,
-	"body":  true,
-	"path":  true,
-}
-
-var validHTTPMethods = map[string]bool{
-	"GET":    true,
-	"POST":   true,
-	"PUT":    true,
-	"PATCH":  true,
-	"DELETE": true,
-}
-
-func validateDeclarativeProvider(provider *providermanifestv1.Spec) error {
-	if provider.RESTBaseURL() == "" {
-		return fmt.Errorf("provider.baseUrl is required for declarative providers")
-	}
-	ops := provider.RESTOperations()
-	seen := make(map[string]struct{}, len(ops))
-	for i := range ops {
-		op := &ops[i]
-		if op.Name == "" {
-			return fmt.Errorf("provider.operations[%d].name is required", i)
-		}
-		if _, exists := seen[op.Name]; exists {
-			return fmt.Errorf("duplicate operation name %q", op.Name)
-		}
-		seen[op.Name] = struct{}{}
-		if !validHTTPMethods[op.Method] {
-			return fmt.Errorf("provider.operations[%d].method %q is not a valid HTTP method", i, op.Method)
-		}
-		if op.Path == "" {
-			return fmt.Errorf("provider.operations[%d].path is required", i)
-		}
-		seenParams := make(map[string]struct{}, len(op.Parameters))
-		for j, param := range op.Parameters {
-			if param.Name == "" {
-				return fmt.Errorf("provider.operations[%d].parameters[%d].name is required", i, j)
-			}
-			if _, dup := seenParams[param.Name]; dup {
-				return fmt.Errorf("provider.operations[%d] has duplicate parameter name %q", i, param.Name)
-			}
-			seenParams[param.Name] = struct{}{}
-			if !validParamIn[param.In] {
-				return fmt.Errorf("provider.operations[%d].parameters[%d].in %q must be query, body, or path", i, j, param.In)
-			}
-			if param.In == "path" && !strings.Contains(op.Path, "{"+param.Name+"}") {
-				return fmt.Errorf("provider.operations[%d].parameters[%d] %q declared as path param but %q has no {%s} placeholder", i, j, param.Name, op.Path, param.Name)
-			}
-		}
-	}
-	return nil
+	return packageio.EnsureEntrypoint(manifest)
 }
 
 func EncodeManifest(manifest *providermanifestv1.Manifest) ([]byte, error) {
-	return EncodeManifestFormat(manifest, ManifestFormatJSON)
+	return packageio.EncodeManifest(manifest)
 }
 
 func EncodeManifestFormat(manifest *providermanifestv1.Manifest, format string) ([]byte, error) {
-	return encodeManifestFormat(manifest, format, false)
+	return packageio.EncodeManifestFormat(manifest, format)
 }
 
 func EncodeSourceManifestFormat(manifest *providermanifestv1.Manifest, format string) ([]byte, error) {
-	return encodeManifestFormat(manifest, format, true)
-}
-
-func encodeManifestFormat(manifest *providermanifestv1.Manifest, format string, sourceMode bool) ([]byte, error) {
-	encodedManifest, err := cloneManifest(manifest)
-	if err != nil {
-		return nil, fmt.Errorf("clone manifest: %w", err)
-	}
-	if err := validateManifest(encodedManifest, sourceMode); err != nil {
-		return nil, err
-	}
-	if _, err := normalizeManifestKind(encodedManifest); err != nil {
-		return nil, err
-	}
-	switch format {
-	case ManifestFormatJSON:
-		return encodeManifestJSON(encodedManifest)
-	case ManifestFormatYAML:
-		return encodeManifestYAML(encodedManifest)
-	default:
-		return nil, fmt.Errorf("unsupported manifest format %q", format)
-	}
-}
-
-func cloneManifest(manifest *providermanifestv1.Manifest) (*providermanifestv1.Manifest, error) {
-	if manifest == nil {
-		return nil, nil
-	}
-
-	data, err := json.Marshal(manifest)
-	if err != nil {
-		return nil, err
-	}
-
-	var cloned providermanifestv1.Manifest
-	if err := json.Unmarshal(data, &cloned); err != nil {
-		return nil, err
-	}
-	return &cloned, nil
-}
-
-func encodeManifestJSON(manifest *providermanifestv1.Manifest) ([]byte, error) {
-	data, err := json.MarshalIndent(manifest, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("marshal manifest: %w", err)
-	}
-	return append(data, '\n'), nil
-}
-
-func encodeManifestYAML(manifest *providermanifestv1.Manifest) ([]byte, error) {
-	data, err := yaml.Marshal(manifest)
-	if err != nil {
-		return nil, fmt.Errorf("marshal manifest YAML: %w", err)
-	}
-	return data, nil
-}
-
-func decodeStrict(data []byte, format, subject string, target any) error {
-	switch format {
-	case ManifestFormatJSON:
-		dec := json.NewDecoder(bytes.NewReader(data))
-		dec.DisallowUnknownFields()
-		if err := dec.Decode(target); err != nil {
-			return fmt.Errorf("parse %s JSON: %w", subject, err)
-		}
-		return nil
-	case ManifestFormatYAML:
-		dec := yaml.NewDecoder(bytes.NewReader(data))
-		dec.KnownFields(true)
-		if err := dec.Decode(target); err != nil {
-			return fmt.Errorf("parse %s YAML: %w", subject, err)
-		}
-		return nil
-	default:
-		return fmt.Errorf("unsupported %s format %q", subject, format)
-	}
+	return packageio.EncodeSourceManifestFormat(manifest, format)
 }
 
 func ManifestEqual(a, b *providermanifestv1.Manifest) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	aj, err := EncodeManifest(a)
-	if err != nil {
-		return false
-	}
-	bj, err := EncodeManifest(b)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(aj, bj)
+	return packageio.ManifestEqual(a, b)
+}
+
+func cloneManifest(manifest *providermanifestv1.Manifest) (*providermanifestv1.Manifest, error) {
+	return packageio.CloneManifest(manifest)
 }

--- a/gestaltd/services/plugins/providerpkg/platform.go
+++ b/gestaltd/services/plugins/providerpkg/platform.go
@@ -1,33 +1,19 @@
 package providerpkg
 
-import (
-	"fmt"
-	"runtime"
-	"strings"
-)
+import "github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 
 func PlatformString(goos, goarch string) string {
-	return fmt.Sprintf("%s/%s", goos, goarch)
+	return packageio.PlatformString(goos, goarch)
 }
 
 func PlatformArchiveSuffix(goos, goarch string) string {
-	return fmt.Sprintf("%s_%s", goos, goarch)
+	return packageio.PlatformArchiveSuffix(goos, goarch)
 }
 
-// CurrentPlatformString returns the platform string for the host running
-// this process (e.g. "darwin/arm64", "linux/amd64").
 func CurrentPlatformString() string {
-	return PlatformString(runtime.GOOS, runtime.GOARCH)
+	return packageio.CurrentPlatformString()
 }
 
-// ParsePlatformString parses "darwin/arm64" or "linux/amd64" into (goos, goarch).
 func ParsePlatformString(s string) (goos, goarch string, err error) {
-	parts := strings.Split(s, "/")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid platform string %q: expected os/arch", s)
-	}
-	if parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("invalid platform string %q: empty component", s)
-	}
-	return parts[0], parts[1], nil
+	return packageio.ParsePlatformString(s)
 }

--- a/gestaltd/services/plugins/providerpkg/references.go
+++ b/gestaltd/services/plugins/providerpkg/references.go
@@ -1,104 +1,16 @@
 package providerpkg
 
 import (
-	"path/filepath"
-	"strings"
-
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 )
 
-type LocalPackageReference struct {
-	Path        string
-	Description string
-}
+type LocalPackageReference = packageio.LocalPackageReference
 
 func LocalPackageReferences(manifest *providermanifestv1.Manifest) []LocalPackageReference {
-	if manifest == nil {
-		return nil
-	}
-
-	refs := make([]LocalPackageReference, 0, 3)
-	seen := make(map[string]struct{}, 3)
-	add := func(path, description string) {
-		if path == "" {
-			return
-		}
-		if _, ok := seen[path]; ok {
-			return
-		}
-		seen[path] = struct{}{}
-		refs = append(refs, LocalPackageReference{
-			Path:        path,
-			Description: description,
-		})
-	}
-
-	if manifest.Spec != nil {
-		add(manifest.Spec.ConfigSchemaPath, "provider config schema")
-		if doc := manifest.Spec.OpenAPIDocument(); doc != "" && !strings.Contains(doc, "://") {
-			add(doc, "provider openapi document")
-		}
-		if url := manifest.Spec.GraphQLURL(); url != "" && !strings.Contains(url, "://") {
-			add(url, "provider graphql document")
-		}
-		if url := manifest.Spec.MCPURL(); url != "" && !strings.Contains(url, "://") {
-			add(url, "provider mcp document")
-		}
-	}
-	add(manifest.IconFile, "icon_file")
-	return refs
+	return packageio.LocalPackageReferences(manifest)
 }
 
 func ResolveManifestLocalReferences(manifest *providermanifestv1.Manifest, manifestPath string) *providermanifestv1.Manifest {
-	if manifest == nil || manifest.Spec == nil || manifestPath == "" {
-		return manifest
-	}
-	if manifest.Spec.Surfaces == nil {
-		return manifest
-	}
-
-	resolve := func(value string) string {
-		if value == "" || filepath.IsAbs(value) || strings.Contains(value, "://") {
-			return value
-		}
-		return filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(value))
-	}
-
-	provider := *manifest.Spec
-	surfaces := *provider.Surfaces
-	changed := false
-
-	if surfaces.OpenAPI != nil {
-		s := *surfaces.OpenAPI
-		if resolved := resolve(s.Document); resolved != s.Document {
-			s.Document = resolved
-			surfaces.OpenAPI = &s
-			changed = true
-		}
-	}
-	if surfaces.GraphQL != nil {
-		s := *surfaces.GraphQL
-		if resolved := resolve(s.URL); resolved != s.URL {
-			s.URL = resolved
-			surfaces.GraphQL = &s
-			changed = true
-		}
-	}
-	if surfaces.MCP != nil {
-		s := *surfaces.MCP
-		if resolved := resolve(s.URL); resolved != s.URL {
-			s.URL = resolved
-			surfaces.MCP = &s
-			changed = true
-		}
-	}
-
-	if !changed {
-		return manifest
-	}
-
-	provider.Surfaces = &surfaces
-	cloned := *manifest
-	cloned.Spec = &provider
-	return &cloned
+	return packageio.ResolveManifestLocalReferences(manifest, manifestPath)
 }

--- a/gestaltd/services/plugins/providerpkg/test_helpers_test.go
+++ b/gestaltd/services/plugins/providerpkg/test_helpers_test.go
@@ -16,9 +16,11 @@ import (
 )
 
 type archiveTestFile struct {
-	name string
-	data []byte
-	mode int64
+	name     string
+	data     []byte
+	mode     int64
+	typeflag byte
+	linkname string
 }
 
 const (
@@ -185,9 +187,20 @@ func mustCreateArchive(t *testing.T, archivePath string, files ...archiveTestFil
 	}()
 
 	for _, file := range files {
-		hdr := &tar.Header{Name: file.name, Mode: file.mode, Size: int64(len(file.data))}
+		typeflag := file.typeflag
+		if typeflag == 0 {
+			typeflag = tar.TypeReg
+		}
+		size := int64(len(file.data))
+		if typeflag != tar.TypeReg {
+			size = 0
+		}
+		hdr := &tar.Header{Name: file.name, Mode: file.mode, Size: size, Typeflag: typeflag, Linkname: file.linkname}
 		if err := tw.WriteHeader(hdr); err != nil {
 			t.Fatalf("WriteHeader(%q): %v", file.name, err)
+		}
+		if size == 0 {
+			continue
 		}
 		if _, err := tw.Write(file.data); err != nil {
 			t.Fatalf("Write(%q): %v", file.name, err)

--- a/gestaltd/services/plugins/providerpkg/ui_routes.go
+++ b/gestaltd/services/plugins/providerpkg/ui_routes.go
@@ -1,81 +1,15 @@
 package providerpkg
 
-import (
-	"fmt"
-	stdpath "path"
-	"strings"
-)
+import "github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 
 func NormalizeUIRoutePath(label, routePath string) (string, error) {
-	routePath = strings.TrimSpace(routePath)
-	if routePath == "" {
-		return "", fmt.Errorf("%s is required", label)
-	}
-	if !strings.HasPrefix(routePath, "/") {
-		return "", fmt.Errorf("%s must start with /", label)
-	}
-	if strings.ContainsAny(routePath, "{}") {
-		return "", fmt.Errorf("%s route patterns are not supported", label)
-	}
-	if strings.Contains(routePath, "*") {
-		if routePath != "/*" && (!strings.HasSuffix(routePath, "/*") || strings.Count(routePath, "*") != 1) {
-			return "", fmt.Errorf("%s wildcards are only supported as a terminal /*", label)
-		}
-		base := strings.TrimSuffix(routePath, "/*")
-		if base == "" {
-			return "/*", nil
-		}
-		base = stdpath.Clean(base)
-		if base == "." {
-			base = "/"
-		}
-		if base == "/" {
-			return "/*", nil
-		}
-		base = strings.TrimRight(base, "/")
-		return base + "/*", nil
-	}
-
-	routePath = stdpath.Clean(routePath)
-	if routePath == "." {
-		routePath = "/"
-	}
-	if routePath != "/" {
-		routePath = strings.TrimRight(routePath, "/")
-	}
-	return routePath, nil
+	return packageio.NormalizeUIRoutePath(label, routePath)
 }
 
 func NormalizeUIAllowedRoles(label string, allowedRoles []string) ([]string, error) {
-	if len(allowedRoles) == 0 {
-		return nil, fmt.Errorf("%s must not be empty", label)
-	}
-	roles := allowedRoles[:0]
-	seenRoles := make(map[string]struct{}, len(allowedRoles))
-	for i, role := range allowedRoles {
-		role = strings.TrimSpace(role)
-		if role == "" {
-			return nil, fmt.Errorf("%s[%d] is required", label, i)
-		}
-		if _, exists := seenRoles[role]; exists {
-			continue
-		}
-		seenRoles[role] = struct{}{}
-		roles = append(roles, role)
-	}
-	return roles, nil
+	return packageio.NormalizeUIAllowedRoles(label, allowedRoles)
 }
 
 func UIRouteMatches(routePath, requestPath string) bool {
-	if routePath == "/*" {
-		return true
-	}
-	if strings.HasSuffix(routePath, "/*") {
-		base := strings.TrimSuffix(routePath, "/*")
-		return requestPath == base || strings.HasPrefix(requestPath, base+"/")
-	}
-	if routePath == "/" {
-		return requestPath == "/"
-	}
-	return requestPath == routePath
+	return packageio.UIRouteMatches(routePath, requestPath)
 }

--- a/gestaltd/services/plugins/store/store.go
+++ b/gestaltd/services/plugins/store/store.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	providerpkg "github.com/valon-technologies/gestalt/server/services/plugins/providerpkg"
+	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 )
 
 type InstalledPlugin struct {
@@ -25,20 +25,20 @@ type InstalledPlugin struct {
 }
 
 func isUIOnly(manifest *providermanifestv1.Manifest) bool {
-	kind, err := providerpkg.ManifestKind(manifest)
+	kind, err := packageio.ManifestKind(manifest)
 	return err == nil && kind == providermanifestv1.KindUI
 }
 
 func manifestNeedsExecutableArtifact(manifest *providermanifestv1.Manifest) bool {
-	kind, err := providerpkg.ManifestKind(manifest)
+	kind, err := packageio.ManifestKind(manifest)
 	if err != nil {
 		return false
 	}
-	return providerpkg.EntrypointForKind(manifest, kind) != nil
+	return packageio.EntrypointForKind(manifest, kind) != nil
 }
 
 func Install(packagePath, destDir string) (*InstalledPlugin, error) {
-	_, manifest, err := providerpkg.ReadPackageManifest(packagePath)
+	_, manifest, err := packageio.ReadPackageManifest(packagePath)
 	if err != nil {
 		return nil, err
 	}
@@ -47,12 +47,12 @@ func Install(packagePath, destDir string) (*InstalledPlugin, error) {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return nil, fmt.Errorf("create plugin directory: %w", err)
 		}
-		if err := providerpkg.ExtractPackage(packagePath, destDir); err != nil {
+		if err := packageio.ExtractPackage(packagePath, destDir); err != nil {
 			return nil, err
 		}
-		manifestPath, _ := providerpkg.FindManifestFile(destDir)
+		manifestPath, _ := packageio.FindManifestFile(destDir)
 		if manifestPath == "" {
-			manifestPath = filepath.Join(destDir, providerpkg.ManifestFile)
+			manifestPath = filepath.Join(destDir, packageio.ManifestFile)
 		}
 		assetRoot := filepath.Join(destDir, filepath.FromSlash(manifest.Spec.AssetRoot))
 		installed := buildInstalledPlugin(manifest, destDir, manifestPath, "", nil, assetRoot)
@@ -61,11 +61,11 @@ func Install(packagePath, destDir string) (*InstalledPlugin, error) {
 
 	var artifact *providermanifestv1.Artifact
 	if manifestNeedsExecutableArtifact(manifest) {
-		artifact, err = providerpkg.CurrentPlatformArtifact(manifest)
+		artifact, err = packageio.CurrentPlatformArtifact(manifest)
 		if err != nil {
 			return nil, err
 		}
-		artifactBytes, err := providerpkg.ReadArchiveEntry(packagePath, artifact.Path)
+		artifactBytes, err := packageio.ReadArchiveEntry(packagePath, artifact.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -78,15 +78,15 @@ func Install(packagePath, destDir string) (*InstalledPlugin, error) {
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return nil, fmt.Errorf("create plugin directory: %w", err)
 	}
-	if err := providerpkg.ExtractPackage(packagePath, destDir); err != nil {
+	if err := packageio.ExtractPackage(packagePath, destDir); err != nil {
 		return nil, err
 	}
 
-	manifestPath, _ := providerpkg.FindManifestFile(destDir)
+	manifestPath, _ := packageio.FindManifestFile(destDir)
 	if manifestPath == "" {
-		manifestPath = filepath.Join(destDir, providerpkg.ManifestFile)
+		manifestPath = filepath.Join(destDir, packageio.ManifestFile)
 	}
-	manifest = providerpkg.ResolveManifestLocalReferences(manifest, manifestPath)
+	manifest = packageio.ResolveManifestLocalReferences(manifest, manifestPath)
 	executablePath, err := executablePathForManifest(destDir, manifest)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func Install(packagePath, destDir string) (*InstalledPlugin, error) {
 }
 
 func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
-	_, manifest, _, err := providerpkg.LoadManifestFromPath(dirPath)
+	_, manifest, _, err := packageio.LoadManifestFromPath(dirPath)
 	if err != nil {
 		return nil, err
 	}
@@ -109,9 +109,9 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 		if err := copyDir(dirPath, destDir); err != nil {
 			return nil, fmt.Errorf("copy plugin directory: %w", err)
 		}
-		mfPath, _ := providerpkg.FindManifestFile(destDir)
+		mfPath, _ := packageio.FindManifestFile(destDir)
 		if mfPath == "" {
-			mfPath = filepath.Join(destDir, providerpkg.ManifestFile)
+			mfPath = filepath.Join(destDir, packageio.ManifestFile)
 		}
 		assetRoot := filepath.Join(destDir, filepath.FromSlash(manifest.Spec.AssetRoot))
 		installed := buildInstalledPlugin(manifest, destDir, mfPath, "", nil, assetRoot)
@@ -120,7 +120,7 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 
 	var artifact *providermanifestv1.Artifact
 	if manifestNeedsExecutableArtifact(manifest) {
-		artifact, err = providerpkg.CurrentPlatformArtifact(manifest)
+		artifact, err = packageio.CurrentPlatformArtifact(manifest)
 		if err != nil {
 			return nil, err
 		}
@@ -144,7 +144,7 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 		return nil, fmt.Errorf("create plugin directory: %w", err)
 	}
 
-	manifestSrc, err := providerpkg.FindManifestFile(dirPath)
+	manifestSrc, err := packageio.FindManifestFile(dirPath)
 	if err != nil {
 		return nil, fmt.Errorf("find manifest: %w", err)
 	}
@@ -167,7 +167,7 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 	if err := copyManifestReferencedFiles(dirPath, destDir, manifest); err != nil {
 		return nil, err
 	}
-	manifest = providerpkg.ResolveManifestLocalReferences(manifest, manifestDest)
+	manifest = packageio.ResolveManifestLocalReferences(manifest, manifestDest)
 
 	executablePath, err := executablePathForManifest(destDir, manifest)
 	if err != nil {
@@ -202,11 +202,11 @@ func executablePathForManifest(root string, manifest *providermanifestv1.Manifes
 	if isUIOnly(manifest) {
 		return "", nil
 	}
-	kind, err := providerpkg.ManifestKind(manifest)
+	kind, err := packageio.ManifestKind(manifest)
 	if err != nil {
 		return "", err
 	}
-	entry := providerpkg.EntrypointForKind(manifest, kind)
+	entry := packageio.EntrypointForKind(manifest, kind)
 	if entry == nil {
 		if manifest.Spec != nil && manifest.Spec.IsManifestBacked() {
 			return "", nil
@@ -220,7 +220,7 @@ func executablePathForManifest(root string, manifest *providermanifestv1.Manifes
 }
 
 func copyManifestReferencedFiles(srcDir, destDir string, manifest *providermanifestv1.Manifest) error {
-	for _, ref := range providerpkg.LocalPackageReferences(manifest) {
+	for _, ref := range packageio.LocalPackageReferences(manifest) {
 		src := filepath.Join(srcDir, filepath.FromSlash(ref.Path))
 		dest := filepath.Join(destDir, filepath.FromSlash(ref.Path))
 		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
@@ -231,16 +231,16 @@ func copyManifestReferencedFiles(srcDir, destDir string, manifest *providermanif
 		}
 	}
 	if manifest != nil && manifest.Spec != nil {
-		src := providerpkg.StaticCatalogPath(srcDir)
-		dest := providerpkg.StaticCatalogPath(destDir)
+		src := packageio.StaticCatalogPath(srcDir)
+		dest := packageio.StaticCatalogPath(destDir)
 		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 			return fmt.Errorf("create provider static catalog directory: %w", err)
 		}
 		if err := copyFile(src, dest); err != nil {
-			if os.IsNotExist(err) && !providerpkg.StaticCatalogRequired(manifest) {
+			if os.IsNotExist(err) && !packageio.StaticCatalogRequired(manifest) {
 				return nil
 			}
-			return fmt.Errorf("copy provider static catalog %s: %w", providerpkg.StaticCatalogFile, err)
+			return fmt.Errorf("copy provider static catalog %s: %w", packageio.StaticCatalogFile, err)
 		}
 	}
 	return nil

--- a/gestaltd/services/plugins/store/store_test.go
+++ b/gestaltd/services/plugins/store/store_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
-	providerpkg "github.com/valon-technologies/gestalt/server/services/plugins/providerpkg"
+	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 )
 
 const testCatalogYAML = "name: provider\noperations:\n  - id: echo\n    method: POST\n"
@@ -40,7 +40,7 @@ func TestInstall(t *testing.T) {
 	if installed1.Root != dest1 {
 		t.Fatalf("Root = %q, want %q", installed1.Root, dest1)
 	}
-	if installed1.ManifestPath != filepath.Join(dest1, providerpkg.ManifestFile) {
+	if installed1.ManifestPath != filepath.Join(dest1, packageio.ManifestFile) {
 		t.Fatalf("ManifestPath = %q", installed1.ManifestPath)
 	}
 	if installed1.ExecutablePath != filepath.Join(dest1, "artifacts", runtime.GOOS, runtime.GOARCH, "provider") {
@@ -321,11 +321,11 @@ func mustBuildPluginDir(t *testing.T, dir, source, version, content, schema stri
 			ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")),
 		},
 	}
-	manifestBytes, err := providerpkg.EncodeManifest(manifest)
+	manifestBytes, err := packageio.EncodeManifest(manifest)
 	if err != nil {
 		t.Fatalf("EncodeManifest: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, providerpkg.ManifestFile), manifestBytes, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, packageio.ManifestFile), manifestBytes, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "catalog.yaml"), []byte(testCatalogYAML), 0644); err != nil {
@@ -362,11 +362,11 @@ func mustBuildPluginDirWithDigest(t *testing.T, dir, source, version, content, d
 			ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")),
 		},
 	}
-	manifestBytes, err := providerpkg.EncodeManifest(manifest)
+	manifestBytes, err := packageio.EncodeManifest(manifest)
 	if err != nil {
 		t.Fatalf("EncodeManifest: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, providerpkg.ManifestFile), manifestBytes, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, packageio.ManifestFile), manifestBytes, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "catalog.yaml"), []byte(testCatalogYAML), 0644); err != nil {
@@ -413,11 +413,11 @@ func mustBuildPackageWithDigest(t *testing.T, dir, source, version, content, dig
 			ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")),
 		},
 	}
-	manifestBytes, err := providerpkg.EncodeManifest(manifest)
+	manifestBytes, err := packageio.EncodeManifest(manifest)
 	if err != nil {
 		t.Fatalf("EncodeManifest: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, providerpkg.ManifestFile), manifestBytes, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, packageio.ManifestFile), manifestBytes, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "catalog.yaml"), []byte(testCatalogYAML), 0644); err != nil {
@@ -425,7 +425,7 @@ func mustBuildPackageWithDigest(t *testing.T, dir, source, version, content, dig
 	}
 
 	archivePath := filepath.Join(dir, filepath.Base(srcDir)+".tar.gz")
-	if err := providerpkg.CreatePackageFromDir(srcDir, archivePath); err != nil {
+	if err := packageio.CreatePackageFromDir(srcDir, archivePath); err != nil {
 		t.Fatalf("CreatePackageFromDir: %v", err)
 	}
 	return archivePath
@@ -451,7 +451,7 @@ func mustBuildMismatchPackage(t *testing.T, dir, source, version, content, diges
 			ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")),
 		},
 	}
-	manifestBytes, err := providerpkg.EncodeManifest(manifest)
+	manifestBytes, err := packageio.EncodeManifest(manifest)
 	if err != nil {
 		t.Fatalf("EncodeManifest: %v", err)
 	}
@@ -473,7 +473,7 @@ func mustBuildMismatchPackage(t *testing.T, dir, source, version, content, diges
 			t.Fatalf("Write file %s: %v", name, err)
 		}
 	}
-	writeFile(providerpkg.ManifestFile, manifestBytes, 0644)
+	writeFile(packageio.ManifestFile, manifestBytes, 0644)
 	writeFile("catalog.yaml", []byte(testCatalogYAML), 0644)
 	writeFile(filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")), []byte(content), 0755)
 
@@ -511,7 +511,7 @@ func mustBuildPackageWithDuplicateArtifact(t *testing.T, dir, source, version, f
 			ArtifactPath: artifactName,
 		},
 	}
-	manifestBytes, err := providerpkg.EncodeManifest(manifest)
+	manifestBytes, err := packageio.EncodeManifest(manifest)
 	if err != nil {
 		t.Fatalf("EncodeManifest: %v", err)
 	}
@@ -533,7 +533,7 @@ func mustBuildPackageWithDuplicateArtifact(t *testing.T, dir, source, version, f
 			t.Fatalf("Write file %s: %v", name, err)
 		}
 	}
-	writeFile(providerpkg.ManifestFile, manifestBytes, 0644)
+	writeFile(packageio.ManifestFile, manifestBytes, 0644)
 	writeFile("catalog.yaml", []byte(testCatalogYAML), 0644)
 	writeFile(artifactName, []byte(firstContent), 0755)
 	writeFile(artifactName, []byte(secondContent), 0755)
@@ -586,11 +586,11 @@ func mustBuildV2Package(t *testing.T, dir, source, version, content string) stri
 	}
 
 	manifest := newV2Manifest(source, version, content)
-	manifestBytes, err := providerpkg.EncodeManifest(manifest)
+	manifestBytes, err := packageio.EncodeManifest(manifest)
 	if err != nil {
 		t.Fatalf("EncodeManifest: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sourceDir, providerpkg.ManifestFile), manifestBytes, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(sourceDir, packageio.ManifestFile), manifestBytes, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(sourceDir, "catalog.yaml"), []byte(testCatalogYAML), 0644); err != nil {
@@ -598,7 +598,7 @@ func mustBuildV2Package(t *testing.T, dir, source, version, content string) stri
 	}
 
 	archivePath := filepath.Join(dir, safeName+".tar.gz")
-	if err := providerpkg.CreatePackageFromDir(sourceDir, archivePath); err != nil {
+	if err := packageio.CreatePackageFromDir(sourceDir, archivePath); err != nil {
 		t.Fatalf("CreatePackageFromDir: %v", err)
 	}
 	return archivePath
@@ -618,11 +618,11 @@ func mustBuildV2PluginDir(t *testing.T, dir, source, version, content string) st
 	}
 
 	manifest := newV2Manifest(source, version, content)
-	manifestBytes, err := providerpkg.EncodeManifest(manifest)
+	manifestBytes, err := packageio.EncodeManifest(manifest)
 	if err != nil {
 		t.Fatalf("EncodeManifest: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sourceDir, providerpkg.ManifestFile), manifestBytes, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(sourceDir, packageio.ManifestFile), manifestBytes, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(sourceDir, "catalog.yaml"), []byte(testCatalogYAML), 0644); err != nil {

--- a/gestaltd/services/plugins/validation_config.go
+++ b/gestaltd/services/plugins/validation_config.go
@@ -6,94 +6,36 @@ import (
 	"path/filepath"
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
 	"github.com/valon-technologies/gestalt/server/services/plugins/openapi"
-	"github.com/valon-technologies/gestalt/server/services/plugins/providerpkg"
+	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 )
 
 func ValidateEffectiveManifest(ctx context.Context, name, manifestPath string, manifest *providermanifestv1.Manifest) error {
 	return ValidateEffectiveCatalog(ctx, name, ValidationPluginFromManifest(manifestPath, manifest))
 }
 
-func ValidationConfigFromConfig(cfg *config.Config) *ValidationConfig {
-	if cfg == nil {
-		return nil
-	}
-	validation := &ValidationConfig{
-		Plugins: make(map[string]*ValidationPlugin, len(cfg.Plugins)),
-	}
-	for name, entry := range cfg.Plugins {
-		validation.Plugins[name] = ValidationPluginFromProviderEntry(entry)
-	}
-	return validation
-}
-
-func ValidationPluginFromProviderEntry(entry *config.ProviderEntry) *ValidationPlugin {
-	if entry == nil {
-		return nil
-	}
-	return &ValidationPlugin{
-		Manifest:            entry.ResolvedManifest,
-		ManifestPath:        entry.ResolvedManifestPath,
-		AllowedOperations:   entry.AllowedOperations,
-		Invokes:             invocationDependencies(entry.Invokes),
-		SurfaceURLOverrides: surfaceURLOverrides(entry),
-		ReadStaticCatalog:   staticCatalogReader(entry),
-		LoadAPICatalog:      loadAPICatalog,
-	}
-}
-
 func ValidationPluginFromManifest(manifestPath string, manifest *providermanifestv1.Manifest) *ValidationPlugin {
-	return ValidationPluginFromProviderEntry(&config.ProviderEntry{
-		ResolvedManifestPath: manifestPath,
-		ResolvedManifest:     manifest,
-	})
+	return &ValidationPlugin{
+		Manifest:          manifest,
+		ManifestPath:      manifestPath,
+		ReadStaticCatalog: StaticCatalogReaderForManifest(manifestPath),
+		LoadAPICatalog:    DefaultAPICatalogLoader,
+	}
 }
 
-func invocationDependencies(dependencies []config.PluginInvocationDependency) []InvocationDependency {
-	if len(dependencies) == 0 {
+func StaticCatalogReaderForManifest(manifestPath string) StaticCatalogReader {
+	if manifestPath == "" {
 		return nil
 	}
-	result := make([]InvocationDependency, 0, len(dependencies))
-	for _, dependency := range dependencies {
-		result = append(result, InvocationDependency{
-			Plugin:    dependency.Plugin,
-			Operation: dependency.Operation,
-			Surface:   SpecSurface(dependency.Surface),
-		})
-	}
-	return result
-}
-
-func surfaceURLOverrides(entry *config.ProviderEntry) map[SpecSurface]string {
-	if entry == nil {
-		return nil
-	}
-	overrides := make(map[SpecSurface]string)
-	for _, surface := range []SpecSurface{SpecSurfaceGraphQL, SpecSurfaceMCP} {
-		if url := config.ProviderSurfaceURLOverride(entry, config.SpecSurface(surface)); url != "" {
-			overrides[surface] = url
-		}
-	}
-	if len(overrides) == 0 {
-		return nil
-	}
-	return overrides
-}
-
-func staticCatalogReader(entry *config.ProviderEntry) StaticCatalogReader {
-	if entry == nil || entry.ResolvedManifestPath == "" {
-		return nil
-	}
-	root := filepath.Dir(entry.ResolvedManifestPath)
+	root := filepath.Dir(manifestPath)
 	return func(name string) (*catalog.Catalog, error) {
-		return providerpkg.ReadStaticCatalog(root, name)
+		return packageio.ReadStaticCatalog(root, name)
 	}
 }
 
-func loadAPICatalog(ctx context.Context, name string, surface SpecSurface, specURL string, allowed map[string]*OperationOverride) (*catalog.Catalog, error) {
+func DefaultAPICatalogLoader(ctx context.Context, name string, surface SpecSurface, specURL string, allowed map[string]*OperationOverride) (*catalog.Catalog, error) {
 	switch surface {
 	case SpecSurfaceOpenAPI:
 		def, err := openapi.LoadDefinition(ctx, name, specURL, allowed)

--- a/gestaltd/services/plugins/validation_types.go
+++ b/gestaltd/services/plugins/validation_types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/plugins/operationexposure"
+	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 )
 
 type OperationOverride = operationexposure.OperationOverride
@@ -19,7 +20,7 @@ const (
 	SpecSurfaceGraphQL SpecSurface = "graphql"
 	SpecSurfaceMCP     SpecSurface = "mcp"
 
-	StaticCatalogFile = "catalog.yaml"
+	StaticCatalogFile = packageio.StaticCatalogFile
 )
 
 type InvocationDependency struct {
@@ -103,5 +104,5 @@ func resolveManifestRelativeSpecURL(manifestPath, raw string) string {
 }
 
 func staticCatalogRequired(manifest *providermanifestv1.Manifest) bool {
-	return manifest != nil && manifest.Kind == providermanifestv1.KindPlugin && manifest.Spec != nil && !manifest.Spec.IsManifestBacked()
+	return packageio.StaticCatalogRequired(manifest)
 }


### PR DESCRIPTION
## Summary

Move shared plugin package IO primitives into `services/plugins/packageio` and keep `services/plugins/providerpkg` as a compatibility facade for existing packaging/build callers. This removes the remaining `internal/config` and provider package leakage from `services/plugins` validation/store code while preserving providerpkg's public surface for source build and release flows.

## Interface Changes

- New service-owned package primitives:
  ```go
  data, manifest, err := packageio.ReadPackageManifest(packagePath)
  err = packageio.ExtractPackage(packagePath, installRoot)
  cat, err := packageio.ReadStaticCatalog(filepath.Dir(manifestPath), pluginName)
  ```

- Config-free plugin validation helper now wires static catalog loading and API catalog loading without importing daemon config:
  ```go
  entry := plugins.ValidationPluginFromManifest(manifestPath, manifest)
  err := plugins.ValidateEffectiveCatalog(ctx, name, entry)
  ```

- Daemon config projection is now an internal config adapter:
  ```go
  validation := config.PluginValidationConfig(cfg)
  err := plugins.ValidateEffectiveCatalogsAndDependencies(ctx, validation)
  ```

- `services/plugins/providerpkg` remains a compatibility facade:
  ```go
  archivePath, err := providerpkg.ArchiveDigest(path)
  data, manifest, err := providerpkg.ReadManifestFile(manifestPath)
  ```

## Functional/Integration Tests

- `cd gestaltd && go test ./services/plugins/...`
- `cd gestaltd && go test ./internal/config ./internal/bootstrap ./services/operator ./internal/server`
- `cd gestaltd && go test -race ./services/plugins/providerpkg`
- `git diff --check`
- `git grep -n "github.com/valon-technologies/gestalt/server/internal" -- 'gestaltd/services/plugins/**/*.go' 'gestaltd/services/plugins/*.go' ':!**/*_test.go'` returned no output

## Contract Boundary Covered

- Plugin archive/directory input -> `packageio`/store install output.
- Daemon config -> internal config adapter -> `plugins.ValidationConfig` -> plugin validation.
- Existing `providerpkg` callers -> compatibility facade -> service-owned package IO implementation.