### PR TITLE
fix docker image publish step

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -206,3 +206,32 @@ jobs:
 
       - name: Validate Kubernetes schemas (preparation)
         run: kubeconform -strict -summary /tmp/rendered-preparation.yaml
+
+  docker-build:
+    name: Docker Image Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Build static image
+        env:
+          DOCKER_BUILDKIT: "1"
+        run: |
+          docker build \
+            --file gestaltd/Dockerfile \
+            --target static \
+            --build-arg GESTALT_VERSION=ci \
+            --tag gestaltd:ci-static \
+            .
+
+      - name: Build Alpine image
+        env:
+          DOCKER_BUILDKIT: "1"
+        run: |
+          docker build \
+            --file gestaltd/Dockerfile \
+            --target alpine \
+            --build-arg GESTALT_VERSION=ci \
+            --tag gestaltd:ci-alpine \
+            .

--- a/gestaltd/Dockerfile
+++ b/gestaltd/Dockerfile
@@ -7,6 +7,7 @@ ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestaltd
 
 FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS build-binary
 WORKDIR /build
+COPY go.mod go.sum ./
 COPY gestaltd/go.mod gestaltd/go.sum gestaltd/
 COPY sdk/go/go.mod sdk/go/go.sum sdk/go/
 RUN cd gestaltd && go mod download


### PR DESCRIPTION
## Description

Fix the `gestaltd` Docker build after [#1712](https://github.com/valon-technologies/gestalt/pull/1712) introduced the root Go module replacement, which made the Docker dependency layer look for `/build/go.mod` before it had been copied.

The failure showed up in the [`Publish Docker Image (static)` job](https://github.com/valon-technologies/gestalt/actions/runs/25259881320/job/74065389590) and the [`Publish Docker Image (Alpine)` job](https://github.com/valon-technologies/gestalt/actions/runs/25259881320/job/74065389605). This change copies the root `go.mod`/`go.sum` before `go mod download` and adds CI Docker builds for both image targets so this is caught before release tagging.
