### PR TITLE
Surface connection guidance for missing credentials

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -140,6 +140,8 @@ server:
     host: 127.0.0.1
     port: 9090
   baseUrl: https://gestalt.example.com
+  connectionHelp:
+    notConnectedMessage: "{DISPLAY_NAME} is not connected. Go to {CONNECT_URL} to connect {DISPLAY_NAME} first."
   encryptionKey:
     secret:
       provider: default
@@ -174,6 +176,8 @@ authorization:
 
 `baseUrl` derives OAuth callback URLs when explicit redirect URLs are omitted, and gives the management admin UI an absolute link back to the public client UI. When unset, the management admin UI omits the `Client UI` link rather than sending operators to a broken same-origin `/`.
 
+`connectionHelp` configures user-facing guidance when an operation cannot run because the caller has not connected a user-owned plugin credential. `{CONNECT_URL}` resolves to `server.baseUrl`. `notConnectedMessage` is an optional template; when omitted and `server.baseUrl` is set, Gestalt uses a default message that tells the user to open the deployment root. Templates may use `{BASE_URL}`, `{CONNECT_URL}`, `{PLUGIN}`, `{DISPLAY_NAME}`, `{CONNECTION}`, and `{INSTANCE}`.
+
 `encryptionKey` is the only required server field. It is the root deployment secret, used for encryption and derived session material.
 
 `apiTokenTtl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifactsDir` is a writable directory for prepared artifacts produced by `gestaltd sync --locked` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `lock`/`sync`/`serve` lifecycle.
@@ -200,6 +204,7 @@ Plugins without `authorizationPolicy` are open to any authenticated subject. Bin
 | `management.port` | | Port for the management listener. Required when `management.host` is set. |
 | `management.baseUrl` | | Browser-facing absolute URL for the management listener. Required for protected built-in `/admin` on split public/management deployments. |
 | `baseUrl` | | Public origin URL used for OAuth callbacks and admin UI links. |
+| `connectionHelp.notConnectedMessage` | | Optional template for missing user credential errors. |
 | `encryptionKey` | | **Required.** Root encryption key. Typically a structured secret ref. |
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared artifacts produced by `gestaltd sync --locked`. |

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1077,6 +1077,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),
 		invocation.WithConnectionRuntime(connRuntime.Resolve),
 		invocation.WithProviderOverrides(providerDevSessions),
+		invocation.WithNotConnectedMessage(notConnectedMessageFunc(cfg)),
 	)
 	prepared.Deps.WorkflowRuntime.SetInvoker(sharedInvoker)
 	prepared.Deps.AgentRuntime.SetInvoker(sharedInvoker)

--- a/gestaltd/internal/bootstrap/connection_help.go
+++ b/gestaltd/internal/bootstrap/connection_help.go
@@ -1,0 +1,54 @@
+package bootstrap
+
+import (
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+const defaultNotConnectedMessageTemplate = `{DISPLAY_NAME} is not connected. Go to {CONNECT_URL} to connect {DISPLAY_NAME} first.`
+
+func notConnectedMessageFunc(cfg *config.Config) invocation.NotConnectedMessageFunc {
+	if cfg == nil {
+		return nil
+	}
+	help := cfg.Server.ConnectionHelp
+	template := strings.TrimSpace(help.NotConnectedMessage)
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.Server.BaseURL), "/")
+	if template == "" && baseURL == "" {
+		return nil
+	}
+	if template == "" {
+		template = defaultNotConnectedMessageTemplate
+	}
+	pluginDefs := cfg.Plugins
+	return func(providerName, connection, instance string) string {
+		displayName := providerDisplayName(pluginDefs, providerName)
+		replacer := strings.NewReplacer(
+			"{BASE_URL}", baseURL,
+			"{baseUrl}", baseURL,
+			"{CONNECT_URL}", baseURL,
+			"{connectUrl}", baseURL,
+			"{PLUGIN}", strings.TrimSpace(providerName),
+			"{plugin}", strings.TrimSpace(providerName),
+			"{DISPLAY_NAME}", displayName,
+			"{displayName}", displayName,
+			"{CONNECTION}", strings.TrimSpace(connection),
+			"{connection}", strings.TrimSpace(connection),
+			"{INSTANCE}", strings.TrimSpace(instance),
+			"{instance}", strings.TrimSpace(instance),
+		)
+		return strings.TrimSpace(replacer.Replace(template))
+	}
+}
+
+func providerDisplayName(pluginDefs map[string]*config.ProviderEntry, providerName string) string {
+	providerName = strings.TrimSpace(providerName)
+	if entry := pluginDefs[providerName]; entry != nil {
+		if displayName := strings.TrimSpace(entry.DisplayName); displayName != "" {
+			return displayName
+		}
+	}
+	return providerName
+}

--- a/gestaltd/internal/bootstrap/connection_help_test.go
+++ b/gestaltd/internal/bootstrap/connection_help_test.go
@@ -1,0 +1,56 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func TestNotConnectedMessageFuncUsesBaseURLAsConnectURL(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			BaseURL: "https://gestalt.example.test/root/",
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"slack": {DisplayName: "Slack"},
+		},
+	}
+
+	messageFunc := notConnectedMessageFunc(cfg)
+	if messageFunc == nil {
+		t.Fatal("message func = nil")
+	}
+	got := messageFunc("slack", "default", "")
+	want := "Slack is not connected. Go to https://gestalt.example.test/root to connect Slack first."
+	if got != want {
+		t.Fatalf("message = %q, want %q", got, want)
+	}
+}
+
+func TestNotConnectedMessageFuncSupportsTemplatePlaceholders(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			BaseURL: "https://gestalt.example.test",
+			ConnectionHelp: config.ConnectionHelpConfig{
+				NotConnectedMessage: "{DISPLAY_NAME} requires setup at {CONNECT_URL} for {CONNECTION}.",
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"slack": {DisplayName: "Slack"},
+		},
+	}
+
+	messageFunc := notConnectedMessageFunc(cfg)
+	if messageFunc == nil {
+		t.Fatal("message func = nil")
+	}
+	got := messageFunc("slack", "workspace", "")
+	want := "Slack requires setup at https://gestalt.example.test for workspace."
+	if got != want {
+		t.Fatalf("message = %q, want %q", got, want)
+	}
+}

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -80,6 +80,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),
 		invocation.WithConnectionRuntime(connRuntime.Resolve),
+		invocation.WithNotConnectedMessage(notConnectedMessageFunc(cfg)),
 	)
 	prepared.Deps.WorkflowRuntime.SetInvoker(sharedInvoker)
 	prepared.Deps.AgentRuntime.SetInvoker(sharedInvoker)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1460,17 +1460,22 @@ type AdminConfig struct {
 }
 
 type ServerConfig struct {
-	Public        ListenerConfig           `yaml:"public"`
-	Management    ManagementListenerConfig `yaml:"management"`
-	BaseURL       string                   `yaml:"baseUrl"`
-	EncryptionKey string                   `yaml:"encryptionKey"`
-	APITokenTTL   string                   `yaml:"apiTokenTtl"`
-	ArtifactsDir  string                   `yaml:"artifactsDir"`
-	Providers     ServerProvidersConfig    `yaml:"providers,omitempty"`
-	Dev           DevConfig                `yaml:"dev,omitempty"`
-	Runtime       ServerRuntimeConfig      `yaml:"runtime,omitempty"`
-	Egress        EgressConfig             `yaml:"egress,omitempty"`
-	Admin         AdminConfig              `yaml:"admin,omitempty"`
+	Public         ListenerConfig           `yaml:"public"`
+	Management     ManagementListenerConfig `yaml:"management"`
+	BaseURL        string                   `yaml:"baseUrl"`
+	ConnectionHelp ConnectionHelpConfig     `yaml:"connectionHelp,omitempty"`
+	EncryptionKey  string                   `yaml:"encryptionKey"`
+	APITokenTTL    string                   `yaml:"apiTokenTtl"`
+	ArtifactsDir   string                   `yaml:"artifactsDir"`
+	Providers      ServerProvidersConfig    `yaml:"providers,omitempty"`
+	Dev            DevConfig                `yaml:"dev,omitempty"`
+	Runtime        ServerRuntimeConfig      `yaml:"runtime,omitempty"`
+	Egress         EgressConfig             `yaml:"egress,omitempty"`
+	Admin          AdminConfig              `yaml:"admin,omitempty"`
+}
+
+type ConnectionHelpConfig struct {
+	NotConnectedMessage string `yaml:"notConnectedMessage,omitempty"`
 }
 
 type DevConfig struct {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -135,6 +135,31 @@ plugins:
 	}
 }
 
+func TestLoadConfigParsesServerConnectionHelp(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+server:
+  encryptionKey: server-key
+  baseUrl: https://gestalt.example.test/
+  connectionHelp:
+    notConnectedMessage: '{DISPLAY_NAME} is not connected. Visit {CONNECT_URL}.'
+plugins:
+  slack:
+    displayName: Slack
+    source:
+      path: /tmp/slack/manifest.yaml
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Server.ConnectionHelp.NotConnectedMessage; got != "{DISPLAY_NAME} is not connected. Visit {CONNECT_URL}." {
+		t.Fatalf("notConnectedMessage = %q", got)
+	}
+}
+
 func TestLoadConfigValidatesProviderDevAttachmentState(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -844,12 +844,16 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 			)
 			return
 		}
+		message := fmt.Sprintf("no external credential stored for integration %q; connect via OAuth first", providerName)
+		if customMessage, ok := invocation.NoCredentialErrorMessage(err); ok {
+			message = customMessage
+		}
 		writeTypedError(
 			w,
 			http.StatusPreconditionFailed,
 			"not_connected",
 			providerName,
-			fmt.Sprintf("no external credential stored for integration %q; connect via OAuth first", providerName),
+			message,
 		)
 	case errors.Is(err, invocation.ErrReconnectRequired):
 		writeTypedError(

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -12166,6 +12166,62 @@ func TestListOperations_TokenSelectionErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("no_token_uses_configured_connection_help", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &stubIntegrationWithSessionCatalog{
+			stubIntegrationWithOps: stubIntegrationWithOps{
+				StubIntegration: coretesting.StubIntegration{N: "slack", ConnMode: core.ConnectionModeUser},
+			},
+		}
+		providers := testutil.NewProviderRegistry(t, stub)
+		svc := testutil.NewStubServices(t)
+		broker := invocation.NewBroker(
+			providers,
+			svc.Users,
+			svc.ExternalCredentials,
+			invocation.WithConnectionMapper(invocation.ConnectionMap{"slack": testCatalogConnection}),
+			invocation.WithNotConnectedMessage(func(providerName, _, _ string) string {
+				return fmt.Sprintf("%s is not connected. Go to https://gestalt.example.test/integrations/ to connect %s first.", providerName, providerName)
+			}),
+		)
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = providers
+			cfg.Services = svc
+			cfg.Invoker = broker
+			cfg.CatalogConnection = map[string]string{"slack": testCatalogConnection}
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/slack/operations", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusPreconditionFailed {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 412, got %d: %s", resp.StatusCode, body)
+		}
+
+		var errResp struct {
+			Error       string `json:"error"`
+			Code        string `json:"code"`
+			Integration string `json:"integration"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+			t.Fatalf("decoding error response: %v", err)
+		}
+		if errResp.Error != "slack is not connected. Go to https://gestalt.example.test/integrations/ to connect slack first." {
+			t.Fatalf("expected configured message, got %q", errResp.Error)
+		}
+		if errResp.Code != "not_connected" || errResp.Integration != "slack" {
+			t.Fatalf("typed error = {%q, %q}, want not_connected/slack", errResp.Code, errResp.Integration)
+		}
+	})
+
 	t.Run("ambiguous_instance", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -123,9 +123,12 @@ type Broker struct {
 	mcpMapper         ConnectionMapper
 	connectionRuntime ConnectionRuntimeResolver
 	providerOverrides ProviderOverrideResolver
+	notConnected      NotConnectedMessageFunc
 }
 
 type BrokerOption func(*Broker)
+
+type NotConnectedMessageFunc func(providerName, connection, instance string) string
 
 func WithConnectionMapper(m ConnectionMapper) BrokerOption {
 	return func(b *Broker) { b.connMapper = m }
@@ -147,12 +150,25 @@ func WithProviderOverrides(r ProviderOverrideResolver) BrokerOption {
 	return func(b *Broker) { b.providerOverrides = r }
 }
 
+func WithNotConnectedMessage(f NotConnectedMessageFunc) BrokerOption {
+	return func(b *Broker) { b.notConnected = f }
+}
+
 func NewBroker(providers *registry.ProviderMap[core.Provider], users UserStore, externalCreds core.ExternalCredentialProvider, opts ...BrokerOption) *Broker {
 	b := &Broker{providers: providers, users: users, externalCreds: externalCreds}
 	for _, o := range opts {
 		o(b)
 	}
 	return b
+}
+
+func (b *Broker) noCredentialError(providerName, connection, instance, fallback string) error {
+	if b != nil && b.notConnected != nil {
+		if message := strings.TrimSpace(b.notConnected(providerName, connection, instance)); message != "" {
+			return &NoCredentialError{Message: message}
+		}
+	}
+	return fmt.Errorf("%w: %s", ErrNoCredential, fallback)
 }
 
 func (b *Broker) ListProviders() []string {
@@ -881,9 +897,19 @@ func (b *Broker) resolveSubjectRuntimeCredential(ctx context.Context, prov core.
 		switch {
 		case errors.Is(err, core.ErrNotFound):
 			if instance != "" {
-				return ctx, ConnectionRuntimeCredential{}, fmt.Errorf("%w: no external credential stored for integration %q instance %q", ErrNoCredential, providerName, instance)
+				return ctx, ConnectionRuntimeCredential{}, b.noCredentialError(
+					providerName,
+					connection,
+					instance,
+					fmt.Sprintf("no external credential stored for integration %q instance %q", providerName, instance),
+				)
 			}
-			return ctx, ConnectionRuntimeCredential{}, fmt.Errorf("%w: no external credential stored for integration %q", ErrNoCredential, providerName)
+			return ctx, ConnectionRuntimeCredential{}, b.noCredentialError(
+				providerName,
+				connection,
+				instance,
+				fmt.Sprintf("no external credential stored for integration %q", providerName),
+			)
 		case errors.Is(err, core.ErrAmbiguousCredential):
 			return ctx, ConnectionRuntimeCredential{}, fmt.Errorf("%w: integration %q has multiple connections; specify which instance to use with the %q parameter",
 				ErrAmbiguousInstance, providerName, "_instance")
@@ -898,7 +924,12 @@ func (b *Broker) resolveSubjectRuntimeCredential(ctx context.Context, prov core.
 	}
 	storedCredential := resp.Credential
 	if storedCredential == nil {
-		return ctx, ConnectionRuntimeCredential{}, fmt.Errorf("%w: no external credential stored for integration %q", ErrNoCredential, providerName)
+		return ctx, ConnectionRuntimeCredential{}, b.noCredentialError(
+			providerName,
+			connection,
+			instance,
+			fmt.Sprintf("no external credential stored for integration %q", providerName),
+		)
 	}
 	credentialConnection := strings.TrimSpace(storedCredential.Connection)
 	if credentialConnection == "" {

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -2,6 +2,7 @@ package invocation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -148,6 +149,49 @@ func TestBrokerResolveToken_AllowsInternalConnectionWhenContextAuthorized(t *tes
 	}
 	if cred := CredentialContextFromContext(ctx); cred.Mode != core.ConnectionModePlatform || cred.Connection != "bot" {
 		t.Fatalf("credential context = %#v, want platform bot", cred)
+	}
+}
+
+func TestBrokerResolveToken_UsesConfiguredNotConnectedMessage(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeUser,
+		}),
+		svc.Users,
+		svc.ExternalCredentials,
+		WithNotConnectedMessage(func(providerName, connection, instance string) string {
+			if providerName != "slack" || connection != "workspace" || instance != "team-a" {
+				t.Fatalf("not-connected callback got %q/%q/%q", providerName, connection, instance)
+			}
+			return "Slack is not connected. Go to https://gestalt.example.test/integrations/ to connect Slack first."
+		}),
+	)
+
+	_, _, err := broker.ResolveToken(
+		context.Background(),
+		&principal.Principal{
+			SubjectID: principal.UserSubjectID("u-slack"),
+			UserID:    "u-slack",
+			Kind:      principal.KindUser,
+		},
+		"slack",
+		"workspace",
+		"team-a",
+	)
+	if !errors.Is(err, ErrNoCredential) {
+		t.Fatalf("ResolveToken error = %v, want ErrNoCredential", err)
+	}
+	message, ok := NoCredentialErrorMessage(err)
+	if !ok {
+		t.Fatalf("NoCredentialErrorMessage(%v) ok = false", err)
+	}
+	want := "Slack is not connected. Go to https://gestalt.example.test/integrations/ to connect Slack first."
+	if message != want || err.Error() != want {
+		t.Fatalf("not-connected message = %q / error %q, want %q", message, err.Error(), want)
 	}
 }
 

--- a/gestaltd/services/invocation/errors.go
+++ b/gestaltd/services/invocation/errors.go
@@ -1,6 +1,9 @@
 package invocation
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 var (
 	ErrProviderNotFound    = errors.New("provider not found")
@@ -15,3 +18,31 @@ var (
 	ErrScopeDenied         = errors.New("token scope denied")
 	ErrInvalidInvocation   = errors.New("invalid invocation")
 )
+
+type NoCredentialError struct {
+	Message string
+}
+
+func (e *NoCredentialError) Error() string {
+	if e == nil {
+		return ErrNoCredential.Error()
+	}
+	message := strings.TrimSpace(e.Message)
+	if message == "" {
+		return ErrNoCredential.Error()
+	}
+	return message
+}
+
+func (e *NoCredentialError) Unwrap() error {
+	return ErrNoCredential
+}
+
+func NoCredentialErrorMessage(err error) (string, bool) {
+	var noCredential *NoCredentialError
+	if !errors.As(err, &noCredential) || noCredential == nil {
+		return "", false
+	}
+	message := strings.TrimSpace(noCredential.Message)
+	return message, message != ""
+}


### PR DESCRIPTION
## Summary
- Add deploy-configured not-connected guidance to broker credential resolution.
- Use `server.baseUrl` as the default connect URL for missing user credentials.
- Document `server.connectionHelp.notConnectedMessage` and add focused coverage for config, bootstrap, invocation, and HTTP responses.

## Test plan
- [x] `go test ./internal/config -run TestLoadConfigParsesServerConnectionHelp`
- [x] `go test ./internal/bootstrap -run TestNotConnectedMessageFunc`
- [x] `go test ./services/invocation -run TestBrokerResolveToken_UsesConfiguredNotConnectedMessage`
- [x] `go test ./internal/server -run TestListOperations_TokenSelectionErrors`