### PR TITLE
Hide protobuf timestamp and empty helpers behind SDK boundaries

### DIFF
--- a/docs/content/custom-providers/external-credentials.mdx
+++ b/docs/content/custom-providers/external-credentials.mdx
@@ -47,9 +47,9 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
-	gproto "google.golang.org/protobuf/proto"
 )
 
 type Provider struct {
@@ -78,9 +78,9 @@ func (p *Provider) UpsertCredential(
 		return nil, fmt.Errorf("credential is required")
 	}
 
-	value := gproto.Clone(credential).(*gestalt.ExternalCredential)
+	value := cloneCredential(credential)
 	if value.GetId() == "" {
-		value.Id = value.GetSubjectId() + ":" + value.GetConnectionId() + ":" + value.GetInstance()
+		value.ID = value.GetSubjectId() + ":" + value.GetConnectionId() + ":" + value.GetInstance()
 	}
 
 	p.mu.Lock()
@@ -89,7 +89,7 @@ func (p *Provider) UpsertCredential(
 	key := lookupKey(value.GetSubjectId(), value.GetConnectionId(), value.GetInstance())
 	p.credentials[key] = value
 	p.lookupByID[value.GetId()] = key
-	return gproto.Clone(value).(*gestalt.ExternalCredential), nil
+	return cloneCredential(value), nil
 }
 
 func (p *Provider) GetCredential(
@@ -112,7 +112,7 @@ func (p *Provider) GetCredential(
 	if !ok {
 		return nil, gestalt.ErrExternalCredentialNotFound
 	}
-	return gproto.Clone(credential).(*gestalt.ExternalCredential), nil
+	return cloneCredential(credential), nil
 }
 
 func (p *Provider) ListCredentials(
@@ -135,7 +135,7 @@ func (p *Provider) ListCredentials(
 		}
 		response.Credentials = append(
 			response.Credentials,
-			gproto.Clone(credential).(*gestalt.ExternalCredential),
+			cloneCredential(credential),
 		)
 	}
 	return response, nil
@@ -170,8 +170,8 @@ func (p *Provider) ResolveCredential(
 ) (*gestalt.ResolveExternalCredentialResponse, error) {
 	credential, err := p.GetCredential(ctx, &gestalt.GetExternalCredentialRequest{
 		Lookup: &gestalt.ExternalCredentialLookup{
-			SubjectId:    req.GetCredentialSubjectId(),
-			ConnectionId: req.GetConnectionId(),
+			SubjectID:    req.GetCredentialSubjectId(),
+			ConnectionID: req.GetConnectionId(),
 			Instance:     req.GetInstance(),
 		},
 	})
@@ -195,6 +195,26 @@ func (p *Provider) ExchangeCredential(
 
 func lookupKey(subjectID, connectionID, instance string) string {
 	return subjectID + "\x00" + connectionID + "\x00" + instance
+}
+
+func cloneCredential(in *gestalt.ExternalCredential) *gestalt.ExternalCredential {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.ExpiresAt = cloneTime(in.ExpiresAt)
+	out.LastRefreshedAt = cloneTime(in.LastRefreshedAt)
+	out.CreatedAt = cloneTime(in.CreatedAt)
+	out.UpdatedAt = cloneTime(in.UpdatedAt)
+	return &out
+}
+
+func cloneTime(in *time.Time) *time.Time {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 ```
 

--- a/docs/content/reference/sdk/go.mdx
+++ b/docs/content/reference/sdk/go.mdx
@@ -98,10 +98,10 @@ The same module includes host-service clients such as `CacheClient`,
 `ExternalCredentialClient`, `RuntimeLogHostClient`, and `InvokerClient`.
 
 `AgentHostClient` exposes plain Go helpers named `ListToolsForTurn`,
-`ExecuteToolForTurn`, and `ResolveConnectionForTurn`. Use `StructFromMap`,
-`StructFromAny`, `ValueFromAny`, `ValuesFromMap`, `TimestampFromTime`,
-`TimestampFromTimePtr`, and the matching map/time clone helpers for protobuf
-well-known type conversions. The `gen/v1` subpackage re-exports selected
+`ExecuteToolForTurn`, and `ResolveConnectionForTurn`. Workflow and external
+credential helpers accept native `time.Time` values, pointers, maps, structs,
+and slices; provider code should not need protobuf timestamp or empty-message
+constructors for normal authoring. The `gen/v1` subpackage re-exports selected
 generated bindings for transport fixtures, and the IndexedDB codec helpers
 convert records, keys, and typed values without importing internal packages.
 
@@ -127,8 +127,8 @@ func connectedInstances(ctx context.Context, subjectID, connectionID string) ([]
 	defer credentials.Close()
 
 	resp, err := credentials.ListCredentials(ctx, &gestalt.ListExternalCredentialsRequest{
-		SubjectId:    subjectID,
-		ConnectionId: connectionID,
+		SubjectID:    subjectID,
+		ConnectionID: connectionID,
 	})
 	if err != nil {
 		return nil, err

--- a/gestaltd/internal/testutil/sdkplugin.go
+++ b/gestaltd/internal/testutil/sdkplugin.go
@@ -438,9 +438,9 @@ import (
 	"os"
 	"sort"
 	"sync"
+	"time"
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type Provider struct {
@@ -479,26 +479,26 @@ func (p *Provider) UpsertCredential(ctx context.Context, req *gestalt.UpsertExte
 
 	value := cloneExternalCredential(req.GetCredential())
 	key := externalCredentialLookupKey(value.GetSubjectId(), value.GetConnectionId(), value.GetInstance())
-	now := timestamppb.Now()
+	now := time.Now().UTC()
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	if existing := p.credentials[key]; existing != nil {
-		value.Id = existing.GetId()
+		value.ID = existing.GetId()
 		if value.GetCreatedAt() == nil {
-			value.CreatedAt = existing.GetCreatedAt()
+			value.CreatedAt = cloneTime(existing.GetCreatedAt())
 		}
 	} else {
 		if value.GetId() == "" {
-			value.Id = "cred-" + value.GetConnectionId() + "-" + value.GetInstance()
+			value.ID = "cred-" + value.GetConnectionId() + "-" + value.GetInstance()
 		}
 		if value.GetCreatedAt() == nil {
-			value.CreatedAt = now
+			value.CreatedAt = timePtr(now)
 		}
 	}
 	if value.GetUpdatedAt() == nil {
-		value.UpdatedAt = now
+		value.UpdatedAt = timePtr(now)
 	}
 
 	p.credentials[key] = cloneExternalCredential(value)
@@ -628,7 +628,7 @@ func (p *Provider) ResolveCredential(ctx context.Context, req *gestalt.ResolveEx
 	return &gestalt.ResolveExternalCredentialResponse{
 		Token:        credential.GetAccessToken(),
 		ExpiresAt:    credential.GetExpiresAt(),
-		MetadataJson: credential.GetMetadataJson(),
+		MetadataJSON: credential.GetMetadataJson(),
 		Credential:   cloneExternalCredential(credential),
 	}, nil
 }
@@ -650,6 +650,22 @@ func (p *Provider) ExchangeCredential(ctx context.Context, req *gestalt.Exchange
 }
 
 func cloneExternalCredential(src *gestalt.ExternalCredential) *gestalt.ExternalCredential {
+	if src == nil {
+		return nil
+	}
+	value := *src
+	value.ExpiresAt = cloneTime(src.ExpiresAt)
+	value.LastRefreshedAt = cloneTime(src.LastRefreshedAt)
+	value.CreatedAt = cloneTime(src.CreatedAt)
+	value.UpdatedAt = cloneTime(src.UpdatedAt)
+	return &value
+}
+
+func timePtr(value time.Time) *time.Time {
+	return &value
+}
+
+func cloneTime(src *time.Time) *time.Time {
 	if src == nil {
 		return nil
 	}

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -68,14 +68,13 @@
 // ListToolsForTurn, and ResolveConnectionForTurn. For lower-level fixtures and
 // interoperability tests, package gen/v1 re-exports selected generated
 // protobuf bindings. SDK constructors such as NewBoundWorkflowRun,
-// NewWorkflowSignal, and NewAuthorizationModelRef accept native time.Time
-// values and JSON-compatible maps or structs, so provider code can keep
-// protobuf timestamp and Struct conversion at the SDK boundary. SetTime and
-// SetOptionalTime accept native time.Time values when provider code needs to
-// update existing generated messages in place. StructFromMap, StructFromAny,
-// ValueFromAny, ValuesFromMap, TimestampFromTime, TimestampFromTimePtr, and the
-// IndexedDB codec helpers remain available for lower-level interop and tests.
-// Empty, Struct, Value, Timestamp, ProtoMessage, MarshalProtoDeterministic,
+// NewWorkflowSignal, NewAuthorizationModelRef, and the external credential
+// request/response structs accept native time.Time values and JSON-compatible
+// maps or structs, so provider code can keep protobuf timestamp and Struct
+// conversion at the SDK boundary. StructFromMap, StructFromAny, ValueFromAny,
+// ValuesFromMap, TimestampFromTime, TimestampFromTimePtr, and the IndexedDB
+// codec helpers remain available for lower-level interop and transport tests.
+// Struct, Value, Timestamp, ProtoMessage, MarshalProtoDeterministic,
 // UnmarshalProto, MarshalProtoJSON, and UnmarshalProtoJSON are thin aliases or
 // wrappers for RPC and persistence boundaries that still need protocol-shaped
 // values.

--- a/sdk/go/external_credential.go
+++ b/sdk/go/external_credential.go
@@ -2,46 +2,732 @@ package gestalt
 
 import (
 	"context"
-
-	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
+	"time"
 )
 
-// ExternalCredential is the generated credential record stored by the host.
-type ExternalCredential = proto.ExternalCredential
+// ExternalCredential is the credential record stored by the host.
+type ExternalCredential struct {
+	ID                string
+	SubjectID         string
+	Instance          string
+	AccessToken       string
+	RefreshToken      string
+	Scopes            string
+	ExpiresAt         *time.Time
+	LastRefreshedAt   *time.Time
+	RefreshErrorCount int32
+	MetadataJSON      string
+	CreatedAt         *time.Time
+	UpdatedAt         *time.Time
+	ConnectionID      string
+}
 
 // ExternalCredentialLookup selects a host-managed external credential.
-type ExternalCredentialLookup = proto.ExternalCredentialLookup
+type ExternalCredentialLookup struct {
+	SubjectID    string
+	Instance     string
+	ConnectionID string
+}
 
 // UpsertExternalCredentialRequest is the request for creating or updating a credential.
-type UpsertExternalCredentialRequest = proto.UpsertExternalCredentialRequest
+type UpsertExternalCredentialRequest struct {
+	Credential         *ExternalCredential
+	PreserveTimestamps bool
+}
 
 // GetExternalCredentialRequest is the request for fetching one credential.
-type GetExternalCredentialRequest = proto.GetExternalCredentialRequest
+type GetExternalCredentialRequest struct {
+	Lookup *ExternalCredentialLookup
+}
 
 // ListExternalCredentialsRequest is the request for listing credentials.
-type ListExternalCredentialsRequest = proto.ListExternalCredentialsRequest
+type ListExternalCredentialsRequest struct {
+	SubjectID    string
+	Instance     string
+	ConnectionID string
+}
 
 // ListExternalCredentialsResponse is the response returned when listing credentials.
-type ListExternalCredentialsResponse = proto.ListExternalCredentialsResponse
+type ListExternalCredentialsResponse struct {
+	Credentials []*ExternalCredential
+}
 
 // DeleteExternalCredentialRequest is the request for deleting one credential.
-type DeleteExternalCredentialRequest = proto.DeleteExternalCredentialRequest
+type DeleteExternalCredentialRequest struct {
+	ID string
+}
 
-type ExternalCredentialTokenExchangeDriver = proto.ExternalCredentialTokenExchangeDriver
+type ExternalCredentialTokenExchangeDriver struct {
+	Type            string
+	TargetPrincipal string
+	Scopes          []string
+	LifetimeSeconds int32
+	Endpoint        string
+	Params          map[string]string
+}
 
-type ExternalCredentialAuthConfig = proto.ExternalCredentialAuthConfig
+type ExternalCredentialAuthConfig struct {
+	Type                 string
+	Token                string
+	TokenPrefix          string
+	GrantType            string
+	TokenURL             string
+	ClientID             string
+	ClientSecret         string
+	ClientAuth           string
+	TokenExchange        string
+	Scopes               []string
+	ScopeParam           string
+	ScopeSeparator       string
+	TokenParams          map[string]string
+	RefreshParams        map[string]string
+	AcceptHeader         string
+	AccessTokenPath      string
+	TokenExchangeDrivers []*ExternalCredentialTokenExchangeDriver
+	RefreshToken         string
+}
 
-type ValidateExternalCredentialConfigRequest = proto.ValidateExternalCredentialConfigRequest
+type ValidateExternalCredentialConfigRequest struct {
+	Provider         string
+	Connection       string
+	ConnectionID     string
+	Mode             string
+	Auth             *ExternalCredentialAuthConfig
+	ConnectionParams map[string]string
+}
 
-type ResolveExternalCredentialRequest = proto.ResolveExternalCredentialRequest
+type ResolveExternalCredentialRequest struct {
+	Provider            string
+	Connection          string
+	ConnectionID        string
+	Mode                string
+	CredentialSubjectID string
+	ActorSubjectID      string
+	Instance            string
+	Auth                *ExternalCredentialAuthConfig
+	ConnectionParams    map[string]string
+}
 
-type ResolveExternalCredentialResponse = proto.ResolveExternalCredentialResponse
+type ResolveExternalCredentialResponse struct {
+	Token        string
+	ExpiresAt    *time.Time
+	MetadataJSON string
+	Params       map[string]string
+	Credential   *ExternalCredential
+}
 
-type ExternalCredentialTokenResponse = proto.ExternalCredentialTokenResponse
+type ExternalCredentialTokenResponse struct {
+	AccessToken   string
+	RefreshToken  string
+	ExpiresIn     int32
+	TokenType     string
+	ExtraJSON     string
+	RefreshSource string
+}
 
-type ExchangeExternalCredentialRequest = proto.ExchangeExternalCredentialRequest
+type ExchangeExternalCredentialRequest struct {
+	Provider            string
+	Connection          string
+	ConnectionID        string
+	CredentialSubjectID string
+	ActorSubjectID      string
+	Instance            string
+	Auth                *ExternalCredentialAuthConfig
+	CredentialJSON      string
+	ConnectionParams    map[string]string
+}
 
-type ExchangeExternalCredentialResponse = proto.ExchangeExternalCredentialResponse
+type ExchangeExternalCredentialResponse struct {
+	TokenResponse *ExternalCredentialTokenResponse
+}
+
+func (c *ExternalCredential) GetId() string {
+	if c == nil {
+		return ""
+	}
+	return c.ID
+}
+
+func (c *ExternalCredential) GetSubjectId() string {
+	if c == nil {
+		return ""
+	}
+	return c.SubjectID
+}
+
+func (c *ExternalCredential) GetInstance() string {
+	if c == nil {
+		return ""
+	}
+	return c.Instance
+}
+
+func (c *ExternalCredential) GetAccessToken() string {
+	if c == nil {
+		return ""
+	}
+	return c.AccessToken
+}
+
+func (c *ExternalCredential) GetRefreshToken() string {
+	if c == nil {
+		return ""
+	}
+	return c.RefreshToken
+}
+
+func (c *ExternalCredential) GetScopes() string {
+	if c == nil {
+		return ""
+	}
+	return c.Scopes
+}
+
+func (c *ExternalCredential) GetExpiresAt() *time.Time {
+	if c == nil {
+		return nil
+	}
+	return c.ExpiresAt
+}
+
+func (c *ExternalCredential) GetLastRefreshedAt() *time.Time {
+	if c == nil {
+		return nil
+	}
+	return c.LastRefreshedAt
+}
+
+func (c *ExternalCredential) GetRefreshErrorCount() int32 {
+	if c == nil {
+		return 0
+	}
+	return c.RefreshErrorCount
+}
+
+func (c *ExternalCredential) GetMetadataJson() string {
+	if c == nil {
+		return ""
+	}
+	return c.MetadataJSON
+}
+
+func (c *ExternalCredential) GetCreatedAt() *time.Time {
+	if c == nil {
+		return nil
+	}
+	return c.CreatedAt
+}
+
+func (c *ExternalCredential) GetUpdatedAt() *time.Time {
+	if c == nil {
+		return nil
+	}
+	return c.UpdatedAt
+}
+
+func (c *ExternalCredential) GetConnectionId() string {
+	if c == nil {
+		return ""
+	}
+	return c.ConnectionID
+}
+
+func (l *ExternalCredentialLookup) GetSubjectId() string {
+	if l == nil {
+		return ""
+	}
+	return l.SubjectID
+}
+
+func (l *ExternalCredentialLookup) GetInstance() string {
+	if l == nil {
+		return ""
+	}
+	return l.Instance
+}
+
+func (l *ExternalCredentialLookup) GetConnectionId() string {
+	if l == nil {
+		return ""
+	}
+	return l.ConnectionID
+}
+
+func (r *UpsertExternalCredentialRequest) GetCredential() *ExternalCredential {
+	if r == nil {
+		return nil
+	}
+	return r.Credential
+}
+
+func (r *UpsertExternalCredentialRequest) GetPreserveTimestamps() bool {
+	if r == nil {
+		return false
+	}
+	return r.PreserveTimestamps
+}
+
+func (r *GetExternalCredentialRequest) GetLookup() *ExternalCredentialLookup {
+	if r == nil {
+		return nil
+	}
+	return r.Lookup
+}
+
+func (r *ListExternalCredentialsRequest) GetSubjectId() string {
+	if r == nil {
+		return ""
+	}
+	return r.SubjectID
+}
+
+func (r *ListExternalCredentialsRequest) GetInstance() string {
+	if r == nil {
+		return ""
+	}
+	return r.Instance
+}
+
+func (r *ListExternalCredentialsRequest) GetConnectionId() string {
+	if r == nil {
+		return ""
+	}
+	return r.ConnectionID
+}
+
+func (r *ListExternalCredentialsResponse) GetCredentials() []*ExternalCredential {
+	if r == nil {
+		return nil
+	}
+	return r.Credentials
+}
+
+func (r *DeleteExternalCredentialRequest) GetId() string {
+	if r == nil {
+		return ""
+	}
+	return r.ID
+}
+
+func (d *ExternalCredentialTokenExchangeDriver) GetType() string {
+	if d == nil {
+		return ""
+	}
+	return d.Type
+}
+
+func (d *ExternalCredentialTokenExchangeDriver) GetTargetPrincipal() string {
+	if d == nil {
+		return ""
+	}
+	return d.TargetPrincipal
+}
+
+func (d *ExternalCredentialTokenExchangeDriver) GetScopes() []string {
+	if d == nil {
+		return nil
+	}
+	return d.Scopes
+}
+
+func (d *ExternalCredentialTokenExchangeDriver) GetLifetimeSeconds() int32 {
+	if d == nil {
+		return 0
+	}
+	return d.LifetimeSeconds
+}
+
+func (d *ExternalCredentialTokenExchangeDriver) GetEndpoint() string {
+	if d == nil {
+		return ""
+	}
+	return d.Endpoint
+}
+
+func (d *ExternalCredentialTokenExchangeDriver) GetParams() map[string]string {
+	if d == nil {
+		return nil
+	}
+	return d.Params
+}
+
+func (a *ExternalCredentialAuthConfig) GetType() string {
+	if a == nil {
+		return ""
+	}
+	return a.Type
+}
+
+func (a *ExternalCredentialAuthConfig) GetToken() string {
+	if a == nil {
+		return ""
+	}
+	return a.Token
+}
+
+func (a *ExternalCredentialAuthConfig) GetTokenPrefix() string {
+	if a == nil {
+		return ""
+	}
+	return a.TokenPrefix
+}
+
+func (a *ExternalCredentialAuthConfig) GetGrantType() string {
+	if a == nil {
+		return ""
+	}
+	return a.GrantType
+}
+
+func (a *ExternalCredentialAuthConfig) GetTokenUrl() string {
+	if a == nil {
+		return ""
+	}
+	return a.TokenURL
+}
+
+func (a *ExternalCredentialAuthConfig) GetClientId() string {
+	if a == nil {
+		return ""
+	}
+	return a.ClientID
+}
+
+func (a *ExternalCredentialAuthConfig) GetClientSecret() string {
+	if a == nil {
+		return ""
+	}
+	return a.ClientSecret
+}
+
+func (a *ExternalCredentialAuthConfig) GetClientAuth() string {
+	if a == nil {
+		return ""
+	}
+	return a.ClientAuth
+}
+
+func (a *ExternalCredentialAuthConfig) GetTokenExchange() string {
+	if a == nil {
+		return ""
+	}
+	return a.TokenExchange
+}
+
+func (a *ExternalCredentialAuthConfig) GetScopes() []string {
+	if a == nil {
+		return nil
+	}
+	return a.Scopes
+}
+
+func (a *ExternalCredentialAuthConfig) GetScopeParam() string {
+	if a == nil {
+		return ""
+	}
+	return a.ScopeParam
+}
+
+func (a *ExternalCredentialAuthConfig) GetScopeSeparator() string {
+	if a == nil {
+		return ""
+	}
+	return a.ScopeSeparator
+}
+
+func (a *ExternalCredentialAuthConfig) GetTokenParams() map[string]string {
+	if a == nil {
+		return nil
+	}
+	return a.TokenParams
+}
+
+func (a *ExternalCredentialAuthConfig) GetRefreshParams() map[string]string {
+	if a == nil {
+		return nil
+	}
+	return a.RefreshParams
+}
+
+func (a *ExternalCredentialAuthConfig) GetAcceptHeader() string {
+	if a == nil {
+		return ""
+	}
+	return a.AcceptHeader
+}
+
+func (a *ExternalCredentialAuthConfig) GetAccessTokenPath() string {
+	if a == nil {
+		return ""
+	}
+	return a.AccessTokenPath
+}
+
+func (a *ExternalCredentialAuthConfig) GetTokenExchangeDrivers() []*ExternalCredentialTokenExchangeDriver {
+	if a == nil {
+		return nil
+	}
+	return a.TokenExchangeDrivers
+}
+
+func (a *ExternalCredentialAuthConfig) GetRefreshToken() string {
+	if a == nil {
+		return ""
+	}
+	return a.RefreshToken
+}
+
+func (r *ValidateExternalCredentialConfigRequest) GetProvider() string {
+	if r == nil {
+		return ""
+	}
+	return r.Provider
+}
+
+func (r *ValidateExternalCredentialConfigRequest) GetConnection() string {
+	if r == nil {
+		return ""
+	}
+	return r.Connection
+}
+
+func (r *ValidateExternalCredentialConfigRequest) GetConnectionId() string {
+	if r == nil {
+		return ""
+	}
+	return r.ConnectionID
+}
+
+func (r *ValidateExternalCredentialConfigRequest) GetMode() string {
+	if r == nil {
+		return ""
+	}
+	return r.Mode
+}
+
+func (r *ValidateExternalCredentialConfigRequest) GetAuth() *ExternalCredentialAuthConfig {
+	if r == nil {
+		return nil
+	}
+	return r.Auth
+}
+
+func (r *ValidateExternalCredentialConfigRequest) GetConnectionParams() map[string]string {
+	if r == nil {
+		return nil
+	}
+	return r.ConnectionParams
+}
+
+func (r *ResolveExternalCredentialRequest) GetProvider() string {
+	if r == nil {
+		return ""
+	}
+	return r.Provider
+}
+
+func (r *ResolveExternalCredentialRequest) GetConnection() string {
+	if r == nil {
+		return ""
+	}
+	return r.Connection
+}
+
+func (r *ResolveExternalCredentialRequest) GetConnectionId() string {
+	if r == nil {
+		return ""
+	}
+	return r.ConnectionID
+}
+
+func (r *ResolveExternalCredentialRequest) GetMode() string {
+	if r == nil {
+		return ""
+	}
+	return r.Mode
+}
+
+func (r *ResolveExternalCredentialRequest) GetCredentialSubjectId() string {
+	if r == nil {
+		return ""
+	}
+	return r.CredentialSubjectID
+}
+
+func (r *ResolveExternalCredentialRequest) GetActorSubjectId() string {
+	if r == nil {
+		return ""
+	}
+	return r.ActorSubjectID
+}
+
+func (r *ResolveExternalCredentialRequest) GetInstance() string {
+	if r == nil {
+		return ""
+	}
+	return r.Instance
+}
+
+func (r *ResolveExternalCredentialRequest) GetAuth() *ExternalCredentialAuthConfig {
+	if r == nil {
+		return nil
+	}
+	return r.Auth
+}
+
+func (r *ResolveExternalCredentialRequest) GetConnectionParams() map[string]string {
+	if r == nil {
+		return nil
+	}
+	return r.ConnectionParams
+}
+
+func (r *ResolveExternalCredentialResponse) GetToken() string {
+	if r == nil {
+		return ""
+	}
+	return r.Token
+}
+
+func (r *ResolveExternalCredentialResponse) GetExpiresAt() *time.Time {
+	if r == nil {
+		return nil
+	}
+	return r.ExpiresAt
+}
+
+func (r *ResolveExternalCredentialResponse) GetMetadataJson() string {
+	if r == nil {
+		return ""
+	}
+	return r.MetadataJSON
+}
+
+func (r *ResolveExternalCredentialResponse) GetParams() map[string]string {
+	if r == nil {
+		return nil
+	}
+	return r.Params
+}
+
+func (r *ResolveExternalCredentialResponse) GetCredential() *ExternalCredential {
+	if r == nil {
+		return nil
+	}
+	return r.Credential
+}
+
+func (r *ExternalCredentialTokenResponse) GetAccessToken() string {
+	if r == nil {
+		return ""
+	}
+	return r.AccessToken
+}
+
+func (r *ExternalCredentialTokenResponse) GetRefreshToken() string {
+	if r == nil {
+		return ""
+	}
+	return r.RefreshToken
+}
+
+func (r *ExternalCredentialTokenResponse) GetExpiresIn() int32 {
+	if r == nil {
+		return 0
+	}
+	return r.ExpiresIn
+}
+
+func (r *ExternalCredentialTokenResponse) GetTokenType() string {
+	if r == nil {
+		return ""
+	}
+	return r.TokenType
+}
+
+func (r *ExternalCredentialTokenResponse) GetExtraJson() string {
+	if r == nil {
+		return ""
+	}
+	return r.ExtraJSON
+}
+
+func (r *ExternalCredentialTokenResponse) GetRefreshSource() string {
+	if r == nil {
+		return ""
+	}
+	return r.RefreshSource
+}
+
+func (r *ExchangeExternalCredentialRequest) GetProvider() string {
+	if r == nil {
+		return ""
+	}
+	return r.Provider
+}
+
+func (r *ExchangeExternalCredentialRequest) GetConnection() string {
+	if r == nil {
+		return ""
+	}
+	return r.Connection
+}
+
+func (r *ExchangeExternalCredentialRequest) GetConnectionId() string {
+	if r == nil {
+		return ""
+	}
+	return r.ConnectionID
+}
+
+func (r *ExchangeExternalCredentialRequest) GetCredentialSubjectId() string {
+	if r == nil {
+		return ""
+	}
+	return r.CredentialSubjectID
+}
+
+func (r *ExchangeExternalCredentialRequest) GetActorSubjectId() string {
+	if r == nil {
+		return ""
+	}
+	return r.ActorSubjectID
+}
+
+func (r *ExchangeExternalCredentialRequest) GetInstance() string {
+	if r == nil {
+		return ""
+	}
+	return r.Instance
+}
+
+func (r *ExchangeExternalCredentialRequest) GetAuth() *ExternalCredentialAuthConfig {
+	if r == nil {
+		return nil
+	}
+	return r.Auth
+}
+
+func (r *ExchangeExternalCredentialRequest) GetCredentialJson() string {
+	if r == nil {
+		return ""
+	}
+	return r.CredentialJSON
+}
+
+func (r *ExchangeExternalCredentialRequest) GetConnectionParams() map[string]string {
+	if r == nil {
+		return nil
+	}
+	return r.ConnectionParams
+}
+
+func (r *ExchangeExternalCredentialResponse) GetTokenResponse() *ExternalCredentialTokenResponse {
+	if r == nil {
+		return nil
+	}
+	return r.TokenResponse
+}
 
 // ExternalCredentialProvider serves CRUD operations for host-managed external
 // credentials.

--- a/sdk/go/external_credential_client.go
+++ b/sdk/go/external_credential_client.go
@@ -54,7 +54,11 @@ func (c *ExternalCredentialClient) UpsertCredential(ctx context.Context, req *Up
 	if req == nil {
 		return nil, fmt.Errorf("external credentials: request is required")
 	}
-	return c.client.UpsertCredential(ctx, req)
+	resp, err := c.client.UpsertCredential(ctx, upsertExternalCredentialRequestToProto(req))
+	if err != nil {
+		return nil, err
+	}
+	return externalCredentialFromProto(resp)
 }
 
 // GetCredential fetches one host-managed external credential.
@@ -65,7 +69,11 @@ func (c *ExternalCredentialClient) GetCredential(ctx context.Context, req *GetEx
 	if req == nil {
 		return nil, fmt.Errorf("external credentials: request is required")
 	}
-	return c.client.GetCredential(ctx, req)
+	resp, err := c.client.GetCredential(ctx, getExternalCredentialRequestToProto(req))
+	if err != nil {
+		return nil, err
+	}
+	return externalCredentialFromProto(resp)
 }
 
 // ListCredentials lists host-managed external credentials.
@@ -76,7 +84,11 @@ func (c *ExternalCredentialClient) ListCredentials(ctx context.Context, req *Lis
 	if req == nil {
 		return nil, fmt.Errorf("external credentials: request is required")
 	}
-	return c.client.ListCredentials(ctx, req)
+	resp, err := c.client.ListCredentials(ctx, listExternalCredentialsRequestToProto(req))
+	if err != nil {
+		return nil, err
+	}
+	return listExternalCredentialsResponseFromProto(resp)
 }
 
 // DeleteCredential deletes one host-managed external credential.
@@ -87,7 +99,7 @@ func (c *ExternalCredentialClient) DeleteCredential(ctx context.Context, req *De
 	if req == nil {
 		return fmt.Errorf("external credentials: request is required")
 	}
-	_, err := c.client.DeleteCredential(ctx, req)
+	_, err := c.client.DeleteCredential(ctx, deleteExternalCredentialRequestToProto(req))
 	return err
 }
 
@@ -98,7 +110,7 @@ func (c *ExternalCredentialClient) ValidateCredentialConfig(ctx context.Context,
 	if req == nil {
 		return fmt.Errorf("external credentials: request is required")
 	}
-	_, err := c.client.ValidateCredentialConfig(ctx, req)
+	_, err := c.client.ValidateCredentialConfig(ctx, validateExternalCredentialConfigRequestToProto(req))
 	return err
 }
 
@@ -109,7 +121,11 @@ func (c *ExternalCredentialClient) ResolveCredential(ctx context.Context, req *R
 	if req == nil {
 		return nil, fmt.Errorf("external credentials: request is required")
 	}
-	return c.client.ResolveCredential(ctx, req)
+	resp, err := c.client.ResolveCredential(ctx, resolveExternalCredentialRequestToProto(req))
+	if err != nil {
+		return nil, err
+	}
+	return resolveExternalCredentialResponseFromProto(resp)
 }
 
 func (c *ExternalCredentialClient) ExchangeCredential(ctx context.Context, req *ExchangeExternalCredentialRequest) (*ExchangeExternalCredentialResponse, error) {
@@ -119,5 +135,9 @@ func (c *ExternalCredentialClient) ExchangeCredential(ctx context.Context, req *
 	if req == nil {
 		return nil, fmt.Errorf("external credentials: request is required")
 	}
-	return c.client.ExchangeCredential(ctx, req)
+	resp, err := c.client.ExchangeCredential(ctx, exchangeExternalCredentialRequestToProto(req))
+	if err != nil {
+		return nil, err
+	}
+	return exchangeExternalCredentialResponseFromProto(resp), nil
 }

--- a/sdk/go/external_credential_proto.go
+++ b/sdk/go/external_credential_proto.go
@@ -1,0 +1,467 @@
+package gestalt
+
+import proto "github.com/valon-technologies/gestalt/internal/gen/v1"
+
+func externalCredentialFromProto(value *proto.ExternalCredential) (*ExternalCredential, error) {
+	if value == nil {
+		return nil, nil
+	}
+	expiresAt, err := TimePtrFromTimestamp(value.GetExpiresAt())
+	if err != nil {
+		return nil, err
+	}
+	lastRefreshedAt, err := TimePtrFromTimestamp(value.GetLastRefreshedAt())
+	if err != nil {
+		return nil, err
+	}
+	createdAt, err := TimePtrFromTimestamp(value.GetCreatedAt())
+	if err != nil {
+		return nil, err
+	}
+	updatedAt, err := TimePtrFromTimestamp(value.GetUpdatedAt())
+	if err != nil {
+		return nil, err
+	}
+	return &ExternalCredential{
+		ID:                value.GetId(),
+		SubjectID:         value.GetSubjectId(),
+		Instance:          value.GetInstance(),
+		AccessToken:       value.GetAccessToken(),
+		RefreshToken:      value.GetRefreshToken(),
+		Scopes:            value.GetScopes(),
+		ExpiresAt:         expiresAt,
+		LastRefreshedAt:   lastRefreshedAt,
+		RefreshErrorCount: value.GetRefreshErrorCount(),
+		MetadataJSON:      value.GetMetadataJson(),
+		CreatedAt:         createdAt,
+		UpdatedAt:         updatedAt,
+		ConnectionID:      value.GetConnectionId(),
+	}, nil
+}
+
+func externalCredentialToProto(value *ExternalCredential) *proto.ExternalCredential {
+	if value == nil {
+		return nil
+	}
+	return &proto.ExternalCredential{
+		Id:                value.GetId(),
+		SubjectId:         value.GetSubjectId(),
+		Instance:          value.GetInstance(),
+		AccessToken:       value.GetAccessToken(),
+		RefreshToken:      value.GetRefreshToken(),
+		Scopes:            value.GetScopes(),
+		ExpiresAt:         timestampFromOptionalTime(value.GetExpiresAt()),
+		LastRefreshedAt:   timestampFromOptionalTime(value.GetLastRefreshedAt()),
+		RefreshErrorCount: value.GetRefreshErrorCount(),
+		MetadataJson:      value.GetMetadataJson(),
+		CreatedAt:         timestampFromOptionalTime(value.GetCreatedAt()),
+		UpdatedAt:         timestampFromOptionalTime(value.GetUpdatedAt()),
+		ConnectionId:      value.GetConnectionId(),
+	}
+}
+
+func externalCredentialLookupFromProto(value *proto.ExternalCredentialLookup) *ExternalCredentialLookup {
+	if value == nil {
+		return nil
+	}
+	return &ExternalCredentialLookup{
+		SubjectID:    value.GetSubjectId(),
+		Instance:     value.GetInstance(),
+		ConnectionID: value.GetConnectionId(),
+	}
+}
+
+func externalCredentialLookupToProto(value *ExternalCredentialLookup) *proto.ExternalCredentialLookup {
+	if value == nil {
+		return nil
+	}
+	return &proto.ExternalCredentialLookup{
+		SubjectId:    value.GetSubjectId(),
+		Instance:     value.GetInstance(),
+		ConnectionId: value.GetConnectionId(),
+	}
+}
+
+func upsertExternalCredentialRequestFromProto(value *proto.UpsertExternalCredentialRequest) (*UpsertExternalCredentialRequest, error) {
+	if value == nil {
+		return nil, nil
+	}
+	credential, err := externalCredentialFromProto(value.GetCredential())
+	if err != nil {
+		return nil, err
+	}
+	return &UpsertExternalCredentialRequest{
+		Credential:         credential,
+		PreserveTimestamps: value.GetPreserveTimestamps(),
+	}, nil
+}
+
+func upsertExternalCredentialRequestToProto(value *UpsertExternalCredentialRequest) *proto.UpsertExternalCredentialRequest {
+	if value == nil {
+		return nil
+	}
+	return &proto.UpsertExternalCredentialRequest{
+		Credential:         externalCredentialToProto(value.GetCredential()),
+		PreserveTimestamps: value.GetPreserveTimestamps(),
+	}
+}
+
+func getExternalCredentialRequestFromProto(value *proto.GetExternalCredentialRequest) *GetExternalCredentialRequest {
+	if value == nil {
+		return nil
+	}
+	return &GetExternalCredentialRequest{Lookup: externalCredentialLookupFromProto(value.GetLookup())}
+}
+
+func getExternalCredentialRequestToProto(value *GetExternalCredentialRequest) *proto.GetExternalCredentialRequest {
+	if value == nil {
+		return nil
+	}
+	return &proto.GetExternalCredentialRequest{Lookup: externalCredentialLookupToProto(value.GetLookup())}
+}
+
+func listExternalCredentialsRequestFromProto(value *proto.ListExternalCredentialsRequest) *ListExternalCredentialsRequest {
+	if value == nil {
+		return nil
+	}
+	return &ListExternalCredentialsRequest{
+		SubjectID:    value.GetSubjectId(),
+		Instance:     value.GetInstance(),
+		ConnectionID: value.GetConnectionId(),
+	}
+}
+
+func listExternalCredentialsRequestToProto(value *ListExternalCredentialsRequest) *proto.ListExternalCredentialsRequest {
+	if value == nil {
+		return nil
+	}
+	return &proto.ListExternalCredentialsRequest{
+		SubjectId:    value.GetSubjectId(),
+		Instance:     value.GetInstance(),
+		ConnectionId: value.GetConnectionId(),
+	}
+}
+
+func listExternalCredentialsResponseFromProto(value *proto.ListExternalCredentialsResponse) (*ListExternalCredentialsResponse, error) {
+	if value == nil {
+		return nil, nil
+	}
+	credentials := make([]*ExternalCredential, 0, len(value.GetCredentials()))
+	for _, credential := range value.GetCredentials() {
+		native, err := externalCredentialFromProto(credential)
+		if err != nil {
+			return nil, err
+		}
+		credentials = append(credentials, native)
+	}
+	return &ListExternalCredentialsResponse{Credentials: credentials}, nil
+}
+
+func listExternalCredentialsResponseToProto(value *ListExternalCredentialsResponse) *proto.ListExternalCredentialsResponse {
+	if value == nil {
+		return nil
+	}
+	credentials := make([]*proto.ExternalCredential, 0, len(value.GetCredentials()))
+	for _, credential := range value.GetCredentials() {
+		credentials = append(credentials, externalCredentialToProto(credential))
+	}
+	return &proto.ListExternalCredentialsResponse{Credentials: credentials}
+}
+
+func deleteExternalCredentialRequestFromProto(value *proto.DeleteExternalCredentialRequest) *DeleteExternalCredentialRequest {
+	if value == nil {
+		return nil
+	}
+	return &DeleteExternalCredentialRequest{ID: value.GetId()}
+}
+
+func deleteExternalCredentialRequestToProto(value *DeleteExternalCredentialRequest) *proto.DeleteExternalCredentialRequest {
+	if value == nil {
+		return nil
+	}
+	return &proto.DeleteExternalCredentialRequest{Id: value.GetId()}
+}
+
+func externalCredentialAuthConfigFromProto(value *proto.ExternalCredentialAuthConfig) *ExternalCredentialAuthConfig {
+	if value == nil {
+		return nil
+	}
+	drivers := make([]*ExternalCredentialTokenExchangeDriver, 0, len(value.GetTokenExchangeDrivers()))
+	for _, driver := range value.GetTokenExchangeDrivers() {
+		drivers = append(drivers, externalCredentialTokenExchangeDriverFromProto(driver))
+	}
+	return &ExternalCredentialAuthConfig{
+		Type:                 value.GetType(),
+		Token:                value.GetToken(),
+		TokenPrefix:          value.GetTokenPrefix(),
+		GrantType:            value.GetGrantType(),
+		TokenURL:             value.GetTokenUrl(),
+		ClientID:             value.GetClientId(),
+		ClientSecret:         value.GetClientSecret(),
+		ClientAuth:           value.GetClientAuth(),
+		TokenExchange:        value.GetTokenExchange(),
+		Scopes:               copyStringSlice(value.GetScopes()),
+		ScopeParam:           value.GetScopeParam(),
+		ScopeSeparator:       value.GetScopeSeparator(),
+		TokenParams:          copyStringMap(value.GetTokenParams()),
+		RefreshParams:        copyStringMap(value.GetRefreshParams()),
+		AcceptHeader:         value.GetAcceptHeader(),
+		AccessTokenPath:      value.GetAccessTokenPath(),
+		TokenExchangeDrivers: drivers,
+		RefreshToken:         value.GetRefreshToken(),
+	}
+}
+
+func externalCredentialAuthConfigToProto(value *ExternalCredentialAuthConfig) *proto.ExternalCredentialAuthConfig {
+	if value == nil {
+		return nil
+	}
+	drivers := make([]*proto.ExternalCredentialTokenExchangeDriver, 0, len(value.GetTokenExchangeDrivers()))
+	for _, driver := range value.GetTokenExchangeDrivers() {
+		drivers = append(drivers, externalCredentialTokenExchangeDriverToProto(driver))
+	}
+	return &proto.ExternalCredentialAuthConfig{
+		Type:                 value.GetType(),
+		Token:                value.GetToken(),
+		TokenPrefix:          value.GetTokenPrefix(),
+		GrantType:            value.GetGrantType(),
+		TokenUrl:             value.GetTokenUrl(),
+		ClientId:             value.GetClientId(),
+		ClientSecret:         value.GetClientSecret(),
+		ClientAuth:           value.GetClientAuth(),
+		TokenExchange:        value.GetTokenExchange(),
+		Scopes:               copyStringSlice(value.GetScopes()),
+		ScopeParam:           value.GetScopeParam(),
+		ScopeSeparator:       value.GetScopeSeparator(),
+		TokenParams:          copyStringMap(value.GetTokenParams()),
+		RefreshParams:        copyStringMap(value.GetRefreshParams()),
+		AcceptHeader:         value.GetAcceptHeader(),
+		AccessTokenPath:      value.GetAccessTokenPath(),
+		TokenExchangeDrivers: drivers,
+		RefreshToken:         value.GetRefreshToken(),
+	}
+}
+
+func externalCredentialTokenExchangeDriverFromProto(value *proto.ExternalCredentialTokenExchangeDriver) *ExternalCredentialTokenExchangeDriver {
+	if value == nil {
+		return nil
+	}
+	return &ExternalCredentialTokenExchangeDriver{
+		Type:            value.GetType(),
+		TargetPrincipal: value.GetTargetPrincipal(),
+		Scopes:          copyStringSlice(value.GetScopes()),
+		LifetimeSeconds: value.GetLifetimeSeconds(),
+		Endpoint:        value.GetEndpoint(),
+		Params:          copyStringMap(value.GetParams()),
+	}
+}
+
+func externalCredentialTokenExchangeDriverToProto(value *ExternalCredentialTokenExchangeDriver) *proto.ExternalCredentialTokenExchangeDriver {
+	if value == nil {
+		return nil
+	}
+	return &proto.ExternalCredentialTokenExchangeDriver{
+		Type:            value.GetType(),
+		TargetPrincipal: value.GetTargetPrincipal(),
+		Scopes:          copyStringSlice(value.GetScopes()),
+		LifetimeSeconds: value.GetLifetimeSeconds(),
+		Endpoint:        value.GetEndpoint(),
+		Params:          copyStringMap(value.GetParams()),
+	}
+}
+
+func validateExternalCredentialConfigRequestFromProto(value *proto.ValidateExternalCredentialConfigRequest) *ValidateExternalCredentialConfigRequest {
+	if value == nil {
+		return nil
+	}
+	return &ValidateExternalCredentialConfigRequest{
+		Provider:         value.GetProvider(),
+		Connection:       value.GetConnection(),
+		ConnectionID:     value.GetConnectionId(),
+		Mode:             value.GetMode(),
+		Auth:             externalCredentialAuthConfigFromProto(value.GetAuth()),
+		ConnectionParams: copyStringMap(value.GetConnectionParams()),
+	}
+}
+
+func validateExternalCredentialConfigRequestToProto(value *ValidateExternalCredentialConfigRequest) *proto.ValidateExternalCredentialConfigRequest {
+	if value == nil {
+		return nil
+	}
+	return &proto.ValidateExternalCredentialConfigRequest{
+		Provider:         value.GetProvider(),
+		Connection:       value.GetConnection(),
+		ConnectionId:     value.GetConnectionId(),
+		Mode:             value.GetMode(),
+		Auth:             externalCredentialAuthConfigToProto(value.GetAuth()),
+		ConnectionParams: copyStringMap(value.GetConnectionParams()),
+	}
+}
+
+func resolveExternalCredentialRequestFromProto(value *proto.ResolveExternalCredentialRequest) *ResolveExternalCredentialRequest {
+	if value == nil {
+		return nil
+	}
+	return &ResolveExternalCredentialRequest{
+		Provider:            value.GetProvider(),
+		Connection:          value.GetConnection(),
+		ConnectionID:        value.GetConnectionId(),
+		Mode:                value.GetMode(),
+		CredentialSubjectID: value.GetCredentialSubjectId(),
+		ActorSubjectID:      value.GetActorSubjectId(),
+		Instance:            value.GetInstance(),
+		Auth:                externalCredentialAuthConfigFromProto(value.GetAuth()),
+		ConnectionParams:    copyStringMap(value.GetConnectionParams()),
+	}
+}
+
+func resolveExternalCredentialRequestToProto(value *ResolveExternalCredentialRequest) *proto.ResolveExternalCredentialRequest {
+	if value == nil {
+		return nil
+	}
+	return &proto.ResolveExternalCredentialRequest{
+		Provider:            value.GetProvider(),
+		Connection:          value.GetConnection(),
+		ConnectionId:        value.GetConnectionId(),
+		Mode:                value.GetMode(),
+		CredentialSubjectId: value.GetCredentialSubjectId(),
+		ActorSubjectId:      value.GetActorSubjectId(),
+		Instance:            value.GetInstance(),
+		Auth:                externalCredentialAuthConfigToProto(value.GetAuth()),
+		ConnectionParams:    copyStringMap(value.GetConnectionParams()),
+	}
+}
+
+func resolveExternalCredentialResponseFromProto(value *proto.ResolveExternalCredentialResponse) (*ResolveExternalCredentialResponse, error) {
+	if value == nil {
+		return nil, nil
+	}
+	expiresAt, err := TimePtrFromTimestamp(value.GetExpiresAt())
+	if err != nil {
+		return nil, err
+	}
+	credential, err := externalCredentialFromProto(value.GetCredential())
+	if err != nil {
+		return nil, err
+	}
+	return &ResolveExternalCredentialResponse{
+		Token:        value.GetToken(),
+		ExpiresAt:    expiresAt,
+		MetadataJSON: value.GetMetadataJson(),
+		Params:       copyStringMap(value.GetParams()),
+		Credential:   credential,
+	}, nil
+}
+
+func resolveExternalCredentialResponseToProto(value *ResolveExternalCredentialResponse) *proto.ResolveExternalCredentialResponse {
+	if value == nil {
+		return nil
+	}
+	return &proto.ResolveExternalCredentialResponse{
+		Token:        value.GetToken(),
+		ExpiresAt:    timestampFromOptionalTime(value.GetExpiresAt()),
+		MetadataJson: value.GetMetadataJson(),
+		Params:       copyStringMap(value.GetParams()),
+		Credential:   externalCredentialToProto(value.GetCredential()),
+	}
+}
+
+func externalCredentialTokenResponseFromProto(value *proto.ExternalCredentialTokenResponse) *ExternalCredentialTokenResponse {
+	if value == nil {
+		return nil
+	}
+	return &ExternalCredentialTokenResponse{
+		AccessToken:   value.GetAccessToken(),
+		RefreshToken:  value.GetRefreshToken(),
+		ExpiresIn:     value.GetExpiresIn(),
+		TokenType:     value.GetTokenType(),
+		ExtraJSON:     value.GetExtraJson(),
+		RefreshSource: value.GetRefreshSource(),
+	}
+}
+
+func externalCredentialTokenResponseToProto(value *ExternalCredentialTokenResponse) *proto.ExternalCredentialTokenResponse {
+	if value == nil {
+		return nil
+	}
+	return &proto.ExternalCredentialTokenResponse{
+		AccessToken:   value.GetAccessToken(),
+		RefreshToken:  value.GetRefreshToken(),
+		ExpiresIn:     value.GetExpiresIn(),
+		TokenType:     value.GetTokenType(),
+		ExtraJson:     value.GetExtraJson(),
+		RefreshSource: value.GetRefreshSource(),
+	}
+}
+
+func exchangeExternalCredentialRequestFromProto(value *proto.ExchangeExternalCredentialRequest) *ExchangeExternalCredentialRequest {
+	if value == nil {
+		return nil
+	}
+	return &ExchangeExternalCredentialRequest{
+		Provider:            value.GetProvider(),
+		Connection:          value.GetConnection(),
+		ConnectionID:        value.GetConnectionId(),
+		CredentialSubjectID: value.GetCredentialSubjectId(),
+		ActorSubjectID:      value.GetActorSubjectId(),
+		Instance:            value.GetInstance(),
+		Auth:                externalCredentialAuthConfigFromProto(value.GetAuth()),
+		CredentialJSON:      value.GetCredentialJson(),
+		ConnectionParams:    copyStringMap(value.GetConnectionParams()),
+	}
+}
+
+func exchangeExternalCredentialRequestToProto(value *ExchangeExternalCredentialRequest) *proto.ExchangeExternalCredentialRequest {
+	if value == nil {
+		return nil
+	}
+	return &proto.ExchangeExternalCredentialRequest{
+		Provider:            value.GetProvider(),
+		Connection:          value.GetConnection(),
+		ConnectionId:        value.GetConnectionId(),
+		CredentialSubjectId: value.GetCredentialSubjectId(),
+		ActorSubjectId:      value.GetActorSubjectId(),
+		Instance:            value.GetInstance(),
+		Auth:                externalCredentialAuthConfigToProto(value.GetAuth()),
+		CredentialJson:      value.GetCredentialJson(),
+		ConnectionParams:    copyStringMap(value.GetConnectionParams()),
+	}
+}
+
+func exchangeExternalCredentialResponseFromProto(value *proto.ExchangeExternalCredentialResponse) *ExchangeExternalCredentialResponse {
+	if value == nil {
+		return nil
+	}
+	return &ExchangeExternalCredentialResponse{
+		TokenResponse: externalCredentialTokenResponseFromProto(value.GetTokenResponse()),
+	}
+}
+
+func exchangeExternalCredentialResponseToProto(value *ExchangeExternalCredentialResponse) *proto.ExchangeExternalCredentialResponse {
+	if value == nil {
+		return nil
+	}
+	return &proto.ExchangeExternalCredentialResponse{
+		TokenResponse: externalCredentialTokenResponseToProto(value.GetTokenResponse()),
+	}
+}
+
+func copyStringMap(value map[string]string) map[string]string {
+	if len(value) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(value))
+	for key, entry := range value {
+		out[key] = entry
+	}
+	return out
+}
+
+func copyStringSlice(value []string) []string {
+	if len(value) == 0 {
+		return nil
+	}
+	out := make([]string, len(value))
+	copy(out, value)
+	return out
+}

--- a/sdk/go/external_credential_server.go
+++ b/sdk/go/external_credential_server.go
@@ -22,49 +22,53 @@ func (s *externalCredentialServer) UpsertCredential(ctx context.Context, req *pr
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
-	credential, err := s.provider.UpsertCredential(ctx, req)
+	nativeReq, err := upsertExternalCredentialRequestFromProto(req)
+	if err != nil {
+		return nil, providerRPCError("upsert external credential", err)
+	}
+	credential, err := s.provider.UpsertCredential(ctx, nativeReq)
 	if err != nil {
 		return nil, providerRPCError("upsert external credential", err)
 	}
 	if credential == nil {
 		return nil, status.Error(codes.Internal, "external credential provider returned nil credential")
 	}
-	return credential, nil
+	return externalCredentialToProto(credential), nil
 }
 
 func (s *externalCredentialServer) GetCredential(ctx context.Context, req *proto.GetExternalCredentialRequest) (*proto.ExternalCredential, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
-	credential, err := s.provider.GetCredential(ctx, req)
+	credential, err := s.provider.GetCredential(ctx, getExternalCredentialRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("get external credential", err)
 	}
 	if credential == nil {
 		return nil, status.Error(codes.Internal, "external credential provider returned nil credential")
 	}
-	return credential, nil
+	return externalCredentialToProto(credential), nil
 }
 
 func (s *externalCredentialServer) ListCredentials(ctx context.Context, req *proto.ListExternalCredentialsRequest) (*proto.ListExternalCredentialsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
-	resp, err := s.provider.ListCredentials(ctx, req)
+	resp, err := s.provider.ListCredentials(ctx, listExternalCredentialsRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("list external credentials", err)
 	}
 	if resp == nil {
 		return nil, status.Error(codes.Internal, "external credential provider returned nil response")
 	}
-	return resp, nil
+	return listExternalCredentialsResponseToProto(resp), nil
 }
 
 func (s *externalCredentialServer) DeleteCredential(ctx context.Context, req *proto.DeleteExternalCredentialRequest) (*emptypb.Empty, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
-	if err := s.provider.DeleteCredential(ctx, req); err != nil {
+	if err := s.provider.DeleteCredential(ctx, deleteExternalCredentialRequestFromProto(req)); err != nil {
 		return nil, providerRPCError("delete external credential", err)
 	}
 	return &emptypb.Empty{}, nil
@@ -74,7 +78,7 @@ func (s *externalCredentialServer) ValidateCredentialConfig(ctx context.Context,
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
-	if err := s.provider.ValidateCredentialConfig(ctx, req); err != nil {
+	if err := s.provider.ValidateCredentialConfig(ctx, validateExternalCredentialConfigRequestFromProto(req)); err != nil {
 		return nil, providerRPCError("validate external credential config", err)
 	}
 	return &emptypb.Empty{}, nil
@@ -84,26 +88,26 @@ func (s *externalCredentialServer) ResolveCredential(ctx context.Context, req *p
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
-	resp, err := s.provider.ResolveCredential(ctx, req)
+	resp, err := s.provider.ResolveCredential(ctx, resolveExternalCredentialRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("resolve external credential", err)
 	}
 	if resp == nil {
 		return nil, status.Error(codes.Internal, "external credential provider returned nil response")
 	}
-	return resp, nil
+	return resolveExternalCredentialResponseToProto(resp), nil
 }
 
 func (s *externalCredentialServer) ExchangeCredential(ctx context.Context, req *proto.ExchangeExternalCredentialRequest) (*proto.ExchangeExternalCredentialResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
-	resp, err := s.provider.ExchangeCredential(ctx, req)
+	resp, err := s.provider.ExchangeCredential(ctx, exchangeExternalCredentialRequestFromProto(req))
 	if err != nil {
 		return nil, providerRPCError("exchange external credential", err)
 	}
 	if resp == nil {
 		return nil, status.Error(codes.Internal, "external credential provider returned nil response")
 	}
-	return resp, nil
+	return exchangeExternalCredentialResponseToProto(resp), nil
 }

--- a/sdk/go/external_credential_transport_test.go
+++ b/sdk/go/external_credential_transport_test.go
@@ -17,20 +17,19 @@ import (
 	"google.golang.org/grpc/status"
 	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type stubExternalCredentialProvider struct {
 	closeTracker
 
 	mu          sync.Mutex
-	credentials map[string]*proto.ExternalCredential
+	credentials map[string]*gestalt.ExternalCredential
 	lookupByID  map[string]string
 }
 
 func newStubExternalCredentialProvider() *stubExternalCredentialProvider {
 	return &stubExternalCredentialProvider{
-		credentials: make(map[string]*proto.ExternalCredential),
+		credentials: make(map[string]*gestalt.ExternalCredential),
 		lookupByID:  make(map[string]string),
 	}
 }
@@ -39,40 +38,40 @@ func (p *stubExternalCredentialProvider) Configure(context.Context, string, map[
 	return nil
 }
 
-func (p *stubExternalCredentialProvider) UpsertCredential(_ context.Context, req *proto.UpsertExternalCredentialRequest) (*proto.ExternalCredential, error) {
+func (p *stubExternalCredentialProvider) UpsertCredential(_ context.Context, req *gestalt.UpsertExternalCredentialRequest) (*gestalt.ExternalCredential, error) {
 	if req == nil || req.GetCredential() == nil {
 		return nil, fmt.Errorf("credential is required")
 	}
-	value := gproto.Clone(req.GetCredential()).(*proto.ExternalCredential)
+	value := cloneExternalCredential(req.GetCredential())
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	key := externalCredentialLookupKey(&proto.ExternalCredentialLookup{
-		SubjectId:    value.GetSubjectId(),
-		ConnectionId: value.GetConnectionId(),
+	key := externalCredentialLookupKey(&gestalt.ExternalCredentialLookup{
+		SubjectID:    value.GetSubjectId(),
+		ConnectionID: value.GetConnectionId(),
 		Instance:     value.GetInstance(),
 	})
 	existing := p.credentials[key]
-	now := timestamppb.Now()
+	now := time.Now().UTC()
 	if existing != nil {
-		value.Id = existing.GetId()
+		value.ID = existing.GetId()
 		value.CreatedAt = existing.GetCreatedAt()
 	} else {
 		if value.GetId() == "" {
-			value.Id = "cred-" + value.GetConnectionId() + "-" + value.GetInstance()
+			value.ID = "cred-" + value.GetConnectionId() + "-" + value.GetInstance()
 		}
 		if value.GetCreatedAt() == nil {
-			value.CreatedAt = now
+			value.CreatedAt = &now
 		}
 	}
-	value.UpdatedAt = now
-	p.credentials[key] = gproto.Clone(value).(*proto.ExternalCredential)
+	value.UpdatedAt = &now
+	p.credentials[key] = cloneExternalCredential(value)
 	p.lookupByID[value.GetId()] = key
 	return value, nil
 }
 
-func (p *stubExternalCredentialProvider) GetCredential(_ context.Context, req *proto.GetExternalCredentialRequest) (*proto.ExternalCredential, error) {
+func (p *stubExternalCredentialProvider) GetCredential(_ context.Context, req *gestalt.GetExternalCredentialRequest) (*gestalt.ExternalCredential, error) {
 	if req == nil || req.GetLookup() == nil {
 		return nil, fmt.Errorf("lookup is required")
 	}
@@ -83,17 +82,17 @@ func (p *stubExternalCredentialProvider) GetCredential(_ context.Context, req *p
 	if !ok {
 		return nil, gestalt.ErrExternalCredentialNotFound
 	}
-	return gproto.Clone(credential).(*proto.ExternalCredential), nil
+	return cloneExternalCredential(credential), nil
 }
 
-func (p *stubExternalCredentialProvider) ListCredentials(_ context.Context, req *proto.ListExternalCredentialsRequest) (*proto.ListExternalCredentialsResponse, error) {
+func (p *stubExternalCredentialProvider) ListCredentials(_ context.Context, req *gestalt.ListExternalCredentialsRequest) (*gestalt.ListExternalCredentialsResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("request is required")
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	credentials := make([]*proto.ExternalCredential, 0, len(p.credentials))
+	credentials := make([]*gestalt.ExternalCredential, 0, len(p.credentials))
 	for _, credential := range p.credentials {
 		if req.GetSubjectId() != "" && credential.GetSubjectId() != req.GetSubjectId() {
 			continue
@@ -104,15 +103,15 @@ func (p *stubExternalCredentialProvider) ListCredentials(_ context.Context, req 
 		if req.GetInstance() != "" && credential.GetInstance() != req.GetInstance() {
 			continue
 		}
-		credentials = append(credentials, gproto.Clone(credential).(*proto.ExternalCredential))
+		credentials = append(credentials, cloneExternalCredential(credential))
 	}
 	sort.Slice(credentials, func(i, j int) bool {
 		return credentials[i].GetId() < credentials[j].GetId()
 	})
-	return &proto.ListExternalCredentialsResponse{Credentials: credentials}, nil
+	return &gestalt.ListExternalCredentialsResponse{Credentials: credentials}, nil
 }
 
-func (p *stubExternalCredentialProvider) DeleteCredential(_ context.Context, req *proto.DeleteExternalCredentialRequest) error {
+func (p *stubExternalCredentialProvider) DeleteCredential(_ context.Context, req *gestalt.DeleteExternalCredentialRequest) error {
 	if req == nil || req.GetId() == "" {
 		return fmt.Errorf("credential id is required")
 	}
@@ -128,31 +127,31 @@ func (p *stubExternalCredentialProvider) DeleteCredential(_ context.Context, req
 	return nil
 }
 
-func (p *stubExternalCredentialProvider) ValidateCredentialConfig(context.Context, *proto.ValidateExternalCredentialConfigRequest) error {
+func (p *stubExternalCredentialProvider) ValidateCredentialConfig(context.Context, *gestalt.ValidateExternalCredentialConfigRequest) error {
 	return nil
 }
 
-func (p *stubExternalCredentialProvider) ResolveCredential(ctx context.Context, req *proto.ResolveExternalCredentialRequest) (*proto.ResolveExternalCredentialResponse, error) {
+func (p *stubExternalCredentialProvider) ResolveCredential(ctx context.Context, req *gestalt.ResolveExternalCredentialRequest) (*gestalt.ResolveExternalCredentialResponse, error) {
 	if req == nil {
 		return nil, fmt.Errorf("request is required")
 	}
-	credential, err := p.GetCredential(ctx, &proto.GetExternalCredentialRequest{Lookup: &proto.ExternalCredentialLookup{
-		SubjectId:    req.GetCredentialSubjectId(),
-		ConnectionId: req.GetConnectionId(),
+	credential, err := p.GetCredential(ctx, &gestalt.GetExternalCredentialRequest{Lookup: &gestalt.ExternalCredentialLookup{
+		SubjectID:    req.GetCredentialSubjectId(),
+		ConnectionID: req.GetConnectionId(),
 		Instance:     req.GetInstance(),
 	}})
 	if err != nil {
 		return nil, err
 	}
-	return &proto.ResolveExternalCredentialResponse{
+	return &gestalt.ResolveExternalCredentialResponse{
 		Token:      credential.GetAccessToken(),
 		ExpiresAt:  credential.GetExpiresAt(),
 		Credential: credential,
 	}, nil
 }
 
-func (*stubExternalCredentialProvider) ExchangeCredential(context.Context, *proto.ExchangeExternalCredentialRequest) (*proto.ExchangeExternalCredentialResponse, error) {
-	return &proto.ExchangeExternalCredentialResponse{}, nil
+func (*stubExternalCredentialProvider) ExchangeCredential(context.Context, *gestalt.ExchangeExternalCredentialRequest) (*gestalt.ExchangeExternalCredentialResponse, error) {
+	return &gestalt.ExchangeExternalCredentialResponse{}, nil
 }
 
 type externalCredentialTransportHarness struct {
@@ -297,10 +296,10 @@ func TestTransport_ExternalCredentialTCPTargetTokenEnv(t *testing.T) {
 	}
 	defer func() { _ = client.Close() }()
 
-	credential, err := client.UpsertCredential(context.Background(), &proto.UpsertExternalCredentialRequest{
-		Credential: &proto.ExternalCredential{
-			SubjectId:    "user:user-123",
-			ConnectionId: "slack:default",
+	credential, err := client.UpsertCredential(context.Background(), &gestalt.UpsertExternalCredentialRequest{
+		Credential: &gestalt.ExternalCredential{
+			SubjectID:    "user:user-123",
+			ConnectionID: "slack:default",
 			Instance:     "workspace-1",
 			AccessToken:  "xoxb-123",
 		},
@@ -329,9 +328,33 @@ func TestTransport_ExternalCredentialTCPTargetTokenEnv(t *testing.T) {
 	}
 }
 
-func externalCredentialLookupKey(lookup *proto.ExternalCredentialLookup) string {
+func externalCredentialLookupKey(lookup interface {
+	GetSubjectId() string
+	GetConnectionId() string
+	GetInstance() string
+}) string {
 	if lookup == nil {
 		return ""
 	}
 	return lookup.GetSubjectId() + "\x00" + lookup.GetConnectionId() + "\x00" + lookup.GetInstance()
+}
+
+func cloneExternalCredential(value *gestalt.ExternalCredential) *gestalt.ExternalCredential {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	clone.ExpiresAt = cloneTime(value.ExpiresAt)
+	clone.LastRefreshedAt = cloneTime(value.LastRefreshedAt)
+	clone.CreatedAt = cloneTime(value.CreatedAt)
+	clone.UpdatedAt = cloneTime(value.UpdatedAt)
+	return &clone
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
 }

--- a/sdk/go/protocol_helpers.go
+++ b/sdk/go/protocol_helpers.go
@@ -10,16 +10,12 @@ import (
 
 	"google.golang.org/protobuf/encoding/protojson"
 	gproto "google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ProtoMessage is the common interface implemented by generated protobuf messages.
 type ProtoMessage = gproto.Message
-
-// Empty aliases google.protobuf.Empty for provider RPC boundary methods.
-type Empty = emptypb.Empty
 
 // Struct aliases google.protobuf.Struct for low-level protocol interop.
 type Struct = structpb.Struct

--- a/sdk/go/protocol_helpers_test.go
+++ b/sdk/go/protocol_helpers_test.go
@@ -6,8 +6,6 @@ import (
 )
 
 func TestProtoBoundaryHelpers(t *testing.T) {
-	var _ ProtoMessage = (*Empty)(nil)
-
 	msg, err := StructFromAny(map[string]any{"ok": true, "count": 2})
 	if err != nil {
 		t.Fatalf("StructFromAny: %v", err)

--- a/sdk/go/provider_lifecycle_client.go
+++ b/sdk/go/provider_lifecycle_client.go
@@ -1,0 +1,21 @@
+package gestalt
+
+import (
+	"context"
+	"fmt"
+
+	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// ProbeProviderLifecycle checks that a provider lifecycle endpoint can answer
+// an identity RPC. It is intended for runtime readiness loops that only need to
+// know whether the provider server is accepting requests.
+func ProbeProviderLifecycle(ctx context.Context, conn grpc.ClientConnInterface, opts ...grpc.CallOption) error {
+	if conn == nil {
+		return fmt.Errorf("provider lifecycle: connection is nil")
+	}
+	_, err := proto.NewProviderLifecycleClient(conn).GetProviderIdentity(ctx, &emptypb.Empty{}, opts...)
+	return err
+}

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -143,7 +143,6 @@ _AGENT_HELPER_EXPORTS = (
 
 _PROTOBUF_HELPER_EXPORTS = (
     "datetime_from_timestamp",
-    "Empty",
     "has_field",
     "JsonInput",
     "JsonObject",

--- a/sdk/python/gestalt/_protocol.py
+++ b/sdk/python/gestalt/_protocol.py
@@ -8,7 +8,6 @@ import math as _math
 from collections.abc import Mapping, Sequence
 from typing import Any, TypeAlias
 
-from google.protobuf import empty_pb2 as _empty_pb2
 from google.protobuf import json_format as _json_format
 from google.protobuf import message as _message
 from google.protobuf import struct_pb2 as _struct_pb2
@@ -19,7 +18,6 @@ struct_pb2: Any = _struct_pb2
 timestamp_pb2: Any = _timestamp_pb2
 
 ProtoMessage: TypeAlias = _message.Message
-Empty: Any = getattr(_empty_pb2, "Empty")
 Struct: Any = getattr(_struct_pb2, "Struct")
 Value: Any = getattr(_struct_pb2, "Value")
 Timestamp: Any = getattr(_timestamp_pb2, "Timestamp")

--- a/sdk/python/tests/test_protocol_helpers.py
+++ b/sdk/python/tests/test_protocol_helpers.py
@@ -20,7 +20,6 @@ class ProtocolHelperTests(unittest.TestCase):
         self.assertEqual(gestalt.struct_to_dict(from_json), {"a": 1.0, "b": 2.0})
 
     def test_well_known_type_aliases_are_public(self) -> None:
-        self.assertIsInstance(gestalt.Empty(), gestalt.ProtoMessage)
         self.assertIsInstance(gestalt.Timestamp(), gestalt.ProtoMessage)
         self.assertIsInstance(gestalt.Value(), gestalt.ProtoMessage)
 

--- a/sdk/rust/src/protocol.rs
+++ b/sdk/rust/src/protocol.rs
@@ -13,9 +13,6 @@ use crate::{Error, Result};
 
 const NANOS_PER_SECOND: i128 = 1_000_000_000;
 
-/// Alias for google.protobuf.Empty at protocol boundaries.
-pub type Empty = ();
-
 /// Common trait implemented by generated protobuf messages.
 pub trait ProtoMessage: Message {}
 

--- a/sdk/rust/tests/protocol.rs
+++ b/sdk/rust/tests/protocol.rs
@@ -19,14 +19,5 @@ fn protocol_boundary_helpers_round_trip_binary() -> gestalt::Result<()> {
         })
     );
 
-    let empty: gestalt::protocol::Empty = ();
-    gestalt::protocol::unmarshal_proto::<gestalt::protocol::Empty>(
-        gestalt::protocol::marshal_proto_deterministic(&empty),
-    )?;
-    assert_eq!(
-        gestalt::protocol::marshal_proto_deterministic(&empty),
-        Vec::<u8>::new()
-    );
-
     Ok(())
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -113,7 +113,6 @@ export {
   parseBuildArgs,
 } from "./build.ts";
 export {
-  EmptySchema,
   dateFromTimestamp,
   jsonFromInput,
   jsonFromValue,
@@ -131,7 +130,6 @@ export {
   valueFromJson,
   type BinaryReadOptions,
   type BinaryWriteOptions,
-  type Empty,
   type JsonInput,
   type JsonObjectInput,
   type JsonPrimitiveInput,

--- a/sdk/typescript/src/protocol.ts
+++ b/sdk/typescript/src/protocol.ts
@@ -18,11 +18,9 @@ import {
   type MessageShape,
 } from "@bufbuild/protobuf";
 import {
-  EmptySchema,
   StructSchema,
   TimestampSchema,
   ValueSchema,
-  type Empty,
   type Struct,
   type Timestamp,
   type Value,
@@ -41,8 +39,6 @@ export type JsonInput = JsonPrimitiveInput | readonly unknown[] | object;
 export type JsonObjectInput = object;
 /** Common shape implemented by generated protobuf messages. */
 export type ProtoMessage = Message;
-/** Alias for google.protobuf.Empty at protocol boundaries. */
-export type { Empty };
 /** Alias for google.protobuf.Struct at protocol boundaries. */
 export type { Struct };
 /** Alias for google.protobuf.Value at protocol boundaries. */
@@ -58,8 +54,6 @@ export type { JsonReadOptions };
 /** JSON serialize options accepted by marshalProtoJson. */
 export type { JsonWriteStringOptions };
 
-/** Schema for google.protobuf.Empty. */
-export { EmptySchema };
 /** Schema for google.protobuf.Struct. */
 export { StructSchema };
 /** Schema for google.protobuf.Value. */

--- a/sdk/typescript/tests/protocol.test.ts
+++ b/sdk/typescript/tests/protocol.test.ts
@@ -3,7 +3,6 @@ import type { Timestamp } from "@bufbuild/protobuf/wkt";
 import { expect, test } from "bun:test";
 
 import {
-  EmptySchema,
   ValueSchema,
   dateFromTimestamp,
   jsonFromValue,
@@ -16,7 +15,6 @@ import {
   unmarshalProto,
   unmarshalProtoJson,
   valueFromJson,
-  type Empty,
 } from "../src/index.ts";
 import {
   WorkflowEventSchema,
@@ -63,9 +61,6 @@ test("protocol helpers produce generated workflow field shapes", () => {
 });
 
 test("protocol boundary helpers round-trip protobuf binary and JSON", () => {
-  const empty: Empty = create(EmptySchema);
-  expect(empty.$typeName).toBe("google.protobuf.Empty");
-
   const message = valueFromJson({ b: 2, a: 1 });
   const sameMessageDifferentOrder = valueFromJson({ a: 1, b: 2 });
   const first = marshalProtoDeterministic(ValueSchema, message);


### PR DESCRIPTION
## Summary
- replace Go external credential aliases with native structs using time.Time pointers while converting to generated protos only at transport boundaries
- add a provider lifecycle probe helper so providers do not construct Empty requests for readiness checks
- remove public Empty aliases/re-exports from Go, Python, TypeScript, and Rust SDK surfaces
- update protocol tests and SDK/provider docs to steer authors toward native inputs rather than protobuf WKT constructors

## Verification
- go test ./... (sdk/go)
- bun run check (sdk/typescript)
- uv run pytest (sdk/python)
- cargo test (sdk/rust)
- uv run sphinx-build -W -b html docs docs/_build/html (sdk/python)
- bun run docs:build (sdk/typescript)
- cargo doc --no-deps (sdk/rust)