### PR TITLE
Skip no-op secrets provider metadata resolution

### DIFF
--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1666,6 +1666,41 @@ plugins:
 			t.Fatalf("telemetry path = %q, want empty", cfg.Providers.Telemetry["default"].Source.Path)
 		}
 	})
+
+	t.Run("apiVersion preserves package host provider sources", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v5
+server:
+  encryptionKey: server-key
+providers:
+  secrets:
+    default:
+      source:
+        repo: valon
+        package: github.com/valon-technologies/gestalt-providers/secrets/google
+        version: 0.0.1-alpha.2
+      config:
+        project: test-project
+plugins:
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		source := cfg.Providers.Secrets["default"].Source
+		if source.Builtin != "" {
+			t.Fatalf("secrets builtin = %q, want empty", source.Builtin)
+		}
+		if !source.IsPackage() {
+			t.Fatalf("secrets source should remain package-backed: %#v", source)
+		}
+		if got := source.PackageAddress(); got != "github.com/valon-technologies/gestalt-providers/secrets/google" {
+			t.Fatalf("secrets package = %q, want google secrets package", got)
+		}
+	})
 }
 
 func TestLoadConfigUIEntries(t *testing.T) {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -772,6 +772,13 @@ func (l *Lifecycle) resolveSecretsProviderMetadata(ctx context.Context, name str
 	if l.configSecretResolver == nil || provider == nil {
 		return nil
 	}
+	deps, err := secretsProviderMetadataDependencies(name, provider)
+	if err != nil {
+		return err
+	}
+	if len(deps) == 0 {
+		return nil
+	}
 	secrets := make(map[string]*config.ProviderEntry, len(available)+1)
 	for availableName, entry := range available {
 		secrets[availableName] = entry

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3083,6 +3083,26 @@ func TestLockMatchesConfig_FalseWithNilLock(t *testing.T) {
 	}
 }
 
+func TestResolveSecretsProviderMetadataSkipsResolverWithoutMetadataDependencies(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	lc := NewLifecycle().WithConfigSecretResolver(func(context.Context, *config.Config) error {
+		called = true
+		return fmt.Errorf("resolver should not be called")
+	})
+	provider := &config.ProviderEntry{
+		Source: config.NewMetadataSource("https://example.invalid/github-com-testowner-providers-secrets/v0.0.1-alpha.1/provider-release.yaml"),
+	}
+
+	if err := lc.resolveSecretsProviderMetadata(context.Background(), "secrets", provider, nil); err != nil {
+		t.Fatalf("resolveSecretsProviderMetadata: %v", err)
+	}
+	if called {
+		t.Fatal("config secret resolver was called for provider metadata without secret dependencies")
+	}
+}
+
 func TestLockMatchesConfig_RemoteS3UsesResourceNameFingerprint(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- preserve package-backed host provider sources when applying default builtin providers
- skip secrets provider metadata resolution when the provider has no metadata secret dependencies
- avoid bootstrapping source-backed secrets providers before they have been materialized

## Test plan
- [x] go test ./internal/config ./internal/operator -run 'TestLoadConfigDefaultsAndEnv/apiVersion_preserves_package_host_provider_sources|TestResolveSecretsProviderMetadataSkipsResolverWithoutMetadataDependencies|TestLoadForExecutionAtPath_UnlockedMetadataSecretsProviderResolvesConfigSecrets'