### PR TITLE
Decouple service driver factories from bootstrap

### DIFF
--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -137,6 +137,13 @@ func TestE2EValidateAcceptsV3TelemetryBuiltins(t *testing.T) {
 			name:   "noop",
 			source: "noop",
 		},
+		{
+			name:   "stdout",
+			source: "stdout",
+			telemetryBlock: `      config:
+        level: debug
+        format: json`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
@@ -17,8 +19,10 @@ import (
 	telemetrystdout "github.com/valon-technologies/gestalt/server/services/observability/drivers/stdout"
 	"github.com/valon-technologies/gestalt/server/services/operator"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	secretsenv "github.com/valon-technologies/gestalt/server/services/secrets/drivers/env"
 	secretsfile "github.com/valon-technologies/gestalt/server/services/secrets/drivers/file"
+	"gopkg.in/yaml.v3"
 )
 
 type bootstrapEnv struct {
@@ -111,14 +115,36 @@ func buildFactories() *bootstrap.FactoryRegistry {
 			return nil, nil, fmt.Errorf("unknown audit provider %q", cfg.Source.Builtin)
 		}
 	}
-	factories.Auth = providerdrivers.AuthenticationFactory
-	factories.Authorization = providerdrivers.AuthorizationFactory
-	factories.ExternalCredentials = providerdrivers.ExternalCredentialsFactory
+	factories.Auth = func(node yaml.Node, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
+		defaultCallbackURL := ""
+		if deps.BaseURL != "" {
+			defaultCallbackURL = deps.BaseURL + config.AuthCallbackPath
+		}
+		return providerdrivers.AuthenticationFactory(node, providerdrivers.AuthenticationDeps{
+			DefaultCallbackURL: defaultCallbackURL,
+			SessionKey:         deps.EncryptionKey,
+		})
+	}
+	factories.Authorization = func(node yaml.Node, hostServices []runtimehost.HostService, _ bootstrap.Deps) (core.AuthorizationProvider, error) {
+		return providerdrivers.AuthorizationFactory(node, hostServices)
+	}
+	factories.ExternalCredentials = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, _ bootstrap.Deps) (core.ExternalCredentialProvider, error) {
+		return providerdrivers.ExternalCredentialsFactory(ctx, name, node, hostServices)
+	}
 	factories.IndexedDB = providerdrivers.IndexedDBFactory
 	factories.Cache = providerdrivers.CacheFactory
 	factories.S3 = providerdrivers.S3Factory
-	factories.Workflow = providerdrivers.WorkflowFactory
-	factories.Agent = providerdrivers.AgentFactory
+	factories.Workflow = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
+		return providerdrivers.WorkflowFactory(ctx, name, node, hostServices, providerdrivers.WorkflowDeps{
+			EgressDefaultAction: deps.Egress.DefaultAction,
+		})
+	}
+	factories.Agent = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
+		return providerdrivers.AgentFactory(ctx, name, node, hostServices, providerdrivers.AgentDeps{
+			EgressDefaultAction: deps.Egress.DefaultAction,
+			Telemetry:           deps.Telemetry,
+		})
+	}
 	factories.Secrets["env"] = secretsenv.Factory
 	factories.Secrets["file"] = secretsfile.Factory
 	factories.Secrets["provider"] = providerdrivers.SecretsProviderFactory

--- a/gestaltd/services/observability/drivers/noop/noop.go
+++ b/gestaltd/services/observability/drivers/noop/noop.go
@@ -11,7 +11,6 @@ import (
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -37,6 +36,6 @@ func (p *Provider) MeterProvider() metric.MeterProvider  { return p.mp }
 func (p *Provider) PrometheusHandler() http.Handler      { return nil }
 func (p *Provider) Shutdown(context.Context) error       { return nil }
 
-var Factory bootstrap.TelemetryFactory = func(yaml.Node) (core.TelemetryProvider, error) {
+func Factory(yaml.Node) (core.TelemetryProvider, error) {
 	return New(), nil
 }

--- a/gestaltd/services/observability/drivers/otlp/otlp.go
+++ b/gestaltd/services/observability/drivers/otlp/otlp.go
@@ -27,7 +27,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/services/observability/drivers/metricspipeline"
 	telemetrystdout "github.com/valon-technologies/gestalt/server/services/observability/drivers/stdout"
 	"github.com/valon-technologies/gestalt/server/services/observability/drivers/telemetryutil"
@@ -453,7 +452,7 @@ func decodeConfig(node yaml.Node, subject string) (yamlConfig, error) {
 	return cfg, nil
 }
 
-var Factory bootstrap.TelemetryFactory = func(node yaml.Node) (core.TelemetryProvider, error) {
+func Factory(node yaml.Node) (core.TelemetryProvider, error) {
 	cfg, err := decodeConfig(node, "otlp telemetry")
 	if err != nil {
 		return nil, err

--- a/gestaltd/services/observability/drivers/stdout/stdout.go
+++ b/gestaltd/services/observability/drivers/stdout/stdout.go
@@ -14,7 +14,6 @@ import (
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/services/observability/drivers/metricspipeline"
 	"github.com/valon-technologies/gestalt/server/services/observability/drivers/telemetryutil"
 	"gopkg.in/yaml.v3"
@@ -85,7 +84,7 @@ func (p *Provider) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-var Factory bootstrap.TelemetryFactory = func(node yaml.Node) (core.TelemetryProvider, error) {
+func Factory(node yaml.Node) (core.TelemetryProvider, error) {
 	var cfg yamlConfig
 	if node.Kind != 0 {
 		if err := node.Decode(&cfg); err != nil {

--- a/gestaltd/services/plugins/grpc_telemetry_test.go
+++ b/gestaltd/services/plugins/grpc_telemetry_test.go
@@ -3,12 +3,15 @@ package plugins
 import (
 	"context"
 	"testing"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/trace"
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
@@ -46,12 +49,49 @@ func TestProviderServerGRPCOptionsRecordServerDurationWithTelemetryAttrs(t *test
 		t.Fatalf("GetMetadata: %v", err)
 	}
 
-	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
 		"gestaltd.rpc.role":      "provider_server",
 		"gestaltd.provider.name": providerName,
 	}
+	rm := collectMetricsUntilFloat64Histogram(t, metrics.Reader, "rpc.server.call.duration", attrs)
 	metrictest.RequireFloat64Histogram(t, rm, "rpc.server.call.duration", attrs)
 	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.server.call.duration", attrs, "gestalt.rpc.role")
 	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.server.call.duration", attrs, "gestalt.provider")
+}
+
+func collectMetricsUntilFloat64Histogram(t *testing.T, reader *sdkmetric.ManualReader, name string, attrs map[string]string) metricdata.ResourceMetrics {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var rm metricdata.ResourceMetrics
+	for {
+		rm = metrictest.CollectMetrics(t, reader)
+		if hasFloat64Histogram(rm, name, attrs) {
+			return rm
+		}
+		if time.Now().After(deadline) {
+			return rm
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func hasFloat64Histogram(rm metricdata.ResourceMetrics, name string, attrs map[string]string) bool {
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			histogram, ok := metric.Data.(metricdata.Histogram[float64])
+			if !ok {
+				continue
+			}
+			for _, point := range histogram.DataPoints {
+				if metrictest.AttrsMatch(point.Attributes, attrs) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/gestaltd/services/providerdrivers/agent.go
+++ b/gestaltd/services/providerdrivers/agent.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	agentservice "github.com/valon-technologies/gestalt/server/services/agents"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
@@ -13,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var AgentFactory bootstrap.AgentFactory = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreagent.Provider, error) {
+func AgentFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps AgentDeps) (coreagent.Provider, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("agent provider: parsing config: %w", err)
@@ -34,7 +33,7 @@ var AgentFactory bootstrap.AgentFactory = func(ctx context.Context, name string,
 		Args:         cfg.Args,
 		Env:          cfg.Env,
 		Config:       cfg.Config,
-		Egress:       cfg.EgressPolicy(deps.Egress.DefaultAction),
+		Egress:       cfg.EgressPolicy(deps.EgressDefaultAction),
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      prepared.Cleanup,
 		HostServices: hostServices,

--- a/gestaltd/services/providerdrivers/authentication.go
+++ b/gestaltd/services/providerdrivers/authentication.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
-	"github.com/valon-technologies/gestalt/server/internal/config"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	authenticationservice "github.com/valon-technologies/gestalt/server/services/authentication"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
@@ -18,7 +16,7 @@ type yamlConfig struct {
 	CallbackURL                  string `yaml:"callbackUrl"`
 }
 
-var AuthenticationFactory bootstrap.AuthFactory = func(node yaml.Node, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
+func AuthenticationFactory(node yaml.Node, deps AuthenticationDeps) (core.AuthenticationProvider, error) {
 	var cfg yamlConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("authentication provider: parsing config: %w", err)
@@ -35,8 +33,8 @@ var AuthenticationFactory bootstrap.AuthFactory = func(node yaml.Node, deps boot
 	cfg.YAMLConfig = prepared.YAMLConfig
 
 	callbackURL := cfg.CallbackURL
-	if callbackURL == "" && deps.BaseURL != "" {
-		callbackURL = deps.BaseURL + config.AuthCallbackPath
+	if callbackURL == "" {
+		callbackURL = deps.DefaultCallbackURL
 	}
 	return authenticationservice.NewExecutable(context.Background(), authenticationservice.ExecConfig{
 		Command:     cfg.Command,
@@ -48,6 +46,6 @@ var AuthenticationFactory bootstrap.AuthFactory = func(node yaml.Node, deps boot
 		Cleanup:     prepared.Cleanup,
 		Name:        cfg.Name,
 		CallbackURL: callbackURL,
-		SessionKey:  deps.EncryptionKey,
+		SessionKey:  deps.SessionKey,
 	})
 }

--- a/gestaltd/services/providerdrivers/authorization.go
+++ b/gestaltd/services/providerdrivers/authorization.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	authorizationservice "github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
@@ -13,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var AuthorizationFactory bootstrap.AuthorizationFactory = func(node yaml.Node, hostServices []runtimehost.HostService, _ bootstrap.Deps) (core.AuthorizationProvider, error) {
+func AuthorizationFactory(node yaml.Node, hostServices []runtimehost.HostService) (core.AuthorizationProvider, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("authorization provider: parsing config: %w", err)

--- a/gestaltd/services/providerdrivers/cache.go
+++ b/gestaltd/services/providerdrivers/cache.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 
 	corecache "github.com/valon-technologies/gestalt/server/core/cache"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	cacheservice "github.com/valon-technologies/gestalt/server/services/cache"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
 	"gopkg.in/yaml.v3"
 )
 
-var CacheFactory bootstrap.CacheFactory = func(node yaml.Node) (corecache.Cache, error) {
+func CacheFactory(node yaml.Node) (corecache.Cache, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("cache provider: parsing config: %w", err)

--- a/gestaltd/services/providerdrivers/deps.go
+++ b/gestaltd/services/providerdrivers/deps.go
@@ -1,0 +1,20 @@
+package providerdrivers
+
+import (
+	"github.com/valon-technologies/gestalt/server/services/egress"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+)
+
+type AuthenticationDeps struct {
+	DefaultCallbackURL string
+	SessionKey         []byte
+}
+
+type WorkflowDeps struct {
+	EgressDefaultAction egress.PolicyAction
+}
+
+type AgentDeps struct {
+	EgressDefaultAction egress.PolicyAction
+	Telemetry           runtimehost.TelemetryProviders
+}

--- a/gestaltd/services/providerdrivers/externalcredentials.go
+++ b/gestaltd/services/providerdrivers/externalcredentials.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	externalcredentialsservice "github.com/valon-technologies/gestalt/server/services/externalcredentials"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
@@ -13,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var ExternalCredentialsFactory bootstrap.ExternalCredentialFactory = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (core.ExternalCredentialProvider, error) {
+func ExternalCredentialsFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService) (core.ExternalCredentialProvider, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("external credentials provider: parsing config: %w", err)

--- a/gestaltd/services/providerdrivers/indexeddb.go
+++ b/gestaltd/services/providerdrivers/indexeddb.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
 	"gopkg.in/yaml.v3"
 )
 
-var IndexedDBFactory bootstrap.IndexedDBFactory = func(node yaml.Node) (indexeddb.IndexedDB, error) {
+func IndexedDBFactory(node yaml.Node) (indexeddb.IndexedDB, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("datastore provider: parsing config: %w", err)

--- a/gestaltd/services/providerdrivers/runtime_deps_contract_test.go
+++ b/gestaltd/services/providerdrivers/runtime_deps_contract_test.go
@@ -1,0 +1,189 @@
+package providerdrivers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
+	"github.com/valon-technologies/gestalt/server/core/session"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/providerpkg"
+	"gopkg.in/yaml.v3"
+)
+
+func TestAuthenticationFactoryForwardsRuntimeDepsToExecutableProvider(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const (
+		callbackURL   = "http://127.0.0.1:18088/auth/callback"
+		encryptionKey = "factory-adapter-contract-key"
+	)
+
+	authManifest := componentProviderManifestPath(t, setupGoContractProviderDir(t, dir, providermanifestv1.KindAuthentication, "local", authContractProviderSource(callbackURL)))
+	auth, err := AuthenticationFactory(contractRuntimeNode(t, "local", authManifest), AuthenticationDeps{
+		DefaultCallbackURL: callbackURL,
+		SessionKey:         corecrypto.DeriveKey(encryptionKey),
+	})
+	if err != nil {
+		t.Fatalf("AuthenticationFactory: %v", err)
+	}
+	defer closeProviderIfSupported(t, auth)
+
+	if _, err := auth.LoginURL("host-state"); err != nil {
+		t.Fatalf("LoginURL: %v", err)
+	}
+
+	token, err := session.IssueToken(&core.UserIdentity{
+		Email:       "session@example.com",
+		DisplayName: "Session User",
+	}, corecrypto.DeriveKey(encryptionKey), time.Minute)
+	if err != nil {
+		t.Fatalf("IssueToken: %v", err)
+	}
+	identity, err := auth.ValidateToken(context.Background(), token)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if identity == nil || identity.Email != "session@example.com" {
+		t.Fatalf("ValidateToken identity = %+v, want session@example.com", identity)
+	}
+}
+
+func setupGoContractProviderDir(t *testing.T, baseDir, kind, name, source string) string {
+	t.Helper()
+
+	providerDir := filepath.Join(baseDir, kind, name)
+	if err := os.MkdirAll(providerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", providerDir, err)
+	}
+	writeTestFile(t, providerDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/providers/"+kind+"/"+name)), 0o644)
+	writeTestFile(t, providerDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
+	writeTestFile(t, providerDir, "provider.go", []byte(source), 0o644)
+
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "gestalt-"+name))
+	artifactPath := filepath.Join(providerDir, filepath.FromSlash(artifactRel))
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(artifactPath), err)
+	}
+	if _, err := providerpkg.BuildSourceComponentReleaseBinary(providerDir, artifactPath, kind, runtime.GOOS, runtime.GOARCH); err != nil {
+		t.Fatalf("BuildSourceComponentReleaseBinary(%s): %v", providerDir, err)
+	}
+	binData, err := os.ReadFile(artifactPath)
+	if err != nil {
+		t.Fatalf("read provider artifact: %v", err)
+	}
+	sum := sha256.Sum256(binData)
+	writeManifestFile(t, providerDir, &providermanifestv1.Manifest{
+		Kind:        kind,
+		Source:      "github.com/test/providers/" + name,
+		Version:     "0.0.1-alpha.1",
+		DisplayName: name,
+		Spec:        &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{
+			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: artifactRel, SHA256: hex.EncodeToString(sum[:])},
+		},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactRel},
+	})
+	return providerDir
+}
+
+func componentProviderManifestPath(t *testing.T, providerDir string) string {
+	t.Helper()
+
+	manifestPath, err := providerpkg.FindManifestFile(providerDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile(%s): %v", providerDir, err)
+	}
+	return manifestPath
+}
+
+func contractRuntimeNode(t *testing.T, name, manifestPath string) yaml.Node {
+	t.Helper()
+
+	var node yaml.Node
+	if err := node.Encode(map[string]any{
+		"name":         name,
+		"manifestPath": manifestPath,
+	}); err != nil {
+		t.Fatalf("encode runtime node: %v", err)
+	}
+	return node
+}
+
+func closeProviderIfSupported(t *testing.T, provider any) {
+	t.Helper()
+
+	closer, ok := provider.(interface{ Close() error })
+	if !ok {
+		return
+	}
+	if err := closer.Close(); err != nil {
+		t.Fatalf("close provider: %v", err)
+	}
+}
+
+func authContractProviderSource(wantCallbackURL string) string {
+	source := testutil.GeneratedAuthPackageSource()
+	source = strings.Replace(source, `func (p *Provider) BeginLogin(_ context.Context, req *gestalt.BeginLoginRequest) (*gestalt.BeginLoginResponse, error) {
+	return &gestalt.BeginLoginResponse{
+		AuthorizationUrl: "https://auth.example.test/login?state=idp-state&prompt=consent",
+	}, nil
+}`, fmt.Sprintf(`func (p *Provider) BeginLogin(_ context.Context, req *gestalt.BeginLoginRequest) (*gestalt.BeginLoginResponse, error) {
+	if req.GetCallbackUrl() != %q {
+		return nil, fmt.Errorf("callback URL = %%q, want %%q", req.GetCallbackUrl(), %q)
+	}
+	return &gestalt.BeginLoginResponse{
+		AuthorizationUrl: "https://auth.example.test/login?state=idp-state&prompt=consent",
+	}, nil
+}`, wantCallbackURL, wantCallbackURL), 1)
+	source = strings.Replace(source, `func (p *Provider) ValidateExternalToken(_ context.Context, token string) (*gestalt.AuthenticatedUser, error) {
+	if token == "" {
+		return nil, fmt.Errorf("token is required")
+	}
+	if strings.Count(token, ".") == 2 {
+		return &gestalt.AuthenticatedUser{
+			Email:       "jwt@example.com",
+			DisplayName: "Validated JWT User",
+		}, nil
+	}
+	return &gestalt.AuthenticatedUser{
+		Email:       token + "@example.com",
+		DisplayName: "Validated User",
+	}, nil
+}`, `func (p *Provider) ValidateExternalToken(_ context.Context, token string) (*gestalt.AuthenticatedUser, error) {
+	return nil, fmt.Errorf("external token fallback should not be used for %q", token)
+}`, 1)
+	source = strings.Replace(source, `
+	"strings"`, ``, 1)
+	return source
+}
+
+func writeTestFile(t *testing.T, dir, name string, data []byte, perm os.FileMode) {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, perm); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func writeManifestFile(t *testing.T, dir string, manifest *providermanifestv1.Manifest) {
+	t.Helper()
+
+	data, err := yaml.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	writeTestFile(t, dir, "manifest.yaml", data, 0o644)
+}

--- a/gestaltd/services/providerdrivers/s3.go
+++ b/gestaltd/services/providerdrivers/s3.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 
 	s3store "github.com/valon-technologies/gestalt/server/core/s3"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
 	s3service "github.com/valon-technologies/gestalt/server/services/s3"
 	"gopkg.in/yaml.v3"
 )
 
-var S3Factory bootstrap.S3Factory = func(node yaml.Node) (s3store.Client, error) {
+func S3Factory(node yaml.Node) (s3store.Client, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("s3 provider: parsing config: %w", err)

--- a/gestaltd/services/providerdrivers/secrets.go
+++ b/gestaltd/services/providerdrivers/secrets.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
 	secretsservice "github.com/valon-technologies/gestalt/server/services/secrets"
 	"gopkg.in/yaml.v3"
 )
 
-var SecretsProviderFactory bootstrap.SecretManagerFactory = func(node yaml.Node) (core.SecretManager, error) {
+func SecretsProviderFactory(node yaml.Node) (core.SecretManager, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("secrets provider: parsing config: %w", err)

--- a/gestaltd/services/providerdrivers/workflow.go
+++ b/gestaltd/services/providerdrivers/workflow.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
@@ -13,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var WorkflowFactory bootstrap.WorkflowFactory = func(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
+func WorkflowFactory(ctx context.Context, name string, node yaml.Node, hostServices []runtimehost.HostService, deps WorkflowDeps) (coreworkflow.Provider, error) {
 	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("workflow provider: parsing config: %w", err)
@@ -34,7 +33,7 @@ var WorkflowFactory bootstrap.WorkflowFactory = func(ctx context.Context, name s
 		Args:         cfg.Args,
 		Env:          cfg.Env,
 		Config:       cfg.Config,
-		Egress:       cfg.EgressPolicy(deps.Egress.DefaultAction),
+		Egress:       cfg.EgressPolicy(deps.EgressDefaultAction),
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      prepared.Cleanup,
 		HostServices: hostServices,

--- a/gestaltd/services/secrets/drivers/env/factory.go
+++ b/gestaltd/services/secrets/drivers/env/factory.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -12,7 +11,7 @@ type yamlConfig struct {
 	Prefix string `yaml:"prefix"`
 }
 
-var Factory bootstrap.SecretManagerFactory = func(node yaml.Node) (core.SecretManager, error) {
+func Factory(node yaml.Node) (core.SecretManager, error) {
 	var cfg yamlConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("env secrets: parsing config: %w", err)

--- a/gestaltd/services/secrets/drivers/file/factory.go
+++ b/gestaltd/services/secrets/drivers/file/factory.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -13,7 +12,7 @@ type yamlConfig struct {
 	Dir string `yaml:"dir"`
 }
 
-var Factory bootstrap.SecretManagerFactory = func(node yaml.Node) (core.SecretManager, error) {
+func Factory(node yaml.Node) (core.SecretManager, error) {
 	var cfg yamlConfig
 	if err := node.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("file secrets: parsing config: %w", err)


### PR DESCRIPTION
## Summary

Move service-owned driver factories off `internal/bootstrap` types and adapt them at the daemon composition root.

- `services/providerdrivers` no longer imports `server/internal/bootstrap` or `server/internal/config`.
- `services/observability/drivers/{noop,stdout,otlp}` and `services/secrets/drivers/{env,file}` now expose plain service-owned factory functions instead of bootstrap-typed variables.
- `internal/daemon/buildFactories` now bridges service-owned constructors into `bootstrap.FactoryRegistry`.
- Keeps config, provider runtime protocol, lockfile, and generated default config shapes unchanged.
- Rebased on current `main` after the `services/testutil` move and updated the contract test import path.

## Interface Diff

```diff
- var AuthenticationFactory bootstrap.AuthenticationFactory
+ func AuthenticationFactory(node yaml.Node, deps AuthenticationDeps) (core.AuthenticationProvider, error)
+
+ type AuthenticationDeps struct {
+     DefaultCallbackURL string
+     SessionKey         []byte
+ }

- var WorkflowFactory bootstrap.WorkflowFactory
+ func WorkflowFactory(
+     ctx context.Context,
+     name string,
+     node yaml.Node,
+     hostServices []runtimehost.HostService,
+     deps WorkflowDeps,
+ ) (coreworkflow.Provider, error)
+
+ type WorkflowDeps struct {
+     EgressDefaultAction egress.PolicyAction
+ }

- var AgentFactory bootstrap.AgentFactory
+ func AgentFactory(
+     ctx context.Context,
+     name string,
+     node yaml.Node,
+     hostServices []runtimehost.HostService,
+     deps AgentDeps,
+ ) (coreagent.Provider, error)
+
+ type AgentDeps struct {
+     EgressDefaultAction egress.PolicyAction
+     Telemetry           runtimehost.TelemetryProviders
+ }
```

## Example

```go
factories.Auth = func(node yaml.Node, deps bootstrap.Deps) (core.AuthenticationProvider, error) {
    defaultCallbackURL := ""
    if deps.BaseURL != "" {
        defaultCallbackURL = deps.BaseURL + config.AuthCallbackPath
    }
    return providerdrivers.AuthenticationFactory(node, providerdrivers.AuthenticationDeps{
        DefaultCallbackURL: defaultCallbackURL,
        SessionKey:         deps.EncryptionKey,
    })
}
```

Configured provider `callbackUrl` still wins over the daemon default callback URL.

## Functional/Integration Checks

- `go test ./services/providerdrivers -run TestAuthenticationFactoryForwardsRuntimeDepsToExecutableProvider -count=1`
- `go test -cover ./services/providerdrivers -run TestAuthenticationFactoryForwardsRuntimeDepsToExecutableProvider -count=1`
- `go test ./services/providerdrivers ./services/observability/drivers/... ./services/secrets/drivers/...`
- `go test ./internal/daemon -run TestE2EValidateAcceptsV3TelemetryBuiltins -count=1`
- `go test -cover ./services/plugins -run TestProviderServerGRPCOptionsRecordServerDurationWithTelemetryAttrs -count=1`
- `golangci-lint run ./services/providerdrivers ./internal/daemon ./services/plugins`
- `git diff --check`

## Follow-up

`services/operator` still imports `internal/config`; that remains a larger boundary because operator lifecycle currently owns config loading, canonicalization, secret resolution, lock generation, and validation over `*config.Config`.
