### PR TITLE
Add proactive credential refresh configuration

### DIFF
--- a/docs/content/providers/external-credentials.mdx
+++ b/docs/content/providers/external-credentials.mdx
@@ -162,6 +162,13 @@ Runtime resolution is where providers can refresh expiring credentials, resolve
 platform credentials, or apply configured token exchange behavior. Callers should
 not need to know which of those paths was used.
 
+Connections can also opt into proactive OAuth2 maintenance with
+`credentialRefresh`. Gestalt expands that connection-level config into external
+credentials provider runtime config containing the resolved connection ID, auth
+config, params, `refreshInterval`, and `refreshBeforeExpiry`. The first-party
+provider uses those targets to refresh stored credentials before expiry; omitted
+`credentialRefresh` keeps the default on-demand-only behavior.
+
 ### SDK request fields
 
 External credential SDK requests include both display-oriented connection

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1357,11 +1357,40 @@ is exactly one.
 Connection `mode` determines how credentials are managed: `none` requires no credentials, `platform` uses deployer-managed credential material, and `user` stores credentials for the caller's effective subject. For humans that is typically `user:<id>`; for non-human API token callers it can be `service_account:<id>` or another canonical non-system subject ID. Runtime surfaces can also supply system subjects such as `system:http_binding:<plugin>:<binding>` as the effective credential owner. All connections in a single plugin must share the same mode.
 
 Binding entries that use `ref` may set only binding metadata such as
-`displayName` and `exposure`; they cannot override `mode`, `auth`, or `params`.
-Top-level connections cannot set `ref` or `exposure`. Inline connection bindings
-are available for simple single-use `none` or `platform` cases; user-owned
-connections that collect or exchange credentials must be declared at the top
-level and referenced by `ref`.
+`displayName`, `exposure`, and `credentialRefresh`; they cannot override `mode`,
+`auth`, or `params`. Top-level connections cannot set `ref` or `exposure`.
+Inline connection bindings are available for simple single-use `none` or
+`platform` cases; user-owned connections that collect or exchange credentials
+must be declared at the top level and referenced by `ref`.
+
+#### Credential Refresh
+
+`credentialRefresh` opts a refresh-capable `mode: user` OAuth2 connection into
+proactive maintenance by the configured external credentials provider. When the
+block is omitted, credentials still refresh on demand during runtime resolution.
+
+```yaml
+connections:
+  google-user:
+    mode: user
+    auth:
+      type: oauth2
+      authorizationUrl: https://accounts.google.com/o/oauth2/v2/auth
+      tokenUrl: https://oauth2.googleapis.com/token
+      clientId: ${GOOGLE_CLIENT_ID}
+      clientSecret: ${GOOGLE_CLIENT_SECRET}
+      authorizationParams:
+        access_type: offline
+        prompt: consent
+    credentialRefresh:
+      refreshInterval: 15m
+      refreshBeforeExpiry: 30m
+```
+
+| Field | Description |
+| --- | --- |
+| `credentialRefresh.refreshInterval` | How often the external credentials provider should scan stored credentials for this connection. |
+| `credentialRefresh.refreshBeforeExpiry` | Refresh credentials whose access token expires within this duration. |
 
 #### Authentication Shapes
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1390,10 +1390,10 @@ func buildExternalCredentialsProvider(ctx context.Context, cfg *config.Config, f
 		name = config.DefaultProviderInstance
 		entry = defaultExternalCredentialsProviderEntry()
 	}
-	return buildNamedExternalCredentialsProvider(ctx, name, entry, factories, deps)
+	return buildNamedExternalCredentialsProvider(ctx, name, entry, cfg, factories, deps)
 }
 
-func buildNamedExternalCredentialsProvider(ctx context.Context, name string, entry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (core.ExternalCredentialProvider, error) {
+func buildNamedExternalCredentialsProvider(ctx context.Context, name string, entry *config.ProviderEntry, runtimeConfig *config.Config, factories *FactoryRegistry, deps Deps) (core.ExternalCredentialProvider, error) {
 	logicalName := strings.TrimSpace(name)
 	if logicalName == "" {
 		logicalName = "external-credentials"
@@ -1404,7 +1404,7 @@ func buildNamedExternalCredentialsProvider(ctx context.Context, name string, ent
 	if factories.ExternalCredentials == nil {
 		return nil, fmt.Errorf("bootstrap: external credentials provider factory is not registered")
 	}
-	node, err := buildExternalCredentialsRuntimeConfigNode(logicalName, entry, deps.EncryptionKey)
+	node, err := buildExternalCredentialsRuntimeConfigNode(logicalName, entry, runtimeConfig, deps.EncryptionKey)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: external credentials provider %q: %w", logicalName, err)
 	}
@@ -1435,7 +1435,7 @@ func defaultExternalCredentialsProviderEntry() *config.ProviderEntry {
 	}
 }
 
-func buildExternalCredentialsRuntimeConfigNode(name string, entry *config.ProviderEntry, encryptionKey []byte) (yaml.Node, error) {
+func buildExternalCredentialsRuntimeConfigNode(name string, entry *config.ProviderEntry, runtimeConfig *config.Config, encryptionKey []byte) (yaml.Node, error) {
 	if entry == nil {
 		return yaml.Node{}, fmt.Errorf("external credentials provider %q is required", name)
 	}
@@ -1451,6 +1451,16 @@ func buildExternalCredentialsRuntimeConfigNode(name string, entry *config.Provid
 			return yaml.Node{}, fmt.Errorf("config.encryptionKey is required")
 		}
 		cfg["encryptionKey"] = hex.EncodeToString(encryptionKey)
+	}
+	targets, err := buildExternalCredentialRefreshRuntimeTargets(runtimeConfig)
+	if err != nil {
+		return yaml.Node{}, fmt.Errorf("credentialRefresh: %w", err)
+	}
+	if len(targets) > 0 {
+		if _, ok := cfg["credentialRefresh"]; ok {
+			return yaml.Node{}, fmt.Errorf("config.credentialRefresh is managed by connection credentialRefresh settings")
+		}
+		cfg["credentialRefresh"] = externalCredentialRefreshRuntimeConfig{Targets: targets}
 	}
 	return mapToYAMLNode(cfg)
 }

--- a/gestaltd/internal/bootstrap/connections_test.go
+++ b/gestaltd/internal/bootstrap/connections_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"gopkg.in/yaml.v3"
 )
 
 func TestBuildConnectionRuntimePlatformManualDirectAuthMapping(t *testing.T) {
@@ -85,6 +86,245 @@ func TestBuildConnectionRuntimePlatformManualDirectAuthMapping(t *testing.T) {
 	}
 	if info.Token != "{}" {
 		t.Fatalf("Token = %q, want placeholder JSON token", info.Token)
+	}
+}
+
+func TestBuildExternalCredentialsRuntimeConfigNodeIncludesCredentialRefreshTargets(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"gmail": {
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{
+						Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+							"default": {
+								Mode: providermanifestv1.ConnectionModeUser,
+								Auth: &providermanifestv1.ProviderAuth{
+									Type:            providermanifestv1.AuthTypeOAuth2,
+									TokenURL:        "https://oauth2.googleapis.com/token/{tenant}",
+									ClientAuth:      "header",
+									TokenExchange:   "json",
+									Scopes:          []string{"https://www.googleapis.com/auth/gmail.modify"},
+									RefreshParams:   map[string]string{"audience": "google"},
+									AcceptHeader:    "application/json",
+									AccessTokenPath: "data.access_token",
+								},
+								Params: map[string]providermanifestv1.ProviderConnectionParam{
+									"tenant": {Default: "acme"},
+								},
+								CredentialRefresh: &providermanifestv1.CredentialRefreshConfig{
+									RefreshInterval:     "15m",
+									RefreshBeforeExpiry: "30m",
+								},
+							},
+						},
+					},
+				},
+				Connections: map[string]*config.ConnectionDef{
+					"default": {
+						Auth: config.ConnectionAuthDef{
+							ClientID:     "client-id",
+							ClientSecret: "client-secret",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	node, err := buildExternalCredentialsRuntimeConfigNode("default", &config.ProviderEntry{}, cfg, []byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("buildExternalCredentialsRuntimeConfigNode() error = %v", err)
+	}
+	var decoded struct {
+		CredentialRefresh externalCredentialRefreshRuntimeConfig `yaml:"credentialRefresh"`
+	}
+	if err := node.Decode(&decoded); err != nil {
+		t.Fatalf("Decode(runtime config): %v", err)
+	}
+	if len(decoded.CredentialRefresh.Targets) != 1 {
+		t.Fatalf("targets = %+v, want one", decoded.CredentialRefresh.Targets)
+	}
+	target := decoded.CredentialRefresh.Targets[0]
+	if target.Provider != "gmail" || target.Connection != "default" || target.ConnectionID != "gmail:default" {
+		t.Fatalf("target identity = %+v, want gmail/default fallback connection id", target)
+	}
+	if target.RefreshInterval != "15m0s" || target.RefreshBeforeExpiry != "30m0s" {
+		t.Fatalf("target refresh durations = %q/%q", target.RefreshInterval, target.RefreshBeforeExpiry)
+	}
+	if target.Auth.TokenURL != "https://oauth2.googleapis.com/token/{tenant}" ||
+		target.Auth.ClientID != "client-id" ||
+		target.Auth.ClientSecret != "client-secret" ||
+		target.Auth.ClientAuth != "header" ||
+		target.Auth.TokenExchange != "json" ||
+		target.Auth.RefreshParams["audience"] != "google" ||
+		target.Auth.AcceptHeader != "application/json" ||
+		target.Auth.AccessTokenPath != "data.access_token" {
+		t.Fatalf("target auth = %+v, want lower-camel runtime auth config", target.Auth)
+	}
+	if target.ConnectionParams["tenant"] != "acme" {
+		t.Fatalf("connectionParams = %+v, want tenant default", target.ConnectionParams)
+	}
+
+	raw, err := yaml.Marshal(node)
+	if err != nil {
+		t.Fatalf("Marshal(runtime config): %v", err)
+	}
+	text := string(raw)
+	for _, want := range []string{"credentialRefresh:", "connectionId: gmail:default", "tokenUrl: https://oauth2.googleapis.com/token/{tenant}", "clientId: client-id", "refreshBeforeExpiry: 30m0s"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("runtime config YAML missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestBuildExternalCredentialRefreshTargetsOmittedConfigProducesNoTargets(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"gmail": {
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{
+						Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+							"default": {
+								Mode: providermanifestv1.ConnectionModeUser,
+								Auth: &providermanifestv1.ProviderAuth{
+									Type:     providermanifestv1.AuthTypeOAuth2,
+									TokenURL: "https://oauth2.googleapis.com/token",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	targets, err := buildExternalCredentialRefreshRuntimeTargets(cfg)
+	if err != nil {
+		t.Fatalf("buildExternalCredentialRefreshRuntimeTargets() error = %v", err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("targets = %+v, want none", targets)
+	}
+}
+
+func TestBuildExternalCredentialRefreshTargetsUseResolvedConnectionIDAndDedupeSharedScopes(t *testing.T) {
+	t.Parallel()
+
+	shared := &config.ConnectionDef{
+		Mode: providermanifestv1.ConnectionModeUser,
+		Auth: config.ConnectionAuthDef{
+			Type:         providermanifestv1.AuthTypeOAuth2,
+			TokenURL:     "https://oauth2.googleapis.com/token",
+			ClientID:     "client-id",
+			ClientSecret: "client-secret",
+		},
+		CredentialRefresh: &config.CredentialRefreshDef{
+			RefreshInterval:     "15m",
+			RefreshBeforeExpiry: "30m",
+		},
+	}
+	cfg := &config.Config{
+		APIVersion: config.ConfigAPIVersion,
+		Connections: map[string]*config.ConnectionDef{
+			"shared_google": shared,
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"gmail":           googleRefPlugin("shared_google", "https://www.googleapis.com/auth/gmail.modify"),
+			"google_calendar": googleRefPlugin("shared_google", "https://www.googleapis.com/auth/calendar.events"),
+		},
+	}
+	if err := config.ValidateStructure(cfg); err != nil {
+		t.Fatalf("ValidateStructure() error = %v", err)
+	}
+
+	targets, err := buildExternalCredentialRefreshRuntimeTargets(cfg)
+	if err != nil {
+		t.Fatalf("buildExternalCredentialRefreshRuntimeTargets() error = %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("targets = %+v, want one deduped shared target", targets)
+	}
+	if targets[0].ConnectionID != "shared_google" {
+		t.Fatalf("connectionId = %q, want resolved shared_google", targets[0].ConnectionID)
+	}
+}
+
+func TestBuildExternalCredentialRefreshTargetsRejectConflictingDuplicateConnectionID(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"gmail": {
+				Connections: map[string]*config.ConnectionDef{
+					"default": {
+						Mode:         providermanifestv1.ConnectionModeUser,
+						ConnectionID: "shared_google",
+						Auth: config.ConnectionAuthDef{
+							Type:         providermanifestv1.AuthTypeOAuth2,
+							TokenURL:     "https://oauth2.googleapis.com/token",
+							ClientID:     "client-id",
+							ClientSecret: "client-secret",
+						},
+						CredentialRefresh: &config.CredentialRefreshDef{
+							RefreshInterval:     "15m",
+							RefreshBeforeExpiry: "30m",
+						},
+					},
+				},
+			},
+			"google_calendar": {
+				Connections: map[string]*config.ConnectionDef{
+					"default": {
+						Mode:         providermanifestv1.ConnectionModeUser,
+						ConnectionID: "shared_google",
+						Auth: config.ConnectionAuthDef{
+							Type:         providermanifestv1.AuthTypeOAuth2,
+							TokenURL:     "https://oauth2.googleapis.com/token",
+							ClientID:     "client-id",
+							ClientSecret: "different-secret",
+						},
+						CredentialRefresh: &config.CredentialRefreshDef{
+							RefreshInterval:     "15m",
+							RefreshBeforeExpiry: "30m",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := buildExternalCredentialRefreshRuntimeTargets(cfg)
+	if err == nil {
+		t.Fatal("buildExternalCredentialRefreshRuntimeTargets() error = nil, want duplicate conflict")
+	}
+	if !strings.Contains(err.Error(), "conflicting refresh configuration") {
+		t.Fatalf("error = %v, want conflicting refresh configuration", err)
+	}
+}
+
+func googleRefPlugin(ref, scope string) *config.ProviderEntry {
+	return &config.ProviderEntry{
+		Source: config.ProviderSource{Path: "./manifest.yaml"},
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Spec: &providermanifestv1.Spec{
+				Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+					"default": {
+						Mode: providermanifestv1.ConnectionModeUser,
+						Auth: &providermanifestv1.ProviderAuth{
+							Type:     providermanifestv1.AuthTypeOAuth2,
+							TokenURL: "https://oauth2.googleapis.com/token",
+							Scopes:   []string{scope},
+						},
+					},
+				},
+			},
+		},
+		Connections: map[string]*config.ConnectionDef{
+			"default": {Ref: ref},
+		},
 	}
 }
 

--- a/gestaltd/internal/bootstrap/credential_refresh.go
+++ b/gestaltd/internal/bootstrap/credential_refresh.go
@@ -1,0 +1,249 @@
+package bootstrap
+
+import (
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+type externalCredentialRefreshRuntimeConfig struct {
+	Targets []externalCredentialRefreshRuntimeTarget `json:"targets" yaml:"targets"`
+}
+
+type externalCredentialRefreshRuntimeTarget struct {
+	Provider            string                           `json:"provider" yaml:"provider"`
+	Connection          string                           `json:"connection" yaml:"connection"`
+	ConnectionID        string                           `json:"connectionId" yaml:"connectionId"`
+	RefreshInterval     string                           `json:"refreshInterval" yaml:"refreshInterval"`
+	RefreshBeforeExpiry string                           `json:"refreshBeforeExpiry" yaml:"refreshBeforeExpiry"`
+	Auth                externalCredentialAuthConfigYAML `json:"auth" yaml:"auth"`
+	ConnectionParams    map[string]string                `json:"connectionParams,omitempty" yaml:"connectionParams,omitempty"`
+}
+
+type externalCredentialAuthConfigYAML struct {
+	Type                 string                                      `json:"type,omitempty" yaml:"type,omitempty"`
+	Token                string                                      `json:"token,omitempty" yaml:"token,omitempty"`
+	TokenPrefix          string                                      `json:"tokenPrefix,omitempty" yaml:"tokenPrefix,omitempty"`
+	GrantType            string                                      `json:"grantType,omitempty" yaml:"grantType,omitempty"`
+	TokenURL             string                                      `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
+	ClientID             string                                      `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret         string                                      `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	ClientAuth           string                                      `json:"clientAuth,omitempty" yaml:"clientAuth,omitempty"`
+	TokenExchange        string                                      `json:"tokenExchange,omitempty" yaml:"tokenExchange,omitempty"`
+	Scopes               []string                                    `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	ScopeParam           string                                      `json:"scopeParam,omitempty" yaml:"scopeParam,omitempty"`
+	ScopeSeparator       string                                      `json:"scopeSeparator,omitempty" yaml:"scopeSeparator,omitempty"`
+	TokenParams          map[string]string                           `json:"tokenParams,omitempty" yaml:"tokenParams,omitempty"`
+	RefreshParams        map[string]string                           `json:"refreshParams,omitempty" yaml:"refreshParams,omitempty"`
+	AcceptHeader         string                                      `json:"acceptHeader,omitempty" yaml:"acceptHeader,omitempty"`
+	AccessTokenPath      string                                      `json:"accessTokenPath,omitempty" yaml:"accessTokenPath,omitempty"`
+	TokenExchangeDrivers []externalCredentialTokenExchangeDriverYAML `json:"tokenExchangeDrivers,omitempty" yaml:"tokenExchangeDrivers,omitempty"`
+}
+
+type externalCredentialTokenExchangeDriverYAML struct {
+	Type            string            `json:"type,omitempty" yaml:"type,omitempty"`
+	TargetPrincipal string            `json:"targetPrincipal,omitempty" yaml:"targetPrincipal,omitempty"`
+	Scopes          []string          `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	LifetimeSeconds int               `json:"lifetimeSeconds,omitempty" yaml:"lifetimeSeconds,omitempty"`
+	Endpoint        string            `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	Params          map[string]string `json:"params,omitempty" yaml:"params,omitempty"`
+}
+
+func buildExternalCredentialRefreshRuntimeTargets(cfg *config.Config) ([]externalCredentialRefreshRuntimeTarget, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	egressDeps := newEgressDeps(cfg)
+	targets := make([]externalCredentialRefreshRuntimeTarget, 0)
+	addProvider := func(kind, providerName string, entry *config.ProviderEntry) error {
+		if entry == nil {
+			return nil
+		}
+		providerName = strings.TrimSpace(providerName)
+		if providerName == "" {
+			return fmt.Errorf("%s name is empty", kind)
+		}
+		plan, err := config.BuildStaticConnectionPlan(entry, entry.ManifestSpec())
+		if err != nil {
+			return fmt.Errorf("%s %q: %w", kind, providerName, err)
+		}
+		policy := egressDeps.ProviderPolicy(entry)
+		addConnection := func(connectionName string, resolved config.ResolvedConnectionDef) error {
+			if resolved.CredentialRefresh == nil {
+				return nil
+			}
+			conn := resolved.ConnectionDef()
+			info, err := staticConnectionRuntimeInfo(providerName, connectionName, conn, policy)
+			if err != nil {
+				return fmt.Errorf("%s %q connection %q: %w", kind, providerName, connectionName, err)
+			}
+			if info.Mode != core.ConnectionModeUser {
+				return fmt.Errorf("%s %q connection %q credentialRefresh requires mode user", kind, providerName, connectionName)
+			}
+			if strings.TrimSpace(info.AuthConfig.Type) != "oauth2" {
+				return fmt.Errorf("%s %q connection %q credentialRefresh requires auth.type oauth2", kind, providerName, connectionName)
+			}
+			if strings.TrimSpace(info.AuthConfig.GrantType) == "client_credentials" {
+				return fmt.Errorf("%s %q connection %q credentialRefresh does not support oauth2 client_credentials", kind, providerName, connectionName)
+			}
+			if strings.TrimSpace(info.AuthConfig.TokenURL) == "" {
+				return fmt.Errorf("%s %q connection %q credentialRefresh requires auth.tokenUrl", kind, providerName, connectionName)
+			}
+			interval, before, err := credentialRefreshDurations(resolved.CredentialRefresh)
+			if err != nil {
+				return fmt.Errorf("%s %q connection %q credentialRefresh: %w", kind, providerName, connectionName, err)
+			}
+			connectionID := strings.TrimSpace(info.ConnectionID)
+			if connectionID == "" {
+				connectionID = providerName + ":" + connectionName
+			}
+			targets = append(targets, externalCredentialRefreshRuntimeTarget{
+				Provider:            providerName,
+				Connection:          connectionName,
+				ConnectionID:        connectionID,
+				RefreshInterval:     interval.String(),
+				RefreshBeforeExpiry: before.String(),
+				Auth:                externalCredentialAuthConfigToYAML(info.AuthConfig),
+				ConnectionParams:    maps.Clone(info.Params),
+			})
+			return nil
+		}
+		if err := addConnection(config.PluginConnectionName, plan.ResolvedPluginConnection()); err != nil {
+			return err
+		}
+		for _, connectionName := range plan.NamedConnectionNames() {
+			resolved, _ := plan.ResolvedNamedConnectionDef(connectionName)
+			if err := addConnection(connectionName, resolved); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for providerName, entry := range cfg.Plugins {
+		if err := addProvider("integration", providerName, entry); err != nil {
+			return nil, err
+		}
+	}
+	for providerName, entry := range cfg.Providers.Agent {
+		if err := addProvider("agent provider", providerName, entry); err != nil {
+			return nil, err
+		}
+	}
+	return dedupeExternalCredentialRefreshTargets(targets)
+}
+
+func credentialRefreshDurations(refresh *config.CredentialRefreshDef) (time.Duration, time.Duration, error) {
+	if refresh == nil {
+		return 0, 0, fmt.Errorf("config is required")
+	}
+	interval, err := config.ParseDuration(strings.TrimSpace(refresh.RefreshInterval))
+	if err != nil {
+		return 0, 0, fmt.Errorf("refreshInterval: %w", err)
+	}
+	before, err := config.ParseDuration(strings.TrimSpace(refresh.RefreshBeforeExpiry))
+	if err != nil {
+		return 0, 0, fmt.Errorf("refreshBeforeExpiry: %w", err)
+	}
+	return interval, before, nil
+}
+
+func dedupeExternalCredentialRefreshTargets(targets []externalCredentialRefreshRuntimeTarget) ([]externalCredentialRefreshRuntimeTarget, error) {
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]externalCredentialRefreshRuntimeTarget, len(targets))
+	out := make([]externalCredentialRefreshRuntimeTarget, 0, len(targets))
+	for i := range targets {
+		target := targets[i]
+		connectionID := strings.TrimSpace(target.ConnectionID)
+		if connectionID == "" {
+			return nil, fmt.Errorf("credentialRefresh target for %s/%s has empty connectionId", target.Provider, target.Connection)
+		}
+		if existing, ok := seen[connectionID]; ok {
+			if !reflect.DeepEqual(refreshConflictKey(existing), refreshConflictKey(target)) {
+				return nil, fmt.Errorf("credentialRefresh target connectionId %q has conflicting refresh configuration", connectionID)
+			}
+			continue
+		}
+		seen[connectionID] = target
+		out = append(out, target)
+	}
+	return out, nil
+}
+
+type externalCredentialRefreshConflictKey struct {
+	RefreshInterval     string
+	RefreshBeforeExpiry string
+	Auth                externalCredentialRefreshAuthConflictKey
+	ConnectionParams    map[string]string
+}
+
+type externalCredentialRefreshAuthConflictKey struct {
+	Type            string
+	TokenURL        string
+	ClientID        string
+	ClientSecret    string
+	ClientAuth      string
+	TokenExchange   string
+	RefreshParams   map[string]string
+	AcceptHeader    string
+	AccessTokenPath string
+}
+
+func refreshConflictKey(target externalCredentialRefreshRuntimeTarget) externalCredentialRefreshConflictKey {
+	return externalCredentialRefreshConflictKey{
+		RefreshInterval:     target.RefreshInterval,
+		RefreshBeforeExpiry: target.RefreshBeforeExpiry,
+		Auth: externalCredentialRefreshAuthConflictKey{
+			Type:            target.Auth.Type,
+			TokenURL:        target.Auth.TokenURL,
+			ClientID:        target.Auth.ClientID,
+			ClientSecret:    target.Auth.ClientSecret,
+			ClientAuth:      target.Auth.ClientAuth,
+			TokenExchange:   target.Auth.TokenExchange,
+			RefreshParams:   maps.Clone(target.Auth.RefreshParams),
+			AcceptHeader:    target.Auth.AcceptHeader,
+			AccessTokenPath: target.Auth.AccessTokenPath,
+		},
+		ConnectionParams: maps.Clone(target.ConnectionParams),
+	}
+}
+
+func externalCredentialAuthConfigToYAML(auth core.ExternalCredentialAuthConfig) externalCredentialAuthConfigYAML {
+	drivers := make([]externalCredentialTokenExchangeDriverYAML, 0, len(auth.TokenExchangeDrivers))
+	for _, driver := range auth.TokenExchangeDrivers {
+		drivers = append(drivers, externalCredentialTokenExchangeDriverYAML{
+			Type:            driver.Type,
+			TargetPrincipal: driver.TargetPrincipal,
+			Scopes:          slices.Clone(driver.Scopes),
+			LifetimeSeconds: driver.LifetimeSeconds,
+			Endpoint:        driver.Endpoint,
+			Params:          maps.Clone(driver.Params),
+		})
+	}
+	return externalCredentialAuthConfigYAML{
+		Type:                 auth.Type,
+		Token:                auth.Token,
+		TokenPrefix:          auth.TokenPrefix,
+		GrantType:            auth.GrantType,
+		TokenURL:             auth.TokenURL,
+		ClientID:             auth.ClientID,
+		ClientSecret:         auth.ClientSecret,
+		ClientAuth:           auth.ClientAuth,
+		TokenExchange:        auth.TokenExchange,
+		Scopes:               slices.Clone(auth.Scopes),
+		ScopeParam:           auth.ScopeParam,
+		ScopeSeparator:       auth.ScopeSeparator,
+		TokenParams:          maps.Clone(auth.TokenParams),
+		RefreshParams:        maps.Clone(auth.RefreshParams),
+		AcceptHeader:         auth.AcceptHeader,
+		AccessTokenPath:      auth.AccessTokenPath,
+		TokenExchangeDrivers: drivers,
+	}
+}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1529,16 +1529,19 @@ func (s ServerConfig) ManagementBaseURL() string {
 // ConnectionDef owns authentication and connection parameters for a named
 // connection.
 type ConnectionDef struct {
-	Ref              string                                `yaml:"ref,omitempty"`
-	DisplayName      string                                `yaml:"displayName,omitempty"`
-	Mode             providermanifestv1.ConnectionMode     `yaml:"mode"`
-	Exposure         providermanifestv1.ConnectionExposure `yaml:"exposure,omitempty"`
-	Auth             ConnectionAuthDef                     `yaml:"auth"`
-	ConnectionParams map[string]ConnectionParamDef         `yaml:"params"`
-	Discovery        *providermanifestv1.ProviderDiscovery `yaml:"-"`
-	ConnectionID     string                                `yaml:"-"`
-	BindingResolved  bool                                  `yaml:"-"`
+	Ref               string                                `yaml:"ref,omitempty"`
+	DisplayName       string                                `yaml:"displayName,omitempty"`
+	Mode              providermanifestv1.ConnectionMode     `yaml:"mode"`
+	Exposure          providermanifestv1.ConnectionExposure `yaml:"exposure,omitempty"`
+	Auth              ConnectionAuthDef                     `yaml:"auth"`
+	ConnectionParams  map[string]ConnectionParamDef         `yaml:"params"`
+	CredentialRefresh *CredentialRefreshDef                 `yaml:"credentialRefresh,omitempty"`
+	Discovery         *providermanifestv1.ProviderDiscovery `yaml:"-"`
+	ConnectionID      string                                `yaml:"-"`
+	BindingResolved   bool                                  `yaml:"-"`
 }
+
+type CredentialRefreshDef = providermanifestv1.CredentialRefreshConfig
 
 type ConnectionAuthDef struct {
 	Type                 providermanifestv1.AuthType `yaml:"type"`
@@ -1706,6 +1709,9 @@ func MergeConnectionDef(dst *ConnectionDef, src *ConnectionDef) {
 	MergeConnectionAuth(&dst.Auth, src.Auth)
 	if len(src.ConnectionParams) > 0 {
 		dst.ConnectionParams = maps.Clone(src.ConnectionParams)
+	}
+	if src.CredentialRefresh != nil {
+		dst.CredentialRefresh = cloneCredentialRefreshDef(src.CredentialRefresh)
 	}
 	if src.Discovery != nil {
 		dst.Discovery = src.Discovery

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5104,6 +5104,55 @@ func TestValidateStructureCanonicalizesConnectionAliasBindings(t *testing.T) {
 	}
 }
 
+func TestValidateStructureConnectionRefBindingOverridesCredentialRefresh(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		APIVersion: ConfigAPIVersion,
+		Connections: map[string]*ConnectionDef{
+			"shared_google": {
+				Mode: providermanifestv1.ConnectionModeUser,
+				Auth: ConnectionAuthDef{
+					Type:     providermanifestv1.AuthTypeOAuth2,
+					TokenURL: "https://oauth2.googleapis.com/token",
+				},
+				CredentialRefresh: &CredentialRefreshDef{
+					RefreshInterval:     "1h",
+					RefreshBeforeExpiry: "30m",
+				},
+			},
+		},
+		Plugins: map[string]*ProviderEntry{
+			"gmail": {
+				Source: ProviderSource{Path: "./manifest.yaml"},
+				Connections: map[string]*ConnectionDef{
+					"default": {
+						Ref: "shared_google",
+						CredentialRefresh: &CredentialRefreshDef{
+							RefreshInterval:     "15m",
+							RefreshBeforeExpiry: "10m",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := ValidateStructure(cfg); err != nil {
+		t.Fatalf("ValidateStructure() error = %v", err)
+	}
+	resolved := cfg.Plugins["gmail"].Connections["default"]
+	if resolved == nil || resolved.ConnectionID != "shared_google" {
+		t.Fatalf("resolved connection = %+v, want shared_google ref", resolved)
+	}
+	if resolved.CredentialRefresh == nil {
+		t.Fatal("resolved CredentialRefresh is nil")
+	}
+	if resolved.CredentialRefresh.RefreshInterval != "15m" || resolved.CredentialRefresh.RefreshBeforeExpiry != "10m" {
+		t.Fatalf("resolved CredentialRefresh = %+v, want binding override", resolved.CredentialRefresh)
+	}
+}
+
 func TestValidateStructureRejectsConnectionAliasConflict(t *testing.T) {
 	t.Parallel()
 
@@ -5156,6 +5205,122 @@ func TestValidateStructureRejectsInlineUserMCPOAuthConnection(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "user-owned inline connections are not supported") {
 		t.Fatalf("ValidateStructure() error = %v, want inline user connection rejection", err)
+	}
+}
+
+func TestValidateResolvedStructureCredentialRefreshContract(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		conn    *providermanifestv1.ManifestConnectionDef
+		wantErr string
+	}{
+		{
+			name: "valid user oauth2",
+			conn: &providermanifestv1.ManifestConnectionDef{
+				Mode: providermanifestv1.ConnectionModeUser,
+				Auth: &providermanifestv1.ProviderAuth{
+					Type:     providermanifestv1.AuthTypeOAuth2,
+					TokenURL: "https://oauth2.googleapis.com/token",
+				},
+				CredentialRefresh: &providermanifestv1.CredentialRefreshConfig{
+					RefreshInterval:     "15m",
+					RefreshBeforeExpiry: "30m",
+				},
+			},
+		},
+		{
+			name: "invalid duration",
+			conn: &providermanifestv1.ManifestConnectionDef{
+				Mode: providermanifestv1.ConnectionModeUser,
+				Auth: &providermanifestv1.ProviderAuth{
+					Type:     providermanifestv1.AuthTypeOAuth2,
+					TokenURL: "https://oauth2.googleapis.com/token",
+				},
+				CredentialRefresh: &providermanifestv1.CredentialRefreshConfig{
+					RefreshInterval:     "not-a-duration",
+					RefreshBeforeExpiry: "30m",
+				},
+			},
+			wantErr: "credentialRefresh.refreshInterval",
+		},
+		{
+			name: "platform mode",
+			conn: &providermanifestv1.ManifestConnectionDef{
+				Mode: providermanifestv1.ConnectionModePlatform,
+				Auth: &providermanifestv1.ProviderAuth{
+					Type:     providermanifestv1.AuthTypeOAuth2,
+					TokenURL: "https://oauth2.googleapis.com/token",
+				},
+				CredentialRefresh: &providermanifestv1.CredentialRefreshConfig{
+					RefreshInterval:     "15m",
+					RefreshBeforeExpiry: "30m",
+				},
+			},
+			wantErr: "credentialRefresh requires mode user",
+		},
+		{
+			name: "manual auth",
+			conn: &providermanifestv1.ManifestConnectionDef{
+				Mode: providermanifestv1.ConnectionModeUser,
+				Auth: &providermanifestv1.ProviderAuth{
+					Type: providermanifestv1.AuthTypeManual,
+				},
+				CredentialRefresh: &providermanifestv1.CredentialRefreshConfig{
+					RefreshInterval:     "15m",
+					RefreshBeforeExpiry: "30m",
+				},
+			},
+			wantErr: "credentialRefresh requires auth.type oauth2",
+		},
+		{
+			name: "missing token url",
+			conn: &providermanifestv1.ManifestConnectionDef{
+				Mode: providermanifestv1.ConnectionModeUser,
+				Auth: &providermanifestv1.ProviderAuth{
+					Type: providermanifestv1.AuthTypeOAuth2,
+				},
+				CredentialRefresh: &providermanifestv1.CredentialRefreshConfig{
+					RefreshInterval:     "15m",
+					RefreshBeforeExpiry: "30m",
+				},
+			},
+			wantErr: "credentialRefresh requires auth.tokenUrl",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{
+				Plugins: map[string]*ProviderEntry{
+					"gmail": {
+						ResolvedManifest: &providermanifestv1.Manifest{
+							Spec: &providermanifestv1.Spec{
+								Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+									"default": tc.conn,
+								},
+							},
+						},
+					},
+				},
+			}
+			err := ValidateResolvedStructure(cfg)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateResolvedStructure() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateResolvedStructure() error = nil, want %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ValidateResolvedStructure() error = %v, want %q", err, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -282,6 +282,9 @@ func normalizeConnectionBindings(cfg *Config) error {
 				resolved.DisplayName = binding.DisplayName
 			}
 			resolved.Exposure = binding.Exposure
+			if binding.CredentialRefresh != nil {
+				resolved.CredentialRefresh = cloneCredentialRefreshDef(binding.CredentialRefresh)
+			}
 			entry.Connections[localName] = &resolved
 		}
 		return nil
@@ -350,7 +353,16 @@ func cloneConnectionDef(src ConnectionDef) ConnectionDef {
 	dst := src
 	dst.Auth = cloneConnectionAuthDef(src.Auth)
 	dst.ConnectionParams = maps.Clone(src.ConnectionParams)
+	dst.CredentialRefresh = cloneCredentialRefreshDef(src.CredentialRefresh)
 	return dst
+}
+
+func cloneCredentialRefreshDef(src *CredentialRefreshDef) *CredentialRefreshDef {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	return &dst
 }
 
 func cloneConnectionAuthDef(src ConnectionAuthDef) ConnectionAuthDef {
@@ -580,6 +592,9 @@ func validateTopLevelConnections(cfg *Config) error {
 		case core.ConnectionModeNone, core.ConnectionModePlatform, core.ConnectionModeUser:
 		default:
 			return fmt.Errorf("config validation: connections.%s mode %q is not supported", id, conn.Mode)
+		}
+		if err := validateCredentialRefresh(fmt.Sprintf("connections.%s", id), *conn); err != nil {
+			return err
 		}
 		if len(conn.Auth.TokenExchangeDrivers) > 0 {
 			if mode != core.ConnectionModePlatform {
@@ -1908,11 +1923,43 @@ func validatePluginIntegrationConnections(name string, entry *ProviderEntry) err
 	if err := validateConnectionAuthMappings(name, plan.PluginConnection().Auth, "plugin"); err != nil {
 		return err
 	}
+	if err := validateCredentialRefresh(fmt.Sprintf("integration %q plugin connection", name), plan.PluginConnection()); err != nil {
+		return err
+	}
 	for _, connName := range plan.NamedConnectionNames() {
 		conn, _ := plan.NamedConnectionDef(connName)
 		if err := validateConnectionAuthMappings(name, conn.Auth, fmt.Sprintf("connection %q", connName)); err != nil {
 			return err
 		}
+		if err := validateCredentialRefresh(fmt.Sprintf("integration %q connection %q", name, connName), conn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCredentialRefresh(scope string, conn ConnectionDef) error {
+	refresh := conn.CredentialRefresh
+	if refresh == nil {
+		return nil
+	}
+	if _, err := ParseDuration(strings.TrimSpace(refresh.RefreshInterval)); err != nil {
+		return fmt.Errorf("config validation: %s credentialRefresh.refreshInterval: %w", scope, err)
+	}
+	if _, err := ParseDuration(strings.TrimSpace(refresh.RefreshBeforeExpiry)); err != nil {
+		return fmt.Errorf("config validation: %s credentialRefresh.refreshBeforeExpiry: %w", scope, err)
+	}
+	if ConnectionModeForConnection(conn) != core.ConnectionModeUser {
+		return fmt.Errorf("config validation: %s credentialRefresh requires mode user", scope)
+	}
+	if conn.Auth.Type != providermanifestv1.AuthTypeOAuth2 {
+		return fmt.Errorf("config validation: %s credentialRefresh requires auth.type oauth2", scope)
+	}
+	if strings.TrimSpace(conn.Auth.GrantType) == "client_credentials" {
+		return fmt.Errorf("config validation: %s credentialRefresh does not support oauth2 client_credentials", scope)
+	}
+	if strings.TrimSpace(conn.Auth.TokenURL) == "" {
+		return fmt.Errorf("config validation: %s credentialRefresh requires auth.tokenUrl", scope)
 	}
 	return nil
 }

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -37,29 +37,31 @@ type ResolvedConnectionSource struct {
 }
 
 type ResolvedConnectionDef struct {
-	Provider     string
-	Name         string
-	Ref          string
-	ConnectionID string
-	DisplayName  string
-	Mode         providermanifestv1.ConnectionMode
-	Exposure     providermanifestv1.ConnectionExposure
-	Auth         ConnectionAuthDef
-	Params       map[string]ConnectionParamDef
-	Discovery    *providermanifestv1.ProviderDiscovery
-	Source       ResolvedConnectionSource
+	Provider          string
+	Name              string
+	Ref               string
+	ConnectionID      string
+	DisplayName       string
+	Mode              providermanifestv1.ConnectionMode
+	Exposure          providermanifestv1.ConnectionExposure
+	Auth              ConnectionAuthDef
+	Params            map[string]ConnectionParamDef
+	Discovery         *providermanifestv1.ProviderDiscovery
+	CredentialRefresh *CredentialRefreshDef
+	Source            ResolvedConnectionSource
 }
 
 func (r ResolvedConnectionDef) ConnectionDef() ConnectionDef {
 	return ConnectionDef{
-		Ref:              r.Ref,
-		DisplayName:      r.DisplayName,
-		Mode:             r.Mode,
-		Exposure:         r.Exposure,
-		Auth:             r.Auth,
-		ConnectionParams: r.Params,
-		Discovery:        r.Discovery,
-		ConnectionID:     r.ConnectionID,
+		Ref:               r.Ref,
+		DisplayName:       r.DisplayName,
+		Mode:              r.Mode,
+		Exposure:          r.Exposure,
+		Auth:              r.Auth,
+		ConnectionParams:  r.Params,
+		Discovery:         r.Discovery,
+		CredentialRefresh: r.CredentialRefresh,
+		ConnectionID:      r.ConnectionID,
 	}
 }
 
@@ -582,6 +584,9 @@ func ResolveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *providerma
 			if len(def.Params) > 0 {
 				conn.ConnectionParams = maps.Clone(def.Params)
 			}
+			if def.CredentialRefresh != nil {
+				conn.CredentialRefresh = cloneCredentialRefreshDef(def.CredentialRefresh)
+			}
 			if def.Discovery != nil {
 				conn.Discovery = def.Discovery
 			}
@@ -628,16 +633,17 @@ func ResolveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *providerma
 
 func resolvedConnectionDef(name string, conn ConnectionDef, source ResolvedConnectionSource) ResolvedConnectionDef {
 	return ResolvedConnectionDef{
-		Name:         name,
-		Ref:          conn.Ref,
-		ConnectionID: conn.ConnectionID,
-		DisplayName:  conn.DisplayName,
-		Mode:         conn.Mode,
-		Exposure:     conn.Exposure,
-		Auth:         conn.Auth,
-		Params:       conn.ConnectionParams,
-		Discovery:    conn.Discovery,
-		Source:       source,
+		Name:              name,
+		Ref:               conn.Ref,
+		ConnectionID:      conn.ConnectionID,
+		DisplayName:       conn.DisplayName,
+		Mode:              conn.Mode,
+		Exposure:          conn.Exposure,
+		Auth:              conn.Auth,
+		Params:            conn.ConnectionParams,
+		Discovery:         conn.Discovery,
+		CredentialRefresh: conn.CredentialRefresh,
+		Source:            source,
 	}
 }
 

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -372,12 +372,18 @@ type ManifestOperationOverride struct {
 }
 
 type ManifestConnectionDef struct {
-	DisplayName string                             `json:"displayName,omitempty" yaml:"displayName,omitempty"`
-	Mode        ConnectionMode                     `json:"mode,omitempty" yaml:"mode,omitempty"`
-	Exposure    ConnectionExposure                 `json:"exposure,omitempty" yaml:"exposure,omitempty"`
-	Auth        *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
-	Params      map[string]ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
-	Discovery   *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
+	DisplayName       string                             `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Mode              ConnectionMode                     `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Exposure          ConnectionExposure                 `json:"exposure,omitempty" yaml:"exposure,omitempty"`
+	Auth              *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Params            map[string]ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
+	Discovery         *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
+	CredentialRefresh *CredentialRefreshConfig           `json:"credentialRefresh,omitempty" yaml:"credentialRefresh,omitempty"`
+}
+
+type CredentialRefreshConfig struct {
+	RefreshInterval     string `json:"refreshInterval,omitempty" yaml:"refreshInterval,omitempty"`
+	RefreshBeforeExpiry string `json:"refreshBeforeExpiry,omitempty" yaml:"refreshBeforeExpiry,omitempty"`
 }
 
 type UIRoute struct {


### PR DESCRIPTION
## Summary

- Adds optional connection-level `credentialRefresh` config with `refreshInterval` and `refreshBeforeExpiry`.
- Carries the config through manifest/deploy connection resolution, including `ref` binding overrides.
- Generates external credentials provider `credentialRefresh.targets` from the resolved connection plan using a dedicated lower-camel auth wire shape.
- Validates that proactive refresh is only configured on refresh-capable `mode: user` OAuth2 connections and rejects conflicting duplicate connection IDs.
- Documents the new connection config and external credentials provider handoff.

## Interface Changes

- New/changed interface: `connections.<name>.credentialRefresh` and manifest `connections.<name>.credentialRefresh`.
- Omitted `credentialRefresh` keeps on-demand refresh behavior.

```yaml
connections:
  google-user:
    mode: user
    auth:
      type: oauth2
      authorizationUrl: https://accounts.google.com/o/oauth2/v2/auth
      tokenUrl: https://oauth2.googleapis.com/token
      clientId: ${GOOGLE_CLIENT_ID}
      clientSecret: ${GOOGLE_CLIENT_SECRET}
      authorizationParams:
        access_type: offline
        prompt: consent
    credentialRefresh:
      refreshInterval: 15m
      refreshBeforeExpiry: 30m
```

Gestaltd expands opted-in connections into runtime config for the external credentials provider:

```yaml
credentialRefresh:
  targets:
    - provider: gmail
      connection: default
      connectionId: gmail:default
      refreshInterval: 15m0s
      refreshBeforeExpiry: 30m0s
      auth:
        type: oauth2
        tokenUrl: https://oauth2.googleapis.com/token
        clientId: ...
        clientSecret: ...
      connectionParams: {}
```

## Functional/Integration Tests

- Tests added or augmented: config and bootstrap contract coverage for `credentialRefresh`, ref binding overrides, exact generated runtime YAML keys, omitted config, resolved connection IDs, shared Google refs with different scopes, conflicting duplicate connection IDs, and unsupported modes/auth/durations.
- Contract boundary covered: manifest/deploy YAML shape -> resolved connection plan -> external credentials provider runtime config.
- Commands run:
  - `go test ./internal/config`
  - `go test ./internal/bootstrap`

## Test plan

- [x] `go test ./internal/config`
- [x] `go test ./internal/bootstrap`