### PR TITLE
Support macOS in installer scripts

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -136,8 +136,8 @@ jobs:
       - name: Build docs
         run: npm run build
 
-      - name: Test Linux installer
-        run: npm run test:linux-installer
+      - name: Test installer
+        run: npm run test:installer
 
   helm-validate:
     name: Helm Chart Validation

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -55,7 +55,7 @@ jobs:
       component-summary: |
         Command-line client for authenticating with Gestalt, working with integrations and workflows, and running interactive agent sessions from the terminal.
       install-markdown: |
-        - Linux installer: `curl -fsSL https://gestaltd.ai/install-gestalt.sh | sh -s -- --version ${version}`
+        - Installer: `curl -fsSL https://gestaltd.ai/install-gestalt.sh | sh -s -- --version ${version}`
         - Homebrew: `brew upgrade valon-technologies/gestalt/gestalt`
         - Docker: `docker pull valontechnologies/gestalt:${version}`
         - Docs: [CLI guide](https://gestaltd.ai/client/cli)

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -89,7 +89,7 @@ jobs:
       component-summary: |
         Self-hosted integration gateway for Gestalt with the embedded client UI, admin UI, HTTP API, and optional MCP endpoint.
       install-markdown: |
-        - Linux installer: `curl -fsSL https://gestaltd.ai/install-gestaltd.sh | sh -s -- --version ${version}`
+        - Installer: `curl -fsSL https://gestaltd.ai/install-gestaltd.sh | sh -s -- --version ${version}`
         - Homebrew: `brew upgrade valon-technologies/gestalt/gestaltd`
         - Docker: `docker pull valontechnologies/gestaltd:${version}`
         - Docs: [Deployment guide](https://gestaltd.ai/deploy)

--- a/README.md
+++ b/README.md
@@ -32,15 +32,14 @@ Gestalt also does not replace your existing APIs. It sits between agents and ups
 
 ## Quick Start
 
-On Linux, install the server and CLI with the installer scripts:
+Install the server and CLI with the installer scripts:
 
 ```sh
 curl -fsSL https://gestaltd.ai/install-gestaltd.sh | sh
 curl -fsSL https://gestaltd.ai/install-gestalt.sh | sh
 ```
 
-On macOS, or on Linux when you prefer Homebrew, tap the Gestalt Homebrew
-repository and install the packages you need:
+Or use Homebrew:
 
 ```sh
 brew tap valon-technologies/gestalt

--- a/docs/content/install/binary.mdx
+++ b/docs/content/install/binary.mdx
@@ -4,8 +4,8 @@ import { Tabs } from 'nextra/components'
 
 Pre-built binaries are published for every release on GitHub.
 
-On Linux, the installer scripts are usually simpler than manual archive handling.
-See [Installer](/install/installer).
+The installer scripts are usually simpler than manual archive handling. See
+[Installer](/install/installer).
 
 ## Server
 

--- a/docs/content/install/homebrew.mdx
+++ b/docs/content/install/homebrew.mdx
@@ -2,7 +2,7 @@
 
 Gestalt publishes a Homebrew tap for macOS and Linux.
 
-For the native Linux installer scripts, see [Installer](/install/installer). If you need
+For the installer scripts, see [Installer](/install/installer). If you need
 a direct-download archive, see [Binary Releases](/install/binary).
 
 Tap the repository first:

--- a/docs/content/install/index.mdx
+++ b/docs/content/install/index.mdx
@@ -8,7 +8,7 @@ Gestalt ships two binaries: `gestaltd` (the server) and `gestalt` (the CLI clien
 
 ## Installer
 
-The fastest native Linux path uses the installer scripts. See [Installer](/install/installer).
+The fastest native path uses the installer scripts. See [Installer](/install/installer).
 
 ```sh
 curl -fsSL https://gestaltd.ai/install-gestaltd.sh | sh
@@ -17,7 +17,7 @@ curl -fsSL https://gestaltd.ai/install-gestalt.sh | sh
 
 ## Homebrew
 
-The fastest path on macOS, and a supported package-manager path on Linux. See [Homebrew](/install/homebrew).
+The package-manager path for macOS and Linux uses Homebrew. See [Homebrew](/install/homebrew).
 
 ```sh
 brew tap valon-technologies/gestalt
@@ -26,7 +26,7 @@ brew install valon-technologies/gestalt/gestalt
 
 ## Binary releases
 
-Pre-built binaries for all supported platforms, including Linux-specific CLI variants. See [Binary Releases](/install/binary).
+Pre-built binaries for all supported platforms. See [Binary Releases](/install/binary).
 
 ## Build from source
 

--- a/docs/content/install/installer.mdx
+++ b/docs/content/install/installer.mdx
@@ -1,7 +1,6 @@
 # Installer
 
-Gestalt publishes Linux installer scripts for installing release binaries
-directly.
+Gestalt publishes installer scripts for installing release binaries directly.
 
 For a package-manager install, see [Homebrew](/install/homebrew). For manual
 archive downloads, see [Binary Releases](/install/binary).

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "next lint",
-    "test:linux-installer": "bash scripts/test-linux-installer.sh",
+    "test:installer": "bash scripts/test-installer.sh",
+    "test:linux-installer": "npm run test:installer",
     "test:registry": "node scripts/check-registry-static.mjs",
     "test:registry-docs": "node scripts/check-registry-docs-render.mjs"
   },

--- a/docs/public/install-gestalt.sh
+++ b/docs/public/install-gestalt.sh
@@ -5,7 +5,7 @@ script_url="${GESTALT_INSTALL_SCRIPT_URL:-https://gestaltd.ai/install.sh}"
 
 usage() {
   cat <<'USAGE'
-Install the Gestalt CLI on Linux.
+Install the Gestalt CLI on Linux or macOS.
 
 Usage:
   install-gestalt.sh [options]

--- a/docs/public/install-gestaltd.sh
+++ b/docs/public/install-gestaltd.sh
@@ -5,7 +5,7 @@ script_url="${GESTALT_INSTALL_SCRIPT_URL:-https://gestaltd.ai/install.sh}"
 
 usage() {
   cat <<'USAGE'
-Install gestaltd on Linux.
+Install gestaltd on Linux or macOS.
 
 Usage:
   install-gestaltd.sh [options]

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -18,7 +18,7 @@ max_release_pages="${GESTALT_INSTALL_MAX_PAGES:-5}"
 
 usage() {
   cat <<'USAGE'
-Install Gestalt on Linux.
+Install Gestalt on Linux or macOS.
 
 Usage:
   install.sh [options]
@@ -128,8 +128,11 @@ detect_platform() {
     linux)
       os_part="linux"
       ;;
+    darwin)
+      os_part="macos"
+      ;;
     *)
-      fail "this installer supports Linux; use Homebrew or binary releases for ${os_name}"
+      fail "unsupported operating system: ${os_name}"
       ;;
   esac
 
@@ -141,10 +144,13 @@ detect_platform() {
       arch_part="arm64"
       ;;
     armv7 | armv7l)
+      if [ "$os_part" != "linux" ]; then
+        fail "unsupported ${os_name} architecture: ${arch_name}"
+      fi
       arch_part="armv7"
       ;;
     *)
-      fail "unsupported Linux architecture: ${arch_name}"
+      fail "unsupported ${os_name} architecture: ${arch_name}"
       ;;
   esac
 

--- a/docs/scripts/test-installer.sh
+++ b/docs/scripts/test-installer.sh
@@ -15,7 +15,7 @@ cleanup() {
 trap cleanup EXIT
 
 fail() {
-  printf 'test-linux-installer: %s\n' "$*" >&2
+  printf 'test-installer: %s\n' "$*" >&2
   exit 1
 }
 
@@ -118,6 +118,7 @@ make_archive gestaltd 3.0.0 linux-x86_64 gestalt
 make_archive gestalt 4.0.0 linux-x86_64 gestalt
 make_archive gestalt 5.0.0 linux-x86_64 gestalt
 make_archive gestalt 6.0.0 linux-x86_64 gestalt
+make_archive gestalt 8.0.0 macos-arm64 gestalt
 
 symlink_stage="$tmp_dir/stage/gestalt-7.0.0-linux-x86_64"
 symlink_dest="$download_root/gestalt/v7.0.0"
@@ -140,6 +141,15 @@ default_bin="$tmp_dir/bin-default"
 run_core_installer --version 1.2.3 --bin-dir "$default_bin" >/dev/null
 assert_executable "$default_bin/gestalt"
 assert_not_exists "$default_bin/gestaltd"
+
+macos_bin="$tmp_dir/bin-macos"
+env \
+  GESTALT_INSTALL_DOWNLOAD_BASE="file://${download_root}" \
+  GESTALT_INSTALL_OS=Darwin \
+  GESTALT_INSTALL_ARCH=arm64 \
+  sh "$installer" --component gestalt --version 8.0.0 --bin-dir "$macos_bin" >/dev/null
+assert_executable "$macos_bin/gestalt"
+assert_not_exists "$macos_bin/gestaltd"
 
 cat >"$tmp_dir/releases-page-1.json" <<'JSON'
 [
@@ -211,6 +221,25 @@ dry_run_dead_base="$(
 )"
 assert_contains "$dry_run_dead_base" "archive: file:///does-not-exist/gestalt/v1.2.3/gestalt-linux-x86_64.tar.gz"
 
+dry_run_macos="$(
+  env \
+    GESTALT_INSTALL_SCRIPT_URL="file://${installer}" \
+    GESTALT_INSTALL_DOWNLOAD_BASE="file:///does-not-exist" \
+    GESTALT_INSTALL_OS=darwin \
+    GESTALT_INSTALL_ARCH=arm64 \
+    sh "$cli_installer" --version 8.0.0 --dry-run --bin-dir "$tmp_dir/dry-run-bin"
+)"
+assert_contains "$dry_run_macos" "platform: macos-arm64"
+assert_contains "$dry_run_macos" "archive: file:///does-not-exist/gestalt/v8.0.0/gestalt-macos-arm64.tar.gz"
+
+unsupported_macos_output="$(
+  assert_fails env \
+    GESTALT_INSTALL_OS=darwin \
+    GESTALT_INSTALL_ARCH=armv7l \
+    sh "$installer" --component gestalt --dry-run --bin-dir "$tmp_dir/unsupported-bin"
+)"
+assert_contains "$unsupported_macos_output" "unsupported darwin architecture: armv7l"
+
 mismatch_output="$(
   assert_fails env \
     GESTALT_INSTALL_OS=linux \
@@ -226,10 +255,10 @@ wrapper_component_output="$(assert_fails sh "$cli_installer" --component gestalt
 assert_contains "$wrapper_component_output" "install-gestalt.sh does not accept --component"
 
 cli_help_output="$(sh "$cli_installer" --help)"
-assert_contains "$cli_help_output" "Install the Gestalt CLI on Linux."
+assert_contains "$cli_help_output" "Install the Gestalt CLI on Linux or macOS."
 
 daemon_help_output="$(sh "$daemon_installer" --help)"
-assert_contains "$daemon_help_output" "Install gestaltd on Linux."
+assert_contains "$daemon_help_output" "Install gestaltd on Linux or macOS."
 
 conflict_output="$(assert_fails sh "$installer" --user --bin-dir "$tmp_dir/conflict-bin")"
 assert_contains "$conflict_output" "mutually exclusive"
@@ -294,4 +323,4 @@ else
   printf 'Skipping static export assertion because docs/out does not exist; run npm run build first.\n'
 fi
 
-printf 'Linux installer integration tests passed.\n'
+printf 'Installer integration tests passed.\n'


### PR DESCRIPTION
## Summary
- map Darwin to existing macOS release assets in the shared installer
- update installer docs and release notes so the curl installer path is no longer Linux-only
- rename the installer integration test and add macOS fixture coverage

## Verification
- npm run typecheck
- npm run build
- npm run test:installer
- npm run test:linux-installer
- sh -n docs/public/install.sh && sh -n docs/public/install-gestalt.sh && sh -n docs/public/install-gestaltd.sh && bash -n docs/scripts/test-installer.sh
- git diff --cached --check
- checked current release assets for gestalt/v0.0.1-alpha.16 and gestaltd/v0.0.1-alpha.20 include macos-arm64 and macos-x86_64 tarballs