### PR TITLE
Make provider dev remote polling resilient

### DIFF
--- a/gestaltd/services/providerdev/indexeddb_store.go
+++ b/gestaltd/services/providerdev/indexeddb_store.go
@@ -381,6 +381,9 @@ func (s *indexedDBSessionStore) consumeAttachAuthorization(ctx context.Context, 
 func (s *indexedDBSessionStore) poll(ctx context.Context, id, dispatcherSecret string) (*PollResponse, bool, error) {
 	nextHeartbeat := time.Time{}
 	for {
+		if pollContextDone(ctx) {
+			return nil, false, nil
+		}
 		now := time.Now()
 		heartbeat := nextHeartbeat.IsZero() || !now.Before(nextHeartbeat)
 		resp, ok, err := s.claimCall(ctx, id, dispatcherSecret, now, heartbeat)
@@ -406,6 +409,9 @@ func (s *indexedDBSessionStore) poll(ctx context.Context, id, dispatcherSecret s
 func (s *indexedDBSessionStore) claimCall(ctx context.Context, id, dispatcherSecret string, now time.Time, heartbeat bool) (*PollResponse, bool, error) {
 	tx, err := s.db.Transaction(ctx, []string{indexedDBAttachmentStore, indexedDBCallStore}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
 	if err != nil {
+		if pollContextOperationDone(ctx, err) {
+			return nil, false, nil
+		}
 		return nil, false, status.Errorf(codes.Internal, "open provider dev poll transaction: %v", err)
 	}
 	committed := false
@@ -413,37 +419,46 @@ func (s *indexedDBSessionStore) claimCall(ctx context.Context, id, dispatcherSec
 
 	attachments := tx.ObjectStore(indexedDBAttachmentStore)
 	calls := tx.ObjectStore(indexedDBCallStore)
-	session, err := s.attachmentFromStore(ctx, attachments, id, now)
+	session, err := pollAttachmentFromStore(ctx, attachments, id, now)
 	if err != nil {
+		if pollContextOperationDone(ctx, err) {
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 	if err := verifyStoredDispatcherSecret(session, dispatcherSecret); err != nil {
 		return nil, false, err
 	}
 	touched := false
-	touchSession := func() error {
+	touchSession := func(suppressContextDone bool) (bool, error) {
 		if touched {
-			return nil
+			return false, nil
 		}
 		rec, err := attachmentToRecord(session)
 		if err != nil {
-			return err
+			return false, err
 		}
 		rec["last_seen_at"] = unixNano(now)
 		if err := attachments.Put(ctx, rec); err != nil {
-			return status.Errorf(codes.Internal, "touch provider dev attachment: %v", err)
+			if suppressContextDone && pollContextOperationDone(ctx, err) {
+				return true, nil
+			}
+			return false, status.Errorf(codes.Internal, "touch provider dev attachment: %v", err)
 		}
 		touched = true
-		return nil
+		return false, nil
 	}
 	if heartbeat {
-		if err := touchSession(); err != nil {
+		if done, err := touchSession(true); done || err != nil {
 			return nil, false, err
 		}
 	}
 
 	callRecords, err := calls.Index("by_attachment_state").GetAll(ctx, nil, id, indexedDBCallStatePending)
 	if err != nil {
+		if pollContextOperationDone(ctx, err) {
+			return nil, false, nil
+		}
 		return nil, false, status.Errorf(codes.Internal, "list provider dev calls: %v", err)
 	}
 	var claim *indexedDBCallRecord
@@ -460,6 +475,9 @@ func (s *indexedDBSessionStore) claimCall(ctx context.Context, id, dispatcherSec
 			call.errorCode = codes.DeadlineExceeded
 			call.errorMessage = "provider dev call expired before dispatch"
 			if err := calls.Put(ctx, callToRecord(call)); err != nil {
+				if pollContextOperationDone(ctx, err) {
+					return nil, false, nil
+				}
 				return nil, false, status.Errorf(codes.Internal, "expire provider dev call: %v", err)
 			}
 			continue
@@ -471,6 +489,9 @@ func (s *indexedDBSessionStore) claimCall(ctx context.Context, id, dispatcherSec
 	}
 	if claim == nil {
 		if err := tx.Commit(ctx); err != nil {
+			if pollContextOperationDone(ctx, err) {
+				return nil, false, nil
+			}
 			return nil, false, status.Errorf(codes.Internal, "commit provider dev poll heartbeat: %v", err)
 		}
 		committed = true
@@ -478,7 +499,7 @@ func (s *indexedDBSessionStore) claimCall(ctx context.Context, id, dispatcherSec
 	}
 	claim.state = indexedDBCallStateLeased
 	claim.leasedAt = now
-	if err := touchSession(); err != nil {
+	if _, err := touchSession(false); err != nil {
 		return nil, false, err
 	}
 	if err := calls.Put(ctx, callToRecord(*claim)); err != nil {
@@ -494,6 +515,50 @@ func (s *indexedDBSessionStore) claimCall(ctx context.Context, id, dispatcherSec
 		Method:        claim.method,
 		RequestBase64: base64.StdEncoding.EncodeToString(claim.request),
 	}, true, nil
+}
+
+func pollContextDone(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	err := ctx.Err()
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func pollContextOperationDone(ctx context.Context, err error) bool {
+	if err == nil || !pollContextDone(ctx) {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	return st.Code() == codes.Canceled || st.Code() == codes.DeadlineExceeded
+}
+
+func pollAttachmentFromStore(ctx context.Context, attachments indexeddb.TransactionObjectStore, id string, now time.Time) (*indexedDBSessionRecord, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, status.Error(codes.InvalidArgument, "session id is required")
+	}
+	raw, err := attachments.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "provider dev session %q not found", id)
+		}
+		return nil, err
+	}
+	session, err := sessionFromRecord(raw)
+	if err != nil {
+		return nil, err
+	}
+	if !attachmentActive(session, now) {
+		return nil, status.Errorf(codes.NotFound, "provider dev session %q not found", id)
+	}
+	return &session, nil
 }
 
 func (s *indexedDBSessionStore) completeCall(ctx context.Context, attachmentID, callID, dispatcherSecret string, req CompleteCallRequest) error {
@@ -1349,7 +1414,13 @@ func abortIfUncommitted(ctx context.Context, tx indexeddb.Transaction, committed
 	if tx == nil || committed == nil || *committed {
 		return
 	}
-	_ = tx.Abort(ctx)
+	abortCtx := ctx
+	var cancel context.CancelFunc
+	if pollContextDone(ctx) {
+		abortCtx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+	}
+	_ = tx.Abort(abortCtx)
 }
 
 func recordString(rec indexeddb.Record, key string) string {

--- a/gestaltd/services/providerdev/session.go
+++ b/gestaltd/services/providerdev/session.go
@@ -13,7 +13,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"maps"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1676,12 +1678,42 @@ type DispatcherOption func(*dispatcherConfig)
 
 type dispatcherConfig struct {
 	UIHandlers map[string]http.Handler
+	PollRetry  dispatcherPollRetryConfig
+}
+
+type dispatcherPollRetryConfig struct {
+	InitialDelay time.Duration
+	MaxDelay     time.Duration
+	MaxElapsed   time.Duration
 }
 
 func WithUIHandlers(handlers map[string]http.Handler) DispatcherOption {
 	return func(cfg *dispatcherConfig) {
 		cfg.UIHandlers = handlers
 	}
+}
+
+func withDispatcherPollRetryConfig(cfg dispatcherPollRetryConfig) DispatcherOption {
+	return func(dispatcher *dispatcherConfig) {
+		dispatcher.PollRetry = cfg
+	}
+}
+
+func (cfg dispatcherConfig) pollRetryConfig() dispatcherPollRetryConfig {
+	retry := cfg.PollRetry
+	if retry.InitialDelay <= 0 {
+		retry.InitialDelay = 250 * time.Millisecond
+	}
+	if retry.MaxDelay <= 0 {
+		retry.MaxDelay = 5 * time.Second
+	}
+	if retry.MaxElapsed <= 0 {
+		retry.MaxElapsed = 2 * time.Minute
+	}
+	if retry.MaxDelay < retry.InitialDelay {
+		retry.MaxDelay = retry.InitialDelay
+	}
+	return retry
 }
 
 func (c *Client) CreateSession(ctx context.Context, req CreateSessionRequest) (*CreateSessionResponse, error) {
@@ -1769,14 +1801,43 @@ func (c Client) RunDispatcher(ctx context.Context, sessionID string, providers m
 			option(&cfg)
 		}
 	}
+	retryCfg := cfg.pollRetryConfig()
+	retryAttempt := 0
+	var retryStarted time.Time
 	for {
 		call, ok, err := c.Poll(ctx, sessionID)
 		if err != nil {
 			if dispatcherContextDone(ctx) {
 				return nil
 			}
+			if isTransientPollError(ctx, err) {
+				now := time.Now()
+				if retryStarted.IsZero() {
+					retryStarted = now
+				}
+				elapsed := now.Sub(retryStarted)
+				if elapsed >= retryCfg.MaxElapsed {
+					return err
+				}
+				delay := dispatcherPollRetryDelay(retryCfg, retryAttempt)
+				if remaining := retryCfg.MaxElapsed - elapsed; delay > remaining {
+					delay = remaining
+				}
+				slog.WarnContext(ctx, "provider dev remote poll failed; retrying", "error", err, "delay", delay.String())
+				timer := time.NewTimer(delay)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return nil
+				case <-timer.C:
+				}
+				retryAttempt++
+				continue
+			}
 			return err
 		}
+		retryAttempt = 0
+		retryStarted = time.Time{}
 		if !ok {
 			continue
 		}
@@ -1788,6 +1849,78 @@ func (c Client) RunDispatcher(ctx context.Context, sessionID string, providers m
 			return err
 		}
 	}
+}
+
+func dispatcherPollRetryDelay(cfg dispatcherPollRetryConfig, attempt int) time.Duration {
+	delay := cfg.InitialDelay
+	for i := 0; i < attempt; i++ {
+		if delay >= cfg.MaxDelay/2 {
+			return cfg.MaxDelay
+		}
+		delay *= 2
+	}
+	if delay > cfg.MaxDelay {
+		return cfg.MaxDelay
+	}
+	return delay
+}
+
+func isTransientPollError(ctx context.Context, err error) bool {
+	if err == nil || dispatcherContextDone(ctx) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var statusErr *remoteStatusError
+	if errors.As(err, &statusErr) {
+		switch statusErr.statusCode {
+		case http.StatusInternalServerError:
+			return isTransientPollInternalServerError(statusErr)
+		case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			return true
+		default:
+			return false
+		}
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Timeout() {
+			return true
+		}
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "server closed idle connection") ||
+		strings.Contains(msg, "unexpected eof") ||
+		(strings.Contains(msg, "stream error:") && strings.Contains(msg, "cancel")) ||
+		(strings.Contains(msg, "rst_stream") && strings.Contains(msg, "cancel"))
+}
+
+func isTransientPollInternalServerError(err *remoteStatusError) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.body)
+	if msg == "" {
+		msg = strings.ToLower(err.message)
+	}
+	hasContextReset := strings.Contains(msg, "canceled") ||
+		strings.Contains(msg, "deadlineexceeded") ||
+		strings.Contains(msg, "deadline exceeded") ||
+		strings.Contains(msg, "rst_stream") ||
+		strings.Contains(msg, "stream terminated")
+	if !hasContextReset {
+		return false
+	}
+	return strings.Contains(msg, "open provider dev poll transaction:") ||
+		strings.Contains(msg, "list provider dev calls:") ||
+		strings.Contains(msg, "expire provider dev call:") ||
+		strings.Contains(msg, "commit provider dev poll heartbeat:")
 }
 
 func dispatcherContextDone(ctx context.Context) bool {
@@ -1994,7 +2127,9 @@ func (c Client) doJSONStatus(ctx context.Context, method, path string, in any, o
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return resp.StatusCode, fmt.Errorf("provider dev remote %s %s: %s: %s", method, path, resp.Status, strings.TrimSpace(string(payload)))
+		body := strings.TrimSpace(string(payload))
+		err := fmt.Sprintf("provider dev remote %s %s: %s: %s", method, path, resp.Status, body)
+		return resp.StatusCode, &remoteStatusError{statusCode: resp.StatusCode, body: body, message: err}
 	}
 	if out != nil {
 		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
@@ -2002,6 +2137,19 @@ func (c Client) doJSONStatus(ctx context.Context, method, path string, in any, o
 		}
 	}
 	return resp.StatusCode, nil
+}
+
+type remoteStatusError struct {
+	statusCode int
+	body       string
+	message    string
+}
+
+func (e *remoteStatusError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.message
 }
 
 func (c Client) endpoint(path string) (string, error) {

--- a/gestaltd/services/providerdev/session_test.go
+++ b/gestaltd/services/providerdev/session_test.go
@@ -17,13 +17,16 @@ import (
 	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
@@ -465,6 +468,131 @@ func TestIndexedDBAttachmentStateDispatchesAcrossManagers(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("dispatcher did not stop")
+	}
+}
+
+func TestIndexedDBAttachmentStatePollTransactionOpenContextDoneReturnsNoContent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &interceptIndexedDB{inner: &coretesting.StubIndexedDB{}}
+	manager, session := newSharedProviderDevSession(t, ctx, db)
+
+	db.transactionFn = func(ctx context.Context, stores []string, mode indexeddb.TransactionMode, opts indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+		if isProviderDevPollTransaction(stores) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return db.inner.Transaction(ctx, stores, mode, opts)
+	}
+
+	statusCode, body := pollProviderDevAttachment(t, manager, session, session.DispatcherSecret, 10*time.Millisecond)
+	if statusCode != http.StatusNoContent {
+		t.Fatalf("poll status = %d, want 204: %s", statusCode, body)
+	}
+}
+
+func TestIndexedDBAttachmentStatePollNoClaimCommitContextDoneReturnsNoContent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &interceptIndexedDB{inner: &coretesting.StubIndexedDB{}}
+	manager, session := newSharedProviderDevSession(t, ctx, db)
+
+	db.transactionFn = func(ctx context.Context, stores []string, mode indexeddb.TransactionMode, opts indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+		tx, err := db.inner.Transaction(ctx, stores, mode, opts)
+		if err != nil || !isProviderDevPollTransaction(stores) {
+			return tx, err
+		}
+		return interceptTransaction{
+			Transaction: tx,
+			commitFn: func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}, nil
+	}
+
+	statusCode, body := pollProviderDevAttachment(t, manager, session, session.DispatcherSecret, 10*time.Millisecond)
+	if statusCode != http.StatusNoContent {
+		t.Fatalf("poll status = %d, want 204: %s", statusCode, body)
+	}
+}
+
+func TestIndexedDBAttachmentStatePollLiveTransactionErrorReturnsInternal(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &interceptIndexedDB{inner: &coretesting.StubIndexedDB{}}
+	manager, session := newSharedProviderDevSession(t, ctx, db)
+
+	db.transactionFn = func(ctx context.Context, stores []string, mode indexeddb.TransactionMode, opts indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+		if isProviderDevPollTransaction(stores) {
+			return nil, errors.New("indexeddb unavailable")
+		}
+		return db.inner.Transaction(ctx, stores, mode, opts)
+	}
+
+	statusCode, body := pollProviderDevAttachment(t, manager, session, session.DispatcherSecret, time.Second)
+	if statusCode != http.StatusInternalServerError {
+		t.Fatalf("poll status = %d, want 500: %s", statusCode, body)
+	}
+}
+
+func TestIndexedDBAttachmentStatePollPostClaimCommitContextDoneReturnsInternal(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &interceptIndexedDB{inner: &coretesting.StubIndexedDB{}}
+	manager, session := newSharedProviderDevSession(t, ctx, db)
+	if _, err := manager.shared.enqueueCall(ctx, session.AttachID, "user:user-123", "roadmap", "Execute", []byte("payload")); err != nil {
+		t.Fatalf("enqueueCall: %v", err)
+	}
+
+	db.transactionFn = func(ctx context.Context, stores []string, mode indexeddb.TransactionMode, opts indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+		tx, err := db.inner.Transaction(ctx, stores, mode, opts)
+		if err != nil || !isProviderDevPollTransaction(stores) {
+			return tx, err
+		}
+		return interceptTransaction{
+			Transaction: tx,
+			commitFn: func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}, nil
+	}
+
+	statusCode, body := pollProviderDevAttachment(t, manager, session, session.DispatcherSecret, 10*time.Millisecond)
+	if statusCode != http.StatusInternalServerError {
+		t.Fatalf("poll status = %d, want 500: %s", statusCode, body)
+	}
+}
+
+func TestIndexedDBAttachmentStatePollDispatcherSecretErrorsRemainVisible(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	manager, session := newSharedProviderDevSession(t, ctx, db)
+
+	for _, tc := range []struct {
+		name       string
+		secret     string
+		wantStatus int
+	}{
+		{name: "missing", secret: "", wantStatus: http.StatusUnauthorized},
+		{name: "invalid", secret: "wrong-secret", wantStatus: http.StatusForbidden},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			statusCode, body := pollProviderDevAttachment(t, manager, session, tc.secret, time.Second)
+			if statusCode != tc.wantStatus {
+				t.Fatalf("poll status = %d, want %d: %s", statusCode, tc.wantStatus, body)
+			}
+		})
 	}
 }
 
@@ -1036,6 +1164,487 @@ func TestSessionCloseReturnsSameErrorToConcurrentCallers(t *testing.T) {
 	if err := <-secondDone; !errors.Is(err, expected) {
 		t.Fatalf("second Close error = %v, want %v", err, expected)
 	}
+}
+
+func TestRunDispatcherRetriesTransientPollError(t *testing.T) {
+	t.Parallel()
+
+	executePayload := mustExecuteRequestBase64(t, "hello")
+	var mu sync.Mutex
+	polls := 0
+	completed := make(chan CompleteCallRequest, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == PathAttachments+"/session-1/poll":
+			mu.Lock()
+			polls++
+			poll := polls
+			mu.Unlock()
+			if poll == 1 {
+				http.Error(w, "open provider dev poll transaction: rpc error: code = DeadlineExceeded desc = stream terminated by RST_STREAM with error code: CANCEL", http.StatusInternalServerError)
+				return
+			}
+			writeProviderDevTestJSON(w, http.StatusOK, PollResponse{
+				CallID:        "call-1",
+				Provider:      "roadmap",
+				Method:        "Execute",
+				RequestBase64: executePayload,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == PathAttachments+"/session-1/calls/call-1":
+			var req CompleteCallRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			completed <- req
+			writeProviderDevTestJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+		done <- client.RunDispatcher(ctx, "session-1", map[string]proto.IntegrationProviderClient{
+			"roadmap": &recordingIntegrationClient{},
+		}, withDispatcherPollRetryConfig(dispatcherPollRetryConfig{
+			InitialDelay: time.Millisecond,
+			MaxDelay:     time.Millisecond,
+			MaxElapsed:   time.Second,
+		}))
+	}()
+
+	select {
+	case req := <-completed:
+		if req.Error != nil {
+			t.Fatalf("completion error = %#v", req.Error)
+		}
+		cancel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("dispatcher did not complete call after transient poll error")
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("RunDispatcher: %v", err)
+	}
+	mu.Lock()
+	gotPolls := polls
+	mu.Unlock()
+	if gotPolls < 2 {
+		t.Fatalf("polls = %d, want retry", gotPolls)
+	}
+}
+
+func TestRunDispatcherRetriesHTTP2StreamCancelPollError(t *testing.T) {
+	t.Parallel()
+
+	executePayload := mustExecuteRequestBase64(t, "hello")
+	var mu sync.Mutex
+	polls := 0
+	completed := make(chan CompleteCallRequest, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == PathAttachments+"/session-1/poll":
+			writeProviderDevTestJSON(w, http.StatusOK, PollResponse{
+				CallID:        "call-1",
+				Provider:      "roadmap",
+				Method:        "Execute",
+				RequestBase64: executePayload,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == PathAttachments+"/session-1/calls/call-1":
+			var req CompleteCallRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			completed <- req
+			writeProviderDevTestJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	baseTransport := ts.Client().Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == PathAttachments+"/session-1/poll" {
+			mu.Lock()
+			polls++
+			poll := polls
+			mu.Unlock()
+			if poll == 1 {
+				return nil, errors.New("stream error: stream ID 7; CANCEL")
+			}
+		}
+		return baseTransport.RoundTrip(req)
+	})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		client := Client{BaseURL: ts.URL, HTTPClient: httpClient}
+		done <- client.RunDispatcher(ctx, "session-1", map[string]proto.IntegrationProviderClient{
+			"roadmap": &recordingIntegrationClient{},
+		}, withDispatcherPollRetryConfig(dispatcherPollRetryConfig{
+			InitialDelay: time.Millisecond,
+			MaxDelay:     time.Millisecond,
+			MaxElapsed:   time.Second,
+		}))
+	}()
+
+	select {
+	case req := <-completed:
+		if req.Error != nil {
+			t.Fatalf("completion error = %#v", req.Error)
+		}
+		cancel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("dispatcher did not complete call after HTTP/2 stream cancel")
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("RunDispatcher: %v", err)
+	}
+	mu.Lock()
+	gotPolls := polls
+	mu.Unlock()
+	if gotPolls < 2 {
+		t.Fatalf("polls = %d, want retry", gotPolls)
+	}
+}
+
+func TestRunDispatcherDoesNotRetryPostClaimPollInternalError(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	polls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != PathAttachments+"/session-1/poll" {
+			http.NotFound(w, r)
+			return
+		}
+		mu.Lock()
+		polls++
+		mu.Unlock()
+		http.Error(w, "commit provider dev call lease: context deadline exceeded", http.StatusInternalServerError)
+	}))
+	t.Cleanup(ts.Close)
+
+	client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	err := client.RunDispatcher(context.Background(), "session-1", nil, withDispatcherPollRetryConfig(dispatcherPollRetryConfig{
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+		MaxElapsed:   time.Second,
+	}))
+	if err == nil || !strings.Contains(err.Error(), "commit provider dev call lease") {
+		t.Fatalf("RunDispatcher error = %v, want post-claim poll 500", err)
+	}
+	mu.Lock()
+	gotPolls := polls
+	mu.Unlock()
+	if gotPolls != 1 {
+		t.Fatalf("polls = %d, want no retry for post-claim poll failure", gotPolls)
+	}
+}
+
+func TestRunDispatcherReturnsAfterTransientPollRetryWindow(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	polls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != PathAttachments+"/session-1/poll" {
+			http.NotFound(w, r)
+			return
+		}
+		mu.Lock()
+		polls++
+		mu.Unlock()
+		http.Error(w, `{"error":"still down"}`, http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	err := client.RunDispatcher(ctx, "session-1", nil, withDispatcherPollRetryConfig(dispatcherPollRetryConfig{
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+		MaxElapsed:   5 * time.Millisecond,
+	}))
+	if err == nil || !strings.Contains(err.Error(), "503 Service Unavailable") {
+		t.Fatalf("RunDispatcher error = %v, want original 503", err)
+	}
+	mu.Lock()
+	gotPolls := polls
+	mu.Unlock()
+	if gotPolls < 2 {
+		t.Fatalf("polls = %d, want bounded retries", gotPolls)
+	}
+}
+
+func TestRunDispatcherDoesNotRetryNonTransientPollStatuses(t *testing.T) {
+	t.Parallel()
+
+	for _, statusCode := range []int{
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+	} {
+		t.Run(fmt.Sprintf("status_%d", statusCode), func(t *testing.T) {
+			t.Parallel()
+			var mu sync.Mutex
+			polls := 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != PathAttachments+"/session-1/poll" {
+					http.NotFound(w, r)
+					return
+				}
+				mu.Lock()
+				polls++
+				mu.Unlock()
+				http.Error(w, `{"error":"no"}`, statusCode)
+			}))
+			t.Cleanup(ts.Close)
+
+			client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+			err := client.RunDispatcher(context.Background(), "session-1", nil, withDispatcherPollRetryConfig(dispatcherPollRetryConfig{
+				InitialDelay: time.Millisecond,
+				MaxDelay:     time.Millisecond,
+				MaxElapsed:   time.Second,
+			}))
+			if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("%d", statusCode)) {
+				t.Fatalf("RunDispatcher error = %v, want status %d", err, statusCode)
+			}
+			mu.Lock()
+			gotPolls := polls
+			mu.Unlock()
+			if gotPolls != 1 {
+				t.Fatalf("polls = %d, want no retry", gotPolls)
+			}
+		})
+	}
+}
+
+func TestRunDispatcherDoesNotRetryCompleteFailure(t *testing.T) {
+	t.Parallel()
+
+	executePayload := mustExecuteRequestBase64(t, "hello")
+	var mu sync.Mutex
+	polls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == PathAttachments+"/session-1/poll":
+			mu.Lock()
+			polls++
+			mu.Unlock()
+			writeProviderDevTestJSON(w, http.StatusOK, PollResponse{
+				CallID:        "call-1",
+				Provider:      "roadmap",
+				Method:        "Execute",
+				RequestBase64: executePayload,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == PathAttachments+"/session-1/calls/call-1":
+			http.Error(w, `{"error":"complete failed"}`, http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	err := client.RunDispatcher(context.Background(), "session-1", map[string]proto.IntegrationProviderClient{
+		"roadmap": &recordingIntegrationClient{},
+	}, withDispatcherPollRetryConfig(dispatcherPollRetryConfig{
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+		MaxElapsed:   time.Second,
+	}))
+	if err == nil || !strings.Contains(err.Error(), "500 Internal Server Error") {
+		t.Fatalf("RunDispatcher error = %v, want completion 500", err)
+	}
+	mu.Lock()
+	gotPolls := polls
+	mu.Unlock()
+	if gotPolls != 1 {
+		t.Fatalf("polls = %d, want no retry after completion failure", gotPolls)
+	}
+}
+
+func TestRunDispatcherCanceledContextDoesNotRetryPoll(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	client := Client{BaseURL: "http://127.0.0.1:1"}
+	if err := client.RunDispatcher(ctx, "session-1", nil, withDispatcherPollRetryConfig(dispatcherPollRetryConfig{
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+		MaxElapsed:   time.Second,
+	})); err != nil {
+		t.Fatalf("RunDispatcher with canceled context = %v, want nil", err)
+	}
+}
+
+func newSharedProviderDevSession(t *testing.T, ctx context.Context, db indexeddb.IndexedDB) (*Manager, *CreateSessionResponse) {
+	t.Helper()
+	manager, err := NewManager([]Target{{Name: "roadmap"}}, WithIndexedDBAttachmentState(ctx, db))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	session, err := manager.CreateSession(ctx, p, CreateSessionRequest{Providers: []AttachProvider{{Name: "roadmap"}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	return manager, session
+}
+
+func pollProviderDevAttachment(t *testing.T, manager *Manager, session *CreateSessionResponse, dispatcherSecret string, timeout time.Duration) (int, string) {
+	t.Helper()
+	ts := httptest.NewServer(providerDevPollOnlyHandler(t, manager, timeout))
+	t.Cleanup(ts.Close)
+	req, err := http.NewRequest(http.MethodGet, ts.URL+PathAttachments+"/"+session.AttachID+"/poll", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if dispatcherSecret != "" {
+		req.Header.Set(HeaderDispatcherSecret, dispatcherSecret)
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("poll request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read poll body: %v", err)
+	}
+	return resp.StatusCode, string(body)
+}
+
+func providerDevPollOnlyHandler(t *testing.T, manager *Manager, timeout time.Duration) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		rest := strings.TrimPrefix(r.URL.Path, PathAttachments+"/")
+		parts := strings.Split(rest, "/")
+		if len(parts) != 2 || parts[1] != "poll" {
+			http.NotFound(w, r)
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		resp, ok, err := manager.PollSessionWithDispatcherSecretOnly(ctx, parts[0], r.Header.Get(HeaderDispatcherSecret))
+		if err != nil {
+			writeProviderDevTestError(w, err)
+			return
+		}
+		if !ok {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		writeProviderDevTestJSON(w, http.StatusOK, resp)
+	})
+}
+
+type interceptIndexedDB struct {
+	inner         indexeddb.IndexedDB
+	transactionFn func(context.Context, []string, indexeddb.TransactionMode, indexeddb.TransactionOptions) (indexeddb.Transaction, error)
+}
+
+func (db *interceptIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	return db.inner.ObjectStore(name)
+}
+
+func (db *interceptIndexedDB) Transaction(ctx context.Context, stores []string, mode indexeddb.TransactionMode, opts indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+	if db.transactionFn != nil {
+		return db.transactionFn(ctx, stores, mode, opts)
+	}
+	return db.inner.Transaction(ctx, stores, mode, opts)
+}
+
+func (db *interceptIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	return db.inner.CreateObjectStore(ctx, name, schema)
+}
+
+func (db *interceptIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
+	return db.inner.DeleteObjectStore(ctx, name)
+}
+
+func (db *interceptIndexedDB) Ping(ctx context.Context) error {
+	return db.inner.Ping(ctx)
+}
+
+func (db *interceptIndexedDB) Close() error {
+	return db.inner.Close()
+}
+
+type interceptTransaction struct {
+	indexeddb.Transaction
+	commitFn func(context.Context) error
+	abortFn  func(context.Context) error
+}
+
+func (tx interceptTransaction) Commit(ctx context.Context) error {
+	if tx.commitFn != nil {
+		return tx.commitFn(ctx)
+	}
+	return tx.Transaction.Commit(ctx)
+}
+
+func (tx interceptTransaction) Abort(ctx context.Context) error {
+	if tx.abortFn != nil {
+		return tx.abortFn(ctx)
+	}
+	return tx.Transaction.Abort(ctx)
+}
+
+func isProviderDevPollTransaction(stores []string) bool {
+	hasAttachments := false
+	hasCalls := false
+	for _, store := range stores {
+		switch store {
+		case indexedDBAttachmentStore:
+			hasAttachments = true
+		case indexedDBCallStore:
+			hasCalls = true
+		}
+	}
+	return hasAttachments && hasCalls
+}
+
+func mustExecuteRequestBase64(t *testing.T, message string) string {
+	t.Helper()
+	params, err := structpb.NewStruct(map[string]any{"message": message})
+	if err != nil {
+		t.Fatalf("NewStruct: %v", err)
+	}
+	payload, err := gproto.Marshal(&proto.ExecuteRequest{
+		Operation: "echo",
+		Params:    params,
+		Token:     "remote-token",
+	})
+	if err != nil {
+		t.Fatalf("Marshal ExecuteRequest: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(payload)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }
 
 func providerDevTestHandler(t *testing.T, manager *Manager, p *principal.Principal) http.Handler {


### PR DESCRIPTION
## Summary

- Treat shared IndexedDB provider-dev poll deadline/cancel races before call delivery as no-call/204 instead of detaching the local dispatcher with a 500.
- Add bounded poll-only retry in the remote dispatcher for gateway/service failures, transport resets, and the observed pre-delivery poll transaction reset shape.
- Add HTTP/persistence/client contract coverage for cancellation, retry, and fatal post-claim boundaries.

## Interface Changes
- New/changed interface: No public API, CLI flag, config, or schema changes. This changes internal provider-dev remote polling behavior only.
- Example usage:
  ```bash
  gestaltd provider dev --remote https://valon.tools --path valon-tools/plugins/workplace-hub
  ```
  During idle remote polling, server-side poll deadline/cancel races before call delivery now behave like no pending call (`204 No Content`). The dispatcher retries poll-only 502/503/504, transport resets including HTTP/2 stream CANCEL, and the old pre-delivery poll transaction reset 500 shape for a bounded window. Completion errors, auth/session failures, and post-claim poll failures still surface immediately.

## Functional/Integration Tests
- Tests added or augmented: shared IndexedDB provider-dev poll contract tests and dispatcher retry/fatal-boundary contract tests in `gestaltd/services/providerdev/session_test.go`.
- Contract boundary covered: HTTP poll route semantics, shared IndexedDB attachment state, and the provider-dev dispatcher HTTP client loop.
- Commands run:
  ```bash
  go test ./services/providerdev -run 'Test.*(IndexedDBAttachmentState|HTTPTransport|RunDispatcher)'
  go test ./services/providerdev
  go test ./internal/server -run TestProviderDev
  golangci-lint run ./services/providerdev
  golangci-lint run ./...
  ```