### PR TITLE
Add durable agent route store

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1071,6 +1071,11 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		prepared.Deps.WorkflowRuntime.FailPendingProviders(err)
 		return nil, err
 	}
+	agentRouteStore, err := agentmanager.NewIndexedDBRouteStore(ctx, prepared.Deps.IndexedDBs[prepared.Deps.SelectedIndexedDBName])
+	if err != nil {
+		prepared.Deps.WorkflowRuntime.FailPendingProviders(err)
+		return nil, fmt.Errorf("bootstrap: agent route store: %w", err)
+	}
 	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.ExternalCredentials,
 		invocation.WithAuthorizer(authz),
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),
@@ -1103,6 +1108,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		CatalogConnection: connMaps.APIConnection,
 		PluginInvokes:     agentPluginInvokes(cfg),
 		AgentConnections:  agentConnectionBindings(cfg),
+		RouteStore:        agentRouteStore,
 	}))
 	prepared.Deps.AgentRuntime.SetToolSearcher(agentManager)
 	extraWorkflows, err := buildWorkflows(ctx, cfg, factories, prepared.Deps)

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -4164,6 +4164,30 @@ func TestBootstrapPassesIndexedDBHostSocketToAgentProviders(t *testing.T) {
 	}
 }
 
+func TestBootstrapProvisionsAgentRouteStoresOnSelectedIndexedDB(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	factories := validFactories()
+	selectedDB := &trackedIndexedDB{StubIndexedDB: &coretesting.StubIndexedDB{}}
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) {
+		return selectedDB, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+
+	if !selectedDB.HasObjectStore("agent_session_routes") {
+		t.Fatal("selected indexeddb missing agent_session_routes store")
+	}
+	if !selectedDB.HasObjectStore("agent_turn_routes") {
+		t.Fatal("selected indexeddb missing agent_turn_routes store")
+	}
+}
+
 func TestBootstrapPassesIndexedDBHostSocketsToAuthorizationProviders(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -209,6 +209,122 @@ func TestAgentTurnRechecksProviderAuthorization(t *testing.T) {
 	}
 }
 
+func TestAgentCreateTurnReportsMissingSession(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAgentProvider()
+	authz := &dynamicProviderAuthorizer{}
+	authz.allowed.Store(true)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		services := testutil.NewStubServices(t)
+		agentControl := &stubAgentControl{defaultProviderName: "managed", provider: provider}
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "ada@example.com", DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Agent = agentControl
+		cfg.Authorizer = authz
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:      agentControl,
+			Authorizer: authz,
+			RunGrants:  newServerTestAgentRunGrants(t),
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/missing-session/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	turnResp, err := http.DefaultClient.Do(turnReq)
+	if err != nil {
+		t.Fatalf("create turn: %v", err)
+	}
+	defer func() { _ = turnResp.Body.Close() }()
+	body, _ := io.ReadAll(turnResp.Body)
+	if turnResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("create turn status = %d body=%s, want 404", turnResp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), `session \"missing-session\" not found`) {
+		t.Fatalf("create turn body = %s, want missing session", body)
+	}
+	if strings.Contains(string(body), `turn \"missing-session\" not found`) {
+		t.Fatalf("create turn body = %s, should not report missing turn", body)
+	}
+}
+
+func TestAgentCreateTurnDoesNotReportSessionMissingAfterSessionResolved(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAgentProvider()
+	provider.createTurnHook = func(turn *coreagent.Turn) {
+		turn.CreatedBy.SubjectID = principal.UserSubjectID("someone-else")
+	}
+	authz := &dynamicProviderAuthorizer{}
+	authz.allowed.Store(true)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		services := testutil.NewStubServices(t)
+		agentControl := &stubAgentControl{defaultProviderName: "managed", provider: provider}
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "ada@example.com", DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Agent = agentControl
+		cfg.Authorizer = authz
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:      agentControl,
+			Authorizer: authz,
+			RunGrants:  newServerTestAgentRunGrants(t),
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions", bytes.NewBufferString(`{"provider":"managed","model":"gpt-5.4"}`))
+	sessionReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	sessionResp, err := http.DefaultClient.Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(sessionResp.Body)
+		t.Fatalf("create session status = %d body=%s, want 201", sessionResp.StatusCode, body)
+	}
+	var session map[string]any
+	if err := json.NewDecoder(sessionResp.Body).Decode(&session); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	sessionID := session["id"].(string)
+
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}]}`))
+	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	turnResp, err := http.DefaultClient.Do(turnReq)
+	if err != nil {
+		t.Fatalf("create turn: %v", err)
+	}
+	defer func() { _ = turnResp.Body.Close() }()
+	body, _ := io.ReadAll(turnResp.Body)
+	if turnResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("create turn status = %d body=%s, want 404", turnResp.StatusCode, body)
+	}
+	if strings.Contains(string(body), `session \"`+sessionID+`\" not found`) {
+		t.Fatalf("create turn body = %s, should not report missing session", body)
+	}
+	if !strings.Contains(string(body), `turn \"`) {
+		t.Fatalf("create turn body = %s, want missing turn", body)
+	}
+}
+
 func TestAgentRequestsRejectMissingProviderTokenPermission(t *testing.T) {
 	t.Parallel()
 
@@ -337,6 +453,7 @@ type memoryAgentProvider struct {
 	listSessionRequests []coreagent.ListSessionsRequest
 	listTurnRequests    []coreagent.ListTurnsRequest
 	createSessionHook   func()
+	createTurnHook      func(*coreagent.Turn)
 	listTurnEventsErr   error
 	capabilities        *coreagent.ProviderCapabilities
 }
@@ -444,6 +561,9 @@ func (p *memoryAgentProvider) CreateTurn(_ context.Context, req coreagent.Create
 		CompletedAt:  &now,
 		ExecutionRef: req.ExecutionRef,
 		OutputText:   "turn completed",
+	}
+	if p.createTurnHook != nil {
+		p.createTurnHook(turn)
 	}
 	p.turns[turn.ID] = turn
 	p.appendTurnEventLocked(turn.ID, "turn.started", map[string]any{"session_id": req.SessionID})

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -399,6 +399,10 @@ func (s *Server) createAgentTurn(w http.ResponseWriter, r *http.Request) {
 		ModelOptions:   maps.Clone(req.ModelOptions),
 	})
 	if err != nil {
+		if errors.Is(err, agentmanager.ErrAgentSessionNotFound) {
+			s.writeAgentManagerError(w, r, "session", sessionID, req.ToolRefs, err)
+			return
+		}
 		s.writeAgentManagerError(w, r, "turn", sessionID, req.ToolRefs, err)
 		return
 	}

--- a/gestaltd/services/agents/agentmanager/indexeddb_route_store.go
+++ b/gestaltd/services/agents/agentmanager/indexeddb_route_store.go
@@ -1,0 +1,178 @@
+package agentmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+const (
+	indexedDBAgentSessionRouteStore = "agent_session_routes"
+	indexedDBAgentTurnRouteStore    = "agent_turn_routes"
+)
+
+var (
+	indexedDBAgentSessionRouteSchema = indexeddb.ObjectStoreSchema{
+		Columns: []indexeddb.ColumnDef{
+			{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+			{Name: "provider", Type: indexeddb.TypeString, NotNull: true},
+		},
+	}
+	indexedDBAgentTurnRouteSchema = indexeddb.ObjectStoreSchema{
+		Columns: []indexeddb.ColumnDef{
+			{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+			{Name: "session_id", Type: indexeddb.TypeString, NotNull: true},
+			{Name: "provider", Type: indexeddb.TypeString, NotNull: true},
+		},
+	}
+)
+
+type indexedDBRouteStore struct {
+	db indexeddb.IndexedDB
+}
+
+func NewIndexedDBRouteStore(ctx context.Context, db indexeddb.IndexedDB) (RouteStore, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if db == nil {
+		return nil, fmt.Errorf("agent route store requires an IndexedDB provider")
+	}
+	if err := db.CreateObjectStore(ctx, indexedDBAgentSessionRouteStore, indexedDBAgentSessionRouteSchema); err != nil && !errors.Is(err, indexeddb.ErrAlreadyExists) {
+		return nil, fmt.Errorf("create agent session route store: %w", err)
+	}
+	if err := db.CreateObjectStore(ctx, indexedDBAgentTurnRouteStore, indexedDBAgentTurnRouteSchema); err != nil && !errors.Is(err, indexeddb.ErrAlreadyExists) {
+		return nil, fmt.Errorf("create agent turn route store: %w", err)
+	}
+	return &indexedDBRouteStore{db: db}, nil
+}
+
+func (s *indexedDBRouteStore) LookupSession(ctx context.Context, sessionID string) (AgentRoute, bool, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	if s == nil || s.db == nil || sessionID == "" {
+		return AgentRoute{}, false, nil
+	}
+	record, err := s.db.ObjectStore(indexedDBAgentSessionRouteStore).Get(ctx, sessionID)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return AgentRoute{}, false, nil
+		}
+		return AgentRoute{}, false, fmt.Errorf("lookup agent session route %q: %w", sessionID, err)
+	}
+	providerName := strings.TrimSpace(stringValue(record["provider"]))
+	if providerName == "" {
+		return AgentRoute{}, false, fmt.Errorf("agent session route %q has no provider", sessionID)
+	}
+	return AgentRoute{ProviderName: providerName, SessionID: sessionID}, true, nil
+}
+
+func (s *indexedDBRouteStore) RememberSession(ctx context.Context, sessionID, providerName string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	providerName = strings.TrimSpace(providerName)
+	if s == nil || s.db == nil || sessionID == "" || providerName == "" {
+		return nil
+	}
+	if err := s.db.ObjectStore(indexedDBAgentSessionRouteStore).Put(ctx, indexeddb.Record{
+		"id":       sessionID,
+		"provider": providerName,
+	}); err != nil {
+		return fmt.Errorf("remember agent session route %q: %w", sessionID, err)
+	}
+	return nil
+}
+
+func (s *indexedDBRouteStore) ForgetSession(ctx context.Context, sessionID, providerName string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	providerName = strings.TrimSpace(providerName)
+	if s == nil || s.db == nil || sessionID == "" {
+		return nil
+	}
+	return s.forgetMatching(ctx, indexedDBAgentSessionRouteStore, sessionID, providerName, "agent session")
+}
+
+func (s *indexedDBRouteStore) LookupTurn(ctx context.Context, turnID string) (AgentRoute, bool, error) {
+	turnID = strings.TrimSpace(turnID)
+	if s == nil || s.db == nil || turnID == "" {
+		return AgentRoute{}, false, nil
+	}
+	record, err := s.db.ObjectStore(indexedDBAgentTurnRouteStore).Get(ctx, turnID)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return AgentRoute{}, false, nil
+		}
+		return AgentRoute{}, false, fmt.Errorf("lookup agent turn route %q: %w", turnID, err)
+	}
+	providerName := strings.TrimSpace(stringValue(record["provider"]))
+	sessionID := strings.TrimSpace(stringValue(record["session_id"]))
+	if providerName == "" {
+		return AgentRoute{}, false, fmt.Errorf("agent turn route %q has no provider", turnID)
+	}
+	if sessionID == "" {
+		return AgentRoute{}, false, fmt.Errorf("agent turn route %q has no session id", turnID)
+	}
+	return AgentRoute{ProviderName: providerName, SessionID: sessionID}, true, nil
+}
+
+func (s *indexedDBRouteStore) RememberTurn(ctx context.Context, turnID, sessionID, providerName string) error {
+	turnID = strings.TrimSpace(turnID)
+	sessionID = strings.TrimSpace(sessionID)
+	providerName = strings.TrimSpace(providerName)
+	if s == nil || s.db == nil || turnID == "" || sessionID == "" || providerName == "" {
+		return nil
+	}
+	if err := s.db.ObjectStore(indexedDBAgentTurnRouteStore).Put(ctx, indexeddb.Record{
+		"id":         turnID,
+		"session_id": sessionID,
+		"provider":   providerName,
+	}); err != nil {
+		return fmt.Errorf("remember agent turn route %q: %w", turnID, err)
+	}
+	return nil
+}
+
+func (s *indexedDBRouteStore) ForgetTurn(ctx context.Context, turnID, providerName string) error {
+	turnID = strings.TrimSpace(turnID)
+	providerName = strings.TrimSpace(providerName)
+	if s == nil || s.db == nil || turnID == "" {
+		return nil
+	}
+	return s.forgetMatching(ctx, indexedDBAgentTurnRouteStore, turnID, providerName, "agent turn")
+}
+
+func (s *indexedDBRouteStore) forgetMatching(ctx context.Context, storeName, id, providerName, label string) error {
+	store := s.db.ObjectStore(storeName)
+	record, err := store.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("lookup %s route %q before delete: %w", label, id, err)
+	}
+	if providerName != "" && strings.TrimSpace(stringValue(record["provider"])) != providerName {
+		return nil
+	}
+	if err := store.Delete(ctx, id); err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("delete %s route %q: %w", label, id, err)
+	}
+	return nil
+}
+
+func stringValue(value any) string {
+	if value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return fmt.Sprint(value)
+	}
+}

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -38,6 +38,7 @@ var (
 	ErrAgentInheritedSurfaceTool       = errors.New("agent inherited surface tools are not supported")
 	ErrAgentInteractionRequired        = errors.New("agent interaction is required")
 	ErrAgentInteractionNotFound        = errors.New("agent interaction is not found")
+	ErrAgentSessionNotFound            = errors.New("agent session is not found")
 	ErrAgentWorkflowToolsNotConfigured = errors.New("agent workflow tools are not configured")
 	ErrAgentBoundedListUnsupported     = errors.New("agent provider does not support bounded list hydration")
 	ErrAgentInvalidListRequest         = errors.New("agent list request is invalid")
@@ -115,6 +116,7 @@ type Config struct {
 	CatalogConnection map[string]string
 	PluginInvokes     map[string][]invocation.PluginInvocationDependency
 	AgentConnections  map[string][]string
+	RouteStore        RouteStore
 }
 
 type Manager struct {
@@ -128,7 +130,8 @@ type Manager struct {
 	catalogConnection map[string]string
 	pluginInvokes     map[string][]invocation.PluginInvocationDependency
 	agentConnections  map[string][]string
-	// Route caches are process-local accelerators; providers remain the durable source of truth.
+	routeStore        RouteStore
+	// Route caches are process-local accelerators; the route store is the durable provider index.
 	routeMu       sync.Mutex
 	sessionRoutes agentRouteCache
 	turnRoutes    agentRouteCache
@@ -146,6 +149,7 @@ func New(cfg Config) *Manager {
 		catalogConnection: maps.Clone(cfg.CatalogConnection),
 		pluginInvokes:     invocation.ClonePluginInvocationDependencyMap(cfg.PluginInvokes),
 		agentConnections:  cloneStringSliceMap(cfg.AgentConnections),
+		routeStore:        cfg.RouteStore,
 		sessionRoutes:     newAgentRouteCache(),
 		turnRoutes:        newAgentRouteCache(),
 	}
@@ -162,20 +166,80 @@ func cloneStringSliceMap(src map[string][]string) map[string][]string {
 	return dst
 }
 
-func (m *Manager) cachedSessionRoute(sessionID string) string {
+func (m *Manager) cachedSessionRoute(sessionID string) (AgentRoute, bool) {
 	if m == nil {
-		return ""
+		return AgentRoute{}, false
 	}
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {
-		return ""
+		return AgentRoute{}, false
 	}
 	m.routeMu.Lock()
 	defer m.routeMu.Unlock()
 	return m.sessionRoutes.get(sessionID)
 }
 
-func (m *Manager) rememberSessionRoute(sessionID, providerName string) {
+func (m *Manager) storedSessionRoute(ctx context.Context, sessionID string) (AgentRoute, bool, error) {
+	if m == nil {
+		return AgentRoute{}, false, nil
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" || m.routeStore == nil {
+		return AgentRoute{}, false, nil
+	}
+	route, ok, err := m.routeStore.LookupSession(ctx, sessionID)
+	if err != nil || !ok {
+		return AgentRoute{}, false, err
+	}
+	route.SessionID = sessionID
+	return route, true, nil
+}
+
+func (m *Manager) rememberSessionRoute(ctx context.Context, sessionID, providerName string) error {
+	if m == nil {
+		return nil
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	providerName = strings.TrimSpace(providerName)
+	if sessionID == "" || providerName == "" {
+		return nil
+	}
+	if m.routeStore != nil {
+		if err := m.routeStore.RememberSession(ctx, sessionID, providerName); err != nil {
+			return err
+		}
+	}
+	m.rememberCachedSessionRoute(sessionID, providerName)
+	return nil
+}
+
+func (m *Manager) rememberSessionRouteBestEffort(ctx context.Context, sessionID, providerName string) {
+	if m == nil {
+		return
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	providerName = strings.TrimSpace(providerName)
+	if sessionID == "" || providerName == "" {
+		return
+	}
+	if m.routeStore == nil {
+		m.rememberCachedSessionRoute(sessionID, providerName)
+		return
+	}
+	if existing, ok, err := m.routeStore.LookupSession(ctx, sessionID); err != nil {
+		return
+	} else if ok {
+		if existing.ProviderName != providerName {
+			m.forgetCachedSessionRoute(sessionID, providerName)
+			return
+		}
+	} else if err := m.routeStore.RememberSession(ctx, sessionID, providerName); err != nil {
+		return
+	}
+	m.rememberCachedSessionRoute(sessionID, providerName)
+}
+
+func (m *Manager) rememberCachedSessionRoute(sessionID, providerName string) {
 	if m == nil {
 		return
 	}
@@ -186,10 +250,10 @@ func (m *Manager) rememberSessionRoute(sessionID, providerName string) {
 	}
 	m.routeMu.Lock()
 	defer m.routeMu.Unlock()
-	m.sessionRoutes.remember(sessionID, providerName)
+	m.sessionRoutes.remember(sessionID, AgentRoute{ProviderName: providerName, SessionID: sessionID})
 }
 
-func (m *Manager) forgetSessionRoute(sessionID, providerName string) {
+func (m *Manager) forgetCachedSessionRoute(sessionID, providerName string) {
 	if m == nil {
 		return
 	}
@@ -203,34 +267,114 @@ func (m *Manager) forgetSessionRoute(sessionID, providerName string) {
 	m.sessionRoutes.forget(sessionID, providerName)
 }
 
-func (m *Manager) cachedTurnRoute(turnID string) string {
+func (m *Manager) forgetSessionRoute(ctx context.Context, sessionID, providerName string) error {
 	if m == nil {
-		return ""
+		return nil
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	providerName = strings.TrimSpace(providerName)
+	if sessionID == "" {
+		return nil
+	}
+	if m.routeStore != nil {
+		if err := m.routeStore.ForgetSession(ctx, sessionID, providerName); err != nil {
+			return err
+		}
+	}
+	m.forgetCachedSessionRoute(sessionID, providerName)
+	return nil
+}
+
+func (m *Manager) cachedTurnRoute(turnID string) (AgentRoute, bool) {
+	if m == nil {
+		return AgentRoute{}, false
 	}
 	turnID = strings.TrimSpace(turnID)
 	if turnID == "" {
-		return ""
+		return AgentRoute{}, false
 	}
 	m.routeMu.Lock()
 	defer m.routeMu.Unlock()
 	return m.turnRoutes.get(turnID)
 }
 
-func (m *Manager) rememberTurnRoute(turnID, providerName string) {
+func (m *Manager) storedTurnRoute(ctx context.Context, turnID string) (AgentRoute, bool, error) {
+	if m == nil {
+		return AgentRoute{}, false, nil
+	}
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" || m.routeStore == nil {
+		return AgentRoute{}, false, nil
+	}
+	route, ok, err := m.routeStore.LookupTurn(ctx, turnID)
+	if err != nil || !ok {
+		return AgentRoute{}, false, err
+	}
+	return route, true, nil
+}
+
+func (m *Manager) rememberTurnRoute(ctx context.Context, turnID, sessionID, providerName string) error {
+	if m == nil {
+		return nil
+	}
+	turnID = strings.TrimSpace(turnID)
+	sessionID = strings.TrimSpace(sessionID)
+	providerName = strings.TrimSpace(providerName)
+	if turnID == "" || sessionID == "" || providerName == "" {
+		return nil
+	}
+	if m.routeStore != nil {
+		if err := m.routeStore.RememberTurn(ctx, turnID, sessionID, providerName); err != nil {
+			return err
+		}
+	}
+	m.rememberCachedTurnRoute(turnID, sessionID, providerName)
+	return nil
+}
+
+func (m *Manager) rememberTurnRouteBestEffort(ctx context.Context, turnID, sessionID, providerName string) {
 	if m == nil {
 		return
 	}
 	turnID = strings.TrimSpace(turnID)
+	sessionID = strings.TrimSpace(sessionID)
 	providerName = strings.TrimSpace(providerName)
-	if turnID == "" || providerName == "" {
+	if turnID == "" || sessionID == "" || providerName == "" {
+		return
+	}
+	if m.routeStore == nil {
+		m.rememberCachedTurnRoute(turnID, sessionID, providerName)
+		return
+	}
+	if existing, ok, err := m.routeStore.LookupTurn(ctx, turnID); err != nil {
+		return
+	} else if ok {
+		if existing.ProviderName != providerName || existing.SessionID != sessionID {
+			m.forgetCachedTurnRoute(turnID, providerName)
+			return
+		}
+	} else if err := m.routeStore.RememberTurn(ctx, turnID, sessionID, providerName); err != nil {
+		return
+	}
+	m.rememberCachedTurnRoute(turnID, sessionID, providerName)
+}
+
+func (m *Manager) rememberCachedTurnRoute(turnID, sessionID, providerName string) {
+	if m == nil {
+		return
+	}
+	turnID = strings.TrimSpace(turnID)
+	sessionID = strings.TrimSpace(sessionID)
+	providerName = strings.TrimSpace(providerName)
+	if turnID == "" || sessionID == "" || providerName == "" {
 		return
 	}
 	m.routeMu.Lock()
 	defer m.routeMu.Unlock()
-	m.turnRoutes.remember(turnID, providerName)
+	m.turnRoutes.remember(turnID, AgentRoute{ProviderName: providerName, SessionID: sessionID})
 }
 
-func (m *Manager) forgetTurnRoute(turnID, providerName string) {
+func (m *Manager) forgetCachedTurnRoute(turnID, providerName string) {
 	if m == nil {
 		return
 	}
@@ -244,6 +388,24 @@ func (m *Manager) forgetTurnRoute(turnID, providerName string) {
 	m.turnRoutes.forget(turnID, providerName)
 }
 
+func (m *Manager) forgetTurnRoute(ctx context.Context, turnID, providerName string) error {
+	if m == nil {
+		return nil
+	}
+	turnID = strings.TrimSpace(turnID)
+	providerName = strings.TrimSpace(providerName)
+	if turnID == "" {
+		return nil
+	}
+	if m.routeStore != nil {
+		if err := m.routeStore.ForgetTurn(ctx, turnID, providerName); err != nil {
+			return err
+		}
+	}
+	m.forgetCachedTurnRoute(turnID, providerName)
+	return nil
+}
+
 type agentRouteCache struct {
 	values map[string]*list.Element
 	order  *list.List
@@ -251,7 +413,7 @@ type agentRouteCache struct {
 
 type agentRouteEntry struct {
 	key   string
-	value string
+	value AgentRoute
 }
 
 func newAgentRouteCache() agentRouteCache {
@@ -270,19 +432,19 @@ func (c *agentRouteCache) ensure() {
 	}
 }
 
-func (c *agentRouteCache) get(key string) string {
+func (c *agentRouteCache) get(key string) (AgentRoute, bool) {
 	if c == nil || c.values == nil {
-		return ""
+		return AgentRoute{}, false
 	}
 	elem := c.values[key]
 	if elem == nil {
-		return ""
+		return AgentRoute{}, false
 	}
 	c.order.MoveToBack(elem)
-	return elem.Value.(agentRouteEntry).value
+	return elem.Value.(agentRouteEntry).value, true
 }
 
-func (c *agentRouteCache) remember(key, value string) {
+func (c *agentRouteCache) remember(key string, value AgentRoute) {
 	c.ensure()
 	if elem := c.values[key]; elem != nil {
 		elem.Value = agentRouteEntry{key: key, value: value}
@@ -303,7 +465,7 @@ func (c *agentRouteCache) forget(key, value string) {
 		return
 	}
 	entry := elem.Value.(agentRouteEntry)
-	if value != "" && entry.value != value {
+	if value != "" && strings.TrimSpace(entry.value.ProviderName) != value {
 		return
 	}
 	delete(c.values, key)
@@ -451,7 +613,9 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 	if !providerSessionOwnedBy(normalized, p) {
 		return nil, core.ErrNotFound
 	}
-	m.rememberSessionRoute(normalized.ID, providerName)
+	if err := m.rememberSessionRoute(ctx, normalized.ID, providerName); err != nil {
+		return nil, err
+	}
 	return normalized, nil
 }
 
@@ -514,7 +678,7 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 			if req.State != "" && normalized.State != req.State {
 				continue
 			}
-			m.rememberSessionRoute(normalized.ID, candidate.name)
+			m.rememberSessionRouteBestEffort(ctx, normalized.ID, candidate.name)
 			if req.SummaryOnly {
 				normalized = summarizeAgentSession(normalized)
 			}
@@ -563,7 +727,7 @@ func (m *Manager) UpdateSession(ctx context.Context, p *principal.Principal, req
 	if !providerSessionOwnedBy(normalized, p) {
 		return nil, core.ErrNotFound
 	}
-	m.rememberSessionRoute(normalized.ID, owned.providerName)
+	m.rememberSessionRouteBestEffort(ctx, normalized.ID, owned.providerName)
 	return normalized, nil
 }
 
@@ -578,6 +742,9 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	}
 	ownedSession, err := m.findOwnedSession(ctx, p, req.SessionID, "")
 	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return nil, fmt.Errorf("%w: %w", ErrAgentSessionNotFound, err)
+		}
 		return nil, err
 	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ownedSession.providerName))
@@ -655,7 +822,9 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	if !providerTurnOwnedBy(normalized, p) {
 		return nil, core.ErrNotFound
 	}
-	m.rememberTurnRoute(normalized.ID, ownedSession.providerName)
+	if err := m.rememberTurnRoute(ctx, normalized.ID, normalized.SessionID, ownedSession.providerName); err != nil {
+		return nil, err
+	}
 	return normalized, nil
 }
 
@@ -714,7 +883,7 @@ func (m *Manager) ListTurns(ctx context.Context, p *principal.Principal, req cor
 		if req.Status != "" && normalized.Status != req.Status {
 			continue
 		}
-		m.rememberTurnRoute(normalized.ID, ownedSession.providerName)
+		m.rememberTurnRouteBestEffort(ctx, normalized.ID, normalized.SessionID, ownedSession.providerName)
 		if req.SummaryOnly {
 			normalized = summarizeAgentTurn(normalized)
 		}
@@ -767,7 +936,7 @@ func (m *Manager) CancelTurn(ctx context.Context, p *principal.Principal, turnID
 			m.runGrants.RevokeTurn(owned.providerName, normalized.SessionID, executionRef)
 		}
 	}
-	m.rememberTurnRoute(normalized.ID, owned.providerName)
+	m.rememberTurnRouteBestEffort(ctx, normalized.ID, normalized.SessionID, owned.providerName)
 	return normalized, nil
 }
 
@@ -948,6 +1117,22 @@ func (m *Manager) authorizedProviderCandidates(ctx context.Context, p *principal
 	return authorized, nil
 }
 
+func (m *Manager) agentProviderConfigured(providerName string) bool {
+	if m == nil || m.agent == nil {
+		return false
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return false
+	}
+	for _, name := range m.agent.ProviderNames() {
+		if strings.TrimSpace(name) == providerName {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *Manager) findOwnedSession(ctx context.Context, p *principal.Principal, sessionID, providerName string) (*ownedAgentSession, error) {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {
@@ -959,25 +1144,47 @@ func (m *Manager) findOwnedSession(ctx context.Context, p *principal.Principal, 
 		if err != nil {
 			return nil, err
 		}
-		m.rememberSessionRoute(found.session.ID, found.providerName)
+		m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
 		return found, nil
 	}
-	if cachedProviderName := m.cachedSessionRoute(sessionID); cachedProviderName != "" {
-		found, err := m.findOwnedSessionInProviders(ctx, p, sessionID, cachedProviderName)
-		if err == nil {
-			m.rememberSessionRoute(found.session.ID, found.providerName)
+	if storedRoute, ok, err := m.storedSessionRoute(ctx, sessionID); err != nil {
+		return nil, err
+	} else if ok {
+		found, findErr := m.findOwnedSessionInProviders(ctx, p, sessionID, storedRoute.ProviderName)
+		if findErr == nil {
+			m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
 			return found, nil
 		}
-		if !errors.Is(err, core.ErrNotFound) {
+		if errors.Is(findErr, ErrAgentProviderNotAvailable) {
+			if m.agentProviderConfigured(storedRoute.ProviderName) {
+				return nil, findErr
+			}
+			if err := m.forgetSessionRoute(ctx, sessionID, storedRoute.ProviderName); err != nil {
+				return nil, err
+			}
+		} else if !errors.Is(findErr, core.ErrNotFound) {
+			return nil, findErr
+		}
+	}
+	if cachedRoute, ok := m.cachedSessionRoute(sessionID); ok {
+		found, err := m.findOwnedSessionInProviders(ctx, p, sessionID, cachedRoute.ProviderName)
+		if err == nil {
+			m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
+			return found, nil
+		}
+		m.forgetCachedSessionRoute(sessionID, cachedRoute.ProviderName)
+		if !errors.Is(err, core.ErrNotFound) && !errors.Is(err, ErrAgentProviderNotAvailable) {
 			return nil, err
 		}
-		m.forgetSessionRoute(sessionID, cachedProviderName)
+		if errors.Is(err, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(cachedRoute.ProviderName) {
+			_ = m.forgetSessionRoute(ctx, sessionID, cachedRoute.ProviderName)
+		}
 	}
 	found, err := m.findOwnedSessionInProviders(ctx, p, sessionID, "")
 	if err != nil {
 		return nil, err
 	}
-	m.rememberSessionRoute(found.session.ID, found.providerName)
+	m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
 	return found, nil
 }
 
@@ -1027,33 +1234,55 @@ func (m *Manager) findOwnedTurn(ctx context.Context, p *principal.Principal, tur
 	}
 	providerName = strings.TrimSpace(providerName)
 	if providerName != "" {
-		found, err := m.findOwnedTurnInProviders(ctx, p, turnID, providerName)
+		found, err := m.findOwnedTurnInProviders(ctx, p, turnID, providerName, "")
 		if err != nil {
 			return nil, err
 		}
-		m.rememberTurnRoute(found.turn.ID, found.providerName)
+		m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
 		return found, nil
 	}
-	if cachedProviderName := m.cachedTurnRoute(turnID); cachedProviderName != "" {
-		found, err := m.findOwnedTurnInProviders(ctx, p, turnID, cachedProviderName)
-		if err == nil {
-			m.rememberTurnRoute(found.turn.ID, found.providerName)
+	if storedRoute, ok, err := m.storedTurnRoute(ctx, turnID); err != nil {
+		return nil, err
+	} else if ok {
+		found, findErr := m.findOwnedTurnInProviders(ctx, p, turnID, storedRoute.ProviderName, storedRoute.SessionID)
+		if findErr == nil {
+			m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
 			return found, nil
 		}
-		if !errors.Is(err, core.ErrNotFound) {
+		if errors.Is(findErr, ErrAgentProviderNotAvailable) {
+			if m.agentProviderConfigured(storedRoute.ProviderName) {
+				return nil, findErr
+			}
+			if err := m.forgetTurnRoute(ctx, turnID, storedRoute.ProviderName); err != nil {
+				return nil, err
+			}
+		} else if !errors.Is(findErr, core.ErrNotFound) {
+			return nil, findErr
+		}
+	}
+	if cachedRoute, ok := m.cachedTurnRoute(turnID); ok {
+		found, err := m.findOwnedTurnInProviders(ctx, p, turnID, cachedRoute.ProviderName, cachedRoute.SessionID)
+		if err == nil {
+			m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
+			return found, nil
+		}
+		m.forgetCachedTurnRoute(turnID, cachedRoute.ProviderName)
+		if !errors.Is(err, core.ErrNotFound) && !errors.Is(err, ErrAgentProviderNotAvailable) {
 			return nil, err
 		}
-		m.forgetTurnRoute(turnID, cachedProviderName)
+		if errors.Is(err, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(cachedRoute.ProviderName) {
+			_ = m.forgetTurnRoute(ctx, turnID, cachedRoute.ProviderName)
+		}
 	}
-	found, err := m.findOwnedTurnInProviders(ctx, p, turnID, "")
+	found, err := m.findOwnedTurnInProviders(ctx, p, turnID, "", "")
 	if err != nil {
 		return nil, err
 	}
-	m.rememberTurnRoute(found.turn.ID, found.providerName)
+	m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
 	return found, nil
 }
 
-func (m *Manager) findOwnedTurnInProviders(ctx context.Context, p *principal.Principal, turnID, providerName string) (*ownedAgentTurn, error) {
+func (m *Manager) findOwnedTurnInProviders(ctx context.Context, p *principal.Principal, turnID, providerName, expectedSessionID string) (*ownedAgentTurn, error) {
 	candidates, err := m.authorizedProviderCandidates(ctx, p, providerName)
 	if err != nil {
 		return nil, err
@@ -1074,6 +1303,9 @@ func (m *Manager) findOwnedTurnInProviders(ctx context.Context, p *principal.Pri
 			continue
 		}
 		sessionID := strings.TrimSpace(turn.SessionID)
+		if expectedSessionID = strings.TrimSpace(expectedSessionID); expectedSessionID != "" {
+			sessionID = expectedSessionID
+		}
 		normalized, err := normalizeProviderTurn(candidate.name, sessionID, turnID, turn)
 		if err != nil {
 			return nil, err

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentgrant"
@@ -43,6 +44,26 @@ func newTestManager(t testing.TB, cfg Config) *Manager {
 		cfg.RunGrants = newAgentManagerTestRunGrants(t)
 	}
 	return New(cfg)
+}
+
+func newTestRouteStore(t testing.TB, db *coretesting.StubIndexedDB) RouteStore {
+	t.Helper()
+	store, err := NewIndexedDBRouteStore(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewIndexedDBRouteStore: %v", err)
+	}
+	return store
+}
+
+type alreadyExistsCreateIndexedDB struct {
+	*coretesting.StubIndexedDB
+}
+
+func (db *alreadyExistsCreateIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	if db.HasObjectStore(name) {
+		return indexeddb.ErrAlreadyExists
+	}
+	return db.StubIndexedDB.CreateObjectStore(ctx, name, schema)
 }
 
 type routeCountingAgentControl struct {
@@ -268,22 +289,22 @@ func TestAgentRouteCacheEvictsLeastRecentlyUsed(t *testing.T) {
 	t.Parallel()
 
 	var cache agentRouteCache
-	cache.remember("old", "alpha")
-	cache.remember("warm", "alpha")
-	if got := cache.get("old"); got != "alpha" {
-		t.Fatalf("cache.get(old) = %q, want alpha", got)
+	cache.remember("old", AgentRoute{ProviderName: "alpha", SessionID: "session-old"})
+	cache.remember("warm", AgentRoute{ProviderName: "alpha", SessionID: "session-warm"})
+	if got, ok := cache.get("old"); !ok || got.ProviderName != "alpha" {
+		t.Fatalf("cache.get(old) = %+v, %t, want alpha", got, ok)
 	}
-	cache.remember("new", "alpha")
+	cache.remember("new", AgentRoute{ProviderName: "alpha", SessionID: "session-new"})
 	cache.trim(2)
 
-	if got := cache.get("warm"); got != "" {
-		t.Fatalf("cache.get(warm) = %q, want evicted", got)
+	if got, ok := cache.get("warm"); ok {
+		t.Fatalf("cache.get(warm) = %+v, %t, want evicted", got, ok)
 	}
-	if got := cache.get("old"); got != "alpha" {
-		t.Fatalf("cache.get(old) = %q, want retained alpha", got)
+	if got, ok := cache.get("old"); !ok || got.ProviderName != "alpha" {
+		t.Fatalf("cache.get(old) = %+v, %t, want retained alpha", got, ok)
 	}
-	if got := cache.get("new"); got != "alpha" {
-		t.Fatalf("cache.get(new) = %q, want retained alpha", got)
+	if got, ok := cache.get("new"); !ok || got.ProviderName != "alpha" {
+		t.Fatalf("cache.get(new) = %+v, %t, want retained alpha", got, ok)
 	}
 }
 
@@ -346,6 +367,313 @@ func TestManagerCachesProviderRoutesForOwnedSessionAndTurn(t *testing.T) {
 	}
 	if alpha.getTurnCalls != 1 || beta.getTurnCalls != 0 {
 		t.Fatalf("GetTurn calls = alpha:%d beta:%d, want alpha:1 beta:0", alpha.getTurnCalls, beta.getTurnCalls)
+	}
+}
+
+func TestManagerUsesDurableProviderRoutesAcrossManagers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	alpha := newRouteCountingAgentProvider("alpha")
+	alpha.capabilities = &coreagent.ProviderCapabilities{
+		SupportedToolSources: []coreagent.ToolSourceMode{coreagent.ToolSourceModeMCPCatalog},
+	}
+	beta := newRouteCountingAgentProvider("beta")
+	control := &routeCountingAgentControl{
+		defaultName: "alpha",
+		names:       []string{"beta", "alpha"},
+		providers: map[string]*routeCountingAgentProvider{
+			"alpha": alpha,
+			"beta":  beta,
+		},
+	}
+	managerA := newTestManager(t, Config{
+		Agent:      control,
+		RunGrants:  newAgentManagerTestRunGrants(t),
+		RouteStore: newTestRouteStore(t, db),
+	})
+	managerB := newTestManager(t, Config{
+		Agent:      control,
+		RunGrants:  newAgentManagerTestRunGrants(t),
+		RouteStore: newTestRouteStore(t, db),
+	})
+	managerC := newTestManager(t, Config{
+		Agent:      control,
+		RunGrants:  newAgentManagerTestRunGrants(t),
+		RouteStore: newTestRouteStore(t, db),
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := managerA.CreateSession(ctx, p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	alpha.getSessionCalls = 0
+	beta.getSessionCalls = 0
+	turn, err := managerB.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn(cold manager): %v", err)
+	}
+	if alpha.getSessionCalls != 1 || beta.getSessionCalls != 0 {
+		t.Fatalf("CreateTurn session lookup calls = alpha:%d beta:%d, want alpha:1 beta:0", alpha.getSessionCalls, beta.getSessionCalls)
+	}
+
+	alpha.getTurnCalls = 0
+	beta.getTurnCalls = 0
+	if _, err := managerC.GetTurn(ctx, p, turn.ID); err != nil {
+		t.Fatalf("GetTurn(cold manager): %v", err)
+	}
+	if alpha.getTurnCalls != 1 || beta.getTurnCalls != 0 {
+		t.Fatalf("GetTurn calls = alpha:%d beta:%d, want alpha:1 beta:0", alpha.getTurnCalls, beta.getTurnCalls)
+	}
+}
+
+func TestManagerWrongPrincipalDoesNotDeleteDurableSessionRoute(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	routeStore := newTestRouteStore(t, db)
+	alpha := newRouteCountingAgentProvider("alpha")
+	control := &routeCountingAgentControl{
+		defaultName: "alpha",
+		names:       []string{"alpha"},
+		providers: map[string]*routeCountingAgentProvider{
+			"alpha": alpha,
+		},
+	}
+	managerA := newTestManager(t, Config{Agent: control, RouteStore: routeStore})
+	managerB := newTestManager(t, Config{Agent: control, RouteStore: newTestRouteStore(t, db)})
+	managerC := newTestManager(t, Config{Agent: control, RouteStore: newTestRouteStore(t, db)})
+	owner := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	other := &principal.Principal{SubjectID: principal.UserSubjectID("user-2")}
+
+	session, err := managerA.CreateSession(ctx, owner, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := managerB.GetSession(ctx, other, session.ID); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetSession(wrong principal) error = %v, want not found", err)
+	}
+	route, ok, err := routeStore.LookupSession(ctx, session.ID)
+	if err != nil {
+		t.Fatalf("LookupSession: %v", err)
+	}
+	if !ok || route.ProviderName != "alpha" {
+		t.Fatalf("LookupSession route = %+v, %t, want alpha", route, ok)
+	}
+	if _, err := managerC.GetSession(ctx, owner, session.ID); err != nil {
+		t.Fatalf("GetSession(owner after wrong principal): %v", err)
+	}
+}
+
+func TestManagerDurableTurnRouteValidatesStoredSessionID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	routeStore := newTestRouteStore(t, db)
+	alpha := newRouteCountingAgentProvider("alpha")
+	control := &routeCountingAgentControl{
+		defaultName: "alpha",
+		names:       []string{"alpha"},
+		providers: map[string]*routeCountingAgentProvider{
+			"alpha": alpha,
+		},
+	}
+	managerA := newTestManager(t, Config{Agent: control, RouteStore: routeStore})
+	managerB := newTestManager(t, Config{Agent: control, RouteStore: newTestRouteStore(t, db)})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := managerA.CreateSession(ctx, p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	turn, err := managerA.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if err := routeStore.RememberTurn(ctx, turn.ID, "wrong-session", "alpha"); err != nil {
+		t.Fatalf("RememberTurn(wrong session): %v", err)
+	}
+	_, err = managerB.GetTurn(ctx, p, turn.ID)
+	if err == nil || !strings.Contains(err.Error(), `turn session id`) || !strings.Contains(err.Error(), `wrong-session`) {
+		t.Fatalf("GetTurn error = %v, want turn session id mismatch", err)
+	}
+}
+
+func TestManagerDurableRoutesBeatStaleProcessCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	routeStore := newTestRouteStore(t, db)
+	alpha := newRouteCountingAgentProvider("alpha")
+	beta := newRouteCountingAgentProvider("beta")
+	control := &routeCountingAgentControl{
+		defaultName: "alpha",
+		names:       []string{"alpha", "beta"},
+		providers: map[string]*routeCountingAgentProvider{
+			"alpha": alpha,
+			"beta":  beta,
+		},
+	}
+	managerA := newTestManager(t, Config{Agent: control, RouteStore: routeStore})
+	managerB := newTestManager(t, Config{Agent: control, RouteStore: newTestRouteStore(t, db)})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := managerA.CreateSession(ctx, p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	turn, err := managerA.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := managerB.GetSession(ctx, p, session.ID); err != nil {
+		t.Fatalf("GetSession(warm stale cache): %v", err)
+	}
+	if _, err := managerB.GetTurn(ctx, p, turn.ID); err != nil {
+		t.Fatalf("GetTurn(warm stale cache): %v", err)
+	}
+
+	beta.sessions[session.ID] = cloneRouteSession(session)
+	beta.sessions[session.ID].ProviderName = "beta"
+	beta.turns[turn.ID] = cloneRouteTurn(turn)
+	beta.turns[turn.ID].ProviderName = "beta"
+	if err := routeStore.RememberSession(ctx, session.ID, "beta"); err != nil {
+		t.Fatalf("RememberSession(beta): %v", err)
+	}
+	if err := routeStore.RememberTurn(ctx, turn.ID, session.ID, "beta"); err != nil {
+		t.Fatalf("RememberTurn(beta): %v", err)
+	}
+
+	alpha.getSessionCalls = 0
+	beta.getSessionCalls = 0
+	fetchedSession, err := managerB.GetSession(ctx, p, session.ID)
+	if err != nil {
+		t.Fatalf("GetSession(after durable route update): %v", err)
+	}
+	if fetchedSession.ProviderName != "beta" {
+		t.Fatalf("GetSession provider = %q, want beta", fetchedSession.ProviderName)
+	}
+	if alpha.getSessionCalls != 0 || beta.getSessionCalls != 1 {
+		t.Fatalf("GetSession calls = alpha:%d beta:%d, want alpha:0 beta:1", alpha.getSessionCalls, beta.getSessionCalls)
+	}
+
+	alpha.getTurnCalls = 0
+	beta.getTurnCalls = 0
+	fetchedTurn, err := managerB.GetTurn(ctx, p, turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn(after durable route update): %v", err)
+	}
+	if fetchedTurn.ProviderName != "beta" {
+		t.Fatalf("GetTurn provider = %q, want beta", fetchedTurn.ProviderName)
+	}
+	if alpha.getTurnCalls != 0 || beta.getTurnCalls != 1 {
+		t.Fatalf("GetTurn calls = alpha:%d beta:%d, want alpha:0 beta:1", alpha.getTurnCalls, beta.getTurnCalls)
+	}
+}
+
+func TestManagerStaleDurableRouteDoesNotPopulateProcessCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	routeStore := newTestRouteStore(t, db)
+	alpha := newRouteCountingAgentProvider("alpha")
+	control := &routeCountingAgentControl{
+		defaultName: "alpha",
+		names:       []string{"alpha"},
+		providers: map[string]*routeCountingAgentProvider{
+			"alpha": alpha,
+		},
+	}
+	manager := newTestManager(t, Config{Agent: control, RouteStore: routeStore})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	if err := routeStore.RememberSession(ctx, "missing-session", "alpha"); err != nil {
+		t.Fatalf("RememberSession: %v", err)
+	}
+	if err := routeStore.RememberTurn(ctx, "missing-turn", "missing-session", "alpha"); err != nil {
+		t.Fatalf("RememberTurn: %v", err)
+	}
+
+	if _, err := manager.GetSession(ctx, p, "missing-session"); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetSession error = %v, want not found", err)
+	}
+	if route, ok := manager.cachedSessionRoute("missing-session"); ok {
+		t.Fatalf("cachedSessionRoute = %+v, want none", route)
+	}
+	if _, err := manager.GetTurn(ctx, p, "missing-turn"); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetTurn error = %v, want not found", err)
+	}
+	if route, ok := manager.cachedTurnRoute("missing-turn"); ok {
+		t.Fatalf("cachedTurnRoute = %+v, want none", route)
+	}
+}
+
+func TestManagerBestEffortRoutesDoNotCacheDurableConflicts(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	routeStore := newTestRouteStore(t, db)
+	manager := newTestManager(t, Config{RouteStore: routeStore})
+	if err := routeStore.RememberSession(ctx, "session-1", "beta"); err != nil {
+		t.Fatalf("RememberSession: %v", err)
+	}
+	if err := routeStore.RememberTurn(ctx, "turn-1", "session-1", "beta"); err != nil {
+		t.Fatalf("RememberTurn: %v", err)
+	}
+	manager.rememberCachedSessionRoute("session-1", "alpha")
+	manager.rememberCachedTurnRoute("turn-1", "session-1", "alpha")
+
+	manager.rememberSessionRouteBestEffort(ctx, "session-1", "alpha")
+	manager.rememberTurnRouteBestEffort(ctx, "turn-1", "session-1", "alpha")
+
+	if route, ok := manager.cachedSessionRoute("session-1"); ok {
+		t.Fatalf("cachedSessionRoute = %+v, want none", route)
+	}
+	if route, ok := manager.cachedTurnRoute("turn-1"); ok {
+		t.Fatalf("cachedTurnRoute = %+v, want none", route)
+	}
+}
+
+func TestIndexedDBRouteStoreAcceptsExistingObjectStores(t *testing.T) {
+	t.Parallel()
+
+	db := &alreadyExistsCreateIndexedDB{StubIndexedDB: &coretesting.StubIndexedDB{}}
+	if _, err := NewIndexedDBRouteStore(context.Background(), db); err != nil {
+		t.Fatalf("NewIndexedDBRouteStore(first): %v", err)
+	}
+	if _, err := NewIndexedDBRouteStore(context.Background(), db); err != nil {
+		t.Fatalf("NewIndexedDBRouteStore(existing stores): %v", err)
 	}
 }
 

--- a/gestaltd/services/agents/agentmanager/route_store.go
+++ b/gestaltd/services/agents/agentmanager/route_store.go
@@ -1,0 +1,17 @@
+package agentmanager
+
+import "context"
+
+type AgentRoute struct {
+	ProviderName string
+	SessionID    string
+}
+
+type RouteStore interface {
+	LookupSession(ctx context.Context, sessionID string) (AgentRoute, bool, error)
+	RememberSession(ctx context.Context, sessionID, providerName string) error
+	ForgetSession(ctx context.Context, sessionID, providerName string) error
+	LookupTurn(ctx context.Context, turnID string) (AgentRoute, bool, error)
+	RememberTurn(ctx context.Context, turnID, sessionID, providerName string) error
+	ForgetTurn(ctx context.Context, turnID, providerName string) error
+}


### PR DESCRIPTION
## Summary

Adds a minimal durable route index for agent sessions and turns so `gestaltd` can route follow-up agent RPCs to the provider that owns the session/turn across Cloud Run replicas. The durable state is intentionally only routing metadata:

- `agent_session_routes`: `id`, `provider`
- `agent_turn_routes`: `id`, `session_id`, `provider`

Provider-owned session/turn state remains behind the existing agent provider protobuf methods.

## Interface Changes

- New internal `agentmanager.RouteStore` interface:
  - `LookupSession`, `RememberSession`, `ForgetSession`
  - `LookupTurn`, `RememberTurn`, `ForgetTurn`
- New `agentmanager.NewIndexedDBRouteStore(ctx, db)` backed by the selected host IndexedDB.
- `agentmanager.Config` now accepts `RouteStore`.
- Bootstrap creates the route store on the selected IndexedDB and passes it into the agent manager.

Example runtime flow:

```text
CreateSession -> provider.CreateSession -> RememberSession(session_id, provider)
CreateTurn    -> durable session route -> provider.CreateTurn -> RememberTurn(turn_id, session_id, provider)
GetTurn       -> durable route, then process cache, then authorized scan
```

Create-path route writes are mandatory. Read/list route warming is best-effort and does not overwrite a different durable route. Subject-scoped `NOT_FOUND` does not delete durable routes; a route is only forgotten when the routed provider is no longer configured. Existing route stores are accepted during bootstrap so replica/restart provisioning is idempotent across IndexedDB backends.

Also fixes create-turn 404 reporting so a missing session path reports `session "..." not found` rather than `turn "..." not found`.

## Functional/Integration Tests

- Tests added or augmented:
  - manager route-store contract tests with shared IndexedDB across cold manager instances
  - wrong-principal route preservation test
  - durable route beats stale process cache test
  - durable turn route session-id validation test
  - existing route-store object stores are accepted
  - bootstrap test provisioning route stores on selected IndexedDB
  - HTTP create-turn missing-session error-shape test
- Contract boundary covered:
  - manager/provider routing across process-local cache boundaries
  - bootstrap IndexedDB provisioning
  - HTTP API error mapping
- Commands run:
  - `go test ./services/agents/agentmanager ./internal/bootstrap ./internal/server`
  - `go test ./...`
  - `git diff --check`

## Stack / Follow-up

Pairs with valon-technologies/gestalt-providers#531, which moves `agent/claude` session and turn storage from process memory to provider-owned IndexedDB storage. This PR is the `gestaltd` durable routing half of the cross-replica fix.
