### PR TITLE
[gestaltd] defer stage chart reader grant

### DIFF
--- a/gestaltd/terraform/README.md
+++ b/gestaltd/terraform/README.md
@@ -27,8 +27,10 @@ GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER
 variables instead of creating their own per-environment chart repository.
 The `gestaltd_chart_reader_service_accounts` variable controls which
 environment Terraform service accounts can read the chart repository. By
-default this grants read access to the dev and stage `valon-tools` Terraform
-service accounts.
+default this grants read access to the dev `valon-tools` Terraform service
+account. Add stage and prod service account emails only after their bootstrap
+stacks have created those service accounts, because Artifact Registry rejects
+IAM bindings for service accounts that do not exist yet.
 
 ## Continuous Deployment
 

--- a/gestaltd/terraform/variables.tf
+++ b/gestaltd/terraform/variables.tf
@@ -20,7 +20,6 @@ variable "gestaltd_chart_reader_service_accounts" {
   type        = set(string)
   default = [
     "terraform-dev@valon-tools-dev.iam.gserviceaccount.com",
-    "terraform-stage@valon-tools-stage.iam.gserviceaccount.com",
   ]
 }
 


### PR DESCRIPTION
## Description

Remove the stage valon-tools Terraform service account from the default chart reader grants until the stage bootstrap creates that service account.