### PR TITLE
gestaltd: bound agent tool list pages

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2136,7 +2137,7 @@ func TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn(t *testing.T) {
 	invoker := &recordingAgentRuntimeInvoker{}
 	toolGrants := newTestAgentToolGrants(t)
 	readOnly := true
-	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+	roadmapProvider := &coretesting.StubIntegration{
 		N:        "roadmap",
 		ConnMode: core.ConnectionModeNone,
 		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{
@@ -2162,7 +2163,32 @@ func TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn(t *testing.T) {
 				InputSchema: json.RawMessage(`{"type":"object","properties":{"taskId":{"type":"string"}}}`),
 			},
 		}},
-	})
+	}
+	docsOps := make([]catalog.CatalogOperation, 12)
+	docsRefs := make([]coreagent.ToolRef, 12)
+	docsPermissions := make([]string, 12)
+	oversizedOutputSchema := json.RawMessage(`{"type":"object","properties":{"payload":{"type":"string","description":"` + strings.Repeat("x", 129*1024) + `"}}}`)
+	for i := range docsOps {
+		id := fmt.Sprintf("fetch_%02d", i+1)
+		docsOps[i] = catalog.CatalogOperation{
+			ID:           id,
+			Title:        fmt.Sprintf("Fetch docs %02d", i+1),
+			Description:  "Fetch a docs page",
+			InputSchema:  json.RawMessage(`{"type":"object"}`),
+			OutputSchema: oversizedOutputSchema,
+		}
+		docsRefs[i] = coreagent.ToolRef{Plugin: "docs", Operation: id}
+		docsPermissions[i] = id
+	}
+	docsProvider := &coretesting.StubIntegration{
+		N:        "docs",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name:       "docs",
+			Operations: docsOps,
+		},
+	}
+	providers := testutil.NewProviderRegistry(t, roadmapProvider, docsProvider)
 	manager := agentmanager.New(agentmanager.Config{
 		Providers:  providers,
 		ToolGrants: toolGrants,
@@ -2278,6 +2304,61 @@ func TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn(t *testing.T) {
 	if len(emptyListResp.Tools) != 0 || emptyListResp.NextPageToken != "" {
 		t.Fatalf("ListTools empty grant = %#v, want no tools", emptyListResp)
 	}
+
+	manyDocsGrant, err := toolGrants.Mint(agentgrant.Grant{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		SubjectID:    "user:user-123",
+		SubjectKind:  string(principal.KindUser),
+		Permissions: []core.AccessPermission{{
+			Plugin:     "docs",
+			Operations: docsPermissions,
+		}},
+		ToolRefs:   docsRefs,
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+	})
+	if err != nil {
+		t.Fatalf("Mint docs grant: %v", err)
+	}
+	pagedDocs, err := runtime.ListTools(context.Background(), coreagent.ListToolsRequest{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		PageSize:     100,
+		ToolGrant:    manyDocsGrant,
+	})
+	if err != nil {
+		t.Fatalf("ListTools with oversized page size: %v", err)
+	}
+	if len(pagedDocs.Tools) != 10 || pagedDocs.NextPageToken != "10" {
+		t.Fatalf("ListTools oversized page = %d tools, next %q; want 10 tools and token 10", len(pagedDocs.Tools), pagedDocs.NextPageToken)
+	}
+	for _, listed := range pagedDocs.Tools {
+		if listed.OutputSchemaJSON != "" {
+			t.Fatalf("listed output schema for %q is %d bytes, want omitted oversized schema", listed.MCPName, len(listed.OutputSchemaJSON))
+		}
+	}
+	finalDocs, err := runtime.ListTools(context.Background(), coreagent.ListToolsRequest{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		PageSize:     100,
+		PageToken:    pagedDocs.NextPageToken,
+		ToolGrant:    manyDocsGrant,
+	})
+	if err != nil {
+		t.Fatalf("ListTools final oversized page: %v", err)
+	}
+	if len(finalDocs.Tools) != 2 || finalDocs.NextPageToken != "" {
+		t.Fatalf("ListTools final oversized page = %d tools, next %q; want 2 tools and no token", len(finalDocs.Tools), finalDocs.NextPageToken)
+	}
+	for _, listed := range finalDocs.Tools {
+		if listed.OutputSchemaJSON != "" {
+			t.Fatalf("listed final output schema for %q is %d bytes, want omitted oversized schema", listed.MCPName, len(listed.OutputSchemaJSON))
+		}
+	}
+
 	_, err = runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
 		ProviderName: "claude",
 		SessionID:    "session-1",

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -49,9 +49,9 @@ const (
 	agentToolSearchAdaptiveMaxResults = 3
 	agentToolSearchMaxResults         = 20
 	agentToolSearchMaxCandidates      = 20
-	agentToolListDefaultPageSize      = 100
-	agentToolListMaxPageSize          = 500
-	agentToolInputSchemaMaxBytes      = 128 * 1024
+	agentToolListDefaultPageSize      = 10
+	agentToolListMaxPageSize          = 10
+	agentToolSchemaMaxBytes           = 128 * 1024
 	maxAgentRouteCacheEntries         = 20_000
 	AgentListSummaryDefaultLimit      = 100
 	AgentListMaxLimit                 = 500
@@ -2291,7 +2291,7 @@ func paginateListedAgentTools(tools []coreagent.ListedTool, pageSize, offset int
 }
 
 func agentToolInputSchema(op catalog.CatalogOperation) json.RawMessage {
-	if len(op.InputSchema) <= agentToolInputSchemaMaxBytes {
+	if len(op.InputSchema) <= agentToolSchemaMaxBytes {
 		return op.InputSchema
 	}
 	if synthesized := integration.SynthesizeInputSchema(op.Parameters); len(synthesized) > 0 {
@@ -2306,6 +2306,13 @@ func agentToolInputSchemaJSON(op catalog.CatalogOperation) string {
 		return `{"type":"object","additionalProperties":true}`
 	}
 	return string(raw)
+}
+
+func agentToolOutputSchemaJSON(op catalog.CatalogOperation) string {
+	if len(op.OutputSchema) == 0 || len(op.OutputSchema) > agentToolSchemaMaxBytes {
+		return ""
+	}
+	return string(op.OutputSchema)
 }
 
 func agentToolSchemaJSON(schema map[string]any) (string, error) {
@@ -2347,7 +2354,7 @@ func listedAgentPluginTool(tool coreagent.Tool, candidate agentToolSearchCandida
 		Title:            tool.Name,
 		Description:      tool.Description,
 		InputSchemaJSON:  agentToolInputSchemaJSON(candidate.operation),
-		OutputSchemaJSON: string(candidate.operation.OutputSchema),
+		OutputSchemaJSON: agentToolOutputSchemaJSON(candidate.operation),
 		Annotations:      capabilityAnnotationsFromCatalog(candidate.operation.Annotations),
 		Ref:              ref,
 		Target:           tool.Target,

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -629,7 +629,7 @@ func TestSearchToolsCompactsOversizedInputSchemaFromParameters(t *testing.T) {
 				ID:          "pulls.list",
 				Title:       "List Pull Requests",
 				Description: "List pull requests for a repository.",
-				InputSchema: []byte(`{"type":"object","properties":{"payload":{"type":"string","description":"` + strings.Repeat("x", agentToolInputSchemaMaxBytes) + `"}}}`),
+				InputSchema: []byte(`{"type":"object","properties":{"payload":{"type":"string","description":"` + strings.Repeat("x", agentToolSchemaMaxBytes) + `"}}}`),
 				Parameters: []catalog.CatalogParameter{
 					{Name: "owner", Type: "string", Description: "Repository owner.", Required: true},
 					{Name: "repo", Type: "string", Description: "Repository name.", Required: true},
@@ -679,7 +679,7 @@ func TestSearchToolsUsesOpenObjectSchemaForOversizedInputSchemaWithoutParameters
 				ID:          "search.code",
 				Title:       "Search Code",
 				Description: "Search code.",
-				InputSchema: []byte(`{"type":"object","properties":{"payload":{"type":"string","description":"` + strings.Repeat("x", agentToolInputSchemaMaxBytes) + `"}}}`),
+				InputSchema: []byte(`{"type":"object","properties":{"payload":{"type":"string","description":"` + strings.Repeat("x", agentToolSchemaMaxBytes) + `"}}}`),
 				ReadOnly:    true,
 			}}},
 		},


### PR DESCRIPTION
## Summary
- Clamp `AgentHost.ListTools` default and maximum page size to 10 tools.
- Omit oversized listed output schemas using the same 128 KiB schema cap already applied to agent tool input schemas.
- This keeps MCP catalog pages below the default 4 MiB gRPC receive limit even when tools have large schemas.
- Cover the contract through the existing agent runtime grant path instead of a private helper test.

## Interface Changes
- `coreagent.ListToolsRequest.PageSize` keeps the same field shape, but the agent manager now treats `0` as a 10-tool default and clamps any value above 10 back to 10.
- Negative `page_size` requests remain invalid.
- `ListedAgentTool.OutputSchemaJSON` is preserved when it is within the 128 KiB agent tool schema cap and omitted when it exceeds that cap.

Example provider callback:

```go
resp, err := agentHost.ListTools(ctx, &proto.ListAgentToolsRequest{
    SessionId: sessionID,
    TurnId:    turnID,
    PageSize:  100,
    ToolGrant: grant,
})
// resp.Tools has at most 10 entries.
// resp.NextPageToken is "10" when additional tools remain.
// Oversized listed output schemas are returned as empty output_schema strings.
```

## Context
GKE smoke testing no longer fails with `host-service-relay-unavailable`, but a real turn against the hosted `simple` provider hit a host callback payload issue:

```text
ResourceExhausted desc = grpc: received message larger than max (23890490 vs. 4194304)
```

The deployed providers request 100 tools per `ListTools` page. With the existing 128 KiB per-tool schema cap, a single page can still be far larger than the provider-side gRPC default. gestaltd already owns this paginated contract, so bounding the host page size and omitting oversized listed output schemas fixes existing providers without requiring a provider release.

## Functional/Integration Tests
- Augmented `TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn` so an MCP catalog grant with 12 tools, oversized output schemas, and `PageSize: 100` returns 10 tools plus `NextPageToken: "10"`, omits the oversized output schemas, then returns the final 2 tools on the next page.
- This exercises the runtime/grant/agent-manager contract used by the host callback path.

Commands run from `gestaltd`:

```text
go test ./internal/bootstrap -run TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn -count=1
go test -cover ./internal/bootstrap -run TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn -count=1
go test ./services/agents/agentmanager
go test ./services/agents -run TestAgentHostServerListToolsForwardsCatalogRequest -count=1
golangci-lint run ./internal/bootstrap ./services/agents ./services/agents/agentmanager
git diff --check
```
