### PR TITLE
Allow no-tool agent turns without catalog grants

### DIFF
--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1847,6 +1847,8 @@ fn build_turn_create_body(args: &AgentTurnCreateArgs) -> Result<Value> {
             "toolRefs".to_string(),
             Value::Array(args.tools.iter().map(agent_tool_ref_value).collect()),
         );
+    } else if !body.contains_key("toolRefs") {
+        body.insert("toolRefs".to_string(), Value::Array(Vec::new()));
     }
 
     validate_turn_create_body(&body)?;

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -712,7 +712,8 @@ fn test_cli_runs_interactive_agent_session_with_display_events() {
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
     .match_body(Matcher::JsonString(
-        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display events"}]}"#.to_string(),
+        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display events"}],"toolRefs":[]}"#
+            .to_string(),
     ))
     .with_body(TURN_JSON)
     .create();
@@ -801,7 +802,7 @@ fn test_cli_runs_tty_agent_session_in_isolated_selectable_ui() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello tui"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello tui"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -910,7 +911,7 @@ fn test_cli_tty_resume_model_override_updates_visible_model_and_turn_payload() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"override model"}]}"#,
+            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"override model"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -983,7 +984,7 @@ fn test_cli_tty_renders_display_tool_activity_rows() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display tools"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display tools"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1116,7 +1117,7 @@ fn test_cli_tty_groups_tool_activity_rows() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"use tools"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"use tools"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1205,7 +1206,7 @@ fn test_cli_tty_reconciles_unmatched_tool_activity_rows() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"ambiguous tools"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"ambiguous tools"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1282,7 +1283,7 @@ fn test_cli_tty_help_and_prompt_history() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"remember this"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"remember this"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1318,7 +1319,7 @@ fn test_cli_tty_help_and_prompt_history() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"remember this"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"remember this"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1354,7 +1355,7 @@ fn test_cli_tty_help_and_prompt_history() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"draft text"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"draft text"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1512,7 +1513,7 @@ fn test_cli_tty_renders_markdown_like_assistant_content() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"render markdown"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"render markdown"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1595,7 +1596,7 @@ fn test_cli_tty_wraps_wide_transcript_text_by_display_width() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"wide text"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"wide text"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1663,7 +1664,7 @@ fn test_cli_tty_queues_prompt_while_turn_is_running() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"slow turn"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"slow turn"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1700,7 +1701,7 @@ fn test_cli_tty_queues_prompt_while_turn_is_running() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"pending turn"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"pending turn"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1803,7 +1804,7 @@ fn test_cli_tty_turn_boundary_stops_stale_streaming_transcript_item() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"first turn"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"first turn"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1838,7 +1839,7 @@ fn test_cli_tty_turn_boundary_stops_stale_streaming_transcript_item() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"second turn"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"second turn"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1910,7 +1911,7 @@ fn test_cli_tty_secret_interaction_masks_and_requires_input() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"needs secret"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"needs secret"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2056,7 +2057,7 @@ fn test_cli_resumes_latest_active_agent_session() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-new/turns",
-            r#"{"messages":[{"role":"user","text":"continue plan"}]}"#,
+            r#"{"messages":[{"role":"user","text":"continue plan"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2234,7 +2235,7 @@ fn test_cli_agent_model_slash_sets_future_turn_model() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"hello"}]}"#,
+            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"hello"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2304,7 +2305,7 @@ fn test_cli_resumes_existing_agent_session_and_resolves_input_interaction() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-2/turns",
-            r#"{"messages":[{"role":"user","text":"need incident context"}]}"#,
+            r#"{"messages":[{"role":"user","text":"need incident context"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2437,7 +2438,7 @@ fn test_cli_resolves_agent_interaction_in_interactive_mode() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"approve deployment"}]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"approve deployment"}],"toolRefs":[]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -568,10 +568,6 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 		return nil, err
 	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ownedSession.providerName))
-	toolSource, err := validateProviderTurnToolSource(req.ToolSource)
-	if err != nil {
-		return nil, err
-	}
 	toolRefs, err := normalizeToolRefs(req.ToolRefs)
 	if err != nil {
 		return nil, err
@@ -580,23 +576,35 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	if err != nil {
 		return nil, err
 	}
-	if err := validateMCPCatalogToolRefs(toolRefs); err != nil {
+	toolSource, err := validateProviderTurnToolSource(req.ToolSource)
+	if err != nil {
 		return nil, err
 	}
-	if err := m.authorizeToolRefs(ctx, p, toolRefs); err != nil {
-		return nil, err
+	if toolSource == coreagent.ToolSourceModeUnspecified && len(toolRefs) > 0 {
+		toolSource = coreagent.ToolSourceModeMCPCatalog
 	}
 	var tools []coreagent.Tool
-	if supported, err := agentProviderSupportsToolSource(ctx, ownedSession.provider, toolSource); err != nil {
-		return nil, err
-	} else if !supported {
-		return nil, fmt.Errorf("agent provider %q does not support tool source %q", ownedSession.providerName, toolSource)
+	if toolSource == coreagent.ToolSourceModeMCPCatalog {
+		if err := validateMCPCatalogToolRefs(toolRefs); err != nil {
+			return nil, err
+		}
+		if err := m.authorizeToolRefs(ctx, p, toolRefs); err != nil {
+			return nil, err
+		}
+		if supported, err := agentProviderSupportsToolSource(ctx, ownedSession.provider, toolSource); err != nil {
+			return nil, err
+		} else if !supported {
+			return nil, fmt.Errorf("agent provider %q does not support tool source %q", ownedSession.providerName, toolSource)
+		}
 	}
 	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
 	turnID := newAgentTurnID(ownedSession.session.ID, idempotencyKey)
-	toolGrant, err := m.mintToolGrant(ctx, p, ownedSession.providerName, ownedSession.session.ID, turnID, req.CallerPluginName, toolRefs, tools, toolSource)
-	if err != nil {
-		return nil, err
+	var toolGrant string
+	if toolSource == coreagent.ToolSourceModeMCPCatalog {
+		toolGrant, err = m.mintToolGrant(ctx, p, ownedSession.providerName, ownedSession.session.ID, turnID, req.CallerPluginName, toolRefs, tools, toolSource)
+		if err != nil {
+			return nil, err
+		}
 	}
 	turn, err = ownedSession.provider.CreateTurn(ctx, coreagent.CreateTurnRequest{
 		TurnID:          turnID,
@@ -2237,7 +2245,7 @@ func validateProviderTurnToolSource(source coreagent.ToolSourceMode) (coreagent.
 	source = coreagent.ToolSourceMode(strings.TrimSpace(string(source)))
 	switch source {
 	case coreagent.ToolSourceModeUnspecified, coreagent.ToolSourceModeMCPCatalog:
-		return coreagent.ToolSourceModeMCPCatalog, nil
+		return source, nil
 	default:
 		return "", fmt.Errorf("%w: unsupported agent tool source %q", invocation.ErrInvalidInvocation, source)
 	}

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -461,14 +461,12 @@ func TestManagerListTurnsRequiresBoundedHydrationForSummaryLists(t *testing.T) {
 	}
 }
 
-func TestManagerCreateTurnDefaultsToMCPCatalogForProviderTurns(t *testing.T) {
+func TestManagerCreateTurnLeavesToolSourceUnsetWhenNoToolsRequested(t *testing.T) {
 	t.Parallel()
 
 	alpha := newRouteCountingAgentProvider("alpha")
 	alpha.capabilities = &coreagent.ProviderCapabilities{
-		SupportedToolSources: []coreagent.ToolSourceMode{
-			coreagent.ToolSourceModeMCPCatalog,
-		},
+		BoundedListHydration: true,
 	}
 	manager := newTestManager(t, Config{
 		Agent: &routeCountingAgentControl{
@@ -499,11 +497,14 @@ func TestManagerCreateTurnDefaultsToMCPCatalogForProviderTurns(t *testing.T) {
 	if len(alpha.createTurnReqs) != 1 {
 		t.Fatalf("CreateTurn requests = %d, want 1", len(alpha.createTurnReqs))
 	}
-	if got := alpha.createTurnReqs[0].ToolSource; got != coreagent.ToolSourceModeMCPCatalog {
-		t.Fatalf("CreateTurn tool source = %q, want mcp_catalog", got)
+	if got := alpha.createTurnReqs[0].ToolSource; got != coreagent.ToolSourceModeUnspecified {
+		t.Fatalf("CreateTurn tool source = %q, want empty", got)
 	}
 	if got := alpha.createTurnReqs[0].Tools; len(got) != 0 {
 		t.Fatalf("CreateTurn tools = %#v, want no preloaded tools", got)
+	}
+	if got := alpha.createTurnReqs[0].ToolGrant; got != "" {
+		t.Fatalf("CreateTurn tool grant = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Have the CLI send an explicit empty toolRefs array when no --tool flags are supplied.
- Preserve unspecified tool source for no-tool turns in the agent manager.
- Only mint and forward tool grants for MCP catalog turns.

## Validation
- go test ./services/agents/agentmanager
- go test ./internal/server -run 'TestAgent'
- cargo test --manifest-path gestalt/Cargo.toml -p gestalt --test agents_cli
- Local smoke: patched gestalt CLI against patched gestaltd with Hermes provider returned `assistant> hermes smoke ok`.