### PR TITLE
docs: add README license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gestalt
 
 [![Stability: Alpha](https://img.shields.io/badge/stability-alpha-f4d03f.svg)](https://github.com/valon-technologies/gestalt/issues)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/valon-technologies/gestalt)
 
 > Gestalt is under active development. APIs and configuration may change between releases. Feedback and bug reports are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).


### PR DESCRIPTION
## Summary
- Add an Apache 2.0 license badge to the top-level README, matching gestalt-providers.

## Tests
- Not run (README-only change).