### PR TITLE
Require TypeScript subject email

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -6,7 +6,7 @@ export interface Subject {
   kind: string;
   displayName: string;
   authSource: string;
-  email?: string;
+  email: string;
 }
 
 /**

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -698,6 +698,7 @@ test("integration provider service resolves hosted HTTP subjects through the plu
         kind: "user",
         displayName: "Slack User",
         authSource: "slack",
+        email: "",
       };
     },
     operations: [


### PR DESCRIPTION
## Summary
- Makes TypeScript `Subject.email` a required string to match runtime behavior and the Go, Python, and Rust SDK surfaces.
- Updates the HTTP subject resolver test fixture to return the required empty-string email.

## Test plan
- [x] `bun run check` from `sdk/typescript`
- [x] `git diff --check`