### PR TITLE
Register workflow host relay for executable workflows

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1913,6 +1913,13 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 		hostServices = append(hostServices, indexedDBHostServices...)
 		cleanup = chainCleanup(cleanup, indexedDBCleanup)
 	}
+	if !entry.UsesRuntimePlacement() {
+		publicWorkflowHostServicesCleanup, err := registerPublicWorkflowHostServices(name, hostServices, deps)
+		if err != nil {
+			return nil, fmt.Errorf("workflow provider: %w", err)
+		}
+		cleanup = chainCleanup(cleanup, publicWorkflowHostServicesCleanup)
+	}
 	if factories.Workflow == nil {
 		return nil, fmt.Errorf("workflow factory is not registered")
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1901,6 +1901,37 @@ func registerPublicRuntimeHostServices(providerName string, hostServices []runti
 	}, nil
 }
 
+type workflowHostServiceSessionVerifier struct{}
+
+func (workflowHostServiceSessionVerifier) VerifyHostServiceSession(context.Context, string) error {
+	// Non-runtime workflow providers do not allocate runtime sessions; the
+	// signed relay token is scoped by provider, service, and method.
+	return nil
+}
+
+func registerPublicWorkflowHostServices(providerName string, hostServices []runtimehost.HostService, deps Deps) (func(), error) {
+	if deps.PublicHostServices == nil || !hostCanRelayPluginRuntimeHostServices(deps) {
+		return nil, nil
+	}
+	registerHostServices := make([]runtimehost.HostService, 0, len(hostServices))
+	for _, hostService := range hostServices {
+		if strings.TrimSpace(hostService.EnvVar) != workflowservice.DefaultHostSocketEnv || hostService.Register == nil {
+			continue
+		}
+		if strings.TrimSpace(hostService.Name) == "" {
+			return nil, fmt.Errorf("host service %q requires a service name for public relay", hostService.EnvVar)
+		}
+		registerHostServices = append(registerHostServices, hostService)
+	}
+	if len(registerHostServices) == 0 {
+		return nil, nil
+	}
+	registration := deps.PublicHostServices.RegisterVerified(providerName, workflowHostServiceSessionVerifier{}, registerHostServices...)
+	return func() {
+		registration.Unregister()
+	}, nil
+}
+
 func buildHostedRuntimePublicEgressProxy(providerName, sessionID string, allowedHosts []string, defaultAction egress.PolicyAction, deps Deps) (map[string]string, error) {
 	baseURL, explicitRelayBaseURL := hostedRuntimeRelayBaseURL(deps)
 	if baseURL == "" || len(deps.EncryptionKey) == 0 {

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"go.opentelemetry.io/otel/metric"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
@@ -129,6 +130,34 @@ func (p startupTestWorkflowProvider) PublishEvent(context.Context, coreworkflow.
 
 func (p startupTestWorkflowProvider) Ping(context.Context) error { return nil }
 func (p startupTestWorkflowProvider) Close() error               { return nil }
+
+func TestBuildWorkflowRegistersExecutableWorkflowHostPublicRelay(t *testing.T) {
+	t.Parallel()
+
+	factories := NewFactoryRegistry()
+	factories.Workflow = func(context.Context, string, yaml.Node, []runtimehost.HostService, Deps) (coreworkflow.Provider, error) {
+		return startupTestWorkflowProvider{}, nil
+	}
+	deps := Deps{
+		BaseURL:            "https://gestalt.example.test",
+		EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
+		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
+	}
+	provider, err := buildWorkflow(context.Background(), "local", &config.ProviderEntry{
+		Config: mustNode(t, map[string]any{"command": "/bin/workflow-provider"}),
+	}, factories, deps)
+	if err != nil {
+		t.Fatalf("buildWorkflow: %v", err)
+	}
+
+	assertPublicHostServicesVerified(t, deps.PublicHostServices, "workflow_host", workflowservice.DefaultHostSocketEnv)
+	if err := provider.Close(); err != nil {
+		t.Fatalf("provider.Close: %v", err)
+	}
+	if services := deps.PublicHostServices.Snapshot(); len(services) != 0 {
+		t.Fatalf("public host services after provider close = %#v, want none", services)
+	}
+}
 
 func (noopTelemetryProvider) Logger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, nil))


### PR DESCRIPTION
## Summary
- Register the workflow host as a public host service for non-runtime workflow providers when public relay support is configured.
- Keep the registration tied to workflow provider cleanup.
- Add bootstrap coverage for executable workflow provider public relay registration and cleanup.

## Why
Slack-triggered Temporal workflow runs were reaching `WorkflowHost/InvokeOperation` over the signed public host-service relay and getting `host-service-relay-unavailable`. The deployed workflow provider is the non-runtime `local` Temporal provider, so its workflow host was only bound as a child-process Unix socket and was not present in the public relay registry. This makes the signed relay path resolvable for executable workflow providers without changing hosted workflow worker behavior.

## Tests
- `go test ./internal/bootstrap -run 'TestBuildWorkflowRegistersExecutableWorkflowHostPublicRelay|TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup|TestBootstrapStartsWorkflowProvidersAfterInvokerIsReady' -count=1`
- `go test ./internal/bootstrap -run 'TestBuildWorkflowRegistersExecutableWorkflowHostPublicRelay|TestHostedWorkflowProviderPoolStartsWorkersFromWorkflowProviderStartup|TestBootstrapStartsWorkflowProvidersAfterInvokerIsReady|TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartFails' -count=1`

Note: full `go test ./internal/bootstrap -count=1` hit `TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartFails` once; that exact test passed on rerun.