### PR TITLE
Enable TLS for Rust AgentHost relay clients

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -24,7 +24,7 @@ serde_yaml = "0.9"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.14", features = ["transport"] }
+tonic = { version = "0.14", features = ["transport", "tls-native-roots", "tls-ring"] }
 tonic-prost = "0.14"
 tower = "0.5"
 hyper-util = "0.1"


### PR DESCRIPTION
## Summary\n- enable tonic TLS/native root support for the Rust SDK transport\n- allows Rust AgentHost clients to use tls:// public relay targets correctly\n\n## Test\n- cargo test (sdk/rust)