### PR TITLE
Make Python provider SDK resolution explicit

### DIFF
--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -614,6 +614,10 @@ func TestRun_ProviderReleaseBuildsPythonSourcePluginForCurrentPlatform(t *testin
 
 	t.Setenv("GESTALT_TEST_PYINSTALLER_BINARY", pluginBin)
 	t.Setenv("PATH", pathWithoutGo(t))
+	ambientPythonPath := filepath.Join(t.TempDir(), "ambient-sdk")
+	t.Setenv("PYTHONPATH", ambientPythonPath)
+	t.Setenv("GESTALT_TEST_EXPECT_EMPTY_PYTHONPATH", "1")
+	t.Setenv("GESTALT_TEST_FORBID_PYTHONPATH_ENTRY", ambientPythonPath)
 
 	pluginDir := newPythonSourceReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
@@ -671,6 +675,35 @@ func TestRun_ProviderReleaseBuildsPythonSourcePluginForCurrentPlatform(t *testin
 	}
 	if !strings.Contains(result.Body, "Hi, Ada!") {
 		t.Fatalf("body = %q, want greeting", result.Body)
+	}
+}
+
+func TestRun_ProviderReleaseUsesExplicitPythonSDKDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Python build fixture is POSIX-only")
+	}
+
+	t.Setenv("GESTALT_TEST_PYINSTALLER_BINARY", pluginBin)
+	t.Setenv("PATH", pathWithoutGo(t))
+	sdkDir := writeFakePythonSDKDir(t, t.TempDir())
+	ambientPythonPath := filepath.Join(t.TempDir(), "ambient-pythonpath")
+	t.Setenv("GESTALT_PYTHON_SDK_DIR", sdkDir)
+	t.Setenv("PYTHONPATH", ambientPythonPath)
+	t.Setenv("GESTALT_TEST_EXPECT_PYTHONPATH_PREFIX", sdkDir)
+	t.Setenv("GESTALT_TEST_EXPECT_PYTHONPATH_ENTRY", ambientPythonPath)
+
+	pluginDir := newPythonSourceReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.12-test-sdk-dir"
+
+	runProviderReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := expectedPythonArchiveName(testVersion, runtime.GOOS, runtime.GOARCH)
+	if _, err := os.Stat(filepath.Join(outputDir, archiveName)); err != nil {
+		t.Fatalf("expected archive %s: %v", archiveName, err)
 	}
 }
 
@@ -2646,6 +2679,18 @@ def dynamic_catalog(request: gestalt.Request) -> gestalt.Catalog:
 	return pluginDir
 }
 
+func writeFakePythonSDKDir(t *testing.T, dir string) string {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Join(dir, "gestalt"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(fake Python SDK): %v", err)
+	}
+	writeTestFile(t, dir, "pyproject.toml", []byte(`[project]
+name = "gestalt-sdk"
+`), 0o644)
+	return dir
+}
+
 func newManifestBackedPythonSourceReleaseFixture(t *testing.T, dir string) string {
 	t.Helper()
 
@@ -2866,6 +2911,37 @@ func writeFakePythonReleaseInterpreterForKind(
 
 	script := `#!/bin/sh
 set -eu
+
+if [ "${GESTALT_TEST_EXPECT_EMPTY_PYTHONPATH:-}" = "1" ] && [ -n "${PYTHONPATH:-}" ]; then
+  echo "unexpected PYTHONPATH: ${PYTHONPATH}" >&2
+  exit 1
+fi
+if [ -n "${GESTALT_TEST_EXPECT_PYTHONPATH_PREFIX:-}" ]; then
+  case "${PYTHONPATH:-}" in
+    "${GESTALT_TEST_EXPECT_PYTHONPATH_PREFIX}"|"${GESTALT_TEST_EXPECT_PYTHONPATH_PREFIX}":*) ;;
+    *)
+      echo "PYTHONPATH ${PYTHONPATH:-} does not start with ${GESTALT_TEST_EXPECT_PYTHONPATH_PREFIX}" >&2
+      exit 1
+      ;;
+  esac
+fi
+if [ -n "${GESTALT_TEST_EXPECT_PYTHONPATH_ENTRY:-}" ]; then
+  case ":${PYTHONPATH:-}:" in
+    *:"${GESTALT_TEST_EXPECT_PYTHONPATH_ENTRY}":*) ;;
+    *)
+      echo "expected PYTHONPATH entry missing: ${GESTALT_TEST_EXPECT_PYTHONPATH_ENTRY}" >&2
+      exit 1
+      ;;
+  esac
+fi
+if [ -n "${GESTALT_TEST_FORBID_PYTHONPATH_ENTRY:-}" ]; then
+  case ":${PYTHONPATH:-}:" in
+    *:"${GESTALT_TEST_FORBID_PYTHONPATH_ENTRY}":*)
+      echo "forbidden PYTHONPATH entry present: ${GESTALT_TEST_FORBID_PYTHONPATH_ENTRY}" >&2
+      exit 1
+      ;;
+  esac
+fi
 
 if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._build" ]; then
   if [ -z "${GESTALT_TEST_PYINSTALLER_BINARY:-}" ]; then

--- a/gestaltd/services/plugins/providerpkg/go_provider.go
+++ b/gestaltd/services/plugins/providerpkg/go_provider.go
@@ -123,7 +123,7 @@ func SourceComponentExecutionEnv(root, kind, goos, goarch string) (map[string]st
 	if sourceKind != sourceProviderKindPython {
 		return nil, nil
 	}
-	return pythonBackendEnvMap(), nil
+	return pythonBackendEnvMap()
 }
 
 func ValidateSourceComponentRelease(root, kind, goos, goarch string) error {

--- a/gestaltd/services/plugins/providerpkg/python_provider.go
+++ b/gestaltd/services/plugins/providerpkg/python_provider.go
@@ -21,6 +21,7 @@ const (
 	pythonRuntimeModule = "gestalt._runtime"
 	pythonBuildModule   = "gestalt._build"
 	pythonEnvVarPrefix  = "GESTALT_PYTHON_"
+	pythonSDKDirEnvVar  = "GESTALT_PYTHON_SDK_DIR"
 )
 
 var ErrNoPythonProviderPackage = errors.New("no Python provider package found")
@@ -112,7 +113,11 @@ func BuildPythonComponentBinary(sourceDir, binaryPath, pluginName, target, runti
 
 	cmd := exec.Command(interpreter, "-m", pythonBuildModule, sourceDir, target, binaryPath, pluginName, runtimeKind, goos, goarch)
 	cmd.Dir = sourceDir
-	cmd.Env = append(os.Environ(), pythonBackendEnv()...)
+	env, err := pythonBackendEnv(os.Environ())
+	if err != nil {
+		return "", fmt.Errorf("prepare Python release build environment: %w", err)
+	}
+	cmd.Env = env
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -143,39 +148,73 @@ func DetectPythonInterpreter(root, goos, goarch string) (string, error) {
 	return "", fmt.Errorf("detect Python interpreter: %w (set %s or provide a target-specific virtualenv)", exec.ErrNotFound, envVar)
 }
 
-func pythonBackendImportPaths() []string {
-	if sdkPath := localPythonSDKPath(); sdkPath != "" {
-		return []string{sdkPath}
+func pythonBackendEnv(base []string) ([]string, error) {
+	env, err := pythonBackendEnvMap()
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	out := make([]string, 0, len(base)+len(env))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && key == "PYTHONPATH" {
+			continue
+		}
+		out = append(out, entry)
+	}
+	for key, value := range env {
+		out = append(out, key+"="+value)
+	}
+	return out, nil
 }
 
-func pythonBackendEnv() []string {
-	env := pythonBackendEnvMap()
-	if len(env) == 0 {
-		return nil
+func pythonBackendEnvMap() (map[string]string, error) {
+	value, err := pythonBackendPythonPath()
+	if err != nil {
+		return nil, err
 	}
-	return []string{"PYTHONPATH=" + env["PYTHONPATH"]}
+	return map[string]string{"PYTHONPATH": value}, nil
 }
 
-func pythonBackendEnvMap() map[string]string {
-	paths := pythonBackendImportPaths()
-	if len(paths) == 0 {
-		return nil
+func pythonBackendPythonPath() (string, error) {
+	sdkPath, err := explicitPythonSDKPath()
+	if err != nil {
+		return "", err
 	}
-	value := strings.Join(paths, string(os.PathListSeparator))
+	if sdkPath == "" {
+		return "", nil
+	}
+	value := sdkPath
 	if existing := os.Getenv("PYTHONPATH"); existing != "" {
 		value += string(os.PathListSeparator) + existing
 	}
-	return map[string]string{"PYTHONPATH": value}
+	return value, nil
 }
 
-func localPythonSDKPath() string {
-	path := localRepositorySubdir("sdk", "python")
-	if path == "" {
-		return ""
+func explicitPythonSDKPath() (string, error) {
+	raw := strings.TrimSpace(os.Getenv(pythonSDKDirEnvVar))
+	if raw == "" {
+		return "", nil
 	}
-	return path
+	path, err := filepath.Abs(raw)
+	if err != nil {
+		return "", fmt.Errorf("%s %q: resolve absolute path: %w", pythonSDKDirEnvVar, raw, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("%s %q: %w", pythonSDKDirEnvVar, path, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s %q is not a directory", pythonSDKDirEnvVar, path)
+	}
+	if _, err := os.Stat(filepath.Join(path, pythonProjectFile)); err != nil {
+		return "", fmt.Errorf("%s %q: missing %s: %w", pythonSDKDirEnvVar, path, pythonProjectFile, err)
+	}
+	if info, err := os.Stat(filepath.Join(path, "gestalt")); err != nil {
+		return "", fmt.Errorf("%s %q: missing gestalt package: %w", pythonSDKDirEnvVar, path, err)
+	} else if !info.IsDir() {
+		return "", fmt.Errorf("%s %q: gestalt package is not a directory", pythonSDKDirEnvVar, path)
+	}
+	return path, nil
 }
 
 func pythonInterpreterCandidates(root, goos, goarch string) []string {

--- a/gestaltd/services/plugins/providerpkg/python_provider_test.go
+++ b/gestaltd/services/plugins/providerpkg/python_provider_test.go
@@ -189,30 +189,86 @@ func TestPythonRuntimeKind_Cache(t *testing.T) {
 	}
 }
 
-func TestSourceProviderExecutionEnv_PythonUsesLocalSDK(t *testing.T) {
-	t.Parallel()
-
+func TestSourceProviderExecutionEnv_PythonClearsPythonPathByDefault(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
 provider = "provider"
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(pyproject.toml): %v", err)
 	}
+	t.Setenv(pythonSDKDirEnvVar, "")
+	t.Setenv("PYTHONPATH", filepath.Join(t.TempDir(), "ambient-sdk"))
 
 	env, err := SourceProviderExecutionEnv(root, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		t.Fatalf("SourceProviderExecutionEnv: %v", err)
 	}
-	if len(env) == 0 {
-		t.Fatal("SourceProviderExecutionEnv returned no environment overrides")
+	if got, ok := env["PYTHONPATH"]; !ok {
+		t.Fatal("SourceProviderExecutionEnv did not clear PYTHONPATH")
+	} else if got != "" {
+		t.Fatalf("PYTHONPATH = %q, want empty", got)
 	}
-	want := localPythonSDKPath()
-	if want == "" {
-		t.Fatal("localPythonSDKPath returned empty path")
+}
+
+func TestSourceProviderExecutionEnv_PythonUsesExplicitSDKDir(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
+provider = "provider"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(pyproject.toml): %v", err)
 	}
-	if got := env["PYTHONPATH"]; !strings.Contains(got, want) {
-		t.Fatalf("PYTHONPATH = %q, want to contain %q", got, want)
+	sdkDir := writePythonSDKDir(t)
+	inheritedPath := filepath.Join(t.TempDir(), "ambient-pythonpath")
+	t.Setenv(pythonSDKDirEnvVar, sdkDir)
+	t.Setenv("PYTHONPATH", inheritedPath)
+
+	env, err := SourceProviderExecutionEnv(root, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("SourceProviderExecutionEnv: %v", err)
 	}
+	parts := filepath.SplitList(env["PYTHONPATH"])
+	if len(parts) != 2 {
+		t.Fatalf("PYTHONPATH = %q, want explicit SDK plus inherited path", env["PYTHONPATH"])
+	}
+	if parts[0] != sdkDir {
+		t.Fatalf("PYTHONPATH first entry = %q, want %q", parts[0], sdkDir)
+	}
+	if parts[1] != inheritedPath {
+		t.Fatalf("PYTHONPATH inherited entry = %q, want %q", parts[1], inheritedPath)
+	}
+}
+
+func TestSourceProviderExecutionEnv_PythonRejectsInvalidExplicitSDKDir(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
+provider = "provider"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(pyproject.toml): %v", err)
+	}
+	t.Setenv(pythonSDKDirEnvVar, filepath.Join(t.TempDir(), "missing-sdk"))
+
+	_, err := SourceProviderExecutionEnv(root, runtime.GOOS, runtime.GOARCH)
+	if err == nil {
+		t.Fatal("expected invalid explicit SDK dir error")
+	}
+	if !strings.Contains(err.Error(), pythonSDKDirEnvVar) {
+		t.Fatalf("error = %q, want %s", err, pythonSDKDirEnvVar)
+	}
+}
+
+func writePythonSDKDir(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte(`[project]
+name = "gestalt-sdk"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(pyproject.toml): %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "gestalt"), 0o755); err != nil {
+		t.Fatalf("Mkdir(gestalt): %v", err)
+	}
+	return dir
 }
 
 func pythonTestOtherPlatform() (string, string) {

--- a/gestaltd/services/plugins/providerpkg/source_provider.go
+++ b/gestaltd/services/plugins/providerpkg/source_provider.go
@@ -82,7 +82,7 @@ func SourceProviderExecutionEnv(root, goos, goarch string) (map[string]string, e
 	if kind != sourceProviderKindPython {
 		return nil, nil
 	}
-	return pythonBackendEnvMap(), nil
+	return pythonBackendEnvMap()
 }
 
 func ValidateSourceProviderRelease(root, goos, goarch string) error {


### PR DESCRIPTION
## Summary

Python provider release/build paths now use the SDK installed in the selected Python environment by default instead of silently prepending a sibling Gestalt checkout's `sdk/python` directory to `PYTHONPATH`.

This is the long-term fix for Python provider releases: provider `uv.lock` is the source of truth, and local SDK source is only used when explicitly requested.

## Interface Changes

- Changed interface: Python provider subprocess environment construction now clears ambient `PYTHONPATH` by default.
- New explicit opt-in: `GESTALT_PYTHON_SDK_DIR` points at a local Gestalt Python SDK source directory.

Example default release path:

```bash
cd plugins/vercel
uv sync --frozen --no-dev
GESTALT_PYTHON_DARWIN_ARM64="$PWD/.venv/bin/python" \
  gestaltd provider release --version 0.0.1-alpha.12 --platform darwin/arm64
```

Example local SDK override for SDK development:

```bash
GESTALT_PYTHON_SDK_DIR=/Users/hugh/src/gestalt/sdk/python \
  gestaltd provider release --version 0.0.1-dev --platform darwin/arm64
```

`GESTALT_PYTHON_SDK_DIR` is validated before launch: it must resolve to a directory containing `pyproject.toml` and a `gestalt/` package directory.

## Functional/Integration Tests

- Augmented existing provider release command tests to assert ambient `PYTHONPATH` does not leak into Python source release builds.
- Added a provider release command test covering explicit `GESTALT_PYTHON_SDK_DIR` ordering.
- Replaced the old providerpkg test that expected implicit local SDK discovery with the new environment contract.

Commands run:

```bash
go test ./services/plugins/providerpkg
go test ./internal/daemon -run 'TestRun_ProviderRelease(BuildsPythonSourcePluginForCurrentPlatform|UsesExplicitPythonSDKDir|WritesExecutableMetadataForManifestBackedPythonSourcePlugin|RejectsMissingCrossTargetInterpreterForPythonSourcePlugin|RejectsInvalidPythonProviderTarget)'
go test ./services/providerdrivers/componentprovider ./internal/bootstrap ./internal/daemon -run '^$'
```

## Follow-ups

After this merges to `main`, the provider repo should rerun Python provider releases using pure `uv` state, then toolshed `valon-tools/deploy` can move to the new provider versions and this Gestalt ref.
