### PR TITLE
Allow external credentials v2 IndexedDB store

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1462,7 +1462,7 @@ func externalCredentialsIndexedDBHostService(envVar, providerName string, ds ind
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, providerName, indexeddbservice.ServerOptions{
-				AllowedStores: []string{"external_credentials"},
+				AllowedStores: []string{"external_credentials", "external_credentials_v2"},
 			}))
 		},
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -4315,6 +4315,23 @@ func TestBootstrapRoutesExternalCredentialsIndexedDBHostServices(t *testing.T) {
 			t.Fatalf("external credentials indexeddb env[%d] = %q, want %q", i, got, want)
 		}
 	}
+
+	withIndexedDBHostClient(t, hostServices[0], func(client proto.IndexedDBClient) {
+		for _, store := range []string{"external_credentials", "external_credentials_v2"} {
+			if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{
+				Name:   store,
+				Schema: &proto.ObjectStoreSchema{},
+			}); err != nil {
+				t.Fatalf("CreateObjectStore(%s): %v", store, err)
+			}
+		}
+		if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{
+			Name:   "plugin_credentials",
+			Schema: &proto.ObjectStoreSchema{},
+		}); err == nil {
+			t.Fatal("CreateObjectStore(plugin_credentials) succeeded, want allowlist failure")
+		}
+	})
 }
 
 func TestBootstrapRoutesWorkflowIndexedDBHostServices(t *testing.T) {


### PR DESCRIPTION
## Summary
- allow external credentials providers to access both the legacy `external_credentials` store and the new `external_credentials_v2` store
- add a bootstrap regression test that exercises the IndexedDB host service allowlist over gRPC

## Testing
- go test ./internal/bootstrap -run TestBootstrapRoutesExternalCredentialsIndexedDBHostServices -count=1
- go test ./internal/bootstrap
- git diff --check