### PR TITLE
Add declarative post-connect metadata mapping

### DIFF
--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -139,3 +139,27 @@ type DiscoveryConfig struct {
 	NamePath  string
 	Metadata  map[string]string
 }
+
+type PostConnectConfig struct {
+	Request          PostConnectRequestConfig
+	SourcePath       string
+	Success          *PostConnectSuccessCheck
+	ExternalIdentity *PostConnectExternalIdentityConfig
+	Metadata         map[string]string
+}
+
+type PostConnectRequestConfig struct {
+	Method  string
+	URL     string
+	Headers map[string]string
+}
+
+type PostConnectSuccessCheck struct {
+	Path   string
+	Equals any
+}
+
+type PostConnectExternalIdentityConfig struct {
+	Type string
+	ID   string
+}

--- a/gestaltd/core/provider_capabilities.go
+++ b/gestaltd/core/provider_capabilities.go
@@ -121,7 +121,7 @@ func PostConnect(ctx context.Context, prov Provider, token *ExternalCredential) 
 	metadata, err := pcp.PostConnect(ctx, token)
 	if err != nil {
 		if errors.Is(err, ErrPostConnectUnsupported) {
-			return nil, true, nil
+			return nil, false, nil
 		}
 		return nil, true, err
 	}

--- a/gestaltd/core/provider_capabilities_test.go
+++ b/gestaltd/core/provider_capabilities_test.go
@@ -37,6 +37,7 @@ type postConnectProbeProvider struct {
 	coretesting.StubIntegration
 	supports bool
 	called   bool
+	err      error
 }
 
 func (p *postConnectProbeProvider) SupportsPostConnect() bool {
@@ -45,6 +46,9 @@ func (p *postConnectProbeProvider) SupportsPostConnect() bool {
 
 func (p *postConnectProbeProvider) PostConnect(context.Context, *core.ExternalCredential) (map[string]string, error) {
 	p.called = true
+	if p.err != nil {
+		return nil, p.err
+	}
 	return map[string]string{"ok": "true"}, nil
 }
 
@@ -91,6 +95,22 @@ func TestCapabilityHelpersRespectExplicitSupportFlags(t *testing.T) {
 	}
 	if postConnect.called {
 		t.Fatal("explicit false support should prevent PostConnect from being called")
+	}
+
+	unsupportedPostConnect := &postConnectProbeProvider{
+		StubIntegration: coretesting.StubIntegration{N: "post-connect"},
+		supports:        true,
+		err:             core.ErrPostConnectUnsupported,
+	}
+	metadata, supported, err = core.PostConnect(context.Background(), unsupportedPostConnect, &core.ExternalCredential{})
+	if err != nil {
+		t.Fatalf("PostConnect unsupported connection: %v", err)
+	}
+	if supported {
+		t.Fatal("expected provider-level unsupported post-connect to report unsupported")
+	}
+	if metadata != nil {
+		t.Fatalf("expected nil metadata, got %#v", metadata)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/declarative_connection.go
+++ b/gestaltd/internal/bootstrap/declarative_connection.go
@@ -4,7 +4,9 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
 )
 
@@ -14,6 +16,14 @@ func declarativeConnectionDef(conn config.ConnectionDef) declarative.ConnectionD
 		Auth:             declarativeConnectionAuthDef(conn.Auth),
 		ConnectionParams: declarativeConnectionParamDefs(conn.ConnectionParams),
 	}
+}
+
+func declarativeNamedConnectionDef(name string, conn config.ConnectionDef) declarative.ConnectionDef {
+	out := declarativeConnectionDef(conn)
+	if postConnect := pluginservice.PostConnectConfigFromManifest(conn.PostConnect); postConnect != nil {
+		out.PostConnect = map[string]*core.PostConnectConfig{name: postConnect}
+	}
+	return out
 }
 
 func declarativeConnectionAuthDef(auth config.ConnectionAuthDef) declarative.ConnectionAuthDef {

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -2393,6 +2393,121 @@ paths:
 	}
 }
 
+func TestSpecLoadedOpenAPIProviderSupportsPostConnectOnNonSurfaceConnection(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth atomic.Value
+	var gotHeader atomic.Value
+	identitySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Authorization"))
+		gotHeader.Store(r.Header.Get("X-Identity"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"user":{"id":"U123"}}`))
+	}))
+	t.Cleanup(identitySrv.Close)
+
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte("kind: plugin\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(manifest.yaml): %v", err)
+	}
+	openapiPath := filepath.Join(root, "openapi.yaml")
+	openapiDoc := `openapi: "3.1.0"
+info:
+  title: Example
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: list_items
+      responses:
+        "200":
+          description: OK
+`
+	if err := os.WriteFile(openapiPath, []byte(openapiDoc), 0o644); err != nil {
+		t.Fatalf("WriteFile(openapi.yaml): %v", err)
+	}
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"example": {
+				ResolvedManifestPath: manifestPath,
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Kind:        providermanifestv1.KindPlugin,
+					DisplayName: "Example",
+					Description: "OpenAPI example",
+					Spec: &providermanifestv1.Spec{
+						Surfaces: &providermanifestv1.ProviderSurfaces{
+							OpenAPI: &providermanifestv1.OpenAPISurface{
+								Document:   "openapi.yaml",
+								Connection: "api",
+							},
+						},
+						Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+							"api": {
+								Mode: providermanifestv1.ConnectionModeUser,
+								Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
+							},
+							"identity": {
+								Mode: providermanifestv1.ConnectionModeUser,
+								Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
+								PostConnect: &providermanifestv1.ProviderPostConnect{
+									Request: providermanifestv1.ProviderPostConnectRequest{
+										Method: http.MethodGet,
+										URL:    identitySrv.URL,
+										Headers: map[string]string{
+											"X-Identity": "true",
+										},
+									},
+									SourcePath: "user",
+									Metadata: map[string]string{
+										"identity.user_id": "id",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	prov, err := providers.Get("example")
+	if err != nil {
+		t.Fatalf("providers.Get(example): %v", err)
+	}
+
+	metadata, supported, err := core.PostConnect(context.Background(), prov, &core.ExternalCredential{
+		Integration:  "example",
+		Connection:   "identity",
+		AccessToken:  "identity-token",
+		RefreshToken: "refresh-token",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if !supported {
+		t.Fatal("expected post-connect support for identity connection")
+	}
+	if got := metadata["identity.user_id"]; got != "U123" {
+		t.Fatalf("identity.user_id = %q, want U123", got)
+	}
+	if got, _ := gotAuth.Load().(string); got != "Bearer identity-token" {
+		t.Fatalf("Authorization = %q, want bearer token", got)
+	}
+	if got, _ := gotHeader.Load().(string); got != "true" {
+		t.Fatalf("X-Identity = %q, want true", got)
+	}
+}
+
 func TestHybridExecutableProviderAppliesAllowedOperationsToStaticAndOpenAPICatalogs(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -378,6 +378,7 @@ func buildProvider(ctx context.Context, name string, entry *config.ProviderEntry
 			pluginservice.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
 			pluginservice.WithDeclarativeConnectionMode(plan.ConnectionMode()),
 			pluginservice.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
+			pluginservice.WithDeclarativeEgressCheck(deps.Egress.CheckFunc(entry.EffectiveAllowedHosts())),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
@@ -431,10 +432,16 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 			pluginservice.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
 			pluginservice.WithDeclarativeConnectionMode(plan.ConnectionMode()),
 			pluginservice.WithDeclarativeOperationConnections(restConnections, restSelectors, restLocks),
+			pluginservice.WithDeclarativeEgressCheck(deps.Egress.CheckFunc(entry.EffectiveAllowedHosts())),
 		)
 		if err != nil {
 			closeIfPossible(pluginProv)
 			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
+		}
+		if len(declarative.PostConnectConfigs) > 0 && core.SupportsPostConnect(pluginProv) {
+			closeIfPossible(pluginProv)
+			closeIfPossible(declarative)
+			return nil, fmt.Errorf("provider %q declares postConnect in the manifest and implements provider post-connect; remove one to avoid metadata conflicts", name)
 		}
 		apiAllowedOperations := operationexposure.MatchingAllowedOperations(allowedOperations, declarative.Catalog())
 		apiProv, err := applyAllowedOperations(name, apiAllowedOperations, declarative)
@@ -469,6 +476,10 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 			return nil, err
 		}
 		return newProviderBuildResult(name, entry, manifest, pluginConfig, restricted, nil, deps)
+	}
+	if core.SupportsPostConnect(specProv) && core.SupportsPostConnect(pluginProv) {
+		closeIfPossible(specProv, pluginProv)
+		return nil, fmt.Errorf("provider %q declares postConnect in the manifest and implements provider post-connect; remove one to avoid metadata conflicts", name)
 	}
 	filteredPluginProv, err := applyAllowedOperations(name, staticAllowedOperations, pluginProv)
 	if err != nil {
@@ -559,6 +570,11 @@ type builtSpecSurface struct {
 	definition *declarative.Definition
 }
 
+type postConnectOnlyProvider struct {
+	connection string
+	provider   core.Provider
+}
+
 func buildSpecLoadedProvider(ctx context.Context, name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, pluginConfig map[string]any, meta providerMetadata, deps Deps, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
 	mp := manifest.Spec
 	plan, err := config.BuildStaticConnectionPlan(entry, mp)
@@ -641,6 +657,7 @@ func buildConfiguredAPIProvider(ctx context.Context, name string, plan config.St
 	}
 
 	built := make([]builtSpecSurface, 0, len(resolvedSurfaces))
+	surfaceConnections := make(map[string]bool, len(resolvedSurfaces))
 	authFallback := newSpecAuthFallback()
 	for i := range resolvedSurfaces {
 		resolved := resolvedSurfaces[i]
@@ -654,18 +671,27 @@ func buildConfiguredAPIProvider(ctx context.Context, name string, plan config.St
 			resolved:   resolved,
 			definition: def,
 		})
+		if resolved.ConnectionName != "" {
+			surfaceConnections[resolved.ConnectionName] = true
+		}
 		authFallback.add(resolved.ConnectionName, def)
 	}
 
-	if len(built) == 1 {
+	postConnectOnly, err := buildPostConnectOnlyProviders(name, plan, meta, cfg, deps, surfaceConnections)
+	if err != nil {
+		closeBuiltSpecSurfaces(built)
+		return nil, nil, err
+	}
+
+	if len(built) == 1 && len(postConnectOnly) == 0 {
 		if authFallback.empty() {
 			authFallback = nil
 		}
 		return bindProviderConnection(built[0].provider, built[0].resolved.ConnectionName), authFallback, nil
 	}
 
-	boundProviders := make([]composite.BoundProvider, 0, len(built))
-	providers := make([]core.Provider, 0, len(built))
+	boundProviders := make([]composite.BoundProvider, 0, len(built)+len(postConnectOnly))
+	providers := make([]core.Provider, 0, len(built)+len(postConnectOnly))
 	for i := range built {
 		specSurface := &built[i]
 		boundProviders = append(boundProviders, composite.BoundProvider{
@@ -673,6 +699,13 @@ func buildConfiguredAPIProvider(ctx context.Context, name string, plan config.St
 			Connection: specSurface.resolved.ConnectionName,
 		})
 		providers = append(providers, specSurface.provider)
+	}
+	for i := range postConnectOnly {
+		boundProviders = append(boundProviders, composite.BoundProvider{
+			Provider:   postConnectOnly[i].provider,
+			Connection: postConnectOnly[i].connection,
+		})
+		providers = append(providers, postConnectOnly[i].provider)
 	}
 
 	merged, err := composite.NewMergedWithConnections(
@@ -684,6 +717,7 @@ func buildConfiguredAPIProvider(ctx context.Context, name string, plan config.St
 	)
 	if err != nil {
 		closeBuiltSpecSurfaces(built)
+		closePostConnectOnlyProviders(postConnectOnly)
 		return nil, nil, err
 	}
 	if authFallback.empty() {
@@ -692,9 +726,60 @@ func buildConfiguredAPIProvider(ctx context.Context, name string, plan config.St
 	return merged, authFallback, nil
 }
 
+func buildPostConnectOnlyProviders(name string, plan config.StaticConnectionPlan, meta providerMetadata, cfg specProviderConfig, deps Deps, excludedConnections map[string]bool) ([]postConnectOnlyProvider, error) {
+	var providers []postConnectOnlyProvider
+	for _, connectionName := range plan.NamedConnectionNames() {
+		if excludedConnections[connectionName] {
+			continue
+		}
+		conn, ok := plan.NamedConnectionDef(connectionName)
+		if !ok || conn.PostConnect == nil {
+			continue
+		}
+		prov, err := buildPostConnectOnlyProvider(name, connectionName, conn, meta, cfg, deps)
+		if err != nil {
+			closePostConnectOnlyProviders(providers)
+			return nil, err
+		}
+		providers = append(providers, postConnectOnlyProvider{
+			connection: connectionName,
+			provider:   prov,
+		})
+	}
+	return providers, nil
+}
+
+func buildPostConnectOnlyProvider(name, connectionName string, conn config.ConnectionDef, meta providerMetadata, cfg specProviderConfig, deps Deps) (core.Provider, error) {
+	def := &declarative.Definition{
+		Provider:    name,
+		DisplayName: meta.displayName,
+		Description: meta.description,
+		IconSVG:     meta.iconSVG,
+		BaseURL:     cfg.baseURL,
+		Headers:     manifestHeaders(cfg.manifestPlugin),
+	}
+	buildOpts := []declarative.BuildOption{
+		declarative.WithEgressCheck(deps.Egress.CheckFunc(cfg.allowedHosts)),
+	}
+	if cfg.providerBuildOptions != nil {
+		buildOpts = append(buildOpts, cfg.providerBuildOptions(conn)...)
+	}
+	prov, err := declarative.Build(def, declarativeNamedConnectionDef(connectionName, conn), buildOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("build post-connect provider for connection %q: %w", connectionName, err)
+	}
+	return prov, nil
+}
+
 func closeBuiltSpecSurfaces(surfaces []builtSpecSurface) {
 	for i := range surfaces {
 		closeIfPossible(surfaces[i].provider)
+	}
+}
+
+func closePostConnectOnlyProviders(providers []postConnectOnlyProvider) {
+	for i := range providers {
+		closeIfPossible(providers[i].provider)
 	}
 }
 
@@ -739,7 +824,7 @@ func buildConfiguredSpecProvider(ctx context.Context, name string, resolved conf
 		if err != nil {
 			return nil, nil, err
 		}
-		prov, err := declarative.Build(def, declarativeConnectionDef(resolved.Connection), buildOpts...)
+		prov, err := declarative.Build(def, declarativeNamedConnectionDef(resolved.ConnectionName, resolved.Connection), buildOpts...)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -2608,16 +2693,17 @@ func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *p
 	}
 
 	return pluginservice.StaticProviderSpec{
-		Name:             name,
-		DisplayName:      displayName,
-		Description:      description,
-		IconSVG:          iconSVG,
-		ConnectionMode:   connMode,
-		Catalog:          staticCatalog,
-		AuthTypes:        staticAuthTypes(conn.Auth.Type),
-		ConnectionParams: pluginservice.ConnectionParamDefsFromManifest(conn.ConnectionParams),
-		CredentialFields: pluginservice.CredentialFieldsFromManifest(conn.Auth.Credentials),
-		DiscoveryConfig:  pluginservice.DiscoveryConfigFromManifest(conn.Discovery),
+		Name:               name,
+		DisplayName:        displayName,
+		Description:        description,
+		IconSVG:            iconSVG,
+		ConnectionMode:     connMode,
+		Catalog:            staticCatalog,
+		AuthTypes:          staticAuthTypes(conn.Auth.Type),
+		ConnectionParams:   pluginservice.ConnectionParamDefsFromManifest(conn.ConnectionParams),
+		CredentialFields:   pluginservice.CredentialFieldsFromManifest(conn.Auth.Credentials),
+		DiscoveryConfig:    pluginservice.DiscoveryConfigFromManifest(conn.Discovery),
+		PostConnectConfigs: pluginservice.PostConnectConfigsFromManifestConnections(manifest.Spec.Connections),
 	}, plan, nil
 }
 

--- a/gestaltd/internal/bootstrap/startup_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_proxy.go
@@ -169,6 +169,13 @@ func (p *startupProviderProxy) SupportsHTTPSubject() bool {
 	}
 	return core.SupportsHTTPSubject(provider)
 }
+func (p *startupProviderProxy) SupportsPostConnect() bool {
+	provider := p.resolved()
+	if provider == nil {
+		return len(p.spec.PostConnectConfigs) > 0
+	}
+	return core.SupportsPostConnect(provider)
+}
 func (p *startupProviderProxy) Catalog() *catalog.Catalog {
 	if p.spec.Catalog == nil {
 		return nil
@@ -203,6 +210,24 @@ func (p *startupProviderProxy) ResolveHTTPSubject(ctx context.Context, req *core
 	}
 	subject, _, err := core.ResolveHTTPSubject(ctx, provider, req)
 	return subject, err
+}
+
+func (p *startupProviderProxy) PostConnect(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
+	done, err := p.beginWorkflowWait(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+
+	provider, err := p.await(ctx)
+	if err != nil {
+		return nil, err
+	}
+	metadata, supported, err := core.PostConnect(ctx, provider, token)
+	if !supported {
+		return nil, core.ErrPostConnectUnsupported
+	}
+	return metadata, err
 }
 
 func (p *startupProviderProxy) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1529,16 +1529,17 @@ func (s ServerConfig) ManagementBaseURL() string {
 // ConnectionDef owns authentication and connection parameters for a named
 // connection.
 type ConnectionDef struct {
-	Ref               string                                `yaml:"ref,omitempty"`
-	DisplayName       string                                `yaml:"displayName,omitempty"`
-	Mode              providermanifestv1.ConnectionMode     `yaml:"mode"`
-	Exposure          providermanifestv1.ConnectionExposure `yaml:"exposure,omitempty"`
-	Auth              ConnectionAuthDef                     `yaml:"auth"`
-	ConnectionParams  map[string]ConnectionParamDef         `yaml:"params"`
-	CredentialRefresh *CredentialRefreshDef                 `yaml:"credentialRefresh,omitempty"`
-	Discovery         *providermanifestv1.ProviderDiscovery `yaml:"-"`
-	ConnectionID      string                                `yaml:"-"`
-	BindingResolved   bool                                  `yaml:"-"`
+	Ref               string                                  `yaml:"ref,omitempty"`
+	DisplayName       string                                  `yaml:"displayName,omitempty"`
+	Mode              providermanifestv1.ConnectionMode       `yaml:"mode"`
+	Exposure          providermanifestv1.ConnectionExposure   `yaml:"exposure,omitempty"`
+	Auth              ConnectionAuthDef                       `yaml:"auth"`
+	ConnectionParams  map[string]ConnectionParamDef           `yaml:"params"`
+	CredentialRefresh *CredentialRefreshDef                   `yaml:"credentialRefresh,omitempty"`
+	Discovery         *providermanifestv1.ProviderDiscovery   `yaml:"-"`
+	PostConnect       *providermanifestv1.ProviderPostConnect `yaml:"-"`
+	ConnectionID      string                                  `yaml:"-"`
+	BindingResolved   bool                                    `yaml:"-"`
 }
 
 type CredentialRefreshDef = providermanifestv1.CredentialRefreshConfig
@@ -1715,6 +1716,9 @@ func MergeConnectionDef(dst *ConnectionDef, src *ConnectionDef) {
 	}
 	if src.Discovery != nil {
 		dst.Discovery = src.Discovery
+	}
+	if src.PostConnect != nil {
+		dst.PostConnect = providermanifestv1.CloneProviderPostConnect(src.PostConnect)
 	}
 	if src.ConnectionID != "" {
 		dst.ConnectionID = src.ConnectionID

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -354,6 +354,7 @@ func cloneConnectionDef(src ConnectionDef) ConnectionDef {
 	dst.Auth = cloneConnectionAuthDef(src.Auth)
 	dst.ConnectionParams = maps.Clone(src.ConnectionParams)
 	dst.CredentialRefresh = cloneCredentialRefreshDef(src.CredentialRefresh)
+	dst.PostConnect = providermanifestv1.CloneProviderPostConnect(src.PostConnect)
 	return dst
 }
 

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -47,6 +47,7 @@ type ResolvedConnectionDef struct {
 	Auth              ConnectionAuthDef
 	Params            map[string]ConnectionParamDef
 	Discovery         *providermanifestv1.ProviderDiscovery
+	PostConnect       *providermanifestv1.ProviderPostConnect
 	CredentialRefresh *CredentialRefreshDef
 	Source            ResolvedConnectionSource
 }
@@ -60,6 +61,7 @@ func (r ResolvedConnectionDef) ConnectionDef() ConnectionDef {
 		Auth:              r.Auth,
 		ConnectionParams:  r.Params,
 		Discovery:         r.Discovery,
+		PostConnect:       providermanifestv1.CloneProviderPostConnect(r.PostConnect),
 		CredentialRefresh: r.CredentialRefresh,
 		ConnectionID:      r.ConnectionID,
 	}
@@ -590,6 +592,9 @@ func ResolveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *providerma
 			if def.Discovery != nil {
 				conn.Discovery = def.Discovery
 			}
+			if def.PostConnect != nil {
+				conn.PostConnect = providermanifestv1.CloneProviderPostConnect(def.PostConnect)
+			}
 		}
 	}
 	if plugin != nil {
@@ -642,6 +647,7 @@ func resolvedConnectionDef(name string, conn ConnectionDef, source ResolvedConne
 		Auth:              conn.Auth,
 		Params:            conn.ConnectionParams,
 		Discovery:         conn.Discovery,
+		PostConnect:       providermanifestv1.CloneProviderPostConnect(conn.PostConnect),
 		CredentialRefresh: conn.CredentialRefresh,
 		Source:            source,
 	}

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -602,12 +602,18 @@ func (s *Server) applyProviderPostConnect(ctx context.Context, prov core.Provide
 		ExpiresAt:    tm.TokenExpiresAt,
 		MetadataJSON: tm.MetadataJSON,
 	}
-	metadata, _, err := core.PostConnect(ctx, prov, token)
+	metadata, supported, err := core.PostConnect(ctx, prov, token)
 	if err != nil {
 		return tm, err
 	}
+	if !supported {
+		return tm, nil
+	}
 	if metadata == nil {
 		slog.Warn("provider post-connect returned nil metadata", "integration", tm.Integration, "connection", tm.Connection, "instance", tm.Instance)
+	}
+	if len(metadata) == 0 {
+		return tm, nil
 	}
 	if err := validatePostConnectMetadata(metadata); err != nil {
 		return tm, err

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -15708,6 +15708,149 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		}
 	})
 
+	t.Run("declarative post-connect stores external identity relationship", func(t *testing.T) {
+		t.Parallel()
+
+		identitySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				t.Fatalf("identity request method = %q, want GET", r.Method)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer pagerduty-token" {
+				t.Fatalf("identity Authorization = %q, want bearer token", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"user":{"id":"P12345","email":"user@example.com"}}`)
+		}))
+		testutil.CloseOnCleanup(t, identitySrv)
+
+		svc := testutil.NewStubServices(t)
+		externalIdentityID := testExternalIdentityResourceID("pagerduty_identity", "user:P12345")
+		authzProvider := newMemoryAuthorizationProvider("memory-authorization")
+		baseAuthz, err := newTestAuthorizer(config.AuthorizationConfig{}, map[string]*config.ProviderEntry{})
+		if err != nil {
+			t.Fatalf("authorization.New: %v", err)
+		}
+		authz := mustProviderBackedAuthorizer(t, baseAuthz, authzProvider)
+		handler := &testOAuthHandler{
+			authorizationBaseURLVal: "https://identity.pagerduty.com/oauth/authorize",
+			exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+				if code == "good-code" {
+					return &core.TokenResponse{AccessToken: "pagerduty-token"}, nil
+				}
+				return nil, fmt.Errorf("bad code")
+			},
+		}
+		prov := &declarative.Base{
+			IntegrationName:    "pagerduty",
+			IntegrationDisplay: "PagerDuty",
+			IntegrationDesc:    "PagerDuty",
+			ConnMode:           core.ConnectionModeUser,
+			HTTPClient:         identitySrv.Client(),
+			PostConnectConfigs: map[string]*core.PostConnectConfig{
+				"default": {
+					Request: core.PostConnectRequestConfig{
+						Method: http.MethodGet,
+						URL:    identitySrv.URL,
+					},
+					SourcePath: "user",
+					ExternalIdentity: &core.PostConnectExternalIdentityConfig{
+						Type: "pagerduty_identity",
+						ID:   "user:{id}",
+					},
+					Metadata: map[string]string{
+						"pagerduty.user_id": "id",
+					},
+				},
+			},
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "session-token" {
+						return nil, fmt.Errorf("bad token")
+					}
+					return &core.UserIdentity{Email: "pagerduty-user@example.com"}, nil
+				},
+			}
+			cfg.Providers = testutil.NewProviderRegistry(t, prov)
+			cfg.DefaultConnection = map[string]string{"pagerduty": testDefaultConnection}
+			cfg.ConnectionAuth = testConnectionAuth("pagerduty", handler)
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.AuthorizationProvider = authzProvider
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		startBody := bytes.NewBufferString(`{"integration":"pagerduty"}`)
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+		startReq.Header.Set("Content-Type", "application/json")
+		startReq.Header.Set("Authorization", "Bearer session-token")
+		startResp, err := http.DefaultClient.Do(startReq)
+		if err != nil {
+			t.Fatalf("start request: %v", err)
+		}
+		defer func() { _ = startResp.Body.Close() }()
+		if startResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(startResp.Body)
+			t.Fatalf("expected 200 from start-oauth, got %d: %s", startResp.StatusCode, body)
+		}
+		var startResult map[string]string
+		if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+			t.Fatalf("decoding start response: %v", err)
+		}
+
+		noRedirect := &http.Client{
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+		resp, err := noRedirect.Do(req)
+		if err != nil {
+			t.Fatalf("callback request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusSeeOther {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 303, got %d: %s", resp.StatusCode, body)
+		}
+
+		u, _ := svc.Users.FindOrCreateUser(context.Background(), "pagerduty-user@example.com")
+		tokens, _ := svc.ExternalCredentials.ListCredentials(context.Background(), principal.UserSubjectID(u.ID))
+		if len(tokens) == 0 {
+			t.Fatal("expected token to be stored")
+		}
+		var metadata map[string]string
+		if err := json.Unmarshal([]byte(tokens[0].MetadataJSON), &metadata); err != nil {
+			t.Fatalf("unmarshal metadata: %v", err)
+		}
+		if !reflect.DeepEqual(metadata, map[string]string{
+			"pagerduty.user_id":              "P12345",
+			"gestalt.external_identity.type": "pagerduty_identity",
+			"gestalt.external_identity.id":   "user:P12345",
+		}) {
+			t.Fatalf("stored metadata = %+v", metadata)
+		}
+		respAuthz, err := authzProvider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
+			Relation: authorization.ProviderExternalIdentityRelationAssume,
+			Resource: &core.ResourceRef{
+				Type: authorization.ProviderResourceTypeExternalIdentity,
+				Id:   externalIdentityID,
+			},
+		})
+		if err != nil {
+			t.Fatalf("ReadRelationships after connect: %v", err)
+		}
+		if len(respAuthz.GetRelationships()) != 1 {
+			t.Fatalf("relationships after connect = %+v, want one", respAuthz.GetRelationships())
+		}
+		if got := respAuthz.GetRelationships()[0].GetSubject().GetId(); got != principal.UserSubjectID(u.ID) {
+			t.Fatalf("linked subject = %q, want %q", got, principal.UserSubjectID(u.ID))
+		}
+	})
+
 	t.Run("selection_required", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -399,8 +399,108 @@
         "discovery": {
           "$ref": "#/$defs/providerDiscovery"
         },
+        "postConnect": {
+          "$ref": "#/$defs/providerPostConnect"
+        },
         "credentialRefresh": {
           "$ref": "#/$defs/credentialRefreshConfig"
+        }
+      }
+    },
+    "providerPostConnect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request"
+      ],
+      "properties": {
+        "request": {
+          "$ref": "#/$defs/providerPostConnectRequest"
+        },
+        "sourcePath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "success": {
+          "$ref": "#/$defs/providerPostConnectSuccess"
+        },
+        "externalIdentity": {
+          "$ref": "#/$defs/providerPostConnectExternalIdentity"
+        },
+        "metadata": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "providerPostConnectRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "method",
+        "url"
+      ],
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": [
+            "GET",
+            "POST"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "minLength": 1
+        },
+        "headers": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "providerPostConnectSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "equals"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "equals": {}
+      }
+    },
+    "providerPostConnectExternalIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "id"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"reflect"
 	"strings"
 
@@ -344,6 +345,30 @@ type ProviderDiscovery struct {
 	Metadata map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
+type ProviderPostConnect struct {
+	Request          ProviderPostConnectRequest           `json:"request" yaml:"request"`
+	SourcePath       string                               `json:"sourcePath,omitempty" yaml:"sourcePath,omitempty"`
+	Success          *ProviderPostConnectSuccess          `json:"success,omitempty" yaml:"success,omitempty"`
+	ExternalIdentity *ProviderPostConnectExternalIdentity `json:"externalIdentity,omitempty" yaml:"externalIdentity,omitempty"`
+	Metadata         map[string]string                    `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+}
+
+type ProviderPostConnectRequest struct {
+	Method  string            `json:"method" yaml:"method"`
+	URL     string            `json:"url" yaml:"url"`
+	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+}
+
+type ProviderPostConnectSuccess struct {
+	Path   string `json:"path" yaml:"path"`
+	Equals any    `json:"equals" yaml:"equals"`
+}
+
+type ProviderPostConnectExternalIdentity struct {
+	Type string `json:"type" yaml:"type"`
+	ID   string `json:"id" yaml:"id"`
+}
+
 type ProviderConnectionParam struct {
 	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
@@ -378,6 +403,7 @@ type ManifestConnectionDef struct {
 	Auth              *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
 	Params            map[string]ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
 	Discovery         *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
+	PostConnect       *ProviderPostConnect               `json:"postConnect,omitempty" yaml:"postConnect,omitempty"`
 	CredentialRefresh *CredentialRefreshConfig           `json:"credentialRefresh,omitempty" yaml:"credentialRefresh,omitempty"`
 }
 
@@ -715,9 +741,50 @@ func cloneManifestConnections(src map[string]*ManifestConnectionDef) map[string]
 			continue
 		}
 		copyDef := *def
+		copyDef.Params = maps.Clone(def.Params)
+		copyDef.Discovery = cloneProviderDiscovery(def.Discovery)
+		copyDef.PostConnect = CloneProviderPostConnect(def.PostConnect)
+		copyDef.CredentialRefresh = cloneCredentialRefreshConfig(def.CredentialRefresh)
 		cloned[name] = &copyDef
 	}
 	return cloned
+}
+
+func cloneProviderDiscovery(src *ProviderDiscovery) *ProviderDiscovery {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	dst.Metadata = maps.Clone(src.Metadata)
+	return &dst
+}
+
+// CloneProviderPostConnect returns a deep copy of a provider post-connect
+// declaration.
+func CloneProviderPostConnect(src *ProviderPostConnect) *ProviderPostConnect {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	dst.Request.Headers = maps.Clone(src.Request.Headers)
+	if src.Success != nil {
+		success := *src.Success
+		dst.Success = &success
+	}
+	if src.ExternalIdentity != nil {
+		externalIdentity := *src.ExternalIdentity
+		dst.ExternalIdentity = &externalIdentity
+	}
+	dst.Metadata = maps.Clone(src.Metadata)
+	return &dst
+}
+
+func cloneCredentialRefreshConfig(src *CredentialRefreshConfig) *CredentialRefreshConfig {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	return &dst
 }
 
 func cloneHTTPSecuritySchemes(src map[string]*HTTPSecurityScheme) map[string]*HTTPSecurityScheme {

--- a/gestaltd/services/plugins/composite/merged_test.go
+++ b/gestaltd/services/plugins/composite/merged_test.go
@@ -344,6 +344,14 @@ func (p *falsePositivePostConnectProvider) PostConnect(_ context.Context, _ *cor
 	return nil, core.ErrPostConnectUnsupported
 }
 
+type unsupportedPostConnectProvider struct {
+	*fakeProvider
+}
+
+func (p *unsupportedPostConnectProvider) PostConnect(_ context.Context, _ *core.ExternalCredential) (map[string]string, error) {
+	return nil, core.ErrPostConnectUnsupported
+}
+
 func TestMergedPostConnectSkipsProvidersThatAdvertiseNoSupport(t *testing.T) {
 	t.Parallel()
 
@@ -367,6 +375,43 @@ func TestMergedPostConnectSkipsProvidersThatAdvertiseNoSupport(t *testing.T) {
 
 	got, supported, err := core.PostConnect(context.Background(), merged, &core.ExternalCredential{
 		Integration: "slack",
+		Connection:  "default",
+		AccessToken: "tok",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if !supported {
+		t.Fatal("expected core.PostConnect to report support")
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PostConnect metadata = %#v, want %#v", got, want)
+	}
+}
+
+func TestMergedPostConnectSkipsUnsupportedProviderForConnection(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]string{
+		"gestalt.external_identity.type": "pagerduty_identity",
+		"gestalt.external_identity.id":   "user:P12345",
+	}
+
+	merged, err := composite.NewMergedWithConnections("test", "Test", "desc", "",
+		composite.BoundProvider{Provider: &unsupportedPostConnectProvider{
+			fakeProvider: &fakeProvider{name: "first"},
+		}},
+		composite.BoundProvider{Provider: &fakePostConnectProvider{
+			fakeProvider: &fakeProvider{name: "pagerduty"},
+			metadata:     want,
+		}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, supported, err := core.PostConnect(context.Background(), merged, &core.ExternalCredential{
+		Integration: "pagerduty",
 		Connection:  "default",
 		AccessToken: "tok",
 	})

--- a/gestaltd/services/plugins/declarative/base.go
+++ b/gestaltd/services/plugins/declarative/base.go
@@ -19,6 +19,7 @@ import (
 var (
 	_ core.OAuthProvider         = (*Base)(nil)
 	_ core.GraphQLSurfaceInvoker = (*Base)(nil)
+	_ core.PostConnectCapable    = (*Base)(nil)
 )
 
 type manualChecker interface{ IsManual() bool }
@@ -70,6 +71,7 @@ type Base struct {
 
 	ConnectionDefs      map[string]core.ConnectionParamDef
 	DiscoveryDef        *core.DiscoveryConfig
+	PostConnectConfigs  map[string]*core.PostConnectConfig
 	ManualAuthEnabled   bool
 	CredentialFieldDefs []core.CredentialFieldDef
 

--- a/gestaltd/services/plugins/declarative/build.go
+++ b/gestaltd/services/plugins/declarative/build.go
@@ -75,6 +75,7 @@ func Build(def *Definition, conn ConnectionDef, opts ...BuildOption) (core.Provi
 		Headers:            def.Headers,
 		Pagination:         buildPaginationConfigs(def),
 		CheckEgress:        bo.egressCheck,
+		PostConnectConfigs: conn.PostConnect,
 	}
 
 	connMode := conn.Mode

--- a/gestaltd/services/plugins/declarative/build_test.go
+++ b/gestaltd/services/plugins/declarative/build_test.go
@@ -3,16 +3,19 @@ package declarative
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/egress"
 )
 
 func testDefinition(name string) *Definition {
@@ -75,6 +78,97 @@ func TestBuildManualAuth(t *testing.T) {
 	}
 	if intg.Name() != "manual_api" {
 		t.Errorf("Name() = %q", intg.Name())
+	}
+}
+
+func TestBuildPostConnectMapsNestedSource(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer pagerduty-token" {
+			t.Fatalf("Authorization = %q, want bearer token", r.Header.Get("Authorization"))
+		}
+		if r.Header.Get("Accept") != "application/vnd.pagerduty+json;version=2" {
+			t.Fatalf("Accept = %q, want PagerDuty API version", r.Header.Get("Accept"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", r.Header.Get("Content-Type"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"user":{"id":"P12345","email":"user@example.com"}}`))
+	}))
+	defer srv.Close()
+
+	prov, err := Build(testDefinition("pagerduty"), ConnectionDef{
+		PostConnect: map[string]*core.PostConnectConfig{
+			"default": {
+				Request: core.PostConnectRequestConfig{
+					Method: http.MethodGet,
+					URL:    srv.URL,
+					Headers: map[string]string{
+						"Accept":       "application/vnd.pagerduty+json;version=2",
+						"Content-Type": "application/json",
+					},
+				},
+				SourcePath: "user",
+				ExternalIdentity: &core.PostConnectExternalIdentityConfig{
+					Type: "pagerduty_identity",
+					ID:   "user:{id}",
+				},
+				Metadata: map[string]string{
+					"pagerduty.user_id": "id",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	metadata, supported, err := core.PostConnect(context.Background(), prov, &core.ExternalCredential{
+		Connection:  "default",
+		AccessToken: "pagerduty-token",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if !supported {
+		t.Fatal("expected post-connect support")
+	}
+	want := map[string]string{
+		"gestalt.external_identity.type": "pagerduty_identity",
+		"gestalt.external_identity.id":   "user:P12345",
+		"pagerduty.user_id":              "P12345",
+	}
+	if !reflect.DeepEqual(metadata, want) {
+		t.Fatalf("metadata = %#v, want %#v", metadata, want)
+	}
+}
+
+func TestBuildPostConnectAppliesEgressCheck(t *testing.T) {
+	t.Parallel()
+
+	prov, err := Build(testDefinition("pagerduty"), ConnectionDef{
+		PostConnect: map[string]*core.PostConnectConfig{
+			"default": {
+				Request: core.PostConnectRequestConfig{
+					Method: http.MethodGet,
+					URL:    "https://api.pagerduty.com/users/me",
+				},
+				Metadata: map[string]string{"pagerduty.user_id": "id"},
+			},
+		},
+	}, WithEgressCheck(func(string) error {
+		return egress.ErrEgressDenied
+	}))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	_, _, err = core.PostConnect(context.Background(), prov, &core.ExternalCredential{
+		Connection:  "default",
+		AccessToken: "pagerduty-token",
+	})
+	if !errors.Is(err, egress.ErrEgressDenied) {
+		t.Fatalf("PostConnect error = %v, want egress denied", err)
 	}
 }
 

--- a/gestaltd/services/plugins/declarative/connection.go
+++ b/gestaltd/services/plugins/declarative/connection.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
@@ -13,6 +14,7 @@ type ConnectionDef struct {
 	Mode             providermanifestv1.ConnectionMode
 	Auth             ConnectionAuthDef
 	ConnectionParams map[string]ConnectionParamDef
+	PostConnect      map[string]*core.PostConnectConfig
 }
 
 // ConnectionAuthDef is the auth material needed to construct a declarative

--- a/gestaltd/services/plugins/declarative/post_connect.go
+++ b/gestaltd/services/plugins/declarative/post_connect.go
@@ -1,0 +1,214 @@
+package declarative
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"reflect"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/services/egress"
+	"github.com/valon-technologies/gestalt/server/services/plugins/apiexec"
+)
+
+const maxPostConnectResponseSize = 5 * 1024 * 1024
+
+func (b *Base) SupportsPostConnect() bool {
+	return b != nil && len(b.PostConnectConfigs) > 0
+}
+
+func (b *Base) PostConnect(ctx context.Context, token *core.ExternalCredential) (map[string]string, error) {
+	if b == nil || len(b.PostConnectConfigs) == 0 {
+		return nil, core.ErrPostConnectUnsupported
+	}
+	if token == nil {
+		return nil, fmt.Errorf("post-connect token is required")
+	}
+	cfg := b.PostConnectConfigs[strings.TrimSpace(token.Connection)]
+	if cfg == nil {
+		return nil, core.ErrPostConnectUnsupported
+	}
+	return b.runDeclarativePostConnect(ctx, cfg, token.AccessToken)
+}
+
+func (b *Base) runDeclarativePostConnect(ctx context.Context, cfg *core.PostConnectConfig, accessToken string) (map[string]string, error) {
+	method := strings.ToUpper(strings.TrimSpace(cfg.Request.Method))
+	switch method {
+	case http.MethodGet, http.MethodPost:
+	default:
+		return nil, fmt.Errorf("post-connect request method %q is not supported", cfg.Request.Method)
+	}
+	rawURL := strings.TrimSpace(cfg.Request.URL)
+	if rawURL == "" {
+		return nil, fmt.Errorf("post-connect request URL is required")
+	}
+	if err := b.checkEgressHost(rawURL); err != nil {
+		return nil, err
+	}
+
+	credential, err := b.materializeCredential(accessToken)
+	if err != nil {
+		return nil, err
+	}
+	staticHeaders := maps.Clone(b.Headers)
+	for k, v := range cfg.Request.Headers {
+		if staticHeaders == nil {
+			staticHeaders = make(map[string]string, len(cfg.Request.Headers))
+		}
+		staticHeaders[k] = v
+	}
+	headers := egress.ApplyHeaderMutations(staticHeaders, credential.Headers)
+
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create post-connect request: %w", err)
+	}
+	if credential.Authorization != "" {
+		req.Header.Set("Authorization", credential.Authorization)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := b.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute post-connect request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPostConnectResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("read post-connect response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("post-connect request failed: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var raw any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("parse post-connect response: %w", err)
+	}
+	if err := validatePostConnectSuccess(raw, cfg.Success); err != nil {
+		return nil, err
+	}
+	source, err := postConnectSource(raw, cfg.SourcePath)
+	if err != nil {
+		return nil, err
+	}
+	return renderPostConnectMetadata(source, cfg)
+}
+
+func validatePostConnectSuccess(raw any, success *core.PostConnectSuccessCheck) error {
+	if success == nil {
+		return nil
+	}
+	value, ok := apiexec.ExtractJSONPath(raw, strings.TrimSpace(success.Path))
+	if !ok {
+		return fmt.Errorf("post-connect success path %q not found", success.Path)
+	}
+	if !reflect.DeepEqual(value, success.Equals) {
+		return fmt.Errorf("post-connect success check failed at %q", success.Path)
+	}
+	return nil
+}
+
+func postConnectSource(raw any, sourcePath string) (map[string]any, error) {
+	source := raw
+	if strings.TrimSpace(sourcePath) != "" {
+		value, ok := apiexec.ExtractJSONPath(raw, strings.TrimSpace(sourcePath))
+		if !ok {
+			return nil, fmt.Errorf("post-connect source path %q not found", sourcePath)
+		}
+		source = value
+	}
+	obj, ok := source.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("post-connect source path %q is not an object", sourcePath)
+	}
+	return obj, nil
+}
+
+func renderPostConnectMetadata(source map[string]any, cfg *core.PostConnectConfig) (map[string]string, error) {
+	metadata := make(map[string]string)
+	if cfg.ExternalIdentity != nil {
+		typ := strings.TrimSpace(cfg.ExternalIdentity.Type)
+		id, err := renderPostConnectTemplate(cfg.ExternalIdentity.ID, source)
+		if err != nil {
+			return nil, fmt.Errorf("post-connect external identity id: %w", err)
+		}
+		if typ != "" {
+			metadata["gestalt.external_identity.type"] = typ
+		}
+		if id != "" {
+			metadata["gestalt.external_identity.id"] = id
+		}
+	}
+	for key, expr := range cfg.Metadata {
+		value, err := renderPostConnectMapping(expr, source)
+		if err != nil {
+			return nil, fmt.Errorf("post-connect metadata %q: %w", key, err)
+		}
+		metadata[key] = value
+	}
+	return metadata, nil
+}
+
+func renderPostConnectMapping(expr string, source map[string]any) (string, error) {
+	if strings.Contains(expr, "{") || strings.Contains(expr, "}") {
+		return renderPostConnectTemplate(expr, source)
+	}
+	value, ok := apiexec.ExtractJSONPath(source, strings.TrimSpace(expr))
+	if !ok {
+		return "", fmt.Errorf("path %q not found", expr)
+	}
+	return postConnectValueString(value)
+}
+
+func renderPostConnectTemplate(tmpl string, source map[string]any) (string, error) {
+	var out strings.Builder
+	for {
+		start := strings.Index(tmpl, "{")
+		if start < 0 {
+			out.WriteString(tmpl)
+			return out.String(), nil
+		}
+		end := strings.Index(tmpl[start+1:], "}")
+		if end < 0 {
+			return "", fmt.Errorf("unclosed template placeholder")
+		}
+		end += start + 1
+		out.WriteString(tmpl[:start])
+		path := strings.TrimSpace(tmpl[start+1 : end])
+		if path == "" {
+			return "", fmt.Errorf("empty template placeholder")
+		}
+		value, ok := apiexec.ExtractJSONPath(source, path)
+		if !ok {
+			return "", fmt.Errorf("path %q not found", path)
+		}
+		rendered, err := postConnectValueString(value)
+		if err != nil {
+			return "", err
+		}
+		out.WriteString(rendered)
+		tmpl = tmpl[end+1:]
+	}
+}
+
+func postConnectValueString(value any) (string, error) {
+	switch v := value.(type) {
+	case nil:
+		return "", fmt.Errorf("value is null")
+	case string:
+		return v, nil
+	case bool:
+		return fmt.Sprintf("%t", v), nil
+	case float64:
+		return fmt.Sprintf("%v", v), nil
+	default:
+		return "", fmt.Errorf("value has unsupported type %T", value)
+	}
+}

--- a/gestaltd/services/plugins/declarative_provider.go
+++ b/gestaltd/services/plugins/declarative_provider.go
@@ -26,6 +26,7 @@ type declarativeOptions struct {
 	operationConnections map[string]string
 	connectionSelectors  map[string]core.OperationConnectionSelector
 	operationLocks       map[string]bool
+	egressCheck          func(string) error
 }
 
 type DeclarativeProviderOption func(*declarativeOptions)
@@ -56,6 +57,10 @@ func WithDeclarativeOperationConnections(connections map[string]string, selector
 		opts.connectionSelectors = cloneOperationConnectionSelectors(selectors)
 		opts.operationLocks = maps.Clone(locks)
 	}
+}
+
+func WithDeclarativeEgressCheck(fn func(string) error) DeclarativeProviderOption {
+	return func(opts *declarativeOptions) { opts.egressCheck = fn }
 }
 
 type DeclarativeProvider struct {
@@ -108,7 +113,9 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 		RequestContentType:          declarativeJSONContentType,
 		ConnectionDefs:              ConnectionParamDefsFromManifest(params),
 		DiscoveryDef:                DiscoveryConfigFromManifest(discovery),
+		PostConnectConfigs:          PostConnectConfigsFromManifestConnections(manifest.Spec.Connections),
 		CredentialFieldDefs:         declarativeCredentialFields(auth),
+		CheckEgress:                 options.egressCheck,
 		NoRetry:                     true,
 	}
 	if auth != nil {

--- a/gestaltd/services/plugins/declarative_provider_test.go
+++ b/gestaltd/services/plugins/declarative_provider_test.go
@@ -3,10 +3,13 @@ package plugins
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
@@ -81,5 +84,106 @@ func TestDeclarativeProvider_POSTUsesExplicitJSONContentType(t *testing.T) {
 	}
 	if got := prov.Catalog().Operations[0].Tags; len(got) != 2 || got[0] != "chat" || got[1] != "message" {
 		t.Fatalf("catalog operation tags = %#v, want chat/message", got)
+	}
+}
+
+func TestDeclarativeProvider_PostConnectMapsManifestConnectionMetadata(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod string
+	var gotAuthorization string
+	var gotAccept string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotAuthorization = r.Header.Get("Authorization")
+		gotAccept = r.Header.Get("Accept")
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"team_id":"T123","user_id":"U456"}`))
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  "github.com/test/slack",
+		Version: "0.0.1-alpha.1",
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL: "https://slack.com/api",
+					Operations: []providermanifestv1.ProviderOperation{{
+						Name:   "conversations.list",
+						Method: http.MethodGet,
+						Path:   "/conversations.list",
+					}},
+				},
+			},
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"default": {
+					PostConnect: &providermanifestv1.ProviderPostConnect{
+						Request: providermanifestv1.ProviderPostConnectRequest{
+							Method: http.MethodPost,
+							URL:    srv.URL,
+							Headers: map[string]string{
+								"Accept": "application/json",
+							},
+						},
+						Success: &providermanifestv1.ProviderPostConnectSuccess{
+							Path:   "ok",
+							Equals: true,
+						},
+						ExternalIdentity: &providermanifestv1.ProviderPostConnectExternalIdentity{
+							Type: "slack_identity",
+							ID:   "team:{team_id}:user:{user_id}",
+						},
+						Metadata: map[string]string{
+							"slack.team_id": "team_id",
+							"slack.user_id": "user_id",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	prov, err := NewDeclarativeProvider(manifest, srv.Client())
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+	metadata, supported, err := core.PostConnect(context.Background(), prov, &core.ExternalCredential{
+		Connection:  "default",
+		AccessToken: "slack-token",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if !supported {
+		t.Fatal("expected post-connect support")
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %q, want POST", gotMethod)
+	}
+	if gotAuthorization != "Bearer slack-token" {
+		t.Fatalf("Authorization = %q, want bearer token", gotAuthorization)
+	}
+	if gotAccept != "application/json" {
+		t.Fatalf("Accept = %q, want application/json", gotAccept)
+	}
+	if len(gotBody) != 0 {
+		t.Fatalf("POST body = %q, want empty", string(gotBody))
+	}
+	want := map[string]string{
+		"gestalt.external_identity.type": "slack_identity",
+		"gestalt.external_identity.id":   "team:T123:user:U456",
+		"slack.team_id":                  "T123",
+		"slack.user_id":                  "U456",
+	}
+	if !reflect.DeepEqual(metadata, want) {
+		t.Fatalf("metadata = %#v, want %#v", metadata, want)
 	}
 }

--- a/gestaltd/services/plugins/manifest_core.go
+++ b/gestaltd/services/plugins/manifest_core.go
@@ -50,3 +50,48 @@ func DiscoveryConfigFromManifest(discovery *providermanifestv1.ProviderDiscovery
 		Metadata: maps.Clone(discovery.Metadata),
 	}
 }
+
+func PostConnectConfigsFromManifestConnections(connections map[string]*providermanifestv1.ManifestConnectionDef) map[string]*core.PostConnectConfig {
+	if len(connections) == 0 {
+		return nil
+	}
+	out := make(map[string]*core.PostConnectConfig)
+	for name, conn := range connections {
+		if conn == nil || conn.PostConnect == nil {
+			continue
+		}
+		out[name] = PostConnectConfigFromManifest(conn.PostConnect)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func PostConnectConfigFromManifest(postConnect *providermanifestv1.ProviderPostConnect) *core.PostConnectConfig {
+	if postConnect == nil {
+		return nil
+	}
+	cfg := &core.PostConnectConfig{
+		Request: core.PostConnectRequestConfig{
+			Method:  postConnect.Request.Method,
+			URL:     postConnect.Request.URL,
+			Headers: maps.Clone(postConnect.Request.Headers),
+		},
+		SourcePath: postConnect.SourcePath,
+		Metadata:   maps.Clone(postConnect.Metadata),
+	}
+	if postConnect.Success != nil {
+		cfg.Success = &core.PostConnectSuccessCheck{
+			Path:   postConnect.Success.Path,
+			Equals: postConnect.Success.Equals,
+		}
+	}
+	if postConnect.ExternalIdentity != nil {
+		cfg.ExternalIdentity = &core.PostConnectExternalIdentityConfig{
+			Type: postConnect.ExternalIdentity.Type,
+			ID:   postConnect.ExternalIdentity.ID,
+		}
+	}
+	return cfg
+}

--- a/gestaltd/services/plugins/packageio/manifest.go
+++ b/gestaltd/services/plugins/packageio/manifest.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"mime"
+	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -548,6 +550,9 @@ func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error
 		if conn == nil {
 			continue
 		}
+		if err := validateProviderPostConnect(fmt.Sprintf("provider.connections.%s.postConnect", name), conn.PostConnect, provider); err != nil {
+			return err
+		}
 		if err := validateProviderAuth(fmt.Sprintf("provider.connections.%s.auth", name), conn.Auth); err != nil {
 			return err
 		}
@@ -595,6 +600,60 @@ func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error
 	for _, check := range checks {
 		if check.present {
 			return fmt.Errorf("%s is no longer supported for executable providers", check.field)
+		}
+	}
+	return nil
+}
+
+func validateProviderPostConnect(path string, postConnect *providermanifestv1.ProviderPostConnect, provider *providermanifestv1.Spec) error {
+	if postConnect == nil {
+		return nil
+	}
+	if provider == nil || !provider.IsManifestBacked() {
+		return fmt.Errorf("%s requires a declarative, OpenAPI, GraphQL, or MCP surface", path)
+	}
+	method := strings.ToUpper(strings.TrimSpace(postConnect.Request.Method))
+	switch method {
+	case http.MethodGet, http.MethodPost:
+	default:
+		return fmt.Errorf("%s.request.method must be GET or POST", path)
+	}
+	rawURL := strings.TrimSpace(postConnect.Request.URL)
+	if rawURL == "" {
+		return fmt.Errorf("%s.request.url is required", path)
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || !parsed.IsAbs() || parsed.Scheme != "https" || parsed.Host == "" {
+		return fmt.Errorf("%s.request.url must be an absolute https URL", path)
+	}
+	for key, value := range postConnect.Request.Headers {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("%s.request.headers keys must be non-empty", path)
+		}
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s.request.headers.%s is required", path, key)
+		}
+	}
+	if postConnect.Success != nil && strings.TrimSpace(postConnect.Success.Path) == "" {
+		return fmt.Errorf("%s.success.path is required", path)
+	}
+	if postConnect.ExternalIdentity != nil {
+		if strings.TrimSpace(postConnect.ExternalIdentity.Type) == "" {
+			return fmt.Errorf("%s.externalIdentity.type is required", path)
+		}
+		if strings.TrimSpace(postConnect.ExternalIdentity.ID) == "" {
+			return fmt.Errorf("%s.externalIdentity.id is required", path)
+		}
+	}
+	if postConnect.ExternalIdentity == nil && len(postConnect.Metadata) == 0 {
+		return fmt.Errorf("%s must declare externalIdentity or metadata", path)
+	}
+	for key, value := range postConnect.Metadata {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("%s.metadata keys must be non-empty", path)
+		}
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s.metadata.%s is required", path, key)
 		}
 	}
 	return nil

--- a/gestaltd/services/plugins/packageio/manifest_post_connect_test.go
+++ b/gestaltd/services/plugins/packageio/manifest_post_connect_test.go
@@ -1,0 +1,87 @@
+package packageio
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeSourceManifestPostConnectContract(t *testing.T) {
+	t.Parallel()
+
+	const manifest = `
+source: github.com/test/gestalt-providers/plugins/pagerduty
+version: 0.0.1-alpha.1
+kind: plugin
+spec:
+  surfaces:
+    openapi:
+      connection: default
+      document: https://example.com/openapi.json
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorizationUrl: https://identity.example.com/oauth/authorize
+        tokenUrl: https://identity.example.com/oauth/token
+      postConnect:
+        request:
+          method: GET
+          url: https://api.example.com/users/me
+          headers:
+            Accept: application/vnd.pagerduty+json;version=2
+        sourcePath: user
+        externalIdentity:
+          type: pagerduty_identity
+          id: user:{id}
+        metadata:
+          pagerduty.user_id: id
+`
+	parsed, err := DecodeSourceManifestFormat([]byte(manifest), ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("DecodeSourceManifestFormat: %v", err)
+	}
+	postConnect := parsed.Spec.Connections["default"].PostConnect
+	if postConnect == nil {
+		t.Fatal("expected postConnect to decode")
+	}
+	if postConnect.ExternalIdentity.ID != "user:{id}" {
+		t.Fatalf("externalIdentity.id = %q, want user:{id}", postConnect.ExternalIdentity.ID)
+	}
+	if got := postConnect.Request.Headers["Accept"]; got != "application/vnd.pagerduty+json;version=2" {
+		t.Fatalf("request.headers.Accept = %q, want PagerDuty API version", got)
+	}
+}
+
+func TestDecodeSourceManifestRejectsInsecurePostConnectURL(t *testing.T) {
+	t.Parallel()
+
+	const manifest = `
+source: github.com/test/gestalt-providers/plugins/pagerduty
+version: 0.0.1-alpha.1
+kind: plugin
+spec:
+  surfaces:
+    openapi:
+      connection: default
+      document: https://example.com/openapi.json
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorizationUrl: https://identity.example.com/oauth/authorize
+        tokenUrl: https://identity.example.com/oauth/token
+      postConnect:
+        request:
+          method: GET
+          url: http://api.example.com/users/me
+        metadata:
+          pagerduty.user_id: id
+`
+	_, err := DecodeSourceManifestFormat([]byte(manifest), ManifestFormatYAML)
+	if err == nil {
+		t.Fatal("expected insecure postConnect URL to be rejected")
+	}
+	if !strings.Contains(err.Error(), "postConnect.request.url must be an absolute https URL") {
+		t.Fatalf("error = %v, want https URL validation", err)
+	}
+}

--- a/gestaltd/services/plugins/provider_client.go
+++ b/gestaltd/services/plugins/provider_client.go
@@ -20,16 +20,17 @@ import (
 )
 
 type StaticProviderSpec struct {
-	Name             string
-	DisplayName      string
-	Description      string
-	IconSVG          string
-	ConnectionMode   core.ConnectionMode
-	Catalog          *catalog.Catalog
-	AuthTypes        []string
-	ConnectionParams map[string]core.ConnectionParamDef
-	CredentialFields []core.CredentialFieldDef
-	DiscoveryConfig  *core.DiscoveryConfig
+	Name               string
+	DisplayName        string
+	Description        string
+	IconSVG            string
+	ConnectionMode     core.ConnectionMode
+	Catalog            *catalog.Catalog
+	AuthTypes          []string
+	ConnectionParams   map[string]core.ConnectionParamDef
+	CredentialFields   []core.CredentialFieldDef
+	DiscoveryConfig    *core.DiscoveryConfig
+	PostConnectConfigs map[string]*core.PostConnectConfig
 }
 
 type remoteProviderBase struct {
@@ -270,6 +271,9 @@ func (p *remoteProviderBase) postConnect(ctx context.Context, token *core.Extern
 		Token: postConnectCredentialToProto(token),
 	})
 	if err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			return nil, core.ErrPostConnectUnsupported
+		}
 		return nil, err
 	}
 	metadata := resp.GetMetadata()

--- a/gestaltd/services/plugins/provider_server.go
+++ b/gestaltd/services/plugins/provider_server.go
@@ -103,9 +103,12 @@ func (s *ProviderServer) PostConnect(ctx context.Context, req *proto.PostConnect
 	if !core.SupportsPostConnect(s.provider) {
 		return nil, status.Error(codes.Unimplemented, "provider does not support post connect")
 	}
-	metadata, _, err := core.PostConnect(ctx, s.provider, postConnectCredentialFromProto(req.GetToken()))
+	metadata, supported, err := core.PostConnect(ctx, s.provider, postConnectCredentialFromProto(req.GetToken()))
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "post connect: %v", err)
+	}
+	if !supported {
+		return nil, status.Error(codes.Unimplemented, "provider does not support post connect for credential")
 	}
 	return &proto.PostConnectResponse{Metadata: metadata}, nil
 }

--- a/gestaltd/services/providerdev/session.go
+++ b/gestaltd/services/providerdev/session.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -2157,6 +2158,26 @@ func cloneStaticProviderSpec(spec pluginservice.StaticProviderSpec) pluginservic
 	if spec.DiscoveryConfig != nil {
 		discovery := *spec.DiscoveryConfig
 		out.DiscoveryConfig = &discovery
+	}
+	if spec.PostConnectConfigs != nil {
+		out.PostConnectConfigs = make(map[string]*core.PostConnectConfig, len(spec.PostConnectConfigs))
+		for name, cfg := range spec.PostConnectConfigs {
+			if cfg == nil {
+				continue
+			}
+			clone := *cfg
+			clone.Request.Headers = maps.Clone(cfg.Request.Headers)
+			if cfg.Success != nil {
+				success := *cfg.Success
+				clone.Success = &success
+			}
+			if cfg.ExternalIdentity != nil {
+				externalIdentity := *cfg.ExternalIdentity
+				clone.ExternalIdentity = &externalIdentity
+			}
+			clone.Metadata = maps.Clone(cfg.Metadata)
+			out.PostConnectConfigs[name] = &clone
+		}
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

Adds a connection-level declarative `postConnect` primitive that feeds the existing `core.PostConnect` flow. Declarative and spec-loaded providers can now call a bounded identity endpoint after OAuth/manual connect, map response fields into credential metadata, and emit the existing external identity metadata keys that gestaltd already syncs into authorization relationships.

## Interface Changes
- New/changed interface: manifest connections may declare `postConnect` with `request`, optional `request.headers`, optional `success`, optional `sourcePath`, `externalIdentity`, and `metadata` mappings.
- Example usage:

```yaml
connections:
  default:
    postConnect:
      request:
        method: GET
        url: https://api.pagerduty.com/users/me
        headers:
          Accept: application/vnd.pagerduty+json;version=2
          Content-Type: application/json
      sourcePath: user
      externalIdentity:
        type: pagerduty_identity
        id: user:{id}
      metadata:
        pagerduty.user_id: id
```

## Functional/Integration Tests
- Tests added or augmented:
  - manifest decode/validation contract for `postConnect`, including request headers
  - manifest REST provider `core.PostConnect` contract for Slack-shaped POST/no-body mapping
  - spec-loaded/declarative build contract for PagerDuty-shaped nested source mapping and request headers
  - bootstrap contract for spec-loaded OpenAPI providers with `postConnect` on a non-surface named connection
  - merged provider routing when a provider supports post-connect globally but not for the credential connection
  - server OAuth callback integration for metadata persistence and external identity relationship sync
- Contract boundary covered: manifest YAML -> provider construction -> post-connect HTTP transport -> credential metadata -> authorization relationship sync.
- Commands run:
  - `go test ./core ./services/plugins ./services/plugins/composite ./services/plugins/declarative ./services/plugins/packageio ./services/providerdev ./internal/config ./internal/bootstrap ./internal/server`
  - `go test ./...`
  - `go build -o /tmp/gestaltd-postconnect ./cmd/gestaltd`

## Follow-up PRs
- Stacked provider migration: PagerDuty manifest will declare this primitive in `valon-technologies/gestalt-providers`.
- Slack migration should follow separately by removing the Python `@gestalt.post_connect` hook before adding the Slack manifest declaration.
