### PR TITLE
Route hosted runtime pools around stale sessions

### DIFF
--- a/gestaltd/internal/bootstrap/hosted_agent_pool.go
+++ b/gestaltd/internal/bootstrap/hosted_agent_pool.go
@@ -1010,24 +1010,45 @@ func (p *hostedAgentProviderPool) acquireBackend(ctx context.Context, preferred 
 }
 
 func (p *hostedAgentProviderPool) acquireBackendForNewWork(ctx context.Context, preferred *hostedAgentPoolBackend, allowDraining bool) (*hostedAgentPoolBackend, func(), error) {
-	if preferred != nil {
-		p.mu.Lock()
-		if p.closed {
+	for {
+		var backend *hostedAgentPoolBackend
+		var release func()
+		var err error
+		if preferred != nil {
+			p.mu.Lock()
+			if p.closed {
+				p.mu.Unlock()
+				return nil, nil, fmt.Errorf("hosted agent provider %q is closed", p.name)
+			}
+			now := time.Now().UTC()
+			if p.backendAcceptsNewWorkLocked(preferred, now) || (allowDraining && p.backendAvailableLocked(preferred, true) && !p.backendRuntimeDrainDueLocked(preferred, now) && !p.backendRuntimeSessionStaleLocked(preferred)) {
+				preferred.active++
+				backend = preferred
+				release = p.releaseBackend(preferred)
+			}
 			p.mu.Unlock()
-			return nil, nil, fmt.Errorf("hosted agent provider %q is closed", p.name)
+			preferred = nil
+			if backend == nil {
+				if ctx.Err() != nil {
+					return nil, nil, ctx.Err()
+				}
+				continue
+			}
+		} else {
+			backend, release, err = p.acquireBackend(ctx, nil, false)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
-		now := time.Now().UTC()
-		if p.backendAcceptsNewWorkLocked(preferred, now) || (allowDraining && p.backendAvailableLocked(preferred, true) && !p.backendRuntimeDrainDueLocked(preferred, now)) {
-			preferred.active++
-			p.mu.Unlock()
-			return preferred, p.releaseBackend(preferred), nil
+		if err := p.ensureBackendFreshForNewWork(ctx, backend); err != nil {
+			release()
+			if ctx.Err() != nil {
+				return nil, nil, ctx.Err()
+			}
+			continue
 		}
-		p.mu.Unlock()
-		if ctx.Err() != nil {
-			return nil, nil, ctx.Err()
-		}
+		return backend, release, nil
 	}
-	return p.acquireBackend(ctx, nil, false)
 }
 
 func (p *hostedAgentProviderPool) releaseBackend(backend *hostedAgentPoolBackend) func() {
@@ -1117,7 +1138,7 @@ func (p *hostedAgentProviderPool) backendAvailableLocked(backend *hostedAgentPoo
 }
 
 func (p *hostedAgentProviderPool) backendAcceptsNewWorkLocked(backend *hostedAgentPoolBackend, now time.Time) bool {
-	return p.backendAvailableLocked(backend, false) && !p.backendRuntimeDrainDueLocked(backend, now)
+	return p.backendAvailableLocked(backend, false) && !p.backendRuntimeDrainDueLocked(backend, now) && !p.backendRuntimeSessionStaleLocked(backend)
 }
 
 func (p *hostedAgentProviderPool) backendRuntimeDrainDueLocked(backend *hostedAgentPoolBackend, now time.Time) bool {
@@ -1129,6 +1150,10 @@ func (p *hostedAgentProviderPool) backendRuntimeDrainDueLocked(backend *hostedAg
 		now = time.Now().UTC()
 	}
 	return !now.Before(drainAt)
+}
+
+func (p *hostedAgentProviderPool) backendRuntimeSessionStaleLocked(backend *hostedAgentPoolBackend) bool {
+	return backend != nil && hostedRuntimeSessionCompatibilityReason(backend.runtimeSession) != ""
 }
 
 func (p *hostedAgentProviderPool) readyBackends() []*hostedAgentPoolBackend {
@@ -1435,6 +1460,66 @@ func (p *hostedAgentProviderPool) refreshBackendRuntimeSession(backend *hostedAg
 	return session, drainAt, nil
 }
 
+func (p *hostedAgentProviderPool) ensureBackendFreshForNewWork(ctx context.Context, backend *hostedAgentPoolBackend) error {
+	if backend == nil {
+		return fmt.Errorf("runtime instance is unavailable")
+	}
+	p.mu.Lock()
+	knownReason := hostedRuntimeSessionCompatibilityReason(backend.runtimeSession)
+	p.mu.Unlock()
+	if knownReason != "" {
+		p.replaceBackendAllowNever(backend, knownReason, true)
+		return p.unavailableError(fmt.Errorf("hosted agent provider %q runtime instance is stale: %s", p.name, knownReason))
+	}
+	if p.policy.RestartPolicy != config.HostedRuntimeRestartPolicyNever {
+		return nil
+	}
+	session, drainAt, err := p.refreshBackendRuntimeSessionWithContext(ctx, backend, 10*time.Second)
+	if err != nil {
+		p.replaceBackendAllowNever(backend, err.Error(), true)
+		return p.unavailableError(fmt.Errorf("hosted agent provider %q runtime instance refresh failed: %w", p.name, err))
+	}
+	if reason := p.runtimeSessionRetirementReason(session, drainAt, time.Now().UTC()); reason != "" {
+		p.replaceBackendAllowNever(backend, reason, true)
+		return p.unavailableError(fmt.Errorf("hosted agent provider %q runtime instance is retiring: %s", p.name, reason))
+	}
+	return nil
+}
+
+func (p *hostedAgentProviderPool) refreshBackendRuntimeSessionWithContext(ctx context.Context, backend *hostedAgentPoolBackend, timeout time.Duration) (*pluginruntime.Session, *time.Time, error) {
+	if backend == nil {
+		return nil, nil, fmt.Errorf("runtime instance is unavailable")
+	}
+	p.mu.Lock()
+	runtimeProvider := backend.runtimeProvider
+	sessionID := strings.TrimSpace(backend.runtimeSessionID)
+	p.mu.Unlock()
+	if runtimeProvider == nil || sessionID == "" {
+		return nil, nil, nil
+	}
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	refreshCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	session, err := runtimeProvider.GetSession(refreshCtx, pluginruntime.GetSessionRequest{SessionID: sessionID})
+	if err != nil {
+		return nil, nil, fmt.Errorf("get runtime session %q: %w", sessionID, err)
+	}
+	drainAt := p.runtimeSessionDrainAt(session, time.Now().UTC())
+	p.mu.Lock()
+	if p.backendAvailableLocked(backend, true) {
+		if backend.runtimeDrainAt != nil && (drainAt == nil || backend.runtimeDrainAt.Before(*drainAt)) {
+			drainAt = cloneTime(backend.runtimeDrainAt)
+		}
+		backend.runtimeSession = session
+		backend.runtimeDrainAt = cloneTime(drainAt)
+		backend.forceCloseAt = runtimeSessionExpiresAt(session)
+	}
+	p.mu.Unlock()
+	return session, drainAt, nil
+}
+
 func (p *hostedAgentProviderPool) runtimeSessionRetirementReason(session *pluginruntime.Session, drainAt *time.Time, now time.Time) string {
 	if session == nil {
 		return ""
@@ -1442,6 +1527,9 @@ func (p *hostedAgentProviderPool) runtimeSessionRetirementReason(session *plugin
 	switch session.State {
 	case pluginruntime.SessionStateFailed, pluginruntime.SessionStateStopped:
 		return fmt.Sprintf("runtime session entered %q state", session.State)
+	}
+	if reason := hostedRuntimeSessionCompatibilityReason(session); reason != "" {
+		return reason
 	}
 	if drainAt == nil || now.Before(*drainAt) {
 		return ""
@@ -1579,7 +1667,11 @@ func (p *hostedAgentProviderPool) pingBackend(backend *hostedAgentPoolBackend) e
 }
 
 func (p *hostedAgentProviderPool) replaceBackend(backend *hostedAgentPoolBackend) {
-	if p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever || !p.markBackendDraining(backend) {
+	p.replaceBackendAllowNever(backend, "", false)
+}
+
+func (p *hostedAgentProviderPool) replaceBackendAllowNever(backend *hostedAgentPoolBackend, reason string, allowRestartPolicyNever bool) {
+	if (p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever && !allowRestartPolicyNever) || !p.markBackendDraining(backend) {
 		return
 	}
 	if !p.addLifecycleWork() {
@@ -1592,10 +1684,10 @@ func (p *hostedAgentProviderPool) replaceBackend(backend *hostedAgentPoolBackend
 		startErr := p.ensureMinReady(p.ctx)
 		recordHostedAgentRuntimeReplacement(p.ctx, p.name, startErr)
 		if startErr != nil && !errors.Is(startErr, context.Canceled) {
-			slog.Warn("failed to replace hosted agent runtime instance", "provider", p.name, "instance", backend.id, "error", startErr)
+			slog.Warn("failed to replace hosted agent runtime instance", "provider", p.name, "instance", backend.id, "reason", reason, "error", startErr)
 		}
 		if err := p.drainAndCloseBackend(backend); err != nil {
-			slog.Warn("failed to close unhealthy hosted agent runtime instance", "provider", p.name, "instance", backend.id, "error", err)
+			slog.Warn("failed to close unhealthy hosted agent runtime instance", "provider", p.name, "instance", backend.id, "reason", reason, "error", err)
 		}
 	}()
 }

--- a/gestaltd/internal/bootstrap/hosted_runtime_compatibility.go
+++ b/gestaltd/internal/bootstrap/hosted_runtime_compatibility.go
@@ -1,0 +1,64 @@
+package bootstrap
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/services/runtimehost/pluginruntime"
+)
+
+const (
+	hostedRuntimeMetadataImageMatch    = "runtime.imageMatch"
+	hostedRuntimeMetadataExpectedImage = "runtime.expectedImage"
+	hostedRuntimeMetadataCurrentImage  = "runtime.currentImage"
+	hostedRuntimeMetadataActualImage   = "runtime.actualImage"
+	hostedRuntimeMetadataTemplate      = "runtime.template"
+)
+
+func hostedRuntimeSessionCompatibilityReason(session *pluginruntime.Session) string {
+	if session == nil || len(session.Metadata) == 0 {
+		return ""
+	}
+	metadata := session.Metadata
+	actual := strings.TrimSpace(metadata[hostedRuntimeMetadataActualImage])
+	current := strings.TrimSpace(metadata[hostedRuntimeMetadataCurrentImage])
+	expected := strings.TrimSpace(metadata[hostedRuntimeMetadataExpectedImage])
+	template := strings.TrimSpace(metadata[hostedRuntimeMetadataTemplate])
+
+	if current != "" && actual != "" && current != actual {
+		return hostedRuntimeImageMismatchReason(template, current, actual)
+	}
+	if match, ok := parseRuntimeImageMatch(metadata[hostedRuntimeMetadataImageMatch]); ok && !match {
+		if current == "" {
+			current = expected
+		}
+		return hostedRuntimeImageMismatchReason(template, current, actual)
+	}
+	return ""
+}
+
+func parseRuntimeImageMatch(raw string) (bool, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false, false
+	}
+	parsed, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, false
+	}
+	return parsed, true
+}
+
+func hostedRuntimeImageMismatchReason(template, expected, actual string) string {
+	if template == "" {
+		template = "runtime template"
+	}
+	if expected == "" {
+		expected = "unknown"
+	}
+	if actual == "" {
+		actual = "unknown"
+	}
+	return fmt.Sprintf("%s image mismatch: expected %q, actual %q", template, expected, actual)
+}

--- a/gestaltd/internal/bootstrap/hosted_runtime_compatibility_test.go
+++ b/gestaltd/internal/bootstrap/hosted_runtime_compatibility_test.go
@@ -1,0 +1,148 @@
+package bootstrap
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost/pluginruntime"
+)
+
+func TestHostedRuntimeSessionCompatibilityReasonDetectsImageMismatch(t *testing.T) {
+	t.Parallel()
+
+	session := &pluginruntime.Session{Metadata: map[string]string{
+		hostedRuntimeMetadataTemplate:     "agent-runtime",
+		hostedRuntimeMetadataCurrentImage: "runtime@sha256:current",
+		hostedRuntimeMetadataActualImage:  "runtime@sha256:old",
+		hostedRuntimeMetadataImageMatch:   "false",
+	}}
+
+	reason := hostedRuntimeSessionCompatibilityReason(session)
+	if !strings.Contains(reason, "agent-runtime image mismatch") {
+		t.Fatalf("reason = %q, want image mismatch", reason)
+	}
+}
+
+func TestHostedRuntimeSessionCompatibilityReasonTreatsMissingMetadataAsCompatible(t *testing.T) {
+	t.Parallel()
+
+	if reason := hostedRuntimeSessionCompatibilityReason(&pluginruntime.Session{}); reason != "" {
+		t.Fatalf("reason = %q, want compatible", reason)
+	}
+}
+
+func TestHostedAgentPoolDoesNotRouteNewWorkToKnownStaleBackend(t *testing.T) {
+	t.Parallel()
+
+	pool := &hostedAgentProviderPool{}
+	backend := &hostedAgentPoolBackend{
+		provider:        &pingAgentProvider{},
+		runtimeSession:  staleRuntimeSessionForTest(),
+		runtimeDrainAt:  nil,
+		forceCloseAt:    nil,
+		liveTurns:       map[string]struct{}{},
+		runtimeProvider: nil,
+	}
+	pool.backends = []*hostedAgentPoolBackend{backend}
+	pool.mu.Lock()
+	accepts := pool.backendAcceptsNewWorkLocked(backend, time.Now().UTC())
+	pool.mu.Unlock()
+	if accepts {
+		t.Fatalf("backendAcceptsNewWorkLocked = true, want false for stale runtime session")
+	}
+}
+
+func TestHostedWorkflowWorkerKnownStaleSessionIsNotReady(t *testing.T) {
+	t.Parallel()
+
+	pool := &hostedWorkflowProviderPool{}
+	worker := &hostedWorkflowWorker{
+		provider:       &noopWorkflowProvider{},
+		runtimeSession: staleRuntimeSessionForTest(),
+	}
+	pool.workers = []*hostedWorkflowWorker{worker}
+	pool.mu.Lock()
+	available := pool.workerAvailableLocked(worker, time.Now().UTC())
+	reason := pool.runtimeSessionRetirementReason(worker.runtimeSession, nil, time.Now().UTC())
+	pool.mu.Unlock()
+	if available {
+		t.Fatalf("workerAvailableLocked = true, want false for stale runtime session")
+	}
+	if !strings.Contains(reason, "image mismatch") {
+		t.Fatalf("retirement reason = %q, want image mismatch", reason)
+	}
+}
+
+func staleRuntimeSessionForTest() *pluginruntime.Session {
+	return &pluginruntime.Session{Metadata: map[string]string{
+		hostedRuntimeMetadataTemplate:     "agent-runtime",
+		hostedRuntimeMetadataCurrentImage: "runtime@sha256:current",
+		hostedRuntimeMetadataActualImage:  "runtime@sha256:old",
+		hostedRuntimeMetadataImageMatch:   "false",
+	}}
+}
+
+type noopWorkflowProvider struct{}
+
+func (p *noopWorkflowProvider) StartRun(context.Context, coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) GetRun(context.Context, coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) ListRuns(context.Context, coreworkflow.ListRunsRequest) ([]*coreworkflow.Run, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) CancelRun(context.Context, coreworkflow.CancelRunRequest) (*coreworkflow.Run, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) SignalRun(context.Context, coreworkflow.SignalRunRequest) (*coreworkflow.SignalRunResponse, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) SignalOrStartRun(context.Context, coreworkflow.SignalOrStartRunRequest) (*coreworkflow.SignalRunResponse, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) UpsertSchedule(context.Context, coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) GetSchedule(context.Context, coreworkflow.GetScheduleRequest) (*coreworkflow.Schedule, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) ListSchedules(context.Context, coreworkflow.ListSchedulesRequest) ([]*coreworkflow.Schedule, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) DeleteSchedule(context.Context, coreworkflow.DeleteScheduleRequest) error {
+	return nil
+}
+func (p *noopWorkflowProvider) PauseSchedule(context.Context, coreworkflow.PauseScheduleRequest) (*coreworkflow.Schedule, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) ResumeSchedule(context.Context, coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) UpsertEventTrigger(context.Context, coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) GetEventTrigger(context.Context, coreworkflow.GetEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) ListEventTriggers(context.Context, coreworkflow.ListEventTriggersRequest) ([]*coreworkflow.EventTrigger, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) DeleteEventTrigger(context.Context, coreworkflow.DeleteEventTriggerRequest) error {
+	return nil
+}
+func (p *noopWorkflowProvider) PauseEventTrigger(context.Context, coreworkflow.PauseEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) ResumeEventTrigger(context.Context, coreworkflow.ResumeEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return nil, nil
+}
+func (p *noopWorkflowProvider) PublishEvent(context.Context, coreworkflow.PublishEventRequest) error {
+	return nil
+}
+func (p *noopWorkflowProvider) Ping(context.Context) error { return nil }
+func (p *noopWorkflowProvider) Close() error               { return nil }

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider.go
@@ -383,6 +383,12 @@ func (p *hostedWorkflowProviderPool) Start(ctx context.Context) error {
 			defer p.wg.Done()
 			p.healthLoop()
 		}()
+	} else {
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			p.runtimeSessionLoop()
+		}()
 	}
 	return nil
 }
@@ -656,6 +662,35 @@ func (p *hostedWorkflowProviderPool) healthLoop() {
 	}
 }
 
+func (p *hostedWorkflowProviderPool) runtimeSessionLoop() {
+	interval := p.policy.HealthCheckInterval
+	if interval <= 0 {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		_ = p.ensureMinReady(p.ctx)
+		for _, worker := range p.runtimeManagedWorkers() {
+			session, drainAt, err := p.refreshWorkerRuntimeSession(worker)
+			if err != nil {
+				slog.Warn("hosted workflow runtime session refresh failed", "provider", p.name, "worker", worker.id, "error", err)
+				p.replaceWorkerAllowNever(worker, err.Error(), true)
+				continue
+			}
+			if reason := p.runtimeSessionRetirementReason(session, drainAt, time.Now().UTC()); reason != "" {
+				slog.Info("retiring hosted workflow runtime worker", "provider", p.name, "worker", worker.id, "reason", reason)
+				p.replaceWorkerAllowNever(worker, reason, true)
+			}
+		}
+	}
+}
+
 func (p *hostedWorkflowProviderPool) readyWorkers() []*hostedWorkflowWorker {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -669,8 +704,23 @@ func (p *hostedWorkflowProviderPool) readyWorkers() []*hostedWorkflowWorker {
 	return out
 }
 
+func (p *hostedWorkflowProviderPool) runtimeManagedWorkers() []*hostedWorkflowWorker {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*hostedWorkflowWorker, 0, len(p.workers))
+	for _, worker := range p.workers {
+		if worker != nil && worker.provider != nil && !worker.closed && !worker.closing {
+			out = append(out, worker)
+		}
+	}
+	return out
+}
+
 func (p *hostedWorkflowProviderPool) workerAvailableLocked(worker *hostedWorkflowWorker, now time.Time) bool {
 	if worker == nil || worker.provider == nil || worker.closed || worker.closing || worker.draining {
+		return false
+	}
+	if hostedRuntimeSessionCompatibilityReason(worker.runtimeSession) != "" {
 		return false
 	}
 	if worker.forceCloseAt != nil && !now.Before(*worker.forceCloseAt) {
@@ -739,17 +789,21 @@ func (p *hostedWorkflowProviderPool) refreshWorkerRuntimeSession(worker *hostedW
 }
 
 func (p *hostedWorkflowProviderPool) replaceWorker(worker *hostedWorkflowWorker) {
-	if p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever || !p.markWorkerDraining(worker) {
+	p.replaceWorkerAllowNever(worker, "", false)
+}
+
+func (p *hostedWorkflowProviderPool) replaceWorkerAllowNever(worker *hostedWorkflowWorker, reason string, allowRestartPolicyNever bool) {
+	if (p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever && !allowRestartPolicyNever) || !p.markWorkerDraining(worker) {
 		return
 	}
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
 		if err := p.ensureMinReady(p.ctx); err != nil && !errors.Is(err, context.Canceled) {
-			slog.Warn("failed to replace hosted workflow runtime worker", "provider", p.name, "worker", worker.id, "error", err)
+			slog.Warn("failed to replace hosted workflow runtime worker", "provider", p.name, "worker", worker.id, "reason", reason, "error", err)
 		}
 		if err := p.drainAndCloseWorker(worker); err != nil {
-			slog.Warn("failed to close hosted workflow runtime worker", "provider", p.name, "worker", worker.id, "error", err)
+			slog.Warn("failed to close hosted workflow runtime worker", "provider", p.name, "worker", worker.id, "reason", reason, "error", err)
 		}
 	}()
 }
@@ -857,6 +911,9 @@ func (p *hostedWorkflowProviderPool) runtimeSessionRetirementReason(session *plu
 	switch session.State {
 	case pluginruntime.SessionStateFailed, pluginruntime.SessionStateStopped:
 		return fmt.Sprintf("runtime session entered %q state", session.State)
+	}
+	if reason := hostedRuntimeSessionCompatibilityReason(session); reason != "" {
+		return reason
 	}
 	if drainAt == nil || now.Before(*drainAt) {
 		return ""


### PR DESCRIPTION
## Summary
- Treat runtime image mismatch metadata as a hosted runtime retirement signal.
- Refresh `restartPolicy: never` agent backends before new work and replace stale/draining sessions safely.
- Add a limited workflow runtime-session loop so hosted workers with `restartPolicy: never` can drain stale sandboxes without broad health restarts.

## Test plan
- [x] `go test ./internal/bootstrap` from `gestaltd`

Made with [Cursor](https://cursor.com)