### PR TITLE
Document auth provider optional hooks

### DIFF
--- a/docs/content/custom-providers/authentication.mdx
+++ b/docs/content/custom-providers/authentication.mdx
@@ -59,7 +59,7 @@ You implement three methods: `Configure`, `BeginLogin`, and `CompleteLogin`. `Be
     	return nil
     }
 
-    func (g *GoogleAuth) BeginLogin(_ context.Context, req gestalt.BeginLoginRequest) (*gestalt.BeginLoginResponse, error) {
+    func (g *GoogleAuth) BeginLogin(_ context.Context, req *gestalt.BeginLoginRequest) (*gestalt.BeginLoginResponse, error) {
     	cfg := &oauth2.Config{
     		ClientID:     g.clientID,
     		ClientSecret: g.clientSecret,
@@ -72,7 +72,7 @@ You implement three methods: `Configure`, `BeginLogin`, and `CompleteLogin`. `Be
     	}, nil
     }
 
-    func (g *GoogleAuth) CompleteLogin(ctx context.Context, req gestalt.CompleteLoginRequest) (*gestalt.AuthenticatedUser, error) {
+    func (g *GoogleAuth) CompleteLogin(ctx context.Context, req *gestalt.CompleteLoginRequest) (*gestalt.AuthenticatedUser, error) {
     	// Exchange req.Query["code"] for a token, then fetch userinfo.
     	return &gestalt.AuthenticatedUser{
     		Subject:       "user-123",
@@ -223,9 +223,168 @@ You implement three methods: `Configure`, `BeginLogin`, and `CompleteLogin`. `Be
 
 Two optional interfaces extend the base contract.
 
-**ExternalTokenValidator** lets API clients present a bearer token directly instead of going through the browser login flow. In Go, implement the `ExternalTokenValidator` interface on your provider. In Python, inherit from `gestalt.ExternalTokenValidator`. In Rust, override the `validate_external_token` method, which returns an unimplemented error by default. In TypeScript, provide the optional `validateExternalToken` handler to `defineAuthenticationProvider`.
+### External token validation
 
-**SessionTTLProvider** controls session lifetime. The default is 24 hours. In Go, implement the `SessionTTLProvider` interface. In Python, inherit from `gestalt.SessionTTLProvider`. In Rust, override the `session_ttl` method, which returns `None` (the 24-hour default) by default. In TypeScript, provide the optional `sessionSettings` handler to `defineAuthenticationProvider`.
+External token validation lets API clients present a bearer token directly instead of going through the browser login flow. Return a user when the token is valid. Return `nil`, `None`, `null`, or `undefined` when the token is not recognized.
+
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    Implement `ExternalTokenValidator` on the same provider type:
+
+    ```go
+    func (g *GoogleAuth) ValidateExternalToken(ctx context.Context, token string) (*gestalt.AuthenticatedUser, error) {
+        if token == "" {
+            return nil, nil
+        }
+
+        // Validate the bearer token with the upstream issuer, then map the
+        // token claims into a Gestalt identity.
+        return &gestalt.AuthenticatedUser{
+            Subject:       "user-123",
+            Email:         "user@example.com",
+            EmailVerified: true,
+            DisplayName:   "Example User",
+            Claims: map[string]string{
+                "issuer": "https://accounts.google.com",
+            },
+        }, nil
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Inherit from `gestalt.ExternalTokenValidator` and implement `validate_external_token`:
+
+    ```python
+    from typing import Any
+
+    import gestalt
+
+    class GoogleAuth(gestalt.AuthenticationProvider, gestalt.ExternalTokenValidator):
+        def validate_external_token(self, token: str) -> Any:
+            if not token:
+                return None
+
+            # Validate the bearer token with the upstream issuer, then map the
+            # token claims into a Gestalt identity.
+            return gestalt.AuthenticatedUser(
+                subject="user-123",
+                email="user@example.com",
+                email_verified=True,
+                display_name="Example User",
+                claims={"issuer": "https://accounts.google.com"},
+            )
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Override `validate_external_token` on the `AuthenticationProvider` implementation:
+
+    ```rust
+    async fn validate_external_token(
+        &self,
+        token: &str,
+    ) -> gestalt::Result<Option<AuthenticatedUser>> {
+        if token.is_empty() {
+            return Ok(None);
+        }
+
+        // Validate the bearer token with the upstream issuer, then map the
+        // token claims into a Gestalt identity.
+        Ok(Some(AuthenticatedUser {
+            subject: "user-123".into(),
+            email: "user@example.com".into(),
+            email_verified: true,
+            display_name: "Example User".into(),
+            claims: std::collections::BTreeMap::from([(
+                "issuer".into(),
+                "https://accounts.google.com".into(),
+            )]),
+            ..Default::default()
+        }))
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Add `validateExternalToken` to `defineAuthenticationProvider`:
+
+    ```ts
+    export const provider = defineAuthenticationProvider({
+      // configure, beginLogin, and completeLogin omitted for brevity
+
+      async validateExternalToken(token) {
+        if (!token) {
+          return null;
+        }
+
+        // Validate the bearer token with the upstream issuer, then map the
+        // token claims into a Gestalt identity.
+        return {
+          subject: "user-123",
+          email: "user@example.com",
+          emailVerified: true,
+          displayName: "Example User",
+          claims: {
+            issuer: "https://accounts.google.com",
+          },
+        };
+      },
+    });
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+### Session TTL
+
+Session TTL controls how long Gestalt persists a successful browser login. If you do not implement the optional hook, sessions default to 24 hours.
+
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    Implement `SessionTTLProvider` on the same provider type:
+
+    ```go
+    import "time"
+
+    func (g *GoogleAuth) SessionTTL() time.Duration {
+        return 8 * time.Hour
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Inherit from `gestalt.SessionTTLProvider` and return a `datetime.timedelta`:
+
+    ```python
+    import datetime as dt
+    import gestalt
+
+    class GoogleAuth(gestalt.AuthenticationProvider, gestalt.SessionTTLProvider):
+        def session_ttl(self) -> dt.timedelta:
+            return dt.timedelta(hours=8)
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Override `session_ttl` on the `AuthenticationProvider` implementation:
+
+    ```rust
+    fn session_ttl(&self) -> Option<std::time::Duration> {
+        Some(std::time::Duration::from_secs(8 * 60 * 60))
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Add `sessionSettings` to `defineAuthenticationProvider`:
+
+    ```ts
+    export const provider = defineAuthenticationProvider({
+      // configure, beginLogin, and completeLogin omitted for brevity
+
+      sessionSettings() {
+        return {
+          sessionTtlSeconds: 8 * 60 * 60,
+        };
+      },
+    });
+    ```
+  </Tabs.Tab>
+</Tabs>
 
 ## Config Reference
 


### PR DESCRIPTION
## Summary
- add SDK examples for authentication provider external token validation across Go, Python, Rust, and TypeScript
- add SDK examples for authentication provider session TTL hooks across all supported languages
- fix Go authentication provider request signatures in the page to use the SDK pointer types

## Tests
- npm run build (docs)
- npm run typecheck (docs)
- git diff --check