### PR TITLE
Make agent session listing best effort across providers

### DIFF
--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"sort"
 	"strconv"
@@ -734,10 +735,19 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 	}
 	requireBounded := req.SummaryOnly || limit > 0
 	out := make([]*coreagent.Session, 0)
+	var providerErrs []error
+	providerSucceeded := false
+	strictProvider := providerName != ""
 	for _, candidate := range candidates {
 		if requireBounded {
 			if err := requireAgentProviderBoundedListHydration(ctx, candidate.name, candidate.provider); err != nil {
-				return nil, err
+				err = fmt.Errorf("agent provider %q list sessions: %w", candidate.name, err)
+				if strictProvider {
+					return nil, err
+				}
+				slog.WarnContext(ctx, "agent provider list sessions failed", "provider", candidate.name, "error", err)
+				providerErrs = append(providerErrs, err)
+				continue
 			}
 		}
 		sessions, err := candidate.provider.ListSessions(ctx, coreagent.ListSessionsRequest{
@@ -747,8 +757,16 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 			SummaryOnly: req.SummaryOnly,
 		})
 		if err != nil {
-			return nil, err
+			err = fmt.Errorf("agent provider %q list sessions: %w", candidate.name, err)
+			if strictProvider {
+				return nil, err
+			}
+			slog.WarnContext(ctx, "agent provider list sessions failed", "provider", candidate.name, "error", err)
+			providerErrs = append(providerErrs, err)
+			continue
 		}
+		candidateOut := make([]*coreagent.Session, 0, len(sessions))
+		var candidateErr error
 		for _, session := range sessions {
 			if session == nil {
 				continue
@@ -758,7 +776,8 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 			}
 			normalized, err := normalizeProviderSession(candidate.name, strings.TrimSpace(session.ID), session)
 			if err != nil {
-				return nil, err
+				candidateErr = fmt.Errorf("agent provider %q list sessions: %w", candidate.name, err)
+				break
 			}
 			if req.State != "" && normalized.State != req.State {
 				continue
@@ -767,8 +786,21 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 			if req.SummaryOnly {
 				normalized = summarizeAgentSession(normalized)
 			}
-			out = append(out, normalized)
+			candidateOut = append(candidateOut, normalized)
 		}
+		if candidateErr != nil {
+			if strictProvider {
+				return nil, candidateErr
+			}
+			slog.WarnContext(ctx, "agent provider list sessions failed", "provider", candidate.name, "error", candidateErr)
+			providerErrs = append(providerErrs, candidateErr)
+			continue
+		}
+		providerSucceeded = true
+		out = append(out, candidateOut...)
+	}
+	if !providerSucceeded && len(providerErrs) > 0 {
+		return nil, errors.Join(providerErrs...)
 	}
 	sort.Slice(out, func(i, j int) bool {
 		left := out[i]

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -143,6 +143,7 @@ type routeCountingAgentProvider struct {
 	createSessionReqs []coreagent.CreateSessionRequest
 	createTurnReqs    []coreagent.CreateTurnRequest
 	listSessionReqs   []coreagent.ListSessionsRequest
+	listSessionsErr   error
 	listTurnReqs      []coreagent.ListTurnsRequest
 	turnIDOverride    string
 	cancelStatus      coreagent.ExecutionStatus
@@ -188,6 +189,9 @@ func (p *routeCountingAgentProvider) GetSession(_ context.Context, req coreagent
 
 func (p *routeCountingAgentProvider) ListSessions(_ context.Context, req coreagent.ListSessionsRequest) ([]*coreagent.Session, error) {
 	p.listSessionReqs = append(p.listSessionReqs, req)
+	if p.listSessionsErr != nil {
+		return nil, p.listSessionsErr
+	}
 	var sessions []*coreagent.Session
 	requested := map[string]struct{}{}
 	for _, id := range req.SessionIDs {
@@ -1110,6 +1114,92 @@ func TestManagerListSessionsRequiresBoundedHydrationForLimitedLists(t *testing.T
 	}
 	if len(provider.listSessionReqs) != 0 {
 		t.Fatalf("provider ListSessions calls = %d, want 0", len(provider.listSessionReqs))
+	}
+}
+
+func TestManagerListSessionsContinuesAfterUnfilteredProviderFailure(t *testing.T) {
+	t.Parallel()
+
+	subjectID := principal.UserSubjectID("user-1")
+	brokenErr := errors.New("backend unavailable")
+	broken := newRouteCountingAgentProvider("broken")
+	broken.listSessionsErr = brokenErr
+	healthy := newRouteCountingAgentProvider("healthy")
+	healthy.sessions["session-1"] = &coreagent.Session{
+		ID:           "session-1",
+		ProviderName: "healthy",
+		State:        coreagent.SessionStateActive,
+		CreatedBy:    coreagent.Actor{SubjectID: subjectID},
+	}
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "healthy",
+			names:       []string{"broken", "healthy"},
+			providers: map[string]*routeCountingAgentProvider{
+				"broken":  broken,
+				"healthy": healthy,
+			},
+		},
+		RunGrants: newAgentManagerTestRunGrants(t),
+	})
+
+	sessions, err := manager.ListSessions(context.Background(), &principal.Principal{SubjectID: subjectID}, coreagent.ManagerListSessionsRequest{
+		SummaryOnly: true,
+		Limit:       100,
+	})
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "session-1" || sessions[0].ProviderName != "healthy" {
+		t.Fatalf("ListSessions = %#v, want healthy session", sessions)
+	}
+	if len(broken.listSessionReqs) != 1 {
+		t.Fatalf("broken ListSessions calls = %d, want 1", len(broken.listSessionReqs))
+	}
+	if len(healthy.listSessionReqs) != 1 {
+		t.Fatalf("healthy ListSessions calls = %d, want 1", len(healthy.listSessionReqs))
+	}
+}
+
+func TestManagerListSessionsReturnsFilteredProviderFailure(t *testing.T) {
+	t.Parallel()
+
+	subjectID := principal.UserSubjectID("user-1")
+	brokenErr := errors.New("backend unavailable")
+	broken := newRouteCountingAgentProvider("broken")
+	broken.listSessionsErr = brokenErr
+	healthy := newRouteCountingAgentProvider("healthy")
+	healthy.sessions["session-1"] = &coreagent.Session{
+		ID:           "session-1",
+		ProviderName: "healthy",
+		State:        coreagent.SessionStateActive,
+		CreatedBy:    coreagent.Actor{SubjectID: subjectID},
+	}
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "healthy",
+			names:       []string{"broken", "healthy"},
+			providers: map[string]*routeCountingAgentProvider{
+				"broken":  broken,
+				"healthy": healthy,
+			},
+		},
+		RunGrants: newAgentManagerTestRunGrants(t),
+	})
+
+	_, err := manager.ListSessions(context.Background(), &principal.Principal{SubjectID: subjectID}, coreagent.ManagerListSessionsRequest{
+		ProviderName: "broken",
+		SummaryOnly:  true,
+		Limit:        100,
+	})
+	if !errors.Is(err, brokenErr) {
+		t.Fatalf("ListSessions error = %v, want backend error", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), `agent provider "broken"`) {
+		t.Fatalf("ListSessions error = %v, want provider name", err)
+	}
+	if len(healthy.listSessionReqs) != 0 {
+		t.Fatalf("healthy ListSessions calls = %d, want 0", len(healthy.listSessionReqs))
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep provider-filtered session listing strict, but allow unfiltered list calls to continue when one provider fails
- annotate provider list failures with the provider name so production logs identify the failing backend
- add regression coverage for best-effort unfiltered fan-out and strict provider-filtered failures

## Tests
- go test ./services/agents/agentmanager
- go test ./services/agents/...
- go test ./internal/server