### PR TITLE
Mirror subject in agent session SDK grants

### DIFF
--- a/sdk/go/authorization.go
+++ b/sdk/go/authorization.go
@@ -353,13 +353,18 @@ func NewAgentSessionAuthorizationResource(sessionID string) *AuthorizationResour
 // agent session with a canonical Gestalt subject id such as "user:123".
 //
 // The editor relation grants both view and edit actions in the host-managed
-// authorization model.
+// authorization model. The returned relationship mirrors the subject into both
+// the legacy Subject field and the generalized Target field so it remains
+// compatible with mixed host/provider versions.
 func NewAgentSessionEditorRelationship(subjectID, sessionID string) *Relationship {
-	return NewRelationshipWithTarget(
-		NewAuthorizationSubjectTarget(NewAuthorizationSubject(AuthorizationSubjectTypeSubject, subjectID)),
+	subject := NewAuthorizationSubject(AuthorizationSubjectTypeSubject, subjectID)
+	rel := NewRelationshipWithTarget(
+		NewAuthorizationSubjectTarget(subject),
 		AuthorizationAgentSessionRelationEditor,
 		NewAgentSessionAuthorizationResource(sessionID),
 	)
+	rel.Subject = subject
+	return rel
 }
 
 // NewAgentSessionEditorWriteRequest creates a relationship-write request that

--- a/sdk/go/authorization_transport_test.go
+++ b/sdk/go/authorization_transport_test.go
@@ -279,6 +279,12 @@ func TestTransport_AuthorizationTCPTargetTokenEnv(t *testing.T) {
 	if !gproto.Equal(helperWrite, expectedHelperWrite) {
 		t.Fatalf("helper write = %#v, want %#v", helperWrite, expectedHelperWrite)
 	}
+	if helperWrite.GetSubject().GetType() != "subject" || helperWrite.GetSubject().GetId() != "user:user-123" {
+		t.Fatalf("helper write subject = %#v, want subject/user:user-123", helperWrite.GetSubject())
+	}
+	if helperWrite.GetTarget().GetSubject().GetType() != "subject" || helperWrite.GetTarget().GetSubject().GetId() != "user:user-123" {
+		t.Fatalf("helper write target subject = %#v, want subject/user:user-123", helperWrite.GetTarget().GetSubject())
+	}
 }
 
 type fullAuthorizationProvider struct {

--- a/sdk/python/gestalt/_authorization.py
+++ b/sdk/python/gestalt/_authorization.py
@@ -146,15 +146,19 @@ def agent_session_editor_relationship(subject_id: str, session_id: str) -> Any:
 
     The ``editor`` relation grants both ``view`` and ``edit`` actions in the
     host-managed authorization model. ``subject_id`` should be the canonical
-    Gestalt subject id, for example ``user:123``.
+    Gestalt subject id, for example ``user:123``. The returned relationship
+    fills both the legacy ``subject`` field and the generalized
+    ``target.subject`` field so it works across mixed host/provider versions.
     """
 
+    subject = AuthorizationSubject(
+        type=AUTHORIZATION_SUBJECT_TYPE_SUBJECT,
+        id=subject_id,
+    )
     return Relationship(
+        subject=subject,
         target=AuthorizationRelationshipTarget(
-            subject=AuthorizationSubject(
-                type=AUTHORIZATION_SUBJECT_TYPE_SUBJECT,
-                id=subject_id,
-            ),
+            subject=subject,
         ),
         relation=AGENT_SESSION_RELATION_EDITOR,
         resource=agent_session_resource(session_id),

--- a/sdk/python/tests/test_authorization_transport.py
+++ b/sdk/python/tests/test_authorization_transport.py
@@ -190,6 +190,10 @@ class AuthorizationTransportTest(unittest.TestCase):
         self.assertEqual(
             agent_session_editor_relationship("user:shared", "session-1"),
             authorization_pb2.Relationship(
+                subject=authorization_pb2.Subject(
+                    type="subject",
+                    id="user:shared",
+                ),
                 target=authorization_pb2.RelationshipTarget(
                     subject=authorization_pb2.Subject(
                         type="subject",

--- a/sdk/rust/src/authorization.rs
+++ b/sdk/rust/src/authorization.rs
@@ -368,19 +368,21 @@ impl Relationship {
     /// Gestalt subject id such as `user:123`.
     ///
     /// The editor relation grants both view and edit actions in the
-    /// host-managed authorization model.
+    /// host-managed authorization model. The returned relationship mirrors the
+    /// subject into both the legacy `subject` field and generalized `target`
+    /// field so it remains compatible with mixed host/provider versions.
     pub fn agent_session_editor(
         subject_id: impl Into<String>,
         session_id: impl Into<String>,
     ) -> Self {
-        Self::with_target(
-            AuthorizationRelationshipTarget::Subject(AuthorizationSubject::new(
-                AUTHORIZATION_SUBJECT_TYPE_SUBJECT,
-                subject_id,
-            )),
-            AGENT_SESSION_RELATION_EDITOR,
-            AuthorizationResource::agent_session(session_id),
-        )
+        let subject = AuthorizationSubject::new(AUTHORIZATION_SUBJECT_TYPE_SUBJECT, subject_id);
+        Self {
+            subject: subject.clone(),
+            target: Some(AuthorizationRelationshipTarget::Subject(subject)),
+            relation: AGENT_SESSION_RELATION_EDITOR.to_string(),
+            resource: AuthorizationResource::agent_session(session_id),
+            properties: serde_json::Map::new(),
+        }
     }
 }
 

--- a/sdk/rust/tests/authorization_transport.rs
+++ b/sdk/rust/tests/authorization_transport.rs
@@ -385,7 +385,11 @@ async fn authorization_client_uses_public_sdk_types_for_search_and_writes() {
 
     let helper_write = writes[1].writes[0].clone();
     let helper = Relationship::agent_session_editor("user:user-123", "session-123");
-    assert_eq!(helper_write.subject, None);
+    assert_eq!(helper.subject.r#type, "subject");
+    assert_eq!(helper.subject.id, "user:user-123");
+    let helper_write_subject = helper_write.subject.as_ref().expect("subject");
+    assert_eq!(helper_write_subject.r#type, "subject");
+    assert_eq!(helper_write_subject.id, "user:user-123");
     assert!(matches!(
         helper.target,
         Some(AuthorizationRelationshipTarget::Subject(subject))

--- a/sdk/typescript/src/authorization.ts
+++ b/sdk/typescript/src/authorization.ts
@@ -346,18 +346,25 @@ export function authorizationRelationshipWithTarget(
 /**
  * Creates the relationship that shares an agent session with a canonical
  * Gestalt subject id such as `user:123`.
+ *
+ * The returned relationship mirrors the subject into both the legacy `subject`
+ * field and the generalized `target.subject` field so it remains compatible
+ * with mixed host/provider versions.
  */
 export function agentSessionEditorRelationship(
   subjectId: string,
   sessionId: string,
 ): AuthorizationRelationship {
-  return authorizationRelationshipWithTarget(
-    authorizationSubjectTarget(
-      authorizationSubject(AUTHORIZATION_SUBJECT_TYPE_SUBJECT, subjectId),
-    ),
-    AGENT_SESSION_RELATION_EDITOR,
-    agentSessionAuthorizationResource(sessionId),
+  const subject = authorizationSubject(
+    AUTHORIZATION_SUBJECT_TYPE_SUBJECT,
+    subjectId,
   );
+  return {
+    subject,
+    target: authorizationSubjectTarget(subject),
+    relation: AGENT_SESSION_RELATION_EDITOR,
+    resource: agentSessionAuthorizationResource(sessionId),
+  };
 }
 
 /** Creates a relationship-write request that shares an agent session. */

--- a/sdk/typescript/tests/authorization.transport.test.ts
+++ b/sdk/typescript/tests/authorization.transport.test.ts
@@ -75,6 +75,7 @@ test("Authorization() forwards authorization requests to the host socket", async
     relation: string;
   }> = [];
   const writeCalls: Array<{
+    subjectId: string;
     targetSubjectId: string;
     targetResourceType: string;
     targetRelation: string;
@@ -170,6 +171,7 @@ test("Authorization() forwards authorization requests to the host socket", async
           async writeRelationships(input) {
             for (const write of input.writes) {
               writeCalls.push({
+                subjectId: write.subject?.id ?? "",
                 targetSubjectId:
                   write.target?.kind.case === "subject"
                     ? write.target.kind.value.id
@@ -297,6 +299,7 @@ test("Authorization() forwards authorization requests to the host socket", async
     expect(
       agentSessionEditorRelationship("user:user-123", "session-123"),
     ).toEqual({
+      subject: { type: "subject", id: "user:user-123" },
       target: {
         kind: {
           case: "subject",
@@ -308,6 +311,7 @@ test("Authorization() forwards authorization requests to the host socket", async
     });
     expect(writeCalls).toEqual([
       {
+        subjectId: "",
         targetSubjectId: "",
         targetResourceType: "slack_channel",
         targetRelation: "member",
@@ -316,6 +320,7 @@ test("Authorization() forwards authorization requests to the host socket", async
         resourceId: "session-123",
       },
       {
+        subjectId: "user:user-123",
         targetSubjectId: "user:user-123",
         targetResourceType: "",
         targetRelation: "",


### PR DESCRIPTION
## Summary
- Mirror canonical agent-session grant subjects into both the legacy subject field and `target.subject` in Python, Go, TypeScript, and Rust SDK helpers
- Document the mixed host/provider compatibility behavior in each SDK helper
- Update SDK transport tests to assert both fields are populated

## Context
Slack session-start delivery in production returned `{"error":"failed to share agent session"}` before posting the link. The deployed Slack provider writes the SDK helper output through `AuthorizationProvider.WriteRelationships`. Populating both fields keeps the helper compatible with target-aware Zanzibar providers while avoiding failures in mixed-version paths that still require the legacy subject field.

## Tests
- `uv run pytest tests/test_authorization_transport.py` (sdk/python)
- `go test ./...` (sdk/go)
- `bun test tests/authorization.transport.test.ts` (sdk/typescript)
- `cargo test --manifest-path sdk/rust/Cargo.toml --test authorization_transport`