### PR TITLE
Add provider registry docs site

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -10,6 +10,44 @@ COPY --from=builder /app/out /usr/share/nginx/html
 COPY <<'EOF' /etc/nginx/conf.d/default.conf
 server {
     listen 8080;
+    server_name registry.gestaltd.ai;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /_next/ {
+        try_files $uri =404;
+    }
+
+    location /_pagefind/ {
+        try_files $uri =404;
+    }
+
+    location /favicon.svg {
+        try_files $uri =404;
+    }
+
+    location /images/ {
+        try_files $uri =404;
+    }
+
+    location /fonts/ {
+        try_files $uri =404;
+    }
+
+    location = /404.html {
+        try_files /404.html =404;
+    }
+
+    location / {
+        try_files /registry.html =404;
+    }
+
+    error_page 404 /404.html;
+}
+
+server {
+    listen 8080 default_server;
+    server_name gestaltd.ai _;
     root /usr/share/nginx/html;
     index index.html;
 

--- a/docs/app/(docs)/[[...mdxPath]]/page.tsx
+++ b/docs/app/(docs)/[[...mdxPath]]/page.tsx
@@ -1,5 +1,5 @@
 import { generateStaticParamsFor, importPage } from "nextra/pages";
-import { useMDXComponents as getMDXComponents } from "../../mdx-components";
+import { useMDXComponents as getMDXComponents } from "../../../mdx-components";
 
 type PageParams = {
   mdxPath?: string[];

--- a/docs/app/(docs)/layout.tsx
+++ b/docs/app/(docs)/layout.tsx
@@ -1,0 +1,71 @@
+import { Footer, Layout, Navbar } from "nextra-theme-docs";
+import { Search } from "nextra/components";
+import { GitHubIcon } from "nextra/icons";
+import { getPageMap } from "nextra/page-map";
+
+const repositoryUrl = "https://github.com/valon-technologies/gestalt";
+
+const navbar = (
+  <Navbar
+    logo={
+      <span
+        style={{
+          fontFamily: "'Season Serif', Georgia, serif",
+          fontSize: "1.7rem",
+        }}
+      >
+        Gestalt
+      </span>
+    }
+  />
+);
+
+const search = (
+  <div className="docs-header-search">
+    <a
+      href={repositoryUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="docs-header-repo-link"
+      aria-label="View the Gestalt GitHub repository"
+    >
+      <GitHubIcon height="20" aria-hidden="true" />
+      <span>GitHub</span>
+    </a>
+    <Search />
+  </div>
+);
+
+const footer = <Footer />;
+
+export default async function DocsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <Layout
+      navbar={navbar}
+      footer={footer}
+      search={search}
+      pageMap={await getPageMap()}
+      docsRepositoryBase="https://github.com/valon-technologies/gestalt/tree/main/docs"
+      nextThemes={{
+        defaultTheme: "system",
+        storageKey: "gestalt-docs-theme",
+      }}
+      sidebar={{
+        defaultMenuCollapseLevel: 1,
+      }}
+      toc={{
+        float: true,
+      }}
+      navigation={{
+        prev: true,
+        next: true,
+      }}
+    >
+      {children}
+    </Layout>
+  );
+}

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,8 +1,4 @@
 import type { Metadata, Viewport } from "next";
-import { Footer, Layout, Navbar } from "nextra-theme-docs";
-import { Head, Search } from "nextra/components";
-import { GitHubIcon } from "nextra/icons";
-import { getPageMap } from "nextra/page-map";
 import "nextra-theme-docs/style.css";
 import "../globals.css";
 
@@ -20,77 +16,14 @@ export const viewport: Viewport = {
   themeColor: "#FDFCF9",
 };
 
-const repositoryUrl = "https://github.com/valon-technologies/gestalt";
-
-const navbar = (
-  <Navbar
-    logo={
-      <span
-        style={{
-          fontFamily: "'Season Serif', Georgia, serif",
-          fontSize: "1.7rem",
-          letterSpacing: "-0.03em",
-        }}
-      >
-        Gestalt
-      </span>
-    }
-  />
-);
-
-const search = (
-  <div className="docs-header-search">
-    <a
-      href={repositoryUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="docs-header-repo-link"
-      aria-label="View the Gestalt GitHub repository"
-    >
-      <GitHubIcon height="20" aria-hidden="true" />
-      <span>GitHub</span>
-    </a>
-    <Search />
-  </div>
-);
-
-const footer = <Footer />;
-
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>
-      <Head>
-        <meta name="theme-color" content="#FDFCF9" />
-      </Head>
-      <body>
-        <Layout
-          navbar={navbar}
-          footer={footer}
-          search={search}
-          pageMap={await getPageMap()}
-          docsRepositoryBase="https://github.com/valon-technologies/gestalt/tree/main/docs"
-          nextThemes={{
-            defaultTheme: "system",
-            storageKey: "gestalt-docs-theme",
-          }}
-          sidebar={{
-            defaultMenuCollapseLevel: 1,
-          }}
-          toc={{
-            float: true,
-          }}
-          navigation={{
-            prev: true,
-            next: true,
-          }}
-        >
-          {children}
-        </Layout>
-      </body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/docs/app/registry/page.tsx
+++ b/docs/app/registry/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import RegistryApp from "./registry-app";
+
+const defaultCatalogUrl =
+  "https://raw.githubusercontent.com/valon-technologies/gestalt-providers/main/registry/catalog.json";
+
+export const metadata: Metadata = {
+  title: "Provider Registry",
+  description: "Browse installable Gestalt provider packages.",
+};
+
+export default function RegistryPage() {
+  return (
+    <RegistryApp
+      catalogUrl={
+        process.env.NEXT_PUBLIC_PROVIDER_REGISTRY_CATALOG_URL ??
+        defaultCatalogUrl
+      }
+    />
+  );
+}

--- a/docs/app/registry/registry-app.tsx
+++ b/docs/app/registry/registry-app.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import styles from "./registry.module.css";
+
+type ConfigTarget = {
+  section: string;
+  entryKind: string;
+  requiredSet?: Record<string, string>;
+};
+
+type ProviderVersion = {
+  version: string;
+  metadata: string;
+  kind: string;
+  runtime: string;
+  platforms: string[];
+  yanked?: boolean;
+};
+
+type Provider = {
+  package: string;
+  packagePath: string;
+  name: string;
+  kind: string;
+  configTarget: ConfigTarget;
+  displayName: string;
+  description: string;
+  manifestVersion: string | null;
+  latestInstallableVersion: string | null;
+  versions: ProviderVersion[];
+  registryPath: string;
+  sourceUrl: string | null;
+  readmeUrl: string | null;
+  manifestUrl: string | null;
+  iconUrl: string | null;
+};
+
+type Catalog = {
+  schema: string;
+  schemaVersion: number;
+  repository: string;
+  indexUrl: string;
+  providers: Provider[];
+};
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "loaded"; catalog: Catalog }
+  | { status: "error"; message: string };
+
+type RouteSelection = {
+  kind: string;
+  name: string;
+};
+
+const allKinds = "all";
+const catalogSchemaVersion = 1;
+
+export default function RegistryApp({ catalogUrl }: { catalogUrl: string }) {
+  const [loadState, setLoadState] = useState<LoadState>({ status: "loading" });
+  const [query, setQuery] = useState("");
+  const [kind, setKind] = useState(allKinds);
+  const [selectedRoute, setSelectedRoute] = useState<RouteSelection | null>(
+    null,
+  );
+  const [routePrefix, setRoutePrefix] = useState("");
+
+  useEffect(() => {
+    const updateRoute = () => {
+      const pathname = window.location.pathname;
+      const isDocsRegistryRoute =
+        pathname === "/registry" ||
+        pathname === "/registry.html" ||
+        pathname.startsWith("/registry/");
+      setRoutePrefix(isDocsRegistryRoute ? "/registry" : "");
+      setSelectedRoute(selectionFromPath(pathname));
+    };
+    updateRoute();
+    window.addEventListener("popstate", updateRoute);
+    return () => window.removeEventListener("popstate", updateRoute);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadCatalog() {
+      setLoadState({ status: "loading" });
+      try {
+        const response = await fetch(catalogUrl, { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(`catalog returned ${response.status}`);
+        }
+        const catalog = (await response.json()) as Catalog;
+        if (catalog.schema !== "gestaltd-provider-catalog") {
+          throw new Error("catalog schema mismatch");
+        }
+        if (catalog.schemaVersion !== catalogSchemaVersion) {
+          throw new Error("catalog schema version mismatch");
+        }
+        if (!cancelled) {
+          setLoadState({ status: "loaded", catalog });
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setLoadState({
+            status: "error",
+            message:
+              error instanceof Error ? error.message : "catalog unavailable",
+          });
+        }
+      }
+    }
+    loadCatalog();
+    return () => {
+      cancelled = true;
+    };
+  }, [catalogUrl]);
+
+  const providers = loadState.status === "loaded" ? loadState.catalog.providers : [];
+
+  const kinds = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const provider of providers) {
+      counts.set(provider.kind, (counts.get(provider.kind) ?? 0) + 1);
+    }
+    return Array.from(counts)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([value, count]) => ({ value, count }));
+  }, [providers]);
+
+  const filteredProviders = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return providers.filter((provider) => {
+      if (kind !== allKinds && provider.kind !== kind) {
+        return false;
+      }
+      if (!normalizedQuery) {
+        return true;
+      }
+      const haystack = [
+        provider.displayName,
+        provider.name,
+        provider.kind,
+        provider.package,
+        provider.description,
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(normalizedQuery);
+    });
+  }, [kind, providers, query]);
+
+  const selectedProvider = useMemo(() => {
+    if (selectedRoute) {
+      const byRoute = providers.find(
+        (provider) =>
+          provider.kind === selectedRoute.kind &&
+          provider.name === selectedRoute.name,
+      );
+      if (byRoute) {
+        return byRoute;
+      }
+    }
+    return filteredProviders[0] ?? providers[0] ?? null;
+  }, [filteredProviders, providers, selectedRoute]);
+
+  function selectProvider(provider: Provider) {
+    const href = `${routePrefix}${provider.registryPath}`;
+    window.history.pushState(null, "", href);
+    setSelectedRoute({ kind: provider.kind, name: provider.name });
+  }
+
+  return (
+    <main className={styles.shell}>
+      <header className={styles.header}>
+        <a className={styles.brand} href={routePrefix || "/"}>
+          <span className={styles.brandMark}>G</span>
+          <span>
+            <strong>Gestalt</strong>
+            <small>Provider Registry</small>
+          </span>
+        </a>
+        <nav className={styles.nav}>
+          <a href="https://gestaltd.ai">Docs</a>
+          <a href="https://github.com/valon-technologies/gestalt-providers">
+            GitHub
+          </a>
+        </nav>
+      </header>
+
+      <section className={styles.toolbar}>
+        <label className={styles.search}>
+          <span>Search</span>
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="slack, indexeddb, runtime"
+          />
+        </label>
+        <div className={styles.kindTabs} aria-label="Provider kind">
+          <button
+            className={kind === allKinds ? styles.activeTab : undefined}
+            onClick={() => setKind(allKinds)}
+            type="button"
+          >
+            All <span>{providers.length}</span>
+          </button>
+          {kinds.map((entry) => (
+            <button
+              className={kind === entry.value ? styles.activeTab : undefined}
+              key={entry.value}
+              onClick={() => setKind(entry.value)}
+              type="button"
+            >
+              {kindLabel(entry.value)} <span>{entry.count}</span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {loadState.status === "error" ? (
+        <section className={styles.statePanel}>
+          <h1>Registry unavailable</h1>
+          <p>{loadState.message}</p>
+        </section>
+      ) : (
+        <section className={styles.content}>
+          <div className={styles.listPane}>
+            <div className={styles.listHeader}>
+              <span>{loadState.status === "loaded" ? filteredProviders.length : 0} providers</span>
+              <span>Installable packages</span>
+            </div>
+            {loadState.status === "loading" ? (
+              <div className={styles.statePanel}>Loading registry</div>
+            ) : (
+              <div className={styles.providerList}>
+                {filteredProviders.map((provider) => (
+                  <button
+                    type="button"
+                    key={provider.package}
+                    className={
+                      selectedProvider?.package === provider.package
+                        ? `${styles.providerCard} ${styles.selectedCard}`
+                        : styles.providerCard
+                    }
+                    onClick={() => selectProvider(provider)}
+                  >
+                    <ProviderIcon provider={provider} />
+                    <span className={styles.providerText}>
+                      <strong>{provider.displayName}</strong>
+                      <small>{provider.packagePath}</small>
+                    </span>
+                    <span className={styles.kindBadge}>{kindLabel(provider.kind)}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <aside className={styles.detailPane}>
+            {selectedProvider ? (
+              <ProviderDetail provider={selectedProvider} />
+            ) : (
+              <div className={styles.statePanel}>No provider selected</div>
+            )}
+          </aside>
+        </section>
+      )}
+    </main>
+  );
+}
+
+function selectionFromPath(pathname: string): RouteSelection | null {
+  const normalized = pathname.replace(/^\/registry/, "");
+  const match = normalized.match(/^\/providers\/([^/]+)\/([^/]+)\/?$/);
+  if (!match) {
+    return null;
+  }
+  return {
+    kind: decodeURIComponent(match[1]),
+    name: decodeURIComponent(match[2]),
+  };
+}
+
+function ProviderDetail({ provider }: { provider: Provider }) {
+  const latest = provider.versions[0];
+  const installCommand = provider.configTarget.requiredSet?.path
+    ? `gestaltd provider add ${provider.package} --set path=/`
+    : `gestaltd provider add ${provider.package}`;
+  return (
+    <div className={styles.detail}>
+      <div className={styles.detailTitle}>
+        <ProviderIcon provider={provider} large />
+        <div>
+          <span className={styles.kindBadge}>{kindLabel(provider.kind)}</span>
+          <h1 className={styles.providerName}>{provider.displayName}</h1>
+          <p>{provider.description || provider.packagePath}</p>
+        </div>
+      </div>
+
+      <div className={styles.installBlock}>
+        <span>Install</span>
+        <code>{installCommand}</code>
+      </div>
+
+      <dl className={styles.metaGrid}>
+        <div>
+          <dt>Package</dt>
+          <dd>{provider.package}</dd>
+        </div>
+        <div>
+          <dt>Config target</dt>
+          <dd>{provider.configTarget.section}</dd>
+        </div>
+        <div>
+          <dt>Latest</dt>
+          <dd>{provider.latestInstallableVersion ?? "Not released"}</dd>
+        </div>
+        <div>
+          <dt>Manifest</dt>
+          <dd>{provider.manifestVersion ?? "Release only"}</dd>
+        </div>
+      </dl>
+
+      {latest ? (
+        <section className={styles.versionPanel}>
+          <div className={styles.panelTitle}>
+            <h2>{latest.version}</h2>
+            <span>{latest.runtime}</span>
+          </div>
+          <div className={styles.platforms}>
+            {latest.platforms.map((platform) => (
+              <span key={platform}>
+                {platform === "generic" ? "all platforms" : platform}
+              </span>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className={styles.versionPanel}>
+        <div className={styles.panelTitle}>
+          <h2>Versions</h2>
+          <span>{provider.versions.length}</span>
+        </div>
+        <div className={styles.versionList}>
+          {provider.versions.slice(0, 12).map((version) => (
+            <a href={version.metadata} key={version.version}>
+              <span>{version.version}</span>
+              <small>{version.platforms.length} targets</small>
+            </a>
+          ))}
+        </div>
+      </section>
+
+      <div className={styles.links}>
+        {provider.sourceUrl ? <a href={provider.sourceUrl}>Source</a> : null}
+        {provider.readmeUrl ? <a href={provider.readmeUrl}>README</a> : null}
+        {provider.manifestUrl ? <a href={provider.manifestUrl}>Manifest</a> : null}
+      </div>
+    </div>
+  );
+}
+
+function ProviderIcon({
+  provider,
+  large = false,
+}: {
+  provider: Provider;
+  large?: boolean;
+}) {
+  if (provider.iconUrl) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        alt=""
+        className={large ? styles.largeIcon : styles.icon}
+        src={provider.iconUrl}
+      />
+    );
+  }
+  return (
+    <span className={large ? styles.largeFallbackIcon : styles.fallbackIcon}>
+      {provider.displayName.slice(0, 1).toUpperCase()}
+    </span>
+  );
+}
+
+function kindLabel(kind: string) {
+  return kind
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}

--- a/docs/app/registry/registry.module.css
+++ b/docs/app/registry/registry.module.css
@@ -1,0 +1,470 @@
+.shell {
+  min-height: 100vh;
+  background: #f8f6f1;
+  color: #171717;
+}
+
+.shell,
+.shell * {
+  box-sizing: border-box;
+}
+
+.header {
+  align-items: center;
+  background: #fffcf4;
+  border-bottom: 1px solid #ddd7c8;
+  display: flex;
+  justify-content: space-between;
+  min-height: 68px;
+  padding: 0 32px;
+}
+
+.brand {
+  align-items: center;
+  color: inherit;
+  display: inline-flex;
+  gap: 12px;
+  text-decoration: none;
+}
+
+.brandMark {
+  align-items: center;
+  background: #172c2a;
+  border-radius: 8px;
+  color: #fff7e8;
+  display: inline-flex;
+  font-family: "Season Serif", Georgia, serif;
+  font-size: 24px;
+  height: 42px;
+  justify-content: center;
+  width: 42px;
+}
+
+.brand strong {
+  display: block;
+  font-family: "Season Serif", Georgia, serif;
+  font-size: 24px;
+  font-weight: 500;
+}
+
+.brand small {
+  color: #6e6658;
+  display: block;
+  font-size: 13px;
+  margin-top: 2px;
+}
+
+.nav {
+  display: flex;
+  gap: 18px;
+}
+
+.nav a,
+.links a {
+  color: #1d5d58;
+  font-size: 14px;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.toolbar {
+  border-bottom: 1px solid #ddd7c8;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(240px, 380px) 1fr;
+  overflow: hidden;
+  padding: 20px 32px;
+}
+
+.search {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.search span,
+.installBlock span,
+.listHeader,
+.metaGrid dt {
+  color: #70685b;
+  font-size: 12px;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.search input {
+  background: #fffdf8;
+  border: 1px solid #cfc7b7;
+  border-radius: 8px;
+  color: #171717;
+  font: inherit;
+  height: 42px;
+  padding: 0 12px;
+  width: 100%;
+}
+
+.kindTabs {
+  align-content: end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.kindTabs button {
+  background: #fffdf8;
+  border: 1px solid #d8d1c2;
+  border-radius: 8px;
+  color: #38342e;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  height: 34px;
+  max-width: 100%;
+  padding: 0 10px;
+}
+
+.kindTabs button span {
+  color: #887c6a;
+  margin-left: 5px;
+}
+
+.kindTabs .activeTab {
+  background: #1d5d58;
+  border-color: #1d5d58;
+  color: #fff;
+}
+
+.kindTabs .activeTab span {
+  color: #cce7e4;
+}
+
+.content {
+  display: grid;
+  grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
+  min-height: calc(100vh - 129px);
+  overflow: hidden;
+}
+
+.listPane {
+  border-right: 1px solid #ddd7c8;
+  min-width: 0;
+}
+
+.listHeader {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: 14px 20px;
+}
+
+.providerList {
+  display: grid;
+  gap: 8px;
+  padding: 0 12px 20px;
+}
+
+.providerCard {
+  align-items: center;
+  background: #fffdf8;
+  border: 1px solid #ded6c6;
+  border-radius: 8px;
+  color: inherit;
+  cursor: pointer;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 38px minmax(0, 1fr) auto;
+  min-height: 68px;
+  padding: 10px;
+  text-align: left;
+}
+
+.providerCard:hover,
+.selectedCard {
+  border-color: #1d5d58;
+  box-shadow: 0 0 0 1px #1d5d58;
+}
+
+.providerText {
+  min-width: 0;
+}
+
+.providerText strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.providerText small {
+  color: #71695c;
+  display: block;
+  font-size: 12px;
+  margin-top: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kindBadge {
+  background: #ede7da;
+  border-radius: 999px;
+  color: #51483c;
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 5px 8px;
+  white-space: nowrap;
+}
+
+.detailPane {
+  min-width: 0;
+  padding: 26px 32px;
+}
+
+.detail {
+  display: grid;
+  gap: 22px;
+  max-width: 980px;
+}
+
+.detailTitle {
+  align-items: start;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: 64px minmax(0, 1fr);
+}
+
+.detailTitle .providerName {
+  font-family: inherit;
+  font-size: 32px;
+  font-weight: 750;
+  letter-spacing: 0;
+  line-height: 1.15;
+  margin: 10px 0 8px;
+}
+
+.detailTitle p {
+  color: #4f4a42;
+  font-size: 16px;
+  line-height: 1.6;
+  margin: 0;
+  max-width: 760px;
+}
+
+.icon,
+.fallbackIcon,
+.largeIcon,
+.largeFallbackIcon {
+  align-items: center;
+  background: #f3ead9;
+  border: 1px solid #ded4c1;
+  border-radius: 8px;
+  display: inline-flex;
+  height: 38px;
+  justify-content: center;
+  object-fit: contain;
+  width: 38px;
+}
+
+.largeIcon,
+.largeFallbackIcon {
+  height: 64px;
+  width: 64px;
+}
+
+.fallbackIcon,
+.largeFallbackIcon {
+  color: #7b2f38;
+  font-family: "Season Serif", Georgia, serif;
+  font-size: 19px;
+}
+
+.largeFallbackIcon {
+  font-size: 30px;
+}
+
+.installBlock {
+  background: #172c2a;
+  border-radius: 8px;
+  color: #fff7e8;
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+}
+
+.installBlock span {
+  color: #afd1cc;
+}
+
+.installBlock code {
+  color: #fff7e8;
+  font-family: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 14px;
+  overflow-wrap: anywhere;
+}
+
+.metaGrid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
+}
+
+.metaGrid div,
+.versionPanel {
+  background: #fffdf8;
+  border: 1px solid #ddd5c5;
+  border-radius: 8px;
+  padding: 14px;
+}
+
+.metaGrid dd {
+  font-size: 14px;
+  margin: 6px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.panelTitle {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.panelTitle h2 {
+  font-size: 16px;
+  margin: 0;
+}
+
+.panelTitle span {
+  color: #70685b;
+  font-size: 13px;
+}
+
+.platforms {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.platforms span {
+  background: #f1eadf;
+  border-radius: 999px;
+  color: #403a32;
+  font-size: 12px;
+  font-weight: 650;
+  padding: 6px 8px;
+}
+
+.versionList {
+  display: grid;
+  gap: 6px;
+}
+
+.versionList a {
+  align-items: center;
+  border-radius: 6px;
+  color: inherit;
+  display: flex;
+  justify-content: space-between;
+  padding: 8px;
+  text-decoration: none;
+}
+
+.versionList a:hover {
+  background: #f3ede2;
+}
+
+.versionList small {
+  color: #756c5f;
+}
+
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.statePanel {
+  background: #fffdf8;
+  border: 1px solid #ddd5c5;
+  border-radius: 8px;
+  margin: 24px;
+  padding: 20px;
+}
+
+.statePanel h1 {
+  margin: 0 0 8px;
+}
+
+.statePanel p {
+  color: #5c554b;
+  margin: 0;
+}
+
+@media (max-width: 900px) {
+  .header {
+    padding: 0 18px;
+  }
+
+  .toolbar {
+    grid-template-columns: 1fr;
+    padding: 16px 18px;
+  }
+
+  .content {
+    grid-template-columns: 1fr;
+  }
+
+  .listPane {
+    border-right: 0;
+  }
+
+  .listHeader span:last-child {
+    display: none;
+  }
+
+  .detailPane {
+    padding: 20px 18px 32px;
+  }
+
+  .metaGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .nav {
+    display: none;
+  }
+
+  .kindTabs {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .kindTabs button {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
+  }
+
+  .providerCard {
+    grid-template-columns: 38px minmax(0, 1fr);
+  }
+
+  .providerCard .kindBadge {
+    grid-column: 2;
+    justify-self: start;
+  }
+
+  .detailTitle {
+    grid-template-columns: 1fr;
+  }
+
+  .detailTitle .providerName {
+    font-size: 28px;
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,8 @@
     "build": "next build && pagefind --site out --output-subdir _pagefind",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:registry": "node scripts/check-registry-static.mjs"
   },
   "dependencies": {
     "@types/react-dom": "^19.2.3",

--- a/docs/scripts/check-registry-static.mjs
+++ b/docs/scripts/check-registry-static.mjs
@@ -1,0 +1,159 @@
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import path from "node:path";
+
+const siteRoot = path.resolve("out");
+const registryHtml = path.join(siteRoot, "registry.html");
+
+if (!existsSync(registryHtml)) {
+  throw new Error("out/registry.html is missing; run npm run build first");
+}
+
+const contentTypes = new Map([
+  [".css", "text/css"],
+  [".html", "text/html"],
+  [".js", "text/javascript"],
+  [".json", "application/json"],
+  [".svg", "image/svg+xml"],
+  [".txt", "text/plain"],
+  [".woff", "font/woff"],
+  [".woff2", "font/woff2"],
+]);
+
+const server = createServer(async (request, response) => {
+  try {
+    const host =
+      request.headers["x-test-host"]?.split(":")[0] ??
+      request.headers.host?.split(":")[0] ??
+      "";
+    const url = new URL(request.url ?? "/", "http://localhost");
+    const pathname = decodeURIComponent(url.pathname);
+    if (host === "registry.gestaltd.ai") {
+      await serveRegistryHost(pathname, response);
+    } else {
+      await serveDocsHost(pathname, response);
+    }
+  } catch (error) {
+    response.writeHead(500, { "content-type": "text/plain" });
+    response.end(error instanceof Error ? error.message : "server error");
+  }
+});
+
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+try {
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  await assertResponse({
+    url: `${baseUrl}/`,
+    host: "registry.gestaltd.ai",
+    status: 200,
+    includes: "registry-module",
+  });
+  await assertResponse({
+    url: `${baseUrl}/providers`,
+    host: "registry.gestaltd.ai",
+    status: 200,
+    includes: "registry-module",
+  });
+  await assertResponse({
+    url: `${baseUrl}/providers/plugin/slack/`,
+    host: "registry.gestaltd.ai",
+    status: 200,
+    includes: "registry-module",
+  });
+  await assertResponse({
+    url: `${baseUrl}/_next/static/chunks/does-not-exist.js`,
+    host: "registry.gestaltd.ai",
+    status: 404,
+    excludes: "registry-module",
+  });
+  await assertResponse({
+    url: `${baseUrl}/providers`,
+    host: "gestaltd.ai",
+    status: 200,
+    excludes: "registry-module",
+  });
+  await assertResponse({
+    url: `${baseUrl}/providers/plugin/slack/`,
+    host: "gestaltd.ai",
+    status: 404,
+    excludes: "registry-module",
+  });
+} finally {
+  server.close();
+}
+
+async function serveRegistryHost(pathname, response) {
+  if (
+    pathname.startsWith("/_next/") ||
+    pathname.startsWith("/_pagefind/") ||
+    pathname === "/favicon.svg" ||
+    pathname.startsWith("/images/") ||
+    pathname.startsWith("/fonts/") ||
+    pathname === "/404.html"
+  ) {
+    return serveFile(pathname, response, false);
+  }
+  return serveFile("/registry.html", response, false);
+}
+
+async function serveDocsHost(pathname, response) {
+  if (pathname.match(/^\/reference\/(python|typescript|go|rust)-sdk(?:\.html)?$/)) {
+    const target = pathname.replace(/-sdk(?:\.html)?$/, "");
+    response.writeHead(301, { location: `/reference/sdk${target.replace("/reference", "")}` });
+    response.end();
+    return;
+  }
+  return serveFile(pathname, response, true, null);
+}
+
+async function serveFile(pathname, response, htmlFallback, fallbackFile = null) {
+  const candidates = candidateFiles(pathname);
+  for (const candidate of candidates) {
+    if (
+      candidate.startsWith(siteRoot) &&
+      existsSync(candidate) &&
+      statSync(candidate).isFile()
+    ) {
+      const ext = path.extname(candidate);
+      response.writeHead(200, {
+        "content-type": contentTypes.get(ext) ?? "application/octet-stream",
+      });
+      response.end(await readFile(candidate));
+      return;
+    }
+  }
+  if (htmlFallback && fallbackFile) {
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end(await readFile(fallbackFile));
+    return;
+  }
+  response.writeHead(404, { "content-type": "text/plain" });
+  response.end("not found");
+}
+
+function candidateFiles(pathname) {
+  const cleanPath = pathname === "/" ? "/index" : pathname.replace(/\/$/, "");
+  const fullPath = path.join(siteRoot, cleanPath);
+  return [
+    fullPath,
+    `${fullPath}.html`,
+    path.join(siteRoot, pathname, "index.html"),
+  ];
+}
+
+async function assertResponse({ url, host, status, includes, excludes }) {
+  const response = await fetch(url, { headers: { "x-test-host": host } });
+  const body = await response.text();
+  if (response.status !== status) {
+    throw new Error(`${host} ${url} returned ${response.status}, want ${status}`);
+  }
+  if (includes && !body.includes(includes)) {
+    throw new Error(`${host} ${url} did not include ${includes}`);
+  }
+  if (excludes && body.includes(excludes)) {
+    throw new Error(`${host} ${url} unexpectedly included ${excludes}`);
+  }
+}

--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -20,7 +20,7 @@ provider "google" {
 }
 
 locals {
-  docs_cert_name = "${var.resource_prefix}-cert-${replace(var.domain, ".", "-")}"
+  docs_cert_name = "${var.resource_prefix}-cert-${replace(var.domain, ".", "-")}-${replace(var.registry_domain, ".", "-")}"
 }
 
 # ---------- Cloud Run ----------
@@ -88,7 +88,7 @@ resource "google_compute_managed_ssl_certificate" "docs" {
   name = local.docs_cert_name
 
   managed {
-    domains = [var.domain]
+    domains = [var.domain, var.registry_domain]
   }
 
   lifecycle {
@@ -152,6 +152,15 @@ resource "google_dns_record_set" "docs" {
   provider     = google.dns
   managed_zone = google_dns_managed_zone.docs.name
   name         = "${var.domain}."
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [google_compute_global_address.docs.address]
+}
+
+resource "google_dns_record_set" "registry" {
+  provider     = google.dns
+  managed_zone = google_dns_managed_zone.docs.name
+  name         = "${var.registry_domain}."
   type         = "A"
   ttl          = 300
   rrdatas      = [google_compute_global_address.docs.address]

--- a/docs/terraform/outputs.tf
+++ b/docs/terraform/outputs.tf
@@ -3,6 +3,11 @@ output "docs_url" {
   value       = "https://${var.domain}"
 }
 
+output "registry_url" {
+  description = "Public URL for the provider registry"
+  value       = "https://${var.registry_domain}"
+}
+
 output "load_balancer_ip" {
   description = "Global IP address of the load balancer"
   value       = google_compute_global_address.docs.address

--- a/docs/terraform/variables.tf
+++ b/docs/terraform/variables.tf
@@ -24,6 +24,12 @@ variable "domain" {
   default     = "gestaltd.ai"
 }
 
+variable "registry_domain" {
+  description = "Provider registry site domain"
+  type        = string
+  default     = "registry.gestaltd.ai"
+}
+
 variable "docs_image" {
   description = "Container image for the docs service (required, no default to prevent accidental reverts)"
   type        = string


### PR DESCRIPTION
## Summary

Adds a standalone provider registry shell to the docs app and configures the docs container/infra so the same Cloud Run service can serve both `gestaltd.ai` and `registry.gestaltd.ai`.

- Moves the existing Nextra docs shell into an `(docs)` route group so `/registry` can render outside the docs chrome.
- Adds a provider registry browser at `/registry`, backed by the provider catalog JSON generated in valon-technologies/gestalt-providers#528.
- Updates nginx routing so `registry.gestaltd.ai/`, `/providers`, and `/providers/<kind>/<name>/` fall back to the registry shell while missing static assets still 404.
- Adds Terraform DNS/certificate coverage for `registry.gestaltd.ai` on the existing docs load balancer.

## Interface Changes

- New/changed interface: `registry.gestaltd.ai` becomes a host-routed provider registry using the docs image.
- Example usage: `https://registry.gestaltd.ai/providers/plugin/slack/` loads the registry shell with the Slack provider selected.
- Example usage: `https://registry.gestaltd.ai/providers/indexeddb/mongodb/` loads the registry shell with the MongoDB IndexedDB provider selected.
- Build-time override: `NEXT_PUBLIC_PROVIDER_REGISTRY_CATALOG_URL` can point the registry shell at an alternate complete catalog URL for non-production builds.
- Production catalog: defaults to `https://raw.githubusercontent.com/valon-technologies/gestalt-providers/main/registry/catalog.json`.

## Functional/Integration Tests

- Tests added or augmented: added `docs/scripts/check-registry-static.mjs` and `npm run test:registry` to exercise exported-site host routing.
- Contract boundary covered: exported Next static output plus nginx-equivalent routing for `registry.gestaltd.ai` and `gestaltd.ai`, including registry root/provider path fallback and missing static asset 404s.
- Commands run:
  - `npm run build`
  - `npm run test:registry`
  - `npm run typecheck`
  - `terraform -chdir=terraform fmt -check`
  - `git diff --check`
  - Headless Chrome desktop/mobile screenshots against local `out/registry.html` with the provider catalog fixture
- Not run: Docker image build, because the local Docker daemon is unavailable. `terraform validate` also could not complete because provider initialization stalled locally after installing began; CI will run Terraform init/apply with the configured backend.

## Stack / Follow-up

This PR is not code-stacked on the provider repo PR, but production catalog data depends on valon-technologies/gestalt-providers#528 merging first.
