### PR TITLE
Document SDK host-service gaps

### DIFF
--- a/docs/content/reference/sdk/go.mdx
+++ b/docs/content/reference/sdk/go.mdx
@@ -97,6 +97,46 @@ The same module includes host-service clients such as `CacheClient`,
 `AgentHostClient`, `AgentManagerClient`, `AuthorizationClient`,
 `ExternalCredentialClient`, `RuntimeLogHostClient`, and `InvokerClient`.
 
+## Use external credential clients
+
+Go provider code can call the selected host external-credential provider through
+`ExternalCredentials()`. Use this when trusted provider-side code needs to
+inspect or resolve stored connection credentials through the same provider that
+Gestalt uses at runtime.
+
+```go
+import (
+	"context"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+)
+
+func connectedInstances(ctx context.Context, subjectID, connectionID string) ([]string, error) {
+	credentials, err := gestalt.ExternalCredentials()
+	if err != nil {
+		return nil, err
+	}
+	defer credentials.Close()
+
+	resp, err := credentials.ListCredentials(ctx, &gestalt.ListExternalCredentialsRequest{
+		SubjectId:    subjectID,
+		ConnectionId: connectionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	instances := make([]string, 0, len(resp.GetCredentials()))
+	for _, credential := range resp.GetCredentials() {
+		instances = append(instances, credential.GetInstance())
+	}
+	return instances, nil
+}
+```
+
+Python, Rust, and TypeScript do not currently expose this external-credential
+host-service client.
+
 ## API reference
 
 The canonical Go API reference is published on pkg.go.dev:

--- a/docs/content/reference/sdk/typescript.mdx
+++ b/docs/content/reference/sdk/typescript.mdx
@@ -94,7 +94,6 @@ surface.
 | --- | --- |
 | `definePlugin` | Integration operations and session catalogs. |
 | `defineAuthenticationProvider` | Login flows and optional bearer-token validation. |
-| `defineAuthorizationProvider` | Subject authorization decisions. |
 | `defineCacheProvider` | Plugin-bound cache storage. |
 | `defineIndexedDBProvider` | IndexedDB-style system state. |
 | `defineS3Provider` | S3-compatible object storage. |
@@ -102,6 +101,9 @@ surface.
 | `defineWorkflowProvider` | Workflow runs, schedules, and event triggers. |
 | `defineAgentProvider` | Agent sessions, turns, events, interactions, and capabilities. |
 | `definePluginRuntimeProvider` | Hosted plugin execution backends. |
+
+The TypeScript SDK does not currently expose an authored authorization-provider
+helper. Use the Go SDK when you need to build a custom authorization provider.
 
 ## Use host-service clients
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -62,16 +62,15 @@ is omitted, the runtime looks for `provider`, then `plugin`, then the default
 export.
 
 Use `"plugin"` as the kind token for executable plugin providers. Use an object
-target with an explicit kind for authentication, authorization, cache,
-IndexedDB, S3, secrets, workflow, agent, and hosted-runtime providers.
+target with an explicit kind for authentication, cache, IndexedDB, S3, secrets,
+workflow, agent, and hosted-runtime providers.
 
 ## Public surface
 
 The root package exports provider definition helpers:
 
 - `definePlugin` for integration operations and session catalogs.
-- `defineAuthenticationProvider` and `defineAuthorizationProvider` for auth
-  surfaces.
+- `defineAuthenticationProvider` for authentication surfaces.
 - `defineCacheProvider`, `defineIndexedDBProvider`, `defineS3Provider`, and
   `defineSecretsProvider` for host-service backends.
 - `defineWorkflowProvider`, `defineAgentProvider`, and
@@ -80,6 +79,9 @@ The root package exports provider definition helpers:
 - `s` schema builders for operation input, output, and catalog metadata.
 - Host-service clients for cache, IndexedDB, S3, workflows, agents,
   invocations, and telemetry.
+
+The TypeScript SDK does not currently expose an authored authorization-provider
+helper. Use the Go SDK when you need to build a custom authorization provider.
 
 TypeScript types are not enough to describe runtime payloads. Use the schema
 builders for every operation input and output that should appear in the


### PR DESCRIPTION
## Summary
- add a Go SDK example for the external credential host-service client
- clarify that Python, Rust, and TypeScript do not currently expose that external credential client
- remove stale TypeScript SDK references to a non-existent defineAuthorizationProvider helper

## Tests
- npm run build (docs)
- npm run typecheck (docs)
- git diff --check