### PR TITLE
Export IndexedDB SDK codec helpers

### DIFF
--- a/sdk/go/indexeddb_codec.go
+++ b/sdk/go/indexeddb_codec.go
@@ -11,16 +11,40 @@ func typedValueFromAny(v any) (*proto.TypedValue, error) {
 	return indexeddbcodec.TypedValueFromAny(v)
 }
 
+// TypedValueFromAny converts a Go IndexedDB value into the provider wire
+// representation used by cursor and record APIs.
+func TypedValueFromAny(v any) (*proto.TypedValue, error) {
+	return typedValueFromAny(v)
+}
+
 func anyFromTypedValue(v *proto.TypedValue) (any, error) {
 	return indexeddbcodec.AnyFromTypedValue(v)
+}
+
+// AnyFromTypedValue converts a provider wire value into the corresponding Go
+// IndexedDB value.
+func AnyFromTypedValue(v *proto.TypedValue) (any, error) {
+	return anyFromTypedValue(v)
 }
 
 func typedValuesFromAny(values []any) ([]*proto.TypedValue, error) {
 	return indexeddbcodec.TypedValuesFromAny(values)
 }
 
+// TypedValuesFromAny converts ordered Go IndexedDB values into provider wire
+// values.
+func TypedValuesFromAny(values []any) ([]*proto.TypedValue, error) {
+	return typedValuesFromAny(values)
+}
+
 func anyFromTypedValues(values []*proto.TypedValue) ([]any, error) {
 	return indexeddbcodec.AnyFromTypedValues(values)
+}
+
+// AnyFromTypedValues converts ordered provider wire values into Go IndexedDB
+// values.
+func AnyFromTypedValues(values []*proto.TypedValue) ([]any, error) {
+	return anyFromTypedValues(values)
 }
 
 func recordToProto(record Record) (*proto.Record, error) {
@@ -43,16 +67,40 @@ func keyValuesToAny(kvs []*proto.KeyValue) ([]any, error) {
 	return indexeddbcodec.KeyValuesToAny(kvs)
 }
 
+// KeyValuesToAny converts provider cursor key parts into Go IndexedDB key
+// values.
+func KeyValuesToAny(kvs []*proto.KeyValue) ([]any, error) {
+	return keyValuesToAny(kvs)
+}
+
 func keyValueToAny(kv *proto.KeyValue) (any, error) {
 	return indexeddbcodec.KeyValueToAny(kv)
+}
+
+// KeyValueToAny converts one provider cursor key part into a Go IndexedDB key
+// value.
+func KeyValueToAny(kv *proto.KeyValue) (any, error) {
+	return keyValueToAny(kv)
 }
 
 func anyToKeyValue(v any) (*proto.KeyValue, error) {
 	return indexeddbcodec.AnyToKeyValue(v)
 }
 
+// AnyToKeyValue converts a Go IndexedDB key value into one provider cursor key
+// part.
+func AnyToKeyValue(v any) (*proto.KeyValue, error) {
+	return anyToKeyValue(v)
+}
+
 func cursorKeyToProto(key any, indexCursor bool) ([]*proto.KeyValue, error) {
 	return indexeddbcodec.CursorKeyToProto(key, indexCursor)
+}
+
+// CursorKeyToProto converts a primary-key or index-key cursor target into the
+// provider wire key representation.
+func CursorKeyToProto(key any, indexCursor bool) ([]*proto.KeyValue, error) {
+	return cursorKeyToProto(key, indexCursor)
 }
 
 // EncodeIndexedDBKey serializes an IndexedDB key using the SDK's stable


### PR DESCRIPTION
## Summary

Export the Go SDK IndexedDB value/key codec helpers that downstream IndexedDB providers already use.

This unblocks `gestalt-providers` UI E2E, which builds `indexeddb/relationaldb` against Gestalt `main` and currently fails with undefined SDK helpers.

## Interface diff

```diff
 package gestalt
 
+func TypedValueFromAny(v any) (*proto.TypedValue, error)
+func AnyFromTypedValue(v *proto.TypedValue) (any, error)
+func TypedValuesFromAny(values []any) ([]*proto.TypedValue, error)
+func AnyFromTypedValues(values []*proto.TypedValue) ([]any, error)
+func KeyValuesToAny(kvs []*proto.KeyValue) ([]any, error)
+func KeyValueToAny(kv *proto.KeyValue) (any, error)
+func AnyToKeyValue(v any) (*proto.KeyValue, error)
+func CursorKeyToProto(key any, indexCursor bool) ([]*proto.KeyValue, error)
```

These are exported wrappers around the existing SDK codec behavior. They do not add new IndexedDB schema primitives; they expose the wire conversion layer needed by provider implementations that handle cursor keys and typed record fields.

## Example

```go
kv, err := gestalt.AnyToKeyValue("customer-123")
if err != nil {
    return err
}

value, err := gestalt.AnyFromTypedValue(record.Fields["created_at"])
if err != nil {
    return err
}
```

## Validation

- `go test ./...` from `sdk/go`