### PR TITLE
Cover service-account agent tool delegation

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -2442,7 +2442,7 @@ func TestAgentRuntimeExecuteToolRejectsHiddenOperationWithoutExactGrant(t *testi
 	}
 }
 
-func TestAgentRuntimeExecuteToolAppliesRunAsOnlyForDelegatedTool(t *testing.T) {
+func TestAgentRuntimeExecuteToolAppliesCredentialModeAndRunAsOnlyForDelegatedTool(t *testing.T) {
 	t.Parallel()
 
 	invoker := &recordingAgentRuntimeInvoker{}
@@ -2510,7 +2510,7 @@ func TestAgentRuntimeExecuteToolAppliesRunAsOnlyForDelegatedTool(t *testing.T) {
 		},
 		ToolRefs: []coreagent.ToolRef{
 			{Plugin: "slack", Operation: "events.reply"},
-			{Plugin: "github", Operation: "bot.createPullRequest", RunAs: runAs, RunAsExternalIdentity: externalIdentity},
+			{Plugin: "github", Operation: "bot.createPullRequest", CredentialMode: core.ConnectionModeNone, RunAs: runAs, RunAsExternalIdentity: externalIdentity},
 		},
 		ToolSource: coreagent.ToolSourceModeMCPCatalog,
 	})
@@ -2539,6 +2539,7 @@ func TestAgentRuntimeExecuteToolAppliesRunAsOnlyForDelegatedTool(t *testing.T) {
 		ToolID: mustMintAgentToolID(t, runGrants, coreagent.ToolTarget{
 			Plugin:                "github",
 			Operation:             "bot.createPullRequest",
+			CredentialMode:        core.ConnectionModeNone,
 			RunAs:                 runAs,
 			RunAsExternalIdentity: externalIdentity,
 		}),
@@ -2555,8 +2556,14 @@ func TestAgentRuntimeExecuteToolAppliesRunAsOnlyForDelegatedTool(t *testing.T) {
 	if calls[0].providerName != "slack" || calls[0].subjectID != "user:user-123" || calls[0].runAsSubjectID != "" {
 		t.Fatalf("slack call = %#v, want original user subject without runAs", calls[0])
 	}
+	if calls[0].credentialModeOverride != "" {
+		t.Fatalf("slack credential mode override = %q, want none", calls[0].credentialModeOverride)
+	}
 	if calls[1].providerName != "github" || calls[1].subjectID != runAs.SubjectID {
 		t.Fatalf("github call = %#v, want delegated subject %q", calls[1], runAs.SubjectID)
+	}
+	if calls[1].credentialModeOverride != core.ConnectionModeNone {
+		t.Fatalf("github credential mode override = %q, want %q", calls[1].credentialModeOverride, core.ConnectionModeNone)
 	}
 	if calls[1].agentSubjectID != "user:user-123" || calls[1].runAsSubjectID != runAs.SubjectID {
 		t.Fatalf("github audit context = %#v, want original and delegated subjects", calls[1])

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -2281,6 +2281,59 @@ func TestResolveToolsAppliesDeclaredInvokeRunAs(t *testing.T) {
 	}
 }
 
+func TestResolveToolsAppliesDeclaredInvokeCredentialModeAndRunAs(t *testing.T) {
+	t.Parallel()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:    "chat.postMessage",
+				Title: "Post message",
+			}}},
+		},
+	}
+	runAs := &core.RunAsSubject{
+		SubjectID:   "service_account:slack-bot",
+		SubjectKind: "service_account",
+		DisplayName: "Platform Slack Bot",
+	}
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, provider),
+		PluginInvokes: map[string][]invocation.PluginInvocationDependency{
+			"slack": {{
+				Plugin:         "slack",
+				Operation:      "chat.postMessage",
+				CredentialMode: core.ConnectionModeNone,
+				RunAs:          runAs,
+			}},
+		},
+	})
+
+	tools, err := manager.ResolveTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, coreagent.ResolveToolsRequest{
+		CallerPluginName: "slack",
+		ToolRefs: []coreagent.ToolRef{{
+			Plugin:    "slack",
+			Operation: "chat.postMessage",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTools: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("ResolveTools returned %d tools, want 1", len(tools))
+	}
+	if tools[0].Target.CredentialMode != core.ConnectionModeNone {
+		t.Fatalf("tool credential mode = %q, want %q", tools[0].Target.CredentialMode, core.ConnectionModeNone)
+	}
+	if tools[0].Target.RunAs == nil || tools[0].Target.RunAs.SubjectID != runAs.SubjectID {
+		t.Fatalf("tool runAs = %#v, want %q", tools[0].Target.RunAs, runAs.SubjectID)
+	}
+}
+
 func TestResolveToolsRejectsUndeclaredCredentialMode(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add contract coverage for resolving a Slack-owned `chat.postMessage` invoke with both `credentialMode: none` and `runAs: service_account:slack-bot`.
- Extend agent runtime coverage to assert a delegated no-credential tool preserves both the runAs subject and credential-mode override into provider invocation.

## Interface Changes

- New/changed interface: none. This is test-only coverage for existing caller invoke policy and agent tool execution behavior.
- Example resolved target covered by the tests:

```yaml
- plugin: slack
  operation: chat.postMessage
  credentialMode: none
  runAs:
    subject:
      id: service_account:slack-bot
      kind: service_account
```

## Functional/Integration Tests

- Tests added or augmented: agent manager resolve-tools contract and agent runtime delegated-tool execution contract.
- Contract boundary covered: caller plugin invoke policy -> resolved agent tool target; agent run grant -> provider invocation context.
- Commands run:
  - `go test ./services/agents/agentmanager -run 'TestResolveToolsAppliesDeclaredInvoke(CredentialMode|RunAs|CredentialModeAndRunAs)$'`
  - `go test ./internal/bootstrap -run 'TestAgentRuntimeExecuteToolAppliesCredentialModeAndRunAsOnlyForDelegatedTool|TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefAcceptsCanonicalTarget'`