### PR TITLE
Add resolved credential refresh metadata

### DIFF
--- a/docs/content/providers/external-credentials.mdx
+++ b/docs/content/providers/external-credentials.mdx
@@ -162,6 +162,21 @@ Runtime resolution is where providers can refresh expiring credentials, resolve
 platform credentials, or apply configured token exchange behavior. Callers should
 not need to know which of those paths was used.
 
+### Proactive maintenance
+
+Connections may declare `credentialRefresh` metadata in provider manifests or
+deployment config. Gestalt resolves that metadata with the rest of the
+connection definition and passes a generic `resolvedConnections` catalog to the
+configured external credentials provider only when at least one resolved
+connection declares proactive refresh.
+
+External credentials providers own maintenance support. A provider that supports
+the resolved auth shape can scan stored credentials and refresh them before
+expiry. A provider that receives `credentialRefresh` metadata it cannot support
+should fail configuration rather than silently ignore it. Gestalt does not add a
+separate refresh RPC; maintenance is provider behavior configured through the
+normal provider lifecycle.
+
 ### SDK request fields
 
 External credential SDK requests include both display-oriented connection

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1357,11 +1357,42 @@ is exactly one.
 Connection `mode` determines how credentials are managed: `none` requires no credentials, `platform` uses deployer-managed credential material, and `user` stores credentials for the caller's effective subject. For humans that is typically `user:<id>`; for non-human API token callers it can be `service_account:<id>` or another canonical non-system subject ID. Runtime surfaces can also supply system subjects such as `system:http_binding:<plugin>:<binding>` as the effective credential owner. All connections in a single plugin must share the same mode.
 
 Binding entries that use `ref` may set only binding metadata such as
-`displayName` and `exposure`; they cannot override `mode`, `auth`, or `params`.
+`displayName`, `exposure`, and `credentialRefresh`; they cannot override `mode`, `auth`, or `params`.
 Top-level connections cannot set `ref` or `exposure`. Inline connection bindings
 are available for simple single-use `none` or `platform` cases; user-owned
 connections that collect or exchange credentials must be declared at the top
 level and referenced by `ref`.
+
+#### Credential Refresh
+
+Connections can opt into proactive external credential maintenance with
+`credentialRefresh`. Omitting this block keeps the connection on the default
+on-demand refresh path.
+
+```yaml
+connections:
+  google-workspace:
+    mode: user
+    auth:
+      type: oauth2
+      tokenUrl: https://oauth2.googleapis.com/token
+      clientId: ${GOOGLE_CLIENT_ID}
+      clientSecret: ${GOOGLE_CLIENT_SECRET}
+    credentialRefresh:
+      refreshInterval: 15m
+      refreshBeforeExpiry: 30m
+```
+
+| Field | Description |
+| --- | --- |
+| `refreshInterval` | How often a supporting external credentials provider should scan stored credentials for this connection. Must be a positive duration. |
+| `refreshBeforeExpiry` | How far before expiry credentials should be refreshed. Must be a positive duration. |
+
+Gestalt treats this as connection metadata. It resolves manifest defaults,
+deployment overrides, and `ref` bindings, then passes the resolved connection
+metadata to the configured external credentials provider. The external
+credentials provider decides whether it supports proactive maintenance for the
+resolved auth shape and owns the refresh behavior.
 
 #### Authentication Shapes
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1390,10 +1390,10 @@ func buildExternalCredentialsProvider(ctx context.Context, cfg *config.Config, f
 		name = config.DefaultProviderInstance
 		entry = defaultExternalCredentialsProviderEntry()
 	}
-	return buildNamedExternalCredentialsProvider(ctx, name, entry, factories, deps)
+	return buildNamedExternalCredentialsProvider(ctx, cfg, name, entry, factories, deps)
 }
 
-func buildNamedExternalCredentialsProvider(ctx context.Context, name string, entry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (core.ExternalCredentialProvider, error) {
+func buildNamedExternalCredentialsProvider(ctx context.Context, cfg *config.Config, name string, entry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (core.ExternalCredentialProvider, error) {
 	logicalName := strings.TrimSpace(name)
 	if logicalName == "" {
 		logicalName = "external-credentials"
@@ -1404,7 +1404,7 @@ func buildNamedExternalCredentialsProvider(ctx context.Context, name string, ent
 	if factories.ExternalCredentials == nil {
 		return nil, fmt.Errorf("bootstrap: external credentials provider factory is not registered")
 	}
-	node, err := buildExternalCredentialsRuntimeConfigNode(logicalName, entry, deps.EncryptionKey)
+	node, err := buildExternalCredentialsRuntimeConfigNode(logicalName, entry, deps.EncryptionKey, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: external credentials provider %q: %w", logicalName, err)
 	}
@@ -1435,24 +1435,34 @@ func defaultExternalCredentialsProviderEntry() *config.ProviderEntry {
 	}
 }
 
-func buildExternalCredentialsRuntimeConfigNode(name string, entry *config.ProviderEntry, encryptionKey []byte) (yaml.Node, error) {
+func buildExternalCredentialsRuntimeConfigNode(name string, entry *config.ProviderEntry, encryptionKey []byte, appCfg *config.Config) (yaml.Node, error) {
 	if entry == nil {
 		return yaml.Node{}, fmt.Errorf("external credentials provider %q is required", name)
 	}
-	cfg, err := config.NodeToMap(entry.Config)
+	providerCfg, err := config.NodeToMap(entry.Config)
 	if err != nil {
 		return yaml.Node{}, fmt.Errorf("decode config: %w", err)
 	}
-	if cfg == nil {
-		cfg = map[string]any{}
+	if providerCfg == nil {
+		providerCfg = map[string]any{}
 	}
-	if _, ok := cfg["encryptionKey"]; !ok {
+	if _, ok := providerCfg["encryptionKey"]; !ok {
 		if len(encryptionKey) == 0 {
 			return yaml.Node{}, fmt.Errorf("config.encryptionKey is required")
 		}
-		cfg["encryptionKey"] = hex.EncodeToString(encryptionKey)
+		providerCfg["encryptionKey"] = hex.EncodeToString(encryptionKey)
 	}
-	return mapToYAMLNode(cfg)
+	resolvedConnections, err := buildExternalCredentialsResolvedConnections(appCfg)
+	if err != nil {
+		return yaml.Node{}, err
+	}
+	if len(resolvedConnections) > 0 {
+		if _, exists := providerCfg["resolvedConnections"]; exists {
+			return yaml.Node{}, fmt.Errorf("config.resolvedConnections is managed by gestaltd")
+		}
+		providerCfg["resolvedConnections"] = resolvedConnections
+	}
+	return mapToYAMLNode(providerCfg)
 }
 
 func buildExternalCredentialsHostServices(name string, deps Deps) ([]runtimehost.HostService, error) {

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -107,9 +107,13 @@ func BuildConnectionRuntime(cfg *config.Config) (invocation.ConnectionRuntimeMap
 		if err != nil {
 			return fmt.Errorf("%s %q: %w", kind, name, err)
 		}
+		providerConfig, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			return fmt.Errorf("%s %q config: %w", kind, name, err)
+		}
 		policy := egressDeps.ProviderPolicy(entry)
 		addRuntimeInfo := func(connName string, conn *config.ConnectionDef) error {
-			info, err := connectionRuntimeInfo(name, connName, conn, policy)
+			info, err := connectionRuntimeInfo(name, connName, conn, policy, providerConfig)
 			if err != nil {
 				return err
 			}
@@ -168,26 +172,28 @@ func ValidateConnectionRuntimeCredentials(ctx context.Context, provider core.Ext
 	return nil
 }
 
-func connectionRuntimeInfo(integration, connection string, conn *config.ConnectionDef, policy egress.Policy) (invocation.ConnectionRuntimeInfo, error) {
-	return staticConnectionRuntimeInfo(integration, connection, *conn, policy)
+func connectionRuntimeInfo(integration, connection string, conn *config.ConnectionDef, policy egress.Policy, providerConfig map[string]any) (invocation.ConnectionRuntimeInfo, error) {
+	return staticConnectionRuntimeInfo(integration, connection, *conn, policy, providerConfig)
 }
 
 // StaticConnectionRuntimeInfo validates and materializes deployment-owned
 // connection material using the same rules as invocation bootstrap.
 func StaticConnectionRuntimeInfo(integration, connection string, conn config.ConnectionDef) (invocation.ConnectionRuntimeInfo, error) {
-	return staticConnectionRuntimeInfo(integration, connection, conn, egress.Policy{DefaultAction: egress.PolicyAllow})
+	return staticConnectionRuntimeInfo(integration, connection, conn, egress.Policy{DefaultAction: egress.PolicyAllow}, nil)
 }
 
-func staticConnectionRuntimeInfo(integration, connection string, conn config.ConnectionDef, _ egress.Policy) (invocation.ConnectionRuntimeInfo, error) {
+func staticConnectionRuntimeInfo(integration, connection string, conn config.ConnectionDef, _ egress.Policy, providerConfig map[string]any) (invocation.ConnectionRuntimeInfo, error) {
 	mode := config.ConnectionModeForConnection(conn)
+	authConfig := applyConnectionRuntimeAuthOverlay(ExternalCredentialAuthConfig(conn.Auth), providerConfig)
 	info := invocation.ConnectionRuntimeInfo{
-		ConnectionID: conn.ConnectionID,
-		Mode:         mode,
-		Exposure:     config.ConnectionExposureForConnection(conn),
-		AuthType:     conn.Auth.Type,
-		AuthConfig:   ExternalCredentialAuthConfig(conn.Auth),
-		AuthMapping:  config.CloneAuthMapping(conn.Auth.AuthMapping),
-		Params:       connectionParamDefaults(conn.ConnectionParams),
+		ConnectionID:      conn.ConnectionID,
+		Mode:              mode,
+		Exposure:          config.ConnectionExposureForConnection(conn),
+		AuthType:          conn.Auth.Type,
+		AuthConfig:        authConfig,
+		AuthMapping:       config.CloneAuthMapping(conn.Auth.AuthMapping),
+		Params:            connectionParamDefaults(conn.ConnectionParams),
+		CredentialRefresh: cloneCredentialRefreshConfig(conn.CredentialRefresh),
 	}
 	if mode != core.ConnectionModePlatform {
 		return info, nil
@@ -219,22 +225,43 @@ func staticConnectionRuntimeInfo(integration, connection string, conn config.Con
 		info.Token = token
 		return info, nil
 	case providermanifestv1.AuthTypeOAuth2:
-		if strings.TrimSpace(conn.Auth.GrantType) != "client_credentials" {
+		if strings.TrimSpace(authConfig.GrantType) != "client_credentials" {
 			return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q mode platform oauth2 requires auth.grantType client_credentials", integration, connection)
 		}
-		if strings.TrimSpace(conn.Auth.TokenURL) == "" {
+		if strings.TrimSpace(authConfig.TokenURL) == "" {
 			return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q oauth2 client_credentials: auth.tokenUrl is required", integration, connection)
 		}
-		if strings.TrimSpace(conn.Auth.ClientID) == "" {
+		if strings.TrimSpace(authConfig.ClientID) == "" {
 			return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q oauth2 client_credentials: auth.clientId is required", integration, connection)
 		}
-		if strings.TrimSpace(conn.Auth.ClientSecret) == "" {
+		if strings.TrimSpace(authConfig.ClientSecret) == "" {
 			return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q oauth2 client_credentials: auth.clientSecret is required", integration, connection)
 		}
 		return info, nil
 	default:
 		return invocation.ConnectionRuntimeInfo{}, fmt.Errorf("integration %q connection %q mode platform requires auth.type bearer, manual, or oauth2 client_credentials", integration, connection)
 	}
+}
+
+func applyConnectionRuntimeAuthOverlay(auth core.ExternalCredentialAuthConfig, providerConfig map[string]any) core.ExternalCredentialAuthConfig {
+	if auth.Type != string(providermanifestv1.AuthTypeOAuth2) || providerConfig == nil {
+		return auth
+	}
+	if id, _ := providerConfig["clientId"].(string); id != "" {
+		auth.ClientID = id
+	}
+	if sec, _ := providerConfig["clientSecret"].(string); sec != "" {
+		auth.ClientSecret = sec
+	}
+	return auth
+}
+
+func cloneCredentialRefreshConfig(src *providermanifestv1.CredentialRefreshConfig) *providermanifestv1.CredentialRefreshConfig {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	return &dst
 }
 
 func ExternalCredentialAuthConfig(auth config.ConnectionAuthDef) core.ExternalCredentialAuthConfig {

--- a/gestaltd/internal/bootstrap/connections_test.go
+++ b/gestaltd/internal/bootstrap/connections_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"gopkg.in/yaml.v3"
 )
 
 func TestBuildConnectionRuntimePlatformManualDirectAuthMapping(t *testing.T) {
@@ -196,6 +197,10 @@ func TestBuildConnectionRuntimeClientCredentialsAuthConfig(t *testing.T) {
 		Plugins: map[string]*config.ProviderEntry{
 			"sample": {
 				Egress: &config.ProviderEgressConfig{AllowedHosts: []string{"allowed.example.com"}},
+				Config: mustConnectionTestYAMLNode(t, map[string]any{
+					"clientId":     "config-client-id",
+					"clientSecret": "config-client-secret",
+				}),
 				Connections: map[string]*config.ConnectionDef{
 					"default": {
 						Mode: providermanifestv1.ConnectionModePlatform,
@@ -203,8 +208,6 @@ func TestBuildConnectionRuntimeClientCredentialsAuthConfig(t *testing.T) {
 							Type:         providermanifestv1.AuthTypeOAuth2,
 							GrantType:    "client_credentials",
 							TokenURL:     tokenServer.URL,
-							ClientID:     "client-id",
-							ClientSecret: "client-secret",
 							ClientAuth:   "header",
 							AcceptHeader: "application/json",
 						},
@@ -226,8 +229,207 @@ func TestBuildConnectionRuntimeClientCredentialsAuthConfig(t *testing.T) {
 	if info.AuthConfig.TokenURL != tokenServer.URL {
 		t.Fatalf("AuthConfig.TokenURL = %q, want %q", info.AuthConfig.TokenURL, tokenServer.URL)
 	}
-	if info.AuthConfig.ClientID != "client-id" || info.AuthConfig.ClientSecret != "client-secret" {
+	if info.AuthConfig.ClientID != "config-client-id" || info.AuthConfig.ClientSecret != "config-client-secret" {
 		t.Fatalf("AuthConfig client credentials = %q/%q", info.AuthConfig.ClientID, info.AuthConfig.ClientSecret)
+	}
+}
+
+func TestBuildConnectionRuntimeCarriesCredentialRefreshMetadata(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := BuildConnectionRuntime(&config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"gmail": {
+				Config: mustConnectionTestYAMLNode(t, map[string]any{
+					"clientId":     "config-client-id",
+					"clientSecret": "config-client-secret",
+				}),
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{
+						Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+							"default": {
+								Mode: providermanifestv1.ConnectionModeUser,
+								Auth: &providermanifestv1.ProviderAuth{
+									Type:     providermanifestv1.AuthTypeOAuth2,
+									TokenURL: "https://oauth2.googleapis.com/token",
+								},
+								CredentialRefresh: &providermanifestv1.CredentialRefreshConfig{
+									RefreshInterval:     "15m",
+									RefreshBeforeExpiry: "30m",
+								},
+							},
+						},
+					},
+				},
+				Connections: map[string]*config.ConnectionDef{
+					"default": {
+						ConnectionID: "google-workspace",
+						ConnectionParams: map[string]config.ConnectionParamDef{
+							"tenant": {Default: "valon"},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildConnectionRuntime() error = %v", err)
+	}
+	info, ok := runtime.Resolve("gmail", "default")
+	if !ok {
+		t.Fatal("runtime.Resolve(gmail, default) not found")
+	}
+	if info.CredentialRefresh == nil {
+		t.Fatal("CredentialRefresh is nil")
+	}
+	if info.CredentialRefresh.RefreshInterval != "15m" || info.CredentialRefresh.RefreshBeforeExpiry != "30m" {
+		t.Fatalf("CredentialRefresh = %+v, want manifest metadata", info.CredentialRefresh)
+	}
+	if info.AuthConfig.ClientID != "config-client-id" || info.AuthConfig.ClientSecret != "config-client-secret" {
+		t.Fatalf("AuthConfig client credentials = %q/%q, want provider config overlay", info.AuthConfig.ClientID, info.AuthConfig.ClientSecret)
+	}
+}
+
+func TestBuildExternalCredentialsRuntimeConfigNodeResolvedConnectionsContract(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"gmail": {
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{
+						Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+							"default": {
+								Mode: providermanifestv1.ConnectionModeUser,
+								Auth: &providermanifestv1.ProviderAuth{
+									Type:       providermanifestv1.AuthTypeOAuth2,
+									TokenURL:   "https://oauth2.googleapis.com/token",
+									ClientAuth: "header",
+									RefreshParams: map[string]string{
+										"prompt": "consent",
+									},
+								},
+								CredentialRefresh: &providermanifestv1.CredentialRefreshConfig{
+									RefreshInterval:     "15m",
+									RefreshBeforeExpiry: "1h",
+								},
+							},
+						},
+					},
+				},
+				Config: mustConnectionTestYAMLNode(t, map[string]any{
+					"clientId":     "client-id",
+					"clientSecret": "client-secret",
+				}),
+				Connections: map[string]*config.ConnectionDef{
+					"default": {
+						ConnectionID: "google-workspace",
+						ConnectionParams: map[string]config.ConnectionParamDef{
+							"tenant": {Default: "valon"},
+						},
+					},
+				},
+			},
+			"slack": {
+				Connections: map[string]*config.ConnectionDef{
+					"default": {
+						Mode: providermanifestv1.ConnectionModeUser,
+						Auth: config.ConnectionAuthDef{
+							Type:     providermanifestv1.AuthTypeOAuth2,
+							TokenURL: "https://slack.example.test/oauth/token",
+						},
+					},
+				},
+			},
+		},
+	}
+	node, err := buildExternalCredentialsRuntimeConfigNode("default", &config.ProviderEntry{
+		Config: mustConnectionTestYAMLNode(t, map[string]any{"indexeddb": "creds"}),
+	}, []byte{0x01, 0x02, 0x03}, cfg)
+	if err != nil {
+		t.Fatalf("buildExternalCredentialsRuntimeConfigNode() error = %v", err)
+	}
+	raw, err := config.NodeToMap(node)
+	if err != nil {
+		t.Fatalf("NodeToMap() error = %v", err)
+	}
+	connections, ok := raw["resolvedConnections"].([]any)
+	if !ok || len(connections) != 4 {
+		t.Fatalf("resolvedConnections = %#v, want all resolved connections once any opts in", raw["resolvedConnections"])
+	}
+	var conn map[string]any
+	for _, candidate := range connections {
+		candidateMap, ok := candidate.(map[string]any)
+		if !ok {
+			t.Fatalf("resolvedConnections entry = %#v, want map", candidate)
+		}
+		if candidateMap["provider"] == "gmail" && candidateMap["connection"] == "default" {
+			conn = candidateMap
+			break
+		}
+	}
+	if conn == nil {
+		t.Fatalf("gmail default resolved connection missing from %#v", connections)
+	}
+	if conn["provider"] != "gmail" || conn["connection"] != "default" || conn["connectionId"] != "google-workspace" || conn["mode"] != "user" {
+		t.Fatalf("resolved connection identity = %#v", conn)
+	}
+	auth, ok := conn["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("auth = %#v, want map", conn["auth"])
+	}
+	if _, exists := auth["TokenURL"]; exists {
+		t.Fatalf("auth has Go field key TokenURL: %#v", auth)
+	}
+	if auth["tokenUrl"] != "https://oauth2.googleapis.com/token" || auth["clientId"] != "client-id" || auth["clientSecret"] != "client-secret" {
+		t.Fatalf("auth lower-camel fields = %#v", auth)
+	}
+	refresh, ok := conn["credentialRefresh"].(map[string]any)
+	if !ok {
+		t.Fatalf("credentialRefresh = %#v, want map", conn["credentialRefresh"])
+	}
+	if refresh["refreshInterval"] != "15m0s" || refresh["refreshBeforeExpiry"] != "1h0m0s" {
+		t.Fatalf("credentialRefresh = %#v, want canonical durations", refresh)
+	}
+	params, ok := conn["connectionParams"].(map[string]any)
+	if !ok || params["tenant"] != "valon" {
+		t.Fatalf("connectionParams = %#v, want tenant default", conn["connectionParams"])
+	}
+}
+
+func TestBuildExternalCredentialsRuntimeConfigNodeOmitsResolvedConnectionsWithoutCredentialRefresh(t *testing.T) {
+	t.Parallel()
+
+	node, err := buildExternalCredentialsRuntimeConfigNode("default", &config.ProviderEntry{
+		Config: mustConnectionTestYAMLNode(t, map[string]any{"indexeddb": "creds"}),
+	}, []byte{0x01, 0x02, 0x03}, &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"gmail": {
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{
+						Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+							"default": {
+								Mode: providermanifestv1.ConnectionModeUser,
+								Auth: &providermanifestv1.ProviderAuth{
+									Type:     providermanifestv1.AuthTypeOAuth2,
+									TokenURL: "https://oauth2.googleapis.com/token",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildExternalCredentialsRuntimeConfigNode() error = %v", err)
+	}
+	raw, err := config.NodeToMap(node)
+	if err != nil {
+		t.Fatalf("NodeToMap() error = %v", err)
+	}
+	if _, exists := raw["resolvedConnections"]; exists {
+		t.Fatalf("resolvedConnections present without credentialRefresh: %#v", raw["resolvedConnections"])
 	}
 }
 
@@ -286,6 +488,22 @@ func TestClientCredentialsTokenSourceHeaderAuth(t *testing.T) {
 	if credential.ExpiresAt == nil {
 		t.Fatal("ExpiresAt = nil, want expiry from token endpoint")
 	}
+}
+
+func mustConnectionTestYAMLNode(t *testing.T, value any) yaml.Node {
+	t.Helper()
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal YAML: %v", err)
+	}
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		t.Fatalf("Unmarshal YAML: %v", err)
+	}
+	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {
+		return *node.Content[0]
+	}
+	return node
 }
 
 func TestClientCredentialsTokenSourceCachesTokenWithoutExpiresIn(t *testing.T) {

--- a/gestaltd/internal/bootstrap/external_credentials_runtime.go
+++ b/gestaltd/internal/bootstrap/external_credentials_runtime.go
@@ -1,0 +1,177 @@
+package bootstrap
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
+)
+
+type externalCredentialsResolvedConnectionConfig struct {
+	Provider          string                                      `yaml:"provider"`
+	Connection        string                                      `yaml:"connection"`
+	ConnectionID      string                                      `yaml:"connectionId"`
+	Mode              string                                      `yaml:"mode"`
+	Auth              externalCredentialsResolvedAuthConfig       `yaml:"auth"`
+	ConnectionParams  map[string]string                           `yaml:"connectionParams,omitempty"`
+	CredentialRefresh *externalCredentialsCredentialRefreshConfig `yaml:"credentialRefresh,omitempty"`
+}
+
+type externalCredentialsCredentialRefreshConfig struct {
+	RefreshInterval     string `yaml:"refreshInterval"`
+	RefreshBeforeExpiry string `yaml:"refreshBeforeExpiry"`
+}
+
+type externalCredentialsResolvedAuthConfig struct {
+	Type                 string                                           `yaml:"type,omitempty"`
+	Token                string                                           `yaml:"token,omitempty"`
+	TokenPrefix          string                                           `yaml:"tokenPrefix,omitempty"`
+	GrantType            string                                           `yaml:"grantType,omitempty"`
+	TokenURL             string                                           `yaml:"tokenUrl,omitempty"`
+	ClientID             string                                           `yaml:"clientId,omitempty"`
+	ClientSecret         string                                           `yaml:"clientSecret,omitempty"`
+	ClientAuth           string                                           `yaml:"clientAuth,omitempty"`
+	TokenExchange        string                                           `yaml:"tokenExchange,omitempty"`
+	Scopes               []string                                         `yaml:"scopes,omitempty"`
+	ScopeParam           string                                           `yaml:"scopeParam,omitempty"`
+	ScopeSeparator       string                                           `yaml:"scopeSeparator,omitempty"`
+	TokenParams          map[string]string                                `yaml:"tokenParams,omitempty"`
+	RefreshParams        map[string]string                                `yaml:"refreshParams,omitempty"`
+	AcceptHeader         string                                           `yaml:"acceptHeader,omitempty"`
+	AccessTokenPath      string                                           `yaml:"accessTokenPath,omitempty"`
+	TokenExchangeDrivers []externalCredentialsResolvedTokenExchangeDriver `yaml:"tokenExchangeDrivers,omitempty"`
+}
+
+type externalCredentialsResolvedTokenExchangeDriver struct {
+	Type            string            `yaml:"type,omitempty"`
+	TargetPrincipal string            `yaml:"targetPrincipal,omitempty"`
+	Scopes          []string          `yaml:"scopes,omitempty"`
+	LifetimeSeconds int               `yaml:"lifetimeSeconds,omitempty"`
+	Endpoint        string            `yaml:"endpoint,omitempty"`
+	Params          map[string]string `yaml:"params,omitempty"`
+}
+
+func buildExternalCredentialsResolvedConnections(cfg *config.Config) ([]externalCredentialsResolvedConnectionConfig, error) {
+	runtime, err := BuildConnectionRuntime(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if len(runtime) == 0 {
+		return nil, nil
+	}
+	providers := make([]string, 0, len(runtime))
+	for provider := range runtime {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+
+	var out []externalCredentialsResolvedConnectionConfig
+	hasCredentialRefresh := false
+	for _, provider := range providers {
+		connections := runtime[provider]
+		names := make([]string, 0, len(connections))
+		for name := range connections {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, connection := range names {
+			info := connections[connection]
+			refresh, err := externalCredentialsCredentialRefresh(info.CredentialRefresh)
+			if err != nil {
+				return nil, fmt.Errorf("%s/%s credentialRefresh: %w", provider, connection, err)
+			}
+			if refresh != nil {
+				hasCredentialRefresh = true
+			}
+			out = append(out, externalCredentialsResolvedConnectionConfig{
+				Provider:          provider,
+				Connection:        connection,
+				ConnectionID:      connectionRuntimeID(provider, connection, info),
+				Mode:              string(info.Mode),
+				Auth:              externalCredentialsResolvedAuth(info.AuthConfig),
+				ConnectionParams:  maps.Clone(info.Params),
+				CredentialRefresh: refresh,
+			})
+		}
+	}
+	if !hasCredentialRefresh {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func connectionRuntimeID(provider, connection string, info invocation.ConnectionRuntimeInfo) string {
+	if id := strings.TrimSpace(info.ConnectionID); id != "" {
+		return id
+	}
+	connection = strings.TrimSpace(connection)
+	if connection == "" {
+		connection = core.PluginConnectionName
+	}
+	return strings.TrimSpace(provider) + ":" + connection
+}
+
+func externalCredentialsCredentialRefresh(src *providermanifestv1.CredentialRefreshConfig) (*externalCredentialsCredentialRefreshConfig, error) {
+	if src == nil {
+		return nil, nil
+	}
+	refreshInterval, err := canonicalCredentialRefreshDuration(src.RefreshInterval)
+	if err != nil {
+		return nil, fmt.Errorf("refreshInterval: %w", err)
+	}
+	refreshBeforeExpiry, err := canonicalCredentialRefreshDuration(src.RefreshBeforeExpiry)
+	if err != nil {
+		return nil, fmt.Errorf("refreshBeforeExpiry: %w", err)
+	}
+	return &externalCredentialsCredentialRefreshConfig{
+		RefreshInterval:     refreshInterval,
+		RefreshBeforeExpiry: refreshBeforeExpiry,
+	}, nil
+}
+
+func canonicalCredentialRefreshDuration(value string) (string, error) {
+	duration, err := config.ParseDuration(strings.TrimSpace(value))
+	if err != nil {
+		return "", err
+	}
+	return duration.String(), nil
+}
+
+func externalCredentialsResolvedAuth(auth core.ExternalCredentialAuthConfig) externalCredentialsResolvedAuthConfig {
+	drivers := make([]externalCredentialsResolvedTokenExchangeDriver, 0, len(auth.TokenExchangeDrivers))
+	for _, driver := range auth.TokenExchangeDrivers {
+		drivers = append(drivers, externalCredentialsResolvedTokenExchangeDriver{
+			Type:            strings.TrimSpace(driver.Type),
+			TargetPrincipal: strings.TrimSpace(driver.TargetPrincipal),
+			Scopes:          slices.Clone(driver.Scopes),
+			LifetimeSeconds: driver.LifetimeSeconds,
+			Endpoint:        strings.TrimSpace(driver.Endpoint),
+			Params:          maps.Clone(driver.Params),
+		})
+	}
+	return externalCredentialsResolvedAuthConfig{
+		Type:                 auth.Type,
+		Token:                auth.Token,
+		TokenPrefix:          auth.TokenPrefix,
+		GrantType:            auth.GrantType,
+		TokenURL:             auth.TokenURL,
+		ClientID:             auth.ClientID,
+		ClientSecret:         auth.ClientSecret,
+		ClientAuth:           auth.ClientAuth,
+		TokenExchange:        auth.TokenExchange,
+		Scopes:               slices.Clone(auth.Scopes),
+		ScopeParam:           auth.ScopeParam,
+		ScopeSeparator:       auth.ScopeSeparator,
+		TokenParams:          maps.Clone(auth.TokenParams),
+		RefreshParams:        maps.Clone(auth.RefreshParams),
+		AcceptHeader:         auth.AcceptHeader,
+		AccessTokenPath:      auth.AccessTokenPath,
+		TokenExchangeDrivers: drivers,
+	}
+}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1529,16 +1529,19 @@ func (s ServerConfig) ManagementBaseURL() string {
 // ConnectionDef owns authentication and connection parameters for a named
 // connection.
 type ConnectionDef struct {
-	Ref              string                                `yaml:"ref,omitempty"`
-	DisplayName      string                                `yaml:"displayName,omitempty"`
-	Mode             providermanifestv1.ConnectionMode     `yaml:"mode"`
-	Exposure         providermanifestv1.ConnectionExposure `yaml:"exposure,omitempty"`
-	Auth             ConnectionAuthDef                     `yaml:"auth"`
-	ConnectionParams map[string]ConnectionParamDef         `yaml:"params"`
-	Discovery        *providermanifestv1.ProviderDiscovery `yaml:"-"`
-	ConnectionID     string                                `yaml:"-"`
-	BindingResolved  bool                                  `yaml:"-"`
+	Ref               string                                `yaml:"ref,omitempty"`
+	DisplayName       string                                `yaml:"displayName,omitempty"`
+	Mode              providermanifestv1.ConnectionMode     `yaml:"mode"`
+	Exposure          providermanifestv1.ConnectionExposure `yaml:"exposure,omitempty"`
+	Auth              ConnectionAuthDef                     `yaml:"auth"`
+	ConnectionParams  map[string]ConnectionParamDef         `yaml:"params"`
+	CredentialRefresh *CredentialRefreshDef                 `yaml:"credentialRefresh,omitempty"`
+	Discovery         *providermanifestv1.ProviderDiscovery `yaml:"-"`
+	ConnectionID      string                                `yaml:"-"`
+	BindingResolved   bool                                  `yaml:"-"`
 }
+
+type CredentialRefreshDef = providermanifestv1.CredentialRefreshConfig
 
 type ConnectionAuthDef struct {
 	Type                 providermanifestv1.AuthType `yaml:"type"`
@@ -1706,6 +1709,9 @@ func MergeConnectionDef(dst *ConnectionDef, src *ConnectionDef) {
 	MergeConnectionAuth(&dst.Auth, src.Auth)
 	if len(src.ConnectionParams) > 0 {
 		dst.ConnectionParams = maps.Clone(src.ConnectionParams)
+	}
+	if src.CredentialRefresh != nil {
+		dst.CredentialRefresh = cloneCredentialRefreshDef(src.CredentialRefresh)
 	}
 	if src.Discovery != nil {
 		dst.Discovery = src.Discovery

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5104,6 +5104,77 @@ func TestValidateStructureCanonicalizesConnectionAliasBindings(t *testing.T) {
 	}
 }
 
+func TestValidateStructureConnectionRefPreservesCredentialRefreshOverride(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		APIVersion: ConfigAPIVersion,
+		Connections: map[string]*ConnectionDef{
+			"shared": {
+				Mode: providermanifestv1.ConnectionModeUser,
+				Auth: ConnectionAuthDef{
+					Type:     providermanifestv1.AuthTypeOAuth2,
+					TokenURL: "https://oauth.example.test/token",
+				},
+				CredentialRefresh: &CredentialRefreshDef{
+					RefreshInterval:     "30m",
+					RefreshBeforeExpiry: "45m",
+				},
+			},
+		},
+		Plugins: map[string]*ProviderEntry{
+			"sample": {
+				Source: ProviderSource{Path: "./manifest.yaml"},
+				Connections: map[string]*ConnectionDef{
+					"default": {
+						Ref: "shared",
+						CredentialRefresh: &CredentialRefreshDef{
+							RefreshInterval:     "15m",
+							RefreshBeforeExpiry: "30m",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := ValidateStructure(cfg); err != nil {
+		t.Fatalf("ValidateStructure() error = %v", err)
+	}
+	canonical := cfg.Plugins["sample"].Connections["default"]
+	if canonical == nil || canonical.CredentialRefresh == nil {
+		t.Fatalf("resolved credentialRefresh missing: %+v", canonical)
+	}
+	if canonical.CredentialRefresh.RefreshInterval != "15m" || canonical.CredentialRefresh.RefreshBeforeExpiry != "30m" {
+		t.Fatalf("credentialRefresh = %+v, want binding override", canonical.CredentialRefresh)
+	}
+}
+
+func TestValidateStructureCredentialRefreshDurationContract(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		APIVersion: ConfigAPIVersion,
+		Connections: map[string]*ConnectionDef{
+			"shared": {
+				Mode: providermanifestv1.ConnectionModeUser,
+				CredentialRefresh: &CredentialRefreshDef{
+					RefreshInterval:     "0s",
+					RefreshBeforeExpiry: "30m",
+				},
+			},
+		},
+	}
+
+	err := ValidateStructure(cfg)
+	if err == nil {
+		t.Fatal("ValidateStructure() error = nil, want invalid duration")
+	}
+	if !strings.Contains(err.Error(), "credentialRefresh.refreshInterval") {
+		t.Fatalf("ValidateStructure() error = %v, want credentialRefresh.refreshInterval", err)
+	}
+}
+
 func TestValidateStructureRejectsConnectionAliasConflict(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -282,6 +282,9 @@ func normalizeConnectionBindings(cfg *Config) error {
 				resolved.DisplayName = binding.DisplayName
 			}
 			resolved.Exposure = binding.Exposure
+			if binding.CredentialRefresh != nil {
+				resolved.CredentialRefresh = cloneCredentialRefreshDef(binding.CredentialRefresh)
+			}
 			entry.Connections[localName] = &resolved
 		}
 		return nil
@@ -350,7 +353,16 @@ func cloneConnectionDef(src ConnectionDef) ConnectionDef {
 	dst := src
 	dst.Auth = cloneConnectionAuthDef(src.Auth)
 	dst.ConnectionParams = maps.Clone(src.ConnectionParams)
+	dst.CredentialRefresh = cloneCredentialRefreshDef(src.CredentialRefresh)
 	return dst
+}
+
+func cloneCredentialRefreshDef(src *CredentialRefreshDef) *CredentialRefreshDef {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	return &dst
 }
 
 func cloneConnectionAuthDef(src ConnectionAuthDef) ConnectionAuthDef {
@@ -580,6 +592,9 @@ func validateTopLevelConnections(cfg *Config) error {
 		case core.ConnectionModeNone, core.ConnectionModePlatform, core.ConnectionModeUser:
 		default:
 			return fmt.Errorf("config validation: connections.%s mode %q is not supported", id, conn.Mode)
+		}
+		if err := validateCredentialRefresh(fmt.Sprintf("connections.%s", id), *conn); err != nil {
+			return err
 		}
 		if len(conn.Auth.TokenExchangeDrivers) > 0 {
 			if mode != core.ConnectionModePlatform {
@@ -1908,11 +1923,31 @@ func validatePluginIntegrationConnections(name string, entry *ProviderEntry) err
 	if err := validateConnectionAuthMappings(name, plan.PluginConnection().Auth, "plugin"); err != nil {
 		return err
 	}
+	if err := validateCredentialRefresh(fmt.Sprintf("integration %q plugin connection", name), plan.PluginConnection()); err != nil {
+		return err
+	}
 	for _, connName := range plan.NamedConnectionNames() {
 		conn, _ := plan.NamedConnectionDef(connName)
 		if err := validateConnectionAuthMappings(name, conn.Auth, fmt.Sprintf("connection %q", connName)); err != nil {
 			return err
 		}
+		if err := validateCredentialRefresh(fmt.Sprintf("integration %q connection %q", name, connName), conn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCredentialRefresh(scope string, conn ConnectionDef) error {
+	refresh := conn.CredentialRefresh
+	if refresh == nil {
+		return nil
+	}
+	if _, err := ParseDuration(strings.TrimSpace(refresh.RefreshInterval)); err != nil {
+		return fmt.Errorf("config validation: %s credentialRefresh.refreshInterval: %w", scope, err)
+	}
+	if _, err := ParseDuration(strings.TrimSpace(refresh.RefreshBeforeExpiry)); err != nil {
+		return fmt.Errorf("config validation: %s credentialRefresh.refreshBeforeExpiry: %w", scope, err)
 	}
 	return nil
 }

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -37,29 +37,31 @@ type ResolvedConnectionSource struct {
 }
 
 type ResolvedConnectionDef struct {
-	Provider     string
-	Name         string
-	Ref          string
-	ConnectionID string
-	DisplayName  string
-	Mode         providermanifestv1.ConnectionMode
-	Exposure     providermanifestv1.ConnectionExposure
-	Auth         ConnectionAuthDef
-	Params       map[string]ConnectionParamDef
-	Discovery    *providermanifestv1.ProviderDiscovery
-	Source       ResolvedConnectionSource
+	Provider          string
+	Name              string
+	Ref               string
+	ConnectionID      string
+	DisplayName       string
+	Mode              providermanifestv1.ConnectionMode
+	Exposure          providermanifestv1.ConnectionExposure
+	Auth              ConnectionAuthDef
+	Params            map[string]ConnectionParamDef
+	Discovery         *providermanifestv1.ProviderDiscovery
+	CredentialRefresh *CredentialRefreshDef
+	Source            ResolvedConnectionSource
 }
 
 func (r ResolvedConnectionDef) ConnectionDef() ConnectionDef {
 	return ConnectionDef{
-		Ref:              r.Ref,
-		DisplayName:      r.DisplayName,
-		Mode:             r.Mode,
-		Exposure:         r.Exposure,
-		Auth:             r.Auth,
-		ConnectionParams: r.Params,
-		Discovery:        r.Discovery,
-		ConnectionID:     r.ConnectionID,
+		Ref:               r.Ref,
+		DisplayName:       r.DisplayName,
+		Mode:              r.Mode,
+		Exposure:          r.Exposure,
+		Auth:              r.Auth,
+		ConnectionParams:  r.Params,
+		Discovery:         r.Discovery,
+		CredentialRefresh: r.CredentialRefresh,
+		ConnectionID:      r.ConnectionID,
 	}
 }
 
@@ -582,6 +584,9 @@ func ResolveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *providerma
 			if len(def.Params) > 0 {
 				conn.ConnectionParams = maps.Clone(def.Params)
 			}
+			if def.CredentialRefresh != nil {
+				conn.CredentialRefresh = cloneCredentialRefreshDef(def.CredentialRefresh)
+			}
 			if def.Discovery != nil {
 				conn.Discovery = def.Discovery
 			}
@@ -628,16 +633,17 @@ func ResolveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *providerma
 
 func resolvedConnectionDef(name string, conn ConnectionDef, source ResolvedConnectionSource) ResolvedConnectionDef {
 	return ResolvedConnectionDef{
-		Name:         name,
-		Ref:          conn.Ref,
-		ConnectionID: conn.ConnectionID,
-		DisplayName:  conn.DisplayName,
-		Mode:         conn.Mode,
-		Exposure:     conn.Exposure,
-		Auth:         conn.Auth,
-		Params:       conn.ConnectionParams,
-		Discovery:    conn.Discovery,
-		Source:       source,
+		Name:              name,
+		Ref:               conn.Ref,
+		ConnectionID:      conn.ConnectionID,
+		DisplayName:       conn.DisplayName,
+		Mode:              conn.Mode,
+		Exposure:          conn.Exposure,
+		Auth:              conn.Auth,
+		Params:            conn.ConnectionParams,
+		Discovery:         conn.Discovery,
+		CredentialRefresh: conn.CredentialRefresh,
+		Source:            source,
 	}
 }
 

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -398,6 +398,27 @@
         },
         "discovery": {
           "$ref": "#/$defs/providerDiscovery"
+        },
+        "credentialRefresh": {
+          "$ref": "#/$defs/credentialRefreshConfig"
+        }
+      }
+    },
+    "credentialRefreshConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "refreshInterval",
+        "refreshBeforeExpiry"
+      ],
+      "properties": {
+        "refreshInterval": {
+          "type": "string",
+          "minLength": 1
+        },
+        "refreshBeforeExpiry": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -372,12 +372,18 @@ type ManifestOperationOverride struct {
 }
 
 type ManifestConnectionDef struct {
-	DisplayName string                             `json:"displayName,omitempty" yaml:"displayName,omitempty"`
-	Mode        ConnectionMode                     `json:"mode,omitempty" yaml:"mode,omitempty"`
-	Exposure    ConnectionExposure                 `json:"exposure,omitempty" yaml:"exposure,omitempty"`
-	Auth        *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
-	Params      map[string]ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
-	Discovery   *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
+	DisplayName       string                             `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Mode              ConnectionMode                     `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Exposure          ConnectionExposure                 `json:"exposure,omitempty" yaml:"exposure,omitempty"`
+	Auth              *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Params            map[string]ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
+	Discovery         *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
+	CredentialRefresh *CredentialRefreshConfig           `json:"credentialRefresh,omitempty" yaml:"credentialRefresh,omitempty"`
+}
+
+type CredentialRefreshConfig struct {
+	RefreshInterval     string `json:"refreshInterval,omitempty" yaml:"refreshInterval,omitempty"`
+	RefreshBeforeExpiry string `json:"refreshBeforeExpiry,omitempty" yaml:"refreshBeforeExpiry,omitempty"`
 }
 
 type UIRoute struct {

--- a/gestaltd/services/invocation/connection_runtime.go
+++ b/gestaltd/services/invocation/connection_runtime.go
@@ -21,15 +21,16 @@ type ConnectionRuntimeCredentialSource interface {
 // ConnectionRuntimeInfo describes deployment-owned connection material that is
 // resolved after an operation selects its concrete connection.
 type ConnectionRuntimeInfo struct {
-	ConnectionID string
-	Mode         core.ConnectionMode
-	Exposure     core.ConnectionExposure
-	AuthType     providermanifestv1.AuthType
-	AuthConfig   core.ExternalCredentialAuthConfig
-	Token        string
-	TokenSource  ConnectionRuntimeCredentialSource
-	AuthMapping  *providermanifestv1.AuthMapping
-	Params       map[string]string
+	ConnectionID      string
+	Mode              core.ConnectionMode
+	Exposure          core.ConnectionExposure
+	AuthType          providermanifestv1.AuthType
+	AuthConfig        core.ExternalCredentialAuthConfig
+	Token             string
+	TokenSource       ConnectionRuntimeCredentialSource
+	AuthMapping       *providermanifestv1.AuthMapping
+	Params            map[string]string
+	CredentialRefresh *providermanifestv1.CredentialRefreshConfig
 }
 
 // ConnectionRuntimeResolver resolves runtime metadata for a provider


### PR DESCRIPTION
## Summary

- Add connection-level `credentialRefresh` metadata to provider manifests and deployment connection config.
- Preserve the metadata through manifest/deploy/ref resolution and `ConnectionRuntimeInfo` without adding refresh execution logic to gestaltd.
- Pass a generic `resolvedConnections` catalog to the external credentials provider only when a resolved connection declares `credentialRefresh`.
- Document that external credentials providers own proactive maintenance support.

## Interface Changes

- New/changed interface: connection definitions may include `credentialRefresh.refreshInterval` and `credentialRefresh.refreshBeforeExpiry`.
- Example usage:

```yaml
connections:
  google-workspace:
    mode: user
    auth:
      type: oauth2
      tokenUrl: https://oauth2.googleapis.com/token
    credentialRefresh:
      refreshInterval: 15m
      refreshBeforeExpiry: 30m
```

- Provider runtime config example when at least one connection opts in:

```yaml
resolvedConnections:
  - provider: gmail
    connection: default
    connectionId: google-workspace
    mode: user
    auth:
      type: oauth2
      tokenUrl: https://oauth2.googleapis.com/token
    credentialRefresh:
      refreshInterval: 15m0s
      refreshBeforeExpiry: 30m0s
```

## Functional/Integration Tests

- Tests added or augmented: config/ref resolution contract tests and bootstrap runtime-config contract tests.
- Contract boundary covered: provider manifest/deploy config -> resolved connection runtime -> external credentials provider Configure YAML.
- Commands run:
  - `go test ./internal/config ./internal/bootstrap`
  - `go test ./internal/bootstrap -run 'Test(BuildConnectionRuntime|BuildExternalCredentialsRuntimeConfigNode|ClientCredentialsTokenSourceFetchTimeoutReleasesFlight)'`
  - `git diff --check`

## Test plan

- [x] `go test ./internal/config ./internal/bootstrap`
- [x] `git diff --check`
