### PR TITLE
[codex] Fix response mapping passthrough

### DIFF
--- a/gestaltd/services/plugins/declarative/response_mapping.go
+++ b/gestaltd/services/plugins/declarative/response_mapping.go
@@ -30,12 +30,14 @@ func applyResponseMapping(result *core.OperationResult, cfg *ResponseMappingConf
 
 	output := make(map[string]any)
 
-	if cfg.DataPath != "" {
-		if data, ok := apiexec.ExtractJSONPath(raw, cfg.DataPath); ok {
-			output["data"] = data
-		} else {
-			return result
-		}
+	if cfg.DataPath == "" {
+		return result
+	}
+
+	if data, ok := apiexec.ExtractJSONPath(raw, cfg.DataPath); ok {
+		output["data"] = data
+	} else {
+		return result
 	}
 
 	if cfg.Pagination != nil {

--- a/gestaltd/services/plugins/declarative/response_mapping_test.go
+++ b/gestaltd/services/plugins/declarative/response_mapping_test.go
@@ -143,6 +143,43 @@ func TestResponseMappingPassesThroughErrors(t *testing.T) {
 	}
 }
 
+func TestResponseMappingPassesThroughWhenDataPathMissing(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"not_abc123","title":"Meeting notes","hasMore":true,"cursor":"next"}`))
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		ResponseMapping: &ResponseMappingConfig{
+			Pagination: &PaginationProjectionConfig{
+				HasMore: &apiexec.ValueSelector{
+					Source: apiexec.ValueSelectorSourceBody,
+					Path:   "hasMore",
+				},
+				Cursor: &apiexec.ValueSelector{
+					Source: apiexec.ValueSelectorSourceBody,
+					Path:   "cursor",
+				},
+			},
+		},
+	}
+	setTestCatalog(b, restCatalogOp("get", http.MethodGet, "/get"))
+
+	result, err := b.Execute(context.Background(), "get", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if result.Body != `{"id":"not_abc123","title":"Meeting notes","hasMore":true,"cursor":"next"}` {
+		t.Fatalf("body = %s, want original response", result.Body)
+	}
+}
+
 func TestResponseMappingWithoutConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Preserve original declarative plugin responses when `responseMapping` does not declare a `dataPath`
- Add regression coverage for pagination-only mappings so single-object responses are not rewritten away
- Fixes the runtime side of Granola `getNote` returning an empty object with the currently pinned provider artifact

## Test plan
- [x] `go test ./services/plugins/declarative`
- [x] `go test ./services/plugins/providerpkg`
- [x] `go test ./services/plugins/apiexec`
- [x] `gestaltd provider validate --path /Users/hugh/src/gestalt-providers/plugins/granola`
- [x] Temporary `gestaltd provider release --version 0.0.1-alpha.5` for Granola