### PR TITLE
Allow runtime callbacks on management listener

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -262,10 +262,14 @@ The built-in `local` runtime handles same-machine execution. Installable
 The current Modal backend requires `runtime.providers.<name>.config.app` and
 `plugins.<name>.execution.runtime.image`. Modal can satisfy plugins that need
 Gestalt-owned services or hostname-based egress when the host is configured for
-the public relay and proxy path. In practice that means `server.baseUrl` and
-`server.encryptionKey` must be set, and the runtime must report a compatible
-support profile. Without those prerequisites, Gestalt rejects Modal for plugins
-that require relay-backed host services or hostname-based egress.
+the public relay and proxy path. In practice that means `server.baseUrl` (or
+`server.runtime.relayBaseUrl`) and `server.encryptionKey` must be set, and the
+runtime must report a compatible support profile. Set
+`server.runtime.relayBaseUrl` when hosted runtimes should call back through a
+private listener, the management listener, or an internal reverse proxy instead
+of the browser/OAuth public origin. Without those prerequisites, Gestalt rejects
+Modal for plugins that require relay-backed host services or hostname-based
+egress.
 
 For the runtime-provider lifecycle and support model, see
 [Providers > Runtime](/providers/runtime).

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -145,10 +145,12 @@ first installable hosted runtime provider is `modal`. It requires
 Gestalt only uses it for plain executable plugins today. Modal can still run
 plugins that need Gestalt-owned services or hostname-based egress when the host
 is configured for the public relay and proxy path. In practice that means
-`server.baseUrl` and `server.encryptionKey` must be set, and the runtime must
-report a compatible support profile. Without those prerequisites, plugins that
-need `indexeddb`, `cache`, `s3`, workflow-manager access when workflows are
-configured, nested `invokes`, `egress.allowedHosts`, or
+`server.baseUrl` (or `server.runtime.relayBaseUrl`) and `server.encryptionKey`
+must be set, and the runtime must report a compatible support profile. Set
+`server.runtime.relayBaseUrl` when hosted runtimes should use a private callback
+origin instead of the browser/OAuth public origin. Without those prerequisites,
+plugins that need `indexeddb`, `cache`, `s3`, workflow-manager access when
+workflows are configured, nested `invokes`, `egress.allowedHosts`, or
 `server.egress.defaultAction: deny` stay on `local`.
 
 For the runtime-provider model itself, see [Providers > Runtime](/providers/runtime).

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -82,10 +82,12 @@ and whether the runtime can preserve hostname-based `egress.allowedHosts`.
 
 Host-service access is derived by Gestalt from the current host deployment.
 `none` means host services are unavailable for that runtime, while `relay`
-means Gestalt can provide those services through the public relay path. Egress
-support is separate: a runtime must preserve Gestalt's hostname-based policy
-model before plugins with `egress.allowedHosts` or a default-deny egress policy
-can run there.
+means Gestalt can provide those services through the relay path exposed at
+`server.baseUrl`, or at `server.runtime.relayBaseUrl` when hosted runtimes need
+a private callback origin such as the management listener or an internal reverse
+proxy. Egress support is separate: a runtime must preserve Gestalt's
+hostname-based policy model before plugins with `egress.allowedHosts` or a
+default-deny egress policy can run there.
 
 The admin inspection API exposes both sides of that decision. `GET
 /admin/api/v1/runtime/providers` includes `profile.advertised`, which is what
@@ -97,8 +99,8 @@ considered.
 
 Plugins do not talk directly to host-local services over the public network.
 `gestaltd` starts those services on the host and gives the runtime relay-backed
-bindings. The hosted plugin talks back to `gestaltd` over a scoped public relay
-target, and `gestaltd` forwards the request to the real host-local service.
+bindings. The hosted plugin talks back to `gestaltd` over a scoped relay target,
+and `gestaltd` forwards the request to the real host-local service.
 
 That same split shows up in hostname-based egress. A runtime may preserve
 `egress.allowedHosts` internally, or it may preserve it by routing hosted

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -151,7 +151,7 @@ authorization:
 
 `apiTokenTtl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifactsDir` is a writable directory for prepared artifacts produced by `gestaltd sync --locked` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `lock`/`sync`/`serve` lifecycle.
 
-`runtime.defaultHostedProvider` selects the runtime provider used when a plugin or agent opts into hosted execution without naming a provider. `runtime.relayBaseUrl` overrides the URL handed to hosted runtimes for Gestalt host-service callbacks and hostname egress proxying. It defaults to `server.baseUrl`; set it when hosted runtimes need to call back through a private deployment URL while browser and OAuth flows still use the public origin.
+`runtime.defaultHostedProvider` selects the runtime provider used when a plugin or agent opts into hosted execution without naming a provider. `runtime.relayBaseUrl` overrides the URL handed to hosted runtimes for Gestalt host-service callbacks and hostname egress proxying. It defaults to `server.baseUrl`; set it when hosted runtimes need to call back through a private listener or internal reverse proxy while browser and OAuth flows still use the public origin. The target may be the management listener when that listener is reachable from the hosted runtime network.
 
 `admin.authorizationPolicy` binds the built-in `/admin` route to one shared subject access policy from `authorization.policies`. `admin.allowedRoles` controls which roles may load the built-in admin UI, defaulting to `[admin]`.
 
@@ -185,7 +185,9 @@ Plugins without `authorizationPolicy` are open to any authenticated subject. Bin
 | `admin.ui` | | Optional named `providers.ui` bundle whose `admin/` assets should back `/admin`. When omitted, Gestalt auto-discovers `admin/` assets from the root UI bundle before using the built-in fallback. |
 | `authorization.policies` | | Shared subject access policies resolved by canonical `subjectID`. |
 
-When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/admin/api/v1/*`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener. When `server.admin.authorizationPolicy` is set, Gestalt does apply browser session auth plus role-based policy checks to `/admin` and `/admin/api/v1/*`.
+When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/admin/api/v1/*`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener can also serve token-authenticated hosted-runtime host-service relay and egress proxy callbacks when `server.runtime.relayBaseUrl` points at that origin.
+
+The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener. When `server.admin.authorizationPolicy` is set, Gestalt does apply browser session auth plus role-based policy checks to `/admin` and `/admin/api/v1/*`.
 
 ## `runtime`
 
@@ -262,13 +264,15 @@ When a plugin uses the Modal runtime provider,
 `plugins.<name>.execution.runtime.image` is required. Modal can still run
 hosted plugins that need Gestalt-owned services or hostname-based egress when
 the host is configured for the public relay and proxy path. In practice that
-means `server.baseUrl` and `server.encryptionKey` must be set, and the runtime
-must report a compatible support profile. Without those prerequisites, Gestalt
-will reject Modal for plugins that need relay-backed host services,
+means `server.baseUrl` (or `server.runtime.relayBaseUrl`) and
+`server.encryptionKey` must be set, and the runtime must report a compatible
+support profile. Without those prerequisites, Gestalt will reject Modal for
+plugins that need relay-backed host services,
 `egress.allowedHosts`, or a server-wide default-deny egress policy.
 When hosted runtimes cannot reach `server.baseUrl` directly, set
 `server.runtime.relayBaseUrl` to the private HTTP(S) origin they should use for
-host-service relay and egress proxy callbacks.
+host-service relay and egress proxy callbacks. The origin can point at the
+management listener or another internal reverse proxy that reaches gestaltd.
 
 Hosted runtime images are expected to contain the provider package at the image
 working directory. Gestalt starts the executable declared by the provider

--- a/gestaltd/internal/server/egress_proxy.go
+++ b/gestaltd/internal/server/egress_proxy.go
@@ -23,7 +23,7 @@ func (s *Server) egressProxyMiddleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		if s.routeProfile == RouteProfileManagement || s.egressProxyTokens == nil || !isEgressProxyRequest(r) {
+		if s.egressProxyTokens == nil || !isEgressProxyRequest(r) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/gestaltd/internal/server/host_service_relay.go
+++ b/gestaltd/internal/server/host_service_relay.go
@@ -16,7 +16,7 @@ func (s *Server) hostServiceRelayMiddleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		if !isGRPCRequest(r) || s.routeProfile == RouteProfileManagement || s.hostServiceRelayTokens == nil {
+		if !isGRPCRequest(r) || s.hostServiceRelayTokens == nil {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -732,6 +732,63 @@ func TestHostServiceRelayProxiesGRPCRequests(t *testing.T) {
 	}
 }
 
+func TestHostServiceRelayProxiesGRPCRequestsOnManagementProfile(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	cacheSrv := &relayTestCacheServer{}
+	const envVar = "GESTALT_TEST_CACHE_SOCKET"
+	publicHostServices := runtimehost.NewPublicHostServiceRegistry()
+	publicHostServices.RegisterVerified("support", newRelayTestSessionVerifier("session-1"), runtimehost.HostService{
+		Name:   "cache",
+		EnvVar: envVar,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterCacheServer(srv, cacheSrv)
+		},
+	})
+
+	ts := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfileManagement
+		cfg.StateSecret = secret
+		cfg.PublicHostServices = publicHostServices
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	testutil.CloseOnCleanup(t, ts)
+
+	tokenManager, err := runtimehost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	token, err := tokenManager.MintToken(runtimehost.HostServiceRelayTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-1",
+		Service:      "cache",
+		EnvVar:       envVar,
+		MethodPrefix: "/" + proto.Cache_ServiceDesc.ServiceName + "/",
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	conn := newRelayGRPCConn(t, ts)
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(runtimehost.HostServiceRelayTokenHeader, token))
+	resp, err := proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "management"})
+	if err != nil {
+		t.Fatalf("Cache.Get via management relay: %v", err)
+	}
+	if got := string(resp.GetValue()); got != "relay:management" {
+		t.Fatalf("Cache.Get value = %q, want relay:management", got)
+	}
+	if got := cacheSrv.calls(); got != 1 {
+		t.Fatalf("backend calls = %d, want 1", got)
+	}
+}
+
 func TestHostServiceRelaySelectsVerifierForDuplicateProviderWideServices(t *testing.T) {
 	t.Parallel()
 
@@ -1391,6 +1448,55 @@ func TestEgressProxyProxiesHTTPRequest(t *testing.T) {
 	}
 	if got := string(body); got != "proxied-ok" {
 		t.Fatalf("proxy body = %q, want %q", got, "proxied-ok")
+	}
+}
+
+func TestEgressProxyProxiesHTTPRequestOnManagementProfile(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/management" {
+			t.Fatalf("target path = %q, want /management", got)
+		}
+		_, _ = io.WriteString(w, "management-proxied-ok")
+	}))
+	testutil.CloseOnCleanup(t, target)
+
+	proxy := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfileManagement
+		cfg.StateSecret = secret
+	}))
+	proxy.EnableHTTP2 = true
+	proxy.StartTLS()
+	testutil.CloseOnCleanup(t, proxy)
+
+	proxyURL := mustEgressProxyURL(t, proxy.URL, secret, egressproxy.TokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-1",
+		AllowedHosts: []string{"127.0.0.1", "localhost"},
+	})
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
+		},
+	}
+	resp, err := client.Get(target.URL + "/management")
+	if err != nil {
+		t.Fatalf("GET via management egress proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("proxy status = %d, want %d (body=%s)", resp.StatusCode, http.StatusOK, string(body))
+	}
+	if got := string(body); got != "management-proxied-ok" {
+		t.Fatalf("proxy body = %q, want %q", got, "management-proxied-ok")
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow token-authenticated host-service relay callbacks on `RouteProfileManagement`
- allow token-authenticated hostname egress proxy callbacks on `RouteProfileManagement`
- document that `server.runtime.relayBaseUrl` can target a private listener, the management listener, or an internal reverse proxy

## Interface Changes
- Changed interface: hosted runtime callbacks can now use `server.runtime.relayBaseUrl` pointing at the management/private origin, while `server.baseUrl` remains the browser/OAuth public origin.
- Example usage:

```yaml
server:
  baseUrl: https://gestalt.example.com
  management:
    host: 0.0.0.0
    port: 9090
    baseUrl: https://gestalt-admin.internal.example.com
  runtime:
    defaultHostedProvider: modal
    relayBaseUrl: https://gestalt-admin.internal.example.com
```

## Functional/Integration Tests
- Tests added or augmented: management-profile gRPC host-service relay transport test, management-profile HTTP egress proxy transport test, hosted egress proxy env contract test from #1684.
- Contract boundary covered: runtime callback URL selection plus actual token-authenticated transport through server middleware into registered host-service/proxy handlers.
- Commands run:
  - `go test ./internal/server -run 'TestHostServiceRelayProxiesGRPCRequests|TestHostServiceRelayProxiesGRPCRequestsOnManagementProfile|TestEgressProxyProxiesHTTPRequest|TestEgressProxyProxiesHTTPRequestOnManagementProfile|TestEgressProxySupportsHTTPSConnect|TestHostServiceRelayRoutesRegisteredRuntimeCoreServices' -count=1`
  - `go test ./internal/config ./internal/bootstrap ./internal/server -count=1`
  - `git diff --check origin/main...HEAD`
