### PR TITLE
Bump gestalt CLI to alpha.12

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.1-alpha.11"
+version = "0.0.1-alpha.12"
 edition = "2024"


### PR DESCRIPTION
## Summary
- bump the gestalt CLI crate version to 0.0.1-alpha.12 so the merged no-tool agent fix can be released under a new tag

## Tests
- `cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name=="gestalt") | .version'`\n- `cargo test --workspace`\n- `cargo fmt --all -- --check`