### PR TITLE
Remove legacy connection validation fallback

### DIFF
--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -88,7 +88,7 @@ The `spec` block for a `kind: plugin` manifest describes a plugin. It supports d
 | Field | Type | Purpose |
 | --- | --- | --- |
 | `configSchemaPath` | string | Path to a JSON/YAML schema that validates `plugins.<name>.config` in the server config. |
-| `auth` | RouteAuthRef | Optional plugin route-auth reference. Use `auth.provider` to bind the plugin’s mounted routes to a named request-auth provider. Legacy manifests may also use `spec.auth` for upstream connection auth when no `connections` map is defined. |
+| `auth` | RouteAuthRef | Optional plugin route-auth reference. Use `auth.provider` to bind the plugin’s mounted routes to a named request-auth provider. Upstream auth belongs in `spec.connections.<name>.auth`. |
 | `securitySchemes` | map[string]HTTPSecurityScheme | Named hosted HTTP security schemes referenced by `spec.http.<name>.security`. |
 | `http` | map[string]HTTPBinding | Optional hosted HTTP bindings layered on top of operations. Each binding mounts under the plugin prefix and targets an operation ID. |
 | `mcp` | bool | When true, the plugin exposes its operations as MCP tools. |

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1769,59 +1769,6 @@ func cloneAuthValue(src AuthValueDef) AuthValueDef {
 	return dst
 }
 
-func EffectivePluginConnectionDef(plugin *ProviderEntry) ConnectionDef {
-	conn := ConnectionDef{}
-	if plugin != nil {
-		override := &ConnectionDef{
-			Mode:             plugin.ConnectionMode,
-			ConnectionParams: plugin.ConnectionParams,
-		}
-		if plugin.Auth != nil {
-			override.Auth = *plugin.Auth
-		}
-		MergeConnectionDef(&conn, override)
-	}
-	return conn
-}
-
-func EffectiveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *providermanifestv1.Spec, name string) (ConnectionDef, bool) {
-	conn := ConnectionDef{}
-	found := false
-
-	if manifestPlugin != nil && manifestPlugin.Connections != nil {
-		if def, ok := manifestPlugin.Connections[name]; ok && def != nil {
-			found = true
-			conn.DisplayName = def.DisplayName
-			if def.Mode != "" {
-				conn.Mode = def.Mode
-			}
-			if def.Exposure != "" {
-				conn.Exposure = def.Exposure
-			}
-			if def.Auth != nil {
-				MergeConnectionAuth(&conn.Auth, ManifestAuthToConnectionAuthDef(def.Auth))
-			}
-			if len(def.Params) > 0 {
-				conn.ConnectionParams = maps.Clone(def.Params)
-			}
-			if def.Discovery != nil {
-				conn.Discovery = def.Discovery
-			}
-		}
-	}
-	if plugin != nil {
-		if def, ok := plugin.Connections[name]; ok {
-			found = true
-			MergeConnectionDef(&conn, def)
-		}
-	}
-
-	if found {
-		return conn, true
-	}
-	return ConnectionDef{}, false
-}
-
 // OperationOverride holds optional alias and description for an allowed operation.
 type OperationOverride = providermanifestv1.ManifestOperationOverride
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -660,7 +660,7 @@ func ValidateResolvedStructure(cfg *Config) error {
 		if entry == nil {
 			return fmt.Errorf("config validation: integration %q requires a source", name)
 		}
-		if err := validateManifestBackedIntegration(name, entry); err != nil {
+		if err := validatePluginIntegrationConnections(name, entry); err != nil {
 			return err
 		}
 		if strings.TrimSpace(entry.MountPath) == "" || strings.TrimSpace(entry.UI) != "" {
@@ -842,7 +842,7 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 	if _, err := cfg.EffectiveHostedRuntime("plugins."+name, entry); err != nil {
 		return err
 	}
-	return validateManifestBackedIntegration(name, entry)
+	return validatePluginIntegrationConnections(name, entry)
 }
 
 func validatePluginRouteAuth(cfg *Config, name string, entry *ProviderEntry) error {
@@ -1912,38 +1912,14 @@ func pluginOwnedUIBindings(cfg *Config) map[string]struct{} {
 	return refs
 }
 
-func validateExecutableConnectionAuthSupport(name string, plan *StaticConnectionPlan, plugin *ProviderEntry, provider *providermanifestv1.Spec) error {
-	supportsMCPOAuth := false
-	if plan != nil {
-		_, supportsMCPOAuth = plan.ResolvedSurface(SpecSurfaceMCP)
-		if conn := plan.PluginConnection(); conn.Auth.Type == providermanifestv1.AuthTypeMCPOAuth && !supportsMCPOAuth {
-			return fmt.Errorf("config validation: integration %q plugin auth type %q requires an MCP surface", name, providermanifestv1.AuthTypeMCPOAuth)
-		}
-		for _, connName := range plan.NamedConnectionNames() {
-			conn, _ := plan.NamedConnectionDef(connName)
-			if conn.Auth.Type != providermanifestv1.AuthTypeMCPOAuth {
-				continue
-			}
-			if !supportsMCPOAuth {
-				return fmt.Errorf("config validation: integration %q connection %q auth type %q requires an MCP surface", name, connName, providermanifestv1.AuthTypeMCPOAuth)
-			}
-		}
-		return nil
-	}
-
-	supportsMCPOAuth = provider != nil && provider.MCPURL() != ""
-	if conn := EffectivePluginConnectionDef(plugin); conn.Auth.Type == providermanifestv1.AuthTypeMCPOAuth && !supportsMCPOAuth {
+func validateExecutableConnectionAuthSupport(name string, plan StaticConnectionPlan) error {
+	_, supportsMCPOAuth := plan.ResolvedSurface(SpecSurfaceMCP)
+	if conn := plan.PluginConnection(); conn.Auth.Type == providermanifestv1.AuthTypeMCPOAuth && !supportsMCPOAuth {
 		return fmt.Errorf("config validation: integration %q plugin auth type %q requires an MCP surface", name, providermanifestv1.AuthTypeMCPOAuth)
 	}
-
-	names := make([]string, 0, len(namedConnectionNames(plugin, provider)))
-	for connName := range namedConnectionNames(plugin, provider) {
-		names = append(names, connName)
-	}
-	sort.Strings(names)
-	for _, connName := range names {
-		conn, ok := EffectiveNamedConnectionDef(plugin, provider, connName)
-		if !ok || conn.Auth.Type != providermanifestv1.AuthTypeMCPOAuth {
+	for _, connName := range plan.NamedConnectionNames() {
+		conn, _ := plan.NamedConnectionDef(connName)
+		if conn.Auth.Type != providermanifestv1.AuthTypeMCPOAuth {
 			continue
 		}
 		if !supportsMCPOAuth {
@@ -1953,48 +1929,23 @@ func validateExecutableConnectionAuthSupport(name string, plan *StaticConnection
 	return nil
 }
 
-func validateManifestBackedIntegration(name string, entry *ProviderEntry) error {
+func validatePluginIntegrationConnections(name string, entry *ProviderEntry) error {
 	if entry == nil {
 		return nil
 	}
 	effectiveProvider := entry.ManifestSpec()
-	var plan *StaticConnectionPlan
-	if effectiveProvider != nil {
-		resolvedPlan, err := BuildStaticConnectionPlan(entry, effectiveProvider)
-		if err != nil {
-			return fmt.Errorf("config validation: integration %q %w", name, err)
-		}
-		plan = &resolvedPlan
+	plan, err := BuildStaticConnectionPlan(entry, effectiveProvider)
+	if err != nil {
+		return fmt.Errorf("config validation: integration %q %w", name, err)
 	}
-	if err := validateExecutableConnectionAuthSupport(name, plan, entry, effectiveProvider); err != nil {
+	if err := validateExecutableConnectionAuthSupport(name, plan); err != nil {
 		return err
 	}
-	pluginConnection := EffectivePluginConnectionDef(entry)
-	if plan != nil {
-		pluginConnection = plan.PluginConnection()
-	}
-	if err := validateConnectionAuthMappings(name, pluginConnection.Auth, "plugin"); err != nil {
+	if err := validateConnectionAuthMappings(name, plan.PluginConnection().Auth, "plugin"); err != nil {
 		return err
 	}
-	if plan != nil {
-		for _, connName := range plan.NamedConnectionNames() {
-			conn, _ := plan.NamedConnectionDef(connName)
-			if err := validateConnectionAuthMappings(name, conn.Auth, fmt.Sprintf("connection %q", connName)); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-	names := make([]string, 0, len(namedConnectionNames(entry, effectiveProvider)))
-	for connName := range namedConnectionNames(entry, effectiveProvider) {
-		names = append(names, connName)
-	}
-	sort.Strings(names)
-	for _, connName := range names {
-		conn, ok := EffectiveNamedConnectionDef(entry, effectiveProvider, connName)
-		if !ok {
-			continue
-		}
+	for _, connName := range plan.NamedConnectionNames() {
+		conn, _ := plan.NamedConnectionDef(connName)
 		if err := validateConnectionAuthMappings(name, conn.Auth, fmt.Sprintf("connection %q", connName)); err != nil {
 			return err
 		}

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -520,7 +520,17 @@ func namedConnectionNames(plugin *ProviderEntry, manifestPlugin *providermanifes
 }
 
 func ResolvePluginConnectionDef(plugin *ProviderEntry) ResolvedConnectionDef {
-	conn := EffectivePluginConnectionDef(plugin)
+	conn := ConnectionDef{}
+	if plugin != nil {
+		override := &ConnectionDef{
+			Mode:             plugin.ConnectionMode,
+			ConnectionParams: plugin.ConnectionParams,
+		}
+		if plugin.Auth != nil {
+			override.Auth = *plugin.Auth
+		}
+		MergeConnectionDef(&conn, override)
+	}
 	conn.Mode = providermanifestv1.ConnectionMode(ConnectionModeForConnection(conn))
 	conn.Exposure = providermanifestv1.ConnectionExposure(ConnectionExposureForConnection(conn))
 	source := ResolvedConnectionSource{

--- a/sdk/rust/src/api.rs
+++ b/sdk/rust/src/api.rs
@@ -44,7 +44,7 @@ pub struct Access {
 #[derive(Clone, Debug, Default, PartialEq)]
 /// Carries execution-scoped metadata into typed operation handlers.
 pub struct Request {
-    /// Request token used by legacy operation handlers.
+    /// Request token supplied to hosted HTTP operation handlers.
     pub token: String,
     /// Connection parameters resolved by the host.
     pub connection_params: BTreeMap<String, String>,


### PR DESCRIPTION
## Summary
- Remove the old no-plan connection validation fallback and validate every plugin through `BuildStaticConnectionPlan`.
- Delete the duplicate `EffectivePluginConnectionDef` / `EffectiveNamedConnectionDef` helpers.
- Remove stale docs/comments that described `spec.auth` and Rust request tokens as legacy behavior.

## Contract diff
```diff
- validateExecutableConnectionAuthSupport(name, maybePlan, plugin, manifest)
-   if maybePlan == nil:
-     recompute plugin and named connection auth from deploy/manifest structs
-   else:
-     use StaticConnectionPlan
+ validateExecutableConnectionAuthSupport(name, plan)
+   always use StaticConnectionPlan
+
- EffectivePluginConnectionDef(plugin) ConnectionDef
- EffectiveNamedConnectionDef(plugin, manifest, name) (ConnectionDef, bool)
+ ResolvePluginConnectionDef(plugin) ResolvedConnectionDef
+ ResolveNamedConnectionDef(plugin, manifest, name) (ResolvedConnectionDef, bool, error)
```

## Example
```go
plan, err := config.BuildStaticConnectionPlan(entry, entry.ManifestSpec())
if err != nil {
    return err
}
conn, ok := plan.NamedConnectionDef("default")
```

## Verification
- `go test ./internal/config -count=1`
- `go test ./internal/bootstrap -run TestClientCredentialsTokenSourceFetchTimeoutReleasesFlight -count=1`
- `go test ./internal/bootstrap -count=1`
- `go test ./internal/...` was also run; it hit a one-off timeout in `TestClientCredentialsTokenSourceFetchTimeoutReleasesFlight`, which passed on direct rerun. Other reported internal packages passed.
