### PR TITLE
Default agent turns to connected MCP tools

### DIFF
--- a/gestaltd/core/agent/agent.go
+++ b/gestaltd/core/agent/agent.go
@@ -149,17 +149,34 @@ func ValidateMCPCatalogToolRefs(refs []ToolRef, fieldName string) error {
 		system := strings.TrimSpace(ref.System)
 		pluginName := strings.TrimSpace(ref.Plugin)
 		operation := strings.TrimSpace(ref.Operation)
-		if operation == "" {
-			return fmt.Errorf("mcp catalog %s[%d].operation is required", fieldName, i)
-		}
-		if system == "" && (pluginName == "" || pluginName == "*") {
-			return fmt.Errorf("mcp catalog %s[%d].plugin must be explicit", fieldName, i)
-		}
+		connection := strings.TrimSpace(ref.Connection)
+		instance := strings.TrimSpace(ref.Instance)
 		if system != "" && system != SystemToolWorkflow {
 			return fmt.Errorf("mcp catalog %s[%d].system %q is not supported", fieldName, i, system)
 		}
 		if system != "" && pluginName != "" {
 			return fmt.Errorf("mcp catalog %s[%d] must set exactly one of plugin or system", fieldName, i)
+		}
+		if system != "" {
+			if operation == "" {
+				return fmt.Errorf("mcp catalog %s[%d].operation is required for system refs", fieldName, i)
+			}
+			if operation == "*" {
+				return fmt.Errorf("mcp catalog %s[%d].operation wildcard is not supported", fieldName, i)
+			}
+			if connection != "" || instance != "" || ref.CredentialMode != "" || strings.TrimSpace(ref.Title) != "" || strings.TrimSpace(ref.Description) != "" {
+				return fmt.Errorf("mcp catalog %s[%d] system refs cannot include connection, instance, credential mode, title, or description", fieldName, i)
+			}
+			continue
+		}
+		if pluginName == "" {
+			return fmt.Errorf("mcp catalog %s[%d].plugin is required", fieldName, i)
+		}
+		if operation == "*" || connection == "*" || instance == "*" {
+			return fmt.Errorf("mcp catalog %s[%d] wildcard fields are not supported", fieldName, i)
+		}
+		if pluginName == "*" && (operation != "" || connection != "" || instance != "" || ref.CredentialMode != "" || strings.TrimSpace(ref.Title) != "" || strings.TrimSpace(ref.Description) != "") {
+			return fmt.Errorf("mcp catalog %s[%d] global ref cannot include operation, connection, instance, credential mode, title, or description", fieldName, i)
 		}
 	}
 	return nil

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -564,6 +564,9 @@ func validateAgentListedTools(p *principal.Principal, refs []coreagent.ToolRef, 
 		if len(refs) > 0 && !agentToolMatchesRefs(target, refs) {
 			return fmt.Errorf("%w: listed agent tool %q is outside the turn tool scope", invocation.ErrAuthorizationDenied, tools[i].ToolID)
 		}
+		if tools[i].Hidden && !agentToolHiddenExplicitlyGranted(target, tools[i].ToolID, refs, nil) {
+			return fmt.Errorf("%w: listed hidden agent tool %q was not explicitly granted", invocation.ErrAuthorizationDenied, tools[i].ToolID)
+		}
 	}
 	return nil
 }

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -2264,15 +2264,18 @@ func TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Mint broad grant: %v", err)
 	}
-	_, err = runtime.ListTools(context.Background(), coreagent.ListToolsRequest{
+	broadListResp, err := runtime.ListTools(context.Background(), coreagent.ListToolsRequest{
 		ProviderName: "claude",
 		SessionID:    "session-1",
 		TurnID:       "turn-1",
 		PageSize:     10,
 		ToolGrant:    broadGrant,
 	})
-	if !errors.Is(err, invocation.ErrAuthorizationDenied) {
-		t.Fatalf("ListTools with broad mcp catalog grant error = %v, want ErrAuthorizationDenied", err)
+	if err != nil {
+		t.Fatalf("ListTools with broad mcp catalog grant: %v", err)
+	}
+	if broadListResp.NextPageToken != "" || len(broadListResp.Tools) != 1 || broadListResp.Tools[0].Ref.Operation != "sync" {
+		t.Fatalf("ListTools broad grant response = %#v, want sync tool", broadListResp)
 	}
 
 	execResp, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
@@ -2290,16 +2293,19 @@ func TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn(t *testing.T) {
 		t.Fatalf("ExecuteTool response = %#v, want accepted task body", execResp)
 	}
 
-	_, err = runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+	broadExecResp, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
 		ProviderName: "claude",
 		SessionID:    "session-1",
 		TurnID:       "turn-1",
-		ToolID:       tool.ToolID,
+		ToolID:       broadListResp.Tools[0].ToolID,
 		ToolGrant:    broadGrant,
 		Arguments:    map[string]any{"taskId": "task-123"},
 	})
-	if !errors.Is(err, invocation.ErrAuthorizationDenied) {
-		t.Fatalf("ExecuteTool with broad mcp catalog grant error = %v, want ErrAuthorizationDenied", err)
+	if err != nil {
+		t.Fatalf("ExecuteTool with broad mcp catalog grant: %v", err)
+	}
+	if broadExecResp == nil || broadExecResp.Status != http.StatusAccepted || broadExecResp.Body != `{"taskId":"task-123"}` {
+		t.Fatalf("ExecuteTool broad response = %#v, want accepted task body", broadExecResp)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -907,6 +907,15 @@ func (p *callbackSessionCatalogIntegration) CatalogForRequest(context.Context, s
 	return p.sessionCatalog, nil
 }
 
+type unavailableSessionCatalogIntegration struct {
+	coretesting.StubIntegration
+	err error
+}
+
+func (p *unavailableSessionCatalogIntegration) CatalogForRequest(context.Context, string) (*catalog.Catalog, error) {
+	return nil, p.err
+}
+
 func newCallbackAgentProvider(started *runtimehost.StartedHostServices) (*callbackAgentProvider, error) {
 	if started == nil {
 		return nil, fmt.Errorf("started host services are required")
@@ -2906,6 +2915,7 @@ func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T)
 
 	factories := validFactories()
 	hidden := false
+	destructive := true
 	factories.Builtins = append(factories.Builtins, &coretesting.StubIntegration{
 		N:        "docs",
 		ConnMode: core.ConnectionModeNone,
@@ -2917,8 +2927,9 @@ func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T)
 				{ID: "alpha_search", Method: http.MethodGet, Title: "Docs alpha search", Description: "Search docs alpha", ReadOnly: true},
 				{ID: "beta_list", Method: http.MethodGet, Title: "Docs beta list", Description: "List docs beta", ReadOnly: true},
 				{ID: "delta_export", Method: http.MethodGet, Title: "Docs delta export", Description: "Export docs delta", ReadOnly: true},
+				{ID: "epsilon_delete", Method: http.MethodDelete, Title: "Docs epsilon delete", Description: "Delete docs epsilon", Annotations: catalog.OperationAnnotations{DestructiveHint: &destructive}},
 				{ID: "gamma_get", Method: http.MethodGet, Title: "Docs gamma get", Description: "Get docs gamma", ReadOnly: true},
-				{ID: "hidden_admin", Method: http.MethodPost, Title: "Hidden docs admin", Description: "Hidden admin operation", Visible: &hidden},
+				{ID: "aardvark_admin", Method: http.MethodPost, Title: "Hidden docs admin", Description: "Hidden admin operation", Visible: &hidden},
 			},
 		},
 		ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
@@ -2957,7 +2968,7 @@ func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T)
 
 	perms := principal.CompilePermissions([]core.AccessPermission{{
 		Plugin:     "docs",
-		Operations: []string{"alpha_search", "beta_list", "delta_export", "gamma_get", "hidden_admin"},
+		Operations: []string{"aardvark_admin", "alpha_search", "beta_list", "delta_export", "epsilon_delete", "gamma_get"},
 	}, {
 		Plugin: "managed",
 	}})
@@ -2984,12 +2995,7 @@ func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T)
 		IdempotencyKey: "candidate-search-idempotency-key",
 		Model:          "gpt-test",
 		Messages:       []coreagent.Message{{Role: "user", Text: "search docs"}},
-		ToolRefs: []coreagent.ToolRef{
-			{Plugin: "docs", Operation: "alpha_search"},
-			{Plugin: "docs", Operation: "beta_list"},
-			{Plugin: "docs", Operation: "delta_export"},
-			{Plugin: "docs", Operation: "gamma_get"},
-		},
+		ToolRefs:       []coreagent.ToolRef{{Plugin: "docs"}},
 	})
 	if err != nil {
 		t.Fatalf("AgentManager.CreateTurn(search): %v", err)
@@ -3006,8 +3012,8 @@ func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T)
 		t.Fatalf("list response count = %d, want 1", len(listResponses))
 	}
 	listResp := listResponses[0]
-	if len(listResp.GetTools()) != 4 {
-		t.Fatalf("listed tools = %#v, want four visible docs tools", listResp.GetTools())
+	if len(listResp.GetTools()) != 5 {
+		t.Fatalf("listed tools = %#v, want five visible docs tools", listResp.GetTools())
 	}
 	if len(toolBodies) != 1 {
 		t.Fatalf("tool callback bodies = %#v, want one listed tool execution", toolBodies)
@@ -3020,21 +3026,28 @@ func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T)
 		t.Fatalf("tool callback body = %#v, want docs provider", loadedBody)
 	}
 	loadedOperation := loadedBody["operation"]
-	if loadedOperation == "" || loadedOperation == "hidden_admin" {
+	if loadedOperation == "" || loadedOperation == "aardvark_admin" {
 		t.Fatalf("loaded operation = %q, want visible docs operation", loadedOperation)
 	}
 	var betaOperation string
+	var destructiveOperation string
 	for _, tool := range listResp.GetTools() {
 		ref := tool.GetRef()
-		if ref.GetOperation() == "hidden_admin" {
+		if ref.GetOperation() == "aardvark_admin" {
 			t.Fatalf("listed hidden tool = %#v, want only visible tools for broad catalog", tool)
 		}
 		if ref.GetOperation() == "beta_list" {
 			betaOperation = ref.GetOperation()
 		}
+		if ref.GetOperation() == "epsilon_delete" {
+			destructiveOperation = ref.GetOperation()
+		}
 	}
 	if betaOperation == "" {
 		t.Fatalf("listed tools = %#v, want beta_list", listResp.GetTools())
+	}
+	if destructiveOperation == "" {
+		t.Fatalf("listed tools = %#v, want visible destructive epsilon_delete", listResp.GetTools())
 	}
 	exact, err := result.AgentManager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
 		SessionID:      session.ID,
@@ -3056,9 +3069,42 @@ func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T)
 	if len(toolBodies) != 2 || !strings.Contains(toolBodies[1], fmt.Sprintf(`"operation":"%s"`, betaOperation)) {
 		t.Fatalf("tool callback bodies after exact ref = %#v, want %s", toolBodies, betaOperation)
 	}
+
+	mixed, err := result.AgentManager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
+		SessionID:      session.ID,
+		IdempotencyKey: "candidate-mixed-global-exact-hidden-idempotency-key",
+		Model:          "gpt-test",
+		Messages:       []coreagent.Message{{Role: "user", Text: "load hidden docs"}},
+		ToolRefs: []coreagent.ToolRef{
+			{Plugin: "*"},
+			{Plugin: "docs", Operation: "aardvark_admin"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AgentManager.CreateTurn(mixed global exact hidden ref): %v", err)
+	}
+	if mixed == nil {
+		t.Fatal("AgentManager.CreateTurn(mixed global exact hidden ref) returned nil turn")
+	}
+	provider.mu.Lock()
+	listResponses = append([]*proto.ListAgentToolsResponse(nil), provider.listResponses...)
+	provider.mu.Unlock()
+	if len(listResponses) != 3 {
+		t.Fatalf("list response count after mixed global exact hidden ref = %d, want 3", len(listResponses))
+	}
+	hiddenListed := false
+	for _, tool := range listResponses[2].GetTools() {
+		if tool.GetRef().GetPlugin() == "docs" && tool.GetRef().GetOperation() == "aardvark_admin" {
+			hiddenListed = true
+			break
+		}
+	}
+	if !hiddenListed {
+		t.Fatalf("mixed global exact hidden listed tools = %#v, want aardvark_admin", listResponses[2].GetTools())
+	}
 }
 
-func TestBootstrapHTTPCallerWildcardCatalogToolRefsAreRejected(t *testing.T) {
+func TestBootstrapHTTPCallerWildcardCatalogToolRefsAreScopedByAuthorization(t *testing.T) {
 	t.Parallel()
 
 	cfg := validConfig()
@@ -3096,6 +3142,7 @@ func TestBootstrapHTTPCallerWildcardCatalogToolRefsAreRejected(t *testing.T) {
 		},
 	})
 
+	var provider *callbackAgentProvider
 	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, hostServices []runtimehost.HostService, _ bootstrap.Deps) (coreagent.Provider, error) {
 		started, err := runtimehost.StartHostServices(hostServices)
 		if err != nil {
@@ -3106,6 +3153,7 @@ func TestBootstrapHTTPCallerWildcardCatalogToolRefsAreRejected(t *testing.T) {
 			_ = started.Close()
 			return nil, err
 		}
+		provider = value
 		return value, nil
 	}
 
@@ -3129,6 +3177,7 @@ func TestBootstrapHTTPCallerWildcardCatalogToolRefsAreRejected(t *testing.T) {
 		SubjectID:        "user:user-123",
 		UserID:           "user-123",
 		Kind:             principal.KindUser,
+		Source:           principal.SourceAPIToken,
 		TokenPermissions: slackOnly,
 		Scopes:           principal.PermissionPlugins(slackOnly),
 	}
@@ -3150,11 +3199,158 @@ func TestBootstrapHTTPCallerWildcardCatalogToolRefsAreRejected(t *testing.T) {
 		Messages:         []coreagent.Message{{Role: "user", Text: "get my linear tickets"}},
 		ToolRefs:         []coreagent.ToolRef{{Plugin: "*"}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "mcp catalog") {
-		t.Fatalf("AgentManager.CreateTurn wildcard error = %v, want mcp catalog validation error", err)
+	if err != nil {
+		t.Fatalf("AgentManager.CreateTurn wildcard scoped turn: %v", err)
 	}
-	if turn != nil {
-		t.Fatalf("AgentManager.CreateTurn returned turn %#v, want nil on wildcard rejection", turn)
+	if turn == nil {
+		t.Fatal("AgentManager.CreateTurn wildcard scoped turn returned nil")
+	}
+	provider.mu.Lock()
+	listResponses := append([]*proto.ListAgentToolsResponse(nil), provider.listResponses...)
+	toolBodies := append([]string(nil), provider.toolBodies...)
+	provider.mu.Unlock()
+	if len(listResponses) != 1 {
+		t.Fatalf("list response count = %d, want 1", len(listResponses))
+	}
+	if len(listResponses[0].GetTools()) != 0 {
+		t.Fatalf("listed tools = %#v, want none outside principal permissions", listResponses[0].GetTools())
+	}
+	if len(toolBodies) != 0 {
+		t.Fatalf("tool callback bodies = %#v, want no execution outside principal permissions", toolBodies)
+	}
+}
+
+func TestBootstrapGlobalCatalogToolRefsSkipUnavailableProviders(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.Agent = map[string]*config.ProviderEntry{
+		"managed": {
+			Source:  config.ProviderSource{Path: "stub"},
+			Default: true,
+		},
+	}
+
+	factories := validFactories()
+	factories.Builtins = append(factories.Builtins,
+		&coretesting.StubIntegration{
+			N:        "linear",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name: "linear",
+				Operations: []catalog.CatalogOperation{{
+					ID:          "issues",
+					Method:      http.MethodGet,
+					Description: "All issues visible to the authenticated user.",
+					ReadOnly:    true,
+				}},
+			},
+			ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				body, err := json.Marshal(map[string]any{
+					"provider":  "linear",
+					"operation": operation,
+				})
+				if err != nil {
+					return nil, err
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+			},
+		},
+		&unavailableSessionCatalogIntegration{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "ashby",
+				ConnMode: core.ConnectionModeUser,
+				CatalogVal: &catalog.Catalog{
+					Name: "ashby",
+					Operations: []catalog.CatalogOperation{{
+						ID:          "candidates",
+						Method:      http.MethodGet,
+						Description: "All candidates visible to the authenticated user.",
+						ReadOnly:    true,
+					}},
+				},
+			},
+			err: invocation.ErrNoCredential,
+		},
+	)
+
+	var provider *callbackAgentProvider
+	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, hostServices []runtimehost.HostService, _ bootstrap.Deps) (coreagent.Provider, error) {
+		started, err := runtimehost.StartHostServices(hostServices)
+		if err != nil {
+			return nil, err
+		}
+		value, err := newCallbackAgentProvider(started)
+		if err != nil {
+			_ = started.Close()
+			return nil, err
+		}
+		provider = value
+		return value, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	perms := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "linear",
+		Operations: []string{"issues"},
+	}, {
+		Plugin:     "ashby",
+		Operations: []string{"candidates"},
+	}, {
+		Plugin: "managed",
+	}})
+	p := &principal.Principal{
+		SubjectID:        "user:user-123",
+		UserID:           "user-123",
+		Kind:             principal.KindUser,
+		Source:           principal.SourceSession,
+		TokenPermissions: perms,
+		Scopes:           principal.PermissionPlugins(perms),
+	}
+	ctx := invocation.WithInvocationSurface(principal.WithPrincipal(context.Background(), p), invocation.InvocationSurfaceHTTP)
+
+	session, err := result.AgentManager.CreateSession(ctx, p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "managed",
+		Model:        "gpt-test",
+		ClientRef:    "cli-session-http-global-search",
+	})
+	if err != nil {
+		t.Fatalf("AgentManager.CreateSession: %v", err)
+	}
+	turn, err := result.AgentManager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
+		CallerPluginName: "slack",
+		SessionID:        session.ID,
+		IdempotencyKey:   "http-global-linear-search",
+		Model:            "gpt-test",
+		Messages:         []coreagent.Message{{Role: "user", Text: "get my linear tickets"}},
+		ToolRefs:         []coreagent.ToolRef{{Plugin: "*"}},
+	})
+	if err != nil {
+		t.Fatalf("AgentManager.CreateTurn global scoped turn: %v", err)
+	}
+	if turn == nil {
+		t.Fatal("AgentManager.CreateTurn global scoped turn returned nil")
+	}
+
+	provider.mu.Lock()
+	listResponses := append([]*proto.ListAgentToolsResponse(nil), provider.listResponses...)
+	toolBodies := append([]string(nil), provider.toolBodies...)
+	provider.mu.Unlock()
+	if len(listResponses) != 1 {
+		t.Fatalf("list response count = %d, want 1", len(listResponses))
+	}
+	tools := listResponses[0].GetTools()
+	if len(tools) != 1 || tools[0].GetRef().GetPlugin() != "linear" || tools[0].GetRef().GetOperation() != "issues" {
+		t.Fatalf("listed tools = %#v, want only connected linear issues", tools)
+	}
+	if len(toolBodies) != 1 || !strings.Contains(toolBodies[0], `"provider":"linear"`) || !strings.Contains(toolBodies[0], `"operation":"issues"`) {
+		t.Fatalf("tool callback bodies = %#v, want executed linear issues", toolBodies)
 	}
 }
 

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -921,19 +921,19 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 		t.Fatalf("provider turn tool refs = %#v, want docs.search", got)
 	}
 
-	broadTurnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}],"toolSource":"mcp_catalog","toolRefs":[{"plugin":"docs"}]}`))
+	broadTurnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}],"toolSource":"mcp_catalog","toolRefs":null}`))
 	broadTurnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	broadTurnResp, err := http.DefaultClient.Do(broadTurnReq)
 	if err != nil {
-		t.Fatalf("create broad mcp catalog turn: %v", err)
+		t.Fatalf("create null tool refs turn: %v", err)
 	}
 	defer func() { _ = broadTurnResp.Body.Close() }()
 	if broadTurnResp.StatusCode != http.StatusBadRequest {
 		body, _ := io.ReadAll(broadTurnResp.Body)
-		t.Fatalf("create broad mcp catalog turn status = %d body=%s, want 400", broadTurnResp.StatusCode, body)
+		t.Fatalf("create null tool refs turn status = %d body=%s, want 400", broadTurnResp.StatusCode, body)
 	}
 	if got := len(provider.capturedTurnRequests()); got != 1 {
-		t.Fatalf("provider turn requests len after broad mcp catalog turn = %d, want 1", got)
+		t.Fatalf("provider turn requests len after null tool refs turn = %d, want 1", got)
 	}
 
 	eventsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/turns/"+turnID+"/events?after=0&limit=10", nil)
@@ -1046,6 +1046,94 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	if cancelResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(cancelResp.Body)
 		t.Fatalf("cancel turn status = %d body=%s", cancelResp.StatusCode, body)
+	}
+}
+
+func TestAgentTurnToolRefsDefaultBroadAndExplicitEmpty(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAgentProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		services := testutil.NewStubServices(t)
+		agentControl := &stubAgentControl{defaultProviderName: "managed", provider: provider}
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "ada@example.com", DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Agent = agentControl
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent: agentControl,
+			Providers: testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+				N:        "docs",
+				ConnMode: core.ConnectionModeNone,
+				CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+					ID:       "search",
+					Title:    "Search",
+					ReadOnly: true,
+				}}},
+			}),
+			ToolGrants: newServerTestAgentToolGrants(t),
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions", bytes.NewBufferString(`{"provider":"managed","model":"gpt-5.4"}`))
+	sessionReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	sessionResp, err := http.DefaultClient.Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(sessionResp.Body)
+		t.Fatalf("create session status = %d body=%s", sessionResp.StatusCode, body)
+	}
+	var session map[string]any
+	if err := json.NewDecoder(sessionResp.Body).Decode(&session); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	sessionID := session["id"].(string)
+
+	createTurn := func(name, body string, wantStatus int) {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(body))
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: create turn: %v", name, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != wantStatus {
+			respBody, _ := io.ReadAll(resp.Body)
+			t.Fatalf("%s: create turn status = %d body=%s, want %d", name, resp.StatusCode, respBody, wantStatus)
+		}
+	}
+
+	createTurn("omitted", `{"messages":[{"role":"user","text":"hello"}]}`, http.StatusCreated)
+	createTurn("explicit empty", `{"messages":[{"role":"user","text":"hello"}],"toolRefs":[]}`, http.StatusCreated)
+	createTurn("plugin broad", `{"messages":[{"role":"user","text":"hello"}],"toolRefs":[{"plugin":"docs"}]}`, http.StatusCreated)
+	createTurn("null", `{"messages":[{"role":"user","text":"hello"}],"toolRefs":null}`, http.StatusBadRequest)
+	createTurn("global credential mode", `{"messages":[{"role":"user","text":"hello"}],"toolRefs":[{"plugin":"*","credentialMode":"none"}]}`, http.StatusBadRequest)
+	createTurn("system title", `{"messages":[{"role":"user","text":"hello"}],"toolRefs":[{"system":"workflow","operation":"schedules.list","title":"Schedules"}]}`, http.StatusBadRequest)
+
+	turnRequests := provider.capturedTurnRequests()
+	if len(turnRequests) != 3 {
+		t.Fatalf("provider turn requests len = %d, want 3", len(turnRequests))
+	}
+	if got := turnRequests[0].ToolRefs; len(got) != 1 || got[0].Plugin != "*" || got[0].Operation != "" {
+		t.Fatalf("omitted toolRefs provider refs = %#v, want global broad ref", got)
+	}
+	if got := turnRequests[1].ToolRefs; len(got) != 0 {
+		t.Fatalf("explicit empty toolRefs provider refs = %#v, want none", got)
+	}
+	if got := turnRequests[2].ToolRefs; len(got) != 1 || got[0].Plugin != "docs" || got[0].Operation != "" {
+		t.Fatalf("plugin broad provider refs = %#v, want docs broad ref", got)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -100,6 +101,7 @@ type agentTurnCreateRequest struct {
 	Metadata        map[string]any        `json:"metadata,omitempty"`
 	ProviderOptions map[string]any        `json:"providerOptions,omitempty"`
 	IdempotencyKey  string                `json:"idempotencyKey,omitempty"`
+	toolRefsSet     bool
 }
 
 type agentTurnCancelRequest struct {
@@ -362,8 +364,12 @@ func (s *Server) createAgentTurn(w http.ResponseWriter, r *http.Request) {
 	var req agentTurnCreateRequest
 	if r.Body != nil {
 		defer func() { _ = r.Body.Close() }()
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		if err := decodeAgentTurnCreateRequest(r.Body, &req); err != nil && !errors.Is(err, io.EOF) {
 			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+		if req.toolRefsSet && req.ToolRefs == nil {
+			writeError(w, http.StatusBadRequest, "toolRefs cannot be null")
 			return
 		}
 	}
@@ -385,7 +391,7 @@ func (s *Server) createAgentTurn(w http.ResponseWriter, r *http.Request) {
 		Model:           strings.TrimSpace(req.Model),
 		SessionID:       strings.TrimSpace(sessionID),
 		Messages:        agentMessagesFromRequest(req.Messages),
-		ToolRefs:        agentToolRefsFromRequest(req.ToolRefs),
+		ToolRefs:        agentToolRefsForCreateTurn(req),
 		ToolSource:      toolSource,
 		ResponseSchema:  maps.Clone(req.ResponseSchema),
 		Metadata:        maps.Clone(req.Metadata),
@@ -396,6 +402,29 @@ func (s *Server) createAgentTurn(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, agentTurnInfoFromCore(turn))
+}
+
+func decodeAgentTurnCreateRequest(r io.Reader, req *agentTurnCreateRequest) error {
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return io.EOF
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return err
+	}
+	rawToolRefs, hasToolRefs := fields["toolRefs"]
+	if err := json.Unmarshal(body, req); err != nil {
+		return err
+	}
+	req.toolRefsSet = hasToolRefs
+	if hasToolRefs && bytes.Equal(bytes.TrimSpace(rawToolRefs), []byte("null")) {
+		req.ToolRefs = nil
+	}
+	return nil
 }
 
 func (s *Server) listAgentTurns(w http.ResponseWriter, r *http.Request) {
@@ -811,6 +840,13 @@ func agentToolRefsFromRequest(refs []agentToolRefRequest) []coreagent.ToolRef {
 	return out
 }
 
+func agentToolRefsForCreateTurn(req agentTurnCreateRequest) []coreagent.ToolRef {
+	if !req.toolRefsSet {
+		return []coreagent.ToolRef{{Plugin: "*"}}
+	}
+	return agentToolRefsFromRequest(req.ToolRefs)
+}
+
 func agentToolRefsToRequest(refs []coreagent.ToolRef) []agentToolRefRequest {
 	if len(refs) == 0 {
 		return nil
@@ -837,6 +873,10 @@ func validateAgentToolRefs(refs []agentToolRefRequest) error {
 		ref := refs[idx]
 		system := strings.TrimSpace(ref.System)
 		plugin := strings.TrimSpace(ref.Plugin)
+		operation := strings.TrimSpace(ref.Operation)
+		connection := strings.TrimSpace(ref.Connection)
+		instance := strings.TrimSpace(ref.Instance)
+		credentialMode := strings.TrimSpace(ref.CredentialMode)
 		if system == "" && plugin == "" {
 			return fmt.Errorf("toolRefs[%d].plugin or system is required", idx)
 		}
@@ -847,14 +887,24 @@ func validateAgentToolRefs(refs []agentToolRefRequest) error {
 			if system != coreagent.SystemToolWorkflow {
 				return fmt.Errorf("toolRefs[%d].system %q is not supported", idx, system)
 			}
-			if strings.TrimSpace(ref.Operation) == "" {
+			if operation == "" {
 				return fmt.Errorf("toolRefs[%d].operation is required for system tool refs", idx)
 			}
-			if strings.TrimSpace(ref.Connection) != "" || strings.TrimSpace(ref.Instance) != "" {
-				return fmt.Errorf("toolRefs[%d] system refs cannot include connection or instance", idx)
+			if operation == "*" {
+				return fmt.Errorf("toolRefs[%d].operation wildcard is not supported", idx)
+			}
+			if connection != "" || instance != "" || credentialMode != "" || strings.TrimSpace(ref.Title) != "" || strings.TrimSpace(ref.Description) != "" {
+				return fmt.Errorf("toolRefs[%d] system refs cannot include connection, instance, credentialMode, title, or description", idx)
+			}
+		} else {
+			if operation == "*" || connection == "*" || instance == "*" {
+				return fmt.Errorf("toolRefs[%d] wildcard fields are not supported", idx)
+			}
+			if plugin == "*" && (operation != "" || connection != "" || instance != "" || credentialMode != "" || strings.TrimSpace(ref.Title) != "" || strings.TrimSpace(ref.Description) != "") {
+				return fmt.Errorf("toolRefs[%d] global ref cannot include operation, connection, instance, credentialMode, title, or description", idx)
 			}
 		}
-		switch strings.ToLower(strings.TrimSpace(ref.CredentialMode)) {
+		switch strings.ToLower(credentialMode) {
 		case "":
 		default:
 			return fmt.Errorf("toolRefs[%d].credentialMode is not supported on public agent requests", idx)

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -1176,7 +1176,7 @@ func (m *Manager) listTools(ctx context.Context, p *principal.Principal, req cor
 	var firstUnavailableErr error
 	for i := range candidates {
 		candidate := candidates[i]
-		tool, err := m.resolveTool(ctx, p, candidate.ref)
+		listed, err := m.listedAgentPluginCandidateTool(candidate)
 		if err != nil {
 			if errors.Is(err, invocation.ErrAuthorizationDenied) || errors.Is(err, invocation.ErrProviderNotFound) || errors.Is(err, invocation.ErrOperationNotFound) {
 				continue
@@ -1189,12 +1189,12 @@ func (m *Manager) listTools(ctx context.Context, p *principal.Principal, req cor
 			}
 			return nil, err
 		}
-		key := agentToolTargetKeyFromTarget(tool.Target)
+		key := agentToolTargetKeyFromTarget(listed.Target)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
-		out = append(out, listedAgentPluginTool(tool, candidate))
+		out = append(out, listed)
 	}
 	if len(out) == 0 && len(refs) > 0 && firstUnavailableErr != nil {
 		return nil, firstUnavailableErr
@@ -1744,10 +1744,10 @@ func (s agentToolSearchScope) providerNames() []string {
 }
 
 func (s agentToolSearchScope) refsForProvider(pluginName string) []coreagent.ToolRef {
-	if s.all {
-		return []coreagent.ToolRef{{Plugin: pluginName}}
-	}
 	refs := []coreagent.ToolRef{}
+	if s.all {
+		refs = append(refs, coreagent.ToolRef{Plugin: pluginName})
+	}
 	if ops := s.exactOps[pluginName]; len(ops) > 0 {
 		operations := make([]string, 0, len(ops))
 		for operation := range ops {
@@ -2074,23 +2074,45 @@ func listedAgentSystemTool(tool coreagent.Tool) (coreagent.ListedTool, error) {
 	}, nil
 }
 
-func listedAgentPluginTool(tool coreagent.Tool, candidate agentToolSearchCandidate) coreagent.ListedTool {
+func (m *Manager) listedAgentPluginCandidateTool(candidate agentToolSearchCandidate) (coreagent.ListedTool, error) {
 	ref := candidate.ref
-	ref.Connection = tool.Target.Connection
-	ref.Instance = tool.Target.Instance
-	ref.CredentialMode = tool.Target.CredentialMode
+	target := coreagent.ToolTarget{
+		Plugin:         strings.TrimSpace(ref.Plugin),
+		Operation:      strings.TrimSpace(ref.Operation),
+		Connection:     core.ResolveConnectionAlias(strings.TrimSpace(ref.Connection)),
+		Instance:       strings.TrimSpace(ref.Instance),
+		CredentialMode: ref.CredentialMode,
+	}
+	toolID, err := m.mintAgentToolID(target)
+	if err != nil {
+		return coreagent.ListedTool{}, err
+	}
+	name := strings.TrimSpace(ref.Title)
+	if name == "" {
+		name = strings.TrimSpace(candidate.operation.Title)
+	}
+	if name == "" {
+		name = target.Plugin + "." + candidate.operation.ID
+	}
+	description := strings.TrimSpace(ref.Description)
+	if description == "" {
+		description = strings.TrimSpace(candidate.operation.Description)
+	}
+	ref.Connection = target.Connection
+	ref.Instance = target.Instance
+	ref.CredentialMode = target.CredentialMode
 	return coreagent.ListedTool{
-		ToolID:           tool.ID,
-		MCPName:          agentToolMCPName(tool.Target),
-		Title:            tool.Name,
-		Description:      tool.Description,
+		ToolID:           toolID,
+		MCPName:          agentToolMCPName(target),
+		Title:            name,
+		Description:      description,
 		InputSchemaJSON:  agentToolInputSchemaJSON(candidate.operation),
 		OutputSchemaJSON: agentToolOutputSchemaJSON(candidate.operation),
 		Annotations:      capabilityAnnotationsFromCatalog(candidate.operation.Annotations),
 		Ref:              ref,
-		Target:           tool.Target,
-		Hidden:           tool.Hidden,
-	}
+		Target:           target,
+		Hidden:           !catalog.OperationVisibleByDefault(candidate.operation),
+	}, nil
 }
 
 func capabilityAnnotationsFromCatalog(value catalog.OperationAnnotations) core.CapabilityAnnotations {
@@ -2286,8 +2308,8 @@ func normalizeToolRefs(refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
 			if ref.Operation == "" {
 				return nil, fmt.Errorf("%w: agent tool_refs[%d].operation is required for system tool refs", invocation.ErrOperationNotFound, idx)
 			}
-			if ref.Connection != "" || ref.Instance != "" || ref.CredentialMode != "" {
-				return nil, fmt.Errorf("%w: agent tool_refs[%d] system refs cannot include connection, instance, or credential mode", invocation.ErrInvalidInvocation, idx)
+			if ref.Connection != "" || ref.Instance != "" || ref.CredentialMode != "" || ref.Title != "" || ref.Description != "" {
+				return nil, fmt.Errorf("%w: agent tool_refs[%d] system refs cannot include connection, instance, credential mode, title, or description", invocation.ErrInvalidInvocation, idx)
 			}
 			out = append(out, ref)
 			continue


### PR DESCRIPTION
## Summary
- Default omitted HTTP `toolRefs` on agent turns to a broad MCP catalog grant, represented internally as `[{"plugin":"*"}]`.
- Preserve explicit opt-out with `toolRefs: []` and reject ambiguous `toolRefs: null`.
- Expand broad refs through authorized visible catalog operations, including visible write/destructive tools, while hidden operations and workflow system tools still require exact refs.
- Avoid per-candidate tool resolution during list hydration by materializing listed tools directly from catalog candidates after authorization filtering.

## Interface Changes
- New/changed interface: `POST /api/v1/agent/sessions/{sessionID}/turns` now treats omitted `toolRefs` as all visible connected MCP tools available to the caller.
- Example usage: `{ "messages": [{"role":"user","text":"show me my Linear tickets"}] }` now sends `[{"plugin":"*"}]` to the provider; `{ "toolRefs": [] }` still creates a no-tools turn; `{ "toolRefs": null }` returns `400`.
- Stack order: deploy this only after the Claude provider change in valon-technologies/gestalt-providers#452 is released/consumed, because older Claude providers reject `plugin: "*"` refs.

## Test plan
- [x] `go test ./services/agents/agentmanager -run 'TestManagerCreateTurnDefaultsToMCPCatalogForProviderTurns|TestResolveToolsExpandsPluginOnlyRefs'`
- [x] `go test ./internal/server -run 'TestAgentSessionsAndTurnsRoundTrip|TestAgentTurnToolRefsDefaultBroadAndExplicitEmpty|TestAgentTurnEventsNormalizeToolPayloads'`
- [x] `go test ./internal/bootstrap -run 'TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn|TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools|TestBootstrapHTTPCallerWildcardCatalogToolRefsAreScopedByAuthorization|TestBootstrapGlobalCatalogToolRefsSkipUnavailableProviders'`
- [x] `go test ./services/agents/agentmanager`
- [x] `go test ./internal/server`
- [x] `go test ./internal/bootstrap`
- [x] `golangci-lint run`