### PR TITLE
Use native roots for Rust SDK TLS relays

### DIFF
--- a/sdk/rust/src/agent.rs
+++ b/sdk/rust/src/agent.rs
@@ -6,7 +6,7 @@ use tonic::codegen::async_trait;
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Channel, Endpoint, Uri};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 use tower::service_fn;
 
@@ -58,6 +58,7 @@ impl AgentHost {
             }
             AgentHostTarget::Tls(address) => {
                 Endpoint::from_shared(format!("https://{address}"))?
+                    .tls_config(ClientTlsConfig::new().with_native_roots())?
                     .connect()
                     .await?
             }

--- a/sdk/rust/src/agent_manager.rs
+++ b/sdk/rust/src/agent_manager.rs
@@ -4,7 +4,7 @@ use tonic::Request;
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Channel, Endpoint, Uri};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tower::service_fn;
 
 use crate::generated::v1::{
@@ -72,6 +72,7 @@ impl AgentManager {
             }
             AgentManagerTarget::Tls(address) => {
                 Endpoint::from_shared(format!("https://{address}"))?
+                    .tls_config(ClientTlsConfig::new().with_native_roots())?
                     .connect()
                     .await?
             }

--- a/sdk/rust/src/cache.rs
+++ b/sdk/rust/src/cache.rs
@@ -8,7 +8,7 @@ use tonic::codegen::async_trait;
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Channel, Endpoint, Uri};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tower::service_fn;
 
 use crate::api::RuntimeMetadata;
@@ -177,6 +177,7 @@ impl Cache {
             }
             CacheTarget::Tls(address) => {
                 Endpoint::from_shared(format!("https://{address}"))?
+                    .tls_config(ClientTlsConfig::new().with_native_roots())?
                     .connect()
                     .await?
             }

--- a/sdk/rust/src/indexeddb.rs
+++ b/sdk/rust/src/indexeddb.rs
@@ -7,7 +7,7 @@ use tonic::Request;
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Channel, Endpoint, Uri};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tower::service_fn;
 
 use crate::generated::v1::{self as pb, indexed_db_client::IndexedDbClient};
@@ -423,6 +423,7 @@ impl IndexedDB {
             }
             IndexedDBTarget::Tls(address) => {
                 Endpoint::from_shared(format!("https://{address}"))?
+                    .tls_config(ClientTlsConfig::new().with_native_roots())?
                     .connect()
                     .await?
             }

--- a/sdk/rust/src/invoker.rs
+++ b/sdk/rust/src/invoker.rs
@@ -7,7 +7,7 @@ use tonic::Request;
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Channel, Endpoint, Uri};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tower::service_fn;
 
 use crate::OperationResult;
@@ -107,6 +107,7 @@ impl PluginInvoker {
             }
             PluginInvokerTarget::Tls(address) => {
                 Endpoint::from_shared(format!("https://{address}"))?
+                    .tls_config(ClientTlsConfig::new().with_native_roots())?
                     .connect()
                     .await?
             }

--- a/sdk/rust/src/runtime_log_host.rs
+++ b/sdk/rust/src/runtime_log_host.rs
@@ -6,7 +6,7 @@ use tonic::Request;
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Channel, Endpoint, Uri};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tower::service_fn;
 
 use crate::generated::v1::{
@@ -70,6 +70,7 @@ impl RuntimeLogHost {
             }
             RuntimeLogHostTarget::Tls(address) => {
                 Endpoint::from_shared(format!("https://{address}"))?
+                    .tls_config(ClientTlsConfig::new().with_native_roots())?
                     .connect()
                     .await?
             }

--- a/sdk/rust/src/s3.rs
+++ b/sdk/rust/src/s3.rs
@@ -9,7 +9,7 @@ use tonic::codegen::async_trait;
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Channel, Endpoint, Uri};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tower::service_fn;
 
 use crate::api::RuntimeMetadata;
@@ -360,6 +360,7 @@ impl S3 {
             }
             S3Target::Tls(address) => {
                 Endpoint::from_shared(format!("https://{address}"))?
+                    .tls_config(ClientTlsConfig::new().with_native_roots())?
                     .connect()
                     .await?
             }

--- a/sdk/rust/src/workflow_manager.rs
+++ b/sdk/rust/src/workflow_manager.rs
@@ -4,7 +4,7 @@ use tonic::Request;
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Channel, Endpoint, Uri};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tower::service_fn;
 
 use crate::generated::v1::{
@@ -82,6 +82,7 @@ impl WorkflowManager {
             }
             WorkflowManagerTarget::Tls(address) => {
                 Endpoint::from_shared(format!("https://{address}"))?
+                    .tls_config(ClientTlsConfig::new().with_native_roots())?
                     .connect()
                     .await?
             }


### PR DESCRIPTION
## Summary
- Configure Rust SDK `tls://` host-service clients with Tonic `ClientTlsConfig::with_native_roots()`.
- Applies consistently across AgentHost, AgentManager, PluginInvoker, RuntimeLogHost, Cache, IndexedDB, S3, and WorkflowManager relay clients.

## Why
Hermes alpha6 proved the Rust SDK was compiled with TLS support, but AgentHost relay connection still failed in the hosted runtime with a Tonic transport error before any relay request reached Cloud Run. The SDK needs to install native root certificates when building HTTPS endpoints for public relay targets.

## Verification
- `cargo fmt && cargo test` in `sdk/rust`.