### PR TITLE
Prune public host service registry API

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -6081,7 +6081,7 @@ func TestBuildProviderDevManagerRegistersMemoryModePublicHostServiceVerifiers(t 
 	if calls := cacheFactoryCalls.Load(); calls != 1 {
 		t.Fatalf("cache factory calls after CreateSession = %d, want startup-only open", calls)
 	}
-	for _, service := range publicHostServices.Services() {
+	for _, service := range publicHostServices.Snapshot() {
 		if strings.TrimSpace(service.Service.Name) != "s3" || strings.TrimSpace(service.Service.EnvVar) != s3service.SocketEnv("main") {
 			continue
 		}
@@ -6099,7 +6099,7 @@ func TestBuildProviderDevManagerRegistersMemoryModePublicHostServiceVerifiers(t 
 		}
 		return
 	}
-	t.Fatalf("public host services = %#v, want s3/%s", publicHostServices.Services(), s3service.SocketEnv("main"))
+	t.Fatalf("public host services = %#v, want s3/%s", publicHostServices.Snapshot(), s3service.SocketEnv("main"))
 }
 
 func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnelCapability(t *testing.T) {
@@ -7284,7 +7284,7 @@ func assertPublicHostServicesVerified(t *testing.T, registry *runtimehost.Public
 		t.Fatalf("public host services registry is nil, want %s/%s verifier entry", serviceName, envVar)
 	}
 	found := false
-	for _, service := range registry.Services() {
+	for _, service := range registry.Snapshot() {
 		if strings.TrimSpace(service.Service.Name) != strings.TrimSpace(serviceName) {
 			continue
 		}
@@ -7293,11 +7293,11 @@ func assertPublicHostServicesVerified(t *testing.T, registry *runtimehost.Public
 		}
 		found = true
 		if service.SessionVerifier == nil {
-			t.Fatalf("public host services = %#v, want %s/%s verifier entry", registry.Services(), serviceName, envVar)
+			t.Fatalf("public host services = %#v, want %s/%s verifier entry", registry.Snapshot(), serviceName, envVar)
 		}
 	}
 	if !found {
-		t.Fatalf("public host services = %#v, want %s/%s verifier entry", registry.Services(), serviceName, envVar)
+		t.Fatalf("public host services = %#v, want %s/%s verifier entry", registry.Snapshot(), serviceName, envVar)
 	}
 }
 
@@ -7381,7 +7381,7 @@ func runtimeRelayPublicHostServiceHandler(ctx context.Context, registry *runtime
 	if registry == nil {
 		return nil, nil
 	}
-	for _, entry := range registry.Services() {
+	for _, entry := range registry.Snapshot() {
 		if strings.TrimSpace(entry.PluginName) != strings.TrimSpace(target.PluginName) {
 			continue
 		}

--- a/gestaltd/services/runtimehost/public_host_service.go
+++ b/gestaltd/services/runtimehost/public_host_service.go
@@ -2,17 +2,9 @@ package runtimehost
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"sync"
 )
-
-// ErrProviderNotHostedRuntime means a public host-service callback did not
-// belong to a provider backed by a hosted runtime.
-//
-// Deprecated: public host-service relay callbacks now resolve exclusively
-// through registered PublicHostService entries and their session verifiers.
-var ErrProviderNotHostedRuntime = errors.New("provider does not use a hosted runtime")
 
 type PublicHostServiceSessionVerifier interface {
 	VerifyHostServiceSession(context.Context, string) error
@@ -107,47 +99,6 @@ func (r *PublicHostServiceRegistry) unregisterIDs(ids ...uint64) {
 	r.services = filtered
 }
 
-func (r *PublicHostServiceRegistry) Unregister(pluginName string, services ...HostService) {
-	if r == nil {
-		return
-	}
-	pluginName = strings.TrimSpace(pluginName)
-	if pluginName == "" {
-		return
-	}
-	removing := make(map[string]struct{}, len(services))
-	for _, service := range services {
-		key := publicHostServiceKey(service)
-		if key != "" {
-			removing[key] = struct{}{}
-		}
-	}
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	originalLen := len(r.services)
-	filtered := r.services[:0]
-	for _, service := range r.services {
-		if strings.TrimSpace(service.PluginName) == pluginName {
-			if len(removing) == 0 {
-				continue
-			}
-			if _, ok := removing[publicHostServiceKey(service.Service)]; ok {
-				continue
-			}
-		}
-		filtered = append(filtered, service)
-	}
-	for i := len(filtered); i < originalLen; i++ {
-		r.services[i] = PublicHostService{}
-	}
-	r.services = filtered
-}
-
-func (r *PublicHostServiceRegistry) Services() []PublicHostService {
-	return r.Snapshot()
-}
-
 func (r *PublicHostServiceRegistry) Snapshot() []PublicHostService {
 	if r == nil {
 		return nil
@@ -158,15 +109,6 @@ func (r *PublicHostServiceRegistry) Snapshot() []PublicHostService {
 		return nil
 	}
 	return append([]PublicHostService(nil), r.services...)
-}
-
-func publicHostServiceKey(service HostService) string {
-	name := strings.TrimSpace(service.Name)
-	envVar := strings.TrimSpace(service.EnvVar)
-	if name == "" || envVar == "" {
-		return ""
-	}
-	return name + "\x00" + envVar
 }
 
 func (s PublicHostService) RegistrationID() uint64 {


### PR DESCRIPTION
## Summary

Prunes unused public host-service registry API now that relay callbacks resolve through registered verified services.

## Simplification

- Removed: `runtimehost.ErrProviderNotHostedRuntime`, which had no callers.
- Removed: `PublicHostServiceRegistry.Unregister(pluginName, services...)`, which had no callers and duplicated registration-scoped cleanup.
- Removed: `PublicHostServiceRegistry.Services()`, leaving `Snapshot()` as the single read API.
- Removed: private `publicHostServiceKey`, which only supported the deleted registry-wide unregister path.

## Interface Changes

```diff
- runtimehost.ErrProviderNotHostedRuntime
- registry.Unregister(pluginName, services...)
- registry.Services()
  registration.Unregister()
  registry.Snapshot()
```

Example:

```go
registration := registry.RegisterVerified(pluginName, verifier, services...)
defer registration.Unregister()

services := registry.Snapshot()
```

## Functional/Integration Tests

- Tests added or augmented: none; existing host-service relay coverage now uses `Snapshot()`.
- Tests consolidated or removed: no behavior tests removed.
- Unit tests removed: none.
- Contract boundary covered: public host-service relay registration, session verification, and runtime/bootstrap integration paths.
- Commands run:
  - `go test ./services/runtimehost ./internal/server -run 'PublicHost|HostServiceRelay|RuntimeRelay'`
  - `go test ./internal/bootstrap -run 'PublicHostServices|Public.*HostService|RuntimePublic.*Relay|ProviderDev.*PublicHostService|Public.*Egress'`
  - `go test ./services/runtimehost ./internal/server ./internal/bootstrap`
  - `git diff --check`

## Follow-ups

- `native_search` is not safe to delete as a blind cleanup. It is still the provider-host `SearchTools` path, while `mcp_catalog` is the provider-turn/listing path. That needs a separate interface decision if we want to collapse those concepts.
