### PR TITLE
Register workflow provider host services for public relay

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1915,7 +1915,7 @@ func registerPublicWorkflowHostServices(providerName string, hostServices []runt
 	}
 	registerHostServices := make([]runtimehost.HostService, 0, len(hostServices))
 	for _, hostService := range hostServices {
-		if strings.TrimSpace(hostService.EnvVar) != workflowservice.DefaultHostSocketEnv || hostService.Register == nil {
+		if hostService.Register == nil {
 			continue
 		}
 		if strings.TrimSpace(hostService.Name) == "" {

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	indexeddbservice "github.com/valon-technologies/gestalt/server/services/indexeddb"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
 	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
 	"go.opentelemetry.io/otel/metric"
@@ -139,18 +140,29 @@ func TestBuildWorkflowRegistersExecutableWorkflowHostPublicRelay(t *testing.T) {
 		return startupTestWorkflowProvider{}, nil
 	}
 	deps := Deps{
-		BaseURL:            "https://gestalt.example.test",
-		EncryptionKey:      []byte("0123456789abcdef0123456789abcdef"),
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		IndexedDBDefs: map[string]*config.ProviderEntry{
+			"main": {
+				Source: config.NewMetadataSource("https://example.invalid/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml"),
+				Config: mustNode(t, map[string]any{"bucket": "workflow-state"}),
+			},
+		},
+		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) {
+			return &coretesting.StubIndexedDB{}, nil
+		},
 		PublicHostServices: runtimehost.NewPublicHostServiceRegistry(),
 	}
 	provider, err := buildWorkflow(context.Background(), "local", &config.ProviderEntry{
-		Config: mustNode(t, map[string]any{"command": "/bin/workflow-provider"}),
+		Config:    mustNode(t, map[string]any{"command": "/bin/workflow-provider"}),
+		IndexedDB: &config.HostIndexedDBBindingConfig{Provider: "main"},
 	}, factories, deps)
 	if err != nil {
 		t.Fatalf("buildWorkflow: %v", err)
 	}
 
 	assertPublicHostServicesVerified(t, deps.PublicHostServices, "workflow_host", workflowservice.DefaultHostSocketEnv)
+	assertPublicHostServicesVerified(t, deps.PublicHostServices, "indexeddb", indexeddbservice.DefaultSocketEnv)
 	if err := provider.Close(); err != nil {
 		t.Fatalf("provider.Close: %v", err)
 	}


### PR DESCRIPTION
## Summary
- register all executable workflow provider host services with the public host-service relay, not just `workflow_host`
- extend the workflow startup test to cover the IndexedDB host service used by Temporal `StoreRun` activities

## Test plan
- `go test ./internal/bootstrap -run 'TestBuildWorkflowRegistersExecutableWorkflowHostPublicRelay|TestBootstrapRoutesWorkflowIndexedDBHostServices|TestBootstrapPassesIndexedDBHostSocketToWorkflowProviders' -count=1`\n- `go test ./internal/bootstrap -count=1`