### PR TITLE
Accept native times in SDK protocol builders

### DIFF
--- a/sdk/go/authorization.go
+++ b/sdk/go/authorization.go
@@ -2,6 +2,7 @@ package gestalt
 
 import (
 	"context"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
 )
@@ -117,6 +118,16 @@ func NewAuthorizationResource(resourceType, id string) *AuthorizationResource {
 // NewAuthorizationAction creates an action reference for authorization requests.
 func NewAuthorizationAction(name string) *AuthorizationAction {
 	return &AuthorizationAction{Name: name}
+}
+
+// NewAuthorizationModelRef creates an authorization model reference from native
+// Go values.
+func NewAuthorizationModelRef(id, version string, createdAt time.Time) *AuthorizationModelRef {
+	return &AuthorizationModelRef{
+		Id:        id,
+		Version:   version,
+		CreatedAt: timestampFromNonZeroTime(createdAt),
+	}
 }
 
 // NewAccessEvaluationRequest creates an access-evaluation request.

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -67,15 +67,17 @@
 // AgentHostClient includes plain Go helper methods such as ExecuteToolForTurn,
 // ListToolsForTurn, and ResolveConnectionForTurn. For lower-level fixtures and
 // interoperability tests, package gen/v1 re-exports selected generated
-// protobuf bindings. StructFromMap, StructFromAny, ValueFromAny,
-// ValuesFromMap, TimestampFromTime, TimestampFromTimePtr, and the IndexedDB
-// codec helpers convert between native Go values and protobuf well-known or
-// IndexedDB wire types without importing internal packages. StructFromAny also
-// accepts structs, string-keyed map aliases, and pointers to either form; it
-// rejects time.Time, json.Marshaler values, non-string map keys, cycles, and
-// non-finite numbers in generic Struct payloads. Embedded struct fields are
-// not flattened like encoding/json; anonymous embedded fields must have an
-// explicit json tag name.
+// protobuf bindings. SDK constructors such as NewBoundWorkflowRun,
+// NewWorkflowSignal, and NewAuthorizationModelRef accept native time.Time
+// values and JSON-compatible maps or structs, so provider code can keep
+// protobuf timestamp and Struct conversion at the SDK boundary. StructFromMap,
+// StructFromAny, ValueFromAny, ValuesFromMap, TimestampFromTime,
+// TimestampFromTimePtr, and the IndexedDB codec helpers remain available for
+// lower-level interop and tests. StructFromAny accepts structs, string-keyed
+// map aliases, and pointers to either form; it rejects time.Time,
+// json.Marshaler values, non-string map keys, cycles, and non-finite numbers in
+// generic Struct payloads. Embedded struct fields are not flattened like
+// encoding/json; anonymous embedded fields must have an explicit json tag name.
 //
 // See https://gestaltd.ai/reference/go-sdk for the Go SDK guide.
 // See https://gestaltd.ai/custom-providers/plugins for the full typed plugin

--- a/sdk/go/workflow_builders.go
+++ b/sdk/go/workflow_builders.go
@@ -1,0 +1,236 @@
+package gestalt
+
+import (
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// WorkflowEventInput contains native Go values for constructing a WorkflowEvent.
+type WorkflowEventInput struct {
+	ID              string
+	Source          string
+	SpecVersion     string
+	Type            string
+	Subject         string
+	Time            time.Time
+	DataContentType string
+	Data            any
+	Extensions      map[string]any
+}
+
+// NewWorkflowEvent creates a workflow event from native Go values.
+func NewWorkflowEvent(input WorkflowEventInput) (*WorkflowEvent, error) {
+	data, err := StructFromAny(input.Data)
+	if err != nil {
+		return nil, err
+	}
+	extensions, err := ValuesFromMap(input.Extensions)
+	if err != nil {
+		return nil, err
+	}
+	return &WorkflowEvent{
+		Id:              input.ID,
+		Source:          input.Source,
+		SpecVersion:     input.SpecVersion,
+		Type:            input.Type,
+		Subject:         input.Subject,
+		Time:            timestampFromNonZeroTime(input.Time),
+		Datacontenttype: input.DataContentType,
+		Data:            data,
+		Extensions:      extensions,
+	}, nil
+}
+
+// WorkflowSignalInput contains native Go values for constructing a
+// WorkflowSignal.
+type WorkflowSignalInput struct {
+	ID             string
+	Name           string
+	Payload        any
+	Metadata       any
+	CreatedBy      *WorkflowActor
+	CreatedAt      time.Time
+	IdempotencyKey string
+	Sequence       int64
+}
+
+// NewWorkflowSignal creates a workflow signal from native Go values.
+func NewWorkflowSignal(input WorkflowSignalInput) (*WorkflowSignal, error) {
+	payload, err := StructFromAny(input.Payload)
+	if err != nil {
+		return nil, err
+	}
+	metadata, err := StructFromAny(input.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	return &WorkflowSignal{
+		Id:             input.ID,
+		Name:           input.Name,
+		Payload:        payload,
+		Metadata:       metadata,
+		CreatedBy:      input.CreatedBy,
+		CreatedAt:      timestampFromNonZeroTime(input.CreatedAt),
+		IdempotencyKey: input.IdempotencyKey,
+		Sequence:       input.Sequence,
+	}, nil
+}
+
+// NewWorkflowScheduleTrigger creates a schedule-trigger run trigger from native
+// Go values.
+func NewWorkflowScheduleTrigger(scheduleID string, scheduledFor time.Time) *WorkflowRunTrigger {
+	return &WorkflowRunTrigger{Kind: &WorkflowRunTriggerSchedule{Schedule: &WorkflowScheduleTrigger{
+		ScheduleId:   scheduleID,
+		ScheduledFor: timestampFromNonZeroTime(scheduledFor),
+	}}}
+}
+
+// BoundWorkflowRunInput contains native Go values for constructing a
+// BoundWorkflowRun.
+type BoundWorkflowRunInput struct {
+	ID            string
+	Status        WorkflowRunStatus
+	Target        *BoundWorkflowTarget
+	Trigger       *WorkflowRunTrigger
+	CreatedAt     time.Time
+	StartedAt     *time.Time
+	CompletedAt   *time.Time
+	StatusMessage string
+	ResultBody    string
+	CreatedBy     *WorkflowActor
+	ExecutionRef  string
+	WorkflowKey   string
+}
+
+// NewBoundWorkflowRun creates a bound workflow run from native Go values.
+func NewBoundWorkflowRun(input BoundWorkflowRunInput) *BoundWorkflowRun {
+	return &BoundWorkflowRun{
+		Id:            input.ID,
+		Status:        input.Status,
+		Target:        input.Target,
+		Trigger:       input.Trigger,
+		CreatedAt:     timestampFromNonZeroTime(input.CreatedAt),
+		StartedAt:     timestampFromOptionalTime(input.StartedAt),
+		CompletedAt:   timestampFromOptionalTime(input.CompletedAt),
+		StatusMessage: input.StatusMessage,
+		ResultBody:    input.ResultBody,
+		CreatedBy:     input.CreatedBy,
+		ExecutionRef:  input.ExecutionRef,
+		WorkflowKey:   input.WorkflowKey,
+	}
+}
+
+// BoundWorkflowScheduleInput contains native Go values for constructing a
+// BoundWorkflowSchedule.
+type BoundWorkflowScheduleInput struct {
+	ID           string
+	Cron         string
+	Timezone     string
+	Target       *BoundWorkflowTarget
+	Paused       bool
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	NextRunAt    *time.Time
+	CreatedBy    *WorkflowActor
+	ExecutionRef string
+}
+
+// NewBoundWorkflowSchedule creates a bound workflow schedule from native Go
+// values.
+func NewBoundWorkflowSchedule(input BoundWorkflowScheduleInput) *BoundWorkflowSchedule {
+	return &BoundWorkflowSchedule{
+		Id:           input.ID,
+		Cron:         input.Cron,
+		Timezone:     input.Timezone,
+		Target:       input.Target,
+		Paused:       input.Paused,
+		CreatedAt:    timestampFromNonZeroTime(input.CreatedAt),
+		UpdatedAt:    timestampFromNonZeroTime(input.UpdatedAt),
+		NextRunAt:    timestampFromOptionalTime(input.NextRunAt),
+		CreatedBy:    input.CreatedBy,
+		ExecutionRef: input.ExecutionRef,
+	}
+}
+
+// BoundWorkflowEventTriggerInput contains native Go values for constructing a
+// BoundWorkflowEventTrigger.
+type BoundWorkflowEventTriggerInput struct {
+	ID           string
+	Match        *WorkflowEventMatch
+	Target       *BoundWorkflowTarget
+	Paused       bool
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	CreatedBy    *WorkflowActor
+	ExecutionRef string
+}
+
+// NewBoundWorkflowEventTrigger creates a bound workflow event trigger from
+// native Go values.
+func NewBoundWorkflowEventTrigger(input BoundWorkflowEventTriggerInput) *BoundWorkflowEventTrigger {
+	return &BoundWorkflowEventTrigger{
+		Id:           input.ID,
+		Match:        input.Match,
+		Target:       input.Target,
+		Paused:       input.Paused,
+		CreatedAt:    timestampFromNonZeroTime(input.CreatedAt),
+		UpdatedAt:    timestampFromNonZeroTime(input.UpdatedAt),
+		CreatedBy:    input.CreatedBy,
+		ExecutionRef: input.ExecutionRef,
+	}
+}
+
+// WorkflowExecutionReferenceInput contains native Go values for constructing a
+// WorkflowExecutionReference.
+type WorkflowExecutionReferenceInput struct {
+	ID                  string
+	ProviderName        string
+	Target              *BoundWorkflowTarget
+	SubjectID           string
+	CredentialSubjectID string
+	Permissions         []*WorkflowAccessPermission
+	CreatedAt           time.Time
+	RevokedAt           *time.Time
+	SubjectKind         string
+	DisplayName         string
+	AuthSource          string
+	CallerPluginName    string
+	RunAs               *WorkflowRunAsSubject
+	SourceDefinitionID  string
+}
+
+// NewWorkflowExecutionReference creates a workflow execution reference from
+// native Go values.
+func NewWorkflowExecutionReference(input WorkflowExecutionReferenceInput) *WorkflowExecutionReference {
+	return &WorkflowExecutionReference{
+		Id:                  input.ID,
+		ProviderName:        input.ProviderName,
+		Target:              input.Target,
+		SubjectId:           input.SubjectID,
+		CredentialSubjectId: input.CredentialSubjectID,
+		Permissions:         input.Permissions,
+		CreatedAt:           timestampFromNonZeroTime(input.CreatedAt),
+		RevokedAt:           timestampFromOptionalTime(input.RevokedAt),
+		SubjectKind:         input.SubjectKind,
+		DisplayName:         input.DisplayName,
+		AuthSource:          input.AuthSource,
+		CallerPluginName:    input.CallerPluginName,
+		RunAs:               input.RunAs,
+		SourceDefinitionId:  input.SourceDefinitionID,
+	}
+}
+
+func timestampFromNonZeroTime(value time.Time) *timestamppb.Timestamp {
+	if value.IsZero() {
+		return nil
+	}
+	return TimestampFromTime(value)
+}
+
+func timestampFromOptionalTime(value *time.Time) *timestamppb.Timestamp {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	return TimestampFromTime(*value)
+}

--- a/sdk/go/workflow_builders_test.go
+++ b/sdk/go/workflow_builders_test.go
@@ -1,0 +1,108 @@
+package gestalt_test
+
+import (
+	"testing"
+	"time"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+)
+
+func TestNewBoundWorkflowRunUsesNativeTimes(t *testing.T) {
+	createdAt := time.Date(2026, 5, 8, 12, 0, 0, 123_000_000, time.UTC)
+	startedAt := createdAt.Add(time.Minute)
+	run := gestalt.NewBoundWorkflowRun(gestalt.BoundWorkflowRunInput{
+		ID:        "run-1",
+		Status:    gestalt.WorkflowRunStatusValueRunning,
+		CreatedAt: createdAt,
+		StartedAt: &startedAt,
+	})
+
+	if run.GetId() != "run-1" {
+		t.Fatalf("id = %q, want run-1", run.GetId())
+	}
+	if got := run.GetCreatedAt().AsTime(); !got.Equal(createdAt) {
+		t.Fatalf("created_at = %v, want %v", got, createdAt)
+	}
+	if got := run.GetStartedAt().AsTime(); !got.Equal(startedAt) {
+		t.Fatalf("started_at = %v, want %v", got, startedAt)
+	}
+	if run.GetCompletedAt() != nil {
+		t.Fatalf("completed_at = %#v, want nil", run.GetCompletedAt())
+	}
+}
+
+func TestWorkflowNativeBuildersOmitZeroTimes(t *testing.T) {
+	run := gestalt.NewBoundWorkflowRun(gestalt.BoundWorkflowRunInput{})
+	if run.GetCreatedAt() != nil {
+		t.Fatalf("created_at = %#v, want nil", run.GetCreatedAt())
+	}
+
+	schedule := gestalt.NewBoundWorkflowSchedule(gestalt.BoundWorkflowScheduleInput{})
+	if schedule.GetCreatedAt() != nil || schedule.GetUpdatedAt() != nil || schedule.GetNextRunAt() != nil {
+		t.Fatalf("schedule timestamps = %#v/%#v/%#v, want nil", schedule.GetCreatedAt(), schedule.GetUpdatedAt(), schedule.GetNextRunAt())
+	}
+}
+
+func TestNewWorkflowSignalUsesNativePayloadsAndTime(t *testing.T) {
+	createdAt := time.Date(2026, 5, 8, 13, 0, 0, 0, time.UTC)
+	signal, err := gestalt.NewWorkflowSignal(gestalt.WorkflowSignalInput{
+		ID:      "signal-1",
+		Name:    "changed",
+		Payload: map[string]any{"count": 2},
+		Metadata: struct {
+			Source string `json:"source"`
+		}{Source: "test"},
+		CreatedAt: createdAt,
+	})
+	if err != nil {
+		t.Fatalf("NewWorkflowSignal: %v", err)
+	}
+	if got := signal.GetPayload().AsMap()["count"]; got != float64(2) {
+		t.Fatalf("payload.count = %#v, want 2", got)
+	}
+	if got := signal.GetMetadata().AsMap()["source"]; got != "test" {
+		t.Fatalf("metadata.source = %#v, want test", got)
+	}
+	if got := signal.GetCreatedAt().AsTime(); !got.Equal(createdAt) {
+		t.Fatalf("created_at = %v, want %v", got, createdAt)
+	}
+}
+
+func TestNewWorkflowEventUsesNativeDataExtensionsAndTime(t *testing.T) {
+	eventTime := time.Date(2026, 5, 8, 14, 0, 0, 0, time.UTC)
+	event, err := gestalt.NewWorkflowEvent(gestalt.WorkflowEventInput{
+		ID:              "event-1",
+		Source:          "provider",
+		SpecVersion:     "1.0",
+		Type:            "thing.changed",
+		Subject:         "thing:1",
+		Time:            eventTime,
+		DataContentType: "application/json",
+		Data:            map[string]any{"ok": true},
+		Extensions:      map[string]any{"attempt": 1},
+	})
+	if err != nil {
+		t.Fatalf("NewWorkflowEvent: %v", err)
+	}
+	if got := event.GetTime().AsTime(); !got.Equal(eventTime) {
+		t.Fatalf("time = %v, want %v", got, eventTime)
+	}
+	if got := event.GetData().AsMap()["ok"]; got != true {
+		t.Fatalf("data.ok = %#v, want true", got)
+	}
+	if got := event.GetExtensions()["attempt"].AsInterface(); got != float64(1) {
+		t.Fatalf("extensions.attempt = %#v, want 1", got)
+	}
+}
+
+func TestNewAuthorizationModelRefUsesNativeTime(t *testing.T) {
+	createdAt := time.Date(2026, 5, 8, 15, 0, 0, 0, time.UTC)
+	ref := gestalt.NewAuthorizationModelRef("model-1", "v1", createdAt)
+
+	if ref.GetId() != "model-1" || ref.GetVersion() != "v1" {
+		t.Fatalf("ref = %q/%q, want model-1/v1", ref.GetId(), ref.GetVersion())
+	}
+	if got := ref.GetCreatedAt().AsTime(); !got.Equal(createdAt) {
+		t.Fatalf("created_at = %v, want %v", got, createdAt)
+	}
+}

--- a/sdk/go/workflow_provider.go
+++ b/sdk/go/workflow_provider.go
@@ -173,6 +173,7 @@ type (
 	WorkflowOutputValueSourceSignalMetadata   = proto.WorkflowOutputValueSource_SignalMetadata
 	WorkflowOutputValueSourceLiteral          = proto.WorkflowOutputValueSource_Literal
 	WorkflowActor                             = proto.WorkflowActor
+	WorkflowRunAsSubject                      = proto.WorkflowRunAsSubject
 	WorkflowEvent                             = proto.WorkflowEvent
 	WorkflowEventMatch                        = proto.WorkflowEventMatch
 	WorkflowManualTrigger                     = proto.WorkflowManualTrigger

--- a/sdk/python/docs/reference.rst
+++ b/sdk/python/docs/reference.rst
@@ -170,13 +170,18 @@ rejected in generic JSON payloads and should use timestamp helpers instead.
 Agent protocol helpers
 ----------------------
 
-These helpers convert common agent protocol messages to and from plain
-lower-snake-case dictionaries while preserving protobuf field presence for
-optional structured payloads.
+These helpers build common agent protocol messages from native Python values
+and convert them to and from plain lower-snake-case dictionaries while
+preserving protobuf field presence for optional structured payloads. Timestamp
+fields on ``AgentSession``, ``AgentTurn``, and ``AgentTurnEvent`` accept
+timezone-aware ``datetime`` values.
 
 .. autosummary::
    :nosignatures:
 
+   AgentSession
+   AgentTurn
+   AgentTurnEvent
    agent_actor_to_dict
    agent_actor_from_dict
    agent_subject_context_to_dict
@@ -195,6 +200,12 @@ optional structured payloads.
    agent_message_from_proto_dict
    agent_messages_to_proto_dicts
    agent_messages_from_proto_dicts
+
+.. autofunction:: AgentSession
+
+.. autofunction:: AgentTurn
+
+.. autofunction:: AgentTurnEvent
 
 .. autofunction:: agent_actor_to_dict
 

--- a/sdk/python/gestalt/_agent.py
+++ b/sdk/python/gestalt/_agent.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import datetime as _dt
 import os
 from collections.abc import Iterable, Mapping
-from typing import Any
+from typing import Any, TypeAlias
 
 import grpc
+from typing_extensions import TypedDict, Unpack
 
 from ._gen.v1 import agent_pb2 as _pb
 from ._gen.v1 import agent_pb2_grpc as _pb_grpc
@@ -57,6 +59,49 @@ AGENT_SESSION_STATE_ARCHIVED = pb.AGENT_SESSION_STATE_ARCHIVED
 
 AGENT_TOOL_SOURCE_MODE_UNSPECIFIED = pb.AGENT_TOOL_SOURCE_MODE_UNSPECIFIED
 AGENT_TOOL_SOURCE_MODE_MCP_CATALOG = pb.AGENT_TOOL_SOURCE_MODE_MCP_CATALOG
+
+TimestampInput: TypeAlias = _dt.datetime | Mapping[str, Any] | None
+
+
+class AgentSessionInput(TypedDict, total=False):
+    id: str
+    provider_name: str
+    model: str
+    client_ref: str
+    state: int | str
+    metadata: JsonObjectInput | None
+    created_by: Any
+    created_at: TimestampInput
+    updated_at: TimestampInput
+    last_turn_at: TimestampInput
+
+
+class AgentTurnInput(TypedDict, total=False):
+    id: str
+    session_id: str
+    provider_name: str
+    model: str
+    status: int | str
+    messages: Iterable[Any]
+    output_text: str
+    structured_output: JsonObjectInput | None
+    status_message: str
+    execution_ref: str
+    created_by: Any
+    created_at: TimestampInput
+    started_at: TimestampInput
+    completed_at: TimestampInput
+
+
+class AgentTurnEventInput(TypedDict, total=False):
+    id: str
+    turn_id: str
+    seq: int
+    type: str
+    source: str
+    visibility: str
+    data: JsonObjectInput | None
+    created_at: TimestampInput
 
 
 def AgentMessage(*args: Any, **kwargs: Any) -> Any:
@@ -113,7 +158,7 @@ def AgentProviderCapabilities(*args: Any, **kwargs: Any) -> Any:
     return pb.AgentProviderCapabilities(*args, **kwargs)
 
 
-def AgentSession(*args: Any, **kwargs: Any) -> Any:
+def AgentSession(*args: Any, **kwargs: Unpack[AgentSessionInput]) -> Any:
     """Create an agent session protocol value."""
 
     return pb.AgentSession(*args, **kwargs)
@@ -137,13 +182,13 @@ def AgentSessionStartHookOutput(*args: Any, **kwargs: Any) -> Any:
     return pb.AgentSessionStartHookOutput(*args, **kwargs)
 
 
-def AgentTurn(*args: Any, **kwargs: Any) -> Any:
+def AgentTurn(*args: Any, **kwargs: Unpack[AgentTurnInput]) -> Any:
     """Create an agent turn protocol value."""
 
     return pb.AgentTurn(*args, **kwargs)
 
 
-def AgentTurnEvent(*args: Any, **kwargs: Any) -> Any:
+def AgentTurnEvent(*args: Any, **kwargs: Unpack[AgentTurnEventInput]) -> Any:
     """Create an agent turn event protocol value."""
 
     return pb.AgentTurnEvent(*args, **kwargs)

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -7,6 +7,7 @@ import tempfile
 import unittest
 from concurrent import futures
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from importlib import resources
 from typing import Any
 
@@ -24,6 +25,9 @@ from gestalt import (
     AgentManager,
     AgentMessage,
     AgentProvider,
+    AgentSession,
+    AgentTurn,
+    AgentTurnEvent,
     MetadataProvider,
     ProviderKind,
     ProviderMetadata,
@@ -702,6 +706,17 @@ class AgentTransportTests(unittest.TestCase):
         self.assertTrue(
             resources.files("gestalt").joinpath("_gen/v1/agent_pb2.pyi").is_file()
         )
+
+    def test_agent_protocol_wrappers_accept_native_datetimes(self) -> None:
+        created_at = datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc)
+
+        session = AgentSession(id="session-1", created_at=created_at)
+        turn = AgentTurn(id="turn-1", created_at=created_at)
+        event = AgentTurnEvent(id="event-1", created_at=created_at)
+
+        self.assertEqual(session.created_at.ToDatetime(tzinfo=timezone.utc), created_at)
+        self.assertEqual(turn.created_at.ToDatetime(tzinfo=timezone.utc), created_at)
+        self.assertEqual(event.created_at.ToDatetime(tzinfo=timezone.utc), created_at)
 
     def test_agent_message_dict_helpers_preserve_presence(self) -> None:
         message = agent_message_from_dict(

--- a/sdk/rust/src/runtime_log_host.rs
+++ b/sdk/rust/src/runtime_log_host.rs
@@ -1,4 +1,4 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
 use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
@@ -311,11 +311,5 @@ pub fn runtime_session_id() -> std::result::Result<String, RuntimeLogHostError> 
 }
 
 fn timestamp_now() -> prost_types::Timestamp {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("unix epoch");
-    prost_types::Timestamp {
-        seconds: now.as_secs() as i64,
-        nanos: now.subsec_nanos() as i32,
-    }
+    crate::protocol::timestamp_from_system_time(SystemTime::now())
 }

--- a/sdk/typescript/src/indexeddb.ts
+++ b/sdk/typescript/src/indexeddb.ts
@@ -8,6 +8,7 @@ import {
   TransactionMode as ProtoTransactionMode,
   TransactionDurabilityHint as ProtoTransactionDurabilityHint,
 } from "./internal/gen/v1/datastore_pb";
+import { dateFromTimestamp, timestampFromDate } from "./protocol.ts";
 
 const ENV_INDEXEDDB_SOCKET = "GESTALT_INDEXEDDB_SOCKET";
 const INDEXEDDB_SOCKET_TOKEN_SUFFIX = "_TOKEN";
@@ -1283,7 +1284,7 @@ export function toProtoTypedValue(v: unknown): any {
     return { kind: { case: "floatValue", value: v } };
   }
   if (typeof v === "string") return { kind: { case: "stringValue", value: v } };
-  if (v instanceof Date) return { kind: { case: "timeValue", value: toProtoTimestamp(v) } };
+  if (v instanceof Date) return { kind: { case: "timeValue", value: timestampFromDate(v) } };
   if (v instanceof Uint8Array) return { kind: { case: "bytesValue", value: v } };
   if (v instanceof ArrayBuffer) return { kind: { case: "bytesValue", value: new Uint8Array(v) } };
   return { kind: { case: "jsonValue", value: toProtoJsonValue(v) } };
@@ -1304,7 +1305,7 @@ export function fromProtoTypedValue(v: any): unknown {
     case "boolValue":
       return v.kind.value;
     case "timeValue":
-      return fromProtoTimestamp(v.kind.value);
+      return dateFromTimestamp(v.kind.value);
     case "bytesValue":
       return new Uint8Array(v.kind.value);
     case "jsonValue":
@@ -1322,19 +1323,6 @@ export function toProtoKeyRange(kr: KeyRange): any {
     lowerOpen: kr.lowerOpen ?? false,
     upperOpen: kr.upperOpen ?? false,
   };
-}
-
-function toProtoTimestamp(value: Date): any {
-  const millis = value.getTime();
-  const seconds = Math.trunc(millis / 1000);
-  const nanos = Math.trunc((millis % 1000) * 1_000_000);
-  return { seconds: BigInt(seconds), nanos };
-}
-
-function fromProtoTimestamp(value: any): Date {
-  const seconds = Number(value?.seconds ?? 0n);
-  const nanos = Number(value?.nanos ?? 0);
-  return new Date((seconds * 1000) + Math.trunc(nanos / 1_000_000));
 }
 
 function toJsInt(value: bigint): number | bigint {

--- a/sdk/typescript/src/runtime-log-host.ts
+++ b/sdk/typescript/src/runtime-log-host.ts
@@ -15,6 +15,7 @@ import {
   PluginRuntimeLogHost as PluginRuntimeLogHostService,
   PluginRuntimeLogStream,
 } from "./internal/gen/v1/pluginruntime_pb.ts";
+import { timestampFromDate } from "./protocol.ts";
 
 /** Environment variable containing the runtime-log host-service target. */
 export const ENV_RUNTIME_LOG_HOST_SOCKET = "GESTALT_RUNTIME_LOG_SOCKET";
@@ -123,7 +124,7 @@ export class RuntimeLogHost {
         {
           stream: runtimeLogStream(input.stream ?? "runtime"),
           message: runtimeLogMessage(input.message),
-          observedAt: toProtoTimestamp(input.observedAt ?? new Date()),
+          observedAt: timestampFromDate(input.observedAt ?? new Date()),
           sourceSeq,
         },
       ],
@@ -253,16 +254,6 @@ function runtimeLogMessage(message: string | Uint8Array): string {
     return message;
   }
   return Buffer.from(message).toString("utf8");
-}
-
-function toProtoTimestamp(value: Date): { seconds: bigint; nanos: number } {
-  const millis = value.getTime();
-  const seconds = Math.floor(millis / 1000);
-  const nanos = Math.trunc((millis - (seconds * 1000)) * 1_000_000);
-  return {
-    seconds: BigInt(seconds),
-    nanos,
-  };
 }
 
 function toError(error: unknown): Error {

--- a/sdk/typescript/src/s3.ts
+++ b/sdk/typescript/src/s3.ts
@@ -29,6 +29,7 @@ import {
 } from "./internal/gen/v1/s3_pb.ts";
 import { errorMessage, type MaybePromise } from "./api.ts";
 import { ProviderBase, type ProviderBaseOptions } from "./provider.ts";
+import { dateFromTimestamp, timestampFromDate } from "./protocol.ts";
 
 /** Base environment variable for discovering S3 runtime sockets. */
 export const ENV_S3_SOCKET = "GESTALT_S3_SOCKET";
@@ -517,7 +518,7 @@ export function createS3Service(
         expiresAt?: { seconds: bigint; nanos: number };
       };
       if (result.expiresAt) {
-        response.expiresAt = toProtoTimestamp(result.expiresAt);
+        response.expiresAt = timestampFromDate(result.expiresAt);
       }
       return create(PresignObjectResponseSchema, response);
     },
@@ -693,7 +694,7 @@ export class S3 {
       headers: cloneStringMap(response.headers),
     };
     if (response.expiresAt) {
-      result.expiresAt = fromProtoTimestamp(response.expiresAt);
+      result.expiresAt = dateFromTimestamp(response.expiresAt);
     }
     return result;
   }
@@ -722,7 +723,7 @@ export class S3 {
       headers: cloneStringMap(response.headers),
     };
     if (response.expiresAt) {
-      result.expiresAt = fromProtoTimestamp(response.expiresAt);
+      result.expiresAt = dateFromTimestamp(response.expiresAt);
     }
     return result;
   }
@@ -1185,7 +1186,7 @@ function toProtoObjectMeta(meta: ObjectMeta) {
     storageClass: meta.storageClass,
   };
   if (meta.lastModified) {
-    value.lastModified = toProtoTimestamp(meta.lastModified);
+    value.lastModified = timestampFromDate(meta.lastModified);
   }
   return value;
 }
@@ -1200,7 +1201,7 @@ function fromProtoObjectMeta(meta: ProtoS3ObjectMeta | undefined): ObjectMeta {
     storageClass: meta?.storageClass ?? "",
   };
   if (meta?.lastModified) {
-    value.lastModified = fromProtoTimestamp(meta.lastModified);
+    value.lastModified = dateFromTimestamp(meta.lastModified);
   }
   return value;
 }
@@ -1214,10 +1215,10 @@ function toProtoReadOptions(options?: ReadOptions) {
     proto.range = toProtoByteRange(options.range);
   }
   if (options?.ifModifiedSince) {
-    proto.ifModifiedSince = toProtoTimestamp(options.ifModifiedSince);
+    proto.ifModifiedSince = timestampFromDate(options.ifModifiedSince);
   }
   if (options?.ifUnmodifiedSince) {
-    proto.ifUnmodifiedSince = toProtoTimestamp(options.ifUnmodifiedSince);
+    proto.ifUnmodifiedSince = timestampFromDate(options.ifUnmodifiedSince);
   }
   return proto;
 }
@@ -1234,10 +1235,10 @@ function fromProtoReadOptions(request: ProtoReadObjectRequest | undefined): Read
     options.ifNoneMatch = request.ifNoneMatch;
   }
   if (request?.ifModifiedSince) {
-    options.ifModifiedSince = fromProtoTimestamp(request.ifModifiedSince);
+    options.ifModifiedSince = dateFromTimestamp(request.ifModifiedSince);
   }
   if (request?.ifUnmodifiedSince) {
-    options.ifUnmodifiedSince = fromProtoTimestamp(request.ifUnmodifiedSince);
+    options.ifUnmodifiedSince = dateFromTimestamp(request.ifUnmodifiedSince);
   }
   return options;
 }
@@ -1328,22 +1329,6 @@ function fromProtoPresignMethod(method: ProtoPresignMethod): PresignMethod {
     default:
       return PresignMethod.Get;
   }
-}
-
-function toProtoTimestamp(value: Date) {
-  const millis = value.getTime();
-  const seconds = Math.floor(millis / 1000);
-  const nanos = Math.trunc((millis - (seconds * 1000)) * 1_000_000);
-  return {
-    seconds: BigInt(seconds),
-    nanos,
-  };
-}
-
-function fromProtoTimestamp(value: { seconds?: bigint; nanos?: number }): Date {
-  const seconds = Number(value.seconds ?? 0n);
-  const nanos = Number(value.nanos ?? 0);
-  return new Date((seconds * 1000) + Math.trunc(nanos / 1_000_000));
 }
 
 function normalizeProtoInt(value: number | bigint | undefined): bigint {


### PR DESCRIPTION
## Summary
- add Go workflow and authorization constructors that accept native `time.Time` / `*time.Time` and JSON-compatible maps or structs, keeping protobuf timestamp/Struct conversion at the SDK boundary
- expose typed Python agent protocol wrapper kwargs for `AgentSession`, `AgentTurn`, and `AgentTurnEvent`, including native `datetime` timestamp inputs
- reuse the central TypeScript `Date` timestamp conversions in S3, IndexedDB, and runtime-log transports
- route Rust runtime-log timestamps through the existing `SystemTime` conversion helper

`TimestampFromTime` and equivalent low-level helpers remain available for interop and tests; providers should be able to use native time values in the authored SDK surface.

## Tests
- `sdk/go`: `go test ./...`
- `sdk/python`: `uv run ruff check gestalt/_agent.py tests/test_agent_transport.py`
- `sdk/python`: `uv run ty check gestalt/_agent.py tests/test_agent_transport.py`
- `sdk/python`: `uv run pytest tests/test_agent_transport.py -q`
- `sdk/python`: `uv run sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html`
- `sdk/typescript`: `bun run typecheck`
- `sdk/typescript`: `bun run docs:lint`
- `sdk/typescript`: `bun test tests/protocol.test.ts tests/indexeddb.transport.test.ts tests/s3.transport.test.ts tests/runtime-log-host.transport.test.ts --max-concurrency 1`
- `sdk/rust`: `cargo test`