### PR TITLE
Allow external credentials v2 indexeddb store

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1474,7 +1474,7 @@ func externalCredentialsIndexedDBHostService(envVar, providerName string, ds ind
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, providerName, indexeddbservice.ServerOptions{
-				AllowedStores: []string{"external_credentials"},
+				AllowedStores: []string{"external_credentials", "external_credentials_v2"},
 			}))
 		},
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -4324,6 +4324,12 @@ func TestBootstrapRoutesExternalCredentialsIndexedDBHostServices(t *testing.T) {
 			t.Fatalf("CreateObjectStore(external_credentials): %v", err)
 		}
 		if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{
+			Name:   "external_credentials_v2",
+			Schema: &proto.ObjectStoreSchema{},
+		}); err != nil {
+			t.Fatalf("CreateObjectStore(external_credentials_v2): %v", err)
+		}
+		if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{
 			Name:   "plugin_credentials",
 			Schema: &proto.ObjectStoreSchema{},
 		}); err == nil {


### PR DESCRIPTION
## Summary
- allow the external credentials host IndexedDB service to expose both the legacy `external_credentials` store and the new `external_credentials_v2` store used by `external_credentials/default@0.0.1-alpha.2`
- extend the bootstrap host-service routing test to verify both stores remain accessible while unrelated stores are still blocked

## Root Cause
`toolshed-test-00978-z66` crashed on startup with `create object store "external_credentials_v2": indexeddb: not found`. The alpha2 external credentials provider creates the v2 store and then reads the legacy store for backfill, but Gestalt still allowed only `external_credentials` through the external-credentials IndexedDB host-service allowlist.

## Tests
- `go test ./internal/bootstrap -run TestBootstrapRoutesExternalCredentialsIndexedDBHostServices -count=1`
- `go test ./internal/bootstrap -count=1`
- `git diff --check`