### PR TITLE
Add one-off workflow run delegation

### DIFF
--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"maps"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -63,6 +64,17 @@ type OutputDelivery struct {
 	Target         PluginTarget
 	InputBindings  []OutputBinding
 	CredentialMode core.ConnectionMode
+}
+
+// CloneOutputDelivery returns a detached shallow clone of delivery.
+func CloneOutputDelivery(delivery *OutputDelivery) *OutputDelivery {
+	if delivery == nil {
+		return nil
+	}
+	out := *delivery
+	out.Target.Input = maps.Clone(delivery.Target.Input)
+	out.InputBindings = append([]OutputBinding(nil), delivery.InputBindings...)
+	return &out
 }
 
 type OutputBinding struct {

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentgrant"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
@@ -36,18 +37,19 @@ type agentRuntime struct {
 }
 
 type agentSystemToolExecutionRequest struct {
-	Principal        *principal.Principal
-	ProviderName     string
-	CallerPluginName string
-	SessionID        string
-	TurnID           string
-	ToolCallID       string
-	ToolID           string
-	Tool             coreagent.Tool
-	Arguments        map[string]any
-	IdempotencyKey   string
-	ToolRefs         []coreagent.ToolRef
-	Tools            []coreagent.Tool
+	Principal               *principal.Principal
+	ProviderName            string
+	CallerPluginName        string
+	SessionID               string
+	TurnID                  string
+	ToolCallID              string
+	ToolID                  string
+	Tool                    coreagent.Tool
+	Arguments               map[string]any
+	IdempotencyKey          string
+	ToolRefs                []coreagent.ToolRef
+	Tools                   []coreagent.Tool
+	InheritedOutputDelivery *coreworkflow.OutputDelivery
 }
 
 type agentSystemToolExecutor interface {
@@ -351,18 +353,19 @@ func (r *agentRuntime) ExecuteTool(ctx context.Context, req coreagent.ExecuteToo
 			return nil, agentmanager.ErrAgentWorkflowToolsNotConfigured
 		}
 		return systemTools.ExecuteSystemTool(ctx, agentSystemToolExecutionRequest{
-			Principal:        principalValue,
-			ProviderName:     strings.TrimSpace(grant.ProviderName),
-			CallerPluginName: strings.TrimSpace(grant.CallerPluginName),
-			SessionID:        strings.TrimSpace(req.SessionID),
-			TurnID:           strings.TrimSpace(req.TurnID),
-			ToolCallID:       strings.TrimSpace(req.ToolCallID),
-			ToolID:           strings.TrimSpace(req.ToolID),
-			Tool:             resolvedTool,
-			Arguments:        maps.Clone(req.Arguments),
-			IdempotencyKey:   idempotencyKey,
-			ToolRefs:         append([]coreagent.ToolRef(nil), grant.ToolRefs...),
-			Tools:            append([]coreagent.Tool(nil), grant.Tools...),
+			Principal:               principalValue,
+			ProviderName:            strings.TrimSpace(grant.ProviderName),
+			CallerPluginName:        strings.TrimSpace(grant.CallerPluginName),
+			SessionID:               strings.TrimSpace(req.SessionID),
+			TurnID:                  strings.TrimSpace(req.TurnID),
+			ToolCallID:              strings.TrimSpace(req.ToolCallID),
+			ToolID:                  strings.TrimSpace(req.ToolID),
+			Tool:                    resolvedTool,
+			Arguments:               maps.Clone(req.Arguments),
+			IdempotencyKey:          idempotencyKey,
+			ToolRefs:                append([]coreagent.ToolRef(nil), grant.ToolRefs...),
+			Tools:                   append([]coreagent.Tool(nil), grant.Tools...),
+			InheritedOutputDelivery: coreworkflow.CloneOutputDelivery(grant.InheritedOutputDelivery),
 		})
 	}
 	if invoker == nil {

--- a/gestaltd/internal/bootstrap/agent_workflow_tools.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools.go
@@ -33,6 +33,7 @@ const (
 	workflowSystemToolSchedulesDelete   = "schedules.delete"
 	workflowSystemToolSchedulesPause    = "schedules.pause"
 	workflowSystemToolSchedulesResume   = "schedules.resume"
+	workflowSystemToolRunsStart         = "runs.start"
 	workflowSystemToolRunsList          = "runs.list"
 	workflowSystemToolRunsGet           = "runs.get"
 )
@@ -123,6 +124,12 @@ var workflowSystemToolDescriptors = map[string]workflowSystemToolDescriptor{
 		Name:             "workflow_schedules_resume",
 		Description:      "Resume a workflow schedule owned by the current caller.",
 		ParametersSchema: workflowSystemToolObjectSchema([]string{"scheduleId"}, map[string]any{"scheduleId": workflowSystemToolStringSchema("Schedule ID.")}),
+	},
+	workflowSystemToolRunsStart: {
+		Operation:        workflowSystemToolRunsStart,
+		Name:             "workflow_runs_start",
+		Description:      "Start a one-off workflow run for a delegated agent target or an existing workflow definition.",
+		ParametersSchema: workflowSystemToolStartRunSchema(),
 	},
 	workflowSystemToolRunsList: {
 		Operation:        workflowSystemToolRunsList,
@@ -257,6 +264,8 @@ func (t *workflowSystemTools) ExecuteSystemTool(ctx context.Context, req agentSy
 			return nil, err
 		}
 		return workflowSystemToolJSONResponse(http.StatusOK, map[string]any{"schedule": workflowSystemToolScheduleInfo(schedule)})
+	case workflowSystemToolRunsStart:
+		return t.executeStartRun(ctx, req)
 	case workflowSystemToolRunsList:
 		if err := workflowSystemToolRejectUnknownKeys(req.Arguments, "workflow.runs.list"); err != nil {
 			return nil, err
@@ -473,6 +482,93 @@ func (t *workflowSystemTools) executeCreateSchedule(ctx context.Context, req age
 	return workflowSystemToolJSONResponse(http.StatusCreated, map[string]any{"schedule": workflowSystemToolScheduleInfo(schedule)})
 }
 
+func (t *workflowSystemTools) executeStartRun(ctx context.Context, req agentSystemToolExecutionRequest) (*coreagent.ExecuteToolResponse, error) {
+	args := req.Arguments
+	if err := workflowSystemToolRejectUnknownKeys(args, "workflow.runs.start", "provider", "workflowKey", "target", "definitionId", "deliverResultToCaller"); err != nil {
+		return nil, err
+	}
+	deliverResultToCaller, _, err := workflowSystemToolBoolArgPresent(args, "deliverResultToCaller", "workflow.runs.start")
+	if err != nil {
+		return nil, err
+	}
+	definitionID := workflowSystemToolStringArg(args, "definitionId")
+	targetValue, hasTarget := args["target"]
+	if definitionID == "" && !hasTarget {
+		return nil, fmt.Errorf("%w: target or definitionId is required", invocation.ErrInvalidInvocation)
+	}
+	if definitionID != "" && hasTarget {
+		return nil, fmt.Errorf("%w: target and definitionId cannot both be set", invocation.ErrInvalidInvocation)
+	}
+	if definitionID != "" && deliverResultToCaller {
+		return nil, fmt.Errorf("%w: deliverResultToCaller is only supported with direct agent targets", invocation.ErrInvalidInvocation)
+	}
+
+	var target coreworkflow.Target
+	startTarget := coreworkflow.Target{}
+	var scopedPrincipal *principal.Principal
+	var permissions []core.AccessPermission
+	if definitionID != "" {
+		definitionPrincipal := workflowSystemToolPrincipalWithTrustedProvider(req.Principal, strings.TrimSpace(req.ProviderName))
+		definition, err := t.manager.GetDefinition(ctx, definitionPrincipal, definitionID)
+		if err != nil {
+			return nil, err
+		}
+		if definition == nil || definition.Definition == nil {
+			return nil, core.ErrNotFound
+		}
+		target = definition.Definition.Target
+		if err := workflowSystemToolValidateCreateScope(req, target); err != nil {
+			return nil, err
+		}
+		permissions = definition.Definition.Permissions
+		if permissions == nil {
+			permissions = workflowSystemToolPermissionsForTarget(target, req.ProviderName)
+		}
+		scopedPrincipal, err = workflowSystemToolExactPermissionsPrincipal(req.Principal, permissions, workflowSystemToolTrustedAgentProvider(req, target))
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var err error
+		target, err = workflowSystemToolTargetFromValue(targetValue)
+		if err != nil {
+			return nil, err
+		}
+		if target.Plugin != nil {
+			return nil, fmt.Errorf("%w: workflow.runs.start only supports direct agent targets", invocation.ErrInvalidInvocation)
+		}
+		workflowSystemToolInheritAgentToolRefs(req, &target)
+		if deliverResultToCaller {
+			if err := workflowSystemToolApplyInheritedOutputDelivery(req, &target); err != nil {
+				return nil, err
+			}
+		}
+		if err := workflowSystemToolValidateCreateScope(req, target); err != nil {
+			return nil, err
+		}
+		permissions = workflowSystemToolPermissionsForTarget(target, req.ProviderName)
+		scopedPrincipal, err = workflowSystemToolScopedPrincipal(req.Principal, permissions, workflowSystemToolTrustedAgentProvider(req, target))
+		if err != nil {
+			return nil, err
+		}
+		startTarget = target
+	}
+	run, err := t.manager.StartRun(ctx, scopedPrincipal, workflowmanager.RunStart{
+		ProviderName:     workflowSystemToolStringArg(args, "provider"),
+		Target:           startTarget,
+		DefinitionID:     definitionID,
+		IdempotencyKey:   strings.TrimSpace(req.IdempotencyKey),
+		WorkflowKey:      workflowSystemToolStringArg(args, "workflowKey"),
+		CallerPluginName: workflowSystemToolCallerScope(req),
+		Permissions:      permissions,
+	})
+	if err != nil {
+		return nil, err
+	}
+	slog.InfoContext(ctx, "agent workflow system tool started run", workflowSystemToolRunLogAttrs(req, run)...)
+	return workflowSystemToolJSONResponse(http.StatusCreated, map[string]any{"run": workflowSystemRunInfo(run)})
+}
+
 func (t *workflowSystemTools) executeUpdateSchedule(ctx context.Context, req agentSystemToolExecutionRequest) (*coreagent.ExecuteToolResponse, error) {
 	args := req.Arguments
 	if err := workflowSystemToolRejectUnknownKeys(args, "workflow.schedules.update", "scheduleId", "provider", "cron", "timezone", "paused", "target", "definitionId"); err != nil {
@@ -687,6 +783,30 @@ func workflowSystemToolScheduleLogAttrs(req agentSystemToolExecutionRequest, sch
 	return attrs
 }
 
+func workflowSystemToolRunLogAttrs(req agentSystemToolExecutionRequest, run *workflowmanager.ManagedRun) []any {
+	attrs := workflowSystemToolBaseLogAttrs(req)
+	if run == nil {
+		return attrs
+	}
+	attrs = append(attrs, "workflow_provider", strings.TrimSpace(run.ProviderName))
+	if run.Run != nil {
+		attrs = append(attrs,
+			"workflow_run_id", strings.TrimSpace(run.Run.ID),
+			"workflow_run_status", strings.TrimSpace(string(run.Run.Status)),
+			"workflow_run_execution_ref", strings.TrimSpace(run.Run.ExecutionRef),
+			"workflow_target", workflowTargetContext(run.Run.Target),
+		)
+	}
+	if run.ExecutionRef != nil {
+		attrs = append(attrs,
+			"workflow_execution_ref", strings.TrimSpace(run.ExecutionRef.ID),
+			"workflow_source_definition_id", strings.TrimSpace(run.ExecutionRef.SourceDefinitionID),
+			"workflow_caller_plugin", strings.TrimSpace(run.ExecutionRef.CallerPluginName),
+		)
+	}
+	return attrs
+}
+
 func workflowSystemToolCallerScope(req agentSystemToolExecutionRequest) string {
 	if callerPluginName := strings.TrimSpace(req.CallerPluginName); callerPluginName != "" {
 		return callerPluginName
@@ -743,6 +863,25 @@ func workflowSystemToolCreateScheduleSchema() map[string]any {
 	})
 }
 
+func workflowSystemToolStartRunSchema() map[string]any {
+	common := map[string]any{
+		"provider":    workflowSystemToolStringSchema("Workflow provider name."),
+		"workflowKey": workflowSystemToolStringSchema("Workflow key."),
+	}
+	targetProperties := maps.Clone(common)
+	targetProperties["target"] = workflowSystemToolAgentTargetSchema()
+	targetProperties["deliverResultToCaller"] = map[string]any{"type": "boolean", "description": "When true, deliver the child agent's final result back to the current caller."}
+	definitionProperties := maps.Clone(common)
+	definitionProperties["definitionId"] = workflowSystemToolStringSchema("Workflow definition ID to run.")
+	return map[string]any{
+		"type": "object",
+		"oneOf": []any{
+			workflowSystemToolObjectSchema([]string{"target"}, targetProperties),
+			workflowSystemToolObjectSchema([]string{"definitionId"}, definitionProperties),
+		},
+	}
+}
+
 func workflowSystemToolUpdateScheduleSchema() map[string]any {
 	return workflowSystemToolObjectSchema([]string{"scheduleId"}, map[string]any{
 		"scheduleId":   workflowSystemToolStringSchema("Schedule ID."),
@@ -779,17 +918,27 @@ func workflowSystemToolTargetSchema() map[string]any {
 			"instance":   workflowSystemToolStringSchema("Instance name."),
 			"input":      map[string]any{"type": "object"},
 		}),
-		"agent": workflowSystemToolObjectSchema([]string{}, map[string]any{
-			"provider":       workflowSystemToolStringSchema("Agent provider name."),
-			"model":          workflowSystemToolStringSchema("Agent model."),
-			"prompt":         workflowSystemToolStringSchema("Agent prompt."),
-			"messages":       map[string]any{"type": "array", "items": map[string]any{"type": "object"}},
-			"toolRefs":       map[string]any{"type": "array", "items": map[string]any{"type": "object"}, "description": "Agent tool references. If omitted, the created workflow agent inherits the current agent turn's tool references."},
-			"responseSchema": map[string]any{"type": "object"},
-			"metadata":       map[string]any{"type": "object"},
-			"modelOptions":   map[string]any{"type": "object"},
-			"timeoutSeconds": map[string]any{"type": "integer", "minimum": 0},
-		}),
+		"agent": workflowSystemToolAgentSchema(),
+	})
+}
+
+func workflowSystemToolAgentTargetSchema() map[string]any {
+	return workflowSystemToolObjectSchema([]string{"agent"}, map[string]any{
+		"agent": workflowSystemToolAgentSchema(),
+	})
+}
+
+func workflowSystemToolAgentSchema() map[string]any {
+	return workflowSystemToolObjectSchema([]string{}, map[string]any{
+		"provider":       workflowSystemToolStringSchema("Agent provider name."),
+		"model":          workflowSystemToolStringSchema("Agent model."),
+		"prompt":         workflowSystemToolStringSchema("Agent prompt."),
+		"messages":       map[string]any{"type": "array", "items": map[string]any{"type": "object"}},
+		"toolRefs":       map[string]any{"type": "array", "items": map[string]any{"type": "object"}, "description": "Agent tool references. If omitted, the created workflow agent inherits the current agent turn's tool references."},
+		"responseSchema": map[string]any{"type": "object"},
+		"metadata":       map[string]any{"type": "object"},
+		"modelOptions":   map[string]any{"type": "object"},
+		"timeoutSeconds": map[string]any{"type": "integer", "minimum": 0},
 	})
 }
 
@@ -907,6 +1056,20 @@ func workflowSystemToolInheritAgentToolRefs(req agentSystemToolExecutionRequest,
 		return
 	}
 	target.Agent.ToolRefs = workflowSystemToolInheritedAgentToolRefs(req)
+}
+
+func workflowSystemToolApplyInheritedOutputDelivery(req agentSystemToolExecutionRequest, target *coreworkflow.Target) error {
+	if target == nil || target.Agent == nil {
+		return fmt.Errorf("%w: deliverResultToCaller requires a direct agent target", invocation.ErrInvalidInvocation)
+	}
+	if target.Agent.OutputDelivery != nil || target.Agent.SessionReadyDelivery != nil {
+		return fmt.Errorf("%w: deliverResultToCaller cannot override an agent delivery target", invocation.ErrInvalidInvocation)
+	}
+	if req.InheritedOutputDelivery == nil {
+		return fmt.Errorf("%w: no caller output delivery is available for this turn", invocation.ErrInvalidInvocation)
+	}
+	target.Agent.OutputDelivery = coreworkflow.CloneOutputDelivery(req.InheritedOutputDelivery)
+	return nil
 }
 
 func workflowSystemToolInheritedAgentToolRefs(req agentSystemToolExecutionRequest) []coreagent.ToolRef {
@@ -1215,6 +1378,12 @@ func workflowSystemToolPermissionsForTarget(target coreworkflow.Target, defaultA
 			if strings.TrimSpace(ref.System) == "" {
 				addOperation(ref.Plugin, ref.Operation)
 			}
+		}
+		if delivery := target.Agent.OutputDelivery; delivery != nil {
+			addOperation(delivery.Target.PluginName, delivery.Target.Operation)
+		}
+		if delivery := target.Agent.SessionReadyDelivery; delivery != nil {
+			addOperation(delivery.Target.PluginName, delivery.Target.Operation)
 		}
 	}
 	if len(operationsByPlugin) == 0 {

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
@@ -134,12 +134,286 @@ func TestAgentRuntimeWorkflowSystemToolCreatesScopedSchedule(t *testing.T) {
 	}
 }
 
+func TestAgentRuntimeWorkflowSystemToolStartsRunWithInheritedOutputDelivery(t *testing.T) {
+	t.Parallel()
+
+	agentRuntime, workflowProvider := newWorkflowSystemToolRuntime(t)
+	workflowTool := mustWorkflowSystemTool(t, agentRuntime, workflowSystemToolRunsStart)
+	runGrant := mustMintWorkflowSystemRunGrant(t, agentRuntime, workflowSystemRunGrantScope{
+		CallerPluginName: "slack",
+		Permissions: []core.AccessPermission{
+			{Plugin: "managed"},
+			{Plugin: "roadmap", Operations: []string{"sync"}},
+			{Plugin: "notification", Operations: []string{"reply"}},
+		},
+		ToolRefs: []coreagent.ToolRef{
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolRunsStart},
+			{Plugin: "roadmap", Operation: "sync"},
+		},
+		Tools: []coreagent.Tool{workflowTool},
+		InheritedOutputDelivery: &coreworkflow.OutputDelivery{
+			Target: coreworkflow.PluginTarget{
+				PluginName: "notification",
+				Operation:  "reply",
+				Input:      map[string]any{"format": "plain"},
+			},
+			CredentialMode: core.ConnectionModeNone,
+			InputBindings: []coreworkflow.OutputBinding{
+				{InputField: "text", Value: coreworkflow.OutputValueSource{AgentOutput: "text"}},
+				{InputField: "reply_ref", Value: coreworkflow.OutputValueSource{Literal: "signed-parent-reply-ref"}},
+			},
+		},
+	})
+
+	req := coreagent.ExecuteToolRequest{
+		ProviderName: "managed",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolCallID:   "call-run-1",
+		ToolID:       workflowTool.ID,
+		RunGrant:     runGrant,
+		Arguments: map[string]any{
+			"workflowKey": "slack-child-run",
+			"target": map[string]any{
+				"agent": map[string]any{
+					"provider": "managed",
+					"prompt":   "Investigate the deployment and summarize the result.",
+					"toolRefs": []any{map[string]any{"plugin": "roadmap", "operation": "sync"}},
+				},
+			},
+			"deliverResultToCaller": true,
+		},
+	}
+	resp, err := agentRuntime.ExecuteTool(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ExecuteTool: %v", err)
+	}
+	if resp == nil || resp.Status != http.StatusCreated {
+		t.Fatalf("response = %#v, want 201", resp)
+	}
+	if strings.Contains(resp.Body, "outputDelivery") || strings.Contains(resp.Body, "signed-parent-reply-ref") || strings.Contains(resp.Body, "notification") {
+		t.Fatalf("response leaked inherited delivery: %s", resp.Body)
+	}
+	var body struct {
+		Run struct {
+			ID          string `json:"id"`
+			WorkflowKey string `json:"workflowKey"`
+			Target      struct {
+				Agent struct {
+					Prompt string `json:"prompt"`
+				} `json:"agent"`
+			} `json:"target"`
+		} `json:"run"`
+	}
+	if err := json.Unmarshal([]byte(resp.Body), &body); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+	if body.Run.ID == "" || body.Run.WorkflowKey != "slack-child-run" || body.Run.Target.Agent.Prompt == "" {
+		t.Fatalf("run response = %#v", body.Run)
+	}
+	if len(workflowProvider.startedRuns) != 1 {
+		t.Fatalf("started runs = %d, want 1", len(workflowProvider.startedRuns))
+	}
+	started := workflowProvider.startedRuns[0]
+	if started.Target.Agent == nil || started.Target.Agent.OutputDelivery == nil {
+		t.Fatalf("started target missing output delivery: %#v", started.Target)
+	}
+	if got := started.Target.Agent.OutputDelivery.InputBindings[1].Value.Literal; got != "signed-parent-reply-ref" {
+		t.Fatalf("inherited reply ref = %#v, want signed-parent-reply-ref", got)
+	}
+	ref, err := workflowProvider.GetExecutionReference(context.Background(), started.ExecutionRef)
+	if err != nil {
+		t.Fatalf("GetExecutionReference: %v", err)
+	}
+	assertWorkflowSystemPermissions(t, ref.Permissions, []core.AccessPermission{
+		{Plugin: "managed"},
+		{Plugin: "notification", Operations: []string{"reply"}},
+		{Plugin: "roadmap", Operations: []string{"sync"}},
+	})
+	replayResp, err := agentRuntime.ExecuteTool(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ExecuteTool replay: %v", err)
+	}
+	var replayBody struct {
+		Run struct {
+			ID string `json:"id"`
+		} `json:"run"`
+	}
+	if err := json.Unmarshal([]byte(replayResp.Body), &replayBody); err != nil {
+		t.Fatalf("decode replay body: %v", err)
+	}
+	if replayBody.Run.ID != body.Run.ID || len(workflowProvider.startedRuns) != 1 {
+		t.Fatalf("replay run id = %q startedRuns=%d, want %q and one provider start", replayBody.Run.ID, len(workflowProvider.startedRuns), body.Run.ID)
+	}
+	conflictingReq := req
+	conflictingReq.Arguments = maps.Clone(req.Arguments)
+	conflictingReq.Arguments["workflowKey"] = "different-slack-child-run"
+	_, err = agentRuntime.ExecuteTool(context.Background(), conflictingReq)
+	if err == nil {
+		t.Fatal("ExecuteTool conflicting workflow key replay succeeded, want provider idempotency conflict")
+	}
+
+	childAgentManager := &workflowRuntimeAgentManagerStub{}
+	childRuntime := &workflowRuntime{}
+	childRuntime.SetAgentManager(childAgentManager)
+	var gotDeliveryParams map[string]any
+	childRuntime.SetInvoker(funcInvoker{
+		invoke: func(_ context.Context, _ *principal.Principal, providerName, _ string, operation string, params map[string]any) (*core.OperationResult, error) {
+			if providerName != "notification" || operation != "reply" {
+				t.Fatalf("delivery target = %s.%s, want notification.reply", providerName, operation)
+			}
+			gotDeliveryParams = maps.Clone(params)
+			return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+		},
+	})
+	p := principal.Canonicalize(&principal.Principal{
+		SubjectID: principal.UserSubjectID("ada"),
+		TokenPermissions: principal.CompilePermissions([]core.AccessPermission{
+			{Plugin: "notification", Operations: []string{"reply"}},
+		}),
+	})
+	childResp, err := childRuntime.Invoke(principal.WithPrincipal(context.Background(), p), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		RunID:        "child-run",
+		Target:       started.Target,
+	})
+	if err != nil {
+		t.Fatalf("Invoke child: %v", err)
+	}
+	if childResp.Status != http.StatusOK {
+		t.Fatalf("child response = %#v", childResp)
+	}
+	if gotDeliveryParams["text"] != "turn completed" || gotDeliveryParams["reply_ref"] != "signed-parent-reply-ref" || gotDeliveryParams["format"] != "plain" {
+		t.Fatalf("child delivery params = %#v", gotDeliveryParams)
+	}
+}
+
+func TestWorkflowSystemToolStartRunSchemaMatchesV1Contract(t *testing.T) {
+	t.Parallel()
+
+	schema := workflowSystemToolStartRunSchema()
+	branches, ok := schema["oneOf"].([]any)
+	if !ok || len(branches) != 2 {
+		t.Fatalf("runs.start schema oneOf = %#v, want target and definition branches", schema["oneOf"])
+	}
+	targetBranch, ok := branches[0].(map[string]any)
+	if !ok {
+		t.Fatalf("target branch = %#v", branches[0])
+	}
+	targetProps, ok := targetBranch["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("target branch properties = %#v", targetBranch["properties"])
+	}
+	if _, ok := targetProps["definitionId"]; ok {
+		t.Fatalf("target branch exposes definitionId: %#v", targetProps)
+	}
+	target, ok := targetProps["target"].(map[string]any)
+	if !ok {
+		t.Fatalf("target property = %#v", targetProps["target"])
+	}
+	targetTargetProps, ok := target["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("target properties = %#v", target["properties"])
+	}
+	if _, ok := targetTargetProps["plugin"]; ok {
+		t.Fatalf("runs.start target schema exposes plugin target: %#v", targetTargetProps)
+	}
+	if _, ok := targetTargetProps["agent"]; !ok {
+		t.Fatalf("runs.start target schema missing agent target: %#v", targetTargetProps)
+	}
+	definitionBranch, ok := branches[1].(map[string]any)
+	if !ok {
+		t.Fatalf("definition branch = %#v", branches[1])
+	}
+	definitionProps, ok := definitionBranch["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("definition branch properties = %#v", definitionBranch["properties"])
+	}
+	if _, ok := definitionProps["target"]; ok {
+		t.Fatalf("definition branch exposes target: %#v", definitionProps)
+	}
+	if _, ok := definitionProps["deliverResultToCaller"]; ok {
+		t.Fatalf("definition branch exposes deliverResultToCaller: %#v", definitionProps)
+	}
+}
+
+func TestAgentRuntimeWorkflowSystemToolStartRunRejectsInvalidCallerDelivery(t *testing.T) {
+	t.Parallel()
+
+	agentRuntime, _ := newWorkflowSystemToolRuntime(t)
+	workflowTool := mustWorkflowSystemTool(t, agentRuntime, workflowSystemToolRunsStart)
+	runGrant := mustMintWorkflowSystemRunGrant(t, agentRuntime, workflowSystemRunGrantScope{
+		Permissions: []core.AccessPermission{{Plugin: "roadmap", Operations: []string{"sync"}}},
+		ToolRefs: []coreagent.ToolRef{
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolRunsStart},
+			{Plugin: "roadmap", Operation: "sync"},
+		},
+		Tools: []coreagent.Tool{workflowTool},
+	})
+	baseReq := coreagent.ExecuteToolRequest{
+		ProviderName: "managed",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolCallID:   "call-run-invalid",
+		ToolID:       workflowTool.ID,
+		RunGrant:     runGrant,
+	}
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "missing inherited output delivery",
+			args: map[string]any{
+				"deliverResultToCaller": true,
+				"target":                map[string]any{"agent": map[string]any{"prompt": "run", "toolRefs": []any{map[string]any{"plugin": "roadmap", "operation": "sync"}}}},
+			},
+		},
+		{
+			name: "definition callback",
+			args: map[string]any{
+				"definitionId":          "workflow_definition_abc",
+				"deliverResultToCaller": true,
+			},
+		},
+		{
+			name: "direct plugin target",
+			args: map[string]any{
+				"target": map[string]any{"plugin": map[string]any{"name": "roadmap", "operation": "sync"}},
+			},
+		},
+		{
+			name: "non boolean callback flag",
+			args: map[string]any{
+				"deliverResultToCaller": "true",
+				"target":                map[string]any{"agent": map[string]any{"prompt": "run", "toolRefs": []any{map[string]any{"plugin": "roadmap", "operation": "sync"}}}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := baseReq
+			req.Arguments = tt.args
+			_, err := agentRuntime.ExecuteTool(context.Background(), req)
+			if err == nil {
+				t.Fatal("ExecuteTool succeeded, want invalid invocation")
+			}
+			if !errors.Is(err, invocation.ErrInvalidInvocation) {
+				t.Fatalf("ExecuteTool error = %v, want invalid invocation", err)
+			}
+		})
+	}
+}
+
 func TestAgentRuntimeWorkflowSystemToolCreatesDefinitionAndScheduleFromDefinition(t *testing.T) {
 	t.Parallel()
 
 	runtime, workflowProvider := newWorkflowSystemToolRuntime(t)
 	definitionTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolDefinitionsCreate)
 	scheduleTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolSchedulesCreate)
+	runTool := mustWorkflowSystemTool(t, runtime, workflowSystemToolRunsStart)
 	runGrant := mustMintWorkflowSystemRunGrant(t, runtime, workflowSystemRunGrantScope{
 		Permissions: []core.AccessPermission{
 			{Plugin: "roadmap", Operations: []string{"sync"}},
@@ -148,9 +422,10 @@ func TestAgentRuntimeWorkflowSystemToolCreatesDefinitionAndScheduleFromDefinitio
 		ToolRefs: []coreagent.ToolRef{
 			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolDefinitionsCreate},
 			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolSchedulesCreate},
+			{System: coreagent.SystemToolWorkflow, Operation: workflowSystemToolRunsStart},
 			{Plugin: "roadmap", Operation: "sync"},
 		},
-		Tools: []coreagent.Tool{definitionTool, scheduleTool},
+		Tools: []coreagent.Tool{definitionTool, scheduleTool, runTool},
 	})
 
 	definitionResp, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
@@ -255,6 +530,39 @@ func TestAgentRuntimeWorkflowSystemToolCreatesDefinitionAndScheduleFromDefinitio
 		t.Fatalf("schedule ref source definition id = %q, want %q", scheduleRef.SourceDefinitionID, definitionID)
 	}
 	assertWorkflowSystemPermissions(t, scheduleRef.Permissions, []core.AccessPermission{
+		{Plugin: "managed"},
+		{Plugin: "roadmap", Operations: []string{"sync"}},
+	})
+
+	runResp, err := runtime.ExecuteTool(context.Background(), coreagent.ExecuteToolRequest{
+		ProviderName: "managed",
+		SessionID:    "session-1",
+		TurnID:       "turn-1",
+		ToolCallID:   "run-definition-call",
+		ToolID:       runTool.ID,
+		RunGrant:     runGrant,
+		Arguments: map[string]any{
+			"definitionId": definitionID,
+			"workflowKey":  "definition-one-off",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTool run from definition: %v", err)
+	}
+	if runResp == nil || runResp.Status != http.StatusCreated {
+		t.Fatalf("run response = %#v, want 201", runResp)
+	}
+	if len(workflowProvider.startedRuns) != 1 {
+		t.Fatalf("started runs = %d, want 1", len(workflowProvider.startedRuns))
+	}
+	runRef, err := workflowProvider.GetExecutionReference(context.Background(), workflowProvider.startedRuns[0].ExecutionRef)
+	if err != nil {
+		t.Fatalf("GetExecutionReference(run): %v", err)
+	}
+	if runRef.SourceDefinitionID != definitionID {
+		t.Fatalf("run ref source definition id = %q, want %q", runRef.SourceDefinitionID, definitionID)
+	}
+	assertWorkflowSystemPermissions(t, runRef.Permissions, []core.AccessPermission{
 		{Plugin: "managed"},
 		{Plugin: "roadmap", Operations: []string{"sync"}},
 	})
@@ -1120,6 +1428,19 @@ func newWorkflowSystemToolRuntime(t *testing.T) (*agentRuntime, *workflowSystemT
 	}); err != nil {
 		t.Fatalf("Register roadmap: %v", err)
 	}
+	if err := reg.Providers.Register("notification", &coretesting.StubIntegration{
+		N:        "notification",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "notification",
+			Operations: []catalog.CatalogOperation{{
+				ID:     "reply",
+				Method: http.MethodPost,
+			}},
+		},
+	}); err != nil {
+		t.Fatalf("Register notification: %v", err)
+	}
 	workflowProvider := &workflowSystemToolRecordingProvider{}
 	workflowRuntime := &workflowRuntime{
 		defaultProviderName: "temporal",
@@ -1151,6 +1472,11 @@ func newWorkflowSystemToolRuntime(t *testing.T) (*agentRuntime, *workflowSystemT
 		Workflow:     workflowRuntime,
 		Agent:        runtime,
 		AgentManager: agentManager,
+		PluginInvokes: map[string][]invocation.PluginInvocationDependency{
+			"slack": {
+				{Plugin: "notification", Operation: "reply", CredentialMode: core.ConnectionModeNone},
+			},
+		},
 	})
 	runtime.SetRunGrants(newTestAgentRunGrants(t))
 	runtime.SetToolSearcher(workflowSystemToolResolver{})
@@ -1180,19 +1506,63 @@ func (workflowSystemToolAgentManagerStub) Available() bool {
 }
 
 type workflowSystemToolRecordingProvider struct {
+	startedRuns       []coreworkflow.StartRunRequest
+	runs              map[string]*coreworkflow.Run
+	runIdempotency    map[string]string
 	upsertedSchedules []coreworkflow.UpsertScheduleRequest
 	schedules         map[string]*coreworkflow.Schedule
 	executionRefs     map[string]*coreworkflow.ExecutionReference
 }
 
-func (p *workflowSystemToolRecordingProvider) StartRun(context.Context, coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
-	return &coreworkflow.Run{}, nil
+func (p *workflowSystemToolRecordingProvider) StartRun(_ context.Context, req coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
+	if p.runs == nil {
+		p.runs = map[string]*coreworkflow.Run{}
+	}
+	if p.runIdempotency == nil {
+		p.runIdempotency = map[string]string{}
+	}
+	if req.IdempotencyKey != "" {
+		for runID, idempotencyKey := range p.runIdempotency {
+			if idempotencyKey == req.IdempotencyKey {
+				run := p.runs[runID]
+				if run.ExecutionRef != req.ExecutionRef {
+					return nil, errors.New("idempotent run replay used a different execution ref")
+				}
+				value := *run
+				return &value, nil
+			}
+		}
+	}
+	p.startedRuns = append(p.startedRuns, req)
+	run := &coreworkflow.Run{
+		ID:           "run-" + req.ExecutionRef,
+		Status:       coreworkflow.RunStatusPending,
+		WorkflowKey:  req.WorkflowKey,
+		Target:       req.Target,
+		ExecutionRef: req.ExecutionRef,
+		CreatedBy:    req.CreatedBy,
+	}
+	p.runs[run.ID] = run
+	if req.IdempotencyKey != "" {
+		p.runIdempotency[run.ID] = req.IdempotencyKey
+	}
+	value := *run
+	return &value, nil
 }
-func (p *workflowSystemToolRecordingProvider) GetRun(context.Context, coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
-	return &coreworkflow.Run{}, nil
+func (p *workflowSystemToolRecordingProvider) GetRun(_ context.Context, req coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
+	if run := p.runs[req.RunID]; run != nil {
+		value := *run
+		return &value, nil
+	}
+	return nil, core.ErrNotFound
 }
 func (p *workflowSystemToolRecordingProvider) ListRuns(context.Context, coreworkflow.ListRunsRequest) ([]*coreworkflow.Run, error) {
-	return nil, nil
+	out := make([]*coreworkflow.Run, 0, len(p.runs))
+	for _, run := range p.runs {
+		value := *run
+		out = append(out, &value)
+	}
+	return out, nil
 }
 func (p *workflowSystemToolRecordingProvider) CancelRun(context.Context, coreworkflow.CancelRunRequest) (*coreworkflow.Run, error) {
 	return &coreworkflow.Run{}, nil
@@ -1296,10 +1666,11 @@ func (p *workflowSystemToolRecordingProvider) Ping(context.Context) error { retu
 func (p *workflowSystemToolRecordingProvider) Close() error               { return nil }
 
 type workflowSystemRunGrantScope struct {
-	CallerPluginName string
-	Permissions      []core.AccessPermission
-	ToolRefs         []coreagent.ToolRef
-	Tools            []coreagent.Tool
+	CallerPluginName        string
+	Permissions             []core.AccessPermission
+	ToolRefs                []coreagent.ToolRef
+	Tools                   []coreagent.Tool
+	InheritedOutputDelivery *coreworkflow.OutputDelivery
 }
 
 func mustMintWorkflowSystemRunGrant(t *testing.T, runtime *agentRuntime, scope workflowSystemRunGrantScope) string {
@@ -1307,16 +1678,17 @@ func mustMintWorkflowSystemRunGrant(t *testing.T, runtime *agentRuntime, scope w
 
 	grants := workflowSystemRunGrants(t, runtime)
 	grant, err := grants.Mint(agentgrant.Grant{
-		ProviderName:        "managed",
-		SessionID:           "session-1",
-		TurnID:              "turn-1",
-		CallerPluginName:    strings.TrimSpace(scope.CallerPluginName),
-		SubjectID:           principal.UserSubjectID("ada"),
-		SubjectKind:         string(principal.KindUser),
-		CredentialSubjectID: principal.UserSubjectID("ada"),
-		Permissions:         append([]core.AccessPermission(nil), scope.Permissions...),
-		ToolRefs:            append([]coreagent.ToolRef(nil), scope.ToolRefs...),
-		Tools:               append([]coreagent.Tool(nil), scope.Tools...),
+		ProviderName:            "managed",
+		SessionID:               "session-1",
+		TurnID:                  "turn-1",
+		CallerPluginName:        strings.TrimSpace(scope.CallerPluginName),
+		SubjectID:               principal.UserSubjectID("ada"),
+		SubjectKind:             string(principal.KindUser),
+		CredentialSubjectID:     principal.UserSubjectID("ada"),
+		Permissions:             append([]core.AccessPermission(nil), scope.Permissions...),
+		ToolRefs:                append([]coreagent.ToolRef(nil), scope.ToolRefs...),
+		Tools:                   append([]coreagent.Tool(nil), scope.Tools...),
+		InheritedOutputDelivery: coreworkflow.CloneOutputDelivery(scope.InheritedOutputDelivery),
 	})
 	if err != nil {
 		t.Fatalf("Mint workflow system run grant: %v", err)

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -406,7 +406,11 @@ func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.Invo
 	if signalMessage := workflowSignalMessage(req.Signals); signalMessage != nil {
 		messages = append(messages, *signalMessage)
 	}
-	turn, err := agentManager.CreateTurn(runCtx, principalValue, coreagent.ManagerCreateTurnRequest{
+	turnCtx := runCtx
+	if inheritedDelivery := workflowInheritedOutputDelivery(agentTarget.OutputDelivery, workflowOutputDeliverySignal(req.Signals)); inheritedDelivery != nil {
+		turnCtx = agentmanager.WithInheritedOutputDelivery(turnCtx, inheritedDelivery)
+	}
+	turn, err := agentManager.CreateTurn(turnCtx, principalValue, coreagent.ManagerCreateTurnRequest{
 		CallerPluginName: callerPluginName,
 		SessionID:        session.ID,
 		Model:            agentTarget.Model,
@@ -537,6 +541,43 @@ func workflowOutputDeliverySignal(signals []coreworkflow.Signal) *coreworkflow.S
 		return nil
 	}
 	return &signals[len(signals)-1]
+}
+
+func workflowInheritedOutputDelivery(delivery *coreworkflow.OutputDelivery, signal *coreworkflow.Signal) *coreworkflow.OutputDelivery {
+	if delivery == nil {
+		return nil
+	}
+	out := *delivery
+	out.Target.Input = maps.Clone(delivery.Target.Input)
+	out.InputBindings = make([]coreworkflow.OutputBinding, 0, len(delivery.InputBindings))
+	for i := range delivery.InputBindings {
+		binding := delivery.InputBindings[i]
+		source := binding.Value
+		switch {
+		case strings.TrimSpace(source.SignalPayload) != "":
+			if signal == nil {
+				return nil
+			}
+			value, ok, err := workflowMapPathValue(signal.Payload, source.SignalPayload)
+			if err != nil || !ok || value == nil {
+				return nil
+			}
+			binding.Value = coreworkflow.OutputValueSource{Literal: value}
+		case strings.TrimSpace(source.SignalMetadata) != "":
+			if signal == nil {
+				return nil
+			}
+			value, ok, err := workflowMapPathValue(signal.Metadata, source.SignalMetadata)
+			if err != nil || !ok || value == nil {
+				return nil
+			}
+			binding.Value = coreworkflow.OutputValueSource{Literal: value}
+		default:
+			binding.Value = source
+		}
+		out.InputBindings = append(out.InputBindings, binding)
+	}
+	return &out
 }
 
 func workflowOutputBindingValue(turn *coreagent.Turn, signal *coreworkflow.Signal, session *coreagent.Session, source coreworkflow.OutputValueSource) (any, bool, error) {

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -193,6 +193,7 @@ type workflowRuntimeAgentManagerStub struct {
 	createSessionRequests           []coreagent.ManagerCreateSessionRequest
 	createSessionDeadlines          []time.Duration
 	createTurnRequests              []coreagent.ManagerCreateTurnRequest
+	createTurnInheritedDeliveries   []*coreworkflow.OutputDelivery
 	createTurnDeadlines             []time.Duration
 	createTurnProviderCallDeadlines []time.Duration
 	getTurnDeadlines                []time.Duration
@@ -221,6 +222,7 @@ func (m *workflowRuntimeAgentManagerStub) CreateSession(ctx context.Context, _ *
 func (m *workflowRuntimeAgentManagerStub) CreateTurn(ctx context.Context, _ *principal.Principal, req coreagent.ManagerCreateTurnRequest) (*coreagent.Turn, error) {
 	m.events = append(m.events, "create-turn")
 	m.createTurnRequests = append(m.createTurnRequests, req)
+	m.createTurnInheritedDeliveries = append(m.createTurnInheritedDeliveries, agentmanager.InheritedOutputDeliveryFromContext(ctx))
 	m.createTurnDeadlines = append(m.createTurnDeadlines, remainingDeadline(ctx))
 	callCtx, cancel := runtimehost.ProviderWorkflowAgentCallContext(ctx)
 	m.createTurnProviderCallDeadlines = append(m.createTurnProviderCallDeadlines, remainingDeadline(callCtx))
@@ -882,6 +884,91 @@ func TestWorkflowRuntimeInvokeAgentTargetDeliversFinalOutput(t *testing.T) {
 	}
 	if gotCredentialMode != "" {
 		t.Fatalf("delivery credential mode without override = %q, want empty", gotCredentialMode)
+	}
+}
+
+func TestWorkflowRuntimeInvokeAgentTargetCarriesMaterializedInheritedOutputDelivery(t *testing.T) {
+	t.Parallel()
+
+	agentManager := &workflowRuntimeAgentManagerStub{}
+	runtime := &workflowRuntime{}
+	runtime.SetAgentManager(agentManager)
+	runtime.SetInvoker(funcInvoker{
+		invoke: func(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+			return &core.OperationResult{Status: http.StatusOK}, nil
+		},
+	})
+	req := coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		RunID:        "run-agent-delivery-inherit",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName: "managed",
+			Prompt:       "Start a child workflow if this takes a while.",
+			OutputDelivery: &coreworkflow.OutputDelivery{
+				Target: coreworkflow.PluginTarget{
+					PluginName: "notification",
+					Operation:  "reply",
+					Input:      map[string]any{"format": "plain"},
+				},
+				CredentialMode: core.ConnectionModeNone,
+				InputBindings: []coreworkflow.OutputBinding{
+					{InputField: "text", Value: coreworkflow.OutputValueSource{AgentOutput: "text"}},
+					{InputField: "reply_ref", Value: coreworkflow.OutputValueSource{SignalPayload: "reply_ref"}},
+					{InputField: "event_type", Value: coreworkflow.OutputValueSource{SignalMetadata: "event.type"}},
+					{InputField: "session_id", Value: coreworkflow.OutputValueSource{AgentSession: "id"}},
+				},
+			},
+		}},
+		Signals: []coreworkflow.Signal{{
+			ID:       "signal-1",
+			Payload:  map[string]any{"reply_ref": "signed-parent-reply-ref"},
+			Metadata: map[string]any{"event": map[string]any{"type": "app_mention"}},
+		}},
+	}
+	p := principal.Canonicalize(&principal.Principal{SubjectID: principal.UserSubjectID("ada")})
+
+	resp, err := runtime.Invoke(principal.WithPrincipal(context.Background(), p), req)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("response = %#v", resp)
+	}
+	if len(agentManager.createTurnInheritedDeliveries) != 1 {
+		t.Fatalf("inherited deliveries = %d, want 1", len(agentManager.createTurnInheritedDeliveries))
+	}
+	delivery := agentManager.createTurnInheritedDeliveries[0]
+	if delivery == nil {
+		t.Fatal("inherited delivery is nil")
+	}
+	if delivery.Target.PluginName != "notification" || delivery.Target.Operation != "reply" || delivery.CredentialMode != core.ConnectionModeNone {
+		t.Fatalf("inherited delivery target = %#v", delivery)
+	}
+	if got := delivery.InputBindings[0].Value.AgentOutput; got != "text" {
+		t.Fatalf("agent output binding = %q, want text", got)
+	}
+	if got := delivery.InputBindings[1].Value.Literal; got != "signed-parent-reply-ref" {
+		t.Fatalf("reply_ref binding = %#v, want signed-parent-reply-ref", got)
+	}
+	if got := delivery.InputBindings[2].Value.Literal; got != "app_mention" {
+		t.Fatalf("event_type binding = %#v, want app_mention", got)
+	}
+	if got := delivery.InputBindings[3].Value.AgentSession; got != "id" {
+		t.Fatalf("agent session binding = %q, want id", got)
+	}
+}
+
+func TestWorkflowRuntimeInheritedOutputDeliverySkipsNilSignalValues(t *testing.T) {
+	t.Parallel()
+
+	delivery := workflowInheritedOutputDelivery(&coreworkflow.OutputDelivery{
+		Target: coreworkflow.PluginTarget{PluginName: "notification", Operation: "reply"},
+		InputBindings: []coreworkflow.OutputBinding{
+			{InputField: "reply_ref", Value: coreworkflow.OutputValueSource{SignalPayload: "reply_ref"}},
+		},
+	}, &coreworkflow.Signal{Payload: map[string]any{"reply_ref": nil}})
+	if delivery != nil {
+		t.Fatalf("delivery = %#v, want nil for unmaterializable nil signal value", delivery)
 	}
 }
 

--- a/gestaltd/services/agents/agentgrant/grant.go
+++ b/gestaltd/services/agents/agentgrant/grant.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 )
 
 const (
@@ -34,21 +35,22 @@ type Manager struct {
 }
 
 type Grant struct {
-	ID                  string
-	ProviderName        string
-	SessionID           string
-	TurnID              string
-	CallerPluginName    string
-	SubjectID           string
-	SubjectKind         string
-	CredentialSubjectID string
-	DisplayName         string
-	AuthSource          string
-	Permissions         []core.AccessPermission
-	ToolRefs            []coreagent.ToolRef
-	Tools               []coreagent.Tool
-	ToolSource          coreagent.ToolSourceMode
-	Connections         []ConnectionBinding
+	ID                      string
+	ProviderName            string
+	SessionID               string
+	TurnID                  string
+	CallerPluginName        string
+	SubjectID               string
+	SubjectKind             string
+	CredentialSubjectID     string
+	DisplayName             string
+	AuthSource              string
+	Permissions             []core.AccessPermission
+	ToolRefs                []coreagent.ToolRef
+	Tools                   []coreagent.Tool
+	ToolSource              coreagent.ToolSourceMode
+	Connections             []ConnectionBinding
+	InheritedOutputDelivery *coreworkflow.OutputDelivery
 }
 
 type claims struct {
@@ -66,10 +68,11 @@ type claims struct {
 }
 
 type toolScope struct {
-	ToolRefs    []coreagent.ToolRef      `json:"tool_refs,omitempty"`
-	Tools       []coreagent.Tool         `json:"tools,omitempty"`
-	ToolSource  coreagent.ToolSourceMode `json:"tool_source,omitempty"`
-	Connections []ConnectionBinding      `json:"connections,omitempty"`
+	ToolRefs                []coreagent.ToolRef          `json:"tool_refs,omitempty"`
+	Tools                   []coreagent.Tool             `json:"tools,omitempty"`
+	ToolSource              coreagent.ToolSourceMode     `json:"tool_source,omitempty"`
+	Connections             []ConnectionBinding          `json:"connections,omitempty"`
+	InheritedOutputDelivery *coreworkflow.OutputDelivery `json:"inherited_output_delivery,omitempty"`
 }
 
 func NewManager(secret []byte) (*Manager, error) {
@@ -116,10 +119,11 @@ func (m *Manager) Mint(grant Grant) (string, error) {
 		Permissions:         append([]core.AccessPermission(nil), grant.Permissions...),
 	}
 	scope, err := m.sealValue(sealPurposeToolScope, toolScope{
-		ToolRefs:    append([]coreagent.ToolRef(nil), grant.ToolRefs...),
-		Tools:       append([]coreagent.Tool(nil), grant.Tools...),
-		ToolSource:  grant.ToolSource,
-		Connections: append([]ConnectionBinding(nil), grant.Connections...),
+		ToolRefs:                append([]coreagent.ToolRef(nil), grant.ToolRefs...),
+		Tools:                   append([]coreagent.Tool(nil), grant.Tools...),
+		ToolSource:              grant.ToolSource,
+		Connections:             append([]ConnectionBinding(nil), grant.Connections...),
+		InheritedOutputDelivery: coreworkflow.CloneOutputDelivery(grant.InheritedOutputDelivery),
 	})
 	if err != nil {
 		return "", err
@@ -155,21 +159,22 @@ func (m *Manager) Resolve(token string) (Grant, error) {
 		return Grant{}, fmt.Errorf("agent run grant is invalid or expired")
 	}
 	grant := Grant{
-		ID:                  strings.TrimSpace(decoded.ID),
-		ProviderName:        strings.TrimSpace(decoded.ProviderName),
-		SessionID:           strings.TrimSpace(decoded.SessionID),
-		TurnID:              strings.TrimSpace(decoded.TurnID),
-		CallerPluginName:    strings.TrimSpace(decoded.CallerPluginName),
-		SubjectID:           strings.TrimSpace(decoded.Subject),
-		SubjectKind:         strings.TrimSpace(decoded.SubjectKind),
-		CredentialSubjectID: strings.TrimSpace(decoded.CredentialSubjectID),
-		DisplayName:         strings.TrimSpace(decoded.DisplayName),
-		AuthSource:          strings.TrimSpace(decoded.AuthSource),
-		Permissions:         append([]core.AccessPermission(nil), decoded.Permissions...),
-		ToolRefs:            append([]coreagent.ToolRef(nil), scope.ToolRefs...),
-		Tools:               append([]coreagent.Tool(nil), scope.Tools...),
-		ToolSource:          scope.ToolSource,
-		Connections:         append([]ConnectionBinding(nil), scope.Connections...),
+		ID:                      strings.TrimSpace(decoded.ID),
+		ProviderName:            strings.TrimSpace(decoded.ProviderName),
+		SessionID:               strings.TrimSpace(decoded.SessionID),
+		TurnID:                  strings.TrimSpace(decoded.TurnID),
+		CallerPluginName:        strings.TrimSpace(decoded.CallerPluginName),
+		SubjectID:               strings.TrimSpace(decoded.Subject),
+		SubjectKind:             strings.TrimSpace(decoded.SubjectKind),
+		CredentialSubjectID:     strings.TrimSpace(decoded.CredentialSubjectID),
+		DisplayName:             strings.TrimSpace(decoded.DisplayName),
+		AuthSource:              strings.TrimSpace(decoded.AuthSource),
+		Permissions:             append([]core.AccessPermission(nil), decoded.Permissions...),
+		ToolRefs:                append([]coreagent.ToolRef(nil), scope.ToolRefs...),
+		Tools:                   append([]coreagent.Tool(nil), scope.Tools...),
+		ToolSource:              scope.ToolSource,
+		Connections:             append([]ConnectionBinding(nil), scope.Connections...),
+		InheritedOutputDelivery: coreworkflow.CloneOutputDelivery(scope.InheritedOutputDelivery),
 	}
 	if m.revokedTurn(grant) {
 		return Grant{}, fmt.Errorf("agent run grant is revoked")

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentgrant"
 	"github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
@@ -956,7 +957,8 @@ func (m *Manager) CreateTurn(ctx context.Context, p *principal.Principal, req co
 	}
 	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
 	turnID := newAgentTurnID(ownedSession.session.ID, idempotencyKey)
-	runGrant, err := m.mintRunGrant(ctx, p, ownedSession.providerName, ownedSession.session.ID, turnID, req.CallerPluginName, toolRefs, tools, toolSource)
+	inheritedOutputDelivery := InheritedOutputDeliveryFromContext(ctx)
+	runGrant, err := m.mintRunGrant(ctx, p, ownedSession.providerName, ownedSession.session.ID, turnID, req.CallerPluginName, toolRefs, tools, toolSource, inheritedOutputDelivery)
 	if err != nil {
 		return nil, err
 	}
@@ -1687,26 +1689,29 @@ func agentProviderReturnedNotFound(err error) bool {
 	return errors.Is(err, core.ErrNotFound) || status.Code(err) == codes.NotFound
 }
 
-func (m *Manager) mintRunGrant(ctx context.Context, p *principal.Principal, providerName, sessionID, turnID, callerPluginName string, toolRefs []coreagent.ToolRef, tools []coreagent.Tool, toolSource coreagent.ToolSourceMode) (string, error) {
+func (m *Manager) mintRunGrant(ctx context.Context, p *principal.Principal, providerName, sessionID, turnID, callerPluginName string, toolRefs []coreagent.ToolRef, tools []coreagent.Tool, toolSource coreagent.ToolSourceMode, inheritedOutputDelivery *coreworkflow.OutputDelivery) (string, error) {
 	if m == nil || m.runGrants == nil {
 		return "", fmt.Errorf("%w: agent run grants are not configured", invocation.ErrInternal)
 	}
 	subject := agentSubjectFromPrincipal(p)
+	permissions := agentRunPermissions(ctx, p, callerPluginName, toolRefs)
+	permissions = agentRunPermissionsWithInheritedOutputDelivery(p, permissions, inheritedOutputDelivery)
 	return m.runGrants.Mint(agentgrant.Grant{
-		ProviderName:        providerName,
-		SessionID:           sessionID,
-		TurnID:              turnID,
-		CallerPluginName:    strings.TrimSpace(callerPluginName),
-		SubjectID:           subject.SubjectID,
-		SubjectKind:         subject.SubjectKind,
-		CredentialSubjectID: subject.CredentialSubjectID,
-		DisplayName:         subject.DisplayName,
-		AuthSource:          subject.AuthSource,
-		Permissions:         agentRunPermissions(ctx, p, callerPluginName, toolRefs),
-		ToolRefs:            append([]coreagent.ToolRef(nil), toolRefs...),
-		Tools:               append([]coreagent.Tool(nil), tools...),
-		ToolSource:          toolSource,
-		Connections:         m.agentConnectionBindings(providerName),
+		ProviderName:            providerName,
+		SessionID:               sessionID,
+		TurnID:                  turnID,
+		CallerPluginName:        strings.TrimSpace(callerPluginName),
+		SubjectID:               subject.SubjectID,
+		SubjectKind:             subject.SubjectKind,
+		CredentialSubjectID:     subject.CredentialSubjectID,
+		DisplayName:             subject.DisplayName,
+		AuthSource:              subject.AuthSource,
+		Permissions:             permissions,
+		ToolRefs:                append([]coreagent.ToolRef(nil), toolRefs...),
+		Tools:                   append([]coreagent.Tool(nil), tools...),
+		ToolSource:              toolSource,
+		Connections:             m.agentConnectionBindings(providerName),
+		InheritedOutputDelivery: coreworkflow.CloneOutputDelivery(inheritedOutputDelivery),
 	})
 }
 
@@ -3334,6 +3339,38 @@ func agentRunPermissions(ctx context.Context, p *principal.Principal, callerPlug
 		return nil
 	}
 	return principal.PermissionsToAccessPermissions(p.TokenPermissions)
+}
+
+func agentRunPermissionsWithInheritedOutputDelivery(p *principal.Principal, permissions []core.AccessPermission, delivery *coreworkflow.OutputDelivery) []core.AccessPermission {
+	if permissions == nil || delivery == nil {
+		return permissions
+	}
+	pluginName := strings.TrimSpace(delivery.Target.PluginName)
+	operation := strings.TrimSpace(delivery.Target.Operation)
+	if pluginName == "" || operation == "" || !principal.AllowsOperationPermission(p, pluginName, operation) {
+		return permissions
+	}
+	compiled := principal.CompilePermissions(permissions)
+	if compiled == nil {
+		compiled = principal.PermissionSet{}
+	}
+	addAgentRunPermission(compiled, pluginName, operation)
+	return principal.PermissionsToAccessPermissions(compiled)
+}
+
+func addAgentRunPermission(permissions principal.PermissionSet, pluginName, operation string) {
+	if permissions == nil {
+		return
+	}
+	if operations, ok := permissions[pluginName]; ok && operations == nil {
+		return
+	}
+	operations := permissions[pluginName]
+	if operations == nil {
+		operations = map[string]struct{}{}
+		permissions[pluginName] = operations
+	}
+	operations[operation] = struct{}{}
 }
 
 func compactAgentRunPermissionsForRefs(p *principal.Principal, refs []coreagent.ToolRef) ([]core.AccessPermission, bool) {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentgrant"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
@@ -1257,6 +1258,87 @@ func TestManagerCreateTurnDefaultsToCatalogToolsForCatalogOnlyProvider(t *testin
 	}
 	if got := grant.ToolRefs; len(got) != 1 || got[0].Plugin != agentToolSearchAllPlugin || got[0].Operation != "" {
 		t.Fatalf("grant tool refs = %#v, want global broad catalog ref", got)
+	}
+}
+
+func TestManagerCreateTurnCarriesInheritedOutputDeliveryInRunGrant(t *testing.T) {
+	t.Parallel()
+
+	alpha := newRouteCountingAgentProvider("alpha")
+	roadmap := &catalogCountingProvider{StubIntegration: coretesting.StubIntegration{
+		N:        "roadmap",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+			ID: "sync",
+		}}},
+	}}
+	notification := &catalogCountingProvider{StubIntegration: coretesting.StubIntegration{
+		N:        "notification",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+			ID: "reply",
+		}}},
+	}}
+	grants := newAgentManagerTestRunGrants(t)
+	manager := newTestManager(t, Config{
+		Providers: testutil.NewProviderRegistry(t, roadmap, notification),
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		RunGrants: grants,
+	})
+	p := &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+		TokenPermissions: principal.CompilePermissions([]core.AccessPermission{
+			{Plugin: "alpha"},
+			{Plugin: "roadmap", Operations: []string{"sync"}},
+			{Plugin: "notification", Operations: []string{"reply"}},
+		}),
+	}
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	ctx := WithInheritedOutputDelivery(context.Background(), &coreworkflow.OutputDelivery{
+		Target: coreworkflow.PluginTarget{PluginName: "notification", Operation: "reply"},
+		InputBindings: []coreworkflow.OutputBinding{
+			{InputField: "text", Value: coreworkflow.OutputValueSource{AgentOutput: "text"}},
+			{InputField: "reply_ref", Value: coreworkflow.OutputValueSource{Literal: "signed-ref"}},
+		},
+	})
+	_, err = manager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		ToolRefs:  []coreagent.ToolRef{{Plugin: "roadmap", Operation: "sync"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if len(alpha.createTurnReqs) != 1 {
+		t.Fatalf("CreateTurn requests = %d, want 1", len(alpha.createTurnReqs))
+	}
+	grant, err := grants.Resolve(alpha.createTurnReqs[0].RunGrant)
+	if err != nil {
+		t.Fatalf("Resolve run grant: %v", err)
+	}
+	if grant.InheritedOutputDelivery == nil || grant.InheritedOutputDelivery.Target.PluginName != "notification" || grant.InheritedOutputDelivery.Target.Operation != "reply" {
+		t.Fatalf("inherited output delivery = %#v", grant.InheritedOutputDelivery)
+	}
+	if got := grant.ToolRefs; len(got) != 1 || got[0].Plugin != "roadmap" || got[0].Operation != "sync" {
+		t.Fatalf("grant tool refs = %#v, want only visible roadmap tool", got)
+	}
+	if !reflect.DeepEqual(grant.Permissions, []core.AccessPermission{
+		{Plugin: "notification", Operations: []string{"reply"}},
+		{Plugin: "roadmap", Operations: []string{"sync"}},
+	}) {
+		t.Fatalf("grant permissions = %#v, want hidden delivery permission merged", grant.Permissions)
 	}
 }
 

--- a/gestaltd/services/agents/agentmanager/workflow_delivery.go
+++ b/gestaltd/services/agents/agentmanager/workflow_delivery.go
@@ -1,0 +1,24 @@
+package agentmanager
+
+import (
+	"context"
+
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+)
+
+type inheritedOutputDeliveryKey struct{}
+
+func WithInheritedOutputDelivery(ctx context.Context, delivery *coreworkflow.OutputDelivery) context.Context {
+	if delivery == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, inheritedOutputDeliveryKey{}, coreworkflow.CloneOutputDelivery(delivery))
+}
+
+func InheritedOutputDeliveryFromContext(ctx context.Context) *coreworkflow.OutputDelivery {
+	if ctx == nil {
+		return nil
+	}
+	delivery, _ := ctx.Value(inheritedOutputDeliveryKey{}).(*coreworkflow.OutputDelivery)
+	return coreworkflow.CloneOutputDelivery(delivery)
+}

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -151,6 +151,7 @@ type RunStart struct {
 	IdempotencyKey   string
 	WorkflowKey      string
 	CallerPluginName string
+	Permissions      []core.AccessPermission
 }
 
 type RunSignal struct {
@@ -392,8 +393,8 @@ func (m *Manager) StartRun(ctx context.Context, p *principal.Principal, req RunS
 		return nil, err
 	}
 
-	executionRefID := runExecutionRefID(uuid.NewString())
-	ref, err := m.putExecutionRef(ctx, executionRefID, providerName, provider, target, p, req.CallerPluginName, req.DefinitionID)
+	executionRefID := newRunExecutionRefID(workflowCreateIdempotencyScope(p, req.CallerPluginName, req.IdempotencyKey), req.WorkflowKey)
+	ref, createdRef, err := m.putRunExecutionRef(ctx, executionRefID, providerName, provider, target, p, req.CallerPluginName, req.DefinitionID, req.Permissions)
 	if err != nil {
 		return nil, err
 	}
@@ -405,11 +406,15 @@ func (m *Manager) StartRun(ctx context.Context, p *principal.Principal, req RunS
 		ExecutionRef:   executionRefID,
 	})
 	if err != nil {
-		m.revokeExecutionRef(ctx, ref)
+		if createdRef {
+			m.revokeExecutionRef(ctx, ref)
+		}
 		return nil, err
 	}
-	if !runMatchesExecutionRef(providerName, run, ref) {
-		m.revokeExecutionRef(ctx, ref)
+	if !runMatchesExecutionRef(providerName, run, ref) || strings.TrimSpace(ref.ID) != strings.TrimSpace(run.ExecutionRef) {
+		if createdRef {
+			m.revokeExecutionRef(ctx, ref)
+		}
 		return nil, core.ErrNotFound
 	}
 	return &ManagedRun{
@@ -1334,8 +1339,8 @@ func (m *Manager) resolveAgentTarget(ctx context.Context, p *principal.Principal
 	target.Metadata = maps.Clone(target.Metadata)
 	target.Messages = append([]coreagent.Message(nil), target.Messages...)
 	target.ToolRefs = append([]coreagent.ToolRef(nil), target.ToolRefs...)
-	target.OutputDelivery = cloneWorkflowOutputDelivery(target.OutputDelivery)
-	target.SessionReadyDelivery = cloneWorkflowOutputDelivery(target.SessionReadyDelivery)
+	target.OutputDelivery = coreworkflow.CloneOutputDelivery(target.OutputDelivery)
+	target.SessionReadyDelivery = coreworkflow.CloneOutputDelivery(target.SessionReadyDelivery)
 	if err := validateWorkflowAgentToolRefs(target.ToolRefs); err != nil {
 		return coreworkflow.Target{}, err
 	}
@@ -1548,6 +1553,49 @@ func (m *Manager) putExecutionRefWithPermissions(ctx context.Context, executionR
 		CredentialSubjectID: strings.TrimSpace(principal.EffectiveCredentialSubjectID(p)),
 		Permissions:         m.executionRefPermissionsWithOverride(p, target, callerPluginName, permissions),
 	})
+}
+
+func (m *Manager) putRunExecutionRef(ctx context.Context, executionRefID, providerName string, provider coreworkflow.Provider, target coreworkflow.Target, p *principal.Principal, callerPluginName, sourceDefinitionID string, permissions []core.AccessPermission) (*coreworkflow.ExecutionReference, bool, error) {
+	store, err := workflowExecutionReferenceStore(providerName, provider)
+	if err != nil {
+		return nil, false, err
+	}
+	expectedPermissions := m.executionRefPermissionsWithOverride(p, target, callerPluginName, permissions)
+	existing, err := store.GetExecutionReference(ctx, executionRefID)
+	if err == nil {
+		existing = workflowExecutionRefForProvider(existing, providerName)
+		if !runExecutionRefMatches(existing, executionRefID, providerName, target, p, callerPluginName, sourceDefinitionID, expectedPermissions) {
+			return nil, false, fmt.Errorf("%w: %s", ErrDuplicateExecutionRefs, executionRefID)
+		}
+		if executionRefActive(existing) {
+			return existing, false, nil
+		}
+	} else if !isWorkflowProviderNotFound(err) {
+		return nil, false, err
+	}
+	p = principal.Canonicalized(p)
+	subjectID := strings.TrimSpace(principalSubjectID(p))
+	if subjectID == "" {
+		return nil, false, ErrWorkflowSubjectRequired
+	}
+	actor := workflowActorFromPrincipal(p)
+	ref, err := store.PutExecutionReference(ctx, &coreworkflow.ExecutionReference{
+		ID:                  executionRefID,
+		ProviderName:        strings.TrimSpace(providerName),
+		Target:              target,
+		CallerPluginName:    strings.TrimSpace(callerPluginName),
+		SourceDefinitionID:  strings.TrimSpace(sourceDefinitionID),
+		SubjectID:           subjectID,
+		SubjectKind:         actor.SubjectKind,
+		DisplayName:         actor.DisplayName,
+		AuthSource:          actor.AuthSource,
+		CredentialSubjectID: strings.TrimSpace(principal.EffectiveCredentialSubjectID(p)),
+		Permissions:         expectedPermissions,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return ref, true, nil
 }
 
 func (m *Manager) executionRefPermissionsWithOverride(p *principal.Principal, target coreworkflow.Target, callerPluginName string, override []core.AccessPermission) []core.AccessPermission {
@@ -1878,16 +1926,6 @@ func validateWorkflowAgentToolRefs(refs []coreagent.ToolRef) error {
 	return nil
 }
 
-func cloneWorkflowOutputDelivery(delivery *coreworkflow.OutputDelivery) *coreworkflow.OutputDelivery {
-	if delivery == nil {
-		return nil
-	}
-	out := *delivery
-	out.Target.Input = maps.Clone(delivery.Target.Input)
-	out.InputBindings = append([]coreworkflow.OutputBinding(nil), delivery.InputBindings...)
-	return &out
-}
-
 func (m *Manager) normalizeWorkflowOutputDelivery(delivery *coreworkflow.OutputDelivery, callerPluginName string) error {
 	return m.normalizeWorkflowAgentDelivery(delivery, callerPluginName, "output_delivery")
 }
@@ -2120,6 +2158,13 @@ func signalOrStartExecutionRefMatches(ref *coreworkflow.ExecutionReference, exec
 	return executionRefOwnedBy(ref, p) && targetMatchesExecutionRef(target, ref)
 }
 
+func runExecutionRefMatches(ref *coreworkflow.ExecutionReference, executionRefID, providerName string, target coreworkflow.Target, p *principal.Principal, callerPluginName, sourceDefinitionID string, permissions []core.AccessPermission) bool {
+	if !signalOrStartExecutionRefMatches(ref, executionRefID, providerName, target, p, callerPluginName, permissions) {
+		return false
+	}
+	return strings.TrimSpace(ref.SourceDefinitionID) == strings.TrimSpace(sourceDefinitionID)
+}
+
 func normalizeEventMatch(match coreworkflow.EventMatch) coreworkflow.EventMatch {
 	return coreworkflow.EventMatch{
 		Type:    strings.TrimSpace(match.Type),
@@ -2257,6 +2302,15 @@ func runExecutionRefID(value string) string {
 		value = uuid.NewString()
 	}
 	return workflowRunExecutionRefBasePrefix + value
+}
+
+func newRunExecutionRefID(idempotencyScope, workflowKey string) string {
+	idempotencyScope = strings.TrimSpace(idempotencyScope)
+	if idempotencyScope == "" {
+		return runExecutionRefID("")
+	}
+	scope := strings.Join([]string{"gestalt.workflow.run", idempotencyScope, strings.TrimSpace(workflowKey)}, "\x00")
+	return runExecutionRefID(uuid.NewSHA1(uuid.NameSpaceURL, []byte(scope)).String())
 }
 
 func signalOrStartExecutionRefID(providerName, workflowKey string, target coreworkflow.Target, p *principal.Principal, callerPluginName string, permissions []core.AccessPermission) (string, error) {

--- a/gestaltd/services/workflows/workflowmanager/manager_test.go
+++ b/gestaltd/services/workflows/workflowmanager/manager_test.go
@@ -115,6 +115,75 @@ func TestDefinitionCanStartRunFromStoredTargetSnapshot(t *testing.T) {
 	}
 }
 
+func TestStartRunRejectsProviderReplayWithDifferentExecutionRef(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWorkflowProvider()
+	manager := New(Config{
+		Providers: testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "github",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name: "github",
+				Operations: []catalog.CatalogOperation{
+					{ID: "issues.triage", Method: "POST"},
+				},
+			},
+		}),
+		Workflow: testWorkflowControl{provider: provider},
+	})
+	permissions := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "github",
+		Operations: []string{"issues.triage"},
+	}})
+	caller := principal.Canonicalize(&principal.Principal{
+		SubjectID:        principal.UserSubjectID("ada"),
+		UserID:           "ada",
+		Kind:             principal.KindUser,
+		TokenPermissions: permissions,
+		Scopes:           principal.PermissionPlugins(permissions),
+	})
+	req := RunStart{
+		ProviderName:     "local",
+		CallerPluginName: "github",
+		IdempotencyKey:   "same-idempotency-key",
+		WorkflowKey:      "github:issues:triage:first",
+		Target: coreworkflow.Target{Plugin: &coreworkflow.PluginTarget{
+			PluginName: "github",
+			Operation:  "issues.triage",
+		}},
+	}
+
+	first, err := manager.StartRun(context.Background(), caller, req)
+	if err != nil {
+		t.Fatalf("StartRun(first): %v", err)
+	}
+	if first == nil || first.Run == nil || first.ExecutionRef == nil {
+		t.Fatalf("first run = %#v, want run and execution ref", first)
+	}
+	firstRefID := first.ExecutionRef.ID
+	provider.startRunHook = func(req coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
+		copied := *first.Run
+		return &copied, nil
+	}
+	req.WorkflowKey = "github:issues:triage:second"
+
+	_, err = manager.StartRun(context.Background(), caller, req)
+	if !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("StartRun(second) error = %v, want not found from mismatched execution ref", err)
+	}
+	secondRefID := newRunExecutionRefID(workflowCreateIdempotencyScope(caller, req.CallerPluginName, req.IdempotencyKey), req.WorkflowKey)
+	if secondRefID == firstRefID {
+		t.Fatalf("second execution ref ID = first ref ID %q, want workflow-key scoped ref", firstRefID)
+	}
+	if provider.refs[firstRefID] == nil || provider.refs[firstRefID].RevokedAt != nil {
+		t.Fatalf("first execution ref = %#v, want active", provider.refs[firstRefID])
+	}
+	if provider.refs[secondRefID] == nil || provider.refs[secondRefID].RevokedAt == nil {
+		t.Fatalf("second execution ref = %#v, want revoked after mismatch", provider.refs[secondRefID])
+	}
+}
+
 func TestDefinitionCanCreateScheduleAndEventTriggerFromStoredTargetSnapshot(t *testing.T) {
 	t.Parallel()
 
@@ -1445,6 +1514,7 @@ type testWorkflowProvider struct {
 	runs                            map[string]*coreworkflow.Run
 	schedules                       map[string]*coreworkflow.Schedule
 	eventTriggers                   map[string]*coreworkflow.EventTrigger
+	startRunHook                    func(coreworkflow.StartRunRequest) (*coreworkflow.Run, error)
 	upsertedSchedules               []coreworkflow.UpsertScheduleRequest
 	upsertedEventTriggers           []coreworkflow.UpsertEventTriggerRequest
 	signalOrStartErr                error
@@ -1464,6 +1534,9 @@ func newTestWorkflowProvider() *testWorkflowProvider {
 }
 
 func (p *testWorkflowProvider) StartRun(_ context.Context, req coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
+	if p.startRunHook != nil {
+		return p.startRunHook(req)
+	}
 	run := &coreworkflow.Run{
 		ID:           "run-started",
 		Status:       coreworkflow.RunStatusRunning,


### PR DESCRIPTION
## Summary

- Add the `workflow.runs.start` agent system tool for one-off workflow runs.
- Reuse existing `OutputDelivery` so child agent runs can explicitly deliver their final result back to the caller with `deliverResultToCaller: true`.
- Carry materialized inherited output delivery through sealed agent grants without exposing the callback target as a visible tool.
- Make idempotent run starts use deterministic execution refs scoped by caller, idempotency key, and workflow key.

## Interface Changes

Agent-visible workflow tool surface:

```diff
- Backend workflow manager/provider APIs already supported `StartRun` and `SignalOrStartRun`.
- Agent workflow system tools exposed definition/schedule management plus `runs.list` and `runs.get`.
- Agents did not have a direct system tool for starting a one-off workflow run.
+ system: workflow
+ operation: runs.start
+ args:
+   provider?: string
+   workflowKey?: string
+   target?: { agent: AgentTarget }
+   definitionId?: string
+   deliverResultToCaller?: boolean
```

Start-mode contract:

```diff
- Backend callers could start workflow runs through the manager API.
- Agents could create definitions/schedules, but could not directly start an ad hoc child agent run through `system: workflow`.
- Existing workflow target shapes in other APIs could include direct plugin targets.
+ Exactly one of `target` or `definitionId` is required for `workflow.runs.start`.
+ `target.agent` is supported for direct one-off child agent runs.
+ `definitionId` is supported for normal definition-backed one-off starts.
+ `target.plugin` is rejected for `runs.start` v1.
+ `definitionId + deliverResultToCaller: true` is rejected for v1.
```

Delivery model:

```diff
- Workflow agent targets already supported explicit `OutputDelivery` when that delivery target was part of the workflow target.
- A Slack-started parent agent turn did not propagate its caller-specific `OutputDelivery` through the agent grant into child workflow starts.
- Solving Slack thread callbacks with explicit workflow config would leak channel/thread details into workflow implementation or workflow definitions.
+ A child agent run can opt into caller result delivery with `deliverResultToCaller: true`.
+ The runtime carries the existing parent `OutputDelivery` object; no Slack fields are added to workflow definitions or run targets.
+ Delivery permissions are inherited as hidden grant scope, not exposed as visible tool refs.
```

Example usage:

```diff
- // Before: available to agents for reusable/recurring work, not direct one-off start.
- {
-   "tool": "workflow.definitions.create",
-   "arguments": {
-     "target": { "agent": { "prompt": "Investigate and summarize." } }
-   }
- }
- {
-   "tool": "workflow.schedules.create",
-   "arguments": {
-     "definitionId": "workflow_definition:...",
-     "cron": "0 * * * *"
-   }
- }
+ // Now: direct one-off child run that can deliver back to the caller.
+ {
+   "workflowKey": "deploy-investigation-1778278610",
+   "target": {
+     "agent": {
+       "prompt": "Investigate the failed deployment and summarize the root cause.",
+       "toolRefs": [
+         { "plugin": "datadog", "operation": "logs.search" },
+         { "plugin": "github", "operation": "user.createPullRequest" }
+       ]
+     }
+   },
+   "deliverResultToCaller": true
+ }
```

## Test plan

- [x] Added/updated workflow system tool contract tests, including the `runs.start` schema shape.
- [x] Added/updated workflow runtime inherited delivery materialization tests.
- [x] Added/updated agent run grant delivery-permission contract coverage.
- [x] Added `StartRun` idempotent replay coverage for a provider-returned run whose `ExecutionRef` does not match the new workflow-key-scoped execution ref.
- [x] Centralized output-delivery cloning in `coreworkflow.CloneOutputDelivery` and replaced package-local copies in bootstrap, agentmanager, agentgrant, and workflowmanager.
- [x] Fixed the Actions lint failure from job `75113632373` by adding `t.Parallel()` inside the flagged subtest loop.
- [x] Ran `go test ./internal/bootstrap -run 'TestAgentRuntimeWorkflowSystemTool(Start|CreatesDefinitionAndScheduleFromDefinition)|TestWorkflowSystemToolStartRunSchemaMatchesV1Contract|TestWorkflowRuntimeInvokeAgentTarget(CarriesMaterializedInheritedOutputDelivery|DeliversFinalOutput)|TestWorkflowRuntimeInheritedOutputDeliverySkipsNilSignalValues'`.
- [x] Ran `go test ./services/workflows/workflowmanager -run 'TestDefinitionCanStartRunFromStoredTargetSnapshot|TestStartRunUsesDefinitionProvider|TestStartRunRejectsProviderReplayWithDifferentExecutionRef'`.
- [x] Ran `go test ./services/workflows`.
- [x] Ran `go test ./services/agents/agentmanager -run 'TestManagerCreateTurnCarriesInheritedOutputDeliveryInRunGrant'`.
- [x] Ran `go test ./services/agents/agentgrant`.
- [x] Ran `go test ./core/workflow ./services/workflows`.
- [x] Ran `golangci-lint run ./internal/bootstrap`.
- [x] Ran `git diff --check`.

## Notes

- A broader `go test ./internal/bootstrap ./services/agents/agentmanager ./services/agents/agentgrant ./services/workflows/workflowmanager` run hit existing timing-sensitive failure `TestAgentRuntimeConfigReplacesHostedAgentBeforeRuntimeDrainDeadline`; the targeted workflow contract tests passed afterward.
- Follow-up PR: expose `workflow.runs.start` in toolshed Slack config after this runtime change is available.
