### PR TITLE
Add Zanzibar agent session product semantics

### DIFF
--- a/gestaltd/internal/server/handlers_admin_authorization_provider.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider.go
@@ -213,7 +213,8 @@ func (s *Server) adminAuthorizationRowsFromProviderRelationships(ctx context.Con
 }
 
 func (s *Server) adminAuthorizationDynamicRowFromProviderRelationship(ctx context.Context, plugin string, rel *core.Relationship) (adminAuthorizationMemberRow, bool, error) {
-	if rel == nil || rel.GetSubject() == nil {
+	subject := authorization.RelationshipSubject(rel)
+	if subject == nil {
 		return adminAuthorizationMemberRow{}, false, nil
 	}
 
@@ -228,9 +229,9 @@ func (s *Server) adminAuthorizationDynamicRowFromProviderRelationship(ctx contex
 		return adminAuthorizationMemberRow{}, false, nil
 	}
 
-	switch strings.TrimSpace(rel.GetSubject().GetType()) {
+	switch strings.TrimSpace(subject.GetType()) {
 	case authorization.ProviderSubjectTypeSubject:
-		subjectID := strings.TrimSpace(rel.GetSubject().GetId())
+		subjectID := strings.TrimSpace(subject.GetId())
 		if !adminAuthorizationValidSubjectID(subjectID) {
 			return adminAuthorizationMemberRow{}, false, nil
 		}
@@ -263,6 +264,7 @@ func (s *Server) readAllAuthorizationRelationships(ctx context.Context, req *cor
 			PageSize:  pageSize,
 			PageToken: pageToken,
 			ModelId:   req.GetModelId(),
+			Target:    req.GetTarget(),
 		})
 		if err != nil {
 			return nil, err

--- a/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/services/authorization"
 )
@@ -282,11 +283,12 @@ func (s *Server) providerDynamicRelationshipsForSubject(ctx context.Context, res
 }
 
 func (s *Server) providerRelationshipMatchesSubject(_ context.Context, rel *core.Relationship, subjectID string) (bool, error) {
-	if rel == nil || rel.GetSubject() == nil {
+	subject := authorization.RelationshipSubject(rel)
+	if subject == nil {
 		return false, nil
 	}
-	subjectType := strings.TrimSpace(rel.GetSubject().GetType())
-	relationshipSubjectID := strings.TrimSpace(rel.GetSubject().GetId())
+	subjectType := strings.TrimSpace(subject.GetType())
+	relationshipSubjectID := strings.TrimSpace(subject.GetId())
 	switch subjectType {
 	case authorization.ProviderSubjectTypeSubject:
 		return subjectID != "" && relationshipSubjectID == subjectID, nil
@@ -343,6 +345,7 @@ func relationshipKeys(rels []*core.Relationship) []*core.RelationshipKey {
 			Subject:  cloneSubjectRef(rel.GetSubject()),
 			Relation: rel.GetRelation(),
 			Resource: cloneResourceRef(rel.GetResource()),
+			Target:   cloneRelationshipTarget(rel.GetTarget(), rel.GetSubject()),
 		})
 	}
 	return keys
@@ -368,18 +371,18 @@ func filterRelationshipKeys(rels []*core.Relationship, keep []*core.Relationship
 			Subject:  cloneSubjectRef(rel.GetSubject()),
 			Relation: rel.GetRelation(),
 			Resource: cloneResourceRef(rel.GetResource()),
+			Target:   cloneRelationshipTarget(rel.GetTarget(), rel.GetSubject()),
 		})
 	}
 	return keys
 }
 
 func providerRelationshipKey(rel *core.Relationship) string {
-	if rel == nil || rel.GetSubject() == nil || rel.GetResource() == nil {
+	if rel == nil || rel.GetResource() == nil {
 		return ""
 	}
 	return strings.Join([]string{
-		strings.TrimSpace(rel.GetSubject().GetType()),
-		strings.TrimSpace(rel.GetSubject().GetId()),
+		authorization.RelationshipTargetMapKey(rel.GetTarget(), rel.GetSubject()),
 		strings.TrimSpace(rel.GetRelation()),
 		strings.TrimSpace(rel.GetResource().GetType()),
 		strings.TrimSpace(rel.GetResource().GetId()),
@@ -399,6 +402,7 @@ func cloneRelationships(rels []*core.Relationship) []*core.Relationship {
 			Subject:  cloneSubjectRef(rel.GetSubject()),
 			Relation: rel.GetRelation(),
 			Resource: cloneResourceRef(rel.GetResource()),
+			Target:   cloneRelationshipTarget(rel.GetTarget(), rel.GetSubject()),
 		})
 	}
 	return out
@@ -421,5 +425,34 @@ func cloneResourceRef(resource *core.ResourceRef) *core.ResourceRef {
 	return &core.ResourceRef{
 		Type: resource.GetType(),
 		Id:   resource.GetId(),
+	}
+}
+
+func cloneRelationshipTarget(target *core.RelationshipTargetRef, subject *core.SubjectRef) *core.RelationshipTargetRef {
+	if target != nil {
+		if targetSubject := target.GetSubject(); targetSubject != nil {
+			return &core.RelationshipTargetRef{
+				Kind: &proto.RelationshipTarget_Subject{Subject: cloneSubjectRef(targetSubject)},
+			}
+		}
+		if targetResource := target.GetResource(); targetResource != nil {
+			return &core.RelationshipTargetRef{
+				Kind: &proto.RelationshipTarget_Resource{Resource: cloneResourceRef(targetResource)},
+			}
+		}
+		if targetSet := target.GetSubjectSet(); targetSet != nil {
+			return &core.RelationshipTargetRef{
+				Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &core.SubjectSetRef{
+					Resource: cloneResourceRef(targetSet.GetResource()),
+					Relation: targetSet.GetRelation(),
+				}},
+			}
+		}
+	}
+	if subject == nil {
+		return nil
+	}
+	return &core.RelationshipTargetRef{
+		Kind: &proto.RelationshipTarget_Subject{Subject: cloneSubjectRef(subject)},
 	}
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2103,15 +2103,15 @@ func (p *memoryAuthorizationProvider) WriteRelationships(_ context.Context, req 
 	if p.validateModel {
 		for _, rel := range req.GetWrites() {
 			if !memoryAuthorizationModelAllowsRelationship(p.modelDefs[modelID], rel) {
-				return fmt.Errorf("model %q does not allow relationship %s", modelID, memoryAuthorizationRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource()))
+				return fmt.Errorf("model %q does not allow relationship %s", modelID, memoryAuthorizationRelationshipKeyForRelationship(rel))
 			}
 		}
 	}
 	for _, key := range req.GetDeletes() {
-		delete(rels, memoryAuthorizationRelationshipKey(key.GetSubject(), key.GetRelation(), key.GetResource()))
+		delete(rels, memoryAuthorizationRelationshipKeyForKey(key))
 	}
 	for _, rel := range req.GetWrites() {
-		rels[memoryAuthorizationRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource())] = cloneMemoryAuthorizationRelationship(rel)
+		rels[memoryAuthorizationRelationshipKeyForRelationship(rel)] = cloneMemoryAuthorizationRelationship(rel)
 	}
 	return nil
 }
@@ -2194,10 +2194,11 @@ func memoryAuthorizationModelAllowsRelationship(model *core.AuthorizationModel, 
 }
 
 func memoryAuthorizationRelationshipGrantsAction(model *core.AuthorizationModel, rel *core.Relationship, subject *core.SubjectRef, action string, resource *core.ResourceRef) bool {
-	if rel == nil || rel.GetSubject() == nil || rel.GetResource() == nil || resource == nil {
+	targetSubject := memoryAuthorizationRelationshipSubject(rel)
+	if rel == nil || targetSubject == nil || rel.GetResource() == nil || resource == nil {
 		return false
 	}
-	if subject != nil && (rel.GetSubject().GetType() != subject.GetType() || rel.GetSubject().GetId() != subject.GetId()) {
+	if subject != nil && (targetSubject.GetType() != subject.GetType() || targetSubject.GetId() != subject.GetId()) {
 		return false
 	}
 	if rel.GetResource().GetType() != resource.GetType() || rel.GetResource().GetId() != resource.GetId() {
@@ -2233,7 +2234,12 @@ func memoryAuthorizationRelationshipMatches(rel *core.Relationship, req *core.Re
 		return rel != nil
 	}
 	if subject := req.GetSubject(); subject != nil {
-		if got := rel.GetSubject(); got == nil || got.GetType() != subject.GetType() || got.GetId() != subject.GetId() {
+		if got := memoryAuthorizationRelationshipSubject(rel); got == nil || got.GetType() != subject.GetType() || got.GetId() != subject.GetId() {
+			return false
+		}
+	}
+	if target := req.GetTarget(); target != nil {
+		if memoryAuthorizationRelationshipTargetKey(rel.GetTarget(), rel.GetSubject()) != memoryAuthorizationRelationshipTargetKey(target, nil) {
 			return false
 		}
 	}
@@ -2248,14 +2254,35 @@ func memoryAuthorizationRelationshipMatches(rel *core.Relationship, req *core.Re
 	return true
 }
 
-func memoryAuthorizationRelationshipKey(subject *core.SubjectRef, relation string, resource *core.ResourceRef) string {
+func memoryAuthorizationRelationshipKeyForRelationship(rel *core.Relationship) string {
+	if rel == nil {
+		return ""
+	}
+	return memoryAuthorizationRelationshipKey(rel.GetTarget(), rel.GetSubject(), rel.GetRelation(), rel.GetResource())
+}
+
+func memoryAuthorizationRelationshipKeyForKey(key *core.RelationshipKey) string {
+	if key == nil {
+		return ""
+	}
+	return memoryAuthorizationRelationshipKey(key.GetTarget(), key.GetSubject(), key.GetRelation(), key.GetResource())
+}
+
+func memoryAuthorizationRelationshipKey(target *core.RelationshipTargetRef, subject *core.SubjectRef, relation string, resource *core.ResourceRef) string {
 	return strings.Join([]string{
-		subject.GetType(),
-		subject.GetId(),
+		memoryAuthorizationRelationshipTargetKey(target, subject),
 		relation,
 		resource.GetType(),
 		resource.GetId(),
 	}, "\x00")
+}
+
+func memoryAuthorizationRelationshipTargetKey(target *core.RelationshipTargetRef, subject *core.SubjectRef) string {
+	return authorization.RelationshipTargetMapKey(target, subject)
+}
+
+func memoryAuthorizationRelationshipSubject(rel *core.Relationship) *core.SubjectRef {
+	return authorization.RelationshipSubject(rel)
 }
 
 func cloneMemoryAuthorizationRelationship(rel *core.Relationship) *core.Relationship {
@@ -2263,16 +2290,49 @@ func cloneMemoryAuthorizationRelationship(rel *core.Relationship) *core.Relation
 		return nil
 	}
 	return &core.Relationship{
-		Subject: &core.SubjectRef{
-			Type: rel.GetSubject().GetType(),
-			Id:   rel.GetSubject().GetId(),
-		},
+		Subject:  cloneMemoryAuthorizationSubject(rel.GetSubject()),
 		Relation: rel.GetRelation(),
 		Resource: &core.ResourceRef{
 			Type: rel.GetResource().GetType(),
 			Id:   rel.GetResource().GetId(),
 		},
+		Target: cloneMemoryAuthorizationTarget(rel.GetTarget(), rel.GetSubject()),
 	}
+}
+
+func cloneMemoryAuthorizationSubject(subject *core.SubjectRef) *core.SubjectRef {
+	if subject == nil {
+		return nil
+	}
+	return &core.SubjectRef{Type: subject.GetType(), Id: subject.GetId()}
+}
+
+func cloneMemoryAuthorizationResource(resource *core.ResourceRef) *core.ResourceRef {
+	if resource == nil {
+		return nil
+	}
+	return &core.ResourceRef{Type: resource.GetType(), Id: resource.GetId()}
+}
+
+func cloneMemoryAuthorizationTarget(target *core.RelationshipTargetRef, subject *core.SubjectRef) *core.RelationshipTargetRef {
+	if target != nil {
+		if targetSubject := target.GetSubject(); targetSubject != nil {
+			return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Subject{Subject: cloneMemoryAuthorizationSubject(targetSubject)}}
+		}
+		if targetResource := target.GetResource(); targetResource != nil {
+			return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Resource{Resource: cloneMemoryAuthorizationResource(targetResource)}}
+		}
+		if targetSet := target.GetSubjectSet(); targetSet != nil {
+			return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &core.SubjectSetRef{
+				Resource: cloneMemoryAuthorizationResource(targetSet.GetResource()),
+				Relation: targetSet.GetRelation(),
+			}}}
+		}
+	}
+	if subject == nil {
+		return nil
+	}
+	return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Subject{Subject: cloneMemoryAuthorizationSubject(subject)}}
 }
 
 func (p *memoryAuthorizationProvider) putRelationship(modelID string, rel *core.Relationship) {
@@ -2281,7 +2341,7 @@ func (p *memoryAuthorizationProvider) putRelationship(modelID string, rel *core.
 	if p.relsByModel[modelID] == nil {
 		p.relsByModel[modelID] = map[string]*core.Relationship{}
 	}
-	p.relsByModel[modelID][memoryAuthorizationRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource())] = cloneMemoryAuthorizationRelationship(rel)
+	p.relsByModel[modelID][memoryAuthorizationRelationshipKeyForRelationship(rel)] = cloneMemoryAuthorizationRelationship(rel)
 }
 
 func newVirtualHostClient(t *testing.T, hostAddrs map[string]string) *http.Client {
@@ -2553,6 +2613,49 @@ func mustProviderBackedAuthorizer(t *testing.T, base *authorization.Authorizer, 
 	return authz
 }
 
+func TestMemoryAuthorizationProviderDoesNotGrantMixedSubjectAndSubjectSetTarget(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	provider.activeModelID = "model"
+	invalidMixedGrant := &core.Relationship{
+		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: "user:invalid"},
+		Relation: authorization.ProviderAgentSessionActionView,
+		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAgentSession, Id: "agent-session-1"},
+		Target: &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &core.SubjectSetRef{
+			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeSlackChannel, Id: "T999:C999"},
+			Relation: authorization.ProviderRelationMember,
+		}}},
+	}
+	if err := provider.WriteRelationships(context.Background(), &core.WriteRelationshipsRequest{Writes: []*core.Relationship{invalidMixedGrant}}); err != nil {
+		t.Fatalf("WriteRelationships: %v", err)
+	}
+
+	decision, err := provider.Evaluate(context.Background(), &core.AccessEvaluationRequest{
+		Subject:  invalidMixedGrant.Subject,
+		Action:   &core.ActionRef{Name: invalidMixedGrant.Relation},
+		Resource: invalidMixedGrant.Resource,
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision.GetAllowed() {
+		t.Fatal("Evaluate allowed invalid mixed subject/subject-set relationship, want denied")
+	}
+
+	resp, err := provider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
+		Subject:  invalidMixedGrant.Subject,
+		Relation: invalidMixedGrant.Relation,
+		Resource: invalidMixedGrant.Resource,
+	})
+	if err != nil {
+		t.Fatalf("ReadRelationships(subject): %v", err)
+	}
+	if len(resp.GetRelationships()) != 0 {
+		t.Fatalf("ReadRelationships(subject) = %+v, want no direct-subject match", resp.GetRelationships())
+	}
+}
+
 func TestAuthorizationProviderBackedReloadPreservesAgentSessionGrants(t *testing.T) {
 	t.Parallel()
 
@@ -2568,27 +2671,82 @@ func TestAuthorizationProviderBackedReloadPreservesAgentSessionGrants(t *testing
 		t.Fatalf("authorization.New: %v", err)
 	}
 	authz := mustProviderBackedAuthorizer(t, baseAuthz, provider)
-	grant := &core.Relationship{
+	editorGrant := &core.Relationship{
 		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: "user:shared"},
 		Relation: authorization.ProviderAgentSessionRelationEditor,
 		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAgentSession, Id: "agent-session-1"},
 	}
-	if err := provider.WriteRelationships(context.Background(), &core.WriteRelationshipsRequest{Writes: []*core.Relationship{grant}}); err != nil {
+	channelGrant := &core.Relationship{
+		Relation: authorization.ProviderAgentSessionRelationViewer,
+		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAgentSession, Id: "agent-session-1"},
+		Target: &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &core.SubjectSetRef{
+			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeSlackChannel, Id: "T123:C456"},
+			Relation: authorization.ProviderRelationMember,
+		}}},
+	}
+	parentGrant := &core.Relationship{
+		Relation: authorization.ProviderAgentSessionRelationParent,
+		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAgentSession, Id: "agent-session-child"},
+		Target:   &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Resource{Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAgentSession, Id: "agent-session-1"}}},
+	}
+	invalidMixedGrant := &core.Relationship{
+		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: "user:invalid"},
+		Relation: authorization.ProviderAgentSessionRelationViewer,
+		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAgentSession, Id: "agent-session-1"},
+		Target: &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &core.SubjectSetRef{
+			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeSlackChannel, Id: "T999:C999"},
+			Relation: authorization.ProviderRelationMember,
+		}}},
+	}
+	if err := provider.WriteRelationships(context.Background(), &core.WriteRelationshipsRequest{Writes: []*core.Relationship{editorGrant, channelGrant, parentGrant, invalidMixedGrant}}); err != nil {
 		t.Fatalf("WriteRelationships: %v", err)
 	}
 	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
 		t.Fatalf("ReloadAuthorizationState: %v", err)
 	}
 	resp, err := provider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
-		Subject:  grant.Subject,
-		Relation: grant.Relation,
-		Resource: grant.Resource,
+		Subject:  editorGrant.Subject,
+		Relation: editorGrant.Relation,
+		Resource: editorGrant.Resource,
 	})
 	if err != nil {
 		t.Fatalf("ReadRelationships: %v", err)
 	}
 	if len(resp.GetRelationships()) != 1 {
 		t.Fatalf("agent session grants after reload = %+v, want preserved editor grant", resp.GetRelationships())
+	}
+	resp, err = provider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
+		Target:   channelGrant.Target,
+		Relation: channelGrant.Relation,
+		Resource: channelGrant.Resource,
+	})
+	if err != nil {
+		t.Fatalf("ReadRelationships channel grant: %v", err)
+	}
+	if len(resp.GetRelationships()) != 1 {
+		t.Fatalf("agent session channel grants after reload = %+v, want preserved subject-set grant", resp.GetRelationships())
+	}
+	resp, err = provider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
+		Target:   parentGrant.Target,
+		Relation: parentGrant.Relation,
+		Resource: parentGrant.Resource,
+	})
+	if err != nil {
+		t.Fatalf("ReadRelationships parent grant: %v", err)
+	}
+	if len(resp.GetRelationships()) != 1 {
+		t.Fatalf("agent session parent grants after reload = %+v, want preserved resource-target grant", resp.GetRelationships())
+	}
+	resp, err = provider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
+		Target:   invalidMixedGrant.Target,
+		Relation: invalidMixedGrant.Relation,
+		Resource: invalidMixedGrant.Resource,
+	})
+	if err != nil {
+		t.Fatalf("ReadRelationships invalid mixed grant: %v", err)
+	}
+	if len(resp.GetRelationships()) != 0 {
+		t.Fatalf("invalid mixed subject/target grant after reload = %+v, want removed", resp.GetRelationships())
 	}
 }
 
@@ -5818,8 +5976,9 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
 		t.Fatalf("ReloadAuthorizationState after provider-backed plugin write: %v", err)
 	}
+	rawSubjectID := principal.UserSubjectID("raw-subject")
 	provider.putRelationship(provider.activeModelID, &core.Relationship{
-		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: "raw-subject"},
+		Target:   &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_Subject{Subject: &core.SubjectRef{Type: authorization.ProviderSubjectTypeSubject, Id: rawSubjectID}}},
 		Relation: "viewer",
 		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypePluginDynamic, Id: "sample_plugin"},
 	})
@@ -5839,8 +5998,18 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
 		t.Fatalf("decoding members: %v", err)
 	}
-	if len(members) != 2 {
+	if len(members) != 3 {
 		t.Fatalf("expected provider-backed merged members, got %d (%+v)", len(members), members)
+	}
+	foundRawSubject := false
+	for _, member := range members {
+		if member["selectorValue"] == rawSubjectID {
+			foundRawSubject = true
+			break
+		}
+	}
+	if !foundRawSubject {
+		t.Fatalf("members = %+v, want target-only direct subject %q", members, rawSubjectID)
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/provider", nil)

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -827,7 +827,7 @@ func (m *Manager) listSharedAgentSessions(ctx context.Context, p *principal.Prin
 	out := make([]*coreagent.Session, 0)
 	seen := map[string]struct{}{}
 	for {
-		resp, err := m.authorizationProvider.SearchResources(ctx, &core.ResourceSearchRequest{
+		resp, err := m.searchSharedAgentSessionResources(ctx, &core.ResourceSearchRequest{
 			Subject: &core.SubjectRef{
 				Type: authorization.ProviderSubjectTypeSubject,
 				Id:   subjectID,
@@ -870,6 +870,22 @@ func (m *Manager) listSharedAgentSessions(ctx context.Context, p *principal.Prin
 			return out
 		}
 	}
+}
+
+func (m *Manager) searchSharedAgentSessionResources(ctx context.Context, req *core.ResourceSearchRequest) (*core.ResourceSearchResponse, error) {
+	if m == nil || m.authorizationProvider == nil {
+		return &core.ResourceSearchResponse{}, nil
+	}
+	if effective, ok := m.authorizationProvider.(core.AuthorizationProviderEffectiveSearch); ok {
+		resp, err := effective.EffectiveSearchResources(ctx, req)
+		if err == nil {
+			return resp, nil
+		}
+		if status.Code(err) != codes.Unimplemented {
+			return nil, err
+		}
+	}
+	return m.authorizationProvider.SearchResources(ctx, req)
 }
 
 func (m *Manager) UpdateSession(ctx context.Context, p *principal.Principal, req coreagent.ManagerUpdateSessionRequest) (session *coreagent.Session, err error) {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -17,8 +17,11 @@ import (
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentgrant"
+	"github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type catalogCountingProvider struct {
@@ -150,6 +153,94 @@ type routeCountingAgentProvider struct {
 	cancelStatus      coreagent.ExecutionStatus
 	getSessionCalls   int
 	getTurnCalls      int
+}
+
+type sharedSessionAuthorizationProvider struct {
+	directResources              []*core.ResourceRef
+	effectiveResources           []*core.ResourceRef
+	effectiveErr                 error
+	allowedSessions              map[string]struct{}
+	searchResourceCalls          int
+	effectiveSearchResourceCalls int
+}
+
+func (p *sharedSessionAuthorizationProvider) Name() string { return "shared-session-authz" }
+
+func (p *sharedSessionAuthorizationProvider) Evaluate(_ context.Context, req *core.AccessEvaluationRequest) (*core.AccessDecision, error) {
+	_, allowed := p.allowedSessions[strings.TrimSpace(req.GetResource().GetId())]
+	return &core.AccessDecision{Allowed: allowed}, nil
+}
+
+func (p *sharedSessionAuthorizationProvider) EvaluateMany(ctx context.Context, req *core.AccessEvaluationsRequest) (*core.AccessEvaluationsResponse, error) {
+	resp := &core.AccessEvaluationsResponse{Decisions: make([]*core.AccessDecision, 0, len(req.GetRequests()))}
+	for _, item := range req.GetRequests() {
+		decision, err := p.Evaluate(ctx, item)
+		if err != nil {
+			return nil, err
+		}
+		resp.Decisions = append(resp.Decisions, decision)
+	}
+	return resp, nil
+}
+
+func (p *sharedSessionAuthorizationProvider) SearchResources(context.Context, *core.ResourceSearchRequest) (*core.ResourceSearchResponse, error) {
+	p.searchResourceCalls++
+	return &core.ResourceSearchResponse{Resources: cloneAuthzResources(p.directResources)}, nil
+}
+
+func (p *sharedSessionAuthorizationProvider) EffectiveSearchResources(context.Context, *core.ResourceSearchRequest) (*core.ResourceSearchResponse, error) {
+	p.effectiveSearchResourceCalls++
+	if p.effectiveErr != nil {
+		return nil, p.effectiveErr
+	}
+	return &core.ResourceSearchResponse{Resources: cloneAuthzResources(p.effectiveResources)}, nil
+}
+
+func (*sharedSessionAuthorizationProvider) SearchSubjects(context.Context, *core.SubjectSearchRequest) (*core.SubjectSearchResponse, error) {
+	return &core.SubjectSearchResponse{}, nil
+}
+
+func (*sharedSessionAuthorizationProvider) EffectiveSearchSubjects(context.Context, *core.EffectiveSubjectSearchRequest) (*core.EffectiveSubjectSearchResponse, error) {
+	return &core.EffectiveSubjectSearchResponse{}, nil
+}
+
+func (*sharedSessionAuthorizationProvider) SearchActions(context.Context, *core.ActionSearchRequest) (*core.ActionSearchResponse, error) {
+	return &core.ActionSearchResponse{}, nil
+}
+
+func (*sharedSessionAuthorizationProvider) GetMetadata(context.Context) (*core.AuthorizationMetadata, error) {
+	return &core.AuthorizationMetadata{}, nil
+}
+
+func (*sharedSessionAuthorizationProvider) ReadRelationships(context.Context, *core.ReadRelationshipsRequest) (*core.ReadRelationshipsResponse, error) {
+	return &core.ReadRelationshipsResponse{}, nil
+}
+
+func (*sharedSessionAuthorizationProvider) WriteRelationships(context.Context, *core.WriteRelationshipsRequest) error {
+	return nil
+}
+
+func (*sharedSessionAuthorizationProvider) GetActiveModel(context.Context) (*core.GetActiveModelResponse, error) {
+	return &core.GetActiveModelResponse{}, nil
+}
+
+func (*sharedSessionAuthorizationProvider) ListModels(context.Context, *core.ListModelsRequest) (*core.ListModelsResponse, error) {
+	return &core.ListModelsResponse{}, nil
+}
+
+func (*sharedSessionAuthorizationProvider) WriteModel(context.Context, *core.WriteModelRequest) (*core.AuthorizationModelRef, error) {
+	return &core.AuthorizationModelRef{Id: "model-test", Version: "1"}, nil
+}
+
+func cloneAuthzResources(resources []*core.ResourceRef) []*core.ResourceRef {
+	out := make([]*core.ResourceRef, 0, len(resources))
+	for _, resource := range resources {
+		if resource == nil {
+			continue
+		}
+		out = append(out, &core.ResourceRef{Type: resource.GetType(), Id: resource.GetId()})
+	}
+	return out
 }
 
 func newRouteCountingAgentProvider(name string) *routeCountingAgentProvider {
@@ -1112,6 +1203,89 @@ func TestManagerListSessionsRequiresBoundedHydrationForLimitedLists(t *testing.T
 	}
 	if len(provider.listSessionReqs) != 0 {
 		t.Fatalf("provider ListSessions calls = %d, want 0", len(provider.listSessionReqs))
+	}
+}
+
+func TestManagerListSharedSessionsUsesEffectiveSearchResources(t *testing.T) {
+	t.Parallel()
+
+	provider := newRouteCountingAgentProvider("alpha")
+	provider.sessions["shared-session"] = &coreagent.Session{
+		ID:           "shared-session",
+		ProviderName: "alpha",
+		State:        coreagent.SessionStateActive,
+		CreatedBy:    coreagent.Actor{SubjectID: principal.UserSubjectID("owner")},
+	}
+	authz := &sharedSessionAuthorizationProvider{
+		effectiveResources: []*core.ResourceRef{{Type: authorization.ProviderResourceTypeAgentSession, Id: "shared-session"}},
+		allowedSessions:    map[string]struct{}{"shared-session": {}},
+	}
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": provider},
+		},
+		AuthorizationProvider: authz,
+	})
+
+	sessions, err := manager.ListSessions(context.Background(), &principal.Principal{SubjectID: principal.UserSubjectID("viewer")}, coreagent.ManagerListSessionsRequest{
+		SummaryOnly: true,
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "shared-session" {
+		t.Fatalf("ListSessions shared sessions = %#v, want shared-session", sessions)
+	}
+	if authz.effectiveSearchResourceCalls != 1 {
+		t.Fatalf("EffectiveSearchResources calls = %d, want 1", authz.effectiveSearchResourceCalls)
+	}
+	if authz.searchResourceCalls != 0 {
+		t.Fatalf("SearchResources calls = %d, want 0", authz.searchResourceCalls)
+	}
+}
+
+func TestManagerListSharedSessionsFallsBackWhenEffectiveSearchUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	provider := newRouteCountingAgentProvider("alpha")
+	provider.sessions["shared-session"] = &coreagent.Session{
+		ID:           "shared-session",
+		ProviderName: "alpha",
+		State:        coreagent.SessionStateActive,
+		CreatedBy:    coreagent.Actor{SubjectID: principal.UserSubjectID("owner")},
+	}
+	authz := &sharedSessionAuthorizationProvider{
+		effectiveErr:    status.Error(codes.Unimplemented, "effective search is not supported"),
+		directResources: []*core.ResourceRef{{Type: authorization.ProviderResourceTypeAgentSession, Id: "shared-session"}},
+		allowedSessions: map[string]struct{}{"shared-session": {}},
+	}
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": provider},
+		},
+		AuthorizationProvider: authz,
+	})
+
+	sessions, err := manager.ListSessions(context.Background(), &principal.Principal{SubjectID: principal.UserSubjectID("viewer")}, coreagent.ManagerListSessionsRequest{
+		SummaryOnly: true,
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "shared-session" {
+		t.Fatalf("ListSessions shared sessions = %#v, want shared-session", sessions)
+	}
+	if authz.effectiveSearchResourceCalls != 1 {
+		t.Fatalf("EffectiveSearchResources calls = %d, want 1", authz.effectiveSearchResourceCalls)
+	}
+	if authz.searchResourceCalls != 1 {
+		t.Fatalf("SearchResources calls = %d, want 1", authz.searchResourceCalls)
 	}
 }
 

--- a/gestaltd/services/authorization/provider_backed.go
+++ b/gestaltd/services/authorization/provider_backed.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
@@ -633,10 +634,11 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 			adminDynamicRoles[relation] = struct{}{}
 		case resourceTypeExternalIdentity:
 			relation := strings.TrimSpace(rel.GetRelation())
-			if relation != relationExternalIdentityAssume || rel.GetSubject() == nil || strings.TrimSpace(rel.GetSubject().GetId()) == "" {
+			subject := relationshipTargetSubject(rel)
+			if relation != relationExternalIdentityAssume || subject == nil || strings.TrimSpace(subject.GetId()) == "" {
 				continue
 			}
-			switch strings.TrimSpace(rel.GetSubject().GetType()) {
+			switch strings.TrimSpace(subject.GetType()) {
 			case subjectTypeSubject, subjectTypeUser:
 			default:
 				continue
@@ -644,18 +646,21 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 			addDesiredRelationship(desired, rel)
 		case resourceTypeManagedSubject:
 			relation := strings.TrimSpace(rel.GetRelation())
-			if !managedSubjectManagementRelation(relation) || rel.GetSubject() == nil || strings.TrimSpace(rel.GetSubject().GetId()) == "" {
+			subject := relationshipTargetSubject(rel)
+			if !managedSubjectManagementRelation(relation) || subject == nil || strings.TrimSpace(subject.GetId()) == "" {
 				continue
 			}
-			if strings.TrimSpace(rel.GetSubject().GetType()) != subjectTypeSubject {
+			if strings.TrimSpace(subject.GetType()) != subjectTypeSubject {
 				continue
 			}
 			addDesiredRelationship(desired, rel)
 		case resourceTypeAgentSession:
-			if strings.TrimSpace(rel.GetResource().GetId()) == "" || strings.TrimSpace(rel.GetRelation()) != relationAgentSessionEditor {
+			if !validManagedAgentSessionRelationship(rel) {
 				continue
 			}
-			if rel.GetSubject() == nil || strings.TrimSpace(rel.GetSubject().GetType()) != subjectTypeSubject || strings.TrimSpace(rel.GetSubject().GetId()) == "" {
+			addDesiredRelationship(desired, rel)
+		case resourceTypeEveryone, resourceTypeTeam, resourceTypeSlackChannel:
+			if !validManagedMembershipRelationship(rel) {
 				continue
 			}
 			addDesiredRelationship(desired, rel)
@@ -735,11 +740,7 @@ func diffRelationships(existing, desired map[string]*core.Relationship) ([]*core
 		if _, ok := desired[key]; ok {
 			continue
 		}
-		deletes = append(deletes, &core.RelationshipKey{
-			Subject:  rel.GetSubject(),
-			Relation: rel.GetRelation(),
-			Resource: rel.GetResource(),
-		})
+		deletes = append(deletes, relationshipKeyForRelationship(rel))
 	}
 	sort.Slice(writes, func(i, j int) bool { return relationshipMapKey(writes[i]) < relationshipMapKey(writes[j]) })
 	sort.Slice(deletes, func(i, j int) bool { return relationshipKeyMapKey(deletes[i]) < relationshipKeyMapKey(deletes[j]) })
@@ -796,6 +797,61 @@ func managedSubjectManagementRelation(relation string) bool {
 	default:
 		return false
 	}
+}
+
+func validManagedAgentSessionRelationship(rel *core.Relationship) bool {
+	if rel == nil || rel.GetResource() == nil || strings.TrimSpace(rel.GetResource().GetId()) == "" {
+		return false
+	}
+	switch strings.TrimSpace(rel.GetRelation()) {
+	case relationAgentSessionViewer, relationAgentSessionEditor:
+		return validAgentSessionAccessTarget(rel)
+	case relationAgentSessionParent:
+		target := relationshipTargetResource(rel)
+		return target != nil &&
+			strings.TrimSpace(target.GetType()) == resourceTypeAgentSession &&
+			strings.TrimSpace(target.GetId()) != ""
+	default:
+		return false
+	}
+}
+
+func validAgentSessionAccessTarget(rel *core.Relationship) bool {
+	if subject := relationshipTargetSubject(rel); subject != nil {
+		return strings.TrimSpace(subject.GetType()) == subjectTypeSubject && strings.TrimSpace(subject.GetId()) != ""
+	}
+	subjectSet := relationshipTargetSubjectSet(rel)
+	if subjectSet == nil || strings.TrimSpace(subjectSet.GetRelation()) != relationMember {
+		return false
+	}
+	resource := subjectSet.GetResource()
+	if resource == nil || strings.TrimSpace(resource.GetId()) == "" {
+		return false
+	}
+	switch strings.TrimSpace(resource.GetType()) {
+	case resourceTypeEveryone:
+		return strings.TrimSpace(resource.GetId()) == resourceIDEveryoneGlobal
+	case resourceTypeTeam, resourceTypeSlackChannel:
+		return true
+	default:
+		return false
+	}
+}
+
+func validManagedMembershipRelationship(rel *core.Relationship) bool {
+	if rel == nil || rel.GetResource() == nil {
+		return false
+	}
+	if strings.TrimSpace(rel.GetRelation()) != relationMember || strings.TrimSpace(rel.GetResource().GetId()) == "" {
+		return false
+	}
+	if strings.TrimSpace(rel.GetResource().GetType()) == resourceTypeEveryone && strings.TrimSpace(rel.GetResource().GetId()) != resourceIDEveryoneGlobal {
+		return false
+	}
+	subject := relationshipTargetSubject(rel)
+	return subject != nil &&
+		strings.TrimSpace(subject.GetType()) == subjectTypeSubject &&
+		strings.TrimSpace(subject.GetId()) != ""
 }
 
 func roleSortKey(role string) string {
@@ -886,8 +942,7 @@ func relationshipMapKey(rel *core.Relationship) string {
 		return ""
 	}
 	return strings.Join([]string{
-		rel.GetSubject().GetType(),
-		rel.GetSubject().GetId(),
+		RelationshipTargetMapKey(rel.GetTarget(), rel.GetSubject()),
 		rel.GetRelation(),
 		rel.GetResource().GetType(),
 		rel.GetResource().GetId(),
@@ -899,12 +954,100 @@ func relationshipKeyMapKey(rel *core.RelationshipKey) string {
 		return ""
 	}
 	return strings.Join([]string{
-		rel.GetSubject().GetType(),
-		rel.GetSubject().GetId(),
+		RelationshipTargetMapKey(rel.GetTarget(), rel.GetSubject()),
 		rel.GetRelation(),
 		rel.GetResource().GetType(),
 		rel.GetResource().GetId(),
 	}, "\x00")
+}
+
+func relationshipKeyForRelationship(rel *core.Relationship) *core.RelationshipKey {
+	if rel == nil {
+		return nil
+	}
+	key := &core.RelationshipKey{
+		Subject:  rel.GetSubject(),
+		Relation: rel.GetRelation(),
+		Resource: rel.GetResource(),
+		Target:   rel.GetTarget(),
+	}
+	if key.GetTarget() == nil && key.GetSubject() != nil {
+		key.Target = &core.RelationshipTargetRef{
+			Kind: &proto.RelationshipTarget_Subject{Subject: key.GetSubject()},
+		}
+	}
+	return key
+}
+
+// RelationshipTargetMapKey returns the canonical key for a target-aware
+// relationship target. Legacy subject-only tuples are represented as subject
+// targets.
+func RelationshipTargetMapKey(target *core.RelationshipTargetRef, subject *core.SubjectRef) string {
+	if target != nil {
+		if targetSubject := target.GetSubject(); targetSubject != nil {
+			return strings.Join([]string{"subject", strings.TrimSpace(targetSubject.GetType()), strings.TrimSpace(targetSubject.GetId())}, "\x00")
+		}
+		if targetResource := target.GetResource(); targetResource != nil {
+			return strings.Join([]string{"resource", strings.TrimSpace(targetResource.GetType()), strings.TrimSpace(targetResource.GetId())}, "\x00")
+		}
+		if targetSet := target.GetSubjectSet(); targetSet != nil {
+			resource := targetSet.GetResource()
+			return strings.Join([]string{
+				"subject_set",
+				strings.TrimSpace(resource.GetType()),
+				strings.TrimSpace(resource.GetId()),
+				strings.TrimSpace(targetSet.GetRelation()),
+			}, "\x00")
+		}
+	}
+	if subject != nil {
+		return strings.Join([]string{"subject", strings.TrimSpace(subject.GetType()), strings.TrimSpace(subject.GetId())}, "\x00")
+	}
+	return ""
+}
+
+// RelationshipSubject returns the effective direct subject for a relationship.
+// Non-subject targets and inconsistent legacy subject/target pairs return nil.
+func RelationshipSubject(rel *core.Relationship) *core.SubjectRef {
+	if rel == nil {
+		return nil
+	}
+	if target := rel.GetTarget(); target != nil {
+		targetSubject := target.GetSubject()
+		if targetSubject == nil {
+			return nil
+		}
+		if subject := rel.GetSubject(); subject != nil && !sameSubjectRef(subject, targetSubject) {
+			return nil
+		}
+		return targetSubject
+	}
+	return rel.GetSubject()
+}
+
+func relationshipTargetSubject(rel *core.Relationship) *core.SubjectRef {
+	return RelationshipSubject(rel)
+}
+
+func relationshipTargetResource(rel *core.Relationship) *core.ResourceRef {
+	if rel == nil || rel.GetTarget() == nil || rel.GetSubject() != nil {
+		return nil
+	}
+	return rel.GetTarget().GetResource()
+}
+
+func relationshipTargetSubjectSet(rel *core.Relationship) *core.SubjectSetRef {
+	if rel == nil || rel.GetTarget() == nil || rel.GetSubject() != nil {
+		return nil
+	}
+	return rel.GetTarget().GetSubjectSet()
+}
+
+func sameSubjectRef(left, right *core.SubjectRef) bool {
+	return left != nil &&
+		right != nil &&
+		strings.TrimSpace(left.GetType()) == strings.TrimSpace(right.GetType()) &&
+		strings.TrimSpace(left.GetId()) == strings.TrimSpace(right.GetId())
 }
 
 func (a *ProviderBackedAuthorizer) logProviderEvalError(scope, name string, err error) {

--- a/gestaltd/services/authorization/provider_backed_test.go
+++ b/gestaltd/services/authorization/provider_backed_test.go
@@ -268,3 +268,61 @@ func providerBackedRoleRelationshipMatches(rel *core.Relationship, req *core.Rea
 	}
 	return true
 }
+
+func TestProviderAuthorizationModelIncludesAgentSessionUsersets(t *testing.T) {
+	t.Parallel()
+
+	model := ProviderAuthorizationModelForRoles(nil, nil, nil, nil)
+	agentSession := authorizationModelResourceType(model, ProviderResourceTypeAgentSession)
+	if agentSession == nil {
+		t.Fatal("agent_session resource type is missing")
+	}
+	viewer := authorizationModelRelation(agentSession, ProviderAgentSessionRelationViewer)
+	if viewer == nil {
+		t.Fatal("agent_session viewer relation is missing")
+	}
+	if !relationAllowsSubjectSet(viewer, ProviderResourceTypeEveryone, ProviderRelationMember) {
+		t.Fatalf("agent_session viewer allowed targets = %#v, want everyone member subject set", viewer.GetAllowedTargets())
+	}
+	if !relationAllowsSubjectSet(viewer, ProviderResourceTypeSlackChannel, ProviderRelationMember) {
+		t.Fatalf("agent_session viewer allowed targets = %#v, want slack_channel member subject set", viewer.GetAllowedTargets())
+	}
+	parent := authorizationModelRelation(agentSession, ProviderAgentSessionRelationParent)
+	if parent == nil {
+		t.Fatal("agent_session parent relation is missing")
+	}
+	if len(parent.GetAllowedTargets()) != 1 || parent.GetAllowedTargets()[0].GetResourceType() != ProviderResourceTypeAgentSession {
+		t.Fatalf("agent_session parent allowed targets = %#v, want agent_session resource target", parent.GetAllowedTargets())
+	}
+	if authorizationModelResourceType(model, ProviderResourceTypeTeam) == nil {
+		t.Fatal("team membership resource type is missing")
+	}
+}
+
+func authorizationModelResourceType(model *core.AuthorizationModel, name string) *core.AuthorizationModelResourceType {
+	for _, resourceType := range model.GetResourceTypes() {
+		if resourceType.GetName() == name {
+			return resourceType
+		}
+	}
+	return nil
+}
+
+func authorizationModelRelation(resourceType *core.AuthorizationModelResourceType, name string) *core.AuthorizationModelRelation {
+	for _, relation := range resourceType.GetRelations() {
+		if relation.GetName() == name {
+			return relation
+		}
+	}
+	return nil
+}
+
+func relationAllowsSubjectSet(relation *core.AuthorizationModelRelation, resourceType, setRelation string) bool {
+	for _, target := range relation.GetAllowedTargets() {
+		subjectSet := target.GetSubjectSet()
+		if subjectSet != nil && subjectSet.GetResourceType() == resourceType && subjectSet.GetRelation() == setRelation {
+			return true
+		}
+	}
+	return false
+}

--- a/gestaltd/services/authorization/provider_schema.go
+++ b/gestaltd/services/authorization/provider_schema.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 
+	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 )
 
@@ -16,9 +17,16 @@ const (
 	ProviderResourceTypeExternalIdentity               = "external_identity"
 	ProviderResourceTypeManagedSubject                 = "managed_subject"
 	ProviderResourceTypeAgentSession                   = "agent_session"
+	ProviderResourceTypeEveryone                       = "everyone"
+	ProviderResourceTypeTeam                           = "team"
+	ProviderResourceTypeSlackChannel                   = "slack_channel"
 	ProviderResourceIDAdminDynamicGlobal               = "global"
+	ProviderResourceIDEveryoneGlobal                   = "global"
 	ProviderExternalIdentityRelationAssume             = "assume"
+	ProviderRelationMember                             = "member"
+	ProviderAgentSessionRelationViewer                 = "viewer"
 	ProviderAgentSessionRelationEditor                 = "editor"
+	ProviderAgentSessionRelationParent                 = "parent"
 	ProviderAgentSessionActionView                     = "view"
 	ProviderAgentSessionActionEdit                     = "edit"
 	ProviderManagedSubjectRelationViewer               = "viewer"
@@ -44,9 +52,16 @@ const (
 	resourceTypeExternalIdentity   = ProviderResourceTypeExternalIdentity
 	resourceTypeManagedSubject     = ProviderResourceTypeManagedSubject
 	resourceTypeAgentSession       = ProviderResourceTypeAgentSession
+	resourceTypeEveryone           = ProviderResourceTypeEveryone
+	resourceTypeTeam               = ProviderResourceTypeTeam
+	resourceTypeSlackChannel       = ProviderResourceTypeSlackChannel
 	resourceIDAdminDynamicGlobal   = ProviderResourceIDAdminDynamicGlobal
+	resourceIDEveryoneGlobal       = ProviderResourceIDEveryoneGlobal
 	relationExternalIdentityAssume = ProviderExternalIdentityRelationAssume
+	relationMember                 = ProviderRelationMember
+	relationAgentSessionViewer     = ProviderAgentSessionRelationViewer
 	relationAgentSessionEditor     = ProviderAgentSessionRelationEditor
+	relationAgentSessionParent     = ProviderAgentSessionRelationParent
 	relationManagedSubjectViewer   = ProviderManagedSubjectRelationViewer
 	relationManagedSubjectEditor   = ProviderManagedSubjectRelationEditor
 	relationManagedSubjectAdmin    = ProviderManagedSubjectRelationAdmin
@@ -67,7 +82,10 @@ func IsManagedProviderRelationship(rel *core.Relationship) bool {
 		ProviderResourceTypeAdminDynamic,
 		ProviderResourceTypeExternalIdentity,
 		ProviderResourceTypeManagedSubject,
-		ProviderResourceTypeAgentSession:
+		ProviderResourceTypeAgentSession,
+		ProviderResourceTypeEveryone,
+		ProviderResourceTypeTeam,
+		ProviderResourceTypeSlackChannel:
 		return true
 	default:
 		return false
@@ -166,21 +184,113 @@ func buildProviderAuthorizationModel(state providerBackedRoleState) *core.Author
 	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
 		&core.AuthorizationModelResourceType{
 			Name: resourceTypeAgentSession,
-			Relations: []*core.AuthorizationModelRelation{{
-				Name:         relationAgentSessionEditor,
-				SubjectTypes: []string{subjectTypeSubject},
-			}},
+			Relations: []*core.AuthorizationModelRelation{
+				agentSessionAccessRelation(relationAgentSessionViewer),
+				agentSessionAccessRelation(relationAgentSessionEditor),
+				{
+					Name:         relationAgentSessionParent,
+					SubjectTypes: []string{subjectTypeSubject},
+					AllowedTargets: []*core.AuthorizationModelAllowedTarget{{
+						Kind: &proto.AuthorizationModelAllowedTarget_ResourceType{ResourceType: resourceTypeAgentSession},
+					}},
+				},
+			},
 			Actions: []*core.AuthorizationModelAction{
-				{Name: ProviderAgentSessionActionView, Relations: []string{relationAgentSessionEditor}},
-				{Name: ProviderAgentSessionActionEdit, Relations: []string{relationAgentSessionEditor}},
+				{
+					Name:      ProviderAgentSessionActionView,
+					Relations: []string{relationAgentSessionViewer, relationAgentSessionEditor},
+					Rewrite: rewriteUnion(
+						rewriteComputedUserset(relationAgentSessionViewer),
+						rewriteComputedUserset(relationAgentSessionEditor),
+					),
+				},
+				{
+					Name:      ProviderAgentSessionActionEdit,
+					Relations: []string{relationAgentSessionEditor},
+					Rewrite:   rewriteComputedUserset(relationAgentSessionEditor),
+				},
 			},
 		},
+	)
+	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
+		membershipResourceType(resourceTypeEveryone),
+	)
+	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
+		membershipResourceType(resourceTypeTeam),
+	)
+	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
+		membershipResourceType(resourceTypeSlackChannel),
 	)
 
 	slices.SortFunc(model.ResourceTypes, func(left, right *core.AuthorizationModelResourceType) int {
 		return strings.Compare(left.GetName(), right.GetName())
 	})
 	return model
+}
+
+func agentSessionAccessRelation(name string) *core.AuthorizationModelRelation {
+	children := []*core.AuthorizationModelRewrite{rewriteThis()}
+	if name == relationAgentSessionViewer {
+		children = append(children, rewriteComputedUserset(relationAgentSessionEditor))
+	}
+	children = append(children, rewriteTupleToUserset(relationAgentSessionParent, name))
+	return &core.AuthorizationModelRelation{
+		Name:         name,
+		SubjectTypes: []string{subjectTypeSubject},
+		AllowedTargets: []*core.AuthorizationModelAllowedTarget{
+			{Kind: &proto.AuthorizationModelAllowedTarget_SubjectType{SubjectType: subjectTypeSubject}},
+			{Kind: &proto.AuthorizationModelAllowedTarget_SubjectSet{SubjectSet: &core.AuthorizationModelSubjectSetTarget{ResourceType: resourceTypeEveryone, Relation: relationMember}}},
+			{Kind: &proto.AuthorizationModelAllowedTarget_SubjectSet{SubjectSet: &core.AuthorizationModelSubjectSetTarget{ResourceType: resourceTypeTeam, Relation: relationMember}}},
+			{Kind: &proto.AuthorizationModelAllowedTarget_SubjectSet{SubjectSet: &core.AuthorizationModelSubjectSetTarget{ResourceType: resourceTypeSlackChannel, Relation: relationMember}}},
+		},
+		Rewrite: rewriteUnion(children...),
+	}
+}
+
+func membershipResourceType(name string) *core.AuthorizationModelResourceType {
+	return &core.AuthorizationModelResourceType{
+		Name: name,
+		Relations: []*core.AuthorizationModelRelation{{
+			Name:         relationMember,
+			SubjectTypes: []string{subjectTypeSubject},
+			AllowedTargets: []*core.AuthorizationModelAllowedTarget{{
+				Kind: &proto.AuthorizationModelAllowedTarget_SubjectType{SubjectType: subjectTypeSubject},
+			}},
+			Rewrite: rewriteThis(),
+		}},
+		Actions: []*core.AuthorizationModelAction{{
+			Name:      relationMember,
+			Relations: []string{relationMember},
+			Rewrite:   rewriteComputedUserset(relationMember),
+		}},
+	}
+}
+
+func rewriteThis() *core.AuthorizationModelRewrite {
+	return &core.AuthorizationModelRewrite{
+		Kind: &proto.AuthorizationModelRewrite_This{This: &core.AuthorizationModelRewriteThis{}},
+	}
+}
+
+func rewriteComputedUserset(relation string) *core.AuthorizationModelRewrite {
+	return &core.AuthorizationModelRewrite{
+		Kind: &proto.AuthorizationModelRewrite_ComputedUserset{ComputedUserset: &core.AuthorizationModelComputedUserset{Relation: relation}},
+	}
+}
+
+func rewriteTupleToUserset(tuplesetRelation, computedRelation string) *core.AuthorizationModelRewrite {
+	return &core.AuthorizationModelRewrite{
+		Kind: &proto.AuthorizationModelRewrite_TupleToUserset{TupleToUserset: &core.AuthorizationModelTupleToUserset{
+			TuplesetRelation: tuplesetRelation,
+			ComputedRelation: computedRelation,
+		}},
+	}
+}
+
+func rewriteUnion(children ...*core.AuthorizationModelRewrite) *core.AuthorizationModelRewrite {
+	return &core.AuthorizationModelRewrite{
+		Kind: &proto.AuthorizationModelRewrite_Union{Union: &core.AuthorizationModelRewriteUnion{Children: children}},
+	}
 }
 
 func appendIfModelResourceType(target []*core.AuthorizationModelResourceType, resourceType *core.AuthorizationModelResourceType) []*core.AuthorizationModelResourceType {


### PR DESCRIPTION
## Summary

Adds the Gestalt product semantics that use the Zanzibar authorization interfaces introduced in #1890.

- Publishes `agent_session` viewer/editor/parent relations with allowed direct subjects plus `everyone`, `team`, and `slack_channel` subject-set targets.
- Adds managed membership resource types for `everyone`, `team`, and `slack_channel`.
- Preserves generalized `Relationship.target` tuples during provider-backed managed relationship reconciliation and admin rollback/delete helpers.
- Uses `EffectiveSearchResources` for shared agent session listing, falling back to direct `SearchResources` when a remote or older provider returns `Unimplemented`.

## Interface Changes

- New managed constants:
  - `ProviderAgentSessionRelationViewer = "viewer"`
  - `ProviderAgentSessionRelationParent = "parent"`
  - `ProviderResourceTypeEveryone = "everyone"`
  - `ProviderResourceTypeTeam = "team"`
  - `ProviderResourceTypeSlackChannel = "slack_channel"`
  - `ProviderRelationMember = "member"`
- Example relationships:
  - `agent_session:sess#viewer@everyone:global#member`
  - `agent_session:sess#viewer@slack_channel:T123:C456#member`
  - `agent_session:sess#editor@team:platform#member`
  - `agent_session:child#parent@agent_session:parent`

## Functional/Integration Tests

- Tests added or augmented:
  - `TestProviderAuthorizationModelIncludesAgentSessionUsersets`
  - `TestAuthorizationProviderBackedReloadPreservesAgentSessionGrants`
  - `TestManagerListSharedSessionsUsesEffectiveSearchResources`
  - `TestManagerListSharedSessionsFallsBackWhenEffectiveSearchUnimplemented`
- Contract boundary covered:
  - Gestalt managed authorization model generation
  - Provider-backed relationship reconciliation with generalized targets
  - Agent session listing through effective search with old-provider fallback
- Commands run:
  - `go test ./services/authorization ./services/agents/agentmanager`
  - `go test ./internal/server -run 'TestAuthorizationProviderBackedReloadPreservesAgentSessionGrants|TestAgentSessionSharedAuthorizationAllowsCollaborator'`
  - `git diff --check`

## Stack

Depends on #1890. Follow-up stack item: implement effective Zanzibar evaluation/search/expand in the first-party `authorization/indexeddb` provider.