### PR TITLE
Surface stale OAuth credentials as reconnect required

### DIFF
--- a/gestaltd/internal/server/connection_status.go
+++ b/gestaltd/internal/server/connection_status.go
@@ -61,6 +61,9 @@ func (s *Server) defaultIntegrationStatus(info *integrationInfo, prov core.Provi
 	if info == nil {
 		return unknownConnectionStatus()
 	}
+	if status, ok := summarizeReconnectRequiredConnectionStatuses(info.Connections); ok {
+		return status
+	}
 	if conn, ok := info.connectionStatusForDefaultTarget(s.defaultConnectionName(info.Name)); ok {
 		return statusFromConnectionInfo(conn)
 	}
@@ -188,6 +191,9 @@ func summarizeConnectionStatuses(connections []connectionDefInfo) connectionStat
 	if len(connections) == 0 {
 		return unknownConnectionStatus()
 	}
+	if status, ok := summarizeReconnectRequiredConnectionStatuses(connections); ok {
+		return status
+	}
 	for i := range connections {
 		conn := &connections[i]
 		if conn.Status == connectionStatusNeedsInstanceSelection {
@@ -245,6 +251,49 @@ func summarizeConnectionStatuses(connections []connectionDefInfo) connectionStat
 	return unknownConnectionStatus()
 }
 
+func summarizeReconnectRequiredConnectionStatuses(connections []connectionDefInfo) (connectionStatusInfo, bool) {
+	if len(connections) == 0 {
+		return connectionStatusInfo{}, false
+	}
+	var (
+		invalidStatus *connectionDefInfo
+		hasConnected  bool
+	)
+	for i := range connections {
+		conn := &connections[i]
+		if conn.Status == connectionStatusDegraded {
+			return statusFromConnectionInfo(conn), true
+		}
+		if conn.CredentialState == credentialStateInvalid || conn.StatusCode == "reconnect_required" {
+			if invalidStatus == nil {
+				invalidStatus = conn
+			}
+			continue
+		}
+		if conn.connected || conn.Status == connectionStatusReady || conn.CredentialState == credentialStateConnected || conn.CredentialState == credentialStateConfigured {
+			hasConnected = true
+		}
+	}
+	if invalidStatus == nil {
+		return connectionStatusInfo{}, false
+	}
+	if hasConnected {
+		return connectionStatusInfo{
+			Status:          connectionStatusDegraded,
+			CredentialState: credentialStateInvalid,
+			HealthState:     healthStateUnhealthy,
+			Actions:         []string{},
+			CredentialMode:  invalidStatus.CredentialMode,
+			OwnerKind:       invalidStatus.OwnerKind,
+			Disconnectable:  invalidStatus.disconnectable,
+			Connected:       true,
+			StatusCode:      "reconnect_required",
+			StatusReason:    "one or more stored credentials are expired and refresh has failed; reconnect them",
+		}, true
+	}
+	return statusFromConnectionInfo(invalidStatus), true
+}
+
 func unknownConnectionStatus() connectionStatusInfo {
 	return connectionStatusInfo{
 		Status:          connectionStatusUnknown,
@@ -300,6 +349,8 @@ func subjectConnectionStatus(instances []instanceInfo, connectable bool, ownerKi
 		Actions:        []string{},
 		Connected:      false,
 	}
+	invalidCount := invalidInstanceCount(instances)
+	validCount := len(instances) - invalidCount
 	switch len(instances) {
 	case 0:
 		status.Status = connectionStatusNeedsUserConnection
@@ -307,24 +358,76 @@ func subjectConnectionStatus(instances []instanceInfo, connectable bool, ownerKi
 		if connectable {
 			status.Actions = []string{actionConnect}
 		}
-	case 1:
-		status.Status = connectionStatusReady
-		status.CredentialState = credentialStateConnected
-		status.HealthState = healthStateNotChecked
-		status.Disconnectable = true
-		status.Connected = true
-		status.Actions = subjectConnectionActions(true, connectable, false)
 	default:
-		status.Status = connectionStatusNeedsInstanceSelection
-		status.CredentialState = credentialStateConnected
-		status.HealthState = healthStateNotChecked
-		status.Disconnectable = true
-		status.Connected = true
-		status.Actions = subjectConnectionActions(true, connectable, true)
-		status.StatusCode = "instance_selection_required"
-		status.StatusReason = "multiple connected instances require explicit instance selection"
+		switch {
+		case invalidCount == 0 && len(instances) == 1:
+			status.Status = connectionStatusReady
+			status.CredentialState = credentialStateConnected
+			status.HealthState = healthStateNotChecked
+			status.Disconnectable = true
+			status.Connected = true
+			status.Actions = subjectConnectionActions(true, connectable, false)
+		case invalidCount == 0:
+			status.Status = connectionStatusNeedsInstanceSelection
+			status.CredentialState = credentialStateConnected
+			status.HealthState = healthStateNotChecked
+			status.Disconnectable = true
+			status.Connected = true
+			status.Actions = subjectConnectionActions(true, connectable, true)
+			status.StatusCode = "instance_selection_required"
+			status.StatusReason = "multiple connected instances require explicit instance selection"
+		case validCount == 0:
+			status.Status = connectionStatusNeedsUserConnection
+			status.CredentialState = credentialStateInvalid
+			status.HealthState = healthStateUnhealthy
+			status.Disconnectable = true
+			status.Connected = false
+			status.Actions = reconnectStatusActions(instances, connectable, true, false)
+			status.StatusCode = "reconnect_required"
+			status.StatusReason = "stored credential is expired and refresh has failed; reconnect it"
+		default:
+			status.Status = connectionStatusDegraded
+			status.CredentialState = credentialStateInvalid
+			status.HealthState = healthStateUnhealthy
+			status.Disconnectable = true
+			status.Connected = true
+			status.Actions = reconnectStatusActions(instances, connectable, true, connectable)
+			status.StatusCode = "reconnect_required"
+			status.StatusReason = "one or more stored credentials are expired and refresh has failed; reconnect them"
+		}
 	}
 	return status
+}
+
+func invalidInstanceCount(instances []instanceInfo) int {
+	count := 0
+	for _, instance := range instances {
+		if instance.credentialInvalid {
+			count++
+		}
+	}
+	return count
+}
+
+func reconnectStatusActions(instances []instanceInfo, reconnectable, disconnectable, addInstance bool) []string {
+	var actions []string
+	if len(instances) > 1 {
+		actions = append(actions, actionSelectInstance)
+	}
+	if reconnectable && reconnectTargetsDefaultInstance(instances) {
+		actions = append(actions, actionReconnect)
+	}
+	if disconnectable {
+		actions = append(actions, actionDisconnect)
+	}
+	if addInstance {
+		actions = append(actions, actionAddInstance)
+	}
+	return actions
+}
+
+func reconnectTargetsDefaultInstance(instances []instanceInfo) bool {
+	return len(instances) == 1 && instances[0].Name == defaultTokenInstance
 }
 
 func subjectConnectionActions(disconnectable, connectable, selectInstance bool) []string {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -52,6 +52,8 @@ var (
 type instanceInfo struct {
 	Name       string `json:"name"`
 	Connection string `json:"connection,omitempty"`
+
+	credentialInvalid bool
 }
 
 type credentialFieldInfo struct {
@@ -249,19 +251,29 @@ func (s *Server) connectedIntegrationsForSubject(ctx context.Context, subjectID 
 	if err != nil {
 		return nil, fmt.Errorf("listing external credentials: %w", err)
 	}
+	now := time.Now()
 	m := make(map[string][]instanceInfo, len(tokens))
 	for _, tok := range tokens {
 		if tok == nil {
 			continue
 		}
+		credentialInvalid := credentialNeedsReconnect(tok, now)
 		for _, binding := range s.pluginConnectionBindingsForCredentialID(tok.ConnectionID) {
 			m[binding.Plugin] = append(m[binding.Plugin], instanceInfo{
-				Name:       tok.Instance,
-				Connection: userFacingConnectionName(binding.Connection),
+				Name:              tok.Instance,
+				Connection:        userFacingConnectionName(binding.Connection),
+				credentialInvalid: credentialInvalid,
 			})
 		}
 	}
 	return m, nil
+}
+
+func credentialNeedsReconnect(credential *core.ExternalCredential, now time.Time) bool {
+	if credential == nil || credential.ExpiresAt == nil || credential.RefreshErrorCount <= 0 {
+		return false
+	}
+	return !credential.ExpiresAt.After(now)
 }
 
 type pluginConnectionBinding struct {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -9554,6 +9554,158 @@ func TestListIntegrations_ConnectionStatusContract(t *testing.T) {
 	}
 }
 
+func TestListIntegrations_StaleRefreshFailuresRequireReconnect(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	subjectID := principal.UserSubjectID(u.ID)
+	past := time.Now().Add(-1 * time.Hour)
+	future := time.Now().Add(1 * time.Hour)
+
+	seedStatusToken := func(integration, connection, instance string, expiresAt *time.Time, refreshErrors int) {
+		t.Helper()
+		seedToken(t, svc, &core.ExternalCredential{
+			ID:                integration + "-" + connection + "-" + instance,
+			SubjectID:         subjectID,
+			ConnectionID:      integration + ":" + config.ResolveConnectionAlias(connection),
+			Integration:       integration,
+			Connection:        connection,
+			Instance:          instance,
+			AccessToken:       integration + "-" + instance + "-access-token",
+			RefreshToken:      integration + "-" + instance + "-refresh-token",
+			ExpiresAt:         expiresAt,
+			RefreshErrorCount: refreshErrors,
+		})
+	}
+
+	seedStatusToken("expired-failed", testDefaultConnection, "default", &past, 2)
+	seedStatusToken("expired-untried", testDefaultConnection, "default", &past, 0)
+	seedStatusToken("unexpired-error", testDefaultConnection, "default", &future, 3)
+	seedStatusToken("mixed", testDefaultConnection, "valid", &future, 0)
+	seedStatusToken("mixed", testDefaultConnection, "stale", &past, 1)
+	seedStatusToken("all-invalid-multi", testDefaultConnection, "stale-a", &past, 1)
+	seedStatusToken("all-invalid-multi", testDefaultConnection, "stale-b", &past, 3)
+	seedStatusToken("named-stale", testDefaultConnection, "default", &future, 0)
+	seedStatusToken("named-stale", "archive", "archive", &past, 1)
+
+	providers := testutil.NewProviderRegistry(t,
+		&stubManualProvider{StubIntegration: coretesting.StubIntegration{N: "expired-failed", DN: "Expired Failed"}},
+		&stubManualProvider{StubIntegration: coretesting.StubIntegration{N: "expired-untried", DN: "Expired Untried"}},
+		&stubManualProvider{StubIntegration: coretesting.StubIntegration{N: "unexpired-error", DN: "Unexpired Error"}},
+		&stubManualProvider{StubIntegration: coretesting.StubIntegration{N: "mixed", DN: "Mixed"}},
+		&stubManualProvider{StubIntegration: coretesting.StubIntegration{N: "all-invalid-multi", DN: "All Invalid Multi"}},
+		&stubManualProvider{StubIntegration: coretesting.StubIntegration{N: "named-stale", DN: "Named Stale"}},
+	)
+	pluginDefs := map[string]*config.ProviderEntry{}
+	for _, name := range []string{"expired-failed", "expired-untried", "unexpired-error", "mixed", "all-invalid-multi"} {
+		pluginDefs[name] = testPluginDefsForConnections(name, testDefaultConnection)[name]
+	}
+	pluginDefs["named-stale"] = &config.ProviderEntry{
+		Connections: map[string]*config.ConnectionDef{
+			testDefaultConnection: {
+				ConnectionID: "named-stale:" + testDefaultConnection,
+				Mode:         providermanifestv1.ConnectionModeUser,
+			},
+			"archive": {
+				ConnectionID: "named-stale:archive",
+				Mode:         providermanifestv1.ConnectionModeUser,
+			},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.PluginDefs = pluginDefs
+		cfg.Services = svc
+		cfg.DefaultConnection = map[string]string{"named-stale": testDefaultConnection}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	type statusConnection struct {
+		Name            string           `json:"name"`
+		Status          string           `json:"status"`
+		CredentialState string           `json:"credentialState"`
+		HealthState     string           `json:"healthState"`
+		Actions         []string         `json:"actions"`
+		Instances       []map[string]any `json:"instances"`
+		StatusCode      string           `json:"statusCode"`
+	}
+	type statusIntegration struct {
+		Name            string             `json:"name"`
+		Connections     []statusConnection `json:"connections"`
+		Status          string             `json:"status"`
+		CredentialState string             `json:"credentialState"`
+		HealthState     string             `json:"healthState"`
+		Actions         []string           `json:"actions"`
+	}
+	var integrations []statusIntegration
+	if err := json.Unmarshal(body, &integrations); err != nil {
+		t.Fatalf("decode integrations: %v (body: %s)", err, body)
+	}
+	got := make(map[string]statusIntegration, len(integrations))
+	for _, integration := range integrations {
+		got[integration.Name] = integration
+	}
+
+	assertStatus := func(name, status, credentialState, healthState string, actions []string) statusIntegration {
+		t.Helper()
+		integration, ok := got[name]
+		if !ok {
+			t.Fatalf("integration %q missing from response: %s", name, body)
+		}
+		if integration.Status != status || integration.CredentialState != credentialState || integration.HealthState != healthState || !reflect.DeepEqual(integration.Actions, actions) {
+			t.Fatalf("%s status = {status:%q credential:%q health:%q actions:%v}, want {%q %q %q %v}",
+				name, integration.Status, integration.CredentialState, integration.HealthState, integration.Actions,
+				status, credentialState, healthState, actions)
+		}
+		return integration
+	}
+	assertConnection := func(integration statusIntegration, connection, status, credentialState, healthState, statusCode string, actions []string) statusConnection {
+		t.Helper()
+		for _, conn := range integration.Connections {
+			if conn.Name != connection {
+				continue
+			}
+			if conn.Status != status || conn.CredentialState != credentialState || conn.HealthState != healthState || conn.StatusCode != statusCode || !reflect.DeepEqual(conn.Actions, actions) {
+				t.Fatalf("%s/%s connection = {status:%q credential:%q health:%q code:%q actions:%v}, want {%q %q %q %q %v}",
+					integration.Name, connection, conn.Status, conn.CredentialState, conn.HealthState, conn.StatusCode, conn.Actions,
+					status, credentialState, healthState, statusCode, actions)
+			}
+			return conn
+		}
+		t.Fatalf("%s connection %q missing: %+v", integration.Name, connection, integration.Connections)
+		return statusConnection{}
+	}
+
+	expiredFailed := assertStatus("expired-failed", "needs_user_connection", "invalid", "unhealthy", []string{"reconnect", "disconnect"})
+	assertConnection(expiredFailed, testDefaultConnection, "needs_user_connection", "invalid", "unhealthy", "reconnect_required", []string{"reconnect", "disconnect"})
+	assertStatus("expired-untried", "ready", "connected", "not_checked", []string{"disconnect", "add_instance"})
+	assertStatus("unexpired-error", "ready", "connected", "not_checked", []string{"disconnect", "add_instance"})
+	mixed := assertStatus("mixed", "degraded", "invalid", "unhealthy", []string{"select_instance", "disconnect", "add_instance"})
+	assertConnection(mixed, testDefaultConnection, "degraded", "invalid", "unhealthy", "reconnect_required", []string{"select_instance", "disconnect", "add_instance"})
+	allInvalid := assertStatus("all-invalid-multi", "needs_user_connection", "invalid", "unhealthy", []string{"select_instance", "disconnect"})
+	assertConnection(allInvalid, testDefaultConnection, "needs_user_connection", "invalid", "unhealthy", "reconnect_required", []string{"select_instance", "disconnect"})
+	namedStale := assertStatus("named-stale", "degraded", "invalid", "unhealthy", []string{})
+	assertConnection(namedStale, testDefaultConnection, "ready", "connected", "not_checked", "", []string{"disconnect", "add_instance"})
+	assertConnection(namedStale, "archive", "needs_user_connection", "invalid", "unhealthy", "reconnect_required", []string{"disconnect"})
+}
+
 func TestListIntegrations_AuthTypes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Classifies retained subject credentials with `expires_at <= now` and `refresh_error_count > 0` as reconnect-required instead of connected.
- Adds invalid/degraded status aggregation so stale named connections are not hidden by a healthy default connection.
- Preserves existing ready/connected behavior for valid rows, expired rows with no refresh failure, and unexpired rows with previous transient errors.

## Interface Changes
- New/changed interface: `/api/v1/integrations` can now return `credentialState: "invalid"`, `healthState: "unhealthy"`, and `statusCode: "reconnect_required"` for retained stale credentials. The `reconnect` action is emitted only when the stale target is an unambiguous single `default` instance; multi-instance and non-default stale rows stay invalid/degraded without advertising a misleading one-click reconnect target.
- Example usage: `GET /api/v1/integrations` for a stale default Gmail row now reports reconnect-required instead of `ready`/`connected`.

## Functional/Integration Tests
- Tests added or augmented: `TestListIntegrations_StaleRefreshFailuresRequireReconnect`.
- Contract boundary covered: HTTP `/api/v1/integrations` response contract with seeded external credential metadata.
- Commands run: `GOWORK=off go test ./internal/server -run 'TestListIntegrations_ConnectionStatusContract|TestListIntegrations_StaleRefreshFailuresRequireReconnect|TestListIntegrationsShowsConnected' -count=1`; `GOWORK=off go test ./internal/server -count=1`.

Follow-up: after the external credential provider fix is released, `valon-tools/deploy` should update its gestaltd refs and provider lock to roll this into `valon.tools`.