### PR TITLE
Add Linux installer script

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Build docs
         run: npm run build
 
+      - name: Test Linux installer
+        run: npm run test:linux-installer
+
   helm-validate:
     name: Helm Chart Validation
     runs-on: ubuntu-latest

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -55,6 +55,7 @@ jobs:
       component-summary: |
         Command-line client for authenticating with Gestalt, working with integrations and workflows, and running interactive agent sessions from the terminal.
       install-markdown: |
+        - Linux installer: `curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component both --version ${version}`
         - Homebrew: `brew upgrade valon-technologies/gestalt/gestalt`
         - Docker: `docker pull valontechnologies/gestalt:${version}`
         - Docs: [CLI guide](https://gestaltd.ai/client/cli)

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -89,6 +89,7 @@ jobs:
       component-summary: |
         Self-hosted integration gateway for Gestalt with the embedded client UI, admin UI, HTTP API, and optional MCP endpoint.
       install-markdown: |
+        - Linux installer: `curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component gestaltd --version ${version}`
         - Homebrew: `brew upgrade valon-technologies/gestalt/gestaltd`
         - Docker: `docker pull valontechnologies/gestaltd:${version}`
         - Docs: [Deployment guide](https://gestaltd.ai/deploy)

--- a/README.md
+++ b/README.md
@@ -32,11 +32,18 @@ Gestalt also does not replace your existing APIs. It sits between agents and ups
 
 ## Quick Start
 
-Tap the Gestalt Homebrew repository and install both binaries:
+On Linux, install both binaries with the installer script:
+
+```sh
+curl -fsSL https://gestaltd.ai/install.sh | sh
+```
+
+On macOS, or on Linux when you prefer Homebrew, tap the Gestalt Homebrew
+repository and install the CLI package. The CLI package also includes the
+bundled `gestaltd` helper binary:
 
 ```sh
 brew tap valon-technologies/gestalt
-brew install valon-technologies/gestalt/gestaltd
 brew install valon-technologies/gestalt/gestalt
 ```
 

--- a/docs/content/install/_meta.ts
+++ b/docs/content/install/_meta.ts
@@ -1,4 +1,5 @@
 export default {
+  linux: "Linux",
   homebrew: "Homebrew",
   binary: "Binary Releases",
   source: "Build from Source",

--- a/docs/content/install/binary.mdx
+++ b/docs/content/install/binary.mdx
@@ -4,6 +4,9 @@ import { Tabs } from 'nextra/components'
 
 Pre-built binaries are published for every release on GitHub.
 
+On Linux, the installer script is usually simpler than manual archive handling.
+See [Linux](/install/linux).
+
 ## Server
 
 `gestaltd` is the long-running process that manages authentication and plugins.
@@ -63,6 +66,10 @@ gestaltd --version
 
 `gestalt` is the CLI for communicating with the Gestalt server.
 
+On Unix platforms, the `gestalt` archive also includes a matching `gestaltd`
+helper binary. Install both files when you want the same behavior as the Linux
+installer's default `--component both` mode.
+
 ### Install
 
 <Tabs items={['macOS Apple Silicon', 'macOS Intel', 'Linux x86_64', 'Linux ARM64', 'Linux ARMv7', 'Windows x86_64']}>
@@ -71,7 +78,7 @@ gestaltd --version
 
     ```sh
     tar xzf gestalt-macos-arm64.tar.gz
-    sudo mv gestalt /usr/local/bin/
+    sudo mv gestalt gestaltd /usr/local/bin/
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -79,7 +86,7 @@ gestaltd --version
 
     ```sh
     tar xzf gestalt-macos-x86_64.tar.gz
-    sudo mv gestalt /usr/local/bin/
+    sudo mv gestalt gestaltd /usr/local/bin/
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -87,7 +94,7 @@ gestaltd --version
 
     ```sh
     tar xzf gestalt-linux-x86_64.tar.gz
-    sudo mv gestalt /usr/local/bin/
+    sudo mv gestalt gestaltd /usr/local/bin/
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -95,7 +102,7 @@ gestaltd --version
 
     ```sh
     tar xzf gestalt-linux-arm64.tar.gz
-    sudo mv gestalt /usr/local/bin/
+    sudo mv gestalt gestaltd /usr/local/bin/
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -103,7 +110,7 @@ gestaltd --version
 
     ```sh
     tar xzf gestalt-linux-armv7.tar.gz
-    sudo mv gestalt /usr/local/bin/
+    sudo mv gestalt gestaltd /usr/local/bin/
     ```
   </Tabs.Tab>
   <Tabs.Tab>

--- a/docs/content/install/homebrew.mdx
+++ b/docs/content/install/homebrew.mdx
@@ -2,7 +2,8 @@
 
 Gestalt publishes a Homebrew tap for macOS and Linux.
 
-If you need a direct-download install or a Linux-specific release artifact, see [Binary Releases](/install/binary).
+For the native Linux installer script, see [Linux](/install/linux). If you need
+a direct-download archive, see [Binary Releases](/install/binary).
 
 Tap the repository first:
 
@@ -10,9 +11,10 @@ Tap the repository first:
 brew tap valon-technologies/gestalt
 ```
 
-## Server
+## Server only
 
 `gestaltd` is the long-running process that manages authentication and plugins.
+Install this formula when you only want the server daemon.
 
 ### Install
 
@@ -26,9 +28,10 @@ brew install valon-technologies/gestalt/gestaltd
 gestaltd --version
 ```
 
-## Client
+## Client and bundled server
 
-`gestalt` is the CLI for communicating with the Gestalt server.
+`gestalt` is the CLI for communicating with the Gestalt server. This formula
+also installs the bundled `gestaltd` helper binary from the CLI release archive.
 
 ### Install
 

--- a/docs/content/install/index.mdx
+++ b/docs/content/install/index.mdx
@@ -6,13 +6,20 @@ asIndexPage: true
 
 Gestalt ships two binaries: `gestaltd` (the server) and `gestalt` (the CLI client). Install both to get started.
 
+## Linux
+
+The fastest native Linux path is the installer script. See [Linux](/install/linux).
+
+```sh
+curl -fsSL https://gestaltd.ai/install.sh | sh
+```
+
 ## Homebrew
 
-The fastest path on macOS and Linux. See [Homebrew](/install/homebrew).
+The fastest path on macOS, and a supported package-manager path on Linux. See [Homebrew](/install/homebrew).
 
 ```sh
 brew tap valon-technologies/gestalt
-brew install valon-technologies/gestalt/gestaltd
 brew install valon-technologies/gestalt/gestalt
 ```
 

--- a/docs/content/install/linux.mdx
+++ b/docs/content/install/linux.mdx
@@ -1,0 +1,88 @@
+# Linux
+
+The recommended native Linux install is the installer script. It downloads the
+matching GitHub release archive, verifies the published SHA-256 checksum, and
+installs the requested binaries.
+
+## Install both binaries
+
+Install `gestalt` and `gestaltd` into `/usr/local/bin`:
+
+```sh
+curl -fsSL https://gestaltd.ai/install.sh | sh
+```
+
+Or with `wget`:
+
+```sh
+wget -qO- https://gestaltd.ai/install.sh | sh
+```
+
+The default install uses the latest `gestalt/v*` CLI release archive. On Linux,
+that archive also includes the matching `gestaltd` helper binary. Because
+Gestalt is currently alpha, `latest` includes prerelease tags; use `--version`
+for deterministic installs.
+
+## Install one component
+
+Install only the CLI:
+
+```sh
+curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component gestalt
+```
+
+Install only the server daemon from the `gestaltd/v*` release family:
+
+```sh
+curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component gestaltd
+```
+
+Pin a specific release:
+
+```sh
+curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component both --version 0.0.1-alpha.16
+curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component gestaltd --version gestaltd/v0.0.1-alpha.20
+```
+
+Install without `sudo`:
+
+```sh
+curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --user
+```
+
+Choose an explicit install directory:
+
+```sh
+curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --bin-dir ~/.local/bin
+```
+
+Preview the selected archive without downloading or installing binaries:
+
+```sh
+curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --dry-run
+```
+
+## Package managers
+
+Homebrew also works on Linux and remains supported:
+
+```sh
+brew tap valon-technologies/gestalt
+brew install valon-technologies/gestalt/gestalt
+```
+
+`apt` and `apt-get` are not the distribution path yet. `apt` is the interactive
+Debian/Ubuntu package-manager frontend, while `apt-get` is the tool to use in
+scripts once a project publishes `.deb` packages through an APT repository.
+Gestalt does not currently publish `.deb`, `.rpm`, or distro repository
+packages.
+
+For production `gestaltd` deployments, prefer the published Docker image or Helm
+chart. See [Deploy](/deploy).
+
+## Manual fallback
+
+If you prefer to inspect the files yourself, download the release archives and
+checksums from [Binary Releases](/install/binary).
+
+Once both binaries are on your `PATH`, continue to [Getting Started](/getting-started).

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "next lint",
+    "test:linux-installer": "bash scripts/test-linux-installer.sh",
     "test:registry": "node scripts/check-registry-static.mjs",
     "test:registry-docs": "node scripts/check-registry-docs-render.mjs"
   },

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -1,0 +1,433 @@
+#!/bin/sh
+set -eu
+
+repo="valon-technologies/gestalt"
+component="both"
+version="latest"
+prefix="/usr/local"
+prefix_set=0
+bin_dir=""
+user_install=0
+dry_run=0
+path_flags=0
+
+default_releases_url="https://api.github.com/repos/${repo}/releases?per_page=100&page={page}"
+releases_url="${GESTALT_INSTALL_RELEASES_URL:-$default_releases_url}"
+download_base="${GESTALT_INSTALL_DOWNLOAD_BASE:-https://github.com/${repo}/releases/download}"
+max_release_pages="${GESTALT_INSTALL_MAX_PAGES:-5}"
+
+usage() {
+  cat <<'USAGE'
+Install Gestalt on Linux.
+
+Usage:
+  install.sh [options]
+
+Options:
+  --component both|gestalt|gestaltd  Component to install. Default: both.
+  --version VERSION                  Release version or family-prefixed tag. Default: latest, including prereleases.
+  --prefix PATH                      Install into PATH/bin. Default: /usr/local/bin.
+  --bin-dir PATH                     Install directly into PATH.
+  --user                             Install into $HOME/.local/bin.
+  --dry-run                          Print the planned install without downloading binaries.
+  -h, --help                         Show this help.
+USAGE
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  printf 'gestalt installer: %s\n' "$*" >&2
+  exit 1
+}
+
+need_value() {
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+    fail "$1 requires a value"
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --component)
+      need_value "$@"
+      component="$2"
+      shift 2
+      ;;
+    --version)
+      need_value "$@"
+      version="$2"
+      shift 2
+      ;;
+    --prefix)
+      need_value "$@"
+      prefix="$2"
+      prefix_set=1
+      path_flags=$((path_flags + 1))
+      shift 2
+      ;;
+    --bin-dir)
+      need_value "$@"
+      bin_dir="$2"
+      path_flags=$((path_flags + 1))
+      shift 2
+      ;;
+    --user)
+      user_install=1
+      path_flags=$((path_flags + 1))
+      shift
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+case "$component" in
+  both | gestalt)
+    release_family="gestalt"
+    ;;
+  gestaltd)
+    release_family="gestaltd"
+    ;;
+  *)
+    fail "--component must be one of: both, gestalt, gestaltd"
+    ;;
+esac
+
+if [ "$path_flags" -gt 1 ]; then
+  fail "--bin-dir, --prefix, and --user are mutually exclusive"
+fi
+
+if [ "$user_install" -eq 1 ]; then
+  [ -n "${HOME:-}" ] || fail "--user requires HOME to be set"
+  bin_dir="${HOME}/.local/bin"
+elif [ -n "$bin_dir" ]; then
+  :
+elif [ "$prefix_set" -eq 1 ]; then
+  bin_dir="${prefix}/bin"
+else
+  bin_dir="/usr/local/bin"
+fi
+
+lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+detect_platform() {
+  os_name="$(lower "${GESTALT_INSTALL_OS:-$(uname -s)}")"
+  arch_name="$(lower "${GESTALT_INSTALL_ARCH:-$(uname -m)}")"
+
+  case "$os_name" in
+    linux)
+      os_part="linux"
+      ;;
+    *)
+      fail "this installer supports Linux; use Homebrew or binary releases for ${os_name}"
+      ;;
+  esac
+
+  case "$arch_name" in
+    x86_64 | amd64)
+      arch_part="x86_64"
+      ;;
+    aarch64 | arm64)
+      arch_part="arm64"
+      ;;
+    armv7 | armv7l)
+      arch_part="armv7"
+      ;;
+    *)
+      fail "unsupported Linux architecture: ${arch_name}"
+      ;;
+  esac
+
+  platform="${os_part}-${arch_part}"
+}
+
+download() {
+  download_url="$1"
+  download_path="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$download_url" -o "$download_path"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$download_path" "$download_url"
+  else
+    fail "curl or wget is required"
+  fi
+}
+
+release_page_url() {
+  page_number="$1"
+  case "$releases_url" in
+    *"{page}"*)
+      page_prefix=${releases_url%%\{page\}*}
+      page_suffix=${releases_url#*\{page\}}
+      printf '%s%s%s\n' "$page_prefix" "$page_number" "$page_suffix"
+      ;;
+    *"?"*)
+      printf '%s&page=%s\n' "$releases_url" "$page_number"
+      ;;
+    *)
+      printf '%s?page=%s\n' "$releases_url" "$page_number"
+      ;;
+  esac
+}
+
+extract_matching_tag() {
+  release_file="$1"
+  tag_prefix="$2"
+
+  awk -v tag_prefix="$tag_prefix" '
+    /"tag_name"[[:space:]]*:/ {
+      tag_line = $0
+      sub(/^.*"tag_name"[[:space:]]*:[[:space:]]*"/, "", tag_line)
+      sub(/".*$/, "", tag_line)
+      tag = tag_line
+    }
+    /"draft"[[:space:]]*:/ {
+      draft_line = $0
+      sub(/^.*"draft"[[:space:]]*:[[:space:]]*/, "", draft_line)
+      sub(/[,}].*$/, "", draft_line)
+      gsub(/[[:space:]]/, "", draft_line)
+      if (tag ~ "^" tag_prefix && draft_line != "true") {
+        print tag
+        exit
+      }
+      tag = ""
+    }
+  ' "$release_file"
+}
+
+resolve_latest_version() {
+  tag_prefix="${release_family}/v"
+  page=1
+
+  while [ "$page" -le "$max_release_pages" ]; do
+    page_url="$(release_page_url "$page")"
+    release_file="${tmp_dir}/releases-${page}.json"
+    download "$page_url" "$release_file" || fail "failed to fetch GitHub releases page ${page}"
+    matching_tag="$(extract_matching_tag "$release_file" "$tag_prefix")"
+    if [ -n "$matching_tag" ]; then
+      printf '%s\n' "${matching_tag#"$tag_prefix"}"
+      return
+    fi
+    page=$((page + 1))
+  done
+
+  fail "no ${tag_prefix} release found after ${max_release_pages} pages; pass --version VERSION to install a specific release"
+}
+
+normalize_version() {
+  requested="$1"
+  family="$2"
+
+  case "$requested" in
+    latest)
+      resolve_latest_version
+      ;;
+    "${family}/v"*)
+      printf '%s\n' "${requested#"${family}/v"}"
+      ;;
+    */v*)
+      fail "--version ${requested} does not match --component ${component}; expected ${family}/v*"
+      ;;
+    v*)
+      printf '%s\n' "${requested#v}"
+      ;;
+    *)
+      printf '%s\n' "$requested"
+      ;;
+  esac
+}
+
+sha256_actual() {
+  archive_path="$1"
+  sha_tool="${GESTALT_INSTALL_SHA256_TOOL:-}"
+
+  case "$sha_tool" in
+    none)
+      fail "no supported SHA-256 tool found"
+      ;;
+    sha256sum | "")
+      if [ "$sha_tool" = "sha256sum" ] && ! command -v sha256sum >/dev/null 2>&1; then
+        fail "sha256sum is not available"
+      fi
+      if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$archive_path" | awk '{print $1}'
+        return
+      fi
+      ;;
+    shasum)
+      if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$archive_path" | awk '{print $1}'
+        return
+      fi
+      fail "shasum is not available"
+      ;;
+    *)
+      fail "unsupported GESTALT_INSTALL_SHA256_TOOL: ${sha_tool}"
+      ;;
+  esac
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$archive_path" | awk '{print $1}'
+    return
+  fi
+
+  fail "no supported SHA-256 tool found"
+}
+
+verify_checksum() {
+  archive_path="$1"
+  archive_name="$2"
+  checksum_path="$3"
+
+  expected_hash="$(awk 'NF >= 1 { print $1; exit }' "$checksum_path")"
+  expected_name="$(awk 'NF >= 2 { print $2; exit }' "$checksum_path")"
+
+  case "$expected_hash" in
+    "" | *[!0123456789abcdefABCDEF]*)
+      fail "checksum file is malformed: ${checksum_path}"
+      ;;
+  esac
+
+  if [ "$expected_name" != "$archive_name" ]; then
+    fail "checksum file is for ${expected_name:-<missing>}, expected ${archive_name}"
+  fi
+
+  actual_hash="$(sha256_actual "$archive_path")"
+  expected_hash="$(printf '%s' "$expected_hash" | tr '[:upper:]' '[:lower:]')"
+  actual_hash="$(printf '%s' "$actual_hash" | tr '[:upper:]' '[:lower:]')"
+
+  if [ "$actual_hash" != "$expected_hash" ]; then
+    fail "checksum mismatch for ${archive_name}"
+  fi
+}
+
+expected_binaries() {
+  case "$component" in
+    both)
+      printf '%s\n' "gestalt gestaltd"
+      ;;
+    gestalt)
+      printf '%s\n' "gestalt"
+      ;;
+    gestaltd)
+      printf '%s\n' "gestaltd"
+      ;;
+  esac
+}
+
+ensure_install_dir() {
+  if [ -d "$bin_dir" ] && [ -w "$bin_dir" ]; then
+    sudo_cmd=""
+    return
+  fi
+
+  if mkdir -p "$bin_dir" 2>/dev/null && [ -w "$bin_dir" ]; then
+    sudo_cmd=""
+    return
+  fi
+
+  if command -v sudo >/dev/null 2>&1; then
+    sudo mkdir -p "$bin_dir"
+    sudo_cmd="sudo"
+    return
+  fi
+
+  fail "cannot write to ${bin_dir}; rerun with --user or --bin-dir PATH"
+}
+
+install_binary() {
+  source_path="$1"
+  binary_name="$2"
+  target_path="${bin_dir}/${binary_name}"
+
+  if [ -n "$sudo_cmd" ]; then
+    $sudo_cmd install -m 0755 "$source_path" "$target_path"
+  else
+    install -m 0755 "$source_path" "$target_path"
+  fi
+}
+
+warn_path() {
+  case ":${PATH:-}:" in
+    *":${bin_dir}:"*)
+      ;;
+    *)
+      log "Warning: ${bin_dir} is not on PATH."
+      ;;
+  esac
+}
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+detect_platform
+resolved_version="$(normalize_version "$version" "$release_family")"
+release_tag="${release_family}/v${resolved_version}"
+archive_name="${release_family}-${platform}.tar.gz"
+archive_url="${download_base}/${release_tag}/${archive_name}"
+checksum_url="${archive_url}.sha256"
+binaries="$(expected_binaries)"
+
+if [ "$dry_run" -eq 1 ]; then
+  log "gestalt installer dry run"
+  log "component: ${component}"
+  log "platform: ${platform}"
+  log "tag: ${release_tag}"
+  log "archive: ${archive_url}"
+  log "checksum: ${checksum_url}"
+  log "install directory: ${bin_dir}"
+  log "binaries: ${binaries}"
+  if [ "$user_install" -eq 1 ]; then
+    warn_path
+  fi
+  exit 0
+fi
+
+archive_path="${tmp_dir}/${archive_name}"
+checksum_path="${archive_path}.sha256"
+extract_dir="${tmp_dir}/extract"
+
+log "Downloading ${archive_url}"
+download "$archive_url" "$archive_path" || fail "failed to download ${archive_url}"
+download "$checksum_url" "$checksum_path" || fail "failed to download ${checksum_url}"
+verify_checksum "$archive_path" "$archive_name" "$checksum_path"
+
+mkdir -p "$extract_dir"
+tar -xzf "$archive_path" -C "$extract_dir"
+
+for binary in $binaries; do
+  if [ ! -f "${extract_dir}/${binary}" ] || [ -L "${extract_dir}/${binary}" ]; then
+    fail "${archive_name} did not contain expected regular binary: ${binary}"
+  fi
+done
+
+ensure_install_dir
+
+for binary in $binaries; do
+  install_binary "${extract_dir}/${binary}" "$binary"
+  log "Installed ${binary} to ${bin_dir}/${binary}"
+done
+
+if [ "$user_install" -eq 1 ]; then
+  warn_path
+fi
+
+log "Done."

--- a/docs/scripts/test-linux-installer.sh
+++ b/docs/scripts/test-linux-installer.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+installer="$PWD/public/install.sh"
+tmp_dir="$(mktemp -d)"
+download_root="$tmp_dir/releases"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'test-linux-installer: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local text="$1"
+  local expected="$2"
+  case "$text" in
+    *"$expected"*) ;;
+    *) fail "expected output to contain: $expected"$'\n'"actual output:"$'\n'"$text" ;;
+  esac
+}
+
+assert_executable() {
+  local path="$1"
+  [[ -x "$path" ]] || fail "expected executable: $path"
+}
+
+assert_not_exists() {
+  local path="$1"
+  [[ ! -e "$path" ]] || fail "expected path not to exist: $path"
+}
+
+assert_fails() {
+  local output
+  local status
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+  if [[ "$status" -eq 0 ]]; then
+    fail "command unexpectedly succeeded: $*"
+  fi
+  printf '%s' "$output"
+}
+
+checksum_archive() {
+  local archive="$1"
+  local archive_name
+  archive_name="$(basename "$archive")"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$(dirname "$archive")" && sha256sum "$archive_name")
+  else
+    (cd "$(dirname "$archive")" && shasum -a 256 "$archive_name")
+  fi
+}
+
+make_archive() {
+  local family="$1"
+  local version="$2"
+  local platform="$3"
+  shift 3
+
+  local stage_dir="$tmp_dir/stage/${family}-${version}-${platform}"
+  local dest_dir="$download_root/${family}/v${version}"
+  local archive="${dest_dir}/${family}-${platform}.tar.gz"
+
+  mkdir -p "$stage_dir" "$dest_dir"
+  for binary in "$@"; do
+    {
+      printf '#!/bin/sh\n'
+      printf 'printf "%s %s\\n"\n' "$binary" "$version"
+    } >"${stage_dir}/${binary}"
+    chmod +x "${stage_dir}/${binary}"
+  done
+
+  (cd "$stage_dir" && tar -czf "$archive" "$@")
+  checksum_archive "$archive" >"${archive}.sha256"
+}
+
+run_installer() {
+  env \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=x86_64 \
+    sh "$installer" "$@"
+}
+
+make_archive gestalt 1.2.3 linux-x86_64 gestalt gestaltd
+make_archive gestaltd 2.0.0 linux-x86_64 gestaltd
+make_archive gestalt 3.0.0 linux-x86_64 gestalt
+make_archive gestalt 4.0.0 linux-x86_64 gestalt gestaltd
+make_archive gestalt 5.0.0 linux-x86_64 gestalt gestaltd
+make_archive gestalt 6.0.0 linux-x86_64 gestalt gestaltd
+
+symlink_stage="$tmp_dir/stage/gestalt-7.0.0-linux-x86_64"
+symlink_dest="$download_root/gestalt/v7.0.0"
+mkdir -p "$symlink_stage" "$symlink_dest"
+ln -s /etc/hosts "$symlink_stage/gestalt"
+{
+  printf '#!/bin/sh\n'
+  printf 'printf "gestaltd 7.0.0\\n"\n'
+} >"$symlink_stage/gestaltd"
+chmod +x "$symlink_stage/gestaltd"
+(cd "$symlink_stage" && tar -czf "$symlink_dest/gestalt-linux-x86_64.tar.gz" gestalt gestaltd)
+checksum_archive "$symlink_dest/gestalt-linux-x86_64.tar.gz" >"$symlink_dest/gestalt-linux-x86_64.tar.gz.sha256"
+
+both_bin="$tmp_dir/bin-both"
+run_installer --component both --version 1.2.3 --bin-dir "$both_bin" >/dev/null
+assert_executable "$both_bin/gestalt"
+assert_executable "$both_bin/gestaltd"
+
+cli_bin="$tmp_dir/bin-cli"
+run_installer --component gestalt --version gestalt/v1.2.3 --bin-dir "$cli_bin" >/dev/null
+assert_executable "$cli_bin/gestalt"
+assert_not_exists "$cli_bin/gestaltd"
+
+daemon_bin="$tmp_dir/bin-daemon"
+run_installer --component gestaltd --version 2.0.0 --bin-dir "$daemon_bin" >/dev/null
+assert_executable "$daemon_bin/gestaltd"
+assert_not_exists "$daemon_bin/gestalt"
+
+cat >"$tmp_dir/releases-page-1.json" <<'JSON'
+[
+  {
+    "tag_name": "sdk/go/v9.9.9",
+    "draft": false,
+    "prerelease": true
+  },
+  {
+    "tag_name": "gestalt/v9.9.9",
+    "draft": true,
+    "prerelease": true
+  }
+]
+JSON
+
+cat >"$tmp_dir/releases-page-2.json" <<'JSON'
+[
+  {
+    "tag_name": "gestalt/v0.2.0-alpha.1",
+    "draft": false,
+    "prerelease": true
+  },
+  {
+    "tag_name": "gestaltd/v0.9.0-alpha.1",
+    "draft": false,
+    "prerelease": true
+  }
+]
+JSON
+
+latest_cli_output="$(
+  env \
+    GESTALT_INSTALL_RELEASES_URL="file://${tmp_dir}/releases-page-{page}.json" \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file:///does-not-exist" \
+    GESTALT_INSTALL_MAX_PAGES=2 \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=aarch64 \
+    sh "$installer" --component both --dry-run --bin-dir "$tmp_dir/dry-run-bin"
+)"
+assert_contains "$latest_cli_output" "tag: gestalt/v0.2.0-alpha.1"
+assert_contains "$latest_cli_output" "gestalt-linux-arm64.tar.gz"
+
+latest_daemon_output="$(
+  env \
+    GESTALT_INSTALL_RELEASES_URL="file://${tmp_dir}/releases-page-{page}.json" \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file:///does-not-exist" \
+    GESTALT_INSTALL_MAX_PAGES=2 \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=armv7l \
+    sh "$installer" --component gestaltd --dry-run --bin-dir "$tmp_dir/dry-run-bin"
+)"
+assert_contains "$latest_daemon_output" "tag: gestaltd/v0.9.0-alpha.1"
+assert_contains "$latest_daemon_output" "gestaltd-linux-armv7.tar.gz"
+
+dry_run_dead_base="$(
+  env \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file:///does-not-exist" \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=x86_64 \
+    sh "$installer" --component both --version 1.2.3 --dry-run --bin-dir "$tmp_dir/dry-run-bin"
+)"
+assert_contains "$dry_run_dead_base" "archive: file:///does-not-exist/gestalt/v1.2.3/gestalt-linux-x86_64.tar.gz"
+
+mismatch_output="$(
+  assert_fails env \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=x86_64 \
+    sh "$installer" --component gestaltd --version gestalt/v1.2.3 --dry-run --bin-dir "$tmp_dir/mismatch-bin"
+)"
+assert_contains "$mismatch_output" "does not match --component gestaltd"
+
+conflict_output="$(assert_fails sh "$installer" --user --bin-dir "$tmp_dir/conflict-bin")"
+assert_contains "$conflict_output" "mutually exclusive"
+
+missing_output="$(
+  assert_fails env \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=x86_64 \
+    sh "$installer" --component both --version 3.0.0 --bin-dir "$tmp_dir/missing-bin"
+)"
+assert_contains "$missing_output" "did not contain expected regular binary: gestaltd"
+
+symlink_output="$(
+  assert_fails env \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=x86_64 \
+    sh "$installer" --component both --version 7.0.0 --bin-dir "$tmp_dir/symlink-bin"
+)"
+assert_contains "$symlink_output" "did not contain expected regular binary: gestalt"
+
+bad_checksum="$download_root/gestalt/v4.0.0/gestalt-linux-x86_64.tar.gz.sha256"
+printf '0000000000000000000000000000000000000000000000000000000000000000  gestalt-linux-x86_64.tar.gz\n' >"$bad_checksum"
+checksum_output="$(
+  assert_fails env \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=x86_64 \
+    sh "$installer" --component both --version 4.0.0 --bin-dir "$tmp_dir/bad-checksum-bin"
+)"
+assert_contains "$checksum_output" "checksum mismatch"
+
+empty_checksum="$download_root/gestalt/v5.0.0/gestalt-linux-x86_64.tar.gz.sha256"
+: >"$empty_checksum"
+malformed_output="$(
+  assert_fails env \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=x86_64 \
+    sh "$installer" --component both --version 5.0.0 --bin-dir "$tmp_dir/empty-checksum-bin"
+)"
+assert_contains "$malformed_output" "checksum file is malformed"
+
+sha_tool_output="$(
+  assert_fails env \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=x86_64 \
+    GESTALT_INSTALL_SHA256_TOOL=none \
+    sh "$installer" --component both --version 6.0.0 --bin-dir "$tmp_dir/no-sha-bin"
+)"
+assert_contains "$sha_tool_output" "no supported SHA-256 tool"
+
+if [[ -d out ]]; then
+  [[ -f out/install.sh ]] || fail "docs static export did not include out/install.sh"
+  first_line="$(sed -n '1p' out/install.sh)"
+  [[ "$first_line" == "#!/bin/sh" ]] || fail "out/install.sh did not preserve installer shebang"
+else
+  printf 'Skipping static export assertion because docs/out does not exist; run npm run build first.\n'
+fi
+
+printf 'Linux installer integration tests passed.\n'


### PR DESCRIPTION
## Summary

Adds a first-class Linux install path for Gestalt by serving a POSIX `sh` installer from the docs static site at `/install.sh`. The installer downloads GitHub release archives, verifies the published SHA-256 checksum, extracts into a temporary directory, and installs only expected `gestalt` / `gestaltd` binaries.

Also updates Linux/Homebrew/binary install docs, README quick start guidance, version-pinned release-note install commands, and PR CI coverage for the installer contract.

## Interface Changes
- New/changed interface: `https://gestaltd.ai/install.sh`
- New/changed interface: `/install/linux` docs page
- New/changed interface: `npm run test:linux-installer`
- Example usage:

```sh
curl -fsSL https://gestaltd.ai/install.sh | sh
wget -qO- https://gestaltd.ai/install.sh | sh
curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component gestaltd
curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component both --version 0.0.1-alpha.16
curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --user
curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --dry-run
```

## Functional/Integration Tests
- Tests added or augmented: `docs/scripts/test-linux-installer.sh`, wired into `docs/package.json` and the docs CI job in `build-gestaltd.yml`.
- Contract boundary covered: installer CLI options, release-family latest resolution with pagination, draft filtering, prefixed version validation, Linux arch mapping, checksum success/failure, extraction/install behavior, missing bundled binary failure, and static export of `/install.sh`.
- Commands run:

```sh
shellcheck docs/public/install.sh docs/scripts/test-linux-installer.sh
npm ci
npm run typecheck
npm run build
npm run test:linux-installer
GESTALT_INSTALL_OS=linux GESTALT_INSTALL_ARCH=x86_64 sh docs/public/install.sh --dry-run --bin-dir /tmp/gestalt-install-test
GESTALT_INSTALL_OS=linux GESTALT_INSTALL_ARCH=armv7l sh docs/public/install.sh --component gestaltd --dry-run --bin-dir /tmp/gestalt-install-test
```
