### PR TITLE
Add SDK helpers for agent session sharing

### DIFF
--- a/docs/content/reference/sdk/go.mdx
+++ b/docs/content/reference/sdk/go.mdx
@@ -105,6 +105,12 @@ well-known type conversions. The `gen/v1` subpackage re-exports selected
 generated bindings for transport fixtures, and the IndexedDB codec helpers
 convert records, keys, and typed values without importing internal packages.
 
+Use `AuthorizationClient.GrantAgentSessionEditor` when trusted provider code
+needs to share an agent session with another canonical Gestalt subject id. For
+lower-level composition, `NewAgentSessionEditorWriteRequest` builds the same
+host-managed `agent_session#editor` relationship without generated protobuf
+imports.
+
 ## Use external credential clients
 
 Go provider code can call the selected host external-credential provider through

--- a/docs/content/reference/sdk/python.mdx
+++ b/docs/content/reference/sdk/python.mdx
@@ -109,6 +109,11 @@ that need the protobuf JSON form of `AgentMessage` can use
 `agent_message_to_proto_dict` and `agent_message_from_proto_dict` without
 importing `google.protobuf.json_format`.
 
+Use `Authorization().grant_agent_session_editor(subject_id, session_id)` when
+trusted provider code needs to share an agent session with another canonical
+Gestalt subject id. The helper writes the host-managed `agent_session#editor`
+relationship without requiring generated protobuf imports.
+
 ## Record provider telemetry
 
 `gestaltd` owns OpenTelemetry exporter configuration and passes standard

--- a/docs/content/reference/sdk/rust.mdx
+++ b/docs/content/reference/sdk/rust.mdx
@@ -111,7 +111,7 @@ source-provider wrapper.
 The crate also exposes clients for provider code that needs to call
 Gestalt-managed sibling host services, including `Cache`, `IndexedDB`, `S3`,
 `WorkflowHost`, `WorkflowManager`, `AgentHost`, `AgentManager`,
-`PluginInvoker`, and `RuntimeLogHost`.
+`PluginInvoker`, `Authorization`, and `RuntimeLogHost`.
 
 `AgentHost` includes plain-input helpers named `list_tools_for_turn`,
 `execute_tool_for_turn`, and `resolve_connection_for_turn`. Use
@@ -121,6 +121,11 @@ system_time_from_timestamp}` for protobuf well-known type conversions,
 `gestalt::proto::v1` for generated protocol bindings in transport fixtures, and
 the JSON-named IndexedDB conversion helpers when asserting lower-level datastore
 wire shapes.
+
+Use `Authorization::grant_agent_session_editor` when trusted provider code
+needs to share an agent session with another canonical Gestalt subject id. The
+helper writes the host-managed `agent_session#editor` relationship without
+generated protobuf imports.
 
 ## Generated bindings
 

--- a/docs/content/reference/sdk/typescript.mdx
+++ b/docs/content/reference/sdk/typescript.mdx
@@ -132,6 +132,11 @@ helpers for lower-level datastore tests. Use root exports such as
 `jsonFromValue`, `timestampFromDate`, and `dateFromTimestamp` for protobuf
 well-known type fields without importing from `@bufbuild/protobuf/wkt`.
 
+Use `Authorization().grantAgentSessionEditor(subjectId, sessionId)` when
+trusted provider code needs to share an agent session with another canonical
+Gestalt subject id. The helper writes the host-managed `agent_session#editor`
+relationship without generated protobuf imports.
+
 ## Runtime and build entrypoints
 
 Use the runtime entrypoint for local source execution:

--- a/sdk/go/authorization.go
+++ b/sdk/go/authorization.go
@@ -151,6 +151,28 @@ type ExpandNode = proto.ExpandNode
 // ExpandResponse contains an expanded authorization graph.
 type ExpandResponse = proto.ExpandResponse
 
+const (
+	// AuthorizationSubjectTypeSubject identifies canonical Gestalt subjects in
+	// managed authorization relationships.
+	AuthorizationSubjectTypeSubject = "subject"
+
+	// AuthorizationResourceTypeAgentSession is the managed authorization
+	// resource type for agent sessions.
+	AuthorizationResourceTypeAgentSession = "agent_session"
+
+	// AuthorizationAgentSessionRelationEditor grants view and edit access to an
+	// agent session in the host-managed authorization model.
+	AuthorizationAgentSessionRelationEditor = "editor"
+
+	// AuthorizationAgentSessionActionView is the action checked when reading a
+	// shared agent session.
+	AuthorizationAgentSessionActionView = "view"
+
+	// AuthorizationAgentSessionActionEdit is the action checked when creating
+	// turns or resolving interactions in a shared agent session.
+	AuthorizationAgentSessionActionEdit = "edit"
+)
+
 // NewAuthorizationSubject creates a subject reference for authorization requests.
 func NewAuthorizationSubject(subjectType, id string) *AuthorizationSubject {
 	return &AuthorizationSubject{Type: subjectType, Id: id}
@@ -319,6 +341,34 @@ func NewAuthorizationModelUnionRewrite(children ...*AuthorizationModelRewrite) *
 			Union: &AuthorizationModelRewriteUnion{Children: children},
 		},
 	}
+}
+
+// NewAgentSessionAuthorizationResource creates the managed authorization
+// resource for an agent session.
+func NewAgentSessionAuthorizationResource(sessionID string) *AuthorizationResource {
+	return NewAuthorizationResource(AuthorizationResourceTypeAgentSession, sessionID)
+}
+
+// NewAgentSessionEditorRelationship creates the relationship that shares an
+// agent session with a canonical Gestalt subject id such as "user:123".
+//
+// The editor relation grants both view and edit actions in the host-managed
+// authorization model.
+func NewAgentSessionEditorRelationship(subjectID, sessionID string) *Relationship {
+	return NewRelationshipWithTarget(
+		NewAuthorizationSubjectTarget(NewAuthorizationSubject(AuthorizationSubjectTypeSubject, subjectID)),
+		AuthorizationAgentSessionRelationEditor,
+		NewAgentSessionAuthorizationResource(sessionID),
+	)
+}
+
+// NewAgentSessionEditorWriteRequest creates a relationship-write request that
+// shares an agent session with a canonical Gestalt subject id.
+func NewAgentSessionEditorWriteRequest(subjectID, sessionID string) *WriteRelationshipsRequest {
+	return NewWriteRelationshipsRequest(
+		[]*Relationship{NewAgentSessionEditorRelationship(subjectID, sessionID)},
+		nil,
+	)
 }
 
 // AuthorizationProvider serves authorization APIs to the host.

--- a/sdk/go/authorization_client.go
+++ b/sdk/go/authorization_client.go
@@ -307,6 +307,15 @@ func (c *AuthorizationClient) WriteRelationships(ctx context.Context, req *Write
 	return err
 }
 
+// GrantAgentSessionEditor grants a canonical Gestalt subject id editor access
+// to an agent session.
+//
+// This is a convenience wrapper around WriteRelationships using the managed
+// agent-session resource and editor relation.
+func (c *AuthorizationClient) GrantAgentSessionEditor(ctx context.Context, subjectID, sessionID string) error {
+	return c.WriteRelationships(ctx, NewAgentSessionEditorWriteRequest(subjectID, sessionID))
+}
+
 // GetMetadata returns host authorization provider metadata.
 func (c *AuthorizationClient) GetMetadata(ctx context.Context) (*AuthorizationMetadata, error) {
 	if c == nil || c.client == nil {

--- a/sdk/go/authorization_transport_test.go
+++ b/sdk/go/authorization_transport_test.go
@@ -214,11 +214,14 @@ func TestTransport_AuthorizationTCPTargetTokenEnv(t *testing.T) {
 	)); err != nil {
 		t.Fatalf("WriteRelationships: %v", err)
 	}
+	if err := client.GrantAgentSessionEditor(context.Background(), "user:user-123", "session-123"); err != nil {
+		t.Fatalf("GrantAgentSessionEditor: %v", err)
+	}
 
 	harness.mu.Lock()
 	defer harness.mu.Unlock()
-	if len(harness.tokens) != 5 {
-		t.Fatalf("relay tokens = %#v, want five relay-token-go entries", harness.tokens)
+	if len(harness.tokens) != 6 {
+		t.Fatalf("relay tokens = %#v, want six relay-token-go entries", harness.tokens)
 	}
 	for i, token := range harness.tokens {
 		if token != "relay-token-go" {
@@ -255,8 +258,8 @@ func TestTransport_AuthorizationTCPTargetTokenEnv(t *testing.T) {
 	if harness.requests[0].GetAction().GetName() != "assume" {
 		t.Fatalf("action name = %q, want %q", harness.requests[0].GetAction().GetName(), "assume")
 	}
-	if len(harness.writes) != 1 {
-		t.Fatalf("write relationship requests len = %d, want 1", len(harness.writes))
+	if len(harness.writes) != 2 {
+		t.Fatalf("write relationship requests len = %d, want 2", len(harness.writes))
 	}
 	write := harness.writes[0].GetWrites()[0]
 	if write.GetTarget().GetSubjectSet().GetResource().GetType() != "slack_channel" {
@@ -270,6 +273,11 @@ func TestTransport_AuthorizationTCPTargetTokenEnv(t *testing.T) {
 	}
 	if write.GetResource().GetType() != "agent_session" || write.GetResource().GetId() != "session-123" {
 		t.Fatalf("write resource = %#v, want agent_session/session-123", write.GetResource())
+	}
+	helperWrite := harness.writes[1].GetWrites()[0]
+	expectedHelperWrite := gestalt.NewAgentSessionEditorWriteRequest("user:user-123", "session-123").GetWrites()[0]
+	if !gproto.Equal(helperWrite, expectedHelperWrite) {
+		t.Fatalf("helper write = %#v, want %#v", helperWrite, expectedHelperWrite)
 	}
 }
 

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -190,8 +190,13 @@ _AUTHENTICATION_PROTOCOL_EXPORTS = (
 )
 
 _AUTHORIZATION_PROTOCOL_EXPORTS = (
+    "AGENT_SESSION_ACTION_EDIT",
+    "AGENT_SESSION_ACTION_VIEW",
+    "AGENT_SESSION_RELATION_EDITOR",
+    "AGENT_SESSION_RESOURCE_TYPE",
     "AccessEvaluationRequest",
     "ActionSearchRequest",
+    "AUTHORIZATION_SUBJECT_TYPE_SUBJECT",
     "AuthorizationAction",
     "AuthorizationRelationshipTarget",
     "AuthorizationResource",
@@ -205,6 +210,9 @@ _AUTHORIZATION_PROTOCOL_EXPORTS = (
     "ResourceSearchRequest",
     "SubjectSearchRequest",
     "WriteRelationshipsRequest",
+    "agent_session_editor_relationship",
+    "agent_session_editor_write_request",
+    "agent_session_resource",
 )
 
 _WORKFLOW_PROTOCOL_EXPORTS = (

--- a/sdk/python/gestalt/_authorization.py
+++ b/sdk/python/gestalt/_authorization.py
@@ -26,6 +26,11 @@ authorization_pb2_grpc: Any = _authorization_pb2_grpc
 ENV_AUTHORIZATION_SOCKET = "GESTALT_AUTHORIZATION_SOCKET"
 ENV_AUTHORIZATION_SOCKET_TOKEN = f"{ENV_AUTHORIZATION_SOCKET}_TOKEN"
 _AUTHORIZATION_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token"
+AUTHORIZATION_SUBJECT_TYPE_SUBJECT = "subject"
+AGENT_SESSION_RESOURCE_TYPE = "agent_session"
+AGENT_SESSION_RELATION_EDITOR = "editor"
+AGENT_SESSION_ACTION_VIEW = "view"
+AGENT_SESSION_ACTION_EDIT = "edit"
 
 _shared_authorization_transport: dict[str, Any] = {
     "target": "",
@@ -123,6 +128,45 @@ def WriteRelationshipsRequest(*args: Any, **kwargs: Any) -> Any:
     """Create an authorization relationship-write request."""
 
     return authorization_pb2.WriteRelationshipsRequest(*args, **kwargs)
+
+
+def agent_session_resource(session_id: str) -> Any:
+    """Create the managed authorization resource for an agent session.
+
+    Gestalt core treats agent-session sharing as normal authorization data:
+    the resource type is ``agent_session`` and the resource id is the concrete
+    provider session id.
+    """
+
+    return AuthorizationResource(type=AGENT_SESSION_RESOURCE_TYPE, id=session_id)
+
+
+def agent_session_editor_relationship(subject_id: str, session_id: str) -> Any:
+    """Create the relationship that shares an agent session with a subject.
+
+    The ``editor`` relation grants both ``view`` and ``edit`` actions in the
+    host-managed authorization model. ``subject_id`` should be the canonical
+    Gestalt subject id, for example ``user:123``.
+    """
+
+    return Relationship(
+        target=AuthorizationRelationshipTarget(
+            subject=AuthorizationSubject(
+                type=AUTHORIZATION_SUBJECT_TYPE_SUBJECT,
+                id=subject_id,
+            ),
+        ),
+        relation=AGENT_SESSION_RELATION_EDITOR,
+        resource=agent_session_resource(session_id),
+    )
+
+
+def agent_session_editor_write_request(subject_id: str, session_id: str) -> Any:
+    """Create a relationship-write request that shares an agent session."""
+
+    return WriteRelationshipsRequest(
+        writes=[agent_session_editor_relationship(subject_id, session_id)]
+    )
 
 
 class AuthorizationClient:
@@ -247,6 +291,18 @@ class AuthorizationClient:
                 request,
                 authorization_pb2.WriteRelationshipsRequest,
             )
+        )
+
+    def grant_agent_session_editor(self, subject_id: str, session_id: str) -> None:
+        """Grant a subject editor access to an agent session.
+
+        This convenience method writes the same managed authorization tuple as
+        ``agent_session_editor_write_request`` and does not require callers to
+        import generated protobuf modules.
+        """
+
+        self.write_relationships(
+            agent_session_editor_write_request(subject_id, session_id)
         )
 
     def get_metadata(self) -> Any:

--- a/sdk/python/tests/test_authorization_transport.py
+++ b/sdk/python/tests/test_authorization_transport.py
@@ -22,6 +22,7 @@ from gestalt import (
     Relationship,
     ResourceSearchRequest,
     WriteRelationshipsRequest,
+    agent_session_editor_relationship,
 )
 from gestalt.testing import authorization_pb2, authorization_pb2_grpc
 
@@ -156,11 +157,12 @@ class AuthorizationTransportTest(unittest.TestCase):
                         ]
                     )
                 )
+                client.grant_agent_session_editor("user:shared", "session-1")
                 client.close()
             finally:
                 server.stop(grace=0)
 
-        self.assertEqual(len(provider.writes), 1)
+        self.assertEqual(len(provider.writes), 2)
         self.assertEqual(
             provider.writes[0].writes[0],
             authorization_pb2.Relationship(
@@ -172,6 +174,27 @@ class AuthorizationTransportTest(unittest.TestCase):
                         ),
                         relation="member",
                     )
+                ),
+                relation="editor",
+                resource=authorization_pb2.Resource(
+                    type="agent_session",
+                    id="session-1",
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            provider.writes[1].writes[0],
+            agent_session_editor_relationship("user:shared", "session-1"),
+        )
+        self.assertEqual(
+            agent_session_editor_relationship("user:shared", "session-1"),
+            authorization_pb2.Relationship(
+                target=authorization_pb2.RelationshipTarget(
+                    subject=authorization_pb2.Subject(
+                        type="subject",
+                        id="user:shared",
+                    ),
                 ),
                 relation="editor",
                 resource=authorization_pb2.Resource(

--- a/sdk/rust/src/authorization.rs
+++ b/sdk/rust/src/authorization.rs
@@ -19,6 +19,16 @@ pub const ENV_AUTHORIZATION_SOCKET: &str = "GESTALT_AUTHORIZATION_SOCKET";
 /// Environment variable containing the optional authorization relay token.
 pub const ENV_AUTHORIZATION_SOCKET_TOKEN: &str = "GESTALT_AUTHORIZATION_SOCKET_TOKEN";
 const AUTHORIZATION_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
+/// Subject type used for canonical Gestalt subject ids in managed grants.
+pub const AUTHORIZATION_SUBJECT_TYPE_SUBJECT: &str = "subject";
+/// Managed authorization resource type for agent sessions.
+pub const AGENT_SESSION_RESOURCE_TYPE: &str = "agent_session";
+/// Relation that grants view and edit access to an agent session.
+pub const AGENT_SESSION_RELATION_EDITOR: &str = "editor";
+/// Action checked when reading a shared agent session.
+pub const AGENT_SESSION_ACTION_VIEW: &str = "view";
+/// Action checked when creating turns or resolving interactions in a session.
+pub const AGENT_SESSION_ACTION_EDIT: &str = "edit";
 
 #[derive(Debug, thiserror::Error)]
 /// Errors returned by the authorization host-service client.
@@ -82,6 +92,11 @@ impl AuthorizationResource {
             id: id.into(),
             properties: serde_json::Map::new(),
         }
+    }
+
+    /// Creates the managed authorization resource for an agent session.
+    pub fn agent_session(session_id: impl Into<String>) -> Self {
+        Self::new(AGENT_SESSION_RESOURCE_TYPE, session_id)
     }
 }
 
@@ -348,6 +363,25 @@ impl Relationship {
             properties: serde_json::Map::new(),
         }
     }
+
+    /// Creates the relationship that shares an agent session with a canonical
+    /// Gestalt subject id such as `user:123`.
+    ///
+    /// The editor relation grants both view and edit actions in the
+    /// host-managed authorization model.
+    pub fn agent_session_editor(
+        subject_id: impl Into<String>,
+        session_id: impl Into<String>,
+    ) -> Self {
+        Self::with_target(
+            AuthorizationRelationshipTarget::Subject(AuthorizationSubject::new(
+                AUTHORIZATION_SUBJECT_TYPE_SUBJECT,
+                subject_id,
+            )),
+            AGENT_SESSION_RELATION_EDITOR,
+            AuthorizationResource::agent_session(session_id),
+        )
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -445,6 +479,15 @@ impl WriteRelationshipsRequest {
             deletes: Vec::new(),
             model_id: String::new(),
         }
+    }
+
+    /// Creates a write request that shares an agent session with a canonical
+    /// Gestalt subject id.
+    pub fn agent_session_editor(
+        subject_id: impl Into<String>,
+        session_id: impl Into<String>,
+    ) -> Self {
+        Self::writes([Relationship::agent_session_editor(subject_id, session_id)])
     }
 }
 
@@ -675,6 +718,18 @@ impl Authorization {
             .write_relationships(pb::WriteRelationshipsRequest::from(request))
             .await?;
         Ok(())
+    }
+
+    /// Grants a canonical Gestalt subject id editor access to an agent session.
+    pub async fn grant_agent_session_editor(
+        &mut self,
+        subject_id: impl Into<String>,
+        session_id: impl Into<String>,
+    ) -> std::result::Result<(), AuthorizationError> {
+        self.write_relationships(WriteRelationshipsRequest::agent_session_editor(
+            subject_id, session_id,
+        ))
+        .await
     }
 
     /// Returns host authorization provider metadata.

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -57,8 +57,10 @@ pub use auth::{
     CompleteLoginRequest,
 };
 pub use authorization::{
-    AccessDecision, AccessEvaluationRequest, ActionSearchRequest, ActionSearchResponse,
-    Authorization, AuthorizationAction, AuthorizationError, AuthorizationMetadata,
+    AGENT_SESSION_ACTION_EDIT, AGENT_SESSION_ACTION_VIEW, AGENT_SESSION_RELATION_EDITOR,
+    AGENT_SESSION_RESOURCE_TYPE, AUTHORIZATION_SUBJECT_TYPE_SUBJECT, AccessDecision,
+    AccessEvaluationRequest, ActionSearchRequest, ActionSearchResponse, Authorization,
+    AuthorizationAction, AuthorizationError, AuthorizationMetadata,
     AuthorizationRelationshipTarget, AuthorizationResource, AuthorizationSubject,
     AuthorizationSubjectSet, ENV_AUTHORIZATION_SOCKET, ENV_AUTHORIZATION_SOCKET_TOKEN,
     EffectiveSubjectSearchRequest, EffectiveSubjectSearchResponse, ExpandNode, ExpandRequest,

--- a/sdk/rust/tests/authorization_transport.rs
+++ b/sdk/rust/tests/authorization_transport.rs
@@ -352,6 +352,10 @@ async fn authorization_client_uses_public_sdk_types_for_search_and_writes() {
         ]))
         .await
         .expect("write relationships");
+    authorization
+        .grant_agent_session_editor("user:user-123", "session-123")
+        .await
+        .expect("grant agent session editor");
 
     let searches = server.searches.lock().expect("searches lock").clone();
     assert_eq!(searches.len(), 1);
@@ -362,7 +366,7 @@ async fn authorization_client_uses_public_sdk_types_for_search_and_writes() {
     assert_eq!(searches[0].action.as_ref().expect("action").name, "assume");
 
     let writes = server.writes.lock().expect("writes lock").clone();
-    assert_eq!(writes.len(), 1);
+    assert_eq!(writes.len(), 2);
     let write = writes[0].writes[0].clone();
     assert!(write.subject.is_none());
     let target = write.target.expect("target");
@@ -379,10 +383,34 @@ async fn authorization_client_uses_public_sdk_types_for_search_and_writes() {
     );
     assert_eq!(write.resource.as_ref().expect("resource").id, "session-123");
 
+    let helper_write = writes[1].writes[0].clone();
+    let helper = Relationship::agent_session_editor("user:user-123", "session-123");
+    assert_eq!(helper_write.subject, None);
+    assert!(matches!(
+        helper.target,
+        Some(AuthorizationRelationshipTarget::Subject(subject))
+            if subject.r#type == "subject" && subject.id == "user:user-123"
+    ));
+    assert!(matches!(
+        helper_write.target.expect("target").kind,
+        Some(relationship_target::Kind::Subject(subject))
+            if subject.r#type == "subject" && subject.id == "user:user-123"
+    ));
+    assert_eq!(helper.relation, helper_write.relation);
+    assert_eq!(
+        helper.resource.r#type,
+        helper_write.resource.as_ref().expect("resource").r#type
+    );
+    assert_eq!(
+        helper.resource.id,
+        helper_write.resource.as_ref().expect("resource").id
+    );
+
     let tokens = server.seen_tokens.lock().expect("seen tokens lock").clone();
     assert_eq!(
         tokens,
         vec![
+            "relay-token-rust".to_string(),
             "relay-token-rust".to_string(),
             "relay-token-rust".to_string(),
             "relay-token-rust".to_string(),

--- a/sdk/typescript/src/authorization.ts
+++ b/sdk/typescript/src/authorization.ts
@@ -49,6 +49,17 @@ export const ENV_AUTHORIZATION_SOCKET_TOKEN =
 const AUTHORIZATION_RELAY_TOKEN_HEADER =
   "x-gestalt-host-service-relay-token";
 
+/** Subject type used for canonical Gestalt subject ids in managed grants. */
+export const AUTHORIZATION_SUBJECT_TYPE_SUBJECT = "subject";
+/** Managed authorization resource type for agent sessions. */
+export const AGENT_SESSION_RESOURCE_TYPE = "agent_session";
+/** Relation that grants view and edit access to an agent session. */
+export const AGENT_SESSION_RELATION_EDITOR = "editor";
+/** Action checked when reading a shared agent session. */
+export const AGENT_SESSION_ACTION_VIEW = "view";
+/** Action checked when creating turns or resolving interactions in a session. */
+export const AGENT_SESSION_ACTION_EDIT = "edit";
+
 export type AuthorizationEvaluateInput = MessageInitShape<
   typeof AccessEvaluationRequestSchema
 >;
@@ -199,6 +210,21 @@ export class AuthorizationClient {
     await this.client.writeRelationships(request);
   }
 
+  /**
+   * Grants a canonical Gestalt subject id editor access to an agent session.
+   *
+   * This writes the host-managed `agent_session` relationship without requiring
+   * callers to import generated protobuf modules.
+   */
+  async grantAgentSessionEditor(
+    subjectId: string,
+    sessionId: string,
+  ): Promise<void> {
+    await this.writeRelationships(
+      agentSessionEditorWriteRequest(subjectId, sessionId),
+    );
+  }
+
   async getMetadata(): Promise<AuthorizationMetadataMessage> {
     return await this.client.getMetadata({});
   }
@@ -278,6 +304,13 @@ export function authorizationSubjectSetTarget(
   };
 }
 
+/** Creates the managed authorization resource for an agent session. */
+export function agentSessionAuthorizationResource(
+  sessionId: string,
+): AuthorizationResource {
+  return authorizationResource(AGENT_SESSION_RESOURCE_TYPE, sessionId);
+}
+
 /** Creates an authorization action reference. */
 export function authorizationAction(
   name: string,
@@ -308,6 +341,33 @@ export function authorizationRelationshipWithTarget(
   return properties === undefined
     ? { target, relation, resource }
     : { target, relation, resource, properties };
+}
+
+/**
+ * Creates the relationship that shares an agent session with a canonical
+ * Gestalt subject id such as `user:123`.
+ */
+export function agentSessionEditorRelationship(
+  subjectId: string,
+  sessionId: string,
+): AuthorizationRelationship {
+  return authorizationRelationshipWithTarget(
+    authorizationSubjectTarget(
+      authorizationSubject(AUTHORIZATION_SUBJECT_TYPE_SUBJECT, subjectId),
+    ),
+    AGENT_SESSION_RELATION_EDITOR,
+    agentSessionAuthorizationResource(sessionId),
+  );
+}
+
+/** Creates a relationship-write request that shares an agent session. */
+export function agentSessionEditorWriteRequest(
+  subjectId: string,
+  sessionId: string,
+): AuthorizationWriteRelationshipsInput {
+  return {
+    writes: [agentSessionEditorRelationship(subjectId, sessionId)],
+  };
 }
 
 /** Creates a relationship key for authorization deletes. */

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -29,10 +29,18 @@
  * ```
  */
 export {
+  AGENT_SESSION_ACTION_EDIT,
+  AGENT_SESSION_ACTION_VIEW,
+  AGENT_SESSION_RELATION_EDITOR,
+  AGENT_SESSION_RESOURCE_TYPE,
   Authorization,
   AuthorizationClient,
+  AUTHORIZATION_SUBJECT_TYPE_SUBJECT,
   ENV_AUTHORIZATION_SOCKET,
   ENV_AUTHORIZATION_SOCKET_TOKEN,
+  agentSessionAuthorizationResource,
+  agentSessionEditorRelationship,
+  agentSessionEditorWriteRequest,
   authorizationAction,
   authorizationRelationship,
   authorizationRelationshipKeyWithTarget,

--- a/sdk/typescript/tests/authorization.transport.test.ts
+++ b/sdk/typescript/tests/authorization.transport.test.ts
@@ -24,6 +24,7 @@ import {
   AuthorizationClient,
   ENV_AUTHORIZATION_SOCKET,
   ENV_AUTHORIZATION_SOCKET_TOKEN,
+  agentSessionEditorRelationship,
   authorizationAction,
   authorizationRelationshipWithTarget,
   authorizationResource,
@@ -74,6 +75,7 @@ test("Authorization() forwards authorization requests to the host socket", async
     relation: string;
   }> = [];
   const writeCalls: Array<{
+    targetSubjectId: string;
     targetResourceType: string;
     targetRelation: string;
     relation: string;
@@ -168,6 +170,10 @@ test("Authorization() forwards authorization requests to the host socket", async
           async writeRelationships(input) {
             for (const write of input.writes) {
               writeCalls.push({
+                targetSubjectId:
+                  write.target?.kind.case === "subject"
+                    ? write.target.kind.value.id
+                    : "",
                 targetResourceType:
                   write.target?.kind.case === "subjectSet"
                     ? write.target.kind.value.resource?.type ?? ""
@@ -287,10 +293,32 @@ test("Authorization() forwards authorization requests to the host socket", async
         ),
       ],
     });
+    await Authorization().grantAgentSessionEditor("user:user-123", "session-123");
+    expect(
+      agentSessionEditorRelationship("user:user-123", "session-123"),
+    ).toEqual({
+      target: {
+        kind: {
+          case: "subject",
+          value: { type: "subject", id: "user:user-123" },
+        },
+      },
+      relation: "editor",
+      resource: { type: "agent_session", id: "session-123" },
+    });
     expect(writeCalls).toEqual([
       {
+        targetSubjectId: "",
         targetResourceType: "slack_channel",
         targetRelation: "member",
+        relation: "editor",
+        resourceType: "agent_session",
+        resourceId: "session-123",
+      },
+      {
+        targetSubjectId: "user:user-123",
+        targetResourceType: "",
+        targetRelation: "",
         relation: "editor",
         resourceType: "agent_session",
         resourceId: "session-123",


### PR DESCRIPTION
## Summary
- add agent-session authorization constants, builders, and grant helpers across Python, Go, TypeScript, and Rust SDKs
- use the generalized relationship target shape for the helper writes, preserving the existing AuthorizationProvider RPC/model surface
- document the helper usage in the SDK reference pages

## Tests
- sdk/python: uv run ruff check gestalt/_authorization.py gestalt/__init__.py tests/test_authorization_transport.py && uv run python -m unittest tests.test_authorization_transport
- sdk/go: go test -run TestTransport_AuthorizationTCPTargetTokenEnv .
- sdk/typescript: bun test tests/authorization.transport.test.ts && bun run typecheck
- sdk/rust: cargo test --manifest-path sdk/rust/Cargo.toml --test authorization_transport authorization_client_uses_public_sdk_types_for_search_and_writes
- git diff --check