### PR TITLE
Require bounded agent list hydration

### DIFF
--- a/docs/content/custom-providers/agent.mdx
+++ b/docs/content/custom-providers/agent.mdx
@@ -61,6 +61,11 @@ The host passes a `tool_grant` to `CreateTurn` when tools are available. Pass
 that grant back to `ListTools` or `ExecuteTool`; it is the scoped authority
 for resolving or executing tools during that turn.
 
+Providers that support limited or summary list requests must advertise bounded
+list hydration from `GetCapabilities`. When Gestalt asks for `limit` or
+`summary_only`, it expects the provider to apply those options before returning
+results instead of hydrating the full session or turn history in the daemon.
+
 ## Observability
 
 Provider authors do not need to emit the baseline `gestaltd` agent metrics.
@@ -251,11 +256,12 @@ events.
 
     func (p *Provider) GetCapabilities(context.Context, *proto.GetAgentProviderCapabilitiesRequest) (*proto.AgentProviderCapabilities, error) {
       return &proto.AgentProviderCapabilities{
-        StreamingText:    true,
-        ToolCalls:        true,
-        StructuredOutput: true,
-        Interactions:     true,
-        ResumableTurns:   true,
+        StreamingText:        true,
+        ToolCalls:            true,
+        StructuredOutput:     true,
+        Interactions:         true,
+        ResumableTurns:       true,
+        BoundedListHydration: true,
       }, nil
     }
 
@@ -368,6 +374,7 @@ events.
                 structured_output=True,
                 interactions=True,
                 resumable_turns=True,
+                bounded_list_hydration=True,
             )
 
 
@@ -551,6 +558,7 @@ events.
                 structured_output: true,
                 interactions: true,
                 resumable_turns: true,
+                bounded_list_hydration: true,
                 ..Default::default()
             }))
         }
@@ -715,6 +723,7 @@ events.
           structuredOutput: true,
           interactions: true,
           resumableTurns: true,
+          boundedListHydration: true,
         };
       },
     });

--- a/gestaltd/core/agent/agent.go
+++ b/gestaltd/core/agent/agent.go
@@ -198,11 +198,11 @@ type ListSessionsRequest struct {
 	Subject    SubjectContext
 	SessionIDs []string
 	State      SessionState
-	// Limit asks providers with BoundedListHydration to apply the cap before returning.
+	// Limit asks providers to apply the cap before returning.
 	// Providers must order sessions by recency before limiting: last turn time, then
 	// updated time, then created time, newest first.
 	Limit int
-	// SummaryOnly asks providers with BoundedListHydration to omit heavy fields.
+	// SummaryOnly asks providers to omit heavy fields.
 	// Exact SessionIDs may still be served by direct lookup rather than projections.
 	SummaryOnly bool
 }
@@ -260,10 +260,10 @@ type ListTurnsRequest struct {
 	Subject   SubjectContext
 	TurnIDs   []string
 	Status    ExecutionStatus
-	// Limit asks providers with BoundedListHydration to apply the cap before returning.
+	// Limit asks providers to apply the cap before returning.
 	// Providers must order turns by creation time, newest first, before limiting.
 	Limit int
-	// SummaryOnly asks providers with BoundedListHydration to omit heavy turn fields.
+	// SummaryOnly asks providers to omit heavy turn fields.
 	// Exact TurnIDs may still be served by direct lookup rather than projections.
 	SummaryOnly bool
 }
@@ -448,8 +448,8 @@ type ManagerCreateTurnRequest struct {
 type ManagerListSessionsRequest struct {
 	ProviderName string
 	State        SessionState
-	// Limit caps the globally sorted manager response. Providers that advertise
-	// BoundedListHydration also receive this cap for per-provider bounded listing.
+	// Limit caps the globally sorted manager response. Bounded providers receive
+	// this cap for per-provider listing.
 	Limit       int
 	SummaryOnly bool
 }

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -473,22 +473,16 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 	requireBounded := req.SummaryOnly || limit > 0
 	out := make([]*coreagent.Session, 0)
 	for _, candidate := range candidates {
-		providerLimit := limit
-		providerSummaryOnly := req.SummaryOnly
 		if requireBounded {
 			if err := requireAgentProviderBoundedListHydration(ctx, candidate.name, candidate.provider); err != nil {
-				if !errors.Is(err, ErrAgentBoundedListUnsupported) {
-					return nil, err
-				}
-				providerLimit = 0
-				providerSummaryOnly = false
+				return nil, err
 			}
 		}
 		sessions, err := candidate.provider.ListSessions(ctx, coreagent.ListSessionsRequest{
 			Subject:     agentSubjectFromPrincipal(p),
 			State:       req.State,
-			Limit:       providerLimit,
-			SummaryOnly: providerSummaryOnly,
+			Limit:       limit,
+			SummaryOnly: req.SummaryOnly,
 		})
 		if err != nil {
 			return nil, err
@@ -668,23 +662,17 @@ func (m *Manager) ListTurns(ctx context.Context, p *principal.Principal, req cor
 	if err != nil {
 		return nil, err
 	}
-	providerLimit := limit
-	providerSummaryOnly := req.SummaryOnly
 	if req.SummaryOnly || limit > 0 {
 		if err := requireAgentProviderBoundedListHydration(ctx, ownedSession.providerName, ownedSession.provider); err != nil {
-			if !errors.Is(err, ErrAgentBoundedListUnsupported) {
-				return nil, err
-			}
-			providerLimit = 0
-			providerSummaryOnly = false
+			return nil, err
 		}
 	}
 	turns, err = ownedSession.provider.ListTurns(ctx, coreagent.ListTurnsRequest{
 		SessionID:   ownedSession.session.ID,
 		Subject:     agentSubjectFromPrincipal(p),
 		Status:      req.Status,
-		Limit:       providerLimit,
-		SummaryOnly: providerSummaryOnly,
+		Limit:       limit,
+		SummaryOnly: req.SummaryOnly,
 	})
 	if err != nil {
 		return nil, err
@@ -2405,23 +2393,12 @@ func requireAgentProviderBoundedListHydration(ctx context.Context, providerName 
 	}
 	caps, err := provider.GetCapabilities(ctx, coreagent.GetCapabilitiesRequest{})
 	if err != nil {
-		if agentProviderCapabilitiesUnimplemented(err) {
-			return errAgentBoundedListUnsupported(providerName)
-		}
 		return err
 	}
 	if caps != nil && caps.BoundedListHydration {
 		return nil
 	}
 	return errAgentBoundedListUnsupported(providerName)
-}
-
-func agentProviderCapabilitiesUnimplemented(err error) bool {
-	if status.Code(err) == codes.Unimplemented {
-		return true
-	}
-	message := strings.ToLower(strings.TrimSpace(err.Error()))
-	return strings.Contains(message, "get capabilities") && strings.Contains(message, "not implemented")
 }
 
 func errAgentBoundedListUnsupported(providerName string) error {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
@@ -393,250 +392,72 @@ func TestManagerCreateTurnAcceptsProviderOwnedIDForIdempotentReplay(t *testing.T
 	}
 }
 
-func TestManagerListSessionsFallsBackToFullListForLegacyProvider(t *testing.T) {
+func TestManagerListSessionsRequiresBoundedHydrationForLimitedLists(t *testing.T) {
 	t.Parallel()
 
-	provider := newRouteCountingAgentProvider("legacy")
+	provider := newRouteCountingAgentProvider("unbounded")
 	provider.capabilities = &coreagent.ProviderCapabilities{
 		SupportedToolSources: []coreagent.ToolSourceMode{coreagent.ToolSourceModeMCPCatalog},
 	}
 	subjectID := principal.UserSubjectID("user-1")
-	oldTime := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
-	newTime := oldTime.Add(time.Hour)
-	provider.sessions["old"] = &coreagent.Session{
-		ID:           "old",
-		ProviderName: "legacy",
-		State:        coreagent.SessionStateActive,
-		Metadata:     map[string]any{"heavy": "metadata"},
-		CreatedBy:    coreagent.Actor{SubjectID: subjectID},
-		UpdatedAt:    &oldTime,
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "unbounded",
+			names:       []string{"unbounded"},
+			providers: map[string]*routeCountingAgentProvider{
+				"unbounded": provider,
+			},
+		},
+		ToolGrants: newAgentManagerTestToolGrants(t),
+	})
+
+	_, err := manager.ListSessions(context.Background(), &principal.Principal{SubjectID: subjectID}, coreagent.ManagerListSessionsRequest{
+		ProviderName: "unbounded",
+		Limit:        1,
+	})
+	if !errors.Is(err, ErrAgentBoundedListUnsupported) {
+		t.Fatalf("ListSessions error = %v, want ErrAgentBoundedListUnsupported", err)
 	}
-	provider.sessions["new"] = &coreagent.Session{
-		ID:           "new",
-		ProviderName: "legacy",
+	if len(provider.listSessionReqs) != 0 {
+		t.Fatalf("provider ListSessions calls = %d, want 0", len(provider.listSessionReqs))
+	}
+}
+
+func TestManagerListTurnsRequiresBoundedHydrationForSummaryLists(t *testing.T) {
+	t.Parallel()
+
+	provider := newRouteCountingAgentProvider("unbounded")
+	provider.capabilities = &coreagent.ProviderCapabilities{
+		SupportedToolSources: []coreagent.ToolSourceMode{coreagent.ToolSourceModeMCPCatalog},
+	}
+	subjectID := principal.UserSubjectID("user-1")
+	provider.sessions["session-1"] = &coreagent.Session{
+		ID:           "session-1",
+		ProviderName: "unbounded",
 		State:        coreagent.SessionStateActive,
-		Metadata:     map[string]any{"heavy": "metadata"},
 		CreatedBy:    coreagent.Actor{SubjectID: subjectID},
-		UpdatedAt:    &newTime,
 	}
 	manager := newTestManager(t, Config{
 		Agent: &routeCountingAgentControl{
-			defaultName: "legacy",
-			names:       []string{"legacy"},
+			defaultName: "unbounded",
+			names:       []string{"unbounded"},
 			providers: map[string]*routeCountingAgentProvider{
-				"legacy": provider,
+				"unbounded": provider,
 			},
 		},
 		ToolGrants: newAgentManagerTestToolGrants(t),
 	})
 	p := &principal.Principal{SubjectID: subjectID}
 
-	sessions, err := manager.ListSessions(context.Background(), p, coreagent.ManagerListSessionsRequest{
-		ProviderName: "legacy",
-		State:        coreagent.SessionStateActive,
-		Limit:        1,
-		SummaryOnly:  true,
-	})
-	if err != nil {
-		t.Fatalf("ListSessions: %v", err)
-	}
-	if len(provider.listSessionReqs) != 1 {
-		t.Fatalf("provider ListSessions calls = %d, want 1", len(provider.listSessionReqs))
-	}
-	if got := provider.listSessionReqs[0].Limit; got != 0 {
-		t.Fatalf("legacy provider limit = %d, want fallback limit 0", got)
-	}
-	if provider.listSessionReqs[0].SummaryOnly {
-		t.Fatal("legacy provider received summary_only=true, want fallback full hydration")
-	}
-	if len(sessions) != 1 || sessions[0].ID != "new" {
-		t.Fatalf("manager sessions = %#v, want only newest session", sessions)
-	}
-	if sessions[0].Metadata != nil {
-		t.Fatalf("summary session metadata = %#v, want nil", sessions[0].Metadata)
-	}
-}
-
-func TestManagerListSessionsFallsBackWhenLegacyProviderCapabilitiesUnimplemented(t *testing.T) {
-	t.Parallel()
-
-	provider := newRouteCountingAgentProvider("legacy")
-	_, provider.capabilitiesErr = coreagent.UnimplementedProvider{}.GetCapabilities(context.Background(), coreagent.GetCapabilitiesRequest{})
-	subjectID := principal.UserSubjectID("user-1")
-	updatedAt := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
-	provider.sessions["session-1"] = &coreagent.Session{
-		ID:           "session-1",
-		ProviderName: "legacy",
-		State:        coreagent.SessionStateActive,
-		Metadata:     map[string]any{"heavy": "metadata"},
-		CreatedBy:    coreagent.Actor{SubjectID: subjectID},
-		UpdatedAt:    &updatedAt,
-	}
-	manager := newTestManager(t, Config{
-		Agent: &routeCountingAgentControl{
-			defaultName: "legacy",
-			names:       []string{"legacy"},
-			providers: map[string]*routeCountingAgentProvider{
-				"legacy": provider,
-			},
-		},
-		ToolGrants: newAgentManagerTestToolGrants(t),
-	})
-
-	sessions, err := manager.ListSessions(context.Background(), &principal.Principal{SubjectID: subjectID}, coreagent.ManagerListSessionsRequest{
-		ProviderName: "legacy",
-		Limit:        1,
-		SummaryOnly:  true,
-	})
-	if err != nil {
-		t.Fatalf("ListSessions: %v", err)
-	}
-	if len(provider.listSessionReqs) != 1 {
-		t.Fatalf("provider ListSessions calls = %d, want 1", len(provider.listSessionReqs))
-	}
-	if got := provider.listSessionReqs[0].Limit; got != 0 {
-		t.Fatalf("legacy provider limit = %d, want fallback limit 0", got)
-	}
-	if provider.listSessionReqs[0].SummaryOnly {
-		t.Fatal("legacy provider received summary_only=true, want fallback full hydration")
-	}
-	if len(sessions) != 1 || sessions[0].ID != "session-1" {
-		t.Fatalf("manager sessions = %#v, want session-1", sessions)
-	}
-	if sessions[0].Metadata != nil {
-		t.Fatalf("summary session metadata = %#v, want nil", sessions[0].Metadata)
-	}
-}
-
-func TestManagerListTurnsFallsBackToFullListForLegacyProvider(t *testing.T) {
-	t.Parallel()
-
-	provider := newRouteCountingAgentProvider("legacy")
-	provider.capabilities = &coreagent.ProviderCapabilities{
-		SupportedToolSources: []coreagent.ToolSourceMode{coreagent.ToolSourceModeMCPCatalog},
-	}
-	subjectID := principal.UserSubjectID("user-1")
-	oldTime := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
-	newTime := oldTime.Add(time.Hour)
-	provider.sessions["session-1"] = &coreagent.Session{
-		ID:           "session-1",
-		ProviderName: "legacy",
-		State:        coreagent.SessionStateActive,
-		CreatedBy:    coreagent.Actor{SubjectID: subjectID},
-		UpdatedAt:    &newTime,
-	}
-	provider.turns["old"] = &coreagent.Turn{
-		ID:           "old",
-		SessionID:    "session-1",
-		ProviderName: "legacy",
-		Status:       coreagent.ExecutionStatusSucceeded,
-		Messages:     []coreagent.Message{{Role: "user", Text: "heavy"}},
-		CreatedBy:    coreagent.Actor{SubjectID: subjectID},
-		CreatedAt:    &oldTime,
-	}
-	provider.turns["new"] = &coreagent.Turn{
-		ID:           "new",
-		SessionID:    "session-1",
-		ProviderName: "legacy",
-		Status:       coreagent.ExecutionStatusSucceeded,
-		Messages:     []coreagent.Message{{Role: "user", Text: "heavy"}},
-		CreatedBy:    coreagent.Actor{SubjectID: subjectID},
-		CreatedAt:    &newTime,
-	}
-	manager := newTestManager(t, Config{
-		Agent: &routeCountingAgentControl{
-			defaultName: "legacy",
-			names:       []string{"legacy"},
-			providers: map[string]*routeCountingAgentProvider{
-				"legacy": provider,
-			},
-		},
-		ToolGrants: newAgentManagerTestToolGrants(t),
-	})
-	p := &principal.Principal{SubjectID: subjectID}
-
-	turns, err := manager.ListTurns(context.Background(), p, coreagent.ManagerListTurnsRequest{
+	_, err := manager.ListTurns(context.Background(), p, coreagent.ManagerListTurnsRequest{
 		SessionID:   "session-1",
-		Status:      coreagent.ExecutionStatusSucceeded,
-		Limit:       1,
 		SummaryOnly: true,
 	})
-	if err != nil {
-		t.Fatalf("ListTurns: %v", err)
+	if !errors.Is(err, ErrAgentBoundedListUnsupported) {
+		t.Fatalf("ListTurns error = %v, want ErrAgentBoundedListUnsupported", err)
 	}
-	if len(provider.listTurnReqs) != 1 {
-		t.Fatalf("provider ListTurns calls = %d, want 1", len(provider.listTurnReqs))
-	}
-	if got := provider.listTurnReqs[0].Limit; got != 0 {
-		t.Fatalf("legacy provider turn limit = %d, want fallback limit 0", got)
-	}
-	if provider.listTurnReqs[0].SummaryOnly {
-		t.Fatal("legacy provider received turn summary_only=true, want fallback full hydration")
-	}
-	if len(turns) != 1 || turns[0].ID != "new" {
-		t.Fatalf("manager turns = %#v, want only newest turn", turns)
-	}
-	if turns[0].Messages != nil {
-		t.Fatalf("summary turn messages = %#v, want nil", turns[0].Messages)
-	}
-}
-
-func TestManagerListTurnsFallsBackWhenLegacyProviderCapabilitiesUnimplemented(t *testing.T) {
-	t.Parallel()
-
-	provider := newRouteCountingAgentProvider("legacy")
-	_, provider.capabilitiesErr = coreagent.UnimplementedProvider{}.GetCapabilities(context.Background(), coreagent.GetCapabilitiesRequest{})
-	subjectID := principal.UserSubjectID("user-1")
-	createdAt := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
-	provider.sessions["session-1"] = &coreagent.Session{
-		ID:           "session-1",
-		ProviderName: "legacy",
-		State:        coreagent.SessionStateActive,
-		CreatedBy:    coreagent.Actor{SubjectID: subjectID},
-		UpdatedAt:    &createdAt,
-	}
-	provider.turns["turn-1"] = &coreagent.Turn{
-		ID:           "turn-1",
-		SessionID:    "session-1",
-		ProviderName: "legacy",
-		Status:       coreagent.ExecutionStatusSucceeded,
-		Messages:     []coreagent.Message{{Role: "user", Text: "heavy"}},
-		CreatedBy:    coreagent.Actor{SubjectID: subjectID},
-		CreatedAt:    &createdAt,
-	}
-	manager := newTestManager(t, Config{
-		Agent: &routeCountingAgentControl{
-			defaultName: "legacy",
-			names:       []string{"legacy"},
-			providers: map[string]*routeCountingAgentProvider{
-				"legacy": provider,
-			},
-		},
-		ToolGrants: newAgentManagerTestToolGrants(t),
-	})
-
-	turns, err := manager.ListTurns(context.Background(), &principal.Principal{SubjectID: subjectID}, coreagent.ManagerListTurnsRequest{
-		SessionID:   "session-1",
-		Limit:       1,
-		SummaryOnly: true,
-	})
-	if err != nil {
-		t.Fatalf("ListTurns: %v", err)
-	}
-	if len(provider.listTurnReqs) != 1 {
-		t.Fatalf("provider ListTurns calls = %d, want 1", len(provider.listTurnReqs))
-	}
-	if got := provider.listTurnReqs[0].Limit; got != 0 {
-		t.Fatalf("legacy provider turn limit = %d, want fallback limit 0", got)
-	}
-	if provider.listTurnReqs[0].SummaryOnly {
-		t.Fatal("legacy provider received turn summary_only=true, want fallback full hydration")
-	}
-	if len(turns) != 1 || turns[0].ID != "turn-1" {
-		t.Fatalf("manager turns = %#v, want turn-1", turns)
-	}
-	if turns[0].Messages != nil {
-		t.Fatalf("summary turn messages = %#v, want nil", turns[0].Messages)
+	if len(provider.listTurnReqs) != 0 {
+		t.Fatalf("provider ListTurns calls = %d, want 0", len(provider.listTurnReqs))
 	}
 }
 


### PR DESCRIPTION
## Summary

Removes the agent manager fallback that hydrated full provider session/turn lists when a provider did not advertise bounded list support. Limited or summary list requests now require provider-owned bounded hydration.

This is a simplification pass: `gestaltd` no longer downloads full agent histories, sorts them, trims them, and summarizes them as a compatibility path for providers that do not implement the current contract.

## Contract diff

```diff
 if limit > 0 || summaryOnly {
     err := requireAgentProviderBoundedListHydration(ctx, providerName, provider)
-    if errors.Is(err, ErrAgentBoundedListUnsupported) {
-        providerLimit = 0
-        providerSummaryOnly = false
-    } else if err != nil {
+    if err != nil {
         return nil, err
     }
 }
 
 provider.ListSessions(ctx, coreagent.ListSessionsRequest{
-    Limit: providerLimit,
-    SummaryOnly: providerSummaryOnly,
+    Limit: limit,
+    SummaryOnly: summaryOnly,
 })
```

`ListTurns` follows the same contract.

## Provider example

```go
func (p *Provider) GetCapabilities(context.Context, coreagent.GetCapabilitiesRequest) (*coreagent.ProviderCapabilities, error) {
    return &coreagent.ProviderCapabilities{
        BoundedListHydration: true,
        SupportedToolSources: []coreagent.ToolSourceMode{
            coreagent.ToolSourceModeMCPCatalog,
        },
    }, nil
}
```

SDK-facing docs now show the corresponding capability flag for Go, Python, Rust, and TypeScript provider examples.

## Changes

- Remove manager-side full-list fallback for unbounded agent providers.
- Remove the special `GetCapabilities` unimplemented handling used only by that fallback.
- Replace four legacy-framed fallback tests with direct bounded-hydration requirement tests.
- Update agent provider docs to state that limited and summary list requests require bounded provider hydration.

## Verification

- `go test ./services/agents/...` from `gestaltd`
