### PR TITLE
Default empty agent tool refs to catalog

### DIFF
--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1847,8 +1847,6 @@ fn build_turn_create_body(args: &AgentTurnCreateArgs) -> Result<Value> {
             "toolRefs".to_string(),
             Value::Array(args.tools.iter().map(agent_tool_ref_value).collect()),
         );
-    } else if !body.contains_key("toolRefs") {
-        body.insert("toolRefs".to_string(), Value::Array(Vec::new()));
     }
 
     validate_turn_create_body(&body)?;

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -712,8 +712,7 @@ fn test_cli_runs_interactive_agent_session_with_display_events() {
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
     .match_body(Matcher::JsonString(
-        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display events"}],"toolRefs":[]}"#
-            .to_string(),
+        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display events"}]}"#.to_string(),
     ))
     .with_body(TURN_JSON)
     .create();
@@ -802,7 +801,7 @@ fn test_cli_runs_tty_agent_session_in_isolated_selectable_ui() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello tui"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello tui"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -911,7 +910,7 @@ fn test_cli_tty_resume_model_override_updates_visible_model_and_turn_payload() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"override model"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"override model"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -984,7 +983,7 @@ fn test_cli_tty_renders_display_tool_activity_rows() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display tools"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"display tools"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1117,7 +1116,7 @@ fn test_cli_tty_groups_tool_activity_rows() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"use tools"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"use tools"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1206,7 +1205,7 @@ fn test_cli_tty_reconciles_unmatched_tool_activity_rows() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"ambiguous tools"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"ambiguous tools"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1283,7 +1282,7 @@ fn test_cli_tty_help_and_prompt_history() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"remember this"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"remember this"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1319,7 +1318,7 @@ fn test_cli_tty_help_and_prompt_history() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"remember this"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"remember this"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1355,7 +1354,7 @@ fn test_cli_tty_help_and_prompt_history() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"draft text"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"draft text"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1513,7 +1512,7 @@ fn test_cli_tty_renders_markdown_like_assistant_content() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"render markdown"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"render markdown"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1596,7 +1595,7 @@ fn test_cli_tty_wraps_wide_transcript_text_by_display_width() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"wide text"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"wide text"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1664,7 +1663,7 @@ fn test_cli_tty_queues_prompt_while_turn_is_running() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"slow turn"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"slow turn"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1701,7 +1700,7 @@ fn test_cli_tty_queues_prompt_while_turn_is_running() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"pending turn"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"pending turn"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1804,7 +1803,7 @@ fn test_cli_tty_turn_boundary_stops_stale_streaming_transcript_item() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"first turn"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"first turn"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1839,7 +1838,7 @@ fn test_cli_tty_turn_boundary_stops_stale_streaming_transcript_item() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"second turn"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"second turn"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -1911,7 +1910,7 @@ fn test_cli_tty_secret_interaction_masks_and_requires_input() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"needs secret"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"needs secret"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2057,7 +2056,7 @@ fn test_cli_resumes_latest_active_agent_session() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-new/turns",
-            r#"{"messages":[{"role":"user","text":"continue plan"}],"toolRefs":[]}"#,
+            r#"{"messages":[{"role":"user","text":"continue plan"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2235,7 +2234,7 @@ fn test_cli_agent_model_slash_sets_future_turn_model() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"hello"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.5","messages":[{"role":"user","text":"hello"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2305,7 +2304,7 @@ fn test_cli_resumes_existing_agent_session_and_resolves_input_interaction() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-2/turns",
-            r#"{"messages":[{"role":"user","text":"need incident context"}],"toolRefs":[]}"#,
+            r#"{"messages":[{"role":"user","text":"need incident context"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{
@@ -2438,7 +2437,7 @@ fn test_cli_resolves_agent_interaction_in_interactive_mode() {
         ExpectedRequest::json(
             Method::POST,
             "/api/v1/agent/sessions/session-1/turns",
-            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"approve deployment"}],"toolRefs":[]}"#,
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"approve deployment"}]}"#,
             StatusCode::CREATED,
             http::APPLICATION_JSON,
             r#"{

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -1129,8 +1129,8 @@ func TestAgentTurnToolRefsDefaultBroadAndExplicitEmpty(t *testing.T) {
 	if got := turnRequests[0].ToolRefs; len(got) != 1 || got[0].Plugin != "*" || got[0].Operation != "" {
 		t.Fatalf("omitted toolRefs provider refs = %#v, want global broad ref", got)
 	}
-	if got := turnRequests[1].ToolRefs; len(got) != 0 {
-		t.Fatalf("explicit empty toolRefs provider refs = %#v, want none", got)
+	if got := turnRequests[1].ToolRefs; len(got) != 1 || got[0].Plugin != "*" || got[0].Operation != "" {
+		t.Fatalf("explicit empty toolRefs provider refs = %#v, want global broad ref", got)
 	}
 	if got := turnRequests[2].ToolRefs; len(got) != 1 || got[0].Plugin != "docs" || got[0].Operation != "" {
 		t.Fatalf("plugin broad provider refs = %#v, want docs broad ref", got)

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -841,7 +841,7 @@ func agentToolRefsFromRequest(refs []agentToolRefRequest) []coreagent.ToolRef {
 }
 
 func agentToolRefsForCreateTurn(req agentTurnCreateRequest) []coreagent.ToolRef {
-	if !req.toolRefsSet {
+	if !req.toolRefsSet || (strings.TrimSpace(req.ToolSource) == "" && len(req.ToolRefs) == 0) {
 		return []coreagent.ToolRef{{Plugin: "*"}}
 	}
 	return agentToolRefsFromRequest(req.ToolRefs)


### PR DESCRIPTION
## Summary
- Treat HTTP agent turns with `toolRefs: []` and no `toolSource` as the default broad catalog request.
- Stop the CLI/TUI from emitting an explicit empty `toolRefs` array when no `--tool` args are passed.

## Test plan
- [x] `go test ./internal/server -run TestAgentTurnToolRefsDefaultBroadAndExplicitEmpty`
- [x] `cargo test --manifest-path gestalt/cli/Cargo.toml --test agents_cli`