### PR TITLE
Add Go protobuf boundary helpers

### DIFF
--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -75,6 +75,10 @@
 // update existing generated messages in place. StructFromMap, StructFromAny,
 // ValueFromAny, ValuesFromMap, TimestampFromTime, TimestampFromTimePtr, and the
 // IndexedDB codec helpers remain available for lower-level interop and tests.
+// Empty, Struct, Value, Timestamp, ProtoMessage, MarshalProtoDeterministic,
+// UnmarshalProto, MarshalProtoJSON, and UnmarshalProtoJSON are thin aliases or
+// wrappers for RPC and persistence boundaries that still need protocol-shaped
+// values.
 // StructFromAny accepts structs, string-keyed map aliases, and pointers to
 // either form; it rejects time.Time,
 // json.Marshaler values, non-string map keys, cycles, and non-finite numbers in

--- a/sdk/go/protocol_helpers.go
+++ b/sdk/go/protocol_helpers.go
@@ -8,15 +8,81 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/encoding/protojson"
 	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// ProtoMessage is the common interface implemented by generated protobuf messages.
+type ProtoMessage = gproto.Message
+
+// Empty aliases google.protobuf.Empty for provider RPC boundary methods.
+type Empty = emptypb.Empty
+
+// Struct aliases google.protobuf.Struct for low-level protocol interop.
+type Struct = structpb.Struct
+
+// Value aliases google.protobuf.Value for low-level protocol interop.
+type Value = structpb.Value
+
+// Timestamp aliases google.protobuf.Timestamp for low-level protocol interop.
+type Timestamp = timestamppb.Timestamp
+
+// ProtoJSONMarshalOptions configures MarshalProtoJSON.
+type ProtoJSONMarshalOptions struct {
+	UseProtoNames     bool
+	EmitUnpopulated   bool
+	EmitDefaultValues bool
+}
+
+// ProtoJSONUnmarshalOptions configures UnmarshalProtoJSON.
+type ProtoJSONUnmarshalOptions struct {
+	DiscardUnknown bool
+}
 
 var (
 	jsonMarshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
 	timeType          = reflect.TypeOf(time.Time{})
 )
+
+// MarshalProtoDeterministic serializes a protobuf message with deterministic
+// map ordering. It is intended for hashes, persistence keys, and wire payloads
+// that must remain stable across process runs.
+func MarshalProtoDeterministic(msg ProtoMessage) ([]byte, error) {
+	if msg == nil {
+		return nil, nil
+	}
+	return gproto.MarshalOptions{Deterministic: true}.Marshal(msg)
+}
+
+// UnmarshalProto parses protobuf binary wire data into msg.
+func UnmarshalProto(data []byte, msg ProtoMessage) error {
+	return gproto.Unmarshal(data, msg)
+}
+
+// MarshalProtoJSON serializes a protobuf message using protojson.
+func MarshalProtoJSON(msg ProtoMessage, options ...ProtoJSONMarshalOptions) ([]byte, error) {
+	var opt ProtoJSONMarshalOptions
+	if len(options) > 0 {
+		opt = options[0]
+	}
+	return (protojson.MarshalOptions{
+		UseProtoNames:     opt.UseProtoNames,
+		EmitUnpopulated:   opt.EmitUnpopulated,
+		EmitDefaultValues: opt.EmitDefaultValues,
+	}).Marshal(msg)
+}
+
+// UnmarshalProtoJSON parses protojson data into msg.
+func UnmarshalProtoJSON(data []byte, msg ProtoMessage, options ...ProtoJSONUnmarshalOptions) error {
+	var opt ProtoJSONUnmarshalOptions
+	if len(options) > 0 {
+		opt = options[0]
+	}
+	return (protojson.UnmarshalOptions{DiscardUnknown: opt.DiscardUnknown}).Unmarshal(data, msg)
+}
 
 // StructFromMap converts a Go map into a protobuf Struct.
 func StructFromMap(value map[string]any) (*structpb.Struct, error) {

--- a/sdk/go/protocol_helpers_test.go
+++ b/sdk/go/protocol_helpers_test.go
@@ -1,0 +1,47 @@
+package gestalt
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestProtoBoundaryHelpers(t *testing.T) {
+	var _ ProtoMessage = (*Empty)(nil)
+
+	msg, err := StructFromAny(map[string]any{"ok": true, "count": 2})
+	if err != nil {
+		t.Fatalf("StructFromAny: %v", err)
+	}
+
+	first, err := MarshalProtoDeterministic(msg)
+	if err != nil {
+		t.Fatalf("MarshalProtoDeterministic: %v", err)
+	}
+	second, err := MarshalProtoDeterministic(msg)
+	if err != nil {
+		t.Fatalf("MarshalProtoDeterministic second: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("MarshalProtoDeterministic returned unstable bytes")
+	}
+
+	var decoded Struct
+	if err := UnmarshalProto(first, &decoded); err != nil {
+		t.Fatalf("UnmarshalProto: %v", err)
+	}
+	if got := MapFromStruct(&decoded); got["ok"] != true || got["count"] != float64(2) {
+		t.Fatalf("decoded = %#v", got)
+	}
+
+	jsonData, err := MarshalProtoJSON(msg, ProtoJSONMarshalOptions{UseProtoNames: true})
+	if err != nil {
+		t.Fatalf("MarshalProtoJSON: %v", err)
+	}
+	var fromJSON Struct
+	if err := UnmarshalProtoJSON(jsonData, &fromJSON); err != nil {
+		t.Fatalf("UnmarshalProtoJSON: %v", err)
+	}
+	if got := MapFromStruct(&fromJSON); got["ok"] != true || got["count"] != float64(2) {
+		t.Fatalf("fromJSON = %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go SDK aliases for protobuf boundary types: `Empty`, `Struct`, `Value`, `Timestamp`, and `ProtoMessage`
- add deterministic binary marshal/unmarshal and protojson marshal/unmarshal helpers
- document these as low-level RPC/persistence boundary APIs

## Tests
- `go test ./...` in `sdk/go`
- `git diff --check`

## Follow-up
This enables the next gestalt-providers cleanup pass to replace remaining direct Go `google.golang.org/protobuf` imports that are only used for Empty RPC signatures, timestamp type annotations, deterministic proto persistence, and protojson persistence.