### PR TITLE
Use workflow keys for workflow agent sessions

### DIFF
--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -382,7 +382,7 @@ func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.Invo
 		ProviderName:   agentTarget.ProviderName,
 		Model:          agentTarget.Model,
 		Metadata:       metadata,
-		IdempotencyKey: workflowAgentIdempotencyKey(req, "session"),
+		IdempotencyKey: workflowAgentSessionIdempotencyKey(req),
 	})
 	if err != nil {
 		return nil, err
@@ -617,6 +617,33 @@ func workflowAgentIdempotencyKey(req coreworkflow.InvokeOperationRequest, suffix
 		strings.TrimSpace(req.RunID),
 		strings.TrimSpace(suffix),
 	}, ":")
+}
+
+func workflowAgentSessionIdempotencyKey(req coreworkflow.InvokeOperationRequest) string {
+	if workflowKey := workflowInvocationWorkflowKey(req.Metadata); workflowKey != "" {
+		return strings.Join([]string{
+			"workflow",
+			strings.TrimSpace(req.ProviderName),
+			"workflow-key",
+			workflowKey,
+			"session",
+		}, ":")
+	}
+	return workflowAgentIdempotencyKey(req, "session")
+}
+
+func workflowInvocationWorkflowKey(metadata map[string]any) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	for _, key := range []string{"workflow_key", "workflowKey"} {
+		if value, ok := metadata[key].(string); ok {
+			if value = strings.TrimSpace(value); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
 }
 
 func workflowAgentTurnIdempotencyKey(req coreworkflow.InvokeOperationRequest) string {

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -680,6 +680,54 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 	}
 }
 
+func TestWorkflowRuntimeInvokeAgentTargetUsesWorkflowKeyForSessionIdempotency(t *testing.T) {
+	t.Parallel()
+
+	agentManager := &workflowRuntimeAgentManagerStub{}
+	runtime := &workflowRuntime{}
+	runtime.SetAgentManager(agentManager)
+	p := principal.Canonicalize(&principal.Principal{
+		SubjectID:           principal.UserSubjectID("ada"),
+		CredentialSubjectID: principal.UserSubjectID("ada"),
+	})
+
+	resp, err := runtime.Invoke(principal.WithPrincipal(context.Background(), p), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		RunID:        "run-agent-thread-reply-2",
+		Metadata: map[string]any{
+			"workflow_key": "slack:T123:C123:1778255568.567059",
+		},
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "managed",
+			Model:        "deep",
+			Prompt:       "Continue the Slack thread",
+		}},
+		Signals: []coreworkflow.Signal{{
+			ID:             "signal-agent-2",
+			Name:           "slack.event",
+			IdempotencyKey: "evt-2",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("response = %#v", resp)
+	}
+	if len(agentManager.createSessionRequests) != 1 {
+		t.Fatalf("session requests = %d, want 1", len(agentManager.createSessionRequests))
+	}
+	if got, want := agentManager.createSessionRequests[0].IdempotencyKey, "workflow:temporal:workflow-key:slack:T123:C123:1778255568.567059:session"; got != want {
+		t.Fatalf("session idempotency key = %q, want %q", got, want)
+	}
+	if len(agentManager.createTurnRequests) != 1 {
+		t.Fatalf("turn requests = %d, want 1", len(agentManager.createTurnRequests))
+	}
+	if got := agentManager.createTurnRequests[0].IdempotencyKey; !strings.HasPrefix(got, "workflow:temporal:run-agent-thread-reply-2:turn:signal-batch-") {
+		t.Fatalf("turn idempotency key = %q, want run-scoped signal batch key", got)
+	}
+}
+
 func TestWorkflowRuntimeInvokeAgentTargetMarksProviderCallsWithWorkflowDeadline(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Use workflow invocation `workflow_key` metadata as the stable idempotency key for workflow-owned agent sessions.
- Keep workflow agent turns run and signal-batch scoped so Slack thread replies append as separate turns in the same session.
- Add a regression test covering workflow-keyed agent session creation.

## Test plan
- [x] `go test ./internal/bootstrap -run 'TestWorkflowRuntimeInvokeAgentTarget'` from `gestaltd/`
