### PR TITLE
Raise Python SDK internal gRPC message limits

### DIFF
--- a/sdk/python/gestalt/_grpc_transport.py
+++ b/sdk/python/gestalt/_grpc_transport.py
@@ -9,7 +9,15 @@ import grpc as _grpc
 
 grpc: Any = cast(Any, _grpc)
 
-_INTERNAL_CHANNEL_OPTIONS = (("grpc.enable_http_proxy", 0),)
+INTERNAL_GRPC_MAX_MESSAGE_BYTES = 64 * 1024 * 1024
+INTERNAL_GRPC_MESSAGE_OPTIONS = (
+    ("grpc.max_receive_message_length", INTERNAL_GRPC_MAX_MESSAGE_BYTES),
+    ("grpc.max_send_message_length", INTERNAL_GRPC_MAX_MESSAGE_BYTES),
+)
+_INTERNAL_CHANNEL_OPTIONS = (
+    ("grpc.enable_http_proxy", 0),
+    *INTERNAL_GRPC_MESSAGE_OPTIONS,
+)
 _HOST_SERVICE_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token"
 
 

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -19,6 +19,7 @@ from . import _telemetry
 from ._api import Access, Credential, ExternalIdentity, Host, Request, Subject
 from ._bootstrap import parse_plugin_target, read_bundled_plugin_config
 from ._catalog import catalog_to_proto
+from ._grpc_transport import INTERNAL_GRPC_MESSAGE_OPTIONS
 from ._http_subject import HTTPSubjectRequest, HTTPSubjectResolutionError
 from ._operations import INTERNAL_ERROR_MESSAGE
 from ._plugin import ConnectedToken, Plugin, _module_plugin
@@ -196,7 +197,8 @@ def serve(
         bind_target = f"unix:{address}"
 
     server = grpc.server(
-        futures.ThreadPoolExecutor(max_workers=GRPC_SERVER_MAX_WORKERS)
+        futures.ThreadPoolExecutor(max_workers=GRPC_SERVER_MAX_WORKERS),
+        options=INTERNAL_GRPC_MESSAGE_OPTIONS,
     )
     servable = _servable_target(target, runtime_kind=runtime_kind)
     _register_services(server=server, servable=servable)

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -249,7 +249,19 @@ class _AgentHostServicer(agent_pb2_grpc.AgentHostServicer):
                     "page_size": request.page_size,
                     "page_token": request.page_token,
                     "run_grant": request.run_grant,
-                }
+            }
+        )
+        if request.page_token == "large":
+            return agent_pb2.ListAgentToolsResponse(
+                tools=[
+                    agent_pb2.ListedAgentTool(
+                        id="tool-large",
+                        mcp_name="large__tool",
+                        title="Large tool",
+                        description="x" * (5 * 1024 * 1024),
+                        input_schema='{"type":"object"}',
+                    )
+                ]
             )
         return agent_pb2.ListAgentToolsResponse(
             tools=[
@@ -823,6 +835,19 @@ class AgentTransportTests(unittest.TestCase):
                 }
             ],
         )
+
+    def test_agent_host_accepts_large_internal_responses(self) -> None:
+        with AgentHost() as host:
+            list_response = host.list_tools(
+                agent_pb2.ListAgentToolsRequest(
+                    session_id="session-1",
+                    turn_id="turn-1",
+                    page_token="large",
+                )
+            )
+
+        self.assertEqual(list_response.tools[0].id, "tool-large")
+        self.assertEqual(len(list_response.tools[0].description), 5 * 1024 * 1024)
 
     def test_agent_manager_roundtrip(self) -> None:
         with AgentManager("token-123") as manager:

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -38,6 +38,7 @@ from gestalt import (
     WarningsProvider,
     WorkflowProvider,
     _bootstrap,
+    _grpc_transport,
     _runtime,
 )
 from gestalt._gen.v1 import authentication_pb2 as _authentication_pb2
@@ -202,6 +203,20 @@ class ProviderSocketTargetTests(unittest.TestCase):
             "unsupported provider socket target scheme 'tls'",
         ):
             _runtime._parse_provider_socket_target("tls://127.0.0.1:50051")
+
+
+class InternalGrpcTransportTests(unittest.TestCase):
+    def test_internal_channels_raise_message_size_limits(self) -> None:
+        options = dict(_grpc_transport._INTERNAL_CHANNEL_OPTIONS)
+
+        self.assertEqual(
+            options["grpc.max_receive_message_length"],
+            _grpc_transport.INTERNAL_GRPC_MAX_MESSAGE_BYTES,
+        )
+        self.assertEqual(
+            options["grpc.max_send_message_length"],
+            _grpc_transport.INTERNAL_GRPC_MAX_MESSAGE_BYTES,
+        )
 
 
 class RuntimeServeTransportTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- raise Python SDK internal gRPC send/receive message limits to 64 MiB
- apply the same message limit to Python provider runtime servers
- add a regression test for a >4 MiB host-service response over the AgentHost transport

## Context
Valon Tools `/api/v1/agent/sessions?view=summary&limit=100` is failing with `agent request failed`. Cloud Run logs show the Python agent provider hitting the default 4 MiB gRPC receive cap while calling the host IndexedDB service:

```
rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5226422 vs. 4194304)
```

The summary endpoint still needs the provider to hydrate session records before projection; large stored session payloads can exceed the default grpcio cap on that internal host-service call.

## Tests
- `cd sdk/python && uv run ruff check gestalt tests`
- `cd sdk/python && uv run ty check --exclude 'gestalt/_gen/**' gestalt scripts tests`\n- `cd sdk/python && uv run vulture --config pyproject.toml`\n- `cd sdk/python && uv run python -m unittest discover -s tests`