### PR TITLE
Render provider docs in registry

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -55,6 +55,14 @@ server {
         try_files $uri $uri.html $uri/ =404;
     }
 
+    location = /registry {
+        try_files /registry.html =404;
+    }
+
+    location /registry/ {
+        try_files /registry.html =404;
+    }
+
     location ~ ^/reference/(python|typescript|go|rust)-sdk(\.html)?$ {
         return 301 /reference/sdk/$1;
     }

--- a/docs/app/registry/registry-app.tsx
+++ b/docs/app/registry/registry-app.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import type { MouseEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
+import { renderMarkdown } from "./registry-markdown";
 import styles from "./registry.module.css";
 
 type ConfigTarget = {
@@ -16,6 +18,14 @@ type ProviderVersion = {
   runtime: string;
   platforms: string[];
   yanked?: boolean;
+};
+
+type ProviderDoc = {
+  path: string;
+  title: string;
+  sourcePath: string;
+  rawUrl: string;
+  editUrl: string;
 };
 
 type Provider = {
@@ -34,6 +44,7 @@ type Provider = {
   readmeUrl: string | null;
   manifestUrl: string | null;
   iconUrl: string | null;
+  docs?: ProviderDoc[];
 };
 
 type Catalog = {
@@ -52,13 +63,21 @@ type LoadState =
 type RouteSelection = {
   kind: string;
   name: string;
+  docPath: string;
 };
+
+type DocLoadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "loaded"; source: string }
+  | { status: "error"; message: string };
 
 const allKinds = "all";
 const catalogSchemaVersion = 1;
 const urlParseBase = "https://registry.gestaltd.ai";
 // Raw GitHub SVG responses include a sandboxing CSP, so render fetched SVGs as data URLs.
 const svgIconDataUrlCache = new Map<string, Promise<string | null>>();
+const providerDocTextCache = new Map<string, Promise<string | null>>();
 
 export default function RegistryApp({ catalogUrl }: { catalogUrl: string }) {
   const [loadState, setLoadState] = useState<LoadState>({ status: "loading" });
@@ -170,7 +189,17 @@ export default function RegistryApp({ catalogUrl }: { catalogUrl: string }) {
   function selectProvider(provider: Provider) {
     const href = `${routePrefix}${provider.registryPath}`;
     window.history.pushState(null, "", href);
-    setSelectedRoute({ kind: provider.kind, name: provider.name });
+    setSelectedRoute({ kind: provider.kind, name: provider.name, docPath: "/" });
+  }
+
+  function selectProviderDoc(provider: Provider, doc: ProviderDoc) {
+    const href = providerDocHref(provider, doc, routePrefix);
+    window.history.pushState(null, "", href);
+    setSelectedRoute({
+      kind: provider.kind,
+      name: provider.name,
+      docPath: normalizeDocPath(doc.path),
+    });
   }
 
   return (
@@ -260,7 +289,12 @@ export default function RegistryApp({ catalogUrl }: { catalogUrl: string }) {
 
           <aside className={styles.detailPane}>
             {selectedProvider ? (
-              <ProviderDetail provider={selectedProvider} />
+              <ProviderDetail
+                onSelectDoc={(doc) => selectProviderDoc(selectedProvider, doc)}
+                provider={selectedProvider}
+                routePrefix={routePrefix}
+                selectedDocPath={selectedRoute?.docPath ?? "/"}
+              />
             ) : (
               <div className={styles.statePanel}>No provider selected</div>
             )}
@@ -273,17 +307,28 @@ export default function RegistryApp({ catalogUrl }: { catalogUrl: string }) {
 
 function selectionFromPath(pathname: string): RouteSelection | null {
   const normalized = pathname.replace(/^\/registry/, "");
-  const match = normalized.match(/^\/providers\/([^/]+)\/([^/]+)\/?$/);
+  const match = normalized.match(/^\/providers\/([^/]+)\/([^/]+)(?:\/(.*))?\/?$/);
   if (!match) {
     return null;
   }
   return {
     kind: decodeURIComponent(match[1]),
     name: decodeURIComponent(match[2]),
+    docPath: normalizeDocPath(match[3] ? `/${decodeURIComponent(match[3])}/` : "/"),
   };
 }
 
-function ProviderDetail({ provider }: { provider: Provider }) {
+function ProviderDetail({
+  onSelectDoc,
+  provider,
+  routePrefix,
+  selectedDocPath,
+}: {
+  onSelectDoc: (doc: ProviderDoc) => void;
+  provider: Provider;
+  routePrefix: string;
+  selectedDocPath: string;
+}) {
   const latest = provider.versions[0];
   const installCommand = provider.configTarget.requiredSet?.path
     ? `gestaltd provider add ${provider.package} --set path=/`
@@ -354,11 +399,129 @@ function ProviderDetail({ provider }: { provider: Provider }) {
         </div>
       </section>
 
+      <ProviderDocs
+        onSelectDoc={onSelectDoc}
+        provider={provider}
+        routePrefix={routePrefix}
+        selectedDocPath={selectedDocPath}
+      />
+
       <div className={styles.links}>
         {provider.sourceUrl ? <a href={provider.sourceUrl}>Source</a> : null}
         {provider.readmeUrl ? <a href={provider.readmeUrl}>README</a> : null}
         {provider.manifestUrl ? <a href={provider.manifestUrl}>Manifest</a> : null}
       </div>
+    </div>
+  );
+}
+
+function ProviderDocs({
+  onSelectDoc,
+  provider,
+  routePrefix,
+  selectedDocPath,
+}: {
+  onSelectDoc: (doc: ProviderDoc) => void;
+  provider: Provider;
+  routePrefix: string;
+  selectedDocPath: string;
+}) {
+  const docs = provider.docs ?? [];
+  if (docs.length === 0) {
+    return null;
+  }
+  const normalizedSelectedPath = normalizeDocPath(selectedDocPath);
+  const selectedDoc =
+    docs.find((doc) => normalizeDocPath(doc.path) === normalizedSelectedPath) ??
+    (normalizedSelectedPath === "/" ? docs[0] : null);
+
+  return (
+    <section className={styles.docsPanel}>
+      <div className={styles.docsHeader}>
+        <h2>Documentation</h2>
+        {selectedDoc?.editUrl ? <a href={selectedDoc.editUrl}>Edit</a> : null}
+      </div>
+      <nav className={styles.docsNav} aria-label={`${provider.displayName} docs`}>
+        {docs.map((doc) => {
+          const isActive =
+            selectedDoc !== null &&
+            normalizeDocPath(doc.path) === normalizeDocPath(selectedDoc.path);
+          return (
+            <a
+              aria-current={isActive ? "page" : undefined}
+              className={isActive ? styles.activeDocLink : undefined}
+              href={providerDocHref(provider, doc, routePrefix)}
+              key={doc.path}
+              onClick={(event) => {
+                if (!shouldHandleDocNavigationClick(event)) {
+                  return;
+                }
+                event.preventDefault();
+                onSelectDoc(doc);
+              }}
+            >
+              {doc.title}
+            </a>
+          );
+        })}
+      </nav>
+      {selectedDoc ? (
+        <ProviderDocBody
+          docs={docs}
+          provider={provider}
+          routePrefix={routePrefix}
+          selectedDoc={selectedDoc}
+        />
+      ) : (
+        <div className={styles.docsState}>
+          <h3>Documentation page not found</h3>
+          <p>Select one of the available provider docs pages.</p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function shouldHandleDocNavigationClick(event: MouseEvent<HTMLAnchorElement>) {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey &&
+    !event.defaultPrevented
+  );
+}
+
+function ProviderDocBody({
+  docs,
+  provider,
+  routePrefix,
+  selectedDoc,
+}: {
+  docs: ProviderDoc[];
+  provider: Provider;
+  routePrefix: string;
+  selectedDoc: ProviderDoc;
+}) {
+  const loadState = useProviderDocSource(selectedDoc);
+  if (loadState.status === "loading" || loadState.status === "idle") {
+    return <div className={styles.docsState}>Loading documentation</div>;
+  }
+  if (loadState.status === "error") {
+    return (
+      <div className={styles.docsState}>
+        <h3>Documentation unavailable</h3>
+        <p>{loadState.message}</p>
+      </div>
+    );
+  }
+  return (
+    <div className={styles.markdownBody}>
+      {renderMarkdown(loadState.source, {
+        resolveLink: (href) =>
+          resolveProviderDocLink(href, provider, docs, selectedDoc, routePrefix),
+      })}
     </div>
   );
 }
@@ -451,6 +614,123 @@ function loadSvgIconDataUrl(iconUrl: string) {
     .catch(() => null);
   svgIconDataUrlCache.set(iconUrl, promise);
   return promise;
+}
+
+function useProviderDocSource(doc: ProviderDoc) {
+  const [loadState, setLoadState] = useState<DocLoadState>({ status: "idle" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadState({ status: "loading" });
+    void loadProviderDocText(doc.rawUrl).then((source) => {
+      if (cancelled) {
+        return;
+      }
+      if (source === null) {
+        setLoadState({
+          status: "error",
+          message: `Unable to load ${doc.sourcePath}`,
+        });
+        return;
+      }
+      setLoadState({ status: "loaded", source });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [doc.rawUrl, doc.sourcePath]);
+
+  return loadState;
+}
+
+function loadProviderDocText(rawUrl: string) {
+  const cached = providerDocTextCache.get(rawUrl);
+  if (cached) {
+    return cached;
+  }
+  const promise = fetch(rawUrl)
+    .then(async (response) => {
+      if (!response.ok) {
+        return null;
+      }
+      return response.text();
+    })
+    .catch(() => null);
+  providerDocTextCache.set(rawUrl, promise);
+  return promise;
+}
+
+function normalizeDocPath(path: string) {
+  const clean = path.split(/[?#]/, 1)[0].replace(/^\/+/, "").replace(/\/+$/, "");
+  return clean ? `/${clean}/` : "/";
+}
+
+function providerDocHref(provider: Provider, doc: ProviderDoc, routePrefix: string) {
+  const base = `${routePrefix}${provider.registryPath}`;
+  const docPath = normalizeDocPath(doc.path);
+  if (docPath === "/") {
+    return base;
+  }
+  return `${base.replace(/\/$/, "")}${docPath}`;
+}
+
+function resolveProviderDocLink(
+  href: string,
+  provider: Provider,
+  docs: ProviderDoc[],
+  currentDoc: ProviderDoc,
+  routePrefix: string,
+) {
+  const trimmed = href.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.startsWith("#")) {
+    return { href: trimmed, external: false };
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (["http:", "https:", "mailto:"].includes(parsed.protocol)) {
+      return { href: trimmed, external: parsed.protocol !== "mailto:" };
+    }
+    return null;
+  } catch {
+    // Relative links are handled below.
+  }
+  if (trimmed.startsWith("/providers/")) {
+    return { href: `${routePrefix}${trimmed}`, external: false };
+  }
+  if (trimmed.startsWith("/")) {
+    return { href: `https://gestaltd.ai${trimmed}`, external: true };
+  }
+
+  const [withoutHash, hash = ""] = trimmed.split("#", 2);
+  const targetDoc = docForRelativeHref(withoutHash, docs, currentDoc);
+  if (targetDoc) {
+    return {
+      href: `${providerDocHref(provider, targetDoc, routePrefix)}${hash ? `#${hash}` : ""}`,
+      external: false,
+    };
+  }
+  return null;
+}
+
+function docForRelativeHref(
+  href: string,
+  docs: ProviderDoc[],
+  currentDoc: ProviderDoc,
+) {
+  const cleanHref = href.split("?", 1)[0].replace(/^\.\//, "");
+  if (!cleanHref) {
+    return currentDoc;
+  }
+  if (!cleanHref.endsWith(".md") && !cleanHref.endsWith(".mdx")) {
+    return null;
+  }
+  const fileName = cleanHref.split("/").pop() ?? "";
+  const stem = fileName.replace(/\.mdx?$/, "");
+  const docPath = stem === "index" ? "/" : `/${stem}/`;
+  return docs.find((doc) => normalizeDocPath(doc.path) === docPath) ?? null;
 }
 
 function kindLabel(kind: string) {

--- a/docs/app/registry/registry-markdown.tsx
+++ b/docs/app/registry/registry-markdown.tsx
@@ -1,0 +1,317 @@
+import type { ReactNode } from "react";
+import { Fragment } from "react";
+
+type LinkTarget = {
+  href: string;
+  external: boolean;
+};
+
+export type MarkdownRenderContext = {
+  resolveLink: (href: string) => LinkTarget | null;
+};
+
+type Block =
+  | { kind: "blockquote"; lines: string[] }
+  | { kind: "code"; language: string; text: string }
+  | { kind: "heading"; depth: number; text: string }
+  | { kind: "list"; ordered: boolean; items: string[][] }
+  | { kind: "paragraph"; text: string }
+  | { kind: "table"; headers: string[]; rows: string[][] };
+
+const headingPattern = /^(#{1,6})\s+(.+?)\s*#*$/;
+const unorderedListPattern = /^(\s*)[-*]\s+(.+)$/;
+const orderedListPattern = /^(\s*)\d+\.\s+(.+)$/;
+const tableSeparatorPattern = /^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$/;
+const inlinePatternSource =
+  /(`[^`]+`|\[([^\]]+)\]\(([^)]+)\)|\*\*([^*]+)\*\*|\*([^*]+)\*)/.source;
+
+export function renderMarkdown(source: string, context: MarkdownRenderContext) {
+  return parseBlocks(stripFrontmatter(source)).map((block, index) =>
+    renderBlock(block, context, index),
+  );
+}
+
+function stripFrontmatter(source: string) {
+  const normalized = source.replace(/\r\n?/g, "\n");
+  const lines = normalized.split("\n");
+  if (lines[0]?.trim() !== "---") {
+    return normalized;
+  }
+  const closeIndex = lines.slice(1).findIndex((line) => line.trim() === "---");
+  if (closeIndex === -1) {
+    return normalized;
+  }
+  return lines.slice(closeIndex + 2).join("\n");
+}
+
+function parseBlocks(source: string) {
+  const blocks: Block[] = [];
+  const lines = source.split("\n");
+  let index = 0;
+  while (index < lines.length) {
+    const line = lines[index];
+    const trimmed = line.trim();
+    if (!trimmed) {
+      index += 1;
+      continue;
+    }
+    if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+      const fence = trimmed.slice(0, 3);
+      const language = trimmed.slice(3).trim();
+      const codeLines: string[] = [];
+      index += 1;
+      while (index < lines.length && !lines[index].trim().startsWith(fence)) {
+        codeLines.push(lines[index]);
+        index += 1;
+      }
+      if (index < lines.length) {
+        index += 1;
+      }
+      blocks.push({ kind: "code", language, text: codeLines.join("\n") });
+      continue;
+    }
+    const heading = headingPattern.exec(trimmed);
+    if (heading) {
+      blocks.push({
+        kind: "heading",
+        depth: heading[1].length,
+        text: heading[2].trim(),
+      });
+      index += 1;
+      continue;
+    }
+    if (trimmed.startsWith(">")) {
+      const quoteLines: string[] = [];
+      while (index < lines.length && lines[index].trim().startsWith(">")) {
+        quoteLines.push(lines[index].trim().replace(/^>\s?/, ""));
+        index += 1;
+      }
+      blocks.push({ kind: "blockquote", lines: quoteLines });
+      continue;
+    }
+    const unorderedListMatch = unorderedListPattern.exec(line);
+    const orderedListMatch = orderedListPattern.exec(line);
+    if (unorderedListMatch || orderedListMatch) {
+      const ordered = orderedListMatch !== null;
+      const markerIndent = (orderedListMatch ?? unorderedListMatch)?.[1].length ?? 0;
+      const { items, nextIndex } = parseListItems(lines, index, ordered, markerIndent);
+      blocks.push({ kind: "list", ordered, items });
+      index = nextIndex;
+      continue;
+    }
+    if (isTableStart(lines, index)) {
+      const headers = parseTableRow(lines[index]);
+      index += 2;
+      const rows: string[][] = [];
+      while (index < lines.length && lines[index].includes("|") && lines[index].trim()) {
+        rows.push(parseTableRow(lines[index]));
+        index += 1;
+      }
+      blocks.push({ kind: "table", headers, rows });
+      continue;
+    }
+
+    const paragraphLines: string[] = [];
+    while (index < lines.length && lines[index].trim() && !startsSpecialBlock(lines, index)) {
+      paragraphLines.push(lines[index].trim());
+      index += 1;
+    }
+    blocks.push({ kind: "paragraph", text: paragraphLines.join(" ") });
+  }
+  return blocks;
+}
+
+function parseListItems(
+  lines: string[],
+  startIndex: number,
+  ordered: boolean,
+  markerIndent: number,
+) {
+  const items: string[][] = [];
+  let currentItem: string[] | null = null;
+  let index = startIndex;
+  while (index < lines.length) {
+    const line = lines[index];
+    if (!line.trim()) {
+      break;
+    }
+
+    const listMatch = ordered
+      ? orderedListPattern.exec(line)
+      : unorderedListPattern.exec(line);
+    if (listMatch && listMatch[1].length === markerIndent) {
+      currentItem = [listMatch[2].trim()];
+      items.push(currentItem);
+      index += 1;
+      continue;
+    }
+
+    if (
+      currentItem &&
+      lineIndent(line) > markerIndent &&
+      !isBlockBoundary(lines, index)
+    ) {
+      currentItem.push(line.trim());
+      index += 1;
+      continue;
+    }
+
+    break;
+  }
+  return { items, nextIndex: index };
+}
+
+function lineIndent(line: string) {
+  return line.length - line.trimStart().length;
+}
+
+function isBlockBoundary(lines: string[], index: number) {
+  const trimmed = lines[index].trim();
+  return (
+    trimmed.startsWith("```") ||
+    trimmed.startsWith("~~~") ||
+    headingPattern.test(trimmed) ||
+    isTableStart(lines, index)
+  );
+}
+
+function startsSpecialBlock(lines: string[], index: number) {
+  const trimmed = lines[index].trim();
+  return (
+    trimmed.startsWith("```") ||
+    trimmed.startsWith("~~~") ||
+    trimmed.startsWith(">") ||
+    headingPattern.test(trimmed) ||
+    unorderedListPattern.test(lines[index]) ||
+    orderedListPattern.test(lines[index]) ||
+    isTableStart(lines, index)
+  );
+}
+
+function isTableStart(lines: string[], index: number) {
+  return (
+    index + 1 < lines.length &&
+    lines[index].includes("|") &&
+    tableSeparatorPattern.test(lines[index + 1])
+  );
+}
+
+function parseTableRow(line: string) {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+function renderBlock(block: Block, context: MarkdownRenderContext, index: number) {
+  switch (block.kind) {
+    case "blockquote":
+      return (
+        <blockquote key={index}>
+          {block.lines.map((line, lineIndex) => (
+            <Fragment key={lineIndex}>
+              {lineIndex > 0 ? <br /> : null}
+              {renderInline(line, context)}
+            </Fragment>
+          ))}
+        </blockquote>
+      );
+    case "code":
+      return (
+        <pre key={index}>
+          <code data-language={block.language || undefined}>{block.text}</code>
+        </pre>
+      );
+    case "heading": {
+      const depth = Math.min(block.depth + 1, 4);
+      const Heading = `h${depth}` as "h2" | "h3" | "h4";
+      return <Heading key={index}>{renderInline(block.text, context)}</Heading>;
+    }
+    case "list": {
+      const List = block.ordered ? "ol" : "ul";
+      return (
+        <List key={index}>
+          {block.items.map((item, itemIndex) => (
+            <li key={itemIndex}>
+              {item.map((line, lineIndex) => (
+                <Fragment key={lineIndex}>
+                  {lineIndex > 0 ? <br /> : null}
+                  {renderInline(line, context)}
+                </Fragment>
+              ))}
+            </li>
+          ))}
+        </List>
+      );
+    }
+    case "paragraph":
+      return <p key={index}>{renderInline(block.text, context)}</p>;
+    case "table":
+      return (
+        <div key={index} className="registry-markdown-table">
+          <table>
+            <thead>
+              <tr>
+                {block.headers.map((header, headerIndex) => (
+                  <th key={headerIndex}>{renderInline(header, context)}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {block.rows.map((row, rowIndex) => (
+                <tr key={rowIndex}>
+                  {row.map((cell, cellIndex) => (
+                    <td key={cellIndex}>{renderInline(cell, context)}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+  }
+}
+
+function renderInline(text: string, context: MarkdownRenderContext): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  const inlinePattern = new RegExp(inlinePatternSource, "g");
+  while ((match = inlinePattern.exec(text)) !== null) {
+    if (match.index > cursor) {
+      nodes.push(text.slice(cursor, match.index));
+    }
+    const token = match[0];
+    const key = `${match.index}-${token}`;
+    if (token.startsWith("`")) {
+      nodes.push(<code key={key}>{token.slice(1, -1)}</code>);
+    } else if (match[2] && match[3]) {
+      const target = context.resolveLink(match[3]);
+      if (target) {
+        nodes.push(
+          <a
+            href={target.href}
+            key={key}
+            rel={target.external ? "noreferrer" : undefined}
+            target={target.external ? "_blank" : undefined}
+          >
+            {renderInline(match[2], context)}
+          </a>,
+        );
+      } else {
+        nodes.push(match[2]);
+      }
+    } else if (match[4]) {
+      nodes.push(<strong key={key}>{renderInline(match[4], context)}</strong>);
+    } else if (match[5]) {
+      nodes.push(<em key={key}>{renderInline(match[5], context)}</em>);
+    }
+    cursor = match.index + token.length;
+  }
+  if (cursor < text.length) {
+    nodes.push(text.slice(cursor));
+  }
+  return nodes;
+}

--- a/docs/app/registry/registry.module.css
+++ b/docs/app/registry/registry.module.css
@@ -538,6 +538,219 @@
   color: rgba(var(--valon-ink), 1);
 }
 
+.docsPanel {
+  display: grid;
+  gap: 16px;
+  border-top: 1px solid var(--valon-line);
+  padding-top: 8px;
+}
+
+.docsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.docsHeader h2 {
+  margin: 0;
+  color: rgba(var(--valon-ink), 1);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.docsHeader a {
+  color: var(--valon-muted);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.docsHeader a:hover {
+  color: rgba(var(--valon-ink), 1);
+}
+
+.docsNav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.docsNav a {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--valon-line);
+  border-radius: 8px;
+  background: rgba(248, 246, 243, 0.9);
+  color: rgba(var(--valon-ink), 0.78);
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0 12px;
+  text-decoration: none;
+}
+
+.docsNav a:hover {
+  border-color: var(--valon-line-strong);
+  color: rgba(var(--valon-ink), 1);
+}
+
+.docsNav .activeDocLink {
+  border-color: rgba(var(--valon-ink), 1);
+  background: rgba(var(--valon-ink), 1);
+  color: #ffffff;
+}
+
+.docsState {
+  border: 1px solid var(--valon-line);
+  border-radius: 12px;
+  background: rgba(248, 246, 243, 0.9);
+  color: var(--valon-secondary);
+  padding: 18px;
+}
+
+.docsState h3 {
+  margin: 0 0 8px;
+  color: rgba(var(--valon-ink), 1);
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.docsState p {
+  margin: 0;
+}
+
+.markdownBody {
+  color: var(--valon-secondary);
+  font-size: 0.96rem;
+  line-height: 1.7;
+}
+
+.markdownBody h2,
+.markdownBody h3,
+.markdownBody h4 {
+  margin: 1.6em 0 0.55em;
+  color: rgba(var(--valon-ink), 1);
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.markdownBody h2:first-child,
+.markdownBody h3:first-child,
+.markdownBody h4:first-child {
+  margin-top: 0;
+}
+
+.markdownBody h2 {
+  font-family: "Season Serif", Georgia, serif;
+  font-size: 2rem;
+  font-weight: 400;
+}
+
+.markdownBody h3 {
+  font-size: 1.15rem;
+}
+
+.markdownBody h4 {
+  font-size: 1rem;
+}
+
+.markdownBody p,
+.markdownBody ul,
+.markdownBody ol,
+.markdownBody blockquote,
+.markdownBody pre,
+.markdownBody :global(.registry-markdown-table) {
+  margin: 0 0 1rem;
+}
+
+.markdownBody ul,
+.markdownBody ol {
+  padding-left: 1.25rem;
+}
+
+.markdownBody li + li {
+  margin-top: 0.35rem;
+}
+
+.markdownBody a {
+  color: rgba(var(--valon-ink), 1);
+  font-weight: 700;
+  text-decoration-color: rgba(var(--valon-ink), 0.28);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.markdownBody a:hover {
+  text-decoration-color: rgba(var(--valon-ink), 0.75);
+}
+
+.markdownBody code {
+  border: 1px solid var(--valon-line);
+  border-radius: 5px;
+  background: rgba(248, 246, 243, 0.9);
+  color: rgba(var(--valon-ink), 0.9);
+  font-family: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.86em;
+  padding: 0.12rem 0.28rem;
+}
+
+.markdownBody pre {
+  overflow-x: auto;
+  border: 1px solid rgba(var(--valon-ink), 1);
+  border-radius: 12px;
+  background: rgba(var(--valon-ink), 1);
+  padding: 16px;
+}
+
+.markdownBody pre code {
+  display: block;
+  border: 0;
+  background: transparent;
+  color: #ffffff;
+  padding: 0;
+  white-space: pre;
+}
+
+.markdownBody blockquote {
+  border-left: 3px solid var(--valon-gold);
+  color: rgba(var(--valon-ink), 0.72);
+  padding-left: 1rem;
+}
+
+.markdownBody :global(.registry-markdown-table) {
+  overflow-x: auto;
+}
+
+.markdownBody table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--valon-line);
+  background: rgba(248, 246, 243, 0.72);
+}
+
+.markdownBody th,
+.markdownBody td {
+  border-bottom: 1px solid var(--valon-line);
+  padding: 0.65rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.markdownBody th {
+  color: rgba(var(--valon-ink), 0.62);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.markdownBody td {
+  color: var(--valon-secondary);
+}
+
 .statePanel {
   margin: 24px;
   border: 1px solid var(--valon-line);

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "next lint",
-    "test:registry": "node scripts/check-registry-static.mjs"
+    "test:registry": "node scripts/check-registry-static.mjs",
+    "test:registry-docs": "node scripts/check-registry-docs-render.mjs"
   },
   "dependencies": {
     "@types/react-dom": "^19.2.3",

--- a/docs/scripts/check-registry-docs-render.mjs
+++ b/docs/scripts/check-registry-docs-render.mjs
@@ -1,0 +1,222 @@
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { createElement, Fragment } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ts from "typescript";
+
+const siteRoot = path.resolve("out");
+const fixtureRoot = path.resolve("scripts/fixtures/registry-docs");
+const registryHtml = path.join(siteRoot, "registry.html");
+
+if (!existsSync(registryHtml)) {
+  throw new Error("out/registry.html is missing; run npm run build first");
+}
+
+const contentTypes = new Map([
+  [".css", "text/css"],
+  [".html", "text/html"],
+  [".js", "text/javascript"],
+  [".json", "application/json"],
+  [".mdx", "text/markdown"],
+  [".svg", "image/svg+xml"],
+  [".woff", "font/woff"],
+  [".woff2", "font/woff2"],
+]);
+
+const server = createServer(async (request, response) => {
+  try {
+    const url = new URL(request.url ?? "/", "http://localhost");
+    const pathname = decodeURIComponent(url.pathname);
+    if (pathname.startsWith("/registry-test/")) {
+      return serveFixture(pathname, response);
+    }
+    if (
+      pathname.startsWith("/_next/") ||
+      pathname.startsWith("/_pagefind/") ||
+      pathname === "/favicon.svg" ||
+      pathname.startsWith("/images/") ||
+      pathname.startsWith("/fonts/")
+    ) {
+      return serveFile(siteRoot, pathname, response);
+    }
+    return serveFile(siteRoot, "/registry.html", response);
+  } catch (error) {
+    response.writeHead(500, { "content-type": "text/plain" });
+    response.end(error instanceof Error ? error.message : "server error");
+  }
+});
+
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+try {
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  await assertResponse({
+    url: `${baseUrl}/providers/plugin/slack/`,
+    status: 200,
+    includes: "registry-module",
+  });
+  await assertResponse({
+    url: `${baseUrl}/providers/plugin/slack/events/`,
+    status: 200,
+    includes: "registry-module",
+  });
+  await assertResponse({
+    url: `${baseUrl}/providers/plugin/slack/missing/`,
+    status: 200,
+    includes: "registry-module",
+  });
+
+  const catalogResponse = await fetch(`${baseUrl}/registry-test/catalog.json`);
+  const catalog = await catalogResponse.json();
+  const slack = catalog.providers.find(
+    (provider) => provider.packagePath === "plugins/slack",
+  );
+  if (!slack) {
+    throw new Error("fixture catalog missing plugins/slack");
+  }
+  if (slack.docs?.[0]?.path !== "/" || slack.docs?.[1]?.path !== "/events/") {
+    throw new Error("fixture catalog docs paths are not provider-relative");
+  }
+
+  const overviewSource = await assertResponse({
+    url: `${baseUrl}${slack.docs[0].rawUrl}`,
+    status: 200,
+    includes: "Fixture overview rendered from provider-owned MDX",
+  });
+  const eventsSource = await assertResponse({
+    url: `${baseUrl}${slack.docs[1].rawUrl}`,
+    status: 200,
+    includes: "Fixture events rendered from provider-owned MDX",
+  });
+  await assertRenderedDocs({
+    eventsSource,
+    overviewSource,
+  });
+} finally {
+  server.close();
+}
+
+async function serveFixture(pathname, response) {
+  const fixturePath = pathname.replace(/^\/registry-test\//, "");
+  return serveFile(fixtureRoot, `/${fixturePath}`, response);
+}
+
+async function serveFile(root, pathname, response) {
+  const fullPath = path.join(root, pathname);
+  if (
+    !fullPath.startsWith(root) ||
+    !existsSync(fullPath) ||
+    !statSync(fullPath).isFile()
+  ) {
+    response.writeHead(404, { "content-type": "text/plain" });
+    response.end("not found");
+    return;
+  }
+  const ext = path.extname(fullPath);
+  response.writeHead(200, {
+    "access-control-allow-origin": "*",
+    "content-type": contentTypes.get(ext) ?? "application/octet-stream",
+  });
+  response.end(await readFile(fullPath));
+}
+
+async function assertResponse({ url, status, includes }) {
+  const response = await fetch(url);
+  const body = await response.text();
+  if (response.status !== status) {
+    throw new Error(`${url} returned ${response.status}, want ${status}`);
+  }
+  if (includes && !body.includes(includes)) {
+    throw new Error(`${url} did not include ${includes}`);
+  }
+  return body;
+}
+
+async function assertRenderedDocs({ overviewSource, eventsSource }) {
+  const renderMarkdown = await loadRegistryMarkdownRenderer();
+  const overviewHtml = renderFixtureMarkdown(renderMarkdown, overviewSource);
+  if (!overviewHtml.includes("<h2>Slack</h2>")) {
+    throw new Error("renderer did not render the fixture overview heading");
+  }
+  if (!overviewHtml.includes('href="/providers/plugin/slack/events/"')) {
+    throw new Error("renderer did not resolve provider-relative MDX links");
+  }
+  const eventsHtml = renderFixtureMarkdown(renderMarkdown, eventsSource);
+  if (!eventsHtml.includes("Fixture events rendered from provider-owned MDX")) {
+    throw new Error("renderer did not render the fixture events source");
+  }
+
+  const continuationHtml = renderFixtureMarkdown(
+    renderMarkdown,
+    [
+      "# README fallback",
+      "",
+      "- optional Codex surfaces such as apps, multi-agent tools, hooks, skills, and",
+      "  web search disabled in the generated per-turn config",
+      "- `connection`: Optional database/sql pool and retry tuning.",
+      "  - `max_open_conns`: Maximum open connections.",
+    ].join("\n"),
+  );
+  const listItemCount = continuationHtml.match(/<li>/g)?.length ?? 0;
+  if (listItemCount !== 2) {
+    throw new Error(`renderer split README continuation lists into ${listItemCount} items`);
+  }
+  if (!continuationHtml.includes("web search disabled in the generated per-turn config")) {
+    throw new Error("renderer dropped README list continuation text");
+  }
+}
+
+function renderFixtureMarkdown(renderMarkdown, source) {
+  const nodes = renderMarkdown(source, {
+    resolveLink: (href) => {
+      if (href === "events.mdx") {
+        return { href: "/providers/plugin/slack/events/", external: false };
+      }
+      if (href.startsWith("http")) {
+        return { href, external: true };
+      }
+      return null;
+    },
+  });
+  return renderToStaticMarkup(createElement(Fragment, null, ...nodes));
+}
+
+async function loadRegistryMarkdownRenderer() {
+  const sourcePath = path.resolve("app/registry/registry-markdown.tsx");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: sourcePath,
+  }).outputText;
+  const require = createRequire(import.meta.url);
+  const testModule = { exports: {} };
+  const compile = new Function(
+    "exports",
+    "require",
+    "module",
+    "__filename",
+    "__dirname",
+    transpiled,
+  );
+  compile(
+    testModule.exports,
+    require,
+    testModule,
+    sourcePath,
+    path.dirname(sourcePath),
+  );
+  if (typeof testModule.exports.renderMarkdown !== "function") {
+    throw new Error("registry markdown renderer did not export renderMarkdown");
+  }
+  return testModule.exports.renderMarkdown;
+}

--- a/docs/scripts/check-registry-static.mjs
+++ b/docs/scripts/check-registry-static.mjs
@@ -64,6 +64,12 @@ try {
     includes: "registry-module",
   });
   await assertResponse({
+    url: `${baseUrl}/providers/plugin/slack/events/`,
+    host: "registry.gestaltd.ai",
+    status: 200,
+    includes: "registry-module",
+  });
+  await assertResponse({
     url: `${baseUrl}/_next/static/chunks/does-not-exist.js`,
     host: "registry.gestaltd.ai",
     status: 404,
@@ -76,7 +82,25 @@ try {
     excludes: "registry-module",
   });
   await assertResponse({
+    url: `${baseUrl}/registry/providers/plugin/slack/`,
+    host: "gestaltd.ai",
+    status: 200,
+    includes: "registry-module",
+  });
+  await assertResponse({
+    url: `${baseUrl}/registry/providers/plugin/slack/events/`,
+    host: "gestaltd.ai",
+    status: 200,
+    includes: "registry-module",
+  });
+  await assertResponse({
     url: `${baseUrl}/providers/plugin/slack/`,
+    host: "gestaltd.ai",
+    status: 404,
+    excludes: "registry-module",
+  });
+  await assertResponse({
+    url: `${baseUrl}/providers/plugin/slack/events/`,
     host: "gestaltd.ai",
     status: 404,
     excludes: "registry-module",
@@ -100,6 +124,9 @@ async function serveRegistryHost(pathname, response) {
 }
 
 async function serveDocsHost(pathname, response) {
+  if (pathname === "/registry" || pathname.startsWith("/registry/")) {
+    return serveFile("/registry.html", response, false);
+  }
   if (pathname.match(/^\/reference\/(python|typescript|go|rust)-sdk(?:\.html)?$/)) {
     const target = pathname.replace(/-sdk(?:\.html)?$/, "");
     response.writeHead(301, { location: `/reference/sdk${target.replace("/reference", "")}` });

--- a/docs/scripts/fixtures/registry-docs/catalog.json
+++ b/docs/scripts/fixtures/registry-docs/catalog.json
@@ -1,0 +1,57 @@
+{
+  "indexUrl": "https://raw.githubusercontent.com/valon-technologies/gestalt-providers/main/provider-index.yaml",
+  "providers": [
+    {
+      "configTarget": {
+        "entryKind": "plugin",
+        "section": "plugins"
+      },
+      "description": "Read public and private conversations, DMs, and group DMs; send messages; and manage channels.",
+      "displayName": "Slack",
+      "docs": [
+        {
+          "editUrl": "https://github.com/valon-technologies/gestalt-providers/blob/main/plugins/slack/docs/index.mdx",
+          "path": "/",
+          "rawUrl": "/registry-test/slack-index.mdx",
+          "sourcePath": "plugins/slack/docs/index.mdx",
+          "title": "Overview"
+        },
+        {
+          "editUrl": "https://github.com/valon-technologies/gestalt-providers/blob/main/plugins/slack/docs/events.mdx",
+          "path": "/events/",
+          "rawUrl": "/registry-test/slack-events.mdx",
+          "sourcePath": "plugins/slack/docs/events.mdx",
+          "title": "Events"
+        }
+      ],
+      "iconUrl": null,
+      "kind": "plugin",
+      "latestInstallableVersion": "0.0.1-alpha.42",
+      "manifestUrl": "https://github.com/valon-technologies/gestalt-providers/blob/main/plugins/slack/manifest.yaml",
+      "manifestVersion": "0.0.1-alpha.42",
+      "name": "slack",
+      "package": "github.com/valon-technologies/gestalt-providers/plugins/slack",
+      "packagePath": "plugins/slack",
+      "readmeUrl": "https://github.com/valon-technologies/gestalt-providers/blob/main/plugins/slack/README.md",
+      "registryPath": "/providers/plugin/slack/",
+      "sourceUrl": "https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/slack",
+      "versions": [
+        {
+          "kind": "plugin",
+          "metadata": "https://github.com/valon-technologies/gestalt-providers/releases/download/plugins/slack/v0.0.1-alpha.42/provider-release.yaml",
+          "platforms": [
+            "darwin/amd64",
+            "darwin/arm64",
+            "linux/amd64",
+            "linux/arm64"
+          ],
+          "runtime": "executable",
+          "version": "0.0.1-alpha.42"
+        }
+      ]
+    }
+  ],
+  "repository": "valon-technologies/gestalt-providers",
+  "schema": "gestaltd-provider-catalog",
+  "schemaVersion": 1
+}

--- a/docs/scripts/fixtures/registry-docs/slack-events.mdx
+++ b/docs/scripts/fixtures/registry-docs/slack-events.mdx
@@ -1,0 +1,15 @@
+---
+title: Events
+---
+
+# Slack Events
+
+Fixture events rendered from provider-owned MDX.
+
+## HTTP Routes
+
+Slack should send Events API requests to:
+
+```text
+POST /api/v1/slack/event
+```

--- a/docs/scripts/fixtures/registry-docs/slack-index.mdx
+++ b/docs/scripts/fixtures/registry-docs/slack-index.mdx
@@ -1,0 +1,17 @@
+---
+title: Overview
+---
+
+# Slack
+
+Fixture overview rendered from provider-owned MDX.
+
+## Bot Configuration
+
+Use [Events](events.mdx) for event setup.
+
+```yaml
+plugins:
+  slack:
+    source: github.com/valon-technologies/gestalt-providers/plugins/slack
+```


### PR DESCRIPTION
## Summary

Renders provider-owned docs inside the registry UI when `registry/catalog.json` includes optional provider `docs[]` metadata.

- Adds nested provider docs routes such as `/providers/plugin/slack/events/`.
- Fetches only the selected docs page from its catalog `rawUrl` and caches doc text by URL.
- Renders a safe Markdown-compatible MDX subset as React nodes without remote MDX eval or `dangerouslySetInnerHTML`.
- Keeps old catalogs working by hiding the docs panel when `docs` is absent.
- Adds a fixture catalog/docs contract check for the renderer PR.

## Interface Changes
- New/changed interface: the registry app consumes optional provider `docs[]` entries with provider-relative paths.
- Example usage:

```json
{
  "registryPath": "/providers/plugin/slack/",
  "docs": [
    {
      "path": "/",
      "title": "Overview",
      "rawUrl": "https://raw.githubusercontent.com/valon-technologies/gestalt-providers/main/plugins/slack/docs/index.mdx"
    },
    {
      "path": "/events/",
      "title": "Events",
      "rawUrl": "https://raw.githubusercontent.com/valon-technologies/gestalt-providers/main/plugins/slack/docs/events.mdx"
    }
  ]
}
```

Routes:

```text
https://registry.gestaltd.ai/providers/plugin/slack/
https://registry.gestaltd.ai/providers/plugin/slack/events/
```

## Functional/Integration Tests
- Tests added or augmented:
  - `scripts/check-registry-static.mjs` now checks nested registry provider-doc route fallback behavior.
  - `scripts/check-registry-docs-render.mjs` serves a fixture catalog/docs set and validates provider-relative docs metadata plus raw docs fetchability.
- Contract boundary covered: static registry route fallback -> catalog docs contract -> raw provider docs fetch inputs -> client renderer/typecheck/build.
- Commands run:
  - `npm run typecheck`
  - `npm run build`
  - `npm run test:registry`
  - `npm run test:registry-docs`
  - `git diff --check`

Logical companion PR: `valon-technologies/gestalt-providers#556` publishes `docs[]` metadata and Slack docs content. This PR is backward compatible with catalogs that do not have `docs` yet.
