### PR TITLE
Decode managed subject URL parameters

### DIFF
--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -215,7 +215,12 @@ func (s *Server) deleteAdminAuthorizationPluginMember(w http.ResponseWriter, r *
 	if !s.ensureAdminDynamicAuthorizationAvailable(w) {
 		return
 	}
-	subjectID, err := adminAuthorizationSubjectID(strings.TrimSpace(chi.URLParam(r, "subjectID")))
+	subjectIDParam, err := decodedURLParam(r, "subjectID")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	subjectID, err := adminAuthorizationSubjectID(strings.TrimSpace(subjectIDParam))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -327,7 +332,12 @@ func (s *Server) deleteAdminAuthorizationAdminMember(w http.ResponseWriter, r *h
 	if !s.ensureAdminAuthorizationWriteAccess(w, r) {
 		return
 	}
-	subjectID, err := adminAuthorizationSubjectID(strings.TrimSpace(chi.URLParam(r, "subjectID")))
+	subjectIDParam, err := decodedURLParam(r, "subjectID")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	subjectID, err := adminAuthorizationSubjectID(strings.TrimSpace(subjectIDParam))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/gestaltd/internal/server/handlers_authorization_subjects.go
+++ b/gestaltd/internal/server/handlers_authorization_subjects.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -299,7 +300,12 @@ func (s *Server) deleteManagedSubjectMember(w http.ResponseWriter, r *http.Reque
 	if !ok {
 		return
 	}
-	memberSubjectID, err := adminAuthorizationSubjectID(strings.TrimSpace(chi.URLParam(r, "memberSubjectID")))
+	memberSubjectIDParam, err := decodedURLParam(r, "memberSubjectID")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	memberSubjectID, err := adminAuthorizationSubjectID(strings.TrimSpace(memberSubjectIDParam))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -627,7 +633,12 @@ func (s *Server) managedSubjectIDFromPath(w http.ResponseWriter, r *http.Request
 	if !s.ensureManagedSubjectsAvailable(w) {
 		return "", false
 	}
-	subjectID, err := canonicalServiceAccountSubjectID(chi.URLParam(r, "subjectID"))
+	subjectIDParam, err := decodedURLParam(r, "subjectID")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return "", false
+	}
+	subjectID, err := canonicalServiceAccountSubjectID(subjectIDParam)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return "", false
@@ -929,6 +940,14 @@ func (s *Server) deleteAuthorizationRelationships(ctx context.Context, relations
 
 func managedSubjectResource(subjectID string) *core.ResourceRef {
 	return &core.ResourceRef{Type: authorization.ProviderResourceTypeManagedSubject, Id: strings.TrimSpace(subjectID)}
+}
+
+func decodedURLParam(r *http.Request, name string) (string, error) {
+	value, err := url.PathUnescape(chi.URLParam(r, name))
+	if err != nil {
+		return "", fmt.Errorf("%s path parameter is invalid", name)
+	}
+	return value, nil
 }
 
 func managedSubjectInfoFromCore(subject *core.ManagedSubject) managedSubjectInfo {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -5223,6 +5223,10 @@ func TestAuthorizationManagedSubjectsAPI(t *testing.T) {
 	escapedSubjectID := url.PathEscape(created.SubjectID)
 	expectJSONStatus(http.MethodGet, "/api/v1/authorization/subjects/"+escapedSubjectID, "owner-session", "", http.StatusOK)
 
+	encodedColonSubjectID := strings.ReplaceAll(created.SubjectID, ":", "%3A")
+	expectJSONStatus(http.MethodGet, "/api/v1/authorization/subjects/"+encodedColonSubjectID, "owner-session", "", http.StatusOK)
+	expectJSONStatus(http.MethodGet, "/api/v1/authorization/subjects/"+encodedColonSubjectID+"/tokens", "owner-session", "", http.StatusOK)
+
 	expectJSONStatus(http.MethodPut, "/api/v1/authorization/subjects/"+escapedSubjectID+"/members", "owner-session", `{"email":"viewer@example.test","role":"viewer"}`, http.StatusOK)
 
 	expectJSONStatus(http.MethodGet, "/api/v1/authorization/subjects/"+escapedSubjectID, "viewer-session", "", http.StatusOK)


### PR DESCRIPTION
## Summary
- Decode managed-subject URL path params before validating canonical subject IDs.
- Apply the same decoding to managed-subject member deletion and admin authorization member deletion paths.
- Add regression coverage for `service_account%3A...` managed-subject detail/token routes.

## Test plan
- [x] `go test ./internal/server -run 'TestAdminAPI_AdminAuthorizationCRUD|TestAuthorizationManagedSubjectsAPI' -count=1`