### PR TITLE
Accept native JSON inputs in SDK invokers

### DIFF
--- a/sdk/go/agent_host.go
+++ b/sdk/go/agent_host.go
@@ -40,7 +40,7 @@ type AgentHostExecuteToolInput struct {
 	TurnID         string
 	ToolCallID     string
 	ToolID         string
-	Arguments      map[string]any
+	Arguments      any
 	RunGrant       string
 	IdempotencyKey string
 }
@@ -92,7 +92,7 @@ func (c *AgentHostClient) ExecuteToolForTurn(ctx context.Context, input AgentHos
 	var arguments *structpb.Struct
 	if input.Arguments != nil {
 		var err error
-		arguments, err = StructFromMap(input.Arguments)
+		arguments, err = StructFromAny(input.Arguments)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/agent_host_transport_test.go
+++ b/sdk/go/agent_host_transport_test.go
@@ -13,6 +13,10 @@ import (
 	gproto "google.golang.org/protobuf/proto"
 )
 
+type agentToolArguments struct {
+	Query string `json:"query"`
+}
+
 type agentHostTransportHarness struct {
 	proto.UnimplementedAgentHostServer
 
@@ -104,7 +108,7 @@ func TestTransport_AgentHostUnixSocket(t *testing.T) {
 		TurnID:         "turn-1",
 		ToolCallID:     "call-1",
 		ToolID:         "tool-1",
-		Arguments:      map[string]any{"query": "Ada Lovelace"},
+		Arguments:      agentToolArguments{Query: "Ada Lovelace"},
 		RunGrant:       "run-grant-1",
 		IdempotencyKey: "tool-call-key-1",
 	})

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -70,7 +70,12 @@
 // protobuf bindings. StructFromMap, StructFromAny, ValueFromAny,
 // ValuesFromMap, TimestampFromTime, TimestampFromTimePtr, and the IndexedDB
 // codec helpers convert between native Go values and protobuf well-known or
-// IndexedDB wire types without importing internal packages.
+// IndexedDB wire types without importing internal packages. StructFromAny also
+// accepts structs, string-keyed map aliases, and pointers to either form; it
+// rejects time.Time, json.Marshaler values, non-string map keys, cycles, and
+// non-finite numbers in generic Struct payloads. Embedded struct fields are
+// not flattened like encoding/json; anonymous embedded fields must have an
+// explicit json tag name.
 //
 // See https://gestaltd.ai/reference/go-sdk for the Go SDK guide.
 // See https://gestaltd.ai/custom-providers/plugins for the full typed plugin

--- a/sdk/go/invoker.go
+++ b/sdk/go/invoker.go
@@ -230,16 +230,19 @@ func (c *InvokerClient) Close() error {
 }
 
 // Invoke calls one operation on another plugin.
-func (c *InvokerClient) Invoke(ctx context.Context, plugin, operation string, params map[string]any, opts *InvokeOptions) (*OperationResult, error) {
+func (c *InvokerClient) Invoke(ctx context.Context, plugin, operation string, params any, opts *InvokeOptions) (*OperationResult, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("plugin invoker: client is not initialized")
 	}
 	if params == nil {
 		params = map[string]any{}
 	}
-	msg, err := structpb.NewStruct(params)
+	msg, err := StructFromAny(params)
 	if err != nil {
 		return nil, fmt.Errorf("plugin invoker: encode params: %w", err)
+	}
+	if msg == nil {
+		msg = &structpb.Struct{}
 	}
 
 	req := &proto.PluginInvokeRequest{
@@ -265,7 +268,7 @@ func (c *InvokerClient) Invoke(ctx context.Context, plugin, operation string, pa
 }
 
 // InvokeGraphQL calls another plugin's GraphQL surface.
-func (c *InvokerClient) InvokeGraphQL(ctx context.Context, plugin, document string, variables map[string]any, opts *InvokeOptions) (*OperationResult, error) {
+func (c *InvokerClient) InvokeGraphQL(ctx context.Context, plugin, document string, variables any, opts *InvokeOptions) (*OperationResult, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("plugin invoker: client is not initialized")
 	}
@@ -276,10 +279,13 @@ func (c *InvokerClient) InvokeGraphQL(ctx context.Context, plugin, document stri
 
 	var msg *structpb.Struct
 	var err error
-	if len(variables) > 0 {
-		msg, err = structpb.NewStruct(variables)
+	if variables != nil {
+		msg, err = StructFromAny(variables)
 		if err != nil {
 			return nil, fmt.Errorf("plugin invoker: encode variables: %w", err)
+		}
+		if msg != nil && len(msg.GetFields()) == 0 {
+			msg = nil
 		}
 	}
 

--- a/sdk/go/invoker_transport_test.go
+++ b/sdk/go/invoker_transport_test.go
@@ -2,9 +2,11 @@ package gestalt_test
 
 import (
 	"context"
+	"math"
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
@@ -13,6 +15,32 @@ import (
 	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+type invokeIssueParams struct {
+	IssueNumber int `json:"issue_number"`
+}
+
+type invokeOmitEmptyParams struct {
+	IssueNumber int               `json:"issue_number"`
+	Tags        []string          `json:"tags,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+type pointerMarshaler struct {
+	Hidden string
+}
+
+func (*pointerMarshaler) MarshalJSON() ([]byte, error) {
+	return []byte(`{"redacted":true}`), nil
+}
+
+type EmbeddedIssueParams struct {
+	IssueNumber int `json:"issue_number"`
+}
+
+type embeddedIssueParams struct {
+	EmbeddedIssueParams
+}
 
 type pluginInvokerTransportHarness struct {
 	proto.UnimplementedPluginInvokerServer
@@ -101,8 +129,8 @@ func TestTransport_PluginInvokerTCPTargetTokenEnv(t *testing.T) {
 	}
 	defer func() { _ = client.Close() }()
 
-	result, err := client.Invoke(context.Background(), "github", "get_issue", map[string]any{
-		"issue_number": 42,
+	result, err := client.Invoke(context.Background(), "github", "get_issue", invokeIssueParams{
+		IssueNumber: 42,
 	}, &gestalt.InvokeOptions{
 		IdempotencyKey: " issue-42-create ",
 	})
@@ -111,6 +139,17 @@ func TestTransport_PluginInvokerTCPTargetTokenEnv(t *testing.T) {
 	}
 	if result.Status != 207 || result.Body != "relay-ok" {
 		t.Fatalf("Invoke result = %+v, want status=207 body=relay-ok", result)
+	}
+	result, err = client.Invoke(context.Background(), "github", "get_issue", invokeOmitEmptyParams{
+		IssueNumber: 43,
+		Tags:        []string{},
+		Metadata:    map[string]string{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Invoke omitempty params: %v", err)
+	}
+	if result.Status != 207 || result.Body != "relay-ok" {
+		t.Fatalf("Invoke omitempty result = %+v, want status=207 body=relay-ok", result)
 	}
 	graphQLResult, err := client.InvokeGraphQL(context.Background(), "linear", " query { viewer { id } } ", map[string]any{
 		"team": "eng",
@@ -123,14 +162,35 @@ func TestTransport_PluginInvokerTCPTargetTokenEnv(t *testing.T) {
 	if graphQLResult.Status != 208 || graphQLResult.Body != "graphql-ok" {
 		t.Fatalf("InvokeGraphQL result = %+v, want status=208 body=graphql-ok", graphQLResult)
 	}
+	if _, err := client.Invoke(context.Background(), "github", "bad", time.Now(), nil); err == nil {
+		t.Fatal("Invoke(time.Time) error = nil, want error")
+	}
+	if _, err := client.Invoke(context.Background(), "github", "bad", map[int]any{1: "bad"}, nil); err == nil {
+		t.Fatal("Invoke(non-string map key) error = nil, want error")
+	}
+	if _, err := client.Invoke(context.Background(), "github", "bad", map[string]any{"score": math.NaN()}, nil); err == nil {
+		t.Fatal("Invoke(NaN) error = nil, want error")
+	}
+	if _, err := client.Invoke(context.Background(), "github", "bad", pointerMarshaler{Hidden: "secret"}, nil); err == nil {
+		t.Fatal("Invoke(pointer json.Marshaler) error = nil, want error")
+	}
+	if _, err := client.Invoke(context.Background(), "github", "bad", map[string]any{"bad": pointerMarshaler{Hidden: "secret"}}, nil); err == nil {
+		t.Fatal("Invoke(map pointer json.Marshaler) error = nil, want error")
+	}
+	if _, err := client.Invoke(context.Background(), "github", "bad", embeddedIssueParams{EmbeddedIssueParams: EmbeddedIssueParams{IssueNumber: 42}}, nil); err == nil {
+		t.Fatal("Invoke(anonymous embedded field) error = nil, want error")
+	}
+	if _, err := client.Invoke(context.Background(), "github", "bad", "not-object", nil); err == nil {
+		t.Fatal("Invoke(non-object) error = nil, want error")
+	}
 
 	harness.mu.Lock()
 	defer harness.mu.Unlock()
-	if len(harness.tokens) != 2 || harness.tokens[0] != "relay-token-go" || harness.tokens[1] != "relay-token-go" {
-		t.Fatalf("relay tokens = %#v, want two relay-token-go entries", harness.tokens)
+	if len(harness.tokens) != 3 || harness.tokens[0] != "relay-token-go" || harness.tokens[1] != "relay-token-go" || harness.tokens[2] != "relay-token-go" {
+		t.Fatalf("relay tokens = %#v, want three relay-token-go entries", harness.tokens)
 	}
-	if len(harness.requests) != 1 {
-		t.Fatalf("invoke requests len = %d, want 1", len(harness.requests))
+	if len(harness.requests) != 2 {
+		t.Fatalf("invoke requests len = %d, want 2", len(harness.requests))
 	}
 	if harness.requests[0].GetInvocationToken() != "parent-token" {
 		t.Fatalf("invocation token = %q, want %q", harness.requests[0].GetInvocationToken(), "parent-token")
@@ -140,6 +200,12 @@ func TestTransport_PluginInvokerTCPTargetTokenEnv(t *testing.T) {
 	}
 	if harness.requests[0].GetIdempotencyKey() != "issue-42-create" {
 		t.Fatalf("idempotency key = %q, want issue-42-create", harness.requests[0].GetIdempotencyKey())
+	}
+	if got := gestalt.MapFromStruct(harness.requests[0].GetParams()); got["issue_number"] != float64(42) {
+		t.Fatalf("invoke params = %#v, want issue_number=42", got)
+	}
+	if got := gestalt.MapFromStruct(harness.requests[1].GetParams()); len(got) != 1 || got["issue_number"] != float64(43) {
+		t.Fatalf("omitempty invoke params = %#v, want only issue_number=43", got)
 	}
 	if len(harness.graphQL) != 1 {
 		t.Fatalf("graphql requests len = %d, want 1", len(harness.graphQL))

--- a/sdk/go/protocol_helpers.go
+++ b/sdk/go/protocol_helpers.go
@@ -1,7 +1,11 @@
 package gestalt
 
 import (
+	"encoding/json"
 	"fmt"
+	"math"
+	"reflect"
+	"strings"
 	"time"
 
 	gproto "google.golang.org/protobuf/proto"
@@ -9,24 +13,45 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+var (
+	jsonMarshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	timeType          = reflect.TypeOf(time.Time{})
+)
+
 // StructFromMap converts a Go map into a protobuf Struct.
 func StructFromMap(value map[string]any) (*structpb.Struct, error) {
 	if value == nil {
 		value = map[string]any{}
 	}
-	return structpb.NewStruct(value)
+	normalized, err := normalizeJSONObject(value, "struct")
+	if err != nil {
+		return nil, err
+	}
+	if normalized == nil {
+		return nil, nil
+	}
+	return structpb.NewStruct(normalized)
 }
 
-// StructFromAny converts a JSON-compatible map into an optional protobuf Struct.
+// StructFromAny converts a JSON-compatible object into an optional protobuf Struct.
+//
+// The input may be nil, a string-keyed map, a struct, or a pointer to one of
+// those. Struct fields use their exported field names unless a json tag
+// supplies a name; json:"-" skips the field and omitempty skips zero values.
+// Anonymous embedded fields must have an explicit json tag name; embedded
+// fields are not flattened.
 func StructFromAny(value any) (*structpb.Struct, error) {
-	switch typed := value.(type) {
-	case nil:
+	if value == nil {
 		return nil, nil
-	case map[string]any:
-		return structpb.NewStruct(typed)
-	default:
-		return nil, fmt.Errorf("expected map[string]any, got %T", value)
 	}
+	normalized, err := normalizeJSONObject(value, "struct")
+	if err != nil {
+		return nil, err
+	}
+	if normalized == nil {
+		return nil, nil
+	}
+	return structpb.NewStruct(normalized)
 }
 
 // MapFromStruct converts a protobuf Struct into its Go map representation.
@@ -47,7 +72,11 @@ func CloneStruct(value *structpb.Struct) *structpb.Struct {
 
 // ValueFromAny converts a Go JSON-compatible value into a protobuf Value.
 func ValueFromAny(value any) (*structpb.Value, error) {
-	return structpb.NewValue(value)
+	normalized, err := normalizeJSONValue(reflect.ValueOf(value), "value", map[uintptr]string{})
+	if err != nil {
+		return nil, err
+	}
+	return structpb.NewValue(normalized)
 }
 
 // AnyFromValue converts a protobuf Value into its Go representation.
@@ -65,7 +94,7 @@ func ValuesFromMap(values map[string]any) (map[string]*structpb.Value, error) {
 	}
 	out := make(map[string]*structpb.Value, len(values))
 	for key, value := range values {
-		pbValue, err := structpb.NewValue(value)
+		pbValue, err := ValueFromAny(value)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", key, err)
 		}
@@ -129,4 +158,190 @@ func CloneTimestamp(value *timestamppb.Timestamp) *timestamppb.Timestamp {
 		return nil
 	}
 	return gproto.Clone(value).(*timestamppb.Timestamp)
+}
+
+func normalizeJSONObject(value any, path string) (map[string]any, error) {
+	normalized, err := normalizeJSONValue(reflect.ValueOf(value), path, map[uintptr]string{})
+	if err != nil {
+		return nil, err
+	}
+	if normalized == nil {
+		return nil, nil
+	}
+	object, ok := normalized.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s: expected JSON object, got %T", path, value)
+	}
+	return object, nil
+}
+
+func normalizeJSONValue(value reflect.Value, path string, seen map[uintptr]string) (any, error) {
+	if !value.IsValid() {
+		return nil, nil
+	}
+	for value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return nil, nil
+		}
+		if value.Kind() == reflect.Pointer {
+			ptr := value.Pointer()
+			if prior, ok := seen[ptr]; ok {
+				return nil, fmt.Errorf("%s: contains cycle through %s", path, prior)
+			}
+			seen[ptr] = path
+			defer delete(seen, ptr)
+		}
+		value = value.Elem()
+	}
+
+	if value.Type() == timeType {
+		return nil, fmt.Errorf("%s: time.Time is not JSON-compatible; use timestamp helpers", path)
+	}
+	if implementsJSONMarshaler(value.Type()) {
+		return nil, fmt.Errorf("%s: json.Marshaler values are not accepted in protobuf Struct payloads", path)
+	}
+	if value.Kind() == reflect.Map || value.Kind() == reflect.Slice {
+		if value.IsNil() {
+			return nil, nil
+		}
+		ptr := value.Pointer()
+		if ptr != 0 {
+			if prior, ok := seen[ptr]; ok {
+				return nil, fmt.Errorf("%s: contains cycle through %s", path, prior)
+			}
+			seen[ptr] = path
+			defer delete(seen, ptr)
+		}
+	}
+
+	switch value.Kind() {
+	case reflect.Bool:
+		return value.Bool(), nil
+	case reflect.String:
+		return value.String(), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return value.Int(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return value.Uint(), nil
+	case reflect.Float32, reflect.Float64:
+		number := value.Float()
+		if math.IsNaN(number) || math.IsInf(number, 0) {
+			return nil, fmt.Errorf("%s: expected finite number", path)
+		}
+		return number, nil
+	case reflect.Map:
+		return normalizeJSONMap(value, path, seen)
+	case reflect.Slice, reflect.Array:
+		if value.Kind() == reflect.Slice && value.IsNil() {
+			return nil, nil
+		}
+		if value.Type().Elem().Kind() == reflect.Uint8 {
+			return nil, fmt.Errorf("%s: []byte is not JSON-compatible", path)
+		}
+		out := make([]any, value.Len())
+		for index := 0; index < value.Len(); index++ {
+			item, err := normalizeJSONValue(value.Index(index), fmt.Sprintf("%s[%d]", path, index), seen)
+			if err != nil {
+				return nil, err
+			}
+			out[index] = item
+		}
+		return out, nil
+	case reflect.Struct:
+		return normalizeJSONStruct(value, path, seen)
+	default:
+		return nil, fmt.Errorf("%s: unsupported JSON value %s", path, value.Type())
+	}
+}
+
+func implementsJSONMarshaler(valueType reflect.Type) bool {
+	if valueType.Implements(jsonMarshalerType) {
+		return true
+	}
+	return valueType.Kind() != reflect.Pointer && reflect.PointerTo(valueType).Implements(jsonMarshalerType)
+}
+
+func normalizeJSONMap(value reflect.Value, path string, seen map[uintptr]string) (map[string]any, error) {
+	if value.IsNil() {
+		return map[string]any{}, nil
+	}
+	if value.Type().Key().Kind() != reflect.String {
+		return nil, fmt.Errorf("%s: map keys must be strings", path)
+	}
+	out := make(map[string]any, value.Len())
+	for _, key := range value.MapKeys() {
+		keyString := key.String()
+		item, err := normalizeJSONValue(value.MapIndex(key), path+"."+keyString, seen)
+		if err != nil {
+			return nil, err
+		}
+		out[keyString] = item
+	}
+	return out, nil
+}
+
+func normalizeJSONStruct(value reflect.Value, path string, seen map[uintptr]string) (map[string]any, error) {
+	out := map[string]any{}
+	valueType := value.Type()
+	for index := 0; index < value.NumField(); index++ {
+		field := valueType.Field(index)
+		if field.PkgPath != "" {
+			continue
+		}
+		name, omitEmpty, skip, explicitName := jsonFieldName(field)
+		if skip {
+			continue
+		}
+		if field.Anonymous && !explicitName {
+			return nil, fmt.Errorf("%s.%s: anonymous embedded fields are not flattened; add a json tag name", path, field.Name)
+		}
+		fieldValue := value.Field(index)
+		if omitEmpty && isJSONEmptyValue(fieldValue) {
+			continue
+		}
+		item, err := normalizeJSONValue(fieldValue, path+"."+name, seen)
+		if err != nil {
+			return nil, err
+		}
+		out[name] = item
+	}
+	return out, nil
+}
+
+func isJSONEmptyValue(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return value.Len() == 0
+	case reflect.Bool:
+		return !value.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return value.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return value.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return value.Float() == 0
+	case reflect.Interface, reflect.Pointer:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func jsonFieldName(field reflect.StructField) (name string, omitEmpty bool, skip bool, explicitName bool) {
+	tag := field.Tag.Get("json")
+	if tag == "-" {
+		return "", false, true, false
+	}
+	parts := strings.Split(tag, ",")
+	name = strings.TrimSpace(parts[0])
+	explicitName = name != ""
+	if name == "" {
+		name = field.Name
+	}
+	for _, option := range parts[1:] {
+		if option == "omitempty" {
+			omitEmpty = true
+		}
+	}
+	return name, omitEmpty, false, explicitName
 }

--- a/sdk/python/docs/reference.rst
+++ b/sdk/python/docs/reference.rst
@@ -126,13 +126,16 @@ Protocol helpers
 ----------------
 
 These helpers convert between Python values and protobuf well-known types
-without importing generated runtime internals.
+without importing generated runtime internals. Struct and Value helpers accept
+JSON-compatible mappings and dataclass instances; datetime-like values are
+rejected in generic JSON payloads and should use timestamp helpers instead.
 
 .. autosummary::
    :nosignatures:
 
    struct_from_dict
    struct_to_dict
+   json_from_native
    value_from_json
    value_to_json
    message_to_dict
@@ -145,6 +148,8 @@ without importing generated runtime internals.
 .. autofunction:: struct_from_dict
 
 .. autofunction:: struct_to_dict
+
+.. autofunction:: json_from_native
 
 .. autofunction:: value_from_json
 

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -144,6 +144,12 @@ _AGENT_HELPER_EXPORTS = (
 _PROTOBUF_HELPER_EXPORTS = (
     "datetime_from_timestamp",
     "has_field",
+    "JsonInput",
+    "JsonObject",
+    "JsonObjectInput",
+    "JsonPrimitive",
+    "JsonValue",
+    "json_from_native",
     "message_from_dict",
     "message_to_dict",
     "struct_from_dict",

--- a/sdk/python/gestalt/_agent.py
+++ b/sdk/python/gestalt/_agent.py
@@ -10,6 +10,7 @@ from ._gen.v1 import agent_pb2 as _pb
 from ._gen.v1 import agent_pb2_grpc as _pb_grpc
 from ._grpc_transport import host_service_channel
 from ._protocol import (
+    JsonObjectInput,
     has_field,
     message_from_dict,
     message_to_dict,
@@ -500,7 +501,7 @@ def agent_message_part_from_dict(value: Mapping[str, Any]) -> Any:
     if "text" in data:
         part.text = str(data["text"])
     if data.get("json") is not None:
-        part.json.CopyFrom(struct_from_dict(_mapping_value(data["json"], "json")))
+        part.json.CopyFrom(struct_from_dict(data["json"]))
     if data.get("tool_call") is not None:
         part.tool_call.CopyFrom(_tool_call_from_dict(data["tool_call"]))
     if data.get("tool_result") is not None:
@@ -540,9 +541,7 @@ def agent_message_from_dict(value: Mapping[str, Any]) -> Any:
             agent_message_part_from_dict(_mapping_value(part, "parts[]"))
         )
     if data.get("metadata") is not None:
-        message.metadata.CopyFrom(
-            struct_from_dict(_mapping_value(data["metadata"], "metadata"))
-        )
+        message.metadata.CopyFrom(struct_from_dict(data["metadata"]))
     return message
 
 
@@ -612,7 +611,7 @@ class AgentHost:
         *,
         tool_call_id: str,
         tool_id: str,
-        arguments: Mapping[str, Any] | None = None,
+        arguments: JsonObjectInput | None = None,
         run_grant: str = "",
         idempotency_key: str = "",
     ) -> Any:
@@ -835,9 +834,7 @@ def _tool_call_from_dict(value: Any) -> Any:
         tool_id=data.get("tool_id", ""),
     )
     if data.get("arguments") is not None:
-        tool_call.arguments.CopyFrom(
-            struct_from_dict(_mapping_value(data["arguments"], "tool_call.arguments"))
-        )
+        tool_call.arguments.CopyFrom(struct_from_dict(data["arguments"]))
     return tool_call
 
 
@@ -857,9 +854,7 @@ def _tool_result_from_dict(value: Any) -> Any:
         content=data.get("content", ""),
     )
     if data.get("output") is not None:
-        tool_result.output.CopyFrom(
-            struct_from_dict(_mapping_value(data["output"], "tool_result.output"))
-        )
+        tool_result.output.CopyFrom(struct_from_dict(data["output"]))
     return tool_result
 
 

--- a/sdk/python/gestalt/_invoker.py
+++ b/sdk/python/gestalt/_invoker.py
@@ -6,8 +6,6 @@ from typing import Any, Protocol, cast
 from urllib import parse as _urlparse
 
 import grpc
-from google.protobuf import json_format
-from google.protobuf import struct_pb2 as _struct_pb2
 
 from ._api import Response
 from ._gen.v1 import plugin_pb2 as _pb
@@ -17,10 +15,14 @@ from ._grpc_transport import (
     internal_channel_target,
     secure_internal_channel,
 )
+from ._protocol import (
+    JsonObjectInput,
+    _struct_from_normalized_object,
+    json_from_native,
+)
 
 pb: Any = _pb
 pb_grpc: Any = _pb_grpc
-struct_pb2: Any = _struct_pb2
 
 # Matches the host-side socket name exposed by gestaltd.
 ENV_PLUGIN_INVOKER_SOCKET = "GESTALT_PLUGIN_INVOKER_SOCKET"
@@ -44,7 +46,9 @@ class PluginInvoker:
 
         socket_path = os.environ.get(ENV_PLUGIN_INVOKER_SOCKET, "")
         if not socket_path:
-            raise RuntimeError(f"plugin invoker: {ENV_PLUGIN_INVOKER_SOCKET} is not set")
+            raise RuntimeError(
+                f"plugin invoker: {ENV_PLUGIN_INVOKER_SOCKET} is not set"
+            )
         relay_token = os.environ.get(ENV_PLUGIN_INVOKER_SOCKET_TOKEN, "")
 
         self._channel = _plugin_invoker_channel(socket_path, token=relay_token)
@@ -60,7 +64,7 @@ class PluginInvoker:
         self,
         plugin: str,
         operation: str,
-        params: dict[str, Any] | None = None,
+        params: JsonObjectInput | None = None,
         *,
         connection: str = "",
         instance: str = "",
@@ -92,7 +96,7 @@ class PluginInvoker:
         self,
         plugin: str,
         document: str,
-        variables: dict[str, Any] | None = None,
+        variables: JsonObjectInput | None = None,
         *,
         connection: str = "",
         instance: str = "",
@@ -112,7 +116,9 @@ class PluginInvoker:
             instance=instance,
             idempotency_key=idempotency_key.strip(),
         )
-        message = _struct_from_dict_optional(variables, preserve_empty=False)
+        message = _struct_from_dict_optional(
+            variables, preserve_empty=False, path="plugin invoker variables"
+        )
         if message is not None:
             request.variables.CopyFrom(message)
 
@@ -147,26 +153,30 @@ class PluginInvoker:
         self.close()
 
 
-def _struct_from_dict(values: dict[str, Any] | None) -> Any:
+def _struct_from_dict(values: JsonObjectInput | None) -> Any:
     if values is None:
         return None
 
-    return _struct_from_dict_optional(values, preserve_empty=True)
+    return _struct_from_dict_optional(
+        values, preserve_empty=True, path="plugin invoker params"
+    )
 
 
 def _struct_from_dict_optional(
-    values: dict[str, Any] | None,
+    values: JsonObjectInput | None,
     *,
     preserve_empty: bool,
+    path: str,
 ) -> Any:
     if values is None:
         return None
-    if not preserve_empty and not values:
+    normalized = json_from_native(values, path=path)
+    if not isinstance(normalized, dict):
+        raise TypeError(f"{path} must be a JSON object, got {type(values).__name__}")
+    if not preserve_empty and not normalized:
         return None
 
-    message = struct_pb2.Struct()
-    json_format.ParseDict(values, message)
-    return message
+    return _struct_from_normalized_object(normalized)
 
 
 def _grants_from_values(values: Sequence[Any] | None) -> list[Any]:
@@ -194,7 +204,9 @@ def _grant_parts(value: Any) -> tuple[str, list[str], list[str], bool]:
         raw_plugin = value.get("plugin", "")
         raw_operations = value.get("operations", ())
         raw_surfaces = value.get("surfaces", ())
-        raw_all_operations = value.get("all_operations", value.get("allOperations", False))
+        raw_all_operations = value.get(
+            "all_operations", value.get("allOperations", False)
+        )
     else:
         raw_plugin = getattr(value, "plugin", "")
         raw_operations = getattr(value, "operations", ())
@@ -266,9 +278,7 @@ def _plugin_invoker_channel(raw_target: str, *, token: str = "") -> grpc.Channel
     )
 
 
-def _with_plugin_invoker_relay_token(
-    channel: grpc.Channel, token: str
-) -> grpc.Channel:
+def _with_plugin_invoker_relay_token(channel: grpc.Channel, token: str) -> grpc.Channel:
     token = token.strip()
     if not token:
         return channel

--- a/sdk/python/gestalt/_protocol.py
+++ b/sdk/python/gestalt/_protocol.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import dataclasses as _dataclasses
 import datetime as _dt
-from collections.abc import Mapping
-from typing import Any
+import math as _math
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeAlias
 
 from google.protobuf import json_format as _json_format
 from google.protobuf import message as _message
@@ -15,17 +17,30 @@ _UTC = _dt.timezone.utc
 struct_pb2: Any = _struct_pb2
 timestamp_pb2: Any = _timestamp_pb2
 
+JsonPrimitive: TypeAlias = None | bool | int | float | str
+JsonValue: TypeAlias = JsonPrimitive | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
+JsonInput: TypeAlias = Any
+JsonObjectInput: TypeAlias = Any
 
-def struct_from_dict(value: Mapping[str, Any] | None = None) -> Any:
-    """Convert a JSON-like mapping into a protobuf ``Struct``."""
+
+def struct_from_dict(value: JsonObjectInput | None = None) -> Any:
+    """Convert a JSON-like object into a protobuf ``Struct``.
+
+    ``value`` may be a mapping or a dataclass instance whose fields are
+    JSON-compatible. Unsupported values raise ``TypeError`` instead of being
+    stringified or silently dropped.
+    """
 
     message = struct_pb2.Struct()
     if value is None:
         return message
-    if not isinstance(value, Mapping):
-        raise TypeError("struct_from_dict expects a mapping or None")
-    _json_format.ParseDict(dict(value), message)
-    return message
+    normalized = json_from_native(value, path="struct")
+    if not isinstance(normalized, dict):
+        raise TypeError(
+            f"struct_from_dict expects an object, got {type(value).__name__}"
+        )
+    return _struct_from_normalized_object(normalized)
 
 
 def struct_to_dict(value: Any | None) -> dict[str, Any]:
@@ -36,11 +51,11 @@ def struct_to_dict(value: Any | None) -> dict[str, Any]:
     return dict(_json_format.MessageToDict(value, preserving_proto_field_name=True))
 
 
-def value_from_json(value: Any) -> Any:
+def value_from_json(value: JsonInput) -> Any:
     """Convert a JSON-like Python value into a protobuf ``Value``."""
 
     message = struct_pb2.Value()
-    _json_format.ParseDict(value, message)
+    _json_format.ParseDict(json_from_native(value), message)
     return message
 
 
@@ -68,6 +83,23 @@ def message_to_dict(
 def message_from_dict(value: Any, message: Any) -> Any:
     """Parse protobuf JSON data into ``message`` and return the same message."""
 
+    _json_format.ParseDict(value, message)
+    return message
+
+
+def json_from_native(value: JsonInput, *, path: str = "value") -> JsonValue:
+    """Return a JSON-compatible Python value from native SDK input.
+
+    Mappings, sequences, and dataclass instances are recursively normalized.
+    Datetimes and other rich objects are rejected for generic JSON payloads;
+    use timestamp-specific helpers for timestamp fields.
+    """
+
+    return _json_from_native(value, path=path, seen=set())
+
+
+def _struct_from_normalized_object(value: JsonObject) -> Any:
+    message = struct_pb2.Struct()
     _json_format.ParseDict(value, message)
     return message
 
@@ -115,3 +147,75 @@ def which_oneof(message: Any, group: str) -> str | None:
         return message.WhichOneof(group)
     except ValueError:
         return None
+
+
+def _json_from_native(value: Any, *, path: str, seen: set[int]) -> JsonValue:
+    if value is None or isinstance(value, bool | str):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not _math.isfinite(value):
+            raise TypeError(f"{path} must be a finite number")
+        return value
+    if isinstance(value, _dt.datetime | _dt.date | _dt.time):
+        raise TypeError(
+            f"{path} must be JSON-compatible; use timestamp helpers for datetime values"
+        )
+    if isinstance(value, bytes | bytearray | memoryview):
+        raise TypeError(f"{path} must be JSON-compatible, got bytes")
+    if _dataclasses.is_dataclass(value):
+        if isinstance(value, type):
+            raise TypeError(
+                f"{path} must be a dataclass instance, not a dataclass type"
+            )
+        return _json_object_from_items(
+            (
+                (field.name, getattr(value, field.name))
+                for field in _dataclasses.fields(value)
+            ),
+            path=path,
+            seen=seen,
+            container=value,
+        )
+    if isinstance(value, Mapping):
+        return _json_object_from_items(
+            value.items(), path=path, seen=seen, container=value
+        )
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        obj_id = id(value)
+        if obj_id in seen:
+            raise TypeError(f"{path} contains a cycle")
+        seen.add(obj_id)
+        try:
+            return [
+                _json_from_native(item, path=f"{path}[{index}]", seen=seen)
+                for index, item in enumerate(value)
+            ]
+        finally:
+            seen.remove(obj_id)
+    raise TypeError(f"{path} must be JSON-compatible, got {type(value).__name__}")
+
+
+def _json_object_from_items(
+    items: Any,
+    *,
+    path: str,
+    seen: set[int],
+    container: Any,
+) -> JsonObject:
+    obj_id = id(container)
+    if obj_id in seen:
+        raise TypeError(f"{path} contains a cycle")
+    seen.add(obj_id)
+    try:
+        output: JsonObject = {}
+        for key, item in items:
+            if not isinstance(key, str):
+                raise TypeError(
+                    f"{path} keys must be strings, got {type(key).__name__}"
+                )
+            output[key] = _json_from_native(item, path=f"{path}.{key}", seen=seen)
+        return output
+    finally:
+        seen.remove(obj_id)

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import unittest
 from concurrent import futures
+from dataclasses import dataclass
 from importlib import resources
 from typing import Any
 
@@ -65,6 +66,11 @@ _host_execute_requests: list[dict[str, Any]] = []
 _host_connection_requests: list[dict[str, Any]] = []
 _manager_requests: list[dict[str, str]] = []
 _manager_relay_tokens: list[str] = []
+
+
+@dataclass
+class ToolArguments:
+    query: str
 
 
 class _AgentRuntimeProvider(AgentProvider, MetadataProvider, WarningsProvider):
@@ -765,7 +771,9 @@ class AgentTransportTests(unittest.TestCase):
             },
         )
 
-    def test_agent_message_proto_dict_helpers_preserve_protobuf_json_shape(self) -> None:
+    def test_agent_message_proto_dict_helpers_preserve_protobuf_json_shape(
+        self,
+    ) -> None:
         message = AgentMessage(role="assistant")
         message.metadata.CopyFrom(struct_from_dict({"tenant": "acme"}))
         part = message.parts.add()
@@ -945,7 +953,7 @@ class AgentTransportTests(unittest.TestCase):
                 "turn-1",
                 tool_call_id="call-7",
                 tool_id="lookup",
-                arguments={"query": "Ada Lovelace"},
+                arguments=ToolArguments(query="Ada Lovelace"),
                 run_grant="grant-token",
                 idempotency_key="tool-call-key-7",
             )

--- a/sdk/python/tests/test_plugin_invoker_transport.py
+++ b/sdk/python/tests/test_plugin_invoker_transport.py
@@ -1,4 +1,5 @@
 """Transport-backed PluginInvoker SDK tests over a real Unix socket."""
+
 from __future__ import annotations
 
 import json
@@ -6,6 +7,8 @@ import os
 import tempfile
 import unittest
 from concurrent import futures
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 import grpc
@@ -22,6 +25,13 @@ from gestalt._gen.v1 import plugin_pb2_grpc as _plugin_pb2_grpc
 
 plugin_pb2: Any = _plugin_pb2
 plugin_pb2_grpc: Any = _plugin_pb2_grpc
+
+
+@dataclass
+class IssueParams:
+    repo: str
+    issue_number: int
+
 
 _server: grpc.Server | None = None
 _socket_path: str = ""
@@ -178,7 +188,7 @@ class PluginInvokerTransportTests(unittest.TestCase):
             response = client.invoke(
                 "github",
                 "get_issue",
-                {"repo": "valon-technologies/gestalt", "issue_number": 1026},
+                IssueParams(repo="valon-technologies/gestalt", issue_number=1026),
                 connection="work",
                 instance="prod",
                 idempotency_key=" issue-1026-create ",
@@ -208,7 +218,7 @@ class PluginInvokerTransportTests(unittest.TestCase):
                             "operations": [],
                             "surfaces": [],
                             "all_operations": True,
-                        }
+                        },
                     ],
                     "ttl_seconds": 45,
                 }
@@ -231,6 +241,24 @@ class PluginInvokerTransportTests(unittest.TestCase):
                 "idempotency_key": "issue-1026-create",
             },
         )
+
+    def test_invoke_rejects_non_json_dataclass_values(self) -> None:
+        @dataclass
+        class BadParams:
+            created_at: datetime
+
+        with PluginInvoker("invoke-bad") as client:
+            with self.assertRaisesRegex(TypeError, "timestamp helpers"):
+                client.invoke(
+                    "github",
+                    "bad",
+                    BadParams(created_at=datetime(2026, 5, 8, tzinfo=timezone.utc)),
+                )
+
+    def test_invoke_rejects_dataclass_types(self) -> None:
+        with PluginInvoker("invoke-bad-type") as client:
+            with self.assertRaisesRegex(TypeError, "dataclass instance"):
+                client.invoke("github", "bad", IssueParams)
 
     def test_invoke_graphql_roundtrip(self) -> None:
         with PluginInvoker("invoke-graphql") as client:

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -125,8 +125,12 @@ The crate keeps generated bindings behind a higher-level authoring API:
   socket exposed by `gestaltd`.
 - `proto::v1` exposes generated protocol bindings for low-level integration
   work.
-- `protocol` converts JSON values, `Struct`, `Value`, `SystemTime`, and
-  `Timestamp` without depending on private generated modules.
+- `protocol` converts JSON and `Serialize` values, `Struct`, `Value`,
+  `SystemTime`, and `Timestamp` without depending on private generated modules.
+  SDK clients that own request construction use these conversions so typed
+  structs can become protobuf `Struct` payloads without hand-building protos.
+  Generic JSON payloads reject non-finite numbers, bytes, and non-string map
+  keys instead of coercing them through `serde_json`.
 
 ## Package layout
 

--- a/sdk/rust/src/agent.rs
+++ b/sdk/rust/src/agent.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use hyper_util::rt::TokioIo;
+use serde::Serialize;
 use tokio::net::UnixStream;
 use tonic::codegen::async_trait;
 use tonic::metadata::MetadataValue;
@@ -77,6 +78,20 @@ pub struct AgentHostExecuteToolInput {
     pub run_grant: String,
     /// Caller-supplied idempotency key for retries.
     pub idempotency_key: String,
+}
+
+impl AgentHostExecuteToolInput {
+    /// Returns this input with JSON object arguments serialized from a typed value.
+    pub fn with_arguments<T: Serialize>(mut self, arguments: T) -> ProviderResult<Self> {
+        let arguments = protocol::json_from_serializable(arguments)?;
+        if !arguments.is_object() {
+            return Err(crate::Error::bad_request(
+                "agent host tool arguments must serialize to a JSON object",
+            ));
+        }
+        self.arguments = Some(arguments);
+        Ok(self)
+    }
 }
 
 /// Plain input for resolving a configured connection during one agent turn.

--- a/sdk/rust/src/invoker.rs
+++ b/sdk/rust/src/invoker.rs
@@ -14,6 +14,7 @@ use crate::OperationResult;
 use crate::generated::v1::{
     self as pb, plugin_invoker_client::PluginInvokerClient as ProtoPluginInvokerClient,
 };
+use crate::protocol;
 
 type PluginInvokerTransport = InterceptedService<Channel, RelayTokenInterceptor>;
 
@@ -138,7 +139,7 @@ impl PluginInvoker {
             .invoke(pb::PluginInvokeRequest {
                 plugin: plugin.to_string(),
                 operation: operation.to_string(),
-                params: Some(json_to_struct(serde_json::to_value(params)?)?),
+                params: Some(serializable_to_struct(params, "params")?),
                 connection: options
                     .as_ref()
                     .map(|opts| opts.connection.clone())
@@ -193,9 +194,7 @@ impl PluginInvoker {
                 plugin: plugin.to_string(),
                 document: document.to_string(),
                 variables: variables
-                    .map(serde_json::to_value)
-                    .transpose()?
-                    .map(|value| json_to_optional_struct(value, "variables"))
+                    .map(|value| serializable_to_optional_struct(value, "variables"))
                     .transpose()?
                     .flatten(),
                 connection: options
@@ -378,51 +377,36 @@ impl Interceptor for RelayTokenInterceptor {
     }
 }
 
-fn json_to_struct(
-    value: serde_json::Value,
+fn serializable_to_struct<T: Serialize>(
+    value: T,
+    field_name: &str,
 ) -> std::result::Result<prost_types::Struct, PluginInvokerError> {
-    Ok(json_to_optional_struct(value, "params")?.unwrap_or_default())
+    let value = protocol::json_value_from_serializable(value)?;
+    Ok(json_to_optional_struct(value, field_name)?.unwrap_or_default())
 }
 
 fn json_to_optional_struct(
     value: serde_json::Value,
     field_name: &str,
 ) -> std::result::Result<Option<prost_types::Struct>, PluginInvokerError> {
-    let serde_json::Value::Object(fields) = value else {
-        if value.is_null() {
-            return Ok(None);
-        }
+    if value.is_null() {
+        return Ok(None);
+    }
+    let serde_json::Value::Object(_) = &value else {
         return Err(PluginInvokerError::Protocol(format!(
             "plugin invoker: {field_name} must serialize to a JSON object"
         )));
     };
 
-    Ok(Some(prost_types::Struct {
-        fields: fields
-            .into_iter()
-            .map(|(key, value)| (key, json_value_to_prost(value)))
-            .collect(),
-    }))
+    protocol::struct_from_json(value)
+        .map(Some)
+        .map_err(|err| PluginInvokerError::Protocol(err.to_string()))
 }
 
-fn json_value_to_prost(value: serde_json::Value) -> prost_types::Value {
-    use prost_types::value::Kind;
-
-    let kind = match value {
-        serde_json::Value::Null => Kind::NullValue(0),
-        serde_json::Value::Bool(boolean) => Kind::BoolValue(boolean),
-        serde_json::Value::Number(number) => Kind::NumberValue(number.as_f64().unwrap_or_default()),
-        serde_json::Value::String(string) => Kind::StringValue(string),
-        serde_json::Value::Array(items) => Kind::ListValue(prost_types::ListValue {
-            values: items.into_iter().map(json_value_to_prost).collect(),
-        }),
-        serde_json::Value::Object(fields) => Kind::StructValue(prost_types::Struct {
-            fields: fields
-                .into_iter()
-                .map(|(key, value)| (key, json_value_to_prost(value)))
-                .collect(),
-        }),
-    };
-
-    prost_types::Value { kind: Some(kind) }
+fn serializable_to_optional_struct<T: Serialize>(
+    value: T,
+    field_name: &str,
+) -> std::result::Result<Option<prost_types::Struct>, PluginInvokerError> {
+    let value = protocol::json_value_from_serializable(value)?;
+    json_to_optional_struct(value, field_name)
 }

--- a/sdk/rust/src/protocol.rs
+++ b/sdk/rust/src/protocol.rs
@@ -1,6 +1,11 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use prost_types::{ListValue, Struct, Timestamp, Value, value::Kind};
+use serde::Serialize;
+use serde::ser::{
+    self, Impossible, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant,
+    SerializeTuple, SerializeTupleStruct, SerializeTupleVariant,
+};
 
 use crate::{Error, Result};
 
@@ -14,6 +19,28 @@ pub fn struct_from_json(value: serde_json::Value) -> Result<Struct> {
             "expected JSON object when building protobuf Struct",
         )),
     }
+}
+
+/// Serializes a JSON object-like value into a protobuf `Struct`.
+pub fn struct_from_serializable<T: Serialize>(value: T) -> Result<Struct> {
+    struct_from_json(json_from_serializable(value)?)
+}
+
+/// Serializes an optional JSON object-like value into an optional protobuf `Struct`.
+pub fn optional_struct_from_serializable<T: Serialize>(value: Option<T>) -> Result<Option<Struct>> {
+    value.map(struct_from_serializable).transpose()
+}
+
+/// Serializes a value into `serde_json::Value` for protocol conversion.
+pub fn json_from_serializable<T: Serialize>(value: T) -> Result<serde_json::Value> {
+    json_value_from_serializable(value)
+        .map_err(|err| Error::bad_request(format!("serialize JSON value: {err}")))
+}
+
+pub(crate) fn json_value_from_serializable<T: Serialize>(
+    value: T,
+) -> std::result::Result<serde_json::Value, serde_json::Error> {
+    value.serialize(JsonInputSerializer)
 }
 
 /// Converts a JSON object map into a protobuf `Struct`.
@@ -109,4 +136,562 @@ fn nanos_to_duration(nanos: u128) -> Result<Duration> {
             .map_err(|_| Error::bad_request("protobuf Timestamp seconds out of range"))?,
         subnanos as u32,
     ))
+}
+
+struct JsonInputSerializer;
+
+impl ser::Serializer for JsonInputSerializer {
+    type Error = serde_json::Error;
+    type Ok = serde_json::Value;
+    type SerializeMap = JsonObjectSerializer;
+    type SerializeSeq = JsonArraySerializer;
+    type SerializeStruct = JsonObjectSerializer;
+    type SerializeStructVariant = JsonObjectSerializer;
+    type SerializeTuple = JsonArraySerializer;
+    type SerializeTupleStruct = JsonArraySerializer;
+    type SerializeTupleVariant = JsonArraySerializer;
+
+    fn serialize_bool(self, value: bool) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Bool(value))
+    }
+
+    fn serialize_i8(self, value: i8) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn serialize_i16(self, value: i16) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn serialize_i32(self, value: i32) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn serialize_i64(self, value: i64) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn serialize_u8(self, value: u8) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn serialize_u16(self, value: u16) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn serialize_u32(self, value: u32) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn serialize_u64(self, value: u64) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn serialize_f32(self, value: f32) -> std::result::Result<Self::Ok, Self::Error> {
+        self.serialize_f64(f64::from(value))
+    }
+
+    fn serialize_f64(self, value: f64) -> std::result::Result<Self::Ok, Self::Error> {
+        if !value.is_finite() {
+            return Err(json_input_error("numbers must be finite"));
+        }
+        let number = serde_json::Number::from_f64(value)
+            .ok_or_else(|| json_input_error("numbers must be finite"))?;
+        Ok(serde_json::Value::Number(number))
+    }
+
+    fn serialize_char(self, value: char) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::String(value.to_string()))
+    }
+
+    fn serialize_str(self, value: &str) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::String(value.to_string()))
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("bytes are not JSON-compatible"))
+    }
+
+    fn serialize_none(self) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Null)
+    }
+
+    fn serialize_some<T>(self, value: &T) -> std::result::Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Null)
+    }
+
+    fn serialize_unit_struct(
+        self,
+        _name: &'static str,
+    ) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::Null)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(serde_json::Value::String(variant.to_string()))
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> std::result::Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> std::result::Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        let mut fields = serde_json::Map::new();
+        fields.insert(variant.to_string(), value.serialize(JsonInputSerializer)?);
+        Ok(serde_json::Value::Object(fields))
+    }
+
+    fn serialize_seq(
+        self,
+        len: Option<usize>,
+    ) -> std::result::Result<Self::SerializeSeq, Self::Error> {
+        Ok(JsonArraySerializer {
+            values: Vec::with_capacity(len.unwrap_or(0)),
+            variant: None,
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> std::result::Result<Self::SerializeTuple, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> std::result::Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> std::result::Result<Self::SerializeTupleVariant, Self::Error> {
+        Ok(JsonArraySerializer {
+            values: Vec::with_capacity(len),
+            variant: Some(variant),
+        })
+    }
+
+    fn serialize_map(
+        self,
+        len: Option<usize>,
+    ) -> std::result::Result<Self::SerializeMap, Self::Error> {
+        Ok(JsonObjectSerializer {
+            fields: serde_json::Map::with_capacity(len.unwrap_or(0)),
+            next_key: None,
+            variant: None,
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> std::result::Result<Self::SerializeStruct, Self::Error> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> std::result::Result<Self::SerializeStructVariant, Self::Error> {
+        Ok(JsonObjectSerializer {
+            fields: serde_json::Map::with_capacity(len),
+            next_key: None,
+            variant: Some(variant),
+        })
+    }
+}
+
+struct JsonArraySerializer {
+    values: Vec<serde_json::Value>,
+    variant: Option<&'static str>,
+}
+
+impl JsonArraySerializer {
+    fn finish(self) -> std::result::Result<serde_json::Value, serde_json::Error> {
+        let value = serde_json::Value::Array(self.values);
+        if let Some(variant) = self.variant {
+            let mut fields = serde_json::Map::new();
+            fields.insert(variant.to_string(), value);
+            return Ok(serde_json::Value::Object(fields));
+        }
+        Ok(value)
+    }
+}
+
+impl SerializeSeq for JsonArraySerializer {
+    type Error = serde_json::Error;
+    type Ok = serde_json::Value;
+
+    fn serialize_element<T>(&mut self, value: &T) -> std::result::Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.values.push(value.serialize(JsonInputSerializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> std::result::Result<Self::Ok, Self::Error> {
+        self.finish()
+    }
+}
+
+impl SerializeTuple for JsonArraySerializer {
+    type Error = serde_json::Error;
+    type Ok = serde_json::Value;
+
+    fn serialize_element<T>(&mut self, value: &T) -> std::result::Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> std::result::Result<Self::Ok, Self::Error> {
+        self.finish()
+    }
+}
+
+impl SerializeTupleStruct for JsonArraySerializer {
+    type Error = serde_json::Error;
+    type Ok = serde_json::Value;
+
+    fn serialize_field<T>(&mut self, value: &T) -> std::result::Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> std::result::Result<Self::Ok, Self::Error> {
+        self.finish()
+    }
+}
+
+impl SerializeTupleVariant for JsonArraySerializer {
+    type Error = serde_json::Error;
+    type Ok = serde_json::Value;
+
+    fn serialize_field<T>(&mut self, value: &T) -> std::result::Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> std::result::Result<Self::Ok, Self::Error> {
+        self.finish()
+    }
+}
+
+struct JsonObjectSerializer {
+    fields: serde_json::Map<String, serde_json::Value>,
+    next_key: Option<String>,
+    variant: Option<&'static str>,
+}
+
+impl JsonObjectSerializer {
+    fn finish(self) -> std::result::Result<serde_json::Value, serde_json::Error> {
+        let value = serde_json::Value::Object(self.fields);
+        if let Some(variant) = self.variant {
+            let mut fields = serde_json::Map::new();
+            fields.insert(variant.to_string(), value);
+            return Ok(serde_json::Value::Object(fields));
+        }
+        Ok(value)
+    }
+}
+
+impl SerializeMap for JsonObjectSerializer {
+    type Error = serde_json::Error;
+    type Ok = serde_json::Value;
+
+    fn serialize_key<T>(&mut self, key: &T) -> std::result::Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.next_key = Some(key.serialize(JsonKeySerializer)?);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> std::result::Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        let key = self
+            .next_key
+            .take()
+            .ok_or_else(|| json_input_error("map value serialized before map key"))?;
+        self.fields
+            .insert(key, value.serialize(JsonInputSerializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> std::result::Result<Self::Ok, Self::Error> {
+        self.finish()
+    }
+}
+
+impl SerializeStruct for JsonObjectSerializer {
+    type Error = serde_json::Error;
+    type Ok = serde_json::Value;
+
+    fn serialize_field<T>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> std::result::Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.fields
+            .insert(key.to_string(), value.serialize(JsonInputSerializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> std::result::Result<Self::Ok, Self::Error> {
+        self.finish()
+    }
+}
+
+impl SerializeStructVariant for JsonObjectSerializer {
+    type Error = serde_json::Error;
+    type Ok = serde_json::Value;
+
+    fn serialize_field<T>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> std::result::Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        SerializeStruct::serialize_field(self, key, value)
+    }
+
+    fn end(self) -> std::result::Result<Self::Ok, Self::Error> {
+        self.finish()
+    }
+}
+
+struct JsonKeySerializer;
+
+impl ser::Serializer for JsonKeySerializer {
+    type Error = serde_json::Error;
+    type Ok = String;
+    type SerializeMap = Impossible<String, serde_json::Error>;
+    type SerializeSeq = Impossible<String, serde_json::Error>;
+    type SerializeStruct = Impossible<String, serde_json::Error>;
+    type SerializeStructVariant = Impossible<String, serde_json::Error>;
+    type SerializeTuple = Impossible<String, serde_json::Error>;
+    type SerializeTupleStruct = Impossible<String, serde_json::Error>;
+    type SerializeTupleVariant = Impossible<String, serde_json::Error>;
+
+    fn serialize_str(self, value: &str) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> std::result::Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_bool(self, _value: bool) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_i8(self, _value: i8) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_i16(self, _value: i16) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_i32(self, _value: i32) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_i64(self, _value: i64) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_u8(self, _value: u8) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_u16(self, _value: u16) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_u32(self, _value: u32) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_u64(self, _value: u64) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_f32(self, _value: f32) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_f64(self, _value: f64) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_char(self, _value: char) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_none(self) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_some<T>(self, _value: &T) -> std::result::Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_unit(self) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_unit_struct(
+        self,
+        _name: &'static str,
+    ) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> std::result::Result<Self::Ok, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> std::result::Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_seq(
+        self,
+        _len: Option<usize>,
+    ) -> std::result::Result<Self::SerializeSeq, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_tuple(
+        self,
+        _len: usize,
+    ) -> std::result::Result<Self::SerializeTuple, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> std::result::Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> std::result::Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_map(
+        self,
+        _len: Option<usize>,
+    ) -> std::result::Result<Self::SerializeMap, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> std::result::Result<Self::SerializeStruct, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> std::result::Result<Self::SerializeStructVariant, Self::Error> {
+        Err(json_input_error("map keys must be strings"))
+    }
+}
+
+fn json_input_error(message: &'static str) -> serde_json::Error {
+    ser::Error::custom(message)
 }

--- a/sdk/rust/tests/agent_transport.rs
+++ b/sdk/rust/tests/agent_transport.rs
@@ -19,10 +19,21 @@ use gestalt::{
     AgentProvider, ENV_AGENT_HOST_SOCKET_TOKEN, RuntimeMetadata,
 };
 use hyper_util::rt::tokio::TokioIo;
+use serde::Serialize;
 use tokio::net::{TcpListener, UnixListener, UnixStream};
 use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
 use tonic::transport::{Endpoint, Server};
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
+
+#[derive(Serialize)]
+struct LookupArguments {
+    query: String,
+}
+
+#[derive(Serialize)]
+struct BadLookupArguments {
+    score: f64,
+}
 use tower::service_fn;
 
 #[derive(Default)]
@@ -737,21 +748,37 @@ async fn agent_host_client_round_trip_over_unix_socket() {
     assert_eq!(listed.next_page_token, "next-1");
 
     let invoked = host
-        .execute_tool_for_turn(AgentHostExecuteToolInput {
-            session_id: "session-1".to_string(),
-            turn_id: "turn-1".to_string(),
-            tool_call_id: "call-7".to_string(),
-            tool_id: "lookup".to_string(),
-            run_grant: "grant-token".to_string(),
-            idempotency_key: "agent/simple:agent-runtime:turn-1:call-7".to_string(),
-            arguments: Some(serde_json::json!({
-                "query": "Ada Lovelace"
-            })),
-        })
+        .execute_tool_for_turn(
+            AgentHostExecuteToolInput {
+                session_id: "session-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                tool_call_id: "call-7".to_string(),
+                tool_id: "lookup".to_string(),
+                run_grant: "grant-token".to_string(),
+                idempotency_key: "agent/simple:agent-runtime:turn-1:call-7".to_string(),
+                arguments: None,
+            }
+            .with_arguments(LookupArguments {
+                query: "Ada Lovelace".to_string(),
+            })
+            .expect("typed tool arguments"),
+        )
         .await
         .expect("execute tool");
     assert_eq!(invoked.status, 207);
     assert_eq!(invoked.body, "session-1:turn-1:call-7:lookup");
+    let bad_arguments = AgentHostExecuteToolInput::default().with_arguments("not-object");
+    assert!(
+        bad_arguments.is_err(),
+        "non-object tool arguments should fail"
+    );
+    let bad_arguments = AgentHostExecuteToolInput::default().with_arguments(BadLookupArguments {
+        score: f64::INFINITY,
+    });
+    assert!(
+        bad_arguments.is_err(),
+        "non-finite tool arguments should fail"
+    );
 
     let resolved_connection = host
         .resolve_connection_for_turn(AgentHostResolveConnectionInput {

--- a/sdk/rust/tests/plugin_invoker_transport.rs
+++ b/sdk/rust/tests/plugin_invoker_transport.rs
@@ -1,6 +1,7 @@
 #[allow(dead_code)]
 mod helpers;
 
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -17,11 +18,23 @@ use gestalt::{
     PluginInvoker, Request,
 };
 use prost_types::Struct;
+use serde::Serialize;
 use tokio::net::{TcpListener, UnixListener};
 use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
 use tonic::codegen::async_trait;
 use tonic::transport::Server;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
+
+#[derive(Serialize)]
+struct IssueParams {
+    issue: i32,
+    labels: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct BadNumberParams {
+    score: f64,
+}
 
 #[derive(Clone, Debug, Default, PartialEq)]
 struct SeenRequest {
@@ -183,7 +196,10 @@ async fn plugin_invoker_connects_over_unix_socket_and_sends_invocation_token() {
         .invoke(
             "github",
             "get_issue",
-            serde_json::json!({ "issue": 42, "labels": ["bug"] }),
+            IssueParams {
+                issue: 42,
+                labels: vec!["bug".to_string()],
+            },
             Some(InvokeOptions {
                 connection: "work".to_string(),
                 instance: "secondary".to_string(),
@@ -205,6 +221,35 @@ async fn plugin_invoker_connects_over_unix_socket_and_sends_invocation_token() {
             "instance": "secondary",
             "idempotency_key": "issue-42-create",
         })
+    );
+    let err = invoker
+        .invoke("github", "bad", "not-object", None)
+        .await
+        .expect_err("non-object params should fail");
+    assert!(
+        err.to_string().contains("must serialize to a JSON object"),
+        "unexpected error: {err}"
+    );
+    let err = invoker
+        .invoke("github", "bad", BadNumberParams { score: f64::NAN }, None)
+        .await
+        .expect_err("non-finite params should fail");
+    assert!(
+        err.to_string().contains("finite"),
+        "unexpected error: {err}"
+    );
+    let err = invoker
+        .invoke(
+            "github",
+            "bad",
+            BTreeMap::from([(1_i32, "not-a-string-key".to_string())]),
+            None,
+        )
+        .await
+        .expect_err("non-string map keys should fail");
+    assert!(
+        err.to_string().contains("map keys must be strings"),
+        "unexpected error: {err}"
     );
 
     let seen = server

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -86,8 +86,11 @@ can import generated schemas, services, and message types from
 `@valon-technologies/gestalt/protocol/v1` instead of reaching into internal
 paths. Public IndexedDB conversion helpers are exported for lower-level
 datastore fixtures. The root package also exports protocol conversion helpers
-such as `structFromJsonObject`, `valueFromJson`, and `timestampFromDate` for
-protobuf well-known type fields used by workflow and agent payloads.
+such as `structFromObject`, `structFromJsonObject`, `valueFromJson`, and
+`timestampFromDate` for protobuf well-known type fields used by workflow and
+agent payloads. Struct helpers accept plain JSON objects and reject unsupported
+values like `Date`, `Map`, class instances, `undefined`, `bigint`, and
+non-finite numbers instead of silently dropping or stringifying them.
 
 The TypeScript SDK does not currently expose an authored authorization-provider
 helper. Use the Go SDK when you need to build a custom authorization provider.

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -2,7 +2,6 @@ import {
   create,
   fromJson,
   isMessage,
-  type JsonObject,
   type JsonValue,
   type MessageInitShape,
 } from "@bufbuild/protobuf";
@@ -76,6 +75,7 @@ import {
   type UpdateAgentProviderSessionRequest,
 } from "./internal/gen/v1/agent_pb.ts";
 import { errorMessage, type MaybePromise } from "./api.ts";
+import { structFromObject, type JsonObjectInput } from "./protocol.ts";
 import { ProviderBase, type ProviderBaseOptions } from "./provider.ts";
 
 /** Environment variable containing the agent-host service target. */
@@ -175,7 +175,7 @@ export interface AgentHostExecuteToolInput {
   turnId: string;
   toolCallId: string;
   toolId: string;
-  arguments?: JsonObject | undefined;
+  arguments?: JsonObjectInput | undefined;
   runGrant?: string | undefined;
   idempotencyKey?: string | undefined;
 }
@@ -503,7 +503,7 @@ export class AgentHost {
         turnId: input.turnId,
         toolCallId: input.toolCallId,
         toolId: input.toolId,
-        arguments: input.arguments,
+        arguments: input.arguments === undefined ? undefined : structFromObject(input.arguments),
         runGrant: input.runGrant ?? "",
         idempotencyKey: input.idempotencyKey ?? "",
       }),

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -87,11 +87,16 @@ export {
 } from "./build.ts";
 export {
   dateFromTimestamp,
+  jsonFromInput,
   jsonFromValue,
   jsonObjectFromStruct,
+  structFromObject,
   structFromJsonObject,
   timestampFromDate,
   valueFromJson,
+  type JsonInput,
+  type JsonObjectInput,
+  type JsonPrimitiveInput,
 } from "./protocol.ts";
 export {
   ENV_PLUGIN_INVOKER_SOCKET,

--- a/sdk/typescript/src/invoker.ts
+++ b/sdk/typescript/src/invoker.ts
@@ -1,9 +1,9 @@
-import type { JsonObject, JsonValue } from "@bufbuild/protobuf";
 import { createClient, type Client, type Interceptor } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 
 import { PluginInvoker as PluginInvokerService } from "./internal/gen/v1/plugin_pb.ts";
 import type { OperationResult, Request } from "./api.ts";
+import { structFromObject, type JsonObjectInput } from "./protocol.ts";
 
 /** Environment variable containing the plugin-invoker host-service target. */
 export const ENV_PLUGIN_INVOKER_SOCKET = "GESTALT_PLUGIN_INVOKER_SOCKET";
@@ -37,7 +37,7 @@ export interface PluginInvocationGrant {
 /** Options for invoking a plugin GraphQL surface. */
 export interface PluginGraphQLInvokeOptions extends PluginInvokeOptions {
   /** GraphQL variables encoded as a JSON object. */
-  variables?: Record<string, unknown>;
+  variables?: JsonObjectInput;
 }
 
 /**
@@ -72,14 +72,14 @@ export class PluginInvoker {
   async invoke(
     plugin: string,
     operation: string,
-    params: Record<string, unknown> = {},
+    params: JsonObjectInput = {},
     options?: PluginInvokeOptions,
   ): Promise<OperationResult> {
     const response = await this.client.invoke({
       invocationToken: this.invocationToken,
       plugin,
       operation,
-      params: toJsonObject(params),
+      params: structFromObject(params),
       connection: options?.connection ?? "",
       instance: options?.instance ?? "",
       idempotencyKey: options?.idempotencyKey?.trim() ?? "",
@@ -105,8 +105,8 @@ export class PluginInvoker {
       invocationToken: this.invocationToken,
       plugin,
       document: trimmedDocument,
-      ...(options?.variables
-        ? { variables: toJsonObject(options.variables) }
+      ...(options?.variables !== undefined
+        ? { variables: structFromObject(options.variables) }
         : {}),
       connection: options?.connection ?? "",
       instance: options?.instance ?? "",
@@ -198,33 +198,4 @@ function normalizeInvocationToken(requestOrToken: Request | string): string {
     throw new Error("plugin invoker: invocation token is not available");
   }
   return trimmed;
-}
-
-function toJsonObject(params: Record<string, unknown>): JsonObject {
-  const output: JsonObject = {};
-  for (const [key, value] of Object.entries(params ?? {})) {
-    if (value === undefined) {
-      continue;
-    }
-    output[key] = toJsonValue(value);
-  }
-  return output;
-}
-
-function toJsonValue(value: unknown): JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return value as JsonValue;
-  }
-  if (Array.isArray(value)) {
-    return value.map((entry) => toJsonValue(entry));
-  }
-  if (typeof value === "object") {
-    return toJsonObject(value as Record<string, unknown>);
-  }
-  throw new Error("plugin invoker: params must be JSON-serializable");
 }

--- a/sdk/typescript/src/protocol.ts
+++ b/sdk/typescript/src/protocol.ts
@@ -17,9 +17,21 @@ const MAX_TIMESTAMP_SECONDS = 253_402_300_799n;
 const MIN_TIMESTAMP_SECONDS_NUMBER = Number(MIN_TIMESTAMP_SECONDS);
 const MAX_TIMESTAMP_SECONDS_NUMBER = Number(MAX_TIMESTAMP_SECONDS);
 
+/** Primitive values accepted in protobuf JSON payloads. */
+export type JsonPrimitiveInput = null | boolean | number | string;
+/** Native value accepted by SDK-owned protocol helpers before runtime validation. */
+export type JsonInput = JsonPrimitiveInput | readonly unknown[] | object;
+/** Native object accepted by SDK-owned Struct helpers before runtime validation. */
+export type JsonObjectInput = object;
+
+/** Returns a protobuf Struct-compatible JSON object for generated message fields. */
+export function structFromObject(value: JsonObjectInput = {}): JsonObject {
+  return normalizeJsonObject(value, "struct", new WeakSet<object>());
+}
+
 /** Returns a protobuf Struct-compatible JSON object for generated message fields. */
 export function structFromJsonObject(value: JsonObject = {}): JsonObject {
-  return { ...value };
+  return structFromObject(value);
 }
 
 /** Converts a protobuf Struct-compatible field value back to a JSON object. */
@@ -27,9 +39,9 @@ export function jsonObjectFromStruct(value?: JsonObject | undefined): JsonObject
   return value === undefined ? {} : { ...value };
 }
 
-/** Converts a JSON value into a protobuf Value message. */
-export function valueFromJson(value: JsonValue): Value {
-  return fromJson(ValueSchema, value);
+/** Converts a JSON-compatible native value into a protobuf Value message. */
+export function valueFromJson(value: JsonInput): Value {
+  return fromJson(ValueSchema, jsonFromInput(value));
 }
 
 /** Converts a protobuf Value message into its JSON value. */
@@ -78,4 +90,79 @@ export function dateFromTimestamp(value: Timestamp): Date {
     throw new RangeError("protobuf Timestamp seconds out of range");
   }
   return date;
+}
+
+/** Returns a protobuf-compatible JSON value from native SDK input. */
+export function jsonFromInput(value: JsonInput): JsonValue {
+  return normalizeJsonValue(value, "value", new WeakSet<object>());
+}
+
+function normalizeJsonObject(
+  value: unknown,
+  path: string,
+  seen: WeakSet<object>,
+): JsonObject {
+  if (!isPlainObject(value)) {
+    throw new TypeError(`${path} must be a plain JSON object`);
+  }
+  if (seen.has(value)) {
+    throw new TypeError(`${path} contains a cycle`);
+  }
+  seen.add(value);
+  try {
+    const output: JsonObject = {};
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== "string") {
+        throw new TypeError(`${path} keys must be strings`);
+      }
+    }
+    for (const [key, entry] of Object.entries(value)) {
+      output[key] = normalizeJsonValue(entry, `${path}.${key}`, seen);
+    }
+    return output;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function normalizeJsonValue(
+  value: unknown,
+  path: string,
+  seen: WeakSet<object>,
+): JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(`${path} must be a finite number`);
+    }
+    return value;
+  }
+  if (typeof value === "undefined") {
+    throw new TypeError(`${path} must not be undefined`);
+  }
+  if (typeof value === "bigint" || typeof value === "symbol" || typeof value === "function") {
+    throw new TypeError(`${path} must be JSON-compatible`);
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      throw new TypeError(`${path} contains a cycle`);
+    }
+    seen.add(value);
+    try {
+      return value.map((entry, index) => normalizeJsonValue(entry, `${path}[${index}]`, seen));
+    } finally {
+      seen.delete(value);
+    }
+  }
+  return normalizeJsonObject(value, path, seen);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }

--- a/sdk/typescript/tests/agent.transport.test.ts
+++ b/sdk/typescript/tests/agent.transport.test.ts
@@ -308,6 +308,7 @@ test("AgentHost executes tools through the configured unix socket", async () => 
       toolId: "lookup-status",
       arguments: {
         deployment: "blue",
+        metadata: Object.freeze({ owner: "runtime" }),
       },
       runGrant: "grant-token",
       idempotencyKey: "tool-call-key-123",
@@ -317,6 +318,7 @@ test("AgentHost executes tools through the configured unix socket", async () => 
     expect(JSON.parse(response.body)).toEqual({
       arguments: {
         deployment: "blue",
+        metadata: { owner: "runtime" },
       },
       toolId: "lookup-status",
     });
@@ -328,6 +330,7 @@ test("AgentHost executes tools through the configured unix socket", async () => 
         toolId: "lookup-status",
         arguments: {
           deployment: "blue",
+          metadata: { owner: "runtime" },
         },
         runGrant: "grant-token",
         idempotencyKey: "tool-call-key-123",

--- a/sdk/typescript/tests/invoker.transport.test.ts
+++ b/sdk/typescript/tests/invoker.transport.test.ts
@@ -22,6 +22,10 @@ import {
 } from "../src/index.ts";
 import { removeTempDir } from "./helpers.ts";
 
+interface IssueLookupParams {
+  issue_number: number;
+}
+
 test("PluginInvoker forwards invocation tokens from strings and Request objects", async () => {
   const tempDir = mkdtempSync(join(tmpdir(), "gts-plugin-invoker-"));
   const socketPath = join(tempDir, "plugin-invoker.sock");
@@ -163,12 +167,13 @@ test("PluginInvoker forwards invocation tokens from strings and Request objects"
     });
     expect(childToken).toBe("invocation-token-123:child");
 
+    const issueLookupParams: IssueLookupParams = {
+      issue_number: 42,
+    };
     const first = await fromHandle.invoke(
       "github",
       "get_issue",
-      {
-        issue_number: 42,
-      },
+      issueLookupParams,
       {
         connection: "work",
         instance: "secondary",
@@ -195,6 +200,7 @@ test("PluginInvoker forwards invocation tokens from strings and Request objects"
     const second = await fromRequest.invoke("slack", "post_message", {
       channel: "eng",
       text: "hello",
+      nested: Object.freeze({ urgent: true }),
     });
 
     expect(second.status).toBe(207);
@@ -205,11 +211,16 @@ test("PluginInvoker forwards invocation tokens from strings and Request objects"
       params: {
         channel: "eng",
         text: "hello",
+        nested: { urgent: true },
       },
       connection: "",
       instance: "",
       idempotencyKey: "",
     });
+
+    await expect(
+      fromRequest.invoke("slack", "bad", { when: new Date() } as any),
+    ).rejects.toThrow(TypeError);
 
     const graphql = await fromRequest.invokeGraphQL(
       "linear",
@@ -280,6 +291,7 @@ test("PluginInvoker forwards invocation tokens from strings and Request objects"
         params: {
           channel: "eng",
           text: "hello",
+          nested: { urgent: true },
         },
         connection: "",
         instance: "",

--- a/sdk/typescript/tests/protocol.test.ts
+++ b/sdk/typescript/tests/protocol.test.ts
@@ -6,6 +6,7 @@ import {
   dateFromTimestamp,
   jsonFromValue,
   jsonObjectFromStruct,
+  structFromObject,
   structFromJsonObject,
   timestampFromDate,
   valueFromJson,
@@ -16,7 +17,7 @@ import {
 } from "../src/internal/gen/v1/workflow_pb.ts";
 
 test("protocol helpers produce generated workflow field shapes", () => {
-  const payload = structFromJsonObject({ ok: true, nested: { value: "yes" } });
+  const payload = structFromObject({ ok: true, nested: { value: "yes" } });
   const metadata = structFromJsonObject({ source: "test" });
   const extension = valueFromJson(["trace", 1]);
   const timestamp = timestampFromDate(new Date("1969-12-31T23:59:59.999Z"));
@@ -52,6 +53,26 @@ test("protocol helpers produce generated workflow field shapes", () => {
   expect(dateFromTimestamp(timestamp).toISOString()).toBe(
     "1969-12-31T23:59:59.999Z",
   );
+});
+
+test("structFromObject rejects non-JSON object values explicitly", () => {
+  class CustomObject {
+    value = "hidden";
+  }
+  const cyclic: Record<string, unknown> = {};
+  cyclic.self = cyclic;
+  const symbolKey = Symbol("hidden");
+
+  expect(() => structFromObject({ when: new Date() } as any)).toThrow(TypeError);
+  expect(() => structFromObject({ map: new Map() } as any)).toThrow(TypeError);
+  expect(() => structFromObject({ custom: new CustomObject() } as any)).toThrow(TypeError);
+  expect(() => structFromObject({ missing: undefined } as any)).toThrow(TypeError);
+  expect(() => structFromObject({ id: 1n } as any)).toThrow(TypeError);
+  expect(() => structFromObject({ score: Number.NaN } as any)).toThrow(TypeError);
+  expect(() => structFromObject({ [symbolKey]: "secret", visible: true } as any)).toThrow(
+    TypeError,
+  );
+  expect(() => structFromObject(cyclic as any)).toThrow(TypeError);
 });
 
 test("timestampFromDate rejects invalid dates and dateFromTimestamp validates nanos", () => {


### PR DESCRIPTION
## Summary

Make SDK-owned protobuf Struct construction accept native JSON-shaped inputs directly, so provider authors do not have to hand-build protobufs or call conversion helpers at invoker/agent-host call sites.

This intentionally does not add Pydantic support.

## Interface Changes

- Python: `struct_from_dict`, `value_from_json`, `PluginInvoker.invoke`, `PluginInvoker.invoke_graphql`, and `AgentHost.execute_tool_for_turn` accept JSON-compatible mappings and dataclass instances. Generic JSON payloads reject datetime-like values, bytes, non-string keys, cycles, and unsupported rich objects.
- TypeScript: exports `structFromObject`, `jsonFromInput`, and `Json*Input` types. `PluginInvoker` and `AgentHost` accept native plain objects, including named interface values, with runtime rejection for `Date`, `Map`, class instances, `undefined`, `bigint`, non-finite numbers, and cycles.
- Go: `StructFromAny`, invoker params/variables, and agent-host arguments accept structs, string-keyed map aliases, and pointers while preserving nil/empty request-presence behavior. Generic Struct payloads reject `time.Time`, `json.Marshaler`, non-string keys, cycles, `[]byte`, and non-finite numbers.
- Rust: centralizes `Serialize` to protobuf Struct conversion in `protocol`, reuses it from `PluginInvoker`, and adds `AgentHostExecuteToolInput::with_arguments<T: Serialize>()` for typed arguments without changing the public field shape.

Example usage:

```python
@dataclass
class IssueParams:
    repo: str
    issue_number: int

request.invoker().invoke("github", "get_issue", IssueParams("valon-technologies/gestalt", 42))
```

```ts
interface IssueParams { issue_number: number }
await invoker.invoke("github", "get_issue", { issue_number: 42 } satisfies IssueParams);
```

```go
type IssueParams struct {
    IssueNumber int `json:"issue_number"`
}
_, err := client.Invoke(ctx, "github", "get_issue", IssueParams{IssueNumber: 42}, nil)
```

```rust
#[derive(serde::Serialize)]
struct IssueParams { issue: i32 }
invoker.invoke("github", "get_issue", IssueParams { issue: 42 }, None).await?;
```

## Functional/Integration Tests

- Tests added or augmented:
  - Python transport tests for `PluginInvoker` and `AgentHost` native dataclass inputs and explicit rejection paths.
  - TypeScript protocol and transport tests for plain objects, named interface inputs, nested frozen objects, and rejection paths.
  - Go transport tests for struct inputs and rejection paths through `InvokerClient` plus agent-host struct arguments.
  - Rust transport tests for `Serialize` invoker params and agent-host `with_arguments`.
- Contract boundary covered: public SDK APIs through existing transport-backed host-service tests and docs builds.
- Commands run:
  - `cd sdk/python && uv run ruff check . && uv run ty check --exclude 'gestalt/_gen/**' gestalt scripts tests && uv run vulture --config pyproject.toml && uv run python -m unittest discover -s tests && uv run sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html`
  - `cd sdk/typescript && bun run check && bun run docs:lint && bun run docs:build`
  - `cd sdk/go && go test ./...`
  - `cd sdk/rust && cargo test`
  - `cd sdk/rust && cargo fmt --check && cargo clippy --all-targets -- -D warnings && RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`
