### PR TITLE
Add provider-level runtime config

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -415,6 +415,7 @@ type ProviderEntry struct {
 	IndexedDB         *HostIndexedDBBindingConfig   `yaml:"indexeddb,omitempty"`
 	Cache             []string                      `yaml:"cache,omitempty"`
 	S3                []string                      `yaml:"s3,omitempty"`
+	Runtime           *HostedRuntimeConfig          `yaml:"runtime,omitempty"`
 	Execution         *ExecutionConfig              `yaml:"execution,omitempty"`
 	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
 	MCP               bool                          `yaml:"mcp,omitempty"`
@@ -942,6 +943,7 @@ func (f providerEntryFields) toProviderEntry() ProviderEntry {
 
 func providerEntryFieldsFromEntry(e ProviderEntry) providerEntryFields {
 	e.Egress = cloneProviderEgressConfig(e.Egress)
+	e.Runtime = cloneHostedRuntimeConfig(e.Runtime)
 	e.Execution = cloneExecutionConfig(e.Execution)
 	e.Dev = cloneProviderEntryDevConfig(e.Dev)
 	e.Harnesses = cloneProviderEntryHarnessConfigMap(e.Harnesses)
@@ -1140,6 +1142,9 @@ func (e *ProviderEntry) UsesRuntimePlacement() bool {
 	if e == nil {
 		return false
 	}
+	if e.Runtime != nil {
+		return true
+	}
 	if e.Execution != nil {
 		mode := ExecutionMode(strings.ToLower(strings.TrimSpace(string(e.Execution.Mode))))
 		if mode == "" {
@@ -1153,6 +1158,9 @@ func (e *ProviderEntry) UsesRuntimePlacement() bool {
 func (e *ProviderEntry) HostedRuntimeConfig() *HostedRuntimeConfig {
 	if e == nil {
 		return nil
+	}
+	if e.Runtime != nil {
+		return e.Runtime
 	}
 	if e.Execution != nil {
 		return e.Execution.Runtime

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3560,6 +3560,37 @@ server:
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("rejects unknown top-level hosted runtime on agent providers", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      runtime:
+        provider: missing
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  runtime:
+    defaultHostedProvider: hosted
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `providers.agent.simple.runtime.provider references unknown runtime "missing"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestLoadConfigAgentRuntimeLifecycleFields(t *testing.T) {
@@ -3661,6 +3692,53 @@ server:
 		}
 		if runtimeCfg.Pool.RestartPolicy != HostedRuntimeRestartPolicyAlways {
 			t.Fatalf("execution restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, HostedRuntimeRestartPolicyAlways)
+		}
+	})
+
+	t.Run("accepts required lifecycle fields under agent runtime", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      indexeddb: agent_state
+      runtime:
+        provider: hosted
+        pool:
+          minReadyInstances: 1
+          maxReadyInstances: 2
+          startupTimeout: 5m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 2m
+  indexeddb:
+    agent_state:
+      source:
+        path: ./providers/datastore/sqlite
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		runtimeCfg := cfg.Providers.Agent["simple"].Runtime
+		if runtimeCfg == nil || runtimeCfg.Pool == nil {
+			t.Fatalf("runtime pool = %#v", runtimeCfg)
+		}
+		if cfg.Providers.Agent["simple"].HostedRuntimeConfig() != runtimeCfg {
+			t.Fatal("HostedRuntimeConfig did not return top-level runtime")
+		}
+		if runtimeCfg.Pool.MinReadyInstances != 1 || runtimeCfg.Pool.MaxReadyInstances != 2 {
+			t.Fatalf("runtime pool ready instances = %d/%d, want 1/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)
 		}
 	})
 
@@ -4001,6 +4079,82 @@ server:
 `,
 			want: "plugins.service.execution.runtime lifecycle fields are only supported on hosted agent and workflow providers",
 		},
+		{
+			name: "rejects lifecycle fields on plugin top-level runtime",
+			yaml: `
+plugins:
+  service:
+    source:
+      path: ./plugins/service/manifest.yaml
+    runtime:
+      provider: hosted
+      pool:
+        minReadyInstances: 1
+        maxReadyInstances: 2
+        startupTimeout: 5m
+        healthCheckInterval: 30s
+        restartPolicy: always
+        drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: "plugins.service.runtime lifecycle fields are only supported on hosted agent and workflow providers",
+		},
+		{
+			name: "rejects duplicate runtime config",
+			yaml: `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      indexeddb: agent_state
+      runtime:
+        provider: hosted
+      execution:
+        runtime:
+          provider: hosted
+  indexeddb:
+    agent_state:
+      source:
+        path: ./providers/datastore/sqlite
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: "providers.agent.simple.runtime may not be set with providers.agent.simple.execution.runtime",
+		},
+		{
+			name: "rejects runtime with local execution mode",
+			yaml: `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      runtime:
+        provider: hosted
+      execution:
+        mode: local
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: `providers.agent.simple.runtime is only valid when execution.mode is "hosted"`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -4059,6 +4213,54 @@ server:
 		runtimeCfg := cfg.Providers.Workflow["temporal"].Execution.Runtime
 		if runtimeCfg == nil || runtimeCfg.Pool == nil {
 			t.Fatalf("workflow execution runtime pool = %#v", runtimeCfg)
+		}
+		if runtimeCfg.Pool.MinReadyInstances != 2 || runtimeCfg.Pool.MaxReadyInstances != 2 {
+			t.Fatalf("workflow pool ready instances = %d/%d, want 2/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)
+		}
+		if runtimeCfg.Pool.RestartPolicy != HostedRuntimeRestartPolicyAlways {
+			t.Fatalf("workflow restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, HostedRuntimeRestartPolicyAlways)
+		}
+	})
+
+	t.Run("accepts top-level hosted workflow runtime pool without indexeddb", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+      runtime:
+        provider: hosted
+        template: workflow-workers
+        metadata:
+          workload: temporal-workers
+        pool:
+          minReadyInstances: 2
+          maxReadyInstances: 2
+          startupTimeout: 5m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/gke
+server:
+  encryptionKey: server-key
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		runtimeCfg := cfg.Providers.Workflow["temporal"].Runtime
+		if runtimeCfg == nil || runtimeCfg.Pool == nil {
+			t.Fatalf("workflow runtime pool = %#v", runtimeCfg)
+		}
+		if cfg.Providers.Workflow["temporal"].HostedRuntimeConfig() != runtimeCfg {
+			t.Fatal("HostedRuntimeConfig did not return top-level workflow runtime")
 		}
 		if runtimeCfg.Pool.MinReadyInstances != 2 || runtimeCfg.Pool.MaxReadyInstances != 2 {
 			t.Fatalf("workflow pool ready instances = %d/%d, want 2/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -804,10 +804,8 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 			entry.IndexedDB.ObjectStores[i] = strings.TrimSpace(store)
 		}
 	}
-	if entry.Execution != nil {
-		if err := normalizeExecutionConfig("plugins."+name, entry.Execution, false); err != nil {
-			return err
-		}
+	if err := normalizeProviderRuntimeConfig("plugins."+name, entry, false); err != nil {
+		return err
 	}
 	seenInvokes := make(map[string]int, len(entry.Invokes))
 	for i := range entry.Invokes {
@@ -1028,10 +1026,8 @@ func validateAgentConfig(cfg *Config) error {
 				entry.IndexedDB.ObjectStores[i] = strings.TrimSpace(store)
 			}
 		}
-		if entry.Execution != nil {
-			if err := normalizeExecutionConfig("providers.agent."+name, entry.Execution, true); err != nil {
-				return err
-			}
+		if err := normalizeProviderRuntimeConfig("providers.agent."+name, entry, true); err != nil {
+			return err
 		}
 		if err := validateAgentProviderLifecycleConfig("providers.agent."+name+".lifecycle", entry.Lifecycle); err != nil {
 			return err
@@ -1273,10 +1269,16 @@ func validateHostedRuntimeLifecyclePolicy(subject string, entry *ProviderEntry, 
 }
 
 func hostedRuntimeConfigAndPath(subject string, entry *ProviderEntry) (*HostedRuntimeConfig, string) {
-	if entry != nil && entry.Execution != nil {
+	if entry == nil {
+		return nil, subject + ".runtime"
+	}
+	if entry.Runtime != nil {
+		return entry.Runtime, subject + ".runtime"
+	}
+	if entry.Execution != nil {
 		return entry.Execution.Runtime, subject + ".execution.runtime"
 	}
-	return nil, subject + ".execution.runtime"
+	return nil, subject + ".runtime"
 }
 
 func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEntry) error {
@@ -1305,7 +1307,7 @@ func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEnt
 	if entry.Lifecycle != nil {
 		return fmt.Errorf("config validation: %s.lifecycle is only supported on providers.agent.*", subject)
 	}
-	if err := normalizeExecutionConfig(subject, entry.Execution, true); err != nil {
+	if err := normalizeProviderRuntimeConfig(subject, entry, true); err != nil {
 		return err
 	}
 	if _, err := cfg.EffectiveHostedRuntime(subject, entry); err != nil {
@@ -1370,8 +1372,11 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	if entry.Lifecycle != nil {
 		return fmt.Errorf("config validation: %s.lifecycle is only supported on providers.agent.*", subject)
 	}
+	if entry.Runtime != nil {
+		return fmt.Errorf("config validation: %s.runtime is only supported on plugins.* and providers.agent.* and providers.workflow.*", subject)
+	}
 	if entry.Execution != nil {
-		return fmt.Errorf("config validation: %s.execution is only supported on plugins.* and providers.agent.*", subject)
+		return fmt.Errorf("config validation: %s.execution is only supported on plugins.* and providers.agent.* and providers.workflow.*", subject)
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
@@ -1472,6 +1477,33 @@ func normalizeExecutionConfig(subject string, execution *ExecutionConfig, allowL
 	}
 	if !allowLifecycle && execution.Runtime.LifecyclePolicyFieldsSet() {
 		return fmt.Errorf("config validation: %s.execution.runtime lifecycle fields are only supported on hosted agent and workflow providers", subject)
+	}
+	return nil
+}
+
+func normalizeProviderRuntimeConfig(subject string, entry *ProviderEntry, allowLifecycle bool) error {
+	if entry == nil {
+		return nil
+	}
+	if entry.Runtime != nil && entry.Execution != nil && entry.Execution.Runtime != nil {
+		return fmt.Errorf("config validation: %s.runtime may not be set with %s.execution.runtime", subject, subject)
+	}
+	if entry.Execution != nil {
+		if err := normalizeExecutionConfig(subject, entry.Execution, allowLifecycle); err != nil {
+			return err
+		}
+		if entry.Runtime != nil && entry.Execution.Mode == ExecutionModeLocal {
+			return fmt.Errorf("config validation: %s.runtime is only valid when execution.mode is %q", subject, ExecutionModeHosted)
+		}
+	}
+	if entry.Runtime == nil {
+		return nil
+	}
+	if err := normalizeHostedRuntimeConfig(subject, entry.Runtime); err != nil {
+		return err
+	}
+	if !allowLifecycle && entry.Runtime.LifecyclePolicyFieldsSet() {
+		return fmt.Errorf("config validation: %s.runtime lifecycle fields are only supported on hosted agent and workflow providers", subject)
 	}
 	return nil
 }

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -314,12 +314,19 @@ func ResolveEffectiveExecution(configPath string, entry *ProviderEntry, selected
 	if entry == nil {
 		return EffectiveExecution{Mode: ExecutionModeLocal}, nil
 	}
-	providerPath := "execution.runtime.provider"
 	var runtimeCfg *HostedRuntimeConfig
+	runtimePath := "runtime"
 	enabled := false
+	mode := ExecutionMode("")
 	if entry.Execution != nil {
+		mode = ExecutionMode(strings.ToLower(strings.TrimSpace(string(entry.Execution.Mode))))
+	}
+	if entry.Runtime != nil {
+		runtimeCfg = entry.Runtime
+		enabled = true
+	} else if entry.Execution != nil {
 		runtimeCfg = entry.Execution.Runtime
-		mode := ExecutionMode(strings.ToLower(strings.TrimSpace(string(entry.Execution.Mode))))
+		runtimePath = "execution.runtime"
 		enabled = runtimeCfg != nil || mode == ExecutionModeHosted
 	}
 	if !enabled {
@@ -339,7 +346,7 @@ func ResolveEffectiveExecution(configPath string, entry *ProviderEntry, selected
 		var ok bool
 		provider, ok = entries[providerName]
 		if !ok || provider == nil {
-			return EffectiveExecution{}, fmt.Errorf("config validation: %s.%s references unknown runtime %q", configPath, providerPath, providerName)
+			return EffectiveExecution{}, fmt.Errorf("config validation: %s.%s.provider references unknown runtime %q", configPath, runtimePath, providerName)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add provider-level `runtime:` as the primary config shape for runtime placement on plugins, agent providers, and workflow providers.
- Keep `execution.runtime` and `execution.mode: hosted` working for compatibility, while making `ProviderEntry.HostedRuntimeConfig()` and runtime placement detection prefer top-level `runtime:`.
- Reject ambiguous configs that set both `runtime:` and `execution.runtime`, and reject `runtime:` when `execution.mode: local` is explicitly set.
- Preserve error paths for legacy `execution.runtime` configs and use `runtime.*` paths for the new top-level form.

## Interface Changes

New preferred shape:

```yaml
providers:
  workflow:
    temporal:
      source:
        path: ./providers/workflow/temporal
      runtime:
        provider: kubernetes
        template: workflow-workers
        metadata:
          workload: temporal-workers
        pool:
          minReadyInstances: 2
          maxReadyInstances: 2
          startupTimeout: 5m
          healthCheckInterval: 30s
          restartPolicy: always
          drainTimeout: 2m
```

Compatibility shape remains accepted:

```yaml
providers:
  workflow:
    temporal:
      source:
        path: ./providers/workflow/temporal
      execution:
        mode: hosted
        runtime:
          provider: kubernetes
          pool:
            minReadyInstances: 2
            maxReadyInstances: 2
            startupTimeout: 5m
            healthCheckInterval: 30s
            restartPolicy: always
            drainTimeout: 2m
```

Invalid ambiguous shape:

```yaml
providers:
  agent:
    hermes:
      runtime:
        provider: kubernetes
      execution:
        runtime:
          provider: kubernetes
```

This keeps the runtime provider contract unchanged; it only cleans up how deployers express provider runtime placement.