### PR TITLE
Document remaining provider SDK host-service examples

### DIFF
--- a/docs/content/custom-providers/_meta.ts
+++ b/docs/content/custom-providers/_meta.ts
@@ -3,6 +3,7 @@ export default {
   authentication: "Authentication",
   authorization: "Authorization",
   cache: "Cache",
+  "external-credentials": "External Credentials",
   indexeddb: "IndexedDB",
   plugins: "Plugin",
   runtime: "Runtime",

--- a/docs/content/custom-providers/external-credentials.mdx
+++ b/docs/content/custom-providers/external-credentials.mdx
@@ -1,0 +1,232 @@
+# External Credentials
+
+This page covers building custom external credential providers. If you only need
+to configure credential storage for a deployment, use
+[Providers > External Credentials](/providers/external-credentials).
+
+External credential providers store, validate, exchange, and resolve connection
+credentials for plugins and agent providers. Gestalt owns connection config and
+authorization; the external credential provider owns the backing storage and any
+backend-specific token handling.
+
+External credential provider authoring is currently exposed through the Go SDK.
+
+## Manifest
+
+An external credential provider manifest declares `kind: external_credential`:
+
+```yaml
+kind: external_credential
+source: github.com/your-org/external-credentials/vault
+version: 0.0.1
+displayName: Vault External Credentials
+description: Stores Gestalt connection credentials in Vault.
+spec:
+  configSchemaPath: ./external_credentials_config.json
+```
+
+## Provider interface
+
+The external credential provider contract has three responsibilities:
+
+| Area | Methods |
+| --- | --- |
+| Stored credentials | `UpsertCredential`, `GetCredential`, `ListCredentials`, `DeleteCredential` |
+| Connection config | `ValidateCredentialConfig` |
+| Runtime material | `ResolveCredential`, `ExchangeCredential` |
+
+`ResolveCredential` is on the hot path for plugin and agent-provider calls. It
+receives the configured connection, credential subject, and instance, then
+returns the token or connection parameters that Gestalt should pass to the
+target provider.
+
+```go
+package vaultcredentials
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+type Provider struct {
+	mu          sync.Mutex
+	credentials map[string]*gestalt.ExternalCredential
+	lookupByID  map[string]string
+}
+
+func New() *Provider {
+	return &Provider{
+		credentials: map[string]*gestalt.ExternalCredential{},
+		lookupByID:  map[string]string{},
+	}
+}
+
+func (p *Provider) Configure(_ context.Context, _ string, _ map[string]any) error {
+	return nil
+}
+
+func (p *Provider) UpsertCredential(
+	_ context.Context,
+	req *gestalt.UpsertExternalCredentialRequest,
+) (*gestalt.ExternalCredential, error) {
+	credential := req.GetCredential()
+	if credential == nil {
+		return nil, fmt.Errorf("credential is required")
+	}
+
+	value := gproto.Clone(credential).(*gestalt.ExternalCredential)
+	if value.GetId() == "" {
+		value.Id = value.GetSubjectId() + ":" + value.GetConnectionId() + ":" + value.GetInstance()
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	key := lookupKey(value.GetSubjectId(), value.GetConnectionId(), value.GetInstance())
+	p.credentials[key] = value
+	p.lookupByID[value.GetId()] = key
+	return gproto.Clone(value).(*gestalt.ExternalCredential), nil
+}
+
+func (p *Provider) GetCredential(
+	_ context.Context,
+	req *gestalt.GetExternalCredentialRequest,
+) (*gestalt.ExternalCredential, error) {
+	lookup := req.GetLookup()
+	if lookup == nil {
+		return nil, fmt.Errorf("lookup is required")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	credential, ok := p.credentials[lookupKey(
+		lookup.GetSubjectId(),
+		lookup.GetConnectionId(),
+		lookup.GetInstance(),
+	)]
+	if !ok {
+		return nil, gestalt.ErrExternalCredentialNotFound
+	}
+	return gproto.Clone(credential).(*gestalt.ExternalCredential), nil
+}
+
+func (p *Provider) ListCredentials(
+	_ context.Context,
+	req *gestalt.ListExternalCredentialsRequest,
+) (*gestalt.ListExternalCredentialsResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	response := &gestalt.ListExternalCredentialsResponse{}
+	for _, credential := range p.credentials {
+		if req.GetSubjectId() != "" && credential.GetSubjectId() != req.GetSubjectId() {
+			continue
+		}
+		if req.GetConnectionId() != "" && credential.GetConnectionId() != req.GetConnectionId() {
+			continue
+		}
+		if req.GetInstance() != "" && credential.GetInstance() != req.GetInstance() {
+			continue
+		}
+		response.Credentials = append(
+			response.Credentials,
+			gproto.Clone(credential).(*gestalt.ExternalCredential),
+		)
+	}
+	return response, nil
+}
+
+func (p *Provider) DeleteCredential(
+	_ context.Context,
+	req *gestalt.DeleteExternalCredentialRequest,
+) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	key, ok := p.lookupByID[req.GetId()]
+	if !ok {
+		return gestalt.ErrExternalCredentialNotFound
+	}
+	delete(p.lookupByID, req.GetId())
+	delete(p.credentials, key)
+	return nil
+}
+
+func (p *Provider) ValidateCredentialConfig(
+	context.Context,
+	*gestalt.ValidateExternalCredentialConfigRequest,
+) error {
+	return nil
+}
+
+func (p *Provider) ResolveCredential(
+	ctx context.Context,
+	req *gestalt.ResolveExternalCredentialRequest,
+) (*gestalt.ResolveExternalCredentialResponse, error) {
+	credential, err := p.GetCredential(ctx, &gestalt.GetExternalCredentialRequest{
+		Lookup: &gestalt.ExternalCredentialLookup{
+			SubjectId:    req.GetCredentialSubjectId(),
+			ConnectionId: req.GetConnectionId(),
+			Instance:     req.GetInstance(),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &gestalt.ResolveExternalCredentialResponse{
+		Token:      credential.GetAccessToken(),
+		ExpiresAt:  credential.GetExpiresAt(),
+		Credential: credential,
+	}, nil
+}
+
+func (p *Provider) ExchangeCredential(
+	context.Context,
+	*gestalt.ExchangeExternalCredentialRequest,
+) (*gestalt.ExchangeExternalCredentialResponse, error) {
+	return &gestalt.ExchangeExternalCredentialResponse{}, nil
+}
+
+func lookupKey(subjectID, connectionID, instance string) string {
+	return subjectID + "\x00" + connectionID + "\x00" + instance
+}
+```
+
+This example keeps credentials in memory to show the SDK shape. Production
+providers should persist credentials durably, encrypt at rest, preserve created
+and updated timestamps, and implement refresh or exchange behavior that matches
+the supported connection auth modes.
+
+## Config reference
+
+Custom external credential providers are selected globally:
+
+```yaml
+server:
+  providers:
+    externalCredentials: vault
+
+providers:
+  externalCredentials:
+    vault:
+      source: ./providers/external-credentials/vault/manifest.yaml
+      config:
+        mount: secret/data/gestalt
+```
+
+Plugins, workflows, and agent providers do not select external credential
+providers directly. They declare or bind connections, and Gestalt resolves those
+connections through the selected deployment-wide external credential provider.
+
+## What to read next
+
+For the operator-facing model, see
+[Providers > External Credentials](/providers/external-credentials). For
+connection config, read [Config File](/reference/config-file#connections). For
+provider packaging, read [Releasing](/custom-providers/releasing).

--- a/docs/content/custom-providers/runtime.mdx
+++ b/docs/content/custom-providers/runtime.mdx
@@ -400,6 +400,74 @@ runtime log host service. The SDK environment exposes that service as
 Use this for logs that originate in the runtime backend or in hosted provider
 processes before Gestalt has dialed the provider directly.
 
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    import (
+        "context"
+
+        gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    )
+
+    func recordRuntimeStartup(ctx context.Context) error {
+        logs, err := gestalt.RuntimeLogHost()
+        if err != nil {
+            return err
+        }
+        defer logs.Close()
+
+        return logs.Append(
+            ctx,
+            "started hosted provider process",
+            gestalt.WithRuntimeLogStream(gestalt.RuntimeLogStreamRuntime),
+        )
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```python
+    import gestalt
+
+
+    def record_runtime_startup() -> None:
+        with gestalt.RuntimeLogHost() as logs:
+            logs.append(
+                "started hosted provider process",
+                stream="runtime",
+            )
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```rust
+    async fn record_runtime_startup() -> Result<(), Box<dyn std::error::Error>> {
+        let mut logs = gestalt::RuntimeLogHost::connect().await?;
+        logs.append_current_runtime("started hosted provider process")
+            .await?;
+        Ok(())
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import { RuntimeLogHost } from "@valon-technologies/gestalt";
+
+    export async function recordRuntimeStartup() {
+      const logs = new RuntimeLogHost();
+
+      await logs.append({
+        stream: "runtime",
+        message: "started hosted provider process",
+      });
+    }
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+`append` uses `GESTALT_RUNTIME_SESSION_ID` by default. Pass an explicit session
+ID only when the runtime backend is forwarding logs for a different hosted
+session. Python and TypeScript also expose writer helpers for redirecting
+standard streams.
+
 ## Releasing
 
 Runtime providers use the same release flow as other executable providers:

--- a/docs/content/providers/authorization.mdx
+++ b/docs/content/providers/authorization.mdx
@@ -1,3 +1,5 @@
+import { Tabs } from 'nextra/components'
+
 # Authorization
 
 Authorization providers back dynamic subject authorization state. They are
@@ -363,6 +365,115 @@ provider:
 Every managed resource type follows the same pattern: a resource instance
 has relations, and relations have subject types. Actions are computed from
 relations. This is the core Zanzibar model.
+
+## Using `Authorization` from provider code
+
+Provider code can query the selected host authorization provider through the
+read-only SDK authorization client. Use this when a plugin or provider needs to
+look up authorization-derived routing information, such as the Gestalt users
+allowed to assume an external identity. This client is for reads only; Gestalt
+still owns relationship writes and model lifecycle for managed authorization
+state.
+
+<Tabs items={['Go', 'Python', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    import (
+        "context"
+
+        gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    )
+
+    func usersForSlackIdentity(
+        ctx context.Context,
+        request gestalt.Request,
+        teamID string,
+        slackUserID string,
+    ) ([]string, error) {
+        authz, err := request.Authorization()
+        if err != nil {
+            return nil, err
+        }
+        defer authz.Close()
+
+        subjects, err := authz.SearchSubjects(ctx, &gestalt.SubjectSearchRequest{
+            Resource: &gestalt.AuthorizationResource{
+                Type: "slack_identity",
+                Id:   "team:" + teamID + ":user:" + slackUserID,
+            },
+            Action: &gestalt.AuthorizationAction{Name: "assume"},
+            SubjectType: "user",
+            PageSize:    10,
+        })
+        if err != nil {
+            return nil, err
+        }
+
+        ids := make([]string, 0, len(subjects.GetSubjects()))
+        for _, subject := range subjects.GetSubjects() {
+            ids = append(ids, subject.GetId())
+        }
+        return ids, nil
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```python
+    import gestalt
+
+
+    def users_for_slack_identity(
+        request: gestalt.Request,
+        team_id: str,
+        slack_user_id: str,
+    ) -> list[str]:
+        with request.authorization() as authz:
+            subjects = authz.search_subjects(
+                gestalt.SubjectSearchRequest(
+                    resource=gestalt.AuthorizationResource(
+                        type="slack_identity",
+                        id=f"team:{team_id}:user:{slack_user_id}",
+                    ),
+                    action=gestalt.AuthorizationAction(name="assume"),
+                    subject_type="user",
+                    page_size=10,
+                )
+            )
+
+        return [subject.id for subject in subjects.subjects]
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import { Authorization, type Request } from "@valon-technologies/gestalt";
+
+    export async function usersForSlackIdentity(
+      _request: Request,
+      teamId: string,
+      slackUserId: string,
+    ) {
+      const authz = Authorization();
+
+      const subjects = await authz.searchSubjects({
+        resource: {
+          type: "slack_identity",
+          id: `team:${teamId}:user:${slackUserId}`,
+        },
+        action: {
+          name: "assume",
+        },
+        subjectType: "user",
+        pageSize: 10,
+      });
+
+      return subjects.subjects.map((subject) => subject.id);
+    }
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+The Rust SDK does not currently expose a read-only authorization host-service
+client wrapper.
 
 ## First-party authorization providers
 

--- a/docs/content/providers/external-credentials.mdx
+++ b/docs/content/providers/external-credentials.mdx
@@ -303,3 +303,5 @@ reference, continue to [Config File](/reference/config-file). To understand
 plugin connection declarations, read [Plugin](/providers/plugins) and
 [Provider Manifests](/reference/plugin-manifests). To understand agent
 connection bindings, read [Custom Providers > Agent](/custom-providers/agent).
+To build a custom credential backend, read
+[Custom Providers > External Credentials](/custom-providers/external-credentials).

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -415,25 +415,161 @@ by the configured trigger.
 
 For a provider that receives external callbacks, the usual shape is to publish
 an integration-neutral workflow event from the provider and let a configured
-trigger route it to deployer-owned code:
+trigger route it to deployer-owned code.
 
-```ts
-const workflowManager = new WorkflowManager(request);
+## Using `WorkflowManager` from a plugin
 
-await workflowManager.publishEvent({
-  providerName: "local",
-  event: {
-    type: "slack.event.received",
-    source: "slack",
-    subject: "route:knowledge-ingest",
-    datacontenttype: "application/json",
-    data: {
-      event: slackEvent,
-      authorization: slackAuthorization,
-    },
-  },
-});
-```
+Plugins and other executable provider code can use `WorkflowManager` to publish
+workflow events, start runs, signal runs, and create schedules or triggers from
+the current provider request. The SDK attaches the request invocation token to
+each manager call, so the host keeps the same subject and permission ceiling.
+
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    import (
+        "context"
+
+        gestalt "github.com/valon-technologies/gestalt/sdk/go"
+        proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+        "google.golang.org/protobuf/types/known/structpb"
+    )
+
+    func publishSlackEvent(
+        ctx context.Context,
+        request gestalt.Request,
+        slackEvent map[string]any,
+    ) (string, error) {
+        workflows, err := request.WorkflowManager()
+        if err != nil {
+            return "", err
+        }
+        defer workflows.Close()
+
+        data, err := structpb.NewStruct(map[string]any{
+            "event": slackEvent,
+        })
+        if err != nil {
+            return "", err
+        }
+
+        event, err := workflows.PublishEvent(ctx, &proto.WorkflowManagerPublishEventRequest{
+            ProviderName: "local",
+            Event: &proto.WorkflowEvent{
+                Type:            "slack.event.received",
+                Source:          "slack",
+                Subject:         "route:knowledge-ingest",
+                Datacontenttype: "application/json",
+                Data:            data,
+            },
+        })
+        if err != nil {
+            return "", err
+        }
+        return event.GetId(), nil
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```python
+    import gestalt
+
+
+    def publish_slack_event(
+        request: gestalt.Request,
+        slack_event: dict[str, object],
+    ) -> str:
+        event = gestalt.WorkflowEvent(
+            type="slack.event.received",
+            source="slack",
+            subject="route:knowledge-ingest",
+            datacontenttype="application/json",
+        )
+        event.data.update({"event": slack_event})
+
+        with request.workflow_manager() as workflows:
+            published = workflows.publish_event(
+                gestalt.WorkflowManagerPublishEventRequest(
+                    provider_name="local",
+                    event=event,
+                )
+            )
+
+        return published.id
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```rust
+    use std::collections::BTreeMap;
+
+    use gestalt::proto::v1::{WorkflowEvent, WorkflowManagerPublishEventRequest};
+    use prost_types::{value::Kind, Struct, Value};
+
+    async fn publish_slack_event(
+        request: &gestalt::Request,
+        slack_event_json: String,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let mut workflows = request.workflow_manager().await?;
+
+        let event = workflows
+            .publish_event(WorkflowManagerPublishEventRequest {
+                provider_name: "local".to_string(),
+                event: Some(WorkflowEvent {
+                    r#type: "slack.event.received".to_string(),
+                    source: "slack".to_string(),
+                    subject: "route:knowledge-ingest".to_string(),
+                    datacontenttype: "application/json".to_string(),
+                    data: Some(Struct {
+                        fields: BTreeMap::from([(
+                            "event_json".to_string(),
+                            Value {
+                                kind: Some(Kind::StringValue(slack_event_json)),
+                            },
+                        )]),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .await?;
+
+        Ok(event.id)
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import { WorkflowManager, type Request } from "@valon-technologies/gestalt";
+
+    export async function publishSlackEvent(
+      request: Request,
+      slackEvent: Record<string, unknown>,
+    ) {
+      const workflowManager = new WorkflowManager(request);
+
+      const event = await workflowManager.publishEvent({
+        providerName: "local",
+        event: {
+          type: "slack.event.received",
+          source: "slack",
+          subject: "route:knowledge-ingest",
+          datacontenttype: "application/json",
+          data: {
+            event: slackEvent,
+          },
+        },
+      });
+
+      return event.id;
+    }
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+The same client also exposes start-run, signal-run, signal-or-start-run, and
+schedule or trigger management methods in each SDK. Use `providerName` /
+`provider_name` / `ProviderName` only when the deployment has more than one
+workflow provider or the caller needs to target a specific backend.
 
 ```yaml
 workflows:

--- a/docs/content/reference/sdk/go.mdx
+++ b/docs/content/reference/sdk/go.mdx
@@ -94,7 +94,8 @@ services.
 
 The same module includes host-service clients such as `CacheClient`,
 `IndexedDBClient`, `S3Client`, `WorkflowHostClient`, `WorkflowManagerClient`,
-`AgentHostClient`, `AgentManagerClient`, and `InvokerClient`.
+`AgentHostClient`, `AgentManagerClient`, `AuthorizationClient`,
+`ExternalCredentialClient`, `RuntimeLogHostClient`, and `InvokerClient`.
 
 ## API reference
 

--- a/docs/content/reference/sdk/python.mdx
+++ b/docs/content/reference/sdk/python.mdx
@@ -94,8 +94,9 @@ you are implementing a host-service provider.
 | `PluginRuntimeProvider` | Hosted plugin execution backends. |
 
 The SDK also exposes clients such as `Cache`, `IndexedDB`, `S3`,
-`WorkflowHost`, `WorkflowManager`, `AgentHost`, `AgentManager`, and
-`PluginInvoker` for provider code that needs to call sibling host services.
+`WorkflowHost`, `WorkflowManager`, `AgentHost`, `AgentManager`,
+`PluginInvoker`, `Authorization`, and `RuntimeLogHost` for provider code that
+needs to call sibling host services.
 
 ## Record provider telemetry
 

--- a/docs/content/reference/sdk/rust.mdx
+++ b/docs/content/reference/sdk/rust.mdx
@@ -106,6 +106,13 @@ Use the export macro that matches the provider surface you are serving.
 The macros export the symbols that `gestaltd` calls when it synthesizes the
 source-provider wrapper.
 
+## Use host-service clients
+
+The crate also exposes clients for provider code that needs to call
+Gestalt-managed sibling host services, including `Cache`, `IndexedDB`, `S3`,
+`WorkflowHost`, `WorkflowManager`, `AgentHost`, `AgentManager`,
+`PluginInvoker`, and `RuntimeLogHost`.
+
 ## Generated bindings
 
 The crate includes checked-in protobuf and gRPC bindings compiled from

--- a/docs/content/reference/sdk/typescript.mdx
+++ b/docs/content/reference/sdk/typescript.mdx
@@ -103,6 +103,24 @@ surface.
 | `defineAgentProvider` | Agent sessions, turns, events, interactions, and capabilities. |
 | `definePluginRuntimeProvider` | Hosted plugin execution backends. |
 
+## Use host-service clients
+
+The root package also exports clients for provider code that needs to call
+Gestalt-managed sibling host services:
+
+| Client | Use it when provider code needs to |
+| --- | --- |
+| `Cache` | Read or write plugin-bound cache state. |
+| `IndexedDB` | Read or write plugin-bound IndexedDB state. |
+| `S3` | Read, write, list, or presign plugin-bound objects. |
+| `WorkflowHost` | Let a workflow provider invoke its target operation. |
+| `WorkflowManager` | Publish workflow events or manage schedules, triggers, and runs from provider code. |
+| `AgentHost` | Let an agent provider list tools, execute tools, or resolve model connections. |
+| `AgentManager` | Create sessions and turns from plugin or provider code. |
+| `PluginInvoker` | Invoke another configured plugin from an executable plugin. |
+| `Authorization` / `AuthorizationClient` | Query the selected host authorization provider. |
+| `RuntimeLogHost` | Append hosted-runtime logs back to Gestalt. |
+
 ## Runtime and build entrypoints
 
 Use the runtime entrypoint for local source execution:

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -147,6 +147,7 @@ _WORKFLOW_PROTOCOL_EXPORTS = (
     "WORKFLOW_RUN_STATUS_SUCCEEDED",
     "WORKFLOW_RUN_STATUS_UNSPECIFIED",
     "WorkflowActor",
+    "WorkflowEvent",
     "WorkflowManagerCreateEventTriggerRequest",
     "WorkflowManagerCreateScheduleRequest",
     "WorkflowManagerDeleteEventTriggerRequest",

--- a/sdk/python/gestalt/_workflow.py
+++ b/sdk/python/gestalt/_workflow.py
@@ -73,6 +73,12 @@ def WorkflowSignal(*args: Any, **kwargs: Any) -> Any:
     return pb.WorkflowSignal(*args, **kwargs)
 
 
+def WorkflowEvent(*args: Any, **kwargs: Any) -> Any:
+    """Create a workflow event protocol value."""
+
+    return pb.WorkflowEvent(*args, **kwargs)
+
+
 def BoundWorkflowRun(*args: Any, **kwargs: Any) -> Any:
     """Create a workflow-provider run protocol value."""
 


### PR DESCRIPTION
## Summary
- add all-language WorkflowManager examples on the Workflow provider page
- add runtime log host examples for Go, Python, Rust, and TypeScript
- add read-only Authorization client examples for supported SDKs
- add a custom external-credentials provider guide for the current Go SDK surface
- update SDK overview pages to list host-service clients
- export Python `WorkflowEvent` helper used by the workflow docs example

## Verification
- `npm run typecheck` from `docs/`
- `npm run build` from `docs/`
- `uv run python -c "import gestalt; event = gestalt.WorkflowEvent(type='test.event'); assert event.type == 'test.event'"` from `sdk/python/`

Note: `npm run lint` still fails because the existing `next lint` script is interpreted as a project directory named `lint`.