### PR TITLE
Preserve GitHub workflow signal summaries

### DIFF
--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -1091,7 +1091,29 @@ func compactWorkflowSignalPayload(payload map[string]any) map[string]any {
 	copyCompactPayloadField(out, payload, "payloadSha256")
 	copyCompactPayloadField(out, payload, "payload_omitted")
 	copyCompactPayloadField(out, payload, "payloadOmitted")
-	for _, key := range []string{"agent_request", "agentRequest", "installation", "repository", "sender", "pull_request", "pullRequest", "issue", "comment", "review", "ref"} {
+	for _, key := range []string{
+		"agent_request",
+		"agentRequest",
+		"installation",
+		"repository",
+		"sender",
+		"webhook_policy",
+		"webhookPolicy",
+		"pull_request",
+		"pullRequest",
+		"issue",
+		"comment",
+		"review",
+		"ref",
+		"check_run",
+		"checkRun",
+		"check_suite",
+		"checkSuite",
+		"workflow_run",
+		"workflowRun",
+		"review_check_run",
+		"reviewCheckRun",
+	} {
 		if value, ok := payload[key]; ok {
 			out[key] = compactWorkflowJSONValue(value, workflowSignalContextMaxDepth)
 		}

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -420,6 +420,24 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 						"number":     123,
 					},
 				},
+				"webhook_policy": map[string]any{
+					"id": "github-review",
+					"trigger": map[string]any{
+						"manual_commands": []any{"@gestalt review"},
+					},
+				},
+				"review_check_run": map[string]any{
+					"id":          456,
+					"name":        "Gestalt Review",
+					"status":      "in_progress",
+					"external_id": "gestalt-review:abc123",
+				},
+				"check_run": map[string]any{
+					"id":         789,
+					"name":       "CI",
+					"status":     "completed",
+					"conclusion": "success",
+				},
 				"payload_sha256": "abc123",
 			},
 		}},
@@ -545,6 +563,27 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	}
 	if prompt, _ := agentRequest["user_prompt"].(string); !strings.Contains(prompt, "please inspect") || len(prompt) > workflowSignalContextMaxStringBytes {
 		t.Fatalf("workflow signal user_prompt = %q", prompt)
+	}
+	webhookPolicy, ok := signalPayload["webhook_policy"].(map[string]any)
+	if !ok {
+		t.Fatalf("workflow signal webhook_policy = %#v", signalPayload["webhook_policy"])
+	}
+	if webhookPolicy["id"] != "github-review" {
+		t.Fatalf("workflow signal webhook_policy.id = %#v", webhookPolicy["id"])
+	}
+	reviewCheckRun, ok := signalPayload["review_check_run"].(map[string]any)
+	if !ok {
+		t.Fatalf("workflow signal review_check_run = %#v", signalPayload["review_check_run"])
+	}
+	if got := reviewCheckRun["id"]; got != 456 && got != float64(456) {
+		t.Fatalf("workflow signal review_check_run.id = %#v", got)
+	}
+	checkRun, ok := signalPayload["check_run"].(map[string]any)
+	if !ok {
+		t.Fatalf("workflow signal check_run = %#v", signalPayload["check_run"])
+	}
+	if checkRun["name"] != "CI" {
+		t.Fatalf("workflow signal check_run.name = %#v", checkRun["name"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Preserve compact GitHub signal objects in the workflow runtime context, including `review_check_run`, `webhook_policy`, and CI run summaries.
- Allows `github.reviewPullRequest` workflow targets to adopt the pending check run created at webhook dispatch instead of creating a duplicate check.
- Add regression coverage for the workflow invocation context projection.

## Root cause
Temporal received the full signal payload with `review_check_run`, but `gestaltd` compacted workflow signals before invoking the target plugin. The compaction allowlist dropped nested `review_check_run`, so the GitHub provider saw no reusable check run and fell back to creating a second `Gestalt Review` check.

## Test plan
- [x] `go test ./internal/bootstrap`
- [x] `go test ./internal/bootstrap ./services/plugins`