### PR TITLE
Raise agent tool list page size for catalog loading

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -2202,14 +2202,14 @@ func TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn(t *testing.T) {
 		ProviderName: "claude",
 		SessionID:    "session-1",
 		TurnID:       "turn-1",
-		PageSize:     100,
+		PageSize:     5,
 		ToolGrant:    manyDocsGrant,
 	})
 	if err != nil {
-		t.Fatalf("ListTools with oversized page size: %v", err)
+		t.Fatalf("ListTools with small page size: %v", err)
 	}
-	if len(pagedDocs.Tools) != 10 || pagedDocs.NextPageToken != "10" {
-		t.Fatalf("ListTools oversized page = %d tools, next %q; want 10 tools and token 10", len(pagedDocs.Tools), pagedDocs.NextPageToken)
+	if len(pagedDocs.Tools) != 5 || pagedDocs.NextPageToken != "5" {
+		t.Fatalf("ListTools small page = %d tools, next %q; want 5 tools and token 5", len(pagedDocs.Tools), pagedDocs.NextPageToken)
 	}
 	for _, listed := range pagedDocs.Tools {
 		if listed.OutputSchemaJSON != "" {
@@ -2220,15 +2220,15 @@ func TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn(t *testing.T) {
 		ProviderName: "claude",
 		SessionID:    "session-1",
 		TurnID:       "turn-1",
-		PageSize:     100,
+		PageSize:     10000,
 		PageToken:    pagedDocs.NextPageToken,
 		ToolGrant:    manyDocsGrant,
 	})
 	if err != nil {
-		t.Fatalf("ListTools final oversized page: %v", err)
+		t.Fatalf("ListTools final large page: %v", err)
 	}
-	if len(finalDocs.Tools) != 2 || finalDocs.NextPageToken != "" {
-		t.Fatalf("ListTools final oversized page = %d tools, next %q; want 2 tools and no token", len(finalDocs.Tools), finalDocs.NextPageToken)
+	if len(finalDocs.Tools) != 7 || finalDocs.NextPageToken != "" {
+		t.Fatalf("ListTools final large page = %d tools, next %q; want 7 tools and no token", len(finalDocs.Tools), finalDocs.NextPageToken)
 	}
 	for _, listed := range finalDocs.Tools {
 		if listed.OutputSchemaJSON != "" {

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -45,8 +45,8 @@ var (
 
 const (
 	agentToolSearchAllPlugin     = "*"
-	agentToolListDefaultPageSize = 10
-	agentToolListMaxPageSize     = 10
+	agentToolListDefaultPageSize = 100
+	agentToolListMaxPageSize     = 1000
 	agentToolSchemaMaxBytes      = 128 * 1024
 	maxAgentRouteCacheEntries    = 20_000
 	AgentListSummaryDefaultLimit = 100

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -3,6 +3,7 @@ package agentmanager
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -731,6 +732,68 @@ func TestResolveToolsExpandsPluginOnlyRefs(t *testing.T) {
 	}
 	if tools[0].Target.Operation != "search" || tools[1].Target.Operation != "summarize" {
 		t.Fatalf("ResolveTools operations = %q, %q; want search, summarize", tools[0].Target.Operation, tools[1].Target.Operation)
+	}
+}
+
+func TestListToolsClampsOversizedPageSize(t *testing.T) {
+	t.Parallel()
+
+	const toolCount = agentToolListMaxPageSize + 7
+	docsOps := make([]catalog.CatalogOperation, toolCount)
+	for i := range docsOps {
+		docsOps[i] = catalog.CatalogOperation{
+			ID:       fmt.Sprintf("fetch_%04d", i+1),
+			Title:    "Fetch",
+			ReadOnly: true,
+		}
+	}
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:          "docs",
+			ConnMode:   core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: docsOps},
+		},
+	}
+	manager := newTestManager(t, Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	firstPage, err := manager.ListTools(context.Background(), p, coreagent.ListToolsRequest{
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+		ToolRefs:   []coreagent.ToolRef{{Plugin: "docs"}},
+		PageSize:   5,
+	})
+	if err != nil {
+		t.Fatalf("ListTools first page: %v", err)
+	}
+	if len(firstPage.Tools) != 5 || firstPage.NextPageToken != "5" {
+		t.Fatalf("ListTools first page = %d tools, next %q; want 5 tools and token 5", len(firstPage.Tools), firstPage.NextPageToken)
+	}
+
+	clampedPage, err := manager.ListTools(context.Background(), p, coreagent.ListToolsRequest{
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+		ToolRefs:   []coreagent.ToolRef{{Plugin: "docs"}},
+		PageSize:   10000,
+		PageToken:  firstPage.NextPageToken,
+	})
+	if err != nil {
+		t.Fatalf("ListTools clamped page: %v", err)
+	}
+	wantNextPageToken := fmt.Sprintf("%d", 5+agentToolListMaxPageSize)
+	if len(clampedPage.Tools) != agentToolListMaxPageSize || clampedPage.NextPageToken != wantNextPageToken {
+		t.Fatalf("ListTools clamped page = %d tools, next %q; want %d tools and token %s", len(clampedPage.Tools), clampedPage.NextPageToken, agentToolListMaxPageSize, wantNextPageToken)
+	}
+
+	lastPage, err := manager.ListTools(context.Background(), p, coreagent.ListToolsRequest{
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+		ToolRefs:   []coreagent.ToolRef{{Plugin: "docs"}},
+		PageSize:   10000,
+		PageToken:  clampedPage.NextPageToken,
+	})
+	if err != nil {
+		t.Fatalf("ListTools last page: %v", err)
+	}
+	if len(lastPage.Tools) != 2 || lastPage.NextPageToken != "" {
+		t.Fatalf("ListTools last page = %d tools, next %q; want 2 tools and no token", len(lastPage.Tools), lastPage.NextPageToken)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Raise the agent MCP catalog list default page size from 10 to 100.
- Raise the max page size from 10 to 1000 so agent providers can hydrate broad tool catalogs for native tool search without hundreds of host calls.
- Add focused manager pagination coverage for oversized page-size clamping while keeping bootstrap runtime catalog pagination coverage lightweight.

## Test plan
- [x] `go test ./services/agents/agentmanager ./internal/bootstrap`