### PR TITLE
Stabilize core race telemetry tests

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -110,7 +110,7 @@ jobs:
           cache-dependency-path: gestaltd/go.sum
 
       - name: Run race tests
-        run: go test -race ./...
+        run: go test -race -timeout=15m ./...
 
   docs-build:
     name: Docs Build

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -4035,6 +4035,14 @@ func extractReleasedArchive(t *testing.T, outputDir, archiveName string) string 
 		t.Fatalf("expected archive %s to exist: %v", archiveName, err)
 	}
 	extractDir := filepath.Join(outputDir, strings.TrimSuffix(archiveName, ".tar.gz"))
+	if info, err := os.Stat(extractDir); err == nil {
+		if !info.IsDir() {
+			t.Fatalf("extract path %s exists and is not a directory", extractDir)
+		}
+		return extractDir
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat extract dir %s: %v", extractDir, err)
+	}
 	if err := providerpkg.ExtractPackage(archivePath, extractDir); err != nil {
 		t.Fatalf("extract archive: %v", err)
 	}

--- a/gestaltd/internal/testutil/metrictest/metrictest.go
+++ b/gestaltd/internal/testutil/metrictest/metrictest.go
@@ -3,6 +3,7 @@ package metrictest
 import (
 	"context"
 	"testing"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -36,6 +37,23 @@ func CollectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.Res
 		t.Fatalf("collect metrics: %v", err)
 	}
 	return rm
+}
+
+func CollectMetricsUntilFloat64Histogram(t *testing.T, reader *sdkmetric.ManualReader, name string, attrs map[string]string) metricdata.ResourceMetrics {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var rm metricdata.ResourceMetrics
+	for {
+		rm = CollectMetrics(t, reader)
+		if HasFloat64Histogram(rm, name, attrs) {
+			return rm
+		}
+		if time.Now().After(deadline) {
+			return rm
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func RequireInt64Sum(t *testing.T, rm metricdata.ResourceMetrics, name string, want int64, attrs map[string]string) {
@@ -136,6 +154,27 @@ func RequireFloat64Histogram(t *testing.T, rm metricdata.ResourceMetrics, name s
 	}
 
 	t.Fatalf("metric %q with attrs %v not found", name, attrs)
+}
+
+func HasFloat64Histogram(rm metricdata.ResourceMetrics, name string, attrs map[string]string) bool {
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			histogram, ok := metric.Data.(metricdata.Histogram[float64])
+			if !ok {
+				continue
+			}
+			for _, point := range histogram.DataPoints {
+				if AttrsMatch(point.Attributes, attrs) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }
 
 func RequireNoMetric(t *testing.T, rm metricdata.ResourceMetrics, name string) {

--- a/gestaltd/services/runtimehost/host_services_test.go
+++ b/gestaltd/services/runtimehost/host_services_test.go
@@ -98,12 +98,12 @@ func TestStartHostServicesRecordsRPCServerDurationWithTelemetryAttrs(t *testing.
 		t.Fatal("Cache.Get found = false, want true")
 	}
 
-	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
 		"gestaltd.rpc.role":          "host_service_server",
 		"gestaltd.provider.name":     providerName,
 		"gestaltd.host_service.name": "cache",
 	}
+	rm := metrictest.CollectMetricsUntilFloat64Histogram(t, metrics.Reader, "rpc.server.call.duration", attrs)
 	metrictest.RequireFloat64Histogram(t, rm, "rpc.server.call.duration", attrs)
 	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.server.call.duration", attrs, "gestalt.rpc.role")
 	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "rpc.server.call.duration", attrs, "gestalt.provider")


### PR DESCRIPTION
## Summary
- wait for the runtimehost gRPC server duration histogram before asserting telemetry attributes
- avoid redundant daemon test archive extraction when helpers read the manifest after an archive was already unpacked
- make the race job package timeout explicit at 15m within the existing 20m job timeout

## Verification
- go test -race ./services/runtimehost
- go test -race -run TestRun_ProviderReleaseStagesOwnedUIPackage ./internal/daemon

## Notes
- The full local daemon race package with the old extraction behavior got past the CI timeout point but hit an unrelated local e2e readiness timeout on macOS; CI failure being addressed was Go's default 10m package timeout plus the runtimehost metric race assertion.