### PR TITLE
[gestaltd] grant chart reader access to valon-tools

### DIFF
--- a/gestaltd/terraform/README.md
+++ b/gestaltd/terraform/README.md
@@ -10,6 +10,8 @@ It creates:
 - GitHub Actions Workload Identity Pool and provider
 - chart publisher service account
 - Artifact Registry writer access for the publisher service account
+- Artifact Registry reader access for configured `valon-tools` Terraform
+  service accounts
 
 The release workflow consumes the `github_actions_variables` output. Copy those
 values into the `valon-technologies/gestalt` repository variables:
@@ -23,6 +25,10 @@ GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER
 
 `valon-tools` environments should consume the chart repository location as input
 variables instead of creating their own per-environment chart repository.
+The `gestaltd_chart_reader_service_accounts` variable controls which
+environment Terraform service accounts can read the chart repository. By
+default this grants read access to the dev and stage `valon-tools` Terraform
+service accounts.
 
 ## Continuous Deployment
 

--- a/gestaltd/terraform/main.tf
+++ b/gestaltd/terraform/main.tf
@@ -133,3 +133,13 @@ resource "google_artifact_registry_repository_iam_member" "chart_publisher" {
   role       = "roles/artifactregistry.writer"
   member     = "serviceAccount:${google_service_account.chart_publisher.email}"
 }
+
+resource "google_artifact_registry_repository_iam_member" "chart_readers" {
+  for_each = var.gestaltd_chart_reader_service_accounts
+
+  project    = var.project_id
+  location   = google_artifact_registry_repository.gestaltd_charts.location
+  repository = google_artifact_registry_repository.gestaltd_charts.repository_id
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${each.value}"
+}

--- a/gestaltd/terraform/variables.tf
+++ b/gestaltd/terraform/variables.tf
@@ -15,6 +15,15 @@ variable "artifact_registry_repository_id" {
   default     = "gestaltd-charts"
 }
 
+variable "gestaltd_chart_reader_service_accounts" {
+  description = "Service account emails allowed to read gestaltd Helm charts from Artifact Registry."
+  type        = set(string)
+  default = [
+    "terraform-dev@valon-tools-dev.iam.gserviceaccount.com",
+    "terraform-stage@valon-tools-stage.iam.gserviceaccount.com",
+  ]
+}
+
 variable "deployer_service_account_id" {
   description = "Service account ID used by GitHub Actions to apply this Terraform root."
   type        = string


### PR DESCRIPTION
## Description

Grant the dev and stage valon-tools Terraform service accounts Artifact Registry reader access for the gestaltd chart repository.