### PR TITLE
Guard docs SSL certificate replacement

### DIFF
--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -93,6 +93,10 @@ resource "google_compute_managed_ssl_certificate" "docs" {
 
   lifecycle {
     create_before_destroy = true
+    # A newly-created Google-managed certificate can be provisioned in Terraform
+    # before it is actually served at the edge. Refuse certificate replacement
+    # plans so domain changes cannot detach the active certificate first.
+    prevent_destroy = true
   }
 }
 


### PR DESCRIPTION
## Summary
- add a Terraform guard so the docs managed SSL certificate cannot be destroyed during domain changes
- documents why Google-managed certificate replacement can briefly leave the HTTPS proxy without an edge-served certificate

## Validation
- terraform -chdir=docs/terraform fmt -check
- terraform -chdir=docs/terraform init -backend=false
- terraform -chdir=docs/terraform validate
- git diff --check
- curl -I https://gestaltd.ai/registry
- curl -I https://registry.gestaltd.ai/providers/plugin/slack/