### PR TITLE
Bump gestalt CLI to v0.0.1-alpha.13

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.1-alpha.12"
+version = "0.0.1-alpha.13"
 edition = "2024"


### PR DESCRIPTION
## Summary

- Bump the `gestalt` CLI workspace package version to `0.0.1-alpha.13` so the tag-driven release workflow can publish `gestalt/v0.0.1-alpha.13`.

## Verification

- `cargo metadata --manifest-path gestalt/Cargo.toml --format-version 1 --no-deps` reports `gestalt` version `0.0.1-alpha.13`
- `cargo test --manifest-path gestalt/Cargo.toml --workspace -- --test-threads=1`
- `cargo fmt --manifest-path gestalt/Cargo.toml --check`
- `git diff --check`

After this merges, I will tag the merge commit as `gestalt/v0.0.1-alpha.13` to trigger the CLI release workflow.
