### PR TITLE
Raise provider RPC timeout

### DIFF
--- a/gestaltd/services/runtimehost/runtime_client.go
+++ b/gestaltd/services/runtimehost/runtime_client.go
@@ -14,7 +14,11 @@ import (
 
 const (
 	// ProviderRPCTimeout is the default deadline for individual provider RPCs.
-	ProviderRPCTimeout   = 10 * time.Second
+	//
+	// Hosted agent providers can do real setup work during session creation
+	// after the runtime itself is ready. Keep this below the API route timeout,
+	// but above short health-check style deadlines.
+	ProviderRPCTimeout   = 30 * time.Second
 	providerStartTimeout = 2 * time.Minute
 )
 


### PR DESCRIPTION
## Summary
- raise the default provider RPC deadline from 10s to 30s so hosted agent session creation can finish when a provider does setup work after runtime readiness
- keep the deadline below the 60s API route timeout

## Tests
- `go test ./services/runtimehost ./services/agents ./internal/bootstrap ./internal/server`