### PR TITLE
Make workflow config cleanup best effort

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -5261,6 +5261,78 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedules(t *testing.T) {
 	}
 }
 
+func TestBootstrapSkipsRemovedConfiguredWorkflowScheduleCleanupWhenListFails(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	recorders := []*recordingWorkflowProvider{}
+	sharedSchedules := map[string]*coreworkflow.Schedule{}
+	sharedExecutionRefs := map[string]*coreworkflow.ExecutionReference{}
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{
+			schedules:     sharedSchedules,
+			executionRefs: sharedExecutionRefs,
+		}
+		if len(recorders) == 1 {
+			recorder.listSchedulesErr = errors.New("visibility index unavailable")
+		}
+		recorders = append(recorders, recorder)
+		return recorder, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		Schedules: map[string]workflowFixtureSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	})
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	if len(recorders) != 1 || len(recorders[0].upsertedSchedules) != 1 {
+		t.Fatalf("initial upserts = %#v", recorders)
+	}
+	_ = result.Close(context.Background())
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+	})
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap remove schedule with list failure: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(recorders) != 2 {
+		t.Fatalf("recorders = %d, want 2", len(recorders))
+	}
+	recorder := recorders[1]
+	if len(recorder.deletedSchedules) != 0 {
+		t.Fatalf("deleted schedules = %d, want 0", len(recorder.deletedSchedules))
+	}
+	if sharedSchedules[workflowConfigScheduleID("nightly_sync")] == nil {
+		t.Fatal("stale schedule should remain for a later cleanup pass")
+	}
+}
+
 func TestBootstrapIgnoresUserSchedulesThatOnlyShareCfgPrefix(t *testing.T) {
 	t.Parallel()
 
@@ -6255,6 +6327,79 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowEventTriggers(t *testing.T) {
 	}
 	if len(recorder.upsertedEventTriggers) != 0 {
 		t.Fatalf("upserted event triggers = %d, want 0", len(recorder.upsertedEventTriggers))
+	}
+}
+
+func TestBootstrapSkipsRemovedConfiguredWorkflowEventTriggerCleanupWhenListFails(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	recorders := []*recordingWorkflowProvider{}
+	sharedEventTriggers := map[string]*coreworkflow.EventTrigger{}
+	sharedExecutionRefs := map[string]*coreworkflow.ExecutionReference{}
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{
+			eventTriggers: sharedEventTriggers,
+			executionRefs: sharedExecutionRefs,
+		}
+		if len(recorders) == 1 {
+			recorder.listEventTriggersErr = errors.New("visibility index unavailable")
+		}
+		recorders = append(recorders, recorder)
+		return recorder, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		EventTriggers: map[string]workflowFixtureEventTrigger{
+			"task_updated": {
+				Match: workflowFixtureEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+			},
+		},
+	})
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	if len(recorders) != 1 || len(recorders[0].upsertedEventTriggers) != 1 {
+		t.Fatalf("initial upserts = %#v", recorders)
+	}
+	_ = result.Close(context.Background())
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+	})
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap remove event trigger with list failure: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(recorders) != 2 {
+		t.Fatalf("recorders = %d, want 2", len(recorders))
+	}
+	recorder := recorders[1]
+	if len(recorder.deletedEventTriggers) != 0 {
+		t.Fatalf("deleted event triggers = %d, want 0", len(recorder.deletedEventTriggers))
+	}
+	if sharedEventTriggers[workflowConfigEventTriggerID("task_updated")] == nil {
+		t.Fatal("stale event trigger should remain for a later cleanup pass")
 	}
 }
 

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"maps"
 	"slices"
 	"strings"
@@ -137,7 +138,8 @@ func cleanupRemovedWorkflowConfigEventTriggers(ctx context.Context, runtime *wor
 		}
 		triggers, err := provider.ListEventTriggers(ctx, coreworkflow.ListEventTriggersRequest{})
 		if err != nil {
-			return fmt.Errorf("bootstrap: list workflow event triggers for provider %q: %w", providerName, err)
+			slog.WarnContext(ctx, "skipping workflow event trigger cleanup because provider list failed", "workflow_provider", providerName, "error", err)
+			continue
 		}
 		var executionRefs coreworkflow.ExecutionReferenceStore
 		for _, trigger := range triggers {

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -168,7 +168,8 @@ func cleanupRemovedWorkflowConfigSchedules(ctx context.Context, runtime *workflo
 		}
 		schedules, err := provider.ListSchedules(ctx, coreworkflow.ListSchedulesRequest{})
 		if err != nil {
-			return fmt.Errorf("bootstrap: list workflow schedules for provider %q: %w", providerName, err)
+			slog.WarnContext(ctx, "skipping workflow schedule cleanup because provider list failed", "workflow_provider", providerName, "error", err)
+			continue
 		}
 		var executionRefs coreworkflow.ExecutionReferenceStore
 		for _, schedule := range schedules {


### PR DESCRIPTION
## Summary
- Treat workflow schedule and event-trigger cleanup list failures as non-fatal during bootstrap.
- Log and skip cleanup for the affected workflow provider so desired config can still be reconciled and the service can start.
- Add regression coverage for both removed schedule cleanup and removed event-trigger cleanup when provider visibility/listing fails.

## Context
The toolshed deploy from valon-technologies/toolshed#1427 got past the schedule execution-ref outage handled by #1808, then repeatedly failed Cloud Run startup with:

```
bootstrap: bootstrap: list workflow event triggers for provider "local": rpc error: code = Internal desc = query temporal index shard 0: context canceled
```

Cleanup of removed config-owned workflow objects should not be an availability gate. Leaving stale config-owned schedules/triggers in place is safer than blocking startup; a later successful bootstrap can clean them up.

## Tests
- `go test ./internal/bootstrap`
