### PR TITLE
Compact exact agent run grants after authorization

### DIFF
--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -2336,17 +2336,6 @@ func compactAgentRunPermissionsForRefs(p *principal.Principal, refs []coreagent.
 			delete(operationsByPlugin, plugin)
 			continue
 		}
-		if p != nil && p.TokenPermissions != nil {
-			tokenOps, ok := p.TokenPermissions[plugin]
-			if !ok {
-				return nil, false
-			}
-			if len(tokenOps) > 0 {
-				if _, ok := tokenOps[operation]; !ok {
-					return nil, false
-				}
-			}
-		}
 		if _, ok := providerWide[plugin]; ok {
 			continue
 		}

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -845,6 +845,30 @@ func TestAgentRunPermissionsCompactsExplicitCatalogRefs(t *testing.T) {
 	}
 }
 
+func TestAgentRunPermissionsCompactsExactRefsAfterAuthorization(t *testing.T) {
+	t.Parallel()
+
+	perms := principal.CompilePermissions([]core.AccessPermission{
+		{Plugin: "linear", Operations: []string{"mcp.call"}},
+		{Plugin: "slack"},
+	})
+	p := &principal.Principal{
+		SubjectID:        principal.UserSubjectID("user-1"),
+		UserID:           "user-1",
+		Kind:             principal.KindUser,
+		Source:           principal.SourceAPIToken,
+		TokenPermissions: perms,
+		Scopes:           principal.PermissionPlugins(perms),
+	}
+	ctx := invocation.WithInvocationSurface(context.Background(), invocation.InvocationSurfaceHTTP)
+
+	got := agentRunPermissions(ctx, p, "", []coreagent.ToolRef{{Plugin: "linear", Operation: "viewer"}})
+	want := []core.AccessPermission{{Plugin: "linear", Operations: []string{"viewer"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("agentRunPermissions = %#v, want %#v", got, want)
+	}
+}
+
 func TestAgentRunPermissionsCompactsProviderWideCatalogRef(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- keep exact MCP catalog tool refs compact even when API-token permissions use a different resolved operation shape
- continue preserving API-token restrictions for provider-wide refs
- add a regression test for exact MCP refs that have already passed authorization

## Why
Hermes MCP smoke still hit AgentHost HTTP/2 frame errors because exact MCP passthrough refs could fall back to embedding the full API-token permission set in the run grant. Exact refs are already authorized before the grant is minted, so the run grant can safely carry the exact ref scope.

## Tests
- go test ./services/agents/agentmanager ./internal/bootstrap