### PR TITLE
Surface unavailable MCP catalog tools to agents

### DIFF
--- a/gestaltd/core/agent/agent.go
+++ b/gestaltd/core/agent/agent.go
@@ -104,7 +104,21 @@ type ToolTarget struct {
 	Connection     string
 	Instance       string
 	CredentialMode core.ConnectionMode
+	Unavailable    *UnavailableToolTarget `json:",omitempty"`
 }
+
+type UnavailableToolTarget struct {
+	Reason  string
+	Message string
+}
+
+const (
+	ToolUnavailableReasonReconnectRequired = "reconnect_required"
+	ToolUnavailableReasonNotAuthenticated  = "not_authenticated"
+	ToolUnavailableReasonNoCredential      = "no_credential"
+	ToolUnavailableReasonScopeDenied       = "scope_denied"
+	ToolUnavailableReasonInstanceRequired  = "instance_required"
+)
 
 type Tool struct {
 	ID               string

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -274,6 +275,12 @@ func (r *agentRuntime) ExecuteTool(ctx context.Context, req coreagent.ExecuteToo
 	principalValue := agentRunGrantPrincipal(grant)
 	if principalValue == nil || strings.TrimSpace(principalValue.SubjectID) == "" {
 		return nil, fmt.Errorf("%w: agent execution principal is required", invocation.ErrInternal)
+	}
+	if toolTarget.Unavailable != nil {
+		if err := validateUnavailableAgentToolTargetForGrant(grant, principalValue, toolTarget, req.ToolID); err != nil {
+			return nil, err
+		}
+		return executeUnavailableAgentTool(toolTarget)
 	}
 	if searcher == nil {
 		return nil, fmt.Errorf("%w: agent tool resolver is not configured", invocation.ErrInternal)
@@ -604,6 +611,115 @@ func validateAgentToolTargetForGrant(grant agentgrant.Grant, principalValue *pri
 	return nil
 }
 
+func validateUnavailableAgentToolTargetForGrant(grant agentgrant.Grant, principalValue *principal.Principal, target coreagent.ToolTarget, rawToolID string) error {
+	if err := validateAgentRunGrantForToolTarget(grant, target, rawToolID); err != nil {
+		return err
+	}
+	return validateUnavailableAgentToolTarget(principalValue, grant.ToolRefs, target, rawToolID)
+}
+
+func validateAgentRunGrantForToolTarget(grant agentgrant.Grant, target coreagent.ToolTarget, rawToolID string) error {
+	source := normalizeAgentToolSource(grant.ToolSource)
+	if source != coreagent.ToolSourceModeMCPCatalog {
+		return fmt.Errorf("%w: unsupported agent tool source %q", invocation.ErrInternal, grant.ToolSource)
+	}
+	if err := validateAgentMCPCatalogToolRefs(grant.ToolRefs); err != nil {
+		return fmt.Errorf("%w: %v", invocation.ErrAuthorizationDenied, err)
+	}
+	if len(grant.ToolRefs) == 0 || !agentToolMatchesRefs(target, grant.ToolRefs) {
+		return fmt.Errorf("%w: agent tool %q is outside the turn tool scope", invocation.ErrAuthorizationDenied, rawToolID)
+	}
+	if target.CredentialMode != "" && !agentToolCredentialModeExplicitlyGranted(target, grant.ToolRefs, grant.Tools) {
+		return fmt.Errorf("%w: agent tool %q credential mode was not granted to this turn", invocation.ErrAuthorizationDenied, rawToolID)
+	}
+	return nil
+}
+
+func validateListedUnavailableAgentToolTarget(p *principal.Principal, refs []coreagent.ToolRef, target coreagent.ToolTarget, rawToolID string) error {
+	if len(refs) == 0 || !agentToolMatchesRefs(target, refs) {
+		return fmt.Errorf("%w: listed agent tool %q is outside the turn tool scope", invocation.ErrAuthorizationDenied, rawToolID)
+	}
+	return validateUnavailableAgentToolTarget(p, refs, target, rawToolID)
+}
+
+func validateUnavailableAgentToolTarget(principalValue *principal.Principal, refs []coreagent.ToolRef, target coreagent.ToolTarget, rawToolID string) error {
+	if principalValue == nil {
+		return fmt.Errorf("%w: agent execution principal is required", invocation.ErrInternal)
+	}
+	if target.Unavailable == nil || strings.TrimSpace(target.Unavailable.Reason) == "" {
+		return fmt.Errorf("%w: unavailable agent tool %q is incomplete", invocation.ErrAuthorizationDenied, rawToolID)
+	}
+	if strings.TrimSpace(target.System) != "" || strings.TrimSpace(target.Operation) != "" {
+		return fmt.Errorf("%w: unavailable agent tool %q cannot target a concrete operation", invocation.ErrAuthorizationDenied, rawToolID)
+	}
+	pluginName := strings.TrimSpace(target.Plugin)
+	if pluginName == "" {
+		return fmt.Errorf("%w: unavailable agent tool %q plugin is required", invocation.ErrAuthorizationDenied, rawToolID)
+	}
+	if !principal.AllowsProviderPermission(principalValue, pluginName) {
+		return fmt.Errorf("%w: unavailable agent tool %q is not authorized", invocation.ErrAuthorizationDenied, rawToolID)
+	}
+	if !agentUnavailableReasonAllowed(strings.TrimSpace(target.Unavailable.Reason)) {
+		return fmt.Errorf("%w: unavailable agent tool %q reason is invalid", invocation.ErrAuthorizationDenied, rawToolID)
+	}
+	if len(refs) > 0 && !agentToolMatchesRefs(target, refs) {
+		return fmt.Errorf("%w: unavailable agent tool %q is outside the turn tool scope", invocation.ErrAuthorizationDenied, rawToolID)
+	}
+	return nil
+}
+
+func agentUnavailableReasonAllowed(reason string) bool {
+	switch reason {
+	case coreagent.ToolUnavailableReasonReconnectRequired,
+		coreagent.ToolUnavailableReasonNotAuthenticated,
+		coreagent.ToolUnavailableReasonNoCredential,
+		coreagent.ToolUnavailableReasonScopeDenied,
+		coreagent.ToolUnavailableReasonInstanceRequired:
+		return true
+	default:
+		return false
+	}
+}
+
+func executeUnavailableAgentTool(target coreagent.ToolTarget) (*coreagent.ExecuteToolResponse, error) {
+	reason := coreagent.ToolUnavailableReasonReconnectRequired
+	message := ""
+	if target.Unavailable != nil {
+		if strings.TrimSpace(target.Unavailable.Reason) != "" {
+			reason = strings.TrimSpace(target.Unavailable.Reason)
+		}
+		message = strings.TrimSpace(target.Unavailable.Message)
+	}
+	if message == "" {
+		message = "The requested integration is unavailable for this agent turn."
+	}
+	status := http.StatusFailedDependency
+	switch reason {
+	case coreagent.ToolUnavailableReasonScopeDenied:
+		status = http.StatusForbidden
+	case coreagent.ToolUnavailableReasonInstanceRequired:
+		status = http.StatusPreconditionRequired
+	case coreagent.ToolUnavailableReasonNotAuthenticated, coreagent.ToolUnavailableReasonNoCredential:
+		status = http.StatusUnauthorized
+	}
+	body, err := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"code":       reason,
+			"message":    message,
+			"plugin":     strings.TrimSpace(target.Plugin),
+			"connection": strings.TrimSpace(target.Connection),
+			"instance":   strings.TrimSpace(target.Instance),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: encode unavailable agent tool response: %v", invocation.ErrInternal, err)
+	}
+	return &coreagent.ExecuteToolResponse{
+		Status: status,
+		Body:   string(body),
+	}, nil
+}
+
 func normalizeAgentToolSource(source coreagent.ToolSourceMode) coreagent.ToolSourceMode {
 	if strings.TrimSpace(string(source)) == "" {
 		return coreagent.ToolSourceModeMCPCatalog
@@ -627,6 +743,12 @@ func validateAgentListedTools(p *principal.Principal, refs []coreagent.ToolRef, 
 			return fmt.Errorf("%w: listed agent tool mcp_name is required", invocation.ErrAuthorizationDenied)
 		}
 		target := tools[i].Target
+		if target.Unavailable != nil {
+			if err := validateListedUnavailableAgentToolTarget(p, refs, target, tools[i].ToolID); err != nil {
+				return err
+			}
+			continue
+		}
 		if systemName := strings.TrimSpace(target.System); systemName != "" {
 			if systemName != coreagent.SystemToolWorkflow || strings.TrimSpace(target.Operation) == "" {
 				return fmt.Errorf("%w: listed agent system tool target is incomplete", invocation.ErrAuthorizationDenied)

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -106,6 +106,26 @@ func (i *recordingAgentRuntimeInvoker) Calls() []agentRuntimeInvokerCall {
 	return out
 }
 
+type reconnectingAgentRuntimeInvoker struct {
+	recordingAgentRuntimeInvoker
+	tokenErrs map[string]error
+}
+
+func (i *reconnectingAgentRuntimeInvoker) ResolveToken(ctx context.Context, _ *principal.Principal, providerName, _, _ string) (context.Context, string, error) {
+	if err := i.tokenErrs[strings.TrimSpace(providerName)]; err != nil {
+		return ctx, "", err
+	}
+	return ctx, "token", nil
+}
+
+type failingSessionCatalogIntegration struct {
+	coretesting.StubIntegration
+}
+
+func (p *failingSessionCatalogIntegration) CatalogForRequest(context.Context, string) (*catalog.Catalog, error) {
+	return p.CatalogVal, nil
+}
+
 func cloneAnyMap(src map[string]any) map[string]any {
 	if src == nil {
 		return nil
@@ -2397,6 +2417,171 @@ func TestAgentRuntimeListsMCPCatalogToolsForGrantedTurn(t *testing.T) {
 	}
 	if broadExecResp == nil || broadExecResp.Status != http.StatusAccepted || broadExecResp.Body != `{"taskId":"task-123"}` {
 		t.Fatalf("ExecuteTool broad response = %#v, want accepted task body", broadExecResp)
+	}
+}
+
+func TestAgentRuntimeListsUnavailableMCPCatalogSentinelForBroadGrants(t *testing.T) {
+	t.Parallel()
+
+	invoker := &reconnectingAgentRuntimeInvoker{
+		tokenErrs: map[string]error{
+			"linear": fmt.Errorf("%w: token expired and refresh failed", invocation.ErrReconnectRequired),
+		},
+	}
+	runGrants := newTestAgentRunGrants(t)
+	githubProvider := &coretesting.StubIntegration{
+		N:        "github",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+			ID:          "issues",
+			Title:       "List GitHub issues",
+			Description: "List issues assigned to the current user",
+		}}},
+	}
+	linearProvider := &failingSessionCatalogIntegration{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "linear",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:    "viewer",
+				Title: "Current Linear viewer",
+			}}},
+		},
+	}
+	manager := agentmanager.New(agentmanager.Config{
+		Providers: testutil.NewProviderRegistry(t, githubProvider, linearProvider),
+		RunGrants: runGrants,
+		Invoker:   invoker,
+	})
+	runtime := &agentRuntime{
+		providers: map[string]coreagent.Provider{
+			"claude": &routingAgentProvider{
+				getTurn: func(context.Context, coreagent.GetTurnRequest) (*coreagent.Turn, error) {
+					return &coreagent.Turn{
+						ID:        "turn-1",
+						SessionID: "session-1",
+						Status:    coreagent.ExecutionStatusRunning,
+						CreatedBy: coreagent.Actor{SubjectID: "user:user-123"},
+					}, nil
+				},
+			},
+		},
+	}
+	runtime.SetInvoker(invoker)
+	runtime.SetRunGrants(runGrants)
+	runtime.SetToolSearcher(manager)
+
+	broadGrant, err := runGrants.Mint(agentgrant.Grant{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		SubjectID:    "user:user-123",
+		SubjectKind:  string(principal.KindUser),
+		Permissions: []core.AccessPermission{
+			{Plugin: "github", Operations: []string{"issues"}},
+			{Plugin: "linear", Operations: []string{"viewer"}},
+		},
+		ToolRefs:   []coreagent.ToolRef{{Plugin: "*"}},
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+	})
+	if err != nil {
+		t.Fatalf("Mint broad grant: %v", err)
+	}
+	broadListResp, err := runtime.ListTools(context.Background(), coreagent.ListToolsRequest{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		PageSize:     10,
+		RunGrant:     broadGrant,
+	})
+	if err != nil {
+		t.Fatalf("ListTools with broad grant: %v", err)
+	}
+	if len(broadListResp.Tools) != 2 || broadListResp.NextPageToken != "" {
+		t.Fatalf("ListTools broad response = %#v, want GitHub tool plus Linear sentinel", broadListResp)
+	}
+	var linearSentinel coreagent.ListedTool
+	for _, listed := range broadListResp.Tools {
+		if listed.MCPName == "linear__reconnect_required" {
+			linearSentinel = listed
+		}
+	}
+	if linearSentinel.ToolID == "" || linearSentinel.Ref.Plugin != "linear" || linearSentinel.Ref.Operation != "" || linearSentinel.Target.Unavailable == nil {
+		t.Fatalf("Linear sentinel = %#v, want unavailable plugin-level tool", linearSentinel)
+	}
+
+	sentinelResp, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolID:       linearSentinel.ToolID,
+		RunGrant:     broadGrant,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTool sentinel: %v", err)
+	}
+	if sentinelResp == nil || sentinelResp.Status != http.StatusFailedDependency || !strings.Contains(sentinelResp.Body, `"code":"reconnect_required"`) {
+		t.Fatalf("ExecuteTool sentinel response = %#v, want reconnect error body", sentinelResp)
+	}
+	if calls := invoker.Calls(); len(calls) != 0 {
+		t.Fatalf("ExecuteTool sentinel invoked provider = %#v, want no provider invoke", calls)
+	}
+
+	pluginGrant, err := runGrants.Mint(agentgrant.Grant{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		SubjectID:    "user:user-123",
+		SubjectKind:  string(principal.KindUser),
+		Permissions: []core.AccessPermission{{
+			Plugin:     "linear",
+			Operations: []string{"viewer"},
+		}},
+		ToolRefs:   []coreagent.ToolRef{{Plugin: "linear"}},
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+	})
+	if err != nil {
+		t.Fatalf("Mint plugin grant: %v", err)
+	}
+	pluginListResp, err := runtime.ListTools(context.Background(), coreagent.ListToolsRequest{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		PageSize:     10,
+		RunGrant:     pluginGrant,
+	})
+	if err != nil {
+		t.Fatalf("ListTools plugin-level unavailable: %v", err)
+	}
+	if len(pluginListResp.Tools) != 1 || pluginListResp.Tools[0].MCPName != "linear__reconnect_required" {
+		t.Fatalf("ListTools plugin-level unavailable = %#v, want only Linear sentinel", pluginListResp)
+	}
+
+	exactGrant, err := runGrants.Mint(agentgrant.Grant{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		SubjectID:    "user:user-123",
+		SubjectKind:  string(principal.KindUser),
+		Permissions: []core.AccessPermission{{
+			Plugin:     "linear",
+			Operations: []string{"viewer"},
+		}},
+		ToolRefs:   []coreagent.ToolRef{{Plugin: "linear", Operation: "viewer"}},
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+	})
+	if err != nil {
+		t.Fatalf("Mint exact grant: %v", err)
+	}
+	_, err = runtime.ListTools(context.Background(), coreagent.ListToolsRequest{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		PageSize:     10,
+		RunGrant:     exactGrant,
+	})
+	if !errors.Is(err, invocation.ErrReconnectRequired) {
+		t.Fatalf("ListTools exact unavailable error = %v, want ErrReconnectRequired", err)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3229,7 +3229,7 @@ func TestBootstrapHTTPCallerWildcardCatalogToolRefsAreScopedByAuthorization(t *t
 	}
 }
 
-func TestBootstrapGlobalCatalogToolRefsSkipUnavailableProviders(t *testing.T) {
+func TestBootstrapGlobalCatalogToolRefsSurfaceUnavailableProviders(t *testing.T) {
 	t.Parallel()
 
 	cfg := validConfig()
@@ -3355,8 +3355,14 @@ func TestBootstrapGlobalCatalogToolRefsSkipUnavailableProviders(t *testing.T) {
 		t.Fatalf("list response count = %d, want 1", len(listResponses))
 	}
 	tools := listResponses[0].GetTools()
-	if len(tools) != 1 || tools[0].GetRef().GetPlugin() != "linear" || tools[0].GetRef().GetOperation() != "issues" {
-		t.Fatalf("listed tools = %#v, want only connected linear issues", tools)
+	if len(tools) != 2 {
+		t.Fatalf("listed tools = %#v, want connected linear issues plus ashby unavailable sentinel", tools)
+	}
+	if tools[0].GetRef().GetPlugin() != "linear" || tools[0].GetRef().GetOperation() != "issues" {
+		t.Fatalf("first listed tool = %#v, want connected linear issues before unavailable sentinels", tools[0])
+	}
+	if tools[1].GetRef().GetPlugin() != "ashby" || tools[1].GetRef().GetOperation() != "" || tools[1].GetMcpName() != "ashby__no_credential" {
+		t.Fatalf("second listed tool = %#v, want ashby unavailable sentinel", tools[1])
 	}
 	if len(toolBodies) != 1 || !strings.Contains(toolBodies[0], `"provider":"linear"`) || !strings.Contains(toolBodies[0], `"operation":"issues"`) {
 		t.Fatalf("tool callback bodies = %#v, want executed linear issues", toolBodies)

--- a/gestaltd/services/agents/agentgrant/seal.go
+++ b/gestaltd/services/agents/agentgrant/seal.go
@@ -37,8 +37,13 @@ func (m *Manager) MintToolID(target coreagent.ToolTarget) (string, error) {
 		Connection:     strings.TrimSpace(target.Connection),
 		Instance:       strings.TrimSpace(target.Instance),
 		CredentialMode: core.ConnectionMode(strings.TrimSpace(string(target.CredentialMode))),
+		Unavailable:    normalizeUnavailableToolTarget(target.Unavailable),
 	}
-	if target.Operation == "" || (target.Plugin == "" && target.System == "") || (target.Plugin != "" && target.System != "") {
+	if target.Unavailable != nil {
+		if target.Plugin == "" || target.System != "" || target.Operation != "" {
+			return "", fmt.Errorf("agent tool target is incomplete")
+		}
+	} else if target.Operation == "" || (target.Plugin == "" && target.System == "") || (target.Plugin != "" && target.System != "") {
 		return "", fmt.Errorf("agent tool target is incomplete")
 	}
 	sealed, err := m.sealValue(sealPurposeToolID, toolBinding{Target: target})
@@ -67,10 +72,29 @@ func (m *Manager) ResolveToolID(id string) (coreagent.ToolTarget, error) {
 	target.Connection = strings.TrimSpace(target.Connection)
 	target.Instance = strings.TrimSpace(target.Instance)
 	target.CredentialMode = core.ConnectionMode(strings.TrimSpace(string(target.CredentialMode)))
-	if target.Operation == "" || (target.Plugin == "" && target.System == "") || (target.Plugin != "" && target.System != "") {
+	target.Unavailable = normalizeUnavailableToolTarget(target.Unavailable)
+	if target.Unavailable != nil {
+		if target.Plugin == "" || target.System != "" || target.Operation != "" {
+			return coreagent.ToolTarget{}, fmt.Errorf("agent tool id is invalid")
+		}
+	} else if target.Operation == "" || (target.Plugin == "" && target.System == "") || (target.Plugin != "" && target.System != "") {
 		return coreagent.ToolTarget{}, fmt.Errorf("agent tool id is invalid")
 	}
 	return target, nil
+}
+
+func normalizeUnavailableToolTarget(value *coreagent.UnavailableToolTarget) *coreagent.UnavailableToolTarget {
+	if value == nil {
+		return nil
+	}
+	reason := strings.TrimSpace(value.Reason)
+	if reason == "" {
+		return nil
+	}
+	return &coreagent.UnavailableToolTarget{
+		Reason:  reason,
+		Message: strings.TrimSpace(value.Message),
+	}
 }
 
 func (m *Manager) sealValue(purpose string, value any) (string, error) {

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -371,7 +371,7 @@ func (m *Manager) ResolveTools(ctx context.Context, p *principal.Principal, req 
 	if err != nil {
 		return nil, err
 	}
-	candidates, err := m.searchToolCandidates(ctx, p, refs, "", false)
+	candidates, _, err := m.searchToolCandidates(ctx, p, refs, "", false)
 	if err != nil {
 		return nil, err
 	}
@@ -1210,11 +1210,10 @@ func (m *Manager) listTools(ctx context.Context, p *principal.Principal, req cor
 		out = append(out, listed)
 	}
 
-	candidates, err := m.searchToolCandidates(ctx, p, refs, "", true)
+	candidates, unavailable, err := m.searchToolCandidates(ctx, p, refs, "", true)
 	if err != nil {
 		return nil, err
 	}
-	var firstUnavailableErr error
 	for i := range candidates {
 		candidate := candidates[i]
 		listed, err := m.listedAgentPluginCandidateTool(candidate)
@@ -1223,9 +1222,6 @@ func (m *Manager) listTools(ctx context.Context, p *principal.Principal, req cor
 				continue
 			}
 			if candidate.skipUnavailable && agentToolSearchUnavailable(err) {
-				if firstUnavailableErr == nil {
-					firstUnavailableErr = err
-				}
 				continue
 			}
 			return nil, err
@@ -1237,11 +1233,23 @@ func (m *Manager) listTools(ctx context.Context, p *principal.Principal, req cor
 		seen[key] = struct{}{}
 		out = append(out, listed)
 	}
-	if len(out) == 0 && len(refs) > 0 && firstUnavailableErr != nil {
-		return nil, firstUnavailableErr
+	for i := range unavailable {
+		listed, err := m.listedUnavailableAgentPluginTool(unavailable[i])
+		if err != nil {
+			return nil, err
+		}
+		key := agentToolTargetKeyFromTarget(listed.Target)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, listed)
 	}
 
 	sort.SliceStable(out, func(i, j int) bool {
+		if leftUnavailable, rightUnavailable := listedAgentToolUnavailable(out[i]), listedAgentToolUnavailable(out[j]); leftUnavailable != rightUnavailable {
+			return !leftUnavailable
+		}
 		if out[i].MCPName != out[j].MCPName {
 			return out[i].MCPName < out[j].MCPName
 		}
@@ -1461,6 +1469,13 @@ type agentToolSearchCandidate struct {
 	score           float64
 }
 
+type agentToolUnavailableCandidate struct {
+	ref     coreagent.ToolRef
+	err     error
+	reason  string
+	message string
+}
+
 type agentToolSearchCatalog struct {
 	ref     coreagent.ToolRef
 	catalog *catalog.Catalog
@@ -1508,12 +1523,12 @@ func (k agentToolTargetKey) String() string {
 	return strings.Join(parts, "/")
 }
 
-func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef, query string, skipUnavailable bool) ([]agentToolSearchCandidate, error) {
+func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef, query string, skipUnavailable bool) ([]agentToolSearchCandidate, []agentToolUnavailableCandidate, error) {
 	scope := newAgentToolSearchScope(refs)
 	providerNames := scope.providerNames()
 	if len(providerNames) == 0 {
 		if !scope.all {
-			return nil, nil
+			return nil, nil, nil
 		}
 		providerNames = m.providers.List()
 	}
@@ -1524,6 +1539,7 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 		}
 	}
 	candidates := make([]agentToolSearchCandidate, 0)
+	unavailable := make([]agentToolUnavailableCandidate, 0)
 	var firstUnavailableErr error
 	for _, pluginName := range providerNames {
 		pluginName = strings.TrimSpace(pluginName)
@@ -1535,7 +1551,7 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 			if errors.Is(err, core.ErrNotFound) {
 				continue
 			}
-			return nil, fmt.Errorf("%w: looking up provider: %v", invocation.ErrInternal, err)
+			return nil, nil, fmt.Errorf("%w: looking up provider: %v", invocation.ErrInternal, err)
 		}
 		if !m.allowProvider(ctx, p, pluginName) {
 			continue
@@ -1550,9 +1566,12 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 					if firstUnavailableErr == nil {
 						firstUnavailableErr = err
 					}
+					if principal.AllowsProviderPermission(p, pluginName) {
+						unavailable = append(unavailable, unavailableAgentToolCandidate(searchRef, err))
+					}
 					continue
 				}
-				return nil, err
+				return nil, nil, err
 			}
 			for j := range searchCatalogs {
 				searchCatalog := searchCatalogs[j]
@@ -1592,10 +1611,14 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 			}
 		}
 	}
-	if len(candidates) == 0 && !scope.all && firstUnavailableErr != nil {
-		return nil, firstUnavailableErr
+	if len(candidates) == 0 && len(unavailable) == 0 && !scope.all && firstUnavailableErr != nil {
+		return nil, nil, firstUnavailableErr
 	}
-	return rankAgentToolSearchCandidates(query, candidates)
+	ranked, err := rankAgentToolSearchCandidates(query, candidates)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ranked, unavailable, nil
 }
 
 func agentToolSearchUnavailable(err error) bool {
@@ -1604,6 +1627,75 @@ func agentToolSearchUnavailable(err error) bool {
 		errors.Is(err, invocation.ErrReconnectRequired) ||
 		errors.Is(err, invocation.ErrNotAuthenticated) ||
 		errors.Is(err, invocation.ErrScopeDenied)
+}
+
+func unavailableAgentToolCandidate(ref coreagent.ToolRef, err error) agentToolUnavailableCandidate {
+	ref.Plugin = strings.TrimSpace(ref.Plugin)
+	ref.Operation = ""
+	ref.Title = ""
+	ref.Description = ""
+	reason := unavailableAgentToolReason(err)
+	return agentToolUnavailableCandidate{
+		ref:     ref,
+		err:     err,
+		reason:  reason,
+		message: unavailableAgentToolMessage(ref.Plugin, reason, err),
+	}
+}
+
+func listedAgentToolUnavailable(tool coreagent.ListedTool) bool {
+	return tool.Target.Unavailable != nil
+}
+
+func unavailableAgentToolReason(err error) string {
+	switch {
+	case errors.Is(err, invocation.ErrAmbiguousInstance):
+		return coreagent.ToolUnavailableReasonInstanceRequired
+	case errors.Is(err, invocation.ErrScopeDenied):
+		return coreagent.ToolUnavailableReasonScopeDenied
+	case errors.Is(err, invocation.ErrNotAuthenticated):
+		return coreagent.ToolUnavailableReasonNotAuthenticated
+	case errors.Is(err, invocation.ErrNoCredential):
+		return coreagent.ToolUnavailableReasonNoCredential
+	default:
+		return coreagent.ToolUnavailableReasonReconnectRequired
+	}
+}
+
+func unavailableAgentToolTitle(pluginName, reason string) string {
+	pluginName = strings.TrimSpace(pluginName)
+	switch reason {
+	case coreagent.ToolUnavailableReasonInstanceRequired:
+		return pluginName + " instance required"
+	case coreagent.ToolUnavailableReasonScopeDenied:
+		return pluginName + " scope denied"
+	case coreagent.ToolUnavailableReasonNotAuthenticated:
+		return pluginName + " authentication required"
+	case coreagent.ToolUnavailableReasonNoCredential:
+		return pluginName + " connection required"
+	default:
+		return pluginName + " reconnect required"
+	}
+}
+
+func unavailableAgentToolMessage(pluginName, reason string, err error) string {
+	pluginName = strings.TrimSpace(pluginName)
+	if pluginName == "" {
+		pluginName = "this integration"
+	}
+	switch reason {
+	case coreagent.ToolUnavailableReasonInstanceRequired:
+		return fmt.Sprintf("%s has multiple matching instances. Ask the user to choose or reconnect a specific instance before using these tools.", pluginName)
+	case coreagent.ToolUnavailableReasonScopeDenied:
+		return fmt.Sprintf("%s is connected but is missing required OAuth scopes. Ask the user to reconnect %s with the required scopes before using these tools.", pluginName, pluginName)
+	case coreagent.ToolUnavailableReasonNotAuthenticated, coreagent.ToolUnavailableReasonNoCredential, coreagent.ToolUnavailableReasonReconnectRequired:
+		return fmt.Sprintf("%s is not connected, its credentials expired, or refresh failed. Ask the user to reconnect %s before using these tools.", pluginName, pluginName)
+	default:
+		if err != nil {
+			return err.Error()
+		}
+		return fmt.Sprintf("%s is unavailable.", pluginName)
+	}
 }
 
 func agentToolSearchRefSkipsUnavailable(ref coreagent.ToolRef) bool {
@@ -2156,6 +2248,48 @@ func (m *Manager) listedAgentPluginCandidateTool(candidate agentToolSearchCandid
 	}, nil
 }
 
+func (m *Manager) listedUnavailableAgentPluginTool(candidate agentToolUnavailableCandidate) (coreagent.ListedTool, error) {
+	ref := candidate.ref
+	ref.Plugin = strings.TrimSpace(ref.Plugin)
+	ref.Operation = ""
+	ref.Connection = core.ResolveConnectionAlias(strings.TrimSpace(ref.Connection))
+	ref.Instance = strings.TrimSpace(ref.Instance)
+	ref.Title = ""
+	ref.Description = ""
+	target := coreagent.ToolTarget{
+		Plugin:         ref.Plugin,
+		Connection:     ref.Connection,
+		Instance:       ref.Instance,
+		CredentialMode: ref.CredentialMode,
+		Unavailable: &coreagent.UnavailableToolTarget{
+			Reason:  candidate.reason,
+			Message: candidate.message,
+		},
+	}
+	toolID, err := m.mintAgentToolID(target)
+	if err != nil {
+		return coreagent.ListedTool{}, err
+	}
+	return coreagent.ListedTool{
+		ToolID:          toolID,
+		MCPName:         agentUnavailableToolMCPName(target),
+		Title:           unavailableAgentToolTitle(ref.Plugin, candidate.reason),
+		Description:     candidate.message,
+		InputSchemaJSON: `{"type":"object","properties":{},"additionalProperties":false}`,
+		Annotations: core.CapabilityAnnotations{
+			ReadOnlyHint:    agentToolBoolPtr(true),
+			DestructiveHint: agentToolBoolPtr(false),
+			OpenWorldHint:   agentToolBoolPtr(false),
+		},
+		Ref:    ref,
+		Target: target,
+	}, nil
+}
+
+func agentToolBoolPtr(value bool) *bool {
+	return &value
+}
+
 func capabilityAnnotationsFromCatalog(value catalog.OperationAnnotations) core.CapabilityAnnotations {
 	return core.CapabilityAnnotations{
 		ReadOnlyHint:    value.ReadOnlyHint,
@@ -2207,6 +2341,9 @@ func assignUniqueListedAgentToolNames(tools []coreagent.ListedTool) {
 }
 
 func agentToolMCPName(target coreagent.ToolTarget) string {
+	if target.Unavailable != nil {
+		return agentUnavailableToolMCPName(target)
+	}
 	var parts []string
 	if strings.TrimSpace(target.System) != "" {
 		parts = []string{"system", target.System, target.Operation}
@@ -2227,6 +2364,19 @@ func agentToolMCPName(target coreagent.ToolTarget) string {
 		return "tool"
 	}
 	return strings.Join(out, "__")
+}
+
+func agentUnavailableToolMCPName(target coreagent.ToolTarget) string {
+	reason := coreagent.ToolUnavailableReasonReconnectRequired
+	if target.Unavailable != nil && strings.TrimSpace(target.Unavailable.Reason) != "" {
+		reason = strings.TrimSpace(target.Unavailable.Reason)
+	}
+	return agentToolMCPName(coreagent.ToolTarget{
+		Plugin:     strings.TrimSpace(target.Plugin),
+		Operation:  reason,
+		Connection: core.ResolveConnectionAlias(strings.TrimSpace(target.Connection)),
+		Instance:   strings.TrimSpace(target.Instance),
+	})
 }
 
 func sanitizeMCPNamePart(value string) string {


### PR DESCRIPTION
## Summary

Surfaces unavailable MCP catalog integrations as native MCP-listed sentinel tools instead of silently dropping them from broad/plugin-level grants. This lets native agent tool search discover that Linear or another integration needs reconnecting, while exact operation refs continue to return the underlying error.

## Interface Changes
- New internal `ToolTarget.Unavailable` target variant sealed in agent tool IDs.
- Broad/plugin-level `ListTools` may now include tools such as `linear__reconnect_required`, `ashby__no_credential`, or `plugin__instance_required`.
- Calling a sentinel returns a non-2xx JSON tool result without invoking the provider.

Example tool result:
```json
{"error":{"code":"reconnect_required","message":"linear is not connected, its credentials expired, or refresh failed. Ask the user to reconnect linear before using these tools.","plugin":"linear","connection":"","instance":""}}
```

## Functional/Integration Tests
- Tests added or augmented: agent runtime MCP catalog contract and bootstrap AgentHost MCP catalog contract.
- Contract boundary covered: run-grant sealed tool IDs, AgentRuntime ListTools/ExecuteTool, AgentHost-facing bootstrap flow.
- Commands run:
```bash
cd gestaltd && go test ./services/agents/agentmanager ./services/agents ./internal/bootstrap
```