### PR TITLE
Document internal Gmail platform connections

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1386,6 +1386,30 @@ plugins:
         exposure: internal
 ```
 
+Use `exposure: internal` for deployer-owned accounts that only provider code
+should call. The platform connection supplies the upstream token; the target
+provider should still enforce any domain-specific policy, such as the expected
+mailbox address and the operation allowlist.
+
+Internal callers select that binding when invoking the target plugin:
+
+```ts
+const invoker = new gestalt.PluginInvoker(request);
+
+await invoker.invoke(
+  "gmail",
+  "messages.list",
+  { q: "to:athena-implementation@valon.com newer_than:7d" },
+  { connection: "platform" },
+);
+```
+
+If the target provider deliberately manages its own upstream credentials, such
+as by minting a short-lived Google domain-wide-delegation token from provider
+config, declare the nested grant with `credentialMode: none` instead. That skips
+Gestalt credential resolution for the call and leaves token minting and policy
+enforcement to the provider.
+
 The effective connection is resolved from the most specific declaration first.
 A manifest surface can name a connection with `spec.surfaces.<surface>.connection`,
 and declarative REST operations can name a connection directly. If no surface

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1387,7 +1387,9 @@ plugins:
 ```
 
 Use `exposure: internal` for deployer-owned accounts that only provider code
-should call. The platform connection supplies the upstream token; the target
+should call. This is separate from `mode: platform`: `mode` decides who owns the
+credential, while `exposure` decides whether public callers can select the
+binding. The platform connection supplies the upstream token; the target
 provider should still enforce any domain-specific policy, such as the expected
 mailbox address and the operation allowlist.
 
@@ -1399,7 +1401,7 @@ const invoker = new gestalt.PluginInvoker(request);
 await invoker.invoke(
   "gmail",
   "messages.list",
-  { q: "to:athena-implementation@valon.com newer_than:7d" },
+  { q: "to:group@example.com newer_than:7d" },
   { connection: "platform" },
 );
 ```


### PR DESCRIPTION
## Summary
- Document how internal provider callers should use deployer-owned platform OAuth mailbox connections.
- Clarify why target providers should still enforce mailbox and operation policy.
- Note that provider-managed domain-wide-delegation credentials should use credentialMode none.

## Test plan
- [x] git diff --check