### PR TITLE
Document external credential provider contract

### DIFF
--- a/docs/content/providers/external-credentials.mdx
+++ b/docs/content/providers/external-credentials.mdx
@@ -1,14 +1,14 @@
 # External Credentials
 
-The external credentials provider stores subject-scoped third-party credentials.
-When a user completes an OAuth flow or an administrator provisions an API key
-for a service account, the external credentials provider persists the token or
-key so that future plugin invocations can use it on behalf of that subject.
+The external credentials provider is the Gestalt provider responsible for
+connection credentials. When a user completes OAuth, enters a manual API key, or
+an operator configures a platform connection, Gestalt uses the configured
+external credentials provider to validate, exchange, store, and resolve the
+runtime credential for that connection.
 
-External credentials are separate from the Gestalt session system. A session
-cookie or API token proves who the caller is to Gestalt. An external credential
-is the token or key Gestalt uses to prove itself to an upstream API on behalf
-of that caller.
+External credentials are separate from Gestalt sign-in. A session cookie or API
+token proves who the caller is to Gestalt. An external credential is the
+credential Gestalt uses to call an upstream API for a configured connection.
 
 ## Core concepts
 
@@ -16,87 +16,179 @@ of that caller.
 
 Every external credential is scoped to exactly one canonical subject. The
 subject is usually a user like `user:alice` or a managed subject like
-`service_account:deploy-bot`. When a plugin operation runs, the broker resolves
-the effective credential subject from the current principal, then asks the
-external credentials provider for a credential matching that subject, the target
-integration, and the selected connection.
+`service_account:deploy-bot`. User-mode connections resolve credentials for the
+effective credential subject of the current request. Platform-mode connections
+resolve deployer-owned credentials for the deployment.
 
 ### Integration and connection
 
-A credential is stored for a specific integration and connection:
+A credential belongs to a specific configured connection:
 
-- **Integration** is the provider name, such as `github` or `slack`
-- **Connection** is the named connection within that provider, such as `default`
-or `enterprise`
-- **Instance** is an optional sub-identifier for multi-tenant integrations
+- **Provider** is the configured provider name, such as `github` or `slack`
+- **Connection** is the named connection within that provider, such as
+  `default` or `enterprise`
+- **Instance** is an optional sub-identifier for multi-account integrations
 
-This three-part key lets the same subject have different credentials for the
-same integration depending on which connection or instance is selected.
+This lets the same subject connect more than one account for the same provider
+when the provider supports instances.
 
-### Token lifecycle
+### Connection modes
 
-Credentials can be:
+Connection `mode` controls credential ownership:
 
-- **Access tokens** used directly in API requests
-- **Refresh tokens** used to obtain new access tokens when they expire
-- **API keys** that do not expire and are used as-is
+| Mode | Credential ownership |
+| --- | --- |
+| `none` | No upstream credential is required. |
+| `user` | Credentials are owned by the effective subject of the request. |
+| `platform` | Credentials are owned by the deployment and configured by the operator. |
 
-When an access token has a refresh token and an expiry timestamp, Gestalt
-automatically refreshes it if the token expires within 5 minutes. Refresh
-failures are tracked with a count so that repeatedly failing tokens can be
-identified and repaired.
+Use `user` for SaaS APIs that should act as the caller. Use `platform` for
+shared service accounts, service-to-service credentials, and model/API
+credentials owned by the deployment.
+
+### Credential lifecycle
+
+The external credentials provider participates in two parts of the lifecycle:
+
+1. **Connect time.** Gestalt validates the connection auth config, completes
+   OAuth or manual auth, optionally exchanges submitted credentials, and stores
+   the resulting credential.
+2. **Runtime.** When a plugin, workflow, or agent-bound connection needs to call
+   an upstream service, Gestalt asks the external credentials provider to resolve
+   a usable runtime credential for the selected connection.
+
+Credential material can include access tokens, refresh tokens, API keys, and
+provider-specific token responses. The exact shape depends on the connection's
+`auth` block and the configured external credentials provider.
 
 ## How external credentials work
 
-The external credentials provider sits between the broker and the upstream
-integration. The broker resolves the caller's principal, determines the
-credential subject, asks the provider for a matching credential, and then
-uses that credential to invoke the provider operation.
+External credentials are driven by connection config. A plugin or agent provider
+declares a connection, the deployer binds or overrides that connection in
+server config, and callers select a connection and instance when needed.
 
-This flow is the same for all transport types: REST, GraphQL, and MCP.
+```yaml
+connections:
+  github-user:
+    mode: user
+    auth:
+      type: oauth2
+      authorizationUrl: https://github.com/login/oauth/authorize
+      tokenUrl: https://github.com/login/oauth/access_token
+      scopes:
+        - repo
 
-### Credential resolution order
+plugins:
+  github:
+    source: ./plugins/github/manifest.yaml
+    connections:
+      default:
+        ref: github-user
+```
 
-When the broker resolves a token for an operation, it consults the external
-credentials provider in this order:
+For platform-owned credentials, the connection can be configured once and bound
+where it is needed:
 
-1. If the connection mode is `platform`, look for a platform-scoped credential
-2. If the connection mode is `user`, look for a user-scoped credential for the
-credential subject
-3. If no external credential exists, fall back to the connection's configured
-credential (such as an API key stored in the provider config)
+```yaml
+connections:
+  model-api:
+    mode: platform
+    auth:
+      type: oauth2
+      grantType: client_credentials
+      tokenUrl: https://auth.example.com/oauth/token
+      clientId: ${MODEL_CLIENT_ID}
+      clientSecret: ${MODEL_CLIENT_SECRET}
+    params:
+      baseUrl: https://models.example.com/v1
 
-Platform-scoped credentials are useful for integrations that should act as the
-deployment, not as a user. User-scoped credentials are useful for integrations
-that act on behalf of the calling user.
+providers:
+  agent:
+    default:
+      source: ./providers/agent/example/manifest.yaml
+      connections:
+        model:
+          ref: model-api
+```
 
-### Dynamic credential subjects
-
-Some workflows and plugin invocations create a principal with a
-`credentialSubjectID` that differs from the principal's own `subjectID`. This
-is common when a user-owned workflow delegates to a service account, or when
-a plugin invocation token carries a different credential subject for nested calls.
-
-The broker always uses `EffectiveCredentialSubjectID` to look up credentials.
-This resolves `credentialSubjectID` first, then `subjectID`, then the user ID.
+At runtime, providers that support connection bindings receive resolved runtime
+connection material from Gestalt. They should treat that material as the
+connection contract and avoid depending on how the credential was obtained.
 
 ## Provider interface
 
-External credential providers implement this interface:
+External credential providers implement this SDK interface:
 
 | Method | Purpose |
 | --- | --- |
-| `PutCredential` | Store a new or updated credential |
-| `RestoreCredential` | Restore a credential from a backup or import |
-| `GetCredential` | Retrieve a credential by subject, integration, connection, and instance |
-| `ListCredentials` | List all credentials for a subject |
-| `ListCredentialsForProvider` | List credentials for a subject and integration |
-| `ListCredentialsForConnection` | List credentials for a subject, integration, and connection |
-| `DeleteCredential` | Remove a credential by its internal ID |
+| `UpsertCredential` | Create or update a stored connection credential. |
+| `GetCredential` | Fetch one stored credential by lookup. |
+| `ListCredentials` | List stored credentials for a subject, with optional connection or instance filters. |
+| `DeleteCredential` | Delete one stored credential. |
+| `ValidateCredentialConfig` | Validate that a connection auth config is supported by this provider. |
+| `ExchangeCredential` | Exchange user-supplied connection material during connect, such as manual credentials submitted through `gestalt plugin connect`. |
+| `ResolveCredential` | Resolve a configured connection into usable runtime credential material. |
 
-`PutCredential` and `RestoreCredential` are similar, but `RestoreCredential`
-is intended for idempotent re-imports where the caller wants to overwrite an
-existing credential only if it matches the expected state.
+Most deployments should use the first-party external credentials provider. Write
+a custom external credentials provider when you need a different storage backend,
+different encryption boundary, or custom validation/exchange/resolution behavior
+for your organization's connection model.
+
+### Validation
+
+`ValidateCredentialConfig` runs against configured connection auth. Return an
+error when the config is incomplete or unsupported. This lets deployers catch
+invalid connection config before users try to connect or invoke the provider.
+
+### Connect-time exchange
+
+`ExchangeCredential` runs when a connection flow submits credential material that
+must be exchanged before storage. For example, a manual credential form may
+submit an API token or account identifier that the external credentials provider
+exchanges for a short-lived access token and refresh material.
+
+If no exchange is required, return an empty response and let Gestalt store the
+submitted credential according to the connection auth type.
+
+### Runtime resolution
+
+`ResolveCredential` runs when a configured connection needs runtime credential
+material. It receives the selected provider, connection, instance, credential
+subject, connection mode, auth config, and connection params. It returns the
+runtime token, expiry metadata, resolved params, and any metadata needed by the
+caller.
+
+Runtime resolution is where providers can refresh expiring credentials, resolve
+platform credentials, or apply configured token exchange behavior. Callers should
+not need to know which of those paths was used.
+
+### SDK request fields
+
+External credential SDK requests include both display-oriented connection
+context and a stable lookup key:
+
+| Field | Purpose |
+| --- | --- |
+| `provider` | Configured provider name, useful for validation and diagnostics. |
+| `connection` | Named connection as written in provider or deployment config. |
+| `connection_id` | Canonical connection identifier for credential lookup. |
+| `credential_subject_id` | Subject whose credential should be resolved or exchanged. |
+| `actor_subject_id` | Subject that initiated the request, when different from the credential owner. |
+| `instance` | Optional selected account or workspace instance. |
+| `auth` | Connection auth config after manifest and deployment config are combined. |
+| `connection_params` | Resolved connection parameters available to exchange and resolution. |
+
+Use `connection_id` with `subject_id` and `instance` for stored credential
+lookups. Use `provider`, `connection`, `auth`, and `connection_params` to decide
+whether the request is valid and how to exchange or resolve the credential.
+
+### Token exchange drivers
+
+Connection auth config can include `tokenExchangeDrivers`. Driver entries are
+part of the external credentials provider contract: Gestalt validates the config
+through `ValidateCredentialConfig`, then passes the configured driver entries
+back to `ResolveCredential`. The external credentials provider decides which
+driver types it supports and what each driver's fields mean.
 
 ## First-party external credentials providers
 
@@ -107,13 +199,13 @@ First-party external credentials providers live under
 | --- | --- |
 | [`github.com/valon-technologies/gestalt-providers/external_credentials/default`](https://github.com/valon-technologies/gestalt-providers/tree/main/external_credentials/default) | Stores credentials in the host IndexedDB provider |
 
-## Configuring `providers.external_credentials`
+## Configuring `providers.externalCredentials`
 
 ```yaml
 server:
   providers:
     indexeddb: main
-    external_credentials: default
+    externalCredentials: default
 
 providers:
   indexeddb:
@@ -122,7 +214,7 @@ providers:
       config:
         dsn: ${DATABASE_URL}
 
-  external_credentials:
+  externalCredentials:
     default:
       source: https://artifacts.example.com/external_credentials/default/v0.0.1-alpha.1/provider-release.yaml
       config:
@@ -130,10 +222,9 @@ providers:
 ```
 
 The first-party `external_credentials/default` provider stores credentials in
-the selected host IndexedDB provider and encrypts token material before writing
-rows.
+the selected host IndexedDB provider.
 
-If you omit `providers.external_credentials`, Gestalt uses the first-party
+If you omit `providers.externalCredentials`, Gestalt uses the first-party
 `external_credentials/default` provider with the selected host IndexedDB
 provider.
 
@@ -143,7 +234,7 @@ provider.
 | --- | --- |
 | `providers.authentication` | Creates sessions and identifies subjects |
 | `providers.authorization` | Decides whether a subject may access a resource |
-| `providers.external_credentials` | Stores the upstream tokens used to invoke resources |
+| `providers.externalCredentials` | Stores the upstream tokens used to invoke resources |
 | `providers.indexeddb` | Often the storage backend for the other three |
 
 Authentication answers who the caller is. Authorization answers what the caller
@@ -152,20 +243,25 @@ These are three independent systems that compose at runtime.
 
 ## Operational notes
 
-`server.providers.external_credentials` selects the host external credentials
-provider. If more than one entry exists under `providers.external_credentials`,
-set `server.providers.external_credentials` explicitly or mark one entry
+`server.providers.externalCredentials` selects the host external credentials
+provider. If more than one entry exists under `providers.externalCredentials`,
+set `server.providers.externalCredentials` explicitly or mark one entry
 `default: true`.
 
 Credentials are encrypted at rest using the deployment's encryption key. Check
 the provider's documentation to understand its storage and encryption
 guarantees.
 
+`providers.externalCredentials` is a deployment-wide provider selection. Plugin,
+workflow, and agent providers do not select their own external credentials
+provider; they declare or bind connections and let Gestalt resolve those
+connections through the configured external credentials provider.
+
 ## What to read next
 
 For the full server and provider config structure, read
-[Configuration](/configuration). For the exact `providers.external_credentials`
-reference, continue to [Config File](/reference/config-file). To understand how
-credentials are resolved at invocation time, read
-[Plugin](/providers/plugins) and [Security](/security). For provider
-implementation details, see [Custom Providers > Authentication](/custom-providers/authentication).
+[Configuration](/configuration). For the exact `providers.externalCredentials`
+reference, continue to [Config File](/reference/config-file). To understand
+plugin connection declarations, read [Plugin](/providers/plugins) and
+[Provider Manifests](/reference/plugin-manifests). To understand agent
+connection bindings, read [Custom Providers > Agent](/custom-providers/agent).


### PR DESCRIPTION
## Summary
- Reframe External Credentials docs around the public provider contract and connection credential lifecycle
- Document connect-time exchange, runtime resolution, validation, SDK request fields, and token exchange driver ownership
- Update config examples and references to use `externalCredentials`

## Tests
- `git diff --check`