### PR TITLE
Expose workflow definition creation to agents

### DIFF
--- a/gestaltd/internal/bootstrap/agent_workflow_tools.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools.go
@@ -21,13 +21,14 @@ import (
 )
 
 const (
-	workflowSystemToolSchedulesCreate = "schedules.create"
-	workflowSystemToolSchedulesList   = "schedules.list"
-	workflowSystemToolSchedulesGet    = "schedules.get"
-	workflowSystemToolSchedulesPause  = "schedules.pause"
-	workflowSystemToolSchedulesResume = "schedules.resume"
-	workflowSystemToolRunsList        = "runs.list"
-	workflowSystemToolRunsGet         = "runs.get"
+	workflowSystemToolDefinitionsCreate = "definitions.create"
+	workflowSystemToolSchedulesCreate   = "schedules.create"
+	workflowSystemToolSchedulesList     = "schedules.list"
+	workflowSystemToolSchedulesGet      = "schedules.get"
+	workflowSystemToolSchedulesPause    = "schedules.pause"
+	workflowSystemToolSchedulesResume   = "schedules.resume"
+	workflowSystemToolRunsList          = "runs.list"
+	workflowSystemToolRunsGet           = "runs.get"
 )
 
 type workflowSystemToolAvailability interface {
@@ -51,10 +52,16 @@ func newWorkflowSystemTools(manager workflowmanager.Service, availability workfl
 }
 
 var workflowSystemToolDescriptors = map[string]workflowSystemToolDescriptor{
+	workflowSystemToolDefinitionsCreate: {
+		Operation:        workflowSystemToolDefinitionsCreate,
+		Name:             "workflow_definitions_create",
+		Description:      "Create a reusable workflow definition for a delegated target.",
+		ParametersSchema: workflowSystemToolCreateDefinitionSchema(),
+	},
 	workflowSystemToolSchedulesCreate: {
 		Operation:        workflowSystemToolSchedulesCreate,
 		Name:             "workflow_schedules_create",
-		Description:      "Create a recurring workflow schedule for a delegated target.",
+		Description:      "Create a recurring workflow schedule for a delegated target or workflow definition.",
 		ParametersSchema: workflowSystemToolCreateScheduleSchema(),
 	},
 	workflowSystemToolSchedulesList: {
@@ -148,6 +155,8 @@ func (t *workflowSystemTools) ExecuteSystemTool(ctx context.Context, req agentSy
 		return nil, fmt.Errorf("%w: unsupported agent system tool %q", invocation.ErrInvalidInvocation, req.Tool.Target.System)
 	}
 	switch strings.TrimSpace(req.Tool.Target.Operation) {
+	case workflowSystemToolDefinitionsCreate:
+		return t.executeCreateDefinition(ctx, req)
 	case workflowSystemToolSchedulesCreate:
 		return t.executeCreateSchedule(ctx, req)
 	case workflowSystemToolSchedulesList:
@@ -233,14 +242,10 @@ func (t *workflowSystemTools) ExecuteSystemTool(ctx context.Context, req agentSy
 	}
 }
 
-func (t *workflowSystemTools) executeCreateSchedule(ctx context.Context, req agentSystemToolExecutionRequest) (*coreagent.ExecuteToolResponse, error) {
+func (t *workflowSystemTools) executeCreateDefinition(ctx context.Context, req agentSystemToolExecutionRequest) (*coreagent.ExecuteToolResponse, error) {
 	args := req.Arguments
-	if err := workflowSystemToolRejectUnknownKeys(args, "workflow.schedules.create", "provider", "cron", "timezone", "paused", "target"); err != nil {
+	if err := workflowSystemToolRejectUnknownKeys(args, "workflow.definitions.create", "provider", "target"); err != nil {
 		return nil, err
-	}
-	cron := workflowSystemToolStringArg(args, "cron")
-	if cron == "" {
-		return nil, fmt.Errorf("%w: cron is required", invocation.ErrInvalidInvocation)
 	}
 	targetValue, ok := args["target"]
 	if !ok {
@@ -253,16 +258,89 @@ func (t *workflowSystemTools) executeCreateSchedule(ctx context.Context, req age
 	if err := workflowSystemToolValidateCreateScope(req, target); err != nil {
 		return nil, err
 	}
-	permissions := workflowSystemToolPermissionsForTarget(target)
-	scopedPrincipal, err := workflowSystemToolScopedPrincipal(req.Principal, permissions)
+	permissions := workflowSystemToolPermissionsForTarget(target, req.ProviderName)
+	scopedPrincipal, err := workflowSystemToolScopedPrincipal(req.Principal, permissions, workflowSystemToolTrustedAgentProvider(req, target))
 	if err != nil {
 		return nil, err
+	}
+	definition, err := t.manager.CreateDefinition(ctx, scopedPrincipal, workflowmanager.DefinitionUpsert{
+		ProviderName:     workflowSystemToolStringArg(args, "provider"),
+		Target:           target,
+		IdempotencyKey:   strings.TrimSpace(req.IdempotencyKey),
+		CallerPluginName: workflowSystemToolCallerScope(req.ProviderName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return workflowSystemToolJSONResponse(http.StatusCreated, map[string]any{"definition": workflowSystemToolDefinitionInfo(definition)})
+}
+
+func (t *workflowSystemTools) executeCreateSchedule(ctx context.Context, req agentSystemToolExecutionRequest) (*coreagent.ExecuteToolResponse, error) {
+	args := req.Arguments
+	if err := workflowSystemToolRejectUnknownKeys(args, "workflow.schedules.create", "provider", "cron", "timezone", "paused", "target", "definitionId"); err != nil {
+		return nil, err
+	}
+	cron := workflowSystemToolStringArg(args, "cron")
+	if cron == "" {
+		return nil, fmt.Errorf("%w: cron is required", invocation.ErrInvalidInvocation)
+	}
+	definitionID := workflowSystemToolStringArg(args, "definitionId")
+	targetValue, hasTarget := args["target"]
+	if definitionID == "" && !hasTarget {
+		return nil, fmt.Errorf("%w: target or definitionId is required", invocation.ErrInvalidInvocation)
+	}
+	if definitionID != "" && hasTarget {
+		return nil, fmt.Errorf("%w: target and definitionId cannot both be set", invocation.ErrInvalidInvocation)
+	}
+
+	var target coreworkflow.Target
+	var scopedPrincipal *principal.Principal
+	if definitionID != "" {
+		definitionPrincipal := workflowSystemToolPrincipalWithTrustedProvider(req.Principal, strings.TrimSpace(req.ProviderName))
+		definition, err := t.manager.GetDefinition(ctx, definitionPrincipal, definitionID)
+		if err != nil {
+			return nil, err
+		}
+		if definition == nil || definition.Definition == nil {
+			return nil, core.ErrNotFound
+		}
+		target = definition.Definition.Target
+		if err := workflowSystemToolValidateCreateScope(req, target); err != nil {
+			return nil, err
+		}
+		permissions := definition.Definition.Permissions
+		if permissions == nil {
+			permissions = workflowSystemToolPermissionsForTarget(target, req.ProviderName)
+		}
+		scopedPrincipal, err = workflowSystemToolExactPermissionsPrincipal(req.Principal, permissions, workflowSystemToolTrustedAgentProvider(req, target))
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var err error
+		target, err = workflowSystemToolTargetFromValue(targetValue)
+		if err != nil {
+			return nil, err
+		}
+		if err := workflowSystemToolValidateCreateScope(req, target); err != nil {
+			return nil, err
+		}
+		permissions := workflowSystemToolPermissionsForTarget(target, req.ProviderName)
+		scopedPrincipal, err = workflowSystemToolScopedPrincipal(req.Principal, permissions, workflowSystemToolTrustedAgentProvider(req, target))
+		if err != nil {
+			return nil, err
+		}
+	}
+	upsertTarget := target
+	if definitionID != "" {
+		upsertTarget = coreworkflow.Target{}
 	}
 	schedule, err := t.manager.CreateSchedule(ctx, scopedPrincipal, workflowmanager.ScheduleUpsert{
 		ProviderName:     workflowSystemToolStringArg(args, "provider"),
 		Cron:             cron,
 		Timezone:         workflowSystemToolStringArg(args, "timezone"),
-		Target:           target,
+		Target:           upsertTarget,
+		DefinitionID:     definitionID,
 		Paused:           workflowSystemToolBoolArg(args, "paused"),
 		IdempotencyKey:   strings.TrimSpace(req.IdempotencyKey),
 		CallerPluginName: workflowSystemToolCallerScope(req.ProviderName),
@@ -312,7 +390,25 @@ func workflowSystemToolFromRef(ref coreagent.ToolRef) (coreagent.Tool, error) {
 }
 
 func workflowSystemToolCreateScheduleSchema() map[string]any {
-	targetSchema := workflowSystemToolObjectSchema([]string{}, map[string]any{
+	return workflowSystemToolObjectSchema([]string{"cron"}, map[string]any{
+		"provider":     workflowSystemToolStringSchema("Workflow provider name."),
+		"cron":         workflowSystemToolStringSchema("Cron expression."),
+		"timezone":     workflowSystemToolStringSchema("IANA timezone."),
+		"paused":       map[string]any{"type": "boolean"},
+		"target":       workflowSystemToolTargetSchema(),
+		"definitionId": workflowSystemToolStringSchema("Workflow definition ID to schedule."),
+	})
+}
+
+func workflowSystemToolCreateDefinitionSchema() map[string]any {
+	return workflowSystemToolObjectSchema([]string{"target"}, map[string]any{
+		"provider": workflowSystemToolStringSchema("Workflow provider name."),
+		"target":   workflowSystemToolTargetSchema(),
+	})
+}
+
+func workflowSystemToolTargetSchema() map[string]any {
+	return workflowSystemToolObjectSchema([]string{}, map[string]any{
 		"plugin": workflowSystemToolObjectSchema([]string{"name", "operation"}, map[string]any{
 			"name":       workflowSystemToolStringSchema("Plugin name."),
 			"operation":  workflowSystemToolStringSchema("Plugin operation."),
@@ -331,13 +427,6 @@ func workflowSystemToolCreateScheduleSchema() map[string]any {
 			"modelOptions":   map[string]any{"type": "object"},
 			"timeoutSeconds": map[string]any{"type": "integer", "minimum": 0},
 		}),
-	})
-	return workflowSystemToolObjectSchema([]string{"cron", "target"}, map[string]any{
-		"provider": workflowSystemToolStringSchema("Workflow provider name."),
-		"cron":     workflowSystemToolStringSchema("Cron expression."),
-		"timezone": workflowSystemToolStringSchema("IANA timezone."),
-		"paused":   map[string]any{"type": "boolean"},
-		"target":   targetSchema,
 	})
 }
 
@@ -631,12 +720,15 @@ func workflowSystemToolResolvedBindingMatchesTarget(scopeConnection, scopeInstan
 	return true
 }
 
-func workflowSystemToolPermissionsForTarget(target coreworkflow.Target) []core.AccessPermission {
+func workflowSystemToolPermissionsForTarget(target coreworkflow.Target, defaultAgentProvider string) []core.AccessPermission {
 	operationsByPlugin := map[string]map[string]struct{}{}
-	add := func(pluginName, operation string) {
+	addOperation := func(pluginName, operation string) {
 		pluginName = strings.TrimSpace(pluginName)
 		operation = strings.TrimSpace(operation)
 		if pluginName == "" || operation == "" {
+			return
+		}
+		if ops, ok := operationsByPlugin[pluginName]; ok && ops == nil {
 			return
 		}
 		if operationsByPlugin[pluginName] == nil {
@@ -644,19 +736,33 @@ func workflowSystemToolPermissionsForTarget(target coreworkflow.Target) []core.A
 		}
 		operationsByPlugin[pluginName][operation] = struct{}{}
 	}
+	addProvider := func(providerName string) {
+		providerName = strings.TrimSpace(providerName)
+		if providerName == "" {
+			return
+		}
+		if _, ok := operationsByPlugin[providerName]; !ok {
+			operationsByPlugin[providerName] = nil
+		}
+	}
 	if target.Plugin != nil {
-		add(target.Plugin.PluginName, target.Plugin.Operation)
+		addOperation(target.Plugin.PluginName, target.Plugin.Operation)
 	}
 	if target.Agent != nil {
+		agentProvider := strings.TrimSpace(target.Agent.ProviderName)
+		if agentProvider == "" {
+			agentProvider = strings.TrimSpace(defaultAgentProvider)
+		}
+		addProvider(agentProvider)
 		for i := range target.Agent.ToolRefs {
 			ref := target.Agent.ToolRefs[i]
 			if strings.TrimSpace(ref.System) == "" {
-				add(ref.Plugin, ref.Operation)
+				addOperation(ref.Plugin, ref.Operation)
 			}
 		}
 	}
 	if len(operationsByPlugin) == 0 {
-		return nil
+		return []core.AccessPermission{}
 	}
 	plugins := slices.Sorted(maps.Keys(operationsByPlugin))
 	out := make([]core.AccessPermission, 0, len(plugins))
@@ -667,28 +773,88 @@ func workflowSystemToolPermissionsForTarget(target coreworkflow.Target) []core.A
 	return out
 }
 
-func workflowSystemToolScopedPrincipal(p *principal.Principal, permissions []core.AccessPermission) (*principal.Principal, error) {
+func workflowSystemToolTrustedAgentProvider(req agentSystemToolExecutionRequest, target coreworkflow.Target) string {
+	if target.Agent == nil {
+		return ""
+	}
+	currentProvider := strings.TrimSpace(req.ProviderName)
+	if currentProvider == "" {
+		return ""
+	}
+	targetProvider := strings.TrimSpace(target.Agent.ProviderName)
+	if targetProvider == "" || targetProvider == currentProvider {
+		return currentProvider
+	}
+	return ""
+}
+
+func workflowSystemToolPrincipalWithTrustedProvider(p *principal.Principal, trustedProvider string) *principal.Principal {
+	p = principal.Canonicalized(p)
+	trustedProvider = strings.TrimSpace(trustedProvider)
+	if p == nil || trustedProvider == "" || p.TokenPermissions == nil {
+		return p
+	}
+	next := *p
+	next.TokenPermissions = principal.ClonePermissionSet(p.TokenPermissions)
+	next.TokenPermissions[trustedProvider] = nil
+	next.Scopes = principal.PermissionPlugins(next.TokenPermissions)
+	return principal.Canonicalize(&next)
+}
+
+func workflowSystemToolScopedPrincipal(p *principal.Principal, permissions []core.AccessPermission, trustedProvider string) (*principal.Principal, error) {
+	return workflowSystemToolScopedPrincipalWithPermissions(p, permissions, trustedProvider, true)
+}
+
+func workflowSystemToolExactPermissionsPrincipal(p *principal.Principal, permissions []core.AccessPermission, trustedProvider string) (*principal.Principal, error) {
+	return workflowSystemToolScopedPrincipalWithPermissions(p, permissions, trustedProvider, false)
+}
+
+func workflowSystemToolScopedPrincipalWithPermissions(p *principal.Principal, permissions []core.AccessPermission, trustedProvider string, requireWithinCaller bool) (*principal.Principal, error) {
 	p = principal.Canonicalized(p)
 	if p == nil || strings.TrimSpace(p.SubjectID) == "" {
 		return nil, fmt.Errorf("%w: agent execution principal is required", invocation.ErrAuthorizationDenied)
 	}
-	if len(permissions) == 0 {
+	if permissions == nil {
 		return p, nil
 	}
 	requested := principal.CompilePermissions(permissions)
 	if requested == nil {
-		return p, nil
+		requested = principal.PermissionSet{}
 	}
 	if p.TokenPermissions != nil {
 		requested = principal.IntersectPermissions(requested, p.TokenPermissions)
-		if len(requested) == 0 {
+		if trustedProvider != "" {
+			if requested == nil {
+				requested = principal.PermissionSet{}
+			}
+			requested[trustedProvider] = nil
+		}
+		if requireWithinCaller && len(permissions) > 0 && len(requested) == 0 {
 			return nil, fmt.Errorf("%w: workflow target is outside the caller permission scope", invocation.ErrScopeDenied)
 		}
 	}
 	next := *p
 	next.TokenPermissions = requested
+	next.ActionPermissions = nil
 	next.Scopes = principal.PermissionPlugins(requested)
 	return principal.Canonicalize(&next), nil
+}
+
+func workflowSystemToolDefinitionInfo(definition *workflowmanager.ManagedDefinition) map[string]any {
+	value := map[string]any{}
+	if definition == nil {
+		return value
+	}
+	if providerName := strings.TrimSpace(definition.ProviderName); providerName != "" {
+		value["provider"] = providerName
+	}
+	if definition.Definition != nil {
+		coreDefinition := definition.Definition
+		value["id"] = coreDefinition.ID
+		value["target"] = workflowSystemToolTargetInfo(coreDefinition.Target)
+		workflowSystemToolPutTime(value, "createdAt", coreDefinition.CreatedAt)
+	}
+	return value
 }
 
 func workflowSystemToolScheduleInfo(schedule *workflowmanager.ManagedSchedule) map[string]any {
@@ -709,6 +875,11 @@ func workflowSystemToolScheduleInfo(schedule *workflowmanager.ManagedSchedule) m
 		workflowSystemToolPutTime(value, "createdAt", coreSchedule.CreatedAt)
 		workflowSystemToolPutTime(value, "updatedAt", coreSchedule.UpdatedAt)
 		workflowSystemToolPutTime(value, "nextRunAt", coreSchedule.NextRunAt)
+	}
+	if schedule.ExecutionRef != nil {
+		if sourceDefinitionID := strings.TrimSpace(schedule.ExecutionRef.SourceDefinitionID); sourceDefinitionID != "" {
+			value["sourceDefinitionId"] = sourceDefinitionID
+		}
 	}
 	return value
 }

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"maps"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -129,6 +130,249 @@ func TestAgentRuntimeWorkflowSystemToolCreatesScopedSchedule(t *testing.T) {
 	}
 	if ref.CallerPluginName != "agent:managed" {
 		t.Fatalf("execution ref caller = %q, want agent:managed", ref.CallerPluginName)
+	}
+}
+
+func TestAgentRuntimeWorkflowSystemToolCreatesDefinitionAndScheduleFromDefinition(t *testing.T) {
+	t.Parallel()
+
+	runtime, workflowProvider := newWorkflowSystemToolRuntime(t)
+	definitionTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolDefinitionsCreate)
+	scheduleTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolSchedulesCreate)
+	runGrant := mustMintWorkflowSystemRunGrant(t, runtime, workflowSystemRunGrantScope{
+		Permissions: []core.AccessPermission{
+			{Plugin: "roadmap", Operations: []string{"sync"}},
+			{Plugin: "linear", Operations: []string{"viewer"}},
+		},
+		ToolRefs: []coreagent.ToolRef{
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolDefinitionsCreate},
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolSchedulesCreate},
+			{Plugin: "roadmap", Operation: "sync"},
+		},
+		Tools: []coreagent.Tool{definitionTool, scheduleTool},
+	})
+
+	definitionResp, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "managed",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolCallID:   "definition-call",
+		ToolID:       definitionTool.ID,
+		RunGrant:     runGrant,
+		Arguments: map[string]any{
+			"target": map[string]any{
+				"agent": map[string]any{
+					"provider": "managed",
+					"prompt":   "Sync the roadmap and open the needed code changes.",
+					"toolRefs": []any{
+						map[string]any{"plugin": "roadmap", "operation": "sync"},
+						map[string]any{"system": coreagent.SystemToolWorkflow, "operation": workflowSystemToolSchedulesCreate},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTool definition: %v", err)
+	}
+	if definitionResp == nil || definitionResp.Status != http.StatusCreated {
+		t.Fatalf("definition response = %#v, want 201", definitionResp)
+	}
+	var definitionBody struct {
+		Definition struct {
+			ID       string `json:"id"`
+			Provider string `json:"provider"`
+			Target   struct {
+				Agent struct {
+					Provider string `json:"provider"`
+					Prompt   string `json:"prompt"`
+				} `json:"agent"`
+			} `json:"target"`
+		} `json:"definition"`
+	}
+	if err := json.Unmarshal([]byte(definitionResp.Body), &definitionBody); err != nil {
+		t.Fatalf("decode definition response body: %v", err)
+	}
+	definitionID := definitionBody.Definition.ID
+	if definitionID == "" || definitionBody.Definition.Provider != "temporal" || definitionBody.Definition.Target.Agent.Provider != "managed" {
+		t.Fatalf("definition response = %#v", definitionBody.Definition)
+	}
+	definitionRef, err := workflowProvider.GetExecutionReference(context.Background(), definitionID)
+	if err != nil {
+		t.Fatalf("GetExecutionReference(definition): %v", err)
+	}
+	assertWorkflowSystemPermissions(t, definitionRef.Permissions, []core.AccessPermission{
+		{Plugin: "managed"},
+		{Plugin: "roadmap", Operations: []string{"sync"}},
+	})
+
+	scheduleResp, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "managed",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolCallID:   "schedule-call",
+		ToolID:       scheduleTool.ID,
+		RunGrant:     runGrant,
+		Arguments: map[string]any{
+			"cron":         "0 9 * * 1-5",
+			"timezone":     "America/New_York",
+			"definitionId": definitionID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTool schedule: %v", err)
+	}
+	if scheduleResp == nil || scheduleResp.Status != http.StatusCreated {
+		t.Fatalf("schedule response = %#v, want 201", scheduleResp)
+	}
+	var scheduleBody struct {
+		Schedule struct {
+			ID                 string `json:"id"`
+			SourceDefinitionID string `json:"sourceDefinitionId"`
+			Target             struct {
+				Agent struct {
+					Provider string `json:"provider"`
+				} `json:"agent"`
+			} `json:"target"`
+		} `json:"schedule"`
+	}
+	if err := json.Unmarshal([]byte(scheduleResp.Body), &scheduleBody); err != nil {
+		t.Fatalf("decode schedule response body: %v", err)
+	}
+	if scheduleBody.Schedule.ID == "" || scheduleBody.Schedule.SourceDefinitionID != definitionID || scheduleBody.Schedule.Target.Agent.Provider != "managed" {
+		t.Fatalf("schedule response = %#v", scheduleBody.Schedule)
+	}
+	if len(workflowProvider.upsertedSchedules) != 1 {
+		t.Fatalf("upserted schedules = %d, want 1", len(workflowProvider.upsertedSchedules))
+	}
+	upsert := workflowProvider.upsertedSchedules[0]
+	scheduleRef, err := workflowProvider.GetExecutionReference(context.Background(), upsert.ExecutionRef)
+	if err != nil {
+		t.Fatalf("GetExecutionReference(schedule): %v", err)
+	}
+	if scheduleRef.SourceDefinitionID != definitionID {
+		t.Fatalf("schedule ref source definition id = %q, want %q", scheduleRef.SourceDefinitionID, definitionID)
+	}
+	assertWorkflowSystemPermissions(t, scheduleRef.Permissions, []core.AccessPermission{
+		{Plugin: "managed"},
+		{Plugin: "roadmap", Operations: []string{"sync"}},
+	})
+}
+
+func TestAgentRuntimeWorkflowSystemToolRejectsUndelegatedDefinitionTarget(t *testing.T) {
+	t.Parallel()
+
+	runtime, _ := newWorkflowSystemToolRuntime(t)
+	definitionTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolDefinitionsCreate)
+	runGrant := mustMintWorkflowSystemRunGrant(t, runtime, workflowSystemRunGrantScope{
+		Permissions: []core.AccessPermission{
+			{Plugin: "roadmap", Operations: []string{"sync"}},
+		},
+		ToolRefs: []coreagent.ToolRef{
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolDefinitionsCreate},
+		},
+		Tools: []coreagent.Tool{definitionTool},
+	})
+
+	cases := []struct {
+		name      string
+		arguments map[string]any
+	}{
+		{
+			name: "plugin target",
+			arguments: map[string]any{
+				"target": map[string]any{
+					"plugin": map[string]any{
+						"name":      "roadmap",
+						"operation": "sync",
+					},
+				},
+			},
+		},
+		{
+			name: "future system ref",
+			arguments: map[string]any{
+				"target": map[string]any{
+					"agent": map[string]any{
+						"provider": "managed",
+						"prompt":   "Create another cron.",
+						"toolRefs": []any{
+							map[string]any{"system": coreagent.SystemToolWorkflow, "operation": workflowSystemToolSchedulesCreate},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		_, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+			ProviderName: "managed",
+			SessionID:    "session-1",
+			TurnID:       "turn-1",
+			ToolID:       definitionTool.ID,
+			RunGrant:     runGrant,
+			Arguments:    tc.arguments,
+		})
+		if err == nil {
+			t.Fatalf("%s: ExecuteTool succeeded, want scope denial", tc.name)
+		}
+		if !errors.Is(err, invocation.ErrScopeDenied) {
+			t.Fatalf("%s: ExecuteTool error = %v, want scope denied", tc.name, err)
+		}
+	}
+}
+
+func TestAgentRuntimeWorkflowSystemToolRejectsInvalidScheduleDefinitionArguments(t *testing.T) {
+	t.Parallel()
+
+	runtime, _ := newWorkflowSystemToolRuntime(t)
+	scheduleTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolSchedulesCreate)
+	runGrant := mustMintWorkflowSystemRunGrant(t, runtime, workflowSystemRunGrantScope{
+		ToolRefs: []coreagent.ToolRef{
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolSchedulesCreate},
+		},
+		Tools: []coreagent.Tool{scheduleTool},
+	})
+
+	cases := []struct {
+		name      string
+		arguments map[string]any
+	}{
+		{
+			name: "missing target and definition",
+			arguments: map[string]any{
+				"cron": "*/5 * * * *",
+			},
+		},
+		{
+			name: "target and definition",
+			arguments: map[string]any{
+				"cron":         "*/5 * * * *",
+				"definitionId": "workflow_definition:def-1",
+				"target": map[string]any{
+					"plugin": map[string]any{
+						"name":      "roadmap",
+						"operation": "sync",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		_, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+			ProviderName: "managed",
+			SessionID:    "session-1",
+			TurnID:       "turn-1",
+			ToolID:       scheduleTool.ID,
+			RunGrant:     runGrant,
+			Arguments:    tc.arguments,
+		})
+		if err == nil {
+			t.Fatalf("%s: ExecuteTool succeeded, want invalid invocation", tc.name)
+		}
+		if !errors.Is(err, invocation.ErrInvalidInvocation) {
+			t.Fatalf("%s: ExecuteTool error = %v, want invalid invocation", tc.name, err)
+		}
 	}
 }
 
@@ -526,4 +770,12 @@ func mustWorkflowSystemTool(t *testing.T, runtime *agentRuntime, operation strin
 	}
 	tool.ID = mustMintAgentToolID(t, workflowSystemRunGrants(t, runtime), tool.Target)
 	return tool
+}
+
+func assertWorkflowSystemPermissions(t *testing.T, got, want []core.AccessPermission) {
+	t.Helper()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("permissions = %#v, want %#v", got, want)
+	}
 }


### PR DESCRIPTION
## Summary
- Add workflow `definitions.create` as an agent system tool.
- Let workflow `schedules.create` create schedules from either an inline target or `definitionId`.
- Preserve definition-scoped permissions for definition-backed schedules and include `sourceDefinitionId` in schedule responses.

## Interface Changes
- New system tool ref: `{system: "workflow", operation: "definitions.create"}`.
- `workflow_definitions_create` input: `{provider?, target}`.
- `workflow_schedules_create` input: `{provider?, cron, timezone?, paused?, target? OR definitionId?}`.

## Tests
- `go test ./internal/bootstrap`
- `go test ./services/workflows/workflowmanager ./internal/config -run 'Test.*Workflow|Test.*PluginWorkflow|Test.*Config'`