### PR TITLE
Keep workflow cleanup from blocking startup on list outages

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -5942,6 +5942,37 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedulesWhenProviderDropsExec
 	}
 }
 
+func TestBootstrapSkipsRemovedWorkflowScheduleCleanupWhenProviderListFails(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+	})
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	provider := &recordingWorkflowProvider{
+		listSchedulesErr: status.Error(codes.Internal, "query temporal index: context canceled"),
+	}
+	factories := validFactories()
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return provider, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(provider.deletedSchedules) != 0 {
+		t.Fatalf("deleted schedules = %d, want 0", len(provider.deletedSchedules))
+	}
+}
+
 func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
 	t.Parallel()
 
@@ -6585,6 +6616,37 @@ func TestBootstrapIgnoresMissingPreviousEventTriggerDuringWorkflowProviderMove(t
 	}
 	if len(temporal.deletedEventTriggers) != 0 {
 		t.Fatalf("temporal deleted event triggers = %d, want 0", len(temporal.deletedEventTriggers))
+	}
+}
+
+func TestBootstrapSkipsRemovedWorkflowEventTriggerCleanupWhenProviderListFails(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
+		Provider: "temporal",
+	})
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	provider := &recordingWorkflowProvider{
+		listEventTriggersErr: status.Error(codes.Internal, "query temporal index shard 0: context canceled"),
+	}
+	factories := validFactories()
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return provider, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(provider.deletedEventTriggers) != 0 {
+		t.Fatalf("deleted event triggers = %d, want 0", len(provider.deletedEventTriggers))
 	}
 }
 

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -137,7 +137,8 @@ func cleanupRemovedWorkflowConfigEventTriggers(ctx context.Context, runtime *wor
 		}
 		triggers, err := provider.ListEventTriggers(ctx, coreworkflow.ListEventTriggersRequest{})
 		if err != nil {
-			return fmt.Errorf("bootstrap: list workflow event triggers for provider %q: %w", providerName, err)
+			workflowLogSkippedConfigWorkflowCleanup(ctx, "event_triggers", providerName, err)
+			continue
 		}
 		var executionRefs coreworkflow.ExecutionReferenceStore
 		for _, trigger := range triggers {

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -168,7 +168,8 @@ func cleanupRemovedWorkflowConfigSchedules(ctx context.Context, runtime *workflo
 		}
 		schedules, err := provider.ListSchedules(ctx, coreworkflow.ListSchedulesRequest{})
 		if err != nil {
-			return fmt.Errorf("bootstrap: list workflow schedules for provider %q: %w", providerName, err)
+			workflowLogSkippedConfigWorkflowCleanup(ctx, "schedules", providerName, err)
+			continue
 		}
 		var executionRefs coreworkflow.ExecutionReferenceStore
 		for _, schedule := range schedules {
@@ -199,6 +200,14 @@ func cleanupRemovedWorkflowConfigSchedules(ctx context.Context, runtime *workflo
 
 func workflowConfigProviderObjectKey(providerName, objectID string) string {
 	return strings.TrimSpace(providerName) + "\x00" + strings.TrimSpace(objectID)
+}
+
+func workflowLogSkippedConfigWorkflowCleanup(ctx context.Context, objectType, providerName string, err error) {
+	slog.WarnContext(ctx, "skipping config-managed workflow cleanup after provider list failed",
+		"object_type", objectType,
+		"provider", providerName,
+		"error", err,
+	)
 }
 
 func isWorkflowConfigOwnedSchedule(existing *coreworkflow.Schedule, pluginName, scheduleID string) bool {


### PR DESCRIPTION
## Summary
- Keeps config-managed workflow cleanup best-effort when a workflow provider cannot list existing schedules or event triggers.
- Desired config-managed schedules/event triggers are still reconciled first; only stale-object cleanup is deferred until a later bootstrap when the provider index is queryable again.
- Adds regression coverage for Temporal-style list failures on both schedule and event-trigger cleanup.

## Why
The Valon Tools post-merge deploy for `fc8b7aa` got past the previous failed-workflow-task schedule ref issue, but Cloud Run startup is still failing while bootstrapping workflow cleanup:

```text
bootstrap: bootstrap: list workflow event triggers for provider "local": rpc error: code = Internal desc = query temporal index shard 0: context canceled
```

That cleanup path is not required for serving the current config. Failing startup there turns a transient Temporal index/list outage into Cloud Run unavailability.

## Functional/Integration Tests
- `go test ./internal/bootstrap`

## Rollout
After this lands, toolshed should pin `GESTALT_REF` to the merge commit and rerun Deploy Valon Tools. The existing Claude alpha20 config is already on toolshed `main` and the GKE agent runtime image build has passed with it.
