### PR TITLE
Serve mounted UI directory routes from static exports

### DIFF
--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6901,15 +6901,24 @@ func TestMountedUIAuthorizationPolicyUsesCanonicalNavigationPaths(t *testing.T) 
 		t.Fatalf("asset status = %d, want %d", assetResp.StatusCode, http.StatusOK)
 	}
 
-	reportsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/reports/index.html", nil)
-	reportsReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
-	reportsResp, err := http.DefaultClient.Do(reportsReq)
-	if err != nil {
-		t.Fatalf("GET protected mounted reports html: %v", err)
-	}
-	defer func() { _ = reportsResp.Body.Close() }()
-	if reportsResp.StatusCode != http.StatusOK {
-		t.Fatalf("reports html status = %d, want %d", reportsResp.StatusCode, http.StatusOK)
+	for _, path := range []string{"/sample-portal/reports", "/sample-portal/reports/", "/sample-portal/reports/index.html"} {
+		reportsReq, _ := http.NewRequest(http.MethodGet, ts.URL+path, nil)
+		reportsReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+		reportsResp, err := http.DefaultClient.Do(reportsReq)
+		if err != nil {
+			t.Fatalf("GET protected mounted reports html %s: %v", path, err)
+		}
+		body, err := io.ReadAll(reportsResp.Body)
+		_ = reportsResp.Body.Close()
+		if err != nil {
+			t.Fatalf("read protected mounted reports html %s: %v", path, err)
+		}
+		if reportsResp.StatusCode != http.StatusOK {
+			t.Fatalf("%s status = %d, want %d", path, reportsResp.StatusCode, http.StatusOK)
+		}
+		if !strings.Contains(string(body), "<html>reports</html>") {
+			t.Fatalf("%s body = %q, want reports html", path, string(body))
+		}
 	}
 }
 

--- a/gestaltd/services/ui/static_handler.go
+++ b/gestaltd/services/ui/static_handler.go
@@ -159,6 +159,9 @@ func cleanStaticPath(path string) (string, bool) {
 	if path == "" {
 		return "index.html", true
 	}
+	if strings.Contains(path, "\\") {
+		return "", false
+	}
 	if hasParentPathElement(path) {
 		return "", false
 	}

--- a/gestaltd/services/ui/static_handler.go
+++ b/gestaltd/services/ui/static_handler.go
@@ -89,10 +89,14 @@ type requestResolution struct {
 }
 
 func (h *handler) resolve(path string) requestResolution {
-	if path == "" {
-		path = "index.html"
+	path, ok := cleanStaticPath(path)
+	if !ok {
+		return requestResolution{
+			navigation: true,
+			routePath:  "/",
+			serveIndex: true,
+		}
 	}
-	path = strings.TrimPrefix(path, "/")
 
 	if info, err := fs.Stat(h.fs, path); err == nil && !info.IsDir() {
 		if routePath, ok := navigationRoutePath(path); ok {
@@ -150,6 +154,31 @@ func isNavigationHTML(path string) bool {
 	return ok
 }
 
+func cleanStaticPath(path string) (string, bool) {
+	path = strings.TrimPrefix(path, "/")
+	if path == "" {
+		return "index.html", true
+	}
+	if hasParentPathElement(path) {
+		return "", false
+	}
+	path = stdpath.Clean(path)
+	if path == "." {
+		return "index.html", true
+	}
+	path = strings.TrimPrefix(path, "/")
+	return path, fs.ValidPath(path)
+}
+
+func hasParentPathElement(path string) bool {
+	for _, part := range strings.Split(path, "/") {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
+}
+
 func cleanRoutePath(path string) string {
 	path = stdpath.Clean(path)
 	if path == "." {
@@ -169,7 +198,11 @@ func serveIndex(w http.ResponseWriter, r *http.Request, readIndex func() ([]byte
 }
 
 func serveFile(w http.ResponseWriter, r *http.Request, fsys fs.FS, path string) {
-	path = strings.TrimPrefix(path, "/")
+	path, ok := cleanStaticPath(path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
 	data, err := fs.ReadFile(fsys, path)
 	if err != nil {
 		http.NotFound(w, r)

--- a/gestaltd/services/ui/static_handler.go
+++ b/gestaltd/services/ui/static_handler.go
@@ -67,6 +67,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case resolution.serveIndex:
 		serveIndex(w, r, h.readIndex)
+	case resolution.servePath != "" && isNavigationHTML(resolution.servePath):
+		serveFile(w, r, h.fs, resolution.servePath)
 	case resolution.servePath != "":
 		serve(h.fileServer, w, r, resolution.servePath)
 	default:
@@ -102,19 +104,23 @@ func (h *handler) resolve(path string) requestResolution {
 		return requestResolution{servePath: "/" + path}
 	}
 
-	if !strings.Contains(path, ".") {
-		if _, err := fs.Stat(h.fs, path+".html"); err == nil {
+	routePath := strings.TrimRight(path, "/")
+	if routePath == "" {
+		routePath = "index.html"
+	}
+	if !strings.Contains(routePath, ".") {
+		if _, err := fs.Stat(h.fs, routePath+".html"); err == nil {
 			return requestResolution{
 				navigation: true,
-				routePath:  cleanRoutePath("/" + path),
-				servePath:  "/" + path + ".html",
+				routePath:  cleanRoutePath("/" + routePath),
+				servePath:  "/" + routePath + ".html",
 			}
 		}
-		if _, err := fs.Stat(h.fs, path+"/index.html"); err == nil {
+		if _, err := fs.Stat(h.fs, routePath+"/index.html"); err == nil {
 			return requestResolution{
 				navigation: true,
-				routePath:  cleanRoutePath("/" + path),
-				servePath:  "/" + path + "/index.html",
+				routePath:  cleanRoutePath("/" + routePath),
+				servePath:  "/" + routePath + "/index.html",
 			}
 		}
 	}
@@ -139,6 +145,11 @@ func navigationRoutePath(path string) (string, bool) {
 	}
 }
 
+func isNavigationHTML(path string) bool {
+	_, ok := navigationRoutePath(strings.TrimPrefix(path, "/"))
+	return ok
+}
+
 func cleanRoutePath(path string) string {
 	path = stdpath.Clean(path)
 	if path == "." {
@@ -155,6 +166,16 @@ func serveIndex(w http.ResponseWriter, r *http.Request, readIndex func() ([]byte
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	http.ServeContent(w, r, "index.html", time.Time{}, bytes.NewReader(data))
+}
+
+func serveFile(w http.ResponseWriter, r *http.Request, fsys fs.FS, path string) {
+	path = strings.TrimPrefix(path, "/")
+	data, err := fs.ReadFile(fsys, path)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	http.ServeContent(w, r, stdpath.Base(path), time.Time{}, bytes.NewReader(data))
 }
 
 func serve(h http.Handler, w http.ResponseWriter, r *http.Request, path string) {

--- a/gestaltd/services/ui/ui_test.go
+++ b/gestaltd/services/ui/ui_test.go
@@ -38,6 +38,14 @@ func mustServe(t *testing.T, handler http.Handler, path string) (int, string) {
 	return resp.StatusCode, string(body)
 }
 
+func mustServeRequest(t *testing.T, handler http.Handler, path string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
 func TestDirHandler_ServesFilesAndFallbacks(t *testing.T) {
 	t.Parallel()
 
@@ -157,6 +165,30 @@ func TestDirHandler_ServesFilesAndFallbacks(t *testing.T) {
 				t.Fatalf("body = %q, want content containing %q", body, tc.want)
 			}
 		})
+	}
+}
+
+func TestDirHandler_DoesNotServeParentPathElements(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	assetDir := filepath.Join(parent, "assets")
+	mustWriteFile(t, assetDir, "index.html", "<html>home</html>")
+	mustWriteFile(t, parent, "secret.html", "<html>secret</html>")
+
+	handler, err := DirHandler(assetDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{"/../secret.html", "/../secret"} {
+		code, body := mustServeRequest(t, handler, path)
+		if code != http.StatusOK {
+			t.Fatalf("%s status = %d, want %d", path, code, http.StatusOK)
+		}
+		if strings.Contains(body, "secret") {
+			t.Fatalf("%s body = %q, should not include parent file content", path, body)
+		}
 	}
 }
 

--- a/gestaltd/services/ui/ui_test.go
+++ b/gestaltd/services/ui/ui_test.go
@@ -181,7 +181,7 @@ func TestDirHandler_DoesNotServeParentPathElements(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, path := range []string{"/../secret.html", "/../secret"} {
+	for _, path := range []string{"/../secret.html", "/../secret", `/..\secret.html`} {
 		code, body := mustServeRequest(t, handler, path)
 		if code != http.StatusOK {
 			t.Fatalf("%s status = %d, want %d", path, code, http.StatusOK)

--- a/gestaltd/services/ui/ui_test.go
+++ b/gestaltd/services/ui/ui_test.go
@@ -105,6 +105,33 @@ func TestDirHandler_ServesFilesAndFallbacks(t *testing.T) {
 			path: "/integrations",
 			want: "integrations",
 		},
+		{
+			name: "directory index fallback",
+			files: map[string]string{
+				"index.html":         "<html>home</html>",
+				"reports/index.html": "<html>reports</html>",
+			},
+			path: "/reports",
+			want: "reports",
+		},
+		{
+			name: "directory index fallback with trailing slash",
+			files: map[string]string{
+				"index.html":         "<html>home</html>",
+				"reports/index.html": "<html>reports</html>",
+			},
+			path: "/reports/",
+			want: "reports",
+		},
+		{
+			name: "directory index file served without root fallback",
+			files: map[string]string{
+				"index.html":         "<html>home</html>",
+				"reports/index.html": "<html>reports</html>",
+			},
+			path: "/reports/index.html",
+			want: "reports",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
- Preserve route-specific directory exports for mounted UI bundles, including slash, no-slash, and explicit `index.html` requests.
- Avoid `http.FileServer` index redirects for generated navigation HTML while leaving normal static asset serving unchanged.
- Reject parent path elements and backslash separators before direct static HTML reads so route serving stays within the UI asset root across platforms.

## Interface Changes
- New/changed interface: Mounted UI HTTP serving now resolves `/route`, `/route/`, and `/route/index.html` to `route/index.html` when that file exists.
- Example usage: `GET /it-account-onboarding/manual/` serves the manual route export instead of falling back to the root dashboard shell.

## Functional/Integration Tests
- Tests added or augmented: `TestDirHandler_ServesFilesAndFallbacks`, `TestDirHandler_DoesNotServeParentPathElements`, `TestMountedUIAuthorizationPolicyUsesCanonicalNavigationPaths`.
- Contract boundary covered: mounted HTTP UI routes resolving to directory-export HTML under route authorization, with direct-read path traversal guarded.
- Commands run: `go test ./services/ui ./internal/server -run 'TestDirHandler_ServesFilesAndFallbacks|TestDirHandler_DoesNotServeParentPathElements|TestMountedUIAuthorizationPolicyUsesCanonicalNavigationPaths' -count=1`.