### PR TITLE
Pin provider-backed role checks to cached auth model

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -271,12 +271,38 @@ func (p *memoryAuthorizationProvider) ReadRelationships(_ context.Context, req *
 	}
 	out := make([]*core.Relationship, 0, len(p.relsByModel[modelID]))
 	for _, rel := range p.relsByModel[modelID] {
+		if !bootstrapRelationshipMatches(rel, req) {
+			continue
+		}
 		out = append(out, cloneRelationship(rel))
+		if req.GetPageSize() > 0 && int32(len(out)) >= req.GetPageSize() {
+			break
+		}
 	}
 	return &core.ReadRelationshipsResponse{
 		Relationships: out,
 		ModelId:       modelID,
 	}, nil
+}
+
+func bootstrapRelationshipMatches(rel *core.Relationship, req *core.ReadRelationshipsRequest) bool {
+	if rel == nil {
+		return false
+	}
+	if subject := req.GetSubject(); subject != nil {
+		if rel.GetSubject().GetType() != subject.GetType() || rel.GetSubject().GetId() != subject.GetId() {
+			return false
+		}
+	}
+	if relation := strings.TrimSpace(req.GetRelation()); relation != "" && rel.GetRelation() != relation {
+		return false
+	}
+	if resource := req.GetResource(); resource != nil {
+		if rel.GetResource().GetType() != resource.GetType() || rel.GetResource().GetId() != resource.GetId() {
+			return false
+		}
+	}
+	return true
 }
 
 func (p *memoryAuthorizationProvider) WriteRelationships(_ context.Context, req *core.WriteRelationshipsRequest) error {
@@ -9579,7 +9605,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
-	t.Run("authorization provider denies until reload heals active model drift", func(t *testing.T) {
+	t.Run("authorization provider uses cached model while active model drifts", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := validConfig()
@@ -9634,11 +9660,11 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			Kind:      principal.KindUser,
 		}
 		access, allowed := result.Authorizer.ResolveAccess(ctx, staticPrincipal, "calendar")
-		if allowed {
-			t.Fatal("expected access to be denied while the provider active model drifts")
+		if !allowed {
+			t.Fatal("expected access to use the cached model while the provider active model drifts")
 		}
-		if access.Role != "" {
-			t.Fatalf("role during active model drift = %q, want empty", access.Role)
+		if access.Role != "viewer" {
+			t.Fatalf("role during active model drift = %q, want %q", access.Role, "viewer")
 		}
 		if err := result.Authorizer.ReloadAuthorizationState(ctx); err != nil {
 			t.Fatalf("expected authorization state reload to heal active model drift: %v", err)

--- a/gestaltd/services/authorization/provider_backed.go
+++ b/gestaltd/services/authorization/provider_backed.go
@@ -13,8 +13,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
-	"github.com/valon-technologies/gestalt/server/services/observability"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 type providerBackedRoleState struct {
@@ -538,35 +536,22 @@ func (a *ProviderBackedAuthorizer) resolveRoleVariants(ctx context.Context, subj
 
 	resource := &core.ResourceRef{Type: resourceType, Id: resourceID}
 	for _, subject := range subjects {
-		reqs := make([]*core.AccessEvaluationRequest, 0, len(roles))
 		for _, role := range roles {
-			reqs = append(reqs, &core.AccessEvaluationRequest{
+			resp, err := a.provider.ReadRelationships(ctx, &core.ReadRelationshipsRequest{
 				Subject:  subject,
-				Action:   &core.ActionRef{Name: role},
+				Relation: role,
 				Resource: resource,
+				PageSize: 1,
+				ModelId:  expectedModelID,
 			})
-		}
-		startedAt := time.Now()
-		attrs := []attribute.KeyValue{
-			observability.AttrAuthorizationProvider.String(observability.AuthorizationProviderMetricName(a.provider)),
-			observability.AttrAuthorizationScope.String(resourceType),
-		}
-		evalCtx, span := observability.StartSpan(ctx, "authorization.provider.evaluate", attrs...)
-		resp, err := a.provider.EvaluateMany(evalCtx, &core.AccessEvaluationsRequest{Requests: reqs})
-		observability.EndSpan(span, err)
-		observability.RecordAuthorizationProviderEvaluate(evalCtx, startedAt, err != nil, attrs...)
-		if err != nil {
-			return "", false, err
-		}
-		for i, decision := range resp.GetDecisions() {
-			if i >= len(roles) {
-				break
+			if err != nil {
+				return "", false, err
 			}
-			if decisionModelID := strings.TrimSpace(decision.GetModelId()); expectedModelID != "" && decisionModelID != "" && decisionModelID != expectedModelID {
-				return "", false, fmt.Errorf("authorization provider active model changed: expected %q, got %q", expectedModelID, decisionModelID)
+			if respModelID := strings.TrimSpace(resp.GetModelId()); expectedModelID != "" && respModelID != "" && respModelID != expectedModelID {
+				return "", false, fmt.Errorf("authorization provider active model changed: expected %q, got %q", expectedModelID, respModelID)
 			}
-			if decision != nil && decision.GetAllowed() {
-				return roles[i], true, nil
+			if len(resp.GetRelationships()) > 0 {
+				return role, true, nil
 			}
 		}
 	}

--- a/gestaltd/services/authorization/provider_backed_test.go
+++ b/gestaltd/services/authorization/provider_backed_test.go
@@ -1,8 +1,11 @@
 package authorization
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 )
 
@@ -23,4 +26,245 @@ func TestExternalIdentityAssumptionSubjectRefsIncludesLegacyUserSubjectType(t *t
 	if refs[1].GetType() != subjectTypeUser || refs[1].GetId() != "user:user-123" {
 		t.Fatalf("subject ref[1] = %#v", refs[1])
 	}
+}
+
+func TestProviderBackedResolveAccessUsesModelPinnedRelationships(t *testing.T) {
+	t.Parallel()
+
+	provider := &providerBackedRoleContractProvider{
+		activeModelID: "model-b",
+		relationshipsByModelID: map[string][]*core.Relationship{
+			"model-a": {
+				providerBackedRoleTestRelationship("user:user-123", resourceTypePluginStatic, "slack", "editor"),
+				providerBackedRoleTestRelationship("user:user-123", resourceTypePluginStatic, "slack", "viewer"),
+			},
+		},
+	}
+	authorizer := newProviderBackedRoleTestAuthorizer(t, provider, []string{"admin", "editor", "viewer"}, "model-a")
+
+	access, allowed := authorizer.ResolveAccess(context.Background(), providerBackedRoleTestPrincipal(), "slack")
+	if !allowed {
+		t.Fatal("ResolveAccess denied, want allowed")
+	}
+	if access.Role != "editor" {
+		t.Fatalf("resolved role = %q, want editor", access.Role)
+	}
+	if provider.evaluateManyCalls != 0 {
+		t.Fatalf("EvaluateMany calls = %d, want 0", provider.evaluateManyCalls)
+	}
+	if len(provider.readRequests) != 2 {
+		t.Fatalf("ReadRelationships calls = %d, want 2", len(provider.readRequests))
+	}
+	first := provider.readRequests[0]
+	if got, want := first.GetSubject().GetType(), subjectTypeSubject; got != want {
+		t.Fatalf("first subject type = %q, want %q", got, want)
+	}
+	if got, want := first.GetSubject().GetId(), "user:user-123"; got != want {
+		t.Fatalf("first subject id = %q, want %q", got, want)
+	}
+	if got, want := first.GetResource().GetType(), resourceTypePluginStatic; got != want {
+		t.Fatalf("first resource type = %q, want %q", got, want)
+	}
+	if got, want := first.GetResource().GetId(), "slack"; got != want {
+		t.Fatalf("first resource id = %q, want %q", got, want)
+	}
+	if got, want := first.GetRelation(), "admin"; got != want {
+		t.Fatalf("first relation = %q, want %q", got, want)
+	}
+	if got, want := first.GetPageSize(), int32(1); got != want {
+		t.Fatalf("first page size = %d, want %d", got, want)
+	}
+	if got, want := first.GetModelId(), "model-a"; got != want {
+		t.Fatalf("first model id = %q, want %q", got, want)
+	}
+	if got, want := provider.readRequests[1].GetRelation(), "editor"; got != want {
+		t.Fatalf("second relation = %q, want %q", got, want)
+	}
+}
+
+func TestProviderBackedResolveAccessDeniesMissingCachedModelRelationship(t *testing.T) {
+	t.Parallel()
+
+	provider := &providerBackedRoleContractProvider{
+		activeModelID: "model-b",
+		relationshipsByModelID: map[string][]*core.Relationship{
+			"model-b": {
+				providerBackedRoleTestRelationship("user:user-123", resourceTypePluginStatic, "slack", "admin"),
+			},
+		},
+	}
+	authorizer := newProviderBackedRoleTestAuthorizer(t, provider, []string{"admin"}, "model-a")
+
+	_, allowed := authorizer.ResolveAccess(context.Background(), providerBackedRoleTestPrincipal(), "slack")
+	if allowed {
+		t.Fatal("ResolveAccess allowed relationship from active model, want denial against cached model")
+	}
+	if provider.evaluateManyCalls != 0 {
+		t.Fatalf("EvaluateMany calls = %d, want 0", provider.evaluateManyCalls)
+	}
+}
+
+func TestProviderBackedResolveAccessDeniesMismatchedReadRelationshipsModel(t *testing.T) {
+	t.Parallel()
+
+	provider := &providerBackedRoleContractProvider{
+		responseModelID: "model-b",
+		relationshipsByModelID: map[string][]*core.Relationship{
+			"model-a": {
+				providerBackedRoleTestRelationship("user:user-123", resourceTypePluginStatic, "slack", "admin"),
+			},
+		},
+	}
+	authorizer := newProviderBackedRoleTestAuthorizer(t, provider, []string{"admin"}, "model-a")
+
+	_, allowed := authorizer.ResolveAccess(context.Background(), providerBackedRoleTestPrincipal(), "slack")
+	if allowed {
+		t.Fatal("ResolveAccess allowed mismatched response model, want fail-closed denial")
+	}
+}
+
+func newProviderBackedRoleTestAuthorizer(t *testing.T, provider *providerBackedRoleContractProvider, roles []string, modelID string) *ProviderBackedAuthorizer {
+	t.Helper()
+
+	base, err := New(StaticConfig{
+		Policies: map[string]StaticSubjectPolicy{
+			"platform": {},
+		},
+		ProviderPolicies: map[string]string{
+			"slack": "platform",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New authorizer: %v", err)
+	}
+	authorizer, err := NewProviderBacked(base, provider)
+	if err != nil {
+		t.Fatalf("NewProviderBacked: %v", err)
+	}
+	authorizer.state = providerBackedRoleState{
+		modelID: modelID,
+		pluginStaticRoles: map[string][]string{
+			"slack": roles,
+		},
+		pluginDynamicRoles: map[string][]string{},
+		policyStaticRoles:  map[string][]string{},
+	}
+	return authorizer
+}
+
+func providerBackedRoleTestPrincipal() *principal.Principal {
+	return &principal.Principal{
+		UserID:    "user-123",
+		SubjectID: principal.UserSubjectID("user-123"),
+		Kind:      principal.KindUser,
+	}
+}
+
+func providerBackedRoleTestRelationship(subjectID, resourceType, resourceID, relation string) *core.Relationship {
+	return &core.Relationship{
+		Subject:  &core.SubjectRef{Type: subjectTypeSubject, Id: subjectID},
+		Relation: relation,
+		Resource: &core.ResourceRef{Type: resourceType, Id: resourceID},
+	}
+}
+
+type providerBackedRoleContractProvider struct {
+	activeModelID          string
+	responseModelID        string
+	relationshipsByModelID map[string][]*core.Relationship
+	readRequests           []*core.ReadRelationshipsRequest
+	evaluateManyCalls      int
+}
+
+func (p *providerBackedRoleContractProvider) Name() string { return "role-contract" }
+
+func (p *providerBackedRoleContractProvider) Evaluate(ctx context.Context, req *core.AccessEvaluationRequest) (*core.AccessDecision, error) {
+	resp, err := p.EvaluateMany(ctx, &core.AccessEvaluationsRequest{Requests: []*core.AccessEvaluationRequest{req}})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.GetDecisions()) == 0 {
+		return &core.AccessDecision{}, nil
+	}
+	return resp.GetDecisions()[0], nil
+}
+
+func (p *providerBackedRoleContractProvider) EvaluateMany(context.Context, *core.AccessEvaluationsRequest) (*core.AccessEvaluationsResponse, error) {
+	p.evaluateManyCalls++
+	return &core.AccessEvaluationsResponse{}, nil
+}
+
+func (p *providerBackedRoleContractProvider) SearchResources(context.Context, *core.ResourceSearchRequest) (*core.ResourceSearchResponse, error) {
+	return nil, errors.New("SearchResources not implemented")
+}
+
+func (p *providerBackedRoleContractProvider) SearchSubjects(context.Context, *core.SubjectSearchRequest) (*core.SubjectSearchResponse, error) {
+	return nil, errors.New("SearchSubjects not implemented")
+}
+
+func (p *providerBackedRoleContractProvider) SearchActions(context.Context, *core.ActionSearchRequest) (*core.ActionSearchResponse, error) {
+	return nil, errors.New("SearchActions not implemented")
+}
+
+func (p *providerBackedRoleContractProvider) GetMetadata(context.Context) (*core.AuthorizationMetadata, error) {
+	return &core.AuthorizationMetadata{}, nil
+}
+
+func (p *providerBackedRoleContractProvider) ReadRelationships(_ context.Context, req *core.ReadRelationshipsRequest) (*core.ReadRelationshipsResponse, error) {
+	p.readRequests = append(p.readRequests, req)
+	modelID := req.GetModelId()
+	if modelID == "" {
+		modelID = p.activeModelID
+	}
+	respModelID := modelID
+	if p.responseModelID != "" {
+		respModelID = p.responseModelID
+	}
+	out := make([]*core.Relationship, 0)
+	for _, rel := range p.relationshipsByModelID[modelID] {
+		if !providerBackedRoleRelationshipMatches(rel, req) {
+			continue
+		}
+		out = append(out, rel)
+		if req.GetPageSize() > 0 && int32(len(out)) >= req.GetPageSize() {
+			break
+		}
+	}
+	return &core.ReadRelationshipsResponse{Relationships: out, ModelId: respModelID}, nil
+}
+
+func (p *providerBackedRoleContractProvider) WriteRelationships(context.Context, *core.WriteRelationshipsRequest) error {
+	return errors.New("WriteRelationships not implemented")
+}
+
+func (p *providerBackedRoleContractProvider) GetActiveModel(context.Context) (*core.GetActiveModelResponse, error) {
+	return &core.GetActiveModelResponse{Model: &core.AuthorizationModelRef{Id: p.activeModelID}}, nil
+}
+
+func (p *providerBackedRoleContractProvider) ListModels(context.Context, *core.ListModelsRequest) (*core.ListModelsResponse, error) {
+	return &core.ListModelsResponse{}, nil
+}
+
+func (p *providerBackedRoleContractProvider) WriteModel(context.Context, *core.WriteModelRequest) (*core.AuthorizationModelRef, error) {
+	return nil, errors.New("WriteModel not implemented")
+}
+
+func providerBackedRoleRelationshipMatches(rel *core.Relationship, req *core.ReadRelationshipsRequest) bool {
+	if rel == nil {
+		return false
+	}
+	if subject := req.GetSubject(); subject != nil {
+		if rel.GetSubject().GetType() != subject.GetType() || rel.GetSubject().GetId() != subject.GetId() {
+			return false
+		}
+	}
+	if resource := req.GetResource(); resource != nil {
+		if rel.GetResource().GetType() != resource.GetType() || rel.GetResource().GetId() != resource.GetId() {
+			return false
+		}
+	}
+	if relation := req.GetRelation(); relation != "" && rel.GetRelation() != relation {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
## Summary

Use the existing model-pinned `ReadRelationships` authorization primitive for provider-backed runtime role resolution. This avoids failing service-account/plugin authorization when the provider's active model advances after gestaltd has cached a managed authorization model.

## Interface Changes
- New/changed interface: no wire API change. `ProviderBackedAuthorizer.resolveRoleVariants` now reads role relationships with `ReadRelationshipsRequest.ModelId` instead of evaluating role actions through `EvaluateMany`.
- Example usage:

```go
resp, err := provider.ReadRelationships(ctx, &core.ReadRelationshipsRequest{
    Subject:  subject,
    Resource: resource,
    Relation: role,
    PageSize: 1,
    ModelId:  expectedModelID,
})
```

## Functional/Integration Tests
- Tests added or augmented: provider-backed authorization contract coverage for model-pinned role reads, role precedence/early stop, missing cached-model relationship denial, and non-empty response model mismatch fail-closed behavior.
- Contract boundary covered: `RuntimeAuthorizer.ResolveAccess` through the `core.AuthorizationProvider.ReadRelationships` contract.
- Commands run:

```bash
(cd gestaltd && go test ./services/authorization)
```

## Follow-ups
- Pair with the Slack provider hardening PR in `valon-technologies/gestalt-providers`; this PR is the primary fix for the Datadog alert authorization failure.