### PR TITLE
docs: migrate SDK snippets off proto helpers

### DIFF
--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -218,7 +218,6 @@ details. Those come from the deployment bindings.
       "time"
 
       gestalt "github.com/valon-technologies/gestalt/sdk/go"
-      "google.golang.org/protobuf/types/known/structpb"
     )
 
     type Provider struct{}
@@ -313,18 +312,18 @@ details. Those come from the deployment bindings.
       if err != nil {
         return gestalt.Response[NightlyReportOutput]{}, err
       }
-      data, err := structpb.NewStruct(map[string]any{"reportUrl": access.URL})
+      event, err := gestalt.NewWorkflowEvent(gestalt.WorkflowEventInput{
+        Type:            "workspace_review.report.generated",
+        Source:          "workspace_review",
+        Subject:         "nightly",
+        DataContentType: "application/json",
+        Data:            map[string]any{"reportUrl": access.URL},
+      })
       if err != nil {
         return gestalt.Response[NightlyReportOutput]{}, err
       }
       _, err = workflows.PublishEvent(ctx, &gestalt.WorkflowManagerPublishEventRequest{
-        Event: &gestalt.WorkflowEvent{
-          Type:            "workspace_review.report.generated",
-          Source:          "workspace_review",
-          Subject:         "nightly",
-          Datacontenttype: "application/json",
-          Data:            data,
-        },
+        Event: event,
       })
       if err != nil {
         return gestalt.Response[NightlyReportOutput]{}, err
@@ -363,7 +362,7 @@ details. Those come from the deployment bindings.
         WriteOptions,
         PresignOptions,
         PresignMethod,
-        WorkflowEvent,
+        workflow_event,
         WorkflowManagerPublishEventRequest,
     )
 
@@ -419,13 +418,13 @@ details. Those come from the deployment bindings.
             }
         )
 
-        event = WorkflowEvent(
+        event = workflow_event(
             type="workspace_review.report.generated",
             source="workspace_review",
             subject="nightly",
             datacontenttype="application/json",
+            data={"reportUrl": access.url},
         )
-        event.data.update({"reportUrl": access.url})
         with request.workflow_manager() as workflows:
             workflows.publish_event(
                 WorkflowManagerPublishEventRequest(event=event)
@@ -441,10 +440,9 @@ details. Those come from the deployment bindings.
     use std::collections::BTreeMap;
 
     use gestalt::{
-        proto::v1::{WorkflowEvent, WorkflowManagerPublishEventRequest},
-        IndexedDB, PresignMethod, PresignOptions, S3,
+        IndexedDB, PresignMethod, PresignOptions, S3, WorkflowEventInput,
+        WorkflowManagerPublishEventRequest,
     };
-    use prost_types::{value::Kind, Struct, Value};
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
@@ -524,23 +522,17 @@ details. Those come from the deployment bindings.
             .await?;
 
         let mut workflows = request.workflow_manager().await?;
+        let event = gestalt::new_workflow_event(WorkflowEventInput {
+            event_type: "workspace_review.report.generated".to_string(),
+            source: "workspace_review".to_string(),
+            subject: "nightly".to_string(),
+            datacontenttype: "application/json".to_string(),
+            data: Some(json!({ "reportUrl": access.url.clone() })),
+            ..Default::default()
+        })?;
         workflows
             .publish_event(WorkflowManagerPublishEventRequest {
-                event: Some(WorkflowEvent {
-                    r#type: "workspace_review.report.generated".to_string(),
-                    source: "workspace_review".to_string(),
-                    subject: "nightly".to_string(),
-                    datacontenttype: "application/json".to_string(),
-                    data: Some(Struct {
-                        fields: BTreeMap::from([(
-                            "reportUrl".to_string(),
-                            Value {
-                                kind: Some(Kind::StringValue(access.url.clone())),
-                            },
-                        )]),
-                    }),
-                    ..Default::default()
-                }),
+                event: Some(event),
                 ..Default::default()
             })
             .await?;

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -403,7 +403,6 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
         "context"
 
         gestalt "github.com/valon-technologies/gestalt/sdk/go"
-        proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
     )
 
     type AgentSummary struct {
@@ -419,7 +418,7 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
         }
         defer agents.Close()
 
-        session, err := agents.CreateSession(ctx, &proto.AgentManagerCreateSessionRequest{
+        session, err := agents.CreateSession(ctx, &gestalt.AgentManagerCreateSessionRequest{
             ProviderName: "simple",
             Model:        "fast",
             ClientRef:    "roadmap-risk",
@@ -428,14 +427,14 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
             return AgentSummary{}, err
         }
 
-        turn, err := agents.CreateTurn(ctx, &proto.AgentManagerCreateTurnRequest{
+        turn, err := agents.CreateTurn(ctx, &gestalt.AgentManagerCreateTurnRequest{
             SessionId: session.GetId(),
             Model:     "fast",
-            Messages: []*proto.AgentMessage{{
+            Messages: []*gestalt.AgentMessage{{
                 Role: "user",
                 Text: "Summarize the latest roadmap risk.",
             }},
-            ToolRefs: []*proto.AgentToolRef{{
+            ToolRefs: []*gestalt.AgentToolRef{{
                 Plugin:    "roadmap",
                 Operation: "sync",
             }},
@@ -444,7 +443,7 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
             return AgentSummary{}, err
         }
 
-        events, err := agents.ListTurnEvents(ctx, &proto.AgentManagerListTurnEventsRequest{
+        events, err := agents.ListTurnEvents(ctx, &gestalt.AgentManagerListTurnEventsRequest{
             TurnId: turn.GetId(),
             Limit:  100,
         })
@@ -513,7 +512,7 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use gestalt::proto::v1::{
+    use gestalt::{
         AgentManagerCreateSessionRequest, AgentManagerCreateTurnRequest,
         AgentManagerListTurnEventsRequest, AgentMessage, AgentToolRef,
     };
@@ -734,7 +733,6 @@ signals instead of creating duplicate runs.
         "context"
 
         gestalt "github.com/valon-technologies/gestalt/sdk/go"
-        proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
     )
 
     func enqueueAgentWorkflow(ctx context.Context, request gestalt.Request, itemID string) (string, error) {
@@ -744,26 +742,33 @@ signals instead of creating duplicate runs.
         }
         defer workflows.Close()
 
-        queued, err := workflows.SignalOrStartRun(ctx, &proto.WorkflowManagerSignalOrStartRunRequest{
+        target, err := gestalt.NewBoundWorkflowTarget(gestalt.BoundWorkflowTargetInput{
+            Agent: &gestalt.BoundWorkflowAgentTargetInput{
+                ProviderName: "simple",
+                Model:        "fast",
+                Prompt:       "Summarize the updated roadmap item.",
+                ToolRefs: []*gestalt.AgentToolRef{{
+                    Plugin:    "roadmap",
+                    Operation: "items.get",
+                }},
+            },
+        })
+        if err != nil {
+            return "", err
+        }
+        signal, err := gestalt.NewWorkflowSignal(gestalt.WorkflowSignalInput{
+            Name:           "roadmap.item.updated",
+            IdempotencyKey: "roadmap-item-updated:" + itemID,
+        })
+        if err != nil {
+            return "", err
+        }
+
+        queued, err := workflows.SignalOrStartRun(ctx, &gestalt.WorkflowManagerSignalOrStartRunRequest{
             ProviderName: "local",
             WorkflowKey:  "roadmap-summary:" + itemID,
-            Target: &proto.BoundWorkflowTarget{
-                Kind: &proto.BoundWorkflowTarget_Agent{
-                    Agent: &proto.BoundWorkflowAgentTarget{
-                        ProviderName: "simple",
-                        Model:        "fast",
-                        Prompt:       "Summarize the updated roadmap item.",
-                        ToolRefs: []*proto.AgentToolRef{{
-                            Plugin:    "roadmap",
-                            Operation: "items.get",
-                        }},
-                    },
-                },
-            },
-            Signal: &proto.WorkflowSignal{
-                Name:           "roadmap.item.updated",
-                IdempotencyKey: "roadmap-item-updated:" + itemID,
-            },
+            Target:       target,
+            Signal:       signal,
         })
         if err != nil {
             return "", err
@@ -814,10 +819,9 @@ signals instead of creating duplicate runs.
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use gestalt::proto::v1::{
-        bound_workflow_target, AgentToolRef, BoundWorkflowAgentTarget,
-        BoundWorkflowTarget, WorkflowManagerSignalOrStartRunRequest,
-        WorkflowSignal,
+    use gestalt::{
+        AgentToolRef, BoundWorkflowAgentTargetInput, BoundWorkflowTargetInput,
+        WorkflowManagerSignalOrStartRunRequest, WorkflowSignalInput,
     };
 
     async fn enqueue_agent_workflow(
@@ -825,31 +829,32 @@ signals instead of creating duplicate runs.
         item_id: &str,
     ) -> Result<String, Box<dyn std::error::Error>> {
         let mut workflows = request.workflow_manager().await?;
+        let target = gestalt::new_bound_workflow_target(BoundWorkflowTargetInput {
+            agent: Some(BoundWorkflowAgentTargetInput {
+                provider_name: "simple".to_string(),
+                model: "fast".to_string(),
+                prompt: "Summarize the updated roadmap item.".to_string(),
+                tool_refs: vec![AgentToolRef {
+                    plugin: "roadmap".to_string(),
+                    operation: "items.get".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        })?;
+        let signal = gestalt::new_workflow_signal(WorkflowSignalInput {
+            name: "roadmap.item.updated".to_string(),
+            idempotency_key: format!("roadmap-item-updated:{item_id}"),
+            ..Default::default()
+        })?;
 
         let queued = workflows
             .signal_or_start_run(WorkflowManagerSignalOrStartRunRequest {
                 provider_name: "local".to_string(),
                 workflow_key: format!("roadmap-summary:{item_id}"),
-                target: Some(BoundWorkflowTarget {
-                    kind: Some(bound_workflow_target::Kind::Agent(
-                        BoundWorkflowAgentTarget {
-                            provider_name: "simple".to_string(),
-                            model: "fast".to_string(),
-                            prompt: "Summarize the updated roadmap item.".to_string(),
-                            tool_refs: vec![AgentToolRef {
-                                plugin: "roadmap".to_string(),
-                                operation: "items.get".to_string(),
-                                ..Default::default()
-                            }],
-                            ..Default::default()
-                        },
-                    )),
-                }),
-                signal: Some(WorkflowSignal {
-                    name: "roadmap.item.updated".to_string(),
-                    idempotency_key: format!("roadmap-item-updated:{item_id}"),
-                    ..Default::default()
-                }),
+                target: Some(target),
+                signal: Some(signal),
                 ..Default::default()
             })
             .await?;
@@ -963,7 +968,7 @@ Providers that support deployer-defined session setup must advertise
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    return &proto.AgentProviderCapabilities{
+    return &gestalt.AgentProviderCapabilities{
         SupportsSessionStart: true,
     }, nil
     ```
@@ -982,9 +987,9 @@ Providers that support deployer-defined session setup must advertise
     ```rust
     async fn get_capabilities(
         &self,
-        _request: pb::GetAgentProviderCapabilitiesRequest,
-    ) -> gestalt::Result<pb::AgentProviderCapabilities> {
-        Ok(pb::AgentProviderCapabilities {
+        _request: gestalt::GetAgentProviderCapabilitiesRequest,
+    ) -> gestalt::Result<gestalt::AgentProviderCapabilities> {
+        Ok(gestalt::AgentProviderCapabilities {
             supports_session_start: true,
             ..Default::default()
         })
@@ -1020,19 +1025,19 @@ prepared `root` and `cwd` first.
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    func (p *Provider) GetCapabilities(context.Context, *proto.GetAgentProviderCapabilitiesRequest) (*proto.AgentProviderCapabilities, error) {
-        return &proto.AgentProviderCapabilities{
+    func (p *Provider) GetCapabilities(context.Context, *gestalt.GetAgentProviderCapabilitiesRequest) (*gestalt.AgentProviderCapabilities, error) {
+        return &gestalt.AgentProviderCapabilities{
             SupportsPreparedWorkspace: true,
         }, nil
     }
 
-    func (p *Provider) CreateSession(ctx context.Context, req *proto.CreateAgentProviderSessionRequest) (*proto.AgentSession, error) {
+    func (p *Provider) CreateSession(ctx context.Context, req *gestalt.CreateAgentProviderSessionRequest) (*gestalt.AgentSession, error) {
         prepared := req.GetPreparedWorkspace()
         if prepared != nil {
             // Launch the vendor harness with prepared.GetCwd() as its working directory.
         }
 
-        return &proto.AgentSession{Id: req.GetSessionId()}, nil
+        return &gestalt.AgentSession{Id: req.GetSessionId()}, nil
     }
     ```
   </Tabs.Tab>
@@ -1067,9 +1072,9 @@ prepared `root` and `cwd` first.
     ```rust
     async fn get_capabilities(
         &self,
-        _request: pb::GetAgentProviderCapabilitiesRequest,
-    ) -> gestalt::Result<pb::AgentProviderCapabilities> {
-        Ok(pb::AgentProviderCapabilities {
+        _request: gestalt::GetAgentProviderCapabilitiesRequest,
+    ) -> gestalt::Result<gestalt::AgentProviderCapabilities> {
+        Ok(gestalt::AgentProviderCapabilities {
             supports_prepared_workspace: true,
             ..Default::default()
         })
@@ -1077,17 +1082,17 @@ prepared `root` and `cwd` first.
 
     async fn create_session(
         &self,
-        request: pb::CreateAgentProviderSessionRequest,
-    ) -> gestalt::Result<pb::AgentSession> {
+        request: gestalt::CreateAgentProviderSessionRequest,
+    ) -> gestalt::Result<gestalt::AgentSession> {
         if let Some(prepared) = request.prepared_workspace.as_ref() {
             let cwd = &prepared.cwd;
             // Launch the vendor harness with cwd as its working directory.
         }
 
-        Ok(pb::AgentSession {
+        Ok(gestalt::AgentSession {
             id: request.session_id,
             provider_name: "example".to_string(),
-            state: pb::AgentSessionState::Active as i32,
+            state: gestalt::AgentSessionState::Active as i32,
             ..Default::default()
         })
     }
@@ -1122,10 +1127,10 @@ Agent providers opt in to Gestalt integration tools by advertising
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    return &proto.AgentProviderCapabilities{
+    return &gestalt.AgentProviderCapabilities{
         ToolCalls: true,
-        SupportedToolSources: []proto.AgentToolSourceMode{
-            proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_MCP_CATALOG,
+        SupportedToolSources: []gestalt.AgentToolSourceMode{
+            gestalt.AgentToolSourceModeMCPCatalog,
         },
     }, nil
     ```
@@ -1147,11 +1152,11 @@ Agent providers opt in to Gestalt integration tools by advertising
     ```rust
     async fn get_capabilities(
         &self,
-        _request: pb::GetAgentProviderCapabilitiesRequest,
-    ) -> gestalt::Result<pb::AgentProviderCapabilities> {
-        Ok(pb::AgentProviderCapabilities {
+        _request: gestalt::GetAgentProviderCapabilitiesRequest,
+    ) -> gestalt::Result<gestalt::AgentProviderCapabilities> {
+        Ok(gestalt::AgentProviderCapabilities {
             tool_calls: true,
-            supported_tool_sources: vec![pb::AgentToolSourceMode::McpCatalog as i32],
+            supported_tool_sources: vec![gestalt::AgentToolSourceMode::McpCatalog as i32],
             ..Default::default()
         })
     }
@@ -1208,10 +1213,9 @@ provider-owned inference.
       "fmt"
 
       gestalt "github.com/valon-technologies/gestalt/sdk/go"
-      proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
     )
 
-    func executeGrantedTool(ctx context.Context, turn *proto.CreateAgentProviderTurnRequest) (string, error) {
+    func executeGrantedTool(ctx context.Context, turn *gestalt.CreateAgentProviderTurnRequest) (string, error) {
       host, err := gestalt.AgentHost()
       if err != nil {
         return "", err
@@ -1301,10 +1305,8 @@ provider-owned inference.
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use gestalt::proto::v1 as proto;
-
     async fn execute_granted_tool(
-        turn: &proto::CreateAgentProviderTurnRequest,
+        turn: &gestalt::CreateAgentProviderTurnRequest,
     ) -> Result<Option<String>, gestalt::AgentHostError> {
         let mut host = gestalt::AgentHost::connect().await?;
 
@@ -1465,21 +1467,22 @@ own events.
     import (
       "context"
 
-      proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
-      "google.golang.org/protobuf/types/known/timestamppb"
+      gestalt "github.com/valon-technologies/gestalt/sdk/go"
     )
 
-    type Provider struct {
-      proto.UnimplementedAgentProviderServer
-    }
+    type Provider struct{}
 
     func New() *Provider { return &Provider{} }
 
-    func actorFromSubject(subject *proto.AgentSubjectContext) *proto.AgentActor {
+    func (p *Provider) Configure(_ context.Context, _ string, _ map[string]any) error {
+      return nil
+    }
+
+    func actorFromSubject(subject *gestalt.AgentSubjectContext) *gestalt.AgentActor {
       if subject == nil {
         return nil
       }
-      return &proto.AgentActor{
+      return &gestalt.AgentActor{
         SubjectId:   subject.GetSubjectId(),
         SubjectKind: subject.GetSubjectKind(),
         DisplayName: subject.GetDisplayName(),
@@ -1487,109 +1490,101 @@ own events.
       }
     }
 
-    func (p *Provider) CreateSession(ctx context.Context, req *proto.CreateAgentProviderSessionRequest) (*proto.AgentSession, error) {
-      return &proto.AgentSession{
+    func (p *Provider) CreateSession(ctx context.Context, req *gestalt.CreateAgentProviderSessionRequest) (*gestalt.AgentSession, error) {
+      return &gestalt.AgentSession{
         Id:           req.GetSessionId(),
         ProviderName: "example",
         Model:        req.GetModel(),
         ClientRef:    req.GetClientRef(),
-        State:        proto.AgentSessionState_AGENT_SESSION_STATE_ACTIVE,
+        State:        gestalt.AgentSessionStateActive,
         CreatedBy:    req.GetCreatedBy(),
-        CreatedAt:    timestamppb.Now(),
-        UpdatedAt:    timestamppb.Now(),
       }, nil
     }
 
-    func (p *Provider) GetSession(_ context.Context, req *proto.GetAgentProviderSessionRequest) (*proto.AgentSession, error) {
-      return &proto.AgentSession{
+    func (p *Provider) GetSession(_ context.Context, req *gestalt.GetAgentProviderSessionRequest) (*gestalt.AgentSession, error) {
+      return &gestalt.AgentSession{
         Id:           req.GetSessionId(),
         ProviderName: "example",
-        State:        proto.AgentSessionState_AGENT_SESSION_STATE_ACTIVE,
+        State:        gestalt.AgentSessionStateActive,
         CreatedBy:    actorFromSubject(req.GetSubject()),
       }, nil
     }
 
-    func (p *Provider) ListSessions(context.Context, *proto.ListAgentProviderSessionsRequest) (*proto.ListAgentProviderSessionsResponse, error) {
-      return &proto.ListAgentProviderSessionsResponse{}, nil
+    func (p *Provider) ListSessions(context.Context, *gestalt.ListAgentProviderSessionsRequest) (*gestalt.ListAgentProviderSessionsResponse, error) {
+      return &gestalt.ListAgentProviderSessionsResponse{}, nil
     }
 
-    func (p *Provider) UpdateSession(_ context.Context, req *proto.UpdateAgentProviderSessionRequest) (*proto.AgentSession, error) {
-      return &proto.AgentSession{
+    func (p *Provider) UpdateSession(_ context.Context, req *gestalt.UpdateAgentProviderSessionRequest) (*gestalt.AgentSession, error) {
+      return &gestalt.AgentSession{
         Id:           req.GetSessionId(),
         ProviderName: "example",
         ClientRef:    req.GetClientRef(),
         State:        req.GetState(),
         CreatedBy:    actorFromSubject(req.GetSubject()),
-        UpdatedAt:    timestamppb.Now(),
       }, nil
     }
 
-    func (p *Provider) CreateTurn(ctx context.Context, req *proto.CreateAgentProviderTurnRequest) (*proto.AgentTurn, error) {
-      return &proto.AgentTurn{
+    func (p *Provider) CreateTurn(ctx context.Context, req *gestalt.CreateAgentProviderTurnRequest) (*gestalt.AgentTurn, error) {
+      return &gestalt.AgentTurn{
         Id:           req.GetTurnId(),
         SessionId:    req.GetSessionId(),
         ProviderName: "example",
         Model:        req.GetModel(),
-        Status:       proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_RUNNING,
+        Status:       gestalt.AgentExecutionStatusRunning,
         Messages:     req.GetMessages(),
         CreatedBy:    req.GetCreatedBy(),
-        CreatedAt:    timestamppb.Now(),
-        StartedAt:    timestamppb.Now(),
         ExecutionRef: req.GetExecutionRef(),
       }, nil
     }
 
-    func (p *Provider) GetTurn(_ context.Context, req *proto.GetAgentProviderTurnRequest) (*proto.AgentTurn, error) {
-      return &proto.AgentTurn{
+    func (p *Provider) GetTurn(_ context.Context, req *gestalt.GetAgentProviderTurnRequest) (*gestalt.AgentTurn, error) {
+      return &gestalt.AgentTurn{
         Id:           req.GetTurnId(),
         SessionId:    "session-1",
         ProviderName: "example",
-        Status:       proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_SUCCEEDED,
+        Status:       gestalt.AgentExecutionStatusSucceeded,
         OutputText:   "done",
         CreatedBy:    actorFromSubject(req.GetSubject()),
-        CompletedAt:  timestamppb.Now(),
       }, nil
     }
 
-    func (p *Provider) ListTurns(context.Context, *proto.ListAgentProviderTurnsRequest) (*proto.ListAgentProviderTurnsResponse, error) {
-      return &proto.ListAgentProviderTurnsResponse{}, nil
+    func (p *Provider) ListTurns(context.Context, *gestalt.ListAgentProviderTurnsRequest) (*gestalt.ListAgentProviderTurnsResponse, error) {
+      return &gestalt.ListAgentProviderTurnsResponse{}, nil
     }
 
-    func (p *Provider) CancelTurn(_ context.Context, req *proto.CancelAgentProviderTurnRequest) (*proto.AgentTurn, error) {
-      return &proto.AgentTurn{
+    func (p *Provider) CancelTurn(_ context.Context, req *gestalt.CancelAgentProviderTurnRequest) (*gestalt.AgentTurn, error) {
+      return &gestalt.AgentTurn{
         Id:            req.GetTurnId(),
         SessionId:     "session-1",
         ProviderName:  "example",
-        Status:        proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_CANCELED,
+        Status:        gestalt.AgentExecutionStatusCanceled,
         StatusMessage: "operator requested",
         CreatedBy:     actorFromSubject(req.GetSubject()),
-        CompletedAt:   timestamppb.Now(),
       }, nil
     }
 
-    func (p *Provider) ListTurnEvents(context.Context, *proto.ListAgentProviderTurnEventsRequest) (*proto.ListAgentProviderTurnEventsResponse, error) {
-      return &proto.ListAgentProviderTurnEventsResponse{}, nil
+    func (p *Provider) ListTurnEvents(context.Context, *gestalt.ListAgentProviderTurnEventsRequest) (*gestalt.ListAgentProviderTurnEventsResponse, error) {
+      return &gestalt.ListAgentProviderTurnEventsResponse{}, nil
     }
 
-    func (p *Provider) GetInteraction(_ context.Context, req *proto.GetAgentProviderInteractionRequest) (*proto.AgentInteraction, error) {
-      return &proto.AgentInteraction{Id: req.GetInteractionId()}, nil
+    func (p *Provider) GetInteraction(_ context.Context, req *gestalt.GetAgentProviderInteractionRequest) (*gestalt.AgentInteraction, error) {
+      return &gestalt.AgentInteraction{Id: req.GetInteractionId()}, nil
     }
 
-    func (p *Provider) ListInteractions(context.Context, *proto.ListAgentProviderInteractionsRequest) (*proto.ListAgentProviderInteractionsResponse, error) {
-      return &proto.ListAgentProviderInteractionsResponse{}, nil
+    func (p *Provider) ListInteractions(context.Context, *gestalt.ListAgentProviderInteractionsRequest) (*gestalt.ListAgentProviderInteractionsResponse, error) {
+      return &gestalt.ListAgentProviderInteractionsResponse{}, nil
     }
 
-    func (p *Provider) ResolveInteraction(_ context.Context, req *proto.ResolveAgentProviderInteractionRequest) (*proto.AgentInteraction, error) {
-      return &proto.AgentInteraction{
+    func (p *Provider) ResolveInteraction(_ context.Context, req *gestalt.ResolveAgentProviderInteractionRequest) (*gestalt.AgentInteraction, error) {
+      return &gestalt.AgentInteraction{
         Id:         req.GetInteractionId(),
-        State:      proto.AgentInteractionState_AGENT_INTERACTION_STATE_RESOLVED,
+        State:      gestalt.AgentInteractionStateResolved,
         Resolution: req.GetResolution(),
-        ResolvedAt: timestamppb.Now(),
       }, nil
     }
 
-    func (p *Provider) GetCapabilities(context.Context, *proto.GetAgentProviderCapabilitiesRequest) (*proto.AgentProviderCapabilities, error) {
-      return &proto.AgentProviderCapabilities{
+    func (p *Provider) GetCapabilities(context.Context, *gestalt.GetAgentProviderCapabilitiesRequest) (*gestalt.AgentProviderCapabilities, error) {
+      return &gestalt.AgentProviderCapabilities{
         StreamingText:        true,
         ToolCalls:            true,
         StructuredOutput:     true,
@@ -1734,15 +1729,13 @@ own events.
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use tonic::{Request, Response, Status};
-
-    use gestalt::proto::v1 as proto;
-
     #[derive(Default)]
     struct ExampleAgent;
 
-    fn actor_from_subject(subject: Option<proto::AgentSubjectContext>) -> Option<proto::AgentActor> {
-        subject.map(|subject| proto::AgentActor {
+    fn actor_from_subject(
+        subject: Option<gestalt::AgentSubjectContext>,
+    ) -> Option<gestalt::AgentActor> {
+        subject.map(|subject| gestalt::AgentActor {
             subject_id: subject.subject_id,
             subject_kind: subject.subject_kind,
             display_name: subject.display_name,
@@ -1751,159 +1744,152 @@ own events.
     }
 
     #[gestalt::async_trait]
-    impl proto::agent_provider_server::AgentProvider for ExampleAgent {
+    impl gestalt::AgentProvider for ExampleAgent {
         async fn create_session(
             &self,
-            request: Request<proto::CreateAgentProviderSessionRequest>,
-        ) -> Result<Response<proto::AgentSession>, Status> {
-            let req = request.into_inner();
-            Ok(Response::new(proto::AgentSession {
+            req: gestalt::CreateAgentProviderSessionRequest,
+        ) -> gestalt::Result<gestalt::AgentSession> {
+            Ok(gestalt::AgentSession {
                 id: req.session_id,
                 provider_name: "example".into(),
                 model: req.model,
                 client_ref: req.client_ref,
-                state: proto::AgentSessionState::Active as i32,
+                state: gestalt::AgentSessionState::Active as i32,
                 created_by: req.created_by,
                 ..Default::default()
-            }))
+            })
         }
 
         async fn get_session(
             &self,
-            request: Request<proto::GetAgentProviderSessionRequest>,
-        ) -> Result<Response<proto::AgentSession>, Status> {
-            let req = request.into_inner();
-            Ok(Response::new(proto::AgentSession {
+            req: gestalt::GetAgentProviderSessionRequest,
+        ) -> gestalt::Result<gestalt::AgentSession> {
+            Ok(gestalt::AgentSession {
                 id: req.session_id,
                 provider_name: "example".into(),
-                state: proto::AgentSessionState::Active as i32,
+                state: gestalt::AgentSessionState::Active as i32,
                 created_by: actor_from_subject(req.subject),
                 ..Default::default()
-            }))
+            })
         }
 
         async fn list_sessions(
             &self,
-            _request: Request<proto::ListAgentProviderSessionsRequest>,
-        ) -> Result<Response<proto::ListAgentProviderSessionsResponse>, Status> {
-            Ok(Response::new(proto::ListAgentProviderSessionsResponse::default()))
+            _request: gestalt::ListAgentProviderSessionsRequest,
+        ) -> gestalt::Result<gestalt::ListAgentProviderSessionsResponse> {
+            Ok(gestalt::ListAgentProviderSessionsResponse::default())
         }
 
         async fn update_session(
             &self,
-            request: Request<proto::UpdateAgentProviderSessionRequest>,
-        ) -> Result<Response<proto::AgentSession>, Status> {
-            let req = request.into_inner();
-            Ok(Response::new(proto::AgentSession {
+            req: gestalt::UpdateAgentProviderSessionRequest,
+        ) -> gestalt::Result<gestalt::AgentSession> {
+            Ok(gestalt::AgentSession {
                 id: req.session_id,
                 provider_name: "example".into(),
                 client_ref: req.client_ref,
                 state: req.state,
                 created_by: actor_from_subject(req.subject),
                 ..Default::default()
-            }))
+            })
         }
 
         async fn create_turn(
             &self,
-            request: Request<proto::CreateAgentProviderTurnRequest>,
-        ) -> Result<Response<proto::AgentTurn>, Status> {
-            let req = request.into_inner();
-            Ok(Response::new(proto::AgentTurn {
+            req: gestalt::CreateAgentProviderTurnRequest,
+        ) -> gestalt::Result<gestalt::AgentTurn> {
+            Ok(gestalt::AgentTurn {
                 id: req.turn_id,
                 session_id: req.session_id,
                 provider_name: "example".into(),
                 model: req.model,
-                status: proto::AgentExecutionStatus::Running as i32,
+                status: gestalt::AgentExecutionStatus::Running as i32,
                 messages: req.messages,
                 created_by: req.created_by,
                 execution_ref: req.execution_ref,
                 ..Default::default()
-            }))
+            })
         }
 
         async fn get_turn(
             &self,
-            request: Request<proto::GetAgentProviderTurnRequest>,
-        ) -> Result<Response<proto::AgentTurn>, Status> {
-            let req = request.into_inner();
-            Ok(Response::new(proto::AgentTurn {
+            req: gestalt::GetAgentProviderTurnRequest,
+        ) -> gestalt::Result<gestalt::AgentTurn> {
+            Ok(gestalt::AgentTurn {
                 id: req.turn_id,
                 session_id: "session-1".into(),
                 provider_name: "example".into(),
-                status: proto::AgentExecutionStatus::Succeeded as i32,
+                status: gestalt::AgentExecutionStatus::Succeeded as i32,
                 output_text: "done".into(),
                 created_by: actor_from_subject(req.subject),
                 ..Default::default()
-            }))
+            })
         }
 
         async fn list_turns(
             &self,
-            _request: Request<proto::ListAgentProviderTurnsRequest>,
-        ) -> Result<Response<proto::ListAgentProviderTurnsResponse>, Status> {
-            Ok(Response::new(proto::ListAgentProviderTurnsResponse::default()))
+            _request: gestalt::ListAgentProviderTurnsRequest,
+        ) -> gestalt::Result<gestalt::ListAgentProviderTurnsResponse> {
+            Ok(gestalt::ListAgentProviderTurnsResponse::default())
         }
 
         async fn cancel_turn(
             &self,
-            request: Request<proto::CancelAgentProviderTurnRequest>,
-        ) -> Result<Response<proto::AgentTurn>, Status> {
-            let req = request.into_inner();
-            Ok(Response::new(proto::AgentTurn {
+            req: gestalt::CancelAgentProviderTurnRequest,
+        ) -> gestalt::Result<gestalt::AgentTurn> {
+            Ok(gestalt::AgentTurn {
                 id: req.turn_id,
                 session_id: "session-1".into(),
                 provider_name: "example".into(),
-                status: proto::AgentExecutionStatus::Canceled as i32,
+                status: gestalt::AgentExecutionStatus::Canceled as i32,
                 status_message: "operator requested".into(),
                 created_by: actor_from_subject(req.subject),
                 ..Default::default()
-            }))
+            })
         }
 
         async fn list_turn_events(
             &self,
-            _request: Request<proto::ListAgentProviderTurnEventsRequest>,
-        ) -> Result<Response<proto::ListAgentProviderTurnEventsResponse>, Status> {
-            Ok(Response::new(proto::ListAgentProviderTurnEventsResponse::default()))
+            _request: gestalt::ListAgentProviderTurnEventsRequest,
+        ) -> gestalt::Result<gestalt::ListAgentProviderTurnEventsResponse> {
+            Ok(gestalt::ListAgentProviderTurnEventsResponse::default())
         }
 
         async fn get_interaction(
             &self,
-            request: Request<proto::GetAgentProviderInteractionRequest>,
-        ) -> Result<Response<proto::AgentInteraction>, Status> {
-            Ok(Response::new(proto::AgentInteraction {
-                id: request.into_inner().interaction_id,
-                state: proto::AgentInteractionState::Pending as i32,
+            request: gestalt::GetAgentProviderInteractionRequest,
+        ) -> gestalt::Result<gestalt::AgentInteraction> {
+            Ok(gestalt::AgentInteraction {
+                id: request.interaction_id,
+                state: gestalt::AgentInteractionState::Pending as i32,
                 ..Default::default()
-            }))
+            })
         }
 
         async fn list_interactions(
             &self,
-            _request: Request<proto::ListAgentProviderInteractionsRequest>,
-        ) -> Result<Response<proto::ListAgentProviderInteractionsResponse>, Status> {
-            Ok(Response::new(proto::ListAgentProviderInteractionsResponse::default()))
+            _request: gestalt::ListAgentProviderInteractionsRequest,
+        ) -> gestalt::Result<gestalt::ListAgentProviderInteractionsResponse> {
+            Ok(gestalt::ListAgentProviderInteractionsResponse::default())
         }
 
         async fn resolve_interaction(
             &self,
-            request: Request<proto::ResolveAgentProviderInteractionRequest>,
-        ) -> Result<Response<proto::AgentInteraction>, Status> {
-            let req = request.into_inner();
-            Ok(Response::new(proto::AgentInteraction {
+            req: gestalt::ResolveAgentProviderInteractionRequest,
+        ) -> gestalt::Result<gestalt::AgentInteraction> {
+            Ok(gestalt::AgentInteraction {
                 id: req.interaction_id,
-                state: proto::AgentInteractionState::Resolved as i32,
+                state: gestalt::AgentInteractionState::Resolved as i32,
                 resolution: req.resolution,
                 ..Default::default()
-            }))
+            })
         }
 
         async fn get_capabilities(
             &self,
-            _request: Request<proto::GetAgentProviderCapabilitiesRequest>,
-        ) -> Result<Response<proto::AgentProviderCapabilities>, Status> {
-            Ok(Response::new(proto::AgentProviderCapabilities {
+            _request: gestalt::GetAgentProviderCapabilitiesRequest,
+        ) -> gestalt::Result<gestalt::AgentProviderCapabilities> {
+            Ok(gestalt::AgentProviderCapabilities {
                 streaming_text: true,
                 tool_calls: true,
                 structured_output: true,
@@ -1912,12 +1898,9 @@ own events.
                 bounded_list_hydration: true,
                 supports_prepared_workspace: true,
                 ..Default::default()
-            }))
+            })
         }
     }
-
-    #[gestalt::async_trait]
-    impl gestalt::AgentProvider for ExampleAgent {}
 
     gestalt::export_agent_provider!(constructor = ExampleAgent::default);
     ```

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -309,103 +309,96 @@ the exported provider for the selected language.
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use tonic::{Request, Response, Status};
-
-    use gestalt::proto::v1 as proto;
-
     #[derive(Default)]
     struct ExampleRuntime;
 
     #[gestalt::async_trait]
-    impl proto::plugin_runtime_provider_server::PluginRuntimeProvider for ExampleRuntime {
+    impl gestalt::PluginRuntimeProvider for ExampleRuntime {
         async fn get_support(
             &self,
-            _request: Request<()>,
-        ) -> Result<Response<proto::PluginRuntimeSupport>, Status> {
-            Ok(Response::new(proto::PluginRuntimeSupport {
+            _request: (),
+        ) -> gestalt::Result<gestalt::PluginRuntimeSupport> {
+            Ok(gestalt::PluginRuntimeSupport {
                 can_host_plugins: true,
-                egress_mode: proto::PluginRuntimeEgressMode::Hostname as i32,
                 supports_prepare_workspace: true,
-            }))
+                ..Default::default()
+            })
         }
 
         async fn start_session(
             &self,
-            _request: Request<proto::StartPluginRuntimeSessionRequest>,
-        ) -> Result<Response<proto::PluginRuntimeSession>, Status> {
-            Ok(Response::new(proto::PluginRuntimeSession {
+            _request: gestalt::StartPluginRuntimeSessionRequest,
+        ) -> gestalt::Result<gestalt::PluginRuntimeSession> {
+            Ok(gestalt::PluginRuntimeSession {
                 id: "session-1".into(),
                 state: "ready".into(),
                 ..Default::default()
-            }))
+            })
         }
 
         async fn get_session(
             &self,
-            request: Request<proto::GetPluginRuntimeSessionRequest>,
-        ) -> Result<Response<proto::PluginRuntimeSession>, Status> {
-            Ok(Response::new(proto::PluginRuntimeSession {
-                id: request.into_inner().session_id,
+            request: gestalt::GetPluginRuntimeSessionRequest,
+        ) -> gestalt::Result<gestalt::PluginRuntimeSession> {
+            Ok(gestalt::PluginRuntimeSession {
+                id: request.session_id,
                 state: "ready".into(),
                 ..Default::default()
-            }))
+            })
         }
 
         async fn list_sessions(
             &self,
-            _request: Request<proto::ListPluginRuntimeSessionsRequest>,
-        ) -> Result<Response<proto::ListPluginRuntimeSessionsResponse>, Status> {
-            Ok(Response::new(proto::ListPluginRuntimeSessionsResponse {
-                sessions: vec![proto::PluginRuntimeSession {
+            _request: gestalt::ListPluginRuntimeSessionsRequest,
+        ) -> gestalt::Result<gestalt::ListPluginRuntimeSessionsResponse> {
+            Ok(gestalt::ListPluginRuntimeSessionsResponse {
+                sessions: vec![gestalt::PluginRuntimeSession {
                     id: "session-1".into(),
                     state: "ready".into(),
                     ..Default::default()
                 }],
-            }))
+            })
         }
 
         async fn stop_session(
             &self,
-            _request: Request<proto::StopPluginRuntimeSessionRequest>,
-        ) -> Result<Response<()>, Status> {
-            Ok(Response::new(()))
+            _request: gestalt::StopPluginRuntimeSessionRequest,
+        ) -> gestalt::Result<()> {
+            Ok(())
         }
 
         async fn prepare_workspace(
             &self,
-            _request: Request<proto::PreparePluginRuntimeWorkspaceRequest>,
-        ) -> Result<Response<proto::PreparePluginRuntimeWorkspaceResponse>, Status> {
-            Ok(Response::new(proto::PreparePluginRuntimeWorkspaceResponse {
-                workspace: Some(proto::PreparedAgentWorkspace {
+            _request: gestalt::PreparePluginRuntimeWorkspaceRequest,
+        ) -> gestalt::Result<gestalt::PreparePluginRuntimeWorkspaceResponse> {
+            Ok(gestalt::PreparePluginRuntimeWorkspaceResponse {
+                workspace: Some(gestalt::AgentPreparedWorkspace {
                     root: "/sandboxes/runtime-session-1/workspaces/agent-session-1".into(),
                     cwd: "/sandboxes/runtime-session-1/workspaces/agent-session-1/repo".into(),
                 }),
-            }))
+            })
         }
 
         async fn remove_workspace(
             &self,
-            _request: Request<proto::RemovePluginRuntimeWorkspaceRequest>,
-        ) -> Result<Response<()>, Status> {
-            Ok(Response::new(()))
+            _request: gestalt::RemovePluginRuntimeWorkspaceRequest,
+        ) -> gestalt::Result<()> {
+            Ok(())
         }
 
         async fn start_plugin(
             &self,
-            request: Request<proto::StartHostedPluginRequest>,
-        ) -> Result<Response<proto::HostedPlugin>, Status> {
-            let req = request.into_inner();
-            Ok(Response::new(proto::HostedPlugin {
+            req: gestalt::StartHostedPluginRequest,
+        ) -> gestalt::Result<gestalt::HostedPlugin> {
+            Ok(gestalt::HostedPlugin {
                 id: "plugin-1".into(),
                 session_id: req.session_id,
                 plugin_name: req.plugin_name,
                 dial_target: "unix:///tmp/example-runtime/plugin.sock".into(),
-            }))
+                ..Default::default()
+            })
         }
     }
-
-    #[gestalt::async_trait]
-    impl gestalt::PluginRuntimeProvider for ExampleRuntime {}
 
     gestalt::export_plugin_runtime_provider!(constructor = ExampleRuntime::default);
     ```

--- a/docs/content/providers/s3.mdx
+++ b/docs/content/providers/s3.mdx
@@ -330,12 +330,6 @@ interface to the underlying gRPC service:
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use std::pin::Pin;
-
-    use futures_core::Stream;
-    use gestalt::{self, proto::v1 as proto};
-    use tonic::{Request, Response, Status};
-
     #[derive(Default)]
     pub struct MinioS3;
 
@@ -348,62 +342,54 @@ interface to the underlying gRPC service:
         ) -> gestalt::Result<()> {
             Ok(())
         }
-    }
-
-    type ReadObjectStream =
-        Pin<Box<dyn Stream<Item = Result<proto::ReadObjectChunk, Status>> + Send>>;
-
-    #[gestalt::async_trait]
-    impl proto::s3_server::S3 for MinioS3 {
-        type ReadObjectStream = ReadObjectStream;
 
         async fn head_object(
             &self,
-            _request: Request<proto::HeadObjectRequest>,
-        ) -> Result<Response<proto::HeadObjectResponse>, Status> {
-            Err(Status::unimplemented("todo"))
+            _request: gestalt::HeadObjectRequest,
+        ) -> gestalt::Result<gestalt::HeadObjectResponse> {
+            Err(gestalt::Error::unimplemented("todo"))
         }
 
         async fn read_object(
             &self,
-            _request: Request<proto::ReadObjectRequest>,
-        ) -> Result<Response<Self::ReadObjectStream>, Status> {
-            Err(Status::unimplemented("todo"))
+            _request: gestalt::ReadObjectRequest,
+        ) -> gestalt::Result<gestalt::S3ReadObjectStream> {
+            Err(gestalt::Error::unimplemented("todo"))
         }
 
         async fn write_object(
             &self,
-            _request: Request<tonic::Streaming<proto::WriteObjectRequest>>,
-        ) -> Result<Response<proto::WriteObjectResponse>, Status> {
-            Err(Status::unimplemented("todo"))
+            _request: gestalt::S3WriteObjectStream,
+        ) -> gestalt::Result<gestalt::WriteObjectResponse> {
+            Err(gestalt::Error::unimplemented("todo"))
         }
 
         async fn delete_object(
             &self,
-            _request: Request<proto::DeleteObjectRequest>,
-        ) -> Result<Response<()>, Status> {
-            Err(Status::unimplemented("todo"))
+            _request: gestalt::DeleteObjectRequest,
+        ) -> gestalt::Result<()> {
+            Err(gestalt::Error::unimplemented("todo"))
         }
 
         async fn list_objects(
             &self,
-            _request: Request<proto::ListObjectsRequest>,
-        ) -> Result<Response<proto::ListObjectsResponse>, Status> {
-            Err(Status::unimplemented("todo"))
+            _request: gestalt::ListObjectsRequest,
+        ) -> gestalt::Result<gestalt::ListObjectsResponse> {
+            Err(gestalt::Error::unimplemented("todo"))
         }
 
         async fn copy_object(
             &self,
-            _request: Request<proto::CopyObjectRequest>,
-        ) -> Result<Response<proto::CopyObjectResponse>, Status> {
-            Err(Status::unimplemented("todo"))
+            _request: gestalt::CopyObjectRequest,
+        ) -> gestalt::Result<gestalt::CopyObjectResponse> {
+            Err(gestalt::Error::unimplemented("todo"))
         }
 
         async fn presign_object(
             &self,
-            _request: Request<proto::PresignObjectRequest>,
-        ) -> Result<Response<proto::PresignObjectResponse>, Status> {
-            Err(Status::unimplemented("todo"))
+            _request: gestalt::PresignObjectRequest,
+        ) -> gestalt::Result<gestalt::PresignObjectResponse> {
+            Err(gestalt::Error::unimplemented("todo"))
         }
     }
 

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -474,8 +474,6 @@ definition do not silently change existing automation.
         "context"
 
         gestalt "github.com/valon-technologies/gestalt/sdk/go"
-        proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
-        "google.golang.org/protobuf/types/known/structpb"
     )
 
     func publishSlackEvent(
@@ -489,45 +487,43 @@ definition do not silently change existing automation.
         }
         defer workflows.Close()
 
-        data, err := structpb.NewStruct(map[string]any{
-            "event": slackEvent,
+        event, err := gestalt.NewWorkflowEvent(gestalt.WorkflowEventInput{
+            Type:            "slack.event.received",
+            Source:          "slack",
+            Subject:         "route:knowledge-ingest",
+            DataContentType: "application/json",
+            Data:            map[string]any{"event": slackEvent},
         })
         if err != nil {
             return "", err
         }
 
-        event, err := workflows.PublishEvent(ctx, &proto.WorkflowManagerPublishEventRequest{
+        published, err := workflows.PublishEvent(ctx, &gestalt.WorkflowManagerPublishEventRequest{
             ProviderName: "local",
-            Event: &proto.WorkflowEvent{
-                Type:            "slack.event.received",
-                Source:          "slack",
-                Subject:         "route:knowledge-ingest",
-                Datacontenttype: "application/json",
-                Data:            data,
-            },
+            Event:        event,
         })
         if err != nil {
             return "", err
         }
-        return event.GetId(), nil
+        return published.GetId(), nil
     }
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```python
-    from gestalt import Request, WorkflowEvent, WorkflowManagerPublishEventRequest
+    from gestalt import Request, WorkflowManagerPublishEventRequest, workflow_event
 
     def publish_slack_event(
         request: Request,
         slack_event: dict[str, object],
     ) -> str:
-        event = WorkflowEvent(
+        event = workflow_event(
             type="slack.event.received",
             source="slack",
             subject="route:knowledge-ingest",
             datacontenttype="application/json",
+            data={"event": slack_event},
         )
-        event.data.update({"event": slack_event})
 
         with request.workflow_manager() as workflows:
             published = workflows.publish_event(
@@ -542,35 +538,27 @@ definition do not silently change existing automation.
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use std::collections::BTreeMap;
-
-    use gestalt::proto::v1::{WorkflowEvent, WorkflowManagerPublishEventRequest};
-    use prost_types::{value::Kind, Struct, Value};
+    use gestalt::{WorkflowEventInput, WorkflowManagerPublishEventRequest};
+    use serde_json::json;
 
     async fn publish_slack_event(
         request: &gestalt::Request,
-        slack_event_json: String,
+        slack_event: serde_json::Value,
     ) -> Result<String, Box<dyn std::error::Error>> {
         let mut workflows = request.workflow_manager().await?;
+        let event = gestalt::new_workflow_event(WorkflowEventInput {
+            event_type: "slack.event.received".to_string(),
+            source: "slack".to_string(),
+            subject: "route:knowledge-ingest".to_string(),
+            datacontenttype: "application/json".to_string(),
+            data: Some(json!({ "event": slack_event })),
+            ..Default::default()
+        })?;
 
         let event = workflows
             .publish_event(WorkflowManagerPublishEventRequest {
                 provider_name: "local".to_string(),
-                event: Some(WorkflowEvent {
-                    r#type: "slack.event.received".to_string(),
-                    source: "slack".to_string(),
-                    subject: "route:knowledge-ingest".to_string(),
-                    datacontenttype: "application/json".to_string(),
-                    data: Some(Struct {
-                        fields: BTreeMap::from([(
-                            "event_json".to_string(),
-                            Value {
-                                kind: Some(Kind::StringValue(slack_event_json)),
-                            },
-                        )]),
-                    }),
-                    ..Default::default()
-                }),
+                event: Some(event),
                 ..Default::default()
             })
             .await?;
@@ -820,7 +808,7 @@ signal sequence numbers exactly as stored.
     import (
         "context"
 
-        proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+        gestalt "github.com/valon-technologies/gestalt/sdk/go"
     )
 
     type Provider struct{}
@@ -831,33 +819,33 @@ signal sequence numbers exactly as stored.
         return nil
     }
 
-    func (p *Provider) StartRun(_ context.Context, req *proto.StartWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
-        return &proto.BoundWorkflowRun{
+    func (p *Provider) StartRun(_ context.Context, req *gestalt.StartWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
+        return &gestalt.BoundWorkflowRun{
             Id:     req.GetTarget().GetPlugin().GetPluginName() + ":run-1",
-            Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_PENDING,
+            Status: gestalt.WorkflowRunStatusValuePending,
             Target: req.GetTarget(),
         }, nil
     }
 
-    func (p *Provider) GetRun(_ context.Context, req *proto.GetWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
-        return &proto.BoundWorkflowRun{
+    func (p *Provider) GetRun(_ context.Context, req *gestalt.GetWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
+        return &gestalt.BoundWorkflowRun{
             Id: req.GetRunId(),
         }, nil
     }
 
-    func (p *Provider) ListRuns(context.Context, *proto.ListWorkflowProviderRunsRequest) (*proto.ListWorkflowProviderRunsResponse, error) {
-        return &proto.ListWorkflowProviderRunsResponse{}, nil
+    func (p *Provider) ListRuns(context.Context, *gestalt.ListWorkflowProviderRunsRequest) (*gestalt.ListWorkflowProviderRunsResponse, error) {
+        return &gestalt.ListWorkflowProviderRunsResponse{}, nil
     }
 
-    func (p *Provider) CancelRun(_ context.Context, req *proto.CancelWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
-        return &proto.BoundWorkflowRun{
+    func (p *Provider) CancelRun(_ context.Context, req *gestalt.CancelWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
+        return &gestalt.BoundWorkflowRun{
             Id:     req.GetRunId(),
-            Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_CANCELED,
+            Status: gestalt.WorkflowRunStatusValueCanceled,
         }, nil
     }
 
-    func (p *Provider) UpsertSchedule(_ context.Context, req *proto.UpsertWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-        return &proto.BoundWorkflowSchedule{
+    func (p *Provider) UpsertSchedule(_ context.Context, req *gestalt.UpsertWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
+        return &gestalt.BoundWorkflowSchedule{
             Id:     req.GetScheduleId(),
             Cron:   req.GetCron(),
             Target: req.GetTarget(),
@@ -865,28 +853,28 @@ signal sequence numbers exactly as stored.
         }, nil
     }
 
-    func (p *Provider) GetSchedule(_ context.Context, req *proto.GetWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-        return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId()}, nil
+    func (p *Provider) GetSchedule(_ context.Context, req *gestalt.GetWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
+        return &gestalt.BoundWorkflowSchedule{Id: req.GetScheduleId()}, nil
     }
 
-    func (p *Provider) ListSchedules(context.Context, *proto.ListWorkflowProviderSchedulesRequest) (*proto.ListWorkflowProviderSchedulesResponse, error) {
-        return &proto.ListWorkflowProviderSchedulesResponse{}, nil
+    func (p *Provider) ListSchedules(context.Context, *gestalt.ListWorkflowProviderSchedulesRequest) (*gestalt.ListWorkflowProviderSchedulesResponse, error) {
+        return &gestalt.ListWorkflowProviderSchedulesResponse{}, nil
     }
 
-    func (p *Provider) DeleteSchedule(context.Context, *proto.DeleteWorkflowProviderScheduleRequest) error {
+    func (p *Provider) DeleteSchedule(context.Context, *gestalt.DeleteWorkflowProviderScheduleRequest) error {
         return nil
     }
 
-    func (p *Provider) PauseSchedule(_ context.Context, req *proto.PauseWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-        return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId(), Paused: true}, nil
+    func (p *Provider) PauseSchedule(_ context.Context, req *gestalt.PauseWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
+        return &gestalt.BoundWorkflowSchedule{Id: req.GetScheduleId(), Paused: true}, nil
     }
 
-    func (p *Provider) ResumeSchedule(_ context.Context, req *proto.ResumeWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
-        return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId(), Paused: false}, nil
+    func (p *Provider) ResumeSchedule(_ context.Context, req *gestalt.ResumeWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
+        return &gestalt.BoundWorkflowSchedule{Id: req.GetScheduleId(), Paused: false}, nil
     }
 
-    func (p *Provider) UpsertEventTrigger(_ context.Context, req *proto.UpsertWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-        return &proto.BoundWorkflowEventTrigger{
+    func (p *Provider) UpsertEventTrigger(_ context.Context, req *gestalt.UpsertWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
+        return &gestalt.BoundWorkflowEventTrigger{
             Id:     req.GetTriggerId(),
             Match:  req.GetMatch(),
             Target: req.GetTarget(),
@@ -894,27 +882,27 @@ signal sequence numbers exactly as stored.
         }, nil
     }
 
-    func (p *Provider) GetEventTrigger(_ context.Context, req *proto.GetWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-        return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId()}, nil
+    func (p *Provider) GetEventTrigger(_ context.Context, req *gestalt.GetWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
+        return &gestalt.BoundWorkflowEventTrigger{Id: req.GetTriggerId()}, nil
     }
 
-    func (p *Provider) ListEventTriggers(context.Context, *proto.ListWorkflowProviderEventTriggersRequest) (*proto.ListWorkflowProviderEventTriggersResponse, error) {
-        return &proto.ListWorkflowProviderEventTriggersResponse{}, nil
+    func (p *Provider) ListEventTriggers(context.Context, *gestalt.ListWorkflowProviderEventTriggersRequest) (*gestalt.ListWorkflowProviderEventTriggersResponse, error) {
+        return &gestalt.ListWorkflowProviderEventTriggersResponse{}, nil
     }
 
-    func (p *Provider) DeleteEventTrigger(context.Context, *proto.DeleteWorkflowProviderEventTriggerRequest) error {
+    func (p *Provider) DeleteEventTrigger(context.Context, *gestalt.DeleteWorkflowProviderEventTriggerRequest) error {
         return nil
     }
 
-    func (p *Provider) PauseEventTrigger(_ context.Context, req *proto.PauseWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-        return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId(), Paused: true}, nil
+    func (p *Provider) PauseEventTrigger(_ context.Context, req *gestalt.PauseWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
+        return &gestalt.BoundWorkflowEventTrigger{Id: req.GetTriggerId(), Paused: true}, nil
     }
 
-    func (p *Provider) ResumeEventTrigger(_ context.Context, req *proto.ResumeWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
-        return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId(), Paused: false}, nil
+    func (p *Provider) ResumeEventTrigger(_ context.Context, req *gestalt.ResumeWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
+        return &gestalt.BoundWorkflowEventTrigger{Id: req.GetTriggerId(), Paused: false}, nil
     }
 
-    func (p *Provider) PublishEvent(context.Context, *proto.PublishWorkflowProviderEventRequest) error {
+    func (p *Provider) PublishEvent(context.Context, *gestalt.PublishWorkflowProviderEventRequest) error {
         return nil
     }
 
@@ -965,10 +953,6 @@ signal sequence numbers exactly as stored.
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use tonic::{Request, Response, Status};
-
-    use gestalt::generated::v1 as proto;
-
     #[derive(Default)]
     struct ExampleWorkflow;
 
@@ -976,58 +960,59 @@ signal sequence numbers exactly as stored.
     impl gestalt::WorkflowProvider for ExampleWorkflow {
         async fn start_run(
             &self,
-            request: Request<proto::StartWorkflowProviderRunRequest>,
-        ) -> Result<Response<proto::BoundWorkflowRun>, Status> {
-            let req = request.into_inner();
+            req: gestalt::StartWorkflowProviderRunRequest,
+        ) -> gestalt::Result<gestalt::BoundWorkflowRun> {
             let plugin_name = req
                 .target
                 .as_ref()
-                .and_then(|target| target.plugin.as_ref())
-                .map(|plugin| plugin.plugin_name.clone())
+                .and_then(|target| match target.kind.as_ref() {
+                    Some(gestalt::bound_workflow_target::Kind::Plugin(plugin)) => {
+                        Some(plugin.plugin_name.clone())
+                    }
+                    _ => None,
+                })
                 .unwrap_or_else(|| "workflow".into());
-            Ok(Response::new(proto::BoundWorkflowRun {
+            Ok(gestalt::BoundWorkflowRun {
                 id: format!("{plugin_name}:run-1"),
-                status: proto::WorkflowRunStatus::Pending as i32,
+                status: gestalt::WorkflowRunStatus::Pending as i32,
                 target: req.target,
                 ..Default::default()
-            }))
+            })
         }
 
         async fn get_run(
             &self,
-            request: Request<proto::GetWorkflowProviderRunRequest>,
-        ) -> Result<Response<proto::BoundWorkflowRun>, Status> {
-            let req = request.into_inner();
-            Ok(Response::new(proto::BoundWorkflowRun {
+            req: gestalt::GetWorkflowProviderRunRequest,
+        ) -> gestalt::Result<gestalt::BoundWorkflowRun> {
+            Ok(gestalt::BoundWorkflowRun {
                 id: req.run_id,
                 ..Default::default()
-            }))
+            })
         }
 
         async fn list_runs(
             &self,
-            _request: Request<proto::ListWorkflowProviderRunsRequest>,
-        ) -> Result<Response<proto::ListWorkflowProviderRunsResponse>, Status> {
-            Ok(Response::new(proto::ListWorkflowProviderRunsResponse { runs: vec![] }))
+            _request: gestalt::ListWorkflowProviderRunsRequest,
+        ) -> gestalt::Result<gestalt::ListWorkflowProviderRunsResponse> {
+            Ok(gestalt::ListWorkflowProviderRunsResponse { runs: vec![] })
         }
 
         async fn cancel_run(
             &self,
-            request: Request<proto::CancelWorkflowProviderRunRequest>,
-        ) -> Result<Response<proto::BoundWorkflowRun>, Status> {
-            let req = request.into_inner();
-            Ok(Response::new(proto::BoundWorkflowRun {
+            req: gestalt::CancelWorkflowProviderRunRequest,
+        ) -> gestalt::Result<gestalt::BoundWorkflowRun> {
+            Ok(gestalt::BoundWorkflowRun {
                 id: req.run_id,
-                status: proto::WorkflowRunStatus::Canceled as i32,
+                status: gestalt::WorkflowRunStatus::Canceled as i32,
                 ..Default::default()
-            }))
+            })
         }
 
         async fn publish_event(
             &self,
-            _request: Request<proto::PublishWorkflowProviderEventRequest>,
-        ) -> Result<Response<()>, Status> {
-            Ok(Response::new(()))
+            _request: gestalt::PublishWorkflowProviderEventRequest,
+        ) -> gestalt::Result<()> {
+            Ok(())
         }
     }
 


### PR DESCRIPTION
## Summary
- migrate application and workflow event snippets to SDK native workflow builders
- replace direct Go generated proto imports in workflow and agent examples with SDK package types
- move Rust workflow, agent, runtime, and S3 examples onto SDK provider traits where supported

## Remaining SDK gap
- Rust IndexedDB provider docs still use raw proto-shaped types because the Rust SDK does not expose a server-side native IndexedDB provider trait/export surface yet.

## Verification
- npm run typecheck
- npm run build
- git diff --check
- fenced-code scan for protobuf/proto imports