### PR TITLE
Fix authentication provider docs references

### DIFF
--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -148,9 +148,7 @@ providers:
       source:
         package: github.com/valon-technologies/gestalt-providers/s3/s3
         version: 0.0.1-alpha.1
-      config:
-        region: us-east-1
-        endpoint: https://s3.us-east-1.amazonaws.com
+      config: ...
 
   workflow:
     local:

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -1,4 +1,4 @@
-import { Callout } from 'nextra/components'
+import { Callout, Tabs } from 'nextra/components'
 
 # Agent
 
@@ -209,6 +209,121 @@ cat <<'JSON' | gestalt --format json agent turns create <session-id> --input -
 }
 JSON
 ```
+
+Provider code can invoke agents through the SDK agent manager:
+
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    import (
+        "context"
+
+        gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    )
+
+    func summarize(ctx context.Context, req gestalt.Request) (string, error) {
+        agents, err := req.AgentManager()
+        if err != nil {
+            return "", err
+        }
+        defer agents.Close()
+
+        session, err := agents.CreateSession(ctx, gestalt.AgentManagerCreateSessionInput{
+            ClientRef: "roadmap-risk",
+        })
+        if err != nil {
+            return "", err
+        }
+
+        turn, err := agents.CreateTurn(ctx, gestalt.AgentManagerCreateTurnInput{
+            SessionID: session.GetId(),
+            Messages: []gestalt.AgentMessageInput{{
+                Role: "user",
+                Text: "Summarize the latest roadmap risk.",
+            }},
+        })
+        if err != nil {
+            return "", err
+        }
+        return turn.GetId(), nil
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```python
+    from gestalt import AgentManagerCreateSessionInput, AgentManagerCreateTurnInput
+    from gestalt import AgentMessageInput, Request
+
+    def summarize(request: Request) -> str:
+        with request.agent_manager() as agents:
+            session = agents.create_session(
+                AgentManagerCreateSessionInput(client_ref="roadmap-risk")
+            )
+            turn = agents.create_turn(
+                AgentManagerCreateTurnInput(
+                    session_id=session.id,
+                    messages=[
+                        AgentMessageInput(
+                            role="user",
+                            text="Summarize the latest roadmap risk.",
+                        )
+                    ],
+                )
+            )
+            return turn.id
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```rust
+    use gestalt::{
+        AgentManagerCreateSessionInput, AgentManagerCreateTurnInput,
+        AgentMessageInput, Request,
+    };
+
+    async fn summarize(req: &Request) -> Result<String, Box<dyn std::error::Error>> {
+        let mut agents = req.agent_manager().await?;
+        let session = agents.create_session(AgentManagerCreateSessionInput {
+            client_ref: "roadmap-risk".into(),
+            ..Default::default()
+        }).await?;
+
+        let turn = agents.create_turn(AgentManagerCreateTurnInput {
+            session_id: session.id,
+            messages: vec![AgentMessageInput {
+                role: "user".into(),
+                text: "Summarize the latest roadmap risk.".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }).await?;
+
+        Ok(turn.id)
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import { AgentManager, type Request } from "@valon-technologies/gestalt";
+
+    export async function summarize(request: Request) {
+      const agents = new AgentManager(request);
+      const session = await agents.createSession({
+        clientRef: "roadmap-risk",
+      });
+      const turn = await agents.createTurn({
+        sessionId: session.id,
+        messages: [
+          {
+            role: "user",
+            text: "Summarize the latest roadmap risk.",
+          },
+        ],
+      });
+      return turn.id;
+    }
+    ```
+  </Tabs.Tab>
+</Tabs>
 
 ## Agent workflow targets
 

--- a/docs/content/providers/authentication.mdx
+++ b/docs/content/providers/authentication.mdx
@@ -14,22 +14,13 @@ authentication provider to begin login, redirects the user to the identity provi
 then calls the provider again to complete the callback. After that, Gestalt
 issues and stores its own session.
 
-Some authentication providers also support:
-
-- validating externally issued bearer tokens for API clients
-- customizing session TTL
-- restricting login to allowed email domains or tenant settings
-
 ## First-Party Authentication Providers
 
-Gestalt includes one built-in authentication provider, `local`, for
-single-user development. Published first-party authentication providers live
-under
+Published first-party authentication providers live under
 [`valon-technologies/gestalt-providers/auth`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth).
 
 | Provider | Use case |
 | --- | --- |
-| `local` | Single-user development on a trusted machine |
 | [`github.com/valon-technologies/gestalt-providers/auth/oidc`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth/oidc) | Generic OpenID Connect providers such as Google, Okta, Auth0, Azure AD, or Keycloak |
 
 ## Configuring `providers.authentication`
@@ -43,13 +34,8 @@ providers:
         version: 0.0.1-alpha.1
       config:
         issuerUrl: https://login.example.com
-        clientId: ${OIDC_CLIENT_ID}
-        clientSecret:
-          secret:
-            provider: default
-            name: oidc-client-secret
-        allowedDomains:
-          - example.com
+        clientId: ...
+        clientSecret: ...
 ```
 
 Structured secret refs such as `clientSecret.secret.provider: default` are
@@ -70,11 +56,8 @@ providers:
       source: ./oidc-auth/manifest.yaml
       config:
         issuerUrl: https://login.example.com
-        clientId: ${OIDC_CLIENT_ID}
-        clientSecret:
-          secret:
-            provider: default
-            name: oidc-client-secret
+        clientId: ...
+        clientSecret: ...
 ```
 
 
@@ -96,7 +79,7 @@ spec:
 
 ### Interface
 
-You implement three methods: `Configure`, `BeginLogin`, and `CompleteLogin`. `BeginLogin` returns an authorization URL that Gestalt redirects the user to. `CompleteLogin` exchanges the callback parameters for an authenticated identity.
+The authentication surface has two required methods: `BeginLogin` and `CompleteLogin`. `BeginLogin` returns an authorization URL that Gestalt redirects the user to. `CompleteLogin` exchanges callback parameters for an authenticated identity.
 
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
@@ -307,6 +290,12 @@ External token validation lets API clients present a bearer token directly inste
     Implement `ExternalTokenValidator` on the same provider type:
 
     ```go
+    import (
+        "context"
+
+        gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    )
+
     func (g *GoogleAuth) ValidateExternalToken(ctx context.Context, token string) (*gestalt.AuthenticatedUser, error) {
         if token == "" {
             return nil, nil
@@ -354,6 +343,9 @@ External token validation lets API clients present a bearer token directly inste
     Override `validate_external_token` on the `AuthenticationProvider` implementation:
 
     ```rust
+    use std::collections::BTreeMap;
+    use gestalt::AuthenticatedUser;
+
     async fn validate_external_token(
         &self,
         token: &str,
@@ -369,7 +361,7 @@ External token validation lets API clients present a bearer token directly inste
             email: "user@example.com".into(),
             email_verified: true,
             display_name: "Example User".into(),
-            claims: std::collections::BTreeMap::from([(
+            claims: BTreeMap::from([(
                 "issuer".into(),
                 "https://accounts.google.com".into(),
             )]),
@@ -382,6 +374,8 @@ External token validation lets API clients present a bearer token directly inste
     Add `validateExternalToken` to `defineAuthenticationProvider`:
 
     ```ts
+    import { defineAuthenticationProvider } from "@valon-technologies/gestalt";
+
     export const provider = defineAuthenticationProvider({
       // configure, beginLogin, and completeLogin omitted for brevity
 
@@ -448,6 +442,8 @@ Session TTL controls how long Gestalt persists a successful browser login. If yo
     Add `sessionSettings` to `defineAuthenticationProvider`:
 
     ```ts
+    import { defineAuthenticationProvider } from "@valon-technologies/gestalt";
+
     export const provider = defineAuthenticationProvider({
       // configure, beginLogin, and completeLogin omitted for brevity
 

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -11,12 +11,13 @@ Two simple secrets providers (`env` and `file`), telemetry, and audit remain bui
 
 ## Authentication Providers
 
-Authentication providers handle platform login. They are configured under `providers.authentication.<name>` in your config file.
+Authentication providers handle platform login. They are configured under
+`providers.authentication.<name>` in your config file. Omit
+`providers.authentication` for local or unauthenticated deployments.
 
-| Name | Purpose |
+| Package | Purpose |
 | --- | --- |
-| `local` | Single-user authentication for local development. No external identity provider required. |
-| `oidc` | Generic OpenID Connect. Works with Okta, Auth0, Azure AD, Keycloak, and others. |
+| `github.com/valon-technologies/gestalt-providers/auth/oidc` | Generic OpenID Connect. Works with Okta, Auth0, Azure AD, Keycloak, and others. |
 
 ```yaml
 providers:

--- a/gestaltd/services/providerdrivers/authentication.go
+++ b/gestaltd/services/providerdrivers/authentication.go
@@ -24,7 +24,7 @@ func AuthenticationFactory(node yaml.Node, deps AuthenticationDeps) (core.Authen
 	prepared, err := componentprovider.PrepareExecution(componentprovider.PrepareParams{
 		Kind:                 providermanifestv1.KindAuthentication,
 		Subject:              "authentication provider",
-		SourceMissingMessage: "no Go, Rust, or Python authentication provider source package found",
+		SourceMissingMessage: "no Go, Rust, Python, or TypeScript authentication provider source package found",
 		Config:               cfg.YAMLConfig,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Removes stale references to a built-in `local` authentication provider.
- Clarifies that authentication providers require `BeginLogin` and `CompleteLogin`.
- Updates the authentication provider source diagnostic to include TypeScript providers.

## Tests

- `git diff --check`
- `cd gestaltd && go test ./services/providerdrivers`
- `cd docs && npm run build`