### PR TITLE
Default to UI provider alpha.34

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -39,7 +39,7 @@ const (
 	DefaultExternalCredentialsProvider = DefaultProviderRepo + "/external_credentials/default"
 	DefaultExternalCredentialsVersion  = "0.0.1-alpha.5"
 	DefaultUIProvider                  = DefaultProviderRepo + "/ui/default"
-	DefaultUIVersion                   = "0.0.1-alpha.27"
+	DefaultUIVersion                   = "0.0.1-alpha.34"
 	DefaultProviderInstance            = "default"
 )
 


### PR DESCRIPTION
## Summary
- update gestaltd's default UI provider version to 0.0.1-alpha.34

## Test Plan
- go test ./internal/config ./internal/operator