### PR TITLE
Add hosted runtime relay base URL override

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -119,6 +119,9 @@ server:
       name: gestalt-encryption-key
   apiTokenTtl: 30d
   artifactsDir: ./state
+  runtime:
+    defaultHostedProvider: modal
+    relayBaseUrl: https://gestalt.example.com
   providers:
     authorization: indexeddb
     authentication: oidc
@@ -148,6 +151,8 @@ authorization:
 
 `apiTokenTtl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifactsDir` is a writable directory for prepared artifacts produced by `gestaltd sync --locked` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `lock`/`sync`/`serve` lifecycle.
 
+`runtime.defaultHostedProvider` selects the runtime provider used when a plugin or agent opts into hosted execution without naming a provider. `runtime.relayBaseUrl` overrides the URL handed to hosted runtimes for Gestalt host-service callbacks and hostname egress proxying. It defaults to `server.baseUrl`; set it when hosted runtimes need to call back through a private deployment URL while browser and OAuth flows still use the public origin.
+
 `admin.authorizationPolicy` binds the built-in `/admin` route to one shared subject access policy from `authorization.policies`. `admin.allowedRoles` controls which roles may load the built-in admin UI, defaulting to `[admin]`.
 
 `admin.ui` optionally pins `/admin` to one named `providers.ui.<name>` bundle. The selected bundle must ship `admin/index.html` inside its prepared asset root. When `admin.ui` is omitted, Gestalt first auto-discovers admin assets from the root-mounted UI bundle (`path: /`) when that bundle contains `admin/index.html`, then falls back to the built-in admin shell.
@@ -174,6 +179,7 @@ Plugins without `authorizationPolicy` are open to any authenticated subject. Bin
 | `providers.audit` / `providers.authentication` / `providers.authorization` / `providers.indexeddb` / `providers.secrets` / `providers.telemetry` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
 | `dev.attachmentState` | | Enables private remote provider-dev attach routes and selects where attachment state is stored. The only supported value is `indexeddb`, which stores attachment state in the configured host IndexedDB for shared and load-balanced servers. |
 | `runtime.defaultHostedProvider` | | Default runtime-provider selector for plugins that opt into `execution.mode: hosted`. This does not move plugins into hosted runtimes by itself. |
+| `runtime.relayBaseUrl` | `server.baseUrl` | Absolute HTTP(S) URL that hosted runtimes use for Gestalt host-service relay and egress proxy callbacks. |
 | `admin.authorizationPolicy` | | Shared subject access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
 | `admin.ui` | | Optional named `providers.ui` bundle whose `admin/` assets should back `/admin`. When omitted, Gestalt auto-discovers `admin/` assets from the root UI bundle before using the built-in fallback. |
@@ -260,6 +266,9 @@ means `server.baseUrl` and `server.encryptionKey` must be set, and the runtime
 must report a compatible support profile. Without those prerequisites, Gestalt
 will reject Modal for plugins that need relay-backed host services,
 `egress.allowedHosts`, or a server-wide default-deny egress policy.
+When hosted runtimes cannot reach `server.baseUrl` directly, set
+`server.runtime.relayBaseUrl` to the private HTTP(S) origin they should use for
+host-service relay and egress proxy callbacks.
 
 Hosted runtime images are expected to contain the provider package at the image
 working directory. Gestalt starts the executable declared by the provider

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -1455,11 +1455,12 @@ func TestAgentRuntimeConfigUsesPublicAgentHostBinding(t *testing.T) {
 	}
 
 	deps := Deps{
-		BaseURL:            relaySrv.URL,
-		EncryptionKey:      secret,
-		Services:           services,
-		AgentRuntime:       agentRuntime,
-		PublicHostServices: publicHostServices,
+		BaseURL:             "https://gestalt.example.test",
+		RuntimeRelayBaseURL: relaySrv.URL,
+		EncryptionKey:       secret,
+		Services:            services,
+		AgentRuntime:        agentRuntime,
+		PublicHostServices:  publicHostServices,
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -147,6 +147,7 @@ type Deps struct {
 	// raw config value.
 	EncryptionKey         []byte
 	BaseURL               string
+	RuntimeRelayBaseURL   string
 	SecretManager         core.SecretManager
 	Services              *coredata.Services
 	SelectedIndexedDBName string
@@ -791,6 +792,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	deps := Deps{
 		EncryptionKey:        encKey,
 		BaseURL:              cfg.Server.BaseURL,
+		RuntimeRelayBaseURL:  cfg.Server.Runtime.RelayBaseURL,
 		SecretManager:        sm,
 		Telemetry:            tp,
 		AgentToolGrants:      agentToolGrants,

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -7905,9 +7905,10 @@ func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapa
 		},
 	}
 	deps := Deps{
-		BaseURL:       "https://gestalt.example.test",
-		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
-		Egress:        EgressDeps{DefaultAction: egress.PolicyDeny},
+		BaseURL:             "https://gestalt.example.test",
+		RuntimeRelayBaseURL: "http://gestaltd.gestalt-runtime.svc.cluster.local:8080",
+		EncryptionKey:       []byte("0123456789abcdef0123456789abcdef"),
+		Egress:              EgressDeps{DefaultAction: egress.PolicyDeny},
 	}
 	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 
@@ -7936,11 +7937,11 @@ func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapa
 	if err != nil {
 		t.Fatalf("parse HTTP_PROXY: %v", err)
 	}
-	if parsed.Scheme != "https" {
-		t.Fatalf("HTTP_PROXY scheme = %q, want https", parsed.Scheme)
+	if parsed.Scheme != "http" {
+		t.Fatalf("HTTP_PROXY scheme = %q, want explicit relay base URL scheme http", parsed.Scheme)
 	}
-	if parsed.Host != "gestalt.example.test" {
-		t.Fatalf("HTTP_PROXY host = %q, want gestalt.example.test", parsed.Host)
+	if parsed.Host != "gestaltd.gestalt-runtime.svc.cluster.local:8080" {
+		t.Fatalf("HTTP_PROXY host = %q, want explicit relay base URL host", parsed.Host)
 	}
 	if parsed.User == nil {
 		t.Fatal("HTTP_PROXY should include relay credentials")

--- a/gestaltd/internal/bootstrap/plugin_runtime_plan.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_plan.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost/pluginruntime"
@@ -95,12 +96,20 @@ func hostCanRelayPluginRuntimeHostServices(deps Deps) bool {
 	if len(deps.EncryptionKey) == 0 {
 		return false
 	}
-	_, _, err := pluginRuntimePublicProxyBaseURL(deps.BaseURL)
+	baseURL, explicit := hostedRuntimeRelayBaseURL(deps)
+	_, _, err := pluginRuntimePublicProxyBaseURL(baseURL, explicit)
 	return err == nil
 }
 
 func hostCanProvideHostedHostnameEgress(deps Deps) bool {
 	return hostCanRelayPluginRuntimeHostServices(deps)
+}
+
+func hostedRuntimeRelayBaseURL(deps Deps) (string, bool) {
+	if baseURL := strings.TrimSpace(deps.RuntimeRelayBaseURL); baseURL != "" {
+		return baseURL, true
+	}
+	return strings.TrimSpace(deps.BaseURL), false
 }
 
 func pluginRuntimeRequirementsForPlugin(name string, entry *config.ProviderEntry, deps Deps) (bool, bool, error) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1761,10 +1761,11 @@ func registerPublicRuntimeHostServices(providerName string, hostServices []runti
 }
 
 func buildHostedRuntimePublicEgressProxy(providerName, sessionID string, allowedHosts []string, defaultAction egress.PolicyAction, deps Deps) (map[string]string, error) {
-	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
+	baseURL, explicitRelayBaseURL := hostedRuntimeRelayBaseURL(deps)
+	if baseURL == "" || len(deps.EncryptionKey) == 0 {
 		return nil, fmt.Errorf("provider %q requires server.baseURL and server.encryptionKey to enforce hostname-based egress for hosted runtimes", providerName)
 	}
-	proxyBaseURL, _, err := pluginRuntimePublicProxyBaseURL(deps.BaseURL)
+	proxyBaseURL, _, err := pluginRuntimePublicProxyBaseURL(baseURL, explicitRelayBaseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -1798,10 +1799,11 @@ func publicRuntimeRegistryHostServices(hostServices []runtimehost.HostService) [
 }
 
 func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, hostService hostServiceBindingDescriptor, deps Deps, serviceKey, serviceLabel, methodPrefix string) (string, map[string]string, string, bool, error) {
-	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
+	baseURL, explicitRelayBaseURL := hostedRuntimeRelayBaseURL(deps)
+	if baseURL == "" || len(deps.EncryptionKey) == 0 {
 		return "", nil, "", false, nil
 	}
-	dialTarget, relayHost, err := pluginRuntimePublicRelayTarget(deps.BaseURL)
+	dialTarget, relayHost, err := pluginRuntimePublicRelayTarget(baseURL, explicitRelayBaseURL)
 	if err != nil {
 		return "", nil, "", false, err
 	}
@@ -1825,8 +1827,8 @@ func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, ho
 	}, relayHost, true, nil
 }
 
-func pluginRuntimePublicRelayTarget(baseURL string) (string, string, error) {
-	parsed, host, err := pluginRuntimePublicProxyBaseURL(baseURL)
+func pluginRuntimePublicRelayTarget(baseURL string, allowInsecureHTTP bool) (string, string, error) {
+	parsed, host, err := pluginRuntimePublicProxyBaseURL(baseURL, allowInsecureHTTP)
 	if err != nil {
 		return "", "", err
 	}
@@ -1849,7 +1851,7 @@ func pluginRuntimePublicRelayTarget(baseURL string) (string, string, error) {
 	}
 }
 
-func pluginRuntimePublicProxyBaseURL(baseURL string) (*url.URL, string, error) {
+func pluginRuntimePublicProxyBaseURL(baseURL string, allowInsecureHTTP bool) (*url.URL, string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(baseURL))
 	if err != nil {
 		return nil, "", fmt.Errorf("parse server.baseURL for public runtime relay: %w", err)
@@ -1867,7 +1869,7 @@ func pluginRuntimePublicProxyBaseURL(baseURL string) (*url.URL, string, error) {
 	switch strings.ToLower(parsed.Scheme) {
 	case "https":
 	case "http":
-		if !isLoopbackAllowedHost(host) {
+		if !allowInsecureHTTP && !isLoopbackAllowedHost(host) {
 			return nil, "", fmt.Errorf("server.baseURL %q must use https for public runtime relay unless it targets loopback", baseURL)
 		}
 	default:

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1428,6 +1428,7 @@ const DevAttachmentStateIndexedDB DevAttachmentState = "indexeddb"
 
 type ServerRuntimeConfig struct {
 	DefaultHostedProvider string `yaml:"defaultHostedProvider,omitempty"`
+	RelayBaseURL          string `yaml:"relayBaseUrl,omitempty"`
 }
 
 func (s ServerConfig) PublicListener() ListenerConfig {
@@ -2880,6 +2881,7 @@ func applyPluginMountBindings(cfg *Config) error {
 func resolveBaseURL(cfg *Config) {
 	cfg.Server.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.BaseURL), "/")
 	cfg.Server.Management.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Management.BaseURL), "/")
+	cfg.Server.Runtime.RelayBaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Runtime.RelayBaseURL), "/")
 }
 
 func resolveRelativePathsInValue(configPath string, root map[string]any) {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3834,6 +3834,46 @@ server:
 	}
 }
 
+func TestLoadConfigRuntimeRelayBaseURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("accepts and trims relay base url", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  runtime:
+    relayBaseUrl: http://valon-tools-gestaltd.gestalt-runtime.svc.cluster.local:8080/
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Server.Runtime.RelayBaseURL; got != "http://valon-tools-gestaltd.gestalt-runtime.svc.cluster.local:8080" {
+			t.Fatalf("server.runtime.relayBaseUrl = %q", got)
+		}
+	})
+
+	t.Run("rejects relay base url with path", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  runtime:
+    relayBaseUrl: https://gestalt.example.test/relay
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "server.runtime.relayBaseUrl must not include a path") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestLoadPathsProviderExecutionAndEgressOverride(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -427,6 +427,10 @@ func validateRuntimeConfig(cfg *Config) error {
 		return nil
 	}
 	cfg.Server.Runtime.DefaultHostedProvider = strings.TrimSpace(cfg.Server.Runtime.DefaultHostedProvider)
+	cfg.Server.Runtime.RelayBaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Runtime.RelayBaseURL), "/")
+	if err := validateRuntimeRelayBaseURL(cfg.Server.Runtime.RelayBaseURL); err != nil {
+		return err
+	}
 	for name, entry := range cfg.Runtime.Providers {
 		if entry == nil {
 			return fmt.Errorf("config validation: runtime.providers.%s is required", name)
@@ -458,6 +462,22 @@ func validateRuntimeConfig(cfg *Config) error {
 		return err
 	}
 	return nil
+}
+
+func validateRuntimeRelayBaseURL(raw string) error {
+	parsed, err := validateAbsoluteBaseURL("server.runtime.relayBaseUrl", raw)
+	if err != nil || parsed == nil {
+		return err
+	}
+	if path := strings.TrimSpace(parsed.EscapedPath()); path != "" && path != "/" {
+		return fmt.Errorf("config validation: server.runtime.relayBaseUrl must not include a path")
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https":
+		return nil
+	default:
+		return fmt.Errorf("config validation: server.runtime.relayBaseUrl must use http or https")
+	}
 }
 
 func runtimeProviderUsesSource(entry *RuntimeProviderEntry) bool {


### PR DESCRIPTION
## Summary
- add `server.runtime.relayBaseUrl` so hosted runtimes can call back through a private relay origin instead of the public browser/OAuth origin
- use the relay override for hosted runtime host-service callbacks and hostname egress proxy planning
- document the setting and cover config/bootstrap behavior in tests

## Testing
- `go test ./internal/config -run 'TestLoadConfigRuntimeRelayBaseURL|TestLoadConfigAgentRuntimeLifecycleFields'`\n- `go test ./internal/bootstrap -run 'TestHostedAgent'`\n- `go test ./internal/config ./internal/bootstrap`