### PR TITLE
Simplify integration connection metadata API

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -29,10 +29,32 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `GET` | `/api/v1/integrations` | List plugins, connection state, authentication types, instances, icons, and connection parameter hints. |
+| `GET` | `/api/v1/integrations` | List plugins, aggregate status, icons, and nested connection metadata. Authentication types, instances, credential fields, and connection parameter hints are returned per item in `connections[]`. |
 | `DELETE` | `/api/v1/integrations/{name}` | Disconnect a plugin. Use `?_connection=...` and `?_instance=...` to target one stored connection. |
 | `GET` | `/api/v1/integrations/{name}/operations` | List operations for one plugin. Supports `_connection` and `_instance` selectors. |
 | `GET` or `POST` | `/api/v1/{integration}/{operation}` | Invoke a plugin operation. Supports `_connection` and `_instance`. |
+
+`GET /api/v1/integrations` returns one object per plugin. Use top-level `status`,
+`credentialState`, `healthState`, and `actions` for aggregate display state. Use
+`connections[]` for connection-specific auth and credential metadata:
+
+```json
+{
+  "name": "github",
+  "status": "ready",
+  "credentialState": "connected",
+  "connections": [
+    {
+      "name": "default",
+      "status": "ready",
+      "authTypes": ["oauth"],
+      "instances": [{"id": "acme", "name": "Acme"}],
+      "connectionParams": {},
+      "credentialFields": []
+    }
+  ]
+}
+```
 
 ### Plugin Connection Flows
 

--- a/gestalt/cli/src/commands/plugins.rs
+++ b/gestalt/cli/src/commands/plugins.rs
@@ -76,10 +76,7 @@ fn plugin_status(item: &serde_json::Value) -> String {
     item["status"]
         .as_str()
         .map(str::to_string)
-        .unwrap_or_else(|| match item["connected"].as_bool() {
-            Some(true) => "ready".to_string(),
-            _ => "needs_user_connection".to_string(),
-        })
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 fn plugin_connections(item: &serde_json::Value) -> String {
@@ -94,22 +91,14 @@ fn plugin_connections(item: &serde_json::Value) -> String {
                 let status = connection["status"]
                     .as_str()
                     .map(str::to_string)
-                    .unwrap_or_else(|| match connection["connected"].as_bool() {
-                        Some(true) => "ready".to_string(),
-                        _ => "needs_user_connection".to_string(),
-                    });
+                    .unwrap_or_else(|| "unknown".to_string());
                 format!("{name}: {status}")
             })
             .collect::<Vec<_>>()
             .join(", ");
     }
 
-    let instance_count = item["instances"].as_array().map(Vec::len).unwrap_or(0);
-    match instance_count {
-        0 => "-".to_string(),
-        1 => "1 instance".to_string(),
-        n => format!("{n} instances"),
-    }
+    "-".to_string()
 }
 
 pub fn disconnect(

--- a/gestalt/cli/src/commands/plugins/connect.rs
+++ b/gestalt/cli/src/commands/plugins/connect.rs
@@ -18,13 +18,7 @@ struct IntegrationInfo {
     #[serde(default)]
     description: Option<String>,
     #[serde(default)]
-    auth_types: Vec<String>,
-    #[serde(default)]
-    connection_params: BTreeMap<String, ConnectionParamDef>,
-    #[serde(default)]
     connections: Vec<ConnectionDefInfo>,
-    #[serde(default)]
-    credential_fields: Vec<CredentialFieldInfo>,
     #[serde(default)]
     status: Option<String>,
 }
@@ -37,6 +31,8 @@ struct ConnectionDefInfo {
     display_name: Option<String>,
     #[serde(default)]
     auth_types: Vec<String>,
+    #[serde(default)]
+    connection_params: BTreeMap<String, ConnectionParamDef>,
     #[serde(default)]
     credential_fields: Vec<CredentialFieldInfo>,
     #[serde(default)]
@@ -156,6 +152,7 @@ struct ResolvedConnectFlow<'a> {
     integration: &'a IntegrationInfo,
     connection: Option<ResolvedConnection<'a>>,
     mode: ConnectMode,
+    connection_params: Option<&'a BTreeMap<String, ConnectionParamDef>>,
     credential_fields: &'a [CredentialFieldInfo],
 }
 
@@ -167,19 +164,19 @@ impl<'a> ResolvedConnectFlow<'a> {
         let connection = resolve_connection(integration, requested_connection)?;
         let definition = connection.as_ref().and_then(|selected| selected.definition);
         let auth_types = definition
-            .filter(|connection| !connection.auth_types.is_empty())
             .map(|connection| connection.auth_types.as_slice())
-            .unwrap_or(integration.auth_types.as_slice());
+            .unwrap_or(&[]);
+        let connection_params = definition.map(|connection| &connection.connection_params);
         let credential_fields = definition
-            .filter(|connection| !connection.credential_fields.is_empty())
             .map(|connection| connection.credential_fields.as_slice())
-            .unwrap_or(integration.credential_fields.as_slice());
+            .unwrap_or(&[]);
         validate_user_connectable(integration, connection.as_ref())?;
 
         Ok(Self {
             integration,
             connection,
             mode: resolve_connect_mode(&integration.name, auth_types)?,
+            connection_params,
             credential_fields,
         })
     }
@@ -206,8 +203,8 @@ impl<'a> ResolvedConnectFlow<'a> {
             .map(ResolvedConnection::selector_name)
     }
 
-    fn connection_param_defs(&self) -> &BTreeMap<String, ConnectionParamDef> {
-        &self.integration.connection_params
+    fn connection_param_defs(&self) -> Option<&BTreeMap<String, ConnectionParamDef>> {
+        self.connection_params.filter(|params| !params.is_empty())
     }
 
     fn credential_fields(&self) -> &[CredentialFieldInfo] {
@@ -564,11 +561,11 @@ fn rewrite_connect_api_error(err: anyhow::Error) -> anyhow::Error {
 }
 
 fn prompt_connection_params(
-    connection_params: &BTreeMap<String, ConnectionParamDef>,
+    connection_params: Option<&BTreeMap<String, ConnectionParamDef>>,
 ) -> Result<Option<BTreeMap<String, String>>> {
-    if connection_params.is_empty() {
+    let Some(connection_params) = connection_params else {
         return Ok(None);
-    }
+    };
 
     let mut values = BTreeMap::new();
     for (name, def) in connection_params {

--- a/gestalt/cli/tests/plugins_connect.rs
+++ b/gestalt/cli/tests/plugins_connect.rs
@@ -25,10 +25,16 @@ fn test_list_plugins() {
 #[test]
 fn test_connect_includes_connection_and_instance() {
     let mut server = Server::new();
-    let _integrations =
-        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"acme_crm","authTypes":["oauth"],"connected":false}]"#)
-            .create();
+    let _integrations = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{"name":"acme_crm","connections":[{"name":"workspace","authTypes":["oauth"]}]}]"#,
+    )
+    .create();
     let mock = authed_json_mock!(
         server,
         Method::POST,
@@ -56,12 +62,18 @@ fn test_connect_includes_connection_and_instance() {
 }
 
 #[test]
-fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_connection_and_instance() {
+fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_instance() {
     let mut server = Server::new();
-    let _integrations =
-        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"acme_crm","authTypes":["oauth","manual"],"connected":false}]"#)
-            .create();
+    let _integrations = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{"name":"acme_crm","connections":[{"name":"plugin","authTypes":["oauth","manual"]}]}]"#,
+    )
+    .create();
     let mock = authed_json_mock!(
         server,
         Method::POST,
@@ -70,7 +82,7 @@ fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_connection_
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
     .match_body(Matcher::JsonString(
-        r#"{"integration":"acme_crm"}"#.to_string(),
+        r#"{"connection":"plugin","integration":"acme_crm"}"#.to_string(),
     ))
     .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
     .create();
@@ -98,17 +110,17 @@ fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_connection_
 }
 
 #[test]
-fn test_connect_uses_defined_plugin_connection_name_on_the_wire() {
+fn test_connect_uses_user_facing_plugin_connection_name_on_the_wire() {
     let mut server = Server::new();
-    let _integrations = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-        .with_body(
-            r#"[{
+    let _integrations =
+        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+            .with_body(
+                r#"[{
                 "name":"acme_crm",
-                "authTypes":["oauth"],
-                "connections":[{"name":"_plugin","displayName":"Plugin OAuth","authTypes":["oauth"]}]
+                "connections":[{"name":"plugin","displayName":"Plugin OAuth","authTypes":["oauth"]}]
             }]"#,
-        )
-        .create();
+            )
+            .create();
     let mock = authed_json_mock!(
         server,
         Method::POST,
@@ -117,7 +129,7 @@ fn test_connect_uses_defined_plugin_connection_name_on_the_wire() {
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
     .match_body(Matcher::JsonString(
-        r#"{"connection":"_plugin","integration":"acme_crm"}"#.to_string(),
+        r#"{"connection":"plugin","integration":"acme_crm"}"#.to_string(),
     ))
     .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
     .create();
@@ -168,39 +180,6 @@ fn test_connect_platform_connection_uses_admin_copy_without_starting_flow() {
 
     assert!(message.contains("requires deployment/admin configuration"));
     assert!(!message.contains("OAuth"));
-}
-
-#[test]
-fn test_connect_preserves_requested_plugin_connection_when_no_definitions_exist() {
-    let mut server = Server::new();
-    let _integrations =
-        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"acme_crm","authTypes":["oauth"],"connected":false}]"#)
-            .create();
-    let mock = authed_json_mock!(
-        server,
-        Method::POST,
-        "/api/v1/auth/start-oauth",
-        StatusCode::OK
-    )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"connection":"plugin","integration":"acme_crm"}"#.to_string(),
-    ))
-    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
-    .create();
-
-    let client = create_client(&server);
-    let result = gestalt::commands::plugins::connect_with_browser_opener(
-        &client,
-        "acme_crm",
-        Some("plugin"),
-        None,
-        |_| Ok(()),
-    );
-
-    mock.assert();
-    assert!(result.is_ok());
 }
 
 #[test]
@@ -269,30 +248,33 @@ fn test_disconnect_without_optional_params() {
 fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
     let mut server = Server::new();
     let _integrations =
-        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(
-                r#"[{
+		authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+			.with_body(
+				r#"[{
                 "name":"widget_metrics",
                 "displayName":"Widget Metrics",
                 "description":"Metrics and logs",
-                "authTypes":["manual"],
-                "connectionParams":{"region":{"description":"API region","default":"us-east","required":true}},
-                "credentialFields":[{"name":"api_key","label":"API key","description":"Use a personal API key"}]
+                "connections":[{
+                    "name":"plugin",
+                    "authTypes":["manual"],
+                    "connectionParams":{"region":{"description":"API region","default":"us-east","required":true}},
+                    "credentialFields":[{"name":"api_key","label":"API key","description":"Use a personal API key"}]
+                }]
             }]"#,
-            )
-            .create();
+			)
+			.create();
     let _connect = authed_json_mock!(
         server,
         Method::POST,
         "/api/v1/auth/connect-manual",
         StatusCode::OK
     )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"connectionParams":{"region":"eu-west"},"credential":"wm-key","integration":"widget_metrics"}"#.to_string(),
-    ))
-    .with_body(r#"{"status":"connected","integration":"widget_metrics"}"#)
-    .create();
+		.match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+		.match_body(Matcher::JsonString(
+			r#"{"connection":"plugin","connectionParams":{"region":"eu-west"},"credential":"wm-key","integration":"widget_metrics"}"#.to_string(),
+		))
+		.with_body(r#"{"status":"connected","integration":"widget_metrics"}"#)
+		.create();
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
@@ -314,9 +296,8 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
                 r#"[{
                     "name":"manual-svc",
                     "displayName":"Manual Service",
-                    "authTypes":["manual"],
                     "connections":[
-                        {"name":"workspace","displayName":"Workspace OAuth","credentialFields":[{"name":"token","label":"Workspace token"}]},
+                        {"name":"workspace","displayName":"Workspace OAuth","authTypes":["manual"],"credentialFields":[{"name":"token","label":"Workspace token"}]},
                         {"name":"plugin","displayName":"Plugin OAuth","authTypes":["oauth"]}
                     ]
                 }]"#,
@@ -391,7 +372,6 @@ fn test_connection_selection_uses_selected_connection_auth_type() {
                 r#"[{
                     "name":"manual-svc",
                     "displayName":"Manual Service",
-                    "authTypes":["manual"],
                     "connections":[
                         {"name":"workspace","displayName":"Workspace OAuth","authTypes":["oauth"]},
                         {"name":"apikey","displayName":"API Key","authTypes":["manual"],"credentialFields":[{"name":"token","label":"Token"}]}
@@ -436,7 +416,6 @@ fn test_connect_auto_selects_single_connection_and_uses_its_auth_type() {
                 r#"[{
                     "name":"single-svc",
                     "displayName":"Single Service",
-                    "authTypes":["manual"],
                     "connections":[
                         {"name":"workspace","displayName":"Workspace OAuth","authTypes":["oauth"]}
                     ]
@@ -503,11 +482,14 @@ fn test_manual_connect_uses_credentials_object_for_multi_field_auth() {
                 r#"[{
                 "name":"widget_metrics",
                 "displayName":"Widget Metrics",
-                "authTypes":["manual"],
-                "credentialFields":[
-                    {"name":"api_key","label":"API key"},
-                    {"name":"workspace_id","label":"Workspace ID"}
-                ]
+                "connections":[{
+                    "name":"plugin",
+                    "authTypes":["manual"],
+                    "credentialFields":[
+                        {"name":"api_key","label":"API key"},
+                        {"name":"workspace_id","label":"Workspace ID"}
+                    ]
+                }]
             }]"#,
             )
             .create();
@@ -517,12 +499,12 @@ fn test_manual_connect_uses_credentials_object_for_multi_field_auth() {
         "/api/v1/auth/connect-manual",
         StatusCode::OK
     )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"credentials":{"api_key":"wm-key","workspace_id":"workspace-42"},"integration":"widget_metrics"}"#.to_string(),
-    ))
-    .with_body(r#"{"status":"connected","integration":"widget_metrics"}"#)
-    .create();
+		.match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+		.match_body(Matcher::JsonString(
+			r#"{"connection":"plugin","credentials":{"api_key":"wm-key","workspace_id":"workspace-42"},"integration":"widget_metrics"}"#.to_string(),
+		))
+		.with_body(r#"{"status":"connected","integration":"widget_metrics"}"#)
+		.create();
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
@@ -538,10 +520,16 @@ fn test_manual_connect_uses_credentials_object_for_multi_field_auth() {
 #[test]
 fn test_manual_connect_falls_back_to_generic_credential_prompt() {
     let mut server = Server::new();
-    let _integrations =
-        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"manual-svc","authTypes":["manual"]}]"#)
-            .create();
+    let _integrations = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{"name":"manual-svc","connections":[{"name":"plugin","authTypes":["manual"]}]}]"#,
+    )
+    .create();
     let _connect = authed_json_mock!(
         server,
         Method::POST,
@@ -550,7 +538,7 @@ fn test_manual_connect_falls_back_to_generic_credential_prompt() {
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
     .match_body(Matcher::JsonString(
-        r#"{"credential":"secret","integration":"manual-svc"}"#.to_string(),
+        r#"{"connection":"plugin","credential":"secret","integration":"manual-svc"}"#.to_string(),
     ))
     .with_body(r#"{"status":"connected","integration":"manual-svc"}"#)
     .create();
@@ -568,10 +556,16 @@ fn test_manual_connect_falls_back_to_generic_credential_prompt() {
 #[test]
 fn test_manual_connect_fails_when_stdin_closes_during_prompt() {
     let mut server = Server::new();
-    let _integrations =
-        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"manual-svc","authTypes":["manual"]}]"#)
-            .create();
+    let _integrations = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{"name":"manual-svc","connections":[{"name":"plugin","authTypes":["manual"]}]}]"#,
+    )
+    .create();
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
@@ -597,9 +591,9 @@ fn test_cli_plugins_list_table_output() {
         }),
     );
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-        .with_body(
-            r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","connected":true,"status":"ready","connections":[{"name":"workspace","status":"ready"}]}]"#,
-        )
+		.with_body(
+			r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","status":"ready","connections":[{"name":"workspace","status":"ready"}]}]"#,
+		)
         .create();
 
     let mut cmd = cli_command(home.path());
@@ -616,9 +610,9 @@ fn test_cli_plugins_list_table_output() {
     mock.assert();
 
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-        .with_body(
-            r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","connected":true}]"#,
-        )
+		.with_body(
+			r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","status":"ready"}]"#,
+		)
         .create();
 
     let mut cmd = cli_command(home.path());
@@ -630,9 +624,9 @@ fn test_cli_plugins_list_table_output() {
     mock.assert();
 
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-        .with_body(
-            r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","connected":true}]"#,
-        )
+		.with_body(
+			r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","status":"ready"}]"#,
+		)
         .create();
 
     let mut cmd = cli_command(home.path());

--- a/gestaltd/internal/bootstrap/declarative_connection.go
+++ b/gestaltd/internal/bootstrap/declarative_connection.go
@@ -51,6 +51,7 @@ func declarativeConnectionParamDefs(params map[string]config.ConnectionParamDef)
 		out[name] = declarative.ConnectionParamDef{
 			Required:    param.Required,
 			Description: param.Description,
+			Default:     param.Default,
 			From:        param.From,
 			Field:       param.Field,
 		}

--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -50,16 +50,15 @@ const (
 	ownerKindUnknown         = "unknown"
 )
 
-func (s *Server) applyIntegrationConnectionStatus(info *integrationInfo, prov core.Provider, instances []instanceInfo, p *principal.Principal) {
-	status := s.defaultIntegrationStatus(info, prov, instances, p)
+func (s *Server) applyIntegrationConnectionStatus(info *integrationInfo, prov core.Provider, instances []instanceInfo, authTypes []string, p *principal.Principal) {
+	status := s.defaultIntegrationStatus(info, prov, instances, authTypes, p)
 	info.Status = status.Status
 	info.CredentialState = status.CredentialState
 	info.HealthState = status.HealthState
 	info.Actions = status.Actions
-	info.Connected = status.Connected
 }
 
-func (s *Server) defaultIntegrationStatus(info *integrationInfo, prov core.Provider, instances []instanceInfo, p *principal.Principal) connectionStatusInfo {
+func (s *Server) defaultIntegrationStatus(info *integrationInfo, prov core.Provider, instances []instanceInfo, authTypes []string, p *principal.Principal) connectionStatusInfo {
 	if info == nil {
 		return unknownConnectionStatus()
 	}
@@ -70,7 +69,7 @@ func (s *Server) defaultIntegrationStatus(info *integrationInfo, prov core.Provi
 		return statusFromConnectionInfo(conn)
 	}
 	if len(info.Connections) == 0 {
-		return s.implicitIntegrationStatus(info.Name, prov, instances, info.AuthTypes, p)
+		return s.implicitIntegrationStatus(info.Name, prov, instances, authTypes, p)
 	}
 	return summarizeConnectionStatuses(info.Connections)
 }
@@ -172,8 +171,8 @@ func statusFromConnectionInfo(conn *connectionDefInfo) connectionStatusInfo {
 		Actions:         cloneStatusActions(conn.Actions),
 		CredentialMode:  conn.CredentialMode,
 		OwnerKind:       conn.OwnerKind,
-		Disconnectable:  conn.Disconnectable,
-		Connected:       conn.Connected,
+		Disconnectable:  conn.disconnectable,
+		Connected:       conn.connected,
 		StatusCode:      conn.StatusCode,
 		StatusReason:    conn.StatusReason,
 	}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -60,41 +60,38 @@ type credentialFieldInfo struct {
 }
 
 type connectionDefInfo struct {
-	DisplayName      string                `json:"displayName,omitempty"`
-	Name             string                `json:"name"`
-	Mode             string                `json:"mode,omitempty"`
-	Connected        bool                  `json:"connected"`
-	Connectable      bool                  `json:"connectable"`
-	AuthTypes        []string              `json:"authTypes"`
-	CredentialFields []credentialFieldInfo `json:"credentialFields"`
-	Status           string                `json:"status"`
-	CredentialState  string                `json:"credentialState"`
-	HealthState      string                `json:"healthState"`
-	Actions          []string              `json:"actions"`
-	CredentialMode   string                `json:"credentialMode"`
-	OwnerKind        string                `json:"ownerKind"`
-	Disconnectable   bool                  `json:"disconnectable"`
-	Instances        []instanceInfo        `json:"instances"`
-	StatusCode       string                `json:"statusCode,omitempty"`
-	StatusReason     string                `json:"statusReason,omitempty"`
-}
-
-type integrationInfo struct {
-	Name             string                         `json:"name"`
 	DisplayName      string                         `json:"displayName,omitempty"`
-	Description      string                         `json:"description,omitempty"`
-	IconSVG          string                         `json:"iconSvg,omitempty"`
-	MountedPath      string                         `json:"mountedPath,omitempty"`
-	Connected        bool                           `json:"connected"`
-	Instances        []instanceInfo                 `json:"instances"`
+	Name             string                         `json:"name"`
+	Mode             string                         `json:"mode,omitempty"`
 	AuthTypes        []string                       `json:"authTypes"`
-	ConnectionParams map[string]connectionParamInfo `json:"connectionParams"`
-	Connections      []connectionDefInfo            `json:"connections"`
+	ConnectionParams map[string]connectionParamInfo `json:"connectionParams,omitempty"`
 	CredentialFields []credentialFieldInfo          `json:"credentialFields"`
 	Status           string                         `json:"status"`
 	CredentialState  string                         `json:"credentialState"`
 	HealthState      string                         `json:"healthState"`
 	Actions          []string                       `json:"actions"`
+	CredentialMode   string                         `json:"credentialMode"`
+	OwnerKind        string                         `json:"ownerKind"`
+	Instances        []instanceInfo                 `json:"instances"`
+	StatusCode       string                         `json:"statusCode,omitempty"`
+	StatusReason     string                         `json:"statusReason,omitempty"`
+
+	connected      bool
+	connectable    bool
+	disconnectable bool
+}
+
+type integrationInfo struct {
+	Name            string              `json:"name"`
+	DisplayName     string              `json:"displayName,omitempty"`
+	Description     string              `json:"description,omitempty"`
+	IconSVG         string              `json:"iconSvg,omitempty"`
+	MountedPath     string              `json:"mountedPath,omitempty"`
+	Connections     []connectionDefInfo `json:"connections"`
+	Status          string              `json:"status"`
+	CredentialState string              `json:"credentialState"`
+	HealthState     string              `json:"healthState"`
+	Actions         []string            `json:"actions"`
 }
 
 type connectionParamInfo struct {
@@ -187,19 +184,14 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			surfaceProv = override
 		}
 		info := integrationInfo{
-			Name:             name,
-			DisplayName:      surfaceProv.DisplayName(),
-			Description:      surfaceProv.Description(),
-			Connected:        false,
-			Instances:        []instanceInfo{},
-			AuthTypes:        []string{},
-			ConnectionParams: map[string]connectionParamInfo{},
-			Connections:      []connectionDefInfo{},
-			CredentialFields: []credentialFieldInfo{},
-			Status:           connectionStatusUnknown,
-			CredentialState:  credentialStateUnknown,
-			HealthState:      healthStateUnknown,
-			Actions:          []string{},
+			Name:            name,
+			DisplayName:     surfaceProv.DisplayName(),
+			Description:     surfaceProv.Description(),
+			Connections:     []connectionDefInfo{},
+			Status:          connectionStatusUnknown,
+			CredentialState: credentialStateUnknown,
+			HealthState:     healthStateUnknown,
+			Actions:         []string{},
 		}
 		if cat := surfaceProv.Catalog(); cat != nil {
 			info.IconSVG = cat.IconSVG
@@ -208,9 +200,8 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
 		}
 		instances := connected[name]
-		info.Instances = append(make([]instanceInfo, 0, len(instances)), instances...)
-		s.populateIntegrationSettings(&info, prov, instances, p)
-		s.applyIntegrationConnectionStatus(&info, prov, instances, p)
+		authTypes := s.populateIntegrationSettings(&info, prov, instances, p)
+		s.applyIntegrationConnectionStatus(&info, prov, instances, authTypes, p)
 		info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, info.MountedPath)
 		if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, surfaceProv, info) {
 			continue

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -246,7 +246,7 @@ func (s *Server) revokeAllAPITokens(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"status": "revoked", "count": count})
 }
 
-func (s *Server) connectionInfosForPlugin(integration string, plugin *config.ProviderEntry, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, p *principal.Principal) []connectionDefInfo {
+func (s *Server) connectionInfosForPlugin(integration string, plugin *config.ProviderEntry, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, defaultConnectionParams map[string]connectionParamInfo, p *principal.Principal) []connectionDefInfo {
 	if plugin == nil {
 		return []connectionDefInfo{}
 	}
@@ -268,7 +268,7 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 		if name == config.PluginConnectionName {
 			conn = displayPluginConnectionDef(plugin, manifestSpec, conn)
 		}
-		if info, ok := s.connectionInfoFromAuth(integration, name, userFacingConnectionName(name), conn, instances, integrationAuthTypes, defaultCredentialFields, name != config.PluginConnectionName, p); ok {
+		if info, ok := s.connectionInfoFromAuth(integration, name, userFacingConnectionName(name), name, conn, instances, integrationAuthTypes, defaultCredentialFields, defaultConnectionParams, name != config.PluginConnectionName, p); ok {
 			infos = append(infos, info)
 		}
 	}
@@ -306,18 +306,37 @@ func userFacingConnectionName(name string) string {
 	return name
 }
 
-func (s *Server) populateIntegrationSettings(info *integrationInfo, prov core.Provider, instances []instanceInfo, p *principal.Principal) {
+func (s *Server) populateIntegrationSettings(info *integrationInfo, prov core.Provider, instances []instanceInfo, p *principal.Principal) []string {
 	authTypes := userFacingAuthTypes(prov.AuthTypes())
 	if core.NormalizeConnectionMode(prov.ConnectionMode()) == core.ConnectionModePlatform {
 		authTypes = nil
 	}
-	info.ConnectionParams = connectionParamInfosFromProvider(prov)
-	info.CredentialFields = credentialFieldInfosFromProvider(prov, authTypes)
-	info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, authTypes, info.CredentialFields, p)
-	info.AuthTypes = resolvedIntegrationAuthTypes(prov, authTypes, info.Connections)
-	if len(authTypes) == 0 && len(info.AuthTypes) > 0 {
-		info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, info.AuthTypes, info.CredentialFields, p)
+	defaultConnectionParams := connectionParamInfosFromProvider(prov)
+	defaultCredentialFields := credentialFieldInfosFromProvider(prov, authTypes)
+	info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, authTypes, defaultCredentialFields, defaultConnectionParams, p)
+	resolvedAuthTypes := resolvedIntegrationAuthTypes(prov, authTypes, info.Connections)
+	if len(authTypes) == 0 && len(resolvedAuthTypes) > 0 {
+		info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], instances, resolvedAuthTypes, defaultCredentialFields, defaultConnectionParams, p)
 	}
+	if len(info.Connections) == 0 && shouldExposeProviderConnectionFallback(prov, resolvedAuthTypes, defaultCredentialFields, defaultConnectionParams) {
+		if fallback, ok := s.providerConnectionInfo(info.Name, prov, instances, resolvedAuthTypes, defaultCredentialFields, defaultConnectionParams, p); ok {
+			info.Connections = []connectionDefInfo{fallback}
+		}
+	}
+	return resolvedIntegrationAuthTypes(prov, resolvedAuthTypes, info.Connections)
+}
+
+func shouldExposeProviderConnectionFallback(prov core.Provider, authTypes []string, credentialFields []credentialFieldInfo, connectionParams map[string]connectionParamInfo) bool {
+	if prov == nil {
+		return false
+	}
+	switch core.NormalizeConnectionMode(prov.ConnectionMode()) {
+	case core.ConnectionModeNone:
+		return false
+	case core.ConnectionModePlatform:
+		return true
+	}
+	return len(authTypes) > 0 || len(credentialFields) > 0 || len(connectionParams) > 0
 }
 
 func credentialFieldInfosFromProvider(prov core.Provider, authTypes []string) []credentialFieldInfo {
@@ -353,6 +372,24 @@ func connectionParamInfosFromProvider(prov core.Provider) map[string]connectionP
 	return infos
 }
 
+func connectionParamInfosFromConnection(conn config.ConnectionDef) map[string]connectionParamInfo {
+	if len(conn.ConnectionParams) == 0 {
+		return map[string]connectionParamInfo{}
+	}
+	infos := make(map[string]connectionParamInfo, len(conn.ConnectionParams))
+	for name, def := range conn.ConnectionParams {
+		if def.From != "" {
+			continue
+		}
+		infos[name] = connectionParamInfo{
+			Required:    def.Required,
+			Description: def.Description,
+			Default:     def.Default,
+		}
+	}
+	return infos
+}
+
 func credentialFieldInfos[T any](fields []T, mapField func(T) credentialFieldInfo) []credentialFieldInfo {
 	if len(fields) == 0 {
 		return []credentialFieldInfo{}
@@ -364,18 +401,28 @@ func credentialFieldInfos[T any](fields []T, mapField func(T) credentialFieldInf
 	return infos
 }
 
-func (s *Server) connectionInfoFromAuth(integration, internalName, name string, conn config.ConnectionDef, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, includeWithoutAuth bool, p *principal.Principal) (connectionDefInfo, bool) {
+func (s *Server) providerConnectionInfo(integration string, prov core.Provider, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, defaultConnectionParams map[string]connectionParamInfo, p *principal.Principal) (connectionDefInfo, bool) {
+	conn := config.ConnectionDef{
+		Mode: providermanifestv1.ConnectionMode(core.NormalizeConnectionMode(prov.ConnectionMode())),
+	}
+	return s.connectionInfoFromAuth(integration, config.PluginConnectionName, config.PluginConnectionAlias, "", conn, instances, integrationAuthTypes, defaultCredentialFields, defaultConnectionParams, true, p)
+}
+
+func (s *Server) connectionInfoFromAuth(integration, internalName, name, instanceConnection string, conn config.ConnectionDef, instances []instanceInfo, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, defaultConnectionParams map[string]connectionParamInfo, includeWithoutAuth bool, p *principal.Principal) (connectionDefInfo, bool) {
 	mode := config.ConnectionModeForConnection(conn)
-	connectionInstances := groupInstancesForConnection(instances, name)
+	connectionInstances := groupInstancesForConnection(instances, instanceConnection)
+	connectionParams := connectionParamInfosFromConnection(conn)
+	if len(connectionParams) == 0 && config.ResolveConnectionAlias(name) == config.PluginConnectionName {
+		connectionParams = cloneConnectionParamInfos(defaultConnectionParams)
+	}
 	if mode == core.ConnectionModePlatform {
 		status := s.platformConnectionStatus(integration, internalName, conn)
 		return connectionDefInfo{
 			DisplayName:      connectionDisplayName(name, conn.DisplayName),
 			Name:             name,
 			Mode:             string(mode),
-			Connected:        status.Connected,
-			Connectable:      false,
 			AuthTypes:        []string{},
+			ConnectionParams: connectionParams,
 			CredentialFields: []credentialFieldInfo{},
 			Status:           status.Status,
 			CredentialState:  status.CredentialState,
@@ -383,10 +430,12 @@ func (s *Server) connectionInfoFromAuth(integration, internalName, name string, 
 			Actions:          status.Actions,
 			CredentialMode:   status.CredentialMode,
 			OwnerKind:        status.OwnerKind,
-			Disconnectable:   status.Disconnectable,
 			Instances:        []instanceInfo{},
 			StatusCode:       status.StatusCode,
 			StatusReason:     status.StatusReason,
+			connected:        status.Connected,
+			connectable:      false,
+			disconnectable:   status.Disconnectable,
 		}, true
 	}
 	authTypes := connectionAuthTypes(conn.Auth, integrationAuthTypes)
@@ -407,9 +456,8 @@ func (s *Server) connectionInfoFromAuth(integration, internalName, name string, 
 		DisplayName:      connectionDisplayName(name, conn.DisplayName),
 		Name:             name,
 		Mode:             string(displayMode),
-		Connected:        status.Connected,
-		Connectable:      len(authTypes) > 0,
 		AuthTypes:        []string{},
+		ConnectionParams: connectionParams,
 		CredentialFields: []credentialFieldInfo{},
 		Status:           status.Status,
 		CredentialState:  status.CredentialState,
@@ -417,10 +465,12 @@ func (s *Server) connectionInfoFromAuth(integration, internalName, name string, 
 		Actions:          status.Actions,
 		CredentialMode:   status.CredentialMode,
 		OwnerKind:        status.OwnerKind,
-		Disconnectable:   status.Disconnectable,
 		Instances:        connectionInstances,
 		StatusCode:       status.StatusCode,
 		StatusReason:     status.StatusReason,
+		connected:        status.Connected,
+		connectable:      len(authTypes) > 0,
+		disconnectable:   status.Disconnectable,
 	}
 	if len(authTypes) > 0 {
 		info.AuthTypes = authTypes
@@ -439,6 +489,17 @@ func (s *Server) connectionInfoFromAuth(integration, internalName, name string, 
 		info.CredentialFields = defaultManualCredentialFieldInfos()
 	}
 	return info, true
+}
+
+func cloneConnectionParamInfos(params map[string]connectionParamInfo) map[string]connectionParamInfo {
+	if len(params) == 0 {
+		return map[string]connectionParamInfo{}
+	}
+	out := make(map[string]connectionParamInfo, len(params))
+	for key, value := range params {
+		out[key] = value
+	}
+	return out
 }
 
 func (s *Server) hasConfiguredPlatformConnection(integration string) bool {

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -23,7 +23,10 @@ func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info inte
 	if principal.IsNonUserPrincipal(p) {
 		return false
 	}
-	return info.Connected || len(info.AuthTypes) > 0 || len(info.Connections) > 0
+	return info.CredentialState == credentialStateConnected ||
+		info.CredentialState == credentialStateConfigured ||
+		info.CredentialState == credentialStateNotRequired ||
+		len(info.Connections) > 0
 }
 
 func (s *Server) integrationHasVisibleHTTPOperationsContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider) bool {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -5113,7 +5113,6 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 	}
 	var integrations []struct {
 		Name            string `json:"name"`
-		Connected       bool   `json:"connected"`
 		Status          string `json:"status"`
 		CredentialState string `json:"credentialState"`
 	}
@@ -5124,7 +5123,6 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 	_ = resp.Body.Close()
 	var manualIntegration *struct {
 		Name            string `json:"name"`
-		Connected       bool   `json:"connected"`
 		Status          string `json:"status"`
 		CredentialState string `json:"credentialState"`
 	}
@@ -5137,7 +5135,7 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 	if manualIntegration == nil {
 		t.Fatalf("manual-svc missing from managed subject integrations: %+v", integrations)
 	}
-	if !manualIntegration.Connected || manualIntegration.Status != "ready" || manualIntegration.CredentialState != "connected" {
+	if manualIntegration.Status != "ready" || manualIntegration.CredentialState != "connected" {
 		t.Fatalf("manual-svc status = %+v, want connected ready", *manualIntegration)
 	}
 
@@ -8520,10 +8518,11 @@ func TestListIntegrations(t *testing.T) {
 	}
 
 	var integrations []struct {
-		Name        string `json:"name"`
-		DisplayName string `json:"displayName"`
-		Description string `json:"description"`
-		Connected   bool   `json:"connected"`
+		Name            string `json:"name"`
+		DisplayName     string `json:"displayName"`
+		Description     string `json:"description"`
+		Status          string `json:"status"`
+		CredentialState string `json:"credentialState"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
@@ -8537,8 +8536,8 @@ func TestListIntegrations(t *testing.T) {
 	if integrations[0].DisplayName != "Slack" {
 		t.Fatalf("expected display name Slack, got %q", integrations[0].DisplayName)
 	}
-	if integrations[0].Connected {
-		t.Fatal("expected connected=false when no tokens stored")
+	if integrations[0].Status != "needs_user_connection" || integrations[0].CredentialState != "missing" {
+		t.Fatalf("status = {%q, %q}, want needs_user_connection/missing", integrations[0].Status, integrations[0].CredentialState)
 	}
 }
 
@@ -8920,13 +8919,13 @@ func TestSubjectAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t 
 	}
 
 	var integrations []struct {
-		Name             string                    `json:"name"`
-		Connected        bool                      `json:"connected"`
-		Instances        []map[string]any          `json:"instances"`
-		AuthTypes        []string                  `json:"authTypes"`
-		Connections      []map[string]any          `json:"connections"`
-		CredentialFields []map[string]any          `json:"credentialFields"`
-		ConnectionParams map[string]map[string]any `json:"connectionParams"`
+		Name            string `json:"name"`
+		Status          string `json:"status"`
+		CredentialState string `json:"credentialState"`
+		Connections     []struct {
+			Name      string           `json:"name"`
+			Instances []map[string]any `json:"instances"`
+		} `json:"connections"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
@@ -8936,28 +8935,25 @@ func TestSubjectAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t 
 	}
 
 	got := map[string]struct {
-		Connected        bool
-		Instances        []map[string]any
-		AuthTypes        []string
-		Connections      []map[string]any
-		CredentialFields []map[string]any
-		ConnectionParams map[string]map[string]any
+		Status          string
+		CredentialState string
+		Connections     []struct {
+			Name      string           `json:"name"`
+			Instances []map[string]any `json:"instances"`
+		}
 	}{}
 	for _, integration := range integrations {
 		got[integration.Name] = struct {
-			Connected        bool
-			Instances        []map[string]any
-			AuthTypes        []string
-			Connections      []map[string]any
-			CredentialFields []map[string]any
-			ConnectionParams map[string]map[string]any
+			Status          string
+			CredentialState string
+			Connections     []struct {
+				Name      string           `json:"name"`
+				Instances []map[string]any `json:"instances"`
+			}
 		}{
-			Connected:        integration.Connected,
-			Instances:        integration.Instances,
-			AuthTypes:        integration.AuthTypes,
-			Connections:      integration.Connections,
-			CredentialFields: integration.CredentialFields,
-			ConnectionParams: integration.ConnectionParams,
+			Status:          integration.Status,
+			CredentialState: integration.CredentialState,
+			Connections:     integration.Connections,
 		}
 	}
 	if _, ok := got["secret"]; ok {
@@ -8966,14 +8962,18 @@ func TestSubjectAuthorization_ListIntegrationsUsesSubjectPolicyAndCredentials(t 
 	if _, ok := got["mcp-only"]; ok {
 		t.Fatalf("mcp-only integration should not be visible over HTTP: %+v", integrations)
 	}
-	if !got["svc"].Connected {
+	if got["svc"].Status != "ready" || got["svc"].CredentialState != "connected" {
 		t.Fatalf("expected service account integration to be connected, got %+v", got["svc"])
 	}
-	if !got["weather"].Connected {
+	if got["weather"].Status != "ready" || got["weather"].CredentialState != "not_required" {
 		t.Fatalf("expected connection-mode none integration to be connected, got %+v", got["weather"])
 	}
-	if len(got["svc"].Instances) != 1 {
-		t.Fatalf("expected service-account-owned svc instance to be listed, got %+v", got["svc"].Instances)
+	var svcInstances []map[string]any
+	for _, conn := range got["svc"].Connections {
+		svcInstances = append(svcInstances, conn.Instances...)
+	}
+	if len(svcInstances) != 1 {
+		t.Fatalf("expected service-account-owned svc instance to be listed, got %+v", got["svc"])
 	}
 
 	provider := svc.ExternalCredentials.(*coretesting.StubExternalCredentialProvider)
@@ -9155,8 +9155,9 @@ func TestListIntegrationsShowsConnected(t *testing.T) {
 	}
 
 	var integrations []struct {
-		Name      string `json:"name"`
-		Connected bool   `json:"connected"`
+		Name            string `json:"name"`
+		Status          string `json:"status"`
+		CredentialState string `json:"credentialState"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
@@ -9164,8 +9165,8 @@ func TestListIntegrationsShowsConnected(t *testing.T) {
 	if len(integrations) != 1 {
 		t.Fatalf("expected 1 integration, got %d", len(integrations))
 	}
-	if !integrations[0].Connected {
-		t.Fatal("expected connected=true when token exists")
+	if integrations[0].Status != "ready" || integrations[0].CredentialState != "connected" {
+		t.Fatalf("status = {%q, %q}, want ready/connected", integrations[0].Status, integrations[0].CredentialState)
 	}
 }
 
@@ -9244,15 +9245,12 @@ func TestListIntegrations_ConnectionStatusContract(t *testing.T) {
 	type statusConnection struct {
 		Name             string           `json:"name"`
 		Mode             string           `json:"mode"`
-		Connected        bool             `json:"connected"`
-		Connectable      bool             `json:"connectable"`
 		Status           string           `json:"status"`
 		CredentialState  string           `json:"credentialState"`
 		HealthState      string           `json:"healthState"`
 		Actions          []string         `json:"actions"`
 		CredentialMode   string           `json:"credentialMode"`
 		OwnerKind        string           `json:"ownerKind"`
-		Disconnectable   bool             `json:"disconnectable"`
 		Instances        []map[string]any `json:"instances"`
 		StatusCode       string           `json:"statusCode"`
 		StatusReason     string           `json:"statusReason"`
@@ -9260,17 +9258,12 @@ func TestListIntegrations_ConnectionStatusContract(t *testing.T) {
 		CredentialFields []map[string]any `json:"credentialFields"`
 	}
 	type statusIntegration struct {
-		Name             string                    `json:"name"`
-		Connected        bool                      `json:"connected"`
-		Instances        []map[string]any          `json:"instances"`
-		AuthTypes        []string                  `json:"authTypes"`
-		ConnectionParams map[string]map[string]any `json:"connectionParams"`
-		Connections      []statusConnection        `json:"connections"`
-		CredentialFields []map[string]any          `json:"credentialFields"`
-		Status           string                    `json:"status"`
-		CredentialState  string                    `json:"credentialState"`
-		HealthState      string                    `json:"healthState"`
-		Actions          []string                  `json:"actions"`
+		Name            string             `json:"name"`
+		Connections     []statusConnection `json:"connections"`
+		Status          string             `json:"status"`
+		CredentialState string             `json:"credentialState"`
+		HealthState     string             `json:"healthState"`
+		Actions         []string           `json:"actions"`
 	}
 	var integrations []statusIntegration
 	if err := json.Unmarshal(body, &integrations); err != nil {
@@ -9279,37 +9272,33 @@ func TestListIntegrations_ConnectionStatusContract(t *testing.T) {
 	got := make(map[string]statusIntegration, len(integrations))
 	for _, integration := range integrations {
 		got[integration.Name] = integration
-		credentialPresent := integration.CredentialState == "not_required" || integration.CredentialState == "connected" || integration.CredentialState == "configured"
-		if integration.Connected != credentialPresent {
-			t.Fatalf("%s legacy connected=%v status=%q violates compatibility invariant", integration.Name, integration.Connected, integration.Status)
-		}
-		if integration.Instances == nil || integration.AuthTypes == nil || integration.ConnectionParams == nil || integration.Connections == nil || integration.CredentialFields == nil {
-			t.Fatalf("%s legacy collections must stay non-nil: %+v", integration.Name, integration)
+		if integration.Connections == nil {
+			t.Fatalf("%s connections must stay non-nil: %+v", integration.Name, integration)
 		}
 	}
 
-	assertIntegrationStatus := func(name, status, credentialState, healthState string, connected bool, actions []string) statusIntegration {
+	assertIntegrationStatus := func(name, status, credentialState, healthState string, actions []string) statusIntegration {
 		t.Helper()
 		integration, ok := got[name]
 		if !ok {
 			t.Fatalf("integration %q missing from response: %s", name, body)
 		}
-		if integration.Status != status || integration.CredentialState != credentialState || integration.HealthState != healthState || integration.Connected != connected || !reflect.DeepEqual(integration.Actions, actions) {
-			t.Fatalf("%s status = {status:%q credential:%q health:%q connected:%v actions:%v}, want {%q %q %q %v %v}",
-				name, integration.Status, integration.CredentialState, integration.HealthState, integration.Connected, integration.Actions,
-				status, credentialState, healthState, connected, actions)
+		if integration.Status != status || integration.CredentialState != credentialState || integration.HealthState != healthState || !reflect.DeepEqual(integration.Actions, actions) {
+			t.Fatalf("%s status = {status:%q credential:%q health:%q actions:%v}, want {%q %q %q %v}",
+				name, integration.Status, integration.CredentialState, integration.HealthState, integration.Actions,
+				status, credentialState, healthState, actions)
 		}
 		return integration
 	}
 
-	assertIntegrationStatus("no-auth", "ready", "not_required", "not_applicable", true, []string{})
-	assertIntegrationStatus("manual-disconnected", "needs_user_connection", "missing", "not_applicable", false, []string{"connect"})
-	assertIntegrationStatus("manual-connected", "ready", "connected", "not_checked", true, []string{"disconnect", "add_instance"})
-	assertIntegrationStatus("manual-multi", "needs_instance_selection", "connected", "not_checked", true, []string{"select_instance", "disconnect", "add_instance"})
+	assertIntegrationStatus("no-auth", "ready", "not_required", "not_applicable", []string{})
+	assertIntegrationStatus("manual-disconnected", "needs_user_connection", "missing", "not_applicable", []string{"connect"})
+	assertIntegrationStatus("manual-connected", "ready", "connected", "not_checked", []string{"disconnect", "add_instance"})
+	assertIntegrationStatus("manual-multi", "needs_instance_selection", "connected", "not_checked", []string{"select_instance", "disconnect", "add_instance"})
 
-	platformBearer := assertIntegrationStatus("platform-bearer", "ready", "configured", "not_checked", true, []string{})
-	platformManual := assertIntegrationStatus("platform-manual", "ready", "configured", "not_checked", true, []string{})
-	platformMissing := assertIntegrationStatus("platform-missing", "needs_admin_configuration", "missing", "unknown", false, []string{"admin_configure"})
+	platformBearer := assertIntegrationStatus("platform-bearer", "ready", "configured", "not_checked", []string{})
+	platformManual := assertIntegrationStatus("platform-manual", "ready", "configured", "not_checked", []string{})
+	platformMissing := assertIntegrationStatus("platform-missing", "needs_admin_configuration", "missing", "unknown", []string{"admin_configure"})
 
 	for _, tc := range []struct {
 		name        string
@@ -9328,7 +9317,7 @@ func TestListIntegrations_ConnectionStatusContract(t *testing.T) {
 				t.Fatalf("connections = %+v, want one platform connection", tc.integration.Connections)
 			}
 			conn := tc.integration.Connections[0]
-			if conn.Mode != string(core.ConnectionModePlatform) || conn.CredentialMode != "platform" || conn.OwnerKind != "platform" || conn.Connectable || conn.Disconnectable {
+			if conn.Mode != string(core.ConnectionModePlatform) || conn.CredentialMode != "platform" || conn.OwnerKind != "platform" {
 				t.Fatalf("platform connection fields = %+v", conn)
 			}
 			if conn.Status != tc.wantStatus {
@@ -9373,8 +9362,10 @@ func TestListIntegrations_AuthTypes(t *testing.T) {
 	}
 
 	var integrations []struct {
-		Name      string   `json:"name"`
-		AuthTypes []string `json:"authTypes"`
+		Name        string `json:"name"`
+		Connections []struct {
+			AuthTypes []string `json:"authTypes"`
+		} `json:"connections"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
@@ -9385,7 +9376,9 @@ func TestListIntegrations_AuthTypes(t *testing.T) {
 
 	authTypes := make(map[string][]string)
 	for _, i := range integrations {
-		authTypes[i.Name] = i.AuthTypes
+		if len(i.Connections) > 0 {
+			authTypes[i.Name] = i.Connections[0].AuthTypes
+		}
 	}
 	if len(authTypes["manual-svc"]) != 1 || authTypes["manual-svc"][0] != "manual" {
 		t.Fatalf("expected manual-svc auth_types=[manual], got %v", authTypes["manual-svc"])
@@ -9444,8 +9437,10 @@ func TestListIntegrations_DerivesAuthTypesFromConnectionsWhenProviderOmitsThem(t
 	}
 
 	var integrations []struct {
-		Name      string   `json:"name"`
-		AuthTypes []string `json:"authTypes"`
+		Name        string `json:"name"`
+		Connections []struct {
+			AuthTypes []string `json:"authTypes"`
+		} `json:"connections"`
 	}
 	if err := json.Unmarshal(body, &integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
@@ -9453,8 +9448,13 @@ func TestListIntegrations_DerivesAuthTypesFromConnectionsWhenProviderOmitsThem(t
 	if len(integrations) != 1 {
 		t.Fatalf("expected 1 integration, got %d", len(integrations))
 	}
-	if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"manual"}) {
-		t.Fatalf("auth types = %v, want [manual]", integrations[0].AuthTypes)
+	if len(integrations[0].Connections) == 0 {
+		t.Fatalf("connections = %+v, want manual connection metadata", integrations[0].Connections)
+	}
+	for _, conn := range integrations[0].Connections {
+		if !reflect.DeepEqual(conn.AuthTypes, []string{"manual"}) {
+			t.Fatalf("connection auth types = %+v, want [manual]", conn)
+		}
 	}
 	if strings.Contains(text, `"authTypes":null`) {
 		t.Fatalf("unexpected null authTypes in response: %s", text)
@@ -9511,7 +9511,6 @@ func TestListIntegrations_ShowsCredentialedConnectionsInUserFacingMetadata(t *te
 
 	var integrations []struct {
 		Name        string `json:"name"`
-		AuthTypes   []string
 		Connections []struct {
 			Name      string   `json:"name"`
 			AuthTypes []string `json:"authTypes"`
@@ -9522,9 +9521,6 @@ func TestListIntegrations_ShowsCredentialedConnectionsInUserFacingMetadata(t *te
 	}
 	if len(integrations) != 1 {
 		t.Fatalf("expected 1 integration, got %d", len(integrations))
-	}
-	if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"manual"}) {
-		t.Fatalf("auth types = %v, want [manual]", integrations[0].AuthTypes)
 	}
 	if len(integrations[0].Connections) != 2 {
 		t.Fatalf("connections = %+v, want plugin and default user-facing connections", integrations[0].Connections)
@@ -9575,10 +9571,8 @@ func TestListIntegrations_ManualProvidersWithoutDeclaredCredentialsExposeGeneric
 		Description string `json:"description"`
 	}
 	var integrations []struct {
-		Name             string            `json:"name"`
-		AuthTypes        []string          `json:"authTypes"`
-		CredentialFields []credentialField `json:"credentialFields"`
-		Connections      []struct {
+		Name        string `json:"name"`
+		Connections []struct {
 			Name             string            `json:"name"`
 			AuthTypes        []string          `json:"authTypes"`
 			CredentialFields []credentialField `json:"credentialFields"`
@@ -9592,12 +9586,6 @@ func TestListIntegrations_ManualProvidersWithoutDeclaredCredentialsExposeGeneric
 	}
 
 	wantFields := []credentialField{{Name: "credential", Label: "Credential"}}
-	if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"manual"}) {
-		t.Fatalf("auth types = %v, want [manual]", integrations[0].AuthTypes)
-	}
-	if !reflect.DeepEqual(integrations[0].CredentialFields, wantFields) {
-		t.Fatalf("credential fields = %+v, want %+v", integrations[0].CredentialFields, wantFields)
-	}
 	if len(integrations[0].Connections) != 1 {
 		t.Fatalf("connections = %+v, want one default connection", integrations[0].Connections)
 	}
@@ -9634,6 +9622,9 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 							{Name: "workspace_token", Label: "Workspace Config Token"},
 							{Name: "workspace_local_only", Label: "Workspace Local Only", Description: "Workspace Local Only Description"},
 						},
+					},
+					ConnectionParams: map[string]config.ConnectionParamDef{
+						"region": {Required: true, Description: "Workspace region", Default: "us-east"},
 					},
 				},
 			},
@@ -9691,7 +9682,6 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		text := string(body)
 		for _, fragment := range []string{
 			`"instances":[]`,
-			`"connectionParams":{}`,
 			`"connections":[`,
 			`"credentialFields":[`,
 		} {
@@ -9715,20 +9705,22 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 			Label       string `json:"label"`
 			Description string `json:"description"`
 		}
+		type connectionParam struct {
+			Required    bool   `json:"required"`
+			Description string `json:"description"`
+			Default     string `json:"default"`
+		}
 		type connectionInfo struct {
-			DisplayName      string            `json:"displayName"`
-			Name             string            `json:"name"`
-			AuthTypes        []string          `json:"authTypes"`
-			CredentialFields []credentialField `json:"credentialFields"`
+			DisplayName      string                     `json:"displayName"`
+			Name             string                     `json:"name"`
+			AuthTypes        []string                   `json:"authTypes"`
+			CredentialFields []credentialField          `json:"credentialFields"`
+			ConnectionParams map[string]connectionParam `json:"connectionParams"`
 		}
 
 		var integrations []struct {
-			Name             string           `json:"name"`
-			AuthTypes        []string         `json:"authTypes"`
-			Instances        []map[string]any `json:"instances"`
-			ConnectionParams map[string]any   `json:"connectionParams"`
-			CredentialFields []map[string]any `json:"credentialFields"`
-			Connections      []connectionInfo `json:"connections"`
+			Name        string           `json:"name"`
+			Connections []connectionInfo `json:"connections"`
 		}
 		if err := json.Unmarshal(body, &integrations); err != nil {
 			t.Fatalf("decoding: %v", err)
@@ -9736,8 +9728,8 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		if len(integrations) != 1 {
 			t.Fatalf("expected 1 integration, got %d", len(integrations))
 		}
-		if integrations[0].Instances == nil || integrations[0].ConnectionParams == nil || integrations[0].CredentialFields == nil || integrations[0].Connections == nil {
-			t.Fatalf("expected non-nil collections, got %+v", integrations[0])
+		if integrations[0].Connections == nil {
+			t.Fatalf("expected non-nil connections, got %+v", integrations[0])
 		}
 
 		got := make(map[string]connectionInfo, len(integrations[0].Connections))
@@ -9761,6 +9753,11 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 			{Name: "workspace_local_only", Label: "Workspace Local Only", Description: "Workspace Local Only Description"},
 		}) {
 			t.Fatalf("workspace connection info = %+v", got["workspace"])
+		}
+		if !reflect.DeepEqual(got["workspace"].ConnectionParams, map[string]connectionParam{
+			"region": {Required: true, Description: "Workspace region", Default: "us-east"},
+		}) {
+			t.Fatalf("workspace connection params = %+v", got["workspace"].ConnectionParams)
 		}
 	})
 
@@ -9900,14 +9897,12 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 			Default     string `json:"default"`
 		}
 		var integrations []struct {
-			Name             string                     `json:"name"`
-			AuthTypes        []string                   `json:"authTypes"`
-			CredentialFields []credentialField          `json:"credentialFields"`
-			ConnectionParams map[string]connectionParam `json:"connectionParams"`
-			Connections      []struct {
-				Name             string            `json:"name"`
-				AuthTypes        []string          `json:"authTypes"`
-				CredentialFields []credentialField `json:"credentialFields"`
+			Name        string `json:"name"`
+			Connections []struct {
+				Name             string                     `json:"name"`
+				AuthTypes        []string                   `json:"authTypes"`
+				CredentialFields []credentialField          `json:"credentialFields"`
+				ConnectionParams map[string]connectionParam `json:"connectionParams"`
 			} `json:"connections"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
@@ -9918,21 +9913,6 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		}
 
 		wantFields := []credentialField{{Name: "api_key", Label: "API Key", Description: "Docs API key"}}
-		if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"manual"}) {
-			t.Fatalf("auth types = %v, want [manual]", integrations[0].AuthTypes)
-		}
-		if !reflect.DeepEqual(integrations[0].CredentialFields, wantFields) {
-			t.Fatalf("credential fields = %+v, want %+v", integrations[0].CredentialFields, wantFields)
-		}
-		if !reflect.DeepEqual(integrations[0].ConnectionParams, map[string]connectionParam{
-			"tenant": {
-				Required:    true,
-				Description: "Tenant slug",
-				Default:     "acme",
-			},
-		}) {
-			t.Fatalf("connection params = %+v", integrations[0].ConnectionParams)
-		}
 		if len(integrations[0].Connections) != 1 {
 			t.Fatalf("connections = %+v, want one default connection", integrations[0].Connections)
 		}
@@ -9944,6 +9924,15 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		}
 		if !reflect.DeepEqual(integrations[0].Connections[0].CredentialFields, wantFields) {
 			t.Fatalf("connection credential fields = %+v, want %+v", integrations[0].Connections[0].CredentialFields, wantFields)
+		}
+		if !reflect.DeepEqual(integrations[0].Connections[0].ConnectionParams, map[string]connectionParam{
+			"tenant": {
+				Required:    true,
+				Description: "Tenant slug",
+				Default:     "acme",
+			},
+		}) {
+			t.Fatalf("connection params = %+v", integrations[0].Connections[0].ConnectionParams)
 		}
 	})
 
@@ -9990,8 +9979,7 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		defer func() { _ = resp.Body.Close() }()
 
 		var integrations []struct {
-			Name        string   `json:"name"`
-			AuthTypes   []string `json:"authTypes"`
+			Name        string `json:"name"`
 			Connections []struct {
 				Name      string   `json:"name"`
 				AuthTypes []string `json:"authTypes"`
@@ -10002,9 +9990,6 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		}
 		if len(integrations) != 1 {
 			t.Fatalf("expected 1 integration, got %d", len(integrations))
-		}
-		if len(integrations[0].AuthTypes) != 0 {
-			t.Fatalf("expected no auth types, got %+v", integrations[0].AuthTypes)
 		}
 		if len(integrations[0].Connections) != 0 {
 			t.Fatalf("expected no connectable connections, got %+v", integrations[0].Connections)
@@ -10055,8 +10040,7 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		defer func() { _ = resp.Body.Close() }()
 
 		var integrations []struct {
-			Name        string   `json:"name"`
-			AuthTypes   []string `json:"authTypes"`
+			Name        string `json:"name"`
 			Connections []struct {
 				Name        string   `json:"name"`
 				DisplayName string   `json:"displayName"`
@@ -10068,9 +10052,6 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		}
 		if len(integrations) != 1 {
 			t.Fatalf("expected 1 integration, got %d", len(integrations))
-		}
-		if len(integrations[0].AuthTypes) != 0 {
-			t.Fatalf("expected no top-level auth types, got %+v", integrations[0].AuthTypes)
 		}
 		if len(integrations[0].Connections) != 1 {
 			t.Fatalf("expected one explicit no-auth connection, got %+v", integrations[0].Connections)
@@ -10125,8 +10106,7 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		defer func() { _ = resp.Body.Close() }()
 
 		var integrations []struct {
-			Name        string   `json:"name"`
-			AuthTypes   []string `json:"authTypes"`
+			Name        string `json:"name"`
 			Connections []struct {
 				Name string `json:"name"`
 			} `json:"connections"`
@@ -10136,9 +10116,6 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		}
 		if len(integrations) != 1 {
 			t.Fatalf("expected 1 integration, got %d", len(integrations))
-		}
-		if len(integrations[0].AuthTypes) != 0 {
-			t.Fatalf("expected no top-level auth types, got %+v", integrations[0].AuthTypes)
 		}
 		if len(integrations[0].Connections) != 0 {
 			t.Fatalf("expected passive default connection to stay hidden, got %+v", integrations[0].Connections)
@@ -10499,8 +10476,9 @@ func TestListIntegrations_ShowsConnectedStatus(t *testing.T) {
 	}
 
 	var integrations []struct {
-		Name      string `json:"name"`
-		Connected bool   `json:"connected"`
+		Name            string `json:"name"`
+		Status          string `json:"status"`
+		CredentialState string `json:"credentialState"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
@@ -10509,15 +10487,21 @@ func TestListIntegrations_ShowsConnectedStatus(t *testing.T) {
 		t.Fatalf("expected 2 integrations, got %d", len(integrations))
 	}
 
-	connected := make(map[string]bool)
+	states := make(map[string]struct {
+		Status          string
+		CredentialState string
+	})
 	for _, i := range integrations {
-		connected[i.Name] = i.Connected
+		states[i.Name] = struct {
+			Status          string
+			CredentialState string
+		}{Status: i.Status, CredentialState: i.CredentialState}
 	}
-	if !connected["slack"] {
-		t.Fatal("expected slack to be connected")
+	if states["slack"].Status != "ready" || states["slack"].CredentialState != "connected" {
+		t.Fatalf("expected slack to be connected, got %+v", states["slack"])
 	}
-	if connected["github"] {
-		t.Fatal("expected github to be disconnected")
+	if states["github"].Status != "needs_user_connection" || states["github"].CredentialState != "missing" {
+		t.Fatalf("expected github to be disconnected, got %+v", states["github"])
 	}
 }
 
@@ -12672,32 +12656,36 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 		t.Fatalf("integrations status = %d: %s", integrationsResp.StatusCode, payload)
 	}
 	var integrations []struct {
-		Name        string `json:"name"`
-		Connected   bool   `json:"connected"`
-		Connections []struct {
-			Name        string   `json:"name"`
-			Mode        string   `json:"mode"`
-			Connected   bool     `json:"connected"`
-			Connectable bool     `json:"connectable"`
-			AuthTypes   []string `json:"authTypes"`
+		Name            string `json:"name"`
+		Status          string `json:"status"`
+		CredentialState string `json:"credentialState"`
+		Connections     []struct {
+			Name            string   `json:"name"`
+			Mode            string   `json:"mode"`
+			Status          string   `json:"status"`
+			CredentialState string   `json:"credentialState"`
+			Actions         []string `json:"actions"`
+			AuthTypes       []string `json:"authTypes"`
 		} `json:"connections"`
 	}
 	if err := json.NewDecoder(integrationsResp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decode integrations: %v", err)
 	}
 	var defaultConnection *struct {
-		Name        string   `json:"name"`
-		Mode        string   `json:"mode"`
-		Connected   bool     `json:"connected"`
-		Connectable bool     `json:"connectable"`
-		AuthTypes   []string `json:"authTypes"`
+		Name            string   `json:"name"`
+		Mode            string   `json:"mode"`
+		Status          string   `json:"status"`
+		CredentialState string   `json:"credentialState"`
+		Actions         []string `json:"actions"`
+		AuthTypes       []string `json:"authTypes"`
 	}
-	slackConnected := false
+	var slackStatus, slackCredentialState string
 	for i := range integrations {
 		if integrations[i].Name != "slack" {
 			continue
 		}
-		slackConnected = integrations[i].Connected
+		slackStatus = integrations[i].Status
+		slackCredentialState = integrations[i].CredentialState
 		for j := range integrations[i].Connections {
 			if integrations[i].Connections[j].Name == "default" {
 				defaultConnection = &integrations[i].Connections[j]
@@ -12710,10 +12698,10 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 	if defaultConnection == nil {
 		t.Fatal("default connection missing from integrations response")
 	}
-	if !slackConnected {
-		t.Fatal("slack integration connected = false, want true when the user connection is connected")
+	if slackStatus != "ready" || slackCredentialState != "connected" {
+		t.Fatalf("slack status = {%q, %q}, want ready/connected", slackStatus, slackCredentialState)
 	}
-	if defaultConnection.Mode != "user" || !defaultConnection.Connected || !defaultConnection.Connectable {
+	if defaultConnection.Mode != "user" || defaultConnection.Status != "ready" || defaultConnection.CredentialState != "connected" || !reflect.DeepEqual(defaultConnection.Actions, []string{"disconnect", "add_instance"}) {
 		t.Fatalf("default connection metadata = %+v, want connected user connection", *defaultConnection)
 	}
 	for _, tc := range []struct {

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -411,6 +411,9 @@
         "description": {
           "type": "string"
         },
+        "default": {
+          "type": "string"
+        },
         "from": {
           "type": "string",
           "enum": [

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -347,6 +347,7 @@ type ProviderDiscovery struct {
 type ProviderConnectionParam struct {
 	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Default     string `json:"default,omitempty" yaml:"default,omitempty"`
 	From        string `json:"from,omitempty" yaml:"from,omitempty"`
 	Field       string `json:"field,omitempty" yaml:"field,omitempty"`
 }

--- a/gestaltd/services/plugins/manifest_core.go
+++ b/gestaltd/services/plugins/manifest_core.go
@@ -16,6 +16,7 @@ func ConnectionParamDefsFromManifest(defs map[string]providermanifestv1.Provider
 		out[name] = core.ConnectionParamDef{
 			Required:    def.Required,
 			Description: def.Description,
+			Default:     def.Default,
 			From:        def.From,
 			Field:       def.Field,
 		}


### PR DESCRIPTION
## Summary
- remove legacy top-level `/api/v1/integrations` connection metadata (`connected`, `instances`, `authTypes`, `connectionParams`, `credentialFields`)
- expose auth types, credential fields, instances, and connection params only on canonical `connections[]`
- update the CLI connect/list contract to consume the canonical nested shape
- document the current `/api/v1/integrations` response contract

## Interface diff
Before:
```json
{
  "name": "github",
  "connected": true,
  "authTypes": ["oauth"],
  "instances": [{"id": "acme", "name": "Acme"}],
  "connectionParams": {},
  "credentialFields": [],
  "status": "ready"
}
```

After:
```json
{
  "name": "github",
  "status": "ready",
  "credentialState": "connected",
  "healthState": "not_checked",
  "actions": [],
  "connections": [
    {
      "name": "default",
      "status": "ready",
      "credentialState": "connected",
      "healthState": "not_checked",
      "actions": ["disconnect", "add_instance"],
      "authTypes": ["oauth"],
      "instances": [{"id": "acme", "name": "Acme"}],
      "connectionParams": {},
      "credentialFields": []
    }
  ]
}
```

CLI connect now resolves auth and prompts from the selected connection:
```json
{
  "name": "widget_metrics",
  "connections": [
    {
      "name": "plugin",
      "authTypes": ["manual"],
      "connectionParams": {
        "region": {"description": "API region", "default": "us-east", "required": true}
      },
      "credentialFields": [{"name": "api_key", "label": "API key"}]
    }
  ]
}
```

## Verification
- `go test ./internal/server`
- `cargo fmt -- --check && cargo test --test plugins_connect`
