### PR TITLE
Preserve internal connection access for agent tools

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -304,6 +304,7 @@ func (r *agentRuntime) ExecuteTool(ctx context.Context, req coreagent.ExecuteToo
 	if err := r.validateAgentRunGrantTurn(ctx, grant, requestedTurnID); err != nil {
 		return nil, err
 	}
+	ctx = agentRunGrantInvocationContext(ctx, grant)
 	toolTarget, err := grants.ResolveToolID(req.ToolID)
 	if err != nil {
 		return nil, fmt.Errorf("%w: agent tool id is invalid", invocation.ErrAuthorizationDenied)
@@ -417,6 +418,7 @@ func (r *agentRuntime) ListTools(ctx context.Context, req coreagent.ListToolsReq
 	if err := r.validateAgentRunGrantTurn(ctx, grant, requestedTurnID); err != nil {
 		return nil, err
 	}
+	ctx = agentRunGrantInvocationContext(ctx, grant)
 	principalValue := agentRunGrantPrincipal(grant)
 	if principalValue == nil || strings.TrimSpace(principalValue.SubjectID) == "" {
 		return nil, fmt.Errorf("%w: agent execution principal is required", invocation.ErrInternal)
@@ -625,6 +627,13 @@ func agentRunGrantAllowsConnection(grant agentgrant.Grant, connection string) bo
 		}
 	}
 	return false
+}
+
+func agentRunGrantInvocationContext(ctx context.Context, grant agentgrant.Grant) context.Context {
+	if grant.InternalConnectionAccess {
+		return invocation.WithInternalConnectionAccess(ctx)
+	}
+	return ctx
 }
 
 func materializeAgentConnectionHeaders(token string, info invocation.ConnectionRuntimeInfo) (map[string]string, error) {

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -67,16 +67,18 @@ func testAgentRuntimeIndexedDBDefs() map[string]*config.ProviderEntry {
 }
 
 type agentRuntimeInvokerCall struct {
-	providerName           string
-	operation              string
-	params                 map[string]any
-	subjectID              string
-	credentialModeOverride core.ConnectionMode
-	idempotencyKey         string
-	agentSubjectID         string
-	runAsSubjectID         string
-	externalIdentityType   string
-	externalIdentityID     string
+	providerName             string
+	operation                string
+	params                   map[string]any
+	subjectID                string
+	connection               string
+	credentialModeOverride   core.ConnectionMode
+	internalConnectionAccess bool
+	idempotencyKey           string
+	agentSubjectID           string
+	runAsSubjectID           string
+	externalIdentityType     string
+	externalIdentityID       string
 }
 
 type recordingAgentRuntimeInvoker struct {
@@ -96,16 +98,18 @@ func (i *recordingAgentRuntimeInvoker) Invoke(ctx context.Context, p *principal.
 		runAsSubjectID = runAsAudit.RunAsSubject.SubjectID
 	}
 	i.calls = append(i.calls, agentRuntimeInvokerCall{
-		providerName:           providerName,
-		operation:              operation,
-		params:                 cloneAnyMap(params),
-		subjectID:              p.SubjectID,
-		credentialModeOverride: invocation.CredentialModeOverrideFromContext(ctx),
-		idempotencyKey:         invocation.IdempotencyKeyFromContext(ctx),
-		agentSubjectID:         agentSubjectID,
-		runAsSubjectID:         runAsSubjectID,
-		externalIdentityType:   invocation.ExternalIdentityContextFromContext(ctx).Type,
-		externalIdentityID:     invocation.ExternalIdentityContextFromContext(ctx).ID,
+		providerName:             providerName,
+		operation:                operation,
+		params:                   cloneAnyMap(params),
+		subjectID:                p.SubjectID,
+		connection:               invocation.ConnectionFromContext(ctx),
+		credentialModeOverride:   invocation.CredentialModeOverrideFromContext(ctx),
+		internalConnectionAccess: invocation.InternalConnectionAccessFromContext(ctx),
+		idempotencyKey:           invocation.IdempotencyKeyFromContext(ctx),
+		agentSubjectID:           agentSubjectID,
+		runAsSubjectID:           runAsSubjectID,
+		externalIdentityType:     invocation.ExternalIdentityContextFromContext(ctx).Type,
+		externalIdentityID:       invocation.ExternalIdentityContextFromContext(ctx).ID,
 	})
 	i.mu.Unlock()
 
@@ -134,6 +138,54 @@ func (i *reconnectingAgentRuntimeInvoker) ResolveToken(ctx context.Context, _ *p
 		return ctx, "", err
 	}
 	return ctx, "token", nil
+}
+
+type internalAccessRecordingToolResolver struct {
+	mu              sync.Mutex
+	listInternal    bool
+	resolveInternal bool
+}
+
+func (r *internalAccessRecordingToolResolver) ListTools(ctx context.Context, _ *principal.Principal, req coreagent.ListToolsRequest) (*coreagent.ListToolsResponse, error) {
+	r.mu.Lock()
+	r.listInternal = invocation.InternalConnectionAccessFromContext(ctx)
+	r.mu.Unlock()
+	if len(req.ToolRefs) != 1 {
+		return nil, fmt.Errorf("tool refs = %d, want 1", len(req.ToolRefs))
+	}
+	ref := req.ToolRefs[0]
+	return &coreagent.ListToolsResponse{Tools: []coreagent.ListedTool{{
+		ToolID:  "slack-post-message",
+		MCPName: "slack_chat_postMessage",
+		Ref:     ref,
+		Target: coreagent.ToolTarget{
+			Plugin:     ref.Plugin,
+			Operation:  ref.Operation,
+			Connection: ref.Connection,
+			Instance:   ref.Instance,
+		},
+	}}}, nil
+}
+
+func (r *internalAccessRecordingToolResolver) ResolveTool(ctx context.Context, _ *principal.Principal, ref coreagent.ToolRef) (coreagent.Tool, error) {
+	r.mu.Lock()
+	r.resolveInternal = invocation.InternalConnectionAccessFromContext(ctx)
+	r.mu.Unlock()
+	return coreagent.Tool{
+		Name: "Slack post message",
+		Target: coreagent.ToolTarget{
+			Plugin:     ref.Plugin,
+			Operation:  ref.Operation,
+			Connection: ref.Connection,
+			Instance:   ref.Instance,
+		},
+	}, nil
+}
+
+func (r *internalAccessRecordingToolResolver) Flags() (bool, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.listInternal, r.resolveInternal
 }
 
 type failingSessionCatalogIntegration struct {
@@ -264,6 +316,92 @@ func TestAgentRuntimeResolveConnectionUsesAgentConnectionRuntime(t *testing.T) {
 	}
 	if got.ExpiresAt == nil || !got.ExpiresAt.Equal(expiresAt) {
 		t.Fatalf("ExpiresAt = %v, want %v", got.ExpiresAt, expiresAt)
+	}
+}
+
+func TestAgentRuntimeToolCallsPropagateGrantInternalConnectionAccess(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := newAgentRuntime(&config.Config{})
+	if err != nil {
+		t.Fatalf("newAgentRuntime() error = %v", err)
+	}
+	runGrants := newTestAgentRunGrants(t)
+	resolver := &internalAccessRecordingToolResolver{}
+	invoker := &recordingAgentRuntimeInvoker{}
+	runtime.SetRunGrants(runGrants)
+	runtime.SetToolSearcher(resolver)
+	runtime.SetInvoker(invoker)
+	runtime.PublishProvider("claude", &turnLookupAgentProvider{turn: &coreagent.Turn{
+		ID:        "turn-1",
+		SessionID: "session-1",
+		Status:    coreagent.ExecutionStatusRunning,
+	}})
+
+	toolRef := coreagent.ToolRef{
+		Plugin:     "slack",
+		Operation:  "chat.postMessage",
+		Connection: "bot",
+	}
+	runGrant, err := runGrants.Mint(agentgrant.Grant{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		SubjectID:    "user:user-123",
+		SubjectKind:  string(principal.KindUser),
+		Permissions: []core.AccessPermission{{
+			Plugin:     "slack",
+			Operations: []string{"chat.postMessage"},
+		}},
+		ToolRefs:                 []coreagent.ToolRef{toolRef},
+		ToolSource:               coreagent.ToolSourceModeMCPCatalog,
+		InternalConnectionAccess: true,
+	})
+	if err != nil {
+		t.Fatalf("Mint run grant: %v", err)
+	}
+
+	if _, err := runtime.ListTools(context.Background(), coreagent.ListToolsRequest{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		RunGrant:     runGrant,
+	}); err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	listInternal, _ := resolver.Flags()
+	if !listInternal {
+		t.Fatal("ListTools did not receive internal connection access from run grant")
+	}
+
+	_, err = runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "claude",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolID: mustMintAgentToolID(t, runGrants, coreagent.ToolTarget{
+			Plugin:     "slack",
+			Operation:  "chat.postMessage",
+			Connection: "bot",
+		}),
+		RunGrant:  runGrant,
+		Arguments: map[string]any{"channel": "C123", "text": "hello"},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTool: %v", err)
+	}
+	_, resolveInternal := resolver.Flags()
+	if !resolveInternal {
+		t.Fatal("ResolveTool did not receive internal connection access from run grant")
+	}
+	calls := invoker.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("invoker calls = %#v, want one call", calls)
+	}
+	if calls[0].connection != "bot" {
+		t.Fatalf("invoker connection = %q, want bot", calls[0].connection)
+	}
+	if !calls[0].internalConnectionAccess {
+		t.Fatal("invoker did not receive internal connection access from run grant")
 	}
 }
 

--- a/gestaltd/services/agents/agentgrant/grant.go
+++ b/gestaltd/services/agents/agentgrant/grant.go
@@ -34,33 +34,35 @@ type Manager struct {
 }
 
 type Grant struct {
-	ID                  string
-	ProviderName        string
-	SessionID           string
-	TurnID              string
-	SubjectID           string
-	SubjectKind         string
-	CredentialSubjectID string
-	DisplayName         string
-	AuthSource          string
-	Permissions         []core.AccessPermission
-	ToolRefs            []coreagent.ToolRef
-	Tools               []coreagent.Tool
-	ToolSource          coreagent.ToolSourceMode
-	Connections         []ConnectionBinding
+	ID                       string
+	ProviderName             string
+	SessionID                string
+	TurnID                   string
+	SubjectID                string
+	SubjectKind              string
+	CredentialSubjectID      string
+	DisplayName              string
+	AuthSource               string
+	Permissions              []core.AccessPermission
+	ToolRefs                 []coreagent.ToolRef
+	Tools                    []coreagent.Tool
+	ToolSource               coreagent.ToolSourceMode
+	Connections              []ConnectionBinding
+	InternalConnectionAccess bool
 }
 
 type claims struct {
 	jwt.RegisteredClaims
-	ProviderName        string                  `json:"provider_name,omitempty"`
-	SessionID           string                  `json:"session_id,omitempty"`
-	TurnID              string                  `json:"turn_id,omitempty"`
-	SubjectKind         string                  `json:"subject_kind,omitempty"`
-	CredentialSubjectID string                  `json:"credential_subject_id,omitempty"`
-	DisplayName         string                  `json:"display_name,omitempty"`
-	AuthSource          string                  `json:"auth_source,omitempty"`
-	Permissions         []core.AccessPermission `json:"permissions,omitempty"`
-	ToolScope           string                  `json:"tool_scope,omitempty"`
+	ProviderName             string                  `json:"provider_name,omitempty"`
+	SessionID                string                  `json:"session_id,omitempty"`
+	TurnID                   string                  `json:"turn_id,omitempty"`
+	SubjectKind              string                  `json:"subject_kind,omitempty"`
+	CredentialSubjectID      string                  `json:"credential_subject_id,omitempty"`
+	DisplayName              string                  `json:"display_name,omitempty"`
+	AuthSource               string                  `json:"auth_source,omitempty"`
+	Permissions              []core.AccessPermission `json:"permissions,omitempty"`
+	ToolScope                string                  `json:"tool_scope,omitempty"`
+	InternalConnectionAccess bool                    `json:"internal_connection_access,omitempty"`
 }
 
 type toolScope struct {
@@ -103,14 +105,15 @@ func (m *Manager) Mint(grant Grant) (string, error) {
 			NotBefore: jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(runGrantTTL)),
 		},
-		ProviderName:        strings.TrimSpace(grant.ProviderName),
-		SessionID:           strings.TrimSpace(grant.SessionID),
-		TurnID:              strings.TrimSpace(grant.TurnID),
-		SubjectKind:         strings.TrimSpace(grant.SubjectKind),
-		CredentialSubjectID: strings.TrimSpace(grant.CredentialSubjectID),
-		DisplayName:         strings.TrimSpace(grant.DisplayName),
-		AuthSource:          strings.TrimSpace(grant.AuthSource),
-		Permissions:         append([]core.AccessPermission(nil), grant.Permissions...),
+		ProviderName:             strings.TrimSpace(grant.ProviderName),
+		SessionID:                strings.TrimSpace(grant.SessionID),
+		TurnID:                   strings.TrimSpace(grant.TurnID),
+		SubjectKind:              strings.TrimSpace(grant.SubjectKind),
+		CredentialSubjectID:      strings.TrimSpace(grant.CredentialSubjectID),
+		DisplayName:              strings.TrimSpace(grant.DisplayName),
+		AuthSource:               strings.TrimSpace(grant.AuthSource),
+		Permissions:              append([]core.AccessPermission(nil), grant.Permissions...),
+		InternalConnectionAccess: grant.InternalConnectionAccess,
 	}
 	scope, err := m.sealValue(sealPurposeToolScope, toolScope{
 		ToolRefs:    append([]coreagent.ToolRef(nil), grant.ToolRefs...),
@@ -152,20 +155,21 @@ func (m *Manager) Resolve(token string) (Grant, error) {
 		return Grant{}, fmt.Errorf("agent run grant is invalid or expired")
 	}
 	grant := Grant{
-		ID:                  strings.TrimSpace(decoded.ID),
-		ProviderName:        strings.TrimSpace(decoded.ProviderName),
-		SessionID:           strings.TrimSpace(decoded.SessionID),
-		TurnID:              strings.TrimSpace(decoded.TurnID),
-		SubjectID:           strings.TrimSpace(decoded.Subject),
-		SubjectKind:         strings.TrimSpace(decoded.SubjectKind),
-		CredentialSubjectID: strings.TrimSpace(decoded.CredentialSubjectID),
-		DisplayName:         strings.TrimSpace(decoded.DisplayName),
-		AuthSource:          strings.TrimSpace(decoded.AuthSource),
-		Permissions:         append([]core.AccessPermission(nil), decoded.Permissions...),
-		ToolRefs:            append([]coreagent.ToolRef(nil), scope.ToolRefs...),
-		Tools:               append([]coreagent.Tool(nil), scope.Tools...),
-		ToolSource:          scope.ToolSource,
-		Connections:         append([]ConnectionBinding(nil), scope.Connections...),
+		ID:                       strings.TrimSpace(decoded.ID),
+		ProviderName:             strings.TrimSpace(decoded.ProviderName),
+		SessionID:                strings.TrimSpace(decoded.SessionID),
+		TurnID:                   strings.TrimSpace(decoded.TurnID),
+		SubjectID:                strings.TrimSpace(decoded.Subject),
+		SubjectKind:              strings.TrimSpace(decoded.SubjectKind),
+		CredentialSubjectID:      strings.TrimSpace(decoded.CredentialSubjectID),
+		DisplayName:              strings.TrimSpace(decoded.DisplayName),
+		AuthSource:               strings.TrimSpace(decoded.AuthSource),
+		Permissions:              append([]core.AccessPermission(nil), decoded.Permissions...),
+		ToolRefs:                 append([]coreagent.ToolRef(nil), scope.ToolRefs...),
+		Tools:                    append([]coreagent.Tool(nil), scope.Tools...),
+		ToolSource:               scope.ToolSource,
+		Connections:              append([]ConnectionBinding(nil), scope.Connections...),
+		InternalConnectionAccess: decoded.InternalConnectionAccess,
 	}
 	if m.revokedTurn(grant) {
 		return Grant{}, fmt.Errorf("agent run grant is revoked")

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -1427,19 +1427,20 @@ func (m *Manager) mintRunGrant(ctx context.Context, p *principal.Principal, prov
 	}
 	subject := agentSubjectFromPrincipal(p)
 	return m.runGrants.Mint(agentgrant.Grant{
-		ProviderName:        providerName,
-		SessionID:           sessionID,
-		TurnID:              turnID,
-		SubjectID:           subject.SubjectID,
-		SubjectKind:         subject.SubjectKind,
-		CredentialSubjectID: subject.CredentialSubjectID,
-		DisplayName:         subject.DisplayName,
-		AuthSource:          subject.AuthSource,
-		Permissions:         agentRunPermissions(ctx, p, callerPluginName, toolRefs),
-		ToolRefs:            append([]coreagent.ToolRef(nil), toolRefs...),
-		Tools:               append([]coreagent.Tool(nil), tools...),
-		ToolSource:          toolSource,
-		Connections:         m.agentConnectionBindings(providerName),
+		ProviderName:             providerName,
+		SessionID:                sessionID,
+		TurnID:                   turnID,
+		SubjectID:                subject.SubjectID,
+		SubjectKind:              subject.SubjectKind,
+		CredentialSubjectID:      subject.CredentialSubjectID,
+		DisplayName:              subject.DisplayName,
+		AuthSource:               subject.AuthSource,
+		Permissions:              agentRunPermissions(ctx, p, callerPluginName, toolRefs),
+		ToolRefs:                 append([]coreagent.ToolRef(nil), toolRefs...),
+		Tools:                    append([]coreagent.Tool(nil), tools...),
+		ToolSource:               toolSource,
+		Connections:              m.agentConnectionBindings(providerName),
+		InternalConnectionAccess: invocation.InternalConnectionAccessFromContext(ctx),
 	})
 }
 

--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -301,7 +301,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		overrideAllowed := transport == catalog.TransportPlugin || OperationConnectionOverrideAllowed(execProv, opMeta.ID, params)
 		overrideDenied := !overrideAllowed
 		overrideTargetsInternal := b.connectionIsInternal(providerName, explicitConnection)
-		if operationConnection != "" && operationConnection != explicitConnection && (overrideDenied || overrideTargetsInternal) {
+		if operationConnection != "" && operationConnection != explicitConnection && (overrideDenied || (overrideTargetsInternal && !allowsInternalConnection(ctx))) {
 			return fail(fmt.Errorf(
 				"%w: operation %q on integration %q uses connection %q; omit the connection override or use that connection instead of %q",
 				ErrInvalidInvocation,

--- a/gestaltd/services/invocation/broker_test.go
+++ b/gestaltd/services/invocation/broker_test.go
@@ -534,6 +534,91 @@ func TestBrokerInvokeRejectsExplicitInternalConnectionOverride(t *testing.T) {
 	}
 }
 
+func TestBrokerInvokeAllowsExplicitInternalConnectionOverrideWithInternalAccess(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	cat := &catalog.Catalog{
+		Name: "slack",
+		Operations: []catalog.CatalogOperation{{
+			ID:        "chat.postMessage",
+			Method:    "POST",
+			Transport: catalog.TransportPlugin,
+		}},
+	}
+	executed := false
+	provider := &brokerOperationConnectionProvider{
+		StubIntegration: &coretesting.StubIntegration{
+			N:          "slack",
+			ConnMode:   core.ConnectionModeUser,
+			CatalogVal: cat,
+			ExecuteFn: func(_ context.Context, operation string, _ map[string]any, token string) (*core.OperationResult, error) {
+				executed = true
+				if operation != "chat.postMessage" {
+					t.Fatalf("operation = %q, want chat.postMessage", operation)
+				}
+				if token != "bot-token" {
+					t.Fatalf("token = %q, want bot-token", token)
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: "ok"}, nil
+			},
+		},
+		operationConnections: map[string]string{"chat.postMessage": "default"},
+	}
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, provider),
+		svc.Users,
+		svc.ExternalCredentials,
+		WithConnectionRuntime(ConnectionRuntimeMap{
+			"slack": {
+				"default": {Mode: core.ConnectionModeUser},
+				"bot": {
+					Mode:     core.ConnectionModePlatform,
+					Exposure: core.ConnectionExposureInternal,
+					Token:    "bot-token",
+				},
+			},
+		}.Resolve),
+	)
+	subject := &principal.Principal{SubjectID: "service_account:slack-agent", Kind: principal.Kind("service_account")}
+
+	_, err := broker.Invoke(
+		WithConnection(context.Background(), "bot"),
+		subject,
+		"slack",
+		"",
+		"chat.postMessage",
+		map[string]any{"channel": "C123", "text": "hello"},
+	)
+	if err == nil {
+		t.Fatal("Invoke without internal access succeeded, want internal connection rejection")
+	}
+	if !errors.Is(err, ErrInvalidInvocation) {
+		t.Fatalf("Invoke error = %v, want ErrInvalidInvocation", err)
+	}
+	if executed {
+		t.Fatal("Execute was called after rejected internal connection override")
+	}
+
+	result, err := broker.Invoke(
+		WithInternalConnectionAccess(WithConnection(context.Background(), "bot")),
+		subject,
+		"slack",
+		"",
+		"chat.postMessage",
+		map[string]any{"channel": "C123", "text": "hello"},
+	)
+	if err != nil {
+		t.Fatalf("Invoke with internal access: %v", err)
+	}
+	if result.Body != "ok" {
+		t.Fatalf("result body = %q, want ok", result.Body)
+	}
+	if !executed {
+		t.Fatal("Execute was not called")
+	}
+}
+
 func TestBrokerAgentExternalIdentitySkipsIncompleteConnectionMatchForFallback(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Allow explicit internal connection overrides only when the invocation context already has internal connection access.
- Persist internal-connection access in agent run grants and restore it for agent tool listing and execution.
- Add broker and agent runtime contract coverage for internal `bot` connection tool calls.

## Interface Changes

- New/changed interface: agent run grants now carry `internal_connection_access` so trusted config-owned agent turns can keep using internal tool connections after the run grant is minted.
- Example usage: a config-owned agent turn with a tool ref like `{ plugin: "slack", operation: "chat.postMessage", connection: "bot" }` can list and execute that tool while ordinary user contexts still cannot explicitly target the internal `bot` connection.
- Stack note: this should merge/deploy before the Slack provider PR that moves `chat.postMessage` to a code-backed plugin operation.

## Functional/Integration Tests

- Tests added or augmented: broker invocation contract for explicit internal connection override with and without internal access; agent runtime contract for propagating internal access through tool listing and execution.
- Contract boundary covered: broker connection override policy, signed agent run grant propagation, agent runtime tool invocation context.
- Commands run:
  - `go test ./services/invocation ./internal/bootstrap -run 'TestBrokerInvoke(RejectsExplicitInternalConnectionOverride|AllowsExplicitInternalConnectionOverrideWithInternalAccess)|TestAgentRuntime(ToolCallsPropagateGrantInternalConnectionAccess|ResolveConnectionUsesAgentConnectionRuntime)'`
  - `go test ./services/agents/agentgrant ./services/agents/agentmanager`
  - `go test ./services/invocation ./services/agents/agentgrant ./services/agents/agentmanager ./internal/bootstrap` (hit a timeout in unrelated `TestClientCredentialsTokenSourceFetchTimeoutReleasesFlight`)
  - `go test ./internal/bootstrap -run TestClientCredentialsTokenSourceFetchTimeoutReleasesFlight -count=1`