### PR TITLE
Fix agent event stream timeout handling

### DIFF
--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -1551,6 +1551,8 @@ func TestAgentTurnEventStreamSendsHeartbeatBeforeEvents(t *testing.T) {
 			Agent:     &stubAgentControl{defaultProviderName: "managed", provider: provider},
 			RunGrants: newServerTestAgentRunGrants(t),
 		})
+		cfg.APIRouteTimeout = 25 * time.Millisecond
+		cfg.AgentStreamHeartbeat = 10 * time.Millisecond
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -1617,6 +1619,16 @@ func TestAgentTurnEventStreamSendsHeartbeatBeforeEvents(t *testing.T) {
 	}
 	if got := strings.TrimRight(line, "\r\n"); got != ": stream-open" {
 		t.Fatalf("first stream line = %q, want stream-open heartbeat", got)
+	}
+	time.Sleep(50 * time.Millisecond)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read post-timeout heartbeat: %v", err)
+		}
+		if got := strings.TrimRight(line, "\r\n"); got == ": keepalive" {
+			break
+		}
 	}
 
 	provider.mu.Lock()

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -1640,7 +1640,7 @@ func TestAgentTurnEventStreamSendsHeartbeatBeforeEvents(t *testing.T) {
 	}
 }
 
-func TestAgentTurnEventStreamClosesQuietlyOnContextCancellation(t *testing.T) {
+func TestAgentTurnEventStreamReportsProviderContextErrorWhileRequestOpen(t *testing.T) {
 	t.Parallel()
 
 	provider := newMemoryAgentProvider()
@@ -1730,22 +1730,23 @@ func TestAgentTurnEventStreamClosesQuietlyOnContextCancellation(t *testing.T) {
 	provider.listTurnEventsErr = context.Canceled
 	provider.mu.Unlock()
 
-	var body strings.Builder
+	var errorFrame string
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
-			if err == io.EOF {
-				break
-			}
 			t.Fatalf("read stream body: %v", err)
 		}
-		body.WriteString(line)
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "data: ") {
+			errorFrame = strings.TrimPrefix(line, "data: ")
+			break
+		}
 	}
 	if streamCtx.Err() != nil {
-		t.Fatal("stream did not close before context deadline")
+		t.Fatal("stream error frame did not arrive before context deadline")
 	}
-	if strings.Contains(body.String(), "stream.error") || strings.Contains(body.String(), "agent event stream failed") {
-		t.Fatalf("stream body = %q, did not expect public stream error", body.String())
+	if !strings.Contains(errorFrame, `"type":"stream.error"`) {
+		t.Fatalf("stream error frame = %s, want stream.error event", errorFrame)
 	}
 }
 

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -1640,6 +1640,115 @@ func TestAgentTurnEventStreamSendsHeartbeatBeforeEvents(t *testing.T) {
 	}
 }
 
+func TestAgentTurnEventStreamClosesQuietlyOnContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAgentProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		services := testutil.NewStubServices(t)
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "ada@example.com", DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:     &stubAgentControl{defaultProviderName: "managed", provider: provider},
+			RunGrants: newServerTestAgentRunGrants(t),
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/", bytes.NewBufferString(`{"provider":"managed","model":"gpt-5.4"}`))
+	sessionReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	sessionResp, err := http.DefaultClient.Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(sessionResp.Body)
+		t.Fatalf("create session status = %d body=%s", sessionResp.StatusCode, body)
+	}
+	var session map[string]any
+	if err := json.NewDecoder(sessionResp.Body).Decode(&session); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	sessionID := session["id"].(string)
+
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"wait"}]}`))
+	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	turnResp, err := http.DefaultClient.Do(turnReq)
+	if err != nil {
+		t.Fatalf("create turn: %v", err)
+	}
+	defer func() { _ = turnResp.Body.Close() }()
+	if turnResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(turnResp.Body)
+		t.Fatalf("create turn status = %d body=%s", turnResp.StatusCode, body)
+	}
+	var turn map[string]any
+	if err := json.NewDecoder(turnResp.Body).Decode(&turn); err != nil {
+		t.Fatalf("decode turn: %v", err)
+	}
+	turnID := turn["id"].(string)
+
+	provider.mu.Lock()
+	provider.turns[turnID].Status = coreagent.ExecutionStatusRunning
+	provider.turns[turnID].CompletedAt = nil
+	provider.turnEvents[turnID] = nil
+	provider.mu.Unlock()
+
+	streamCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	streamReq, _ := http.NewRequestWithContext(streamCtx, http.MethodGet, ts.URL+"/api/v1/agent/turns/"+turnID+"/events/stream?after=0&limit=10", nil)
+	streamReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	streamResp, err := http.DefaultClient.Do(streamReq)
+	if err != nil {
+		t.Fatalf("stream quiet events: %v", err)
+	}
+	defer func() { _ = streamResp.Body.Close() }()
+	if streamResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(streamResp.Body)
+		t.Fatalf("stream quiet events status = %d body=%s", streamResp.StatusCode, body)
+	}
+
+	reader := bufio.NewReader(streamResp.Body)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read heartbeat: %v", err)
+	}
+	if got := strings.TrimRight(line, "\r\n"); got != ": stream-open" {
+		t.Fatalf("first stream line = %q, want stream-open heartbeat", got)
+	}
+
+	provider.mu.Lock()
+	provider.listTurnEventsErr = context.Canceled
+	provider.mu.Unlock()
+
+	var body strings.Builder
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("read stream body: %v", err)
+		}
+		body.WriteString(line)
+	}
+	if streamCtx.Err() != nil {
+		t.Fatal("stream did not close before context deadline")
+	}
+	if strings.Contains(body.String(), "stream.error") || strings.Contains(body.String(), "agent event stream failed") {
+		t.Fatalf("stream body = %q, did not expect public stream error", body.String())
+	}
+}
+
 func TestAgentInteractionResolutionAndEventStream(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -588,6 +588,9 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeStreamError := func(err error) {
+		if agentTurnEventStreamContextDone(ctx, err) {
+			return
+		}
 		slog.ErrorContext(ctx, "agent turn event stream failed", "turn_id", turnID, "error", err)
 		info := agentTurnEventInfo{
 			TurnID:     turnID,
@@ -660,6 +663,21 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 			pageFull = writeEvents(events)
 		}
 	}
+}
+
+func agentTurnEventStreamContextDone(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if ctx != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil && errors.Is(err, ctxErr) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) listAgentTurnInteractions(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -666,18 +666,16 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 func agentTurnEventStreamContextDone(ctx context.Context, err error) bool {
-	if err == nil {
+	if err == nil || ctx == nil {
 		return false
 	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return true
+	ctxErr := ctx.Err()
+	if ctxErr == nil {
+		return false
 	}
-	if ctx != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil && errors.Is(err, ctxErr) {
-			return true
-		}
-	}
-	return false
+	return errors.Is(err, ctxErr) ||
+		errors.Is(err, context.Canceled) && errors.Is(ctxErr, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) && errors.Is(ctxErr, context.DeadlineExceeded)
 }
 
 func (s *Server) listAgentTurnInteractions(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -31,7 +31,7 @@ const defaultAgentTurnEventLimit = 100
 const maxAgentTurnEventLimit = 1000
 const agentTurnEventStreamUntilTerminal = "terminal"
 const agentTurnEventStreamUntilBlockedOrTerminal = "blocked_or_terminal"
-const agentTurnEventStreamHeartbeatInterval = 15 * time.Second
+const defaultAgentTurnEventStreamHeartbeatInterval = 15 * time.Second
 
 type agentMessageRequest struct {
 	Role     string                    `json:"role,omitempty"`
@@ -652,7 +652,7 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if time.Since(lastWrite) >= agentTurnEventStreamHeartbeatInterval {
+			if time.Since(lastWrite) >= s.agentStreamHeartbeat {
 				writeHeartbeat("keepalive")
 			}
 			events, err := s.agentRuns.ListTurnEvents(ctx, p, turnID, afterSeq, limit)

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -168,14 +168,19 @@ func (s *Server) mountMCPRoutes(r chi.Router) {
 
 func (s *Server) mountAPIRoutes(r chi.Router) {
 	r.Route("/api/v1", func(r chi.Router) {
-		r.Use(middleware.Timeout(60 * time.Second))
-		s.mountAuthRoutes(r)
-		s.mountProviderDevPublicRoutes(r)
-		s.mountAuthenticatedRoutes(r)
+		s.mountAuthenticatedStreamRoutes(r)
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.Timeout(apiRouteTimeout))
+			s.mountAuthRoutes(r)
+			s.mountProviderDevPublicRoutes(r)
+			s.mountAuthenticatedRoutes(r)
+		})
 		r.NotFound(apiNotFound)
 		r.MethodNotAllowed(apiMethodNotAllowed)
 	})
 }
+
+const apiRouteTimeout = 60 * time.Second
 
 func apiNotFound(w http.ResponseWriter, r *http.Request) {
 	writeError(w, http.StatusNotFound, fmt.Sprintf("API route %q not found", r.URL.Path))

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -170,7 +170,7 @@ func (s *Server) mountAPIRoutes(r chi.Router) {
 	r.Route("/api/v1", func(r chi.Router) {
 		s.mountAuthenticatedStreamRoutes(r)
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.Timeout(apiRouteTimeout))
+			r.Use(middleware.Timeout(s.apiRouteTimeout))
 			s.mountAuthRoutes(r)
 			s.mountProviderDevPublicRoutes(r)
 			s.mountAuthenticatedRoutes(r)
@@ -180,7 +180,7 @@ func (s *Server) mountAPIRoutes(r chi.Router) {
 	})
 }
 
-const apiRouteTimeout = 60 * time.Second
+const defaultAPIRouteTimeout = 60 * time.Second
 
 func apiNotFound(w http.ResponseWriter, r *http.Request) {
 	writeError(w, http.StatusNotFound, fmt.Sprintf("API route %q not found", r.URL.Path))

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -4,6 +4,13 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+func (s *Server) mountAuthenticatedStreamRoutes(r chi.Router) {
+	r.Group(func(r chi.Router) {
+		r.Use(s.authMiddleware)
+		r.Get("/agent/turns/{turnID}/events/stream", s.streamAgentTurnEvents)
+	})
+}
+
 func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMiddleware)
@@ -56,7 +63,6 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Get("/{turnID}", s.getAgentTurn)
 			r.Post("/{turnID}/cancel", s.cancelAgentTurn)
 			r.Get("/{turnID}/events", s.listAgentTurnEvents)
-			r.Get("/{turnID}/events/stream", s.streamAgentTurnEvents)
 			r.Get("/{turnID}/interactions", s.listAgentTurnInteractions)
 			r.Post("/{turnID}/interactions/{interactionID}/resolve", s.resolveAgentInteraction)
 		})

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -101,6 +101,8 @@ type Server struct {
 	authResolvers          map[string]*principal.Resolver
 	invoker                invocation.Invoker
 	pluginInvoker          invocation.Invoker
+	apiRouteTimeout        time.Duration
+	agentStreamHeartbeat   time.Duration
 	defaultConnection      map[string]string
 	catalogConnection      map[string]string
 	connectionAuth         func() map[string]map[string]bootstrap.OAuthHandler
@@ -172,6 +174,8 @@ type Config struct {
 	SecureCookies         bool
 	StateSecret           []byte
 	APITokenTTL           time.Duration
+	APIRouteTimeout       time.Duration
+	AgentStreamHeartbeat  time.Duration
 	Now                   func() time.Time
 	Readiness             ReadinessChecker
 	PrometheusMetrics     http.Handler
@@ -225,6 +229,14 @@ func New(cfg Config) (*Server, error) {
 	now := cfg.Now
 	if now == nil {
 		now = time.Now
+	}
+	apiRouteTimeout := cfg.APIRouteTimeout
+	if apiRouteTimeout <= 0 {
+		apiRouteTimeout = defaultAPIRouteTimeout
+	}
+	agentStreamHeartbeat := cfg.AgentStreamHeartbeat
+	if agentStreamHeartbeat <= 0 {
+		agentStreamHeartbeat = defaultAgentTurnEventStreamHeartbeatInterval
 	}
 	adminRoute, err := normalizeAdminRouteConfig(cfg.Admin)
 	if err != nil {
@@ -340,6 +352,8 @@ func New(cfg Config) (*Server, error) {
 		authResolvers:          authResolvers,
 		invoker:                cfg.Invoker,
 		pluginInvoker:          pluginInvoker,
+		apiRouteTimeout:        apiRouteTimeout,
+		agentStreamHeartbeat:   agentStreamHeartbeat,
 		defaultConnection:      cfg.DefaultConnection,
 		catalogConnection:      cfg.CatalogConnection,
 		connectionAuth:         cfg.ConnectionAuth,


### PR DESCRIPTION
## Summary

Move the long-lived agent SSE stream outside the generic `/api/v1` 60s timeout while keeping it authenticated. Context cancellation/deadline-style stream closure now exits quietly instead of emitting a public `stream.error` turn event.

## Interface Changes
- New/changed interface: `/api/v1/agent/turns/{turnID}/events/stream` remains the same authenticated SSE endpoint, but it is no longer wrapped by the generic API timeout.
- Example usage: `GET /api/v1/agent/turns/turn-1/events/stream?after=0&limit=100&until=blocked_or_terminal` streams heartbeats/events until the turn blocks, completes, or the client closes.

## Functional/Integration Tests
- Tests added or augmented: `TestAgentTurnEventStreamClosesQuietlyOnContextCancellation`.
- Contract boundary covered: authenticated HTTP/SSE agent event stream route and stream error framing.
- Commands run: `go test ./internal/server -run 'TestAgentTurnEventStream(SendsHeartbeatBeforeEvents|ClosesQuietlyOnContextCancellation)|TestAgentInteractionResolutionAndEventStream'`.

Made with [Cursor](https://cursor.com)