### PR TITLE
Support commit-pinned provider sources

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -129,6 +129,24 @@ supply a token.
 | --- | --- |
 | `providerRepositories.<name>.url` | HTTP(S) or `file://` URL for a `gestaltd-provider-index` YAML file. |
 
+## `providerSnapshotRepositories`
+
+`providerSnapshotRepositories` declares immutable artifact roots for commit-pinned
+git provider sources. Snapshot repositories are used by `source.git` entries
+that set `artifactRepository`.
+
+```yaml
+providerSnapshotRepositories:
+  valon:
+    url: https://storage.googleapis.com/valon-gestalt-provider-snapshots
+    gestaltRef: 651a5c30feb995c9364c38f63d0d5c3880bc2055
+```
+
+| Field | Description |
+| --- | --- |
+| `providerSnapshotRepositories.<name>.url` | HTTP(S) root containing deterministic snapshot `provider-release.yaml` files and archives. |
+| `providerSnapshotRepositories.<name>.gestaltRef` | Optional full Gestalt commit SHA expected for snapshots from this repository. |
+
 ## `server`
 
 ```yaml
@@ -1144,7 +1162,7 @@ plugins:
 | `authorizationPolicy` | Optional shared subject access policy from `authorization.policies`. When set, host-side operation filtering and execution checks use the resolved role for this plugin, and the built-in admin UI / admin API can manage plugin-scoped dynamic grants for additional members. Static policy members still take precedence. |
 | `ui` | Optional plugin-backed mounted UI binding. Use `ui.path` plus optional `ui.bundle`. `ui.bundle` names a `providers.ui` entry; omit it to mount the plugin manifest's owned `spec.ui`. |
 | `source` | **Required.** The backing provider source. See [source shape](#pluginssource) below. |
-| `source.auth` | Optional metadata-fetch auth for package repositories, `source.url`, `source.githubRelease`, or local `provider-release.yaml` metadata. |
+| `source.auth` | Optional metadata-fetch auth for package repositories, `source.url`, `source.githubRelease`, `source.git`, or local `provider-release.yaml` metadata. |
 | `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either the reserved `server` alias or a named entry from `providers.authentication`. Gestalt enforces this on plugin HTTP operation routes (`/api/v1/integrations/{name}/operations` and `/api/v1/{integration}/{operation}`) and on plugin-backed mounted UIs, including browser-login flows whose `next` path resolves into that plugin's mount. Standalone `providers.ui` bundles, the built-in admin UI/admin API, and `/mcp` still use the server-wide auth provider in this phase. |
 | `config` | Provider-specific configuration passed into the provider package. |
 | `securitySchemes` | Optional hosted HTTP security scheme overrides merged over the plugin manifest's `spec.securitySchemes`. Use this for deployment-specific secrets or for deployment-local hosted HTTP bindings. |
@@ -1186,6 +1204,38 @@ source:
 `gestaltd provider add` writes package sources by default. See
 [Provider Packages](/providers/packages) for repository, add, list, remove, and
 upgrade behavior.
+
+For commit-pinned first-party development, use a git source. `ref` must be a
+full commit SHA. `artifactMode: source` fetches and builds from the git source
+when prepared artifacts are missing:
+
+```yaml
+source:
+  git:
+    repo: https://github.com/acme/gestalt-providers.git
+    ref: 60fa7e0521eeedea8b28abdd9b43284e9ea246e2
+    path: plugins/github/manifest.yaml
+    artifactMode: source
+```
+
+To consume prebuilt snapshots, set `artifactRepository` and an explicit
+`artifactMode`. `require` never falls back to git or provider indexes:
+
+```yaml
+providerSnapshotRepositories:
+  acme:
+    url: https://storage.googleapis.com/acme-gestalt-provider-snapshots
+
+plugins:
+  github:
+    source:
+      git:
+        repo: https://github.com/acme/gestalt-providers.git
+        ref: 60fa7e0521eeedea8b28abdd9b43284e9ea246e2
+        path: plugins/github/manifest.yaml
+        artifactRepository: acme
+        artifactMode: require
+```
 
 For exact published releases, point at a `provider-release.yaml` URL:
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -48,19 +48,25 @@ const PluginConnectionAlias = core.PluginConnectionAlias
 const ConfigAPIVersion = "gestaltd.config/v5"
 
 type Config struct {
-	APIVersion           string                              `yaml:"apiVersion,omitempty"`
-	ProviderRepositories map[string]ProviderRepositoryConfig `yaml:"providerRepositories,omitempty"`
-	Server               ServerConfig                        `yaml:"server"`
-	Authorization        AuthorizationConfig                 `yaml:"authorization,omitempty"`
-	Connections          map[string]*ConnectionDef           `yaml:"connections,omitempty"`
-	Providers            ProvidersConfig                     `yaml:"providers"`
-	Runtime              RuntimeConfig                       `yaml:"runtime,omitempty"`
-	Workflows            WorkflowsConfig                     `yaml:"workflows,omitempty"`
-	Plugins              map[string]*ProviderEntry           `yaml:"plugins,omitempty"`
+	APIVersion                   string                                      `yaml:"apiVersion,omitempty"`
+	ProviderRepositories         map[string]ProviderRepositoryConfig         `yaml:"providerRepositories,omitempty"`
+	ProviderSnapshotRepositories map[string]ProviderSnapshotRepositoryConfig `yaml:"providerSnapshotRepositories,omitempty"`
+	Server                       ServerConfig                                `yaml:"server"`
+	Authorization                AuthorizationConfig                         `yaml:"authorization,omitempty"`
+	Connections                  map[string]*ConnectionDef                   `yaml:"connections,omitempty"`
+	Providers                    ProvidersConfig                             `yaml:"providers"`
+	Runtime                      RuntimeConfig                               `yaml:"runtime,omitempty"`
+	Workflows                    WorkflowsConfig                             `yaml:"workflows,omitempty"`
+	Plugins                      map[string]*ProviderEntry                   `yaml:"plugins,omitempty"`
 }
 
 type ProviderRepositoryConfig struct {
 	URL string `yaml:"url,omitempty"`
+}
+
+type ProviderSnapshotRepositoryConfig struct {
+	URL        string `yaml:"url,omitempty"`
+	GestaltRef string `yaml:"gestaltRef,omitempty"`
 }
 
 type ProvidersConfig struct {
@@ -143,6 +149,7 @@ type ServerProvidersConfig struct {
 //   - Builtin:  recognized host builtins such as source: "env" or "stdout"
 //   - Metadata: source: "https://.../provider-release.yaml"  -> ProviderSource{metadataURL: "..."}
 //   - GitHub:   source: {githubRelease: {repo, tag, asset}}  -> ProviderSource{GitHubRelease: ...}
+//   - Git:      source: {git: {repo, ref, path}} -> ProviderSource{Git: ...}
 //   - Local:    source: {path} or source: "./manifest.yaml"  -> ProviderSource{Path: "..."}
 //   - Local metadata: source: {path} or source: "./dist/provider-release.yaml"
 //     -> ProviderSource{metadataPath: "..."}
@@ -158,6 +165,7 @@ type ProviderSource struct {
 	resolvedVersion     string                  `yaml:"-"`
 	unsupported         string                  `yaml:"-"`
 	GitHubRelease       *GitHubReleaseSourceDef `yaml:"githubRelease,omitempty"`
+	Git                 *GitSourceDef           `yaml:"git,omitempty"`
 	Path                string                  `yaml:"path,omitempty"`
 	Auth                *SourceAuthDef          `yaml:"auth,omitempty"`
 }
@@ -168,6 +176,7 @@ type providerSourceYAML struct {
 	Package       string                  `yaml:"package,omitempty"`
 	Version       string                  `yaml:"version,omitempty"`
 	GitHubRelease *GitHubReleaseSourceDef `yaml:"githubRelease,omitempty"`
+	Git           *GitSourceDef           `yaml:"git,omitempty"`
 	Path          string                  `yaml:"path,omitempty"`
 	Auth          *SourceAuthDef          `yaml:"auth,omitempty"`
 }
@@ -180,6 +189,14 @@ type GitHubReleaseSourceDef struct {
 	Repo  string `yaml:"repo,omitempty"`
 	Tag   string `yaml:"tag,omitempty"`
 	Asset string `yaml:"asset,omitempty"`
+}
+
+type GitSourceDef struct {
+	Repo               string `yaml:"repo,omitempty"`
+	Ref                string `yaml:"ref,omitempty"`
+	Path               string `yaml:"path,omitempty"`
+	ArtifactRepository string `yaml:"artifactRepository,omitempty"`
+	ArtifactMode       string `yaml:"artifactMode,omitempty"`
 }
 
 func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
@@ -202,6 +219,7 @@ func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
 			return err
 		}
 		s.GitHubRelease = cloneGitHubReleaseSourceDef(raw.GitHubRelease)
+		s.Git = cloneGitSourceDef(raw.Git)
 		s.Path = strings.TrimSpace(raw.Path)
 		s.metadataURL = strings.TrimSpace(raw.URL)
 		s.packageRepo = strings.TrimSpace(raw.Repo)
@@ -215,6 +233,7 @@ func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 	s.GitHubRelease = cloneGitHubReleaseSourceDef(raw.GitHubRelease)
+	s.Git = cloneGitSourceDef(raw.Git)
 	s.Path = strings.TrimSpace(raw.Path)
 	s.metadataURL = strings.TrimSpace(raw.URL)
 	s.packageRepo = strings.TrimSpace(raw.Repo)
@@ -246,6 +265,12 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 			Auth:          auth,
 		}, nil
 	}
+	if s.Git != nil && s.Path == "" && s.metadataPath == "" && s.metadataURL == "" && s.packageName == "" && s.GitHubRelease == nil {
+		return providerSourceYAML{
+			Git:  cloneGitSourceDef(s.Git),
+			Auth: auth,
+		}, nil
+	}
 	if s.scalar != "" && s.Path == "" && s.metadataPath == "" && auth == nil {
 		return s.scalar, nil
 	}
@@ -258,6 +283,7 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 		Package:       strings.TrimSpace(s.packageName),
 		Version:       strings.TrimSpace(s.packageVersion),
 		GitHubRelease: cloneGitHubReleaseSourceDef(s.GitHubRelease),
+		Git:           cloneGitSourceDef(s.Git),
 		Path:          s.Path,
 		Auth:          auth,
 	}, nil
@@ -266,6 +292,7 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 func (s ProviderSource) IsBuiltin() bool       { return s.Builtin != "" }
 func (s ProviderSource) IsMetadataURL() bool   { return s.metadataURL != "" }
 func (s ProviderSource) IsGitHubRelease() bool { return s.GitHubRelease != nil }
+func (s ProviderSource) IsGit() bool           { return s.Git != nil }
 func (s ProviderSource) IsPackage() bool       { return s.packageName != "" }
 func (s ProviderSource) IsLocal() bool         { return s.Path != "" }
 func (s ProviderSource) IsLocalMetadataPath() bool {
@@ -290,6 +317,9 @@ func (s *ProviderSource) SetResolvedPackage(metadataURL, version string) {
 func (s ProviderSource) GitHubReleaseSource() *GitHubReleaseSourceDef {
 	return cloneGitHubReleaseSourceDef(s.GitHubRelease)
 }
+func (s ProviderSource) GitSource() *GitSourceDef {
+	return cloneGitSourceDef(s.Git)
+}
 func (s ProviderSource) UnsupportedURL() string {
 	return s.unsupported
 }
@@ -299,6 +329,13 @@ func (s ProviderSource) GitHubReleaseLocation() string {
 		return ""
 	}
 	return s.GitHubRelease.Location()
+}
+
+func (s ProviderSource) GitLocation() string {
+	if s.Git == nil {
+		return ""
+	}
+	return s.Git.Location()
 }
 
 func NewMetadataSource(rawURL string) ProviderSource {
@@ -347,6 +384,10 @@ func NewLocalReleaseMetadataSource(rawPath string) ProviderSource {
 	return ProviderSource{metadataPath: strings.TrimSpace(rawPath)}
 }
 
+func NewGitSource(src GitSourceDef) ProviderSource {
+	return ProviderSource{Git: cloneGitSourceDef(&src)}
+}
+
 func cloneSourceAuthDef(src *SourceAuthDef) *SourceAuthDef {
 	if src == nil {
 		return nil
@@ -367,6 +408,19 @@ func cloneGitHubReleaseSourceDef(src *GitHubReleaseSourceDef) *GitHubReleaseSour
 	return &cloned
 }
 
+func cloneGitSourceDef(src *GitSourceDef) *GitSourceDef {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	cloned.Repo = strings.TrimSpace(cloned.Repo)
+	cloned.Ref = strings.TrimSpace(cloned.Ref)
+	cloned.Path = strings.TrimSpace(cloned.Path)
+	cloned.ArtifactRepository = strings.TrimSpace(cloned.ArtifactRepository)
+	cloned.ArtifactMode = strings.TrimSpace(cloned.ArtifactMode)
+	return &cloned
+}
+
 func (g GitHubReleaseSourceDef) Location() string {
 	repo := strings.TrimSpace(g.Repo)
 	tag := strings.TrimSpace(g.Tag)
@@ -383,6 +437,41 @@ func (g GitHubReleaseSourceDef) Location() string {
 			"asset": []string{asset},
 		}.Encode(),
 	}).String()
+}
+
+func (g GitSourceDef) Location() string {
+	repo, ref, manifestPath := g.NormalizedLocationParts()
+	if repo == "" || ref == "" || manifestPath == "" {
+		return ""
+	}
+	return "git+" + repo + "@" + ref + "#" + manifestPath
+}
+
+// NormalizedLocationParts returns the canonical repo, ref, and manifest path used by Location.
+func (g GitSourceDef) NormalizedLocationParts() (repo, ref, manifestPath string) {
+	return normalizeGitLocationRepoURL(g.Repo),
+		strings.ToLower(strings.TrimSpace(g.Ref)),
+		normalizeGitLocationManifestPath(g.Path)
+}
+
+func normalizeGitLocationRepoURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if parsed, err := url.Parse(trimmed); err == nil && parsed.Scheme != "" {
+		switch parsed.Scheme {
+		case "http", "https":
+			parsed.Scheme = strings.ToLower(parsed.Scheme)
+			parsed.Host = strings.ToLower(parsed.Host)
+			if strings.EqualFold(parsed.Host, "github.com") {
+				parsed.Path = strings.TrimSuffix(parsed.Path, ".git") + ".git"
+			}
+			return parsed.String()
+		}
+	}
+	return trimmed
+}
+
+func normalizeGitLocationManifestPath(raw string) string {
+	return path.Clean(filepath.ToSlash(strings.TrimSpace(raw)))
 }
 
 // ProviderEntry is the universal configuration for any provider.
@@ -1486,7 +1575,7 @@ func (e *ProviderEntry) HasReleaseMetadataSource() bool {
 }
 
 func (e *ProviderEntry) HasRemoteSource() bool {
-	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsGitHubRelease() || e.Source.IsPackage())
+	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsGitHubRelease() || e.Source.IsPackage() || e.Source.IsGit())
 }
 
 func (e *ProviderEntry) HasRemoteReleaseSource() bool {
@@ -1499,6 +1588,10 @@ func (e *ProviderEntry) HasLocalSource() bool {
 
 func (e *ProviderEntry) HasLocalReleaseSource() bool {
 	return e != nil && e.Source.IsLocalMetadataPath()
+}
+
+func (e *ProviderEntry) HasGitSource() bool {
+	return e != nil && e.Source.IsGit()
 }
 
 func (e *ProviderEntry) SourceMetadataURL() string {
@@ -1524,6 +1617,9 @@ func (e *ProviderEntry) SourceRemoteLocation() string {
 	if e.Source.IsPackage() {
 		return e.Source.ResolvedPackageMetadataURL()
 	}
+	if e.Source.IsGit() {
+		return e.Source.GitLocation()
+	}
 	return ""
 }
 
@@ -1542,6 +1638,9 @@ func (e *ProviderEntry) SourceReleaseLocation() string {
 	}
 	if e.Source.IsPackage() {
 		return e.Source.ResolvedPackageMetadataURL()
+	}
+	if e.Source.IsGit() {
+		return e.Source.GitLocation()
 	}
 	return ""
 }
@@ -3145,7 +3244,7 @@ func applyDefaultBuiltinProviderEntries(entries map[string]*ProviderEntry, defau
 		}
 	}
 	for _, entry := range entries {
-		if entry == nil || entry.Source.IsBuiltin() || entry.Source.IsMetadataURL() || entry.Source.IsGitHubRelease() || entry.Source.IsLocalMetadataPath() || entry.Source.IsLocal() || entry.Source.IsPackage() || entry.Source.UnsupportedURL() != "" {
+		if entry == nil || entry.Source.IsBuiltin() || entry.Source.IsMetadataURL() || entry.Source.IsGitHubRelease() || entry.Source.IsGit() || entry.Source.IsLocalMetadataPath() || entry.Source.IsLocal() || entry.Source.IsPackage() || entry.Source.UnsupportedURL() != "" {
 			continue
 		}
 		entry.Source.Builtin = builtin

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1663,6 +1663,46 @@ plugins:
 		}
 	})
 
+	t.Run("apiVersion normalizes git source locations", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v5
+providers:
+plugins:
+    custom_tool:
+      source:
+        git:
+          repo: HTTPS://GitHub.com/Valon-Technologies/Gestalt-Providers
+          ref: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          path: plugins//custom_tool/../custom_tool/manifest.yaml
+          artifactMode: source
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		entry := cfg.Plugins["custom_tool"]
+		wantLocation := "git+https://github.com/Valon-Technologies/Gestalt-Providers.git@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#plugins/custom_tool/manifest.yaml"
+		if got := entry.SourceRemoteLocation(); got != wantLocation {
+			t.Fatalf("SourceRemoteLocation = %q, want %q", got, wantLocation)
+		}
+		if got := entry.SourceReleaseLocation(); got != wantLocation {
+			t.Fatalf("SourceReleaseLocation = %q, want %q", got, wantLocation)
+		}
+		gitSource := entry.Source.GitSource()
+		if gitSource == nil {
+			t.Fatal("Source.GitSource() = nil")
+		}
+		repo, ref, manifestPath := gitSource.NormalizedLocationParts()
+		if repo != "https://github.com/Valon-Technologies/Gestalt-Providers.git" ||
+			ref != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ||
+			manifestPath != "plugins/custom_tool/manifest.yaml" {
+			t.Fatalf("NormalizedLocationParts = (%q, %q, %q)", repo, ref, manifestPath)
+		}
+	})
+
 	t.Run("apiVersion preserves nested source auth on local release metadata sources", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -90,6 +90,9 @@ func ValidateCanonicalStructure(cfg *Config) error {
 	if err := validateProviderRepositories(cfg); err != nil {
 		return err
 	}
+	if err := validateProviderSnapshotRepositories(cfg); err != nil {
+		return err
+	}
 
 	for _, collection := range []struct {
 		kind    HostProviderKind
@@ -211,6 +214,46 @@ func validateProviderRepositories(cfg *Config) error {
 		}
 	}
 	return nil
+}
+
+func validateProviderSnapshotRepositories(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	for name, repo := range cfg.ProviderSnapshotRepositories {
+		if err := providerregistry.ValidateRepositoryName(name); err != nil {
+			return fmt.Errorf("config validation: providerSnapshotRepositories.%s: %w", name, err)
+		}
+		rawURL := strings.TrimSpace(repo.URL)
+		if rawURL == "" {
+			return fmt.Errorf("config validation: providerSnapshotRepositories.%s.url is required", name)
+		}
+		parsed, err := url.ParseRequestURI(rawURL)
+		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+			return fmt.Errorf("config validation: providerSnapshotRepositories.%s.url must be an absolute http(s) URL", name)
+		}
+		if ref := strings.TrimSpace(repo.GestaltRef); ref != "" && !isFullGitSHA(ref) {
+			return fmt.Errorf("config validation: providerSnapshotRepositories.%s.gestaltRef must be a 40-character commit SHA", name)
+		}
+	}
+	return nil
+}
+
+func isFullGitSHA(value string) bool {
+	value = strings.TrimSpace(value)
+	if len(value) != 40 {
+		return false
+	}
+	for _, ch := range value {
+		switch {
+		case ch >= '0' && ch <= '9':
+		case ch >= 'a' && ch <= 'f':
+		case ch >= 'A' && ch <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func normalizeConnectionBindings(cfg *Config) error {
@@ -514,6 +557,9 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	if src.IsGitHubRelease() {
 		modeCount++
 	}
+	if src.IsGit() {
+		modeCount++
+	}
 	if src.IsPackage() {
 		modeCount++
 	}
@@ -553,6 +599,55 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 			return fmt.Errorf("config validation: %s %q source.githubRelease.repo must be owner/name", kind, name)
 		}
 	}
+	if src.IsGit() {
+		git := src.GitSource()
+		switch {
+		case git == nil:
+			return fmt.Errorf("config validation: %s %q source.git is required", kind, name)
+		case strings.TrimSpace(git.Repo) == "":
+			return fmt.Errorf("config validation: %s %q source.git.repo is required", kind, name)
+		case strings.TrimSpace(git.Ref) == "":
+			return fmt.Errorf("config validation: %s %q source.git.ref is required", kind, name)
+		case !isFullGitSHA(git.Ref):
+			return fmt.Errorf("config validation: %s %q source.git.ref must be a 40-character commit SHA", kind, name)
+		case strings.TrimSpace(git.Path) == "":
+			return fmt.Errorf("config validation: %s %q source.git.path is required", kind, name)
+		}
+		cleanPath := path.Clean(filepath.ToSlash(strings.TrimSpace(git.Path)))
+		if cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") || path.IsAbs(cleanPath) {
+			return fmt.Errorf("config validation: %s %q source.git.path must be a clean relative path", kind, name)
+		}
+		if base := path.Base(cleanPath); base != "manifest.yaml" && base != "manifest.json" {
+			return fmt.Errorf("config validation: %s %q source.git.path must reference a provider manifest", kind, name)
+		}
+		parsedRepo, err := url.Parse(strings.TrimSpace(git.Repo))
+		if err != nil || parsedRepo.Scheme == "" {
+			return fmt.Errorf("config validation: %s %q source.git.repo must be an absolute URL", kind, name)
+		}
+		switch parsedRepo.Scheme {
+		case "http", "https", "file":
+		default:
+			return fmt.Errorf("config validation: %s %q source.git.repo must use http(s) or file URL", kind, name)
+		}
+		mode := strings.TrimSpace(git.ArtifactMode)
+		repoName := strings.TrimSpace(git.ArtifactRepository)
+		switch mode {
+		case "", "source", "prefer", "require":
+		default:
+			return fmt.Errorf("config validation: %s %q source.git.artifactMode must be source, prefer, or require", kind, name)
+		}
+		if repoName != "" && mode == "" {
+			return fmt.Errorf("config validation: %s %q source.git.artifactMode is required when artifactRepository is set", kind, name)
+		}
+		if (mode == "prefer" || mode == "require") && repoName == "" {
+			return fmt.Errorf("config validation: %s %q source.git.artifactRepository is required for artifactMode %q", kind, name, mode)
+		}
+		if repoName != "" {
+			if err := providerregistry.ValidateRepositoryName(repoName); err != nil {
+				return fmt.Errorf("config validation: %s %q source.git.artifactRepository: %w", kind, name, err)
+			}
+		}
+	}
 	if src.IsPackage() {
 		if err := providerregistry.ValidatePackageAddress(src.PackageAddress()); err != nil {
 			return fmt.Errorf("config validation: %s %q source.package: %w", kind, name, err)
@@ -564,7 +659,7 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 		}
 	}
 	if auth != nil {
-		if !src.IsMetadataURL() && !src.IsGitHubRelease() && !src.IsLocalMetadataPath() && !src.IsPackage() {
+		if !src.IsMetadataURL() && !src.IsGitHubRelease() && !src.IsLocalMetadataPath() && !src.IsPackage() && !src.IsGit() {
 			return fmt.Errorf("config validation: %s %q auth is only valid with provider-release metadata sources", kind, name)
 		}
 		if strings.TrimSpace(auth.Token) == "" {
@@ -742,6 +837,7 @@ func runtimeProviderUsesSource(entry *RuntimeProviderEntry) bool {
 	return entry.Source.IsBuiltin() ||
 		entry.Source.IsMetadataURL() ||
 		entry.Source.IsGitHubRelease() ||
+		entry.Source.IsGit() ||
 		entry.Source.IsLocalMetadataPath() ||
 		entry.Source.IsLocal() ||
 		entry.Source.UnsupportedURL() != ""

--- a/gestaltd/internal/operator/git_source.go
+++ b/gestaltd/internal/operator/git_source.go
@@ -1,0 +1,426 @@
+package operator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/providerpkg"
+)
+
+const (
+	gitSourceRefType        = "git"
+	gitArtifactModeSource   = "source"
+	gitArtifactModePrefer   = "prefer"
+	gitArtifactModeRequire  = "require"
+	gitResolvedModeSource   = "source"
+	gitResolvedModeSnapshot = "snapshot"
+)
+
+type gitSnapshotSource struct {
+	MetadataURL string
+	GestaltRef  string
+}
+
+func gitSourceDef(entry *config.ProviderEntry) *config.GitSourceDef {
+	if entry == nil {
+		return nil
+	}
+	return entry.Source.GitSource()
+}
+
+func gitSourceArtifactMode(git *config.GitSourceDef) string {
+	if git == nil {
+		return ""
+	}
+	mode := strings.TrimSpace(git.ArtifactMode)
+	if mode == "" {
+		return gitArtifactModeSource
+	}
+	return mode
+}
+
+func gitSourceLockRef(entry *config.ProviderEntry, resolvedMode, resolvedGestaltRef string) *LockSourceRef {
+	git := gitSourceDef(entry)
+	if git == nil {
+		return nil
+	}
+	repo, ref, manifestPath := git.NormalizedLocationParts()
+	return &LockSourceRef{
+		Type:               gitSourceRefType,
+		Repo:               repo,
+		Ref:                ref,
+		Path:               manifestPath,
+		ArtifactRepository: strings.TrimSpace(git.ArtifactRepository),
+		ArtifactMode:       gitSourceArtifactMode(git),
+		ResolvedMode:       strings.TrimSpace(resolvedMode),
+		ResolvedGestaltRef: strings.TrimSpace(resolvedGestaltRef),
+	}
+}
+
+func gitSourceFingerprintLocation(entry *config.ProviderEntry) string {
+	ref := gitSourceLockRef(entry, "", "")
+	if ref == nil {
+		return ""
+	}
+	return strings.Join([]string{
+		ref.Type,
+		ref.Repo,
+		ref.Ref,
+		ref.Path,
+		ref.ArtifactRepository,
+		ref.ArtifactMode,
+	}, "\x00")
+}
+
+func gitSourceMatchesLockRef(entry *config.ProviderEntry, lockRef *LockSourceRef) bool {
+	expected := gitSourceLockRef(entry, "", "")
+	if expected == nil || lockRef == nil {
+		return false
+	}
+	if lockRef.Type != gitSourceRefType ||
+		lockRef.Repo != expected.Repo ||
+		!strings.EqualFold(lockRef.Ref, expected.Ref) ||
+		lockRef.Path != expected.Path ||
+		lockRef.ArtifactRepository != expected.ArtifactRepository ||
+		lockRef.ArtifactMode != expected.ArtifactMode {
+		return false
+	}
+	switch expected.ArtifactMode {
+	case gitArtifactModeRequire:
+		return lockRef.ResolvedMode == gitResolvedModeSnapshot
+	case gitArtifactModeSource:
+		return lockRef.ResolvedMode == gitResolvedModeSource
+	default:
+		return lockRef.ResolvedMode == gitResolvedModeSnapshot || lockRef.ResolvedMode == gitResolvedModeSource
+	}
+}
+
+func canonicalGitSourceLocation(entry *config.ProviderEntry) string {
+	git := gitSourceDef(entry)
+	if git == nil {
+		return ""
+	}
+	return git.Location()
+}
+
+func resolveGitSnapshotSource(cfg *config.Config, entry *config.ProviderEntry) (gitSnapshotSource, error) {
+	git := gitSourceDef(entry)
+	if git == nil {
+		return gitSnapshotSource{}, fmt.Errorf("source.git is required")
+	}
+	repoName := strings.TrimSpace(git.ArtifactRepository)
+	if repoName == "" {
+		return gitSnapshotSource{}, fmt.Errorf("source.git.artifactRepository is required")
+	}
+	repo, ok := cfg.ProviderSnapshotRepositories[repoName]
+	if !ok {
+		return gitSnapshotSource{}, fmt.Errorf("providerSnapshotRepositories.%s is not configured", repoName)
+	}
+	owner, name, err := githubRepoPath(git.Repo)
+	if err != nil {
+		return gitSnapshotSource{}, err
+	}
+	base := strings.TrimRight(strings.TrimSpace(repo.URL), "/")
+	_, ref, manifestPath := git.NormalizedLocationParts()
+	providerDir := path.Dir(manifestPath)
+	if providerDir == "." {
+		providerDir = ""
+	}
+	parts := []string{base, "github.com", owner, name, ref}
+	if providerDir != "" {
+		parts = append(parts, strings.Split(providerDir, "/")...)
+	}
+	parts = append(parts, "provider-release.yaml")
+	return gitSnapshotSource{
+		MetadataURL: strings.Join(parts, "/"),
+		GestaltRef:  strings.TrimSpace(repo.GestaltRef),
+	}, nil
+}
+
+func githubRepoPath(raw string) (string, string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", "", fmt.Errorf("parse source.git.repo: %w", err)
+	}
+	if parsed.Scheme != "https" || !strings.EqualFold(parsed.Host, "github.com") {
+		return "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
+	}
+	clean := strings.Trim(path.Clean(parsed.Path), "/")
+	parts := strings.Split(clean, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("source.git snapshots require https://github.com/<owner>/<repo>[.git]")
+	}
+	return parts[0], strings.TrimSuffix(parts[1], ".git"), nil
+}
+
+func (l *Lifecycle) gitSourceManifestPath(ctx context.Context, paths lifecyclePaths, entry *config.ProviderEntry) (string, error) {
+	git := gitSourceDef(entry)
+	if git == nil {
+		return "", fmt.Errorf("source.git is required")
+	}
+	repo, ref, manifestRel := git.NormalizedLocationParts()
+	cacheRoot := filepath.Join(paths.artifactsDir, ".gestaltd", "git-source-cache")
+	cacheKey := sha256.Sum256([]byte(repo + "\x00" + ref))
+	checkoutDir := filepath.Join(cacheRoot, hex.EncodeToString(cacheKey[:]))
+	if err := ensureGitCheckout(ctx, checkoutDir, repo, ref); err != nil {
+		return "", err
+	}
+	manifestPath := filepath.Join(checkoutDir, filepath.FromSlash(manifestRel))
+	if !pathWithinRoot(checkoutDir, manifestPath) {
+		return "", fmt.Errorf("source.git.path %q escapes repository checkout", git.Path)
+	}
+	if _, err := os.Stat(manifestPath); err != nil {
+		return "", fmt.Errorf("source.git.path %q not found at ref %s: %w", git.Path, ref, err)
+	}
+	return manifestPath, nil
+}
+
+func (l *Lifecycle) lockGitProviderEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, name string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
+	destDir := providerDestDir(paths, name)
+	if entry, installed, ok, err := l.tryLockGitSnapshotSource(ctx, cfg, paths, providermanifestv1.KindPlugin, name, fmt.Sprintf("provider %q", name), destDir, plugin); ok || err != nil {
+		if err != nil {
+			return LockEntry{}, err
+		}
+		if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindPlugin, configMap); err != nil {
+			return LockEntry{}, fmt.Errorf("provider config validation for provider %q: %w", name, err)
+		}
+		return finalizeGitInstalledLockEntry(paths, name, plugin, entry, installed, providermanifestv1.KindPlugin, false)
+	}
+
+	install, err := l.prepareGitSourceInstall(ctx, paths, providermanifestv1.KindPlugin, name, destDir, plugin)
+	if err != nil {
+		return LockEntry{}, err
+	}
+	if err := providerpkg.ValidateConfigForManifest(install.manifestPath, install.manifest, providermanifestv1.KindPlugin, configMap); err != nil {
+		return LockEntry{}, fmt.Errorf("provider config validation for provider %q: %w", name, err)
+	}
+	return gitLocalLockEntryFromPreparedInstall(paths, providermanifestv1.KindPlugin, name, plugin, install, false)
+}
+
+func (l *Lifecycle) lockGitComponentEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
+	subject := fmt.Sprintf("%s %q", kind, name)
+	if entry, installed, ok, err := l.tryLockGitSnapshotSource(ctx, cfg, paths, kind, name, subject, destDir, plugin); ok || err != nil {
+		if err != nil {
+			return LockEntry{}, err
+		}
+		if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, kind, configMap); err != nil {
+			return LockEntry{}, fmt.Errorf("provider config validation for %s %q: %w", kind, name, err)
+		}
+		return finalizeGitInstalledLockEntry(paths, name, plugin, entry, installed, kind, false)
+	}
+
+	install, err := l.prepareGitSourceInstall(ctx, paths, kind, name, destDir, plugin)
+	if err != nil {
+		return LockEntry{}, err
+	}
+	if err := providerpkg.ValidateConfigForManifest(install.manifestPath, install.manifest, kind, configMap); err != nil {
+		return LockEntry{}, fmt.Errorf("provider config validation for %s %q: %w", kind, name, err)
+	}
+	return gitLocalLockEntryFromPreparedInstall(paths, kind, name, plugin, install, false)
+}
+
+func (l *Lifecycle) lockGitUIEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, name string, plugin *config.ProviderEntry, destDir, subject string, configMap map[string]any) (LockEntry, error) {
+	if entry, installed, ok, err := l.tryLockGitSnapshotSource(ctx, cfg, paths, providermanifestv1.KindUI, name, subject, destDir, plugin); ok || err != nil {
+		if err != nil {
+			return LockEntry{}, err
+		}
+		if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindUI, configMap); err != nil {
+			return LockEntry{}, fmt.Errorf("provider config validation for %s: %w", subject, err)
+		}
+		return finalizeGitInstalledLockEntry(paths, "ui:"+name, plugin, entry, installed, providermanifestv1.KindUI, true)
+	}
+
+	install, err := l.prepareGitSourceInstall(ctx, paths, providermanifestv1.KindUI, name, destDir, plugin)
+	if err != nil {
+		return LockEntry{}, err
+	}
+	if err := providerpkg.ValidateConfigForManifest(install.manifestPath, install.manifest, providermanifestv1.KindUI, configMap); err != nil {
+		return LockEntry{}, fmt.Errorf("provider config validation for %s: %w", subject, err)
+	}
+	return gitLocalLockEntryFromPreparedInstall(paths, providermanifestv1.KindUI, "ui:"+name, plugin, install, true)
+}
+
+func (l *Lifecycle) tryLockGitSnapshotSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, expectedKind, name, subject, destDir string, plugin *config.ProviderEntry) (LockEntry, *installedPackage, bool, error) {
+	git := gitSourceDef(plugin)
+	mode := gitSourceArtifactMode(git)
+	if mode == gitArtifactModeSource {
+		return LockEntry{}, nil, false, nil
+	}
+	if cfg == nil {
+		if mode == gitArtifactModeRequire {
+			return LockEntry{}, nil, false, fmt.Errorf("%s source.git snapshot resolution requires loaded config", subject)
+		}
+		return LockEntry{}, nil, false, nil
+	}
+	snapshot, err := resolveGitSnapshotSource(cfg, plugin)
+	if err != nil {
+		if mode == gitArtifactModeRequire {
+			return LockEntry{}, nil, false, fmt.Errorf("%s resolve source.git snapshot: %w", subject, err)
+		}
+		return LockEntry{}, nil, false, nil
+	}
+	metadataProvider := *plugin
+	metadataProvider.Source = config.NewMetadataSource(snapshot.MetadataURL)
+	metadataProvider.Source.Auth = plugin.Source.Auth
+	installed, entry, err := l.installMetadataSourcePackage(ctx, expectedKind, name, subject, destDir, &metadataProvider, paths.configDir)
+	if err != nil {
+		if mode == gitArtifactModeRequire {
+			return LockEntry{}, nil, false, fmt.Errorf("%s source.git snapshot %s: %w", subject, snapshot.MetadataURL, err)
+		}
+		return LockEntry{}, nil, false, nil
+	}
+	entry.Source = snapshot.MetadataURL
+	entry.SourceRef = gitSourceLockRef(plugin, gitResolvedModeSnapshot, snapshot.GestaltRef)
+	return entry, installed, true, nil
+}
+
+func (l *Lifecycle) prepareGitSourceInstall(ctx context.Context, paths lifecyclePaths, kind, name, destDir string, plugin *config.ProviderEntry) (*preparedInstall, error) {
+	manifestPath, err := l.gitSourceManifestPath(ctx, paths, plugin)
+	if err != nil {
+		return nil, err
+	}
+	install, err := prepareLocalSourceInstall(kind, name, manifestPath, destDir)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateInstalledManifestKind(kind, name, install.manifest); err != nil {
+		return nil, err
+	}
+	return install, nil
+}
+
+func (l *Lifecycle) stageGitSourceInstall(ctx context.Context, paths lifecyclePaths, kind, name, destDir string, plugin *config.ProviderEntry) (*preparedInstall, func() error, func() error, error) {
+	manifestPath, err := l.gitSourceManifestPath(ctx, paths, plugin)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return stageLocalSourceInstall(kind, name, manifestPath, destDir)
+}
+
+func gitLocalLockEntryFromPreparedInstall(paths lifecyclePaths, kind, fingerprintName string, plugin *config.ProviderEntry, install *preparedInstall, ui bool) (LockEntry, error) {
+	var entry LockEntry
+	var err error
+	if ui {
+		entry, err = localUILockEntryFromPreparedInstall(paths, strings.TrimPrefix(fingerprintName, "ui:"), plugin, install)
+	} else {
+		entry, err = localLockEntryFromPreparedInstall(paths, kind, fingerprintName, plugin, install)
+	}
+	if err != nil {
+		return LockEntry{}, err
+	}
+	entry.Source = canonicalGitSourceLocation(plugin)
+	entry.SourceRef = gitSourceLockRef(plugin, gitResolvedModeSource, "")
+	entry.Package = install.manifest.Source
+	entry.Kind = install.manifest.Kind
+	entry.Runtime = releaseRuntimeForManifest(install.manifest, archivePolicyKind(kind))
+	entry.Version = install.manifest.Version
+	return entry, nil
+}
+
+func finalizeGitInstalledLockEntry(paths lifecyclePaths, fingerprintName string, plugin *config.ProviderEntry, entry LockEntry, installed *installedPackage, kind string, ui bool) (LockEntry, error) {
+	var fingerprint string
+	var err error
+	if ui {
+		fingerprint, err = NamedUIProviderFingerprint(strings.TrimPrefix(fingerprintName, "ui:"), plugin, paths.configDir)
+	} else {
+		fingerprint, err = ProviderFingerprint(fingerprintName, plugin, paths.configDir)
+	}
+	if err != nil {
+		return LockEntry{}, fmt.Errorf("fingerprinting %s provider: %w", kind, err)
+	}
+	manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
+	if err != nil {
+		return LockEntry{}, fmt.Errorf("compute manifest path for %s provider: %w", kind, err)
+	}
+	entry.Fingerprint = fingerprint
+	entry.Manifest = filepath.ToSlash(manifestPath)
+	if ui {
+		assetRoot, err := filepath.Rel(paths.artifactsDir, installed.AssetRoot)
+		if err != nil {
+			return LockEntry{}, fmt.Errorf("compute asset root path for ui provider: %w", err)
+		}
+		entry.AssetRoot = filepath.ToSlash(assetRoot)
+		return entry, nil
+	}
+	executableRel := ""
+	if installed.ExecutablePath != "" {
+		executableRel, err = filepath.Rel(paths.artifactsDir, installed.ExecutablePath)
+		if err != nil {
+			return LockEntry{}, fmt.Errorf("compute executable path for %s provider: %w", kind, err)
+		}
+	}
+	entry.Executable = filepath.ToSlash(executableRel)
+	return entry, nil
+}
+
+func ensureGitCheckout(ctx context.Context, checkoutDir, repo, ref string) error {
+	if head, err := gitOutput(ctx, checkoutDir, "rev-parse", "HEAD"); err == nil && strings.EqualFold(strings.TrimSpace(head), ref) {
+		return nil
+	}
+	if _, err := os.Stat(filepath.Join(checkoutDir, ".git")); os.IsNotExist(err) {
+		if err := os.RemoveAll(checkoutDir); err != nil {
+			return fmt.Errorf("remove stale git source cache: %w", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(checkoutDir), 0o755); err != nil {
+			return fmt.Errorf("create git source cache: %w", err)
+		}
+		if err := gitRun(ctx, "", "clone", "--quiet", "--filter=blob:none", "--no-checkout", repo, checkoutDir); err != nil {
+			_ = os.RemoveAll(checkoutDir)
+			if fallbackErr := gitRun(ctx, "", "clone", "--quiet", "--no-checkout", repo, checkoutDir); fallbackErr != nil {
+				return fmt.Errorf("clone source.git repo %s: %w", repo, err)
+			}
+		}
+	} else if err != nil {
+		return fmt.Errorf("inspect git source cache: %w", err)
+	}
+	if err := gitRun(ctx, checkoutDir, "fetch", "--quiet", "--depth=1", "origin", ref); err != nil {
+		if fallbackErr := gitRun(ctx, checkoutDir, "fetch", "--quiet", "origin", ref); fallbackErr != nil {
+			return fmt.Errorf("fetch source.git ref %s from %s: %w", ref, repo, err)
+		}
+	}
+	if err := gitRun(ctx, checkoutDir, "checkout", "--quiet", "--detach", ref); err != nil {
+		return fmt.Errorf("checkout source.git ref %s: %w", ref, err)
+	}
+	head, err := gitOutput(ctx, checkoutDir, "rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("verify source.git checkout: %w", err)
+	}
+	if !strings.EqualFold(strings.TrimSpace(head), ref) {
+		return fmt.Errorf("source.git checkout resolved %s, want %s", strings.TrimSpace(head), ref)
+	}
+	return nil
+}
+
+func gitRun(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %s", strings.Join(args, " "), strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s: %s", strings.Join(args, " "), strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -70,12 +70,24 @@ type LockArchive struct {
 	SHA256 string `json:"sha256,omitempty"`
 }
 
+type LockSourceRef struct {
+	Type               string `json:"type,omitempty"`
+	Repo               string `json:"repo,omitempty"`
+	Ref                string `json:"ref,omitempty"`
+	Path               string `json:"path,omitempty"`
+	ArtifactRepository string `json:"artifactRepository,omitempty"`
+	ArtifactMode       string `json:"artifactMode,omitempty"`
+	ResolvedMode       string `json:"resolvedMode,omitempty"`
+	ResolvedGestaltRef string `json:"resolvedGestaltRef,omitempty"`
+}
+
 type LockEntry struct {
 	Fingerprint              string                       `json:"fingerprint"`
 	Package                  string                       `json:"package,omitempty"`
 	Kind                     string                       `json:"kind,omitempty"`
 	Runtime                  string                       `json:"runtime,omitempty"`
 	Source                   string                       `json:"source,omitempty"`
+	SourceRef                *LockSourceRef               `json:"sourceRef,omitempty"`
 	Version                  string                       `json:"version,omitempty"`
 	Archives                 map[string]LockArchive       `json:"archives,omitempty"`
 	Manifest                 string                       `json:"manifest"`
@@ -351,7 +363,7 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 				}
 			}
 			destDir := componentDestDir(paths, collection.kind, name)
-			lockEntry, err := l.writeComponentArtifact(ctx, paths, providerManifestKind(collection.kind), name, destDir, entry, entry.Config)
+			lockEntry, err := l.writeComponentArtifact(ctx, cfg, paths, providerManifestKind(collection.kind), name, destDir, entry, entry.Config)
 			if err != nil {
 				return nil, err
 			}
@@ -363,7 +375,7 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 			continue
 		}
 		destDir := componentDestDir(paths, config.HostProviderKindRuntime, name)
-		lockEntry, err := l.writeComponentArtifact(ctx, paths, providerManifestKind(config.HostProviderKindRuntime), name, destDir, &entry.ProviderEntry, entry.Config)
+		lockEntry, err := l.writeComponentArtifact(ctx, cfg, paths, providerManifestKind(config.HostProviderKindRuntime), name, destDir, &entry.ProviderEntry, entry.Config)
 		if err != nil {
 			return nil, err
 		}
@@ -384,7 +396,7 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 	}
 	for name, def := range cfg.Providers.IndexedDB {
 		if sourceBacked(def) {
-			entry, err := l.writeComponentArtifact(ctx, paths, providermanifestv1.KindIndexedDB, name, indexeddbDestDir(paths, name), def, def.Config)
+			entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindIndexedDB, name, indexeddbDestDir(paths, name), def, def.Config)
 			if err != nil {
 				return nil, err
 			}
@@ -393,7 +405,7 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 	}
 	for name, def := range cfg.Providers.S3 {
 		if sourceBacked(def) {
-			entry, err := l.writeComponentArtifact(ctx, paths, providermanifestv1.KindS3, name, s3DestDir(paths, name), def, def.Config)
+			entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindS3, name, s3DestDir(paths, name), def, def.Config)
 			if err != nil {
 				return nil, err
 			}
@@ -407,7 +419,7 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 					continue
 				}
 			}
-			uiEntry, err := l.writeNamedUIProviderArtifact(ctx, paths, name, &entry.ProviderEntry, uiDestDir(paths, name), "ui "+strconv.Quote(name))
+			uiEntry, err := l.writeNamedUIProviderArtifact(ctx, cfg, paths, name, &entry.ProviderEntry, uiDestDir(paths, name), "ui "+strconv.Quote(name))
 			if err != nil {
 				return nil, err
 			}
@@ -592,6 +604,11 @@ func buildSourceTokenMap(cfg *config.Config) map[string]string {
 			return
 		}
 		tokens[location] = entry.Source.Auth.Token
+		if entry.Source.IsGit() {
+			if snapshot, err := resolveGitSnapshotSource(cfg, entry); err == nil && snapshot.MetadataURL != "" {
+				tokens[snapshot.MetadataURL] = entry.Source.Auth.Token
+			}
+		}
 	}
 	for _, entry := range cfg.Plugins {
 		addEntry(entry)
@@ -957,7 +974,7 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 						return nil, err
 					}
 				} else {
-					entry, err := l.writeComponentArtifact(ctx, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config)
+					entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config)
 					if err != nil {
 						return nil, err
 					}
@@ -1669,6 +1686,9 @@ func providerSourceLockLocation(entry *config.ProviderEntry, configDir string) s
 	if entry.Source.IsPackage() {
 		return strings.TrimSpace(entry.Source.ResolvedPackageMetadataURL())
 	}
+	if entry.Source.IsGit() {
+		return canonicalGitSourceLocation(entry)
+	}
 	if entry.HasRemoteSource() {
 		return entry.SourceRemoteLocation()
 	}
@@ -1690,12 +1710,18 @@ func providerSourceFingerprintLocation(entry *config.ProviderEntry, configDir st
 			entry.Source.PackageVersionConstraint(),
 		}, "\x00")
 	}
+	if entry.Source.IsGit() {
+		return gitSourceFingerprintLocation(entry)
+	}
 	return providerSourceLockLocation(entry, configDir)
 }
 
 func lockEntrySourceMatchesProvider(paths lifecyclePaths, provider *config.ProviderEntry, entry LockEntry) bool {
 	if provider == nil {
 		return false
+	}
+	if provider.Source.IsGit() {
+		return gitSourceMatchesLockRef(provider, entry.SourceRef)
 	}
 	if provider.Source.IsPackage() {
 		if strings.TrimSpace(entry.Package) != provider.Source.PackageAddress() {
@@ -2258,7 +2284,7 @@ func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Conf
 		if !sourceBacked(entry) {
 			continue
 		}
-		lockEntry, err := l.lockProviderEntryForSource(ctx, paths, name, entry, configMap)
+		lockEntry, err := l.lockProviderEntryForSource(ctx, cfg, paths, name, entry, configMap)
 		if err != nil {
 			return nil, err
 		}
@@ -2268,15 +2294,15 @@ func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Conf
 	return written, nil
 }
 
-func (l *Lifecycle) writeComponentArtifact(ctx context.Context, paths lifecyclePaths, kind, name, destDir string, plugin *config.ProviderEntry, configNode yaml.Node) (LockEntry, error) {
+func (l *Lifecycle) writeComponentArtifact(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, plugin *config.ProviderEntry, configNode yaml.Node) (LockEntry, error) {
 	configMap, err := config.NodeToMap(configNode)
 	if err != nil {
 		return LockEntry{}, fmt.Errorf("decode provider config for %s %q: %w", kind, name, err)
 	}
-	return l.lockComponentEntryForSource(ctx, paths, kind, name, destDir, plugin, configMap)
+	return l.lockComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, plugin, configMap)
 }
 
-func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths lifecyclePaths, kind, name, destDir string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
+func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
 	if plugin != nil && plugin.HasLocalSource() {
 		install, err := prepareLocalSourceInstall(kind, name, plugin.SourcePath(), destDir)
 		if err != nil {
@@ -2289,6 +2315,9 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths lifec
 			return LockEntry{}, fmt.Errorf("provider config validation for %s %q: %w", kind, name, err)
 		}
 		return localLockEntryFromPreparedInstall(paths, kind, name, plugin, install)
+	}
+	if plugin != nil && plugin.HasGitSource() {
+		return l.lockGitComponentEntryForSource(ctx, cfg, paths, kind, name, destDir, plugin, configMap)
 	}
 
 	sourceLocation := plugin.SourceReleaseLocation()
@@ -2331,7 +2360,7 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths lifec
 	return entry, nil
 }
 
-func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths lifecyclePaths, name string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
+func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, name string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
 	if plugin != nil && plugin.HasLocalSource() {
 		install, err := prepareLocalSourceInstall(providermanifestv1.KindPlugin, name, plugin.SourcePath(), providerDestDir(paths, name))
 		if err != nil {
@@ -2344,6 +2373,9 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths lifecy
 			return LockEntry{}, fmt.Errorf("provider config validation for provider %q: %w", name, err)
 		}
 		return localLockEntryFromPreparedInstall(paths, providermanifestv1.KindPlugin, name, plugin, install)
+	}
+	if plugin != nil && plugin.HasGitSource() {
+		return l.lockGitProviderEntryForSource(ctx, cfg, paths, name, plugin, configMap)
 	}
 
 	sourceLocation := plugin.SourceReleaseLocation()
@@ -2385,7 +2417,7 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths lifecy
 	return entry, nil
 }
 
-func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths lifecyclePaths, name string, plugin *config.ProviderEntry, destDir string, subject string) (LockEntry, error) {
+func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, cfg *config.Config, paths lifecyclePaths, name string, plugin *config.ProviderEntry, destDir string, subject string) (LockEntry, error) {
 	if plugin == nil || !sourceBacked(plugin) {
 		return LockEntry{}, fmt.Errorf("%s requires source configuration", subject)
 	}
@@ -2414,6 +2446,9 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths life
 		}
 		entry.Fingerprint = fingerprint
 		return entry, nil
+	}
+	if plugin.HasGitSource() {
+		return l.lockGitUIEntryForSource(ctx, cfg, paths, name, plugin, destDir, subject, configMap)
 	}
 	expectedPackage := plugin.SourceReleaseLocation()
 
@@ -3026,6 +3061,28 @@ func (l *Lifecycle) applyStaticValidationEntry(ctx context.Context, paths lifecy
 		}
 		return nil
 	}
+	if provider.HasGitSource() && found && len(entry.Archives) == 0 {
+		install, cleanup, _, err := l.stageGitSourceInstall(ctx, paths, kind, name, destDir, provider)
+		if err != nil {
+			if cleanup != nil {
+				_ = cleanup()
+			}
+			return err
+		}
+		if !preparedManifestMatchesLock(entry, install.manifest) {
+			if cleanup != nil {
+				_ = cleanup()
+			}
+			return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
+		}
+		if err := bind(install.manifestPath, install.manifest); err != nil {
+			if cleanup != nil {
+				_ = cleanup()
+			}
+			return err
+		}
+		return nil
+	}
 	if !found {
 		return lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", kind, name)
 	}
@@ -3350,11 +3407,15 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 				return "", preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
 			}
 			if len(lockEntry.Archives) == 0 {
-				if !provider.HasLocalSource() {
+				if !provider.HasLocalSource() && !provider.HasGitSource() {
 					return "", preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
 				}
 				if stagedInstall == nil {
-					stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindUI, logicalName, provider.SourcePath(), destDir)
+					if provider.HasGitSource() {
+						stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, providermanifestv1.KindUI, logicalName, destDir, provider)
+					} else {
+						stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindUI, logicalName, provider.SourcePath(), destDir)
+					}
 					if err != nil {
 						return "", err
 					}
@@ -3478,11 +3539,15 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 			return preparedArtifactStaleError(paths, "prepared artifact for provider %q is missing or stale", name)
 		}
 		if len(entry.Archives) == 0 {
-			if !plugin.HasLocalSource() {
+			if !plugin.HasLocalSource() && !plugin.HasGitSource() {
 				return preparedArtifactStaleError(paths, "prepared artifact for provider %q is missing or stale", name)
 			}
 			if stagedInstall == nil {
-				stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindPlugin, name, plugin.SourcePath(), destDir)
+				if plugin.HasGitSource() {
+					stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, providermanifestv1.KindPlugin, name, destDir, plugin)
+				} else {
+					stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(providermanifestv1.KindPlugin, name, plugin.SourcePath(), destDir)
+				}
 				if err != nil {
 					return err
 				}
@@ -3574,11 +3639,15 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 			return preparedArtifactStaleError(paths, "prepared artifact for %s %q is missing or stale", kind, name)
 		}
 		if len(entry.Archives) == 0 {
-			if !plugin.HasLocalSource() {
+			if !plugin.HasLocalSource() && !plugin.HasGitSource() {
 				return preparedArtifactStaleError(paths, "prepared artifact for %s %q is missing or stale", kind, name)
 			}
 			if stagedInstall == nil {
-				stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(kind, name, plugin.SourcePath(), destDir)
+				if plugin.HasGitSource() {
+					stagedInstall, cleanupStaged, commitStaged, err = l.stageGitSourceInstall(context.Background(), paths, kind, name, destDir, plugin)
+				} else {
+					stagedInstall, cleanupStaged, commitStaged, err = stageLocalSourceInstall(kind, name, plugin.SourcePath(), destDir)
+				}
 				if err != nil {
 					return err
 				}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -36,6 +37,299 @@ const (
 	testBinary  = "fake-binary-content"
 )
 
+func TestLifecycleGitSourceBuildLockSyncContract(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "providers")
+	const packageSource = "github.com/acme/providers/plugins/alpha"
+	writeSourceProviderTree(t, filepath.Join(repoDir, "plugins", "alpha"), packageSource, "1.2.3", "alpha-binary")
+	runGitTestCommand(t, repoDir, "init")
+	runGitTestCommand(t, repoDir, "config", "user.email", "test@example.com")
+	runGitTestCommand(t, repoDir, "config", "user.name", "Test")
+	runGitTestCommand(t, repoDir, "add", ".")
+	runGitTestCommand(t, repoDir, "commit", "-m", "provider")
+	ref := strings.TrimSpace(runGitTestOutput(t, repoDir, "rev-parse", "HEAD"))
+
+	artifactsDir := filepath.Join(dir, "artifacts")
+	configPath := filepath.Join(dir, "gestaltd.yaml")
+	configYAML := fmt.Sprintf(`
+apiVersion: gestaltd.config/v5
+%s
+server:
+  providers:
+    indexeddb: sqlite
+  artifactsDir: %s
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+plugins:
+  alpha:
+    source:
+      git:
+        repo: file://%s
+        ref: %s
+        path: plugins/alpha/manifest.yaml
+        artifactMode: source
+`, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), filepath.ToSlash(artifactsDir), filepath.ToSlash(repoDir), ref)
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle()
+	lock, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	if err != nil {
+		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	}
+	entry := lock.Providers["alpha"]
+	if entry.SourceRef == nil {
+		t.Fatal("sourceRef missing")
+	}
+	if entry.SourceRef.ResolvedMode != gitResolvedModeSource {
+		t.Fatalf("sourceRef.resolvedMode = %q, want %q", entry.SourceRef.ResolvedMode, gitResolvedModeSource)
+	}
+	if entry.SourceRef.Ref != ref {
+		t.Fatalf("sourceRef.ref = %q, want %q", entry.SourceRef.Ref, ref)
+	}
+	if entry.Source != "git+file://"+repoDir+"@"+ref+"#plugins/alpha/manifest.yaml" {
+		t.Fatalf("source = %q", entry.Source)
+	}
+	if entry.Version != "1.2.3" {
+		t.Fatalf("version = %q, want 1.2.3", entry.Version)
+	}
+	if len(entry.Archives) != 0 {
+		t.Fatalf("source-built git lock archives = %+v, want none", entry.Archives)
+	}
+
+	if err := os.RemoveAll(filepath.Join(artifactsDir, ".gestaltd", "providers", "alpha")); err != nil {
+		t.Fatalf("remove prepared provider: %v", err)
+	}
+	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePaths after removing prepared provider: %v", err)
+	}
+	preparedManifest := filepath.Join(artifactsDir, ".gestaltd", "providers", "alpha", "manifest.yaml")
+	if _, err := os.Stat(preparedManifest); err != nil {
+		t.Fatalf("prepared manifest not restored: %v", err)
+	}
+}
+
+func TestLifecycleGitSourceSnapshotRequireContract(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const (
+		ref           = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		gestaltRef    = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		packageSource = "github.com/acme/providers/plugins/alpha"
+		version       = "0.0.0-snapshot.gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+	archivePath := buildV2Archive(t, dir, packageSource, version, "snapshot-binary")
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSHA, err := providerpkg.ArchiveDigest(archivePath)
+	if err != nil {
+		t.Fatalf("archive digest: %v", err)
+	}
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/snapshots/github.com/acme/providers/" + ref + "/plugins/alpha/provider-release.yaml":
+			metadataCount.Add(1)
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   "alpha.tar.gz",
+						SHA256: archiveSHA,
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				t.Fatalf("marshal metadata: %v", err)
+			}
+			_, _ = w.Write(data)
+		case "/snapshots/github.com/acme/providers/" + ref + "/plugins/alpha/alpha.tar.gz":
+			archiveCount.Add(1)
+			_, _ = w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "artifacts")
+	configPath := filepath.Join(dir, "gestaltd.yaml")
+	configYAML := fmt.Sprintf(`
+apiVersion: gestaltd.config/v5
+providerSnapshotRepositories:
+  valon:
+    url: %s/snapshots
+    gestaltRef: %s
+%s
+server:
+  providers:
+    indexeddb: sqlite
+  artifactsDir: %s
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+plugins:
+  alpha:
+    source:
+      git:
+        repo: https://github.com/acme/providers.git
+        ref: %s
+        path: plugins/alpha/manifest.yaml
+        artifactRepository: valon
+        artifactMode: require
+`, srv.URL, gestaltRef, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "snapshot.db")), filepath.ToSlash(artifactsDir), ref)
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lock, err := NewLifecycle().WithHTTPClient(srv.Client()).LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	if err != nil {
+		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	}
+	entry := lock.Providers["alpha"]
+	if entry.SourceRef == nil {
+		t.Fatal("sourceRef missing")
+	}
+	if entry.SourceRef.ResolvedMode != gitResolvedModeSnapshot {
+		t.Fatalf("resolvedMode = %q, want %q", entry.SourceRef.ResolvedMode, gitResolvedModeSnapshot)
+	}
+	if entry.SourceRef.ResolvedGestaltRef != gestaltRef {
+		t.Fatalf("resolvedGestaltRef = %q, want %q", entry.SourceRef.ResolvedGestaltRef, gestaltRef)
+	}
+	if entry.Source != srv.URL+"/snapshots/github.com/acme/providers/"+ref+"/plugins/alpha/provider-release.yaml" {
+		t.Fatalf("source = %q", entry.Source)
+	}
+	if entry.Version != version {
+		t.Fatalf("version = %q, want %q", entry.Version, version)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata count = %d, want 1", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive count = %d, want 1", got)
+	}
+}
+
+func TestLifecycleGitSourceSnapshotRequirePrimesSecretsProvider(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const (
+		ref           = "cccccccccccccccccccccccccccccccccccccccc"
+		gestaltRef    = "dddddddddddddddddddddddddddddddddddddddd"
+		packageSource = "github.com/acme/providers/secrets/google"
+		version       = "0.0.0-snapshot.gcccccccccccccccccccccccccccccccccccccccc"
+	)
+	archivePath := buildV2ArchiveForKind(t, dir, providermanifestv1.KindSecrets, packageSource, version, artifactRelPath("secrets-provider"), "secrets-binary")
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSHA, err := providerpkg.ArchiveDigest(archivePath)
+	if err != nil {
+		t.Fatalf("archive digest: %v", err)
+	}
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/snapshots/github.com/acme/providers/" + ref + "/secrets/google/provider-release.yaml":
+			metadataCount.Add(1)
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindSecrets,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   "secrets.tar.gz",
+						SHA256: archiveSHA,
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				t.Fatalf("marshal metadata: %v", err)
+			}
+			_, _ = w.Write(data)
+		case "/snapshots/github.com/acme/providers/" + ref + "/secrets/google/secrets.tar.gz":
+			archiveCount.Add(1)
+			_, _ = w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "artifacts")
+	indexedDBManifestPath := writeStubIndexedDBManifest(t, dir)
+	configPath := filepath.Join(dir, "gestaltd.yaml")
+	configYAML := fmt.Sprintf(`
+apiVersion: gestaltd.config/v5
+providerSnapshotRepositories:
+  valon:
+    url: %s/snapshots
+    gestaltRef: %s
+server:
+  providers:
+    indexeddb: sqlite
+  artifactsDir: %s
+  encryptionKey:
+    secret:
+      provider: secrets
+      name: encryption-key
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: %s
+      config:
+        path: %q
+  secrets:
+    secrets:
+      source:
+        git:
+          repo: https://github.com/acme/providers.git
+          ref: %s
+          path: secrets/google/manifest.yaml
+          artifactRepository: valon
+          artifactMode: require
+`, srv.URL, gestaltRef, filepath.ToSlash(artifactsDir), filepath.ToSlash(indexedDBManifestPath), filepath.Join(dir, "secrets.db"), ref)
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lock, err := NewLifecycle().WithHTTPClient(srv.Client()).LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	if err != nil {
+		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	}
+	entry := lock.Secrets["secrets"]
+	if entry.SourceRef == nil {
+		t.Fatal("secrets sourceRef missing")
+	}
+	if entry.SourceRef.ResolvedMode != gitResolvedModeSnapshot {
+		t.Fatalf("secrets resolvedMode = %q, want %q", entry.SourceRef.ResolvedMode, gitResolvedModeSnapshot)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata count = %d, want 1", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive count = %d, want 1", got)
+	}
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -47,6 +341,61 @@ func sha256hex(data string) string {
 	return hex.EncodeToString(sum[:])
 }
 
+func writeSourceProviderTree(t *testing.T, dir, source, version, binaryContent string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create source provider dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "provider"), []byte(binaryContent), 0o755); err != nil {
+		t.Fatalf("write provider binary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "catalog.yaml"), []byte("name: alpha\noperations:\n  - id: ping\n    method: GET\n"), 0o644); err != nil {
+		t.Fatalf("write catalog: %v", err)
+	}
+	manifest := &providermanifestv1.Manifest{
+		Source:      source,
+		Version:     version,
+		Kind:        providermanifestv1.KindPlugin,
+		DisplayName: "Alpha",
+		Spec:        &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:     runtime.GOOS,
+			Arch:   runtime.GOARCH,
+			Path:   "provider",
+			SHA256: sha256hex(binaryContent),
+		}},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: "provider"},
+	}
+	data, err := providerpkg.EncodeSourceManifestFormat(manifest, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("encode manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func runGitTestCommand(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+}
+
+func runGitTestOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out)
+}
+
 func artifactRelPath(binary string) string {
 	return filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, binary))
 }
@@ -56,6 +405,45 @@ func buildV2Archive(t *testing.T, dir, source, version, binaryContent string) st
 
 	artPath := artifactRelPath("provider")
 	return buildV2ArchiveForArtifact(t, dir, source, version, artPath, "", binaryContent)
+}
+
+func buildV2ArchiveForKind(t *testing.T, dir, kind, source, version, artifactPath, binaryContent string) string {
+	t.Helper()
+
+	safeName := strings.NewReplacer("/", "-", ".", "_").Replace(kind + "-" + artifactPath + "-" + binaryContent)
+	srcDir := filepath.Join(dir, safeName+"-src")
+	if err := os.MkdirAll(filepath.Join(srcDir, filepath.Dir(filepath.FromSlash(artifactPath))), 0o755); err != nil {
+		t.Fatalf("create provider src dir: %v", err)
+	}
+	manifest := &providermanifestv1.Manifest{
+		Source:  source,
+		Version: version,
+		Kind:    kind,
+		Spec:    &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:     runtime.GOOS,
+			Arch:   runtime.GOARCH,
+			Path:   artifactPath,
+			SHA256: sha256hex(binaryContent),
+		}},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactPath},
+	}
+	manifestBytes, err := providerpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("encode manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "manifest.json"), manifestBytes, 0o644); err != nil {
+		t.Fatalf("write provider manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, filepath.FromSlash(artifactPath)), []byte(binaryContent), 0o755); err != nil {
+		t.Fatalf("write provider artifact: %v", err)
+	}
+
+	archivePath := filepath.Join(dir, safeName+".tar.gz")
+	if err := providerpkg.CreatePackageFromDir(srcDir, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir %s: %v", kind, err)
+	}
+	return archivePath
 }
 
 func buildV2ArchiveForArtifact(t *testing.T, dir, source, version, artifactPath, libc, binaryContent string) string {

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -2326,7 +2326,7 @@ func TestLockEntryForSource_RejectsManifestWithoutProviderKind(t *testing.T) {
 		Source: config.NewMetadataSource(srv.URL + "/providers/auth-only/v" + version + "/provider-release.yaml"),
 	}
 
-	_, err := lc.lockProviderEntryForSource(context.Background(), paths, "example", plugin, map[string]any{})
+	_, err := lc.lockProviderEntryForSource(context.Background(), nil, paths, "example", plugin, map[string]any{})
 	if err == nil {
 		t.Fatal("expected provider kind validation error")
 		return

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -10,17 +10,18 @@ import (
 )
 
 const (
-	providerLockSchemaName         = "gestaltd-provider-lock"
-	providerLockSchemaVersion      = 6
-	providerLockMinSchemaVersion   = 5
-	providerLockRevision           = 0
-	providerLockKindWorkflow       = "workflow"
-	providerLockKindTelemetry      = "telemetry"
-	providerLockKindAudit          = "audit"
-	providerLockRuntimeExecutable  = providerReleaseRuntimeExecutable
-	providerLockRuntimeDeclarative = providerReleaseRuntimeDeclarative
-	providerLockRuntimeUI          = providerReleaseRuntimeUI
-	providerLockRuntimeAssets      = providerLockRuntimeUI
+	providerLockSchemaName          = "gestaltd-provider-lock"
+	providerLockLegacySchemaVersion = 6
+	providerLockSchemaVersion       = 7
+	providerLockMinSchemaVersion    = 5
+	providerLockRevision            = 0
+	providerLockKindWorkflow        = "workflow"
+	providerLockKindTelemetry       = "telemetry"
+	providerLockKindAudit           = "audit"
+	providerLockRuntimeExecutable   = providerReleaseRuntimeExecutable
+	providerLockRuntimeDeclarative  = providerReleaseRuntimeDeclarative
+	providerLockRuntimeUI           = providerReleaseRuntimeUI
+	providerLockRuntimeAssets       = providerLockRuntimeUI
 )
 
 type providerLockfile struct {
@@ -53,6 +54,7 @@ type portableLockEntry struct {
 	Kind               string                       `json:"kind"`
 	Runtime            string                       `json:"runtime"`
 	Source             string                       `json:"source,omitempty"`
+	SourceRef          *LockSourceRef               `json:"sourceRef,omitempty"`
 	Version            string                       `json:"version,omitempty"`
 	Archives           map[string]LockArchive       `json:"archives,omitempty"`
 	Manifest           *providermanifestv1.Manifest `json:"manifest,omitempty"`
@@ -191,7 +193,7 @@ func providerLockfileFromLockfile(lock *Lockfile) *providerLockfile {
 	lock = normalizeLockfile(lock)
 	return &providerLockfile{
 		Schema:        providerLockSchemaName,
-		SchemaVersion: providerLockSchemaVersion,
+		SchemaVersion: providerLockSchemaVersionForLock(lock),
 		Revision:      providerLockRevision,
 		Providers: providerLockBuckets{
 			Plugin:              portableEntriesFromLockEntries(lock.Providers, providermanifestv1.KindPlugin),
@@ -265,6 +267,7 @@ func portableEntriesFromLockEntries(entries map[string]LockEntry, kind string) m
 			Kind:               lockEntryKind(entry, kind),
 			Runtime:            lockEntryRuntime(entry, kind),
 			Source:             source,
+			SourceRef:          cloneLockSourceRef(entry.SourceRef),
 			Version:            entry.Version,
 			Archives:           maps.Clone(entry.Archives),
 			Manifest:           entry.StaticManifest,
@@ -294,6 +297,7 @@ func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[st
 			Kind:                     providermanifestv1.NormalizeKind(entry.Kind),
 			Runtime:                  entry.Runtime,
 			Source:                   source,
+			SourceRef:                cloneLockSourceRef(entry.SourceRef),
 			Version:                  entry.Version,
 			Archives:                 maps.Clone(entry.Archives),
 			StaticManifest:           entry.Manifest,
@@ -304,4 +308,24 @@ func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[st
 		}
 	}
 	return runtimeEntries
+}
+
+func providerLockSchemaVersionForLock(lock *Lockfile) int {
+	for _, kind := range providerLockKinds() {
+		entries := lockEntriesForProviderKind(lock, kind)
+		for idx := range entries {
+			if entries[idx].SourceRef != nil {
+				return providerLockSchemaVersion
+			}
+		}
+	}
+	return providerLockLegacySchemaVersion
+}
+
+func cloneLockSourceRef(src *LockSourceRef) *LockSourceRef {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	return &cloned
 }


### PR DESCRIPTION
## Summary
- Add `providerSnapshotRepositories` and `source.git` provider sources with full-SHA refs, normalized manifest paths, and explicit `source`/`prefer`/`require` artifact modes.
- Persist git provenance in lock `sourceRef` while keeping `source` as the effective materialization URL or canonical synthetic git URL.
- Support snapshot resolution, source-build fallback, locked sync source rebuilds for source-backed entries, docs, and coverage for plugin and secrets providers.

## Test plan
- [x] `go test ./internal/operator -run 'TestLifecycleGitSource'`
- [x] `go test ./internal/config ./internal/operator`
- [x] `go test ./internal/daemon`
- [x] `golangci-lint run --path-prefix=gestaltd ./...`
