### PR TITLE
Remove stale CLI compatibility paths

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -90,7 +90,7 @@ When repeated, `--config` files merge left-to-right. Maps deep-merge, later
 scalar values win, lists replace inherited lists, and `null` deletes inherited
 keys. By default, lockfiles and artifact paths stay rooted at the leftmost
 config file. `--lockfile` overrides only the lockfile path. `--artifacts-dir`
-keeps its existing config-relative behavior for backward compatibility.
+keeps the same config-relative resolution used by `sync` and `serve`.
 
 `provider dev --remote` is environment-agnostic: the URL is just the remote
 `gestaltd` instance to attach to. The local command only replaces source-backed

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1060,7 +1060,7 @@ plugins:
 | `execution` | Optional executable-plugin execution config. `execution.mode` is `local` or `hosted`; `execution.runtime` carries the hosted runtime fields. |
 | `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 | `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Supported providers derive plugin scoping from that `db` name using provider-native namespace config; Gestalt does not rewrite object-store names at the SDK transport layer. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
-| `s3` | Optional list of named `providers.s3` bindings exposed to the executable plugin through the SDK transport. A single binding also populates the default S3 SDK env var for compatibility. |
+| `s3` | Optional list of named `providers.s3` bindings exposed to the executable plugin through the SDK transport. A single binding also populates the default S3 SDK env var for SDK clients. |
 
 S3 bindings are exposed as `GESTALT_S3_SOCKET_<NAME>`. When exactly one S3
 binding is configured, Gestalt also sets `GESTALT_S3_SOCKET`.

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -63,9 +63,8 @@ its capabilities, not just the host-local child-process wrapper.
 ### Egress control
 
 Every provider entry supports `egress.allowedHosts` to declare which upstream
-hosts it can reach. Provider-level `allowedHosts` is no longer accepted. When
-`server.egress.defaultAction` is `deny`, providers without an explicit allowlist
-are blocked from host-mediated outbound requests.
+hosts it can reach. When `server.egress.defaultAction` is `deny`, providers
+without an explicit allowlist are blocked from host-mediated outbound requests.
 
 ```yaml
 server:

--- a/gestaltd/internal/daemon/provider_lifecycle_test.go
+++ b/gestaltd/internal/daemon/provider_lifecycle_test.go
@@ -26,7 +26,7 @@ func TestE2EProviderAddDefaultsToPackageSource(t *testing.T) {
 
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	writeProviderLifecycleTestFile(t, cfgPath, "apiVersion: gestaltd.config/v4\nplugins:\n")
+	writeProviderLifecycleTestFile(t, cfgPath, "apiVersion: gestaltd.config/v5\nplugins:\n")
 	indexURL := writeProviderLifecycleIndex(t, dir)
 
 	runGestaltd(t, "provider", "repo", "add", "local", indexURL, "--config", cfgPath)
@@ -149,7 +149,7 @@ func TestE2EProviderAddExactSourceAndRejectsRepeatedConfig(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "gestalt.yaml")
 	otherCfgPath := filepath.Join(dir, "other.yaml")
-	writeProviderLifecycleTestFile(t, cfgPath, "apiVersion: gestaltd.config/v4\nplugins:\n")
+	writeProviderLifecycleTestFile(t, cfgPath, "apiVersion: gestaltd.config/v5\nplugins:\n")
 	writeProviderLifecycleTestFile(t, otherCfgPath, "apiVersion: gestaltd.config/v5\n")
 	indexURL := writeProviderLifecycleIndex(t, dir)
 

--- a/gestaltd/internal/daemon/provider_registry.go
+++ b/gestaltd/internal/daemon/provider_registry.go
@@ -315,7 +315,6 @@ func runProviderAdd(args []string) error {
 	noLock := fs.Bool("no-lock", false, "do not update lockfile")
 	sync := fs.Bool("sync", false, "materialize prepared artifacts after locking")
 	exactSource := fs.Bool("exact-source", false, "write resolved provider-release metadata URL instead of package source")
-	fs.Bool("package-source", false, "accepted for compatibility; package sources are written by default")
 	dryRun := fs.Bool("dry-run", false, "print resolved package without editing")
 	fs.Var(&configPaths, "config", "path to config file")
 	fs.Var(&setFlags, "set", "set shallow entry field, e.g. path=/ui")

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -346,7 +346,7 @@ func printValidateUsage(w io.Writer) {
 	writeUsageLine(w, "Validation always stages source-backed providers in a temporary scratch dir.")
 	writeUsageLine(w, "Repeated --config flags merge left-to-right.")
 	writeUsageLine(w, "The --lockfile path follows normal CLI path resolution; --artifacts-dir keeps")
-	writeUsageLine(w, "its existing config-relative behavior on sync/serve paths for compatibility.")
+	writeUsageLine(w, "the same config-relative resolution used by sync and serve.")
 }
 
 func writeUsageLine(w io.Writer, line string) {


### PR DESCRIPTION
## Summary

- Remove the stale `gestaltd provider add --package-source` compatibility flag; package sources are already the default behavior.
- Update remaining daemon provider lifecycle E2E fixtures from `gestaltd.config/v4` to current `gestaltd.config/v5`.
- Reword CLI/security/S3 docs so they describe current behavior directly instead of old compatibility/rejection framing.

## Interface diff

`gestaltd provider add` no longer accepts the redundant compatibility flag:

```diff
 gestaltd provider add PACKAGE \
   --config gestalt.yaml \
   --repo valon \
   --name default \
-  --package-source
```

Current usage for package-source output is just the default command:

```bash
gestaltd provider add github.com/valon-technologies/gestalt-providers/ui/default \
  --config gestalt.yaml \
  --repo valon \
  --name root
```

Exact metadata URL output remains explicit:

```bash
gestaltd provider add github.com/valon-technologies/gestalt-providers/ui/default \
  --config gestalt.yaml \
  --repo valon \
  --name root \
  --exact-source
```

## Config fixture diff

```diff
-apiVersion: gestaltd.config/v4
+apiVersion: gestaltd.config/v5
 plugins:
```

## Verification

- `go test ./internal/daemon -run 'TestE2EProviderAddDefaultsToPackageSource|TestE2EProviderAddExactSourceAndRejectsRepeatedConfig'`
- `go test ./internal/daemon -run TestE2EProviderAddAndUpgradeWriteLockWithTokenedRepository`
- `rg -n "gestaltd\\.config/v[0-4]|--package-source|for backward compatibility|for compatibility|no longer accepted|external_credentials_v2|workload:|/api/v1/identities" gestaltd docs/content --glob '!gestaltd/ui/out/**' --glob '!gestaltd/services/ui/**/out/**' --glob '!**/*.min.js' --glob '!**/node_modules/**'`
