### PR TITLE
Add provider package registry workflow

### DIFF
--- a/gestaltd/go.mod
+++ b/gestaltd/go.mod
@@ -3,6 +3,7 @@ module github.com/valon-technologies/gestalt/server
 go 1.26
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/blevesearch/bleve/v2 v2.5.7
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/gestaltd/go.sum
+++ b/gestaltd/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/RoaringBitmap/roaring/v2 v2.4.5 h1:uGrrMreGjvAtTBobc0g5IrW1D5ldxDQYe2JW2gggRdg=
 github.com/RoaringBitmap/roaring/v2 v2.4.5/go.mod h1:FiJcsfkGje/nZBZgCu0ZxCPOKD/hVXDS2dXi7/eUFE0=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -44,17 +44,24 @@ const (
 
 const PluginConnectionName = core.PluginConnectionName
 const PluginConnectionAlias = core.PluginConnectionAlias
-const ConfigAPIVersion = "gestaltd.config/v5"
+const ConfigAPIVersionV4 = "gestaltd.config/v4"
+const ConfigAPIVersionV5 = "gestaltd.config/v5"
+const ConfigAPIVersion = ConfigAPIVersionV5
 
 type Config struct {
-	APIVersion    string                    `yaml:"apiVersion,omitempty"`
-	Server        ServerConfig              `yaml:"server"`
-	Authorization AuthorizationConfig       `yaml:"authorization,omitempty"`
-	Connections   map[string]*ConnectionDef `yaml:"connections,omitempty"`
-	Providers     ProvidersConfig           `yaml:"providers"`
-	Runtime       RuntimeConfig             `yaml:"runtime,omitempty"`
-	Workflows     WorkflowsConfig           `yaml:"workflows,omitempty"`
-	Plugins       map[string]*ProviderEntry `yaml:"plugins,omitempty"`
+	APIVersion           string                              `yaml:"apiVersion,omitempty"`
+	ProviderRepositories map[string]ProviderRepositoryConfig `yaml:"providerRepositories,omitempty"`
+	Server               ServerConfig                        `yaml:"server"`
+	Authorization        AuthorizationConfig                 `yaml:"authorization,omitempty"`
+	Connections          map[string]*ConnectionDef           `yaml:"connections,omitempty"`
+	Providers            ProvidersConfig                     `yaml:"providers"`
+	Runtime              RuntimeConfig                       `yaml:"runtime,omitempty"`
+	Workflows            WorkflowsConfig                     `yaml:"workflows,omitempty"`
+	Plugins              map[string]*ProviderEntry           `yaml:"plugins,omitempty"`
+}
+
+type ProviderRepositoryConfig struct {
+	URL string `yaml:"url,omitempty"`
 }
 
 type ProvidersConfig struct {
@@ -141,18 +148,26 @@ type ServerProvidersConfig struct {
 //   - Local metadata: source: {path} or source: "./dist/provider-release.yaml"
 //     -> ProviderSource{metadataPath: "..."}
 type ProviderSource struct {
-	Builtin       string                  `yaml:"-"`
-	scalar        string                  `yaml:"-"`
-	metadataURL   string                  `yaml:"-"`
-	metadataPath  string                  `yaml:"-"`
-	unsupported   string                  `yaml:"-"`
-	GitHubRelease *GitHubReleaseSourceDef `yaml:"githubRelease,omitempty"`
-	Path          string                  `yaml:"path,omitempty"`
-	Auth          *SourceAuthDef          `yaml:"auth,omitempty"`
+	Builtin             string                  `yaml:"-"`
+	scalar              string                  `yaml:"-"`
+	metadataURL         string                  `yaml:"-"`
+	metadataPath        string                  `yaml:"-"`
+	packageRepo         string                  `yaml:"-"`
+	packageName         string                  `yaml:"-"`
+	packageVersion      string                  `yaml:"-"`
+	resolvedMetadataURL string                  `yaml:"-"`
+	resolvedVersion     string                  `yaml:"-"`
+	unsupported         string                  `yaml:"-"`
+	GitHubRelease       *GitHubReleaseSourceDef `yaml:"githubRelease,omitempty"`
+	Path                string                  `yaml:"path,omitempty"`
+	Auth                *SourceAuthDef          `yaml:"auth,omitempty"`
 }
 
 type providerSourceYAML struct {
 	URL           string                  `yaml:"url,omitempty"`
+	Repo          string                  `yaml:"repo,omitempty"`
+	Package       string                  `yaml:"package,omitempty"`
+	Version       string                  `yaml:"version,omitempty"`
 	GitHubRelease *GitHubReleaseSourceDef `yaml:"githubRelease,omitempty"`
 	Path          string                  `yaml:"path,omitempty"`
 	Auth          *SourceAuthDef          `yaml:"auth,omitempty"`
@@ -190,6 +205,9 @@ func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
 		s.GitHubRelease = cloneGitHubReleaseSourceDef(raw.GitHubRelease)
 		s.Path = strings.TrimSpace(raw.Path)
 		s.metadataURL = strings.TrimSpace(raw.URL)
+		s.packageRepo = strings.TrimSpace(raw.Repo)
+		s.packageName = strings.TrimSpace(raw.Package)
+		s.packageVersion = strings.TrimSpace(raw.Version)
 		s.Auth = cloneSourceAuthDef(raw.Auth)
 		return nil
 	}
@@ -200,6 +218,9 @@ func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
 	s.GitHubRelease = cloneGitHubReleaseSourceDef(raw.GitHubRelease)
 	s.Path = strings.TrimSpace(raw.Path)
 	s.metadataURL = strings.TrimSpace(raw.URL)
+	s.packageRepo = strings.TrimSpace(raw.Repo)
+	s.packageName = strings.TrimSpace(raw.Package)
+	s.packageVersion = strings.TrimSpace(raw.Version)
 	s.Auth = cloneSourceAuthDef(raw.Auth)
 	return nil
 }
@@ -211,6 +232,14 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 	auth := cloneSourceAuthDef(s.Auth)
 	if s.metadataURL != "" && s.Path == "" && s.metadataPath == "" {
 		return providerSourceYAML{URL: s.metadataURL, Auth: auth}, nil
+	}
+	if s.packageName != "" && s.Path == "" && s.metadataPath == "" && s.metadataURL == "" && s.GitHubRelease == nil {
+		return providerSourceYAML{
+			Repo:    strings.TrimSpace(s.packageRepo),
+			Package: strings.TrimSpace(s.packageName),
+			Version: strings.TrimSpace(s.packageVersion),
+			Auth:    auth,
+		}, nil
 	}
 	if s.GitHubRelease != nil && s.Path == "" && s.metadataPath == "" {
 		return providerSourceYAML{
@@ -226,6 +255,9 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 	}
 	return providerSourceYAML{
 		URL:           s.metadataURL,
+		Repo:          strings.TrimSpace(s.packageRepo),
+		Package:       strings.TrimSpace(s.packageName),
+		Version:       strings.TrimSpace(s.packageVersion),
 		GitHubRelease: cloneGitHubReleaseSourceDef(s.GitHubRelease),
 		Path:          s.Path,
 		Auth:          auth,
@@ -235,12 +267,27 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 func (s ProviderSource) IsBuiltin() bool       { return s.Builtin != "" }
 func (s ProviderSource) IsMetadataURL() bool   { return s.metadataURL != "" }
 func (s ProviderSource) IsGitHubRelease() bool { return s.GitHubRelease != nil }
+func (s ProviderSource) IsPackage() bool       { return s.packageName != "" }
 func (s ProviderSource) IsLocal() bool         { return s.Path != "" }
 func (s ProviderSource) IsLocalMetadataPath() bool {
 	return s.metadataPath != ""
 }
-func (s ProviderSource) MetadataURL() string  { return s.metadataURL }
-func (s ProviderSource) MetadataPath() string { return s.metadataPath }
+func (s ProviderSource) MetadataURL() string              { return s.metadataURL }
+func (s ProviderSource) MetadataPath() string             { return s.metadataPath }
+func (s ProviderSource) PackageRepo() string              { return strings.TrimSpace(s.packageRepo) }
+func (s ProviderSource) PackageAddress() string           { return strings.TrimSpace(s.packageName) }
+func (s ProviderSource) PackageVersionConstraint() string { return strings.TrimSpace(s.packageVersion) }
+func (s ProviderSource) ResolvedPackageMetadataURL() string {
+	return strings.TrimSpace(s.resolvedMetadataURL)
+}
+func (s ProviderSource) ResolvedPackageVersion() string { return strings.TrimSpace(s.resolvedVersion) }
+func (s *ProviderSource) SetResolvedPackage(metadataURL, version string) {
+	if s == nil {
+		return
+	}
+	s.resolvedMetadataURL = strings.TrimSpace(metadataURL)
+	s.resolvedVersion = strings.TrimSpace(version)
+}
 func (s ProviderSource) GitHubReleaseSource() *GitHubReleaseSourceDef {
 	return cloneGitHubReleaseSourceDef(s.GitHubRelease)
 }
@@ -1209,19 +1256,19 @@ func mergeHTTPBinding(base, override *HTTPBinding) *HTTPBinding {
 }
 
 func (e *ProviderEntry) HasMetadataSource() bool {
-	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsGitHubRelease())
+	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsGitHubRelease() || e.Source.IsPackage())
 }
 
 func (e *ProviderEntry) HasReleaseMetadataSource() bool {
-	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsGitHubRelease() || e.Source.IsLocalMetadataPath())
+	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsGitHubRelease() || e.Source.IsLocalMetadataPath() || e.Source.IsPackage())
 }
 
 func (e *ProviderEntry) HasRemoteSource() bool {
-	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsGitHubRelease())
+	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsGitHubRelease() || e.Source.IsPackage())
 }
 
 func (e *ProviderEntry) HasRemoteReleaseSource() bool {
-	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsGitHubRelease())
+	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsGitHubRelease() || e.Source.IsPackage())
 }
 
 func (e *ProviderEntry) HasLocalSource() bool {
@@ -1236,6 +1283,9 @@ func (e *ProviderEntry) SourceMetadataURL() string {
 	if e == nil {
 		return ""
 	}
+	if e.Source.IsPackage() {
+		return e.Source.ResolvedPackageMetadataURL()
+	}
 	return e.Source.MetadataURL()
 }
 
@@ -1248,6 +1298,9 @@ func (e *ProviderEntry) SourceRemoteLocation() string {
 	}
 	if e.Source.IsGitHubRelease() {
 		return e.Source.GitHubReleaseLocation()
+	}
+	if e.Source.IsPackage() {
+		return e.Source.ResolvedPackageMetadataURL()
 	}
 	return ""
 }
@@ -1264,6 +1317,9 @@ func (e *ProviderEntry) SourceReleaseLocation() string {
 	}
 	if e.Source.IsLocalMetadataPath() {
 		return e.Source.MetadataPath()
+	}
+	if e.Source.IsPackage() {
+		return e.Source.ResolvedPackageMetadataURL()
 	}
 	return ""
 }
@@ -2134,7 +2190,7 @@ func validateConfigRootAPIVersion(root yaml.Node) error {
 	if value == "" {
 		return requiredAPIVersionError()
 	}
-	if value != ConfigAPIVersion {
+	if value != ConfigAPIVersionV4 && value != ConfigAPIVersionV5 {
 		return fmt.Errorf("config validation: unsupported apiVersion %q", value)
 	}
 	return nil
@@ -2637,6 +2693,11 @@ func normalizeProviderSource(kind string, source *ProviderSource) {
 	source.Path = strings.TrimSpace(source.Path)
 	source.metadataURL = strings.TrimSpace(source.metadataURL)
 	source.metadataPath = strings.TrimSpace(source.metadataPath)
+	source.packageRepo = strings.TrimSpace(source.packageRepo)
+	source.packageName = strings.TrimSpace(source.packageName)
+	source.packageVersion = strings.TrimSpace(source.packageVersion)
+	source.resolvedMetadataURL = strings.TrimSpace(source.resolvedMetadataURL)
+	source.resolvedVersion = strings.TrimSpace(source.resolvedVersion)
 	source.unsupported = strings.TrimSpace(source.unsupported)
 	source.Auth = cloneSourceAuthDef(source.Auth)
 	if source.Path != "" && source.metadataPath == "" && isLocalReleaseMetadataPath(source.Path) {
@@ -2646,7 +2707,7 @@ func normalizeProviderSource(kind string, source *ProviderSource) {
 	if source.GitHubRelease != nil {
 		source.GitHubRelease = cloneGitHubReleaseSourceDef(source.GitHubRelease)
 	}
-	if source.Builtin != "" || source.Path != "" || source.metadataURL != "" || source.metadataPath != "" || source.GitHubRelease != nil {
+	if source.Builtin != "" || source.Path != "" || source.metadataURL != "" || source.metadataPath != "" || source.packageName != "" || source.GitHubRelease != nil {
 		source.scalar = ""
 		return
 	}

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3929,6 +3929,188 @@ plugins:
 	}
 }
 
+func TestLoadConfigProviderPackageSources(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteRawConfigFile(t, `
+apiVersion: gestaltd.config/v5
+providerRepositories:
+  local:
+    url: https://providers.example.test/index.yaml
+plugins:
+  service:
+    source:
+      repo: local
+      package: github.com/acme/providers/service
+      version: ">= 1.2.0, < 2.0.0"
+      auth:
+        token: test-token
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.APIVersion; got != ConfigAPIVersionV5 {
+		t.Fatalf("APIVersion = %q, want %q", got, ConfigAPIVersionV5)
+	}
+	if got := cfg.ProviderRepositories["local"].URL; got != "https://providers.example.test/index.yaml" {
+		t.Fatalf("providerRepositories.local.url = %q", got)
+	}
+	entry := cfg.Plugins["service"]
+	if entry == nil {
+		t.Fatal(`Plugins["service"] = nil`)
+	}
+	if !entry.Source.IsPackage() {
+		t.Fatal("Source.IsPackage = false, want true")
+	}
+	if got := entry.Source.PackageRepo(); got != "local" {
+		t.Fatalf("Source.PackageRepo = %q, want local", got)
+	}
+	if got := entry.Source.PackageAddress(); got != "github.com/acme/providers/service" {
+		t.Fatalf("Source.PackageAddress = %q", got)
+	}
+	if got := entry.Source.PackageVersionConstraint(); got != ">= 1.2.0, < 2.0.0" {
+		t.Fatalf("Source.PackageVersionConstraint = %q", got)
+	}
+	if entry.Source.Auth == nil || entry.Source.Auth.Token != "test-token" {
+		t.Fatalf("Source.Auth = %#v, want token", entry.Source.Auth)
+	}
+}
+
+func TestLoadConfigProviderPackageSourcesRequireV5(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "v4 rejects package source",
+			yaml: `
+apiVersion: gestaltd.config/v4
+plugins:
+  service:
+    source:
+      package: github.com/acme/providers/service
+`,
+			want: `source.package requires apiVersion "gestaltd.config/v5"`,
+		},
+		{
+			name: "v4 rejects provider repositories",
+			yaml: `
+apiVersion: gestaltd.config/v4
+providerRepositories:
+  local:
+    url: https://providers.example.test/index.yaml
+plugins:
+`,
+			want: `providerRepositories requires apiVersion "gestaltd.config/v5"`,
+		},
+		{
+			name: "package and url are mutually exclusive",
+			yaml: `
+apiVersion: gestaltd.config/v5
+plugins:
+  service:
+    source:
+      url: https://example.com/provider-release.yaml
+      package: github.com/acme/providers/service
+`,
+			want: `source.path and metadata URL sources are mutually exclusive`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := mustWriteRawConfigFile(t, tc.yaml)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("Load: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Load error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadPathsProviderPackageSourceAPIVersionLayering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("v5 overlay enables package source", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		basePath := filepath.Join(dir, "base.yaml")
+		overridePath := filepath.Join(dir, "override.yaml")
+		if err := os.WriteFile(basePath, []byte(`
+apiVersion: gestaltd.config/v4
+plugins:
+  service:
+    source: https://example.com/service/provider-release.yaml
+`), 0o644); err != nil {
+			t.Fatalf("write base: %v", err)
+		}
+		if err := os.WriteFile(overridePath, []byte(`
+apiVersion: gestaltd.config/v5
+providerRepositories:
+  local:
+    url: https://providers.example.test/index.yaml
+plugins:
+  service:
+    source:
+      repo: local
+      package: github.com/acme/providers/service
+`), 0o644); err != nil {
+			t.Fatalf("write override: %v", err)
+		}
+
+		cfg, err := LoadPaths([]string{basePath, overridePath})
+		if err != nil {
+			t.Fatalf("LoadPaths: %v", err)
+		}
+		if got := cfg.APIVersion; got != ConfigAPIVersionV5 {
+			t.Fatalf("APIVersion = %q, want %q", got, ConfigAPIVersionV5)
+		}
+		if !cfg.Plugins["service"].Source.IsPackage() {
+			t.Fatal("merged source is not package source")
+		}
+	})
+
+	t.Run("v4 overlay disables package source features", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		basePath := filepath.Join(dir, "base.yaml")
+		overridePath := filepath.Join(dir, "override.yaml")
+		if err := os.WriteFile(basePath, []byte(`
+apiVersion: gestaltd.config/v5
+plugins:
+  service:
+    source:
+      package: github.com/acme/providers/service
+`), 0o644); err != nil {
+			t.Fatalf("write base: %v", err)
+		}
+		if err := os.WriteFile(overridePath, []byte(`
+apiVersion: gestaltd.config/v4
+`), 0o644); err != nil {
+			t.Fatalf("write override: %v", err)
+		}
+
+		_, err := LoadPaths([]string{basePath, overridePath})
+		if err == nil {
+			t.Fatal("LoadPaths: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `source.package requires apiVersion "gestaltd.config/v5"`) {
+			t.Fatalf("LoadPaths error = %v, want package source apiVersion error", err)
+		}
+	})
+}
+
 func TestLoadRejectsUnknownProviderFields(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -16,6 +16,7 @@ import (
 
 	cronv3 "github.com/robfig/cron/v3"
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 	"github.com/valon-technologies/gestalt/server/services/s3"
@@ -79,6 +80,9 @@ func ValidateCanonicalStructure(cfg *Config) error {
 		return err
 	}
 	if err := validateTopLevelConnections(cfg); err != nil {
+		return err
+	}
+	if err := validateAPIVersionFeatures(cfg); err != nil {
 		return err
 	}
 
@@ -178,7 +182,7 @@ func validateAPIVersion(cfg *Config) error {
 	// Config values may omit it and use current source normalization.
 	apiVersion := strings.TrimSpace(cfg.APIVersion)
 	switch apiVersion {
-	case "", ConfigAPIVersion:
+	case "", ConfigAPIVersionV4, ConfigAPIVersionV5:
 		return nil
 	default:
 		return fmt.Errorf("config validation: unsupported apiVersion %q", apiVersion)
@@ -186,7 +190,72 @@ func validateAPIVersion(cfg *Config) error {
 }
 
 func requiredAPIVersionError() error {
-	return fmt.Errorf("config validation: apiVersion is required; supported value is %q", ConfigAPIVersion)
+	return fmt.Errorf("config validation: apiVersion is required; supported values are %q and %q", ConfigAPIVersionV4, ConfigAPIVersionV5)
+}
+
+func validateAPIVersionFeatures(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	v5 := strings.TrimSpace(cfg.APIVersion) == ConfigAPIVersionV5
+	if len(cfg.ProviderRepositories) > 0 && !v5 {
+		return fmt.Errorf("config validation: providerRepositories requires apiVersion %q", ConfigAPIVersionV5)
+	}
+	for name, repo := range cfg.ProviderRepositories {
+		if err := providerregistry.ValidateRepositoryName(name); err != nil {
+			return fmt.Errorf("config validation: providerRepositories.%s: %w", name, err)
+		}
+		if strings.TrimSpace(repo.URL) == "" {
+			return fmt.Errorf("config validation: providerRepositories.%s.url is required", name)
+		}
+	}
+	checkEntry := func(kind, name string, entry *ProviderEntry) error {
+		if entry == nil || !entry.Source.IsPackage() || v5 {
+			return nil
+		}
+		return fmt.Errorf("config validation: %s %q source.package requires apiVersion %q", kind, name, ConfigAPIVersionV5)
+	}
+	for name, entry := range cfg.Plugins {
+		if err := checkEntry("plugin", name, entry); err != nil {
+			return err
+		}
+	}
+	for _, collection := range []struct {
+		kind    HostProviderKind
+		entries map[string]*ProviderEntry
+	}{
+		{HostProviderKindAuthentication, cfg.Providers.Authentication},
+		{HostProviderKindAuthorization, cfg.Providers.Authorization},
+		{HostProviderKindExternalCredentials, cfg.Providers.ExternalCredentials},
+		{HostProviderKindSecrets, cfg.Providers.Secrets},
+		{HostProviderKindTelemetry, cfg.Providers.Telemetry},
+		{HostProviderKindAudit, cfg.Providers.Audit},
+		{HostProviderKindIndexedDB, cfg.Providers.IndexedDB},
+		{HostProviderKindCache, cfg.Providers.Cache},
+		{HostProviderKindWorkflow, cfg.Providers.Workflow},
+		{HostProviderKindAgent, cfg.Providers.Agent},
+	} {
+		for name, entry := range collection.entries {
+			if err := checkEntry(string(collection.kind), name, entry); err != nil {
+				return err
+			}
+		}
+	}
+	for name, entry := range cfg.Runtime.Providers {
+		if entry != nil {
+			if err := checkEntry("runtime", name, &entry.ProviderEntry); err != nil {
+				return err
+			}
+		}
+	}
+	for name, entry := range cfg.Providers.UI {
+		if entry != nil {
+			if err := checkEntry("ui", name, &entry.ProviderEntry); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func normalizeConnectionBindings(cfg *Config) error {
@@ -473,6 +542,9 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	if src.IsGitHubRelease() {
 		modeCount++
 	}
+	if src.IsPackage() {
+		modeCount++
+	}
 	if src.IsLocalMetadataPath() {
 		modeCount++
 	}
@@ -509,8 +581,18 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 			return fmt.Errorf("config validation: %s %q source.githubRelease.repo must be owner/name", kind, name)
 		}
 	}
+	if src.IsPackage() {
+		if err := providerregistry.ValidatePackageAddress(src.PackageAddress()); err != nil {
+			return fmt.Errorf("config validation: %s %q source.package: %w", kind, name, err)
+		}
+		if src.PackageRepo() != "" {
+			if err := providerregistry.ValidateRepositoryName(src.PackageRepo()); err != nil {
+				return fmt.Errorf("config validation: %s %q source.repo: %w", kind, name, err)
+			}
+		}
+	}
 	if auth != nil {
-		if !src.IsMetadataURL() && !src.IsGitHubRelease() && !src.IsLocalMetadataPath() {
+		if !src.IsMetadataURL() && !src.IsGitHubRelease() && !src.IsLocalMetadataPath() && !src.IsPackage() {
 			return fmt.Errorf("config validation: %s %q auth is only valid with provider-release metadata sources", kind, name)
 		}
 		if strings.TrimSpace(auth.Token) == "" {

--- a/gestaltd/internal/config/runtime_config.go
+++ b/gestaltd/internal/config/runtime_config.go
@@ -26,9 +26,12 @@ func BuildComponentRuntimeConfigNode(name, kind string, entry *ProviderEntry, pr
 	node := componentRuntimeConfig{
 		Name: name,
 		Source: &ProviderSource{
-			Path:          entry.Source.Path,
-			metadataURL:   entry.Source.MetadataURL(),
-			GitHubRelease: entry.Source.GitHubReleaseSource(),
+			Path:           entry.Source.Path,
+			metadataURL:    entry.Source.MetadataURL(),
+			packageRepo:    entry.Source.PackageRepo(),
+			packageName:    entry.Source.PackageAddress(),
+			packageVersion: entry.Source.PackageVersionConstraint(),
+			GitHubRelease:  entry.Source.GitHubReleaseSource(),
 		},
 		Command:      entry.Command,
 		Args:         append([]string(nil), entry.Args...),

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -1,9 +1,14 @@
 package daemon
 
 import (
+	"net/url"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
 )
 
 func TestE2ECLIHelp(t *testing.T) {
@@ -39,7 +44,12 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "provider",
 			args:      []string{"provider", "--help"},
-			wantParts: []string{"gestaltd provider <command> [flags]", "attach", "dev", "validate", "release"},
+			wantParts: []string{"gestaltd provider <command> [flags]", "add", "attach", "dev", "info", "remove", "repo", "search", "upgrade", "validate", "release"},
+		},
+		{
+			name:      "provider repo",
+			args:      []string{"provider", "repo", "--help"},
+			wantParts: []string{"gestaltd provider repo <command> [flags]", "add", "list", "remove", "update"},
 		},
 		{
 			name:      "provider attach",
@@ -78,6 +88,63 @@ func TestE2ECLIHelp(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestE2EProviderAddPackageSourceUpdatesConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(cfgPath, []byte("apiVersion: gestaltd.config/v4\nplugins:\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	indexPath := filepath.Join(dir, "provider-index.yaml")
+	indexYAML := `
+schema: gestaltd-provider-index
+schemaVersion: 1
+packages:
+  github.com/acme/providers/alpha:
+    displayName: Alpha
+    versions:
+      1.2.3:
+        metadata: file:///tmp/provider-release.yaml
+        kind: plugin
+        runtime: executable
+`
+	if err := os.WriteFile(indexPath, []byte(indexYAML), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	indexURL := (&url.URL{Scheme: "file", Path: indexPath}).String()
+
+	out, err := exec.Command(gestaltdBin, "provider", "repo", "add", "local", indexURL, "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("provider repo add failed: %v\n%s", err, out)
+	}
+	out, err = exec.Command(gestaltdBin, "provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--package-source", "--no-lock").CombinedOutput()
+	if err != nil {
+		t.Fatalf("provider add failed: %v\n%s", err, out)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.APIVersion; got != config.ConfigAPIVersionV5 {
+		t.Fatalf("APIVersion = %q, want %q", got, config.ConfigAPIVersionV5)
+	}
+	if got := cfg.ProviderRepositories["local"].URL; got != indexURL {
+		t.Fatalf("providerRepositories.local.url = %q, want %q", got, indexURL)
+	}
+	entry := cfg.Plugins["alpha"]
+	if entry == nil {
+		t.Fatal(`Plugins["alpha"] = nil`)
+	}
+	if got := entry.Source.PackageRepo(); got != "local" {
+		t.Fatalf("Source.PackageRepo = %q, want local", got)
+	}
+	if got := entry.Source.PackageAddress(); got != "github.com/acme/providers/alpha" {
+		t.Fatalf("Source.PackageAddress = %q, want package", got)
 	}
 }
 

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -32,8 +32,20 @@ func runProvider(args []string) error {
 		return flag.ErrHelp
 	case "attach":
 		return runProviderAttach(args[1:])
+	case "add":
+		return runProviderAdd(args[1:])
 	case "dev":
 		return runProviderDev(args[1:])
+	case "info":
+		return runProviderInfo(args[1:])
+	case "remove":
+		return runProviderRemove(args[1:])
+	case "repo":
+		return runProviderRepo(args[1:])
+	case "search":
+		return runProviderSearch(args[1:])
+	case "upgrade":
+		return runProviderUpgrade(args[1:])
 	case "validate":
 		return runProviderValidate(args[1:])
 	case "release":
@@ -606,8 +618,14 @@ func printProviderUsage(w io.Writer) {
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
 	writeUsageLine(w, "  attach      List, inspect, or detach remote provider-dev attachments")
+	writeUsageLine(w, "  add         Add a provider package to config and update lock state")
 	writeUsageLine(w, "  dev         Run a local source plugin inside a synthesized Gestalt config")
+	writeUsageLine(w, "  info        Show provider package metadata from configured repositories")
 	writeUsageLine(w, "  release     Build provider release archives")
+	writeUsageLine(w, "  remove      Remove a provider entry from config and update lock state")
+	writeUsageLine(w, "  repo        Manage provider package repositories")
+	writeUsageLine(w, "  search      Search configured provider package repositories")
+	writeUsageLine(w, "  upgrade     Refresh a provider package lock or version constraint")
 	writeUsageLine(w, "  validate    Validate a local source plugin inside a synthesized Gestalt config")
 }
 

--- a/gestaltd/internal/daemon/provider_registry.go
+++ b/gestaltd/internal/daemon/provider_registry.go
@@ -1,0 +1,827 @@
+package daemon
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"maps"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"gopkg.in/yaml.v3"
+)
+
+type repeatedSetFlag []string
+
+func (f *repeatedSetFlag) String() string { return strings.Join(*f, ",") }
+func (f *repeatedSetFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+type boolValueFlag interface {
+	IsBoolFlag() bool
+}
+
+func parseInterspersed(fs *flag.FlagSet, args []string) error {
+	reordered := make([]string, 0, len(args))
+	positionals := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			positionals = append(positionals, args[i+1:]...)
+			break
+		}
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
+			positionals = append(positionals, arg)
+			continue
+		}
+		reordered = append(reordered, arg)
+		if strings.Contains(arg, "=") {
+			continue
+		}
+		name := strings.TrimLeft(arg, "-")
+		if f := fs.Lookup(name); f != nil {
+			if boolFlag, ok := f.Value.(boolValueFlag); ok && boolFlag.IsBoolFlag() {
+				continue
+			}
+		}
+		if i+1 < len(args) {
+			i++
+			reordered = append(reordered, args[i])
+		}
+	}
+	reordered = append(reordered, positionals...)
+	return fs.Parse(reordered)
+}
+
+func runProviderRepo(args []string) error {
+	if len(args) == 0 {
+		printProviderRepoUsage(os.Stderr)
+		return flag.ErrHelp
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		printProviderRepoUsage(os.Stderr)
+		return flag.ErrHelp
+	case "add":
+		return runProviderRepoAdd(args[1:])
+	case "list":
+		return runProviderRepoList(args[1:])
+	case "remove":
+		return runProviderRepoRemove(args[1:])
+	case "update":
+		return runProviderRepoUpdate(args[1:])
+	default:
+		return fmt.Errorf("unknown provider repo command %q", args[0])
+	}
+}
+
+func runProviderRepoAdd(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider repo add", flag.ContinueOnError)
+	fs.Usage = func() { printProviderRepoAddUsage(fs.Output()) }
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to project config to update")
+	if err := parseInterspersed(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 2 {
+		return fmt.Errorf("usage: gestaltd provider repo add NAME URL")
+	}
+	name, repoURL := strings.TrimSpace(fs.Arg(0)), strings.TrimSpace(fs.Arg(1))
+	if err := providerregistry.ValidateRepositoryName(name); err != nil {
+		return err
+	}
+	parsedRepoURL, err := url.Parse(repoURL)
+	if err != nil {
+		return fmt.Errorf("invalid provider repository URL %q: %w", repoURL, err)
+	}
+	if parsedRepoURL.Scheme == "" {
+		return fmt.Errorf("invalid provider repository URL %q: scheme is required", repoURL)
+	}
+	if len(configPaths) > 0 {
+		path := operator.ResolveConfigPaths(configPaths)[0]
+		return editProjectProviderRepository(path, name, repoURL, false)
+	}
+	storePath := providerregistry.UserRepositoryStorePath()
+	store, err := providerregistry.ReadRepositoryStore(storePath)
+	if err != nil {
+		return err
+	}
+	if store.Repositories == nil {
+		store.Repositories = make(map[string]providerregistry.Repository)
+	}
+	store.Repositories[name] = providerregistry.Repository{URL: repoURL}
+	return providerregistry.WriteRepositoryStore(storePath, store)
+}
+
+func runProviderRepoRemove(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider repo remove", flag.ContinueOnError)
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to project config to update")
+	if err := parseInterspersed(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: gestaltd provider repo remove NAME")
+	}
+	name := strings.TrimSpace(fs.Arg(0))
+	if len(configPaths) > 0 {
+		path := operator.ResolveConfigPaths(configPaths)[0]
+		return removeProjectProviderRepository(path, name)
+	}
+	storePath := providerregistry.UserRepositoryStorePath()
+	store, err := providerregistry.ReadRepositoryStore(storePath)
+	if err != nil {
+		return err
+	}
+	delete(store.Repositories, name)
+	return providerregistry.WriteRepositoryStore(storePath, store)
+}
+
+func runProviderRepoList(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider repo list", flag.ContinueOnError)
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to config file")
+	if err := parseInterspersed(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	repos, err := loadProviderRepositories(operator.ResolveConfigPaths(configPaths))
+	if err != nil {
+		return err
+	}
+	for _, repo := range repos {
+		fmt.Printf("%s\t%s\n", repo.Name, repo.URL)
+	}
+	return nil
+}
+
+func runProviderRepoUpdate(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider repo update", flag.ContinueOnError)
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to config file")
+	if err := parseInterspersed(fs, args); err != nil {
+		return err
+	}
+	repos, err := loadProviderRepositories(operator.ResolveConfigPaths(configPaths))
+	if err != nil {
+		return err
+	}
+	cacheDir := providerregistry.UserRepositoryCacheDir()
+	if cacheDir == "" {
+		return fmt.Errorf("provider repository cache directory is unavailable")
+	}
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return err
+	}
+	for _, repo := range repos {
+		index, err := providerregistry.FetchIndex(context.Background(), nil, repo.URL, repo.Token)
+		if err != nil {
+			return fmt.Errorf("update provider repo %s: %w", repo.Name, err)
+		}
+		data, err := yaml.Marshal(index)
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(cacheDir, repo.Name+".yaml")
+		tmp := path + ".tmp"
+		if err := os.WriteFile(tmp, data, 0o600); err != nil {
+			return err
+		}
+		if err := os.Rename(tmp, path); err != nil {
+			return err
+		}
+		fmt.Printf("updated %s\n", repo.Name)
+	}
+	return nil
+}
+
+func runProviderSearch(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider search", flag.ContinueOnError)
+	var configPaths repeatedStringFlag
+	repoName := fs.String("repo", "", "provider repository name")
+	fs.Var(&configPaths, "config", "path to config file")
+	if err := parseInterspersed(fs, args); err != nil {
+		return err
+	}
+	query := strings.ToLower(strings.Join(fs.Args(), " "))
+	repos, err := loadProviderRepositories(operator.ResolveConfigPaths(configPaths))
+	if err != nil {
+		return err
+	}
+	for _, repo := range filterProviderRepositories(repos, *repoName) {
+		index, err := providerregistry.FetchIndex(context.Background(), nil, repo.URL, repo.Token)
+		if err != nil {
+			return fmt.Errorf("search provider repo %s: %w", repo.Name, err)
+		}
+		for _, pkg := range slices.Sorted(maps.Keys(index.Packages)) {
+			entry := index.Packages[pkg]
+			haystack := strings.ToLower(pkg + " " + entry.DisplayName + " " + entry.Description)
+			if query == "" || strings.Contains(haystack, query) {
+				fmt.Printf("%s\t%s\t%s\n", repo.Name, pkg, entry.DisplayName)
+			}
+		}
+	}
+	return nil
+}
+
+func runProviderInfo(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider info", flag.ContinueOnError)
+	var configPaths repeatedStringFlag
+	repoName := fs.String("repo", "", "provider repository name")
+	fs.Var(&configPaths, "config", "path to config file")
+	if err := parseInterspersed(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: gestaltd provider info PACKAGE")
+	}
+	pkg := fs.Arg(0)
+	repos, err := loadProviderRepositories(operator.ResolveConfigPaths(configPaths))
+	if err != nil {
+		return err
+	}
+	for _, repo := range filterProviderRepositories(repos, *repoName) {
+		index, err := providerregistry.FetchIndex(context.Background(), nil, repo.URL, repo.Token)
+		if err != nil {
+			return fmt.Errorf("info provider repo %s: %w", repo.Name, err)
+		}
+		entry, ok := index.Packages[pkg]
+		if !ok {
+			continue
+		}
+		fmt.Printf("%s\t%s\t%s\n", repo.Name, pkg, entry.DisplayName)
+		for _, version := range slices.Sorted(maps.Keys(entry.Versions)) {
+			release := entry.Versions[version]
+			fmt.Printf("  %s\t%s\t%s\t%s\n", version, release.Kind, release.Runtime, release.Metadata)
+		}
+		return nil
+	}
+	return fmt.Errorf("provider package %q not found", pkg)
+}
+
+func runProviderAdd(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider add", flag.ContinueOnError)
+	var configPaths repeatedStringFlag
+	var setFlags repeatedSetFlag
+	name := fs.String("name", "", "provider entry name")
+	kind := fs.String("kind", "", "provider kind")
+	version := fs.String("version", "", "version constraint")
+	repoName := fs.String("repo", "", "provider repository name")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile")
+	noLock := fs.Bool("no-lock", false, "do not update lockfile")
+	sync := fs.Bool("sync", false, "materialize prepared artifacts after locking")
+	exactSource := fs.Bool("exact-source", false, "write resolved provider-release metadata URL instead of package source")
+	packageSource := fs.Bool("package-source", false, "upgrade v4 config and write package source")
+	dryRun := fs.Bool("dry-run", false, "print resolved package without editing")
+	fs.Var(&configPaths, "config", "path to config file")
+	fs.Var(&setFlags, "set", "set shallow entry field, e.g. path=/ui")
+	if err := parseInterspersed(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: gestaltd provider add PACKAGE")
+	}
+	paths := operator.ResolveConfigPaths(configPaths)
+	primary, err := ensurePrimaryProviderConfig(paths)
+	if err != nil {
+		return err
+	}
+	if len(paths) == 0 {
+		paths = []string{primary}
+	} else {
+		paths[0] = primary
+	}
+	cfg, err := config.LoadAllowMissingEnvPaths(paths)
+	if err != nil {
+		return err
+	}
+	repos, err := loadProviderRepositories(paths)
+	if err != nil {
+		return err
+	}
+	resolved, err := (&providerregistry.Resolver{}).Resolve(context.Background(), providerregistry.ResolveRequest{
+		Package:           fs.Arg(0),
+		VersionConstraint: *version,
+		RepositoryName:    *repoName,
+		Repositories:      repos,
+	})
+	if err != nil {
+		return err
+	}
+	if *dryRun {
+		fmt.Printf("%s\t%s\t%s\t%s\n", resolved.Package, resolved.Version, resolved.Kind, resolved.MetadataURL)
+		return nil
+	}
+	apiVersion := config.ConfigAPIVersionV4
+	if cfg != nil && strings.TrimSpace(cfg.APIVersion) != "" {
+		apiVersion = strings.TrimSpace(cfg.APIVersion)
+	}
+	writePackageSource := apiVersion == config.ConfigAPIVersionV5 && !*exactSource
+	if *packageSource {
+		writePackageSource = true
+		apiVersion = config.ConfigAPIVersionV5
+	}
+	entryKind := providermanifestv1.NormalizeKind(*kind)
+	if entryKind == "" {
+		entryKind = resolved.Kind
+	}
+	if entryKind == "telemetry" || entryKind == "audit" {
+		return fmt.Errorf("provider add --kind %s is not supported yet; provider-backed %s is not supported at bootstrap", entryKind, entryKind)
+	}
+	entryName := strings.TrimSpace(*name)
+	if entryName == "" {
+		entryName = sanitizeDerivedPluginKey(providerregistry.PackageName(resolved.Package))
+	}
+	if entryName == "" {
+		return fmt.Errorf("--name is required")
+	}
+	setValues := parseSetFlags(setFlags)
+	if entryKind == providermanifestv1.KindUI && strings.TrimSpace(setValues["path"]) == "" {
+		return fmt.Errorf("provider add for kind ui requires --set path=/mount")
+	}
+	if err := editProviderEntry(primary, apiVersion, entryKind, entryName, resolved, *version, *repoName, writePackageSource, setValues); err != nil {
+		return err
+	}
+	if *noLock {
+		return nil
+	}
+	state := operator.StatePaths{LockfilePath: *lockfilePath}
+	if err := lockConfigWithStatePaths(configPaths, state, "", false); err != nil {
+		return err
+	}
+	if *sync {
+		return syncConfigWithStatePaths(configPaths, state, false)
+	}
+	return nil
+}
+
+func runProviderRemove(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider remove", flag.ContinueOnError)
+	var configPaths repeatedStringFlag
+	kind := fs.String("kind", "plugin", "provider kind")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile")
+	noLock := fs.Bool("no-lock", false, "do not update lockfile")
+	fs.Var(&configPaths, "config", "path to config file")
+	if err := parseInterspersed(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: gestaltd provider remove NAME")
+	}
+	paths := operator.ResolveConfigPaths(configPaths)
+	if len(paths) == 0 {
+		return fmt.Errorf("no config file found")
+	}
+	if err := removeProviderEntry(paths[0], providermanifestv1.NormalizeKind(*kind), fs.Arg(0)); err != nil {
+		return err
+	}
+	if !*noLock {
+		return lockConfigWithStatePaths(configPaths, operator.StatePaths{LockfilePath: *lockfilePath}, "", false)
+	}
+	return nil
+}
+
+func runProviderUpgrade(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider upgrade", flag.ContinueOnError)
+	var configPaths repeatedStringFlag
+	kind := fs.String("kind", "", "provider kind")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile")
+	version := fs.String("version", "", "new version constraint")
+	fs.Var(&configPaths, "config", "path to config file")
+	if err := parseInterspersed(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() > 1 {
+		return fmt.Errorf("usage: gestaltd provider upgrade [NAME]")
+	}
+	if *version != "" && fs.NArg() != 1 {
+		return fmt.Errorf("--version requires a provider name")
+	}
+	if *version != "" {
+		paths := operator.ResolveConfigPaths(configPaths)
+		if len(paths) == 0 {
+			return fmt.Errorf("no config file found")
+		}
+		if err := updateProviderVersionConstraint(paths[0], providermanifestv1.NormalizeKind(*kind), fs.Arg(0), *version); err != nil {
+			return err
+		}
+	}
+	return lockConfigWithStatePaths(configPaths, operator.StatePaths{LockfilePath: *lockfilePath}, "", false)
+}
+
+func loadProviderRepositories(configPaths []string) ([]providerregistry.NamedRepository, error) {
+	byName := map[string]providerregistry.NamedRepository{}
+	order := []string{providerregistry.DefaultRepositoryName}
+	for _, repo := range providerregistry.DefaultRepositories() {
+		byName[repo.Name] = repo
+	}
+	if storePath := providerregistry.UserRepositoryStorePath(); storePath != "" {
+		store, err := providerregistry.ReadRepositoryStore(storePath)
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range slices.Sorted(maps.Keys(store.Repositories)) {
+			repo := store.Repositories[name]
+			if _, ok := byName[name]; !ok {
+				order = append(order, name)
+			}
+			byName[name] = providerregistry.NamedRepository{Name: name, URL: repo.URL, Token: repo.Token}
+		}
+	}
+	if len(configPaths) > 0 {
+		cfg, err := config.LoadAllowMissingEnvPaths(configPaths)
+		if err != nil {
+			return nil, err
+		}
+		if cfg != nil {
+			for _, name := range slices.Sorted(maps.Keys(cfg.ProviderRepositories)) {
+				repo := cfg.ProviderRepositories[name]
+				if _, ok := byName[name]; !ok {
+					order = append(order, name)
+				}
+				byName[name] = providerregistry.NamedRepository{Name: name, URL: repo.URL}
+			}
+		}
+	}
+	out := make([]providerregistry.NamedRepository, 0, len(order))
+	for _, name := range order {
+		out = append(out, byName[name])
+	}
+	return out, nil
+}
+
+func filterProviderRepositories(repos []providerregistry.NamedRepository, name string) []providerregistry.NamedRepository {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return repos
+	}
+	out := repos[:0]
+	for _, repo := range repos {
+		if repo.Name == name {
+			out = append(out, repo)
+		}
+	}
+	return out
+}
+
+func ensurePrimaryProviderConfig(paths []string) (string, error) {
+	if len(paths) == 0 {
+		paths = operator.ResolveConfigPaths(nil)
+	}
+	if len(paths) == 0 || strings.TrimSpace(paths[0]) == "" {
+		return "", fmt.Errorf("no config file found")
+	}
+	primary := paths[0]
+	if _, err := os.Stat(primary); err == nil {
+		return primary, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	return operator.GenerateDefaultConfig(filepath.Dir(primary))
+}
+
+func parseSetFlags(flags []string) map[string]string {
+	values := make(map[string]string, len(flags))
+	for _, flag := range flags {
+		key, value, ok := strings.Cut(flag, "=")
+		if !ok {
+			continue
+		}
+		values[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return values
+}
+
+func editProjectProviderRepository(path, name, repoURL string, dryRun bool) error {
+	root, doc, err := readConfigDocument(path)
+	if err != nil {
+		return err
+	}
+	setScalar(doc, "apiVersion", config.ConfigAPIVersionV5)
+	repos := ensureMapping(doc, "providerRepositories")
+	repoNode := yamlMapping(map[string]any{"url": repoURL})
+	setNode(repos, name, repoNode)
+	if dryRun {
+		return nil
+	}
+	return writeConfigDocument(path, root)
+}
+
+func removeProjectProviderRepository(path, name string) error {
+	root, doc, err := readConfigDocument(path)
+	if err != nil {
+		return err
+	}
+	if repos := mappingValueNodeLocal(doc, "providerRepositories"); repos != nil {
+		deleteKey(repos, name)
+	}
+	return writeConfigDocument(path, root)
+}
+
+func editProviderEntry(path, apiVersion, kind, name string, resolved *providerregistry.ResolvedPackage, constraint, repoName string, packageSource bool, setValues map[string]string) error {
+	root, doc, err := readConfigDocument(path)
+	if err != nil {
+		return err
+	}
+	setScalar(doc, "apiVersion", apiVersion)
+	entry := map[string]any{}
+	if packageSource {
+		source := map[string]any{"package": resolved.Package}
+		sourceRepoName := ""
+		if repoName != "" {
+			sourceRepoName = repoName
+		} else if resolved.RepositoryName != providerregistry.DefaultRepositoryName {
+			sourceRepoName = resolved.RepositoryName
+		}
+		if sourceRepoName != "" {
+			source["repo"] = sourceRepoName
+			if resolved.RepositoryURL != "" {
+				repos := ensureMapping(doc, "providerRepositories")
+				setNode(repos, sourceRepoName, yamlMapping(map[string]any{"url": resolved.RepositoryURL}))
+			}
+		}
+		if constraint != "" {
+			source["version"] = constraint
+		}
+		entry["source"] = source
+	} else {
+		entry["source"] = resolved.MetadataURL
+	}
+	if kind == providermanifestv1.KindUI {
+		entry["path"] = setValues["path"]
+	}
+	target := providerEntryCollection(doc, kind)
+	setNode(target, name, yamlMapping(entry))
+	return writeConfigDocument(path, root)
+}
+
+func removeProviderEntry(path, kind, name string) error {
+	root, doc, err := readConfigDocument(path)
+	if err != nil {
+		return err
+	}
+	deleteKey(providerEntryCollection(doc, kind), name)
+	return writeConfigDocument(path, root)
+}
+
+func updateProviderVersionConstraint(path, kind, name, version string) error {
+	root, doc, err := readConfigDocument(path)
+	if err != nil {
+		return err
+	}
+	targets := providerVersionTargets(doc, kind, name)
+	if len(targets) == 0 {
+		if kind != "" {
+			return fmt.Errorf("provider %q of kind %q not found or is not a package source", name, kind)
+		}
+		return fmt.Errorf("provider %q not found or is not a package source", name)
+	}
+	if len(targets) > 1 {
+		kinds := make([]string, 0, len(targets))
+		for _, target := range targets {
+			kinds = append(kinds, target.kind)
+		}
+		slices.Sort(kinds)
+		return fmt.Errorf("provider %q is ambiguous across kinds %s; pass --kind", name, strings.Join(kinds, ", "))
+	}
+	setScalar(targets[0].source, "version", version)
+	return writeConfigDocument(path, root)
+}
+
+type providerVersionTarget struct {
+	kind   string
+	source *yaml.Node
+}
+
+type providerEntryCollectionRef struct {
+	kind string
+	node *yaml.Node
+}
+
+func providerVersionTargets(doc *yaml.Node, kind, name string) []providerVersionTarget {
+	collections := providerEntryCollectionsForVersionUpdate(doc, kind)
+	targets := make([]providerVersionTarget, 0, 1)
+	for _, collection := range collections {
+		source := packageSourceInCollection(collection.node, name)
+		if source == nil {
+			continue
+		}
+		targets = append(targets, providerVersionTarget{
+			kind:   collection.kind,
+			source: source,
+		})
+	}
+	return targets
+}
+
+func providerEntryCollectionsForVersionUpdate(doc *yaml.Node, kind string) []providerEntryCollectionRef {
+	if kind != "" {
+		return []providerEntryCollectionRef{{
+			kind: kind,
+			node: providerEntryCollectionNode(doc, kind),
+		}}
+	}
+	providers := mappingValueNodeLocal(doc, "providers")
+	runtimeProviders := mappingValueNodeLocal(mappingValueNodeLocal(doc, "runtime"), "providers")
+	return []providerEntryCollectionRef{
+		{kind: providermanifestv1.KindPlugin, node: mappingValueNodeLocal(doc, "plugins")},
+		{kind: providermanifestv1.KindAuthentication, node: mappingValueNodeLocal(providers, configKindKey(providermanifestv1.KindAuthentication))},
+		{kind: providermanifestv1.KindAuthorization, node: mappingValueNodeLocal(providers, configKindKey(providermanifestv1.KindAuthorization))},
+		{kind: providermanifestv1.KindExternalCredentials, node: mappingValueNodeLocal(providers, configKindKey(providermanifestv1.KindExternalCredentials))},
+		{kind: providermanifestv1.KindSecrets, node: mappingValueNodeLocal(providers, configKindKey(providermanifestv1.KindSecrets))},
+		{kind: "telemetry", node: mappingValueNodeLocal(providers, configKindKey("telemetry"))},
+		{kind: "audit", node: mappingValueNodeLocal(providers, configKindKey("audit"))},
+		{kind: providermanifestv1.KindIndexedDB, node: mappingValueNodeLocal(providers, configKindKey(providermanifestv1.KindIndexedDB))},
+		{kind: providermanifestv1.KindCache, node: mappingValueNodeLocal(providers, configKindKey(providermanifestv1.KindCache))},
+		{kind: providermanifestv1.KindS3, node: mappingValueNodeLocal(providers, configKindKey(providermanifestv1.KindS3))},
+		{kind: providermanifestv1.KindWorkflow, node: mappingValueNodeLocal(providers, configKindKey(providermanifestv1.KindWorkflow))},
+		{kind: providermanifestv1.KindAgent, node: mappingValueNodeLocal(providers, configKindKey(providermanifestv1.KindAgent))},
+		{kind: providermanifestv1.KindUI, node: mappingValueNodeLocal(providers, configKindKey(providermanifestv1.KindUI))},
+		{kind: providermanifestv1.KindRuntime, node: runtimeProviders},
+	}
+}
+
+func providerEntryCollectionNode(doc *yaml.Node, kind string) *yaml.Node {
+	switch kind {
+	case "", providermanifestv1.KindPlugin:
+		return mappingValueNodeLocal(doc, "plugins")
+	case providermanifestv1.KindRuntime:
+		return mappingValueNodeLocal(mappingValueNodeLocal(doc, "runtime"), "providers")
+	default:
+		return mappingValueNodeLocal(mappingValueNodeLocal(doc, "providers"), configKindKey(kind))
+	}
+}
+
+func packageSourceInCollection(collection *yaml.Node, name string) *yaml.Node {
+	if collection == nil {
+		return nil
+	}
+	entry := mappingValueNodeLocal(collection, name)
+	if entry == nil {
+		return nil
+	}
+	source := mappingValueNodeLocal(entry, "source")
+	if source == nil || mappingValueNodeLocal(source, "package") == nil {
+		return nil
+	}
+	return source
+}
+
+func providerEntryCollection(doc *yaml.Node, kind string) *yaml.Node {
+	switch kind {
+	case "", providermanifestv1.KindPlugin:
+		return ensureMapping(doc, "plugins")
+	case providermanifestv1.KindUI:
+		return ensureMapping(ensureMapping(doc, "providers"), "ui")
+	case providermanifestv1.KindRuntime:
+		return ensureMapping(ensureMapping(doc, "runtime"), "providers")
+	default:
+		return ensureMapping(ensureMapping(doc, "providers"), configKindKey(kind))
+	}
+}
+
+func configKindKey(kind string) string {
+	switch kind {
+	case providermanifestv1.KindAuthentication:
+		return "authentication"
+	case providermanifestv1.KindAuthorization:
+		return "authorization"
+	case providermanifestv1.KindExternalCredentials:
+		return "externalCredentials"
+	default:
+		return kind
+	}
+}
+
+func readConfigDocument(path string) (*yaml.Node, *yaml.Node, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, nil, err
+	}
+	doc := documentNode(&root)
+	if doc.Kind == 0 {
+		doc.Kind = yaml.MappingNode
+		root.Kind = yaml.DocumentNode
+		root.Content = []*yaml.Node{doc}
+	}
+	if doc.Kind != yaml.MappingNode {
+		return nil, nil, fmt.Errorf("config %s must be a mapping document", path)
+	}
+	return &root, doc, nil
+}
+
+func writeConfigDocument(path string, root *yaml.Node) error {
+	data, err := yaml.Marshal(root)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func documentNode(root *yaml.Node) *yaml.Node {
+	if root.Kind == yaml.DocumentNode {
+		if len(root.Content) == 0 {
+			root.Content = []*yaml.Node{{Kind: yaml.MappingNode}}
+		}
+		return root.Content[0]
+	}
+	return root
+}
+
+func mappingValueNodeLocal(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func ensureMapping(node *yaml.Node, key string) *yaml.Node {
+	if existing := mappingValueNodeLocal(node, key); existing != nil {
+		if existing.Kind == yaml.MappingNode {
+			return existing
+		}
+		existing.Kind = yaml.MappingNode
+		existing.Tag = "!!map"
+		existing.Value = ""
+		existing.Content = nil
+		return existing
+	}
+	child := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	node.Content = append(node.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, child)
+	return child
+}
+
+func setScalar(node *yaml.Node, key, value string) {
+	setNode(node, key, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value})
+}
+
+func setNode(node *yaml.Node, key string, value *yaml.Node) {
+	if node.Kind != yaml.MappingNode {
+		node.Kind = yaml.MappingNode
+		node.Tag = "!!map"
+		node.Content = nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			node.Content[i+1] = value
+			return
+		}
+	}
+	node.Content = append(node.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, value)
+}
+
+func deleteKey(node *yaml.Node, key string) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			node.Content = append(node.Content[:i], node.Content[i+2:]...)
+			return
+		}
+	}
+}
+
+func yamlMapping(value map[string]any) *yaml.Node {
+	data, _ := yaml.Marshal(value)
+	var node yaml.Node
+	_ = yaml.Unmarshal(data, &node)
+	return documentNode(&node)
+}
+
+func printProviderRepoUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd provider repo <command> [flags]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  add      Add a provider repository")
+	writeUsageLine(w, "  list     List configured provider repositories")
+	writeUsageLine(w, "  remove   Remove a provider repository")
+	writeUsageLine(w, "  update   Fetch and cache provider repository indexes")
+}
+
+func printProviderRepoAddUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd provider repo add NAME URL [--config PATH]")
+}

--- a/gestaltd/internal/daemon/provider_registry_test.go
+++ b/gestaltd/internal/daemon/provider_registry_test.go
@@ -1,0 +1,98 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestUpdateProviderVersionConstraintFindsProviderCollections(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "gestalt.yaml")
+	if err := os.WriteFile(path, []byte(`
+apiVersion: gestaltd.config/v5
+providers:
+  authentication:
+    authn:
+      source:
+        package: github.com/acme/providers/authn
+        version: "1.0.0"
+  ui:
+    dashboard:
+      path: /dashboard
+      source:
+        package: github.com/acme/providers/dashboard
+        version: "1.0.0"
+plugins:
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := updateProviderVersionConstraint(path, "", "dashboard", ">= 2.0.0"); err != nil {
+		t.Fatalf("update ui version: %v", err)
+	}
+	if err := updateProviderVersionConstraint(path, providermanifestv1.KindAuthentication, "authn", "~1.4.0"); err != nil {
+		t.Fatalf("update authentication version: %v", err)
+	}
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Providers.UI["dashboard"].Source.PackageVersionConstraint(); got != ">= 2.0.0" {
+		t.Fatalf("ui version = %q, want >= 2.0.0", got)
+	}
+	if got := cfg.Providers.Authentication["authn"].Source.PackageVersionConstraint(); got != "~1.4.0" {
+		t.Fatalf("authentication version = %q, want ~1.4.0", got)
+	}
+}
+
+func TestUpdateProviderVersionConstraintRequiresKindForAmbiguousName(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "gestalt.yaml")
+	if err := os.WriteFile(path, []byte(`
+apiVersion: gestaltd.config/v5
+providers:
+  ui:
+    shared:
+      path: /shared
+      source:
+        package: github.com/acme/providers/shared-ui
+        version: "1.0.0"
+plugins:
+  shared:
+    source:
+      package: github.com/acme/providers/shared-plugin
+      version: "1.0.0"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	err := updateProviderVersionConstraint(path, "", "shared", "2.0.0")
+	if err == nil {
+		t.Fatal("update version: expected ambiguity error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") || !strings.Contains(err.Error(), "--kind") {
+		t.Fatalf("update version error = %v, want --kind ambiguity", err)
+	}
+
+	if err := updateProviderVersionConstraint(path, providermanifestv1.KindUI, "shared", "2.0.0"); err != nil {
+		t.Fatalf("update ui version: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Providers.UI["shared"].Source.PackageVersionConstraint(); got != "2.0.0" {
+		t.Fatalf("ui version = %q, want 2.0.0", got)
+	}
+	if got := cfg.Plugins["shared"].Source.PackageVersionConstraint(); got != "1.0.0" {
+		t.Fatalf("plugin version = %q, want 1.0.0", got)
+	}
+}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/plugins/providerpkg"
@@ -83,6 +84,7 @@ type LockEntry struct {
 type Lifecycle struct {
 	configSecretResolver func(context.Context, *config.Config) error
 	httpClient           *http.Client
+	providerResolver     *providerregistry.Resolver
 }
 
 type StatePaths struct {
@@ -118,11 +120,23 @@ func (l *Lifecycle) WithHTTPClient(client *http.Client) *Lifecycle {
 	return l
 }
 
+func (l *Lifecycle) WithProviderResolver(resolver *providerregistry.Resolver) *Lifecycle {
+	l.providerResolver = resolver
+	return l
+}
+
 func (l *Lifecycle) metadataHTTPClient() *http.Client {
 	if l != nil && l.httpClient != nil {
 		return l.httpClient
 	}
 	return http.DefaultClient
+}
+
+func (l *Lifecycle) providerPackageResolver() *providerregistry.Resolver {
+	if l != nil && l.providerResolver != nil {
+		return l.providerResolver
+	}
+	return &providerregistry.Resolver{Client: l.metadataHTTPClient()}
 }
 
 func (l *Lifecycle) PrepareAtPath(configPath string) (*Lockfile, error) {
@@ -289,6 +303,9 @@ func (l *Lifecycle) prepareLockAtPaths(configPaths []string, state StatePaths, d
 }
 
 func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, paths lifecyclePaths, cfg *config.Config) (*Lockfile, error) {
+	if err := l.resolvePackageSources(ctx, cfg); err != nil {
+		return nil, err
+	}
 	secretsEntries, err := l.primeSecretsProviderForConfigResolution(ctx, paths, cfg, nil, artifactModeMaterialize)
 	if err != nil {
 		return nil, err
@@ -383,6 +400,149 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 		}
 	}
 	return lock, nil
+}
+
+func (l *Lifecycle) resolvePackageSources(ctx context.Context, cfg *config.Config) error {
+	if cfg == nil {
+		return nil
+	}
+	if !configHasPackageSources(cfg) {
+		return nil
+	}
+	repos, err := providerRepositoriesForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	resolveEntry := func(subject string, entry *config.ProviderEntry) error {
+		if entry == nil || !entry.Source.IsPackage() || entry.Source.ResolvedPackageMetadataURL() != "" {
+			return nil
+		}
+		reqRepos := cloneProviderRepositories(repos)
+		if token := sourceAuthToken(entry); token != "" {
+			for i := range reqRepos {
+				if entry.Source.PackageRepo() == "" || reqRepos[i].Name == entry.Source.PackageRepo() {
+					reqRepos[i].Token = token
+				}
+			}
+		}
+		resolved, err := l.providerPackageResolver().Resolve(ctx, providerregistry.ResolveRequest{
+			Package:           entry.Source.PackageAddress(),
+			VersionConstraint: entry.Source.PackageVersionConstraint(),
+			RepositoryName:    entry.Source.PackageRepo(),
+			Repositories:      reqRepos,
+		})
+		if err != nil {
+			return fmt.Errorf("%s resolve provider package: %w", subject, err)
+		}
+		entry.Source.SetResolvedPackage(resolved.MetadataURL, resolved.Version)
+		return nil
+	}
+	for name, entry := range cfg.Plugins {
+		if err := resolveEntry("plugin "+strconv.Quote(name), entry); err != nil {
+			return err
+		}
+	}
+	for _, collection := range hostProviderCollections(cfg) {
+		for name, entry := range collection.entries {
+			if err := resolveEntry(string(collection.kind)+" "+strconv.Quote(name), entry); err != nil {
+				return err
+			}
+		}
+	}
+	for name, entry := range cfg.Runtime.Providers {
+		if entry != nil {
+			if err := resolveEntry("runtime "+strconv.Quote(name), &entry.ProviderEntry); err != nil {
+				return err
+			}
+		}
+	}
+	for name, entry := range cfg.Providers.UI {
+		if entry != nil {
+			if err := resolveEntry("ui "+strconv.Quote(name), &entry.ProviderEntry); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func configHasPackageSources(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, entry := range cfg.Plugins {
+		if entry != nil && entry.Source.IsPackage() {
+			return true
+		}
+	}
+	for _, collection := range hostProviderCollections(cfg) {
+		for _, entry := range collection.entries {
+			if entry != nil && entry.Source.IsPackage() {
+				return true
+			}
+		}
+	}
+	for _, entry := range cfg.Runtime.Providers {
+		if entry != nil && entry.Source.IsPackage() {
+			return true
+		}
+	}
+	for _, entry := range cfg.Providers.UI {
+		if entry != nil && entry.Source.IsPackage() {
+			return true
+		}
+	}
+	return false
+}
+
+func providerRepositoriesForConfig(cfg *config.Config) ([]providerregistry.NamedRepository, error) {
+	byName := make(map[string]providerregistry.NamedRepository)
+	order := []string{providerregistry.DefaultRepositoryName}
+	for _, repo := range providerregistry.DefaultRepositories() {
+		byName[repo.Name] = repo
+	}
+	if storePath := providerregistry.UserRepositoryStorePath(); storePath != "" {
+		store, err := providerregistry.ReadRepositoryStore(storePath)
+		if err != nil {
+			return nil, fmt.Errorf("read provider repository store: %w", err)
+		}
+		userNames := slices.Sorted(maps.Keys(store.Repositories))
+		for _, name := range userNames {
+			repo := store.Repositories[name]
+			if err := providerregistry.ValidateRepositoryName(name); err != nil {
+				return nil, err
+			}
+			if _, ok := byName[name]; !ok {
+				order = append(order, name)
+			}
+			byName[name] = providerregistry.NamedRepository{Name: name, URL: repo.URL, Token: repo.Token}
+		}
+	}
+	projectNames := slices.Sorted(maps.Keys(cfg.ProviderRepositories))
+	for _, name := range projectNames {
+		repo := cfg.ProviderRepositories[name]
+		if err := providerregistry.ValidateRepositoryName(name); err != nil {
+			return nil, err
+		}
+		if _, ok := byName[name]; !ok {
+			order = append(order, name)
+		}
+		byName[name] = providerregistry.NamedRepository{Name: name, URL: repo.URL}
+	}
+	out := make([]providerregistry.NamedRepository, 0, len(order))
+	for _, name := range order {
+		if repo, ok := byName[name]; ok {
+			out = append(out, repo)
+		}
+	}
+	return out, nil
+}
+
+func cloneProviderRepositories(repos []providerregistry.NamedRepository) []providerregistry.NamedRepository {
+	if len(repos) == 0 {
+		return nil
+	}
+	return append([]providerregistry.NamedRepository(nil), repos...)
 }
 
 func buildSourceTokenMap(cfg *config.Config) map[string]string {
@@ -1323,8 +1483,7 @@ func lockMatchesConfig(cfg *config.Config, paths lifecyclePaths, lock *Lockfile)
 		if !ok {
 			return false
 		}
-		fingerprint, err := NamedUIProviderFingerprint(name, &entry.ProviderEntry, paths.configDir)
-		if err != nil || lockEntry.Fingerprint != fingerprint {
+		if !uiLockEntryMetadataMatches(paths, name, &entry.ProviderEntry, lockEntry, true) {
 			return false
 		}
 		install, err := inspectPreparedInstall(uiDestDir(paths, name))
@@ -1415,7 +1574,7 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 
 	input := providerFingerprintInput{
 		Name:   name,
-		Source: providerSourceLockLocation(entry, configDir),
+		Source: providerSourceFingerprintLocation(entry, configDir),
 	}
 	if entry.HasLocalSource() {
 		input.Path = fingerprintLocalSourcePath(entry.SourcePath(), configDir)
@@ -1432,6 +1591,10 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 		input.Digest = digest
 	}
 
+	return hashProviderFingerprintInput(input)
+}
+
+func hashProviderFingerprintInput(input providerFingerprintInput) (string, error) {
 	payload, err := json.Marshal(input)
 	if err != nil {
 		return "", err
@@ -1448,6 +1611,9 @@ func providerSourceLockLocation(entry *config.ProviderEntry, configDir string) s
 	if entry == nil {
 		return ""
 	}
+	if entry.Source.IsPackage() {
+		return strings.TrimSpace(entry.Source.ResolvedPackageMetadataURL())
+	}
 	if entry.HasRemoteSource() {
 		return entry.SourceRemoteLocation()
 	}
@@ -1455,6 +1621,59 @@ func providerSourceLockLocation(entry *config.ProviderEntry, configDir string) s
 		return fingerprintLocalSourcePath(entry.SourceReleasePath(), configDir)
 	}
 	return ""
+}
+
+func providerSourceFingerprintLocation(entry *config.ProviderEntry, configDir string) string {
+	if entry == nil {
+		return ""
+	}
+	if entry.Source.IsPackage() {
+		return strings.Join([]string{
+			"package",
+			entry.Source.PackageRepo(),
+			entry.Source.PackageAddress(),
+			entry.Source.PackageVersionConstraint(),
+		}, "\x00")
+	}
+	return providerSourceLockLocation(entry, configDir)
+}
+
+func lockEntrySourceMatchesProvider(paths lifecyclePaths, provider *config.ProviderEntry, entry LockEntry) bool {
+	if provider == nil {
+		return false
+	}
+	if provider.Source.IsPackage() {
+		if strings.TrimSpace(entry.Package) != provider.Source.PackageAddress() {
+			return false
+		}
+		return providerregistry.VersionSatisfiesConstraint(entry.Version, provider.Source.PackageVersionConstraint())
+	}
+	return entry.Source == providerSourceLockLocation(provider, paths.configDir)
+}
+
+func lockEntryFingerprintMatchesProvider(name string, provider *config.ProviderEntry, configDir string, entry LockEntry) (bool, error) {
+	fingerprint, err := ProviderFingerprint(name, provider, configDir)
+	if err != nil {
+		return false, err
+	}
+	if entry.Fingerprint == fingerprint {
+		return true, nil
+	}
+	if provider == nil || !provider.Source.IsPackage() {
+		return false, nil
+	}
+	legacySource := strings.TrimSpace(entry.Source)
+	if legacySource == "" {
+		return false, nil
+	}
+	legacyFingerprint, err := hashProviderFingerprintInput(providerFingerprintInput{
+		Name:   name,
+		Source: legacySource,
+	})
+	if err != nil {
+		return false, err
+	}
+	return entry.Fingerprint == legacyFingerprint, nil
 }
 
 func resolveLockedArchiveLocation(configDir, sourceLocation, archiveRef string) (string, error) {
@@ -1695,11 +1914,11 @@ func lockEntryMetadataMatches(paths lifecyclePaths, kind, name string, providerE
 	if !found {
 		return false
 	}
-	fingerprint, err := ProviderFingerprint(name, providerEntry, paths.configDir)
-	if err != nil || entry.Fingerprint != fingerprint {
+	fingerprintMatches, err := lockEntryFingerprintMatchesProvider(name, providerEntry, paths.configDir, entry)
+	if err != nil || !fingerprintMatches {
 		return false
 	}
-	if entry.Source != providerSourceLockLocation(providerEntry, paths.configDir) {
+	if !lockEntrySourceMatchesProvider(paths, providerEntry, entry) {
 		return false
 	}
 	if entry.Kind != "" && entry.Kind != kind {
@@ -1712,11 +1931,11 @@ func uiLockEntryMetadataMatches(paths lifecyclePaths, name string, providerEntry
 	if !found {
 		return false
 	}
-	fingerprint, err := NamedUIProviderFingerprint(name, providerEntry, paths.configDir)
-	if err != nil || entry.Fingerprint != fingerprint {
+	fingerprintMatches, err := lockEntryFingerprintMatchesProvider("ui:"+name, providerEntry, paths.configDir, entry)
+	if err != nil || !fingerprintMatches {
 		return false
 	}
-	if entry.Source != providerSourceLockLocation(providerEntry, paths.configDir) {
+	if !lockEntrySourceMatchesProvider(paths, providerEntry, entry) {
 		return false
 	}
 	if entry.Kind != "" && entry.Kind != providermanifestv1.KindUI {
@@ -2471,10 +2690,10 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 			}
 			return "", lockMetadataStaleError(paths, "lock entry for %s is missing or stale", subject)
 		}
-		if lockEntry.Source != providerSourceLockLocation(provider, paths.configDir) {
+		if !lockEntrySourceMatchesProvider(paths, provider, *lockEntry) {
 			return "", lockMetadataStaleError(paths, "lock entry for %s is stale", subject)
 		}
-		fingerprint, err := NamedUIProviderFingerprint(logicalName, provider, paths.configDir)
+		fingerprintMatches, err := lockEntryFingerprintMatchesProvider("ui:"+logicalName, provider, paths.configDir, *lockEntry)
 		if err != nil {
 			return "", fmt.Errorf("fingerprinting %s: %w", subject, err)
 		}
@@ -2486,7 +2705,7 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 				_ = cleanupStaged()
 			}
 		}()
-		if lockEntry.Fingerprint != fingerprint {
+		if !fingerprintMatches {
 			return "", lockMetadataStaleError(paths, "lock entry for %s is stale", subject)
 		}
 		install, err := inspectPreparedInstall(destDir)
@@ -2512,7 +2731,7 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 					if err != nil {
 						return "", err
 					}
-					fingerprint, err = NamedUIProviderFingerprint(logicalName, provider, paths.configDir)
+					fingerprint, err := NamedUIProviderFingerprint(logicalName, provider, paths.configDir)
 					if err != nil {
 						return "", fmt.Errorf("fingerprinting %s: %w", subject, err)
 					}
@@ -2591,10 +2810,10 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 	if !ok {
 		return lockMetadataStaleError(paths, "lock entry for provider %q is missing or stale", name)
 	}
-	if entry.Source != providerSourceLockLocation(plugin, paths.configDir) {
+	if !lockEntrySourceMatchesProvider(paths, plugin, entry) {
 		return lockMetadataStaleError(paths, "lock entry for provider %q is stale", name)
 	}
-	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
+	fingerprintMatches, err := lockEntryFingerprintMatchesProvider(name, plugin, paths.configDir, entry)
 	if err != nil {
 		return fmt.Errorf("fingerprinting provider %q: %w", name, err)
 	}
@@ -2608,7 +2827,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 			_ = cleanupStaged()
 		}
 	}()
-	if entry.Fingerprint != fingerprint {
+	if !fingerprintMatches {
 		return lockMetadataStaleError(paths, "lock entry for provider %q is stale", name)
 	}
 
@@ -2640,7 +2859,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 				if err != nil {
 					return err
 				}
-				fingerprint, err = ProviderFingerprint(name, plugin, paths.configDir)
+				fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 				if err != nil {
 					return fmt.Errorf("fingerprinting provider %q: %w", name, err)
 				}
@@ -2685,10 +2904,10 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 	if entry == nil {
 		return lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", kind, name)
 	}
-	if entry.Source != providerSourceLockLocation(plugin, paths.configDir) {
+	if !lockEntrySourceMatchesProvider(paths, plugin, *entry) {
 		return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
 	}
-	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
+	fingerprintMatches, err := lockEntryFingerprintMatchesProvider(name, plugin, paths.configDir, *entry)
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
 	}
@@ -2701,7 +2920,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 			_ = cleanupStaged()
 		}
 	}()
-	if entry.Fingerprint != fingerprint {
+	if !fingerprintMatches {
 		return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
 	}
 
@@ -2736,7 +2955,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 				if err != nil {
 					return err
 				}
-				fingerprint, err = ProviderFingerprint(name, plugin, paths.configDir)
+				fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 				if err != nil {
 					return fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
 				}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -758,6 +758,305 @@ func TestSourcePluginMetadataURLPrepareAndLockedLoad(t *testing.T) {
 	}
 }
 
+func TestSourceProviderPackagePrepareAndLockedSync(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	packageSource := "github.com/acme/tools/alpha"
+	version := "1.2.3"
+	currentArchivePath := buildV2Archive(t, dir, packageSource, version, "provider-package-alpha")
+	currentArchiveData, err := os.ReadFile(currentArchivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	currentArchiveSHA := sha256.Sum256(currentArchiveData)
+	currentArchiveSHAHex := hex.EncodeToString(currentArchiveSHA[:])
+
+	var indexCount atomic.Int64
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	var failIndexAndMetadata atomic.Bool
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+	requireAuth := func(w http.ResponseWriter, r *http.Request, subject string) bool {
+		t.Helper()
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			handlerErrs <- fmt.Errorf("%s authorization = %q, want %q", subject, got, "Bearer test-token")
+			http.Error(w, "bad authorization", http.StatusBadRequest)
+			return false
+		}
+		return true
+	}
+
+	indexPath := "/provider-index.yaml"
+	metadataPath := "/providers/alpha/v1.2.3/provider-release.yaml"
+	archivePath := "/providers/alpha/v1.2.3/alpha.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case indexPath:
+			indexCount.Add(1)
+			if failIndexAndMetadata.Load() {
+				http.Error(w, "index should not be fetched after lock", http.StatusInternalServerError)
+				return
+			}
+			if !requireAuth(w, r, "index") {
+				return
+			}
+			index := fmt.Sprintf(`
+schema: gestaltd-provider-index
+schemaVersion: 1
+packages:
+  github.com/acme/tools/alpha:
+    displayName: Alpha
+    versions:
+      %s:
+        metadata: providers/alpha/v1.2.3/provider-release.yaml
+        kind: plugin
+        runtime: executable
+        platforms:
+          - %s
+`, version, providerpkg.CurrentPlatformString())
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte(index))
+		case metadataPath:
+			metadataCount.Add(1)
+			if failIndexAndMetadata.Load() {
+				http.Error(w, "metadata should not be fetched after lock", http.StatusInternalServerError)
+				return
+			}
+			if !requireAuth(w, r, "metadata") {
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   filepath.Base(archivePath),
+						SHA256: currentArchiveSHAHex,
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case archivePath:
+			archiveCount.Add(1)
+			if !requireAuth(w, r, "archive") {
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(currentArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := strings.Join([]string{
+		"apiVersion: " + config.ConfigAPIVersionV5,
+		"providerRepositories:",
+		"  local:",
+		"    url: " + srv.URL + indexPath,
+		strings.TrimSuffix(requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), "\n"),
+		"plugins:",
+		"  alpha:",
+		"    source:",
+		"      repo: local",
+		"      package: " + packageSource,
+		"      version: \">= 1.0.0, < 2.0.0\"",
+		"      auth:",
+		"        token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	legacyConfigPath := filepath.Join(dir, "legacy-direct-url.yaml")
+	legacyConfigYAML := "apiVersion: " + config.ConfigAPIVersion + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "legacy-data.db")) + strings.Join([]string{
+		"plugins:",
+		"  alpha:",
+		"    source:",
+		"      url: " + srv.URL + metadataPath,
+		"      auth:",
+		"        token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(legacyConfigPath, []byte(legacyConfigYAML), 0o644); err != nil {
+		t.Fatalf("write legacy config: %v", err)
+	}
+	legacyCfg, err := config.Load(legacyConfigPath)
+	if err != nil {
+		t.Fatalf("load legacy config: %v", err)
+	}
+	legacyFingerprint, err := ProviderFingerprint("alpha", legacyCfg.Plugins["alpha"], filepath.Dir(legacyConfigPath))
+	if err != nil {
+		t.Fatalf("legacy ProviderFingerprint: %v", err)
+	}
+
+	lc := NewLifecycle()
+	lock, err := lc.PrepareAtPath(configPath)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("PrepareAtPath: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	entry, ok := lock.Providers["alpha"]
+	if !ok {
+		t.Fatal(`lock.Providers["alpha"] not found`)
+	}
+	if entry.Source != srv.URL+metadataPath {
+		t.Fatalf("lock source = %q, want %q", entry.Source, srv.URL+metadataPath)
+	}
+	if entry.Package != packageSource {
+		t.Fatalf("lock package = %q, want %q", entry.Package, packageSource)
+	}
+	if entry.Version != version {
+		t.Fatalf("lock version = %q, want %q", entry.Version, version)
+	}
+	if got := entry.Archives[providerpkg.CurrentPlatformString()].SHA256; got != currentArchiveSHAHex {
+		t.Fatalf("archive SHA256 = %q, want %q", got, currentArchiveSHAHex)
+	}
+	if got := indexCount.Load(); got != 1 {
+		t.Fatalf("index request count = %d, want 1", got)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive request count = %d, want 1", got)
+	}
+
+	entry.Source = srv.URL + metadataPath + "?mirror=1"
+	lock.Providers["alpha"] = entry
+	if err := WriteLockfile(filepath.Join(dir, LockfileName), lock); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+	pluginRoot := filepath.Join(artifactsDir, ".gestaltd", "providers", "alpha")
+	if err := os.RemoveAll(pluginRoot); err != nil {
+		t.Fatalf("RemoveAll plugin root: %v", err)
+	}
+	failIndexAndMetadata.Store(true)
+	indexBefore := indexCount.Load()
+	metadataBefore := metadataCount.Load()
+	archiveBefore := archiveCount.Load()
+	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := indexCount.Load(); got != indexBefore {
+		t.Fatalf("index request count after sync = %d, want %d", got, indexBefore)
+	}
+	if got := metadataCount.Load(); got != metadataBefore {
+		t.Fatalf("metadata request count after sync = %d, want %d", got, metadataBefore)
+	}
+	if got := archiveCount.Load(); got != archiveBefore+1 {
+		t.Fatalf("archive request count after sync = %d, want %d", got, archiveBefore+1)
+	}
+
+	archiveBeforeLoad := archiveCount.Load()
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if got := indexCount.Load(); got != indexBefore {
+		t.Fatalf("index request count after locked load = %d, want %d", got, indexBefore)
+	}
+	if got := metadataCount.Load(); got != metadataBefore {
+		t.Fatalf("metadata request count after locked load = %d, want %d", got, metadataBefore)
+	}
+	if got := archiveCount.Load(); got != archiveBeforeLoad {
+		t.Fatalf("archive request count after locked load = %d, want %d", got, archiveBeforeLoad)
+	}
+	if cfg.Plugins["alpha"] == nil || cfg.Plugins["alpha"].ResolvedManifest == nil {
+		t.Fatal(`cfg.Plugins["alpha"].ResolvedManifest missing`)
+	}
+	if got := cfg.Plugins["alpha"].ResolvedManifest.Source; got != packageSource {
+		t.Fatalf("ResolvedManifest.Source = %q, want %q", got, packageSource)
+	}
+
+	legacyEntry := lock.Providers["alpha"]
+	legacyEntry.Source = srv.URL + metadataPath
+	legacyEntry.Fingerprint = legacyFingerprint
+	lock.Providers["alpha"] = legacyEntry
+	if err := WriteLockfile(filepath.Join(dir, LockfileName), lock); err != nil {
+		t.Fatalf("WriteLockfile legacy: %v", err)
+	}
+	if err := os.RemoveAll(pluginRoot); err != nil {
+		t.Fatalf("RemoveAll plugin root before legacy sync: %v", err)
+	}
+	archiveBeforeLegacy := archiveCount.Load()
+	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+		t.Fatalf("SyncAtPathsWithStatePaths legacy lock: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := indexCount.Load(); got != indexBefore {
+		t.Fatalf("index request count after legacy sync = %d, want %d", got, indexBefore)
+	}
+	if got := metadataCount.Load(); got != metadataBefore {
+		t.Fatalf("metadata request count after legacy sync = %d, want %d", got, metadataBefore)
+	}
+	if got := archiveCount.Load(); got != archiveBeforeLegacy+1 {
+		t.Fatalf("archive request count after legacy sync = %d, want %d", got, archiveBeforeLegacy+1)
+	}
+	archiveBeforeLegacyLoad := archiveCount.Load()
+	if _, _, err := lc.LoadForExecutionAtPath(configPath, true); err != nil {
+		t.Fatalf("LoadForExecutionAtPath(legacy locked=true): %v", err)
+	}
+	if got := indexCount.Load(); got != indexBefore {
+		t.Fatalf("index request count after legacy locked load = %d, want %d", got, indexBefore)
+	}
+	if got := metadataCount.Load(); got != metadataBefore {
+		t.Fatalf("metadata request count after legacy locked load = %d, want %d", got, metadataBefore)
+	}
+	if got := archiveCount.Load(); got != archiveBeforeLegacyLoad {
+		t.Fatalf("archive request count after legacy locked load = %d, want %d", got, archiveBeforeLegacyLoad)
+	}
+}
+
 func TestSourceWorkflowMetadataURLPrepareAndLockedLoad(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3125,6 +3125,97 @@ func TestLockMatchesConfig_RemoteS3UsesResourceNameFingerprint(t *testing.T) {
 	}
 }
 
+func TestLockMatchesConfig_UIPackageSourceAllowsLegacyMetadataURLFingerprint(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	packageSource := "github.com/acme/tools/roadmap-ui"
+	version := "0.9.1"
+	metadataURL := "https://example.invalid/providers/roadmap/provider-release.yaml"
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfgYAML := "apiVersion: " + config.ConfigAPIVersionV5 + "\n" + strings.Join([]string{
+		"providerRepositories:",
+		"  local:",
+		"    url: file://" + filepath.ToSlash(filepath.Join(dir, "provider-index.yaml")),
+	}, "\n") + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + strings.Join([]string{
+		"  ui:",
+		"    roadmap:",
+		"      source:",
+		"        repo: local",
+		"        package: " + packageSource,
+		"        version: " + version,
+		"      path: /roadmap",
+		"server:",
+	}, "\n") + "\n" + requiredServerDatastoreYAML() + "  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	cfg.Plugins = nil
+	cfg.Runtime.Providers = nil
+	cfg.Providers = config.ProvidersConfig{UI: map[string]*config.UIEntry{"roadmap": cfg.Providers.UI["roadmap"]}}
+	paths := lifecyclePathsForConfig(cfgPath)
+	uiDir := uiDestDir(paths, "roadmap")
+	if err := os.MkdirAll(filepath.Join(uiDir, "dist"), 0o755); err != nil {
+		t.Fatalf("MkdirAll ui dist: %v", err)
+	}
+	manifest, err := providerpkg.EncodeManifest(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindUI,
+		Source:      packageSource,
+		Version:     version,
+		DisplayName: "Roadmap UI",
+		Spec:        &providermanifestv1.Spec{AssetRoot: "dist"},
+	})
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(uiDir, providerpkg.ManifestFile), manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(uiDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index: %v", err)
+	}
+
+	legacyFingerprint, err := NamedUIProviderFingerprint("roadmap", &config.ProviderEntry{
+		Source: config.NewMetadataSource(metadataURL),
+	}, paths.configDir)
+	if err != nil {
+		t.Fatalf("NamedUIProviderFingerprint legacy: %v", err)
+	}
+	lock := newLockfile()
+	lock.UIs["roadmap"] = LockEntry{
+		Fingerprint: legacyFingerprint,
+		Package:     packageSource,
+		Kind:        providermanifestv1.KindUI,
+		Runtime:     providerReleaseRuntimeUI,
+		Source:      metadataURL,
+		Version:     version,
+	}
+	lockEntry := lock.UIs["roadmap"]
+	if !uiLockEntryMetadataMatches(paths, "roadmap", &cfg.Providers.UI["roadmap"].ProviderEntry, lockEntry, true) {
+		t.Fatal("uiLockEntryMetadataMatches returned false for legacy metadata URL fingerprint")
+	}
+	install, err := inspectPreparedInstall(uiDestDir(paths, "roadmap"))
+	if err != nil {
+		t.Fatalf("inspectPreparedInstall: %v", err)
+	}
+	if !preparedManifestMatchesLock(lockEntry, install.manifest) {
+		t.Fatal("preparedManifestMatchesLock returned false")
+	}
+	if install.assetRootPath == "" {
+		t.Fatal("prepared install assetRootPath is empty")
+	}
+	if _, err := os.Stat(install.assetRootPath); err != nil {
+		t.Fatalf("Stat assetRootPath: %v", err)
+	}
+	if !lockMatchesConfig(cfg, paths, lock) {
+		t.Fatal("lockMatchesConfig returned false for UI package source with legacy metadata URL fingerprint")
+	}
+}
+
 func mustFingerprint(t *testing.T, name string, entry *config.ProviderEntry, configDir string) string {
 	t.Helper()
 	fingerprint, err := ProviderFingerprint(name, entry, configDir)

--- a/gestaltd/internal/providerregistry/registry.go
+++ b/gestaltd/internal/providerregistry/registry.go
@@ -1,0 +1,480 @@
+package providerregistry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	IndexSchema        = "gestaltd-provider-index"
+	IndexSchemaVersion = 1
+	MaxIndexBytes      = 10 << 20
+
+	DefaultRepositoryName = "valon"
+	DefaultRepositoryURL  = "https://raw.githubusercontent.com/valon-technologies/gestalt-providers/main/provider-index.yaml"
+)
+
+var (
+	repoNameRe        = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+	hostRe            = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$`)
+	pathSegmentRe     = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+	exactVersionRe    = regexp.MustCompile(`^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
+	errNoPackageMatch = errors.New("provider package not found")
+)
+
+type Repository struct {
+	URL   string `yaml:"url"`
+	Token string `yaml:"token,omitempty"`
+}
+
+type NamedRepository struct {
+	Name  string
+	URL   string
+	Token string
+}
+
+type Index struct {
+	Schema        string             `yaml:"schema"`
+	SchemaVersion int                `yaml:"schemaVersion"`
+	Packages      map[string]Package `yaml:"packages"`
+}
+
+type Package struct {
+	DisplayName string             `yaml:"displayName,omitempty"`
+	Description string             `yaml:"description,omitempty"`
+	Versions    map[string]Version `yaml:"versions"`
+}
+
+type Version struct {
+	Metadata  string   `yaml:"metadata"`
+	Kind      string   `yaml:"kind"`
+	Runtime   string   `yaml:"runtime"`
+	Platforms []string `yaml:"platforms,omitempty"`
+	Yanked    bool     `yaml:"yanked,omitempty"`
+}
+
+type ResolvedPackage struct {
+	RepositoryName string
+	RepositoryURL  string
+	Package        string
+	Version        string
+	MetadataURL    string
+	Kind           string
+	Runtime        string
+	Platforms      []string
+	Yanked         bool
+}
+
+type ResolveRequest struct {
+	Package           string
+	VersionConstraint string
+	RepositoryName    string
+	Repositories      []NamedRepository
+}
+
+type Resolver struct {
+	Client *http.Client
+}
+
+func ValidateRepositoryName(name string) error {
+	name = strings.TrimSpace(name)
+	if !repoNameRe.MatchString(name) {
+		return fmt.Errorf("provider repository name %q must contain only lowercase letters, digits, dots, underscores, and hyphens", name)
+	}
+	return nil
+}
+
+func ValidatePackageAddress(address string) error {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return fmt.Errorf("provider package address is required")
+	}
+	parts := strings.Split(address, "/")
+	if len(parts) < 4 {
+		return fmt.Errorf("provider package address %q must be host/owner/repo/path", address)
+	}
+	if !hostRe.MatchString(parts[0]) {
+		return fmt.Errorf("provider package address %q has invalid host %q", address, parts[0])
+	}
+	for _, seg := range parts[1:] {
+		if !pathSegmentRe.MatchString(seg) {
+			return fmt.Errorf("provider package address %q has invalid segment %q", address, seg)
+		}
+	}
+	return nil
+}
+
+func PackageName(address string) string {
+	return path.Base(strings.TrimSpace(address))
+}
+
+func DefaultRepositories() []NamedRepository {
+	return []NamedRepository{{
+		Name: DefaultRepositoryName,
+		URL:  DefaultRepositoryURL,
+	}}
+}
+
+func (r *Resolver) Resolve(ctx context.Context, req ResolveRequest) (*ResolvedPackage, error) {
+	pkg := strings.TrimSpace(req.Package)
+	if err := ValidatePackageAddress(pkg); err != nil {
+		return nil, err
+	}
+	repos := req.Repositories
+	if len(repos) == 0 {
+		repos = DefaultRepositories()
+	}
+	if repoName := strings.TrimSpace(req.RepositoryName); repoName != "" {
+		if err := ValidateRepositoryName(repoName); err != nil {
+			return nil, err
+		}
+		repos = filterRepositories(repos, repoName)
+		if len(repos) == 0 {
+			return nil, fmt.Errorf("provider repository %q is not configured", repoName)
+		}
+	}
+
+	var matches []ResolvedPackage
+	var errs []error
+	for _, repo := range repos {
+		index, err := FetchIndex(ctx, r.client(), repo.URL, repo.Token)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", repo.Name, err))
+			continue
+		}
+		entry, ok := index.Packages[pkg]
+		if !ok {
+			continue
+		}
+		version, selected, err := SelectVersion(entry.Versions, req.VersionConstraint)
+		if err != nil {
+			return nil, fmt.Errorf("resolve %s from %s: %w", pkg, repo.Name, err)
+		}
+		metadataURL, err := ResolveMetadataURL(repo.URL, selected.Metadata)
+		if err != nil {
+			return nil, fmt.Errorf("resolve metadata URL for %s %s from %s: %w", pkg, version, repo.Name, err)
+		}
+		matches = append(matches, ResolvedPackage{
+			RepositoryName: repo.Name,
+			RepositoryURL:  repo.URL,
+			Package:        pkg,
+			Version:        version,
+			MetadataURL:    metadataURL,
+			Kind:           strings.TrimSpace(selected.Kind),
+			Runtime:        strings.TrimSpace(selected.Runtime),
+			Platforms:      slices.Clone(selected.Platforms),
+			Yanked:         selected.Yanked,
+		})
+	}
+	if len(matches) == 0 {
+		if len(errs) > 0 {
+			return nil, errors.Join(errs...)
+		}
+		return nil, fmt.Errorf("%w: %s", errNoPackageMatch, pkg)
+	}
+	if len(matches) > 1 && strings.TrimSpace(req.RepositoryName) == "" {
+		names := make([]string, 0, len(matches))
+		for i := range matches {
+			names = append(names, matches[i].RepositoryName)
+		}
+		slices.Sort(names)
+		return nil, fmt.Errorf("provider package %q is available from multiple repositories (%s); pass --repo or set source.repo", pkg, strings.Join(names, ", "))
+	}
+	return &matches[0], nil
+}
+
+func (r *Resolver) client() *http.Client {
+	if r != nil && r.Client != nil {
+		return r.Client
+	}
+	return http.DefaultClient
+}
+
+func filterRepositories(repos []NamedRepository, name string) []NamedRepository {
+	out := repos[:0]
+	for _, repo := range repos {
+		if repo.Name == name {
+			out = append(out, repo)
+		}
+	}
+	return out
+}
+
+func FetchIndex(ctx context.Context, client *http.Client, rawURL, token string) (*Index, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return nil, fmt.Errorf("provider repository URL is required")
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+	case "file":
+		return readIndexFile(parsed.Path)
+	default:
+		return nil, fmt.Errorf("provider repository URL must be http(s) or file URL")
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/yaml, application/x-yaml, text/yaml, application/octet-stream")
+	if token = strings.TrimSpace(token); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d fetching provider repository index from %s", resp.StatusCode, rawURL)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, MaxIndexBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > MaxIndexBytes {
+		return nil, fmt.Errorf("provider repository index exceeds %d byte limit", MaxIndexBytes)
+	}
+	return DecodeIndex(data)
+}
+
+func readIndexFile(path string) (*Index, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > MaxIndexBytes {
+		return nil, fmt.Errorf("provider repository index exceeds %d byte limit", MaxIndexBytes)
+	}
+	return DecodeIndex(data)
+}
+
+func DecodeIndex(data []byte) (*Index, error) {
+	var index Index
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&index); err != nil && err != io.EOF {
+		return nil, fmt.Errorf("parse provider repository index: %w", err)
+	}
+	if err := ValidateIndex(&index); err != nil {
+		return nil, err
+	}
+	return &index, nil
+}
+
+func ValidateIndex(index *Index) error {
+	if index == nil {
+		return fmt.Errorf("provider repository index is required")
+	}
+	if index.Schema != IndexSchema {
+		return fmt.Errorf("unsupported provider repository index schema %q", index.Schema)
+	}
+	if index.SchemaVersion != IndexSchemaVersion {
+		return fmt.Errorf("unsupported provider repository index schema version %d", index.SchemaVersion)
+	}
+	for pkg, entry := range index.Packages {
+		if err := ValidatePackageAddress(pkg); err != nil {
+			return err
+		}
+		if len(entry.Versions) == 0 {
+			return fmt.Errorf("provider package %q has no versions", pkg)
+		}
+		for version, release := range entry.Versions {
+			if _, err := semver.NewVersion(version); err != nil {
+				return fmt.Errorf("provider package %q version %q is invalid: %w", pkg, version, err)
+			}
+			if strings.TrimSpace(release.Metadata) == "" {
+				return fmt.Errorf("provider package %q version %q metadata is required", pkg, version)
+			}
+			if strings.TrimSpace(release.Kind) == "" {
+				return fmt.Errorf("provider package %q version %q kind is required", pkg, version)
+			}
+			if strings.TrimSpace(release.Runtime) == "" {
+				return fmt.Errorf("provider package %q version %q runtime is required", pkg, version)
+			}
+		}
+	}
+	return nil
+}
+
+func SelectVersion(versions map[string]Version, constraint string) (string, Version, error) {
+	if len(versions) == 0 {
+		return "", Version{}, fmt.Errorf("no versions available")
+	}
+	type candidate struct {
+		raw     string
+		version *semver.Version
+		entry   Version
+	}
+	candidates := make([]candidate, 0, len(versions))
+	for raw, entry := range versions {
+		v, err := semver.NewVersion(raw)
+		if err != nil {
+			return "", Version{}, fmt.Errorf("invalid version %q: %w", raw, err)
+		}
+		candidates = append(candidates, candidate{raw: raw, version: v, entry: entry})
+	}
+	slices.SortFunc(candidates, func(a, b candidate) int {
+		return -a.version.Compare(b.version)
+	})
+
+	constraint = strings.TrimSpace(constraint)
+	if constraint == "" {
+		for _, c := range candidates {
+			if !c.entry.Yanked && c.version.Prerelease() == "" {
+				return c.raw, c.entry, nil
+			}
+		}
+		for _, c := range candidates {
+			if !c.entry.Yanked {
+				return c.raw, c.entry, nil
+			}
+		}
+		return "", Version{}, fmt.Errorf("all versions are yanked")
+	}
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return "", Version{}, fmt.Errorf("invalid version constraint %q: %w", constraint, err)
+	}
+	exact := exactVersionRe.MatchString(constraint)
+	for _, candidate := range candidates {
+		if candidate.entry.Yanked && (!exact || candidate.raw != constraint) {
+			continue
+		}
+		if c.Check(candidate.version) {
+			return candidate.raw, candidate.entry, nil
+		}
+	}
+	return "", Version{}, fmt.Errorf("no versions match constraint %q", constraint)
+}
+
+func VersionSatisfiesConstraint(version, constraint string) bool {
+	version = strings.TrimSpace(version)
+	constraint = strings.TrimSpace(constraint)
+	if version == "" {
+		return false
+	}
+	if constraint == "" {
+		return true
+	}
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return false
+	}
+	return c.Check(v)
+}
+
+func ResolveMetadataURL(indexURL, metadata string) (string, error) {
+	metadata = strings.TrimSpace(metadata)
+	if metadata == "" {
+		return "", fmt.Errorf("metadata URL is required")
+	}
+	parsed, err := url.Parse(metadata)
+	if err != nil {
+		return "", err
+	}
+	if parsed.IsAbs() {
+		switch parsed.Scheme {
+		case "http", "https", "file":
+			return parsed.String(), nil
+		default:
+			return "", fmt.Errorf("metadata URL must be http(s), file, or relative")
+		}
+	}
+	base, err := url.Parse(strings.TrimSpace(indexURL))
+	if err != nil {
+		return "", err
+	}
+	return base.ResolveReference(parsed).String(), nil
+}
+
+func UserRepositoryStorePath() string {
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+		return filepath.Join(xdg, "gestalt", "provider-repositories.yaml")
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".config", "gestalt", "provider-repositories.yaml")
+	}
+	return ""
+}
+
+func UserRepositoryCacheDir() string {
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CACHE_HOME")); xdg != "" {
+		return filepath.Join(xdg, "gestalt", "provider-repositories")
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".cache", "gestalt", "provider-repositories")
+	}
+	return ""
+}
+
+type RepositoryStore struct {
+	Repositories map[string]Repository `yaml:"repositories,omitempty"`
+}
+
+func ReadRepositoryStore(path string) (*RepositoryStore, error) {
+	if strings.TrimSpace(path) == "" {
+		return &RepositoryStore{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &RepositoryStore{}, nil
+		}
+		return nil, err
+	}
+	var store RepositoryStore
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&store); err != nil && err != io.EOF {
+		return nil, err
+	}
+	return &store, nil
+}
+
+func WriteRepositoryStore(path string, store *RepositoryStore) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("provider repository store path is required")
+	}
+	if store == nil {
+		store = &RepositoryStore{}
+	}
+	for name := range store.Repositories {
+		if err := ValidateRepositoryName(name); err != nil {
+			return err
+		}
+	}
+	data, err := yaml.Marshal(store)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}

--- a/gestaltd/services/plugins/source/source.go
+++ b/gestaltd/services/plugins/source/source.go
@@ -16,6 +16,7 @@ const (
 )
 
 var segmentRe = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+var hostRe = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$`)
 
 type Source struct {
 	Host  string
@@ -37,8 +38,8 @@ func Parse(raw string) (Source, error) {
 
 	host, owner, repo := parts[0], parts[1], parts[2]
 
-	if host != HostGitHub {
-		return Source{}, fmt.Errorf("plugin source: unsupported host %q (only %s is supported)", host, HostGitHub)
+	if !hostRe.MatchString(host) {
+		return Source{}, fmt.Errorf("plugin source: invalid host %q", host)
 	}
 
 	for _, seg := range parts[1:] {

--- a/gestaltd/services/plugins/source/source_test.go
+++ b/gestaltd/services/plugins/source/source_test.go
@@ -44,9 +44,9 @@ func TestParse(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "reject non-github host",
-			input:   "gitlab.com/testowner/testrepo/testplugin",
-			wantErr: true,
+			name:  "valid non-github host",
+			input: "gitlab.com/testowner/testrepo/testplugin",
+			want:  Source{Host: "gitlab.com", Owner: "testowner", Repo: "testrepo", Path: "testplugin"},
 		},
 		{
 			name:    "reject empty segment",


### PR DESCRIPTION
## Summary
Adds the `gestaltd` provider-package registry path for `gestaltd provider add` style workflows:
- v5 config supports `providerRepositories` and `source: { repo, package, version }`
- package sources resolve through provider indexes during lock/prepare and lock by package/version
- locked sync/load rely on existing lock metadata, not live index metadata
- migrated package-source configs continue accepting existing direct-URL lock fingerprints when package/version match, including named UI providers
- provider package addresses now support generic DNS-like hosts
- adds `gestaltd provider add/info/remove/search/upgrade/repo` commands

## Interface Changes
- New/changed interface:
  - `apiVersion: gestaltd.config/v5`
  - `providerRepositories.<name>.url`
  - provider `source.repo/source.package/source.version`
  - `gestaltd provider repo add|list|remove|update`
  - `gestaltd provider search|info|add|remove|upgrade`
- Example usage:

```yaml
apiVersion: gestaltd.config/v5
providerRepositories:
  valon:
    url: https://raw.githubusercontent.com/valon-technologies/gestalt-providers/main/provider-index.yaml
plugins:
  slack:
    source:
      repo: valon
      package: github.com/valon-technologies/gestalt-providers/plugins/slack
      version: 0.0.1-alpha.35
```

```sh
gestaltd provider repo add local file:///tmp/provider-index.yaml --config gestalt.yaml
gestaltd provider add github.com/acme/providers/alpha --config gestalt.yaml --repo local --package-source
```

## Functional/Integration Tests
- Tests added or augmented:
  - config package source parsing/v5 requirement/layered v4-v5 behavior
  - lifecycle package index prepare plus locked sync/load without index/metadata fetch
  - lifecycle migration case where a package-source config reuses a pre-existing direct-URL lock fingerprint
  - lock matching migration case for package-source UI providers with legacy direct-URL lock fingerprints
  - CLI help and real-binary `provider repo add` + `provider add --package-source`
  - generic provider package source parsing
- Contract boundary covered:
  - YAML config contract, provider index resolution, lockfile matching/materialization, CLI config edit flow, lockfile migration compatibility
- Commands run:
  - `golangci-lint run`
  - `go test ./internal/operator -run 'TestLockMatchesConfig_UIPackageSourceAllowsLegacyMetadataURLFingerprint|TestSourceProviderPackagePrepareAndLockedSync|TestLockMatchesConfig_FalseWithNilLock' -count=1`
  - `go test ./internal/config ./internal/operator ./internal/daemon ./services/plugins/source ./internal/providerregistry`
