### PR TITLE
Accept native time updates for protobuf timestamp fields

### DIFF
--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -70,11 +70,13 @@
 // protobuf bindings. SDK constructors such as NewBoundWorkflowRun,
 // NewWorkflowSignal, and NewAuthorizationModelRef accept native time.Time
 // values and JSON-compatible maps or structs, so provider code can keep
-// protobuf timestamp and Struct conversion at the SDK boundary. StructFromMap,
-// StructFromAny, ValueFromAny, ValuesFromMap, TimestampFromTime,
-// TimestampFromTimePtr, and the IndexedDB codec helpers remain available for
-// lower-level interop and tests. StructFromAny accepts structs, string-keyed
-// map aliases, and pointers to either form; it rejects time.Time,
+// protobuf timestamp and Struct conversion at the SDK boundary. SetTime and
+// SetOptionalTime accept native time.Time values when provider code needs to
+// update existing generated messages in place. StructFromMap, StructFromAny,
+// ValueFromAny, ValuesFromMap, TimestampFromTime, TimestampFromTimePtr, and the
+// IndexedDB codec helpers remain available for lower-level interop and tests.
+// StructFromAny accepts structs, string-keyed map aliases, and pointers to
+// either form; it rejects time.Time,
 // json.Marshaler values, non-string map keys, cycles, and non-finite numbers in
 // generic Struct payloads. Embedded struct fields are not flattened like
 // encoding/json; anonymous embedded fields must have an explicit json tag name.

--- a/sdk/go/protocol_helpers.go
+++ b/sdk/go/protocol_helpers.go
@@ -132,6 +132,20 @@ func TimestampFromTimePtr(value *time.Time) *timestamppb.Timestamp {
 	return TimestampFromTime(*value)
 }
 
+// SetTime writes a native Go time into a generated protobuf timestamp field.
+//
+// Prefer native SDK constructors when creating new values. Use SetTime when
+// updating an existing generated message in place.
+func SetTime(target **timestamppb.Timestamp, value time.Time) {
+	*target = timestampFromNonZeroTime(value)
+}
+
+// SetOptionalTime writes an optional native Go time into a generated protobuf
+// timestamp field.
+func SetOptionalTime(target **timestamppb.Timestamp, value *time.Time) {
+	*target = timestampFromOptionalTime(value)
+}
+
 // TimeFromTimestamp converts a protobuf Timestamp into a Go time.
 func TimeFromTimestamp(value *timestamppb.Timestamp) time.Time {
 	if value == nil {

--- a/sdk/go/workflow_manager_transport_test.go
+++ b/sdk/go/workflow_manager_transport_test.go
@@ -239,6 +239,25 @@ func TestTransport_WorkflowManagerSignalOrStartRunInjectsInvocationToken(t *test
 	if value := gestalt.TimestampFromTimePtr(nil); value != nil {
 		t.Fatalf("TimestampFromTimePtr(nil) = %#v, want nil", value)
 	}
+	var setTimeValue *timestamppb.Timestamp
+	setTimeWant := time.Unix(1700, 25).UTC()
+	gestalt.SetTime(&setTimeValue, setTimeWant)
+	if setTimeValue == nil || !setTimeValue.AsTime().Equal(setTimeWant) {
+		t.Fatalf("SetTime = %#v, want %v", setTimeValue, setTimeWant)
+	}
+	gestalt.SetTime(&setTimeValue, time.Time{})
+	if setTimeValue != nil {
+		t.Fatalf("SetTime(zero) = %#v, want nil", setTimeValue)
+	}
+	setOptionalWant := time.Unix(1800, 0).UTC()
+	gestalt.SetOptionalTime(&setTimeValue, &setOptionalWant)
+	if setTimeValue == nil || !setTimeValue.AsTime().Equal(setOptionalWant) {
+		t.Fatalf("SetOptionalTime = %#v, want %v", setTimeValue, setOptionalWant)
+	}
+	gestalt.SetOptionalTime(&setTimeValue, nil)
+	if setTimeValue != nil {
+		t.Fatalf("SetOptionalTime(nil) = %#v, want nil", setTimeValue)
+	}
 	if value, err := gestalt.TimePtrFromTimestamp(nil); err != nil || value != nil {
 		t.Fatalf("TimePtrFromTimestamp(nil) = %#v, %v; want nil, nil", value, err)
 	}


### PR DESCRIPTION
## Summary
- add Go SDK `SetTime` and `SetOptionalTime` helpers for updating generated protobuf timestamp fields from native `time.Time` values
- document the intended split: constructors for new SDK values, setters for in-place generated-message updates
- cover zero and optional time behavior in the Go SDK transport helper tests

## Tests
- `go test ./...` from `sdk/go`
- `git diff --check`