### PR TITLE
Propagate caller scope into scheduled agent workflows

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -36,13 +36,14 @@ type agentRuntime struct {
 }
 
 type agentSystemToolExecutionRequest struct {
-	Principal      *principal.Principal
-	ProviderName   string
-	Tool           coreagent.Tool
-	Arguments      map[string]any
-	IdempotencyKey string
-	ToolRefs       []coreagent.ToolRef
-	Tools          []coreagent.Tool
+	Principal        *principal.Principal
+	ProviderName     string
+	CallerPluginName string
+	Tool             coreagent.Tool
+	Arguments        map[string]any
+	IdempotencyKey   string
+	ToolRefs         []coreagent.ToolRef
+	Tools            []coreagent.Tool
 }
 
 type agentSystemToolExecutor interface {
@@ -346,13 +347,14 @@ func (r *agentRuntime) ExecuteTool(ctx context.Context, req coreagent.ExecuteToo
 			return nil, agentmanager.ErrAgentWorkflowToolsNotConfigured
 		}
 		return systemTools.ExecuteSystemTool(ctx, agentSystemToolExecutionRequest{
-			Principal:      principalValue,
-			ProviderName:   strings.TrimSpace(grant.ProviderName),
-			Tool:           resolvedTool,
-			Arguments:      maps.Clone(req.Arguments),
-			IdempotencyKey: idempotencyKey,
-			ToolRefs:       append([]coreagent.ToolRef(nil), grant.ToolRefs...),
-			Tools:          append([]coreagent.Tool(nil), grant.Tools...),
+			Principal:        principalValue,
+			ProviderName:     strings.TrimSpace(grant.ProviderName),
+			CallerPluginName: strings.TrimSpace(grant.CallerPluginName),
+			Tool:             resolvedTool,
+			Arguments:        maps.Clone(req.Arguments),
+			IdempotencyKey:   idempotencyKey,
+			ToolRefs:         append([]coreagent.ToolRef(nil), grant.ToolRefs...),
+			Tools:            append([]coreagent.Tool(nil), grant.Tools...),
 		})
 	}
 	if invoker == nil {

--- a/gestaltd/internal/bootstrap/agent_workflow_tools.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools.go
@@ -313,7 +313,7 @@ func (t *workflowSystemTools) executeCreateDefinition(ctx context.Context, req a
 		ProviderName:     workflowSystemToolStringArg(args, "provider"),
 		Target:           target,
 		IdempotencyKey:   strings.TrimSpace(req.IdempotencyKey),
-		CallerPluginName: workflowSystemToolCallerScope(req.ProviderName),
+		CallerPluginName: workflowSystemToolCallerScope(req),
 	})
 	if err != nil {
 		return nil, err
@@ -365,7 +365,7 @@ func (t *workflowSystemTools) executeUpdateDefinition(ctx context.Context, req a
 	definition, err := t.manager.UpdateDefinition(ctx, workflowSystemToolManagementPrincipal(req), definitionID, workflowmanager.DefinitionUpsert{
 		ProviderName:     workflowSystemToolStringArg(args, "provider"),
 		Target:           target,
-		CallerPluginName: workflowSystemToolCallerScope(req.ProviderName),
+		CallerPluginName: workflowSystemToolCallerScope(req),
 		Permissions:      permissions,
 	})
 	if err != nil {
@@ -458,7 +458,7 @@ func (t *workflowSystemTools) executeCreateSchedule(ctx context.Context, req age
 		DefinitionID:     definitionID,
 		Paused:           workflowSystemToolBoolArg(args, "paused"),
 		IdempotencyKey:   strings.TrimSpace(req.IdempotencyKey),
-		CallerPluginName: workflowSystemToolCallerScope(req.ProviderName),
+		CallerPluginName: workflowSystemToolCallerScope(req),
 	})
 	if err != nil {
 		return nil, err
@@ -585,7 +585,7 @@ func (t *workflowSystemTools) executeUpdateSchedule(ctx context.Context, req age
 		DefinitionID:       definitionID,
 		SourceDefinitionID: sourceDefinitionID,
 		Paused:             paused,
-		CallerPluginName:   workflowSystemToolCallerScope(req.ProviderName),
+		CallerPluginName:   workflowSystemToolCallerScope(req),
 		Permissions:        permissions,
 	})
 	if err != nil {
@@ -609,8 +609,11 @@ func (t *workflowSystemTools) executeDeleteSchedule(ctx context.Context, req age
 	return workflowSystemToolJSONResponse(http.StatusOK, map[string]any{"scheduleId": scheduleID, "deleted": true})
 }
 
-func workflowSystemToolCallerScope(providerName string) string {
-	providerName = strings.TrimSpace(providerName)
+func workflowSystemToolCallerScope(req agentSystemToolExecutionRequest) string {
+	if callerPluginName := strings.TrimSpace(req.CallerPluginName); callerPluginName != "" {
+		return callerPluginName
+	}
+	providerName := strings.TrimSpace(req.ProviderName)
 	if providerName == "" {
 		return "agent"
 	}
@@ -844,13 +847,8 @@ func workflowSystemToolInheritedAgentToolRefs(req agentSystemToolExecutionReques
 			if ref.Plugin != "" || ref.Connection != "" || ref.Instance != "" || ref.CredentialMode != "" || ref.RunAs != nil || ref.RunAsExternalIdentity != nil {
 				return
 			}
-		} else {
-			if ref.Plugin == "" || ref.Plugin == "*" || ref.Operation == "" {
-				return
-			}
-			if ref.CredentialMode != "" || ref.RunAs != nil || ref.RunAsExternalIdentity != nil {
-				return
-			}
+		} else if ref.Plugin == "" || ref.Plugin == "*" || ref.Operation == "" {
+			return
 		}
 		inherited := coreagent.ToolRef{
 			System:     ref.System,
@@ -972,13 +970,10 @@ func workflowSystemToolValidateCreateScope(req agentSystemToolExecutionRequest, 
 		if ref.CredentialMode != "" {
 			return fmt.Errorf("%w: target.agent.toolRefs[%d] credentialMode is not supported for scheduled agent targets", invocation.ErrInvalidInvocation, i)
 		}
-		pluginTarget := coreworkflow.PluginTarget{
-			PluginName: ref.Plugin,
-			Operation:  ref.Operation,
-			Connection: ref.Connection,
-			Instance:   ref.Instance,
+		if ref.RunAs != nil || ref.RunAsExternalIdentity != nil {
+			return fmt.Errorf("%w: target.agent.toolRefs[%d] runAs is not supported for scheduled agent targets", invocation.ErrInvalidInvocation, i)
 		}
-		if !workflowSystemToolPluginTargetAllowed(pluginTarget, req.ToolRefs, req.Tools) {
+		if !workflowSystemToolAgentPluginRefAllowed(ref, req.ToolRefs, req.Tools) {
 			return fmt.Errorf("%w: target.agent.toolRefs[%d] %s.%s is outside the current agent tool scope", invocation.ErrScopeDenied, i, ref.Plugin, ref.Operation)
 		}
 	}
@@ -989,8 +984,8 @@ func workflowSystemToolValidateFutureSystemRef(index int, ref coreagent.ToolRef,
 	if strings.TrimSpace(ref.System) != coreagent.SystemToolWorkflow || strings.TrimSpace(ref.Operation) == "" {
 		return fmt.Errorf("%w: target.agent.toolRefs[%d] workflow system refs require an exact operation", invocation.ErrInvalidInvocation, index)
 	}
-	if strings.TrimSpace(ref.Plugin) != "" || strings.TrimSpace(ref.Connection) != "" || strings.TrimSpace(ref.Instance) != "" || ref.CredentialMode != "" {
-		return fmt.Errorf("%w: target.agent.toolRefs[%d] system refs cannot include plugin, connection, instance, or credentialMode", invocation.ErrInvalidInvocation, index)
+	if strings.TrimSpace(ref.Plugin) != "" || strings.TrimSpace(ref.Connection) != "" || strings.TrimSpace(ref.Instance) != "" || ref.CredentialMode != "" || ref.RunAs != nil || ref.RunAsExternalIdentity != nil {
+		return fmt.Errorf("%w: target.agent.toolRefs[%d] system refs cannot include plugin, connection, instance, credentialMode, or runAs", invocation.ErrInvalidInvocation, index)
 	}
 	for i := range req.ToolRefs {
 		if strings.TrimSpace(req.ToolRefs[i].System) == coreagent.SystemToolWorkflow && strings.TrimSpace(req.ToolRefs[i].Operation) == strings.TrimSpace(ref.Operation) {
@@ -1003,6 +998,20 @@ func workflowSystemToolValidateFutureSystemRef(index int, ref coreagent.ToolRef,
 		}
 	}
 	return fmt.Errorf("%w: target.agent.toolRefs[%d] workflow.%s is outside the current agent tool scope", invocation.ErrScopeDenied, index, ref.Operation)
+}
+
+func workflowSystemToolAgentPluginRefAllowed(target coreagent.ToolRef, refs []coreagent.ToolRef, tools []coreagent.Tool) bool {
+	for i := range refs {
+		if workflowSystemToolPluginRefMatchesAgentRef(refs[i], target) {
+			return true
+		}
+	}
+	for i := range tools {
+		if workflowSystemToolResolvedToolMatchesAgentRef(tools[i], target) {
+			return true
+		}
+	}
+	return false
 }
 
 func workflowSystemToolPluginTargetAllowed(target coreworkflow.PluginTarget, refs []coreagent.ToolRef, tools []coreagent.Tool) bool {
@@ -1032,6 +1041,16 @@ func workflowSystemToolPluginRefMatchesTarget(ref coreagent.ToolRef, target core
 	return workflowSystemToolRefBindingMatchesTarget(ref.Connection, ref.Instance, target.Connection, target.Instance)
 }
 
+func workflowSystemToolPluginRefMatchesAgentRef(ref coreagent.ToolRef, target coreagent.ToolRef) bool {
+	if strings.TrimSpace(ref.System) != "" || strings.TrimSpace(ref.Plugin) == "" || strings.TrimSpace(ref.Plugin) == "*" || strings.TrimSpace(ref.Operation) == "" {
+		return false
+	}
+	if strings.TrimSpace(ref.Plugin) != strings.TrimSpace(target.Plugin) || strings.TrimSpace(ref.Operation) != strings.TrimSpace(target.Operation) {
+		return false
+	}
+	return workflowSystemToolRefBindingMatchesTarget(ref.Connection, ref.Instance, target.Connection, target.Instance)
+}
+
 func workflowSystemToolResolvedToolMatchesTarget(tool coreagent.Tool, target coreworkflow.PluginTarget) bool {
 	if strings.TrimSpace(tool.Target.System) != "" || strings.TrimSpace(tool.Target.Plugin) == "" || strings.TrimSpace(tool.Target.Operation) == "" {
 		return false
@@ -1040,6 +1059,16 @@ func workflowSystemToolResolvedToolMatchesTarget(tool coreagent.Tool, target cor
 		return false
 	}
 	if strings.TrimSpace(tool.Target.Plugin) != strings.TrimSpace(target.PluginName) || strings.TrimSpace(tool.Target.Operation) != strings.TrimSpace(target.Operation) {
+		return false
+	}
+	return workflowSystemToolResolvedBindingMatchesTarget(tool.Target.Connection, tool.Target.Instance, target.Connection, target.Instance)
+}
+
+func workflowSystemToolResolvedToolMatchesAgentRef(tool coreagent.Tool, target coreagent.ToolRef) bool {
+	if strings.TrimSpace(tool.Target.System) != "" || strings.TrimSpace(tool.Target.Plugin) == "" || strings.TrimSpace(tool.Target.Operation) == "" {
+		return false
+	}
+	if strings.TrimSpace(tool.Target.Plugin) != strings.TrimSpace(target.Plugin) || strings.TrimSpace(tool.Target.Operation) != strings.TrimSpace(target.Operation) {
 		return false
 	}
 	return workflowSystemToolResolvedBindingMatchesTarget(tool.Target.Connection, tool.Target.Instance, target.Connection, target.Instance)

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -394,6 +395,85 @@ func TestAgentRuntimeWorkflowSystemToolCreatesScheduleWithInheritedAgentToolRefs
 	}
 	if !reflect.DeepEqual(upsert.Target.Agent.ToolRefs, wantRefs) {
 		t.Fatalf("inherited tool refs = %#v, want %#v", upsert.Target.Agent.ToolRefs, wantRefs)
+	}
+}
+
+func TestAgentRuntimeWorkflowSystemToolCreatesScheduleWithDelegatedCallerToolRefs(t *testing.T) {
+	t.Parallel()
+
+	runtime, workflowProvider := newWorkflowSystemToolRuntime(t)
+	workflowTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolSchedulesCreate)
+	runAs := &core.RunAsSubject{
+		SubjectID:   "service_account:github-toolshed",
+		SubjectKind: "service_account",
+	}
+	externalIdentity := &core.ExternalIdentityRef{
+		Type: "github_app_installation",
+		ID:   "repo:valon-technologies/toolshed",
+	}
+	runGrant := mustMintWorkflowSystemRunGrant(t, runtime, workflowSystemRunGrantScope{
+		CallerPluginName: "slack",
+		Permissions: []core.AccessPermission{{
+			Plugin:     "github",
+			Operations: []string{"bot.createPullRequest"},
+		}},
+		ToolRefs: []coreagent.ToolRef{
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolSchedulesCreate},
+			{
+				Plugin:                "github",
+				Operation:             "bot.createPullRequest",
+				CredentialMode:        core.ConnectionModeNone,
+				RunAs:                 runAs,
+				RunAsExternalIdentity: externalIdentity,
+			},
+		},
+		Tools: []coreagent.Tool{workflowTool},
+	})
+
+	resp, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "managed",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolCallID:   "schedule-call",
+		ToolID:       workflowTool.ID,
+		RunGrant:     runGrant,
+		Arguments: map[string]any{
+			"cron":     "*/5 * * * *",
+			"timezone": "UTC",
+			"target": map[string]any{
+				"agent": map[string]any{
+					"provider": "managed",
+					"prompt":   "Open a GitHub pull request.",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTool schedule: %v", err)
+	}
+	if resp == nil || resp.Status != http.StatusCreated {
+		t.Fatalf("schedule response = %#v, want 201", resp)
+	}
+	if len(workflowProvider.upsertedSchedules) != 1 {
+		t.Fatalf("upserted schedules = %d, want 1", len(workflowProvider.upsertedSchedules))
+	}
+	upsert := workflowProvider.upsertedSchedules[0]
+	if upsert.Target.Agent == nil {
+		t.Fatalf("schedule target = %#v, want agent", upsert.Target)
+	}
+	wantRefs := []coreagent.ToolRef{
+		{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolSchedulesCreate},
+		{Plugin: "github", Operation: "bot.createPullRequest"},
+	}
+	if !reflect.DeepEqual(upsert.Target.Agent.ToolRefs, wantRefs) {
+		t.Fatalf("inherited tool refs = %#v, want %#v", upsert.Target.Agent.ToolRefs, wantRefs)
+	}
+	ref, err := workflowProvider.GetExecutionReference(context.Background(), upsert.ExecutionRef)
+	if err != nil {
+		t.Fatalf("GetExecutionReference(schedule): %v", err)
+	}
+	if ref.CallerPluginName != "slack" {
+		t.Fatalf("schedule caller plugin = %q, want slack", ref.CallerPluginName)
 	}
 }
 
@@ -1216,9 +1296,10 @@ func (p *workflowSystemToolRecordingProvider) Ping(context.Context) error { retu
 func (p *workflowSystemToolRecordingProvider) Close() error               { return nil }
 
 type workflowSystemRunGrantScope struct {
-	Permissions []core.AccessPermission
-	ToolRefs    []coreagent.ToolRef
-	Tools       []coreagent.Tool
+	CallerPluginName string
+	Permissions      []core.AccessPermission
+	ToolRefs         []coreagent.ToolRef
+	Tools            []coreagent.Tool
 }
 
 func mustMintWorkflowSystemRunGrant(t *testing.T, runtime *agentRuntime, scope workflowSystemRunGrantScope) string {
@@ -1229,6 +1310,7 @@ func mustMintWorkflowSystemRunGrant(t *testing.T, runtime *agentRuntime, scope w
 		ProviderName:        "managed",
 		SessionID:           "session-1",
 		TurnID:              "turn-1",
+		CallerPluginName:    strings.TrimSpace(scope.CallerPluginName),
 		SubjectID:           principal.UserSubjectID("ada"),
 		SubjectKind:         string(principal.KindUser),
 		CredentialSubjectID: principal.UserSubjectID("ada"),

--- a/gestaltd/services/agents/agentgrant/grant.go
+++ b/gestaltd/services/agents/agentgrant/grant.go
@@ -38,6 +38,7 @@ type Grant struct {
 	ProviderName        string
 	SessionID           string
 	TurnID              string
+	CallerPluginName    string
 	SubjectID           string
 	SubjectKind         string
 	CredentialSubjectID string
@@ -55,6 +56,7 @@ type claims struct {
 	ProviderName        string                  `json:"provider_name,omitempty"`
 	SessionID           string                  `json:"session_id,omitempty"`
 	TurnID              string                  `json:"turn_id,omitempty"`
+	CallerPluginName    string                  `json:"caller_plugin_name,omitempty"`
 	SubjectKind         string                  `json:"subject_kind,omitempty"`
 	CredentialSubjectID string                  `json:"credential_subject_id,omitempty"`
 	DisplayName         string                  `json:"display_name,omitempty"`
@@ -106,6 +108,7 @@ func (m *Manager) Mint(grant Grant) (string, error) {
 		ProviderName:        strings.TrimSpace(grant.ProviderName),
 		SessionID:           strings.TrimSpace(grant.SessionID),
 		TurnID:              strings.TrimSpace(grant.TurnID),
+		CallerPluginName:    strings.TrimSpace(grant.CallerPluginName),
 		SubjectKind:         strings.TrimSpace(grant.SubjectKind),
 		CredentialSubjectID: strings.TrimSpace(grant.CredentialSubjectID),
 		DisplayName:         strings.TrimSpace(grant.DisplayName),
@@ -156,6 +159,7 @@ func (m *Manager) Resolve(token string) (Grant, error) {
 		ProviderName:        strings.TrimSpace(decoded.ProviderName),
 		SessionID:           strings.TrimSpace(decoded.SessionID),
 		TurnID:              strings.TrimSpace(decoded.TurnID),
+		CallerPluginName:    strings.TrimSpace(decoded.CallerPluginName),
 		SubjectID:           strings.TrimSpace(decoded.Subject),
 		SubjectKind:         strings.TrimSpace(decoded.SubjectKind),
 		CredentialSubjectID: strings.TrimSpace(decoded.CredentialSubjectID),

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -1430,6 +1430,7 @@ func (m *Manager) mintRunGrant(ctx context.Context, p *principal.Principal, prov
 		ProviderName:        providerName,
 		SessionID:           sessionID,
 		TurnID:              turnID,
+		CallerPluginName:    strings.TrimSpace(callerPluginName),
 		SubjectID:           subject.SubjectID,
 		SubjectKind:         subject.SubjectKind,
 		CredentialSubjectID: subject.CredentialSubjectID,

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -1456,6 +1456,7 @@ func TestManagerCreateTurnKeepsImplicitWildcardForCallerPluginDefaults(t *testin
 	threshold := 0
 	linear := agentCatalogTestProvider("linear", "Linear", "issues")
 	alpha := newRouteCountingAgentProvider("alpha")
+	grants := newAgentManagerTestRunGrants(t)
 	manager := newTestManager(t, Config{
 		Providers: testutil.NewProviderRegistry(t, linear),
 		Agent: &routeCountingAgentControl{
@@ -1465,6 +1466,7 @@ func TestManagerCreateTurnKeepsImplicitWildcardForCallerPluginDefaults(t *testin
 				"alpha": alpha,
 			},
 		},
+		RunGrants:                     grants,
 		DefaultToolNarrowingThreshold: &threshold,
 	})
 	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
@@ -1487,6 +1489,13 @@ func TestManagerCreateTurnKeepsImplicitWildcardForCallerPluginDefaults(t *testin
 	}
 	if got := alpha.createTurnReqs[0].ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
 		t.Fatalf("CreateTurn tool refs = %#v, want broad wildcard for caller plugin default", got)
+	}
+	grant, err := grants.Resolve(alpha.createTurnReqs[0].RunGrant)
+	if err != nil {
+		t.Fatalf("Resolve run grant: %v", err)
+	}
+	if grant.CallerPluginName != "slack" {
+		t.Fatalf("grant caller plugin = %q, want slack", grant.CallerPluginName)
 	}
 	if linear.catalogCalls != 0 {
 		t.Fatalf("linear catalog calls = %d, want caller plugin default to skip narrowing probes", linear.catalogCalls)


### PR DESCRIPTION
## Summary
- store the creating turn's caller plugin in agent run grants and pass it into workflow system tools
- keep delegated exact plugin tool refs when inheriting scheduled agent tool scope, while storing future workflow targets without per-turn credential/runAs fields
- add coverage for delegated GitHub bot refs and caller-plugin propagation into schedule execution refs

## Test plan
- [x] go test ./internal/bootstrap
- [x] go test ./services/agents/agentmanager
- [x] go test ./services/agents/agentgrant
- [x] go test ./services/workflows/workflowmanager