### PR TITLE
Do not force catalog tools for unsupported agents

### DIFF
--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -338,6 +338,7 @@ type memoryAgentProvider struct {
 	listTurnRequests    []coreagent.ListTurnsRequest
 	createSessionHook   func()
 	listTurnEventsErr   error
+	capabilities        *coreagent.ProviderCapabilities
 }
 
 func newMemoryAgentProvider() *memoryAgentProvider {
@@ -662,6 +663,11 @@ func (p *memoryAgentProvider) ResolveInteraction(_ context.Context, req coreagen
 }
 
 func (p *memoryAgentProvider) GetCapabilities(context.Context, coreagent.GetCapabilitiesRequest) (*coreagent.ProviderCapabilities, error) {
+	if p.capabilities != nil {
+		caps := *p.capabilities
+		caps.SupportedToolSources = append([]coreagent.ToolSourceMode(nil), p.capabilities.SupportedToolSources...)
+		return &caps, nil
+	}
 	return &coreagent.ProviderCapabilities{
 		StreamingText:        true,
 		ToolCalls:            true,
@@ -1053,7 +1059,7 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	}
 }
 
-func TestAgentTurnToolRefsDefaultBroadAndExplicitEmpty(t *testing.T) {
+func TestAgentTurnToolRefsDefaultBroadAndExplicitEmptyNone(t *testing.T) {
 	t.Parallel()
 
 	provider := newMemoryAgentProvider()
@@ -1133,11 +1139,68 @@ func TestAgentTurnToolRefsDefaultBroadAndExplicitEmpty(t *testing.T) {
 	if got := turnRequests[0].ToolRefs; len(got) != 1 || got[0].Plugin != "*" || got[0].Operation != "" {
 		t.Fatalf("omitted toolRefs provider refs = %#v, want global broad ref", got)
 	}
-	if got := turnRequests[1].ToolRefs; len(got) != 1 || got[0].Plugin != "*" || got[0].Operation != "" {
-		t.Fatalf("explicit empty toolRefs provider refs = %#v, want global broad ref", got)
+	if got := turnRequests[1].ToolRefs; len(got) != 0 {
+		t.Fatalf("explicit empty toolRefs provider refs = %#v, want none", got)
 	}
 	if got := turnRequests[2].ToolRefs; len(got) != 1 || got[0].Plugin != "docs" || got[0].Operation != "" {
 		t.Fatalf("plugin broad provider refs = %#v, want docs broad ref", got)
+	}
+}
+
+func TestAgentTurnOmittedToolsDoNotForceCatalogForUnsupportedProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAgentProvider()
+	provider.capabilities = &coreagent.ProviderCapabilities{
+		BoundedListHydration: true,
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		services := testutil.NewStubServices(t)
+		cfg.Auth = nil
+		cfg.Services = services
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:     &stubAgentControl{defaultProviderName: "managed", provider: provider},
+			RunGrants: newServerTestAgentRunGrants(t),
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/", bytes.NewBufferString(`{"provider":"managed","model":"gpt-5.4"}`))
+	sessionResp, err := http.DefaultClient.Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(sessionResp.Body)
+		t.Fatalf("create session status = %d body=%s", sessionResp.StatusCode, body)
+	}
+	var session map[string]any
+	if err := json.NewDecoder(sessionResp.Body).Decode(&session); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	sessionID := session["id"].(string)
+
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}]}`))
+	turnResp, err := http.DefaultClient.Do(turnReq)
+	if err != nil {
+		t.Fatalf("create turn: %v", err)
+	}
+	defer func() { _ = turnResp.Body.Close() }()
+	if turnResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(turnResp.Body)
+		t.Fatalf("create turn status = %d body=%s", turnResp.StatusCode, body)
+	}
+
+	turnRequests := provider.capturedTurnRequests()
+	if len(turnRequests) != 1 {
+		t.Fatalf("provider turn requests len = %d, want 1", len(turnRequests))
+	}
+	if got := turnRequests[0].ToolSource; got != coreagent.ToolSourceModeUnspecified {
+		t.Fatalf("provider turn tool source = %q, want unspecified", got)
+	}
+	if got := turnRequests[0].ToolRefs; len(got) != 0 {
+		t.Fatalf("provider turn tool refs = %#v, want none", got)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -898,9 +898,6 @@ func agentToolRefsFromRequest(refs []agentToolRefRequest) []coreagent.ToolRef {
 }
 
 func agentToolRefsForCreateTurn(req agentTurnCreateRequest) []coreagent.ToolRef {
-	if !req.toolRefsSet || (strings.TrimSpace(req.ToolSource) == "" && len(req.ToolRefs) == 0) {
-		return []coreagent.ToolRef{{Plugin: "*"}}
-	}
 	return agentToolRefsFromRequest(req.ToolRefs)
 }
 


### PR DESCRIPTION
## Summary
- stop the public agent turn handler from injecting a broad catalog tool ref when the client omits tools
- preserve the manager-level provider-aware default so catalog-capable agents still get broad catalog access by default
- add regression coverage for providers that do not support mcp_catalog, matching the Hermes provider path

## Testing
- go test ./internal/server ./services/agents/agentmanager