### PR TITLE
Skip workflow config cleanup when indexes are unavailable

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -5261,6 +5261,64 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedules(t *testing.T) {
 	}
 }
 
+func TestBootstrapSkipsRemovedConfiguredWorkflowScheduleCleanupWhenListFails(t *testing.T) {
+	t.Parallel()
+
+	factories := validFactories()
+	recorders := []*recordingWorkflowProvider{}
+	sharedSchedules := map[string]*coreworkflow.Schedule{}
+	sharedExecutionRefs := map[string]*coreworkflow.ExecutionReference{}
+	failListSchedules := false
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{
+			schedules:     sharedSchedules,
+			executionRefs: sharedExecutionRefs,
+		}
+		if failListSchedules {
+			recorder.listSchedulesErr = errors.New("schedule index unavailable")
+		}
+		recorders = append(recorders, recorder)
+		return recorder, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		Schedules: map[string]workflowFixtureSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	})
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	<-result.ProvidersReady
+	_ = result.Close(context.Background())
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{Provider: "temporal"})
+	failListSchedules = true
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap with schedule cleanup list failure: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(recorders) != 2 {
+		t.Fatalf("recorders = %d, want 2", len(recorders))
+	}
+	if len(recorders[1].deletedSchedules) != 0 {
+		t.Fatalf("deleted schedules = %d, want 0", len(recorders[1].deletedSchedules))
+	}
+}
+
 func TestBootstrapIgnoresUserSchedulesThatOnlyShareCfgPrefix(t *testing.T) {
 	t.Parallel()
 
@@ -6255,6 +6313,63 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowEventTriggers(t *testing.T) {
 	}
 	if len(recorder.upsertedEventTriggers) != 0 {
 		t.Fatalf("upserted event triggers = %d, want 0", len(recorder.upsertedEventTriggers))
+	}
+}
+
+func TestBootstrapSkipsRemovedConfiguredWorkflowEventTriggerCleanupWhenListFails(t *testing.T) {
+	t.Parallel()
+
+	factories := validFactories()
+	recorders := []*recordingWorkflowProvider{}
+	sharedEventTriggers := map[string]*coreworkflow.EventTrigger{}
+	sharedExecutionRefs := map[string]*coreworkflow.ExecutionReference{}
+	failListEventTriggers := false
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{
+			eventTriggers: sharedEventTriggers,
+			executionRefs: sharedExecutionRefs,
+		}
+		if failListEventTriggers {
+			recorder.listEventTriggersErr = errors.New("event trigger index unavailable")
+		}
+		recorders = append(recorders, recorder)
+		return recorder, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+		EventTriggers: map[string]workflowFixtureEventTrigger{
+			"task_updated": {
+				Match:     workflowFixtureEventMatch{Type: "task.updated"},
+				Operation: "sync",
+			},
+		},
+	})
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	<-result.ProvidersReady
+	_ = result.Close(context.Background())
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{Provider: "temporal"})
+	failListEventTriggers = true
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap with event trigger cleanup list failure: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(recorders) != 2 {
+		t.Fatalf("recorders = %d, want 2", len(recorders))
+	}
+	if len(recorders[1].deletedEventTriggers) != 0 {
+		t.Fatalf("deleted event triggers = %d, want 0", len(recorders[1].deletedEventTriggers))
 	}
 }
 

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"maps"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -71,6 +72,9 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 			existingExecutionRef,
 		)
 		if err != nil {
+			if existingExecutionRef != "" && workflowConfigEventTriggerDefinitionMatches(existing, target, trigger) {
+				continue
+			}
 			return fmt.Errorf("bootstrap: store workflow execution ref for event trigger %q on plugin %q: %w", desiredEntry.TriggerKey, pluginName, err)
 		}
 		if _, err := provider.UpsertEventTrigger(providerCtx, coreworkflow.UpsertEventTriggerRequest{
@@ -137,7 +141,8 @@ func cleanupRemovedWorkflowConfigEventTriggers(ctx context.Context, runtime *wor
 		}
 		triggers, err := provider.ListEventTriggers(ctx, coreworkflow.ListEventTriggersRequest{})
 		if err != nil {
-			return fmt.Errorf("bootstrap: list workflow event triggers for provider %q: %w", providerName, err)
+			workflowLogSkippedConfigCleanup(ctx, "event_triggers", providerName, err)
+			continue
 		}
 		var executionRefs coreworkflow.ExecutionReferenceStore
 		for _, trigger := range triggers {
@@ -164,6 +169,15 @@ func cleanupRemovedWorkflowConfigEventTriggers(ctx context.Context, runtime *wor
 		}
 	}
 	return nil
+}
+
+func workflowConfigEventTriggerDefinitionMatches(existing *coreworkflow.EventTrigger, target coreworkflow.Target, trigger config.WorkflowEventTriggerConfig) bool {
+	if existing == nil {
+		return false
+	}
+	return existing.Paused == trigger.Paused &&
+		reflect.DeepEqual(existing.Match, workflowConfigEventTriggerMatch(trigger)) &&
+		reflect.DeepEqual(existing.Target, target)
 }
 
 func isWorkflowConfigOwnedEventTrigger(existing *coreworkflow.EventTrigger, pluginName, triggerID string) bool {

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -168,7 +168,8 @@ func cleanupRemovedWorkflowConfigSchedules(ctx context.Context, runtime *workflo
 		}
 		schedules, err := provider.ListSchedules(ctx, coreworkflow.ListSchedulesRequest{})
 		if err != nil {
-			return fmt.Errorf("bootstrap: list workflow schedules for provider %q: %w", providerName, err)
+			workflowLogSkippedConfigCleanup(ctx, "schedules", providerName, err)
+			continue
 		}
 		var executionRefs coreworkflow.ExecutionReferenceStore
 		for _, schedule := range schedules {
@@ -679,6 +680,14 @@ func workflowLogReplacedUnreadableExecutionRef(ctx context.Context, objectType, 
 		"old_execution_ref", strings.TrimSpace(oldExecutionRef),
 		"new_execution_ref", strings.TrimSpace(newExecutionRef),
 		"error", lookupErr,
+	)
+}
+
+func workflowLogSkippedConfigCleanup(ctx context.Context, objectType, providerName string, err error) {
+	slog.WarnContext(ctx, "skipping workflow config cleanup because provider objects could not be listed",
+		"workflow_object_type", strings.TrimSpace(objectType),
+		"workflow_provider", strings.TrimSpace(providerName),
+		"error", err,
 	)
 }
 


### PR DESCRIPTION
## Summary
- Skip stale workflow schedule/event-trigger cleanup when the workflow provider cannot list indexed objects during bootstrap.
- Apply the existing-object fallback to event triggers as well as schedules when execution-ref refresh fails but the provider object still matches config.
- Add regression coverage for schedule and event-trigger cleanup list failures.

## Test plan
- [x] `go test ./internal/bootstrap`


Made with [Cursor](https://cursor.com)