### PR TITLE
Accept Struct integer values in Python SDK decoding

### DIFF
--- a/sdk/python/gestalt/_operations.py
+++ b/sdk/python/gestalt/_operations.py
@@ -215,6 +215,8 @@ def _decode_int(value: Any) -> int:
         return int(value)
     if isinstance(value, int):
         return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
     if isinstance(value, str):
         return int(value)
     raise TypeError(f"expected int, got {type(value).__name__}")

--- a/sdk/python/tests/test_operations.py
+++ b/sdk/python/tests/test_operations.py
@@ -62,6 +62,7 @@ class DecodeInputTests(unittest.TestCase):
     def test_decode_primitives(self) -> None:
         self.assertEqual(decode_input(str, {"value": "hello"}), "hello")
         self.assertEqual(decode_input(int, {"value": 42}), 42)
+        self.assertEqual(decode_input(int, {"value": 42.0}), 42)
         self.assertEqual(decode_input(int, {"value": "42"}), 42)
         self.assertEqual(decode_input(float, {"v": 3.14}), 3.14)
         self.assertEqual(decode_input(float, {"v": 3}), 3.0)


### PR DESCRIPTION
## Summary
- allow Python SDK int decoding to accept integer-valued floats emitted through protobuf Struct
- cover the Struct-style 42.0 case in primitive decoding tests

## Test plan
- uv run --project sdk/python pytest sdk/python/tests/test_operations.py