### PR TITLE
Support manual token exchange auth

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -59,6 +59,14 @@ type OAuthHandler interface {
 	TokenURL() string
 }
 
+type ManualTokenExchanger interface {
+	ExchangeCredentials(ctx context.Context, credentialJSON string) (*core.TokenResponse, error)
+	ExchangeCredentialsWithURL(ctx context.Context, credentialJSON, tokenURL string) (*core.TokenResponse, error)
+	RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error)
+	RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	TokenURL() string
+}
+
 // upstreamHandlerAdapter wraps an oauth.UpstreamHandler to satisfy OAuthHandler.
 type upstreamHandlerAdapter struct {
 	*oauth.UpstreamHandler
@@ -100,8 +108,9 @@ func (a *upstreamHandlerAdapter) ExchangeCodeWithVerifier(ctx context.Context, c
 // ProviderBuildResult carries the constructed provider and an OAuth handler
 // for each named connection that uses oauth2 or mcp_oauth auth.
 type ProviderBuildResult struct {
-	Provider       core.Provider
-	ConnectionAuth map[string]OAuthHandler
+	Provider             core.Provider
+	ConnectionAuth       map[string]OAuthHandler
+	ManualConnectionAuth map[string]ManualTokenExchanger
 }
 
 type providerMetadata struct {
@@ -228,6 +237,7 @@ type Result struct {
 	ProvidersReady        <-chan struct{}
 	Authorizer            authorization.RuntimeAuthorizer
 	ConnectionAuth        func() map[string]map[string]OAuthHandler
+	ManualConnectionAuth  func() map[string]map[string]ManualTokenExchanger
 	Invoker               invocation.Invoker
 	PluginInvoker         invocation.Invoker
 	CapabilityLister      invocation.CapabilityLister
@@ -1011,7 +1021,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	prepared.Deps.PublicHostServices = publicHostServices
 	prepared.Deps.WorkflowRuntime.SetAgentManager(agentManager)
 
-	providers, providersReady, connAuthResolver, err := buildProviders(ctx, cfg, factories, prepared.Deps)
+	providers, providersReady, connAuthResolver, manualConnAuthResolver, err := buildProviders(ctx, cfg, factories, prepared.Deps)
 	if err != nil {
 		return nil, err
 	}
@@ -1062,6 +1072,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),
 		invocation.WithConnectionAuth(lazyRefreshers(providersReady, connAuthResolver)),
+		invocation.WithManualConnectionAuth(lazyManualRefreshers(providersReady, manualConnAuthResolver)),
 		invocation.WithConnectionRuntime(connRuntime.Resolve),
 		invocation.WithProviderOverrides(providerDevSessions),
 	)
@@ -1154,6 +1165,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		ProvidersReady:        providersReady,
 		Authorizer:            authz,
 		ConnectionAuth:        connAuthResolver,
+		ManualConnectionAuth:  manualConnAuthResolver,
 		Invoker:               sharedInvoker,
 		PluginInvoker:         pluginInvoker,
 		CapabilityLister:      sharedInvoker,

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -17,6 +17,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/egress"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
+	"github.com/valon-technologies/gestalt/server/services/plugins/oauth"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -486,4 +487,75 @@ func buildConnectionHandler(conn config.ConnectionDef, mcpURL string, pluginConf
 	default:
 		return nil, nil
 	}
+}
+
+func buildManualConnectionAuthMap(name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, authFallback *specAuthFallback) (map[string]ManualTokenExchanger, error) {
+	manifestPlugin := (*providermanifestv1.Spec)(nil)
+	if manifest != nil {
+		manifestPlugin = manifest.Spec
+	}
+	plan, err := config.BuildStaticConnectionPlan(entry, manifestPlugin)
+	if err != nil {
+		return nil, fmt.Errorf("resolve manual token connections for %q: %w", name, err)
+	}
+
+	specAuthForConnection := func(connectionName string) *declarative.Definition {
+		return authFallback.definitionFor(connectionName)
+	}
+
+	handlers := make(map[string]ManualTokenExchanger)
+	if handler, err := buildManualConnectionHandler(plan.PluginConnection(), specAuthForConnection(config.PluginConnectionName)); err != nil {
+		return nil, fmt.Errorf("build plugin manual token auth for %q: %w", name, err)
+	} else if handler != nil {
+		handlers[config.PluginConnectionName] = handler
+	}
+
+	for _, resolvedName := range plan.NamedConnectionNames() {
+		conn, _ := plan.NamedConnectionDef(resolvedName)
+		handler, err := buildManualConnectionHandler(conn, specAuthForConnection(resolvedName))
+		if err != nil {
+			return nil, fmt.Errorf("build named manual token auth for %q/%q: %w", name, resolvedName, err)
+		}
+		if handler != nil {
+			handlers[resolvedName] = handler
+		}
+	}
+
+	if len(handlers) == 0 {
+		return nil, nil
+	}
+	return handlers, nil
+}
+
+func buildManualConnectionHandler(conn config.ConnectionDef, specDef *declarative.Definition) (ManualTokenExchanger, error) {
+	auth := conn.Auth
+	if auth.Type == "" && specDef != nil && specDef.Auth.Type != "" {
+		auth = config.ConnectionAuthDef{
+			Type:            providermanifestv1.AuthType(specDef.Auth.Type),
+			TokenURL:        specDef.Auth.TokenURL,
+			TokenExchange:   specDef.Auth.TokenExchange,
+			TokenParams:     specDef.Auth.TokenParams,
+			AcceptHeader:    specDef.Auth.AcceptHeader,
+			AccessTokenPath: specDef.Auth.AccessTokenPath,
+			Credentials:     append([]config.CredentialFieldDef(nil), specDef.CredentialFields...),
+		}
+	}
+	if auth.Type != providermanifestv1.AuthTypeManual || strings.TrimSpace(auth.TokenURL) == "" {
+		return nil, nil
+	}
+	return buildManualTokenExchangerFromAuth(auth)
+}
+
+func buildManualTokenExchangerFromAuth(auth config.ConnectionAuthDef) (ManualTokenExchanger, error) {
+	tokenExchange, err := oauth.ParseTokenExchangeFormat(auth.TokenExchange)
+	if err != nil {
+		return nil, err
+	}
+	return oauth.NewCredentialExchanger(oauth.CredentialExchangeConfig{
+		TokenURL:        auth.TokenURL,
+		TokenParams:     auth.TokenParams,
+		TokenExchange:   tokenExchange,
+		AcceptHeader:    auth.AcceptHeader,
+		AccessTokenPath: auth.AccessTokenPath,
+	}), nil
 }

--- a/gestaltd/internal/bootstrap/connections_test.go
+++ b/gestaltd/internal/bootstrap/connections_test.go
@@ -89,6 +89,37 @@ func TestBuildConnectionRuntimePlatformManualDirectAuthMapping(t *testing.T) {
 	}
 }
 
+func TestBuildManualConnectionAuthMapIsSeparateFromOAuthHandlers(t *testing.T) {
+	t.Parallel()
+
+	entry := &config.ProviderEntry{
+		Auth: &config.ConnectionAuthDef{
+			Type:     providermanifestv1.AuthTypeManual,
+			TokenURL: "https://looker.example.com/api/4.0/login",
+			Credentials: []config.CredentialFieldDef{
+				{Name: "client_id"},
+				{Name: "client_secret"},
+			},
+		},
+	}
+
+	oauthHandlers, err := buildConnectionAuthMap("looker", entry, nil, nil, nil, Deps{})
+	if err != nil {
+		t.Fatalf("buildConnectionAuthMap: %v", err)
+	}
+	if len(oauthHandlers) != 0 {
+		t.Fatalf("OAuth handlers = %+v, want none", oauthHandlers)
+	}
+
+	manualHandlers, err := buildManualConnectionAuthMap("looker", entry, nil, nil)
+	if err != nil {
+		t.Fatalf("buildManualConnectionAuthMap: %v", err)
+	}
+	if manualHandlers[config.PluginConnectionName] == nil {
+		t.Fatalf("manual token exchanger for plugin connection not built: %+v", manualHandlers)
+	}
+}
+
 func TestBuildConnectionRuntimePlatformManualCredentialRefsRequireToken(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/declarative_connection.go
+++ b/gestaltd/internal/bootstrap/declarative_connection.go
@@ -28,6 +28,7 @@ func declarativeConnectionAuthDef(auth config.ConnectionAuthDef) declarative.Con
 		RedirectURL:         auth.RedirectURL,
 		ClientAuth:          auth.ClientAuth,
 		TokenExchange:       auth.TokenExchange,
+		TokenPrefix:         auth.TokenPrefix,
 		Scopes:              slices.Clone(auth.Scopes),
 		ScopeParam:          auth.ScopeParam,
 		ScopeSeparator:      auth.ScopeSeparator,

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -68,9 +68,9 @@ func buildRegistrationStore(deps Deps) mcpoauth.RegistrationStore {
 	return nil
 }
 
-func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.ProviderMap[core.Provider], <-chan struct{}, func() map[string]map[string]OAuthHandler, error) {
-	providers, ready, connAuthResolver, _, err := buildProvidersAsync(ctx, cfg, factories, deps, buildProvider)
-	return providers, ready, connAuthResolver, err
+func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.ProviderMap[core.Provider], <-chan struct{}, func() map[string]map[string]OAuthHandler, func() map[string]map[string]ManualTokenExchanger, error) {
+	providers, ready, connAuthResolver, manualConnAuthResolver, _, err := buildProvidersAsync(ctx, cfg, factories, deps, buildProvider)
+	return providers, ready, connAuthResolver, manualConnAuthResolver, err
 }
 
 func buildProvidersAsync(
@@ -79,20 +79,21 @@ func buildProvidersAsync(
 	factories *FactoryRegistry,
 	deps Deps,
 	builder func(context.Context, string, *config.ProviderEntry, Deps) (*ProviderBuildResult, error),
-) (*registry.ProviderMap[core.Provider], <-chan struct{}, func() map[string]map[string]OAuthHandler, func() []error, error) {
+) (*registry.ProviderMap[core.Provider], <-chan struct{}, func() map[string]map[string]OAuthHandler, func() map[string]map[string]ManualTokenExchanger, func() []error, error) {
 	reg := registry.New()
 	connAuth := make(map[string]map[string]OAuthHandler)
+	manualConnAuth := make(map[string]map[string]ManualTokenExchanger)
 	var buildErrs []error
 	var connMu sync.Mutex
 
 	for _, builtin := range factories.Builtins {
 		if err := validateProviderConnectionMode(builtin.Name(), builtin.ConnectionMode()); err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("bootstrap: builtin provider %q: %w", builtin.Name(), err)
+			return nil, nil, nil, nil, nil, fmt.Errorf("bootstrap: builtin provider %q: %w", builtin.Name(), err)
 		}
 		if err := reg.Providers.Register(builtin.Name(), builtin); errors.Is(err, core.ErrAlreadyRegistered) {
 			continue
 		} else if err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("bootstrap: registering builtin %q: %w", builtin.Name(), err)
+			return nil, nil, nil, nil, nil, fmt.Errorf("bootstrap: registering builtin %q: %w", builtin.Name(), err)
 		}
 		slog.Info("loaded builtin provider", "provider", builtin.Name(), "operations", catalogOperationCount(builtin.Catalog()))
 	}
@@ -100,7 +101,11 @@ func buildProvidersAsync(
 	ready := make(chan struct{})
 	if len(cfg.Plugins) == 0 {
 		close(ready)
-		return &reg.Providers, ready, func() map[string]map[string]OAuthHandler { return connAuth }, func() []error { return nil }, nil
+		return &reg.Providers, ready,
+			func() map[string]map[string]OAuthHandler { return connAuth },
+			func() map[string]map[string]ManualTokenExchanger { return manualConnAuth },
+			func() []error { return nil },
+			nil
 	}
 
 	var wg sync.WaitGroup
@@ -177,6 +182,11 @@ func buildProvidersAsync(
 				connAuth[name] = result.ConnectionAuth
 				connMu.Unlock()
 			}
+			if len(result.ManualConnectionAuth) > 0 {
+				connMu.Lock()
+				manualConnAuth[name] = result.ManualConnectionAuth
+				connMu.Unlock()
+			}
 			slog.Info("loaded provider", "provider", name, "operations", catalogOperationCount(result.Provider.Catalog()))
 		}(name, intgDef, proxy)
 	}
@@ -190,13 +200,17 @@ func buildProvidersAsync(
 		<-ready
 		return connAuth
 	}
+	manualResolver := func() map[string]map[string]ManualTokenExchanger {
+		<-ready
+		return manualConnAuth
+	}
 	errResolver := func() []error {
 		<-ready
 		errMu.Lock()
 		defer errMu.Unlock()
 		return append([]error(nil), buildErrs...)
 	}
-	return &reg.Providers, ready, resolver, errResolver, nil
+	return &reg.Providers, ready, resolver, manualResolver, errResolver, nil
 }
 
 func validateProviderConnectionMode(provider string, mode core.ConnectionMode) error {
@@ -527,6 +541,11 @@ func newProviderBuildResult(name string, entry *config.ProviderEntry, manifest *
 	result := &ProviderBuildResult{Provider: prov}
 	var err error
 	result.ConnectionAuth, err = buildConnectionAuthMap(name, entry, manifest, pluginConfig, authFallback, deps)
+	if err != nil {
+		closeIfPossible(prov)
+		return nil, err
+	}
+	result.ManualConnectionAuth, err = buildManualConnectionAuthMap(name, entry, manifest, authFallback)
 	if err != nil {
 		closeIfPossible(prov)
 		return nil, err
@@ -2831,14 +2850,9 @@ func buildOAuthHandlerFromAuth(auth *config.ConnectionAuthDef, pluginConfig map[
 		return nil, fmt.Errorf("clientId and clientSecret are required for oauth2 auth")
 	}
 
-	var tokenExchange oauth.TokenExchangeFormat
-	switch auth.TokenExchange {
-	case "", "form":
-		tokenExchange = oauth.TokenExchangeForm
-	case "json":
-		tokenExchange = oauth.TokenExchangeJSON
-	default:
-		return nil, fmt.Errorf("unknown tokenExchange %q", auth.TokenExchange)
+	tokenExchange, err := oauth.ParseTokenExchangeFormat(auth.TokenExchange)
+	if err != nil {
+		return nil, err
 	}
 
 	oauthCfg := oauth.UpstreamConfig{
@@ -2909,24 +2923,40 @@ func buildMCPOAuthHandler(conn config.ConnectionDef, mcpURL string, store mcpoau
 }
 
 func lazyRefreshers(ready <-chan struct{}, resolver func() map[string]map[string]OAuthHandler) invocation.RefresherResolver {
+	return lazyTokenRefreshers(ready, resolver)
+}
+
+func lazyManualRefreshers(ready <-chan struct{}, resolver func() map[string]map[string]ManualTokenExchanger) invocation.RefresherResolver {
+	return lazyTokenRefreshers(ready, resolver)
+}
+
+func lazyTokenRefreshers[T invocation.TokenRefresher](ready <-chan struct{}, resolver func() map[string]map[string]T) invocation.RefresherResolver {
 	var once sync.Once
-	var result map[string]map[string]invocation.OAuthRefresher
-	return func() map[string]map[string]invocation.OAuthRefresher {
+	var result map[string]map[string]invocation.TokenRefresher
+	return func() map[string]map[string]invocation.TokenRefresher {
 		once.Do(func() {
 			<-ready
-			result = connectionAuthToRefreshers(resolver())
+			result = tokenRefreshers(resolver())
 		})
 		return result
 	}
 }
 
-func connectionAuthToRefreshers(m map[string]map[string]OAuthHandler) map[string]map[string]invocation.OAuthRefresher {
+func connectionAuthToRefreshers(m map[string]map[string]OAuthHandler) map[string]map[string]invocation.TokenRefresher {
+	return tokenRefreshers(m)
+}
+
+func manualConnectionAuthToRefreshers(m map[string]map[string]ManualTokenExchanger) map[string]map[string]invocation.TokenRefresher {
+	return tokenRefreshers(m)
+}
+
+func tokenRefreshers[T invocation.TokenRefresher](m map[string]map[string]T) map[string]map[string]invocation.TokenRefresher {
 	if len(m) == 0 {
 		return nil
 	}
-	out := make(map[string]map[string]invocation.OAuthRefresher, len(m))
+	out := make(map[string]map[string]invocation.TokenRefresher, len(m))
 	for intg, conns := range m {
-		inner := make(map[string]invocation.OAuthRefresher, len(conns))
+		inner := make(map[string]invocation.TokenRefresher, len(conns))
 		for conn, handler := range conns {
 			inner[conn] = handler
 		}

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -38,7 +38,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		warnings = w.Warnings()
 	}
 
-	providers, providersReady, connAuthResolver, errResolver, err := buildProvidersAsync(
+	providers, providersReady, connAuthResolver, manualConnAuthResolver, errResolver, err := buildProvidersAsync(
 		ctx,
 		cfg,
 		factories,
@@ -78,6 +78,9 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),
 		invocation.WithConnectionAuth(func() map[string]map[string]invocation.OAuthRefresher {
 			return connectionAuthToRefreshers(connAuthResolver())
+		}),
+		invocation.WithManualConnectionAuth(func() map[string]map[string]invocation.TokenRefresher {
+			return manualConnectionAuthToRefreshers(manualConnAuthResolver())
 		}),
 		invocation.WithConnectionRuntime(connRuntime.Resolve),
 	)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1548,6 +1548,7 @@ type ConnectionAuthDef struct {
 	RedirectURL         string                      `yaml:"redirectUrl"`
 	ClientAuth          string                      `yaml:"clientAuth"`
 	TokenExchange       string                      `yaml:"tokenExchange"`
+	TokenPrefix         string                      `yaml:"tokenPrefix"`
 	Scopes              []string                    `yaml:"scopes"`
 	ScopeParam          string                      `yaml:"scopeParam"`
 	ScopeSeparator      string                      `yaml:"scopeSeparator"`
@@ -1601,6 +1602,7 @@ func MergeConnectionAuth(dst *ConnectionAuthDef, src ConnectionAuthDef) {
 	setString(&dst.RedirectURL, src.RedirectURL)
 	setString(&dst.ClientAuth, src.ClientAuth)
 	setString(&dst.TokenExchange, src.TokenExchange)
+	setString(&dst.TokenPrefix, src.TokenPrefix)
 	if src.Scopes != nil {
 		dst.Scopes = src.Scopes
 	}
@@ -1720,6 +1722,7 @@ func ManifestAuthToConnectionAuthDef(auth *providermanifestv1.ProviderAuth) Conn
 		ClientSecret:        auth.ClientSecret,
 		ClientAuth:          auth.ClientAuth,
 		TokenExchange:       auth.TokenExchange,
+		TokenPrefix:         auth.TokenPrefix,
 		Scopes:              slices.Clone(auth.Scopes),
 		ScopeParam:          auth.ScopeParam,
 		ScopeSeparator:      auth.ScopeSeparator,

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -368,6 +368,7 @@ func connectionBindingHasCredentialMaterial(conn *ConnectionDef) bool {
 		conn.Auth.RedirectURL != "" ||
 		conn.Auth.ClientAuth != "" ||
 		conn.Auth.TokenExchange != "" ||
+		conn.Auth.TokenPrefix != "" ||
 		len(conn.Auth.Scopes) > 0 ||
 		conn.Auth.ScopeParam != "" ||
 		conn.Auth.ScopeSeparator != "" ||

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -12,10 +12,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"github.com/valon-technologies/gestalt/server/services/plugins/apiexec"
+	"github.com/valon-technologies/gestalt/server/services/plugins/oauth"
+	"github.com/valon-technologies/gestalt/server/services/plugins/paraminterp"
 )
 
 type connectManualRequest struct {
@@ -91,7 +95,14 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	}
 	auditTarget = connectionAuditTarget(req.Integration, manualConnection, manualInstance)
 
-	effectiveCredential, credErr := buildEffectiveManualCredential(req, auth)
+	manualExchanger, exchangerErr := s.manualTokenExchanger(auth, req.Integration, manualConnection)
+	if exchangerErr != nil {
+		auditErr = errors.New("manual token exchange is not configured")
+		writeError(w, http.StatusBadGateway, "manual token exchange is not configured")
+		return
+	}
+
+	effectiveCredential, credErr := buildEffectiveManualCredential(req, manualCredentialAuth(auth, prov, manualExchanger != nil), manualExchanger != nil)
 	if credErr != nil {
 		auditErr = credErr
 		writeError(w, http.StatusBadRequest, credErr.Error())
@@ -109,7 +120,15 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	manualMeta, metaErr := buildConnectionMetadata(prov, connParams, nil)
+	tokenResp, exchangeErr := s.exchangeManualToken(r.Context(), manualExchanger, effectiveCredential, connParams)
+	if exchangeErr != nil {
+		auditErr = errors.New("token exchange failed")
+		slog.ErrorContext(r.Context(), "manual token exchange failed", "provider", req.Integration, "error", exchangeErr)
+		writeError(w, http.StatusBadGateway, "token exchange failed")
+		return
+	}
+
+	manualMeta, metaErr := buildConnectionMetadata(prov, connParams, tokenResp)
 	if metaErr != nil {
 		auditErr = errors.New(metaErr.Error())
 		writeError(w, http.StatusBadRequest, metaErr.Error())
@@ -130,6 +149,14 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		AccessToken:  effectiveCredential,
 		MetadataJSON: manualMeta,
 	}
+	if tokenResp != nil {
+		tm.AccessToken = tokenResp.AccessToken
+		tm.RefreshToken = effectiveCredential
+		if tokenResp.ExpiresIn > 0 {
+			t := s.now().UTC().Truncate(time.Second).Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+			tm.TokenExpiresAt = &t
+		}
+	}
 	credentialActorFromPrincipal(p, subjectID).applyTo(&tm)
 
 	result, err := s.runPostConnect(r.Context(), prov, tm)
@@ -143,6 +170,62 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	auditAllowed = true
 	auditErr = nil
 	writeJSON(w, http.StatusOK, result)
+}
+
+func manualCredentialAuth(auth config.ConnectionAuthDef, prov core.Provider, tokenExchange bool) config.ConnectionAuthDef {
+	if !tokenExchange || len(auth.Credentials) > 0 {
+		return auth
+	}
+	for _, field := range prov.CredentialFields() {
+		auth.Credentials = append(auth.Credentials, config.CredentialFieldDef{
+			Name:        field.Name,
+			Label:       field.Label,
+			Description: field.Description,
+		})
+	}
+	return auth
+}
+
+func (s *Server) exchangeManualToken(ctx context.Context, exchanger bootstrap.ManualTokenExchanger, credential string, connParams map[string]string) (*core.TokenResponse, error) {
+	if exchanger == nil {
+		return nil, nil
+	}
+
+	tokenURL := exchanger.TokenURL()
+	if len(connParams) > 0 {
+		resolved := paraminterp.Interpolate(tokenURL, connParams)
+		if resolved != tokenURL {
+			return exchanger.ExchangeCredentialsWithURL(ctx, credential, resolved)
+		}
+	}
+	return exchanger.ExchangeCredentials(ctx, credential)
+}
+
+func (s *Server) manualTokenExchanger(auth config.ConnectionAuthDef, integration, connection string) (bootstrap.ManualTokenExchanger, error) {
+	if auth.Type != providermanifestv1.AuthTypeManual && auth.Type != "" {
+		return nil, nil
+	}
+	if s.manualConnectionAuth != nil {
+		if connMap := s.manualConnectionAuth()[integration]; connMap != nil {
+			if exchanger := connMap[connection]; exchanger != nil {
+				return exchanger, nil
+			}
+		}
+	}
+	if strings.TrimSpace(auth.TokenURL) == "" {
+		return nil, nil
+	}
+	tokenExchange, err := oauth.ParseTokenExchangeFormat(auth.TokenExchange)
+	if err != nil {
+		return nil, err
+	}
+	return oauth.NewCredentialExchanger(oauth.CredentialExchangeConfig{
+		TokenURL:        auth.TokenURL,
+		TokenParams:     auth.TokenParams,
+		TokenExchange:   tokenExchange,
+		AcceptHeader:    auth.AcceptHeader,
+		AccessTokenPath: auth.AccessTokenPath,
+	}), nil
 }
 
 func (s *Server) resolveConnectionProvider(w http.ResponseWriter, integration, requestedConnection string) (core.Provider, string, error) {
@@ -552,7 +635,17 @@ func discoveryCandidateInfos(candidates []core.DiscoveryCandidate) []discoveryCa
 	return out
 }
 
-func buildEffectiveManualCredential(req connectManualRequest, auth config.ConnectionAuthDef) (string, error) {
+func buildEffectiveManualCredential(req connectManualRequest, auth config.ConnectionAuthDef, tokenExchange bool) (string, error) {
+	if tokenExchange {
+		if req.Credential != "" {
+			return "", errors.New("manual token exchange requires named credentials")
+		}
+		if len(auth.Credentials) == 0 {
+			return "", errors.New("manual token exchange requires declared credentials")
+		}
+		return marshalDeclaredManualCredentials(req.Credentials, auth.Credentials)
+	}
+
 	if len(req.Credentials) > 0 {
 		return marshalManualCredentials(req.Credentials)
 	}
@@ -569,6 +662,32 @@ func buildEffectiveManualCredential(req connectManualRequest, auth config.Connec
 		return "", errors.New("manual connection requires named credentials")
 	}
 	return "", nil
+}
+
+func marshalDeclaredManualCredentials(provided map[string]string, fields []config.CredentialFieldDef) (string, error) {
+	declared := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		if field.Name != "" {
+			declared[field.Name] = struct{}{}
+		}
+	}
+	if len(declared) == 0 {
+		return "", errors.New("manual token exchange requires declared credentials")
+	}
+	for name := range provided {
+		if _, ok := declared[name]; !ok {
+			return "", fmt.Errorf("unknown credential: %s", name)
+		}
+	}
+	for _, field := range fields {
+		if field.Name == "" {
+			continue
+		}
+		if _, ok := provided[field.Name]; !ok {
+			return "", fmt.Errorf("missing required credential: %s", field.Name)
+		}
+	}
+	return marshalManualCredentials(provided)
 }
 
 func marshalManualCredentials(creds map[string]string) (string, error) {

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -87,6 +87,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		// its own MCP-specific routing below.
 		CatalogConnection:     httpCatalogConnectionMap(connMaps),
 		ConnectionAuth:        result.ConnectionAuth,
+		ManualConnectionAuth:  result.ManualConnectionAuth,
 		PluginDefs:            cfg.Plugins,
 		Authorizer:            result.Authorizer,
 		AuthorizationProvider: result.AuthorizationProvider,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -104,6 +104,7 @@ type Server struct {
 	defaultConnection      map[string]string
 	catalogConnection      map[string]string
 	connectionAuth         func() map[string]map[string]bootstrap.OAuthHandler
+	manualConnectionAuth   func() map[string]map[string]bootstrap.ManualTokenExchanger
 	pluginDefs             map[string]*config.ProviderEntry
 	authorizer             authorization.RuntimeAuthorizer
 	noAuth                 bool
@@ -161,6 +162,7 @@ type Config struct {
 	DefaultConnection     map[string]string
 	CatalogConnection     map[string]string
 	ConnectionAuth        func() map[string]map[string]bootstrap.OAuthHandler
+	ManualConnectionAuth  func() map[string]map[string]bootstrap.ManualTokenExchanger
 	PluginDefs            map[string]*config.ProviderEntry
 	ProviderUIs           map[string]*config.UIEntry
 	Authorizer            authorization.RuntimeAuthorizer
@@ -341,6 +343,7 @@ func New(cfg Config) (*Server, error) {
 		defaultConnection:      cfg.DefaultConnection,
 		catalogConnection:      cfg.CatalogConnection,
 		connectionAuth:         cfg.ConnectionAuth,
+		manualConnectionAuth:   cfg.ManualConnectionAuth,
 		pluginDefs:             cfg.PluginDefs,
 		authorizer:             cfg.Authorizer,
 		noAuth:                 noAuth,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -143,6 +143,21 @@ func newTestHandler(t *testing.T, opts ...func(*server.Config)) http.Handler {
 			return refreshers
 		}))
 	}
+	if cfg.ManualConnectionAuth != nil {
+		authFn := cfg.ManualConnectionAuth
+		brokerOpts = append(brokerOpts, invocation.WithManualConnectionAuth(func() map[string]map[string]invocation.TokenRefresher {
+			m := authFn()
+			refreshers := make(map[string]map[string]invocation.TokenRefresher, len(m))
+			for intg, conns := range m {
+				inner := make(map[string]invocation.TokenRefresher, len(conns))
+				for conn, h := range conns {
+					inner[conn] = h
+				}
+				refreshers[intg] = inner
+			}
+			return refreshers
+		}))
+	}
 	if cfg.Authorizer != nil {
 		brokerOpts = append(brokerOpts, invocation.WithAuthorizer(cfg.Authorizer))
 	}
@@ -22350,6 +22365,424 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 				t.Fatalf("token data = %+v, want %+v", tokenData, tc.wantTokenData)
 			}
 		})
+	}
+}
+
+func TestConnectManual_TokenExchange(t *testing.T) {
+	t.Parallel()
+
+	fixedNow := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+
+	t.Run("exchanges declared credentials and stores refresh source", func(t *testing.T) {
+		t.Parallel()
+
+		var seenAccept string
+		var seenContentType string
+		var seenForm url.Values
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/login" {
+				t.Fatalf("token path = %q, want /login", r.URL.Path)
+			}
+			seenAccept = r.Header.Get("Accept")
+			seenContentType = r.Header.Get("Content-Type")
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
+			seenForm = maps.Clone(r.PostForm)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"manual-access","refresh_token":"ignored-refresh","expires_in":3600,"account":{"id":"acct_123"}}`))
+		}))
+		testutil.CloseOnCleanup(t, tokenSrv)
+
+		svc := testutil.NewStubServices(t)
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProviderWithCapabilities{
+				stubManualProvider: stubManualProvider{
+					StubIntegration: coretesting.StubIntegration{N: "looker-like"},
+				},
+				connectionParams: map[string]core.ConnectionParamDef{
+					"account_id": {From: "token_response", Field: "account.id", Required: true},
+				},
+			})
+			cfg.DefaultConnection = map[string]string{"looker-like": config.PluginConnectionName}
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"looker-like": {
+					Auth: &config.ConnectionAuthDef{
+						Type:          providermanifestv1.AuthTypeManual,
+						TokenURL:      tokenSrv.URL + "/login",
+						TokenExchange: "form",
+						TokenParams:   map[string]string{"audience": "api"},
+						AcceptHeader:  "application/json",
+						Credentials: []config.CredentialFieldDef{
+							{Name: "client_id", Label: "Client ID"},
+							{Name: "client_secret", Label: "Client Secret"},
+						},
+					},
+				},
+			}
+			cfg.Now = func() time.Time { return fixedNow }
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"looker-like","credentials":{"client_id":"id-123","client_secret":"secret-456"}}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+		}
+
+		if seenAccept != "application/json" {
+			t.Fatalf("Accept = %q, want application/json", seenAccept)
+		}
+		if !strings.HasPrefix(seenContentType, "application/x-www-form-urlencoded") {
+			t.Fatalf("Content-Type = %q, want form", seenContentType)
+		}
+		if got := seenForm.Get("client_id"); got != "id-123" {
+			t.Fatalf("client_id = %q", got)
+		}
+		if got := seenForm.Get("client_secret"); got != "secret-456" {
+			t.Fatalf("client_secret = %q", got)
+		}
+		if got := seenForm.Get("audience"); got != "api" {
+			t.Fatalf("audience = %q", got)
+		}
+
+		u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
+		tokens, _ := svc.ExternalCredentials.ListCredentials(context.Background(), principal.UserSubjectID(u.ID))
+		if len(tokens) != 1 {
+			t.Fatalf("stored credentials = %d, want 1", len(tokens))
+		}
+		stored := tokens[0]
+		if stored.AccessToken != "manual-access" {
+			t.Fatalf("access token = %q, want manual-access", stored.AccessToken)
+		}
+		var refreshSource map[string]string
+		if err := json.Unmarshal([]byte(stored.RefreshToken), &refreshSource); err != nil {
+			t.Fatalf("refresh source is not credential JSON: %v", err)
+		}
+		if !reflect.DeepEqual(refreshSource, map[string]string{"client_id": "id-123", "client_secret": "secret-456"}) {
+			t.Fatalf("refresh source = %+v", refreshSource)
+		}
+		if stored.ExpiresAt == nil || !stored.ExpiresAt.Equal(fixedNow.Add(time.Hour)) {
+			t.Fatalf("expires_at = %v, want %v", stored.ExpiresAt, fixedNow.Add(time.Hour))
+		}
+		var metadata map[string]string
+		if err := json.Unmarshal([]byte(stored.MetadataJSON), &metadata); err != nil {
+			t.Fatalf("metadata JSON: %v", err)
+		}
+		if metadata["account_id"] != "acct_123" {
+			t.Fatalf("account_id metadata = %q, want acct_123", metadata["account_id"])
+		}
+	})
+
+	t.Run("supports json exchange and accessTokenPath", func(t *testing.T) {
+		t.Parallel()
+
+		var seen map[string]string
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+				t.Fatalf("Content-Type = %q, want JSON", got)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&seen); err != nil {
+				t.Fatalf("decode token request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"token":"nested-access"},"expires_in":"120"}`))
+		}))
+		testutil.CloseOnCleanup(t, tokenSrv)
+
+		svc := testutil.NewStubServices(t)
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
+				StubIntegration: coretesting.StubIntegration{N: "json-token"},
+			})
+			cfg.DefaultConnection = map[string]string{"json-token": config.PluginConnectionName}
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"json-token": {
+					Auth: &config.ConnectionAuthDef{
+						Type:            providermanifestv1.AuthTypeManual,
+						TokenURL:        tokenSrv.URL,
+						TokenExchange:   "json",
+						AccessTokenPath: "data.token",
+						Credentials: []config.CredentialFieldDef{
+							{Name: "client_id"},
+							{Name: "client_secret"},
+						},
+					},
+				},
+			}
+			cfg.Now = func() time.Time { return fixedNow }
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"json-token","credentials":{"client_id":"json-id","client_secret":"json-secret"}}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+		}
+		if !reflect.DeepEqual(seen, map[string]string{"client_id": "json-id", "client_secret": "json-secret"}) {
+			t.Fatalf("token request body = %+v", seen)
+		}
+
+		u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
+		tokens, _ := svc.ExternalCredentials.ListCredentials(context.Background(), principal.UserSubjectID(u.ID))
+		if len(tokens) != 1 {
+			t.Fatalf("stored credentials = %d, want 1", len(tokens))
+		}
+		if tokens[0].AccessToken != "nested-access" {
+			t.Fatalf("access token = %q, want nested-access", tokens[0].AccessToken)
+		}
+		if tokens[0].ExpiresAt == nil || !tokens[0].ExpiresAt.Equal(fixedNow.Add(120*time.Second)) {
+			t.Fatalf("expires_at = %v, want %v", tokens[0].ExpiresAt, fixedNow.Add(120*time.Second))
+		}
+	})
+
+	t.Run("uses registered exchanger when connection auth has no token URL", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int64
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
+			if got := r.Form.Get("client_id"); got != "fallback-id" {
+				t.Fatalf("client_id = %q, want fallback-id", got)
+			}
+			if got := r.Form.Get("client_secret"); got != "fallback-secret" {
+				t.Fatalf("client_secret = %q, want fallback-secret", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"fallback-access","expires_in":300}`))
+		}))
+		testutil.CloseOnCleanup(t, tokenSrv)
+
+		svc := testutil.NewStubServices(t)
+		exchanger := oauth.NewCredentialExchanger(oauth.CredentialExchangeConfig{TokenURL: tokenSrv.URL})
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProviderWithCapabilities{
+				stubManualProvider: stubManualProvider{
+					StubIntegration: coretesting.StubIntegration{N: "fallback-token"},
+				},
+				credentialFields: []core.CredentialFieldDef{
+					{Name: "client_id"},
+					{Name: "client_secret"},
+				},
+			})
+			cfg.DefaultConnection = map[string]string{"fallback-token": config.PluginConnectionName}
+			cfg.ManualConnectionAuth = func() map[string]map[string]bootstrap.ManualTokenExchanger {
+				return map[string]map[string]bootstrap.ManualTokenExchanger{
+					"fallback-token": {
+						config.PluginConnectionName: exchanger,
+					},
+				}
+			}
+			cfg.Now = func() time.Time { return fixedNow }
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		rawReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"fallback-token","credential":"raw-token"}`))
+		rawReq.Header.Set("Content-Type", "application/json")
+		rawResp, err := http.DefaultClient.Do(rawReq)
+		if err != nil {
+			t.Fatalf("raw request: %v", err)
+		}
+		defer func() { _ = rawResp.Body.Close() }()
+		if rawResp.StatusCode != http.StatusBadRequest {
+			body, _ := io.ReadAll(rawResp.Body)
+			t.Fatalf("raw status = %d, want 400: %s", rawResp.StatusCode, body)
+		}
+		if calls.Load() != 0 {
+			t.Fatalf("token endpoint calls after raw credential = %d, want 0", calls.Load())
+		}
+
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(`{"integration":"fallback-token","credentials":{"client_id":"fallback-id","client_secret":"fallback-secret"}}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+		}
+		if calls.Load() != 1 {
+			t.Fatalf("token endpoint calls = %d, want 1", calls.Load())
+		}
+
+		u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
+		tokens, _ := svc.ExternalCredentials.ListCredentials(context.Background(), principal.UserSubjectID(u.ID))
+		if len(tokens) != 1 {
+			t.Fatalf("stored credentials = %d, want 1", len(tokens))
+		}
+		if tokens[0].AccessToken != "fallback-access" {
+			t.Fatalf("access token = %q, want fallback-access", tokens[0].AccessToken)
+		}
+	})
+
+	t.Run("rejects raw missing and unknown credentials before exchange", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int64
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			http.Error(w, "should not be called", http.StatusInternalServerError)
+		}))
+		testutil.CloseOnCleanup(t, tokenSrv)
+
+		cases := []string{
+			`{"integration":"strict-token","credential":"raw-token"}`,
+			`{"integration":"strict-token","credentials":{"client_id":"id-only"}}`,
+			`{"integration":"strict-token","credentials":{"client_id":"id","client_secret":"secret","extra":"nope"}}`,
+		}
+		t.Cleanup(func() {
+			if calls.Load() != 0 {
+				t.Fatalf("token endpoint calls = %d, want 0", calls.Load())
+			}
+		})
+		for _, body := range cases {
+			body := body
+			t.Run(body, func(t *testing.T) {
+				t.Parallel()
+
+				svc := testutil.NewStubServices(t)
+				ts := newTestServer(t, func(cfg *server.Config) {
+					cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
+						StubIntegration: coretesting.StubIntegration{N: "strict-token"},
+					})
+					cfg.DefaultConnection = map[string]string{"strict-token": config.PluginConnectionName}
+					cfg.PluginDefs = map[string]*config.ProviderEntry{
+						"strict-token": {
+							Auth: &config.ConnectionAuthDef{
+								Type:     providermanifestv1.AuthTypeManual,
+								TokenURL: tokenSrv.URL,
+								Credentials: []config.CredentialFieldDef{
+									{Name: "client_id"},
+									{Name: "client_secret"},
+								},
+							},
+						},
+					}
+					cfg.Services = svc
+				})
+				testutil.CloseOnCleanup(t, ts)
+
+				req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(body))
+				req.Header.Set("Content-Type", "application/json")
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("request: %v", err)
+				}
+				defer func() { _ = resp.Body.Close() }()
+				if resp.StatusCode != http.StatusBadRequest {
+					responseBody, _ := io.ReadAll(resp.Body)
+					t.Fatalf("status = %d, want 400: %s", resp.StatusCode, responseBody)
+				}
+			})
+		}
+	})
+}
+
+func TestRefresh_UsesManualTokenExchangeHandlers(t *testing.T) {
+	t.Parallel()
+
+	sourceCredential := `{"client_id":"id-123","client_secret":"secret-456"}`
+	var seenForm url.Values
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		seenForm = maps.Clone(r.PostForm)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"refreshed-manual","refresh_token":"ignored-by-gestalt","expires_in":3600}`))
+	}))
+	testutil.CloseOnCleanup(t, tokenSrv)
+
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	expired := time.Now().Add(-1 * time.Hour)
+	seedToken(t, svc, &core.ExternalCredential{
+		ID:           "tok-manual",
+		SubjectID:    principal.UserSubjectID(u.ID),
+		Integration:  "manual-refresh",
+		Connection:   "default",
+		Instance:     "default",
+		AccessToken:  "expired-manual",
+		RefreshToken: sourceCredential,
+		ExpiresAt:    &expired,
+	})
+
+	var usedToken string
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N: "manual-refresh",
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
+				usedToken = token
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
+	}
+
+	exchanger := oauth.NewCredentialExchanger(oauth.CredentialExchangeConfig{
+		TokenURL: tokenSrv.URL,
+	})
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"manual-refresh": testDefaultConnection}
+		cfg.ManualConnectionAuth = func() map[string]map[string]bootstrap.ManualTokenExchanger {
+			return map[string]map[string]bootstrap.ManualTokenExchanger{
+				"manual-refresh": {
+					testDefaultConnection: exchanger,
+				},
+			}
+		}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/manual-refresh/list", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if usedToken != "refreshed-manual" {
+		t.Fatalf("used token = %q, want refreshed-manual", usedToken)
+	}
+	if seenForm.Get("client_id") != "id-123" || seenForm.Get("client_secret") != "secret-456" {
+		t.Fatalf("token request form = %+v", seenForm)
+	}
+
+	tokens, _ := svc.ExternalCredentials.ListCredentials(context.Background(), principal.UserSubjectID(u.ID))
+	if len(tokens) != 1 {
+		t.Fatalf("stored credentials = %d, want 1", len(tokens))
+	}
+	if tokens[0].AccessToken != "refreshed-manual" {
+		t.Fatalf("stored access token = %q, want refreshed-manual", tokens[0].AccessToken)
+	}
+	if tokens[0].RefreshToken != sourceCredential {
+		t.Fatalf("stored refresh source = %q, want original credential JSON", tokens[0].RefreshToken)
 	}
 }
 

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -747,6 +747,9 @@
             "json"
           ]
         },
+        "tokenPrefix": {
+          "type": "string"
+        },
         "accessTokenPath": {
           "type": "string"
         },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -461,6 +461,7 @@ type ProviderAuth struct {
 	PKCE                bool              `json:"pkce,omitempty" yaml:"pkce,omitempty"`
 	ClientAuth          string            `json:"clientAuth,omitempty" yaml:"clientAuth,omitempty"`
 	TokenExchange       string            `json:"tokenExchange,omitempty" yaml:"tokenExchange,omitempty"`
+	TokenPrefix         string            `json:"tokenPrefix,omitempty" yaml:"tokenPrefix,omitempty"`
 	AccessTokenPath     string            `json:"accessTokenPath,omitempty" yaml:"accessTokenPath,omitempty"`
 	ScopeParam          string            `json:"scopeParam,omitempty" yaml:"scopeParam,omitempty"`
 	ScopeSeparator      string            `json:"scopeSeparator,omitempty" yaml:"scopeSeparator,omitempty"`

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -117,29 +117,32 @@ func (m ConnectionMap) ConnectionForProvider(provider string) string {
 	return m[provider]
 }
 
-// OAuthRefresher is the subset of OAuthHandler that the broker needs for
+// TokenRefresher is the subset of auth handlers that the broker needs for
 // token refresh. Defined here to avoid importing the bootstrap package.
-type OAuthRefresher interface {
+type TokenRefresher interface {
 	RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error)
 	RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
 	TokenURL() string
 }
 
+type OAuthRefresher = TokenRefresher
+
 // RefresherResolver returns the connection auth map, blocking until providers
 // finish loading if needed.
-type RefresherResolver func() map[string]map[string]OAuthRefresher
+type RefresherResolver func() map[string]map[string]TokenRefresher
 
 type Broker struct {
-	providers         *registry.ProviderMap[core.Provider]
-	users             UserStore
-	externalCreds     core.ExternalCredentialProvider
-	authorizer        authorization.RuntimeAuthorizer
-	connMapper        ConnectionMapper
-	mcpMapper         ConnectionMapper
-	connectionAuth    RefresherResolver
-	connectionRuntime ConnectionRuntimeResolver
-	providerOverrides ProviderOverrideResolver
-	refreshGroup      singleflight.Group
+	providers            *registry.ProviderMap[core.Provider]
+	users                UserStore
+	externalCreds        core.ExternalCredentialProvider
+	authorizer           authorization.RuntimeAuthorizer
+	connMapper           ConnectionMapper
+	mcpMapper            ConnectionMapper
+	connectionAuth       RefresherResolver
+	manualConnectionAuth RefresherResolver
+	connectionRuntime    ConnectionRuntimeResolver
+	providerOverrides    ProviderOverrideResolver
+	refreshGroup         singleflight.Group
 }
 
 type BrokerOption func(*Broker)
@@ -154,6 +157,10 @@ func WithMCPConnectionMapper(m ConnectionMapper) BrokerOption {
 
 func WithConnectionAuth(r RefresherResolver) BrokerOption {
 	return func(b *Broker) { b.connectionAuth = r }
+}
+
+func WithManualConnectionAuth(r RefresherResolver) BrokerOption {
+	return func(b *Broker) { b.manualConnectionAuth = r }
 }
 
 func WithConnectionRuntime(r ConnectionRuntimeResolver) BrokerOption {
@@ -947,7 +954,7 @@ func (b *Broker) refreshCredentialIfNeeded(ctx context.Context, token *core.Exte
 		return token.AccessToken, nil
 	}
 
-	refresher := b.resolveRefresher(providerName, connection)
+	refresher, authMethod := b.resolveRefresher(providerName, connection)
 	if refresher == nil {
 		return token.AccessToken, nil
 	}
@@ -961,7 +968,7 @@ func (b *Broker) refreshCredentialIfNeeded(ctx context.Context, token *core.Exte
 		refreshCtx := context.WithoutCancel(ctx)
 		startedAt := time.Now()
 		resp, err := b.refreshOAuth(refreshCtx, refresher, token.RefreshToken)
-		metricutil.RecordConnectionAuthMetrics(refreshCtx, startedAt, providerName, "oauth", "refresh", connectionMode, err != nil)
+		metricutil.RecordConnectionAuthMetrics(refreshCtx, startedAt, providerName, authMethod, "refresh", connectionMode, err != nil)
 		return resp, err
 	})
 	if err != nil {
@@ -1002,18 +1009,28 @@ func (b *Broker) refreshCredentialIfNeeded(ctx context.Context, token *core.Exte
 	return token.AccessToken, nil
 }
 
-func (b *Broker) resolveRefresher(integration, connection string) OAuthRefresher {
-	if b.connectionAuth == nil {
+func (b *Broker) resolveRefresher(integration, connection string) (TokenRefresher, string) {
+	if refresher := lookupRefresher(b.manualConnectionAuth, integration, connection); refresher != nil {
+		return refresher, "manual"
+	}
+	if refresher := lookupRefresher(b.connectionAuth, integration, connection); refresher != nil {
+		return refresher, "oauth"
+	}
+	return nil, ""
+}
+
+func lookupRefresher(resolver RefresherResolver, integration, connection string) TokenRefresher {
+	if resolver == nil {
 		return nil
 	}
-	m := b.connectionAuth()
+	m := resolver()
 	if m == nil {
 		return nil
 	}
 	return m[integration][connection]
 }
 
-func (b *Broker) refreshOAuth(ctx context.Context, refresher OAuthRefresher, refreshToken string) (*core.TokenResponse, error) {
+func (b *Broker) refreshOAuth(ctx context.Context, refresher TokenRefresher, refreshToken string) (*core.TokenResponse, error) {
 	if cp := core.ConnectionParams(ctx); cp != nil {
 		raw := refresher.TokenURL()
 		resolved := paraminterp.Interpolate(raw, cp)

--- a/gestaltd/services/plugins/declarative/build.go
+++ b/gestaltd/services/plugins/declarative/build.go
@@ -218,6 +218,7 @@ func ApplyConnectionAuth(def *Definition, conn ConnectionDef) {
 	setStr(&def.Auth.TokenURL, o.TokenURL)
 	setStr(&def.Auth.ClientAuth, o.ClientAuth)
 	setStr(&def.Auth.TokenExchange, o.TokenExchange)
+	setStr(&def.TokenPrefix, o.TokenPrefix)
 	if o.Scopes != nil {
 		def.Auth.Scopes = slices.Clone(o.Scopes)
 	}

--- a/gestaltd/services/plugins/declarative/build_test.go
+++ b/gestaltd/services/plugins/declarative/build_test.go
@@ -443,6 +443,51 @@ func TestBuildOAuthConnectionOverrideClearsOpenAPIManualAuth(t *testing.T) {
 	}
 }
 
+func TestBuildManualConnectionOverrideAppliesTokenPrefix(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"authorization": r.Header.Get("Authorization"),
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	def := &Definition{
+		Provider:    "prefixed_manual",
+		DisplayName: "Prefixed Manual API",
+		BaseURL:     srv.URL,
+		Auth:        AuthDef{Type: "manual"},
+		Operations: map[string]OperationDef{
+			"list": {Description: "List items", Method: http.MethodGet, Path: "/items"},
+		},
+	}
+
+	prov, err := Build(def, ConnectionDef{
+		Auth: ConnectionAuthDef{
+			Type:        providermanifestv1.AuthTypeManual,
+			TokenPrefix: "token ",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	result, err := prov.Execute(context.Background(), "list", nil, "manual-access-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if resp["authorization"] != "token manual-access-token" {
+		t.Errorf("Authorization = %v, want token manual-access-token", resp["authorization"])
+	}
+}
+
 func TestBuildAuthMapping(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/plugins/declarative/connection.go
+++ b/gestaltd/services/plugins/declarative/connection.go
@@ -28,6 +28,7 @@ type ConnectionAuthDef struct {
 	RedirectURL         string
 	ClientAuth          string
 	TokenExchange       string
+	TokenPrefix         string
 	Scopes              []string
 	ScopeParam          string
 	ScopeSeparator      string

--- a/gestaltd/services/plugins/oauth/upstream.go
+++ b/gestaltd/services/plugins/oauth/upstream.go
@@ -37,6 +37,17 @@ const (
 	TokenExchangeJSON TokenExchangeFormat = "json"
 )
 
+func ParseTokenExchangeFormat(raw string) (TokenExchangeFormat, error) {
+	switch raw {
+	case "", string(TokenExchangeForm):
+		return TokenExchangeForm, nil
+	case string(TokenExchangeJSON):
+		return TokenExchangeJSON, nil
+	default:
+		return "", fmt.Errorf("unknown tokenExchange %q", raw)
+	}
+}
+
 type UpstreamConfig struct {
 	ClientID         string
 	ClientSecret     string
@@ -326,6 +337,77 @@ func (h *UpstreamHandler) tokenRequest(ctx context.Context, data url.Values, tok
 		TokenType:    tokenType,
 		Extra:        raw,
 	}, nil
+}
+
+type CredentialExchangeConfig struct {
+	TokenURL        string
+	TokenParams     map[string]string
+	TokenExchange   TokenExchangeFormat
+	AcceptHeader    string
+	AccessTokenPath string
+}
+
+type CredentialExchanger struct {
+	upstream *UpstreamHandler
+}
+
+func NewCredentialExchanger(cfg CredentialExchangeConfig, opts ...Option) *CredentialExchanger {
+	return &CredentialExchanger{
+		upstream: NewUpstream(UpstreamConfig{
+			TokenURL:        cfg.TokenURL,
+			TokenParams:     cfg.TokenParams,
+			TokenExchange:   cfg.TokenExchange,
+			AcceptHeader:    cfg.AcceptHeader,
+			AccessTokenPath: cfg.AccessTokenPath,
+		}, opts...),
+	}
+}
+
+func (h *CredentialExchanger) TokenURL() string {
+	if h == nil || h.upstream == nil {
+		return ""
+	}
+	return h.upstream.TokenURL()
+}
+
+func (h *CredentialExchanger) ExchangeCredentials(ctx context.Context, credentialJSON string) (*core.TokenResponse, error) {
+	return h.ExchangeCredentialsWithURL(ctx, credentialJSON, "")
+}
+
+func (h *CredentialExchanger) ExchangeCredentialsWithURL(ctx context.Context, credentialJSON, tokenURLOverride string) (*core.TokenResponse, error) {
+	if h == nil || h.upstream == nil {
+		return nil, fmt.Errorf("credential exchanger is not configured")
+	}
+	var credentials map[string]string
+	if err := json.Unmarshal([]byte(credentialJSON), &credentials); err != nil {
+		return nil, fmt.Errorf("decoding manual credentials: %w", err)
+	}
+	if len(credentials) == 0 {
+		return nil, fmt.Errorf("manual credentials are required")
+	}
+
+	data := url.Values{}
+	for k, v := range h.upstream.cfg.TokenParams {
+		data.Set(k, v)
+	}
+	for k, v := range credentials {
+		data.Set(k, v)
+	}
+
+	resp, err := h.upstream.tokenRequest(ctx, data, tokenURLOverride)
+	if err != nil {
+		return nil, err
+	}
+	resp.RefreshToken = credentialJSON
+	return resp, nil
+}
+
+func (h *CredentialExchanger) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return h.ExchangeCredentials(ctx, refreshToken)
+}
+
+func (h *CredentialExchanger) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	return h.ExchangeCredentialsWithURL(ctx, refreshToken, tokenURL)
 }
 
 func GenerateVerifier() string {


### PR DESCRIPTION
## Summary
- add a declarative manual token exchange primitive for providers that collect named credentials and exchange them for short-lived access tokens
- keep manual token exchange refreshers separate from browser OAuth handlers, so manual connections do not expose start-oauth/callback flows
- preserve the original credential JSON as the refresh source and feed token responses into connection metadata extraction
- add manifest/config/declarative propagation for `auth.tokenPrefix`

## Interface Changes
- New/changed interface: manual provider auth can declare `auth.tokenUrl`, `auth.tokenExchange`, named `auth.credentials`, optional token params, optional access token path, and optional `auth.tokenPrefix`.
- Example usage:

```json
POST /api/v1/auth/connect-manual
{
  "integration": "looker",
  "credentials": {
    "client_id": "...",
    "client_secret": "..."
  },
  "connection_params": {
    "host": "acme.looker.com"
  }
}
```

## Functional/Integration Tests
- Tests added or augmented: `TestConnectManual_TokenExchange`, `TestRefresh_UsesManualTokenExchangeHandlers`, `TestBuildManualConnectionAuthMapIsSeparateFromOAuthHandlers`, and declarative manual connection override coverage.
- Contract boundary covered: connect-manual HTTP API -> token endpoint exchange -> credential persistence -> broker refresh, plus manifest/declarative build propagation.
- Commands run:
  - `golangci-lint run`
  - `go test ./internal/config ./internal/bootstrap ./internal/server ./services/invocation ./services/plugins/oauth ./services/plugins/declarative`
  - `git diff --check`
