### PR TITLE
Add hosted workflow runtime pools

### DIFF
--- a/docs/content/custom-providers/runtime.mdx
+++ b/docs/content/custom-providers/runtime.mdx
@@ -21,9 +21,9 @@ Gestalt-owned services. How is hostname-based egress preserved. How does the
 host dial the hosted plugin back once it starts.
 
 It does **not** replace the host-local authentication, authorization,
-IndexedDB, cache, S3, secrets, or workflow providers. Those remain on the
-`gestaltd` host. A runtime provider only changes where the plugin process runs
-and how the host reaches it.
+IndexedDB, cache, S3, or secrets providers. Those remain on the `gestaltd`
+host. A runtime provider changes where executable plugin, agent, and workflow
+provider processes run and how the host reaches them.
 
 ## Manifest
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -524,6 +524,39 @@ named host IndexedDB provider into the workflow provider. `indexeddb.db`
 defaults to the workflow provider name, and `indexeddb.objectStores` can
 allowlist logical stores exposed through that binding.
 
+Workflow providers can also opt into hosted execution. `gestaltd serve`
+starts hosted workflow workers automatically after the provider graph is ready;
+there is no separate worker command to run. A hosted workflow provider may set
+`execution.runtime.pool` to keep a fixed pool of runtime sessions ready for
+polling backends such as Temporal. Workflow runtime pools are fixed-size:
+`maxReadyInstances` must match `minReadyInstances`.
+
+```yaml
+providers:
+  workflow:
+    temporal:
+      source: https://artifacts.example.com/workflow/temporal/v0.0.1-alpha.1/provider-release.yaml
+      execution:
+        mode: hosted
+        runtime:
+          provider: gke
+          template: workflow-workers
+          pool:
+            minReadyInstances: 2
+            maxReadyInstances: 2
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
+      config:
+        namespace: default
+
+runtime:
+  providers:
+    gke:
+      source: https://artifacts.example.com/runtime/gke/v0.0.1-alpha.1/provider-release.yaml
+```
+
 | Field | Description |
 | --- | --- |
 | `default` | Marks this named workflow entry as the default selection when a config-managed workflow object or API request omits `provider`. |
@@ -532,6 +565,7 @@ allowlist logical stores exposed through that binding.
 | `config` | Provider-specific config passed into the workflow provider. |
 | `indexeddb` | Optional host IndexedDB binding for the workflow provider, including `provider`, optional `db`, and optional `objectStores`. |
 | `env` | Extra environment variables passed to the provider process. |
+| `execution` | Optional hosted execution selection for this workflow provider. `execution.mode` is `local` or `hosted`; `execution.runtime` supports `provider`, `template`, `image`, `imagePullAuth`, `metadata`, and `pool`. `pool` contains hosted workflow worker lifecycle fields: `minReadyInstances`, `maxReadyInstances`, `startupTimeout`, `healthCheckInterval`, `restartPolicy`, and `drainTimeout`. |
 | `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `providers.agent`

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1749,9 +1749,6 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 	if entry == nil {
 		return nil, fmt.Errorf("workflow provider is required")
 	}
-	if factories.Workflow == nil {
-		return nil, fmt.Errorf("workflow factory is not registered")
-	}
 	node := entry.Config
 	if !config.IsComponentRuntimeConfigNode(node) {
 		var err error
@@ -1785,7 +1782,15 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 		hostServices = append(hostServices, indexedDBHostServices...)
 		cleanup = chainCleanup(cleanup, indexedDBCleanup)
 	}
-	provider, err := factories.Workflow(ctx, name, node, hostServices, deps)
+	var provider coreworkflow.Provider
+	if entry.UsesHostedExecution() {
+		provider, err = buildHostedWorkflowProvider(ctx, name, entry, node, hostServices, deps)
+	} else {
+		if factories.Workflow == nil {
+			return nil, fmt.Errorf("workflow factory is not registered")
+		}
+		provider, err = factories.Workflow(ctx, name, node, hostServices, deps)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("workflow provider: %w", err)
 	}

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider.go
@@ -1,0 +1,871 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"sync"
+	"time"
+
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/providerdrivers/componentprovider"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost/pluginruntime"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
+	"gopkg.in/yaml.v3"
+)
+
+const hostedWorkflowRuntimeLifecycleSafetyMargin = 5 * time.Second
+
+type hostedWorkflowProviderLaunch struct {
+	name            string
+	runtimeConfig   config.EffectiveHostedRuntime
+	runtimeProvider pluginruntime.Provider
+	runtimeOwned    bool
+	runtimePlan     HostedRuntimePlan
+	cfg             componentprovider.YAMLConfig
+	allowedHosts    []string
+	launch          hostedProcessLaunch
+	cleanup         func()
+}
+
+type hostedWorkflowProviderInstance struct {
+	provider         coreworkflow.Provider
+	runtimeProvider  pluginruntime.Provider
+	runtimeSessionID string
+	runtimeSession   *pluginruntime.Session
+}
+
+func buildHostedWorkflowProvider(ctx context.Context, name string, entry *config.ProviderEntry, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (coreworkflow.Provider, error) {
+	launch, err := prepareHostedWorkflowProviderLaunch(ctx, name, entry, node, deps)
+	if err != nil {
+		return nil, err
+	}
+	hostServices = appendRuntimeLogHostService(hostServices, launch.runtimeConfig, deps, launch.runtimePlan)
+	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps, launch.runtimePlan, launch.runtimeProvider)
+	if err != nil {
+		launch.close()
+		return nil, err
+	}
+	launch.cleanup = chainCleanup(launch.cleanup, publicHostServicesCleanup)
+
+	runtimeCfg := entry.HostedRuntimeConfig()
+	if runtimeCfg != nil && runtimeCfg.LifecyclePolicyFieldsSet() {
+		policy, err := runtimeCfg.LifecyclePolicy()
+		if err != nil {
+			launch.close()
+			return nil, fmt.Errorf("parse hosted workflow runtime lifecycle policy: %w", err)
+		}
+		return newHostedWorkflowProviderPool(ctx, launch, hostServices, deps, policy)
+	}
+	cleanup := launch.cleanup
+	launch.cleanup = nil
+	instance, err := startHostedWorkflowProviderInstance(ctx, launch, hostServices, deps, launch.runtimeOwned, cleanup, 0)
+	if err != nil {
+		launch.close()
+		return nil, err
+	}
+	return instance.provider, nil
+}
+
+func (p *hostedWorkflowProviderLaunch) close() {
+	if p == nil {
+		return
+	}
+	if p.runtimeOwned && p.runtimeProvider != nil {
+		_ = p.runtimeProvider.Close()
+	}
+	if p.cleanup != nil {
+		p.cleanup()
+		p.cleanup = nil
+	}
+}
+
+func prepareHostedWorkflowProviderLaunch(ctx context.Context, name string, entry *config.ProviderEntry, node yaml.Node, deps Deps) (*hostedWorkflowProviderLaunch, error) {
+	runtimeConfig, runtimeProvider, runtimeOwned, err := effectiveConfiguredHostedRuntime(ctx, "providers.workflow."+name, entry, deps)
+	if err != nil {
+		return nil, err
+	}
+	if runtimeProvider == nil {
+		return nil, fmt.Errorf("workflow provider: runtime is required")
+	}
+	runtimeSupport, err := runtimeProvider.Support(ctx)
+	if err != nil {
+		if runtimeOwned {
+			_ = runtimeProvider.Close()
+		}
+		return nil, fmt.Errorf("query %s support: %w", hostedRuntimeLabel(runtimeConfig), err)
+	}
+	requiresHostnameEgress := deps.Egress.ProviderPolicy(entry).RequiresHostnameEnforcement()
+	runtimePlan := buildHostedRuntimePlan(runtimeSupport, deps, true, requiresHostnameEgress)
+	if err := runtimePlan.Validate(hostedRuntimeLabel(runtimeConfig)); err != nil {
+		if runtimeOwned {
+			_ = runtimeProvider.Close()
+		}
+		return nil, err
+	}
+
+	cfg, err := componentprovider.DecodeYAMLConfig(node, "workflow provider")
+	if err != nil {
+		if runtimeOwned {
+			_ = runtimeProvider.Close()
+		}
+		return nil, err
+	}
+	cleanup := func() {}
+	if !hostedRuntimeUsesImageEntrypoint(runtimeConfig) {
+		prepared, err := componentprovider.PrepareExecution(componentprovider.PrepareParams{
+			Kind:                 providermanifestv1.KindWorkflow,
+			Subject:              "workflow provider",
+			SourceMissingMessage: "no Go, Rust, Python, or TypeScript workflow provider source package found",
+			Config:               cfg,
+		})
+		if err != nil {
+			if runtimeOwned {
+				_ = runtimeProvider.Close()
+			}
+			return nil, err
+		}
+		cfg = prepared.YAMLConfig
+		cleanup = prepared.Cleanup
+	}
+	defer func() {
+		if cleanup != nil {
+			cleanup()
+		}
+	}()
+
+	launch, err := prepareHostedProcessLaunch(providermanifestv1.KindWorkflow, name, entry, cfg.Command, cfg.Args, cleanup, runtimeConfig)
+	if err != nil {
+		if runtimeOwned {
+			_ = runtimeProvider.Close()
+		}
+		return nil, err
+	}
+	cleanup = launch.cleanup
+
+	preparedLaunch := &hostedWorkflowProviderLaunch{
+		name:            name,
+		runtimeConfig:   runtimeConfig,
+		runtimeProvider: runtimeProvider,
+		runtimeOwned:    runtimeOwned,
+		runtimePlan:     runtimePlan,
+		cfg:             cfg,
+		allowedHosts:    entry.EffectiveAllowedHosts(),
+		launch:          launch,
+		cleanup:         cleanup,
+	}
+	cleanup = nil
+	return preparedLaunch, nil
+}
+
+func startHostedWorkflowProviderInstance(ctx context.Context, launch *hostedWorkflowProviderLaunch, hostServices []runtimehost.HostService, deps Deps, closeRuntime bool, cleanup func(), stopTimeout time.Duration) (*hostedWorkflowProviderInstance, error) {
+	if launch == nil {
+		return nil, fmt.Errorf("hosted workflow launch is required")
+	}
+	runtimeProvider := launch.runtimeProvider
+	if runtimeProvider == nil {
+		return nil, fmt.Errorf("workflow provider: runtime is required")
+	}
+	name := launch.name
+	session, err := runtimeProvider.StartSession(ctx, buildHostedRuntimeStartSessionRequest(providermanifestv1.KindWorkflow, name, launch.runtimeConfig))
+	if err != nil {
+		if closeRuntime {
+			_ = runtimeProvider.Close()
+		}
+		if cleanup != nil {
+			cleanup()
+		}
+		return nil, fmt.Errorf("start workflow runtime session: %w", err)
+	}
+	sessionID := session.ID
+	stopSession := true
+	closeOnFailure := closeRuntime
+	defer func() {
+		if !stopSession {
+			return
+		}
+		_ = stopPluginRuntimeSessionWithTimeout(runtimeProvider, sessionID, stopTimeout)
+		if closeOnFailure {
+			_ = runtimeProvider.Close()
+		}
+		if cleanup != nil {
+			cleanup()
+		}
+	}()
+	readySession, err := waitForPluginRuntimeSessionReady(ctx, runtimeProvider, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("wait for hosted workflow runtime session %q ready: %w", sessionID, err)
+	}
+
+	startEnv := withRuntimeSessionEnv(maps.Clone(launch.cfg.Env), sessionID)
+	startEnv = withHostServiceTLSCAEnv(startEnv, deps)
+	workflowAllowedHosts := launch.cfg.EgressPolicy("").AllowedHosts
+	if len(workflowAllowedHosts) == 0 {
+		workflowAllowedHosts = append([]string(nil), launch.allowedHosts...)
+	}
+	allowedHosts := hostedWorkflowAllowedHosts(workflowAllowedHosts, launch.runtimePlan)
+	for _, hostService := range hostServiceBindingDescriptorsFromConfigured(hostServices) {
+		bindingEnv, relayHost, err := buildHostedRuntimeHostServiceEnv(name, sessionID, hostService, deps)
+		if err != nil {
+			return nil, err
+		}
+		if len(bindingEnv) > 0 {
+			if startEnv == nil {
+				startEnv = make(map[string]string, len(bindingEnv))
+			}
+			maps.Copy(startEnv, bindingEnv)
+		}
+		if launch.runtimePlan.RequiresHostnameEgress {
+			allowedHosts = appendAllowedHost(allowedHosts, relayHost)
+		}
+	}
+	egressPlan, err := buildHostedRuntimeEgressLaunchPlan(name, sessionID, deps.Egress.Policy(workflowAllowedHosts), allowedHosts, launch.runtimePlan, deps)
+	if err != nil {
+		return nil, err
+	}
+	if len(egressPlan.Env) > 0 {
+		if startEnv == nil {
+			startEnv = make(map[string]string, len(egressPlan.Env))
+		}
+		maps.Copy(startEnv, egressPlan.Env)
+	}
+
+	hostedPlugin, err := runtimeProvider.StartPlugin(ctx, pluginruntime.StartPluginRequest{
+		SessionID:  sessionID,
+		PluginName: name,
+		Command:    launch.launch.command,
+		Args:       launch.launch.args,
+		Env:        startEnv,
+		Egress: pluginruntime.RuntimeEgressPolicy{
+			AllowedHosts:  egressPlan.RuntimeAllowedHosts,
+			DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
+		},
+		HostBinary: launch.cfg.HostBinary,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start hosted workflow provider: %w", err)
+	}
+	conn, err := pluginruntime.DialHostedWorkflow(ctx, hostedPlugin.DialTarget,
+		pluginruntime.WithProviderName(name),
+		pluginruntime.WithTelemetry(deps.Telemetry),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("dial hosted workflow provider: %w", err)
+	}
+	provider, err := workflowservice.NewRemote(ctx, workflowservice.RemoteConfig{
+		Client:  conn.Workflow(),
+		Runtime: conn.Lifecycle(),
+		Closer: &runtimeBackedHostedCloser{
+			conn:         conn,
+			runtime:      runtimeProvider,
+			sessionID:    sessionID,
+			closeRuntime: closeRuntime,
+			cleanup:      cleanup,
+			stopTimeout:  stopTimeout,
+		},
+		Config: launch.cfg.Config,
+		Name:   name,
+	})
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	stopSession = false
+	closeOnFailure = false
+	cleanup = nil
+	return &hostedWorkflowProviderInstance{
+		provider:         provider,
+		runtimeProvider:  runtimeProvider,
+		runtimeSessionID: sessionID,
+		runtimeSession:   readySession,
+	}, nil
+}
+
+func hostedWorkflowAllowedHosts(configured []string, runtimePlan HostedRuntimePlan) []string {
+	return hostedAgentAllowedHosts(configured, runtimePlan)
+}
+
+type hostedWorkflowProviderPool struct {
+	coreworkflow.Provider
+
+	executionRefs coreworkflow.ExecutionReferenceStore
+
+	name         string
+	launch       *hostedWorkflowProviderLaunch
+	hostServices []runtimehost.HostService
+	deps         Deps
+	policy       config.HostedRuntimeLifecyclePolicy
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	mu             sync.Mutex
+	nextID         int
+	starting       int
+	started        bool
+	controlStarted bool
+	closed         bool
+	workers        []*hostedWorkflowWorker
+}
+
+type hostedWorkflowWorker struct {
+	id               int
+	provider         coreworkflow.Provider
+	runtimeProvider  pluginruntime.Provider
+	runtimeSessionID string
+	runtimeSession   *pluginruntime.Session
+	startedAt        time.Time
+	runtimeDrainAt   *time.Time
+	forceCloseAt     *time.Time
+	active           int
+	draining         bool
+	closing          bool
+	closed           bool
+}
+
+func newHostedWorkflowProviderPool(ctx context.Context, launch *hostedWorkflowProviderLaunch, hostServices []runtimehost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy) (coreworkflow.Provider, error) {
+	if launch == nil {
+		return nil, fmt.Errorf("hosted workflow launch is required")
+	}
+	control, err := startHostedWorkflowProviderInstance(ctx, launch, hostServices, deps, false, nil, 0)
+	if err != nil {
+		launch.close()
+		return nil, err
+	}
+	executionRefs, _ := control.provider.(coreworkflow.ExecutionReferenceStore)
+	poolCtx, cancel := context.WithCancel(context.Background())
+	return &hostedWorkflowProviderPool{
+		Provider:      control.provider,
+		executionRefs: executionRefs,
+		name:          launch.name,
+		launch:        launch,
+		hostServices:  append([]runtimehost.HostService(nil), hostServices...),
+		deps:          deps,
+		policy:        policy,
+		ctx:           poolCtx,
+		cancel:        cancel,
+	}, nil
+}
+
+func (p *hostedWorkflowProviderPool) Start(ctx context.Context) error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return fmt.Errorf("hosted workflow provider %q is closed", p.name)
+	}
+	if p.started {
+		p.mu.Unlock()
+		return nil
+	}
+	p.started = true
+	p.mu.Unlock()
+
+	if err := p.startControl(ctx); err != nil {
+		p.markStartFailed()
+		return err
+	}
+	if err := p.ensureMinReady(ctx); err != nil {
+		p.markStartFailed()
+		return err
+	}
+	if p.policy.RestartPolicy != config.HostedRuntimeRestartPolicyNever {
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			p.healthLoop()
+		}()
+	}
+	return nil
+}
+
+func (p *hostedWorkflowProviderPool) startControl(ctx context.Context) error {
+	p.mu.Lock()
+	if p.controlStarted {
+		p.mu.Unlock()
+		return nil
+	}
+	provider := p.Provider
+	p.mu.Unlock()
+
+	if provider == nil {
+		return fmt.Errorf("hosted workflow provider %q has no control provider", p.name)
+	}
+	if starter, ok := provider.(startableWorkflowProvider); ok {
+		if err := starter.Start(ctx); err != nil {
+			return fmt.Errorf("start hosted workflow control provider: %w", err)
+		}
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return fmt.Errorf("hosted workflow provider %q is closed", p.name)
+	}
+	p.controlStarted = true
+	return nil
+}
+
+func (p *hostedWorkflowProviderPool) markStartFailed() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.closed {
+		p.started = false
+	}
+}
+
+func (p *hostedWorkflowProviderPool) Ping(ctx context.Context) error {
+	var joined []error
+	if p.Provider == nil {
+		joined = append(joined, fmt.Errorf("hosted workflow provider %q has no control provider", p.name))
+	} else if err := p.Provider.Ping(ctx); err != nil {
+		joined = append(joined, fmt.Errorf("control provider: %w", err))
+	}
+	if !p.isStarted() {
+		return errors.Join(joined...)
+	}
+	workers := p.readyWorkers()
+	if len(workers) == 0 {
+		joined = append(joined, fmt.Errorf("hosted workflow provider %q has no ready runtime workers", p.name))
+		return errors.Join(joined...)
+	}
+	errs := make(chan error, len(workers))
+	var wg sync.WaitGroup
+	for _, worker := range workers {
+		wg.Add(1)
+		go func(worker *hostedWorkflowWorker) {
+			defer wg.Done()
+			if !p.acquireWorker(worker) {
+				return
+			}
+			if err := worker.provider.Ping(ctx); err != nil {
+				errs <- fmt.Errorf("runtime worker %d: %w", worker.id, err)
+			}
+			p.releaseWorker(worker)
+		}(worker)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		joined = append(joined, err)
+	}
+	return errors.Join(joined...)
+}
+
+func (p *hostedWorkflowProviderPool) PutExecutionReference(ctx context.Context, ref *coreworkflow.ExecutionReference) (*coreworkflow.ExecutionReference, error) {
+	store, err := p.executionReferenceStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.PutExecutionReference(ctx, ref)
+}
+
+func (p *hostedWorkflowProviderPool) GetExecutionReference(ctx context.Context, id string) (*coreworkflow.ExecutionReference, error) {
+	store, err := p.executionReferenceStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.GetExecutionReference(ctx, id)
+}
+
+func (p *hostedWorkflowProviderPool) ListExecutionReferences(ctx context.Context, subjectID string) ([]*coreworkflow.ExecutionReference, error) {
+	store, err := p.executionReferenceStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.ListExecutionReferences(ctx, subjectID)
+}
+
+func (p *hostedWorkflowProviderPool) executionReferenceStore() (coreworkflow.ExecutionReferenceStore, error) {
+	if p == nil || p.executionRefs == nil {
+		name := ""
+		if p != nil {
+			name = p.name
+		}
+		return nil, fmt.Errorf("hosted workflow provider %q does not expose execution references", name)
+	}
+	return p.executionRefs, nil
+}
+
+func (p *hostedWorkflowProviderPool) Close() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	workers := append([]*hostedWorkflowWorker(nil), p.workers...)
+	for _, worker := range workers {
+		if worker != nil && !worker.closed {
+			worker.draining = true
+		}
+	}
+	p.mu.Unlock()
+	p.cancel()
+
+	errs := make(chan error, len(workers))
+	var wg sync.WaitGroup
+	for _, worker := range workers {
+		wg.Add(1)
+		go func(worker *hostedWorkflowWorker) {
+			defer wg.Done()
+			errs <- p.drainAndCloseWorker(worker)
+		}(worker)
+	}
+	wg.Wait()
+	close(errs)
+	p.wg.Wait()
+	var closeErrs []error
+	for err := range errs {
+		if err != nil {
+			closeErrs = append(closeErrs, err)
+		}
+	}
+	p.mu.Lock()
+	p.workers = nil
+	p.mu.Unlock()
+	if p.Provider != nil {
+		closeErrs = append(closeErrs, p.Provider.Close())
+	}
+	if p.launch != nil {
+		p.launch.close()
+	}
+	return errors.Join(closeErrs...)
+}
+
+func (p *hostedWorkflowProviderPool) isStarted() bool {
+	if p == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.started
+}
+
+func (p *hostedWorkflowProviderPool) startWorker(ctx context.Context) (*hostedWorkflowWorker, error) {
+	startCtx, cancel := context.WithTimeout(ctx, p.policy.StartupTimeout)
+	defer cancel()
+	instance, err := startHostedWorkflowProviderInstance(startCtx, p.launch, p.hostServices, p.deps, false, nil, p.policy.DrainTimeout)
+	if err != nil {
+		return nil, err
+	}
+	if starter, ok := instance.provider.(startableWorkflowProvider); ok {
+		if err := starter.Start(startCtx); err != nil {
+			_ = instance.provider.Close()
+			return nil, fmt.Errorf("start hosted workflow worker: %w", err)
+		}
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		_ = instance.provider.Close()
+		return nil, fmt.Errorf("hosted workflow provider %q is closed", p.name)
+	}
+	p.nextID++
+	now := time.Now().UTC()
+	worker := &hostedWorkflowWorker{
+		id:               p.nextID,
+		provider:         instance.provider,
+		runtimeProvider:  instance.runtimeProvider,
+		runtimeSessionID: instance.runtimeSessionID,
+		runtimeSession:   instance.runtimeSession,
+		startedAt:        now,
+		runtimeDrainAt:   p.runtimeSessionDrainAt(instance.runtimeSession, now),
+		forceCloseAt:     runtimeSessionExpiresAt(instance.runtimeSession),
+	}
+	p.workers = append(p.workers, worker)
+	p.mu.Unlock()
+	return worker, nil
+}
+
+func (p *hostedWorkflowProviderPool) ensureMinReady(ctx context.Context) error {
+	for {
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return nil
+		}
+		ready := 0
+		now := time.Now().UTC()
+		for _, worker := range p.workers {
+			if p.workerAvailableLocked(worker, now) {
+				ready++
+			}
+		}
+		if ready+p.starting >= p.policy.MinReadyInstances {
+			p.mu.Unlock()
+			return nil
+		}
+		p.starting++
+		p.mu.Unlock()
+
+		_, err := p.startWorker(ctx)
+		p.mu.Lock()
+		p.starting--
+		p.mu.Unlock()
+		if err != nil {
+			slog.Warn("failed to start hosted workflow runtime worker", "provider", p.name, "error", err)
+			return err
+		}
+	}
+}
+
+func (p *hostedWorkflowProviderPool) healthLoop() {
+	ticker := time.NewTicker(p.policy.HealthCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		_ = p.ensureMinReady(p.ctx)
+		for _, worker := range p.readyWorkers() {
+			session, drainAt, err := p.refreshWorkerRuntimeSession(worker)
+			if err != nil {
+				slog.Warn("hosted workflow runtime session refresh failed", "provider", p.name, "worker", worker.id, "error", err)
+				p.replaceWorker(worker)
+				continue
+			}
+			if reason := p.runtimeSessionRetirementReason(session, drainAt, time.Now().UTC()); reason != "" {
+				slog.Info("retiring hosted workflow runtime worker", "provider", p.name, "worker", worker.id, "reason", reason)
+				p.replaceWorker(worker)
+				continue
+			}
+			if !p.acquireWorker(worker) {
+				continue
+			}
+			err = worker.provider.Ping(p.ctx)
+			p.releaseWorker(worker)
+			if err != nil {
+				slog.Warn("hosted workflow runtime worker failed health check", "provider", p.name, "worker", worker.id, "error", err)
+				p.replaceWorker(worker)
+			}
+		}
+	}
+}
+
+func (p *hostedWorkflowProviderPool) readyWorkers() []*hostedWorkflowWorker {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now().UTC()
+	out := make([]*hostedWorkflowWorker, 0, len(p.workers))
+	for _, worker := range p.workers {
+		if p.workerAvailableLocked(worker, now) {
+			out = append(out, worker)
+		}
+	}
+	return out
+}
+
+func (p *hostedWorkflowProviderPool) workerAvailableLocked(worker *hostedWorkflowWorker, now time.Time) bool {
+	if worker == nil || worker.provider == nil || worker.closed || worker.closing || worker.draining {
+		return false
+	}
+	if worker.forceCloseAt != nil && !now.Before(*worker.forceCloseAt) {
+		return false
+	}
+	return true
+}
+
+func (p *hostedWorkflowProviderPool) acquireWorker(worker *hostedWorkflowWorker) bool {
+	if worker == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.workerAvailableLocked(worker, time.Now().UTC()) {
+		return false
+	}
+	worker.active++
+	return true
+}
+
+func (p *hostedWorkflowProviderPool) releaseWorker(worker *hostedWorkflowWorker) {
+	if worker == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if worker.active > 0 {
+		worker.active--
+	}
+}
+
+func (p *hostedWorkflowProviderPool) refreshWorkerRuntimeSession(worker *hostedWorkflowWorker) (*pluginruntime.Session, *time.Time, error) {
+	if worker == nil {
+		return nil, nil, fmt.Errorf("runtime worker is unavailable")
+	}
+	p.mu.Lock()
+	runtimeProvider := worker.runtimeProvider
+	sessionID := worker.runtimeSessionID
+	p.mu.Unlock()
+	if runtimeProvider == nil || sessionID == "" {
+		return nil, nil, nil
+	}
+	timeout := p.policy.HealthCheckInterval
+	if timeout <= 0 || timeout > 10*time.Second {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(p.ctx, timeout)
+	defer cancel()
+	session, err := runtimeProvider.GetSession(ctx, pluginruntime.GetSessionRequest{SessionID: sessionID})
+	if err != nil {
+		return nil, nil, fmt.Errorf("get runtime session %q: %w", sessionID, err)
+	}
+	drainAt := p.runtimeSessionDrainAt(session, time.Now().UTC())
+	p.mu.Lock()
+	if p.workerAvailableLocked(worker, time.Now().UTC()) {
+		if worker.runtimeDrainAt != nil && (drainAt == nil || worker.runtimeDrainAt.Before(*drainAt)) {
+			drainAt = cloneTime(worker.runtimeDrainAt)
+		}
+		worker.runtimeSession = session
+		worker.runtimeDrainAt = cloneTime(drainAt)
+		worker.forceCloseAt = runtimeSessionExpiresAt(session)
+	}
+	p.mu.Unlock()
+	return session, drainAt, nil
+}
+
+func (p *hostedWorkflowProviderPool) replaceWorker(worker *hostedWorkflowWorker) {
+	if p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever || !p.markWorkerDraining(worker) {
+		return
+	}
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		if err := p.ensureMinReady(p.ctx); err != nil && !errors.Is(err, context.Canceled) {
+			slog.Warn("failed to replace hosted workflow runtime worker", "provider", p.name, "worker", worker.id, "error", err)
+		}
+		if err := p.drainAndCloseWorker(worker); err != nil {
+			slog.Warn("failed to close hosted workflow runtime worker", "provider", p.name, "worker", worker.id, "error", err)
+		}
+	}()
+}
+
+func (p *hostedWorkflowProviderPool) markWorkerDraining(worker *hostedWorkflowWorker) bool {
+	if worker == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed || worker.draining || worker.closed {
+		return false
+	}
+	worker.draining = true
+	return true
+}
+
+func (p *hostedWorkflowProviderPool) drainAndCloseWorker(worker *hostedWorkflowWorker) error {
+	if worker == nil {
+		return nil
+	}
+	p.mu.Lock()
+	if worker.closed || worker.closing {
+		p.mu.Unlock()
+		return nil
+	}
+	worker.closing = true
+	worker.draining = true
+	p.mu.Unlock()
+
+	deadline := time.Now().Add(p.policy.DrainTimeout)
+	p.mu.Lock()
+	if worker.forceCloseAt != nil && worker.forceCloseAt.Before(deadline) {
+		deadline = worker.forceCloseAt.UTC()
+	}
+	p.mu.Unlock()
+
+	for {
+		p.mu.Lock()
+		active := worker.active
+		if active == 0 || time.Now().After(deadline) {
+			worker.closed = true
+			p.removeWorkerLocked(worker)
+			p.mu.Unlock()
+			break
+		}
+		p.mu.Unlock()
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	return worker.provider.Close()
+}
+
+func (p *hostedWorkflowProviderPool) removeWorkerLocked(worker *hostedWorkflowWorker) {
+	for i, candidate := range p.workers {
+		if candidate == worker {
+			p.workers = append(p.workers[:i], p.workers[i+1:]...)
+			return
+		}
+	}
+}
+
+func (p *hostedWorkflowProviderPool) runtimeSessionDrainAt(session *pluginruntime.Session, now time.Time) *time.Time {
+	if session == nil || session.Lifecycle == nil {
+		return nil
+	}
+	var drainAt *time.Time
+	if session.Lifecycle.RecommendedDrainAt != nil {
+		recommended := session.Lifecycle.RecommendedDrainAt.UTC()
+		drainAt = &recommended
+	}
+	if session.Lifecycle.ExpiresAt != nil {
+		expiryDrain := p.runtimeSessionExpiryDrainAt(session.Lifecycle, now)
+		if drainAt == nil || expiryDrain.Before(*drainAt) {
+			drainAt = &expiryDrain
+		}
+	}
+	return drainAt
+}
+
+func (p *hostedWorkflowProviderPool) runtimeSessionExpiryDrainAt(lifecycle *pluginruntime.SessionLifecycle, now time.Time) time.Time {
+	expiresAt := lifecycle.ExpiresAt.UTC()
+	reserve := p.policy.StartupTimeout + p.policy.DrainTimeout + p.policy.HealthCheckInterval + hostedWorkflowRuntimeLifecycleSafetyMargin
+	drainAt := expiresAt.Add(-reserve).UTC()
+	if lifecycle.StartedAt != nil {
+		startedAt := lifecycle.StartedAt.UTC()
+		lifetime := expiresAt.Sub(startedAt)
+		if lifetime > 0 {
+			minDrainAt := startedAt.Add(lifetime / 2).UTC()
+			if drainAt.Before(minDrainAt) {
+				return minDrainAt
+			}
+		}
+	}
+	if !now.IsZero() && expiresAt.After(now) && drainAt.Before(now) {
+		return now.Add(expiresAt.Sub(now) / 2).UTC()
+	}
+	return drainAt
+}
+
+func (p *hostedWorkflowProviderPool) runtimeSessionRetirementReason(session *pluginruntime.Session, drainAt *time.Time, now time.Time) string {
+	if session == nil {
+		return ""
+	}
+	switch session.State {
+	case pluginruntime.SessionStateFailed, pluginruntime.SessionStateStopped:
+		return fmt.Sprintf("runtime session entered %q state", session.State)
+	}
+	if drainAt == nil || now.Before(*drainAt) {
+		return ""
+	}
+	if expiresAt := runtimeSessionExpiresAt(session); expiresAt != nil && !now.Before(*expiresAt) {
+		return fmt.Sprintf("runtime session expired at %s", expiresAt.Format(time.RFC3339Nano))
+	}
+	return fmt.Sprintf("runtime session reached drain deadline %s", drainAt.Format(time.RFC3339Nano))
+}
+
+var _ coreworkflow.Provider = (*hostedWorkflowProviderPool)(nil)
+var _ coreworkflow.ExecutionReferenceStore = (*hostedWorkflowProviderPool)(nil)

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider_test.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider_test.go
@@ -1,0 +1,512 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost/pluginruntime"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtimeProvider := newRecordingHostedWorkflowRuntime(t)
+	t.Cleanup(func() { _ = runtimeProvider.Close() })
+
+	deps := Deps{
+		BaseURL:            "http://127.0.0.1:8080",
+		EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
+		PluginRuntime:      runtimeProvider,
+		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
+	}
+	entry := &config.ProviderEntry{
+		Execution: &config.ExecutionConfig{
+			Mode: config.ExecutionModeHosted,
+			Runtime: &config.HostedRuntimeConfig{
+				Provider: "gke",
+				Metadata: map[string]string{
+					"workload": "temporal-workers",
+				},
+				Pool: &config.HostedRuntimePoolConfig{
+					MinReadyInstances:   2,
+					MaxReadyInstances:   2,
+					StartupTimeout:      "5s",
+					HealthCheckInterval: "1m",
+					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+					DrainTimeout:        "50ms",
+				},
+			},
+		},
+	}
+
+	provider, err := buildHostedWorkflowProvider(ctx, "temporal", entry, mustNode(t, map[string]any{
+		"command": "/bin/temporal-provider",
+		"config":  map[string]any{"namespace": "default"},
+	}), []runtimehost.HostService{{
+		Name:   "workflow_host",
+		EnvVar: workflowservice.DefaultHostSocketEnv,
+	}}, deps)
+	if err != nil {
+		t.Fatalf("buildHostedWorkflowProvider: %v", err)
+	}
+	result := &Result{ExtraWorkflows: []workflow.Provider{provider}}
+	t.Cleanup(func() { _ = provider.Close() })
+	assertPublicHostServicesVerified(t, deps.PublicHostServices, "workflow_host", workflowservice.DefaultHostSocketEnv)
+	executionRefs, ok := provider.(workflow.ExecutionReferenceStore)
+	if !ok {
+		t.Fatalf("hosted workflow pool does not expose ExecutionReferenceStore")
+	}
+	ref, err := executionRefs.PutExecutionReference(ctx, &workflow.ExecutionReference{
+		ID:           "workflow_schedule:sched-test:ref-test",
+		ProviderName: "temporal",
+		SubjectID:    "subject-test",
+		SubjectKind:  "user",
+		Target: workflow.Target{
+			Plugin: &workflow.PluginTarget{
+				PluginName: "roadmap",
+				Operation:  "sync_items",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PutExecutionReference: %v", err)
+	}
+	if ref.ID != "workflow_schedule:sched-test:ref-test" {
+		t.Fatalf("PutExecutionReference id = %q, want workflow_schedule:sched-test:ref-test", ref.ID)
+	}
+	if _, err := executionRefs.GetExecutionReference(ctx, "workflow_schedule:sched-test:ref-test"); err != nil {
+		t.Fatalf("GetExecutionReference: %v", err)
+	}
+
+	if got := runtimeProvider.startProviderCalls(); got != 0 {
+		t.Fatalf("StartProvider calls before StartWorkflowProviders = %d, want 0", got)
+	}
+	if got := len(runtimeProvider.startPluginRequestsCopy()); got != 1 {
+		t.Fatalf("StartPlugin requests before StartWorkflowProviders = %d, want control provider only", got)
+	}
+
+	if err := result.Start(ctx); err != nil {
+		t.Fatalf("Result.Start: %v", err)
+	}
+	if got := runtimeProvider.startProviderCalls(); got != 0 {
+		t.Fatalf("StartProvider calls after Result.Start = %d, want 0", got)
+	}
+	if err := result.StartWorkflowProviders(ctx); err != nil {
+		t.Fatalf("StartWorkflowProviders: %v", err)
+	}
+	if got := runtimeProvider.startProviderCalls(); got != 3 {
+		t.Fatalf("StartProvider calls after StartWorkflowProviders = %d, want control + worker pool size 2", got)
+	}
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 3 {
+		t.Fatalf("StartPlugin requests after StartWorkflowProviders = %d, want control + 2 workers", len(startRequests))
+	}
+	workerReq := startRequests[1]
+	if got := workerReq.Env[workflowservice.DefaultHostSocketEnv]; got != "tcp://127.0.0.1:8080" {
+		t.Fatalf("worker env %s = %q, want public relay target", workflowservice.DefaultHostSocketEnv, got)
+	}
+	if got := workerReq.Env[workflowservice.HostSocketTokenEnv()]; got == "" {
+		t.Fatalf("worker env missing %s", workflowservice.HostSocketTokenEnv())
+	}
+	sessions := runtimeProvider.startSessionRequestsCopy()
+	if len(sessions) != 3 {
+		t.Fatalf("StartSession requests = %d, want control + 2 workers", len(sessions))
+	}
+	if got := sessions[1].Metadata["provider_kind"]; got != providermanifestKindWorkflow {
+		t.Fatalf("worker session provider_kind = %q, want %q", got, providermanifestKindWorkflow)
+	}
+	if got := sessions[1].Metadata["provider_name"]; got != "temporal" {
+		t.Fatalf("worker session provider_name = %q, want temporal", got)
+	}
+	if got := sessions[1].Metadata["workload"]; got != "temporal-workers" {
+		t.Fatalf("worker session workload = %q, want temporal-workers", got)
+	}
+}
+
+func TestHostedWorkflowAllowedHostsFiltersLoopbackRelayTargets(t *testing.T) {
+	t.Parallel()
+
+	allowed := hostedWorkflowAllowedHosts([]string{"localhost", "127.0.0.1", "api.example.com"}, HostedRuntimePlan{
+		Resolved: RuntimeBehavior{
+			HostServiceAccess: RuntimeHostServiceAccessRelay,
+			EgressMode:        RuntimeEgressModeNone,
+		},
+	})
+	if !slices.Equal(allowed, []string{"api.example.com"}) {
+		t.Fatalf("hostedWorkflowAllowedHosts = %#v, want api.example.com only", allowed)
+	}
+}
+
+func TestHostedWorkflowProviderKeepsSharedRuntimeOpen(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtimeProvider := newRecordingHostedWorkflowRuntime(t)
+	t.Cleanup(func() { _ = runtimeProvider.Close() })
+	deps := Deps{
+		BaseURL:            "http://127.0.0.1:8080",
+		EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
+		PluginRuntime:      runtimeProvider,
+		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
+	}
+	entry := &config.ProviderEntry{
+		Execution: &config.ExecutionConfig{
+			Mode: config.ExecutionModeHosted,
+			Runtime: &config.HostedRuntimeConfig{
+				Provider: "gke",
+			},
+		},
+	}
+
+	provider, err := buildHostedWorkflowProvider(ctx, "temporal", entry, mustNode(t, map[string]any{
+		"command": "/bin/temporal-provider",
+	}), []runtimehost.HostService{{
+		Name:   "workflow_host",
+		EnvVar: workflowservice.DefaultHostSocketEnv,
+	}}, deps)
+	if err != nil {
+		t.Fatalf("buildHostedWorkflowProvider: %v", err)
+	}
+	if err := provider.Close(); err != nil {
+		t.Fatalf("provider.Close: %v", err)
+	}
+	if got := runtimeProvider.closeCalls.Load(); got != 0 {
+		t.Fatalf("runtime Close calls after provider.Close = %d, want 0 for shared runtime", got)
+	}
+}
+
+func TestHostedWorkflowProviderPoolDrainWaitsBeforeClosingWorker(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtimeProvider := newRecordingHostedWorkflowRuntime(t)
+	t.Cleanup(func() { _ = runtimeProvider.Close() })
+	deps := Deps{
+		BaseURL:            "http://127.0.0.1:8080",
+		EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
+		PluginRuntime:      runtimeProvider,
+		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
+	}
+	entry := &config.ProviderEntry{
+		Execution: &config.ExecutionConfig{
+			Mode: config.ExecutionModeHosted,
+			Runtime: &config.HostedRuntimeConfig{
+				Provider: "gke",
+				Pool: &config.HostedRuntimePoolConfig{
+					MinReadyInstances:   1,
+					MaxReadyInstances:   1,
+					StartupTimeout:      "5s",
+					HealthCheckInterval: "1m",
+					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+					DrainTimeout:        "150ms",
+				},
+			},
+		},
+	}
+
+	provider, err := buildHostedWorkflowProvider(ctx, "temporal", entry, mustNode(t, map[string]any{
+		"command": "/bin/temporal-provider",
+	}), []runtimehost.HostService{{
+		Name:   "workflow_host",
+		EnvVar: workflowservice.DefaultHostSocketEnv,
+	}}, deps)
+	if err != nil {
+		t.Fatalf("buildHostedWorkflowProvider: %v", err)
+	}
+	t.Cleanup(func() { _ = provider.Close() })
+	pool, ok := provider.(*hostedWorkflowProviderPool)
+	if !ok {
+		t.Fatalf("provider = %T, want *hostedWorkflowProviderPool", provider)
+	}
+	if err := pool.Start(ctx); err != nil {
+		t.Fatalf("pool.Start: %v", err)
+	}
+	workers := pool.readyWorkers()
+	if len(workers) != 1 {
+		t.Fatalf("ready workers = %d, want 1", len(workers))
+	}
+	pool.mu.Lock()
+	workers[0].active = 1
+	pool.mu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- pool.drainAndCloseWorker(workers[0])
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("drainAndCloseWorker finished before drain timeout with error %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	pool.mu.Lock()
+	workers[0].active = 0
+	pool.mu.Unlock()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("drainAndCloseWorker: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainAndCloseWorker did not finish after drain timeout")
+	}
+}
+
+const providermanifestKindWorkflow = "workflow"
+
+type recordingHostedWorkflowRuntime struct {
+	provider *pluginruntime.LocalProvider
+	t        *testing.T
+
+	mu                  sync.Mutex
+	startRequests       []pluginruntime.StartSessionRequest
+	startPluginRequests []pluginruntime.StartPluginRequest
+	servers             map[string]*recordingHostedWorkflowServer
+	closeCalls          atomic.Int32
+}
+
+func newRecordingHostedWorkflowRuntime(t *testing.T) *recordingHostedWorkflowRuntime {
+	t.Helper()
+	return &recordingHostedWorkflowRuntime{
+		provider: pluginruntime.NewLocalProvider(),
+		t:        t,
+		servers:  map[string]*recordingHostedWorkflowServer{},
+	}
+}
+
+func (r *recordingHostedWorkflowRuntime) Support(context.Context) (pluginruntime.Support, error) {
+	return pluginruntime.Support{
+		CanHostPlugins: true,
+		EgressMode:     pluginruntime.EgressModeHostname,
+	}, nil
+}
+
+func (r *recordingHostedWorkflowRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
+	r.mu.Lock()
+	r.startRequests = append(r.startRequests, pluginruntime.StartSessionRequest{
+		PluginName:    req.PluginName,
+		Template:      req.Template,
+		Image:         req.Image,
+		ImagePullAuth: cloneImagePullAuth(req.ImagePullAuth),
+		Metadata:      cloneRuntimeMetadata(req.Metadata),
+	})
+	r.mu.Unlock()
+	return r.provider.StartSession(ctx, req)
+}
+
+func (r *recordingHostedWorkflowRuntime) ListSessions(ctx context.Context) ([]pluginruntime.Session, error) {
+	return r.provider.ListSessions(ctx)
+}
+
+func (r *recordingHostedWorkflowRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
+	return r.provider.GetSession(ctx, req)
+}
+
+func (r *recordingHostedWorkflowRuntime) StopSession(ctx context.Context, req pluginruntime.StopSessionRequest) error {
+	r.cleanupServer(req.SessionID)
+	return r.provider.StopSession(ctx, req)
+}
+
+func (r *recordingHostedWorkflowRuntime) StartPlugin(_ context.Context, req pluginruntime.StartPluginRequest) (*pluginruntime.HostedPlugin, error) {
+	r.mu.Lock()
+	r.startPluginRequests = append(r.startPluginRequests, pluginruntime.StartPluginRequest{
+		SessionID:  req.SessionID,
+		PluginName: req.PluginName,
+		Command:    req.Command,
+		Args:       slices.Clone(req.Args),
+		Env:        cloneRuntimeMetadata(req.Env),
+		Egress:     cloneRuntimeEgressPolicy(req.Egress),
+		HostBinary: req.HostBinary,
+	})
+	r.mu.Unlock()
+
+	dir, err := runtimehost.NewPluginTempDir("gst-workflow-runtime-*")
+	if err != nil {
+		return nil, fmt.Errorf("create fake hosted workflow dir: %w", err)
+	}
+	socketPath := filepath.Join(dir, "workflow.sock")
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("listen for fake hosted workflow: %w", err)
+	}
+	workflowServer := newRecordingHostedWorkflowServer()
+	grpcServer := grpc.NewServer()
+	proto.RegisterProviderLifecycleServer(grpcServer, workflowServer)
+	proto.RegisterWorkflowProviderServer(grpcServer, workflowServer)
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
+
+	r.mu.Lock()
+	r.servers[req.SessionID] = workflowServer
+	r.mu.Unlock()
+	r.t.Cleanup(func() {
+		grpcServer.Stop()
+		_ = lis.Close()
+		_ = os.RemoveAll(dir)
+	})
+	return &pluginruntime.HostedPlugin{
+		ID:         "fake-" + req.SessionID,
+		SessionID:  req.SessionID,
+		PluginName: req.PluginName,
+		DialTarget: "unix://" + socketPath,
+	}, nil
+}
+
+func (r *recordingHostedWorkflowRuntime) Close() error {
+	r.closeCalls.Add(1)
+	r.mu.Lock()
+	sessionIDs := make([]string, 0, len(r.servers))
+	for sessionID := range r.servers {
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	r.mu.Unlock()
+	for _, sessionID := range sessionIDs {
+		r.cleanupServer(sessionID)
+	}
+	return r.provider.Close()
+}
+
+func (r *recordingHostedWorkflowRuntime) startSessionRequestsCopy() []pluginruntime.StartSessionRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]pluginruntime.StartSessionRequest, len(r.startRequests))
+	for i, req := range r.startRequests {
+		out[i] = pluginruntime.StartSessionRequest{
+			PluginName:    req.PluginName,
+			Template:      req.Template,
+			Image:         req.Image,
+			ImagePullAuth: cloneImagePullAuth(req.ImagePullAuth),
+			Metadata:      cloneRuntimeMetadata(req.Metadata),
+		}
+	}
+	return out
+}
+
+func (r *recordingHostedWorkflowRuntime) startPluginRequestsCopy() []pluginruntime.StartPluginRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]pluginruntime.StartPluginRequest, len(r.startPluginRequests))
+	for i, req := range r.startPluginRequests {
+		out[i] = pluginruntime.StartPluginRequest{
+			SessionID:  req.SessionID,
+			PluginName: req.PluginName,
+			Command:    req.Command,
+			Args:       slices.Clone(req.Args),
+			Env:        cloneRuntimeMetadata(req.Env),
+			Egress:     cloneRuntimeEgressPolicy(req.Egress),
+			HostBinary: req.HostBinary,
+		}
+	}
+	return out
+}
+
+func (r *recordingHostedWorkflowRuntime) startProviderCalls() int32 {
+	r.mu.Lock()
+	servers := make([]*recordingHostedWorkflowServer, 0, len(r.servers))
+	for _, server := range r.servers {
+		servers = append(servers, server)
+	}
+	r.mu.Unlock()
+	var total int32
+	for _, server := range servers {
+		total += server.startProviderCalls.Load()
+	}
+	return total
+}
+
+func (r *recordingHostedWorkflowRuntime) cleanupServer(sessionID string) {
+	r.mu.Lock()
+	delete(r.servers, sessionID)
+	r.mu.Unlock()
+}
+
+type recordingHostedWorkflowServer struct {
+	proto.UnimplementedProviderLifecycleServer
+	proto.UnimplementedWorkflowProviderServer
+
+	startProviderCalls atomic.Int32
+	mu                 sync.Mutex
+	executionRefs      map[string]*proto.WorkflowExecutionReference
+}
+
+func newRecordingHostedWorkflowServer() *recordingHostedWorkflowServer {
+	return &recordingHostedWorkflowServer{
+		executionRefs: map[string]*proto.WorkflowExecutionReference{},
+	}
+}
+
+func (s *recordingHostedWorkflowServer) GetProviderIdentity(context.Context, *emptypb.Empty) (*proto.ProviderIdentity, error) {
+	return &proto.ProviderIdentity{
+		Kind:               proto.ProviderKind_PROVIDER_KIND_WORKFLOW,
+		Name:               "temporal",
+		MinProtocolVersion: proto.CurrentProtocolVersion,
+		MaxProtocolVersion: proto.CurrentProtocolVersion,
+	}, nil
+}
+
+func (s *recordingHostedWorkflowServer) ConfigureProvider(context.Context, *proto.ConfigureProviderRequest) (*proto.ConfigureProviderResponse, error) {
+	return &proto.ConfigureProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+}
+
+func (s *recordingHostedWorkflowServer) HealthCheck(context.Context, *emptypb.Empty) (*proto.HealthCheckResponse, error) {
+	return &proto.HealthCheckResponse{Ready: true}, nil
+}
+
+func (s *recordingHostedWorkflowServer) StartProvider(context.Context, *emptypb.Empty) (*proto.StartRuntimeProviderResponse, error) {
+	s.startProviderCalls.Add(1)
+	return &proto.StartRuntimeProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+}
+
+func (s *recordingHostedWorkflowServer) PutExecutionReference(_ context.Context, req *proto.PutWorkflowExecutionReferenceRequest) (*proto.WorkflowExecutionReference, error) {
+	ref := req.GetReference()
+	if ref.GetId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "missing execution reference id")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.executionRefs[ref.GetId()] = gproto.Clone(ref).(*proto.WorkflowExecutionReference)
+	return gproto.Clone(ref).(*proto.WorkflowExecutionReference), nil
+}
+
+func (s *recordingHostedWorkflowServer) GetExecutionReference(_ context.Context, req *proto.GetWorkflowExecutionReferenceRequest) (*proto.WorkflowExecutionReference, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ref := s.executionRefs[req.GetId()]
+	if ref == nil {
+		return nil, status.Error(codes.NotFound, "execution reference not found")
+	}
+	return gproto.Clone(ref).(*proto.WorkflowExecutionReference), nil
+}
+
+func (s *recordingHostedWorkflowServer) ListExecutionReferences(_ context.Context, req *proto.ListWorkflowExecutionReferencesRequest) (*proto.ListWorkflowExecutionReferencesResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	refs := make([]*proto.WorkflowExecutionReference, 0, len(s.executionRefs))
+	for _, ref := range s.executionRefs {
+		if req.GetSubjectId() == "" || ref.GetSubjectId() == req.GetSubjectId() {
+			refs = append(refs, gproto.Clone(ref).(*proto.WorkflowExecutionReference))
+		}
+	}
+	return &proto.ListWorkflowExecutionReferencesResponse{References: refs}, nil
+}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1553,6 +1553,7 @@ type runtimeBackedHostedCloser struct {
 	sessionID    string
 	closeRuntime bool
 	cleanup      func()
+	stopTimeout  time.Duration
 }
 
 func (c *runtimeBackedHostedCloser) Close() error {
@@ -1561,7 +1562,7 @@ func (c *runtimeBackedHostedCloser) Close() error {
 	}
 	var errs []error
 	if c.runtime != nil && c.sessionID != "" {
-		errs = append(errs, stopPluginRuntimeSession(c.runtime, c.sessionID))
+		errs = append(errs, stopPluginRuntimeSessionWithTimeout(c.runtime, c.sessionID, c.stopTimeout))
 	}
 	if c.conn != nil {
 		errs = append(errs, c.conn.Close())
@@ -1576,10 +1577,17 @@ func (c *runtimeBackedHostedCloser) Close() error {
 }
 
 func stopPluginRuntimeSession(runtimeProvider pluginruntime.Provider, sessionID string) error {
+	return stopPluginRuntimeSessionWithTimeout(runtimeProvider, sessionID, 0)
+}
+
+func stopPluginRuntimeSessionWithTimeout(runtimeProvider pluginruntime.Provider, sessionID string, timeout time.Duration) error {
 	if runtimeProvider == nil || sessionID == "" {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), pluginRuntimeStopTimeout)
+	if timeout <= 0 {
+		timeout = pluginRuntimeStopTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	done := make(chan error, 1)
@@ -1780,6 +1788,10 @@ func buildHostedRuntimeHostServiceEnv(providerName, sessionID string, hostServic
 		serviceKey = "workflow_manager"
 		serviceLabel = "workflow manager"
 		methodPrefix = "/" + proto.WorkflowManagerHost_ServiceDesc.ServiceName + "/"
+	case hostService.EnvVar == workflowservice.DefaultHostSocketEnv:
+		serviceKey = "workflow_host"
+		serviceLabel = "workflow host"
+		methodPrefix = "/" + proto.WorkflowHost_ServiceDesc.ServiceName + "/"
 	case hostService.EnvVar == agentservice.DefaultHostSocketEnv:
 		serviceKey = "agent_host"
 		serviceLabel = "agent host"

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3935,7 +3935,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "plugins.service.execution.runtime lifecycle fields are only supported on providers.agent.*.execution.runtime",
+			want: "plugins.service.execution.runtime lifecycle fields are only supported on hosted agent and workflow providers",
 		},
 	}
 	for _, tc := range cases {
@@ -3952,6 +3952,161 @@ server:
 			}
 		})
 	}
+}
+
+func TestLoadConfigWorkflowRuntimeLifecycleFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("accepts hosted workflow runtime pool without indexeddb", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          template: workflow-workers
+          metadata:
+            workload: temporal-workers
+          pool:
+            minReadyInstances: 2
+            maxReadyInstances: 2
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/gke
+server:
+  encryptionKey: server-key
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		runtimeCfg := cfg.Providers.Workflow["temporal"].Execution.Runtime
+		if runtimeCfg == nil || runtimeCfg.Pool == nil {
+			t.Fatalf("workflow execution runtime pool = %#v", runtimeCfg)
+		}
+		if runtimeCfg.Pool.MinReadyInstances != 2 || runtimeCfg.Pool.MaxReadyInstances != 2 {
+			t.Fatalf("workflow pool ready instances = %d/%d, want 2/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)
+		}
+		if runtimeCfg.Pool.RestartPolicy != HostedRuntimeRestartPolicyAlways {
+			t.Fatalf("workflow restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, HostedRuntimeRestartPolicyAlways)
+		}
+	})
+
+	t.Run("accepts hosted workflow runtime without pool", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/gke
+server:
+  encryptionKey: server-key
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		runtimeCfg := cfg.Providers.Workflow["temporal"].Execution.Runtime
+		if runtimeCfg == nil || runtimeCfg.Provider != "hosted" {
+			t.Fatalf("workflow execution runtime = %#v", runtimeCfg)
+		}
+	})
+
+	t.Run("rejects incomplete hosted workflow runtime pool", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          pool:
+            minReadyInstances: 1
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/gke
+server:
+  encryptionKey: server-key
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "providers.workflow.temporal.execution.runtime.pool.maxReadyInstances is required") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects autoscale-shaped hosted workflow runtime pool", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+      execution:
+        mode: hosted
+        runtime:
+          provider: hosted
+          pool:
+            minReadyInstances: 2
+            maxReadyInstances: 3
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/gke
+server:
+  encryptionKey: server-key
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "providers.workflow.temporal.execution.runtime.pool.maxReadyInstances must equal minReadyInstances") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestLoadConfigAgentSessionStartLifecycle(t *testing.T) {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -1200,12 +1200,34 @@ func validateHostedRuntimeDockerConfigJSON(value string) error {
 }
 
 func validateHostedAgentRuntimeLifecyclePolicy(subject string, entry *ProviderEntry) error {
+	return validateHostedRuntimeLifecyclePolicy(subject, entry, true, "agent")
+}
+
+func validateHostedWorkflowRuntimeLifecyclePolicy(subject string, entry *ProviderEntry) error {
+	runtimeCfg, runtimePath := hostedRuntimeConfigAndPath(subject, entry)
+	if runtimeCfg == nil || !runtimeCfg.LifecyclePolicyFieldsSet() {
+		return nil
+	}
+	if err := validateHostedRuntimeLifecyclePolicy(subject, entry, false, "workflow"); err != nil {
+		return err
+	}
+	lifecycle := runtimeCfg.lifecyclePolicyConfig()
+	if lifecycle.MaxReadyInstances != lifecycle.MinReadyInstances {
+		return fmt.Errorf("config validation: %s.pool.maxReadyInstances must equal minReadyInstances for fixed workflow worker pools", runtimePath)
+	}
+	return nil
+}
+
+func validateHostedRuntimeLifecyclePolicy(subject string, entry *ProviderEntry, requireIndexedDB bool, providerKind string) error {
 	if entry == nil || !entry.UsesHostedExecution() {
 		return nil
 	}
 	runtimeCfg, runtimePath := hostedRuntimeConfigAndPath(subject, entry)
 	if runtimeCfg == nil {
-		return fmt.Errorf("config validation: %s is required for hosted agent providers", runtimePath)
+		if providerKind == "" {
+			providerKind = "provider"
+		}
+		return fmt.Errorf("config validation: %s is required for hosted %s providers", runtimePath, providerKind)
 	}
 	lifecycle := runtimeCfg.lifecyclePolicyConfig()
 	lifecycleSubject := runtimePath + ".pool"
@@ -1232,7 +1254,7 @@ func validateHostedAgentRuntimeLifecyclePolicy(subject string, entry *ProviderEn
 	default:
 		return fmt.Errorf("config validation: %s.restartPolicy must be one of %q or %q", lifecycleSubject, HostedRuntimeRestartPolicyAlways, HostedRuntimeRestartPolicyNever)
 	}
-	if lifecycle.RestartPolicy == HostedRuntimeRestartPolicyAlways && entry.IndexedDB == nil {
+	if requireIndexedDB && lifecycle.RestartPolicy == HostedRuntimeRestartPolicyAlways && entry.IndexedDB == nil {
 		return fmt.Errorf("config validation: %s.restartPolicy %q requires %s.indexeddb as the provider persistence hook; runtime replacement does not make backend-local state durable", lifecycleSubject, HostedRuntimeRestartPolicyAlways, subject)
 	}
 	if _, err := runtimeCfg.LifecyclePolicy(); err != nil {
@@ -1274,8 +1296,16 @@ func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEnt
 	if entry.Lifecycle != nil {
 		return fmt.Errorf("config validation: %s.lifecycle is only supported on providers.agent.*", subject)
 	}
-	if entry.Execution != nil {
-		return fmt.Errorf("config validation: %s.execution is only supported on plugins.* and providers.agent.*", subject)
+	if err := normalizeExecutionConfig(subject, entry.Execution, true); err != nil {
+		return err
+	}
+	if _, err := cfg.EffectiveHostedRuntime(subject, entry); err != nil {
+		return err
+	}
+	if entry.UsesHostedExecution() {
+		if err := validateHostedWorkflowRuntimeLifecyclePolicy(subject, entry); err != nil {
+			return err
+		}
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
@@ -1432,7 +1462,7 @@ func normalizeExecutionConfig(subject string, execution *ExecutionConfig, allowL
 		return err
 	}
 	if !allowLifecycle && execution.Runtime.LifecyclePolicyFieldsSet() {
-		return fmt.Errorf("config validation: %s.execution.runtime lifecycle fields are only supported on providers.agent.*.execution.runtime", subject)
+		return fmt.Errorf("config validation: %s.execution.runtime lifecycle fields are only supported on hosted agent and workflow providers", subject)
 	}
 	return nil
 }

--- a/gestaltd/services/runtimehost/pluginruntime/dial.go
+++ b/gestaltd/services/runtimehost/pluginruntime/dial.go
@@ -33,6 +33,12 @@ type dialedHostedAgentConn struct {
 	agent     proto.AgentProviderClient
 }
 
+type dialedHostedWorkflowConn struct {
+	conn      *grpc.ClientConn
+	lifecycle proto.ProviderLifecycleClient
+	workflow  proto.WorkflowProviderClient
+}
+
 type DialOption func(*dialConfig)
 
 type dialConfig struct {
@@ -102,6 +108,18 @@ func DialHostedAgent(ctx context.Context, target string, opts ...DialOption) (Ho
 		conn:      conn,
 		lifecycle: proto.NewProviderLifecycleClient(conn),
 		agent:     proto.NewAgentProviderClient(conn),
+	}, nil
+}
+
+func DialHostedWorkflow(ctx context.Context, target string, opts ...DialOption) (HostedWorkflowConn, error) {
+	conn, err := dialHostedConn(ctx, target, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &dialedHostedWorkflowConn{
+		conn:      conn,
+		lifecycle: proto.NewProviderLifecycleClient(conn),
+		workflow:  proto.NewWorkflowProviderClient(conn),
 	}, nil
 }
 
@@ -198,6 +216,27 @@ func (c *dialedHostedAgentConn) Agent() proto.AgentProviderClient {
 }
 
 func (c *dialedHostedAgentConn) Close() error {
+	if c == nil || c.conn == nil {
+		return nil
+	}
+	return c.conn.Close()
+}
+
+func (c *dialedHostedWorkflowConn) Lifecycle() proto.ProviderLifecycleClient {
+	if c == nil {
+		return nil
+	}
+	return c.lifecycle
+}
+
+func (c *dialedHostedWorkflowConn) Workflow() proto.WorkflowProviderClient {
+	if c == nil {
+		return nil
+	}
+	return c.workflow
+}
+
+func (c *dialedHostedWorkflowConn) Close() error {
 	if c == nil || c.conn == nil {
 		return nil
 	}

--- a/gestaltd/services/runtimehost/pluginruntime/runtime.go
+++ b/gestaltd/services/runtimehost/pluginruntime/runtime.go
@@ -141,6 +141,12 @@ type HostedAgentConn interface {
 	Close() error
 }
 
+type HostedWorkflowConn interface {
+	Lifecycle() proto.ProviderLifecycleClient
+	Workflow() proto.WorkflowProviderClient
+	Close() error
+}
+
 type Provider interface {
 	Support(ctx context.Context) (Support, error)
 	ListSessions(ctx context.Context) ([]Session, error)

--- a/gestaltd/services/workflows/client.go
+++ b/gestaltd/services/workflows/client.go
@@ -2,6 +2,7 @@ package workflows
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
@@ -21,6 +22,14 @@ type ExecConfig struct {
 	Cleanup      func()
 	HostServices []runtimehost.HostService
 	Name         string
+}
+
+type RemoteConfig struct {
+	Client  proto.WorkflowProviderClient
+	Runtime proto.ProviderLifecycleClient
+	Closer  io.Closer
+	Config  map[string]any
+	Name    string
 }
 
 var startWorkflowProviderProcess = runtimehost.StartPluginProcess
@@ -53,6 +62,28 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (coreworkflow.Provider, 
 		return nil, err
 	}
 	return &remoteWorkflow{client: workflowClient, runtime: runtimeClient, closer: proc}, nil
+}
+
+func NewRemote(ctx context.Context, cfg RemoteConfig) (coreworkflow.Provider, error) {
+	if cfg.Client == nil {
+		if cfg.Closer != nil {
+			_ = cfg.Closer.Close()
+		}
+		return nil, fmt.Errorf("workflow provider client is required")
+	}
+	if cfg.Runtime == nil {
+		if cfg.Closer != nil {
+			_ = cfg.Closer.Close()
+		}
+		return nil, fmt.Errorf("workflow provider lifecycle client is required")
+	}
+	if _, err := runtimehost.ConfigureRuntimeProvider(ctx, cfg.Runtime, proto.ProviderKind_PROVIDER_KIND_WORKFLOW, cfg.Name, cfg.Config); err != nil {
+		if cfg.Closer != nil {
+			_ = cfg.Closer.Close()
+		}
+		return nil, err
+	}
+	return &remoteWorkflow{client: cfg.Client, runtime: cfg.Runtime, closer: cfg.Closer}, nil
 }
 
 func (r *remoteWorkflow) StartRun(ctx context.Context, req coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {

--- a/sdk/go/workflow_host.go
+++ b/sdk/go/workflow_host.go
@@ -7,47 +7,45 @@ import (
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
-// EnvWorkflowHostSocket names the environment variable containing the
-// workflow-host service socket path.
+// EnvWorkflowHostSocket names the environment variable containing the workflow-host
+// service target.
 const EnvWorkflowHostSocket = "GESTALT_WORKFLOW_HOST_SOCKET"
+
+// EnvWorkflowHostSocketToken names the optional workflow-host relay-token variable.
+const EnvWorkflowHostSocketToken = EnvWorkflowHostSocket + "_TOKEN"
 
 // WorkflowHostClient invokes operations from workflow provider code.
 type WorkflowHostClient struct {
 	client proto.WorkflowHostClient
-	conn   *grpc.ClientConn
 }
 
-// WorkflowHost returns a client for the workflow host service.
+var sharedWorkflowHostTransport sharedManagerTransport[proto.WorkflowHostClient]
+
+// WorkflowHost returns a shared client for the workflow host service.
 func WorkflowHost() (*WorkflowHostClient, error) {
-	socketPath := os.Getenv(EnvWorkflowHostSocket)
-	if socketPath == "" {
+	target := os.Getenv(EnvWorkflowHostSocket)
+	if target == "" {
 		return nil, fmt.Errorf("workflow host: %s is not set", EnvWorkflowHostSocket)
 	}
+	token := os.Getenv(EnvWorkflowHostSocketToken)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, "unix:"+socketPath,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
-	)
+
+	client, err := managerTransportClient(ctx, "workflow host", target, token, &sharedWorkflowHostTransport, proto.NewWorkflowHostClient)
 	if err != nil {
-		return nil, fmt.Errorf("workflow host: connect to host: %w", err)
+		return nil, err
 	}
 	return &WorkflowHostClient{
-		client: proto.NewWorkflowHostClient(conn),
-		conn:   conn,
+		client: client,
 	}, nil
 }
 
-// Close closes the underlying workflow-host connection.
+// Close is a no-op compatibility method because this client uses shared transport.
 func (c *WorkflowHostClient) Close() error {
-	if c == nil || c.conn == nil {
-		return nil
-	}
-	return c.conn.Close()
+	return nil
 }
 
 // InvokeOperation invokes an operation through the workflow host service.

--- a/sdk/go/workflow_host_transport_test.go
+++ b/sdk/go/workflow_host_transport_test.go
@@ -1,0 +1,95 @@
+package gestalt_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+type workflowHostTransportHarness struct {
+	proto.UnimplementedWorkflowHostServer
+
+	mu       sync.Mutex
+	requests []*proto.InvokeWorkflowOperationRequest
+	tokens   []string
+}
+
+func (h *workflowHostTransportHarness) InvokeOperation(ctx context.Context, req *proto.InvokeWorkflowOperationRequest) (*proto.InvokeWorkflowOperationResponse, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+
+	h.mu.Lock()
+	if values := md.Get("x-gestalt-host-service-relay-token"); len(values) > 0 {
+		h.tokens = append(h.tokens, values...)
+	}
+	h.requests = append(h.requests, gproto.Clone(req).(*proto.InvokeWorkflowOperationRequest))
+	h.mu.Unlock()
+
+	return &proto.InvokeWorkflowOperationResponse{
+		Status: 202,
+		Body:   req.GetRunId() + ":" + req.GetTarget().GetPlugin().GetOperation(),
+	}, nil
+}
+
+func TestTransport_WorkflowHostTCPTargetTokenEnv(t *testing.T) {
+	address := reserveTCPAddress()
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+
+	harness := &workflowHostTransportHarness{}
+	srv := grpc.NewServer()
+	proto.RegisterWorkflowHostServer(srv, harness)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.Stop)
+
+	t.Setenv(gestalt.EnvWorkflowHostSocket, "tcp://"+address)
+	t.Setenv(gestalt.EnvWorkflowHostSocketToken, "relay-token-go")
+
+	client, err := gestalt.WorkflowHost()
+	if err != nil {
+		t.Fatalf("WorkflowHost: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	resp, err := client.InvokeOperation(context.Background(), &proto.InvokeWorkflowOperationRequest{
+		RunId: "run-1",
+		Target: &proto.BoundWorkflowTarget{
+			Kind: &proto.BoundWorkflowTarget_Plugin{
+				Plugin: &proto.BoundWorkflowPluginTarget{
+					PluginName: "roadmap",
+					Operation:  "sync_items",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InvokeOperation: %v", err)
+	}
+	if resp.GetStatus() != 202 || resp.GetBody() != "run-1:sync_items" {
+		t.Fatalf("response = %#v", resp)
+	}
+
+	harness.mu.Lock()
+	defer harness.mu.Unlock()
+	if len(harness.tokens) != 1 || harness.tokens[0] != "relay-token-go" {
+		t.Fatalf("relay tokens = %#v, want [relay-token-go]", harness.tokens)
+	}
+	if len(harness.requests) != 1 {
+		t.Fatalf("invoke requests len = %d, want 1", len(harness.requests))
+	}
+	got := harness.requests[0]
+	if got.GetRunId() != "run-1" || got.GetTarget().GetPlugin().GetPluginName() != "roadmap" || got.GetTarget().GetPlugin().GetOperation() != "sync_items" {
+		t.Fatalf("invoke request = %#v", got)
+	}
+}

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -79,7 +79,10 @@ pub use s3::{
 };
 pub use secrets::SecretsProvider;
 pub use tonic::codegen::async_trait;
-pub use workflow::{ENV_WORKFLOW_HOST_SOCKET, WorkflowHost, WorkflowHostError, WorkflowProvider};
+pub use workflow::{
+    ENV_WORKFLOW_HOST_SOCKET, ENV_WORKFLOW_HOST_SOCKET_TOKEN, WorkflowHost, WorkflowHostError,
+    WorkflowProvider,
+};
 pub use workflow_manager::{
     ENV_WORKFLOW_MANAGER_SOCKET, ENV_WORKFLOW_MANAGER_SOCKET_TOKEN, WorkflowManager,
     WorkflowManagerError,

--- a/sdk/rust/src/workflow.rs
+++ b/sdk/rust/src/workflow.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
 use tonic::codegen::async_trait;
-use tonic::transport::{Channel, Endpoint, Uri};
+use tonic::metadata::MetadataValue;
+use tonic::service::Interceptor;
+use tonic::service::interceptor::InterceptedService;
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 use tower::service_fn;
 
@@ -13,8 +16,13 @@ use crate::generated::v1::{
     self as pb, workflow_host_client::WorkflowHostClient as ProtoWorkflowHostClient,
 };
 
-/// Environment variable containing the workflow-host service socket path.
+type WorkflowHostTransport = InterceptedService<Channel, WorkflowHostRelayTokenInterceptor>;
+
+/// Environment variable containing the workflow-host service target.
 pub const ENV_WORKFLOW_HOST_SOCKET: &str = "GESTALT_WORKFLOW_HOST_SOCKET";
+/// Environment variable containing the optional workflow-host relay token.
+pub const ENV_WORKFLOW_HOST_SOCKET_TOKEN: &str = "GESTALT_WORKFLOW_HOST_SOCKET_TOKEN";
+const WORKFLOW_HOST_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
 #[derive(Debug, thiserror::Error)]
 /// Errors returned by [`WorkflowHost`].
@@ -32,18 +40,35 @@ pub enum WorkflowHostError {
 
 /// Client for invoking operations from workflow provider code.
 pub struct WorkflowHost {
-    client: ProtoWorkflowHostClient<Channel>,
+    client: ProtoWorkflowHostClient<WorkflowHostTransport>,
 }
 
 impl WorkflowHost {
     /// Connects to the workflow host service described by the environment.
     pub async fn connect() -> std::result::Result<Self, WorkflowHostError> {
-        let socket_path = std::env::var(ENV_WORKFLOW_HOST_SOCKET).map_err(|_| {
+        let target = std::env::var(ENV_WORKFLOW_HOST_SOCKET).map_err(|_| {
             WorkflowHostError::Env(format!("{ENV_WORKFLOW_HOST_SOCKET} is not set"))
         })?;
-        let channel = connect_unix(socket_path).await?;
+        let relay_token = std::env::var(ENV_WORKFLOW_HOST_SOCKET_TOKEN).unwrap_or_default();
+        let channel = match parse_workflow_host_target(&target)? {
+            WorkflowHostTarget::Unix(path) => connect_unix(path).await?,
+            WorkflowHostTarget::Tcp(address) => {
+                Endpoint::from_shared(format!("http://{address}"))?
+                    .connect()
+                    .await?
+            }
+            WorkflowHostTarget::Tls(address) => {
+                Endpoint::from_shared(format!("https://{address}"))?
+                    .tls_config(ClientTlsConfig::new().with_native_roots())?
+                    .connect()
+                    .await?
+            }
+        };
         Ok(Self {
-            client: ProtoWorkflowHostClient::new(channel),
+            client: ProtoWorkflowHostClient::with_interceptor(
+                channel,
+                workflow_host_relay_token_interceptor(relay_token.trim())?,
+            ),
         })
     }
 
@@ -65,6 +90,91 @@ async fn connect_unix(
             async move { UnixStream::connect(path).await.map(TokioIo::new) }
         }))
         .await
+}
+
+#[derive(Clone)]
+struct WorkflowHostRelayTokenInterceptor {
+    token: Option<MetadataValue<tonic::metadata::Ascii>>,
+}
+
+impl Interceptor for WorkflowHostRelayTokenInterceptor {
+    fn call(
+        &mut self,
+        mut request: tonic::Request<()>,
+    ) -> std::result::Result<tonic::Request<()>, tonic::Status> {
+        if let Some(token) = self.token.clone() {
+            request
+                .metadata_mut()
+                .insert(WORKFLOW_HOST_RELAY_TOKEN_HEADER, token);
+        }
+        Ok(request)
+    }
+}
+
+fn workflow_host_relay_token_interceptor(
+    token: &str,
+) -> std::result::Result<WorkflowHostRelayTokenInterceptor, WorkflowHostError> {
+    let trimmed = token.trim();
+    let token = if trimmed.is_empty() {
+        None
+    } else {
+        Some(MetadataValue::try_from(trimmed).map_err(|err| {
+            WorkflowHostError::Env(format!(
+                "workflow host: invalid relay token metadata: {err}"
+            ))
+        })?)
+    };
+    Ok(WorkflowHostRelayTokenInterceptor { token })
+}
+
+enum WorkflowHostTarget {
+    Unix(String),
+    Tcp(String),
+    Tls(String),
+}
+
+fn parse_workflow_host_target(
+    raw: &str,
+) -> std::result::Result<WorkflowHostTarget, WorkflowHostError> {
+    let target = raw.trim();
+    if target.is_empty() {
+        return Err(WorkflowHostError::Env(
+            "workflow host: transport target is required".to_string(),
+        ));
+    }
+    if let Some(address) = target.strip_prefix("tcp://") {
+        let address = address.trim();
+        if address.is_empty() {
+            return Err(WorkflowHostError::Env(format!(
+                "workflow host: tcp target {raw:?} is missing host:port"
+            )));
+        }
+        return Ok(WorkflowHostTarget::Tcp(address.to_string()));
+    }
+    if let Some(address) = target.strip_prefix("tls://") {
+        let address = address.trim();
+        if address.is_empty() {
+            return Err(WorkflowHostError::Env(format!(
+                "workflow host: tls target {raw:?} is missing host:port"
+            )));
+        }
+        return Ok(WorkflowHostTarget::Tls(address.to_string()));
+    }
+    if let Some(path) = target.strip_prefix("unix://") {
+        let path = path.trim();
+        if path.is_empty() {
+            return Err(WorkflowHostError::Env(format!(
+                "workflow host: unix target {raw:?} is missing a socket path"
+            )));
+        }
+        return Ok(WorkflowHostTarget::Unix(path.to_string()));
+    }
+    if target.contains("://") {
+        return Err(WorkflowHostError::Env(format!(
+            "workflow host: unsupported target scheme in {raw:?}"
+        )));
+    }
+    Ok(WorkflowHostTarget::Unix(target.to_string()))
 }
 
 #[async_trait]

--- a/sdk/rust/tests/workflow_transport.rs
+++ b/sdk/rust/tests/workflow_transport.rs
@@ -14,11 +14,10 @@ use gestalt::proto::v1::{
     ConfigureProviderRequest, ProviderKind, PublishWorkflowProviderEventRequest,
     StartWorkflowProviderRunRequest, WorkflowEvent, WorkflowRunStatus, bound_workflow_target,
 };
-use gestalt::{RuntimeMetadata, WorkflowHost, WorkflowProvider};
+use gestalt::{ENV_WORKFLOW_HOST_SOCKET_TOKEN, RuntimeMetadata, WorkflowHost, WorkflowProvider};
 use hyper_util::rt::tokio::TokioIo;
-use tokio::net::UnixListener;
-use tokio::net::UnixStream;
-use tokio_stream::wrappers::UnixListenerStream;
+use tokio::net::{TcpListener, UnixListener, UnixStream};
+use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
 use tonic::transport::{Endpoint, Server};
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 use tower::service_fn;
@@ -30,7 +29,9 @@ struct TestWorkflowProvider {
 }
 
 #[derive(Default, Clone)]
-struct TestWorkflowHostService;
+struct TestWorkflowHostService {
+    relay_tokens: Arc<Mutex<Vec<String>>>,
+}
 
 #[gestalt::async_trait]
 impl WorkflowProvider for TestWorkflowProvider {
@@ -257,6 +258,12 @@ impl WorkflowHostRpc for TestWorkflowHostService {
         &self,
         request: GrpcRequest<pb::InvokeWorkflowOperationRequest>,
     ) -> std::result::Result<GrpcResponse<pb::InvokeWorkflowOperationResponse>, Status> {
+        if let Some(token) = request.metadata().get("x-gestalt-host-service-relay-token") {
+            self.relay_tokens
+                .lock()
+                .expect("lock relay tokens")
+                .push(token.to_str().expect("relay token ascii").to_string());
+        }
         let request = request.into_inner();
         let target = request
             .target
@@ -409,13 +416,14 @@ async fn workflow_host_client_round_trip_over_unix_socket() {
     let host_socket = helpers::temp_socket("gestalt-rust-workflow-host.sock");
     let _workflow_host_env =
         helpers::EnvGuard::set(gestalt::ENV_WORKFLOW_HOST_SOCKET, host_socket.as_os_str());
+    let host_service = TestWorkflowHostService::default();
 
     let host_socket_for_task = host_socket.clone();
     let host_task = tokio::spawn(async move {
         let listener =
             UnixListener::bind(&host_socket_for_task).expect("bind workflow host socket");
         Server::builder()
-            .add_service(WorkflowHostGrpcServer::new(TestWorkflowHostService))
+            .add_service(WorkflowHostGrpcServer::new(host_service))
             .serve_with_incoming(UnixListenerStream::new(listener))
             .await
             .expect("serve workflow host");
@@ -444,6 +452,63 @@ async fn workflow_host_client_round_trip_over_unix_socket() {
         .expect("invoke operation");
     assert_eq!(invoked.status, 202);
     assert_eq!(invoked.body, "run-42:sync");
+
+    host_task.abort();
+    let _ = host_task.await;
+}
+
+#[tokio::test]
+async fn workflow_host_client_round_trip_over_tcp_and_sends_relay_token() {
+    let _env_lock = helpers::env_lock().lock().await;
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind tcp listener");
+    let address = listener.local_addr().expect("local addr");
+    let _workflow_host_env = helpers::EnvGuard::set(
+        gestalt::ENV_WORKFLOW_HOST_SOCKET,
+        format!("tcp://{address}"),
+    );
+    let _token_guard = helpers::EnvGuard::set(ENV_WORKFLOW_HOST_SOCKET_TOKEN, "relay-token-rust");
+
+    let host_service = TestWorkflowHostService::default();
+    let served_service = host_service.clone();
+    let host_task = tokio::spawn(async move {
+        Server::builder()
+            .add_service(WorkflowHostGrpcServer::new(served_service))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .expect("serve workflow host");
+    });
+
+    let mut host = WorkflowHost::connect()
+        .await
+        .expect("connect workflow host");
+    let invoked = host
+        .invoke_operation(pb::InvokeWorkflowOperationRequest {
+            target: Some(pb::BoundWorkflowTarget {
+                kind: Some(pb::bound_workflow_target::Kind::Plugin(
+                    pb::BoundWorkflowPluginTarget {
+                        plugin_name: "demo".to_string(),
+                        operation: "sync".to_string(),
+                        ..Default::default()
+                    },
+                )),
+            }),
+            run_id: "run-42".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("invoke operation");
+    assert_eq!(invoked.status, 202);
+    assert_eq!(invoked.body, "run-42:sync");
+    assert_eq!(
+        host_service
+            .relay_tokens
+            .lock()
+            .expect("lock relay tokens")
+            .clone(),
+        vec!["relay-token-rust".to_string()]
+    );
 
     host_task.abort();
     let _ = host_task.await;

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -372,6 +372,7 @@ export {
 } from "./agent.ts";
 export {
   ENV_WORKFLOW_HOST_SOCKET,
+  ENV_WORKFLOW_HOST_SOCKET_TOKEN,
   WorkflowHost,
   WorkflowProvider,
   WorkflowRunStatus,

--- a/sdk/typescript/src/workflow.ts
+++ b/sdk/typescript/src/workflow.ts
@@ -1,5 +1,3 @@
-import { connect } from "node:net";
-
 import { create, type MessageInitShape } from "@bufbuild/protobuf";
 import { EmptySchema } from "@bufbuild/protobuf/wkt";
 import {
@@ -7,6 +5,7 @@ import {
   ConnectError,
   createClient,
   type Client,
+  type Interceptor,
   type ServiceImpl,
 } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
@@ -48,8 +47,11 @@ import {
 import { errorMessage, type MaybePromise } from "./api.ts";
 import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
 
-/** Environment variable containing the workflow-host service socket path. */
+/** Environment variable containing the workflow-host service target. */
 export const ENV_WORKFLOW_HOST_SOCKET = "GESTALT_WORKFLOW_HOST_SOCKET";
+/** Environment variable containing the optional workflow-host relay token. */
+export const ENV_WORKFLOW_HOST_SOCKET_TOKEN = `${ENV_WORKFLOW_HOST_SOCKET}_TOKEN`;
+const WORKFLOW_HOST_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token";
 
 /**
  * Generated workflow protocol message types commonly used by providers.
@@ -325,15 +327,16 @@ export class WorkflowHost {
   private readonly client: Client<typeof WorkflowHostService>;
 
   constructor() {
-    const socketPath = process.env[ENV_WORKFLOW_HOST_SOCKET];
-    if (!socketPath) {
+    const target = process.env[ENV_WORKFLOW_HOST_SOCKET];
+    if (!target) {
       throw new Error(`workflow host: ${ENV_WORKFLOW_HOST_SOCKET} is not set`);
     }
+    const relayToken = process.env[ENV_WORKFLOW_HOST_SOCKET_TOKEN]?.trim() ?? "";
     const transport = createGrpcTransport({
-      baseUrl: "http://localhost",
-      nodeOptions: {
-        createConnection: () => connect({ path: socketPath }),
-      },
+      ...workflowHostTransportOptions(target),
+      interceptors: relayToken
+        ? [workflowHostRelayTokenInterceptor(relayToken)]
+        : [],
     });
     this.client = createClient(WorkflowHostService, transport);
   }
@@ -344,6 +347,57 @@ export class WorkflowHost {
   ): Promise<InvokeWorkflowOperationResponse> {
     return await this.client.invokeOperation(request);
   }
+}
+
+function workflowHostTransportOptions(rawTarget: string): {
+  baseUrl: string;
+  nodeOptions?: { path: string };
+} {
+  const target = rawTarget.trim();
+  if (!target) {
+    throw new Error("workflow host: transport target is required");
+  }
+  if (target.startsWith("tcp://")) {
+    const address = target.slice("tcp://".length).trim();
+    if (!address) {
+      throw new Error(
+        `workflow host: tcp target ${JSON.stringify(rawTarget)} is missing host:port`,
+      );
+    }
+    return { baseUrl: `http://${address}` };
+  }
+  if (target.startsWith("tls://")) {
+    const address = target.slice("tls://".length).trim();
+    if (!address) {
+      throw new Error(
+        `workflow host: tls target ${JSON.stringify(rawTarget)} is missing host:port`,
+      );
+    }
+    return { baseUrl: `https://${address}` };
+  }
+  if (target.startsWith("unix://")) {
+    const socketPath = target.slice("unix://".length).trim();
+    if (!socketPath) {
+      throw new Error(
+        `workflow host: unix target ${JSON.stringify(rawTarget)} is missing a socket path`,
+      );
+    }
+    return { baseUrl: "http://localhost", nodeOptions: { path: socketPath } };
+  }
+  if (target.includes("://")) {
+    const parsed = new URL(target);
+    throw new Error(
+      `workflow host: unsupported target scheme ${JSON.stringify(parsed.protocol.replace(/:$/, ""))}`,
+    );
+  }
+  return { baseUrl: "http://localhost", nodeOptions: { path: target } };
+}
+
+function workflowHostRelayTokenInterceptor(token: string): Interceptor {
+  return (next) => async (req) => {
+    req.header.set(WORKFLOW_HOST_RELAY_TOKEN_HEADER, token);
+    return next(req);
+  };
 }
 
 /** Builds the Connect service implementation used by the TypeScript runtime. */

--- a/sdk/typescript/tests/workflow.transport.test.ts
+++ b/sdk/typescript/tests/workflow.transport.test.ts
@@ -1,0 +1,111 @@
+import { createServer } from "node:http2";
+import { createServer as createNetServer } from "node:net";
+
+import { create } from "@bufbuild/protobuf";
+import { type ServiceImpl } from "@connectrpc/connect";
+import { connectNodeAdapter } from "@connectrpc/connect-node";
+import { expect, test } from "bun:test";
+
+import {
+  InvokeWorkflowOperationRequestSchema,
+  InvokeWorkflowOperationResponseSchema,
+  WorkflowHost as WorkflowHostService,
+} from "../src/internal/gen/v1/workflow_pb.ts";
+import {
+  ENV_WORKFLOW_HOST_SOCKET,
+  ENV_WORKFLOW_HOST_SOCKET_TOKEN,
+  WorkflowHost,
+} from "../src/index.ts";
+
+async function reserveTCPAddress(): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const server = createNetServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to reserve tcp address"));
+        return;
+      }
+      const result = `${address.address}:${address.port}`;
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(result);
+      });
+    });
+  });
+}
+
+test("WorkflowHost honors tcp target env and relay token env", async () => {
+  const previousSocket = process.env[ENV_WORKFLOW_HOST_SOCKET];
+  const previousToken = process.env[ENV_WORKFLOW_HOST_SOCKET_TOKEN];
+  const seenTokens: string[] = [];
+  const address = await reserveTCPAddress();
+
+  const handler = connectNodeAdapter({
+    grpc: true,
+    grpcWeb: false,
+    connect: false,
+    routes(router) {
+      router.service(WorkflowHostService, {
+        async invokeOperation(input) {
+          return create(InvokeWorkflowOperationResponseSchema, {
+            status: 202,
+            body: input.runId,
+          });
+        },
+      } satisfies Partial<ServiceImpl<typeof WorkflowHostService>>);
+    },
+  });
+  const server = createServer((req, res) => {
+    const tokenHeader = req.headers["x-gestalt-host-service-relay-token"];
+    if (typeof tokenHeader === "string") {
+      seenTokens.push(tokenHeader);
+    }
+    handler(req, res);
+  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(Number(address.split(":").at(-1)), "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+
+    process.env[ENV_WORKFLOW_HOST_SOCKET] = `tcp://${address}`;
+    process.env[ENV_WORKFLOW_HOST_SOCKET_TOKEN] = "relay-token-typescript";
+
+    const host = new WorkflowHost();
+    const response = await host.invokeOperation(
+      create(InvokeWorkflowOperationRequestSchema, {
+        runId: "run-123",
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(response.body).toBe("run-123");
+    expect(seenTokens).toEqual(["relay-token-typescript"]);
+  } finally {
+    if (previousSocket === undefined) {
+      delete process.env[ENV_WORKFLOW_HOST_SOCKET];
+    } else {
+      process.env[ENV_WORKFLOW_HOST_SOCKET] = previousSocket;
+    }
+    if (previousToken === undefined) {
+      delete process.env[ENV_WORKFLOW_HOST_SOCKET_TOKEN];
+    } else {
+      process.env[ENV_WORKFLOW_HOST_SOCKET_TOKEN] = previousToken;
+    }
+    if (server.listening) {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Adds hosted execution support for workflow providers and fixed-size hosted workflow runtime pools. `gestaltd serve` remains the only runtime entrypoint: after the provider graph is ready, the existing workflow provider startup lifecycle starts the hosted workflow control provider plus its ready worker pool.

There is no `gestaltd workflow-worker` command. The workflow provider contract stays provider-shaped; deployment config decides whether the provider runs locally or through a runtime provider.

## Interface Diff

### Workflow Provider Config

Previously `providers.workflow.<name>` could configure source, provider config, env, egress, and optional host IndexedDB binding, but not hosted execution:

```yaml
providers:
  workflow:
    temporal:
      source: ./providers/workflow/temporal
      config:
        namespace: default
        taskQueue: gestalt-workflows
```

New optional hosted execution fields:

```diff
 providers:
   workflow:
     temporal:
       source: ./providers/workflow/temporal
+      execution:
+        mode: hosted
+        runtime:
+          provider: gke
+          template: workflow-workers
+          pool:
+            minReadyInstances: 2
+            maxReadyInstances: 2
+            startupTimeout: 5m
+            healthCheckInterval: 30s
+            restartPolicy: always
+            drainTimeout: 2m
       config:
         namespace: default
+        taskQueue: gestalt-workflows
```

Workflow runtime pools are fixed-size in this PR: `maxReadyInstances` must equal `minReadyInstances`.

`execution.runtime.metadata` remains an opaque runtime-provider metadata map passed to `StartSession`. This PR does not define a `taskQueue` metadata key. Provider-specific workflow settings such as a Temporal task queue belong under `providers.workflow.<name>.config` unless a concrete runtime provider explicitly documents otherwise.

### Workflow Host SDK Transport

Previously Go, TypeScript, and Rust `WorkflowHost` clients treated `GESTALT_WORKFLOW_HOST_SOCKET` as a Unix socket path.

New target forms:

```text
GESTALT_WORKFLOW_HOST_SOCKET=/path/to/workflow-host.sock
GESTALT_WORKFLOW_HOST_SOCKET=unix:///path/to/workflow-host.sock
GESTALT_WORKFLOW_HOST_SOCKET=tcp://127.0.0.1:8080
GESTALT_WORKFLOW_HOST_SOCKET=tls://workflow-host.example.com:443
GESTALT_WORKFLOW_HOST_SOCKET_TOKEN=<relay token>
```

The token is sent as `x-gestalt-host-service-relay-token` when present. Existing plain Unix socket values continue to work.

## Layer Examples

### 1. Workflow Provider Expresses Its Surface

Provider packages still express only that they are workflow providers. They do not name GKE, worker pools, or any other runtime-provider implementation detail.

Provider manifest example:

```yaml
kind: workflow
source: github.com/your-org/workflow/temporal
version: 0.0.1
displayName: Temporal Workflow
description: Temporal-backed workflow run, schedule, and event trigger provider.
spec:
  configSchemaPath: ./workflow_config.json
```

TypeScript package entrypoint example:

```json
{
  "gestalt": {
    "provider": {
      "kind": "workflow",
      "target": "./workflow.ts#provider"
    }
  }
}
```

### 2. Workflow Provider Implements The Existing Workflow Contract

Provider implementation code continues to implement the workflow provider protocol and calls back into Gestalt through `WorkflowHost` when a run should invoke a plugin or agent target. The SDK reads the host target and relay token from env; provider code does not need to know whether it is local, TCP-relayed, or hosted by GKE.

Go sketch:

```go
type TemporalProvider struct {
	proto.UnimplementedWorkflowProviderServer
}

func (p *TemporalProvider) StartRun(ctx context.Context, req *proto.StartWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
	host, err := gestalt.WorkflowHost()
	if err != nil {
		return nil, err
	}
	defer host.Close()

	resp, err := host.InvokeOperation(ctx, &proto.InvokeWorkflowOperationRequest{
		Target: req.GetTarget(),
		RunId:  "run-123",
	})
	if err != nil {
		return nil, err
	}

	return &proto.BoundWorkflowRun{
		Id:         "run-123",
		Status:     proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_SUCCEEDED,
		ResultBody: resp.GetBody(),
	}, nil
}
```

The same provider binary can run locally or as a hosted workflow runtime process. `gestaltd` injects `GESTALT_WORKFLOW_HOST_SOCKET` and `GESTALT_WORKFLOW_HOST_SOCKET_TOKEN` when the hosted runtime needs the public host-service relay.

### 3. Deployer Expresses Runtime Placement

The deployer chooses where the workflow provider runs by configuring `execution.runtime` and the runtime provider. `gestaltd serve` starts the hosted control provider and ready worker pool automatically during workflow provider startup.

```yaml
providers:
  workflow:
    temporal:
      source: https://artifacts.example.com/workflow/temporal/v0.0.1-alpha.1/provider-release.yaml
      execution:
        mode: hosted
        runtime:
          provider: gke
          template: workflow-workers
          pool:
            minReadyInstances: 2
            maxReadyInstances: 2
            startupTimeout: 5m
            healthCheckInterval: 30s
            restartPolicy: always
            drainTimeout: 2m
      config:
        namespace: default
        taskQueue: gestalt-workflows

runtime:
  providers:
    gke:
      source: https://artifacts.example.com/runtime/gke/v0.0.1-alpha.1/provider-release.yaml
      config:
        project: production-platform
        cluster: gestalt-runtime
        namespace: gestalt-workers
```

Local deployments can omit `execution` and keep the old behavior:

```yaml
providers:
  workflow:
    temporal:
      source: ./providers/workflow/temporal
      config:
        namespace: default
        taskQueue: gestalt-workflows
```
