### PR TITLE
Clean up workflow runtime placement

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -249,10 +249,17 @@ type Result struct {
 	ProviderDevSessions   *providerdev.Manager
 	PublicHostServices    *runtimehost.PublicHostServiceRegistry
 
-	pluginRuntimeRegistry *pluginRuntimeRegistry
-	auditClose            func(context.Context) error
-	mu                    sync.Mutex
-	closed                bool
+	pluginRuntimeRegistry               *pluginRuntimeRegistry
+	workflowConfigReconcileTasks        []workflowConfigReconcileTask
+	workflowConfigReconcileTasksStarted bool
+	auditClose                          func(context.Context) error
+	mu                                  sync.Mutex
+	closed                              bool
+}
+
+type workflowConfigReconcileTask struct {
+	name      string
+	reconcile func(context.Context) error
 }
 
 func (r *Result) Start(ctx context.Context) error {
@@ -300,6 +307,53 @@ func (r *Result) StartWorkflowProviders(ctx context.Context) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (r *Result) StartWorkflowConfigReconciliation(ctx context.Context) {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	if r.closed || r.workflowConfigReconcileTasksStarted || len(r.workflowConfigReconcileTasks) == 0 {
+		r.mu.Unlock()
+		return
+	}
+	r.workflowConfigReconcileTasksStarted = true
+	tasks := append([]workflowConfigReconcileTask(nil), r.workflowConfigReconcileTasks...)
+	r.mu.Unlock()
+
+	for _, task := range tasks {
+		task := task
+		go runWorkflowConfigReconcileTask(ctx, task)
+	}
+}
+
+func runWorkflowConfigReconcileTask(ctx context.Context, task workflowConfigReconcileTask) {
+	if task.reconcile == nil {
+		return
+	}
+	taskName := strings.TrimSpace(task.name)
+	if taskName == "" {
+		taskName = "workflow config"
+	}
+	interval := 5 * time.Second
+	for {
+		if err := task.reconcile(ctx); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			slog.WarnContext(ctx, "workflow config reconciliation failed; will retry", "task", taskName, "error", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(interval):
+				continue
+			}
+		}
+		slog.InfoContext(ctx, "workflow config reconciled", "task", taskName)
+		return
+	}
 }
 
 func (r *Result) Close(ctx context.Context) error {
@@ -444,6 +498,16 @@ func (p *workflowProviderWithCleanup) Start(ctx context.Context) error {
 	return nil
 }
 
+func (p *workflowProviderWithCleanup) WaitRuntimeWorkersReady(ctx context.Context) error {
+	if p == nil || p.Provider == nil {
+		return nil
+	}
+	if workerProvider, ok := p.Provider.(runtimeWorkerWorkflowProvider); ok {
+		return workerProvider.WaitRuntimeWorkersReady(ctx)
+	}
+	return nil
+}
+
 func (p *workflowProviderWithExecutionReferencesAndCleanup) Close() error {
 	var errs []error
 	if p != nil && p.Provider != nil {
@@ -463,6 +527,16 @@ func (p *workflowProviderWithExecutionReferencesAndCleanup) Start(ctx context.Co
 	}
 	if starter, ok := p.Provider.(startableWorkflowProvider); ok {
 		return starter.Start(ctx)
+	}
+	return nil
+}
+
+func (p *workflowProviderWithExecutionReferencesAndCleanup) WaitRuntimeWorkersReady(ctx context.Context) error {
+	if p == nil || p.Provider == nil {
+		return nil
+	}
+	if workerProvider, ok := p.Provider.(runtimeWorkerWorkflowProvider); ok {
+		return workerProvider.WaitRuntimeWorkersReady(ctx)
 	}
 	return nil
 }
@@ -1161,10 +1235,27 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		}
 	}()
 	pluginInvoker.SetTarget(invocation.NewGuarded(sharedInvoker, nil, "plugin", audit, invocation.WithoutRateLimit()))
-	if err := reconcileWorkflowConfigSchedules(ctx, cfg, prepared.Deps.WorkflowRuntime); err != nil {
-		return nil, err
+	reconcileWorkflowConfig := func(ctx context.Context, includeProvider workflowConfigProviderFilter) error {
+		if err := reconcileWorkflowConfigSchedules(ctx, cfg, prepared.Deps.WorkflowRuntime, includeProvider); err != nil {
+			return err
+		}
+		if err := reconcileWorkflowConfigEventTriggers(ctx, cfg, prepared.Deps.WorkflowRuntime, includeProvider); err != nil {
+			return err
+		}
+		return nil
 	}
-	if err := reconcileWorkflowConfigEventTriggers(ctx, cfg, prepared.Deps.WorkflowRuntime); err != nil {
+	var deferredWorkflowConfigReconcileTasks []workflowConfigReconcileTask
+	runtimePlacedWorkflowProviders := runtimePlacedWorkflowProviderNames(cfg)
+	if len(runtimePlacedWorkflowProviders) > 0 {
+		localWorkflowProviders := func(providerName string) bool {
+			_, runtimePlaced := runtimePlacedWorkflowProviders[strings.TrimSpace(providerName)]
+			return !runtimePlaced
+		}
+		if err := reconcileWorkflowConfig(ctx, localWorkflowProviders); err != nil {
+			return nil, err
+		}
+		deferredWorkflowConfigReconcileTasks = runtimeWorkflowConfigReconcileTasks(prepared.Deps.WorkflowRuntime, runtimePlacedWorkflowProviders, reconcileWorkflowConfig)
+	} else if err := reconcileWorkflowConfig(ctx, nil); err != nil {
 		return nil, err
 	}
 
@@ -1175,36 +1266,92 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	closeWorkflowsOnError = false
 	closeAgentsOnError = false
 	return &Result{
-		Auth:                  prepared.Auth,
-		SelectedAuthProvider:  prepared.SelectedAuthProvider,
-		AuthProviders:         prepared.AuthProviders,
-		AuthorizationProvider: prepared.AuthorizationProvider,
-		Services:              prepared.Services,
-		ExtraIndexedDBs:       prepared.ExtraIndexedDBs,
-		S3:                    prepared.Deps.S3,
-		ExtraS3s:              prepared.ExtraS3s,
-		ExtraWorkflows:        extraWorkflows,
-		ExtraAgents:           extraAgents,
-		Providers:             providers,
-		WorkflowControl:       prepared.Deps.WorkflowRuntime,
-		AgentControl:          prepared.Deps.AgentRuntime,
-		AgentManager:          prepared.Deps.AgentManager,
-		ProvidersReady:        providersReady,
-		Authorizer:            authz,
-		ConnectionAuth:        connAuthResolver,
-		ManualConnectionAuth:  manualConnAuthResolver,
-		Invoker:               sharedInvoker,
-		PluginInvoker:         pluginInvoker,
-		CapabilityLister:      sharedInvoker,
-		AuditSink:             audit,
-		SecretManager:         prepared.SecretManager,
-		Telemetry:             prepared.Telemetry,
-		PluginRuntimes:        prepared.pluginRuntimeRegistry,
-		ProviderDevSessions:   providerDevSessions,
-		PublicHostServices:    publicHostServices,
-		pluginRuntimeRegistry: prepared.pluginRuntimeRegistry,
-		auditClose:            auditClose,
+		Auth:                         prepared.Auth,
+		SelectedAuthProvider:         prepared.SelectedAuthProvider,
+		AuthProviders:                prepared.AuthProviders,
+		AuthorizationProvider:        prepared.AuthorizationProvider,
+		Services:                     prepared.Services,
+		ExtraIndexedDBs:              prepared.ExtraIndexedDBs,
+		S3:                           prepared.Deps.S3,
+		ExtraS3s:                     prepared.ExtraS3s,
+		ExtraWorkflows:               extraWorkflows,
+		ExtraAgents:                  extraAgents,
+		Providers:                    providers,
+		WorkflowControl:              prepared.Deps.WorkflowRuntime,
+		AgentControl:                 prepared.Deps.AgentRuntime,
+		AgentManager:                 prepared.Deps.AgentManager,
+		ProvidersReady:               providersReady,
+		Authorizer:                   authz,
+		ConnectionAuth:               connAuthResolver,
+		ManualConnectionAuth:         manualConnAuthResolver,
+		Invoker:                      sharedInvoker,
+		PluginInvoker:                pluginInvoker,
+		CapabilityLister:             sharedInvoker,
+		AuditSink:                    audit,
+		SecretManager:                prepared.SecretManager,
+		Telemetry:                    prepared.Telemetry,
+		PluginRuntimes:               prepared.pluginRuntimeRegistry,
+		ProviderDevSessions:          providerDevSessions,
+		PublicHostServices:           publicHostServices,
+		pluginRuntimeRegistry:        prepared.pluginRuntimeRegistry,
+		workflowConfigReconcileTasks: deferredWorkflowConfigReconcileTasks,
+		auditClose:                   auditClose,
 	}, nil
+}
+
+type runtimeWorkerWorkflowProvider interface {
+	WaitRuntimeWorkersReady(context.Context) error
+}
+
+func runtimePlacedWorkflowProviderNames(cfg *config.Config) map[string]struct{} {
+	providerNames := map[string]struct{}{}
+	if cfg == nil {
+		return providerNames
+	}
+	for name, entry := range cfg.Providers.Workflow {
+		if entry != nil && entry.UsesRuntimePlacement() {
+			providerNames[strings.TrimSpace(name)] = struct{}{}
+		}
+	}
+	return providerNames
+}
+
+func runtimeWorkflowConfigReconcileTasks(runtime *workflowRuntime, providerNames map[string]struct{}, reconcile func(context.Context, workflowConfigProviderFilter) error) []workflowConfigReconcileTask {
+	tasks := make([]workflowConfigReconcileTask, 0, len(providerNames))
+	for _, providerName := range slices.Sorted(maps.Keys(providerNames)) {
+		providerName := providerName
+		tasks = append(tasks, workflowConfigReconcileTask{
+			name: "workflow provider " + providerName,
+			reconcile: func(ctx context.Context) error {
+				if err := waitRuntimeWorkflowProviderReady(ctx, runtime, providerName); err != nil {
+					return err
+				}
+				return reconcile(ctx, workflowConfigOnlyProvider(providerName))
+			},
+		})
+	}
+	return tasks
+}
+
+func workflowConfigOnlyProvider(providerName string) workflowConfigProviderFilter {
+	return func(candidateName string) bool {
+		return strings.TrimSpace(candidateName) == strings.TrimSpace(providerName)
+	}
+}
+
+func waitRuntimeWorkflowProviderReady(ctx context.Context, runtime *workflowRuntime, providerName string) error {
+	provider, err := runtime.ResolveProvider(providerName)
+	if err != nil {
+		return err
+	}
+	workerProvider, ok := provider.(runtimeWorkerWorkflowProvider)
+	if !ok {
+		return nil
+	}
+	if err := workerProvider.WaitRuntimeWorkersReady(ctx); err != nil {
+		return err
+	}
+	return nil
 }
 
 func buildWorkflows(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) ([]coreworkflow.Provider, error) {
@@ -1766,17 +1913,20 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 		hostServices = append(hostServices, indexedDBHostServices...)
 		cleanup = chainCleanup(cleanup, indexedDBCleanup)
 	}
-	var provider coreworkflow.Provider
-	if entry.UsesHostedExecution() {
-		provider, err = buildHostedWorkflowProvider(ctx, name, entry, node, hostServices, deps)
-	} else {
-		if factories.Workflow == nil {
-			return nil, fmt.Errorf("workflow factory is not registered")
-		}
-		provider, err = factories.Workflow(ctx, name, node, hostServices, deps)
+	if factories.Workflow == nil {
+		return nil, fmt.Errorf("workflow factory is not registered")
 	}
+	provider, err := factories.Workflow(ctx, name, node, hostServices, deps)
 	if err != nil {
 		return nil, fmt.Errorf("workflow provider: %w", err)
+	}
+	if entry.UsesRuntimePlacement() {
+		workerPool, err := buildHostedWorkflowWorkerPool(ctx, name, entry, node, hostServices, deps)
+		if err != nil {
+			_ = provider.Close()
+			return nil, fmt.Errorf("workflow provider: %w", err)
+		}
+		provider = wrapWorkflowProviderWithRuntimeWorkers(provider, workerPool)
 	}
 	if cleanup != nil {
 		if executionRefs, ok := provider.(coreworkflow.ExecutionReferenceStore); ok {
@@ -1837,7 +1987,7 @@ func buildAgent(ctx context.Context, name string, entry *config.ProviderEntry, f
 		provider    coreagent.Provider
 		providerErr error
 	)
-	if entry.UsesHostedExecution() {
+	if entry.UsesRuntimePlacement() {
 		provider, providerErr = buildHostedAgentProvider(ctx, name, entry, node, hostServices, deps)
 	} else {
 		if factories.Agent == nil {

--- a/gestaltd/internal/bootstrap/hosted_runtime_compatibility_test.go
+++ b/gestaltd/internal/bootstrap/hosted_runtime_compatibility_test.go
@@ -58,7 +58,7 @@ func TestHostedAgentPoolDoesNotRouteNewWorkToKnownStaleBackend(t *testing.T) {
 func TestHostedWorkflowWorkerKnownStaleSessionIsNotReady(t *testing.T) {
 	t.Parallel()
 
-	pool := &hostedWorkflowProviderPool{}
+	pool := &hostedWorkflowWorkerPool{}
 	worker := &hostedWorkflowWorker{
 		provider:       &noopWorkflowProvider{},
 		runtimeSession: staleRuntimeSessionForTest(),

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider.go
@@ -21,6 +21,8 @@ import (
 
 const hostedWorkflowRuntimeLifecycleSafetyMargin = 5 * time.Second
 
+var errHostedWorkflowWorkerPoolClosed = errors.New("hosted workflow worker pool closed")
+
 type hostedWorkflowProviderLaunch struct {
 	name            string
 	runtimeConfig   config.EffectiveHostedRuntime
@@ -40,7 +42,7 @@ type hostedWorkflowProviderInstance struct {
 	runtimeSession   *pluginruntime.Session
 }
 
-func buildHostedWorkflowProvider(ctx context.Context, name string, entry *config.ProviderEntry, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (coreworkflow.Provider, error) {
+func buildHostedWorkflowWorkerPool(ctx context.Context, name string, entry *config.ProviderEntry, node yaml.Node, hostServices []runtimehost.HostService, deps Deps) (*hostedWorkflowWorkerPool, error) {
 	launch, err := prepareHostedWorkflowProviderLaunch(ctx, name, entry, node, deps)
 	if err != nil {
 		return nil, err
@@ -54,22 +56,16 @@ func buildHostedWorkflowProvider(ctx context.Context, name string, entry *config
 	launch.cleanup = chainCleanup(launch.cleanup, publicHostServicesCleanup)
 
 	runtimeCfg := entry.HostedRuntimeConfig()
-	if runtimeCfg != nil && runtimeCfg.LifecyclePolicyFieldsSet() {
-		policy, err := runtimeCfg.LifecyclePolicy()
-		if err != nil {
-			launch.close()
-			return nil, fmt.Errorf("parse hosted workflow runtime lifecycle policy: %w", err)
-		}
-		return newHostedWorkflowProviderPool(ctx, launch, hostServices, deps, policy)
+	if runtimeCfg == nil || !runtimeCfg.LifecyclePolicyFieldsSet() {
+		launch.close()
+		return nil, fmt.Errorf("workflow runtime pool is required")
 	}
-	cleanup := launch.cleanup
-	launch.cleanup = nil
-	instance, err := startHostedWorkflowProviderInstance(ctx, launch, hostServices, deps, launch.runtimeOwned, cleanup, 0)
+	policy, err := runtimeCfg.LifecyclePolicy()
 	if err != nil {
 		launch.close()
-		return nil, err
+		return nil, fmt.Errorf("parse hosted workflow runtime lifecycle policy: %w", err)
 	}
-	return instance.provider, nil
+	return newHostedWorkflowWorkerPool(launch, hostServices, deps, policy)
 }
 
 func (p *hostedWorkflowProviderLaunch) close() {
@@ -201,6 +197,9 @@ func startHostedWorkflowProviderInstance(ctx context.Context, launch *hostedWork
 	if err != nil {
 		return nil, fmt.Errorf("wait for hosted workflow runtime session %q ready: %w", sessionID, err)
 	}
+	if reason := hostedRuntimeSessionCompatibilityReason(readySession); reason != "" {
+		return nil, fmt.Errorf("hosted workflow runtime session is not compatible: %s", reason)
+	}
 
 	startEnv := withRuntimeSessionEnv(maps.Clone(launch.cfg.Env), sessionID)
 	startEnv = withHostServiceTLSCAEnv(startEnv, deps)
@@ -290,11 +289,56 @@ func hostedWorkflowAllowedHosts(configured []string, runtimePlan HostedRuntimePl
 	return hostedAgentAllowedHosts(configured, runtimePlan)
 }
 
-type hostedWorkflowProviderPool struct {
+type workflowProviderWithRuntimeWorkers struct {
 	coreworkflow.Provider
+	workers *hostedWorkflowWorkerPool
+}
 
-	executionRefs coreworkflow.ExecutionReferenceStore
+type workflowProviderWithRuntimeWorkersAndExecutionReferences struct {
+	*workflowProviderWithRuntimeWorkers
+	coreworkflow.ExecutionReferenceStore
+}
 
+func wrapWorkflowProviderWithRuntimeWorkers(provider coreworkflow.Provider, workers *hostedWorkflowWorkerPool) coreworkflow.Provider {
+	wrapped := &workflowProviderWithRuntimeWorkers{
+		Provider: provider,
+		workers:  workers,
+	}
+	if executionRefs, ok := provider.(coreworkflow.ExecutionReferenceStore); ok {
+		return &workflowProviderWithRuntimeWorkersAndExecutionReferences{
+			workflowProviderWithRuntimeWorkers: wrapped,
+			ExecutionReferenceStore:            executionRefs,
+		}
+	}
+	return wrapped
+}
+
+func (p *workflowProviderWithRuntimeWorkers) Start(ctx context.Context) error {
+	if p == nil || p.workers == nil {
+		return nil
+	}
+	return p.workers.Start(ctx)
+}
+
+func (p *workflowProviderWithRuntimeWorkers) WaitRuntimeWorkersReady(ctx context.Context) error {
+	if p == nil || p.workers == nil {
+		return nil
+	}
+	return p.workers.WaitReady(ctx)
+}
+
+func (p *workflowProviderWithRuntimeWorkers) Close() error {
+	var errs []error
+	if p != nil && p.workers != nil {
+		errs = append(errs, p.workers.Close())
+	}
+	if p != nil && p.Provider != nil {
+		errs = append(errs, p.Provider.Close())
+	}
+	return errors.Join(errs...)
+}
+
+type hostedWorkflowWorkerPool struct {
 	name         string
 	launch       *hostedWorkflowProviderLaunch
 	hostServices []runtimehost.HostService
@@ -304,14 +348,15 @@ type hostedWorkflowProviderPool struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+	ready  chan struct{}
+	once   sync.Once
 
-	mu             sync.Mutex
-	nextID         int
-	starting       int
-	started        bool
-	controlStarted bool
-	closed         bool
-	workers        []*hostedWorkflowWorker
+	mu       sync.Mutex
+	nextID   int
+	starting int
+	started  bool
+	closed   bool
+	workers  []*hostedWorkflowWorker
 }
 
 type hostedWorkflowWorker struct {
@@ -329,38 +374,31 @@ type hostedWorkflowWorker struct {
 	closed           bool
 }
 
-func newHostedWorkflowProviderPool(ctx context.Context, launch *hostedWorkflowProviderLaunch, hostServices []runtimehost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy) (coreworkflow.Provider, error) {
+func newHostedWorkflowWorkerPool(launch *hostedWorkflowProviderLaunch, hostServices []runtimehost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy) (*hostedWorkflowWorkerPool, error) {
 	if launch == nil {
 		return nil, fmt.Errorf("hosted workflow launch is required")
 	}
-	control, err := startHostedWorkflowProviderInstance(ctx, launch, hostServices, deps, false, nil, 0)
-	if err != nil {
-		launch.close()
-		return nil, err
-	}
-	executionRefs, _ := control.provider.(coreworkflow.ExecutionReferenceStore)
 	poolCtx, cancel := context.WithCancel(context.Background())
-	return &hostedWorkflowProviderPool{
-		Provider:      control.provider,
-		executionRefs: executionRefs,
-		name:          launch.name,
-		launch:        launch,
-		hostServices:  append([]runtimehost.HostService(nil), hostServices...),
-		deps:          deps,
-		policy:        policy,
-		ctx:           poolCtx,
-		cancel:        cancel,
+	return &hostedWorkflowWorkerPool{
+		name:         launch.name,
+		launch:       launch,
+		hostServices: append([]runtimehost.HostService(nil), hostServices...),
+		deps:         deps,
+		policy:       policy,
+		ctx:          poolCtx,
+		cancel:       cancel,
+		ready:        make(chan struct{}),
 	}, nil
 }
 
-func (p *hostedWorkflowProviderPool) Start(ctx context.Context) error {
+func (p *hostedWorkflowWorkerPool) Start(ctx context.Context) error {
 	if p == nil {
 		return nil
 	}
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
-		return fmt.Errorf("hosted workflow provider %q is closed", p.name)
+		return fmt.Errorf("hosted workflow provider %q is closed: %w", p.name, errHostedWorkflowWorkerPoolClosed)
 	}
 	if p.started {
 		p.mu.Unlock()
@@ -369,139 +407,90 @@ func (p *hostedWorkflowProviderPool) Start(ctx context.Context) error {
 	p.started = true
 	p.mu.Unlock()
 
-	if err := p.startControl(ctx); err != nil {
-		p.markStartFailed()
-		return err
-	}
-	if err := p.ensureMinReady(ctx); err != nil {
-		p.markStartFailed()
-		return err
-	}
-	if p.policy.RestartPolicy != config.HostedRuntimeRestartPolicyNever {
-		p.wg.Add(1)
-		go func() {
-			defer p.wg.Done()
-			p.healthLoop()
-		}()
-	} else {
-		p.wg.Add(1)
-		go func() {
-			defer p.wg.Done()
-			p.runtimeSessionLoop()
-		}()
-	}
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		p.startLoop()
+	}()
 	return nil
 }
 
-func (p *hostedWorkflowProviderPool) startControl(ctx context.Context) error {
-	p.mu.Lock()
-	if p.controlStarted {
-		p.mu.Unlock()
-		return nil
+func (p *hostedWorkflowWorkerPool) startLoop() {
+	interval := p.policy.HealthCheckInterval
+	if interval <= 0 {
+		interval = time.Second
 	}
-	provider := p.Provider
-	p.mu.Unlock()
-
-	if provider == nil {
-		return fmt.Errorf("hosted workflow provider %q has no control provider", p.name)
-	}
-	if starter, ok := provider.(startableWorkflowProvider); ok {
-		if err := starter.Start(ctx); err != nil {
-			return fmt.Errorf("start hosted workflow control provider: %w", err)
+	for {
+		if err := p.ensureMinReady(p.ctx); err != nil {
+			if hostedWorkflowWorkerPoolStopped(err) {
+				return
+			}
+			slog.Warn("failed to start hosted workflow runtime workers", "provider", p.name, "error", err)
+			select {
+			case <-p.ctx.Done():
+				return
+			case <-time.After(interval):
+				continue
+			}
 		}
+		if !p.markReady() {
+			return
+		}
+		break
 	}
+	if p.policy.RestartPolicy != config.HostedRuntimeRestartPolicyNever {
+		p.healthLoop()
+		return
+	}
+	p.runtimeSessionLoop()
+}
 
+func (p *hostedWorkflowWorkerPool) markReady() bool {
+	if p == nil {
+		return false
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.closed {
-		return fmt.Errorf("hosted workflow provider %q is closed", p.name)
+		return false
 	}
-	p.controlStarted = true
-	return nil
+	p.once.Do(func() {
+		close(p.ready)
+	})
+	return true
 }
 
-func (p *hostedWorkflowProviderPool) markStartFailed() {
+func (p *hostedWorkflowWorkerPool) WaitReady(ctx context.Context) error {
+	if p == nil {
+		return nil
+	}
+	var poolDone <-chan struct{}
+	if p.ctx != nil {
+		poolDone = p.ctx.Done()
+	}
+	select {
+	case <-p.ready:
+		if p.isClosed() {
+			return errHostedWorkflowWorkerPoolClosed
+		}
+		return nil
+	case <-poolDone:
+		return errHostedWorkflowWorkerPoolClosed
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *hostedWorkflowWorkerPool) isClosed() bool {
+	if p == nil {
+		return true
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if !p.closed {
-		p.started = false
-	}
+	return p.closed
 }
 
-func (p *hostedWorkflowProviderPool) Ping(ctx context.Context) error {
-	var joined []error
-	if p.Provider == nil {
-		joined = append(joined, fmt.Errorf("hosted workflow provider %q has no control provider", p.name))
-	} else if err := p.Provider.Ping(ctx); err != nil {
-		joined = append(joined, fmt.Errorf("control provider: %w", err))
-	}
-	if !p.isStarted() {
-		return errors.Join(joined...)
-	}
-	workers := p.readyWorkers()
-	if len(workers) == 0 {
-		joined = append(joined, fmt.Errorf("hosted workflow provider %q has no ready runtime workers", p.name))
-		return errors.Join(joined...)
-	}
-	errs := make(chan error, len(workers))
-	var wg sync.WaitGroup
-	for _, worker := range workers {
-		wg.Add(1)
-		go func(worker *hostedWorkflowWorker) {
-			defer wg.Done()
-			if !p.acquireWorker(worker) {
-				return
-			}
-			if err := worker.provider.Ping(ctx); err != nil {
-				errs <- fmt.Errorf("runtime worker %d: %w", worker.id, err)
-			}
-			p.releaseWorker(worker)
-		}(worker)
-	}
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		joined = append(joined, err)
-	}
-	return errors.Join(joined...)
-}
-
-func (p *hostedWorkflowProviderPool) PutExecutionReference(ctx context.Context, ref *coreworkflow.ExecutionReference) (*coreworkflow.ExecutionReference, error) {
-	store, err := p.executionReferenceStore()
-	if err != nil {
-		return nil, err
-	}
-	return store.PutExecutionReference(ctx, ref)
-}
-
-func (p *hostedWorkflowProviderPool) GetExecutionReference(ctx context.Context, id string) (*coreworkflow.ExecutionReference, error) {
-	store, err := p.executionReferenceStore()
-	if err != nil {
-		return nil, err
-	}
-	return store.GetExecutionReference(ctx, id)
-}
-
-func (p *hostedWorkflowProviderPool) ListExecutionReferences(ctx context.Context, subjectID string) ([]*coreworkflow.ExecutionReference, error) {
-	store, err := p.executionReferenceStore()
-	if err != nil {
-		return nil, err
-	}
-	return store.ListExecutionReferences(ctx, subjectID)
-}
-
-func (p *hostedWorkflowProviderPool) executionReferenceStore() (coreworkflow.ExecutionReferenceStore, error) {
-	if p == nil || p.executionRefs == nil {
-		name := ""
-		if p != nil {
-			name = p.name
-		}
-		return nil, fmt.Errorf("hosted workflow provider %q does not expose execution references", name)
-	}
-	return p.executionRefs, nil
-}
-
-func (p *hostedWorkflowProviderPool) Close() error {
+func (p *hostedWorkflowWorkerPool) Close() error {
 	if p == nil {
 		return nil
 	}
@@ -541,25 +530,13 @@ func (p *hostedWorkflowProviderPool) Close() error {
 	p.mu.Lock()
 	p.workers = nil
 	p.mu.Unlock()
-	if p.Provider != nil {
-		closeErrs = append(closeErrs, p.Provider.Close())
-	}
 	if p.launch != nil {
 		p.launch.close()
 	}
 	return errors.Join(closeErrs...)
 }
 
-func (p *hostedWorkflowProviderPool) isStarted() bool {
-	if p == nil {
-		return false
-	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.started
-}
-
-func (p *hostedWorkflowProviderPool) startWorker(ctx context.Context) (*hostedWorkflowWorker, error) {
+func (p *hostedWorkflowWorkerPool) startWorker(ctx context.Context) (*hostedWorkflowWorker, error) {
 	startCtx, cancel := context.WithTimeout(ctx, p.policy.StartupTimeout)
 	defer cancel()
 	instance, err := startHostedWorkflowProviderInstance(startCtx, p.launch, p.hostServices, p.deps, false, nil, p.policy.DrainTimeout)
@@ -576,7 +553,7 @@ func (p *hostedWorkflowProviderPool) startWorker(ctx context.Context) (*hostedWo
 	if p.closed {
 		p.mu.Unlock()
 		_ = instance.provider.Close()
-		return nil, fmt.Errorf("hosted workflow provider %q is closed", p.name)
+		return nil, fmt.Errorf("hosted workflow provider %q is closed: %w", p.name, errHostedWorkflowWorkerPoolClosed)
 	}
 	p.nextID++
 	now := time.Now().UTC()
@@ -595,12 +572,12 @@ func (p *hostedWorkflowProviderPool) startWorker(ctx context.Context) (*hostedWo
 	return worker, nil
 }
 
-func (p *hostedWorkflowProviderPool) ensureMinReady(ctx context.Context) error {
+func (p *hostedWorkflowWorkerPool) ensureMinReady(ctx context.Context) error {
 	for {
 		p.mu.Lock()
 		if p.closed {
 			p.mu.Unlock()
-			return nil
+			return errHostedWorkflowWorkerPoolClosed
 		}
 		ready := 0
 		now := time.Now().UTC()
@@ -627,7 +604,7 @@ func (p *hostedWorkflowProviderPool) ensureMinReady(ctx context.Context) error {
 	}
 }
 
-func (p *hostedWorkflowProviderPool) healthLoop() {
+func (p *hostedWorkflowWorkerPool) healthLoop() {
 	ticker := time.NewTicker(p.policy.HealthCheckInterval)
 	defer ticker.Stop()
 	for {
@@ -662,7 +639,7 @@ func (p *hostedWorkflowProviderPool) healthLoop() {
 	}
 }
 
-func (p *hostedWorkflowProviderPool) runtimeSessionLoop() {
+func (p *hostedWorkflowWorkerPool) runtimeSessionLoop() {
 	interval := p.policy.HealthCheckInterval
 	if interval <= 0 {
 		interval = time.Second
@@ -691,7 +668,7 @@ func (p *hostedWorkflowProviderPool) runtimeSessionLoop() {
 	}
 }
 
-func (p *hostedWorkflowProviderPool) readyWorkers() []*hostedWorkflowWorker {
+func (p *hostedWorkflowWorkerPool) readyWorkers() []*hostedWorkflowWorker {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	now := time.Now().UTC()
@@ -704,7 +681,7 @@ func (p *hostedWorkflowProviderPool) readyWorkers() []*hostedWorkflowWorker {
 	return out
 }
 
-func (p *hostedWorkflowProviderPool) runtimeManagedWorkers() []*hostedWorkflowWorker {
+func (p *hostedWorkflowWorkerPool) runtimeManagedWorkers() []*hostedWorkflowWorker {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	out := make([]*hostedWorkflowWorker, 0, len(p.workers))
@@ -716,7 +693,7 @@ func (p *hostedWorkflowProviderPool) runtimeManagedWorkers() []*hostedWorkflowWo
 	return out
 }
 
-func (p *hostedWorkflowProviderPool) workerAvailableLocked(worker *hostedWorkflowWorker, now time.Time) bool {
+func (p *hostedWorkflowWorkerPool) workerAvailableLocked(worker *hostedWorkflowWorker, now time.Time) bool {
 	if worker == nil || worker.provider == nil || worker.closed || worker.closing || worker.draining {
 		return false
 	}
@@ -729,7 +706,7 @@ func (p *hostedWorkflowProviderPool) workerAvailableLocked(worker *hostedWorkflo
 	return true
 }
 
-func (p *hostedWorkflowProviderPool) acquireWorker(worker *hostedWorkflowWorker) bool {
+func (p *hostedWorkflowWorkerPool) acquireWorker(worker *hostedWorkflowWorker) bool {
 	if worker == nil {
 		return false
 	}
@@ -742,7 +719,7 @@ func (p *hostedWorkflowProviderPool) acquireWorker(worker *hostedWorkflowWorker)
 	return true
 }
 
-func (p *hostedWorkflowProviderPool) releaseWorker(worker *hostedWorkflowWorker) {
+func (p *hostedWorkflowWorkerPool) releaseWorker(worker *hostedWorkflowWorker) {
 	if worker == nil {
 		return
 	}
@@ -753,7 +730,7 @@ func (p *hostedWorkflowProviderPool) releaseWorker(worker *hostedWorkflowWorker)
 	}
 }
 
-func (p *hostedWorkflowProviderPool) refreshWorkerRuntimeSession(worker *hostedWorkflowWorker) (*pluginruntime.Session, *time.Time, error) {
+func (p *hostedWorkflowWorkerPool) refreshWorkerRuntimeSession(worker *hostedWorkflowWorker) (*pluginruntime.Session, *time.Time, error) {
 	if worker == nil {
 		return nil, nil, fmt.Errorf("runtime worker is unavailable")
 	}
@@ -788,18 +765,18 @@ func (p *hostedWorkflowProviderPool) refreshWorkerRuntimeSession(worker *hostedW
 	return session, drainAt, nil
 }
 
-func (p *hostedWorkflowProviderPool) replaceWorker(worker *hostedWorkflowWorker) {
+func (p *hostedWorkflowWorkerPool) replaceWorker(worker *hostedWorkflowWorker) {
 	p.replaceWorkerAllowNever(worker, "", false)
 }
 
-func (p *hostedWorkflowProviderPool) replaceWorkerAllowNever(worker *hostedWorkflowWorker, reason string, allowRestartPolicyNever bool) {
+func (p *hostedWorkflowWorkerPool) replaceWorkerAllowNever(worker *hostedWorkflowWorker, reason string, allowRestartPolicyNever bool) {
 	if (p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever && !allowRestartPolicyNever) || !p.markWorkerDraining(worker) {
 		return
 	}
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
-		if err := p.ensureMinReady(p.ctx); err != nil && !errors.Is(err, context.Canceled) {
+		if err := p.ensureMinReady(p.ctx); err != nil && !hostedWorkflowWorkerPoolStopped(err) {
 			slog.Warn("failed to replace hosted workflow runtime worker", "provider", p.name, "worker", worker.id, "reason", reason, "error", err)
 		}
 		if err := p.drainAndCloseWorker(worker); err != nil {
@@ -808,7 +785,11 @@ func (p *hostedWorkflowProviderPool) replaceWorkerAllowNever(worker *hostedWorkf
 	}()
 }
 
-func (p *hostedWorkflowProviderPool) markWorkerDraining(worker *hostedWorkflowWorker) bool {
+func hostedWorkflowWorkerPoolStopped(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, errHostedWorkflowWorkerPoolClosed)
+}
+
+func (p *hostedWorkflowWorkerPool) markWorkerDraining(worker *hostedWorkflowWorker) bool {
 	if worker == nil {
 		return false
 	}
@@ -821,7 +802,7 @@ func (p *hostedWorkflowProviderPool) markWorkerDraining(worker *hostedWorkflowWo
 	return true
 }
 
-func (p *hostedWorkflowProviderPool) drainAndCloseWorker(worker *hostedWorkflowWorker) error {
+func (p *hostedWorkflowWorkerPool) drainAndCloseWorker(worker *hostedWorkflowWorker) error {
 	if worker == nil {
 		return nil
 	}
@@ -857,7 +838,7 @@ func (p *hostedWorkflowProviderPool) drainAndCloseWorker(worker *hostedWorkflowW
 	return worker.provider.Close()
 }
 
-func (p *hostedWorkflowProviderPool) removeWorkerLocked(worker *hostedWorkflowWorker) {
+func (p *hostedWorkflowWorkerPool) removeWorkerLocked(worker *hostedWorkflowWorker) {
 	for i, candidate := range p.workers {
 		if candidate == worker {
 			p.workers = append(p.workers[:i], p.workers[i+1:]...)
@@ -866,7 +847,7 @@ func (p *hostedWorkflowProviderPool) removeWorkerLocked(worker *hostedWorkflowWo
 	}
 }
 
-func (p *hostedWorkflowProviderPool) runtimeSessionDrainAt(session *pluginruntime.Session, now time.Time) *time.Time {
+func (p *hostedWorkflowWorkerPool) runtimeSessionDrainAt(session *pluginruntime.Session, now time.Time) *time.Time {
 	if session == nil || session.Lifecycle == nil {
 		return nil
 	}
@@ -884,7 +865,7 @@ func (p *hostedWorkflowProviderPool) runtimeSessionDrainAt(session *pluginruntim
 	return drainAt
 }
 
-func (p *hostedWorkflowProviderPool) runtimeSessionExpiryDrainAt(lifecycle *pluginruntime.SessionLifecycle, now time.Time) time.Time {
+func (p *hostedWorkflowWorkerPool) runtimeSessionExpiryDrainAt(lifecycle *pluginruntime.SessionLifecycle, now time.Time) time.Time {
 	expiresAt := lifecycle.ExpiresAt.UTC()
 	reserve := p.policy.StartupTimeout + p.policy.DrainTimeout + p.policy.HealthCheckInterval + hostedWorkflowRuntimeLifecycleSafetyMargin
 	drainAt := expiresAt.Add(-reserve).UTC()
@@ -904,7 +885,7 @@ func (p *hostedWorkflowProviderPool) runtimeSessionExpiryDrainAt(lifecycle *plug
 	return drainAt
 }
 
-func (p *hostedWorkflowProviderPool) runtimeSessionRetirementReason(session *pluginruntime.Session, drainAt *time.Time, now time.Time) string {
+func (p *hostedWorkflowWorkerPool) runtimeSessionRetirementReason(session *pluginruntime.Session, drainAt *time.Time, now time.Time) string {
 	if session == nil {
 		return ""
 	}
@@ -923,6 +904,3 @@ func (p *hostedWorkflowProviderPool) runtimeSessionRetirementReason(session *plu
 	}
 	return fmt.Sprintf("runtime session reached drain deadline %s", drainAt.Format(time.RFC3339Nano))
 }
-
-var _ coreworkflow.Provider = (*hostedWorkflowProviderPool)(nil)
-var _ coreworkflow.ExecutionReferenceStore = (*hostedWorkflowProviderPool)(nil)

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider_test.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
@@ -40,7 +42,6 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 	}
 	entry := &config.ProviderEntry{
 		Execution: &config.ExecutionConfig{
-			Mode: config.ExecutionModeHosted,
 			Runtime: &config.HostedRuntimeConfig{
 				Provider: "gke",
 				Metadata: map[string]string{
@@ -58,7 +59,7 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 		},
 	}
 
-	provider, err := buildHostedWorkflowProvider(ctx, "temporal", entry, mustNode(t, map[string]any{
+	workers, err := buildHostedWorkflowWorkerPool(ctx, "temporal", entry, mustNode(t, map[string]any{
 		"command": "/bin/temporal-provider",
 		"config":  map[string]any{"namespace": "default"},
 	}), []runtimehost.HostService{{
@@ -66,8 +67,10 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 		EnvVar: workflowservice.DefaultHostSocketEnv,
 	}}, deps)
 	if err != nil {
-		t.Fatalf("buildHostedWorkflowProvider: %v", err)
+		t.Fatalf("buildHostedWorkflowWorkerPool: %v", err)
 	}
+	control := &recordingWorkflowControlProvider{}
+	provider := wrapWorkflowProviderWithRuntimeWorkers(control, workers)
 	result := &Result{ExtraWorkflows: []workflow.Provider{provider}}
 	t.Cleanup(func() { _ = provider.Close() })
 	assertPublicHostServicesVerified(t, deps.PublicHostServices, "workflow_host", workflowservice.DefaultHostSocketEnv)
@@ -100,8 +103,8 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 	if got := runtimeProvider.startProviderCalls(); got != 0 {
 		t.Fatalf("StartProvider calls before StartWorkflowProviders = %d, want 0", got)
 	}
-	if got := len(runtimeProvider.startPluginRequestsCopy()); got != 1 {
-		t.Fatalf("StartPlugin requests before StartWorkflowProviders = %d, want control provider only", got)
+	if got := len(runtimeProvider.startPluginRequestsCopy()); got != 0 {
+		t.Fatalf("StartPlugin requests before StartWorkflowProviders = %d, want 0", got)
 	}
 
 	if err := result.Start(ctx); err != nil {
@@ -113,15 +116,22 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 	if err := result.StartWorkflowProviders(ctx); err != nil {
 		t.Fatalf("StartWorkflowProviders: %v", err)
 	}
-	if got := runtimeProvider.startProviderCalls(); got != 3 {
-		t.Fatalf("StartProvider calls after StartWorkflowProviders = %d, want control + worker pool size 2", got)
+	workerProvider, ok := provider.(runtimeWorkerWorkflowProvider)
+	if !ok {
+		t.Fatalf("provider does not expose runtime worker readiness")
+	}
+	if err := workerProvider.WaitRuntimeWorkersReady(ctx); err != nil {
+		t.Fatalf("WaitRuntimeWorkersReady: %v", err)
+	}
+	if got := runtimeProvider.startProviderCalls(); got != 2 {
+		t.Fatalf("StartProvider calls after StartWorkflowProviders = %d, want worker pool size 2", got)
 	}
 
 	startRequests := runtimeProvider.startPluginRequestsCopy()
-	if len(startRequests) != 3 {
-		t.Fatalf("StartPlugin requests after StartWorkflowProviders = %d, want control + 2 workers", len(startRequests))
+	if len(startRequests) != 2 {
+		t.Fatalf("StartPlugin requests after StartWorkflowProviders = %d, want 2 workers", len(startRequests))
 	}
-	workerReq := startRequests[1]
+	workerReq := startRequests[0]
 	if got := workerReq.Env[workflowservice.DefaultHostSocketEnv]; got != "tcp://127.0.0.1:8080" {
 		t.Fatalf("worker env %s = %q, want public relay target", workflowservice.DefaultHostSocketEnv, got)
 	}
@@ -129,17 +139,493 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 		t.Fatalf("worker env missing %s", workflowservice.HostSocketTokenEnv())
 	}
 	sessions := runtimeProvider.startSessionRequestsCopy()
-	if len(sessions) != 3 {
-		t.Fatalf("StartSession requests = %d, want control + 2 workers", len(sessions))
+	if len(sessions) != 2 {
+		t.Fatalf("StartSession requests = %d, want 2 workers", len(sessions))
 	}
-	if got := sessions[1].Metadata["provider_kind"]; got != providermanifestKindWorkflow {
+	if got := sessions[0].Metadata["provider_kind"]; got != providermanifestKindWorkflow {
 		t.Fatalf("worker session provider_kind = %q, want %q", got, providermanifestKindWorkflow)
 	}
-	if got := sessions[1].Metadata["provider_name"]; got != "temporal" {
+	if got := sessions[0].Metadata["provider_name"]; got != "temporal" {
 		t.Fatalf("worker session provider_name = %q, want temporal", got)
 	}
-	if got := sessions[1].Metadata["workload"]; got != "temporal-workers" {
+	if got := sessions[0].Metadata["workload"]; got != "temporal-workers" {
 		t.Fatalf("worker session workload = %q, want temporal-workers", got)
+	}
+}
+
+func TestHostedWorkflowProviderPoolStartupDoesNotBlockWorkflowReadiness(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtimeProvider := &blockingStartSessionWorkflowRuntime{
+		recordingHostedWorkflowRuntime: newRecordingHostedWorkflowRuntime(t),
+		started:                        make(chan struct{}),
+	}
+	t.Cleanup(func() { _ = runtimeProvider.Close() })
+	deps := Deps{
+		BaseURL:            "http://127.0.0.1:8080",
+		EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
+		PluginRuntime:      runtimeProvider,
+		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
+	}
+	entry := &config.ProviderEntry{
+		Execution: &config.ExecutionConfig{
+			Runtime: &config.HostedRuntimeConfig{
+				Provider: "gke",
+				Pool: &config.HostedRuntimePoolConfig{
+					MinReadyInstances:   1,
+					MaxReadyInstances:   1,
+					StartupTimeout:      "5s",
+					HealthCheckInterval: "1m",
+					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+					DrainTimeout:        "50ms",
+				},
+			},
+		},
+	}
+
+	workers, err := buildHostedWorkflowWorkerPool(ctx, "temporal", entry, mustNode(t, map[string]any{
+		"command": "/bin/temporal-provider",
+	}), []runtimehost.HostService{{
+		Name:   "workflow_host",
+		EnvVar: workflowservice.DefaultHostSocketEnv,
+	}}, deps)
+	if err != nil {
+		t.Fatalf("buildHostedWorkflowWorkerPool: %v", err)
+	}
+	provider := wrapWorkflowProviderWithRuntimeWorkers(&recordingWorkflowControlProvider{}, workers)
+	result := &Result{ExtraWorkflows: []workflow.Provider{provider}}
+	t.Cleanup(func() { _ = provider.Close() })
+
+	done := make(chan error, 1)
+	go func() {
+		done <- result.StartWorkflowProviders(ctx)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("StartWorkflowProviders: %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("StartWorkflowProviders blocked on runtime worker startup")
+	}
+	select {
+	case <-runtimeProvider.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runtime worker startup did not begin")
+	}
+}
+
+func TestWorkflowConfigReconciliationWaitsForRuntimeWorkers(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	runtimeProvider := newRecordingHostedWorkflowRuntime(t)
+	t.Cleanup(func() { _ = runtimeProvider.Close() })
+	deps := Deps{
+		BaseURL:            "http://127.0.0.1:8080",
+		EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
+		PluginRuntime:      runtimeProvider,
+		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
+	}
+	entry := &config.ProviderEntry{
+		Execution: &config.ExecutionConfig{
+			Runtime: &config.HostedRuntimeConfig{
+				Provider: "gke",
+				Pool: &config.HostedRuntimePoolConfig{
+					MinReadyInstances:   1,
+					MaxReadyInstances:   1,
+					StartupTimeout:      "5s",
+					HealthCheckInterval: "1m",
+					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+					DrainTimeout:        "50ms",
+				},
+			},
+		},
+	}
+
+	workers, err := buildHostedWorkflowWorkerPool(ctx, "temporal", entry, mustNode(t, map[string]any{
+		"command": "/bin/temporal-provider",
+	}), []runtimehost.HostService{{
+		Name:   "workflow_host",
+		EnvVar: workflowservice.DefaultHostSocketEnv,
+	}}, deps)
+	if err != nil {
+		t.Fatalf("buildHostedWorkflowWorkerPool: %v", err)
+	}
+	provider := wrapWorkflowProviderWithRuntimeWorkers(&recordingWorkflowControlProvider{}, workers)
+	workflowRuntime, err := newWorkflowRuntime(&config.Config{})
+	if err != nil {
+		t.Fatalf("newWorkflowRuntime: %v", err)
+	}
+	workflowRuntime.PublishProvider("temporal", provider)
+	reconciled := make(chan struct{})
+	result := &Result{
+		ExtraWorkflows: []workflow.Provider{provider},
+		workflowConfigReconcileTasks: []workflowConfigReconcileTask{{
+			name: "temporal",
+			reconcile: func(context.Context) error {
+				if err := waitRuntimeWorkflowProviderReady(ctx, workflowRuntime, "temporal"); err != nil {
+					return err
+				}
+				close(reconciled)
+				return nil
+			},
+		}},
+	}
+	t.Cleanup(func() { _ = provider.Close() })
+
+	result.StartWorkflowConfigReconciliation(ctx)
+	select {
+	case <-reconciled:
+		t.Fatal("workflow config reconciliation ran before runtime workers were started")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if err := result.StartWorkflowProviders(ctx); err != nil {
+		t.Fatalf("StartWorkflowProviders: %v", err)
+	}
+	select {
+	case <-reconciled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("workflow config reconciliation did not run after runtime workers became ready")
+	}
+}
+
+func TestWorkflowConfigReconciliationReconcilesReadyRuntimeProvidersIndependently(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := &config.Config{
+		Providers: config.ProvidersConfig{
+			Workflow: map[string]*config.ProviderEntry{
+				"ready": {
+					Source: config.ProviderSource{Path: "stub"},
+					Execution: &config.ExecutionConfig{Runtime: &config.HostedRuntimeConfig{
+						Provider: "gke",
+						Pool: &config.HostedRuntimePoolConfig{
+							MinReadyInstances:   1,
+							MaxReadyInstances:   1,
+							StartupTimeout:      "5s",
+							HealthCheckInterval: "1m",
+							RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+							DrainTimeout:        "50ms",
+						},
+					}},
+				},
+				"stuck": {
+					Source: config.ProviderSource{Path: "stub"},
+					Execution: &config.ExecutionConfig{Runtime: &config.HostedRuntimeConfig{
+						Provider: "gke",
+						Pool: &config.HostedRuntimePoolConfig{
+							MinReadyInstances:   1,
+							MaxReadyInstances:   1,
+							StartupTimeout:      "5s",
+							HealthCheckInterval: "1m",
+							RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+							DrainTimeout:        "50ms",
+						},
+					}},
+				},
+			},
+		},
+		Workflows: config.WorkflowsConfig{
+			Schedules: map[string]config.WorkflowScheduleConfig{
+				"ready_schedule": {
+					Provider: "ready",
+					Target:   workflowConfigTestAgentTarget(),
+					Cron:     "* * * * *",
+				},
+			},
+		},
+	}
+	workflowRuntime, err := newWorkflowRuntime(cfg)
+	if err != nil {
+		t.Fatalf("newWorkflowRuntime: %v", err)
+	}
+	readyProvider := &notifyingRuntimeWorkflowControlProvider{
+		recordingWorkflowControlProvider: &recordingWorkflowControlProvider{},
+		upsertedSchedule:                 make(chan struct{}),
+	}
+	stuckProvider := &blockingRuntimeWorkflowControlProvider{
+		recordingWorkflowControlProvider: &recordingWorkflowControlProvider{},
+		waitStarted:                      make(chan struct{}),
+	}
+	workflowRuntime.PublishProvider("ready", readyProvider)
+	workflowRuntime.PublishProvider("stuck", stuckProvider)
+	reconcileWorkflowConfig := func(ctx context.Context, includeProvider workflowConfigProviderFilter) error {
+		if err := reconcileWorkflowConfigSchedules(ctx, cfg, workflowRuntime, includeProvider); err != nil {
+			return err
+		}
+		return reconcileWorkflowConfigEventTriggers(ctx, cfg, workflowRuntime, includeProvider)
+	}
+	result := &Result{
+		workflowConfigReconcileTasks: runtimeWorkflowConfigReconcileTasks(workflowRuntime, runtimePlacedWorkflowProviderNames(cfg), reconcileWorkflowConfig),
+	}
+
+	result.StartWorkflowConfigReconciliation(ctx)
+	select {
+	case <-stuckProvider.waitStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stuck provider readiness wait did not start")
+	}
+	select {
+	case <-readyProvider.upsertedSchedule:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("ready provider schedules = %d, want 1 while another provider is stuck", len(readyProvider.upsertedSchedules))
+	}
+	if got := len(stuckProvider.upsertedSchedules); got != 0 {
+		t.Fatalf("stuck provider schedules = %d, want 0 before readiness", got)
+	}
+}
+
+func TestHostedWorkflowProviderPoolRejectsIncompatibleStartupSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtimeProvider := &staleSessionWorkflowRuntime{
+		recordingHostedWorkflowRuntime: newRecordingHostedWorkflowRuntime(t),
+	}
+	t.Cleanup(func() { _ = runtimeProvider.Close() })
+	deps := Deps{
+		BaseURL:            "http://127.0.0.1:8080",
+		EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
+		PluginRuntime:      runtimeProvider,
+		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
+	}
+	entry := &config.ProviderEntry{
+		Execution: &config.ExecutionConfig{
+			Runtime: &config.HostedRuntimeConfig{
+				Provider: "gke",
+				Pool: &config.HostedRuntimePoolConfig{
+					MinReadyInstances:   1,
+					MaxReadyInstances:   1,
+					StartupTimeout:      "5s",
+					HealthCheckInterval: "1m",
+					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+					DrainTimeout:        "50ms",
+				},
+			},
+		},
+	}
+
+	pool, err := buildHostedWorkflowWorkerPool(ctx, "temporal", entry, mustNode(t, map[string]any{
+		"command": "/bin/temporal-provider",
+	}), []runtimehost.HostService{{
+		Name:   "workflow_host",
+		EnvVar: workflowservice.DefaultHostSocketEnv,
+	}}, deps)
+	if err != nil {
+		t.Fatalf("buildHostedWorkflowWorkerPool: %v", err)
+	}
+	t.Cleanup(func() { _ = pool.Close() })
+	if err := pool.Start(ctx); err != nil {
+		t.Fatalf("pool.Start: %v", err)
+	}
+	waitForHostedWorkflowRuntimeStartSessionRequests(t, runtimeProvider.recordingHostedWorkflowRuntime, 1)
+	if got := len(runtimeProvider.startPluginRequestsCopy()); got != 0 {
+		t.Fatalf("StartPlugin requests = %d, want 0 for incompatible runtime session", got)
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	if err := pool.WaitReady(waitCtx); err == nil {
+		t.Fatal("pool.WaitReady: expected timeout for incompatible runtime session")
+	}
+	if got := len(pool.readyWorkers()); got != 0 {
+		t.Fatalf("ready workers = %d, want 0 for incompatible runtime session", got)
+	}
+}
+
+func TestHostedWorkflowProviderPoolClosedStartLoopDoesNotMarkReady(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := &hostedWorkflowWorkerPool{
+		name:   "temporal",
+		ctx:    ctx,
+		cancel: cancel,
+		ready:  make(chan struct{}),
+		policy: config.HostedRuntimeLifecyclePolicy{
+			MinReadyInstances:   1,
+			HealthCheckInterval: time.Hour,
+			RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+		},
+	}
+	pool.mu.Lock()
+	pool.closed = true
+	pool.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pool.startLoop()
+	}()
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		select {
+		case <-pool.ready:
+			t.Fatal("pool marked ready after it was closed")
+		default:
+		}
+		t.Fatal("startLoop did not exit after pool closed")
+	}
+	select {
+	case <-pool.ready:
+		t.Fatal("pool marked ready after it was closed")
+	default:
+	}
+}
+
+func TestHostedWorkflowProviderPoolCloseUnblocksWaitReady(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pool := &hostedWorkflowWorkerPool{
+		name:   "temporal",
+		ctx:    ctx,
+		cancel: cancel,
+		ready:  make(chan struct{}),
+		policy: config.HostedRuntimeLifecyclePolicy{
+			MinReadyInstances:   1,
+			HealthCheckInterval: time.Hour,
+			RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+		},
+	}
+	t.Cleanup(func() { _ = pool.Close() })
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- pool.WaitReady(context.Background())
+	}()
+	select {
+	case err := <-waitDone:
+		t.Fatalf("WaitReady returned before pool close: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	if err := pool.Close(); err != nil {
+		t.Fatalf("pool.Close: %v", err)
+	}
+	select {
+	case err := <-waitDone:
+		if !errors.Is(err, errHostedWorkflowWorkerPoolClosed) {
+			t.Fatalf("WaitReady error = %v, want hosted workflow worker pool closed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitReady did not unblock after pool close")
+	}
+}
+
+func TestWorkflowConfigReconciliationFiltersRuntimePlacedProviders(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := &config.Config{
+		Providers: config.ProvidersConfig{
+			Workflow: map[string]*config.ProviderEntry{
+				"local": {Source: config.ProviderSource{Path: "stub"}},
+				"runtime": {
+					Source: config.ProviderSource{Path: "stub"},
+					Execution: &config.ExecutionConfig{Runtime: &config.HostedRuntimeConfig{
+						Provider: "gke",
+						Pool: &config.HostedRuntimePoolConfig{
+							MinReadyInstances:   1,
+							MaxReadyInstances:   1,
+							StartupTimeout:      "5s",
+							HealthCheckInterval: "1m",
+							RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+							DrainTimeout:        "50ms",
+						},
+					}},
+				},
+			},
+		},
+		Workflows: config.WorkflowsConfig{
+			Schedules: map[string]config.WorkflowScheduleConfig{
+				"local_schedule": {
+					Provider: "local",
+					Target:   workflowConfigTestAgentTarget(),
+					Cron:     "* * * * *",
+				},
+				"runtime_schedule": {
+					Provider: "runtime",
+					Target:   workflowConfigTestAgentTarget(),
+					Cron:     "* * * * *",
+				},
+			},
+			EventTriggers: map[string]config.WorkflowEventTriggerConfig{
+				"local_trigger": {
+					Provider: "local",
+					Target:   workflowConfigTestAgentTarget(),
+					Match:    config.WorkflowEventMatch{Type: "local.changed"},
+				},
+				"runtime_trigger": {
+					Provider: "runtime",
+					Target:   workflowConfigTestAgentTarget(),
+					Match:    config.WorkflowEventMatch{Type: "runtime.changed"},
+				},
+			},
+		},
+	}
+	workflowRuntime, err := newWorkflowRuntime(cfg)
+	if err != nil {
+		t.Fatalf("newWorkflowRuntime: %v", err)
+	}
+	localProvider := &recordingWorkflowControlProvider{}
+	runtimeProvider := &recordingWorkflowControlProvider{}
+	workflowRuntime.PublishProvider("local", localProvider)
+	workflowRuntime.PublishProvider("runtime", runtimeProvider)
+
+	runtimePlaced := runtimePlacedWorkflowProviderNames(cfg)
+	localFilter := func(providerName string) bool {
+		_, ok := runtimePlaced[providerName]
+		return !ok
+	}
+	runtimeFilter := func(providerName string) bool {
+		_, ok := runtimePlaced[providerName]
+		return ok
+	}
+
+	if err := reconcileWorkflowConfigSchedules(ctx, cfg, workflowRuntime, localFilter); err != nil {
+		t.Fatalf("reconcile local schedules: %v", err)
+	}
+	if err := reconcileWorkflowConfigEventTriggers(ctx, cfg, workflowRuntime, localFilter); err != nil {
+		t.Fatalf("reconcile local event triggers: %v", err)
+	}
+	if got := len(localProvider.upsertedSchedules); got != 1 {
+		t.Fatalf("local upserted schedules = %d, want 1", got)
+	}
+	if got := len(localProvider.upsertedEventTriggers); got != 1 {
+		t.Fatalf("local upserted event triggers = %d, want 1", got)
+	}
+	if got := len(runtimeProvider.upsertedSchedules); got != 0 {
+		t.Fatalf("runtime upserted schedules during local reconcile = %d, want 0", got)
+	}
+	if got := len(runtimeProvider.upsertedEventTriggers); got != 0 {
+		t.Fatalf("runtime upserted event triggers during local reconcile = %d, want 0", got)
+	}
+
+	if err := reconcileWorkflowConfigSchedules(ctx, cfg, workflowRuntime, runtimeFilter); err != nil {
+		t.Fatalf("reconcile runtime schedules: %v", err)
+	}
+	if err := reconcileWorkflowConfigEventTriggers(ctx, cfg, workflowRuntime, runtimeFilter); err != nil {
+		t.Fatalf("reconcile runtime event triggers: %v", err)
+	}
+	if got := len(runtimeProvider.upsertedSchedules); got != 1 {
+		t.Fatalf("runtime upserted schedules = %d, want 1", got)
+	}
+	if got := len(runtimeProvider.upsertedEventTriggers); got != 1 {
+		t.Fatalf("runtime upserted event triggers = %d, want 1", got)
+	}
+}
+
+func workflowConfigTestAgentTarget() *config.WorkflowTargetConfig {
+	return &config.WorkflowTargetConfig{
+		Agent: &config.WorkflowAgentConfig{
+			Prompt: "summarize",
+		},
 	}
 }
 
@@ -171,27 +657,34 @@ func TestHostedWorkflowProviderKeepsSharedRuntimeOpen(t *testing.T) {
 	}
 	entry := &config.ProviderEntry{
 		Execution: &config.ExecutionConfig{
-			Mode: config.ExecutionModeHosted,
 			Runtime: &config.HostedRuntimeConfig{
 				Provider: "gke",
+				Pool: &config.HostedRuntimePoolConfig{
+					MinReadyInstances:   1,
+					MaxReadyInstances:   1,
+					StartupTimeout:      "5s",
+					HealthCheckInterval: "1m",
+					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+					DrainTimeout:        "50ms",
+				},
 			},
 		},
 	}
 
-	provider, err := buildHostedWorkflowProvider(ctx, "temporal", entry, mustNode(t, map[string]any{
+	workers, err := buildHostedWorkflowWorkerPool(ctx, "temporal", entry, mustNode(t, map[string]any{
 		"command": "/bin/temporal-provider",
 	}), []runtimehost.HostService{{
 		Name:   "workflow_host",
 		EnvVar: workflowservice.DefaultHostSocketEnv,
 	}}, deps)
 	if err != nil {
-		t.Fatalf("buildHostedWorkflowProvider: %v", err)
+		t.Fatalf("buildHostedWorkflowWorkerPool: %v", err)
 	}
-	if err := provider.Close(); err != nil {
-		t.Fatalf("provider.Close: %v", err)
+	if err := workers.Close(); err != nil {
+		t.Fatalf("workers.Close: %v", err)
 	}
 	if got := runtimeProvider.closeCalls.Load(); got != 0 {
-		t.Fatalf("runtime Close calls after provider.Close = %d, want 0 for shared runtime", got)
+		t.Fatalf("runtime Close calls after workers.Close = %d, want 0 for shared runtime", got)
 	}
 }
 
@@ -209,7 +702,6 @@ func TestHostedWorkflowProviderPoolDrainWaitsBeforeClosingWorker(t *testing.T) {
 	}
 	entry := &config.ProviderEntry{
 		Execution: &config.ExecutionConfig{
-			Mode: config.ExecutionModeHosted,
 			Runtime: &config.HostedRuntimeConfig{
 				Provider: "gke",
 				Pool: &config.HostedRuntimePoolConfig{
@@ -224,22 +716,21 @@ func TestHostedWorkflowProviderPoolDrainWaitsBeforeClosingWorker(t *testing.T) {
 		},
 	}
 
-	provider, err := buildHostedWorkflowProvider(ctx, "temporal", entry, mustNode(t, map[string]any{
+	pool, err := buildHostedWorkflowWorkerPool(ctx, "temporal", entry, mustNode(t, map[string]any{
 		"command": "/bin/temporal-provider",
 	}), []runtimehost.HostService{{
 		Name:   "workflow_host",
 		EnvVar: workflowservice.DefaultHostSocketEnv,
 	}}, deps)
 	if err != nil {
-		t.Fatalf("buildHostedWorkflowProvider: %v", err)
+		t.Fatalf("buildHostedWorkflowWorkerPool: %v", err)
 	}
-	t.Cleanup(func() { _ = provider.Close() })
-	pool, ok := provider.(*hostedWorkflowProviderPool)
-	if !ok {
-		t.Fatalf("provider = %T, want *hostedWorkflowProviderPool", provider)
-	}
+	t.Cleanup(func() { _ = pool.Close() })
 	if err := pool.Start(ctx); err != nil {
 		t.Fatalf("pool.Start: %v", err)
+	}
+	if err := pool.WaitReady(ctx); err != nil {
+		t.Fatalf("pool.WaitReady: %v", err)
 	}
 	workers := pool.readyWorkers()
 	if len(workers) != 1 {
@@ -282,6 +773,201 @@ type recordingHostedWorkflowRuntime struct {
 	startPluginRequests []pluginruntime.StartPluginRequest
 	servers             map[string]*recordingHostedWorkflowServer
 	closeCalls          atomic.Int32
+}
+
+type blockingStartSessionWorkflowRuntime struct {
+	*recordingHostedWorkflowRuntime
+	started chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingStartSessionWorkflowRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
+	r.once.Do(func() {
+		close(r.started)
+	})
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+type staleSessionWorkflowRuntime struct {
+	*recordingHostedWorkflowRuntime
+}
+
+func (r *staleSessionWorkflowRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
+	session, err := r.recordingHostedWorkflowRuntime.GetSession(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if session.Metadata == nil {
+		session.Metadata = map[string]string{}
+	}
+	for key, value := range staleRuntimeSessionForTest().Metadata {
+		session.Metadata[key] = value
+	}
+	return session, nil
+}
+
+type notifyingRuntimeWorkflowControlProvider struct {
+	*recordingWorkflowControlProvider
+	upsertedSchedule chan struct{}
+	once             sync.Once
+}
+
+func (p *notifyingRuntimeWorkflowControlProvider) WaitRuntimeWorkersReady(context.Context) error {
+	return nil
+}
+
+func (p *notifyingRuntimeWorkflowControlProvider) UpsertSchedule(ctx context.Context, req workflow.UpsertScheduleRequest) (*workflow.Schedule, error) {
+	schedule, err := p.recordingWorkflowControlProvider.UpsertSchedule(ctx, req)
+	if err == nil {
+		p.once.Do(func() {
+			close(p.upsertedSchedule)
+		})
+	}
+	return schedule, err
+}
+
+type blockingRuntimeWorkflowControlProvider struct {
+	*recordingWorkflowControlProvider
+	waitStarted chan struct{}
+	once        sync.Once
+}
+
+func (p *blockingRuntimeWorkflowControlProvider) WaitRuntimeWorkersReady(ctx context.Context) error {
+	p.once.Do(func() {
+		close(p.waitStarted)
+	})
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+type recordingWorkflowControlProvider struct {
+	noopWorkflowProvider
+	refs                  map[string]*workflow.ExecutionReference
+	schedules             map[string]*workflow.Schedule
+	upsertedSchedules     []workflow.UpsertScheduleRequest
+	eventTriggers         map[string]*workflow.EventTrigger
+	upsertedEventTriggers []workflow.UpsertEventTriggerRequest
+}
+
+func (p *recordingWorkflowControlProvider) PutExecutionReference(_ context.Context, ref *workflow.ExecutionReference) (*workflow.ExecutionReference, error) {
+	if p.refs == nil {
+		p.refs = map[string]*workflow.ExecutionReference{}
+	}
+	stored := cloneWorkflowExecutionReference(ref)
+	p.refs[stored.ID] = stored
+	return cloneWorkflowExecutionReference(stored), nil
+}
+
+func (p *recordingWorkflowControlProvider) GetExecutionReference(_ context.Context, id string) (*workflow.ExecutionReference, error) {
+	ref := p.refs[id]
+	if ref == nil {
+		return nil, status.Error(codes.NotFound, "execution reference not found")
+	}
+	return cloneWorkflowExecutionReference(ref), nil
+}
+
+func (p *recordingWorkflowControlProvider) ListExecutionReferences(_ context.Context, subjectID string) ([]*workflow.ExecutionReference, error) {
+	out := make([]*workflow.ExecutionReference, 0, len(p.refs))
+	for _, ref := range p.refs {
+		if ref == nil {
+			continue
+		}
+		if subjectID != "" && ref.SubjectID != subjectID {
+			continue
+		}
+		out = append(out, cloneWorkflowExecutionReference(ref))
+	}
+	return out, nil
+}
+
+func (p *recordingWorkflowControlProvider) GetSchedule(_ context.Context, req workflow.GetScheduleRequest) (*workflow.Schedule, error) {
+	if schedule := p.schedules[req.ScheduleID]; schedule != nil {
+		return cloneWorkflowSchedule(schedule), nil
+	}
+	return nil, core.ErrNotFound
+}
+
+func (p *recordingWorkflowControlProvider) UpsertSchedule(_ context.Context, req workflow.UpsertScheduleRequest) (*workflow.Schedule, error) {
+	p.upsertedSchedules = append(p.upsertedSchedules, req)
+	if p.schedules == nil {
+		p.schedules = map[string]*workflow.Schedule{}
+	}
+	schedule := &workflow.Schedule{
+		ID:           req.ScheduleID,
+		Cron:         req.Cron,
+		Timezone:     req.Timezone,
+		Target:       req.Target,
+		Paused:       req.Paused,
+		CreatedBy:    req.RequestedBy,
+		ExecutionRef: req.ExecutionRef,
+	}
+	p.schedules[req.ScheduleID] = schedule
+	return cloneWorkflowSchedule(schedule), nil
+}
+
+func (p *recordingWorkflowControlProvider) ListSchedules(context.Context, workflow.ListSchedulesRequest) ([]*workflow.Schedule, error) {
+	out := make([]*workflow.Schedule, 0, len(p.schedules))
+	for _, schedule := range p.schedules {
+		out = append(out, cloneWorkflowSchedule(schedule))
+	}
+	return out, nil
+}
+
+func (p *recordingWorkflowControlProvider) GetEventTrigger(_ context.Context, req workflow.GetEventTriggerRequest) (*workflow.EventTrigger, error) {
+	if trigger := p.eventTriggers[req.TriggerID]; trigger != nil {
+		return cloneWorkflowEventTrigger(trigger), nil
+	}
+	return nil, core.ErrNotFound
+}
+
+func (p *recordingWorkflowControlProvider) UpsertEventTrigger(_ context.Context, req workflow.UpsertEventTriggerRequest) (*workflow.EventTrigger, error) {
+	p.upsertedEventTriggers = append(p.upsertedEventTriggers, req)
+	if p.eventTriggers == nil {
+		p.eventTriggers = map[string]*workflow.EventTrigger{}
+	}
+	trigger := &workflow.EventTrigger{
+		ID:           req.TriggerID,
+		Match:        req.Match,
+		Target:       req.Target,
+		Paused:       req.Paused,
+		CreatedBy:    req.RequestedBy,
+		ExecutionRef: req.ExecutionRef,
+	}
+	p.eventTriggers[req.TriggerID] = trigger
+	return cloneWorkflowEventTrigger(trigger), nil
+}
+
+func (p *recordingWorkflowControlProvider) ListEventTriggers(context.Context, workflow.ListEventTriggersRequest) ([]*workflow.EventTrigger, error) {
+	out := make([]*workflow.EventTrigger, 0, len(p.eventTriggers))
+	for _, trigger := range p.eventTriggers {
+		out = append(out, cloneWorkflowEventTrigger(trigger))
+	}
+	return out, nil
+}
+
+func cloneWorkflowExecutionReference(ref *workflow.ExecutionReference) *workflow.ExecutionReference {
+	if ref == nil {
+		return nil
+	}
+	clone := *ref
+	return &clone
+}
+
+func cloneWorkflowSchedule(schedule *workflow.Schedule) *workflow.Schedule {
+	if schedule == nil {
+		return nil
+	}
+	clone := *schedule
+	return &clone
+}
+
+func cloneWorkflowEventTrigger(trigger *workflow.EventTrigger) *workflow.EventTrigger {
+	if trigger == nil {
+		return nil
+	}
+	clone := *trigger
+	return &clone
 }
 
 func newRecordingHostedWorkflowRuntime(t *testing.T) *recordingHostedWorkflowRuntime {
@@ -433,6 +1119,18 @@ func (r *recordingHostedWorkflowRuntime) startProviderCalls() int32 {
 		total += server.startProviderCalls.Load()
 	}
 	return total
+}
+
+func waitForHostedWorkflowRuntimeStartSessionRequests(t *testing.T, runtimeProvider *recordingHostedWorkflowRuntime, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := len(runtimeProvider.startSessionRequestsCopy()); got >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("StartSession requests = %d, want at least %d", len(runtimeProvider.startSessionRequestsCopy()), want)
 }
 
 func (r *recordingHostedWorkflowRuntime) cleanupServer(sessionID string) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1377,7 +1377,7 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 }
 
 func effectiveConfiguredHostedRuntime(ctx context.Context, configPath string, entry *config.ProviderEntry, deps Deps) (config.EffectiveHostedRuntime, pluginruntime.Provider, bool, error) {
-	if entry == nil || !entry.UsesHostedExecution() {
+	if entry == nil || !entry.UsesRuntimePlacement() {
 		return config.EffectiveHostedRuntime{}, nil, false, nil
 	}
 	explicitRuntimeConfig := providerEntryHostedRuntimeConfig(entry)
@@ -1424,10 +1424,10 @@ func providerEntryHostedRuntimeConfig(entry *config.ProviderEntry) config.Effect
 	}
 	runtimeCfg := entry.HostedRuntimeConfig()
 	if runtimeCfg == nil {
-		return config.EffectiveHostedRuntime{Enabled: entry.UsesHostedExecution()}
+		return config.EffectiveHostedRuntime{Enabled: entry.UsesRuntimePlacement()}
 	}
 	effective := config.EffectiveHostedRuntime{
-		Enabled:       entry.UsesHostedExecution(),
+		Enabled:       entry.UsesRuntimePlacement(),
 		ProviderName:  strings.TrimSpace(runtimeCfg.Provider),
 		Template:      strings.TrimSpace(runtimeCfg.Template),
 		Image:         strings.TrimSpace(runtimeCfg.Image),

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -22,7 +22,7 @@ type desiredWorkflowConfigEventTrigger struct {
 	trigger      config.WorkflowEventTriggerConfig
 }
 
-func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Config, runtime *workflowRuntime) error {
+func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, includeProvider workflowConfigProviderFilter) error {
 	if cfg == nil || runtime == nil {
 		return nil
 	}
@@ -33,6 +33,9 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 
 	for _, rowID := range slices.Sorted(maps.Keys(desired)) {
 		desiredEntry := desired[rowID]
+		if !workflowConfigProviderIncluded(includeProvider, desiredEntry.ProviderName) {
+			continue
+		}
 		trigger := desiredEntry.trigger
 		target := workflowConfigTarget(trigger.Target)
 		pluginName := workflowConfigTargetLabel(target)
@@ -96,7 +99,7 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 		}
 	}
 
-	if err := cleanupRemovedWorkflowConfigEventTriggers(ctx, runtime, desired); err != nil {
+	if err := cleanupRemovedWorkflowConfigEventTriggers(ctx, runtime, desired, includeProvider); err != nil {
 		return err
 	}
 	return nil
@@ -124,13 +127,19 @@ func desiredWorkflowConfigEventTriggers(cfg *config.Config) (map[string]desiredW
 	return desired, nil
 }
 
-func cleanupRemovedWorkflowConfigEventTriggers(ctx context.Context, runtime *workflowRuntime, desired map[string]desiredWorkflowConfigEventTrigger) error {
+func cleanupRemovedWorkflowConfigEventTriggers(ctx context.Context, runtime *workflowRuntime, desired map[string]desiredWorkflowConfigEventTrigger, includeProvider workflowConfigProviderFilter) error {
 	desiredByProviderTrigger := make(map[string]struct{}, len(desired))
 	for rowID := range desired {
 		entry := desired[rowID]
+		if !workflowConfigProviderIncluded(includeProvider, entry.ProviderName) {
+			continue
+		}
 		desiredByProviderTrigger[workflowConfigProviderObjectKey(entry.ProviderName, entry.TriggerID)] = struct{}{}
 	}
 	for _, providerName := range runtime.ProviderNames() {
+		if !workflowConfigProviderIncluded(includeProvider, providerName) {
+			continue
+		}
 		provider, err := runtime.ResolveProvider(providerName)
 		if err != nil {
 			return fmt.Errorf("bootstrap: cleanup workflow event triggers requires provider %q: %w", providerName, err)

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -32,7 +32,9 @@ type desiredWorkflowConfigSchedule struct {
 	schedule     config.WorkflowScheduleConfig
 }
 
-func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, runtime *workflowRuntime) error {
+type workflowConfigProviderFilter func(providerName string) bool
+
+func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, includeProvider workflowConfigProviderFilter) error {
 	if cfg == nil || runtime == nil {
 		return nil
 	}
@@ -43,6 +45,9 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 
 	for _, rowID := range slices.Sorted(maps.Keys(desired)) {
 		desiredEntry := desired[rowID]
+		if !workflowConfigProviderIncluded(includeProvider, desiredEntry.ProviderName) {
+			continue
+		}
 		schedule := desiredEntry.schedule
 		target := workflowConfigTarget(schedule.Target)
 		pluginName := workflowConfigTargetLabel(target)
@@ -113,10 +118,17 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 		}
 	}
 
-	if err := cleanupRemovedWorkflowConfigSchedules(ctx, runtime, desired); err != nil {
+	if err := cleanupRemovedWorkflowConfigSchedules(ctx, runtime, desired, includeProvider); err != nil {
 		return err
 	}
 	return nil
+}
+
+func workflowConfigProviderIncluded(includeProvider workflowConfigProviderFilter, providerName string) bool {
+	if includeProvider == nil {
+		return true
+	}
+	return includeProvider(strings.TrimSpace(providerName))
 }
 
 func workflowConfigScheduleDefinitionMatches(existing *coreworkflow.Schedule, target coreworkflow.Target, schedule config.WorkflowScheduleConfig) bool {
@@ -155,13 +167,19 @@ func isWorkflowObjectNotFound(err error) bool {
 	return errors.Is(err, core.ErrNotFound) || status.Code(err) == codes.NotFound
 }
 
-func cleanupRemovedWorkflowConfigSchedules(ctx context.Context, runtime *workflowRuntime, desired map[string]desiredWorkflowConfigSchedule) error {
+func cleanupRemovedWorkflowConfigSchedules(ctx context.Context, runtime *workflowRuntime, desired map[string]desiredWorkflowConfigSchedule, includeProvider workflowConfigProviderFilter) error {
 	desiredByProviderSchedule := make(map[string]struct{}, len(desired))
 	for rowID := range desired {
 		entry := desired[rowID]
+		if !workflowConfigProviderIncluded(includeProvider, entry.ProviderName) {
+			continue
+		}
 		desiredByProviderSchedule[workflowConfigProviderObjectKey(entry.ProviderName, entry.ScheduleID)] = struct{}{}
 	}
 	for _, providerName := range runtime.ProviderNames() {
+		if !workflowConfigProviderIncluded(includeProvider, providerName) {
+			continue
+		}
 		provider, err := runtime.ResolveProvider(providerName)
 		if err != nil {
 			return fmt.Errorf("bootstrap: cleanup workflow schedules requires provider %q: %w", providerName, err)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1133,6 +1133,10 @@ func (e *ProviderEntry) EffectiveAllowedHosts() []string {
 }
 
 func (e *ProviderEntry) UsesHostedExecution() bool {
+	return e.UsesRuntimePlacement()
+}
+
+func (e *ProviderEntry) UsesRuntimePlacement() bool {
 	if e == nil {
 		return false
 	}

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -4068,7 +4068,7 @@ server:
 		}
 	})
 
-	t.Run("accepts hosted workflow runtime without pool", func(t *testing.T) {
+	t.Run("rejects workflow runtime without pool", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -4089,13 +4089,12 @@ runtime:
 server:
   encryptionKey: server-key
 `)
-		cfg, err := Load(path)
-		if err != nil {
-			t.Fatalf("Load: %v", err)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
 		}
-		runtimeCfg := cfg.Providers.Workflow["temporal"].Execution.Runtime
-		if runtimeCfg == nil || runtimeCfg.Provider != "hosted" {
-			t.Fatalf("workflow execution runtime = %#v", runtimeCfg)
+		if !strings.Contains(err.Error(), "providers.workflow.temporal.execution.runtime.pool is required for runtime-placed workflow providers") {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -1082,7 +1082,7 @@ func validateAgentProviderFields(cfg *Config, name string, entry *ProviderEntry)
 	if _, err := cfg.EffectiveHostedRuntime(subject, entry); err != nil {
 		return err
 	}
-	if entry.UsesHostedExecution() {
+	if entry.UsesRuntimePlacement() {
 		if err := validateHostedAgentRuntimeLifecyclePolicy(subject, entry); err != nil {
 			return err
 		}
@@ -1211,8 +1211,11 @@ func validateHostedAgentRuntimeLifecyclePolicy(subject string, entry *ProviderEn
 
 func validateHostedWorkflowRuntimeLifecyclePolicy(subject string, entry *ProviderEntry) error {
 	runtimeCfg, runtimePath := hostedRuntimeConfigAndPath(subject, entry)
-	if runtimeCfg == nil || !runtimeCfg.LifecyclePolicyFieldsSet() {
-		return nil
+	if runtimeCfg == nil {
+		return fmt.Errorf("config validation: %s is required for runtime-placed workflow providers", runtimePath)
+	}
+	if !runtimeCfg.LifecyclePolicyFieldsSet() {
+		return fmt.Errorf("config validation: %s.pool is required for runtime-placed workflow providers", runtimePath)
 	}
 	if err := validateHostedRuntimeLifecyclePolicy(subject, entry, false, "workflow"); err != nil {
 		return err
@@ -1225,7 +1228,7 @@ func validateHostedWorkflowRuntimeLifecyclePolicy(subject string, entry *Provide
 }
 
 func validateHostedRuntimeLifecyclePolicy(subject string, entry *ProviderEntry, requireIndexedDB bool, providerKind string) error {
-	if entry == nil || !entry.UsesHostedExecution() {
+	if entry == nil || !entry.UsesRuntimePlacement() {
 		return nil
 	}
 	runtimeCfg, runtimePath := hostedRuntimeConfigAndPath(subject, entry)
@@ -1308,7 +1311,7 @@ func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEnt
 	if _, err := cfg.EffectiveHostedRuntime(subject, entry); err != nil {
 		return err
 	}
-	if entry.UsesHostedExecution() {
+	if entry.UsesRuntimePlacement() {
 		if err := validateHostedWorkflowRuntimeLifecyclePolicy(subject, entry); err != nil {
 			return err
 		}

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -314,26 +314,16 @@ func ResolveEffectiveExecution(configPath string, entry *ProviderEntry, selected
 	if entry == nil {
 		return EffectiveExecution{Mode: ExecutionModeLocal}, nil
 	}
-	mode := ExecutionModeLocal
 	providerPath := "execution.runtime.provider"
 	var runtimeCfg *HostedRuntimeConfig
+	enabled := false
 	if entry.Execution != nil {
-		mode = entry.Execution.Mode
-		if mode == "" {
-			if entry.Execution.Runtime != nil {
-				mode = ExecutionModeHosted
-			} else {
-				mode = ExecutionModeLocal
-			}
-		}
 		runtimeCfg = entry.Execution.Runtime
+		mode := ExecutionMode(strings.ToLower(strings.TrimSpace(string(entry.Execution.Mode))))
+		enabled = runtimeCfg != nil || mode == ExecutionModeHosted
 	}
-	switch mode {
-	case "", ExecutionModeLocal:
+	if !enabled {
 		return EffectiveExecution{Mode: ExecutionModeLocal}, nil
-	case ExecutionModeHosted:
-	default:
-		return EffectiveExecution{}, fmt.Errorf("config validation: %s.execution.mode must be %q or %q, got %q", configPath, ExecutionModeLocal, ExecutionModeHosted, mode)
 	}
 	if runtimeCfg == nil {
 		runtimeCfg = &HostedRuntimeConfig{}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -240,6 +240,7 @@ func serveRuntime(ctx context.Context, cfg *config.Config, connMaps bootstrap.Co
 		return err
 	}
 	close(workflowProvidersReady)
+	result.StartWorkflowConfigReconciliation(ctx)
 	slog.Info("workflow providers ready", "count", len(result.ExtraWorkflows))
 
 	mcpHandler, err := newMCPHandler(cfg, connMaps, result, mcpInvoker)


### PR DESCRIPTION
## Summary

- Replace the hosted workflow provider proxy from #1820 with a cleaner split: gestaltd always builds the local workflow provider as the control surface, and runtime placement only owns remote worker capacity.
- Add an internal runtime worker wrapper so StartWorkflowProviders starts workflow worker pools asynchronously without starting a hosted control provider.
- Split workflow config reconciliation by provider placement: local workflow providers reconcile during bootstrap; runtime-placed workflow providers reconcile in independent per-provider tasks that wait only for that provider workers to be ready and retry only that provider on failure.
- Require execution.runtime.pool for runtime-placed workflow providers, reject stale/incompatible runtime sessions during worker startup, and preserve drain behavior on shutdown.

Supersedes #1820. Pairs with valon-technologies/gestalt-providers#643 for the Temporal provider Start contract.

## Interface Changes

- Provider placement is inferred from execution.runtime. execution.mode remains accepted for compatibility but is no longer needed for workflow runtime placement.

```yaml
providers:
  workflow:
    temporal:
      source:
        repo: valon
        package: github.com/valon-technologies/gestalt-providers/workflow/temporal
        version: 0.0.1-alpha.x
      execution:
        runtime:
          provider: kubernetes
          pool:
            minReadyInstances: 1
            maxReadyInstances: 1
            startupTimeout: 5m
            healthCheckInterval: 30s
            restartPolicy: always
            drainTimeout: 2m
```

- Internal workflow provider boundary: workflow providers remain coreworkflow.Provider; runtime-placed providers are wrapped only to start and observe worker capacity.

```go
type runtimeWorkerWorkflowProvider interface {
    WaitRuntimeWorkersReady(context.Context) error
}

func (p *workflowProviderWithRuntimeWorkers) Start(ctx context.Context) error {
    return p.workers.Start(ctx) // starts remote workers only
}
```

- Example layer usage:

```go
// Workflow provider factory builds the local control provider.
provider, _ := factories.Workflow(ctx, name, node, hostServices, deps)

// gestaltd attaches runtime workers when execution.runtime is configured.
workers, _ := buildHostedWorkflowWorkerPool(ctx, name, entry, node, hostServices, deps)
provider = wrapWorkflowProviderWithRuntimeWorkers(provider, workers)

// Runtime worker sessions still run the same provider binary remotely.
remote, _ := workflowservice.NewRemote(ctx, workflowservice.RemoteConfig{...})
_ = remote.Start(ctx)
```

- Deployer behavior: agent providers can keep using the existing GKE agent sandbox runtime, while workflow providers can point at a generic Kubernetes runtime via providers.workflow.<name>.execution.runtime.provider. The workflow provider and runtime provider contracts do not need to know about each others implementation details beyond runtime session/plugin launch and workflow host-service bindings.