### PR TITLE
Add per-tool run-as delegation for agent invokes

### DIFF
--- a/gestaltd/core/agent/agent.go
+++ b/gestaltd/core/agent/agent.go
@@ -105,6 +105,7 @@ type ToolTarget struct {
 	Instance       string
 	CredentialMode core.ConnectionMode
 	Unavailable    *UnavailableToolTarget `json:",omitempty"`
+	RunAs          *core.RunAsSubject
 }
 
 type UnavailableToolTarget struct {
@@ -136,6 +137,7 @@ type ToolRef struct {
 	Connection     string
 	Instance       string
 	CredentialMode core.ConnectionMode
+	RunAs          *core.RunAsSubject
 	Title          string
 	Description    string
 }
@@ -178,8 +180,8 @@ func ValidateMCPCatalogToolRefs(refs []ToolRef, fieldName string) error {
 			if operation == "*" {
 				return fmt.Errorf("mcp catalog %s[%d].operation wildcard is not supported", fieldName, i)
 			}
-			if connection != "" || instance != "" || ref.CredentialMode != "" || strings.TrimSpace(ref.Title) != "" || strings.TrimSpace(ref.Description) != "" {
-				return fmt.Errorf("mcp catalog %s[%d] system refs cannot include connection, instance, credential mode, title, or description", fieldName, i)
+			if connection != "" || instance != "" || ref.CredentialMode != "" || ref.RunAs != nil || strings.TrimSpace(ref.Title) != "" || strings.TrimSpace(ref.Description) != "" {
+				return fmt.Errorf("mcp catalog %s[%d] system refs cannot include connection, instance, credential mode, runAs, title, or description", fieldName, i)
 			}
 			continue
 		}
@@ -189,8 +191,11 @@ func ValidateMCPCatalogToolRefs(refs []ToolRef, fieldName string) error {
 		if operation == "*" || connection == "*" || instance == "*" {
 			return fmt.Errorf("mcp catalog %s[%d] wildcard fields are not supported", fieldName, i)
 		}
-		if pluginName == "*" && (operation != "" || connection != "" || instance != "" || ref.CredentialMode != "" || strings.TrimSpace(ref.Title) != "" || strings.TrimSpace(ref.Description) != "") {
-			return fmt.Errorf("mcp catalog %s[%d] global ref cannot include operation, connection, instance, credential mode, title, or description", fieldName, i)
+		if pluginName == "*" && (operation != "" || connection != "" || instance != "" || ref.CredentialMode != "" || ref.RunAs != nil || strings.TrimSpace(ref.Title) != "" || strings.TrimSpace(ref.Description) != "") {
+			return fmt.Errorf("mcp catalog %s[%d] global ref cannot include operation, connection, instance, credential mode, runAs, title, or description", fieldName, i)
+		}
+		if ref.RunAs != nil && operation == "" {
+			return fmt.Errorf("mcp catalog %s[%d].runAs requires an exact operation", fieldName, i)
 		}
 	}
 	return nil

--- a/gestaltd/core/audit.go
+++ b/gestaltd/core/audit.go
@@ -16,10 +16,10 @@ type AuditEntry struct {
 	AgentSubjectKind             string
 	AgentDisplayName             string
 	AgentAuthSource              string
-	RunAsSubjectID                string
-	RunAsSubjectKind              string
-	RunAsDisplayName              string
-	RunAsAuthSource               string
+	RunAsSubjectID               string
+	RunAsSubjectKind             string
+	RunAsDisplayName             string
+	RunAsAuthSource              string
 	AccessPolicy                 string
 	AccessRole                   string
 	AuthorizationDecision        string

--- a/gestaltd/core/audit.go
+++ b/gestaltd/core/audit.go
@@ -12,6 +12,14 @@ type AuditEntry struct {
 	AuthSource                   string
 	SubjectID                    string
 	SubjectKind                  string
+	AgentSubjectID               string
+	AgentSubjectKind             string
+	AgentDisplayName             string
+	AgentAuthSource              string
+	RunAsSubjectID                string
+	RunAsSubjectKind              string
+	RunAsDisplayName              string
+	RunAsAuthSource               string
 	AccessPolicy                 string
 	AccessRole                   string
 	AuthorizationDecision        string

--- a/gestaltd/core/subjects.go
+++ b/gestaltd/core/subjects.go
@@ -45,9 +45,9 @@ func RunAsSubjectsEqual(left, right *RunAsSubject) bool {
 	if left == nil || right == nil {
 		return left == nil && right == nil
 	}
-	return strings.TrimSpace(left.SubjectID) == strings.TrimSpace(right.SubjectID) &&
-		strings.TrimSpace(left.SubjectKind) == strings.TrimSpace(right.SubjectKind) &&
-		strings.TrimSpace(left.CredentialSubjectID) == strings.TrimSpace(right.CredentialSubjectID) &&
-		strings.TrimSpace(left.DisplayName) == strings.TrimSpace(right.DisplayName) &&
-		strings.TrimSpace(left.AuthSource) == strings.TrimSpace(right.AuthSource)
+	return left.SubjectID == right.SubjectID &&
+		left.SubjectKind == right.SubjectKind &&
+		left.CredentialSubjectID == right.CredentialSubjectID &&
+		left.DisplayName == right.DisplayName &&
+		left.AuthSource == right.AuthSource
 }

--- a/gestaltd/core/subjects.go
+++ b/gestaltd/core/subjects.go
@@ -2,6 +2,11 @@ package core
 
 import "strings"
 
+// TODO(hughhan1): Run-as delegation currently treats SubjectID as an opaque
+// provider-owned string and infers kind from the first colon when omitted. This
+// is intentionally integration-agnostic, but still brittle for wider use. Add a
+// structured service-account/subject reference primitive before adding more
+// delegation patterns that depend on encoded subject-id grammars.
 type RunAsSubject struct {
 	SubjectID           string
 	SubjectKind         string

--- a/gestaltd/core/subjects.go
+++ b/gestaltd/core/subjects.go
@@ -38,3 +38,16 @@ func NormalizeRunAsSubject(subject *RunAsSubject) *RunAsSubject {
 	}
 	return out
 }
+
+func RunAsSubjectsEqual(left, right *RunAsSubject) bool {
+	left = NormalizeRunAsSubject(left)
+	right = NormalizeRunAsSubject(right)
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return strings.TrimSpace(left.SubjectID) == strings.TrimSpace(right.SubjectID) &&
+		strings.TrimSpace(left.SubjectKind) == strings.TrimSpace(right.SubjectKind) &&
+		strings.TrimSpace(left.CredentialSubjectID) == strings.TrimSpace(right.CredentialSubjectID) &&
+		strings.TrimSpace(left.DisplayName) == strings.TrimSpace(right.DisplayName) &&
+		strings.TrimSpace(left.AuthSource) == strings.TrimSpace(right.AuthSource)
+}

--- a/gestaltd/core/subjects.go
+++ b/gestaltd/core/subjects.go
@@ -2,9 +2,39 @@ package core
 
 import "strings"
 
+type RunAsSubject struct {
+	SubjectID           string
+	SubjectKind         string
+	CredentialSubjectID string
+	DisplayName         string
+	AuthSource          string
+}
+
 func ParseSubjectID(subjectID string) (kind, id string, ok bool) {
 	kind, id, ok = strings.Cut(strings.TrimSpace(subjectID), ":")
 	kind = strings.TrimSpace(kind)
 	id = strings.TrimSpace(id)
 	return kind, id, ok && kind != "" && id != ""
+}
+
+func NormalizeRunAsSubject(subject *RunAsSubject) *RunAsSubject {
+	if subject == nil {
+		return nil
+	}
+	out := &RunAsSubject{
+		SubjectID:           strings.TrimSpace(subject.SubjectID),
+		SubjectKind:         strings.TrimSpace(subject.SubjectKind),
+		CredentialSubjectID: strings.TrimSpace(subject.CredentialSubjectID),
+		DisplayName:         strings.TrimSpace(subject.DisplayName),
+		AuthSource:          strings.TrimSpace(subject.AuthSource),
+	}
+	if out.SubjectKind == "" {
+		if kind, _, ok := ParseSubjectID(out.SubjectID); ok {
+			out.SubjectKind = kind
+		}
+	}
+	if out.CredentialSubjectID == "" {
+		out.CredentialSubjectID = out.SubjectID
+	}
+	return out
 }

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -583,6 +583,9 @@ func agentRunAsPrincipal(base *principal.Principal, runAs *core.RunAsSubject) *p
 	if runAs == nil {
 		return base
 	}
+	if base == nil {
+		base = &principal.Principal{}
+	}
 	value := &principal.Principal{
 		SubjectID:           strings.TrimSpace(runAs.SubjectID),
 		CredentialSubjectID: strings.TrimSpace(runAs.CredentialSubjectID),
@@ -903,7 +906,7 @@ func agentToolMatchesRefs(target coreagent.ToolTarget, refs []coreagent.ToolRef)
 		if ref.CredentialMode != "" && ref.CredentialMode != target.CredentialMode {
 			continue
 		}
-		if ref.RunAs != nil && !agentRunAsSubjectsEqual(ref.RunAs, target.RunAs) {
+		if ref.RunAs != nil && !core.RunAsSubjectsEqual(ref.RunAs, target.RunAs) {
 			continue
 		}
 		return true
@@ -963,7 +966,7 @@ func agentToolHiddenExplicitlyGranted(target coreagent.ToolTarget, rawToolID str
 		if ref.CredentialMode != "" && ref.CredentialMode != target.CredentialMode {
 			continue
 		}
-		if ref.RunAs != nil && !agentRunAsSubjectsEqual(ref.RunAs, target.RunAs) {
+		if ref.RunAs != nil && !core.RunAsSubjectsEqual(ref.RunAs, target.RunAs) {
 			continue
 		}
 		return true
@@ -1021,7 +1024,7 @@ func agentToolRunAsExplicitlyGranted(target coreagent.ToolTarget, refs []coreage
 		if strings.TrimSpace(ref.Operation) != strings.TrimSpace(target.Operation) {
 			continue
 		}
-		if !agentRunAsSubjectsEqual(ref.RunAs, target.RunAs) {
+		if !core.RunAsSubjectsEqual(ref.RunAs, target.RunAs) {
 			continue
 		}
 		if connection := strings.TrimSpace(ref.Connection); connection != "" && config.ResolveConnectionAlias(connection) != config.ResolveConnectionAlias(strings.TrimSpace(target.Connection)) {
@@ -1042,18 +1045,5 @@ func agentToolTargetsEqual(left, right coreagent.ToolTarget) bool {
 		config.ResolveConnectionAlias(strings.TrimSpace(left.Connection)) == config.ResolveConnectionAlias(strings.TrimSpace(right.Connection)) &&
 		strings.TrimSpace(left.Instance) == strings.TrimSpace(right.Instance) &&
 		left.CredentialMode == right.CredentialMode &&
-		agentRunAsSubjectsEqual(left.RunAs, right.RunAs)
-}
-
-func agentRunAsSubjectsEqual(left, right *core.RunAsSubject) bool {
-	left = core.NormalizeRunAsSubject(left)
-	right = core.NormalizeRunAsSubject(right)
-	if left == nil || right == nil {
-		return left == nil && right == nil
-	}
-	return strings.TrimSpace(left.SubjectID) == strings.TrimSpace(right.SubjectID) &&
-		strings.TrimSpace(left.SubjectKind) == strings.TrimSpace(right.SubjectKind) &&
-		strings.TrimSpace(left.CredentialSubjectID) == strings.TrimSpace(right.CredentialSubjectID) &&
-		strings.TrimSpace(left.DisplayName) == strings.TrimSpace(right.DisplayName) &&
-		strings.TrimSpace(left.AuthSource) == strings.TrimSpace(right.AuthSource)
+		core.RunAsSubjectsEqual(left.RunAs, right.RunAs)
 }

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -592,8 +592,8 @@ func agentRunAsPrincipal(base *principal.Principal, runAs *core.RunAsSubject) *p
 		DisplayName:         strings.TrimSpace(runAs.DisplayName),
 		Kind:                principal.Kind(strings.TrimSpace(runAs.SubjectKind)),
 		Scopes:              append([]string(nil), base.Scopes...),
-		TokenPermissions:    clonePermissionSet(base.TokenPermissions),
-		ActionPermissions:   cloneActionPermissionSet(base.ActionPermissions),
+		TokenPermissions:    principal.ClonePermissionSet(base.TokenPermissions),
+		ActionPermissions:   principal.CloneActionPermissionSet(base.ActionPermissions),
 		Identity:            base.Identity,
 	}
 	principal.SetAuthSource(value, runAs.AuthSource)
@@ -615,36 +615,6 @@ func agentAuditSubjectFromPrincipal(p *principal.Principal) *core.RunAsSubject {
 		DisplayName:         strings.TrimSpace(p.DisplayName),
 		AuthSource:          p.AuthSource(),
 	})
-}
-
-func clonePermissionSet(in principal.PermissionSet) principal.PermissionSet {
-	if in == nil {
-		return nil
-	}
-	out := make(principal.PermissionSet, len(in))
-	for plugin, operations := range in {
-		cloned := make(map[string]struct{}, len(operations))
-		for operation := range operations {
-			cloned[operation] = struct{}{}
-		}
-		out[plugin] = cloned
-	}
-	return out
-}
-
-func cloneActionPermissionSet(in principal.ActionPermissionSet) principal.ActionPermissionSet {
-	if in == nil {
-		return nil
-	}
-	out := make(principal.ActionPermissionSet, len(in))
-	for resource, actions := range in {
-		cloned := make(map[string]struct{}, len(actions))
-		for action := range actions {
-			cloned[action] = struct{}{}
-		}
-		out[resource] = cloned
-	}
-	return out
 }
 
 func validateAgentToolTargetForGrant(grant agentgrant.Grant, principalValue *principal.Principal, target coreagent.ToolTarget, rawToolID string) error {

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -292,6 +292,7 @@ func (r *agentRuntime) ExecuteTool(ctx context.Context, req coreagent.ExecuteToo
 		Connection:     toolTarget.Connection,
 		Instance:       toolTarget.Instance,
 		CredentialMode: toolTarget.CredentialMode,
+		RunAs:          core.NormalizeRunAsSubject(toolTarget.RunAs),
 	})
 	if err != nil {
 		return nil, err
@@ -326,11 +327,16 @@ func (r *agentRuntime) ExecuteTool(ctx context.Context, req coreagent.ExecuteToo
 	if mode := resolvedTool.Target.CredentialMode; mode != "" {
 		ctx = invocation.WithCredentialModeOverride(ctx, mode)
 	}
+	invokePrincipal := principalValue
+	if runAs := core.NormalizeRunAsSubject(resolvedTool.Target.RunAs); runAs != nil {
+		invokePrincipal = agentRunAsPrincipal(principalValue, runAs)
+		ctx = invocation.WithRunAsAudit(ctx, agentAuditSubjectFromPrincipal(principalValue), runAs)
+	}
 	if idempotencyKey != "" {
 		ctx = invocation.WithIdempotencyKey(ctx, idempotencyKey)
 	}
 	params := maps.Clone(req.Arguments)
-	result, err := invoker.Invoke(ctx, principalValue, resolvedTool.Target.Plugin, strings.TrimSpace(resolvedTool.Target.Instance), resolvedTool.Target.Operation, params)
+	result, err := invoker.Invoke(ctx, invokePrincipal, resolvedTool.Target.Plugin, strings.TrimSpace(resolvedTool.Target.Instance), resolvedTool.Target.Operation, params)
 	if err != nil {
 		return nil, err
 	}
@@ -571,6 +577,73 @@ func agentRunGrantPrincipal(grant agentgrant.Grant) *principal.Principal {
 	return principal.Canonicalize(value)
 }
 
+func agentRunAsPrincipal(base *principal.Principal, runAs *core.RunAsSubject) *principal.Principal {
+	base = principal.Canonicalized(base)
+	runAs = core.NormalizeRunAsSubject(runAs)
+	if runAs == nil {
+		return base
+	}
+	value := &principal.Principal{
+		SubjectID:           strings.TrimSpace(runAs.SubjectID),
+		CredentialSubjectID: strings.TrimSpace(runAs.CredentialSubjectID),
+		DisplayName:         strings.TrimSpace(runAs.DisplayName),
+		Kind:                principal.Kind(strings.TrimSpace(runAs.SubjectKind)),
+		Scopes:              append([]string(nil), base.Scopes...),
+		TokenPermissions:    clonePermissionSet(base.TokenPermissions),
+		ActionPermissions:   cloneActionPermissionSet(base.ActionPermissions),
+		Identity:            base.Identity,
+	}
+	principal.SetAuthSource(value, runAs.AuthSource)
+	if value.CredentialSubjectID == "" && principal.IsSystemSubjectID(value.SubjectID) {
+		value.CredentialSubjectID = value.SubjectID
+	}
+	return principal.Canonicalize(value)
+}
+
+func agentAuditSubjectFromPrincipal(p *principal.Principal) *core.RunAsSubject {
+	p = principal.Canonicalized(p)
+	if p == nil {
+		return nil
+	}
+	return core.NormalizeRunAsSubject(&core.RunAsSubject{
+		SubjectID:           strings.TrimSpace(p.SubjectID),
+		SubjectKind:         string(p.Kind),
+		CredentialSubjectID: strings.TrimSpace(principal.EffectiveCredentialSubjectID(p)),
+		DisplayName:         strings.TrimSpace(p.DisplayName),
+		AuthSource:          p.AuthSource(),
+	})
+}
+
+func clonePermissionSet(in principal.PermissionSet) principal.PermissionSet {
+	if in == nil {
+		return nil
+	}
+	out := make(principal.PermissionSet, len(in))
+	for plugin, operations := range in {
+		cloned := make(map[string]struct{}, len(operations))
+		for operation := range operations {
+			cloned[operation] = struct{}{}
+		}
+		out[plugin] = cloned
+	}
+	return out
+}
+
+func cloneActionPermissionSet(in principal.ActionPermissionSet) principal.ActionPermissionSet {
+	if in == nil {
+		return nil
+	}
+	out := make(principal.ActionPermissionSet, len(in))
+	for resource, actions := range in {
+		cloned := make(map[string]struct{}, len(actions))
+		for action := range actions {
+			cloned[action] = struct{}{}
+		}
+		out[resource] = cloned
+	}
+	return out
+}
+
 func validateAgentToolTargetForGrant(grant agentgrant.Grant, principalValue *principal.Principal, target coreagent.ToolTarget, rawToolID string) error {
 	if principalValue == nil {
 		return fmt.Errorf("%w: agent execution principal is required", invocation.ErrInternal)
@@ -607,6 +680,9 @@ func validateAgentToolTargetForGrant(grant agentgrant.Grant, principalValue *pri
 	}
 	if target.CredentialMode != "" && !agentToolCredentialModeExplicitlyGranted(target, grant.ToolRefs, grant.Tools) {
 		return fmt.Errorf("%w: agent tool %q credential mode was not granted to this turn", invocation.ErrAuthorizationDenied, rawToolID)
+	}
+	if target.RunAs != nil && !agentToolRunAsExplicitlyGranted(target, grant.ToolRefs, grant.Tools) {
+		return fmt.Errorf("%w: agent tool %q runAs delegation was not granted to this turn", invocation.ErrAuthorizationDenied, rawToolID)
 	}
 	return nil
 }
@@ -772,6 +848,9 @@ func validateAgentListedTools(p *principal.Principal, refs []coreagent.ToolRef, 
 		if tools[i].Hidden && !agentToolHiddenExplicitlyGranted(target, tools[i].ToolID, refs, nil) {
 			return fmt.Errorf("%w: listed hidden agent tool %q was not explicitly granted", invocation.ErrAuthorizationDenied, tools[i].ToolID)
 		}
+		if target.RunAs != nil && !agentToolRunAsExplicitlyGranted(target, refs, nil) {
+			return fmt.Errorf("%w: listed agent tool %q runAs delegation was not explicitly granted", invocation.ErrAuthorizationDenied, tools[i].ToolID)
+		}
 	}
 	return nil
 }
@@ -822,6 +901,9 @@ func agentToolMatchesRefs(target coreagent.ToolTarget, refs []coreagent.ToolRef)
 			continue
 		}
 		if ref.CredentialMode != "" && ref.CredentialMode != target.CredentialMode {
+			continue
+		}
+		if ref.RunAs != nil && !agentRunAsSubjectsEqual(ref.RunAs, target.RunAs) {
 			continue
 		}
 		return true
@@ -881,6 +963,9 @@ func agentToolHiddenExplicitlyGranted(target coreagent.ToolTarget, rawToolID str
 		if ref.CredentialMode != "" && ref.CredentialMode != target.CredentialMode {
 			continue
 		}
+		if ref.RunAs != nil && !agentRunAsSubjectsEqual(ref.RunAs, target.RunAs) {
+			continue
+		}
 		return true
 	}
 	return false
@@ -918,11 +1003,57 @@ func agentToolCredentialModeExplicitlyGranted(target coreagent.ToolTarget, refs 
 	return false
 }
 
+func agentToolRunAsExplicitlyGranted(target coreagent.ToolTarget, refs []coreagent.ToolRef, tools []coreagent.Tool) bool {
+	if target.RunAs == nil {
+		return true
+	}
+	if agentToolMatchesResolvedTools(target, "", tools) {
+		return true
+	}
+	for i := range refs {
+		ref := refs[i]
+		if strings.TrimSpace(ref.Plugin) == "*" {
+			continue
+		}
+		if strings.TrimSpace(ref.Plugin) != strings.TrimSpace(target.Plugin) {
+			continue
+		}
+		if strings.TrimSpace(ref.Operation) != strings.TrimSpace(target.Operation) {
+			continue
+		}
+		if !agentRunAsSubjectsEqual(ref.RunAs, target.RunAs) {
+			continue
+		}
+		if connection := strings.TrimSpace(ref.Connection); connection != "" && config.ResolveConnectionAlias(connection) != config.ResolveConnectionAlias(strings.TrimSpace(target.Connection)) {
+			continue
+		}
+		if instance := strings.TrimSpace(ref.Instance); instance != "" && instance != strings.TrimSpace(target.Instance) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 func agentToolTargetsEqual(left, right coreagent.ToolTarget) bool {
 	return strings.TrimSpace(left.System) == strings.TrimSpace(right.System) &&
 		strings.TrimSpace(left.Plugin) == strings.TrimSpace(right.Plugin) &&
 		strings.TrimSpace(left.Operation) == strings.TrimSpace(right.Operation) &&
 		config.ResolveConnectionAlias(strings.TrimSpace(left.Connection)) == config.ResolveConnectionAlias(strings.TrimSpace(right.Connection)) &&
 		strings.TrimSpace(left.Instance) == strings.TrimSpace(right.Instance) &&
-		left.CredentialMode == right.CredentialMode
+		left.CredentialMode == right.CredentialMode &&
+		agentRunAsSubjectsEqual(left.RunAs, right.RunAs)
+}
+
+func agentRunAsSubjectsEqual(left, right *core.RunAsSubject) bool {
+	left = core.NormalizeRunAsSubject(left)
+	right = core.NormalizeRunAsSubject(right)
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return strings.TrimSpace(left.SubjectID) == strings.TrimSpace(right.SubjectID) &&
+		strings.TrimSpace(left.SubjectKind) == strings.TrimSpace(right.SubjectKind) &&
+		strings.TrimSpace(left.CredentialSubjectID) == strings.TrimSpace(right.CredentialSubjectID) &&
+		strings.TrimSpace(left.DisplayName) == strings.TrimSpace(right.DisplayName) &&
+		strings.TrimSpace(left.AuthSource) == strings.TrimSpace(right.AuthSource)
 }

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -72,6 +72,8 @@ type agentRuntimeInvokerCall struct {
 	subjectID              string
 	credentialModeOverride core.ConnectionMode
 	idempotencyKey         string
+	agentSubjectID         string
+	runAsSubjectID         string
 }
 
 type recordingAgentRuntimeInvoker struct {
@@ -81,6 +83,15 @@ type recordingAgentRuntimeInvoker struct {
 
 func (i *recordingAgentRuntimeInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	i.mu.Lock()
+	runAsAudit := invocation.RunAsAuditFromContext(ctx)
+	agentSubjectID := ""
+	if runAsAudit.AgentSubject != nil {
+		agentSubjectID = runAsAudit.AgentSubject.SubjectID
+	}
+	runAsSubjectID := ""
+	if runAsAudit.RunAsSubject != nil {
+		runAsSubjectID = runAsAudit.RunAsSubject.SubjectID
+	}
 	i.calls = append(i.calls, agentRuntimeInvokerCall{
 		providerName:           providerName,
 		operation:              operation,
@@ -88,6 +99,8 @@ func (i *recordingAgentRuntimeInvoker) Invoke(ctx context.Context, p *principal.
 		subjectID:              p.SubjectID,
 		credentialModeOverride: invocation.CredentialModeOverrideFromContext(ctx),
 		idempotencyKey:         invocation.IdempotencyKeyFromContext(ctx),
+		agentSubjectID:         agentSubjectID,
+		runAsSubjectID:         runAsSubjectID,
 	})
 	i.mu.Unlock()
 
@@ -1944,6 +1957,123 @@ func TestAgentRuntimeExecuteToolRejectsHiddenOperationWithoutExactGrant(t *testi
 	calls = invoker.Calls()
 	if len(calls) != 1 || calls[0].providerName != "slack" || calls[0].operation != "events.reply" {
 		t.Fatalf("invoker calls = %#v, want slack events.reply once", calls)
+	}
+}
+
+func TestAgentRuntimeExecuteToolAppliesRunAsOnlyForDelegatedTool(t *testing.T) {
+	t.Parallel()
+
+	invoker := &recordingAgentRuntimeInvoker{}
+	runGrants := newTestAgentRunGrants(t)
+	providers := testutil.NewProviderRegistry(t,
+		&coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:    "events.reply",
+				Title: "Reply",
+			}}},
+		},
+		&coretesting.StubIntegration{
+			N:        "github",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:    "bot.createPullRequest",
+				Title: "Create pull request",
+			}}},
+		},
+	)
+	manager := agentmanager.New(agentmanager.Config{
+		Providers: providers,
+		RunGrants: runGrants,
+		Invoker:   invoker,
+	})
+	runtime := &agentRuntime{
+		providers: map[string]coreagent.Provider{
+			"simple": &routingAgentProvider{
+				getTurn: func(context.Context, coreagent.GetTurnRequest) (*coreagent.Turn, error) {
+					return &coreagent.Turn{
+						ID:        "turn-1",
+						SessionID: "session-1",
+						Status:    coreagent.ExecutionStatusRunning,
+						CreatedBy: coreagent.Actor{SubjectID: "user:user-123"},
+					}, nil
+				},
+			},
+		},
+	}
+	runtime.SetInvoker(invoker)
+	runtime.SetRunGrants(runGrants)
+	runtime.SetToolSearcher(manager)
+
+	runAs := &core.RunAsSubject{
+		SubjectID:   "service_account:github_app_installation:99:repo:acme/widgets",
+		SubjectKind: "service_account",
+		AuthSource:  "github_app_webhook",
+	}
+	grant, err := runGrants.Mint(agentgrant.Grant{
+		ProviderName: "simple",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		SubjectID:    "user:user-123",
+		SubjectKind:  string(principal.KindUser),
+		DisplayName:  "Hugh",
+		AuthSource:   "slack",
+		Permissions: []core.AccessPermission{
+			{Plugin: "slack", Operations: []string{"events.reply"}},
+			{Plugin: "github", Operations: []string{"bot.createPullRequest"}},
+		},
+		ToolRefs: []coreagent.ToolRef{
+			{Plugin: "slack", Operation: "events.reply"},
+			{Plugin: "github", Operation: "bot.createPullRequest", RunAs: runAs},
+		},
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+	})
+	if err != nil {
+		t.Fatalf("Mint runAs grant: %v", err)
+	}
+
+	if _, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "simple",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolID: mustMintAgentToolID(t, runGrants, coreagent.ToolTarget{
+			Plugin:    "slack",
+			Operation: "events.reply",
+		}),
+		RunGrant:  grant,
+		Arguments: map[string]any{"eventId": "evt-1"},
+	}); err != nil {
+		t.Fatalf("ExecuteTool slack: %v", err)
+	}
+
+	if _, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "simple",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolID: mustMintAgentToolID(t, runGrants, coreagent.ToolTarget{
+			Plugin:    "github",
+			Operation: "bot.createPullRequest",
+			RunAs:     runAs,
+		}),
+		RunGrant:  grant,
+		Arguments: map[string]any{"owner": "acme", "repo": "widgets"},
+	}); err != nil {
+		t.Fatalf("ExecuteTool github: %v", err)
+	}
+
+	calls := invoker.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("invoker calls = %#v, want two calls", calls)
+	}
+	if calls[0].providerName != "slack" || calls[0].subjectID != "user:user-123" || calls[0].runAsSubjectID != "" {
+		t.Fatalf("slack call = %#v, want original user subject without runAs", calls[0])
+	}
+	if calls[1].providerName != "github" || calls[1].subjectID != runAs.SubjectID {
+		t.Fatalf("github call = %#v, want delegated subject %q", calls[1], runAs.SubjectID)
+	}
+	if calls[1].agentSubjectID != "user:user-123" || calls[1].runAsSubjectID != runAs.SubjectID {
+		t.Fatalf("github audit context = %#v, want original and delegated subjects", calls[1])
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1259,6 +1259,7 @@ func pluginInvocationDependencies(deps []config.PluginInvocationDependency) []in
 			Operation:      dep.Operation,
 			Surface:        dep.Surface,
 			CredentialMode: core.ConnectionMode(dep.CredentialMode),
+			RunAs:          dep.RunAsSubject(),
 		})
 	}
 	return out

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1833,8 +1833,7 @@ type PluginInvocationDependency struct {
 }
 
 type PluginInvocationRunAsConfig struct {
-	Subject               *PluginInvocationRunAsSubjectConfig               `yaml:"subject,omitempty"`
-	GitHubAppInstallation *PluginInvocationRunAsGitHubAppInstallationConfig `yaml:"githubAppInstallation,omitempty"`
+	Subject *PluginInvocationRunAsSubjectConfig `yaml:"subject,omitempty"`
 }
 
 type PluginInvocationRunAsSubjectConfig struct {
@@ -1843,13 +1842,6 @@ type PluginInvocationRunAsSubjectConfig struct {
 	CredentialSubjectID string `yaml:"credentialSubjectId,omitempty"`
 	DisplayName         string `yaml:"displayName,omitempty"`
 	AuthSource          string `yaml:"authSource,omitempty"`
-}
-
-type PluginInvocationRunAsGitHubAppInstallationConfig struct {
-	InstallationID int64  `yaml:"installationId,omitempty"`
-	Owner          string `yaml:"owner,omitempty"`
-	Repo           string `yaml:"repo,omitempty"`
-	AuthSource     string `yaml:"authSource,omitempty"`
 }
 
 func (d PluginInvocationDependency) RunAsSubject() *core.RunAsSubject {
@@ -1863,16 +1855,6 @@ func (d PluginInvocationDependency) RunAsSubject() *core.RunAsSubject {
 			CredentialSubjectID: subject.CredentialSubjectID,
 			DisplayName:         subject.DisplayName,
 			AuthSource:          subject.AuthSource,
-		})
-	}
-	if installation := d.RunAs.GitHubAppInstallation; installation != nil && installation.InstallationID > 0 {
-		owner := strings.TrimSpace(installation.Owner)
-		repo := strings.TrimSpace(installation.Repo)
-		subjectID := fmt.Sprintf("service_account:github_app_installation:%d:repo:%s/%s", installation.InstallationID, owner, repo)
-		return core.NormalizeRunAsSubject(&core.RunAsSubject{
-			SubjectID:   subjectID,
-			SubjectKind: "service_account",
-			AuthSource:  installation.AuthSource,
 		})
 	}
 	return nil

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1829,6 +1829,53 @@ type PluginInvocationDependency struct {
 	Operation      string                            `yaml:"operation,omitempty"`
 	Surface        string                            `yaml:"surface,omitempty"`
 	CredentialMode providermanifestv1.ConnectionMode `yaml:"credentialMode,omitempty"`
+	RunAs          *PluginInvocationRunAsConfig      `yaml:"runAs,omitempty"`
+}
+
+type PluginInvocationRunAsConfig struct {
+	Subject               *PluginInvocationRunAsSubjectConfig               `yaml:"subject,omitempty"`
+	GitHubAppInstallation *PluginInvocationRunAsGitHubAppInstallationConfig `yaml:"githubAppInstallation,omitempty"`
+}
+
+type PluginInvocationRunAsSubjectConfig struct {
+	ID                  string `yaml:"id,omitempty"`
+	Kind                string `yaml:"kind,omitempty"`
+	CredentialSubjectID string `yaml:"credentialSubjectId,omitempty"`
+	DisplayName         string `yaml:"displayName,omitempty"`
+	AuthSource          string `yaml:"authSource,omitempty"`
+}
+
+type PluginInvocationRunAsGitHubAppInstallationConfig struct {
+	InstallationID int64  `yaml:"installationId,omitempty"`
+	Owner          string `yaml:"owner,omitempty"`
+	Repo           string `yaml:"repo,omitempty"`
+	AuthSource     string `yaml:"authSource,omitempty"`
+}
+
+func (d PluginInvocationDependency) RunAsSubject() *core.RunAsSubject {
+	if d.RunAs == nil {
+		return nil
+	}
+	if subject := d.RunAs.Subject; subject != nil {
+		return core.NormalizeRunAsSubject(&core.RunAsSubject{
+			SubjectID:           subject.ID,
+			SubjectKind:         subject.Kind,
+			CredentialSubjectID: subject.CredentialSubjectID,
+			DisplayName:         subject.DisplayName,
+			AuthSource:          subject.AuthSource,
+		})
+	}
+	if installation := d.RunAs.GitHubAppInstallation; installation != nil && installation.InstallationID > 0 {
+		owner := strings.TrimSpace(installation.Owner)
+		repo := strings.TrimSpace(installation.Repo)
+		subjectID := fmt.Sprintf("service_account:github_app_installation:%d:repo:%s/%s", installation.InstallationID, owner, repo)
+		return core.NormalizeRunAsSubject(&core.RunAsSubject{
+			SubjectID:   subjectID,
+			SubjectKind: "service_account",
+			AuthSource:  installation.AuthSource,
+		})
+	}
+	return nil
 }
 
 func Load(path string) (*Config, error) {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5150,6 +5150,45 @@ func TestValidateStructureConnectionRefPreservesCredentialRefreshOverride(t *tes
 	}
 }
 
+func TestValidateStructureCanonicalizesPluginInvokeRunAs(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		APIVersion: ConfigAPIVersion,
+		Plugins: map[string]*ProviderEntry{
+			"slack": {
+				Source: ProviderSource{Path: "./manifest.yaml"},
+				Invokes: []PluginInvocationDependency{{
+					Plugin:         "github",
+					Operation:      "bot.createPullRequest",
+					CredentialMode: providermanifestv1.ConnectionModeNone,
+					RunAs: &PluginInvocationRunAsConfig{
+						GitHubAppInstallation: &PluginInvocationRunAsGitHubAppInstallationConfig{
+							InstallationID: 99,
+							Owner:          " acme ",
+							Repo:           " widgets ",
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	if err := ValidateStructure(cfg); err != nil {
+		t.Fatalf("ValidateStructure() error = %v", err)
+	}
+	subject := cfg.Plugins["slack"].Invokes[0].RunAsSubject()
+	if subject == nil {
+		t.Fatal("RunAsSubject() = nil, want subject")
+	}
+	if subject.SubjectID != "service_account:github_app_installation:99:repo:acme/widgets" {
+		t.Fatalf("RunAsSubject().SubjectID = %q", subject.SubjectID)
+	}
+	if subject.SubjectKind != "service_account" || subject.AuthSource != "github_app_webhook" {
+		t.Fatalf("RunAsSubject() = %#v, want service account github app source", subject)
+	}
+}
+
 func TestValidateStructureCredentialRefreshDurationContract(t *testing.T) {
 	t.Parallel()
 
@@ -5172,6 +5211,34 @@ func TestValidateStructureCredentialRefreshDurationContract(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "credentialRefresh.refreshInterval") {
 		t.Fatalf("ValidateStructure() error = %v, want credentialRefresh.refreshInterval", err)
+	}
+}
+
+func TestValidateStructureRejectsPluginInvokeRunAsOnSurface(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		APIVersion: ConfigAPIVersion,
+		Plugins: map[string]*ProviderEntry{
+			"slack": {
+				Source: ProviderSource{Path: "./manifest.yaml"},
+				Invokes: []PluginInvocationDependency{{
+					Plugin:  "github",
+					Surface: string(SpecSurfaceGraphQL),
+					RunAs: &PluginInvocationRunAsConfig{
+						Subject: &PluginInvocationRunAsSubjectConfig{
+							ID:   "service_account:github_app_installation:99:repo:acme/widgets",
+							Kind: "service_account",
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	err := ValidateStructure(cfg)
+	if err == nil || !strings.Contains(err.Error(), "runAs requires an exact operation") {
+		t.Fatalf("ValidateStructure() error = %v, want runAs exact operation error", err)
 	}
 }
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5163,10 +5163,9 @@ func TestValidateStructureCanonicalizesPluginInvokeRunAs(t *testing.T) {
 					Operation:      "bot.createPullRequest",
 					CredentialMode: providermanifestv1.ConnectionModeNone,
 					RunAs: &PluginInvocationRunAsConfig{
-						GitHubAppInstallation: &PluginInvocationRunAsGitHubAppInstallationConfig{
-							InstallationID: 99,
-							Owner:          " acme ",
-							Repo:           " widgets ",
+						Subject: &PluginInvocationRunAsSubjectConfig{
+							ID:          " service_account:github_app_installation:99:repo:acme/widgets ",
+							DisplayName: " Toolshed app ",
 						},
 					},
 				}},
@@ -5184,8 +5183,8 @@ func TestValidateStructureCanonicalizesPluginInvokeRunAs(t *testing.T) {
 	if subject.SubjectID != "service_account:github_app_installation:99:repo:acme/widgets" {
 		t.Fatalf("RunAsSubject().SubjectID = %q", subject.SubjectID)
 	}
-	if subject.SubjectKind != "service_account" || subject.AuthSource != "github_app_webhook" {
-		t.Fatalf("RunAsSubject() = %#v, want service account github app source", subject)
+	if subject.SubjectKind != "service_account" || subject.CredentialSubjectID != subject.SubjectID || subject.DisplayName != "Toolshed app" {
+		t.Fatalf("RunAsSubject() = %#v, want normalized service account subject", subject)
 	}
 }
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -795,6 +795,9 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 		case entry.Invokes[i].CredentialMode != "" && entry.Invokes[i].CredentialMode != providermanifestv1.ConnectionModeNone && entry.Invokes[i].CredentialMode != providermanifestv1.ConnectionModeUser:
 			return fmt.Errorf("config validation: plugins.%s.invokes[%d].credentialMode %q is not supported", name, i, entry.Invokes[i].CredentialMode)
 		}
+		if err := normalizePluginInvocationRunAs("plugins."+name+".invokes["+strconv.Itoa(i)+"]", &entry.Invokes[i]); err != nil {
+			return err
+		}
 		key := entry.Invokes[i].Plugin + "\x00op:" + entry.Invokes[i].Operation + "\x00surface:" + entry.Invokes[i].Surface
 		if prev, ok := seenInvokes[key]; ok {
 			return fmt.Errorf("config validation: plugins.%s.invokes[%d] duplicates invokes[%d]", name, i, prev)
@@ -848,6 +851,63 @@ func validatePluginRouteAuth(cfg *Config, name string, entry *ProviderEntry) err
 	}
 	if _, ok := cfg.Providers.Authentication[entry.RouteAuth.Provider]; !ok {
 		return fmt.Errorf("config validation: plugins.%s.auth.provider references unknown authentication provider %q", name, entry.RouteAuth.Provider)
+	}
+	return nil
+}
+
+func normalizePluginInvocationRunAs(path string, invoke *PluginInvocationDependency) error {
+	if invoke == nil || invoke.RunAs == nil {
+		return nil
+	}
+	if strings.TrimSpace(invoke.Surface) != "" {
+		return fmt.Errorf("config validation: %s.runAs requires an exact operation", path)
+	}
+	runAs := invoke.RunAs
+	count := 0
+	if runAs.Subject != nil {
+		count++
+	}
+	if runAs.GitHubAppInstallation != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("config validation: %s.runAs must set exactly one delegation target", path)
+	}
+	if runAs.Subject != nil {
+		subject := runAs.Subject
+		subject.ID = strings.TrimSpace(subject.ID)
+		subject.Kind = strings.TrimSpace(subject.Kind)
+		subject.CredentialSubjectID = strings.TrimSpace(subject.CredentialSubjectID)
+		subject.DisplayName = strings.TrimSpace(subject.DisplayName)
+		subject.AuthSource = strings.TrimSpace(subject.AuthSource)
+		if subject.ID == "" {
+			return fmt.Errorf("config validation: %s.runAs.subject.id is required", path)
+		}
+		if subject.Kind == "" {
+			if kind, _, ok := core.ParseSubjectID(subject.ID); ok {
+				subject.Kind = kind
+			}
+		}
+		if subject.Kind == "" {
+			return fmt.Errorf("config validation: %s.runAs.subject.kind is required", path)
+		}
+		if subject.CredentialSubjectID == "" {
+			subject.CredentialSubjectID = subject.ID
+		}
+		return nil
+	}
+	installation := runAs.GitHubAppInstallation
+	installation.Owner = strings.TrimSpace(installation.Owner)
+	installation.Repo = strings.TrimSpace(installation.Repo)
+	installation.AuthSource = strings.TrimSpace(installation.AuthSource)
+	if installation.InstallationID <= 0 {
+		return fmt.Errorf("config validation: %s.runAs.githubAppInstallation.installationId is required", path)
+	}
+	if installation.Owner == "" || installation.Repo == "" {
+		return fmt.Errorf("config validation: %s.runAs.githubAppInstallation.owner and repo are required", path)
+	}
+	if installation.AuthSource == "" {
+		installation.AuthSource = "github_app_webhook"
 	}
 	return nil
 }

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -867,47 +867,28 @@ func normalizePluginInvocationRunAs(path string, invoke *PluginInvocationDepende
 	if runAs.Subject != nil {
 		count++
 	}
-	if runAs.GitHubAppInstallation != nil {
-		count++
-	}
 	if count != 1 {
 		return fmt.Errorf("config validation: %s.runAs must set exactly one delegation target", path)
 	}
-	if runAs.Subject != nil {
-		subject := runAs.Subject
-		subject.ID = strings.TrimSpace(subject.ID)
-		subject.Kind = strings.TrimSpace(subject.Kind)
-		subject.CredentialSubjectID = strings.TrimSpace(subject.CredentialSubjectID)
-		subject.DisplayName = strings.TrimSpace(subject.DisplayName)
-		subject.AuthSource = strings.TrimSpace(subject.AuthSource)
-		if subject.ID == "" {
-			return fmt.Errorf("config validation: %s.runAs.subject.id is required", path)
-		}
-		if subject.Kind == "" {
-			if kind, _, ok := core.ParseSubjectID(subject.ID); ok {
-				subject.Kind = kind
-			}
-		}
-		if subject.Kind == "" {
-			return fmt.Errorf("config validation: %s.runAs.subject.kind is required", path)
-		}
-		if subject.CredentialSubjectID == "" {
-			subject.CredentialSubjectID = subject.ID
-		}
-		return nil
+	subject := runAs.Subject
+	subject.ID = strings.TrimSpace(subject.ID)
+	subject.Kind = strings.TrimSpace(subject.Kind)
+	subject.CredentialSubjectID = strings.TrimSpace(subject.CredentialSubjectID)
+	subject.DisplayName = strings.TrimSpace(subject.DisplayName)
+	subject.AuthSource = strings.TrimSpace(subject.AuthSource)
+	if subject.ID == "" {
+		return fmt.Errorf("config validation: %s.runAs.subject.id is required", path)
 	}
-	installation := runAs.GitHubAppInstallation
-	installation.Owner = strings.TrimSpace(installation.Owner)
-	installation.Repo = strings.TrimSpace(installation.Repo)
-	installation.AuthSource = strings.TrimSpace(installation.AuthSource)
-	if installation.InstallationID <= 0 {
-		return fmt.Errorf("config validation: %s.runAs.githubAppInstallation.installationId is required", path)
+	if subject.Kind == "" {
+		if kind, _, ok := core.ParseSubjectID(subject.ID); ok {
+			subject.Kind = kind
+		}
 	}
-	if installation.Owner == "" || installation.Repo == "" {
-		return fmt.Errorf("config validation: %s.runAs.githubAppInstallation.owner and repo are required", path)
+	if subject.Kind == "" {
+		return fmt.Errorf("config validation: %s.runAs.subject.kind is required", path)
 	}
-	if installation.AuthSource == "" {
-		installation.AuthSource = "github_app_webhook"
+	if subject.CredentialSubjectID == "" {
+		subject.CredentialSubjectID = subject.ID
 	}
 	return nil
 }

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -444,6 +444,7 @@ func pluginInvocationDependencies(deps []config.PluginInvocationDependency) []in
 			Operation:      dep.Operation,
 			Surface:        dep.Surface,
 			CredentialMode: core.ConnectionMode(dep.CredentialMode),
+			RunAs:          dep.RunAsSubject(),
 		})
 	}
 	return out

--- a/gestaltd/services/agents/agentgrant/grant.go
+++ b/gestaltd/services/agents/agentgrant/grant.go
@@ -148,7 +148,7 @@ func (m *Manager) Resolve(token string) (Grant, error) {
 		return Grant{}, fmt.Errorf("agent run grant is invalid or expired")
 	}
 	var scope toolScope
-	if err := m.openValue(sealPurposeToolScope, strings.TrimSpace(decoded.ToolScope), &scope); err != nil {
+	if err := m.openValueAny([]string{sealPurposeToolScope, legacySealPurposeToolScope}, strings.TrimSpace(decoded.ToolScope), &scope); err != nil {
 		return Grant{}, fmt.Errorf("agent run grant is invalid or expired")
 	}
 	grant := Grant{

--- a/gestaltd/services/agents/agentgrant/seal.go
+++ b/gestaltd/services/agents/agentgrant/seal.go
@@ -38,6 +38,7 @@ func (m *Manager) MintToolID(target coreagent.ToolTarget) (string, error) {
 		Instance:       strings.TrimSpace(target.Instance),
 		CredentialMode: core.ConnectionMode(strings.TrimSpace(string(target.CredentialMode))),
 		Unavailable:    normalizeUnavailableToolTarget(target.Unavailable),
+		RunAs:          core.NormalizeRunAsSubject(target.RunAs),
 	}
 	if target.Unavailable != nil {
 		if target.Plugin == "" || target.System != "" || target.Operation != "" {
@@ -73,6 +74,7 @@ func (m *Manager) ResolveToolID(id string) (coreagent.ToolTarget, error) {
 	target.Instance = strings.TrimSpace(target.Instance)
 	target.CredentialMode = core.ConnectionMode(strings.TrimSpace(string(target.CredentialMode)))
 	target.Unavailable = normalizeUnavailableToolTarget(target.Unavailable)
+	target.RunAs = core.NormalizeRunAsSubject(target.RunAs)
 	if target.Unavailable != nil {
 		if target.Plugin == "" || target.System != "" || target.Operation != "" {
 			return coreagent.ToolTarget{}, fmt.Errorf("agent tool id is invalid")

--- a/gestaltd/services/agents/agentgrant/seal.go
+++ b/gestaltd/services/agents/agentgrant/seal.go
@@ -16,10 +16,12 @@ import (
 )
 
 const (
-	sealVersion          = "v1"
-	sealPurposeToolID    = "agent-tool-id"
-	sealPurposeToolScope = "agent-tool-scope"
-	toolIDPrefix         = "agt_tool_"
+	sealVersion                = "v1"
+	sealPurposeToolID          = "agent-tool-id-v2"
+	sealPurposeToolScope       = "agent-tool-scope-v2"
+	legacySealPurposeToolID    = "agent-tool-id"
+	legacySealPurposeToolScope = "agent-tool-scope"
+	toolIDPrefix               = "agt_tool_"
 )
 
 type toolBinding struct {
@@ -63,7 +65,7 @@ func (m *Manager) ResolveToolID(id string) (coreagent.ToolTarget, error) {
 		return coreagent.ToolTarget{}, fmt.Errorf("agent tool id is invalid")
 	}
 	var binding toolBinding
-	if err := m.openValue(sealPurposeToolID, strings.TrimPrefix(id, toolIDPrefix), &binding); err != nil {
+	if err := m.openValueAny([]string{sealPurposeToolID, legacySealPurposeToolID}, strings.TrimPrefix(id, toolIDPrefix), &binding); err != nil {
 		return coreagent.ToolTarget{}, fmt.Errorf("agent tool id is invalid")
 	}
 	target := binding.Target
@@ -142,6 +144,24 @@ func (m *Manager) openValue(purpose, token string, value any) error {
 		return fmt.Errorf("decode agent grant payload: %w", err)
 	}
 	return nil
+}
+
+func (m *Manager) openValueAny(purposes []string, token string, value any) error {
+	var lastErr error
+	for _, purpose := range purposes {
+		if strings.TrimSpace(purpose) == "" {
+			continue
+		}
+		if err := m.openValue(purpose, token, value); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("agent grant payload purpose is invalid")
 }
 
 func (m *Manager) sealer(purpose string) (cipher.AEAD, error) {

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -3164,7 +3164,7 @@ func (m *Manager) applyCallerInvokePolicies(callerPluginName string, refs []core
 		if !hasMode && out[i].CredentialMode != "" {
 			return nil, fmt.Errorf("%w: agent tool_refs[%d].credentialMode requires a declared invoke mode", invocation.ErrAuthorizationDenied, i)
 		}
-		if hasRunAs && out[i].RunAs != nil && !runAsSubjectsEqual(out[i].RunAs, runAs) {
+		if hasRunAs && out[i].RunAs != nil && !core.RunAsSubjectsEqual(out[i].RunAs, runAs) {
 			return nil, fmt.Errorf("%w: agent tool_refs[%d].runAs exceeds declared invoke delegation", invocation.ErrAuthorizationDenied, i)
 		}
 		if !hasRunAs && out[i].RunAs != nil {
@@ -3189,19 +3189,6 @@ func runAsSubjectID(subject *core.RunAsSubject) string {
 		return ""
 	}
 	return strings.TrimSpace(core.NormalizeRunAsSubject(subject).SubjectID)
-}
-
-func runAsSubjectsEqual(left, right *core.RunAsSubject) bool {
-	left = core.NormalizeRunAsSubject(left)
-	right = core.NormalizeRunAsSubject(right)
-	if left == nil || right == nil {
-		return left == nil && right == nil
-	}
-	return strings.TrimSpace(left.SubjectID) == strings.TrimSpace(right.SubjectID) &&
-		strings.TrimSpace(left.SubjectKind) == strings.TrimSpace(right.SubjectKind) &&
-		strings.TrimSpace(left.CredentialSubjectID) == strings.TrimSpace(right.CredentialSubjectID) &&
-		strings.TrimSpace(left.DisplayName) == strings.TrimSpace(right.DisplayName) &&
-		strings.TrimSpace(left.AuthSource) == strings.TrimSpace(right.AuthSource)
 }
 
 func agentProviderSupportsToolSource(ctx context.Context, provider coreagent.Provider, source coreagent.ToolSourceMode) (bool, error) {

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -546,7 +546,7 @@ func (m *Manager) ResolveTools(ctx context.Context, p *principal.Principal, req 
 	if err != nil {
 		return nil, err
 	}
-	refs, err = m.applyCallerInvokeCredentialModes(req.CallerPluginName, refs)
+	refs, err = m.applyCallerInvokePolicies(req.CallerPluginName, refs)
 	if err != nil {
 		return nil, err
 	}
@@ -773,7 +773,7 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	if err != nil {
 		return nil, err
 	}
-	toolRefs, err = m.applyCallerInvokeCredentialModes(req.CallerPluginName, toolRefs)
+	toolRefs, err = m.applyCallerInvokePolicies(req.CallerPluginName, toolRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -1699,6 +1699,7 @@ func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref c
 		Connection:     connection,
 		Instance:       sessionInstance,
 		CredentialMode: credentialMode,
+		RunAs:          core.NormalizeRunAsSubject(ref.RunAs),
 	}
 	toolID, err := m.mintAgentToolID(target)
 	if err != nil {
@@ -1741,6 +1742,7 @@ type agentToolTargetKey struct {
 	connection     string
 	instance       string
 	credentialMode core.ConnectionMode
+	runAsSubjectID string
 }
 
 func agentToolTargetKeyFromRef(ref coreagent.ToolRef) agentToolTargetKey {
@@ -1751,6 +1753,7 @@ func agentToolTargetKeyFromRef(ref coreagent.ToolRef) agentToolTargetKey {
 		connection:     core.ResolveConnectionAlias(strings.TrimSpace(ref.Connection)),
 		instance:       strings.TrimSpace(ref.Instance),
 		credentialMode: ref.CredentialMode,
+		runAsSubjectID: runAsSubjectID(ref.RunAs),
 	}
 }
 
@@ -1762,6 +1765,7 @@ func agentToolTargetKeyFromTarget(target coreagent.ToolTarget) agentToolTargetKe
 		connection:     core.ResolveConnectionAlias(strings.TrimSpace(target.Connection)),
 		instance:       strings.TrimSpace(target.Instance),
 		credentialMode: target.CredentialMode,
+		runAsSubjectID: runAsSubjectID(target.RunAs),
 	}
 }
 
@@ -1770,8 +1774,8 @@ func (k agentToolTargetKey) String() string {
 		return strings.Join([]string{"system", k.system, k.operation}, "/")
 	}
 	parts := []string{k.plugin, k.operation}
-	if k.connection != "" || k.instance != "" || k.credentialMode != "" {
-		parts = append(parts, k.connection, k.instance, string(k.credentialMode))
+	if k.connection != "" || k.instance != "" || k.credentialMode != "" || k.runAsSubjectID != "" {
+		parts = append(parts, k.connection, k.instance, string(k.credentialMode), k.runAsSubjectID)
 	}
 	return strings.Join(parts, "/")
 }
@@ -2515,6 +2519,7 @@ func (m *Manager) listedAgentPluginCandidateTool(candidate agentToolSearchCandid
 		Connection:     core.ResolveConnectionAlias(strings.TrimSpace(ref.Connection)),
 		Instance:       strings.TrimSpace(ref.Instance),
 		CredentialMode: ref.CredentialMode,
+		RunAs:          core.NormalizeRunAsSubject(ref.RunAs),
 	}
 	toolID, err := m.mintAgentToolID(target)
 	if err != nil {
@@ -2607,6 +2612,7 @@ func agentToolRefFromTarget(target coreagent.ToolTarget) coreagent.ToolRef {
 		Connection:     target.Connection,
 		Instance:       target.Instance,
 		CredentialMode: target.CredentialMode,
+		RunAs:          core.NormalizeRunAsSubject(target.RunAs),
 	}
 }
 
@@ -3058,6 +3064,7 @@ func normalizeToolRefs(refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
 		ref.Instance = strings.TrimSpace(ref.Instance)
 		ref.Title = strings.TrimSpace(ref.Title)
 		ref.Description = strings.TrimSpace(ref.Description)
+		ref.RunAs = core.NormalizeRunAsSubject(ref.RunAs)
 		credentialMode, err := normalizeAgentToolCredentialMode(ref.CredentialMode)
 		if err != nil {
 			return nil, err
@@ -3073,8 +3080,8 @@ func normalizeToolRefs(refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
 			if ref.Operation == "" {
 				return nil, fmt.Errorf("%w: agent tool_refs[%d].operation is required for system tool refs", invocation.ErrOperationNotFound, idx)
 			}
-			if ref.Connection != "" || ref.Instance != "" || ref.CredentialMode != "" || ref.Title != "" || ref.Description != "" {
-				return nil, fmt.Errorf("%w: agent tool_refs[%d] system refs cannot include connection, instance, credential mode, title, or description", invocation.ErrInvalidInvocation, idx)
+			if ref.Connection != "" || ref.Instance != "" || ref.CredentialMode != "" || ref.RunAs != nil || ref.Title != "" || ref.Description != "" {
+				return nil, fmt.Errorf("%w: agent tool_refs[%d] system refs cannot include connection, instance, credential mode, runAs, title, or description", invocation.ErrInvalidInvocation, idx)
 			}
 			out = append(out, ref)
 			continue
@@ -3083,8 +3090,8 @@ func normalizeToolRefs(refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
 			return nil, fmt.Errorf("%w: agent tool_refs[%d].plugin is required", invocation.ErrProviderNotFound, idx)
 		}
 		if ref.Plugin == agentToolSearchAllPlugin {
-			if ref.Operation != "" || ref.Connection != "" || ref.Instance != "" || ref.Title != "" || ref.Description != "" || ref.CredentialMode != "" {
-				return nil, fmt.Errorf("%w: agent tool_refs[%d] global search ref cannot include operation, connection, instance, credential mode, title, or description", invocation.ErrProviderNotFound, idx)
+			if ref.Operation != "" || ref.Connection != "" || ref.Instance != "" || ref.Title != "" || ref.Description != "" || ref.CredentialMode != "" || ref.RunAs != nil {
+				return nil, fmt.Errorf("%w: agent tool_refs[%d] global search ref cannot include operation, connection, instance, credential mode, runAs, title, or description", invocation.ErrProviderNotFound, idx)
 			}
 		}
 		out = append(out, ref)
@@ -3092,12 +3099,13 @@ func normalizeToolRefs(refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
 	return out, nil
 }
 
-func (m *Manager) applyCallerInvokeCredentialModes(callerPluginName string, refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
+func (m *Manager) applyCallerInvokePolicies(callerPluginName string, refs []coreagent.ToolRef) ([]coreagent.ToolRef, error) {
 	callerPluginName = strings.TrimSpace(callerPluginName)
 	if len(refs) == 0 || m == nil {
 		return refs, nil
 	}
 	modes := make(map[string]core.ConnectionMode)
+	runAsSubjects := make(map[string]*core.RunAsSubject)
 	if callerPluginName != "" {
 		for _, invoke := range m.pluginInvokes[callerPluginName] {
 			if strings.TrimSpace(invoke.Surface) != "" {
@@ -3115,6 +3123,9 @@ func (m *Manager) applyCallerInvokeCredentialModes(callerPluginName string, refs
 			if mode != "" {
 				modes[agentToolInvokeKey(pluginName, operation)] = mode
 			}
+			if runAs := core.NormalizeRunAsSubject(invoke.RunAs); runAs != nil {
+				runAsSubjects[agentToolInvokeKey(pluginName, operation)] = runAs
+			}
 		}
 	}
 	out := append([]coreagent.ToolRef(nil), refs...)
@@ -3123,29 +3134,74 @@ func (m *Manager) applyCallerInvokeCredentialModes(callerPluginName string, refs
 		if out[i].CredentialMode != "" && callerPluginName == "" {
 			return nil, fmt.Errorf("%w: agent tool_refs[%d].credentialMode requires a caller plugin declaration", invocation.ErrAuthorizationDenied, i)
 		}
+		if out[i].RunAs != nil && callerPluginName == "" {
+			return nil, fmt.Errorf("%w: agent tool_refs[%d].runAs requires a caller plugin declaration", invocation.ErrAuthorizationDenied, i)
+		}
 		if operation == "" {
 			if out[i].CredentialMode != "" {
 				return nil, fmt.Errorf("%w: agent tool_refs[%d].credentialMode requires an exact operation", invocation.ErrAuthorizationDenied, i)
 			}
-			continue
-		}
-		mode, ok := modes[agentToolInvokeKey(out[i].Plugin, operation)]
-		if !ok {
-			if out[i].CredentialMode != "" {
-				return nil, fmt.Errorf("%w: agent tool_refs[%d].credentialMode requires a declared invoke mode", invocation.ErrAuthorizationDenied, i)
+			if out[i].RunAs != nil {
+				return nil, fmt.Errorf("%w: agent tool_refs[%d].runAs requires an exact operation", invocation.ErrAuthorizationDenied, i)
 			}
 			continue
 		}
-		if out[i].CredentialMode != "" && out[i].CredentialMode != mode {
+		key := agentToolInvokeKey(out[i].Plugin, operation)
+		mode, hasMode := modes[key]
+		runAs, hasRunAs := runAsSubjects[key]
+		if !hasMode && !hasRunAs {
+			if out[i].CredentialMode != "" {
+				return nil, fmt.Errorf("%w: agent tool_refs[%d].credentialMode requires a declared invoke mode", invocation.ErrAuthorizationDenied, i)
+			}
+			if out[i].RunAs != nil {
+				return nil, fmt.Errorf("%w: agent tool_refs[%d].runAs requires a declared invoke delegation", invocation.ErrAuthorizationDenied, i)
+			}
+			continue
+		}
+		if hasMode && out[i].CredentialMode != "" && out[i].CredentialMode != mode {
 			return nil, fmt.Errorf("%w: agent tool_refs[%d].credentialMode %q exceeds declared invoke mode %q", invocation.ErrAuthorizationDenied, i, out[i].CredentialMode, mode)
 		}
-		out[i].CredentialMode = mode
+		if !hasMode && out[i].CredentialMode != "" {
+			return nil, fmt.Errorf("%w: agent tool_refs[%d].credentialMode requires a declared invoke mode", invocation.ErrAuthorizationDenied, i)
+		}
+		if hasRunAs && out[i].RunAs != nil && !runAsSubjectsEqual(out[i].RunAs, runAs) {
+			return nil, fmt.Errorf("%w: agent tool_refs[%d].runAs exceeds declared invoke delegation", invocation.ErrAuthorizationDenied, i)
+		}
+		if !hasRunAs && out[i].RunAs != nil {
+			return nil, fmt.Errorf("%w: agent tool_refs[%d].runAs requires a declared invoke delegation", invocation.ErrAuthorizationDenied, i)
+		}
+		if hasMode {
+			out[i].CredentialMode = mode
+		}
+		if hasRunAs {
+			out[i].RunAs = runAs
+		}
 	}
 	return out, nil
 }
 
 func agentToolInvokeKey(pluginName, operation string) string {
 	return strings.TrimSpace(pluginName) + "\x00" + strings.TrimSpace(operation)
+}
+
+func runAsSubjectID(subject *core.RunAsSubject) string {
+	if subject == nil {
+		return ""
+	}
+	return strings.TrimSpace(core.NormalizeRunAsSubject(subject).SubjectID)
+}
+
+func runAsSubjectsEqual(left, right *core.RunAsSubject) bool {
+	left = core.NormalizeRunAsSubject(left)
+	right = core.NormalizeRunAsSubject(right)
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return strings.TrimSpace(left.SubjectID) == strings.TrimSpace(right.SubjectID) &&
+		strings.TrimSpace(left.SubjectKind) == strings.TrimSpace(right.SubjectKind) &&
+		strings.TrimSpace(left.CredentialSubjectID) == strings.TrimSpace(right.CredentialSubjectID) &&
+		strings.TrimSpace(left.DisplayName) == strings.TrimSpace(right.DisplayName) &&
+		strings.TrimSpace(left.AuthSource) == strings.TrimSpace(right.AuthSource)
 }
 
 func agentProviderSupportsToolSource(ctx context.Context, provider coreagent.Provider, source coreagent.ToolSourceMode) (bool, error) {

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -1742,7 +1742,7 @@ type agentToolTargetKey struct {
 	connection     string
 	instance       string
 	credentialMode core.ConnectionMode
-	runAsSubjectID string
+	runAs          core.RunAsSubject
 }
 
 func agentToolTargetKeyFromRef(ref coreagent.ToolRef) agentToolTargetKey {
@@ -1753,7 +1753,7 @@ func agentToolTargetKeyFromRef(ref coreagent.ToolRef) agentToolTargetKey {
 		connection:     core.ResolveConnectionAlias(strings.TrimSpace(ref.Connection)),
 		instance:       strings.TrimSpace(ref.Instance),
 		credentialMode: ref.CredentialMode,
-		runAsSubjectID: runAsSubjectID(ref.RunAs),
+		runAs:          agentToolRunAsKey(ref.RunAs),
 	}
 }
 
@@ -1765,7 +1765,7 @@ func agentToolTargetKeyFromTarget(target coreagent.ToolTarget) agentToolTargetKe
 		connection:     core.ResolveConnectionAlias(strings.TrimSpace(target.Connection)),
 		instance:       strings.TrimSpace(target.Instance),
 		credentialMode: target.CredentialMode,
-		runAsSubjectID: runAsSubjectID(target.RunAs),
+		runAs:          agentToolRunAsKey(target.RunAs),
 	}
 }
 
@@ -1774,8 +1774,9 @@ func (k agentToolTargetKey) String() string {
 		return strings.Join([]string{"system", k.system, k.operation}, "/")
 	}
 	parts := []string{k.plugin, k.operation}
-	if k.connection != "" || k.instance != "" || k.credentialMode != "" || k.runAsSubjectID != "" {
-		parts = append(parts, k.connection, k.instance, string(k.credentialMode), k.runAsSubjectID)
+	runAsKey := agentToolRunAsKeyString(k.runAs)
+	if k.connection != "" || k.instance != "" || k.credentialMode != "" || runAsKey != "" {
+		parts = append(parts, k.connection, k.instance, string(k.credentialMode), runAsKey)
 	}
 	return strings.Join(parts, "/")
 }
@@ -3184,11 +3185,28 @@ func agentToolInvokeKey(pluginName, operation string) string {
 	return strings.TrimSpace(pluginName) + "\x00" + strings.TrimSpace(operation)
 }
 
-func runAsSubjectID(subject *core.RunAsSubject) string {
+func agentToolRunAsKey(subject *core.RunAsSubject) core.RunAsSubject {
 	if subject == nil {
+		return core.RunAsSubject{}
+	}
+	normalized := core.NormalizeRunAsSubject(subject)
+	if normalized == nil {
+		return core.RunAsSubject{}
+	}
+	return *normalized
+}
+
+func agentToolRunAsKeyString(subject core.RunAsSubject) string {
+	if subject == (core.RunAsSubject{}) {
 		return ""
 	}
-	return strings.TrimSpace(core.NormalizeRunAsSubject(subject).SubjectID)
+	return strings.Join([]string{
+		subject.SubjectID,
+		subject.SubjectKind,
+		subject.CredentialSubjectID,
+		subject.DisplayName,
+		subject.AuthSource,
+	}, "\x00")
 }
 
 func agentProviderSupportsToolSource(ctx context.Context, provider coreagent.Provider, source coreagent.ToolSourceMode) (bool, error) {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -1882,6 +1882,55 @@ func TestResolveToolsAppliesDeclaredInvokeCredentialMode(t *testing.T) {
 	}
 }
 
+func TestResolveToolsAppliesDeclaredInvokeRunAs(t *testing.T) {
+	t.Parallel()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "github",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:    "bot.createPullRequest",
+				Title: "Create pull request",
+			}}},
+		},
+	}
+	runAs := &core.RunAsSubject{
+		SubjectID:   "service_account:github_app_installation:99:repo:acme/widgets",
+		SubjectKind: "service_account",
+		AuthSource:  "github_app_webhook",
+	}
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, provider),
+		PluginInvokes: map[string][]invocation.PluginInvocationDependency{
+			"slack": {{
+				Plugin:    "github",
+				Operation: "bot.createPullRequest",
+				RunAs:     runAs,
+			}},
+		},
+	})
+
+	tools, err := manager.ResolveTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.ResolveToolsRequest{
+		CallerPluginName: "slack",
+		ToolRefs: []coreagent.ToolRef{{
+			Plugin:    "github",
+			Operation: "bot.createPullRequest",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTools: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("ResolveTools returned %d tools, want 1", len(tools))
+	}
+	if tools[0].Target.RunAs == nil || tools[0].Target.RunAs.SubjectID != runAs.SubjectID {
+		t.Fatalf("tool runAs = %#v, want %q", tools[0].Target.RunAs, runAs.SubjectID)
+	}
+}
+
 func TestResolveToolsRejectsUndeclaredCredentialMode(t *testing.T) {
 	t.Parallel()
 
@@ -1925,6 +1974,63 @@ func TestResolveToolsRejectsUndeclaredCredentialMode(t *testing.T) {
 					Plugin:         "slack",
 					Operation:      "events.reply",
 					CredentialMode: core.ConnectionModeNone,
+				}},
+			})
+			if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+				t.Fatalf("ResolveTools error = %v, want ErrAuthorizationDenied", err)
+			}
+		})
+	}
+}
+
+func TestResolveToolsRejectsUndeclaredRunAs(t *testing.T) {
+	t.Parallel()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "github",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:    "bot.createPullRequest",
+				Title: "Create pull request",
+			}}},
+		},
+	}
+	runAs := &core.RunAsSubject{
+		SubjectID:   "service_account:github_app_installation:99:repo:acme/widgets",
+		SubjectKind: "service_account",
+		AuthSource:  "github_app_webhook",
+	}
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, provider),
+		PluginInvokes: map[string][]invocation.PluginInvocationDependency{
+			"slack": {{
+				Plugin:    "github",
+				Operation: "bot.getPullRequest",
+				RunAs:     runAs,
+			}},
+		},
+	})
+
+	for _, tc := range []struct {
+		name             string
+		callerPluginName string
+	}{
+		{name: "public request"},
+		{name: "caller without matching invoke", callerPluginName: "slack"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := manager.ResolveTools(context.Background(), &principal.Principal{
+				SubjectID: principal.UserSubjectID("user-1"),
+			}, coreagent.ResolveToolsRequest{
+				CallerPluginName: tc.callerPluginName,
+				ToolRefs: []coreagent.ToolRef{{
+					Plugin:    "github",
+					Operation: "bot.createPullRequest",
+					RunAs:     runAs,
 				}},
 			})
 			if !errors.Is(err, invocation.ErrAuthorizationDenied) {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -2039,3 +2039,42 @@ func TestResolveToolsRejectsUndeclaredRunAs(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentToolTargetKeyIncludesFullRunAsSubject(t *testing.T) {
+	t.Parallel()
+
+	base := coreagent.ToolRef{
+		Plugin:    "github",
+		Operation: "bot.createPullRequest",
+		RunAs: &core.RunAsSubject{
+			SubjectID:           "service_account:github_app_installation:99:repo:acme/widgets",
+			SubjectKind:         "service_account",
+			CredentialSubjectID: "service_account:github_app_installation:99:repo:acme/widgets",
+			DisplayName:         "Toolshed app",
+			AuthSource:          "github_app_webhook",
+		},
+	}
+	same := base
+	same.RunAs = &core.RunAsSubject{
+		SubjectID:           " service_account:github_app_installation:99:repo:acme/widgets ",
+		SubjectKind:         " service_account ",
+		CredentialSubjectID: " service_account:github_app_installation:99:repo:acme/widgets ",
+		DisplayName:         " Toolshed app ",
+		AuthSource:          " github_app_webhook ",
+	}
+	differentMetadata := base
+	differentMetadata.RunAs = &core.RunAsSubject{
+		SubjectID:           base.RunAs.SubjectID,
+		SubjectKind:         base.RunAs.SubjectKind,
+		CredentialSubjectID: base.RunAs.CredentialSubjectID,
+		DisplayName:         "Another display name",
+		AuthSource:          base.RunAs.AuthSource,
+	}
+
+	if agentToolTargetKeyFromRef(base) != agentToolTargetKeyFromRef(same) {
+		t.Fatal("agentToolTargetKeyFromRef should normalize equivalent runAs subjects")
+	}
+	if agentToolTargetKeyFromRef(base) == agentToolTargetKeyFromRef(differentMetadata) {
+		t.Fatal("agentToolTargetKeyFromRef collapsed distinct runAs metadata")
+	}
+}

--- a/gestaltd/services/identity/principal/principal.go
+++ b/gestaltd/services/identity/principal/principal.go
@@ -40,6 +40,44 @@ type Principal struct {
 type PermissionSet map[string]map[string]struct{}
 type ActionPermissionSet map[string]map[string]struct{}
 
+func ClonePermissionSet(src PermissionSet) PermissionSet {
+	if src == nil {
+		return nil
+	}
+	out := make(PermissionSet, len(src))
+	for pluginName, operations := range src {
+		if operations == nil {
+			out[pluginName] = nil
+			continue
+		}
+		copied := make(map[string]struct{}, len(operations))
+		for operation := range operations {
+			copied[operation] = struct{}{}
+		}
+		out[pluginName] = copied
+	}
+	return out
+}
+
+func CloneActionPermissionSet(src ActionPermissionSet) ActionPermissionSet {
+	if src == nil {
+		return nil
+	}
+	out := make(ActionPermissionSet, len(src))
+	for resource, actions := range src {
+		if actions == nil {
+			out[resource] = nil
+			continue
+		}
+		copied := make(map[string]struct{}, len(actions))
+		for action := range actions {
+			copied[action] = struct{}{}
+		}
+		out[resource] = copied
+	}
+	return out
+}
+
 func (s Source) String() string {
 	switch s {
 	case SourceSession:

--- a/gestaltd/services/invocation/audit.go
+++ b/gestaltd/services/invocation/audit.go
@@ -68,6 +68,19 @@ func buildAuditEntry(ctx context.Context, p *principal.Principal, source, provid
 			entry.SubjectKind = string(p.Kind)
 		}
 	}
+	if delegation := RunAsAuditFromContext(ctx); delegation.RunAsSubject != nil {
+		if agentSubject := delegation.AgentSubject; agentSubject != nil {
+			entry.AgentSubjectID = agentSubject.SubjectID
+			entry.AgentSubjectKind = agentSubject.SubjectKind
+			entry.AgentDisplayName = agentSubject.DisplayName
+			entry.AgentAuthSource = agentSubject.AuthSource
+		}
+		runAs := delegation.RunAsSubject
+		entry.RunAsSubjectID = runAs.SubjectID
+		entry.RunAsSubjectKind = runAs.SubjectKind
+		entry.RunAsDisplayName = runAs.DisplayName
+		entry.RunAsAuthSource = runAs.AuthSource
+	}
 	access := AccessContextFromContext(ctx)
 	if access.Policy != "" {
 		entry.AccessPolicy = access.Policy
@@ -131,6 +144,30 @@ func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
 	}
 	if auditPrincipal.Kind != "" {
 		attrs = append(attrs, slog.String("subject_kind", string(auditPrincipal.Kind)))
+	}
+	if entry.AgentSubjectID != "" {
+		attrs = append(attrs, slog.String("agent_subject_id", entry.AgentSubjectID))
+	}
+	if entry.AgentSubjectKind != "" {
+		attrs = append(attrs, slog.String("agent_subject_kind", entry.AgentSubjectKind))
+	}
+	if entry.AgentDisplayName != "" {
+		attrs = append(attrs, slog.String("agent_display_name", entry.AgentDisplayName))
+	}
+	if entry.AgentAuthSource != "" {
+		attrs = append(attrs, slog.String("agent_auth_source", entry.AgentAuthSource))
+	}
+	if entry.RunAsSubjectID != "" {
+		attrs = append(attrs, slog.String("run_as_subject_id", entry.RunAsSubjectID))
+	}
+	if entry.RunAsSubjectKind != "" {
+		attrs = append(attrs, slog.String("run_as_subject_kind", entry.RunAsSubjectKind))
+	}
+	if entry.RunAsDisplayName != "" {
+		attrs = append(attrs, slog.String("run_as_display_name", entry.RunAsDisplayName))
+	}
+	if entry.RunAsAuthSource != "" {
+		attrs = append(attrs, slog.String("run_as_auth_source", entry.RunAsAuthSource))
 	}
 	if entry.AccessPolicy != "" {
 		attrs = append(attrs, slog.String("access_policy", entry.AccessPolicy))

--- a/gestaltd/services/invocation/audit_test.go
+++ b/gestaltd/services/invocation/audit_test.go
@@ -127,6 +127,47 @@ func TestSlogAuditSink_DeniedEntry(t *testing.T) {
 	}
 }
 
+func TestSlogAuditSink_RunAsDelegationFields(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	sink := invocation.NewSlogAuditSink(&buf)
+
+	entry := core.AuditEntry{
+		Timestamp:        time.Now(),
+		RequestID:        "req-run-as",
+		Source:           "agent",
+		SubjectID:        "service_account:github_app_installation:99:repo:acme/widgets",
+		SubjectKind:      "service_account",
+		AgentSubjectID:   principal.UserSubjectID("user-42"),
+		AgentSubjectKind: string(principal.KindUser),
+		AgentDisplayName: "Hugh",
+		AgentAuthSource:  "slack",
+		RunAsSubjectID:   "service_account:github_app_installation:99:repo:acme/widgets",
+		RunAsSubjectKind: "service_account",
+		RunAsAuthSource:  "github_app_webhook",
+		Provider:         "github",
+		Operation:        "bot.createPullRequest",
+		Allowed:          true,
+	}
+
+	sink.Log(context.Background(), entry)
+
+	var record map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to parse JSON log output: %v", err)
+	}
+	if record["agent_subject_id"] != principal.UserSubjectID("user-42") {
+		t.Fatalf("agent_subject_id = %v", record["agent_subject_id"])
+	}
+	if record["run_as_subject_id"] != entry.RunAsSubjectID {
+		t.Fatalf("run_as_subject_id = %v", record["run_as_subject_id"])
+	}
+	if record["run_as_auth_source"] != "github_app_webhook" {
+		t.Fatalf("run_as_auth_source = %v", record["run_as_auth_source"])
+	}
+}
+
 func TestSlogAuditSink_WithSpanContext(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/invocation/context.go
+++ b/gestaltd/services/invocation/context.go
@@ -39,11 +39,17 @@ func ensureMeta(ctx context.Context) (context.Context, *InvocationMeta) {
 
 type requestMetaCtxKey struct{}
 type auditEntryCtxKey struct{}
+type runAsAuditCtxKey struct{}
 
 type RequestMeta struct {
 	ClientIP   string
 	RemoteAddr string
 	UserAgent  string
+}
+
+type RunAsAuditContext struct {
+	AgentSubject *core.RunAsSubject
+	RunAsSubject *core.RunAsSubject
 }
 
 type CredentialContext struct {
@@ -91,6 +97,25 @@ func withAuditEntry(ctx context.Context, entry *core.AuditEntry) context.Context
 func auditEntryFromContext(ctx context.Context) *core.AuditEntry {
 	entry, _ := ctx.Value(auditEntryCtxKey{}).(*core.AuditEntry)
 	return entry
+}
+
+func WithRunAsAudit(ctx context.Context, agentSubject, runAsSubject *core.RunAsSubject) context.Context {
+	runAsSubject = core.NormalizeRunAsSubject(runAsSubject)
+	if runAsSubject == nil {
+		return ctx
+	}
+	audit := RunAsAuditContext{
+		AgentSubject: core.NormalizeRunAsSubject(agentSubject),
+		RunAsSubject: runAsSubject,
+	}
+	return context.WithValue(ctx, runAsAuditCtxKey{}, audit)
+}
+
+func RunAsAuditFromContext(ctx context.Context) RunAsAuditContext {
+	audit, _ := ctx.Value(runAsAuditCtxKey{}).(RunAsAuditContext)
+	audit.AgentSubject = core.NormalizeRunAsSubject(audit.AgentSubject)
+	audit.RunAsSubject = core.NormalizeRunAsSubject(audit.RunAsSubject)
+	return audit
 }
 
 func WithCredentialContext(ctx context.Context, cred CredentialContext) context.Context {

--- a/gestaltd/services/invocation/plugin_invocation_dependency.go
+++ b/gestaltd/services/invocation/plugin_invocation_dependency.go
@@ -9,13 +9,22 @@ type PluginInvocationDependency struct {
 	Operation      string
 	Surface        string
 	CredentialMode core.ConnectionMode
+	RunAs          *core.RunAsSubject
 }
 
 func ClonePluginInvocationDependencies(src []PluginInvocationDependency) []PluginInvocationDependency {
 	if len(src) == 0 {
 		return nil
 	}
-	return append([]PluginInvocationDependency(nil), src...)
+	out := make([]PluginInvocationDependency, len(src))
+	for i := range src {
+		out[i] = src[i]
+		if src[i].RunAs != nil {
+			runAs := *src[i].RunAs
+			out[i].RunAs = &runAs
+		}
+	}
+	return out
 }
 
 func ClonePluginInvocationDependencyMap(src map[string][]PluginInvocationDependency) map[string][]PluginInvocationDependency {

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -1275,7 +1275,7 @@ func (m *Manager) executionRefPermissions(p *principal.Principal, target corewor
 	if p == nil || p.TokenPermissions == nil {
 		return principal.PermissionsToAccessPermissions(nil)
 	}
-	permissions := cloneWorkflowPermissionSet(p.TokenPermissions)
+	permissions := principal.ClonePermissionSet(p.TokenPermissions)
 	if target.Agent != nil {
 		for i := range target.Agent.ToolRefs {
 			tool := target.Agent.ToolRefs[i]
@@ -1331,25 +1331,6 @@ func (m *Manager) callerPluginDeclaresInvoke(callerPluginName, pluginName, opera
 		}
 	}
 	return false
-}
-
-func cloneWorkflowPermissionSet(src principal.PermissionSet) principal.PermissionSet {
-	if src == nil {
-		return nil
-	}
-	out := make(principal.PermissionSet, len(src))
-	for pluginName, operations := range src {
-		if operations == nil {
-			out[pluginName] = nil
-			continue
-		}
-		copied := make(map[string]struct{}, len(operations))
-		for operation := range operations {
-			copied[operation] = struct{}{}
-		}
-		out[pluginName] = copied
-	}
-	return out
 }
 
 func addWorkflowPermission(permissions principal.PermissionSet, pluginName, operation string) {


### PR DESCRIPTION
## Summary

- Adds generic per-invoke `runAs` policy to plugin invocation dependencies.
- Seals delegated subjects into agent tool refs/targets and applies them only for the selected tool at execution time.
- Records both the original agent subject and effective run-as subject in audit logs.
- Mints new delegated grant/tool payloads with versioned seal purposes so older runtimes reject them instead of silently dropping `runAs`; new runtimes can still read legacy payloads.

## Interface Changes

`plugins.<caller>.invokes[]` now accepts `runAs.subject` alongside `credentialMode`.

`runAs.subject` is intentionally opaque to gestaltd. Gestaltd does not know what GitHub, Slack, or a GitHub App installation means; it only normalizes and carries subject metadata. Provider-specific discovery, such as resolving a GitHub repository to a GitHub App installation subject, belongs in the provider layer.

`runAs` is declared on the caller's invoke allowlist, not by the Slack provider and not by a user-supplied tool call. The agent manager stamps the configured delegation onto matching tool refs, seals it into the tool grant/tool ID, and the runtime applies the delegated principal only when that exact tool executes.

### Full Example: Slack Can Reply As The User And Create A GitHub PR As An Opaque Service Account

```yaml
plugins:
  slack:
    invokes:
      # Slack-native tools remain authorized as the original Slack/user subject.
      - plugin: slack
        operation: chat.postMessage

      # This GitHub bot tool is available to Slack without user GitHub OAuth,
      # but the effective execution subject is the configured service account.
      # Gestaltd treats this subject id as opaque provider-owned data.
      - plugin: github
        operation: bot.createPullRequest
        credentialMode: none
        runAs:
          subject:
            id: service_account:github_app_installation:127579767:repo:valon-technologies/toolshed
            kind: service_account
            authSource: github_app_webhook

      - plugin: github
        operation: bot.commitFiles
        credentialMode: none
        runAs:
          subject:
            id: service_account:github_app_installation:127579767:repo:valon-technologies/toolshed
            kind: service_account
            authSource: github_app_webhook

    config:
      agent:
        provider: anthropic
        model: claude-sonnet-4-5-20250929
        tools:
          - plugin: slack
            operation: chat.postMessage
          - plugin: github
            operation: bot.createPullRequest
          - plugin: github
            operation: bot.commitFiles
```

In a Slack agent turn started by `user:U123`, the runtime behavior is:

```text
Tool call: slack.chat.postMessage
Original subject: user:slack:U123
Effective subject: user:slack:U123

Tool call: github.bot.createPullRequest
Original subject: user:slack:U123
Effective subject: service_account:github_app_installation:127579767:repo:valon-technologies/toolshed
```

Audit logs for the delegated GitHub call include both identities:

```json
{
  "subject_id": "service_account:github_app_installation:127579767:repo:valon-technologies/toolshed",
  "subject_kind": "service_account",
  "agent_subject_id": "user:slack:U123",
  "agent_subject_kind": "user",
  "run_as_subject_id": "service_account:github_app_installation:127579767:repo:valon-technologies/toolshed",
  "run_as_subject_kind": "service_account",
  "operation": "bot.createPullRequest",
  "provider_name": "github"
}
```

### Full Example: Subject With Optional Metadata

`credentialSubjectId`, `displayName`, and `authSource` are optional metadata fields. If `kind` is omitted, gestaltd infers it from the prefix before the first colon in `id`. If `credentialSubjectId` is omitted, gestaltd uses `id`.

```yaml
plugins:
  slack:
    invokes:
      - plugin: github
        operation: bot.createPullRequest
        credentialMode: none
        runAs:
          subject:
            id: service_account:github_app_installation:127579767:repo:valon-technologies/toolshed
            kind: service_account
            credentialSubjectId: service_account:github_app_installation:127579767:repo:valon-technologies/toolshed
            displayName: Toolshed GitHub App installation
            authSource: github_app_webhook

    config:
      agent:
        tools:
          - plugin: github
            operation: bot.createPullRequest
```

### Full Example: Same Agent Turn With Delegated And Non-Delegated Tools

```yaml
plugins:
  slack:
    invokes:
      - plugin: slack
        operation: reactions.add
      - plugin: linear
        operation: searchIssues
      - plugin: github
        operation: bot.closePullRequest
        credentialMode: none
        runAs:
          subject:
            id: service_account:github_app_installation:127579767:repo:valon-technologies/toolshed
            kind: service_account
            authSource: github_app_webhook

    config:
      agent:
        tools:
          - plugin: slack
            operation: reactions.add
          - plugin: linear
            operation: searchIssues
          - plugin: github
            operation: bot.closePullRequest
```

Expected execution identity:

```text
slack.reactions.add         -> original Slack/user subject
linear.searchIssues         -> original Slack/user subject or normal connection policy
github.bot.closePullRequest -> configured service-account subject
```

### How To Get The GitHub Installation Subject

Gestaltd does not derive GitHub installation IDs from secrets. A GitHub App private key identifies the app, not a specific installation. The installation ID can be discovered from GitHub-owned surfaces, for example:

- GitHub App webhook payloads include `installation.id`.
- GitHub's app-authenticated REST API can resolve a repository installation with `GET /repos/{owner}/{repo}/installation`.
- The companion GitHub provider PR exposes this as `bot.resolveInstallation`, which returns the canonical subject id to copy into `runAs.subject.id`.
- A deployment can also store the discovered subject id in ordinary config or a secret/config-management system and render it into the Gestalt config.

### Validation Rules

- `runAs` requires an exact `operation`; it is rejected on broad surface-level invokes.
- A caller cannot supply or override `runAs` unless that exact invoke delegation was declared in config.
- `credentialMode: none` does not change the subject by itself; `runAs` is the part that changes the effective execution subject.
- Delegation is scoped to the matching plugin and operation declared in `plugins.<caller>.invokes[]`.
- Gestaltd treats `runAs.subject.id` as an opaque subject identifier and does not contain provider-specific shorthands.

## Functional/Integration Tests

- Tests added or augmented: config validation, agent manager tool policy stamping/rejection, agent runtime delegated tool execution, audit log field emission.
- Contract boundary covered: config -> invocation dependency -> sealed agent grant/tool ID -> runtime invocation principal -> audit log.
- Commands run:
  - `go test ./core ./core/agent ./services/agents/agentgrant ./services/agents/agentmanager ./services/invocation ./internal/config`
  - `go test ./internal/bootstrap -run TestClientCredentialsTokenSourceFetchTimeoutReleasesFlight -count=1`

Note: the broad bootstrap package currently fails on `TestClientCredentialsTokenSourceFetchTimeoutReleasesFlight` when run with the entire package, while that exact test passes by itself. The changed packages outside that flaky/package-interference case pass.

## Follow-up PRs

- Pairs with https://github.com/valon-technologies/gestalt-providers/pull/583 for GitHub installation discovery.
- Toolshed config can consume this runtime support after it is released/deployed.