### PR TITLE
[gestaltd] add chart artifact registry terraform

### DIFF
--- a/.github/workflows/deploy-gestaltd-artifacts.yml
+++ b/.github/workflows/deploy-gestaltd-artifacts.yml
@@ -1,0 +1,61 @@
+name: Deploy gestaltd Artifacts
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'gestaltd/terraform/**'
+      - '.github/workflows/deploy-gestaltd-artifacts.yml'
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  PROJECT_NUMBER: ${{ secrets.GCP_PROJECT_NUMBER }}
+  REGION: us-east1
+  TERRAFORM_STATE_BUCKET: ${{ secrets.DOCS_TERRAFORM_STATE_BUCKET }}
+  TERRAFORM_STATE_PREFIX: gestaltd-artifacts
+  WIF_POOL_ID: ${{ vars.GCP_WIF_POOL_ID }}
+  WIF_PROVIDER_ID: ${{ vars.GCP_WIF_PROVIDER_ID }}
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: projects/${{ env.PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.WIF_POOL_ID }}/providers/${{ env.WIF_PROVIDER_ID }}
+          service_account: github-actions@${{ env.PROJECT_ID }}.iam.gserviceaccount.com
+          token_format: access_token
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+
+      - name: Terraform Init
+        working-directory: gestaltd/terraform
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ env.TERRAFORM_STATE_BUCKET }}" \
+            -backend-config="prefix=${{ env.TERRAFORM_STATE_PREFIX }}"
+
+      - name: Terraform Format Check
+        working-directory: gestaltd/terraform
+        run: terraform fmt -check
+
+      - name: Terraform Validate
+        working-directory: gestaltd/terraform
+        run: terraform validate
+
+      - name: Terraform Apply
+        working-directory: gestaltd/terraform
+        env:
+          TF_VAR_project_id: ${{ env.PROJECT_ID }}
+          TF_VAR_region: ${{ env.REGION }}
+        run: terraform apply -auto-approve

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -229,7 +229,7 @@ jobs:
           workload_identity_provider: ${{ vars.GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GESTALTD_GCP_SERVICE_ACCOUNT }}
           token_format: access_token
-      - name: Push Helm chart to Artifact Registry
+      - name: Push Helm chart to Gestalt Artifact Registry
         env:
           VERSION: ${{ steps.version.outputs.version }}
           ARTIFACT_REGISTRY_HOST: ${{ vars.GESTALTD_ARTIFACT_REGISTRY_HOST }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ Cargo.lock
 .env.local
 .env.*.local
 
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.*
+
 # Database
 *.db
 *.sqlite

--- a/gestaltd/terraform/.terraform.lock.hcl
+++ b/gestaltd/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/gestaltd/terraform/README.md
+++ b/gestaltd/terraform/README.md
@@ -1,0 +1,54 @@
+# gestaltd Artifact Infrastructure
+
+This Terraform root owns the GCP resources used by the `gestaltd` release
+workflow to publish Helm charts.
+
+It creates:
+
+- deployer IAM grants required by this Terraform root
+- Artifact Registry Docker repository for OCI Helm charts
+- GitHub Actions Workload Identity Pool and provider
+- chart publisher service account
+- Artifact Registry writer access for the publisher service account
+
+The release workflow consumes the `github_actions_variables` output. Copy those
+values into the `valon-technologies/gestalt` repository variables:
+
+```text
+GESTALTD_ARTIFACT_REGISTRY_HOST
+GESTALTD_CHART_REPOSITORY
+GESTALTD_GCP_SERVICE_ACCOUNT
+GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER
+```
+
+`valon-tools` environments should consume the chart repository location as input
+variables instead of creating their own per-environment chart repository.
+
+## Continuous Deployment
+
+`.github/workflows/deploy-gestaltd-artifacts.yml` runs Terraform for this root:
+
+- pushes to `main` run `terraform apply -auto-approve`
+- manual runs are supported with `workflow_dispatch`
+
+Configure these GitHub repository secrets:
+
+```text
+GCP_PROJECT_ID
+GCP_PROJECT_NUMBER
+DOCS_TERRAFORM_STATE_BUCKET
+```
+
+Configure these GitHub repository variables:
+
+```text
+GCP_WIF_POOL_ID
+GCP_WIF_PROVIDER_ID
+```
+
+The workflow authenticates as
+`github-actions@${GCP_PROJECT_ID}.iam.gserviceaccount.com`.
+That bootstrap identity, its GitHub Actions Workload Identity provider, and the
+GCS backend bucket must exist before this Terraform root can deploy itself. The
+root grants the deployer service account the additional project roles it needs
+to manage gestaltd artifact resources.

--- a/gestaltd/terraform/backend.tf
+++ b/gestaltd/terraform/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  backend "gcs" {
+  }
+}

--- a/gestaltd/terraform/main.tf
+++ b/gestaltd/terraform/main.tf
@@ -1,0 +1,135 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_project" "current" {
+  project_id = var.project_id
+}
+
+locals {
+  labels = merge(
+    {
+      component  = "gestaltd"
+      managed_by = "terraform"
+    },
+    var.labels,
+  )
+
+  artifact_registry_host     = "${var.region}-docker.pkg.dev"
+  chart_repository           = "oci://${local.artifact_registry_host}/${var.project_id}/${var.artifact_registry_repository_id}"
+  deployer_member            = "serviceAccount:${var.deployer_service_account_id}@${var.project_id}.iam.gserviceaccount.com"
+  workload_identity_provider = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.gestaltd_github_actions.workload_identity_pool_provider_id}"
+}
+
+resource "google_project_iam_member" "deployer_permissions" {
+  for_each = toset([
+    "roles/artifactregistry.admin",
+    "roles/iam.workloadIdentityPoolAdmin",
+    "roles/serviceusage.serviceUsageAdmin",
+  ])
+
+  project = var.project_id
+  role    = each.value
+  member  = local.deployer_member
+}
+
+resource "google_project_service" "required" {
+  for_each = toset([
+    "artifactregistry.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "sts.googleapis.com",
+  ])
+
+  project = var.project_id
+  service = each.value
+
+  disable_on_destroy = false
+
+  depends_on = [
+    google_project_iam_member.deployer_permissions,
+  ]
+}
+
+resource "google_artifact_registry_repository" "gestaltd_charts" {
+  project       = var.project_id
+  location      = var.region
+  repository_id = var.artifact_registry_repository_id
+  format        = "DOCKER"
+  description   = "OCI Helm charts for gestaltd"
+  labels        = local.labels
+
+  depends_on = [
+    google_project_service.required,
+  ]
+}
+
+resource "google_service_account" "chart_publisher" {
+  project      = var.project_id
+  account_id   = var.chart_publisher_service_account_id
+  display_name = "gestaltd chart publisher"
+  description  = "Publishes gestaltd Helm charts to Artifact Registry from GitHub Actions."
+
+  depends_on = [
+    google_project_service.required,
+  ]
+}
+
+resource "google_iam_workload_identity_pool" "github_actions" {
+  project                   = var.project_id
+  workload_identity_pool_id = var.github_actions_workload_identity_pool_id
+  display_name              = "GitHub Actions"
+  description               = "GitHub Actions identities for publishing gestaltd artifacts."
+
+  depends_on = [
+    google_project_service.required,
+  ]
+}
+
+resource "google_iam_workload_identity_pool_provider" "gestaltd_github_actions" {
+  project                            = var.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_actions.workload_identity_pool_id
+  workload_identity_pool_provider_id = var.gestaltd_github_actions_provider_id
+  display_name                       = "gestaltd"
+  description                        = "OIDC provider for ${var.github_repository} gestaltd release workflows."
+
+  attribute_mapping = {
+    "google.subject"             = "assertion.sub"
+    "attribute.actor"            = "assertion.actor"
+    "attribute.repository"       = "assertion.repository"
+    "attribute.repository_owner" = "assertion.repository_owner"
+    "attribute.ref"              = "assertion.ref"
+  }
+
+  attribute_condition = "assertion.repository == \"${var.github_repository}\" && assertion.ref.startsWith(\"${var.github_ref_prefix}\")"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+resource "google_service_account_iam_member" "github_actions_workload_identity_user" {
+  service_account_id = google_service_account.chart_publisher.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.repository/${var.github_repository}"
+}
+
+resource "google_artifact_registry_repository_iam_member" "chart_publisher" {
+  project    = var.project_id
+  location   = google_artifact_registry_repository.gestaltd_charts.location
+  repository = google_artifact_registry_repository.gestaltd_charts.repository_id
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.chart_publisher.email}"
+}

--- a/gestaltd/terraform/outputs.tf
+++ b/gestaltd/terraform/outputs.tf
@@ -1,0 +1,29 @@
+output "github_actions_variables" {
+  description = "GitHub Actions repository variables required by .github/workflows/release-gestaltd.yml."
+  value = {
+    GESTALTD_ARTIFACT_REGISTRY_HOST         = local.artifact_registry_host
+    GESTALTD_CHART_REPOSITORY               = local.chart_repository
+    GESTALTD_GCP_SERVICE_ACCOUNT            = google_service_account.chart_publisher.email
+    GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER = local.workload_identity_provider
+  }
+}
+
+output "artifact_registry_host" {
+  description = "Artifact Registry host for gestaltd Helm charts."
+  value       = local.artifact_registry_host
+}
+
+output "chart_repository" {
+  description = "OCI repository URL for gestaltd Helm charts."
+  value       = local.chart_repository
+}
+
+output "chart_publisher_service_account" {
+  description = "Service account used by GitHub Actions to publish gestaltd Helm charts."
+  value       = google_service_account.chart_publisher.email
+}
+
+output "workload_identity_provider" {
+  description = "Workload Identity provider resource name used by GitHub Actions."
+  value       = local.workload_identity_provider
+}

--- a/gestaltd/terraform/terraform.tfvars.example
+++ b/gestaltd/terraform/terraform.tfvars.example
@@ -1,0 +1,4 @@
+project_id = "<gestaltd artifact GCP project ID>"
+region     = "us-east1"
+
+artifact_registry_repository_id = "gestaltd-charts"

--- a/gestaltd/terraform/variables.tf
+++ b/gestaltd/terraform/variables.tf
@@ -1,0 +1,58 @@
+variable "project_id" {
+  description = "GCP project that owns gestaltd release artifacts."
+  type        = string
+}
+
+variable "region" {
+  description = "Artifact Registry region for gestaltd Helm charts."
+  type        = string
+  default     = "us-east1"
+}
+
+variable "artifact_registry_repository_id" {
+  description = "Artifact Registry repository ID for gestaltd OCI Helm charts."
+  type        = string
+  default     = "gestaltd-charts"
+}
+
+variable "deployer_service_account_id" {
+  description = "Service account ID used by GitHub Actions to apply this Terraform root."
+  type        = string
+  default     = "github-actions"
+}
+
+variable "chart_publisher_service_account_id" {
+  description = "Service account ID used by GitHub Actions to publish gestaltd charts."
+  type        = string
+  default     = "gestaltd-chart-publisher"
+}
+
+variable "github_actions_workload_identity_pool_id" {
+  description = "Workload Identity Pool ID for GitHub Actions OIDC."
+  type        = string
+  default     = "github-actions"
+}
+
+variable "gestaltd_github_actions_provider_id" {
+  description = "Workload Identity Pool provider ID for the gestaltd release workflow."
+  type        = string
+  default     = "gestaltd"
+}
+
+variable "github_repository" {
+  description = "GitHub repository allowed to publish gestaltd charts."
+  type        = string
+  default     = "valon-technologies/gestalt"
+}
+
+variable "github_ref_prefix" {
+  description = "Git ref prefix allowed to publish gestaltd charts."
+  type        = string
+  default     = "refs/tags/gestaltd/v"
+}
+
+variable "labels" {
+  description = "Additional labels applied to gestaltd artifact resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Description

Adds a gestaltd Terraform root that owns the Artifact Registry chart repository and GitHub Actions publishing identity. The release workflow continues to publish via repository variables, now sourced from this Gestalt-owned infrastructure instead of a valon-tools environment repo.