### PR TITLE
Add workflow manager capability grants

### DIFF
--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -433,6 +433,28 @@ workflow events, start runs, signal runs, and create schedules or triggers from
 the current provider request. The SDK attaches the request invocation token to
 each manager call, so the host keeps the same subject and permission ceiling.
 
+Deployments can make this host-service access explicit with plugin workflow
+capabilities. When `capabilities.workflow` is omitted, plugins keep the legacy
+behavior and workflow-manager calls are allowed subject to the current principal
+and target authorization. When it is present, `operations` is an allowlist for
+the workflow-manager methods that plugin code may call:
+
+```yaml
+plugins:
+  slack:
+    capabilities:
+      workflow:
+        operations:
+          - runs.signalOrStart
+          - schedules.create
+          - eventTriggers.create
+          - events.publish
+```
+
+Workflow capabilities gate the manager method only. The workflow target still
+has to pass the same provider, operation, credential-mode, catalog, and runtime
+authorization checks as any other delayed workflow invocation.
+
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/runtimehost/pluginruntime"
 	s3service "github.com/valon-technologies/gestalt/server/services/s3"
 	workflowservice "github.com/valon-technologies/gestalt/server/services/workflows"
+	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowmanager"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1709,6 +1710,12 @@ func (m *stubWorkflowManager) ScheduleIdempotencyKeys() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return slices.Clone(m.scheduleKeys)
+}
+
+func (m *stubWorkflowManager) ScheduleCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.schedules)
 }
 
 type stubAgentTurnManagerProvider struct {
@@ -4588,6 +4595,105 @@ func TestPluginWorkflowManagerCRUDUsesRequestContext(t *testing.T) {
 		"user:user-123",
 	}) {
 		t.Fatalf("manager subjects = %v, want all user:user-123", got)
+	}
+}
+
+func TestPluginWorkflowManagerCapabilitiesRestrictHostMethods(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echo",
+		Operations: []catalog.CatalogOperation{
+			{ID: "create_workflow_schedule", Method: http.MethodPost},
+			{ID: "publish_workflow_event", Method: http.MethodPost},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Workflow manager capabilities")
+	manager := newStubWorkflowManager()
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"echo": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Capabilities: &config.PluginCapabilitiesConfig{
+					Workflow: &config.PluginWorkflowCapabilitiesConfig{
+						Operations: []string{workflowgrants.OperationEventsPublish},
+					},
+				},
+			},
+		},
+	}
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), testRuntimePublicEndpointDeps(t, Deps{
+		EncryptionKey:   secret,
+		WorkflowManager: manager,
+	}))
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("echo")
+	if err != nil {
+		t.Fatalf("providers.Get(echo): %v", err)
+	}
+	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "user:user-123",
+		UserID:    "user-123",
+		Kind:      principal.KindUser,
+		Source:    principal.SourceSession,
+		Scopes:    []string{"echo"},
+	})
+
+	publishEventResult, err := prov.Execute(ctx, "publish_workflow_event", map[string]any{
+		"provider_name": "advanced",
+		"type":          "roadmap.item.updated",
+		"source":        "roadmap",
+		"subject":       "item-123",
+	}, "")
+	if err != nil {
+		t.Fatalf("Execute(publish_workflow_event): %v", err)
+	}
+	var publishedEvent struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(publishEventResult.Body), &publishedEvent); err != nil {
+		t.Fatalf("json.Unmarshal(publish event): %v", err)
+	}
+	if publishedEvent.ID == "" {
+		t.Fatalf("publish event result = %+v, want event id", publishedEvent)
+	}
+	if !slices.Equal(manager.publishedProviderNames, []string{"advanced"}) {
+		t.Fatalf("published provider names = %v, want [advanced]", manager.publishedProviderNames)
+	}
+
+	createResult, err := prov.Execute(ctx, "create_workflow_schedule", map[string]any{
+		"provider_name": "basic",
+		"cron":          "*/5 * * * *",
+		"target": map[string]any{
+			"plugin":    "roadmap",
+			"operation": "sync",
+		},
+	}, "")
+	if err != nil {
+		t.Fatalf("Execute(create_workflow_schedule): %v", err)
+	}
+	var createBody struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(createResult.Body), &createBody); err != nil {
+		t.Fatalf("json.Unmarshal(create): %v", err)
+	}
+	if !strings.Contains(createBody.Error, "PermissionDenied") || !strings.Contains(createBody.Error, workflowgrants.OperationSchedulesCreate) {
+		t.Fatalf("create workflow schedule error = %q, want permission denied for %s", createBody.Error, workflowgrants.OperationSchedulesCreate)
+	}
+	if got := manager.ScheduleCount(); got != 0 {
+		t.Fatalf("schedule count = %d, want 0 denied calls to skip manager", got)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1078,6 +1078,9 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 					invocationconfig.PluginInvocationDependencies(entry.Invokes),
 				),
 			),
+			pluginservice.WithWorkflowManagerGrants(
+				invocationconfig.PluginWorkflowManagerGrants(entry.Capabilities),
+			),
 		)
 	}
 	prov, err := pluginservice.NewRemote(ctx, conn.Integration(), spec, pluginConfig, opts...)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -412,6 +412,7 @@ type ProviderEntry struct {
 	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
 	Invokes           []PluginInvocationDependency  `yaml:"invokes,omitempty"`
+	Capabilities      *PluginCapabilitiesConfig     `yaml:"capabilities,omitempty"`
 	IndexedDB         *HostIndexedDBBindingConfig   `yaml:"indexeddb,omitempty"`
 	Cache             []string                      `yaml:"cache,omitempty"`
 	S3                []string                      `yaml:"s3,omitempty"`
@@ -2034,6 +2035,14 @@ type PluginInvocationDependency struct {
 	Surface        string                            `yaml:"surface,omitempty"`
 	CredentialMode providermanifestv1.ConnectionMode `yaml:"credentialMode,omitempty"`
 	RunAs          *PluginInvocationRunAsConfig      `yaml:"runAs,omitempty"`
+}
+
+type PluginCapabilitiesConfig struct {
+	Workflow *PluginWorkflowCapabilitiesConfig `yaml:"workflow,omitempty"`
+}
+
+type PluginWorkflowCapabilitiesConfig struct {
+	Operations []string `yaml:"operations,omitempty"`
 }
 
 type PluginInvocationRunAsConfig struct {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -21,6 +21,7 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/plugins/packageio"
 	"github.com/valon-technologies/gestalt/server/services/s3"
+	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
 )
 
 // ValidateStructure checks config shape: integration references, plugin
@@ -834,6 +835,9 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 		}
 		seenInvokes[key] = i
 	}
+	if err := validatePluginCapabilities("plugins."+name+".capabilities", entry.Capabilities); err != nil {
+		return err
+	}
 	if entry.UI != "" && entry.MountPath == "" {
 		return fmt.Errorf("config validation: plugins.%s.ui.bundle requires plugins.%s.ui.path", name, name)
 	}
@@ -859,6 +863,32 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 		return err
 	}
 	return validatePluginIntegrationConnections(name, entry)
+}
+
+func validatePluginCapabilities(path string, capabilities *PluginCapabilitiesConfig) error {
+	if capabilities == nil || capabilities.Workflow == nil {
+		return nil
+	}
+	operations := capabilities.Workflow.Operations
+	if len(operations) == 0 {
+		return fmt.Errorf("config validation: %s.workflow.operations is required when workflow capabilities are set", path)
+	}
+	seen := make(map[string]int, len(operations))
+	for i := range operations {
+		operation := strings.TrimSpace(operations[i])
+		operations[i] = operation
+		switch {
+		case operation == "":
+			return fmt.Errorf("config validation: %s.workflow.operations[%d] is required", path, i)
+		case !workflowgrants.IsSupportedOperation(operation):
+			return fmt.Errorf("config validation: %s.workflow.operations[%d] %q is not supported; supported operations: %s", path, i, operation, strings.Join(workflowgrants.SupportedOperations(), ", "))
+		}
+		if prev, ok := seen[operation]; ok {
+			return fmt.Errorf("config validation: %s.workflow.operations[%d] duplicates operations[%d]", path, i, prev)
+		}
+		seen[operation] = i
+	}
+	return nil
 }
 
 func validatePluginRouteAuth(cfg *Config, name string, entry *ProviderEntry) error {
@@ -1068,6 +1098,9 @@ func validateAgentProviderFields(cfg *Config, name string, entry *ProviderEntry)
 	}
 	if len(entry.Invokes) > 0 {
 		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
+	}
+	if entry.Capabilities != nil {
+		return fmt.Errorf("config validation: %s.capabilities is only supported on plugins.*", subject)
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
@@ -1301,6 +1334,9 @@ func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEnt
 	if len(entry.Invokes) > 0 {
 		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
 	}
+	if entry.Capabilities != nil {
+		return fmt.Errorf("config validation: %s.capabilities is only supported on plugins.*", subject)
+	}
 	if entry.Lifecycle != nil {
 		return fmt.Errorf("config validation: %s.lifecycle is only supported on providers.agent.*", subject)
 	}
@@ -1365,6 +1401,9 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	}
 	if len(entry.Invokes) > 0 {
 		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
+	}
+	if entry.Capabilities != nil {
+		return fmt.Errorf("config validation: %s.capabilities is only supported on plugins.*", subject)
 	}
 	if entry.Lifecycle != nil {
 		return fmt.Errorf("config validation: %s.lifecycle is only supported on providers.agent.*", subject)

--- a/gestaltd/internal/invocationconfig/dependencies.go
+++ b/gestaltd/internal/invocationconfig/dependencies.go
@@ -4,6 +4,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
 )
 
 func PluginInvocationDependencies(deps []config.PluginInvocationDependency) []invocation.PluginInvocationDependency {
@@ -22,4 +23,11 @@ func PluginInvocationDependencies(deps []config.PluginInvocationDependency) []in
 		})
 	}
 	return out
+}
+
+func PluginWorkflowManagerGrants(capabilities *config.PluginCapabilitiesConfig) workflowgrants.Grants {
+	if capabilities == nil || capabilities.Workflow == nil {
+		return nil
+	}
+	return workflowgrants.DecodeClaims(capabilities.Workflow.Operations)
 }

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -784,6 +784,89 @@ func TestPrepareAtPath_RejectsInvalidPluginInvokesShape(t *testing.T) {
 	}
 }
 
+func TestPrepareAtPath_RejectsInvalidPluginWorkflowCapabilitiesShape(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "missing operations",
+			body: `plugins:
+    caller:
+      source:
+        path: ./caller/manifest.yaml
+      capabilities:
+        workflow: {}
+`,
+			want: `plugins.caller.capabilities.workflow.operations is required`,
+		},
+		{
+			name: "unsupported operation",
+			body: `plugins:
+    caller:
+      source:
+        path: ./caller/manifest.yaml
+      capabilities:
+        workflow:
+          operations:
+            - workflow.create
+`,
+			want: `plugins.caller.capabilities.workflow.operations[0] "workflow.create" is not supported`,
+		},
+		{
+			name: "duplicate operation",
+			body: `plugins:
+    caller:
+      source:
+        path: ./caller/manifest.yaml
+      capabilities:
+        workflow:
+          operations:
+            - events.publish
+            - events.publish
+`,
+			want: `plugins.caller.capabilities.workflow.operations[1] duplicates operations[0]`,
+		},
+		{
+			name: "non plugin provider",
+			body: `  cache:
+    shared:
+      source:
+        path: ./cache-manifest.yaml
+      capabilities:
+        workflow:
+          operations:
+            - events.publish
+`,
+			want: `providers.cache.shared.capabilities is only supported on plugins.*`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			caseDir := t.TempDir()
+			cfgPath := filepath.Join(caseDir, "config.yaml")
+			cfg := requiredComponentConfigWithAPIVersionYAML(t, caseDir, filepath.Join(caseDir, "gestalt.db")) + tc.body + `server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
+
+			_, err := NewLifecycle().PrepareAtPath(cfgPath)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("PrepareAtPath error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestPrepareAtPath_AllowsInvokesAgainstEffectiveAlias(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/plugininvoker/invocation_token.go
+++ b/gestaltd/services/plugininvoker/invocation_token.go
@@ -14,6 +14,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
 )
 
 const (
@@ -43,6 +44,7 @@ type invocationTokenClaims struct {
 	CredentialSubjectID string                           `json:"credential_subject_id,omitempty"`
 	TokenPermissions    map[string][]string              `json:"token_permissions,omitempty"`
 	Grants              map[string]invocationGrantClaims `json:"grants,omitempty"`
+	WorkflowGrants      *workflowGrantClaims             `json:"workflow_grants,omitempty"`
 	RequestMeta         requestMetaClaims                `json:"request_meta,omitempty"`
 	Credential          credentialClaims                 `json:"credential,omitempty"`
 	Invocation          invocationClaims                 `json:"invocation,omitempty"`
@@ -70,6 +72,10 @@ type invocationClaims struct {
 	InternalConnectionAccess bool     `json:"internal_connection_access,omitempty"`
 }
 
+type workflowGrantClaims struct {
+	Operations []string `json:"operations,omitempty"`
+}
+
 type invocationTokenContext struct {
 	principal              *principal.Principal
 	requestMeta            invocation.RequestMeta
@@ -80,6 +86,7 @@ type invocationTokenContext struct {
 	internalConnection     bool
 	connection             string
 	grants                 InvocationGrants
+	workflowGrants         workflowgrants.Grants
 }
 
 func NewInvocationTokenManager(secret []byte) (*InvocationTokenManager, error) {
@@ -99,12 +106,16 @@ func NewInvocationTokenManager(secret []byte) (*InvocationTokenManager, error) {
 }
 
 func (m *InvocationTokenManager) MintRootToken(ctx context.Context, pluginName string, grants InvocationGrants) (string, error) {
+	return m.MintRootTokenWithWorkflowGrants(ctx, pluginName, grants, nil)
+}
+
+func (m *InvocationTokenManager) MintRootTokenWithWorkflowGrants(ctx context.Context, pluginName string, grants InvocationGrants, workflowGrants workflowgrants.Grants) (string, error) {
 	if m == nil {
 		return "", fmt.Errorf("invocation tokens are not available")
 	}
 	now := m.now()
 	expiresAt := now.Add(m.rootTTL)
-	return m.signClaims(claimsFromContext(ctx, pluginName, grants, now, expiresAt, m.delegationExpiry(expiresAt, now)))
+	return m.signClaims(claimsFromContext(ctx, pluginName, grants, workflowGrants, now, expiresAt, m.delegationExpiry(expiresAt, now)))
 }
 
 func (m *InvocationTokenManager) ExchangeToken(parentToken, pluginName string, grants InvocationGrants, ttl time.Duration) (string, error) {
@@ -175,6 +186,7 @@ func (m *InvocationTokenManager) resolveToken(token, pluginName string) (invocat
 		internalConnection: claims.Invocation.InternalConnectionAccess,
 		connection:         strings.TrimSpace(claims.Connection),
 		grants:             decodeInvocationGrantClaims(claims.Grants),
+		workflowGrants:     decodeWorkflowGrantClaims(claims.WorkflowGrants),
 	}, nil
 }
 
@@ -195,6 +207,10 @@ func (m *InvocationTokenManager) ResolveToken(token, pluginName string) (TokenCo
 
 func (c TokenContext) Principal() *principal.Principal {
 	return principal.Canonicalized(c.inner.principal)
+}
+
+func (c TokenContext) AllowsWorkflowManagerOperation(operation string) bool {
+	return c.inner.workflowGrants.Allows(operation)
 }
 
 func (m *InvocationTokenManager) parseClaims(token string) (*invocationTokenClaims, error) {
@@ -259,7 +275,7 @@ func (m *InvocationTokenManager) delegationExpiresAt(claims *invocationTokenClai
 	return expiresAt, nil
 }
 
-func claimsFromContext(ctx context.Context, pluginName string, grants InvocationGrants, now, expiresAt, delegationExpiresAt time.Time) *invocationTokenClaims {
+func claimsFromContext(ctx context.Context, pluginName string, grants InvocationGrants, workflowGrants workflowgrants.Grants, now, expiresAt, delegationExpiresAt time.Time) *invocationTokenClaims {
 	p := principal.FromContext(ctx)
 	meta := invocation.MetaFromContext(ctx)
 	if meta == nil {
@@ -286,6 +302,7 @@ func claimsFromContext(ctx context.Context, pluginName string, grants Invocation
 		CredentialSubjectID: credentialSubjectIDForInvocationClaims(p),
 		TokenPermissions:    encodePermissionSet(tokenPermissionsForInvocationClaims(p)),
 		Grants:              encodeInvocationGrantClaims(grants),
+		WorkflowGrants:      encodeWorkflowGrantClaims(workflowGrants),
 		RequestMeta: requestMetaClaims{
 			ClientIP:   reqMeta.ClientIP,
 			RemoteAddr: reqMeta.RemoteAddr,
@@ -306,6 +323,24 @@ func claimsFromContext(ctx context.Context, pluginName string, grants Invocation
 		},
 		Connection: invocation.ConnectionFromContext(ctx),
 	}
+}
+
+func encodeWorkflowGrantClaims(src workflowgrants.Grants) *workflowGrantClaims {
+	if src == nil {
+		return nil
+	}
+	return &workflowGrantClaims{Operations: workflowgrants.EncodeClaims(src)}
+}
+
+func decodeWorkflowGrantClaims(src *workflowGrantClaims) workflowgrants.Grants {
+	if src == nil {
+		return nil
+	}
+	grants := workflowgrants.DecodeClaims(src.Operations)
+	if grants == nil {
+		return workflowgrants.Grants{}
+	}
+	return grants
 }
 
 func restoreInvocationTokenContext(ctx context.Context, tokenCtx invocationTokenContext, connectionOverride string) context.Context {

--- a/gestaltd/services/plugins/process.go
+++ b/gestaltd/services/plugins/process.go
@@ -13,6 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost"
+	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 )
@@ -30,6 +31,7 @@ type ExecConfig struct {
 	PublicBaseURL    string
 	InvocationTokens *plugininvokerservice.InvocationTokenManager
 	InvocationGrants plugininvokerservice.InvocationGrants
+	WorkflowGrants   workflowgrants.Grants
 	ProviderName     string
 	Telemetry        metricutil.TelemetryProviders
 }
@@ -48,6 +50,7 @@ func NewExecutable(ctx context.Context, cfg ExecConfig) (core.Provider, error) {
 		opts = append(opts,
 			WithInvocationTokens(cfg.InvocationTokens),
 			WithInvocationTokenSubject(cfg.StaticSpec.Name, cfg.InvocationGrants),
+			WithWorkflowManagerGrants(cfg.WorkflowGrants),
 		)
 	}
 	prov, err := NewRemote(

--- a/gestaltd/services/plugins/provider_client.go
+++ b/gestaltd/services/plugins/provider_client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
+	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -34,23 +35,24 @@ type StaticProviderSpec struct {
 }
 
 type remoteProviderBase struct {
-	client        proto.IntegrationProviderClient
-	support       integrationProviderSupport
-	name          string
-	displayName   string
-	description   string
-	connection    core.ConnectionMode
-	catalog       *catalog.Catalog
-	iconSVG       string
-	authTypes     []string
-	connParams    map[string]core.ConnectionParamDef
-	credFields    []core.CredentialFieldDef
-	discovery     *core.DiscoveryConfig
-	closer        io.Closer
-	publicBaseURL string
-	invTokens     *plugininvokerservice.InvocationTokenManager
-	callerPlugin  string
-	invokeGrants  plugininvokerservice.InvocationGrants
+	client         proto.IntegrationProviderClient
+	support        integrationProviderSupport
+	name           string
+	displayName    string
+	description    string
+	connection     core.ConnectionMode
+	catalog        *catalog.Catalog
+	iconSVG        string
+	authTypes      []string
+	connParams     map[string]core.ConnectionParamDef
+	credFields     []core.CredentialFieldDef
+	discovery      *core.DiscoveryConfig
+	closer         io.Closer
+	publicBaseURL  string
+	invTokens      *plugininvokerservice.InvocationTokenManager
+	callerPlugin   string
+	invokeGrants   plugininvokerservice.InvocationGrants
+	workflowGrants workflowgrants.Grants
 }
 
 var (
@@ -84,6 +86,12 @@ func WithInvocationTokenSubject(pluginName string, grants plugininvokerservice.I
 	return func(b *remoteProviderBase) {
 		b.callerPlugin = strings.TrimSpace(pluginName)
 		b.invokeGrants = plugininvokerservice.CloneInvocationGrants(grants)
+	}
+}
+
+func WithWorkflowManagerGrants(grants workflowgrants.Grants) RemoteProviderOption {
+	return func(b *remoteProviderBase) {
+		b.workflowGrants = workflowgrants.Clone(grants)
 	}
 }
 
@@ -173,7 +181,7 @@ func (p *remoteProviderBase) Execute(ctx context.Context, operation string, para
 	}
 	requestToken := ""
 	if p != nil && p.invTokens != nil && p.callerPlugin != "" {
-		requestToken, err = p.invTokens.MintRootToken(ctx, p.callerPlugin, p.invokeGrants)
+		requestToken, err = p.invTokens.MintRootTokenWithWorkflowGrants(ctx, p.callerPlugin, p.invokeGrants, p.workflowGrants)
 		if err != nil {
 			return nil, err
 		}

--- a/gestaltd/services/workflows/manager_server.go
+++ b/gestaltd/services/workflows/manager_server.go
@@ -10,6 +10,7 @@ import (
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 	plugininvokerservice "github.com/valon-technologies/gestalt/server/services/plugininvoker"
+	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowmanager"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -47,6 +48,9 @@ func (s *ManagerServer) CreateSchedule(ctx context.Context, req *proto.WorkflowM
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationSchedulesCreate); err != nil {
+		return nil, err
+	}
 	upsert, err := workflowManagerScheduleUpsert(
 		req.GetProviderName(),
 		req.GetCron(),
@@ -78,6 +82,9 @@ func (s *ManagerServer) StartRun(ctx context.Context, req *proto.WorkflowManager
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationRunsStart); err != nil {
+		return nil, err
+	}
 	target, err := workflowManagerTarget(req.GetTarget())
 	if err != nil {
 		return nil, err
@@ -107,6 +114,9 @@ func (s *ManagerServer) SignalRun(ctx context.Context, req *proto.WorkflowManage
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationRunsSignal); err != nil {
+		return nil, err
+	}
 	runID := strings.TrimSpace(req.GetRunId())
 	if runID == "" {
 		return nil, status.Error(codes.InvalidArgument, "run_id is required")
@@ -131,6 +141,9 @@ func (s *ManagerServer) SignalOrStartRun(ctx context.Context, req *proto.Workflo
 	}
 	tokenCtx, err := s.tokenContext(req.GetInvocationToken())
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationRunsSignalOrStart); err != nil {
 		return nil, err
 	}
 	target, err := workflowManagerTarget(req.GetTarget())
@@ -163,6 +176,9 @@ func (s *ManagerServer) GetSchedule(ctx context.Context, req *proto.WorkflowMana
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationSchedulesGet); err != nil {
+		return nil, err
+	}
 	scheduleID := strings.TrimSpace(req.GetScheduleId())
 	if scheduleID == "" {
 		return nil, status.Error(codes.InvalidArgument, "schedule_id is required")
@@ -184,6 +200,9 @@ func (s *ManagerServer) UpdateSchedule(ctx context.Context, req *proto.WorkflowM
 	}
 	tokenCtx, err := s.tokenContext(req.GetInvocationToken())
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationSchedulesUpdate); err != nil {
 		return nil, err
 	}
 	scheduleID := strings.TrimSpace(req.GetScheduleId())
@@ -220,6 +239,9 @@ func (s *ManagerServer) DeleteSchedule(ctx context.Context, req *proto.WorkflowM
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationSchedulesDelete); err != nil {
+		return nil, err
+	}
 	scheduleID := strings.TrimSpace(req.GetScheduleId())
 	if scheduleID == "" {
 		return nil, status.Error(codes.InvalidArgument, "schedule_id is required")
@@ -236,6 +258,9 @@ func (s *ManagerServer) PauseSchedule(ctx context.Context, req *proto.WorkflowMa
 	}
 	tokenCtx, err := s.tokenContext(req.GetInvocationToken())
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationSchedulesPause); err != nil {
 		return nil, err
 	}
 	scheduleID := strings.TrimSpace(req.GetScheduleId())
@@ -261,6 +286,9 @@ func (s *ManagerServer) ResumeSchedule(ctx context.Context, req *proto.WorkflowM
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationSchedulesResume); err != nil {
+		return nil, err
+	}
 	scheduleID := strings.TrimSpace(req.GetScheduleId())
 	if scheduleID == "" {
 		return nil, status.Error(codes.InvalidArgument, "schedule_id is required")
@@ -282,6 +310,9 @@ func (s *ManagerServer) CreateEventTrigger(ctx context.Context, req *proto.Workf
 	}
 	tokenCtx, err := s.tokenContext(req.GetInvocationToken())
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationEventTriggersCreate); err != nil {
 		return nil, err
 	}
 	upsert, err := workflowManagerEventTriggerUpsert(
@@ -314,6 +345,9 @@ func (s *ManagerServer) GetEventTrigger(ctx context.Context, req *proto.Workflow
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationEventTriggersGet); err != nil {
+		return nil, err
+	}
 	triggerID := strings.TrimSpace(req.GetTriggerId())
 	if triggerID == "" {
 		return nil, status.Error(codes.InvalidArgument, "trigger_id is required")
@@ -335,6 +369,9 @@ func (s *ManagerServer) UpdateEventTrigger(ctx context.Context, req *proto.Workf
 	}
 	tokenCtx, err := s.tokenContext(req.GetInvocationToken())
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationEventTriggersUpdate); err != nil {
 		return nil, err
 	}
 	triggerID := strings.TrimSpace(req.GetTriggerId())
@@ -370,6 +407,9 @@ func (s *ManagerServer) DeleteEventTrigger(ctx context.Context, req *proto.Workf
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationEventTriggersDelete); err != nil {
+		return nil, err
+	}
 	triggerID := strings.TrimSpace(req.GetTriggerId())
 	if triggerID == "" {
 		return nil, status.Error(codes.InvalidArgument, "trigger_id is required")
@@ -386,6 +426,9 @@ func (s *ManagerServer) PauseEventTrigger(ctx context.Context, req *proto.Workfl
 	}
 	tokenCtx, err := s.tokenContext(req.GetInvocationToken())
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationEventTriggersPause); err != nil {
 		return nil, err
 	}
 	triggerID := strings.TrimSpace(req.GetTriggerId())
@@ -411,6 +454,9 @@ func (s *ManagerServer) ResumeEventTrigger(ctx context.Context, req *proto.Workf
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationEventTriggersResume); err != nil {
+		return nil, err
+	}
 	triggerID := strings.TrimSpace(req.GetTriggerId())
 	if triggerID == "" {
 		return nil, status.Error(codes.InvalidArgument, "trigger_id is required")
@@ -434,6 +480,9 @@ func (s *ManagerServer) PublishEvent(ctx context.Context, req *proto.WorkflowMan
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireWorkflowGrant(tokenCtx, workflowgrants.OperationEventsPublish); err != nil {
+		return nil, err
+	}
 	event, err := workflowEventFromProto(req.GetEvent())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "event: %v", err)
@@ -455,6 +504,13 @@ func (s *ManagerServer) tokenContext(token string) (plugininvokerservice.TokenCo
 		return plugininvokerservice.TokenContext{}, status.Error(codes.FailedPrecondition, err.Error())
 	}
 	return tokenCtx, nil
+}
+
+func (s *ManagerServer) requireWorkflowGrant(tokenCtx plugininvokerservice.TokenContext, operation string) error {
+	if tokenCtx.AllowsWorkflowManagerOperation(operation) {
+		return nil
+	}
+	return status.Errorf(codes.PermissionDenied, "workflow manager operation %q is not allowed for plugin %q", operation, strings.TrimSpace(s.pluginName))
 }
 
 func workflowManagerScheduleUpsert(

--- a/gestaltd/services/workflows/manager_server_test.go
+++ b/gestaltd/services/workflows/manager_server_test.go
@@ -1,0 +1,43 @@
+package workflows
+
+import (
+	"context"
+	"testing"
+
+	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
+	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestManagerServerEmptyWorkflowGrantsDenyWorkflowManagerMethods(t *testing.T) {
+	t.Parallel()
+
+	tokens, err := NewInvocationTokenManager([]byte("workflow-manager-token-test-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	token, err := tokens.MintRootTokenWithWorkflowGrants(
+		principal.WithPrincipal(context.Background(), &principal.Principal{
+			SubjectID: "user:user-123",
+			UserID:    "user-123",
+			Kind:      principal.KindUser,
+			Source:    principal.SourceSession,
+		}),
+		"caller",
+		nil,
+		workflowgrants.Grants{},
+	)
+	if err != nil {
+		t.Fatalf("MintRootTokenWithWorkflowGrants: %v", err)
+	}
+
+	server := NewManagerServer("caller", nil, tokens)
+	_, err = server.CreateSchedule(context.Background(), &proto.WorkflowManagerCreateScheduleRequest{
+		InvocationToken: token,
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("CreateSchedule error = %v, want PermissionDenied", err)
+	}
+}

--- a/gestaltd/services/workflows/workflowgrants/grants.go
+++ b/gestaltd/services/workflows/workflowgrants/grants.go
@@ -1,0 +1,102 @@
+package workflowgrants
+
+import (
+	"maps"
+	"slices"
+	"strings"
+)
+
+const (
+	OperationRunsStart         = "runs.start"
+	OperationRunsSignal        = "runs.signal"
+	OperationRunsSignalOrStart = "runs.signalOrStart"
+
+	OperationSchedulesCreate = "schedules.create"
+	OperationSchedulesGet    = "schedules.get"
+	OperationSchedulesUpdate = "schedules.update"
+	OperationSchedulesDelete = "schedules.delete"
+	OperationSchedulesPause  = "schedules.pause"
+	OperationSchedulesResume = "schedules.resume"
+
+	OperationEventTriggersCreate = "eventTriggers.create"
+	OperationEventTriggersGet    = "eventTriggers.get"
+	OperationEventTriggersUpdate = "eventTriggers.update"
+	OperationEventTriggersDelete = "eventTriggers.delete"
+	OperationEventTriggersPause  = "eventTriggers.pause"
+	OperationEventTriggersResume = "eventTriggers.resume"
+
+	OperationEventsPublish = "events.publish"
+)
+
+type Grants map[string]struct{}
+
+var supportedOperations = map[string]struct{}{
+	OperationRunsStart:         {},
+	OperationRunsSignal:        {},
+	OperationRunsSignalOrStart: {},
+
+	OperationSchedulesCreate: {},
+	OperationSchedulesGet:    {},
+	OperationSchedulesUpdate: {},
+	OperationSchedulesDelete: {},
+	OperationSchedulesPause:  {},
+	OperationSchedulesResume: {},
+
+	OperationEventTriggersCreate: {},
+	OperationEventTriggersGet:    {},
+	OperationEventTriggersUpdate: {},
+	OperationEventTriggersDelete: {},
+	OperationEventTriggersPause:  {},
+	OperationEventTriggersResume: {},
+
+	OperationEventsPublish: {},
+}
+
+func IsSupportedOperation(operation string) bool {
+	_, ok := supportedOperations[strings.TrimSpace(operation)]
+	return ok
+}
+
+func SupportedOperations() []string {
+	return slices.Sorted(maps.Keys(supportedOperations))
+}
+
+func Clone(src Grants) Grants {
+	if src == nil {
+		return nil
+	}
+	return maps.Clone(src)
+}
+
+func EncodeClaims(src Grants) []string {
+	if src == nil {
+		return nil
+	}
+	if len(src) == 0 {
+		return []string{}
+	}
+	return slices.Sorted(maps.Keys(src))
+}
+
+func DecodeClaims(src []string) Grants {
+	if src == nil {
+		return nil
+	}
+	out := make(Grants, len(src))
+	for _, operation := range src {
+		operation = strings.TrimSpace(operation)
+		if operation == "" {
+			continue
+		}
+		out[operation] = struct{}{}
+	}
+	return out
+}
+
+func (g Grants) Allows(operation string) bool {
+	if g == nil {
+		return true
+	}
+	_, ok := g[strings.TrimSpace(operation)]
+	return ok
+}

--- a/gestaltd/services/workflows/workflowgrants/grants_test.go
+++ b/gestaltd/services/workflows/workflowgrants/grants_test.go
@@ -1,0 +1,19 @@
+package workflowgrants
+
+import "testing"
+
+func TestClaimsRoundTripPreservesNilAllowAllAndEmptyDenyAll(t *testing.T) {
+	t.Parallel()
+
+	if got := DecodeClaims(EncodeClaims(nil)); got != nil {
+		t.Fatalf("nil grants round trip = %#v, want nil allow-all grants", got)
+	}
+
+	got := DecodeClaims(EncodeClaims(Grants{}))
+	if got == nil {
+		t.Fatal("empty grants round trip = nil, want explicit empty deny-all grants")
+	}
+	if got.Allows(OperationEventsPublish) {
+		t.Fatalf("empty grants allow %q, want denied", OperationEventsPublish)
+	}
+}


### PR DESCRIPTION
## Summary

Adds explicit plugin workflow-manager capabilities so deployments can allowlist which WorkflowManagerHost methods a plugin may call. Omitted `capabilities.workflow` preserves the existing legacy behavior.

## Interface Changes
- New/changed interface:
  - `plugins.<name>.capabilities.workflow.operations` is an optional allowlist for workflow-manager methods.
  - Supported operations: `runs.start`, `runs.signal`, `runs.signalOrStart`, `schedules.create`, `schedules.get`, `schedules.update`, `schedules.delete`, `schedules.pause`, `schedules.resume`, `eventTriggers.create`, `eventTriggers.get`, `eventTriggers.update`, `eventTriggers.delete`, `eventTriggers.pause`, `eventTriggers.resume`, `events.publish`.
- Example usage:

```yaml
plugins:
  slack:
    capabilities:
      workflow:
        operations:
          - runs.signalOrStart
          - schedules.create
          - eventTriggers.create
          - events.publish
```

With `capabilities.workflow.operations: [events.publish]`, `request.workflow_manager().publish_event(...)` succeeds, while `create_schedule(...)` is rejected at the WorkflowManagerHost boundary before the workflow manager service is called.

## Functional/Integration Tests
- Tests added or augmented:
  - `TestPrepareAtPath_RejectsInvalidPluginWorkflowCapabilitiesShape`
  - `TestPluginWorkflowManagerCapabilitiesRestrictHostMethods`
- Contract boundary covered:
  - YAML/config validation for the new plugin-only capability field.
  - Hosted plugin process -> SDK WorkflowManager client -> gRPC WorkflowManagerHost -> token grant enforcement -> workflow manager stub.
- Commands run:
  - `go test ./internal/operator -run TestPrepareAtPath_RejectsInvalidPluginWorkflowCapabilitiesShape`
  - `go test ./internal/bootstrap -run TestPluginWorkflowManagerCapabilitiesRestrictHostMethods`
  - `go test ./internal/bootstrap -run TestPluginWorkflowManagerCRUDUsesRequestContext`
  - `go test ./internal/bootstrap -run 'TestPluginWorkflowManager(CRUDUsesRequestContext|CapabilitiesRestrictHostMethods)'`
  - `go test ./services/plugininvoker ./services/workflows ./services/plugins`