### PR TITLE
Improve agent TUI scroll controls

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -255,10 +255,15 @@ parses the event stream, renders assistant/tool/interaction events, cancels the
 active turn on Ctrl-C, and resolves pending interactions inline. TTY sessions
 use a full-screen terminal UI with a persistent transcript, streaming assistant
 output, a multiline composer, queued prompts while a turn is running, Ctrl-C
-cancellation, and inline interaction panels. Press Enter to send, Alt-Enter to
-insert a newline, PageUp/PageDown to scroll, `/session` to show the active
-session and resume command, and `/model` to show or set the model for future
-turns. Non-TTY sessions keep the
+cancellation, and inline interaction panels. Press Enter to send, Alt-Enter or
+supported Shift-Enter to insert a newline, Ctrl-J to insert a portable newline,
+PageUp/PageDown to scroll half a screen, Ctrl-Home/Ctrl-End to jump to the
+transcript start or end, Ctrl-L to redraw, Ctrl-D to exit an idle empty prompt,
+Up/Down to recall input history, `/session` to show the active session and
+resume command, and `/model` to show or set the model for future turns. Wheel
+and trackpad scrolling moves the transcript; set `GESTALT_CLI_DISABLE_MOUSE=1`
+before launching the CLI to keep terminal-native mouse selection instead.
+Non-TTY sessions keep the
 prompt-and-print fallback used by scripts and tests; there, end an input line
 with `\` to continue the same user message on the next prompt.
 

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -307,10 +307,38 @@ fn agent_help_lines() -> Vec<String> {
 
 fn agent_tui_help_lines() -> Vec<String> {
     let mut lines = agent_help_lines();
+    for line in &mut lines {
+        match line.as_str() {
+            "  Alt-Enter inserts a newline." => {
+                *line =
+                    "  Alt-Enter/Ctrl-J/Shift-Enter inserts a newline where supported.".to_string();
+            }
+            "  Up/Down recalls prompt history." => {
+                *line = "  Up/Down recalls input history.".to_string();
+            }
+            "  PgUp/PgDn scrolls the transcript." => {
+                *line = "  PgUp/PgDn scrolls the transcript by half a screen.".to_string();
+            }
+            _ => {}
+        }
+    }
     let insert_at = lines
         .iter()
         .position(|line| line.contains("Ctrl-C cancels"))
         .unwrap_or(lines.len());
+    lines.insert(
+        insert_at,
+        "  Ctrl-D exits when idle and input is empty.".to_string(),
+    );
+    lines.insert(insert_at, "  Ctrl-L redraws the terminal.".to_string());
+    lines.insert(
+        insert_at,
+        "  Ctrl-Home/Ctrl-End jumps to transcript start/end.".to_string(),
+    );
+    lines.insert(
+        insert_at,
+        "  Wheel/trackpad scrolls the transcript.".to_string(),
+    );
     lines.insert(
         insert_at,
         "  Ctrl-O toggles compact/full tool details.".to_string(),

--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -8,7 +8,11 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
+    KeyModifiers, MouseEvent, MouseEventKind,
+};
+use ratatui::crossterm::execute;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, TextArea};
@@ -32,6 +36,7 @@ use super::{
 
 const TICK_RATE: Duration = Duration::from_millis(50);
 const HISTORY_LIMIT: usize = 100;
+const MOUSE_SCROLL_LINES: usize = 3;
 const SPINNER_FRAMES: [&str; 4] = ["|", "/", "-", "\\"];
 const USER_PROMPT: &str = "› ";
 const ASSISTANT_BULLET: &str = "● ";
@@ -66,14 +71,22 @@ pub(super) fn run_shell(
 struct TerminalGuard {
     terminal: ratatui::DefaultTerminal,
     restored: bool,
+    mouse_capture_enabled: bool,
 }
 
 impl TerminalGuard {
     fn start() -> Result<Self> {
         let terminal = ratatui::try_init().context("failed to initialize terminal UI")?;
+        let mouse_capture_enabled = !mouse_capture_disabled();
+        if mouse_capture_enabled && let Err(err) = execute!(io::stdout(), EnableMouseCapture) {
+            let _ = execute!(io::stdout(), DisableMouseCapture);
+            let _ = ratatui::try_restore();
+            return Err(err).context("failed to enable terminal mouse capture");
+        }
         Ok(Self {
             terminal,
             restored: false,
+            mouse_capture_enabled,
         })
     }
 
@@ -83,11 +96,24 @@ impl TerminalGuard {
 
     fn restore(&mut self) -> Result<()> {
         if !self.restored {
-            let restore_result = ratatui::try_restore();
-            restore_result.context("failed to restore terminal UI")?;
-            self.restored = true;
+            let mouse_result = if self.mouse_capture_enabled {
+                execute!(io::stdout(), DisableMouseCapture)
+                    .context("failed to disable terminal mouse capture")
+            } else {
+                Ok(())
+            };
+            let restore_result = ratatui::try_restore().context("failed to restore terminal UI");
+            if mouse_result.is_ok() && restore_result.is_ok() {
+                self.restored = true;
+            }
+            mouse_result?;
+            restore_result?;
         }
         Ok(())
+    }
+
+    fn clear(&mut self) -> Result<()> {
+        self.terminal.clear().context("failed to clear terminal UI")
     }
 
     fn resize(&mut self) -> Result<()> {
@@ -100,10 +126,20 @@ impl TerminalGuard {
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
         if !self.restored {
+            if self.mouse_capture_enabled {
+                let _ = execute!(io::stdout(), DisableMouseCapture);
+            }
             ratatui::restore();
             self.restored = true;
         }
     }
+}
+
+fn mouse_capture_disabled() -> bool {
+    matches!(
+        env::var("GESTALT_CLI_DISABLE_MOUSE").as_deref(),
+        Ok("1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON")
+    )
 }
 
 struct TuiApp {
@@ -120,6 +156,7 @@ struct TuiApp {
     transcript_visible_height: usize,
     transcript_content_height: usize,
     tick: usize,
+    clear_requested: bool,
     input_history: Vec<String>,
     history_cursor: Option<usize>,
     history_draft: String,
@@ -146,6 +183,7 @@ impl TuiApp {
             transcript_visible_height: 1,
             transcript_content_height: 0,
             tick: 0,
+            clear_requested: false,
             input_history: Vec::new(),
             history_cursor: None,
             history_draft: String::new(),
@@ -159,6 +197,10 @@ impl TuiApp {
             self.drain_worker_events();
             self.start_next_queued_turn();
             self.tick = self.tick.wrapping_add(1);
+            if self.clear_requested {
+                terminal.clear()?;
+                self.clear_requested = false;
+            }
             terminal.inner_mut().draw(|frame| self.draw(frame))?;
 
             if self.should_quit {
@@ -168,6 +210,7 @@ impl TuiApp {
             if event::poll(TICK_RATE).context("failed to poll terminal events")? {
                 match event::read().context("failed to read terminal event")? {
                     Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_key(key),
+                    Event::Mouse(mouse) => self.handle_mouse(mouse),
                     Event::Resize(_, _) => terminal.resize()?,
                     _ => {}
                 }
@@ -262,7 +305,7 @@ impl TuiApp {
             let help = if interaction.request.get("secret").and_then(Value::as_bool) == Some(true) {
                 "Enter submits. Typed secret input is masked."
             } else {
-                "Enter submits. Alt-Enter inserts a newline."
+                "Enter submits. Alt-Enter/Ctrl-J/Shift-Enter inserts a newline."
             };
             interaction_summary(interaction, self.interaction_input.validation(), help)
         };
@@ -367,6 +410,10 @@ impl TuiApp {
     }
 
     fn handle_key(&mut self, key: KeyEvent) {
+        if self.handle_global_key(&key) {
+            return;
+        }
+
         if self.state.pending_interaction.is_some() {
             self.handle_interaction_key(key);
             return;
@@ -376,19 +423,12 @@ impl TuiApp {
             (KeyCode::Char('c'), modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
                 self.handle_interrupt();
             }
-            (KeyCode::PageUp, _) => self.state.scroll_up(
-                self.transcript_visible_height,
-                self.transcript_content_height,
-            ),
-            (KeyCode::PageDown, _) => self.state.scroll_down(),
-            (KeyCode::Home, modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
-                self.state.scroll_to_top(
-                    self.transcript_visible_height,
-                    self.transcript_content_height,
-                );
-            }
-            (KeyCode::End, modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
-                self.state.scroll_to_bottom();
+            (KeyCode::Char('d'), modifiers)
+                if modifiers.contains(KeyModifiers::CONTROL)
+                    && !self.state.busy
+                    && textarea_text(&self.composer).is_empty() =>
+            {
+                self.should_quit = true;
             }
             (KeyCode::Char('o'), modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
                 self.toggle_tool_detail_mode();
@@ -399,7 +439,7 @@ impl TuiApp {
             (KeyCode::Down, modifiers) if modifiers.is_empty() && self.history_cursor.is_some() => {
                 self.history_next();
             }
-            (KeyCode::Enter, modifiers) if modifiers.contains(KeyModifiers::ALT) => {
+            _ if is_newline_shortcut(&key) => {
                 self.reset_history_navigation();
                 self.composer.insert_newline();
             }
@@ -409,6 +449,59 @@ impl TuiApp {
                 self.composer.input(key);
             }
         }
+    }
+
+    fn handle_global_key(&mut self, key: &KeyEvent) -> bool {
+        match (key.code, key.modifiers) {
+            (KeyCode::PageUp, _) => {
+                self.scroll_transcript_up(self.page_scroll_lines());
+                true
+            }
+            (KeyCode::PageDown, _) => {
+                self.scroll_transcript_down(self.page_scroll_lines());
+                true
+            }
+            (KeyCode::Home, modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
+                self.state.scroll_to_top(
+                    self.transcript_visible_height,
+                    self.transcript_content_height,
+                );
+                true
+            }
+            (KeyCode::End, modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
+                self.state.scroll_to_bottom();
+                true
+            }
+            (KeyCode::Char('l'), modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
+                self.clear_requested = true;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent) {
+        match mouse.kind {
+            MouseEventKind::ScrollUp => self.scroll_transcript_up(MOUSE_SCROLL_LINES),
+            MouseEventKind::ScrollDown => self.scroll_transcript_down(MOUSE_SCROLL_LINES),
+            _ => {}
+        }
+    }
+
+    fn page_scroll_lines(&self) -> usize {
+        (self.transcript_visible_height / 2).max(1)
+    }
+
+    fn scroll_transcript_up(&mut self, amount: usize) {
+        self.state.scroll_up_by(
+            self.transcript_visible_height,
+            self.transcript_content_height,
+            amount,
+        );
+    }
+
+    fn scroll_transcript_down(&mut self, amount: usize) {
+        self.state.scroll_down_by(amount);
     }
 
     fn handle_interaction_key(&mut self, key: KeyEvent) {
@@ -441,7 +534,7 @@ impl TuiApp {
             (KeyCode::Char('c'), modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
                 self.handle_interrupt();
             }
-            (KeyCode::Enter, modifiers) if modifiers.contains(KeyModifiers::ALT) => {
+            _ if is_newline_shortcut(&key) => {
                 self.interaction_input.insert_newline();
             }
             (KeyCode::Enter, _) => {
@@ -719,6 +812,16 @@ impl TuiApp {
 
 fn styled_textarea(title: &'static str) -> TextArea<'static> {
     textarea_with_text(title, "")
+}
+
+fn is_newline_shortcut(key: &KeyEvent) -> bool {
+    match (key.code, key.modifiers) {
+        (KeyCode::Enter, modifiers) => {
+            modifiers.contains(KeyModifiers::ALT) || modifiers.contains(KeyModifiers::SHIFT)
+        }
+        (KeyCode::Char('j'), modifiers) => modifiers.contains(KeyModifiers::CONTROL),
+        _ => false,
+    }
 }
 
 fn visible_lines(

--- a/gestalt/cli/src/commands/agents/tui/state.rs
+++ b/gestalt/cli/src/commands/agents/tui/state.rs
@@ -633,15 +633,15 @@ impl AgentUiState {
             .map(|started_at| format_brewed_duration(started_at.elapsed()))
     }
 
-    pub(super) fn scroll_up(&mut self, height: usize, content_height: usize) {
+    pub(super) fn scroll_up_by(&mut self, height: usize, content_height: usize, amount: usize) {
         self.scroll_offset = self
             .scroll_offset
-            .saturating_add(5)
+            .saturating_add(amount.max(1))
             .min(max_scroll_offset(height, content_height));
     }
 
-    pub(super) fn scroll_down(&mut self) {
-        self.scroll_offset = self.scroll_offset.saturating_sub(5);
+    pub(super) fn scroll_down_by(&mut self, amount: usize) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(amount.max(1));
     }
 
     pub(super) fn scroll_to_top(&mut self, height: usize, content_height: usize) {

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -122,6 +122,30 @@ const TURN_EVENTS_JSON: &str = r#"[
     }
 ]"#;
 
+#[cfg(unix)]
+const MOUSE_ENABLE_SEQUENCES: [&str; 5] = [
+    "\x1b[?1000h",
+    "\x1b[?1002h",
+    "\x1b[?1003h",
+    "\x1b[?1015h",
+    "\x1b[?1006h",
+];
+
+#[cfg(unix)]
+const MOUSE_DISABLE_SEQUENCES: [&str; 5] = [
+    "\x1b[?1006l",
+    "\x1b[?1015l",
+    "\x1b[?1003l",
+    "\x1b[?1002l",
+    "\x1b[?1000l",
+];
+
+#[cfg(unix)]
+const MOUSE_SCROLL_UP: &str = "\x1b[<64;1;1M";
+
+#[cfg(unix)]
+const MOUSE_SCROLL_DOWN: &str = "\x1b[<65;1;1M";
+
 const TURN_TRANSCRIPT_JSON: &str = r#"{
     "id":"turn-1",
     "sessionId":"session-1",
@@ -858,6 +882,7 @@ fn test_cli_runs_tty_agent_session_in_isolated_selectable_ui() {
     session.write("\x03");
     session.wait_for(&mut output, "Resume with: gestalt agent resume session-1");
     session.wait_for_exit();
+    session.drain_pending(&mut output);
 
     assert!(
         output.contains("› hello tui") && output.contains("●"),
@@ -868,12 +893,16 @@ fn test_cli_runs_tty_agent_session_in_isolated_selectable_ui() {
         "TTY did not enter the alternate screen, so terminal scrollback can include shell output before the session:\n{output}"
     );
     assert!(
-        !output.contains("\x1b[?1000h")
-            && !output.contains("\x1b[?1002h")
-            && !output.contains("\x1b[?1003h")
-            && !output.contains("\x1b[?1015h")
-            && !output.contains("\x1b[?1006h"),
-        "TTY enabled mouse capture, which prevents normal drag selection:\n{output}"
+        MOUSE_ENABLE_SEQUENCES
+            .iter()
+            .all(|sequence| output.contains(sequence)),
+        "TTY did not enable mouse capture for wheel scrolling:\n{output}"
+    );
+    assert!(
+        MOUSE_DISABLE_SEQUENCES
+            .iter()
+            .all(|sequence| output.contains(sequence)),
+        "TTY did not disable mouse capture on exit:\n{output}"
     );
     assert!(
         !output.contains("**hello**"),
@@ -893,6 +922,50 @@ fn test_cli_runs_tty_agent_session_in_isolated_selectable_ui() {
             && !output.contains("assistant>"),
         "TTY transcript rendered prompt labels:\n{output}"
     );
+    server.assert_finished();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_tty_can_disable_mouse_capture() {
+    let server = ScriptedServer::spawn(vec![ExpectedRequest::json(
+        Method::POST,
+        "/api/v1/agent/sessions",
+        r#"{"provider":"managed","model":"gpt-5.4"}"#,
+        StatusCode::CREATED,
+        http::APPLICATION_JSON,
+        SESSION_JSON,
+    )]);
+
+    let home = tempfile::tempdir().unwrap();
+    let mut session = spawn_tty_cli_with_size_and_env(
+        home.path(),
+        server.url(),
+        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        24,
+        100,
+        &[("GESTALT_CLI_DISABLE_MOUSE", "1")],
+    );
+    let mut output = String::new();
+    session.wait_for(&mut output, "Session");
+    session.write("\x03");
+    session.wait_for(&mut output, "Resume with: gestalt agent resume session-1");
+    session.wait_for_exit();
+    session.drain_pending(&mut output);
+
+    assert!(
+        MOUSE_ENABLE_SEQUENCES
+            .iter()
+            .all(|sequence| !output.contains(sequence)),
+        "TTY enabled mouse capture despite GESTALT_CLI_DISABLE_MOUSE=1:\n{output}"
+    );
+    assert!(
+        MOUSE_DISABLE_SEQUENCES
+            .iter()
+            .all(|sequence| !output.contains(sequence)),
+        "TTY disabled mouse capture even though it was never enabled:\n{output}"
+    );
+
     server.assert_finished();
 }
 
@@ -1419,6 +1492,72 @@ fn test_cli_tty_help_and_prompt_history() {
 
 #[cfg(unix)]
 #[test]
+fn test_cli_tty_ctrl_j_inserts_multiline_prompt() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions",
+            r#"{"provider":"managed","model":"gpt-5.4"}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            SESSION_JSON,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-1/turns",
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"first\nsecond"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-multiline",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-multiline/events/stream?after=0&limit=100&until=blocked_or_terminal",
+            StatusCode::OK,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"assistant.completed\",\"data\":{\"text\":\"multiline received\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-multiline",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-multiline",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"succeeded",
+                "outputText":"multiline received"
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    let mut session = spawn_tty_cli(
+        home.path(),
+        server.url(),
+        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+    );
+    let mut output = String::new();
+    session.wait_for(&mut output, "Session");
+    session.write("first\x0asecond\r");
+    session.wait_for(&mut output, "multiline received");
+    session.write("\x03");
+    session.wait_for_exit();
+
+    server.assert_finished();
+}
+
+#[cfg(unix)]
+#[test]
 fn test_cli_tty_scrolls_multiline_help_rows() {
     let server = ScriptedServer::spawn(vec![ExpectedRequest::json(
         Method::POST,
@@ -1434,19 +1573,130 @@ fn test_cli_tty_scrolls_multiline_help_rows() {
         home.path(),
         server.url(),
         &["agent", "--provider", "managed", "--model", "gpt-5.4"],
-        8,
+        15,
         80,
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
     session.write("/help\r");
-    session.wait_for(&mut output, "PgUp/PgDn");
+    session.wait_for(&mut output, "Wheel/trackpad");
+    session.write("/help\r");
+    session.wait_for(&mut output, "Ctrl-D exits");
     output.clear();
-    session.write("\x1b[5~\x1b[5~");
+    session.write("\x1b[5~\x0c");
+    session.wait_for(&mut output, "Ctrl-C");
+    output.clear();
+    session.write(&format!("{}\x0c", MOUSE_SCROLL_UP.repeat(5)));
     session.wait_for(&mut output, "Commands");
     output.clear();
-    session.write("\x1b[6~\x1b[6~");
+    session.write(&format!("{}\x0c", MOUSE_SCROLL_DOWN.repeat(5)));
     session.wait_for(&mut output, "Ctrl-C");
+    output.clear();
+    session.write("\x1b[6~\x0c");
+    session.wait_for(&mut output, "Ctrl-C");
+    session.write("\x03");
+    session.wait_for_exit();
+
+    server.assert_finished();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_tty_ctrl_d_exits_empty_prompt() {
+    let server = ScriptedServer::spawn(vec![ExpectedRequest::json(
+        Method::POST,
+        "/api/v1/agent/sessions",
+        r#"{"provider":"managed","model":"gpt-5.4"}"#,
+        StatusCode::CREATED,
+        http::APPLICATION_JSON,
+        SESSION_JSON,
+    )]);
+
+    let home = tempfile::tempdir().unwrap();
+    let mut session = spawn_tty_cli(
+        home.path(),
+        server.url(),
+        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+    );
+    let mut output = String::new();
+    session.wait_for(&mut output, "Session");
+    session.write("\x04");
+    session.wait_for(&mut output, "Resume with: gestalt agent resume session-1");
+    session.wait_for_exit();
+
+    server.assert_finished();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_tty_ctrl_l_redraw_preserves_transcript_and_input() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions",
+            r#"{"provider":"managed","model":"gpt-5.4"}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            SESSION_JSON,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-1/turns",
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"draft input"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-redraw",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-redraw/events/stream?after=0&limit=100&until=blocked_or_terminal",
+            StatusCode::OK,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"assistant.completed\",\"data\":{\"text\":\"redraw preserved input\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-redraw",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-redraw",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"succeeded",
+                "outputText":"redraw preserved input"
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    let mut session = spawn_tty_cli(
+        home.path(),
+        server.url(),
+        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+    );
+    let mut output = String::new();
+    session.wait_for(&mut output, "Session");
+    session.write("/help\r");
+    session.wait_for(&mut output, "Show commands");
+    session.write("draft input");
+    output.clear();
+    session.write("\x0c");
+    session.wait_for(&mut output, "Commands:");
+    assert!(
+        output.contains("Commands:"),
+        "Ctrl-L redraw did not preserve transcript content:\n{output}"
+    );
+    session.write("\r");
+    session.wait_for(&mut output, "redraw preserved input");
     session.write("\x03");
     session.wait_for_exit();
 
@@ -1745,6 +1995,7 @@ fn test_cli_tty_queues_prompt_while_turn_is_running() {
     session.wait_for(&mut output, "Session");
     session.write("slow turn\r");
     session.wait_for(&mut output, "working");
+    session.write("\x04");
     session.write("pending turn\r");
     session.wait_for(&mut output, "queued");
     output.clear();
@@ -2744,6 +2995,13 @@ impl TtyCliSession {
         }
     }
 
+    fn drain_pending(&mut self, output: &mut String) {
+        while let Ok(chunk) = self.rx.try_recv() {
+            self.respond_to_cursor_position_requests(&chunk);
+            output.push_str(&chunk);
+        }
+    }
+
     fn resize(&mut self, rows: u16, cols: u16) {
         self.rows = rows.max(1);
         self.cols = cols.max(1);
@@ -2796,6 +3054,18 @@ fn spawn_tty_cli_with_size(
     rows: u16,
     cols: u16,
 ) -> TtyCliSession {
+    spawn_tty_cli_with_size_and_env(home, url, args, rows, cols, &[])
+}
+
+#[cfg(unix)]
+fn spawn_tty_cli_with_size_and_env(
+    home: &std::path::Path,
+    url: &str,
+    args: &[&str],
+    rows: u16,
+    cols: u16,
+    envs: &[(&str, &str)],
+) -> TtyCliSession {
     use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
     std::fs::create_dir_all(home).unwrap();
@@ -2814,6 +3084,10 @@ fn spawn_tty_cli_with_size(
     cmd.env("XDG_CONFIG_HOME", home.join("xdg-config"));
     cmd.env("GESTALT_API_KEY", TEST_TOKEN);
     cmd.env_remove("GESTALT_URL");
+    cmd.env_remove("GESTALT_CLI_DISABLE_MOUSE");
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
     cmd.arg("--url");
     cmd.arg(url);
     cmd.args(args);


### PR DESCRIPTION
## Summary

- Route mouse wheel and PageUp/PageDown transcript scrolling to the conversation transcript instead of prompt history.
- Keep Up/Down for input history, add Claude Code-style Ctrl-J/Shift-Enter newline handling, Ctrl-L redraw, Ctrl-D empty-prompt exit, Ctrl-Home/Ctrl-End jumps, and documented mouse capture opt-out.
- Update CLI docs and TTY integration coverage for the changed terminal contract.

## Interface Changes

- New/changed interface: `gestalt agent` TTY sessions enable mouse capture by default so wheel/trackpad scrolling moves the transcript; set `GESTALT_CLI_DISABLE_MOUSE=1` before launch to preserve terminal-native mouse selection.
- Example usage: `GESTALT_CLI_DISABLE_MOUSE=1 gestalt agent --provider managed --model gpt-5.4`.
- New/changed shortcuts: `Up`/`Down` recall input history, `PageUp`/`PageDown` scroll transcript by half a screen, `Ctrl-Home`/`Ctrl-End` jump transcript start/end, `Ctrl-L` redraws preserving input/history, `Ctrl-D` exits an empty idle prompt, `Ctrl-J`/`Alt-Enter`/supported `Shift-Enter` insert newlines.

## Functional/Integration Tests

- Tests added or augmented: TTY agent integration tests for mouse capture opt-out, wheel/PageUp/PageDown transcript scrolling, Ctrl-J multiline prompt submission, Ctrl-L redraw preservation, Ctrl-D exit, and mouse capture cleanup on exit.
- Contract boundary covered: `gestalt agent` running under a pseudo-terminal against the scripted HTTP agent API.
- Commands run:
  - `cargo fmt --manifest-path gestalt/cli/Cargo.toml`
  - `cargo fmt --manifest-path gestalt/cli/Cargo.toml --check`
  - `cargo test --manifest-path gestalt/cli/Cargo.toml --test agents_cli tty -- --test-threads=1`
  - `cargo test --manifest-path gestalt/cli/Cargo.toml --test agents_cli -- --test-threads=1`
  - `cargo test --manifest-path gestalt/cli/Cargo.toml -- --test-threads=1`
  - `git diff --check`
