### PR TITLE
Clean up runtime placement interfaces

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -4,7 +4,7 @@ Gestalt is configured from one or more YAML files. This page covers the key conc
 
 ## Config file structure
 
-A Gestalt config has six top-level keys: `server` for host settings and host-provider selection, `authorization` for shared subject access policy, `providers` for named host-scoped providers and UIs, `runtime` for named plugin runtime backends, `workflows` for config-managed schedules and event triggers, and `plugins` for executable integrations and optional plugin-backed UI mounts.
+A Gestalt config has six top-level keys: `server` for host settings and host-provider selection, `authorization` for shared subject access policy, `providers` for named host-scoped providers and UIs, `runtime` for named runtime placement backends, `workflows` for config-managed schedules and event triggers, and `plugins` for executable integrations and optional plugin-backed UI mounts.
 
 ```yaml
 authorization:
@@ -88,9 +88,9 @@ server:
     secrets: ...
     telemetry: ...
 
-  # default runtime selection for plugins that opt in
+  # default runtime selection for providers that opt in
   runtime:
-    defaultHostedProvider: ...
+    defaultProvider: ...
 
   # public listener (default port 8080)
   public:
@@ -102,7 +102,7 @@ ProviderEntry-backed entries accept `source` (where to load it from), `config`
 (provider-specific settings), `egress.allowedHosts`, and optional metadata
 fields. Plugin entries additionally support plugin-only fields such as
 `connections`, `allowedOperations`, `ui.path`, `ui.bundle`, and
-`execution.runtime`. See the [Config File](/reference/config-file) reference for
+`runtime`. See the [Config File](/reference/config-file) reference for
 every field.
 
 ## Key concepts
@@ -118,7 +118,7 @@ Gestalt has ten core concepts you configure in YAML:
 - **[Secrets.](/providers/secrets)** Resolves structured secret refs in the config at startup. Backed by environment variables, files, or cloud secret managers.
 - **[Workflow.](/providers/workflow)** Global workflow runs, schedules, and triggers backed by a workflow provider and optional host IndexedDB storage.
 - **[UI.](/providers/ui)** Public static UI bundles served under configured path prefixes, either directly from `providers.ui` or through `plugins.<name>.ui.path`. Omit `providers.ui` to run headless.
-- **Runtime.** Optional execution backends for executable plugins. Plugins stay host-local by default; `plugins.<name>.execution.mode: hosted` opts a plugin into hosted execution and `runtime.providers` names the available backends.
+- **Runtime.** Optional execution backends for executable plugins. Plugins stay host-local by default; `plugins.<name>.runtime` opts a plugin into hosted execution and `runtime.providers` names the available backends.
 
 ## Adding a plugin
 
@@ -206,10 +206,10 @@ plugins:
 Executable plugins run on the same machine as `gestaltd` unless the plugin opts
 into a hosted runtime. Runtime selection is two-step: define named backends
 under `runtime.providers`, then opt an individual plugin in with
-`plugins.<name>.execution.mode: hosted`.
+`plugins.<name>.runtime`.
 
-`server.runtime.defaultHostedProvider` is only a default selector for plugins
-that already set `execution.mode: hosted`; it does not move every plugin into a
+`server.runtime.defaultProvider` is only a default selector for plugins
+that already set `runtime`; it does not move every plugin into a
 hosted runtime automatically.
 
 ```yaml
@@ -225,22 +225,20 @@ runtime:
 
 server:
   runtime:
-    defaultHostedProvider: modal
+    defaultProvider: modal
 
 plugins:
   support:
     source: ./plugins/support/manifest.yaml
-    execution:
-      mode: hosted
-      runtime:
-        template: python-dev
-        image: ghcr.io/example/support-plugin:2026-04-21
-        metadata:
-          environment: production
-          owner: support-platform
+    runtime:
+      template: python-dev
+      image: ghcr.io/example/support-plugin:2026-04-21
+      metadata:
+        environment: production
+        owner: support-platform
 ```
 
-`plugins.<name>.execution.runtime.template`, `image`, and `metadata` are
+`plugins.<name>.runtime.template`, `image`, and `metadata` are
 forwarded to the selected runtime backend. Their meaning is backend-specific: a
 local runtime may ignore them, while a hosted runtime may use them to choose a
 sandbox template, container image, or labels/tags for lifecycle management.
@@ -249,18 +247,16 @@ package at the image working directory. It starts the executable declared by
 the provider manifest entrypoint and passes the manifest entrypoint args:
 
 ```yaml
-execution:
-  mode: hosted
-  runtime:
-    provider: modal
-    image: ghcr.io/example/support-plugin@sha256:...
+runtime:
+  provider: modal
+  image: ghcr.io/example/support-plugin@sha256:...
 ```
 
 The built-in `local` runtime handles same-machine execution. Installable
 `kind: runtime` providers such as Modal handle hosted execution.
 
 The current Modal backend requires `runtime.providers.<name>.config.app` and
-`plugins.<name>.execution.runtime.image`. Modal can satisfy plugins that need
+`plugins.<name>.runtime.image`. Modal can satisfy plugins that need
 Gestalt-owned services or hostname-based egress when the host is configured for
 the public relay and proxy path. In practice that means `server.baseUrl` (or
 `server.runtime.relayBaseUrl`) and `server.encryptionKey` must be set, and the

--- a/docs/content/custom-providers/runtime.mdx
+++ b/docs/content/custom-providers/runtime.mdx
@@ -62,8 +62,12 @@ runtime:
         pool: default
 ```
 
-Plugins then opt into that runtime with `plugins.<name>.execution.mode: hosted`
-and `plugins.<name>.execution.runtime`.
+Plugins and hosted providers then opt into that runtime with their own
+`runtime` block, for example `plugins.<name>.runtime`,
+`providers.agent.<name>.runtime`, or `providers.workflow.<name>.runtime`.
+They can select the backend explicitly with `runtime.provider`, or inherit the
+default runtime selected by `server.runtime.defaultProvider` or
+`runtime.providers.<name>.default`.
 
 ## Provider interface
 
@@ -72,13 +76,13 @@ The runtime surface is intentionally small but lifecycle-oriented:
 | Method | Purpose |
 | --- | --- |
 | `GetSupport` | Advertise grouped runtime support for this backend. |
-| `StartSession` | Create a hosted runtime session for a plugin. |
+| `StartSession` | Create a hosted runtime session for the placed plugin, agent provider, or workflow provider. |
 | `GetSession` | Report session status so Gestalt can wait for readiness. |
 | `ListSessions` | Return sessions currently known to the runtime backend. |
 | `StopSession` | Tear a session down on shutdown or bootstrap failure. |
 | `PrepareWorkspace` | Optional. Prepare a per-agent workspace inside an existing runtime session before the hosted agent provider creates a session. |
 | `RemoveWorkspace` | Optional. Remove a per-agent workspace by runtime session and agent session ID. |
-| `StartPlugin` | Start the hosted plugin with the provided env and return a host-reachable dial target. |
+| `StartPlugin` | Start the hosted provider process with the provided env and return a host-reachable dial target. The RPC name is retained for wire compatibility even when the placed provider is an agent or workflow provider. |
 
 In addition to the runtime-specific RPCs, the provider still implements the
 normal provider lifecycle surface, including `Configure`.

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -132,31 +132,28 @@ the agent process is launched from. Use hooks for context or metadata, and use
 `workspace` for checkout and cwd setup.
 
 If you want the provider to run in a hosted sandbox instead of directly on the
-`gestaltd` host, add `execution.mode: hosted` and `execution.runtime` to that
-same `providers.agent.<name>` entry:
+`gestaltd` host, add `runtime` to that same `providers.agent.<name>` entry:
 
 ```yaml
 providers:
   agent:
     simple:
       source: ./providers/agent/simple/manifest.yaml
-      execution:
-        mode: hosted
-        runtime:
-          provider: modal
-          image: ghcr.io/valon/gestalt-python-runtime:latest
-          workspace:
-            prepareTimeout: 10m
-            git:
-              allowedRepositories:
-                - github.com/valon-technologies/*
-          pool:
-            minReadyInstances: 1
-            maxReadyInstances: 4
-            startupTimeout: 2m
-            healthCheckInterval: 30s
-            restartPolicy: always
-            drainTimeout: 1m
+      runtime:
+        provider: modal
+        image: ghcr.io/valon/gestalt-python-runtime:latest
+        workspace:
+          prepareTimeout: 10m
+          git:
+            allowedRepositories:
+              - github.com/valon-technologies/*
+        pool:
+          minReadyInstances: 1
+          maxReadyInstances: 4
+          startupTimeout: 2m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 1m
       egress:
         allowedHosts:
           - api.openai.com
@@ -169,7 +166,7 @@ This keeps the caller interface the same. The request still targets
 `provider: simple`. The only difference is where the provider executes and how
 `gestaltd` enforces host-service access and egress.
 
-`execution.runtime.pool` is the hosted agent lifecycle block.
+`runtime.pool` is the hosted agent lifecycle block.
 
 ## Session and turn shape
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -13,7 +13,7 @@ fully declarative, and some are hybrid packages that combine both models.
 From a deployment point of view, `source` chooses the package, `config`
 passes provider-specific settings such as OAuth app credentials,
 `allowedOperations` publishes only part of a large catalog,
-`egress.allowedHosts` declares outbound egress policy, and `execution` opts an
+`egress.allowedHosts` declares outbound egress policy, and `runtime` opts an
 executable plugin into hosted execution.
 
 If the manifest enables MCP, the same operations are also exposed through the
@@ -102,8 +102,7 @@ plugins:
 ```
 
 By default, executable plugins run on the same machine as `gestaltd`. A plugin
-only uses a hosted runtime when it sets `execution.mode: hosted` with
-`execution.runtime`.
+only uses a hosted runtime when it sets `runtime`.
 
 ## Choosing a runtime
 
@@ -122,23 +121,21 @@ runtime:
 
 server:
   runtime:
-    defaultHostedProvider: modal
+    defaultProvider: modal
 
 plugins:
   support:
     source: ./plugins/support/manifest.yaml
-    execution:
-      mode: hosted
-      runtime:
-        template: python-dev
-        image: ghcr.io/example/support-plugin:2026-04-21
-        metadata:
-          environment: production
+    runtime:
+      template: python-dev
+      image: ghcr.io/example/support-plugin:2026-04-21
+      metadata:
+        environment: production
 ```
 
-`plugins.<name>.execution.runtime.provider` selects a named backend from
+`plugins.<name>.runtime.provider` selects a named backend from
 `runtime.providers`. When `provider` is omitted, Gestalt uses
-`server.runtime.defaultHostedProvider` or the one runtime entry marked
+`server.runtime.defaultProvider` or the one runtime entry marked
 `default: true`.
 
 `template`, `image`, and `metadata` are forwarded to the runtime backend. Their
@@ -148,7 +145,7 @@ them to choose a sandbox template, container image, or lifecycle labels.
 A built-in `local` runtime is always available for same-machine execution. The
 first installable hosted runtime provider is `modal`. It requires
 `runtime.providers.<name>.config.app` and
-`plugins.<name>.execution.runtime.image`.
+`plugins.<name>.runtime.image`.
 Gestalt only uses it for plain executable plugins today. Modal can still run
 plugins that need Gestalt-owned services or hostname-based egress when the host
 is configured for the public relay and proxy path. In practice that means

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -1,27 +1,28 @@
 # Runtime
 
-Runtime providers manage **where executable plugins and hosted agent providers run**.
+Runtime providers manage **where executable plugins, hosted agent providers, and hosted workflow providers run**.
 
-A runtime provider is not the plugin itself, and it is not a host provider like
-authentication, IndexedDB, or workflow. Instead, it is a control-plane backend
-that lets `gestaltd` create a plugin runtime session, prepare relay-backed
-host-service environment variables, start the plugin process there, and dial
-the plugin back over gRPC.
+A runtime provider is not the plugin or hosted provider itself, and it is not a
+host provider like authentication, IndexedDB, or workflow. Instead, it is a
+control-plane backend that lets `gestaltd` create a runtime session, prepare
+relay-backed host-service environment variables, start the provider process
+there, and dial the provider back over gRPC.
 
 ## Scope
 
-Runtime providers apply to executable plugins under `plugins.<name>` and agent
-providers under `providers.agent.<name>` when they opt into hosted execution.
+Runtime providers apply to executable plugins under `plugins.<name>`, agent
+providers under `providers.agent.<name>`, and workflow providers under
+`providers.workflow.<name>` when they opt into hosted execution.
 They do **not** replace host-local infrastructure providers such as
 authentication, authorization, IndexedDB, cache, S3, secrets, or workflow.
 Those providers still live on the `gestaltd` host. A runtime provider only
-changes where the configured plugin or agent provider process runs.
+changes where the configured provider process runs.
 
 ## Mental model
 
-By default, executable plugins and agent providers run on the same machine as
+By default, executable plugins, agent providers, and workflow providers run on the same machine as
 `gestaltd`. A provider only uses a runtime provider when it opts in with
-`execution.mode: hosted` and selects a backend with `execution.runtime`.
+`runtime` and selects a backend with `runtime`.
 
 When a provider does opt in, Gestalt selects a backend from `runtime.providers`,
 reads the backend's support profile, starts a runtime session, waits for that
@@ -52,23 +53,21 @@ runtime:
 
 server:
   runtime:
-    defaultHostedProvider: modal
+    defaultProvider: modal
 
 plugins:
   support:
     source: ./plugins/support/manifest.yaml
-    execution:
-      mode: hosted
-      runtime:
-        image: ghcr.io/example/support-plugin:2026-04-21
-        template: python-dev
-        metadata:
-          environment: production
+    runtime:
+      image: ghcr.io/example/support-plugin:2026-04-21
+      template: python-dev
+      metadata:
+        environment: production
 ```
 
 Selection is intentionally two-step. `runtime.providers` defines named
-backends, while `execution.mode: hosted` opts a specific plugin or agent
-provider into hosted execution. `server.runtime.defaultHostedProvider` is only
+backends, while `runtime` opts a specific plugin, agent provider, or workflow
+provider into hosted execution. `server.runtime.defaultProvider` is only
 a default selector for providers that already opted into hosted execution.
 
 ## Runtime profiles
@@ -140,7 +139,7 @@ Today there are two main runtime choices:
 | Backend | Type | Notes |
 | --- | --- | --- |
 | `local` | Built-in driver | Runs the plugin on the same machine as `gestaltd`. Supports host-path execution and the existing host-local runtime behavior. |
-| `modal` | Installable `kind: runtime` provider | Runs the plugin in a hosted Linux sandbox. Requires `runtime.providers.<name>.config.app` and `plugins.<name>.execution.runtime.image`. When the host is configured for the public relay and proxy path, Modal can run plugins that need Gestalt-owned services and hostname-based egress. |
+| `modal` | Installable `kind: runtime` provider | Runs the plugin in a hosted Linux sandbox. Requires `runtime.providers.<name>.config.app` and `plugins.<name>.runtime.image`. When the host is configured for the public relay and proxy path, Modal can run plugins that need Gestalt-owned services and hostname-based egress. |
 
 ## Provider images
 
@@ -154,14 +153,12 @@ directory and passes the manifest entrypoint args.
 plugins:
   support:
     source: https://artifacts.example.com/support/v0.1.0/provider-release.yaml
-    execution:
-      mode: hosted
-      runtime:
-        provider: modal
-        image: ghcr.io/example/support-plugin@sha256:...
+    runtime:
+      provider: modal
+      image: ghcr.io/example/support-plugin@sha256:...
 ```
 
-This is why `plugins.<name>.execution.runtime.image`, `template`,
+This is why `plugins.<name>.runtime.image`, `template`,
 `imagePullAuth`, and `metadata` are forwarded to the runtime backend: they are
 runtime-specific session hints, not universal plugin semantics. For private OCI
 images, `imagePullAuth.dockerConfigJson` carries Docker config JSON, matching

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -89,9 +89,10 @@ providers:
 
 ## Runtime Providers
 
-Runtime providers manage hosted execution backends for executable plugins. They
-are configured under top-level `runtime.providers`, and plugins opt into them
-with `plugins.<name>.execution.mode: hosted`.
+Runtime providers manage hosted execution backends for executable plugins,
+hosted agent providers, and hosted workflow providers. They are configured
+under top-level `runtime.providers`, and providers opt into them with their
+own `runtime` block.
 
 ```yaml
 runtime:
@@ -105,15 +106,13 @@ runtime:
 plugins:
   support:
     source: ./plugins/support/manifest.yaml
-    execution:
-      mode: hosted
-      runtime:
-        image: ghcr.io/example/support-plugin:2026-04-21
+    runtime:
+      image: ghcr.io/example/support-plugin:2026-04-21
 ```
 
 | Name | Purpose |
 | --- | --- |
-| `local` | Built-in same-machine runtime driver. Used by default when a plugin does not opt into hosted execution. |
+| `local` | Built-in same-machine runtime driver. Used by default when a provider does not opt into hosted execution. |
 | `modal` | First-party hosted runtime provider for Modal sandboxes. |
 
 ## Workflow Providers

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -147,7 +147,7 @@ server:
   apiTokenTtl: 30d
   artifactsDir: ./state
   runtime:
-    defaultHostedProvider: modal
+    defaultProvider: modal
     relayBaseUrl: https://gestalt.example.com
   agent:
     defaultToolNarrowingThreshold: 200
@@ -180,7 +180,7 @@ authorization:
 
 `apiTokenTtl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifactsDir` is a writable directory for prepared artifacts produced by `gestaltd sync --locked` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `lock`/`sync`/`serve` lifecycle.
 
-`runtime.defaultHostedProvider` selects the runtime provider used when a plugin or agent opts into hosted execution without naming a provider. `runtime.relayBaseUrl` overrides the URL handed to hosted runtimes for Gestalt host-service callbacks and hostname egress proxying. It defaults to `server.baseUrl`; set it when hosted runtimes need to call back through a private listener or internal reverse proxy while browser and OAuth flows still use the public origin. The target may be the management listener when that listener is reachable from the hosted runtime network.
+`runtime.defaultProvider` selects the runtime provider used when a plugin, agent provider, or workflow provider opts into hosted execution without naming a provider. `runtime.relayBaseUrl` overrides the URL handed to hosted runtimes for Gestalt host-service callbacks and hostname egress proxying. It defaults to `server.baseUrl`; set it when hosted runtimes need to call back through a private listener or internal reverse proxy while browser and OAuth flows still use the public origin. The target may be the management listener when that listener is reachable from the hosted runtime network.
 
 `agent.defaultToolNarrowingThreshold` controls implicit default MCP catalog grants for agent providers that support the catalog. When the total visible catalog is larger than this threshold and the latest user message exactly names a provider, Gestalt grants that provider instead of a global wildcard. Omit it to use the server default; set it to `0` to narrow whenever any visible catalog tool exists.
 
@@ -210,7 +210,7 @@ Plugins without `authorizationPolicy` are open to any authenticated subject. Bin
 | `agent.defaultToolNarrowingThreshold` | `200` | Visible catalog size above which implicit default agent catalog grants may be narrowed to exactly mentioned providers. Set `0` to narrow whenever a matching provider has any visible tools. |
 | `providers.audit` / `providers.authentication` / `providers.authorization` / `providers.indexeddb` / `providers.secrets` / `providers.telemetry` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
 | `dev.attachmentState` | | Enables private remote provider-dev attach routes and selects where attachment state is stored. The only supported value is `indexeddb`, which stores attachment state in the configured host IndexedDB for shared and load-balanced servers. |
-| `runtime.defaultHostedProvider` | | Default runtime-provider selector for plugins that opt into `execution.mode: hosted`. This does not move plugins into hosted runtimes by itself. |
+| `runtime.defaultProvider` | | Default runtime-provider selector for plugins and providers that opt into `runtime`. This does not move anything into hosted runtimes by itself. |
 | `runtime.relayBaseUrl` | `server.baseUrl` | Absolute HTTP(S) URL that hosted runtimes use for Gestalt host-service relay and egress proxy callbacks. |
 | `admin.authorizationPolicy` | | Shared subject access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
@@ -223,10 +223,9 @@ The management listener is intended to be protected by deployment infrastructure
 
 ## `runtime`
 
-`runtime.providers` defines named execution backends for executable plugins.
-These backends are only used when a plugin opts into `execution.mode: hosted`.
-If a plugin omits `execution` or sets `execution.mode: local`, it still runs on
-the same machine as `gestaltd`.
+`runtime.providers` defines named execution backends for runtime-placed providers.
+These backends are only used when a plugin, agent provider, or workflow provider opts into `runtime`.
+If a provider omits `runtime`, it still runs on the same machine as `gestaltd`.
 
 See [Providers > Runtime](/providers/runtime) for the lifecycle and capability
 model behind these fields.
@@ -245,15 +244,15 @@ runtime:
         environment: main
 ```
 
-`server.runtime.defaultHostedProvider` supplies the default runtime name for
-plugins that set `execution.mode: hosted` without an explicit
-`execution.runtime.provider`.
+`server.runtime.defaultProvider` supplies the default runtime name for
+plugins, agent providers, or workflow providers that set `runtime` without an explicit
+`runtime.provider`.
 
 | Field | Description |
 | --- | --- |
 | `providers.<name>.driver` | Optional built-in runtime selector. The only built-in runtime is `local`. |
 | `providers.<name>.source` | Package source, local manifest path, metadata URL, `source.url`, or `source.githubRelease` for an installable `kind: runtime` provider such as Modal. |
-| `providers.<name>.default` | Marks the runtime as the default selection when `server.runtime.defaultHostedProvider` is omitted. Only one runtime may be default. |
+| `providers.<name>.default` | Marks the runtime as the default selection when `server.runtime.defaultProvider` is omitted. Only one runtime may be default. |
 | `providers.<name>.config` | Runtime-provider-specific config blob. Built-ins such as `local` reject custom config entirely. |
 
 ### `runtime.providers.*.config` for the Modal runtime provider
@@ -293,7 +292,7 @@ runtime:
 | `regions` | Optional region allowlist passed through to Modal. |
 
 When a plugin uses the Modal runtime provider,
-`plugins.<name>.execution.runtime.image` is required. Modal can still run
+`plugins.<name>.runtime.image` is required. Modal can still run
 hosted plugins that need Gestalt-owned services or hostname-based egress when
 the host is configured for the public relay and proxy path. In practice that
 means `server.baseUrl` (or `server.runtime.relayBaseUrl`) and
@@ -314,11 +313,9 @@ manifest entrypoint and passes the manifest entrypoint args:
 plugins:
   support:
     source: https://artifacts.example.com/support/v0.1.0/provider-release.yaml
-    execution:
-      mode: hosted
-      runtime:
-        provider: modal
-        image: ghcr.io/example/support-plugin@sha256:...
+    runtime:
+      provider: modal
+      image: ghcr.io/example/support-plugin@sha256:...
 ```
 
 There is no separate launch source or runtime command override. If
@@ -527,7 +524,7 @@ allowlist logical stores exposed through that binding.
 Workflow providers can also opt into hosted execution. `gestaltd serve`
 starts hosted workflow workers automatically after the provider graph is ready;
 there is no separate worker command to run. A hosted workflow provider may set
-`execution.runtime.pool` to keep a fixed pool of runtime sessions ready for
+`runtime.pool` to keep a fixed pool of runtime sessions ready for
 polling backends such as Temporal. Workflow runtime pools are fixed-size:
 `maxReadyInstances` must match `minReadyInstances`.
 
@@ -536,18 +533,16 @@ providers:
   workflow:
     temporal:
       source: https://artifacts.example.com/workflow/temporal/v0.0.1-alpha.1/provider-release.yaml
-      execution:
-        mode: hosted
-        runtime:
-          provider: gke
-          template: workflow-workers
-          pool:
-            minReadyInstances: 2
-            maxReadyInstances: 2
-            startupTimeout: 5m
-            healthCheckInterval: 30s
-            restartPolicy: always
-            drainTimeout: 2m
+      runtime:
+        provider: gke
+        template: workflow-workers
+        pool:
+          minReadyInstances: 2
+          maxReadyInstances: 2
+          startupTimeout: 5m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 2m
       config:
         namespace: default
 
@@ -565,7 +560,7 @@ runtime:
 | `config` | Provider-specific config passed into the workflow provider. |
 | `indexeddb` | Optional host IndexedDB binding for the workflow provider, including `provider`, optional `db`, and optional `objectStores`. |
 | `env` | Extra environment variables passed to the provider process. |
-| `execution` | Optional hosted execution selection for this workflow provider. `execution.mode` is `local` or `hosted`; `execution.runtime` supports `provider`, `template`, `image`, `imagePullAuth`, `metadata`, and `pool`. `pool` contains hosted workflow worker lifecycle fields: `minReadyInstances`, `maxReadyInstances`, `startupTimeout`, `healthCheckInterval`, `restartPolicy`, and `drainTimeout`. |
+| `runtime` | Optional runtime placement for this workflow provider. Supports `provider`, `template`, `image`, `imagePullAuth`, `metadata`, and `pool`. `pool` contains hosted workflow worker lifecycle fields: `minReadyInstances`, `maxReadyInstances`, `startupTimeout`, `healthCheckInterval`, `restartPolicy`, and `drainTimeout`. |
 | `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `providers.agent`
@@ -586,23 +581,21 @@ providers:
       indexeddb:
         provider: default
         db: simple_agent
-      execution:
-        mode: hosted
-        runtime:
-          provider: modal
-          image: ghcr.io/valon/gestalt-python-runtime:latest
-          workspace:
-            prepareTimeout: 10m
-            git:
-              allowedRepositories:
-                - github.com/valon-technologies/*
-          pool:
-            minReadyInstances: 1
-            maxReadyInstances: 4
-            startupTimeout: 2m
-            healthCheckInterval: 30s
-            restartPolicy: always
-            drainTimeout: 1m
+      runtime:
+        provider: modal
+        image: ghcr.io/valon/gestalt-python-runtime:latest
+        workspace:
+          prepareTimeout: 10m
+          git:
+            allowedRepositories:
+              - github.com/valon-technologies/*
+        pool:
+          minReadyInstances: 1
+          maxReadyInstances: 4
+          startupTimeout: 2m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 1m
       config:
         runStore: runs
         idempotencyStore: run_idempotency
@@ -619,15 +612,15 @@ IndexedDB binding with `indexeddb`; the provider process then uses the SDK
 IndexedDB helper against `GESTALT_INDEXEDDB_SOCKET`.
 
 Agent providers may also opt into a hosted runtime with
-`execution.mode: hosted`, using the same runtime-provider selection model as
-executable plugins. When `providers.agent.<name>.execution.mode` is `hosted`,
+`runtime`, using the same runtime-provider selection model as
+executable plugins. When `providers.agent.<name>.runtime` is set,
 `gestaltd` starts the agent provider inside the selected hosted runtime instead
 of launching it directly on the `gestaltd` host. Tool callbacks still route
 back through the host agent socket, and `egress.allowedHosts` remains the
 operator-facing egress policy.
 
 When hosted agents accept caller-supplied workspaces,
-`execution.runtime.workspace` controls the pre-session checkout step. Gestalt
+`runtime.workspace` controls the pre-session checkout step. Gestalt
 validates the requested repositories against `workspace.git.allowedRepositories`,
 then asks the selected runtime provider to prepare the checkout before calling
 the agent provider's `CreateSession`. `workspace.prepareTimeout` defaults to
@@ -652,7 +645,7 @@ through the platform shell.
 | `env` | Extra environment variables passed to the provider process. |
 | `defaultHarness` | Optional default local harness name used by `gestalt agent` and `gestalt agent doctor` when `--harness` is omitted. |
 | `harnesses` | Optional named local harness configs for `gestalt agent`. Each harness can define `command`, `args`, `env`, `workingDirectory`, `requiredCommands`, and `install` guidance. |
-| `execution` | Optional hosted execution selection for this agent provider. `execution.mode` is `local` or `hosted`; `execution.runtime` supports `provider`, `template`, `image`, `imagePullAuth`, `metadata`, `workspace`, and `pool`. `imagePullAuth.dockerConfigJson` contains Docker config JSON used by runtime providers when pulling private OCI images. `workspace.prepareTimeout` bounds runtime workspace preparation, and `workspace.git.allowedRepositories` is an allowlist of canonical Git repository identities or path-style wildcards such as `github.com/valon-technologies/*`. `pool` contains hosted agent lifecycle fields: `minReadyInstances`, `maxReadyInstances`, `startupTimeout`, `healthCheckInterval`, `restartPolicy`, and `drainTimeout`. |
+| `runtime` | Optional runtime placement for this agent provider. Supports `provider`, `template`, `image`, `imagePullAuth`, `metadata`, `workspace`, and `pool`. `imagePullAuth.dockerConfigJson` contains Docker config JSON used by runtime providers when pulling private OCI images. `workspace.prepareTimeout` bounds runtime workspace preparation, and `workspace.git.allowedRepositories` is an allowlist of canonical Git repository identities or path-style wildcards such as `github.com/valon-technologies/*`. `pool` contains hosted agent lifecycle fields: `minReadyInstances`, `maxReadyInstances`, `startupTimeout`, `healthCheckInterval`, `restartPolicy`, and `drainTimeout`. |
 | `egress.allowedHosts` | Outbound host allowlist. For executable providers, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `workflows`
@@ -1144,7 +1137,7 @@ plugins:
 | `connections` | Named connection bindings. A binding usually uses `ref` to attach a top-level connection to the local plugin connection name; single-use platform or `none` connections may be declared inline. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
 | `dev.attach.allowedRoles` | Roles from this plugin's `authorizationPolicy` that may create private remote provider-dev attachments for this plugin. This is denied when omitted, empty, or when the plugin has no `authorizationPolicy`. |
-| `execution` | Optional executable-plugin execution config. `execution.mode` is `local` or `hosted`; `execution.runtime` carries the hosted runtime fields. |
+| `runtime` | Optional runtime placement for executable plugins. Supports hosted runtime fields such as `provider`, `template`, `image`, `imagePullAuth`, and `metadata`. |
 | `egress.allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 | `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Supported providers derive plugin scoping from that `db` name using provider-native namespace config; Gestalt does not rewrite object-store names at the SDK transport layer. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
 | `s3` | Optional list of named `providers.s3` bindings exposed to the executable plugin through the SDK transport. A single binding also populates the default S3 SDK env var for SDK clients. |

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -45,14 +45,14 @@ func buildAgentProviderBinary(t *testing.T) string {
 
 type agentRuntimeFactoryContextKey struct{}
 
-func testHostedAgentRuntimeConfig() *config.HostedRuntimeConfig {
-	return &config.HostedRuntimeConfig{
-		Pool: &config.HostedRuntimePoolConfig{
+func testHostedAgentRuntimeConfig() *config.RuntimePlacementConfig {
+	return &config.RuntimePlacementConfig{
+		Pool: &config.RuntimePlacementPoolConfig{
 			MinReadyInstances:   1,
 			MaxReadyInstances:   1,
 			StartupTimeout:      "5s",
 			HealthCheckInterval: "1s",
-			RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+			RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
 			DrainTimeout:        "1s",
 		},
 	}
@@ -718,16 +718,16 @@ func hostedWorkspacePoolForTest(t *testing.T, agentProvider coreagent.Provider, 
 		name: "simple",
 		launch: &hostedAgentProviderLaunch{
 			name: "simple",
-			runtimeConfig: config.EffectiveHostedRuntime{
-				Workspace: &config.HostedRuntimeWorkspaceConfig{
+			runtimeConfig: config.EffectiveRuntimePlacement{
+				Workspace: &config.RuntimePlacementWorkspaceConfig{
 					PrepareTimeout: "10s",
-					Git: &config.HostedRuntimeWorkspaceGitConfig{
+					Git: &config.RuntimePlacementWorkspaceGitConfig{
 						AllowedRepositories: allowedRepos,
 					},
 				},
 			},
 		},
-		policy:              config.HostedRuntimeLifecyclePolicy{MaxReadyInstances: 1},
+		policy:              config.RuntimePlacementLifecyclePolicy{MaxReadyInstances: 1},
 		ctx:                 ctx,
 		cancel:              cancel,
 		backends:            []*hostedAgentPoolBackend{{id: 1, provider: agentProvider, runtimeProvider: runtimeProvider, runtimeSessionID: runtimeSession.ID, runtimeSession: runtimeSession, liveTurns: map[string]struct{}{}}},
@@ -858,7 +858,7 @@ func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *tes
 	runtimeConfig := testHostedAgentRuntimeConfig()
 	runtimeConfig.Template = "python-dev"
 	runtimeConfig.Image = "ghcr.io/valon/gestalt-python-runtime:latest"
-	runtimeConfig.ImagePullAuth = &config.HostedRuntimeImagePullAuth{
+	runtimeConfig.ImagePullAuth = &config.RuntimePlacementImagePullAuth{
 		DockerConfigJSON: `{"auths":{"ghcr.io":{"username":"ghcr-user","password":"ghcr-token"}}}`,
 	}
 	runtimeConfig.Metadata = map[string]string{"tenant": "eng"}
@@ -878,7 +878,7 @@ func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *tes
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -888,8 +888,8 @@ func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *tes
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command:   bin,
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+					Command: bin,
+					Runtime: runtimeConfig,
 					ResolvedManifest: &providermanifestv1.Manifest{
 						Kind: providermanifestv1.KindAgent,
 						Entrypoint: &providermanifestv1.Entrypoint{
@@ -967,7 +967,7 @@ func TestAgentRuntimeConfigStartsHostedAgentWarmPool(t *testing.T) {
 	runtimeConfig.Pool.DrainTimeout = "2s"
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -977,8 +977,8 @@ func TestAgentRuntimeConfigStartsHostedAgentWarmPool(t *testing.T) {
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command:   bin,
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+					Command: bin,
+					Runtime: runtimeConfig,
 				},
 			},
 		},
@@ -1107,7 +1107,7 @@ func TestAgentRuntimeConfigScalesOutHostedAgentWarmPool(t *testing.T) {
 	runtimeConfig.Pool.MaxReadyInstances = 2
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -1117,8 +1117,8 @@ func TestAgentRuntimeConfigScalesOutHostedAgentWarmPool(t *testing.T) {
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command:   bin,
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+					Command: bin,
+					Runtime: runtimeConfig,
 				},
 			},
 		},
@@ -1212,10 +1212,10 @@ func TestAgentRuntimeConfigRestartsUnhealthyHostedAgent(t *testing.T) {
 	}
 	runtimeConfig := testHostedAgentRuntimeConfig()
 	runtimeConfig.Pool.HealthCheckInterval = "50ms"
-	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	runtimeConfig.Pool.RestartPolicy = config.RuntimePlacementRestartPolicyAlways
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -1227,7 +1227,7 @@ func TestAgentRuntimeConfigRestartsUnhealthyHostedAgent(t *testing.T) {
 				"simple": {
 					Command:   bin,
 					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+					Runtime:   runtimeConfig,
 				},
 			},
 		},
@@ -1303,10 +1303,10 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 	runtimeConfig := testHostedAgentRuntimeConfig()
 	runtimeConfig.Pool.MaxReadyInstances = 2
 	runtimeConfig.Pool.HealthCheckInterval = "25ms"
-	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	runtimeConfig.Pool.RestartPolicy = config.RuntimePlacementRestartPolicyAlways
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -1318,7 +1318,7 @@ func TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline(t *test
 				"simple": {
 					Command:   bin,
 					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+					Runtime:   runtimeConfig,
 				},
 			},
 		},
@@ -1413,10 +1413,10 @@ func TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartF
 	runtimeConfig.Pool.MaxReadyInstances = 2
 	runtimeConfig.Pool.StartupTimeout = "5s"
 	runtimeConfig.Pool.HealthCheckInterval = "25ms"
-	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	runtimeConfig.Pool.RestartPolicy = config.RuntimePlacementRestartPolicyAlways
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -1428,7 +1428,7 @@ func TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartF
 				"simple": {
 					Command:   bin,
 					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+					Runtime:   runtimeConfig,
 				},
 			},
 		},
@@ -1522,10 +1522,10 @@ func TestAgentRuntimeConfigProactiveReplacementRespectsMaxReadyInstances(t *test
 	runtimeConfig.Pool.MinReadyInstances = 2
 	runtimeConfig.Pool.MaxReadyInstances = 3
 	runtimeConfig.Pool.HealthCheckInterval = "25ms"
-	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	runtimeConfig.Pool.RestartPolicy = config.RuntimePlacementRestartPolicyAlways
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -1537,7 +1537,7 @@ func TestAgentRuntimeConfigProactiveReplacementRespectsMaxReadyInstances(t *test
 				"simple": {
 					Command:   bin,
 					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+					Runtime:   runtimeConfig,
 				},
 			},
 		},
@@ -1600,10 +1600,10 @@ func TestAgentRuntimeConfigDoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntim
 	runtimeConfig.Pool.StartupTimeout = "5m"
 	runtimeConfig.Pool.DrainTimeout = "2m"
 	runtimeConfig.Pool.HealthCheckInterval = "25ms"
-	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	runtimeConfig.Pool.RestartPolicy = config.RuntimePlacementRestartPolicyAlways
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -1615,7 +1615,7 @@ func TestAgentRuntimeConfigDoesNotImmediatelyChurnWhenExpiryReserveExceedsRuntim
 				"simple": {
 					Command:   bin,
 					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+					Runtime:   runtimeConfig,
 				},
 			},
 		},
@@ -1671,10 +1671,10 @@ func TestAgentRuntimeConfigReplacesExpiresOnlyRuntimeBeforeExpiry(t *testing.T) 
 	runtimeConfig.Pool.StartupTimeout = "5m"
 	runtimeConfig.Pool.DrainTimeout = "2m"
 	runtimeConfig.Pool.HealthCheckInterval = "25ms"
-	runtimeConfig.Pool.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	runtimeConfig.Pool.RestartPolicy = config.RuntimePlacementRestartPolicyAlways
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -1686,7 +1686,7 @@ func TestAgentRuntimeConfigReplacesExpiresOnlyRuntimeBeforeExpiry(t *testing.T) 
 				"simple": {
 					Command:   bin,
 					IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "agent_state"},
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: runtimeConfig},
+					Runtime:   runtimeConfig,
 				},
 			},
 		},
@@ -2044,7 +2044,7 @@ func TestAgentRuntimeConfigUsesPublicAgentHostBinding(t *testing.T) {
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -2054,8 +2054,8 @@ func TestAgentRuntimeConfigUsesPublicAgentHostBinding(t *testing.T) {
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command:   bin,
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: testHostedAgentRuntimeConfig()},
+					Command: bin,
+					Runtime: testHostedAgentRuntimeConfig(),
 				},
 			},
 		},
@@ -3281,7 +3281,7 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -3291,8 +3291,8 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command:   bin,
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: testHostedAgentRuntimeConfig()},
+					Command: bin,
+					Runtime: testHostedAgentRuntimeConfig(),
 				},
 			},
 		},
@@ -3361,13 +3361,10 @@ func TestAgentRuntimeImageLaunchUsesManifestEntrypoint(t *testing.T) {
 				Args:         []string{"--serve"},
 			},
 		},
-		Execution: &config.ExecutionConfig{
-			Mode: config.ExecutionModeHosted,
-			Runtime: &config.HostedRuntimeConfig{
-				Image: "ghcr.io/example/simple-agent@sha256:abc123",
-				ImagePullAuth: &config.HostedRuntimeImagePullAuth{
-					DockerConfigJSON: `{"auths":{"ghcr.io":{"username":"ghcr-user","password":" ghcr-token "}}}`,
-				},
+		Runtime: &config.RuntimePlacementConfig{
+			Image: "ghcr.io/example/simple-agent@sha256:abc123",
+			ImagePullAuth: &config.RuntimePlacementImagePullAuth{
+				DockerConfigJSON: `{"auths":{"ghcr.io":{"username":"ghcr-user","password":" ghcr-token "}}}`,
 			},
 		},
 	}
@@ -3392,23 +3389,20 @@ func TestAgentRuntimeImageLaunchUsesManifestEntrypoint(t *testing.T) {
 	}
 }
 
-func TestAgentRuntimeProviderEntryHostedRuntimeConfigIncludesImagePullAuth(t *testing.T) {
+func TestAgentRuntimeProviderEntryRuntimePlacementConfigIncludesImagePullAuth(t *testing.T) {
 	t.Parallel()
 
 	dockerConfigJSON := `{"auths":{"ghcr.io":{"username":"ghcr-user","password":" ghcr-token "}}}`
 	entry := &config.ProviderEntry{
-		Execution: &config.ExecutionConfig{
-			Mode: config.ExecutionModeHosted,
-			Runtime: &config.HostedRuntimeConfig{
-				Image: "ghcr.io/example/simple-agent@sha256:abc123",
-				ImagePullAuth: &config.HostedRuntimeImagePullAuth{
-					DockerConfigJSON: dockerConfigJSON,
-				},
+		Runtime: &config.RuntimePlacementConfig{
+			Image: "ghcr.io/example/simple-agent@sha256:abc123",
+			ImagePullAuth: &config.RuntimePlacementImagePullAuth{
+				DockerConfigJSON: dockerConfigJSON,
 			},
 		},
 	}
 
-	runtimeConfig := providerEntryHostedRuntimeConfig(entry)
+	runtimeConfig := providerEntryRuntimePlacementConfig(entry)
 	if runtimeConfig.ImagePullAuth == nil {
 		t.Fatal("ImagePullAuth = nil")
 	}
@@ -3416,7 +3410,7 @@ func TestAgentRuntimeProviderEntryHostedRuntimeConfigIncludesImagePullAuth(t *te
 		t.Fatalf("ImagePullAuth.DockerConfigJSON = %q, want opaque Docker config JSON preserved", runtimeConfig.ImagePullAuth.DockerConfigJSON)
 	}
 
-	entry.Execution.Runtime.ImagePullAuth.DockerConfigJSON = `{"auths":{"ghcr.io":{"username":"mutated","password":"mutated"}}}`
+	entry.Runtime.ImagePullAuth.DockerConfigJSON = `{"auths":{"ghcr.io":{"username":"mutated","password":"mutated"}}}`
 	if runtimeConfig.ImagePullAuth.DockerConfigJSON != dockerConfigJSON {
 		t.Fatalf("ImagePullAuth.DockerConfigJSON aliasing original config = %q, want opaque Docker config JSON preserved", runtimeConfig.ImagePullAuth.DockerConfigJSON)
 	}
@@ -3447,12 +3441,9 @@ func TestAgentRuntimeTemplateLaunchUsesManifestEntrypoint(t *testing.T) {
 				Args:         []string{"--serve"},
 			},
 		},
-		Execution: &config.ExecutionConfig{
-			Mode: config.ExecutionModeHosted,
-			Runtime: &config.HostedRuntimeConfig{
-				Provider: "hosted",
-				Template: "python-runtime",
-			},
+		Runtime: &config.RuntimePlacementConfig{
+			Provider: "hosted",
+			Template: "python-runtime",
 		},
 	}
 
@@ -3491,11 +3482,8 @@ func TestAgentRuntimeLocalFallbackImageLaunchUsesConfiguredCommand(t *testing.T)
 				Args:         []string{"--serve"},
 			},
 		},
-		Execution: &config.ExecutionConfig{
-			Mode: config.ExecutionModeHosted,
-			Runtime: &config.HostedRuntimeConfig{
-				Image: "ghcr.io/example/simple-agent@sha256:abc123",
-			},
+		Runtime: &config.RuntimePlacementConfig{
+			Image: "ghcr.io/example/simple-agent@sha256:abc123",
 		},
 	}
 
@@ -3538,7 +3526,7 @@ func TestAgentRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -3548,8 +3536,8 @@ func TestAgentRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 		Providers: config.ProvidersConfig{
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
-					Command:   bin,
-					Execution: &config.ExecutionConfig{Mode: config.ExecutionModeHosted, Runtime: testHostedAgentRuntimeConfig()},
+					Command: bin,
+					Runtime: testHostedAgentRuntimeConfig(),
 				},
 			},
 		},

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -8728,13 +8728,10 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		cfg := validConfig()
 		cfg.Providers.Agent = map[string]*config.ProviderEntry{
 			"simple": {
-				Execution: &config.ExecutionConfig{
-					Mode: config.ExecutionModeHosted,
-					Runtime: &config.HostedRuntimeConfig{
-						Image: "ghcr.io/example/simple-agent:latest",
-						ImagePullAuth: &config.HostedRuntimeImagePullAuth{
-							DockerConfigJSON: transportSecretRef("ghcr-docker-config"),
-						},
+				Runtime: &config.RuntimePlacementConfig{
+					Image: "ghcr.io/example/simple-agent:latest",
+					ImagePullAuth: &config.RuntimePlacementImagePullAuth{
+						DockerConfigJSON: transportSecretRef("ghcr-docker-config"),
 					},
 				},
 			},
@@ -8744,7 +8741,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			t.Fatalf("ResolveConfigSecrets: %v", err)
 		}
 
-		auth := cfg.Providers.Agent["simple"].Execution.Runtime.ImagePullAuth
+		auth := cfg.Providers.Agent["simple"].Runtime.ImagePullAuth
 		if auth == nil {
 			t.Fatal("imagePullAuth = nil")
 			return

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -1344,13 +1344,6 @@ func cloneRuntimeEgressPolicy(policy pluginruntime.RuntimeEgressPolicy) pluginru
 	}
 }
 
-func hostedExecutionConfig(runtimeCfg *config.HostedRuntimeConfig) *config.ExecutionConfig {
-	return &config.ExecutionConfig{
-		Mode:    config.ExecutionModeHosted,
-		Runtime: runtimeCfg,
-	}
-}
-
 func assertStartPluginEgressPolicy(t *testing.T, req pluginruntime.StartPluginRequest, allowedHosts []string, action pluginruntime.PolicyAction) {
 	t.Helper()
 	if got := req.Egress.AllowedHosts; !slices.Equal(got, allowedHosts) {
@@ -3990,7 +3983,7 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -4005,7 +3998,7 @@ func TestPluginAgentManagerTurnUsesInheritedInvokesAndRequestContext(t *testing.
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				Invokes: []config.PluginInvocationDependency{{
 					Plugin:    "roadmap",
 					Operation: "sync",
@@ -5582,7 +5575,7 @@ func TestPluginRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *te
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -5597,13 +5590,10 @@ func TestPluginRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *te
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution: &config.ExecutionConfig{
-					Mode: config.ExecutionModeHosted,
-					Runtime: &config.HostedRuntimeConfig{
-						Template: "python-dev",
-						Image:    "ghcr.io/valon/gestalt-python-runtime:latest",
-						Metadata: map[string]string{"tenant": "eng"},
-					},
+				Runtime: &config.RuntimePlacementConfig{
+					Template: "python-dev",
+					Image:    "ghcr.io/valon/gestalt-python-runtime:latest",
+					Metadata: map[string]string{"tenant": "eng"},
 				},
 			},
 		},
@@ -5707,7 +5697,7 @@ func TestPluginRuntimeStartsHostedCommandWithoutBundleStaging(t *testing.T) {
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -5722,7 +5712,7 @@ func TestPluginRuntimeStartsHostedCommandWithoutBundleStaging(t *testing.T) {
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: manifestPath,
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 			},
 		},
 	}
@@ -5782,7 +5772,7 @@ func TestPluginRuntimeImageLaunchUsesManifestEntrypoint(t *testing.T) {
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -5795,9 +5785,9 @@ func TestPluginRuntimeImageLaunchUsesManifestEntrypoint(t *testing.T) {
 			"echoext": {
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution: hostedExecutionConfig(&config.HostedRuntimeConfig{
+				Runtime: &config.RuntimePlacementConfig{
 					Image: "ghcr.io/example/echo-plugin@sha256:abc123",
-				}),
+				},
 			},
 		},
 	}
@@ -5850,7 +5840,7 @@ func TestPluginRuntimeTemplateLaunchUsesManifestEntrypoint(t *testing.T) {
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -5865,9 +5855,9 @@ func TestPluginRuntimeTemplateLaunchUsesManifestEntrypoint(t *testing.T) {
 				Args:                 []string{"host-arg"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution: hostedExecutionConfig(&config.HostedRuntimeConfig{
+				Runtime: &config.RuntimePlacementConfig{
 					Template: "python-runtime",
-				}),
+				},
 			},
 		},
 	}
@@ -5920,9 +5910,9 @@ func TestPluginRuntimeLocalFallbackImageLaunchUsesConfiguredCommand(t *testing.T
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution: hostedExecutionConfig(&config.HostedRuntimeConfig{
+				Runtime: &config.RuntimePlacementConfig{
 					Image: "ghcr.io/example/echo-plugin@sha256:abc123",
-				}),
+				},
 			},
 		},
 	}
@@ -5966,7 +5956,7 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -5982,7 +5972,7 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				S3:                   []string{"main"},
 			},
 		},
@@ -6289,7 +6279,7 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -6304,7 +6294,7 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: manifestPath,
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 			},
 		},
 	}
@@ -6380,7 +6370,7 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -6396,7 +6386,7 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				IndexedDB:            &config.HostIndexedDBBindingConfig{ObjectStores: []string{"tasks"}},
 			},
 		},
@@ -6502,7 +6492,7 @@ func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testi
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -6515,7 +6505,7 @@ func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testi
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				IndexedDB:            &config.HostIndexedDBBindingConfig{ObjectStores: []string{"tasks"}},
 			},
 		},
@@ -6620,7 +6610,7 @@ func TestPluginRuntimeConfigUsesPublicCacheRelayWithoutHostServiceTunnelCapabili
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -6636,7 +6626,7 @@ func TestPluginRuntimeConfigUsesPublicCacheRelayWithoutHostServiceTunnelCapabili
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				Cache:                []string{"session", "rate_limit"},
 			},
 		},
@@ -6744,7 +6734,7 @@ func TestPluginRuntimePublicCacheRelayRoundTripsThroughHostedPlugin(t *testing.T
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -6757,7 +6747,7 @@ func TestPluginRuntimePublicCacheRelayRoundTripsThroughHostedPlugin(t *testing.T
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				Cache:                []string{"session"},
 			},
 		},
@@ -6862,7 +6852,7 @@ func TestPluginRuntimePublicS3RelayRoundTripsThroughHostedPlugin(t *testing.T) {
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -6875,7 +6865,7 @@ func TestPluginRuntimePublicS3RelayRoundTripsThroughHostedPlugin(t *testing.T) {
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				S3:                   []string{"main"},
 			},
 		},
@@ -7006,7 +6996,7 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -7019,7 +7009,7 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 				Args:                 []string{"provider"},
 				ResolvedManifest:     callerManifest,
 				ResolvedManifestPath: filepath.Join(callerRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				Invokes:              callerInvokes,
 			},
 			"example": {
@@ -7145,7 +7135,7 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -7161,7 +7151,7 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 			},
 		},
 	}
@@ -7240,7 +7230,7 @@ func TestPluginRuntimeConfigRejectsMissingHostnameEgressCapability(t *testing.T)
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -7255,7 +7245,7 @@ func TestPluginRuntimeConfigRejectsMissingHostnameEgressCapability(t *testing.T)
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            &config.ExecutionConfig{Mode: config.ExecutionModeHosted},
+				Runtime:              &config.RuntimePlacementConfig{},
 				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"api.github.com"}},
 			},
 		},
@@ -7292,7 +7282,7 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -7307,7 +7297,7 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				Cache:                []string{"session"},
 			},
 		},
@@ -7348,7 +7338,7 @@ func TestPluginRuntimeConfigInjectsRuntimeLogSessionAndHostService(t *testing.T)
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -7361,7 +7351,7 @@ func TestPluginRuntimeConfigInjectsRuntimeLogSessionAndHostService(t *testing.T)
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 			},
 		},
 	}
@@ -7738,7 +7728,7 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -7753,7 +7743,7 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 			},
 		},
 	}
@@ -7893,7 +7883,7 @@ func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *t
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -7908,7 +7898,7 @@ func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *t
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 			},
 		},
 	}
@@ -8004,7 +7994,7 @@ func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapa
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -8020,7 +8010,7 @@ func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapa
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"api.github.com"}},
 			},
 		},
@@ -8090,7 +8080,7 @@ func TestPluginRuntimeConfigSkipsPublicEgressProxyWhenHostnameEgressIsNotRequire
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyAllow)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -8106,7 +8096,7 @@ func TestPluginRuntimeConfigSkipsPublicEgressProxyWhenHostnameEgressIsNotRequire
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 			},
 		},
 	}
@@ -8155,7 +8145,7 @@ func TestPluginRuntimeConfigUsesPublicRelayAndEgressProxyWhenHostCanRelay(t *tes
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -8171,7 +8161,7 @@ func TestPluginRuntimeConfigUsesPublicRelayAndEgressProxyWhenHostCanRelay(t *tes
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"api.github.com"}},
 				Cache:                []string{"session"},
 			},
@@ -8244,7 +8234,7 @@ func TestPluginRuntimePublicEgressProxyRoundTripsThroughHostedPlugin(t *testing.
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -8259,7 +8249,7 @@ func TestPluginRuntimePublicEgressProxyRoundTripsThroughHostedPlugin(t *testing.
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 				Egress:               &config.ProviderEgressConfig{AllowedHosts: []string{"127.0.0.1", "localhost"}},
 			},
 		},
@@ -8334,7 +8324,7 @@ func TestPluginRuntimeConfigRejectsDefaultDenyWithoutHostnameEgressCapability(t 
 	}
 	cfg := &config.Config{
 		Server: config.ServerConfig{
-			Runtime: config.ServerRuntimeConfig{DefaultHostedProvider: "hosted"},
+			Runtime: config.ServerRuntimeConfig{DefaultProvider: "hosted"},
 			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
@@ -8350,7 +8340,7 @@ func TestPluginRuntimeConfigRejectsDefaultDenyWithoutHostnameEgressCapability(t 
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Execution:            hostedExecutionConfig(&config.HostedRuntimeConfig{}),
+				Runtime:              &config.RuntimePlacementConfig{},
 			},
 		},
 	}

--- a/gestaltd/internal/bootstrap/hosted_agent_pool.go
+++ b/gestaltd/internal/bootstrap/hosted_agent_pool.go
@@ -28,7 +28,7 @@ type hostedAgentProviderPool struct {
 	launch       *hostedAgentProviderLaunch
 	hostServices []runtimehost.HostService
 	deps         Deps
-	policy       config.HostedRuntimeLifecyclePolicy
+	policy       config.RuntimePlacementLifecyclePolicy
 
 	ctx         context.Context
 	cancel      context.CancelFunc
@@ -62,7 +62,7 @@ type hostedAgentPoolBackend struct {
 	closed           bool
 }
 
-func newHostedAgentProviderPool(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []runtimehost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy) (coreagent.Provider, error) {
+func newHostedAgentProviderPool(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []runtimehost.HostService, deps Deps, policy config.RuntimePlacementLifecyclePolicy) (coreagent.Provider, error) {
 	if launch == nil {
 		return nil, fmt.Errorf("hosted agent launch is required")
 	}
@@ -85,7 +85,7 @@ func newHostedAgentProviderPool(ctx context.Context, launch *hostedAgentProvider
 			return nil, err
 		}
 	}
-	if policy.RestartPolicy != config.HostedRuntimeRestartPolicyNever {
+	if policy.RestartPolicy != config.RuntimePlacementRestartPolicyNever {
 		pool.lifecycleWG.Add(1)
 		go func() {
 			defer pool.lifecycleWG.Done()
@@ -231,7 +231,7 @@ func (p *hostedAgentProviderPool) removeAgentWorkspace(ctx context.Context, back
 	})
 }
 
-func hostedAgentWorkspacePrepareTimeout(cfg *config.HostedRuntimeWorkspaceConfig) time.Duration {
+func hostedAgentWorkspacePrepareTimeout(cfg *config.RuntimePlacementWorkspaceConfig) time.Duration {
 	const defaultTimeout = 10 * time.Minute
 	if cfg == nil || strings.TrimSpace(cfg.PrepareTimeout) == "" {
 		return defaultTimeout
@@ -243,7 +243,7 @@ func hostedAgentWorkspacePrepareTimeout(cfg *config.HostedRuntimeWorkspaceConfig
 	return timeout
 }
 
-func validateWorkspacePolicy(workspace *coreagent.Workspace, policy *config.HostedRuntimeWorkspaceConfig) error {
+func validateWorkspacePolicy(workspace *coreagent.Workspace, policy *config.RuntimePlacementWorkspaceConfig) error {
 	if workspace == nil {
 		return nil
 	}
@@ -1471,7 +1471,7 @@ func (p *hostedAgentProviderPool) ensureBackendFreshForNewWork(ctx context.Conte
 		p.replaceBackendAllowNever(backend, knownReason, true)
 		return p.unavailableError(fmt.Errorf("hosted agent provider %q runtime instance is stale: %s", p.name, knownReason))
 	}
-	if p.policy.RestartPolicy != config.HostedRuntimeRestartPolicyNever {
+	if p.policy.RestartPolicy != config.RuntimePlacementRestartPolicyNever {
 		return nil
 	}
 	session, drainAt, err := p.refreshBackendRuntimeSessionWithContext(ctx, backend, 10*time.Second)
@@ -1637,7 +1637,7 @@ func cloneTime(src *time.Time) *time.Time {
 }
 
 func (p *hostedAgentProviderPool) maybeProbeAfterCallError(backend *hostedAgentPoolBackend, callErr error) {
-	if callErr == nil || backend == nil || errors.Is(callErr, core.ErrNotFound) || p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever {
+	if callErr == nil || backend == nil || errors.Is(callErr, core.ErrNotFound) || p.policy.RestartPolicy == config.RuntimePlacementRestartPolicyNever {
 		return
 	}
 	go func() {
@@ -1671,7 +1671,7 @@ func (p *hostedAgentProviderPool) replaceBackend(backend *hostedAgentPoolBackend
 }
 
 func (p *hostedAgentProviderPool) replaceBackendAllowNever(backend *hostedAgentPoolBackend, reason string, allowRestartPolicyNever bool) {
-	if (p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever && !allowRestartPolicyNever) || !p.markBackendDraining(backend) {
+	if (p.policy.RestartPolicy == config.RuntimePlacementRestartPolicyNever && !allowRestartPolicyNever) || !p.markBackendDraining(backend) {
 		return
 	}
 	if !p.addLifecycleWork() {
@@ -1693,7 +1693,7 @@ func (p *hostedAgentProviderPool) replaceBackendAllowNever(backend *hostedAgentP
 }
 
 func (p *hostedAgentProviderPool) startProactiveReplacement(backend *hostedAgentPoolBackend, reason string) {
-	if backend == nil || p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever {
+	if backend == nil || p.policy.RestartPolicy == config.RuntimePlacementRestartPolicyNever {
 		return
 	}
 	p.mu.Lock()

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider.go
@@ -25,10 +25,10 @@ var errHostedWorkflowWorkerPoolClosed = errors.New("hosted workflow worker pool 
 
 type hostedWorkflowProviderLaunch struct {
 	name            string
-	runtimeConfig   config.EffectiveHostedRuntime
+	runtimeConfig   config.EffectiveRuntimePlacement
 	runtimeProvider pluginruntime.Provider
 	runtimeOwned    bool
-	runtimePlan     HostedRuntimePlan
+	runtimePlan     RuntimePlacementPlan
 	cfg             componentprovider.YAMLConfig
 	allowedHosts    []string
 	launch          hostedProcessLaunch
@@ -55,7 +55,7 @@ func buildHostedWorkflowWorkerPool(ctx context.Context, name string, entry *conf
 	}
 	launch.cleanup = chainCleanup(launch.cleanup, publicHostServicesCleanup)
 
-	runtimeCfg := entry.HostedRuntimeConfig()
+	runtimeCfg := entry.RuntimePlacementConfig()
 	if runtimeCfg == nil || !runtimeCfg.LifecyclePolicyFieldsSet() {
 		launch.close()
 		return nil, fmt.Errorf("workflow runtime pool is required")
@@ -97,7 +97,7 @@ func prepareHostedWorkflowProviderLaunch(ctx context.Context, name string, entry
 		return nil, fmt.Errorf("query %s support: %w", hostedRuntimeLabel(runtimeConfig), err)
 	}
 	requiresHostnameEgress := deps.Egress.ProviderPolicy(entry).RequiresHostnameEnforcement()
-	runtimePlan := buildHostedRuntimePlan(runtimeSupport, deps, true, requiresHostnameEgress)
+	runtimePlan := buildRuntimePlacementPlan(runtimeSupport, deps, true, requiresHostnameEgress)
 	if err := runtimePlan.Validate(hostedRuntimeLabel(runtimeConfig)); err != nil {
 		if runtimeOwned {
 			_ = runtimeProvider.Close()
@@ -285,7 +285,7 @@ func startHostedWorkflowProviderInstance(ctx context.Context, launch *hostedWork
 	}, nil
 }
 
-func hostedWorkflowAllowedHosts(configured []string, runtimePlan HostedRuntimePlan) []string {
+func hostedWorkflowAllowedHosts(configured []string, runtimePlan RuntimePlacementPlan) []string {
 	return hostedAgentAllowedHosts(configured, runtimePlan)
 }
 
@@ -343,7 +343,7 @@ type hostedWorkflowWorkerPool struct {
 	launch       *hostedWorkflowProviderLaunch
 	hostServices []runtimehost.HostService
 	deps         Deps
-	policy       config.HostedRuntimeLifecyclePolicy
+	policy       config.RuntimePlacementLifecyclePolicy
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -374,7 +374,7 @@ type hostedWorkflowWorker struct {
 	closed           bool
 }
 
-func newHostedWorkflowWorkerPool(launch *hostedWorkflowProviderLaunch, hostServices []runtimehost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy) (*hostedWorkflowWorkerPool, error) {
+func newHostedWorkflowWorkerPool(launch *hostedWorkflowProviderLaunch, hostServices []runtimehost.HostService, deps Deps, policy config.RuntimePlacementLifecyclePolicy) (*hostedWorkflowWorkerPool, error) {
 	if launch == nil {
 		return nil, fmt.Errorf("hosted workflow launch is required")
 	}
@@ -438,7 +438,7 @@ func (p *hostedWorkflowWorkerPool) startLoop() {
 		}
 		break
 	}
-	if p.policy.RestartPolicy != config.HostedRuntimeRestartPolicyNever {
+	if p.policy.RestartPolicy != config.RuntimePlacementRestartPolicyNever {
 		p.healthLoop()
 		return
 	}
@@ -770,7 +770,7 @@ func (p *hostedWorkflowWorkerPool) replaceWorker(worker *hostedWorkflowWorker) {
 }
 
 func (p *hostedWorkflowWorkerPool) replaceWorkerAllowNever(worker *hostedWorkflowWorker, reason string, allowRestartPolicyNever bool) {
-	if (p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever && !allowRestartPolicyNever) || !p.markWorkerDraining(worker) {
+	if (p.policy.RestartPolicy == config.RuntimePlacementRestartPolicyNever && !allowRestartPolicyNever) || !p.markWorkerDraining(worker) {
 		return
 	}
 	p.wg.Add(1)

--- a/gestaltd/internal/bootstrap/hosted_workflow_provider_test.go
+++ b/gestaltd/internal/bootstrap/hosted_workflow_provider_test.go
@@ -41,20 +41,18 @@ func TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup(t *t
 		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
 	}
 	entry := &config.ProviderEntry{
-		Execution: &config.ExecutionConfig{
-			Runtime: &config.HostedRuntimeConfig{
-				Provider: "gke",
-				Metadata: map[string]string{
-					"workload": "temporal-workers",
-				},
-				Pool: &config.HostedRuntimePoolConfig{
-					MinReadyInstances:   2,
-					MaxReadyInstances:   2,
-					StartupTimeout:      "5s",
-					HealthCheckInterval: "1m",
-					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
-					DrainTimeout:        "50ms",
-				},
+		Runtime: &config.RuntimePlacementConfig{
+			Provider: "gke",
+			Metadata: map[string]string{
+				"workload": "temporal-workers",
+			},
+			Pool: &config.RuntimePlacementPoolConfig{
+				MinReadyInstances:   2,
+				MaxReadyInstances:   2,
+				StartupTimeout:      "5s",
+				HealthCheckInterval: "1m",
+				RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
+				DrainTimeout:        "50ms",
 			},
 		},
 	}
@@ -169,17 +167,15 @@ func TestHostedWorkflowProviderPoolStartupDoesNotBlockWorkflowReadiness(t *testi
 		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
 	}
 	entry := &config.ProviderEntry{
-		Execution: &config.ExecutionConfig{
-			Runtime: &config.HostedRuntimeConfig{
-				Provider: "gke",
-				Pool: &config.HostedRuntimePoolConfig{
-					MinReadyInstances:   1,
-					MaxReadyInstances:   1,
-					StartupTimeout:      "5s",
-					HealthCheckInterval: "1m",
-					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
-					DrainTimeout:        "50ms",
-				},
+		Runtime: &config.RuntimePlacementConfig{
+			Provider: "gke",
+			Pool: &config.RuntimePlacementPoolConfig{
+				MinReadyInstances:   1,
+				MaxReadyInstances:   1,
+				StartupTimeout:      "5s",
+				HealthCheckInterval: "1m",
+				RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
+				DrainTimeout:        "50ms",
 			},
 		},
 	}
@@ -230,17 +226,15 @@ func TestWorkflowConfigReconciliationWaitsForRuntimeWorkers(t *testing.T) {
 		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
 	}
 	entry := &config.ProviderEntry{
-		Execution: &config.ExecutionConfig{
-			Runtime: &config.HostedRuntimeConfig{
-				Provider: "gke",
-				Pool: &config.HostedRuntimePoolConfig{
-					MinReadyInstances:   1,
-					MaxReadyInstances:   1,
-					StartupTimeout:      "5s",
-					HealthCheckInterval: "1m",
-					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
-					DrainTimeout:        "50ms",
-				},
+		Runtime: &config.RuntimePlacementConfig{
+			Provider: "gke",
+			Pool: &config.RuntimePlacementPoolConfig{
+				MinReadyInstances:   1,
+				MaxReadyInstances:   1,
+				StartupTimeout:      "5s",
+				HealthCheckInterval: "1m",
+				RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
+				DrainTimeout:        "50ms",
 			},
 		},
 	}
@@ -302,31 +296,31 @@ func TestWorkflowConfigReconciliationReconcilesReadyRuntimeProvidersIndependentl
 			Workflow: map[string]*config.ProviderEntry{
 				"ready": {
 					Source: config.ProviderSource{Path: "stub"},
-					Execution: &config.ExecutionConfig{Runtime: &config.HostedRuntimeConfig{
+					Runtime: &config.RuntimePlacementConfig{
 						Provider: "gke",
-						Pool: &config.HostedRuntimePoolConfig{
+						Pool: &config.RuntimePlacementPoolConfig{
 							MinReadyInstances:   1,
 							MaxReadyInstances:   1,
 							StartupTimeout:      "5s",
 							HealthCheckInterval: "1m",
-							RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+							RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
 							DrainTimeout:        "50ms",
 						},
-					}},
+					},
 				},
 				"stuck": {
 					Source: config.ProviderSource{Path: "stub"},
-					Execution: &config.ExecutionConfig{Runtime: &config.HostedRuntimeConfig{
+					Runtime: &config.RuntimePlacementConfig{
 						Provider: "gke",
-						Pool: &config.HostedRuntimePoolConfig{
+						Pool: &config.RuntimePlacementPoolConfig{
 							MinReadyInstances:   1,
 							MaxReadyInstances:   1,
 							StartupTimeout:      "5s",
 							HealthCheckInterval: "1m",
-							RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+							RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
 							DrainTimeout:        "50ms",
 						},
-					}},
+					},
 				},
 			},
 		},
@@ -395,17 +389,15 @@ func TestHostedWorkflowProviderPoolRejectsIncompatibleStartupSession(t *testing.
 		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
 	}
 	entry := &config.ProviderEntry{
-		Execution: &config.ExecutionConfig{
-			Runtime: &config.HostedRuntimeConfig{
-				Provider: "gke",
-				Pool: &config.HostedRuntimePoolConfig{
-					MinReadyInstances:   1,
-					MaxReadyInstances:   1,
-					StartupTimeout:      "5s",
-					HealthCheckInterval: "1m",
-					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
-					DrainTimeout:        "50ms",
-				},
+		Runtime: &config.RuntimePlacementConfig{
+			Provider: "gke",
+			Pool: &config.RuntimePlacementPoolConfig{
+				MinReadyInstances:   1,
+				MaxReadyInstances:   1,
+				StartupTimeout:      "5s",
+				HealthCheckInterval: "1m",
+				RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
+				DrainTimeout:        "50ms",
 			},
 		},
 	}
@@ -447,10 +439,10 @@ func TestHostedWorkflowProviderPoolClosedStartLoopDoesNotMarkReady(t *testing.T)
 		ctx:    ctx,
 		cancel: cancel,
 		ready:  make(chan struct{}),
-		policy: config.HostedRuntimeLifecyclePolicy{
+		policy: config.RuntimePlacementLifecyclePolicy{
 			MinReadyInstances:   1,
 			HealthCheckInterval: time.Hour,
-			RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+			RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
 		},
 	}
 	pool.mu.Lock()
@@ -488,10 +480,10 @@ func TestHostedWorkflowProviderPoolCloseUnblocksWaitReady(t *testing.T) {
 		ctx:    ctx,
 		cancel: cancel,
 		ready:  make(chan struct{}),
-		policy: config.HostedRuntimeLifecyclePolicy{
+		policy: config.RuntimePlacementLifecyclePolicy{
 			MinReadyInstances:   1,
 			HealthCheckInterval: time.Hour,
-			RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+			RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
 		},
 	}
 	t.Cleanup(func() { _ = pool.Close() })
@@ -528,17 +520,17 @@ func TestWorkflowConfigReconciliationFiltersRuntimePlacedProviders(t *testing.T)
 				"local": {Source: config.ProviderSource{Path: "stub"}},
 				"runtime": {
 					Source: config.ProviderSource{Path: "stub"},
-					Execution: &config.ExecutionConfig{Runtime: &config.HostedRuntimeConfig{
+					Runtime: &config.RuntimePlacementConfig{
 						Provider: "gke",
-						Pool: &config.HostedRuntimePoolConfig{
+						Pool: &config.RuntimePlacementPoolConfig{
 							MinReadyInstances:   1,
 							MaxReadyInstances:   1,
 							StartupTimeout:      "5s",
 							HealthCheckInterval: "1m",
-							RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+							RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
 							DrainTimeout:        "50ms",
 						},
-					}},
+					},
 				},
 			},
 		},
@@ -632,7 +624,7 @@ func workflowConfigTestAgentTarget() *config.WorkflowTargetConfig {
 func TestHostedWorkflowAllowedHostsFiltersLoopbackRelayTargets(t *testing.T) {
 	t.Parallel()
 
-	allowed := hostedWorkflowAllowedHosts([]string{"localhost", "127.0.0.1", "api.example.com"}, HostedRuntimePlan{
+	allowed := hostedWorkflowAllowedHosts([]string{"localhost", "127.0.0.1", "api.example.com"}, RuntimePlacementPlan{
 		Resolved: RuntimeBehavior{
 			HostServiceAccess: RuntimeHostServiceAccessRelay,
 			EgressMode:        RuntimeEgressModeNone,
@@ -656,17 +648,15 @@ func TestHostedWorkflowProviderKeepsSharedRuntimeOpen(t *testing.T) {
 		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
 	}
 	entry := &config.ProviderEntry{
-		Execution: &config.ExecutionConfig{
-			Runtime: &config.HostedRuntimeConfig{
-				Provider: "gke",
-				Pool: &config.HostedRuntimePoolConfig{
-					MinReadyInstances:   1,
-					MaxReadyInstances:   1,
-					StartupTimeout:      "5s",
-					HealthCheckInterval: "1m",
-					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
-					DrainTimeout:        "50ms",
-				},
+		Runtime: &config.RuntimePlacementConfig{
+			Provider: "gke",
+			Pool: &config.RuntimePlacementPoolConfig{
+				MinReadyInstances:   1,
+				MaxReadyInstances:   1,
+				StartupTimeout:      "5s",
+				HealthCheckInterval: "1m",
+				RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
+				DrainTimeout:        "50ms",
 			},
 		},
 	}
@@ -701,17 +691,15 @@ func TestHostedWorkflowProviderPoolDrainWaitsBeforeClosingWorker(t *testing.T) {
 		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
 	}
 	entry := &config.ProviderEntry{
-		Execution: &config.ExecutionConfig{
-			Runtime: &config.HostedRuntimeConfig{
-				Provider: "gke",
-				Pool: &config.HostedRuntimePoolConfig{
-					MinReadyInstances:   1,
-					MaxReadyInstances:   1,
-					StartupTimeout:      "5s",
-					HealthCheckInterval: "1m",
-					RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
-					DrainTimeout:        "150ms",
-				},
+		Runtime: &config.RuntimePlacementConfig{
+			Provider: "gke",
+			Pool: &config.RuntimePlacementPoolConfig{
+				MinReadyInstances:   1,
+				MaxReadyInstances:   1,
+				StartupTimeout:      "5s",
+				HealthCheckInterval: "1m",
+				RestartPolicy:       config.RuntimePlacementRestartPolicyNever,
+				DrainTimeout:        "150ms",
 			},
 		},
 	}

--- a/gestaltd/internal/bootstrap/plugin_runtime.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime.go
@@ -31,14 +31,14 @@ func newPluginRuntimeRegistry(cfg *config.Config, factory RuntimeFactory, deps D
 	}
 }
 
-func (r *pluginRuntimeRegistry) Resolve(ctx context.Context, configPath string, entry *config.ProviderEntry) (config.EffectiveHostedRuntime, pluginruntime.Provider, error) {
+func (r *pluginRuntimeRegistry) Resolve(ctx context.Context, configPath string, entry *config.ProviderEntry) (config.EffectiveRuntimePlacement, pluginruntime.Provider, error) {
 	if r == nil || r.cfg == nil {
-		return config.EffectiveHostedRuntime{}, nil, nil
+		return config.EffectiveRuntimePlacement{}, nil, nil
 	}
 
-	effective, err := r.cfg.EffectiveHostedRuntime(configPath, entry)
+	effective, err := r.cfg.EffectiveRuntimePlacement(configPath, entry)
 	if err != nil {
-		return config.EffectiveHostedRuntime{}, nil, err
+		return config.EffectiveRuntimePlacement{}, nil, err
 	}
 	if !effective.Enabled || effective.ProviderName == "" || effective.Provider == nil {
 		return effective, nil, nil
@@ -48,7 +48,7 @@ func (r *pluginRuntimeRegistry) Resolve(ctx context.Context, configPath string, 
 	return effective, provider, err
 }
 
-func (r *pluginRuntimeRegistry) resolveConfigured(ctx context.Context, effective config.EffectiveHostedRuntime) (pluginruntime.Provider, error) {
+func (r *pluginRuntimeRegistry) resolveConfigured(ctx context.Context, effective config.EffectiveRuntimePlacement) (pluginruntime.Provider, error) {
 	if r == nil {
 		return nil, fmt.Errorf("plugin runtime registry is not configured")
 	}

--- a/gestaltd/internal/bootstrap/plugin_runtime_launch.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_launch.go
@@ -16,7 +16,7 @@ type hostedProcessLaunch struct {
 	cleanup func()
 }
 
-func prepareHostedProcessLaunch(kind, name string, entry *config.ProviderEntry, command string, args []string, cleanup func(), runtimeConfig config.EffectiveHostedRuntime) (hostedProcessLaunch, error) {
+func prepareHostedProcessLaunch(kind, name string, entry *config.ProviderEntry, command string, args []string, cleanup func(), runtimeConfig config.EffectiveRuntimePlacement) (hostedProcessLaunch, error) {
 	if hostedRuntimeUsesImageEntrypoint(runtimeConfig) {
 		command, args, err := hostedRuntimeImageEntrypoint(kind, name, entry)
 		if err != nil {
@@ -40,7 +40,7 @@ func prepareHostedProcessLaunch(kind, name string, entry *config.ProviderEntry, 
 	return launch, nil
 }
 
-func hostedRuntimeUsesImageEntrypoint(runtimeConfig config.EffectiveHostedRuntime) bool {
+func hostedRuntimeUsesImageEntrypoint(runtimeConfig config.EffectiveRuntimePlacement) bool {
 	hasRuntimeImageOrTemplate := strings.TrimSpace(runtimeConfig.Image) != "" || strings.TrimSpace(runtimeConfig.Template) != ""
 	if runtimeConfig.Provider != nil {
 		return runtimeConfig.Provider.Driver != config.RuntimeProviderDriverLocal && hasRuntimeImageOrTemplate

--- a/gestaltd/internal/bootstrap/plugin_runtime_plan.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_plan.go
@@ -36,16 +36,16 @@ type RuntimeBehavior struct {
 	EgressMode        RuntimeEgressMode
 }
 
-type HostedRuntimePlan struct {
+type RuntimePlacementPlan struct {
 	Resolved                  RuntimeBehavior
 	RequiresHostServiceAccess bool
 	RequiresHostnameEgress    bool
 	HostnameEgressDelivery    RuntimeHostnameEgressDelivery
 }
 
-func buildHostedRuntimePlan(support pluginruntime.Support, deps Deps, requiresHostServiceAccess, requiresHostnameEgress bool) HostedRuntimePlan {
+func buildRuntimePlacementPlan(support pluginruntime.Support, deps Deps, requiresHostServiceAccess, requiresHostnameEgress bool) RuntimePlacementPlan {
 	resolved := runtimeResolvedBehavior(runtimeAdvertisedBehavior(support), deps)
-	return HostedRuntimePlan{
+	return RuntimePlacementPlan{
 		Resolved:                  resolved,
 		RequiresHostServiceAccess: requiresHostServiceAccess,
 		RequiresHostnameEgress:    requiresHostnameEgress,
@@ -53,12 +53,12 @@ func buildHostedRuntimePlan(support pluginruntime.Support, deps Deps, requiresHo
 	}
 }
 
-func buildPluginRuntimePlan(pluginName string, entry *config.ProviderEntry, deps Deps, support pluginruntime.Support) (HostedRuntimePlan, error) {
+func buildPluginRuntimePlan(pluginName string, entry *config.ProviderEntry, deps Deps, support pluginruntime.Support) (RuntimePlacementPlan, error) {
 	requiresHostServiceAccess, requiresHostnameEgress, err := pluginRuntimeRequirementsForPlugin(pluginName, entry, deps)
 	if err != nil {
-		return HostedRuntimePlan{}, err
+		return RuntimePlacementPlan{}, err
 	}
-	return buildHostedRuntimePlan(support, deps, requiresHostServiceAccess, requiresHostnameEgress), nil
+	return buildRuntimePlacementPlan(support, deps, requiresHostServiceAccess, requiresHostnameEgress), nil
 }
 
 func runtimeAdvertisedBehavior(support pluginruntime.Support) RuntimeBehavior {
@@ -152,7 +152,7 @@ func agentRuntimeRequirementsForProvider(name string, entry *config.ProviderEntr
 	return true, deps.Egress.ProviderPolicy(entry).RequiresHostnameEnforcement(), nil
 }
 
-func (p HostedRuntimePlan) Validate(label string) error {
+func (p RuntimePlacementPlan) Validate(label string) error {
 	if label == "" {
 		label = "hosted runtime"
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1095,15 +1095,15 @@ func buildHostedAgentProvider(ctx context.Context, name string, entry *config.Pr
 	if err != nil {
 		return nil, err
 	}
-	runtimeCfg := entry.HostedRuntimeConfig()
+	runtimeCfg := entry.RuntimePlacementConfig()
 	policy, err := runtimeCfg.LifecyclePolicy()
 	if err != nil {
 		launch.close()
 		return nil, fmt.Errorf("parse hosted agent runtime lifecycle policy: %w", err)
 	}
-	if policy.RestartPolicy == config.HostedRuntimeRestartPolicyAlways && entry.IndexedDB == nil {
+	if policy.RestartPolicy == config.RuntimePlacementRestartPolicyAlways && entry.IndexedDB == nil {
 		launch.close()
-		return nil, fmt.Errorf("hosted agent runtime restart policy %q requires indexeddb persistence hook", config.HostedRuntimeRestartPolicyAlways)
+		return nil, fmt.Errorf("hosted agent runtime restart policy %q requires indexeddb persistence hook", config.RuntimePlacementRestartPolicyAlways)
 	}
 	hostServices = appendRuntimeLogHostService(hostServices, launch.runtimeConfig, deps, launch.runtimePlan)
 	publicHostServicesCleanup, err := registerPublicRuntimeHostServices(name, hostServices, deps, launch.runtimePlan, launch.runtimeProvider)
@@ -1117,10 +1117,10 @@ func buildHostedAgentProvider(ctx context.Context, name string, entry *config.Pr
 
 type hostedAgentProviderLaunch struct {
 	name            string
-	runtimeConfig   config.EffectiveHostedRuntime
+	runtimeConfig   config.EffectiveRuntimePlacement
 	runtimeProvider pluginruntime.Provider
 	runtimeOwned    bool
-	runtimePlan     HostedRuntimePlan
+	runtimePlan     RuntimePlacementPlan
 	cfg             componentprovider.YAMLConfig
 	allowedHosts    []string
 	launch          hostedProcessLaunch
@@ -1169,7 +1169,7 @@ func prepareHostedAgentProviderLaunch(ctx context.Context, name string, entry *c
 		}
 		return nil, err
 	}
-	runtimePlan := buildHostedRuntimePlan(runtimeSupport, deps, requiresHostServiceAccess, requiresHostnameEgress)
+	runtimePlan := buildRuntimePlacementPlan(runtimeSupport, deps, requiresHostServiceAccess, requiresHostnameEgress)
 	if err := runtimePlan.Validate(hostedRuntimeLabel(runtimeConfig)); err != nil {
 		if runtimeOwned {
 			_ = runtimeProvider.Close()
@@ -1376,57 +1376,57 @@ func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentPr
 	}, nil
 }
 
-func effectiveConfiguredHostedRuntime(ctx context.Context, configPath string, entry *config.ProviderEntry, deps Deps) (config.EffectiveHostedRuntime, pluginruntime.Provider, bool, error) {
+func effectiveConfiguredHostedRuntime(ctx context.Context, configPath string, entry *config.ProviderEntry, deps Deps) (config.EffectiveRuntimePlacement, pluginruntime.Provider, bool, error) {
 	if entry == nil || !entry.UsesRuntimePlacement() {
-		return config.EffectiveHostedRuntime{}, nil, false, nil
+		return config.EffectiveRuntimePlacement{}, nil, false, nil
 	}
-	explicitRuntimeConfig := providerEntryHostedRuntimeConfig(entry)
+	explicitRuntimeConfig := providerEntryRuntimePlacementConfig(entry)
 	if deps.PluginRuntime != nil {
 		return explicitRuntimeConfig, deps.PluginRuntime, false, nil
 	}
 	if deps.PluginRuntimeRegistry != nil {
 		runtimeConfig, runtimeProvider, err := deps.PluginRuntimeRegistry.Resolve(ctx, configPath, entry)
 		if err != nil {
-			return config.EffectiveHostedRuntime{}, nil, false, err
+			return config.EffectiveRuntimePlacement{}, nil, false, err
 		}
 		if runtimeProvider != nil {
 			return runtimeConfig, runtimeProvider, false, nil
 		}
 		if runtimeConfig.Enabled {
-			return localHostedRuntimeConfig(runtimeConfig), newLocalPluginRuntime(runtimeConfig.ProviderName, deps), true, nil
+			return localRuntimePlacementConfig(runtimeConfig), newLocalPluginRuntime(runtimeConfig.ProviderName, deps), true, nil
 		}
 	}
-	return localHostedRuntimeConfig(explicitRuntimeConfig), newLocalPluginRuntime(explicitRuntimeConfig.ProviderName, deps), true, nil
+	return localRuntimePlacementConfig(explicitRuntimeConfig), newLocalPluginRuntime(explicitRuntimeConfig.ProviderName, deps), true, nil
 }
 
-func effectivePluginRuntime(ctx context.Context, name string, entry *config.ProviderEntry, deps Deps) (config.EffectiveHostedRuntime, pluginruntime.Provider, bool, error) {
+func effectivePluginRuntime(ctx context.Context, name string, entry *config.ProviderEntry, deps Deps) (config.EffectiveRuntimePlacement, pluginruntime.Provider, bool, error) {
 	if deps.PluginRuntime != nil {
-		return providerEntryHostedRuntimeConfig(entry), deps.PluginRuntime, false, nil
+		return providerEntryRuntimePlacementConfig(entry), deps.PluginRuntime, false, nil
 	}
 	if deps.PluginRuntimeRegistry != nil {
 		runtimeConfig, runtimeProvider, err := deps.PluginRuntimeRegistry.Resolve(ctx, "plugins."+name, entry)
 		if err != nil {
-			return config.EffectiveHostedRuntime{}, nil, false, err
+			return config.EffectiveRuntimePlacement{}, nil, false, err
 		}
 		if runtimeProvider != nil {
 			return runtimeConfig, runtimeProvider, false, nil
 		}
 		if runtimeConfig.Enabled {
-			return localHostedRuntimeConfig(runtimeConfig), newLocalPluginRuntime(runtimeConfig.ProviderName, deps), true, nil
+			return localRuntimePlacementConfig(runtimeConfig), newLocalPluginRuntime(runtimeConfig.ProviderName, deps), true, nil
 		}
 	}
-	return localHostedRuntimeConfig(config.EffectiveHostedRuntime{}), newLocalPluginRuntime("", deps), true, nil
+	return localRuntimePlacementConfig(config.EffectiveRuntimePlacement{}), newLocalPluginRuntime("", deps), true, nil
 }
 
-func providerEntryHostedRuntimeConfig(entry *config.ProviderEntry) config.EffectiveHostedRuntime {
+func providerEntryRuntimePlacementConfig(entry *config.ProviderEntry) config.EffectiveRuntimePlacement {
 	if entry == nil {
-		return config.EffectiveHostedRuntime{}
+		return config.EffectiveRuntimePlacement{}
 	}
-	runtimeCfg := entry.HostedRuntimeConfig()
+	runtimeCfg := entry.RuntimePlacementConfig()
 	if runtimeCfg == nil {
-		return config.EffectiveHostedRuntime{Enabled: entry.UsesRuntimePlacement()}
+		return config.EffectiveRuntimePlacement{Enabled: entry.UsesRuntimePlacement()}
 	}
-	effective := config.EffectiveHostedRuntime{
+	effective := config.EffectiveRuntimePlacement{
 		Enabled:       entry.UsesRuntimePlacement(),
 		ProviderName:  strings.TrimSpace(runtimeCfg.Provider),
 		Template:      strings.TrimSpace(runtimeCfg.Template),
@@ -1438,31 +1438,31 @@ func providerEntryHostedRuntimeConfig(entry *config.ProviderEntry) config.Effect
 	return effective
 }
 
-func hostedRuntimeConfigImagePullAuth(auth *config.HostedRuntimeImagePullAuth) *config.HostedRuntimeImagePullAuth {
+func hostedRuntimeConfigImagePullAuth(auth *config.RuntimePlacementImagePullAuth) *config.RuntimePlacementImagePullAuth {
 	if auth == nil {
 		return nil
 	}
-	return &config.HostedRuntimeImagePullAuth{
+	return &config.RuntimePlacementImagePullAuth{
 		DockerConfigJSON: auth.DockerConfigJSON,
 	}
 }
 
-func hostedRuntimeWorkspaceConfig(workspace *config.HostedRuntimeWorkspaceConfig) *config.HostedRuntimeWorkspaceConfig {
+func hostedRuntimeWorkspaceConfig(workspace *config.RuntimePlacementWorkspaceConfig) *config.RuntimePlacementWorkspaceConfig {
 	if workspace == nil {
 		return nil
 	}
-	out := &config.HostedRuntimeWorkspaceConfig{
+	out := &config.RuntimePlacementWorkspaceConfig{
 		PrepareTimeout: workspace.PrepareTimeout,
 	}
 	if workspace.Git != nil {
-		out.Git = &config.HostedRuntimeWorkspaceGitConfig{
+		out.Git = &config.RuntimePlacementWorkspaceGitConfig{
 			AllowedRepositories: slices.Clone(workspace.Git.AllowedRepositories),
 		}
 	}
 	return out
 }
 
-func localHostedRuntimeConfig(runtimeConfig config.EffectiveHostedRuntime) config.EffectiveHostedRuntime {
+func localRuntimePlacementConfig(runtimeConfig config.EffectiveRuntimePlacement) config.EffectiveRuntimePlacement {
 	if runtimeConfig.Provider == nil {
 		runtimeConfig.Provider = &config.RuntimeProviderEntry{Driver: config.RuntimeProviderDriverLocal}
 	}
@@ -1495,14 +1495,14 @@ type RuntimeEgressLaunchPlan struct {
 	RuntimeAllowedHosts []string
 }
 
-func hostedRuntimeLabel(runtimeConfig config.EffectiveHostedRuntime) string {
+func hostedRuntimeLabel(runtimeConfig config.EffectiveRuntimePlacement) string {
 	if name := strings.TrimSpace(runtimeConfig.ProviderName); name != "" {
 		return fmt.Sprintf("runtime provider %q", name)
 	}
 	return "hosted runtime"
 }
 
-func buildHostedRuntimeStartSessionRequest(kind, name string, runtimeConfig config.EffectiveHostedRuntime) pluginruntime.StartSessionRequest {
+func buildHostedRuntimeStartSessionRequest(kind, name string, runtimeConfig config.EffectiveRuntimePlacement) pluginruntime.StartSessionRequest {
 	metadata := maps.Clone(runtimeConfig.Metadata)
 	if metadata == nil {
 		metadata = map[string]string{}
@@ -1522,7 +1522,7 @@ func buildHostedRuntimeStartSessionRequest(kind, name string, runtimeConfig conf
 	}
 }
 
-func hostedRuntimeImagePullAuth(auth *config.HostedRuntimeImagePullAuth) *pluginruntime.ImagePullAuth {
+func hostedRuntimeImagePullAuth(auth *config.RuntimePlacementImagePullAuth) *pluginruntime.ImagePullAuth {
 	if auth == nil {
 		return nil
 	}
@@ -1531,7 +1531,7 @@ func hostedRuntimeImagePullAuth(auth *config.HostedRuntimeImagePullAuth) *plugin
 	}
 }
 
-func buildHostedRuntimeEgressLaunchPlan(providerName, sessionID string, policy egress.Policy, runtimeAllowedHosts []string, runtimePlan HostedRuntimePlan, deps Deps) (RuntimeEgressLaunchPlan, error) {
+func buildHostedRuntimeEgressLaunchPlan(providerName, sessionID string, policy egress.Policy, runtimeAllowedHosts []string, runtimePlan RuntimePlacementPlan, deps Deps) (RuntimeEgressLaunchPlan, error) {
 	plan := RuntimeEgressLaunchPlan{
 		Policy: egress.Policy{
 			AllowedHosts:  slices.Clone(policy.AllowedHosts),
@@ -1698,7 +1698,7 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 	return hostServices, invTokens, cleanup, nil
 }
 
-func appendRuntimeLogHostService(hostServices []runtimehost.HostService, runtimeConfig config.EffectiveHostedRuntime, deps Deps, runtimePlan HostedRuntimePlan) []runtimehost.HostService {
+func appendRuntimeLogHostService(hostServices []runtimehost.HostService, runtimeConfig config.EffectiveRuntimePlacement, deps Deps, runtimePlan RuntimePlacementPlan) []runtimehost.HostService {
 	if deps.Services == nil || deps.Services.RuntimeSessionLogs == nil || runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessNone {
 		return hostServices
 	}
@@ -1712,7 +1712,7 @@ func appendRuntimeLogHostService(hostServices []runtimehost.HostService, runtime
 	})
 }
 
-func runtimeSessionLogProviderName(runtimeConfig config.EffectiveHostedRuntime) string {
+func runtimeSessionLogProviderName(runtimeConfig config.EffectiveRuntimePlacement) string {
 	if name := strings.TrimSpace(runtimeConfig.ProviderName); name != "" {
 		return name
 	}
@@ -1879,7 +1879,7 @@ func (v runtimeHostServiceSessionVerifier) VerifyHostServiceSession(ctx context.
 	}
 }
 
-func registerPublicRuntimeHostServices(providerName string, hostServices []runtimehost.HostService, deps Deps, runtimePlan HostedRuntimePlan, runtimeProvider pluginruntime.Provider) (func(), error) {
+func registerPublicRuntimeHostServices(providerName string, hostServices []runtimehost.HostService, deps Deps, runtimePlan RuntimePlacementPlan, runtimeProvider pluginruntime.Provider) (func(), error) {
 	if runtimePlan.Resolved.HostServiceAccess != RuntimeHostServiceAccessRelay || deps.PublicHostServices == nil {
 		return nil, nil
 	}
@@ -2051,7 +2051,7 @@ func appendAllowedHost(allowedHosts []string, host string) []string {
 	return append(allowedHosts, host)
 }
 
-func hostedAgentAllowedHosts(allowedHosts []string, runtimePlan HostedRuntimePlan) []string {
+func hostedAgentAllowedHosts(allowedHosts []string, runtimePlan RuntimePlacementPlan) []string {
 	cloned := slices.Clone(allowedHosts)
 	if runtimePlan.Resolved.HostServiceAccess != RuntimeHostServiceAccessRelay || runtimePlan.RequiresHostnameEgress {
 		return cloned

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -415,8 +415,7 @@ type ProviderEntry struct {
 	IndexedDB         *HostIndexedDBBindingConfig   `yaml:"indexeddb,omitempty"`
 	Cache             []string                      `yaml:"cache,omitempty"`
 	S3                []string                      `yaml:"s3,omitempty"`
-	Runtime           *HostedRuntimeConfig          `yaml:"runtime,omitempty"`
-	Execution         *ExecutionConfig              `yaml:"execution,omitempty"`
+	Runtime           *RuntimePlacementConfig       `yaml:"runtime,omitempty"`
 	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
 	MCP               bool                          `yaml:"mcp,omitempty"`
 
@@ -522,6 +521,9 @@ type uiEntryMarshalYAML struct {
 
 func (e *ProviderEntry) UnmarshalYAML(value *yaml.Node) error {
 	normalized := cloneYAMLNode(value)
+	if mappingValueNode(normalized, "execution") != nil {
+		return fmt.Errorf("config validation: provider execution has been removed; use runtime instead")
+	}
 	uiBinding, err := normalizeProviderEntryUINode(normalized)
 	if err != nil {
 		return err
@@ -587,74 +589,62 @@ type ProviderEgressConfig struct {
 	AllowedHosts []string `yaml:"allowedHosts,omitempty"`
 }
 
-type ExecutionMode string
-
-const (
-	ExecutionModeLocal  ExecutionMode = "local"
-	ExecutionModeHosted ExecutionMode = "hosted"
-)
-
-type ExecutionConfig struct {
-	Mode    ExecutionMode        `yaml:"mode,omitempty"`
-	Runtime *HostedRuntimeConfig `yaml:"runtime,omitempty"`
+type RuntimePlacementConfig struct {
+	Provider      string                           `yaml:"provider,omitempty"`
+	Template      string                           `yaml:"template,omitempty"`
+	Image         string                           `yaml:"image,omitempty"`
+	ImagePullAuth *RuntimePlacementImagePullAuth   `yaml:"imagePullAuth,omitempty"`
+	Metadata      map[string]string                `yaml:"metadata,omitempty"`
+	Pool          *RuntimePlacementPoolConfig      `yaml:"pool,omitempty"`
+	Workspace     *RuntimePlacementWorkspaceConfig `yaml:"workspace,omitempty"`
 }
 
-type HostedRuntimeConfig struct {
-	Provider      string                        `yaml:"provider,omitempty"`
-	Template      string                        `yaml:"template,omitempty"`
-	Image         string                        `yaml:"image,omitempty"`
-	ImagePullAuth *HostedRuntimeImagePullAuth   `yaml:"imagePullAuth,omitempty"`
-	Metadata      map[string]string             `yaml:"metadata,omitempty"`
-	Pool          *HostedRuntimePoolConfig      `yaml:"pool,omitempty"`
-	Workspace     *HostedRuntimeWorkspaceConfig `yaml:"workspace,omitempty"`
-}
-
-type HostedRuntimeImagePullAuth struct {
+type RuntimePlacementImagePullAuth struct {
 	DockerConfigJSON string `yaml:"dockerConfigJson,omitempty"`
 }
 
-type HostedRuntimeWorkspaceConfig struct {
-	PrepareTimeout string                           `yaml:"prepareTimeout,omitempty"`
-	Git            *HostedRuntimeWorkspaceGitConfig `yaml:"git,omitempty"`
+type RuntimePlacementWorkspaceConfig struct {
+	PrepareTimeout string                              `yaml:"prepareTimeout,omitempty"`
+	Git            *RuntimePlacementWorkspaceGitConfig `yaml:"git,omitempty"`
 }
 
-type HostedRuntimeWorkspaceGitConfig struct {
+type RuntimePlacementWorkspaceGitConfig struct {
 	AllowedRepositories []string `yaml:"allowedRepositories,omitempty"`
 }
 
-type HostedRuntimePoolConfig struct {
-	MinReadyInstances   int                        `yaml:"minReadyInstances,omitempty"`
-	MaxReadyInstances   int                        `yaml:"maxReadyInstances,omitempty"`
-	StartupTimeout      string                     `yaml:"startupTimeout,omitempty"`
-	HealthCheckInterval string                     `yaml:"healthCheckInterval,omitempty"`
-	RestartPolicy       HostedRuntimeRestartPolicy `yaml:"restartPolicy,omitempty"`
-	DrainTimeout        string                     `yaml:"drainTimeout,omitempty"`
+type RuntimePlacementPoolConfig struct {
+	MinReadyInstances   int                           `yaml:"minReadyInstances,omitempty"`
+	MaxReadyInstances   int                           `yaml:"maxReadyInstances,omitempty"`
+	StartupTimeout      string                        `yaml:"startupTimeout,omitempty"`
+	HealthCheckInterval string                        `yaml:"healthCheckInterval,omitempty"`
+	RestartPolicy       RuntimePlacementRestartPolicy `yaml:"restartPolicy,omitempty"`
+	DrainTimeout        string                        `yaml:"drainTimeout,omitempty"`
 }
 
-type HostedRuntimeRestartPolicy string
+type RuntimePlacementRestartPolicy string
 
 const (
-	HostedRuntimeRestartPolicyAlways HostedRuntimeRestartPolicy = "always"
-	HostedRuntimeRestartPolicyNever  HostedRuntimeRestartPolicy = "never"
+	RuntimePlacementRestartPolicyAlways RuntimePlacementRestartPolicy = "always"
+	RuntimePlacementRestartPolicyNever  RuntimePlacementRestartPolicy = "never"
 )
 
-type HostedRuntimeLifecyclePolicy struct {
+type RuntimePlacementLifecyclePolicy struct {
 	MinReadyInstances   int
 	MaxReadyInstances   int
 	StartupTimeout      time.Duration
 	HealthCheckInterval time.Duration
-	RestartPolicy       HostedRuntimeRestartPolicy
+	RestartPolicy       RuntimePlacementRestartPolicy
 	DrainTimeout        time.Duration
 }
 
-func (c *HostedRuntimeConfig) LifecyclePolicyFieldsSet() bool {
+func (c *RuntimePlacementConfig) LifecyclePolicyFieldsSet() bool {
 	if c == nil {
 		return false
 	}
 	return c.Pool != nil && c.Pool.lifecyclePolicyFieldsSet()
 }
 
-func (c *HostedRuntimePoolConfig) lifecyclePolicyFieldsSet() bool {
+func (c *RuntimePlacementPoolConfig) lifecyclePolicyFieldsSet() bool {
 	if c == nil {
 		return false
 	}
@@ -666,41 +656,41 @@ func (c *HostedRuntimePoolConfig) lifecyclePolicyFieldsSet() bool {
 		strings.TrimSpace(c.DrainTimeout) != ""
 }
 
-func (c *HostedRuntimeConfig) LifecyclePolicy() (HostedRuntimeLifecyclePolicy, error) {
+func (c *RuntimePlacementConfig) LifecyclePolicy() (RuntimePlacementLifecyclePolicy, error) {
 	if c == nil {
-		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("runtime config is required")
+		return RuntimePlacementLifecyclePolicy{}, fmt.Errorf("runtime config is required")
 	}
 	lifecycle := c.lifecyclePolicyConfig()
 	startupTimeout, err := ParseDuration(strings.TrimSpace(lifecycle.StartupTimeout))
 	if err != nil {
-		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("startupTimeout: %w", err)
+		return RuntimePlacementLifecyclePolicy{}, fmt.Errorf("startupTimeout: %w", err)
 	}
 	healthCheckInterval, err := ParseDuration(strings.TrimSpace(lifecycle.HealthCheckInterval))
 	if err != nil {
-		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("healthCheckInterval: %w", err)
+		return RuntimePlacementLifecyclePolicy{}, fmt.Errorf("healthCheckInterval: %w", err)
 	}
 	drainTimeout, err := ParseDuration(strings.TrimSpace(lifecycle.DrainTimeout))
 	if err != nil {
-		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("drainTimeout: %w", err)
+		return RuntimePlacementLifecyclePolicy{}, fmt.Errorf("drainTimeout: %w", err)
 	}
-	return HostedRuntimeLifecyclePolicy{
+	return RuntimePlacementLifecyclePolicy{
 		MinReadyInstances:   lifecycle.MinReadyInstances,
 		MaxReadyInstances:   lifecycle.MaxReadyInstances,
 		StartupTimeout:      startupTimeout,
 		HealthCheckInterval: healthCheckInterval,
-		RestartPolicy:       HostedRuntimeRestartPolicy(strings.TrimSpace(string(lifecycle.RestartPolicy))),
+		RestartPolicy:       RuntimePlacementRestartPolicy(strings.TrimSpace(string(lifecycle.RestartPolicy))),
 		DrainTimeout:        drainTimeout,
 	}, nil
 }
 
-func (c *HostedRuntimeConfig) lifecyclePolicyConfig() HostedRuntimePoolConfig {
+func (c *RuntimePlacementConfig) lifecyclePolicyConfig() RuntimePlacementPoolConfig {
 	if c == nil {
-		return HostedRuntimePoolConfig{}
+		return RuntimePlacementPoolConfig{}
 	}
 	if c.Pool != nil {
 		return *c.Pool
 	}
-	return HostedRuntimePoolConfig{}
+	return RuntimePlacementPoolConfig{}
 }
 
 type WorkflowsConfig struct {
@@ -943,8 +933,7 @@ func (f providerEntryFields) toProviderEntry() ProviderEntry {
 
 func providerEntryFieldsFromEntry(e ProviderEntry) providerEntryFields {
 	e.Egress = cloneProviderEgressConfig(e.Egress)
-	e.Runtime = cloneHostedRuntimeConfig(e.Runtime)
-	e.Execution = cloneExecutionConfig(e.Execution)
+	e.Runtime = cloneRuntimePlacementConfig(e.Runtime)
 	e.Dev = cloneProviderEntryDevConfig(e.Dev)
 	e.Harnesses = cloneProviderEntryHarnessConfigMap(e.Harnesses)
 	e.LocalHarness = cloneProviderEntryHarnessConfig(e.LocalHarness)
@@ -1023,9 +1012,6 @@ func normalizeProviderEntryAliases(entry *ProviderEntry) {
 	}
 	if entry.Egress != nil {
 		entry.Egress.AllowedHosts = trimStringSlice(entry.Egress.AllowedHosts)
-	}
-	if entry.Execution != nil {
-		entry.Execution.Mode = ExecutionMode(strings.ToLower(strings.TrimSpace(string(entry.Execution.Mode))))
 	}
 	if entry.Dev != nil {
 		entry.Dev.Attach.AllowedRoles = trimStringSlice(entry.Dev.Attach.AllowedRoles)
@@ -1134,38 +1120,18 @@ func (e *ProviderEntry) EffectiveAllowedHosts() []string {
 	return nil
 }
 
-func (e *ProviderEntry) UsesHostedExecution() bool {
-	return e.UsesRuntimePlacement()
-}
-
 func (e *ProviderEntry) UsesRuntimePlacement() bool {
 	if e == nil {
 		return false
 	}
-	if e.Runtime != nil {
-		return true
-	}
-	if e.Execution != nil {
-		mode := ExecutionMode(strings.ToLower(strings.TrimSpace(string(e.Execution.Mode))))
-		if mode == "" {
-			return e.Execution.Runtime != nil
-		}
-		return mode == ExecutionModeHosted
-	}
-	return false
+	return e.Runtime != nil
 }
 
-func (e *ProviderEntry) HostedRuntimeConfig() *HostedRuntimeConfig {
+func (e *ProviderEntry) RuntimePlacementConfig() *RuntimePlacementConfig {
 	if e == nil {
 		return nil
 	}
-	if e.Runtime != nil {
-		return e.Runtime
-	}
-	if e.Execution != nil {
-		return e.Execution.Runtime
-	}
-	return nil
+	return e.Runtime
 }
 
 func cloneProviderEgressConfig(src *ProviderEgressConfig) *ProviderEgressConfig {
@@ -1175,45 +1141,35 @@ func cloneProviderEgressConfig(src *ProviderEgressConfig) *ProviderEgressConfig 
 	return &ProviderEgressConfig{AllowedHosts: slices.Clone(src.AllowedHosts)}
 }
 
-func cloneExecutionConfig(src *ExecutionConfig) *ExecutionConfig {
+func cloneRuntimePlacementConfig(src *RuntimePlacementConfig) *RuntimePlacementConfig {
 	if src == nil {
 		return nil
 	}
-	return &ExecutionConfig{
-		Mode:    src.Mode,
-		Runtime: cloneHostedRuntimeConfig(src.Runtime),
-	}
-}
-
-func cloneHostedRuntimeConfig(src *HostedRuntimeConfig) *HostedRuntimeConfig {
-	if src == nil {
-		return nil
-	}
-	return &HostedRuntimeConfig{
+	return &RuntimePlacementConfig{
 		Provider:      src.Provider,
 		Template:      src.Template,
 		Image:         src.Image,
-		ImagePullAuth: cloneHostedRuntimeImagePullAuth(src.ImagePullAuth),
+		ImagePullAuth: cloneRuntimePlacementImagePullAuth(src.ImagePullAuth),
 		Metadata:      maps.Clone(src.Metadata),
-		Pool:          cloneHostedRuntimePoolConfig(src.Pool),
-		Workspace:     cloneHostedRuntimeWorkspaceConfig(src.Workspace),
+		Pool:          cloneRuntimePlacementPoolConfig(src.Pool),
+		Workspace:     cloneRuntimePlacementWorkspaceConfig(src.Workspace),
 	}
 }
 
-func cloneHostedRuntimeImagePullAuth(src *HostedRuntimeImagePullAuth) *HostedRuntimeImagePullAuth {
+func cloneRuntimePlacementImagePullAuth(src *RuntimePlacementImagePullAuth) *RuntimePlacementImagePullAuth {
 	if src == nil {
 		return nil
 	}
-	return &HostedRuntimeImagePullAuth{
+	return &RuntimePlacementImagePullAuth{
 		DockerConfigJSON: src.DockerConfigJSON,
 	}
 }
 
-func cloneHostedRuntimePoolConfig(src *HostedRuntimePoolConfig) *HostedRuntimePoolConfig {
+func cloneRuntimePlacementPoolConfig(src *RuntimePlacementPoolConfig) *RuntimePlacementPoolConfig {
 	if src == nil {
 		return nil
 	}
-	return &HostedRuntimePoolConfig{
+	return &RuntimePlacementPoolConfig{
 		MinReadyInstances:   src.MinReadyInstances,
 		MaxReadyInstances:   src.MaxReadyInstances,
 		StartupTimeout:      src.StartupTimeout,
@@ -1223,21 +1179,21 @@ func cloneHostedRuntimePoolConfig(src *HostedRuntimePoolConfig) *HostedRuntimePo
 	}
 }
 
-func cloneHostedRuntimeWorkspaceConfig(src *HostedRuntimeWorkspaceConfig) *HostedRuntimeWorkspaceConfig {
+func cloneRuntimePlacementWorkspaceConfig(src *RuntimePlacementWorkspaceConfig) *RuntimePlacementWorkspaceConfig {
 	if src == nil {
 		return nil
 	}
-	return &HostedRuntimeWorkspaceConfig{
+	return &RuntimePlacementWorkspaceConfig{
 		PrepareTimeout: src.PrepareTimeout,
-		Git:            cloneHostedRuntimeWorkspaceGitConfig(src.Git),
+		Git:            cloneRuntimePlacementWorkspaceGitConfig(src.Git),
 	}
 }
 
-func cloneHostedRuntimeWorkspaceGitConfig(src *HostedRuntimeWorkspaceGitConfig) *HostedRuntimeWorkspaceGitConfig {
+func cloneRuntimePlacementWorkspaceGitConfig(src *RuntimePlacementWorkspaceGitConfig) *RuntimePlacementWorkspaceGitConfig {
 	if src == nil {
 		return nil
 	}
-	return &HostedRuntimeWorkspaceGitConfig{
+	return &RuntimePlacementWorkspaceGitConfig{
 		AllowedRepositories: slices.Clone(src.AllowedRepositories),
 	}
 }
@@ -1720,8 +1676,22 @@ type DevAttachmentState string
 const DevAttachmentStateIndexedDB DevAttachmentState = "indexeddb"
 
 type ServerRuntimeConfig struct {
-	DefaultHostedProvider string `yaml:"defaultHostedProvider,omitempty"`
-	RelayBaseURL          string `yaml:"relayBaseUrl,omitempty"`
+	DefaultProvider string `yaml:"defaultProvider,omitempty"`
+	RelayBaseURL    string `yaml:"relayBaseUrl,omitempty"`
+}
+
+type serverRuntimeConfigFields ServerRuntimeConfig
+
+func (s *ServerRuntimeConfig) UnmarshalYAML(value *yaml.Node) error {
+	if mappingValueNode(value, "defaultHostedProvider") != nil {
+		return fmt.Errorf("config validation: server.runtime.defaultHostedProvider has been removed; use server.runtime.defaultProvider")
+	}
+	var decoded serverRuntimeConfigFields
+	if err := decodeYAMLNodeKnownFields(value, &decoded); err != nil {
+		return err
+	}
+	*s = ServerRuntimeConfig(decoded)
+	return nil
 }
 
 func (s ServerConfig) PublicListener() ListenerConfig {
@@ -2194,7 +2164,7 @@ func normalizeServerRuntimeConfig(cfg *Config) {
 	if cfg == nil {
 		return
 	}
-	cfg.Server.Runtime.DefaultHostedProvider = strings.TrimSpace(cfg.Server.Runtime.DefaultHostedProvider)
+	cfg.Server.Runtime.DefaultProvider = strings.TrimSpace(cfg.Server.Runtime.DefaultProvider)
 }
 
 func normalizeProviderEntries(cfg *Config) {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3537,9 +3537,7 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: missing
 runtime:
   providers:
@@ -3548,7 +3546,7 @@ runtime:
         path: ./providers/runtime/modal
 server:
   runtime:
-    defaultHostedProvider: hosted
+    defaultProvider: hosted
   encryptionKey: server-key
 `)
 
@@ -3556,7 +3554,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `providers.agent.simple.execution.runtime.provider references unknown runtime "missing"`) {
+		if !strings.Contains(err.Error(), `providers.agent.simple.runtime.provider references unknown runtime "missing"`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -3579,7 +3577,7 @@ runtime:
         path: ./providers/runtime/modal
 server:
   runtime:
-    defaultHostedProvider: hosted
+    defaultProvider: hosted
   encryptionKey: server-key
 `)
 
@@ -3603,9 +3601,7 @@ providers:
       source:
         path: ./providers/agent/simple
       indexeddb: agent_state
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           pool:
             minReadyInstances: 1
@@ -3626,7 +3622,7 @@ runtime:
 server:
   encryptionKey: server-key
 `
-	t.Run("accepts required lifecycle fields under agent execution runtime pool", func(t *testing.T) {
+	t.Run("accepts required lifecycle fields under agent runtime pool", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, base)
@@ -3634,19 +3630,19 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		runtimeCfg := cfg.Providers.Agent["simple"].Execution.Runtime
+		runtimeCfg := cfg.Providers.Agent["simple"].Runtime
 		if runtimeCfg.Pool == nil {
 			t.Fatal("runtime pool = nil")
 		}
 		if runtimeCfg.Pool.MinReadyInstances != 1 || runtimeCfg.Pool.MaxReadyInstances != 2 {
 			t.Fatalf("runtime pool ready instances = %d/%d, want 1/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)
 		}
-		if runtimeCfg.Pool.RestartPolicy != HostedRuntimeRestartPolicyAlways {
-			t.Fatalf("restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, HostedRuntimeRestartPolicyAlways)
+		if runtimeCfg.Pool.RestartPolicy != RuntimePlacementRestartPolicyAlways {
+			t.Fatalf("restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, RuntimePlacementRestartPolicyAlways)
 		}
 	})
 
-	t.Run("accepts required lifecycle fields under agent execution runtime", func(t *testing.T) {
+	t.Run("accepts required lifecycle fields under agent runtime", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -3656,9 +3652,7 @@ providers:
       source:
         path: ./providers/agent/simple
       indexeddb: agent_state
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           pool:
             minReadyInstances: 1
@@ -3683,15 +3677,15 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		runtimeCfg := cfg.Providers.Agent["simple"].Execution.Runtime
+		runtimeCfg := cfg.Providers.Agent["simple"].Runtime
 		if runtimeCfg.Pool == nil {
-			t.Fatal("execution runtime pool = nil")
+			t.Fatal("runtime pool = nil")
 		}
 		if runtimeCfg.Pool.MinReadyInstances != 1 || runtimeCfg.Pool.MaxReadyInstances != 2 {
-			t.Fatalf("execution runtime pool ready instances = %d/%d, want 1/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)
+			t.Fatalf("runtime pool ready instances = %d/%d, want 1/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)
 		}
-		if runtimeCfg.Pool.RestartPolicy != HostedRuntimeRestartPolicyAlways {
-			t.Fatalf("execution restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, HostedRuntimeRestartPolicyAlways)
+		if runtimeCfg.Pool.RestartPolicy != RuntimePlacementRestartPolicyAlways {
+			t.Fatalf("runtime restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, RuntimePlacementRestartPolicyAlways)
 		}
 	})
 
@@ -3734,15 +3728,15 @@ server:
 		if runtimeCfg == nil || runtimeCfg.Pool == nil {
 			t.Fatalf("runtime pool = %#v", runtimeCfg)
 		}
-		if cfg.Providers.Agent["simple"].HostedRuntimeConfig() != runtimeCfg {
-			t.Fatal("HostedRuntimeConfig did not return top-level runtime")
+		if cfg.Providers.Agent["simple"].RuntimePlacementConfig() != runtimeCfg {
+			t.Fatal("RuntimePlacementConfig did not return top-level runtime")
 		}
 		if runtimeCfg.Pool.MinReadyInstances != 1 || runtimeCfg.Pool.MaxReadyInstances != 2 {
 			t.Fatalf("runtime pool ready instances = %d/%d, want 1/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)
 		}
 	})
 
-	t.Run("accepts Docker config JSON image pull auth under agent execution runtime", func(t *testing.T) {
+	t.Run("accepts Docker config JSON image pull auth under agent runtime", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -3751,9 +3745,7 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           image: ghcr.io/example/simple-agent:latest
           imagePullAuth:
@@ -3777,7 +3769,7 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		auth := cfg.Providers.Agent["simple"].Execution.Runtime.ImagePullAuth
+		auth := cfg.Providers.Agent["simple"].Runtime.ImagePullAuth
 		if auth == nil {
 			t.Fatal("imagePullAuth = nil")
 		}
@@ -3786,7 +3778,7 @@ server:
 		}
 	})
 
-	t.Run("accepts secret ref Docker config JSON image pull auth under agent execution runtime", func(t *testing.T) {
+	t.Run("accepts secret ref Docker config JSON image pull auth under agent runtime", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -3798,9 +3790,7 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           image: ghcr.io/example/simple-agent:latest
           imagePullAuth:
@@ -3827,7 +3817,7 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		auth := cfg.Providers.Agent["simple"].Execution.Runtime.ImagePullAuth
+		auth := cfg.Providers.Agent["simple"].Runtime.ImagePullAuth
 		if auth == nil {
 			t.Fatal("imagePullAuth = nil")
 		}
@@ -3849,9 +3839,7 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           image: ghcr.io/example/simple-agent:latest
           imagePullAuth:
@@ -3864,7 +3852,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: `providers.agent.simple.execution.runtime.imagePullAuth.dockerConfigJson: must contain a non-empty "auths" object`,
+			want: `providers.agent.simple.runtime.imagePullAuth.dockerConfigJson: must contain a non-empty "auths" object`,
 		},
 		{
 			name: "rejects missing runtime pool",
@@ -3874,9 +3862,7 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
 runtime:
   providers:
@@ -3886,7 +3872,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.execution.runtime.pool.minReadyInstances is required",
+			want: "providers.agent.simple.runtime.pool.minReadyInstances is required",
 		},
 		{
 			name: "rejects missing lifecycle fields",
@@ -3896,9 +3882,7 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           pool:
             minReadyInstances: 1
@@ -3914,10 +3898,10 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.execution.runtime.pool.maxReadyInstances is required",
+			want: "providers.agent.simple.runtime.pool.maxReadyInstances is required",
 		},
 		{
-			name: "rejects missing execution runtime on hosted agent",
+			name: "rejects removed execution config",
 			yaml: `
 providers:
   agent:
@@ -3934,19 +3918,17 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.execution.runtime is required",
+			want: "provider execution has been removed; use runtime instead",
 		},
 		{
-			name: "rejects missing lifecycle fields under execution runtime",
+			name: "rejects missing lifecycle fields under runtime",
 			yaml: `
 providers:
   agent:
     simple:
       source:
         path: ./providers/agent/simple
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           pool:
             minReadyInstances: 1
@@ -3962,7 +3944,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.execution.runtime.pool.maxReadyInstances is required",
+			want: "providers.agent.simple.runtime.pool.maxReadyInstances is required",
 		},
 		{
 			name: "rejects max below min",
@@ -3972,9 +3954,7 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           pool:
             minReadyInstances: 2
@@ -3991,7 +3971,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.execution.runtime.pool.maxReadyInstances must be greater than or equal to minReadyInstances",
+			want: "providers.agent.simple.runtime.pool.maxReadyInstances must be greater than or equal to minReadyInstances",
 		},
 		{
 			name: "rejects unknown restart policy",
@@ -4001,9 +3981,7 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           pool:
             minReadyInstances: 1
@@ -4020,7 +3998,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "providers.agent.simple.execution.runtime.pool.restartPolicy must be one of",
+			want: "providers.agent.simple.runtime.pool.restartPolicy must be one of",
 		},
 		{
 			name: "rejects restart without agent indexeddb",
@@ -4030,9 +4008,7 @@ providers:
     simple:
       source:
         path: ./providers/agent/simple
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           pool:
             minReadyInstances: 1
@@ -4049,7 +4025,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: `providers.agent.simple.execution.runtime.pool.restartPolicy "always" requires providers.agent.simple.indexeddb as the provider persistence hook`,
+			want: `providers.agent.simple.runtime.pool.restartPolicy "always" requires providers.agent.simple.indexeddb as the provider persistence hook`,
 		},
 		{
 			name: "rejects lifecycle fields on plugin runtime",
@@ -4058,9 +4034,7 @@ plugins:
   service:
     source:
       path: ./plugins/service/manifest.yaml
-    execution:
-      mode: hosted
-      runtime:
+    runtime:
         provider: hosted
         pool:
           minReadyInstances: 1
@@ -4077,7 +4051,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: "plugins.service.execution.runtime lifecycle fields are only supported on hosted agent and workflow providers",
+			want: "plugins.service.runtime lifecycle fields are only supported on hosted agent and workflow providers",
 		},
 		{
 			name: "rejects lifecycle fields on plugin top-level runtime",
@@ -4106,35 +4080,7 @@ server:
 			want: "plugins.service.runtime lifecycle fields are only supported on hosted agent and workflow providers",
 		},
 		{
-			name: "rejects duplicate runtime config",
-			yaml: `
-providers:
-  agent:
-    simple:
-      source:
-        path: ./providers/agent/simple
-      indexeddb: agent_state
-      runtime:
-        provider: hosted
-      execution:
-        runtime:
-          provider: hosted
-  indexeddb:
-    agent_state:
-      source:
-        path: ./providers/datastore/sqlite
-runtime:
-  providers:
-    hosted:
-      source:
-        path: ./providers/runtime/modal
-server:
-  encryptionKey: server-key
-`,
-			want: "providers.agent.simple.runtime may not be set with providers.agent.simple.execution.runtime",
-		},
-		{
-			name: "rejects runtime with local execution mode",
+			name: "rejects removed local execution mode",
 			yaml: `
 providers:
   agent:
@@ -4153,7 +4099,7 @@ runtime:
 server:
   encryptionKey: server-key
 `,
-			want: `providers.agent.simple.runtime is only valid when execution.mode is "hosted"`,
+			want: "provider execution has been removed; use runtime instead",
 		},
 	}
 	for _, tc := range cases {
@@ -4184,9 +4130,7 @@ providers:
     temporal:
       source:
         path: ./providers/workflow/temporal
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           template: workflow-workers
           metadata:
@@ -4210,15 +4154,15 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		runtimeCfg := cfg.Providers.Workflow["temporal"].Execution.Runtime
+		runtimeCfg := cfg.Providers.Workflow["temporal"].Runtime
 		if runtimeCfg == nil || runtimeCfg.Pool == nil {
-			t.Fatalf("workflow execution runtime pool = %#v", runtimeCfg)
+			t.Fatalf("workflow runtime pool = %#v", runtimeCfg)
 		}
 		if runtimeCfg.Pool.MinReadyInstances != 2 || runtimeCfg.Pool.MaxReadyInstances != 2 {
 			t.Fatalf("workflow pool ready instances = %d/%d, want 2/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)
 		}
-		if runtimeCfg.Pool.RestartPolicy != HostedRuntimeRestartPolicyAlways {
-			t.Fatalf("workflow restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, HostedRuntimeRestartPolicyAlways)
+		if runtimeCfg.Pool.RestartPolicy != RuntimePlacementRestartPolicyAlways {
+			t.Fatalf("workflow restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, RuntimePlacementRestartPolicyAlways)
 		}
 	})
 
@@ -4259,14 +4203,14 @@ server:
 		if runtimeCfg == nil || runtimeCfg.Pool == nil {
 			t.Fatalf("workflow runtime pool = %#v", runtimeCfg)
 		}
-		if cfg.Providers.Workflow["temporal"].HostedRuntimeConfig() != runtimeCfg {
-			t.Fatal("HostedRuntimeConfig did not return top-level workflow runtime")
+		if cfg.Providers.Workflow["temporal"].RuntimePlacementConfig() != runtimeCfg {
+			t.Fatal("RuntimePlacementConfig did not return top-level workflow runtime")
 		}
 		if runtimeCfg.Pool.MinReadyInstances != 2 || runtimeCfg.Pool.MaxReadyInstances != 2 {
 			t.Fatalf("workflow pool ready instances = %d/%d, want 2/2", runtimeCfg.Pool.MinReadyInstances, runtimeCfg.Pool.MaxReadyInstances)
 		}
-		if runtimeCfg.Pool.RestartPolicy != HostedRuntimeRestartPolicyAlways {
-			t.Fatalf("workflow restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, HostedRuntimeRestartPolicyAlways)
+		if runtimeCfg.Pool.RestartPolicy != RuntimePlacementRestartPolicyAlways {
+			t.Fatalf("workflow restartPolicy = %q, want %q", runtimeCfg.Pool.RestartPolicy, RuntimePlacementRestartPolicyAlways)
 		}
 	})
 
@@ -4279,9 +4223,7 @@ providers:
     temporal:
       source:
         path: ./providers/workflow/temporal
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
 runtime:
   providers:
@@ -4295,7 +4237,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "providers.workflow.temporal.execution.runtime.pool is required for runtime-placed workflow providers") {
+		if !strings.Contains(err.Error(), "providers.workflow.temporal.runtime.pool is required for runtime-placed workflow providers") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -4309,9 +4251,7 @@ providers:
     temporal:
       source:
         path: ./providers/workflow/temporal
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           pool:
             minReadyInstances: 1
@@ -4331,7 +4271,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "providers.workflow.temporal.execution.runtime.pool.maxReadyInstances is required") {
+		if !strings.Contains(err.Error(), "providers.workflow.temporal.runtime.pool.maxReadyInstances is required") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -4345,9 +4285,7 @@ providers:
     temporal:
       source:
         path: ./providers/workflow/temporal
-      execution:
-        mode: hosted
-        runtime:
+      runtime:
           provider: hosted
           pool:
             minReadyInstances: 2
@@ -4368,7 +4306,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "providers.workflow.temporal.execution.runtime.pool.maxReadyInstances must equal minReadyInstances") {
+		if !strings.Contains(err.Error(), "providers.workflow.temporal.runtime.pool.maxReadyInstances must equal minReadyInstances") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -4556,9 +4494,27 @@ server:
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("rejects removed default hosted provider", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  runtime:
+    defaultHostedProvider: modal
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "server.runtime.defaultHostedProvider has been removed; use server.runtime.defaultProvider") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
-func TestLoadPathsProviderExecutionAndEgressOverride(t *testing.T) {
+func TestLoadPathsProviderRuntimeAndEgressOverride(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -4572,9 +4528,7 @@ plugins:
   service:
     source:
       path: ./plugins/service/manifest.yaml
-    execution:
-      mode: hosted
-      runtime:
+    runtime:
         provider: hosted
     egress:
       allowedHosts:
@@ -4591,9 +4545,7 @@ runtime:
 apiVersion: gestaltd.config/v5
 plugins:
   service:
-    execution:
-      mode: local
-      runtime: null
+    runtime: null
     egress:
       allowedHosts: []
 `), 0o644); err != nil {
@@ -4605,8 +4557,8 @@ plugins:
 		t.Fatalf("LoadPaths: %v", err)
 	}
 	entry := cfg.Plugins["service"]
-	if entry.UsesHostedExecution() {
-		t.Fatal("UsesHostedExecution = true, want execution.mode: local override")
+	if entry.UsesRuntimePlacement() {
+		t.Fatal("UsesRuntimePlacement = true, want runtime override removed")
 	}
 	if got := entry.EffectiveAllowedHosts(); len(got) != 0 {
 		t.Fatalf("EffectiveAllowedHosts = %#v, want empty after egress override", got)

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -719,7 +719,7 @@ func validateRuntimeConfig(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
-	cfg.Server.Runtime.DefaultHostedProvider = strings.TrimSpace(cfg.Server.Runtime.DefaultHostedProvider)
+	cfg.Server.Runtime.DefaultProvider = strings.TrimSpace(cfg.Server.Runtime.DefaultProvider)
 	cfg.Server.Runtime.RelayBaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Runtime.RelayBaseURL), "/")
 	if err := validateRuntimeRelayBaseURL(cfg.Server.Runtime.RelayBaseURL); err != nil {
 		return err
@@ -855,7 +855,7 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 	if err := validateAuthorizationPolicyReference(cfg, "plugin", name, entry.AuthorizationPolicy); err != nil {
 		return err
 	}
-	if _, err := cfg.EffectiveHostedRuntime("plugins."+name, entry); err != nil {
+	if _, err := cfg.EffectiveRuntimePlacement("plugins."+name, entry); err != nil {
 		return err
 	}
 	return validatePluginIntegrationConnections(name, entry)
@@ -1075,11 +1075,11 @@ func validateAgentProviderFields(cfg *Config, name string, entry *ProviderEntry)
 	if entry.AuthorizationPolicy != "" {
 		return fmt.Errorf("config validation: %s.authorizationPolicy is only supported on plugins.* and ui.*", subject)
 	}
-	if _, err := cfg.EffectiveHostedRuntime(subject, entry); err != nil {
+	if _, err := cfg.EffectiveRuntimePlacement(subject, entry); err != nil {
 		return err
 	}
 	if entry.UsesRuntimePlacement() {
-		if err := validateHostedAgentRuntimeLifecyclePolicy(subject, entry); err != nil {
+		if err := validateRuntimePlacedAgentLifecyclePolicy(subject, entry); err != nil {
 			return err
 		}
 	}
@@ -1103,14 +1103,14 @@ func validateAgentProviderFields(cfg *Config, name string, entry *ProviderEntry)
 	return nil
 }
 
-func normalizeHostedRuntimeConfig(subject string, runtimeCfg *HostedRuntimeConfig) error {
+func normalizeRuntimePlacementConfig(subject string, runtimeCfg *RuntimePlacementConfig) error {
 	if runtimeCfg == nil {
 		return nil
 	}
 	if runtimeCfg.Pool != nil {
 		runtimeCfg.Pool.StartupTimeout = strings.TrimSpace(runtimeCfg.Pool.StartupTimeout)
 		runtimeCfg.Pool.HealthCheckInterval = strings.TrimSpace(runtimeCfg.Pool.HealthCheckInterval)
-		runtimeCfg.Pool.RestartPolicy = HostedRuntimeRestartPolicy(strings.TrimSpace(string(runtimeCfg.Pool.RestartPolicy)))
+		runtimeCfg.Pool.RestartPolicy = RuntimePlacementRestartPolicy(strings.TrimSpace(string(runtimeCfg.Pool.RestartPolicy)))
 		runtimeCfg.Pool.DrainTimeout = strings.TrimSpace(runtimeCfg.Pool.DrainTimeout)
 	}
 	runtimeCfg.Provider = strings.TrimSpace(runtimeCfg.Provider)
@@ -1123,7 +1123,7 @@ func normalizeHostedRuntimeConfig(subject string, runtimeCfg *HostedRuntimeConfi
 		if strings.TrimSpace(runtimeCfg.ImagePullAuth.DockerConfigJSON) == "" {
 			return fmt.Errorf("config validation: %s.runtime.imagePullAuth.dockerConfigJson is required when imagePullAuth is set", subject)
 		}
-		if err := validateHostedRuntimeDockerConfigJSON(runtimeCfg.ImagePullAuth.DockerConfigJSON); err != nil {
+		if err := validateRuntimePlacementDockerConfigJSON(runtimeCfg.ImagePullAuth.DockerConfigJSON); err != nil {
 			return fmt.Errorf("config validation: %s.runtime.imagePullAuth.dockerConfigJson: %w", subject, err)
 		}
 	}
@@ -1138,13 +1138,13 @@ func normalizeHostedRuntimeConfig(subject string, runtimeCfg *HostedRuntimeConfi
 	if runtimeCfg.Metadata != nil {
 		runtimeCfg.Metadata = trimmed
 	}
-	if err := normalizeHostedRuntimeWorkspaceConfig(subject, runtimeCfg.Workspace); err != nil {
+	if err := normalizeRuntimePlacementWorkspaceConfig(subject, runtimeCfg.Workspace); err != nil {
 		return err
 	}
 	return nil
 }
 
-func normalizeHostedRuntimeWorkspaceConfig(subject string, workspace *HostedRuntimeWorkspaceConfig) error {
+func normalizeRuntimePlacementWorkspaceConfig(subject string, workspace *RuntimePlacementWorkspaceConfig) error {
 	if workspace == nil {
 		return nil
 	}
@@ -1185,7 +1185,7 @@ func normalizeHostedRuntimeWorkspaceConfig(subject string, workspace *HostedRunt
 	return nil
 }
 
-func validateHostedRuntimeDockerConfigJSON(value string) error {
+func validateRuntimePlacementDockerConfigJSON(value string) error {
 	if _, isSecretRef, err := ParseSecretRefTransport(value); isSecretRef || err != nil {
 		return err
 	}
@@ -1201,19 +1201,19 @@ func validateHostedRuntimeDockerConfigJSON(value string) error {
 	return nil
 }
 
-func validateHostedAgentRuntimeLifecyclePolicy(subject string, entry *ProviderEntry) error {
-	return validateHostedRuntimeLifecyclePolicy(subject, entry, true, "agent")
+func validateRuntimePlacedAgentLifecyclePolicy(subject string, entry *ProviderEntry) error {
+	return validateRuntimePlacementLifecyclePolicy(subject, entry, true, "agent")
 }
 
-func validateHostedWorkflowRuntimeLifecyclePolicy(subject string, entry *ProviderEntry) error {
-	runtimeCfg, runtimePath := hostedRuntimeConfigAndPath(subject, entry)
+func validateRuntimePlacedWorkflowLifecyclePolicy(subject string, entry *ProviderEntry) error {
+	runtimeCfg, runtimePath := runtimePlacementConfigAndPath(subject, entry)
 	if runtimeCfg == nil {
 		return fmt.Errorf("config validation: %s is required for runtime-placed workflow providers", runtimePath)
 	}
 	if !runtimeCfg.LifecyclePolicyFieldsSet() {
 		return fmt.Errorf("config validation: %s.pool is required for runtime-placed workflow providers", runtimePath)
 	}
-	if err := validateHostedRuntimeLifecyclePolicy(subject, entry, false, "workflow"); err != nil {
+	if err := validateRuntimePlacementLifecyclePolicy(subject, entry, false, "workflow"); err != nil {
 		return err
 	}
 	lifecycle := runtimeCfg.lifecyclePolicyConfig()
@@ -1223,11 +1223,11 @@ func validateHostedWorkflowRuntimeLifecyclePolicy(subject string, entry *Provide
 	return nil
 }
 
-func validateHostedRuntimeLifecyclePolicy(subject string, entry *ProviderEntry, requireIndexedDB bool, providerKind string) error {
+func validateRuntimePlacementLifecyclePolicy(subject string, entry *ProviderEntry, requireIndexedDB bool, providerKind string) error {
 	if entry == nil || !entry.UsesRuntimePlacement() {
 		return nil
 	}
-	runtimeCfg, runtimePath := hostedRuntimeConfigAndPath(subject, entry)
+	runtimeCfg, runtimePath := runtimePlacementConfigAndPath(subject, entry)
 	if runtimeCfg == nil {
 		if providerKind == "" {
 			providerKind = "provider"
@@ -1255,12 +1255,12 @@ func validateHostedRuntimeLifecyclePolicy(subject string, entry *ProviderEntry, 
 		return fmt.Errorf("config validation: %s.drainTimeout is required", lifecycleSubject)
 	}
 	switch lifecycle.RestartPolicy {
-	case HostedRuntimeRestartPolicyAlways, HostedRuntimeRestartPolicyNever:
+	case RuntimePlacementRestartPolicyAlways, RuntimePlacementRestartPolicyNever:
 	default:
-		return fmt.Errorf("config validation: %s.restartPolicy must be one of %q or %q", lifecycleSubject, HostedRuntimeRestartPolicyAlways, HostedRuntimeRestartPolicyNever)
+		return fmt.Errorf("config validation: %s.restartPolicy must be one of %q or %q", lifecycleSubject, RuntimePlacementRestartPolicyAlways, RuntimePlacementRestartPolicyNever)
 	}
-	if requireIndexedDB && lifecycle.RestartPolicy == HostedRuntimeRestartPolicyAlways && entry.IndexedDB == nil {
-		return fmt.Errorf("config validation: %s.restartPolicy %q requires %s.indexeddb as the provider persistence hook; runtime replacement does not make backend-local state durable", lifecycleSubject, HostedRuntimeRestartPolicyAlways, subject)
+	if requireIndexedDB && lifecycle.RestartPolicy == RuntimePlacementRestartPolicyAlways && entry.IndexedDB == nil {
+		return fmt.Errorf("config validation: %s.restartPolicy %q requires %s.indexeddb as the provider persistence hook; runtime replacement does not make backend-local state durable", lifecycleSubject, RuntimePlacementRestartPolicyAlways, subject)
 	}
 	if _, err := runtimeCfg.LifecyclePolicy(); err != nil {
 		return fmt.Errorf("config validation: %s.%w", lifecycleSubject, err)
@@ -1268,15 +1268,12 @@ func validateHostedRuntimeLifecyclePolicy(subject string, entry *ProviderEntry, 
 	return nil
 }
 
-func hostedRuntimeConfigAndPath(subject string, entry *ProviderEntry) (*HostedRuntimeConfig, string) {
+func runtimePlacementConfigAndPath(subject string, entry *ProviderEntry) (*RuntimePlacementConfig, string) {
 	if entry == nil {
 		return nil, subject + ".runtime"
 	}
 	if entry.Runtime != nil {
 		return entry.Runtime, subject + ".runtime"
-	}
-	if entry.Execution != nil {
-		return entry.Execution.Runtime, subject + ".execution.runtime"
 	}
 	return nil, subject + ".runtime"
 }
@@ -1310,11 +1307,11 @@ func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEnt
 	if err := normalizeProviderRuntimeConfig(subject, entry, true); err != nil {
 		return err
 	}
-	if _, err := cfg.EffectiveHostedRuntime(subject, entry); err != nil {
+	if _, err := cfg.EffectiveRuntimePlacement(subject, entry); err != nil {
 		return err
 	}
 	if entry.UsesRuntimePlacement() {
-		if err := validateHostedWorkflowRuntimeLifecyclePolicy(subject, entry); err != nil {
+		if err := validateRuntimePlacedWorkflowLifecyclePolicy(subject, entry); err != nil {
 			return err
 		}
 	}
@@ -1374,9 +1371,6 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	}
 	if entry.Runtime != nil {
 		return fmt.Errorf("config validation: %s.runtime is only supported on plugins.* and providers.agent.* and providers.workflow.*", subject)
-	}
-	if entry.Execution != nil {
-		return fmt.Errorf("config validation: %s.execution is only supported on plugins.* and providers.agent.* and providers.workflow.*", subject)
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
@@ -1456,50 +1450,14 @@ func validSessionStartHookID(value string) bool {
 	return true
 }
 
-func normalizeExecutionConfig(subject string, execution *ExecutionConfig, allowLifecycle bool) error {
-	if execution == nil {
-		return nil
-	}
-	execution.Mode = ExecutionMode(strings.ToLower(strings.TrimSpace(string(execution.Mode))))
-	switch execution.Mode {
-	case "", ExecutionModeLocal, ExecutionModeHosted:
-	default:
-		return fmt.Errorf("config validation: %s.execution.mode must be %q or %q, got %q", subject, ExecutionModeLocal, ExecutionModeHosted, execution.Mode)
-	}
-	if execution.Mode == ExecutionModeLocal && execution.Runtime != nil {
-		return fmt.Errorf("config validation: %s.execution.runtime is only valid when execution.mode is %q", subject, ExecutionModeHosted)
-	}
-	if execution.Runtime == nil {
-		return nil
-	}
-	if err := normalizeHostedRuntimeConfig(subject+".execution", execution.Runtime); err != nil {
-		return err
-	}
-	if !allowLifecycle && execution.Runtime.LifecyclePolicyFieldsSet() {
-		return fmt.Errorf("config validation: %s.execution.runtime lifecycle fields are only supported on hosted agent and workflow providers", subject)
-	}
-	return nil
-}
-
 func normalizeProviderRuntimeConfig(subject string, entry *ProviderEntry, allowLifecycle bool) error {
 	if entry == nil {
 		return nil
 	}
-	if entry.Runtime != nil && entry.Execution != nil && entry.Execution.Runtime != nil {
-		return fmt.Errorf("config validation: %s.runtime may not be set with %s.execution.runtime", subject, subject)
-	}
-	if entry.Execution != nil {
-		if err := normalizeExecutionConfig(subject, entry.Execution, allowLifecycle); err != nil {
-			return err
-		}
-		if entry.Runtime != nil && entry.Execution.Mode == ExecutionModeLocal {
-			return fmt.Errorf("config validation: %s.runtime is only valid when execution.mode is %q", subject, ExecutionModeHosted)
-		}
-	}
 	if entry.Runtime == nil {
 		return nil
 	}
-	if err := normalizeHostedRuntimeConfig(subject, entry.Runtime); err != nil {
+	if err := normalizeRuntimePlacementConfig(subject, entry.Runtime); err != nil {
 		return err
 	}
 	if !allowLifecycle && entry.Runtime.LifecyclePolicyFieldsSet() {

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -109,7 +109,7 @@ func (c *Config) SelectedRuntimeProvider() (string, *RuntimeProviderEntry, error
 	if c == nil {
 		return "", nil, nil
 	}
-	return ResolveSelectedRuntimeProvider(c.Server.Runtime.SelectedDefaultHostedProvider(), c.Runtime.Providers)
+	return ResolveSelectedRuntimeProvider(c.Server.Runtime.SelectedDefaultProvider(), c.Runtime.Providers)
 }
 
 type EffectiveHostIndexedDBBinding struct {
@@ -120,20 +120,15 @@ type EffectiveHostIndexedDBBinding struct {
 	ObjectStores []string
 }
 
-type EffectiveHostedRuntime struct {
+type EffectiveRuntimePlacement struct {
 	Enabled       bool
 	ProviderName  string
 	Provider      *RuntimeProviderEntry
 	Template      string
 	Image         string
-	ImagePullAuth *HostedRuntimeImagePullAuth
+	ImagePullAuth *RuntimePlacementImagePullAuth
 	Metadata      map[string]string
-	Workspace     *HostedRuntimeWorkspaceConfig
-}
-
-type EffectiveExecution struct {
-	Mode   ExecutionMode
-	Hosted EffectiveHostedRuntime
+	Workspace     *RuntimePlacementWorkspaceConfig
 }
 
 func (c *Config) EffectivePluginIndexedDB(pluginName string, entry *ProviderEntry) (EffectiveHostIndexedDBBinding, error) {
@@ -182,23 +177,15 @@ func (c *Config) EffectiveAgentIndexedDB(name string, entry *ProviderEntry) (Eff
 	return ResolveEffectiveAgentIndexedDB(name, entry, c.Providers.IndexedDB)
 }
 
-func (c *Config) EffectiveHostedRuntime(configPath string, entry *ProviderEntry) (EffectiveHostedRuntime, error) {
-	execution, err := c.EffectiveExecution(configPath, entry)
-	if err != nil {
-		return EffectiveHostedRuntime{}, err
-	}
-	return execution.Hosted, nil
-}
-
-func (c *Config) EffectiveExecution(configPath string, entry *ProviderEntry) (EffectiveExecution, error) {
+func (c *Config) EffectiveRuntimePlacement(configPath string, entry *ProviderEntry) (EffectiveRuntimePlacement, error) {
 	if c == nil {
-		return EffectiveExecution{Mode: ExecutionModeLocal}, nil
+		return EffectiveRuntimePlacement{}, nil
 	}
 	selectedName, _, err := c.SelectedRuntimeProvider()
 	if err != nil {
-		return EffectiveExecution{}, err
+		return EffectiveRuntimePlacement{}, err
 	}
-	return ResolveEffectiveExecution(configPath, entry, selectedName, c.Runtime.Providers)
+	return ResolveEffectiveRuntimePlacement(configPath, entry, selectedName, c.Runtime.Providers)
 }
 
 func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, selectedName string, entries map[string]*ProviderEntry) (EffectiveHostIndexedDBBinding, error) {
@@ -302,39 +289,15 @@ func ResolveEffectiveAgentIndexedDB(name string, entry *ProviderEntry, entries m
 	}, nil
 }
 
-func ResolveEffectiveHostedRuntime(configPath string, entry *ProviderEntry, selectedName string, entries map[string]*RuntimeProviderEntry) (EffectiveHostedRuntime, error) {
-	execution, err := ResolveEffectiveExecution(configPath, entry, selectedName, entries)
-	if err != nil {
-		return EffectiveHostedRuntime{}, err
-	}
-	return execution.Hosted, nil
-}
-
-func ResolveEffectiveExecution(configPath string, entry *ProviderEntry, selectedName string, entries map[string]*RuntimeProviderEntry) (EffectiveExecution, error) {
+func ResolveEffectiveRuntimePlacement(configPath string, entry *ProviderEntry, selectedName string, entries map[string]*RuntimeProviderEntry) (EffectiveRuntimePlacement, error) {
 	if entry == nil {
-		return EffectiveExecution{Mode: ExecutionModeLocal}, nil
+		return EffectiveRuntimePlacement{}, nil
 	}
-	var runtimeCfg *HostedRuntimeConfig
-	runtimePath := "runtime"
-	enabled := false
-	mode := ExecutionMode("")
-	if entry.Execution != nil {
-		mode = ExecutionMode(strings.ToLower(strings.TrimSpace(string(entry.Execution.Mode))))
-	}
-	if entry.Runtime != nil {
-		runtimeCfg = entry.Runtime
-		enabled = true
-	} else if entry.Execution != nil {
-		runtimeCfg = entry.Execution.Runtime
-		runtimePath = "execution.runtime"
-		enabled = runtimeCfg != nil || mode == ExecutionModeHosted
-	}
-	if !enabled {
-		return EffectiveExecution{Mode: ExecutionModeLocal}, nil
-	}
+	runtimeCfg := entry.Runtime
 	if runtimeCfg == nil {
-		runtimeCfg = &HostedRuntimeConfig{}
+		return EffectiveRuntimePlacement{}, nil
 	}
+	runtimePath := "runtime"
 
 	providerName := strings.TrimSpace(runtimeCfg.Provider)
 	if providerName == "" {
@@ -346,25 +309,25 @@ func ResolveEffectiveExecution(configPath string, entry *ProviderEntry, selected
 		var ok bool
 		provider, ok = entries[providerName]
 		if !ok || provider == nil {
-			return EffectiveExecution{}, fmt.Errorf("config validation: %s.%s.provider references unknown runtime %q", configPath, runtimePath, providerName)
+			return EffectiveRuntimePlacement{}, fmt.Errorf("config validation: %s.%s.provider references unknown runtime %q", configPath, runtimePath, providerName)
 		}
 	}
 
-	runtime := EffectiveHostedRuntime{
+	runtime := EffectiveRuntimePlacement{
 		Enabled:       true,
 		ProviderName:  providerName,
 		Provider:      provider,
 		Template:      strings.TrimSpace(runtimeCfg.Template),
 		Image:         strings.TrimSpace(runtimeCfg.Image),
-		ImagePullAuth: cloneHostedRuntimeImagePullAuth(runtimeCfg.ImagePullAuth),
+		ImagePullAuth: cloneRuntimePlacementImagePullAuth(runtimeCfg.ImagePullAuth),
 		Metadata:      maps.Clone(runtimeCfg.Metadata),
-		Workspace:     cloneHostedRuntimeWorkspaceConfig(runtimeCfg.Workspace),
+		Workspace:     cloneRuntimePlacementWorkspaceConfig(runtimeCfg.Workspace),
 	}
-	return EffectiveExecution{Mode: ExecutionModeHosted, Hosted: runtime}, nil
+	return runtime, nil
 }
 
-func (s ServerRuntimeConfig) SelectedDefaultHostedProvider() string {
-	return strings.TrimSpace(s.DefaultHostedProvider)
+func (s ServerRuntimeConfig) SelectedDefaultProvider() string {
+	return strings.TrimSpace(s.DefaultProvider)
 }
 func ResolveSelectedHostProvider(kind HostProviderKind, explicit string, entries map[string]*ProviderEntry) (string, *ProviderEntry, error) {
 	if len(entries) == 0 {
@@ -411,11 +374,11 @@ func ResolveSelectedRuntimeProvider(explicit string, entries map[string]*Runtime
 	explicit = strings.TrimSpace(explicit)
 	if explicit != "" {
 		if len(entries) == 0 {
-			return "", nil, fmt.Errorf("config validation: server.runtime.defaultHostedProvider references unknown runtime %q", explicit)
+			return "", nil, fmt.Errorf("config validation: server.runtime.defaultProvider references unknown runtime %q", explicit)
 		}
 		entry, ok := entries[explicit]
 		if !ok || entry == nil {
-			return "", nil, fmt.Errorf("config validation: server.runtime.defaultHostedProvider references unknown runtime %q", explicit)
+			return "", nil, fmt.Errorf("config validation: server.runtime.defaultProvider references unknown runtime %q", explicit)
 		}
 		return explicit, entry, nil
 	}

--- a/gestaltd/internal/daemon/agent_local_test.go
+++ b/gestaltd/internal/daemon/agent_local_test.go
@@ -32,9 +32,8 @@ providers:
           OPENAI_API_KEY: secret
           PLAIN: visible
     deployment_only:
-      execution:
-        runtime:
-          provider: missing
+      runtime:
+        provider: missing
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -209,7 +209,7 @@ server:
   providers:
     indexeddb: inmem
   runtime:
-    defaultHostedProvider: hosted
+    defaultProvider: hosted
 providers:
   indexeddb:
     inmem:
@@ -235,18 +235,16 @@ providers:
       indexeddb:
         provider: inmem
         db: agent_state
-      execution:
-        mode: hosted
-        runtime:
-          provider: hosted
-          image: ghcr.io/example/agent:latest
-          pool:
-            minReadyInstances: 1
-            maxReadyInstances: 2
-            startupTimeout: 5m
-            healthCheckInterval: 30s
-            restartPolicy: always
-            drainTimeout: 2m
+      runtime:
+        provider: hosted
+        image: ghcr.io/example/agent:latest
+        pool:
+          minReadyInstances: 1
+          maxReadyInstances: 2
+          startupTimeout: 5m
+          healthCheckInterval: 30s
+          restartPolicy: always
+          drainTimeout: 2m
 runtime:
   providers:
     hosted:

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -1121,8 +1121,8 @@ func writeProviderLocalBaseConfig(path, dbPath string) error {
 
 func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string, port int, mountPath, uiName, uiManifestPath string) error {
 	pluginEntry := map[string]any{
-		"source":    providerLocalSourceOverride(manifestPath),
-		"execution": nil,
+		"source":  providerLocalSourceOverride(manifestPath),
+		"runtime": nil,
 	}
 	if mountPath != "" || uiName != "" {
 		ui := map[string]any{}
@@ -1165,8 +1165,8 @@ func writeProviderRemotePluginOverlayConfig(path, pluginKey, manifestPath string
 		"apiVersion": config.ConfigAPIVersion,
 		"plugins": map[string]any{
 			pluginKey: map[string]any{
-				"source":    providerLocalSourceOverride(manifestPath),
-				"execution": nil,
+				"source":  providerLocalSourceOverride(manifestPath),
+				"runtime": nil,
 			},
 		},
 	}

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -72,7 +72,7 @@ import {
   type UpdateAgentProviderSessionRequest,
 } from "./internal/gen/v1/agent_pb.ts";
 import { errorMessage, type MaybePromise } from "./api.ts";
-import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
+import { ProviderBase, type ProviderBaseOptions } from "./provider.ts";
 
 /** Environment variable containing the agent-host service target. */
 export const ENV_AGENT_HOST_SOCKET = "GESTALT_AGENT_HOST_SOCKET";
@@ -156,7 +156,7 @@ export type AgentTurnEventInit = Omit<
 };
 
 /** Handlers and runtime metadata for an agent provider. */
-export interface AgentProviderOptions extends RuntimeProviderOptions {
+export interface AgentProviderOptions extends ProviderBaseOptions {
   createSession?: (
     request: CreateAgentProviderSessionRequest,
   ) => MaybePromise<MessageInitShape<typeof AgentSessionSchema>>;
@@ -199,7 +199,7 @@ export interface AgentProviderOptions extends RuntimeProviderOptions {
 }
 
 /** Runtime provider implementation for the Gestalt agent host contract. */
-export class AgentProvider extends RuntimeProvider {
+export class AgentProvider extends ProviderBase {
   readonly kind = "agent" as const;
 
   private readonly createSessionHandler: AgentProviderOptions["createSession"];

--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -1,4 +1,4 @@
-import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
+import { ProviderBase, type ProviderBaseOptions } from "./provider.ts";
 import type { MaybePromise } from "./api.ts";
 
 /**
@@ -52,7 +52,7 @@ export interface AuthenticationSessionSettings {
 /**
  * Runtime hooks required to implement a Gestalt authentication provider.
  */
-export interface AuthenticationProviderOptions extends RuntimeProviderOptions {
+export interface AuthenticationProviderOptions extends ProviderBaseOptions {
   beginLogin: (
     request: BeginLoginRequest,
   ) => MaybePromise<BeginLoginResponse>;
@@ -68,7 +68,7 @@ export interface AuthenticationProviderOptions extends RuntimeProviderOptions {
 /**
  * Authentication provider implementation consumed by the Gestalt runtime.
  */
-export class AuthenticationProvider extends RuntimeProvider {
+export class AuthenticationProvider extends ProviderBase {
   readonly kind = "authentication" as const;
 
   private readonly beginLoginHandler: AuthenticationProviderOptions["beginLogin"];

--- a/sdk/typescript/src/cache.ts
+++ b/sdk/typescript/src/cache.ts
@@ -4,7 +4,7 @@ import { createClient, type Client, type Interceptor } from "@connectrpc/connect
 import { createGrpcTransport } from "@connectrpc/connect-node";
 
 import { Cache as CacheService } from "./internal/gen/v1/cache_pb.ts";
-import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
+import { ProviderBase, type ProviderBaseOptions } from "./provider.ts";
 import type { MaybePromise } from "./api.ts";
 
 /** Base environment variable for discovering cache runtime sockets. */
@@ -33,7 +33,7 @@ export interface CacheSetOptions {
 /**
  * Runtime hooks required to implement a Gestalt cache provider.
  */
-export interface CacheProviderOptions extends RuntimeProviderOptions {
+export interface CacheProviderOptions extends ProviderBaseOptions {
   get: (key: string) => MaybePromise<Uint8Array | null | undefined>;
   set: (
     key: string,
@@ -224,7 +224,7 @@ export class Cache {
 /**
  * Cache provider implementation consumed by the Gestalt runtime.
  */
-export class CacheProvider extends RuntimeProvider {
+export class CacheProvider extends ProviderBase {
   readonly kind = "cache" as const;
 
   private readonly getHandler: CacheProviderOptions["get"];

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -189,15 +189,15 @@ export {
   type SessionCatalogHandler,
 } from "./plugin.ts";
 export {
-  RuntimeProvider,
-  isRuntimeProvider,
+  ProviderBase,
+  isProviderBase,
   slugName,
   type CloseHandler,
   type ConfigureHandler,
   type HealthCheckHandler,
   type ProviderKind,
   type ProviderMetadata,
-  type RuntimeProviderOptions,
+  type ProviderBaseOptions,
   type StartHandler,
   type WarningsHandler,
 } from "./provider.ts";

--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -24,9 +24,9 @@ import {
   type HTTPSubjectResolver,
 } from "./http-subject.ts";
 import {
-  isRuntimeProvider,
-  RuntimeProvider,
-  type RuntimeProviderOptions,
+  isProviderBase,
+  ProviderBase,
+  type ProviderBaseOptions,
 } from "./provider.ts";
 import type { Schema } from "./schema.ts";
 
@@ -118,7 +118,7 @@ export type PostConnectHandler = (
 /**
  * Runtime hooks required to implement a plugin provider.
  */
-export interface PluginDefinitionOptions extends RuntimeProviderOptions {
+export interface PluginDefinitionOptions extends ProviderBaseOptions {
   connectionMode?: ConnectionMode;
   authTypes?: string[];
   connectionParams?: Record<string, ConnectionParamDefinition>;
@@ -170,7 +170,7 @@ export function operation<In, Out>(
  * });
  * ```
  */
-export class PluginProvider extends RuntimeProvider {
+export class PluginProvider extends ProviderBase {
   readonly kind = "integration" as const;
   readonly iconSvg: string;
   readonly connectionMode: ConnectionMode;
@@ -390,7 +390,7 @@ export function isPluginProvider(
 ): value is PluginProvider {
   return (
     value instanceof PluginProvider ||
-    (isRuntimeProvider(value) &&
+    (isProviderBase(value) &&
       "kind" in value &&
       (value as { kind?: unknown }).kind === "integration" &&
       "staticCatalog" in value &&

--- a/sdk/typescript/src/pluginruntime.ts
+++ b/sdk/typescript/src/pluginruntime.ts
@@ -26,7 +26,7 @@ import {
   type StopPluginRuntimeSessionRequest,
 } from "./internal/gen/v1/pluginruntime_pb.ts";
 import { errorMessage, type MaybePromise } from "./api.ts";
-import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
+import { ProviderBase, type ProviderBaseOptions } from "./provider.ts";
 
 export type {
   GetPluginRuntimeSessionRequest,
@@ -42,7 +42,7 @@ export type {
 };
 export { PluginRuntimeEgressMode };
 
-export interface PluginRuntimeProviderOptions extends RuntimeProviderOptions {
+export interface PluginRuntimeProviderOptions extends ProviderBaseOptions {
   getSupport: () => MaybePromise<MessageInitShape<typeof PluginRuntimeSupportSchema>>;
   startSession: (
     request: StartPluginRuntimeSessionRequest,
@@ -65,7 +65,7 @@ export interface PluginRuntimeProviderOptions extends RuntimeProviderOptions {
   ) => MaybePromise<MessageInitShape<typeof HostedPluginSchema>>;
 }
 
-export class PluginRuntimeProvider extends RuntimeProvider {
+export class PluginRuntimeProvider extends ProviderBase {
   readonly kind = "runtime" as const;
 
   private readonly getSupportHandler: PluginRuntimeProviderOptions["getSupport"];

--- a/sdk/typescript/src/provider.ts
+++ b/sdk/typescript/src/provider.ts
@@ -55,9 +55,9 @@ export type StartHandler = () => MaybePromise<void>;
 export type CloseHandler = () => MaybePromise<void>;
 
 /**
- * Shared runtime metadata and lifecycle hooks for authored providers.
+ * Shared provider metadata and lifecycle hooks for authored providers.
  */
-export interface RuntimeProviderOptions {
+export interface ProviderBaseOptions {
   name?: string;
   displayName?: string;
   description?: string;
@@ -72,7 +72,7 @@ export interface RuntimeProviderOptions {
 /**
  * Base class shared by all TypeScript SDK provider implementations.
  */
-export abstract class RuntimeProvider {
+export abstract class ProviderBase {
   abstract readonly kind: ProviderKind;
 
   name: string;
@@ -86,7 +86,7 @@ export abstract class RuntimeProvider {
   private readonly startHandler: StartHandler | undefined;
   private readonly closeHandler: CloseHandler | undefined;
 
-  protected constructor(options: RuntimeProviderOptions) {
+  protected constructor(options: ProviderBaseOptions) {
     this.name = slugName(options.name ?? "");
     this.displayName = options.displayName?.trim() ?? "";
     this.description = options.description?.trim() ?? "";
@@ -106,7 +106,7 @@ export abstract class RuntimeProvider {
     }
   }
 
-  runtimeMetadata(): ProviderMetadata {
+  providerMetadata(): ProviderMetadata {
     const metadata: ProviderMetadata = {
       kind: this.kind,
     };
@@ -157,11 +157,11 @@ export abstract class RuntimeProvider {
 }
 
 /**
- * Runtime type guard for values that implement the provider base contract.
+ * Type guard for values that implement the provider base contract.
  */
-export function isRuntimeProvider(value: unknown): value is RuntimeProvider {
+export function isProviderBase(value: unknown): value is ProviderBase {
   return (
-    value instanceof RuntimeProvider ||
+    value instanceof ProviderBase ||
     (typeof value === "object" &&
       value !== null &&
       "kind" in value &&

--- a/sdk/typescript/src/s3.ts
+++ b/sdk/typescript/src/s3.ts
@@ -28,7 +28,7 @@ import {
   WriteObjectResponseSchema,
 } from "./internal/gen/v1/s3_pb.ts";
 import { errorMessage, type MaybePromise } from "./api.ts";
-import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
+import { ProviderBase, type ProviderBaseOptions } from "./provider.ts";
 
 /** Base environment variable for discovering S3 runtime sockets. */
 export const ENV_S3_SOCKET = "GESTALT_S3_SOCKET";
@@ -245,7 +245,7 @@ export interface ProviderReadResult {
 /**
  * Runtime hooks required to implement a Gestalt S3 provider.
  */
-export interface S3ProviderOptions extends RuntimeProviderOptions {
+export interface S3ProviderOptions extends ProviderBaseOptions {
   headObject: (ref: ObjectRef) => MaybePromise<ObjectMeta>;
   readObject: (ref: ObjectRef, options?: ReadOptions) => MaybePromise<ProviderReadResult>;
   writeObject: (
@@ -269,7 +269,7 @@ export interface S3ProviderOptions extends RuntimeProviderOptions {
 /**
  * S3 provider implementation consumed by the Gestalt runtime.
  */
-export class S3Provider extends RuntimeProvider {
+export class S3Provider extends ProviderBase {
   readonly kind = "s3" as const;
 
   private readonly headObjectHandler: S3ProviderOptions["headObject"];

--- a/sdk/typescript/src/secrets.ts
+++ b/sdk/typescript/src/secrets.ts
@@ -1,17 +1,17 @@
-import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
+import { ProviderBase, type ProviderBaseOptions } from "./provider.ts";
 import type { MaybePromise } from "./api.ts";
 
 /**
  * Runtime hooks required to implement a Gestalt secrets provider.
  */
-export interface SecretsProviderOptions extends RuntimeProviderOptions {
+export interface SecretsProviderOptions extends ProviderBaseOptions {
   getSecret: (name: string) => MaybePromise<string>;
 }
 
 /**
  * Secrets provider implementation consumed by the Gestalt runtime.
  */
-export class SecretsProvider extends RuntimeProvider {
+export class SecretsProvider extends ProviderBase {
   readonly kind = "secrets" as const;
 
   private readonly getSecretHandler: SecretsProviderOptions["getSecret"];

--- a/sdk/typescript/src/workflow.ts
+++ b/sdk/typescript/src/workflow.ts
@@ -45,7 +45,7 @@ import {
   WorkflowRunStatus,
 } from "./internal/gen/v1/workflow_pb.ts";
 import { errorMessage, type MaybePromise } from "./api.ts";
-import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
+import { ProviderBase, type ProviderBaseOptions } from "./provider.ts";
 
 /** Environment variable containing the workflow-host service target. */
 export const ENV_WORKFLOW_HOST_SOCKET = "GESTALT_WORKFLOW_HOST_SOCKET";
@@ -87,7 +87,7 @@ export type {
 export { WorkflowRunStatus };
 
 /** Handlers and runtime metadata for a workflow provider. */
-export interface WorkflowProviderOptions extends RuntimeProviderOptions {
+export interface WorkflowProviderOptions extends ProviderBaseOptions {
   startRun: (
     request: StartWorkflowProviderRunRequest,
   ) => MaybePromise<MessageInitShape<typeof BoundWorkflowRunSchema>>;
@@ -142,7 +142,7 @@ export interface WorkflowProviderOptions extends RuntimeProviderOptions {
 }
 
 /** Runtime provider implementation for the Gestalt workflow host contract. */
-export class WorkflowProvider extends RuntimeProvider {
+export class WorkflowProvider extends ProviderBase {
   readonly kind = "workflow" as const;
 
   private readonly startRunHandler: WorkflowProviderOptions["startRun"];


### PR DESCRIPTION
## Summary

- Remove the legacy provider `execution` config path and make direct `runtime` placement the only runtime opt-in contract.
- Rename Go config-facing runtime placement types from `HostedRuntime*` to `RuntimePlacement*`, while keeping internal hosted-runtime implementation helpers and existing wire/proto service names stable.
- Rename the TypeScript SDK all-provider base from `RuntimeProvider` to `ProviderBase` so `PluginRuntimeProvider` remains the actual runtime-provider facade.
- Update provider-dev overlays, config docs, and examples to use the simplified runtime placement shape.

## Interface Changes

- Removed config shape:

```yaml
server:
  runtime:
    defaultHostedProvider: modal

plugins:
  support:
    source: ./plugins/support/manifest.yaml
    execution:
      mode: hosted
      runtime:
        provider: modal
        image: ghcr.io/example/support@sha256:...
```

- New config shape:

```yaml
server:
  runtime:
    defaultProvider: modal

plugins:
  support:
    source: ./plugins/support/manifest.yaml
    runtime:
      provider: modal
      image: ghcr.io/example/support@sha256:...
```

- Agent and workflow providers express placement with the same direct `runtime` contract:

```yaml
providers:
  workflow:
    temporal:
      source: https://artifacts.example.com/workflow/temporal/v0.0.1-alpha.1/provider-release.yaml
      runtime:
        provider: kubernetes
        template: workflow-workers
        pool:
          minReadyInstances: 2
          maxReadyInstances: 2
          startupTimeout: 5m
          healthCheckInterval: 30s
          restartPolicy: always
          drainTimeout: 2m
```

- Go config facade changes:

```go
entry.UsesRuntimePlacement()
entry.RuntimePlacementConfig()
cfg.EffectiveRuntimePlacement("providers.workflow.temporal", entry)
```

- TypeScript SDK provider-base changes:

```ts
import {
  ProviderBase,
  type ProviderBaseOptions,
  definePluginRuntimeProvider,
} from "@valon-technologies/gestalt";
```

- Legacy migration behavior:
  - Any provider `execution:` key now fails config loading with `provider execution has been removed; use runtime instead`.
  - `server.runtime.defaultHostedProvider` now fails config loading with `server.runtime.defaultHostedProvider has been removed; use server.runtime.defaultProvider`.
  - Wire/proto service names such as `PluginRuntimeProvider` and `StartRuntimeProviderResponse` are intentionally unchanged to avoid transport compatibility churn.

## Functional/Integration Tests

- Tests added or augmented:
  - Config fixtures now exercise direct `runtime` placement and explicit legacy-key rejection.
  - Bootstrap hosted agent/workflow fixtures now use `RuntimePlacement*` config-facing types.
  - Provider-dev overlay tests now delete direct `runtime` placement with `runtime: null`.
  - TypeScript runtime/provider-load tests now exercise the renamed `ProviderBase` structural contract.
- Contract boundary covered:
  - YAML config load/validation, provider bootstrap/runtime placement, provider-dev generated overlays, and SDK runtime host transports.
- Commands run:
  - `go test ./...` in `gestaltd`
  - `bun run typecheck` in `sdk/typescript`
  - `bun test --max-concurrency 1` in `sdk/typescript`
  - `go test ./...` in `sdk/go`
  - `uv run pytest` in `sdk/python`
  - `cargo test` in `sdk/rust`
