### PR TITLE
docs: rewrite authorization docs and add external-credentials page

### DIFF
--- a/docs/content/providers/_meta.ts
+++ b/docs/content/providers/_meta.ts
@@ -1,8 +1,9 @@
 export default {
+  agent: "Agent",
   authentication: "Authentication",
   authorization: "Authorization",
-  agent: "Agent",
   cache: "Cache",
+  "external-credentials": "External Credentials",
   indexeddb: "IndexedDB",
   plugins: "Plugin",
   runtime: "Runtime",

--- a/docs/content/providers/authorization.mdx
+++ b/docs/content/providers/authorization.mdx
@@ -1,38 +1,106 @@
 # Authorization
 
 Authorization providers back dynamic subject authorization state. They are
-separate from platform login: `providers.authentication.<name>` decides how users sign in
-to Gestalt, while `providers.authorization.<name>` stores authorization
+separate from platform login: `providers.authentication.<name>` decides how users
+sign in to Gestalt, while `providers.authorization.<name>` stores authorization
 relationships and answers authorization queries for Gestalt itself.
 
 This relationship-oriented authorization model is inspired by
 [Google Zanzibar](https://research.google/pubs/zanzibar-googles-consistent-global-authorization-system/),
-Google's global authorization system.
+Google's global authorization system. Gestalt's implementation follows Zanzibar's
+core ideas---subjects, resources, relations, and relationship tuples---while
+adapting them to a smaller deployment model that does not require its own NewSQL
+cluster.
 
-## How authorization providers work
+## Core concepts
 
-Static shared policies still live under top-level `authorization.policies`.
-When `server.providers.authorization` selects a provider, Gestalt writes its
-authorization model plus dynamic subject plugin and built-in admin relationships
-into that provider and uses it for runtime subject authorization checks.
+Before reading how Gestalt applies authorization, it helps to know the Zanzibar
+concepts it uses.
 
-Dynamic human plugin/admin grants and the built-in authorization control-plane
-APIs require an authorization provider. If you omit `providers.authorization`,
-Gestalt still evaluates static policy members from config, but there is no
-provider-backed relationship storage or dynamic subject-grant control plane.
+### Subjects
+
+A subject is the entity an authorization check is for. In Gestalt, subjects are
+canonical identifiers like `user:<id>`, `service_account:<id>`, or a system
+subject like `system:platform-config`. When a request arrives, Gestalt resolves
+the caller to a subject, then performs every subsequent check in terms of that
+subject.
+
+### Resources
+
+A resource is the thing a subject is asking to access. In Gestalt, the most
+common resources are:
+
+- A **plugin**, such as `plugin_static:github`
+- A **policy**, such as `policy_static:admin`
+- An **external identity**, such as `external_identity:google-123`
+- A **managed subject**, such as `managed_subject:deploy-bot`
+
+### Relations
+
+A relation is the named edge between a subject and a resource. The relation
+`triage` on a plugin means "this subject can triage issues on this plugin."
+The relation `admin` on a policy means "this subject is an admin in this policy."
+
+### Relationship tuples
+
+A relationship tuple is the concrete instance of a relation:
+
+```
+<subject> <relation> <resource>
+```
+
+For example:
+
+```
+user:alice viewer plugin_static:github
+user:bob editor plugin_static:github
+```
+
+These tuples are stored in the configured authorization provider. The provider
+treats them as the source of truth for every dynamic access decision.
+
+### Actions
+
+Relations describe membership. Actions describe what the membership grants.
+A provider's authorization model defines which actions a role implies, then
+maps those actions back to relations. When Gestalt asks "may user:alice read
+this operation?" the provider checks whether alice has any relation on the
+resource that includes the `read` action.
+
+## Static and dynamic authorization
+
+Gestalt has two ways to express who may do what.
+
+### Static authorization
+
+Static authorization lives in config under `authorization.policies`.
+It is loaded at startup, immutable at runtime, and takes precedence over
+dynamic grants. Static membership is useful for:
+
+- Initial admin access when no provider is configured
+- Infrastructure-as-code role assignments
+- Break-glass access that does not depend on a running provider
+
+### Dynamic authorization
+
+Dynamic authorization lives in the configured authorization provider.
+Administrators can add or remove grants through the built-in admin
+authorization API without restarting the server. Dynamic authorization is
+useful for:
+
+- User self-service role requests
+- Time-bound access grants
+- Role changes that must propagate without a deployment
+
+When both static and dynamic grants exist for the same subject and resource,
+static grants win. If a static policy grants alice `admin` on the admin
+policy, the provider is not consulted for alice's admin role.
 
 ## Product authorization semantics
 
 At the product level, authorization is about subjects and runtime surfaces.
-Gestalt resolves each request to a canonical subject such as `user:<id>`,
-`service_account:<id>`, or a system subject, then asks whether that subject may access
-the thing they are trying to use. Static memberships under
-`authorization.policies` are always available. When you configure an
-authorization provider, Gestalt adds dynamic relationship storage on top so
-those decisions can change without editing YAML.
-
-This is separate from authentication. Authentication answers who the caller is.
-Authorization answers what that caller may do once their subject is known.
+Gestalt resolves each request to a canonical subject, then asks whether that
+subject may access the thing they are trying to use.
 
 There are four related layers involved in most runtime decisions:
 
@@ -49,34 +117,99 @@ token does not include the target operation scope. Likewise, an execution can
 have the correct operation scope and still fail if the selected connection has
 no usable credential for the credential subject.
 
-### Plugin invocation
+## Plugin invocation
 
 Plugin authorization happens at request time. Gestalt checks whether the
 calling subject may access the plugin or operation before it invokes the
-target. The subject's upstream connection is also scoped to that same subject,
-so access is both identity-aware and credential-aware.
+target.
 
 The broker is the common runtime gate for HTTP, MCP, workflow, agent-tool, and
-nested plugin invocations. For a plugin operation call, it resolves the target
-plugin and operation, verifies that the principal can call them, applies any
-bound authorization provider or policy for the canonical subject, resolves the
-operation connection and credential, and invokes the provider with only the
-token needed for that invocation.
+nested plugin invocations. For a plugin operation call, it:
+
+1. Resolves the target plugin and operation
+2. Verifies the principal can call them at the operation-scope layer
+3. Applies any bound authorization provider or policy for the canonical subject
+4. Resolves the operation connection and credential
+5. Invokes the provider with only the token needed for that invocation
+
+### Nested plugin calls and invocation tokens
 
 Executable plugins can call other plugins through the host-provided plugin
-invoker. This is intentionally a propagation and attenuation primitive, not an
-authority-expansion primitive. `plugins.<caller>.invokes` defines the allowed
-call graph, while the propagated principal or workflow execution ref defines
-what this specific execution may do. Invocation tokens can be exchanged only
-for subsets of their parent grants, so plugins can narrow delegated authority
-but cannot add new target plugins or operations.
+invoker. This is a propagation and attenuation primitive, not an
+authority-expansion primitive.
 
-### Workflow execution
+`plugins.<caller>.invokes` defines the allowed call graph. The caller declares
+which plugins, operations, or surfaces it may invoke:
+
+```yaml
+plugins:
+  indexer:
+    source: ./plugins/indexer/manifest.yaml
+    invokes:
+      - plugin: source
+        operations:
+          - messages.list
+          - messages.get
+      - plugin: github
+        surface: graphql
+```
+
+At runtime, the caller receives an invocation token that encodes its declared
+grants. When the caller asks to invoke another plugin, the host verifies the
+requested grant is a subset of the parent's declared `invokes`. If the caller
+requests no specific grant, it inherits the full parent grant. If it requests
+a narrower grant, the host intersects the two.
+
+This means plugins can narrow delegated authority but cannot add new target
+plugins or operations. A plugin with `invokes: [source.messages.list]` can
+exchange its token for a token that only has `source.messages.list`, but it
+cannot exchange its token for a token that also has `github.issues.create`.
+
+#### Invocation token lifecycle
+
+Invocation tokens are signed JWTs with the following guarantees:
+
+- **Issuer**: `gestaltd`, audience: `gestalt-provider-host`
+- **Caller binding**: the token is bound to the plugin that minted it
+- **Delegation expiry**: a separate delegation expiry limits how long a token
+can be exchanged, even if the token itself has not expired
+- **Depth tracking**: the call chain depth is tracked to prevent unbounded
+recursion
+- **Principal propagation**: the original subject, permissions, and credential
+context are forwarded so the nested call runs with the same identity
+
+A root invocation token lives for 15 minutes. A child token can be exchanged
+for up to 10 minutes, with a maximum delegation window of 15 minutes from the
+root. If a parent token's delegation window has passed, no child exchange
+succeeds.
+
+#### Credential modes in nested calls
+
+By default, nested plugin calls use the same connection mode as the parent.
+You can declare a different mode per `invokes` entry:
+
+```yaml
+plugins:
+  reporter:
+    source: ./plugins/reporter/manifest.yaml
+    invokes:
+      - plugin: slack
+        credentialMode: platform
+```
+
+This causes the nested call to use a platform-scoped credential instead of the
+calling user's credential. Platform-scoped credentials are useful when the
+caller is a batch job or an integration that should act on behalf of the
+deployment, not on behalf of a user.
+
+## Workflow execution
 
 Workflow authorization happens twice. Gestalt checks access when a user creates
-a schedule, then checks again when that schedule or trigger fires later. User
-owned workflows keep the creating subject plus a permission ceiling for delayed
-execution. Config-managed workflows use the system config subject instead.
+a schedule, then checks again when that schedule or trigger fires later.
+
+User-owned workflows keep the creating subject plus a permission ceiling for
+delayed execution. Config-managed workflows use the system config subject
+instead.
 
 Config-managed workflows include the direct target operation automatically. If
 the target performs nested plugin calls, declare those additional operation
@@ -110,12 +243,80 @@ Config-owned direct targets, agent tools, and output-delivery targets must
 resolve to non-user credentials. Mixed plugins are still supported when the
 target explicitly selects a platform-backed connection.
 
-### UI routes
+## UI routes
 
 Mounted UI bundles can bind an `authorizationPolicy`, and their manifests can
 declare route-level `allowedRoles`. Gestalt resolves the caller's subject,
 derives their role for the bound policy, and checks that role before serving
 the matched route. The built-in admin UI uses the same model.
+
+## Authorization provider architecture
+
+When `server.providers.authorization` selects a provider, Gestalt writes its
+authorization model plus dynamic subject plugin and built-in admin relationships
+into that provider and uses it for runtime subject authorization checks.
+
+### Decision plane
+
+The authorization provider answers access queries through these methods:
+
+| Method | Purpose |
+| --- | --- |
+| `Evaluate` | Check a single subject-action-resource tuple |
+| `EvaluateMany` | Check many tuples in one batch |
+| `SearchResources` | List resources a subject can access |
+| `SearchSubjects` | List subjects that can access a resource |
+| `SearchActions` | List actions a subject can perform on a resource |
+| `GetMetadata` | Return provider capabilities and active model |
+
+Gestalt uses `EvaluateMany` heavily. When it resolves a provider role for a
+principal, it batches all possible role checks into one call. This is
+important for latency: a principal with five possible roles on a resource
+causes one `EvaluateMany` call, not five sequential `Evaluate` calls.
+
+### Relationship control plane
+
+| Method | Purpose |
+| --- | --- |
+| `ReadRelationships` | Query stored relationship tuples |
+| `WriteRelationships` | Atomically write and delete tuples |
+
+Gestalt uses `WriteRelationships` to sync its managed model and state into the
+provider. It computes the desired set of relationship tuples from config and
+current grants, diffs that against the existing set, and issues writes and
+deletes to converge. This runs on startup and then polls every 5 seconds.
+
+### Model lifecycle
+
+| Method | Purpose |
+| --- | --- |
+| `GetActiveModel` | Return the current authorization model |
+| `ListModels` | Return all stored models |
+| `WriteModel` | Store a new authorization model |
+
+Gestalt builds an authorization model from the configured policies and roles.
+The model declares resource types, their relations, and the actions each
+relation implies. When policies change, Gestalt writes a new model and
+then migrates the relationships.
+
+### Managed resource types
+
+Gestalt's provider-backed authorizer manages these resource types in the
+provider:
+
+| Resource type | What it represents |
+| --- | --- |
+| `policy_static` | Static policy definitions from config |
+| `plugin_static` | Static plugin grants from config |
+| `plugin_dynamic` | Dynamic plugin grants from the admin API |
+| `admin_policy_static` | Static admin policy definitions |
+| `admin_dynamic` | Dynamic admin grants from the admin API |
+| `external_identity` | External identity assumption mappings |
+| `managed_subject` | Service accounts and managed subjects |
+
+Every managed resource type follows the same pattern: a resource instance
+has relations, and relations have subject types. Actions are computed from
+relations. This is the core Zanzibar model.
 
 ## First-party authorization providers
 
@@ -172,5 +373,7 @@ For the full server and provider config structure, read
 reference, continue to [Config File](/reference/config-file). If you want to
 see how these semantics apply to concrete surfaces, read
 [Plugin](/providers/plugins), [Workflow](/providers/workflow), and
-[UI](/providers/ui). For provider implementation details, see
+[UI](/providers/ui). For the relationship between authorization and
+credentials, read [External Credentials](/providers/external-credentials).
+For provider implementation details, see
 [Custom Authorization Providers](/custom-providers/authorization).

--- a/docs/content/providers/external-credentials.mdx
+++ b/docs/content/providers/external-credentials.mdx
@@ -1,0 +1,171 @@
+# External Credentials
+
+The external credentials provider stores subject-scoped third-party credentials.
+When a user completes an OAuth flow or an administrator provisions an API key
+for a service account, the external credentials provider persists the token or
+key so that future plugin invocations can use it on behalf of that subject.
+
+External credentials are separate from the Gestalt session system. A session
+cookie or API token proves who the caller is to Gestalt. An external credential
+is the token or key Gestalt uses to prove itself to an upstream API on behalf
+of that caller.
+
+## Core concepts
+
+### Subject scoping
+
+Every external credential is scoped to exactly one canonical subject. The
+subject is usually a user like `user:alice` or a managed subject like
+`service_account:deploy-bot`. When a plugin operation runs, the broker resolves
+the effective credential subject from the current principal, then asks the
+external credentials provider for a credential matching that subject, the target
+integration, and the selected connection.
+
+### Integration and connection
+
+A credential is stored for a specific integration and connection:
+
+- **Integration** is the provider name, such as `github` or `slack`
+- **Connection** is the named connection within that provider, such as `default`
+or `enterprise`
+- **Instance** is an optional sub-identifier for multi-tenant integrations
+
+This three-part key lets the same subject have different credentials for the
+same integration depending on which connection or instance is selected.
+
+### Token lifecycle
+
+Credentials can be:
+
+- **Access tokens** used directly in API requests
+- **Refresh tokens** used to obtain new access tokens when they expire
+- **API keys** that do not expire and are used as-is
+
+When an access token has a refresh token and an expiry timestamp, Gestalt
+automatically refreshes it if the token expires within 5 minutes. Refresh
+failures are tracked with a count so that repeatedly failing tokens can be
+identified and repaired.
+
+## How external credentials work
+
+The external credentials provider sits between the broker and the upstream
+integration. The broker resolves the caller's principal, determines the
+credential subject, asks the provider for a matching credential, and then
+uses that credential to invoke the provider operation.
+
+This flow is the same for all transport types: REST, GraphQL, and MCP.
+
+### Credential resolution order
+
+When the broker resolves a token for an operation, it consults the external
+credentials provider in this order:
+
+1. If the connection mode is `platform`, look for a platform-scoped credential
+2. If the connection mode is `user`, look for a user-scoped credential for the
+credential subject
+3. If no external credential exists, fall back to the connection's configured
+credential (such as an API key stored in the provider config)
+
+Platform-scoped credentials are useful for integrations that should act as the
+deployment, not as a user. User-scoped credentials are useful for integrations
+that act on behalf of the calling user.
+
+### Dynamic credential subjects
+
+Some workflows and plugin invocations create a principal with a
+`credentialSubjectID` that differs from the principal's own `subjectID`. This
+is common when a user-owned workflow delegates to a service account, or when
+a plugin invocation token carries a different credential subject for nested calls.
+
+The broker always uses `EffectiveCredentialSubjectID` to look up credentials.
+This resolves `credentialSubjectID` first, then `subjectID`, then the user ID.
+
+## Provider interface
+
+External credential providers implement this interface:
+
+| Method | Purpose |
+| --- | --- |
+| `PutCredential` | Store a new or updated credential |
+| `RestoreCredential` | Restore a credential from a backup or import |
+| `GetCredential` | Retrieve a credential by subject, integration, connection, and instance |
+| `ListCredentials` | List all credentials for a subject |
+| `ListCredentialsForProvider` | List credentials for a subject and integration |
+| `ListCredentialsForConnection` | List credentials for a subject, integration, and connection |
+| `DeleteCredential` | Remove a credential by its internal ID |
+
+`PutCredential` and `RestoreCredential` are similar, but `RestoreCredential`
+is intended for idempotent re-imports where the caller wants to overwrite an
+existing credential only if it matches the expected state.
+
+## First-party external credentials providers
+
+First-party external credentials providers live under
+[`valon-technologies/gestalt-providers/external_credentials`](https://github.com/valon-technologies/gestalt-providers/tree/main/external_credentials).
+
+| Provider | Use case |
+| --- | --- |
+| [`github.com/valon-technologies/gestalt-providers/external_credentials/default`](https://github.com/valon-technologies/gestalt-providers/tree/main/external_credentials/default) | Stores credentials in the host IndexedDB provider |
+
+## Configuring `providers.external_credentials`
+
+```yaml
+server:
+  providers:
+    indexeddb: main
+    external_credentials: default
+
+providers:
+  indexeddb:
+    main:
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        dsn: ${DATABASE_URL}
+
+  external_credentials:
+    default:
+      source: https://artifacts.example.com/external_credentials/default/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        indexeddb: main
+```
+
+The first-party `external_credentials/default` provider stores credentials in
+the host IndexedDB provider alongside users, sessions, and other platform state.
+
+If you omit `providers.external_credentials`, Gestalt uses a default in-memory
+provider that does not persist credentials across restarts. This is fine for
+development but unsuitable for production.
+
+## Relationship to other providers
+
+| Provider | How it relates |
+| --- | --- |
+| `providers.authentication` | Creates sessions and identifies subjects |
+| `providers.authorization` | Decides whether a subject may access a resource |
+| `providers.external_credentials` | Stores the upstream tokens used to invoke resources |
+| `providers.indexeddb` | Often the storage backend for the other three |
+
+Authentication answers who the caller is. Authorization answers what the caller
+may do. External credentials answer which upstream token the caller uses to do it.
+These are three independent systems that compose at runtime.
+
+## Operational notes
+
+`server.providers.external_credentials` selects the host external credentials
+provider. If more than one entry exists under `providers.external_credentials`,
+set `server.providers.external_credentials` explicitly or mark one entry
+`default: true`.
+
+Credentials are encrypted at rest using the deployment's encryption key. The
+external credentials provider itself does not need to implement encryption; it
+receives already-encrypted tokens from the host in many cases. Check the
+provider's documentation to understand its encryption guarantees.
+
+## What to read next
+
+For the full server and provider config structure, read
+[Configuration](/configuration). For the exact `providers.external_credentials`
+reference, continue to [Config File](/reference/config-file). To understand how
+credentials are resolved at invocation time, read
+[Plugin](/providers/plugins) and [Security](/security). For provider
+implementation details, see [Custom Providers > Authentication](/custom-providers/authentication).

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -21,6 +21,7 @@ starts it with the permissions and request context it needs.
 | `authorization` | Dynamic subject authorization backends | `providers.authorization.<name>` |
 | `agent` | Global agent run backends that reason over messages and tools | `providers.agent.<name>` |
 | `cache` | Plugin-bound cache backends | `providers.cache.<name>` |
+| `external_credentials` | Subject-scoped third-party credential storage | `providers.external_credentials.<name>` |
 | `indexeddb` | Persistent state backends for users, sessions, tokens, and credentials | `providers.indexeddb.<name>` |
 | `runtime` | Hosted execution backends for executable plugins | `runtime.providers.<name>` |
 | `s3` | S3-compatible object stores mounted into plugins | `providers.s3.<name>` |
@@ -139,6 +140,7 @@ release workflow now lives under [Custom Providers](/custom-providers).
 
 - [Authentication](/providers/authentication): platform login providers
 - [Authorization](/providers/authorization): subject authorization providers
+- [External Credentials](/providers/external-credentials): subject-scoped credential storage
 - [Agent](/providers/agent): global agent-provider pool and selection model
 - [Cache](/providers/cache): plugin-bound cache backends
 - [IndexedDB](/providers/indexeddb): storage backends


### PR DESCRIPTION
- Rewrites authorization docs with Zanzibar-aligned concepts, nested plugin call details, invocation tokens, workflow auth, and provider architecture.
- Adds new External Credentials provider documentation.
- Alphabetizes providers/_meta.ts.