### PR TITLE
docs: migrate manager snippets to native inputs

### DIFF
--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -312,18 +312,14 @@ details. Those come from the deployment bindings.
       if err != nil {
         return gestalt.Response[NightlyReportOutput]{}, err
       }
-      event, err := gestalt.NewWorkflowEvent(gestalt.WorkflowEventInput{
-        Type:            "workspace_review.report.generated",
-        Source:          "workspace_review",
-        Subject:         "nightly",
-        DataContentType: "application/json",
-        Data:            map[string]any{"reportUrl": access.URL},
-      })
-      if err != nil {
-        return gestalt.Response[NightlyReportOutput]{}, err
-      }
-      _, err = workflows.PublishEvent(ctx, &gestalt.WorkflowManagerPublishEventRequest{
-        Event: event,
+      _, err = workflows.PublishEvent(ctx, gestalt.WorkflowManagerPublishEventInput{
+        Event: &gestalt.WorkflowEventInput{
+          Type:            "workspace_review.report.generated",
+          Source:          "workspace_review",
+          Subject:         "nightly",
+          DataContentType: "application/json",
+          Data:            map[string]any{"reportUrl": access.URL},
+        },
       })
       if err != nil {
         return gestalt.Response[NightlyReportOutput]{}, err
@@ -362,8 +358,8 @@ details. Those come from the deployment bindings.
         WriteOptions,
         PresignOptions,
         PresignMethod,
-        workflow_event,
-        WorkflowManagerPublishEventRequest,
+        WorkflowEventInput,
+        WorkflowManagerPublishEventInput,
     )
 
     plugin = Plugin("workspace_review")
@@ -418,16 +414,17 @@ details. Those come from the deployment bindings.
             }
         )
 
-        event = workflow_event(
-            type="workspace_review.report.generated",
-            source="workspace_review",
-            subject="nightly",
-            datacontenttype="application/json",
-            data={"reportUrl": access.url},
-        )
         with request.workflow_manager() as workflows:
             workflows.publish_event(
-                WorkflowManagerPublishEventRequest(event=event)
+                WorkflowManagerPublishEventInput(
+                    event=WorkflowEventInput(
+                        type="workspace_review.report.generated",
+                        source="workspace_review",
+                        subject="nightly",
+                        datacontenttype="application/json",
+                        data={"reportUrl": access.url},
+                    )
+                )
             )
 
         db.close()
@@ -441,7 +438,7 @@ details. Those come from the deployment bindings.
 
     use gestalt::{
         IndexedDB, PresignMethod, PresignOptions, S3, WorkflowEventInput,
-        WorkflowManagerPublishEventRequest,
+        WorkflowManagerPublishEventInput,
     };
     use serde::{Deserialize, Serialize};
     use serde_json::json;
@@ -522,17 +519,16 @@ details. Those come from the deployment bindings.
             .await?;
 
         let mut workflows = request.workflow_manager().await?;
-        let event = gestalt::new_workflow_event(WorkflowEventInput {
-            event_type: "workspace_review.report.generated".to_string(),
-            source: "workspace_review".to_string(),
-            subject: "nightly".to_string(),
-            datacontenttype: "application/json".to_string(),
-            data: Some(json!({ "reportUrl": access.url.clone() })),
-            ..Default::default()
-        })?;
         workflows
-            .publish_event(WorkflowManagerPublishEventRequest {
-                event: Some(event),
+            .publish_event(WorkflowManagerPublishEventInput {
+                event: Some(WorkflowEventInput {
+                    event_type: "workspace_review.report.generated".to_string(),
+                    source: "workspace_review".to_string(),
+                    subject: "nightly".to_string(),
+                    datacontenttype: "application/json".to_string(),
+                    data: Some(json!({ "reportUrl": access.url.clone() })),
+                    ..Default::default()
+                }),
                 ..Default::default()
             })
             .await?;
@@ -554,6 +550,7 @@ details. Those come from the deployment bindings.
       ok,
       operation,
       s,
+      workflowEvent,
     } from "@valon-technologies/gestalt";
 
     export const plugin = definePlugin({
@@ -610,13 +607,13 @@ details. Those come from the deployment bindings.
 
             const workflows = new WorkflowManager(request);
             await workflows.publishEvent({
-              event: {
+              event: workflowEvent({
                 type: "workspace_review.report.generated",
                 source: "workspace_review",
                 subject: "nightly",
                 datacontenttype: "application/json",
                 data: { reportUrl: access.url },
-              },
+              }),
             });
 
             return ok({ reportUrl: access.url });

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -418,7 +418,7 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
         }
         defer agents.Close()
 
-        session, err := agents.CreateSession(ctx, &gestalt.AgentManagerCreateSessionRequest{
+        session, err := agents.CreateSession(ctx, gestalt.AgentManagerCreateSessionInput{
             ProviderName: "simple",
             Model:        "fast",
             ClientRef:    "roadmap-risk",
@@ -427,14 +427,14 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
             return AgentSummary{}, err
         }
 
-        turn, err := agents.CreateTurn(ctx, &gestalt.AgentManagerCreateTurnRequest{
-            SessionId: session.GetId(),
+        turn, err := agents.CreateTurn(ctx, gestalt.AgentManagerCreateTurnInput{
+            SessionID: session.GetId(),
             Model:     "fast",
-            Messages: []*gestalt.AgentMessage{{
+            Messages: []gestalt.AgentMessageInput{{
                 Role: "user",
                 Text: "Summarize the latest roadmap risk.",
             }},
-            ToolRefs: []*gestalt.AgentToolRef{{
+            ToolRefs: []gestalt.AgentToolRefInput{{
                 Plugin:    "roadmap",
                 Operation: "sync",
             }},
@@ -443,8 +443,8 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
             return AgentSummary{}, err
         }
 
-        events, err := agents.ListTurnEvents(ctx, &gestalt.AgentManagerListTurnEventsRequest{
-            TurnId: turn.GetId(),
+        events, err := agents.ListTurnEvents(ctx, gestalt.AgentManagerListTurnEventsInput{
+            TurnID: turn.GetId(),
             Limit:  100,
         })
         if err != nil {
@@ -463,17 +463,17 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
     ```python
     from gestalt import (
         Request,
-        AgentManagerCreateSessionRequest,
-        AgentManagerCreateTurnRequest,
-        AgentMessage,
-        AgentToolRef,
-        AgentManagerListTurnEventsRequest,
+        AgentManagerCreateSessionInput,
+        AgentManagerCreateTurnInput,
+        AgentMessageInput,
+        AgentToolRefInput,
+        AgentManagerListTurnEventsInput,
     )
 
     def summarize_with_agent(request: Request) -> dict[str, object]:
         with request.agent_manager() as agents:
             session = agents.create_session(
-                AgentManagerCreateSessionRequest(
+                AgentManagerCreateSessionInput(
                     provider_name="simple",
                     model="fast",
                     client_ref="roadmap-risk",
@@ -481,23 +481,23 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
             )
 
             turn = agents.create_turn(
-                AgentManagerCreateTurnRequest(
+                AgentManagerCreateTurnInput(
                     session_id=session.id,
                     model="fast",
                     messages=[
-                        AgentMessage(
+                        AgentMessageInput(
                             role="user",
                             text="Summarize the latest roadmap risk.",
                         )
                     ],
                     tool_refs=[
-                        AgentToolRef(plugin="roadmap", operation="sync")
+                        AgentToolRefInput(plugin="roadmap", operation="sync")
                     ],
                 )
             )
 
             events = agents.list_turn_events(
-                AgentManagerListTurnEventsRequest(
+                AgentManagerListTurnEventsInput(
                     turn_id=turn.id,
                     limit=100,
                 )
@@ -513,8 +513,8 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
   <Tabs.Tab>
     ```rust
     use gestalt::{
-        AgentManagerCreateSessionRequest, AgentManagerCreateTurnRequest,
-        AgentManagerListTurnEventsRequest, AgentMessage, AgentToolRef,
+        AgentManagerCreateSessionInput, AgentManagerCreateTurnInput,
+        AgentManagerListTurnEventsInput, AgentMessageInput, AgentToolRefInput,
     };
 
     struct AgentSummary {
@@ -529,7 +529,7 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
         let mut agents = request.agent_manager().await?;
 
         let session = agents
-            .create_session(AgentManagerCreateSessionRequest {
+            .create_session(AgentManagerCreateSessionInput {
                 provider_name: "simple".to_string(),
                 model: "fast".to_string(),
                 client_ref: "roadmap-risk".to_string(),
@@ -538,15 +538,15 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
             .await?;
 
         let turn = agents
-            .create_turn(AgentManagerCreateTurnRequest {
+            .create_turn(AgentManagerCreateTurnInput {
                 session_id: session.id,
                 model: "fast".to_string(),
-                messages: vec![AgentMessage {
+                messages: vec![AgentMessageInput {
                     role: "user".to_string(),
                     text: "Summarize the latest roadmap risk.".to_string(),
                     ..Default::default()
                 }],
-                tool_refs: vec![AgentToolRef {
+                tool_refs: vec![AgentToolRefInput {
                     plugin: "roadmap".to_string(),
                     operation: "sync".to_string(),
                     ..Default::default()
@@ -556,7 +556,7 @@ the `GESTALT_AGENT_MANAGER_SOCKET` injected by `gestaltd`.
             .await?;
 
         let events = agents
-            .list_turn_events(AgentManagerListTurnEventsRequest {
+            .list_turn_events(AgentManagerListTurnEventsInput {
                 turn_id: turn.id.clone(),
                 limit: 100,
                 ..Default::default()
@@ -742,33 +742,24 @@ signals instead of creating duplicate runs.
         }
         defer workflows.Close()
 
-        target, err := gestalt.NewBoundWorkflowTarget(gestalt.BoundWorkflowTargetInput{
-            Agent: &gestalt.BoundWorkflowAgentTargetInput{
-                ProviderName: "simple",
-                Model:        "fast",
-                Prompt:       "Summarize the updated roadmap item.",
-                ToolRefs: []*gestalt.AgentToolRef{{
-                    Plugin:    "roadmap",
-                    Operation: "items.get",
-                }},
-            },
-        })
-        if err != nil {
-            return "", err
-        }
-        signal, err := gestalt.NewWorkflowSignal(gestalt.WorkflowSignalInput{
-            Name:           "roadmap.item.updated",
-            IdempotencyKey: "roadmap-item-updated:" + itemID,
-        })
-        if err != nil {
-            return "", err
-        }
-
-        queued, err := workflows.SignalOrStartRun(ctx, &gestalt.WorkflowManagerSignalOrStartRunRequest{
+        queued, err := workflows.SignalOrStartRun(ctx, gestalt.WorkflowManagerSignalOrStartRunInput{
             ProviderName: "local",
             WorkflowKey:  "roadmap-summary:" + itemID,
-            Target:       target,
-            Signal:       signal,
+            Target: &gestalt.BoundWorkflowTargetInput{
+                Agent: &gestalt.BoundWorkflowAgentTargetInput{
+                    ProviderName: "simple",
+                    Model:        "fast",
+                    Prompt:       "Summarize the updated roadmap item.",
+                    ToolRefInputs: []gestalt.AgentToolRefInput{{
+                        Plugin:    "roadmap",
+                        Operation: "items.get",
+                    }},
+                },
+            },
+            Signal: &gestalt.WorkflowSignalInput{
+                Name:           "roadmap.item.updated",
+                IdempotencyKey: "roadmap-item-updated:" + itemID,
+            },
         })
         if err != nil {
             return "", err
@@ -781,33 +772,33 @@ signals instead of creating duplicate runs.
     ```python
     from gestalt import (
         Request,
-        WorkflowManagerSignalOrStartRunRequest,
-        BoundWorkflowTarget,
-        BoundWorkflowAgentTarget,
-        AgentToolRef,
-        WorkflowSignal,
+        WorkflowManagerSignalOrStartRunInput,
+        BoundWorkflowTargetInput,
+        BoundWorkflowAgentTargetInput,
+        AgentToolRefInput,
+        WorkflowSignalInput,
     )
 
     def enqueue_agent_workflow(request: Request, item_id: str) -> str:
         with request.workflow_manager() as workflows:
             queued = workflows.signal_or_start_run(
-                WorkflowManagerSignalOrStartRunRequest(
+                WorkflowManagerSignalOrStartRunInput(
                     provider_name="local",
                     workflow_key=f"roadmap-summary:{item_id}",
-                    target=BoundWorkflowTarget(
-                        agent=BoundWorkflowAgentTarget(
+                    target=BoundWorkflowTargetInput(
+                        agent=BoundWorkflowAgentTargetInput(
                             provider_name="simple",
                             model="fast",
                             prompt="Summarize the updated roadmap item.",
                             tool_refs=[
-                                AgentToolRef(
+                                AgentToolRefInput(
                                     plugin="roadmap",
                                     operation="items.get",
                                 )
                             ],
                         )
                     ),
-                    signal=WorkflowSignal(
+                    signal=WorkflowSignalInput(
                         name="roadmap.item.updated",
                         idempotency_key=f"roadmap-item-updated:{item_id}",
                     ),
@@ -820,8 +811,8 @@ signals instead of creating duplicate runs.
   <Tabs.Tab>
     ```rust
     use gestalt::{
-        AgentToolRef, BoundWorkflowAgentTargetInput, BoundWorkflowTargetInput,
-        WorkflowManagerSignalOrStartRunRequest, WorkflowSignalInput,
+        AgentToolRefInput, BoundWorkflowAgentTargetInput, BoundWorkflowTargetInput,
+        WorkflowManagerSignalOrStartRunInput, WorkflowSignalInput,
     };
 
     async fn enqueue_agent_workflow(
@@ -829,32 +820,29 @@ signals instead of creating duplicate runs.
         item_id: &str,
     ) -> Result<String, Box<dyn std::error::Error>> {
         let mut workflows = request.workflow_manager().await?;
-        let target = gestalt::new_bound_workflow_target(BoundWorkflowTargetInput {
-            agent: Some(BoundWorkflowAgentTargetInput {
-                provider_name: "simple".to_string(),
-                model: "fast".to_string(),
-                prompt: "Summarize the updated roadmap item.".to_string(),
-                tool_refs: vec![AgentToolRef {
-                    plugin: "roadmap".to_string(),
-                    operation: "items.get".to_string(),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            }),
-            ..Default::default()
-        })?;
-        let signal = gestalt::new_workflow_signal(WorkflowSignalInput {
-            name: "roadmap.item.updated".to_string(),
-            idempotency_key: format!("roadmap-item-updated:{item_id}"),
-            ..Default::default()
-        })?;
 
         let queued = workflows
-            .signal_or_start_run(WorkflowManagerSignalOrStartRunRequest {
+            .signal_or_start_run(WorkflowManagerSignalOrStartRunInput {
                 provider_name: "local".to_string(),
                 workflow_key: format!("roadmap-summary:{item_id}"),
-                target: Some(target),
-                signal: Some(signal),
+                target: Some(BoundWorkflowTargetInput::Agent(
+                    BoundWorkflowAgentTargetInput {
+                        provider_name: "simple".to_string(),
+                        model: "fast".to_string(),
+                        prompt: "Summarize the updated roadmap item.".to_string(),
+                        tool_ref_inputs: vec![AgentToolRefInput {
+                            plugin: "roadmap".to_string(),
+                            operation: "items.get".to_string(),
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    },
+                )),
+                signal: Some(WorkflowSignalInput {
+                    name: "roadmap.item.updated".to_string(),
+                    idempotency_key: format!("roadmap-item-updated:{item_id}"),
+                    ..Default::default()
+                }),
                 ..Default::default()
             })
             .await?;
@@ -865,7 +853,12 @@ signals instead of creating duplicate runs.
   </Tabs.Tab>
   <Tabs.Tab>
     ```ts
-    import { WorkflowManager, type Request } from "@valon-technologies/gestalt";
+    import {
+      WorkflowManager,
+      boundWorkflowTarget,
+      workflowSignal,
+      type Request,
+    } from "@valon-technologies/gestalt";
 
     export async function enqueueAgentWorkflow(request: Request, itemId: string) {
       const workflows = new WorkflowManager(request);
@@ -873,26 +866,23 @@ signals instead of creating duplicate runs.
       const queued = await workflows.signalOrStartRun({
         providerName: "local",
         workflowKey: `roadmap-summary:${itemId}`,
-        target: {
-          kind: {
-            case: "agent",
-            value: {
-              providerName: "simple",
-              model: "fast",
-              prompt: "Summarize the updated roadmap item.",
-              toolRefs: [
-                {
-                  plugin: "roadmap",
-                  operation: "items.get",
-                },
-              ],
-            },
+        target: boundWorkflowTarget({
+          agent: {
+            providerName: "simple",
+            model: "fast",
+            prompt: "Summarize the updated roadmap item.",
+            toolRefs: [
+              {
+                plugin: "roadmap",
+                operation: "items.get",
+              },
+            ],
           },
-        },
-        signal: {
+        }),
+        signal: workflowSignal({
           name: "roadmap.item.updated",
           idempotencyKey: `roadmap-item-updated:${itemId}`,
-        },
+        }),
       });
 
       return queued.run?.id ?? "";

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -487,20 +487,15 @@ definition do not silently change existing automation.
         }
         defer workflows.Close()
 
-        event, err := gestalt.NewWorkflowEvent(gestalt.WorkflowEventInput{
-            Type:            "slack.event.received",
-            Source:          "slack",
-            Subject:         "route:knowledge-ingest",
-            DataContentType: "application/json",
-            Data:            map[string]any{"event": slackEvent},
-        })
-        if err != nil {
-            return "", err
-        }
-
-        published, err := workflows.PublishEvent(ctx, &gestalt.WorkflowManagerPublishEventRequest{
+        published, err := workflows.PublishEvent(ctx, gestalt.WorkflowManagerPublishEventInput{
             ProviderName: "local",
-            Event:        event,
+            Event: &gestalt.WorkflowEventInput{
+                Type:            "slack.event.received",
+                Source:          "slack",
+                Subject:         "route:knowledge-ingest",
+                DataContentType: "application/json",
+                Data:            map[string]any{"event": slackEvent},
+            },
         })
         if err != nil {
             return "", err
@@ -511,25 +506,23 @@ definition do not silently change existing automation.
   </Tabs.Tab>
   <Tabs.Tab>
     ```python
-    from gestalt import Request, WorkflowManagerPublishEventRequest, workflow_event
+    from gestalt import Request, WorkflowEventInput, WorkflowManagerPublishEventInput
 
     def publish_slack_event(
         request: Request,
         slack_event: dict[str, object],
     ) -> str:
-        event = workflow_event(
-            type="slack.event.received",
-            source="slack",
-            subject="route:knowledge-ingest",
-            datacontenttype="application/json",
-            data={"event": slack_event},
-        )
-
         with request.workflow_manager() as workflows:
             published = workflows.publish_event(
-                WorkflowManagerPublishEventRequest(
+                WorkflowManagerPublishEventInput(
                     provider_name="local",
-                    event=event,
+                    event=WorkflowEventInput(
+                        type="slack.event.received",
+                        source="slack",
+                        subject="route:knowledge-ingest",
+                        datacontenttype="application/json",
+                        data={"event": slack_event},
+                    ),
                 )
             )
 
@@ -538,7 +531,7 @@ definition do not silently change existing automation.
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use gestalt::{WorkflowEventInput, WorkflowManagerPublishEventRequest};
+    use gestalt::{WorkflowEventInput, WorkflowManagerPublishEventInput};
     use serde_json::json;
 
     async fn publish_slack_event(
@@ -546,19 +539,17 @@ definition do not silently change existing automation.
         slack_event: serde_json::Value,
     ) -> Result<String, Box<dyn std::error::Error>> {
         let mut workflows = request.workflow_manager().await?;
-        let event = gestalt::new_workflow_event(WorkflowEventInput {
-            event_type: "slack.event.received".to_string(),
-            source: "slack".to_string(),
-            subject: "route:knowledge-ingest".to_string(),
-            datacontenttype: "application/json".to_string(),
-            data: Some(json!({ "event": slack_event })),
-            ..Default::default()
-        })?;
-
         let event = workflows
-            .publish_event(WorkflowManagerPublishEventRequest {
+            .publish_event(WorkflowManagerPublishEventInput {
                 provider_name: "local".to_string(),
-                event: Some(event),
+                event: Some(WorkflowEventInput {
+                    event_type: "slack.event.received".to_string(),
+                    source: "slack".to_string(),
+                    subject: "route:knowledge-ingest".to_string(),
+                    datacontenttype: "application/json".to_string(),
+                    data: Some(json!({ "event": slack_event })),
+                    ..Default::default()
+                }),
                 ..Default::default()
             })
             .await?;
@@ -569,7 +560,11 @@ definition do not silently change existing automation.
   </Tabs.Tab>
   <Tabs.Tab>
     ```ts
-    import { WorkflowManager, type Request } from "@valon-technologies/gestalt";
+    import {
+      WorkflowManager,
+      workflowEvent,
+      type Request,
+    } from "@valon-technologies/gestalt";
 
     export async function publishSlackEvent(
       request: Request,
@@ -579,7 +574,7 @@ definition do not silently change existing automation.
 
       const event = await workflowManager.publishEvent({
         providerName: "local",
-        event: {
+        event: workflowEvent({
           type: "slack.event.received",
           source: "slack",
           subject: "route:knowledge-ingest",
@@ -587,7 +582,7 @@ definition do not silently change existing automation.
           data: {
             event: slackEvent,
           },
-        },
+        }),
       });
 
       return event.id;
@@ -788,13 +783,14 @@ The full protocol includes:
 | `PutExecutionReference` / `GetExecutionReference` / `ListExecutionReferences` | Persist delayed-execution identity and permission records |
 | `PublishEvent` | Deliver an event into the provider |
 
-Go and Rust expose the complete generated workflow provider service. Python
-currently registers run, signal, schedule, trigger, and publish methods through
-the SDK runtime. TypeScript currently exposes the core run, schedule, trigger,
-and publish methods through `defineWorkflowProvider`. If you need signal or
-execution-reference methods before the handwritten TypeScript and Python helpers
-grow those methods, implement that provider in Go or Rust, or serve the
-generated protocol directly.
+Go exposes the complete workflow provider service through native request and
+response input types. Rust exposes the complete generated workflow provider
+service. Python currently registers run, signal, schedule, trigger, and publish
+methods through the SDK runtime. TypeScript currently exposes the core run,
+schedule, trigger, and publish methods through `defineWorkflowProvider`. If you
+need signal or execution-reference methods before the handwritten TypeScript
+and Python helpers grow those methods, implement that provider in Go or Rust,
+or serve the generated protocol directly.
 
 The examples below show the core authored shape. Production workflow providers
 should persist returned IDs, timestamps, status, execution references, and
@@ -819,17 +815,17 @@ signal sequence numbers exactly as stored.
         return nil
     }
 
-    func (p *Provider) StartRun(_ context.Context, req *gestalt.StartWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
-        return &gestalt.BoundWorkflowRun{
-            Id:     req.GetTarget().GetPlugin().GetPluginName() + ":run-1",
+    func (p *Provider) StartRun(_ context.Context, req *gestalt.StartWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRunInput, error) {
+        return &gestalt.BoundWorkflowRunInput{
+            ID:     "workflow:run-1",
             Status: gestalt.WorkflowRunStatusValuePending,
-            Target: req.GetTarget(),
+            Target: req.Target,
         }, nil
     }
 
-    func (p *Provider) GetRun(_ context.Context, req *gestalt.GetWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
-        return &gestalt.BoundWorkflowRun{
-            Id: req.GetRunId(),
+    func (p *Provider) GetRun(_ context.Context, req *gestalt.GetWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRunInput, error) {
+        return &gestalt.BoundWorkflowRunInput{
+            ID: req.RunID,
         }, nil
     }
 
@@ -837,24 +833,24 @@ signal sequence numbers exactly as stored.
         return &gestalt.ListWorkflowProviderRunsResponse{}, nil
     }
 
-    func (p *Provider) CancelRun(_ context.Context, req *gestalt.CancelWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
-        return &gestalt.BoundWorkflowRun{
-            Id:     req.GetRunId(),
+    func (p *Provider) CancelRun(_ context.Context, req *gestalt.CancelWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRunInput, error) {
+        return &gestalt.BoundWorkflowRunInput{
+            ID:     req.RunID,
             Status: gestalt.WorkflowRunStatusValueCanceled,
         }, nil
     }
 
-    func (p *Provider) UpsertSchedule(_ context.Context, req *gestalt.UpsertWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
-        return &gestalt.BoundWorkflowSchedule{
-            Id:     req.GetScheduleId(),
-            Cron:   req.GetCron(),
-            Target: req.GetTarget(),
-            Paused: req.GetPaused(),
+    func (p *Provider) UpsertSchedule(_ context.Context, req *gestalt.UpsertWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowScheduleInput, error) {
+        return &gestalt.BoundWorkflowScheduleInput{
+            ID:     req.ScheduleID,
+            Cron:   req.Cron,
+            Target: req.Target,
+            Paused: req.Paused,
         }, nil
     }
 
-    func (p *Provider) GetSchedule(_ context.Context, req *gestalt.GetWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
-        return &gestalt.BoundWorkflowSchedule{Id: req.GetScheduleId()}, nil
+    func (p *Provider) GetSchedule(_ context.Context, req *gestalt.GetWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowScheduleInput, error) {
+        return &gestalt.BoundWorkflowScheduleInput{ID: req.ScheduleID}, nil
     }
 
     func (p *Provider) ListSchedules(context.Context, *gestalt.ListWorkflowProviderSchedulesRequest) (*gestalt.ListWorkflowProviderSchedulesResponse, error) {
@@ -865,25 +861,25 @@ signal sequence numbers exactly as stored.
         return nil
     }
 
-    func (p *Provider) PauseSchedule(_ context.Context, req *gestalt.PauseWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
-        return &gestalt.BoundWorkflowSchedule{Id: req.GetScheduleId(), Paused: true}, nil
+    func (p *Provider) PauseSchedule(_ context.Context, req *gestalt.PauseWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowScheduleInput, error) {
+        return &gestalt.BoundWorkflowScheduleInput{ID: req.ScheduleID, Paused: true}, nil
     }
 
-    func (p *Provider) ResumeSchedule(_ context.Context, req *gestalt.ResumeWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
-        return &gestalt.BoundWorkflowSchedule{Id: req.GetScheduleId(), Paused: false}, nil
+    func (p *Provider) ResumeSchedule(_ context.Context, req *gestalt.ResumeWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowScheduleInput, error) {
+        return &gestalt.BoundWorkflowScheduleInput{ID: req.ScheduleID, Paused: false}, nil
     }
 
-    func (p *Provider) UpsertEventTrigger(_ context.Context, req *gestalt.UpsertWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
-        return &gestalt.BoundWorkflowEventTrigger{
-            Id:     req.GetTriggerId(),
-            Match:  req.GetMatch(),
-            Target: req.GetTarget(),
-            Paused: req.GetPaused(),
+    func (p *Provider) UpsertEventTrigger(_ context.Context, req *gestalt.UpsertWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTriggerInput, error) {
+        return &gestalt.BoundWorkflowEventTriggerInput{
+            ID:     req.TriggerID,
+            Match:  req.Match,
+            Target: req.Target,
+            Paused: req.Paused,
         }, nil
     }
 
-    func (p *Provider) GetEventTrigger(_ context.Context, req *gestalt.GetWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
-        return &gestalt.BoundWorkflowEventTrigger{Id: req.GetTriggerId()}, nil
+    func (p *Provider) GetEventTrigger(_ context.Context, req *gestalt.GetWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTriggerInput, error) {
+        return &gestalt.BoundWorkflowEventTriggerInput{ID: req.TriggerID}, nil
     }
 
     func (p *Provider) ListEventTriggers(context.Context, *gestalt.ListWorkflowProviderEventTriggersRequest) (*gestalt.ListWorkflowProviderEventTriggersResponse, error) {
@@ -894,12 +890,12 @@ signal sequence numbers exactly as stored.
         return nil
     }
 
-    func (p *Provider) PauseEventTrigger(_ context.Context, req *gestalt.PauseWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
-        return &gestalt.BoundWorkflowEventTrigger{Id: req.GetTriggerId(), Paused: true}, nil
+    func (p *Provider) PauseEventTrigger(_ context.Context, req *gestalt.PauseWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTriggerInput, error) {
+        return &gestalt.BoundWorkflowEventTriggerInput{ID: req.TriggerID, Paused: true}, nil
     }
 
-    func (p *Provider) ResumeEventTrigger(_ context.Context, req *gestalt.ResumeWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
-        return &gestalt.BoundWorkflowEventTrigger{Id: req.GetTriggerId(), Paused: false}, nil
+    func (p *Provider) ResumeEventTrigger(_ context.Context, req *gestalt.ResumeWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTriggerInput, error) {
+        return &gestalt.BoundWorkflowEventTriggerInput{ID: req.TriggerID, Paused: false}, nil
     }
 
     func (p *Provider) PublishEvent(context.Context, *gestalt.PublishWorkflowProviderEventRequest) error {

--- a/docs/content/reference/sdk/index.mdx
+++ b/docs/content/reference/sdk/index.mdx
@@ -23,3 +23,17 @@ servers.
 3. Build the smallest plugin provider first.
 4. Add provider-specific surfaces such as authentication, cache, S3, workflow,
    runtime, or agent support only after the basic provider runs locally.
+
+## Native input coverage
+
+The SDK examples use native input helpers for manager requests where those
+helpers exist. That includes agent-manager messages and tool refs, workflow
+events, workflow signals, and bound workflow targets in Go, Python, and Rust.
+TypeScript workflow examples use root helper functions such as
+`workflowEvent`, `workflowSignal`, and `boundWorkflowTarget` when a manager
+field would otherwise expose a generated oneof or protobuf well-known type.
+
+Manager responses still return protocol-backed objects. Examples may therefore
+read response fields with language-specific protocol accessors such as Go
+`GetId`-style methods or generated response fields in Python, Rust, and
+TypeScript. Native response objects are a remaining SDK gap.

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -36,10 +36,10 @@ type funcInvoker struct {
 }
 
 func testWorkflowPluginTarget(pluginName, operation string) coreworkflow.Target {
-	return testWorkflowPluginTargetWithInput(pluginName, operation, "", "", nil)
+	return testWorkflowPluginTargetWithPayload(pluginName, operation, "", "", nil)
 }
 
-func testWorkflowPluginTargetWithInput(pluginName, operation, connection, instance string, input map[string]any) coreworkflow.Target {
+func testWorkflowPluginTargetWithPayload(pluginName, operation, connection, instance string, input map[string]any) coreworkflow.Target {
 	return coreworkflow.Target{
 		Plugin: &coreworkflow.PluginTarget{
 			PluginName: pluginName,
@@ -386,7 +386,7 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	req := coreworkflow.InvokeOperationRequest{
 		ProviderName: "temporal",
 		RunID:        "run-123",
-		Target: testWorkflowPluginTargetWithInput(
+		Target: testWorkflowPluginTargetWithPayload(
 			"roadmap",
 			"sync",
 			"analytics",
@@ -1356,7 +1356,7 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 	if err != nil {
 		t.Fatalf("FindOrCreateUser: %v", err)
 	}
-	target := testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", map[string]any{"mode": "full"})
+	target := testWorkflowPluginTargetWithPayload("roadmap", "sync", "analytics", "tenant-a", map[string]any{"mode": "full"})
 	target.Plugin.CredentialMode = core.ConnectionModeNone
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
@@ -1653,7 +1653,7 @@ func TestWorkflowRuntimeInvokeExecutionRefRechecksAuthorizationThroughBroker(t *
 	if err != nil {
 		t.Fatalf("FindOrCreateUser: %v", err)
 	}
-	target := testWorkflowPluginTargetWithInput("roadmap", "sync", "analytics", "tenant-a", nil)
+	target := testWorkflowPluginTargetWithPayload("roadmap", "sync", "analytics", "tenant-a", nil)
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
 		ID:           "exec-ref-denied",
@@ -1736,7 +1736,7 @@ func TestWorkflowRuntimeInvokeExecutionRefPreservesTokenPermissionCeiling(t *tes
 	services := testutil.NewStubServices(t)
 	ctx := context.Background()
 
-	target := testWorkflowPluginTargetWithInput("roadmap", "export", "analytics", "tenant-a", nil)
+	target := testWorkflowPluginTargetWithPayload("roadmap", "export", "analytics", "tenant-a", nil)
 	refProvider := newWorkflowRuntimeExecutionRefProvider()
 	if _, err := refProvider.PutExecutionReference(ctx, &coreworkflow.ExecutionReference{
 		ID:           "exec-ref-123",

--- a/gestaltd/internal/testutil/testdata/testproviders/echo/proxy_provider.go
+++ b/gestaltd/internal/testutil/testdata/testproviders/echo/proxy_provider.go
@@ -18,7 +18,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/services/plugininvoker"
-	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -360,11 +359,11 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		target, err := workflowTargetInputToProto(input.Target)
+		target, err := workflowTargetInput(input.Target)
 		if err != nil {
 			return jsonResult(http.StatusBadRequest, map[string]any{"error": err.Error()}), nil
 		}
-		result, err := client.CreateSchedule(ctx, &proto.WorkflowManagerCreateScheduleRequest{
+		result, err := client.CreateSchedule(ctx, gestalt.WorkflowManagerCreateScheduleInput{
 			ProviderName: input.ProviderName,
 			Cron:         input.Cron,
 			Timezone:     input.Timezone,
@@ -386,8 +385,8 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		result, err := client.GetSchedule(ctx, &proto.WorkflowManagerGetScheduleRequest{
-			ScheduleId: input.ScheduleID,
+		result, err := client.GetSchedule(ctx, gestalt.WorkflowManagerGetScheduleInput{
+			ScheduleID: input.ScheduleID,
 		})
 		if err != nil {
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
@@ -404,12 +403,12 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		target, err := workflowTargetInputToProto(input.Target)
+		target, err := workflowTargetInput(input.Target)
 		if err != nil {
 			return jsonResult(http.StatusBadRequest, map[string]any{"error": err.Error()}), nil
 		}
-		result, err := client.UpdateSchedule(ctx, &proto.WorkflowManagerUpdateScheduleRequest{
-			ScheduleId:   input.ScheduleID,
+		result, err := client.UpdateSchedule(ctx, gestalt.WorkflowManagerUpdateScheduleInput{
+			ScheduleID:   input.ScheduleID,
 			ProviderName: input.ProviderName,
 			Cron:         input.Cron,
 			Timezone:     input.Timezone,
@@ -431,8 +430,8 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		if err := client.DeleteSchedule(ctx, &proto.WorkflowManagerDeleteScheduleRequest{
-			ScheduleId: input.ScheduleID,
+		if err := client.DeleteSchedule(ctx, gestalt.WorkflowManagerDeleteScheduleInput{
+			ScheduleID: input.ScheduleID,
 		}); err != nil {
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
@@ -448,8 +447,8 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		result, err := client.PauseSchedule(ctx, &proto.WorkflowManagerPauseScheduleRequest{
-			ScheduleId: input.ScheduleID,
+		result, err := client.PauseSchedule(ctx, gestalt.WorkflowManagerPauseScheduleInput{
+			ScheduleID: input.ScheduleID,
 		})
 		if err != nil {
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
@@ -466,8 +465,8 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		result, err := client.ResumeSchedule(ctx, &proto.WorkflowManagerResumeScheduleRequest{
-			ScheduleId: input.ScheduleID,
+		result, err := client.ResumeSchedule(ctx, gestalt.WorkflowManagerResumeScheduleInput{
+			ScheduleID: input.ScheduleID,
 		})
 		if err != nil {
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
@@ -484,13 +483,13 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		target, err := workflowTargetInputToProto(input.Target)
+		target, err := workflowTargetInput(input.Target)
 		if err != nil {
 			return jsonResult(http.StatusBadRequest, map[string]any{"error": err.Error()}), nil
 		}
-		result, err := client.CreateTrigger(ctx, &proto.WorkflowManagerCreateEventTriggerRequest{
+		result, err := client.CreateTrigger(ctx, gestalt.WorkflowManagerCreateEventTriggerInput{
 			ProviderName: input.ProviderName,
-			Match:        workflowEventMatchInputToProto(input.Match),
+			Match:        workflowEventMatch(input.Match),
 			Target:       target,
 			Paused:       input.Paused,
 		})
@@ -509,8 +508,8 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		result, err := client.GetTrigger(ctx, &proto.WorkflowManagerGetEventTriggerRequest{
-			TriggerId: input.TriggerID,
+		result, err := client.GetTrigger(ctx, gestalt.WorkflowManagerGetEventTriggerInput{
+			TriggerID: input.TriggerID,
 		})
 		if err != nil {
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
@@ -527,14 +526,14 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		target, err := workflowTargetInputToProto(input.Target)
+		target, err := workflowTargetInput(input.Target)
 		if err != nil {
 			return jsonResult(http.StatusBadRequest, map[string]any{"error": err.Error()}), nil
 		}
-		result, err := client.UpdateTrigger(ctx, &proto.WorkflowManagerUpdateEventTriggerRequest{
-			TriggerId:    input.TriggerID,
+		result, err := client.UpdateTrigger(ctx, gestalt.WorkflowManagerUpdateEventTriggerInput{
+			TriggerID:    input.TriggerID,
 			ProviderName: input.ProviderName,
-			Match:        workflowEventMatchInputToProto(input.Match),
+			Match:        workflowEventMatch(input.Match),
 			Target:       target,
 			Paused:       input.Paused,
 		})
@@ -553,8 +552,8 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		if err := client.DeleteTrigger(ctx, &proto.WorkflowManagerDeleteEventTriggerRequest{
-			TriggerId: input.TriggerID,
+		if err := client.DeleteTrigger(ctx, gestalt.WorkflowManagerDeleteEventTriggerInput{
+			TriggerID: input.TriggerID,
 		}); err != nil {
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
@@ -570,8 +569,8 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		result, err := client.PauseTrigger(ctx, &proto.WorkflowManagerPauseEventTriggerRequest{
-			TriggerId: input.TriggerID,
+		result, err := client.PauseTrigger(ctx, gestalt.WorkflowManagerPauseEventTriggerInput{
+			TriggerID: input.TriggerID,
 		})
 		if err != nil {
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
@@ -588,8 +587,8 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		result, err := client.ResumeTrigger(ctx, &proto.WorkflowManagerResumeEventTriggerRequest{
-			TriggerId: input.TriggerID,
+		result, err := client.ResumeTrigger(ctx, gestalt.WorkflowManagerResumeEventTriggerInput{
+			TriggerID: input.TriggerID,
 		})
 		if err != nil {
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
@@ -606,11 +605,11 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return jsonResult(http.StatusOK, map[string]any{"error": err.Error()}), nil
 		}
 		defer func() { _ = client.Close() }()
-		event, err := workflowEventInputToProto(input)
+		event, err := workflowEvent(input)
 		if err != nil {
 			return jsonResult(http.StatusBadRequest, map[string]any{"error": err.Error()}), nil
 		}
-		result, err := client.PublishEvent(ctx, &proto.WorkflowManagerPublishEventRequest{
+		result, err := client.PublishEvent(ctx, gestalt.WorkflowManagerPublishEventInput{
 			Event:        event,
 			ProviderName: input.ProviderName,
 		})
@@ -792,57 +791,43 @@ func workflowManagerFromContext(ctx context.Context, invocationToken string) (*g
 	return gestalt.WorkflowManager(token)
 }
 
-func workflowTargetInputToProto(target workflowScheduleTargetInput) (*proto.BoundWorkflowTarget, error) {
-	input, err := structpb.NewStruct(target.Input)
-	if err != nil {
-		return nil, err
-	}
-	return &proto.BoundWorkflowTarget{
-		Kind: &proto.BoundWorkflowTarget_Plugin{
-			Plugin: &proto.BoundWorkflowPluginTarget{
-				PluginName: target.Plugin,
-				Operation:  target.Operation,
-				Connection: target.Connection,
-				Instance:   target.Instance,
-				Input:      input,
-			},
+func workflowTargetInput(target workflowScheduleTargetInput) (*gestalt.BoundWorkflowTargetInput, error) {
+	return &gestalt.BoundWorkflowTargetInput{
+		Plugin: &gestalt.BoundWorkflowPluginTargetInput{
+			PluginName: target.Plugin,
+			Operation:  target.Operation,
+			Connection: target.Connection,
+			Instance:   target.Instance,
+			Input:      target.Input,
 		},
 	}, nil
 }
 
-func workflowEventMatchInputToProto(match workflowEventMatchInput) *proto.WorkflowEventMatch {
-	return &proto.WorkflowEventMatch{
+func workflowEventMatch(match workflowEventMatchInput) *gestalt.WorkflowEventMatchInput {
+	return &gestalt.WorkflowEventMatchInput{
 		Type:    match.Type,
 		Source:  match.Source,
 		Subject: match.Subject,
 	}
 }
 
-func workflowEventInputToProto(input publishWorkflowEventInput) (*proto.WorkflowEvent, error) {
-	data, err := structpb.NewStruct(input.Data)
-	if err != nil {
-		return nil, err
-	}
-	extensions, err := structpb.NewStruct(input.Extensions)
-	if err != nil {
-		return nil, err
-	}
-	event := &proto.WorkflowEvent{
-		Id:              input.ID,
+func workflowEvent(input publishWorkflowEventInput) (*gestalt.WorkflowEventInput, error) {
+	event := &gestalt.WorkflowEventInput{
+		ID:              input.ID,
 		Source:          input.Source,
 		SpecVersion:     input.SpecVersion,
 		Type:            input.Type,
 		Subject:         input.Subject,
-		Datacontenttype: input.DataContentType,
-		Data:            data,
-		Extensions:      extensions.GetFields(),
+		DataContentType: input.DataContentType,
+		Data:            input.Data,
+		Extensions:      input.Extensions,
 	}
 	if strings.TrimSpace(input.Time) != "" {
 		timestamp, err := time.Parse(time.RFC3339, input.Time)
 		if err != nil {
 			return nil, err
 		}
-		event.Time = timestamppb.New(timestamp)
+		event.Time = timestamp
 	}
 	return event, nil
 }

--- a/sdk/go/agent_manager.go
+++ b/sdk/go/agent_manager.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
-	gproto "google.golang.org/protobuf/proto"
 )
 
 // EnvAgentManagerSocket names the environment variable containing the
@@ -60,215 +59,123 @@ func (c *AgentManagerClient) Close() error {
 }
 
 // CreateSession creates an agent session.
-func (c *AgentManagerClient) CreateSession(ctx context.Context, req *proto.AgentManagerCreateSessionRequest) (*proto.AgentSession, error) {
+func (c *AgentManagerClient) CreateSession(ctx context.Context, input AgentManagerCreateSessionInput) (*proto.AgentSession, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
 	}
-	value := &proto.AgentManagerCreateSessionRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerCreateSessionRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.CreateSession(ctx, value)
-}
-
-// CreateSessionWithInput creates an agent session.
-func (c *AgentManagerClient) CreateSessionWithInput(ctx context.Context, input AgentManagerCreateSessionInput) (*proto.AgentSession, error) {
 	req, err := NewAgentManagerCreateSessionRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.CreateSession(ctx, req)
+	req.InvocationToken = c.invocationToken
+	return c.client.CreateSession(ctx, req)
 }
 
 // GetSession fetches one agent session.
-func (c *AgentManagerClient) GetSession(ctx context.Context, req *proto.AgentManagerGetSessionRequest) (*proto.AgentSession, error) {
+func (c *AgentManagerClient) GetSession(ctx context.Context, input AgentManagerGetSessionInput) (*proto.AgentSession, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
 	}
-	value := &proto.AgentManagerGetSessionRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerGetSessionRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.GetSession(ctx, value)
-}
-
-// GetSessionWithInput fetches one agent session.
-func (c *AgentManagerClient) GetSessionWithInput(ctx context.Context, input AgentManagerGetSessionInput) (*proto.AgentSession, error) {
-	return c.GetSession(ctx, NewAgentManagerGetSessionRequest(input))
+	req := NewAgentManagerGetSessionRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.GetSession(ctx, req)
 }
 
 // ListSessions lists agent sessions visible to the invocation token.
-func (c *AgentManagerClient) ListSessions(ctx context.Context, req *proto.AgentManagerListSessionsRequest) (*proto.AgentManagerListSessionsResponse, error) {
+func (c *AgentManagerClient) ListSessions(ctx context.Context, input AgentManagerListSessionsInput) (*proto.AgentManagerListSessionsResponse, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
 	}
-	value := &proto.AgentManagerListSessionsRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerListSessionsRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.ListSessions(ctx, value)
-}
-
-// ListSessionsWithInput lists agent sessions.
-func (c *AgentManagerClient) ListSessionsWithInput(ctx context.Context, input AgentManagerListSessionsInput) (*proto.AgentManagerListSessionsResponse, error) {
-	return c.ListSessions(ctx, NewAgentManagerListSessionsRequest(input))
+	req := NewAgentManagerListSessionsRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.ListSessions(ctx, req)
 }
 
 // UpdateSession updates mutable fields on an agent session.
-func (c *AgentManagerClient) UpdateSession(ctx context.Context, req *proto.AgentManagerUpdateSessionRequest) (*proto.AgentSession, error) {
+func (c *AgentManagerClient) UpdateSession(ctx context.Context, input AgentManagerUpdateSessionInput) (*proto.AgentSession, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
 	}
-	value := &proto.AgentManagerUpdateSessionRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerUpdateSessionRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.UpdateSession(ctx, value)
-}
-
-// UpdateSessionWithInput updates an agent session.
-func (c *AgentManagerClient) UpdateSessionWithInput(ctx context.Context, input AgentManagerUpdateSessionInput) (*proto.AgentSession, error) {
 	req, err := NewAgentManagerUpdateSessionRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.UpdateSession(ctx, req)
+	req.InvocationToken = c.invocationToken
+	return c.client.UpdateSession(ctx, req)
 }
 
 // CreateTurn creates an agent turn.
-func (c *AgentManagerClient) CreateTurn(ctx context.Context, req *proto.AgentManagerCreateTurnRequest) (*proto.AgentTurn, error) {
+func (c *AgentManagerClient) CreateTurn(ctx context.Context, input AgentManagerCreateTurnInput) (*proto.AgentTurn, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
 	}
-	value := &proto.AgentManagerCreateTurnRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerCreateTurnRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.CreateTurn(ctx, value)
-}
-
-// CreateTurnWithInput creates an agent turn.
-func (c *AgentManagerClient) CreateTurnWithInput(ctx context.Context, input AgentManagerCreateTurnInput) (*proto.AgentTurn, error) {
 	req, err := NewAgentManagerCreateTurnRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.CreateTurn(ctx, req)
+	req.InvocationToken = c.invocationToken
+	return c.client.CreateTurn(ctx, req)
 }
 
 // GetTurn fetches one agent turn.
-func (c *AgentManagerClient) GetTurn(ctx context.Context, req *proto.AgentManagerGetTurnRequest) (*proto.AgentTurn, error) {
+func (c *AgentManagerClient) GetTurn(ctx context.Context, input AgentManagerGetTurnInput) (*proto.AgentTurn, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
 	}
-	value := &proto.AgentManagerGetTurnRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerGetTurnRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.GetTurn(ctx, value)
-}
-
-// GetTurnWithInput fetches one agent turn.
-func (c *AgentManagerClient) GetTurnWithInput(ctx context.Context, input AgentManagerGetTurnInput) (*proto.AgentTurn, error) {
-	return c.GetTurn(ctx, NewAgentManagerGetTurnRequest(input))
+	req := NewAgentManagerGetTurnRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.GetTurn(ctx, req)
 }
 
 // ListTurns lists turns for an agent session.
-func (c *AgentManagerClient) ListTurns(ctx context.Context, req *proto.AgentManagerListTurnsRequest) (*proto.AgentManagerListTurnsResponse, error) {
+func (c *AgentManagerClient) ListTurns(ctx context.Context, input AgentManagerListTurnsInput) (*proto.AgentManagerListTurnsResponse, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
 	}
-	value := &proto.AgentManagerListTurnsRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerListTurnsRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.ListTurns(ctx, value)
-}
-
-// ListTurnsWithInput lists turns.
-func (c *AgentManagerClient) ListTurnsWithInput(ctx context.Context, input AgentManagerListTurnsInput) (*proto.AgentManagerListTurnsResponse, error) {
-	return c.ListTurns(ctx, NewAgentManagerListTurnsRequest(input))
+	req := NewAgentManagerListTurnsRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.ListTurns(ctx, req)
 }
 
 // CancelTurn cancels an in-progress agent turn.
-func (c *AgentManagerClient) CancelTurn(ctx context.Context, req *proto.AgentManagerCancelTurnRequest) (*proto.AgentTurn, error) {
+func (c *AgentManagerClient) CancelTurn(ctx context.Context, input AgentManagerCancelTurnInput) (*proto.AgentTurn, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
 	}
-	value := &proto.AgentManagerCancelTurnRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerCancelTurnRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.CancelTurn(ctx, value)
-}
-
-// CancelTurnWithInput cancels an agent turn.
-func (c *AgentManagerClient) CancelTurnWithInput(ctx context.Context, input AgentManagerCancelTurnInput) (*proto.AgentTurn, error) {
-	return c.CancelTurn(ctx, NewAgentManagerCancelTurnRequest(input))
+	req := NewAgentManagerCancelTurnRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.CancelTurn(ctx, req)
 }
 
 // ListTurnEvents lists events emitted for an agent turn.
-func (c *AgentManagerClient) ListTurnEvents(ctx context.Context, req *proto.AgentManagerListTurnEventsRequest) (*proto.AgentManagerListTurnEventsResponse, error) {
+func (c *AgentManagerClient) ListTurnEvents(ctx context.Context, input AgentManagerListTurnEventsInput) (*proto.AgentManagerListTurnEventsResponse, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
 	}
-	value := &proto.AgentManagerListTurnEventsRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerListTurnEventsRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.ListTurnEvents(ctx, value)
-}
-
-// ListTurnEventsWithInput lists turn events.
-func (c *AgentManagerClient) ListTurnEventsWithInput(ctx context.Context, input AgentManagerListTurnEventsInput) (*proto.AgentManagerListTurnEventsResponse, error) {
-	return c.ListTurnEvents(ctx, NewAgentManagerListTurnEventsRequest(input))
+	req := NewAgentManagerListTurnEventsRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.ListTurnEvents(ctx, req)
 }
 
 // ListInteractions lists pending or completed agent interactions.
-func (c *AgentManagerClient) ListInteractions(ctx context.Context, req *proto.AgentManagerListInteractionsRequest) (*proto.AgentManagerListInteractionsResponse, error) {
+func (c *AgentManagerClient) ListInteractions(ctx context.Context, input AgentManagerListInteractionsInput) (*proto.AgentManagerListInteractionsResponse, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
 	}
-	value := &proto.AgentManagerListInteractionsRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerListInteractionsRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.ListInteractions(ctx, value)
-}
-
-// ListInteractionsWithInput lists interactions.
-func (c *AgentManagerClient) ListInteractionsWithInput(ctx context.Context, input AgentManagerListInteractionsInput) (*proto.AgentManagerListInteractionsResponse, error) {
-	return c.ListInteractions(ctx, NewAgentManagerListInteractionsRequest(input))
+	req := NewAgentManagerListInteractionsRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.ListInteractions(ctx, req)
 }
 
 // ResolveInteraction resolves an agent interaction with a host response.
-func (c *AgentManagerClient) ResolveInteraction(ctx context.Context, req *proto.AgentManagerResolveInteractionRequest) (*proto.AgentInteraction, error) {
+func (c *AgentManagerClient) ResolveInteraction(ctx context.Context, input AgentManagerResolveInteractionInput) (*proto.AgentInteraction, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("agent manager: client is not initialized")
 	}
-	value := &proto.AgentManagerResolveInteractionRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerResolveInteractionRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.ResolveInteraction(ctx, value)
-}
-
-// ResolveInteractionWithInput resolves an interaction.
-func (c *AgentManagerClient) ResolveInteractionWithInput(ctx context.Context, input AgentManagerResolveInteractionInput) (*proto.AgentInteraction, error) {
 	req, err := NewAgentManagerResolveInteractionRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.ResolveInteraction(ctx, req)
+	req.InvocationToken = c.invocationToken
+	return c.client.ResolveInteraction(ctx, req)
 }

--- a/sdk/go/agent_manager_transport_test.go
+++ b/sdk/go/agent_manager_transport_test.go
@@ -84,7 +84,7 @@ func TestTransport_AgentManagerTCPTargetTokenEnv(t *testing.T) {
 	}
 	defer func() { _ = client.Close() }()
 
-	session, err := client.CreateSession(context.Background(), &proto.AgentManagerCreateSessionRequest{
+	session, err := client.CreateSession(context.Background(), gestalt.AgentManagerCreateSessionInput{
 		ProviderName: "managed",
 		Model:        "gpt-test",
 		ClientRef:    "cli-session-1",
@@ -99,8 +99,8 @@ func TestTransport_AgentManagerTCPTargetTokenEnv(t *testing.T) {
 		t.Fatalf("session id = %q, want %q", session.GetId(), "session-1")
 	}
 
-	turn, err := client.CreateTurn(context.Background(), &proto.AgentManagerCreateTurnRequest{
-		SessionId: "session-1",
+	turn, err := client.CreateTurn(context.Background(), gestalt.AgentManagerCreateTurnInput{
+		SessionID: "session-1",
 		Model:     "gpt-test",
 	})
 	if err != nil {
@@ -141,7 +141,7 @@ func TestTransport_AgentManagerTCPTargetTokenEnv(t *testing.T) {
 	}
 }
 
-func TestTransport_AgentManagerCreateTurnWithInput(t *testing.T) {
+func TestTransport_AgentManagerCreateTurnNativeValues(t *testing.T) {
 	address := reserveTCPAddress()
 	lis, err := net.Listen("tcp", address)
 	if err != nil {
@@ -166,7 +166,7 @@ func TestTransport_AgentManagerCreateTurnWithInput(t *testing.T) {
 	}
 	defer func() { _ = client.Close() }()
 
-	turn, err := client.CreateTurnWithInput(context.Background(), gestalt.AgentManagerCreateTurnInput{
+	turn, err := client.CreateTurn(context.Background(), gestalt.AgentManagerCreateTurnInput{
 		SessionID: "session-1",
 		Model:     "gpt-test",
 		Messages: []gestalt.AgentMessageInput{{
@@ -188,7 +188,7 @@ func TestTransport_AgentManagerCreateTurnWithInput(t *testing.T) {
 		ModelOptions:   map[string]any{"temperature": 0},
 	})
 	if err != nil {
-		t.Fatalf("CreateTurnWithInput: %v", err)
+		t.Fatalf("CreateTurn: %v", err)
 	}
 	if turn.GetId() != "turn-1" {
 		t.Fatalf("turn id = %q, want turn-1", turn.GetId())

--- a/sdk/go/workflow_manager.go
+++ b/sdk/go/workflow_manager.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/internal/gen/v1"
-	gproto "google.golang.org/protobuf/proto"
 )
 
 // EnvWorkflowManagerSocket names the environment variable containing the
@@ -66,413 +65,243 @@ func (c *WorkflowManagerClient) Close() error {
 }
 
 // StartRun starts a workflow run.
-func (c *WorkflowManagerClient) StartRun(ctx context.Context, req *proto.WorkflowManagerStartRunRequest) (*proto.ManagedWorkflowRun, error) {
+func (c *WorkflowManagerClient) StartRun(ctx context.Context, input WorkflowManagerStartRunInput) (*proto.ManagedWorkflowRun, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerStartRunRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerStartRunRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.StartRun(ctx, value)
-}
-
-// StartRunWithInput starts a workflow run.
-func (c *WorkflowManagerClient) StartRunWithInput(ctx context.Context, input WorkflowManagerStartRunInput) (*proto.ManagedWorkflowRun, error) {
 	req, err := NewWorkflowManagerStartRunRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.StartRun(ctx, req)
+	req.InvocationToken = c.invocationToken
+	return c.client.StartRun(ctx, req)
 }
 
 // SignalRun signals an existing workflow run.
-func (c *WorkflowManagerClient) SignalRun(ctx context.Context, req *proto.WorkflowManagerSignalRunRequest) (*proto.ManagedWorkflowRunSignal, error) {
+func (c *WorkflowManagerClient) SignalRun(ctx context.Context, input WorkflowManagerSignalRunInput) (*proto.ManagedWorkflowRunSignal, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerSignalRunRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerSignalRunRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.SignalRun(ctx, value)
-}
-
-// SignalRunWithInput signals an existing workflow run.
-func (c *WorkflowManagerClient) SignalRunWithInput(ctx context.Context, input WorkflowManagerSignalRunInput) (*proto.ManagedWorkflowRunSignal, error) {
 	req, err := NewWorkflowManagerSignalRunRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.SignalRun(ctx, req)
+	req.InvocationToken = c.invocationToken
+	return c.client.SignalRun(ctx, req)
 }
 
 // SignalOrStartRun signals a run or starts it when no matching run exists.
-func (c *WorkflowManagerClient) SignalOrStartRun(ctx context.Context, req *proto.WorkflowManagerSignalOrStartRunRequest) (*proto.ManagedWorkflowRunSignal, error) {
+func (c *WorkflowManagerClient) SignalOrStartRun(ctx context.Context, input WorkflowManagerSignalOrStartRunInput) (*proto.ManagedWorkflowRunSignal, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerSignalOrStartRunRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerSignalOrStartRunRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.SignalOrStartRun(ctx, value)
-}
-
-// SignalOrStartRunWithInput signals or starts a workflow run.
-func (c *WorkflowManagerClient) SignalOrStartRunWithInput(ctx context.Context, input WorkflowManagerSignalOrStartRunInput) (*proto.ManagedWorkflowRunSignal, error) {
 	req, err := NewWorkflowManagerSignalOrStartRunRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.SignalOrStartRun(ctx, req)
+	req.InvocationToken = c.invocationToken
+	return c.client.SignalOrStartRun(ctx, req)
 }
 
 // CreateDefinition creates a reusable workflow definition.
-func (c *WorkflowManagerClient) CreateDefinition(ctx context.Context, req *proto.WorkflowManagerCreateDefinitionRequest) (*proto.ManagedWorkflowDefinition, error) {
+func (c *WorkflowManagerClient) CreateDefinition(ctx context.Context, input WorkflowManagerCreateDefinitionInput) (*proto.ManagedWorkflowDefinition, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerCreateDefinitionRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerCreateDefinitionRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	if value.IdempotencyKey == "" {
-		value.IdempotencyKey = c.idempotencyKey
-	}
-	return c.client.CreateDefinition(ctx, value)
-}
-
-// CreateDefinitionWithInput creates a reusable workflow definition.
-func (c *WorkflowManagerClient) CreateDefinitionWithInput(ctx context.Context, input WorkflowManagerCreateDefinitionInput) (*proto.ManagedWorkflowDefinition, error) {
 	req, err := NewWorkflowManagerCreateDefinitionRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.CreateDefinition(ctx, req)
+	req.InvocationToken = c.invocationToken
+	if req.IdempotencyKey == "" {
+		req.IdempotencyKey = c.idempotencyKey
+	}
+	return c.client.CreateDefinition(ctx, req)
 }
 
 // GetDefinition fetches one workflow definition.
-func (c *WorkflowManagerClient) GetDefinition(ctx context.Context, req *proto.WorkflowManagerGetDefinitionRequest) (*proto.ManagedWorkflowDefinition, error) {
+func (c *WorkflowManagerClient) GetDefinition(ctx context.Context, input WorkflowManagerGetDefinitionInput) (*proto.ManagedWorkflowDefinition, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerGetDefinitionRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerGetDefinitionRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.GetDefinition(ctx, value)
-}
-
-// GetDefinitionWithInput fetches one workflow definition.
-func (c *WorkflowManagerClient) GetDefinitionWithInput(ctx context.Context, input WorkflowManagerGetDefinitionInput) (*proto.ManagedWorkflowDefinition, error) {
-	return c.GetDefinition(ctx, NewWorkflowManagerGetDefinitionRequest(input))
+	req := NewWorkflowManagerGetDefinitionRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.GetDefinition(ctx, req)
 }
 
 // UpdateDefinition updates a workflow definition.
-func (c *WorkflowManagerClient) UpdateDefinition(ctx context.Context, req *proto.WorkflowManagerUpdateDefinitionRequest) (*proto.ManagedWorkflowDefinition, error) {
+func (c *WorkflowManagerClient) UpdateDefinition(ctx context.Context, input WorkflowManagerUpdateDefinitionInput) (*proto.ManagedWorkflowDefinition, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerUpdateDefinitionRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerUpdateDefinitionRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.UpdateDefinition(ctx, value)
-}
-
-// UpdateDefinitionWithInput updates a workflow definition.
-func (c *WorkflowManagerClient) UpdateDefinitionWithInput(ctx context.Context, input WorkflowManagerUpdateDefinitionInput) (*proto.ManagedWorkflowDefinition, error) {
 	req, err := NewWorkflowManagerUpdateDefinitionRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.UpdateDefinition(ctx, req)
+	req.InvocationToken = c.invocationToken
+	return c.client.UpdateDefinition(ctx, req)
 }
 
 // DeleteDefinition deletes a workflow definition.
-func (c *WorkflowManagerClient) DeleteDefinition(ctx context.Context, req *proto.WorkflowManagerDeleteDefinitionRequest) error {
+func (c *WorkflowManagerClient) DeleteDefinition(ctx context.Context, input WorkflowManagerDeleteDefinitionInput) error {
 	if c == nil || c.client == nil {
 		return fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerDeleteDefinitionRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerDeleteDefinitionRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	_, err := c.client.DeleteDefinition(ctx, value)
+	req := NewWorkflowManagerDeleteDefinitionRequest(input)
+	req.InvocationToken = c.invocationToken
+	_, err := c.client.DeleteDefinition(ctx, req)
 	return err
 }
 
-// DeleteDefinitionWithInput deletes a workflow definition.
-func (c *WorkflowManagerClient) DeleteDefinitionWithInput(ctx context.Context, input WorkflowManagerDeleteDefinitionInput) error {
-	return c.DeleteDefinition(ctx, NewWorkflowManagerDeleteDefinitionRequest(input))
-}
-
 // CreateSchedule creates a workflow schedule.
-func (c *WorkflowManagerClient) CreateSchedule(ctx context.Context, req *proto.WorkflowManagerCreateScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+func (c *WorkflowManagerClient) CreateSchedule(ctx context.Context, input WorkflowManagerCreateScheduleInput) (*proto.ManagedWorkflowSchedule, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerCreateScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerCreateScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	if value.IdempotencyKey == "" {
-		value.IdempotencyKey = c.idempotencyKey
-	}
-	return c.client.CreateSchedule(ctx, value)
-}
-
-// CreateScheduleWithInput creates a workflow schedule.
-func (c *WorkflowManagerClient) CreateScheduleWithInput(ctx context.Context, input WorkflowManagerCreateScheduleInput) (*proto.ManagedWorkflowSchedule, error) {
 	req, err := NewWorkflowManagerCreateScheduleRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.CreateSchedule(ctx, req)
+	req.InvocationToken = c.invocationToken
+	if req.IdempotencyKey == "" {
+		req.IdempotencyKey = c.idempotencyKey
+	}
+	return c.client.CreateSchedule(ctx, req)
 }
 
 // GetSchedule fetches one workflow schedule.
-func (c *WorkflowManagerClient) GetSchedule(ctx context.Context, req *proto.WorkflowManagerGetScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+func (c *WorkflowManagerClient) GetSchedule(ctx context.Context, input WorkflowManagerGetScheduleInput) (*proto.ManagedWorkflowSchedule, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerGetScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerGetScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.GetSchedule(ctx, value)
-}
-
-// GetScheduleWithInput fetches one workflow schedule.
-func (c *WorkflowManagerClient) GetScheduleWithInput(ctx context.Context, input WorkflowManagerGetScheduleInput) (*proto.ManagedWorkflowSchedule, error) {
-	return c.GetSchedule(ctx, NewWorkflowManagerGetScheduleRequest(input))
+	req := NewWorkflowManagerGetScheduleRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.GetSchedule(ctx, req)
 }
 
 // UpdateSchedule updates a workflow schedule.
-func (c *WorkflowManagerClient) UpdateSchedule(ctx context.Context, req *proto.WorkflowManagerUpdateScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+func (c *WorkflowManagerClient) UpdateSchedule(ctx context.Context, input WorkflowManagerUpdateScheduleInput) (*proto.ManagedWorkflowSchedule, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerUpdateScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerUpdateScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.UpdateSchedule(ctx, value)
-}
-
-// UpdateScheduleWithInput updates a workflow schedule.
-func (c *WorkflowManagerClient) UpdateScheduleWithInput(ctx context.Context, input WorkflowManagerUpdateScheduleInput) (*proto.ManagedWorkflowSchedule, error) {
 	req, err := NewWorkflowManagerUpdateScheduleRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.UpdateSchedule(ctx, req)
+	req.InvocationToken = c.invocationToken
+	return c.client.UpdateSchedule(ctx, req)
 }
 
 // DeleteSchedule deletes a workflow schedule.
-func (c *WorkflowManagerClient) DeleteSchedule(ctx context.Context, req *proto.WorkflowManagerDeleteScheduleRequest) error {
+func (c *WorkflowManagerClient) DeleteSchedule(ctx context.Context, input WorkflowManagerDeleteScheduleInput) error {
 	if c == nil || c.client == nil {
 		return fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerDeleteScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerDeleteScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	_, err := c.client.DeleteSchedule(ctx, value)
+	req := NewWorkflowManagerDeleteScheduleRequest(input)
+	req.InvocationToken = c.invocationToken
+	_, err := c.client.DeleteSchedule(ctx, req)
 	return err
 }
 
-// DeleteScheduleWithInput deletes a workflow schedule.
-func (c *WorkflowManagerClient) DeleteScheduleWithInput(ctx context.Context, input WorkflowManagerDeleteScheduleInput) error {
-	return c.DeleteSchedule(ctx, NewWorkflowManagerDeleteScheduleRequest(input))
-}
-
 // PauseSchedule pauses a workflow schedule.
-func (c *WorkflowManagerClient) PauseSchedule(ctx context.Context, req *proto.WorkflowManagerPauseScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+func (c *WorkflowManagerClient) PauseSchedule(ctx context.Context, input WorkflowManagerPauseScheduleInput) (*proto.ManagedWorkflowSchedule, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerPauseScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerPauseScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.PauseSchedule(ctx, value)
-}
-
-// PauseScheduleWithInput pauses a workflow schedule.
-func (c *WorkflowManagerClient) PauseScheduleWithInput(ctx context.Context, input WorkflowManagerPauseScheduleInput) (*proto.ManagedWorkflowSchedule, error) {
-	return c.PauseSchedule(ctx, NewWorkflowManagerPauseScheduleRequest(input))
+	req := NewWorkflowManagerPauseScheduleRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.PauseSchedule(ctx, req)
 }
 
 // ResumeSchedule resumes a workflow schedule.
-func (c *WorkflowManagerClient) ResumeSchedule(ctx context.Context, req *proto.WorkflowManagerResumeScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+func (c *WorkflowManagerClient) ResumeSchedule(ctx context.Context, input WorkflowManagerResumeScheduleInput) (*proto.ManagedWorkflowSchedule, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerResumeScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerResumeScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.ResumeSchedule(ctx, value)
-}
-
-// ResumeScheduleWithInput resumes a workflow schedule.
-func (c *WorkflowManagerClient) ResumeScheduleWithInput(ctx context.Context, input WorkflowManagerResumeScheduleInput) (*proto.ManagedWorkflowSchedule, error) {
-	return c.ResumeSchedule(ctx, NewWorkflowManagerResumeScheduleRequest(input))
+	req := NewWorkflowManagerResumeScheduleRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.ResumeSchedule(ctx, req)
 }
 
 // CreateTrigger creates an event trigger.
-func (c *WorkflowManagerClient) CreateTrigger(ctx context.Context, req *proto.WorkflowManagerCreateEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
+func (c *WorkflowManagerClient) CreateTrigger(ctx context.Context, input WorkflowManagerCreateEventTriggerInput) (*proto.ManagedWorkflowEventTrigger, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerCreateEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerCreateEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	if value.IdempotencyKey == "" {
-		value.IdempotencyKey = c.idempotencyKey
-	}
-	return c.client.CreateEventTrigger(ctx, value)
-}
-
-// CreateTriggerWithInput creates an event trigger.
-func (c *WorkflowManagerClient) CreateTriggerWithInput(ctx context.Context, input WorkflowManagerCreateEventTriggerInput) (*proto.ManagedWorkflowEventTrigger, error) {
 	req, err := NewWorkflowManagerCreateEventTriggerRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.CreateTrigger(ctx, req)
+	req.InvocationToken = c.invocationToken
+	if req.IdempotencyKey == "" {
+		req.IdempotencyKey = c.idempotencyKey
+	}
+	return c.client.CreateEventTrigger(ctx, req)
 }
 
 // GetTrigger fetches one event trigger.
-func (c *WorkflowManagerClient) GetTrigger(ctx context.Context, req *proto.WorkflowManagerGetEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
+func (c *WorkflowManagerClient) GetTrigger(ctx context.Context, input WorkflowManagerGetEventTriggerInput) (*proto.ManagedWorkflowEventTrigger, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerGetEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerGetEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.GetEventTrigger(ctx, value)
-}
-
-// GetTriggerWithInput fetches one event trigger.
-func (c *WorkflowManagerClient) GetTriggerWithInput(ctx context.Context, input WorkflowManagerGetEventTriggerInput) (*proto.ManagedWorkflowEventTrigger, error) {
-	return c.GetTrigger(ctx, NewWorkflowManagerGetEventTriggerRequest(input))
+	req := NewWorkflowManagerGetEventTriggerRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.GetEventTrigger(ctx, req)
 }
 
 // UpdateTrigger updates an event trigger.
-func (c *WorkflowManagerClient) UpdateTrigger(ctx context.Context, req *proto.WorkflowManagerUpdateEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
+func (c *WorkflowManagerClient) UpdateTrigger(ctx context.Context, input WorkflowManagerUpdateEventTriggerInput) (*proto.ManagedWorkflowEventTrigger, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerUpdateEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerUpdateEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.UpdateEventTrigger(ctx, value)
-}
-
-// UpdateTriggerWithInput updates an event trigger.
-func (c *WorkflowManagerClient) UpdateTriggerWithInput(ctx context.Context, input WorkflowManagerUpdateEventTriggerInput) (*proto.ManagedWorkflowEventTrigger, error) {
 	req, err := NewWorkflowManagerUpdateEventTriggerRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.UpdateTrigger(ctx, req)
+	req.InvocationToken = c.invocationToken
+	return c.client.UpdateEventTrigger(ctx, req)
 }
 
 // DeleteTrigger deletes an event trigger.
-func (c *WorkflowManagerClient) DeleteTrigger(ctx context.Context, req *proto.WorkflowManagerDeleteEventTriggerRequest) error {
+func (c *WorkflowManagerClient) DeleteTrigger(ctx context.Context, input WorkflowManagerDeleteEventTriggerInput) error {
 	if c == nil || c.client == nil {
 		return fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerDeleteEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerDeleteEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	_, err := c.client.DeleteEventTrigger(ctx, value)
+	req := NewWorkflowManagerDeleteEventTriggerRequest(input)
+	req.InvocationToken = c.invocationToken
+	_, err := c.client.DeleteEventTrigger(ctx, req)
 	return err
 }
 
-// DeleteTriggerWithInput deletes an event trigger.
-func (c *WorkflowManagerClient) DeleteTriggerWithInput(ctx context.Context, input WorkflowManagerDeleteEventTriggerInput) error {
-	return c.DeleteTrigger(ctx, NewWorkflowManagerDeleteEventTriggerRequest(input))
-}
-
 // PauseTrigger pauses an event trigger.
-func (c *WorkflowManagerClient) PauseTrigger(ctx context.Context, req *proto.WorkflowManagerPauseEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
+func (c *WorkflowManagerClient) PauseTrigger(ctx context.Context, input WorkflowManagerPauseEventTriggerInput) (*proto.ManagedWorkflowEventTrigger, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerPauseEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerPauseEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.PauseEventTrigger(ctx, value)
-}
-
-// PauseTriggerWithInput pauses an event trigger.
-func (c *WorkflowManagerClient) PauseTriggerWithInput(ctx context.Context, input WorkflowManagerPauseEventTriggerInput) (*proto.ManagedWorkflowEventTrigger, error) {
-	return c.PauseTrigger(ctx, NewWorkflowManagerPauseEventTriggerRequest(input))
+	req := NewWorkflowManagerPauseEventTriggerRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.PauseEventTrigger(ctx, req)
 }
 
 // ResumeTrigger resumes an event trigger.
-func (c *WorkflowManagerClient) ResumeTrigger(ctx context.Context, req *proto.WorkflowManagerResumeEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
+func (c *WorkflowManagerClient) ResumeTrigger(ctx context.Context, input WorkflowManagerResumeEventTriggerInput) (*proto.ManagedWorkflowEventTrigger, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerResumeEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerResumeEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.ResumeEventTrigger(ctx, value)
-}
-
-// ResumeTriggerWithInput resumes an event trigger.
-func (c *WorkflowManagerClient) ResumeTriggerWithInput(ctx context.Context, input WorkflowManagerResumeEventTriggerInput) (*proto.ManagedWorkflowEventTrigger, error) {
-	return c.ResumeTrigger(ctx, NewWorkflowManagerResumeEventTriggerRequest(input))
+	req := NewWorkflowManagerResumeEventTriggerRequest(input)
+	req.InvocationToken = c.invocationToken
+	return c.client.ResumeEventTrigger(ctx, req)
 }
 
 // PublishEvent publishes an event into the workflow manager.
-func (c *WorkflowManagerClient) PublishEvent(ctx context.Context, req *proto.WorkflowManagerPublishEventRequest) (*proto.WorkflowEvent, error) {
+func (c *WorkflowManagerClient) PublishEvent(ctx context.Context, input WorkflowManagerPublishEventInput) (*proto.WorkflowEvent, error) {
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	value := &proto.WorkflowManagerPublishEventRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerPublishEventRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.PublishEvent(ctx, value)
-}
-
-// PublishEventWithInput publishes an event.
-func (c *WorkflowManagerClient) PublishEventWithInput(ctx context.Context, input WorkflowManagerPublishEventInput) (*proto.WorkflowEvent, error) {
 	req, err := NewWorkflowManagerPublishEventRequest(input)
 	if err != nil {
 		return nil, err
 	}
-	return c.PublishEvent(ctx, req)
+	req.InvocationToken = c.invocationToken
+	return c.client.PublishEvent(ctx, req)
 }

--- a/sdk/go/workflow_manager_transport_test.go
+++ b/sdk/go/workflow_manager_transport_test.go
@@ -90,7 +90,7 @@ func TestTransport_WorkflowManagerTCPTargetTokenEnv(t *testing.T) {
 	}
 	defer func() { _ = client.Close() }()
 
-	created, err := client.CreateSchedule(context.Background(), &proto.WorkflowManagerCreateScheduleRequest{
+	created, err := client.CreateSchedule(context.Background(), gestalt.WorkflowManagerCreateScheduleInput{
 		ProviderName:   "managed",
 		Cron:           "*/5 * * * *",
 		IdempotencyKey: "workflow-schedule-key-go",
@@ -149,34 +149,25 @@ func TestTransport_WorkflowManagerSignalOrStartRunInjectsInvocationToken(t *test
 	}
 	defer func() { _ = client.Close() }()
 
-	signalPayload, err := gestalt.StructFromAny(map[string]any{"ok": true})
-	if err != nil {
-		t.Fatalf("StructFromAny: %v", err)
-	}
 	signalExtensions, err := gestalt.ValuesFromMap(map[string]any{"attempt": 1})
 	if err != nil {
 		t.Fatalf("ValuesFromMap: %v", err)
 	}
 	createdAtValue := time.Date(1969, 12, 31, 23, 59, 59, 999_000_000, time.UTC)
-	createdAt := timestamppb.New(createdAtValue)
-	resp, err := client.SignalOrStartRun(context.Background(), &proto.WorkflowManagerSignalOrStartRunRequest{
+	resp, err := client.SignalOrStartRun(context.Background(), gestalt.WorkflowManagerSignalOrStartRunInput{
 		ProviderName: "local",
 		WorkflowKey:  "slack:T123:C123:1700000000.000001",
-		Target: &proto.BoundWorkflowTarget{
-			Kind: &proto.BoundWorkflowTarget_Agent{
-				Agent: &proto.BoundWorkflowAgentTarget{
-					ProviderName: "simple",
-					Model:        "gpt-5.5",
-					Prompt:       "Respond in thread.",
-				},
-			},
-		},
+		Target: &gestalt.BoundWorkflowTargetInput{Agent: &gestalt.BoundWorkflowAgentTargetInput{
+			ProviderName: "simple",
+			Model:        "gpt-5.5",
+			Prompt:       "Respond in thread.",
+		}},
 		IdempotencyKey: "slack-event-123",
-		Signal: &proto.WorkflowSignal{
+		Signal: &gestalt.WorkflowSignalInput{
 			Name:           "slack.message",
 			IdempotencyKey: "slack-event-123",
-			Payload:        signalPayload,
-			CreatedAt:      createdAt,
+			Payload:        map[string]any{"ok": true},
+			CreatedAt:      createdAtValue,
 		},
 	})
 	if err != nil {
@@ -238,7 +229,7 @@ func TestTransport_WorkflowManagerSignalOrStartRunInjectsInvocationToken(t *test
 	}
 }
 
-func TestTransport_WorkflowManagerSignalOrStartRunWithInput(t *testing.T) {
+func TestTransport_WorkflowManagerSignalOrStartRunNativeValues(t *testing.T) {
 	address := reserveTCPAddress()
 	lis, err := net.Listen("tcp", address)
 	if err != nil {
@@ -264,7 +255,7 @@ func TestTransport_WorkflowManagerSignalOrStartRunWithInput(t *testing.T) {
 	defer func() { _ = client.Close() }()
 
 	createdAt := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
-	resp, err := client.SignalOrStartRunWithInput(context.Background(), gestalt.WorkflowManagerSignalOrStartRunInput{
+	resp, err := client.SignalOrStartRun(context.Background(), gestalt.WorkflowManagerSignalOrStartRunInput{
 		ProviderName: "local",
 		WorkflowKey:  "slack:T123:C123:1700000000.000001",
 		Target: &gestalt.BoundWorkflowTargetInput{Agent: &gestalt.BoundWorkflowAgentTargetInput{
@@ -284,7 +275,7 @@ func TestTransport_WorkflowManagerSignalOrStartRunWithInput(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("SignalOrStartRunWithInput: %v", err)
+		t.Fatalf("SignalOrStartRun: %v", err)
 	}
 	if resp.GetProviderName() != "local" || resp.GetRun().GetId() != "run-1" || !resp.GetStartedRun() {
 		t.Fatalf("response = %#v", resp)

--- a/sdk/rust/src/agent_manager.rs
+++ b/sdk/rust/src/agent_manager.rs
@@ -378,199 +378,111 @@ impl AgentManager {
     /// Creates an agent session.
     pub async fn create_session(
         &mut self,
-        mut request: pb::AgentManagerCreateSessionRequest,
-    ) -> std::result::Result<pb::AgentSession, AgentManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.create_session(request).await?.into_inner())
-    }
-
-    /// Creates an agent session.
-    pub async fn create_session_input(
-        &mut self,
         input: AgentManagerCreateSessionInput,
     ) -> std::result::Result<pb::AgentSession, AgentManagerError> {
-        self.create_session(new_agent_manager_create_session_request(input)?)
-            .await
+        let mut request = new_agent_manager_create_session_request(input)?;
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.create_session(request).await?.into_inner())
     }
 
     /// Fetches one agent session.
     pub async fn get_session(
         &mut self,
-        mut request: pb::AgentManagerGetSessionRequest,
-    ) -> std::result::Result<pb::AgentSession, AgentManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.get_session(request).await?.into_inner())
-    }
-
-    /// Fetches one agent session.
-    pub async fn get_session_input(
-        &mut self,
         input: AgentManagerGetSessionInput,
     ) -> std::result::Result<pb::AgentSession, AgentManagerError> {
-        self.get_session(new_agent_manager_get_session_request(input))
-            .await
+        let mut request = new_agent_manager_get_session_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.get_session(request).await?.into_inner())
     }
 
     /// Lists agent sessions visible to the invocation token.
     pub async fn list_sessions(
         &mut self,
-        mut request: pb::AgentManagerListSessionsRequest,
-    ) -> std::result::Result<pb::AgentManagerListSessionsResponse, AgentManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.list_sessions(request).await?.into_inner())
-    }
-
-    /// Lists agent sessions.
-    pub async fn list_sessions_input(
-        &mut self,
         input: AgentManagerListSessionsInput,
     ) -> std::result::Result<pb::AgentManagerListSessionsResponse, AgentManagerError> {
-        self.list_sessions(new_agent_manager_list_sessions_request(input))
-            .await
+        let mut request = new_agent_manager_list_sessions_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.list_sessions(request).await?.into_inner())
     }
 
     /// Updates mutable fields on an agent session.
     pub async fn update_session(
         &mut self,
-        mut request: pb::AgentManagerUpdateSessionRequest,
-    ) -> std::result::Result<pb::AgentSession, AgentManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.update_session(request).await?.into_inner())
-    }
-
-    /// Updates mutable fields on an agent session.
-    pub async fn update_session_input(
-        &mut self,
         input: AgentManagerUpdateSessionInput,
     ) -> std::result::Result<pb::AgentSession, AgentManagerError> {
-        self.update_session(new_agent_manager_update_session_request(input)?)
-            .await
+        let mut request = new_agent_manager_update_session_request(input)?;
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.update_session(request).await?.into_inner())
     }
 
     /// Creates an agent turn.
     pub async fn create_turn(
         &mut self,
-        mut request: pb::AgentManagerCreateTurnRequest,
-    ) -> std::result::Result<pb::AgentTurn, AgentManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.create_turn(request).await?.into_inner())
-    }
-
-    /// Creates an agent turn.
-    pub async fn create_turn_input(
-        &mut self,
         input: AgentManagerCreateTurnInput,
     ) -> std::result::Result<pb::AgentTurn, AgentManagerError> {
-        self.create_turn(new_agent_manager_create_turn_request(input)?)
-            .await
+        let mut request = new_agent_manager_create_turn_request(input)?;
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.create_turn(request).await?.into_inner())
     }
 
     /// Fetches one agent turn.
     pub async fn get_turn(
         &mut self,
-        mut request: pb::AgentManagerGetTurnRequest,
-    ) -> std::result::Result<pb::AgentTurn, AgentManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.get_turn(request).await?.into_inner())
-    }
-
-    /// Fetches one agent turn.
-    pub async fn get_turn_input(
-        &mut self,
         input: AgentManagerGetTurnInput,
     ) -> std::result::Result<pb::AgentTurn, AgentManagerError> {
-        self.get_turn(new_agent_manager_get_turn_request(input))
-            .await
+        let mut request = new_agent_manager_get_turn_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.get_turn(request).await?.into_inner())
     }
 
     /// Lists turns for an agent session.
     pub async fn list_turns(
         &mut self,
-        mut request: pb::AgentManagerListTurnsRequest,
-    ) -> std::result::Result<pb::AgentManagerListTurnsResponse, AgentManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.list_turns(request).await?.into_inner())
-    }
-
-    /// Lists turns for an agent session.
-    pub async fn list_turns_input(
-        &mut self,
         input: AgentManagerListTurnsInput,
     ) -> std::result::Result<pb::AgentManagerListTurnsResponse, AgentManagerError> {
-        self.list_turns(new_agent_manager_list_turns_request(input))
-            .await
+        let mut request = new_agent_manager_list_turns_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.list_turns(request).await?.into_inner())
     }
 
     /// Cancels an in-progress agent turn.
     pub async fn cancel_turn(
         &mut self,
-        mut request: pb::AgentManagerCancelTurnRequest,
-    ) -> std::result::Result<pb::AgentTurn, AgentManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.cancel_turn(request).await?.into_inner())
-    }
-
-    /// Cancels an in-progress agent turn.
-    pub async fn cancel_turn_input(
-        &mut self,
         input: AgentManagerCancelTurnInput,
     ) -> std::result::Result<pb::AgentTurn, AgentManagerError> {
-        self.cancel_turn(new_agent_manager_cancel_turn_request(input))
-            .await
+        let mut request = new_agent_manager_cancel_turn_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.cancel_turn(request).await?.into_inner())
     }
 
     /// Lists events emitted for an agent turn.
     pub async fn list_turn_events(
         &mut self,
-        mut request: pb::AgentManagerListTurnEventsRequest,
-    ) -> std::result::Result<pb::AgentManagerListTurnEventsResponse, AgentManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.list_turn_events(request).await?.into_inner())
-    }
-
-    /// Lists events emitted for an agent turn.
-    pub async fn list_turn_events_input(
-        &mut self,
         input: AgentManagerListTurnEventsInput,
     ) -> std::result::Result<pb::AgentManagerListTurnEventsResponse, AgentManagerError> {
-        self.list_turn_events(new_agent_manager_list_turn_events_request(input))
-            .await
+        let mut request = new_agent_manager_list_turn_events_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.list_turn_events(request).await?.into_inner())
     }
 
     /// Lists pending or completed agent interactions.
     pub async fn list_interactions(
         &mut self,
-        mut request: pb::AgentManagerListInteractionsRequest,
-    ) -> std::result::Result<pb::AgentManagerListInteractionsResponse, AgentManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.list_interactions(request).await?.into_inner())
-    }
-
-    /// Lists interactions.
-    pub async fn list_interactions_input(
-        &mut self,
         input: AgentManagerListInteractionsInput,
     ) -> std::result::Result<pb::AgentManagerListInteractionsResponse, AgentManagerError> {
-        self.list_interactions(new_agent_manager_list_interactions_request(input))
-            .await
+        let mut request = new_agent_manager_list_interactions_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.list_interactions(request).await?.into_inner())
     }
 
     /// Resolves an agent interaction with a host response.
     pub async fn resolve_interaction(
         &mut self,
-        mut request: pb::AgentManagerResolveInteractionRequest,
-    ) -> std::result::Result<pb::AgentInteraction, AgentManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.resolve_interaction(request).await?.into_inner())
-    }
-
-    /// Resolves an agent interaction.
-    pub async fn resolve_interaction_input(
-        &mut self,
         input: AgentManagerResolveInteractionInput,
     ) -> std::result::Result<pb::AgentInteraction, AgentManagerError> {
-        self.resolve_interaction(new_agent_manager_resolve_interaction_request(input)?)
-            .await
+        let mut request = new_agent_manager_resolve_interaction_request(input)?;
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.resolve_interaction(request).await?.into_inner())
     }
 }
 

--- a/sdk/rust/src/workflow_manager.rs
+++ b/sdk/rust/src/workflow_manager.rs
@@ -462,8 +462,9 @@ impl WorkflowManager {
     /// Creates a reusable workflow definition.
     pub async fn create_definition(
         &mut self,
-        mut request: pb::WorkflowManagerCreateDefinitionRequest,
+        input: WorkflowManagerCreateDefinitionInput,
     ) -> std::result::Result<pb::ManagedWorkflowDefinition, WorkflowManagerError> {
+        let mut request = new_workflow_manager_create_definition_request(input)?;
         request.invocation_token = self.invocation_token.clone();
         if request.idempotency_key.trim().is_empty() {
             request.idempotency_key = self.idempotency_key.clone();
@@ -471,75 +472,43 @@ impl WorkflowManager {
         Ok(self.client.create_definition(request).await?.into_inner())
     }
 
-    /// Creates a reusable workflow definition.
-    pub async fn create_definition_input(
-        &mut self,
-        input: WorkflowManagerCreateDefinitionInput,
-    ) -> std::result::Result<pb::ManagedWorkflowDefinition, WorkflowManagerError> {
-        self.create_definition(new_workflow_manager_create_definition_request(input)?)
-            .await
-    }
-
     /// Fetches one workflow definition.
     pub async fn get_definition(
         &mut self,
-        mut request: pb::WorkflowManagerGetDefinitionRequest,
-    ) -> std::result::Result<pb::ManagedWorkflowDefinition, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.get_definition(request).await?.into_inner())
-    }
-
-    /// Fetches one workflow definition.
-    pub async fn get_definition_input(
-        &mut self,
         input: WorkflowManagerGetDefinitionInput,
     ) -> std::result::Result<pb::ManagedWorkflowDefinition, WorkflowManagerError> {
-        self.get_definition(new_workflow_manager_get_definition_request(input))
-            .await
+        let mut request = new_workflow_manager_get_definition_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.get_definition(request).await?.into_inner())
     }
 
     /// Updates a workflow definition.
     pub async fn update_definition(
         &mut self,
-        mut request: pb::WorkflowManagerUpdateDefinitionRequest,
-    ) -> std::result::Result<pb::ManagedWorkflowDefinition, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.update_definition(request).await?.into_inner())
-    }
-
-    /// Updates a workflow definition.
-    pub async fn update_definition_input(
-        &mut self,
         input: WorkflowManagerUpdateDefinitionInput,
     ) -> std::result::Result<pb::ManagedWorkflowDefinition, WorkflowManagerError> {
-        self.update_definition(new_workflow_manager_update_definition_request(input)?)
-            .await
+        let mut request = new_workflow_manager_update_definition_request(input)?;
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.update_definition(request).await?.into_inner())
     }
 
     /// Deletes a workflow definition.
     pub async fn delete_definition(
         &mut self,
-        mut request: pb::WorkflowManagerDeleteDefinitionRequest,
+        input: WorkflowManagerDeleteDefinitionInput,
     ) -> std::result::Result<(), WorkflowManagerError> {
+        let mut request = new_workflow_manager_delete_definition_request(input);
         request.invocation_token = self.invocation_token.clone();
         self.client.delete_definition(request).await?;
         Ok(())
     }
 
-    /// Deletes a workflow definition.
-    pub async fn delete_definition_input(
-        &mut self,
-        input: WorkflowManagerDeleteDefinitionInput,
-    ) -> std::result::Result<(), WorkflowManagerError> {
-        self.delete_definition(new_workflow_manager_delete_definition_request(input))
-            .await
-    }
-
     /// Creates a workflow schedule.
     pub async fn create_schedule(
         &mut self,
-        mut request: pb::WorkflowManagerCreateScheduleRequest,
+        input: WorkflowManagerCreateScheduleInput,
     ) -> std::result::Result<pb::ManagedWorkflowSchedule, WorkflowManagerError> {
+        let mut request = new_workflow_manager_create_schedule_request(input)?;
         request.invocation_token = self.invocation_token.clone();
         if request.idempotency_key.trim().is_empty() {
             request.idempotency_key = self.idempotency_key.clone();
@@ -547,165 +516,93 @@ impl WorkflowManager {
         Ok(self.client.create_schedule(request).await?.into_inner())
     }
 
-    /// Creates a workflow schedule.
-    pub async fn create_schedule_input(
-        &mut self,
-        input: WorkflowManagerCreateScheduleInput,
-    ) -> std::result::Result<pb::ManagedWorkflowSchedule, WorkflowManagerError> {
-        self.create_schedule(new_workflow_manager_create_schedule_request(input)?)
-            .await
-    }
-
     /// Starts a workflow run.
     pub async fn start_run(
         &mut self,
-        mut request: pb::WorkflowManagerStartRunRequest,
-    ) -> std::result::Result<pb::ManagedWorkflowRun, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.start_run(request).await?.into_inner())
-    }
-
-    /// Starts a workflow run.
-    pub async fn start_run_input(
-        &mut self,
         input: WorkflowManagerStartRunInput,
     ) -> std::result::Result<pb::ManagedWorkflowRun, WorkflowManagerError> {
-        self.start_run(new_workflow_manager_start_run_request(input)?)
-            .await
+        let mut request = new_workflow_manager_start_run_request(input)?;
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.start_run(request).await?.into_inner())
     }
 
     /// Signals an existing workflow run.
     pub async fn signal_run(
         &mut self,
-        mut request: pb::WorkflowManagerSignalRunRequest,
-    ) -> std::result::Result<pb::ManagedWorkflowRunSignal, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.signal_run(request).await?.into_inner())
-    }
-
-    /// Signals an existing workflow run.
-    pub async fn signal_run_input(
-        &mut self,
         input: WorkflowManagerSignalRunInput,
     ) -> std::result::Result<pb::ManagedWorkflowRunSignal, WorkflowManagerError> {
-        self.signal_run(new_workflow_manager_signal_run_request(input)?)
-            .await
+        let mut request = new_workflow_manager_signal_run_request(input)?;
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.signal_run(request).await?.into_inner())
     }
 
     /// Signals a run or starts it when no matching run exists.
     pub async fn signal_or_start_run(
         &mut self,
-        mut request: pb::WorkflowManagerSignalOrStartRunRequest,
-    ) -> std::result::Result<pb::ManagedWorkflowRunSignal, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.signal_or_start_run(request).await?.into_inner())
-    }
-
-    /// Signals or starts a workflow run.
-    pub async fn signal_or_start_run_input(
-        &mut self,
         input: WorkflowManagerSignalOrStartRunInput,
     ) -> std::result::Result<pb::ManagedWorkflowRunSignal, WorkflowManagerError> {
-        self.signal_or_start_run(new_workflow_manager_signal_or_start_run_request(input)?)
-            .await
+        let mut request = new_workflow_manager_signal_or_start_run_request(input)?;
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.signal_or_start_run(request).await?.into_inner())
     }
 
     /// Fetches one workflow schedule.
     pub async fn get_schedule(
         &mut self,
-        mut request: pb::WorkflowManagerGetScheduleRequest,
-    ) -> std::result::Result<pb::ManagedWorkflowSchedule, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.get_schedule(request).await?.into_inner())
-    }
-
-    /// Fetches one workflow schedule.
-    pub async fn get_schedule_input(
-        &mut self,
         input: WorkflowManagerGetScheduleInput,
     ) -> std::result::Result<pb::ManagedWorkflowSchedule, WorkflowManagerError> {
-        self.get_schedule(new_workflow_manager_get_schedule_request(input))
-            .await
+        let mut request = new_workflow_manager_get_schedule_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.get_schedule(request).await?.into_inner())
     }
 
     /// Updates a workflow schedule.
     pub async fn update_schedule(
         &mut self,
-        mut request: pb::WorkflowManagerUpdateScheduleRequest,
-    ) -> std::result::Result<pb::ManagedWorkflowSchedule, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.update_schedule(request).await?.into_inner())
-    }
-
-    /// Updates a workflow schedule.
-    pub async fn update_schedule_input(
-        &mut self,
         input: WorkflowManagerUpdateScheduleInput,
     ) -> std::result::Result<pb::ManagedWorkflowSchedule, WorkflowManagerError> {
-        self.update_schedule(new_workflow_manager_update_schedule_request(input)?)
-            .await
+        let mut request = new_workflow_manager_update_schedule_request(input)?;
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.update_schedule(request).await?.into_inner())
     }
 
     /// Deletes a workflow schedule.
     pub async fn delete_schedule(
         &mut self,
-        mut request: pb::WorkflowManagerDeleteScheduleRequest,
+        input: WorkflowManagerDeleteScheduleInput,
     ) -> std::result::Result<(), WorkflowManagerError> {
+        let mut request = new_workflow_manager_delete_schedule_request(input);
         request.invocation_token = self.invocation_token.clone();
         self.client.delete_schedule(request).await?;
         Ok(())
     }
 
-    /// Deletes a workflow schedule.
-    pub async fn delete_schedule_input(
-        &mut self,
-        input: WorkflowManagerDeleteScheduleInput,
-    ) -> std::result::Result<(), WorkflowManagerError> {
-        self.delete_schedule(new_workflow_manager_delete_schedule_request(input))
-            .await
-    }
-
     /// Pauses a workflow schedule.
     pub async fn pause_schedule(
         &mut self,
-        mut request: pb::WorkflowManagerPauseScheduleRequest,
-    ) -> std::result::Result<pb::ManagedWorkflowSchedule, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.pause_schedule(request).await?.into_inner())
-    }
-
-    /// Pauses a workflow schedule.
-    pub async fn pause_schedule_input(
-        &mut self,
         input: WorkflowManagerPauseScheduleInput,
     ) -> std::result::Result<pb::ManagedWorkflowSchedule, WorkflowManagerError> {
-        self.pause_schedule(new_workflow_manager_pause_schedule_request(input))
-            .await
+        let mut request = new_workflow_manager_pause_schedule_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.pause_schedule(request).await?.into_inner())
     }
 
     /// Resumes a workflow schedule.
     pub async fn resume_schedule(
         &mut self,
-        mut request: pb::WorkflowManagerResumeScheduleRequest,
-    ) -> std::result::Result<pb::ManagedWorkflowSchedule, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.resume_schedule(request).await?.into_inner())
-    }
-
-    /// Resumes a workflow schedule.
-    pub async fn resume_schedule_input(
-        &mut self,
         input: WorkflowManagerResumeScheduleInput,
     ) -> std::result::Result<pb::ManagedWorkflowSchedule, WorkflowManagerError> {
-        self.resume_schedule(new_workflow_manager_resume_schedule_request(input))
-            .await
+        let mut request = new_workflow_manager_resume_schedule_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.resume_schedule(request).await?.into_inner())
     }
 
     /// Creates an event trigger.
     pub async fn create_trigger(
         &mut self,
-        mut request: pb::WorkflowManagerCreateEventTriggerRequest,
+        input: WorkflowManagerCreateEventTriggerInput,
     ) -> std::result::Result<pb::ManagedWorkflowEventTrigger, WorkflowManagerError> {
+        let mut request = new_workflow_manager_create_event_trigger_request(input)?;
         request.invocation_token = self.invocation_token.clone();
         if request.idempotency_key.trim().is_empty() {
             request.idempotency_key = self.idempotency_key.clone();
@@ -717,38 +614,22 @@ impl WorkflowManager {
             .into_inner())
     }
 
-    /// Creates an event trigger.
-    pub async fn create_trigger_input(
-        &mut self,
-        input: WorkflowManagerCreateEventTriggerInput,
-    ) -> std::result::Result<pb::ManagedWorkflowEventTrigger, WorkflowManagerError> {
-        self.create_trigger(new_workflow_manager_create_event_trigger_request(input)?)
-            .await
-    }
-
     /// Fetches one event trigger.
     pub async fn get_trigger(
         &mut self,
-        mut request: pb::WorkflowManagerGetEventTriggerRequest,
-    ) -> std::result::Result<pb::ManagedWorkflowEventTrigger, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.get_event_trigger(request).await?.into_inner())
-    }
-
-    /// Fetches one event trigger.
-    pub async fn get_trigger_input(
-        &mut self,
         input: WorkflowManagerGetEventTriggerInput,
     ) -> std::result::Result<pb::ManagedWorkflowEventTrigger, WorkflowManagerError> {
-        self.get_trigger(new_workflow_manager_get_event_trigger_request(input))
-            .await
+        let mut request = new_workflow_manager_get_event_trigger_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.get_event_trigger(request).await?.into_inner())
     }
 
     /// Updates an event trigger.
     pub async fn update_trigger(
         &mut self,
-        mut request: pb::WorkflowManagerUpdateEventTriggerRequest,
+        input: WorkflowManagerUpdateEventTriggerInput,
     ) -> std::result::Result<pb::ManagedWorkflowEventTrigger, WorkflowManagerError> {
+        let mut request = new_workflow_manager_update_event_trigger_request(input)?;
         request.invocation_token = self.invocation_token.clone();
         Ok(self
             .client
@@ -757,57 +638,33 @@ impl WorkflowManager {
             .into_inner())
     }
 
-    /// Updates an event trigger.
-    pub async fn update_trigger_input(
-        &mut self,
-        input: WorkflowManagerUpdateEventTriggerInput,
-    ) -> std::result::Result<pb::ManagedWorkflowEventTrigger, WorkflowManagerError> {
-        self.update_trigger(new_workflow_manager_update_event_trigger_request(input)?)
-            .await
-    }
-
     /// Deletes an event trigger.
     pub async fn delete_trigger(
         &mut self,
-        mut request: pb::WorkflowManagerDeleteEventTriggerRequest,
+        input: WorkflowManagerDeleteEventTriggerInput,
     ) -> std::result::Result<(), WorkflowManagerError> {
+        let mut request = new_workflow_manager_delete_event_trigger_request(input);
         request.invocation_token = self.invocation_token.clone();
         self.client.delete_event_trigger(request).await?;
         Ok(())
     }
 
-    /// Deletes an event trigger.
-    pub async fn delete_trigger_input(
-        &mut self,
-        input: WorkflowManagerDeleteEventTriggerInput,
-    ) -> std::result::Result<(), WorkflowManagerError> {
-        self.delete_trigger(new_workflow_manager_delete_event_trigger_request(input))
-            .await
-    }
-
     /// Pauses an event trigger.
     pub async fn pause_trigger(
         &mut self,
-        mut request: pb::WorkflowManagerPauseEventTriggerRequest,
-    ) -> std::result::Result<pb::ManagedWorkflowEventTrigger, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.pause_event_trigger(request).await?.into_inner())
-    }
-
-    /// Pauses an event trigger.
-    pub async fn pause_trigger_input(
-        &mut self,
         input: WorkflowManagerPauseEventTriggerInput,
     ) -> std::result::Result<pb::ManagedWorkflowEventTrigger, WorkflowManagerError> {
-        self.pause_trigger(new_workflow_manager_pause_event_trigger_request(input))
-            .await
+        let mut request = new_workflow_manager_pause_event_trigger_request(input);
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.pause_event_trigger(request).await?.into_inner())
     }
 
     /// Resumes an event trigger.
     pub async fn resume_trigger(
         &mut self,
-        mut request: pb::WorkflowManagerResumeEventTriggerRequest,
+        input: WorkflowManagerResumeEventTriggerInput,
     ) -> std::result::Result<pb::ManagedWorkflowEventTrigger, WorkflowManagerError> {
+        let mut request = new_workflow_manager_resume_event_trigger_request(input);
         request.invocation_token = self.invocation_token.clone();
         Ok(self
             .client
@@ -816,31 +673,14 @@ impl WorkflowManager {
             .into_inner())
     }
 
-    /// Resumes an event trigger.
-    pub async fn resume_trigger_input(
-        &mut self,
-        input: WorkflowManagerResumeEventTriggerInput,
-    ) -> std::result::Result<pb::ManagedWorkflowEventTrigger, WorkflowManagerError> {
-        self.resume_trigger(new_workflow_manager_resume_event_trigger_request(input))
-            .await
-    }
-
     /// Publishes an event into the workflow manager.
     pub async fn publish_event(
         &mut self,
-        mut request: pb::WorkflowManagerPublishEventRequest,
-    ) -> std::result::Result<pb::WorkflowEvent, WorkflowManagerError> {
-        request.invocation_token = self.invocation_token.clone();
-        Ok(self.client.publish_event(request).await?.into_inner())
-    }
-
-    /// Publishes an event.
-    pub async fn publish_event_input(
-        &mut self,
         input: WorkflowManagerPublishEventInput,
     ) -> std::result::Result<pb::WorkflowEvent, WorkflowManagerError> {
-        self.publish_event(new_workflow_manager_publish_event_request(input)?)
-            .await
+        let mut request = new_workflow_manager_publish_event_request(input)?;
+        request.invocation_token = self.invocation_token.clone();
+        Ok(self.client.publish_event(request).await?.into_inner())
     }
 }
 

--- a/sdk/rust/tests/agent_manager_transport.rs
+++ b/sdk/rust/tests/agent_manager_transport.rs
@@ -15,12 +15,17 @@ use gestalt::proto::v1::{
     AgentManagerListSessionsResponse, AgentManagerListTurnEventsRequest,
     AgentManagerListTurnEventsResponse, AgentManagerListTurnsRequest,
     AgentManagerListTurnsResponse, AgentManagerResolveInteractionRequest,
-    AgentManagerUpdateSessionRequest, AgentMessage, AgentMessagePart, AgentMessagePartType,
-    AgentSession, AgentSessionState, AgentToolSourceMode, AgentTurn, AgentTurnEvent,
+    AgentManagerUpdateSessionRequest, AgentMessagePartType, AgentSession, AgentSessionState,
+    AgentToolSourceMode, AgentTurn, AgentTurnEvent,
 };
 use gestalt::{
-    AgentManager, AgentManagerCreateTurnInput, AgentMessageInput, AgentMessagePartInput,
-    AgentToolRefInput, ENV_AGENT_MANAGER_SOCKET, ENV_AGENT_MANAGER_SOCKET_TOKEN, Request,
+    AgentManager, AgentManagerCancelTurnInput, AgentManagerCreateSessionInput,
+    AgentManagerCreateTurnInput, AgentManagerGetSessionInput, AgentManagerGetTurnInput,
+    AgentManagerListInteractionsInput, AgentManagerListSessionsInput,
+    AgentManagerListTurnEventsInput, AgentManagerListTurnsInput,
+    AgentManagerResolveInteractionInput, AgentManagerUpdateSessionInput, AgentMessageInput,
+    AgentMessagePartInput, AgentToolRefInput, ENV_AGENT_MANAGER_SOCKET,
+    ENV_AGENT_MANAGER_SOCKET_TOKEN, Request,
 };
 use tokio::net::{TcpListener, UnixListener};
 use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
@@ -387,7 +392,7 @@ async fn agent_manager_connects_over_tcp_and_sends_relay_token() {
         .await
         .expect("connect agent manager");
     let created = manager
-        .create_session(AgentManagerCreateSessionRequest {
+        .create_session(AgentManagerCreateSessionInput {
             provider_name: "openai".to_string(),
             model: "gpt-5.1".to_string(),
             client_ref: "cli-session-1".to_string(),
@@ -431,7 +436,7 @@ async fn agent_manager_connects_over_unix_socket_and_sends_invocation_token() {
         .await
         .expect("connect agent manager");
     let created_session = manager
-        .create_session(AgentManagerCreateSessionRequest {
+        .create_session(AgentManagerCreateSessionInput {
             provider_name: "openai".to_string(),
             model: "gpt-5.1".to_string(),
             client_ref: "cli-session-1".to_string(),
@@ -440,63 +445,63 @@ async fn agent_manager_connects_over_unix_socket_and_sends_invocation_token() {
         .await
         .expect("create session");
     let fetched_session = manager
-        .get_session(AgentManagerGetSessionRequest {
+        .get_session(AgentManagerGetSessionInput {
             session_id: "session-managed-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("get session");
     let listed_sessions = manager
-        .list_sessions(AgentManagerListSessionsRequest {
+        .list_sessions(AgentManagerListSessionsInput {
             provider_name: "openai".to_string(),
             ..Default::default()
         })
         .await
         .expect("list sessions");
     let updated_session = manager
-        .update_session(AgentManagerUpdateSessionRequest {
+        .update_session(AgentManagerUpdateSessionInput {
             session_id: "session-managed-1".to_string(),
             client_ref: "cli-session-2".to_string(),
-            state: AgentSessionState::Archived as i32,
+            state: AgentSessionState::Archived,
             ..Default::default()
         })
         .await
         .expect("update session");
     let created_turn = manager
-        .create_turn(AgentManagerCreateTurnRequest {
+        .create_turn(AgentManagerCreateTurnInput {
             session_id: "session-managed-1".to_string(),
             model: "gpt-5.1".to_string(),
-            messages: vec![AgentMessage {
+            messages: vec![AgentMessageInput {
                 role: "user".to_string(),
                 text: "Summarize this".to_string(),
-                parts: vec![AgentMessagePart {
-                    r#type: AgentMessagePartType::Text as i32,
+                parts: vec![AgentMessagePartInput {
+                    part_type: AgentMessagePartType::Text,
                     text: "Summarize this".to_string(),
                     ..Default::default()
                 }],
                 ..Default::default()
             }],
-            tool_source: AgentToolSourceMode::McpCatalog as i32,
+            tool_source: AgentToolSourceMode::McpCatalog,
             ..Default::default()
         })
         .await
         .expect("create turn");
     let fetched_turn = manager
-        .get_turn(AgentManagerGetTurnRequest {
+        .get_turn(AgentManagerGetTurnInput {
             turn_id: "turn-managed-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("get turn");
     let listed_turns = manager
-        .list_turns(AgentManagerListTurnsRequest {
+        .list_turns(AgentManagerListTurnsInput {
             session_id: "session-managed-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("list turns");
     let canceled_turn = manager
-        .cancel_turn(AgentManagerCancelTurnRequest {
+        .cancel_turn(AgentManagerCancelTurnInput {
             turn_id: "turn-managed-1".to_string(),
             reason: "user canceled".to_string(),
             ..Default::default()
@@ -504,7 +509,7 @@ async fn agent_manager_connects_over_unix_socket_and_sends_invocation_token() {
         .await
         .expect("cancel turn");
     let turn_events = manager
-        .list_turn_events(AgentManagerListTurnEventsRequest {
+        .list_turn_events(AgentManagerListTurnEventsInput {
             turn_id: "turn-managed-1".to_string(),
             after_seq: 0,
             limit: 10,
@@ -513,19 +518,19 @@ async fn agent_manager_connects_over_unix_socket_and_sends_invocation_token() {
         .await
         .expect("list turn events");
     let interactions = manager
-        .list_interactions(AgentManagerListInteractionsRequest {
+        .list_interactions(AgentManagerListInteractionsInput {
             turn_id: "turn-managed-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("list interactions");
     let resolved = manager
-        .resolve_interaction(AgentManagerResolveInteractionRequest {
+        .resolve_interaction(AgentManagerResolveInteractionInput {
             turn_id: "turn-managed-1".to_string(),
             interaction_id: "interaction-1".to_string(),
-            resolution: Some(helpers::struct_from_json(serde_json::json!({
+            resolution: Some(serde_json::json!({
                 "approved": true
-            }))),
+            })),
             ..Default::default()
         })
         .await
@@ -661,7 +666,7 @@ async fn agent_manager_connects_over_unix_socket_and_sends_invocation_token() {
 }
 
 #[tokio::test]
-async fn agent_manager_native_create_turn_input_reaches_host() {
+async fn agent_manager_create_turn_accepts_native_values() {
     let _env_lock = helpers::env_lock().lock().await;
     let socket = helpers::temp_socket("g-rust-agent-manager-native.sock");
     let _socket_guard = helpers::EnvGuard::set(ENV_AGENT_MANAGER_SOCKET, socket.as_os_str());
@@ -681,7 +686,7 @@ async fn agent_manager_native_create_turn_input_reaches_host() {
         .await
         .expect("connect agent manager");
     let created_turn = manager
-        .create_turn_input(AgentManagerCreateTurnInput {
+        .create_turn(AgentManagerCreateTurnInput {
             session_id: "session-managed-1".to_string(),
             model: "gpt-5.1".to_string(),
             messages: vec![AgentMessageInput {
@@ -781,7 +786,7 @@ async fn request_agent_manager_uses_embedded_invocation_token() {
         .await
         .expect("request agent manager");
     let response = manager
-        .get_session(AgentManagerGetSessionRequest {
+        .get_session(AgentManagerGetSessionInput {
             session_id: "session-managed-1".to_string(),
             ..Default::default()
         })

--- a/sdk/rust/tests/workflow_manager_transport.rs
+++ b/sdk/rust/tests/workflow_manager_transport.rs
@@ -8,10 +8,9 @@ use gestalt::proto::v1::workflow_manager_host_server::{
     WorkflowManagerHost as ProtoWorkflowManagerHost, WorkflowManagerHostServer,
 };
 use gestalt::proto::v1::{
-    AgentMessagePartType, BoundWorkflowDefinition, BoundWorkflowEventTrigger,
-    BoundWorkflowPluginTarget, BoundWorkflowRun, BoundWorkflowSchedule, BoundWorkflowTarget,
-    ManagedWorkflowDefinition, ManagedWorkflowEventTrigger, ManagedWorkflowRun,
-    ManagedWorkflowRunSignal, ManagedWorkflowSchedule, WorkflowEvent, WorkflowEventMatch,
+    AgentMessagePartType, BoundWorkflowDefinition, BoundWorkflowEventTrigger, BoundWorkflowRun,
+    BoundWorkflowSchedule, ManagedWorkflowDefinition, ManagedWorkflowEventTrigger,
+    ManagedWorkflowRun, ManagedWorkflowRunSignal, ManagedWorkflowSchedule, WorkflowEvent,
     WorkflowManagerCreateDefinitionRequest, WorkflowManagerCreateEventTriggerRequest,
     WorkflowManagerCreateScheduleRequest, WorkflowManagerDeleteDefinitionRequest,
     WorkflowManagerDeleteEventTriggerRequest, WorkflowManagerDeleteScheduleRequest,
@@ -21,13 +20,24 @@ use gestalt::proto::v1::{
     WorkflowManagerResumeEventTriggerRequest, WorkflowManagerResumeScheduleRequest,
     WorkflowManagerSignalOrStartRunRequest, WorkflowManagerSignalRunRequest,
     WorkflowManagerStartRunRequest, WorkflowManagerUpdateDefinitionRequest,
-    WorkflowManagerUpdateEventTriggerRequest, WorkflowManagerUpdateScheduleRequest, WorkflowSignal,
+    WorkflowManagerUpdateEventTriggerRequest, WorkflowManagerUpdateScheduleRequest,
     bound_workflow_target,
 };
 use gestalt::{
     AgentMessageInput, AgentMessagePartInput, BoundWorkflowAgentTargetInput,
-    BoundWorkflowTargetInput, ENV_WORKFLOW_MANAGER_SOCKET, ENV_WORKFLOW_MANAGER_SOCKET_TOKEN,
-    Request, WorkflowManager, WorkflowManagerSignalOrStartRunInput, WorkflowSignalInput,
+    BoundWorkflowPluginTargetInput, BoundWorkflowTargetInput, ENV_WORKFLOW_MANAGER_SOCKET,
+    ENV_WORKFLOW_MANAGER_SOCKET_TOKEN, Request, WorkflowEventInput, WorkflowEventMatchInput,
+    WorkflowManager, WorkflowManagerCreateDefinitionInput, WorkflowManagerCreateEventTriggerInput,
+    WorkflowManagerCreateScheduleInput, WorkflowManagerDeleteDefinitionInput,
+    WorkflowManagerDeleteEventTriggerInput, WorkflowManagerDeleteScheduleInput,
+    WorkflowManagerGetDefinitionInput, WorkflowManagerGetEventTriggerInput,
+    WorkflowManagerGetScheduleInput, WorkflowManagerPauseEventTriggerInput,
+    WorkflowManagerPauseScheduleInput, WorkflowManagerPublishEventInput,
+    WorkflowManagerResumeEventTriggerInput, WorkflowManagerResumeScheduleInput,
+    WorkflowManagerSignalOrStartRunInput, WorkflowManagerSignalRunInput,
+    WorkflowManagerStartRunInput, WorkflowManagerUpdateDefinitionInput,
+    WorkflowManagerUpdateEventTriggerInput, WorkflowManagerUpdateScheduleInput,
+    WorkflowSignalInput,
 };
 use tokio::net::{TcpListener, UnixListener};
 use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
@@ -52,16 +62,12 @@ struct TestWorkflowManagerServer {
     signal_or_start_requests: Arc<Mutex<Vec<WorkflowManagerSignalOrStartRunRequest>>>,
 }
 
-fn plugin_target(plugin_name: &str, operation: &str) -> BoundWorkflowTarget {
-    BoundWorkflowTarget {
-        kind: Some(bound_workflow_target::Kind::Plugin(
-            BoundWorkflowPluginTarget {
-                plugin_name: plugin_name.to_string(),
-                operation: operation.to_string(),
-                ..Default::default()
-            },
-        )),
-    }
+fn plugin_target(plugin_name: &str, operation: &str) -> BoundWorkflowTargetInput {
+    BoundWorkflowTargetInput::Plugin(BoundWorkflowPluginTargetInput {
+        plugin_name: plugin_name.to_string(),
+        operation: operation.to_string(),
+        ..Default::default()
+    })
 }
 
 #[async_trait]
@@ -589,7 +595,7 @@ async fn workflow_manager_connects_over_tcp_and_sends_relay_token() {
             .await
             .expect("connect workflow manager");
     let created = manager
-        .create_schedule(WorkflowManagerCreateScheduleRequest {
+        .create_schedule(WorkflowManagerCreateScheduleInput {
             provider_name: "managed".to_string(),
             cron: "*/5 * * * *".to_string(),
             ..Default::default()
@@ -633,7 +639,7 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
             .await
             .expect("connect workflow manager");
     let started_run = manager
-        .start_run(WorkflowManagerStartRunRequest {
+        .start_run(WorkflowManagerStartRunInput {
             provider_name: "basic".to_string(),
             workflow_key: "workflow-key-1".to_string(),
             target: Some(plugin_target("roadmap", "sync")),
@@ -642,9 +648,9 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
         .await
         .expect("start run");
     let signaled_run = manager
-        .signal_run(WorkflowManagerSignalRunRequest {
+        .signal_run(WorkflowManagerSignalRunInput {
             run_id: "run-1".to_string(),
-            signal: Some(WorkflowSignal {
+            signal: Some(WorkflowSignalInput {
                 name: "slack.event".to_string(),
                 ..Default::default()
             }),
@@ -653,11 +659,11 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
         .await
         .expect("signal run");
     let signaled_or_started_run = manager
-        .signal_or_start_run(WorkflowManagerSignalOrStartRunRequest {
+        .signal_or_start_run(WorkflowManagerSignalOrStartRunInput {
             provider_name: "basic".to_string(),
             workflow_key: "workflow-key-1".to_string(),
             target: Some(plugin_target("roadmap", "sync")),
-            signal: Some(WorkflowSignal {
+            signal: Some(WorkflowSignalInput {
                 name: "slack.event".to_string(),
                 ..Default::default()
             }),
@@ -666,7 +672,7 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
         .await
         .expect("signal or start run");
     let created_definition = manager
-        .create_definition(WorkflowManagerCreateDefinitionRequest {
+        .create_definition(WorkflowManagerCreateDefinitionInput {
             provider_name: "basic".to_string(),
             target: Some(plugin_target("roadmap", "sync")),
             ..Default::default()
@@ -674,14 +680,14 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
         .await
         .expect("create definition");
     let fetched_definition = manager
-        .get_definition(WorkflowManagerGetDefinitionRequest {
+        .get_definition(WorkflowManagerGetDefinitionInput {
             definition_id: "definition-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("get definition");
     let updated_definition = manager
-        .update_definition(WorkflowManagerUpdateDefinitionRequest {
+        .update_definition(WorkflowManagerUpdateDefinitionInput {
             definition_id: "definition-1".to_string(),
             provider_name: "secondary".to_string(),
             target: Some(plugin_target("roadmap", "status")),
@@ -690,14 +696,14 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
         .await
         .expect("update definition");
     manager
-        .delete_definition(WorkflowManagerDeleteDefinitionRequest {
+        .delete_definition(WorkflowManagerDeleteDefinitionInput {
             definition_id: "definition-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("delete definition");
     let created = manager
-        .create_schedule(WorkflowManagerCreateScheduleRequest {
+        .create_schedule(WorkflowManagerCreateScheduleInput {
             provider_name: "basic".to_string(),
             cron: "*/5 * * * *".to_string(),
             timezone: "UTC".to_string(),
@@ -708,14 +714,14 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
         .await
         .expect("create schedule");
     let fetched = manager
-        .get_schedule(WorkflowManagerGetScheduleRequest {
+        .get_schedule(WorkflowManagerGetScheduleInput {
             schedule_id: "sched-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("get schedule");
     let updated = manager
-        .update_schedule(WorkflowManagerUpdateScheduleRequest {
+        .update_schedule(WorkflowManagerUpdateScheduleInput {
             schedule_id: "sched-1".to_string(),
             provider_name: "secondary".to_string(),
             cron: "0 * * * *".to_string(),
@@ -727,31 +733,31 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
         .await
         .expect("update schedule");
     let paused = manager
-        .pause_schedule(WorkflowManagerPauseScheduleRequest {
+        .pause_schedule(WorkflowManagerPauseScheduleInput {
             schedule_id: "sched-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("pause schedule");
     let resumed = manager
-        .resume_schedule(WorkflowManagerResumeScheduleRequest {
+        .resume_schedule(WorkflowManagerResumeScheduleInput {
             schedule_id: "sched-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("resume schedule");
     manager
-        .delete_schedule(WorkflowManagerDeleteScheduleRequest {
+        .delete_schedule(WorkflowManagerDeleteScheduleInput {
             schedule_id: "sched-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("delete schedule");
     let created_trigger = manager
-        .create_trigger(WorkflowManagerCreateEventTriggerRequest {
+        .create_trigger(WorkflowManagerCreateEventTriggerInput {
             provider_name: "basic".to_string(),
-            r#match: Some(WorkflowEventMatch {
-                r#type: "roadmap.item.updated".to_string(),
+            event_match: Some(WorkflowEventMatchInput {
+                event_type: "roadmap.item.updated".to_string(),
                 source: "roadmap".to_string(),
                 ..Default::default()
             }),
@@ -762,18 +768,18 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
         .await
         .expect("create trigger");
     let fetched_trigger = manager
-        .get_trigger(WorkflowManagerGetEventTriggerRequest {
+        .get_trigger(WorkflowManagerGetEventTriggerInput {
             trigger_id: "trg-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("get trigger");
     let updated_trigger = manager
-        .update_trigger(WorkflowManagerUpdateEventTriggerRequest {
+        .update_trigger(WorkflowManagerUpdateEventTriggerInput {
             trigger_id: "trg-1".to_string(),
             provider_name: "secondary".to_string(),
-            r#match: Some(WorkflowEventMatch {
-                r#type: "roadmap.item.synced".to_string(),
+            event_match: Some(WorkflowEventMatchInput {
+                event_type: "roadmap.item.synced".to_string(),
                 ..Default::default()
             }),
             target: Some(plugin_target("slack", "chat.postMessage")),
@@ -783,30 +789,30 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
         .await
         .expect("update trigger");
     let paused_trigger = manager
-        .pause_trigger(WorkflowManagerPauseEventTriggerRequest {
+        .pause_trigger(WorkflowManagerPauseEventTriggerInput {
             trigger_id: "trg-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("pause trigger");
     let resumed_trigger = manager
-        .resume_trigger(WorkflowManagerResumeEventTriggerRequest {
+        .resume_trigger(WorkflowManagerResumeEventTriggerInput {
             trigger_id: "trg-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("resume trigger");
     manager
-        .delete_trigger(WorkflowManagerDeleteEventTriggerRequest {
+        .delete_trigger(WorkflowManagerDeleteEventTriggerInput {
             trigger_id: "trg-1".to_string(),
             ..Default::default()
         })
         .await
         .expect("delete trigger");
     let published_event = manager
-        .publish_event(WorkflowManagerPublishEventRequest {
-            event: Some(WorkflowEvent {
-                r#type: "roadmap.item.updated".to_string(),
+        .publish_event(WorkflowManagerPublishEventInput {
+            event: Some(WorkflowEventInput {
+                event_type: "roadmap.item.updated".to_string(),
                 source: "roadmap".to_string(),
                 ..Default::default()
             }),
@@ -1024,7 +1030,7 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
 }
 
 #[tokio::test]
-async fn workflow_manager_native_signal_or_start_input_reaches_host() {
+async fn workflow_manager_signal_or_start_accepts_native_values() {
     let _env_lock = helpers::env_lock().lock().await;
     let socket = helpers::temp_socket("g-rust-wm-native.sock");
     let _socket_guard = helpers::EnvGuard::set(ENV_WORKFLOW_MANAGER_SOCKET, socket.as_os_str());
@@ -1045,7 +1051,7 @@ async fn workflow_manager_native_signal_or_start_input_reaches_host() {
             .await
             .expect("connect workflow manager");
     let signaled = manager
-        .signal_or_start_run_input(WorkflowManagerSignalOrStartRunInput {
+        .signal_or_start_run(WorkflowManagerSignalOrStartRunInput {
             provider_name: "basic".to_string(),
             workflow_key: "workflow-key-1".to_string(),
             idempotency_key: "signal-request-key".to_string(),
@@ -1142,7 +1148,7 @@ async fn request_workflow_manager_uses_embedded_invocation_token() {
         .await
         .expect("request workflow manager");
     let response = manager
-        .get_schedule(WorkflowManagerGetScheduleRequest {
+        .get_schedule(WorkflowManagerGetScheduleInput {
             schedule_id: "sched-1".to_string(),
             ..Default::default()
         })


### PR DESCRIPTION
## Summary
- Migrate agent and workflow manager docs snippets to native input helpers now that SDK support exists
- Update application and provider workflow examples to avoid explicit request/message builders where native inputs are available
- Document remaining native response coverage gaps in the SDK overview

## Verification
- `cd docs && npm run typecheck`
- `cd docs && npm run build`
- `git diff --check`