### PR TITLE
Split Linux installers by component

### DIFF
--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -40,7 +40,7 @@ jobs:
       artifact-prefix: gestalt
       run-tests: true
       package: true
-      bundle-gestaltd: true
+      bundle-gestaltd: false
 
   release:
     name: Publish Release
@@ -55,7 +55,7 @@ jobs:
       component-summary: |
         Command-line client for authenticating with Gestalt, working with integrations and workflows, and running interactive agent sessions from the terminal.
       install-markdown: |
-        - Linux installer: `curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component both --version ${version}`
+        - Linux installer: `curl -fsSL https://gestaltd.ai/install-gestalt.sh | sh -s -- --version ${version}`
         - Homebrew: `brew upgrade valon-technologies/gestalt/gestalt`
         - Docker: `docker pull valontechnologies/gestalt:${version}`
         - Docs: [CLI guide](https://gestaltd.ai/client/cli)
@@ -142,7 +142,7 @@ jobs:
             old_version=$(grep '^\s*version ' "$formula" | sed 's/.*version "\(.*\)"/\1/')
 
             sed -i "s/version \"${old_version}\"/version \"${VERSION}\"/" "$formula"
-            perl -0pi -e 's/bin\.install "gestalt"(?:, "gestaltd")?/bin.install "gestalt", "gestaltd"/' "$formula"
+            perl -0pi -e 's/bin\.install "gestalt"(?:, "gestaltd")?/bin.install "gestalt"/' "$formula"
             perl -0pi -e 's{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-macos-arm64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-macos-arm64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-macos-x86_64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-macos-x86_64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-linux-arm64(?:-musl)?\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-linux-arm64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-linux-x86_64(?:-musl)?\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-linux-x86_64.tar.gz}g' "$formula"
 
             awk -v sha_macos_arm64="$SHA_MACOS_ARM64" \
@@ -174,7 +174,8 @@ jobs:
             cat "$formula"
             echo ""
             grep -q "version \"${VERSION}\"" "$formula" || { echo "ERROR: version not updated in ${formula}"; exit 1; }
-            grep -q 'bin.install "gestalt", "gestaltd"' "$formula" || { echo "ERROR: gestaltd helper not installed in ${formula}"; exit 1; }
+            grep -q 'bin.install "gestalt"$' "$formula" || { echo "ERROR: gestalt install line not updated in ${formula}"; exit 1; }
+            ! grep -q 'bin.install "gestalt", "gestaltd"' "$formula" || { echo "ERROR: gestaltd helper should not be installed in ${formula}"; exit 1; }
             grep -q "PLACEHOLDER" "$formula" && { echo "ERROR: PLACEHOLDER still present in ${formula}"; exit 1; }
           done
           echo "Formula verified successfully"

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -89,7 +89,7 @@ jobs:
       component-summary: |
         Self-hosted integration gateway for Gestalt with the embedded client UI, admin UI, HTTP API, and optional MCP endpoint.
       install-markdown: |
-        - Linux installer: `curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component gestaltd --version ${version}`
+        - Linux installer: `curl -fsSL https://gestaltd.ai/install-gestaltd.sh | sh -s -- --version ${version}`
         - Homebrew: `brew upgrade valon-technologies/gestalt/gestaltd`
         - Docker: `docker pull valontechnologies/gestaltd:${version}`
         - Docs: [Deployment guide](https://gestaltd.ai/deploy)

--- a/Formula/gestalt.rb
+++ b/Formula/gestalt.rb
@@ -31,7 +31,7 @@ class Gestalt < Formula
   end
 
   def install
-    bin.install "gestalt", "gestaltd"
+    bin.install "gestalt"
   end
 
   test do

--- a/README.md
+++ b/README.md
@@ -32,18 +32,19 @@ Gestalt also does not replace your existing APIs. It sits between agents and ups
 
 ## Quick Start
 
-On Linux, install both binaries with the installer script:
+On Linux, install the server and CLI with the installer scripts:
 
 ```sh
-curl -fsSL https://gestaltd.ai/install.sh | sh
+curl -fsSL https://gestaltd.ai/install-gestaltd.sh | sh
+curl -fsSL https://gestaltd.ai/install-gestalt.sh | sh
 ```
 
 On macOS, or on Linux when you prefer Homebrew, tap the Gestalt Homebrew
-repository and install the CLI package. The CLI package also includes the
-bundled `gestaltd` helper binary:
+repository and install the packages you need:
 
 ```sh
 brew tap valon-technologies/gestalt
+brew install valon-technologies/gestalt/gestaltd
 brew install valon-technologies/gestalt/gestalt
 ```
 

--- a/docs/content/install/binary.mdx
+++ b/docs/content/install/binary.mdx
@@ -4,7 +4,7 @@ import { Tabs } from 'nextra/components'
 
 Pre-built binaries are published for every release on GitHub.
 
-On Linux, the installer script is usually simpler than manual archive handling.
+On Linux, the installer scripts are usually simpler than manual archive handling.
 See [Installer](/install/installer).
 
 ## Server
@@ -66,10 +66,6 @@ gestaltd --version
 
 `gestalt` is the CLI for communicating with the Gestalt server.
 
-On Unix platforms, the `gestalt` archive also includes a matching `gestaltd`
-helper binary. Install both files when you want the same behavior as the Linux
-installer's default `--component both` mode.
-
 ### Install
 
 <Tabs items={['macOS Apple Silicon', 'macOS Intel', 'Linux x86_64', 'Linux ARM64', 'Linux ARMv7', 'Windows x86_64']}>
@@ -78,7 +74,7 @@ installer's default `--component both` mode.
 
     ```sh
     tar xzf gestalt-macos-arm64.tar.gz
-    sudo mv gestalt gestaltd /usr/local/bin/
+    sudo mv gestalt /usr/local/bin/
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -86,7 +82,7 @@ installer's default `--component both` mode.
 
     ```sh
     tar xzf gestalt-macos-x86_64.tar.gz
-    sudo mv gestalt gestaltd /usr/local/bin/
+    sudo mv gestalt /usr/local/bin/
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -94,7 +90,7 @@ installer's default `--component both` mode.
 
     ```sh
     tar xzf gestalt-linux-x86_64.tar.gz
-    sudo mv gestalt gestaltd /usr/local/bin/
+    sudo mv gestalt /usr/local/bin/
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -102,7 +98,7 @@ installer's default `--component both` mode.
 
     ```sh
     tar xzf gestalt-linux-arm64.tar.gz
-    sudo mv gestalt gestaltd /usr/local/bin/
+    sudo mv gestalt /usr/local/bin/
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -110,7 +106,7 @@ installer's default `--component both` mode.
 
     ```sh
     tar xzf gestalt-linux-armv7.tar.gz
-    sudo mv gestalt gestaltd /usr/local/bin/
+    sudo mv gestalt /usr/local/bin/
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -126,4 +122,4 @@ installer's default `--component both` mode.
 gestalt --version
 ```
 
-Once both binaries are on your `PATH`, continue to [Getting Started](/getting-started).
+Once the binaries you need are on your `PATH`, continue to [Getting Started](/getting-started).

--- a/docs/content/install/homebrew.mdx
+++ b/docs/content/install/homebrew.mdx
@@ -2,7 +2,7 @@
 
 Gestalt publishes a Homebrew tap for macOS and Linux.
 
-For the native Linux installer script, see [Installer](/install/installer). If you need
+For the native Linux installer scripts, see [Installer](/install/installer). If you need
 a direct-download archive, see [Binary Releases](/install/binary).
 
 Tap the repository first:
@@ -28,10 +28,9 @@ brew install valon-technologies/gestalt/gestaltd
 gestaltd --version
 ```
 
-## Client and bundled server
+## Client
 
-`gestalt` is the CLI for communicating with the Gestalt server. This formula
-also installs the bundled `gestaltd` helper binary from the CLI release archive.
+`gestalt` is the CLI for communicating with the Gestalt server.
 
 ### Install
 
@@ -45,4 +44,4 @@ brew install valon-technologies/gestalt/gestalt
 gestalt --version
 ```
 
-Once both binaries are on your `PATH`, continue to [Getting Started](/getting-started).
+Once the binaries you need are on your `PATH`, continue to [Getting Started](/getting-started).

--- a/docs/content/install/index.mdx
+++ b/docs/content/install/index.mdx
@@ -4,14 +4,15 @@ asIndexPage: true
 
 # Install
 
-Gestalt ships two binaries: `gestaltd` (the server) and `gestalt` (the CLI client). Install both to get started.
+Gestalt ships two binaries: `gestaltd` (the server) and `gestalt` (the CLI client). Install the one you need, or install both.
 
 ## Installer
 
-The fastest native Linux path is the installer script. See [Installer](/install/installer).
+The fastest native Linux path uses the installer scripts. See [Installer](/install/installer).
 
 ```sh
-curl -fsSL https://gestaltd.ai/install.sh | sh
+curl -fsSL https://gestaltd.ai/install-gestaltd.sh | sh
+curl -fsSL https://gestaltd.ai/install-gestalt.sh | sh
 ```
 
 ## Homebrew

--- a/docs/content/install/installer.mdx
+++ b/docs/content/install/installer.mdx
@@ -1,6 +1,6 @@
 # Installer
 
-Gestalt publishes a Linux installer script for installing release binaries
+Gestalt publishes Linux installer scripts for installing release binaries
 directly.
 
 For a package-manager install, see [Homebrew](/install/homebrew). For manual
@@ -13,7 +13,7 @@ archive downloads, see [Binary Releases](/install/binary).
 ### Install
 
 ```sh
-curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component gestaltd
+curl -fsSL https://gestaltd.ai/install-gestaltd.sh | sh
 ```
 
 ### Verify
@@ -22,29 +22,26 @@ curl -fsSL https://gestaltd.ai/install.sh | sh -s -- --component gestaltd
 gestaltd --version
 ```
 
-## Client and bundled server
+## Client
 
-`gestalt` is the CLI for communicating with the Gestalt server. The default
-installer also installs the bundled `gestaltd` helper binary from the CLI release
-archive.
+`gestalt` is the CLI for communicating with the Gestalt server.
 
 ### Install
 
 ```sh
-curl -fsSL https://gestaltd.ai/install.sh | sh
+curl -fsSL https://gestaltd.ai/install-gestalt.sh | sh
 ```
 
 Or with `wget`:
 
 ```sh
-wget -qO- https://gestaltd.ai/install.sh | sh
+wget -qO- https://gestaltd.ai/install-gestalt.sh | sh
 ```
 
 ### Verify
 
 ```sh
 gestalt --version
-gestaltd --version
 ```
 
-Once both binaries are on your `PATH`, continue to [Getting Started](/getting-started).
+Once the binaries you need are on your `PATH`, continue to [Getting Started](/getting-started).

--- a/docs/public/install-gestalt.sh
+++ b/docs/public/install-gestalt.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -eu
+
+script_url="${GESTALT_INSTALL_SCRIPT_URL:-https://gestaltd.ai/install.sh}"
+
+usage() {
+  cat <<'USAGE'
+Install the Gestalt CLI on Linux.
+
+Usage:
+  install-gestalt.sh [options]
+
+Options:
+  --version VERSION  Release version or gestalt/v* tag. Default: latest, including prereleases.
+  --prefix PATH      Install into PATH/bin. Default: /usr/local/bin.
+  --bin-dir PATH     Install directly into PATH.
+  --user             Install into $HOME/.local/bin.
+  --dry-run          Print the planned install without downloading binaries.
+  -h, --help         Show this help.
+USAGE
+}
+
+download() {
+  download_url="$1"
+  download_path="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$download_url" -o "$download_path"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$download_path" "$download_url"
+  else
+    printf '%s\n' "gestalt installer: curl or wget is required" >&2
+    exit 1
+  fi
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --component | --component=*)
+      printf '%s\n' "gestalt installer: install-gestalt.sh does not accept --component" >&2
+      exit 1
+      ;;
+  esac
+done
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+installer="${tmp_dir}/install.sh"
+download "$script_url" "$installer"
+GESTALT_INSTALL_COMPONENT=gestalt sh "$installer" "$@"

--- a/docs/public/install-gestaltd.sh
+++ b/docs/public/install-gestaltd.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -eu
+
+script_url="${GESTALT_INSTALL_SCRIPT_URL:-https://gestaltd.ai/install.sh}"
+
+usage() {
+  cat <<'USAGE'
+Install gestaltd on Linux.
+
+Usage:
+  install-gestaltd.sh [options]
+
+Options:
+  --version VERSION  Release version or gestaltd/v* tag. Default: latest, including prereleases.
+  --prefix PATH      Install into PATH/bin. Default: /usr/local/bin.
+  --bin-dir PATH     Install directly into PATH.
+  --user             Install into $HOME/.local/bin.
+  --dry-run          Print the planned install without downloading binaries.
+  -h, --help         Show this help.
+USAGE
+}
+
+download() {
+  download_url="$1"
+  download_path="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$download_url" -o "$download_path"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$download_path" "$download_url"
+  else
+    printf '%s\n' "gestalt installer: curl or wget is required" >&2
+    exit 1
+  fi
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --component | --component=*)
+      printf '%s\n' "gestalt installer: install-gestaltd.sh does not accept --component" >&2
+      exit 1
+      ;;
+  esac
+done
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+installer="${tmp_dir}/install.sh"
+download "$script_url" "$installer"
+GESTALT_INSTALL_COMPONENT=gestaltd sh "$installer" "$@"

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repo="valon-technologies/gestalt"
-component="both"
+component="${GESTALT_INSTALL_COMPONENT:-gestalt}"
 version="latest"
 prefix="/usr/local"
 prefix_set=0
@@ -24,7 +24,7 @@ Usage:
   install.sh [options]
 
 Options:
-  --component both|gestalt|gestaltd  Component to install. Default: both.
+  --component gestalt|gestaltd       Component to install. Default: gestalt.
   --version VERSION                  Release version or family-prefixed tag. Default: latest, including prereleases.
   --prefix PATH                      Install into PATH/bin. Default: /usr/local/bin.
   --bin-dir PATH                     Install directly into PATH.
@@ -94,16 +94,12 @@ while [ "$#" -gt 0 ]; do
 done
 
 case "$component" in
-  both | gestalt)
-    release_family="gestalt"
-    ;;
-  gestaltd)
-    release_family="gestaltd"
-    ;;
-  *)
-    fail "--component must be one of: both, gestalt, gestaltd"
-    ;;
+  gestalt | gestaltd) ;;
+  both) fail "--component both is no longer supported; run install-gestalt.sh and install-gestaltd.sh separately" ;;
+  *) fail "--component must be one of: gestalt, gestaltd" ;;
 esac
+
+release_family="$component"
 
 if [ "$path_flags" -gt 1 ]; then
   fail "--bin-dir, --prefix, and --user are mutually exclusive"
@@ -318,9 +314,6 @@ verify_checksum() {
 
 expected_binaries() {
   case "$component" in
-    both)
-      printf '%s\n' "gestalt gestaltd"
-      ;;
     gestalt)
       printf '%s\n' "gestalt"
       ;;

--- a/docs/scripts/test-linux-installer.sh
+++ b/docs/scripts/test-linux-installer.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 installer="$PWD/public/install.sh"
+cli_installer="$PWD/public/install-gestalt.sh"
+daemon_installer="$PWD/public/install-gestaltd.sh"
 tmp_dir="$(mktemp -d)"
 download_root="$tmp_dir/releases"
 
@@ -84,7 +86,7 @@ make_archive() {
   checksum_archive "$archive" >"${archive}.sha256"
 }
 
-run_installer() {
+run_core_installer() {
   env \
     GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
     GESTALT_INSTALL_OS=linux \
@@ -92,39 +94,52 @@ run_installer() {
     sh "$installer" "$@"
 }
 
-make_archive gestalt 1.2.3 linux-x86_64 gestalt gestaltd
+run_cli_installer() {
+  env \
+    GESTALT_INSTALL_SCRIPT_URL="file://${installer}" \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=x86_64 \
+    sh "$cli_installer" "$@"
+}
+
+run_daemon_installer() {
+  env \
+    GESTALT_INSTALL_SCRIPT_URL="file://${installer}" \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
+    GESTALT_INSTALL_OS=linux \
+    GESTALT_INSTALL_ARCH=x86_64 \
+    sh "$daemon_installer" "$@"
+}
+
+make_archive gestalt 1.2.3 linux-x86_64 gestalt
 make_archive gestaltd 2.0.0 linux-x86_64 gestaltd
-make_archive gestalt 3.0.0 linux-x86_64 gestalt
-make_archive gestalt 4.0.0 linux-x86_64 gestalt gestaltd
-make_archive gestalt 5.0.0 linux-x86_64 gestalt gestaltd
-make_archive gestalt 6.0.0 linux-x86_64 gestalt gestaltd
+make_archive gestaltd 3.0.0 linux-x86_64 gestalt
+make_archive gestalt 4.0.0 linux-x86_64 gestalt
+make_archive gestalt 5.0.0 linux-x86_64 gestalt
+make_archive gestalt 6.0.0 linux-x86_64 gestalt
 
 symlink_stage="$tmp_dir/stage/gestalt-7.0.0-linux-x86_64"
 symlink_dest="$download_root/gestalt/v7.0.0"
 mkdir -p "$symlink_stage" "$symlink_dest"
 ln -s /etc/hosts "$symlink_stage/gestalt"
-{
-  printf '#!/bin/sh\n'
-  printf 'printf "gestaltd 7.0.0\\n"\n'
-} >"$symlink_stage/gestaltd"
-chmod +x "$symlink_stage/gestaltd"
-(cd "$symlink_stage" && tar -czf "$symlink_dest/gestalt-linux-x86_64.tar.gz" gestalt gestaltd)
+(cd "$symlink_stage" && tar -czf "$symlink_dest/gestalt-linux-x86_64.tar.gz" gestalt)
 checksum_archive "$symlink_dest/gestalt-linux-x86_64.tar.gz" >"$symlink_dest/gestalt-linux-x86_64.tar.gz.sha256"
 
-both_bin="$tmp_dir/bin-both"
-run_installer --component both --version 1.2.3 --bin-dir "$both_bin" >/dev/null
-assert_executable "$both_bin/gestalt"
-assert_executable "$both_bin/gestaltd"
-
 cli_bin="$tmp_dir/bin-cli"
-run_installer --component gestalt --version gestalt/v1.2.3 --bin-dir "$cli_bin" >/dev/null
+run_cli_installer --version gestalt/v1.2.3 --bin-dir "$cli_bin" >/dev/null
 assert_executable "$cli_bin/gestalt"
 assert_not_exists "$cli_bin/gestaltd"
 
 daemon_bin="$tmp_dir/bin-daemon"
-run_installer --component gestaltd --version 2.0.0 --bin-dir "$daemon_bin" >/dev/null
+run_daemon_installer --version 2.0.0 --bin-dir "$daemon_bin" >/dev/null
 assert_executable "$daemon_bin/gestaltd"
 assert_not_exists "$daemon_bin/gestalt"
+
+default_bin="$tmp_dir/bin-default"
+run_core_installer --version 1.2.3 --bin-dir "$default_bin" >/dev/null
+assert_executable "$default_bin/gestalt"
+assert_not_exists "$default_bin/gestaltd"
 
 cat >"$tmp_dir/releases-page-1.json" <<'JSON'
 [
@@ -158,34 +173,41 @@ JSON
 
 latest_cli_output="$(
   env \
+    GESTALT_INSTALL_SCRIPT_URL="file://${installer}" \
     GESTALT_INSTALL_RELEASES_URL="file://${tmp_dir}/releases-page-{page}.json" \
     GESTALT_INSTALL_DOWNLOAD_BASE="file:///does-not-exist" \
     GESTALT_INSTALL_MAX_PAGES=2 \
     GESTALT_INSTALL_OS=linux \
     GESTALT_INSTALL_ARCH=aarch64 \
-    sh "$installer" --component both --dry-run --bin-dir "$tmp_dir/dry-run-bin"
+    sh "$cli_installer" --dry-run --bin-dir "$tmp_dir/dry-run-bin"
 )"
+assert_contains "$latest_cli_output" "component: gestalt"
 assert_contains "$latest_cli_output" "tag: gestalt/v0.2.0-alpha.1"
 assert_contains "$latest_cli_output" "gestalt-linux-arm64.tar.gz"
+assert_contains "$latest_cli_output" "binaries: gestalt"
 
 latest_daemon_output="$(
   env \
+    GESTALT_INSTALL_SCRIPT_URL="file://${installer}" \
     GESTALT_INSTALL_RELEASES_URL="file://${tmp_dir}/releases-page-{page}.json" \
     GESTALT_INSTALL_DOWNLOAD_BASE="file:///does-not-exist" \
     GESTALT_INSTALL_MAX_PAGES=2 \
     GESTALT_INSTALL_OS=linux \
     GESTALT_INSTALL_ARCH=armv7l \
-    sh "$installer" --component gestaltd --dry-run --bin-dir "$tmp_dir/dry-run-bin"
+    sh "$daemon_installer" --dry-run --bin-dir "$tmp_dir/dry-run-bin"
 )"
+assert_contains "$latest_daemon_output" "component: gestaltd"
 assert_contains "$latest_daemon_output" "tag: gestaltd/v0.9.0-alpha.1"
 assert_contains "$latest_daemon_output" "gestaltd-linux-armv7.tar.gz"
+assert_contains "$latest_daemon_output" "binaries: gestaltd"
 
 dry_run_dead_base="$(
   env \
+    GESTALT_INSTALL_SCRIPT_URL="file://${installer}" \
     GESTALT_INSTALL_DOWNLOAD_BASE="file:///does-not-exist" \
     GESTALT_INSTALL_OS=linux \
     GESTALT_INSTALL_ARCH=x86_64 \
-    sh "$installer" --component both --version 1.2.3 --dry-run --bin-dir "$tmp_dir/dry-run-bin"
+    sh "$cli_installer" --version 1.2.3 --dry-run --bin-dir "$tmp_dir/dry-run-bin"
 )"
 assert_contains "$dry_run_dead_base" "archive: file:///does-not-exist/gestalt/v1.2.3/gestalt-linux-x86_64.tar.gz"
 
@@ -197,6 +219,18 @@ mismatch_output="$(
 )"
 assert_contains "$mismatch_output" "does not match --component gestaltd"
 
+both_output="$(assert_fails sh "$installer" --component both --dry-run)"
+assert_contains "$both_output" "--component both is no longer supported"
+
+wrapper_component_output="$(assert_fails sh "$cli_installer" --component gestaltd --dry-run)"
+assert_contains "$wrapper_component_output" "install-gestalt.sh does not accept --component"
+
+cli_help_output="$(sh "$cli_installer" --help)"
+assert_contains "$cli_help_output" "Install the Gestalt CLI on Linux."
+
+daemon_help_output="$(sh "$daemon_installer" --help)"
+assert_contains "$daemon_help_output" "Install gestaltd on Linux."
+
 conflict_output="$(assert_fails sh "$installer" --user --bin-dir "$tmp_dir/conflict-bin")"
 assert_contains "$conflict_output" "mutually exclusive"
 
@@ -205,7 +239,7 @@ missing_output="$(
     GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
     GESTALT_INSTALL_OS=linux \
     GESTALT_INSTALL_ARCH=x86_64 \
-    sh "$installer" --component both --version 3.0.0 --bin-dir "$tmp_dir/missing-bin"
+    sh "$installer" --component gestaltd --version 3.0.0 --bin-dir "$tmp_dir/missing-bin"
 )"
 assert_contains "$missing_output" "did not contain expected regular binary: gestaltd"
 
@@ -214,7 +248,7 @@ symlink_output="$(
     GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
     GESTALT_INSTALL_OS=linux \
     GESTALT_INSTALL_ARCH=x86_64 \
-    sh "$installer" --component both --version 7.0.0 --bin-dir "$tmp_dir/symlink-bin"
+    sh "$installer" --component gestalt --version 7.0.0 --bin-dir "$tmp_dir/symlink-bin"
 )"
 assert_contains "$symlink_output" "did not contain expected regular binary: gestalt"
 
@@ -225,7 +259,7 @@ checksum_output="$(
     GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
     GESTALT_INSTALL_OS=linux \
     GESTALT_INSTALL_ARCH=x86_64 \
-    sh "$installer" --component both --version 4.0.0 --bin-dir "$tmp_dir/bad-checksum-bin"
+    sh "$installer" --component gestalt --version 4.0.0 --bin-dir "$tmp_dir/bad-checksum-bin"
 )"
 assert_contains "$checksum_output" "checksum mismatch"
 
@@ -236,7 +270,7 @@ malformed_output="$(
     GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
     GESTALT_INSTALL_OS=linux \
     GESTALT_INSTALL_ARCH=x86_64 \
-    sh "$installer" --component both --version 5.0.0 --bin-dir "$tmp_dir/empty-checksum-bin"
+    sh "$installer" --component gestalt --version 5.0.0 --bin-dir "$tmp_dir/empty-checksum-bin"
 )"
 assert_contains "$malformed_output" "checksum file is malformed"
 
@@ -246,14 +280,16 @@ sha_tool_output="$(
     GESTALT_INSTALL_OS=linux \
     GESTALT_INSTALL_ARCH=x86_64 \
     GESTALT_INSTALL_SHA256_TOOL=none \
-    sh "$installer" --component both --version 6.0.0 --bin-dir "$tmp_dir/no-sha-bin"
+    sh "$installer" --component gestalt --version 6.0.0 --bin-dir "$tmp_dir/no-sha-bin"
 )"
 assert_contains "$sha_tool_output" "no supported SHA-256 tool"
 
 if [[ -d out ]]; then
-  [[ -f out/install.sh ]] || fail "docs static export did not include out/install.sh"
-  first_line="$(sed -n '1p' out/install.sh)"
-  [[ "$first_line" == "#!/bin/sh" ]] || fail "out/install.sh did not preserve installer shebang"
+  for script in install.sh install-gestalt.sh install-gestaltd.sh; do
+    [[ -f "out/${script}" ]] || fail "docs static export did not include out/${script}"
+    first_line="$(sed -n '1p' "out/${script}")"
+    [[ "$first_line" == "#!/bin/sh" ]] || fail "out/${script} did not preserve installer shebang"
+  done
 else
   printf 'Skipping static export assertion because docs/out does not exist; run npm run build first.\n'
 fi

--- a/gestalt/Dockerfile
+++ b/gestalt/Dockerfile
@@ -16,8 +16,7 @@ RUN case "$TARGETARCH" in \
     esac && \
     mkdir -p /out && \
     tar -xzf "$archive" -C /out && \
-    test -x /out/gestalt && \
-    test -x /out/gestaltd
+    test -x /out/gestalt
 
 FROM gcr.io/distroless/cc-debian12@sha256:847433844c7e04bcf07a3a0f0f5a8de554c6df6fa9e3e3ab14d3f6b73d780235 AS distroless
 ARG GESTALT_VERSION
@@ -27,7 +26,6 @@ ARG GESTALT_SOURCE
 ARG GESTALT_DOCUMENTATION
 ARG GESTALT_URL
 COPY --from=unpack /out/gestalt /gestalt
-COPY --from=unpack /out/gestaltd /gestaltd
 LABEL org.opencontainers.image.title="gestalt" \
       org.opencontainers.image.description="CLI client for managing Gestalt integrations, authentication, and operations." \
       org.opencontainers.image.source="${GESTALT_SOURCE}" \

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -235,14 +235,15 @@ fn missing_harness_commands(
         }
     }
     let command = plan.command.trim();
-    if !missing.iter().any(|missing| missing.command == command) {
-        if let Err(err) = find_command(command, working_directory, env) {
-            missing.push(MissingHarnessCommand {
-                command: command.to_string(),
-                role: MissingHarnessCommandRole::HarnessCommand,
-                detail: err.to_string(),
-            });
-        }
+    if missing.iter().any(|missing| missing.command == command) {
+        return missing;
+    }
+    if let Err(err) = find_command(command, working_directory, env) {
+        missing.push(MissingHarnessCommand {
+            command: command.to_string(),
+            role: MissingHarnessCommandRole::HarnessCommand,
+            detail: err.to_string(),
+        });
     }
     missing
 }


### PR DESCRIPTION
## Summary
- add dedicated Linux installer entrypoints for `gestalt` and `gestaltd`
- make the shared installer default CLI-only and reject `--component both` with guidance
- stop future `gestalt` CLI release archives, Homebrew formula updates, and Docker images from bundling `gestaltd`
- update install docs, binary docs, README, and release-note commands for separate installers
- fix the current stable clippy `collapsible_if` lint that was blocking this PR's Rust check

## Tests
- `npm run typecheck`
- `npm run build`
- `npm run test:linux-installer`
- `ruby -c Formula/gestalt.rb && ruby -c Formula/gestaltd.rb`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
