### PR TITLE
Document external identity grant follow-up

### DIFF
--- a/gestaltd/core/external_identity.go
+++ b/gestaltd/core/external_identity.go
@@ -9,6 +9,8 @@ import (
 // ExternalIdentityRef identifies a provider-owned external identity resource.
 // The Type names the provider namespace; the ID is opaque to Gestalt after any
 // config surface has rendered its own templates.
+// TODO(#1823): Add declarative grant reconciliation for subjects that may
+// assume provider-owned identities.
 type ExternalIdentityRef struct {
 	Type string
 	ID   string

--- a/gestaltd/core/subjects.go
+++ b/gestaltd/core/subjects.go
@@ -2,11 +2,9 @@ package core
 
 import "strings"
 
-// TODO(hughhan1): Run-as delegation currently treats SubjectID as an opaque
-// provider-owned string and infers kind from the first colon when omitted. This
-// is intentionally integration-agnostic, but still brittle for wider use. Add a
-// structured service-account/subject reference primitive before adding more
-// delegation patterns that depend on encoded subject-id grammars.
+// TODO(#1823): Add first-class run-as subject and external-identity grant
+// provisioning instead of relying on opaque subject IDs plus separate tuple
+// seeding.
 type RunAsSubject struct {
 	SubjectID           string
 	SubjectKind         string

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -2047,6 +2047,8 @@ type PluginInvocationRunAsSubjectConfig struct {
 	AuthSource          string `yaml:"authSource,omitempty"`
 }
 
+// TODO(#1823): Reconcile runAs.externalIdentity grants from readable refs at
+// deploy time.
 type PluginInvocationExternalIdentityConfig struct {
 	Type string `yaml:"type,omitempty"`
 	ID   string `yaml:"id,omitempty"`

--- a/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
@@ -106,6 +106,7 @@ func (s *Server) upsertManagedSubjectExternalIdentity(ctx context.Context, subje
 	// Managed subject assumptions are Zanzibar authorization tuples, not
 	// credential ownership links. Do not route these through the credential sync
 	// uniqueness guard.
+	// TODO(#1823): Add declarative reconciliation for deploy-managed bot grants.
 	rel := managedSubjectExternalIdentityRelationship(subjectID, ref)
 	if rel == nil {
 		return fmt.Errorf("external identity relationship is required")
@@ -314,6 +315,8 @@ func managedSubjectExternalIdentityRelationship(subjectID string, ref externalId
 	if subjectID == "" || resourceID == "" {
 		return nil
 	}
+	// TODO(#1823): Keep encoded resource ids internal to the authorization
+	// provider boundary.
 	return &core.Relationship{
 		Subject: &core.SubjectRef{
 			Type: authorization.ProviderSubjectTypeSubject,

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -497,6 +497,7 @@ func (b *Broker) authorizeExternalIdentityAssumption(ctx context.Context, p *pri
 	if identity == nil {
 		return nil
 	}
+	// TODO(#1823): Validate accepted external identity types before invocation.
 	if b == nil || b.authorizer == nil {
 		return fmt.Errorf("%w: external identity %s/%s", ErrAuthorizationDenied, identity.Type, identity.ID)
 	}

--- a/gestaltd/services/plugins/provider_client.go
+++ b/gestaltd/services/plugins/provider_client.go
@@ -401,6 +401,8 @@ func requestContextProto(ctx context.Context, publicBaseURL string) (*proto.Requ
 		}
 	}
 	if identity := invocation.ExternalIdentityContextFromContext(ctx); identity.Type != "" && identity.ID != "" {
+		// TODO(#1823): Let provider install/connect flows report identity
+		// candidates without writing authorization relationships themselves.
 		out.ExternalIdentity = &proto.ExternalIdentityContext{
 			Type: identity.Type,
 			Id:   identity.ID,


### PR DESCRIPTION
## Summary

Adds short `TODO(#1823)` comments at the runAs external identity ownership boundaries:

- run-as subject representation
- external identity refs
- config surface for `runAs.externalIdentity`
- managed-subject external identity tuple writes
- invocation-time assumption authorization
- provider request-context propagation

The full feature-completeness discussion and logic-flow examples live in #1823.

## Test Plan

- `go test ./core ./internal/config ./services/invocation ./services/plugins` from `gestaltd/`
