### PR TITLE
Use default UI alpha26

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -39,7 +39,7 @@ const (
 	DefaultExternalCredentialsProvider = DefaultProviderRepo + "/external_credentials/default"
 	DefaultExternalCredentialsVersion  = "0.0.1-alpha.5"
 	DefaultUIProvider                  = DefaultProviderRepo + "/ui/default"
-	DefaultUIVersion                   = "0.0.1-alpha.18"
+	DefaultUIVersion                   = "0.0.1-alpha.26"
 	DefaultProviderInstance            = "default"
 )
 


### PR DESCRIPTION
## Summary\n- bump gestaltd's generated managed default UI provider from ui/default 0.0.1-alpha.18 to 0.0.1-alpha.26\n- this makes new default configs serve the agent session console released in ui/default alpha26\n\n## Validation\n- GOWORK=off go test ./internal/config ./internal/operator