### PR TITLE
Keep agent event streams alive

### DIFF
--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -337,6 +337,7 @@ type memoryAgentProvider struct {
 	listSessionRequests []coreagent.ListSessionsRequest
 	listTurnRequests    []coreagent.ListTurnsRequest
 	createSessionHook   func()
+	listTurnEventsErr   error
 }
 
 func newMemoryAgentProvider() *memoryAgentProvider {
@@ -597,6 +598,9 @@ func (p *memoryAgentProvider) ListTurnEvents(_ context.Context, req coreagent.Li
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if p.listTurnEventsErr != nil {
+		return nil, p.listTurnEventsErr
+	}
 	events := p.turnEvents[req.TurnID]
 	out := make([]*coreagent.TurnEvent, 0, len(events))
 	for _, event := range events {
@@ -1341,6 +1345,115 @@ func TestAgentSessionsAndTurnsRoundTripWithoutAuth(t *testing.T) {
 	}
 	if turn["sessionId"] != sessionID {
 		t.Fatalf("turn sessionId = %#v, want %q", turn["sessionId"], sessionID)
+	}
+}
+
+func TestAgentTurnEventStreamSendsHeartbeatBeforeEvents(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAgentProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		services := testutil.NewStubServices(t)
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "ada@example.com", DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:     &stubAgentControl{defaultProviderName: "managed", provider: provider},
+			RunGrants: newServerTestAgentRunGrants(t),
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/", bytes.NewBufferString(`{"provider":"managed","model":"gpt-5.4"}`))
+	sessionReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	sessionResp, err := http.DefaultClient.Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(sessionResp.Body)
+		t.Fatalf("create session status = %d body=%s", sessionResp.StatusCode, body)
+	}
+	var session map[string]any
+	if err := json.NewDecoder(sessionResp.Body).Decode(&session); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	sessionID := session["id"].(string)
+
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"wait"}]}`))
+	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	turnResp, err := http.DefaultClient.Do(turnReq)
+	if err != nil {
+		t.Fatalf("create turn: %v", err)
+	}
+	defer func() { _ = turnResp.Body.Close() }()
+	if turnResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(turnResp.Body)
+		t.Fatalf("create turn status = %d body=%s", turnResp.StatusCode, body)
+	}
+	var turn map[string]any
+	if err := json.NewDecoder(turnResp.Body).Decode(&turn); err != nil {
+		t.Fatalf("decode turn: %v", err)
+	}
+	turnID := turn["id"].(string)
+
+	provider.mu.Lock()
+	provider.turns[turnID].Status = coreagent.ExecutionStatusRunning
+	provider.turns[turnID].CompletedAt = nil
+	provider.turnEvents[turnID] = nil
+	provider.mu.Unlock()
+
+	streamCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	streamReq, _ := http.NewRequestWithContext(streamCtx, http.MethodGet, ts.URL+"/api/v1/agent/turns/"+turnID+"/events/stream?after=0&limit=10", nil)
+	streamReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	streamResp, err := http.DefaultClient.Do(streamReq)
+	if err != nil {
+		t.Fatalf("stream quiet events: %v", err)
+	}
+	defer func() { _ = streamResp.Body.Close() }()
+	if streamResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(streamResp.Body)
+		t.Fatalf("stream quiet events status = %d body=%s", streamResp.StatusCode, body)
+	}
+	if got := streamResp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("stream quiet events content-type = %q, want text/event-stream", got)
+	}
+	reader := bufio.NewReader(streamResp.Body)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read heartbeat: %v", err)
+	}
+	if got := strings.TrimRight(line, "\r\n"); got != ": stream-open" {
+		t.Fatalf("first stream line = %q, want stream-open heartbeat", got)
+	}
+
+	provider.mu.Lock()
+	provider.listTurnEventsErr = core.ErrNotFound
+	provider.mu.Unlock()
+
+	var errorFrame string
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read stream error: %v", err)
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "data: ") {
+			errorFrame = strings.TrimPrefix(line, "data: ")
+			break
+		}
+	}
+	if !strings.Contains(errorFrame, `"type":"stream.error"`) {
+		t.Fatalf("stream error frame = %s, want stream.error event", errorFrame)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -31,6 +31,7 @@ const defaultAgentTurnEventLimit = 100
 const maxAgentTurnEventLimit = 1000
 const agentTurnEventStreamUntilTerminal = "terminal"
 const agentTurnEventStreamUntilBlockedOrTerminal = "blocked_or_terminal"
+const agentTurnEventStreamHeartbeatInterval = 15 * time.Second
 
 type agentMessageRequest struct {
 	Role     string                    `json:"role,omitempty"`
@@ -534,6 +535,12 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	ctx := r.Context()
+	events, err := s.agentRuns.ListTurnEvents(ctx, p, turnID, afterSeq, limit)
+	if err != nil {
+		s.writeAgentManagerError(w, r, "turn", turnID, nil, err)
+		return
+	}
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeError(w, http.StatusInternalServerError, "streaming is not supported")
@@ -542,9 +549,18 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	ctx := r.Context()
+	w.Header().Set("X-Accel-Buffering", "no")
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
+	lastWrite := time.Now()
+
+	writeHeartbeat := func(comment string) {
+		_, _ = w.Write([]byte(": "))
+		_, _ = w.Write([]byte(comment))
+		_, _ = w.Write([]byte("\n\n"))
+		flusher.Flush()
+		lastWrite = time.Now()
+	}
 
 	writeEvents := func(events []*coreagent.TurnEvent) bool {
 		pageFull := limit > 0 && len(events) == limit
@@ -559,6 +575,7 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write(payload)
 			_, _ = w.Write([]byte("\n\n"))
 			flusher.Flush()
+			lastWrite = time.Now()
 			if info.Seq > afterSeq {
 				afterSeq = info.Seq
 			}
@@ -566,37 +583,77 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 		return pageFull
 	}
 
-	for {
-		events, err := s.agentRuns.ListTurnEvents(ctx, p, turnID, afterSeq, limit)
-		if err != nil {
-			s.writeAgentManagerError(w, r, "turn", turnID, nil, err)
+	writeStreamError := func(err error) {
+		slog.ErrorContext(ctx, "agent turn event stream failed", "turn_id", turnID, "error", err)
+		info := agentTurnEventInfo{
+			TurnID:     turnID,
+			Type:       "stream.error",
+			Source:     "gestaltd",
+			Visibility: "public",
+			Data: map[string]any{
+				"message": "agent event stream failed",
+			},
+			Display: &agentTurnDisplayInfo{
+				Kind:  "error",
+				Phase: "failed",
+				Text:  "agent event stream failed",
+			},
+		}
+		payload, marshalErr := json.Marshal(info)
+		if marshalErr != nil {
+			slog.ErrorContext(ctx, "marshal agent turn stream error", "turn_id", turnID, "error", marshalErr)
 			return
 		}
-		pageFull := writeEvents(events)
+		_, _ = w.Write([]byte("event: error\n"))
+		_, _ = w.Write([]byte("data: "))
+		_, _ = w.Write(payload)
+		_, _ = w.Write([]byte("\n\n"))
+		flusher.Flush()
+		lastWrite = time.Now()
+	}
+
+	writeHeartbeat("stream-open")
+	pageFull := writeEvents(events)
+	for {
 		if pageFull {
+			events, err := s.agentRuns.ListTurnEvents(ctx, p, turnID, afterSeq, limit)
+			if err != nil {
+				writeStreamError(err)
+				return
+			}
+			pageFull = writeEvents(events)
 			continue
 		}
 		done, err := s.agentTurnStreamDone(ctx, p, turnID, until)
 		if err != nil {
-			s.writeAgentManagerError(w, r, "turn", turnID, nil, err)
+			writeStreamError(err)
 			return
 		}
 		if done {
 			events, err := s.agentRuns.ListTurnEvents(ctx, p, turnID, afterSeq, limit)
 			if err != nil {
-				s.writeAgentManagerError(w, r, "turn", turnID, nil, err)
+				writeStreamError(err)
 				return
 			}
 			if len(events) == 0 {
 				return
 			}
-			writeEvents(events)
+			pageFull = writeEvents(events)
 			continue
 		}
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			if time.Since(lastWrite) >= agentTurnEventStreamHeartbeatInterval {
+				writeHeartbeat("keepalive")
+			}
+			events, err := s.agentRuns.ListTurnEvents(ctx, p, turnID, afterSeq, limit)
+			if err != nil {
+				writeStreamError(err)
+				return
+			}
+			pageFull = writeEvents(events)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Send an initial SSE heartbeat after validating agent turn streams so quiet turns open the response immediately.
- Continue sending keepalive SSE comments when no turn events have been written recently.
- Add a regression test for quiet running turns with no emitted events.

## Test plan
- [x] `go test ./internal/server -run 'TestAgentTurnEventStreamSendsHeartbeatBeforeEvents|TestAgentInteractionResolutionAndEventStream'` from `gestaltd`
- [x] `go test ./internal/server` from `gestaltd`