### PR TITLE
Launch configured local agent harness by default

### DIFF
--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -40,6 +40,7 @@ jobs:
       artifact-prefix: gestalt
       run-tests: true
       package: true
+      bundle-gestaltd: true
 
   release:
     name: Publish Release
@@ -140,6 +141,7 @@ jobs:
             old_version=$(grep '^\s*version ' "$formula" | sed 's/.*version "\(.*\)"/\1/')
 
             sed -i "s/version \"${old_version}\"/version \"${VERSION}\"/" "$formula"
+            perl -0pi -e 's/bin\.install "gestalt"(?:, "gestaltd")?/bin.install "gestalt", "gestaltd"/' "$formula"
             perl -0pi -e 's{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-macos-arm64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-macos-arm64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-macos-x86_64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-macos-x86_64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-linux-arm64(?:-musl)?\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-linux-arm64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-linux-x86_64(?:-musl)?\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-linux-x86_64.tar.gz}g' "$formula"
 
             awk -v sha_macos_arm64="$SHA_MACOS_ARM64" \
@@ -171,6 +173,7 @@ jobs:
             cat "$formula"
             echo ""
             grep -q "version \"${VERSION}\"" "$formula" || { echo "ERROR: version not updated in ${formula}"; exit 1; }
+            grep -q 'bin.install "gestalt", "gestaltd"' "$formula" || { echo "ERROR: gestaltd helper not installed in ${formula}"; exit 1; }
             grep -q "PLACEHOLDER" "$formula" && { echo "ERROR: PLACEHOLDER still present in ${formula}"; exit 1; }
           done
           echo "Formula verified successfully"

--- a/.github/workflows/rust-build-matrix.yml
+++ b/.github/workflows/rust-build-matrix.yml
@@ -23,6 +23,10 @@ on:
         description: 'Run tests on native targets'
         type: boolean
         default: true
+      bundle-gestaltd:
+        description: 'Bundle the gestaltd helper binary with the Rust binary'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -41,30 +45,43 @@ jobs:
             runs-on: macos-latest
             target: aarch64-apple-darwin
             suffix: macos-arm64
+            goos: darwin
+            goarch: arm64
           - name: macOS-x86_64
             runs-on: macos-latest
             target: x86_64-apple-darwin
             suffix: macos-x86_64
+            goos: darwin
+            goarch: amd64
           - name: Linux-x86_64
             runs-on: ubuntu-latest
             target: x86_64-unknown-linux-musl
             suffix: linux-x86_64
             cross: true
+            goos: linux
+            goarch: amd64
           - name: Linux-ARM64
             runs-on: ubuntu-latest
             target: aarch64-unknown-linux-musl
             suffix: linux-arm64
             cross: true
+            goos: linux
+            goarch: arm64
           - name: Linux-ARMv7
             runs-on: ubuntu-latest
             target: armv7-unknown-linux-musleabihf
             suffix: linux-armv7
             cross: true
+            goos: linux
+            goarch: arm
+            goarm: '7'
           - name: Windows-x86_64
             runs-on: windows-latest
             target: x86_64-pc-windows-msvc
             suffix: windows-x86_64
             windows: true
+            goos: windows
+            goarch: amd64
 
     runs-on: ${{ matrix.platform.runs-on }}
 
@@ -94,6 +111,13 @@ jobs:
         run: |
           command -v cross >/dev/null 2>&1 || cargo install cross --version 0.2.5
 
+      - name: Install Go toolchain
+        if: ${{ inputs.bundle-gestaltd }}
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: gestaltd/go.mod
+          cache-dependency-path: gestaltd/go.sum
+
       - name: Build (native)
         if: ${{ !matrix.platform.cross }}
         working-directory: ${{ inputs.working-directory }}
@@ -120,13 +144,41 @@ jobs:
         timeout-minutes: ${{ matrix.platform.windows && 15 || 5 }}
         run: cargo test --release --target ${{ matrix.platform.target }}
 
+      - name: Build gestaltd helper
+        if: ${{ inputs.bundle-gestaltd }}
+        shell: bash
+        env:
+          CGO_ENABLED: '0'
+          GOOS: ${{ matrix.platform.goos }}
+          GOARCH: ${{ matrix.platform.goarch }}
+          GOARM: ${{ matrix.platform.goarm }}
+        run: |
+          mkdir -p helper
+          version="${GITHUB_REF_NAME##*/}"
+          ext=""
+          if [ "$GOOS" = "windows" ]; then
+            ext=".exe"
+          fi
+          (
+            cd gestaltd
+            go build \
+              -ldflags "-X main.version=${version}" \
+              -o "../helper/gestaltd${ext}" \
+              ./cmd/gestaltd
+          )
+
       - name: Package binary (Unix)
         if: ${{ inputs.package && !matrix.platform.windows }}
         run: |
           mkdir -p dist
           cp ${{ inputs.working-directory }}/target/${{ matrix.platform.target }}/release/${{ inputs.binary-name }} dist/
+          files="${{ inputs.binary-name }}"
+          if [ "${{ inputs.bundle-gestaltd }}" = "true" ]; then
+            cp helper/gestaltd dist/
+            files="${files} gestaltd"
+          fi
           cd dist
-          tar -czvf ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.tar.gz ${{ inputs.binary-name }}
+          tar -czvf ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.tar.gz ${files}
           shasum -a 256 ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.tar.gz > ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.tar.gz.sha256
 
       - name: Package binary (Windows)
@@ -135,8 +187,13 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path dist
           Copy-Item ${{ inputs.working-directory }}/target/${{ matrix.platform.target }}/release/${{ inputs.binary-name }}.exe dist/
+          $archivePaths = @("${{ inputs.binary-name }}.exe")
+          if ("${{ inputs.bundle-gestaltd }}" -eq "true") {
+            Copy-Item helper/gestaltd.exe dist/
+            $archivePaths += "gestaltd.exe"
+          }
           Set-Location dist
-          Compress-Archive -Path ${{ inputs.binary-name }}.exe -DestinationPath ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.zip
+          Compress-Archive -Path $archivePaths -DestinationPath ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.zip
           $hash = (Get-FileHash ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.zip -Algorithm SHA256).Hash.ToLower()
           "$hash  ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.zip" | Out-File -Encoding ascii ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.zip.sha256
 

--- a/gestalt/Dockerfile
+++ b/gestalt/Dockerfile
@@ -16,7 +16,8 @@ RUN case "$TARGETARCH" in \
     esac && \
     mkdir -p /out && \
     tar -xzf "$archive" -C /out && \
-    test -x /out/gestalt
+    test -x /out/gestalt && \
+    test -x /out/gestaltd
 
 FROM gcr.io/distroless/cc-debian12@sha256:847433844c7e04bcf07a3a0f0f5a8de554c6df6fa9e3e3ab14d3f6b73d780235 AS distroless
 ARG GESTALT_VERSION
@@ -26,6 +27,7 @@ ARG GESTALT_SOURCE
 ARG GESTALT_DOCUMENTATION
 ARG GESTALT_URL
 COPY --from=unpack /out/gestalt /gestalt
+COPY --from=unpack /out/gestaltd /gestaltd
 LABEL org.opencontainers.image.title="gestalt" \
       org.opencontainers.image.description="CLI client for managing Gestalt integrations, authentication, and operations." \
       org.opencontainers.image.source="${GESTALT_SOURCE}" \

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -221,6 +221,18 @@ pub struct AgentArgs {
     #[command(subcommand)]
     pub command: Option<AgentCommands>,
 
+    /// Run the agent harness locally (default for `gestalt agent`)
+    #[arg(long, conflicts_with = "cloud")]
+    pub local: bool,
+
+    /// Run through the configured Gestalt server
+    #[arg(long, conflicts_with = "local")]
+    pub cloud: bool,
+
+    /// Gestaltd config path for local agent launch; repeat to layer overrides
+    #[arg(long = "config")]
+    pub config: Vec<String>,
+
     /// Agent provider name for a new session
     #[arg(long)]
     pub provider: Option<String>,
@@ -246,6 +258,8 @@ pub struct AgentArgs {
 pub enum AgentCommands {
     /// Resume an interactive agent session
     Resume(AgentResumeArgs),
+    /// Check the configured local agent harness
+    Doctor(AgentDoctorArgs),
     /// Inspect and control agent sessions
     Sessions {
         #[command(subcommand)]
@@ -256,6 +270,17 @@ pub enum AgentCommands {
         #[command(subcommand)]
         command: AgentTurnCommands,
     },
+}
+
+#[derive(Args)]
+pub struct AgentDoctorArgs {
+    /// Agent provider name; defaults to the configured default
+    #[arg(long)]
+    pub provider: Option<String>,
+
+    /// Gestaltd config path for local agent launch; repeat to layer overrides
+    #[arg(long = "config")]
+    pub config: Vec<String>,
 }
 
 #[derive(Args)]

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -3,6 +3,8 @@ use colored::Colorize;
 use serde::{Deserialize, Deserializer, de::DeserializeOwned};
 use serde_json::{Map, Value, json};
 use std::io::{self, BufRead, BufReader, IsTerminal, Write};
+use std::path::PathBuf;
+use std::process::{Command as ProcessCommand, ExitStatus, Stdio};
 use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicU64, Ordering},
@@ -33,6 +35,78 @@ const DEFAULT_EVENT_PAGE_SIZE: u32 = 100;
 const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const EVENT_STREAM_UNTIL_BLOCKED_OR_TERMINAL: &str = "blocked_or_terminal";
 const INTERRUPT_CANCEL_REASON: &str = "operator interrupted";
+
+pub fn launch_local(provider: Option<&str>, config_paths: &[String]) -> Result<()> {
+    run_local_agent_helper("launch", provider, config_paths)
+}
+
+pub fn doctor_local(provider: Option<&str>, config_paths: &[String]) -> Result<()> {
+    run_local_agent_helper("doctor", provider, config_paths)
+}
+
+fn run_local_agent_helper(
+    action: &str,
+    provider: Option<&str>,
+    config_paths: &[String],
+) -> Result<()> {
+    let helper = find_gestaltd_helper()?;
+    let mut cmd = ProcessCommand::new(&helper);
+    cmd.arg("agent").arg(action);
+    for config_path in config_paths {
+        cmd.arg("--config").arg(config_path);
+    }
+    if let Some(provider) = provider {
+        cmd.arg("--provider").arg(provider);
+    }
+    let status = cmd
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .with_context(|| {
+            format!(
+                "failed to start gestaltd local agent helper at {}",
+                helper.display()
+            )
+        })?;
+    if status.success() {
+        return Ok(());
+    }
+    std::process::exit(helper_exit_code(status));
+}
+
+fn helper_exit_code(status: ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            return 128 + signal;
+        }
+    }
+    1
+}
+
+fn find_gestaltd_helper() -> Result<PathBuf> {
+    let current_exe = std::env::current_exe().context("failed to resolve current executable")?;
+    if let Some(parent) = current_exe.parent() {
+        let sibling = parent.join(helper_binary_name());
+        if sibling.exists() {
+            return Ok(sibling);
+        }
+    }
+    Ok(PathBuf::from(helper_binary_name()))
+}
+
+fn helper_binary_name() -> &'static str {
+    if cfg!(windows) {
+        "gestaltd.exe"
+    } else {
+        "gestaltd"
+    }
+}
 
 pub fn create_session(
     client: &ApiClient,

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -13,6 +13,7 @@ fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let format = cli.format;
     let url = cli.url.as_deref();
+    let url_was_explicit = cli.url.is_some();
 
     let command = match cli.command {
         Some(cmd) => cmd,
@@ -124,23 +125,112 @@ fn run() -> anyhow::Result<()> {
                 },
             }
         }
-        Commands::Agent(args) => {
-            if args.command.is_some() {
-                reject_agent_interactive_options(&args)?;
-            }
-            let client = ApiClient::from_env(url)?;
-            match args.command {
-                Some(AgentCommands::Resume(resume)) => {
-                    commands::agents::resume_interactive(&client, &resume)
-                }
-                Some(command) => dispatch_agent_command(&client, command, format),
-                None => commands::agents::run_interactive(&client, &args),
-            }
-        }
+        Commands::Agent(args) => dispatch_agent(args, url, url_was_explicit, format),
     }
 }
 
+fn dispatch_agent(
+    args: AgentArgs,
+    url: Option<&str>,
+    url_was_explicit: bool,
+    format: gestalt::output::Format,
+) -> anyhow::Result<()> {
+    if args.local && url_was_explicit {
+        anyhow::bail!("--local cannot be used with --url; omit --url or use --cloud");
+    }
+
+    if matches!(&args.command, Some(AgentCommands::Doctor(_))) {
+        reject_agent_doctor_root_options(&args)?;
+        if url_was_explicit {
+            anyhow::bail!("agent doctor checks local harness configuration; omit --url");
+        }
+        if args.cloud {
+            anyhow::bail!("agent doctor checks local harness configuration; omit --cloud");
+        }
+        if let Some(AgentCommands::Doctor(doctor)) = args.command {
+            let mut config_paths = args.config;
+            config_paths.extend(doctor.config);
+            return commands::agents::doctor_local(doctor.provider.as_deref(), &config_paths);
+        }
+        unreachable!();
+    }
+
+    if args.command.is_some() {
+        reject_agent_interactive_options(&args)?;
+        if args.local {
+            anyhow::bail!(
+                "agent resource subcommands do not support --local; omit --local to use the configured server"
+            );
+        }
+        let client = ApiClient::from_env(url)?;
+        return match args.command {
+            Some(AgentCommands::Resume(resume)) => {
+                commands::agents::resume_interactive(&client, &resume)
+            }
+            Some(command) => dispatch_agent_command(&client, command, format),
+            None => unreachable!(),
+        };
+    }
+
+    let run_local = args.local || (!args.cloud && !url_was_explicit);
+    if run_local {
+        reject_local_agent_options(&args)?;
+        return commands::agents::launch_local(args.provider.as_deref(), &args.config);
+    }
+    if !args.config.is_empty() {
+        anyhow::bail!("--config is only supported for local agent launch and `agent doctor`");
+    }
+    let client = ApiClient::from_env(url)?;
+    commands::agents::run_interactive(&client, &args)
+}
+
+fn reject_agent_doctor_root_options(args: &AgentArgs) -> anyhow::Result<()> {
+    if args.provider.is_some() {
+        anyhow::bail!("--provider for agent doctor must be passed after `doctor`");
+    }
+    if args.model.is_some() {
+        anyhow::bail!("--model is not supported with agent doctor");
+    }
+    if !args.system.is_empty() {
+        anyhow::bail!("--system is not supported with agent doctor");
+    }
+    if !args.messages.is_empty() {
+        anyhow::bail!("--message is not supported with agent doctor");
+    }
+    if !args.tools.is_empty() {
+        anyhow::bail!("--tool is not supported with agent doctor");
+    }
+    Ok(())
+}
+
+fn reject_local_agent_options(args: &AgentArgs) -> anyhow::Result<()> {
+    if args.model.is_some() {
+        anyhow::bail!(
+            "--model is not supported in local agent mode; use --cloud for server-backed agent sessions"
+        );
+    }
+    if !args.system.is_empty() {
+        anyhow::bail!(
+            "--system is not supported in local agent mode; use --cloud for server-backed agent sessions"
+        );
+    }
+    if !args.messages.is_empty() {
+        anyhow::bail!(
+            "--message is not supported in local agent mode; use --cloud for server-backed agent sessions"
+        );
+    }
+    if !args.tools.is_empty() {
+        anyhow::bail!(
+            "--tool is not supported in local agent mode; use --cloud for server-backed agent sessions"
+        );
+    }
+    Ok(())
+}
+
 fn reject_agent_interactive_options(args: &AgentArgs) -> anyhow::Result<()> {
+    if !args.config.is_empty() {
+        anyhow::bail!("--config is only supported for local agent launch and `agent doctor`");
+    }
     if args.model.is_some() {
         anyhow::bail!("--model must be passed before a prompt or after `agent resume`");
     }
@@ -166,6 +256,7 @@ fn dispatch_agent_command(
 ) -> anyhow::Result<()> {
     match command {
         AgentCommands::Resume(_) => anyhow::bail!("agent resume is interactive"),
+        AgentCommands::Doctor(_) => anyhow::bail!("agent doctor is local-only"),
         AgentCommands::Sessions { command } => match command {
             AgentSessionCommands::Create(args) => {
                 commands::agents::create_session(client, &args, format)

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -4,9 +4,31 @@ use serde_json::Value;
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::path::Path;
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 use support::*;
+
+#[cfg(unix)]
+fn write_fake_gestaltd(dir: &Path, script: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = dir.join("gestaltd");
+    std::fs::write(&path, script).unwrap();
+    let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).unwrap();
+}
+
+fn prepend_path(dir: &Path) -> String {
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&existing));
+    std::env::join_paths(paths)
+        .unwrap()
+        .to_string_lossy()
+        .into_owned()
+}
 
 const SESSION_JSON: &str = r#"{
     "id":"session-1",
@@ -785,7 +807,14 @@ fn test_cli_runs_interactive_agent_session_with_display_events() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
+        .args([
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ])
         .write_stdin("display events\n")
         .assert()
         .success()
@@ -870,7 +899,14 @@ fn test_cli_runs_tty_agent_session_in_isolated_selectable_ui() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -941,7 +977,14 @@ fn test_cli_tty_can_disable_mouse_capture() {
     let mut session = spawn_tty_cli_with_size_and_env(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
         24,
         100,
         &[("GESTALT_CLI_DISABLE_MOUSE", "1")],
@@ -1104,7 +1147,14 @@ fn test_cli_tty_renders_display_tool_activity_rows() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -1227,7 +1277,14 @@ fn test_cli_tty_groups_tool_activity_rows() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -1321,7 +1378,14 @@ fn test_cli_tty_reconciles_unmatched_tool_activity_rows() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -1466,7 +1530,14 @@ fn test_cli_tty_help_and_prompt_history() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -1544,7 +1615,14 @@ fn test_cli_tty_ctrl_j_inserts_multiline_prompt() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -1572,7 +1650,14 @@ fn test_cli_tty_scrolls_multiline_help_rows() {
     let mut session = spawn_tty_cli_with_size(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
         15,
         80,
     );
@@ -1616,7 +1701,14 @@ fn test_cli_tty_ctrl_d_exits_empty_prompt() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -1681,7 +1773,14 @@ fn test_cli_tty_ctrl_l_redraw_preserves_transcript_and_input() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -1719,7 +1818,14 @@ fn test_cli_tty_resize_redraws_isolated_session() {
     let mut session = spawn_tty_cli_with_size(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
         8,
         100,
     );
@@ -1801,7 +1907,14 @@ fn test_cli_tty_renders_markdown_like_assistant_content() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -1884,7 +1997,14 @@ fn test_cli_tty_wraps_wide_transcript_text_by_display_width() {
     let mut session = spawn_tty_cli_with_size(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
         8,
         30,
     );
@@ -1989,7 +2109,14 @@ fn test_cli_tty_queues_prompt_while_turn_is_running() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -2128,7 +2255,14 @@ fn test_cli_tty_turn_boundary_stops_stale_streaming_transcript_item() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -2254,7 +2388,14 @@ fn test_cli_tty_secret_interaction_masks_and_requires_input() {
     let mut session = spawn_tty_cli(
         home.path(),
         server.url(),
-        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+        &[
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ],
     );
     let mut output = String::new();
     session.wait_for(&mut output, "Session");
@@ -2394,6 +2535,134 @@ fn test_cli_resume_fails_without_active_agent_session() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_cli_agent_defaults_to_local_helper_and_preserves_status() {
+    let home = tempfile::tempdir().unwrap();
+    let helper_dir = tempfile::tempdir().unwrap();
+    let args_path = home.path().join("helper-args.txt");
+    write_fake_gestaltd(
+        helper_dir.path(),
+        r#"#!/bin/sh
+printf 'helper stdout\n'
+printf 'helper stderr\n' >&2
+printf '%s\n' "$*" > "$GESTALT_HELPER_ARGS"
+exit 7
+"#,
+    );
+
+    cli_command(home.path())
+        .env("PATH", prepend_path(helper_dir.path()))
+        .env("GESTALT_HELPER_ARGS", &args_path)
+        .args(["agent", "--config", "config.yaml", "--provider", "local"])
+        .assert()
+        .code(7)
+        .stdout(predicate::str::contains("helper stdout"))
+        .stderr(predicate::str::contains("helper stderr"));
+
+    let helper_args = std::fs::read_to_string(args_path).unwrap();
+    assert_eq!(
+        helper_args,
+        "agent launch --config config.yaml --provider local\n"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cli_agent_default_local_ignores_gestalt_url_env() {
+    let home = tempfile::tempdir().unwrap();
+    let helper_dir = tempfile::tempdir().unwrap();
+    write_fake_gestaltd(
+        helper_dir.path(),
+        r#"#!/bin/sh
+printf 'local helper\n'
+exit 0
+"#,
+    );
+
+    cli_command(home.path())
+        .env("PATH", prepend_path(helper_dir.path()))
+        .env("GESTALT_URL", "http://127.0.0.1:9")
+        .args(["agent"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("local helper"));
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cli_agent_doctor_allows_provider_after_subcommand() {
+    let home = tempfile::tempdir().unwrap();
+    let helper_dir = tempfile::tempdir().unwrap();
+    let args_path = home.path().join("doctor-args.txt");
+    write_fake_gestaltd(
+        helper_dir.path(),
+        r#"#!/bin/sh
+printf '%s\n' "$*" > "$GESTALT_HELPER_ARGS"
+exit 0
+"#,
+    );
+
+    cli_command(home.path())
+        .env("PATH", prepend_path(helper_dir.path()))
+        .env("GESTALT_HELPER_ARGS", &args_path)
+        .args([
+            "agent",
+            "doctor",
+            "--provider",
+            "local",
+            "--config",
+            "config.yaml",
+        ])
+        .assert()
+        .success();
+
+    let helper_args = std::fs::read_to_string(args_path).unwrap();
+    assert_eq!(
+        helper_args,
+        "agent doctor --config config.yaml --provider local\n"
+    );
+}
+
+#[test]
+fn test_cli_agent_local_reports_missing_helper() {
+    let home = tempfile::tempdir().unwrap();
+    let empty_path = tempfile::tempdir().unwrap();
+
+    cli_command(home.path())
+        .env("PATH", empty_path.path())
+        .args(["agent"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "failed to start gestaltd local agent helper",
+        ));
+}
+
+#[test]
+fn test_cli_agent_local_rejects_cloud_session_flags() {
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .args(["agent", "--tool", "tracker:searchItems"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--tool is not supported in local agent mode",
+        ));
+}
+
+#[test]
+fn test_cli_agent_local_rejects_resource_subcommands() {
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .args(["agent", "--local", "sessions", "list"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "agent resource subcommands do not support --local",
+        ));
+}
+
+#[test]
 fn test_cli_rejects_interactive_agent_flags_with_subcommands() {
     let home = tempfile::tempdir().unwrap();
     cli_command(home.path())
@@ -2456,7 +2725,14 @@ fn test_cli_agent_model_slash_lists_configured_providers() {
         .env("GESTALT_API_KEY", TEST_TOKEN)
         .arg("--url")
         .arg(server.url())
-        .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
+        .args([
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ])
         .write_stdin("/model\n")
         .assert()
         .success()
@@ -2525,7 +2801,14 @@ fn test_cli_agent_model_slash_sets_future_turn_model() {
         .env("GESTALT_API_KEY", TEST_TOKEN)
         .arg("--url")
         .arg(server.url())
-        .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
+        .args([
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ])
         .write_stdin("/model gpt-5.5\nhello\n")
         .assert()
         .success()
@@ -2782,7 +3065,14 @@ fn test_cli_resolves_agent_interaction_in_interactive_mode() {
         .env("GESTALT_API_KEY", TEST_TOKEN)
         .arg("--url")
         .arg(server.url())
-        .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
+        .args([
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ])
         .write_stdin("approve deployment\nY\n")
         .assert()
         .success()

--- a/gestaltd/cmd/gestaltd/main.go
+++ b/gestaltd/cmd/gestaltd/main.go
@@ -20,6 +20,9 @@ func main() {
 		if errors.Is(err, flag.ErrHelp) {
 			return
 		}
+		if code, ok := daemon.ExitCode(err); ok {
+			os.Exit(code)
+		}
 		slog.Error("gestaltd exited", "error", err)
 		os.Exit(1)
 	}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -387,17 +387,18 @@ func (g GitHubReleaseSourceDef) Location() string {
 
 // ProviderEntry is the universal configuration for any provider.
 type ProviderEntry struct {
-	Source          ProviderSource                 `yaml:"source"`
-	Config          yaml.Node                      `yaml:"config,omitempty"`
-	Default         bool                           `yaml:"default,omitempty"`
-	Env             map[string]string              `yaml:"env,omitempty"`
-	Egress          *ProviderEgressConfig          `yaml:"egress,omitempty"`
-	DisplayName     string                         `yaml:"displayName,omitempty"`
-	Description     string                         `yaml:"description,omitempty"`
-	IconFile        string                         `yaml:"iconFile,omitempty"`
-	RouteAuth       *RouteAuthDef                  `yaml:"-"`
-	SecuritySchemes map[string]*HTTPSecurityScheme `yaml:"securitySchemes,omitempty"`
-	HTTP            map[string]*HTTPBinding        `yaml:"http,omitempty"`
+	Source          ProviderSource                   `yaml:"source"`
+	Config          yaml.Node                        `yaml:"config,omitempty"`
+	Default         bool                             `yaml:"default,omitempty"`
+	Env             map[string]string                `yaml:"env,omitempty"`
+	Egress          *ProviderEgressConfig            `yaml:"egress,omitempty"`
+	DisplayName     string                           `yaml:"displayName,omitempty"`
+	Description     string                           `yaml:"description,omitempty"`
+	IconFile        string                           `yaml:"iconFile,omitempty"`
+	LocalHarness    *ProviderEntryLocalHarnessConfig `yaml:"localHarness,omitempty"`
+	RouteAuth       *RouteAuthDef                    `yaml:"-"`
+	SecuritySchemes map[string]*HTTPSecurityScheme   `yaml:"securitySchemes,omitempty"`
+	HTTP            map[string]*HTTPBinding          `yaml:"http,omitempty"`
 	// AuthorizationPolicy binds this provider to a shared subject access policy.
 	AuthorizationPolicy string                  `yaml:"authorizationPolicy,omitempty"`
 	Dev                 *ProviderEntryDevConfig `yaml:"dev,omitempty"`
@@ -436,6 +437,16 @@ type ProviderEntry struct {
 }
 
 type providerEntryFields ProviderEntry
+
+// ProviderEntryLocalHarnessConfig describes the local process harness used to
+// start an agent provider without the gestaltd server runtime.
+type ProviderEntryLocalHarnessConfig struct {
+	Command          string            `yaml:"command,omitempty"`
+	Args             []string          `yaml:"args,omitempty"`
+	Env              map[string]string `yaml:"env,omitempty"`
+	WorkingDirectory string            `yaml:"workingDirectory,omitempty"`
+	RequiredCommands []string          `yaml:"requiredCommands,omitempty"`
+}
 
 type ProviderEntryDevConfig struct {
 	Attach ProviderEntryDevAttachConfig `yaml:"attach,omitempty"`
@@ -880,8 +891,20 @@ func providerEntryFieldsFromEntry(e ProviderEntry) providerEntryFields {
 	e.Egress = cloneProviderEgressConfig(e.Egress)
 	e.Execution = cloneExecutionConfig(e.Execution)
 	e.Dev = cloneProviderEntryDevConfig(e.Dev)
+	e.LocalHarness = cloneProviderEntryLocalHarnessConfig(e.LocalHarness)
 	normalizeProviderEntryAliases(&e)
 	return providerEntryFields(e)
+}
+
+func cloneProviderEntryLocalHarnessConfig(src *ProviderEntryLocalHarnessConfig) *ProviderEntryLocalHarnessConfig {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	dst.Args = slices.Clone(src.Args)
+	dst.Env = maps.Clone(src.Env)
+	dst.RequiredCommands = slices.Clone(src.RequiredCommands)
+	return &dst
 }
 
 func cloneProviderEntryDevConfig(src *ProviderEntryDevConfig) *ProviderEntryDevConfig {
@@ -905,6 +928,11 @@ func normalizeProviderEntryAliases(entry *ProviderEntry) {
 	}
 	if entry.Dev != nil {
 		entry.Dev.Attach.AllowedRoles = trimStringSlice(entry.Dev.Attach.AllowedRoles)
+	}
+	if entry.LocalHarness != nil {
+		entry.LocalHarness.Command = strings.TrimSpace(entry.LocalHarness.Command)
+		entry.LocalHarness.WorkingDirectory = strings.TrimSpace(entry.LocalHarness.WorkingDirectory)
+		entry.LocalHarness.RequiredCommands = trimStringSlice(entry.LocalHarness.RequiredCommands)
 	}
 }
 
@@ -1825,6 +1853,34 @@ func LoadAllowMissingEnvPaths(paths []string) (*Config, error) {
 // local env vars do not block the caller.
 func LoadPartialAllowMissingEnvPaths(paths []string) (*Config, error) {
 	return loadWithLookupPathsValidation(paths, os.LookupEnv, true, false)
+}
+
+// ValidateSelectedAgentLocalHarnessEnvPaths fails if the selected local agent
+// harness references missing environment variables.
+func ValidateSelectedAgentLocalHarnessEnvPaths(paths []string, providerName string) error {
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return nil
+	}
+	missingEnvSentinelContext, err := newMissingEnvSentinelPrefix()
+	if err != nil {
+		return err
+	}
+	root, err := loadMergedConfigRoot(paths, os.LookupEnv, envMissingSentinel, missingEnvSentinelContext)
+	if err != nil {
+		return err
+	}
+	providers := mappingValueNode(&root, "providers")
+	agentProviders := mappingValueNode(providers, "agent")
+	entry := mappingValueNode(agentProviders, providerName)
+	localHarness := mappingValueNode(entry, "localHarness")
+	if localHarness == nil {
+		return nil
+	}
+	if firstMissing := firstMissingEnvSentinel(localHarness, missingEnvSentinelContext); firstMissing != "" {
+		return fmt.Errorf("expanding providers.agent.%s.localHarness environment variables: environment variable %q not set; use ${%s:-} to allow an empty default", providerName, firstMissing, firstMissing)
+	}
+	return nil
 }
 
 func normalizeConfigShape(cfg *Config) error {
@@ -2972,6 +3028,9 @@ func resolveRelativePathsInEntry(kind string, entry map[string]any, baseDir stri
 		return
 	}
 	resolveRelativeStringField(entry, "iconFile", baseDir)
+	if localHarness, ok := entry["localHarness"].(map[string]any); ok {
+		resolveRelativeStringField(localHarness, "workingDirectory", baseDir)
+	}
 	if source, ok := entry["source"].(map[string]any); ok {
 		resolveRelativeStringField(source, "path", baseDir)
 		return
@@ -3034,6 +3093,9 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 		entry.IconFile = resolveRelativePath(baseDir, entry.IconFile)
 		entry.Source.Path = resolveRelativePath(baseDir, entry.Source.Path)
 		entry.Source.metadataPath = resolveRelativePath(baseDir, entry.Source.metadataPath)
+		if entry.LocalHarness != nil {
+			entry.LocalHarness.WorkingDirectory = resolveRelativePath(baseDir, entry.LocalHarness.WorkingDirectory)
+		}
 	}
 
 	for _, entry := range cfg.Providers.Authentication {

--- a/gestaltd/internal/daemon/agent_exit_other.go
+++ b/gestaltd/internal/daemon/agent_exit_other.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package daemon
+
+import "os/exec"
+
+func processExitCode(exitErr *exec.ExitError) int {
+	if code := exitErr.ExitCode(); code >= 0 {
+		return code
+	}
+	return 1
+}

--- a/gestaltd/internal/daemon/agent_exit_unix.go
+++ b/gestaltd/internal/daemon/agent_exit_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package daemon
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func processExitCode(exitErr *exec.ExitError) int {
+	if code := exitErr.ExitCode(); code >= 0 {
+		return code
+	}
+	if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+		return 128 + int(status.Signal())
+	}
+	return 1
+}

--- a/gestaltd/internal/daemon/agent_local.go
+++ b/gestaltd/internal/daemon/agent_local.go
@@ -1,0 +1,372 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+)
+
+type exitCodeError struct {
+	code int
+}
+
+func (e exitCodeError) Error() string {
+	return fmt.Sprintf("process exited with status %d", e.code)
+}
+
+// ExitCode extracts a daemon command exit code that intentionally mirrors a
+// child process status.
+func ExitCode(err error) (int, bool) {
+	var exitErr exitCodeError
+	if errors.As(err, &exitErr) {
+		return exitErr.code, true
+	}
+	return 0, false
+}
+
+type localAgentCommandOptions struct {
+	ConfigPaths []string
+	Provider    string
+	DryRun      bool
+}
+
+type localAgentHarnessPlan struct {
+	ProviderName    string
+	Harness         config.ProviderEntryLocalHarnessConfig
+	WorkingDir      string
+	Env             map[string]string
+	ResolvedCommand string
+}
+
+func runAgent(args []string) error {
+	if len(args) == 0 {
+		printAgentUsage(os.Stderr)
+		return flag.ErrHelp
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		printAgentUsage(os.Stderr)
+		return flag.ErrHelp
+	case "launch":
+		return runAgentLaunch(args[1:])
+	case "doctor":
+		return runAgentDoctor(args[1:])
+	default:
+		return fmt.Errorf("unknown agent command %q", args[0])
+	}
+}
+
+func runAgentLaunch(args []string) error {
+	opts, err := parseLocalAgentOptions("gestaltd agent launch", printAgentLaunchUsage, args, true)
+	if err != nil {
+		return err
+	}
+	plan, err := resolveLocalAgentHarness(opts)
+	if err != nil {
+		return err
+	}
+	if opts.DryRun {
+		return printLocalAgentDryRun(plan)
+	}
+	return launchLocalAgentHarness(plan)
+}
+
+func runAgentDoctor(args []string) error {
+	opts, err := parseLocalAgentOptions("gestaltd agent doctor", printAgentDoctorUsage, args, false)
+	if err != nil {
+		return err
+	}
+	plan, err := resolveLocalAgentHarness(opts)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "local agent harness %q ok\n", plan.ProviderName)
+	return nil
+}
+
+func parseLocalAgentOptions(name string, usage func(io.Writer), args []string, allowDryRun bool) (localAgentCommandOptions, error) {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.Usage = func() { usage(fs.Output()) }
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
+	provider := fs.String("provider", "", "agent provider name; defaults to the configured default")
+	dryRun := false
+	if allowDryRun {
+		fs.BoolVar(&dryRun, "dry-run", false, "print the resolved local harness command without starting it")
+	}
+	if err := fs.Parse(args); err != nil {
+		return localAgentCommandOptions{}, err
+	}
+	if fs.NArg() > 0 {
+		return localAgentCommandOptions{}, fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	return localAgentCommandOptions{
+		ConfigPaths: []string(configPaths),
+		Provider:    *provider,
+		DryRun:      dryRun,
+	}, nil
+}
+
+func resolveLocalAgentHarness(opts localAgentCommandOptions) (localAgentHarnessPlan, error) {
+	configPaths := operator.ResolveConfigPaths(opts.ConfigPaths)
+	cfg, err := config.LoadPartialAllowMissingEnvPaths(configPaths)
+	if err != nil {
+		return localAgentHarnessPlan{}, err
+	}
+	providerName, entry, err := cfg.EffectiveAgentProvider(opts.Provider)
+	if err != nil {
+		return localAgentHarnessPlan{}, err
+	}
+	if entry == nil {
+		return localAgentHarnessPlan{}, fmt.Errorf("no agent provider configured")
+	}
+	if err := config.ValidateSelectedAgentLocalHarnessEnvPaths(configPaths, providerName); err != nil {
+		return localAgentHarnessPlan{}, err
+	}
+	if entry.LocalHarness == nil {
+		return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness is required for local agent launch", providerName)
+	}
+	harness := *entry.LocalHarness
+	harness.Args = slices.Clone(entry.LocalHarness.Args)
+	harness.Env = maps.Clone(entry.LocalHarness.Env)
+	harness.RequiredCommands = slices.Clone(entry.LocalHarness.RequiredCommands)
+	if harness.Command == "" {
+		return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness.command is required", providerName)
+	}
+
+	workingDir := strings.TrimSpace(harness.WorkingDirectory)
+	if workingDir != "" {
+		info, err := os.Stat(workingDir)
+		if err != nil {
+			return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness.workingDirectory: %w", providerName, err)
+		}
+		if !info.IsDir() {
+			return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness.workingDirectory %q is not a directory", providerName, workingDir)
+		}
+	}
+
+	env := effectiveEnvMap(harness.Env)
+	for _, required := range harness.RequiredCommands {
+		if _, err := lookPathWithEnv(required, workingDir, env); err != nil {
+			return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness.requiredCommands: %w", providerName, err)
+		}
+	}
+	resolvedCommand, err := lookPathWithEnv(harness.Command, workingDir, env)
+	if err != nil {
+		return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness.command: %w", providerName, err)
+	}
+
+	return localAgentHarnessPlan{
+		ProviderName:    providerName,
+		Harness:         harness,
+		WorkingDir:      workingDir,
+		Env:             env,
+		ResolvedCommand: resolvedCommand,
+	}, nil
+}
+
+func launchLocalAgentHarness(plan localAgentHarnessPlan) error {
+	cmd := exec.Command(plan.ResolvedCommand, plan.Harness.Args...)
+	if plan.WorkingDir != "" {
+		cmd.Dir = plan.WorkingDir
+	}
+	cmd.Env = envList(plan.Env)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitCodeError{code: processExitCode(exitErr)}
+		}
+		return fmt.Errorf("run local agent harness %q: %w", plan.ProviderName, err)
+	}
+	return nil
+}
+
+func printLocalAgentDryRun(plan localAgentHarnessPlan) error {
+	payload := struct {
+		Provider         string            `json:"provider"`
+		Command          string            `json:"command"`
+		ResolvedCommand  string            `json:"resolvedCommand"`
+		Args             []string          `json:"args,omitempty"`
+		WorkingDirectory string            `json:"workingDirectory,omitempty"`
+		Env              map[string]string `json:"env,omitempty"`
+	}{
+		Provider:         plan.ProviderName,
+		Command:          plan.Harness.Command,
+		ResolvedCommand:  plan.ResolvedCommand,
+		Args:             plan.Harness.Args,
+		WorkingDirectory: plan.WorkingDir,
+		Env:              redactedEnvOverlay(plan.Harness.Env),
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(payload)
+}
+
+func effectiveEnvMap(overlay map[string]string) map[string]string {
+	env := make(map[string]string)
+	for _, entry := range os.Environ() {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		env[key] = value
+	}
+	for key, value := range overlay {
+		env[key] = value
+	}
+	return env
+}
+
+func envList(env map[string]string) []string {
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, key+"="+env[key])
+	}
+	return out
+}
+
+func redactedEnvOverlay(env map[string]string) map[string]string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(env))
+	for key, value := range env {
+		if isSecretEnvKey(key) {
+			out[key] = "***"
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func isSecretEnvKey(key string) bool {
+	upper := strings.ToUpper(key)
+	for _, marker := range []string{"SECRET", "TOKEN", "PASSWORD", "KEY", "CREDENTIAL", "AUTH"} {
+		if strings.Contains(upper, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func lookPathWithEnv(command, workingDir string, env map[string]string) (string, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return "", fmt.Errorf("command is required")
+	}
+	if hasPathSeparator(command) {
+		path := command
+		if !filepath.IsAbs(path) {
+			baseDir := workingDir
+			if baseDir == "" {
+				var err error
+				baseDir, err = os.Getwd()
+				if err != nil {
+					return "", fmt.Errorf("get working directory: %w", err)
+				}
+			}
+			path = filepath.Join(baseDir, path)
+		}
+		if err := checkExecutable(path); err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+
+	pathEnv := env["PATH"]
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			dir = "."
+		}
+		if !filepath.IsAbs(dir) && workingDir != "" {
+			dir = filepath.Join(workingDir, dir)
+		}
+		for _, candidate := range executableCandidates(filepath.Join(dir, command), env) {
+			if err := checkExecutable(candidate); err == nil {
+				return candidate, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("command %q not found in PATH", command)
+}
+
+func hasPathSeparator(path string) bool {
+	return strings.ContainsRune(path, os.PathSeparator) || (os.PathSeparator != '/' && strings.ContainsRune(path, '/'))
+}
+
+func executableCandidates(path string, env map[string]string) []string {
+	if runtime.GOOS != "windows" || filepath.Ext(path) != "" {
+		return []string{path}
+	}
+	exts := filepath.SplitList(env["PATHEXT"])
+	if len(exts) == 0 {
+		exts = []string{".COM", ".EXE", ".BAT", ".CMD"}
+	}
+	out := make([]string, 0, len(exts)+1)
+	out = append(out, path)
+	for _, ext := range exts {
+		out = append(out, path+ext)
+	}
+	return out
+}
+
+func checkExecutable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%q is a directory", path)
+	}
+	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+		return fmt.Errorf("%q is not executable", path)
+	}
+	return nil
+}
+
+func printAgentUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd agent launch [--config PATH]... [--provider NAME] [--dry-run]")
+	writeUsageLine(w, "  gestaltd agent doctor [--config PATH]... [--provider NAME]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  launch      Start the selected provider's configured local agent harness")
+	writeUsageLine(w, "  doctor      Check that the selected local agent harness can be started")
+}
+
+func printAgentLaunchUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd agent launch [--config PATH]... [--provider NAME] [--dry-run]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Start the selected provider's configured local agent harness.")
+	writeUsageLine(w, "Only providers.agent.<name>.localHarness is used; no server, session,")
+	writeUsageLine(w, "persistence, runtime, tool grant, or AgentProvider RPC stack is started.")
+}
+
+func printAgentDoctorUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd agent doctor [--config PATH]... [--provider NAME]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Check the selected provider's configured local agent harness command,")
+	writeUsageLine(w, "working directory, environment overlay, and requiredCommands.")
+}

--- a/gestaltd/internal/daemon/agent_local_test.go
+++ b/gestaltd/internal/daemon/agent_local_test.go
@@ -1,0 +1,227 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestE2EAgentLaunchDryRunUsesLocalHarnessOnly(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	if err := os.Mkdir(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workDir: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `apiVersion: gestaltd.config/v5
+providers:
+  agent:
+    local:
+      default: true
+      localHarness:
+        command: /bin/sh
+        args: ["-c", "echo hi"]
+        workingDirectory: work
+        env:
+          OPENAI_API_KEY: secret
+          PLAIN: visible
+    deployment_only:
+      execution:
+        runtime:
+          provider: missing
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "agent", "launch", "--config", cfgPath, "--dry-run").CombinedOutput()
+	if err != nil {
+		t.Fatalf("agent launch --dry-run failed: %v\n%s", err, out)
+	}
+	var payload struct {
+		Provider         string            `json:"provider"`
+		Command          string            `json:"command"`
+		ResolvedCommand  string            `json:"resolvedCommand"`
+		Args             []string          `json:"args"`
+		WorkingDirectory string            `json:"workingDirectory"`
+		Env              map[string]string `json:"env"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		t.Fatalf("parse dry-run json: %v\n%s", err, out)
+	}
+	if payload.Provider != "local" {
+		t.Fatalf("provider = %q, want local", payload.Provider)
+	}
+	if payload.Command != "/bin/sh" || payload.ResolvedCommand != "/bin/sh" {
+		t.Fatalf("command = (%q, %q), want /bin/sh", payload.Command, payload.ResolvedCommand)
+	}
+	if got := strings.Join(payload.Args, "\x00"); got != "-c\x00echo hi" {
+		t.Fatalf("args = %#v", payload.Args)
+	}
+	if payload.WorkingDirectory != workDir {
+		t.Fatalf("workingDirectory = %q, want %q", payload.WorkingDirectory, workDir)
+	}
+	if payload.Env["OPENAI_API_KEY"] != "***" {
+		t.Fatalf("OPENAI_API_KEY dry-run value = %q, want redacted", payload.Env["OPENAI_API_KEY"])
+	}
+	if payload.Env["PLAIN"] != "visible" {
+		t.Fatalf("PLAIN dry-run value = %q, want visible", payload.Env["PLAIN"])
+	}
+	if _, ok := payload.Env["PATH"]; ok {
+		t.Fatalf("dry-run env included inherited PATH: %#v", payload.Env)
+	}
+}
+
+func TestE2EAgentLaunchRunsHarnessWithInheritedStdioAndExitCode(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	if err := os.Mkdir(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workDir: %v", err)
+	}
+	harnessPath := filepath.Join(workDir, "harness.sh")
+	writeExecutable(t, harnessPath, `#!/bin/sh
+printf 'harness stdout\n'
+printf 'harness stderr\n' >&2
+printf 'cwd=%s\n' "$(pwd)"
+printf 'overlay=%s\n' "$HARNESS_VALUE"
+exit 7
+`)
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `apiVersion: gestaltd.config/v5
+providers:
+  agent:
+    local:
+      default: true
+      localHarness:
+        command: ./harness.sh
+        workingDirectory: work
+        env:
+          HARNESS_VALUE: from-config
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "agent", "launch", "--config", cfgPath).CombinedOutput()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("agent launch err = %v, want exit status 7\n%s", err, out)
+	}
+	if exitErr.ExitCode() != 7 {
+		t.Fatalf("exit code = %d, want 7\n%s", exitErr.ExitCode(), out)
+	}
+	physicalWorkDir, err := filepath.EvalSymlinks(workDir)
+	if err != nil {
+		t.Fatalf("eval workDir: %v", err)
+	}
+	for _, want := range []string{
+		"harness stdout",
+		"harness stderr",
+		"cwd=" + physicalWorkDir,
+		"overlay=from-config",
+	} {
+		if !strings.Contains(string(out), want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestE2EAgentDoctorReportsMissingRequiredCommand(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `apiVersion: gestaltd.config/v5
+providers:
+  agent:
+    local:
+      default: true
+      localHarness:
+        command: /bin/sh
+        requiredCommands:
+          - definitely-missing-gestalt-agent-command
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "agent", "doctor", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("agent doctor unexpectedly succeeded:\n%s", out)
+	}
+	if !strings.Contains(string(out), "localHarness.requiredCommands") ||
+		!strings.Contains(string(out), "definitely-missing-gestalt-agent-command") {
+		t.Fatalf("doctor output missing required command failure:\n%s", out)
+	}
+}
+
+func TestE2EAgentLaunchFailsWhenSelectedHarnessEnvIsMissing(t *testing.T) {
+	t.Parallel()
+
+	const missingEnv = "GESTALT_TEST_MISSING_SELECTED_HARNESS_ENV"
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `apiVersion: gestaltd.config/v5
+providers:
+  agent:
+    local:
+      default: true
+      localHarness:
+        command: /bin/sh
+        env:
+          OPENAI_API_KEY: ${GESTALT_TEST_MISSING_SELECTED_HARNESS_ENV}
+    unselected:
+      localHarness:
+        command: /bin/sh
+        env:
+          OTHER: ${GESTALT_TEST_MISSING_UNSELECTED_HARNESS_ENV}
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := exec.Command(gestaltdBin, "agent", "launch", "--config", cfgPath, "--dry-run")
+	cmd.Env = withoutEnv(os.Environ(), missingEnv, "GESTALT_TEST_MISSING_UNSELECTED_HARNESS_ENV")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("agent launch unexpectedly succeeded:\n%s", out)
+	}
+	got := string(out)
+	if !strings.Contains(got, "providers.agent.local.localHarness") ||
+		!strings.Contains(got, missingEnv) ||
+		strings.Contains(got, "GESTALT_TEST_MISSING_UNSELECTED_HARNESS_ENV") {
+		t.Fatalf("missing env output = %s", out)
+	}
+}
+
+func withoutEnv(env []string, keys ...string) []string {
+	drop := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		drop[key] = struct{}{}
+	}
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, ok := drop[key]; ok {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func writeExecutable(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+}

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -23,7 +23,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "root",
 			args:      []string{"--help"},
-			wantParts: []string{"gestaltd validate", "gestaltd lock", "gestaltd sync --locked", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "[--config PATH]...", "--lockfile PATH"},
+			wantParts: []string{"gestaltd validate", "gestaltd lock", "gestaltd sync --locked", "gestaltd agent <command> [flags]", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "[--config PATH]...", "--lockfile PATH"},
 			notWant:   []string{"gestaltd bundle", "gestaltd dev", "gestaltd init", "\n  init"},
 		},
 		{

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -50,6 +50,8 @@ func run(args []string, version string) error {
 			return nil
 		case "provider":
 			return runProvider(args[1:])
+		case "agent":
+			return runAgent(args[1:])
 		case "serve":
 			return runServe(args[1:])
 		case "lock":
@@ -305,10 +307,12 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
 	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--check]")
 	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
+	writeUsageLine(w, "  gestaltd agent <command> [flags]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH] [--platform os/arch] [--runtime]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  agent       Launch or inspect local agent harnesses")
 	writeUsageLine(w, "  lock        Resolve provider metadata and write lock state")
 	writeUsageLine(w, "  sync        Materialize prepared artifacts from lock state")
 	writeUsageLine(w, "  provider    Develop, validate, or build provider release archives")


### PR DESCRIPTION
## Summary

Make `gestalt agent` local-first by launching the selected agent provider's configured `localHarness` through a lightweight `gestaltd agent launch` helper. Existing server-backed behavior remains available with `gestalt agent --cloud` or an explicit global `--url`, and agent resource subcommands remain cloud/server backed.

## Interface Changes
- New/changed interface: `providers.agent.<name>.localHarness` supports `command`, `args`, `env`, `workingDirectory`, and `requiredCommands`.
- New/changed interface: `gestalt agent` defaults to local launch; `gestalt agent --cloud` preserves the existing interactive session flow; `gestalt agent doctor` checks the selected local harness.
- New/changed interface: `gestaltd agent launch|doctor` loads only the selected local harness contract and does not start server sessions, persistence, runtimes, tool grants, or AgentProvider RPC.
- Example usage:

```yaml
providers:
  agent:
    claude:
      default: true
      localHarness:
        command: claude
        args: []
        env:
          ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
        workingDirectory: .
        requiredCommands: [claude]
```

```bash
gestalt agent
gestalt agent --provider claude
gestalt agent doctor --provider claude
gestalt agent --cloud --provider managed --model gpt-5.4
```

## Functional/Integration Tests
- Tests added or augmented: daemon E2E tests for `gestaltd agent launch|doctor`; Rust CLI integration tests for local-default helper dispatch, exact exit code propagation, missing helper behavior, `GESTALT_URL` vs explicit `--url`, local flag rejection, and existing cloud-backed agent flows.
- Contract boundary covered: CLI-to-helper process boundary, helper-to-harness process boundary, config loading/path resolution, release artifact packaging path.
- Commands run:
  - `go test ./internal/daemon -run 'TestE2EAgent|TestE2ECLIHelp'` from `gestaltd/`
  - `go test ./internal/config` from `gestaltd/`
  - `cargo test -p gestalt --test agents_cli` from `gestalt/`

## Notes
- CLI release tarballs and the Docker image now bundle `gestaltd` beside `gestalt` so the local default has a helper available in official distributions.
- Missing `${VAR}` placeholders inside the selected `localHarness` fail before launch; unrelated/unselected deployment config can still be partial-loaded for local launch.