### PR TITLE
Add static gestaltd validate

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 	"gopkg.in/yaml.v3"
@@ -415,19 +416,23 @@ type ProviderEntry struct {
 	MCP               bool                          `yaml:"mcp,omitempty"`
 
 	// Runtime-resolved fields (populated during init/bootstrap, not from YAML)
-	Command              string                                `yaml:"-"`
-	Args                 []string                              `yaml:"-"`
-	ResolvedManifestPath string                                `yaml:"-"`
-	ResolvedManifest     *providermanifestv1.Manifest          `yaml:"-"`
-	ResolvedIconFile     string                                `yaml:"-"`
-	HostBinary           string                                `yaml:"-"`
-	ConnectionMode       providermanifestv1.ConnectionMode     `yaml:"-"`
-	Auth                 *ConnectionAuthDef                    `yaml:"-"`
-	DefaultConnection    string                                `yaml:"-"`
-	ConnectionParams     map[string]ConnectionParamDef         `yaml:"-"`
-	Discovery            *providermanifestv1.ProviderDiscovery `yaml:"-"`
-	ResolvedAssetRoot    string                                `yaml:"-"`
-	MCPToolPrefix        string                                `yaml:"-"`
+	Command                    string                                `yaml:"-"`
+	Args                       []string                              `yaml:"-"`
+	ResolvedManifestPath       string                                `yaml:"-"`
+	ResolvedManifest           *providermanifestv1.Manifest          `yaml:"-"`
+	ResolvedCatalog            *catalog.Catalog                      `yaml:"-"`
+	ResolvedCatalogAvailable   bool                                  `yaml:"-"`
+	ResolvedCatalogSessionOnly bool                                  `yaml:"-"`
+	StaticManifestUnavailable  bool                                  `yaml:"-"`
+	ResolvedIconFile           string                                `yaml:"-"`
+	HostBinary                 string                                `yaml:"-"`
+	ConnectionMode             providermanifestv1.ConnectionMode     `yaml:"-"`
+	Auth                       *ConnectionAuthDef                    `yaml:"-"`
+	DefaultConnection          string                                `yaml:"-"`
+	ConnectionParams           map[string]ConnectionParamDef         `yaml:"-"`
+	Discovery                  *providermanifestv1.ProviderDiscovery `yaml:"-"`
+	ResolvedAssetRoot          string                                `yaml:"-"`
+	MCPToolPrefix              string                                `yaml:"-"`
 }
 
 type providerEntryFields ProviderEntry

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -638,6 +638,9 @@ func ValidateResolvedStructure(cfg *Config) error {
 		if entry.AuthorizationPolicy == "" {
 			continue
 		}
+		if entry.StaticManifestUnavailable {
+			continue
+		}
 		if entry.ResolvedManifest == nil || entry.ManifestSpec() == nil {
 			return fmt.Errorf("config validation: ui %q authorizationPolicy requires a resolved ui manifest", name)
 		}

--- a/gestaltd/internal/config/plugin_validation.go
+++ b/gestaltd/internal/config/plugin_validation.go
@@ -20,13 +20,17 @@ func PluginValidationEntry(entry *ProviderEntry) *pluginservice.ValidationPlugin
 		return nil
 	}
 	return &pluginservice.ValidationPlugin{
-		Manifest:            entry.ResolvedManifest,
-		ManifestPath:        entry.ResolvedManifestPath,
-		AllowedOperations:   entry.AllowedOperations,
-		Invokes:             pluginInvocationDependencies(entry.Invokes),
-		SurfaceURLOverrides: pluginSurfaceURLOverrides(entry),
-		ReadStaticCatalog:   pluginservice.StaticCatalogReaderForManifest(entry.ResolvedManifestPath),
-		LoadAPICatalog:      pluginservice.DefaultAPICatalogLoader,
+		Manifest:                    entry.ResolvedManifest,
+		ManifestPath:                entry.ResolvedManifestPath,
+		AllowedOperations:           entry.AllowedOperations,
+		Invokes:                     pluginInvocationDependencies(entry.Invokes),
+		SurfaceURLOverrides:         pluginSurfaceURLOverrides(entry),
+		EffectiveCatalog:            entry.ResolvedCatalog,
+		EffectiveCatalogAvailable:   entry.ResolvedCatalogAvailable,
+		EffectiveCatalogSessionOnly: entry.ResolvedCatalogSessionOnly,
+		StaticMetadataUnavailable:   entry.StaticManifestUnavailable,
+		ReadStaticCatalog:           pluginservice.StaticCatalogReaderForManifest(entry.ResolvedManifestPath),
+		LoadAPICatalog:              pluginservice.DefaultAPICatalogLoader,
 	}
 }
 

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -9,12 +9,14 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -786,6 +788,375 @@ plugins:
 	}
 	if _, err := os.Stat(providedArtifactsDir); !os.IsNotExist(err) {
 		t.Fatalf("validate should not mutate provided artifacts dir, got err=%v", err)
+	}
+}
+
+func TestE2EValidateStaticAcceptsMissingRuntimeEnvPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := writeValidValidateConfig(t, dir)
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	data = []byte(strings.Replace(string(data), "encryptionKey: valid-config-e2e-key", "encryptionKey: ${GESTALT_E2E_VALIDATE_MISSING_KEY}", 1))
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected static validate to succeed with missing runtime env placeholder: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "config ok") {
+		t.Fatalf("expected validate success, got: %s", out)
+	}
+}
+
+func TestE2EValidatePlatformUsesLockedStaticMetadataWithoutArchiveDownload(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := writeValidValidateConfig(t, dir)
+	lockPath := filepath.Join(dir, "gestalt.lock.json")
+	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd lock failed: %v\n%s", err, out)
+	}
+
+	var archiveHits atomic.Int64
+	archiveServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		archiveHits.Add(1)
+		http.Error(w, "static validate must not fetch this archive", http.StatusTeapot)
+	}))
+	t.Cleanup(archiveServer.Close)
+
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+	var lock map[string]any
+	if err := json.Unmarshal(lockData, &lock); err != nil {
+		t.Fatalf("parse lockfile: %v", err)
+	}
+	providers := lock["providers"].(map[string]any)
+	plugins := providers["plugin"].(map[string]any)
+	example := plugins["example"].(map[string]any)
+	example["archives"] = map[string]any{
+		"linux/amd64": map[string]any{
+			"url":    archiveServer.URL + "/provider.tar.gz",
+			"sha256": strings.Repeat("a", 64),
+		},
+	}
+	updated, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal lockfile: %v", err)
+	}
+	updated = append(updated, '\n')
+	if err := os.WriteFile(lockPath, updated, 0o644); err != nil {
+		t.Fatalf("write lockfile: %v", err)
+	}
+
+	out, err = exec.Command(gestaltdBin, "validate", "--platform", "linux/amd64", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected platform validate to use locked static metadata: %v\n%s", err, out)
+	}
+	if got := archiveHits.Load(); got != 0 {
+		t.Fatalf("archive fetches = %d, want 0", got)
+	}
+}
+
+func TestE2EValidateStaticRejectsStaleCatalogExposureMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+	externalCredentialsManifest := componentProviderManifestPath(t, setupExternalCredentialsProviderDir(t, dir))
+	callerManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, filepath.Join(dir, "caller")))
+	targetManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, filepath.Join(dir, "target")))
+	lockPath := filepath.Join(dir, "gestalt.lock.json")
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeConfig := func(targetOperation string) {
+		t.Helper()
+		cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v5
+server:
+  baseUrl: %s
+  encryptionKey: valid-config-e2e-key
+  providers:
+    indexeddb: inmem
+    externalCredentials: default
+providers:
+  externalCredentials:
+    default:
+      source:
+        path: %s
+  indexeddb:
+    inmem:
+      source:
+        path: %s
+plugins:
+  caller:
+    source:
+      path: %s
+    invokes:
+      - plugin: target
+        operation: echo
+  target:
+    source:
+      path: %s
+    allowedOperations:
+      %s: {}
+`, e2eLoopbackBaseURL(8080), externalCredentialsManifest, indexedDBManifest, callerManifest, targetManifest, targetOperation)
+		if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+	writeConfig("echo")
+	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd lock failed: %v\n%s", err, out)
+	}
+
+	writeConfig("greet")
+	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected stale static catalog metadata to fail validation:\n%s", out)
+	}
+	if !strings.Contains(string(out), `lock entry for plugin \"target\" is stale`) {
+		t.Fatalf("expected stale target lock error, got: %s", out)
+	}
+}
+
+func TestE2EValidateStaticPlatformRejectsExplicitMissingLockfile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+	externalCredentialsManifest := componentProviderManifestPath(t, setupExternalCredentialsProviderDir(t, dir))
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v5
+server:
+  baseUrl: %s
+  encryptionKey: valid-config-e2e-key
+  providers:
+    indexeddb: inmem
+    externalCredentials: default
+providers:
+  externalCredentials:
+    default:
+      source:
+        path: %s
+  indexeddb:
+    inmem:
+      source:
+        path: %s
+plugins:
+  remote:
+    source: https://example.com/provider-release.yaml
+`, e2eLoopbackBaseURL(8080), externalCredentialsManifest, indexedDBManifest)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	lockPath := filepath.Join(dir, "missing.lock.json")
+	out, err := exec.Command(gestaltdBin, "validate", "--platform", runtime.GOOS+"/"+runtime.GOARCH, "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected explicit missing lockfile to fail:\n%s", out)
+	}
+	if !strings.Contains(string(out), "lockfile is missing or unreadable") {
+		t.Fatalf("expected missing lockfile error, got: %s", out)
+	}
+}
+
+func TestE2EValidateStaticLegacyLockAllowsUnavailablePolicyBoundUIMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+	externalCredentialsManifest := componentProviderManifestPath(t, setupExternalCredentialsProviderDir(t, dir))
+
+	var archiveHits atomic.Int64
+	archiveServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		archiveHits.Add(1)
+		http.Error(w, "private release asset", http.StatusUnauthorized)
+	}))
+	t.Cleanup(archiveServer.Close)
+
+	uiSource := archiveServer.URL + "/private-ui/provider-release.yaml"
+	uiPackage := "github.com/test/private-ui"
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v5
+server:
+  baseUrl: %s
+  encryptionKey: valid-config-e2e-key
+  providers:
+    indexeddb: inmem
+    externalCredentials: default
+providers:
+  externalCredentials:
+    default:
+      source:
+        path: %s
+  indexeddb:
+    inmem:
+      source:
+        path: %s
+  ui:
+    private:
+      source: %s
+      path: /private
+      authorizationPolicy: sample_policy
+authorization:
+  policies:
+    sample_policy:
+      default: deny
+      members:
+        - subjectID: user:viewer
+          role: viewer
+`, e2eLoopbackBaseURL(8080), externalCredentialsManifest, indexedDBManifest, uiSource)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	fingerprint, err := operator.NamedUIProviderFingerprint("private", &config.ProviderEntry{
+		Source: config.NewMetadataSource(uiSource),
+	}, dir)
+	if err != nil {
+		t.Fatalf("fingerprint ui provider: %v", err)
+	}
+	lock := map[string]any{
+		"schema":        "gestaltd-provider-lock",
+		"schemaVersion": 5,
+		"revision":      0,
+		"providers": map[string]any{
+			"ui": map[string]any{
+				"private": map[string]any{
+					"inputDigest": fingerprint,
+					"package":     uiPackage,
+					"kind":        providermanifestv1.KindUI,
+					"runtime":     "ui",
+					"source":      uiSource,
+					"version":     "0.0.1-alpha.1",
+					"archives": map[string]any{
+						"generic": map[string]any{
+							"url":    archiveServer.URL + "/private-ui.tar.gz",
+							"sha256": strings.Repeat("b", 64),
+						},
+					},
+				},
+			},
+		},
+	}
+	lockData, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal lockfile: %v", err)
+	}
+	lockPath := filepath.Join(dir, "gestalt.lock.json")
+	if err := os.WriteFile(lockPath, append(lockData, '\n'), 0o644); err != nil {
+		t.Fatalf("write lockfile: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected static validate to tolerate unavailable legacy ui metadata: %v\n%s", err, out)
+	}
+	if got := archiveHits.Load(); got == 0 {
+		t.Fatalf("expected static validate to attempt legacy archive download")
+	}
+}
+
+func TestE2EValidateStaticLegacyLockAllowsUnavailableInvokesTargetCatalog(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+	externalCredentialsManifest := componentProviderManifestPath(t, setupExternalCredentialsProviderDir(t, dir))
+	callerManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, dir))
+
+	var archiveHits atomic.Int64
+	archiveServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		archiveHits.Add(1)
+		http.Error(w, "private release asset", http.StatusUnauthorized)
+	}))
+	t.Cleanup(archiveServer.Close)
+
+	targetSource := archiveServer.URL + "/target/provider-release.yaml"
+	targetPackage := "github.com/test/private-target"
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v5
+server:
+  baseUrl: %s
+  encryptionKey: valid-config-e2e-key
+  providers:
+    indexeddb: inmem
+    externalCredentials: default
+providers:
+  externalCredentials:
+    default:
+      source:
+        path: %s
+  indexeddb:
+    inmem:
+      source:
+        path: %s
+plugins:
+  caller:
+    source:
+      path: %s
+    invokes:
+      - plugin: target
+        operation: privateOperation
+  target:
+    source: %s
+`, e2eLoopbackBaseURL(8080), externalCredentialsManifest, indexedDBManifest, callerManifest, targetSource)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	fingerprint, err := operator.ProviderFingerprint("target", &config.ProviderEntry{
+		Source: config.NewMetadataSource(targetSource),
+	}, dir)
+	if err != nil {
+		t.Fatalf("fingerprint target provider: %v", err)
+	}
+	lock := map[string]any{
+		"schema":        "gestaltd-provider-lock",
+		"schemaVersion": 5,
+		"revision":      0,
+		"providers": map[string]any{
+			"plugin": map[string]any{
+				"target": map[string]any{
+					"inputDigest": fingerprint,
+					"package":     targetPackage,
+					"kind":        providermanifestv1.KindPlugin,
+					"runtime":     "executable",
+					"source":      targetSource,
+					"version":     "0.0.1-alpha.1",
+					"archives": map[string]any{
+						runtime.GOOS + "/" + runtime.GOARCH: map[string]any{
+							"url":    archiveServer.URL + "/target.tar.gz",
+							"sha256": strings.Repeat("c", 64),
+						},
+					},
+				},
+			},
+		},
+	}
+	lockData, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal lockfile: %v", err)
+	}
+	lockPath := filepath.Join(dir, "gestalt.lock.json")
+	if err := os.WriteFile(lockPath, append(lockData, '\n'), 0o644); err != nil {
+		t.Fatalf("write lockfile: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected static validate to tolerate unavailable legacy target catalog: %v\n%s", err, out)
+	}
+	if got := archiveHits.Load(); got == 0 {
+		t.Fatalf("expected static validate to attempt legacy archive download")
 	}
 }
 

--- a/gestaltd/internal/daemon/lifecycle.go
+++ b/gestaltd/internal/daemon/lifecycle.go
@@ -61,9 +61,17 @@ func loadConfigForExecutionAtPathsWithStatePaths(configPaths []string, state ope
 	return cfg, nil
 }
 
-func loadConfigForValidationWithStatePaths(configFlags []string, state operator.StatePaths) ([]string, *config.Config, error) {
+func loadConfigForValidationWithStatePaths(configFlags []string, state operator.StatePaths, opts validateConfigOptions) ([]string, *config.Config, error) {
 	configPaths := operator.ResolveConfigPaths(configFlags)
-	cfg, err := operatorLifecycle().LoadForValidationAtPathsWithStatePaths(configPaths, state)
+	var (
+		cfg *config.Config
+		err error
+	)
+	if opts.Runtime {
+		cfg, err = operatorLifecycle().LoadForValidationAtPathsWithStatePaths(configPaths, state)
+	} else {
+		cfg, err = operatorLifecycle().LoadForStaticValidationAtPathsWithStatePaths(configPaths, state, operator.StaticValidationOptions{Platform: opts.Platform})
+	}
 	if err != nil {
 		return nil, nil, err
 	}

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -91,7 +91,7 @@ func runProviderValidate(args []string) error {
 	}
 	defer func() { _ = os.RemoveAll(session.Dir) }()
 
-	result, err := validateConfigWithStatePaths(session.ConfigPaths, session.State)
+	result, err := validateConfigWithStatePaths(session.ConfigPaths, session.State, validateConfigOptions{Runtime: true})
 	if err != nil {
 		return err
 	}
@@ -515,15 +515,19 @@ type validatedConfigResult struct {
 	Warnings []string
 }
 
-func validateConfigWithStatePaths(configFlags []string, state operator.StatePaths) (*validatedConfigResult, error) {
-	paths, cfg, err := loadConfigForValidationWithStatePaths(configFlags, state)
+func validateConfigWithStatePaths(configFlags []string, state operator.StatePaths, opts validateConfigOptions) (*validatedConfigResult, error) {
+	paths, cfg, err := loadConfigForValidationWithStatePaths(configFlags, state, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	warnings, err := bootstrap.Validate(context.Background(), cfg, buildFactories())
-	if err != nil {
-		return nil, err
+	var warnings []string
+	if opts.Runtime {
+		var err error
+		warnings, err = bootstrap.Validate(context.Background(), cfg, buildFactories())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &validatedConfigResult{

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
 	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/services/plugins/providerpkg"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 )
 
@@ -182,6 +183,8 @@ func runValidate(args []string) error {
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
+	platform := fs.String("platform", "", "target platform for static validation, formatted os/arch")
+	runtimeValidation := fs.Bool("runtime", false, "run deep runtime validation that starts configured providers")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -189,10 +192,34 @@ func runValidate(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	return validateConfig(configPaths, *lockfilePath)
+	opts, err := parseValidateConfigOptions(*platform, *runtimeValidation)
+	if err != nil {
+		return err
+	}
+	return validateConfig(configPaths, *lockfilePath, opts)
 }
 
-func validateConfig(configFlags []string, lockfilePath string) error {
+type validateConfigOptions struct {
+	Platform string
+	Runtime  bool
+}
+
+func parseValidateConfigOptions(platform string, runtimeValidation bool) (validateConfigOptions, error) {
+	platform = strings.TrimSpace(platform)
+	if platform != "" {
+		goos, goarch, err := providerpkg.ParsePlatformString(platform)
+		if err != nil {
+			return validateConfigOptions{}, fmt.Errorf("invalid --platform %q, expected os/arch", platform)
+		}
+		platform = goos + "/" + goarch
+	}
+	if runtimeValidation && platform != "" && platform != currentReleasePlatform() {
+		return validateConfigOptions{}, fmt.Errorf("--runtime validation executes host providers; --platform must be omitted or equal the host platform %q", currentReleasePlatform())
+	}
+	return validateConfigOptions{Platform: platform, Runtime: runtimeValidation}, nil
+}
+
+func validateConfig(configFlags []string, lockfilePath string, opts validateConfigOptions) error {
 	scratchDir, err := os.MkdirTemp("", "gestaltd-validate-*")
 	if err != nil {
 		return fmt.Errorf("create validation scratch dir: %w", err)
@@ -202,7 +229,7 @@ func validateConfig(configFlags []string, lockfilePath string) error {
 	result, err := validateConfigWithStatePaths(configFlags, operator.StatePaths{
 		ArtifactsDir: scratchDir,
 		LockfilePath: lockfilePath,
-	})
+	}, opts)
 	if err != nil {
 		return err
 	}
@@ -279,7 +306,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--check]")
 	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
-	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH]")
+	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH] [--platform os/arch] [--runtime]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
 	writeUsageLine(w, "  lock        Resolve provider metadata and write lock state")
@@ -340,10 +367,11 @@ func printSyncUsage(w io.Writer) {
 
 func printValidateUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH]")
+	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH] [--platform os/arch] [--runtime]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Validate configuration without starting the server or running migrations.")
-	writeUsageLine(w, "Validation always stages source-backed providers in a temporary scratch dir.")
+	writeUsageLine(w, "Static validation uses locked provider metadata and temporary scratch state.")
+	writeUsageLine(w, "Use --runtime to opt into deep validation that starts configured providers.")
 	writeUsageLine(w, "Repeated --config flags merge left-to-right.")
 	writeUsageLine(w, "The --lockfile path follows normal CLI path resolution; --artifacts-dir keeps")
 	writeUsageLine(w, "the same config-relative resolution used by sync and serve.")

--- a/gestaltd/internal/operator/archive_policy.go
+++ b/gestaltd/internal/operator/archive_policy.go
@@ -18,7 +18,15 @@ func allowsGenericArchive(kind string, manifest *providermanifestv1.Manifest) bo
 }
 
 func validateLockedArchivePolicy(subject, kind string, manifest *providermanifestv1.Manifest, entry LockEntry, platform, resolvedKey string) error {
-	if allowsGenericArchive(kind, manifest) {
+	return validateLockedArchivePolicyWithGenericAllowance(subject, entry, platform, resolvedKey, allowsGenericArchive(kind, manifest))
+}
+
+func validateStaticLockedArchivePolicy(subject, kind string, entry LockEntry, platform, resolvedKey string) error {
+	return validateLockedArchivePolicyWithGenericAllowance(subject, entry, platform, resolvedKey, allowsStaticGenericArchive(kind, entry))
+}
+
+func validateLockedArchivePolicyWithGenericAllowance(subject string, entry LockEntry, platform, resolvedKey string, allowsGeneric bool) error {
+	if allowsGeneric {
 		return nil
 	}
 	if resolvedKey == platformKeyGeneric {
@@ -30,6 +38,17 @@ func validateLockedArchivePolicy(subject, kind string, manifest *providermanifes
 		return unsafeGenericArchiveError(subject, platform)
 	}
 	return nil
+}
+
+func allowsStaticGenericArchive(kind string, entry LockEntry) bool {
+	switch kind {
+	case providermanifestv1.KindUI:
+		return true
+	case providermanifestv1.KindPlugin:
+		return lockEntryRuntime(entry, kind) == providerReleaseRuntimeDeclarative
+	default:
+		return false
+	}
 }
 
 func unsafeGenericArchiveError(subject, platform string) error {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -19,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/providerregistry"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -69,16 +71,25 @@ type LockArchive struct {
 }
 
 type LockEntry struct {
-	Fingerprint string                 `json:"fingerprint"`
-	Package     string                 `json:"package,omitempty"`
-	Kind        string                 `json:"kind,omitempty"`
-	Runtime     string                 `json:"runtime,omitempty"`
-	Source      string                 `json:"source,omitempty"`
-	Version     string                 `json:"version,omitempty"`
-	Archives    map[string]LockArchive `json:"archives,omitempty"`
-	Manifest    string                 `json:"manifest"`
-	Executable  string                 `json:"executable,omitempty"`
-	AssetRoot   string                 `json:"assetRoot,omitempty"`
+	Fingerprint              string                       `json:"fingerprint"`
+	Package                  string                       `json:"package,omitempty"`
+	Kind                     string                       `json:"kind,omitempty"`
+	Runtime                  string                       `json:"runtime,omitempty"`
+	Source                   string                       `json:"source,omitempty"`
+	Version                  string                       `json:"version,omitempty"`
+	Archives                 map[string]LockArchive       `json:"archives,omitempty"`
+	Manifest                 string                       `json:"manifest"`
+	Executable               string                       `json:"executable,omitempty"`
+	AssetRoot                string                       `json:"assetRoot,omitempty"`
+	StaticManifest           *providermanifestv1.Manifest `json:"-"`
+	StaticCatalogAvailable   bool                         `json:"-"`
+	StaticCatalogFingerprint string                       `json:"-"`
+	StaticCatalogOperations  []string                     `json:"-"`
+	StaticCatalogSessionOnly bool                         `json:"-"`
+}
+
+type StaticValidationOptions struct {
+	Platform string
 }
 
 type Lifecycle struct {
@@ -296,7 +307,11 @@ func (l *Lifecycle) prepareLockAtPaths(configPaths []string, state StatePaths, d
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
-	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), config.PluginValidationConfig(cfg)); err != nil {
+	catalogs, err := pluginservice.EffectiveCatalogsAndDependencies(context.Background(), config.PluginValidationConfig(cfg))
+	if err != nil {
+		return nil, nil, lifecyclePaths{}, err
+	}
+	if err := attachStaticValidationMetadata(lock, cfg, catalogs); err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
 	return lock, cfg, paths, nil
@@ -680,6 +695,50 @@ func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string,
 		return nil, err
 	}
 	if err := pluginservice.ValidateDependencies(context.Background(), config.PluginValidationConfig(cfg)); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func (l *Lifecycle) LoadForStaticValidationAtPathsWithStatePaths(configPaths []string, state StatePaths, opts StaticValidationOptions) (*config.Config, error) {
+	cfg, err := config.LoadAllowMissingEnvPaths(configPaths)
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %v", err)
+	}
+	if err := config.OverlayRemotePluginConfigPaths(configPaths, cfg); err != nil {
+		return nil, fmt.Errorf("loading config: %v", err)
+	}
+	paths := resolveLifecyclePaths(configPaths, cfg, state)
+	platform := strings.TrimSpace(opts.Platform)
+	if platform == "" {
+		platform = providerpkg.CurrentPlatformString()
+	}
+
+	var lock *Lockfile
+	lockErr := error(nil)
+	if configHasProviderLoading(cfg) {
+		lock, lockErr = ReadLockfile(paths.lockfilePath)
+		if lockErr != nil && configRequiresStaticLock(cfg) {
+			if configRequiresRemoteStaticLock(cfg) || platform != providerpkg.CurrentPlatformString() || !os.IsNotExist(lockErr) {
+				return nil, fmt.Errorf("lockfile is missing or unreadable; run `%s`: %w", formatLockCommand(paths), lockErr)
+			}
+			_, scratchCfg, _, cleanup, err := l.prepareLockAtPathsInScratch(configPaths, state)
+			if cleanup != nil {
+				defer cleanup()
+			}
+			if err != nil {
+				return nil, err
+			}
+			return scratchCfg, nil
+		}
+	}
+	if err := l.applyStaticValidationProviders(context.Background(), paths, lock, cfg, platform); err != nil {
+		return nil, err
+	}
+	if err := config.ValidateResolvedStructure(cfg); err != nil {
+		return nil, err
+	}
+	if err := pluginservice.ValidateEffectiveCatalogsAndDependencies(context.Background(), config.PluginValidationConfig(cfg)); err != nil {
 		return nil, err
 	}
 	return cfg, nil
@@ -1091,39 +1150,7 @@ func lockEntriesForKind(lock *Lockfile, kind config.HostProviderKind) map[string
 }
 
 func configHasProviderLoading(cfg *config.Config) bool {
-	for _, entry := range cfg.Plugins {
-		if sourceBacked(entry) {
-			return true
-		}
-	}
-	for _, collection := range hostProviderCollections(cfg) {
-		for _, entry := range collection.entries {
-			if sourceBacked(entry) {
-				return true
-			}
-		}
-	}
-	for _, entry := range cfg.Runtime.Providers {
-		if runtimeSourceBacked(entry) {
-			return true
-		}
-	}
-	for _, entry := range cfg.Providers.UI {
-		if entry != nil && sourceBacked(&entry.ProviderEntry) {
-			return true
-		}
-	}
-	for _, def := range cfg.Providers.IndexedDB {
-		if sourceBacked(def) {
-			return true
-		}
-	}
-	for _, def := range cfg.Providers.S3 {
-		if sourceBacked(def) {
-			return true
-		}
-	}
-	return false
+	return configHasMatchingProviderEntry(cfg, sourceBacked)
 }
 
 func configHasLocalProviderSources(cfg *config.Config) bool {
@@ -2570,6 +2597,502 @@ func installLockedPackageAtomic(packagePath, destDir string) (*installedPackage,
 		}
 		return os.RemoveAll(cleanupDir)
 	}, commit, nil
+}
+
+func attachStaticValidationMetadata(lock *Lockfile, cfg *config.Config, catalogs map[string]pluginservice.EffectiveCatalogResult) error {
+	if lock == nil || cfg == nil {
+		return nil
+	}
+	attach := func(entries map[string]LockEntry, name string, entry *config.ProviderEntry) {
+		if entries == nil || entry == nil || entry.ResolvedManifest == nil {
+			return
+		}
+		lockEntry, ok := entries[name]
+		if !ok {
+			return
+		}
+		lockEntry.StaticManifest = entry.ResolvedManifest
+		entries[name] = lockEntry
+	}
+	for name, entry := range cfg.Plugins {
+		attach(lock.Providers, name, entry)
+		if entry == nil || entry.ResolvedManifest == nil {
+			continue
+		}
+		lockEntry, ok := lock.Providers[name]
+		if !ok {
+			continue
+		}
+		resolved := catalogs[name]
+		fingerprint, err := staticCatalogInputFingerprint(entry)
+		if err != nil {
+			return err
+		}
+		lockEntry.StaticCatalogAvailable = resolved.Available
+		lockEntry.StaticCatalogFingerprint = fingerprint
+		lockEntry.StaticCatalogOperations = staticCatalogOperationIDs(resolved.Catalog)
+		lockEntry.StaticCatalogSessionOnly = resolved.SessionOnly
+		lock.Providers[name] = lockEntry
+		entry.ResolvedCatalog = catalogFromStaticOperationIDs(lockEntry.StaticCatalogOperations, resolved.Available)
+		entry.ResolvedCatalogAvailable = resolved.Available
+		entry.ResolvedCatalogSessionOnly = resolved.SessionOnly
+	}
+	for _, collection := range hostProviderCollections(cfg) {
+		entries := lockEntriesForKind(lock, collection.kind)
+		for name, entry := range collection.entries {
+			attach(entries, name, entry)
+		}
+	}
+	for name, entry := range cfg.Runtime.Providers {
+		if entry != nil {
+			attach(lock.Runtimes, name, &entry.ProviderEntry)
+		}
+	}
+	for name, entry := range cfg.Providers.IndexedDB {
+		attach(lock.IndexedDBs, name, entry)
+	}
+	for name, entry := range cfg.Providers.S3 {
+		attach(lock.S3, name, entry)
+	}
+	for name, entry := range cfg.Providers.UI {
+		if entry != nil {
+			attach(lock.UIs, name, &entry.ProviderEntry)
+		}
+	}
+	return nil
+}
+
+func staticCatalogOperationIDs(cat *catalog.Catalog) []string {
+	if cat == nil || len(cat.Operations) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(cat.Operations))
+	for i := range cat.Operations {
+		id := strings.TrimSpace(cat.Operations[i].ID)
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func catalogFromStaticOperationIDs(ids []string, available bool) *catalog.Catalog {
+	if !available {
+		return nil
+	}
+	cat := &catalog.Catalog{
+		Operations: make([]catalog.CatalogOperation, 0, len(ids)),
+	}
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		cat.Operations = append(cat.Operations, catalog.CatalogOperation{ID: id})
+	}
+	return cat
+}
+
+func staticCatalogInputFingerprint(entry *config.ProviderEntry) (string, error) {
+	type input struct {
+		AllowedOperations map[string]*config.OperationOverride `json:"allowedOperations,omitempty"`
+		GraphQLSurfaceURL string                               `json:"graphqlSurfaceUrl,omitempty"`
+		MCPSurfaceURL     string                               `json:"mcpSurfaceUrl,omitempty"`
+	}
+	var allowed map[string]*config.OperationOverride
+	var graphQLURL, mcpURL string
+	if entry != nil {
+		allowed = entry.AllowedOperations
+		graphQLURL = config.ProviderSurfaceURLOverride(entry, config.SpecSurfaceGraphQL)
+		mcpURL = config.ProviderSurfaceURLOverride(entry, config.SpecSurfaceMCP)
+	}
+	payload, err := json.Marshal(input{
+		AllowedOperations: allowed,
+		GraphQLSurfaceURL: graphQLURL,
+		MCPSurfaceURL:     mcpURL,
+	})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func staticManifestReferencesPackageFiles(manifest *providermanifestv1.Manifest) bool {
+	if manifest == nil {
+		return false
+	}
+	if strings.TrimSpace(manifest.IconFile) != "" {
+		return true
+	}
+	spec := manifest.Spec
+	if spec == nil {
+		return false
+	}
+	if strings.TrimSpace(spec.ConfigSchemaPath) != "" {
+		return true
+	}
+	return spec.UI != nil && strings.TrimSpace(spec.UI.Path) != ""
+}
+
+func configRequiresStaticLock(cfg *config.Config) bool {
+	return configHasMatchingProviderEntry(cfg, func(entry *config.ProviderEntry) bool {
+		return sourceBacked(entry) && !entry.HasLocalSource()
+	})
+}
+
+func configRequiresRemoteStaticLock(cfg *config.Config) bool {
+	return configHasMatchingProviderEntry(cfg, func(entry *config.ProviderEntry) bool {
+		return sourceBacked(entry) && !entry.HasLocalSource() && !entry.HasLocalReleaseSource()
+	})
+}
+
+func configHasMatchingProviderEntry(cfg *config.Config, matches func(*config.ProviderEntry) bool) bool {
+	if cfg == nil || matches == nil {
+		return false
+	}
+	for _, entry := range cfg.Plugins {
+		if matches(entry) {
+			return true
+		}
+	}
+	for _, collection := range hostProviderCollections(cfg) {
+		for _, entry := range collection.entries {
+			if matches(entry) {
+				return true
+			}
+		}
+	}
+	for _, entry := range cfg.Runtime.Providers {
+		if entry != nil && matches(&entry.ProviderEntry) {
+			return true
+		}
+	}
+	for _, entry := range cfg.Providers.IndexedDB {
+		if matches(entry) {
+			return true
+		}
+	}
+	for _, entry := range cfg.Providers.S3 {
+		if matches(entry) {
+			return true
+		}
+	}
+	for _, entry := range cfg.Providers.UI {
+		if entry != nil && matches(&entry.ProviderEntry) {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *Lifecycle) applyStaticValidationProviders(ctx context.Context, paths lifecyclePaths, lock *Lockfile, cfg *config.Config, platform string) error {
+	if !configHasProviderLoading(cfg) {
+		return nil
+	}
+	for name, entry := range cfg.Plugins {
+		if entry == nil {
+			continue
+		}
+		configMap, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			return fmt.Errorf("decode provider config for provider %q: %w", name, err)
+		}
+		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindPlugin), providermanifestv1.KindPlugin, name, entry, configMap, providerDestDir(paths, name), platform, false, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+			return bindResolvedProviderManifest(name, entry, manifestPath, manifest, configMap)
+		}); err != nil {
+			return err
+		}
+		if entry.ResolvedManifest != nil {
+			entry.DisplayName = cmp.Or(entry.DisplayName, entry.ResolvedManifest.DisplayName)
+			entry.Description = cmp.Or(entry.Description, entry.ResolvedManifest.Description)
+		}
+		entry.IconFile = cmp.Or(entry.IconFile, entry.ResolvedIconFile)
+	}
+	if err := synthesizePluginOwnedUIEntries(cfg); err != nil {
+		return err
+	}
+	for _, collection := range hostProviderCollections(cfg) {
+		lockEntries := lockEntriesForKind(lock, collection.kind)
+		kind := providerManifestKind(collection.kind)
+		for name, entry := range collection.entries {
+			if entry == nil {
+				continue
+			}
+			configMap, err := config.NodeToMap(entry.Config)
+			if err != nil {
+				return fmt.Errorf("decode provider config for %s %q: %w", kind, name, err)
+			}
+			if err := l.applyStaticValidationEntry(ctx, paths, lockEntries, kind, name, entry, configMap, componentDestDir(paths, collection.kind, name), platform, false, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+				return bindResolvedComponentManifest(kind, name, entry, manifestPath, manifest, configMap)
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	for name, entry := range cfg.Runtime.Providers {
+		if entry == nil {
+			continue
+		}
+		configMap, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			return fmt.Errorf("decode provider config for %s %q: %w", providermanifestv1.KindRuntime, name, err)
+		}
+		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindRuntime), providermanifestv1.KindRuntime, name, &entry.ProviderEntry, configMap, runtimeDestDir(paths, name), platform, false, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+			return bindResolvedComponentManifest(providermanifestv1.KindRuntime, name, &entry.ProviderEntry, manifestPath, manifest, configMap)
+		}); err != nil {
+			return err
+		}
+	}
+	for name, entry := range cfg.Providers.IndexedDB {
+		if entry == nil {
+			continue
+		}
+		configMap, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			return fmt.Errorf("decode provider config for %s %q: %w", providermanifestv1.KindIndexedDB, name, err)
+		}
+		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindIndexedDB), providermanifestv1.KindIndexedDB, name, entry, configMap, indexeddbDestDir(paths, name), platform, false, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+			return bindResolvedComponentManifest(providermanifestv1.KindIndexedDB, name, entry, manifestPath, manifest, configMap)
+		}); err != nil {
+			return err
+		}
+	}
+	for name, entry := range cfg.Providers.S3 {
+		if entry == nil {
+			continue
+		}
+		configMap, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			return fmt.Errorf("decode provider config for %s %q: %w", providermanifestv1.KindS3, name, err)
+		}
+		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindS3), providermanifestv1.KindS3, name, entry, configMap, s3DestDir(paths, name), platform, false, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+			return bindResolvedComponentManifest(providermanifestv1.KindS3, name, entry, manifestPath, manifest, configMap)
+		}); err != nil {
+			return err
+		}
+	}
+	for name, entry := range cfg.Providers.UI {
+		if entry == nil {
+			continue
+		}
+		configMap, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			return fmt.Errorf("decode ui %q config: %w", name, err)
+		}
+		if err := l.applyStaticValidationEntry(ctx, paths, lockEntriesForProviderKind(lock, providermanifestv1.KindUI), providermanifestv1.KindUI, name, &entry.ProviderEntry, configMap, uiDestDir(paths, name), platform, true, func(manifestPath string, manifest *providermanifestv1.Manifest) error {
+			return bindResolvedUIManifest(&entry.ProviderEntry, manifestPath, manifest, configMap)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *Lifecycle) applyStaticValidationEntry(ctx context.Context, paths lifecyclePaths, lockEntries map[string]LockEntry, kind, name string, provider *config.ProviderEntry, configMap map[string]any, destDir, platform string, ui bool, bind func(string, *providermanifestv1.Manifest) error) error {
+	if provider == nil || !sourceBacked(provider) {
+		return nil
+	}
+	var entry LockEntry
+	found := false
+	if lockEntries != nil {
+		entry, found = lockEntries[name]
+	}
+	if found {
+		if ui {
+			if !uiLockEntryMetadataMatches(paths, name, provider, entry, true) {
+				return lockMetadataStaleError(paths, "lock entry for ui %q is stale", name)
+			}
+		} else if !lockEntryMetadataMatches(paths, kind, name, provider, entry, true) {
+			return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
+		}
+		if len(entry.Archives) > 0 {
+			_, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
+			if !ok {
+				return fmt.Errorf("no archive for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
+			}
+			if err := validateStaticLockedArchivePolicy(archivePolicySubject(kind, name), archivePolicyKind(kind), entry, platform, resolvedKey); err != nil {
+				return err
+			}
+		}
+		if entry.StaticManifest != nil && !staticManifestReferencesPackageFiles(entry.StaticManifest) {
+			if kind == providermanifestv1.KindPlugin {
+				fingerprint, err := staticCatalogInputFingerprint(provider)
+				if err != nil {
+					return err
+				}
+				if entry.StaticCatalogFingerprint != "" && entry.StaticCatalogFingerprint != fingerprint {
+					return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
+				}
+			}
+			provider.ResolvedCatalog = catalogFromStaticOperationIDs(entry.StaticCatalogOperations, entry.StaticCatalogAvailable)
+			provider.ResolvedCatalogAvailable = entry.StaticCatalogAvailable
+			provider.ResolvedCatalogSessionOnly = entry.StaticCatalogSessionOnly
+			return bind("", entry.StaticManifest)
+		}
+	}
+	if provider.HasLocalSource() {
+		install, cleanup, _, err := stageLocalSourceInstall(kind, name, provider.SourcePath(), destDir)
+		if err != nil {
+			if cleanup != nil {
+				_ = cleanup()
+			}
+			return err
+		}
+		if found && !preparedManifestMatchesLock(entry, install.manifest) {
+			if cleanup != nil {
+				_ = cleanup()
+			}
+			return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
+		}
+		if err := bind(install.manifestPath, install.manifest); err != nil {
+			if cleanup != nil {
+				_ = cleanup()
+			}
+			return err
+		}
+		return nil
+	}
+	if !found {
+		return lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", kind, name)
+	}
+	install, cleanup, err := l.installLockedArchiveForStaticValidation(ctx, paths, kind, name, provider, entry, destDir, platform)
+	if cleanup != nil {
+		defer func() { cleanup() }()
+	}
+	if err != nil {
+		if isStaticArchiveUnavailable(err) {
+			if manifest := fallbackStaticValidationManifest(kind, entry); manifest != nil {
+				provider.ResolvedCatalogSessionOnly = kind == providermanifestv1.KindPlugin
+				provider.StaticManifestUnavailable = true
+				return bind("", manifest)
+			}
+		}
+		return err
+	}
+	return bind(install.manifestPath, install.manifest)
+}
+
+type staticArchiveUnavailableError struct {
+	err error
+}
+
+func (e staticArchiveUnavailableError) Error() string {
+	return e.err.Error()
+}
+
+func (e staticArchiveUnavailableError) Unwrap() error {
+	return e.err
+}
+
+func isStaticArchiveUnavailable(err error) bool {
+	var unavailable staticArchiveUnavailableError
+	return errors.As(err, &unavailable)
+}
+
+func fallbackStaticValidationManifest(kind string, entry LockEntry) *providermanifestv1.Manifest {
+	normalizedKind := providermanifestv1.NormalizeKind(lockEntryKind(entry, kind))
+	if normalizedKind == "" {
+		normalizedKind = providermanifestv1.NormalizeKind(kind)
+	}
+	if normalizedKind == "" {
+		return nil
+	}
+	manifest := &providermanifestv1.Manifest{
+		Kind:    normalizedKind,
+		Source:  lockEntryPackage(entry),
+		Version: entry.Version,
+		Spec:    &providermanifestv1.Spec{},
+	}
+	if lockEntryRuntime(entry, kind) == providerReleaseRuntimeExecutable {
+		manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: "static-validation-placeholder"}
+	}
+	return manifest
+}
+
+func (l *Lifecycle) installLockedArchiveForStaticValidation(ctx context.Context, paths lifecyclePaths, kind, name string, provider *config.ProviderEntry, entry LockEntry, destDir, platform string) (*preparedInstall, func(), error) {
+	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
+	if !ok || archive.URL == "" {
+		return nil, nil, fmt.Errorf("no archive for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
+	}
+	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve locked source provider for %s %q: %w", kind, name, err)
+	}
+	if archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
+		return nil, nil, fmt.Errorf("no verified hash for platform %s for %s %q; run `%s --platform %s`", platform, kind, name, formatLockCommand(paths), platform)
+	}
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(provider), archiveLocation)
+	if err != nil {
+		return nil, nil, staticArchiveUnavailableError{
+			err: fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err),
+		}
+	}
+	cleanup := download.Cleanup
+	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
+		cleanup()
+		return nil, nil, fmt.Errorf("locked source provider digest mismatch for %s %q: got %s, want %s", kind, name, download.SHA256Hex, archive.SHA256)
+	}
+	if archive.SHA256 == "" {
+		sourceLocation := entry.Source
+		if !isRemoteReleaseMetadataLocation(sourceLocation) {
+			sourceLocation = resolveLockPath(paths.configDir, sourceLocation)
+		}
+		expectedSHA, err := localReleaseArchiveExpectedSHA(sourceLocation, resolvedKey, archiveLocation)
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("load local archive metadata for %s %q: %w", kind, name, err)
+		}
+		if expectedSHA != "" && download.SHA256Hex != expectedSHA {
+			cleanup()
+			return nil, nil, fmt.Errorf("locked source provider digest mismatch for %s %q: got %s, want %s", kind, name, download.SHA256Hex, expectedSHA)
+		}
+	}
+	if err := os.RemoveAll(destDir); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("reset static validation install dir for %s %q: %w", kind, name, err)
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("create static validation install dir for %s %q: %w", kind, name, err)
+	}
+	install, err := installPackageForStaticValidation(download.LocalPath, destDir)
+	if err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("inspect locked source provider for %s %q: %w", kind, name, err)
+	}
+	if install.manifest.Source != lockEntryPackage(entry) {
+		cleanup()
+		return nil, nil, fmt.Errorf("locked source provider manifest source mismatch for %s %q: got %q, want %q", kind, name, install.manifest.Source, lockEntryPackage(entry))
+	}
+	if install.manifest.Version != entry.Version {
+		cleanup()
+		return nil, nil, fmt.Errorf("locked source provider manifest version mismatch for %s %q: got %q, want %q", kind, name, install.manifest.Version, entry.Version)
+	}
+	if err := validateLockedArchivePolicy(archivePolicySubject(kind, name), archivePolicyKind(kind), install.manifest, entry, platform, resolvedKey); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	return install, cleanup, nil
+}
+
+func installPackageForStaticValidation(packagePath, destDir string) (*preparedInstall, error) {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create plugin directory: %w", err)
+	}
+	if err := providerpkg.ExtractPackage(packagePath, destDir); err != nil {
+		return nil, err
+	}
+	manifestPath, err := providerpkg.FindManifestFile(destDir)
+	if err != nil {
+		return nil, err
+	}
+	_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	manifest = providerpkg.ResolveManifestLocalReferences(manifest, manifestPath)
+	return &preparedInstall{manifestPath: manifestPath, manifest: manifest}, nil
 }
 
 func (l *Lifecycle) resolveConfiguredPlugins(paths lifecyclePaths, lock *Lockfile, cfg *config.Config, mode artifactMode) error {

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3145,6 +3145,51 @@ func TestLockMatchesConfig_RemoteS3UsesResourceNameFingerprint(t *testing.T) {
 	}
 }
 
+func TestConfigHasProviderLoadingIncludesIndexedDBAndS3(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{
+			name: "indexeddb only",
+			cfg: &config.Config{
+				Providers: config.ProvidersConfig{
+					IndexedDB: map[string]*config.ProviderEntry{
+						"main": {
+							Source: config.NewMetadataSource("https://example.invalid/github-com-testowner-providers-indexeddb/v0.0.1-alpha.1/provider-release.yaml"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "s3 only",
+			cfg: &config.Config{
+				Providers: config.ProvidersConfig{
+					S3: map[string]*config.ProviderEntry{
+						"assets": {
+							Source: config.NewMetadataSource("https://example.invalid/github-com-testowner-providers-s3/v0.0.1-alpha.1/provider-release.yaml"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if !configHasProviderLoading(tt.cfg) {
+				t.Fatal("configHasProviderLoading returned false")
+			}
+		})
+	}
+}
+
 func mustFingerprint(t *testing.T, name string, entry *config.ProviderEntry, configDir string) string {
 	t.Helper()
 	fingerprint, err := ProviderFingerprint(name, entry, configDir)

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -10,7 +11,8 @@ import (
 
 const (
 	providerLockSchemaName         = "gestaltd-provider-lock"
-	providerLockSchemaVersion      = 5
+	providerLockSchemaVersion      = 6
+	providerLockMinSchemaVersion   = 5
 	providerLockRevision           = 0
 	providerLockKindWorkflow       = "workflow"
 	providerLockKindTelemetry      = "telemetry"
@@ -46,13 +48,18 @@ type providerLockBuckets struct {
 }
 
 type portableLockEntry struct {
-	InputDigest string                 `json:"inputDigest,omitempty"`
-	Package     string                 `json:"package"`
-	Kind        string                 `json:"kind"`
-	Runtime     string                 `json:"runtime"`
-	Source      string                 `json:"source,omitempty"`
-	Version     string                 `json:"version,omitempty"`
-	Archives    map[string]LockArchive `json:"archives,omitempty"`
+	InputDigest        string                       `json:"inputDigest,omitempty"`
+	Package            string                       `json:"package"`
+	Kind               string                       `json:"kind"`
+	Runtime            string                       `json:"runtime"`
+	Source             string                       `json:"source,omitempty"`
+	Version            string                       `json:"version,omitempty"`
+	Archives           map[string]LockArchive       `json:"archives,omitempty"`
+	Manifest           *providermanifestv1.Manifest `json:"manifest,omitempty"`
+	CatalogAvailable   bool                         `json:"catalogAvailable,omitempty"`
+	CatalogFingerprint string                       `json:"catalogFingerprint,omitempty"`
+	CatalogOperations  []string                     `json:"catalogOperations,omitempty"`
+	CatalogSessionOnly bool                         `json:"catalogSessionOnly,omitempty"`
 }
 
 func newLockfile() *Lockfile {
@@ -234,7 +241,7 @@ func validateProviderLockfile(lock *providerLockfile) error {
 	if lock.Schema != providerLockSchemaName {
 		return fmt.Errorf("unsupported lockfile schema %q; run `gestaltd lock` to upgrade", lock.Schema)
 	}
-	if lock.SchemaVersion != providerLockSchemaVersion {
+	if lock.SchemaVersion < providerLockMinSchemaVersion || lock.SchemaVersion > providerLockSchemaVersion {
 		return fmt.Errorf("unsupported lockfile schema version %d; run `gestaltd lock` to upgrade", lock.SchemaVersion)
 	}
 	return nil
@@ -253,13 +260,18 @@ func portableEntriesFromLockEntries(entries map[string]LockEntry, kind string) m
 			source = ""
 		}
 		portable[name] = portableLockEntry{
-			InputDigest: entry.Fingerprint,
-			Package:     packageRef,
-			Kind:        lockEntryKind(entry, kind),
-			Runtime:     lockEntryRuntime(entry, kind),
-			Source:      source,
-			Version:     entry.Version,
-			Archives:    maps.Clone(entry.Archives),
+			InputDigest:        entry.Fingerprint,
+			Package:            packageRef,
+			Kind:               lockEntryKind(entry, kind),
+			Runtime:            lockEntryRuntime(entry, kind),
+			Source:             source,
+			Version:            entry.Version,
+			Archives:           maps.Clone(entry.Archives),
+			Manifest:           entry.StaticManifest,
+			CatalogAvailable:   entry.StaticCatalogAvailable,
+			CatalogFingerprint: entry.StaticCatalogFingerprint,
+			CatalogOperations:  slices.Clone(entry.StaticCatalogOperations),
+			CatalogSessionOnly: entry.StaticCatalogSessionOnly,
 		}
 	}
 	return portable
@@ -270,19 +282,25 @@ func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[st
 		return make(map[string]LockEntry)
 	}
 	runtimeEntries := make(map[string]LockEntry, len(entries))
-	for name, entry := range entries {
+	for name := range entries {
+		entry := entries[name]
 		source := entry.Source
 		if source == "" {
 			source = entry.Package
 		}
 		runtimeEntries[name] = LockEntry{
-			Fingerprint: entry.InputDigest,
-			Package:     entry.Package,
-			Kind:        providermanifestv1.NormalizeKind(entry.Kind),
-			Runtime:     entry.Runtime,
-			Source:      source,
-			Version:     entry.Version,
-			Archives:    maps.Clone(entry.Archives),
+			Fingerprint:              entry.InputDigest,
+			Package:                  entry.Package,
+			Kind:                     providermanifestv1.NormalizeKind(entry.Kind),
+			Runtime:                  entry.Runtime,
+			Source:                   source,
+			Version:                  entry.Version,
+			Archives:                 maps.Clone(entry.Archives),
+			StaticManifest:           entry.Manifest,
+			StaticCatalogAvailable:   entry.CatalogAvailable,
+			StaticCatalogFingerprint: entry.CatalogFingerprint,
+			StaticCatalogOperations:  slices.Clone(entry.CatalogOperations),
+			StaticCatalogSessionOnly: entry.CatalogSessionOnly,
 		}
 	}
 	return runtimeEntries

--- a/gestaltd/services/plugins/validation.go
+++ b/gestaltd/services/plugins/validation.go
@@ -17,6 +17,12 @@ type resolvedDependencyCatalog struct {
 	err         error
 }
 
+type EffectiveCatalogResult struct {
+	Catalog     *catalog.Catalog
+	Available   bool
+	SessionOnly bool
+}
+
 type catalogResolutionCache struct {
 	entries map[string]resolvedDependencyCatalog
 }
@@ -47,8 +53,12 @@ func ValidateEffectiveCatalog(ctx context.Context, name string, entry *Validatio
 	if entry == nil {
 		return nil
 	}
-	_, _, err := resolveStaticCatalog(ctx, name, entry)
+	_, _, err := EffectiveCatalog(ctx, name, entry)
 	return err
+}
+
+func EffectiveCatalog(ctx context.Context, name string, entry *ValidationPlugin) (*catalog.Catalog, bool, error) {
+	return resolveStaticCatalog(ctx, name, entry)
 }
 
 func ValidateEffectiveCatalogs(ctx context.Context, cfg *ValidationConfig) error {
@@ -59,14 +69,30 @@ func ValidateEffectiveCatalogs(ctx context.Context, cfg *ValidationConfig) error
 }
 
 func ValidateEffectiveCatalogsAndDependencies(ctx context.Context, cfg *ValidationConfig) error {
+	_, err := EffectiveCatalogsAndDependencies(ctx, cfg)
+	return err
+}
+
+func EffectiveCatalogsAndDependencies(ctx context.Context, cfg *ValidationConfig) (map[string]EffectiveCatalogResult, error) {
 	if cfg == nil {
-		return nil
+		return nil, nil
 	}
 	cache := newCatalogResolutionCache(len(cfg.Plugins))
 	if err := validateEffectiveCatalogs(ctx, cfg, cache); err != nil {
-		return err
+		return nil, err
 	}
-	return validateDependencies(ctx, cfg, cache)
+	if err := validateDependencies(ctx, cfg, cache); err != nil {
+		return nil, err
+	}
+	results := make(map[string]EffectiveCatalogResult, len(cache.entries))
+	for name, resolved := range cache.entries {
+		results[name] = EffectiveCatalogResult{
+			Catalog:     resolved.catalog.Clone(),
+			Available:   resolved.catalog != nil,
+			SessionOnly: resolved.sessionOnly,
+		}
+	}
+	return results, nil
 }
 
 func validateEffectiveCatalogs(ctx context.Context, cfg *ValidationConfig, cache *catalogResolutionCache) error {
@@ -108,6 +134,9 @@ func validateDependencies(ctx context.Context, cfg *ValidationConfig, cache *cat
 			targetEntry, ok := cfg.Plugins[dependency.Plugin]
 			if !ok || targetEntry == nil {
 				return fmt.Errorf("config validation: plugins.%s.invokes[%d] references unknown plugin %q", callerName, i, dependency.Plugin)
+			}
+			if targetEntry.StaticMetadataUnavailable {
+				continue
 			}
 			if dependency.Surface != "" {
 				if !pluginSupportsSurface(targetEntry, dependency.Surface) {
@@ -162,6 +191,9 @@ func pluginSupportsSurface(entry *ValidationPlugin, surface SpecSurface) bool {
 }
 
 func resolveStaticCatalog(ctx context.Context, name string, entry *ValidationPlugin) (*catalog.Catalog, bool, error) {
+	if entry != nil && (entry.EffectiveCatalogAvailable || entry.EffectiveCatalog != nil || entry.EffectiveCatalogSessionOnly) {
+		return entry.EffectiveCatalog.Clone(), entry.EffectiveCatalogSessionOnly, nil
+	}
 	manifest := entry.Manifest
 	spec := entry.manifestSpec()
 	if manifest == nil || spec == nil {

--- a/gestaltd/services/plugins/validation_types.go
+++ b/gestaltd/services/plugins/validation_types.go
@@ -38,13 +38,17 @@ type ValidationConfig struct {
 }
 
 type ValidationPlugin struct {
-	Manifest            *providermanifestv1.Manifest
-	ManifestPath        string
-	AllowedOperations   map[string]*OperationOverride
-	Invokes             []InvocationDependency
-	SurfaceURLOverrides map[SpecSurface]string
-	ReadStaticCatalog   StaticCatalogReader
-	LoadAPICatalog      APICatalogLoader
+	Manifest                    *providermanifestv1.Manifest
+	ManifestPath                string
+	AllowedOperations           map[string]*OperationOverride
+	Invokes                     []InvocationDependency
+	SurfaceURLOverrides         map[SpecSurface]string
+	EffectiveCatalog            *catalog.Catalog
+	EffectiveCatalogAvailable   bool
+	EffectiveCatalogSessionOnly bool
+	StaticMetadataUnavailable   bool
+	ReadStaticCatalog           StaticCatalogReader
+	LoadAPICatalog              APICatalogLoader
 }
 
 func (p *ValidationPlugin) manifestSpec() *providermanifestv1.Spec {


### PR DESCRIPTION
## Summary

Adds a static `gestaltd validate` path that validates layered config and source-backed provider metadata without starting configured providers or resolving runtime-only env/secret values. Runtime validation remains available through `--runtime` and `provider validate` keeps using the runtime path.

Lockfiles now write schema v6 with static manifest metadata and compact effective catalog operation IDs so future static validation can avoid archive downloads. Schema v5 lockfiles remain readable; if a legacy private archive cannot be fetched, static validation falls back to metadata-limited checks instead of failing local validation purely because private release assets are inaccessible.

## Interface Changes

- New/changed interface: `gestaltd validate [--config PATH]... [--lockfile PATH] [--platform os/arch] [--runtime]`
- Example usage:

```sh
gestaltd validate --platform linux/amd64 \
  --config valon-tools/deploy/config.yaml \
  --config valon-tools/deploy/prod/config.yaml \
  --lockfile valon-tools/deploy/gestalt.lock.json
```

```sh
gestaltd validate --runtime --config config.yaml
```

## Functional/Integration Tests

- Tests added or augmented:
  - `TestE2EValidateStaticAcceptsMissingRuntimeEnvPlaceholder`
  - `TestE2EValidatePlatformUsesLockedStaticMetadataWithoutArchiveDownload`
  - `TestE2EValidateStaticRejectsStaleCatalogExposureMetadata`
  - `TestE2EValidateStaticPlatformRejectsExplicitMissingLockfile`
  - `TestE2EValidateStaticLegacyLockAllowsUnavailablePolicyBoundUIMetadata`
  - `TestE2EValidateStaticLegacyLockAllowsUnavailableInvokesTargetCatalog`
- Contract boundary covered:
  - CLI `gestaltd validate` static/runtime behavior
  - lockfile v5 compatibility and v6 static metadata
  - stale static catalog exposure metadata rejection
  - cross-platform static validation without host-platform archive inspection
  - explicit remote lockfile requirement when static lock metadata is required
  - legacy private archive fallback for metadata unavailable from v5 locks
- Commands run:

```sh
golangci-lint run ./...
go test ./internal/daemon -run 'TestE2EValidateStaticRejectsStaleCatalogExposureMetadata|TestE2EValidateStaticPlatformRejectsExplicitMissingLockfile|TestE2EValidatePlatformUsesLockedStaticMetadataWithoutArchiveDownload|TestE2EValidateStaticLegacyLockAllowsUnavailableInvokesTargetCatalog'
go test ./internal/daemon -run 'TestE2EValidateUsesScratchPreparedInstallsForLocalSourceConfigs|TestE2EValidateStaticPlatformRejectsExplicitMissingLockfile|TestE2EValidateStaticRejectsStaleCatalogExposureMetadata'
go test ./internal/operator -run 'TestLoadForExecutionAtPath_CachesInvokesTargetCatalogResolution|TestPrepareAtPath_RejectsPolicyBoundManagedMountedUIWithoutExplicitRouteCoverage'
go test ./internal/operator ./services/plugins ./internal/config
go test ./internal/daemon ./internal/operator ./internal/config ./services/plugins
go build -o /tmp/gestaltd-static-validate ./cmd/gestaltd
/tmp/gestaltd-static-validate validate --platform linux/amd64 --config valon-tools/deploy/config.yaml --config valon-tools/deploy/prod/config.yaml --config valon-tools/deploy/brain/prod.config.yaml --config valon-tools/deploy/cloud-run/config.yaml --lockfile valon-tools/deploy/gestalt.lock.json
/tmp/gestaltd-static-validate validate --platform linux/amd64 --config valon-tools/deploy/config.yaml --config valon-tools/deploy/prod/config.yaml --config valon-tools/deploy/brain/prod.config.yaml --config valon-tools/deploy/gke-sandbox/config.yaml --lockfile valon-tools/deploy/gke-sandbox/gestalt.lock.json
```
