### PR TITLE
[codex] refresh SDK docs

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -82,7 +82,7 @@ The manifest is the source of truth for display name, description, the connectio
     ```sh
     mkdir slack && cd slack
     go mod init github.com/your-org/plugins/slack
-    go get github.com/valon-technologies/gestalt/sdk/go
+    go get github.com/valon-technologies/gestalt/sdk/go@latest
     ```
 
     Recommended layout:
@@ -116,7 +116,7 @@ The manifest is the source of truth for display name, description, the connectio
     [project]
     name = "gestalt-slack"
     version = "0.0.1"
-    dependencies = ["gestalt"]
+    dependencies = ["gestalt-sdk"]
 
     [tool.uv]
     package = false
@@ -152,13 +152,14 @@ The manifest is the source of truth for display name, description, the connectio
     edition = "2024"
 
     [dependencies]
-    gestalt = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1" }
+    gestalt = { package = "gestalt-sdk", version = "0.0.1-alpha.12" }
     schemars = { version = "0.8", features = ["derive"] }
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"
     ```
 
-    Use the `sdk/rust/v*` tag that matches the SDK release you want to target.
+    Use the current `gestalt-sdk` version from crates.io when you create a new
+    provider.
   </Tabs.Tab>
   <Tabs.Tab>
     You need Bun 1.3+ and a running `gestaltd` instance for testing.
@@ -166,7 +167,7 @@ The manifest is the source of truth for display name, description, the connectio
     ```sh
     mkdir slack && cd slack
     bun init -y
-    bun add @valon-technologies/gestalt
+    bun add @valon-technologies/gestalt@0.0.1-alpha.16
     ```
 
     Recommended layout:
@@ -187,7 +188,7 @@ The manifest is the source of truth for display name, description, the connectio
       "private": true,
       "type": "module",
       "dependencies": {
-        "@valon-technologies/gestalt": "0.0.1"
+        "@valon-technologies/gestalt": "0.0.1-alpha.16"
       },
       "gestalt": {
         "provider": {

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -52,7 +52,7 @@ packaging.
 
     go 1.26
 
-    require github.com/valon-technologies/gestalt/sdk/go v0.0.1-alpha.1
+    require github.com/valon-technologies/gestalt/sdk/go v0.0.1-alpha.14
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -67,7 +67,7 @@ packaging.
     [project]
     name = "my-plugin"
     version = "0.0.1-alpha.1"
-    dependencies = ["gestalt"]
+    dependencies = ["gestalt-sdk"]
 
     [tool.gestalt]
     provider = "provider"
@@ -89,7 +89,7 @@ packaging.
     edition = "2024"
 
     [dependencies]
-    gestalt = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
+    gestalt = { package = "gestalt-sdk", version = "0.0.1-alpha.12" }
     schemars = { version = "0.8", features = ["derive"] }
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"
@@ -109,7 +109,7 @@ packaging.
       "version": "0.0.1-alpha.1",
       "type": "module",
       "dependencies": {
-        "@valon-technologies/gestalt": "0.0.1-alpha.1"
+        "@valon-technologies/gestalt": "0.0.1-alpha.16"
       },
       "gestalt": {
         "provider": {

--- a/docs/content/reference/_meta.ts
+++ b/docs/content/reference/_meta.ts
@@ -1,9 +1,10 @@
 export default {
+  sdk: "SDKs",
   "config-file": "Config File",
-  "go-sdk": "Go SDK API",
-  "python-sdk": "Python SDK API",
-  "rust-sdk": "Rust SDK API",
+  "python-sdk": "Python SDK",
   "typescript-sdk": "TypeScript SDK",
+  "go-sdk": "Go SDK",
+  "rust-sdk": "Rust SDK",
   "plugin-manifests": "Provider Manifests",
   "http-api": "HTTP API",
   cli: "Server CLI",

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1202,7 +1202,7 @@ Gestalt synthesizes Go and Rust executable wrappers automatically when needed an
     [project]
     name = "my-plugin"
     version = "0.0.1-alpha.1"
-    dependencies = ["gestalt"]
+    dependencies = ["gestalt-sdk"]
 
     [tool.gestalt]
     provider = "provider"
@@ -1218,7 +1218,7 @@ Gestalt synthesizes Go and Rust executable wrappers automatically when needed an
     edition = "2024"
 
     [dependencies]
-    gestalt = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
+    gestalt = { package = "gestalt-sdk", version = "0.0.1-alpha.12" }
     schemars = { version = "0.8", features = ["derive"] }
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"

--- a/docs/content/reference/go-sdk.mdx
+++ b/docs/content/reference/go-sdk.mdx
@@ -1,18 +1,36 @@
 ---
-title: Go SDK API
+title: Go SDK
 ---
 
-# Go SDK API
+# Go SDK
 
-The Go SDK is published as the module
+Use the Go SDK to build executable Gestalt providers with typed handlers and a
+small runtime surface.
+
+The Go module is published as
 `github.com/valon-technologies/gestalt/sdk/go`.
 
-Its canonical API reference is hosted on `pkg.go.dev`:
+## Install
 
-- [Open the Go SDK reference on pkg.go.dev](https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go)
+Add the module to your provider project:
+
+```sh
+go get github.com/valon-technologies/gestalt/sdk/go@latest
+```
+
+Import it with a short package alias:
 
 ```go
-package example
+import gestalt "github.com/valon-technologies/gestalt/sdk/go"
+```
+
+## Create a plugin provider
+
+Define typed input and output structs, register the operation on a router, and
+export `New` plus `Router` from the provider package.
+
+```go
+package provider
 
 import (
 	"context"
@@ -21,75 +39,65 @@ import (
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 )
 
-type EchoProvider struct{}
+type SearchProvider struct{}
 
-func (p *EchoProvider) Configure(ctx context.Context, name string, config map[string]any) error {
+func New() *SearchProvider { return &SearchProvider{} }
+
+func (p *SearchProvider) Configure(ctx context.Context, name string, config map[string]any) error {
 	return nil
 }
 
-func New() *EchoProvider { return &EchoProvider{} }
+type SearchInput struct {
+	Query string `json:"query" doc:"Search query" required:"true"`
+	Limit int    `json:"limit,omitempty" doc:"Maximum results" default:"10"`
+}
+
+type SearchOutput struct {
+	Results []string `json:"results"`
+}
 
 var Router = gestalt.MustRouter(
 	gestalt.Register(
-		gestalt.Operation[struct{ Message string }, struct{ Echoed string }]{
-			ID:     "echo",
-			Method: http.MethodPost,
+		gestalt.Operation[SearchInput, SearchOutput]{
+			ID:     "search",
+			Method: http.MethodGet,
+			Title:  "Search",
 		},
-		func(_ *EchoProvider, _ context.Context, input struct{ Message string }, _ gestalt.Request) (gestalt.Response[struct{ Echoed string }], error) {
-			return gestalt.OK(struct{ Echoed string }{Echoed: input.Message}), nil
+		func(_ *SearchProvider, _ context.Context, input SearchInput, _ gestalt.Request) (gestalt.Response[SearchOutput], error) {
+			return gestalt.OK(SearchOutput{Results: []string{input.Query}}), nil
 		},
 	),
 )
 ```
 
-`pkg.go.dev` renders the source comments directly, so package and symbol docs
-there are the primary Go reference surface.
+`json:"name"` sets the catalog parameter name. `omitempty` makes a field
+optional. `doc:"..."`, `required:"true|false"`, and `default:"..."` control
+the generated catalog metadata.
 
-The same module also exposes the agent-provider runtime:
+## Use provider runtimes
 
-```go
-package exampleagent
+Use `Provider`, `Operation`, `Register`, and `Router` for integration
+providers. The module also exposes lower-level provider interfaces for host
+services.
 
-import (
-	"context"
+| Interface | Use it when you want to serve |
+| --- | --- |
+| `AgentProvider` | Agent sessions, turns, events, interactions, and capabilities. |
+| `AuthenticationProvider` | Login flows and optional bearer-token validation. |
+| `AuthorizationProvider` | Subject authorization decisions. |
+| `CacheProvider` | Plugin-bound cache storage. |
+| `IndexedDBProvider` | IndexedDB-style system state. |
+| `PluginRuntimeProvider` | Hosted plugin execution backends. |
+| `S3Provider` | S3-compatible object storage. |
+| `SecretsProvider` | Secret resolution. |
+| `WorkflowProvider` | Workflow runs, schedules, and event triggers. |
 
-	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
-)
+The same module includes host-service clients such as `CacheClient`,
+`IndexedDBClient`, `S3Client`, `WorkflowHostClient`, `WorkflowManagerClient`,
+`AgentHostClient`, `AgentManagerClient`, and `InvokerClient`.
 
-type Agent struct {
-	proto.UnimplementedAgentProviderServer
-}
+## API reference
 
-func New() *Agent { return &Agent{} }
+The canonical Go API reference is published on pkg.go.dev:
 
-func (a *Agent) CreateSession(_ context.Context, req *proto.CreateAgentProviderSessionRequest) (*proto.AgentSession, error) {
-	return &proto.AgentSession{
-		Id:           req.GetSessionId(),
-		ProviderName: "example",
-		Model:        req.GetModel(),
-		State:        proto.AgentSessionState_AGENT_SESSION_STATE_ACTIVE,
-	}, nil
-}
-
-func (a *Agent) CreateTurn(_ context.Context, req *proto.CreateAgentProviderTurnRequest) (*proto.AgentTurn, error) {
-	return &proto.AgentTurn{
-		Id:           req.GetTurnId(),
-		SessionId:    req.GetSessionId(),
-		ProviderName: "example",
-		Model:        req.GetModel(),
-		Status:       proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_RUNNING,
-		Messages:     req.GetMessages(),
-		ExecutionRef: req.GetExecutionRef(),
-	}, nil
-}
-
-func (a *Agent) GetCapabilities(context.Context, *proto.GetAgentProviderCapabilitiesRequest) (*proto.AgentProviderCapabilities, error) {
-	return &proto.AgentProviderCapabilities{
-		StreamingText:  true,
-		ToolCalls:      true,
-		Interactions:   true,
-		ResumableTurns: true,
-	}, nil
-}
-
-```
+- [Open the Go SDK reference on pkg.go.dev](https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go)

--- a/docs/content/reference/index.mdx
+++ b/docs/content/reference/index.mdx
@@ -7,20 +7,23 @@ import { Cards } from 'nextra/components'
 # Reference
 
 <Cards>
+  <Cards.Card title="SDKs" href="/reference/sdk">
+    Choose a provider SDK and understand how the guides relate to generated API references.
+  </Cards.Card>
   <Cards.Card title="Go SDK API" href="/reference/go-sdk">
-    Source-native docs on pkg.go.dev for the Go provider SDK.
+    Build executable providers with typed Go handlers.
   </Cards.Card>
   <Cards.Card title="Python SDK API" href="/reference/python-sdk">
-    Authored Python interfaces plus generated reference pages.
+    Build providers with Python models, decorators, and runtime helpers.
   </Cards.Card>
   <Cards.Card title="Config File" href="/reference/config-file">
     Every YAML field, validation rules, and load semantics.
   </Cards.Card>
   <Cards.Card title="Rust SDK API" href="/reference/rust-sdk">
-    Crate docs on docs.rs for the Rust provider SDK.
+    Build compiled providers with typed routers and schema-derived catalogs.
   </Cards.Card>
   <Cards.Card title="TypeScript SDK" href="/reference/typescript-sdk">
-    TypeDoc reference for the authored Bun and TypeScript SDK surface.
+    Build Bun-based providers with explicit runtime schemas.
   </Cards.Card>
   <Cards.Card title="Provider Manifests" href="/reference/plugin-manifests">
     Manifest schema for provider packages and UI bundles.

--- a/docs/content/reference/python-sdk.mdx
+++ b/docs/content/reference/python-sdk.mdx
@@ -1,41 +1,107 @@
 ---
-title: Python SDK API
+title: Python SDK
 ---
 
-# Python SDK API
+# Python SDK
 
-The Python SDK is published as `gestalt-sdk` and imported as `gestalt`.
+Use the Python SDK to build executable Gestalt providers with normal Python
+classes, functions, and type annotations.
 
-Use it for authored provider code such as:
+The package is published as `gestalt-sdk` and imported as `gestalt`. Use it
+when you want compact provider code, model classes for operation inputs and
+outputs, and Python runtime helpers for host services such as cache, S3,
+IndexedDB, workflows, agents, and telemetry.
 
-```python
-from gestalt import Model, Plugin
+## Install
 
+Install the package in your provider project:
 
-class SearchInput(Model):
-    query: str
-
-
-plugin = Plugin("search")
-
-
-@plugin.operation(title="Search")
-def search(params: SearchInput):
-    return {"query": params.query}
+```sh
+uv add gestalt-sdk
 ```
 
-The generated API reference is published separately as static HTML:
+Provider code imports the package as `gestalt`:
 
-- [Python SDK Reference](/api/python/index.html)
+```python
+import gestalt
+```
 
-Those pages focus on the handwritten SDK surface. Generated protobuf bindings
-under `gestalt.gen` remain available to provider code, but they are not
-expanded as authored reference pages.
+## Create a plugin provider
 
-Provider runtimes also expose OpenTelemetry helpers through `gestalt.telemetry`.
-`gestaltd` owns exporter configuration through `providers.telemetry` and passes
-standard `OTEL_*` environment into provider processes; Python providers should
-use the SDK helpers only around the GenAI work they own.
+Operations are the callable units of a plugin. Define input and output models,
+then register a function as an operation.
+
+```python
+import gestalt
+
+
+class SearchInput(gestalt.Model):
+    query: str = gestalt.field(description="Search query")
+    limit: int = gestalt.field(description="Maximum results", default=10)
+
+
+class SearchOutput(gestalt.Model):
+    results: list[str]
+
+
+plugin = gestalt.Plugin("search")
+
+
+@plugin.operation(method="GET", title="Search")
+def search(input: SearchInput, request: gestalt.Request) -> SearchOutput:
+    return SearchOutput(results=[input.query][: input.limit])
+```
+
+Fields without defaults are required. Use `gestalt.field(...)` to attach
+catalog descriptions and defaults.
+
+## Point Gestalt at the provider
+
+Python source providers are discovered from `pyproject.toml`. Point
+`[tool.gestalt].provider` at the module or object that exports your provider
+surface.
+
+```toml
+[project]
+name = "gestalt-search"
+version = "0.0.1"
+dependencies = ["gestalt-sdk"]
+
+[tool.uv]
+package = false
+
+[tool.gestalt]
+provider = "provider"
+```
+
+The provider manifest still owns the provider identity, connections, hosted
+HTTP routes, and passthrough surfaces. The Python module owns executable
+operation handlers and runtime hooks.
+
+## Use provider runtimes
+
+Use `Plugin` for integration providers. Inherit from a provider base class when
+you are implementing a host-service provider.
+
+| Base class | Use it when you want to serve |
+| --- | --- |
+| `AuthenticationProvider` | Login flows and optional bearer-token validation. |
+| `CacheProvider` | Plugin-bound cache storage. |
+| `S3Provider` | S3-compatible object storage. |
+| `SecretsProvider` | Secret resolution. |
+| `WorkflowProvider` | Workflow runs, schedules, and event triggers. |
+| `AgentProvider` | Agent sessions, turns, events, interactions, and capabilities. |
+| `PluginRuntimeProvider` | Hosted plugin execution backends. |
+
+The SDK also exposes clients such as `Cache`, `IndexedDB`, `S3`,
+`WorkflowHost`, `WorkflowManager`, `AgentHost`, `AgentManager`, and
+`PluginInvoker` for provider code that needs to call sibling host services.
+
+## Record provider telemetry
+
+`gestaltd` owns OpenTelemetry exporter configuration and passes standard
+`OTEL_*` environment variables into provider processes. Use
+`gestalt.telemetry` around GenAI work that your provider performs.
 
 ```python
 from gestalt import telemetry
@@ -50,40 +116,10 @@ with telemetry.model_operation(
     telemetry.record_openai_usage(operation, response)
 ```
 
-The Python SDK also exposes agent-provider helpers:
+## API reference
 
-```python
-import gestalt
+- [Open the Python API reference](/api/python/index.html)
 
-
-class ExampleAgent(gestalt.AgentProvider):
-    def CreateSession(self, request, context):
-        return gestalt.pb.AgentSession(
-            id=request.session_id,
-            provider_name="example",
-            model=request.model,
-            state=gestalt.pb.AGENT_SESSION_STATE_ACTIVE,
-        )
-
-    def CreateTurn(self, request, context):
-        return gestalt.pb.AgentTurn(
-            id=request.turn_id,
-            session_id=request.session_id,
-            provider_name="example",
-            model=request.model,
-            status=gestalt.pb.AGENT_EXECUTION_STATUS_RUNNING,
-            messages=request.messages,
-            execution_ref=request.execution_ref,
-        )
-
-    def GetCapabilities(self, request, context):
-        return gestalt.pb.AgentProviderCapabilities(
-            streaming_text=True,
-            tool_calls=True,
-            interactions=True,
-            resumable_turns=True,
-        )
-```
-
-Workflow providers use the same runtime pattern through `gestalt.WorkflowProvider`.
-Runtime-provider authors should inherit from `gestalt.PluginRuntimeProvider`.
+Generated protobuf bindings under `gestalt.gen` remain importable for lower
+level protocol work, but they are intentionally not expanded as authored
+reference pages.

--- a/docs/content/reference/rust-sdk.mdx
+++ b/docs/content/reference/rust-sdk.mdx
@@ -1,15 +1,41 @@
 ---
-title: Rust SDK API
+title: Rust SDK
 ---
 
-# Rust SDK API
+# Rust SDK
 
-The Rust SDK is published to crates.io as `gestalt-sdk`, while Rust code
-imports it as `gestalt`.
+Use the Rust SDK to build compiled Gestalt providers with typed routers,
+`serde` input and output types, and schema-derived catalog metadata.
 
-Its canonical API reference is hosted on `docs.rs`:
+The package is published to crates.io as `gestalt-sdk`, while Rust code imports
+the crate as `gestalt`.
 
-- [Open the Rust SDK reference on docs.rs](https://docs.rs/gestalt-sdk/latest/gestalt/)
+## Install
+
+Add the crate under the `gestalt` import name:
+
+```sh
+cargo add gestalt-sdk --rename gestalt
+cargo add serde --features derive
+cargo add schemars --features derive
+```
+
+The equivalent `Cargo.toml` dependency uses the package name explicitly:
+
+```toml
+[dependencies]
+gestalt = { package = "gestalt-sdk", version = "0.0.1-alpha.12" }
+schemars = { version = "0.8", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+```
+
+Use the current `gestalt-sdk` version from crates.io when you create a new
+provider.
+
+## Create a plugin provider
+
+Register typed operations on a `Router`. The SDK derives catalog metadata from
+the input and output types.
 
 ```rust
 use schemars::JsonSchema;
@@ -17,57 +43,80 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Default)]
-struct EchoProvider;
+struct SearchProvider;
 
 #[gestalt::async_trait]
-impl gestalt::Provider for EchoProvider {}
+impl gestalt::Provider for SearchProvider {}
 
 #[derive(Deserialize, JsonSchema)]
-struct EchoInput {
-    message: String,
+struct SearchInput {
+    #[schemars(description = "Search query")]
+    query: String,
+    #[serde(default = "default_limit")]
+    #[schemars(description = "Maximum results")]
+    limit: u32,
+}
+
+fn default_limit() -> u32 {
+    10
 }
 
 #[derive(Serialize, JsonSchema)]
-struct EchoOutput {
-    echoed: String,
+struct SearchOutput {
+    results: Vec<String>,
 }
 
-fn router() -> gestalt::Result<gestalt::Router<EchoProvider>> {
+fn router() -> gestalt::Result<gestalt::Router<SearchProvider>> {
     gestalt::Router::new().register(
-        gestalt::Operation::<EchoInput, EchoOutput>::new("echo"),
-        |_: Arc<EchoProvider>, input, _request| async move {
-            Ok::<_, gestalt::Error>(gestalt::ok(EchoOutput {
-                echoed: input.message,
+        gestalt::Operation::<SearchInput, SearchOutput>::new("search")
+            .method("GET")
+            .title("Search"),
+        |_: Arc<SearchProvider>, input, _request| async move {
+            Ok::<_, gestalt::Error>(gestalt::ok(SearchOutput {
+                results: vec![input.query]
+                    .into_iter()
+                    .take(input.limit as usize)
+                    .collect(),
             }))
         },
     )
 }
 
-gestalt::export_provider!(constructor = EchoProvider::default, router = router);
+gestalt::export_provider!(constructor = SearchProvider::default, router = router);
 ```
 
-`docs.rs` renders the crate docs, module docs, and symbol docs from the source
-and checked-in generated bindings.
+Fields are required unless they are modeled as `Option<T>` or have a serde
+default. Use `schemars` attributes for catalog descriptions.
 
-Agent host and provider utilities are also part of the crate:
+## Export provider entrypoints
 
-```rust
-use gestalt::generated::v1 as pb;
+Use the export macro that matches the provider surface you are serving.
 
-async fn execute_bound_tool() -> Result<(), Box<dyn std::error::Error>> {
-    let mut host = gestalt::AgentHost::connect().await?;
-    let response = host
-        .execute_tool(pb::ExecuteAgentToolRequest {
-            session_id: "session-123".into(),
-            turn_id: "turn-123".into(),
-            tool_call_id: "call-1".into(),
-            tool_id: "roadmap/sync".into(),
-            arguments: None,
-            tool_grant: "grant-token".into(),
-            idempotency_key: "turn-123:call-1".into(),
-        })
-        .await?;
-    println!("{}", response.status);
-    Ok(())
-}
-```
+| Macro | Use it when you want to serve |
+| --- | --- |
+| `export_provider!` | Integration operations and catalogs. |
+| `export_authentication_provider!` | Login flows. |
+| `export_cache_provider!` | Plugin-bound cache storage. |
+| `export_s3_provider!` | S3-compatible object storage. |
+| `export_secrets_provider!` | Secret resolution. |
+| `export_workflow_provider!` | Workflow runs, schedules, and event triggers. |
+| `export_agent_provider!` | Agent sessions, turns, events, interactions, and capabilities. |
+| `export_plugin_runtime_provider!` | Hosted plugin execution backends. |
+
+The macros export the symbols that `gestaltd` calls when it synthesizes the
+source-provider wrapper.
+
+## Generated bindings
+
+The crate includes checked-in protobuf and gRPC bindings compiled from
+`sdk/proto/v1/*.proto`. Consumers do not need a protobuf toolchain to build
+`gestalt-sdk`.
+
+Maintainers regenerate bindings with the Buf template in
+`sdk/proto/buf.rust.gen.yaml`.
+
+## API reference
+
+The canonical Rust API reference is published on docs.rs:
+
+- [Open the Rust SDK reference on docs.rs](https://docs.rs/gestalt-sdk/latest/gestalt/)

--- a/docs/content/reference/sdk.mdx
+++ b/docs/content/reference/sdk.mdx
@@ -1,0 +1,25 @@
+---
+title: SDKs
+---
+
+# SDKs
+
+Use a Gestalt SDK when you want to write an executable provider in a normal
+programming language instead of describing every operation in a manifest.
+
+The manifest still owns static provider metadata, connections, hosted HTTP
+routes, passthrough API surfaces, and release identity. The SDK owns runtime
+code: operation handlers, typed input and output models, provider lifecycle
+hooks, host-service clients, telemetry helpers, and provider-specific runtime
+servers.
+
+## Recommended path
+
+1. Read [Custom Providers](/custom-providers) to understand the provider
+   packaging model.
+2. Read the SDK page for your language:
+   [Python](/reference/python-sdk), [TypeScript](/reference/typescript-sdk),
+   [Go](/reference/go-sdk), or [Rust](/reference/rust-sdk).
+3. Build the smallest plugin provider first.
+4. Add provider-specific surfaces such as authentication, cache, S3, workflow,
+   runtime, or agent support only after the basic provider runs locally.

--- a/docs/content/reference/typescript-sdk.mdx
+++ b/docs/content/reference/typescript-sdk.mdx
@@ -1,158 +1,129 @@
+---
+title: TypeScript SDK
+---
+
 # TypeScript SDK
 
-The TypeScript SDK reference is generated from the authored public surface in
-`sdk/typescript/src`. It covers the root package exports from
-`@valon-technologies/gestalt` together with the `build`, `runtime`, `schema`,
-and `target` entrypoints used by Bun-based providers.
+Use the TypeScript SDK to build Bun-based executable Gestalt providers with
+explicit runtime schemas.
 
-[Open the TypeScript API reference](/api/typescript/index.html)
+The package is published as `@valon-technologies/gestalt`. Use it when you want
+schema-defined operation inputs and outputs, TypeScript handlers, and provider
+runtime helpers for plugins, authentication, cache, S3, IndexedDB, workflows,
+agents, hosted runtimes, and telemetry.
+
+## Install
+
+Install the current pre-1.0 package:
+
+```sh
+bun add @valon-technologies/gestalt@0.0.1-alpha.16
+```
+
+The npm `latest` dist-tag currently points at an older prerelease. Use the
+`alpha` dist-tag to check the newest prerelease, then pin the resolved version
+in provider projects.
+
+## Create a plugin provider
+
+TypeScript types disappear at runtime, so the SDK uses explicit schemas for
+operation inputs and outputs.
 
 ```ts
 import { definePlugin, ok, operation, s } from "@valon-technologies/gestalt";
 
 export const plugin = definePlugin({
-  displayName: "Example Provider",
+  displayName: "Search",
   operations: [
     operation({
-      id: "hello",
-      input: s.object({ name: s.string({ default: "World" }) }),
-      output: s.object({ message: s.string() }),
+      id: "search",
+      method: "GET",
+      title: "Search",
+      readOnly: true,
+      input: s.object({
+        query: s.string({ description: "Search query" }),
+        limit: s.integer({ description: "Maximum results", default: 10 }),
+      }),
+      output: s.object({
+        results: s.array(s.string()),
+      }),
       async handler(input) {
-        return ok({ message: `Hello, ${input.name}` });
+        return ok({ results: [input.query].slice(0, input.limit) });
       },
     }),
   ],
 });
 ```
 
-```ts
-import { parseRuntimeArgs, serve } from "@valon-technologies/gestalt/runtime";
+Use `ok(body)` for normal responses. Use `response(status, body)` when the
+operation needs to return a deliberate non-2xx status.
 
-const args = parseRuntimeArgs(process.argv.slice(2));
+## Point Gestalt at the provider
+
+Declare the provider target in `package.json`. The target is a relative file
+path plus an optional export suffix.
+
+```json
+{
+  "name": "gestalt-search",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@valon-technologies/gestalt": "0.0.1-alpha.16"
+  },
+  "gestalt": {
+    "provider": {
+      "kind": "plugin",
+      "target": "./provider.ts#plugin"
+    }
+  }
+}
 ```
 
-Agent-provider surfaces are part of the same package:
+If the export suffix is omitted, the runtime looks for `provider`, then
+`plugin`, then the default export. Use an object target with an explicit `kind`
+for non-plugin provider surfaces.
 
-```ts
-import {
-  AgentExecutionStatus,
-  AgentSessionState,
-  defineAgentProvider,
-} from "@valon-technologies/gestalt";
+## Use provider runtimes
 
-export const provider = defineAgentProvider({
-  displayName: "Example Agent",
+The root package exports provider definition helpers for each executable
+surface.
 
-  async createSession(request) {
-    return {
-      id: request.sessionId,
-      providerName: "example",
-      model: request.model,
-      clientRef: request.clientRef,
-      state: AgentSessionState.ACTIVE,
-      createdBy: request.createdBy,
-    };
-  },
+| Helper | Use it when you want to serve |
+| --- | --- |
+| `definePlugin` | Integration operations and session catalogs. |
+| `defineAuthenticationProvider` | Login flows and optional bearer-token validation. |
+| `defineAuthorizationProvider` | Subject authorization decisions. |
+| `defineCacheProvider` | Plugin-bound cache storage. |
+| `defineIndexedDBProvider` | IndexedDB-style system state. |
+| `defineS3Provider` | S3-compatible object storage. |
+| `defineSecretsProvider` | Secret resolution. |
+| `defineWorkflowProvider` | Workflow runs, schedules, and event triggers. |
+| `defineAgentProvider` | Agent sessions, turns, events, interactions, and capabilities. |
+| `definePluginRuntimeProvider` | Hosted plugin execution backends. |
 
-  async createTurn(request) {
-    return {
-      id: request.turnId,
-      sessionId: request.sessionId,
-      providerName: "example",
-      model: request.model,
-      status: AgentExecutionStatus.RUNNING,
-      messages: request.messages,
-      createdBy: request.createdBy,
-      executionRef: request.executionRef,
-    };
-  },
+## Runtime and build entrypoints
 
-  async getCapabilities() {
-    return { streamingText: true, toolCalls: true };
-  },
-});
+Use the runtime entrypoint for local source execution:
+
+```sh
+gestalt-ts-runtime ROOT plugin:./provider.ts#plugin
 ```
 
-Workflow-provider helpers expose the authored run, schedule, trigger, and event
-surface:
+Use the build entrypoint when `gestaltd provider release` packages a source
+provider:
 
-```ts
-import {
-  WorkflowRunStatus,
-  defineWorkflowProvider,
-} from "@valon-technologies/gestalt";
-
-export const workflow = defineWorkflowProvider({
-  async startRun(request) {
-    return {
-      id: `${request.target?.plugin?.pluginName ?? "workflow"}:run-1`,
-      status: WorkflowRunStatus.PENDING,
-      target: request.target,
-    };
-  },
-
-  async getRun(request) {
-    return { id: request.runId };
-  },
-
-  async listRuns() {
-    return [];
-  },
-
-  async cancelRun(request) {
-    return { id: request.runId, status: WorkflowRunStatus.CANCELED };
-  },
-
-  async upsertSchedule(request) {
-    return {
-      id: request.scheduleId,
-      cron: request.cron,
-      target: request.target,
-      paused: request.paused,
-    };
-  },
-
-  async getSchedule(request) {
-    return { id: request.scheduleId };
-  },
-
-  async listSchedules() {
-    return [];
-  },
-
-  async deleteSchedule() {},
-  async pauseSchedule(request) {
-    return { id: request.scheduleId, paused: true };
-  },
-  async resumeSchedule(request) {
-    return { id: request.scheduleId, paused: false };
-  },
-
-  async upsertEventTrigger(request) {
-    return {
-      id: request.triggerId,
-      match: request.match,
-      target: request.target,
-      paused: request.paused,
-    };
-  },
-
-  async getEventTrigger(request) {
-    return { id: request.triggerId };
-  },
-
-  async listEventTriggers() {
-    return [];
-  },
-
-  async deleteEventTrigger() {},
-  async pauseEventTrigger(request) {
-    return { id: request.triggerId, paused: true };
-  },
-  async resumeEventTrigger(request) {
-    return { id: request.triggerId, paused: false };
-  },
-
-  async publishEvent() {},
-});
+```sh
+gestalt-ts-build ROOT plugin:./provider.ts#plugin OUTPUT PROVIDER_NAME GOOS GOARCH
 ```
+
+The build entrypoint compiles a standalone executable with Bun and bundles the
+provider source into the result.
+
+## API reference
+
+The generated TypeDoc reference covers the public package exports and the
+`build`, `runtime`, `schema`, `target`, and `telemetry` entrypoints:
+
+- [Open the TypeScript API reference](/api/typescript/index.html)

--- a/sdk/go/agent_host.go
+++ b/sdk/go/agent_host.go
@@ -9,15 +9,21 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 )
 
+// EnvAgentHostSocket names the environment variable containing the agent-host
+// service target.
 const EnvAgentHostSocket = "GESTALT_AGENT_HOST_SOCKET"
+
+// EnvAgentHostSocketToken names the optional agent-host relay-token variable.
 const EnvAgentHostSocketToken = EnvAgentHostSocket + "_TOKEN"
 
+// AgentHostClient calls host tool APIs from an agent provider.
 type AgentHostClient struct {
 	client proto.AgentHostClient
 }
 
 var sharedAgentHostTransport sharedManagerTransport[proto.AgentHostClient]
 
+// AgentHost returns a shared client for the host agent service.
 func AgentHost() (*AgentHostClient, error) {
 	target := os.Getenv(EnvAgentHostSocket)
 	if target == "" {
@@ -37,14 +43,17 @@ func AgentHost() (*AgentHostClient, error) {
 	}, nil
 }
 
+// Close is a no-op compatibility method because this client uses shared transport.
 func (c *AgentHostClient) Close() error {
 	return nil
 }
 
+// ExecuteTool executes a host tool using an agent protocol request.
 func (c *AgentHostClient) ExecuteTool(ctx context.Context, req *proto.ExecuteAgentToolRequest) (*proto.ExecuteAgentToolResponse, error) {
 	return c.client.ExecuteTool(ctx, req)
 }
 
+// ListTools lists host tools visible to the current agent request.
 func (c *AgentHostClient) ListTools(ctx context.Context, req *proto.ListAgentToolsRequest) (*proto.ListAgentToolsResponse, error) {
 	return c.client.ListTools(ctx, req)
 }

--- a/sdk/go/agent_manager.go
+++ b/sdk/go/agent_manager.go
@@ -11,9 +11,15 @@ import (
 	gproto "google.golang.org/protobuf/proto"
 )
 
+// EnvAgentManagerSocket names the environment variable containing the
+// agent-manager service target.
 const EnvAgentManagerSocket = proto.EnvAgentManagerSocket
+
+// EnvAgentManagerSocketToken names the optional agent-manager relay-token
+// variable.
 const EnvAgentManagerSocketToken = EnvAgentManagerSocket + "_TOKEN"
 
+// AgentManagerClient manages agent sessions, turns, events, and interactions.
 type AgentManagerClient struct {
 	client          proto.AgentManagerHostClient
 	invocationToken string
@@ -21,6 +27,7 @@ type AgentManagerClient struct {
 
 var sharedAgentManagerTransport sharedManagerTransport[proto.AgentManagerHostClient]
 
+// AgentManager returns a client that attaches invocationToken to every request.
 func AgentManager(invocationToken string) (*AgentManagerClient, error) {
 	if strings.TrimSpace(invocationToken) == "" {
 		return nil, fmt.Errorf("agent manager: invocation token is not available")
@@ -42,14 +49,17 @@ func AgentManager(invocationToken string) (*AgentManagerClient, error) {
 	return &AgentManagerClient{client: client, invocationToken: strings.TrimSpace(invocationToken)}, nil
 }
 
+// AgentManagerFromContext returns an AgentManager using the context invocation token.
 func AgentManagerFromContext(ctx context.Context) (*AgentManagerClient, error) {
 	return AgentManager(InvocationTokenFromContext(ctx))
 }
 
+// Close is a no-op compatibility method because this client uses shared transport.
 func (c *AgentManagerClient) Close() error {
 	return nil
 }
 
+// CreateSession creates an agent session.
 func (c *AgentManagerClient) CreateSession(ctx context.Context, req *proto.AgentManagerCreateSessionRequest) (*proto.AgentSession, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
@@ -62,6 +72,7 @@ func (c *AgentManagerClient) CreateSession(ctx context.Context, req *proto.Agent
 	return c.client.CreateSession(ctx, value)
 }
 
+// GetSession fetches one agent session.
 func (c *AgentManagerClient) GetSession(ctx context.Context, req *proto.AgentManagerGetSessionRequest) (*proto.AgentSession, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
@@ -74,6 +85,7 @@ func (c *AgentManagerClient) GetSession(ctx context.Context, req *proto.AgentMan
 	return c.client.GetSession(ctx, value)
 }
 
+// ListSessions lists agent sessions visible to the invocation token.
 func (c *AgentManagerClient) ListSessions(ctx context.Context, req *proto.AgentManagerListSessionsRequest) (*proto.AgentManagerListSessionsResponse, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
@@ -86,6 +98,7 @@ func (c *AgentManagerClient) ListSessions(ctx context.Context, req *proto.AgentM
 	return c.client.ListSessions(ctx, value)
 }
 
+// UpdateSession updates mutable fields on an agent session.
 func (c *AgentManagerClient) UpdateSession(ctx context.Context, req *proto.AgentManagerUpdateSessionRequest) (*proto.AgentSession, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
@@ -98,6 +111,7 @@ func (c *AgentManagerClient) UpdateSession(ctx context.Context, req *proto.Agent
 	return c.client.UpdateSession(ctx, value)
 }
 
+// CreateTurn creates an agent turn.
 func (c *AgentManagerClient) CreateTurn(ctx context.Context, req *proto.AgentManagerCreateTurnRequest) (*proto.AgentTurn, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
@@ -110,6 +124,7 @@ func (c *AgentManagerClient) CreateTurn(ctx context.Context, req *proto.AgentMan
 	return c.client.CreateTurn(ctx, value)
 }
 
+// GetTurn fetches one agent turn.
 func (c *AgentManagerClient) GetTurn(ctx context.Context, req *proto.AgentManagerGetTurnRequest) (*proto.AgentTurn, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
@@ -122,6 +137,7 @@ func (c *AgentManagerClient) GetTurn(ctx context.Context, req *proto.AgentManage
 	return c.client.GetTurn(ctx, value)
 }
 
+// ListTurns lists turns for an agent session.
 func (c *AgentManagerClient) ListTurns(ctx context.Context, req *proto.AgentManagerListTurnsRequest) (*proto.AgentManagerListTurnsResponse, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
@@ -134,6 +150,7 @@ func (c *AgentManagerClient) ListTurns(ctx context.Context, req *proto.AgentMana
 	return c.client.ListTurns(ctx, value)
 }
 
+// CancelTurn cancels an in-progress agent turn.
 func (c *AgentManagerClient) CancelTurn(ctx context.Context, req *proto.AgentManagerCancelTurnRequest) (*proto.AgentTurn, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
@@ -146,6 +163,7 @@ func (c *AgentManagerClient) CancelTurn(ctx context.Context, req *proto.AgentMan
 	return c.client.CancelTurn(ctx, value)
 }
 
+// ListTurnEvents lists events emitted for an agent turn.
 func (c *AgentManagerClient) ListTurnEvents(ctx context.Context, req *proto.AgentManagerListTurnEventsRequest) (*proto.AgentManagerListTurnEventsResponse, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
@@ -158,6 +176,7 @@ func (c *AgentManagerClient) ListTurnEvents(ctx context.Context, req *proto.Agen
 	return c.client.ListTurnEvents(ctx, value)
 }
 
+// ListInteractions lists pending or completed agent interactions.
 func (c *AgentManagerClient) ListInteractions(ctx context.Context, req *proto.AgentManagerListInteractionsRequest) (*proto.AgentManagerListInteractionsResponse, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
@@ -170,6 +189,7 @@ func (c *AgentManagerClient) ListInteractions(ctx context.Context, req *proto.Ag
 	return c.client.ListInteractions(ctx, value)
 }
 
+// ResolveInteraction resolves an agent interaction with a host response.
 func (c *AgentManagerClient) ResolveInteraction(ctx context.Context, req *proto.AgentManagerResolveInteractionRequest) (*proto.AgentInteraction, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")

--- a/sdk/go/authorization.go
+++ b/sdk/go/authorization.go
@@ -6,39 +6,91 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 )
 
+// AuthorizationMetadata describes the host authorization provider.
 type AuthorizationMetadata = proto.AuthorizationMetadata
+
+// AuthorizationSubject is a generated subject descriptor.
 type AuthorizationSubject = proto.Subject
+
+// AuthorizationResource is a generated resource descriptor.
 type AuthorizationResource = proto.Resource
+
+// AuthorizationAction is a generated action descriptor.
 type AuthorizationAction = proto.Action
 
+// AccessEvaluationRequest asks whether one subject can perform one action.
 type AccessEvaluationRequest = proto.AccessEvaluationRequest
+
+// AccessDecision is the result of evaluating one access request.
 type AccessDecision = proto.AccessDecision
+
+// AccessEvaluationsRequest batches access evaluation requests.
 type AccessEvaluationsRequest = proto.AccessEvaluationsRequest
+
+// AccessEvaluationsResponse batches access evaluation results.
 type AccessEvaluationsResponse = proto.AccessEvaluationsResponse
 
+// ResourceSearchRequest searches resources visible to a subject.
 type ResourceSearchRequest = proto.ResourceSearchRequest
+
+// ResourceSearchResponse contains resources visible to a subject.
 type ResourceSearchResponse = proto.ResourceSearchResponse
+
+// SubjectSearchRequest searches subjects related to a resource and action.
 type SubjectSearchRequest = proto.SubjectSearchRequest
+
+// SubjectSearchResponse contains subjects related to a resource and action.
 type SubjectSearchResponse = proto.SubjectSearchResponse
+
+// ActionSearchRequest searches actions available between a subject and resource.
 type ActionSearchRequest = proto.ActionSearchRequest
+
+// ActionSearchResponse contains actions available between a subject and resource.
 type ActionSearchResponse = proto.ActionSearchResponse
 
+// Relationship describes one authorization relationship tuple.
 type Relationship = proto.Relationship
+
+// RelationshipKey identifies one authorization relationship tuple.
 type RelationshipKey = proto.RelationshipKey
+
+// ReadRelationshipsRequest selects authorization relationships to read.
 type ReadRelationshipsRequest = proto.ReadRelationshipsRequest
+
+// ReadRelationshipsResponse contains authorization relationships.
 type ReadRelationshipsResponse = proto.ReadRelationshipsResponse
+
+// WriteRelationshipsRequest mutates authorization relationships.
 type WriteRelationshipsRequest = proto.WriteRelationshipsRequest
 
+// AuthorizationModel describes an authorization model.
 type AuthorizationModel = proto.AuthorizationModel
+
+// AuthorizationModelResourceType describes one resource type in a model.
 type AuthorizationModelResourceType = proto.AuthorizationModelResourceType
+
+// AuthorizationModelRelation describes one relation in a model.
 type AuthorizationModelRelation = proto.AuthorizationModelRelation
+
+// AuthorizationModelAction describes one action in a model.
 type AuthorizationModelAction = proto.AuthorizationModelAction
+
+// AuthorizationModelRef identifies a stored authorization model.
 type AuthorizationModelRef = proto.AuthorizationModelRef
+
+// GetActiveModelResponse returns the active authorization model.
 type GetActiveModelResponse = proto.GetActiveModelResponse
+
+// ListModelsRequest selects authorization models to list.
 type ListModelsRequest = proto.ListModelsRequest
+
+// ListModelsResponse contains authorization model refs.
 type ListModelsResponse = proto.ListModelsResponse
+
+// WriteModelRequest stores an authorization model.
 type WriteModelRequest = proto.WriteModelRequest
 
+// AuthorizationProvider serves authorization APIs to the host.
 type AuthorizationProvider interface {
 	Provider
 	Evaluate(ctx context.Context, req *AccessEvaluationRequest) (*AccessDecision, error)

--- a/sdk/go/authorization_client.go
+++ b/sdk/go/authorization_client.go
@@ -18,9 +18,14 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+// EnvAuthorizationSocket names the environment variable containing the
+// authorization service target.
 const EnvAuthorizationSocket = "GESTALT_AUTHORIZATION_SOCKET"
+
+// EnvAuthorizationSocketToken names the optional authorization relay-token variable.
 const EnvAuthorizationSocketToken = EnvAuthorizationSocket + "_TOKEN"
 
+// AuthorizationClient calls the read-only host authorization provider.
 type AuthorizationClient struct {
 	client proto.AuthorizationProviderClient
 }
@@ -33,6 +38,7 @@ var sharedAuthorizationTransport struct {
 	client proto.AuthorizationProviderClient
 }
 
+// Authorization returns a shared read-only authorization client.
 func Authorization() (*AuthorizationClient, error) {
 	target := os.Getenv(EnvAuthorizationSocket)
 	if target == "" {
@@ -182,8 +188,10 @@ func parseAuthorizationTarget(raw string) (network string, address string, err e
 	}
 }
 
+// Close is a no-op compatibility method because this client uses shared transport.
 func (c *AuthorizationClient) Close() error { return nil }
 
+// SearchSubjects searches subjects related to a resource and action.
 func (c *AuthorizationClient) SearchSubjects(ctx context.Context, req *SubjectSearchRequest) (*SubjectSearchResponse, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("authorization: client is not initialized")
@@ -194,6 +202,7 @@ func (c *AuthorizationClient) SearchSubjects(ctx context.Context, req *SubjectSe
 	return c.client.SearchSubjects(ctx, req)
 }
 
+// GetMetadata returns host authorization provider metadata.
 func (c *AuthorizationClient) GetMetadata(ctx context.Context) (*AuthorizationMetadata, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("authorization: client is not initialized")

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -1,49 +1,70 @@
-// Package gestalt provides a Go SDK for building Gestalt executable providers.
+// Package gestalt provides a Go SDK for building executable Gestalt providers.
 //
-// Gestalt providers extend the platform with new integrations and automations.
-// [Provider] is the runtime contract for integration providers: it
-// receives startup config and serves typed executable operations when the host
-// invokes them.
+// Use this package when you want a provider implemented as normal Go code with
+// typed operation inputs, typed operation outputs, and a small runtime surface.
+// The provider manifest still owns static identity, connections, hosted HTTP
+// routes, passthrough surfaces, and release metadata. Go code owns executable
+// handlers and provider runtime hooks.
 //
-// Static metadata still belongs to the provider manifest. Static executable
-// operations are authored in Go and materialized automatically by the SDK and
-// host. The recommended authoring flow is:
+// # Quick start
 //
-//  1. Implement [Provider.Configure].
-//  2. Define typed operations and handlers in Go with [Operation], [Register],
-//     and [Router].
-//  3. Export `New()` plus `Router` from the provider package.
+// Implement Provider.Configure, define typed operations, and export New plus
+// Router from the provider package:
 //
-// This keeps the runtime contract single-source and manifest-backed while still
-// giving provider authors typed Go definitions for executable helper
-// operations.
+//	type SearchProvider struct{}
 //
-// The package also includes first-pass runtime/auth/datastore protocol types
-// for non-integration provider kinds, plus transport helpers like [Cache],
-// [IndexedDB], and [S3] for speaking to sibling provider components. The
-// current host-side execution flow
-// remains integration-focused and is anchored on [ServeProvider].
+//	func New() *SearchProvider { return &SearchProvider{} }
 //
-// # Implementing a Provider
-//
-// The runtime provider interface stays small:
-//
-//	type MyProvider struct{}
-//
-//	func (p *MyProvider) Configure(ctx context.Context, name string, config map[string]any) error {
+//	func (p *SearchProvider) Configure(ctx context.Context, name string, config map[string]any) error {
 //		return nil
 //	}
 //
-//	func New() *MyProvider { return &MyProvider{} }
+//	type SearchInput struct {
+//		Query string `json:"query" doc:"Search query" required:"true"`
+//	}
+//
+//	type SearchOutput struct {
+//		Results []string `json:"results"`
+//	}
 //
 //	var Router = gestalt.MustRouter(
-//		gestalt.Register(myOperation, (*MyProvider).myHandler),
+//		gestalt.Register(
+//			gestalt.Operation[SearchInput, SearchOutput]{
+//				ID:     "search",
+//				Method: http.MethodGet,
+//				Title:  "Search",
+//			},
+//			func(_ *SearchProvider, _ context.Context, input SearchInput, _ gestalt.Request) (gestalt.Response[SearchOutput], error) {
+//				return gestalt.OK(SearchOutput{Results: []string{input.Query}}), nil
+//			},
+//		),
 //	)
 //
 // Source-provider flows derive the executable catalog name from manifest.yaml.
-// Use [Router.WithName] only when you need an explicit catalog name outside
-// that manifest-backed flow.
+// Use Router.WithName only when you need an explicit catalog name outside that
+// manifest-backed flow.
 //
-// See https://gestaltd.ai/custom-providers/plugins for the full typed
+// # Catalog metadata
+//
+// The router derives catalog parameters from Go struct tags. The json tag sets
+// the parameter name. json:",omitempty" makes the parameter optional.
+// doc:"..." sets the description, required:"true|false" overrides requiredness,
+// and default:"..." sets a scalar default.
+//
+// # Provider surfaces
+//
+// Provider, Operation, Register, and Router model integration providers. The
+// package also exposes provider interfaces for host-service backends, including
+// AuthenticationProvider, AuthorizationProvider, CacheProvider,
+// IndexedDBProvider, S3Provider, SecretsProvider, WorkflowProvider,
+// AgentProvider, and PluginRuntimeProvider.
+//
+// Use the host-service clients when provider code needs to call sibling
+// services exposed by gestaltd. These include CacheClient, IndexedDBClient,
+// S3Client, WorkflowHostClient, WorkflowManagerClient, AgentHostClient,
+// AgentManagerClient, AuthorizationClient, and InvokerClient.
+//
+// See https://gestaltd.ai/reference/go-sdk for the Go SDK guide.
+// See https://gestaltd.ai/custom-providers/plugins for the full typed plugin
 // authoring flow.
 package gestalt

--- a/sdk/go/external_credential.go
+++ b/sdk/go/external_credential.go
@@ -6,12 +6,25 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 )
 
+// ExternalCredential is the generated credential record stored by the host.
 type ExternalCredential = proto.ExternalCredential
+
+// ExternalCredentialLookup selects a host-managed external credential.
 type ExternalCredentialLookup = proto.ExternalCredentialLookup
+
+// UpsertExternalCredentialRequest is the request for creating or updating a credential.
 type UpsertExternalCredentialRequest = proto.UpsertExternalCredentialRequest
+
+// GetExternalCredentialRequest is the request for fetching one credential.
 type GetExternalCredentialRequest = proto.GetExternalCredentialRequest
+
+// ListExternalCredentialsRequest is the request for listing credentials.
 type ListExternalCredentialsRequest = proto.ListExternalCredentialsRequest
+
+// ListExternalCredentialsResponse is the response returned when listing credentials.
 type ListExternalCredentialsResponse = proto.ListExternalCredentialsResponse
+
+// DeleteExternalCredentialRequest is the request for deleting one credential.
 type DeleteExternalCredentialRequest = proto.DeleteExternalCredentialRequest
 
 // ExternalCredentialProvider serves CRUD operations for host-managed external

--- a/sdk/go/external_credential_client.go
+++ b/sdk/go/external_credential_client.go
@@ -9,9 +9,15 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 )
 
+// EnvExternalCredentialSocket names the environment variable containing the
+// external-credential service target.
 const EnvExternalCredentialSocket = "GESTALT_EXTERNAL_CREDENTIAL_SOCKET"
+
+// EnvExternalCredentialSocketToken names the optional external-credential
+// relay-token variable.
 const EnvExternalCredentialSocketToken = EnvExternalCredentialSocket + "_TOKEN"
 
+// ExternalCredentialClient calls the host-managed external credential provider.
 type ExternalCredentialClient struct {
 	client proto.ExternalCredentialProviderClient
 }
@@ -37,8 +43,10 @@ func ExternalCredentials() (*ExternalCredentialClient, error) {
 	return &ExternalCredentialClient{client: client}, nil
 }
 
+// Close is a no-op compatibility method because this client uses shared transport.
 func (c *ExternalCredentialClient) Close() error { return nil }
 
+// UpsertCredential creates or updates a host-managed external credential.
 func (c *ExternalCredentialClient) UpsertCredential(ctx context.Context, req *UpsertExternalCredentialRequest) (*ExternalCredential, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("external credentials: client is not initialized")
@@ -49,6 +57,7 @@ func (c *ExternalCredentialClient) UpsertCredential(ctx context.Context, req *Up
 	return c.client.UpsertCredential(ctx, req)
 }
 
+// GetCredential fetches one host-managed external credential.
 func (c *ExternalCredentialClient) GetCredential(ctx context.Context, req *GetExternalCredentialRequest) (*ExternalCredential, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("external credentials: client is not initialized")
@@ -59,6 +68,7 @@ func (c *ExternalCredentialClient) GetCredential(ctx context.Context, req *GetEx
 	return c.client.GetCredential(ctx, req)
 }
 
+// ListCredentials lists host-managed external credentials.
 func (c *ExternalCredentialClient) ListCredentials(ctx context.Context, req *ListExternalCredentialsRequest) (*ListExternalCredentialsResponse, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("external credentials: client is not initialized")
@@ -69,6 +79,7 @@ func (c *ExternalCredentialClient) ListCredentials(ctx context.Context, req *Lis
 	return c.client.ListCredentials(ctx, req)
 }
 
+// DeleteCredential deletes one host-managed external credential.
 func (c *ExternalCredentialClient) DeleteCredential(ctx context.Context, req *DeleteExternalCredentialRequest) error {
 	if c == nil || c.client == nil {
 		return fmt.Errorf("external credentials: client is not initialized")

--- a/sdk/go/invoker.go
+++ b/sdk/go/invoker.go
@@ -18,22 +18,37 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// EnvPluginInvokerSocket names the environment variable containing the
+// plugin-invoker service target.
 const EnvPluginInvokerSocket = proto.EnvPluginInvokerSocket
+
+// EnvPluginInvokerSocketToken names the optional plugin-invoker relay-token
+// variable.
 const EnvPluginInvokerSocketToken = EnvPluginInvokerSocket + "_TOKEN"
 
+// InvokeOptions selects a target connection for a plugin invocation.
 type InvokeOptions struct {
-	Connection     string
-	Instance       string
+	// Connection is the connected account id or name to invoke against.
+	Connection string
+	// Instance is the provider instance id or name to invoke against.
+	Instance string
+	// IdempotencyKey is forwarded to the target operation.
 	IdempotencyKey string
 }
 
+// InvocationGrant describes access granted to an exchanged invocation token.
 type InvocationGrant struct {
-	Plugin        string
-	Operations    []string
-	Surfaces      []string
+	// Plugin is the plugin name the child token may invoke.
+	Plugin string
+	// Operations are the specific operation ids allowed by the child token.
+	Operations []string
+	// Surfaces are the surface names allowed by the child token.
+	Surfaces []string
+	// AllOperations allows every operation on Plugin.
 	AllOperations bool
 }
 
+// InvokerClient invokes sibling plugin operations through the host.
 type InvokerClient struct {
 	client          proto.PluginInvokerClient
 	invocationToken string
@@ -47,6 +62,7 @@ var sharedInvokerTransport struct {
 	client proto.PluginInvokerClient
 }
 
+// Invoker returns a client that attaches invocationToken to every request.
 func Invoker(invocationToken string) (*InvokerClient, error) {
 	if strings.TrimSpace(invocationToken) == "" {
 		return nil, fmt.Errorf("plugin invoker: invocation token is not available")
@@ -203,14 +219,17 @@ func parsePluginInvokerTarget(raw string) (network string, address string, err e
 	}
 }
 
+// InvokerFromContext returns an Invoker using the context invocation token.
 func InvokerFromContext(ctx context.Context) (*InvokerClient, error) {
 	return Invoker(InvocationTokenFromContext(ctx))
 }
 
+// Close is a no-op compatibility method because this client uses shared transport.
 func (c *InvokerClient) Close() error {
 	return nil
 }
 
+// Invoke calls one operation on another plugin.
 func (c *InvokerClient) Invoke(ctx context.Context, plugin, operation string, params map[string]any, opts *InvokeOptions) (*OperationResult, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("plugin invoker: client is not initialized")
@@ -245,6 +264,7 @@ func (c *InvokerClient) Invoke(ctx context.Context, plugin, operation string, pa
 	}, nil
 }
 
+// InvokeGraphQL calls another plugin's GraphQL surface.
 func (c *InvokerClient) InvokeGraphQL(ctx context.Context, plugin, document string, variables map[string]any, opts *InvokeOptions) (*OperationResult, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("plugin invoker: client is not initialized")
@@ -285,6 +305,7 @@ func (c *InvokerClient) InvokeGraphQL(ctx context.Context, plugin, document stri
 	}, nil
 }
 
+// ExchangeInvocationToken exchanges this invocation token for a narrower child token.
 func (c *InvokerClient) ExchangeInvocationToken(ctx context.Context, grants []InvocationGrant, ttl time.Duration) (string, error) {
 	if c == nil || c.client == nil {
 		return "", fmt.Errorf("plugin invoker: client is not initialized")

--- a/sdk/go/runtime_log_host.go
+++ b/sdk/go/runtime_log_host.go
@@ -12,10 +12,18 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// EnvRuntimeLogHostSocket names the environment variable containing the
+// runtime-log service target.
 const EnvRuntimeLogHostSocket = "GESTALT_RUNTIME_LOG_SOCKET"
+
+// EnvRuntimeLogHostSocketToken names the optional runtime-log relay-token variable.
 const EnvRuntimeLogHostSocketToken = EnvRuntimeLogHostSocket + "_TOKEN"
+
+// EnvRuntimeSessionID names the environment variable containing the current
+// plugin-runtime session id.
 const EnvRuntimeSessionID = "GESTALT_RUNTIME_SESSION_ID"
 
+// RuntimeLogHostClient appends plugin-runtime logs to the host.
 type RuntimeLogHostClient struct {
 	client    proto.PluginRuntimeLogHostClient
 	sourceSeq atomic.Int64
@@ -23,6 +31,7 @@ type RuntimeLogHostClient struct {
 
 var sharedRuntimeLogHostTransport sharedManagerTransport[proto.PluginRuntimeLogHostClient]
 
+// RuntimeLogHost returns a shared client for the runtime-log host service.
 func RuntimeLogHost() (*RuntimeLogHostClient, error) {
 	target := strings.TrimSpace(os.Getenv(EnvRuntimeLogHostSocket))
 	if target == "" {
@@ -40,14 +49,17 @@ func RuntimeLogHost() (*RuntimeLogHostClient, error) {
 	return &RuntimeLogHostClient{client: client}, nil
 }
 
+// Close is a no-op compatibility method because this client uses shared transport.
 func (c *RuntimeLogHostClient) Close() error {
 	return nil
 }
 
+// AppendLogs appends logs using a raw protocol request.
 func (c *RuntimeLogHostClient) AppendLogs(ctx context.Context, req *proto.AppendPluginRuntimeLogsRequest) (*proto.AppendPluginRuntimeLogsResponse, error) {
 	return c.client.AppendLogs(ctx, req)
 }
 
+// RuntimeLogAppendOption configures a single Append call.
 type RuntimeLogAppendOption func(*runtimeLogAppendOptions)
 
 type runtimeLogAppendOptions struct {

--- a/sdk/go/workflow_host.go
+++ b/sdk/go/workflow_host.go
@@ -11,13 +11,17 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// EnvWorkflowHostSocket names the environment variable containing the
+// workflow-host service socket path.
 const EnvWorkflowHostSocket = "GESTALT_WORKFLOW_HOST_SOCKET"
 
+// WorkflowHostClient invokes operations from workflow provider code.
 type WorkflowHostClient struct {
 	client proto.WorkflowHostClient
 	conn   *grpc.ClientConn
 }
 
+// WorkflowHost returns a client for the workflow host service.
 func WorkflowHost() (*WorkflowHostClient, error) {
 	socketPath := os.Getenv(EnvWorkflowHostSocket)
 	if socketPath == "" {
@@ -38,6 +42,7 @@ func WorkflowHost() (*WorkflowHostClient, error) {
 	}, nil
 }
 
+// Close closes the underlying workflow-host connection.
 func (c *WorkflowHostClient) Close() error {
 	if c == nil || c.conn == nil {
 		return nil
@@ -45,6 +50,7 @@ func (c *WorkflowHostClient) Close() error {
 	return c.conn.Close()
 }
 
+// InvokeOperation invokes an operation through the workflow host service.
 func (c *WorkflowHostClient) InvokeOperation(ctx context.Context, req *proto.InvokeWorkflowOperationRequest) (*proto.InvokeWorkflowOperationResponse, error) {
 	return c.client.InvokeOperation(ctx, req)
 }

--- a/sdk/go/workflow_manager.go
+++ b/sdk/go/workflow_manager.go
@@ -11,9 +11,15 @@ import (
 	gproto "google.golang.org/protobuf/proto"
 )
 
+// EnvWorkflowManagerSocket names the environment variable containing the
+// workflow-manager service target.
 const EnvWorkflowManagerSocket = proto.EnvWorkflowManagerSocket
+
+// EnvWorkflowManagerSocketToken names the optional workflow-manager relay-token
+// variable.
 const EnvWorkflowManagerSocketToken = EnvWorkflowManagerSocket + "_TOKEN"
 
+// WorkflowManagerClient starts runs and manages workflow schedules or triggers.
 type WorkflowManagerClient struct {
 	client          proto.WorkflowManagerHostClient
 	invocationToken string
@@ -22,6 +28,7 @@ type WorkflowManagerClient struct {
 
 var sharedWorkflowManagerTransport sharedManagerTransport[proto.WorkflowManagerHostClient]
 
+// WorkflowManager returns a client that attaches invocationToken to every request.
 func WorkflowManager(invocationToken string) (*WorkflowManagerClient, error) {
 	if strings.TrimSpace(invocationToken) == "" {
 		return nil, fmt.Errorf("workflow manager: invocation token is not available")
@@ -43,6 +50,7 @@ func WorkflowManager(invocationToken string) (*WorkflowManagerClient, error) {
 	return &WorkflowManagerClient{client: client, invocationToken: strings.TrimSpace(invocationToken)}, nil
 }
 
+// WorkflowManagerFromContext returns a WorkflowManager using context metadata.
 func WorkflowManagerFromContext(ctx context.Context) (*WorkflowManagerClient, error) {
 	client, err := WorkflowManager(InvocationTokenFromContext(ctx))
 	if err != nil {
@@ -52,10 +60,12 @@ func WorkflowManagerFromContext(ctx context.Context) (*WorkflowManagerClient, er
 	return client, nil
 }
 
+// Close is a no-op compatibility method because this client uses shared transport.
 func (c *WorkflowManagerClient) Close() error {
 	return nil
 }
 
+// StartRun starts a workflow run.
 func (c *WorkflowManagerClient) StartRun(ctx context.Context, req *proto.WorkflowManagerStartRunRequest) (*proto.ManagedWorkflowRun, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -68,6 +78,7 @@ func (c *WorkflowManagerClient) StartRun(ctx context.Context, req *proto.Workflo
 	return c.client.StartRun(ctx, value)
 }
 
+// SignalRun signals an existing workflow run.
 func (c *WorkflowManagerClient) SignalRun(ctx context.Context, req *proto.WorkflowManagerSignalRunRequest) (*proto.ManagedWorkflowRunSignal, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -80,6 +91,7 @@ func (c *WorkflowManagerClient) SignalRun(ctx context.Context, req *proto.Workfl
 	return c.client.SignalRun(ctx, value)
 }
 
+// SignalOrStartRun signals a run or starts it when no matching run exists.
 func (c *WorkflowManagerClient) SignalOrStartRun(ctx context.Context, req *proto.WorkflowManagerSignalOrStartRunRequest) (*proto.ManagedWorkflowRunSignal, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -92,6 +104,7 @@ func (c *WorkflowManagerClient) SignalOrStartRun(ctx context.Context, req *proto
 	return c.client.SignalOrStartRun(ctx, value)
 }
 
+// CreateSchedule creates a workflow schedule.
 func (c *WorkflowManagerClient) CreateSchedule(ctx context.Context, req *proto.WorkflowManagerCreateScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -107,6 +120,7 @@ func (c *WorkflowManagerClient) CreateSchedule(ctx context.Context, req *proto.W
 	return c.client.CreateSchedule(ctx, value)
 }
 
+// GetSchedule fetches one workflow schedule.
 func (c *WorkflowManagerClient) GetSchedule(ctx context.Context, req *proto.WorkflowManagerGetScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -119,6 +133,7 @@ func (c *WorkflowManagerClient) GetSchedule(ctx context.Context, req *proto.Work
 	return c.client.GetSchedule(ctx, value)
 }
 
+// UpdateSchedule updates a workflow schedule.
 func (c *WorkflowManagerClient) UpdateSchedule(ctx context.Context, req *proto.WorkflowManagerUpdateScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -131,6 +146,7 @@ func (c *WorkflowManagerClient) UpdateSchedule(ctx context.Context, req *proto.W
 	return c.client.UpdateSchedule(ctx, value)
 }
 
+// DeleteSchedule deletes a workflow schedule.
 func (c *WorkflowManagerClient) DeleteSchedule(ctx context.Context, req *proto.WorkflowManagerDeleteScheduleRequest) error {
 	if c == nil || c.client == nil {
 		return fmt.Errorf("workflow manager: client is not initialized")
@@ -144,6 +160,7 @@ func (c *WorkflowManagerClient) DeleteSchedule(ctx context.Context, req *proto.W
 	return err
 }
 
+// PauseSchedule pauses a workflow schedule.
 func (c *WorkflowManagerClient) PauseSchedule(ctx context.Context, req *proto.WorkflowManagerPauseScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -156,6 +173,7 @@ func (c *WorkflowManagerClient) PauseSchedule(ctx context.Context, req *proto.Wo
 	return c.client.PauseSchedule(ctx, value)
 }
 
+// ResumeSchedule resumes a workflow schedule.
 func (c *WorkflowManagerClient) ResumeSchedule(ctx context.Context, req *proto.WorkflowManagerResumeScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -168,6 +186,7 @@ func (c *WorkflowManagerClient) ResumeSchedule(ctx context.Context, req *proto.W
 	return c.client.ResumeSchedule(ctx, value)
 }
 
+// CreateTrigger creates an event trigger.
 func (c *WorkflowManagerClient) CreateTrigger(ctx context.Context, req *proto.WorkflowManagerCreateEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -183,6 +202,7 @@ func (c *WorkflowManagerClient) CreateTrigger(ctx context.Context, req *proto.Wo
 	return c.client.CreateEventTrigger(ctx, value)
 }
 
+// GetTrigger fetches one event trigger.
 func (c *WorkflowManagerClient) GetTrigger(ctx context.Context, req *proto.WorkflowManagerGetEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -195,6 +215,7 @@ func (c *WorkflowManagerClient) GetTrigger(ctx context.Context, req *proto.Workf
 	return c.client.GetEventTrigger(ctx, value)
 }
 
+// UpdateTrigger updates an event trigger.
 func (c *WorkflowManagerClient) UpdateTrigger(ctx context.Context, req *proto.WorkflowManagerUpdateEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -207,6 +228,7 @@ func (c *WorkflowManagerClient) UpdateTrigger(ctx context.Context, req *proto.Wo
 	return c.client.UpdateEventTrigger(ctx, value)
 }
 
+// DeleteTrigger deletes an event trigger.
 func (c *WorkflowManagerClient) DeleteTrigger(ctx context.Context, req *proto.WorkflowManagerDeleteEventTriggerRequest) error {
 	if c == nil || c.client == nil {
 		return fmt.Errorf("workflow manager: client is not initialized")
@@ -220,6 +242,7 @@ func (c *WorkflowManagerClient) DeleteTrigger(ctx context.Context, req *proto.Wo
 	return err
 }
 
+// PauseTrigger pauses an event trigger.
 func (c *WorkflowManagerClient) PauseTrigger(ctx context.Context, req *proto.WorkflowManagerPauseEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -232,6 +255,7 @@ func (c *WorkflowManagerClient) PauseTrigger(ctx context.Context, req *proto.Wor
 	return c.client.PauseEventTrigger(ctx, value)
 }
 
+// ResumeTrigger resumes an event trigger.
 func (c *WorkflowManagerClient) ResumeTrigger(ctx context.Context, req *proto.WorkflowManagerResumeEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
@@ -244,6 +268,7 @@ func (c *WorkflowManagerClient) ResumeTrigger(ctx context.Context, req *proto.Wo
 	return c.client.ResumeEventTrigger(ctx, value)
 }
 
+// PublishEvent publishes an event into the workflow manager.
 func (c *WorkflowManagerClient) PublishEvent(ctx context.Context, req *proto.WorkflowManagerPublishEventRequest) (*proto.WorkflowEvent, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,27 +1,72 @@
 # Gestalt Python SDK
 
-This package provides the Python authoring surface for executable Gestalt
-providers.
+Use the Python SDK to build executable Gestalt providers with normal Python
+classes, functions, and type annotations.
 
-It is published to PyPI as `gestalt-sdk` and imported in provider code as
-`gestalt`.
+The package is published to PyPI as `gestalt-sdk` and imported in provider code
+as `gestalt`.
 
-It is intended to be used by source providers discovered through
-`[tool.gestalt].provider` in `pyproject.toml` and by packaged providers
-built from that same source tree.
+```sh
+uv add gestalt-sdk
+```
 
-Python source providers are developed locally via `from.source.path` and
-released through `gestaltd provider release` for the host platform by default,
-or for every requested target platform when you pass `--platform`. In CI,
-prefer `--platform all` to build the full supported release matrix.
+```python
+import gestalt
 
-For non-host targets, configure a matching Python build interpreter with
-`GESTALT_PYTHON_<GOOS>_<GOARCH>` or a target-specific virtualenv such as
-`.venv-<goos>-<goarch>/`.
 
-## Regenerating Protobuf Stubs
+class SearchInput(gestalt.Model):
+    query: str = gestalt.field(description="Search query")
 
-The checked-in Python protobuf stubs live in `gestalt/gen/v1`.
+
+plugin = gestalt.Plugin("search")
+
+
+@plugin.operation(method="GET", title="Search")
+def search(input: SearchInput, request: gestalt.Request):
+    return {"results": [input.query]}
+```
+
+## Provider projects
+
+Python source providers are discovered through `[tool.gestalt].provider` in
+`pyproject.toml`.
+
+```toml
+[project]
+name = "gestalt-search"
+version = "0.0.1"
+dependencies = ["gestalt-sdk"]
+
+[tool.uv]
+package = false
+
+[tool.gestalt]
+provider = "provider"
+```
+
+Use the provider manifest for static provider identity, connections, hosted HTTP
+routes, passthrough surfaces, and release metadata. Use Python code for
+executable operations, provider lifecycle hooks, host-service clients, and
+provider-specific runtimes.
+
+## Public surface
+
+The top-level `gestalt` package exposes the supported authoring API:
+
+- `Model`, `field`, `Plugin`, `operation`, and `Request` for integration
+  providers.
+- `AuthenticationProvider`, `CacheProvider`, `S3Provider`, `SecretsProvider`,
+  `WorkflowProvider`, `AgentProvider`, and `PluginRuntimeProvider` for
+  host-service provider runtimes.
+- `Cache`, `IndexedDB`, `S3`, `WorkflowHost`, `WorkflowManager`, `AgentHost`,
+  `AgentManager`, and `PluginInvoker` for calling sibling host services.
+- `gestalt.telemetry` for provider-authored GenAI spans and metrics.
+
+Generated protobuf bindings remain available under `gestalt.gen`, but provider
+authors should prefer the handwritten SDK surface unless they need a low-level
+protocol message directly.
+
+## Regenerating protobuf stubs
 
 This is an SDK maintainer workflow. Provider authors consume the checked-in
 stubs through the `gestalt` package and do not need to regenerate them in
@@ -33,12 +78,12 @@ Regenerate them from the repo root with:
 uv run python sdk/python/scripts/generate_stubs.py
 ```
 
-The script uses pinned `buf` remote Python plugins so the generated stubs stay
+The script uses pinned Buf remote Python plugins so the generated stubs stay
 reproducible while `plugin_pb2.py` tracks the protobuf `6.33.1` runtime floor
 used by this SDK package and remains compatible with protobuf 7 runtimes.
 `buf` must be available on `PATH`.
 
-## API Reference
+## API reference
 
 The authored Python API reference is generated with Sphinx from the SDK's
 docstrings. Build it locally from `sdk/python` with:
@@ -68,32 +113,11 @@ The release workflow normalizes those tag versions to PEP 440 before building
 and publishing with `uv`, so `sdk/python/v0.0.1-alpha.1` becomes package
 version `0.0.1a1`.
 
-Releases are published to PyPI through GitHub Actions Trusted Publishing.
-The release workflow runs in the `pypi` environment and uses GitHub OIDC rather
-than a checked-in upload token. To enable publishing for this repo:
+Releases are published to PyPI through GitHub Actions Trusted Publishing. The
+release workflow runs in the `pypi` environment and uses GitHub OIDC rather
+than a checked-in upload token.
 
-- create or confirm the `gestalt-sdk` project on PyPI
-- add a Trusted Publisher pointing at `valon-technologies/gestalt`
-- set the workflow filename to `release-sdk.yml`
-- set the environment name to `pypi`
-
-Once that publisher is configured, pushing an SDK release tag such as
-`sdk/python/v0.0.1-alpha.1` is enough for the workflow to build and publish the
-package.
-
-Install it in a provider repo with:
-
-```sh
-uv add gestalt-sdk
-```
-
-Then import the authored surface as:
-
-```python
-from gestalt import Model, Plugin
-```
-
-## Local SDK Checks
+## Local SDK checks
 
 From `sdk/python`, install the SDK plus its dev tooling and run the checks used
 in CI:

--- a/sdk/python/docs/index.rst
+++ b/sdk/python/docs/index.rst
@@ -1,8 +1,11 @@
 Gestalt Python SDK
 ==================
 
-The :mod:`gestalt` package is published as ``gestalt-sdk`` and imported as
-``gestalt`` in provider projects.
+Use :mod:`gestalt` to build executable Gestalt providers with Python models,
+decorators, runtime providers, host-service clients, and telemetry helpers.
+
+The package is published as ``gestalt-sdk`` and imported as ``gestalt`` in
+provider projects.
 
 This reference focuses on the handwritten Python SDK surface. Generated
 protobuf bindings under :mod:`gestalt.gen` remain available to the runtime, but

--- a/sdk/python/docs/reference.rst
+++ b/sdk/python/docs/reference.rst
@@ -64,6 +64,12 @@ Plugin authoring
    Plugin
    operation
    session_catalog
+   post_connect
+   http_subject
+   ConnectedToken
+   HTTPSubjectRequest
+   HTTPSubjectResolutionError
+   http_subject_error
    SessionCatalogProvider
    Catalog
    CatalogOperation
@@ -77,6 +83,18 @@ Plugin authoring
 .. autofunction:: operation
 
 .. autofunction:: session_catalog
+
+.. autofunction:: post_connect
+
+.. autofunction:: http_subject
+
+.. autoclass:: ConnectedToken
+
+.. autoclass:: HTTPSubjectRequest
+
+.. autoexception:: HTTPSubjectResolutionError
+
+.. autofunction:: http_subject_error
 
 .. autoclass:: SessionCatalogProvider
    :members:
@@ -115,6 +133,7 @@ Provider interfaces
    PluginProvider
    MetadataProvider
    HealthChecker
+   Starter
    WarningsProvider
    Closer
    PluginProviderAdapter
@@ -124,6 +143,9 @@ Provider interfaces
    SecretsProvider
    CacheProvider
    S3Provider
+   AgentProvider
+   PluginRuntimeProvider
+   WorkflowProvider
    AuthenticatedUser
    BeginLoginRequest
    BeginLoginResponse
@@ -142,6 +164,10 @@ Provider interfaces
    :exclude-members: __dict__, __module__, __weakref__
 
 .. autoclass:: HealthChecker
+   :members:
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: Starter
    :members:
    :exclude-members: __dict__, __module__, __weakref__
 
@@ -178,6 +204,18 @@ Provider interfaces
    :exclude-members: __dict__, __module__, __weakref__
 
 .. autoclass:: S3Provider
+   :members:
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: AgentProvider
+   :members:
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: PluginRuntimeProvider
+   :members:
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: WorkflowProvider
    :members:
    :exclude-members: __dict__, __module__, __weakref__
 
@@ -269,9 +307,13 @@ Cache client
 .. autosummary::
    :nosignatures:
 
+   ENV_CACHE_SOCKET_TOKEN
    CacheEntry
    Cache
    cache_socket_env
+   cache_socket_token_env
+
+.. autodata:: ENV_CACHE_SOCKET_TOKEN
 
 .. autoclass:: CacheEntry
 
@@ -281,6 +323,8 @@ Cache client
    :exclude-members: __dict__, __module__, __weakref__
 
 .. autofunction:: cache_socket_env
+
+.. autofunction:: cache_socket_token_env
 
 IndexedDB client
 ----------------
@@ -293,8 +337,10 @@ IndexedDB client
    CURSOR_PREV
    CURSOR_PREV_UNIQUE
    indexeddb_socket_env
+   indexeddb_socket_token_env
    NotFoundError
    AlreadyExistsError
+   TransactionError
    KeyRange
    IndexSchema
    ObjectStoreSchema
@@ -302,6 +348,9 @@ IndexedDB client
    ObjectStore
    Index
    Cursor
+   Transaction
+   TransactionObjectStore
+   TransactionIndex
 
 .. autodata:: CURSOR_NEXT
 
@@ -313,9 +362,13 @@ IndexedDB client
 
 .. autofunction:: indexeddb_socket_env
 
+.. autofunction:: indexeddb_socket_token_env
+
 .. autoexception:: NotFoundError
 
 .. autoexception:: AlreadyExistsError
+
+.. autoexception:: TransactionError
 
 .. autoclass:: KeyRange
 
@@ -341,6 +394,19 @@ IndexedDB client
    :special-members: __enter__, __exit__
    :exclude-members: __dict__, __module__, __weakref__
 
+.. autoclass:: Transaction
+   :members:
+   :special-members: __enter__, __exit__
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: TransactionObjectStore
+   :members:
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: TransactionIndex
+   :members:
+   :exclude-members: __dict__, __module__, __weakref__
+
 S3 client
 ---------
 
@@ -348,7 +414,9 @@ S3 client
    :nosignatures:
 
    ENV_S3_SOCKET
+   ENV_S3_SOCKET_TOKEN
    s3_socket_env
+   s3_socket_token_env
    S3NotFoundError
    S3PreconditionFailedError
    S3InvalidRangeError
@@ -363,13 +431,19 @@ S3 client
    PresignMethod
    PresignOptions
    PresignResult
+   ObjectAccessURLOptions
+   ObjectAccessURL
    S3ReadStream
    S3
    S3Object
 
 .. autodata:: ENV_S3_SOCKET
 
+.. autodata:: ENV_S3_SOCKET_TOKEN
+
 .. autofunction:: s3_socket_env
+
+.. autofunction:: s3_socket_token_env
 
 .. autoexception:: S3NotFoundError
 
@@ -399,6 +473,12 @@ S3 client
 
 .. autoclass:: PresignResult
 
+.. autodata:: ObjectAccessURLOptions
+   :annotation:
+
+.. autodata:: ObjectAccessURL
+   :annotation:
+
 .. autoclass:: S3ReadStream
    :members:
    :special-members: __enter__, __exit__
@@ -411,4 +491,115 @@ S3 client
 
 .. autoclass:: S3Object
    :members:
+   :exclude-members: __dict__, __module__, __weakref__
+
+Host service clients
+--------------------
+
+These clients connect to host services made available to a provider process by
+``gestaltd``. They read socket and relay-token locations from environment
+variables and add invocation tokens to manager requests when required.
+
+.. autosummary::
+   :nosignatures:
+
+   ENV_AGENT_HOST_SOCKET
+   ENV_AGENT_HOST_SOCKET_TOKEN
+   ENV_AGENT_MANAGER_SOCKET
+   ENV_AGENT_MANAGER_SOCKET_TOKEN
+   ENV_AUTHORIZATION_SOCKET
+   ENV_AUTHORIZATION_SOCKET_TOKEN
+   ENV_PLUGIN_INVOKER_SOCKET
+   ENV_PLUGIN_INVOKER_SOCKET_TOKEN
+   ENV_RUNTIME_LOG_HOST_SOCKET
+   ENV_RUNTIME_LOG_HOST_SOCKET_TOKEN
+   ENV_RUNTIME_SESSION_ID
+   ENV_WORKFLOW_HOST_SOCKET
+   ENV_WORKFLOW_HOST_SOCKET_TOKEN
+   ENV_WORKFLOW_MANAGER_SOCKET
+   ENV_WORKFLOW_MANAGER_SOCKET_TOKEN
+   AgentHost
+   AgentManager
+   Authorization
+   AuthorizationClient
+   PluginInvoker
+   RuntimeLogHost
+   RuntimeLogWriter
+   RuntimeLogHandler
+   WorkflowHost
+   WorkflowManager
+
+.. autodata:: ENV_AGENT_HOST_SOCKET
+
+.. autodata:: ENV_AGENT_HOST_SOCKET_TOKEN
+
+.. autodata:: ENV_AGENT_MANAGER_SOCKET
+
+.. autodata:: ENV_AGENT_MANAGER_SOCKET_TOKEN
+
+.. autodata:: ENV_AUTHORIZATION_SOCKET
+
+.. autodata:: ENV_AUTHORIZATION_SOCKET_TOKEN
+
+.. autodata:: ENV_PLUGIN_INVOKER_SOCKET
+
+.. autodata:: ENV_PLUGIN_INVOKER_SOCKET_TOKEN
+
+.. autodata:: ENV_RUNTIME_LOG_HOST_SOCKET
+
+.. autodata:: ENV_RUNTIME_LOG_HOST_SOCKET_TOKEN
+
+.. autodata:: ENV_RUNTIME_SESSION_ID
+
+.. autodata:: ENV_WORKFLOW_HOST_SOCKET
+
+.. autodata:: ENV_WORKFLOW_HOST_SOCKET_TOKEN
+
+.. autodata:: ENV_WORKFLOW_MANAGER_SOCKET
+
+.. autodata:: ENV_WORKFLOW_MANAGER_SOCKET_TOKEN
+
+.. autoclass:: AgentHost
+   :members:
+   :special-members: __enter__, __exit__
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: AgentManager
+   :members:
+   :special-members: __enter__, __exit__
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autofunction:: Authorization
+
+.. autoclass:: AuthorizationClient
+   :members:
+   :special-members: __enter__, __exit__
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: PluginInvoker
+   :members:
+   :special-members: __enter__, __exit__
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: RuntimeLogHost
+   :members:
+   :special-members: __enter__, __exit__
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: RuntimeLogWriter
+   :members:
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: RuntimeLogHandler
+   :members:
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: WorkflowHost
+   :members:
+   :special-members: __enter__, __exit__
+   :exclude-members: __dict__, __module__, __weakref__
+
+.. autoclass:: WorkflowManager
+   :members:
+   :special-members: __enter__, __exit__
    :exclude-members: __dict__, __module__, __weakref__

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -1,8 +1,8 @@
 """Public authoring surface for Gestalt Python providers.
 
 The package is published as ``gestalt-sdk`` and imported as ``gestalt``.
-Provider authors typically build integrations around the re-exported symbols
-documented in the Sphinx reference:
+Use it for executable provider code: integration operations, host-service
+providers, host-service clients, and provider-owned telemetry.
 
 .. code-block:: python
 

--- a/sdk/python/gestalt/_agent.py
+++ b/sdk/python/gestalt/_agent.py
@@ -19,6 +19,13 @@ ENV_AGENT_MANAGER_SOCKET_TOKEN = f"{ENV_AGENT_MANAGER_SOCKET}_TOKEN"
 
 
 class AgentHost:
+    """Client for the agent host service available inside agent providers.
+
+    ``AgentHost`` reads ``GESTALT_AGENT_HOST_SOCKET`` and its optional relay
+    token from the environment and exposes the host RPCs that agent providers
+    use to discover and call tools during a turn.
+    """
+
     def __init__(self) -> None:
         target = os.environ.get(ENV_AGENT_HOST_SOCKET, "")
         if not target:
@@ -28,22 +35,39 @@ class AgentHost:
         self._stub = pb_grpc.AgentHostStub(self._channel)
 
     def close(self) -> None:
+        """Close the underlying gRPC channel."""
+
         self._channel.close()
 
     def execute_tool(self, request: Any) -> Any:
+        """Execute a host tool using an agent protocol request message."""
+
         return _grpc_call(self._stub.ExecuteTool, request)
 
     def list_tools(self, request: Any) -> Any:
+        """List host tools visible to the current agent request."""
+
         return _grpc_call(self._stub.ListTools, request)
 
     def __enter__(self) -> AgentHost:
+        """Return the client for ``with`` statements."""
+
         return self
 
     def __exit__(self, *args: Any) -> None:
+        """Close the client at the end of a context manager block."""
+
         self.close()
 
 
 class AgentManager:
+    """Client for managing agent sessions, turns, events, and interactions.
+
+    The manager is for provider code that receives an invocation token and then
+    needs to call the host's agent-management API. Each request passed to a
+    method is mutated to include that invocation token before the RPC is sent.
+    """
+
     def __init__(self, invocation_token: str) -> None:
         trimmed_token = invocation_token.strip()
         if not trimmed_token:
@@ -59,56 +83,84 @@ class AgentManager:
         self._invocation_token = trimmed_token
 
     def close(self) -> None:
+        """Close the underlying gRPC channel."""
+
         self._channel.close()
 
     def create_session(self, request: Any) -> Any:
+        """Create an agent session."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.CreateSession, request)
 
     def get_session(self, request: Any) -> Any:
+        """Fetch one agent session."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.GetSession, request)
 
     def list_sessions(self, request: Any) -> Any:
+        """List agent sessions visible to the invocation token."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.ListSessions, request)
 
     def update_session(self, request: Any) -> Any:
+        """Update mutable fields on an agent session."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.UpdateSession, request)
 
     def create_turn(self, request: Any) -> Any:
+        """Create an agent turn."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.CreateTurn, request)
 
     def get_turn(self, request: Any) -> Any:
+        """Fetch one agent turn."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.GetTurn, request)
 
     def list_turns(self, request: Any) -> Any:
+        """List turns for an agent session."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.ListTurns, request)
 
     def cancel_turn(self, request: Any) -> Any:
+        """Cancel an in-progress agent turn."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.CancelTurn, request)
 
     def list_turn_events(self, request: Any) -> Any:
+        """List events emitted for an agent turn."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.ListTurnEvents, request)
 
     def list_interactions(self, request: Any) -> Any:
+        """List pending or completed agent interactions."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.ListInteractions, request)
 
     def resolve_interaction(self, request: Any) -> Any:
+        """Resolve an agent interaction with a host response."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.ResolveInteraction, request)
 
     def __enter__(self) -> AgentManager:
+        """Return the client for ``with`` statements."""
+
         return self
 
     def __exit__(self, *args: Any) -> None:
+        """Close the client at the end of a context manager block."""
+
         self.close()
 
 

--- a/sdk/python/gestalt/_invoker.py
+++ b/sdk/python/gestalt/_invoker.py
@@ -29,6 +29,14 @@ _PLUGIN_INVOKER_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token"
 
 
 class PluginInvoker:
+    """Client for invoking sibling plugin operations from provider code.
+
+    ``PluginInvoker`` connects to the host plugin-invoker service exposed in
+    ``GESTALT_PLUGIN_INVOKER_SOCKET``. It attaches the invocation token supplied
+    by the host to each request and returns regular :class:`gestalt.Response`
+    objects for operation and GraphQL calls.
+    """
+
     def __init__(self, invocation_token: str) -> None:
         trimmed_token = invocation_token.strip()
         if not trimmed_token:
@@ -44,6 +52,8 @@ class PluginInvoker:
         self._invocation_token = trimmed_token
 
     def close(self) -> None:
+        """Close the underlying gRPC channel."""
+
         self._channel.close()
 
     def invoke(
@@ -56,6 +66,13 @@ class PluginInvoker:
         instance: str = "",
         idempotency_key: str = "",
     ) -> Response[str]:
+        """Invoke one operation on another plugin.
+
+        ``params`` is encoded as a protobuf ``Struct``. ``connection`` and
+        ``instance`` select the connected account or provider instance that the
+        target plugin should invoke against.
+        """
+
         request = pb.PluginInvokeRequest(
             invocation_token=self._invocation_token,
             plugin=plugin,
@@ -81,6 +98,8 @@ class PluginInvoker:
         instance: str = "",
         idempotency_key: str = "",
     ) -> Response[str]:
+        """Invoke another plugin's GraphQL surface."""
+
         trimmed_document = document.strip()
         if not trimmed_document:
             raise RuntimeError("plugin invoker: graphql document is required")
@@ -106,6 +125,8 @@ class PluginInvoker:
         grants: Sequence[Any] | None = None,
         ttl_seconds: int = 0,
     ) -> str:
+        """Exchange this invocation token for a narrower child token."""
+
         request = pb.ExchangeInvocationTokenRequest(
             parent_invocation_token=self._invocation_token,
         )
@@ -116,9 +137,13 @@ class PluginInvoker:
         return response.invocation_token
 
     def __enter__(self) -> PluginInvoker:
+        """Return the client for ``with`` statements."""
+
         return self
 
     def __exit__(self, *args: Any) -> None:
+        """Close the client at the end of a context manager block."""
+
         self.close()
 
 

--- a/sdk/python/gestalt/_providers.py
+++ b/sdk/python/gestalt/_providers.py
@@ -282,7 +282,11 @@ class PluginRuntimeProvider(PluginProvider):
 
 
 class WorkflowProvider(PluginProvider):
+    """Base class for workflow-provider runtimes."""
+
     def serve(self) -> None:
+        """Start the workflow runtime."""
+
         from . import _runtime
 
         _runtime.serve(self, runtime_kind=ProviderKind.WORKFLOW)

--- a/sdk/python/gestalt/_runtime_log_host.py
+++ b/sdk/python/gestalt/_runtime_log_host.py
@@ -28,6 +28,14 @@ _STREAMS = {
 
 
 class RuntimeLogHost:
+    """Client for appending runtime logs to the host log stream.
+
+    ``RuntimeLogHost`` reads ``GESTALT_RUNTIME_LOG_SOCKET`` and its optional
+    relay token from the environment. Use it directly for structured log
+    entries, or create a :class:`RuntimeLogWriter`/:class:`RuntimeLogHandler`
+    when redirecting standard streams or Python logging output.
+    """
+
     def __init__(self) -> None:
         target = os.environ.get(ENV_RUNTIME_LOG_HOST_SOCKET, "").strip()
         if not target:
@@ -44,9 +52,13 @@ class RuntimeLogHost:
         self._source_seq = 0
 
     def close(self) -> None:
+        """Close the underlying gRPC channel."""
+
         self._channel.close()
 
     def append_logs(self, request: Any) -> Any:
+        """Append logs using a raw protocol request message."""
+
         return _grpc_call(self._stub.AppendLogs, request)
 
     def append(
@@ -58,6 +70,12 @@ class RuntimeLogHost:
         observed_at: Any = None,
         source_seq: int | None = None,
     ) -> Any:
+        """Append one log entry.
+
+        When ``message`` is omitted, the first positional argument is treated as
+        the message and the session id is read from ``GESTALT_RUNTIME_SESSION_ID``.
+        """
+
         if message is None:
             message = session_id
             session_id = _runtime_session_id()
@@ -85,6 +103,8 @@ class RuntimeLogHost:
         stream: str | int = "stdout",
         source_seq_start: int = 0,
     ) -> RuntimeLogWriter:
+        """Return a file-like writer that appends data to a runtime log stream."""
+
         return RuntimeLogWriter(
             self,
             _runtime_session_id(session_id),
@@ -93,13 +113,19 @@ class RuntimeLogHost:
         )
 
     def __enter__(self) -> RuntimeLogHost:
+        """Return the client for ``with`` statements."""
+
         return self
 
     def __exit__(self, *args: Any) -> None:
+        """Close the client at the end of a context manager block."""
+
         self.close()
 
 
 class RuntimeLogWriter:
+    """File-like object that forwards writes to :class:`RuntimeLogHost`."""
+
     def __init__(
         self,
         host: RuntimeLogHost,
@@ -115,6 +141,8 @@ class RuntimeLogWriter:
         self.closed = False
 
     def write(self, data: str | bytes) -> int:
+        """Append ``data`` to the configured runtime log stream."""
+
         if self.closed:
             raise ValueError("I/O operation on closed runtime log writer")
         if isinstance(data, bytes):
@@ -135,13 +163,23 @@ class RuntimeLogWriter:
         return written
 
     def flush(self) -> None:
+        """Flush buffered data.
+
+        Runtime log writes are sent eagerly, so this method is a no-op for
+        file-like compatibility.
+        """
+
         return None
 
     def close(self) -> None:
+        """Mark the writer closed."""
+
         self.closed = True
 
 
 class RuntimeLogHandler(logging.Handler):
+    """Python logging handler that forwards records to runtime logs."""
+
     terminator = "\n"
 
     def __init__(
@@ -160,6 +198,8 @@ class RuntimeLogHandler(logging.Handler):
         self._source_seq = 0
 
     def emit(self, record: logging.LogRecord) -> None:
+        """Format and append one Python logging record."""
+
         try:
             message = self.format(record) + self.terminator
             self._source_seq += 1
@@ -173,6 +213,8 @@ class RuntimeLogHandler(logging.Handler):
             self.handleError(record)
 
     def close(self) -> None:
+        """Close the owned runtime-log host, if this handler created it."""
+
         try:
             if self._owns_host:
                 self._host.close()

--- a/sdk/python/gestalt/_workflow.py
+++ b/sdk/python/gestalt/_workflow.py
@@ -19,6 +19,13 @@ ENV_WORKFLOW_MANAGER_SOCKET_TOKEN = f"{ENV_WORKFLOW_MANAGER_SOCKET}_TOKEN"
 
 
 class WorkflowHost:
+    """Client for the workflow host service available inside workflow code.
+
+    ``WorkflowHost`` reads ``GESTALT_WORKFLOW_HOST_SOCKET`` and its optional
+    relay token from the environment, then exposes the host operation-invocation
+    RPC used by workflow providers.
+    """
+
     def __init__(self) -> None:
         target = os.environ.get(ENV_WORKFLOW_HOST_SOCKET, "")
         if not target:
@@ -28,19 +35,35 @@ class WorkflowHost:
         self._stub = pb_grpc.WorkflowHostStub(self._channel)
 
     def close(self) -> None:
+        """Close the underlying gRPC channel."""
+
         self._channel.close()
 
     def invoke_operation(self, request: Any) -> Any:
+        """Invoke an operation through the workflow host."""
+
         return _grpc_call(self._stub.InvokeOperation, request)
 
     def __enter__(self) -> WorkflowHost:
+        """Return the client for ``with`` statements."""
+
         return self
 
     def __exit__(self, *args: Any) -> None:
+        """Close the client at the end of a context manager block."""
+
         self.close()
 
 
 class WorkflowManager:
+    """Client for starting runs and managing workflow schedules or triggers.
+
+    The manager is for provider code that receives an invocation token. Methods
+    attach that token to each request before calling the host service. The
+    optional ``idempotency_key`` is used for create requests that do not already
+    include one.
+    """
+
     def __init__(self, invocation_token: str, *, idempotency_key: str = "") -> None:
         trimmed_token = invocation_token.strip()
         if not trimmed_token:
@@ -61,80 +84,118 @@ class WorkflowManager:
         self._idempotency_key = idempotency_key.strip()
 
     def close(self) -> None:
+        """Close the underlying gRPC channel."""
+
         self._channel.close()
 
     def start_run(self, request: Any) -> Any:
+        """Start a workflow run."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.StartRun, request)
 
     def signal_run(self, request: Any) -> Any:
+        """Signal an existing workflow run."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.SignalRun, request)
 
     def signal_or_start_run(self, request: Any) -> Any:
+        """Signal a run, or start it when no matching run exists."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.SignalOrStartRun, request)
 
     def create_schedule(self, request: Any) -> Any:
+        """Create a workflow schedule."""
+
         request.invocation_token = self._invocation_token
         if not getattr(request, "idempotency_key", "").strip():
             request.idempotency_key = self._idempotency_key
         return _grpc_call(self._stub.CreateSchedule, request)
 
     def get_schedule(self, request: Any) -> Any:
+        """Fetch one workflow schedule."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.GetSchedule, request)
 
     def update_schedule(self, request: Any) -> Any:
+        """Update a workflow schedule."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.UpdateSchedule, request)
 
     def delete_schedule(self, request: Any) -> Any:
+        """Delete a workflow schedule."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.DeleteSchedule, request)
 
     def pause_schedule(self, request: Any) -> Any:
+        """Pause a workflow schedule."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.PauseSchedule, request)
 
     def resume_schedule(self, request: Any) -> Any:
+        """Resume a workflow schedule."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.ResumeSchedule, request)
 
     def create_trigger(self, request: Any) -> Any:
+        """Create an event trigger."""
+
         request.invocation_token = self._invocation_token
         if not getattr(request, "idempotency_key", "").strip():
             request.idempotency_key = self._idempotency_key
         return _grpc_call(self._stub.CreateEventTrigger, request)
 
     def get_trigger(self, request: Any) -> Any:
+        """Fetch one event trigger."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.GetEventTrigger, request)
 
     def update_trigger(self, request: Any) -> Any:
+        """Update an event trigger."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.UpdateEventTrigger, request)
 
     def delete_trigger(self, request: Any) -> Any:
+        """Delete an event trigger."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.DeleteEventTrigger, request)
 
     def pause_trigger(self, request: Any) -> Any:
+        """Pause an event trigger."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.PauseEventTrigger, request)
 
     def resume_trigger(self, request: Any) -> Any:
+        """Resume an event trigger."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.ResumeEventTrigger, request)
 
     def publish_event(self, request: Any) -> Any:
+        """Publish an event into the workflow host."""
+
         request.invocation_token = self._invocation_token
         return _grpc_call(self._stub.PublishEvent, request)
 
     def __enter__(self) -> WorkflowManager:
+        """Return the client for ``with`` statements."""
+
         return self
 
     def __exit__(self, *args: Any) -> None:
+        """Close the client at the end of a context manager block."""
+
         self.close()
 
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "gestalt-sdk"
 version = "0.0.1a1"
 description = "Python SDK for Gestalt executable providers"
+readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "grpcio>=1.80.0,<2",
@@ -31,6 +32,10 @@ dev = [
 
 [tool.setuptools.packages.find]
 include = ["gestalt*"]
+
+[project.urls]
+Documentation = "https://gestaltd.ai/reference/python-sdk"
+Repository = "https://github.com/valon-technologies/gestalt"
 
 [tool.ruff]
 target-version = "py310"

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -1,10 +1,21 @@
 # Gestalt Rust SDK
 
-This directory contains the Rust SDK for Gestalt executable providers.
+Use the Rust SDK to build compiled Gestalt providers with typed routers,
+`serde` input and output types, and schema-derived catalog metadata.
+
+The package is published to crates.io as `gestalt-sdk`, while Rust code imports
+the crate as `gestalt`.
+
+```sh
+cargo add gestalt-sdk --rename gestalt
+cargo add serde --features derive
+cargo add schemars --features derive
+```
 
 ## Quick start
 
-The main integration-provider flow stays small:
+Register typed operations on a router. The router dispatches requests and emits
+catalog metadata for `gestaltd`.
 
 ```rust,no_run
 use schemars::JsonSchema;
@@ -12,62 +23,60 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Default)]
-struct EchoProvider;
+struct SearchProvider;
 
 #[gestalt::async_trait]
-impl gestalt::Provider for EchoProvider {}
+impl gestalt::Provider for SearchProvider {}
 
 #[derive(Deserialize, JsonSchema)]
-struct EchoInput {
-    message: String,
+struct SearchInput {
+    #[schemars(description = "Search query")]
+    query: String,
 }
 
 #[derive(Serialize, JsonSchema)]
-struct EchoOutput {
-    echoed: String,
+struct SearchOutput {
+    results: Vec<String>,
 }
 
-fn router() -> gestalt::Result<gestalt::Router<EchoProvider>> {
+fn router() -> gestalt::Result<gestalt::Router<SearchProvider>> {
     gestalt::Router::new().register(
-        gestalt::Operation::<EchoInput, EchoOutput>::new("echo")
-            .description("Echo one message back to the caller"),
-        |_: Arc<EchoProvider>, input, _request| async move {
-            Ok::<_, gestalt::Error>(gestalt::ok(EchoOutput {
-                echoed: input.message,
+        gestalt::Operation::<SearchInput, SearchOutput>::new("search")
+            .method("GET")
+            .title("Search"),
+        |_: Arc<SearchProvider>, input, _request| async move {
+            Ok::<_, gestalt::Error>(gestalt::ok(SearchOutput {
+                results: vec![input.query],
             }))
         },
     )
 }
 
-gestalt::export_provider!(constructor = EchoProvider::default, router = router);
+gestalt::export_provider!(constructor = SearchProvider::default, router = router);
 ```
 
-Sibling provider surfaces stay source-native too:
+Fields are required unless they are modeled as `Option<T>` or have a serde
+default. Use `schemars` attributes for catalog descriptions.
 
-```rust,no_run
-# async fn example() -> Result<(), Box<dyn std::error::Error>> {
-let mut cache = gestalt::Cache::connect().await?;
-cache.set("token", b"abc123", Default::default()).await?;
+## Provider surfaces
 
-let mut object = gestalt::S3::connect().await?.object("docs", "hello.txt");
-object.write_string("hello", None).await?;
-# Ok(())
-# }
-```
+Use `Provider`, `Operation`, `Router`, and `export_provider!` for integration
+providers. Use the other provider traits and export macros when you are serving
+a host-service backend.
 
-Current scope:
+| Trait | Export macro | Use it when you want to serve |
+| --- | --- | --- |
+| `AuthenticationProvider` | `export_authentication_provider!` | Login flows. |
+| `CacheProvider` | `export_cache_provider!` | Plugin-bound cache storage. |
+| `S3Provider` | `export_s3_provider!` | S3-compatible object storage. |
+| `SecretsProvider` | `export_secrets_provider!` | Secret resolution. |
+| `WorkflowProvider` | `export_workflow_provider!` | Workflow runs, schedules, and event triggers. |
+| `AgentProvider` | `export_agent_provider!` | Agent sessions, turns, events, interactions, and capabilities. |
+| `PluginRuntimeProvider` | `export_plugin_runtime_provider!` | Hosted plugin execution backends. |
 
-- standalone Cargo package published as `gestalt-sdk`
-- library crate name remains `gestalt` in Rust code
-- checked-in protobuf/gRPC bindings generated from `sdk/proto/v1/*.proto`
-- maintainer-only stub generation via Buf remote plugins
-- generated protocol bindings exposed via `proto::v1`
-- typed integration-provider authoring helpers for requests, responses, catalogs, and routing
-- authentication-provider, cache-provider, secrets-provider, and workflow-provider traits that map to the shared executable runtime protocol
-- `Workflow` and `WorkflowHost` client helpers for plugin-side workflow control and workflow-provider host callbacks
-- `S3` client helpers and the `S3Provider` trait for S3-compatible provider components
-- runtime servers for the integration, authentication, cache, secrets, workflow, and S3 provider surfaces over the Unix socket exposed by `gestaltd`
-- `export_provider!`, `export_authentication_provider!`, `export_cache_provider!`, `export_secrets_provider!`, `export_workflow_provider!`, and `export_s3_provider!` macros for source builds that let `gestaltd` synthesize the executable wrapper
+The crate also exposes clients for sibling host services, including `Cache`,
+`S3`, `WorkflowHost`, `WorkflowManager`, `AgentHost`, `AgentManager`, and
+`PluginInvoker`.
 
 ## Codegen strategy
 
@@ -80,7 +89,7 @@ Maintainers regenerate them from the shared proto definitions in
 [`sdk/proto`](https://github.com/valon-technologies/gestalt/tree/main/sdk/proto)
 with the Buf template in
 [`sdk/proto/buf.rust.gen.yaml`](https://github.com/valon-technologies/gestalt/tree/main/sdk/proto/buf.rust.gen.yaml).
-Use the same Buf CLI version as CI (`v1.66.1`) for deterministic remote-plugin output.
+Use the same Buf CLI version as CI for deterministic remote-plugin output.
 
 To regenerate the bindings:
 
@@ -90,27 +99,25 @@ sdk/rust/scripts/generate_stubs.sh
 
 ## Public surface
 
-The crate is intentionally small:
+The crate keeps generated bindings behind a higher-level authoring API:
 
-- `Provider`, `Request`, `Response`, and `ok(...)` model integration providers
-- `AuthenticationProvider`, `BeginLoginRequest`, `BeginLoginResponse`, `CompleteLoginRequest`, and `AuthenticatedUser` model authentication providers
-- `Cache`, `CacheProvider`, `CacheEntry`, and `CacheSetOptions` model cache clients and providers
-- `SecretsProvider` models secrets providers
-- `Workflow`, `WorkflowHost`, and `WorkflowProvider` model workflow clients, host callbacks, and workflow base providers
-- `S3`, `S3Provider`, and `gestalt::s3::*` model S3-compatible object-store clients and providers
-- `PluginRuntimeProvider` models hosted plugin-runtime providers
-- `Router` and `Operation` register typed operations and derive catalog metadata from `serde` + `schemars`
-- `Catalog` types expose explicit static or session-scoped catalogs when needed
-- `RuntimeMetadata` lets any provider kind describe its runtime name/display metadata and version
-- `runtime` runs the integration, authentication, cache, secrets, workflow, S3, or plugin-runtime gRPC servers, or writes the static catalog when `GESTALT_PLUGIN_WRITE_CATALOG` is set
-- `export_provider!` exports `__gestalt_serve` and `__gestalt_write_catalog` for integration providers
-- `export_authentication_provider!` exports `__gestalt_serve_authentication` for authentication providers
-- `export_cache_provider!` exports `__gestalt_serve_cache` for cache providers
-- `export_secrets_provider!` exports `__gestalt_serve_secrets` for secrets providers
-- `export_workflow_provider!` exports `__gestalt_serve_workflow` for workflow providers
-- `export_s3_provider!` exports `__gestalt_serve_s3` for S3 providers
-- `export_plugin_runtime_provider!` exports `__gestalt_serve_runtime` for runtime providers
+- `Provider`, `Request`, `Response`, and `ok(...)` model integration
+  providers.
+- `Router` and `Operation` register typed operations and derive catalog
+  metadata from `serde` and `schemars`.
+- `AuthenticationProvider`, `CacheProvider`, `S3Provider`, `SecretsProvider`,
+  `WorkflowProvider`, `AgentProvider`, and `PluginRuntimeProvider` model
+  executable provider runtimes.
+- `Cache`, `S3`, `WorkflowHost`, `WorkflowManager`, `AgentHost`,
+  `AgentManager`, and `PluginInvoker` call sibling host services.
+- `RuntimeMetadata` lets provider runtimes describe their display metadata and
+  version.
+- `runtime` contains entrypoints for serving provider surfaces over the Unix
+  socket exposed by `gestaltd`.
+- `proto::v1` exposes generated protocol bindings for low-level integration
+  work.
 
 ## Package layout
 
-This package intentionally lives outside the existing `gestalt/` Cargo workspace so the SDK can evolve independently of the CLI crate graph.
+This package intentionally lives outside the existing `gestalt/` Cargo
+workspace so the SDK can evolve independently of the CLI crate graph.

--- a/sdk/rust/src/agent.rs
+++ b/sdk/rust/src/agent.rs
@@ -18,25 +18,33 @@ use crate::generated::v1::{
 
 type AgentHostTransport = InterceptedService<Channel, AgentHostRelayTokenInterceptor>;
 
+/// Environment variable containing the agent-host service target.
 pub const ENV_AGENT_HOST_SOCKET: &str = "GESTALT_AGENT_HOST_SOCKET";
+/// Environment variable containing the optional agent-host relay token.
 pub const ENV_AGENT_HOST_SOCKET_TOKEN: &str = "GESTALT_AGENT_HOST_SOCKET_TOKEN";
 const AGENT_HOST_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
 #[derive(Debug, thiserror::Error)]
+/// Errors returned by [`AgentHost`].
 pub enum AgentHostError {
+    /// The host-service transport could not be created.
     #[error("{0}")]
     Transport(#[from] tonic::transport::Error),
+    /// The host-service RPC returned a gRPC status.
     #[error("{0}")]
     Status(#[from] tonic::Status),
+    /// Required environment or target configuration was invalid.
     #[error("{0}")]
     Env(String),
 }
 
+/// Client for the agent host service available inside agent providers.
 pub struct AgentHost {
     client: ProtoAgentHostClient<AgentHostTransport>,
 }
 
 impl AgentHost {
+    /// Connects to the agent host service described by the environment.
     pub async fn connect() -> std::result::Result<Self, AgentHostError> {
         let target = std::env::var(ENV_AGENT_HOST_SOCKET)
             .map_err(|_| AgentHostError::Env(format!("{ENV_AGENT_HOST_SOCKET} is not set")))?;
@@ -62,6 +70,7 @@ impl AgentHost {
         })
     }
 
+    /// Executes a host tool using an agent protocol request message.
     pub async fn execute_tool(
         &mut self,
         request: pb::ExecuteAgentToolRequest,
@@ -69,6 +78,7 @@ impl AgentHost {
         Ok(self.client.execute_tool(request).await?.into_inner())
     }
 
+    /// Lists host tools visible to the current agent request.
     pub async fn list_tools(
         &mut self,
         request: pb::ListAgentToolsRequest,
@@ -170,7 +180,9 @@ fn parse_agent_host_target(raw: &str) -> std::result::Result<AgentHostTarget, Ag
 }
 
 #[async_trait]
+/// Provider trait for serving the Gestalt agent-provider protocol.
 pub trait AgentProvider: pb::agent_provider_server::AgentProvider + Send + Sync + 'static {
+    /// Configures the provider before it starts serving requests.
     async fn configure(
         &self,
         _name: &str,
@@ -179,22 +191,27 @@ pub trait AgentProvider: pb::agent_provider_server::AgentProvider + Send + Sync 
         Ok(())
     }
 
+    /// Returns runtime metadata that should augment the static manifest.
     fn metadata(&self) -> Option<RuntimeMetadata> {
         None
     }
 
+    /// Returns non-fatal warnings the host should surface to users.
     fn warnings(&self) -> Vec<String> {
         Vec::new()
     }
 
+    /// Performs an optional health check.
     async fn health_check(&self) -> ProviderResult<()> {
         Ok(())
     }
 
+    /// Starts provider-owned background work after configuration.
     async fn start(&self) -> ProviderResult<()> {
         Ok(())
     }
 
+    /// Shuts the provider down before the runtime exits.
     async fn close(&self) -> ProviderResult<()> {
         Ok(())
     }

--- a/sdk/rust/src/agent_manager.rs
+++ b/sdk/rust/src/agent_manager.rs
@@ -13,28 +13,37 @@ use crate::generated::v1::{
 
 type AgentManagerTransport = InterceptedService<Channel, RelayTokenInterceptor>;
 
+/// Environment variable containing the agent-manager host-service target.
 pub const ENV_AGENT_MANAGER_SOCKET: &str = "GESTALT_AGENT_MANAGER_SOCKET";
+/// Environment variable containing the optional agent-manager relay token.
 pub const ENV_AGENT_MANAGER_SOCKET_TOKEN: &str = "GESTALT_AGENT_MANAGER_SOCKET_TOKEN";
 const AGENT_MANAGER_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
 #[derive(Debug, thiserror::Error)]
+/// Errors returned by [`AgentManager`].
 pub enum AgentManagerError {
+    /// The invocation token was empty.
     #[error("agent manager: invocation token is not available")]
     MissingInvocationToken,
+    /// The host-service transport could not be created.
     #[error("{0}")]
     Transport(#[from] tonic::transport::Error),
+    /// The host-service RPC returned a gRPC status.
     #[error("{0}")]
     Status(#[from] tonic::Status),
+    /// Required environment or target configuration was invalid.
     #[error("{0}")]
     Env(String),
 }
 
+/// Client for managing agent sessions, turns, events, and interactions.
 pub struct AgentManager {
     client: ProtoAgentManagerHostClient<AgentManagerTransport>,
     invocation_token: String,
 }
 
 impl AgentManager {
+    /// Connects to the agent manager with an invocation token from the host.
     pub async fn connect(
         invocation_token: impl AsRef<str>,
     ) -> std::result::Result<Self, AgentManagerError> {
@@ -77,6 +86,7 @@ impl AgentManager {
         })
     }
 
+    /// Creates an agent session.
     pub async fn create_session(
         &mut self,
         mut request: pb::AgentManagerCreateSessionRequest,
@@ -85,6 +95,7 @@ impl AgentManager {
         Ok(self.client.create_session(request).await?.into_inner())
     }
 
+    /// Fetches one agent session.
     pub async fn get_session(
         &mut self,
         mut request: pb::AgentManagerGetSessionRequest,
@@ -93,6 +104,7 @@ impl AgentManager {
         Ok(self.client.get_session(request).await?.into_inner())
     }
 
+    /// Lists agent sessions visible to the invocation token.
     pub async fn list_sessions(
         &mut self,
         mut request: pb::AgentManagerListSessionsRequest,
@@ -101,6 +113,7 @@ impl AgentManager {
         Ok(self.client.list_sessions(request).await?.into_inner())
     }
 
+    /// Updates mutable fields on an agent session.
     pub async fn update_session(
         &mut self,
         mut request: pb::AgentManagerUpdateSessionRequest,
@@ -109,6 +122,7 @@ impl AgentManager {
         Ok(self.client.update_session(request).await?.into_inner())
     }
 
+    /// Creates an agent turn.
     pub async fn create_turn(
         &mut self,
         mut request: pb::AgentManagerCreateTurnRequest,
@@ -117,6 +131,7 @@ impl AgentManager {
         Ok(self.client.create_turn(request).await?.into_inner())
     }
 
+    /// Fetches one agent turn.
     pub async fn get_turn(
         &mut self,
         mut request: pb::AgentManagerGetTurnRequest,
@@ -125,6 +140,7 @@ impl AgentManager {
         Ok(self.client.get_turn(request).await?.into_inner())
     }
 
+    /// Lists turns for an agent session.
     pub async fn list_turns(
         &mut self,
         mut request: pb::AgentManagerListTurnsRequest,
@@ -133,6 +149,7 @@ impl AgentManager {
         Ok(self.client.list_turns(request).await?.into_inner())
     }
 
+    /// Cancels an in-progress agent turn.
     pub async fn cancel_turn(
         &mut self,
         mut request: pb::AgentManagerCancelTurnRequest,
@@ -141,6 +158,7 @@ impl AgentManager {
         Ok(self.client.cancel_turn(request).await?.into_inner())
     }
 
+    /// Lists events emitted for an agent turn.
     pub async fn list_turn_events(
         &mut self,
         mut request: pb::AgentManagerListTurnEventsRequest,
@@ -149,6 +167,7 @@ impl AgentManager {
         Ok(self.client.list_turn_events(request).await?.into_inner())
     }
 
+    /// Lists pending or completed agent interactions.
     pub async fn list_interactions(
         &mut self,
         mut request: pb::AgentManagerListInteractionsRequest,
@@ -157,6 +176,7 @@ impl AgentManager {
         Ok(self.client.list_interactions(request).await?.into_inner())
     }
 
+    /// Resolves an agent interaction with a host response.
     pub async fn resolve_interaction(
         &mut self,
         mut request: pb::AgentManagerResolveInteractionRequest,

--- a/sdk/rust/src/api.rs
+++ b/sdk/rust/src/api.rs
@@ -9,41 +9,58 @@ use crate::error::{Error, Result};
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// Identifies the caller that initiated an operation.
 pub struct Subject {
+    /// Stable subject id.
     pub id: String,
+    /// Subject kind, such as user or service account.
     pub kind: String,
+    /// Human-readable display name.
     pub display_name: String,
+    /// Authentication source that produced the subject.
     pub auth_source: String,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// Describes the resolved credential used to authorize an operation.
 pub struct Credential {
+    /// Credential mode used by the host.
     pub mode: String,
+    /// Subject id associated with the credential.
     pub subject_id: String,
+    /// Connection id or name associated with the credential.
     pub connection: String,
+    /// Provider instance id or name associated with the credential.
     pub instance: String,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// Summarizes the host-side access decision attached to an operation.
 pub struct Access {
+    /// Policy name or id applied to the request.
     pub policy: String,
+    /// Effective role granted to the request.
     pub role: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 /// Carries execution-scoped metadata into typed operation handlers.
 pub struct Request {
+    /// Request token used by legacy operation handlers.
     pub token: String,
+    /// Connection parameters resolved by the host.
     pub connection_params: BTreeMap<String, String>,
+    /// Subject that initiated the request.
     pub subject: Subject,
+    /// Credential used to authorize the request.
     pub credential: Credential,
+    /// Access decision attached to the request.
     pub access: Access,
+    /// Idempotency key supplied by the host.
     pub idempotency_key: String,
     /// Workflow callback metadata uses a JSON-style lowerCamelCase object
     /// such as `runId`, `target.plugin.pluginName`, `trigger.scheduleId`, and
     /// `trigger.event.specVersion`.
     pub workflow: serde_json::Map<String, serde_json::Value>,
+    /// Invocation token used to call host services.
     pub invocation_token: String,
 }
 
@@ -53,16 +70,19 @@ impl Request {
         self.connection_params.get(name).map(String::as_str)
     }
 
+    /// Returns the invocation token used to call host services.
     pub fn invocation_token(&self) -> &str {
         &self.invocation_token
     }
 
+    /// Creates a plugin invoker using this request's invocation token.
     pub async fn invoker(
         &self,
     ) -> std::result::Result<crate::PluginInvoker, crate::PluginInvokerError> {
         crate::PluginInvoker::connect(self.invocation_token()).await
     }
 
+    /// Creates a workflow manager using this request's invocation token.
     pub async fn workflow_manager(
         &self,
     ) -> std::result::Result<crate::WorkflowManager, crate::WorkflowManagerError> {
@@ -73,6 +93,7 @@ impl Request {
         .await
     }
 
+    /// Creates an agent manager using this request's invocation token.
     pub async fn agent_manager(
         &self,
     ) -> std::result::Result<crate::AgentManager, crate::AgentManagerError> {
@@ -83,7 +104,9 @@ impl Request {
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// Wraps a typed handler response plus an optional explicit HTTP status code.
 pub struct Response<T> {
+    /// Optional explicit HTTP-style status code.
     pub status: Option<u16>,
+    /// Typed response body returned by the handler.
     pub body: T,
 }
 
@@ -104,6 +127,7 @@ pub fn ok<T>(body: T) -> Response<T> {
 
 /// Converts handler return values into a typed [`Response`].
 pub trait IntoResponse<T> {
+    /// Converts a handler return value into a typed response wrapper.
     fn into_response(self) -> Response<T>;
 }
 
@@ -122,9 +146,13 @@ impl<T> IntoResponse<T> for T {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// Describes provider metadata that should be surfaced by the runtime.
 pub struct RuntimeMetadata {
+    /// Provider name to report to the host.
     pub name: String,
+    /// Human-readable provider display name.
     pub display_name: String,
+    /// Human-readable provider description.
     pub description: String,
+    /// Provider version string.
     pub version: String,
 }
 

--- a/sdk/rust/src/cache.rs
+++ b/sdk/rust/src/cache.rs
@@ -19,30 +19,38 @@ type CacheTransport = InterceptedService<Channel, RelayTokenInterceptor>;
 
 /// Default Unix-socket environment variable used by [`Cache::connect`].
 pub const ENV_CACHE_SOCKET: &str = "GESTALT_CACHE_SOCKET";
+/// Default relay-token environment variable used by [`Cache::connect`].
 pub const ENV_CACHE_SOCKET_TOKEN: &str = "GESTALT_CACHE_SOCKET_TOKEN";
+/// Suffix added to named cache socket variables for relay-token variables.
 pub const ENV_CACHE_SOCKET_TOKEN_SUFFIX: &str = "_TOKEN";
 const CACHE_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// One cache entry written through [`Cache::set_many`].
 pub struct CacheEntry {
+    /// Cache key to store.
     pub key: String,
+    /// Cache value bytes.
     pub value: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 /// Options applied to cache writes.
 pub struct CacheSetOptions {
+    /// Optional time-to-live for the stored value.
     pub ttl: Option<Duration>,
 }
 
 #[derive(Debug, thiserror::Error)]
 /// Errors returned by the cache client transport.
 pub enum CacheError {
+    /// The host-service transport could not be created.
     #[error("{0}")]
     Transport(#[from] tonic::transport::Error),
+    /// The host-service RPC returned a gRPC status.
     #[error("{0}")]
     Status(#[from] tonic::Status),
+    /// Required environment or target configuration was invalid.
     #[error("{0}")]
     Env(String),
 }

--- a/sdk/rust/src/indexeddb.rs
+++ b/sdk/rust/src/indexeddb.rs
@@ -16,6 +16,7 @@ type IndexedDbTransport = InterceptedService<Channel, RelayTokenInterceptor>;
 
 /// Default Unix-socket environment variable used by [`IndexedDB::connect`].
 pub const ENV_INDEXEDDB_SOCKET: &str = "GESTALT_INDEXEDDB_SOCKET";
+/// Suffix added to named IndexedDB socket variables for relay-token variables.
 pub const ENV_INDEXEDDB_SOCKET_TOKEN_SUFFIX: &str = "_TOKEN";
 const INDEXEDDB_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
@@ -25,18 +26,25 @@ const TRANSACTION_CHANNEL_BUFFER: usize = 1;
 #[derive(Debug, thiserror::Error)]
 /// Errors returned by the IndexedDB transport client.
 pub enum IndexedDBError {
+    /// The requested record, object store, index, or cursor entry was missing.
     #[error("not found")]
     NotFound,
+    /// A create operation conflicted with an existing value.
     #[error("already exists")]
     AlreadyExists,
+    /// A cursor was opened in key-only mode and a value was requested.
     #[error("cursor is keys-only; value not available")]
     KeysOnly,
+    /// An explicit transaction failed or was already closed.
     #[error("{0}")]
     Transaction(String),
+    /// The host-service transport could not be created.
     #[error("{0}")]
     Transport(#[from] tonic::transport::Error),
+    /// The host-service RPC returned a gRPC status.
     #[error("{0}")]
     Status(#[from] tonic::Status),
+    /// Required environment or target configuration was invalid.
     #[error("{0}")]
     Env(String),
 }
@@ -46,30 +54,42 @@ pub type Record = BTreeMap<String, serde_json::Value>;
 
 /// Constrains a query or cursor by lower and upper bounds.
 pub struct KeyRange {
+    /// Lower bound, inclusive unless `lower_open` is true.
     pub lower: Option<serde_json::Value>,
+    /// Upper bound, inclusive unless `upper_open` is true.
     pub upper: Option<serde_json::Value>,
+    /// Whether the lower bound is exclusive.
     pub lower_open: bool,
+    /// Whether the upper bound is exclusive.
     pub upper_open: bool,
 }
 
 /// Describes one secondary index on an object store.
 pub struct IndexSchema {
+    /// Index name.
     pub name: String,
+    /// Record path used as the index key.
     pub key_path: Vec<String>,
+    /// Whether the index enforces uniqueness.
     pub unique: bool,
 }
 
 /// Describes the indexes attached to an object store.
 pub struct ObjectStoreSchema {
+    /// Secondary indexes to create with the object store.
     pub indexes: Vec<IndexSchema>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Controls cursor traversal order.
 pub enum CursorDirection {
+    /// Iterate in ascending key order.
     Next,
+    /// Iterate in ascending key order while collapsing duplicate index keys.
     NextUnique,
+    /// Iterate in descending key order.
     Prev,
+    /// Iterate in descending key order while collapsing duplicate index keys.
     PrevUnique,
 }
 
@@ -87,7 +107,9 @@ impl CursorDirection {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Controls whether an explicit transaction may mutate scoped stores.
 pub enum TransactionMode {
+    /// Transaction may only read from scoped object stores.
     Readonly,
+    /// Transaction may read and write scoped object stores.
     Readwrite,
 }
 
@@ -103,9 +125,12 @@ impl TransactionMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 /// Provider durability hint for explicit transactions.
 pub enum TransactionDurabilityHint {
+    /// Let the host choose its default durability behavior.
     #[default]
     Default,
+    /// Prefer stricter durability.
     Strict,
+    /// Prefer relaxed durability.
     Relaxed,
 }
 
@@ -122,6 +147,7 @@ impl TransactionDurabilityHint {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 /// Options for an explicit transaction.
 pub struct TransactionOptions {
+    /// Durability hint for explicit transactions.
     pub durability_hint: TransactionDurabilityHint,
 }
 

--- a/sdk/rust/src/invoker.rs
+++ b/sdk/rust/src/invoker.rs
@@ -17,47 +17,67 @@ use crate::generated::v1::{
 
 type PluginInvokerTransport = InterceptedService<Channel, RelayTokenInterceptor>;
 
+/// Environment variable containing the plugin-invoker host-service target.
 pub const ENV_PLUGIN_INVOKER_SOCKET: &str = "GESTALT_PLUGIN_INVOKER_SOCKET";
+/// Environment variable containing the optional plugin-invoker relay token.
 pub const ENV_PLUGIN_INVOKER_SOCKET_TOKEN: &str = "GESTALT_PLUGIN_INVOKER_SOCKET_TOKEN";
 const PLUGIN_INVOKER_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
 #[derive(Debug, thiserror::Error)]
+/// Errors returned by [`PluginInvoker`].
 pub enum PluginInvokerError {
+    /// The invocation token was empty.
     #[error("plugin invoker: invocation token is not available")]
     MissingInvocationToken,
+    /// The host-service transport could not be created.
     #[error("{0}")]
     Transport(#[from] tonic::transport::Error),
+    /// The host-service RPC returned a gRPC status.
     #[error("{0}")]
     Status(#[from] tonic::Status),
+    /// Required environment or target configuration was invalid.
     #[error("{0}")]
     Env(String),
+    /// Invocation parameters or variables could not be serialized.
     #[error("{0}")]
     Json(#[from] serde_json::Error),
+    /// The host returned a protocol value the SDK could not represent.
     #[error("{0}")]
     Protocol(String),
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+/// Grant included when exchanging an invocation token for a child token.
 pub struct InvocationGrant {
+    /// Plugin name that the child token may invoke.
     pub plugin: String,
+    /// Specific operation ids allowed by the child token.
     pub operations: Vec<String>,
+    /// Surface names allowed by the child token.
     pub surfaces: Vec<String>,
+    /// Whether the child token may invoke every operation on the plugin.
     pub all_operations: bool,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+/// Options that select the target connection for a plugin invocation.
 pub struct InvokeOptions {
+    /// Connected account id or name to invoke against.
     pub connection: String,
+    /// Provider instance id or name to invoke against.
     pub instance: String,
+    /// Idempotency key forwarded to the target operation.
     pub idempotency_key: String,
 }
 
+/// Client for invoking sibling plugin operations through the host.
 pub struct PluginInvoker {
     client: ProtoPluginInvokerClient<PluginInvokerTransport>,
     invocation_token: String,
 }
 
 impl PluginInvoker {
+    /// Connects to the plugin invoker with an invocation token from the host.
     pub async fn connect(
         invocation_token: impl AsRef<str>,
     ) -> std::result::Result<Self, PluginInvokerError> {
@@ -101,6 +121,7 @@ impl PluginInvoker {
         })
     }
 
+    /// Invokes one operation on another plugin.
     pub async fn invoke<P>(
         &mut self,
         plugin: &str,
@@ -147,6 +168,7 @@ impl PluginInvoker {
         })
     }
 
+    /// Invokes another plugin's GraphQL surface.
     pub async fn invoke_graphql<V>(
         &mut self,
         plugin: &str,
@@ -205,6 +227,7 @@ impl PluginInvoker {
         })
     }
 
+    /// Exchanges this invocation token for a narrower child token.
     pub async fn exchange_invocation_token(
         &mut self,
         grants: &[InvocationGrant],

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -181,6 +181,7 @@ macro_rules! export_plugin_runtime_provider {
     };
 }
 
+/// Exports the workflow-provider entrypoint expected by `gestaltd`.
 #[macro_export]
 macro_rules! export_workflow_provider {
     (constructor = $constructor:path $(,)?) => {
@@ -191,6 +192,7 @@ macro_rules! export_workflow_provider {
     };
 }
 
+/// Exports the agent-provider entrypoint expected by `gestaltd`.
 #[macro_export]
 macro_rules! export_agent_provider {
     (constructor = $constructor:path $(,)?) => {

--- a/sdk/rust/src/plugin_runtime.rs
+++ b/sdk/rust/src/plugin_runtime.rs
@@ -8,9 +8,11 @@ use crate::error::Result as ProviderResult;
 use crate::generated::v1::{self as pb};
 
 #[async_trait]
+/// Provider trait for serving hosted plugin-runtime sessions.
 pub trait PluginRuntimeProvider:
     pb::plugin_runtime_provider_server::PluginRuntimeProvider + Send + Sync + 'static
 {
+    /// Configures the provider before it starts serving requests.
     async fn configure(
         &self,
         _name: &str,
@@ -19,22 +21,27 @@ pub trait PluginRuntimeProvider:
         Ok(())
     }
 
+    /// Returns runtime metadata that should augment the static manifest.
     fn metadata(&self) -> Option<RuntimeMetadata> {
         None
     }
 
+    /// Returns non-fatal warnings the host should surface to users.
     fn warnings(&self) -> Vec<String> {
         Vec::new()
     }
 
+    /// Performs an optional health check.
     async fn health_check(&self) -> ProviderResult<()> {
         Ok(())
     }
 
+    /// Starts provider-owned background work after configuration.
     async fn start(&self) -> ProviderResult<()> {
         Ok(())
     }
 
+    /// Shuts the provider down before the runtime exits.
     async fn close(&self) -> ProviderResult<()> {
         Ok(())
     }

--- a/sdk/rust/src/provider_server.rs
+++ b/sdk/rust/src/provider_server.rs
@@ -19,18 +19,23 @@ use crate::rpc_status::{require_protocol_version, rpc_status};
 use crate::{Provider, Router};
 
 #[derive(Clone)]
+/// gRPC integration-provider server used by the Rust runtime.
 pub struct ProviderServer<P> {
     provider: Arc<P>,
     router: Router<P>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Serialized operation result returned by the provider runtime.
 pub struct OperationResult {
+    /// HTTP-style status code.
     pub status: u16,
+    /// JSON-encoded response body.
     pub body: String,
 }
 
 impl OperationResult {
+    /// Serializes a typed handler response.
     pub fn from_response<T: Serialize>(response: Response<T>) -> Self {
         let status = response.status.unwrap_or(200);
         match serde_json::to_string(&response.body) {
@@ -42,6 +47,7 @@ impl OperationResult {
         }
     }
 
+    /// Converts an SDK error into a serialized operation result.
     pub fn from_error(error: Error) -> Self {
         let status = error.status().unwrap_or(HTTP_INTERNAL_SERVER_ERROR);
         if !error.expose_message() {
@@ -51,6 +57,7 @@ impl OperationResult {
         Self::error(status, error.message().to_owned())
     }
 
+    /// Creates a serialized error response.
     pub fn error(status: u16, message: impl Into<String>) -> Self {
         Self {
             status,
@@ -60,6 +67,7 @@ impl OperationResult {
 }
 
 impl<P> ProviderServer<P> {
+    /// Creates a server from a provider and operation router.
     pub fn new(provider: Arc<P>, router: Router<P>) -> Self {
         Self { provider, router }
     }

--- a/sdk/rust/src/router.rs
+++ b/sdk/rust/src/router.rs
@@ -18,13 +18,21 @@ use crate::provider_server::OperationResult;
 #[derive(Clone, Debug)]
 /// Describes one statically declared executable operation.
 pub struct Operation<In, Out> {
+    /// Stable operation id.
     pub id: String,
+    /// HTTP method advertised in the catalog.
     pub method: String,
+    /// Human-readable title.
     pub title: String,
+    /// Human-readable description.
     pub description: String,
+    /// Host-side roles allowed to invoke the operation.
     pub allowed_roles: Vec<String>,
+    /// Free-form catalog tags.
     pub tags: Vec<String>,
+    /// Whether the operation is read-only.
     pub read_only: bool,
+    /// Optional catalog visibility override.
     pub visible: Option<bool>,
     _types: PhantomData<(In, Out)>,
 }

--- a/sdk/rust/src/runtime.rs
+++ b/sdk/rust/src/runtime.rs
@@ -271,6 +271,7 @@ where
 }
 
 #[cfg(unix)]
+/// Serves a workflow provider over the configured Unix socket.
 pub async fn serve_workflow_provider<P>(provider: Arc<P>) -> Result<()>
 where
     P: WorkflowProvider,
@@ -293,6 +294,7 @@ where
 }
 
 #[cfg(unix)]
+/// Serves an agent provider over the configured Unix socket.
 pub async fn serve_agent_provider<P>(provider: Arc<P>) -> Result<()>
 where
     P: AgentProvider,

--- a/sdk/rust/src/runtime_log_host.rs
+++ b/sdk/rust/src/runtime_log_host.rs
@@ -16,29 +16,39 @@ use crate::generated::v1::{
 
 type RuntimeLogHostTransport = InterceptedService<Channel, RelayTokenInterceptor>;
 
+/// Environment variable containing the runtime-log host-service target.
 pub const ENV_RUNTIME_LOG_HOST_SOCKET: &str = "GESTALT_RUNTIME_LOG_SOCKET";
+/// Environment variable containing the optional runtime-log relay token.
 pub const ENV_RUNTIME_LOG_HOST_SOCKET_TOKEN: &str = "GESTALT_RUNTIME_LOG_SOCKET_TOKEN";
+/// Environment variable containing the current plugin-runtime session id.
 pub const ENV_RUNTIME_SESSION_ID: &str = "GESTALT_RUNTIME_SESSION_ID";
 const RUNTIME_LOG_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
+/// Runtime log stream enum generated from the provider protocol.
 pub type RuntimeLogStream = pb::PluginRuntimeLogStream;
 
 #[derive(Debug, thiserror::Error)]
+/// Errors returned by [`RuntimeLogHost`].
 pub enum RuntimeLogHostError {
+    /// The host-service transport could not be created.
     #[error("{0}")]
     Transport(#[from] tonic::transport::Error),
+    /// The host-service RPC returned a gRPC status.
     #[error("{0}")]
     Status(#[from] tonic::Status),
+    /// Required environment or target configuration was invalid.
     #[error("{0}")]
     Env(String),
 }
 
+/// Client for appending plugin-runtime logs to the host.
 pub struct RuntimeLogHost {
     client: ProtoPluginRuntimeLogHostClient<RuntimeLogHostTransport>,
     source_seq: i64,
 }
 
 impl RuntimeLogHost {
+    /// Connects to the runtime-log host service described by the environment.
     pub async fn connect() -> std::result::Result<Self, RuntimeLogHostError> {
         let socket_path = std::env::var(ENV_RUNTIME_LOG_HOST_SOCKET).map_err(|_| {
             RuntimeLogHostError::Env(format!("{ENV_RUNTIME_LOG_HOST_SOCKET} is not set"))
@@ -74,6 +84,7 @@ impl RuntimeLogHost {
         })
     }
 
+    /// Appends logs using a raw protocol request message.
     pub async fn append_logs(
         &mut self,
         request: pb::AppendPluginRuntimeLogsRequest,
@@ -81,6 +92,7 @@ impl RuntimeLogHost {
         Ok(self.client.append_logs(request).await?.into_inner())
     }
 
+    /// Appends one log entry for an explicit session id.
     pub async fn append(
         &mut self,
         session_id: impl Into<String>,
@@ -93,6 +105,7 @@ impl RuntimeLogHost {
             .await
     }
 
+    /// Appends one log entry for `GESTALT_RUNTIME_SESSION_ID`.
     pub async fn append_current(
         &mut self,
         stream: RuntimeLogStream,
@@ -101,6 +114,7 @@ impl RuntimeLogHost {
         self.append(runtime_session_id()?, stream, message).await
     }
 
+    /// Appends one log entry with an explicit timestamp and source sequence.
     pub async fn append_entry(
         &mut self,
         session_id: impl Into<String>,
@@ -122,6 +136,7 @@ impl RuntimeLogHost {
         .await
     }
 
+    /// Appends one explicit log entry for `GESTALT_RUNTIME_SESSION_ID`.
     pub async fn append_current_entry(
         &mut self,
         stream: RuntimeLogStream,
@@ -139,6 +154,7 @@ impl RuntimeLogHost {
         .await
     }
 
+    /// Appends one stdout log entry for an explicit session id.
     pub async fn append_stdout(
         &mut self,
         session_id: impl Into<String>,
@@ -148,6 +164,7 @@ impl RuntimeLogHost {
             .await
     }
 
+    /// Appends one stdout log entry for `GESTALT_RUNTIME_SESSION_ID`.
     pub async fn append_current_stdout(
         &mut self,
         message: impl Into<String>,
@@ -155,6 +172,7 @@ impl RuntimeLogHost {
         self.append_current(RuntimeLogStream::Stdout, message).await
     }
 
+    /// Appends one stderr log entry for an explicit session id.
     pub async fn append_stderr(
         &mut self,
         session_id: impl Into<String>,
@@ -164,6 +182,7 @@ impl RuntimeLogHost {
             .await
     }
 
+    /// Appends one stderr log entry for `GESTALT_RUNTIME_SESSION_ID`.
     pub async fn append_current_stderr(
         &mut self,
         message: impl Into<String>,
@@ -171,6 +190,7 @@ impl RuntimeLogHost {
         self.append_current(RuntimeLogStream::Stderr, message).await
     }
 
+    /// Appends one runtime log entry for an explicit session id.
     pub async fn append_runtime(
         &mut self,
         session_id: impl Into<String>,
@@ -180,6 +200,7 @@ impl RuntimeLogHost {
             .await
     }
 
+    /// Appends one runtime log entry for `GESTALT_RUNTIME_SESSION_ID`.
     pub async fn append_current_runtime(
         &mut self,
         message: impl Into<String>,
@@ -274,6 +295,7 @@ fn parse_runtime_log_host_target(
     Ok(RuntimeLogHostTarget::Unix(target.to_string()))
 }
 
+/// Returns the current runtime session id from `GESTALT_RUNTIME_SESSION_ID`.
 pub fn runtime_session_id() -> std::result::Result<String, RuntimeLogHostError> {
     let session_id = std::env::var(ENV_RUNTIME_SESSION_ID)
         .unwrap_or_default()

--- a/sdk/rust/src/s3.rs
+++ b/sdk/rust/src/s3.rs
@@ -24,7 +24,9 @@ type S3Transport = InterceptedService<Channel, RelayTokenInterceptor>;
 
 /// Default Unix-socket environment variable used by [`S3::connect`].
 pub const ENV_S3_SOCKET: &str = "GESTALT_S3_SOCKET";
+/// Suffix added to named S3 socket variables for relay-token variables.
 pub const ENV_S3_SOCKET_TOKEN_SUFFIX: &str = "_TOKEN";
+/// Default relay-token environment variable used by [`S3::connect`].
 pub const ENV_S3_SOCKET_TOKEN: &str = "GESTALT_S3_SOCKET_TOKEN";
 const S3_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 const WRITE_CHUNK_SIZE: usize = 64 * 1024;
@@ -32,22 +34,31 @@ const WRITE_CHUNK_SIZE: usize = 64 * 1024;
 #[derive(Debug, thiserror::Error)]
 /// Errors returned by the S3 transport client.
 pub enum S3Error {
+    /// The referenced object does not exist.
     #[error("not found")]
     NotFound,
+    /// Conditional request headers failed.
     #[error("precondition failed")]
     PreconditionFailed,
+    /// The requested byte range is invalid.
     #[error("invalid range")]
     InvalidRange,
+    /// The host returned a protocol value the SDK could not represent.
     #[error("{0}")]
     Protocol(String),
+    /// The host-service transport could not be created.
     #[error("{0}")]
     Transport(#[from] tonic::transport::Error),
+    /// The host-service RPC returned a gRPC status.
     #[error("{0}")]
     Status(#[from] tonic::Status),
+    /// Required environment or target configuration was invalid.
     #[error("{0}")]
     Env(String),
+    /// JSON encoding or decoding failed.
     #[error("{0}")]
     Json(#[from] serde_json::Error),
+    /// UTF-8 decoding failed.
     #[error("{0}")]
     Utf8(#[from] std::string::FromUtf8Error),
 }
@@ -55,111 +66,164 @@ pub enum S3Error {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// Identifies one object or object version.
 pub struct ObjectRef {
+    /// Bucket name.
     pub bucket: String,
+    /// Object key.
     pub key: String,
+    /// Optional object version id.
     pub version_id: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 /// Describes an object returned by the provider.
 pub struct ObjectMeta {
+    /// Object reference, including version when returned by the provider.
     pub reference: ObjectRef,
+    /// Entity tag returned by storage.
     pub etag: String,
+    /// Object size in bytes.
     pub size: i64,
+    /// MIME content type.
     pub content_type: String,
+    /// Last-modified timestamp, when known.
     pub last_modified: Option<prost_types::Timestamp>,
+    /// User metadata associated with the object.
     pub metadata: BTreeMap<String, String>,
+    /// Storage class reported by the provider.
     pub storage_class: String,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// Requests a half-open slice of an object's bytes.
 pub struct ByteRange {
+    /// Inclusive starting byte offset.
     pub start: Option<i64>,
+    /// Inclusive ending byte offset.
     pub end: Option<i64>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 /// Configures conditional and ranged reads.
 pub struct ReadOptions {
+    /// Optional byte range to read.
     pub range: Option<ByteRange>,
+    /// Read only if the current ETag matches this value.
     pub if_match: String,
+    /// Read only if the current ETag does not match this value.
     pub if_none_match: String,
+    /// Read only if the object has changed since this timestamp.
     pub if_modified_since: Option<prost_types::Timestamp>,
+    /// Read only if the object has not changed since this timestamp.
     pub if_unmodified_since: Option<prost_types::Timestamp>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// Configures object writes.
 pub struct WriteOptions {
+    /// MIME content type.
     pub content_type: String,
+    /// Cache-Control header value.
     pub cache_control: String,
+    /// Content-Disposition header value.
     pub content_disposition: String,
+    /// Content-Encoding header value.
     pub content_encoding: String,
+    /// Content-Language header value.
     pub content_language: String,
+    /// User metadata to store with the object.
     pub metadata: BTreeMap<String, String>,
+    /// Write only if the current ETag matches this value.
     pub if_match: String,
+    /// Write only if the object does not exist or has a different ETag.
     pub if_none_match: String,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// Configures list-objects requests.
 pub struct ListOptions {
+    /// Bucket to list.
     pub bucket: String,
+    /// Prefix filter.
     pub prefix: String,
+    /// Delimiter for grouping common prefixes.
     pub delimiter: String,
+    /// Continuation token from the previous page.
     pub continuation_token: String,
+    /// Start listing after this key.
     pub start_after: String,
+    /// Maximum number of keys to return.
     pub max_keys: i32,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 /// Represents one page of list-objects results.
 pub struct ListPage {
+    /// Object metadata rows in this page.
     pub objects: Vec<ObjectMeta>,
+    /// Common prefixes returned by delimiter grouping.
     pub common_prefixes: Vec<String>,
+    /// Continuation token for the next page.
     pub next_continuation_token: String,
+    /// Whether another page is available.
     pub has_more: bool,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// Configures conditional copy requests.
 pub struct CopyOptions {
+    /// Copy only if the source ETag matches this value.
     pub if_match: String,
+    /// Copy only if the source ETag does not match this value.
     pub if_none_match: String,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 /// Identifies the HTTP verb encoded into a presigned URL.
 pub enum PresignMethod {
+    /// Let the provider choose the default method.
     #[default]
     Unspecified,
+    /// HTTP GET.
     Get,
+    /// HTTP PUT.
     Put,
+    /// HTTP DELETE.
     Delete,
+    /// HTTP HEAD.
     Head,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// Configures presigned URL generation.
 pub struct PresignOptions {
+    /// HTTP method encoded into the URL.
     pub method: PresignMethod,
+    /// Requested URL lifetime.
     pub expires: Duration,
+    /// Required content type for upload-style URLs.
     pub content_type: String,
+    /// Required content disposition for upload-style URLs.
     pub content_disposition: String,
+    /// Additional signed headers.
     pub headers: BTreeMap<String, String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 /// Contains a presigned URL plus any required headers.
 pub struct PresignResult {
+    /// URL clients should use.
     pub url: String,
+    /// HTTP method clients should use.
     pub method: PresignMethod,
+    /// Expiration timestamp, when known.
     pub expires_at: Option<prost_types::Timestamp>,
+    /// Headers clients must send with the URL.
     pub headers: BTreeMap<String, String>,
 }
 
+/// Options for creating a host-mediated object access URL.
 pub type ObjectAccessURLOptions = PresignOptions;
+/// Result returned when creating a host-mediated object access URL.
 pub type ObjectAccessURL = PresignResult;
 
 #[async_trait]

--- a/sdk/rust/src/telemetry.rs
+++ b/sdk/rust/src/telemetry.rs
@@ -20,11 +20,16 @@ pub const TELEMETRY_INSTRUMENTATION_NAME: &str = "gestalt.provider";
 /// Default GenAI provider name used for Gestalt-owned agent and tool work.
 pub const GENAI_PROVIDER_NAME: &str = "gestalt";
 
+/// GenAI operation name for chat/model calls.
 pub const GENAI_OPERATION_CHAT: &str = "chat";
+/// GenAI operation name for tool executions.
 pub const GENAI_OPERATION_EXECUTE_TOOL: &str = "execute_tool";
+/// GenAI operation name for agent invocations.
 pub const GENAI_OPERATION_INVOKE_AGENT: &str = "invoke_agent";
 
+/// GenAI tool type for datastore-backed tools.
 pub const GENAI_TOOL_TYPE_DATASTORE: &str = "datastore";
+/// GenAI tool type for extension/plugin-backed tools.
 pub const GENAI_TOOL_TYPE_EXTENSION: &str = "extension";
 
 const OPERATION_DURATION_METRIC: &str = "gen_ai.client.operation.duration";
@@ -43,13 +48,18 @@ static TOKEN_USAGE: OnceLock<Histogram<u64>> = OnceLock::new();
 /// Options for recording an upstream model SDK call.
 #[derive(Clone, Debug, Default)]
 pub struct ModelOperationOptions {
+    /// Upstream model provider name.
     pub provider_name: String,
+    /// Requested model name.
     pub request_model: String,
+    /// Common model request options to record.
     pub request_options: RequestOptions,
+    /// Additional span attributes for the request.
     pub request_attributes: Vec<KeyValue>,
 }
 
 impl ModelOperationOptions {
+    /// Creates model-operation options for a provider and model.
     pub fn new(provider_name: impl Into<String>, request_model: impl Into<String>) -> Self {
         Self {
             provider_name: provider_name.into(),
@@ -58,11 +68,13 @@ impl ModelOperationOptions {
         }
     }
 
+    /// Sets common model request options.
     pub fn with_request_options(mut self, request_options: RequestOptions) -> Self {
         self.request_options = request_options;
         self
     }
 
+    /// Adds one request span attribute.
     pub fn with_request_attribute(mut self, attribute: KeyValue) -> Self {
         self.request_attributes.push(attribute);
         self
@@ -72,26 +84,39 @@ impl ModelOperationOptions {
 /// Common GenAI request options that are useful as span attributes.
 #[derive(Clone, Debug, Default)]
 pub struct RequestOptions {
+    /// Number of choices requested.
     pub choice_count: Option<i64>,
+    /// Frequency penalty requested.
     pub frequency_penalty: Option<f64>,
+    /// Maximum output tokens requested.
     pub max_tokens: Option<i64>,
+    /// Presence penalty requested.
     pub presence_penalty: Option<f64>,
+    /// Sampling seed requested.
     pub seed: Option<i64>,
+    /// Sampling temperature requested.
     pub temperature: Option<f64>,
+    /// Top-k sampling parameter requested.
     pub top_k: Option<i64>,
+    /// Top-p sampling parameter requested.
     pub top_p: Option<f64>,
 }
 
 /// Options for recording provider-owned agent turn execution.
 #[derive(Clone, Debug, Default)]
 pub struct AgentInvocationOptions {
+    /// Agent name.
     pub agent_name: String,
+    /// Agent session id.
     pub session_id: String,
+    /// Agent turn id.
     pub turn_id: String,
+    /// Model used by the agent turn.
     pub model: String,
 }
 
 impl AgentInvocationOptions {
+    /// Creates options for an agent invocation span.
     pub fn new(
         agent_name: impl Into<String>,
         session_id: impl Into<String>,
@@ -110,12 +135,16 @@ impl AgentInvocationOptions {
 /// Options for recording provider-owned tool execution.
 #[derive(Clone, Debug, Default)]
 pub struct ToolExecutionOptions {
+    /// Tool name.
     pub tool_name: String,
+    /// Tool call id, when supplied by the model.
     pub tool_call_id: String,
+    /// GenAI tool type.
     pub tool_type: String,
 }
 
 impl ToolExecutionOptions {
+    /// Creates options for a tool execution span.
     pub fn new(tool_name: impl Into<String>) -> Self {
         Self {
             tool_name: tool_name.into(),
@@ -124,11 +153,13 @@ impl ToolExecutionOptions {
         }
     }
 
+    /// Sets the model-supplied tool call id.
     pub fn with_tool_call_id(mut self, tool_call_id: impl Into<String>) -> Self {
         self.tool_call_id = tool_call_id.into();
         self
     }
 
+    /// Sets the GenAI tool type.
     pub fn with_tool_type(mut self, tool_type: impl Into<String>) -> Self {
         self.tool_type = tool_type.into();
         self
@@ -138,10 +169,15 @@ impl ToolExecutionOptions {
 /// GenAI token usage recorded on spans and token usage metrics.
 #[derive(Clone, Debug, Default)]
 pub struct TokenUsage {
+    /// Input token count.
     pub input_tokens: Option<u64>,
+    /// Output token count.
     pub output_tokens: Option<u64>,
+    /// Anthropic cache-creation input token count.
     pub cache_creation_input_tokens: Option<u64>,
+    /// Cached input token count.
     pub cache_read_input_tokens: Option<u64>,
+    /// Reasoning output token count.
     pub reasoning_output_tokens: Option<u64>,
 }
 

--- a/sdk/rust/src/workflow.rs
+++ b/sdk/rust/src/workflow.rs
@@ -13,23 +13,30 @@ use crate::generated::v1::{
     self as pb, workflow_host_client::WorkflowHostClient as ProtoWorkflowHostClient,
 };
 
+/// Environment variable containing the workflow-host service socket path.
 pub const ENV_WORKFLOW_HOST_SOCKET: &str = "GESTALT_WORKFLOW_HOST_SOCKET";
 
 #[derive(Debug, thiserror::Error)]
+/// Errors returned by [`WorkflowHost`].
 pub enum WorkflowHostError {
+    /// The host-service transport could not be created.
     #[error("{0}")]
     Transport(#[from] tonic::transport::Error),
+    /// The host-service RPC returned a gRPC status.
     #[error("{0}")]
     Status(#[from] tonic::Status),
+    /// Required environment or target configuration was invalid.
     #[error("{0}")]
     Env(String),
 }
 
+/// Client for invoking operations from workflow provider code.
 pub struct WorkflowHost {
     client: ProtoWorkflowHostClient<Channel>,
 }
 
 impl WorkflowHost {
+    /// Connects to the workflow host service described by the environment.
     pub async fn connect() -> std::result::Result<Self, WorkflowHostError> {
         let socket_path = std::env::var(ENV_WORKFLOW_HOST_SOCKET).map_err(|_| {
             WorkflowHostError::Env(format!("{ENV_WORKFLOW_HOST_SOCKET} is not set"))
@@ -40,6 +47,7 @@ impl WorkflowHost {
         })
     }
 
+    /// Invokes an operation through the workflow host service.
     pub async fn invoke_operation(
         &mut self,
         request: pb::InvokeWorkflowOperationRequest,
@@ -60,9 +68,11 @@ async fn connect_unix(
 }
 
 #[async_trait]
+/// Provider trait for serving the Gestalt workflow-provider protocol.
 pub trait WorkflowProvider:
     pb::workflow_provider_server::WorkflowProvider + Send + Sync + 'static
 {
+    /// Configures the provider before it starts serving requests.
     async fn configure(
         &self,
         _name: &str,
@@ -71,22 +81,27 @@ pub trait WorkflowProvider:
         Ok(())
     }
 
+    /// Returns runtime metadata that should augment the static manifest.
     fn metadata(&self) -> Option<RuntimeMetadata> {
         None
     }
 
+    /// Returns non-fatal warnings the host should surface to users.
     fn warnings(&self) -> Vec<String> {
         Vec::new()
     }
 
+    /// Performs an optional health check.
     async fn health_check(&self) -> ProviderResult<()> {
         Ok(())
     }
 
+    /// Starts provider-owned background work after configuration.
     async fn start(&self) -> ProviderResult<()> {
         Ok(())
     }
 
+    /// Shuts the provider down before the runtime exits.
     async fn close(&self) -> ProviderResult<()> {
         Ok(())
     }

--- a/sdk/rust/src/workflow_manager.rs
+++ b/sdk/rust/src/workflow_manager.rs
@@ -14,22 +14,30 @@ use crate::generated::v1::{
 
 type WorkflowManagerTransport = InterceptedService<Channel, RelayTokenInterceptor>;
 
+/// Environment variable containing the workflow-manager host-service target.
 pub const ENV_WORKFLOW_MANAGER_SOCKET: &str = "GESTALT_WORKFLOW_MANAGER_SOCKET";
+/// Environment variable containing the optional workflow-manager relay token.
 pub const ENV_WORKFLOW_MANAGER_SOCKET_TOKEN: &str = "GESTALT_WORKFLOW_MANAGER_SOCKET_TOKEN";
 const WORKFLOW_MANAGER_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
 #[derive(Debug, thiserror::Error)]
+/// Errors returned by [`WorkflowManager`].
 pub enum WorkflowManagerError {
+    /// The invocation token was empty.
     #[error("workflow manager: invocation token is not available")]
     MissingInvocationToken,
+    /// The host-service transport could not be created.
     #[error("{0}")]
     Transport(#[from] tonic::transport::Error),
+    /// The host-service RPC returned a gRPC status.
     #[error("{0}")]
     Status(#[from] tonic::Status),
+    /// Required environment or target configuration was invalid.
     #[error("{0}")]
     Env(String),
 }
 
+/// Client for starting workflow runs and managing schedules or triggers.
 pub struct WorkflowManager {
     client: ProtoWorkflowManagerHostClient<WorkflowManagerTransport>,
     invocation_token: String,
@@ -37,12 +45,14 @@ pub struct WorkflowManager {
 }
 
 impl WorkflowManager {
+    /// Connects to the workflow manager with an invocation token from the host.
     pub async fn connect(
         invocation_token: impl AsRef<str>,
     ) -> std::result::Result<Self, WorkflowManagerError> {
         Self::connect_with_idempotency_key(invocation_token, "").await
     }
 
+    /// Connects with a default idempotency key for create requests.
     pub async fn connect_with_idempotency_key(
         invocation_token: impl AsRef<str>,
         idempotency_key: impl AsRef<str>,
@@ -87,6 +97,7 @@ impl WorkflowManager {
         })
     }
 
+    /// Creates a workflow schedule.
     pub async fn create_schedule(
         &mut self,
         mut request: pb::WorkflowManagerCreateScheduleRequest,
@@ -98,6 +109,7 @@ impl WorkflowManager {
         Ok(self.client.create_schedule(request).await?.into_inner())
     }
 
+    /// Starts a workflow run.
     pub async fn start_run(
         &mut self,
         mut request: pb::WorkflowManagerStartRunRequest,
@@ -106,6 +118,7 @@ impl WorkflowManager {
         Ok(self.client.start_run(request).await?.into_inner())
     }
 
+    /// Signals an existing workflow run.
     pub async fn signal_run(
         &mut self,
         mut request: pb::WorkflowManagerSignalRunRequest,
@@ -114,6 +127,7 @@ impl WorkflowManager {
         Ok(self.client.signal_run(request).await?.into_inner())
     }
 
+    /// Signals a run or starts it when no matching run exists.
     pub async fn signal_or_start_run(
         &mut self,
         mut request: pb::WorkflowManagerSignalOrStartRunRequest,
@@ -122,6 +136,7 @@ impl WorkflowManager {
         Ok(self.client.signal_or_start_run(request).await?.into_inner())
     }
 
+    /// Fetches one workflow schedule.
     pub async fn get_schedule(
         &mut self,
         mut request: pb::WorkflowManagerGetScheduleRequest,
@@ -130,6 +145,7 @@ impl WorkflowManager {
         Ok(self.client.get_schedule(request).await?.into_inner())
     }
 
+    /// Updates a workflow schedule.
     pub async fn update_schedule(
         &mut self,
         mut request: pb::WorkflowManagerUpdateScheduleRequest,
@@ -138,6 +154,7 @@ impl WorkflowManager {
         Ok(self.client.update_schedule(request).await?.into_inner())
     }
 
+    /// Deletes a workflow schedule.
     pub async fn delete_schedule(
         &mut self,
         mut request: pb::WorkflowManagerDeleteScheduleRequest,
@@ -147,6 +164,7 @@ impl WorkflowManager {
         Ok(())
     }
 
+    /// Pauses a workflow schedule.
     pub async fn pause_schedule(
         &mut self,
         mut request: pb::WorkflowManagerPauseScheduleRequest,
@@ -155,6 +173,7 @@ impl WorkflowManager {
         Ok(self.client.pause_schedule(request).await?.into_inner())
     }
 
+    /// Resumes a workflow schedule.
     pub async fn resume_schedule(
         &mut self,
         mut request: pb::WorkflowManagerResumeScheduleRequest,
@@ -163,6 +182,7 @@ impl WorkflowManager {
         Ok(self.client.resume_schedule(request).await?.into_inner())
     }
 
+    /// Creates an event trigger.
     pub async fn create_trigger(
         &mut self,
         mut request: pb::WorkflowManagerCreateEventTriggerRequest,
@@ -178,6 +198,7 @@ impl WorkflowManager {
             .into_inner())
     }
 
+    /// Fetches one event trigger.
     pub async fn get_trigger(
         &mut self,
         mut request: pb::WorkflowManagerGetEventTriggerRequest,
@@ -186,6 +207,7 @@ impl WorkflowManager {
         Ok(self.client.get_event_trigger(request).await?.into_inner())
     }
 
+    /// Updates an event trigger.
     pub async fn update_trigger(
         &mut self,
         mut request: pb::WorkflowManagerUpdateEventTriggerRequest,
@@ -198,6 +220,7 @@ impl WorkflowManager {
             .into_inner())
     }
 
+    /// Deletes an event trigger.
     pub async fn delete_trigger(
         &mut self,
         mut request: pb::WorkflowManagerDeleteEventTriggerRequest,
@@ -207,6 +230,7 @@ impl WorkflowManager {
         Ok(())
     }
 
+    /// Pauses an event trigger.
     pub async fn pause_trigger(
         &mut self,
         mut request: pb::WorkflowManagerPauseEventTriggerRequest,
@@ -215,6 +239,7 @@ impl WorkflowManager {
         Ok(self.client.pause_event_trigger(request).await?.into_inner())
     }
 
+    /// Resumes an event trigger.
     pub async fn resume_trigger(
         &mut self,
         mut request: pb::WorkflowManagerResumeEventTriggerRequest,
@@ -227,6 +252,7 @@ impl WorkflowManager {
             .into_inner())
     }
 
+    /// Publishes an event into the workflow manager.
     pub async fn publish_event(
         &mut self,
         mut request: pb::WorkflowManagerPublishEventRequest,

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,22 +1,52 @@
 # Gestalt TypeScript SDK
 
-This package provides the TypeScript authoring surface for executable Gestalt
-providers.
+Use the TypeScript SDK to build Bun-based executable Gestalt providers with
+explicit runtime schemas.
 
-It is intended for source providers discovered through `package.json` and for
-packaged providers built from that same source tree.
+The package is published as `@valon-technologies/gestalt`.
+
+```sh
+bun add @valon-technologies/gestalt@0.0.1-alpha.16
+```
+
+```ts
+import { definePlugin, ok, operation, s } from "@valon-technologies/gestalt";
+
+export const plugin = definePlugin({
+  displayName: "Search",
+  operations: [
+    operation({
+      id: "search",
+      method: "GET",
+      readOnly: true,
+      input: s.object({
+        query: s.string({ description: "Search query" }),
+        limit: s.integer({ description: "Maximum results", default: 10 }),
+      }),
+      output: s.object({
+        results: s.array(s.string()),
+      }),
+      async handler(input) {
+        return ok({ results: [input.query].slice(0, input.limit) });
+      },
+    }),
+  ],
+});
+```
 
 ## Provider target
 
 Point the package at the provider module with a top-level `gestalt.provider`
-property in `package.json`:
+property in `package.json`.
 
 ```json
 {
   "name": "my-provider",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
   "dependencies": {
-    "@valon-technologies/gestalt": "0.0.1-alpha.13"
+    "@valon-technologies/gestalt": "0.0.1-alpha.16"
   },
   "gestalt": {
     "provider": {
@@ -27,83 +57,33 @@ property in `package.json`:
 }
 ```
 
-The target is a relative file path with an optional export suffix. The runtime
-accepts:
+The target is a relative file path with an optional export suffix. If the suffix
+is omitted, the runtime looks for `provider`, then `plugin`, then the default
+export.
 
-- `gestalt.provider` as `{ "kind": "...", "target": "./file.ts#export" }`
-- `gestalt.provider` as a string like `"plugin:./provider.ts#plugin"` or `"cache:./cache.ts#provider"`
+Use `"plugin"` as the kind token for executable plugin providers. Use an object
+target with an explicit kind for authentication, authorization, cache,
+IndexedDB, S3, secrets, workflow, agent, and hosted-runtime providers.
 
-Use `"plugin"` as the kind token for executable plugin providers.
+## Public surface
 
-If the export suffix is omitted, the runtime looks for `provider`, then
-`plugin`, then the default export.
+The root package exports provider definition helpers:
 
-## Authoring
+- `definePlugin` for integration operations and session catalogs.
+- `defineAuthenticationProvider` and `defineAuthorizationProvider` for auth
+  surfaces.
+- `defineCacheProvider`, `defineIndexedDBProvider`, `defineS3Provider`, and
+  `defineSecretsProvider` for host-service backends.
+- `defineWorkflowProvider`, `defineAgentProvider`, and
+  `definePluginRuntimeProvider` for workflow, agent, and hosted-runtime
+  backends.
+- `s` schema builders for operation input, output, and catalog metadata.
+- Host-service clients for cache, IndexedDB, S3, workflows, agents,
+  invocations, and telemetry.
 
-Use explicit runtime schemas to define plugin operation inputs and outputs:
-
-```ts
-import {
-  definePlugin,
-  ok,
-  operation,
-  response,
-  s,
-} from "@valon-technologies/gestalt";
-
-export const plugin = definePlugin({
-  displayName: "Example Provider",
-  description: "A provider implemented with the Gestalt TypeScript SDK",
-  configure(name, config) {
-    console.log("configured", name, config);
-  },
-  sessionCatalog(request) {
-    return {
-      name: "example-session",
-      operations: [
-        {
-          id: "session-ping",
-          method: "GET",
-        },
-      ],
-    };
-  },
-  operations: [
-    operation({
-      id: "greet",
-      method: "GET",
-      readOnly: true,
-      input: s.object({
-        name: s.string({ description: "Name to greet", default: "World" }),
-        excited: s.optional(s.boolean()),
-      }),
-      output: s.object({
-        message: s.string(),
-      }),
-      async handler(input) {
-        return ok({
-          message: `Hello, ${input.name}${input.excited ? "!" : "."}`,
-        });
-      },
-    }),
-  ],
-});
-```
-
-Use `ok(body)` for normal responses and `response(status, body)` when a handler
-needs to set a non-200 status. Plain objects with `status` and `body` fields
-are treated as user data.
-
-Authentication providers, cache providers, and secrets providers use dedicated helpers:
-
-```ts
-import {
-  Cache,
-  defineAuthenticationProvider,
-  defineCacheProvider,
-  defineSecretsProvider,
-} from "@valon-technologies/gestalt";
-```
+TypeScript types are not enough to describe runtime payloads. Use the schema
+builders for every operation input and output that should appear in the
+Gestalt catalog.
 
 ## Runtime and build entrypoints
 
@@ -116,7 +96,7 @@ gestalt-ts-runtime ROOT plugin:./provider.ts#plugin
 Release build:
 
 ```sh
-gestalt-ts-build ROOT cache:./cache.ts#provider OUTPUT PROVIDER_NAME GOOS GOARCH
+gestalt-ts-build ROOT plugin:./provider.ts#plugin OUTPUT PROVIDER_NAME GOOS GOARCH
 ```
 
 The build entrypoint compiles a standalone executable with Bun and bundles the
@@ -130,6 +110,15 @@ From the repo root:
 buf generate --template sdk/proto/buf.typescript.gen.yaml sdk/proto
 ```
 
+## API reference
+
+The TypeDoc reference is generated from the authored public surface plus
+entrypoint shims under `docs/entrypoints`.
+
+```sh
+bun run docs:build
+```
+
 ## Local checks
 
 From `sdk/typescript`:
@@ -139,4 +128,5 @@ export PATH="$HOME/.bun/bin:$PATH"
 bun install
 bun run build:proto
 bun run check
+bun run docs:check
 ```

--- a/sdk/typescript/docs/entrypoints/@valon-technologies/gestalt/index.ts
+++ b/sdk/typescript/docs/entrypoints/@valon-technologies/gestalt/index.ts
@@ -1,5 +1,10 @@
 /**
- * Public API surface for `@valon-technologies/gestalt`.
+ * Public API surface for executable Gestalt providers.
+ *
+ * Use this package to define provider runtimes, operation schemas, handlers,
+ * host-service clients, and provider-owned telemetry. The provider manifest
+ * still owns static identity, connections, hosted HTTP routes, passthrough
+ * surfaces, and release metadata.
  *
  * @example
  * ```ts

--- a/sdk/typescript/docs/entrypoints/build/index.ts
+++ b/sdk/typescript/docs/entrypoints/build/index.ts
@@ -1,5 +1,9 @@
 /**
- * Build-time helpers for producing Gestalt provider binaries.
+ * Build-time helpers for producing standalone Gestalt provider binaries.
+ *
+ * `gestaltd provider release` uses this entrypoint for TypeScript source
+ * providers. It loads the configured provider target, bundles it with Bun, and
+ * writes the executable artifact for the requested target platform.
  *
  * @module
  */

--- a/sdk/typescript/docs/entrypoints/runtime/index.ts
+++ b/sdk/typescript/docs/entrypoints/runtime/index.ts
@@ -1,5 +1,9 @@
 /**
- * Runtime helpers for loading and serving Gestalt providers.
+ * Runtime helpers for loading and serving TypeScript providers locally.
+ *
+ * The runtime entrypoint reads the configured provider target, starts the
+ * matching gRPC provider server, and connects back to the `gestaltd` host over
+ * the socket supplied by the provider process environment.
  *
  * @module
  */

--- a/sdk/typescript/docs/entrypoints/schema/index.ts
+++ b/sdk/typescript/docs/entrypoints/schema/index.ts
@@ -1,6 +1,10 @@
 /**
  * Schema builders for operation inputs, outputs, and catalog metadata.
  *
+ * TypeScript types disappear at runtime. Use these builders to describe the
+ * payloads that Gestalt should validate, dispatch to handlers, and publish in
+ * generated operation catalogs.
+ *
  * @module
  */
 export * from "../../../src/schema.ts";

--- a/sdk/typescript/docs/entrypoints/target/index.ts
+++ b/sdk/typescript/docs/entrypoints/target/index.ts
@@ -1,6 +1,9 @@
 /**
  * Utilities for parsing plugin and provider targets.
  *
+ * Targets identify the provider kind, source file, and optional export name
+ * that the runtime or build entrypoint should load.
+ *
  * @module
  */
 export * from "../../../src/target.ts";

--- a/sdk/typescript/docs/entrypoints/telemetry/index.ts
+++ b/sdk/typescript/docs/entrypoints/telemetry/index.ts
@@ -1,6 +1,10 @@
 /**
  * OpenTelemetry helpers for provider-authored GenAI instrumentation.
  *
+ * `gestaltd` owns exporter configuration. Providers use these helpers around
+ * model calls, agent invocations, and tool execution that happen inside their
+ * own process.
+ *
  * @module
  */
 export * from "../../../src/telemetry.ts";

--- a/sdk/typescript/src/agent-manager.ts
+++ b/sdk/typescript/src/agent-manager.ts
@@ -26,44 +26,64 @@ import {
 } from "../gen/v1/agent_pb.ts";
 import type { Request } from "./api.ts";
 
+/** Environment variable containing the agent-manager host-service target. */
 export const ENV_AGENT_MANAGER_SOCKET = "GESTALT_AGENT_MANAGER_SOCKET";
-export const ENV_AGENT_MANAGER_SOCKET_TOKEN = `${ENV_AGENT_MANAGER_SOCKET}_TOKEN`;
+/** Environment variable containing the optional agent-manager relay token. */
+export const ENV_AGENT_MANAGER_SOCKET_TOKEN =
+  `${ENV_AGENT_MANAGER_SOCKET}_TOKEN`;
 const AGENT_MANAGER_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token";
 
+/** Shape accepted when creating an agent session through the host manager. */
 export type AgentManagerCreateSessionInput = MessageInitShape<
   typeof AgentManagerCreateSessionRequestSchema
 >;
+/** Shape accepted when fetching an agent session through the host manager. */
 export type AgentManagerGetSessionInput = MessageInitShape<
   typeof AgentManagerGetSessionRequestSchema
 >;
+/** Shape accepted when listing agent sessions through the host manager. */
 export type AgentManagerListSessionsInput = MessageInitShape<
   typeof AgentManagerListSessionsRequestSchema
 >;
+/** Shape accepted when updating an agent session through the host manager. */
 export type AgentManagerUpdateSessionInput = MessageInitShape<
   typeof AgentManagerUpdateSessionRequestSchema
 >;
+/** Shape accepted when creating an agent turn through the host manager. */
 export type AgentManagerCreateTurnInput = MessageInitShape<
   typeof AgentManagerCreateTurnRequestSchema
 >;
+/** Shape accepted when fetching an agent turn through the host manager. */
 export type AgentManagerGetTurnInput = MessageInitShape<
   typeof AgentManagerGetTurnRequestSchema
 >;
+/** Shape accepted when listing agent turns through the host manager. */
 export type AgentManagerListTurnsInput = MessageInitShape<
   typeof AgentManagerListTurnsRequestSchema
 >;
+/** Shape accepted when cancelling an agent turn through the host manager. */
 export type AgentManagerCancelTurnInput = MessageInitShape<
   typeof AgentManagerCancelTurnRequestSchema
 >;
+/** Shape accepted when listing events for an agent turn. */
 export type AgentManagerListTurnEventsInput = MessageInitShape<
   typeof AgentManagerListTurnEventsRequestSchema
 >;
+/** Shape accepted when listing agent interactions. */
 export type AgentManagerListInteractionsInput = MessageInitShape<
   typeof AgentManagerListInteractionsRequestSchema
 >;
+/** Shape accepted when resolving an agent interaction. */
 export type AgentManagerResolveInteractionInput = MessageInitShape<
   typeof AgentManagerResolveInteractionRequestSchema
 >;
 
+/**
+ * Client for managing agent sessions, turns, events, and interactions.
+ *
+ * The constructor accepts either a Gestalt request or an invocation token. Each
+ * manager call forwards that token to the host service.
+ */
 export class AgentManager {
   private readonly client: Client<typeof AgentManagerHostService>;
   private readonly invocationToken: string;
@@ -89,6 +109,7 @@ export class AgentManager {
     this.client = createClient(AgentManagerHostService, transport);
   }
 
+  /** Creates an agent session. */
   async createSession(
     request: AgentManagerCreateSessionInput,
   ): Promise<AgentSession> {
@@ -98,6 +119,7 @@ export class AgentManager {
     });
   }
 
+  /** Fetches one agent session. */
   async getSession(request: AgentManagerGetSessionInput): Promise<AgentSession> {
     return await this.client.getSession({
       ...request,
@@ -105,6 +127,7 @@ export class AgentManager {
     });
   }
 
+  /** Lists agent sessions visible to the invocation token. */
   async listSessions(
     request: AgentManagerListSessionsInput = {},
   ): Promise<AgentSession[]> {
@@ -115,6 +138,7 @@ export class AgentManager {
     return [...response.sessions];
   }
 
+  /** Updates mutable fields on an agent session. */
   async updateSession(
     request: AgentManagerUpdateSessionInput,
   ): Promise<AgentSession> {
@@ -124,6 +148,7 @@ export class AgentManager {
     });
   }
 
+  /** Creates an agent turn. */
   async createTurn(request: AgentManagerCreateTurnInput): Promise<AgentTurn> {
     return await this.client.createTurn({
       ...request,
@@ -131,6 +156,7 @@ export class AgentManager {
     });
   }
 
+  /** Fetches one agent turn. */
   async getTurn(request: AgentManagerGetTurnInput): Promise<AgentTurn> {
     return await this.client.getTurn({
       ...request,
@@ -138,6 +164,7 @@ export class AgentManager {
     });
   }
 
+  /** Lists turns for an agent session. */
   async listTurns(request: AgentManagerListTurnsInput): Promise<AgentTurn[]> {
     const response = await this.client.listTurns({
       ...request,
@@ -146,6 +173,7 @@ export class AgentManager {
     return [...response.turns];
   }
 
+  /** Cancels an in-progress agent turn. */
   async cancelTurn(request: AgentManagerCancelTurnInput): Promise<AgentTurn> {
     return await this.client.cancelTurn({
       ...request,
@@ -153,6 +181,7 @@ export class AgentManager {
     });
   }
 
+  /** Lists events emitted for an agent turn. */
   async listTurnEvents(
     request: AgentManagerListTurnEventsInput,
   ): Promise<AgentTurnEvent[]> {
@@ -163,6 +192,7 @@ export class AgentManager {
     return [...response.events];
   }
 
+  /** Lists pending or completed agent interactions. */
   async listInteractions(
     request: AgentManagerListInteractionsInput,
   ): Promise<AgentInteraction[]> {
@@ -173,6 +203,7 @@ export class AgentManager {
     return [...response.interactions];
   }
 
+  /** Resolves an agent interaction with a host response. */
   async resolveInteraction(
     request: AgentManagerResolveInteractionInput,
   ): Promise<AgentInteraction> {

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -72,10 +72,18 @@ import {
 import { errorMessage, type MaybePromise } from "./api.ts";
 import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
 
+/** Environment variable containing the agent-host service target. */
 export const ENV_AGENT_HOST_SOCKET = "GESTALT_AGENT_HOST_SOCKET";
+/** Environment variable containing the optional agent-host relay token. */
 export const ENV_AGENT_HOST_SOCKET_TOKEN = `${ENV_AGENT_HOST_SOCKET}_TOKEN`;
 const AGENT_HOST_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token";
 
+/**
+ * Generated agent protocol message types commonly used by authored providers.
+ *
+ * These are re-exported so provider code can type sessions, turns, messages,
+ * interactions, and host-tool requests without importing from `gen`.
+ */
 export type {
   AgentActor,
   AgentInteraction,
@@ -119,11 +127,13 @@ export {
   AgentToolSourceMode,
 };
 
+/** JSON-like value accepted for an agent turn display payload. */
 export type AgentTurnDisplayValue =
   | JsonValue
   | Value
   | MessageInitShape<typeof ValueSchema>;
 
+/** Initializer for a turn display with JSON-like input/output/error fields. */
 export type AgentTurnDisplayInit = Omit<
   MessageInitShape<typeof AgentTurnDisplaySchema>,
   "$typeName" | "input" | "output" | "error"
@@ -133,6 +143,7 @@ export type AgentTurnDisplayInit = Omit<
   error?: AgentTurnDisplayValue | undefined;
 };
 
+/** Initializer for a turn event with authored display payload helpers. */
 export type AgentTurnEventInit = Omit<
   MessageInitShape<typeof AgentTurnEventSchema>,
   "$typeName" | "display"
@@ -140,6 +151,7 @@ export type AgentTurnEventInit = Omit<
   display?: AgentTurnDisplayInit | undefined;
 };
 
+/** Handlers and runtime metadata for an agent provider. */
 export interface AgentProviderOptions extends RuntimeProviderOptions {
   createSession?: (
     request: CreateAgentProviderSessionRequest,
@@ -182,6 +194,7 @@ export interface AgentProviderOptions extends RuntimeProviderOptions {
   ) => MaybePromise<MessageInitShape<typeof AgentProviderCapabilitiesSchema>>;
 }
 
+/** Runtime provider implementation for the Gestalt agent host contract. */
 export class AgentProvider extends RuntimeProvider {
   readonly kind = "agent" as const;
 
@@ -350,6 +363,7 @@ export class AgentProvider extends RuntimeProvider {
   }
 }
 
+/** Creates an agent provider for export from a provider module. */
 export function defineAgentProvider(options: AgentProviderOptions): AgentProvider {
   return new AgentProvider(options);
 }
@@ -404,6 +418,7 @@ function isValueInit(value: unknown): value is MessageInitShape<typeof ValueSche
   );
 }
 
+/** Runtime type guard for agent providers loaded from user modules. */
 export function isAgentProvider(value: unknown): value is AgentProvider {
   return (
     value instanceof AgentProvider ||
@@ -416,6 +431,7 @@ export function isAgentProvider(value: unknown): value is AgentProvider {
   );
 }
 
+/** Client for the agent host service available inside agent providers. */
 export class AgentHost {
   private readonly client: Client<typeof AgentHostService>;
 
@@ -432,12 +448,14 @@ export class AgentHost {
     this.client = createClient(AgentHostService, transport);
   }
 
+  /** Executes a host tool using an agent protocol request message. */
   async executeTool(
     request: ExecuteAgentToolRequest,
   ): Promise<ExecuteAgentToolResponse> {
     return await this.client.executeTool(request);
   }
 
+  /** Lists host tools visible to the current agent request. */
   async listTools(
     request: ListAgentToolsRequest,
   ): Promise<ListAgentToolsResponse> {
@@ -496,6 +514,7 @@ function agentHostRelayTokenInterceptor(token: string): Interceptor {
   };
 }
 
+/** Builds the Connect service implementation used by the TypeScript runtime. */
 export function createAgentProviderService(
   provider: AgentProvider,
 ): Partial<ServiceImpl<typeof AgentProviderService>> {

--- a/sdk/typescript/src/cache.ts
+++ b/sdk/typescript/src/cache.ts
@@ -7,10 +7,13 @@ import { Cache as CacheService } from "../gen/v1/cache_pb.ts";
 import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
 import type { MaybePromise } from "./api.ts";
 
+/** Base environment variable for discovering cache runtime sockets. */
 export const ENV_CACHE_SOCKET = "GESTALT_CACHE_SOCKET";
 const CACHE_SOCKET_TOKEN_SUFFIX = "_TOKEN";
 const CACHE_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token";
-export const ENV_CACHE_SOCKET_TOKEN = `${ENV_CACHE_SOCKET}${CACHE_SOCKET_TOKEN_SUFFIX}`;
+/** Base environment variable for the default cache relay token. */
+export const ENV_CACHE_SOCKET_TOKEN =
+  `${ENV_CACHE_SOCKET}${CACHE_SOCKET_TOKEN_SUFFIX}`;
 
 /**
  * Single cache entry used by batch cache APIs.
@@ -145,6 +148,7 @@ export class Cache {
     this.client = createClient(CacheService, transport);
   }
 
+  /** Returns a cached value, or `undefined` when the key is missing. */
   async get(key: string): Promise<Uint8Array | undefined> {
     const response = await this.client.get({
       key,
@@ -155,6 +159,7 @@ export class Cache {
     return cloneBytes(response.value);
   }
 
+  /** Returns the subset of requested keys that currently exist. */
   async getMany(keys: string[]): Promise<Record<string, Uint8Array>> {
     const response = await this.client.getMany({
       keys: [...keys],
@@ -162,6 +167,7 @@ export class Cache {
     return entriesToRecord(response.entries);
   }
 
+  /** Stores a cached value with an optional TTL. */
   async set(
     key: string,
     value: Uint8Array,
@@ -175,6 +181,7 @@ export class Cache {
     });
   }
 
+  /** Stores multiple values with an optional shared TTL. */
   async setMany(
     entries: Iterable<CacheEntry>,
     options?: CacheSetOptions,
@@ -186,6 +193,7 @@ export class Cache {
     });
   }
 
+  /** Deletes a cached value and reports whether it existed. */
   async delete(key: string): Promise<boolean> {
     const response = await this.client.delete({
       key,
@@ -193,6 +201,7 @@ export class Cache {
     return response.deleted;
   }
 
+  /** Deletes several cached values and returns the number removed. */
   async deleteMany(keys: string[]): Promise<number | bigint> {
     const response = await this.client.deleteMany({
       keys: [...keys],
@@ -200,6 +209,7 @@ export class Cache {
     return toJsInt(response.deleted);
   }
 
+  /** Refreshes the TTL for an existing key. */
   async touch(key: string, ttlMs: number): Promise<boolean> {
     const ttl = toProtoDuration(ttlMs);
     const response = await this.client.touch({

--- a/sdk/typescript/src/invoker.ts
+++ b/sdk/typescript/src/invoker.ts
@@ -5,27 +5,47 @@ import { createGrpcTransport } from "@connectrpc/connect-node";
 import { PluginInvoker as PluginInvokerService } from "../gen/v1/plugin_pb.ts";
 import type { OperationResult, Request } from "./api.ts";
 
+/** Environment variable containing the plugin-invoker host-service target. */
 export const ENV_PLUGIN_INVOKER_SOCKET = "GESTALT_PLUGIN_INVOKER_SOCKET";
-export const ENV_PLUGIN_INVOKER_SOCKET_TOKEN = `${ENV_PLUGIN_INVOKER_SOCKET}_TOKEN`;
+/** Environment variable containing the optional plugin-invoker relay token. */
+export const ENV_PLUGIN_INVOKER_SOCKET_TOKEN =
+  `${ENV_PLUGIN_INVOKER_SOCKET}_TOKEN`;
 const PLUGIN_INVOKER_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token";
 
+/** Options that select the target connection for an operation invocation. */
 export interface PluginInvokeOptions {
+  /** Connected account id or name to invoke against. */
   connection?: string;
+  /** Provider instance id or name to invoke against. */
   instance?: string;
+  /** Idempotency key forwarded to the target operation. */
   idempotencyKey?: string;
 }
 
+/** Grant included when exchanging an invocation token for a child token. */
 export interface PluginInvocationGrant {
+  /** Plugin name that the child token may invoke. */
   plugin: string;
+  /** Specific operation ids allowed by the child token. */
   operations?: string[];
+  /** Surface names allowed by the child token. */
   surfaces?: string[];
+  /** Whether the child token may invoke every operation on the plugin. */
   allOperations?: boolean;
 }
 
+/** Options for invoking a plugin GraphQL surface. */
 export interface PluginGraphQLInvokeOptions extends PluginInvokeOptions {
+  /** GraphQL variables encoded as a JSON object. */
   variables?: Record<string, unknown>;
 }
 
+/**
+ * Client for invoking sibling plugin operations through the host.
+ *
+ * The constructor accepts either a Gestalt request or an invocation token. The
+ * token is attached to every operation, GraphQL, and token-exchange request.
+ */
 export class PluginInvoker {
   private readonly client: Client<typeof PluginInvokerService>;
   private readonly invocationToken: string;
@@ -48,6 +68,7 @@ export class PluginInvoker {
     this.client = createClient(PluginInvokerService, transport);
   }
 
+  /** Invokes one operation on another plugin. */
   async invoke(
     plugin: string,
     operation: string,
@@ -69,6 +90,7 @@ export class PluginInvoker {
     };
   }
 
+  /** Invokes another plugin's GraphQL surface. */
   async invokeGraphQL(
     plugin: string,
     document: string,
@@ -96,8 +118,11 @@ export class PluginInvoker {
     };
   }
 
+  /** Exchanges this invocation token for a narrower child token. */
   async exchangeInvocationToken(options?: {
+    /** Grants to attach to the child token. */
     grants?: PluginInvocationGrant[];
+    /** Requested child-token time-to-live in seconds. */
     ttlSeconds?: number;
   }): Promise<string> {
     const response = await this.client.exchangeInvocationToken({

--- a/sdk/typescript/src/runtime-log-host.ts
+++ b/sdk/typescript/src/runtime-log-host.ts
@@ -16,35 +16,59 @@ import {
   PluginRuntimeLogStream,
 } from "../gen/v1/pluginruntime_pb.ts";
 
+/** Environment variable containing the runtime-log host-service target. */
 export const ENV_RUNTIME_LOG_HOST_SOCKET = "GESTALT_RUNTIME_LOG_SOCKET";
-export const ENV_RUNTIME_LOG_HOST_SOCKET_TOKEN = `${ENV_RUNTIME_LOG_HOST_SOCKET}_TOKEN`;
+/** Environment variable containing the optional runtime-log relay token. */
+export const ENV_RUNTIME_LOG_HOST_SOCKET_TOKEN =
+  `${ENV_RUNTIME_LOG_HOST_SOCKET}_TOKEN`;
+/** Environment variable containing the current plugin-runtime session id. */
 export const ENV_RUNTIME_SESSION_ID = "GESTALT_RUNTIME_SESSION_ID";
 
 const RUNTIME_LOG_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token";
 
+/** Named runtime log streams accepted by the authored SDK. */
 export type RuntimeLogStreamName = "stdout" | "stderr" | "runtime";
+/** Runtime log stream input, either a named stream or generated enum value. */
 export type RuntimeLogStreamInput =
   | RuntimeLogStreamName
   | PluginRuntimeLogStream;
+/** Shape accepted by `RuntimeLogHost.appendLogs`. */
 export type RuntimeLogAppendLogsInput = MessageInitShape<
   typeof AppendPluginRuntimeLogsRequestSchema
 >;
+/** Response message returned after appending runtime logs. */
 export type RuntimeLogAppendResponseMessage = AppendPluginRuntimeLogsResponse;
 
+/** One runtime log entry to append through `RuntimeLogHost.append`. */
 export interface RuntimeLogAppendInput {
+  /** Runtime session id. Defaults to `GESTALT_RUNTIME_SESSION_ID`. */
   sessionId?: string;
+  /** Log message bytes or text. */
   message: string | Uint8Array;
+  /** Destination stream. Defaults to `runtime`. */
   stream?: RuntimeLogStreamInput;
+  /** Observation timestamp. Defaults to the current time. */
   observedAt?: Date;
+  /** Monotonic source sequence number. Auto-increments when omitted. */
   sourceSeq?: number | bigint;
 }
 
+/** Options for the `Writable` returned by `RuntimeLogHost.writer`. */
 export interface RuntimeLogWriterOptions {
+  /** Runtime session id. Defaults to `GESTALT_RUNTIME_SESSION_ID`. */
   sessionId?: string;
+  /** Destination stream. Defaults to `stdout`. */
   stream?: RuntimeLogStreamInput;
+  /** Initial sequence number for writes. */
   sourceSeqStart?: number | bigint;
 }
 
+/**
+ * Client for appending plugin-runtime logs to the host.
+ *
+ * Use `append` for a single entry, `appendLogs` for a protocol-shaped batch, or
+ * `writer` to bridge Node streams into the runtime log host.
+ */
 export class RuntimeLogHost {
   private readonly client: Client<typeof PluginRuntimeLogHostService>;
   private sourceSeq = 0n;
@@ -82,6 +106,7 @@ export class RuntimeLogHost {
     return await this.client.appendLogs(request);
   }
 
+  /** Appends one runtime log entry. */
   async append(
     input: RuntimeLogAppendInput,
   ): Promise<RuntimeLogAppendResponseMessage> {
@@ -105,6 +130,7 @@ export class RuntimeLogHost {
     });
   }
 
+  /** Returns a `Writable` that appends chunks to a runtime log stream. */
   writer(options?: RuntimeLogWriterOptions): Writable;
   writer(sessionId: string, options?: RuntimeLogWriterOptions): Writable;
   writer(

--- a/sdk/typescript/src/s3.ts
+++ b/sdk/typescript/src/s3.ts
@@ -30,10 +30,13 @@ import {
 import { errorMessage, type MaybePromise } from "./api.ts";
 import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
 
+/** Base environment variable for discovering S3 runtime sockets. */
 export const ENV_S3_SOCKET = "GESTALT_S3_SOCKET";
 const S3_SOCKET_TOKEN_SUFFIX = "_TOKEN";
 const S3_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token";
-export const ENV_S3_SOCKET_TOKEN = `${ENV_S3_SOCKET}${S3_SOCKET_TOKEN_SUFFIX}`;
+/** Base environment variable for the default S3 relay token. */
+export const ENV_S3_SOCKET_TOKEN =
+  `${ENV_S3_SOCKET}${S3_SOCKET_TOKEN_SUFFIX}`;
 const WRITE_CHUNK_SIZE = 64 * 1024;
 const textEncoder = new TextEncoder();
 
@@ -288,14 +291,20 @@ export class S3Provider extends RuntimeProvider {
     this.presignObjectHandler = options.presignObject;
   }
 
+  /** Fetches object metadata without reading the object body. */
   async headObject(ref: ObjectRef): Promise<ObjectMeta> {
     return await this.headObjectHandler(ref);
   }
 
-  async readObject(ref: ObjectRef, options?: ReadOptions): Promise<ProviderReadResult> {
+  /** Reads an object body from the provider implementation. */
+  async readObject(
+    ref: ObjectRef,
+    options?: ReadOptions,
+  ): Promise<ProviderReadResult> {
     return await this.readObjectHandler(ref, options);
   }
 
+  /** Writes an object body through the provider implementation. */
   async writeObject(
     ref: ObjectRef,
     body: AsyncIterable<Uint8Array>,
@@ -304,14 +313,17 @@ export class S3Provider extends RuntimeProvider {
     return await this.writeObjectHandler(ref, body, options);
   }
 
+  /** Deletes an object from the provider implementation. */
   async deleteObject(ref: ObjectRef): Promise<void> {
     await this.deleteObjectHandler(ref);
   }
 
+  /** Lists objects from the provider implementation. */
   async listObjects(options: ListOptions): Promise<ListPage> {
     return await this.listObjectsHandler(options);
   }
 
+  /** Copies an object in the provider implementation. */
   async copyObject(
     source: ObjectRef,
     destination: ObjectRef,
@@ -320,7 +332,11 @@ export class S3Provider extends RuntimeProvider {
     return await this.copyObjectHandler(source, destination, options);
   }
 
-  async presignObject(ref: ObjectRef, options?: PresignOptions): Promise<PresignResult> {
+  /** Generates a presigned URL from the provider implementation. */
+  async presignObject(
+    ref: ObjectRef,
+    options?: PresignOptions,
+  ): Promise<PresignResult> {
     return await this.presignObjectHandler(ref, options);
   }
 }
@@ -555,14 +571,17 @@ export class S3 {
     this.client = createClient(S3Service, transport);
   }
 
+  /** Returns a convenience helper for the latest version of an object. */
   object(bucket: string, key: string): S3Object {
     return new S3Object(this, { bucket, key });
   }
 
+  /** Returns a convenience helper pinned to a specific object version. */
   objectVersion(bucket: string, key: string, versionId: string): S3Object {
     return new S3Object(this, { bucket, key, versionId });
   }
 
+  /** Fetches object metadata without reading the object body. */
   async headObject(ref: ObjectRef): Promise<ObjectMeta> {
     const response = await s3Rpc(() =>
       this.client.headObject({
@@ -572,6 +591,7 @@ export class S3 {
     return fromProtoObjectMeta(response.meta);
   }
 
+  /** Opens a streaming read for an object. */
   async readObject(ref: ObjectRef, options?: ReadOptions): Promise<ReadResult> {
     const response = this.client.readObject({
       ref: toProtoObjectRef(ref),
@@ -588,6 +608,7 @@ export class S3 {
     };
   }
 
+  /** Writes an object body and returns the resulting metadata. */
   async writeObject(
     ref: ObjectRef,
     body?: S3BodySource,
@@ -601,6 +622,7 @@ export class S3 {
     return fromProtoObjectMeta(response.meta);
   }
 
+  /** Deletes an object. */
   async deleteObject(ref: ObjectRef): Promise<void> {
     await s3Rpc(() =>
       this.client.deleteObject({
@@ -609,6 +631,7 @@ export class S3 {
     );
   }
 
+  /** Lists objects within a bucket. */
   async listObjects(options: ListOptions): Promise<ListPage> {
     const response = await s3Rpc(() =>
       this.client.listObjects({
@@ -628,6 +651,7 @@ export class S3 {
     };
   }
 
+  /** Copies an object and returns metadata for the destination. */
   async copyObject(
     source: ObjectRef,
     destination: ObjectRef,
@@ -644,7 +668,11 @@ export class S3 {
     return fromProtoObjectMeta(response.meta);
   }
 
-  async presignObject(ref: ObjectRef, options?: PresignOptions): Promise<PresignResult> {
+  /** Generates a presigned URL for an object operation. */
+  async presignObject(
+    ref: ObjectRef,
+    options?: PresignOptions,
+  ): Promise<PresignResult> {
     const requestedMethod = options?.method ?? PresignMethod.Get;
     const response = await s3Rpc(() =>
       this.client.presignObject({
@@ -669,6 +697,7 @@ export class S3 {
     return result;
   }
 
+  /** Creates a host-mediated object access URL. */
   async createObjectAccessURL(
     ref: ObjectRef,
     options?: ObjectAccessURLOptions,
@@ -704,6 +733,7 @@ export class S3 {
     return this.objectAccessClient;
   }
 
+  /** Alias for `createObjectAccessURL`. */
   async createObjectAccessUrl(
     ref: ObjectRef,
     options?: ObjectAccessURLOptions,
@@ -711,6 +741,7 @@ export class S3 {
     return await this.createObjectAccessURL(ref, options);
   }
 
+  /** Alias for `createObjectAccessURL`. */
   async createAccessURL(
     ref: ObjectRef,
     options?: ObjectAccessURLOptions,
@@ -718,6 +749,7 @@ export class S3 {
     return await this.createObjectAccessURL(ref, options);
   }
 
+  /** Alias for `createObjectAccessURL`. */
   async createAccessUrl(
     ref: ObjectRef,
     options?: ObjectAccessURLOptions,
@@ -846,7 +878,10 @@ export class S3Object {
     return await this.client.createObjectAccessURL(this.ref, options);
   }
 
-  async createAccessUrl(options?: ObjectAccessURLOptions): Promise<ObjectAccessURL> {
+  /** Alias for `createAccessURL`. */
+  async createAccessUrl(
+    options?: ObjectAccessURLOptions,
+  ): Promise<ObjectAccessURL> {
     return await this.createAccessURL(options);
   }
 }

--- a/sdk/typescript/src/workflow-manager.ts
+++ b/sdk/typescript/src/workflow-manager.ts
@@ -27,54 +27,81 @@ import {
 } from "../gen/v1/workflow_pb.ts";
 import type { Request } from "./api.ts";
 
+/** Environment variable containing the workflow-manager host-service target. */
 export const ENV_WORKFLOW_MANAGER_SOCKET = "GESTALT_WORKFLOW_MANAGER_SOCKET";
-export const ENV_WORKFLOW_MANAGER_SOCKET_TOKEN = `${ENV_WORKFLOW_MANAGER_SOCKET}_TOKEN`;
+/** Environment variable containing the optional workflow-manager relay token. */
+export const ENV_WORKFLOW_MANAGER_SOCKET_TOKEN =
+  `${ENV_WORKFLOW_MANAGER_SOCKET}_TOKEN`;
 const WORKFLOW_MANAGER_RELAY_TOKEN_HEADER =
   "x-gestalt-host-service-relay-token";
 
+/** Managed workflow schedule message returned by the host manager. */
 export type ManagedWorkflowScheduleMessage = ManagedWorkflowSchedule;
+/** Managed workflow event-trigger message returned by the host manager. */
 export type ManagedWorkflowEventTriggerMessage = ManagedWorkflowEventTrigger;
+/** Workflow event message returned after publishing an event. */
 export type WorkflowEventMessage = WorkflowEvent;
+/** Shape accepted when creating a workflow schedule. */
 export type WorkflowManagerCreateScheduleInput = MessageInitShape<
   typeof WorkflowManagerCreateScheduleRequestSchema
 >;
+/** Shape accepted when creating an event trigger. */
 export type WorkflowManagerCreateTriggerInput = MessageInitShape<
   typeof WorkflowManagerCreateEventTriggerRequestSchema
 >;
+/** Shape accepted when fetching a workflow schedule. */
 export type WorkflowManagerGetScheduleInput = MessageInitShape<
   typeof WorkflowManagerGetScheduleRequestSchema
 >;
+/** Shape accepted when fetching an event trigger. */
 export type WorkflowManagerGetTriggerInput = MessageInitShape<
   typeof WorkflowManagerGetEventTriggerRequestSchema
 >;
+/** Shape accepted when updating a workflow schedule. */
 export type WorkflowManagerUpdateScheduleInput = MessageInitShape<
   typeof WorkflowManagerUpdateScheduleRequestSchema
 >;
+/** Shape accepted when updating an event trigger. */
 export type WorkflowManagerUpdateTriggerInput = MessageInitShape<
   typeof WorkflowManagerUpdateEventTriggerRequestSchema
 >;
+/** Shape accepted when deleting a workflow schedule. */
 export type WorkflowManagerDeleteScheduleInput = MessageInitShape<
   typeof WorkflowManagerDeleteScheduleRequestSchema
 >;
+/** Shape accepted when deleting an event trigger. */
 export type WorkflowManagerDeleteTriggerInput = MessageInitShape<
   typeof WorkflowManagerDeleteEventTriggerRequestSchema
 >;
+/** Shape accepted when pausing a workflow schedule. */
 export type WorkflowManagerPauseScheduleInput = MessageInitShape<
   typeof WorkflowManagerPauseScheduleRequestSchema
 >;
+/** Shape accepted when pausing an event trigger. */
 export type WorkflowManagerPauseTriggerInput = MessageInitShape<
   typeof WorkflowManagerPauseEventTriggerRequestSchema
 >;
+/** Shape accepted when resuming a workflow schedule. */
 export type WorkflowManagerResumeScheduleInput = MessageInitShape<
   typeof WorkflowManagerResumeScheduleRequestSchema
 >;
+/** Shape accepted when resuming an event trigger. */
 export type WorkflowManagerResumeTriggerInput = MessageInitShape<
   typeof WorkflowManagerResumeEventTriggerRequestSchema
 >;
+/** Shape accepted when publishing a workflow event. */
 export type WorkflowManagerPublishEventInput = MessageInitShape<
   typeof WorkflowManagerPublishEventRequestSchema
 >;
 
+/**
+ * Client for creating and controlling workflow schedules and event triggers.
+ *
+ * The constructor accepts either a Gestalt request or an invocation token. Each
+ * manager call forwards that token to the host service. When constructed from a
+ * request, create operations reuse the request idempotency key unless the call
+ * provides one explicitly.
+ */
 export class WorkflowManager {
   private readonly client: Client<typeof WorkflowManagerHostService>;
   private readonly invocationToken: string;
@@ -104,6 +131,7 @@ export class WorkflowManager {
     this.client = createClient(WorkflowManagerHostService, transport);
   }
 
+  /** Creates a workflow schedule. */
   async createSchedule(
     request: WorkflowManagerCreateScheduleInput,
   ): Promise<ManagedWorkflowScheduleMessage> {
@@ -114,6 +142,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Fetches one workflow schedule. */
   async getSchedule(
     request: WorkflowManagerGetScheduleInput,
   ): Promise<ManagedWorkflowScheduleMessage> {
@@ -123,6 +152,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Updates a workflow schedule. */
   async updateSchedule(
     request: WorkflowManagerUpdateScheduleInput,
   ): Promise<ManagedWorkflowScheduleMessage> {
@@ -132,6 +162,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Deletes a workflow schedule. */
   async deleteSchedule(
     request: WorkflowManagerDeleteScheduleInput,
   ): Promise<void> {
@@ -141,6 +172,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Pauses a workflow schedule. */
   async pauseSchedule(
     request: WorkflowManagerPauseScheduleInput,
   ): Promise<ManagedWorkflowScheduleMessage> {
@@ -150,6 +182,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Resumes a workflow schedule. */
   async resumeSchedule(
     request: WorkflowManagerResumeScheduleInput,
   ): Promise<ManagedWorkflowScheduleMessage> {
@@ -159,6 +192,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Creates an event trigger. */
   async createTrigger(
     request: WorkflowManagerCreateTriggerInput,
   ): Promise<ManagedWorkflowEventTriggerMessage> {
@@ -169,6 +203,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Fetches one event trigger. */
   async getTrigger(
     request: WorkflowManagerGetTriggerInput,
   ): Promise<ManagedWorkflowEventTriggerMessage> {
@@ -178,6 +213,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Updates an event trigger. */
   async updateTrigger(
     request: WorkflowManagerUpdateTriggerInput,
   ): Promise<ManagedWorkflowEventTriggerMessage> {
@@ -187,6 +223,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Deletes an event trigger. */
   async deleteTrigger(
     request: WorkflowManagerDeleteTriggerInput,
   ): Promise<void> {
@@ -196,6 +233,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Pauses an event trigger. */
   async pauseTrigger(
     request: WorkflowManagerPauseTriggerInput,
   ): Promise<ManagedWorkflowEventTriggerMessage> {
@@ -205,6 +243,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Resumes an event trigger. */
   async resumeTrigger(
     request: WorkflowManagerResumeTriggerInput,
   ): Promise<ManagedWorkflowEventTriggerMessage> {
@@ -214,6 +253,7 @@ export class WorkflowManager {
     });
   }
 
+  /** Publishes an event into the workflow manager. */
   async publishEvent(
     request: WorkflowManagerPublishEventInput,
   ): Promise<WorkflowEventMessage> {

--- a/sdk/typescript/src/workflow.ts
+++ b/sdk/typescript/src/workflow.ts
@@ -48,8 +48,15 @@ import {
 import { errorMessage, type MaybePromise } from "./api.ts";
 import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
 
+/** Environment variable containing the workflow-host service socket path. */
 export const ENV_WORKFLOW_HOST_SOCKET = "GESTALT_WORKFLOW_HOST_SOCKET";
 
+/**
+ * Generated workflow protocol message types commonly used by providers.
+ *
+ * These are re-exported so workflow provider code can type runs, schedules,
+ * triggers, and operation-invocation requests without importing from `gen`.
+ */
 export type {
   BoundWorkflowEventTrigger,
   BoundWorkflowRun,
@@ -77,6 +84,7 @@ export type {
 };
 export { WorkflowRunStatus };
 
+/** Handlers and runtime metadata for a workflow provider. */
 export interface WorkflowProviderOptions extends RuntimeProviderOptions {
   startRun: (
     request: StartWorkflowProviderRunRequest,
@@ -131,6 +139,7 @@ export interface WorkflowProviderOptions extends RuntimeProviderOptions {
   ) => MaybePromise<void>;
 }
 
+/** Runtime provider implementation for the Gestalt workflow host contract. */
 export class WorkflowProvider extends RuntimeProvider {
   readonly kind = "workflow" as const;
 
@@ -276,12 +285,14 @@ export class WorkflowProvider extends RuntimeProvider {
   }
 }
 
+/** Creates a workflow provider for export from a provider module. */
 export function defineWorkflowProvider(
   options: WorkflowProviderOptions,
 ): WorkflowProvider {
   return new WorkflowProvider(options);
 }
 
+/** Runtime type guard for workflow providers loaded from user modules. */
 export function isWorkflowProvider(value: unknown): value is WorkflowProvider {
   return (
     value instanceof WorkflowProvider ||
@@ -309,6 +320,7 @@ export function isWorkflowProvider(value: unknown): value is WorkflowProvider {
   );
 }
 
+/** Client for invoking operations from workflow provider code. */
 export class WorkflowHost {
   private readonly client: Client<typeof WorkflowHostService>;
 
@@ -326,6 +338,7 @@ export class WorkflowHost {
     this.client = createClient(WorkflowHostService, transport);
   }
 
+  /** Invokes an operation through the workflow host service. */
   async invokeOperation(
     request: InvokeWorkflowOperationRequest,
   ): Promise<InvokeWorkflowOperationResponse> {
@@ -333,6 +346,7 @@ export class WorkflowHost {
   }
 }
 
+/** Builds the Connect service implementation used by the TypeScript runtime. */
 export function createWorkflowProviderService(
   provider: WorkflowProvider,
 ): Partial<ServiceImpl<typeof WorkflowProviderService>> {


### PR DESCRIPTION
## Summary

- Add a top-level SDK overview page and update reference navigation/cards.
- Rewrite the Python, TypeScript, Go, and Rust SDK pages as install-first guide pages.
- Improve generated API reference quality by adding authored docstrings/JSDoc/rustdoc/Go comments across SDK public surfaces.
- Expand the Python Sphinx reference to cover the public `gestalt.__all__` import surface, including host clients, managers, runtime logs, plugin invocation, transactions, hooks, and selected protocol types.
- Keep generated protobuf bindings out of scope; selected protocol aliases/re-exports are documented from authored wrapper files instead.

## Interface Changes

- New/changed interface: docs only. No runtime API, package API, wire protocol, or dependency behavior changed.
- Example usage: Python install guidance uses `uv add gestalt-sdk`; TypeScript guidance uses the verified pre-1.0 npm version guidance already in the SDK guide.

## Functional/Integration Tests

- Tests added or augmented: no new tests; this is documentation/reference-source coverage.
- Contract boundary covered: generated API documentation paths and SDK hosted docs outputs.
- Commands run:
  - `sdk/python`: `uv run sphinx-build -W -b html -d docs/_build/deploy-doctrees docs ../../docs/public/api/python`
  - `sdk/python`: custom `gestalt.__all__` vs `docs/reference.rst` audit, `missing 0`
  - `sdk/typescript`: `bun install --frozen-lockfile`
  - `sdk/typescript`: `bun run docs:build:deploy`
  - `sdk/typescript`: `bun run docs:check`
  - `sdk/rust`: `cargo test --doc`
  - `sdk/rust`: `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`
  - `sdk/rust`: `cargo rustdoc --lib -- -D missing_docs` as a non-gating audit; remaining failures are from generated protobuf output only
  - `sdk/go`: `go test ./...`
  - `sdk/go`: `go doc -all . >/tmp/gestalt-go-doc.txt`
  - `docs`: `bun install --frozen-lockfile`
  - `docs`: `npm run typecheck && npm run build`
  - repo root: `git diff --check`

The docs build completed with existing Nextra Git timestamp and localstorage warnings, but it succeeded.
