### PR TITLE
Use git source materialization

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -196,7 +196,7 @@ type GitSourceDef struct {
 	Ref                string `yaml:"ref,omitempty"`
 	Path               string `yaml:"path,omitempty"`
 	ArtifactRepository string `yaml:"artifactRepository,omitempty"`
-	ArtifactMode       string `yaml:"artifactMode,omitempty"`
+	Materialization    string `yaml:"materialization,omitempty"`
 }
 
 func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
@@ -417,7 +417,7 @@ func cloneGitSourceDef(src *GitSourceDef) *GitSourceDef {
 	cloned.Ref = strings.TrimSpace(cloned.Ref)
 	cloned.Path = strings.TrimSpace(cloned.Path)
 	cloned.ArtifactRepository = strings.TrimSpace(cloned.ArtifactRepository)
-	cloned.ArtifactMode = strings.TrimSpace(cloned.ArtifactMode)
+	cloned.Materialization = strings.TrimSpace(cloned.Materialization)
 	return &cloned
 }
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1676,7 +1676,7 @@ plugins:
           repo: HTTPS://GitHub.com/Valon-Technologies/Gestalt-Providers
           ref: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           path: plugins//custom_tool/../custom_tool/manifest.yaml
-          artifactMode: source
+          materialization: source
 `)
 
 		cfg, err := Load(path)

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -629,18 +629,21 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 		default:
 			return fmt.Errorf("config validation: %s %q source.git.repo must use http(s) or file URL", kind, name)
 		}
-		mode := strings.TrimSpace(git.ArtifactMode)
+		materialization := strings.TrimSpace(git.Materialization)
 		repoName := strings.TrimSpace(git.ArtifactRepository)
-		switch mode {
-		case "", "source", "prefer", "require":
+		switch materialization {
+		case "":
+			materialization = "source"
+		case "source", "snapshot":
 		default:
-			return fmt.Errorf("config validation: %s %q source.git.artifactMode must be source, prefer, or require", kind, name)
+			return fmt.Errorf("config validation: %s %q source.git.materialization must be source or snapshot", kind, name)
 		}
-		if repoName != "" && mode == "" {
-			return fmt.Errorf("config validation: %s %q source.git.artifactMode is required when artifactRepository is set", kind, name)
-		}
-		if (mode == "prefer" || mode == "require") && repoName == "" {
-			return fmt.Errorf("config validation: %s %q source.git.artifactRepository is required for artifactMode %q", kind, name, mode)
+		if materialization == "snapshot" {
+			if repoName == "" {
+				return fmt.Errorf("config validation: %s %q source.git.artifactRepository is required for materialization %q", kind, name, materialization)
+			}
+		} else if repoName != "" {
+			return fmt.Errorf("config validation: %s %q source.git.artifactRepository is only supported for materialization \"snapshot\"", kind, name)
 		}
 		if repoName != "" {
 			if err := providerregistry.ValidateRepositoryName(repoName); err != nil {

--- a/gestaltd/internal/operator/git_source.go
+++ b/gestaltd/internal/operator/git_source.go
@@ -18,12 +18,9 @@ import (
 )
 
 const (
-	gitSourceRefType        = "git"
-	gitArtifactModeSource   = "source"
-	gitArtifactModePrefer   = "prefer"
-	gitArtifactModeRequire  = "require"
-	gitResolvedModeSource   = "source"
-	gitResolvedModeSnapshot = "snapshot"
+	gitSourceRefType           = "git"
+	gitMaterializationSource   = "source"
+	gitMaterializationSnapshot = "snapshot"
 )
 
 type gitSnapshotSource struct {
@@ -38,18 +35,17 @@ func gitSourceDef(entry *config.ProviderEntry) *config.GitSourceDef {
 	return entry.Source.GitSource()
 }
 
-func gitSourceArtifactMode(git *config.GitSourceDef) string {
+func gitSourceMaterialization(git *config.GitSourceDef) string {
 	if git == nil {
 		return ""
 	}
-	mode := strings.TrimSpace(git.ArtifactMode)
-	if mode == "" {
-		return gitArtifactModeSource
+	if materialization := strings.TrimSpace(git.Materialization); materialization != "" {
+		return materialization
 	}
-	return mode
+	return gitMaterializationSource
 }
 
-func gitSourceLockRef(entry *config.ProviderEntry, resolvedMode, resolvedGestaltRef string) *LockSourceRef {
+func gitSourceLockRef(entry *config.ProviderEntry, resolvedGestaltRef string) *LockSourceRef {
 	git := gitSourceDef(entry)
 	if git == nil {
 		return nil
@@ -61,14 +57,13 @@ func gitSourceLockRef(entry *config.ProviderEntry, resolvedMode, resolvedGestalt
 		Ref:                ref,
 		Path:               manifestPath,
 		ArtifactRepository: strings.TrimSpace(git.ArtifactRepository),
-		ArtifactMode:       gitSourceArtifactMode(git),
-		ResolvedMode:       strings.TrimSpace(resolvedMode),
+		Materialization:    gitSourceMaterialization(git),
 		ResolvedGestaltRef: strings.TrimSpace(resolvedGestaltRef),
 	}
 }
 
 func gitSourceFingerprintLocation(entry *config.ProviderEntry) string {
-	ref := gitSourceLockRef(entry, "", "")
+	ref := gitSourceLockRef(entry, "")
 	if ref == nil {
 		return ""
 	}
@@ -78,31 +73,21 @@ func gitSourceFingerprintLocation(entry *config.ProviderEntry) string {
 		ref.Ref,
 		ref.Path,
 		ref.ArtifactRepository,
-		ref.ArtifactMode,
+		ref.Materialization,
 	}, "\x00")
 }
 
 func gitSourceMatchesLockRef(entry *config.ProviderEntry, lockRef *LockSourceRef) bool {
-	expected := gitSourceLockRef(entry, "", "")
+	expected := gitSourceLockRef(entry, "")
 	if expected == nil || lockRef == nil {
 		return false
 	}
-	if lockRef.Type != gitSourceRefType ||
-		lockRef.Repo != expected.Repo ||
-		!strings.EqualFold(lockRef.Ref, expected.Ref) ||
-		lockRef.Path != expected.Path ||
-		lockRef.ArtifactRepository != expected.ArtifactRepository ||
-		lockRef.ArtifactMode != expected.ArtifactMode {
-		return false
-	}
-	switch expected.ArtifactMode {
-	case gitArtifactModeRequire:
-		return lockRef.ResolvedMode == gitResolvedModeSnapshot
-	case gitArtifactModeSource:
-		return lockRef.ResolvedMode == gitResolvedModeSource
-	default:
-		return lockRef.ResolvedMode == gitResolvedModeSnapshot || lockRef.ResolvedMode == gitResolvedModeSource
-	}
+	return lockRef.Type == gitSourceRefType &&
+		lockRef.Repo == expected.Repo &&
+		strings.EqualFold(lockRef.Ref, expected.Ref) &&
+		lockRef.Path == expected.Path &&
+		lockRef.ArtifactRepository == expected.ArtifactRepository &&
+		lockRef.Materialization == expected.Materialization
 }
 
 func canonicalGitSourceLocation(entry *config.ProviderEntry) string {
@@ -187,7 +172,8 @@ func (l *Lifecycle) gitSourceManifestPath(ctx context.Context, paths lifecyclePa
 
 func (l *Lifecycle) lockGitProviderEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, name string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
 	destDir := providerDestDir(paths, name)
-	if entry, installed, ok, err := l.tryLockGitSnapshotSource(ctx, cfg, paths, providermanifestv1.KindPlugin, name, fmt.Sprintf("provider %q", name), destDir, plugin); ok || err != nil {
+	if gitSourceMaterialization(gitSourceDef(plugin)) == gitMaterializationSnapshot {
+		entry, installed, err := l.lockGitSnapshotSource(ctx, cfg, paths, providermanifestv1.KindPlugin, name, fmt.Sprintf("provider %q", name), destDir, plugin)
 		if err != nil {
 			return LockEntry{}, err
 		}
@@ -209,7 +195,8 @@ func (l *Lifecycle) lockGitProviderEntryForSource(ctx context.Context, cfg *conf
 
 func (l *Lifecycle) lockGitComponentEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, kind, name, destDir string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
 	subject := fmt.Sprintf("%s %q", kind, name)
-	if entry, installed, ok, err := l.tryLockGitSnapshotSource(ctx, cfg, paths, kind, name, subject, destDir, plugin); ok || err != nil {
+	if gitSourceMaterialization(gitSourceDef(plugin)) == gitMaterializationSnapshot {
+		entry, installed, err := l.lockGitSnapshotSource(ctx, cfg, paths, kind, name, subject, destDir, plugin)
 		if err != nil {
 			return LockEntry{}, err
 		}
@@ -230,7 +217,8 @@ func (l *Lifecycle) lockGitComponentEntryForSource(ctx context.Context, cfg *con
 }
 
 func (l *Lifecycle) lockGitUIEntryForSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, name string, plugin *config.ProviderEntry, destDir, subject string, configMap map[string]any) (LockEntry, error) {
-	if entry, installed, ok, err := l.tryLockGitSnapshotSource(ctx, cfg, paths, providermanifestv1.KindUI, name, subject, destDir, plugin); ok || err != nil {
+	if gitSourceMaterialization(gitSourceDef(plugin)) == gitMaterializationSnapshot {
+		entry, installed, err := l.lockGitSnapshotSource(ctx, cfg, paths, providermanifestv1.KindUI, name, subject, destDir, plugin)
 		if err != nil {
 			return LockEntry{}, err
 		}
@@ -250,38 +238,24 @@ func (l *Lifecycle) lockGitUIEntryForSource(ctx context.Context, cfg *config.Con
 	return gitLocalLockEntryFromPreparedInstall(paths, providermanifestv1.KindUI, "ui:"+name, plugin, install, true)
 }
 
-func (l *Lifecycle) tryLockGitSnapshotSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, expectedKind, name, subject, destDir string, plugin *config.ProviderEntry) (LockEntry, *installedPackage, bool, error) {
-	git := gitSourceDef(plugin)
-	mode := gitSourceArtifactMode(git)
-	if mode == gitArtifactModeSource {
-		return LockEntry{}, nil, false, nil
-	}
+func (l *Lifecycle) lockGitSnapshotSource(ctx context.Context, cfg *config.Config, paths lifecyclePaths, expectedKind, name, subject, destDir string, plugin *config.ProviderEntry) (LockEntry, *installedPackage, error) {
 	if cfg == nil {
-		if mode == gitArtifactModeRequire {
-			return LockEntry{}, nil, false, fmt.Errorf("%s source.git snapshot resolution requires loaded config", subject)
-		}
-		return LockEntry{}, nil, false, nil
+		return LockEntry{}, nil, fmt.Errorf("%s source.git snapshot resolution requires loaded config", subject)
 	}
 	snapshot, err := resolveGitSnapshotSource(cfg, plugin)
 	if err != nil {
-		if mode == gitArtifactModeRequire {
-			return LockEntry{}, nil, false, fmt.Errorf("%s resolve source.git snapshot: %w", subject, err)
-		}
-		return LockEntry{}, nil, false, nil
+		return LockEntry{}, nil, fmt.Errorf("%s resolve source.git snapshot: %w", subject, err)
 	}
 	metadataProvider := *plugin
 	metadataProvider.Source = config.NewMetadataSource(snapshot.MetadataURL)
 	metadataProvider.Source.Auth = plugin.Source.Auth
 	installed, entry, err := l.installMetadataSourcePackage(ctx, expectedKind, name, subject, destDir, &metadataProvider, paths.configDir)
 	if err != nil {
-		if mode == gitArtifactModeRequire {
-			return LockEntry{}, nil, false, fmt.Errorf("%s source.git snapshot %s: %w", subject, snapshot.MetadataURL, err)
-		}
-		return LockEntry{}, nil, false, nil
+		return LockEntry{}, nil, fmt.Errorf("%s source.git snapshot %s: %w", subject, snapshot.MetadataURL, err)
 	}
 	entry.Source = snapshot.MetadataURL
-	entry.SourceRef = gitSourceLockRef(plugin, gitResolvedModeSnapshot, snapshot.GestaltRef)
-	return entry, installed, true, nil
+	entry.SourceRef = gitSourceLockRef(plugin, snapshot.GestaltRef)
+	return entry, installed, nil
 }
 
 func (l *Lifecycle) prepareGitSourceInstall(ctx context.Context, paths lifecyclePaths, kind, name, destDir string, plugin *config.ProviderEntry) (*preparedInstall, error) {
@@ -319,7 +293,7 @@ func gitLocalLockEntryFromPreparedInstall(paths lifecyclePaths, kind, fingerprin
 		return LockEntry{}, err
 	}
 	entry.Source = canonicalGitSourceLocation(plugin)
-	entry.SourceRef = gitSourceLockRef(plugin, gitResolvedModeSource, "")
+	entry.SourceRef = gitSourceLockRef(plugin, "")
 	entry.Package = install.manifest.Source
 	entry.Kind = install.manifest.Kind
 	entry.Runtime = releaseRuntimeForManifest(install.manifest, archivePolicyKind(kind))

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -76,8 +76,7 @@ type LockSourceRef struct {
 	Ref                string `json:"ref,omitempty"`
 	Path               string `json:"path,omitempty"`
 	ArtifactRepository string `json:"artifactRepository,omitempty"`
-	ArtifactMode       string `json:"artifactMode,omitempty"`
-	ResolvedMode       string `json:"resolvedMode,omitempty"`
+	Materialization    string `json:"materialization,omitempty"`
 	ResolvedGestaltRef string `json:"resolvedGestaltRef,omitempty"`
 }
 

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -68,7 +68,7 @@ plugins:
         repo: file://%s
         ref: %s
         path: plugins/alpha/manifest.yaml
-        artifactMode: source
+        materialization: source
 `, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), filepath.ToSlash(artifactsDir), filepath.ToSlash(repoDir), ref)
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -83,8 +83,8 @@ plugins:
 	if entry.SourceRef == nil {
 		t.Fatal("sourceRef missing")
 	}
-	if entry.SourceRef.ResolvedMode != gitResolvedModeSource {
-		t.Fatalf("sourceRef.resolvedMode = %q, want %q", entry.SourceRef.ResolvedMode, gitResolvedModeSource)
+	if entry.SourceRef.Materialization != gitMaterializationSource {
+		t.Fatalf("sourceRef materialization = %q", entry.SourceRef.Materialization)
 	}
 	if entry.SourceRef.Ref != ref {
 		t.Fatalf("sourceRef.ref = %q, want %q", entry.SourceRef.Ref, ref)
@@ -186,7 +186,7 @@ plugins:
         ref: %s
         path: plugins/alpha/manifest.yaml
         artifactRepository: valon
-        artifactMode: require
+        materialization: snapshot
 `, srv.URL, gestaltRef, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "snapshot.db")), filepath.ToSlash(artifactsDir), ref)
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -200,8 +200,8 @@ plugins:
 	if entry.SourceRef == nil {
 		t.Fatal("sourceRef missing")
 	}
-	if entry.SourceRef.ResolvedMode != gitResolvedModeSnapshot {
-		t.Fatalf("resolvedMode = %q, want %q", entry.SourceRef.ResolvedMode, gitResolvedModeSnapshot)
+	if entry.SourceRef.Materialization != gitMaterializationSnapshot {
+		t.Fatalf("sourceRef materialization = %q", entry.SourceRef.Materialization)
 	}
 	if entry.SourceRef.ResolvedGestaltRef != gestaltRef {
 		t.Fatalf("resolvedGestaltRef = %q, want %q", entry.SourceRef.ResolvedGestaltRef, gestaltRef)
@@ -305,7 +305,7 @@ providers:
           ref: %s
           path: secrets/google/manifest.yaml
           artifactRepository: valon
-          artifactMode: require
+          materialization: snapshot
 `, srv.URL, gestaltRef, filepath.ToSlash(artifactsDir), filepath.ToSlash(indexedDBManifestPath), filepath.Join(dir, "secrets.db"), ref)
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -319,8 +319,8 @@ providers:
 	if entry.SourceRef == nil {
 		t.Fatal("secrets sourceRef missing")
 	}
-	if entry.SourceRef.ResolvedMode != gitResolvedModeSnapshot {
-		t.Fatalf("secrets resolvedMode = %q, want %q", entry.SourceRef.ResolvedMode, gitResolvedModeSnapshot)
+	if entry.SourceRef.Materialization != gitMaterializationSnapshot {
+		t.Fatalf("secrets materialization = %q", entry.SourceRef.Materialization)
 	}
 	if got := metadataCount.Load(); got != 1 {
 		t.Fatalf("metadata count = %d, want 1", got)


### PR DESCRIPTION
## Summary
- Replace git artifact mode language with `source.git.materialization`.
- Support only `materialization: source` and `materialization: snapshot`; remove `prefer` fallback behavior.
- Remove legacy `artifactMode` and redundant `resolvedMode` config/lock fields entirely.

## Test plan
- [x] `go test ./internal/config`
- [x] `go test ./internal/operator`