### PR TITLE
Support shared agent session authorization

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1195,6 +1195,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		RunGrants:                     prepared.Deps.AgentRunGrants,
 		Invoker:                       sharedInvoker,
 		Authorizer:                    authz,
+		AuthorizationProvider:         prepared.AuthorizationProvider,
 		DefaultConnection:             connMaps.DefaultConnection,
 		CatalogConnection:             connMaps.APIConnection,
 		PluginInvokes:                 agentPluginInvokes(cfg),

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -450,6 +450,7 @@ type memoryAgentProvider struct {
 	interactions        map[string]*coreagent.Interaction
 	turnRequests        []coreagent.CreateTurnRequest
 	getSessionRequests  []coreagent.GetSessionRequest
+	getTurnRequests     []coreagent.GetTurnRequest
 	listSessionRequests []coreagent.ListSessionsRequest
 	listTurnRequests    []coreagent.ListTurnsRequest
 	createSessionHook   func()
@@ -646,6 +647,13 @@ func (p *memoryAgentProvider) capturedTurnRequests() []coreagent.CreateTurnReque
 	return out
 }
 
+func (p *memoryAgentProvider) capturedGetTurnRequests() []coreagent.GetTurnRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return append([]coreagent.GetTurnRequest(nil), p.getTurnRequests...)
+}
+
 func (p *memoryAgentProvider) capturedListSessionRequests() []coreagent.ListSessionsRequest {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -672,6 +680,7 @@ func (p *memoryAgentProvider) GetTurn(_ context.Context, req coreagent.GetTurnRe
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	p.getTurnRequests = append(p.getTurnRequests, req)
 	turn, ok := p.turns[req.TurnID]
 	if !ok {
 		return nil, core.ErrNotFound
@@ -1583,6 +1592,257 @@ func TestAgentSessionAndTurnMetrics(t *testing.T) {
 		"gestalt.agent.provider":  "managed",
 		"gestalt.agent.operation": "create_turn",
 	})
+}
+
+func TestAgentSessionSharingAuthorizesExactSessionAccess(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	owner := seedUser(t, services, "agent-owner@example.test")
+	editor := seedUser(t, services, "agent-editor@example.test")
+	provider := newMemoryAgentProvider()
+	authzProvider := newMemoryAuthorizationProvider("memory-authorization")
+	if _, err := authzProvider.WriteModel(context.Background(), &core.WriteModelRequest{
+		Model: authorization.ProviderAuthorizationModelForRoles(nil, nil, nil, nil),
+	}); err != nil {
+		t.Fatalf("WriteModel: %v", err)
+	}
+	pluginDefs := map[string]*config.ProviderEntry{
+		"managed": {AuthorizationPolicy: "agent_policy"},
+	}
+	baseAuthz, err := newTestAuthorizer(config.AuthorizationConfig{
+		Policies: map[string]config.SubjectPolicyDef{
+			"agent_policy": {
+				Default: "deny",
+				Members: []config.SubjectPolicyMemberDef{{
+					SubjectID: principal.UserSubjectID(owner.ID),
+					Role:      "viewer",
+				}},
+			},
+		},
+	}, pluginDefs)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	agentControl := &stubAgentControl{defaultProviderName: "managed", provider: provider}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "owner-session":
+					return &core.UserIdentity{Email: owner.Email}, nil
+				case "editor-session":
+					return &core.UserIdentity{Email: editor.Email}, nil
+				default:
+					return nil, core.ErrNotFound
+				}
+			},
+		}
+		cfg.Services = services
+		cfg.Agent = agentControl
+		cfg.PluginDefs = pluginDefs
+		cfg.Authorizer = baseAuthz
+		cfg.AuthorizationProvider = authzProvider
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:                 agentControl,
+			Authorizer:            baseAuthz,
+			AuthorizationProvider: authzProvider,
+			RunGrants:             newServerTestAgentRunGrants(t),
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	doJSON := func(method, path, token, body string) (int, []byte) {
+		t.Helper()
+		var reader io.Reader
+		if body != "" {
+			reader = bytes.NewBufferString(body)
+		}
+		req, _ := http.NewRequest(method, ts.URL+path, reader)
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: token})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", method, path, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		payload, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read %s %s: %v", method, path, err)
+		}
+		return resp.StatusCode, payload
+	}
+	doBearerJSON := func(method, path, token, body string) (int, []byte) {
+		t.Helper()
+		var reader io.Reader
+		if body != "" {
+			reader = bytes.NewBufferString(body)
+		}
+		req, _ := http.NewRequest(method, ts.URL+path, reader)
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", method, path, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		payload, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read %s %s: %v", method, path, err)
+		}
+		return resp.StatusCode, payload
+	}
+
+	status, payload := doJSON(http.MethodPost, "/api/v1/agent/sessions", "owner-session", `{"provider":"managed","model":"gpt-5.4","clientRef":"owner"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create owner session status = %d body=%s", status, payload)
+	}
+	var session map[string]any
+	if err := json.Unmarshal(payload, &session); err != nil {
+		t.Fatalf("decode owner session: %v", err)
+	}
+	sessionID := session["id"].(string)
+
+	editorSubjectID := principal.UserSubjectID(editor.ID)
+	restrictedToken, restrictedTokenHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	restrictedTokenExpiresAt := time.Now().Add(24 * time.Hour)
+	if err := services.APITokens.StoreAPIToken(context.Background(), &core.APIToken{
+		ID:                  "api-tok-editor-restricted-agent-share",
+		OwnerKind:           core.APITokenOwnerKindUser,
+		OwnerID:             editor.ID,
+		CredentialSubjectID: editorSubjectID,
+		Name:                "restricted-agent-share",
+		HashedToken:         restrictedTokenHash,
+		ExpiresAt:           &restrictedTokenExpiresAt,
+		Permissions: []core.AccessPermission{{
+			Plugin:     "roadmap",
+			Operations: []string{"sync"},
+		}},
+	}); err != nil {
+		t.Fatalf("StoreAPIToken: %v", err)
+	}
+	for _, sessionResourceID := range []string{"000-missing-agent-session", sessionID} {
+		if err := authzProvider.WriteRelationships(context.Background(), &core.WriteRelationshipsRequest{
+			Writes: []*core.Relationship{{
+				Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: editorSubjectID},
+				Relation: authorization.ProviderAgentSessionRelationEditor,
+				Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAgentSession, Id: sessionResourceID},
+			}},
+		}); err != nil {
+			t.Fatalf("WriteRelationships %s: %v", sessionResourceID, err)
+		}
+	}
+
+	status, payload = doJSON(http.MethodPost, "/api/v1/agent/sessions/"+sessionID+"/turns", "owner-session", `{"messages":[{"role":"user","text":"needs approval"}],"metadata":{"requireInteraction":true},"idempotencyKey":"owner-turn"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create owner turn status = %d body=%s", status, payload)
+	}
+	var ownerTurn map[string]any
+	if err := json.Unmarshal(payload, &ownerTurn); err != nil {
+		t.Fatalf("decode owner turn: %v", err)
+	}
+	ownerTurnID := ownerTurn["id"].(string)
+
+	status, payload = doBearerJSON(http.MethodGet, "/api/v1/agent/sessions/"+sessionID, restrictedToken, "")
+	if status != http.StatusForbidden {
+		t.Fatalf("get shared session with restricted token status = %d body=%s, want 403", status, payload)
+	}
+	status, payload = doBearerJSON(http.MethodGet, "/api/v1/agent/turns/"+ownerTurnID, restrictedToken, "")
+	if status != http.StatusForbidden {
+		t.Fatalf("get shared turn with restricted token status = %d body=%s, want 403", status, payload)
+	}
+	status, payload = doBearerJSON(http.MethodPost, "/api/v1/agent/sessions/"+sessionID+"/turns", restrictedToken, `{"messages":[{"role":"user","text":"blocked by token scope"}],"idempotencyKey":"restricted-token-turn"}`)
+	if status != http.StatusForbidden {
+		t.Fatalf("create shared turn with restricted token status = %d body=%s, want 403", status, payload)
+	}
+
+	status, payload = doJSON(http.MethodGet, "/api/v1/agent/sessions?view=summary&limit=1", "editor-session", "")
+	if status != http.StatusOK {
+		t.Fatalf("list shared sessions status = %d body=%s", status, payload)
+	}
+	var sessions []map[string]any
+	if err := json.Unmarshal(payload, &sessions); err != nil {
+		t.Fatalf("decode shared sessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0]["id"] != sessionID {
+		t.Fatalf("shared sessions = %#v, want %q", sessions, sessionID)
+	}
+	if got := provider.capturedListSessionRequests(); len(got) != 0 {
+		t.Fatalf("provider broad ListSessions requests = %#v, want none for shared-only user", got)
+	}
+
+	status, payload = doJSON(http.MethodGet, "/api/v1/agent/sessions/"+sessionID, "editor-session", "")
+	if status != http.StatusOK {
+		t.Fatalf("get shared session status = %d body=%s", status, payload)
+	}
+	status, payload = doJSON(http.MethodGet, "/api/v1/agent/turns/"+ownerTurnID, "editor-session", "")
+	if status != http.StatusOK {
+		t.Fatalf("get shared turn status = %d body=%s", status, payload)
+	}
+	status, payload = doJSON(http.MethodGet, "/api/v1/agent/sessions/"+sessionID+"/turns", "editor-session", "")
+	if status != http.StatusOK {
+		t.Fatalf("list shared turns status = %d body=%s", status, payload)
+	}
+	var listedTurns []map[string]any
+	if err := json.Unmarshal(payload, &listedTurns); err != nil {
+		t.Fatalf("decode shared turns: %v", err)
+	}
+	if len(listedTurns) != 1 || listedTurns[0]["id"] != ownerTurnID {
+		t.Fatalf("shared turns = %#v, want owner turn %q", listedTurns, ownerTurnID)
+	}
+
+	interactionID := "interaction-" + ownerTurnID
+	status, payload = doJSON(http.MethodPost, "/api/v1/agent/turns/"+ownerTurnID+"/interactions/"+interactionID+"/resolve", "editor-session", `{"resolution":{"approved":true}}`)
+	if status != http.StatusOK {
+		t.Fatalf("resolve shared interaction status = %d body=%s", status, payload)
+	}
+
+	status, payload = doJSON(http.MethodPost, "/api/v1/agent/sessions/"+sessionID+"/turns", "editor-session", `{"messages":[{"role":"user","text":"follow up"}],"idempotencyKey":"editor-turn"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create editor turn status = %d body=%s", status, payload)
+	}
+	var editorTurn map[string]any
+	if err := json.Unmarshal(payload, &editorTurn); err != nil {
+		t.Fatalf("decode editor turn: %v", err)
+	}
+	editorTurnID := editorTurn["id"].(string)
+
+	status, payload = doJSON(http.MethodPatch, "/api/v1/agent/sessions/"+sessionID, "editor-session", `{"metadata":{"shared":true}}`)
+	if status == http.StatusOK {
+		t.Fatalf("shared editor patched owner-only session: %s", payload)
+	}
+	status, payload = doJSON(http.MethodPost, "/api/v1/agent/turns/"+ownerTurnID+"/cancel", "editor-session", `{"reason":"not mine"}`)
+	if status != http.StatusNotFound {
+		t.Fatalf("cancel owner turn as shared editor status = %d body=%s, want 404", status, payload)
+	}
+	status, payload = doJSON(http.MethodPost, "/api/v1/agent/turns/"+editorTurnID+"/cancel", "editor-session", `{"reason":"mine"}`)
+	if status != http.StatusOK {
+		t.Fatalf("cancel editor turn status = %d body=%s", status, payload)
+	}
+
+	for _, req := range provider.capturedGetSessionRequests() {
+		if req.SessionID == sessionID && req.Subject.SubjectID != "" {
+			t.Fatalf("GetSession subject = %#v, want empty exact lookup subject", req.Subject)
+		}
+	}
+	for _, req := range provider.capturedGetTurnRequests() {
+		if req.Subject.SubjectID != "" {
+			t.Fatalf("GetTurn subject = %#v, want empty exact lookup subject", req.Subject)
+		}
+	}
+	for _, req := range provider.capturedListTurnRequests() {
+		if req.SessionID == sessionID && req.Subject.SubjectID != "" {
+			t.Fatalf("ListTurns subject = %#v, want empty manager-authorized session lookup subject", req.Subject)
+		}
+	}
 }
 
 func TestAgentSessionsAndTurnsRoundTripWithoutAuth(t *testing.T) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1941,7 +1941,12 @@ func (p *memoryAuthorizationProvider) EvaluateMany(_ context.Context, req *core.
 	for _, item := range req.GetRequests() {
 		allowed := false
 		if item != nil && rels != nil {
-			_, allowed = rels[memoryAuthorizationRelationshipKey(item.GetSubject(), item.GetAction().GetName(), item.GetResource())]
+			for _, rel := range rels {
+				if memoryAuthorizationRelationshipGrantsAction(p.modelDefs[p.activeModelID], rel, item.GetSubject(), item.GetAction().GetName(), item.GetResource()) {
+					allowed = true
+					break
+				}
+			}
 		}
 		resp.Decisions = append(resp.Decisions, &core.AccessDecision{
 			Allowed: allowed,
@@ -1951,8 +1956,68 @@ func (p *memoryAuthorizationProvider) EvaluateMany(_ context.Context, req *core.
 	return resp, nil
 }
 
-func (p *memoryAuthorizationProvider) SearchResources(context.Context, *core.ResourceSearchRequest) (*core.ResourceSearchResponse, error) {
-	return &core.ResourceSearchResponse{}, nil
+func (p *memoryAuthorizationProvider) SearchResources(_ context.Context, req *core.ResourceSearchRequest) (*core.ResourceSearchResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	modelID := p.activeModelID
+	rels := p.relsByModel[modelID]
+	keys := make([]string, 0, len(rels))
+	resources := map[string]*core.ResourceRef{}
+	for _, rel := range rels {
+		if rel == nil || rel.GetResource() == nil {
+			continue
+		}
+		if resourceType := strings.TrimSpace(req.GetResourceType()); resourceType != "" && rel.GetResource().GetType() != resourceType {
+			continue
+		}
+		if !memoryAuthorizationRelationshipGrantsAction(p.modelDefs[modelID], rel, req.GetSubject(), req.GetAction().GetName(), rel.GetResource()) {
+			continue
+		}
+		resourceKey := rel.GetResource().GetType() + "\x00" + rel.GetResource().GetId()
+		if _, ok := resources[resourceKey]; ok {
+			continue
+		}
+		keys = append(keys, resourceKey)
+		resources[resourceKey] = &core.ResourceRef{
+			Type: rel.GetResource().GetType(),
+			Id:   rel.GetResource().GetId(),
+		}
+	}
+	slices.Sort(keys)
+
+	start := 0
+	if token := strings.TrimSpace(req.GetPageToken()); token != "" {
+		offset, err := strconv.Atoi(token)
+		if err != nil || offset < 0 {
+			offset = 0
+		}
+		start = offset
+	}
+	if start > len(keys) {
+		start = len(keys)
+	}
+	pageSize := int(req.GetPageSize())
+	if pageSize <= 0 {
+		pageSize = len(keys)
+	}
+	end := start + pageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+	out := make([]*core.ResourceRef, 0, end-start)
+	for _, key := range keys[start:end] {
+		out = append(out, resources[key])
+	}
+	nextPageToken := ""
+	if end < len(keys) {
+		nextPageToken = strconv.Itoa(end)
+	}
+	return &core.ResourceSearchResponse{
+		Resources:     out,
+		NextPageToken: nextPageToken,
+		ModelId:       modelID,
+	}, nil
 }
 
 func (p *memoryAuthorizationProvider) SearchSubjects(context.Context, *core.SubjectSearchRequest) (*core.SubjectSearchResponse, error) {
@@ -2126,6 +2191,41 @@ func memoryAuthorizationModelAllowsRelationship(model *core.AuthorizationModel, 
 			if allowed.GetName() == relation {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func memoryAuthorizationRelationshipGrantsAction(model *core.AuthorizationModel, rel *core.Relationship, subject *core.SubjectRef, action string, resource *core.ResourceRef) bool {
+	if rel == nil || rel.GetSubject() == nil || rel.GetResource() == nil || resource == nil {
+		return false
+	}
+	if subject != nil && (rel.GetSubject().GetType() != subject.GetType() || rel.GetSubject().GetId() != subject.GetId()) {
+		return false
+	}
+	if rel.GetResource().GetType() != resource.GetType() || rel.GetResource().GetId() != resource.GetId() {
+		return false
+	}
+	action = strings.TrimSpace(action)
+	relation := strings.TrimSpace(rel.GetRelation())
+	if action == "" || relation == "" {
+		return false
+	}
+	if relation == action {
+		return true
+	}
+	if model == nil {
+		return false
+	}
+	for _, rt := range model.GetResourceTypes() {
+		if rt.GetName() != resource.GetType() {
+			continue
+		}
+		for _, allowedAction := range rt.GetActions() {
+			if allowedAction.GetName() != action {
+				continue
+			}
+			return slices.Contains(allowedAction.GetRelations(), relation)
 		}
 	}
 	return false
@@ -2454,6 +2554,45 @@ func mustProviderBackedAuthorizer(t *testing.T, base *authorization.Authorizer, 
 		t.Fatalf("ReloadAuthorizationState: %v", err)
 	}
 	return authz
+}
+
+func TestAuthorizationProviderBackedReloadPreservesAgentSessionGrants(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	baseAuthz, err := newTestAuthorizer(config.AuthorizationConfig{
+		Policies: map[string]config.SubjectPolicyDef{
+			"sample_policy": {Default: "deny"},
+		},
+	}, map[string]*config.ProviderEntry{
+		"sample_plugin": {AuthorizationPolicy: "sample_policy"},
+	})
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
+	grant := &core.Relationship{
+		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: "user:shared"},
+		Relation: authorization.ProviderAgentSessionRelationEditor,
+		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAgentSession, Id: "agent-session-1"},
+	}
+	if err := provider.WriteRelationships(context.Background(), &core.WriteRelationshipsRequest{Writes: []*core.Relationship{grant}}); err != nil {
+		t.Fatalf("WriteRelationships: %v", err)
+	}
+	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
+		t.Fatalf("ReloadAuthorizationState: %v", err)
+	}
+	resp, err := provider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
+		Subject:  grant.Subject,
+		Relation: grant.Relation,
+		Resource: grant.Resource,
+	})
+	if err != nil {
+		t.Fatalf("ReadRelationships: %v", err)
+	}
+	if len(resp.GetRelationships()) != 1 {
+		t.Fatalf("agent session grants after reload = %+v, want preserved editor grant", resp.GetRelationships())
+	}
 }
 
 func testExternalIdentityResourceID(typ, id string) string {

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -112,18 +112,19 @@ type Service interface {
 }
 
 type Config struct {
-	Providers         *registry.ProviderMap[core.Provider]
-	Agent             AgentControl
-	WorkflowTools     WorkflowSystemTools
-	RunGrants         *agentgrant.Manager
-	Invoker           invocation.Invoker
-	Authorizer        authorization.RuntimeAuthorizer
-	DefaultConnection map[string]string
-	CatalogConnection map[string]string
-	PluginInvokes     map[string][]invocation.PluginInvocationDependency
-	AgentConnections  map[string][]string
-	SessionStart      map[string]*coreagent.SessionStartConfig
-	RouteStore        RouteStore
+	Providers             *registry.ProviderMap[core.Provider]
+	Agent                 AgentControl
+	WorkflowTools         WorkflowSystemTools
+	RunGrants             *agentgrant.Manager
+	Invoker               invocation.Invoker
+	Authorizer            authorization.RuntimeAuthorizer
+	AuthorizationProvider core.AuthorizationProvider
+	DefaultConnection     map[string]string
+	CatalogConnection     map[string]string
+	PluginInvokes         map[string][]invocation.PluginInvocationDependency
+	AgentConnections      map[string][]string
+	SessionStart          map[string]*coreagent.SessionStartConfig
+	RouteStore            RouteStore
 	// DefaultToolNarrowingThreshold controls when implicit default wildcard
 	// catalog grants are narrowed to exactly mentioned providers. Nil uses the
 	// package default; zero means narrow whenever any visible catalog candidate
@@ -138,6 +139,7 @@ type Manager struct {
 	runGrants                     *agentgrant.Manager
 	invoker                       invocation.Invoker
 	authorizer                    authorization.RuntimeAuthorizer
+	authorizationProvider         core.AuthorizationProvider
 	defaultConnection             map[string]string
 	catalogConnection             map[string]string
 	pluginInvokes                 map[string][]invocation.PluginInvocationDependency
@@ -153,18 +155,19 @@ type Manager struct {
 
 func New(cfg Config) *Manager {
 	return &Manager{
-		providers:         cfg.Providers,
-		agent:             cfg.Agent,
-		workflowTools:     cfg.WorkflowTools,
-		runGrants:         cfg.RunGrants,
-		invoker:           cfg.Invoker,
-		authorizer:        cfg.Authorizer,
-		defaultConnection: maps.Clone(cfg.DefaultConnection),
-		catalogConnection: maps.Clone(cfg.CatalogConnection),
-		pluginInvokes:     invocation.ClonePluginInvocationDependencyMap(cfg.PluginInvokes),
-		agentConnections:  cloneStringSliceMap(cfg.AgentConnections),
-		sessionStart:      cloneSessionStartConfigMap(cfg.SessionStart),
-		routeStore:        cfg.RouteStore,
+		providers:             cfg.Providers,
+		agent:                 cfg.Agent,
+		workflowTools:         cfg.WorkflowTools,
+		runGrants:             cfg.RunGrants,
+		invoker:               cfg.Invoker,
+		authorizer:            cfg.Authorizer,
+		authorizationProvider: cfg.AuthorizationProvider,
+		defaultConnection:     maps.Clone(cfg.DefaultConnection),
+		catalogConnection:     maps.Clone(cfg.CatalogConnection),
+		pluginInvokes:         invocation.ClonePluginInvocationDependencyMap(cfg.PluginInvokes),
+		agentConnections:      cloneStringSliceMap(cfg.AgentConnections),
+		sessionStart:          cloneSessionStartConfigMap(cfg.SessionStart),
+		routeStore:            cfg.RouteStore,
 		defaultToolNarrowingThreshold: effectiveAgentToolNarrowingThreshold(
 			cfg.DefaultToolNarrowingThreshold,
 		),
@@ -708,7 +711,7 @@ func (m *Manager) GetSession(ctx context.Context, p *principal.Principal, sessio
 	ctx, finish := startAgentOperation(ctx, "get_session")
 	defer func() { finish(err) }()
 
-	owned, err := m.findOwnedSession(ctx, p, sessionID, "")
+	owned, err := m.findAccessibleSession(ctx, p, sessionID, "", authorization.ProviderAgentSessionActionView)
 	if err != nil {
 		return nil, err
 	}
@@ -726,7 +729,10 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 	}
 	candidates, err := m.authorizedProviderCandidates(ctx, p, providerName)
 	if err != nil {
-		return nil, err
+		if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+			return nil, err
+		}
+		candidates = nil
 	}
 	limit, err := normalizeAgentListLimit(req.Limit, req.SummaryOnly)
 	if err != nil {
@@ -734,6 +740,7 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 	}
 	requireBounded := req.SummaryOnly || limit > 0
 	out := make([]*coreagent.Session, 0)
+	seen := map[string]struct{}{}
 	for _, candidate := range candidates {
 		if requireBounded {
 			if err := requireAgentProviderBoundedListHydration(ctx, candidate.name, candidate.provider); err != nil {
@@ -764,11 +771,26 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 				continue
 			}
 			m.rememberSessionRouteBestEffort(ctx, normalized.ID, candidate.name)
+			if _, ok := seen[normalized.ID]; ok {
+				continue
+			}
+			seen[normalized.ID] = struct{}{}
 			if req.SummaryOnly {
 				normalized = summarizeAgentSession(normalized)
 			}
 			out = append(out, normalized)
 		}
+	}
+	sharedSessions := m.listSharedAgentSessions(ctx, p, req, limit)
+	for _, session := range sharedSessions {
+		if session == nil {
+			continue
+		}
+		if _, ok := seen[session.ID]; ok {
+			continue
+		}
+		seen[session.ID] = struct{}{}
+		out = append(out, session)
 	}
 	sort.Slice(out, func(i, j int) bool {
 		left := out[i]
@@ -784,6 +806,68 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 		out = out[:limit]
 	}
 	return out, nil
+}
+
+func (m *Manager) listSharedAgentSessions(ctx context.Context, p *principal.Principal, req coreagent.ManagerListSessionsRequest, limit int) []*coreagent.Session {
+	if m == nil || m.authorizationProvider == nil {
+		return nil
+	}
+	subjectID := strings.TrimSpace(principalSubjectID(principal.Canonicalized(p)))
+	if subjectID == "" {
+		return nil
+	}
+	pageSize := limit
+	if pageSize <= 0 || pageSize > AgentListSummaryDefaultLimit {
+		pageSize = AgentListSummaryDefaultLimit
+	}
+	providerName := strings.TrimSpace(req.ProviderName)
+	pageToken := ""
+	out := make([]*coreagent.Session, 0)
+	seen := map[string]struct{}{}
+	for {
+		resp, err := m.authorizationProvider.SearchResources(ctx, &core.ResourceSearchRequest{
+			Subject: &core.SubjectRef{
+				Type: authorization.ProviderSubjectTypeSubject,
+				Id:   subjectID,
+			},
+			Action:       &core.ActionRef{Name: authorization.ProviderAgentSessionActionView},
+			ResourceType: authorization.ProviderResourceTypeAgentSession,
+			PageSize:     int32(pageSize),
+			PageToken:    pageToken,
+		})
+		if err != nil {
+			return out
+		}
+		for _, resource := range resp.GetResources() {
+			if resource == nil || strings.TrimSpace(resource.GetType()) != authorization.ProviderResourceTypeAgentSession {
+				continue
+			}
+			sessionID := strings.TrimSpace(resource.GetId())
+			if sessionID == "" {
+				continue
+			}
+			if _, ok := seen[sessionID]; ok {
+				continue
+			}
+			seen[sessionID] = struct{}{}
+			session, err := m.findAccessibleSession(ctx, p, sessionID, providerName, authorization.ProviderAgentSessionActionView)
+			if err != nil {
+				continue
+			}
+			if req.State != "" && session.session.State != req.State {
+				continue
+			}
+			if req.SummaryOnly {
+				out = append(out, summarizeAgentSession(session.session))
+			} else {
+				out = append(out, session.session)
+			}
+		}
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			return out
+		}
+	}
 }
 
 func (m *Manager) UpdateSession(ctx context.Context, p *principal.Principal, req coreagent.ManagerUpdateSessionRequest) (session *coreagent.Session, err error) {
@@ -829,7 +913,7 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	if subjectID == "" {
 		return nil, ErrAgentSubjectRequired
 	}
-	ownedSession, err := m.findOwnedSession(ctx, p, req.SessionID, "")
+	ownedSession, err := m.findAccessibleSession(ctx, p, req.SessionID, "", authorization.ProviderAgentSessionActionEdit)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
 			return nil, fmt.Errorf("%w: %w", ErrAgentSessionNotFound, err)
@@ -921,7 +1005,7 @@ func (m *Manager) GetTurn(ctx context.Context, p *principal.Principal, turnID st
 	ctx, finish := startAgentOperation(ctx, "get_turn")
 	defer func() { finish(err) }()
 
-	owned, err := m.findOwnedTurn(ctx, p, turnID, "")
+	owned, err := m.findAccessibleTurn(ctx, p, turnID, "", "", authorization.ProviderAgentSessionActionView)
 	if err != nil {
 		return nil, err
 	}
@@ -933,7 +1017,7 @@ func (m *Manager) ListTurns(ctx context.Context, p *principal.Principal, req cor
 	ctx, finish := startAgentOperation(ctx, "list_turns")
 	defer func() { finish(err) }()
 
-	ownedSession, err := m.findOwnedSession(ctx, p, req.SessionID, "")
+	ownedSession, err := m.findAccessibleSession(ctx, p, req.SessionID, "", authorization.ProviderAgentSessionActionView)
 	if err != nil {
 		return nil, err
 	}
@@ -949,7 +1033,6 @@ func (m *Manager) ListTurns(ctx context.Context, p *principal.Principal, req cor
 	}
 	turns, err = ownedSession.provider.ListTurns(ctx, coreagent.ListTurnsRequest{
 		SessionID:   ownedSession.session.ID,
-		Subject:     agentSubjectFromPrincipal(p),
 		Status:      req.Status,
 		Limit:       limit,
 		SummaryOnly: req.SummaryOnly,
@@ -960,9 +1043,6 @@ func (m *Manager) ListTurns(ctx context.Context, p *principal.Principal, req cor
 	out := make([]*coreagent.Turn, 0, len(turns))
 	for _, turn := range turns {
 		if turn == nil {
-			continue
-		}
-		if !providerTurnOwnedBy(turn, p) {
 			continue
 		}
 		normalized, err := normalizeProviderTurn(ownedSession.providerName, ownedSession.session.ID, strings.TrimSpace(turn.ID), turn)
@@ -996,15 +1076,17 @@ func (m *Manager) CancelTurn(ctx context.Context, p *principal.Principal, turnID
 	ctx, finish := startAgentOperation(ctx, "cancel_turn")
 	defer func() { finish(err) }()
 
-	owned, err := m.findOwnedTurn(ctx, p, turnID, "")
+	owned, err := m.findAccessibleTurn(ctx, p, turnID, "", "", authorization.ProviderAgentSessionActionEdit)
 	if err != nil {
 		return nil, err
 	}
+	if !owned.sessionOwned && !providerTurnOwnedBy(owned.turn, p) {
+		return nil, core.ErrNotFound
+	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(owned.providerName))
 	turn, err = owned.provider.CancelTurn(ctx, coreagent.CancelTurnRequest{
-		TurnID:  strings.TrimSpace(turnID),
-		Reason:  strings.TrimSpace(reason),
-		Subject: agentSubjectFromPrincipal(p),
+		TurnID: strings.TrimSpace(turnID),
+		Reason: strings.TrimSpace(reason),
 	})
 	if err != nil {
 		return nil, err
@@ -1013,7 +1095,7 @@ func (m *Manager) CancelTurn(ctx context.Context, p *principal.Principal, turnID
 	if err != nil {
 		return nil, err
 	}
-	if !providerTurnOwnedBy(normalized, p) {
+	if !owned.sessionOwned && !providerTurnOwnedBy(normalized, p) {
 		return nil, core.ErrNotFound
 	}
 	if coreagent.ExecutionStatusIsLive(normalized.Status) {
@@ -1033,7 +1115,7 @@ func (m *Manager) ListTurnEvents(ctx context.Context, p *principal.Principal, tu
 	ctx, finish := startAgentOperation(ctx, "list_turn_events")
 	defer func() { finish(err) }()
 
-	owned, err := m.findOwnedTurn(ctx, p, turnID, "")
+	owned, err := m.findAccessibleTurn(ctx, p, turnID, "", "", authorization.ProviderAgentSessionActionView)
 	if err != nil {
 		return nil, err
 	}
@@ -1042,7 +1124,6 @@ func (m *Manager) ListTurnEvents(ctx context.Context, p *principal.Principal, tu
 		TurnID:   owned.turn.ID,
 		AfterSeq: afterSeq,
 		Limit:    limit,
-		Subject:  agentSubjectFromPrincipal(p),
 	})
 	if err != nil {
 		return nil, err
@@ -1054,14 +1135,13 @@ func (m *Manager) ListInteractions(ctx context.Context, p *principal.Principal, 
 	ctx, finish := startAgentOperation(ctx, "list_interactions")
 	defer func() { finish(err) }()
 
-	owned, err := m.findOwnedTurn(ctx, p, turnID, "")
+	owned, err := m.findAccessibleTurn(ctx, p, turnID, "", "", authorization.ProviderAgentSessionActionView)
 	if err != nil {
 		return nil, err
 	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(owned.providerName))
 	interactions, err := owned.provider.ListInteractions(ctx, coreagent.ListInteractionsRequest{
-		TurnID:  owned.turn.ID,
-		Subject: agentSubjectFromPrincipal(p),
+		TurnID: owned.turn.ID,
 	})
 	if err != nil {
 		return nil, err
@@ -1086,7 +1166,7 @@ func (m *Manager) ResolveInteraction(ctx context.Context, p *principal.Principal
 	ctx, finish := startAgentOperation(ctx, "resolve_interaction")
 	defer func() { finish(err) }()
 
-	owned, err := m.findOwnedTurn(ctx, p, turnID, "")
+	owned, err := m.findAccessibleTurn(ctx, p, turnID, "", "", authorization.ProviderAgentSessionActionEdit)
 	if err != nil {
 		return nil, err
 	}
@@ -1098,7 +1178,6 @@ func (m *Manager) ResolveInteraction(ctx context.Context, p *principal.Principal
 	interaction, err = owned.provider.ResolveInteraction(ctx, coreagent.ResolveInteractionRequest{
 		InteractionID: interactionID,
 		Resolution:    maps.Clone(resolution),
-		Subject:       agentSubjectFromPrincipal(p),
 	})
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
@@ -1152,10 +1231,19 @@ type ownedAgentSession struct {
 	session      *coreagent.Session
 }
 
-type ownedAgentTurn struct {
+type accessibleAgentSession struct {
+	providerName string
+	provider     coreagent.Provider
+	session      *coreagent.Session
+	owned        bool
+}
+
+type accessibleAgentTurn struct {
 	providerName string
 	provider     coreagent.Provider
 	turn         *coreagent.Turn
+	session      *coreagent.Session
+	sessionOwned bool
 }
 
 func (m *Manager) providerCandidates(providerName string) ([]namedAgentProvider, error) {
@@ -1220,6 +1308,285 @@ func (m *Manager) agentProviderConfigured(providerName string) bool {
 		}
 	}
 	return false
+}
+
+func (m *Manager) findAccessibleSession(ctx context.Context, p *principal.Principal, sessionID, providerName, action string) (*accessibleAgentSession, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil, core.ErrNotFound
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName != "" {
+		found, err := m.findAccessibleSessionInProviders(ctx, p, sessionID, providerName, action)
+		if err != nil {
+			return nil, err
+		}
+		m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
+		return found, nil
+	}
+	if storedRoute, ok, err := m.storedSessionRoute(ctx, sessionID); err != nil {
+		return nil, err
+	} else if ok {
+		found, findErr := m.findAccessibleSessionInProviders(ctx, p, sessionID, storedRoute.ProviderName, action)
+		if findErr == nil {
+			m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
+			return found, nil
+		}
+		if errors.Is(findErr, ErrAgentProviderNotAvailable) {
+			if m.agentProviderConfigured(storedRoute.ProviderName) {
+				return nil, findErr
+			}
+			if err := m.forgetSessionRoute(ctx, sessionID, storedRoute.ProviderName); err != nil {
+				return nil, err
+			}
+		} else if !errors.Is(findErr, core.ErrNotFound) {
+			return nil, findErr
+		}
+	}
+	if cachedRoute, ok := m.cachedSessionRoute(sessionID); ok {
+		found, err := m.findAccessibleSessionInProviders(ctx, p, sessionID, cachedRoute.ProviderName, action)
+		if err == nil {
+			m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
+			return found, nil
+		}
+		m.forgetCachedSessionRoute(sessionID, cachedRoute.ProviderName)
+		if !errors.Is(err, core.ErrNotFound) && !errors.Is(err, ErrAgentProviderNotAvailable) {
+			return nil, err
+		}
+		if errors.Is(err, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(cachedRoute.ProviderName) {
+			_ = m.forgetSessionRoute(ctx, sessionID, cachedRoute.ProviderName)
+		}
+	}
+	found, err := m.findAccessibleSessionInProviders(ctx, p, sessionID, "", action)
+	if err != nil {
+		return nil, err
+	}
+	m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
+	return found, nil
+}
+
+func (m *Manager) findAccessibleSessionInProviders(ctx context.Context, p *principal.Principal, sessionID, providerName, action string) (*accessibleAgentSession, error) {
+	candidates, err := m.providerCandidates(providerName)
+	if err != nil {
+		return nil, err
+	}
+	candidates, err = filterProviderCandidatesByTokenPermission(p, candidates, providerName)
+	if err != nil {
+		return nil, err
+	}
+	var found *accessibleAgentSession
+	authDenied := false
+	for _, candidate := range candidates {
+		if m.authorizationProvider == nil && !m.allowsAgentProvider(ctx, p, candidate.name) {
+			authDenied = true
+			continue
+		}
+		session, err := candidate.provider.GetSession(ctx, coreagent.GetSessionRequest{
+			SessionID: sessionID,
+		})
+		if err != nil {
+			if agentProviderReturnedNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		normalized, err := normalizeProviderSession(candidate.name, sessionID, session)
+		if err != nil {
+			return nil, err
+		}
+		allowed, owned := m.allowsAgentSessionAccess(ctx, p, candidate.name, normalized, action)
+		if !allowed {
+			if owned {
+				authDenied = true
+			}
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("%w: agent session %q is present in multiple providers", invocation.ErrInternal, sessionID)
+		}
+		found = &accessibleAgentSession{
+			providerName: candidate.name,
+			provider:     candidate.provider,
+			session:      normalized,
+			owned:        owned,
+		}
+	}
+	if found == nil {
+		if authDenied {
+			if providerName = strings.TrimSpace(providerName); providerName != "" {
+				return nil, fmt.Errorf("%w: %s", invocation.ErrAuthorizationDenied, providerName)
+			}
+			return nil, invocation.ErrAuthorizationDenied
+		}
+		return nil, core.ErrNotFound
+	}
+	return found, nil
+}
+
+func (m *Manager) findAccessibleTurn(ctx context.Context, p *principal.Principal, turnID, providerName, expectedSessionID, action string) (*accessibleAgentTurn, error) {
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return nil, core.ErrNotFound
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName != "" {
+		found, err := m.findAccessibleTurnInProviders(ctx, p, turnID, providerName, expectedSessionID, action)
+		if err != nil {
+			return nil, err
+		}
+		m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
+		return found, nil
+	}
+	if storedRoute, ok, err := m.storedTurnRoute(ctx, turnID); err != nil {
+		return nil, err
+	} else if ok {
+		found, findErr := m.findAccessibleTurnInProviders(ctx, p, turnID, storedRoute.ProviderName, storedRoute.SessionID, action)
+		if findErr == nil {
+			m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
+			return found, nil
+		}
+		if errors.Is(findErr, ErrAgentProviderNotAvailable) {
+			if m.agentProviderConfigured(storedRoute.ProviderName) {
+				return nil, findErr
+			}
+			if err := m.forgetTurnRoute(ctx, turnID, storedRoute.ProviderName); err != nil {
+				return nil, err
+			}
+		} else if !errors.Is(findErr, core.ErrNotFound) {
+			return nil, findErr
+		}
+	}
+	if cachedRoute, ok := m.cachedTurnRoute(turnID); ok {
+		found, err := m.findAccessibleTurnInProviders(ctx, p, turnID, cachedRoute.ProviderName, cachedRoute.SessionID, action)
+		if err == nil {
+			m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
+			return found, nil
+		}
+		m.forgetCachedTurnRoute(turnID, cachedRoute.ProviderName)
+		if !errors.Is(err, core.ErrNotFound) && !errors.Is(err, ErrAgentProviderNotAvailable) {
+			return nil, err
+		}
+		if errors.Is(err, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(cachedRoute.ProviderName) {
+			_ = m.forgetTurnRoute(ctx, turnID, cachedRoute.ProviderName)
+		}
+	}
+	found, err := m.findAccessibleTurnInProviders(ctx, p, turnID, "", expectedSessionID, action)
+	if err != nil {
+		return nil, err
+	}
+	m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
+	return found, nil
+}
+
+func (m *Manager) findAccessibleTurnInProviders(ctx context.Context, p *principal.Principal, turnID, providerName, expectedSessionID, action string) (*accessibleAgentTurn, error) {
+	candidates, err := m.providerCandidates(providerName)
+	if err != nil {
+		return nil, err
+	}
+	candidates, err = filterProviderCandidatesByTokenPermission(p, candidates, providerName)
+	if err != nil {
+		return nil, err
+	}
+	var found *accessibleAgentTurn
+	for _, candidate := range candidates {
+		turn, err := candidate.provider.GetTurn(ctx, coreagent.GetTurnRequest{
+			TurnID: turnID,
+		})
+		if err != nil {
+			if agentProviderReturnedNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		if turn == nil {
+			continue
+		}
+		sessionID := strings.TrimSpace(turn.SessionID)
+		if expectedSessionID = strings.TrimSpace(expectedSessionID); expectedSessionID != "" {
+			sessionID = expectedSessionID
+		}
+		normalized, err := normalizeProviderTurn(candidate.name, sessionID, turnID, turn)
+		if err != nil {
+			return nil, err
+		}
+		session, err := m.findAccessibleSessionInProviders(ctx, p, normalized.SessionID, candidate.name, action)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		if found != nil {
+			return nil, fmt.Errorf("%w: agent turn %q is present in multiple providers", invocation.ErrInternal, turnID)
+		}
+		found = &accessibleAgentTurn{
+			providerName: candidate.name,
+			provider:     candidate.provider,
+			turn:         normalized,
+			session:      session.session,
+			sessionOwned: session.owned,
+		}
+	}
+	if found == nil {
+		return nil, core.ErrNotFound
+	}
+	return found, nil
+}
+
+func (m *Manager) allowsAgentSessionAccess(ctx context.Context, p *principal.Principal, providerName string, session *coreagent.Session, action string) (bool, bool) {
+	owned := providerSessionOwnedBy(session, p)
+	if owned && m.allowsAgentProvider(ctx, p, providerName) {
+		return true, true
+	}
+	if m == nil || m.authorizationProvider == nil {
+		return false, owned
+	}
+	subjectID := strings.TrimSpace(principalSubjectID(principal.Canonicalized(p)))
+	if subjectID == "" {
+		return false, owned
+	}
+	action = strings.TrimSpace(action)
+	if action == "" {
+		return false, owned
+	}
+	decision, err := m.authorizationProvider.Evaluate(ctx, &core.AccessEvaluationRequest{
+		Subject: &core.SubjectRef{
+			Type: authorization.ProviderSubjectTypeSubject,
+			Id:   subjectID,
+		},
+		Action:   &core.ActionRef{Name: action},
+		Resource: agentSessionResourceRef(session.ID),
+	})
+	if err != nil {
+		return false, owned
+	}
+	return decision.GetAllowed(), owned
+}
+
+func agentSessionResourceRef(sessionID string) *core.ResourceRef {
+	return &core.ResourceRef{
+		Type: authorization.ProviderResourceTypeAgentSession,
+		Id:   strings.TrimSpace(sessionID),
+	}
+}
+
+func filterProviderCandidatesByTokenPermission(p *principal.Principal, candidates []namedAgentProvider, providerName string) ([]namedAgentProvider, error) {
+	filtered := make([]namedAgentProvider, 0, len(candidates))
+	denied := false
+	for _, candidate := range candidates {
+		if principal.AllowsProviderPermission(p, candidate.name) {
+			filtered = append(filtered, candidate)
+			continue
+		}
+		denied = true
+	}
+	if len(filtered) == 0 && denied {
+		if providerName = strings.TrimSpace(providerName); providerName != "" {
+			return nil, fmt.Errorf("%w: %s", invocation.ErrAuthorizationDenied, providerName)
+		}
+		return nil, invocation.ErrAuthorizationDenied
+	}
+	return filtered, nil
 }
 
 func (m *Manager) findOwnedSession(ctx context.Context, p *principal.Principal, sessionID, providerName string) (*ownedAgentSession, error) {
@@ -1308,107 +1675,6 @@ func (m *Manager) findOwnedSessionInProviders(ctx context.Context, p *principal.
 			providerName: candidate.name,
 			provider:     candidate.provider,
 			session:      normalized,
-		}
-	}
-	if found == nil {
-		return nil, core.ErrNotFound
-	}
-	return found, nil
-}
-
-func (m *Manager) findOwnedTurn(ctx context.Context, p *principal.Principal, turnID, providerName string) (*ownedAgentTurn, error) {
-	turnID = strings.TrimSpace(turnID)
-	if turnID == "" {
-		return nil, core.ErrNotFound
-	}
-	providerName = strings.TrimSpace(providerName)
-	if providerName != "" {
-		found, err := m.findOwnedTurnInProviders(ctx, p, turnID, providerName, "")
-		if err != nil {
-			return nil, err
-		}
-		m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
-		return found, nil
-	}
-	if storedRoute, ok, err := m.storedTurnRoute(ctx, turnID); err != nil {
-		return nil, err
-	} else if ok {
-		found, findErr := m.findOwnedTurnInProviders(ctx, p, turnID, storedRoute.ProviderName, storedRoute.SessionID)
-		if findErr == nil {
-			m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
-			return found, nil
-		}
-		if errors.Is(findErr, ErrAgentProviderNotAvailable) {
-			if m.agentProviderConfigured(storedRoute.ProviderName) {
-				return nil, findErr
-			}
-			if err := m.forgetTurnRoute(ctx, turnID, storedRoute.ProviderName); err != nil {
-				return nil, err
-			}
-		} else if !errors.Is(findErr, core.ErrNotFound) {
-			return nil, findErr
-		}
-	}
-	if cachedRoute, ok := m.cachedTurnRoute(turnID); ok {
-		found, err := m.findOwnedTurnInProviders(ctx, p, turnID, cachedRoute.ProviderName, cachedRoute.SessionID)
-		if err == nil {
-			m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
-			return found, nil
-		}
-		m.forgetCachedTurnRoute(turnID, cachedRoute.ProviderName)
-		if !errors.Is(err, core.ErrNotFound) && !errors.Is(err, ErrAgentProviderNotAvailable) {
-			return nil, err
-		}
-		if errors.Is(err, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(cachedRoute.ProviderName) {
-			_ = m.forgetTurnRoute(ctx, turnID, cachedRoute.ProviderName)
-		}
-	}
-	found, err := m.findOwnedTurnInProviders(ctx, p, turnID, "", "")
-	if err != nil {
-		return nil, err
-	}
-	m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
-	return found, nil
-}
-
-func (m *Manager) findOwnedTurnInProviders(ctx context.Context, p *principal.Principal, turnID, providerName, expectedSessionID string) (*ownedAgentTurn, error) {
-	candidates, err := m.authorizedProviderCandidates(ctx, p, providerName)
-	if err != nil {
-		return nil, err
-	}
-	var found *ownedAgentTurn
-	for _, candidate := range candidates {
-		turn, err := candidate.provider.GetTurn(ctx, coreagent.GetTurnRequest{
-			TurnID:  turnID,
-			Subject: agentSubjectFromPrincipal(p),
-		})
-		if err != nil {
-			if agentProviderReturnedNotFound(err) {
-				continue
-			}
-			return nil, err
-		}
-		if turn == nil {
-			continue
-		}
-		sessionID := strings.TrimSpace(turn.SessionID)
-		if expectedSessionID = strings.TrimSpace(expectedSessionID); expectedSessionID != "" {
-			sessionID = expectedSessionID
-		}
-		normalized, err := normalizeProviderTurn(candidate.name, sessionID, turnID, turn)
-		if err != nil {
-			return nil, err
-		}
-		if !providerTurnOwnedBy(normalized, p) {
-			continue
-		}
-		if found != nil {
-			return nil, fmt.Errorf("%w: agent turn %q is present in multiple providers", invocation.ErrInternal, turnID)
-		}
-		found = &ownedAgentTurn{
-			providerName: candidate.name,
-			provider:     candidate.provider,
-			turn:         normalized,
 		}
 	}
 	if found == nil {

--- a/gestaltd/services/authorization/provider_backed.go
+++ b/gestaltd/services/authorization/provider_backed.go
@@ -666,6 +666,14 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 				continue
 			}
 			addDesiredRelationship(desired, rel)
+		case resourceTypeAgentSession:
+			if strings.TrimSpace(rel.GetResource().GetId()) == "" || strings.TrimSpace(rel.GetRelation()) != relationAgentSessionEditor {
+				continue
+			}
+			if rel.GetSubject() == nil || strings.TrimSpace(rel.GetSubject().GetType()) != subjectTypeSubject || strings.TrimSpace(rel.GetSubject().GetId()) == "" {
+				continue
+			}
+			addDesiredRelationship(desired, rel)
 		}
 	}
 

--- a/gestaltd/services/authorization/provider_schema.go
+++ b/gestaltd/services/authorization/provider_schema.go
@@ -15,8 +15,12 @@ const (
 	ProviderResourceTypeAdminDynamic                   = "admin_dynamic"
 	ProviderResourceTypeExternalIdentity               = "external_identity"
 	ProviderResourceTypeManagedSubject                 = "managed_subject"
+	ProviderResourceTypeAgentSession                   = "agent_session"
 	ProviderResourceIDAdminDynamicGlobal               = "global"
 	ProviderExternalIdentityRelationAssume             = "assume"
+	ProviderAgentSessionRelationEditor                 = "editor"
+	ProviderAgentSessionActionView                     = "view"
+	ProviderAgentSessionActionEdit                     = "edit"
 	ProviderManagedSubjectRelationViewer               = "viewer"
 	ProviderManagedSubjectRelationEditor               = "editor"
 	ProviderManagedSubjectRelationAdmin                = "admin"
@@ -39,8 +43,10 @@ const (
 	resourceTypeAdminDynamic       = ProviderResourceTypeAdminDynamic
 	resourceTypeExternalIdentity   = ProviderResourceTypeExternalIdentity
 	resourceTypeManagedSubject     = ProviderResourceTypeManagedSubject
+	resourceTypeAgentSession       = ProviderResourceTypeAgentSession
 	resourceIDAdminDynamicGlobal   = ProviderResourceIDAdminDynamicGlobal
 	relationExternalIdentityAssume = ProviderExternalIdentityRelationAssume
+	relationAgentSessionEditor     = ProviderAgentSessionRelationEditor
 	relationManagedSubjectViewer   = ProviderManagedSubjectRelationViewer
 	relationManagedSubjectEditor   = ProviderManagedSubjectRelationEditor
 	relationManagedSubjectAdmin    = ProviderManagedSubjectRelationAdmin
@@ -60,7 +66,8 @@ func IsManagedProviderRelationship(rel *core.Relationship) bool {
 		ProviderResourceTypeAdminPolicyStatic,
 		ProviderResourceTypeAdminDynamic,
 		ProviderResourceTypeExternalIdentity,
-		ProviderResourceTypeManagedSubject:
+		ProviderResourceTypeManagedSubject,
+		ProviderResourceTypeAgentSession:
 		return true
 	default:
 		return false
@@ -153,6 +160,19 @@ func buildProviderAuthorizationModel(state providerBackedRoleState) *core.Author
 				{Name: ProviderManagedSubjectActionGrant, Relations: []string{relationManagedSubjectAdmin}},
 				{Name: ProviderManagedSubjectActionConnect, Relations: []string{relationManagedSubjectEditor, relationManagedSubjectAdmin}},
 				{Name: ProviderManagedSubjectActionManageExternalIdentity, Relations: []string{relationManagedSubjectAdmin}},
+			},
+		},
+	)
+	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
+		&core.AuthorizationModelResourceType{
+			Name: resourceTypeAgentSession,
+			Relations: []*core.AuthorizationModelRelation{{
+				Name:         relationAgentSessionEditor,
+				SubjectTypes: []string{subjectTypeSubject},
+			}},
+			Actions: []*core.AuthorizationModelAction{
+				{Name: ProviderAgentSessionActionView, Relations: []string{relationAgentSessionEditor}},
+				{Name: ProviderAgentSessionActionEdit, Relations: []string{relationAgentSessionEditor}},
 			},
 		},
 	)

--- a/sdk/proto/buf.rust.gen.yaml
+++ b/sdk/proto/buf.rust.gen.yaml
@@ -5,6 +5,7 @@ inputs:
     paths:
       - v1/agent.proto
       - v1/authentication.proto
+      - v1/authorization.proto
       - v1/plugin.proto
       - v1/pluginruntime.proto
       - v1/runtime.proto

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -181,8 +181,11 @@ _AUTHORIZATION_PROTOCOL_EXPORTS = (
     "AuthorizationResource",
     "AuthorizationSubject",
     "ReadRelationshipsRequest",
+    "Relationship",
+    "RelationshipKey",
     "ResourceSearchRequest",
     "SubjectSearchRequest",
+    "WriteRelationshipsRequest",
 )
 
 _WORKFLOW_PROTOCOL_EXPORTS = (

--- a/sdk/python/gestalt/_authorization.py
+++ b/sdk/python/gestalt/_authorization.py
@@ -1,4 +1,4 @@
-"""Read-only transport client for the host authorization provider."""
+"""Transport client for the host authorization provider."""
 
 from __future__ import annotations
 
@@ -83,8 +83,26 @@ def ReadRelationshipsRequest(*args: Any, **kwargs: Any) -> Any:
     return authorization_pb2.ReadRelationshipsRequest(*args, **kwargs)
 
 
+def Relationship(*args: Any, **kwargs: Any) -> Any:
+    """Create an authorization relationship value."""
+
+    return authorization_pb2.Relationship(*args, **kwargs)
+
+
+def RelationshipKey(*args: Any, **kwargs: Any) -> Any:
+    """Create an authorization relationship key value."""
+
+    return authorization_pb2.RelationshipKey(*args, **kwargs)
+
+
+def WriteRelationshipsRequest(*args: Any, **kwargs: Any) -> Any:
+    """Create an authorization relationship-write request."""
+
+    return authorization_pb2.WriteRelationshipsRequest(*args, **kwargs)
+
+
 class AuthorizationClient:
-    """Read-only transport client for the host authorization provider."""
+    """Transport client for the host authorization provider."""
 
     def __init__(
         self,
@@ -167,6 +185,16 @@ class AuthorizationClient:
             )
         )
 
+    def write_relationships(self, request: Any) -> None:
+        """Write authorization relationships."""
+
+        self._stub.WriteRelationships(
+            _authorization_message(
+                request,
+                authorization_pb2.WriteRelationshipsRequest,
+            )
+        )
+
     def get_metadata(self) -> Any:
         """Return host authorization provider metadata."""
 
@@ -180,7 +208,7 @@ class AuthorizationClient:
 
 
 def Authorization() -> AuthorizationClient:
-    """Return a cached read-only client for the host authorization provider."""
+    """Return a cached client for the host authorization provider."""
 
     target = _resolve_authorization_socket_target()
     token = os.environ.get(ENV_AUTHORIZATION_SOCKET_TOKEN, "").strip()

--- a/sdk/python/tests/test_authorization_transport.py
+++ b/sdk/python/tests/test_authorization_transport.py
@@ -1,0 +1,84 @@
+"""Transport-backed Authorization SDK tests over real sockets."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from concurrent import futures
+from typing import Any
+
+import grpc
+from google.protobuf import empty_pb2 as _empty_pb2
+
+from gestalt import (
+    AuthorizationClient,
+    AuthorizationResource,
+    AuthorizationSubject,
+    Relationship,
+    WriteRelationshipsRequest,
+)
+from gestalt.testing import authorization_pb2, authorization_pb2_grpc
+
+empty_pb2: Any = _empty_pb2
+
+
+class _AuthorizationProvider(authorization_pb2_grpc.AuthorizationProviderServicer):
+    def __init__(self) -> None:
+        self.writes: list[Any] = []
+
+    def WriteRelationships(self, request: Any, context: grpc.ServicerContext) -> Any:
+        self.writes.append(request)
+        return empty_pb2.Empty()
+
+
+class AuthorizationTransportTest(unittest.TestCase):
+    def test_write_relationships_sends_request_over_transport(self) -> None:
+        provider = _AuthorizationProvider()
+        server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+        authorization_pb2_grpc.add_AuthorizationProviderServicer_to_server(
+            provider,
+            server,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = f"{tmpdir}/authorization.sock"
+            server.add_insecure_port(f"unix:{socket_path}")
+            server.start()
+            try:
+                client = AuthorizationClient(f"unix://{socket_path}")
+                client.write_relationships(
+                    WriteRelationshipsRequest(
+                        writes=[
+                            Relationship(
+                                subject=AuthorizationSubject(
+                                    type="subject",
+                                    id="user:shared",
+                                ),
+                                relation="editor",
+                                resource=AuthorizationResource(
+                                    type="agent_session",
+                                    id="session-1",
+                                ),
+                            )
+                        ]
+                    )
+                )
+                client.close()
+            finally:
+                server.stop(grace=0)
+
+        self.assertEqual(len(provider.writes), 1)
+        self.assertEqual(
+            provider.writes[0].writes[0],
+            authorization_pb2.Relationship(
+                subject=authorization_pb2.Subject(type="subject", id="user:shared"),
+                relation="editor",
+                resource=authorization_pb2.Resource(
+                    type="agent_session",
+                    id="session-1",
+                ),
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.rs
+++ b/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.rs
@@ -1504,6 +1504,254 @@ pub struct AuthSessionSettings {
     #[prost(int64, tag = "1")]
     pub session_ttl_seconds: i64,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Subject {
+    #[prost(string, tag = "1")]
+    pub r#type: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub properties: ::core::option::Option<::prost_types::Struct>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Resource {
+    #[prost(string, tag = "1")]
+    pub r#type: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub properties: ::core::option::Option<::prost_types::Struct>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Action {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub properties: ::core::option::Option<::prost_types::Struct>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AccessEvaluationRequest {
+    #[prost(message, optional, tag = "1")]
+    pub subject: ::core::option::Option<Subject>,
+    #[prost(message, optional, tag = "2")]
+    pub action: ::core::option::Option<Action>,
+    #[prost(message, optional, tag = "3")]
+    pub resource: ::core::option::Option<Resource>,
+    #[prost(message, optional, tag = "4")]
+    pub context: ::core::option::Option<::prost_types::Struct>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AccessDecision {
+    #[prost(bool, tag = "1")]
+    pub allowed: bool,
+    #[prost(message, optional, tag = "2")]
+    pub context: ::core::option::Option<::prost_types::Struct>,
+    #[prost(string, tag = "3")]
+    pub model_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AccessEvaluationsRequest {
+    #[prost(message, repeated, tag = "1")]
+    pub requests: ::prost::alloc::vec::Vec<AccessEvaluationRequest>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AccessEvaluationsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub decisions: ::prost::alloc::vec::Vec<AccessDecision>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ResourceSearchRequest {
+    #[prost(message, optional, tag = "1")]
+    pub subject: ::core::option::Option<Subject>,
+    #[prost(message, optional, tag = "2")]
+    pub action: ::core::option::Option<Action>,
+    #[prost(string, tag = "3")]
+    pub resource_type: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "4")]
+    pub context: ::core::option::Option<::prost_types::Struct>,
+    #[prost(int32, tag = "5")]
+    pub page_size: i32,
+    #[prost(string, tag = "6")]
+    pub page_token: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ResourceSearchResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub resources: ::prost::alloc::vec::Vec<Resource>,
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub model_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SubjectSearchRequest {
+    #[prost(message, optional, tag = "1")]
+    pub resource: ::core::option::Option<Resource>,
+    #[prost(message, optional, tag = "2")]
+    pub action: ::core::option::Option<Action>,
+    #[prost(string, tag = "3")]
+    pub subject_type: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "4")]
+    pub context: ::core::option::Option<::prost_types::Struct>,
+    #[prost(int32, tag = "5")]
+    pub page_size: i32,
+    #[prost(string, tag = "6")]
+    pub page_token: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SubjectSearchResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub subjects: ::prost::alloc::vec::Vec<Subject>,
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub model_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionSearchRequest {
+    #[prost(message, optional, tag = "1")]
+    pub subject: ::core::option::Option<Subject>,
+    #[prost(message, optional, tag = "2")]
+    pub resource: ::core::option::Option<Resource>,
+    #[prost(message, optional, tag = "3")]
+    pub context: ::core::option::Option<::prost_types::Struct>,
+    #[prost(int32, tag = "4")]
+    pub page_size: i32,
+    #[prost(string, tag = "5")]
+    pub page_token: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionSearchResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub actions: ::prost::alloc::vec::Vec<Action>,
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub model_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AuthorizationMetadata {
+    #[prost(string, repeated, tag = "1")]
+    pub capabilities: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, tag = "2")]
+    pub active_model_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Relationship {
+    #[prost(message, optional, tag = "1")]
+    pub subject: ::core::option::Option<Subject>,
+    #[prost(string, tag = "2")]
+    pub relation: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub resource: ::core::option::Option<Resource>,
+    #[prost(message, optional, tag = "4")]
+    pub properties: ::core::option::Option<::prost_types::Struct>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RelationshipKey {
+    #[prost(message, optional, tag = "1")]
+    pub subject: ::core::option::Option<Subject>,
+    #[prost(string, tag = "2")]
+    pub relation: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub resource: ::core::option::Option<Resource>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadRelationshipsRequest {
+    #[prost(message, optional, tag = "1")]
+    pub subject: ::core::option::Option<Subject>,
+    #[prost(string, tag = "2")]
+    pub relation: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub resource: ::core::option::Option<Resource>,
+    #[prost(int32, tag = "4")]
+    pub page_size: i32,
+    #[prost(string, tag = "5")]
+    pub page_token: ::prost::alloc::string::String,
+    #[prost(string, tag = "6")]
+    pub model_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadRelationshipsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub relationships: ::prost::alloc::vec::Vec<Relationship>,
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub model_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WriteRelationshipsRequest {
+    #[prost(message, repeated, tag = "1")]
+    pub writes: ::prost::alloc::vec::Vec<Relationship>,
+    #[prost(message, repeated, tag = "2")]
+    pub deletes: ::prost::alloc::vec::Vec<RelationshipKey>,
+    #[prost(string, tag = "3")]
+    pub model_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthorizationModel {
+    #[prost(int32, tag = "1")]
+    pub version: i32,
+    #[prost(message, repeated, tag = "2")]
+    pub resource_types: ::prost::alloc::vec::Vec<AuthorizationModelResourceType>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthorizationModelResourceType {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub relations: ::prost::alloc::vec::Vec<AuthorizationModelRelation>,
+    #[prost(message, repeated, tag = "3")]
+    pub actions: ::prost::alloc::vec::Vec<AuthorizationModelAction>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AuthorizationModelRelation {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(string, repeated, tag = "2")]
+    pub subject_types: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AuthorizationModelAction {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(string, repeated, tag = "2")]
+    pub relations: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AuthorizationModelRef {
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub version: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub created_at: ::core::option::Option<::prost_types::Timestamp>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetActiveModelResponse {
+    #[prost(message, optional, tag = "1")]
+    pub model: ::core::option::Option<AuthorizationModelRef>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ListModelsRequest {
+    #[prost(int32, tag = "1")]
+    pub page_size: i32,
+    #[prost(string, tag = "2")]
+    pub page_token: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListModelsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub models: ::prost::alloc::vec::Vec<AuthorizationModelRef>,
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WriteModelRequest {
+    #[prost(message, optional, tag = "1")]
+    pub model: ::core::option::Option<AuthorizationModel>,
+}
 /// CacheSetEntry is one key/value pair written by SetMany.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CacheSetEntry {

--- a/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.tonic.rs
+++ b/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.tonic.rs
@@ -3973,6 +3973,946 @@ pub mod authentication_provider_server {
     }
 }
 /// Generated client implementations.
+pub mod authorization_provider_client {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value
+    )]
+    use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
+    ///
+    #[derive(Debug, Clone)]
+    pub struct AuthorizationProviderClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl AuthorizationProviderClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> AuthorizationProviderClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::Body>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> AuthorizationProviderClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                    http::Request<tonic::body::Body>,
+                    Response = http::Response<
+                        <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                    >,
+                >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
+        {
+            AuthorizationProviderClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        ///
+        pub async fn evaluate(
+            &mut self,
+            request: impl tonic::IntoRequest<super::AccessEvaluationRequest>,
+        ) -> std::result::Result<tonic::Response<super::AccessDecision>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/gestalt.provider.v1.AuthorizationProvider/Evaluate",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "gestalt.provider.v1.AuthorizationProvider",
+                "Evaluate",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        pub async fn evaluate_many(
+            &mut self,
+            request: impl tonic::IntoRequest<super::AccessEvaluationsRequest>,
+        ) -> std::result::Result<tonic::Response<super::AccessEvaluationsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/gestalt.provider.v1.AuthorizationProvider/EvaluateMany",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "gestalt.provider.v1.AuthorizationProvider",
+                "EvaluateMany",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        pub async fn search_resources(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ResourceSearchRequest>,
+        ) -> std::result::Result<tonic::Response<super::ResourceSearchResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/gestalt.provider.v1.AuthorizationProvider/SearchResources",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "gestalt.provider.v1.AuthorizationProvider",
+                "SearchResources",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        pub async fn search_subjects(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SubjectSearchRequest>,
+        ) -> std::result::Result<tonic::Response<super::SubjectSearchResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/gestalt.provider.v1.AuthorizationProvider/SearchSubjects",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "gestalt.provider.v1.AuthorizationProvider",
+                "SearchSubjects",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        pub async fn search_actions(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ActionSearchRequest>,
+        ) -> std::result::Result<tonic::Response<super::ActionSearchResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/gestalt.provider.v1.AuthorizationProvider/SearchActions",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "gestalt.provider.v1.AuthorizationProvider",
+                "SearchActions",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        pub async fn get_metadata(
+            &mut self,
+            request: impl tonic::IntoRequest<()>,
+        ) -> std::result::Result<tonic::Response<super::AuthorizationMetadata>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/gestalt.provider.v1.AuthorizationProvider/GetMetadata",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "gestalt.provider.v1.AuthorizationProvider",
+                "GetMetadata",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        pub async fn read_relationships(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ReadRelationshipsRequest>,
+        ) -> std::result::Result<tonic::Response<super::ReadRelationshipsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/gestalt.provider.v1.AuthorizationProvider/ReadRelationships",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "gestalt.provider.v1.AuthorizationProvider",
+                "ReadRelationships",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        pub async fn write_relationships(
+            &mut self,
+            request: impl tonic::IntoRequest<super::WriteRelationshipsRequest>,
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/gestalt.provider.v1.AuthorizationProvider/WriteRelationships",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "gestalt.provider.v1.AuthorizationProvider",
+                "WriteRelationships",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        pub async fn get_active_model(
+            &mut self,
+            request: impl tonic::IntoRequest<()>,
+        ) -> std::result::Result<tonic::Response<super::GetActiveModelResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/gestalt.provider.v1.AuthorizationProvider/GetActiveModel",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "gestalt.provider.v1.AuthorizationProvider",
+                "GetActiveModel",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        pub async fn list_models(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListModelsRequest>,
+        ) -> std::result::Result<tonic::Response<super::ListModelsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/gestalt.provider.v1.AuthorizationProvider/ListModels",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "gestalt.provider.v1.AuthorizationProvider",
+                "ListModels",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        pub async fn write_model(
+            &mut self,
+            request: impl tonic::IntoRequest<super::WriteModelRequest>,
+        ) -> std::result::Result<tonic::Response<super::AuthorizationModelRef>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/gestalt.provider.v1.AuthorizationProvider/WriteModel",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "gestalt.provider.v1.AuthorizationProvider",
+                "WriteModel",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod authorization_provider_server {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value
+    )]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with AuthorizationProviderServer.
+    #[async_trait]
+    pub trait AuthorizationProvider: std::marker::Send + std::marker::Sync + 'static {
+        ///
+        async fn evaluate(
+            &self,
+            request: tonic::Request<super::AccessEvaluationRequest>,
+        ) -> std::result::Result<tonic::Response<super::AccessDecision>, tonic::Status>;
+        ///
+        async fn evaluate_many(
+            &self,
+            request: tonic::Request<super::AccessEvaluationsRequest>,
+        ) -> std::result::Result<tonic::Response<super::AccessEvaluationsResponse>, tonic::Status>;
+        ///
+        async fn search_resources(
+            &self,
+            request: tonic::Request<super::ResourceSearchRequest>,
+        ) -> std::result::Result<tonic::Response<super::ResourceSearchResponse>, tonic::Status>;
+        ///
+        async fn search_subjects(
+            &self,
+            request: tonic::Request<super::SubjectSearchRequest>,
+        ) -> std::result::Result<tonic::Response<super::SubjectSearchResponse>, tonic::Status>;
+        ///
+        async fn search_actions(
+            &self,
+            request: tonic::Request<super::ActionSearchRequest>,
+        ) -> std::result::Result<tonic::Response<super::ActionSearchResponse>, tonic::Status>;
+        ///
+        async fn get_metadata(
+            &self,
+            request: tonic::Request<()>,
+        ) -> std::result::Result<tonic::Response<super::AuthorizationMetadata>, tonic::Status>;
+        ///
+        async fn read_relationships(
+            &self,
+            request: tonic::Request<super::ReadRelationshipsRequest>,
+        ) -> std::result::Result<tonic::Response<super::ReadRelationshipsResponse>, tonic::Status>;
+        ///
+        async fn write_relationships(
+            &self,
+            request: tonic::Request<super::WriteRelationshipsRequest>,
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status>;
+        ///
+        async fn get_active_model(
+            &self,
+            request: tonic::Request<()>,
+        ) -> std::result::Result<tonic::Response<super::GetActiveModelResponse>, tonic::Status>;
+        ///
+        async fn list_models(
+            &self,
+            request: tonic::Request<super::ListModelsRequest>,
+        ) -> std::result::Result<tonic::Response<super::ListModelsResponse>, tonic::Status>;
+        ///
+        async fn write_model(
+            &self,
+            request: tonic::Request<super::WriteModelRequest>,
+        ) -> std::result::Result<tonic::Response<super::AuthorizationModelRef>, tonic::Status>;
+    }
+    ///
+    #[derive(Debug)]
+    pub struct AuthorizationProviderServer<T> {
+        inner: Arc<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    impl<T> AuthorizationProviderServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for AuthorizationProviderServer<T>
+    where
+        T: AuthorizationProvider,
+        B: Body + std::marker::Send + 'static,
+        B::Error: Into<StdError> + std::marker::Send + 'static,
+    {
+        type Response = http::Response<tonic::body::Body>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            match req.uri().path() {
+                "/gestalt.provider.v1.AuthorizationProvider/Evaluate" => {
+                    #[allow(non_camel_case_types)]
+                    struct EvaluateSvc<T: AuthorizationProvider>(pub Arc<T>);
+                    impl<T: AuthorizationProvider>
+                        tonic::server::UnaryService<super::AccessEvaluationRequest>
+                        for EvaluateSvc<T>
+                    {
+                        type Response = super::AccessDecision;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::AccessEvaluationRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AuthorizationProvider>::evaluate(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = EvaluateSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/gestalt.provider.v1.AuthorizationProvider/EvaluateMany" => {
+                    #[allow(non_camel_case_types)]
+                    struct EvaluateManySvc<T: AuthorizationProvider>(pub Arc<T>);
+                    impl<T: AuthorizationProvider>
+                        tonic::server::UnaryService<super::AccessEvaluationsRequest>
+                        for EvaluateManySvc<T>
+                    {
+                        type Response = super::AccessEvaluationsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::AccessEvaluationsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AuthorizationProvider>::evaluate_many(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = EvaluateManySvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/gestalt.provider.v1.AuthorizationProvider/SearchResources" => {
+                    #[allow(non_camel_case_types)]
+                    struct SearchResourcesSvc<T: AuthorizationProvider>(pub Arc<T>);
+                    impl<T: AuthorizationProvider>
+                        tonic::server::UnaryService<super::ResourceSearchRequest>
+                        for SearchResourcesSvc<T>
+                    {
+                        type Response = super::ResourceSearchResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ResourceSearchRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AuthorizationProvider>::search_resources(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = SearchResourcesSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/gestalt.provider.v1.AuthorizationProvider/SearchSubjects" => {
+                    #[allow(non_camel_case_types)]
+                    struct SearchSubjectsSvc<T: AuthorizationProvider>(pub Arc<T>);
+                    impl<T: AuthorizationProvider>
+                        tonic::server::UnaryService<super::SubjectSearchRequest>
+                        for SearchSubjectsSvc<T>
+                    {
+                        type Response = super::SubjectSearchResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SubjectSearchRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AuthorizationProvider>::search_subjects(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = SearchSubjectsSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/gestalt.provider.v1.AuthorizationProvider/SearchActions" => {
+                    #[allow(non_camel_case_types)]
+                    struct SearchActionsSvc<T: AuthorizationProvider>(pub Arc<T>);
+                    impl<T: AuthorizationProvider>
+                        tonic::server::UnaryService<super::ActionSearchRequest>
+                        for SearchActionsSvc<T>
+                    {
+                        type Response = super::ActionSearchResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ActionSearchRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AuthorizationProvider>::search_actions(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = SearchActionsSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/gestalt.provider.v1.AuthorizationProvider/GetMetadata" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetMetadataSvc<T: AuthorizationProvider>(pub Arc<T>);
+                    impl<T: AuthorizationProvider> tonic::server::UnaryService<()> for GetMetadataSvc<T> {
+                        type Response = super::AuthorizationMetadata;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<()>) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AuthorizationProvider>::get_metadata(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetMetadataSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/gestalt.provider.v1.AuthorizationProvider/ReadRelationships" => {
+                    #[allow(non_camel_case_types)]
+                    struct ReadRelationshipsSvc<T: AuthorizationProvider>(pub Arc<T>);
+                    impl<T: AuthorizationProvider>
+                        tonic::server::UnaryService<super::ReadRelationshipsRequest>
+                        for ReadRelationshipsSvc<T>
+                    {
+                        type Response = super::ReadRelationshipsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ReadRelationshipsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AuthorizationProvider>::read_relationships(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ReadRelationshipsSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/gestalt.provider.v1.AuthorizationProvider/WriteRelationships" => {
+                    #[allow(non_camel_case_types)]
+                    struct WriteRelationshipsSvc<T: AuthorizationProvider>(pub Arc<T>);
+                    impl<T: AuthorizationProvider>
+                        tonic::server::UnaryService<super::WriteRelationshipsRequest>
+                        for WriteRelationshipsSvc<T>
+                    {
+                        type Response = ();
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::WriteRelationshipsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AuthorizationProvider>::write_relationships(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = WriteRelationshipsSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/gestalt.provider.v1.AuthorizationProvider/GetActiveModel" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetActiveModelSvc<T: AuthorizationProvider>(pub Arc<T>);
+                    impl<T: AuthorizationProvider> tonic::server::UnaryService<()> for GetActiveModelSvc<T> {
+                        type Response = super::GetActiveModelResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<()>) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AuthorizationProvider>::get_active_model(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetActiveModelSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/gestalt.provider.v1.AuthorizationProvider/ListModels" => {
+                    #[allow(non_camel_case_types)]
+                    struct ListModelsSvc<T: AuthorizationProvider>(pub Arc<T>);
+                    impl<T: AuthorizationProvider>
+                        tonic::server::UnaryService<super::ListModelsRequest> for ListModelsSvc<T>
+                    {
+                        type Response = super::ListModelsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ListModelsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AuthorizationProvider>::list_models(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ListModelsSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/gestalt.provider.v1.AuthorizationProvider/WriteModel" => {
+                    #[allow(non_camel_case_types)]
+                    struct WriteModelSvc<T: AuthorizationProvider>(pub Arc<T>);
+                    impl<T: AuthorizationProvider>
+                        tonic::server::UnaryService<super::WriteModelRequest> for WriteModelSvc<T>
+                    {
+                        type Response = super::AuthorizationModelRef;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::WriteModelRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AuthorizationProvider>::write_model(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = WriteModelSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(tonic::body::Body::default());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
+            }
+        }
+    }
+    impl<T> Clone for AuthorizationProviderServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    /// Generated gRPC service name
+    pub const SERVICE_NAME: &str = "gestalt.provider.v1.AuthorizationProvider";
+    impl<T> tonic::server::NamedService for AuthorizationProviderServer<T> {
+        const NAME: &'static str = SERVICE_NAME;
+    }
+}
+/// Generated client implementations.
 pub mod cache_client {
     #![allow(
         unused_variables,


### PR DESCRIPTION
## Summary
- Adds `agent_session` to the provider-backed authorization model with an `editor` relation that grants `view` and `edit`.
- Lets the agent manager authorize exact session and turn access through `AuthorizationProvider` while keeping provider-level list access owner-scoped.
- Preserves manual `agent_session#editor` grants across provider-backed authorization reloads.
- Exposes Python SDK relationship-write helpers so providers can grant shares through the existing authorization transport.

## Interface Changes
- New/changed interface:
  - `agent_session` authorization resource type.
  - `agent_session#editor` relation for `subject` principals.
  - `view` and `edit` actions on `agent_session`.
  - `AuthorizationClient.write_relationships(...)` plus `Relationship`, `RelationshipKey`, and `WriteRelationshipsRequest` SDK constructors.
- Example usage:
```python
auth.write_relationships(
    gestalt.WriteRelationshipsRequest(
        writes=[
            gestalt.Relationship(
                subject=gestalt.AuthorizationSubject(type="subject", id="user:123"),
                relation="editor",
                resource=gestalt.AuthorizationResource(type="agent_session", id=session_id),
            )
        ]
    )
)
```
- Agent manager behavior:
  - `GET /api/v1/agent/sessions/{id}`, `GET /api/v1/agent/turns/{id}`, and turn/event/interaction reads allow `agent_session:view`.
  - creating turns and resolving interactions require `agent_session:edit`.
  - session metadata updates stay owner-only.
  - session owners may cancel any turn in their session; shared editors may cancel only turns they created.

## Functional/Integration Tests
- Tests added or augmented:
  - Agent manager HTTP integration test for shared session listing, exact session/turn reads, turn listing, interaction resolution, turn creation, update denial, and cancel rules.
  - Provider-backed authorization reload test preserving `agent_session#editor` grants.
  - Python SDK gRPC transport test for `write_relationships`.
- Contract boundary covered:
  - Gestaltd HTTP agent APIs, AgentProvider exact lookup behavior, AuthorizationProvider evaluate/search/write behavior, and Python SDK authorization transport.
- Commands run:
  - `cd gestaltd && go test ./internal/bootstrap ./services/agents/agentmanager ./services/authorization ./internal/server -run 'TestAuthorizationProviderBackedReloadPreservesAgentSessionGrants|TestAgentSessionSharingAuthorizesExactSessionAccess'`
  - `cd sdk/python && uv run pytest tests/test_authorization_transport.py`
  - `cd sdk/python && uv run ruff check gestalt/_authorization.py gestalt/__init__.py tests/test_authorization_transport.py`

## Stack
- Follow-up consumer PR in `gestalt-providers` grants these relationships from Slack and updates UI/provider contracts.