### PR TITLE
Allow explicit connections for plugin operations

### DIFF
--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -503,6 +503,34 @@ func TestBrokerInvokeGraphQLEnrichesAgentExternalIdentity(t *testing.T) {
 	}
 }
 
+func TestOperationConnectionOverrideAllowedForPluginTransportOperations(t *testing.T) {
+	t.Parallel()
+
+	prov := &brokerOperationConnectionProvider{
+		StubIntegration: &coretesting.StubIntegration{
+			N: "slack",
+			CatalogVal: &catalog.Catalog{
+				Name: "slack",
+				Operations: []catalog.CatalogOperation{
+					{ID: "assistant.reconcileStuckRequests", Method: "POST", Transport: catalog.TransportPlugin},
+					{ID: "chat.postMessage", Method: "POST", Transport: catalog.TransportREST},
+				},
+			},
+		},
+		operationConnections: map[string]string{
+			"assistant.reconcileStuckRequests": "default",
+			"chat.postMessage":                 "default",
+		},
+	}
+
+	if !OperationConnectionOverrideAllowed(prov, "assistant.reconcileStuckRequests", nil) {
+		t.Fatal("plugin transport operation should allow explicit connection override")
+	}
+	if OperationConnectionOverrideAllowed(prov, "chat.postMessage", nil) {
+		t.Fatal("REST operation should not allow explicit connection override")
+	}
+}
+
 type staticProviderOverrideResolver struct {
 	provider core.Provider
 }

--- a/gestaltd/services/invocation/catalog.go
+++ b/gestaltd/services/invocation/catalog.go
@@ -189,7 +189,12 @@ func OperationConnectionOverrideAllowed(prov core.Provider, operation string, pa
 		return true
 	}
 	if policy, ok := prov.(core.OperationConnectionOverridePolicy); ok {
-		return policy.OperationConnectionOverrideAllowed(operation, params)
+		if policy.OperationConnectionOverrideAllowed(operation, params) {
+			return true
+		}
+	}
+	if op, ok := CatalogOperation(providerCatalog(prov), operation); ok && OperationTransport(op) == catalog.TransportPlugin {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- Allow plugin-transport operations to accept explicit connection overrides.
- Preserve strict static connection binding for REST operations.
- Cover the Slack assistant reconciler case where a source-backed hidden provider helper needs to run from a config-managed schedule with the platform bot connection.

## Test plan
- [x] `go test ./services/invocation ./internal/bootstrap` from `gestaltd/`


Made with [Cursor](https://cursor.com)