### PR TITLE
Preserve workflow agent deadlines for turn RPCs

### DIFF
--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -21,6 +21,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowprincipal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -349,6 +350,7 @@ func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.Invo
 	timeout := workflowAgentTimeout(agentTarget.TimeoutSeconds)
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
+	runCtx = runtimehost.WithWorkflowAgentProviderDeadline(runCtx)
 
 	metadata := maps.Clone(agentTarget.Metadata)
 	if metadata == nil {

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -179,11 +179,16 @@ func workflowSignalsFromTestContext(value any) []map[string]any {
 
 type workflowRuntimeAgentManagerStub struct {
 	agentmanager.Service
-	createSessionRequests  []coreagent.ManagerCreateSessionRequest
-	createSessionDeadlines []time.Duration
-	createTurnRequests     []coreagent.ManagerCreateTurnRequest
-	cancelTurnIDs          []string
-	returnNilTurn          bool
+	createSessionRequests           []coreagent.ManagerCreateSessionRequest
+	createSessionDeadlines          []time.Duration
+	createTurnRequests              []coreagent.ManagerCreateTurnRequest
+	createTurnDeadlines             []time.Duration
+	createTurnProviderCallDeadlines []time.Duration
+	getTurnDeadlines                []time.Duration
+	getTurnProviderCallDeadlines    []time.Duration
+	cancelTurnIDs                   []string
+	returnNilTurn                   bool
+	completeTurnViaGet              bool
 }
 
 func (m *workflowRuntimeAgentManagerStub) CreateSession(ctx context.Context, _ *principal.Principal, req coreagent.ManagerCreateSessionRequest) (*coreagent.Session, error) {
@@ -201,24 +206,53 @@ func (m *workflowRuntimeAgentManagerStub) CreateSession(ctx context.Context, _ *
 	}, nil
 }
 
-func (m *workflowRuntimeAgentManagerStub) CreateTurn(_ context.Context, _ *principal.Principal, req coreagent.ManagerCreateTurnRequest) (*coreagent.Turn, error) {
+func (m *workflowRuntimeAgentManagerStub) CreateTurn(ctx context.Context, _ *principal.Principal, req coreagent.ManagerCreateTurnRequest) (*coreagent.Turn, error) {
 	m.createTurnRequests = append(m.createTurnRequests, req)
+	m.createTurnDeadlines = append(m.createTurnDeadlines, remainingDeadline(ctx))
+	callCtx, cancel := runtimehost.ProviderWorkflowAgentCallContext(ctx)
+	m.createTurnProviderCallDeadlines = append(m.createTurnProviderCallDeadlines, remainingDeadline(callCtx))
+	cancel()
 	if m.returnNilTurn {
 		return nil, nil
+	}
+	status := coreagent.ExecutionStatusSucceeded
+	outputText := "turn completed"
+	if m.completeTurnViaGet {
+		status = coreagent.ExecutionStatusRunning
+		outputText = ""
 	}
 	return &coreagent.Turn{
 		ID:           "turn-1",
 		SessionID:    req.SessionID,
 		ProviderName: "managed",
 		Model:        req.Model,
-		Status:       coreagent.ExecutionStatusSucceeded,
-		OutputText:   "turn completed",
+		Status:       status,
+		OutputText:   outputText,
+	}, nil
+}
+
+func (m *workflowRuntimeAgentManagerStub) GetTurn(ctx context.Context, _ *principal.Principal, turnID string) (*coreagent.Turn, error) {
+	m.getTurnDeadlines = append(m.getTurnDeadlines, remainingDeadline(ctx))
+	callCtx, cancel := runtimehost.ProviderWorkflowAgentCallContext(ctx)
+	m.getTurnProviderCallDeadlines = append(m.getTurnProviderCallDeadlines, remainingDeadline(callCtx))
+	cancel()
+	return &coreagent.Turn{
+		ID:         turnID,
+		Status:     coreagent.ExecutionStatusSucceeded,
+		OutputText: "turn completed",
 	}, nil
 }
 
 func (m *workflowRuntimeAgentManagerStub) CancelTurn(_ context.Context, _ *principal.Principal, turnID, _ string) (*coreagent.Turn, error) {
 	m.cancelTurnIDs = append(m.cancelTurnIDs, turnID)
 	return &coreagent.Turn{ID: turnID, Status: coreagent.ExecutionStatusCanceled}, nil
+}
+
+func remainingDeadline(ctx context.Context) time.Duration {
+	if deadline, ok := ctx.Deadline(); ok {
+		return time.Until(deadline)
+	}
+	return 0
 }
 
 type workflowRoundTripProvider struct {
@@ -633,10 +667,10 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 	}
 }
 
-func TestWorkflowRuntimeInvokeAgentTargetPassesWorkflowDeadlineToCreateSession(t *testing.T) {
+func TestWorkflowRuntimeInvokeAgentTargetMarksProviderCallsWithWorkflowDeadline(t *testing.T) {
 	t.Parallel()
 
-	agentManager := &workflowRuntimeAgentManagerStub{}
+	agentManager := &workflowRuntimeAgentManagerStub{completeTurnViaGet: true}
 	runtime := &workflowRuntime{}
 	runtime.SetAgentManager(agentManager)
 	p := principal.Canonicalize(&principal.Principal{
@@ -667,6 +701,24 @@ func TestWorkflowRuntimeInvokeAgentTargetPassesWorkflowDeadlineToCreateSession(t
 	}
 	if got := agentManager.createSessionDeadlines[0]; got > workflowAgentTimeout(0) {
 		t.Fatalf("CreateSession remaining deadline = %s, want at most workflow timeout %s", got, workflowAgentTimeout(0))
+	}
+	if len(agentManager.createTurnDeadlines) != 1 {
+		t.Fatalf("create turn deadlines = %#v, want one", agentManager.createTurnDeadlines)
+	}
+	if got := agentManager.createTurnDeadlines[0]; got <= runtimehost.ProviderRPCTimeout {
+		t.Fatalf("CreateTurn remaining deadline = %s, want workflow deadline above provider RPC timeout %s", got, runtimehost.ProviderRPCTimeout)
+	}
+	if got := agentManager.createTurnProviderCallDeadlines[0]; got <= runtimehost.ProviderRPCTimeout {
+		t.Fatalf("CreateTurn provider call deadline = %s, want workflow deadline above provider RPC timeout %s", got, runtimehost.ProviderRPCTimeout)
+	}
+	if len(agentManager.getTurnDeadlines) != 1 {
+		t.Fatalf("get turn deadlines = %#v, want one", agentManager.getTurnDeadlines)
+	}
+	if got := agentManager.getTurnDeadlines[0]; got <= runtimehost.ProviderRPCTimeout {
+		t.Fatalf("GetTurn remaining deadline = %s, want workflow deadline above provider RPC timeout %s", got, runtimehost.ProviderRPCTimeout)
+	}
+	if got := agentManager.getTurnProviderCallDeadlines[0]; got <= runtimehost.ProviderRPCTimeout {
+		t.Fatalf("GetTurn provider call deadline = %s, want workflow deadline above provider RPC timeout %s", got, runtimehost.ProviderRPCTimeout)
 	}
 }
 

--- a/gestaltd/services/agents/client.go
+++ b/gestaltd/services/agents/client.go
@@ -166,7 +166,7 @@ func (r *remoteAgent) UpdateSession(ctx context.Context, req coreagent.UpdateSes
 }
 
 func (r *remoteAgent) CreateTurn(ctx context.Context, req coreagent.CreateTurnRequest) (*coreagent.Turn, error) {
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	ctx, cancel := runtimehost.ProviderWorkflowAgentCallContext(ctx)
 	defer cancel()
 	messages, err := agentMessagesToProto(req.Messages)
 	if err != nil {
@@ -212,7 +212,7 @@ func (r *remoteAgent) CreateTurn(ctx context.Context, req coreagent.CreateTurnRe
 }
 
 func (r *remoteAgent) GetTurn(ctx context.Context, req coreagent.GetTurnRequest) (*coreagent.Turn, error) {
-	ctx, cancel := runtimehost.ProviderCallContext(ctx)
+	ctx, cancel := runtimehost.ProviderWorkflowAgentCallContext(ctx)
 	defer cancel()
 	resp, err := r.client.GetTurn(ctx, &proto.GetAgentProviderTurnRequest{
 		TurnId:  req.TurnID,

--- a/gestaltd/services/agents/client_test.go
+++ b/gestaltd/services/agents/client_test.go
@@ -17,6 +17,9 @@ import (
 
 type fakeAgentProviderClient struct {
 	createSession   func(context.Context, *proto.CreateAgentProviderSessionRequest, ...grpc.CallOption) (*proto.AgentSession, error)
+	getSession      func(context.Context, *proto.GetAgentProviderSessionRequest, ...grpc.CallOption) (*proto.AgentSession, error)
+	createTurn      func(context.Context, *proto.CreateAgentProviderTurnRequest, ...grpc.CallOption) (*proto.AgentTurn, error)
+	getTurn         func(context.Context, *proto.GetAgentProviderTurnRequest, ...grpc.CallOption) (*proto.AgentTurn, error)
 	getCapabilities func(context.Context, *proto.GetAgentProviderCapabilitiesRequest, ...grpc.CallOption) (*proto.AgentProviderCapabilities, error)
 	listSessions    func(context.Context, *proto.ListAgentProviderSessionsRequest, ...grpc.CallOption) (*proto.ListAgentProviderSessionsResponse, error)
 	listTurns       func(context.Context, *proto.ListAgentProviderTurnsRequest, ...grpc.CallOption) (*proto.ListAgentProviderTurnsResponse, error)
@@ -30,7 +33,10 @@ func (c *fakeAgentProviderClient) CreateSession(ctx context.Context, req *proto.
 	return nil, errors.New("unexpected CreateSession call")
 }
 
-func (c *fakeAgentProviderClient) GetSession(context.Context, *proto.GetAgentProviderSessionRequest, ...grpc.CallOption) (*proto.AgentSession, error) {
+func (c *fakeAgentProviderClient) GetSession(ctx context.Context, req *proto.GetAgentProviderSessionRequest, opts ...grpc.CallOption) (*proto.AgentSession, error) {
+	if c.getSession != nil {
+		return c.getSession(ctx, req, opts...)
+	}
 	return nil, errors.New("unexpected GetSession call")
 }
 
@@ -45,11 +51,17 @@ func (c *fakeAgentProviderClient) UpdateSession(context.Context, *proto.UpdateAg
 	return nil, errors.New("unexpected UpdateSession call")
 }
 
-func (c *fakeAgentProviderClient) CreateTurn(context.Context, *proto.CreateAgentProviderTurnRequest, ...grpc.CallOption) (*proto.AgentTurn, error) {
+func (c *fakeAgentProviderClient) CreateTurn(ctx context.Context, req *proto.CreateAgentProviderTurnRequest, opts ...grpc.CallOption) (*proto.AgentTurn, error) {
+	if c.createTurn != nil {
+		return c.createTurn(ctx, req, opts...)
+	}
 	return nil, errors.New("unexpected CreateTurn call")
 }
 
-func (c *fakeAgentProviderClient) GetTurn(context.Context, *proto.GetAgentProviderTurnRequest, ...grpc.CallOption) (*proto.AgentTurn, error) {
+func (c *fakeAgentProviderClient) GetTurn(ctx context.Context, req *proto.GetAgentProviderTurnRequest, opts ...grpc.CallOption) (*proto.AgentTurn, error) {
+	if c.getTurn != nil {
+		return c.getTurn(ctx, req, opts...)
+	}
 	return nil, errors.New("unexpected GetTurn call")
 }
 
@@ -172,6 +184,121 @@ func TestRemoteAgentCreateSessionPreservesWorkflowDeadline(t *testing.T) {
 	}
 	if createSessionRemaining > 2*runtimehost.ProviderRPCTimeout {
 		t.Fatalf("CreateSession remaining deadline = %s, want at most parent deadline %s", createSessionRemaining, 2*runtimehost.ProviderRPCTimeout)
+	}
+}
+
+func TestRemoteAgentWorkflowAgentTurnCallsPreserveMarkedDeadline(t *testing.T) {
+	t.Parallel()
+
+	parentDeadline := time.Now().Add(2 * runtimehost.ProviderSessionCreateTimeout)
+	var createTurnRemaining time.Duration
+	var getTurnRemaining time.Duration
+	agent := &remoteAgent{
+		client: &fakeAgentProviderClient{
+			createTurn: func(ctx context.Context, req *proto.CreateAgentProviderTurnRequest, _ ...grpc.CallOption) (*proto.AgentTurn, error) {
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatal("CreateTurn context has no deadline")
+				}
+				createTurnRemaining = time.Until(deadline)
+				return &proto.AgentTurn{
+					Id:        "turn-1",
+					SessionId: req.GetSessionId(),
+					Status:    proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_RUNNING,
+				}, nil
+			},
+			getTurn: func(ctx context.Context, req *proto.GetAgentProviderTurnRequest, _ ...grpc.CallOption) (*proto.AgentTurn, error) {
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatal("GetTurn context has no deadline")
+				}
+				getTurnRemaining = time.Until(deadline)
+				return &proto.AgentTurn{
+					Id:     req.GetTurnId(),
+					Status: proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_RUNNING,
+				}, nil
+			},
+		},
+	}
+	parent, cancel := context.WithDeadline(context.Background(), parentDeadline)
+	defer cancel()
+	ctx := runtimehost.WithWorkflowAgentProviderDeadline(parent)
+
+	if _, err := agent.CreateTurn(ctx, coreagent.CreateTurnRequest{SessionID: "session-1"}); err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := agent.GetTurn(ctx, coreagent.GetTurnRequest{TurnID: "turn-1"}); err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	for name, remaining := range map[string]time.Duration{
+		"CreateTurn": createTurnRemaining,
+		"GetTurn":    getTurnRemaining,
+	} {
+		if remaining <= runtimehost.ProviderRPCTimeout {
+			t.Fatalf("%s remaining deadline = %s, want above provider RPC timeout %s", name, remaining, runtimehost.ProviderRPCTimeout)
+		}
+		if remaining > 2*runtimehost.ProviderSessionCreateTimeout {
+			t.Fatalf("%s remaining deadline = %s, want at most parent deadline %s", name, remaining, 2*runtimehost.ProviderSessionCreateTimeout)
+		}
+	}
+}
+
+func TestRemoteAgentTurnCallsKeepProviderTimeoutWithoutWorkflowMarker(t *testing.T) {
+	t.Parallel()
+
+	parentDeadline := time.Now().Add(2 * runtimehost.ProviderSessionCreateTimeout)
+	var createTurnRemaining time.Duration
+	var getTurnRemaining time.Duration
+	var getSessionRemaining time.Duration
+	agent := &remoteAgent{
+		client: &fakeAgentProviderClient{
+			createTurn: func(ctx context.Context, req *proto.CreateAgentProviderTurnRequest, _ ...grpc.CallOption) (*proto.AgentTurn, error) {
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatal("CreateTurn context has no deadline")
+				}
+				createTurnRemaining = time.Until(deadline)
+				return &proto.AgentTurn{Id: "turn-1", SessionId: req.GetSessionId()}, nil
+			},
+			getTurn: func(ctx context.Context, req *proto.GetAgentProviderTurnRequest, _ ...grpc.CallOption) (*proto.AgentTurn, error) {
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatal("GetTurn context has no deadline")
+				}
+				getTurnRemaining = time.Until(deadline)
+				return &proto.AgentTurn{Id: req.GetTurnId()}, nil
+			},
+			getSession: func(ctx context.Context, req *proto.GetAgentProviderSessionRequest, _ ...grpc.CallOption) (*proto.AgentSession, error) {
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatal("GetSession context has no deadline")
+				}
+				getSessionRemaining = time.Until(deadline)
+				return &proto.AgentSession{Id: req.GetSessionId(), ProviderName: "claude"}, nil
+			},
+		},
+	}
+	parent, cancel := context.WithDeadline(context.Background(), parentDeadline)
+	defer cancel()
+
+	if _, err := agent.CreateTurn(parent, coreagent.CreateTurnRequest{SessionID: "session-1"}); err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := agent.GetTurn(parent, coreagent.GetTurnRequest{TurnID: "turn-1"}); err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	marked := runtimehost.WithWorkflowAgentProviderDeadline(parent)
+	if _, err := agent.GetSession(marked, coreagent.GetSessionRequest{SessionID: "session-1"}); err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	for name, remaining := range map[string]time.Duration{
+		"CreateTurn": createTurnRemaining,
+		"GetTurn":    getTurnRemaining,
+		"GetSession": getSessionRemaining,
+	} {
+		if remaining > runtimehost.ProviderRPCTimeout {
+			t.Fatalf("%s remaining deadline = %s, want at most provider RPC timeout %s", name, remaining, runtimehost.ProviderRPCTimeout)
+		}
 	}
 }
 

--- a/gestaltd/services/runtimehost/runtime_client.go
+++ b/gestaltd/services/runtimehost/runtime_client.go
@@ -25,6 +25,8 @@ const (
 	providerStartTimeout         = 2 * time.Minute
 )
 
+type workflowAgentProviderDeadlineKey struct{}
+
 var providerConfigureTimeout = 30 * time.Second
 
 type RuntimeProviderMetadata struct {
@@ -156,6 +158,30 @@ func ProviderCallContext(parent context.Context) (context.Context, context.Cance
 		parent = context.Background()
 	}
 	return context.WithTimeout(parent, ProviderRPCTimeout)
+}
+
+// WithWorkflowAgentProviderDeadline marks provider RPCs that are part of a
+// workflow-owned agent run. Only workflow agent call helpers should observe it.
+func WithWorkflowAgentProviderDeadline(parent context.Context) context.Context {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithValue(parent, workflowAgentProviderDeadlineKey{}, true)
+}
+
+// ProviderWorkflowAgentCallContext returns a context for workflow-owned agent
+// turn RPCs. It preserves the workflow run deadline only when explicitly marked;
+// otherwise it keeps the normal provider RPC timeout.
+func ProviderWorkflowAgentCallContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if marked, _ := parent.Value(workflowAgentProviderDeadlineKey{}).(bool); marked {
+		if _, ok := parent.Deadline(); ok {
+			return context.WithCancel(parent)
+		}
+	}
+	return ProviderCallContext(parent)
 }
 
 // ProviderSessionCreateContext returns a child context for agent CreateSession RPCs.

--- a/gestaltd/services/runtimehost/runtime_client_test.go
+++ b/gestaltd/services/runtimehost/runtime_client_test.go
@@ -247,6 +247,58 @@ func TestProviderSessionCreateContextPreservesShortParentDeadline(t *testing.T) 
 	}
 }
 
+func TestProviderWorkflowAgentCallContextRequiresMarkerForParentDeadline(t *testing.T) {
+	t.Parallel()
+
+	parentDeadline := time.Now().Add(2 * ProviderSessionCreateTimeout)
+	parent, parentCancel := context.WithDeadline(context.Background(), parentDeadline)
+	defer parentCancel()
+
+	unmarked, unmarkedCancel := ProviderWorkflowAgentCallContext(parent)
+	defer unmarkedCancel()
+	unmarkedDeadline, ok := unmarked.Deadline()
+	if !ok {
+		t.Fatal("unmarked workflow agent context has no deadline")
+	}
+	if unmarkedDeadline.Equal(parentDeadline) {
+		t.Fatal("unmarked workflow agent context preserved parent deadline")
+	}
+	if remaining := time.Until(unmarkedDeadline); remaining > ProviderRPCTimeout {
+		t.Fatalf("unmarked remaining deadline = %s, want at most provider RPC timeout %s", remaining, ProviderRPCTimeout)
+	}
+
+	markedParent := WithWorkflowAgentProviderDeadline(parent)
+	marked, markedCancel := ProviderWorkflowAgentCallContext(markedParent)
+	defer markedCancel()
+	markedDeadline, ok := marked.Deadline()
+	if !ok {
+		t.Fatal("marked workflow agent context has no deadline")
+	}
+	if !markedDeadline.Equal(parentDeadline) {
+		t.Fatalf("marked deadline = %s, want parent deadline %s", markedDeadline, parentDeadline)
+	}
+	parentCancel()
+	select {
+	case <-marked.Done():
+	case <-time.After(time.Second):
+		t.Fatal("marked workflow agent context did not observe parent cancellation")
+	}
+}
+
+func TestProviderWorkflowAgentCallContextFallsBackWithoutParentDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := ProviderWorkflowAgentCallContext(WithWorkflowAgentProviderDeadline(context.Background()))
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("workflow agent context has no deadline")
+	}
+	if remaining := time.Until(deadline); remaining > ProviderRPCTimeout {
+		t.Fatalf("remaining deadline = %s, want at most provider RPC timeout %s", remaining, ProviderRPCTimeout)
+	}
+}
+
 func TestStartRuntimeProviderValidatesProtocolVersion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Mark workflow-owned agent runs so turn creation and polling can preserve the workflow agent budget.
- Keep the generic provider RPC timeout for unmarked calls and non-turn agent APIs.
- Add contract coverage for runtimehost helper semantics, remote agent turn RPC deadlines, and workflow runtime marker propagation.

## Interface Changes
- New/changed interface: internal `runtimehost.WithWorkflowAgentProviderDeadline(ctx)` and `runtimehost.ProviderWorkflowAgentCallContext(ctx)` helpers.
- Example usage: workflow runtime wraps the agent run context before invoking `CreateTurn`/`GetTurn`, allowing a `BoundWorkflowAgentTarget.timeout_seconds: 1800` run to keep that parent deadline for turn RPCs.

## Functional/Integration Tests
- Tests added or augmented: runtimehost provider context contract tests, remote agent provider RPC deadline contract tests, workflow runtime agent deadline marker test.
- Contract boundary covered: workflow-owned agent deadline marking and remote agent provider RPC context selection.
- Commands run: `go test ./services/runtimehost ./services/agents ./internal/bootstrap` from `gestaltd/`.