### PR TITLE
Remove config v4 compatibility

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -44,9 +44,7 @@ const (
 
 const PluginConnectionName = core.PluginConnectionName
 const PluginConnectionAlias = core.PluginConnectionAlias
-const ConfigAPIVersionV4 = "gestaltd.config/v4"
-const ConfigAPIVersionV5 = "gestaltd.config/v5"
-const ConfigAPIVersion = ConfigAPIVersionV5
+const ConfigAPIVersion = "gestaltd.config/v5"
 
 type Config struct {
 	APIVersion           string                              `yaml:"apiVersion,omitempty"`
@@ -2140,7 +2138,7 @@ func validateConfigRootAPIVersion(root yaml.Node) error {
 	if value == "" {
 		return requiredAPIVersionError()
 	}
-	if value != ConfigAPIVersionV4 && value != ConfigAPIVersionV5 {
+	if value != ConfigAPIVersion {
 		return fmt.Errorf("config validation: unsupported apiVersion %q", value)
 	}
 	return nil
@@ -2664,11 +2662,6 @@ func normalizeProviderSource(kind string, source *ProviderSource) {
 	if source.scalar == "" {
 		return
 	}
-	if kind == providermanifestv1.KindExternalCredentials && source.scalar == "local" {
-		source.Builtin = source.scalar
-		source.scalar = ""
-		return
-	}
 	switch {
 	case isBuiltinScalarSource(kind, source.scalar):
 		source.Builtin = source.scalar
@@ -2930,6 +2923,7 @@ func resolveRelativePathsInValue(configPath string, root map[string]any) {
 		}{
 			{key: "authentication", kind: providermanifestv1.KindAuthentication},
 			{key: "authorization", kind: providermanifestv1.KindAuthorization},
+			{key: "externalCredentials", kind: providermanifestv1.KindExternalCredentials},
 			{key: "secrets", kind: providermanifestv1.KindSecrets},
 			{key: "telemetry", kind: string(HostProviderKindTelemetry)},
 			{key: "audit", kind: string(HostProviderKindAudit)},
@@ -3031,6 +3025,9 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 	for _, entry := range cfg.Providers.Authorization {
 		resolveEntry(entry)
 	}
+	for _, entry := range cfg.Providers.ExternalCredentials {
+		resolveEntry(entry)
+	}
 	for _, entry := range cfg.Providers.Secrets {
 		resolveEntry(entry)
 	}
@@ -3046,6 +3043,9 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 		}
 	}
 	for _, entry := range cfg.Providers.IndexedDB {
+		resolveEntry(entry)
+	}
+	for _, entry := range cfg.Providers.Cache {
 		resolveEntry(entry)
 	}
 	for _, entry := range cfg.Providers.S3 {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2111,7 +2111,7 @@ server:
 		}
 	})
 
-	t.Run("local external credentials source is rejected", func(t *testing.T) {
+	t.Run("external credentials scalar local source is a path", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -2131,12 +2131,12 @@ server:
   encryptionKey: server-key
 `)
 
-		_, err := Load(path)
-		if err == nil {
-			t.Fatal("Load: expected error, got nil")
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
 		}
-		if !strings.Contains(err.Error(), `externalCredentials provider "default" does not support builtin providers`) {
-			t.Fatalf("unexpected error: %v", err)
+		if got := cfg.Providers.ExternalCredentials["default"].SourcePath(); got != filepath.Join(filepath.Dir(path), "local") {
+			t.Fatalf("externalCredentials source path = %q, want local path", got)
 		}
 	})
 }
@@ -3950,8 +3950,8 @@ plugins:
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if got := cfg.APIVersion; got != ConfigAPIVersionV5 {
-		t.Fatalf("APIVersion = %q, want %q", got, ConfigAPIVersionV5)
+	if got := cfg.APIVersion; got != ConfigAPIVersion {
+		t.Fatalf("APIVersion = %q, want %q", got, ConfigAPIVersion)
 	}
 	if got := cfg.ProviderRepositories["local"].URL; got != "https://providers.example.test/index.yaml" {
 		t.Fatalf("providerRepositories.local.url = %q", got)
@@ -4026,7 +4026,7 @@ providers:
 	}
 }
 
-func TestLoadConfigProviderPackageSourcesRequireV5(t *testing.T) {
+func TestLoadConfigProviderPackageSourceValidation(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -4034,28 +4034,6 @@ func TestLoadConfigProviderPackageSourcesRequireV5(t *testing.T) {
 		yaml string
 		want string
 	}{
-		{
-			name: "v4 rejects package source",
-			yaml: `
-apiVersion: gestaltd.config/v4
-plugins:
-  service:
-    source:
-      package: github.com/acme/providers/service
-`,
-			want: `source.package requires apiVersion "gestaltd.config/v5"`,
-		},
-		{
-			name: "v4 rejects provider repositories",
-			yaml: `
-apiVersion: gestaltd.config/v4
-providerRepositories:
-  local:
-    url: https://providers.example.test/index.yaml
-plugins:
-`,
-			want: `providerRepositories requires apiVersion "gestaltd.config/v5"`,
-		},
 		{
 			name: "package and url are mutually exclusive",
 			yaml: `
@@ -4086,17 +4064,17 @@ plugins:
 	}
 }
 
-func TestLoadPathsProviderPackageSourceAPIVersionLayering(t *testing.T) {
+func TestLoadPathsProviderPackageSourceLayering(t *testing.T) {
 	t.Parallel()
 
-	t.Run("v5 overlay enables package source", func(t *testing.T) {
+	t.Run("overlay replaces metadata URL with package source", func(t *testing.T) {
 		t.Parallel()
 
 		dir := t.TempDir()
 		basePath := filepath.Join(dir, "base.yaml")
 		overridePath := filepath.Join(dir, "override.yaml")
 		if err := os.WriteFile(basePath, []byte(`
-apiVersion: gestaltd.config/v4
+apiVersion: gestaltd.config/v5
 plugins:
   service:
     source: https://example.com/service/provider-release.yaml
@@ -4121,41 +4099,11 @@ plugins:
 		if err != nil {
 			t.Fatalf("LoadPaths: %v", err)
 		}
-		if got := cfg.APIVersion; got != ConfigAPIVersionV5 {
-			t.Fatalf("APIVersion = %q, want %q", got, ConfigAPIVersionV5)
+		if got := cfg.APIVersion; got != ConfigAPIVersion {
+			t.Fatalf("APIVersion = %q, want %q", got, ConfigAPIVersion)
 		}
 		if !cfg.Plugins["service"].Source.IsPackage() {
 			t.Fatal("merged source is not package source")
-		}
-	})
-
-	t.Run("v4 overlay disables package source features", func(t *testing.T) {
-		t.Parallel()
-
-		dir := t.TempDir()
-		basePath := filepath.Join(dir, "base.yaml")
-		overridePath := filepath.Join(dir, "override.yaml")
-		if err := os.WriteFile(basePath, []byte(`
-apiVersion: gestaltd.config/v5
-plugins:
-  service:
-    source:
-      package: github.com/acme/providers/service
-`), 0o644); err != nil {
-			t.Fatalf("write base: %v", err)
-		}
-		if err := os.WriteFile(overridePath, []byte(`
-apiVersion: gestaltd.config/v4
-`), 0o644); err != nil {
-			t.Fatalf("write override: %v", err)
-		}
-
-		_, err := LoadPaths([]string{basePath, overridePath})
-		if err == nil {
-			t.Fatal("LoadPaths: expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), `source.package requires apiVersion "gestaltd.config/v5"`) {
-			t.Fatalf("LoadPaths error = %v, want package source apiVersion error", err)
 		}
 	})
 }

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -82,7 +82,7 @@ func ValidateCanonicalStructure(cfg *Config) error {
 	if err := validateTopLevelConnections(cfg); err != nil {
 		return err
 	}
-	if err := validateAPIVersionFeatures(cfg); err != nil {
+	if err := validateProviderRepositories(cfg); err != nil {
 		return err
 	}
 
@@ -182,7 +182,7 @@ func validateAPIVersion(cfg *Config) error {
 	// Config values may omit it and use current source normalization.
 	apiVersion := strings.TrimSpace(cfg.APIVersion)
 	switch apiVersion {
-	case "", ConfigAPIVersionV4, ConfigAPIVersionV5:
+	case "", ConfigAPIVersion:
 		return nil
 	default:
 		return fmt.Errorf("config validation: unsupported apiVersion %q", apiVersion)
@@ -190,16 +190,12 @@ func validateAPIVersion(cfg *Config) error {
 }
 
 func requiredAPIVersionError() error {
-	return fmt.Errorf("config validation: apiVersion is required; supported values are %q and %q", ConfigAPIVersionV4, ConfigAPIVersionV5)
+	return fmt.Errorf("config validation: apiVersion is required; supported value is %q", ConfigAPIVersion)
 }
 
-func validateAPIVersionFeatures(cfg *Config) error {
+func validateProviderRepositories(cfg *Config) error {
 	if cfg == nil {
 		return nil
-	}
-	v5 := strings.TrimSpace(cfg.APIVersion) == ConfigAPIVersionV5
-	if len(cfg.ProviderRepositories) > 0 && !v5 {
-		return fmt.Errorf("config validation: providerRepositories requires apiVersion %q", ConfigAPIVersionV5)
 	}
 	for name, repo := range cfg.ProviderRepositories {
 		if err := providerregistry.ValidateRepositoryName(name); err != nil {
@@ -207,52 +203,6 @@ func validateAPIVersionFeatures(cfg *Config) error {
 		}
 		if strings.TrimSpace(repo.URL) == "" {
 			return fmt.Errorf("config validation: providerRepositories.%s.url is required", name)
-		}
-	}
-	checkEntry := func(kind, name string, entry *ProviderEntry) error {
-		if entry == nil || !entry.Source.IsPackage() || v5 {
-			return nil
-		}
-		return fmt.Errorf("config validation: %s %q source.package requires apiVersion %q", kind, name, ConfigAPIVersionV5)
-	}
-	for name, entry := range cfg.Plugins {
-		if err := checkEntry("plugin", name, entry); err != nil {
-			return err
-		}
-	}
-	for _, collection := range []struct {
-		kind    HostProviderKind
-		entries map[string]*ProviderEntry
-	}{
-		{HostProviderKindAuthentication, cfg.Providers.Authentication},
-		{HostProviderKindAuthorization, cfg.Providers.Authorization},
-		{HostProviderKindExternalCredentials, cfg.Providers.ExternalCredentials},
-		{HostProviderKindSecrets, cfg.Providers.Secrets},
-		{HostProviderKindTelemetry, cfg.Providers.Telemetry},
-		{HostProviderKindAudit, cfg.Providers.Audit},
-		{HostProviderKindIndexedDB, cfg.Providers.IndexedDB},
-		{HostProviderKindCache, cfg.Providers.Cache},
-		{HostProviderKindWorkflow, cfg.Providers.Workflow},
-		{HostProviderKindAgent, cfg.Providers.Agent},
-	} {
-		for name, entry := range collection.entries {
-			if err := checkEntry(string(collection.kind), name, entry); err != nil {
-				return err
-			}
-		}
-	}
-	for name, entry := range cfg.Runtime.Providers {
-		if entry != nil {
-			if err := checkEntry("runtime", name, &entry.ProviderEntry); err != nil {
-				return err
-			}
-		}
-	}
-	for name, entry := range cfg.Providers.UI {
-		if entry != nil {
-			if err := checkEntry("ui", name, &entry.ProviderEntry); err != nil {
-				return err
-			}
 		}
 	}
 	return nil

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -117,7 +117,7 @@ func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
 	}
 }
 
-func TestE2EValidateAcceptsV3TelemetryBuiltins(t *testing.T) {
+func TestE2EValidateAcceptsTelemetryBuiltins(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -96,7 +96,7 @@ func TestE2EProviderAddPackageSourceUpdatesConfig(t *testing.T) {
 
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("apiVersion: gestaltd.config/v4\nplugins:\n"), 0o644); err != nil {
+	if err := os.WriteFile(cfgPath, []byte("apiVersion: gestaltd.config/v5\nplugins:\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	indexPath := filepath.Join(dir, "provider-index.yaml")
@@ -121,7 +121,7 @@ packages:
 	if err != nil {
 		t.Fatalf("provider repo add failed: %v\n%s", err, out)
 	}
-	out, err = exec.Command(gestaltdBin, "provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--package-source", "--no-lock").CombinedOutput()
+	out, err = exec.Command(gestaltdBin, "provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--no-lock").CombinedOutput()
 	if err != nil {
 		t.Fatalf("provider add failed: %v\n%s", err, out)
 	}
@@ -130,8 +130,8 @@ packages:
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if got := cfg.APIVersion; got != config.ConfigAPIVersionV5 {
-		t.Fatalf("APIVersion = %q, want %q", got, config.ConfigAPIVersionV5)
+	if got := cfg.APIVersion; got != config.ConfigAPIVersion {
+		t.Fatalf("APIVersion = %q, want %q", got, config.ConfigAPIVersion)
 	}
 	if got := cfg.ProviderRepositories["local"].URL; got != indexURL {
 		t.Fatalf("providerRepositories.local.url = %q, want %q", got, indexURL)

--- a/gestaltd/internal/daemon/provider_registry.go
+++ b/gestaltd/internal/daemon/provider_registry.go
@@ -283,7 +283,6 @@ func runProviderAdd(args []string) error {
 	noLock := fs.Bool("no-lock", false, "do not update lockfile")
 	sync := fs.Bool("sync", false, "materialize prepared artifacts after locking")
 	exactSource := fs.Bool("exact-source", false, "write resolved provider-release metadata URL instead of package source")
-	packageSource := fs.Bool("package-source", false, "upgrade v4 config and write package source")
 	dryRun := fs.Bool("dry-run", false, "print resolved package without editing")
 	fs.Var(&configPaths, "config", "path to config file")
 	fs.Var(&setFlags, "set", "set shallow entry field, e.g. path=/ui")
@@ -324,15 +323,11 @@ func runProviderAdd(args []string) error {
 		fmt.Printf("%s\t%s\t%s\t%s\n", resolved.Package, resolved.Version, resolved.Kind, resolved.MetadataURL)
 		return nil
 	}
-	apiVersion := config.ConfigAPIVersionV4
+	apiVersion := config.ConfigAPIVersion
 	if cfg != nil && strings.TrimSpace(cfg.APIVersion) != "" {
 		apiVersion = strings.TrimSpace(cfg.APIVersion)
 	}
-	writePackageSource := apiVersion == config.ConfigAPIVersionV5 && !*exactSource
-	if *packageSource {
-		writePackageSource = true
-		apiVersion = config.ConfigAPIVersionV5
-	}
+	writePackageSource := !*exactSource
 	entryKind := providermanifestv1.NormalizeKind(*kind)
 	if entryKind == "" {
 		entryKind = resolved.Kind
@@ -509,7 +504,7 @@ func editProjectProviderRepository(path, name, repoURL string, dryRun bool) erro
 	if err != nil {
 		return err
 	}
-	setScalar(doc, "apiVersion", config.ConfigAPIVersionV5)
+	setScalar(doc, "apiVersion", config.ConfigAPIVersion)
 	repos := ensureMapping(doc, "providerRepositories")
 	repoNode := yamlMapping(map[string]any{"url": repoURL})
 	setNode(repos, name, repoNode)

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -873,7 +873,7 @@ packages:
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := strings.Join([]string{
-		"apiVersion: " + config.ConfigAPIVersionV5,
+		"apiVersion: " + config.ConfigAPIVersion,
 		"providerRepositories:",
 		"  local:",
 		"    url: " + srv.URL + indexPath,
@@ -1099,7 +1099,7 @@ func TestSourceProviderPackagesResolveIndexedDBAndS3(t *testing.T) {
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	configYAML := strings.Join([]string{
-		"apiVersion: " + config.ConfigAPIVersionV5,
+		"apiVersion: " + config.ConfigAPIVersion,
 		"providerRepositories:",
 		"  local:",
 		"    url: " + srv.URL + indexPath,


### PR DESCRIPTION
## Summary
- remove `gestaltd.config/v4` as an accepted config API version
- remove the leftover `ConfigAPIVersionV5` alias so there is only `ConfigAPIVersion`
- remove v4/v5 feature gating for package sources and provider repositories
- make `gestalt provider add` write v5/package-source config by default unless `--exact-source` is requested
- remove the now-redundant `--package-source` flag
- remove the external credentials `source: local` migration-era rejection path; scalar local sources now behave like normal local provider paths
- include `providers.externalCredentials` and `providers.cache` in typed and untyped config-relative path resolution
- remove stale v3/v4 wording from daemon tests and provider-add help text

## Config contract diff
```diff
- apiVersion: gestaltd.config/v4
  apiVersion: gestaltd.config/v5

- const ConfigAPIVersionV5 = "gestaltd.config/v5"
- const ConfigAPIVersion = ConfigAPIVersionV5
+ const ConfigAPIVersion = "gestaltd.config/v5"

- source.package requires apiVersion: gestaltd.config/v5
+ source.package is part of the only supported config version

- providerRepositories requires apiVersion: gestaltd.config/v5
+ providerRepositories is part of the only supported config version

- gestaltd provider add --package-source
+ gestaltd provider add
+ # writes package-source entries by default

- providers.externalCredentials.<name>.source: local
- # classified as a fake builtin, then rejected
+ providers.externalCredentials.<name>.source: local
+ # classified and resolved as a local provider path, like other non-builtin providers
```

## Example
```yaml
apiVersion: gestaltd.config/v5
providerRepositories:
  valon:
    url: https://providers.valon.tools/index.yaml
providers:
  externalCredentials:
    default:
      source: ./providers/external-credentials/default
plugins:
  github:
    source:
      package: github.com/valon-technologies/gestalt-providers/github
```

`gestalt provider add github --source github.com/valon-technologies/gestalt-providers/github` now keeps this package-source form by default. `--exact-source` still writes the resolved metadata URL when a pinned URL is intentionally needed.

## Verification
- `go test ./internal/config`
- `go test ./internal/config ./internal/daemon`
- `go test ./internal/config ./internal/daemon ./internal/operator -run '^$'`\n- `go test ./internal/daemon -run TestE2EProviderAddPackageSourceUpdatesConfig`\n- `go test ./internal/daemon -run TestE2EValidateAcceptsTelemetryBuiltins`\n- `rg -n "V3Telemetry|upgrade v4|source.scalar == \\\"local\\\"|local external credentials source is rejected|ConfigAPIVersionV[0-9]|gestaltd\\.config/v4|validateAPIVersionFeatures|requires apiVersion \\\"gestaltd.config/v5\\\"|providerRepositories requires apiVersion" gestaltd/internal docs/content`