### PR TITLE
Default agent turns to MCP catalog tools

### DIFF
--- a/gestaltd/core/agent/agent.go
+++ b/gestaltd/core/agent/agent.go
@@ -456,6 +456,7 @@ type ManagerCreateTurnRequest struct {
 	SessionID        string
 	Messages         []Message
 	ToolRefs         []ToolRef
+	ToolRefsSet      bool
 	ToolSource       ToolSourceMode
 	ResponseSchema   map[string]any
 	Metadata         map[string]any

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2636,6 +2636,7 @@ func TestBootstrapAgentManagerCreateTurnPersistsMetadataForToolCallbacks(t *test
 		IdempotencyKey: "global-search-idempotency-key",
 		Model:          "gpt-test",
 		Messages:       []coreagent.Message{{Role: "user", Text: "sync it without explicit tools"}},
+		ToolRefsSet:    true,
 	})
 	if err != nil {
 		t.Fatalf("AgentManager.CreateTurn(global search): %v", err)

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -392,6 +392,7 @@ func (s *Server) createAgentTurn(w http.ResponseWriter, r *http.Request) {
 		SessionID:       strings.TrimSpace(sessionID),
 		Messages:        agentMessagesFromRequest(req.Messages),
 		ToolRefs:        agentToolRefsForCreateTurn(req),
+		ToolRefsSet:     req.toolRefsSet,
 		ToolSource:      toolSource,
 		ResponseSchema:  maps.Clone(req.ResponseSchema),
 		Metadata:        maps.Clone(req.Metadata),

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -583,6 +583,10 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	if toolSource == coreagent.ToolSourceModeUnspecified && len(toolRefs) > 0 {
 		toolSource = coreagent.ToolSourceModeMCPCatalog
 	}
+	if toolSource == coreagent.ToolSourceModeUnspecified && len(toolRefs) == 0 && !req.ToolRefsSet && defaultAgentTurnToolSource(ctx, ownedSession.provider) == coreagent.ToolSourceModeMCPCatalog {
+		toolSource = coreagent.ToolSourceModeMCPCatalog
+		toolRefs = []coreagent.ToolRef{{Plugin: agentToolSearchAllPlugin}}
+	}
 	var tools []coreagent.Tool
 	if toolSource == coreagent.ToolSourceModeMCPCatalog {
 		if err := validateMCPCatalogToolRefs(toolRefs); err != nil {
@@ -2249,6 +2253,20 @@ func validateProviderTurnToolSource(source coreagent.ToolSourceMode) (coreagent.
 	default:
 		return "", fmt.Errorf("%w: unsupported agent tool source %q", invocation.ErrInvalidInvocation, source)
 	}
+}
+
+func defaultAgentTurnToolSource(ctx context.Context, provider coreagent.Provider) coreagent.ToolSourceMode {
+	if provider == nil {
+		return coreagent.ToolSourceModeUnspecified
+	}
+	caps, err := provider.GetCapabilities(ctx, coreagent.GetCapabilitiesRequest{})
+	if err != nil {
+		return coreagent.ToolSourceModeUnspecified
+	}
+	if agentProviderCapabilitiesSupportToolSource(caps, coreagent.ToolSourceModeMCPCatalog) {
+		return coreagent.ToolSourceModeMCPCatalog
+	}
+	return coreagent.ToolSourceModeUnspecified
 }
 
 func agentRunPermissions(ctx context.Context, p *principal.Principal, callerPluginName string, refs []coreagent.ToolRef) []core.AccessPermission {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -509,6 +509,152 @@ func TestManagerCreateTurnLeavesToolSourceUnsetWhenNoToolsRequested(t *testing.T
 	}
 }
 
+func TestManagerCreateTurnDefaultsToCatalogToolsForCatalogOnlyProvider(t *testing.T) {
+	t.Parallel()
+
+	alpha := newRouteCountingAgentProvider("alpha")
+	grants := newAgentManagerTestToolGrants(t)
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		ToolGrants: grants,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if len(alpha.createTurnReqs) != 1 {
+		t.Fatalf("CreateTurn requests = %d, want 1", len(alpha.createTurnReqs))
+	}
+	req := alpha.createTurnReqs[0]
+	if req.ToolSource != coreagent.ToolSourceModeMCPCatalog {
+		t.Fatalf("CreateTurn tool source = %q, want mcp_catalog", req.ToolSource)
+	}
+	if got := req.ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
+		t.Fatalf("CreateTurn tool refs = %#v, want global broad catalog ref", got)
+	}
+	if strings.TrimSpace(req.ToolGrant) == "" {
+		t.Fatal("CreateTurn tool grant is empty")
+	}
+	grant, err := grants.Resolve(req.ToolGrant)
+	if err != nil {
+		t.Fatalf("Resolve tool grant: %v", err)
+	}
+	if grant.ToolSource != coreagent.ToolSourceModeMCPCatalog {
+		t.Fatalf("grant tool source = %q, want mcp_catalog", grant.ToolSource)
+	}
+	if got := grant.ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
+		t.Fatalf("grant tool refs = %#v, want global broad catalog ref", got)
+	}
+}
+
+func TestManagerCreateTurnHonorsExplicitCatalogSourceWithNoToolRefs(t *testing.T) {
+	t.Parallel()
+
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID:  session.ID,
+		Model:      "test-model",
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if len(alpha.createTurnReqs) != 1 {
+		t.Fatalf("CreateTurn requests = %d, want 1", len(alpha.createTurnReqs))
+	}
+	req := alpha.createTurnReqs[0]
+	if req.ToolSource != coreagent.ToolSourceModeMCPCatalog {
+		t.Fatalf("CreateTurn tool source = %q, want mcp_catalog", req.ToolSource)
+	}
+	if got := req.ToolRefs; len(got) != 0 {
+		t.Fatalf("CreateTurn tool refs = %#v, want none for explicit empty catalog source", got)
+	}
+	if strings.TrimSpace(req.ToolGrant) == "" {
+		t.Fatal("CreateTurn tool grant is empty")
+	}
+}
+
+func TestManagerCreateTurnHonorsExplicitEmptyToolRefsWithoutToolSource(t *testing.T) {
+	t.Parallel()
+
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID:   session.ID,
+		Model:       "test-model",
+		ToolRefsSet: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if len(alpha.createTurnReqs) != 1 {
+		t.Fatalf("CreateTurn requests = %d, want 1", len(alpha.createTurnReqs))
+	}
+	req := alpha.createTurnReqs[0]
+	if req.ToolSource != coreagent.ToolSourceModeUnspecified {
+		t.Fatalf("CreateTurn tool source = %q, want empty", req.ToolSource)
+	}
+	if got := req.ToolRefs; len(got) != 0 {
+		t.Fatalf("CreateTurn tool refs = %#v, want none for explicit empty tool refs", got)
+	}
+	if req.ToolGrant != "" {
+		t.Fatalf("CreateTurn tool grant = %q, want empty", req.ToolGrant)
+	}
+}
+
 func TestManagerCancelTurnRevokesToolGrantWithoutBootstrapWrapper(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Default omitted agent turn tool refs to the global MCP catalog for providers that advertise `mcp_catalog` support.
- Preserve explicit empty `toolRefs` from HTTP callers so callers can still request no tools.
- Cover manager defaults, explicit empty refs, and existing HTTP/bootstrap behavior.

## Test plan
- [x] `go test ./services/agents/agentmanager ./internal/server ./internal/bootstrap`