### PR TITLE
Prevent duplicate external identity connections

### DIFF
--- a/gestaltd/internal/server/external_identity_sync.go
+++ b/gestaltd/internal/server/external_identity_sync.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -10,6 +11,41 @@ import (
 )
 
 var errExternalIdentityAlreadyLinked = errors.New("external identity already linked")
+var errDuplicateExternalIdentityCredential = errors.New("duplicate external identity credential")
+
+type duplicateExternalIdentityCredentialError struct {
+	integration       string
+	connection        string
+	existingInstance  string
+	requestedInstance string
+}
+
+func (e *duplicateExternalIdentityCredentialError) Error() string {
+	connection := strings.TrimSpace(e.connection)
+	if connection == "" {
+		connection = "default"
+	}
+	existingInstance := strings.TrimSpace(e.existingInstance)
+	if existingInstance == "" {
+		existingInstance = "default"
+	}
+	requestedInstance := strings.TrimSpace(e.requestedInstance)
+	if requestedInstance == "" {
+		requestedInstance = "default"
+	}
+	return fmt.Sprintf(
+		"%s: integration %q connection %q is already connected as instance %q; reconnect that instance or disconnect it before adding instance %q",
+		errDuplicateExternalIdentityCredential,
+		strings.TrimSpace(e.integration),
+		connection,
+		existingInstance,
+		requestedInstance,
+	)
+}
+
+func (e *duplicateExternalIdentityCredentialError) Unwrap() error {
+	return errDuplicateExternalIdentityCredential
+}
 
 func (s *Server) syncStoredCredentialAuthorization(ctx context.Context, tok *core.ExternalCredential) error {
 	if s.authorizationProvider == nil || tok == nil {
@@ -20,6 +56,49 @@ func (s *Server) syncStoredCredentialAuthorization(ctx context.Context, tok *cor
 		return err
 	}
 	return s.ensureExternalIdentityLink(ctx, strings.TrimSpace(tok.SubjectID), ref)
+}
+
+func (s *Server) ensureNoDuplicateExternalIdentityCredential(ctx context.Context, tok *core.ExternalCredential) error {
+	if core.ExternalCredentialProviderMissing(s.externalCredentials) || tok == nil {
+		return nil
+	}
+	ref, ok, err := externalIdentityRefFromMetadataJSON(tok.MetadataJSON)
+	if err != nil || !ok {
+		return err
+	}
+	subjectID := strings.TrimSpace(tok.SubjectID)
+	connectionID := strings.TrimSpace(tok.ConnectionID)
+	if subjectID == "" || connectionID == "" {
+		return nil
+	}
+	tokens, err := s.externalCredentials.ListCredentialsForConnection(ctx, subjectID, connectionID)
+	if err != nil {
+		return err
+	}
+	for _, candidate := range tokens {
+		if candidate == nil {
+			continue
+		}
+		if strings.TrimSpace(candidate.Instance) == strings.TrimSpace(tok.Instance) {
+			continue
+		}
+		candidateRef, candidateOK, err := externalIdentityRefFromMetadataJSON(candidate.MetadataJSON)
+		if err != nil {
+			return err
+		}
+		if !candidateOK {
+			continue
+		}
+		if externalIdentityRefsEqual(candidateRef, ref) {
+			return &duplicateExternalIdentityCredentialError{
+				integration:       tok.Integration,
+				connection:        tok.Connection,
+				existingInstance:  candidate.Instance,
+				requestedInstance: tok.Instance,
+			}
+		}
+	}
+	return nil
 }
 
 func (s *Server) unlinkStoredCredentialAuthorization(ctx context.Context, tok *core.ExternalCredential) error {

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -159,7 +159,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		auditErr = errors.New("connection setup failed")
 		slog.ErrorContext(r.Context(), "post_connect failed", "provider", req.Integration, "error", err)
-		writeError(w, http.StatusBadGateway, "connection setup failed")
+		writeError(w, connectionSetupErrorStatus(err), connectionSetupAPIErrorMessage(err))
 		return
 	}
 
@@ -432,6 +432,9 @@ func (s *Server) storeCredentialFromMaterial(ctx context.Context, tm credentialM
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
+	if err := s.ensureNoDuplicateExternalIdentityCredential(ctx, tok); err != nil {
+		return nil, err
+	}
 	if err := s.externalCredentials.PutCredential(ctx, tok); err != nil {
 		return nil, err
 	}
@@ -569,6 +572,20 @@ func (s *Server) completeConnection(ctx context.Context, prov core.Provider, tm 
 		return nil, err
 	}
 	return &postConnectResult{Status: "connected", Integration: tm.Integration}, nil
+}
+
+func connectionSetupErrorStatus(err error) int {
+	if errors.Is(err, errDuplicateExternalIdentityCredential) {
+		return http.StatusConflict
+	}
+	return http.StatusBadGateway
+}
+
+func connectionSetupAPIErrorMessage(err error) string {
+	if errors.Is(err, errDuplicateExternalIdentityCredential) {
+		return err.Error()
+	}
+	return "connection setup failed"
 }
 
 func (s *Server) applyProviderPostConnect(ctx context.Context, prov core.Provider, tm credentialMaterial) (credentialMaterial, error) {

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -293,11 +293,16 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		auditErr = errors.New("connection setup failed")
 		slog.ErrorContext(r.Context(), "post_connect failed", "provider", providerName, "error", err)
+		status := connectionSetupErrorStatus(err)
+		pageMessage := "Gestalt could not finish saving this connection. Start the connection again from Integrations."
+		if errors.Is(err, errDuplicateExternalIdentityCredential) {
+			pageMessage = "This account is already connected. Reconnect the existing instance or disconnect it before adding another."
+		}
 		writeCallbackError(
-			http.StatusBadGateway,
-			"connection setup failed",
+			status,
+			connectionSetupAPIErrorMessage(err),
 			providerName+" connection failed",
-			"Gestalt could not finish saving this connection. Start the connection again from Integrations.",
+			pageMessage,
 		)
 		return
 	}

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -444,7 +444,11 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 	}
 	if _, err := s.completeConnection(credentialMaterialContext(r.Context(), completionPrincipal, tm), prov, tm); err != nil {
 		auditErr = errors.New("failed to store connection")
-		writeError(w, http.StatusInternalServerError, "failed to store connection")
+		status := http.StatusInternalServerError
+		if errors.Is(err, errDuplicateExternalIdentityCredential) {
+			status = http.StatusConflict
+		}
+		writeError(w, status, connectionSetupAPIErrorMessage(err))
 		return
 	}
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -19513,6 +19513,65 @@ func TestConnectManual(t *testing.T) {
 		}
 	})
 
+	t.Run("duplicate external identity under another instance is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		svc := testutil.NewStubServices(t)
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, &stubPostConnectManualProvider{
+				stubManualProvider: stubManualProvider{
+					StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
+				},
+				connectionParams: map[string]core.ConnectionParamDef{
+					"team_id": {Required: true},
+					"user_id": {Required: true},
+				},
+				postConnect: testSlackPostConnect,
+			})
+			cfg.DefaultConnection = map[string]string{"manual-svc": config.PluginConnectionName}
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		connect := func(instance, credential string) *http.Response {
+			t.Helper()
+			body := bytes.NewBufferString(fmt.Sprintf(`{"integration":"manual-svc","instance":%q,"credential":%q,"connectionParams":{"team_id":"T123","user_id":"U456"}}`, instance, credential))
+			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			return resp
+		}
+
+		firstResp := connect("sa", "first-key")
+		defer func() { _ = firstResp.Body.Close() }()
+		if firstResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(firstResp.Body)
+			t.Fatalf("expected first connect 200, got %d: %s", firstResp.StatusCode, body)
+		}
+
+		duplicateResp := connect("z", "duplicate-key")
+		defer func() { _ = duplicateResp.Body.Close() }()
+		if duplicateResp.StatusCode != http.StatusConflict {
+			body, _ := io.ReadAll(duplicateResp.Body)
+			t.Fatalf("expected duplicate connect 409, got %d: %s", duplicateResp.StatusCode, body)
+		}
+
+		u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
+		tokens, err := svc.ExternalCredentials.ListCredentials(context.Background(), principal.UserSubjectID(u.ID))
+		if err != nil {
+			t.Fatalf("ListCredentials: %v", err)
+		}
+		if len(tokens) != 1 {
+			t.Fatalf("expected exactly one stored token after duplicate rejection, got %d", len(tokens))
+		}
+		if tokens[0].Instance != "sa" || tokens[0].AccessToken != "first-key" {
+			t.Fatalf("unexpected stored token after duplicate rejection: %+v", tokens[0])
+		}
+	})
+
 	t.Run("selection_required", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary
- Reject storing a second credential for the same subject, connection, and provider-reported external identity under a different instance.
- Return HTTP 409 for duplicate connection attempts while preserving normal reconnects for the same instance.
- Add coverage for manual connection duplicate rejection.

## Test plan
- [x] go test ./internal/server -run TestConnectManual -count=1