### PR TITLE
Resolve local agent harnesses from server

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -229,9 +229,9 @@ pub struct AgentArgs {
     #[arg(long, conflicts_with = "local")]
     pub cloud: bool,
 
-    /// Gestaltd config path for local agent launch; repeat to layer overrides
-    #[arg(long = "config")]
-    pub config: Vec<String>,
+    /// Agent harness name for local launch; defaults to the server-selected harness
+    #[arg(long)]
+    pub harness: Option<String>,
 
     /// Agent provider name for a new session
     #[arg(long)]
@@ -278,9 +278,9 @@ pub struct AgentDoctorArgs {
     #[arg(long)]
     pub provider: Option<String>,
 
-    /// Gestaltd config path for local agent launch; repeat to layer overrides
-    #[arg(long = "config")]
-    pub config: Vec<String>,
+    /// Agent harness name; defaults to the server-selected harness
+    #[arg(long)]
+    pub harness: Option<String>,
 }
 
 #[derive(Args)]

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1,9 +1,9 @@
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
-use serde::{Deserialize, Deserializer, de::DeserializeOwned};
+use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
 use serde_json::{Map, Value, json};
 use std::io::{self, BufRead, BufReader, IsTerminal, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, ExitStatus, Stdio};
 use std::sync::{
     Arc,
@@ -29,6 +29,7 @@ mod tui;
 
 const SESSIONS_PATH: &str = "/api/v1/agent/sessions";
 const PROVIDERS_PATH: &str = "/api/v1/agent/providers";
+const HARNESSES_RESOLVE_PATH: &str = "/api/v1/agent/harnesses/resolve";
 const TURNS_PATH: &str = "/api/v1/agent/turns";
 const DEFAULT_SESSION_LIST_LIMIT: usize = 50;
 const DEFAULT_EVENT_PAGE_SIZE: u32 = 100;
@@ -36,39 +37,133 @@ const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const EVENT_STREAM_UNTIL_BLOCKED_OR_TERMINAL: &str = "blocked_or_terminal";
 const INTERRUPT_CANCEL_REASON: &str = "operator interrupted";
 
-pub fn launch_local(provider: Option<&str>, config_paths: &[String]) -> Result<()> {
-    run_local_agent_helper("launch", provider, config_paths)
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentHarnessResolveRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    harness: Option<&'a str>,
 }
 
-pub fn doctor_local(provider: Option<&str>, config_paths: &[String]) -> Result<()> {
-    run_local_agent_helper("doctor", provider, config_paths)
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentHarnessPlan {
+    provider: String,
+    #[serde(default)]
+    harness: String,
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: Map<String, Value>,
+    #[serde(default)]
+    working_directory: String,
+    #[serde(default)]
+    required_commands: Vec<String>,
 }
 
-fn run_local_agent_helper(
-    action: &str,
+pub fn launch_local(
+    client: &ApiClient,
     provider: Option<&str>,
-    config_paths: &[String],
+    harness: Option<&str>,
 ) -> Result<()> {
-    let helper = find_gestaltd_helper()?;
-    let mut cmd = ProcessCommand::new(&helper);
-    cmd.arg("agent").arg(action);
-    for config_path in config_paths {
-        cmd.arg("--config").arg(config_path);
+    let plan = resolve_agent_harness(client, provider, harness)?;
+    let prepared = prepare_agent_harness(&plan)?;
+    launch_agent_harness(&plan, &prepared)
+}
+
+pub fn doctor_local(
+    client: &ApiClient,
+    provider: Option<&str>,
+    harness: Option<&str>,
+) -> Result<()> {
+    let plan = resolve_agent_harness(client, provider, harness)?;
+    let _ = prepare_agent_harness(&plan)?;
+    let harness_label = if plan.harness.trim().is_empty() {
+        plan.provider.clone()
+    } else {
+        format!("{}/{}", plan.provider, plan.harness)
+    };
+    println!("agent harness {:?} ok", harness_label);
+    Ok(())
+}
+
+fn resolve_agent_harness(
+    client: &ApiClient,
+    provider: Option<&str>,
+    harness: Option<&str>,
+) -> Result<AgentHarnessPlan> {
+    let body = AgentHarnessResolveRequest { provider, harness };
+    let resp = client
+        .post(HARNESSES_RESOLVE_PATH, &body)
+        .context("failed to resolve agent harness")?;
+    serde_json::from_value(resp).context("invalid agent harness response")
+}
+
+struct PreparedAgentHarness {
+    command: PathBuf,
+    env: Vec<String>,
+    working_directory: Option<PathBuf>,
+}
+
+fn prepare_agent_harness(plan: &AgentHarnessPlan) -> Result<PreparedAgentHarness> {
+    let env = effective_harness_env(&plan.env)?;
+    let working_directory = if plan.working_directory.trim().is_empty() {
+        None
+    } else {
+        let path = PathBuf::from(plan.working_directory.trim());
+        let metadata = std::fs::metadata(&path).with_context(|| {
+            format!(
+                "agent harness working directory {:?} is not accessible",
+                path.display().to_string()
+            )
+        })?;
+        if !metadata.is_dir() {
+            bail!(
+                "agent harness working directory {:?} is not a directory",
+                path.display().to_string()
+            );
+        }
+        Some(path)
+    };
+
+    for required in &plan.required_commands {
+        let required = required.trim();
+        if required.is_empty() {
+            continue;
+        }
+        find_command(required, working_directory.as_deref(), &env)
+            .with_context(|| format!("required command {:?} is not available", required))?;
     }
-    if let Some(provider) = provider {
-        cmd.arg("--provider").arg(provider);
+    let command = find_command(plan.command.trim(), working_directory.as_deref(), &env)
+        .with_context(|| format!("agent harness command {:?} is not available", plan.command))?;
+    Ok(PreparedAgentHarness {
+        command,
+        env: env_list(env),
+        working_directory,
+    })
+}
+
+fn launch_agent_harness(plan: &AgentHarnessPlan, prepared: &PreparedAgentHarness) -> Result<()> {
+    let mut cmd = ProcessCommand::new(&prepared.command);
+    cmd.args(&plan.args);
+    if let Some(working_directory) = &prepared.working_directory {
+        cmd.current_dir(working_directory);
     }
+    cmd.env_clear();
+    cmd.envs(
+        prepared
+            .env
+            .iter()
+            .filter_map(|entry| entry.split_once('=')),
+    );
     let status = cmd
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()
-        .with_context(|| {
-            format!(
-                "failed to start gestaltd local agent helper at {}",
-                helper.display()
-            )
-        })?;
+        .with_context(|| format!("failed to start agent harness {:?}", plan.provider))?;
     if status.success() {
         return Ok(());
     }
@@ -89,22 +184,103 @@ fn helper_exit_code(status: ExitStatus) -> i32 {
     1
 }
 
-fn find_gestaltd_helper() -> Result<PathBuf> {
-    let current_exe = std::env::current_exe().context("failed to resolve current executable")?;
-    if let Some(parent) = current_exe.parent() {
-        let sibling = parent.join(helper_binary_name());
-        if sibling.exists() {
-            return Ok(sibling);
-        }
+fn effective_harness_env(
+    overlay: &Map<String, Value>,
+) -> Result<std::collections::BTreeMap<String, String>> {
+    let mut env: std::collections::BTreeMap<String, String> = std::env::vars().collect();
+    for (key, value) in overlay {
+        let Some(value) = value.as_str() else {
+            bail!("agent harness env {:?} must be a string", key);
+        };
+        env.insert(key.clone(), value.to_string());
     }
-    Ok(PathBuf::from(helper_binary_name()))
+    Ok(env)
 }
 
-fn helper_binary_name() -> &'static str {
-    if cfg!(windows) {
-        "gestaltd.exe"
-    } else {
-        "gestaltd"
+fn env_list(env: std::collections::BTreeMap<String, String>) -> Vec<String> {
+    env.into_iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect()
+}
+
+fn find_command(
+    command: &str,
+    working_directory: Option<&Path>,
+    env: &std::collections::BTreeMap<String, String>,
+) -> Result<PathBuf> {
+    if command.trim().is_empty() {
+        bail!("command is required");
+    }
+    let candidate = PathBuf::from(command);
+    if has_path_separator(command) {
+        let resolved = if candidate.is_absolute() {
+            candidate
+        } else if let Some(working_directory) = working_directory {
+            working_directory.join(candidate)
+        } else {
+            std::env::current_dir()
+                .context("failed to resolve current directory")?
+                .join(candidate)
+        };
+        if is_executable_file(&resolved) {
+            return Ok(resolved);
+        }
+        bail!("{command} not found");
+    }
+
+    let path_value = env.get("PATH").map(String::as_str).unwrap_or("");
+    for dir in std::env::split_paths(path_value) {
+        let dir = if dir.as_os_str().is_empty() {
+            PathBuf::from(".")
+        } else {
+            dir
+        };
+        let dir = if !dir.is_absolute() {
+            working_directory
+                .map(|working_directory| working_directory.join(&dir))
+                .unwrap_or(dir)
+        } else {
+            dir
+        };
+        let resolved = dir.join(command);
+        if is_executable_file(&resolved) {
+            return Ok(resolved);
+        }
+        #[cfg(windows)]
+        {
+            let resolved = dir.join(format!("{command}.exe"));
+            if is_executable_file(&resolved) {
+                return Ok(resolved);
+            }
+        }
+    }
+    bail!("{command} not found in PATH");
+}
+
+fn has_path_separator(command: &str) -> bool {
+    command.contains('/')
+        || if cfg!(windows) {
+            command.contains('\\')
+        } else {
+            false
+        }
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
     }
 }
 

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -132,25 +132,21 @@ fn run() -> anyhow::Result<()> {
 fn dispatch_agent(
     args: AgentArgs,
     url: Option<&str>,
-    url_was_explicit: bool,
+    _url_was_explicit: bool,
     format: gestalt::output::Format,
 ) -> anyhow::Result<()> {
-    if args.local && url_was_explicit {
-        anyhow::bail!("--local cannot be used with --url; omit --url or use --cloud");
-    }
-
     if matches!(&args.command, Some(AgentCommands::Doctor(_))) {
         reject_agent_doctor_root_options(&args)?;
-        if url_was_explicit {
-            anyhow::bail!("agent doctor checks local harness configuration; omit --url");
-        }
         if args.cloud {
-            anyhow::bail!("agent doctor checks local harness configuration; omit --cloud");
+            anyhow::bail!("agent doctor checks the local agent harness; omit --cloud");
         }
         if let Some(AgentCommands::Doctor(doctor)) = args.command {
-            let mut config_paths = args.config;
-            config_paths.extend(doctor.config);
-            return commands::agents::doctor_local(doctor.provider.as_deref(), &config_paths);
+            let client = ApiClient::from_env(url)?;
+            return commands::agents::doctor_local(
+                &client,
+                doctor.provider.as_deref(),
+                doctor.harness.as_deref(),
+            );
         }
         unreachable!();
     }
@@ -172,13 +168,18 @@ fn dispatch_agent(
         };
     }
 
-    let run_local = args.local || (!args.cloud && !url_was_explicit);
+    let run_local = args.local || !args.cloud;
     if run_local {
         reject_local_agent_options(&args)?;
-        return commands::agents::launch_local(args.provider.as_deref(), &args.config);
+        let client = ApiClient::from_env(url)?;
+        return commands::agents::launch_local(
+            &client,
+            args.provider.as_deref(),
+            args.harness.as_deref(),
+        );
     }
-    if !args.config.is_empty() {
-        anyhow::bail!("--config is only supported for local agent launch and `agent doctor`");
+    if args.harness.is_some() {
+        anyhow::bail!("--harness is only supported for local agent launch and `agent doctor`");
     }
     let client = ApiClient::from_env(url)?;
     commands::agents::run_interactive(&client, &args)
@@ -187,6 +188,9 @@ fn dispatch_agent(
 fn reject_agent_doctor_root_options(args: &AgentArgs) -> anyhow::Result<()> {
     if args.provider.is_some() {
         anyhow::bail!("--provider for agent doctor must be passed after `doctor`");
+    }
+    if args.harness.is_some() {
+        anyhow::bail!("--harness for agent doctor must be passed after `doctor`");
     }
     if args.model.is_some() {
         anyhow::bail!("--model is not supported with agent doctor");
@@ -228,8 +232,8 @@ fn reject_local_agent_options(args: &AgentArgs) -> anyhow::Result<()> {
 }
 
 fn reject_agent_interactive_options(args: &AgentArgs) -> anyhow::Result<()> {
-    if !args.config.is_empty() {
-        anyhow::bail!("--config is only supported for local agent launch and `agent doctor`");
+    if args.harness.is_some() {
+        anyhow::bail!("--harness is only supported for local agent launch and `agent doctor`");
     }
     if args.model.is_some() {
         anyhow::bail!("--model must be passed before a prompt or after `agent resume`");

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -10,24 +10,13 @@ use std::time::{Duration, Instant};
 use support::*;
 
 #[cfg(unix)]
-fn write_fake_gestaltd(dir: &Path, script: &str) {
+fn write_executable(path: &Path, script: &str) {
     use std::os::unix::fs::PermissionsExt;
 
-    let path = dir.join("gestaltd");
-    std::fs::write(&path, script).unwrap();
-    let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+    std::fs::write(path, script).unwrap();
+    let mut permissions = std::fs::metadata(path).unwrap().permissions();
     permissions.set_mode(0o755);
     std::fs::set_permissions(path, permissions).unwrap();
-}
-
-fn prepend_path(dir: &Path) -> String {
-    let existing = std::env::var_os("PATH").unwrap_or_default();
-    let mut paths = vec![dir.to_path_buf()];
-    paths.extend(std::env::split_paths(&existing));
-    std::env::join_paths(paths)
-        .unwrap()
-        .to_string_lossy()
-        .into_owned()
 }
 
 const SESSION_JSON: &str = r#"{
@@ -717,7 +706,14 @@ fn test_cli_runs_interactive_agent_session() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
+        .args([
+            "agent",
+            "--cloud",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ])
         .args(["--tool", "tracker:searchItems"])
         .write_stdin("hello\\\nthere\n")
         .assert()
@@ -2536,106 +2532,157 @@ fn test_cli_resume_fails_without_active_agent_session() {
 
 #[test]
 #[cfg(unix)]
-fn test_cli_agent_defaults_to_local_helper_and_preserves_status() {
+fn test_cli_agent_defaults_to_resolved_harness_and_preserves_status() {
     let home = tempfile::tempdir().unwrap();
-    let helper_dir = tempfile::tempdir().unwrap();
-    let args_path = home.path().join("helper-args.txt");
-    write_fake_gestaltd(
-        helper_dir.path(),
+    let harness_path = home.path().join("harness.sh");
+    write_executable(
+        &harness_path,
         r#"#!/bin/sh
-printf 'helper stdout\n'
-printf 'helper stderr\n' >&2
-printf '%s\n' "$*" > "$GESTALT_HELPER_ARGS"
+printf 'harness stdout\n'
+printf 'harness stderr\n' >&2
+printf 'value=%s\n' "$HARNESS_VALUE"
 exit 7
 "#,
     );
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/harnesses/resolve",
+        StatusCode::OK
+    )
+    .match_body(Matcher::JsonString(
+        r#"{"provider":"local","harness":"fast"}"#.to_string(),
+    ))
+    .with_body(format!(
+        r#"{{
+            "provider":"local",
+            "harness":"fast",
+            "command":{},
+            "args":[],
+            "env":{{"HARNESS_VALUE":"from-server"}}
+        }}"#,
+        serde_json::to_string(harness_path.to_str().unwrap()).unwrap()
+    ))
+    .create();
 
     cli_command(home.path())
-        .env("PATH", prepend_path(helper_dir.path()))
-        .env("GESTALT_HELPER_ARGS", &args_path)
-        .args(["agent", "--config", "config.yaml", "--provider", "local"])
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args(["agent", "--provider", "local", "--harness", "fast"])
         .assert()
         .code(7)
-        .stdout(predicate::str::contains("helper stdout"))
-        .stderr(predicate::str::contains("helper stderr"));
+        .stdout(predicate::str::contains("harness stdout"))
+        .stdout(predicate::str::contains("value=from-server"))
+        .stderr(predicate::str::contains("harness stderr"));
 
-    let helper_args = std::fs::read_to_string(args_path).unwrap();
-    assert_eq!(
-        helper_args,
-        "agent launch --config config.yaml --provider local\n"
-    );
+    mock.assert();
 }
 
 #[test]
 #[cfg(unix)]
-fn test_cli_agent_default_local_ignores_gestalt_url_env() {
+fn test_cli_agent_default_local_uses_gestalt_url_env() {
     let home = tempfile::tempdir().unwrap();
-    let helper_dir = tempfile::tempdir().unwrap();
-    write_fake_gestaltd(
-        helper_dir.path(),
+    let harness_path = home.path().join("harness.sh");
+    write_executable(
+        &harness_path,
         r#"#!/bin/sh
-printf 'local helper\n'
+printf 'local harness\n'
 exit 0
 "#,
     );
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/harnesses/resolve",
+        StatusCode::OK
+    )
+    .match_body(Matcher::JsonString(r#"{}"#.to_string()))
+    .with_body(format!(
+        r#"{{"provider":"default-agent","harness":"default","command":{}}}"#,
+        serde_json::to_string(harness_path.to_str().unwrap()).unwrap()
+    ))
+    .create();
 
     cli_command(home.path())
-        .env("PATH", prepend_path(helper_dir.path()))
-        .env("GESTALT_URL", "http://127.0.0.1:9")
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .env("GESTALT_URL", server.url())
         .args(["agent"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("local helper"));
+        .stdout(predicate::str::contains("local harness"));
+
+    mock.assert();
 }
 
 #[test]
 #[cfg(unix)]
-fn test_cli_agent_doctor_allows_provider_after_subcommand() {
+fn test_cli_agent_doctor_allows_provider_and_harness_after_subcommand() {
     let home = tempfile::tempdir().unwrap();
-    let helper_dir = tempfile::tempdir().unwrap();
-    let args_path = home.path().join("doctor-args.txt");
-    write_fake_gestaltd(
-        helper_dir.path(),
-        r#"#!/bin/sh
-printf '%s\n' "$*" > "$GESTALT_HELPER_ARGS"
-exit 0
-"#,
-    );
+    let harness_path = home.path().join("harness.sh");
+    write_executable(&harness_path, "#!/bin/sh\nexit 0\n");
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/harnesses/resolve",
+        StatusCode::OK
+    )
+    .match_body(Matcher::JsonString(
+        r#"{"provider":"local","harness":"fast"}"#.to_string(),
+    ))
+    .with_body(format!(
+        r#"{{"provider":"local","harness":"fast","command":{}}}"#,
+        serde_json::to_string(harness_path.to_str().unwrap()).unwrap()
+    ))
+    .create();
 
     cli_command(home.path())
-        .env("PATH", prepend_path(helper_dir.path()))
-        .env("GESTALT_HELPER_ARGS", &args_path)
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
         .args([
             "agent",
             "doctor",
             "--provider",
             "local",
-            "--config",
-            "config.yaml",
+            "--harness",
+            "fast",
         ])
         .assert()
-        .success();
+        .success()
+        .stdout(predicate::str::contains("agent harness \"local/fast\" ok"));
 
-    let helper_args = std::fs::read_to_string(args_path).unwrap();
-    assert_eq!(
-        helper_args,
-        "agent doctor --config config.yaml --provider local\n"
-    );
+    mock.assert();
 }
 
 #[test]
-fn test_cli_agent_local_reports_missing_helper() {
+fn test_cli_agent_local_reports_missing_harness_command() {
     let home = tempfile::tempdir().unwrap();
-    let empty_path = tempfile::tempdir().unwrap();
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/harnesses/resolve",
+        StatusCode::OK
+    )
+    .with_body(r#"{"provider":"local","harness":"default","command":"missing-harness-command"}"#)
+    .create();
 
     cli_command(home.path())
-        .env("PATH", empty_path.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
         .args(["agent"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "failed to start gestaltd local agent helper",
+            "agent harness command \"missing-harness-command\" is not available",
         ));
+
+    mock.assert();
 }
 
 #[test]

--- a/gestaltd/internal/config/agent_harness.go
+++ b/gestaltd/internal/config/agent_harness.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// DefaultAgentHarnessName is the conventional harness name selected when a
+// provider has a single legacy localHarness or an explicit default harness.
+const DefaultAgentHarnessName = "default"
+
+// EffectiveAgentHarness is the resolved provider and harness launch
+// configuration for an agent provider.
+type EffectiveAgentHarness struct {
+	ProviderName string
+	HarnessName  string
+	Harness      ProviderEntryHarnessConfig
+}
+
+// ResolveProviderEntryAgentHarness selects a named or default harness from an
+// agent provider entry and returns a cloned launch configuration.
+func ResolveProviderEntryAgentHarness(providerName string, entry *ProviderEntry, harnessName string) (EffectiveAgentHarness, error) {
+	providerName = strings.TrimSpace(providerName)
+	harnessName = strings.TrimSpace(harnessName)
+	if entry == nil {
+		return EffectiveAgentHarness{}, fmt.Errorf("providers.agent.%s is not configured", providerName)
+	}
+
+	selectedName := harnessName
+	if selectedName == "" {
+		selectedName = strings.TrimSpace(entry.DefaultHarness)
+	}
+	if selectedName == "" && entry.Harnesses != nil {
+		if _, ok := entry.Harnesses[DefaultAgentHarnessName]; ok {
+			selectedName = DefaultAgentHarnessName
+		}
+	}
+	if selectedName == "" && len(entry.Harnesses) == 1 {
+		for name := range entry.Harnesses {
+			selectedName = strings.TrimSpace(name)
+		}
+	}
+	if selectedName == "" && entry.LocalHarness != nil {
+		selectedName = DefaultAgentHarnessName
+	}
+	if selectedName == "" {
+		return EffectiveAgentHarness{}, fmt.Errorf("providers.agent.%s.harnesses is required for agent harness launch", providerName)
+	}
+
+	var harness *ProviderEntryHarnessConfig
+	if entry.Harnesses != nil {
+		harness = entry.Harnesses[selectedName]
+	}
+	if harness == nil && selectedName == DefaultAgentHarnessName && entry.LocalHarness != nil {
+		harness = entry.LocalHarness
+	}
+	if harness == nil {
+		return EffectiveAgentHarness{}, fmt.Errorf("providers.agent.%s.harnesses.%s is not configured", providerName, selectedName)
+	}
+
+	cloned := *harness
+	cloned.Args = slices.Clone(harness.Args)
+	cloned.Env = maps.Clone(harness.Env)
+	cloned.RequiredCommands = slices.Clone(harness.RequiredCommands)
+	if strings.TrimSpace(cloned.Command) == "" {
+		return EffectiveAgentHarness{}, fmt.Errorf("providers.agent.%s.harnesses.%s.command is required", providerName, selectedName)
+	}
+	return EffectiveAgentHarness{
+		ProviderName: providerName,
+		HarnessName:  selectedName,
+		Harness:      cloned,
+	}, nil
+}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -387,18 +387,20 @@ func (g GitHubReleaseSourceDef) Location() string {
 
 // ProviderEntry is the universal configuration for any provider.
 type ProviderEntry struct {
-	Source          ProviderSource                   `yaml:"source"`
-	Config          yaml.Node                        `yaml:"config,omitempty"`
-	Default         bool                             `yaml:"default,omitempty"`
-	Env             map[string]string                `yaml:"env,omitempty"`
-	Egress          *ProviderEgressConfig            `yaml:"egress,omitempty"`
-	DisplayName     string                           `yaml:"displayName,omitempty"`
-	Description     string                           `yaml:"description,omitempty"`
-	IconFile        string                           `yaml:"iconFile,omitempty"`
-	LocalHarness    *ProviderEntryLocalHarnessConfig `yaml:"localHarness,omitempty"`
-	RouteAuth       *RouteAuthDef                    `yaml:"-"`
-	SecuritySchemes map[string]*HTTPSecurityScheme   `yaml:"securitySchemes,omitempty"`
-	HTTP            map[string]*HTTPBinding          `yaml:"http,omitempty"`
+	Source          ProviderSource                         `yaml:"source"`
+	Config          yaml.Node                              `yaml:"config,omitempty"`
+	Default         bool                                   `yaml:"default,omitempty"`
+	Env             map[string]string                      `yaml:"env,omitempty"`
+	Egress          *ProviderEgressConfig                  `yaml:"egress,omitempty"`
+	DisplayName     string                                 `yaml:"displayName,omitempty"`
+	Description     string                                 `yaml:"description,omitempty"`
+	IconFile        string                                 `yaml:"iconFile,omitempty"`
+	DefaultHarness  string                                 `yaml:"defaultHarness,omitempty"`
+	Harnesses       map[string]*ProviderEntryHarnessConfig `yaml:"harnesses,omitempty"`
+	LocalHarness    *ProviderEntryHarnessConfig            `yaml:"localHarness,omitempty"`
+	RouteAuth       *RouteAuthDef                          `yaml:"-"`
+	SecuritySchemes map[string]*HTTPSecurityScheme         `yaml:"securitySchemes,omitempty"`
+	HTTP            map[string]*HTTPBinding                `yaml:"http,omitempty"`
 	// AuthorizationPolicy binds this provider to a shared subject access policy.
 	AuthorizationPolicy string                  `yaml:"authorizationPolicy,omitempty"`
 	Dev                 *ProviderEntryDevConfig `yaml:"dev,omitempty"`
@@ -438,15 +440,19 @@ type ProviderEntry struct {
 
 type providerEntryFields ProviderEntry
 
-// ProviderEntryLocalHarnessConfig describes the local process harness used to
-// start an agent provider without the gestaltd server runtime.
-type ProviderEntryLocalHarnessConfig struct {
+// ProviderEntryHarnessConfig describes a process harness that can start an
+// agent provider outside gestaltd's hosted runtime.
+type ProviderEntryHarnessConfig struct {
 	Command          string            `yaml:"command,omitempty"`
 	Args             []string          `yaml:"args,omitempty"`
 	Env              map[string]string `yaml:"env,omitempty"`
 	WorkingDirectory string            `yaml:"workingDirectory,omitempty"`
 	RequiredCommands []string          `yaml:"requiredCommands,omitempty"`
 }
+
+// ProviderEntryLocalHarnessConfig is kept as a compatibility alias for configs
+// that still use providers.agent.<name>.localHarness.
+type ProviderEntryLocalHarnessConfig = ProviderEntryHarnessConfig
 
 type ProviderEntryDevConfig struct {
 	Attach ProviderEntryDevAttachConfig `yaml:"attach,omitempty"`
@@ -891,12 +897,24 @@ func providerEntryFieldsFromEntry(e ProviderEntry) providerEntryFields {
 	e.Egress = cloneProviderEgressConfig(e.Egress)
 	e.Execution = cloneExecutionConfig(e.Execution)
 	e.Dev = cloneProviderEntryDevConfig(e.Dev)
-	e.LocalHarness = cloneProviderEntryLocalHarnessConfig(e.LocalHarness)
+	e.Harnesses = cloneProviderEntryHarnessConfigMap(e.Harnesses)
+	e.LocalHarness = cloneProviderEntryHarnessConfig(e.LocalHarness)
 	normalizeProviderEntryAliases(&e)
 	return providerEntryFields(e)
 }
 
-func cloneProviderEntryLocalHarnessConfig(src *ProviderEntryLocalHarnessConfig) *ProviderEntryLocalHarnessConfig {
+func cloneProviderEntryHarnessConfigMap(src map[string]*ProviderEntryHarnessConfig) map[string]*ProviderEntryHarnessConfig {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]*ProviderEntryHarnessConfig, len(src))
+	for name, harness := range src {
+		dst[name] = cloneProviderEntryHarnessConfig(harness)
+	}
+	return dst
+}
+
+func cloneProviderEntryHarnessConfig(src *ProviderEntryHarnessConfig) *ProviderEntryHarnessConfig {
 	if src == nil {
 		return nil
 	}
@@ -929,11 +947,27 @@ func normalizeProviderEntryAliases(entry *ProviderEntry) {
 	if entry.Dev != nil {
 		entry.Dev.Attach.AllowedRoles = trimStringSlice(entry.Dev.Attach.AllowedRoles)
 	}
-	if entry.LocalHarness != nil {
-		entry.LocalHarness.Command = strings.TrimSpace(entry.LocalHarness.Command)
-		entry.LocalHarness.WorkingDirectory = strings.TrimSpace(entry.LocalHarness.WorkingDirectory)
-		entry.LocalHarness.RequiredCommands = trimStringSlice(entry.LocalHarness.RequiredCommands)
+	entry.DefaultHarness = strings.TrimSpace(entry.DefaultHarness)
+	normalizeProviderEntryHarness(entry.LocalHarness)
+	for name, harness := range entry.Harnesses {
+		trimmed := strings.TrimSpace(name)
+		if trimmed != name {
+			delete(entry.Harnesses, name)
+			if trimmed != "" {
+				entry.Harnesses[trimmed] = harness
+			}
+		}
+		normalizeProviderEntryHarness(harness)
 	}
+}
+
+func normalizeProviderEntryHarness(harness *ProviderEntryHarnessConfig) {
+	if harness == nil {
+		return
+	}
+	harness.Command = strings.TrimSpace(harness.Command)
+	harness.WorkingDirectory = strings.TrimSpace(harness.WorkingDirectory)
+	harness.RequiredCommands = trimStringSlice(harness.RequiredCommands)
 }
 
 func trimStringSlice(values []string) []string {
@@ -1864,13 +1898,14 @@ func LoadPartialAllowMissingEnvPaths(paths []string) (*Config, error) {
 	return loadWithLookupPathsValidation(paths, os.LookupEnv, true, false)
 }
 
-// ValidateSelectedAgentLocalHarnessEnvPaths fails if the selected local agent
-// harness references missing environment variables.
-func ValidateSelectedAgentLocalHarnessEnvPaths(paths []string, providerName string) error {
+// ValidateSelectedAgentHarnessEnvPaths fails if the selected agent harness
+// references missing environment variables.
+func ValidateSelectedAgentHarnessEnvPaths(paths []string, providerName string, harnessName string) error {
 	providerName = strings.TrimSpace(providerName)
 	if providerName == "" {
 		return nil
 	}
+	harnessName = strings.TrimSpace(harnessName)
 	missingEnvSentinelContext, err := newMissingEnvSentinelPrefix()
 	if err != nil {
 		return err
@@ -1882,12 +1917,47 @@ func ValidateSelectedAgentLocalHarnessEnvPaths(paths []string, providerName stri
 	providers := mappingValueNode(&root, "providers")
 	agentProviders := mappingValueNode(providers, "agent")
 	entry := mappingValueNode(agentProviders, providerName)
-	localHarness := mappingValueNode(entry, "localHarness")
-	if localHarness == nil {
+	harness := selectedAgentHarnessNode(entry, harnessName)
+	if harness == nil {
 		return nil
 	}
-	if firstMissing := firstMissingEnvSentinel(localHarness, missingEnvSentinelContext); firstMissing != "" {
-		return fmt.Errorf("expanding providers.agent.%s.localHarness environment variables: environment variable %q not set; use ${%s:-} to allow an empty default", providerName, firstMissing, firstMissing)
+	if firstMissing := firstMissingEnvSentinel(harness, missingEnvSentinelContext); firstMissing != "" {
+		return fmt.Errorf("expanding providers.agent.%s harness environment variables: environment variable %q not set; use ${%s:-} to allow an empty default", providerName, firstMissing, firstMissing)
+	}
+	return nil
+}
+
+// ValidateSelectedAgentLocalHarnessEnvPaths preserves the old helper API.
+func ValidateSelectedAgentLocalHarnessEnvPaths(paths []string, providerName string) error {
+	return ValidateSelectedAgentHarnessEnvPaths(paths, providerName, "")
+}
+
+func selectedAgentHarnessNode(entry *yaml.Node, harnessName string) *yaml.Node {
+	if entry == nil {
+		return nil
+	}
+	harnessName = strings.TrimSpace(harnessName)
+	if harnessName == "" {
+		if defaultHarness := mappingValueNode(entry, "defaultHarness"); defaultHarness != nil && defaultHarness.Kind == yaml.ScalarNode {
+			harnessName = strings.TrimSpace(defaultHarness.Value)
+		}
+	}
+	harnesses := mappingValueNode(entry, "harnesses")
+	if harnessName == "" && harnesses != nil {
+		if defaultHarness := mappingValueNode(harnesses, DefaultAgentHarnessName); defaultHarness != nil {
+			return defaultHarness
+		}
+		if len(harnesses.Content) == 2 {
+			return harnesses.Content[1]
+		}
+	}
+	if harnessName != "" && harnesses != nil {
+		if harness := mappingValueNode(harnesses, harnessName); harness != nil {
+			return harness
+		}
+	}
+	if harnessName == "" || harnessName == DefaultAgentHarnessName {
+		return mappingValueNode(entry, "localHarness")
 	}
 	return nil
 }
@@ -3040,6 +3110,11 @@ func resolveRelativePathsInEntry(kind string, entry map[string]any, baseDir stri
 	if localHarness, ok := entry["localHarness"].(map[string]any); ok {
 		resolveRelativeStringField(localHarness, "workingDirectory", baseDir)
 	}
+	if harnesses, ok := entry["harnesses"].(map[string]any); ok {
+		for _, harness := range mapValues(harnesses) {
+			resolveRelativeStringField(harness, "workingDirectory", baseDir)
+		}
+	}
 	if source, ok := entry["source"].(map[string]any); ok {
 		resolveRelativeStringField(source, "path", baseDir)
 		return
@@ -3104,6 +3179,11 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 		entry.Source.metadataPath = resolveRelativePath(baseDir, entry.Source.metadataPath)
 		if entry.LocalHarness != nil {
 			entry.LocalHarness.WorkingDirectory = resolveRelativePath(baseDir, entry.LocalHarness.WorkingDirectory)
+		}
+		for _, harness := range entry.Harnesses {
+			if harness != nil {
+				harness.WorkingDirectory = resolveRelativePath(baseDir, harness.WorkingDirectory)
+			}
 		}
 	}
 

--- a/gestaltd/internal/daemon/agent_local.go
+++ b/gestaltd/internal/daemon/agent_local.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,11 +38,13 @@ func ExitCode(err error) (int, bool) {
 type localAgentCommandOptions struct {
 	ConfigPaths []string
 	Provider    string
+	Harness     string
 	DryRun      bool
 }
 
 type localAgentHarnessPlan struct {
 	ProviderName    string
+	HarnessName     string
 	Harness         config.ProviderEntryLocalHarnessConfig
 	WorkingDir      string
 	Env             map[string]string
@@ -92,7 +93,7 @@ func runAgentDoctor(args []string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "local agent harness %q ok\n", plan.ProviderName)
+	_, _ = fmt.Fprintf(os.Stdout, "agent harness %q ok\n", plan.ProviderName+"/"+plan.HarnessName)
 	return nil
 }
 
@@ -102,6 +103,7 @@ func parseLocalAgentOptions(name string, usage func(io.Writer), args []string, a
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	provider := fs.String("provider", "", "agent provider name; defaults to the configured default")
+	harness := fs.String("harness", "", "agent harness name; defaults to the configured default")
 	dryRun := false
 	if allowDryRun {
 		fs.BoolVar(&dryRun, "dry-run", false, "print the resolved local harness command without starting it")
@@ -115,6 +117,7 @@ func parseLocalAgentOptions(name string, usage func(io.Writer), args []string, a
 	return localAgentCommandOptions{
 		ConfigPaths: []string(configPaths),
 		Provider:    *provider,
+		Harness:     *harness,
 		DryRun:      dryRun,
 	}, nil
 }
@@ -132,44 +135,40 @@ func resolveLocalAgentHarness(opts localAgentCommandOptions) (localAgentHarnessP
 	if entry == nil {
 		return localAgentHarnessPlan{}, fmt.Errorf("no agent provider configured")
 	}
-	if err := config.ValidateSelectedAgentLocalHarnessEnvPaths(configPaths, providerName); err != nil {
+	if err := config.ValidateSelectedAgentHarnessEnvPaths(configPaths, providerName, opts.Harness); err != nil {
 		return localAgentHarnessPlan{}, err
 	}
-	if entry.LocalHarness == nil {
-		return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness is required for local agent launch", providerName)
+	effective, err := config.ResolveProviderEntryAgentHarness(providerName, entry, opts.Harness)
+	if err != nil {
+		return localAgentHarnessPlan{}, err
 	}
-	harness := *entry.LocalHarness
-	harness.Args = slices.Clone(entry.LocalHarness.Args)
-	harness.Env = maps.Clone(entry.LocalHarness.Env)
-	harness.RequiredCommands = slices.Clone(entry.LocalHarness.RequiredCommands)
-	if harness.Command == "" {
-		return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness.command is required", providerName)
-	}
+	harness := effective.Harness
 
 	workingDir := strings.TrimSpace(harness.WorkingDirectory)
 	if workingDir != "" {
 		info, err := os.Stat(workingDir)
 		if err != nil {
-			return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness.workingDirectory: %w", providerName, err)
+			return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.harnesses.%s.workingDirectory: %w", providerName, effective.HarnessName, err)
 		}
 		if !info.IsDir() {
-			return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness.workingDirectory %q is not a directory", providerName, workingDir)
+			return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.harnesses.%s.workingDirectory %q is not a directory", providerName, effective.HarnessName, workingDir)
 		}
 	}
 
 	env := effectiveEnvMap(harness.Env)
 	for _, required := range harness.RequiredCommands {
 		if _, err := lookPathWithEnv(required, workingDir, env); err != nil {
-			return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness.requiredCommands: %w", providerName, err)
+			return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.harnesses.%s.requiredCommands: %w", providerName, effective.HarnessName, err)
 		}
 	}
 	resolvedCommand, err := lookPathWithEnv(harness.Command, workingDir, env)
 	if err != nil {
-		return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.localHarness.command: %w", providerName, err)
+		return localAgentHarnessPlan{}, fmt.Errorf("providers.agent.%s.harnesses.%s.command: %w", providerName, effective.HarnessName, err)
 	}
 
 	return localAgentHarnessPlan{
 		ProviderName:    providerName,
+		HarnessName:     effective.HarnessName,
 		Harness:         harness,
 		WorkingDir:      workingDir,
 		Env:             env,
@@ -198,6 +197,7 @@ func launchLocalAgentHarness(plan localAgentHarnessPlan) error {
 func printLocalAgentDryRun(plan localAgentHarnessPlan) error {
 	payload := struct {
 		Provider         string            `json:"provider"`
+		Harness          string            `json:"harness,omitempty"`
 		Command          string            `json:"command"`
 		ResolvedCommand  string            `json:"resolvedCommand"`
 		Args             []string          `json:"args,omitempty"`
@@ -205,6 +205,7 @@ func printLocalAgentDryRun(plan localAgentHarnessPlan) error {
 		Env              map[string]string `json:"env,omitempty"`
 	}{
 		Provider:         plan.ProviderName,
+		Harness:          plan.HarnessName,
 		Command:          plan.Harness.Command,
 		ResolvedCommand:  plan.ResolvedCommand,
 		Args:             plan.Harness.Args,
@@ -346,27 +347,28 @@ func checkExecutable(path string) error {
 
 func printAgentUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd agent launch [--config PATH]... [--provider NAME] [--dry-run]")
-	writeUsageLine(w, "  gestaltd agent doctor [--config PATH]... [--provider NAME]")
+	writeUsageLine(w, "  gestaltd agent launch [--config PATH]... [--provider NAME] [--harness NAME] [--dry-run]")
+	writeUsageLine(w, "  gestaltd agent doctor [--config PATH]... [--provider NAME] [--harness NAME]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
-	writeUsageLine(w, "  launch      Start the selected provider's configured local agent harness")
-	writeUsageLine(w, "  doctor      Check that the selected local agent harness can be started")
+	writeUsageLine(w, "  launch      Start the selected provider's configured agent harness")
+	writeUsageLine(w, "  doctor      Check that the selected agent harness can be started")
 }
 
 func printAgentLaunchUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd agent launch [--config PATH]... [--provider NAME] [--dry-run]")
+	writeUsageLine(w, "  gestaltd agent launch [--config PATH]... [--provider NAME] [--harness NAME] [--dry-run]")
 	writeUsageLine(w, "")
-	writeUsageLine(w, "Start the selected provider's configured local agent harness.")
-	writeUsageLine(w, "Only providers.agent.<name>.localHarness is used; no server, session,")
+	writeUsageLine(w, "Start the selected provider's configured agent harness.")
+	writeUsageLine(w, "Only providers.agent.<name>.harnesses is used; legacy localHarness")
+	writeUsageLine(w, "is also accepted. No server, session,")
 	writeUsageLine(w, "persistence, runtime, tool grant, or AgentProvider RPC stack is started.")
 }
 
 func printAgentDoctorUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd agent doctor [--config PATH]... [--provider NAME]")
+	writeUsageLine(w, "  gestaltd agent doctor [--config PATH]... [--provider NAME] [--harness NAME]")
 	writeUsageLine(w, "")
-	writeUsageLine(w, "Check the selected provider's configured local agent harness command,")
+	writeUsageLine(w, "Check the selected provider's configured agent harness command,")
 	writeUsageLine(w, "working directory, environment overlay, and requiredCommands.")
 }

--- a/gestaltd/internal/daemon/agent_local_test.go
+++ b/gestaltd/internal/daemon/agent_local_test.go
@@ -46,6 +46,7 @@ providers:
 	}
 	var payload struct {
 		Provider         string            `json:"provider"`
+		Harness          string            `json:"harness"`
 		Command          string            `json:"command"`
 		ResolvedCommand  string            `json:"resolvedCommand"`
 		Args             []string          `json:"args"`
@@ -57,6 +58,9 @@ providers:
 	}
 	if payload.Provider != "local" {
 		t.Fatalf("provider = %q, want local", payload.Provider)
+	}
+	if payload.Harness != "default" {
+		t.Fatalf("harness = %q, want default", payload.Harness)
 	}
 	if payload.Command != "/bin/sh" || payload.ResolvedCommand != "/bin/sh" {
 		t.Fatalf("command = (%q, %q), want /bin/sh", payload.Command, payload.ResolvedCommand)
@@ -157,7 +161,7 @@ providers:
 	if err == nil {
 		t.Fatalf("agent doctor unexpectedly succeeded:\n%s", out)
 	}
-	if !strings.Contains(string(out), "localHarness.requiredCommands") ||
+	if !strings.Contains(string(out), "harnesses.default.requiredCommands") ||
 		!strings.Contains(string(out), "definitely-missing-gestalt-agent-command") {
 		t.Fatalf("doctor output missing required command failure:\n%s", out)
 	}
@@ -196,7 +200,7 @@ providers:
 		t.Fatalf("agent launch unexpectedly succeeded:\n%s", out)
 	}
 	got := string(out)
-	if !strings.Contains(got, "providers.agent.local.localHarness") ||
+	if !strings.Contains(got, "providers.agent.local harness") ||
 		!strings.Contains(got, missingEnv) ||
 		strings.Contains(got, "GESTALT_TEST_MISSING_UNSELECTED_HARNESS_ENV") {
 		t.Fatalf("missing env output = %s", out)

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -1179,6 +1179,88 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestAgentHarnessResolveUsesDefaultAndNamedHarness(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAgentProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		services := testutil.NewStubServices(t)
+		agentControl := &stubAgentControl{defaultProviderName: "managed", provider: provider}
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-harness" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "ada@example.com", DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Agent = agentControl
+		cfg.AgentDefs = map[string]*config.ProviderEntry{
+			"managed": {
+				DefaultHarness: "default",
+				Harnesses: map[string]*config.ProviderEntryHarnessConfig{
+					"default": {
+						Command:          "hermes",
+						Args:             []string{"acp"},
+						Env:              map[string]string{"OPENAI_BASE_URL": "https://example.test"},
+						WorkingDirectory: "/workspace/default",
+						RequiredCommands: []string{"hermes"},
+					},
+					"no-tools": {
+						Command: "hermes",
+						Args:    []string{"acp", "--no-tools"},
+					},
+				},
+			},
+		}
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:     agentControl,
+			RunGrants: newServerTestAgentRunGrants(t),
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	defaultReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/harnesses/resolve", bytes.NewBufferString(`{}`))
+	defaultReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-harness"})
+	defaultResp, err := http.DefaultClient.Do(defaultReq)
+	if err != nil {
+		t.Fatalf("resolve default harness: %v", err)
+	}
+	defer func() { _ = defaultResp.Body.Close() }()
+	if defaultResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(defaultResp.Body)
+		t.Fatalf("resolve default harness status = %d body=%s, want 200", defaultResp.StatusCode, body)
+	}
+	var defaultPlan map[string]any
+	if err := json.NewDecoder(defaultResp.Body).Decode(&defaultPlan); err != nil {
+		t.Fatalf("decode default plan: %v", err)
+	}
+	if defaultPlan["provider"] != "managed" || defaultPlan["harness"] != "default" || defaultPlan["command"] != "hermes" {
+		t.Fatalf("default plan = %#v", defaultPlan)
+	}
+
+	namedReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/harnesses/resolve", bytes.NewBufferString(`{"provider":"managed","harness":"no-tools"}`))
+	namedReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-harness"})
+	namedResp, err := http.DefaultClient.Do(namedReq)
+	if err != nil {
+		t.Fatalf("resolve named harness: %v", err)
+	}
+	defer func() { _ = namedResp.Body.Close() }()
+	if namedResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(namedResp.Body)
+		t.Fatalf("resolve named harness status = %d body=%s, want 200", namedResp.StatusCode, body)
+	}
+	var namedPlan map[string]any
+	if err := json.NewDecoder(namedResp.Body).Decode(&namedPlan); err != nil {
+		t.Fatalf("decode named plan: %v", err)
+	}
+	if namedPlan["harness"] != "no-tools" {
+		t.Fatalf("named plan = %#v, want no-tools harness", namedPlan)
+	}
+}
+
 func TestAgentTurnToolRefsDefaultBroadAndExplicitEmptyNone(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
@@ -146,6 +147,21 @@ type agentProviderCapabilitiesInfo struct {
 	ReasoningSummaries   bool     `json:"reasoningSummaries,omitempty"`
 	BoundedListHydration bool     `json:"boundedListHydration,omitempty"`
 	SupportedToolSources []string `json:"supportedToolSources,omitempty"`
+}
+
+type agentHarnessResolveRequest struct {
+	ProviderName string `json:"provider,omitempty"`
+	HarnessName  string `json:"harness,omitempty"`
+}
+
+type agentHarnessPlanInfo struct {
+	Provider         string            `json:"provider"`
+	Harness          string            `json:"harness,omitempty"`
+	Command          string            `json:"command"`
+	Args             []string          `json:"args,omitempty"`
+	Env              map[string]string `json:"env,omitempty"`
+	WorkingDirectory string            `json:"workingDirectory,omitempty"`
+	RequiredCommands []string          `json:"requiredCommands,omitempty"`
 }
 
 type agentTurnInfo struct {
@@ -307,6 +323,50 @@ func (s *Server) listAgentProviders(w http.ResponseWriter, r *http.Request) {
 		out.Providers = append(out.Providers, info)
 	}
 	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) resolveAgentHarness(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveAgentActor(w, r)
+	if !ok {
+		return
+	}
+	if s == nil || s.agent == nil {
+		writeError(w, http.StatusPreconditionFailed, agentmanager.ErrAgentNotConfigured.Error())
+		return
+	}
+	var req agentHarnessResolveRequest
+	if r.Body != nil {
+		defer func() { _ = r.Body.Close() }()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+	}
+	providerName, _, err := s.agent.ResolveProviderSelection(strings.TrimSpace(req.ProviderName))
+	if err != nil {
+		s.writeAgentManagerError(w, r, "provider", "", nil, err)
+		return
+	}
+	if !s.allowsAgentProvider(r.Context(), p, providerName) {
+		s.writeAgentManagerError(w, r, "provider", providerName, nil, fmt.Errorf("%w: %s", invocation.ErrAuthorizationDenied, providerName))
+		return
+	}
+	entry := s.agentDefs[providerName]
+	effective, err := config.ResolveProviderEntryAgentHarness(providerName, entry, req.HarnessName)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	harness := effective.Harness
+	writeJSON(w, http.StatusOK, agentHarnessPlanInfo{
+		Provider:         effective.ProviderName,
+		Harness:          effective.HarnessName,
+		Command:          strings.TrimSpace(harness.Command),
+		Args:             append([]string(nil), harness.Args...),
+		Env:              maps.Clone(harness.Env),
+		WorkingDirectory: strings.TrimSpace(harness.WorkingDirectory),
+		RequiredCommands: append([]string(nil), harness.RequiredCommands...),
+	})
 }
 
 func (s *Server) getAgentSession(w http.ResponseWriter, r *http.Request) {
@@ -734,6 +794,16 @@ func (s *Server) resolveAgentActor(w http.ResponseWriter, r *http.Request) (*pri
 		return nil, false
 	}
 	return p, true
+}
+
+func (s *Server) allowsAgentProvider(ctx context.Context, p *principal.Principal, providerName string) bool {
+	if !principal.AllowsProviderPermission(p, providerName) {
+		return false
+	}
+	if s == nil || s.authorizer == nil {
+		return true
+	}
+	return s.authorizer.AllowProvider(ctx, p, providerName)
 }
 
 func resolveAgentIdempotencyKey(w http.ResponseWriter, r *http.Request, bodyValue string) (string, bool) {

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -51,6 +51,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Post("/agent/sessions", s.createAgentSession)
 		r.Get("/agent/sessions", s.listAgentSessions)
 		r.Get("/agent/providers", s.listAgentProviders)
+		r.Post("/agent/harnesses/resolve", s.resolveAgentHarness)
 		r.Route("/agent/sessions", func(r chi.Router) {
 			r.Post("/", s.createAgentSession)
 			r.Get("/", s.listAgentSessions)

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -89,6 +89,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		ConnectionAuth:        result.ConnectionAuth,
 		ManualConnectionAuth:  result.ManualConnectionAuth,
 		PluginDefs:            cfg.Plugins,
+		AgentDefs:             cfg.Providers.Agent,
 		Authorizer:            result.Authorizer,
 		AuthorizationProvider: result.AuthorizationProvider,
 		PublicBaseURL:         cfg.Server.BaseURL,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -108,6 +108,7 @@ type Server struct {
 	connectionAuth         func() map[string]map[string]bootstrap.OAuthHandler
 	manualConnectionAuth   func() map[string]map[string]bootstrap.ManualTokenExchanger
 	pluginDefs             map[string]*config.ProviderEntry
+	agentDefs              map[string]*config.ProviderEntry
 	authorizer             authorization.RuntimeAuthorizer
 	noAuth                 bool
 	anonymousPrincipal     *principal.Principal
@@ -166,6 +167,7 @@ type Config struct {
 	ConnectionAuth        func() map[string]map[string]bootstrap.OAuthHandler
 	ManualConnectionAuth  func() map[string]map[string]bootstrap.ManualTokenExchanger
 	PluginDefs            map[string]*config.ProviderEntry
+	AgentDefs             map[string]*config.ProviderEntry
 	ProviderUIs           map[string]*config.UIEntry
 	Authorizer            authorization.RuntimeAuthorizer
 	AuthorizationProvider core.AuthorizationProvider
@@ -359,6 +361,7 @@ func New(cfg Config) (*Server, error) {
 		connectionAuth:         cfg.ConnectionAuth,
 		manualConnectionAuth:   cfg.ManualConnectionAuth,
 		pluginDefs:             cfg.PluginDefs,
+		agentDefs:              cfg.AgentDefs,
 		authorizer:             cfg.Authorizer,
 		noAuth:                 noAuth,
 		publicBaseURL:          strings.TrimRight(cfg.PublicBaseURL, "/"),


### PR DESCRIPTION
## Summary
- add a server endpoint to resolve the configured agent harness plan, including optional named harness selection
- update local `gestalt agent` launch and doctor to fetch the plan from the configured server and exec locally without requiring a local `gestaltd` helper
- add harness config support with legacy `localHarness` compatibility and focused CLI/server tests

## Tests
- `cargo test --manifest-path gestalt/cli/Cargo.toml --test agents_cli local -- --test-threads=1`
- `go test ./internal/server -run TestAgentHarnessResolveUsesDefaultAndNamedHarness`