### PR TITLE
Compact agent run grant permissions

### DIFF
--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -2303,10 +2303,107 @@ func agentRunPermissions(ctx context.Context, p *principal.Principal, callerPlug
 	if p == nil {
 		return nil
 	}
+	if permissions, ok := compactAgentRunPermissionsForRefs(p, refs); ok {
+		return permissions
+	}
 	if shouldUseResolvedUserToolScope(ctx, p, callerPluginName, refs) {
 		return nil
 	}
 	return principal.PermissionsToAccessPermissions(p.TokenPermissions)
+}
+
+func compactAgentRunPermissionsForRefs(p *principal.Principal, refs []coreagent.ToolRef) ([]core.AccessPermission, bool) {
+	if len(refs) == 0 {
+		return nil, false
+	}
+	operationsByPlugin := map[string]map[string]struct{}{}
+	providerWide := map[string]struct{}{}
+	for i := range refs {
+		ref := refs[i]
+		if strings.TrimSpace(ref.System) != "" {
+			continue
+		}
+		plugin := strings.TrimSpace(ref.Plugin)
+		if plugin == "" || plugin == agentToolSearchAllPlugin || strings.Contains(plugin, "*") {
+			return nil, false
+		}
+		operation := strings.TrimSpace(ref.Operation)
+		if strings.Contains(operation, "*") {
+			return nil, false
+		}
+		if operation == "" {
+			providerWide[plugin] = struct{}{}
+			delete(operationsByPlugin, plugin)
+			continue
+		}
+		if p != nil && p.TokenPermissions != nil {
+			tokenOps, ok := p.TokenPermissions[plugin]
+			if !ok {
+				return nil, false
+			}
+			if len(tokenOps) > 0 {
+				if _, ok := tokenOps[operation]; !ok {
+					return nil, false
+				}
+			}
+		}
+		if _, ok := providerWide[plugin]; ok {
+			continue
+		}
+		ops := operationsByPlugin[plugin]
+		if ops == nil {
+			ops = map[string]struct{}{}
+			operationsByPlugin[plugin] = ops
+		}
+		ops[operation] = struct{}{}
+	}
+	if len(providerWide) == 0 && len(operationsByPlugin) == 0 {
+		return nil, false
+	}
+	plugins := make([]string, 0, len(providerWide)+len(operationsByPlugin))
+	for plugin := range providerWide {
+		plugins = append(plugins, plugin)
+	}
+	for plugin := range operationsByPlugin {
+		if _, ok := providerWide[plugin]; !ok {
+			plugins = append(plugins, plugin)
+		}
+	}
+	sort.Strings(plugins)
+	out := make([]core.AccessPermission, 0, len(plugins))
+	for _, plugin := range plugins {
+		if _, ok := providerWide[plugin]; ok {
+			if p != nil && p.TokenPermissions != nil {
+				tokenOps, ok := p.TokenPermissions[plugin]
+				if !ok {
+					return nil, false
+				}
+				perm := core.AccessPermission{Plugin: plugin}
+				if len(tokenOps) > 0 {
+					ops := make([]string, 0, len(tokenOps))
+					for operation := range tokenOps {
+						ops = append(ops, operation)
+					}
+					sort.Strings(ops)
+					perm.Operations = ops
+				}
+				out = append(out, perm)
+				continue
+			}
+			out = append(out, core.AccessPermission{Plugin: plugin})
+			continue
+		}
+		ops := make([]string, 0, len(operationsByPlugin[plugin]))
+		for operation := range operationsByPlugin[plugin] {
+			ops = append(ops, operation)
+		}
+		sort.Strings(ops)
+		out = append(out, core.AccessPermission{
+			Plugin:     plugin,
+			Operations: ops,
+		})
+	}
+	return out, true
 }
 
 func shouldUseResolvedUserToolScope(ctx context.Context, p *principal.Principal, callerPluginName string, refs []coreagent.ToolRef) bool {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -808,6 +809,66 @@ func TestAgentRunPermissionsKeepsAPITokenRestrictionsForHTTPWildcard(t *testing.
 	got := agentRunPermissions(ctx, p, "slack", []coreagent.ToolRef{{Plugin: "*"}})
 	if len(got) != 1 || got[0].Plugin != "linear" || len(got[0].Operations) != 1 || got[0].Operations[0] != "issues" {
 		t.Fatalf("agentRunPermissions = %#v, want API token permissions preserved", got)
+	}
+}
+
+func TestAgentRunPermissionsCompactsExplicitCatalogRefs(t *testing.T) {
+	t.Parallel()
+
+	perms := principal.CompilePermissions([]core.AccessPermission{
+		{Plugin: "linear", Operations: []string{"viewer", "issues.list", "issues.create"}},
+		{Plugin: "slack"},
+		{Plugin: "github"},
+	})
+	p := &principal.Principal{
+		SubjectID:        principal.UserSubjectID("user-1"),
+		UserID:           "user-1",
+		Kind:             principal.KindUser,
+		Source:           principal.SourceAPIToken,
+		TokenPermissions: perms,
+		Scopes:           principal.PermissionPlugins(perms),
+	}
+	ctx := invocation.WithInvocationSurface(context.Background(), invocation.InvocationSurfaceHTTP)
+
+	got := agentRunPermissions(ctx, p, "", []coreagent.ToolRef{
+		{Plugin: "slack", Operation: "chat.postMessage"},
+		{Plugin: "linear", Operation: "viewer"},
+		{Plugin: "slack", Operation: "chat.postMessage"},
+		{System: coreagent.SystemToolWorkflow, Operation: "run"},
+	})
+	want := []core.AccessPermission{
+		{Plugin: "linear", Operations: []string{"viewer"}},
+		{Plugin: "slack", Operations: []string{"chat.postMessage"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("agentRunPermissions = %#v, want %#v", got, want)
+	}
+}
+
+func TestAgentRunPermissionsCompactsProviderWideCatalogRef(t *testing.T) {
+	t.Parallel()
+
+	perms := principal.CompilePermissions([]core.AccessPermission{
+		{Plugin: "linear", Operations: []string{"viewer"}},
+		{Plugin: "slack"},
+	})
+	p := &principal.Principal{
+		SubjectID:        principal.UserSubjectID("user-1"),
+		UserID:           "user-1",
+		Kind:             principal.KindUser,
+		Source:           principal.SourceAPIToken,
+		TokenPermissions: perms,
+		Scopes:           principal.PermissionPlugins(perms),
+	}
+	ctx := invocation.WithInvocationSurface(context.Background(), invocation.InvocationSurfaceHTTP)
+
+	got := agentRunPermissions(ctx, p, "", []coreagent.ToolRef{
+		{Plugin: "linear", Operation: "viewer"},
+		{Plugin: "linear"},
+	})
+	want := []core.AccessPermission{{Plugin: "linear", Operations: []string{"viewer"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("agentRunPermissions = %#v, want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- compact agent run grant permissions for exact MCP catalog tool refs before minting the provider run grant
- preserve API-token operation restrictions for provider-wide tool refs and keep wildcard refs on the existing path
- add manager tests covering exact ref compaction and provider-wide API-token restriction preservation

## Why
Hermes MCP catalog smoke hit an AgentHost HTTP/2 frame error while listing tools. The provider was sending a run grant that embedded the caller's full API-token permission set even though the turn requested a single explicit tool. Keeping the run grant scoped to the requested tool refs avoids oversized grants without broadening API-token permissions.

## Tests
- go test ./services/agents/agentmanager ./internal/bootstrap