### PR TITLE
Export IndexedDB record proto helpers

### DIFF
--- a/sdk/go/indexeddb_codec.go
+++ b/sdk/go/indexeddb_codec.go
@@ -51,16 +51,37 @@ func recordToProto(record Record) (*proto.Record, error) {
 	return indexeddbcodec.RecordToProto(record)
 }
 
+// RecordToProto converts a Go IndexedDB record into the provider wire
+// representation used by lower-level datastore APIs.
+func RecordToProto(record Record) (*proto.Record, error) {
+	return recordToProto(record)
+}
+
 func recordFromProto(record *proto.Record) (Record, error) {
 	return indexeddbcodec.RecordFromProto(record)
+}
+
+// RecordFromProto converts a provider wire record into a Go IndexedDB record.
+func RecordFromProto(record *proto.Record) (Record, error) {
+	return recordFromProto(record)
 }
 
 func recordsFromProto(records []*proto.Record) ([]Record, error) {
 	return indexeddbcodec.RecordsFromProto(records)
 }
 
+// RecordsFromProto converts provider wire records into Go IndexedDB records.
+func RecordsFromProto(records []*proto.Record) ([]Record, error) {
+	return recordsFromProto(records)
+}
+
 func recordsToProto(records []Record) ([]*proto.Record, error) {
 	return indexeddbcodec.RecordsToProto(records)
+}
+
+// RecordsToProto converts Go IndexedDB records into provider wire records.
+func RecordsToProto(records []Record) ([]*proto.Record, error) {
+	return recordsToProto(records)
 }
 
 func keyValuesToAny(kvs []*proto.KeyValue) ([]any, error) {


### PR DESCRIPTION
## Summary
- export the existing IndexedDB record proto conversion helpers from the Go SDK
- keep the implementation delegated to the shared indexeddbcodec package

## Test plan
- GOWORK=off go test ./... in sdk/go

## Context
Provider validation in gestalt-providers already references these helpers from IndexedDB contract/provider tests. #1722 exported related typed value/key helpers and storage encode/decode helpers, but left the record proto helpers private.