### PR TITLE
Inherit agent tools for created workflows

### DIFF
--- a/gestaltd/internal/bootstrap/agent_workflow_tools.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools.go
@@ -255,6 +255,7 @@ func (t *workflowSystemTools) executeCreateDefinition(ctx context.Context, req a
 	if err != nil {
 		return nil, err
 	}
+	workflowSystemToolInheritAgentToolRefs(req, &target)
 	if err := workflowSystemToolValidateCreateScope(req, target); err != nil {
 		return nil, err
 	}
@@ -322,6 +323,7 @@ func (t *workflowSystemTools) executeCreateSchedule(ctx context.Context, req age
 		if err != nil {
 			return nil, err
 		}
+		workflowSystemToolInheritAgentToolRefs(req, &target)
 		if err := workflowSystemToolValidateCreateScope(req, target); err != nil {
 			return nil, err
 		}
@@ -421,7 +423,7 @@ func workflowSystemToolTargetSchema() map[string]any {
 			"model":          workflowSystemToolStringSchema("Agent model."),
 			"prompt":         workflowSystemToolStringSchema("Agent prompt."),
 			"messages":       map[string]any{"type": "array", "items": map[string]any{"type": "object"}},
-			"toolRefs":       map[string]any{"type": "array", "items": map[string]any{"type": "object"}},
+			"toolRefs":       map[string]any{"type": "array", "items": map[string]any{"type": "object"}, "description": "Agent tool references. If omitted, the created workflow agent inherits the current agent turn's tool references."},
 			"responseSchema": map[string]any{"type": "object"},
 			"metadata":       map[string]any{"type": "object"},
 			"modelOptions":   map[string]any{"type": "object"},
@@ -537,6 +539,73 @@ func workflowSystemToolTargetFromValue(value any) (coreworkflow.Target, error) {
 		ModelOptions:   modelOptions,
 		TimeoutSeconds: workflowSystemToolIntArg(agentMap, "timeoutSeconds"),
 	}}, nil
+}
+
+func workflowSystemToolInheritAgentToolRefs(req agentSystemToolExecutionRequest, target *coreworkflow.Target) {
+	if target == nil || target.Agent == nil || target.Agent.ToolRefs != nil {
+		return
+	}
+	target.Agent.ToolRefs = workflowSystemToolInheritedAgentToolRefs(req)
+}
+
+func workflowSystemToolInheritedAgentToolRefs(req agentSystemToolExecutionRequest) []coreagent.ToolRef {
+	out := []coreagent.ToolRef{}
+	seen := map[string]struct{}{}
+	add := func(ref coreagent.ToolRef) {
+		ref.System = strings.TrimSpace(ref.System)
+		ref.Plugin = strings.TrimSpace(ref.Plugin)
+		ref.Operation = strings.TrimSpace(ref.Operation)
+		ref.Connection = strings.TrimSpace(ref.Connection)
+		ref.Instance = strings.TrimSpace(ref.Instance)
+		if ref.System != "" {
+			if ref.System != coreagent.SystemToolWorkflow || ref.Operation == "" {
+				return
+			}
+			if ref.Plugin != "" || ref.Connection != "" || ref.Instance != "" || ref.CredentialMode != "" || ref.RunAs != nil || ref.RunAsExternalIdentity != nil {
+				return
+			}
+		} else {
+			if ref.Plugin == "" || ref.Plugin == "*" || ref.Operation == "" {
+				return
+			}
+			if ref.CredentialMode != "" || ref.RunAs != nil || ref.RunAsExternalIdentity != nil {
+				return
+			}
+		}
+		inherited := coreagent.ToolRef{
+			System:     ref.System,
+			Plugin:     ref.Plugin,
+			Operation:  ref.Operation,
+			Connection: ref.Connection,
+			Instance:   ref.Instance,
+		}
+		key := strings.Join([]string{inherited.System, inherited.Plugin, inherited.Operation, inherited.Connection, inherited.Instance}, "\x00")
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, inherited)
+	}
+	for i := range req.ToolRefs {
+		add(req.ToolRefs[i])
+	}
+	for i := range req.Tools {
+		target := req.Tools[i].Target
+		if strings.TrimSpace(target.System) != "" {
+			add(coreagent.ToolRef{
+				System:    target.System,
+				Operation: target.Operation,
+			})
+			continue
+		}
+		add(coreagent.ToolRef{
+			Plugin:     target.Plugin,
+			Operation:  target.Operation,
+			Connection: target.Connection,
+			Instance:   target.Instance,
+		})
+	}
+	return out
 }
 
 func workflowSystemToolRefsFromValue(value any) ([]coreagent.ToolRef, error) {

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
@@ -259,6 +259,203 @@ func TestAgentRuntimeWorkflowSystemToolCreatesDefinitionAndScheduleFromDefinitio
 	})
 }
 
+func TestAgentRuntimeWorkflowSystemToolCreatesDefinitionWithInheritedAgentToolRefs(t *testing.T) {
+	t.Parallel()
+
+	runtime, workflowProvider := newWorkflowSystemToolRuntime(t)
+	definitionTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolDefinitionsCreate)
+	scheduleTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolSchedulesCreate)
+	runGrant := mustMintWorkflowSystemRunGrant(t, runtime, workflowSystemRunGrantScope{
+		Permissions: []core.AccessPermission{
+			{Plugin: "roadmap", Operations: []string{"sync"}},
+			{Plugin: "linear", Operations: []string{"viewer"}},
+			{Plugin: "slack", Operations: []string{"chat.postMessage"}},
+		},
+		ToolRefs: []coreagent.ToolRef{
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolDefinitionsCreate},
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolSchedulesCreate},
+			{Plugin: "roadmap", Operation: "sync"},
+			{Plugin: "linear", Operation: "viewer"},
+			{Plugin: "*"},
+		},
+		Tools: []coreagent.Tool{
+			definitionTool,
+			scheduleTool,
+			{Target: coreagent.ToolTarget{Plugin: "slack", Operation: "chat.postMessage"}},
+		},
+	})
+
+	resp, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "managed",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolCallID:   "definition-call",
+		ToolID:       definitionTool.ID,
+		RunGrant:     runGrant,
+		Arguments: map[string]any{
+			"target": map[string]any{
+				"agent": map[string]any{
+					"provider": "managed",
+					"prompt":   "Sync the roadmap and post an update.",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTool definition: %v", err)
+	}
+	if resp == nil || resp.Status != http.StatusCreated {
+		t.Fatalf("definition response = %#v, want 201", resp)
+	}
+	var body struct {
+		Definition struct {
+			ID string `json:"id"`
+		} `json:"definition"`
+	}
+	if err := json.Unmarshal([]byte(resp.Body), &body); err != nil {
+		t.Fatalf("decode definition response body: %v", err)
+	}
+	ref, err := workflowProvider.GetExecutionReference(context.Background(), body.Definition.ID)
+	if err != nil {
+		t.Fatalf("GetExecutionReference(definition): %v", err)
+	}
+	if ref.Target.Agent == nil {
+		t.Fatalf("definition target = %#v, want agent", ref.Target)
+	}
+	wantRefs := []coreagent.ToolRef{
+		{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolDefinitionsCreate},
+		{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolSchedulesCreate},
+		{Plugin: "roadmap", Operation: "sync"},
+		{Plugin: "linear", Operation: "viewer"},
+		{Plugin: "slack", Operation: "chat.postMessage"},
+	}
+	if !reflect.DeepEqual(ref.Target.Agent.ToolRefs, wantRefs) {
+		t.Fatalf("inherited tool refs = %#v, want %#v", ref.Target.Agent.ToolRefs, wantRefs)
+	}
+	assertWorkflowSystemPermissions(t, ref.Permissions, []core.AccessPermission{
+		{Plugin: "linear", Operations: []string{"viewer"}},
+		{Plugin: "managed"},
+		{Plugin: "roadmap", Operations: []string{"sync"}},
+		{Plugin: "slack", Operations: []string{"chat.postMessage"}},
+	})
+}
+
+func TestAgentRuntimeWorkflowSystemToolCreatesScheduleWithInheritedAgentToolRefs(t *testing.T) {
+	t.Parallel()
+
+	runtime, workflowProvider := newWorkflowSystemToolRuntime(t)
+	workflowTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolSchedulesCreate)
+	runGrant := mustMintWorkflowSystemRunGrant(t, runtime, workflowSystemRunGrantScope{
+		Permissions: []core.AccessPermission{{
+			Plugin:     "roadmap",
+			Operations: []string{"sync"},
+		}},
+		ToolRefs: []coreagent.ToolRef{
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolSchedulesCreate},
+			{Plugin: "roadmap", Operation: "sync"},
+		},
+		Tools: []coreagent.Tool{workflowTool},
+	})
+
+	resp, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "managed",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolCallID:   "schedule-call",
+		ToolID:       workflowTool.ID,
+		RunGrant:     runGrant,
+		Arguments: map[string]any{
+			"cron":     "*/5 * * * *",
+			"timezone": "UTC",
+			"target": map[string]any{
+				"agent": map[string]any{
+					"provider": "managed",
+					"prompt":   "Sync the roadmap.",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTool schedule: %v", err)
+	}
+	if resp == nil || resp.Status != http.StatusCreated {
+		t.Fatalf("schedule response = %#v, want 201", resp)
+	}
+	if len(workflowProvider.upsertedSchedules) != 1 {
+		t.Fatalf("upserted schedules = %d, want 1", len(workflowProvider.upsertedSchedules))
+	}
+	upsert := workflowProvider.upsertedSchedules[0]
+	if upsert.Target.Agent == nil {
+		t.Fatalf("schedule target = %#v, want agent", upsert.Target)
+	}
+	wantRefs := []coreagent.ToolRef{
+		{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolSchedulesCreate},
+		{Plugin: "roadmap", Operation: "sync"},
+	}
+	if !reflect.DeepEqual(upsert.Target.Agent.ToolRefs, wantRefs) {
+		t.Fatalf("inherited tool refs = %#v, want %#v", upsert.Target.Agent.ToolRefs, wantRefs)
+	}
+}
+
+func TestAgentRuntimeWorkflowSystemToolCreatesScheduleWithExplicitEmptyAgentToolRefs(t *testing.T) {
+	t.Parallel()
+
+	runtime, workflowProvider := newWorkflowSystemToolRuntime(t)
+	workflowTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolSchedulesCreate)
+	runGrant := mustMintWorkflowSystemRunGrant(t, runtime, workflowSystemRunGrantScope{
+		Permissions: []core.AccessPermission{{
+			Plugin:     "roadmap",
+			Operations: []string{"sync"},
+		}},
+		ToolRefs: []coreagent.ToolRef{
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolSchedulesCreate},
+			{Plugin: "roadmap", Operation: "sync"},
+		},
+		Tools: []coreagent.Tool{workflowTool},
+	})
+
+	resp, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "managed",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolCallID:   "schedule-call",
+		ToolID:       workflowTool.ID,
+		RunGrant:     runGrant,
+		Arguments: map[string]any{
+			"cron":     "*/5 * * * *",
+			"timezone": "UTC",
+			"target": map[string]any{
+				"agent": map[string]any{
+					"provider": "managed",
+					"prompt":   "Run without tools.",
+					"toolRefs": []any{},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTool schedule: %v", err)
+	}
+	if resp == nil || resp.Status != http.StatusCreated {
+		t.Fatalf("schedule response = %#v, want 201", resp)
+	}
+	if len(workflowProvider.upsertedSchedules) != 1 {
+		t.Fatalf("upserted schedules = %d, want 1", len(workflowProvider.upsertedSchedules))
+	}
+	upsert := workflowProvider.upsertedSchedules[0]
+	if upsert.Target.Agent == nil {
+		t.Fatalf("schedule target = %#v, want agent", upsert.Target)
+	}
+	if len(upsert.Target.Agent.ToolRefs) != 0 {
+		t.Fatalf("explicit empty tool refs = %#v, want empty slice", upsert.Target.Agent.ToolRefs)
+	}
+	ref, err := workflowProvider.GetExecutionReference(context.Background(), upsert.ExecutionRef)
+	if err != nil {
+		t.Fatalf("GetExecutionReference: %v", err)
+	}
+	assertWorkflowSystemPermissions(t, ref.Permissions, []core.AccessPermission{{Plugin: "managed"}})
+}
+
 func TestAgentRuntimeWorkflowSystemToolRejectsUndelegatedDefinitionTarget(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- snapshot current agent tool refs onto workflow agent targets when definitions.create or schedules.create omits target.agent.toolRefs
- preserve explicit toolRefs, including an explicit empty list, as caller intent
- filter inherited refs to exact supported plugin/system tool refs and keep workflow execution permissions narrowed to the snapshot

## Tests
- `go test ./internal/bootstrap -run 'TestAgentRuntimeWorkflowSystemTool' -count=1`
- `go test ./internal/bootstrap -count=1`