### PR TITLE
Preserve workflow deadlines for agent session creation

### DIFF
--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	pluginservice "github.com/valon-technologies/gestalt/server/services/plugins"
 	"github.com/valon-technologies/gestalt/server/services/plugins/registry"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -178,14 +179,20 @@ func workflowSignalsFromTestContext(value any) []map[string]any {
 
 type workflowRuntimeAgentManagerStub struct {
 	agentmanager.Service
-	createSessionRequests []coreagent.ManagerCreateSessionRequest
-	createTurnRequests    []coreagent.ManagerCreateTurnRequest
-	cancelTurnIDs         []string
-	returnNilTurn         bool
+	createSessionRequests  []coreagent.ManagerCreateSessionRequest
+	createSessionDeadlines []time.Duration
+	createTurnRequests     []coreagent.ManagerCreateTurnRequest
+	cancelTurnIDs          []string
+	returnNilTurn          bool
 }
 
-func (m *workflowRuntimeAgentManagerStub) CreateSession(_ context.Context, _ *principal.Principal, req coreagent.ManagerCreateSessionRequest) (*coreagent.Session, error) {
+func (m *workflowRuntimeAgentManagerStub) CreateSession(ctx context.Context, _ *principal.Principal, req coreagent.ManagerCreateSessionRequest) (*coreagent.Session, error) {
 	m.createSessionRequests = append(m.createSessionRequests, req)
+	if deadline, ok := ctx.Deadline(); ok {
+		m.createSessionDeadlines = append(m.createSessionDeadlines, time.Until(deadline))
+	} else {
+		m.createSessionDeadlines = append(m.createSessionDeadlines, 0)
+	}
 	return &coreagent.Session{
 		ID:           "session-1",
 		ProviderName: req.ProviderName,
@@ -623,6 +630,43 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 	}
 	if len(turnReq.ToolRefs) != 1 || turnReq.ToolRefs[0].Plugin != "roadmap" || turnReq.ToolRefs[0].Operation != "sync" {
 		t.Fatalf("turn tool refs = %#v", turnReq.ToolRefs)
+	}
+}
+
+func TestWorkflowRuntimeInvokeAgentTargetPassesWorkflowDeadlineToCreateSession(t *testing.T) {
+	t.Parallel()
+
+	agentManager := &workflowRuntimeAgentManagerStub{}
+	runtime := &workflowRuntime{}
+	runtime.SetAgentManager(agentManager)
+	p := principal.Canonicalize(&principal.Principal{
+		SubjectID:           principal.UserSubjectID("ada"),
+		CredentialSubjectID: principal.UserSubjectID("ada"),
+	})
+
+	resp, err := runtime.Invoke(principal.WithPrincipal(context.Background(), p), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		RunID:        "run-agent-default-timeout",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "managed",
+			Model:        "deep",
+			Prompt:       "Send the status summary",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("response = %#v", resp)
+	}
+	if len(agentManager.createSessionDeadlines) != 1 {
+		t.Fatalf("create session deadlines = %#v, want one", agentManager.createSessionDeadlines)
+	}
+	if got := agentManager.createSessionDeadlines[0]; got <= runtimehost.ProviderRPCTimeout {
+		t.Fatalf("CreateSession remaining deadline = %s, want workflow deadline above provider RPC timeout %s", got, runtimehost.ProviderRPCTimeout)
+	}
+	if got := agentManager.createSessionDeadlines[0]; got > workflowAgentTimeout(0) {
+		t.Fatalf("CreateSession remaining deadline = %s, want at most workflow timeout %s", got, workflowAgentTimeout(0))
 	}
 }
 

--- a/gestaltd/services/agents/client.go
+++ b/gestaltd/services/agents/client.go
@@ -85,7 +85,7 @@ func NewRemote(ctx context.Context, cfg RemoteConfig) (coreagent.Provider, error
 }
 
 func (r *remoteAgent) CreateSession(ctx context.Context, req coreagent.CreateSessionRequest) (*coreagent.Session, error) {
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	ctx, cancel := runtimehost.ProviderSessionCreateContext(ctx)
 	defer cancel()
 	metadata, err := structFromMap(req.Metadata)
 	if err != nil {

--- a/gestaltd/services/agents/client_test.go
+++ b/gestaltd/services/agents/client_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -138,6 +140,38 @@ func TestRemoteAgentCreateSessionForwardsSessionStart(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
+	}
+}
+
+func TestRemoteAgentCreateSessionPreservesWorkflowDeadline(t *testing.T) {
+	t.Parallel()
+
+	parentDeadline := time.Now().Add(2 * runtimehost.ProviderRPCTimeout)
+	var createSessionRemaining time.Duration
+	agent := &remoteAgent{
+		client: &fakeAgentProviderClient{
+			createSession: func(ctx context.Context, req *proto.CreateAgentProviderSessionRequest, _ ...grpc.CallOption) (*proto.AgentSession, error) {
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatal("CreateSession context has no deadline")
+				}
+				createSessionRemaining = time.Until(deadline)
+				return &proto.AgentSession{Id: req.GetSessionId(), ProviderName: "claude"}, nil
+			},
+		},
+	}
+	ctx, cancel := context.WithDeadline(context.Background(), parentDeadline)
+	defer cancel()
+
+	_, err := agent.CreateSession(ctx, coreagent.CreateSessionRequest{SessionID: "session-1"})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if createSessionRemaining <= runtimehost.ProviderRPCTimeout {
+		t.Fatalf("CreateSession remaining deadline = %s, want above provider RPC timeout %s", createSessionRemaining, runtimehost.ProviderRPCTimeout)
+	}
+	if createSessionRemaining > 2*runtimehost.ProviderRPCTimeout {
+		t.Fatalf("CreateSession remaining deadline = %s, want at most parent deadline %s", createSessionRemaining, 2*runtimehost.ProviderRPCTimeout)
 	}
 }
 

--- a/gestaltd/services/runtimehost/runtime_client.go
+++ b/gestaltd/services/runtimehost/runtime_client.go
@@ -18,8 +18,11 @@ const (
 	// Hosted agent providers can do real setup work during session creation
 	// after the runtime itself is ready. Keep this below the API route timeout,
 	// but above short health-check style deadlines.
-	ProviderRPCTimeout   = 30 * time.Second
-	providerStartTimeout = 2 * time.Minute
+	ProviderRPCTimeout = 30 * time.Second
+	// ProviderSessionCreateTimeout bounds agent CreateSession RPCs when callers
+	// do not provide their own deadline.
+	ProviderSessionCreateTimeout = 5 * time.Minute
+	providerStartTimeout         = 2 * time.Minute
 )
 
 var providerConfigureTimeout = 30 * time.Second
@@ -153,6 +156,18 @@ func ProviderCallContext(parent context.Context) (context.Context, context.Cance
 		parent = context.Background()
 	}
 	return context.WithTimeout(parent, ProviderRPCTimeout)
+}
+
+// ProviderSessionCreateContext returns a child context for agent CreateSession RPCs.
+// It preserves caller deadlines when present and otherwise applies a bounded fallback.
+func ProviderSessionCreateContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if _, ok := parent.Deadline(); ok {
+		return context.WithCancel(parent)
+	}
+	return context.WithTimeout(parent, ProviderSessionCreateTimeout)
 }
 
 func providerStartContext(parent context.Context) (context.Context, context.CancelFunc) {

--- a/gestaltd/services/runtimehost/runtime_client_test.go
+++ b/gestaltd/services/runtimehost/runtime_client_test.go
@@ -183,6 +183,70 @@ func TestConfigureRuntimeProviderUsesParentDeadlineWhenPresent(t *testing.T) {
 	}
 }
 
+func TestProviderSessionCreateContextUsesBoundedFallbackWithoutParentDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := ProviderSessionCreateContext(context.Background())
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("ProviderSessionCreateContext returned context without deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= ProviderRPCTimeout {
+		t.Fatalf("remaining deadline = %s, want above provider RPC timeout %s", remaining, ProviderRPCTimeout)
+	}
+	if remaining > ProviderSessionCreateTimeout {
+		t.Fatalf("remaining deadline = %s, want at most session create timeout %s", remaining, ProviderSessionCreateTimeout)
+	}
+}
+
+func TestProviderSessionCreateContextPreservesLongParentDeadline(t *testing.T) {
+	t.Parallel()
+
+	parentDeadline := time.Now().Add(2 * ProviderSessionCreateTimeout)
+	parent, parentCancel := context.WithDeadline(context.Background(), parentDeadline)
+	defer parentCancel()
+	ctx, cancel := ProviderSessionCreateContext(parent)
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("ProviderSessionCreateContext returned context without deadline")
+	}
+	if !deadline.Equal(parentDeadline) {
+		t.Fatalf("deadline = %s, want parent deadline %s", deadline, parentDeadline)
+	}
+	if remaining := time.Until(deadline); remaining <= ProviderSessionCreateTimeout {
+		t.Fatalf("remaining deadline = %s, want above fallback timeout %s", remaining, ProviderSessionCreateTimeout)
+	}
+}
+
+func TestProviderSessionCreateContextPreservesShortParentDeadline(t *testing.T) {
+	t.Parallel()
+
+	parentDeadline := time.Now().Add(ProviderRPCTimeout / 2)
+	parent, parentCancel := context.WithDeadline(context.Background(), parentDeadline)
+	defer parentCancel()
+	ctx, cancel := ProviderSessionCreateContext(parent)
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("ProviderSessionCreateContext returned context without deadline")
+	}
+	if !deadline.Equal(parentDeadline) {
+		t.Fatalf("deadline = %s, want parent deadline %s", deadline, parentDeadline)
+	}
+	if remaining := time.Until(deadline); remaining >= ProviderRPCTimeout {
+		t.Fatalf("remaining deadline = %s, want below provider RPC timeout %s", remaining, ProviderRPCTimeout)
+	}
+	parentCancel()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("session create context did not observe parent cancellation")
+	}
+}
+
 func TestStartRuntimeProviderValidatesProtocolVersion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Preserve caller deadlines for agent `CreateSession` RPCs so workflow-triggered agents can spend longer than 30 seconds in synchronous `sessionStart` hooks.
- Keep ordinary provider calls on the existing 30-second `ProviderCallContext`; only `remoteAgent.CreateSession` uses the new session-create helper.
- Add focused deadline propagation coverage in runtimehost, the remote agent client, and workflow runtime boundaries.

## Interface Changes
- New/changed interface: `runtimehost.ProviderSessionCreateContext(parent context.Context)` preserves an existing parent deadline and otherwise applies `ProviderSessionCreateTimeout`.
- Example usage: workflow agent invocation creates a five-minute run context, then `remoteAgent.CreateSession(runCtx, ...)` carries that workflow deadline into the provider while other RPCs continue to use `ProviderCallContext`.

## Functional/Integration Tests
- Tests added or augmented: runtimehost helper deadline contract, remote agent client `CreateSession` deadline propagation, and workflow runtime agent invocation passing its workflow deadline to `CreateSession`.
- Contract boundary covered: focused segments across workflow runtime -> agent manager and remote agent client -> provider RPC context selection.
- Commands run: `go test ./services/runtimehost ./services/agents ./internal/bootstrap` from `gestaltd/`.

## Test plan
- [x] `go test ./services/runtimehost ./services/agents ./internal/bootstrap`

Follow-up: update Toolshed `GESTALT_REF` after this core PR merges, if deployment is requested.