### PR TITLE
Clarify hosted runtime relay docs

### DIFF
--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -4,9 +4,9 @@ Runtime providers manage **where executable plugins and hosted agent providers r
 
 A runtime provider is not the plugin itself, and it is not a host provider like
 authentication, IndexedDB, or workflow. Instead, it is a control-plane backend
-that lets `gestaltd` create a plugin runtime session, bind host-local services
-into that session, start the plugin process there, and dial the plugin back
-over gRPC.
+that lets `gestaltd` create a plugin runtime session, prepare relay-backed
+host-service environment variables, start the plugin process there, and dial
+the plugin back over gRPC.
 
 ## Scope
 
@@ -27,11 +27,11 @@ By default, executable plugins and agent providers run on the same machine as
 
 When a provider does opt in, Gestalt selects a backend from `runtime.providers`,
 reads the backend's support profile, starts a runtime session, waits for that
-session to become ready, binds any required host-local services, starts the
-provider process inside the session, then dials it back over gRPC. From that
-point on, the hosted provider behaves like any other configured provider from
-the caller's point of view. Gestalt stops the runtime session during shutdown
-or after a bootstrap failure.
+session to become ready, prepares any required host-service relay bindings,
+starts the provider process inside the session, then dials it back over gRPC.
+From that point on, the hosted provider behaves like any other configured
+provider from the caller's point of view. Gestalt stops the runtime session
+during shutdown or after a bootstrap failure.
 
 That is why the runtime interface is bigger than a single `StartPlugin` call:
 Gestalt needs an explicit lifecycle boundary, not just a fire-and-forget launch

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -55,10 +55,10 @@ The host resolves the caller's access token and passes it to the provider in eac
 
 Executable plugins may also opt into a runtime provider. In that model,
 `gestaltd` first talks to the runtime provider, which creates a hosted session,
-binds host-local services into that session, starts the plugin there, and
-bridges the plugin's provider gRPC listener back to the host. The effective
-execution boundary then depends on the selected runtime backend and its
-capabilities, not just the host-local child-process wrapper.
+prepares relay-backed host-service environment variables, starts the plugin
+there, and bridges the plugin's provider gRPC listener back to the host. The
+effective execution boundary then depends on the selected runtime backend and
+its capabilities, not just the host-local child-process wrapper.
 
 ### Egress control
 


### PR DESCRIPTION
## Summary

Clarifies hosted runtime documentation so it describes the current relay-backed environment flow instead of implying a runtime-provider host-service bind step.

- Updates the runtime provider overview and hosted runtime mental model.
- Updates the security page provider-isolation section with the same relay-backed language.
- Leaves the deprecated exported runtimehost sentinel in place for Go API compatibility.

## Interface Changes

No runtime protocol, config, SDK, or Go API changes. This is docs-only.

## Functional/Integration Checks

- `npm ci` in `docs/`
- `npm run build` in `docs/`
- `git diff --check`

## Review Notes

Reviewer feedback suggested removing `runtimehost.ErrProviderNotHostedRuntime` would be an exported Go API break. I agreed and kept that symbol unchanged.