### PR TITLE
[gestaltd] remove Helm shell dependency and rename config path

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -204,6 +204,14 @@ jobs:
             -f gestaltd/deploy/helm/gestaltd/ci-values-preparation.yaml \
             > /tmp/rendered-preparation.yaml
 
+      - name: Verify preparation does not require a shell
+        run: |
+          set -euo pipefail
+          if grep -q '"/bin/sh"' /tmp/rendered-preparation.yaml; then
+            echo "Preparation init containers must not require /bin/sh from the gestaltd image" >&2
+            exit 1
+          fi
+
       - name: Validate Kubernetes schemas (preparation)
         run: kubeconform -strict -summary /tmp/rendered-preparation.yaml
 

--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -204,14 +204,6 @@ jobs:
             -f gestaltd/deploy/helm/gestaltd/ci-values-preparation.yaml \
             > /tmp/rendered-preparation.yaml
 
-      - name: Verify preparation does not require a shell
-        run: |
-          set -euo pipefail
-          if grep -q '"/bin/sh"' /tmp/rendered-preparation.yaml; then
-            echo "Preparation init containers must not require /bin/sh from the gestaltd image" >&2
-            exit 1
-          fi
-
       - name: Validate Kubernetes schemas (preparation)
         run: kubeconform -strict -summary /tmp/rendered-preparation.yaml
 

--- a/docs/content/deploy/docker.mdx
+++ b/docs/content/deploy/docker.mdx
@@ -8,12 +8,12 @@ export GESTALT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
 docker run --rm \
   -p 8080:8080 \
   -e GESTALT_ENCRYPTION_KEY="${GESTALT_ENCRYPTION_KEY}" \
-  -v "$(pwd)/config.yaml:/etc/gestalt/config.yaml:ro" \
+  -v "$(pwd)/config.yaml:/etc/gestaltd/config.yaml:ro" \
   -v gestalt-data:/data \
   valontechnologies/gestaltd:latest
 ```
 
-Mount a config file at `/etc/gestalt/config.yaml`. The image is not zero-config and will fail to start without one.
+Mount a config file at `/etc/gestaltd/config.yaml`. The image is not zero-config and will fail to start without one.
 Generate the encryption key once with `openssl rand -hex 32` and reuse that value for the deployment.
 
 ## Docker Compose
@@ -25,7 +25,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./config.yaml:/etc/gestalt/config.yaml:ro
+      - ./config.yaml:/etc/gestaltd/config.yaml:ro
       - gestalt-data:/data
     environment:
       GESTALT_ENCRYPTION_KEY: "${GESTALT_ENCRYPTION_KEY}"
@@ -44,8 +44,8 @@ volumes:
 | Variants | `:latest-alpine` (Alpine, has shell) |
 | Port | `8080` |
 | Entrypoint | `/gestaltd` |
-| Default command | `serve --config /etc/gestalt/config.yaml --artifacts-dir /data` |
-| Config path | `/etc/gestalt/config.yaml` |
+| Default command | `serve --config /etc/gestaltd/config.yaml --artifacts-dir /data` |
+| Config path | `/etc/gestaltd/config.yaml` |
 | Data directory | `/data` |
 
 For the CLI client image, see [Client Docker Image](/client/cli/docker).
@@ -80,7 +80,7 @@ Gestalt expands `${VAR}` placeholders in the config before YAML decoding. The im
 ```sh
 docker run --rm \
   -p 8080:8080 \
-  -v "$(pwd)/config.yaml:/etc/gestalt/config.yaml:ro" \
+  -v "$(pwd)/config.yaml:/etc/gestaltd/config.yaml:ro" \
   -v /run/secrets/encryption-key:/run/secrets/encryption-key:ro \
   -e GESTALT_ENCRYPTION_KEY_FILE=/run/secrets/encryption-key \
   valontechnologies/gestaltd:latest

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -89,10 +89,10 @@ helm upgrade --install gestaltd \
 
 | Value | Purpose |
 | --- | --- |
-| `config` | Rendered as `/etc/gestalt/config.yaml`. |
+| `config` | Rendered as `/etc/gestaltd/config.yaml`. |
 | `extraEnv` | Environment variables used by `${VAR}` placeholders in `config`. |
 | `persistence` | PVC settings for SQLite or other local state. |
-| `preparation.enabled` | Runs `gestaltd lock` and `gestaltd sync --locked` in a preparation container before the main server starts. Use it when the chart should prepare locked state for published provider packages or packaged UI bundles. |
+| `preparation.enabled` | Runs `gestaltd lock` and `gestaltd sync --locked` in init containers before the main server starts. Use it when the chart should prepare locked state for published provider packages or packaged UI bundles. |
 | `lockedServe.enabled` | Adds `--locked` to the main container without enabling the chart preparation container. Use it when lock state and prepared artifacts are baked into the image or mounted by external automation. |
 | `ingress` | Standard ingress settings. |
 | `ingress.hosts[].paths` | Per-host ingress paths and path types. |
@@ -177,9 +177,13 @@ Service rather than exposing it on the public ingress.
 
 ## When to enable `preparation`
 
-Enable the preparation container when your config uses published provider metadata URLs under `plugins.*.source`, `providers.authentication.*.source`, `providers.indexeddb.*.source`, or `providers.ui.*.source` and you want that state prepared before the main container starts. The preparation container copies the rendered config and runs:
+Enable the preparation init containers when your config uses published provider metadata URLs under `plugins.*.source`, `providers.authentication.*.source`, `providers.indexeddb.*.source`, or `providers.ui.*.source` and you want that state prepared before the main container starts. The chart runs:
 
-`/gestaltd lock --config /etc/gestalt/config.yaml && /gestaltd sync --locked --config /etc/gestalt/config.yaml`
+`/gestaltd lock --config /etc/gestaltd-config/config.yaml --lockfile /etc/gestaltd-state/gestalt.lock.json`
+
+followed by:
+
+`/gestaltd sync --locked --config /etc/gestaltd-config/config.yaml --lockfile /etc/gestaltd-state/gestalt.lock.json --artifacts-dir /etc/gestaltd-state/artifacts`
 
 The main container then starts in locked mode against the prepared state.
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -13,10 +13,10 @@
 - Default command:
 
   ```sh
-  /gestaltd serve --config /etc/gestalt/config.yaml --artifacts-dir /data
+  /gestaltd serve --config /etc/gestaltd/config.yaml --artifacts-dir /data
   ```
 
-- Default config path: `/etc/gestalt/config.yaml`
+- Default config path: `/etc/gestaltd/config.yaml`
 - Default writable data and artifacts dir: `/data`
 - This image is not zero-config. Mount or bake a config file before starting it.
 
@@ -48,7 +48,7 @@ export GESTALT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
 docker run --rm \
   -p 8080:8080 \
   -e GESTALT_ENCRYPTION_KEY="${GESTALT_ENCRYPTION_KEY}" \
-  -v "$(pwd)/gestalt.yaml:/etc/gestalt/config.yaml:ro" \
+  -v "$(pwd)/gestalt.yaml:/etc/gestaltd/config.yaml:ro" \
   -v gestalt-data:/data \
   valontechnologies/gestaltd:latest
 ```
@@ -85,7 +85,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./config.yaml:/etc/gestalt/config.yaml:ro
+      - ./config.yaml:/etc/gestaltd/config.yaml:ro
       - gestalt-data:/data
     environment:
       GESTALT_ENCRYPTION_KEY: "${GESTALT_ENCRYPTION_KEY}"

--- a/gestaltd/Dockerfile
+++ b/gestaltd/Dockerfile
@@ -40,7 +40,7 @@ LABEL org.opencontainers.image.title="gestaltd" \
       org.opencontainers.image.created="${GESTALT_CREATED}"
 EXPOSE 8080
 ENTRYPOINT ["/gestaltd"]
-CMD ["serve", "--config", "/etc/gestalt/config.yaml", "--artifacts-dir", "/data"]
+CMD ["serve", "--config", "/etc/gestaltd/config.yaml", "--artifacts-dir", "/data"]
 
 # --- Alpine ---
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS alpine
@@ -64,4 +64,4 @@ LABEL org.opencontainers.image.title="gestaltd" \
 USER nobody:nobody
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/gestaltd"]
-CMD ["serve", "--config", "/etc/gestalt/config.yaml", "--artifacts-dir", "/data"]
+CMD ["serve", "--config", "/etc/gestaltd/config.yaml", "--artifacts-dir", "/data"]

--- a/gestaltd/deploy/helm/gestaltd/templates/NOTES.txt
+++ b/gestaltd/deploy/helm/gestaltd/templates/NOTES.txt
@@ -68,9 +68,9 @@ For Google OAuth:
 For OIDC, override config.auth.plugin in your values file.
 {{- if .Values.preparation.enabled }}
 
-Plugin preparation is enabled. A preparation container runs `gestaltd lock` followed by
-`gestaltd sync --locked` before the main server starts, preparing locked state
-in a shared volume.
+Plugin preparation is enabled. Init containers run `gestaltd lock` followed by
+`gestaltd sync --locked` before the main server starts, preparing lock state
+and artifacts in a shared volume.
 The main container runs with --locked to prevent mutation at startup.
 {{- else if .Values.lockedServe.enabled }}
 

--- a/gestaltd/deploy/helm/gestaltd/templates/deployment.yaml
+++ b/gestaltd/deploy/helm/gestaltd/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           type: RuntimeDefault
       {{- if .Values.preparation.enabled }}
       initContainers:
-        - name: prepare-state
+        - name: lock-state
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true
@@ -51,9 +51,12 @@ spec:
               type: RuntimeDefault
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/bin/sh", "-c"]
           args:
-            - cp -r /etc/gestalt-config/. /etc/gestalt/ && /gestaltd lock --config /etc/gestalt/config.yaml && /gestaltd sync --locked --config /etc/gestalt/config.yaml
+            - lock
+            - --config
+            - /etc/gestalt-config/config.yaml
+            - --lockfile
+            - /etc/gestalt-state/gestalt.lock.json
           {{- with .Values.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -63,7 +66,40 @@ spec:
               mountPath: /etc/gestalt-config
               readOnly: true
             - name: gestaltd-state
-              mountPath: /etc/gestalt
+              mountPath: /etc/gestalt-state
+            - name: tmp
+              mountPath: /tmp
+        - name: sync-state
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - sync
+            - --locked
+            - --config
+            - /etc/gestalt-config/config.yaml
+            - --lockfile
+            - /etc/gestalt-state/gestalt.lock.json
+            - --artifacts-dir
+            - /etc/gestalt-state/artifacts
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/gestalt-config
+              readOnly: true
+            - name: gestaltd-state
+              mountPath: /etc/gestalt-state
             - name: tmp
               mountPath: /tmp
       {{- end }}
@@ -86,7 +122,15 @@ spec:
             - --locked
             {{- end }}
             - --config
+            {{- if .Values.preparation.enabled }}
+            - /etc/gestalt-config/config.yaml
+            - --lockfile
+            - /etc/gestalt-state/gestalt.lock.json
+            - --artifacts-dir
+            - /etc/gestalt-state/artifacts
+            {{- else }}
             - /etc/gestalt/config.yaml
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ get $public "port" | default 8080 }}
@@ -114,8 +158,11 @@ spec:
           {{- end }}
           volumeMounts:
             {{- if .Values.preparation.enabled }}
+            - name: config
+              mountPath: /etc/gestalt-config
+              readOnly: true
             - name: gestaltd-state
-              mountPath: /etc/gestalt
+              mountPath: /etc/gestalt-state
               readOnly: true
             {{- else }}
             - name: config

--- a/gestaltd/deploy/helm/gestaltd/templates/deployment.yaml
+++ b/gestaltd/deploy/helm/gestaltd/templates/deployment.yaml
@@ -54,19 +54,19 @@ spec:
           args:
             - lock
             - --config
-            - /etc/gestalt-config/config.yaml
+            - /etc/gestaltd-config/config.yaml
             - --lockfile
-            - /etc/gestalt-state/gestalt.lock.json
+            - /etc/gestaltd-state/gestalt.lock.json
           {{- with .Values.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: config
-              mountPath: /etc/gestalt-config
+              mountPath: /etc/gestaltd-config
               readOnly: true
             - name: gestaltd-state
-              mountPath: /etc/gestalt-state
+              mountPath: /etc/gestaltd-state
             - name: tmp
               mountPath: /tmp
         - name: sync-state
@@ -85,21 +85,21 @@ spec:
             - sync
             - --locked
             - --config
-            - /etc/gestalt-config/config.yaml
+            - /etc/gestaltd-config/config.yaml
             - --lockfile
-            - /etc/gestalt-state/gestalt.lock.json
+            - /etc/gestaltd-state/gestalt.lock.json
             - --artifacts-dir
-            - /etc/gestalt-state/artifacts
+            - /etc/gestaltd-state/artifacts
           {{- with .Values.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: config
-              mountPath: /etc/gestalt-config
+              mountPath: /etc/gestaltd-config
               readOnly: true
             - name: gestaltd-state
-              mountPath: /etc/gestalt-state
+              mountPath: /etc/gestaltd-state
             - name: tmp
               mountPath: /tmp
       {{- end }}
@@ -123,13 +123,13 @@ spec:
             {{- end }}
             - --config
             {{- if .Values.preparation.enabled }}
-            - /etc/gestalt-config/config.yaml
+            - /etc/gestaltd-config/config.yaml
             - --lockfile
-            - /etc/gestalt-state/gestalt.lock.json
+            - /etc/gestaltd-state/gestalt.lock.json
             - --artifacts-dir
-            - /etc/gestalt-state/artifacts
+            - /etc/gestaltd-state/artifacts
             {{- else }}
-            - /etc/gestalt/config.yaml
+            - /etc/gestaltd/config.yaml
             {{- end }}
           ports:
             - name: http
@@ -159,14 +159,14 @@ spec:
           volumeMounts:
             {{- if .Values.preparation.enabled }}
             - name: config
-              mountPath: /etc/gestalt-config
+              mountPath: /etc/gestaltd-config
               readOnly: true
             - name: gestaltd-state
-              mountPath: /etc/gestalt-state
+              mountPath: /etc/gestaltd-state
               readOnly: true
             {{- else }}
             - name: config
-              mountPath: /etc/gestalt/config.yaml
+              mountPath: /etc/gestaltd/config.yaml
               subPath: config.yaml
               readOnly: true
             {{- end }}

--- a/gestaltd/deploy/helm/gestaltd/values.yaml
+++ b/gestaltd/deploy/helm/gestaltd/values.yaml
@@ -69,7 +69,7 @@ persistence:
     - ReadWriteOnce
   size: 1Gi
 
-# Mounted as /etc/gestalt/config.yaml. The app expands ${ENV_VAR}
+# Mounted as /etc/gestaltd/config.yaml. The app expands ${ENV_VAR}
 # placeholders at startup, so secrets can be injected via extraEnv when
 # you enable OAuth/OIDC or an external datastore below.
 config:


### PR DESCRIPTION
## Description

Updates the gestaltd Helm chart preparation flow to run `gestaltd lock` and `gestaltd sync --locked` as separate init containers instead of using `/bin/sh -c`, which works with the static gestaltd image. Also renames the default container config path to `/etc/gestaltd/config.yaml` and updates the Docker and Helm docs to match.