### PR TITLE
Document proactive external credential refresh

### DIFF
--- a/docs/content/architecture/security-internals.mdx
+++ b/docs/content/architecture/security-internals.mdx
@@ -30,9 +30,11 @@ Manual connections store the user-provided credential as the access token with a
 
 ### Refresh
 
-Refresh is on-demand during invocation, not a background job. If a token expires within 5 minutes and has a refresh token, the broker attempts a refresh. Concurrent attempts for the same token are deduplicated via singleflight.
+By default, refresh happens on demand during invocation. If a token expires within 5 minutes and has a refresh token, the broker asks the external credentials provider to resolve a fresh runtime credential. Concurrent attempts for the same token are deduplicated via singleflight.
 
-On success: new tokens encrypted and stored, `refresh_error_count` reset. On failure: error count incremented. If the token is still technically valid, it's used anyway. If expired, the invocation fails. The persisted error count lets operators spot tokens stuck in a failure loop.
+Connections that declare `credentialRefresh` can also be maintained proactively by a supporting external credentials provider. Gestalt passes the resolved connection auth and refresh cadence to the provider as metadata; the provider owns the scheduler and persistence behavior.
+
+On refresh success: new tokens are encrypted and stored, and refresh failure state is reset. On transient failure: the existing credential is preserved, and if the access token is still technically valid it can still be used. If the token is expired or the upstream provider returns a terminal invalid grant, invocation requires reconnect. Persisted failure state lets operators spot tokens stuck in a failure loop.
 
 ### Revocation
 

--- a/docs/content/providers/external-credentials.mdx
+++ b/docs/content/providers/external-credentials.mdx
@@ -55,7 +55,13 @@ The external credentials provider participates in two parts of the lifecycle:
    the resulting credential.
 2. **Runtime.** When a plugin, workflow, or agent-bound connection needs to call
    an upstream service, Gestalt asks the external credentials provider to resolve
-   a usable runtime credential for the selected connection.
+   a usable runtime credential for the selected connection. Resolution may
+   refresh an expiring access token on demand when the connection auth supports
+   it.
+3. **Maintenance.** Connections with `credentialRefresh` opt into
+   provider-owned background maintenance. Gestalt passes the resolved connection
+   metadata to the external credentials provider; a supporting provider can
+   refresh stored credentials before first use.
 
 Credential material can include access tokens, refresh tokens, API keys, and
 provider-specific token responses. The exact shape depends on the connection's
@@ -164,18 +170,30 @@ not need to know which of those paths was used.
 
 ### Proactive maintenance
 
-Connections may declare `credentialRefresh` metadata in provider manifests or
-deployment config. Gestalt resolves that metadata with the rest of the
-connection definition and passes a generic `resolvedConnections` catalog to the
-configured external credentials provider only when at least one resolved
-connection declares proactive refresh.
+Connections can declare `credentialRefresh` in a provider manifest or deployment
+config. Gestalt resolves that metadata with the final connection definition and
+passes a `resolvedConnections` catalog into the configured external credentials
+provider only when at least one connection declares proactive refresh.
 
-External credentials providers own maintenance support. A provider that supports
-the resolved auth shape can scan stored credentials and refresh them before
-expiry. A provider that receives `credentialRefresh` metadata it cannot support
-should fail configuration rather than silently ignore it. Gestalt does not add a
-separate refresh RPC; maintenance is provider behavior configured through the
-normal provider lifecycle.
+The catalog includes the provider name, connection name, stable connection ID,
+mode, resolved auth config, and canonical `credentialRefresh` durations. It is
+intentionally provider-neutral: Gestalt does not run a refresh scheduler itself
+and does not add a separate refresh RPC. The external credentials provider
+decides whether a resolved connection is refreshable and owns any scheduler,
+token endpoint call, retry, and persistence behavior.
+
+The first-party `external_credentials/default` provider supports proactive
+refresh for user-mode credentials whose resolved auth can refresh tokens. For
+OAuth-style connections that means the auth config must include a token URL and
+client credentials. The provider scans credentials on `refreshInterval`,
+refreshes credentials expiring within `refreshBeforeExpiry`, persists rotated
+access and refresh tokens, preserves existing credentials on transient refresh
+failures, and removes credentials only when the upstream token endpoint returns
+a terminal invalid-grant style response.
+
+This is preventative maintenance, not credential recovery. If the upstream
+provider has already revoked or expired the refresh token, the user or operator
+must reconnect the connection to obtain a new refresh token.
 
 ### SDK request fields
 

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -27,7 +27,7 @@ Access tokens, refresh tokens, pending connection state, and OAuth state paramet
 
 **API tokens.** Generated with 32 random bytes from `crypto/rand` and prefixed with `gst_api_`. The plaintext is returned once at creation time. Only the SHA-256 hash is stored. Default TTL is 30 days, configurable via `server.apiTokenTtl`.
 
-**Plugin tokens (OAuth).** OAuth state is encrypted with a 10-minute TTL to prevent state injection. After the authorization code exchange, access and refresh tokens are encrypted separately and stored. Gestalt automatically refreshes tokens that expire within 5 minutes.
+**Plugin tokens (OAuth).** OAuth state is encrypted with a 10-minute TTL to prevent state injection. After the authorization code exchange, access and refresh tokens are encrypted separately and stored. Gestalt refreshes expiring tokens on demand during invocation, and connections that declare `credentialRefresh` can be maintained proactively by a supporting external credentials provider.
 
 ## Request authentication
 


### PR DESCRIPTION
## Summary
- Document that external credentials providers can maintain `credentialRefresh` connections proactively.
- Clarify that Gestalt still refreshes tokens on demand by default, while provider-owned maintenance handles configured proactive refresh.
- Update security docs so they no longer describe refresh as only invocation-time behavior.

## Test plan
- [x] `git diff --check`
- [x] `npm run typecheck` from `docs/`
- [x] `npm run build` from `docs/`
- [ ] `npm run lint` from `docs/` currently fails because `next lint` is treated as a project directory by the installed Next version.