### PR TITLE
Remove stale credential store compatibility

### DIFF
--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -96,7 +96,8 @@ plugins:
 ```
 
 By default, executable plugins run on the same machine as `gestaltd`. A plugin
-only uses a hosted runtime when it sets `execution.mode: hosted`. Use `execution.mode: hosted` with `execution.runtime`; legacy `plugins.<name>.runtime` is no longer accepted.
+only uses a hosted runtime when it sets `execution.mode: hosted` with
+`execution.runtime`.
 
 ## Choosing a runtime
 

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -21,9 +21,7 @@ changes where the configured plugin or agent provider process runs.
 
 By default, executable plugins and agent providers run on the same machine as
 `gestaltd`. A provider only uses a runtime provider when it opts in with
-`execution.mode: hosted`. Use `execution.mode: hosted` with
-`execution.runtime`; legacy `plugins.<name>.runtime` and
-`providers.agent.<name>.runtime` fields are no longer accepted.
+`execution.mode: hosted` and selects a backend with `execution.runtime`.
 
 When a provider does opt in, Gestalt selects a backend from `runtime.providers`,
 reads the backend's support profile, starts a runtime session, waits for that

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -217,7 +217,7 @@ runtime:
 
 `server.runtime.defaultHostedProvider` supplies the default runtime name for
 plugins that set `execution.mode: hosted` without an explicit
-`execution.runtime.provider`. The legacy `server.runtime.provider` field is no longer accepted.
+`execution.runtime.provider`.
 
 | Field | Description |
 | --- | --- |
@@ -555,8 +555,7 @@ executable plugins. When `providers.agent.<name>.execution.mode` is `hosted`,
 `gestaltd` starts the agent provider inside the selected hosted runtime instead
 of launching it directly on the `gestaltd` host. Tool callbacks still route
 back through the host agent socket, and `egress.allowedHosts` remains the
-operator-facing egress policy. Legacy `providers.agent.<name>.runtime` is no
-longer accepted; use `providers.agent.<name>.execution.runtime`.
+operator-facing egress policy.
 
 | Field | Description |
 | --- | --- |

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1474,7 +1474,7 @@ func externalCredentialsIndexedDBHostService(envVar, providerName string, ds ind
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, providerName, indexeddbservice.ServerOptions{
-				AllowedStores: []string{"external_credentials", "external_credentials_v2"},
+				AllowedStores: []string{"external_credentials"},
 			}))
 		},
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -4324,12 +4324,6 @@ func TestBootstrapRoutesExternalCredentialsIndexedDBHostServices(t *testing.T) {
 			t.Fatalf("CreateObjectStore(external_credentials): %v", err)
 		}
 		if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{
-			Name:   "external_credentials_v2",
-			Schema: &proto.ObjectStoreSchema{},
-		}); err != nil {
-			t.Fatalf("CreateObjectStore(external_credentials_v2): %v", err)
-		}
-		if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{
 			Name:   "plugin_credentials",
 			Schema: &proto.ObjectStoreSchema{},
 		}); err == nil {

--- a/gestaltd/services/plugins/provider_test.go
+++ b/gestaltd/services/plugins/provider_test.go
@@ -414,8 +414,8 @@ func TestPrincipalFromProto_PreservesCustomAuthSource(t *testing.T) {
 	t.Parallel()
 
 	p := principalFromProto(&proto.SubjectContext{
-		Id:          "workload:github_app_installation:127579767:repo:valon-technologies/gestalt",
-		Kind:        "workload",
+		Id:          "service_account:github-app-installation-127579767",
+		Kind:        "service_account",
 		DisplayName: "GitHub App installation 127579767",
 		AuthSource:  "github_app_webhook",
 	})
@@ -425,8 +425,8 @@ func TestPrincipalFromProto_PreservesCustomAuthSource(t *testing.T) {
 	if p.AuthSource() != "github_app_webhook" {
 		t.Fatalf("auth source = %q, want github_app_webhook", p.AuthSource())
 	}
-	if p.Kind != principal.Kind("workload") {
-		t.Fatalf("kind = %q, want workload", p.Kind)
+	if p.Kind != principal.Kind("service_account") {
+		t.Fatalf("kind = %q, want service_account", p.Kind)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove the stale `external_credentials_v2` IndexedDB object-store allowance from the external-credentials host service.
- Keep the external-credentials provider contract on the canonical `external_credentials` store only.
- Update the remaining test-only `workload` subject fixture to use the unified `service_account` subject kind.
- Remove stale docs wording that described rejected runtime fields instead of the current runtime config shape.

## Interface diff

No public Go, HTTP, gRPC, or provider manifest interfaces change in this PR.

The host-service store allowlist is intentionally narrower:

```diff
 externalCredentialsIndexedDBHostService(...):
-  AllowedStores: ["external_credentials", "external_credentials_v2"]
+  AllowedStores: ["external_credentials"]
```

Subject examples now use the canonical non-human subject shape:

```diff
- id:   workload:github_app_installation:127579767:repo:valon-technologies/gestalt
- kind: workload
+ id:   service_account:github-app-installation-127579767
+ kind: service_account
```

## Current usage examples

External credentials providers should persist in the canonical object store:

```go
db.ObjectStore("external_credentials")
```

Non-human callers should use service-account subjects:

```json
{
  "subjectId": "service_account:github-app-installation-127579767",
  "kind": "service_account",
  "authSource": "github_app_webhook"
}
```

## Production data cleanup

Completed manual SQL cleanup in `gitlab-peach-street` / Cloud SQL `terra-east4` before removing the compatibility path:

- Verified `external_credentials` and `external_credentials_v2` both had 1,463 records before cleanup.
- Verified every `external_credentials_v2` primary key existed in `external_credentials`; 4 records differed, with the canonical store containing the current values.
- Deleted only the legacy generic-store rows:
  - `gestaltd._gestalt_index_entries`: 2,926 `external_credentials_v2` rows
  - `gestaltd._gestalt_unique_index_entries`: 1,463 `external_credentials_v2` rows
  - `gestaltd._gestalt_records`: 1,463 `external_credentials_v2` rows
  - `gestaltd._gestalt_stores`: 1 `external_credentials_v2` row
- Rechecked that only `external_credentials` remains, with 1,463 records.

## Verification

- `go test ./internal/bootstrap -run TestBootstrapRoutesExternalCredentialsIndexedDBHostServices`
- `go test ./services/plugins -run 'TestPrincipalFromProto'`
- CI: Go Tests, Go Coverage, Go Lint & Vet, Docs Build, Docker Image Build, Helm Chart Validation, Cursor Bugbot, and Semgrep are green.
