### PR TITLE
Document provider package lifecycle commands

### DIFF
--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -23,6 +23,54 @@ When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml
 2026/04/10 10:00:01 INFO gestaltd ready url=http://localhost:8080
 ```
 
+## Try provider package commands
+
+The generated config is a normal Gestalt config file. In another terminal, list
+the providers it is using:
+
+```sh
+gestaltd provider list --config ~/.gestaltd/config.yaml
+```
+
+Search the first-party provider repository:
+
+```sh
+gestaltd provider search httpbin --config ~/.gestaltd/config.yaml
+gestaltd provider info github.com/valon-technologies/gestalt-providers/plugins/httpbin --config ~/.gestaltd/config.yaml
+```
+
+Add a second HTTPBin plugin entry from the package index:
+
+```sh
+gestaltd provider add github.com/valon-technologies/gestalt-providers/plugins/httpbin \
+  --config ~/.gestaltd/config.yaml \
+  --name httpbin_demo
+```
+
+The command writes the provider entry and updates `~/.gestaltd/gestalt.lock.json`:
+
+```text
+Added plugin httpbin_demo
+Package: github.com/valon-technologies/gestalt-providers/plugins/httpbin
+Repository: valon
+Version: 0.0.1-alpha.3
+Config: ~/.gestaltd/config.yaml
+Lockfile: ~/.gestaltd/gestalt.lock.json
+```
+
+Refresh lock state after package-index updates:
+
+```sh
+gestaltd provider upgrade --config ~/.gestaltd/config.yaml
+```
+
+If `gestaltd` is already running, restart it before invoking the newly added
+plugin. To return to the default generated config, remove the extra entry:
+
+```sh
+gestaltd provider remove httpbin_demo --config ~/.gestaltd/config.yaml --kind plugin
+```
+
 ## Using the client
 
 In a separate terminal, run the setup wizard:

--- a/docs/content/providers/_meta.ts
+++ b/docs/content/providers/_meta.ts
@@ -1,4 +1,5 @@
 export default {
+  packages: "Provider Packages",
   agent: "Agent",
   authentication: "Authentication",
   authorization: "Authorization",

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -17,11 +17,11 @@ starts it with the permissions and request context it needs.
 | Kind | Purpose | Config location |
 | --- | --- | --- |
 | `plugin` | Tool providers that expose operations over CLI, HTTP API, and MCP | `plugins.<name>` |
-| `auth` | Platform authentication backends | `providers.authentication.<name>` |
+| `authentication` | Platform authentication backends | `providers.authentication.<name>` |
 | `authorization` | Dynamic subject authorization backends | `providers.authorization.<name>` |
 | `agent` | Global agent run backends that reason over messages and tools | `providers.agent.<name>` |
 | `cache` | Plugin-bound cache backends | `providers.cache.<name>` |
-| `external_credentials` | Subject-scoped third-party credential storage | `providers.external_credentials.<name>` |
+| `external_credentials` | Subject-scoped third-party credential storage | `providers.externalCredentials.<name>` |
 | `indexeddb` | Persistent state backends for users, sessions, tokens, and credentials | `providers.indexeddb.<name>` |
 | `runtime` | Hosted execution backends for executable plugins | `runtime.providers.<name>` |
 | `s3` | S3-compatible object stores mounted into plugins | `providers.s3.<name>` |
@@ -31,13 +31,18 @@ starts it with the permissions and request context it needs.
 
 ## How providers work
 
+- Use [Provider Packages](/providers/packages) for published providers that are
+  listed in a provider repository. Package sources keep a package address and
+  version constraint in config, so `gestaltd provider add`, `list`, `remove`,
+  and `upgrade` can manage them directly.
 - Use `source.path` during local development to point at a provider manifest in
   a local source tree.
-- Use `source: https://.../provider-release.yaml` to consume a published provider package.
+- Use `source: https://.../provider-release.yaml` when you need an exact
+  metadata URL outside a provider repository.
 - Use `source.githubRelease` when the published `provider-release.yaml` lives in
   a private GitHub Release and you want checked-in config to stay readable.
-- Use sibling `auth.token` when a remote release source, including
-  `source.githubRelease`, needs authenticated metadata or archive fetches.
+- Use `source.auth.token` when a package repository, remote release source, or
+  `source.githubRelease` needs authenticated metadata or archive fetches.
 - Executable providers run as child processes and connect back to the host over
   gRPC on a temporary Unix socket.
 - UI providers are static asset bundles rather than executable processes.
@@ -72,7 +77,17 @@ a custom provider with the neutral agent protocol described in
 
 ## Using providers
 
-Reference the package you want to run, then initialize or start the server:
+Use `gestaltd provider add` when the package is indexed:
+
+```sh
+gestaltd provider add github.com/valon-technologies/gestalt-providers/auth/oidc \
+  --config ./gestalt.yaml \
+  --kind authentication \
+  --name oidc
+gestaltd provider list --config ./gestalt.yaml
+```
+
+The command writes a package source and updates the lockfile by default:
 
 ```yaml
 server:
@@ -82,7 +97,8 @@ server:
 providers:
   authentication:
     oidc:
-      source: https://artifacts.example.com/auth/oidc/v0.0.1-alpha.1/provider-release.yaml
+      source:
+        package: github.com/valon-technologies/gestalt-providers/auth/oidc
       config:
         issuerUrl: https://login.example.com
         clientId: ${OIDC_CLIENT_ID}
@@ -93,13 +109,15 @@ providers:
 
   indexeddb:
     main:
-      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      source:
+        package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
       config:
         dsn: ${DATABASE_URL}
 
   cache:
     session:
-      source: https://artifacts.example.com/cache/valkey/v0.0.1-alpha.1/provider-release.yaml
+      source:
+        package: github.com/valon-technologies/gestalt-providers/cache/valkey
       config:
         address: ${VALKEY_ADDR}
 
@@ -117,7 +135,8 @@ providers:
 
 plugins:
   github:
-    source: https://artifacts.example.com/plugin/github/v0.0.1-alpha.1/provider-release.yaml
+    source:
+      package: github.com/valon-technologies/gestalt-providers/plugins/github
     cache:
       - session
 

--- a/docs/content/providers/packages.mdx
+++ b/docs/content/providers/packages.mdx
@@ -1,0 +1,356 @@
+# Provider Packages
+
+Provider packages let a config name a package address and version constraint
+instead of a release metadata URL. Use package sources for indexed providers
+that should be easy to search, add, list, remove, and upgrade from the CLI.
+
+```sh
+gestaltd provider search github
+gestaltd provider info github.com/valon-technologies/gestalt-providers/plugins/github
+gestaltd provider add github.com/valon-technologies/gestalt-providers/plugins/github --config ./gestalt.yaml --name github
+```
+
+`provider add` writes a package source by default:
+
+```yaml
+apiVersion: gestaltd.config/v5
+plugins:
+  github:
+    source:
+      package: github.com/valon-technologies/gestalt-providers/plugins/github
+```
+
+Then it resolves the selected release and updates the lockfile unless
+`--no-lock` is set.
+
+## Search for a Package
+
+The built-in `valon` repository points at the first-party provider index.
+
+```sh
+gestaltd provider search
+gestaltd provider search github
+gestaltd provider search github --repo valon
+```
+
+Search matches the package address, display name, and description. The output
+prints repository name, package address, and display name:
+
+```text
+valon  github.com/valon-technologies/gestalt-providers/plugins/github  GitHub
+```
+
+Use `provider info` to see the versions published for one package:
+
+```sh
+gestaltd provider info github.com/valon-technologies/gestalt-providers/plugins/github
+```
+
+## Add a Provider
+
+Add the package to one writable config file:
+
+```sh
+gestaltd provider add github.com/valon-technologies/gestalt-providers/plugins/github \
+  --config ./gestalt.yaml \
+  --name github
+```
+
+Mutating provider commands accept one `--config` path. This keeps the command
+from guessing which file should be edited when your normal runtime uses layered
+config.
+
+Set a version constraint when you want future upgrades to stay inside a range:
+
+```sh
+gestaltd provider add github.com/valon-technologies/gestalt-providers/auth/oidc \
+  --config ./gestalt.yaml \
+  --kind authentication \
+  --name oidc \
+  --version '^1.4.0'
+```
+
+When no version is given, Gestalt chooses the newest non-yanked stable version.
+If a package has no stable versions, it chooses the newest non-yanked
+prerelease. Yanked versions are skipped unless you request an exact yanked
+version.
+
+`provider add` validates the changed config and lockfile in a scratch
+directory before writing either file.
+
+## Add Providers by Kind
+
+Gestalt usually infers the config location from the package metadata. Pass
+`--kind` when you need to override that location.
+
+| Kind | Config location | Notes |
+| --- | --- | --- |
+| `plugin` | `plugins.<name>` | Default location for plugin packages. |
+| `ui` | `providers.ui.<name>` | Requires `--set path=/mount` when adding a directly mounted UI. |
+| `authentication` | `providers.authentication.<name>` | Select with `server.providers.authentication` when more than one exists. |
+| `authorization` | `providers.authorization.<name>` | Select with `server.providers.authorization` when more than one exists. |
+| `external_credentials` | `providers.externalCredentials.<name>` | Select with `server.providers.externalCredentials` when more than one exists. |
+| `secrets` | `providers.secrets.<name>` | Select with `server.providers.secrets` when more than one exists. |
+| `indexeddb` | `providers.indexeddb.<name>` | Select with `server.providers.indexeddb`. |
+| `cache` | `providers.cache.<name>` | Bind from `plugins.<name>.cache`. |
+| `s3` | `providers.s3.<name>` | Bind from `plugins.<name>.s3`. |
+| `workflow` | `providers.workflow.<name>` | Bind from workflow schedules and triggers. |
+| `agent` | `providers.agent.<name>` | Used by agent sessions and turns. |
+| `runtime` | `runtime.providers.<name>` | Used by hosted executable providers. |
+
+`provider add` does not create telemetry or audit providers yet. Existing
+telemetry and audit entries can still appear in `provider list`, lockfiles, and
+package-source upgrades.
+
+Add a directly mounted UI with a path:
+
+```sh
+gestaltd provider add github.com/acme/gestalt-providers/ui/console \
+  --config ./gestalt.yaml \
+  --kind ui \
+  --name console \
+  --set path=/console
+```
+
+## List Providers
+
+`provider list` shows configured provider entries and how they relate to the
+lockfile:
+
+```sh
+gestaltd provider list --config ./gestalt.yaml
+gestaltd provider list --config ./gestalt.yaml --kind plugin
+```
+
+Output columns:
+
+| Column | Meaning |
+| --- | --- |
+| `KIND` | Provider kind and config collection. |
+| `NAME` | Config entry name. |
+| `SOURCE` | Source shape: `package`, `metadata`, `github`, `local`, `builtin`, or `unsupported`. |
+| `PACKAGE` | Package address for package sources. |
+| `VERSION` | Version constraint from config. |
+| `LOCKED` | Exact version recorded in the lockfile. |
+| `STATUS` | Lock status for the entry. |
+
+Status values:
+
+| Status | Meaning |
+| --- | --- |
+| `builtin` | Built into `gestaltd`; no release artifact is locked. |
+| `locked` | The lockfile matches the current source config. |
+| `unverified` | The config and lock agree on package and version, but this list operation did not re-resolve package metadata. |
+| `unlocked` | The source-backed entry has no matching lock entry. |
+| `drifted` | A lock entry exists, but it no longer matches the current source config. |
+
+Run `gestaltd lock --check --config ./gestalt.yaml` in CI when you need a
+strict lockfile check.
+
+## Upgrade Providers
+
+Refresh lock state for every configured package source:
+
+```sh
+gestaltd provider upgrade --config ./gestalt.yaml
+```
+
+This does not edit version constraints. It re-resolves package sources and
+writes the lockfile with the selected versions.
+
+Change one package source to a new constraint:
+
+```sh
+gestaltd provider upgrade github \
+  --config ./gestalt.yaml \
+  --kind plugin \
+  --version '^1.5.0'
+```
+
+The named entry must already be a package source. If the same name exists under
+more than one provider kind, pass `--kind`.
+
+## Remove a Provider
+
+Remove one entry from config and update the lockfile:
+
+```sh
+gestaltd provider remove github --config ./gestalt.yaml --kind plugin
+```
+
+Omit `--kind` only when the name is unique across provider kinds.
+
+## Use Provider Repositories
+
+A provider repository is a static YAML index. Gestalt fetches the index, picks a
+version, then fetches that version's `provider-release.yaml`. Normal package
+resolution does not call the GitHub Releases API.
+
+The default repository is named `valon`:
+
+```text
+https://raw.githubusercontent.com/valon-technologies/gestalt-providers/main/provider-index.yaml
+```
+
+List configured repositories:
+
+```sh
+gestaltd provider repo list
+gestaltd provider repo list --config ./gestalt.yaml
+```
+
+Add a repository to your user-level store:
+
+```sh
+gestaltd provider repo add acme https://artifacts.example.com/gestalt/provider-index.yaml
+```
+
+Add a repository to project config:
+
+```sh
+gestaltd provider repo add acme https://artifacts.example.com/gestalt/provider-index.yaml \
+  --config ./gestalt.yaml
+```
+
+The project form writes:
+
+```yaml
+providerRepositories:
+  acme:
+    url: https://artifacts.example.com/gestalt/provider-index.yaml
+```
+
+Project config overrides the repository URL for that project. A user-level
+repository with the same name can still supply a token for private indexes.
+
+Fetch repository indexes into the local cache:
+
+```sh
+gestaltd provider repo update
+gestaltd provider repo update --config ./gestalt.yaml
+```
+
+Remove a repository from the same place you added it:
+
+```sh
+gestaltd provider repo remove acme
+gestaltd provider repo remove acme --config ./gestalt.yaml
+```
+
+Use `source.repo` when the package should resolve from a non-default
+repository, or when the same package address exists in more than one repository:
+
+```yaml
+plugins:
+  support:
+    source:
+      repo: acme
+      package: github.com/acme/gestalt-providers/plugins/support
+      version: ^1.3.0
+```
+
+## Publish an Index
+
+A provider index is ordinary YAML:
+
+```yaml
+schema: gestaltd-provider-index
+schemaVersion: 1
+packages:
+  github.com/acme/gestalt-providers/plugins/support:
+    displayName: Support
+    description: Internal support tools
+    versions:
+      1.3.0:
+        kind: plugin
+        runtime: go
+        metadata: ./plugins/support/1.3.0/provider-release.yaml
+        platforms:
+          - darwin/arm64
+          - linux/amd64
+```
+
+`metadata` may be an absolute `https://` or `file://` URL, or a relative path
+resolved from the index URL. Keep the index small enough to fetch often; Gestalt
+rejects indexes larger than 10 MiB.
+
+## Use Exact Sources
+
+Package sources are the default because they keep the package address and
+version constraint in config. Use exact sources when you need to pin something
+outside an index, such as a one-off metadata URL, a local release file, or a
+private GitHub Release asset.
+
+Write the resolved metadata URL instead of a package source:
+
+```sh
+gestaltd provider add github.com/acme/gestalt-providers/plugins/support \
+  --config ./gestalt.yaml \
+  --repo acme \
+  --exact-source
+```
+
+The resulting config looks like:
+
+```yaml
+plugins:
+  support:
+    source: https://artifacts.example.com/gestalt/plugins/support/1.3.0/provider-release.yaml
+```
+
+Exact sources do not retain repository or version-constraint data, so
+`provider upgrade NAME --version ...` cannot move them to a new package version.
+Edit the source manually or re-add the provider as a package source.
+
+For private metadata or archives, put fetch credentials under `source.auth`:
+
+```yaml
+plugins:
+  support:
+    source:
+      repo: acme
+      package: github.com/acme/gestalt-providers/plugins/support
+      version: ^1.3.0
+      auth:
+        token: ${GESTALT_PROVIDER_TOKEN}
+```
+
+Use `source.githubRelease` when the checked-in config should name a GitHub
+release asset logically:
+
+```yaml
+plugins:
+  support:
+    source:
+      githubRelease:
+        repo: acme/gestalt-provider-releases
+        tag: plugins/support/v1.3.0
+        asset: provider-release.yaml
+      auth:
+        token: ${GITHUB_TOKEN}
+```
+
+GitHub release sources use GitHub release asset lookup. Package sources use the
+static provider repository index instead.
+
+## Lock and Sync
+
+`provider add`, `provider remove`, and `provider upgrade NAME --version ...`
+update the lockfile by default. `provider add` and `provider remove` accept
+`--no-lock` when you need to edit config first and run `gestaltd lock` later.
+
+Materialize artifacts immediately after adding a provider:
+
+```sh
+gestaltd provider add github.com/valon-technologies/gestalt-providers/plugins/github \
+  --config ./gestalt.yaml \
+  --sync
+```
+
+For production deployments, keep the same three-step lifecycle:
+
+```sh
+gestaltd lock --config ./gestalt.yaml
+gestaltd sync --locked --config ./gestalt.yaml
+gestaltd serve --locked --config ./gestalt.yaml
+```

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -33,6 +33,21 @@ import { Callout } from 'nextra/components'
 
 | Command | Purpose |
 | --- | --- |
+| `gestaltd provider search [QUERY]` | Search configured provider repositories. Pass `--repo NAME` to search one repository. |
+| `gestaltd provider info PACKAGE` | Show available versions and release metadata for one package. Pass `--repo NAME` to disambiguate. |
+| `gestaltd provider add PACKAGE --config PATH` | Add an indexed provider package to config and update the lockfile. Package sources are written by default. |
+| `gestaltd provider add PACKAGE --kind KIND --name NAME` | Choose the provider kind and config entry name explicitly. UI providers also require `--set path=/mount`. |
+| `gestaltd provider add PACKAGE --version CONSTRAINT` | Write a semver version constraint such as `^1.4.0`, `~1.4.0`, or an exact version. |
+| `gestaltd provider add PACKAGE --exact-source` | Write the resolved `provider-release.yaml` URL instead of a package source. |
+| `gestaltd provider add PACKAGE --sync` | Materialize prepared artifacts after locking. |
+| `gestaltd provider list --config PATH` | List configured providers and lock status. Pass `--kind KIND` to filter. |
+| `gestaltd provider remove NAME --config PATH` | Remove one provider entry and update the lockfile. Pass `--kind KIND` when the name is ambiguous. |
+| `gestaltd provider upgrade --config PATH` | Refresh lock state for all package sources without editing config version constraints. |
+| `gestaltd provider upgrade NAME --version CONSTRAINT` | Change one package source's version constraint and update the lockfile. |
+| `gestaltd provider repo add NAME URL` | Add a provider repository to the user-level store. Pass `--config PATH` to write `providerRepositories` into project config instead. |
+| `gestaltd provider repo list` | List the default, user-level, and project provider repositories. |
+| `gestaltd provider repo update` | Fetch and cache provider repository indexes. |
+| `gestaltd provider repo remove NAME` | Remove a provider repository from the user-level store. Pass `--config PATH` to remove it from project config instead. |
 | `gestaltd provider dev --path PATH` | Run a local source plugin or UI bundle inside a synthesized Gestalt config. Serves `/admin` and any configured or inferred public UIs. |
 | `gestaltd provider dev --config PATH` | Layer supporting providers, plugins, and UI mounts on top of the synthesized local baseline. Repeat `--config` to merge left-to-right. |
 | `gestaltd provider dev --remote URL --path PATH` | Attach one local source plugin to an authenticated remote `gestaltd` session. The remote server matches by manifest `source` and keeps its configured auth, authorization, connections, plugin config, and host services. |
@@ -53,6 +68,13 @@ precedence for plugin-owned or sibling UI, and explicit
 `providers.ui.<name>.path` values take precedence when developing a UI bundle
 directly.
 
+Provider package commands use the provider repository model described in
+[Provider Packages](/providers/packages). Mutating package commands accept one
+`--config` path so the CLI edits the intended file instead of a merged runtime
+view. `provider add`, `provider remove`, and `provider upgrade NAME --version`
+update the lockfile by default. `provider add` and `provider remove` accept
+`--no-lock` when you need to edit config only.
+
 ## Examples
 
 ```sh
@@ -68,6 +90,19 @@ gestaltd serve --locked --config ./config.yaml --lockfile ./local/gestalt.lock.j
 gestaltd lock --config ./base.yaml --config ./overrides/prod.yaml
 gestaltd sync --locked --config ./base.yaml --config ./overrides/prod.yaml
 gestaltd serve --locked --config ./base.yaml --config ./overrides/prod.yaml
+gestaltd provider search github
+gestaltd provider info github.com/valon-technologies/gestalt-providers/plugins/github
+gestaltd provider repo list
+gestaltd provider repo add acme https://artifacts.example.com/gestalt/provider-index.yaml --config ./config.yaml
+gestaltd provider repo update --config ./config.yaml
+gestaltd provider add github.com/valon-technologies/gestalt-providers/plugins/github --config ./config.yaml --name github
+gestaltd provider add github.com/valon-technologies/gestalt-providers/auth/oidc --config ./config.yaml --kind authentication --name oidc --version '^1.4.0'
+gestaltd provider add github.com/acme/gestalt-providers/ui/console --config ./config.yaml --repo acme --kind ui --name console --set path=/console
+gestaltd provider list --config ./config.yaml
+gestaltd provider list --config ./config.yaml --kind plugin
+gestaltd provider upgrade --config ./config.yaml
+gestaltd provider upgrade github --config ./config.yaml --kind plugin --version '^1.5.0'
+gestaltd provider remove github --config ./config.yaml --kind plugin
 gestaltd provider validate --path ./plugins/support
 gestaltd provider validate --path ./ui/dashboard
 gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml --config ./dev/local.yaml

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -10,9 +10,10 @@ them left-to-right before validation and bootstrap. The top-level keys are
 `authorization` (shared subject access policy), `connections` (reusable
 upstream credential definitions), `providers` (named
 authentication, secrets, telemetry, audit, UI, indexeddb, authorization,
-workflow, cache, s3, and agent entries), `runtime` (hosted execution backends),
-`workflows` (config-managed schedules and triggers), and `plugins`
-(executable integrations and optional plugin-backed UI mounts):
+workflow, cache, s3, and agent entries), `providerRepositories` (package index
+URLs), `runtime` (hosted execution backends), `workflows` (config-managed
+schedules and triggers), and `plugins` (executable integrations and optional
+plugin-backed UI mounts):
 
 ```yaml
 apiVersion: gestaltd.config/v5
@@ -21,6 +22,7 @@ server:
 authorization:
   policies: {}
 connections: {}
+providerRepositories: {}
 runtime:
   providers: {}
 providers:
@@ -103,6 +105,29 @@ gestaltd validate --config ./base.yaml --config ./overrides/local.yaml
 The resulting config keeps `server.public.port`, adds `server.management.port`,
 replaces `plugins.github.egress.allowedHosts`, resolves `iconFile` relative to
 `./overrides/local.yaml`, and deletes the inherited `displayName`.
+
+## `providerRepositories`
+
+`providerRepositories` declares package indexes that this project can use for
+package sources. The built-in `valon` repository points at the first-party
+provider index, so most first-party packages do not need a project-level
+repository entry.
+
+```yaml
+providerRepositories:
+  acme:
+    url: https://artifacts.example.com/gestalt/provider-index.yaml
+```
+
+Use `gestaltd provider repo add NAME URL --config ./gestalt.yaml` to write this
+section from the CLI. Without `--config`, repository commands edit the
+user-level repository store instead. When the same repository name appears in
+both places, project config supplies the URL and the user-level store can still
+supply a token.
+
+| Field | Description |
+| --- | --- |
+| `providerRepositories.<name>.url` | HTTP(S) or `file://` URL for a `gestaltd-provider-index` YAML file. |
 
 ## `server`
 
@@ -222,7 +247,7 @@ plugins that set `execution.mode: hosted` without an explicit
 | Field | Description |
 | --- | --- |
 | `providers.<name>.driver` | Optional built-in runtime selector. The only built-in runtime is `local`. |
-| `providers.<name>.source` | Source or provider-release reference for an installable `kind: runtime` provider such as Modal. |
+| `providers.<name>.source` | Package source, local manifest path, metadata URL, `source.url`, or `source.githubRelease` for an installable `kind: runtime` provider such as Modal. |
 | `providers.<name>.default` | Marks the runtime as the default selection when `server.runtime.defaultHostedProvider` is omitted. Only one runtime may be default. |
 | `providers.<name>.config` | Runtime-provider-specific config blob. Built-ins such as `local` reject custom config entirely. |
 
@@ -351,8 +376,8 @@ Authentication providers use the same `ProviderEntry` shape under `providers.aut
 | Field | Description |
 | --- | --- |
 | `default` | Marks this named authentication entry as the default selection when `server.providers.authentication` is omitted. |
-| `source` | Either a local provider manifest path, a published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
-| `source.auth` | Optional metadata-fetch auth for release sources, including direct metadata URLs and `source.githubRelease`. |
+| `source` | Package source, local provider manifest path, published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
+| `source.auth` | Optional metadata-fetch auth for package repositories, direct metadata URLs, local release metadata, and `source.githubRelease`. |
 | `config` | Provider-specific config passed into the authentication provider. |
 | `env` | Extra environment variables passed to the provider process. |
 | `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
@@ -429,8 +454,8 @@ The exact config fields depend on the selected authorization provider package. T
 | Field | Description |
 | --- | --- |
 | `default` | Marks this named authorization entry as the default selection when `server.providers.authorization` is omitted. |
-| `source` | Either a local provider manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
-| `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
+| `source` | Package source, local provider manifest path, published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
+| `source.auth` | Optional inline source auth for package repositories, remote release sources, direct metadata URLs, and `source.githubRelease`. |
 | `config` | Provider-specific config passed into the authorization provider. |
 | `env` | Extra environment variables passed to the provider process. |
 | `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
@@ -497,8 +522,8 @@ allowlist logical stores exposed through that binding.
 | Field | Description |
 | --- | --- |
 | `default` | Marks this named workflow entry as the default selection when a config-managed workflow object or API request omits `provider`. |
-| `source` | Either a local provider manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
-| `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
+| `source` | Package source, local provider manifest path, published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
+| `source.auth` | Optional inline source auth for package repositories, remote release sources, direct metadata URLs, and `source.githubRelease`. |
 | `config` | Provider-specific config passed into the workflow provider. |
 | `indexeddb` | Optional host IndexedDB binding for the workflow provider, including `provider`, optional `db`, and optional `objectStores`. |
 | `env` | Extra environment variables passed to the provider process. |
@@ -560,8 +585,8 @@ operator-facing egress policy.
 | Field | Description |
 | --- | --- |
 | `default` | Marks this named agent entry as the default selection when a session request omits `provider`. |
-| `source` | Either a local provider manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
-| `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
+| `source` | Package source, local provider manifest path, published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
+| `source.auth` | Optional inline source auth for package repositories, remote release sources, direct metadata URLs, and `source.githubRelease`. |
 | `indexeddb` | Optional agent IndexedDB config. `indexeddb.provider` selects the named `providers.indexeddb` entry backing the agent's single IndexedDB SDK socket; unlike plugins, agents do not inherit the selected/default host IndexedDB automatically. `indexeddb.db` overrides the provider-visible database name and defaults to the agent provider key. `indexeddb.objectStores` optionally allowlists logical object stores the agent may use. |
 | `config` | Provider-specific config passed into the agent provider. |
 | `env` | Extra environment variables passed to the provider process. |
@@ -686,8 +711,8 @@ First-party cache providers are published at
 
 | Field | Description |
 | --- | --- |
-| `source` | Either a local provider manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
-| `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
+| `source` | Package source, local provider manifest path, published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
+| `source.auth` | Optional inline source auth for package repositories, remote release sources, direct metadata URLs, and `source.githubRelease`. |
 | `config` | Arbitrary provider-specific config passed through to the cache provider. |
 | `env` | Extra environment variables passed to the provider process. |
 | `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
@@ -1048,7 +1073,7 @@ plugins:
 | `authorizationPolicy` | Optional shared subject access policy from `authorization.policies`. When set, host-side operation filtering and execution checks use the resolved role for this plugin, and the built-in admin UI / admin API can manage plugin-scoped dynamic grants for additional members. Static policy members still take precedence. |
 | `ui` | Optional plugin-backed mounted UI binding. Use `ui.path` plus optional `ui.bundle`. `ui.bundle` names a `providers.ui` entry; omit it to mount the plugin manifest's owned `spec.ui`. |
 | `source` | **Required.** The backing provider source. See [source shape](#pluginssource) below. |
-| `source.auth` | Optional metadata-fetch auth for release sources. Use this for `source.url`, `source.githubRelease`, or local `provider-release.yaml` metadata. |
+| `source.auth` | Optional metadata-fetch auth for package repositories, `source.url`, `source.githubRelease`, or local `provider-release.yaml` metadata. |
 | `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either the reserved `server` alias or a named entry from `providers.authentication`. Gestalt enforces this on plugin HTTP operation routes (`/api/v1/integrations/{name}/operations` and `/api/v1/{integration}/{operation}`) and on plugin-backed mounted UIs, including browser-login flows whose `next` path resolves into that plugin's mount. Standalone `providers.ui` bundles, the built-in admin UI/admin API, and `/mcp` still use the server-wide auth provider in this phase. |
 | `config` | Provider-specific configuration passed into the provider package. |
 | `securitySchemes` | Optional hosted HTTP security scheme overrides merged over the plugin manifest's `spec.securitySchemes`. Use this for deployment-specific secrets or for deployment-local hosted HTTP bindings. |
@@ -1068,6 +1093,30 @@ binding is configured, Gestalt also sets `GESTALT_S3_SOCKET`.
 ### `plugins.*.source`
 
 Every plugin uses a `source` block to declare its backing provider.
+
+For indexed providers, use a package source:
+
+```yaml
+source:
+  package: github.com/valon-technologies/gestalt-providers/plugins/github
+  version: ^1.2.0
+```
+
+Add `repo` when the package comes from a non-default provider repository, or
+when the package address exists in more than one repository:
+
+```yaml
+source:
+  repo: acme
+  package: github.com/acme/gestalt-providers/plugins/support
+  version: ^1.3.0
+```
+
+`gestaltd provider add` writes package sources by default. See
+[Provider Packages](/providers/packages) for repository, add, list, remove, and
+upgrade behavior.
+
+For exact published releases, point at a `provider-release.yaml` URL:
 
 ```yaml
 source: https://artifacts.example.com/plugin/github/v1.2.3/provider-release.yaml
@@ -1229,8 +1278,8 @@ Gestalt synthesizes Go and Rust executable wrappers automatically when needed an
 
 | Field | Description |
 | --- | --- |
-| `source` | A local provider manifest path, a published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
-| `source.auth` | Optional metadata-fetch auth for release sources, including direct metadata URLs, `source.githubRelease`, and local `provider-release.yaml` metadata. |
+| `source` | Package source, local provider manifest path, published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
+| `source.auth` | Optional metadata-fetch auth for package repositories, direct metadata URLs, `source.githubRelease`, and local `provider-release.yaml` metadata. |
 | `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either `server` or a named `providers.authentication` entry. Gestalt enforces this on plugin HTTP operation routes and on plugin-backed mounted UIs. Standalone `providers.ui` bundles, the built-in admin UI/admin API, and `/mcp` still use the server-wide auth provider in this phase. |
 | `env` | Extra environment variables passed to the provider process. |
 | `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
@@ -1504,8 +1553,8 @@ When `authorizationPolicy` is set on a mounted UI, the referenced UI manifest mu
 | --- | --- |
 | `path` | Direct mount prefix for this UI when not bound through `plugins.<name>.ui.path`. |
 | `authorizationPolicy` | Direct policy binding for this UI when not bound through `plugins.<name>.ui.path`. |
-| `source` | A local UI manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
-| `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
+| `source` | Package source, local UI manifest path, published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
+| `source.auth` | Optional inline source auth for package repositories, remote release sources, direct metadata URLs, and `source.githubRelease`. |
 | `config` | Optional UI-provider config validated against the bundle schema when present. |
 
 ## Validation rules
@@ -1514,7 +1563,9 @@ Structural validation runs at config load time (`lock`, `sync`, `validate`, `ser
 
 ### Structural
 
-Each plugin must set `source` to exactly one loading mode: a local manifest path or a published `provider-release.yaml` metadata URL.
+Each plugin must set `source` to exactly one loading mode: package source,
+local manifest path, published `provider-release.yaml` metadata URL,
+`source.url`, or `source.githubRelease`.
 
 Host-provider entries use the same ProviderEntry shape. When
 `providers.authentication.<name>`, `providers.cache.<name>`,
@@ -1530,7 +1581,11 @@ connections that collect or exchange credentials are not supported; declare a
 top-level connection and reference it with `ref`. All connections in a plugin
 must share the same mode.
 
-Each `providers.ui.<name>` entry must set `source` to exactly one loading mode: a local UI manifest path or a published `provider-release.yaml` metadata URL. `providers.ui.<name>.config` is only allowed when `providers.ui.<name>.source` is set.
+Each `providers.ui.<name>` entry must set `source` to exactly one loading mode:
+package source, local UI manifest path, published `provider-release.yaml`
+metadata URL, `source.url`, or `source.githubRelease`.
+`providers.ui.<name>.config` is only allowed when
+`providers.ui.<name>.source` is set.
 
 Each `plugins.<name>` entry may set `ui.path` to publish a plugin-backed UI. When `ui.bundle` is set, it must reference an existing UI bundle. When `ui.bundle` is omitted, the plugin manifest must declare `spec.ui`. A given UI may be bound by at most one plugin entry. `ui.path` must use the same path rules as a directly mounted UI.
 


### PR DESCRIPTION
## Summary
- add a Provider Packages guide under docs/content/providers covering search/info/add/list/remove/upgrade and repo commands
- add a Getting Started package-command walkthrough using the smoke-tested HTTPBin example
- update provider overview to point at package sources instead of raw release URLs
- add CLI and config reference coverage for package sources and providerRepositories

## Verification
- smoke: `provider add/search/info/list/upgrade/remove` against an isolated generated config using `github.com/valon-technologies/gestalt-providers/plugins/httpbin`
- npm ci
- npm run typecheck
- npm run build

Style references: uv dependency docs, Helm repository docs, and Terraform provider initialization docs.