### PR TITLE
Remove managed identity compatibility remnants

### DIFF
--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -42,12 +42,11 @@ const (
 	credentialModeSubject  = "subject"
 	credentialModePlatform = "platform"
 
-	ownerKindNone            = "none"
-	ownerKindCurrentUser     = "current_user"
-	ownerKindManagedIdentity = "managed_identity"
-	ownerKindServiceAccount  = "service_account"
-	ownerKindPlatform        = "platform"
-	ownerKindUnknown         = "unknown"
+	ownerKindNone           = "none"
+	ownerKindCurrentUser    = "current_user"
+	ownerKindServiceAccount = "service_account"
+	ownerKindPlatform       = "platform"
+	ownerKindUnknown        = "unknown"
 )
 
 func (s *Server) applyIntegrationConnectionStatus(info *integrationInfo, prov core.Provider, instances []instanceInfo, authTypes []string, p *principal.Principal) {
@@ -354,8 +353,6 @@ func ownerKindForPrincipal(p *principal.Principal) string {
 	switch kind {
 	case string(principal.KindUser):
 		return ownerKindCurrentUser
-	case ownerKindManagedIdentity:
-		return ownerKindManagedIdentity
 	case ownerKindServiceAccount:
 		return ownerKindServiceAccount
 	default:

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -7122,7 +7122,7 @@ func TestMountedRootUIRoutes(t *testing.T) {
 		t.Fatalf("health body unexpectedly served root UI: %q", body)
 	}
 
-	resp, err = http.Get(ts.URL + "/api/v1/identities")
+	resp, err = http.Get(ts.URL + "/api/v1/not-a-real-provider")
 	if err != nil {
 		t.Fatalf("GET unknown API route: %v", err)
 	}
@@ -22500,79 +22500,6 @@ func TestCreateAPIToken_InvalidScope(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
-	}
-}
-
-func TestServerAllowsProviderNamedIdentities(t *testing.T) {
-	t.Parallel()
-
-	svc := testutil.NewStubServices(t)
-	seedUser(t, svc, "admin@example.test")
-
-	providers := testutil.NewProviderRegistry(t, &stubIntegrationWithOps{
-		StubIntegration: coretesting.StubIntegration{
-			N:        "identities",
-			ConnMode: core.ConnectionModeNone,
-			ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
-				return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q}`, operation)}, nil
-			},
-		},
-		ops: []core.Operation{
-			{Name: "read", Method: http.MethodGet},
-			{Name: "write", Method: http.MethodPost},
-		},
-	})
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = &coretesting.StubAuthProvider{
-			N: "test",
-			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
-				if token != "admin-session" {
-					return nil, fmt.Errorf("unknown session %q", token)
-				}
-				return &core.UserIdentity{Email: "admin@example.test"}, nil
-			},
-		}
-		cfg.Services = svc
-		cfg.Providers = providers
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	readReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/identities/read", nil)
-	readReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	readResp, err := http.DefaultClient.Do(readReq)
-	if err != nil {
-		t.Fatalf("GET identities/read: %v", err)
-	}
-	defer func() { _ = readResp.Body.Close() }()
-	if readResp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(readResp.Body)
-		t.Fatalf("GET identities/read status = %d, want %d: %s", readResp.StatusCode, http.StatusOK, body)
-	}
-
-	writeReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/write", bytes.NewBufferString(`{}`))
-	writeReq.Header.Set("Content-Type", "application/json")
-	writeReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	writeResp, err := http.DefaultClient.Do(writeReq)
-	if err != nil {
-		t.Fatalf("POST identities/write: %v", err)
-	}
-	defer func() { _ = writeResp.Body.Close() }()
-	if writeResp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(writeResp.Body)
-		t.Fatalf("POST identities/write status = %d, want %d: %s", writeResp.StatusCode, http.StatusOK, body)
-	}
-
-	missingReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/identities/missing", nil)
-	missingReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	missingResp, err := http.DefaultClient.Do(missingReq)
-	if err != nil {
-		t.Fatalf("GET identities/missing: %v", err)
-	}
-	defer func() { _ = missingResp.Body.Close() }()
-	if missingResp.StatusCode != http.StatusNotFound {
-		body, _ := io.ReadAll(missingResp.Body)
-		t.Fatalf("GET identities/missing status = %d, want %d: %s", missingResp.StatusCode, http.StatusNotFound, body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Remove the last managed-identity-shaped compatibility remnants from the server package. This keeps managed subjects on the non-legacy `service_account:<id>` path and stops preserving `/api/v1/identities` in test fixtures.

## Simplification
- Removed: `managed_identity` owner-kind classification from integration connection status.
- Removed: stale `/api/v1/identities` route fixture coverage from server tests.
- Consolidated: connection-status test wording around the current response contract instead of legacy compatibility language.
- Branching/special-casing reduced: `ownerKindForPrincipal` now only recognizes user and service-account subjects.

## Interface Changes
- Changed response behavior: a principal with `EffectiveCredentialSubjectID == "managed_identity:<id>"` no longer reports `ownerKind: "managed_identity"`; unsupported subject kinds fall through to `ownerKind: "unknown"`.
- Current accepted owner-kind examples:

```json
{ "ownerKind": "current_user" }
{ "ownerKind": "service_account" }
{ "ownerKind": "platform" }
{ "ownerKind": "none" }
{ "ownerKind": "unknown" }
```

## Functional/Integration Tests
- Tests added or augmented: adjusted the mounted-root UI API fallback contract to use a generic unknown provider path.
- Tests consolidated or removed: removed the stale provider-named-`identities` test fixture.
- Unit tests removed: none.
- Contract boundary covered: server HTTP/API route and integration connection-status contract.
- Commands run:

```bash
go test ./internal/server
```

## Follow-ups
- `native_search` is still a larger public agent transport cleanup candidate; it spans proto, generated SDKs, manager/runtime logic, and downstream provider contract tests, so it should be handled as a dedicated interface-removal PR.
