### PR TITLE
docs: update secrets provider docs and alpha callouts

### DIFF
--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -3,15 +3,8 @@ import { Callout, Tabs } from 'nextra/components'
 # Applications
 
 <Callout type="warning">
-  Alpha. Applications are under active development and not yet stable. Breaking
-  changes may happen between releases without warning. Feedback and bug reports
-  are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
-</Callout>
-
-<Callout type="info">
-  Build a plugin when you need new operations. Build an application when that
-  plugin becomes the backend for a user-facing workflow with UI, policy,
-  storage, schedules, or other provider bindings.
+  **Alpha.** Building applications is not yet stable due to UI providers not
+  having the ideal developer tooling yet.
 </Callout>
 
 Gestalt can be used to build applications. At a minimum, an application is a

--- a/docs/content/architecture/index.mdx
+++ b/docs/content/architecture/index.mdx
@@ -14,7 +14,7 @@ First, the YAML config file is loaded and `${ENV_VAR}` placeholders are expanded
 
 Next, Gestalt initializes the secret managers from `providers.secrets`. The secret manager config blocks themselves *cannot* use structured secret refs, because the secret managers do not exist yet. Credentials for `providers.secrets.<name>.config` have to come in through `${ENV_VAR}` or `${ENV_VAR_FILE}`.
 
-Once the secret managers are ready, Gestalt resolves every structured secret ref across the rest of the config: server settings, auth, indexeddb, telemetry, audit, cache, and all plugin configs. Every ref names its provider explicitly, and each `providers.secrets.<name>.config` block is skipped to avoid a circular dependency.
+Once the secret managers are ready, Gestalt resolves every structured secret ref across the rest of the config: server settings, connections, non-secrets provider config, runtime provider config, UI config, plugins, and plugin connection config. Every ref names its provider explicitly, and each `providers.secrets.<name>.config` block is skipped to avoid a circular dependency.
 
 With secrets resolved, `server.encryptionKey` gets converted into a 32-byte AES key. A 64-character hex string is decoded directly; anything else goes through Argon2id derivation. This derived key protects all stored tokens.
 

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -20,7 +20,7 @@ The server image `valontechnologies/gestaltd:latest` is published for `linux/amd
 
 **Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use a networked datastore provider such as the first-party `indexeddb/relationaldb`, `indexeddb/dynamodb`, or `indexeddb/mongodb` packages. See [IndexedDB](/providers/indexeddb) for the provider model.
 
-**Secrets.** Use `file` or a cloud secret manager instead of `env` in production. `file` is built in and works with Kubernetes volume-mounted secrets. Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). Gestalt config supports structured secret refs that are resolved at boot time through the configured secrets provider. See [Secrets Providers](/providers/secrets) for setup details.
+**Secrets.** Use `file` or an external secret manager instead of `env` in production. `file` is built in and works with Kubernetes volume-mounted secrets. Cloud, vault, and password-manager backends are available as external providers from [`gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). Gestalt config supports structured secret refs that are resolved at boot time through the configured secrets provider. See [Secrets Providers](/providers/secrets) for setup details.
 
 **TLS.** Gestalt does not terminate TLS. Deploy behind a reverse proxy or load balancer that handles TLS termination. Set `server.baseUrl` to the public HTTPS URL so that OAuth callback URLs are derived correctly.
 

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -3,7 +3,7 @@ import { Callout, Tabs } from 'nextra/components'
 # Agent
 
 <Callout type="warning">
-  Alpha. Agents are under active development and not yet stable. Breaking
+  **Alpha.** Agents are under active development and not yet stable. Breaking
   changes may happen between releases without warning. Feedback and bug reports
   are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
 </Callout>

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -3,7 +3,7 @@ import { Callout, Tabs } from 'nextra/components'
 # Runtime
 
 <Callout type="warning">
-  Alpha. Runtimes are under active development and not yet stable. Breaking
+  **Alpha.** Runtimes are under active development and not yet stable. Breaking
   changes may happen between releases without warning. Feedback and bug reports
   are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
 </Callout>

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -7,16 +7,32 @@ starts. That lets provider config, OAuth app secrets, DSNs, and other sensitive
 values stay out of the main YAML file while still being injected into the final
 runtime config.
 
+Structured secret refs always name the configured secrets provider explicitly:
+
+```yaml
+secret:
+  provider: default
+  name: encryption-key
+```
+
+`gestaltd` resolves these refs once during bootstrap. Secret refs are allowed
+throughout server config, connections, non-secrets provider config, runtime
+provider config, UI config, plugins, and plugin connection config. Secret refs
+are not allowed inside `providers.secrets.<name>.config`, because the secrets
+provider has to be configured before it can resolve anything. Use `${ENV_VAR}`
+or `${ENV_VAR_FILE}` placeholders for credentials needed by the secrets provider
+itself.
+
 ## Built-in vs external secret managers
 
 Two simple secret managers are built into `gestaltd`:
 
 | Provider | How it works |
 | --- | --- |
-| `env` | Reads secrets from environment variables |
-| `file` | Reads secrets from files in a configured directory |
+| `env` | Reads secrets from environment variables. It uppercases the secret name, replaces `-` with `_`, and prepends the optional `prefix`. |
+| `file` | Reads one secret per file from a configured directory, trims trailing newlines, and rejects names that escape the base directory. |
 
-Cloud or vault-backed secret managers are external providers published from
+Cloud, vault, and password-manager-backed secret managers are external providers published from
 [`valon-technologies/gestalt-providers/secrets`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets).
 
 ## Configuring built-in providers
@@ -35,8 +51,10 @@ server:
   encryptionKey:
     secret:
       provider: default
-      name: GESTALT_ENCRYPTION_KEY
+      name: encryption-key
 ```
+
+With the config above, `env` looks up `GESTALT_ENCRYPTION_KEY`.
 
 Or use a directory of mounted files:
 
@@ -47,7 +65,15 @@ providers:
       source: file
       config:
         dir: /run/secrets
+
+server:
+  encryptionKey:
+    secret:
+      provider: default
+      name: encryption-key
 ```
+
+With the config above, `file` reads `/run/secrets/encryption-key`.
 
 ## Configuring external secret providers
 
@@ -63,16 +89,19 @@ providers:
 ```
 
 The configured provider resolves each structured secret ref before any auth
-provider, plugin provider, or datastore provider receives its config.
+provider, plugin provider, datastore provider, runtime provider, or other
+consumer receives its config.
 
 ## First-party external secret providers
 
-| Provider |
-| --- |
-| [`github.com/valon-technologies/gestalt-providers/secrets/aws`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/aws) |
-| [`github.com/valon-technologies/gestalt-providers/secrets/azure`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/azure) |
-| [`github.com/valon-technologies/gestalt-providers/secrets/google`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/google) |
-| [`github.com/valon-technologies/gestalt-providers/secrets/vault`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/vault) |
+| Backend | Package | Config fields |
+| --- | --- | --- |
+| AWS Secrets Manager | [`github.com/valon-technologies/gestalt-providers/secrets/aws`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/aws) | `region` (required), `versionStage`, `endpoint`, `allowInsecureHttp` |
+| Azure Key Vault | [`github.com/valon-technologies/gestalt-providers/secrets/azure`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/azure) | `vaultUrl` (required), `version` |
+| Google Secret Manager | [`github.com/valon-technologies/gestalt-providers/secrets/google`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/google) | `project` (required), `version` |
+| HashiCorp Vault KV v2 | [`github.com/valon-technologies/gestalt-providers/secrets/vault`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/vault) | `address` (required), `token` (required), `mountPath`, `namespace`, `allowInsecureHttp` |
+| Keeper Secrets Manager | [`github.com/valon-technologies/gestalt-providers/secrets/keeper`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/keeper) | `config` (required), `field` |
+| 1Password Connect | [`github.com/valon-technologies/gestalt-providers/secrets/onepassword`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/onepassword) | `host` (required), `token` (required), `vault` (required), `field`, `allowInsecureHttp` |
 
 See each provider directory for its config schema and backend-specific settings.
 
@@ -97,7 +126,11 @@ The optional `spec.configSchemaPath` field points to a JSON Schema that validate
 
 ### Interface
 
-A secrets provider implements two methods: `Configure` and `GetSecret`. `Configure` receives the provider name and the raw config map. `GetSecret` receives a secret name and returns the resolved value as a string.
+A secrets provider implements the shared provider lifecycle plus one secret
+lookup method. `Configure` receives the provider name and raw config map before
+serving starts. `GetSecret` receives a secret name and returns the resolved
+value as a string. SDKs also support optional metadata, health, warning, start,
+and close hooks through the common provider lifecycle.
 
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
@@ -169,6 +202,7 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
     use std::sync::Mutex;
     use gestalt::SecretsProvider;
 
+    #[derive(Default)]
     pub struct GoogleSecrets {
         project: Mutex<String>,
         version: Mutex<String>,
@@ -234,7 +268,7 @@ shape shown in
 [Configuring external secret providers](/providers/secrets#configuring-external-secret-providers).
 The built-in `env` and `file` providers are documented in
 [Configuring built-in providers](/providers/secrets#configuring-built-in-providers),
-and the first-party cloud and vault providers are listed in
+and the first-party external providers are listed in
 [First-party external secret providers](/providers/secrets#first-party-external-secret-providers).
 
 ## What to read next

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -3,7 +3,7 @@ import { Callout, Tabs } from 'nextra/components'
 # UI
 
 <Callout type="warning">
-  Alpha. UI providers are under active development and not yet stable. Breaking
+  **Alpha.** UI providers are under active development and not yet stable. Breaking
   changes may happen between releases without warning. Feedback and bug reports
   are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
 </Callout>

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -3,7 +3,7 @@ import { Callout, Tabs } from 'nextra/components'
 # Workflow
 
 <Callout type="warning">
-  Alpha. Workflows are under active development and not yet stable. Breaking
+  **Alpha.** Workflows are under active development and not yet stable. Breaking
   changes may happen between releases without warning. Feedback and bug reports
   are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
 </Callout>

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -7,7 +7,7 @@ powers plugins. The first-party implementations are published from
 [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers)
 and maintained alongside the server.
 
-Two simple secrets providers (`env` and `file`), telemetry, and audit remain built into the binary. Cloud secret backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). See [Secrets Providers](/providers/secrets) for the full list and configuration.
+Two simple secrets providers (`env` and `file`), telemetry, and audit remain built into the binary. Cloud, vault, and password-manager secret backends are available as external providers from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). See [Secrets Providers](/providers/secrets) for the full list and configuration.
 
 ## Authentication Providers
 
@@ -218,14 +218,14 @@ non-AWS S3-compatible backends.
 
 ## Secret Managers
 
-Two secret managers are compiled into the `gestaltd` binary and resolve structured secret refs during bootstrap. Cloud secret backends are available as external providers published from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers).
+Two secret managers are compiled into the `gestaltd` binary and resolve structured secret refs during bootstrap. External secret backends are available as providers published from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers).
 
 | Name | Purpose |
 | --- | --- |
 | `env` | Resolves secrets from environment variables. Default when `providers.secrets` is omitted. |
 | `file` | Resolves secrets from files in a configured directory. Works with Kubernetes volume-mounted secrets. |
 
-For cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault), see [Secrets Providers](/providers/secrets#available-providers). These use a `source:` config key under `providers.secrets.<name>`.
+For external backends such as Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault, Keeper Secrets Manager, and 1Password Connect, see [Secrets Providers](/providers/secrets#first-party-external-secret-providers). These use a `source:` config key under `providers.secrets.<name>`.
 
 ## Telemetry Providers (built-in)
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -893,9 +893,9 @@ providers:
 | `env` | `prefix` | Reads secrets from environment variables. Default when `providers.secrets` is omitted. |
 | `file` | `dir` | Reads one secret per file from a base directory. Works with Kubernetes volume-mounted secrets. |
 
-### Cloud secret backends
+### External secret backends
 
-Cloud secret managers are external providers configured with package sources:
+External secret managers are providers configured with package sources:
 
 ```yaml
 providers:
@@ -911,9 +911,11 @@ providers:
 | Provider | Package path | Config fields |
 | --- | --- | --- |
 | Google Secret Manager | `github.com/valon-technologies/gestalt-providers/secrets/google` | `project` (required), `version` |
-| AWS Secrets Manager | `github.com/valon-technologies/gestalt-providers/secrets/aws` | `region` (required), `versionStage`, `endpoint` |
-| HashiCorp Vault | `github.com/valon-technologies/gestalt-providers/secrets/vault` | `address` (required), `token` (required), `mountPath`, `namespace` |
+| AWS Secrets Manager | `github.com/valon-technologies/gestalt-providers/secrets/aws` | `region` (required), `versionStage`, `endpoint`, `allowInsecureHttp` |
+| HashiCorp Vault KV v2 | `github.com/valon-technologies/gestalt-providers/secrets/vault` | `address` (required), `token` (required), `mountPath`, `namespace`, `allowInsecureHttp` |
 | Azure Key Vault | `github.com/valon-technologies/gestalt-providers/secrets/azure` | `vaultUrl` (required), `version` |
+| Keeper Secrets Manager | `github.com/valon-technologies/gestalt-providers/secrets/keeper` | `config` (required), `field` |
+| 1Password Connect | `github.com/valon-technologies/gestalt-providers/secrets/onepassword` | `host` (required), `token` (required), `vault` (required), `field`, `allowInsecureHttp` |
 
 See [Secrets Providers](/providers/secrets) for the complete reference and SDK interface.
 
@@ -931,8 +933,10 @@ Each provider authenticates to its backing service differently. The `env` and `f
 | AWS Secrets Manager | Uses the [AWS SDK default credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html). In production, use an instance profile, ECS task role, or IRSA. Locally, run `aws configure` or set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. |
 | HashiCorp Vault | Requires explicit `address` and `token` in config. Inject the token via `${VAULT_TOKEN}` or `${VAULT_TOKEN_FILE}`. |
 | Azure Key Vault | Uses [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication). In production, use managed identity. Locally, run `az login`. |
+| Keeper Secrets Manager | Requires a pre-generated Keeper Secrets Manager `config` value. Inject it via `${KEEPER_CONFIG}` or `${KEEPER_CONFIG_FILE}`. |
+| 1Password Connect | Requires a Connect `host`, `token`, and `vault`. Inject the token via `${OP_CONNECT_TOKEN}` or `${OP_CONNECT_TOKEN_FILE}`. |
 
-For local development, `env` or `file` avoids external dependencies entirely. Switch to a cloud secret manager when deploying to a managed environment where ambient identity is available.
+For local development, `env` or `file` avoids external dependencies entirely. Switch to an external secret manager when deploying to a managed environment where ambient identity or a dedicated secrets service is available.
 
 ## `providers.telemetry`
 

--- a/docs/content/reference/configuration.mdx
+++ b/docs/content/reference/configuration.mdx
@@ -123,8 +123,8 @@ intentional.
 
 Structured secret refs are resolved through the named secret manager during
 bootstrap, not during YAML parsing. This lets you reference secrets from files,
-Vault, AWS Secrets Manager, Google Secret Manager, or Azure Key Vault without
-embedding them in the config file.
+cloud secret managers, Vault, Keeper Secrets Manager, or 1Password Connect
+without embedding them in the config file.
 
 ```yaml
 server:


### PR DESCRIPTION
## Summary
- Update secrets provider docs for structured refs, env/file behavior, external providers, and current first-party provider config fields
- Update related configuration/deploy/reference wording for external secret managers
- Remove the applications guidance callout, replace the Alpha warning text, and bold Alpha in all Alpha callouts

## Tests
- npm run typecheck (docs)
- npm run build (docs)
- git diff --check

Note: docs build completes with existing Nextra warnings about last-modified timestamps in this worktree path.