### PR TITLE
Project agent-facing tool schemas

### DIFF
--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1874,6 +1875,7 @@ func (m *Manager) searchWorkflowSystemTools(ctx context.Context, p *principal.Pr
 		return nil, err
 	}
 	for i := range tools {
+		tools[i] = projectResolvedAgentToolSchema(tools[i])
 		toolID, err := m.mintAgentToolID(tools[i].Target)
 		if err != nil {
 			return nil, err
@@ -1932,6 +1934,7 @@ func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref c
 		if err != nil {
 			return coreagent.Tool{}, err
 		}
+		tool = projectResolvedAgentToolSchema(tool)
 		toolID, err := m.mintAgentToolID(tool.Target)
 		if err != nil {
 			return coreagent.Tool{}, err
@@ -2756,10 +2759,7 @@ func sessionSortTime(session *coreagent.Session) *time.Time {
 }
 
 func operationInputSchema(op catalog.CatalogOperation) (map[string]any, error) {
-	raw := agentToolInputSchema(op)
-	if len(raw) == 0 {
-		return nil, nil
-	}
+	raw := projectAgentToolInputSchema(agentToolInputSchema(op), op.Parameters)
 	var out map[string]any
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil, fmt.Errorf("decode %s input schema: %w", op.ID, err)
@@ -2814,18 +2814,11 @@ func agentToolInputSchema(op catalog.CatalogOperation) json.RawMessage {
 	if len(op.InputSchema) <= agentToolSchemaMaxBytes {
 		return op.InputSchema
 	}
-	if synthesized := integration.SynthesizeInputSchema(op.Parameters); len(synthesized) > 0 {
-		return synthesized
-	}
-	return json.RawMessage(`{"type":"object","additionalProperties":true}`)
+	return synthesizeAgentToolInputSchema(op.Parameters)
 }
 
 func agentToolInputSchemaJSON(op catalog.CatalogOperation) string {
-	raw := agentToolInputSchema(op)
-	if len(raw) == 0 {
-		return `{"type":"object","additionalProperties":true}`
-	}
-	return string(raw)
+	return string(projectAgentToolInputSchema(agentToolInputSchema(op), op.Parameters))
 }
 
 func agentToolOutputSchemaJSON(op catalog.CatalogOperation) string {
@@ -2837,13 +2830,378 @@ func agentToolOutputSchemaJSON(op catalog.CatalogOperation) string {
 
 func agentToolSchemaJSON(schema map[string]any) (string, error) {
 	if len(schema) == 0 {
-		return `{"type":"object","additionalProperties":true}`, nil
+		return string(agentToolPermissiveInputSchema()), nil
 	}
 	raw, err := json.Marshal(schema)
 	if err != nil {
 		return "", fmt.Errorf("marshal agent tool input schema: %w", err)
 	}
-	return string(raw), nil
+	if len(raw) > agentToolSchemaMaxBytes {
+		return string(agentToolPermissiveInputSchema()), nil
+	}
+	return string(projectAgentToolInputSchema(raw, nil)), nil
+}
+
+func projectResolvedAgentToolSchema(tool coreagent.Tool) coreagent.Tool {
+	raw, err := json.Marshal(tool.ParametersSchema)
+	if err != nil || len(raw) == 0 || len(raw) > agentToolSchemaMaxBytes {
+		tool.ParametersSchema = agentToolPermissiveInputSchemaMap()
+		return tool
+	}
+	projected := projectAgentToolInputSchema(raw, nil)
+	var out map[string]any
+	if err := json.Unmarshal(projected, &out); err != nil || len(out) == 0 {
+		tool.ParametersSchema = agentToolPermissiveInputSchemaMap()
+		return tool
+	}
+	tool.ParametersSchema = out
+	return tool
+}
+
+func projectAgentToolOperationForListing(op catalog.CatalogOperation) catalog.CatalogOperation {
+	out := op
+	out.ProviderID = ""
+	out.Path = ""
+	out.Parameters = publicAgentToolParameters(op.Parameters)
+	out.InputSchema = projectAgentToolInputSchema(agentToolInputSchema(op), op.Parameters)
+	return out
+}
+
+func projectAgentToolInputSchema(raw json.RawMessage, params []catalog.CatalogParameter) json.RawMessage {
+	if len(raw) == 0 || len(raw) > agentToolSchemaMaxBytes {
+		return synthesizeAgentToolInputSchema(params)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil || schema == nil {
+		return synthesizeAgentToolInputSchema(params)
+	}
+	projected, ok := projectAgentToolSchemaObject(schema, internalAgentToolSchemaFilter(params))
+	if !ok {
+		return synthesizeAgentToolInputSchema(params)
+	}
+	projectedRaw, err := json.Marshal(projected)
+	if err != nil || len(projectedRaw) > agentToolSchemaMaxBytes {
+		return synthesizeAgentToolInputSchema(params)
+	}
+	return projectedRaw
+}
+
+func synthesizeAgentToolInputSchema(params []catalog.CatalogParameter) json.RawMessage {
+	if synthesized := integration.SynthesizeInputSchema(publicAgentToolParameters(params)); len(synthesized) > 0 && len(synthesized) <= agentToolSchemaMaxBytes {
+		return synthesized
+	}
+	return agentToolPermissiveInputSchema()
+}
+
+func publicAgentToolParameters(params []catalog.CatalogParameter) []catalog.CatalogParameter {
+	if len(params) == 0 {
+		return nil
+	}
+	out := make([]catalog.CatalogParameter, 0, len(params))
+	for _, param := range params {
+		if param.Internal {
+			continue
+		}
+		out = append(out, param)
+	}
+	return out
+}
+
+type agentToolInternalSchemaFilter struct {
+	names   map[string]struct{}
+	phrases []string
+}
+
+func internalAgentToolSchemaFilter(params []catalog.CatalogParameter) agentToolInternalSchemaFilter {
+	var out agentToolInternalSchemaFilter
+	for _, param := range params {
+		if !param.Internal {
+			continue
+		}
+		out.addName(param.Name)
+		out.addName(param.WireName)
+		out.addPhrase(param.Description, 8)
+	}
+	return out
+}
+
+func (f *agentToolInternalSchemaFilter) addName(value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	if f.names == nil {
+		f.names = make(map[string]struct{}, 2)
+	}
+	f.names[value] = struct{}{}
+	f.addPhrase(value, 4)
+}
+
+func (f *agentToolInternalSchemaFilter) addPhrase(value string, minLength int) {
+	value = strings.TrimSpace(value)
+	if len(value) < minLength {
+		return
+	}
+	f.phrases = append(f.phrases, strings.ToLower(value))
+}
+
+func (f agentToolInternalSchemaFilter) internalName(value string) bool {
+	_, ok := f.names[strings.TrimSpace(value)]
+	return ok
+}
+
+func (f agentToolInternalSchemaFilter) mentionsInternal(value string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return false
+	}
+	for _, phrase := range f.phrases {
+		if phrase != "" && strings.Contains(value, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func agentToolPermissiveInputSchema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","additionalProperties":true}`)
+}
+
+func agentToolPermissiveInputSchemaMap() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": true,
+	}
+}
+
+func projectAgentToolSchemaObject(schema map[string]any, filter agentToolInternalSchemaFilter) (map[string]any, bool) {
+	if !agentToolSchemaRootSupportsObject(schema) {
+		return nil, false
+	}
+	out := map[string]any{"type": "object"}
+	if additionalProperties, ok := schema["additionalProperties"].(bool); ok {
+		out["additionalProperties"] = additionalProperties
+	}
+	properties, ok := agentToolSchemaProperties(schema)
+	if !ok {
+		return nil, false
+	}
+	projectedProperties := make(map[string]any, len(properties))
+	rootPropertyNames := make(map[string]struct{}, len(properties))
+	for name, value := range properties {
+		if filter.internalName(name) || filter.mentionsInternal(name) {
+			continue
+		}
+		projectedValue, keep := projectAgentToolSchemaValue(value, filter)
+		if !keep {
+			continue
+		}
+		projectedProperties[name] = projectedValue
+		rootPropertyNames[name] = struct{}{}
+	}
+	required := map[string]struct{}{}
+	for _, spec := range []struct {
+		key           string
+		unionRequired bool
+	}{
+		{key: "allOf", unionRequired: true},
+		{key: "oneOf", unionRequired: false},
+		{key: "anyOf", unionRequired: false},
+	} {
+		if _, exists := schema[spec.key]; !exists {
+			continue
+		}
+		if !mergeAgentToolSchemaCombinator(schema[spec.key], projectedProperties, rootPropertyNames, required, filter, spec.unionRequired) {
+			return nil, false
+		}
+	}
+	for name := range agentToolSchemaRequiredSet(projectedProperties, filter, schema["required"]) {
+		required[name] = struct{}{}
+	}
+	if len(projectedProperties) > 0 {
+		out["properties"] = projectedProperties
+	}
+	if len(required) > 0 {
+		out["required"] = sortedAgentToolRequired(required)
+	}
+	return out, true
+}
+
+func projectAgentToolSchemaValue(value any, filter agentToolInternalSchemaFilter) (any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			if agentToolUnsafeNestedSchemaKey(key) || filter.internalName(key) || filter.mentionsInternal(key) {
+				continue
+			}
+			projected, keep := projectAgentToolSchemaValue(item, filter)
+			if !keep {
+				continue
+			}
+			out[key] = projected
+		}
+		return out, true
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			projected, keep := projectAgentToolSchemaValue(item, filter)
+			if keep {
+				out = append(out, projected)
+			}
+		}
+		return out, true
+	case []string:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if filter.internalName(item) || filter.mentionsInternal(item) {
+				continue
+			}
+			out = append(out, item)
+		}
+		return out, true
+	case string:
+		if filter.mentionsInternal(typed) {
+			return nil, false
+		}
+		return typed, true
+	default:
+		return value, true
+	}
+}
+
+func agentToolUnsafeNestedSchemaKey(key string) bool {
+	if strings.HasPrefix(key, "$") {
+		return true
+	}
+	switch key {
+	case "allOf", "anyOf", "oneOf", "not", "if", "then", "else", "dependentRequired", "dependentSchemas", "patternProperties", "definitions":
+		return true
+	default:
+		return false
+	}
+}
+
+func mergeAgentToolSchemaCombinator(value any, properties map[string]any, rootPropertyNames map[string]struct{}, required map[string]struct{}, filter agentToolInternalSchemaFilter, unionRequired bool) bool {
+	branches, ok := value.([]any)
+	if !ok {
+		return false
+	}
+	for _, branchValue := range branches {
+		branch, ok := branchValue.(map[string]any)
+		if !ok {
+			return false
+		}
+		projected, ok := projectAgentToolSchemaObject(branch, filter)
+		if !ok {
+			return false
+		}
+		branchProperties, ok := agentToolSchemaProperties(projected)
+		if !ok {
+			return false
+		}
+		for name, value := range branchProperties {
+			if _, rootProperty := rootPropertyNames[name]; rootProperty {
+				if existing, exists := properties[name]; !exists || !reflect.DeepEqual(existing, value) {
+					return false
+				}
+				continue
+			}
+			if existing, exists := properties[name]; exists && !reflect.DeepEqual(existing, value) {
+				return false
+			}
+			properties[name] = value
+		}
+		if unionRequired {
+			for name := range agentToolSchemaRequiredSet(properties, filter, projected["required"]) {
+				if _, ok := properties[name]; ok {
+					required[name] = struct{}{}
+				}
+			}
+		}
+	}
+	return true
+}
+
+func agentToolSchemaRootSupportsObject(schema map[string]any) bool {
+	value, exists := schema["type"]
+	if !exists {
+		return true
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed == "object"
+	case []any:
+		for _, item := range typed {
+			if item == "object" {
+				return true
+			}
+		}
+	case []string:
+		for _, item := range typed {
+			if item == "object" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func agentToolSchemaProperties(schema map[string]any) (map[string]any, bool) {
+	value, exists := schema["properties"]
+	if !exists || value == nil {
+		return nil, true
+	}
+	properties, ok := value.(map[string]any)
+	return properties, ok
+}
+
+func agentToolSchemaRequiredSet(properties map[string]any, filter agentToolInternalSchemaFilter, values any) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, name := range agentToolSchemaRequired(values) {
+		if filter.internalName(name) || filter.mentionsInternal(name) {
+			continue
+		}
+		if _, exists := properties[name]; exists {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+func agentToolSchemaRequired(values any) []string {
+	switch typed := values.(type) {
+	case []any:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			name, ok := item.(string)
+			if !ok || name == "" {
+				continue
+			}
+			out = append(out, name)
+		}
+		return out
+	case []string:
+		out := make([]string, 0, len(typed))
+		for _, name := range typed {
+			if name == "" {
+				continue
+			}
+			out = append(out, name)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func sortedAgentToolRequired(required map[string]struct{}) []string {
+	out := make([]string, 0, len(required))
+	for name := range required {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func listedAgentSystemTool(tool coreagent.Tool) (coreagent.ListedTool, error) {
@@ -2864,6 +3222,9 @@ func listedAgentSystemTool(tool coreagent.Tool) (coreagent.ListedTool, error) {
 }
 
 func (m *Manager) listedAgentPluginCandidateTool(candidate agentToolSearchCandidate) (coreagent.ListedTool, error) {
+	projectedOperation := projectAgentToolOperationForListing(candidate.operation)
+	projectedCandidate := candidate
+	projectedCandidate.operation = projectedOperation
 	ref := candidate.ref
 	target := coreagent.ToolTarget{
 		Plugin:                strings.TrimSpace(ref.Plugin),
@@ -2880,14 +3241,14 @@ func (m *Manager) listedAgentPluginCandidateTool(candidate agentToolSearchCandid
 	}
 	name := strings.TrimSpace(ref.Title)
 	if name == "" {
-		name = strings.TrimSpace(candidate.operation.Title)
+		name = strings.TrimSpace(projectedOperation.Title)
 	}
 	if name == "" {
-		name = target.Plugin + "." + candidate.operation.ID
+		name = target.Plugin + "." + projectedOperation.ID
 	}
 	description := strings.TrimSpace(ref.Description)
 	if description == "" {
-		description = strings.TrimSpace(candidate.operation.Description)
+		description = strings.TrimSpace(projectedOperation.Description)
 	}
 	ref.Connection = target.Connection
 	ref.Instance = target.Instance
@@ -2898,14 +3259,14 @@ func (m *Manager) listedAgentPluginCandidateTool(candidate agentToolSearchCandid
 		MCPName:          agentToolMCPName(target),
 		Title:            name,
 		Description:      description,
-		Tags:             append([]string(nil), candidate.operation.Tags...),
-		SearchText:       agentToolSearchMetadataText(candidate),
-		InputSchemaJSON:  agentToolInputSchemaJSON(candidate.operation),
-		OutputSchemaJSON: agentToolOutputSchemaJSON(candidate.operation),
-		Annotations:      capabilityAnnotationsFromCatalog(candidate.operation.Annotations),
+		Tags:             append([]string(nil), projectedOperation.Tags...),
+		SearchText:       agentToolSearchMetadataText(projectedCandidate),
+		InputSchemaJSON:  agentToolInputSchemaJSON(projectedOperation),
+		OutputSchemaJSON: agentToolOutputSchemaJSON(projectedOperation),
+		Annotations:      capabilityAnnotationsFromCatalog(projectedOperation.Annotations),
 		Ref:              ref,
 		Target:           target,
-		Hidden:           !catalog.OperationVisibleByDefault(candidate.operation),
+		Hidden:           !catalog.OperationVisibleByDefault(projectedOperation),
 	}, nil
 }
 

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -2,6 +2,7 @@ package agentmanager
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -2523,6 +2524,409 @@ func TestResolveToolsRejectsUndeclaredRunAs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManagerProjectsAgentFacingPluginToolSchemas(t *testing.T) {
+	t.Parallel()
+
+	hidden := false
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "planner",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name: "planner",
+				Operations: []catalog.CatalogOperation{
+					{
+						ID:          "choose_target",
+						ProviderID:  "internal_secret_provider",
+						Path:        "/planner/{x-secret}/choose",
+						Title:       "Choose target",
+						Description: "Choose a public target",
+						InputSchema: json.RawMessage(`{
+							"type":["object","null"],
+							"properties":{
+								"root_choice":{"type":"string"},
+								"public_body":{
+									"type":"object",
+									"description":"public wrapper around internal tunnel token",
+									"$ref":"#/$defs/internal_secret",
+									"properties":{"internal_secret":{"type":"string","description":"internal tunnel token"},"visible_child":{"type":"string"}},
+									"required":["internal_secret","visible_child"]
+								},
+								"internal_secret":{"type":"string"},
+								"x-secret":{"type":"string"}
+							},
+							"required":["root_choice","internal_secret"],
+							"dependentRequired":{"root_choice":["internal_secret"]},
+							"patternProperties":{"^x-secret$":{"description":"internal tunnel token"}},
+							"$defs":{"internal_secret":{"description":"internal tunnel token"}},
+							"oneOf":[
+								{"type":"object","properties":{"mcp_name":{"type":"string"},"internal_secret":{"type":"string"}},"required":["mcp_name"]},
+								{"properties":{"ref":{"type":"string"},"x-secret":{"type":"string"}},"required":["ref","x-secret"]}
+							],
+							"anyOf":[
+								{"properties":{"optional":{"type":"string"}},"required":["optional"]}
+							]
+						}`),
+						Parameters: []catalog.CatalogParameter{
+							{Name: "root_choice", Type: "string", Required: true},
+							{Name: "internal_secret", WireName: "x-secret", Type: "string", Description: "internal tunnel token", Required: true, Internal: true},
+						},
+					},
+					{
+						ID:          "bad_schema",
+						Title:       "Bad schema",
+						Description: "Falls back to public parameter metadata",
+						InputSchema: json.RawMessage(`"not an object"`),
+						Parameters: []catalog.CatalogParameter{
+							{Name: "visible_query", Type: "string", Description: "Visible query", Required: true},
+							{Name: "private_header", WireName: "X-Private-Header", Type: "string", Description: "private header value", Required: true, Internal: true},
+						},
+					},
+					{
+						ID:          "conflict_schema",
+						Title:       "Conflict schema",
+						Description: "Falls back when merged branches disagree",
+						InputSchema: json.RawMessage(`{
+							"allOf":[
+								{"properties":{"same":{"type":"integer"}}}
+							],
+							"properties":{"local":{"type":"string"},"same":{"type":"string"}}
+						}`),
+						Parameters: []catalog.CatalogParameter{
+							{Name: "fallback_query", Type: "string", Description: "Fallback query", Required: true},
+							{Name: "private_conflict", Type: "string", Description: "private conflict value", Internal: true},
+						},
+					},
+					{
+						ID:          "hidden_admin",
+						Title:       "Hidden admin",
+						Description: "Hidden exact-grant operation",
+						Visible:     &hidden,
+						InputSchema: json.RawMessage(`{
+							"type":"object",
+							"properties":{"public_action":{"type":"string"},"internal_admin":{"type":"string"}},
+							"required":["public_action","internal_admin"]
+						}`),
+						Parameters: []catalog.CatalogParameter{
+							{Name: "public_action", Type: "string", Required: true},
+							{Name: "internal_admin", Type: "string", Description: "admin-only token", Required: true, Internal: true},
+						},
+					},
+					{
+						ID:    "empty_schema",
+						Title: "Empty schema",
+					},
+				},
+			},
+		},
+	}
+	manager := newTestManager(t, Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	refs := []coreagent.ToolRef{
+		{Plugin: "planner", Operation: "choose_target"},
+		{Plugin: "planner", Operation: "bad_schema"},
+		{Plugin: "planner", Operation: "conflict_schema"},
+		{Plugin: "planner", Operation: "hidden_admin"},
+	}
+
+	listed, err := manager.ListTools(context.Background(), p, coreagent.ListToolsRequest{
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+		ToolRefs:   refs,
+		PageSize:   10,
+	})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(listed.Tools) != len(refs) {
+		t.Fatalf("ListTools returned %d tools, want %d: %#v", len(listed.Tools), len(refs), listed.Tools)
+	}
+
+	choose := requireListedOperation(t, listed.Tools, "choose_target")
+	chooseSchema := mustDecodeAgentToolSchema(t, choose.InputSchemaJSON)
+	requireAgentToolSchemaProperties(t, chooseSchema, "root_choice", "public_body", "mcp_name", "ref", "optional")
+	requireAgentToolSchemaMissingProperties(t, chooseSchema, "internal_secret", "x-secret")
+	requireAgentToolSchemaMissingKeys(t, chooseSchema, "oneOf", "anyOf", "allOf", "dependentRequired", "patternProperties", "$defs")
+	requireAgentToolSchemaRequired(t, chooseSchema, "root_choice")
+	requireAgentToolSchemaJSONOmits(t, chooseSchema, "internal_secret", "x-secret", "internal tunnel token", "$ref", "internal_secret_provider")
+	requireSearchTextOmits(t, choose.SearchText, "internal_secret", "x-secret", "internal tunnel token", "internal_secret_provider")
+
+	bad := requireListedOperation(t, listed.Tools, "bad_schema")
+	badSchema := mustDecodeAgentToolSchema(t, bad.InputSchemaJSON)
+	requireAgentToolSchemaProperties(t, badSchema, "visible_query")
+	requireAgentToolSchemaMissingProperties(t, badSchema, "private_header", "X-Private-Header")
+	requireAgentToolSchemaRequired(t, badSchema, "visible_query")
+	requireSearchTextOmits(t, bad.SearchText, "private_header", "X-Private-Header", "private header value")
+
+	conflict := requireListedOperation(t, listed.Tools, "conflict_schema")
+	conflictSchema := mustDecodeAgentToolSchema(t, conflict.InputSchemaJSON)
+	requireAgentToolSchemaProperties(t, conflictSchema, "fallback_query")
+	requireAgentToolSchemaMissingProperties(t, conflictSchema, "local", "same", "private_conflict")
+	requireAgentToolSchemaRequired(t, conflictSchema, "fallback_query")
+
+	hiddenTool := requireListedOperation(t, listed.Tools, "hidden_admin")
+	if !hiddenTool.Hidden {
+		t.Fatal("hidden exact operation was not marked hidden")
+	}
+	hiddenSchema := mustDecodeAgentToolSchema(t, hiddenTool.InputSchemaJSON)
+	requireAgentToolSchemaProperties(t, hiddenSchema, "public_action")
+	requireAgentToolSchemaMissingProperties(t, hiddenSchema, "internal_admin")
+	requireAgentToolSchemaRequired(t, hiddenSchema, "public_action")
+	requireSearchTextOmits(t, hiddenTool.SearchText, "internal_admin", "admin-only token")
+
+	resolved, err := manager.ResolveTools(context.Background(), p, coreagent.ResolveToolsRequest{
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+		ToolRefs: []coreagent.ToolRef{
+			{Plugin: "planner", Operation: "bad_schema"},
+			{Plugin: "planner", Operation: "empty_schema"},
+			{Plugin: "planner", Operation: "hidden_admin"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTools: %v", err)
+	}
+	badResolved := requireResolvedOperation(t, resolved, "bad_schema")
+	requireAgentToolSchemaProperties(t, badResolved.ParametersSchema, "visible_query")
+	requireAgentToolSchemaMissingProperties(t, badResolved.ParametersSchema, "private_header", "X-Private-Header")
+	emptyResolved := requireResolvedOperation(t, resolved, "empty_schema")
+	if emptyResolved.ParametersSchema["type"] != "object" || emptyResolved.ParametersSchema["additionalProperties"] != true {
+		t.Fatalf("empty resolved schema = %#v, want permissive object", emptyResolved.ParametersSchema)
+	}
+	hiddenResolved := requireResolvedOperation(t, resolved, "hidden_admin")
+	requireAgentToolSchemaProperties(t, hiddenResolved.ParametersSchema, "public_action")
+	requireAgentToolSchemaMissingProperties(t, hiddenResolved.ParametersSchema, "internal_admin")
+}
+
+func TestManagerProjectsWorkflowSystemToolSchemas(t *testing.T) {
+	t.Parallel()
+
+	ref := coreagent.ToolRef{System: coreagent.SystemToolWorkflow, Operation: "schedules.update"}
+	workflowTools := projectionWorkflowSystemTools{
+		tools: map[string]coreagent.Tool{
+			ref.Operation: {
+				Name:        "Update schedule",
+				Description: "Update a workflow schedule",
+				ParametersSchema: map[string]any{
+					"allOf": []any{
+						map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"scheduleId": map[string]any{"type": "string"},
+							},
+							"required": []any{"scheduleId"},
+						},
+						map[string]any{
+							"properties": map[string]any{
+								"cron": map[string]any{"type": "string"},
+							},
+							"required": []any{"cron"},
+						},
+					},
+				},
+				Target: coreagent.ToolTarget{System: ref.System, Operation: ref.Operation},
+			},
+		},
+	}
+	provider := agentCatalogTestProvider("docs", "Docs")
+	manager := newTestManager(t, Config{
+		Providers:     testutil.NewProviderRegistry(t, provider),
+		WorkflowTools: workflowTools,
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	listed, err := manager.ListTools(context.Background(), p, coreagent.ListToolsRequest{
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+		ToolRefs:   []coreagent.ToolRef{ref},
+	})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(listed.Tools) != 1 {
+		t.Fatalf("ListTools returned %d tools, want one", len(listed.Tools))
+	}
+	listedSchema := mustDecodeAgentToolSchema(t, listed.Tools[0].InputSchemaJSON)
+	requireAgentToolSchemaProperties(t, listedSchema, "scheduleId", "cron")
+	requireAgentToolSchemaRequired(t, listedSchema, "cron", "scheduleId")
+	requireAgentToolSchemaMissingKeys(t, listedSchema, "allOf", "oneOf", "anyOf")
+
+	resolved, err := manager.ResolveTools(context.Background(), p, coreagent.ResolveToolsRequest{
+		ToolSource: coreagent.ToolSourceModeMCPCatalog,
+		ToolRefs:   []coreagent.ToolRef{ref},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTools: %v", err)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("ResolveTools returned %d tools, want one", len(resolved))
+	}
+	requireAgentToolSchemaProperties(t, resolved[0].ParametersSchema, "scheduleId", "cron")
+	requireAgentToolSchemaRequired(t, resolved[0].ParametersSchema, "cron", "scheduleId")
+	requireAgentToolSchemaMissingKeys(t, resolved[0].ParametersSchema, "allOf", "oneOf", "anyOf")
+
+	one, err := manager.ResolveTool(context.Background(), p, ref)
+	if err != nil {
+		t.Fatalf("ResolveTool: %v", err)
+	}
+	requireAgentToolSchemaProperties(t, one.ParametersSchema, "scheduleId", "cron")
+	requireAgentToolSchemaRequired(t, one.ParametersSchema, "cron", "scheduleId")
+	requireAgentToolSchemaMissingKeys(t, one.ParametersSchema, "allOf", "oneOf", "anyOf")
+}
+
+type projectionWorkflowSystemTools struct {
+	tools map[string]coreagent.Tool
+}
+
+func (t projectionWorkflowSystemTools) Available() bool {
+	return true
+}
+
+func (t projectionWorkflowSystemTools) ResolveTool(_ context.Context, _ *principal.Principal, ref coreagent.ToolRef) (coreagent.Tool, error) {
+	tool, ok := t.tools[strings.TrimSpace(ref.Operation)]
+	if !ok {
+		return coreagent.Tool{}, fmt.Errorf("%w: %s", invocation.ErrOperationNotFound, ref.Operation)
+	}
+	tool.Target = coreagent.ToolTarget{System: strings.TrimSpace(ref.System), Operation: strings.TrimSpace(ref.Operation)}
+	return tool, nil
+}
+
+func (t projectionWorkflowSystemTools) ResolveTools(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef) ([]coreagent.Tool, error) {
+	out := make([]coreagent.Tool, 0, len(refs))
+	for _, ref := range refs {
+		tool, err := t.ResolveTool(ctx, p, ref)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, tool)
+	}
+	return out, nil
+}
+
+func (t projectionWorkflowSystemTools) AllowTool(context.Context, *principal.Principal, coreagent.Tool) bool {
+	return true
+}
+
+func requireListedOperation(t *testing.T, tools []coreagent.ListedTool, operation string) coreagent.ListedTool {
+	t.Helper()
+	for _, tool := range tools {
+		if tool.Ref.Operation == operation {
+			return tool
+		}
+	}
+	t.Fatalf("listed tools missing operation %q: %#v", operation, tools)
+	return coreagent.ListedTool{}
+}
+
+func requireResolvedOperation(t *testing.T, tools []coreagent.Tool, operation string) coreagent.Tool {
+	t.Helper()
+	for _, tool := range tools {
+		if tool.Target.Operation == operation {
+			return tool
+		}
+	}
+	t.Fatalf("resolved tools missing operation %q: %#v", operation, tools)
+	return coreagent.Tool{}
+}
+
+func mustDecodeAgentToolSchema(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(raw), &schema); err != nil {
+		t.Fatalf("decode schema %q: %v", raw, err)
+	}
+	return schema
+}
+
+func requireAgentToolSchemaProperties(t *testing.T, schema map[string]any, names ...string) {
+	t.Helper()
+	properties := agentToolSchemaPropertiesForTest(t, schema)
+	for _, name := range names {
+		if _, ok := properties[name]; !ok {
+			t.Fatalf("schema properties = %#v, missing %q", properties, name)
+		}
+	}
+}
+
+func requireAgentToolSchemaMissingProperties(t *testing.T, schema map[string]any, names ...string) {
+	t.Helper()
+	properties := agentToolSchemaPropertiesForTest(t, schema)
+	for _, name := range names {
+		if _, ok := properties[name]; ok {
+			t.Fatalf("schema properties = %#v, unexpectedly contained %q", properties, name)
+		}
+	}
+}
+
+func requireAgentToolSchemaMissingKeys(t *testing.T, schema map[string]any, keys ...string) {
+	t.Helper()
+	for _, key := range keys {
+		if _, ok := schema[key]; ok {
+			t.Fatalf("schema = %#v, unexpectedly contained key %q", schema, key)
+		}
+	}
+}
+
+func requireAgentToolSchemaJSONOmits(t *testing.T, schema map[string]any, values ...string) {
+	t.Helper()
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	text := string(raw)
+	for _, value := range values {
+		if strings.Contains(text, value) {
+			t.Fatalf("schema JSON %q unexpectedly contained %q", text, value)
+		}
+	}
+}
+
+func requireAgentToolSchemaRequired(t *testing.T, schema map[string]any, names ...string) {
+	t.Helper()
+	got := map[string]struct{}{}
+	switch required := schema["required"].(type) {
+	case []any:
+		for _, item := range required {
+			if name, ok := item.(string); ok {
+				got[name] = struct{}{}
+			}
+		}
+	case []string:
+		for _, name := range required {
+			got[name] = struct{}{}
+		}
+	case nil:
+	default:
+		t.Fatalf("schema required = %#v, want array", schema["required"])
+	}
+	want := map[string]struct{}{}
+	for _, name := range names {
+		want[name] = struct{}{}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("schema required = %#v, want %#v", got, want)
+	}
+}
+
+func requireSearchTextOmits(t *testing.T, searchText string, values ...string) {
+	t.Helper()
+	for _, value := range values {
+		needle := agentToolSearchText(value)
+		if needle == "" {
+			needle = value
+		}
+		if strings.Contains(searchText, needle) {
+			t.Fatalf("search text %q unexpectedly contained %q", searchText, value)
+		}
+	}
+}
+
+func agentToolSchemaPropertiesForTest(t *testing.T, schema map[string]any) map[string]any {
+	t.Helper()
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema properties = %#v, want object", schema["properties"])
+	}
+	return properties
 }
 
 func TestAgentToolTargetKeyIncludesFullRunAsSubject(t *testing.T) {


### PR DESCRIPTION
## Summary

Project agent-facing tool schemas at the AgentManager boundary while leaving canonical catalog schemas unchanged.

- Project plugin catalog tool schemas before returning `ListedTool.InputSchemaJSON` and before resolving direct `coreagent.Tool.ParametersSchema`.
- Project workflow/system tool schemas on both list and resolve paths.
- Strip internal `CatalogParameter` names, wire names, and descriptions from returned schema/search metadata.
- Collapse top-level `oneOf`/`anyOf`/`allOf` into provider-safe object schemas, with fallback to public synthesized parameters or a permissive object when projection is unsafe.
- Keep hidden exact-granted operations available, but with projected agent-facing schemas.

## Interface / behavior notes

No protobuf or SDK interface changes are required. Existing surfaces are used:

- `coreagent.ListedTool.InputSchemaJSON`
- `coreagent.ListedTool.SearchText`
- `coreagent.Tool.ParametersSchema`
- existing `ToolRef`/`ToolSourceModeMCPCatalog` flows

The canonical provider catalog remains the source of truth for execution and search ranking. Projection only applies to schemas and metadata returned to agents/providers/UI list callers.

## Projection rules

- Internal catalog parameters are removed by parameter name and wire name.
- Returned `SearchText` uses a projected operation copy and does not include raw provider path/provider ID.
- Public property schemas are recursively scrubbed for internal names, wire names, descriptions, and unsupported nested reference/dependency keywords.
- `allOf` merges properties and unions required fields.
- `oneOf`/`anyOf` merge properties without unioning branch required fields.
- Conflicting branch/root property definitions fall back to synthesized public parameters or a permissive object.
- Empty direct schemas resolve to a permissive object schema.

## Verification

- `go test ./services/agents/agentmanager -run 'TestManagerProjects'`
- `go test ./services/agents/... ./internal/bootstrap`
- Review agent re-review found no remaining focused correctness issues.
