### PR TITLE
Add range-aware IndexedDB index deletes

### DIFF
--- a/gestaltd/core/indexeddb/datastore.go
+++ b/gestaltd/core/indexeddb/datastore.go
@@ -91,6 +91,7 @@ type TransactionIndex interface {
 	GetAllKeys(ctx context.Context, r *KeyRange, values ...any) ([]string, error)
 	Count(ctx context.Context, r *KeyRange, values ...any) (int64, error)
 	Delete(ctx context.Context, values ...any) (int64, error)
+	DeleteRange(ctx context.Context, r *KeyRange, values ...any) (int64, error)
 }
 
 // ObjectStore provides CRUD by primary key ("id" field) and index-based queries.
@@ -126,6 +127,7 @@ type Index interface {
 	GetAllKeys(ctx context.Context, r *KeyRange, values ...any) ([]string, error)
 	Count(ctx context.Context, r *KeyRange, values ...any) (int64, error)
 	Delete(ctx context.Context, values ...any) (int64, error)
+	DeleteRange(ctx context.Context, r *KeyRange, values ...any) (int64, error)
 
 	// Cursor iteration
 	OpenCursor(ctx context.Context, r *KeyRange, dir CursorDirection, values ...any) (Cursor, error)

--- a/gestaltd/core/testing/indexeddb_stub.go
+++ b/gestaltd/core/testing/indexeddb_stub.go
@@ -640,10 +640,14 @@ func (i *stubTransactionIndex) Count(ctx context.Context, r *indexeddb.KeyRange,
 }
 
 func (i *stubTransactionIndex) Delete(ctx context.Context, values ...any) (int64, error) {
+	return i.DeleteRange(ctx, nil, values...)
+}
+
+func (i *stubTransactionIndex) DeleteRange(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
 	if err := i.tx.ensureActive(true); err != nil {
 		return 0, err
 	}
-	deleted, err := i.index.Delete(ctx, values...)
+	deleted, err := i.index.DeleteRange(ctx, r, values...)
 	if err != nil {
 		return 0, i.tx.abortWithError(err)
 	}
@@ -723,6 +727,10 @@ func (i transactionMissingIndex) Count(context.Context, *indexeddb.KeyRange, ...
 }
 
 func (i transactionMissingIndex) Delete(context.Context, ...any) (int64, error) {
+	return 0, i.tx.abortWithError(indexeddb.ErrNotFound)
+}
+
+func (i transactionMissingIndex) DeleteRange(context.Context, *indexeddb.KeyRange, ...any) (int64, error) {
 	return 0, i.tx.abortWithError(indexeddb.ErrNotFound)
 }
 
@@ -861,24 +869,23 @@ func (idx *stubIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values .
 	return int64(len(c.keys)), nil
 }
 
-func (idx *stubIndex) Delete(_ context.Context, values ...any) (int64, error) {
+func (idx *stubIndex) Delete(ctx context.Context, values ...any) (int64, error) {
+	return idx.DeleteRange(ctx, nil, values...)
+}
+
+func (idx *stubIndex) DeleteRange(_ context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
 	if idx.store.db.Err != nil {
 		return 0, idx.store.db.Err
 	}
 	done := idx.store.writeSchedule()
 	defer done()
+	c := idx.newCursor(indexeddb.CursorNext, r, true, values...)
 	idx.store.mu.Lock()
 	defer idx.store.mu.Unlock()
-	var toDelete []string
-	for id, r := range idx.store.records {
-		if idx.matches(r, values) {
-			toDelete = append(toDelete, id)
-		}
-	}
-	for _, id := range toDelete {
+	for _, id := range c.keys {
 		delete(idx.store.records, id)
 	}
-	return int64(len(toDelete)), nil
+	return int64(len(c.keys)), nil
 }
 
 func (idx *stubIndex) OpenCursor(_ context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {

--- a/gestaltd/internal/bootstrap/plugin_indexeddb.go
+++ b/gestaltd/internal/bootstrap/plugin_indexeddb.go
@@ -178,6 +178,10 @@ func (missingIndex) Delete(context.Context, ...any) (int64, error) {
 	return 0, indexeddb.ErrNotFound
 }
 
+func (missingIndex) DeleteRange(context.Context, *indexeddb.KeyRange, ...any) (int64, error) {
+	return 0, indexeddb.ErrNotFound
+}
+
 func (missingIndex) OpenCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection, ...any) (indexeddb.Cursor, error) {
 	return nil, indexeddb.ErrNotFound
 }
@@ -269,5 +273,9 @@ func (i missingTransactionIndex) Count(ctx context.Context, _ *indexeddb.KeyRang
 }
 
 func (i missingTransactionIndex) Delete(ctx context.Context, _ ...any) (int64, error) {
+	return 0, i.fail(ctx)
+}
+
+func (i missingTransactionIndex) DeleteRange(ctx context.Context, _ *indexeddb.KeyRange, _ ...any) (int64, error) {
 	return 0, i.fail(ctx)
 }

--- a/gestaltd/services/indexeddb/client.go
+++ b/gestaltd/services/indexeddb/client.go
@@ -397,14 +397,22 @@ func (idx *remoteIndex) OpenKeyCursor(ctx context.Context, r *coreindexeddb.KeyR
 }
 
 func (idx *remoteIndex) Delete(ctx context.Context, values ...any) (int64, error) {
+	return idx.DeleteRange(ctx, nil, values...)
+}
+
+func (idx *remoteIndex) DeleteRange(ctx context.Context, r *coreindexeddb.KeyRange, values ...any) (int64, error) {
 	ctx, cancel := runtimehost.ProviderCallContext(ctx)
 	defer cancel()
 	pbValues, err := toProtoValues(values)
 	if err != nil {
 		return 0, err
 	}
+	kr, err := keyRangeToProto(r)
+	if err != nil {
+		return 0, err
+	}
 	resp, err := idx.client.IndexDelete(ctx, &proto.IndexQueryRequest{
-		Store: idx.store, Index: idx.index, Values: pbValues,
+		Store: idx.store, Index: idx.index, Values: pbValues, Range: kr,
 	})
 	if err != nil {
 		return 0, grpcToDatastoreErr(err)
@@ -739,8 +747,12 @@ func (idx *remoteTransactionIndex) Count(_ context.Context, r *coreindexeddb.Key
 	return resp.GetCount().GetCount(), nil
 }
 
-func (idx *remoteTransactionIndex) Delete(_ context.Context, values ...any) (int64, error) {
-	req, err := idx.query(nil, values)
+func (idx *remoteTransactionIndex) Delete(ctx context.Context, values ...any) (int64, error) {
+	return idx.DeleteRange(ctx, nil, values...)
+}
+
+func (idx *remoteTransactionIndex) DeleteRange(_ context.Context, r *coreindexeddb.KeyRange, values ...any) (int64, error) {
+	req, err := idx.query(r, values)
 	if err != nil {
 		return 0, err
 	}

--- a/gestaltd/services/indexeddb/server.go
+++ b/gestaltd/services/indexeddb/server.go
@@ -328,6 +328,10 @@ func (s *indexedDBServer) IndexCount(ctx context.Context, req *proto.IndexQueryR
 }
 
 func (s *indexedDBServer) IndexDelete(ctx context.Context, req *proto.IndexQueryRequest) (*proto.DeleteResponse, error) {
+	keyRange, err := protoToKeyRange(req.Range)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
+	}
 	values, err := protoValuesToAny(req.GetValues())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
@@ -336,7 +340,7 @@ func (s *indexedDBServer) IndexDelete(ctx context.Context, req *proto.IndexQuery
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
-	deleted, err := store.Index(req.GetIndex()).Delete(ctx, values...)
+	deleted, err := store.Index(req.GetIndex()).DeleteRange(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -709,11 +713,11 @@ func (s *indexedDBServer) executeTransactionIndexCount(ctx context.Context, tx c
 }
 
 func (s *indexedDBServer) executeTransactionIndexDelete(ctx context.Context, tx coreindexeddb.Transaction, req *proto.IndexQueryRequest) (int64, error) {
-	idx, values, _, err := s.transactionIndex(ctx, tx, req)
+	idx, values, keyRange, err := s.transactionIndex(ctx, tx, req)
 	if err != nil {
 		return 0, err
 	}
-	return idx.Delete(ctx, values...)
+	return idx.DeleteRange(ctx, keyRange, values...)
 }
 
 func protoTransactionMode(mode proto.TransactionMode) coreindexeddb.TransactionMode {

--- a/gestaltd/services/observability/metricutil/indexeddb.go
+++ b/gestaltd/services/observability/metricutil/indexeddb.go
@@ -210,6 +210,13 @@ func (i *instrumentedIndex) Delete(ctx context.Context, values ...any) (int64, e
 	return n, err
 }
 
+func (i *instrumentedIndex) DeleteRange(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
+	startedAt := time.Now()
+	n, err := i.inner.DeleteRange(ctx, r, values...)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.DeleteRange", err)
+	return n, err
+}
+
 func (i *instrumentedIndex) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
 	startedAt := time.Now()
 	c, err := i.inner.OpenCursor(ctx, r, dir, values...)

--- a/gestaltd/services/observability/metricutil/semantic_metrics.go
+++ b/gestaltd/services/observability/metricutil/semantic_metrics.go
@@ -167,6 +167,8 @@ func normalizeIndexedDBOperationName(operation string) string {
 		return "index_count"
 	case "Index.Delete":
 		return "index_delete"
+	case "Index.DeleteRange":
+		return "index_delete_range"
 	case "Index.OpenCursor":
 		return "index_open_cursor"
 	case "Index.OpenKeyCursor":

--- a/sdk/go/indexeddb.go
+++ b/sdk/go/indexeddb.go
@@ -611,12 +611,21 @@ func (idx *IndexClient) Count(ctx context.Context, r *KeyRange, values ...any) (
 
 // Delete removes all rows that match values.
 func (idx *IndexClient) Delete(ctx context.Context, values ...any) (int64, error) {
+	return idx.DeleteRange(ctx, nil, values...)
+}
+
+// DeleteRange removes all rows that match values and r.
+func (idx *IndexClient) DeleteRange(ctx context.Context, r *KeyRange, values ...any) (int64, error) {
 	vals, err := anyToProtoValues(values)
 	if err != nil {
 		return 0, err
 	}
+	kr, err := krToProto(r)
+	if err != nil {
+		return 0, err
+	}
 	resp, err := idx.client.IndexDelete(ctx, &proto.IndexQueryRequest{
-		Store: idx.store, Index: idx.index, Values: vals,
+		Store: idx.store, Index: idx.index, Values: vals, Range: kr,
 	})
 	if err != nil {
 		return 0, grpcErr(err)
@@ -983,8 +992,13 @@ func (idx *TransactionIndex) Count(ctx context.Context, r *KeyRange, values ...a
 }
 
 func (idx *TransactionIndex) Delete(ctx context.Context, values ...any) (int64, error) {
+	return idx.DeleteRange(ctx, nil, values...)
+}
+
+// DeleteRange removes all transaction-scoped rows that match values and r.
+func (idx *TransactionIndex) DeleteRange(ctx context.Context, r *KeyRange, values ...any) (int64, error) {
 	_ = ctx
-	req, err := idx.query(nil, values)
+	req, err := idx.query(r, values)
 	if err != nil {
 		return 0, err
 	}

--- a/sdk/go/indexeddb_transport_test.go
+++ b/sdk/go/indexeddb_transport_test.go
@@ -539,12 +539,12 @@ func TestTransport_TransactionIndexAndBulkRollback(t *testing.T) {
 	if deletedRange != 2 {
 		t.Fatalf("DeleteRange deleted = %d, want 2", deletedRange)
 	}
-	deletedIndex, err := txs.Index("by_status").Delete(ctx, "active")
+	deletedIndex, err := txs.Index("by_status").DeleteRange(ctx, &gestalt.KeyRange{Lower: "active", Upper: "active"})
 	if err != nil {
-		t.Fatalf("tx index Delete active: %v", err)
+		t.Fatalf("tx index DeleteRange active: %v", err)
 	}
 	if deletedIndex != 2 {
-		t.Fatalf("index Delete deleted = %d, want 2", deletedIndex)
+		t.Fatalf("index DeleteRange deleted = %d, want 2", deletedIndex)
 	}
 	if err := txs.Clear(ctx); err != nil {
 		t.Fatalf("tx Clear: %v", err)
@@ -560,6 +560,31 @@ func TestTransport_TransactionIndexAndBulkRollback(t *testing.T) {
 	}
 	if inactive, err := s.Index("by_status").Count(ctx, nil, "inactive"); err != nil || inactive != 1 {
 		t.Fatalf("public inactive count after abort = %d, %v; want 1, nil", inactive, err)
+	}
+}
+
+func TestTransport_IndexDeleteRange(t *testing.T) {
+	ctx := context.Background()
+	store := seedStore(t)
+	s := testClient.ObjectStore(store)
+
+	deleted, err := s.Index("by_status").DeleteRange(ctx, &gestalt.KeyRange{Lower: "active", Upper: "active"})
+	if err != nil {
+		t.Fatalf("Index DeleteRange active: %v", err)
+	}
+	if deleted != 3 {
+		t.Fatalf("Index DeleteRange deleted = %d, want 3", deleted)
+	}
+
+	remaining, err := s.GetAll(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetAll remaining: %v", err)
+	}
+	if got := len(remaining); got != 1 {
+		t.Fatalf("remaining len = %d, want 1", got)
+	}
+	if got := remaining[0]["id"]; got != "c" {
+		t.Fatalf("remaining id = %v, want c", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add Go SDK `IndexClient.DeleteRange` and `TransactionIndex.DeleteRange`
- plumb index-delete key ranges through gestaltd server, remote client, core interfaces, test stub, and metrics
- add SDK transport coverage for range-aware index deletes

## Tests
- `go test ./...` from `sdk/go`
- `go test ./...` from repo root
- `go test ./...` from `gestaltd`
