### PR TITLE
Break hosted workflow pool startup cycle

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1784,7 +1784,26 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 	}
 	var provider coreworkflow.Provider
 	if entry.UsesHostedExecution() {
-		provider, err = buildHostedWorkflowProvider(ctx, name, entry, node, hostServices, deps)
+		var bootstrapProvider coreworkflow.Provider
+		runtimeCfg := entry.HostedRuntimeConfig()
+		if runtimeCfg != nil && runtimeCfg.LifecyclePolicyFieldsSet() {
+			if factories.Workflow == nil {
+				return nil, fmt.Errorf("workflow factory is not registered")
+			}
+			bootstrapProvider, err = factories.Workflow(ctx, name, node, hostServices, deps)
+			if err != nil {
+				return nil, fmt.Errorf("workflow provider bootstrap control: %w", err)
+			}
+			defer func() {
+				if bootstrapProvider != nil {
+					_ = bootstrapProvider.Close()
+				}
+			}()
+		}
+		provider, err = buildHostedWorkflowProvider(ctx, name, entry, node, hostServices, deps, bootstrapProvider)
+		if err == nil {
+			bootstrapProvider = nil
+		}
 	} else {
 		if factories.Workflow == nil {
 			return nil, fmt.Errorf("workflow factory is not registered")

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider.go
@@ -40,7 +40,7 @@ type hostedWorkflowProviderInstance struct {
 	runtimeSession   *pluginruntime.Session
 }
 
-func buildHostedWorkflowProvider(ctx context.Context, name string, entry *config.ProviderEntry, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (coreworkflow.Provider, error) {
+func buildHostedWorkflowProvider(ctx context.Context, name string, entry *config.ProviderEntry, node yaml.Node, hostServices []runtimehost.HostService, deps Deps, bootstrapProvider coreworkflow.Provider) (coreworkflow.Provider, error) {
 	launch, err := prepareHostedWorkflowProviderLaunch(ctx, name, entry, node, deps)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func buildHostedWorkflowProvider(ctx context.Context, name string, entry *config
 			launch.close()
 			return nil, fmt.Errorf("parse hosted workflow runtime lifecycle policy: %w", err)
 		}
-		return newHostedWorkflowProviderPool(ctx, launch, hostServices, deps, policy)
+		return newHostedWorkflowProviderPool(launch, hostServices, deps, policy, bootstrapProvider)
 	}
 	cleanup := launch.cleanup
 	launch.cleanup = nil
@@ -291,27 +291,23 @@ func hostedWorkflowAllowedHosts(configured []string, runtimePlan HostedRuntimePl
 }
 
 type hostedWorkflowProviderPool struct {
-	coreworkflow.Provider
-
-	executionRefs coreworkflow.ExecutionReferenceStore
-
-	name         string
-	launch       *hostedWorkflowProviderLaunch
-	hostServices []runtimehost.HostService
-	deps         Deps
-	policy       config.HostedRuntimeLifecyclePolicy
+	name              string
+	launch            *hostedWorkflowProviderLaunch
+	hostServices      []runtimehost.HostService
+	deps              Deps
+	policy            config.HostedRuntimeLifecyclePolicy
+	bootstrapProvider coreworkflow.Provider
 
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
-	mu             sync.Mutex
-	nextID         int
-	starting       int
-	started        bool
-	controlStarted bool
-	closed         bool
-	workers        []*hostedWorkflowWorker
+	mu       sync.Mutex
+	nextID   int
+	starting int
+	started  bool
+	closed   bool
+	workers  []*hostedWorkflowWorker
 }
 
 type hostedWorkflowWorker struct {
@@ -329,27 +325,20 @@ type hostedWorkflowWorker struct {
 	closed           bool
 }
 
-func newHostedWorkflowProviderPool(ctx context.Context, launch *hostedWorkflowProviderLaunch, hostServices []runtimehost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy) (coreworkflow.Provider, error) {
+func newHostedWorkflowProviderPool(launch *hostedWorkflowProviderLaunch, hostServices []runtimehost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy, bootstrapProvider coreworkflow.Provider) (coreworkflow.Provider, error) {
 	if launch == nil {
 		return nil, fmt.Errorf("hosted workflow launch is required")
 	}
-	control, err := startHostedWorkflowProviderInstance(ctx, launch, hostServices, deps, false, nil, 0)
-	if err != nil {
-		launch.close()
-		return nil, err
-	}
-	executionRefs, _ := control.provider.(coreworkflow.ExecutionReferenceStore)
 	poolCtx, cancel := context.WithCancel(context.Background())
 	return &hostedWorkflowProviderPool{
-		Provider:      control.provider,
-		executionRefs: executionRefs,
-		name:          launch.name,
-		launch:        launch,
-		hostServices:  append([]runtimehost.HostService(nil), hostServices...),
-		deps:          deps,
-		policy:        policy,
-		ctx:           poolCtx,
-		cancel:        cancel,
+		name:              launch.name,
+		launch:            launch,
+		hostServices:      append([]runtimehost.HostService(nil), hostServices...),
+		deps:              deps,
+		policy:            policy,
+		bootstrapProvider: bootstrapProvider,
+		ctx:               poolCtx,
+		cancel:            cancel,
 	}, nil
 }
 
@@ -369,11 +358,7 @@ func (p *hostedWorkflowProviderPool) Start(ctx context.Context) error {
 	p.started = true
 	p.mu.Unlock()
 
-	if err := p.startControl(ctx); err != nil {
-		p.markStartFailed()
-		return err
-	}
-	if err := p.ensureMinReady(ctx); err != nil {
+	if err := p.closeBootstrapProvider(); err != nil {
 		p.markStartFailed()
 		return err
 	}
@@ -381,43 +366,33 @@ func (p *hostedWorkflowProviderPool) Start(ctx context.Context) error {
 		p.wg.Add(1)
 		go func() {
 			defer p.wg.Done()
+			if err := p.ensureMinReady(p.ctx); err != nil && !errors.Is(err, context.Canceled) {
+				slog.Warn("failed to start hosted workflow runtime workers", "provider", p.name, "error", err)
+			}
 			p.healthLoop()
 		}()
 	} else {
 		p.wg.Add(1)
 		go func() {
 			defer p.wg.Done()
+			if err := p.ensureMinReady(p.ctx); err != nil && !errors.Is(err, context.Canceled) {
+				slog.Warn("failed to start hosted workflow runtime workers", "provider", p.name, "error", err)
+			}
 			p.runtimeSessionLoop()
 		}()
 	}
 	return nil
 }
 
-func (p *hostedWorkflowProviderPool) startControl(ctx context.Context) error {
+func (p *hostedWorkflowProviderPool) closeBootstrapProvider() error {
 	p.mu.Lock()
-	if p.controlStarted {
-		p.mu.Unlock()
+	provider := p.bootstrapProvider
+	p.bootstrapProvider = nil
+	p.mu.Unlock()
+	if provider == nil {
 		return nil
 	}
-	provider := p.Provider
-	p.mu.Unlock()
-
-	if provider == nil {
-		return fmt.Errorf("hosted workflow provider %q has no control provider", p.name)
-	}
-	if starter, ok := provider.(startableWorkflowProvider); ok {
-		if err := starter.Start(ctx); err != nil {
-			return fmt.Errorf("start hosted workflow control provider: %w", err)
-		}
-	}
-
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.closed {
-		return fmt.Errorf("hosted workflow provider %q is closed", p.name)
-	}
-	p.controlStarted = true
-	return nil
+	return provider.Close()
 }
 
 func (p *hostedWorkflowProviderPool) markStartFailed() {
@@ -428,14 +403,132 @@ func (p *hostedWorkflowProviderPool) markStartFailed() {
 	}
 }
 
+func (p *hostedWorkflowProviderPool) StartRun(ctx context.Context, req coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
+	return withHostedWorkflowProvider(p, "start run", func(provider coreworkflow.Provider) (*coreworkflow.Run, error) {
+		return provider.StartRun(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) GetRun(ctx context.Context, req coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
+	return withHostedWorkflowProvider(p, "get run", func(provider coreworkflow.Provider) (*coreworkflow.Run, error) {
+		return provider.GetRun(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) ListRuns(ctx context.Context, req coreworkflow.ListRunsRequest) ([]*coreworkflow.Run, error) {
+	return withHostedWorkflowProvider(p, "list runs", func(provider coreworkflow.Provider) ([]*coreworkflow.Run, error) {
+		return provider.ListRuns(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) CancelRun(ctx context.Context, req coreworkflow.CancelRunRequest) (*coreworkflow.Run, error) {
+	return withHostedWorkflowProvider(p, "cancel run", func(provider coreworkflow.Provider) (*coreworkflow.Run, error) {
+		return provider.CancelRun(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) SignalRun(ctx context.Context, req coreworkflow.SignalRunRequest) (*coreworkflow.SignalRunResponse, error) {
+	return withHostedWorkflowProvider(p, "signal run", func(provider coreworkflow.Provider) (*coreworkflow.SignalRunResponse, error) {
+		return provider.SignalRun(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) SignalOrStartRun(ctx context.Context, req coreworkflow.SignalOrStartRunRequest) (*coreworkflow.SignalRunResponse, error) {
+	return withHostedWorkflowProvider(p, "signal or start run", func(provider coreworkflow.Provider) (*coreworkflow.SignalRunResponse, error) {
+		return provider.SignalOrStartRun(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) UpsertSchedule(ctx context.Context, req coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
+	return withHostedWorkflowProvider(p, "upsert schedule", func(provider coreworkflow.Provider) (*coreworkflow.Schedule, error) {
+		return provider.UpsertSchedule(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) GetSchedule(ctx context.Context, req coreworkflow.GetScheduleRequest) (*coreworkflow.Schedule, error) {
+	return withHostedWorkflowProvider(p, "get schedule", func(provider coreworkflow.Provider) (*coreworkflow.Schedule, error) {
+		return provider.GetSchedule(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) ListSchedules(ctx context.Context, req coreworkflow.ListSchedulesRequest) ([]*coreworkflow.Schedule, error) {
+	return withHostedWorkflowProvider(p, "list schedules", func(provider coreworkflow.Provider) ([]*coreworkflow.Schedule, error) {
+		return provider.ListSchedules(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) DeleteSchedule(ctx context.Context, req coreworkflow.DeleteScheduleRequest) error {
+	_, err := withHostedWorkflowProvider(p, "delete schedule", func(provider coreworkflow.Provider) (struct{}, error) {
+		return struct{}{}, provider.DeleteSchedule(ctx, req)
+	})
+	return err
+}
+
+func (p *hostedWorkflowProviderPool) PauseSchedule(ctx context.Context, req coreworkflow.PauseScheduleRequest) (*coreworkflow.Schedule, error) {
+	return withHostedWorkflowProvider(p, "pause schedule", func(provider coreworkflow.Provider) (*coreworkflow.Schedule, error) {
+		return provider.PauseSchedule(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) ResumeSchedule(ctx context.Context, req coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error) {
+	return withHostedWorkflowProvider(p, "resume schedule", func(provider coreworkflow.Provider) (*coreworkflow.Schedule, error) {
+		return provider.ResumeSchedule(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) UpsertEventTrigger(ctx context.Context, req coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return withHostedWorkflowProvider(p, "upsert event trigger", func(provider coreworkflow.Provider) (*coreworkflow.EventTrigger, error) {
+		return provider.UpsertEventTrigger(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) GetEventTrigger(ctx context.Context, req coreworkflow.GetEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return withHostedWorkflowProvider(p, "get event trigger", func(provider coreworkflow.Provider) (*coreworkflow.EventTrigger, error) {
+		return provider.GetEventTrigger(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) ListEventTriggers(ctx context.Context, req coreworkflow.ListEventTriggersRequest) ([]*coreworkflow.EventTrigger, error) {
+	return withHostedWorkflowProvider(p, "list event triggers", func(provider coreworkflow.Provider) ([]*coreworkflow.EventTrigger, error) {
+		return provider.ListEventTriggers(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) DeleteEventTrigger(ctx context.Context, req coreworkflow.DeleteEventTriggerRequest) error {
+	_, err := withHostedWorkflowProvider(p, "delete event trigger", func(provider coreworkflow.Provider) (struct{}, error) {
+		return struct{}{}, provider.DeleteEventTrigger(ctx, req)
+	})
+	return err
+}
+
+func (p *hostedWorkflowProviderPool) PauseEventTrigger(ctx context.Context, req coreworkflow.PauseEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return withHostedWorkflowProvider(p, "pause event trigger", func(provider coreworkflow.Provider) (*coreworkflow.EventTrigger, error) {
+		return provider.PauseEventTrigger(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) ResumeEventTrigger(ctx context.Context, req coreworkflow.ResumeEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return withHostedWorkflowProvider(p, "resume event trigger", func(provider coreworkflow.Provider) (*coreworkflow.EventTrigger, error) {
+		return provider.ResumeEventTrigger(ctx, req)
+	})
+}
+
+func (p *hostedWorkflowProviderPool) PublishEvent(ctx context.Context, req coreworkflow.PublishEventRequest) error {
+	_, err := withHostedWorkflowProvider(p, "publish event", func(provider coreworkflow.Provider) (struct{}, error) {
+		return struct{}{}, provider.PublishEvent(ctx, req)
+	})
+	return err
+}
+
 func (p *hostedWorkflowProviderPool) Ping(ctx context.Context) error {
 	var joined []error
-	if p.Provider == nil {
-		joined = append(joined, fmt.Errorf("hosted workflow provider %q has no control provider", p.name))
-	} else if err := p.Provider.Ping(ctx); err != nil {
-		joined = append(joined, fmt.Errorf("control provider: %w", err))
-	}
 	if !p.isStarted() {
+		p.mu.Lock()
+		bootstrapProvider := p.bootstrapProvider
+		p.mu.Unlock()
+		if bootstrapProvider != nil {
+			return bootstrapProvider.Ping(ctx)
+		}
 		return errors.Join(joined...)
 	}
 	workers := p.readyWorkers()
@@ -467,38 +560,64 @@ func (p *hostedWorkflowProviderPool) Ping(ctx context.Context) error {
 }
 
 func (p *hostedWorkflowProviderPool) PutExecutionReference(ctx context.Context, ref *coreworkflow.ExecutionReference) (*coreworkflow.ExecutionReference, error) {
-	store, err := p.executionReferenceStore()
-	if err != nil {
-		return nil, err
-	}
-	return store.PutExecutionReference(ctx, ref)
+	return withHostedWorkflowExecutionReferenceStore(p, "put execution reference", func(store coreworkflow.ExecutionReferenceStore) (*coreworkflow.ExecutionReference, error) {
+		return store.PutExecutionReference(ctx, ref)
+	})
 }
 
 func (p *hostedWorkflowProviderPool) GetExecutionReference(ctx context.Context, id string) (*coreworkflow.ExecutionReference, error) {
-	store, err := p.executionReferenceStore()
-	if err != nil {
-		return nil, err
-	}
-	return store.GetExecutionReference(ctx, id)
+	return withHostedWorkflowExecutionReferenceStore(p, "get execution reference", func(store coreworkflow.ExecutionReferenceStore) (*coreworkflow.ExecutionReference, error) {
+		return store.GetExecutionReference(ctx, id)
+	})
 }
 
 func (p *hostedWorkflowProviderPool) ListExecutionReferences(ctx context.Context, subjectID string) ([]*coreworkflow.ExecutionReference, error) {
-	store, err := p.executionReferenceStore()
-	if err != nil {
-		return nil, err
-	}
-	return store.ListExecutionReferences(ctx, subjectID)
+	return withHostedWorkflowExecutionReferenceStore(p, "list execution references", func(store coreworkflow.ExecutionReferenceStore) ([]*coreworkflow.ExecutionReference, error) {
+		return store.ListExecutionReferences(ctx, subjectID)
+	})
 }
 
-func (p *hostedWorkflowProviderPool) executionReferenceStore() (coreworkflow.ExecutionReferenceStore, error) {
-	if p == nil || p.executionRefs == nil {
-		name := ""
-		if p != nil {
-			name = p.name
+func withHostedWorkflowExecutionReferenceStore[T any](p *hostedWorkflowProviderPool, operation string, fn func(coreworkflow.ExecutionReferenceStore) (T, error)) (T, error) {
+	return withHostedWorkflowProvider(p, operation, func(provider coreworkflow.Provider) (T, error) {
+		store, ok := provider.(coreworkflow.ExecutionReferenceStore)
+		if !ok {
+			var zero T
+			return zero, fmt.Errorf("hosted workflow provider %q does not expose execution references", p.name)
 		}
-		return nil, fmt.Errorf("hosted workflow provider %q does not expose execution references", name)
+		return fn(store)
+	})
+}
+
+func withHostedWorkflowProvider[T any](p *hostedWorkflowProviderPool, operation string, fn func(coreworkflow.Provider) (T, error)) (T, error) {
+	var zero T
+	if p == nil {
+		return zero, fmt.Errorf("hosted workflow provider is unavailable")
 	}
-	return p.executionRefs, nil
+	p.mu.Lock()
+	if p.closed {
+		name := p.name
+		p.mu.Unlock()
+		return zero, fmt.Errorf("hosted workflow provider %q is closed", name)
+	}
+	bootstrapProvider := p.bootstrapProvider
+	p.mu.Unlock()
+	if bootstrapProvider != nil {
+		return fn(bootstrapProvider)
+	}
+	workers := p.readyWorkers()
+	for _, worker := range workers {
+		if !p.acquireWorker(worker) {
+			continue
+		}
+		provider := worker.provider
+		result, err := fn(provider)
+		p.releaseWorker(worker)
+		return result, err
+	}
+	if operation == "" {
+		operation = "workflow operation"
+	}
+	return zero, fmt.Errorf("hosted workflow provider %q has no ready runtime workers for %s", p.name, operation)
 }
 
 func (p *hostedWorkflowProviderPool) Close() error {
@@ -540,9 +659,11 @@ func (p *hostedWorkflowProviderPool) Close() error {
 	}
 	p.mu.Lock()
 	p.workers = nil
+	bootstrapProvider := p.bootstrapProvider
+	p.bootstrapProvider = nil
 	p.mu.Unlock()
-	if p.Provider != nil {
-		closeErrs = append(closeErrs, p.Provider.Close())
+	if bootstrapProvider != nil {
+		closeErrs = append(closeErrs, bootstrapProvider.Close())
 	}
 	if p.launch != nil {
 		p.launch.close()

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider_test.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider_test.go
@@ -58,13 +58,14 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 		},
 	}
 
+	bootstrapProvider := newRecordingBootstrapWorkflowProvider()
 	provider, err := buildHostedWorkflowProvider(ctx, "temporal", entry, mustNode(t, map[string]any{
 		"command": "/bin/temporal-provider",
 		"config":  map[string]any{"namespace": "default"},
 	}), []runtimehost.HostService{{
 		Name:   "workflow_host",
 		EnvVar: workflowservice.DefaultHostSocketEnv,
-	}}, deps)
+	}}, deps, bootstrapProvider)
 	if err != nil {
 		t.Fatalf("buildHostedWorkflowProvider: %v", err)
 	}
@@ -100,8 +101,8 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 	if got := runtimeProvider.startProviderCalls(); got != 0 {
 		t.Fatalf("StartProvider calls before StartWorkflowProviders = %d, want 0", got)
 	}
-	if got := len(runtimeProvider.startPluginRequestsCopy()); got != 1 {
-		t.Fatalf("StartPlugin requests before StartWorkflowProviders = %d, want control provider only", got)
+	if got := len(runtimeProvider.startPluginRequestsCopy()); got != 0 {
+		t.Fatalf("StartPlugin requests before StartWorkflowProviders = %d, want 0", got)
 	}
 
 	if err := result.Start(ctx); err != nil {
@@ -113,15 +114,16 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 	if err := result.StartWorkflowProviders(ctx); err != nil {
 		t.Fatalf("StartWorkflowProviders: %v", err)
 	}
-	if got := runtimeProvider.startProviderCalls(); got != 3 {
-		t.Fatalf("StartProvider calls after StartWorkflowProviders = %d, want control + worker pool size 2", got)
+	waitForHostedWorkflowRuntimeStartProviderCalls(t, runtimeProvider, 2)
+	if got := bootstrapProvider.closeCalls.Load(); got != 1 {
+		t.Fatalf("bootstrap provider Close calls = %d, want 1", got)
 	}
 
 	startRequests := runtimeProvider.startPluginRequestsCopy()
-	if len(startRequests) != 3 {
-		t.Fatalf("StartPlugin requests after StartWorkflowProviders = %d, want control + 2 workers", len(startRequests))
+	if len(startRequests) != 2 {
+		t.Fatalf("StartPlugin requests after StartWorkflowProviders = %d, want 2 workers", len(startRequests))
 	}
-	workerReq := startRequests[1]
+	workerReq := startRequests[0]
 	if got := workerReq.Env[workflowservice.DefaultHostSocketEnv]; got != "tcp://127.0.0.1:8080" {
 		t.Fatalf("worker env %s = %q, want public relay target", workflowservice.DefaultHostSocketEnv, got)
 	}
@@ -129,16 +131,16 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 		t.Fatalf("worker env missing %s", workflowservice.HostSocketTokenEnv())
 	}
 	sessions := runtimeProvider.startSessionRequestsCopy()
-	if len(sessions) != 3 {
-		t.Fatalf("StartSession requests = %d, want control + 2 workers", len(sessions))
+	if len(sessions) != 2 {
+		t.Fatalf("StartSession requests = %d, want 2 workers", len(sessions))
 	}
-	if got := sessions[1].Metadata["provider_kind"]; got != providermanifestKindWorkflow {
+	if got := sessions[0].Metadata["provider_kind"]; got != providermanifestKindWorkflow {
 		t.Fatalf("worker session provider_kind = %q, want %q", got, providermanifestKindWorkflow)
 	}
-	if got := sessions[1].Metadata["provider_name"]; got != "temporal" {
+	if got := sessions[0].Metadata["provider_name"]; got != "temporal" {
 		t.Fatalf("worker session provider_name = %q, want temporal", got)
 	}
-	if got := sessions[1].Metadata["workload"]; got != "temporal-workers" {
+	if got := sessions[0].Metadata["workload"]; got != "temporal-workers" {
 		t.Fatalf("worker session workload = %q, want temporal-workers", got)
 	}
 }
@@ -183,7 +185,7 @@ func TestHostedWorkflowProviderKeepsSharedRuntimeOpen(t *testing.T) {
 	}), []runtimehost.HostService{{
 		Name:   "workflow_host",
 		EnvVar: workflowservice.DefaultHostSocketEnv,
-	}}, deps)
+	}}, deps, nil)
 	if err != nil {
 		t.Fatalf("buildHostedWorkflowProvider: %v", err)
 	}
@@ -229,7 +231,7 @@ func TestHostedWorkflowProviderPoolDrainWaitsBeforeClosingWorker(t *testing.T) {
 	}), []runtimehost.HostService{{
 		Name:   "workflow_host",
 		EnvVar: workflowservice.DefaultHostSocketEnv,
-	}}, deps)
+	}}, deps, nil)
 	if err != nil {
 		t.Fatalf("buildHostedWorkflowProvider: %v", err)
 	}
@@ -241,10 +243,7 @@ func TestHostedWorkflowProviderPoolDrainWaitsBeforeClosingWorker(t *testing.T) {
 	if err := pool.Start(ctx); err != nil {
 		t.Fatalf("pool.Start: %v", err)
 	}
-	workers := pool.readyWorkers()
-	if len(workers) != 1 {
-		t.Fatalf("ready workers = %d, want 1", len(workers))
-	}
+	workers := waitForHostedWorkflowReadyWorkers(t, pool, 1)
 	pool.mu.Lock()
 	workers[0].active = 1
 	pool.mu.Unlock()
@@ -269,6 +268,167 @@ func TestHostedWorkflowProviderPoolDrainWaitsBeforeClosingWorker(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("drainAndCloseWorker did not finish after drain timeout")
 	}
+}
+
+func waitForHostedWorkflowRuntimeStartProviderCalls(t *testing.T, runtimeProvider *recordingHostedWorkflowRuntime, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := runtimeProvider.startProviderCalls(); got == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("StartProvider calls = %d, want %d", runtimeProvider.startProviderCalls(), want)
+}
+
+func waitForHostedWorkflowReadyWorkers(t *testing.T, pool *hostedWorkflowProviderPool, want int) []*hostedWorkflowWorker {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		workers := pool.readyWorkers()
+		if len(workers) == want {
+			return workers
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	workers := pool.readyWorkers()
+	t.Fatalf("ready workers = %d, want %d", len(workers), want)
+	return nil
+}
+
+type recordingBootstrapWorkflowProvider struct {
+	mu            sync.Mutex
+	executionRefs map[string]*workflow.ExecutionReference
+	closeCalls    atomic.Int32
+}
+
+func newRecordingBootstrapWorkflowProvider() *recordingBootstrapWorkflowProvider {
+	return &recordingBootstrapWorkflowProvider{
+		executionRefs: map[string]*workflow.ExecutionReference{},
+	}
+}
+
+func (p *recordingBootstrapWorkflowProvider) StartRun(context.Context, workflow.StartRunRequest) (*workflow.Run, error) {
+	return nil, status.Error(codes.Unimplemented, "start run is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) GetRun(context.Context, workflow.GetRunRequest) (*workflow.Run, error) {
+	return nil, status.Error(codes.Unimplemented, "get run is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) ListRuns(context.Context, workflow.ListRunsRequest) ([]*workflow.Run, error) {
+	return nil, status.Error(codes.Unimplemented, "list runs is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) CancelRun(context.Context, workflow.CancelRunRequest) (*workflow.Run, error) {
+	return nil, status.Error(codes.Unimplemented, "cancel run is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) SignalRun(context.Context, workflow.SignalRunRequest) (*workflow.SignalRunResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "signal run is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) SignalOrStartRun(context.Context, workflow.SignalOrStartRunRequest) (*workflow.SignalRunResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "signal or start run is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) UpsertSchedule(context.Context, workflow.UpsertScheduleRequest) (*workflow.Schedule, error) {
+	return nil, status.Error(codes.Unimplemented, "upsert schedule is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) GetSchedule(context.Context, workflow.GetScheduleRequest) (*workflow.Schedule, error) {
+	return nil, status.Error(codes.NotFound, "schedule not found")
+}
+
+func (p *recordingBootstrapWorkflowProvider) ListSchedules(context.Context, workflow.ListSchedulesRequest) ([]*workflow.Schedule, error) {
+	return nil, nil
+}
+
+func (p *recordingBootstrapWorkflowProvider) DeleteSchedule(context.Context, workflow.DeleteScheduleRequest) error {
+	return status.Error(codes.NotFound, "schedule not found")
+}
+
+func (p *recordingBootstrapWorkflowProvider) PauseSchedule(context.Context, workflow.PauseScheduleRequest) (*workflow.Schedule, error) {
+	return nil, status.Error(codes.Unimplemented, "pause schedule is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) ResumeSchedule(context.Context, workflow.ResumeScheduleRequest) (*workflow.Schedule, error) {
+	return nil, status.Error(codes.Unimplemented, "resume schedule is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) UpsertEventTrigger(context.Context, workflow.UpsertEventTriggerRequest) (*workflow.EventTrigger, error) {
+	return nil, status.Error(codes.Unimplemented, "upsert event trigger is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) GetEventTrigger(context.Context, workflow.GetEventTriggerRequest) (*workflow.EventTrigger, error) {
+	return nil, status.Error(codes.NotFound, "event trigger not found")
+}
+
+func (p *recordingBootstrapWorkflowProvider) ListEventTriggers(context.Context, workflow.ListEventTriggersRequest) ([]*workflow.EventTrigger, error) {
+	return nil, nil
+}
+
+func (p *recordingBootstrapWorkflowProvider) DeleteEventTrigger(context.Context, workflow.DeleteEventTriggerRequest) error {
+	return status.Error(codes.NotFound, "event trigger not found")
+}
+
+func (p *recordingBootstrapWorkflowProvider) PauseEventTrigger(context.Context, workflow.PauseEventTriggerRequest) (*workflow.EventTrigger, error) {
+	return nil, status.Error(codes.Unimplemented, "pause event trigger is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) ResumeEventTrigger(context.Context, workflow.ResumeEventTriggerRequest) (*workflow.EventTrigger, error) {
+	return nil, status.Error(codes.Unimplemented, "resume event trigger is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) PublishEvent(context.Context, workflow.PublishEventRequest) error {
+	return status.Error(codes.Unimplemented, "publish event is not implemented")
+}
+
+func (p *recordingBootstrapWorkflowProvider) Ping(context.Context) error {
+	return nil
+}
+
+func (p *recordingBootstrapWorkflowProvider) Close() error {
+	p.closeCalls.Add(1)
+	return nil
+}
+
+func (p *recordingBootstrapWorkflowProvider) PutExecutionReference(_ context.Context, ref *workflow.ExecutionReference) (*workflow.ExecutionReference, error) {
+	if ref == nil || ref.ID == "" {
+		return nil, status.Error(codes.InvalidArgument, "missing execution reference id")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cloned := *ref
+	p.executionRefs[ref.ID] = &cloned
+	out := cloned
+	return &out, nil
+}
+
+func (p *recordingBootstrapWorkflowProvider) GetExecutionReference(_ context.Context, id string) (*workflow.ExecutionReference, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ref := p.executionRefs[id]
+	if ref == nil {
+		return nil, status.Error(codes.NotFound, "execution reference not found")
+	}
+	out := *ref
+	return &out, nil
+}
+
+func (p *recordingBootstrapWorkflowProvider) ListExecutionReferences(_ context.Context, subjectID string) ([]*workflow.ExecutionReference, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	refs := make([]*workflow.ExecutionReference, 0, len(p.executionRefs))
+	for _, ref := range p.executionRefs {
+		if subjectID != "" && ref.SubjectID != subjectID {
+			continue
+		}
+		out := *ref
+		refs = append(refs, &out)
+	}
+	return refs, nil
 }
 
 const providermanifestKindWorkflow = "workflow"


### PR DESCRIPTION
## Summary
- stop creating a hosted workflow control provider during bootstrap for pooled hosted workflow providers
- use a local bootstrap control provider only while config-managed workflow schedules/triggers reconcile, then close it before workflow startup completes
- start long-running hosted workflow workers asynchronously and route workflow/control RPCs to ready runtime workers after the pool is up

## Why
Cloud Run cannot route public host-service relay traffic to a revision until the revision is ready. The old pooled workflow path configured a hosted control provider during bootstrap, so Temporal opened IndexedDB/workflow host services through the public relay before the new revision could receive that traffic. Requests hit the previous revision and failed with stale/unknown relay sessions.

This keeps steady-state workflow workers in the hosted runtime while avoiding the Cloud Run readiness cycle.

## Verification
- go test ./internal/bootstrap
- go test ./internal/server ./services/workflows