### PR TITLE
Narrow default agent tool grants for large catalogs

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -149,6 +149,8 @@ server:
   runtime:
     defaultHostedProvider: modal
     relayBaseUrl: https://gestalt.example.com
+  agent:
+    defaultToolNarrowingThreshold: 200
   providers:
     authorization: indexeddb
     authentication: oidc
@@ -180,6 +182,8 @@ authorization:
 
 `runtime.defaultHostedProvider` selects the runtime provider used when a plugin or agent opts into hosted execution without naming a provider. `runtime.relayBaseUrl` overrides the URL handed to hosted runtimes for Gestalt host-service callbacks and hostname egress proxying. It defaults to `server.baseUrl`; set it when hosted runtimes need to call back through a private listener or internal reverse proxy while browser and OAuth flows still use the public origin. The target may be the management listener when that listener is reachable from the hosted runtime network.
 
+`agent.defaultToolNarrowingThreshold` controls implicit default MCP catalog grants for agent providers that support the catalog. When the total visible catalog is larger than this threshold and the latest user message exactly names a provider, Gestalt grants that provider instead of a global wildcard. Omit it to use the server default; set it to `0` to narrow whenever any visible catalog tool exists.
+
 `admin.authorizationPolicy` binds the built-in `/admin` route to one shared subject access policy from `authorization.policies`. `admin.allowedRoles` controls which roles may load the built-in admin UI, defaulting to `[admin]`.
 
 `admin.ui` optionally pins `/admin` to one named `providers.ui.<name>` bundle. The selected bundle must ship `admin/index.html` inside its prepared asset root. When `admin.ui` is omitted, Gestalt first auto-discovers admin assets from the root-mounted UI bundle (`path: /`) when that bundle contains `admin/index.html`, then falls back to the built-in admin shell.
@@ -203,6 +207,7 @@ Plugins without `authorizationPolicy` are open to any authenticated subject. Bin
 | `encryptionKey` | | **Required.** Root encryption key. Typically a structured secret ref. |
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared artifacts produced by `gestaltd sync --locked`. |
+| `agent.defaultToolNarrowingThreshold` | `200` | Visible catalog size above which implicit default agent catalog grants may be narrowed to exactly mentioned providers. Set `0` to narrow whenever a matching provider has any visible tools. |
 | `providers.audit` / `providers.authentication` / `providers.authorization` / `providers.indexeddb` / `providers.secrets` / `providers.telemetry` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
 | `dev.attachmentState` | | Enables private remote provider-dev attach routes and selects where attachment state is stored. The only supported value is `indexeddb`, which stores attachment state in the configured host IndexedDB for shared and load-balanced servers. |
 | `runtime.defaultHostedProvider` | | Default runtime-provider selector for plugins that opt into `execution.mode: hosted`. This does not move plugins into hosted runtimes by itself. |

--- a/gestaltd/deploy/helm/gestaltd/values.yaml
+++ b/gestaltd/deploy/helm/gestaltd/values.yaml
@@ -97,6 +97,10 @@ config:
     # baseUrl: "${GESTALT_BASE_URL}"
     providers:
       indexeddb: main
+    # Controls when implicit default agent catalog grants are narrowed to
+    # exactly mentioned providers. Omitted uses the gestaltd default.
+    # agent:
+    #   defaultToolNarrowingThreshold: 200
   providers:
     indexeddb:
       main:

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1098,17 +1098,18 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		PluginInvokes:     agentPluginInvokes(cfg),
 	}))
 	agentManager.SetTarget(agentmanager.New(agentmanager.Config{
-		Providers:         providers,
-		Agent:             prepared.Deps.AgentRuntime,
-		WorkflowTools:     workflowTools,
-		RunGrants:         prepared.Deps.AgentRunGrants,
-		Invoker:           sharedInvoker,
-		Authorizer:        authz,
-		DefaultConnection: connMaps.DefaultConnection,
-		CatalogConnection: connMaps.APIConnection,
-		PluginInvokes:     agentPluginInvokes(cfg),
-		AgentConnections:  agentConnectionBindings(cfg),
-		RouteStore:        agentRouteStore,
+		Providers:                     providers,
+		Agent:                         prepared.Deps.AgentRuntime,
+		WorkflowTools:                 workflowTools,
+		RunGrants:                     prepared.Deps.AgentRunGrants,
+		Invoker:                       sharedInvoker,
+		Authorizer:                    authz,
+		DefaultConnection:             connMaps.DefaultConnection,
+		CatalogConnection:             connMaps.APIConnection,
+		PluginInvokes:                 agentPluginInvokes(cfg),
+		AgentConnections:              agentConnectionBindings(cfg),
+		RouteStore:                    agentRouteStore,
+		DefaultToolNarrowingThreshold: cfg.Server.Agent.DefaultToolNarrowingThreshold,
 	}))
 	prepared.Deps.AgentRuntime.SetToolSearcher(agentManager)
 	extraWorkflows, err := buildWorkflows(ctx, cfg, factories, prepared.Deps)

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3113,6 +3113,151 @@ func TestBootstrapAgentHostToolCatalogListsAndExecutesVisibleTools(t *testing.T)
 	}
 }
 
+func TestBootstrapAgentDefaultToolNarrowingThresholdConfigNarrowsImplicitCatalogGrant(t *testing.T) {
+	t.Parallel()
+
+	threshold := 0
+	cfg := validConfig()
+	cfg.Server.Agent.DefaultToolNarrowingThreshold = &threshold
+	cfg.Providers.Agent = map[string]*config.ProviderEntry{
+		"managed": {
+			Source:  config.ProviderSource{Path: "stub"},
+			Default: true,
+		},
+	}
+
+	factories := validFactories()
+	factories.Builtins = append(factories.Builtins,
+		&coretesting.StubIntegration{
+			N:        "linear",
+			DN:       "Linear",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name:        "linear",
+				DisplayName: "Linear",
+				Operations: []catalog.CatalogOperation{{
+					ID:       "issues",
+					Method:   http.MethodGet,
+					Title:    "Issues",
+					ReadOnly: true,
+				}},
+			},
+			ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				body, err := json.Marshal(map[string]any{
+					"provider":  "linear",
+					"operation": operation,
+				})
+				if err != nil {
+					return nil, err
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+			},
+		},
+		&coretesting.StubIntegration{
+			N:        "github",
+			DN:       "GitHub",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name:        "github",
+				DisplayName: "GitHub",
+				Operations: []catalog.CatalogOperation{{
+					ID:       "issues",
+					Method:   http.MethodGet,
+					Title:    "Issues",
+					ReadOnly: true,
+				}},
+			},
+			ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				body, err := json.Marshal(map[string]any{
+					"provider":  "github",
+					"operation": operation,
+				})
+				if err != nil {
+					return nil, err
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+			},
+		},
+	)
+
+	var provider *callbackAgentProvider
+	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, hostServices []runtimehost.HostService, _ bootstrap.Deps) (coreagent.Provider, error) {
+		started, err := runtimehost.StartHostServices(hostServices)
+		if err != nil {
+			return nil, err
+		}
+		value, err := newCallbackAgentProvider(started)
+		if err != nil {
+			_ = started.Close()
+			return nil, err
+		}
+		provider = value
+		return value, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	perms := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "linear",
+		Operations: []string{"issues"},
+	}, {
+		Plugin:     "github",
+		Operations: []string{"issues"},
+	}, {
+		Plugin: "managed",
+	}})
+	p := &principal.Principal{
+		SubjectID:        "user:user-123",
+		UserID:           "user-123",
+		Kind:             principal.KindUser,
+		Source:           principal.SourceSession,
+		TokenPermissions: perms,
+		Scopes:           principal.PermissionPlugins(perms),
+	}
+	ctx := principal.WithPrincipal(context.Background(), p)
+
+	session, err := result.AgentManager.CreateSession(ctx, p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "managed",
+		Model:        "gpt-test",
+		ClientRef:    "cli-session-configured-narrowing",
+	})
+	if err != nil {
+		t.Fatalf("AgentManager.CreateSession: %v", err)
+	}
+	turn, err := result.AgentManager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
+		SessionID:      session.ID,
+		IdempotencyKey: "configured-narrowing-linear",
+		Model:          "gpt-test",
+		Messages:       []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}},
+	})
+	if err != nil {
+		t.Fatalf("AgentManager.CreateTurn: %v", err)
+	}
+	if turn == nil {
+		t.Fatal("AgentManager.CreateTurn returned nil turn")
+	}
+
+	provider.mu.Lock()
+	listResponses := append([]*proto.ListAgentToolsResponse(nil), provider.listResponses...)
+	toolBodies := append([]string(nil), provider.toolBodies...)
+	provider.mu.Unlock()
+	if len(listResponses) != 1 {
+		t.Fatalf("list response count = %d, want 1", len(listResponses))
+	}
+	tools := listResponses[0].GetTools()
+	if len(tools) != 1 || tools[0].GetRef().GetPlugin() != "linear" || tools[0].GetRef().GetOperation() != "issues" {
+		t.Fatalf("listed tools = %#v, want only linear issues from configured narrowing", tools)
+	}
+	if len(toolBodies) != 1 || !strings.Contains(toolBodies[0], `"provider":"linear"`) {
+		t.Fatalf("tool callback bodies = %#v, want linear execution", toolBodies)
+	}
+}
+
 func TestBootstrapHTTPCallerWildcardCatalogToolRefsAreScopedByAuthorization(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1472,10 +1472,15 @@ type ServerConfig struct {
 	APITokenTTL   string                   `yaml:"apiTokenTtl"`
 	ArtifactsDir  string                   `yaml:"artifactsDir"`
 	Providers     ServerProvidersConfig    `yaml:"providers,omitempty"`
+	Agent         ServerAgentConfig        `yaml:"agent,omitempty"`
 	Dev           DevConfig                `yaml:"dev,omitempty"`
 	Runtime       ServerRuntimeConfig      `yaml:"runtime,omitempty"`
 	Egress        EgressConfig             `yaml:"egress,omitempty"`
 	Admin         AdminConfig              `yaml:"admin,omitempty"`
+}
+
+type ServerAgentConfig struct {
+	DefaultToolNarrowingThreshold *int `yaml:"defaultToolNarrowingThreshold,omitempty"`
 }
 
 type DevConfig struct {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5411,6 +5411,64 @@ server:
 	})
 }
 
+func TestLoadConfig_ServerAgentDefaultToolNarrowingThreshold(t *testing.T) {
+	t.Parallel()
+
+	t.Run("explicit zero is preserved", func(t *testing.T) {
+		t.Parallel()
+		path := mustWriteConfigFile(t, `
+server:
+  agent:
+    defaultToolNarrowingThreshold: 0
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Server.Agent.DefaultToolNarrowingThreshold == nil {
+			t.Fatal("defaultToolNarrowingThreshold = nil, want explicit zero")
+		}
+		if got := *cfg.Server.Agent.DefaultToolNarrowingThreshold; got != 0 {
+			t.Fatalf("defaultToolNarrowingThreshold = %d, want 0", got)
+		}
+	})
+
+	t.Run("positive value is parsed", func(t *testing.T) {
+		t.Parallel()
+		path := mustWriteConfigFile(t, `
+server:
+  agent:
+    defaultToolNarrowingThreshold: 123
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Server.Agent.DefaultToolNarrowingThreshold == nil {
+			t.Fatal("defaultToolNarrowingThreshold = nil, want parsed value")
+		}
+		if got := *cfg.Server.Agent.DefaultToolNarrowingThreshold; got != 123 {
+			t.Fatalf("defaultToolNarrowingThreshold = %d, want 123", got)
+		}
+	})
+
+	t.Run("negative value rejected", func(t *testing.T) {
+		t.Parallel()
+		path := mustWriteConfigFile(t, `
+server:
+  agent:
+    defaultToolNarrowingThreshold: -1
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("expected error for negative defaultToolNarrowingThreshold")
+		}
+		if !strings.Contains(err.Error(), "server.agent.defaultToolNarrowingThreshold") {
+			t.Fatalf("Load error = %v, want server.agent.defaultToolNarrowingThreshold", err)
+		}
+	})
+}
+
 func TestLoadErrors(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -73,6 +73,9 @@ func ValidateCanonicalStructure(cfg *Config) error {
 			return fmt.Errorf("config validation: server.apiTokenTtl: %w", err)
 		}
 	}
+	if threshold := cfg.Server.Agent.DefaultToolNarrowingThreshold; threshold != nil && *threshold < 0 {
+		return fmt.Errorf("config validation: server.agent.defaultToolNarrowingThreshold must be non-negative")
+	}
 	if err := validateEgress(&cfg.Server.Egress); err != nil {
 		return err
 	}

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
@@ -49,6 +50,7 @@ const (
 	agentToolListDefaultPageSize = 100
 	agentToolListMaxPageSize     = 1000
 	agentToolSchemaMaxBytes      = 128 * 1024
+	agentDefaultToolNarrowingK   = 200
 	maxAgentRouteCacheEntries    = 20_000
 	AgentListSummaryDefaultLimit = 100
 	AgentListMaxLimit            = 500
@@ -117,20 +119,26 @@ type Config struct {
 	PluginInvokes     map[string][]invocation.PluginInvocationDependency
 	AgentConnections  map[string][]string
 	RouteStore        RouteStore
+	// DefaultToolNarrowingThreshold controls when implicit default wildcard
+	// catalog grants are narrowed to exactly mentioned providers. Nil uses the
+	// package default; zero means narrow whenever any visible catalog candidate
+	// exists.
+	DefaultToolNarrowingThreshold *int
 }
 
 type Manager struct {
-	providers         *registry.ProviderMap[core.Provider]
-	agent             AgentControl
-	workflowTools     WorkflowSystemTools
-	runGrants         *agentgrant.Manager
-	invoker           invocation.Invoker
-	authorizer        authorization.RuntimeAuthorizer
-	defaultConnection map[string]string
-	catalogConnection map[string]string
-	pluginInvokes     map[string][]invocation.PluginInvocationDependency
-	agentConnections  map[string][]string
-	routeStore        RouteStore
+	providers                     *registry.ProviderMap[core.Provider]
+	agent                         AgentControl
+	workflowTools                 WorkflowSystemTools
+	runGrants                     *agentgrant.Manager
+	invoker                       invocation.Invoker
+	authorizer                    authorization.RuntimeAuthorizer
+	defaultConnection             map[string]string
+	catalogConnection             map[string]string
+	pluginInvokes                 map[string][]invocation.PluginInvocationDependency
+	agentConnections              map[string][]string
+	routeStore                    RouteStore
+	defaultToolNarrowingThreshold int
 	// Route caches are process-local accelerators; the route store is the durable provider index.
 	routeMu       sync.Mutex
 	sessionRoutes agentRouteCache
@@ -150,9 +158,22 @@ func New(cfg Config) *Manager {
 		pluginInvokes:     invocation.ClonePluginInvocationDependencyMap(cfg.PluginInvokes),
 		agentConnections:  cloneStringSliceMap(cfg.AgentConnections),
 		routeStore:        cfg.RouteStore,
-		sessionRoutes:     newAgentRouteCache(),
-		turnRoutes:        newAgentRouteCache(),
+		defaultToolNarrowingThreshold: effectiveAgentToolNarrowingThreshold(
+			cfg.DefaultToolNarrowingThreshold,
+		),
+		sessionRoutes: newAgentRouteCache(),
+		turnRoutes:    newAgentRouteCache(),
 	}
+}
+
+func effectiveAgentToolNarrowingThreshold(configured *int) int {
+	if configured == nil {
+		return agentDefaultToolNarrowingK
+	}
+	if *configured < 0 {
+		return 0
+	}
+	return *configured
 }
 
 func cloneStringSliceMap(src map[string][]string) map[string][]string {
@@ -765,7 +786,7 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	}
 	if toolSource == coreagent.ToolSourceModeUnspecified && len(toolRefs) == 0 && !req.ToolRefsSet && defaultAgentTurnToolSource(ctx, ownedSession.provider) == coreagent.ToolSourceModeMCPCatalog {
 		toolSource = coreagent.ToolSourceModeMCPCatalog
-		toolRefs = []coreagent.ToolRef{{Plugin: agentToolSearchAllPlugin}}
+		toolRefs = m.defaultAgentTurnToolRefs(ctx, p, req)
 	}
 	var tools []coreagent.Tool
 	if toolSource == coreagent.ToolSourceModeMCPCatalog {
@@ -1756,22 +1777,54 @@ func (k agentToolTargetKey) String() string {
 }
 
 func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef, query string, skipUnavailable bool) ([]agentToolSearchCandidate, []agentToolUnavailableCandidate, error) {
+	candidates := make([]agentToolSearchCandidate, 0)
+	unavailable := make([]agentToolUnavailableCandidate, 0)
+	err := m.visitToolSearchCandidates(ctx, p, refs, query, skipUnavailable, true,
+		func(candidate agentToolSearchCandidate) (bool, error) {
+			candidates = append(candidates, candidate)
+			return true, nil
+		},
+		func(candidate agentToolUnavailableCandidate) (bool, error) {
+			unavailable = append(unavailable, candidate)
+			return true, nil
+		},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	ranked, err := rankAgentToolSearchCandidates(query, candidates)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ranked, unavailable, nil
+}
+
+func (m *Manager) visitToolSearchCandidates(
+	ctx context.Context,
+	p *principal.Principal,
+	refs []coreagent.ToolRef,
+	query string,
+	skipUnavailable bool,
+	allowQueryProviderNarrowing bool,
+	visitCandidate func(agentToolSearchCandidate) (bool, error),
+	visitUnavailable func(agentToolUnavailableCandidate) (bool, error),
+) error {
 	scope := newAgentToolSearchScope(refs)
 	providerNames := scope.providerNames()
 	if len(providerNames) == 0 {
 		if !scope.all {
-			return nil, nil, nil
+			return nil
 		}
 		providerNames = m.providers.List()
 	}
 	query = strings.TrimSpace(query)
-	if scope.all {
+	if scope.all && allowQueryProviderNarrowing {
 		if mentioned := mentionedAgentToolSearchProviders(query, providerNames); len(mentioned) > 0 {
 			providerNames = mentioned
 		}
 	}
-	candidates := make([]agentToolSearchCandidate, 0)
-	unavailable := make([]agentToolUnavailableCandidate, 0)
+	seenCandidates := false
+	seenUnavailable := false
 	var firstUnavailableErr error
 	for _, pluginName := range providerNames {
 		pluginName = strings.TrimSpace(pluginName)
@@ -1783,7 +1836,7 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 			if errors.Is(err, core.ErrNotFound) {
 				continue
 			}
-			return nil, nil, fmt.Errorf("%w: looking up provider: %v", invocation.ErrInternal, err)
+			return fmt.Errorf("%w: looking up provider: %v", invocation.ErrInternal, err)
 		}
 		if !m.allowProvider(ctx, p, pluginName) {
 			continue
@@ -1799,11 +1852,20 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 						firstUnavailableErr = err
 					}
 					if principal.AllowsProviderPermission(p, pluginName) {
-						unavailable = append(unavailable, unavailableAgentToolCandidate(searchRef, err))
+						seenUnavailable = true
+						if visitUnavailable != nil {
+							keepGoing, visitErr := visitUnavailable(unavailableAgentToolCandidate(searchRef, err))
+							if visitErr != nil {
+								return visitErr
+							}
+							if !keepGoing {
+								return nil
+							}
+						}
 					}
 					continue
 				}
-				return nil, nil, err
+				return err
 			}
 			for j := range searchCatalogs {
 				searchCatalog := searchCatalogs[j]
@@ -1833,24 +1895,30 @@ func (m *Manager) searchToolCandidates(ctx context.Context, p *principal.Princip
 					}
 					ref.Plugin = pluginName
 					ref.Operation = operation
-					candidates = append(candidates, agentToolSearchCandidate{
+					seenCandidates = true
+					if visitCandidate == nil {
+						continue
+					}
+					keepGoing, visitErr := visitCandidate(agentToolSearchCandidate{
 						ref:             ref,
 						catalog:         cat,
 						operation:       op,
 						skipUnavailable: skipUnavailable && agentToolSearchRefSkipsUnavailable(searchRef),
 					})
+					if visitErr != nil {
+						return visitErr
+					}
+					if !keepGoing {
+						return nil
+					}
 				}
 			}
 		}
 	}
-	if len(candidates) == 0 && len(unavailable) == 0 && !scope.all && firstUnavailableErr != nil {
-		return nil, nil, firstUnavailableErr
+	if !seenCandidates && !seenUnavailable && !scope.all && firstUnavailableErr != nil {
+		return firstUnavailableErr
 	}
-	ranked, err := rankAgentToolSearchCandidates(query, candidates)
-	if err != nil {
-		return nil, nil, err
-	}
-	return ranked, unavailable, nil
+	return nil
 }
 
 func agentToolSearchUnavailable(err error) bool {
@@ -2678,6 +2746,180 @@ func defaultAgentTurnToolSource(ctx context.Context, provider coreagent.Provider
 		return coreagent.ToolSourceModeMCPCatalog
 	}
 	return coreagent.ToolSourceModeUnspecified
+}
+
+func (m *Manager) defaultAgentTurnToolRefs(ctx context.Context, p *principal.Principal, req coreagent.ManagerCreateTurnRequest) []coreagent.ToolRef {
+	broadRefs := []coreagent.ToolRef{{Plugin: agentToolSearchAllPlugin}}
+	if m == nil || m.providers == nil {
+		return broadRefs
+	}
+	if strings.TrimSpace(req.CallerPluginName) != "" {
+		return broadRefs
+	}
+	latestUserText := latestAgentUserMessageText(req.Messages)
+	if strings.TrimSpace(latestUserText) == "" {
+		return broadRefs
+	}
+	mentionedProviders := m.exactMentionedAgentToolProviders(ctx, p, latestUserText)
+	if len(mentionedProviders) == 0 {
+		return broadRefs
+	}
+	largeCatalog, err := m.agentToolCandidateCountExceeds(ctx, p, broadRefs, m.defaultToolNarrowingThreshold)
+	if err != nil || !largeCatalog {
+		return broadRefs
+	}
+
+	narrowedRefs := make([]coreagent.ToolRef, 0, len(mentionedProviders))
+	for _, pluginName := range mentionedProviders {
+		hasCandidate, err := m.agentToolVisibleCandidateCountExceeds(ctx, p, []coreagent.ToolRef{{Plugin: pluginName}}, 0)
+		if err != nil {
+			return broadRefs
+		}
+		if hasCandidate {
+			narrowedRefs = append(narrowedRefs, coreagent.ToolRef{Plugin: pluginName})
+		}
+	}
+	if len(narrowedRefs) == 0 {
+		return broadRefs
+	}
+	return narrowedRefs
+}
+
+func latestAgentUserMessageText(messages []coreagent.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if !strings.EqualFold(strings.TrimSpace(msg.Role), "user") {
+			continue
+		}
+		parts := make([]string, 0, 1+len(msg.Parts))
+		if text := strings.TrimSpace(msg.Text); text != "" {
+			parts = append(parts, text)
+		}
+		for j := range msg.Parts {
+			part := msg.Parts[j]
+			if part.Type != coreagent.MessagePartTypeText {
+				continue
+			}
+			if text := strings.TrimSpace(part.Text); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, " ")
+	}
+	return ""
+}
+
+func (m *Manager) exactMentionedAgentToolProviders(ctx context.Context, p *principal.Principal, text string) []string {
+	normalizedText := normalizeAgentToolMentionText(text)
+	if normalizedText == "" || m == nil || m.providers == nil {
+		return nil
+	}
+	out := make([]string, 0)
+	for _, pluginName := range m.providers.List() {
+		pluginName = strings.TrimSpace(pluginName)
+		if pluginName == "" {
+			continue
+		}
+		prov, err := m.providers.Get(pluginName)
+		if err != nil {
+			continue
+		}
+		if !m.allowsAgentProvider(ctx, p, pluginName) {
+			continue
+		}
+		aliases := []string{pluginName}
+		if displayName := strings.TrimSpace(prov.DisplayName()); displayName != "" {
+			aliases = append(aliases, displayName)
+		}
+		for _, alias := range aliases {
+			if exactAgentToolMention(normalizedText, alias) {
+				out = append(out, pluginName)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func exactAgentToolMention(normalizedText, alias string) bool {
+	normalizedAlias := normalizeAgentToolMentionText(alias)
+	if normalizedAlias == "" {
+		return false
+	}
+	return strings.Contains(" "+normalizedText+" ", " "+normalizedAlias+" ")
+}
+
+func normalizeAgentToolMentionText(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	var b strings.Builder
+	lastSeparator := true
+	for _, r := range value {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(unicode.ToLower(r))
+			lastSeparator = false
+		default:
+			if !lastSeparator {
+				b.WriteByte(' ')
+				lastSeparator = true
+			}
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+func (m *Manager) agentToolCandidateCountExceeds(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef, threshold int) (bool, error) {
+	if threshold < 0 {
+		threshold = 0
+	}
+	count := 0
+	exceeded := false
+	visit := func() (bool, error) {
+		count++
+		if count > threshold {
+			exceeded = true
+			return false, nil
+		}
+		return true, nil
+	}
+	err := m.visitToolSearchCandidates(ctx, p, refs, "", true, false,
+		func(agentToolSearchCandidate) (bool, error) {
+			return visit()
+		},
+		func(agentToolUnavailableCandidate) (bool, error) {
+			return visit()
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+	return exceeded, nil
+}
+
+func (m *Manager) agentToolVisibleCandidateCountExceeds(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef, threshold int) (bool, error) {
+	if threshold < 0 {
+		threshold = 0
+	}
+	count := 0
+	exceeded := false
+	err := m.visitToolSearchCandidates(ctx, p, refs, "", true, false,
+		func(agentToolSearchCandidate) (bool, error) {
+			count++
+			if count > threshold {
+				exceeded = true
+				return false, nil
+			}
+			return true, nil
+		},
+		nil,
+	)
+	if err != nil {
+		return false, err
+	}
+	return exceeded, nil
 }
 
 func agentRunPermissions(ctx context.Context, p *principal.Principal, callerPluginName string, refs []coreagent.ToolRef) []core.AccessPermission {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -29,6 +29,38 @@ func (p *catalogCountingProvider) Catalog() *catalog.Catalog {
 	return p.CatalogVal
 }
 
+type unavailableAgentCatalogTestProvider struct {
+	*catalogCountingProvider
+	err error
+}
+
+func (p *unavailableAgentCatalogTestProvider) CatalogForRequest(context.Context, string) (*catalog.Catalog, error) {
+	return nil, p.err
+}
+
+func agentCatalogTestProvider(name, displayName string, operations ...string) *catalogCountingProvider {
+	catalogOperations := make([]catalog.CatalogOperation, 0, len(operations))
+	for _, operation := range operations {
+		catalogOperations = append(catalogOperations, catalog.CatalogOperation{
+			ID:       operation,
+			Title:    operation,
+			ReadOnly: true,
+		})
+	}
+	return &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        name,
+			DN:       displayName,
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name:        name,
+				DisplayName: displayName,
+				Operations:  catalogOperations,
+			},
+		},
+	}
+}
+
 func newAgentManagerTestRunGrants(t testing.TB) *agentgrant.Manager {
 	t.Helper()
 	grants, err := agentgrant.NewManager([]byte("0123456789abcdef0123456789abcdef"))
@@ -891,6 +923,436 @@ func TestManagerCreateTurnDefaultsToCatalogToolsForCatalogOnlyProvider(t *testin
 	}
 	if got := grant.ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
 		t.Fatalf("grant tool refs = %#v, want global broad catalog ref", got)
+	}
+}
+
+func TestManagerCreateTurnNarrowsImplicitDefaultCatalogRefsForLargeMentionedProvider(t *testing.T) {
+	t.Parallel()
+
+	threshold := 1
+	linear := agentCatalogTestProvider("linear", "Linear", "issues")
+	github := agentCatalogTestProvider("github", "GitHub", "issues", "pull_requests")
+	alpha := newRouteCountingAgentProvider("alpha")
+	grants := newAgentManagerTestRunGrants(t)
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, linear, github),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		RunGrants:                     grants,
+		DefaultToolNarrowingThreshold: &threshold,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if len(alpha.createTurnReqs) != 1 {
+		t.Fatalf("CreateTurn requests = %d, want 1", len(alpha.createTurnReqs))
+	}
+	req := alpha.createTurnReqs[0]
+	if req.ToolSource != coreagent.ToolSourceModeMCPCatalog {
+		t.Fatalf("CreateTurn tool source = %q, want mcp_catalog", req.ToolSource)
+	}
+	if got := req.ToolRefs; len(got) != 1 || got[0].Plugin != "linear" || got[0].Operation != "" {
+		t.Fatalf("CreateTurn tool refs = %#v, want linear provider ref", got)
+	}
+	grant, err := grants.Resolve(req.RunGrant)
+	if err != nil {
+		t.Fatalf("Resolve run grant: %v", err)
+	}
+	if got := grant.ToolRefs; len(got) != 1 || got[0].Plugin != "linear" || got[0].Operation != "" {
+		t.Fatalf("grant tool refs = %#v, want linear provider ref", got)
+	}
+
+	listed, err := manager.ListTools(context.Background(), p, coreagent.ListToolsRequest{
+		ToolSource: grant.ToolSource,
+		ToolRefs:   grant.ToolRefs,
+	})
+	if err != nil {
+		t.Fatalf("ListTools narrowed grant: %v", err)
+	}
+	if len(listed.Tools) != 1 || listed.Tools[0].Target.Plugin != "linear" || listed.Tools[0].Target.Operation != "issues" {
+		t.Fatalf("ListTools narrowed grant = %#v, want only linear issues", listed.Tools)
+	}
+}
+
+func TestManagerCreateTurnKeepsImplicitWildcardForSmallCatalogs(t *testing.T) {
+	t.Parallel()
+
+	threshold := 10
+	linear := agentCatalogTestProvider("linear", "Linear", "issues")
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, linear),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		DefaultToolNarrowingThreshold: &threshold,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if got := alpha.createTurnReqs[0].ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
+		t.Fatalf("CreateTurn tool refs = %#v, want broad wildcard for small catalog", got)
+	}
+}
+
+func TestManagerCreateTurnDoesNotEnumerateCatalogsWhenNoProviderMentionMatches(t *testing.T) {
+	t.Parallel()
+
+	threshold := 0
+	linear := agentCatalogTestProvider("linear", "Linear", "issues")
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, linear),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		DefaultToolNarrowingThreshold: &threshold,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "show me my tickets"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if linear.catalogCalls != 0 {
+		t.Fatalf("linear catalog calls = %d, want no enumeration without a provider mention", linear.catalogCalls)
+	}
+	if got := alpha.createTurnReqs[0].ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
+		t.Fatalf("CreateTurn tool refs = %#v, want broad wildcard without provider mention", got)
+	}
+}
+
+func TestManagerCreateTurnDoesNotStemProviderMentionsForImplicitNarrowing(t *testing.T) {
+	t.Parallel()
+
+	threshold := 0
+	docs := agentCatalogTestProvider("docs", "Docs", "search")
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, docs),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		DefaultToolNarrowingThreshold: &threshold,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "open a doc"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if docs.catalogCalls != 0 {
+		t.Fatalf("docs catalog calls = %d, want no enumeration for non-exact provider mention", docs.catalogCalls)
+	}
+	if got := alpha.createTurnReqs[0].ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
+		t.Fatalf("CreateTurn tool refs = %#v, want broad wildcard for non-exact provider mention", got)
+	}
+}
+
+func TestManagerCreateTurnKeepsImplicitWildcardForCallerPluginDefaults(t *testing.T) {
+	t.Parallel()
+
+	threshold := 0
+	linear := agentCatalogTestProvider("linear", "Linear", "issues")
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, linear),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		DefaultToolNarrowingThreshold: &threshold,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		CallerPluginName: "slack",
+		SessionID:        session.ID,
+		Model:            "test-model",
+		Messages:         []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if got := alpha.createTurnReqs[0].ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
+		t.Fatalf("CreateTurn tool refs = %#v, want broad wildcard for caller plugin default", got)
+	}
+	if linear.catalogCalls != 0 {
+		t.Fatalf("linear catalog calls = %d, want caller plugin default to skip narrowing probes", linear.catalogCalls)
+	}
+}
+
+func TestManagerCreateTurnNarrowsFromLatestUserTextOnly(t *testing.T) {
+	t.Parallel()
+
+	threshold := 0
+	linear := agentCatalogTestProvider("linear", "Linear", "issues")
+	github := agentCatalogTestProvider("github", "GitHub", "issues")
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, linear, github),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		DefaultToolNarrowingThreshold: &threshold,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages: []coreagent.Message{
+			{Role: "user", Text: "linear was mentioned earlier"},
+			{Role: "assistant", Text: "linear is still in assistant text"},
+			{
+				Role: "user",
+				Parts: []coreagent.MessagePart{
+					{Type: coreagent.MessagePartTypeJSON, Text: "linear should be ignored"},
+					{Type: coreagent.MessagePartTypeToolResult, ToolResult: &coreagent.ToolResultPart{Content: "linear should be ignored"}},
+					{Type: coreagent.MessagePartTypeText, Text: "show me github issues"},
+				},
+				Metadata: map[string]any{"provider": "linear"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if got := alpha.createTurnReqs[0].ToolRefs; len(got) != 1 || got[0].Plugin != "github" || got[0].Operation != "" {
+		t.Fatalf("CreateTurn tool refs = %#v, want github from latest user text part only", got)
+	}
+}
+
+func TestManagerCreateTurnKeepsImplicitWildcardWhenMentionedProviderCannotBeProbed(t *testing.T) {
+	t.Parallel()
+
+	threshold := 0
+	linear := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "linear",
+			DN:       "Linear",
+			ConnMode: core.ConnectionModeNone,
+		},
+	}
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, linear),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		DefaultToolNarrowingThreshold: &threshold,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if got := alpha.createTurnReqs[0].ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
+		t.Fatalf("CreateTurn tool refs = %#v, want fail-open broad wildcard", got)
+	}
+}
+
+func TestManagerCreateTurnKeepsImplicitWildcardWhenMentionedProviderUnavailable(t *testing.T) {
+	t.Parallel()
+
+	threshold := 0
+	linear := &unavailableAgentCatalogTestProvider{
+		catalogCountingProvider: &catalogCountingProvider{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "linear",
+				DN:       "Linear",
+				ConnMode: core.ConnectionModeUser,
+			},
+		},
+		err: invocation.ErrNoCredential,
+	}
+	github := agentCatalogTestProvider("github", "GitHub", "issues")
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, linear, github),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		DefaultToolNarrowingThreshold: &threshold,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "show me my linear tickets"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if got := alpha.createTurnReqs[0].ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
+		t.Fatalf("CreateTurn tool refs = %#v, want broad wildcard when mentioned provider is unavailable", got)
+	}
+}
+
+func TestManagerCreateTurnKeepsImplicitWildcardWhenMentionedProviderHasNoVisibleCandidates(t *testing.T) {
+	t.Parallel()
+
+	threshold := 0
+	hidden := false
+	linear := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "linear",
+			DN:       "Linear",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:      "admin",
+				Title:   "Admin",
+				Visible: &hidden,
+			}}},
+		},
+	}
+	alpha := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, linear),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		DefaultToolNarrowingThreshold: &threshold,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "show me linear"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if got := alpha.createTurnReqs[0].ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
+		t.Fatalf("CreateTurn tool refs = %#v, want broad wildcard when provider has no visible candidates", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a simple internal default-tool narrowing path for agent turns that would otherwise receive a broad MCP catalog wildcard. When the visible catalog is larger than the configured threshold and the latest user message exactly names a provider, gestaltd grants that provider instead of `*`; otherwise it preserves existing wildcard behavior.

## Interface Changes
- New/changed interface: `server.agent.defaultToolNarrowingThreshold` in gestaltd YAML config and Helm values.
- Example usage:

```yaml
server:
  agent:
    defaultToolNarrowingThreshold: 200
```

Set `0` to narrow whenever any visible matching provider tool exists. Omit the field to use the server default.

## Functional/Integration Tests
- Tests added or augmented:
  - Config parsing and validation for `server.agent.defaultToolNarrowingThreshold`, including explicit `0`.
  - Agent manager contract coverage for large/small catalogs, exact provider mention matching, no-match no-enumeration, caller-plugin wildcard preservation, latest user text only, fail-open probe behavior, unavailable-mentioned-provider behavior, and hidden-only provider handling.
  - Bootstrap contract test proving the YAML-backed config reaches the agent host path and narrows the listed tools.
- Contract boundary covered: gestaltd config -> bootstrap -> agent manager `CreateTurn` -> run grant/tool listing.
- Commands run:
  - `go test ./internal/config ./services/agents/agentmanager` from `gestaltd/`
  - `go test ./internal/bootstrap -run TestBootstrapAgentDefaultToolNarrowingThresholdConfigNarrowsImplicitCatalogGrant` from `gestaltd/`
  - `git diff --check`

Note: full `go test ./internal/bootstrap` is currently failing locally in unrelated `TestClientCredentialsTokenSourceFetchTimeoutReleasesFlight` with a token fetch timeout; the new targeted bootstrap contract test passes.