### PR TITLE
Bootstrap dynamic authorization roles

### DIFF
--- a/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
@@ -113,6 +113,13 @@ func (s *Server) replaceProviderDynamicMembership(ctx context.Context, resource 
 	if len(writes) == 0 && len(deletes) == 0 {
 		return existing, func(context.Context) {}, nil
 	}
+	if len(writes) > 0 {
+		if ensuredModelID, err := s.ensureManagedDynamicRole(ctx, resource, role); err != nil {
+			return nil, nil, err
+		} else if strings.TrimSpace(ensuredModelID) != "" {
+			modelID = strings.TrimSpace(ensuredModelID)
+		}
+	}
 	if err := s.authorizationProvider.WriteRelationships(ctx, &core.WriteRelationshipsRequest{
 		Writes:  writes,
 		Deletes: deletes,
@@ -129,6 +136,18 @@ func (s *Server) replaceProviderDynamicMembership(ctx context.Context, resource 
 			ModelId: modelID,
 		})
 	}, nil
+}
+
+func (s *Server) ensureManagedDynamicRole(ctx context.Context, resource *core.ResourceRef, role string) (string, error) {
+	switch strings.TrimSpace(resource.GetType()) {
+	case authorization.ProviderResourceTypePluginDynamic, authorization.ProviderResourceTypeAdminDynamic:
+	default:
+		return s.managedAuthorizationModelID(ctx)
+	}
+	if ensurer, ok := s.authorizer.(authorization.ManagedAuthorizationDynamicRoleEnsurer); ok {
+		return ensurer.EnsureManagedDynamicRole(ctx, resource, role)
+	}
+	return s.managedAuthorizationModelID(ctx)
 }
 
 func (s *Server) deleteProviderDynamicMembership(ctx context.Context, resource *core.ResourceRef, subjectID string) ([]*core.Relationship, func(context.Context), error) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1904,13 +1904,16 @@ type memoryAuthorizationProvider struct {
 	mu            sync.Mutex
 	activeModelID string
 	models        []*core.AuthorizationModelRef
+	modelDefs     map[string]*core.AuthorizationModel
 	relsByModel   map[string]map[string]*core.Relationship
 	writeErr      error
+	validateModel bool
 }
 
 func newMemoryAuthorizationProvider(name string) *memoryAuthorizationProvider {
 	return &memoryAuthorizationProvider{
 		name:        name,
+		modelDefs:   map[string]*core.AuthorizationModel{},
 		relsByModel: map[string]map[string]*core.Relationship{},
 	}
 }
@@ -2035,6 +2038,13 @@ func (p *memoryAuthorizationProvider) WriteRelationships(_ context.Context, req 
 		rels = map[string]*core.Relationship{}
 		p.relsByModel[modelID] = rels
 	}
+	if p.validateModel {
+		for _, rel := range req.GetWrites() {
+			if !memoryAuthorizationModelAllowsRelationship(p.modelDefs[modelID], rel) {
+				return fmt.Errorf("model %q does not allow relationship %s", modelID, memoryAuthorizationRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource()))
+			}
+		}
+	}
 	for _, key := range req.GetDeletes() {
 		delete(rels, memoryAuthorizationRelationshipKey(key.GetSubject(), key.GetRelation(), key.GetResource()))
 	}
@@ -2082,6 +2092,7 @@ func (p *memoryAuthorizationProvider) WriteModel(_ context.Context, req *core.Wr
 	for _, existing := range p.models {
 		if existing.GetId() == modelID {
 			p.activeModelID = modelID
+			p.modelDefs[modelID] = gproto.Clone(definition).(*core.AuthorizationModel)
 			if p.relsByModel[modelID] == nil {
 				p.relsByModel[modelID] = map[string]*core.Relationship{}
 			}
@@ -2093,11 +2104,31 @@ func (p *memoryAuthorizationProvider) WriteModel(_ context.Context, req *core.Wr
 		Version: fmt.Sprintf("%d", modelVersion),
 	}
 	p.models = append(p.models, model)
+	p.modelDefs[model.GetId()] = gproto.Clone(definition).(*core.AuthorizationModel)
 	p.activeModelID = model.GetId()
 	if p.relsByModel[model.GetId()] == nil {
 		p.relsByModel[model.GetId()] = map[string]*core.Relationship{}
 	}
 	return model, nil
+}
+
+func memoryAuthorizationModelAllowsRelationship(model *core.AuthorizationModel, rel *core.Relationship) bool {
+	if model == nil || rel == nil || rel.GetResource() == nil {
+		return false
+	}
+	resourceType := rel.GetResource().GetType()
+	relation := rel.GetRelation()
+	for _, rt := range model.GetResourceTypes() {
+		if rt.GetName() != resourceType {
+			continue
+		}
+		for _, allowed := range rt.GetRelations() {
+			if allowed.GetName() == relation {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func memoryAuthorizationRelationshipMatches(rel *core.Relationship, req *core.ReadRelationshipsRequest) bool {
@@ -5529,6 +5560,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 
 	svc := testutil.NewStubServices(t)
 	provider := newMemoryAuthorizationProvider("memory-authorization")
+	provider.validateModel = true
 	baseAuthz, err := newTestAuthorizer(config.AuthorizationConfig{
 		Policies: map[string]config.SubjectPolicyDef{
 			"sample_policy": {
@@ -5967,6 +5999,7 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 	seedUser(t, svc, "static-admin@example.test")
 	const adminRole = "owner"
 	provider := newMemoryAuthorizationProvider("memory-authorization")
+	provider.validateModel = true
 	baseAuthz := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.SubjectPolicyDef{
 			"admin_policy": {

--- a/gestaltd/services/authorization/provider_backed.go
+++ b/gestaltd/services/authorization/provider_backed.go
@@ -36,6 +36,8 @@ type ProviderBackedAuthorizer struct {
 	pollCancel  context.CancelFunc
 	pollDone    chan struct{}
 
+	reloadMu sync.Mutex
+
 	stateMu sync.RWMutex
 	state   providerBackedRoleState
 }
@@ -118,27 +120,74 @@ func (a *ProviderBackedAuthorizer) ReloadAuthorizationState(ctx context.Context)
 		return nil
 	}
 
+	a.reloadMu.Lock()
+	defer a.reloadMu.Unlock()
+	_, err := a.reloadAuthorizationStateLocked(ctx, nil)
+	return err
+}
+
+func (a *ProviderBackedAuthorizer) EnsureManagedDynamicRole(ctx context.Context, resource *core.ResourceRef, role string) (string, error) {
+	if a == nil {
+		return "", fmt.Errorf("authorization provider is unavailable")
+	}
+	resourceType := strings.TrimSpace(resource.GetType())
+	resourceID := strings.TrimSpace(resource.GetId())
+	role = strings.TrimSpace(role)
+	if resourceType == "" || resourceID == "" {
+		return "", fmt.Errorf("authorization resource is required")
+	}
+	if role == "" {
+		return "", fmt.Errorf("authorization role is required")
+	}
+
+	a.reloadMu.Lock()
+	defer a.reloadMu.Unlock()
+	return a.reloadAuthorizationStateLocked(ctx, func(roles *providerBackedRoleState) error {
+		switch resourceType {
+		case resourceTypePluginDynamic:
+			if roles.pluginDynamicRoles == nil {
+				roles.pluginDynamicRoles = map[string][]string{}
+			}
+			roles.pluginDynamicRoles[resourceID] = roleListWith(roles.pluginDynamicRoles[resourceID], role)
+		case resourceTypeAdminDynamic:
+			if resourceID != resourceIDAdminDynamicGlobal {
+				return fmt.Errorf("unsupported admin dynamic resource %q", resourceID)
+			}
+			roles.adminDynamicRoles = roleListWith(roles.adminDynamicRoles, role)
+		default:
+			return fmt.Errorf("unsupported managed dynamic resource type %q", resourceType)
+		}
+		return nil
+	})
+}
+
+func (a *ProviderBackedAuthorizer) reloadAuthorizationStateLocked(ctx context.Context, mutateRoles func(*providerBackedRoleState) error) (string, error) {
 	sourceModelID, err := a.sourceModelID(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
 	sourceExisting := map[string]*core.Relationship{}
 	if sourceModelID != "" {
 		sourceExisting, err = a.readAllRelationships(ctx, sourceModelID)
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
 	desired, roles, err := a.buildDesiredRelationships(sourceExisting)
 	if err != nil {
-		return err
+		return "", err
+	}
+	if mutateRoles != nil {
+		if err := mutateRoles(&roles); err != nil {
+			return "", err
+		}
 	}
 	model, err := a.provider.WriteModel(ctx, &core.WriteModelRequest{Model: buildProviderAuthorizationModel(roles)})
 	if err != nil {
-		return fmt.Errorf("write authorization model: %w", err)
+		return "", fmt.Errorf("write authorization model: %w", err)
 	}
 	if model == nil || strings.TrimSpace(model.GetId()) == "" {
-		return fmt.Errorf("write authorization model: missing model id")
+		return "", fmt.Errorf("write authorization model: missing model id")
 	}
 	modelID := strings.TrimSpace(model.GetId())
 
@@ -146,7 +195,7 @@ func (a *ProviderBackedAuthorizer) ReloadAuthorizationState(ctx context.Context)
 	if modelID != sourceModelID {
 		targetExisting, err = a.readAllRelationships(ctx, modelID)
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
 
@@ -157,7 +206,7 @@ func (a *ProviderBackedAuthorizer) ReloadAuthorizationState(ctx context.Context)
 			Deletes: deletes,
 			ModelId: modelID,
 		}); err != nil {
-			return fmt.Errorf("sync authorization relationships: %w", err)
+			return "", fmt.Errorf("sync authorization relationships: %w", err)
 		}
 	}
 
@@ -165,7 +214,7 @@ func (a *ProviderBackedAuthorizer) ReloadAuthorizationState(ctx context.Context)
 	roles.modelID = modelID
 	a.state = roles
 	a.stateMu.Unlock()
-	return nil
+	return modelID, nil
 }
 
 func (a *ProviderBackedAuthorizer) ManagedModelID(ctx context.Context) (string, error) {
@@ -699,6 +748,23 @@ func normalizeRoleList(roles map[string]struct{}) []string {
 		return roleSortKey(out[i]) < roleSortKey(out[j])
 	})
 	return out
+}
+
+func roleListWith(roles []string, role string) []string {
+	role = strings.TrimSpace(role)
+	if role == "" {
+		return append([]string(nil), roles...)
+	}
+	roleSet := make(map[string]struct{}, len(roles)+1)
+	for _, existing := range roles {
+		existing = strings.TrimSpace(existing)
+		if existing == "" {
+			continue
+		}
+		roleSet[existing] = struct{}{}
+	}
+	roleSet[role] = struct{}{}
+	return normalizeRoleList(roleSet)
 }
 
 func ensureRoleSet(target map[string]map[string]struct{}, key string) map[string]struct{} {

--- a/gestaltd/services/authorization/runtime.go
+++ b/gestaltd/services/authorization/runtime.go
@@ -3,6 +3,7 @@ package authorization
 import (
 	"context"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
@@ -41,6 +42,12 @@ type ProviderActionAuthorizer interface {
 // the current runtime authorizer when one exists.
 type ManagedAuthorizationModelResolver interface {
 	ManagedModelID(ctx context.Context) (string, error)
+}
+
+// ManagedAuthorizationDynamicRoleEnsurer prepares the managed authorization
+// model for a dynamic role before the corresponding relationship is written.
+type ManagedAuthorizationDynamicRoleEnsurer interface {
+	EnsureManagedDynamicRole(ctx context.Context, resource *core.ResourceRef, role string) (string, error)
 }
 
 var _ RuntimeAuthorizer = (*Authorizer)(nil)


### PR DESCRIPTION
## Summary
- prepare provider-backed managed models with a requested plugin/admin dynamic role before writing the relationship
- keep non-plugin/admin managed relationship writes on the existing model path
- add test-provider model validation for dynamic admin and plugin grants

## Test plan
- [x] go test ./internal/server -run 'TestAdminAPI_(PluginAuthorizationProviderBackedReadsAndDebug|AdminAuthorizationProviderBackedReads)$' -count=1\n- [x] go test ./internal/server -run '^TestAuthorizationManagedSubjectsAPI$' -count=1\n- [x] go test ./internal/server ./services/authorization