### PR TITLE
Add provider lifecycle CLI UX

### DIFF
--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -44,7 +44,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "provider",
 			args:      []string{"provider", "--help"},
-			wantParts: []string{"gestaltd provider <command> [flags]", "add", "attach", "dev", "info", "remove", "repo", "search", "upgrade", "validate", "release"},
+			wantParts: []string{"gestaltd provider <command> [flags]", "add", "attach", "dev", "info", "list", "remove", "repo", "search", "upgrade", "validate", "release"},
 		},
 		{
 			name:      "provider repo",

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -38,6 +38,8 @@ func runProvider(args []string) error {
 		return runProviderDev(args[1:])
 	case "info":
 		return runProviderInfo(args[1:])
+	case "list":
+		return runProviderList(args[1:])
 	case "remove":
 		return runProviderRemove(args[1:])
 	case "repo":
@@ -621,6 +623,7 @@ func printProviderUsage(w io.Writer) {
 	writeUsageLine(w, "  add         Add a provider package to config and update lock state")
 	writeUsageLine(w, "  dev         Run a local source plugin inside a synthesized Gestalt config")
 	writeUsageLine(w, "  info        Show provider package metadata from configured repositories")
+	writeUsageLine(w, "  list        List configured providers and lock status")
 	writeUsageLine(w, "  release     Build provider release archives")
 	writeUsageLine(w, "  remove      Remove a provider entry from config and update lock state")
 	writeUsageLine(w, "  repo        Manage provider package repositories")

--- a/gestaltd/internal/daemon/provider_lifecycle.go
+++ b/gestaltd/internal/daemon/provider_lifecycle.go
@@ -1,0 +1,600 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"gopkg.in/yaml.v3"
+)
+
+type providerLifecycleKind struct {
+	kind         string
+	manifestKind string
+	collection   func(*yaml.Node) *yaml.Node
+	entryMap     func(*config.Config) map[string]*config.ProviderEntry
+	lockEntries  func(*operator.Lockfile) map[string]operator.LockEntry
+}
+
+type providerLifecycleRow struct {
+	Kind          string
+	Name          string
+	Entry         *config.ProviderEntry
+	Source        string
+	Package       string
+	Version       string
+	LockedVersion string
+	Status        string
+}
+
+type providerMutationResult struct {
+	ConfigPath   string
+	LockfilePath string
+	LockWritten  bool
+}
+
+var providerLifecycleKinds = []providerLifecycleKind{
+	{
+		kind:         providermanifestv1.KindPlugin,
+		manifestKind: providermanifestv1.KindPlugin,
+		collection:   func(doc *yaml.Node) *yaml.Node { return mappingValueNodeLocal(doc, "plugins") },
+		entryMap: func(cfg *config.Config) map[string]*config.ProviderEntry {
+			if cfg == nil {
+				return nil
+			}
+			return cfg.Plugins
+		},
+		lockEntries: func(lock *operator.Lockfile) map[string]operator.LockEntry {
+			if lock == nil {
+				return nil
+			}
+			return lock.Providers
+		},
+	},
+	lifecycleHostProviderKind(providermanifestv1.KindAuthentication, providermanifestv1.KindAuthentication),
+	lifecycleHostProviderKind(providermanifestv1.KindAuthorization, providermanifestv1.KindAuthorization),
+	lifecycleHostProviderKind(providermanifestv1.KindExternalCredentials, providermanifestv1.KindExternalCredentials),
+	lifecycleHostProviderKind(providermanifestv1.KindSecrets, providermanifestv1.KindSecrets),
+	lifecycleHostProviderKind(string(config.HostProviderKindTelemetry), providermanifestv1.KindPlugin),
+	lifecycleHostProviderKind(string(config.HostProviderKindAudit), providermanifestv1.KindPlugin),
+	lifecycleHostProviderKind(providermanifestv1.KindIndexedDB, providermanifestv1.KindIndexedDB),
+	lifecycleHostProviderKind(providermanifestv1.KindCache, providermanifestv1.KindCache),
+	lifecycleHostProviderKind(providermanifestv1.KindS3, providermanifestv1.KindS3),
+	lifecycleHostProviderKind(providermanifestv1.KindWorkflow, providermanifestv1.KindWorkflow),
+	lifecycleHostProviderKind(providermanifestv1.KindAgent, providermanifestv1.KindAgent),
+	{
+		kind:         providermanifestv1.KindRuntime,
+		manifestKind: providermanifestv1.KindRuntime,
+		collection: func(doc *yaml.Node) *yaml.Node {
+			return mappingValueNodeLocal(mappingValueNodeLocal(doc, "runtime"), "providers")
+		},
+		entryMap: func(cfg *config.Config) map[string]*config.ProviderEntry {
+			if cfg == nil || cfg.Runtime.Providers == nil {
+				return nil
+			}
+			entries := make(map[string]*config.ProviderEntry, len(cfg.Runtime.Providers))
+			for name, entry := range cfg.Runtime.Providers {
+				if entry != nil {
+					entries[name] = &entry.ProviderEntry
+				}
+			}
+			return entries
+		},
+		lockEntries: func(lock *operator.Lockfile) map[string]operator.LockEntry {
+			if lock == nil {
+				return nil
+			}
+			return lock.Runtimes
+		},
+	},
+	{
+		kind:         providermanifestv1.KindUI,
+		manifestKind: providermanifestv1.KindUI,
+		collection: func(doc *yaml.Node) *yaml.Node {
+			return mappingValueNodeLocal(mappingValueNodeLocal(doc, "providers"), "ui")
+		},
+		entryMap: func(cfg *config.Config) map[string]*config.ProviderEntry {
+			if cfg == nil || cfg.Providers.UI == nil {
+				return nil
+			}
+			entries := make(map[string]*config.ProviderEntry, len(cfg.Providers.UI))
+			for name, entry := range cfg.Providers.UI {
+				if entry != nil {
+					entries[name] = &entry.ProviderEntry
+				}
+			}
+			return entries
+		},
+		lockEntries: func(lock *operator.Lockfile) map[string]operator.LockEntry {
+			if lock == nil {
+				return nil
+			}
+			return lock.UIs
+		},
+	},
+}
+
+func lifecycleHostProviderKind(kind, manifestKind string) providerLifecycleKind {
+	return providerLifecycleKind{
+		kind:         kind,
+		manifestKind: manifestKind,
+		collection: func(doc *yaml.Node) *yaml.Node {
+			return mappingValueNodeLocal(mappingValueNodeLocal(doc, "providers"), configKindKey(kind))
+		},
+		entryMap: func(cfg *config.Config) map[string]*config.ProviderEntry {
+			if cfg == nil {
+				return nil
+			}
+			switch kind {
+			case providermanifestv1.KindAuthentication:
+				return cfg.Providers.Authentication
+			case providermanifestv1.KindAuthorization:
+				return cfg.Providers.Authorization
+			case providermanifestv1.KindExternalCredentials:
+				return cfg.Providers.ExternalCredentials
+			case providermanifestv1.KindSecrets:
+				return cfg.Providers.Secrets
+			case string(config.HostProviderKindTelemetry):
+				return cfg.Providers.Telemetry
+			case string(config.HostProviderKindAudit):
+				return cfg.Providers.Audit
+			case providermanifestv1.KindIndexedDB:
+				return cfg.Providers.IndexedDB
+			case providermanifestv1.KindCache:
+				return cfg.Providers.Cache
+			case providermanifestv1.KindS3:
+				return cfg.Providers.S3
+			case providermanifestv1.KindWorkflow:
+				return cfg.Providers.Workflow
+			case providermanifestv1.KindAgent:
+				return cfg.Providers.Agent
+			default:
+				return nil
+			}
+		},
+		lockEntries: func(lock *operator.Lockfile) map[string]operator.LockEntry {
+			if lock == nil {
+				return nil
+			}
+			switch kind {
+			case providermanifestv1.KindAuthentication:
+				return lock.Authentication
+			case providermanifestv1.KindAuthorization:
+				return lock.Authorization
+			case providermanifestv1.KindExternalCredentials:
+				return lock.ExternalCredentials
+			case providermanifestv1.KindSecrets:
+				return lock.Secrets
+			case string(config.HostProviderKindTelemetry):
+				return lock.Telemetry
+			case string(config.HostProviderKindAudit):
+				return lock.Audit
+			case providermanifestv1.KindIndexedDB:
+				return lock.IndexedDBs
+			case providermanifestv1.KindCache:
+				return lock.Caches
+			case providermanifestv1.KindS3:
+				return lock.S3
+			case providermanifestv1.KindWorkflow:
+				return lock.Workflows
+			case providermanifestv1.KindAgent:
+				return lock.Agents
+			default:
+				return nil
+			}
+		},
+	}
+}
+
+func normalizeProviderLifecycleKind(kind string) string {
+	kind = providermanifestv1.NormalizeKind(kind)
+	switch strings.TrimSpace(strings.ToLower(kind)) {
+	case string(config.HostProviderKindTelemetry):
+		return string(config.HostProviderKindTelemetry)
+	case string(config.HostProviderKindAudit):
+		return string(config.HostProviderKindAudit)
+	default:
+		return kind
+	}
+}
+
+func providerLifecycleKindFor(kind string) (providerLifecycleKind, bool) {
+	kind = normalizeProviderLifecycleKind(kind)
+	for _, candidate := range providerLifecycleKinds {
+		if candidate.kind == kind {
+			return candidate, true
+		}
+	}
+	return providerLifecycleKind{}, false
+}
+
+func requireProviderLifecycleKind(kind string) (providerLifecycleKind, error) {
+	if entryKind, ok := providerLifecycleKindFor(kind); ok {
+		return entryKind, nil
+	}
+	return providerLifecycleKind{}, fmt.Errorf("unknown provider kind %q", kind)
+}
+
+func printProviderRows(rows []providerLifecycleRow) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "KIND\tNAME\tSOURCE\tPACKAGE\tVERSION\tLOCKED\tSTATUS")
+	for _, row := range rows {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			row.Kind,
+			row.Name,
+			row.Source,
+			row.Package,
+			row.Version,
+			row.LockedVersion,
+			row.Status,
+		)
+	}
+	_ = w.Flush()
+}
+
+func providerLifecycleRows(cfg *config.Config, configPath string, lock *operator.Lockfile, kindFilter string) ([]providerLifecycleRow, error) {
+	if strings.TrimSpace(kindFilter) != "" {
+		if _, err := requireProviderLifecycleKind(kindFilter); err != nil {
+			return nil, err
+		}
+		kindFilter = normalizeProviderLifecycleKind(kindFilter)
+	}
+	rows := make([]providerLifecycleRow, 0)
+	for _, lifecycleKind := range providerLifecycleKinds {
+		if kindFilter != "" && lifecycleKind.kind != kindFilter {
+			continue
+		}
+		entries := lifecycleKind.entryMap(cfg)
+		names := make([]string, 0, len(entries))
+		for name := range entries {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		lockEntries := lifecycleKind.lockEntries(lock)
+		for _, name := range names {
+			entry := entries[name]
+			if entry == nil {
+				continue
+			}
+			lockEntry, found := lockEntries[name]
+			rows = append(rows, providerLifecycleRowFor(lifecycleKind, name, entry, configPath, lockEntry, found))
+		}
+	}
+	return rows, nil
+}
+
+func providerLifecycleRowFor(kind providerLifecycleKind, name string, entry *config.ProviderEntry, configPath string, lockEntry operator.LockEntry, lockFound bool) providerLifecycleRow {
+	row := providerLifecycleRow{
+		Kind:    kind.kind,
+		Name:    name,
+		Entry:   entry,
+		Source:  providerSourceKind(entry),
+		Status:  "unlocked",
+		Package: entry.Source.PackageAddress(),
+		Version: entry.Source.PackageVersionConstraint(),
+	}
+	if lockFound {
+		row.LockedVersion = lockEntry.Version
+	}
+	if entry.Source.IsBuiltin() {
+		row.Status = "builtin"
+		return row
+	}
+	if !providerSourceBacked(entry) {
+		return row
+	}
+	if operator.LockEntryMetadataMatchesProvider(configPath, kind.kind, name, entry, lockEntry, lockFound, kind.kind == providermanifestv1.KindUI) {
+		if entry.Source.IsPackage() && entry.Source.ResolvedPackageMetadataURL() == "" {
+			row.Status = "unverified"
+			return row
+		}
+		row.Status = "locked"
+	} else if lockFound {
+		row.Status = "drifted"
+	}
+	return row
+}
+
+func providerSourceKind(entry *config.ProviderEntry) string {
+	if entry == nil {
+		return ""
+	}
+	switch {
+	case entry.Source.IsPackage():
+		return "package"
+	case entry.Source.IsBuiltin():
+		return "builtin"
+	case entry.Source.IsMetadataURL():
+		return "metadata"
+	case entry.Source.IsGitHubRelease():
+		return "github"
+	case entry.Source.IsLocal(), entry.Source.IsLocalMetadataPath():
+		return "local"
+	case entry.Source.UnsupportedURL() != "":
+		return "unsupported"
+	default:
+		return ""
+	}
+}
+
+func providerSourceBacked(entry *config.ProviderEntry) bool {
+	return entry != nil && (entry.Source.IsPackage() || entry.Source.IsMetadataURL() || entry.Source.IsGitHubRelease() || entry.Source.IsLocal() || entry.Source.IsLocalMetadataPath())
+}
+
+func readProviderListLockfile(configPath, lockfilePath string) (*operator.Lockfile, error) {
+	path := resolveProviderLockfilePath(configPath, lockfilePath)
+	lock, err := operator.ReadLockfile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return lock, nil
+}
+
+func resolveProviderLockfilePath(configPath, lockfilePath string) string {
+	if strings.TrimSpace(lockfilePath) == "" {
+		return filepath.Join(filepath.Dir(configPath), operator.LockfileName)
+	}
+	if filepath.IsAbs(lockfilePath) {
+		return lockfilePath
+	}
+	if abs, err := filepath.Abs(lockfilePath); err == nil {
+		return abs
+	}
+	return lockfilePath
+}
+
+func resolveMutableProviderConfig(configPaths []string) (string, []string, error) {
+	if len(configPaths) > 1 {
+		return "", nil, fmt.Errorf("mutating provider commands accept only one --config; pass the intended writable config as the only --config")
+	}
+	paths := operator.ResolveConfigPaths(configPaths)
+	if len(paths) > 1 {
+		return "", nil, fmt.Errorf("mutating provider commands accept only one resolved config; pass the intended writable config as --config")
+	}
+	primary, err := ensurePrimaryProviderConfig(paths)
+	if err != nil {
+		return "", nil, err
+	}
+	return primary, []string{primary}, nil
+}
+
+func providerEntryExists(cfg *config.Config, kind, name string) bool {
+	lifecycleKind, ok := providerLifecycleKindFor(kind)
+	if !ok {
+		return false
+	}
+	_, exists := lifecycleKind.entryMap(cfg)[name]
+	return exists
+}
+
+type providerMutationPreflight struct {
+	ConfigPath string
+	Root       *yaml.Node
+	Lock       *operator.Lockfile
+	LockPath   string
+}
+
+func preflightProviderConfigMutation(configPath string, root *yaml.Node, lockfilePath string, noLock bool) (*providerMutationPreflight, error) {
+	data, err := configDocumentBytes(root)
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Dir(configPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	tempConfig, err := os.CreateTemp(dir, "."+filepath.Base(configPath)+".preflight-*")
+	if err != nil {
+		return nil, err
+	}
+	tempConfigPath := tempConfig.Name()
+	defer func() { _ = os.Remove(tempConfigPath) }()
+	if _, err := tempConfig.Write(data); err != nil {
+		_ = tempConfig.Close()
+		return nil, err
+	}
+	if err := tempConfig.Close(); err != nil {
+		return nil, err
+	}
+	if noLock {
+		if _, err := config.LoadAllowMissingEnvPaths([]string{tempConfigPath}); err != nil {
+			return nil, err
+		}
+		return &providerMutationPreflight{ConfigPath: configPath, Root: root}, nil
+	}
+	scratchDir, err := os.MkdirTemp("", "gestaltd-provider-preflight-*")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.RemoveAll(scratchDir) }()
+	scratchState := operator.StatePaths{
+		ArtifactsDir: filepath.Join(scratchDir, "artifacts"),
+		LockfilePath: filepath.Join(scratchDir, operator.LockfileName),
+	}
+	lock, err := operatorLifecycle().LockAtPathsWithStatePaths([]string{tempConfigPath}, scratchState)
+	if err != nil {
+		return nil, err
+	}
+	return &providerMutationPreflight{
+		ConfigPath: configPath,
+		Root:       root,
+		Lock:       lock,
+		LockPath:   resolveProviderLockfilePath(configPath, lockfilePath),
+	}, nil
+}
+
+func commitProviderConfigMutation(preflight *providerMutationPreflight) (providerMutationResult, error) {
+	if preflight == nil {
+		return providerMutationResult{}, fmt.Errorf("provider mutation preflight is required")
+	}
+	result := providerMutationResult{ConfigPath: preflight.ConfigPath}
+	configData, err := configDocumentBytes(preflight.Root)
+	if err != nil {
+		return result, err
+	}
+	previousConfig, readErr := os.ReadFile(preflight.ConfigPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return result, readErr
+	}
+	if err := writeFileAtomic(preflight.ConfigPath, configData, 0o600); err != nil {
+		return result, err
+	}
+	restoreConfig := func() error {
+		if readErr == nil {
+			return writeFileAtomic(preflight.ConfigPath, previousConfig, 0o600)
+		}
+		return os.Remove(preflight.ConfigPath)
+	}
+	if preflight.Lock != nil {
+		result.LockfilePath = preflight.LockPath
+		if err := writeLockfileAtomic(preflight.LockPath, preflight.Lock); err != nil {
+			if restoreErr := restoreConfig(); restoreErr != nil {
+				return result, fmt.Errorf("%w; additionally failed to restore config %s: %v", err, preflight.ConfigPath, restoreErr)
+			}
+			return result, err
+		}
+		result.LockWritten = true
+	}
+	return result, nil
+}
+
+func configDocumentBytes(root *yaml.Node) ([]byte, error) {
+	data, err := yaml.Marshal(root)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func writeLockfileAtomic(path string, lock *operator.Lockfile) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	if err := temp.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	if err := operator.WriteLockfile(tempPath, lock); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	return nil
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		_ = os.Remove(tempPath)
+		return err
+	}
+	if err := temp.Chmod(perm); err != nil {
+		_ = temp.Close()
+		_ = os.Remove(tempPath)
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	return nil
+}
+
+func providerRemoveTargets(doc *yaml.Node, kind, name string) ([]providerEntryCollectionRef, error) {
+	if strings.TrimSpace(kind) != "" {
+		lifecycleKind, err := requireProviderLifecycleKind(kind)
+		if err != nil {
+			return nil, err
+		}
+		collection := lifecycleKind.collection(doc)
+		if mappingValueNodeLocal(collection, name) == nil {
+			return nil, fmt.Errorf("provider %q of kind %q not found", name, lifecycleKind.kind)
+		}
+		return []providerEntryCollectionRef{{kind: lifecycleKind.kind, node: collection}}, nil
+	}
+	targets := make([]providerEntryCollectionRef, 0, 1)
+	for _, lifecycleKind := range providerLifecycleKinds {
+		collection := lifecycleKind.collection(doc)
+		if mappingValueNodeLocal(collection, name) != nil {
+			targets = append(targets, providerEntryCollectionRef{kind: lifecycleKind.kind, node: collection})
+		}
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("provider %q not found", name)
+	}
+	if len(targets) > 1 {
+		kinds := make([]string, 0, len(targets))
+		for _, target := range targets {
+			kinds = append(kinds, target.kind)
+		}
+		slices.Sort(kinds)
+		return nil, fmt.Errorf("provider %q is ambiguous across kinds %s; pass --kind", name, strings.Join(kinds, ", "))
+	}
+	return targets, nil
+}
+
+func applyProviderEntry(doc *yaml.Node, apiVersion, kind, name string, resolved *providerregistry.ResolvedPackage, constraint, repoName string, packageSource bool, setValues map[string]string) error {
+	if _, err := requireProviderLifecycleKind(kind); err != nil {
+		return err
+	}
+	setScalar(doc, "apiVersion", apiVersion)
+	entry := map[string]any{}
+	if packageSource {
+		source := map[string]any{"package": resolved.Package}
+		sourceRepoName := ""
+		if repoName != "" {
+			sourceRepoName = repoName
+		} else if resolved.RepositoryName != providerregistry.DefaultRepositoryName {
+			sourceRepoName = resolved.RepositoryName
+		}
+		if sourceRepoName != "" {
+			source["repo"] = sourceRepoName
+			if resolved.RepositoryURL != "" {
+				repos := ensureMapping(doc, "providerRepositories")
+				setNode(repos, sourceRepoName, yamlMapping(map[string]any{"url": resolved.RepositoryURL}))
+			}
+		}
+		if constraint != "" {
+			source["version"] = constraint
+		}
+		entry["source"] = source
+	} else {
+		entry["source"] = resolved.MetadataURL
+	}
+	if kind == providermanifestv1.KindUI {
+		entry["path"] = setValues["path"]
+	}
+	target := providerEntryCollection(doc, kind)
+	setNode(target, name, yamlMapping(entry))
+	return nil
+}

--- a/gestaltd/internal/daemon/provider_lifecycle_test.go
+++ b/gestaltd/internal/daemon/provider_lifecycle_test.go
@@ -1,0 +1,587 @@
+package daemon
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/providerpkg"
+	"gopkg.in/yaml.v3"
+)
+
+func TestE2EProviderAddDefaultsToPackageSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	writeProviderLifecycleTestFile(t, cfgPath, "apiVersion: gestaltd.config/v4\nplugins:\n")
+	indexURL := writeProviderLifecycleIndex(t, dir)
+
+	runGestaltd(t, "provider", "repo", "add", "local", indexURL, "--config", cfgPath)
+	out := runGestaltd(t, "provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--no-lock")
+	assertContains(t, out, "Added plugin alpha")
+	assertContains(t, out, "Version: 1.2.3")
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.APIVersion; got != config.ConfigAPIVersion {
+		t.Fatalf("APIVersion = %q, want %q", got, config.ConfigAPIVersion)
+	}
+	entry := cfg.Plugins["alpha"]
+	if entry == nil {
+		t.Fatal(`Plugins["alpha"] = nil`)
+	}
+	if !entry.Source.IsPackage() {
+		t.Fatal("Source.IsPackage = false, want true")
+	}
+	if got := entry.Source.PackageRepo(); got != "local" {
+		t.Fatalf("Source.PackageRepo = %q, want local", got)
+	}
+	if got := entry.Source.PackageAddress(); got != "github.com/acme/providers/alpha" {
+		t.Fatalf("Source.PackageAddress = %q", got)
+	}
+	if got := entry.Source.PackageVersionConstraint(); got != "" {
+		t.Fatalf("Source.PackageVersionConstraint = %q, want empty", got)
+	}
+}
+
+func TestE2EProviderAddAndUpgradeWriteLockWithTokenedRepository(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const pkg = "github.com/acme/providers/alpha"
+	metadata123 := writeProviderLifecycleRelease(t, dir, pkg, "1.2.3")
+	metadata130 := writeProviderLifecycleRelease(t, dir, pkg, "1.3.0")
+	indexPath := filepath.Join(dir, "provider-index.yaml")
+	writeProviderLifecycleTestFile(t, indexPath, fmt.Sprintf(`schema: gestaltd-provider-index
+schemaVersion: 1
+packages:
+  %s:
+    displayName: Alpha
+    versions:
+      1.2.3:
+        metadata: %s
+        kind: plugin
+        runtime: executable
+      1.3.0:
+        metadata: %s
+        kind: plugin
+        runtime: executable
+`, pkg, metadata123, metadata130))
+
+	var authorizedIndexRequests atomic.Int32
+	fileServer := http.FileServer(http.Dir(dir))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/provider-index.yaml" {
+			if r.Header.Get("Authorization") != "Bearer secret-token" {
+				http.Error(w, "missing token", http.StatusUnauthorized)
+				return
+			}
+			authorizedIndexRequests.Add(1)
+			http.ServeFile(w, r, indexPath)
+			return
+		}
+		fileServer.ServeHTTP(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	xdgConfigHome := filepath.Join(dir, "xdg")
+	writeProviderLifecycleTestFile(t, filepath.Join(xdgConfigHome, "gestalt", "provider-repositories.yaml"), fmt.Sprintf(`repositories:
+  private:
+    url: %s/provider-index.yaml
+    token: secret-token
+`, server.URL))
+
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	lockPath := filepath.Join(dir, "gestalt.lock.json")
+	writeProviderLifecycleTestFile(t, cfgPath, "apiVersion: gestaltd.config/v5\nplugins:\n")
+	env := []string{"XDG_CONFIG_HOME=" + xdgConfigHome}
+
+	out := runGestaltdWithEnv(t, env, "provider", "add", pkg, "--config", cfgPath, "--repo", "private", "--name", "alpha", "--version", "1.2.3", "--lockfile", lockPath)
+	assertContains(t, out, "Added plugin alpha")
+	assertContains(t, out, "Lockfile: "+lockPath)
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load after add: %v", err)
+	}
+	if got := cfg.ProviderRepositories["private"].URL; got != server.URL+"/provider-index.yaml" {
+		t.Fatalf("project repo URL = %q", got)
+	}
+	if got := cfg.Plugins["alpha"].Source.PackageRepo(); got != "private" {
+		t.Fatalf("package repo = %q, want private", got)
+	}
+	assertProviderLifecycleLockEntry(t, lockPath, "1.2.3", server.URL+"/"+metadata123)
+
+	out = runGestaltdWithEnv(t, env, "provider", "upgrade", "alpha", "--version", "1.3.0", "--config", cfgPath, "--lockfile", lockPath)
+	assertContains(t, out, "Updated plugin alpha version constraint to 1.3.0")
+	assertContains(t, out, "Lockfile: "+lockPath)
+	cfg, err = config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load after upgrade: %v", err)
+	}
+	if got := cfg.Plugins["alpha"].Source.PackageVersionConstraint(); got != "1.3.0" {
+		t.Fatalf("version constraint = %q, want 1.3.0", got)
+	}
+	assertProviderLifecycleLockEntry(t, lockPath, "1.3.0", server.URL+"/"+metadata130)
+	if got := authorizedIndexRequests.Load(); got < 3 {
+		t.Fatalf("authorized index requests = %d, want at least 3", got)
+	}
+}
+
+func TestE2EProviderAddExactSourceAndRejectsRepeatedConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	otherCfgPath := filepath.Join(dir, "other.yaml")
+	writeProviderLifecycleTestFile(t, cfgPath, "apiVersion: gestaltd.config/v4\nplugins:\n")
+	writeProviderLifecycleTestFile(t, otherCfgPath, "apiVersion: gestaltd.config/v5\n")
+	indexURL := writeProviderLifecycleIndex(t, dir)
+
+	runGestaltd(t, "provider", "repo", "add", "local", indexURL, "--config", cfgPath)
+	out := runGestaltd(t, "provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--exact-source", "--no-lock")
+	assertContains(t, out, "Added plugin alpha")
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Plugins["alpha"].Source.MetadataURL(); got != "https://example.com/provider-release.yaml" {
+		t.Fatalf("MetadataURL = %q", got)
+	}
+
+	out, err = runGestaltdResult("provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--config", otherCfgPath, "--repo", "local", "--name", "beta", "--no-lock")
+	if err == nil {
+		t.Fatalf("provider add with repeated --config succeeded: %s", out)
+	}
+	assertContains(t, out, "only one --config")
+}
+
+func TestE2EProviderAddRejectsExistingName(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	writeProviderLifecycleTestFile(t, cfgPath, "apiVersion: gestaltd.config/v5\nplugins:\n  alpha:\n    source: env\n")
+	indexURL := writeProviderLifecycleIndex(t, dir)
+
+	runGestaltd(t, "provider", "repo", "add", "local", indexURL, "--config", cfgPath)
+	out, err := runGestaltdResult("provider", "add", "github.com/acme/providers/alpha", "--config", cfgPath, "--repo", "local", "--name", "alpha", "--no-lock")
+	if err == nil {
+		t.Fatalf("provider add duplicate succeeded: %s", out)
+	}
+	assertContains(t, out, "already exists")
+}
+
+func TestE2EProviderListOfflineAndLockStatus(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	writeProviderLifecycleTestFile(t, cfgPath, `apiVersion: gestaltd.config/v5
+providerRepositories:
+  unreachable:
+    url: http://127.0.0.1:1/provider-index.yaml
+plugins:
+  alpha:
+    source:
+      repo: unreachable
+      package: github.com/acme/providers/alpha
+      version: ">= 1.0.0"
+  bravo:
+    source: https://example.com/bravo/provider-release.yaml
+providers:
+  telemetry:
+    traces:
+      source:
+        package: github.com/acme/providers/telemetry
+        version: "1.0.0"
+  audit:
+    ledger:
+      source: https://example.com/audit/provider-release.yaml
+  secrets:
+    env:
+      source: env
+`)
+	out := runGestaltd(t, "provider", "list", "--config", cfgPath)
+	assertContains(t, out, "KIND")
+	assertContains(t, out, "alpha")
+	if got := providerLifecycleListStatus(t, out, "plugin", "alpha"); got != "unlocked" {
+		t.Fatalf("alpha status = %q, want unlocked\n%s", got, out)
+	}
+	assertContains(t, out, "builtin")
+
+	cfg, err := config.LoadPartialAllowMissingEnvPaths([]string{cfgPath})
+	if err != nil {
+		t.Fatalf("LoadPartialAllowMissingEnvPaths: %v", err)
+	}
+	fingerprint, err := operator.ProviderFingerprint("alpha", cfg.Plugins["alpha"], dir)
+	if err != nil {
+		t.Fatalf("ProviderFingerprint: %v", err)
+	}
+	bravoFingerprint, err := operator.ProviderFingerprint("bravo", cfg.Plugins["bravo"], dir)
+	if err != nil {
+		t.Fatalf("ProviderFingerprint(bravo): %v", err)
+	}
+	telemetryFingerprint, err := operator.ProviderFingerprint("traces", cfg.Providers.Telemetry["traces"], dir)
+	if err != nil {
+		t.Fatalf("ProviderFingerprint(telemetry): %v", err)
+	}
+	auditFingerprint, err := operator.ProviderFingerprint("ledger", cfg.Providers.Audit["ledger"], dir)
+	if err != nil {
+		t.Fatalf("ProviderFingerprint(audit): %v", err)
+	}
+	if err := operator.WriteLockfile(filepath.Join(dir, operator.LockfileName), &operator.Lockfile{
+		Providers: map[string]operator.LockEntry{
+			"alpha": {
+				Fingerprint: fingerprint,
+				Package:     "github.com/acme/providers/alpha",
+				Kind:        "plugin",
+				Runtime:     "executable",
+				Version:     "1.2.3",
+			},
+			"bravo": {
+				Fingerprint: bravoFingerprint,
+				Package:     "github.com/acme/providers/bravo",
+				Kind:        "plugin",
+				Runtime:     "executable",
+				Source:      "https://example.com/bravo/provider-release.yaml",
+				Version:     "1.0.0",
+			},
+		},
+		Telemetry: map[string]operator.LockEntry{
+			"traces": {
+				Fingerprint: telemetryFingerprint,
+				Package:     "github.com/acme/providers/telemetry",
+				Kind:        "telemetry",
+				Runtime:     "declarative",
+				Source:      "https://example.com/telemetry/provider-release.yaml",
+				Version:     "1.0.0",
+			},
+		},
+		Audit: map[string]operator.LockEntry{
+			"ledger": {
+				Fingerprint: auditFingerprint,
+				Package:     "github.com/acme/providers/audit",
+				Kind:        "audit",
+				Runtime:     "declarative",
+				Source:      "https://example.com/audit/provider-release.yaml",
+				Version:     "1.0.0",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+	out = runGestaltd(t, "provider", "list", "--config", cfgPath)
+	assertContains(t, out, "1.2.3")
+	if got := providerLifecycleListStatus(t, out, "plugin", "alpha"); got != "drifted" {
+		t.Fatalf("alpha status = %q, want drifted when package lock source is missing\n%s", got, out)
+	}
+
+	if err := operator.WriteLockfile(filepath.Join(dir, operator.LockfileName), &operator.Lockfile{
+		Providers: map[string]operator.LockEntry{
+			"alpha": {
+				Fingerprint: fingerprint,
+				Package:     "github.com/acme/providers/alpha",
+				Kind:        "plugin",
+				Runtime:     "executable",
+				Source:      "https://example.com/provider-release.yaml",
+				Version:     "1.2.3",
+			},
+			"bravo": {
+				Fingerprint: bravoFingerprint,
+				Package:     "github.com/acme/providers/bravo",
+				Kind:        "plugin",
+				Runtime:     "executable",
+				Source:      "https://example.com/bravo/provider-release.yaml",
+				Version:     "1.0.0",
+			},
+		},
+		Telemetry: map[string]operator.LockEntry{
+			"traces": {
+				Fingerprint: telemetryFingerprint,
+				Package:     "github.com/acme/providers/telemetry",
+				Kind:        "telemetry",
+				Runtime:     "declarative",
+				Source:      "https://example.com/telemetry/provider-release.yaml",
+				Version:     "1.0.0",
+			},
+		},
+		Audit: map[string]operator.LockEntry{
+			"ledger": {
+				Fingerprint: auditFingerprint,
+				Package:     "github.com/acme/providers/audit",
+				Kind:        "audit",
+				Runtime:     "declarative",
+				Source:      "https://example.com/audit/provider-release.yaml",
+				Version:     "1.0.0",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+	out = runGestaltd(t, "provider", "list", "--config", cfgPath)
+	if got := providerLifecycleListStatus(t, out, "plugin", "alpha"); got != "unverified" {
+		t.Fatalf("alpha status = %q, want unverified for unresolved package-source lock\n%s", got, out)
+	}
+	if got := providerLifecycleListStatus(t, out, "plugin", "bravo"); got != "locked" {
+		t.Fatalf("bravo status = %q, want locked\n%s", got, out)
+	}
+	if got := providerLifecycleListStatus(t, out, "telemetry", "traces"); got != "unverified" {
+		t.Fatalf("telemetry status = %q, want unverified\n%s", got, out)
+	}
+	if got := providerLifecycleListStatus(t, out, "audit", "ledger"); got != "locked" {
+		t.Fatalf("audit status = %q, want locked\n%s", got, out)
+	}
+
+	writeProviderLifecycleTestFile(t, filepath.Join(dir, operator.LockfileName), "not json")
+	out, err = runGestaltdResult("provider", "list", "--config", cfgPath)
+	if err == nil {
+		t.Fatalf("provider list with corrupt lockfile succeeded: %s", out)
+	}
+	assertContains(t, out, "parsing lockfile")
+}
+
+func TestE2EProviderRemoveUniqueAndAmbiguousKinds(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	writeProviderLifecycleTestFile(t, cfgPath, `apiVersion: gestaltd.config/v5
+plugins:
+  alpha:
+    source: env
+providers:
+  ui:
+    alpha:
+      source: ./ui-manifest.yaml
+      path: /
+  secrets:
+    secretstore:
+      source: env
+`)
+	out, err := runGestaltdResult("provider", "remove", "alpha", "--config", cfgPath, "--no-lock")
+	if err == nil {
+		t.Fatalf("ambiguous provider remove succeeded: %s", out)
+	}
+	assertContains(t, out, "ambiguous")
+
+	out = runGestaltd(t, "provider", "remove", "secretstore", "--config", cfgPath, "--no-lock")
+	assertContains(t, out, "Removed secrets secretstore")
+	cfg, err := config.LoadPartialAllowMissingEnvPaths([]string{cfgPath})
+	if err != nil {
+		t.Fatalf("LoadPartialAllowMissingEnvPaths: %v", err)
+	}
+	if _, ok := cfg.Providers.Secrets["secretstore"]; ok {
+		t.Fatal("secretstore still present after remove")
+	}
+}
+
+func TestE2EProviderUpgradeVersionRejectsRepeatedConfigAndAmbiguousKind(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	otherCfgPath := filepath.Join(dir, "other.yaml")
+	writeProviderLifecycleTestFile(t, cfgPath, `apiVersion: gestaltd.config/v5
+plugins:
+  alpha:
+    source:
+      package: github.com/acme/providers/alpha
+providers:
+  ui:
+    alpha:
+      source:
+        package: github.com/acme/providers/alpha-ui
+      path: /
+`)
+	writeProviderLifecycleTestFile(t, otherCfgPath, "apiVersion: gestaltd.config/v5\n")
+
+	out, err := runGestaltdResult("provider", "upgrade", "alpha", "--version", "1.2.3", "--config", cfgPath, "--config", otherCfgPath)
+	if err == nil {
+		t.Fatalf("provider upgrade with repeated --config succeeded: %s", out)
+	}
+	assertContains(t, out, "only one --config")
+
+	out, err = runGestaltdResult("provider", "upgrade", "alpha", "--version", "1.2.3", "--config", cfgPath)
+	if err == nil {
+		t.Fatalf("ambiguous provider upgrade succeeded: %s", out)
+	}
+	assertContains(t, out, "ambiguous")
+}
+
+func writeProviderLifecycleIndex(t *testing.T, dir string) string {
+	t.Helper()
+	indexPath := filepath.Join(dir, "provider-index.yaml")
+	writeProviderLifecycleTestFile(t, indexPath, `schema: gestaltd-provider-index
+schemaVersion: 1
+packages:
+  github.com/acme/providers/alpha:
+    displayName: Alpha
+    versions:
+      1.2.3:
+        metadata: https://example.com/provider-release.yaml
+        kind: plugin
+        runtime: executable
+`)
+	return (&url.URL{Scheme: "file", Path: indexPath}).String()
+}
+
+func writeProviderLifecycleRelease(t *testing.T, dir, pkg, version string) string {
+	t.Helper()
+	releaseDir := filepath.Join(dir, "releases", version)
+	packageDir := filepath.Join(releaseDir, "package")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(packageDir): %v", err)
+	}
+	executable := []byte("#!/bin/sh\nexit 0\n")
+	executableName := "provider"
+	executableSum := sha256.Sum256(executable)
+	writeProviderLifecycleTestFile(t, filepath.Join(packageDir, executableName), string(executable))
+	if err := os.Chmod(filepath.Join(packageDir, executableName), 0o755); err != nil {
+		t.Fatalf("Chmod(provider): %v", err)
+	}
+	manifest := &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      pkg,
+		Version:     version,
+		DisplayName: "Alpha",
+		Spec:        &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:     runtime.GOOS,
+			Arch:   runtime.GOARCH,
+			Path:   executableName,
+			SHA256: fmt.Sprintf("%x", executableSum[:]),
+		}},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: executableName},
+	}
+	manifestData, err := providerpkg.EncodeSourceManifestFormat(manifest, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+	writeProviderLifecycleTestFile(t, filepath.Join(packageDir, "manifest.yaml"), string(manifestData))
+	writeProviderLifecycleTestFile(t, filepath.Join(packageDir, providerpkg.StaticCatalogFile), "name: alpha\noperations:\n  - id: echo\n    method: POST\n")
+
+	archiveName := "alpha-" + version + ".tar.gz"
+	archivePath := filepath.Join(releaseDir, archiveName)
+	if err := providerpkg.CreatePackageFromDir(packageDir, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+	archiveDigest, err := providerpkg.ArchiveDigest(archivePath)
+	if err != nil {
+		t.Fatalf("ArchiveDigest: %v", err)
+	}
+	metadata := map[string]any{
+		"schema":        "gestaltd-provider-release",
+		"schemaVersion": 1,
+		"package":       pkg,
+		"kind":          providermanifestv1.KindPlugin,
+		"version":       version,
+		"runtime":       "executable",
+		"artifacts": map[string]any{
+			providerpkg.CurrentPlatformString(): map[string]any{
+				"path":   archiveName,
+				"sha256": archiveDigest,
+			},
+		},
+	}
+	metadataData, err := yaml.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("Marshal release metadata: %v", err)
+	}
+	metadataRel := filepath.ToSlash(filepath.Join("releases", version, "provider-release.yaml"))
+	writeProviderLifecycleTestFile(t, filepath.Join(dir, filepath.FromSlash(metadataRel)), string(metadataData))
+	return metadataRel
+}
+
+func writeProviderLifecycleTestFile(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func runGestaltd(t *testing.T, args ...string) string {
+	t.Helper()
+	out, err := runGestaltdResult(args...)
+	if err != nil {
+		t.Fatalf("gestaltd %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return out
+}
+
+func runGestaltdWithEnv(t *testing.T, env []string, args ...string) string {
+	t.Helper()
+	out, err := runGestaltdResultWithEnv(env, args...)
+	if err != nil {
+		t.Fatalf("gestaltd %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return out
+}
+
+func runGestaltdResult(args ...string) (string, error) {
+	return runGestaltdResultWithEnv(nil, args...)
+}
+
+func runGestaltdResultWithEnv(env []string, args ...string) (string, error) {
+	cmd := exec.Command(gestaltdBin, args...)
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func assertProviderLifecycleLockEntry(t *testing.T, lockPath, version, source string) {
+	t.Helper()
+	lock, err := operator.ReadLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	entry, ok := lock.Providers["alpha"]
+	if !ok {
+		t.Fatal(`lock.Providers["alpha"] missing`)
+	}
+	if entry.Version != version {
+		t.Fatalf("lock version = %q, want %q", entry.Version, version)
+	}
+	if entry.Source != source {
+		t.Fatalf("lock source = %q, want %q", entry.Source, source)
+	}
+}
+
+func providerLifecycleListStatus(t *testing.T, output, kind, name string) string {
+	t.Helper()
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[0] == kind && fields[1] == name {
+			return fields[len(fields)-1]
+		}
+	}
+	t.Fatalf("provider list row %s/%s not found in:\n%s", kind, name, output)
+	return ""
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected output to contain %q, got:\n%s", want, got)
+	}
+}

--- a/gestaltd/internal/daemon/provider_registry.go
+++ b/gestaltd/internal/daemon/provider_registry.go
@@ -271,6 +271,38 @@ func runProviderInfo(args []string) error {
 	return fmt.Errorf("provider package %q not found", pkg)
 }
 
+func runProviderList(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider list", flag.ContinueOnError)
+	var configPaths repeatedStringFlag
+	kind := fs.String("kind", "", "provider kind")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile")
+	fs.Var(&configPaths, "config", "path to config file")
+	if err := parseInterspersed(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	paths := operator.ResolveConfigPaths(configPaths)
+	if len(paths) == 0 {
+		return fmt.Errorf("no config file found")
+	}
+	cfg, err := config.LoadPartialAllowMissingEnvPaths(paths)
+	if err != nil {
+		return err
+	}
+	lock, err := readProviderListLockfile(paths[0], *lockfilePath)
+	if err != nil {
+		return err
+	}
+	rows, err := providerLifecycleRows(cfg, paths[0], lock, *kind)
+	if err != nil {
+		return err
+	}
+	printProviderRows(rows)
+	return nil
+}
+
 func runProviderAdd(args []string) error {
 	fs := flag.NewFlagSet("gestaltd provider add", flag.ContinueOnError)
 	var configPaths repeatedStringFlag
@@ -283,6 +315,7 @@ func runProviderAdd(args []string) error {
 	noLock := fs.Bool("no-lock", false, "do not update lockfile")
 	sync := fs.Bool("sync", false, "materialize prepared artifacts after locking")
 	exactSource := fs.Bool("exact-source", false, "write resolved provider-release metadata URL instead of package source")
+	fs.Bool("package-source", false, "accepted for compatibility; package sources are written by default")
 	dryRun := fs.Bool("dry-run", false, "print resolved package without editing")
 	fs.Var(&configPaths, "config", "path to config file")
 	fs.Var(&setFlags, "set", "set shallow entry field, e.g. path=/ui")
@@ -292,15 +325,9 @@ func runProviderAdd(args []string) error {
 	if fs.NArg() != 1 {
 		return fmt.Errorf("usage: gestaltd provider add PACKAGE")
 	}
-	paths := operator.ResolveConfigPaths(configPaths)
-	primary, err := ensurePrimaryProviderConfig(paths)
+	primary, paths, err := resolveMutableProviderConfig(configPaths)
 	if err != nil {
 		return err
-	}
-	if len(paths) == 0 {
-		paths = []string{primary}
-	} else {
-		paths[0] = primary
 	}
 	cfg, err := config.LoadAllowMissingEnvPaths(paths)
 	if err != nil {
@@ -320,7 +347,7 @@ func runProviderAdd(args []string) error {
 		return err
 	}
 	if *dryRun {
-		fmt.Printf("%s\t%s\t%s\t%s\n", resolved.Package, resolved.Version, resolved.Kind, resolved.MetadataURL)
+		fmt.Printf("Package: %s\nVersion: %s\nKind: %s\nMetadata: %s\n", resolved.Package, resolved.Version, resolved.Kind, resolved.MetadataURL)
 		return nil
 	}
 	apiVersion := config.ConfigAPIVersion
@@ -328,12 +355,18 @@ func runProviderAdd(args []string) error {
 		apiVersion = strings.TrimSpace(cfg.APIVersion)
 	}
 	writePackageSource := !*exactSource
+	if writePackageSource {
+		apiVersion = config.ConfigAPIVersion
+	}
 	entryKind := providermanifestv1.NormalizeKind(*kind)
 	if entryKind == "" {
 		entryKind = resolved.Kind
 	}
 	if entryKind == "telemetry" || entryKind == "audit" {
 		return fmt.Errorf("provider add --kind %s is not supported yet; provider-backed %s is not supported at bootstrap", entryKind, entryKind)
+	}
+	if _, err := requireProviderLifecycleKind(entryKind); err != nil {
+		return err
 	}
 	entryName := strings.TrimSpace(*name)
 	if entryName == "" {
@@ -346,18 +379,32 @@ func runProviderAdd(args []string) error {
 	if entryKind == providermanifestv1.KindUI && strings.TrimSpace(setValues["path"]) == "" {
 		return fmt.Errorf("provider add for kind ui requires --set path=/mount")
 	}
-	if err := editProviderEntry(primary, apiVersion, entryKind, entryName, resolved, *version, *repoName, writePackageSource, setValues); err != nil {
+	if providerEntryExists(cfg, entryKind, entryName) {
+		return fmt.Errorf("provider %q of kind %q already exists", entryName, entryKind)
+	}
+	root, doc, err := readConfigDocument(primary)
+	if err != nil {
 		return err
 	}
-	if *noLock {
-		return nil
+	if err := applyProviderEntry(doc, apiVersion, entryKind, entryName, resolved, *version, *repoName, writePackageSource, setValues); err != nil {
+		return err
 	}
-	state := operator.StatePaths{LockfilePath: *lockfilePath}
-	if err := lockConfigWithStatePaths(configPaths, state, "", false); err != nil {
+	preflight, err := preflightProviderConfigMutation(primary, root, *lockfilePath, *noLock)
+	if err != nil {
+		return err
+	}
+	result, err := commitProviderConfigMutation(preflight)
+	if err != nil {
 		return err
 	}
 	if *sync {
-		return syncConfigWithStatePaths(configPaths, state, false)
+		if err := syncConfigWithStatePaths(configPaths, operator.StatePaths{LockfilePath: *lockfilePath}, false); err != nil {
+			return err
+		}
+	}
+	fmt.Printf("Added %s %s\nPackage: %s\nRepository: %s\nVersion: %s\nConfig: %s\n", entryKind, entryName, resolved.Package, resolved.RepositoryName, resolved.Version, result.ConfigPath)
+	if result.LockWritten {
+		fmt.Printf("Lockfile: %s\n", result.LockfilePath)
 	}
 	return nil
 }
@@ -365,7 +412,7 @@ func runProviderAdd(args []string) error {
 func runProviderRemove(args []string) error {
 	fs := flag.NewFlagSet("gestaltd provider remove", flag.ContinueOnError)
 	var configPaths repeatedStringFlag
-	kind := fs.String("kind", "plugin", "provider kind")
+	kind := fs.String("kind", "", "provider kind")
 	lockfilePath := fs.String("lockfile", "", "path to lockfile")
 	noLock := fs.Bool("no-lock", false, "do not update lockfile")
 	fs.Var(&configPaths, "config", "path to config file")
@@ -375,15 +422,30 @@ func runProviderRemove(args []string) error {
 	if fs.NArg() != 1 {
 		return fmt.Errorf("usage: gestaltd provider remove NAME")
 	}
-	paths := operator.ResolveConfigPaths(configPaths)
-	if len(paths) == 0 {
-		return fmt.Errorf("no config file found")
-	}
-	if err := removeProviderEntry(paths[0], providermanifestv1.NormalizeKind(*kind), fs.Arg(0)); err != nil {
+	primary, _, err := resolveMutableProviderConfig(configPaths)
+	if err != nil {
 		return err
 	}
-	if !*noLock {
-		return lockConfigWithStatePaths(configPaths, operator.StatePaths{LockfilePath: *lockfilePath}, "", false)
+	root, doc, err := readConfigDocument(primary)
+	if err != nil {
+		return err
+	}
+	targets, err := providerRemoveTargets(doc, normalizeProviderLifecycleKind(*kind), fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	deleteKey(targets[0].node, fs.Arg(0))
+	preflight, err := preflightProviderConfigMutation(primary, root, *lockfilePath, *noLock)
+	if err != nil {
+		return err
+	}
+	result, err := commitProviderConfigMutation(preflight)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Removed %s %s\nConfig: %s\n", targets[0].kind, fs.Arg(0), result.ConfigPath)
+	if result.LockWritten {
+		fmt.Printf("Lockfile: %s\n", result.LockfilePath)
 	}
 	return nil
 }
@@ -405,15 +467,37 @@ func runProviderUpgrade(args []string) error {
 		return fmt.Errorf("--version requires a provider name")
 	}
 	if *version != "" {
-		paths := operator.ResolveConfigPaths(configPaths)
-		if len(paths) == 0 {
-			return fmt.Errorf("no config file found")
-		}
-		if err := updateProviderVersionConstraint(paths[0], providermanifestv1.NormalizeKind(*kind), fs.Arg(0), *version); err != nil {
+		primary, _, err := resolveMutableProviderConfig(configPaths)
+		if err != nil {
 			return err
 		}
+		root, doc, err := readConfigDocument(primary)
+		if err != nil {
+			return err
+		}
+		targetKind, err := applyProviderVersionConstraint(doc, normalizeProviderLifecycleKind(*kind), fs.Arg(0), *version)
+		if err != nil {
+			return err
+		}
+		preflight, err := preflightProviderConfigMutation(primary, root, *lockfilePath, false)
+		if err != nil {
+			return err
+		}
+		result, err := commitProviderConfigMutation(preflight)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Updated %s %s version constraint to %s\nConfig: %s\n", targetKind, fs.Arg(0), *version, result.ConfigPath)
+		if result.LockWritten {
+			fmt.Printf("Lockfile: %s\n", result.LockfilePath)
+		}
+		return nil
 	}
-	return lockConfigWithStatePaths(configPaths, operator.StatePaths{LockfilePath: *lockfilePath}, "", false)
+	if err := lockConfigWithStatePaths(configPaths, operator.StatePaths{LockfilePath: *lockfilePath}, "", false); err != nil {
+		return err
+	}
+	fmt.Println("Refreshed provider lock state")
+	return nil
 }
 
 func loadProviderRepositories(configPaths []string) ([]providerregistry.NamedRepository, error) {
@@ -446,7 +530,8 @@ func loadProviderRepositories(configPaths []string) ([]providerregistry.NamedRep
 				if _, ok := byName[name]; !ok {
 					order = append(order, name)
 				}
-				byName[name] = providerregistry.NamedRepository{Name: name, URL: repo.URL}
+				existing := byName[name]
+				byName[name] = providerregistry.NamedRepository{Name: name, URL: repo.URL, Token: existing.Token}
 			}
 		}
 	}
@@ -525,63 +610,29 @@ func removeProjectProviderRepository(path, name string) error {
 	return writeConfigDocument(path, root)
 }
 
-func editProviderEntry(path, apiVersion, kind, name string, resolved *providerregistry.ResolvedPackage, constraint, repoName string, packageSource bool, setValues map[string]string) error {
-	root, doc, err := readConfigDocument(path)
-	if err != nil {
-		return err
-	}
-	setScalar(doc, "apiVersion", apiVersion)
-	entry := map[string]any{}
-	if packageSource {
-		source := map[string]any{"package": resolved.Package}
-		sourceRepoName := ""
-		if repoName != "" {
-			sourceRepoName = repoName
-		} else if resolved.RepositoryName != providerregistry.DefaultRepositoryName {
-			sourceRepoName = resolved.RepositoryName
-		}
-		if sourceRepoName != "" {
-			source["repo"] = sourceRepoName
-			if resolved.RepositoryURL != "" {
-				repos := ensureMapping(doc, "providerRepositories")
-				setNode(repos, sourceRepoName, yamlMapping(map[string]any{"url": resolved.RepositoryURL}))
-			}
-		}
-		if constraint != "" {
-			source["version"] = constraint
-		}
-		entry["source"] = source
-	} else {
-		entry["source"] = resolved.MetadataURL
-	}
-	if kind == providermanifestv1.KindUI {
-		entry["path"] = setValues["path"]
-	}
-	target := providerEntryCollection(doc, kind)
-	setNode(target, name, yamlMapping(entry))
-	return writeConfigDocument(path, root)
-}
-
-func removeProviderEntry(path, kind, name string) error {
-	root, doc, err := readConfigDocument(path)
-	if err != nil {
-		return err
-	}
-	deleteKey(providerEntryCollection(doc, kind), name)
-	return writeConfigDocument(path, root)
-}
-
 func updateProviderVersionConstraint(path, kind, name, version string) error {
 	root, doc, err := readConfigDocument(path)
 	if err != nil {
 		return err
 	}
+	if _, err := applyProviderVersionConstraint(doc, kind, name, version); err != nil {
+		return err
+	}
+	return writeConfigDocument(path, root)
+}
+
+func applyProviderVersionConstraint(doc *yaml.Node, kind, name, version string) (string, error) {
+	if strings.TrimSpace(kind) != "" {
+		if _, err := requireProviderLifecycleKind(kind); err != nil {
+			return "", err
+		}
+	}
 	targets := providerVersionTargets(doc, kind, name)
 	if len(targets) == 0 {
 		if kind != "" {
-			return fmt.Errorf("provider %q of kind %q not found or is not a package source", name, kind)
+			return "", fmt.Errorf("provider %q of kind %q not found or is not a package source", name, kind)
 		}
-		return fmt.Errorf("provider %q not found or is not a package source", name)
+		return "", fmt.Errorf("provider %q not found or is not a package source", name)
 	}
 	if len(targets) > 1 {
 		kinds := make([]string, 0, len(targets))
@@ -589,10 +640,10 @@ func updateProviderVersionConstraint(path, kind, name, version string) error {
 			kinds = append(kinds, target.kind)
 		}
 		slices.Sort(kinds)
-		return fmt.Errorf("provider %q is ambiguous across kinds %s; pass --kind", name, strings.Join(kinds, ", "))
+		return "", fmt.Errorf("provider %q is ambiguous across kinds %s; pass --kind", name, strings.Join(kinds, ", "))
 	}
 	setScalar(targets[0].source, "version", version)
-	return writeConfigDocument(path, root)
+	return targets[0].kind, nil
 }
 
 type providerVersionTarget struct {

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -398,8 +398,8 @@ func TestRun_ProviderCLIUsageAndErrors(t *testing.T) {
 		{
 			name:      "root help",
 			args:      []string{"--help"},
-			wantParts: []string{"gestaltd provider <command> [flags]", "attach", "release"},
-			notWant:   []string{"\n  install", "\n  inspect", "\n  list", "\n  init", "\n  package"},
+			wantParts: []string{"gestaltd provider <command> [flags]", "attach", "list", "release"},
+			notWant:   []string{"\n  install", "\n  inspect", "\n  init", "\n  package"},
 		},
 		{
 			name:      "attach help",

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -547,7 +547,8 @@ func providerRepositoriesForConfig(cfg *config.Config) ([]providerregistry.Named
 		if _, ok := byName[name]; !ok {
 			order = append(order, name)
 		}
-		byName[name] = providerregistry.NamedRepository{Name: name, URL: repo.URL}
+		existing := byName[name]
+		byName[name] = providerregistry.NamedRepository{Name: name, URL: repo.URL, Token: existing.Token}
 	}
 	out := make([]providerregistry.NamedRepository, 0, len(order))
 	for _, name := range order {
@@ -1673,7 +1674,14 @@ func lockEntrySourceMatchesProvider(paths lifecyclePaths, provider *config.Provi
 		if strings.TrimSpace(entry.Package) != provider.Source.PackageAddress() {
 			return false
 		}
-		return providerregistry.VersionSatisfiesConstraint(entry.Version, provider.Source.PackageVersionConstraint())
+		if !providerregistry.VersionSatisfiesConstraint(entry.Version, provider.Source.PackageVersionConstraint()) {
+			return false
+		}
+		if resolved := provider.Source.ResolvedPackageMetadataURL(); resolved != "" {
+			return entry.Source == resolved
+		}
+		source := strings.TrimSpace(entry.Source)
+		return source != "" && source != strings.TrimSpace(entry.Package)
 	}
 	return entry.Source == providerSourceLockLocation(provider, paths.configDir)
 }
@@ -1935,6 +1943,19 @@ func lockEntryMetadataMatches(paths lifecyclePaths, kind, name string, providerE
 		return false
 	}
 	return true
+}
+
+// LockEntryMetadataMatchesProvider checks whether a lock entry still matches a
+// provider config entry without inspecting prepared artifact files.
+func LockEntryMetadataMatchesProvider(configPath, kind, name string, providerEntry *config.ProviderEntry, entry LockEntry, found, ui bool) bool {
+	paths := lifecyclePaths{
+		configPath: configPath,
+		configDir:  filepath.Dir(configPath),
+	}
+	if ui {
+		return uiLockEntryMetadataMatches(paths, name, providerEntry, entry, found)
+	}
+	return lockEntryMetadataMatches(paths, kind, name, providerEntry, entry, found)
 }
 
 func uiLockEntryMetadataMatches(paths lifecyclePaths, name string, providerEntry *config.ProviderEntry, entry LockEntry, found bool) bool {


### PR DESCRIPTION
## Summary

Adds the provider lifecycle CLI UX for package-backed providers:

- `gestaltd provider list` for offline config and lock status inspection.
- `gestaltd provider add` defaults to v5 package sources, keeps `--package-source` as a compatibility no-op, supports `--exact-source`, rejects duplicate entries, and validates/locks mutations before committing config changes.
- `gestaltd provider remove` resolves a unique provider name across writable config collections instead of assuming plugins.
- `gestaltd provider upgrade --version` updates package-source version constraints with the same single-config mutation guard and preflight lock behavior.
- Preserves user-store repository tokens when project config overlays the same repository name, so private package indexes keep working after `add` writes the repo URL into config.

## Interface Changes

- New/changed interface:
  - `gestaltd provider list [--config PATH] [--kind KIND] [--lockfile PATH]`
  - `gestaltd provider add PACKAGE [--config PATH] [--repo NAME] [--name NAME] [--version CONSTRAINT] [--lockfile PATH] [--exact-source] [--no-lock] [--sync]`
  - `gestaltd provider remove NAME [--config PATH] [--kind KIND] [--lockfile PATH] [--no-lock]`
  - `gestaltd provider upgrade [NAME] [--config PATH] [--kind KIND] [--lockfile PATH] [--version CONSTRAINT]`
- Example usage:
  - `gestaltd provider add github.com/acme/providers/alpha --repo local --name alpha --lockfile gestalt.lock.json`
  - `gestaltd provider list --kind plugin`
  - `gestaltd provider remove alpha --kind ui`
  - `gestaltd provider upgrade alpha --kind plugin --version '>= 1.2.0'`
- `provider list` statuses include `locked`, `unlocked`, `drifted`, `builtin`, and `unverified`. `unverified` is used for package-source rows where the offline list command can verify package/version lock presence but cannot re-resolve current metadata without hitting the repository.

## Functional/Integration Tests

- Tests added or augmented:
  - Added e2e CLI coverage for provider add defaults/exact-source/repeated-config/duplicates.
  - Added a tokened HTTP repository e2e that exercises successful `provider add` and `provider upgrade --version` writing both config and lockfile.
  - Added offline provider list coverage for unlocked, built-in, drifted missing package-source metadata, unverified package-source lock presence, locked exact-source metadata, telemetry package-source status, audit exact-source status, and corrupt-lockfile states.
  - Added provider remove and upgrade UX coverage for unique/ambiguous name resolution and repeated config rejection.
  - Augmented provider help expectations for `list`.
- Contract boundary covered:
  - Built `gestaltd` binary CLI flows against real temp config files, provider index files, package release metadata/archive files, config loading, lockfile reading/writing, tokened repository resolution, and mutation persistence.
- Commands run:
  - `golangci-lint run --path-prefix=gestaltd`
  - `GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./internal/daemon -run 'TestE2EProviderListOfflineAndLockStatus|TestE2EProvider(Add|Remove|Upgrade)|TestE2ECLIHelp|TestRun_ProviderCLIUsageAndErrors|TestUpdateProviderVersionConstraint' -count=1`
  - `GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./internal/operator -run TestDoesNotExist -count=0`
