### PR TITLE
Recover config workflows from unreadable execution refs

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1316,6 +1316,7 @@ type recordingWorkflowProvider struct {
 	getEventTriggerErr         error
 	eventTriggers              map[string]*coreworkflow.EventTrigger
 	executionRefs              map[string]*coreworkflow.ExecutionReference
+	getExecutionReferenceErrs  map[string]error
 	deleteMissingNotFound      bool
 	deleteEventMissingNotFound bool
 	closed                     *atomic.Bool
@@ -1482,6 +1483,9 @@ func (p *recordingWorkflowProvider) PutExecutionReference(_ context.Context, ref
 	return cloneBootstrapWorkflowExecutionRef(stored), nil
 }
 func (p *recordingWorkflowProvider) GetExecutionReference(_ context.Context, id string) (*coreworkflow.ExecutionReference, error) {
+	if err := p.getExecutionReferenceErrs[strings.TrimSpace(id)]; err != nil {
+		return nil, err
+	}
 	if ref := p.executionRefs[strings.TrimSpace(id)]; ref != nil {
 		return cloneBootstrapWorkflowExecutionRef(ref), nil
 	}
@@ -5507,6 +5511,69 @@ func TestBootstrapReusesConfiguredWorkflowExecutionRefAcrossUnchangedBootstrap(t
 	}
 	if ref.RevokedAt != nil {
 		t.Fatalf("revokedAt = %#v, want nil", ref.RevokedAt)
+	}
+}
+
+func TestBootstrapReplacesUnreadableConfiguredWorkflowExecutionRef(t *testing.T) {
+	t.Parallel()
+
+	const staleExecutionRef = "workflow_schedule:stale-ref"
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		Schedules: map[string]workflowFixtureSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	})
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	provider := &recordingWorkflowProvider{
+		schedules: map[string]*coreworkflow.Schedule{
+			workflowConfigScheduleID("nightly_sync"): {
+				ID:           workflowConfigScheduleID("nightly_sync"),
+				Cron:         "0 2 * * *",
+				Timezone:     "UTC",
+				Target:       coreWorkflowPluginTarget("roadmap", "sync"),
+				ExecutionRef: staleExecutionRef,
+				CreatedBy: coreworkflow.Actor{
+					SubjectID:   "system:config",
+					SubjectKind: "system",
+					AuthSource:  "config",
+				},
+			},
+		},
+		getExecutionReferenceErrs: map[string]error{
+			staleExecutionRef: status.Error(codes.Internal, "query temporal index: workflow task failed"),
+		},
+	}
+	factories := validFactories()
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return provider, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(provider.upsertedSchedules) != 1 {
+		t.Fatalf("upserted schedules = %d, want 1", len(provider.upsertedSchedules))
+	}
+	replacementExecutionRef := provider.upsertedSchedules[0].ExecutionRef
+	if replacementExecutionRef == "" || replacementExecutionRef == staleExecutionRef {
+		t.Fatalf("replacement execution ref = %q, want fresh ref", replacementExecutionRef)
+	}
+	if _, err := provider.GetExecutionReference(context.Background(), replacementExecutionRef); err != nil {
+		t.Fatalf("Get replacement execution ref: %v", err)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -63,7 +63,7 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q: %w", desiredEntry.TriggerKey, pluginName, err)
 		}
-		executionRefID, createdExecutionRef, err := workflowEnsureConfigExecutionRef(
+		executionRefID, createdExecutionRef, replacedUnreadableExecutionRef, replacedUnreadableExecutionRefErr, err := workflowEnsureConfigExecutionRef(
 			ctx,
 			executionRefs,
 			desiredExecutionRef,
@@ -86,7 +86,10 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 			}
 			return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q: %w", desiredEntry.TriggerKey, pluginName, err)
 		}
-		if existingExecutionRef != executionRefID {
+		if replacedUnreadableExecutionRef != "" {
+			workflowLogReplacedUnreadableExecutionRef(ctx, "event_trigger", desiredEntry.TriggerKey, desiredEntry.TriggerID, providerName, pluginName, replacedUnreadableExecutionRef, executionRefID, replacedUnreadableExecutionRefErr)
+		}
+		if existingExecutionRef != executionRefID && replacedUnreadableExecutionRef == "" {
 			if err := workflowRevokeExecutionRefByID(ctx, executionRefs, existingExecutionRef); err != nil {
 				return fmt.Errorf("bootstrap: revoke workflow execution ref %q for event trigger %q on plugin %q: %w", existingExecutionRef, desiredEntry.TriggerID, pluginName, err)
 			}

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"slices"
 	"strings"
@@ -75,7 +76,7 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q: %w", desiredEntry.ScheduleKey, pluginName, err)
 		}
-		executionRefID, createdExecutionRef, err := workflowEnsureConfigExecutionRef(
+		executionRefID, createdExecutionRef, replacedUnreadableExecutionRef, replacedUnreadableExecutionRefErr, err := workflowEnsureConfigExecutionRef(
 			ctx,
 			executionRefs,
 			desiredExecutionRef,
@@ -99,7 +100,10 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 			}
 			return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q: %w", desiredEntry.ScheduleKey, pluginName, err)
 		}
-		if existingExecutionRef != executionRefID {
+		if replacedUnreadableExecutionRef != "" {
+			workflowLogReplacedUnreadableExecutionRef(ctx, "schedule", desiredEntry.ScheduleKey, desiredEntry.ScheduleID, providerName, pluginName, replacedUnreadableExecutionRef, executionRefID, replacedUnreadableExecutionRefErr)
+		}
+		if existingExecutionRef != executionRefID && replacedUnreadableExecutionRef == "" {
 			if err := workflowRevokeExecutionRefByID(ctx, executionRefs, existingExecutionRef); err != nil {
 				return fmt.Errorf("bootstrap: revoke workflow execution ref %q for schedule %q on plugin %q: %w", existingExecutionRef, desiredEntry.ScheduleID, pluginName, err)
 			}
@@ -330,14 +334,16 @@ func workflowEnsureConfigExecutionRef(
 	desired *coreworkflow.ExecutionReference,
 	refID string,
 	candidateIDs ...string,
-) (string, bool, error) {
+) (string, bool, string, error, error) {
 	if store == nil {
-		return "", false, fmt.Errorf("workflow execution refs are not configured")
+		return "", false, "", nil, fmt.Errorf("workflow execution refs are not configured")
 	}
 	refID = strings.TrimSpace(refID)
 	if refID == "" {
-		return "", false, fmt.Errorf("workflow execution ref id is required")
+		return "", false, "", nil, fmt.Errorf("workflow execution ref id is required")
 	}
+	replacedUnreadableCandidateID := ""
+	var replacedUnreadableCandidateErr error
 	for _, candidateID := range candidateIDs {
 		candidateID = strings.TrimSpace(candidateID)
 		if candidateID == "" {
@@ -348,17 +354,21 @@ func workflowEnsureConfigExecutionRef(
 			if isWorkflowObjectNotFound(err) {
 				continue
 			}
-			return "", false, err
+			if replacedUnreadableCandidateID == "" {
+				replacedUnreadableCandidateID = candidateID
+				replacedUnreadableCandidateErr = err
+			}
+			continue
 		}
 		if workflowConfigExecutionRefMatches(existing, desired) {
-			return candidateID, false, nil
+			return candidateID, false, "", nil, nil
 		}
 	}
 	desired.ID = refID
 	if _, err := store.PutExecutionReference(ctx, desired); err != nil {
-		return "", false, err
+		return "", false, "", nil, err
 	}
-	return refID, true, nil
+	return refID, true, replacedUnreadableCandidateID, replacedUnreadableCandidateErr, nil
 }
 
 func workflowExecutionRefPermissionsForTarget(target coreworkflow.Target, explicit ...[]core.AccessPermission) []core.AccessPermission {
@@ -644,6 +654,19 @@ func workflowExecutionReferenceStore(providerName string, provider coreworkflow.
 		return nil, fmt.Errorf("workflow provider %q does not support execution refs", strings.TrimSpace(providerName))
 	}
 	return store, nil
+}
+
+func workflowLogReplacedUnreadableExecutionRef(ctx context.Context, objectType, objectKey, objectID, providerName, pluginName, oldExecutionRef, newExecutionRef string, lookupErr error) {
+	slog.WarnContext(ctx, "replaced unreadable workflow execution ref during config reconciliation",
+		"workflow_object_type", strings.TrimSpace(objectType),
+		"workflow_object_key", strings.TrimSpace(objectKey),
+		"workflow_object_id", strings.TrimSpace(objectID),
+		"workflow_provider", strings.TrimSpace(providerName),
+		"plugin", strings.TrimSpace(pluginName),
+		"old_execution_ref", strings.TrimSpace(oldExecutionRef),
+		"new_execution_ref", strings.TrimSpace(newExecutionRef),
+		"error", lookupErr,
+	)
 }
 
 func workflowRevokeExecutionRefByID(ctx context.Context, store coreworkflow.ExecutionReferenceStore, refID string) error {


### PR DESCRIPTION
## Summary
- Let config-managed workflow schedules and event triggers replace an existing execution ref when that ref cannot be queried.
- Avoid failing server readiness on stale Temporal execution-ref/index state while preserving reuse for healthy matching refs.
- Log a structured warning whenever reconciliation replaces an unreadable execution ref, including provider, object, plugin, old/new refs, and lookup error.
- Add a regression test covering an unreadable configured schedule execution ref.

## Test plan
- [x] `go test ./internal/bootstrap -run 'TestBootstrap(ReusesConfiguredWorkflowExecutionRefAcrossUnchangedBootstrap|ReplacesUnreadableConfiguredWorkflowExecutionRef|RefreshesConfiguredWorkflowExecutionRefWhenMetadataChanges)$'`
- [ ] `go test ./internal/bootstrap` hit unrelated existing `TestClientCredentialsTokenSourceFetchTimeoutReleasesFlight` timeout locally.