### PR TITLE
Select relevant default agent catalog tools

### DIFF
--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -49,6 +49,7 @@ const (
 	agentToolListDefaultPageSize = 100
 	agentToolListMaxPageSize     = 1000
 	agentToolSchemaMaxBytes      = 128 * 1024
+	agentDefaultCatalogToolRefs  = 80
 	maxAgentRouteCacheEntries    = 20_000
 	AgentListSummaryDefaultLimit = 100
 	AgentListMaxLimit            = 500
@@ -766,6 +767,9 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	if toolSource == coreagent.ToolSourceModeUnspecified && len(toolRefs) == 0 && !req.ToolRefsSet && defaultAgentTurnToolSource(ctx, ownedSession.provider) == coreagent.ToolSourceModeMCPCatalog {
 		toolSource = coreagent.ToolSourceModeMCPCatalog
 		toolRefs = []coreagent.ToolRef{{Plugin: agentToolSearchAllPlugin}}
+		if refinedRefs, err := m.defaultAgentTurnCatalogToolRefs(ctx, p, req.Messages); err == nil && len(refinedRefs) > 0 {
+			toolRefs = refinedRefs
+		}
 	}
 	var tools []coreagent.Tool
 	if toolSource == coreagent.ToolSourceModeMCPCatalog {
@@ -826,6 +830,87 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 		return nil, err
 	}
 	return normalized, nil
+}
+
+func (m *Manager) defaultAgentTurnCatalogToolRefs(ctx context.Context, p *principal.Principal, messages []coreagent.Message) ([]coreagent.ToolRef, error) {
+	query := agentTurnToolSearchQuery(messages)
+	if query == "" {
+		return nil, nil
+	}
+	if m == nil || m.providers == nil {
+		return nil, nil
+	}
+	candidates, unavailable, err := m.searchToolCandidates(ctx, p, []coreagent.ToolRef{{Plugin: agentToolSearchAllPlugin}}, query, true)
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]coreagent.ToolRef, 0, min(agentDefaultCatalogToolRefs, len(candidates)+len(unavailable)))
+	seen := map[agentToolTargetKey]struct{}{}
+	appendRef := func(ref coreagent.ToolRef) {
+		if len(refs) >= agentDefaultCatalogToolRefs {
+			return
+		}
+		ref.System = strings.TrimSpace(ref.System)
+		ref.Plugin = strings.TrimSpace(ref.Plugin)
+		ref.Operation = strings.TrimSpace(ref.Operation)
+		ref.Connection = core.ResolveConnectionAlias(strings.TrimSpace(ref.Connection))
+		ref.Instance = strings.TrimSpace(ref.Instance)
+		if ref.System == "" && ref.Plugin == "" {
+			return
+		}
+		key := agentToolTargetKeyFromRef(ref)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, ref)
+	}
+	for i := range candidates {
+		ref := candidates[i].ref
+		ref.Operation = strings.TrimSpace(candidates[i].operation.ID)
+		if strings.TrimSpace(ref.Title) == "" {
+			ref.Title = strings.TrimSpace(candidates[i].operation.Title)
+		}
+		if strings.TrimSpace(ref.Description) == "" {
+			ref.Description = strings.TrimSpace(candidates[i].operation.Description)
+		}
+		appendRef(ref)
+	}
+	for i := range unavailable {
+		appendRef(unavailable[i].ref)
+	}
+	return refs, nil
+}
+
+func agentTurnToolSearchQuery(messages []coreagent.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		role := strings.TrimSpace(strings.ToLower(msg.Role))
+		if role != "" && role != "user" {
+			continue
+		}
+		if text := agentMessageToolSearchText(msg); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func agentMessageToolSearchText(msg coreagent.Message) string {
+	parts := make([]string, 0, 1+len(msg.Parts))
+	if text := strings.TrimSpace(msg.Text); text != "" {
+		parts = append(parts, text)
+	}
+	for i := range msg.Parts {
+		part := msg.Parts[i]
+		if part.Type != "" && part.Type != coreagent.MessagePartTypeText {
+			continue
+		}
+		if text := strings.TrimSpace(part.Text); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n")
 }
 
 func (m *Manager) GetTurn(ctx context.Context, p *principal.Principal, turnID string) (turn *coreagent.Turn, err error) {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -894,6 +894,129 @@ func TestManagerCreateTurnDefaultsToCatalogToolsForCatalogOnlyProvider(t *testin
 	}
 }
 
+func TestManagerCreateTurnDefaultsToRelevantCatalogToolsFromPrompt(t *testing.T) {
+	t.Parallel()
+
+	linear := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "linear",
+			DN:       "Linear",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name:        "linear",
+				DisplayName: "Linear",
+				Operations: []catalog.CatalogOperation{
+					{
+						ID:          "viewer",
+						Title:       "Viewer",
+						Description: "Get the current Linear user",
+						ReadOnly:    true,
+					},
+					{
+						ID:          "issues",
+						Title:       "List issues",
+						Description: "List Linear issues assigned to a user",
+						ReadOnly:    true,
+					},
+					{
+						ID:          "searchIssues",
+						Title:       "Search issues",
+						Description: "Search Linear issues",
+						ReadOnly:    true,
+					},
+				},
+			},
+		},
+	}
+	github := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "github",
+			DN:       "GitHub",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name:        "github",
+				DisplayName: "GitHub",
+				Operations: []catalog.CatalogOperation{{
+					ID:          "issues/list-for-authenticated-user",
+					Title:       "List issues",
+					Description: "List GitHub issues assigned to the authenticated user",
+					ReadOnly:    true,
+				}},
+			},
+		},
+	}
+	alpha := newRouteCountingAgentProvider("alpha")
+	grants := newAgentManagerTestRunGrants(t)
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, linear, github),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		RunGrants: grants,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages: []coreagent.Message{{
+			Role: "user",
+			Text: "show me my linear tickets",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if len(alpha.createTurnReqs) != 1 {
+		t.Fatalf("CreateTurn requests = %d, want 1", len(alpha.createTurnReqs))
+	}
+	req := alpha.createTurnReqs[0]
+	if req.ToolSource != coreagent.ToolSourceModeMCPCatalog {
+		t.Fatalf("CreateTurn tool source = %q, want mcp_catalog", req.ToolSource)
+	}
+	if got := req.ToolRefs; len(got) == 0 || got[0].Plugin == agentToolSearchAllPlugin {
+		t.Fatalf("CreateTurn tool refs = %#v, want bounded relevant catalog refs", got)
+	}
+	for _, ref := range req.ToolRefs {
+		if ref.Plugin != "linear" {
+			t.Fatalf("CreateTurn tool refs = %#v, want only linear refs", req.ToolRefs)
+		}
+		if strings.TrimSpace(ref.Operation) == "" {
+			t.Fatalf("CreateTurn tool refs = %#v, want operation-specific refs", req.ToolRefs)
+		}
+	}
+	if !toolRefsContainOperation(req.ToolRefs, "issues") && !toolRefsContainOperation(req.ToolRefs, "searchIssues") {
+		t.Fatalf("CreateTurn tool refs = %#v, want a Linear issue operation", req.ToolRefs)
+	}
+	grant, err := grants.Resolve(req.RunGrant)
+	if err != nil {
+		t.Fatalf("Resolve run grant: %v", err)
+	}
+	if !reflect.DeepEqual(grant.ToolRefs, req.ToolRefs) {
+		t.Fatalf("grant tool refs = %#v, want %#v", grant.ToolRefs, req.ToolRefs)
+	}
+}
+
+func toolRefsContainOperation(refs []coreagent.ToolRef, operation string) bool {
+	for _, ref := range refs {
+		if ref.Operation == operation {
+			return true
+		}
+	}
+	return false
+}
+
 func TestManagerCreateTurnHonorsExplicitCatalogSourceWithNoToolRefs(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/agents/agentmanager/tool_search.go
+++ b/gestaltd/services/agents/agentmanager/tool_search.go
@@ -320,6 +320,12 @@ func agentToolSearchTokenVariants(token string) []string {
 	case strings.HasSuffix(token, "s") && len(token) > 3 && !strings.HasSuffix(token, "ss"):
 		variants = append(variants, strings.TrimSuffix(token, "s"))
 	}
+	switch token {
+	case "issue", "issues":
+		variants = append(variants, "ticket", "tickets")
+	case "ticket", "tickets":
+		variants = append(variants, "issue", "issues")
+	}
 	return variants
 }
 

--- a/gestaltd/services/agents/agentmanager/tool_search_test.go
+++ b/gestaltd/services/agents/agentmanager/tool_search_test.go
@@ -1,0 +1,23 @@
+package agentmanager
+
+import "testing"
+
+func TestAgentToolSearchTokenVariantsIncludeTicketIssueSynonyms(t *testing.T) {
+	t.Parallel()
+
+	tokens := uniqueAgentToolSearchTokens("tickets")
+	for _, want := range []string{"tickets", "ticket", "issues", "issue"} {
+		if !stringSliceContains(tokens, want) {
+			t.Fatalf("uniqueAgentToolSearchTokens(tickets) = %#v, want %q", tokens, want)
+		}
+	}
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- refine default MCP catalog grants from a wildcard to prompt-ranked, operation-specific tool refs when the user turn has text
- keep the wildcard fallback when there is no query, no candidates, or refinement fails
- add issue/ticket search synonyms so prompts like "linear tickets" rank Linear issue tools

## Tests
- go test ./services/agents/agentmanager ./internal/server