### PR TITLE
Make Rust SDK public surfaces native

### DIFF
--- a/gestaltd/services/plugins/apiexec/apiexec_test.go
+++ b/gestaltd/services/plugins/apiexec/apiexec_test.go
@@ -555,7 +555,7 @@ func TestContextCancellationStopsRetries(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from context cancellation")
 	}
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want context.Canceled", err)
 	}
 	if got := attempts.Load(); got > 2 {

--- a/sdk/rust/src/agent.rs
+++ b/sdk/rust/src/agent.rs
@@ -548,14 +548,14 @@ pub struct AgentToolRefInput {
 }
 
 /// Input for an agent workspace.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AgentWorkspaceInput {
     pub checkouts: Vec<AgentWorkspaceGitCheckoutInput>,
     pub cwd: String,
 }
 
 /// Input for an agent workspace git checkout.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AgentWorkspaceGitCheckoutInput {
     pub url: String,
     pub reference: String,
@@ -924,7 +924,7 @@ pub fn new_agent_tool_ref(input: AgentToolRefInput) -> AgentToolRef {
 }
 
 /// Creates an agent workspace request payload for the manager host service.
-pub fn new_agent_workspace(input: AgentWorkspaceInput) -> pb::AgentWorkspace {
+pub(crate) fn new_agent_workspace(input: AgentWorkspaceInput) -> pb::AgentWorkspace {
     pb::AgentWorkspace {
         checkouts: input
             .checkouts
@@ -1183,10 +1183,6 @@ fn json_from_struct(value: Option<Struct>) -> Option<AgentJson> {
     value.map(|value| protocol::json_from_struct(&value))
 }
 
-fn json_from_value(value: Option<Value>) -> Option<AgentJson> {
-    value.as_ref().map(protocol::json_from_value)
-}
-
 fn struct_from_json(value: Option<AgentJson>) -> ProviderResult<Option<Struct>> {
     value.map(protocol::struct_from_json).transpose()
 }
@@ -1234,7 +1230,7 @@ fn agent_subject_from_proto(value: Option<pb::AgentSubjectContext>) -> Option<Ag
     })
 }
 
-fn agent_tool_ref_from_proto(value: pb::AgentToolRef) -> AgentToolRef {
+pub(crate) fn agent_tool_ref_from_proto(value: pb::AgentToolRef) -> AgentToolRef {
     AgentToolRef {
         plugin: value.plugin,
         operation: value.operation,
@@ -1246,7 +1242,7 @@ fn agent_tool_ref_from_proto(value: pb::AgentToolRef) -> AgentToolRef {
     }
 }
 
-fn agent_tool_ref_to_proto(value: AgentToolRef) -> pb::AgentToolRef {
+pub(crate) fn agent_tool_ref_to_proto(value: AgentToolRef) -> pb::AgentToolRef {
     pb::AgentToolRef {
         plugin: value.plugin,
         operation: value.operation,
@@ -1258,7 +1254,7 @@ fn agent_tool_ref_to_proto(value: AgentToolRef) -> pb::AgentToolRef {
     }
 }
 
-fn message_from_proto(value: pb::AgentMessage) -> AgentMessage {
+pub(crate) fn message_from_proto(value: pb::AgentMessage) -> AgentMessage {
     AgentMessage {
         role: value.role,
         text: value.text,
@@ -1271,7 +1267,7 @@ fn message_from_proto(value: pb::AgentMessage) -> AgentMessage {
     }
 }
 
-fn message_to_proto(value: AgentMessage) -> ProviderResult<pb::AgentMessage> {
+pub(crate) fn message_to_proto(value: AgentMessage) -> ProviderResult<pb::AgentMessage> {
     Ok(pb::AgentMessage {
         role: value.role,
         text: value.text,
@@ -1355,6 +1351,21 @@ fn session_to_proto(value: AgentSession) -> ProviderResult<pb::AgentSession> {
     })
 }
 
+pub(crate) fn session_from_proto(value: pb::AgentSession) -> ProviderResult<AgentSession> {
+    Ok(AgentSession {
+        id: value.id,
+        provider_name: value.provider_name,
+        model: value.model,
+        client_ref: value.client_ref,
+        state: AgentSessionState::try_from(value.state)?,
+        metadata: json_from_struct(value.metadata),
+        created_by: agent_actor_from_proto(value.created_by),
+        created_at: time_from_timestamp(value.created_at)?,
+        updated_at: time_from_timestamp(value.updated_at)?,
+        last_turn_at: time_from_timestamp(value.last_turn_at)?,
+    })
+}
+
 fn turn_to_proto(value: AgentTurn) -> ProviderResult<pb::AgentTurn> {
     Ok(pb::AgentTurn {
         id: value.id,
@@ -1374,6 +1385,25 @@ fn turn_to_proto(value: AgentTurn) -> ProviderResult<pb::AgentTurn> {
         created_at: timestamp_from_time(value.created_at),
         started_at: timestamp_from_time(value.started_at),
         completed_at: timestamp_from_time(value.completed_at),
+        execution_ref: value.execution_ref,
+    })
+}
+
+pub(crate) fn turn_from_proto(value: pb::AgentTurn) -> ProviderResult<AgentTurn> {
+    Ok(AgentTurn {
+        id: value.id,
+        session_id: value.session_id,
+        provider_name: value.provider_name,
+        model: value.model,
+        status: AgentExecutionStatus::try_from(value.status)?,
+        messages: value.messages.into_iter().map(message_from_proto).collect(),
+        output_text: value.output_text,
+        structured_output: json_from_struct(value.structured_output),
+        status_message: value.status_message,
+        created_by: agent_actor_from_proto(value.created_by),
+        created_at: time_from_timestamp(value.created_at)?,
+        started_at: time_from_timestamp(value.started_at)?,
+        completed_at: time_from_timestamp(value.completed_at)?,
         execution_ref: value.execution_ref,
     })
 }
@@ -1409,6 +1439,35 @@ fn event_to_proto(value: AgentTurnEvent) -> ProviderResult<pb::AgentTurnEvent> {
     })
 }
 
+pub(crate) fn event_from_proto(value: pb::AgentTurnEvent) -> ProviderResult<AgentTurnEvent> {
+    Ok(AgentTurnEvent {
+        id: value.id,
+        turn_id: value.turn_id,
+        seq: value.seq,
+        r#type: value.r#type,
+        source: value.source,
+        visibility: value.visibility,
+        data: json_from_struct(value.data),
+        created_at: time_from_timestamp(value.created_at)?,
+        display: value.display.map(|display| AgentTurnDisplay {
+            kind: display.kind,
+            phase: display.phase,
+            text: display.text,
+            label: display.label,
+            r#ref: display.r#ref,
+            parent_ref: display.parent_ref,
+            input: display.input.map(|value| protocol::json_from_value(&value)),
+            output: display
+                .output
+                .map(|value| protocol::json_from_value(&value)),
+            error: display.error.map(|value| protocol::json_from_value(&value)),
+            action: display.action,
+            format: display.format,
+            language: display.language,
+        }),
+    })
+}
+
 fn interaction_to_proto(value: AgentInteraction) -> ProviderResult<pb::AgentInteraction> {
     Ok(pb::AgentInteraction {
         id: value.id,
@@ -1425,80 +1484,13 @@ fn interaction_to_proto(value: AgentInteraction) -> ProviderResult<pb::AgentInte
     })
 }
 
-pub(crate) fn agent_session_from_proto(value: pb::AgentSession) -> ProviderResult<AgentSession> {
-    Ok(AgentSession {
-        id: value.id,
-        provider_name: value.provider_name,
-        model: value.model,
-        client_ref: value.client_ref,
-        state: AgentSessionState::from_i32_lossy(value.state),
-        metadata: json_from_struct(value.metadata),
-        created_by: agent_actor_from_proto(value.created_by),
-        created_at: time_from_timestamp(value.created_at)?,
-        updated_at: time_from_timestamp(value.updated_at)?,
-        last_turn_at: time_from_timestamp(value.last_turn_at)?,
-    })
-}
-
-pub(crate) fn agent_turn_from_proto(value: pb::AgentTurn) -> ProviderResult<AgentTurn> {
-    Ok(AgentTurn {
-        id: value.id,
-        session_id: value.session_id,
-        provider_name: value.provider_name,
-        model: value.model,
-        status: AgentExecutionStatus::from_i32_lossy(value.status),
-        messages: value.messages.into_iter().map(message_from_proto).collect(),
-        output_text: value.output_text,
-        structured_output: json_from_struct(value.structured_output),
-        status_message: value.status_message,
-        created_by: agent_actor_from_proto(value.created_by),
-        created_at: time_from_timestamp(value.created_at)?,
-        started_at: time_from_timestamp(value.started_at)?,
-        completed_at: time_from_timestamp(value.completed_at)?,
-        execution_ref: value.execution_ref,
-    })
-}
-
-pub(crate) fn agent_turn_display_from_proto(value: pb::AgentTurnDisplay) -> AgentTurnDisplay {
-    AgentTurnDisplay {
-        kind: value.kind,
-        phase: value.phase,
-        text: value.text,
-        label: value.label,
-        r#ref: value.r#ref,
-        parent_ref: value.parent_ref,
-        input: json_from_value(value.input),
-        output: json_from_value(value.output),
-        error: json_from_value(value.error),
-        action: value.action,
-        format: value.format,
-        language: value.language,
-    }
-}
-
-pub(crate) fn agent_turn_event_from_proto(
-    value: pb::AgentTurnEvent,
-) -> ProviderResult<AgentTurnEvent> {
-    Ok(AgentTurnEvent {
-        id: value.id,
-        turn_id: value.turn_id,
-        seq: value.seq,
-        r#type: value.r#type,
-        source: value.source,
-        visibility: value.visibility,
-        data: json_from_struct(value.data),
-        created_at: time_from_timestamp(value.created_at)?,
-        display: value.display.map(agent_turn_display_from_proto),
-    })
-}
-
-pub(crate) fn agent_interaction_from_proto(
+pub(crate) fn interaction_from_proto(
     value: pb::AgentInteraction,
 ) -> ProviderResult<AgentInteraction> {
     Ok(AgentInteraction {
         id: value.id,
-        r#type: AgentInteractionType::from_i32_lossy(value.r#type),
-        state: AgentInteractionState::from_i32_lossy(value.state),
+        r#type: AgentInteractionType::try_from(value.r#type)?,
+        state: AgentInteractionState::try_from(value.state)?,
         title: value.title,
         prompt: value.prompt,
         request: json_from_struct(value.request),

--- a/sdk/rust/src/agent_manager.rs
+++ b/sdk/rust/src/agent_manager.rs
@@ -14,8 +14,8 @@ use crate::{
     agent::{
         AgentExecutionStatus, AgentInteraction, AgentMessageInput, AgentSession, AgentSessionState,
         AgentToolRefInput, AgentToolSourceMode, AgentTurn, AgentTurnEvent, AgentWorkspaceInput,
-        agent_interaction_from_proto, agent_session_from_proto, agent_turn_event_from_proto,
-        agent_turn_from_proto, new_agent_messages, new_agent_tool_refs, new_agent_workspace,
+        event_from_proto, interaction_from_proto, new_agent_messages, new_agent_tool_refs,
+        new_agent_workspace, session_from_proto, turn_from_proto,
     },
     protocol,
 };
@@ -190,32 +190,28 @@ pub struct AgentManagerResolveInteractionInput {
     pub resolution: Option<serde_json::Value>,
 }
 
-/// Native response from listing agent sessions through the manager.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct ListAgentManagerSessionsResponse {
+pub struct AgentManagerListSessionsResponse {
     pub sessions: Vec<AgentSession>,
 }
 
-/// Native response from listing agent turns through the manager.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct ListAgentManagerTurnsResponse {
+pub struct AgentManagerListTurnsResponse {
     pub turns: Vec<AgentTurn>,
 }
 
-/// Native response from listing agent turn events through the manager.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct ListAgentManagerTurnEventsResponse {
+pub struct AgentManagerListTurnEventsResponse {
     pub events: Vec<AgentTurnEvent>,
 }
 
-/// Native response from listing agent interactions through the manager.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct ListAgentManagerInteractionsResponse {
+pub struct AgentManagerListInteractionsResponse {
     pub interactions: Vec<AgentInteraction>,
 }
 
 /// Creates a protocol create-session request.
-pub fn new_agent_manager_create_session_request(
+pub(crate) fn new_agent_manager_create_session_request(
     input: AgentManagerCreateSessionInput,
 ) -> crate::Result<pb::AgentManagerCreateSessionRequest> {
     Ok(pb::AgentManagerCreateSessionRequest {
@@ -229,7 +225,7 @@ pub fn new_agent_manager_create_session_request(
     })
 }
 
-pub fn new_agent_manager_get_session_request(
+pub(crate) fn new_agent_manager_get_session_request(
     input: AgentManagerGetSessionInput,
 ) -> pb::AgentManagerGetSessionRequest {
     pb::AgentManagerGetSessionRequest {
@@ -238,7 +234,7 @@ pub fn new_agent_manager_get_session_request(
     }
 }
 
-pub fn new_agent_manager_list_sessions_request(
+pub(crate) fn new_agent_manager_list_sessions_request(
     input: AgentManagerListSessionsInput,
 ) -> pb::AgentManagerListSessionsRequest {
     pb::AgentManagerListSessionsRequest {
@@ -250,7 +246,7 @@ pub fn new_agent_manager_list_sessions_request(
     }
 }
 
-pub fn new_agent_manager_update_session_request(
+pub(crate) fn new_agent_manager_update_session_request(
     input: AgentManagerUpdateSessionInput,
 ) -> crate::Result<pb::AgentManagerUpdateSessionRequest> {
     Ok(pb::AgentManagerUpdateSessionRequest {
@@ -262,7 +258,7 @@ pub fn new_agent_manager_update_session_request(
     })
 }
 
-pub fn new_agent_manager_create_turn_request(
+pub(crate) fn new_agent_manager_create_turn_request(
     input: AgentManagerCreateTurnInput,
 ) -> crate::Result<pb::AgentManagerCreateTurnRequest> {
     Ok(pb::AgentManagerCreateTurnRequest {
@@ -285,7 +281,7 @@ pub fn new_agent_manager_create_turn_request(
     })
 }
 
-pub fn new_agent_manager_get_turn_request(
+pub(crate) fn new_agent_manager_get_turn_request(
     input: AgentManagerGetTurnInput,
 ) -> pb::AgentManagerGetTurnRequest {
     pb::AgentManagerGetTurnRequest {
@@ -294,7 +290,7 @@ pub fn new_agent_manager_get_turn_request(
     }
 }
 
-pub fn new_agent_manager_list_turns_request(
+pub(crate) fn new_agent_manager_list_turns_request(
     input: AgentManagerListTurnsInput,
 ) -> pb::AgentManagerListTurnsRequest {
     pb::AgentManagerListTurnsRequest {
@@ -306,7 +302,7 @@ pub fn new_agent_manager_list_turns_request(
     }
 }
 
-pub fn new_agent_manager_cancel_turn_request(
+pub(crate) fn new_agent_manager_cancel_turn_request(
     input: AgentManagerCancelTurnInput,
 ) -> pb::AgentManagerCancelTurnRequest {
     pb::AgentManagerCancelTurnRequest {
@@ -316,7 +312,7 @@ pub fn new_agent_manager_cancel_turn_request(
     }
 }
 
-pub fn new_agent_manager_list_turn_events_request(
+pub(crate) fn new_agent_manager_list_turn_events_request(
     input: AgentManagerListTurnEventsInput,
 ) -> pb::AgentManagerListTurnEventsRequest {
     pb::AgentManagerListTurnEventsRequest {
@@ -327,7 +323,7 @@ pub fn new_agent_manager_list_turn_events_request(
     }
 }
 
-pub fn new_agent_manager_list_interactions_request(
+pub(crate) fn new_agent_manager_list_interactions_request(
     input: AgentManagerListInteractionsInput,
 ) -> pb::AgentManagerListInteractionsRequest {
     pb::AgentManagerListInteractionsRequest {
@@ -336,7 +332,7 @@ pub fn new_agent_manager_list_interactions_request(
     }
 }
 
-pub fn new_agent_manager_resolve_interaction_request(
+pub(crate) fn new_agent_manager_resolve_interaction_request(
     input: AgentManagerResolveInteractionInput,
 ) -> crate::Result<pb::AgentManagerResolveInteractionRequest> {
     Ok(pb::AgentManagerResolveInteractionRequest {
@@ -408,7 +404,7 @@ impl AgentManager {
     ) -> std::result::Result<AgentSession, AgentManagerError> {
         let mut request = new_agent_manager_create_session_request(input)?;
         request.invocation_token = self.invocation_token.clone();
-        Ok(agent_session_from_proto(
+        Ok(session_from_proto(
             self.client.create_session(request).await?.into_inner(),
         )?)
     }
@@ -420,7 +416,7 @@ impl AgentManager {
     ) -> std::result::Result<AgentSession, AgentManagerError> {
         let mut request = new_agent_manager_get_session_request(input);
         request.invocation_token = self.invocation_token.clone();
-        Ok(agent_session_from_proto(
+        Ok(session_from_proto(
             self.client.get_session(request).await?.into_inner(),
         )?)
     }
@@ -429,16 +425,16 @@ impl AgentManager {
     pub async fn list_sessions(
         &mut self,
         input: AgentManagerListSessionsInput,
-    ) -> std::result::Result<ListAgentManagerSessionsResponse, AgentManagerError> {
+    ) -> std::result::Result<AgentManagerListSessionsResponse, AgentManagerError> {
         let mut request = new_agent_manager_list_sessions_request(input);
         request.invocation_token = self.invocation_token.clone();
         let response = self.client.list_sessions(request).await?.into_inner();
-        Ok(ListAgentManagerSessionsResponse {
+        Ok(AgentManagerListSessionsResponse {
             sessions: response
                 .sessions
                 .into_iter()
-                .map(agent_session_from_proto)
-                .collect::<crate::Result<Vec<_>>>()?,
+                .map(session_from_proto)
+                .collect::<std::result::Result<Vec<_>, _>>()?,
         })
     }
 
@@ -449,7 +445,7 @@ impl AgentManager {
     ) -> std::result::Result<AgentSession, AgentManagerError> {
         let mut request = new_agent_manager_update_session_request(input)?;
         request.invocation_token = self.invocation_token.clone();
-        Ok(agent_session_from_proto(
+        Ok(session_from_proto(
             self.client.update_session(request).await?.into_inner(),
         )?)
     }
@@ -461,7 +457,7 @@ impl AgentManager {
     ) -> std::result::Result<AgentTurn, AgentManagerError> {
         let mut request = new_agent_manager_create_turn_request(input)?;
         request.invocation_token = self.invocation_token.clone();
-        Ok(agent_turn_from_proto(
+        Ok(turn_from_proto(
             self.client.create_turn(request).await?.into_inner(),
         )?)
     }
@@ -473,7 +469,7 @@ impl AgentManager {
     ) -> std::result::Result<AgentTurn, AgentManagerError> {
         let mut request = new_agent_manager_get_turn_request(input);
         request.invocation_token = self.invocation_token.clone();
-        Ok(agent_turn_from_proto(
+        Ok(turn_from_proto(
             self.client.get_turn(request).await?.into_inner(),
         )?)
     }
@@ -482,16 +478,16 @@ impl AgentManager {
     pub async fn list_turns(
         &mut self,
         input: AgentManagerListTurnsInput,
-    ) -> std::result::Result<ListAgentManagerTurnsResponse, AgentManagerError> {
+    ) -> std::result::Result<AgentManagerListTurnsResponse, AgentManagerError> {
         let mut request = new_agent_manager_list_turns_request(input);
         request.invocation_token = self.invocation_token.clone();
         let response = self.client.list_turns(request).await?.into_inner();
-        Ok(ListAgentManagerTurnsResponse {
+        Ok(AgentManagerListTurnsResponse {
             turns: response
                 .turns
                 .into_iter()
-                .map(agent_turn_from_proto)
-                .collect::<crate::Result<Vec<_>>>()?,
+                .map(turn_from_proto)
+                .collect::<std::result::Result<Vec<_>, _>>()?,
         })
     }
 
@@ -502,7 +498,7 @@ impl AgentManager {
     ) -> std::result::Result<AgentTurn, AgentManagerError> {
         let mut request = new_agent_manager_cancel_turn_request(input);
         request.invocation_token = self.invocation_token.clone();
-        Ok(agent_turn_from_proto(
+        Ok(turn_from_proto(
             self.client.cancel_turn(request).await?.into_inner(),
         )?)
     }
@@ -511,16 +507,16 @@ impl AgentManager {
     pub async fn list_turn_events(
         &mut self,
         input: AgentManagerListTurnEventsInput,
-    ) -> std::result::Result<ListAgentManagerTurnEventsResponse, AgentManagerError> {
+    ) -> std::result::Result<AgentManagerListTurnEventsResponse, AgentManagerError> {
         let mut request = new_agent_manager_list_turn_events_request(input);
         request.invocation_token = self.invocation_token.clone();
         let response = self.client.list_turn_events(request).await?.into_inner();
-        Ok(ListAgentManagerTurnEventsResponse {
+        Ok(AgentManagerListTurnEventsResponse {
             events: response
                 .events
                 .into_iter()
-                .map(agent_turn_event_from_proto)
-                .collect::<crate::Result<Vec<_>>>()?,
+                .map(event_from_proto)
+                .collect::<std::result::Result<Vec<_>, _>>()?,
         })
     }
 
@@ -528,16 +524,16 @@ impl AgentManager {
     pub async fn list_interactions(
         &mut self,
         input: AgentManagerListInteractionsInput,
-    ) -> std::result::Result<ListAgentManagerInteractionsResponse, AgentManagerError> {
+    ) -> std::result::Result<AgentManagerListInteractionsResponse, AgentManagerError> {
         let mut request = new_agent_manager_list_interactions_request(input);
         request.invocation_token = self.invocation_token.clone();
         let response = self.client.list_interactions(request).await?.into_inner();
-        Ok(ListAgentManagerInteractionsResponse {
+        Ok(AgentManagerListInteractionsResponse {
             interactions: response
                 .interactions
                 .into_iter()
-                .map(agent_interaction_from_proto)
-                .collect::<crate::Result<Vec<_>>>()?,
+                .map(interaction_from_proto)
+                .collect::<std::result::Result<Vec<_>, _>>()?,
         })
     }
 
@@ -548,7 +544,7 @@ impl AgentManager {
     ) -> std::result::Result<AgentInteraction, AgentManagerError> {
         let mut request = new_agent_manager_resolve_interaction_request(input)?;
         request.invocation_token = self.invocation_token.clone();
-        Ok(agent_interaction_from_proto(
+        Ok(interaction_from_proto(
             self.client.resolve_interaction(request).await?.into_inner(),
         )?)
     }

--- a/sdk/rust/src/auth.rs
+++ b/sdk/rust/src/auth.rs
@@ -4,9 +4,98 @@ use tonic::codegen::async_trait;
 
 use crate::api::RuntimeMetadata;
 use crate::error::{Error, Result};
-pub use crate::generated::v1::{
-    AuthenticatedUser, BeginLoginRequest, BeginLoginResponse, CompleteLoginRequest,
-};
+
+/// Normalized user identity returned by an authentication provider.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AuthenticatedUser {
+    pub subject: String,
+    pub email: String,
+    pub email_verified: bool,
+    pub display_name: String,
+    pub avatar_url: String,
+    pub claims: std::collections::BTreeMap<String, String>,
+}
+
+/// Starts an interactive login flow.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BeginLoginRequest {
+    pub callback_url: String,
+    pub host_state: String,
+    pub scopes: Vec<String>,
+    pub options: std::collections::BTreeMap<String, String>,
+}
+
+/// Provider-managed authorization URL and opaque state for login completion.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BeginLoginResponse {
+    pub authorization_url: String,
+    pub provider_state: Vec<u8>,
+}
+
+/// Finishes an interactive login flow.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CompleteLoginRequest {
+    pub query: std::collections::BTreeMap<String, String>,
+    pub provider_state: Vec<u8>,
+    pub callback_url: String,
+}
+
+/// Host persistence settings for authenticated sessions.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct AuthSessionSettings {
+    pub session_ttl: Duration,
+}
+
+pub(crate) fn begin_login_request_from_proto(
+    value: crate::generated::v1::BeginLoginRequest,
+) -> BeginLoginRequest {
+    BeginLoginRequest {
+        callback_url: value.callback_url,
+        host_state: value.host_state,
+        scopes: value.scopes,
+        options: value.options,
+    }
+}
+
+pub(crate) fn begin_login_response_to_proto(
+    value: BeginLoginResponse,
+) -> crate::generated::v1::BeginLoginResponse {
+    crate::generated::v1::BeginLoginResponse {
+        authorization_url: value.authorization_url,
+        provider_state: value.provider_state,
+    }
+}
+
+pub(crate) fn complete_login_request_from_proto(
+    value: crate::generated::v1::CompleteLoginRequest,
+) -> CompleteLoginRequest {
+    CompleteLoginRequest {
+        query: value.query,
+        provider_state: value.provider_state,
+        callback_url: value.callback_url,
+    }
+}
+
+pub(crate) fn authenticated_user_to_proto(
+    value: AuthenticatedUser,
+) -> crate::generated::v1::AuthenticatedUser {
+    crate::generated::v1::AuthenticatedUser {
+        subject: value.subject,
+        email: value.email,
+        email_verified: value.email_verified,
+        display_name: value.display_name,
+        avatar_url: value.avatar_url,
+        claims: value.claims,
+    }
+}
+
+pub(crate) fn auth_session_settings_to_proto(
+    value: AuthSessionSettings,
+) -> crate::generated::v1::AuthSessionSettings {
+    crate::generated::v1::AuthSessionSettings {
+        session_ttl_seconds: i64::try_from(value.session_ttl.as_secs()).unwrap_or(i64::MAX),
+    }
+}
 
 #[async_trait]
 /// Lifecycle and login contract for Gestalt authentication providers.
@@ -58,7 +147,14 @@ pub trait AuthenticationProvider: Send + Sync + 'static {
         ))
     }
 
+    /// Returns host persistence settings for authenticated sessions.
+    fn session_settings(&self) -> Option<AuthSessionSettings> {
+        None
+    }
+
     /// Returns the TTL the host should use for persisted sessions.
+    ///
+    /// Prefer overriding [`AuthenticationProvider::session_settings`] for new providers.
     fn session_ttl(&self) -> Option<Duration> {
         None
     }

--- a/sdk/rust/src/auth_server.rs
+++ b/sdk/rust/src/auth_server.rs
@@ -2,11 +2,16 @@ use std::sync::Arc;
 
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 
-use crate::auth::AuthenticationProvider;
+use crate::auth::{
+    AuthSessionSettings, AuthenticationProvider, auth_session_settings_to_proto,
+    authenticated_user_to_proto, begin_login_request_from_proto, begin_login_response_to_proto,
+    complete_login_request_from_proto,
+};
 use crate::generated::v1::authentication_provider_server::AuthenticationProvider as AuthenticationProviderGrpc;
 use crate::generated::v1::{
-    AuthSessionSettings, AuthenticatedUser, BeginLoginRequest, BeginLoginResponse,
-    CompleteLoginRequest, ValidateExternalTokenRequest,
+    AuthSessionSettings as ProtoAuthSessionSettings, AuthenticatedUser as ProtoAuthenticatedUser,
+    BeginLoginRequest as ProtoBeginLoginRequest, BeginLoginResponse as ProtoBeginLoginResponse,
+    CompleteLoginRequest as ProtoCompleteLoginRequest, ValidateExternalTokenRequest,
 };
 use crate::rpc_status::rpc_status;
 
@@ -35,32 +40,32 @@ where
 {
     async fn begin_login(
         &self,
-        request: GrpcRequest<BeginLoginRequest>,
-    ) -> std::result::Result<GrpcResponse<BeginLoginResponse>, Status> {
+        request: GrpcRequest<ProtoBeginLoginRequest>,
+    ) -> std::result::Result<GrpcResponse<ProtoBeginLoginResponse>, Status> {
         let response = self
             .provider
-            .begin_login(request.into_inner())
+            .begin_login(begin_login_request_from_proto(request.into_inner()))
             .await
             .map_err(|error| rpc_status("begin login", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(begin_login_response_to_proto(response)))
     }
 
     async fn complete_login(
         &self,
-        request: GrpcRequest<CompleteLoginRequest>,
-    ) -> std::result::Result<GrpcResponse<AuthenticatedUser>, Status> {
+        request: GrpcRequest<ProtoCompleteLoginRequest>,
+    ) -> std::result::Result<GrpcResponse<ProtoAuthenticatedUser>, Status> {
         let user = self
             .provider
-            .complete_login(request.into_inner())
+            .complete_login(complete_login_request_from_proto(request.into_inner()))
             .await
             .map_err(|error| rpc_status("complete login", error))?;
-        Ok(GrpcResponse::new(user))
+        Ok(GrpcResponse::new(authenticated_user_to_proto(user)))
     }
 
     async fn validate_external_token(
         &self,
         request: GrpcRequest<ValidateExternalTokenRequest>,
-    ) -> std::result::Result<GrpcResponse<AuthenticatedUser>, Status> {
+    ) -> std::result::Result<GrpcResponse<ProtoAuthenticatedUser>, Status> {
         let user = self
             .provider
             .validate_external_token(&request.into_inner().token)
@@ -69,21 +74,23 @@ where
         let Some(user) = user else {
             return Err(Status::not_found("token not recognized"));
         };
-        Ok(GrpcResponse::new(user))
+        Ok(GrpcResponse::new(authenticated_user_to_proto(user)))
     }
 
     async fn get_session_settings(
         &self,
         _request: GrpcRequest<()>,
-    ) -> std::result::Result<GrpcResponse<AuthSessionSettings>, Status> {
-        let Some(ttl) = self.provider.session_ttl() else {
+    ) -> std::result::Result<GrpcResponse<ProtoAuthSessionSettings>, Status> {
+        let settings = self.provider.session_settings().or_else(|| {
+            self.provider
+                .session_ttl()
+                .map(|session_ttl| AuthSessionSettings { session_ttl })
+        });
+        let Some(settings) = settings else {
             return Err(Status::unimplemented(
                 "authentication provider does not expose session settings",
             ));
         };
-        let ttl_seconds = i64::try_from(ttl.as_secs()).unwrap_or(i64::MAX);
-        Ok(GrpcResponse::new(AuthSessionSettings {
-            session_ttl_seconds: ttl_seconds,
-        }))
+        Ok(GrpcResponse::new(auth_session_settings_to_proto(settings)))
     }
 }

--- a/sdk/rust/src/authorization.rs
+++ b/sdk/rust/src/authorization.rs
@@ -411,10 +411,11 @@ pub struct AuthorizationModelSubjectSetTarget {
     pub relation: String,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 /// Authorization model rewrite expression.
 pub enum AuthorizationModelRewrite {
     /// Directly related targets.
+    #[default]
     This,
     /// Computed userset on the same resource.
     ComputedUserset(AuthorizationModelComputedUserset),
@@ -422,12 +423,6 @@ pub enum AuthorizationModelRewrite {
     TupleToUserset(AuthorizationModelTupleToUserset),
     /// Union of rewrite branches.
     Union(AuthorizationModelRewriteUnion),
-}
-
-impl Default for AuthorizationModelRewrite {
-    fn default() -> Self {
-        Self::This
-    }
 }
 
 /// Authorization model `this` rewrite leaf.

--- a/sdk/rust/src/cache.rs
+++ b/sdk/rust/src/cache.rs
@@ -21,8 +21,7 @@ type CacheTransport = InterceptedService<Channel, RelayTokenInterceptor>;
 pub const ENV_CACHE_SOCKET: &str = "GESTALT_CACHE_SOCKET";
 /// Default relay-token environment variable used by [`Cache::connect`].
 pub const ENV_CACHE_SOCKET_TOKEN: &str = "GESTALT_CACHE_SOCKET_TOKEN";
-/// Suffix added to named cache socket variables for relay-token variables.
-pub const ENV_CACHE_SOCKET_TOKEN_SUFFIX: &str = "_TOKEN";
+const ENV_CACHE_SOCKET_TOKEN_SUFFIX: &str = "_TOKEN";
 const CACHE_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -332,6 +331,9 @@ pub fn cache_socket_env(name: &str) -> String {
 
 /// Returns the environment variable used for a named cache relay token.
 pub fn cache_socket_token_env(name: &str) -> String {
+    if name.trim().is_empty() {
+        return ENV_CACHE_SOCKET_TOKEN.to_string();
+    }
     format!(
         "{env}{}",
         ENV_CACHE_SOCKET_TOKEN_SUFFIX,

--- a/sdk/rust/src/indexeddb.rs
+++ b/sdk/rust/src/indexeddb.rs
@@ -17,7 +17,7 @@ type IndexedDbTransport = InterceptedService<Channel, RelayTokenInterceptor>;
 /// Default Unix-socket environment variable used by [`IndexedDB::connect`].
 pub const ENV_INDEXEDDB_SOCKET: &str = "GESTALT_INDEXEDDB_SOCKET";
 /// Suffix added to named IndexedDB socket variables for relay-token variables.
-pub const ENV_INDEXEDDB_SOCKET_TOKEN_SUFFIX: &str = "_TOKEN";
+const ENV_INDEXEDDB_SOCKET_TOKEN_SUFFIX: &str = "_TOKEN";
 const INDEXEDDB_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
 const CURSOR_CHANNEL_BUFFER: usize = 1;

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -17,7 +17,7 @@ mod generated;
 pub mod indexeddb;
 mod invoker;
 mod plugin_runtime;
-#[doc(hidden)]
+/// Low-level wire-format conversion helpers for structured values.
 pub mod protocol;
 mod provider_server;
 mod router;
@@ -35,14 +35,12 @@ pub mod telemetry;
 mod workflow;
 mod workflow_manager;
 
-/// Generated protobuf and gRPC bindings for the Gestalt provider protocol.
+/// Low-level provider wire bindings.
 #[doc(hidden)]
 pub mod proto {
     pub use crate::generated::v1;
 }
 
-#[doc(hidden)]
-pub use agent::ENV_AGENT_HOST_SOCKET_TOKEN;
 pub use agent::{
     AgentActor, AgentExecutionStatus, AgentHost, AgentHostError, AgentHostExecuteToolInput,
     AgentHostListToolsInput, AgentHostResolveConnectionInput, AgentInteraction,
@@ -66,35 +64,24 @@ pub use agent::{
     ResolveAgentProviderInteractionRequest, ResolvedAgentConnection, ResolvedAgentTool,
     UpdateAgentProviderSessionRequest, new_agent_image_ref, new_agent_message,
     new_agent_message_part, new_agent_tool_call, new_agent_tool_ref, new_agent_tool_result,
-    new_agent_workspace,
 };
-#[doc(hidden)]
-pub use agent_manager::ENV_AGENT_MANAGER_SOCKET_TOKEN;
 pub use agent_manager::{
     AgentManager, AgentManagerCancelTurnInput, AgentManagerCreateSessionInput,
     AgentManagerCreateTurnInput, AgentManagerError, AgentManagerGetSessionInput,
-    AgentManagerGetTurnInput, AgentManagerListInteractionsInput, AgentManagerListSessionsInput,
-    AgentManagerListTurnEventsInput, AgentManagerListTurnsInput,
+    AgentManagerGetTurnInput, AgentManagerListInteractionsInput,
+    AgentManagerListInteractionsResponse, AgentManagerListSessionsInput,
+    AgentManagerListSessionsResponse, AgentManagerListTurnEventsInput,
+    AgentManagerListTurnEventsResponse, AgentManagerListTurnsInput, AgentManagerListTurnsResponse,
     AgentManagerResolveInteractionInput, AgentManagerUpdateSessionInput, ENV_AGENT_MANAGER_SOCKET,
-    ListAgentManagerInteractionsResponse, ListAgentManagerSessionsResponse,
-    ListAgentManagerTurnEventsResponse, ListAgentManagerTurnsResponse,
-    new_agent_manager_cancel_turn_request, new_agent_manager_create_session_request,
-    new_agent_manager_create_turn_request, new_agent_manager_get_session_request,
-    new_agent_manager_get_turn_request, new_agent_manager_list_interactions_request,
-    new_agent_manager_list_sessions_request, new_agent_manager_list_turn_events_request,
-    new_agent_manager_list_turns_request, new_agent_manager_resolve_interaction_request,
-    new_agent_manager_update_session_request,
 };
 pub use api::{
     Access, Credential, ExternalIdentity, Host, Provider, Request, Response, RuntimeMetadata,
     Subject, ok,
 };
 pub use auth::{
-    AuthenticatedUser, AuthenticationProvider, BeginLoginRequest, BeginLoginResponse,
-    CompleteLoginRequest,
+    AuthSessionSettings, AuthenticatedUser, AuthenticationProvider, BeginLoginRequest,
+    BeginLoginResponse, CompleteLoginRequest,
 };
-#[doc(hidden)]
-pub use authorization::ENV_AUTHORIZATION_SOCKET_TOKEN;
 pub use authorization::{
     AGENT_SESSION_ACTION_EDIT, AGENT_SESSION_ACTION_VIEW, AGENT_SESSION_RELATION_EDITOR,
     AGENT_SESSION_RESOURCE_TYPE, AUTHORIZATION_SUBJECT_TYPE_SUBJECT, AccessDecision,
@@ -113,8 +100,6 @@ pub use authorization::{
     ResourceSearchResponse, SubjectSearchRequest, SubjectSearchResponse, WriteModelRequest,
     WriteRelationshipsRequest,
 };
-#[doc(hidden)]
-pub use cache::ENV_CACHE_SOCKET_TOKEN;
 pub use cache::{
     Cache, CacheEntry, CacheError, CacheProvider, CacheSetOptions, ENV_CACHE_SOCKET,
     cache_socket_env, cache_socket_token_env,
@@ -122,100 +107,66 @@ pub use cache::{
 pub use catalog::{Catalog, CatalogOperation};
 pub use env::{CURRENT_PROTOCOL_VERSION, ENV_PROVIDER_SOCKET};
 pub use error::{Error, Result};
-pub use generated::v1::{
-    AgentManagerCancelTurnRequest, AgentManagerCreateSessionRequest, AgentManagerCreateTurnRequest,
-    AgentManagerGetSessionRequest, AgentManagerGetTurnRequest, AgentManagerListInteractionsRequest,
-    AgentManagerListInteractionsResponse, AgentManagerListSessionsRequest,
-    AgentManagerListSessionsResponse, AgentManagerListTurnEventsRequest,
-    AgentManagerListTurnEventsResponse, AgentManagerListTurnsRequest,
-    AgentManagerListTurnsResponse, AgentManagerResolveInteractionRequest,
-    AgentManagerUpdateSessionRequest, AgentWorkspace as AgentProtocolWorkspace,
-    AgentWorkspaceGitCheckout as AgentProtocolWorkspaceGitCheckout,
-};
-pub use generated::v1::{
-    BoundWorkflowAgentTarget, BoundWorkflowEventTrigger, BoundWorkflowPluginTarget,
-    BoundWorkflowRun, BoundWorkflowSchedule, BoundWorkflowTarget, CancelWorkflowProviderRunRequest,
-    DeleteWorkflowProviderEventTriggerRequest, DeleteWorkflowProviderScheduleRequest,
-    GetWorkflowExecutionReferenceRequest, GetWorkflowProviderEventTriggerRequest,
-    GetWorkflowProviderRunRequest, GetWorkflowProviderScheduleRequest,
-    ListWorkflowExecutionReferencesRequest, ListWorkflowExecutionReferencesResponse,
-    ListWorkflowProviderEventTriggersRequest, ListWorkflowProviderEventTriggersResponse,
-    ListWorkflowProviderRunsRequest, ListWorkflowProviderRunsResponse,
-    ListWorkflowProviderSchedulesRequest, ListWorkflowProviderSchedulesResponse,
-    ManagedWorkflowEventTrigger, ManagedWorkflowRun, ManagedWorkflowRunSignal,
-    ManagedWorkflowSchedule, PauseWorkflowProviderEventTriggerRequest,
-    PauseWorkflowProviderScheduleRequest, PublishWorkflowProviderEventRequest,
-    PutWorkflowExecutionReferenceRequest, ResumeWorkflowProviderEventTriggerRequest,
-    ResumeWorkflowProviderScheduleRequest, SignalOrStartWorkflowProviderRunRequest,
-    SignalWorkflowProviderRunRequest, SignalWorkflowRunResponse, StartWorkflowProviderRunRequest,
-    UpsertWorkflowProviderEventTriggerRequest, UpsertWorkflowProviderScheduleRequest,
-    WorkflowAccessPermission, WorkflowActor, WorkflowEvent, WorkflowEventMatch,
-    WorkflowEventTriggerInvocation, WorkflowExecutionReference,
-    WorkflowManagerCreateEventTriggerRequest, WorkflowManagerCreateScheduleRequest,
-    WorkflowManagerDeleteEventTriggerRequest, WorkflowManagerDeleteScheduleRequest,
-    WorkflowManagerGetEventTriggerRequest, WorkflowManagerGetScheduleRequest,
-    WorkflowManagerPauseEventTriggerRequest, WorkflowManagerPauseScheduleRequest,
-    WorkflowManagerPublishEventRequest, WorkflowManagerResumeEventTriggerRequest,
-    WorkflowManagerResumeScheduleRequest, WorkflowManagerSignalOrStartRunRequest,
-    WorkflowManagerSignalRunRequest, WorkflowManagerStartRunRequest,
-    WorkflowManagerUpdateEventTriggerRequest, WorkflowManagerUpdateScheduleRequest,
-    WorkflowManualTrigger, WorkflowOutputBinding, WorkflowOutputDelivery,
-    WorkflowOutputValueSource, WorkflowRunAsSubject, WorkflowRunStatus, WorkflowRunTrigger,
-    WorkflowScheduleTrigger, WorkflowSignal, bound_workflow_target, workflow_output_value_source,
-    workflow_run_trigger,
-};
-pub use generated::v1::{
-    CopyObjectRequest, CopyObjectResponse, DeleteObjectRequest, HeadObjectRequest,
-    HeadObjectResponse, ListObjectsRequest, ListObjectsResponse, PresignObjectRequest,
-    PresignObjectResponse, ReadObjectChunk, ReadObjectRequest, WriteObjectOpen, WriteObjectRequest,
-    WriteObjectResponse,
-};
-pub use generated::v1::{
-    GetPluginRuntimeSessionRequest, HostedPlugin, ListPluginRuntimeSessionsRequest,
-    ListPluginRuntimeSessionsResponse, PluginRuntimeImagePullAuth, PluginRuntimeSession,
-    PluginRuntimeSessionLifecycle, PluginRuntimeSupport, PreparePluginRuntimeWorkspaceRequest,
-    PreparePluginRuntimeWorkspaceResponse, RemovePluginRuntimeWorkspaceRequest,
-    StartHostedPluginRequest, StartPluginRuntimeSessionRequest, StopPluginRuntimeSessionRequest,
-};
 pub use indexeddb::{
     Cursor, CursorDirection, ENV_INDEXEDDB_SOCKET, IndexedDB, IndexedDBError, Transaction,
     TransactionDurabilityHint, TransactionIndexClient, TransactionMode, TransactionObjectStore,
     TransactionOptions, indexeddb_socket_env, indexeddb_socket_token_env,
 };
-#[doc(hidden)]
-pub use invoker::ENV_PLUGIN_INVOKER_SOCKET_TOKEN;
 pub use invoker::{
     ENV_PLUGIN_INVOKER_SOCKET, InvocationGrant, InvokeOptions, PluginInvoker, PluginInvokerError,
 };
-pub use plugin_runtime::PluginRuntimeProvider;
+pub use plugin_runtime::{
+    GetPluginRuntimeSessionRequest, HostedPlugin, ListPluginRuntimeSessionsRequest,
+    ListPluginRuntimeSessionsResponse, PluginRuntimeEgressMode, PluginRuntimeImagePullAuth,
+    PluginRuntimeProvider, PluginRuntimeSession, PluginRuntimeSessionLifecycle,
+    PluginRuntimeSupport, PreparePluginRuntimeWorkspaceRequest,
+    PreparePluginRuntimeWorkspaceResponse, RemovePluginRuntimeWorkspaceRequest,
+    StartHostedPluginRequest, StartPluginRuntimeSessionRequest, StopPluginRuntimeSessionRequest,
+};
 #[doc(hidden)]
 pub use provider_server::{OperationResult, ProviderServer};
 pub use router::{Operation, Router};
-#[doc(hidden)]
-pub use runtime_log_host::ENV_RUNTIME_LOG_HOST_SOCKET_TOKEN;
 pub use runtime_log_host::{
-    ENV_RUNTIME_LOG_HOST_SOCKET, ENV_RUNTIME_SESSION_ID, RuntimeLogHost, RuntimeLogHostError,
+    AppendPluginRuntimeLogsRequest, AppendPluginRuntimeLogsResponse, ENV_RUNTIME_LOG_HOST_SOCKET,
+    ENV_RUNTIME_SESSION_ID, PluginRuntimeLogEntry, RuntimeLogHost, RuntimeLogHostError,
     RuntimeLogStream, runtime_session_id,
 };
-#[doc(hidden)]
-pub use s3::ENV_S3_SOCKET_TOKEN;
 pub use s3::{ENV_S3_SOCKET, S3, S3Error, S3Provider, s3_socket_env, s3_socket_token_env};
-pub use s3::{S3ReadObjectStream, S3WriteObjectStream};
+pub use s3::{S3ReadObjectFrame, S3ReadObjectStream, S3WriteObjectFrame, S3WriteObjectStream};
 pub use secrets::SecretsProvider;
 pub use tonic::codegen::async_trait;
-#[doc(hidden)]
-pub use workflow::ENV_WORKFLOW_HOST_SOCKET_TOKEN;
 pub use workflow::{
-    BoundWorkflowAgentTargetInput, BoundWorkflowDefinitionInput, BoundWorkflowEventTriggerInput,
-    BoundWorkflowPluginTargetInput, BoundWorkflowRunInput, BoundWorkflowScheduleInput,
-    BoundWorkflowTargetInput, ENV_WORKFLOW_HOST_SOCKET, InvokeWorkflowOperationInput,
-    InvokeWorkflowOperationResponse, WorkflowAccessPermissionInput, WorkflowActorInput,
-    WorkflowEventInput, WorkflowEventMatchInput, WorkflowEventTriggerInvocationInput,
-    WorkflowExecutionReferenceInput, WorkflowHost, WorkflowHostError, WorkflowOutputBindingInput,
-    WorkflowOutputDeliveryInput, WorkflowOutputValueSourceInput, WorkflowProvider,
-    WorkflowRunAsSubjectInput, WorkflowRunTriggerInput, WorkflowScheduleTriggerInput,
-    WorkflowSignalInput, bound_workflow_agent_target_input_from_target,
-    bound_workflow_definition_input_from_definition,
+    BoundWorkflowAgentTarget, BoundWorkflowAgentTargetInput, BoundWorkflowDefinition,
+    BoundWorkflowDefinitionInput, BoundWorkflowEventTrigger, BoundWorkflowEventTriggerInput,
+    BoundWorkflowPluginTarget, BoundWorkflowPluginTargetInput, BoundWorkflowRun,
+    BoundWorkflowRunInput, BoundWorkflowSchedule, BoundWorkflowScheduleInput, BoundWorkflowTarget,
+    BoundWorkflowTargetInput, CancelWorkflowProviderRunRequest,
+    DeleteWorkflowProviderEventTriggerRequest, DeleteWorkflowProviderScheduleRequest,
+    ENV_WORKFLOW_HOST_SOCKET, GetWorkflowExecutionReferenceRequest,
+    GetWorkflowProviderEventTriggerRequest, GetWorkflowProviderRunRequest,
+    GetWorkflowProviderScheduleRequest, InvokeWorkflowOperationInput,
+    InvokeWorkflowOperationResponse, ListWorkflowExecutionReferencesRequest,
+    ListWorkflowExecutionReferencesResponse, ListWorkflowProviderEventTriggersRequest,
+    ListWorkflowProviderEventTriggersResponse, ListWorkflowProviderRunsRequest,
+    ListWorkflowProviderRunsResponse, ListWorkflowProviderSchedulesRequest,
+    ListWorkflowProviderSchedulesResponse, ManagedWorkflowDefinition, ManagedWorkflowEventTrigger,
+    ManagedWorkflowRun, ManagedWorkflowRunSignal, ManagedWorkflowSchedule,
+    PauseWorkflowProviderEventTriggerRequest, PauseWorkflowProviderScheduleRequest,
+    PublishWorkflowProviderEventRequest, PutWorkflowExecutionReferenceRequest,
+    ResumeWorkflowProviderEventTriggerRequest, ResumeWorkflowProviderScheduleRequest,
+    SignalOrStartWorkflowProviderRunRequest, SignalWorkflowProviderRunRequest,
+    SignalWorkflowRunResponse, StartWorkflowProviderRunRequest,
+    UpsertWorkflowProviderEventTriggerRequest, UpsertWorkflowProviderScheduleRequest,
+    WorkflowAccessPermission, WorkflowAccessPermissionInput, WorkflowActor, WorkflowActorInput,
+    WorkflowEvent, WorkflowEventInput, WorkflowEventMatch, WorkflowEventMatchInput,
+    WorkflowEventTriggerInvocation, WorkflowEventTriggerInvocationInput,
+    WorkflowExecutionReference, WorkflowExecutionReferenceInput, WorkflowHost, WorkflowHostError,
+    WorkflowJson, WorkflowOutputBinding, WorkflowOutputBindingInput, WorkflowOutputDelivery,
+    WorkflowOutputDeliveryInput, WorkflowOutputValueSource, WorkflowOutputValueSourceInput,
+    WorkflowProvider, WorkflowRunAsSubject, WorkflowRunAsSubjectInput, WorkflowRunStatus,
+    WorkflowRunTrigger, WorkflowRunTriggerInput, WorkflowScheduleTrigger,
+    WorkflowScheduleTriggerInput, WorkflowSignal, WorkflowSignalInput,
+    bound_workflow_agent_target_input_from_target, bound_workflow_definition_input_from_definition,
     bound_workflow_event_trigger_input_from_trigger,
     bound_workflow_plugin_target_input_from_target, bound_workflow_run_input_from_run,
     bound_workflow_schedule_input_from_schedule, bound_workflow_target_input_from_target,
@@ -237,36 +188,18 @@ pub use workflow::{
     workflow_run_as_subject_input_from_subject, workflow_run_trigger_input_from_trigger,
     workflow_signal_input_from_signal,
 };
-#[doc(hidden)]
-pub use workflow_manager::ENV_WORKFLOW_MANAGER_SOCKET_TOKEN;
 pub use workflow_manager::{
-    ENV_WORKFLOW_MANAGER_SOCKET, WorkflowManager, WorkflowManagerBoundDefinition,
-    WorkflowManagerBoundEventTrigger, WorkflowManagerBoundRun, WorkflowManagerBoundSchedule,
-    WorkflowManagerCreateDefinitionInput, WorkflowManagerCreateEventTriggerInput,
-    WorkflowManagerCreateScheduleInput, WorkflowManagerDefinition,
+    ENV_WORKFLOW_MANAGER_SOCKET, WorkflowManager, WorkflowManagerCreateDefinitionInput,
+    WorkflowManagerCreateEventTriggerInput, WorkflowManagerCreateScheduleInput,
     WorkflowManagerDeleteDefinitionInput, WorkflowManagerDeleteEventTriggerInput,
-    WorkflowManagerDeleteScheduleInput, WorkflowManagerError, WorkflowManagerEventTrigger,
-    WorkflowManagerGetDefinitionInput, WorkflowManagerGetEventTriggerInput,
-    WorkflowManagerGetScheduleInput, WorkflowManagerPauseEventTriggerInput,
-    WorkflowManagerPauseScheduleInput, WorkflowManagerPublishEventInput,
-    WorkflowManagerPublishedEvent, WorkflowManagerResumeEventTriggerInput,
-    WorkflowManagerResumeScheduleInput, WorkflowManagerRun, WorkflowManagerRunSignal,
-    WorkflowManagerSchedule, WorkflowManagerSignalOrStartRunInput, WorkflowManagerSignalRunInput,
-    WorkflowManagerStartRunInput, WorkflowManagerUpdateDefinitionInput,
-    WorkflowManagerUpdateEventTriggerInput, WorkflowManagerUpdateScheduleInput,
-    new_workflow_manager_create_definition_request,
-    new_workflow_manager_create_event_trigger_request,
-    new_workflow_manager_create_schedule_request, new_workflow_manager_delete_definition_request,
-    new_workflow_manager_delete_event_trigger_request,
-    new_workflow_manager_delete_schedule_request, new_workflow_manager_get_definition_request,
-    new_workflow_manager_get_event_trigger_request, new_workflow_manager_get_schedule_request,
-    new_workflow_manager_pause_event_trigger_request, new_workflow_manager_pause_schedule_request,
-    new_workflow_manager_publish_event_request, new_workflow_manager_resume_event_trigger_request,
-    new_workflow_manager_resume_schedule_request, new_workflow_manager_signal_or_start_run_request,
-    new_workflow_manager_signal_run_request, new_workflow_manager_start_run_request,
-    new_workflow_manager_update_definition_request,
-    new_workflow_manager_update_event_trigger_request,
-    new_workflow_manager_update_schedule_request,
+    WorkflowManagerDeleteScheduleInput, WorkflowManagerError, WorkflowManagerGetDefinitionInput,
+    WorkflowManagerGetEventTriggerInput, WorkflowManagerGetScheduleInput,
+    WorkflowManagerPauseEventTriggerInput, WorkflowManagerPauseScheduleInput,
+    WorkflowManagerPublishEventInput, WorkflowManagerResumeEventTriggerInput,
+    WorkflowManagerResumeScheduleInput, WorkflowManagerSignalOrStartRunInput,
+    WorkflowManagerSignalRunInput, WorkflowManagerStartRunInput,
+    WorkflowManagerUpdateDefinitionInput, WorkflowManagerUpdateEventTriggerInput,
+    WorkflowManagerUpdateScheduleInput,
 };
 
 #[doc(hidden)]

--- a/sdk/rust/src/plugin_runtime.rs
+++ b/sdk/rust/src/plugin_runtime.rs
@@ -1,12 +1,245 @@
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use tonic::codegen::async_trait;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 
+use crate::agent::{AgentPreparedWorkspace, AgentWorkspaceInput};
 use crate::api::RuntimeMetadata;
 use crate::error::Result as ProviderResult;
 use crate::generated::v1::{self as pb};
+use crate::protocol;
 use crate::rpc_status::rpc_status;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[repr(i32)]
+pub enum PluginRuntimeEgressMode {
+    #[default]
+    Unspecified = 0,
+    None = 1,
+    Cidr = 2,
+    Hostname = 3,
+}
+
+impl PluginRuntimeEgressMode {
+    pub const fn as_i32(self) -> i32 {
+        self as i32
+    }
+
+    pub const fn from_i32_lossy(value: i32) -> Self {
+        match value {
+            1 => Self::None,
+            2 => Self::Cidr,
+            3 => Self::Hostname,
+            _ => Self::Unspecified,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PluginRuntimeSupport {
+    pub can_host_plugins: bool,
+    pub egress_mode: PluginRuntimeEgressMode,
+    pub supports_prepare_workspace: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PluginRuntimeSession {
+    pub id: String,
+    pub state: String,
+    pub metadata: std::collections::BTreeMap<String, String>,
+    pub lifecycle: Option<PluginRuntimeSessionLifecycle>,
+    pub state_reason: String,
+    pub state_message: String,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PluginRuntimeSessionLifecycle {
+    pub started_at: Option<SystemTime>,
+    pub recommended_drain_at: Option<SystemTime>,
+    pub expires_at: Option<SystemTime>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PluginRuntimeImagePullAuth {
+    pub docker_config_json: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct StartPluginRuntimeSessionRequest {
+    pub plugin_name: String,
+    pub template: String,
+    pub image: String,
+    pub metadata: std::collections::BTreeMap<String, String>,
+    pub image_pull_auth: Option<PluginRuntimeImagePullAuth>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GetPluginRuntimeSessionRequest {
+    pub session_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ListPluginRuntimeSessionsRequest {}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ListPluginRuntimeSessionsResponse {
+    pub sessions: Vec<PluginRuntimeSession>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct StopPluginRuntimeSessionRequest {
+    pub session_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PreparePluginRuntimeWorkspaceRequest {
+    pub session_id: String,
+    pub agent_session_id: String,
+    pub workspace: Option<AgentWorkspaceInput>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PreparePluginRuntimeWorkspaceResponse {
+    pub workspace: Option<AgentPreparedWorkspace>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RemovePluginRuntimeWorkspaceRequest {
+    pub session_id: String,
+    pub agent_session_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct StartHostedPluginRequest {
+    pub session_id: String,
+    pub plugin_name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: std::collections::BTreeMap<String, String>,
+    pub allowed_hosts: Vec<String>,
+    pub default_action: String,
+    pub host_binary: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct HostedPlugin {
+    pub id: String,
+    pub session_id: String,
+    pub plugin_name: String,
+    pub dial_target: String,
+}
+
+fn support_to_proto(value: PluginRuntimeSupport) -> pb::PluginRuntimeSupport {
+    pb::PluginRuntimeSupport {
+        can_host_plugins: value.can_host_plugins,
+        egress_mode: value.egress_mode.as_i32(),
+        supports_prepare_workspace: value.supports_prepare_workspace,
+    }
+}
+
+fn session_to_proto(value: PluginRuntimeSession) -> pb::PluginRuntimeSession {
+    pb::PluginRuntimeSession {
+        id: value.id,
+        state: value.state,
+        metadata: value.metadata,
+        lifecycle: value
+            .lifecycle
+            .map(|lifecycle| pb::PluginRuntimeSessionLifecycle {
+                started_at: lifecycle
+                    .started_at
+                    .map(protocol::timestamp_from_system_time),
+                recommended_drain_at: lifecycle
+                    .recommended_drain_at
+                    .map(protocol::timestamp_from_system_time),
+                expires_at: lifecycle
+                    .expires_at
+                    .map(protocol::timestamp_from_system_time),
+            }),
+        state_reason: value.state_reason,
+        state_message: value.state_message,
+    }
+}
+
+fn start_session_request_from_proto(
+    value: pb::StartPluginRuntimeSessionRequest,
+) -> StartPluginRuntimeSessionRequest {
+    StartPluginRuntimeSessionRequest {
+        plugin_name: value.plugin_name,
+        template: value.template,
+        image: value.image,
+        metadata: value.metadata,
+        image_pull_auth: value
+            .image_pull_auth
+            .map(|auth| PluginRuntimeImagePullAuth {
+                docker_config_json: auth.docker_config_json,
+            }),
+    }
+}
+
+fn list_sessions_response_to_proto(
+    value: ListPluginRuntimeSessionsResponse,
+) -> pb::ListPluginRuntimeSessionsResponse {
+    pb::ListPluginRuntimeSessionsResponse {
+        sessions: value.sessions.into_iter().map(session_to_proto).collect(),
+    }
+}
+
+fn prepare_workspace_request_from_proto(
+    value: pb::PreparePluginRuntimeWorkspaceRequest,
+) -> PreparePluginRuntimeWorkspaceRequest {
+    PreparePluginRuntimeWorkspaceRequest {
+        session_id: value.session_id,
+        agent_session_id: value.agent_session_id,
+        workspace: value.workspace.map(|workspace| AgentWorkspaceInput {
+            checkouts: workspace
+                .checkouts
+                .into_iter()
+                .map(|checkout| crate::agent::AgentWorkspaceGitCheckoutInput {
+                    url: checkout.url,
+                    reference: checkout.r#ref,
+                    path: checkout.path,
+                })
+                .collect(),
+            cwd: workspace.cwd,
+        }),
+    }
+}
+
+fn prepare_workspace_response_to_proto(
+    value: PreparePluginRuntimeWorkspaceResponse,
+) -> pb::PreparePluginRuntimeWorkspaceResponse {
+    pb::PreparePluginRuntimeWorkspaceResponse {
+        workspace: value.workspace.map(|workspace| pb::PreparedAgentWorkspace {
+            root: workspace.root,
+            cwd: workspace.cwd,
+        }),
+    }
+}
+
+fn start_plugin_request_from_proto(
+    value: pb::StartHostedPluginRequest,
+) -> StartHostedPluginRequest {
+    StartHostedPluginRequest {
+        session_id: value.session_id,
+        plugin_name: value.plugin_name,
+        command: value.command,
+        args: value.args,
+        env: value.env,
+        allowed_hosts: value.allowed_hosts,
+        default_action: value.default_action,
+        host_binary: value.host_binary,
+    }
+}
+
+fn hosted_plugin_to_proto(value: HostedPlugin) -> pb::HostedPlugin {
+    pb::HostedPlugin {
+        id: value.id,
+        session_id: value.session_id,
+        plugin_name: value.plugin_name,
+        dial_target: value.dial_target,
+    }
+}
 
 #[async_trait]
 /// Provider trait for serving hosted plugin-runtime sessions.
@@ -46,7 +279,7 @@ pub trait PluginRuntimeProvider: Send + Sync + 'static {
     }
 
     /// Returns the runtime capabilities supported by this provider.
-    async fn get_support(&self, _request: ()) -> ProviderResult<pb::PluginRuntimeSupport> {
+    async fn get_support(&self, _request: ()) -> ProviderResult<PluginRuntimeSupport> {
         Err(crate::Error::unimplemented(
             "runtime get support is not implemented",
         ))
@@ -55,8 +288,8 @@ pub trait PluginRuntimeProvider: Send + Sync + 'static {
     /// Starts a hosted plugin-runtime session.
     async fn start_session(
         &self,
-        _request: pb::StartPluginRuntimeSessionRequest,
-    ) -> ProviderResult<pb::PluginRuntimeSession> {
+        _request: StartPluginRuntimeSessionRequest,
+    ) -> ProviderResult<PluginRuntimeSession> {
         Err(crate::Error::unimplemented(
             "runtime start session is not implemented",
         ))
@@ -65,8 +298,8 @@ pub trait PluginRuntimeProvider: Send + Sync + 'static {
     /// Returns one hosted plugin-runtime session by ID.
     async fn get_session(
         &self,
-        _request: pb::GetPluginRuntimeSessionRequest,
-    ) -> ProviderResult<pb::PluginRuntimeSession> {
+        _request: GetPluginRuntimeSessionRequest,
+    ) -> ProviderResult<PluginRuntimeSession> {
         Err(crate::Error::unimplemented(
             "runtime get session is not implemented",
         ))
@@ -75,18 +308,15 @@ pub trait PluginRuntimeProvider: Send + Sync + 'static {
     /// Lists hosted plugin-runtime sessions.
     async fn list_sessions(
         &self,
-        _request: pb::ListPluginRuntimeSessionsRequest,
-    ) -> ProviderResult<pb::ListPluginRuntimeSessionsResponse> {
+        _request: ListPluginRuntimeSessionsRequest,
+    ) -> ProviderResult<ListPluginRuntimeSessionsResponse> {
         Err(crate::Error::unimplemented(
             "runtime list sessions is not implemented",
         ))
     }
 
     /// Stops a hosted plugin-runtime session.
-    async fn stop_session(
-        &self,
-        _request: pb::StopPluginRuntimeSessionRequest,
-    ) -> ProviderResult<()> {
+    async fn stop_session(&self, _request: StopPluginRuntimeSessionRequest) -> ProviderResult<()> {
         Err(crate::Error::unimplemented(
             "runtime stop session is not implemented",
         ))
@@ -95,8 +325,8 @@ pub trait PluginRuntimeProvider: Send + Sync + 'static {
     /// Prepares an agent workspace for use by a hosted plugin.
     async fn prepare_workspace(
         &self,
-        _request: pb::PreparePluginRuntimeWorkspaceRequest,
-    ) -> ProviderResult<pb::PreparePluginRuntimeWorkspaceResponse> {
+        _request: PreparePluginRuntimeWorkspaceRequest,
+    ) -> ProviderResult<PreparePluginRuntimeWorkspaceResponse> {
         Err(crate::Error::unimplemented(
             "runtime prepare workspace is not implemented",
         ))
@@ -105,7 +335,7 @@ pub trait PluginRuntimeProvider: Send + Sync + 'static {
     /// Removes a previously prepared agent workspace.
     async fn remove_workspace(
         &self,
-        _request: pb::RemovePluginRuntimeWorkspaceRequest,
+        _request: RemovePluginRuntimeWorkspaceRequest,
     ) -> ProviderResult<()> {
         Err(crate::Error::unimplemented(
             "runtime remove workspace is not implemented",
@@ -115,8 +345,8 @@ pub trait PluginRuntimeProvider: Send + Sync + 'static {
     /// Starts one hosted plugin process inside a runtime session.
     async fn start_plugin(
         &self,
-        _request: pb::StartHostedPluginRequest,
-    ) -> ProviderResult<pb::HostedPlugin> {
+        _request: StartHostedPluginRequest,
+    ) -> ProviderResult<HostedPlugin> {
         Err(crate::Error::unimplemented(
             "runtime start plugin is not implemented",
         ))
@@ -148,7 +378,7 @@ where
             .get_support(request.into_inner())
             .await
             .map_err(|error| rpc_status("runtime get support", error))?;
-        Ok(GrpcResponse::new(support))
+        Ok(GrpcResponse::new(support_to_proto(support)))
     }
 
     async fn start_session(
@@ -157,10 +387,10 @@ where
     ) -> std::result::Result<GrpcResponse<pb::PluginRuntimeSession>, Status> {
         let session = self
             .provider
-            .start_session(request.into_inner())
+            .start_session(start_session_request_from_proto(request.into_inner()))
             .await
             .map_err(|error| rpc_status("runtime start session", error))?;
-        Ok(GrpcResponse::new(session))
+        Ok(GrpcResponse::new(session_to_proto(session)))
     }
 
     async fn get_session(
@@ -169,10 +399,15 @@ where
     ) -> std::result::Result<GrpcResponse<pb::PluginRuntimeSession>, Status> {
         let session = self
             .provider
-            .get_session(request.into_inner())
+            .get_session({
+                let request = request.into_inner();
+                GetPluginRuntimeSessionRequest {
+                    session_id: request.session_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("runtime get session", error))?;
-        Ok(GrpcResponse::new(session))
+        Ok(GrpcResponse::new(session_to_proto(session)))
     }
 
     async fn list_sessions(
@@ -181,10 +416,13 @@ where
     ) -> std::result::Result<GrpcResponse<pb::ListPluginRuntimeSessionsResponse>, Status> {
         let response = self
             .provider
-            .list_sessions(request.into_inner())
+            .list_sessions({
+                let _request = request.into_inner();
+                ListPluginRuntimeSessionsRequest {}
+            })
             .await
             .map_err(|error| rpc_status("runtime list sessions", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(list_sessions_response_to_proto(response)))
     }
 
     async fn stop_session(
@@ -192,7 +430,12 @@ where
         request: GrpcRequest<pb::StopPluginRuntimeSessionRequest>,
     ) -> std::result::Result<GrpcResponse<()>, Status> {
         self.provider
-            .stop_session(request.into_inner())
+            .stop_session({
+                let request = request.into_inner();
+                StopPluginRuntimeSessionRequest {
+                    session_id: request.session_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("runtime stop session", error))?;
         Ok(GrpcResponse::new(()))
@@ -204,10 +447,12 @@ where
     ) -> std::result::Result<GrpcResponse<pb::PreparePluginRuntimeWorkspaceResponse>, Status> {
         let response = self
             .provider
-            .prepare_workspace(request.into_inner())
+            .prepare_workspace(prepare_workspace_request_from_proto(request.into_inner()))
             .await
             .map_err(|error| rpc_status("runtime prepare workspace", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(prepare_workspace_response_to_proto(
+            response,
+        )))
     }
 
     async fn remove_workspace(
@@ -215,7 +460,13 @@ where
         request: GrpcRequest<pb::RemovePluginRuntimeWorkspaceRequest>,
     ) -> std::result::Result<GrpcResponse<()>, Status> {
         self.provider
-            .remove_workspace(request.into_inner())
+            .remove_workspace({
+                let request = request.into_inner();
+                RemovePluginRuntimeWorkspaceRequest {
+                    session_id: request.session_id,
+                    agent_session_id: request.agent_session_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("runtime remove workspace", error))?;
         Ok(GrpcResponse::new(()))
@@ -227,9 +478,9 @@ where
     ) -> std::result::Result<GrpcResponse<pb::HostedPlugin>, Status> {
         let plugin = self
             .provider
-            .start_plugin(request.into_inner())
+            .start_plugin(start_plugin_request_from_proto(request.into_inner()))
             .await
             .map_err(|error| rpc_status("runtime start plugin", error))?;
-        Ok(GrpcResponse::new(plugin))
+        Ok(GrpcResponse::new(hosted_plugin_to_proto(plugin)))
     }
 }

--- a/sdk/rust/src/runtime_log_host.rs
+++ b/sdk/rust/src/runtime_log_host.rs
@@ -24,8 +24,72 @@ pub const ENV_RUNTIME_LOG_HOST_SOCKET_TOKEN: &str = "GESTALT_RUNTIME_LOG_SOCKET_
 pub const ENV_RUNTIME_SESSION_ID: &str = "GESTALT_RUNTIME_SESSION_ID";
 const RUNTIME_LOG_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
-/// Runtime log stream enum generated from the provider protocol.
-pub type RuntimeLogStream = pb::PluginRuntimeLogStream;
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[repr(i32)]
+/// Runtime log stream for plugin-runtime log entries.
+pub enum RuntimeLogStream {
+    #[default]
+    Unspecified = 0,
+    Stdout = 1,
+    Stderr = 2,
+    Runtime = 3,
+}
+
+impl RuntimeLogStream {
+    const fn as_i32(self) -> i32 {
+        self as i32
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// One plugin-runtime log entry.
+pub struct PluginRuntimeLogEntry {
+    pub stream: RuntimeLogStream,
+    pub message: String,
+    pub observed_at: SystemTime,
+    pub source_seq: i64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Request for appending plugin-runtime logs.
+pub struct AppendPluginRuntimeLogsRequest {
+    pub session_id: String,
+    pub logs: Vec<PluginRuntimeLogEntry>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+/// Response returned after appending plugin-runtime logs.
+pub struct AppendPluginRuntimeLogsResponse {
+    pub last_seq: i64,
+}
+
+fn append_logs_request_to_proto(
+    request: AppendPluginRuntimeLogsRequest,
+) -> pb::AppendPluginRuntimeLogsRequest {
+    pb::AppendPluginRuntimeLogsRequest {
+        session_id: request.session_id,
+        logs: request
+            .logs
+            .into_iter()
+            .map(|entry| pb::PluginRuntimeLogEntry {
+                stream: entry.stream.as_i32(),
+                message: entry.message,
+                observed_at: Some(crate::protocol::timestamp_from_system_time(
+                    entry.observed_at,
+                )),
+                source_seq: entry.source_seq,
+            })
+            .collect(),
+    }
+}
+
+fn append_logs_response_from_proto(
+    response: pb::AppendPluginRuntimeLogsResponse,
+) -> AppendPluginRuntimeLogsResponse {
+    AppendPluginRuntimeLogsResponse {
+        last_seq: response.last_seq,
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 /// Errors returned by [`RuntimeLogHost`].
@@ -88,9 +152,14 @@ impl RuntimeLogHost {
     /// Appends logs using a raw protocol request message.
     pub async fn append_logs(
         &mut self,
-        request: pb::AppendPluginRuntimeLogsRequest,
-    ) -> std::result::Result<pb::AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
-        Ok(self.client.append_logs(request).await?.into_inner())
+        request: AppendPluginRuntimeLogsRequest,
+    ) -> std::result::Result<AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
+        Ok(append_logs_response_from_proto(
+            self.client
+                .append_logs(append_logs_request_to_proto(request))
+                .await?
+                .into_inner(),
+        ))
     }
 
     /// Appends one log entry for an explicit session id.
@@ -99,7 +168,7 @@ impl RuntimeLogHost {
         session_id: impl Into<String>,
         stream: RuntimeLogStream,
         message: impl Into<String>,
-    ) -> std::result::Result<pb::AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
+    ) -> std::result::Result<AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
         self.source_seq += 1;
         let source_seq = self.source_seq;
         self.append_entry(session_id, stream, message, None, source_seq)
@@ -111,7 +180,7 @@ impl RuntimeLogHost {
         &mut self,
         stream: RuntimeLogStream,
         message: impl Into<String>,
-    ) -> std::result::Result<pb::AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
+    ) -> std::result::Result<AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
         self.append(runtime_session_id()?, stream, message).await
     }
 
@@ -121,16 +190,16 @@ impl RuntimeLogHost {
         session_id: impl Into<String>,
         stream: RuntimeLogStream,
         message: impl Into<String>,
-        observed_at: Option<prost_types::Timestamp>,
+        observed_at: Option<SystemTime>,
         source_seq: i64,
-    ) -> std::result::Result<pb::AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
+    ) -> std::result::Result<AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
         self.source_seq = self.source_seq.max(source_seq);
-        self.append_logs(pb::AppendPluginRuntimeLogsRequest {
+        self.append_logs(AppendPluginRuntimeLogsRequest {
             session_id: session_id.into(),
-            logs: vec![pb::PluginRuntimeLogEntry {
-                stream: stream as i32,
+            logs: vec![PluginRuntimeLogEntry {
+                stream,
                 message: message.into(),
-                observed_at: Some(observed_at.unwrap_or_else(timestamp_now)),
+                observed_at: observed_at.unwrap_or_else(SystemTime::now),
                 source_seq,
             }],
         })
@@ -142,9 +211,9 @@ impl RuntimeLogHost {
         &mut self,
         stream: RuntimeLogStream,
         message: impl Into<String>,
-        observed_at: Option<prost_types::Timestamp>,
+        observed_at: Option<SystemTime>,
         source_seq: i64,
-    ) -> std::result::Result<pb::AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
+    ) -> std::result::Result<AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
         self.append_entry(
             runtime_session_id()?,
             stream,
@@ -160,7 +229,7 @@ impl RuntimeLogHost {
         &mut self,
         session_id: impl Into<String>,
         message: impl Into<String>,
-    ) -> std::result::Result<pb::AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
+    ) -> std::result::Result<AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
         self.append(session_id, RuntimeLogStream::Stdout, message)
             .await
     }
@@ -169,7 +238,7 @@ impl RuntimeLogHost {
     pub async fn append_current_stdout(
         &mut self,
         message: impl Into<String>,
-    ) -> std::result::Result<pb::AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
+    ) -> std::result::Result<AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
         self.append_current(RuntimeLogStream::Stdout, message).await
     }
 
@@ -178,7 +247,7 @@ impl RuntimeLogHost {
         &mut self,
         session_id: impl Into<String>,
         message: impl Into<String>,
-    ) -> std::result::Result<pb::AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
+    ) -> std::result::Result<AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
         self.append(session_id, RuntimeLogStream::Stderr, message)
             .await
     }
@@ -187,7 +256,7 @@ impl RuntimeLogHost {
     pub async fn append_current_stderr(
         &mut self,
         message: impl Into<String>,
-    ) -> std::result::Result<pb::AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
+    ) -> std::result::Result<AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
         self.append_current(RuntimeLogStream::Stderr, message).await
     }
 
@@ -196,7 +265,7 @@ impl RuntimeLogHost {
         &mut self,
         session_id: impl Into<String>,
         message: impl Into<String>,
-    ) -> std::result::Result<pb::AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
+    ) -> std::result::Result<AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
         self.append(session_id, RuntimeLogStream::Runtime, message)
             .await
     }
@@ -205,7 +274,7 @@ impl RuntimeLogHost {
     pub async fn append_current_runtime(
         &mut self,
         message: impl Into<String>,
-    ) -> std::result::Result<pb::AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
+    ) -> std::result::Result<AppendPluginRuntimeLogsResponse, RuntimeLogHostError> {
         self.append_current(RuntimeLogStream::Runtime, message)
             .await
     }
@@ -308,8 +377,4 @@ pub fn runtime_session_id() -> std::result::Result<String, RuntimeLogHostError> 
         )));
     }
     Ok(session_id)
-}
-
-fn timestamp_now() -> prost_types::Timestamp {
-    crate::protocol::timestamp_from_system_time(SystemTime::now())
 }

--- a/sdk/rust/src/s3.rs
+++ b/sdk/rust/src/s3.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use hyper_util::rt::TokioIo;
 use serde::de::DeserializeOwned;
@@ -21,15 +21,45 @@ use crate::generated::v1::{
     self as pb, s3_client::S3Client as ProtoS3Client,
     s3_object_access_client::S3ObjectAccessClient as ProtoS3ObjectAccessClient,
 };
+use crate::protocol;
 use crate::rpc_status::rpc_status;
 
 type ClientResult<T> = std::result::Result<T, S3Error>;
 type S3Transport = InterceptedService<Channel, RelayTokenInterceptor>;
 /// Server-streamed object read chunks returned by [`S3Provider::read_object`].
 pub type S3ReadObjectStream =
-    Pin<Box<dyn Stream<Item = ProviderResult<pb::ReadObjectChunk>> + Send + 'static>>;
+    Pin<Box<dyn Stream<Item = ProviderResult<S3ReadObjectFrame>> + Send + 'static>>;
 type S3RpcReadObjectStream =
     Pin<Box<dyn Stream<Item = std::result::Result<pb::ReadObjectChunk, Status>> + Send + 'static>>;
+
+#[derive(Clone, Debug, PartialEq)]
+/// One frame in a provider-authored object read stream.
+pub enum S3ReadObjectFrame {
+    Meta(ObjectMeta),
+    Data(Vec<u8>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+/// One frame in a host-provided object write stream.
+pub enum S3WriteObjectFrame {
+    Open(Box<S3WriteObjectOpen>),
+    Data(Vec<u8>),
+    Empty,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+/// Metadata frame that starts an object write stream.
+pub struct S3WriteObjectOpen {
+    pub reference: Option<ObjectRef>,
+    pub content_type: String,
+    pub cache_control: String,
+    pub content_disposition: String,
+    pub content_encoding: String,
+    pub content_language: String,
+    pub metadata: BTreeMap<String, String>,
+    pub if_match: String,
+    pub if_none_match: String,
+}
 
 /// Client-streamed object write chunks passed to [`S3Provider::write_object`].
 pub struct S3WriteObjectStream {
@@ -42,20 +72,22 @@ impl S3WriteObjectStream {
     }
 
     /// Reads the next write request frame from the upload stream.
-    pub async fn message(&mut self) -> ProviderResult<Option<pb::WriteObjectRequest>> {
+    pub async fn message(&mut self) -> ProviderResult<Option<S3WriteObjectFrame>> {
         self.inner
             .message()
             .await
-            .map_err(|error| crate::Error::new(error.to_string()))
+            .map_err(|error| crate::Error::new(error.to_string()))?
+            .map(write_object_frame_from_proto)
+            .transpose()
     }
 }
 
 /// Default Unix-socket environment variable used by [`S3::connect`].
 pub const ENV_S3_SOCKET: &str = "GESTALT_S3_SOCKET";
 /// Suffix added to named S3 socket variables for relay-token variables.
-pub const ENV_S3_SOCKET_TOKEN_SUFFIX: &str = "_TOKEN";
+const ENV_S3_SOCKET_TOKEN_SUFFIX: &str = "_TOKEN";
 /// Default relay-token environment variable used by [`S3::connect`].
-pub const ENV_S3_SOCKET_TOKEN: &str = "GESTALT_S3_SOCKET_TOKEN";
+const ENV_S3_SOCKET_TOKEN: &str = "GESTALT_S3_SOCKET_TOKEN";
 const S3_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 const WRITE_CHUNK_SIZE: usize = 64 * 1024;
 
@@ -114,7 +146,7 @@ pub struct ObjectMeta {
     /// MIME content type.
     pub content_type: String,
     /// Last-modified timestamp, when known.
-    pub last_modified: Option<prost_types::Timestamp>,
+    pub last_modified: Option<SystemTime>,
     /// User metadata associated with the object.
     pub metadata: BTreeMap<String, String>,
     /// Storage class reported by the provider.
@@ -140,9 +172,9 @@ pub struct ReadOptions {
     /// Read only if the current ETag does not match this value.
     pub if_none_match: String,
     /// Read only if the object has changed since this timestamp.
-    pub if_modified_since: Option<prost_types::Timestamp>,
+    pub if_modified_since: Option<SystemTime>,
     /// Read only if the object has not changed since this timestamp.
-    pub if_unmodified_since: Option<prost_types::Timestamp>,
+    pub if_unmodified_since: Option<SystemTime>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -244,8 +276,98 @@ pub struct PresignResult {
     /// HTTP method clients should use.
     pub method: PresignMethod,
     /// Expiration timestamp, when known.
-    pub expires_at: Option<prost_types::Timestamp>,
+    pub expires_at: Option<SystemTime>,
     /// Headers clients must send with the URL.
+    pub headers: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Fetches metadata for one object.
+pub struct HeadObjectRequest {
+    pub reference: Option<ObjectRef>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+/// Returns object metadata.
+pub struct HeadObjectResponse {
+    pub meta: Option<ObjectMeta>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+/// Opens a streaming object read.
+pub struct ReadObjectRequest {
+    pub reference: Option<ObjectRef>,
+    pub range: Option<ByteRange>,
+    pub if_match: String,
+    pub if_none_match: String,
+    pub if_modified_since: Option<SystemTime>,
+    pub if_unmodified_since: Option<SystemTime>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+/// Returns metadata for a committed object write.
+pub struct WriteObjectResponse {
+    pub meta: Option<ObjectMeta>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Deletes one object.
+pub struct DeleteObjectRequest {
+    pub reference: Option<ObjectRef>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Lists objects in a bucket.
+pub struct ListObjectsRequest {
+    pub bucket: String,
+    pub prefix: String,
+    pub delimiter: String,
+    pub continuation_token: String,
+    pub start_after: String,
+    pub max_keys: i32,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+/// One page of list-objects results.
+pub struct ListObjectsResponse {
+    pub objects: Vec<ObjectMeta>,
+    pub common_prefixes: Vec<String>,
+    pub next_continuation_token: String,
+    pub has_more: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Copies one object to another location.
+pub struct CopyObjectRequest {
+    pub source: Option<ObjectRef>,
+    pub destination: Option<ObjectRef>,
+    pub if_match: String,
+    pub if_none_match: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+/// Returns metadata for a copied object.
+pub struct CopyObjectResponse {
+    pub meta: Option<ObjectMeta>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Asks the provider to mint a presigned URL.
+pub struct PresignObjectRequest {
+    pub reference: Option<ObjectRef>,
+    pub method: PresignMethod,
+    pub expires: Duration,
+    pub content_type: String,
+    pub content_disposition: String,
+    pub headers: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+/// Returns a presigned URL plus required headers.
+pub struct PresignObjectResponse {
+    pub url: String,
+    pub method: PresignMethod,
+    pub expires_at: Option<SystemTime>,
     pub headers: BTreeMap<String, String>,
 }
 
@@ -292,20 +414,14 @@ pub trait S3Provider: Send + Sync + 'static {
     }
 
     /// Returns object metadata without reading the object body.
-    async fn head_object(
-        &self,
-        _request: pb::HeadObjectRequest,
-    ) -> ProviderResult<pb::HeadObjectResponse> {
+    async fn head_object(&self, _request: HeadObjectRequest) -> ProviderResult<HeadObjectResponse> {
         Err(crate::Error::unimplemented(
             "s3 head object is not implemented",
         ))
     }
 
     /// Streams object metadata followed by object data chunks.
-    async fn read_object(
-        &self,
-        _request: pb::ReadObjectRequest,
-    ) -> ProviderResult<S3ReadObjectStream> {
+    async fn read_object(&self, _request: ReadObjectRequest) -> ProviderResult<S3ReadObjectStream> {
         Err(crate::Error::unimplemented(
             "s3 read object is not implemented",
         ))
@@ -315,14 +431,14 @@ pub trait S3Provider: Send + Sync + 'static {
     async fn write_object(
         &self,
         _request: S3WriteObjectStream,
-    ) -> ProviderResult<pb::WriteObjectResponse> {
+    ) -> ProviderResult<WriteObjectResponse> {
         Err(crate::Error::unimplemented(
             "s3 write object is not implemented",
         ))
     }
 
     /// Deletes one object or object version.
-    async fn delete_object(&self, _request: pb::DeleteObjectRequest) -> ProviderResult<()> {
+    async fn delete_object(&self, _request: DeleteObjectRequest) -> ProviderResult<()> {
         Err(crate::Error::unimplemented(
             "s3 delete object is not implemented",
         ))
@@ -331,18 +447,15 @@ pub trait S3Provider: Send + Sync + 'static {
     /// Lists objects in a bucket using S3-style pagination and delimiters.
     async fn list_objects(
         &self,
-        _request: pb::ListObjectsRequest,
-    ) -> ProviderResult<pb::ListObjectsResponse> {
+        _request: ListObjectsRequest,
+    ) -> ProviderResult<ListObjectsResponse> {
         Err(crate::Error::unimplemented(
             "s3 list objects is not implemented",
         ))
     }
 
     /// Copies one object to another object reference.
-    async fn copy_object(
-        &self,
-        _request: pb::CopyObjectRequest,
-    ) -> ProviderResult<pb::CopyObjectResponse> {
+    async fn copy_object(&self, _request: CopyObjectRequest) -> ProviderResult<CopyObjectResponse> {
         Err(crate::Error::unimplemented(
             "s3 copy object is not implemented",
         ))
@@ -351,8 +464,8 @@ pub trait S3Provider: Send + Sync + 'static {
     /// Creates a presigned URL for direct object access.
     async fn presign_object(
         &self,
-        _request: pb::PresignObjectRequest,
-    ) -> ProviderResult<pb::PresignObjectResponse> {
+        _request: PresignObjectRequest,
+    ) -> ProviderResult<PresignObjectResponse> {
         Err(crate::Error::unimplemented(
             "s3 presign object is not implemented",
         ))
@@ -383,10 +496,13 @@ where
     ) -> std::result::Result<GrpcResponse<pb::HeadObjectResponse>, Status> {
         let response = self
             .provider
-            .head_object(request.into_inner())
+            .head_object(head_object_request_from_proto(request.into_inner()))
             .await
             .map_err(|error| rpc_status("s3 head object", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(
+            head_object_response_to_proto(response)
+                .map_err(|error| rpc_status("s3 head object", error))?,
+        ))
     }
 
     async fn read_object(
@@ -395,10 +511,17 @@ where
     ) -> std::result::Result<GrpcResponse<Self::ReadObjectStream>, Status> {
         let stream = self
             .provider
-            .read_object(request.into_inner())
+            .read_object(
+                read_object_request_from_proto(request.into_inner())
+                    .map_err(|error| rpc_status("s3 read object", error))?,
+            )
             .await
             .map_err(|error| rpc_status("s3 read object", error))?
-            .map(|chunk| chunk.map_err(|error| rpc_status("s3 read object stream", error)));
+            .map(|chunk| {
+                chunk
+                    .and_then(read_object_frame_to_proto)
+                    .map_err(|error| rpc_status("s3 read object stream", error))
+            });
         Ok(GrpcResponse::new(Box::pin(stream)))
     }
 
@@ -411,7 +534,10 @@ where
             .write_object(S3WriteObjectStream::new(request.into_inner()))
             .await
             .map_err(|error| rpc_status("s3 write object", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(
+            write_object_response_to_proto(response)
+                .map_err(|error| rpc_status("s3 write object", error))?,
+        ))
     }
 
     async fn delete_object(
@@ -419,7 +545,7 @@ where
         request: GrpcRequest<pb::DeleteObjectRequest>,
     ) -> std::result::Result<GrpcResponse<()>, Status> {
         self.provider
-            .delete_object(request.into_inner())
+            .delete_object(delete_object_request_from_proto(request.into_inner()))
             .await
             .map_err(|error| rpc_status("s3 delete object", error))?;
         Ok(GrpcResponse::new(()))
@@ -431,10 +557,13 @@ where
     ) -> std::result::Result<GrpcResponse<pb::ListObjectsResponse>, Status> {
         let response = self
             .provider
-            .list_objects(request.into_inner())
+            .list_objects(list_objects_request_from_proto(request.into_inner()))
             .await
             .map_err(|error| rpc_status("s3 list objects", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(
+            list_objects_response_to_proto(response)
+                .map_err(|error| rpc_status("s3 list objects", error))?,
+        ))
     }
 
     async fn copy_object(
@@ -443,10 +572,13 @@ where
     ) -> std::result::Result<GrpcResponse<pb::CopyObjectResponse>, Status> {
         let response = self
             .provider
-            .copy_object(request.into_inner())
+            .copy_object(copy_object_request_from_proto(request.into_inner()))
             .await
             .map_err(|error| rpc_status("s3 copy object", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(
+            copy_object_response_to_proto(response)
+                .map_err(|error| rpc_status("s3 copy object", error))?,
+        ))
     }
 
     async fn presign_object(
@@ -455,10 +587,12 @@ where
     ) -> std::result::Result<GrpcResponse<pb::PresignObjectResponse>, Status> {
         let response = self
             .provider
-            .presign_object(request.into_inner())
+            .presign_object(presign_object_request_from_proto(request.into_inner()))
             .await
             .map_err(|error| rpc_status("s3 presign object", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(presign_object_response_to_proto(
+            response,
+        )))
     }
 }
 
@@ -569,8 +703,12 @@ impl S3 {
                 range: options.range.map(byte_range_to_proto),
                 if_match: options.if_match,
                 if_none_match: options.if_none_match,
-                if_modified_since: options.if_modified_since,
-                if_unmodified_since: options.if_unmodified_since,
+                if_modified_since: options
+                    .if_modified_since
+                    .map(protocol::timestamp_from_system_time),
+                if_unmodified_since: options
+                    .if_unmodified_since
+                    .map(protocol::timestamp_from_system_time),
             })
             .await
             .map_err(map_status)?
@@ -582,7 +720,7 @@ impl S3 {
             })?;
 
         let meta = match first.result {
-            Some(pb::read_object_chunk::Result::Meta(meta)) => object_meta_from_proto(meta),
+            Some(pb::read_object_chunk::Result::Meta(meta)) => object_meta_from_proto(meta)?,
             Some(pb::read_object_chunk::Result::Data(_)) => {
                 return Err(S3Error::Protocol(
                     "read stream started with data instead of metadata".to_string(),
@@ -716,7 +854,7 @@ impl S3 {
             })
             .await
             .map_err(map_status)?;
-        Ok(list_page_from_proto(response.into_inner()))
+        list_page_from_proto(response.into_inner())
     }
 
     /// Copies one object to another location.
@@ -763,10 +901,7 @@ impl S3 {
             })
             .await
             .map_err(map_status)?;
-        Ok(presign_result_from_proto(
-            response.into_inner(),
-            options.method,
-        ))
+        presign_result_from_proto(response.into_inner(), options.method)
     }
 
     /// Creates a host-mediated object-access URL.
@@ -789,10 +924,7 @@ impl S3 {
             })
             .await
             .map_err(map_status)?;
-        Ok(object_access_url_from_proto(
-            response.into_inner(),
-            options.method,
-        ))
+        object_access_url_from_proto(response.into_inner(), options.method)
     }
 
     /// Alias for [`S3::create_object_access_url`].
@@ -1158,28 +1290,46 @@ fn object_ref_to_proto(reference: ObjectRef) -> pb::S3ObjectRef {
     }
 }
 
-fn object_meta_from_proto(meta: pb::S3ObjectMeta) -> ObjectMeta {
-    ObjectMeta {
-        reference: meta
-            .r#ref
-            .map(|reference| ObjectRef {
-                bucket: reference.bucket,
-                key: reference.key,
-                version_id: reference.version_id,
-            })
-            .unwrap_or_default(),
+fn object_ref_from_proto(reference: pb::S3ObjectRef) -> ObjectRef {
+    ObjectRef {
+        bucket: reference.bucket,
+        key: reference.key,
+        version_id: reference.version_id,
+    }
+}
+
+fn object_meta_to_proto(meta: ObjectMeta) -> ProviderResult<pb::S3ObjectMeta> {
+    Ok(pb::S3ObjectMeta {
+        r#ref: Some(object_ref_to_proto(meta.reference)),
         etag: meta.etag,
         size: meta.size,
         content_type: meta.content_type,
-        last_modified: meta.last_modified,
+        last_modified: meta.last_modified.map(protocol::timestamp_from_system_time),
         metadata: meta.metadata,
         storage_class: meta.storage_class,
-    }
+    })
+}
+
+fn object_meta_from_proto(meta: pb::S3ObjectMeta) -> ClientResult<ObjectMeta> {
+    Ok(ObjectMeta {
+        reference: meta.r#ref.map(object_ref_from_proto).unwrap_or_default(),
+        etag: meta.etag,
+        size: meta.size,
+        content_type: meta.content_type,
+        last_modified: meta
+            .last_modified
+            .as_ref()
+            .map(protocol::system_time_from_timestamp)
+            .transpose()
+            .map_err(|error| S3Error::Protocol(error.to_string()))?,
+        metadata: meta.metadata,
+        storage_class: meta.storage_class,
+    })
 }
 
 fn required_object_meta(meta: Option<pb::S3ObjectMeta>, context: &str) -> ClientResult<ObjectMeta> {
     let meta = meta.ok_or_else(|| S3Error::Protocol(context.to_string()))?;
-    Ok(object_meta_from_proto(meta))
+    object_meta_from_proto(meta)
 }
 
 fn byte_range_to_proto(range: ByteRange) -> pb::ByteRange {
@@ -1189,16 +1339,167 @@ fn byte_range_to_proto(range: ByteRange) -> pb::ByteRange {
     }
 }
 
-fn list_page_from_proto(page: pb::ListObjectsResponse) -> ListPage {
-    ListPage {
+fn list_page_from_proto(page: pb::ListObjectsResponse) -> ClientResult<ListPage> {
+    Ok(ListPage {
         objects: page
             .objects
             .into_iter()
             .map(object_meta_from_proto)
-            .collect(),
+            .collect::<ClientResult<Vec<_>>>()?,
         common_prefixes: page.common_prefixes,
         next_continuation_token: page.next_continuation_token,
         has_more: page.has_more,
+    })
+}
+
+fn head_object_request_from_proto(request: pb::HeadObjectRequest) -> HeadObjectRequest {
+    HeadObjectRequest {
+        reference: request.r#ref.map(object_ref_from_proto),
+    }
+}
+
+fn head_object_response_to_proto(
+    response: HeadObjectResponse,
+) -> ProviderResult<pb::HeadObjectResponse> {
+    Ok(pb::HeadObjectResponse {
+        meta: response.meta.map(object_meta_to_proto).transpose()?,
+    })
+}
+
+fn read_object_request_from_proto(
+    request: pb::ReadObjectRequest,
+) -> ProviderResult<ReadObjectRequest> {
+    Ok(ReadObjectRequest {
+        reference: request.r#ref.map(object_ref_from_proto),
+        range: request.range.map(|range| ByteRange {
+            start: range.start,
+            end: range.end,
+        }),
+        if_match: request.if_match,
+        if_none_match: request.if_none_match,
+        if_modified_since: request
+            .if_modified_since
+            .as_ref()
+            .map(protocol::system_time_from_timestamp)
+            .transpose()?,
+        if_unmodified_since: request
+            .if_unmodified_since
+            .as_ref()
+            .map(protocol::system_time_from_timestamp)
+            .transpose()?,
+    })
+}
+
+fn read_object_frame_to_proto(frame: S3ReadObjectFrame) -> ProviderResult<pb::ReadObjectChunk> {
+    let result = match frame {
+        S3ReadObjectFrame::Meta(meta) => {
+            pb::read_object_chunk::Result::Meta(object_meta_to_proto(meta)?)
+        }
+        S3ReadObjectFrame::Data(data) => pb::read_object_chunk::Result::Data(data),
+    };
+    Ok(pb::ReadObjectChunk {
+        result: Some(result),
+    })
+}
+
+fn write_object_frame_from_proto(
+    frame: pb::WriteObjectRequest,
+) -> ProviderResult<S3WriteObjectFrame> {
+    Ok(match frame.msg {
+        Some(pb::write_object_request::Msg::Open(open)) => {
+            S3WriteObjectFrame::Open(Box::new(S3WriteObjectOpen {
+                reference: open.r#ref.map(object_ref_from_proto),
+                content_type: open.content_type,
+                cache_control: open.cache_control,
+                content_disposition: open.content_disposition,
+                content_encoding: open.content_encoding,
+                content_language: open.content_language,
+                metadata: open.metadata,
+                if_match: open.if_match,
+                if_none_match: open.if_none_match,
+            }))
+        }
+        Some(pb::write_object_request::Msg::Data(data)) => S3WriteObjectFrame::Data(data),
+        None => S3WriteObjectFrame::Empty,
+    })
+}
+
+fn write_object_response_to_proto(
+    response: WriteObjectResponse,
+) -> ProviderResult<pb::WriteObjectResponse> {
+    Ok(pb::WriteObjectResponse {
+        meta: response.meta.map(object_meta_to_proto).transpose()?,
+    })
+}
+
+fn delete_object_request_from_proto(request: pb::DeleteObjectRequest) -> DeleteObjectRequest {
+    DeleteObjectRequest {
+        reference: request.r#ref.map(object_ref_from_proto),
+    }
+}
+
+fn list_objects_request_from_proto(request: pb::ListObjectsRequest) -> ListObjectsRequest {
+    ListObjectsRequest {
+        bucket: request.bucket,
+        prefix: request.prefix,
+        delimiter: request.delimiter,
+        continuation_token: request.continuation_token,
+        start_after: request.start_after,
+        max_keys: request.max_keys,
+    }
+}
+
+fn list_objects_response_to_proto(
+    response: ListObjectsResponse,
+) -> ProviderResult<pb::ListObjectsResponse> {
+    Ok(pb::ListObjectsResponse {
+        objects: response
+            .objects
+            .into_iter()
+            .map(object_meta_to_proto)
+            .collect::<ProviderResult<Vec<_>>>()?,
+        common_prefixes: response.common_prefixes,
+        next_continuation_token: response.next_continuation_token,
+        has_more: response.has_more,
+    })
+}
+
+fn copy_object_request_from_proto(request: pb::CopyObjectRequest) -> CopyObjectRequest {
+    CopyObjectRequest {
+        source: request.source.map(object_ref_from_proto),
+        destination: request.destination.map(object_ref_from_proto),
+        if_match: request.if_match,
+        if_none_match: request.if_none_match,
+    }
+}
+
+fn copy_object_response_to_proto(
+    response: CopyObjectResponse,
+) -> ProviderResult<pb::CopyObjectResponse> {
+    Ok(pb::CopyObjectResponse {
+        meta: response.meta.map(object_meta_to_proto).transpose()?,
+    })
+}
+
+fn presign_object_request_from_proto(request: pb::PresignObjectRequest) -> PresignObjectRequest {
+    PresignObjectRequest {
+        reference: request.r#ref.map(object_ref_from_proto),
+        method: presign_method_from_proto(request.method),
+        expires: Duration::from_secs(u64::try_from(request.expires_seconds).unwrap_or_default()),
+        content_type: request.content_type,
+        content_disposition: request.content_disposition,
+        headers: request.headers,
+    }
+}
+
+fn presign_object_response_to_proto(response: PresignObjectResponse) -> pb::PresignObjectResponse {
+    pb::PresignObjectResponse {
+        url: response.url,
+        method: presign_method_to_proto(response.method) as i32,
+        expires_at: response
+            .expires_at
+            .map(protocol::timestamp_from_system_time),
+        headers: response.headers,
     }
 }
 
@@ -1225,35 +1526,45 @@ fn presign_method_from_proto(method: i32) -> PresignMethod {
 fn presign_result_from_proto(
     result: pb::PresignObjectResponse,
     requested_method: PresignMethod,
-) -> PresignResult {
+) -> ClientResult<PresignResult> {
     let method = presign_method_from_proto(result.method);
-    PresignResult {
+    Ok(PresignResult {
         url: result.url,
         method: if method == PresignMethod::Unspecified {
             requested_method
         } else {
             method
         },
-        expires_at: result.expires_at,
+        expires_at: result
+            .expires_at
+            .as_ref()
+            .map(protocol::system_time_from_timestamp)
+            .transpose()
+            .map_err(|error| S3Error::Protocol(error.to_string()))?,
         headers: result.headers,
-    }
+    })
 }
 
 fn object_access_url_from_proto(
     result: pb::CreateObjectAccessUrlResponse,
     requested_method: PresignMethod,
-) -> ObjectAccessURL {
+) -> ClientResult<ObjectAccessURL> {
     let method = presign_method_from_proto(result.method);
-    ObjectAccessURL {
+    Ok(ObjectAccessURL {
         url: result.url,
         method: if method == PresignMethod::Unspecified {
             requested_method
         } else {
             method
         },
-        expires_at: result.expires_at,
+        expires_at: result
+            .expires_at
+            .as_ref()
+            .map(protocol::system_time_from_timestamp)
+            .transpose()
+            .map_err(|error| S3Error::Protocol(error.to_string()))?,
         headers: result.headers,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -1273,8 +1584,8 @@ mod tests {
     impl S3Provider for HiddenErrorS3Provider {
         async fn head_object(
             &self,
-            _request: pb::HeadObjectRequest,
-        ) -> ProviderResult<pb::HeadObjectResponse> {
+            _request: HeadObjectRequest,
+        ) -> ProviderResult<HeadObjectResponse> {
             Err(crate::Error::hidden_internal("backend detail"))
         }
     }

--- a/sdk/rust/src/workflow.rs
+++ b/sdk/rust/src/workflow.rs
@@ -13,7 +13,11 @@ use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 use tower::service_fn;
 
-use crate::agent::{AgentMessageInput, AgentToolRefInput, new_agent_messages, new_agent_tool_refs};
+use crate::agent::{
+    AgentMessage, AgentMessageInput, AgentToolRef, AgentToolRefInput, agent_tool_ref_from_proto,
+    agent_tool_ref_to_proto, message_from_proto, message_to_proto, new_agent_message,
+    new_agent_tool_ref,
+};
 use crate::api::RuntimeMetadata;
 use crate::error::Error;
 use crate::error::Result as ProviderResult;
@@ -30,6 +34,318 @@ pub const ENV_WORKFLOW_HOST_SOCKET: &str = "GESTALT_WORKFLOW_HOST_SOCKET";
 /// Environment variable containing the optional workflow-host relay token.
 pub const ENV_WORKFLOW_HOST_SOCKET_TOKEN: &str = "GESTALT_WORKFLOW_HOST_SOCKET_TOKEN";
 const WORKFLOW_HOST_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
+
+/// Native JSON object used by authored workflow providers.
+pub type WorkflowJson = serde_json::Value;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[repr(i32)]
+pub enum WorkflowRunStatus {
+    #[default]
+    Unspecified = 0,
+    Pending = 1,
+    Running = 2,
+    Succeeded = 3,
+    Failed = 4,
+    Canceled = 5,
+}
+
+impl WorkflowRunStatus {
+    pub const fn as_i32(self) -> i32 {
+        self as i32
+    }
+
+    pub const fn from_i32_lossy(value: i32) -> Self {
+        match value {
+            1 => Self::Pending,
+            2 => Self::Running,
+            3 => Self::Succeeded,
+            4 => Self::Failed,
+            5 => Self::Canceled,
+            _ => Self::Unspecified,
+        }
+    }
+}
+
+impl TryFrom<i32> for WorkflowRunStatus {
+    type Error = crate::Error;
+
+    fn try_from(value: i32) -> ProviderResult<Self> {
+        match value {
+            0 => Ok(Self::Unspecified),
+            1 => Ok(Self::Pending),
+            2 => Ok(Self::Running),
+            3 => Ok(Self::Succeeded),
+            4 => Ok(Self::Failed),
+            5 => Ok(Self::Canceled),
+            _ => Err(crate::Error::bad_request(format!(
+                "unknown workflow run status {value}"
+            ))),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BoundWorkflowPluginTarget {
+    pub plugin_name: String,
+    pub operation: String,
+    pub input: Option<WorkflowJson>,
+    pub connection: String,
+    pub instance: String,
+    pub credential_mode: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum WorkflowOutputValueSource {
+    #[default]
+    Empty,
+    AgentOutput(String),
+    SignalPayload(String),
+    SignalMetadata(String),
+    Literal(WorkflowJson),
+    AgentSession(String),
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct WorkflowOutputBinding {
+    pub input_field: String,
+    pub value: Option<WorkflowOutputValueSource>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct WorkflowOutputDelivery {
+    pub target: Option<BoundWorkflowPluginTarget>,
+    pub input_bindings: Vec<WorkflowOutputBinding>,
+    pub credential_mode: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BoundWorkflowAgentTarget {
+    pub provider_name: String,
+    pub model: String,
+    pub prompt: String,
+    pub messages: Vec<AgentMessage>,
+    pub tool_refs: Vec<AgentToolRef>,
+    pub response_schema: Option<WorkflowJson>,
+    pub metadata: Option<WorkflowJson>,
+    pub timeout_seconds: i32,
+    pub output_delivery: Option<WorkflowOutputDelivery>,
+    pub model_options: Option<WorkflowJson>,
+    pub session_ready_delivery: Option<WorkflowOutputDelivery>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+#[allow(clippy::large_enum_variant)]
+pub enum BoundWorkflowTarget {
+    #[default]
+    Empty,
+    Plugin(BoundWorkflowPluginTarget),
+    Agent(BoundWorkflowAgentTarget),
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkflowActor {
+    pub subject_id: String,
+    pub subject_kind: String,
+    pub display_name: String,
+    pub auth_source: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkflowRunAsSubject {
+    pub subject_id: String,
+    pub subject_kind: String,
+    pub display_name: String,
+    pub auth_source: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkflowAccessPermission {
+    pub plugin: String,
+    pub operations: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct WorkflowEvent {
+    pub id: String,
+    pub source: String,
+    pub spec_version: String,
+    pub event_type: String,
+    pub subject: String,
+    pub time: Option<SystemTime>,
+    pub datacontenttype: String,
+    pub data: Option<WorkflowJson>,
+    pub extensions: BTreeMap<String, WorkflowJson>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkflowEventMatch {
+    pub event_type: String,
+    pub source: String,
+    pub subject: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct WorkflowSignal {
+    pub id: String,
+    pub name: String,
+    pub payload: Option<WorkflowJson>,
+    pub metadata: Option<WorkflowJson>,
+    pub created_by: Option<WorkflowActor>,
+    pub created_at: Option<SystemTime>,
+    pub idempotency_key: String,
+    pub sequence: i64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkflowScheduleTrigger {
+    pub schedule_id: String,
+    pub scheduled_for: Option<SystemTime>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct WorkflowEventTriggerInvocation {
+    pub trigger_id: String,
+    pub event: Option<WorkflowEvent>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum WorkflowRunTrigger {
+    #[default]
+    Empty,
+    Manual,
+    Schedule(WorkflowScheduleTrigger),
+    Event(WorkflowEventTriggerInvocation),
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BoundWorkflowRun {
+    pub id: String,
+    pub status: WorkflowRunStatus,
+    pub target: Option<BoundWorkflowTarget>,
+    pub trigger: Option<WorkflowRunTrigger>,
+    pub created_at: Option<SystemTime>,
+    pub started_at: Option<SystemTime>,
+    pub completed_at: Option<SystemTime>,
+    pub status_message: String,
+    pub result_body: String,
+    pub created_by: Option<WorkflowActor>,
+    pub execution_ref: String,
+    pub workflow_key: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BoundWorkflowSchedule {
+    pub id: String,
+    pub cron: String,
+    pub timezone: String,
+    pub target: Option<BoundWorkflowTarget>,
+    pub paused: bool,
+    pub created_at: Option<SystemTime>,
+    pub updated_at: Option<SystemTime>,
+    pub next_run_at: Option<SystemTime>,
+    pub created_by: Option<WorkflowActor>,
+    pub execution_ref: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BoundWorkflowEventTrigger {
+    pub id: String,
+    pub event_match: Option<WorkflowEventMatch>,
+    pub target: Option<BoundWorkflowTarget>,
+    pub paused: bool,
+    pub created_at: Option<SystemTime>,
+    pub updated_at: Option<SystemTime>,
+    pub created_by: Option<WorkflowActor>,
+    pub execution_ref: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BoundWorkflowDefinition {
+    pub id: String,
+    pub target: Option<BoundWorkflowTarget>,
+    pub created_by: Option<WorkflowActor>,
+    pub created_at: Option<SystemTime>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct WorkflowExecutionReference {
+    pub id: String,
+    pub provider_name: String,
+    pub target: Option<BoundWorkflowTarget>,
+    pub subject_id: String,
+    pub credential_subject_id: String,
+    pub permissions: Vec<WorkflowAccessPermission>,
+    pub created_at: Option<SystemTime>,
+    pub revoked_at: Option<SystemTime>,
+    pub subject_kind: String,
+    pub display_name: String,
+    pub auth_source: String,
+    pub caller_plugin_name: String,
+    pub run_as: Option<WorkflowRunAsSubject>,
+    pub source_definition_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SignalWorkflowRunResponse {
+    pub run: Option<BoundWorkflowRun>,
+    pub signal: Option<WorkflowSignal>,
+    pub started_run: bool,
+    pub workflow_key: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ListWorkflowProviderRunsResponse {
+    pub runs: Vec<BoundWorkflowRun>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ListWorkflowProviderSchedulesResponse {
+    pub schedules: Vec<BoundWorkflowSchedule>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ListWorkflowProviderEventTriggersResponse {
+    pub triggers: Vec<BoundWorkflowEventTrigger>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ListWorkflowExecutionReferencesResponse {
+    pub references: Vec<WorkflowExecutionReference>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ManagedWorkflowSchedule {
+    pub provider_name: String,
+    pub schedule: Option<BoundWorkflowSchedule>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ManagedWorkflowEventTrigger {
+    pub provider_name: String,
+    pub trigger: Option<BoundWorkflowEventTrigger>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ManagedWorkflowDefinition {
+    pub provider_name: String,
+    pub definition: Option<BoundWorkflowDefinition>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ManagedWorkflowRun {
+    pub provider_name: String,
+    pub run: Option<BoundWorkflowRun>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ManagedWorkflowRunSignal {
+    pub provider_name: String,
+    pub run: Option<BoundWorkflowRun>,
+    pub signal: Option<WorkflowSignal>,
+    pub started_run: bool,
+    pub workflow_key: String,
+}
 
 /// Input for a bound plugin workflow target.
 #[derive(Clone, Debug, Default)]
@@ -90,9 +406,9 @@ pub struct BoundWorkflowAgentTargetInput {
     pub provider_name: String,
     pub model: String,
     pub prompt: String,
-    pub messages: Vec<pb::AgentMessage>,
+    pub messages: Vec<AgentMessage>,
     pub message_inputs: Vec<AgentMessageInput>,
-    pub tool_refs: Vec<pb::AgentToolRef>,
+    pub tool_refs: Vec<AgentToolRef>,
     pub tool_ref_inputs: Vec<AgentToolRefInput>,
     pub response_schema: Option<serde_json::Value>,
     pub metadata: Option<serde_json::Value>,
@@ -253,7 +569,7 @@ pub enum WorkflowRunTriggerInput {
 #[derive(Clone, Debug)]
 pub struct BoundWorkflowRunInput {
     pub id: String,
-    pub status: pb::WorkflowRunStatus,
+    pub status: WorkflowRunStatus,
     pub target: Option<BoundWorkflowTargetInput>,
     pub trigger: Option<WorkflowRunTriggerInput>,
     pub created_at: Option<SystemTime>,
@@ -270,7 +586,7 @@ impl Default for BoundWorkflowRunInput {
     fn default() -> Self {
         Self {
             id: String::new(),
-            status: pb::WorkflowRunStatus::Unspecified,
+            status: WorkflowRunStatus::Unspecified,
             target: None,
             trigger: None,
             created_at: None,
@@ -341,6 +657,134 @@ pub struct WorkflowExecutionReferenceInput {
     pub source_definition_id: String,
 }
 
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct StartWorkflowProviderRunRequest {
+    pub target: Option<BoundWorkflowTarget>,
+    pub idempotency_key: String,
+    pub created_by: Option<WorkflowActor>,
+    pub execution_ref: String,
+    pub workflow_key: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GetWorkflowProviderRunRequest {
+    pub run_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ListWorkflowProviderRunsRequest {}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CancelWorkflowProviderRunRequest {
+    pub run_id: String,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SignalWorkflowProviderRunRequest {
+    pub run_id: String,
+    pub signal: Option<WorkflowSignal>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SignalOrStartWorkflowProviderRunRequest {
+    pub workflow_key: String,
+    pub target: Option<BoundWorkflowTarget>,
+    pub idempotency_key: String,
+    pub created_by: Option<WorkflowActor>,
+    pub execution_ref: String,
+    pub signal: Option<WorkflowSignal>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct UpsertWorkflowProviderScheduleRequest {
+    pub schedule_id: String,
+    pub cron: String,
+    pub timezone: String,
+    pub target: Option<BoundWorkflowTarget>,
+    pub paused: bool,
+    pub requested_by: Option<WorkflowActor>,
+    pub execution_ref: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GetWorkflowProviderScheduleRequest {
+    pub schedule_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ListWorkflowProviderSchedulesRequest {}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DeleteWorkflowProviderScheduleRequest {
+    pub schedule_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PauseWorkflowProviderScheduleRequest {
+    pub schedule_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ResumeWorkflowProviderScheduleRequest {
+    pub schedule_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct UpsertWorkflowProviderEventTriggerRequest {
+    pub trigger_id: String,
+    pub event_match: Option<WorkflowEventMatch>,
+    pub target: Option<BoundWorkflowTarget>,
+    pub paused: bool,
+    pub requested_by: Option<WorkflowActor>,
+    pub execution_ref: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GetWorkflowProviderEventTriggerRequest {
+    pub trigger_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ListWorkflowProviderEventTriggersRequest {}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DeleteWorkflowProviderEventTriggerRequest {
+    pub trigger_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PauseWorkflowProviderEventTriggerRequest {
+    pub trigger_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ResumeWorkflowProviderEventTriggerRequest {
+    pub trigger_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PublishWorkflowProviderEventRequest {
+    pub plugin_name: String,
+    pub event: Option<WorkflowEvent>,
+    pub published_by: Option<WorkflowActor>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PutWorkflowExecutionReferenceRequest {
+    pub reference: Option<WorkflowExecutionReference>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GetWorkflowExecutionReferenceRequest {
+    pub id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ListWorkflowExecutionReferencesRequest {
+    pub subject_id: String,
+}
+
 /// Input for invoking a workflow operation through the host service.
 #[derive(Clone, Debug, Default)]
 pub struct InvokeWorkflowOperationInput {
@@ -376,8 +820,8 @@ pub struct InvokeWorkflowOperationResponse {
 }
 
 /// Creates workflow actor metadata.
-pub fn new_workflow_actor(input: WorkflowActorInput) -> pb::WorkflowActor {
-    pb::WorkflowActor {
+pub fn new_workflow_actor(input: WorkflowActorInput) -> WorkflowActor {
+    WorkflowActor {
         subject_id: input.subject_id,
         subject_kind: input.subject_kind,
         display_name: input.display_name,
@@ -386,7 +830,7 @@ pub fn new_workflow_actor(input: WorkflowActorInput) -> pb::WorkflowActor {
 }
 
 /// Returns input copied from workflow actor metadata.
-pub fn workflow_actor_input_from_actor(input: &pb::WorkflowActor) -> WorkflowActorInput {
+pub fn workflow_actor_input_from_actor(input: &WorkflowActor) -> WorkflowActorInput {
     WorkflowActorInput {
         subject_id: input.subject_id.clone(),
         subject_kind: input.subject_kind.clone(),
@@ -395,9 +839,27 @@ pub fn workflow_actor_input_from_actor(input: &pb::WorkflowActor) -> WorkflowAct
     }
 }
 
+fn workflow_actor_to_proto(input: WorkflowActor) -> pb::WorkflowActor {
+    pb::WorkflowActor {
+        subject_id: input.subject_id,
+        subject_kind: input.subject_kind,
+        display_name: input.display_name,
+        auth_source: input.auth_source,
+    }
+}
+
+fn workflow_actor_from_proto(input: pb::WorkflowActor) -> WorkflowActor {
+    WorkflowActor {
+        subject_id: input.subject_id,
+        subject_kind: input.subject_kind,
+        display_name: input.display_name,
+        auth_source: input.auth_source,
+    }
+}
+
 /// Creates workflow run-as metadata.
-pub fn new_workflow_run_as_subject(input: WorkflowRunAsSubjectInput) -> pb::WorkflowRunAsSubject {
-    pb::WorkflowRunAsSubject {
+pub fn new_workflow_run_as_subject(input: WorkflowRunAsSubjectInput) -> WorkflowRunAsSubject {
+    WorkflowRunAsSubject {
         subject_id: input.subject_id,
         subject_kind: input.subject_kind,
         display_name: input.display_name,
@@ -407,7 +869,7 @@ pub fn new_workflow_run_as_subject(input: WorkflowRunAsSubjectInput) -> pb::Work
 
 /// Returns input copied from workflow run-as metadata.
 pub fn workflow_run_as_subject_input_from_subject(
-    input: &pb::WorkflowRunAsSubject,
+    input: &WorkflowRunAsSubject,
 ) -> WorkflowRunAsSubjectInput {
     WorkflowRunAsSubjectInput {
         subject_id: input.subject_id.clone(),
@@ -417,11 +879,29 @@ pub fn workflow_run_as_subject_input_from_subject(
     }
 }
 
+fn workflow_run_as_subject_to_proto(input: WorkflowRunAsSubject) -> pb::WorkflowRunAsSubject {
+    pb::WorkflowRunAsSubject {
+        subject_id: input.subject_id,
+        subject_kind: input.subject_kind,
+        display_name: input.display_name,
+        auth_source: input.auth_source,
+    }
+}
+
+fn workflow_run_as_subject_from_proto(input: pb::WorkflowRunAsSubject) -> WorkflowRunAsSubject {
+    WorkflowRunAsSubject {
+        subject_id: input.subject_id,
+        subject_kind: input.subject_kind,
+        display_name: input.display_name,
+        auth_source: input.auth_source,
+    }
+}
+
 /// Creates an execution-reference permission.
 pub fn new_workflow_access_permission(
     input: WorkflowAccessPermissionInput,
-) -> pb::WorkflowAccessPermission {
-    pb::WorkflowAccessPermission {
+) -> WorkflowAccessPermission {
+    WorkflowAccessPermission {
         plugin: input.plugin,
         operations: input.operations,
     }
@@ -429,7 +909,7 @@ pub fn new_workflow_access_permission(
 
 /// Returns input copied from an execution-reference permission.
 pub fn workflow_access_permission_input_from_permission(
-    input: &pb::WorkflowAccessPermission,
+    input: &WorkflowAccessPermission,
 ) -> WorkflowAccessPermissionInput {
     WorkflowAccessPermissionInput {
         plugin: input.plugin.clone(),
@@ -437,10 +917,28 @@ pub fn workflow_access_permission_input_from_permission(
     }
 }
 
+fn workflow_access_permission_to_proto(
+    input: WorkflowAccessPermission,
+) -> pb::WorkflowAccessPermission {
+    pb::WorkflowAccessPermission {
+        plugin: input.plugin,
+        operations: input.operations,
+    }
+}
+
+fn workflow_access_permission_from_proto(
+    input: pb::WorkflowAccessPermission,
+) -> WorkflowAccessPermission {
+    WorkflowAccessPermission {
+        plugin: input.plugin,
+        operations: input.operations,
+    }
+}
+
 /// Creates workflow event-match fields.
-pub fn new_workflow_event_match(input: WorkflowEventMatchInput) -> pb::WorkflowEventMatch {
-    pb::WorkflowEventMatch {
-        r#type: input.event_type,
+pub fn new_workflow_event_match(input: WorkflowEventMatchInput) -> WorkflowEventMatch {
+    WorkflowEventMatch {
+        event_type: input.event_type,
         source: input.source,
         subject: input.subject,
     }
@@ -448,61 +946,113 @@ pub fn new_workflow_event_match(input: WorkflowEventMatchInput) -> pb::WorkflowE
 
 /// Returns input copied from workflow event-match fields.
 pub fn workflow_event_match_input_from_match(
-    input: &pb::WorkflowEventMatch,
+    input: &WorkflowEventMatch,
 ) -> WorkflowEventMatchInput {
     WorkflowEventMatchInput {
-        event_type: input.r#type.clone(),
+        event_type: input.event_type.clone(),
         source: input.source.clone(),
         subject: input.subject.clone(),
+    }
+}
+
+pub(crate) fn workflow_event_match_to_proto(input: WorkflowEventMatch) -> pb::WorkflowEventMatch {
+    pb::WorkflowEventMatch {
+        r#type: input.event_type,
+        source: input.source,
+        subject: input.subject,
+    }
+}
+
+fn workflow_event_match_from_proto(input: pb::WorkflowEventMatch) -> WorkflowEventMatch {
+    WorkflowEventMatch {
+        event_type: input.r#type,
+        source: input.source,
+        subject: input.subject,
     }
 }
 
 /// Creates a workflow output value source.
 pub fn new_workflow_output_value_source(
     input: WorkflowOutputValueSourceInput,
-) -> pb::WorkflowOutputValueSource {
-    use pb::workflow_output_value_source::Kind;
-    let kind = match input {
-        WorkflowOutputValueSourceInput::Empty => None,
-        WorkflowOutputValueSourceInput::AgentOutput(value) => Some(Kind::AgentOutput(value)),
-        WorkflowOutputValueSourceInput::SignalPayload(value) => Some(Kind::SignalPayload(value)),
-        WorkflowOutputValueSourceInput::SignalMetadata(value) => Some(Kind::SignalMetadata(value)),
-        WorkflowOutputValueSourceInput::Literal(value) => {
-            Some(Kind::Literal(protocol::value_from_json(value)))
+) -> WorkflowOutputValueSource {
+    match input {
+        WorkflowOutputValueSourceInput::Empty => WorkflowOutputValueSource::Empty,
+        WorkflowOutputValueSourceInput::AgentOutput(value) => {
+            WorkflowOutputValueSource::AgentOutput(value)
         }
-        WorkflowOutputValueSourceInput::AgentSession(value) => Some(Kind::AgentSession(value)),
-    };
-    pb::WorkflowOutputValueSource { kind }
+        WorkflowOutputValueSourceInput::SignalPayload(value) => {
+            WorkflowOutputValueSource::SignalPayload(value)
+        }
+        WorkflowOutputValueSourceInput::SignalMetadata(value) => {
+            WorkflowOutputValueSource::SignalMetadata(value)
+        }
+        WorkflowOutputValueSourceInput::Literal(value) => WorkflowOutputValueSource::Literal(value),
+        WorkflowOutputValueSourceInput::AgentSession(value) => {
+            WorkflowOutputValueSource::AgentSession(value)
+        }
+    }
 }
 
 /// Returns input copied from a workflow output value source.
 pub fn workflow_output_value_source_input_from_source(
-    input: &pb::WorkflowOutputValueSource,
+    input: &WorkflowOutputValueSource,
 ) -> WorkflowOutputValueSourceInput {
-    use pb::workflow_output_value_source::Kind;
-    match &input.kind {
-        None => WorkflowOutputValueSourceInput::Empty,
-        Some(Kind::AgentOutput(value)) => {
+    match input {
+        WorkflowOutputValueSource::Empty => WorkflowOutputValueSourceInput::Empty,
+        WorkflowOutputValueSource::AgentOutput(value) => {
             WorkflowOutputValueSourceInput::AgentOutput(value.clone())
         }
-        Some(Kind::SignalPayload(value)) => {
+        WorkflowOutputValueSource::SignalPayload(value) => {
             WorkflowOutputValueSourceInput::SignalPayload(value.clone())
         }
-        Some(Kind::SignalMetadata(value)) => {
+        WorkflowOutputValueSource::SignalMetadata(value) => {
             WorkflowOutputValueSourceInput::SignalMetadata(value.clone())
         }
-        Some(Kind::Literal(value)) => {
-            WorkflowOutputValueSourceInput::Literal(protocol::json_from_value(value))
+        WorkflowOutputValueSource::Literal(value) => {
+            WorkflowOutputValueSourceInput::Literal(value.clone())
         }
-        Some(Kind::AgentSession(value)) => {
+        WorkflowOutputValueSource::AgentSession(value) => {
             WorkflowOutputValueSourceInput::AgentSession(value.clone())
         }
     }
 }
 
+fn workflow_output_value_source_to_proto(
+    input: WorkflowOutputValueSource,
+) -> pb::WorkflowOutputValueSource {
+    use pb::workflow_output_value_source::Kind;
+    let kind = match input {
+        WorkflowOutputValueSource::Empty => None,
+        WorkflowOutputValueSource::AgentOutput(value) => Some(Kind::AgentOutput(value)),
+        WorkflowOutputValueSource::SignalPayload(value) => Some(Kind::SignalPayload(value)),
+        WorkflowOutputValueSource::SignalMetadata(value) => Some(Kind::SignalMetadata(value)),
+        WorkflowOutputValueSource::Literal(value) => {
+            Some(Kind::Literal(protocol::value_from_json(value)))
+        }
+        WorkflowOutputValueSource::AgentSession(value) => Some(Kind::AgentSession(value)),
+    };
+    pb::WorkflowOutputValueSource { kind }
+}
+
+fn workflow_output_value_source_from_proto(
+    input: pb::WorkflowOutputValueSource,
+) -> WorkflowOutputValueSource {
+    use pb::workflow_output_value_source::Kind;
+    match input.kind {
+        None => WorkflowOutputValueSource::Empty,
+        Some(Kind::AgentOutput(value)) => WorkflowOutputValueSource::AgentOutput(value),
+        Some(Kind::SignalPayload(value)) => WorkflowOutputValueSource::SignalPayload(value),
+        Some(Kind::SignalMetadata(value)) => WorkflowOutputValueSource::SignalMetadata(value),
+        Some(Kind::Literal(value)) => {
+            WorkflowOutputValueSource::Literal(protocol::json_from_value(&value))
+        }
+        Some(Kind::AgentSession(value)) => WorkflowOutputValueSource::AgentSession(value),
+    }
+}
+
 /// Creates a workflow output binding.
-pub fn new_workflow_output_binding(input: WorkflowOutputBindingInput) -> pb::WorkflowOutputBinding {
-    pb::WorkflowOutputBinding {
+pub fn new_workflow_output_binding(input: WorkflowOutputBindingInput) -> WorkflowOutputBinding {
+    WorkflowOutputBinding {
         input_field: input.input_field,
         value: input.value.map(new_workflow_output_value_source),
     }
@@ -510,7 +1060,7 @@ pub fn new_workflow_output_binding(input: WorkflowOutputBindingInput) -> pb::Wor
 
 /// Returns input copied from a workflow output binding.
 pub fn workflow_output_binding_input_from_binding(
-    input: &pb::WorkflowOutputBinding,
+    input: &WorkflowOutputBinding,
 ) -> WorkflowOutputBindingInput {
     WorkflowOutputBindingInput {
         input_field: input.input_field.clone(),
@@ -521,11 +1071,25 @@ pub fn workflow_output_binding_input_from_binding(
     }
 }
 
+fn workflow_output_binding_to_proto(input: WorkflowOutputBinding) -> pb::WorkflowOutputBinding {
+    pb::WorkflowOutputBinding {
+        input_field: input.input_field,
+        value: input.value.map(workflow_output_value_source_to_proto),
+    }
+}
+
+fn workflow_output_binding_from_proto(input: pb::WorkflowOutputBinding) -> WorkflowOutputBinding {
+    WorkflowOutputBinding {
+        input_field: input.input_field,
+        value: input.value.map(workflow_output_value_source_from_proto),
+    }
+}
+
 /// Creates a workflow output delivery.
 pub fn new_workflow_output_delivery(
     input: WorkflowOutputDeliveryInput,
-) -> ProviderResult<pb::WorkflowOutputDelivery> {
-    Ok(pb::WorkflowOutputDelivery {
+) -> ProviderResult<WorkflowOutputDelivery> {
+    Ok(WorkflowOutputDelivery {
         target: input
             .target
             .map(new_bound_workflow_plugin_target)
@@ -541,7 +1105,7 @@ pub fn new_workflow_output_delivery(
 
 /// Returns input copied from a workflow output delivery.
 pub fn workflow_output_delivery_input_from_delivery(
-    input: &pb::WorkflowOutputDelivery,
+    input: &WorkflowOutputDelivery,
 ) -> ProviderResult<WorkflowOutputDeliveryInput> {
     Ok(WorkflowOutputDeliveryInput {
         target: input
@@ -558,9 +1122,70 @@ pub fn workflow_output_delivery_input_from_delivery(
     })
 }
 
+fn workflow_output_delivery_to_proto(
+    input: WorkflowOutputDelivery,
+) -> ProviderResult<pb::WorkflowOutputDelivery> {
+    Ok(pb::WorkflowOutputDelivery {
+        target: input
+            .target
+            .map(bound_workflow_plugin_target_to_proto)
+            .transpose()?,
+        input_bindings: input
+            .input_bindings
+            .into_iter()
+            .map(workflow_output_binding_to_proto)
+            .collect(),
+        credential_mode: input.credential_mode,
+    })
+}
+
+fn workflow_output_delivery_from_proto(
+    input: pb::WorkflowOutputDelivery,
+) -> ProviderResult<WorkflowOutputDelivery> {
+    Ok(WorkflowOutputDelivery {
+        target: input
+            .target
+            .map(bound_workflow_plugin_target_from_proto)
+            .transpose()?,
+        input_bindings: input
+            .input_bindings
+            .into_iter()
+            .map(workflow_output_binding_from_proto)
+            .collect(),
+        credential_mode: input.credential_mode,
+    })
+}
+
 /// Creates a bound plugin workflow target.
 pub fn new_bound_workflow_plugin_target(
     input: BoundWorkflowPluginTargetInput,
+) -> ProviderResult<BoundWorkflowPluginTarget> {
+    Ok(BoundWorkflowPluginTarget {
+        plugin_name: input.plugin_name,
+        operation: input.operation,
+        input: input.input,
+        connection: input.connection,
+        instance: input.instance,
+        credential_mode: input.credential_mode,
+    })
+}
+
+/// Returns input copied from a bound plugin workflow target.
+pub fn bound_workflow_plugin_target_input_from_target(
+    input: &BoundWorkflowPluginTarget,
+) -> ProviderResult<BoundWorkflowPluginTargetInput> {
+    Ok(BoundWorkflowPluginTargetInput {
+        plugin_name: input.plugin_name.clone(),
+        operation: input.operation.clone(),
+        input: input.input.clone(),
+        connection: input.connection.clone(),
+        instance: input.instance.clone(),
+        credential_mode: input.credential_mode.clone(),
+    })
+}
+
+fn bound_workflow_plugin_target_to_proto(
+    input: BoundWorkflowPluginTarget,
 ) -> ProviderResult<pb::BoundWorkflowPluginTarget> {
     Ok(pb::BoundWorkflowPluginTarget {
         plugin_name: input.plugin_name,
@@ -572,48 +1197,47 @@ pub fn new_bound_workflow_plugin_target(
     })
 }
 
-/// Returns input copied from a bound plugin workflow target.
-pub fn bound_workflow_plugin_target_input_from_target(
-    input: &pb::BoundWorkflowPluginTarget,
-) -> ProviderResult<BoundWorkflowPluginTargetInput> {
-    Ok(BoundWorkflowPluginTargetInput {
-        plugin_name: input.plugin_name.clone(),
-        operation: input.operation.clone(),
+fn bound_workflow_plugin_target_from_proto(
+    input: pb::BoundWorkflowPluginTarget,
+) -> ProviderResult<BoundWorkflowPluginTarget> {
+    Ok(BoundWorkflowPluginTarget {
+        plugin_name: input.plugin_name,
+        operation: input.operation,
         input: input.input.as_ref().map(protocol::json_from_struct),
-        connection: input.connection.clone(),
-        instance: input.instance.clone(),
-        credential_mode: input.credential_mode.clone(),
+        connection: input.connection,
+        instance: input.instance,
+        credential_mode: input.credential_mode,
     })
 }
 
 /// Creates a bound agent workflow target.
 pub fn new_bound_workflow_agent_target(
     input: BoundWorkflowAgentTargetInput,
-) -> ProviderResult<pb::BoundWorkflowAgentTarget> {
+) -> ProviderResult<BoundWorkflowAgentTarget> {
     let mut messages = input.messages;
-    messages.extend(new_agent_messages(input.message_inputs)?);
+    messages.extend(
+        input
+            .message_inputs
+            .into_iter()
+            .map(new_agent_message)
+            .collect::<ProviderResult<Vec<_>>>()?,
+    );
     let mut tool_refs = input.tool_refs;
-    tool_refs.extend(new_agent_tool_refs(input.tool_ref_inputs));
-    Ok(pb::BoundWorkflowAgentTarget {
+    tool_refs.extend(input.tool_ref_inputs.into_iter().map(new_agent_tool_ref));
+    Ok(BoundWorkflowAgentTarget {
         provider_name: input.provider_name,
         model: input.model,
         prompt: input.prompt,
         messages,
         tool_refs,
-        response_schema: input
-            .response_schema
-            .map(protocol::struct_from_json)
-            .transpose()?,
-        metadata: input.metadata.map(protocol::struct_from_json).transpose()?,
+        response_schema: input.response_schema,
+        metadata: input.metadata,
         timeout_seconds: input.timeout_seconds,
         output_delivery: input
             .output_delivery
             .map(new_workflow_output_delivery)
             .transpose()?,
-        model_options: input
-            .model_options
-            .map(protocol::struct_from_json)
-            .transpose()?,
+        model_options: input.model_options,
         session_ready_delivery: input
             .session_ready_delivery
             .map(new_workflow_output_delivery)
@@ -623,7 +1247,7 @@ pub fn new_bound_workflow_agent_target(
 
 /// Returns input copied from a bound agent workflow target.
 pub fn bound_workflow_agent_target_input_from_target(
-    input: &pb::BoundWorkflowAgentTarget,
+    input: &BoundWorkflowAgentTarget,
 ) -> ProviderResult<BoundWorkflowAgentTargetInput> {
     Ok(BoundWorkflowAgentTargetInput {
         provider_name: input.provider_name.clone(),
@@ -633,18 +1257,15 @@ pub fn bound_workflow_agent_target_input_from_target(
         message_inputs: Vec::new(),
         tool_refs: input.tool_refs.clone(),
         tool_ref_inputs: Vec::new(),
-        response_schema: input
-            .response_schema
-            .as_ref()
-            .map(protocol::json_from_struct),
-        metadata: input.metadata.as_ref().map(protocol::json_from_struct),
+        response_schema: input.response_schema.clone(),
+        metadata: input.metadata.clone(),
         timeout_seconds: input.timeout_seconds,
         output_delivery: input
             .output_delivery
             .as_ref()
             .map(workflow_output_delivery_input_from_delivery)
             .transpose()?,
-        model_options: input.model_options.as_ref().map(protocol::json_from_struct),
+        model_options: input.model_options.clone(),
         session_ready_delivery: input
             .session_ready_delivery
             .as_ref()
@@ -653,48 +1274,176 @@ pub fn bound_workflow_agent_target_input_from_target(
     })
 }
 
+fn bound_workflow_agent_target_to_proto(
+    input: BoundWorkflowAgentTarget,
+) -> ProviderResult<pb::BoundWorkflowAgentTarget> {
+    Ok(pb::BoundWorkflowAgentTarget {
+        provider_name: input.provider_name,
+        model: input.model,
+        prompt: input.prompt,
+        messages: input
+            .messages
+            .into_iter()
+            .map(message_to_proto)
+            .collect::<ProviderResult<Vec<_>>>()?,
+        tool_refs: input
+            .tool_refs
+            .into_iter()
+            .map(agent_tool_ref_to_proto)
+            .collect(),
+        response_schema: input
+            .response_schema
+            .map(protocol::struct_from_json)
+            .transpose()?,
+        metadata: input.metadata.map(protocol::struct_from_json).transpose()?,
+        timeout_seconds: input.timeout_seconds,
+        output_delivery: input
+            .output_delivery
+            .map(workflow_output_delivery_to_proto)
+            .transpose()?,
+        model_options: input
+            .model_options
+            .map(protocol::struct_from_json)
+            .transpose()?,
+        session_ready_delivery: input
+            .session_ready_delivery
+            .map(workflow_output_delivery_to_proto)
+            .transpose()?,
+    })
+}
+
+fn bound_workflow_agent_target_from_proto(
+    input: pb::BoundWorkflowAgentTarget,
+) -> ProviderResult<BoundWorkflowAgentTarget> {
+    Ok(BoundWorkflowAgentTarget {
+        provider_name: input.provider_name,
+        model: input.model,
+        prompt: input.prompt,
+        messages: input.messages.into_iter().map(message_from_proto).collect(),
+        tool_refs: input
+            .tool_refs
+            .into_iter()
+            .map(agent_tool_ref_from_proto)
+            .collect(),
+        response_schema: input
+            .response_schema
+            .as_ref()
+            .map(protocol::json_from_struct),
+        metadata: input.metadata.as_ref().map(protocol::json_from_struct),
+        timeout_seconds: input.timeout_seconds,
+        output_delivery: input
+            .output_delivery
+            .map(workflow_output_delivery_from_proto)
+            .transpose()?,
+        model_options: input.model_options.as_ref().map(protocol::json_from_struct),
+        session_ready_delivery: input
+            .session_ready_delivery
+            .map(workflow_output_delivery_from_proto)
+            .transpose()?,
+    })
+}
+
 /// Creates a bound workflow target.
 pub fn new_bound_workflow_target(
     input: BoundWorkflowTargetInput,
+) -> ProviderResult<BoundWorkflowTarget> {
+    match input {
+        BoundWorkflowTargetInput::Empty => Ok(BoundWorkflowTarget::Empty),
+        BoundWorkflowTargetInput::Plugin(input) => Ok(BoundWorkflowTarget::Plugin(
+            new_bound_workflow_plugin_target(input)?,
+        )),
+        BoundWorkflowTargetInput::Agent(input) => Ok(BoundWorkflowTarget::Agent(
+            new_bound_workflow_agent_target(input)?,
+        )),
+    }
+}
+
+/// Returns input copied from a bound workflow target.
+pub fn bound_workflow_target_input_from_target(
+    input: &BoundWorkflowTarget,
+) -> ProviderResult<BoundWorkflowTargetInput> {
+    match input {
+        BoundWorkflowTarget::Empty => Ok(BoundWorkflowTargetInput::Empty),
+        BoundWorkflowTarget::Plugin(value) => Ok(BoundWorkflowTargetInput::Plugin(
+            bound_workflow_plugin_target_input_from_target(value)?,
+        )),
+        BoundWorkflowTarget::Agent(value) => Ok(BoundWorkflowTargetInput::Agent(
+            bound_workflow_agent_target_input_from_target(value)?,
+        )),
+    }
+}
+
+pub(crate) fn bound_workflow_target_to_proto(
+    input: BoundWorkflowTarget,
 ) -> ProviderResult<pb::BoundWorkflowTarget> {
     use pb::bound_workflow_target::Kind;
     let kind = match input {
-        BoundWorkflowTargetInput::Empty => None,
-        BoundWorkflowTargetInput::Plugin(input) => {
-            Some(Kind::Plugin(new_bound_workflow_plugin_target(input)?))
+        BoundWorkflowTarget::Empty => None,
+        BoundWorkflowTarget::Plugin(input) => {
+            Some(Kind::Plugin(bound_workflow_plugin_target_to_proto(input)?))
         }
-        BoundWorkflowTargetInput::Agent(input) => {
-            Some(Kind::Agent(new_bound_workflow_agent_target(input)?))
+        BoundWorkflowTarget::Agent(input) => {
+            Some(Kind::Agent(bound_workflow_agent_target_to_proto(input)?))
         }
     };
     Ok(pb::BoundWorkflowTarget { kind })
 }
 
-/// Returns input copied from a bound workflow target.
-pub fn bound_workflow_target_input_from_target(
-    input: &pb::BoundWorkflowTarget,
-) -> ProviderResult<BoundWorkflowTargetInput> {
+fn bound_workflow_target_from_proto(
+    input: pb::BoundWorkflowTarget,
+) -> ProviderResult<BoundWorkflowTarget> {
     use pb::bound_workflow_target::Kind;
-    match &input.kind {
-        None => Ok(BoundWorkflowTargetInput::Empty),
-        Some(Kind::Plugin(value)) => Ok(BoundWorkflowTargetInput::Plugin(
-            bound_workflow_plugin_target_input_from_target(value)?,
+    match input.kind {
+        None => Ok(BoundWorkflowTarget::Empty),
+        Some(Kind::Plugin(value)) => Ok(BoundWorkflowTarget::Plugin(
+            bound_workflow_plugin_target_from_proto(value)?,
         )),
-        Some(Kind::Agent(value)) => Ok(BoundWorkflowTargetInput::Agent(
-            bound_workflow_agent_target_input_from_target(value)?,
+        Some(Kind::Agent(value)) => Ok(BoundWorkflowTarget::Agent(
+            bound_workflow_agent_target_from_proto(value)?,
         )),
     }
 }
 
 /// Returns a deep copy of a bound workflow target.
 pub fn new_bound_workflow_target_from_target(
-    input: &pb::BoundWorkflowTarget,
-) -> ProviderResult<pb::BoundWorkflowTarget> {
-    new_bound_workflow_target(bound_workflow_target_input_from_target(input)?)
+    input: &BoundWorkflowTarget,
+) -> ProviderResult<BoundWorkflowTarget> {
+    Ok(input.clone())
 }
 
 /// Creates a workflow event.
-pub fn new_workflow_event(input: WorkflowEventInput) -> ProviderResult<pb::WorkflowEvent> {
+pub fn new_workflow_event(input: WorkflowEventInput) -> ProviderResult<WorkflowEvent> {
+    Ok(WorkflowEvent {
+        id: input.id,
+        source: input.source,
+        spec_version: input.spec_version,
+        event_type: input.event_type,
+        subject: input.subject,
+        time: input.time,
+        datacontenttype: input.datacontenttype,
+        data: input.data,
+        extensions: input.extensions,
+    })
+}
+
+/// Returns input copied from a workflow event.
+pub fn workflow_event_input_from_event(
+    input: &WorkflowEvent,
+) -> ProviderResult<WorkflowEventInput> {
+    Ok(WorkflowEventInput {
+        id: input.id.clone(),
+        source: input.source.clone(),
+        spec_version: input.spec_version.clone(),
+        event_type: input.event_type.clone(),
+        subject: input.subject.clone(),
+        time: input.time,
+        datacontenttype: input.datacontenttype.clone(),
+        data: input.data.clone(),
+        extensions: input.extensions.clone(),
+    })
+}
+
+pub(crate) fn workflow_event_to_proto(input: WorkflowEvent) -> ProviderResult<pb::WorkflowEvent> {
     Ok(pb::WorkflowEvent {
         id: input.id,
         source: input.source,
@@ -712,22 +1461,19 @@ pub fn new_workflow_event(input: WorkflowEventInput) -> ProviderResult<pb::Workf
     })
 }
 
-/// Returns input copied from a workflow event.
-pub fn workflow_event_input_from_event(
-    input: &pb::WorkflowEvent,
-) -> ProviderResult<WorkflowEventInput> {
-    Ok(WorkflowEventInput {
-        id: input.id.clone(),
-        source: input.source.clone(),
-        spec_version: input.spec_version.clone(),
-        event_type: input.r#type.clone(),
-        subject: input.subject.clone(),
+pub(crate) fn workflow_event_from_proto(input: pb::WorkflowEvent) -> ProviderResult<WorkflowEvent> {
+    Ok(WorkflowEvent {
+        id: input.id,
+        source: input.source,
+        spec_version: input.spec_version,
+        event_type: input.r#type,
+        subject: input.subject,
         time: input
             .time
             .as_ref()
             .map(protocol::system_time_from_timestamp)
             .transpose()?,
-        datacontenttype: input.datacontenttype.clone(),
+        datacontenttype: input.datacontenttype,
         data: input.data.as_ref().map(protocol::json_from_struct),
         extensions: input
             .extensions
@@ -738,21 +1484,19 @@ pub fn workflow_event_input_from_event(
 }
 
 /// Returns a deep copy of a workflow event.
-pub fn new_workflow_event_from_event(
-    input: &pb::WorkflowEvent,
-) -> ProviderResult<pb::WorkflowEvent> {
-    new_workflow_event(workflow_event_input_from_event(input)?)
+pub fn new_workflow_event_from_event(input: &WorkflowEvent) -> ProviderResult<WorkflowEvent> {
+    Ok(input.clone())
 }
 
 /// Creates a workflow signal.
-pub fn new_workflow_signal(input: WorkflowSignalInput) -> ProviderResult<pb::WorkflowSignal> {
-    Ok(pb::WorkflowSignal {
+pub fn new_workflow_signal(input: WorkflowSignalInput) -> ProviderResult<WorkflowSignal> {
+    Ok(WorkflowSignal {
         id: input.id,
         name: input.name,
-        payload: input.payload.map(protocol::struct_from_json).transpose()?,
-        metadata: input.metadata.map(protocol::struct_from_json).transpose()?,
+        payload: input.payload,
+        metadata: input.metadata,
         created_by: input.created_by.map(new_workflow_actor),
-        created_at: input.created_at.map(protocol::timestamp_from_system_time),
+        created_at: input.created_at,
         idempotency_key: input.idempotency_key,
         sequence: input.sequence,
     })
@@ -760,37 +1504,74 @@ pub fn new_workflow_signal(input: WorkflowSignalInput) -> ProviderResult<pb::Wor
 
 /// Returns input copied from a workflow signal.
 pub fn workflow_signal_input_from_signal(
-    input: &pb::WorkflowSignal,
+    input: &WorkflowSignal,
 ) -> ProviderResult<WorkflowSignalInput> {
     Ok(WorkflowSignalInput {
         id: input.id.clone(),
         name: input.name.clone(),
-        payload: input.payload.as_ref().map(protocol::json_from_struct),
-        metadata: input.metadata.as_ref().map(protocol::json_from_struct),
+        payload: input.payload.clone(),
+        metadata: input.metadata.clone(),
         created_by: input
             .created_by
             .as_ref()
             .map(workflow_actor_input_from_actor),
-        created_at: input
-            .created_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
+        created_at: input.created_at,
         idempotency_key: input.idempotency_key.clone(),
         sequence: input.sequence,
     })
 }
 
-/// Returns a deep copy of a workflow signal.
-pub fn new_workflow_signal_from_signal(
-    input: &pb::WorkflowSignal,
+pub(crate) fn workflow_signal_to_proto(
+    input: WorkflowSignal,
 ) -> ProviderResult<pb::WorkflowSignal> {
-    new_workflow_signal(workflow_signal_input_from_signal(input)?)
+    Ok(pb::WorkflowSignal {
+        id: input.id,
+        name: input.name,
+        payload: input.payload.map(protocol::struct_from_json).transpose()?,
+        metadata: input.metadata.map(protocol::struct_from_json).transpose()?,
+        created_by: input.created_by.map(workflow_actor_to_proto),
+        created_at: input.created_at.map(protocol::timestamp_from_system_time),
+        idempotency_key: input.idempotency_key,
+        sequence: input.sequence,
+    })
+}
+
+pub(crate) fn workflow_signal_from_proto(
+    input: pb::WorkflowSignal,
+) -> ProviderResult<WorkflowSignal> {
+    Ok(WorkflowSignal {
+        id: input.id,
+        name: input.name,
+        payload: input.payload.as_ref().map(protocol::json_from_struct),
+        metadata: input.metadata.as_ref().map(protocol::json_from_struct),
+        created_by: input.created_by.map(workflow_actor_from_proto),
+        created_at: input
+            .created_at
+            .as_ref()
+            .map(protocol::system_time_from_timestamp)
+            .transpose()?,
+        idempotency_key: input.idempotency_key,
+        sequence: input.sequence,
+    })
+}
+
+/// Returns a deep copy of a workflow signal.
+pub fn new_workflow_signal_from_signal(input: &WorkflowSignal) -> ProviderResult<WorkflowSignal> {
+    Ok(input.clone())
 }
 
 /// Creates a workflow schedule trigger.
 pub fn new_workflow_schedule_trigger(
     input: WorkflowScheduleTriggerInput,
+) -> WorkflowScheduleTrigger {
+    WorkflowScheduleTrigger {
+        schedule_id: input.schedule_id,
+        scheduled_for: input.scheduled_for,
+    }
+}
+
+fn workflow_schedule_trigger_to_proto(
+    input: WorkflowScheduleTrigger,
 ) -> pb::WorkflowScheduleTrigger {
     pb::WorkflowScheduleTrigger {
         schedule_id: input.schedule_id,
@@ -800,53 +1581,77 @@ pub fn new_workflow_schedule_trigger(
     }
 }
 
+fn workflow_schedule_trigger_from_proto(
+    input: pb::WorkflowScheduleTrigger,
+) -> ProviderResult<WorkflowScheduleTrigger> {
+    Ok(WorkflowScheduleTrigger {
+        schedule_id: input.schedule_id,
+        scheduled_for: input
+            .scheduled_for
+            .as_ref()
+            .map(protocol::system_time_from_timestamp)
+            .transpose()?,
+    })
+}
+
 /// Creates a workflow event-trigger invocation.
 pub fn new_workflow_event_trigger_invocation(
     input: WorkflowEventTriggerInvocationInput,
+) -> ProviderResult<WorkflowEventTriggerInvocation> {
+    Ok(WorkflowEventTriggerInvocation {
+        trigger_id: input.trigger_id,
+        event: input.event.map(new_workflow_event).transpose()?,
+    })
+}
+
+fn workflow_event_trigger_invocation_to_proto(
+    input: WorkflowEventTriggerInvocation,
 ) -> ProviderResult<pb::WorkflowEventTriggerInvocation> {
     Ok(pb::WorkflowEventTriggerInvocation {
         trigger_id: input.trigger_id,
-        event: input.event.map(new_workflow_event).transpose()?,
+        event: input.event.map(workflow_event_to_proto).transpose()?,
+    })
+}
+
+fn workflow_event_trigger_invocation_from_proto(
+    input: pb::WorkflowEventTriggerInvocation,
+) -> ProviderResult<WorkflowEventTriggerInvocation> {
+    Ok(WorkflowEventTriggerInvocation {
+        trigger_id: input.trigger_id,
+        event: input.event.map(workflow_event_from_proto).transpose()?,
     })
 }
 
 /// Creates a workflow run trigger.
 pub fn new_workflow_run_trigger(
     input: WorkflowRunTriggerInput,
-) -> ProviderResult<pb::WorkflowRunTrigger> {
-    use pb::workflow_run_trigger::Kind;
-    let kind = match input {
-        WorkflowRunTriggerInput::Empty => None,
-        WorkflowRunTriggerInput::Manual => Some(Kind::Manual(pb::WorkflowManualTrigger {})),
-        WorkflowRunTriggerInput::Schedule(input) => {
-            Some(Kind::Schedule(new_workflow_schedule_trigger(input)))
-        }
-        WorkflowRunTriggerInput::Event(input) => {
-            Some(Kind::Event(new_workflow_event_trigger_invocation(input)?))
-        }
-    };
-    Ok(pb::WorkflowRunTrigger { kind })
+) -> ProviderResult<WorkflowRunTrigger> {
+    match input {
+        WorkflowRunTriggerInput::Empty => Ok(WorkflowRunTrigger::Empty),
+        WorkflowRunTriggerInput::Manual => Ok(WorkflowRunTrigger::Manual),
+        WorkflowRunTriggerInput::Schedule(input) => Ok(WorkflowRunTrigger::Schedule(
+            new_workflow_schedule_trigger(input),
+        )),
+        WorkflowRunTriggerInput::Event(input) => Ok(WorkflowRunTrigger::Event(
+            new_workflow_event_trigger_invocation(input)?,
+        )),
+    }
 }
 
 /// Returns input copied from a workflow run trigger.
 pub fn workflow_run_trigger_input_from_trigger(
-    input: &pb::WorkflowRunTrigger,
+    input: &WorkflowRunTrigger,
 ) -> ProviderResult<WorkflowRunTriggerInput> {
-    use pb::workflow_run_trigger::Kind;
-    match &input.kind {
-        None => Ok(WorkflowRunTriggerInput::Empty),
-        Some(Kind::Manual(_)) => Ok(WorkflowRunTriggerInput::Manual),
-        Some(Kind::Schedule(value)) => Ok(WorkflowRunTriggerInput::Schedule(
+    match input {
+        WorkflowRunTrigger::Empty => Ok(WorkflowRunTriggerInput::Empty),
+        WorkflowRunTrigger::Manual => Ok(WorkflowRunTriggerInput::Manual),
+        WorkflowRunTrigger::Schedule(value) => Ok(WorkflowRunTriggerInput::Schedule(
             WorkflowScheduleTriggerInput {
                 schedule_id: value.schedule_id.clone(),
-                scheduled_for: value
-                    .scheduled_for
-                    .as_ref()
-                    .map(protocol::system_time_from_timestamp)
-                    .transpose()?,
+                scheduled_for: value.scheduled_for,
             },
         )),
-        Some(Kind::Event(value)) => Ok(WorkflowRunTriggerInput::Event(
+        WorkflowRunTrigger::Event(value) => Ok(WorkflowRunTriggerInput::Event(
             WorkflowEventTriggerInvocationInput {
                 trigger_id: value.trigger_id.clone(),
                 event: value
@@ -859,25 +1664,56 @@ pub fn workflow_run_trigger_input_from_trigger(
     }
 }
 
+fn workflow_run_trigger_to_proto(
+    input: WorkflowRunTrigger,
+) -> ProviderResult<pb::WorkflowRunTrigger> {
+    use pb::workflow_run_trigger::Kind;
+    let kind = match input {
+        WorkflowRunTrigger::Empty => None,
+        WorkflowRunTrigger::Manual => Some(Kind::Manual(pb::WorkflowManualTrigger {})),
+        WorkflowRunTrigger::Schedule(input) => {
+            Some(Kind::Schedule(workflow_schedule_trigger_to_proto(input)))
+        }
+        WorkflowRunTrigger::Event(input) => Some(Kind::Event(
+            workflow_event_trigger_invocation_to_proto(input)?,
+        )),
+    };
+    Ok(pb::WorkflowRunTrigger { kind })
+}
+
+fn workflow_run_trigger_from_proto(
+    input: pb::WorkflowRunTrigger,
+) -> ProviderResult<WorkflowRunTrigger> {
+    use pb::workflow_run_trigger::Kind;
+    match input.kind {
+        None => Ok(WorkflowRunTrigger::Empty),
+        Some(Kind::Manual(_)) => Ok(WorkflowRunTrigger::Manual),
+        Some(Kind::Schedule(value)) => Ok(WorkflowRunTrigger::Schedule(
+            workflow_schedule_trigger_from_proto(value)?,
+        )),
+        Some(Kind::Event(value)) => Ok(WorkflowRunTrigger::Event(
+            workflow_event_trigger_invocation_from_proto(value)?,
+        )),
+    }
+}
+
 /// Returns a deep copy of a workflow run trigger.
 pub fn new_workflow_run_trigger_from_trigger(
-    input: &pb::WorkflowRunTrigger,
-) -> ProviderResult<pb::WorkflowRunTrigger> {
-    new_workflow_run_trigger(workflow_run_trigger_input_from_trigger(input)?)
+    input: &WorkflowRunTrigger,
+) -> ProviderResult<WorkflowRunTrigger> {
+    Ok(input.clone())
 }
 
 /// Creates a workflow-provider run.
-pub fn new_bound_workflow_run(
-    input: BoundWorkflowRunInput,
-) -> ProviderResult<pb::BoundWorkflowRun> {
-    Ok(pb::BoundWorkflowRun {
+pub fn new_bound_workflow_run(input: BoundWorkflowRunInput) -> ProviderResult<BoundWorkflowRun> {
+    Ok(BoundWorkflowRun {
         id: input.id,
-        status: input.status as i32,
+        status: input.status,
         target: input.target.map(new_bound_workflow_target).transpose()?,
         trigger: input.trigger.map(new_workflow_run_trigger).transpose()?,
-        created_at: input.created_at.map(protocol::timestamp_from_system_time),
-        started_at: input.started_at.map(protocol::timestamp_from_system_time),
-        completed_at: input.completed_at.map(protocol::timestamp_from_system_time),
+        created_at: input.created_at,
+        started_at: input.started_at,
+        completed_at: input.completed_at,
         status_message: input.status_message,
         result_body: input.result_body,
         created_by: input.created_by.map(new_workflow_actor),
@@ -888,13 +1724,11 @@ pub fn new_bound_workflow_run(
 
 /// Returns input copied from a workflow-provider run.
 pub fn bound_workflow_run_input_from_run(
-    input: &pb::BoundWorkflowRun,
+    input: &BoundWorkflowRun,
 ) -> ProviderResult<BoundWorkflowRunInput> {
     Ok(BoundWorkflowRunInput {
         id: input.id.clone(),
-        status: pb::WorkflowRunStatus::try_from(input.status).map_err(|_| {
-            Error::bad_request(format!("unknown workflow run status {}", input.status))
-        })?,
+        status: input.status,
         target: input
             .target
             .as_ref()
@@ -904,6 +1738,59 @@ pub fn bound_workflow_run_input_from_run(
             .trigger
             .as_ref()
             .map(workflow_run_trigger_input_from_trigger)
+            .transpose()?,
+        created_at: input.created_at,
+        started_at: input.started_at,
+        completed_at: input.completed_at,
+        status_message: input.status_message.clone(),
+        result_body: input.result_body.clone(),
+        created_by: input
+            .created_by
+            .as_ref()
+            .map(workflow_actor_input_from_actor),
+        execution_ref: input.execution_ref.clone(),
+        workflow_key: input.workflow_key.clone(),
+    })
+}
+
+pub(crate) fn bound_workflow_run_to_proto(
+    input: BoundWorkflowRun,
+) -> ProviderResult<pb::BoundWorkflowRun> {
+    Ok(pb::BoundWorkflowRun {
+        id: input.id,
+        status: input.status.as_i32(),
+        target: input
+            .target
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
+        trigger: input
+            .trigger
+            .map(workflow_run_trigger_to_proto)
+            .transpose()?,
+        created_at: input.created_at.map(protocol::timestamp_from_system_time),
+        started_at: input.started_at.map(protocol::timestamp_from_system_time),
+        completed_at: input.completed_at.map(protocol::timestamp_from_system_time),
+        status_message: input.status_message,
+        result_body: input.result_body,
+        created_by: input.created_by.map(workflow_actor_to_proto),
+        execution_ref: input.execution_ref,
+        workflow_key: input.workflow_key,
+    })
+}
+
+pub(crate) fn bound_workflow_run_from_proto(
+    input: pb::BoundWorkflowRun,
+) -> ProviderResult<BoundWorkflowRun> {
+    Ok(BoundWorkflowRun {
+        id: input.id,
+        status: WorkflowRunStatus::try_from(input.status)?,
+        target: input
+            .target
+            .map(bound_workflow_target_from_proto)
+            .transpose()?,
+        trigger: input
+            .trigger
+            .map(workflow_run_trigger_from_proto)
             .transpose()?,
         created_at: input
             .created_at
@@ -920,27 +1807,24 @@ pub fn bound_workflow_run_input_from_run(
             .as_ref()
             .map(protocol::system_time_from_timestamp)
             .transpose()?,
-        status_message: input.status_message.clone(),
-        result_body: input.result_body.clone(),
-        created_by: input
-            .created_by
-            .as_ref()
-            .map(workflow_actor_input_from_actor),
-        execution_ref: input.execution_ref.clone(),
-        workflow_key: input.workflow_key.clone(),
+        status_message: input.status_message,
+        result_body: input.result_body,
+        created_by: input.created_by.map(workflow_actor_from_proto),
+        execution_ref: input.execution_ref,
+        workflow_key: input.workflow_key,
     })
 }
 
 /// Returns a deep copy of a workflow-provider run.
 pub fn new_bound_workflow_run_from_run(
-    input: &pb::BoundWorkflowRun,
-) -> ProviderResult<pb::BoundWorkflowRun> {
-    new_bound_workflow_run(bound_workflow_run_input_from_run(input)?)
+    input: &BoundWorkflowRun,
+) -> ProviderResult<BoundWorkflowRun> {
+    Ok(input.clone())
 }
 
 /// Returns input copied from a workflow-provider definition.
 pub fn bound_workflow_definition_input_from_definition(
-    input: &pb::BoundWorkflowDefinition,
+    input: &BoundWorkflowDefinition,
 ) -> ProviderResult<BoundWorkflowDefinitionInput> {
     Ok(BoundWorkflowDefinitionInput {
         id: input.id.clone(),
@@ -953,27 +1837,23 @@ pub fn bound_workflow_definition_input_from_definition(
             .created_by
             .as_ref()
             .map(workflow_actor_input_from_actor),
-        created_at: input
-            .created_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
+        created_at: input.created_at,
     })
 }
 
 /// Creates a workflow-provider schedule.
 pub fn new_bound_workflow_schedule(
     input: BoundWorkflowScheduleInput,
-) -> ProviderResult<pb::BoundWorkflowSchedule> {
-    Ok(pb::BoundWorkflowSchedule {
+) -> ProviderResult<BoundWorkflowSchedule> {
+    Ok(BoundWorkflowSchedule {
         id: input.id,
         cron: input.cron,
         timezone: input.timezone,
         target: input.target.map(new_bound_workflow_target).transpose()?,
         paused: input.paused,
-        created_at: input.created_at.map(protocol::timestamp_from_system_time),
-        updated_at: input.updated_at.map(protocol::timestamp_from_system_time),
-        next_run_at: input.next_run_at.map(protocol::timestamp_from_system_time),
+        created_at: input.created_at,
+        updated_at: input.updated_at,
+        next_run_at: input.next_run_at,
         created_by: input.created_by.map(new_workflow_actor),
         execution_ref: input.execution_ref,
     })
@@ -981,7 +1861,7 @@ pub fn new_bound_workflow_schedule(
 
 /// Returns input copied from a workflow-provider schedule.
 pub fn bound_workflow_schedule_input_from_schedule(
-    input: &pb::BoundWorkflowSchedule,
+    input: &BoundWorkflowSchedule,
 ) -> ProviderResult<BoundWorkflowScheduleInput> {
     Ok(BoundWorkflowScheduleInput {
         id: input.id.clone(),
@@ -991,6 +1871,49 @@ pub fn bound_workflow_schedule_input_from_schedule(
             .target
             .as_ref()
             .map(bound_workflow_target_input_from_target)
+            .transpose()?,
+        paused: input.paused,
+        created_at: input.created_at,
+        updated_at: input.updated_at,
+        next_run_at: input.next_run_at,
+        created_by: input
+            .created_by
+            .as_ref()
+            .map(workflow_actor_input_from_actor),
+        execution_ref: input.execution_ref.clone(),
+    })
+}
+
+pub(crate) fn bound_workflow_schedule_to_proto(
+    input: BoundWorkflowSchedule,
+) -> ProviderResult<pb::BoundWorkflowSchedule> {
+    Ok(pb::BoundWorkflowSchedule {
+        id: input.id,
+        cron: input.cron,
+        timezone: input.timezone,
+        target: input
+            .target
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
+        paused: input.paused,
+        created_at: input.created_at.map(protocol::timestamp_from_system_time),
+        updated_at: input.updated_at.map(protocol::timestamp_from_system_time),
+        next_run_at: input.next_run_at.map(protocol::timestamp_from_system_time),
+        created_by: input.created_by.map(workflow_actor_to_proto),
+        execution_ref: input.execution_ref,
+    })
+}
+
+pub(crate) fn bound_workflow_schedule_from_proto(
+    input: pb::BoundWorkflowSchedule,
+) -> ProviderResult<BoundWorkflowSchedule> {
+    Ok(BoundWorkflowSchedule {
+        id: input.id,
+        cron: input.cron,
+        timezone: input.timezone,
+        target: input
+            .target
+            .map(bound_workflow_target_from_proto)
             .transpose()?,
         paused: input.paused,
         created_at: input
@@ -1008,6 +1931,52 @@ pub fn bound_workflow_schedule_input_from_schedule(
             .as_ref()
             .map(protocol::system_time_from_timestamp)
             .transpose()?,
+        created_by: input.created_by.map(workflow_actor_from_proto),
+        execution_ref: input.execution_ref,
+    })
+}
+
+/// Returns a deep copy of a workflow-provider schedule.
+pub fn new_bound_workflow_schedule_from_schedule(
+    input: &BoundWorkflowSchedule,
+) -> ProviderResult<BoundWorkflowSchedule> {
+    Ok(input.clone())
+}
+
+/// Creates a workflow-provider event trigger.
+pub fn new_bound_workflow_event_trigger(
+    input: BoundWorkflowEventTriggerInput,
+) -> ProviderResult<BoundWorkflowEventTrigger> {
+    Ok(BoundWorkflowEventTrigger {
+        id: input.id,
+        event_match: input.event_match.map(new_workflow_event_match),
+        target: input.target.map(new_bound_workflow_target).transpose()?,
+        paused: input.paused,
+        created_at: input.created_at,
+        updated_at: input.updated_at,
+        created_by: input.created_by.map(new_workflow_actor),
+        execution_ref: input.execution_ref,
+    })
+}
+
+/// Returns input copied from a workflow-provider event trigger.
+pub fn bound_workflow_event_trigger_input_from_trigger(
+    input: &BoundWorkflowEventTrigger,
+) -> ProviderResult<BoundWorkflowEventTriggerInput> {
+    Ok(BoundWorkflowEventTriggerInput {
+        id: input.id.clone(),
+        event_match: input
+            .event_match
+            .as_ref()
+            .map(workflow_event_match_input_from_match),
+        target: input
+            .target
+            .as_ref()
+            .map(bound_workflow_target_input_from_target)
+            .transpose()?,
+        paused: input.paused,
+        created_at: input.created_at,
+        updated_at: input.updated_at,
         created_by: input
             .created_by
             .as_ref()
@@ -1016,43 +1985,33 @@ pub fn bound_workflow_schedule_input_from_schedule(
     })
 }
 
-/// Returns a deep copy of a workflow-provider schedule.
-pub fn new_bound_workflow_schedule_from_schedule(
-    input: &pb::BoundWorkflowSchedule,
-) -> ProviderResult<pb::BoundWorkflowSchedule> {
-    new_bound_workflow_schedule(bound_workflow_schedule_input_from_schedule(input)?)
-}
-
-/// Creates a workflow-provider event trigger.
-pub fn new_bound_workflow_event_trigger(
-    input: BoundWorkflowEventTriggerInput,
+pub(crate) fn bound_workflow_event_trigger_to_proto(
+    input: BoundWorkflowEventTrigger,
 ) -> ProviderResult<pb::BoundWorkflowEventTrigger> {
     Ok(pb::BoundWorkflowEventTrigger {
         id: input.id,
-        r#match: input.event_match.map(new_workflow_event_match),
-        target: input.target.map(new_bound_workflow_target).transpose()?,
+        r#match: input.event_match.map(workflow_event_match_to_proto),
+        target: input
+            .target
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
         paused: input.paused,
         created_at: input.created_at.map(protocol::timestamp_from_system_time),
         updated_at: input.updated_at.map(protocol::timestamp_from_system_time),
-        created_by: input.created_by.map(new_workflow_actor),
+        created_by: input.created_by.map(workflow_actor_to_proto),
         execution_ref: input.execution_ref,
     })
 }
 
-/// Returns input copied from a workflow-provider event trigger.
-pub fn bound_workflow_event_trigger_input_from_trigger(
-    input: &pb::BoundWorkflowEventTrigger,
-) -> ProviderResult<BoundWorkflowEventTriggerInput> {
-    Ok(BoundWorkflowEventTriggerInput {
-        id: input.id.clone(),
-        event_match: input
-            .r#match
-            .as_ref()
-            .map(workflow_event_match_input_from_match),
+pub(crate) fn bound_workflow_event_trigger_from_proto(
+    input: pb::BoundWorkflowEventTrigger,
+) -> ProviderResult<BoundWorkflowEventTrigger> {
+    Ok(BoundWorkflowEventTrigger {
+        id: input.id,
+        event_match: input.r#match.map(workflow_event_match_from_proto),
         target: input
             .target
-            .as_ref()
-            .map(bound_workflow_target_input_from_target)
+            .map(bound_workflow_target_from_proto)
             .transpose()?,
         paused: input.paused,
         created_at: input
@@ -1065,26 +2024,41 @@ pub fn bound_workflow_event_trigger_input_from_trigger(
             .as_ref()
             .map(protocol::system_time_from_timestamp)
             .transpose()?,
-        created_by: input
-            .created_by
-            .as_ref()
-            .map(workflow_actor_input_from_actor),
-        execution_ref: input.execution_ref.clone(),
+        created_by: input.created_by.map(workflow_actor_from_proto),
+        execution_ref: input.execution_ref,
     })
 }
 
 /// Returns a deep copy of a workflow-provider event trigger.
 pub fn new_bound_workflow_event_trigger_from_trigger(
-    input: &pb::BoundWorkflowEventTrigger,
-) -> ProviderResult<pb::BoundWorkflowEventTrigger> {
-    new_bound_workflow_event_trigger(bound_workflow_event_trigger_input_from_trigger(input)?)
+    input: &BoundWorkflowEventTrigger,
+) -> ProviderResult<BoundWorkflowEventTrigger> {
+    Ok(input.clone())
+}
+
+pub(crate) fn bound_workflow_definition_from_proto(
+    input: pb::BoundWorkflowDefinition,
+) -> ProviderResult<BoundWorkflowDefinition> {
+    Ok(BoundWorkflowDefinition {
+        id: input.id,
+        target: input
+            .target
+            .map(bound_workflow_target_from_proto)
+            .transpose()?,
+        created_by: input.created_by.map(workflow_actor_from_proto),
+        created_at: input
+            .created_at
+            .as_ref()
+            .map(protocol::system_time_from_timestamp)
+            .transpose()?,
+    })
 }
 
 /// Creates a workflow execution reference.
 pub fn new_workflow_execution_reference(
     input: WorkflowExecutionReferenceInput,
-) -> ProviderResult<pb::WorkflowExecutionReference> {
-    Ok(pb::WorkflowExecutionReference {
+) -> ProviderResult<WorkflowExecutionReference> {
+    Ok(WorkflowExecutionReference {
         id: input.id,
         provider_name: input.provider_name,
         target: input.target.map(new_bound_workflow_target).transpose()?,
@@ -1095,8 +2069,8 @@ pub fn new_workflow_execution_reference(
             .into_iter()
             .map(new_workflow_access_permission)
             .collect(),
-        created_at: input.created_at.map(protocol::timestamp_from_system_time),
-        revoked_at: input.revoked_at.map(protocol::timestamp_from_system_time),
+        created_at: input.created_at,
+        revoked_at: input.revoked_at,
         subject_kind: input.subject_kind,
         display_name: input.display_name,
         auth_source: input.auth_source,
@@ -1108,7 +2082,7 @@ pub fn new_workflow_execution_reference(
 
 /// Returns input copied from a workflow execution reference.
 pub fn workflow_execution_reference_input_from_reference(
-    input: &pb::WorkflowExecutionReference,
+    input: &WorkflowExecutionReference,
 ) -> ProviderResult<WorkflowExecutionReferenceInput> {
     Ok(WorkflowExecutionReferenceInput {
         id: input.id.clone(),
@@ -1125,16 +2099,8 @@ pub fn workflow_execution_reference_input_from_reference(
             .iter()
             .map(workflow_access_permission_input_from_permission)
             .collect(),
-        created_at: input
-            .created_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
-        revoked_at: input
-            .revoked_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
+        created_at: input.created_at,
+        revoked_at: input.revoked_at,
         subject_kind: input.subject_kind.clone(),
         display_name: input.display_name.clone(),
         auth_source: input.auth_source.clone(),
@@ -1147,28 +2113,106 @@ pub fn workflow_execution_reference_input_from_reference(
     })
 }
 
+pub(crate) fn workflow_execution_reference_to_proto(
+    input: WorkflowExecutionReference,
+) -> ProviderResult<pb::WorkflowExecutionReference> {
+    Ok(pb::WorkflowExecutionReference {
+        id: input.id,
+        provider_name: input.provider_name,
+        target: input
+            .target
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
+        subject_id: input.subject_id,
+        credential_subject_id: input.credential_subject_id,
+        permissions: input
+            .permissions
+            .into_iter()
+            .map(workflow_access_permission_to_proto)
+            .collect(),
+        created_at: input.created_at.map(protocol::timestamp_from_system_time),
+        revoked_at: input.revoked_at.map(protocol::timestamp_from_system_time),
+        subject_kind: input.subject_kind,
+        display_name: input.display_name,
+        auth_source: input.auth_source,
+        caller_plugin_name: input.caller_plugin_name,
+        run_as: input.run_as.map(workflow_run_as_subject_to_proto),
+        source_definition_id: input.source_definition_id,
+    })
+}
+
+pub(crate) fn workflow_execution_reference_from_proto(
+    input: pb::WorkflowExecutionReference,
+) -> ProviderResult<WorkflowExecutionReference> {
+    Ok(WorkflowExecutionReference {
+        id: input.id,
+        provider_name: input.provider_name,
+        target: input
+            .target
+            .map(bound_workflow_target_from_proto)
+            .transpose()?,
+        subject_id: input.subject_id,
+        credential_subject_id: input.credential_subject_id,
+        permissions: input
+            .permissions
+            .into_iter()
+            .map(workflow_access_permission_from_proto)
+            .collect(),
+        created_at: input
+            .created_at
+            .as_ref()
+            .map(protocol::system_time_from_timestamp)
+            .transpose()?,
+        revoked_at: input
+            .revoked_at
+            .as_ref()
+            .map(protocol::system_time_from_timestamp)
+            .transpose()?,
+        subject_kind: input.subject_kind,
+        display_name: input.display_name,
+        auth_source: input.auth_source,
+        caller_plugin_name: input.caller_plugin_name,
+        run_as: input.run_as.map(workflow_run_as_subject_from_proto),
+        source_definition_id: input.source_definition_id,
+    })
+}
+
 /// Returns a deep copy of a workflow execution reference.
 pub fn new_workflow_execution_reference_from_reference(
-    input: &pb::WorkflowExecutionReference,
-) -> ProviderResult<pb::WorkflowExecutionReference> {
-    new_workflow_execution_reference(workflow_execution_reference_input_from_reference(input)?)
+    input: &WorkflowExecutionReference,
+) -> ProviderResult<WorkflowExecutionReference> {
+    Ok(input.clone())
 }
 
 fn invoke_workflow_operation_request_from_input(
     input: InvokeWorkflowOperationInput,
 ) -> ProviderResult<pb::InvokeWorkflowOperationRequest> {
     Ok(pb::InvokeWorkflowOperationRequest {
-        target: input.target.map(new_bound_workflow_target).transpose()?,
+        target: input
+            .target
+            .map(new_bound_workflow_target)
+            .transpose()?
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
         run_id: input.run_id,
-        trigger: input.trigger.map(new_workflow_run_trigger).transpose()?,
+        trigger: input
+            .trigger
+            .map(new_workflow_run_trigger)
+            .transpose()?
+            .map(workflow_run_trigger_to_proto)
+            .transpose()?,
         input: input.input.map(protocol::struct_from_json).transpose()?,
         metadata: input.metadata.map(protocol::struct_from_json).transpose()?,
-        created_by: input.created_by.map(new_workflow_actor),
+        created_by: input
+            .created_by
+            .map(new_workflow_actor)
+            .map(workflow_actor_to_proto),
         execution_ref: input.execution_ref,
         signals: input
             .signals
             .into_iter()
             .map(new_workflow_signal)
+            .map(|signal| signal.and_then(workflow_signal_to_proto))
             .collect::<ProviderResult<Vec<_>>>()?,
     })
 }
@@ -1180,6 +2224,180 @@ fn invoke_workflow_operation_response_from_proto(
         status: response.status,
         body: response.body,
     }
+}
+
+fn start_workflow_provider_run_request_from_proto(
+    request: pb::StartWorkflowProviderRunRequest,
+) -> ProviderResult<StartWorkflowProviderRunRequest> {
+    Ok(StartWorkflowProviderRunRequest {
+        target: request
+            .target
+            .map(bound_workflow_target_from_proto)
+            .transpose()?,
+        idempotency_key: request.idempotency_key,
+        created_by: request.created_by.map(workflow_actor_from_proto),
+        execution_ref: request.execution_ref,
+        workflow_key: request.workflow_key,
+    })
+}
+
+fn signal_workflow_run_response_to_proto(
+    response: SignalWorkflowRunResponse,
+) -> ProviderResult<pb::SignalWorkflowRunResponse> {
+    Ok(pb::SignalWorkflowRunResponse {
+        run: response.run.map(bound_workflow_run_to_proto).transpose()?,
+        signal: response.signal.map(workflow_signal_to_proto).transpose()?,
+        started_run: response.started_run,
+        workflow_key: response.workflow_key,
+    })
+}
+
+fn list_runs_response_to_proto(
+    response: ListWorkflowProviderRunsResponse,
+) -> ProviderResult<pb::ListWorkflowProviderRunsResponse> {
+    Ok(pb::ListWorkflowProviderRunsResponse {
+        runs: response
+            .runs
+            .into_iter()
+            .map(bound_workflow_run_to_proto)
+            .collect::<ProviderResult<Vec<_>>>()?,
+    })
+}
+
+fn upsert_schedule_request_from_proto(
+    request: pb::UpsertWorkflowProviderScheduleRequest,
+) -> ProviderResult<UpsertWorkflowProviderScheduleRequest> {
+    Ok(UpsertWorkflowProviderScheduleRequest {
+        schedule_id: request.schedule_id,
+        cron: request.cron,
+        timezone: request.timezone,
+        target: request
+            .target
+            .map(bound_workflow_target_from_proto)
+            .transpose()?,
+        paused: request.paused,
+        requested_by: request.requested_by.map(workflow_actor_from_proto),
+        execution_ref: request.execution_ref,
+    })
+}
+
+fn list_schedules_response_to_proto(
+    response: ListWorkflowProviderSchedulesResponse,
+) -> ProviderResult<pb::ListWorkflowProviderSchedulesResponse> {
+    Ok(pb::ListWorkflowProviderSchedulesResponse {
+        schedules: response
+            .schedules
+            .into_iter()
+            .map(bound_workflow_schedule_to_proto)
+            .collect::<ProviderResult<Vec<_>>>()?,
+    })
+}
+
+fn upsert_event_trigger_request_from_proto(
+    request: pb::UpsertWorkflowProviderEventTriggerRequest,
+) -> ProviderResult<UpsertWorkflowProviderEventTriggerRequest> {
+    Ok(UpsertWorkflowProviderEventTriggerRequest {
+        trigger_id: request.trigger_id,
+        event_match: request.r#match.map(workflow_event_match_from_proto),
+        target: request
+            .target
+            .map(bound_workflow_target_from_proto)
+            .transpose()?,
+        paused: request.paused,
+        requested_by: request.requested_by.map(workflow_actor_from_proto),
+        execution_ref: request.execution_ref,
+    })
+}
+
+fn list_event_triggers_response_to_proto(
+    response: ListWorkflowProviderEventTriggersResponse,
+) -> ProviderResult<pb::ListWorkflowProviderEventTriggersResponse> {
+    Ok(pb::ListWorkflowProviderEventTriggersResponse {
+        triggers: response
+            .triggers
+            .into_iter()
+            .map(bound_workflow_event_trigger_to_proto)
+            .collect::<ProviderResult<Vec<_>>>()?,
+    })
+}
+
+fn publish_event_request_from_proto(
+    request: pb::PublishWorkflowProviderEventRequest,
+) -> ProviderResult<PublishWorkflowProviderEventRequest> {
+    Ok(PublishWorkflowProviderEventRequest {
+        plugin_name: request.plugin_name,
+        event: request.event.map(workflow_event_from_proto).transpose()?,
+        published_by: request.published_by.map(workflow_actor_from_proto),
+    })
+}
+
+fn list_execution_references_response_to_proto(
+    response: ListWorkflowExecutionReferencesResponse,
+) -> ProviderResult<pb::ListWorkflowExecutionReferencesResponse> {
+    Ok(pb::ListWorkflowExecutionReferencesResponse {
+        references: response
+            .references
+            .into_iter()
+            .map(workflow_execution_reference_to_proto)
+            .collect::<ProviderResult<Vec<_>>>()?,
+    })
+}
+
+pub(crate) fn managed_workflow_schedule_from_proto(
+    input: pb::ManagedWorkflowSchedule,
+) -> ProviderResult<ManagedWorkflowSchedule> {
+    Ok(ManagedWorkflowSchedule {
+        provider_name: input.provider_name,
+        schedule: input
+            .schedule
+            .map(bound_workflow_schedule_from_proto)
+            .transpose()?,
+    })
+}
+
+pub(crate) fn managed_workflow_event_trigger_from_proto(
+    input: pb::ManagedWorkflowEventTrigger,
+) -> ProviderResult<ManagedWorkflowEventTrigger> {
+    Ok(ManagedWorkflowEventTrigger {
+        provider_name: input.provider_name,
+        trigger: input
+            .trigger
+            .map(bound_workflow_event_trigger_from_proto)
+            .transpose()?,
+    })
+}
+
+pub(crate) fn managed_workflow_definition_from_proto(
+    input: pb::ManagedWorkflowDefinition,
+) -> ProviderResult<ManagedWorkflowDefinition> {
+    Ok(ManagedWorkflowDefinition {
+        provider_name: input.provider_name,
+        definition: input
+            .definition
+            .map(bound_workflow_definition_from_proto)
+            .transpose()?,
+    })
+}
+
+pub(crate) fn managed_workflow_run_from_proto(
+    input: pb::ManagedWorkflowRun,
+) -> ProviderResult<ManagedWorkflowRun> {
+    Ok(ManagedWorkflowRun {
+        provider_name: input.provider_name,
+        run: input.run.map(bound_workflow_run_from_proto).transpose()?,
+    })
+}
+
+pub(crate) fn managed_workflow_run_signal_from_proto(
+    input: pb::ManagedWorkflowRunSignal,
+) -> ProviderResult<ManagedWorkflowRunSignal> {
+    Ok(ManagedWorkflowRunSignal {
+        provider_name: input.provider_name,
+        run: input.run.map(bound_workflow_run_from_proto).transpose()?,
+        signal: input.signal.map(workflow_signal_from_proto).transpose()?,
+        started_run: input.started_run,
+        workflow_key: input.workflow_key,
+    })
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -1380,8 +2598,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Starts or idempotently returns a workflow run.
     async fn start_run(
         &self,
-        _request: pb::StartWorkflowProviderRunRequest,
-    ) -> ProviderResult<pb::BoundWorkflowRun> {
+        _request: StartWorkflowProviderRunRequest,
+    ) -> ProviderResult<BoundWorkflowRun> {
         Err(crate::Error::unimplemented(
             "workflow start run is not implemented",
         ))
@@ -1390,8 +2608,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Returns one workflow run by ID.
     async fn get_run(
         &self,
-        _request: pb::GetWorkflowProviderRunRequest,
-    ) -> ProviderResult<pb::BoundWorkflowRun> {
+        _request: GetWorkflowProviderRunRequest,
+    ) -> ProviderResult<BoundWorkflowRun> {
         Err(crate::Error::unimplemented(
             "workflow get run is not implemented",
         ))
@@ -1400,8 +2618,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Lists workflow runs visible to the request subject.
     async fn list_runs(
         &self,
-        _request: pb::ListWorkflowProviderRunsRequest,
-    ) -> ProviderResult<pb::ListWorkflowProviderRunsResponse> {
+        _request: ListWorkflowProviderRunsRequest,
+    ) -> ProviderResult<ListWorkflowProviderRunsResponse> {
         Err(crate::Error::unimplemented(
             "workflow list runs is not implemented",
         ))
@@ -1410,8 +2628,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Requests cancellation of a pending or running workflow run.
     async fn cancel_run(
         &self,
-        _request: pb::CancelWorkflowProviderRunRequest,
-    ) -> ProviderResult<pb::BoundWorkflowRun> {
+        _request: CancelWorkflowProviderRunRequest,
+    ) -> ProviderResult<BoundWorkflowRun> {
         Err(crate::Error::unimplemented(
             "workflow cancel run is not implemented",
         ))
@@ -1420,8 +2638,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Delivers a signal to an existing workflow run.
     async fn signal_run(
         &self,
-        _request: pb::SignalWorkflowProviderRunRequest,
-    ) -> ProviderResult<pb::SignalWorkflowRunResponse> {
+        _request: SignalWorkflowProviderRunRequest,
+    ) -> ProviderResult<SignalWorkflowRunResponse> {
         Err(crate::Error::unimplemented(
             "workflow signal run is not implemented",
         ))
@@ -1430,8 +2648,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Delivers a signal or starts a run when no target run exists.
     async fn signal_or_start_run(
         &self,
-        _request: pb::SignalOrStartWorkflowProviderRunRequest,
-    ) -> ProviderResult<pb::SignalWorkflowRunResponse> {
+        _request: SignalOrStartWorkflowProviderRunRequest,
+    ) -> ProviderResult<SignalWorkflowRunResponse> {
         Err(crate::Error::unimplemented(
             "workflow signal or start run is not implemented",
         ))
@@ -1440,8 +2658,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Creates or updates a workflow schedule.
     async fn upsert_schedule(
         &self,
-        _request: pb::UpsertWorkflowProviderScheduleRequest,
-    ) -> ProviderResult<pb::BoundWorkflowSchedule> {
+        _request: UpsertWorkflowProviderScheduleRequest,
+    ) -> ProviderResult<BoundWorkflowSchedule> {
         Err(crate::Error::unimplemented(
             "workflow upsert schedule is not implemented",
         ))
@@ -1450,8 +2668,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Returns one workflow schedule by ID.
     async fn get_schedule(
         &self,
-        _request: pb::GetWorkflowProviderScheduleRequest,
-    ) -> ProviderResult<pb::BoundWorkflowSchedule> {
+        _request: GetWorkflowProviderScheduleRequest,
+    ) -> ProviderResult<BoundWorkflowSchedule> {
         Err(crate::Error::unimplemented(
             "workflow get schedule is not implemented",
         ))
@@ -1460,8 +2678,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Lists workflow schedules visible to the request subject.
     async fn list_schedules(
         &self,
-        _request: pb::ListWorkflowProviderSchedulesRequest,
-    ) -> ProviderResult<pb::ListWorkflowProviderSchedulesResponse> {
+        _request: ListWorkflowProviderSchedulesRequest,
+    ) -> ProviderResult<ListWorkflowProviderSchedulesResponse> {
         Err(crate::Error::unimplemented(
             "workflow list schedules is not implemented",
         ))
@@ -1470,7 +2688,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Deletes a workflow schedule.
     async fn delete_schedule(
         &self,
-        _request: pb::DeleteWorkflowProviderScheduleRequest,
+        _request: DeleteWorkflowProviderScheduleRequest,
     ) -> ProviderResult<()> {
         Err(crate::Error::unimplemented(
             "workflow delete schedule is not implemented",
@@ -1480,8 +2698,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Pauses a workflow schedule without deleting it.
     async fn pause_schedule(
         &self,
-        _request: pb::PauseWorkflowProviderScheduleRequest,
-    ) -> ProviderResult<pb::BoundWorkflowSchedule> {
+        _request: PauseWorkflowProviderScheduleRequest,
+    ) -> ProviderResult<BoundWorkflowSchedule> {
         Err(crate::Error::unimplemented(
             "workflow pause schedule is not implemented",
         ))
@@ -1490,8 +2708,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Resumes a paused workflow schedule.
     async fn resume_schedule(
         &self,
-        _request: pb::ResumeWorkflowProviderScheduleRequest,
-    ) -> ProviderResult<pb::BoundWorkflowSchedule> {
+        _request: ResumeWorkflowProviderScheduleRequest,
+    ) -> ProviderResult<BoundWorkflowSchedule> {
         Err(crate::Error::unimplemented(
             "workflow resume schedule is not implemented",
         ))
@@ -1500,8 +2718,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Creates or updates a workflow event trigger.
     async fn upsert_event_trigger(
         &self,
-        _request: pb::UpsertWorkflowProviderEventTriggerRequest,
-    ) -> ProviderResult<pb::BoundWorkflowEventTrigger> {
+        _request: UpsertWorkflowProviderEventTriggerRequest,
+    ) -> ProviderResult<BoundWorkflowEventTrigger> {
         Err(crate::Error::unimplemented(
             "workflow upsert event trigger is not implemented",
         ))
@@ -1510,8 +2728,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Returns one workflow event trigger by ID.
     async fn get_event_trigger(
         &self,
-        _request: pb::GetWorkflowProviderEventTriggerRequest,
-    ) -> ProviderResult<pb::BoundWorkflowEventTrigger> {
+        _request: GetWorkflowProviderEventTriggerRequest,
+    ) -> ProviderResult<BoundWorkflowEventTrigger> {
         Err(crate::Error::unimplemented(
             "workflow get event trigger is not implemented",
         ))
@@ -1520,8 +2738,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Lists workflow event triggers visible to the request subject.
     async fn list_event_triggers(
         &self,
-        _request: pb::ListWorkflowProviderEventTriggersRequest,
-    ) -> ProviderResult<pb::ListWorkflowProviderEventTriggersResponse> {
+        _request: ListWorkflowProviderEventTriggersRequest,
+    ) -> ProviderResult<ListWorkflowProviderEventTriggersResponse> {
         Err(crate::Error::unimplemented(
             "workflow list event triggers is not implemented",
         ))
@@ -1530,7 +2748,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Deletes a workflow event trigger.
     async fn delete_event_trigger(
         &self,
-        _request: pb::DeleteWorkflowProviderEventTriggerRequest,
+        _request: DeleteWorkflowProviderEventTriggerRequest,
     ) -> ProviderResult<()> {
         Err(crate::Error::unimplemented(
             "workflow delete event trigger is not implemented",
@@ -1540,8 +2758,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Pauses a workflow event trigger without deleting it.
     async fn pause_event_trigger(
         &self,
-        _request: pb::PauseWorkflowProviderEventTriggerRequest,
-    ) -> ProviderResult<pb::BoundWorkflowEventTrigger> {
+        _request: PauseWorkflowProviderEventTriggerRequest,
+    ) -> ProviderResult<BoundWorkflowEventTrigger> {
         Err(crate::Error::unimplemented(
             "workflow pause event trigger is not implemented",
         ))
@@ -1550,8 +2768,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Resumes a paused workflow event trigger.
     async fn resume_event_trigger(
         &self,
-        _request: pb::ResumeWorkflowProviderEventTriggerRequest,
-    ) -> ProviderResult<pb::BoundWorkflowEventTrigger> {
+        _request: ResumeWorkflowProviderEventTriggerRequest,
+    ) -> ProviderResult<BoundWorkflowEventTrigger> {
         Err(crate::Error::unimplemented(
             "workflow resume event trigger is not implemented",
         ))
@@ -1560,7 +2778,7 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Publishes a workflow event for trigger matching.
     async fn publish_event(
         &self,
-        _request: pb::PublishWorkflowProviderEventRequest,
+        _request: PublishWorkflowProviderEventRequest,
     ) -> ProviderResult<()> {
         Err(crate::Error::unimplemented(
             "workflow publish event is not implemented",
@@ -1570,8 +2788,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Stores or updates a workflow execution reference.
     async fn put_execution_reference(
         &self,
-        _request: pb::PutWorkflowExecutionReferenceRequest,
-    ) -> ProviderResult<pb::WorkflowExecutionReference> {
+        _request: PutWorkflowExecutionReferenceRequest,
+    ) -> ProviderResult<WorkflowExecutionReference> {
         Err(crate::Error::unimplemented(
             "workflow put execution reference is not implemented",
         ))
@@ -1580,8 +2798,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Returns one workflow execution reference.
     async fn get_execution_reference(
         &self,
-        _request: pb::GetWorkflowExecutionReferenceRequest,
-    ) -> ProviderResult<pb::WorkflowExecutionReference> {
+        _request: GetWorkflowExecutionReferenceRequest,
+    ) -> ProviderResult<WorkflowExecutionReference> {
         Err(crate::Error::unimplemented(
             "workflow get execution reference is not implemented",
         ))
@@ -1590,8 +2808,8 @@ pub trait WorkflowProvider: Send + Sync + 'static {
     /// Lists workflow execution references for a scope.
     async fn list_execution_references(
         &self,
-        _request: pb::ListWorkflowExecutionReferencesRequest,
-    ) -> ProviderResult<pb::ListWorkflowExecutionReferencesResponse> {
+        _request: ListWorkflowExecutionReferencesRequest,
+    ) -> ProviderResult<ListWorkflowExecutionReferencesResponse> {
         Err(crate::Error::unimplemented(
             "workflow list execution references is not implemented",
         ))
@@ -1620,10 +2838,16 @@ where
     ) -> std::result::Result<GrpcResponse<pb::BoundWorkflowRun>, Status> {
         let run = self
             .provider
-            .start_run(request.into_inner())
+            .start_run(
+                start_workflow_provider_run_request_from_proto(request.into_inner())
+                    .map_err(|error| rpc_status("workflow start run", error))?,
+            )
             .await
             .map_err(|error| rpc_status("workflow start run", error))?;
-        Ok(GrpcResponse::new(run))
+        Ok(GrpcResponse::new(
+            bound_workflow_run_to_proto(run)
+                .map_err(|error| rpc_status("workflow start run", error))?,
+        ))
     }
 
     async fn get_run(
@@ -1632,10 +2856,18 @@ where
     ) -> std::result::Result<GrpcResponse<pb::BoundWorkflowRun>, Status> {
         let run = self
             .provider
-            .get_run(request.into_inner())
+            .get_run({
+                let request = request.into_inner();
+                GetWorkflowProviderRunRequest {
+                    run_id: request.run_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow get run", error))?;
-        Ok(GrpcResponse::new(run))
+        Ok(GrpcResponse::new(
+            bound_workflow_run_to_proto(run)
+                .map_err(|error| rpc_status("workflow get run", error))?,
+        ))
     }
 
     async fn list_runs(
@@ -1644,10 +2876,16 @@ where
     ) -> std::result::Result<GrpcResponse<pb::ListWorkflowProviderRunsResponse>, Status> {
         let response = self
             .provider
-            .list_runs(request.into_inner())
+            .list_runs({
+                let _request = request.into_inner();
+                ListWorkflowProviderRunsRequest {}
+            })
             .await
             .map_err(|error| rpc_status("workflow list runs", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(
+            list_runs_response_to_proto(response)
+                .map_err(|error| rpc_status("workflow list runs", error))?,
+        ))
     }
 
     async fn cancel_run(
@@ -1656,10 +2894,19 @@ where
     ) -> std::result::Result<GrpcResponse<pb::BoundWorkflowRun>, Status> {
         let run = self
             .provider
-            .cancel_run(request.into_inner())
+            .cancel_run({
+                let request = request.into_inner();
+                CancelWorkflowProviderRunRequest {
+                    run_id: request.run_id,
+                    reason: request.reason,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow cancel run", error))?;
-        Ok(GrpcResponse::new(run))
+        Ok(GrpcResponse::new(
+            bound_workflow_run_to_proto(run)
+                .map_err(|error| rpc_status("workflow cancel run", error))?,
+        ))
     }
 
     async fn signal_run(
@@ -1668,10 +2915,23 @@ where
     ) -> std::result::Result<GrpcResponse<pb::SignalWorkflowRunResponse>, Status> {
         let response = self
             .provider
-            .signal_run(request.into_inner())
+            .signal_run({
+                let request = request.into_inner();
+                SignalWorkflowProviderRunRequest {
+                    run_id: request.run_id,
+                    signal: request
+                        .signal
+                        .map(workflow_signal_from_proto)
+                        .transpose()
+                        .map_err(|error| rpc_status("workflow signal run", error))?,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow signal run", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(
+            signal_workflow_run_response_to_proto(response)
+                .map_err(|error| rpc_status("workflow signal run", error))?,
+        ))
     }
 
     async fn signal_or_start_run(
@@ -1680,10 +2940,31 @@ where
     ) -> std::result::Result<GrpcResponse<pb::SignalWorkflowRunResponse>, Status> {
         let response = self
             .provider
-            .signal_or_start_run(request.into_inner())
+            .signal_or_start_run({
+                let request = request.into_inner();
+                SignalOrStartWorkflowProviderRunRequest {
+                    workflow_key: request.workflow_key,
+                    target: request
+                        .target
+                        .map(bound_workflow_target_from_proto)
+                        .transpose()
+                        .map_err(|error| rpc_status("workflow signal or start run", error))?,
+                    idempotency_key: request.idempotency_key,
+                    created_by: request.created_by.map(workflow_actor_from_proto),
+                    execution_ref: request.execution_ref,
+                    signal: request
+                        .signal
+                        .map(workflow_signal_from_proto)
+                        .transpose()
+                        .map_err(|error| rpc_status("workflow signal or start run", error))?,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow signal or start run", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(
+            signal_workflow_run_response_to_proto(response)
+                .map_err(|error| rpc_status("workflow signal or start run", error))?,
+        ))
     }
 
     async fn upsert_schedule(
@@ -1692,10 +2973,16 @@ where
     ) -> std::result::Result<GrpcResponse<pb::BoundWorkflowSchedule>, Status> {
         let schedule = self
             .provider
-            .upsert_schedule(request.into_inner())
+            .upsert_schedule(
+                upsert_schedule_request_from_proto(request.into_inner())
+                    .map_err(|error| rpc_status("workflow upsert schedule", error))?,
+            )
             .await
             .map_err(|error| rpc_status("workflow upsert schedule", error))?;
-        Ok(GrpcResponse::new(schedule))
+        Ok(GrpcResponse::new(
+            bound_workflow_schedule_to_proto(schedule)
+                .map_err(|error| rpc_status("workflow upsert schedule", error))?,
+        ))
     }
 
     async fn get_schedule(
@@ -1704,10 +2991,18 @@ where
     ) -> std::result::Result<GrpcResponse<pb::BoundWorkflowSchedule>, Status> {
         let schedule = self
             .provider
-            .get_schedule(request.into_inner())
+            .get_schedule({
+                let request = request.into_inner();
+                GetWorkflowProviderScheduleRequest {
+                    schedule_id: request.schedule_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow get schedule", error))?;
-        Ok(GrpcResponse::new(schedule))
+        Ok(GrpcResponse::new(
+            bound_workflow_schedule_to_proto(schedule)
+                .map_err(|error| rpc_status("workflow get schedule", error))?,
+        ))
     }
 
     async fn list_schedules(
@@ -1716,10 +3011,16 @@ where
     ) -> std::result::Result<GrpcResponse<pb::ListWorkflowProviderSchedulesResponse>, Status> {
         let response = self
             .provider
-            .list_schedules(request.into_inner())
+            .list_schedules({
+                let _request = request.into_inner();
+                ListWorkflowProviderSchedulesRequest {}
+            })
             .await
             .map_err(|error| rpc_status("workflow list schedules", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(
+            list_schedules_response_to_proto(response)
+                .map_err(|error| rpc_status("workflow list schedules", error))?,
+        ))
     }
 
     async fn delete_schedule(
@@ -1727,7 +3028,12 @@ where
         request: GrpcRequest<pb::DeleteWorkflowProviderScheduleRequest>,
     ) -> std::result::Result<GrpcResponse<()>, Status> {
         self.provider
-            .delete_schedule(request.into_inner())
+            .delete_schedule({
+                let request = request.into_inner();
+                DeleteWorkflowProviderScheduleRequest {
+                    schedule_id: request.schedule_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow delete schedule", error))?;
         Ok(GrpcResponse::new(()))
@@ -1739,10 +3045,18 @@ where
     ) -> std::result::Result<GrpcResponse<pb::BoundWorkflowSchedule>, Status> {
         let schedule = self
             .provider
-            .pause_schedule(request.into_inner())
+            .pause_schedule({
+                let request = request.into_inner();
+                PauseWorkflowProviderScheduleRequest {
+                    schedule_id: request.schedule_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow pause schedule", error))?;
-        Ok(GrpcResponse::new(schedule))
+        Ok(GrpcResponse::new(
+            bound_workflow_schedule_to_proto(schedule)
+                .map_err(|error| rpc_status("workflow pause schedule", error))?,
+        ))
     }
 
     async fn resume_schedule(
@@ -1751,10 +3065,18 @@ where
     ) -> std::result::Result<GrpcResponse<pb::BoundWorkflowSchedule>, Status> {
         let schedule = self
             .provider
-            .resume_schedule(request.into_inner())
+            .resume_schedule({
+                let request = request.into_inner();
+                ResumeWorkflowProviderScheduleRequest {
+                    schedule_id: request.schedule_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow resume schedule", error))?;
-        Ok(GrpcResponse::new(schedule))
+        Ok(GrpcResponse::new(
+            bound_workflow_schedule_to_proto(schedule)
+                .map_err(|error| rpc_status("workflow resume schedule", error))?,
+        ))
     }
 
     async fn upsert_event_trigger(
@@ -1763,10 +3085,16 @@ where
     ) -> std::result::Result<GrpcResponse<pb::BoundWorkflowEventTrigger>, Status> {
         let trigger = self
             .provider
-            .upsert_event_trigger(request.into_inner())
+            .upsert_event_trigger(
+                upsert_event_trigger_request_from_proto(request.into_inner())
+                    .map_err(|error| rpc_status("workflow upsert event trigger", error))?,
+            )
             .await
             .map_err(|error| rpc_status("workflow upsert event trigger", error))?;
-        Ok(GrpcResponse::new(trigger))
+        Ok(GrpcResponse::new(
+            bound_workflow_event_trigger_to_proto(trigger)
+                .map_err(|error| rpc_status("workflow upsert event trigger", error))?,
+        ))
     }
 
     async fn get_event_trigger(
@@ -1775,10 +3103,18 @@ where
     ) -> std::result::Result<GrpcResponse<pb::BoundWorkflowEventTrigger>, Status> {
         let trigger = self
             .provider
-            .get_event_trigger(request.into_inner())
+            .get_event_trigger({
+                let request = request.into_inner();
+                GetWorkflowProviderEventTriggerRequest {
+                    trigger_id: request.trigger_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow get event trigger", error))?;
-        Ok(GrpcResponse::new(trigger))
+        Ok(GrpcResponse::new(
+            bound_workflow_event_trigger_to_proto(trigger)
+                .map_err(|error| rpc_status("workflow get event trigger", error))?,
+        ))
     }
 
     async fn list_event_triggers(
@@ -1788,10 +3124,16 @@ where
     {
         let response = self
             .provider
-            .list_event_triggers(request.into_inner())
+            .list_event_triggers({
+                let _request = request.into_inner();
+                ListWorkflowProviderEventTriggersRequest {}
+            })
             .await
             .map_err(|error| rpc_status("workflow list event triggers", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(
+            list_event_triggers_response_to_proto(response)
+                .map_err(|error| rpc_status("workflow list event triggers", error))?,
+        ))
     }
 
     async fn delete_event_trigger(
@@ -1799,7 +3141,12 @@ where
         request: GrpcRequest<pb::DeleteWorkflowProviderEventTriggerRequest>,
     ) -> std::result::Result<GrpcResponse<()>, Status> {
         self.provider
-            .delete_event_trigger(request.into_inner())
+            .delete_event_trigger({
+                let request = request.into_inner();
+                DeleteWorkflowProviderEventTriggerRequest {
+                    trigger_id: request.trigger_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow delete event trigger", error))?;
         Ok(GrpcResponse::new(()))
@@ -1811,10 +3158,18 @@ where
     ) -> std::result::Result<GrpcResponse<pb::BoundWorkflowEventTrigger>, Status> {
         let trigger = self
             .provider
-            .pause_event_trigger(request.into_inner())
+            .pause_event_trigger({
+                let request = request.into_inner();
+                PauseWorkflowProviderEventTriggerRequest {
+                    trigger_id: request.trigger_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow pause event trigger", error))?;
-        Ok(GrpcResponse::new(trigger))
+        Ok(GrpcResponse::new(
+            bound_workflow_event_trigger_to_proto(trigger)
+                .map_err(|error| rpc_status("workflow pause event trigger", error))?,
+        ))
     }
 
     async fn resume_event_trigger(
@@ -1823,10 +3178,18 @@ where
     ) -> std::result::Result<GrpcResponse<pb::BoundWorkflowEventTrigger>, Status> {
         let trigger = self
             .provider
-            .resume_event_trigger(request.into_inner())
+            .resume_event_trigger({
+                let request = request.into_inner();
+                ResumeWorkflowProviderEventTriggerRequest {
+                    trigger_id: request.trigger_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow resume event trigger", error))?;
-        Ok(GrpcResponse::new(trigger))
+        Ok(GrpcResponse::new(
+            bound_workflow_event_trigger_to_proto(trigger)
+                .map_err(|error| rpc_status("workflow resume event trigger", error))?,
+        ))
     }
 
     async fn publish_event(
@@ -1834,7 +3197,10 @@ where
         request: GrpcRequest<pb::PublishWorkflowProviderEventRequest>,
     ) -> std::result::Result<GrpcResponse<()>, Status> {
         self.provider
-            .publish_event(request.into_inner())
+            .publish_event(
+                publish_event_request_from_proto(request.into_inner())
+                    .map_err(|error| rpc_status("workflow publish event", error))?,
+            )
             .await
             .map_err(|error| rpc_status("workflow publish event", error))?;
         Ok(GrpcResponse::new(()))
@@ -1846,10 +3212,22 @@ where
     ) -> std::result::Result<GrpcResponse<pb::WorkflowExecutionReference>, Status> {
         let reference = self
             .provider
-            .put_execution_reference(request.into_inner())
+            .put_execution_reference({
+                let request = request.into_inner();
+                PutWorkflowExecutionReferenceRequest {
+                    reference: request
+                        .reference
+                        .map(workflow_execution_reference_from_proto)
+                        .transpose()
+                        .map_err(|error| rpc_status("workflow put execution reference", error))?,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow put execution reference", error))?;
-        Ok(GrpcResponse::new(reference))
+        Ok(GrpcResponse::new(
+            workflow_execution_reference_to_proto(reference)
+                .map_err(|error| rpc_status("workflow put execution reference", error))?,
+        ))
     }
 
     async fn get_execution_reference(
@@ -1858,10 +3236,16 @@ where
     ) -> std::result::Result<GrpcResponse<pb::WorkflowExecutionReference>, Status> {
         let reference = self
             .provider
-            .get_execution_reference(request.into_inner())
+            .get_execution_reference({
+                let request = request.into_inner();
+                GetWorkflowExecutionReferenceRequest { id: request.id }
+            })
             .await
             .map_err(|error| rpc_status("workflow get execution reference", error))?;
-        Ok(GrpcResponse::new(reference))
+        Ok(GrpcResponse::new(
+            workflow_execution_reference_to_proto(reference)
+                .map_err(|error| rpc_status("workflow get execution reference", error))?,
+        ))
     }
 
     async fn list_execution_references(
@@ -1871,9 +3255,17 @@ where
     {
         let response = self
             .provider
-            .list_execution_references(request.into_inner())
+            .list_execution_references({
+                let request = request.into_inner();
+                ListWorkflowExecutionReferencesRequest {
+                    subject_id: request.subject_id,
+                }
+            })
             .await
             .map_err(|error| rpc_status("workflow list execution references", error))?;
-        Ok(GrpcResponse::new(response))
+        Ok(GrpcResponse::new(
+            list_execution_references_response_to_proto(response)
+                .map_err(|error| rpc_status("workflow list execution references", error))?,
+        ))
     }
 }

--- a/sdk/rust/src/workflow_manager.rs
+++ b/sdk/rust/src/workflow_manager.rs
@@ -1,5 +1,3 @@
-use std::time::SystemTime;
-
 use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
 use tonic::Request;
@@ -13,14 +11,15 @@ use crate::generated::v1::{
     self as pb,
     workflow_manager_host_client::WorkflowManagerHostClient as ProtoWorkflowManagerHostClient,
 };
-use crate::protocol;
 use crate::workflow::{
-    BoundWorkflowTargetInput, WorkflowActorInput, WorkflowEventInput, WorkflowEventMatchInput,
-    WorkflowRunTriggerInput, WorkflowSignalInput, bound_workflow_target_input_from_target,
+    BoundWorkflowTargetInput, ManagedWorkflowDefinition, ManagedWorkflowEventTrigger,
+    ManagedWorkflowRun, ManagedWorkflowRunSignal, ManagedWorkflowSchedule, WorkflowEvent,
+    WorkflowEventInput, WorkflowEventMatchInput, WorkflowSignalInput,
+    bound_workflow_target_to_proto, managed_workflow_definition_from_proto,
+    managed_workflow_event_trigger_from_proto, managed_workflow_run_from_proto,
+    managed_workflow_run_signal_from_proto, managed_workflow_schedule_from_proto,
     new_bound_workflow_target, new_workflow_event, new_workflow_event_match, new_workflow_signal,
-    workflow_actor_input_from_actor, workflow_event_input_from_event,
-    workflow_event_match_input_from_match, workflow_run_trigger_input_from_trigger,
-    workflow_signal_input_from_signal,
+    workflow_event_match_to_proto, workflow_event_to_proto, workflow_signal_to_proto,
 };
 
 type WorkflowManagerTransport = InterceptedService<Channel, RelayTokenInterceptor>;
@@ -188,97 +187,17 @@ pub struct WorkflowManagerPublishEventInput {
     pub event: Option<WorkflowEventInput>,
 }
 
-#[derive(Clone, Debug, Default)]
-pub struct WorkflowManagerBoundRun {
-    pub id: String,
-    pub status: pb::WorkflowRunStatus,
-    pub target: Option<BoundWorkflowTargetInput>,
-    pub trigger: Option<WorkflowRunTriggerInput>,
-    pub created_at: Option<SystemTime>,
-    pub started_at: Option<SystemTime>,
-    pub completed_at: Option<SystemTime>,
-    pub status_message: String,
-    pub result_body: String,
-    pub created_by: Option<WorkflowActorInput>,
-    pub execution_ref: String,
-    pub workflow_key: String,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct WorkflowManagerBoundDefinition {
-    pub id: String,
-    pub target: Option<BoundWorkflowTargetInput>,
-    pub created_by: Option<WorkflowActorInput>,
-    pub created_at: Option<SystemTime>,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct WorkflowManagerBoundSchedule {
-    pub id: String,
-    pub cron: String,
-    pub timezone: String,
-    pub target: Option<BoundWorkflowTargetInput>,
-    pub paused: bool,
-    pub created_at: Option<SystemTime>,
-    pub updated_at: Option<SystemTime>,
-    pub next_run_at: Option<SystemTime>,
-    pub created_by: Option<WorkflowActorInput>,
-    pub execution_ref: String,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct WorkflowManagerBoundEventTrigger {
-    pub id: String,
-    pub r#match: Option<WorkflowEventMatchInput>,
-    pub target: Option<BoundWorkflowTargetInput>,
-    pub paused: bool,
-    pub created_at: Option<SystemTime>,
-    pub updated_at: Option<SystemTime>,
-    pub created_by: Option<WorkflowActorInput>,
-    pub execution_ref: String,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct WorkflowManagerRun {
-    pub provider_name: String,
-    pub run: Option<WorkflowManagerBoundRun>,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct WorkflowManagerRunSignal {
-    pub provider_name: String,
-    pub run: Option<WorkflowManagerBoundRun>,
-    pub signal: Option<WorkflowSignalInput>,
-    pub started_run: bool,
-    pub workflow_key: String,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct WorkflowManagerDefinition {
-    pub provider_name: String,
-    pub definition: Option<WorkflowManagerBoundDefinition>,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct WorkflowManagerSchedule {
-    pub provider_name: String,
-    pub schedule: Option<WorkflowManagerBoundSchedule>,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct WorkflowManagerEventTrigger {
-    pub provider_name: String,
-    pub trigger: Option<WorkflowManagerBoundEventTrigger>,
-}
-
-pub type WorkflowManagerPublishedEvent = WorkflowEventInput;
-
-pub fn new_workflow_manager_start_run_request(
+pub(crate) fn new_workflow_manager_start_run_request(
     input: WorkflowManagerStartRunInput,
 ) -> crate::Result<pb::WorkflowManagerStartRunRequest> {
     Ok(pb::WorkflowManagerStartRunRequest {
         provider_name: input.provider_name,
-        target: input.target.map(new_bound_workflow_target).transpose()?,
+        target: input
+            .target
+            .map(new_bound_workflow_target)
+            .transpose()?
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
         idempotency_key: input.idempotency_key,
         workflow_key: input.workflow_key,
         invocation_token: String::new(),
@@ -286,42 +205,62 @@ pub fn new_workflow_manager_start_run_request(
     })
 }
 
-pub fn new_workflow_manager_signal_run_request(
+pub(crate) fn new_workflow_manager_signal_run_request(
     input: WorkflowManagerSignalRunInput,
 ) -> crate::Result<pb::WorkflowManagerSignalRunRequest> {
     Ok(pb::WorkflowManagerSignalRunRequest {
         run_id: input.run_id,
-        signal: input.signal.map(new_workflow_signal).transpose()?,
+        signal: input
+            .signal
+            .map(new_workflow_signal)
+            .transpose()?
+            .map(workflow_signal_to_proto)
+            .transpose()?,
         invocation_token: String::new(),
     })
 }
 
-pub fn new_workflow_manager_signal_or_start_run_request(
+pub(crate) fn new_workflow_manager_signal_or_start_run_request(
     input: WorkflowManagerSignalOrStartRunInput,
 ) -> crate::Result<pb::WorkflowManagerSignalOrStartRunRequest> {
     Ok(pb::WorkflowManagerSignalOrStartRunRequest {
         provider_name: input.provider_name,
         workflow_key: input.workflow_key,
-        target: input.target.map(new_bound_workflow_target).transpose()?,
+        target: input
+            .target
+            .map(new_bound_workflow_target)
+            .transpose()?
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
         idempotency_key: input.idempotency_key,
-        signal: input.signal.map(new_workflow_signal).transpose()?,
+        signal: input
+            .signal
+            .map(new_workflow_signal)
+            .transpose()?
+            .map(workflow_signal_to_proto)
+            .transpose()?,
         invocation_token: String::new(),
         definition_id: input.definition_id,
     })
 }
 
-pub fn new_workflow_manager_create_definition_request(
+pub(crate) fn new_workflow_manager_create_definition_request(
     input: WorkflowManagerCreateDefinitionInput,
 ) -> crate::Result<pb::WorkflowManagerCreateDefinitionRequest> {
     Ok(pb::WorkflowManagerCreateDefinitionRequest {
         provider_name: input.provider_name,
-        target: input.target.map(new_bound_workflow_target).transpose()?,
+        target: input
+            .target
+            .map(new_bound_workflow_target)
+            .transpose()?
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
         invocation_token: String::new(),
         idempotency_key: input.idempotency_key,
     })
 }
 
-pub fn new_workflow_manager_get_definition_request(
+pub(crate) fn new_workflow_manager_get_definition_request(
     input: WorkflowManagerGetDefinitionInput,
 ) -> pb::WorkflowManagerGetDefinitionRequest {
     pb::WorkflowManagerGetDefinitionRequest {
@@ -330,18 +269,23 @@ pub fn new_workflow_manager_get_definition_request(
     }
 }
 
-pub fn new_workflow_manager_update_definition_request(
+pub(crate) fn new_workflow_manager_update_definition_request(
     input: WorkflowManagerUpdateDefinitionInput,
 ) -> crate::Result<pb::WorkflowManagerUpdateDefinitionRequest> {
     Ok(pb::WorkflowManagerUpdateDefinitionRequest {
         definition_id: input.definition_id,
         provider_name: input.provider_name,
-        target: input.target.map(new_bound_workflow_target).transpose()?,
+        target: input
+            .target
+            .map(new_bound_workflow_target)
+            .transpose()?
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
         invocation_token: String::new(),
     })
 }
 
-pub fn new_workflow_manager_delete_definition_request(
+pub(crate) fn new_workflow_manager_delete_definition_request(
     input: WorkflowManagerDeleteDefinitionInput,
 ) -> pb::WorkflowManagerDeleteDefinitionRequest {
     pb::WorkflowManagerDeleteDefinitionRequest {
@@ -350,14 +294,19 @@ pub fn new_workflow_manager_delete_definition_request(
     }
 }
 
-pub fn new_workflow_manager_create_schedule_request(
+pub(crate) fn new_workflow_manager_create_schedule_request(
     input: WorkflowManagerCreateScheduleInput,
 ) -> crate::Result<pb::WorkflowManagerCreateScheduleRequest> {
     Ok(pb::WorkflowManagerCreateScheduleRequest {
         provider_name: input.provider_name,
         cron: input.cron,
         timezone: input.timezone,
-        target: input.target.map(new_bound_workflow_target).transpose()?,
+        target: input
+            .target
+            .map(new_bound_workflow_target)
+            .transpose()?
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
         paused: input.paused,
         invocation_token: String::new(),
         idempotency_key: input.idempotency_key,
@@ -365,7 +314,7 @@ pub fn new_workflow_manager_create_schedule_request(
     })
 }
 
-pub fn new_workflow_manager_get_schedule_request(
+pub(crate) fn new_workflow_manager_get_schedule_request(
     input: WorkflowManagerGetScheduleInput,
 ) -> pb::WorkflowManagerGetScheduleRequest {
     pb::WorkflowManagerGetScheduleRequest {
@@ -374,7 +323,7 @@ pub fn new_workflow_manager_get_schedule_request(
     }
 }
 
-pub fn new_workflow_manager_update_schedule_request(
+pub(crate) fn new_workflow_manager_update_schedule_request(
     input: WorkflowManagerUpdateScheduleInput,
 ) -> crate::Result<pb::WorkflowManagerUpdateScheduleRequest> {
     Ok(pb::WorkflowManagerUpdateScheduleRequest {
@@ -382,14 +331,19 @@ pub fn new_workflow_manager_update_schedule_request(
         provider_name: input.provider_name,
         cron: input.cron,
         timezone: input.timezone,
-        target: input.target.map(new_bound_workflow_target).transpose()?,
+        target: input
+            .target
+            .map(new_bound_workflow_target)
+            .transpose()?
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
         paused: input.paused,
         invocation_token: String::new(),
         definition_id: input.definition_id,
     })
 }
 
-pub fn new_workflow_manager_delete_schedule_request(
+pub(crate) fn new_workflow_manager_delete_schedule_request(
     input: WorkflowManagerDeleteScheduleInput,
 ) -> pb::WorkflowManagerDeleteScheduleRequest {
     pb::WorkflowManagerDeleteScheduleRequest {
@@ -398,7 +352,7 @@ pub fn new_workflow_manager_delete_schedule_request(
     }
 }
 
-pub fn new_workflow_manager_pause_schedule_request(
+pub(crate) fn new_workflow_manager_pause_schedule_request(
     input: WorkflowManagerPauseScheduleInput,
 ) -> pb::WorkflowManagerPauseScheduleRequest {
     pb::WorkflowManagerPauseScheduleRequest {
@@ -407,7 +361,7 @@ pub fn new_workflow_manager_pause_schedule_request(
     }
 }
 
-pub fn new_workflow_manager_resume_schedule_request(
+pub(crate) fn new_workflow_manager_resume_schedule_request(
     input: WorkflowManagerResumeScheduleInput,
 ) -> pb::WorkflowManagerResumeScheduleRequest {
     pb::WorkflowManagerResumeScheduleRequest {
@@ -416,13 +370,21 @@ pub fn new_workflow_manager_resume_schedule_request(
     }
 }
 
-pub fn new_workflow_manager_create_event_trigger_request(
+pub(crate) fn new_workflow_manager_create_event_trigger_request(
     input: WorkflowManagerCreateEventTriggerInput,
 ) -> crate::Result<pb::WorkflowManagerCreateEventTriggerRequest> {
     Ok(pb::WorkflowManagerCreateEventTriggerRequest {
         provider_name: input.provider_name,
-        r#match: input.event_match.map(new_workflow_event_match),
-        target: input.target.map(new_bound_workflow_target).transpose()?,
+        r#match: input
+            .event_match
+            .map(new_workflow_event_match)
+            .map(workflow_event_match_to_proto),
+        target: input
+            .target
+            .map(new_bound_workflow_target)
+            .transpose()?
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
         paused: input.paused,
         invocation_token: String::new(),
         idempotency_key: input.idempotency_key,
@@ -430,7 +392,7 @@ pub fn new_workflow_manager_create_event_trigger_request(
     })
 }
 
-pub fn new_workflow_manager_get_event_trigger_request(
+pub(crate) fn new_workflow_manager_get_event_trigger_request(
     input: WorkflowManagerGetEventTriggerInput,
 ) -> pb::WorkflowManagerGetEventTriggerRequest {
     pb::WorkflowManagerGetEventTriggerRequest {
@@ -439,21 +401,29 @@ pub fn new_workflow_manager_get_event_trigger_request(
     }
 }
 
-pub fn new_workflow_manager_update_event_trigger_request(
+pub(crate) fn new_workflow_manager_update_event_trigger_request(
     input: WorkflowManagerUpdateEventTriggerInput,
 ) -> crate::Result<pb::WorkflowManagerUpdateEventTriggerRequest> {
     Ok(pb::WorkflowManagerUpdateEventTriggerRequest {
         trigger_id: input.trigger_id,
         provider_name: input.provider_name,
-        r#match: input.event_match.map(new_workflow_event_match),
-        target: input.target.map(new_bound_workflow_target).transpose()?,
+        r#match: input
+            .event_match
+            .map(new_workflow_event_match)
+            .map(workflow_event_match_to_proto),
+        target: input
+            .target
+            .map(new_bound_workflow_target)
+            .transpose()?
+            .map(bound_workflow_target_to_proto)
+            .transpose()?,
         paused: input.paused,
         invocation_token: String::new(),
         definition_id: input.definition_id,
     })
 }
 
-pub fn new_workflow_manager_delete_event_trigger_request(
+pub(crate) fn new_workflow_manager_delete_event_trigger_request(
     input: WorkflowManagerDeleteEventTriggerInput,
 ) -> pb::WorkflowManagerDeleteEventTriggerRequest {
     pb::WorkflowManagerDeleteEventTriggerRequest {
@@ -462,7 +432,7 @@ pub fn new_workflow_manager_delete_event_trigger_request(
     }
 }
 
-pub fn new_workflow_manager_pause_event_trigger_request(
+pub(crate) fn new_workflow_manager_pause_event_trigger_request(
     input: WorkflowManagerPauseEventTriggerInput,
 ) -> pb::WorkflowManagerPauseEventTriggerRequest {
     pb::WorkflowManagerPauseEventTriggerRequest {
@@ -471,7 +441,7 @@ pub fn new_workflow_manager_pause_event_trigger_request(
     }
 }
 
-pub fn new_workflow_manager_resume_event_trigger_request(
+pub(crate) fn new_workflow_manager_resume_event_trigger_request(
     input: WorkflowManagerResumeEventTriggerInput,
 ) -> pb::WorkflowManagerResumeEventTriggerRequest {
     pb::WorkflowManagerResumeEventTriggerRequest {
@@ -480,215 +450,18 @@ pub fn new_workflow_manager_resume_event_trigger_request(
     }
 }
 
-pub fn new_workflow_manager_publish_event_request(
+pub(crate) fn new_workflow_manager_publish_event_request(
     input: WorkflowManagerPublishEventInput,
 ) -> crate::Result<pb::WorkflowManagerPublishEventRequest> {
     Ok(pb::WorkflowManagerPublishEventRequest {
-        event: input.event.map(new_workflow_event).transpose()?,
+        event: input
+            .event
+            .map(new_workflow_event)
+            .transpose()?
+            .map(workflow_event_to_proto)
+            .transpose()?,
         invocation_token: String::new(),
         provider_name: input.provider_name,
-    })
-}
-
-fn workflow_manager_bound_run_from_proto(
-    input: pb::BoundWorkflowRun,
-) -> crate::Result<WorkflowManagerBoundRun> {
-    Ok(WorkflowManagerBoundRun {
-        id: input.id,
-        status: pb::WorkflowRunStatus::try_from(input.status).map_err(|_| {
-            crate::Error::bad_request(format!("unknown workflow run status {}", input.status))
-        })?,
-        target: input
-            .target
-            .as_ref()
-            .map(bound_workflow_target_input_from_target)
-            .transpose()?,
-        trigger: input
-            .trigger
-            .as_ref()
-            .map(workflow_run_trigger_input_from_trigger)
-            .transpose()?,
-        created_at: input
-            .created_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
-        started_at: input
-            .started_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
-        completed_at: input
-            .completed_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
-        status_message: input.status_message,
-        result_body: input.result_body,
-        created_by: input
-            .created_by
-            .as_ref()
-            .map(workflow_actor_input_from_actor),
-        execution_ref: input.execution_ref,
-        workflow_key: input.workflow_key,
-    })
-}
-
-fn workflow_manager_bound_definition_from_proto(
-    input: pb::BoundWorkflowDefinition,
-) -> crate::Result<WorkflowManagerBoundDefinition> {
-    Ok(WorkflowManagerBoundDefinition {
-        id: input.id,
-        target: input
-            .target
-            .as_ref()
-            .map(bound_workflow_target_input_from_target)
-            .transpose()?,
-        created_by: input
-            .created_by
-            .as_ref()
-            .map(workflow_actor_input_from_actor),
-        created_at: input
-            .created_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
-    })
-}
-
-fn workflow_manager_bound_schedule_from_proto(
-    input: pb::BoundWorkflowSchedule,
-) -> crate::Result<WorkflowManagerBoundSchedule> {
-    Ok(WorkflowManagerBoundSchedule {
-        id: input.id,
-        cron: input.cron,
-        timezone: input.timezone,
-        target: input
-            .target
-            .as_ref()
-            .map(bound_workflow_target_input_from_target)
-            .transpose()?,
-        paused: input.paused,
-        created_at: input
-            .created_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
-        updated_at: input
-            .updated_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
-        next_run_at: input
-            .next_run_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
-        created_by: input
-            .created_by
-            .as_ref()
-            .map(workflow_actor_input_from_actor),
-        execution_ref: input.execution_ref,
-    })
-}
-
-fn workflow_manager_bound_event_trigger_from_proto(
-    input: pb::BoundWorkflowEventTrigger,
-) -> crate::Result<WorkflowManagerBoundEventTrigger> {
-    Ok(WorkflowManagerBoundEventTrigger {
-        id: input.id,
-        r#match: input
-            .r#match
-            .as_ref()
-            .map(workflow_event_match_input_from_match),
-        target: input
-            .target
-            .as_ref()
-            .map(bound_workflow_target_input_from_target)
-            .transpose()?,
-        paused: input.paused,
-        created_at: input
-            .created_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
-        updated_at: input
-            .updated_at
-            .as_ref()
-            .map(protocol::system_time_from_timestamp)
-            .transpose()?,
-        created_by: input
-            .created_by
-            .as_ref()
-            .map(workflow_actor_input_from_actor),
-        execution_ref: input.execution_ref,
-    })
-}
-
-fn workflow_manager_run_from_proto(
-    input: pb::ManagedWorkflowRun,
-) -> crate::Result<WorkflowManagerRun> {
-    Ok(WorkflowManagerRun {
-        provider_name: input.provider_name,
-        run: input
-            .run
-            .map(workflow_manager_bound_run_from_proto)
-            .transpose()?,
-    })
-}
-
-fn workflow_manager_run_signal_from_proto(
-    input: pb::ManagedWorkflowRunSignal,
-) -> crate::Result<WorkflowManagerRunSignal> {
-    Ok(WorkflowManagerRunSignal {
-        provider_name: input.provider_name,
-        run: input
-            .run
-            .map(workflow_manager_bound_run_from_proto)
-            .transpose()?,
-        signal: input
-            .signal
-            .as_ref()
-            .map(workflow_signal_input_from_signal)
-            .transpose()?,
-        started_run: input.started_run,
-        workflow_key: input.workflow_key,
-    })
-}
-
-fn workflow_manager_definition_from_proto(
-    input: pb::ManagedWorkflowDefinition,
-) -> crate::Result<WorkflowManagerDefinition> {
-    Ok(WorkflowManagerDefinition {
-        provider_name: input.provider_name,
-        definition: input
-            .definition
-            .map(workflow_manager_bound_definition_from_proto)
-            .transpose()?,
-    })
-}
-
-fn workflow_manager_schedule_from_proto(
-    input: pb::ManagedWorkflowSchedule,
-) -> crate::Result<WorkflowManagerSchedule> {
-    Ok(WorkflowManagerSchedule {
-        provider_name: input.provider_name,
-        schedule: input
-            .schedule
-            .map(workflow_manager_bound_schedule_from_proto)
-            .transpose()?,
-    })
-}
-
-fn workflow_manager_event_trigger_from_proto(
-    input: pb::ManagedWorkflowEventTrigger,
-) -> crate::Result<WorkflowManagerEventTrigger> {
-    Ok(WorkflowManagerEventTrigger {
-        provider_name: input.provider_name,
-        trigger: input
-            .trigger
-            .map(workflow_manager_bound_event_trigger_from_proto)
-            .transpose()?,
     })
 }
 
@@ -757,13 +530,13 @@ impl WorkflowManager {
     pub async fn create_definition(
         &mut self,
         input: WorkflowManagerCreateDefinitionInput,
-    ) -> std::result::Result<WorkflowManagerDefinition, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowDefinition, WorkflowManagerError> {
         let mut request = new_workflow_manager_create_definition_request(input)?;
         request.invocation_token = self.invocation_token.clone();
         if request.idempotency_key.trim().is_empty() {
             request.idempotency_key = self.idempotency_key.clone();
         }
-        Ok(workflow_manager_definition_from_proto(
+        Ok(managed_workflow_definition_from_proto(
             self.client.create_definition(request).await?.into_inner(),
         )?)
     }
@@ -772,10 +545,10 @@ impl WorkflowManager {
     pub async fn get_definition(
         &mut self,
         input: WorkflowManagerGetDefinitionInput,
-    ) -> std::result::Result<WorkflowManagerDefinition, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowDefinition, WorkflowManagerError> {
         let mut request = new_workflow_manager_get_definition_request(input);
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_manager_definition_from_proto(
+        Ok(managed_workflow_definition_from_proto(
             self.client.get_definition(request).await?.into_inner(),
         )?)
     }
@@ -784,10 +557,10 @@ impl WorkflowManager {
     pub async fn update_definition(
         &mut self,
         input: WorkflowManagerUpdateDefinitionInput,
-    ) -> std::result::Result<WorkflowManagerDefinition, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowDefinition, WorkflowManagerError> {
         let mut request = new_workflow_manager_update_definition_request(input)?;
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_manager_definition_from_proto(
+        Ok(managed_workflow_definition_from_proto(
             self.client.update_definition(request).await?.into_inner(),
         )?)
     }
@@ -807,13 +580,13 @@ impl WorkflowManager {
     pub async fn create_schedule(
         &mut self,
         input: WorkflowManagerCreateScheduleInput,
-    ) -> std::result::Result<WorkflowManagerSchedule, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowSchedule, WorkflowManagerError> {
         let mut request = new_workflow_manager_create_schedule_request(input)?;
         request.invocation_token = self.invocation_token.clone();
         if request.idempotency_key.trim().is_empty() {
             request.idempotency_key = self.idempotency_key.clone();
         }
-        Ok(workflow_manager_schedule_from_proto(
+        Ok(managed_workflow_schedule_from_proto(
             self.client.create_schedule(request).await?.into_inner(),
         )?)
     }
@@ -822,13 +595,13 @@ impl WorkflowManager {
     pub async fn start_run(
         &mut self,
         input: WorkflowManagerStartRunInput,
-    ) -> std::result::Result<WorkflowManagerRun, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowRun, WorkflowManagerError> {
         let mut request = new_workflow_manager_start_run_request(input)?;
         request.invocation_token = self.invocation_token.clone();
         if request.idempotency_key.trim().is_empty() {
             request.idempotency_key = self.idempotency_key.clone();
         }
-        Ok(workflow_manager_run_from_proto(
+        Ok(managed_workflow_run_from_proto(
             self.client.start_run(request).await?.into_inner(),
         )?)
     }
@@ -837,10 +610,10 @@ impl WorkflowManager {
     pub async fn signal_run(
         &mut self,
         input: WorkflowManagerSignalRunInput,
-    ) -> std::result::Result<WorkflowManagerRunSignal, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowRunSignal, WorkflowManagerError> {
         let mut request = new_workflow_manager_signal_run_request(input)?;
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_manager_run_signal_from_proto(
+        Ok(managed_workflow_run_signal_from_proto(
             self.client.signal_run(request).await?.into_inner(),
         )?)
     }
@@ -849,13 +622,13 @@ impl WorkflowManager {
     pub async fn signal_or_start_run(
         &mut self,
         input: WorkflowManagerSignalOrStartRunInput,
-    ) -> std::result::Result<WorkflowManagerRunSignal, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowRunSignal, WorkflowManagerError> {
         let mut request = new_workflow_manager_signal_or_start_run_request(input)?;
         request.invocation_token = self.invocation_token.clone();
         if request.idempotency_key.trim().is_empty() {
             request.idempotency_key = self.idempotency_key.clone();
         }
-        Ok(workflow_manager_run_signal_from_proto(
+        Ok(managed_workflow_run_signal_from_proto(
             self.client.signal_or_start_run(request).await?.into_inner(),
         )?)
     }
@@ -864,10 +637,10 @@ impl WorkflowManager {
     pub async fn get_schedule(
         &mut self,
         input: WorkflowManagerGetScheduleInput,
-    ) -> std::result::Result<WorkflowManagerSchedule, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowSchedule, WorkflowManagerError> {
         let mut request = new_workflow_manager_get_schedule_request(input);
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_manager_schedule_from_proto(
+        Ok(managed_workflow_schedule_from_proto(
             self.client.get_schedule(request).await?.into_inner(),
         )?)
     }
@@ -876,10 +649,10 @@ impl WorkflowManager {
     pub async fn update_schedule(
         &mut self,
         input: WorkflowManagerUpdateScheduleInput,
-    ) -> std::result::Result<WorkflowManagerSchedule, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowSchedule, WorkflowManagerError> {
         let mut request = new_workflow_manager_update_schedule_request(input)?;
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_manager_schedule_from_proto(
+        Ok(managed_workflow_schedule_from_proto(
             self.client.update_schedule(request).await?.into_inner(),
         )?)
     }
@@ -899,10 +672,10 @@ impl WorkflowManager {
     pub async fn pause_schedule(
         &mut self,
         input: WorkflowManagerPauseScheduleInput,
-    ) -> std::result::Result<WorkflowManagerSchedule, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowSchedule, WorkflowManagerError> {
         let mut request = new_workflow_manager_pause_schedule_request(input);
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_manager_schedule_from_proto(
+        Ok(managed_workflow_schedule_from_proto(
             self.client.pause_schedule(request).await?.into_inner(),
         )?)
     }
@@ -911,10 +684,10 @@ impl WorkflowManager {
     pub async fn resume_schedule(
         &mut self,
         input: WorkflowManagerResumeScheduleInput,
-    ) -> std::result::Result<WorkflowManagerSchedule, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowSchedule, WorkflowManagerError> {
         let mut request = new_workflow_manager_resume_schedule_request(input);
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_manager_schedule_from_proto(
+        Ok(managed_workflow_schedule_from_proto(
             self.client.resume_schedule(request).await?.into_inner(),
         )?)
     }
@@ -923,13 +696,13 @@ impl WorkflowManager {
     pub async fn create_trigger(
         &mut self,
         input: WorkflowManagerCreateEventTriggerInput,
-    ) -> std::result::Result<WorkflowManagerEventTrigger, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowEventTrigger, WorkflowManagerError> {
         let mut request = new_workflow_manager_create_event_trigger_request(input)?;
         request.invocation_token = self.invocation_token.clone();
         if request.idempotency_key.trim().is_empty() {
             request.idempotency_key = self.idempotency_key.clone();
         }
-        Ok(workflow_manager_event_trigger_from_proto(
+        Ok(managed_workflow_event_trigger_from_proto(
             self.client
                 .create_event_trigger(request)
                 .await?
@@ -941,10 +714,10 @@ impl WorkflowManager {
     pub async fn get_trigger(
         &mut self,
         input: WorkflowManagerGetEventTriggerInput,
-    ) -> std::result::Result<WorkflowManagerEventTrigger, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowEventTrigger, WorkflowManagerError> {
         let mut request = new_workflow_manager_get_event_trigger_request(input);
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_manager_event_trigger_from_proto(
+        Ok(managed_workflow_event_trigger_from_proto(
             self.client.get_event_trigger(request).await?.into_inner(),
         )?)
     }
@@ -953,10 +726,10 @@ impl WorkflowManager {
     pub async fn update_trigger(
         &mut self,
         input: WorkflowManagerUpdateEventTriggerInput,
-    ) -> std::result::Result<WorkflowManagerEventTrigger, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowEventTrigger, WorkflowManagerError> {
         let mut request = new_workflow_manager_update_event_trigger_request(input)?;
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_manager_event_trigger_from_proto(
+        Ok(managed_workflow_event_trigger_from_proto(
             self.client
                 .update_event_trigger(request)
                 .await?
@@ -979,10 +752,10 @@ impl WorkflowManager {
     pub async fn pause_trigger(
         &mut self,
         input: WorkflowManagerPauseEventTriggerInput,
-    ) -> std::result::Result<WorkflowManagerEventTrigger, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowEventTrigger, WorkflowManagerError> {
         let mut request = new_workflow_manager_pause_event_trigger_request(input);
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_manager_event_trigger_from_proto(
+        Ok(managed_workflow_event_trigger_from_proto(
             self.client.pause_event_trigger(request).await?.into_inner(),
         )?)
     }
@@ -991,10 +764,10 @@ impl WorkflowManager {
     pub async fn resume_trigger(
         &mut self,
         input: WorkflowManagerResumeEventTriggerInput,
-    ) -> std::result::Result<WorkflowManagerEventTrigger, WorkflowManagerError> {
+    ) -> std::result::Result<ManagedWorkflowEventTrigger, WorkflowManagerError> {
         let mut request = new_workflow_manager_resume_event_trigger_request(input);
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_manager_event_trigger_from_proto(
+        Ok(managed_workflow_event_trigger_from_proto(
             self.client
                 .resume_event_trigger(request)
                 .await?
@@ -1006,11 +779,11 @@ impl WorkflowManager {
     pub async fn publish_event(
         &mut self,
         input: WorkflowManagerPublishEventInput,
-    ) -> std::result::Result<WorkflowManagerPublishedEvent, WorkflowManagerError> {
+    ) -> std::result::Result<WorkflowEvent, WorkflowManagerError> {
         let mut request = new_workflow_manager_publish_event_request(input)?;
         request.invocation_token = self.invocation_token.clone();
-        Ok(workflow_event_input_from_event(
-            &self.client.publish_event(request).await?.into_inner(),
+        Ok(crate::workflow::workflow_event_from_proto(
+            self.client.publish_event(request).await?.into_inner(),
         )?)
     }
 }

--- a/sdk/rust/tests/agent_manager_transport.rs
+++ b/sdk/rust/tests/agent_manager_transport.rs
@@ -16,24 +16,25 @@ use gestalt::proto::v1::{
     AgentManagerListTurnEventsRequest, AgentManagerListTurnEventsResponse,
     AgentManagerListTurnsRequest, AgentManagerListTurnsResponse,
     AgentManagerResolveInteractionRequest, AgentManagerUpdateSessionRequest, AgentMessagePartType,
-    AgentSession, AgentSessionState as ProtoAgentSessionState, AgentTurn, AgentTurnEvent,
+    AgentSession, AgentSessionState as ProtoAgentSessionState,
+    AgentToolSourceMode as ProtoAgentToolSourceMode, AgentTurn, AgentTurnEvent,
 };
 use gestalt::{
-    AgentInteractionState as NativeAgentInteractionState, AgentManager,
-    AgentManagerCancelTurnInput, AgentManagerCreateSessionInput, AgentManagerCreateTurnInput,
-    AgentManagerGetSessionInput, AgentManagerGetTurnInput, AgentManagerListInteractionsInput,
-    AgentManagerListSessionsInput, AgentManagerListTurnEventsInput, AgentManagerListTurnsInput,
+    AgentInteractionState, AgentManager, AgentManagerCancelTurnInput,
+    AgentManagerCreateSessionInput, AgentManagerCreateTurnInput, AgentManagerGetSessionInput,
+    AgentManagerGetTurnInput, AgentManagerListInteractionsInput, AgentManagerListSessionsInput,
+    AgentManagerListTurnEventsInput, AgentManagerListTurnsInput,
     AgentManagerResolveInteractionInput, AgentManagerUpdateSessionInput, AgentMessageInput,
-    AgentMessagePartInput, AgentMessagePartType as NativeAgentMessagePartType,
-    AgentSessionState as NativeAgentSessionState, AgentToolRefInput,
-    AgentToolSourceMode as NativeAgentToolSourceMode, ENV_AGENT_MANAGER_SOCKET,
-    ENV_AGENT_MANAGER_SOCKET_TOKEN, Request,
+    AgentMessagePartInput, AgentMessagePartType as NativeAgentMessagePartType, AgentSessionState,
+    AgentToolRefInput, AgentToolSourceMode, ENV_AGENT_MANAGER_SOCKET, Request,
 };
 use tokio::net::{TcpListener, UnixListener};
 use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
 use tonic::codegen::async_trait;
 use tonic::transport::Server;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
+
+const ENV_AGENT_MANAGER_SOCKET_TOKEN: &str = "GESTALT_AGENT_MANAGER_SOCKET_TOKEN";
 
 #[derive(Clone, Debug, Default, PartialEq)]
 struct SeenRequest {
@@ -463,7 +464,7 @@ async fn agent_manager_connects_over_unix_socket_and_sends_invocation_token() {
         .update_session(AgentManagerUpdateSessionInput {
             session_id: "session-managed-1".to_string(),
             client_ref: "cli-session-2".to_string(),
-            state: NativeAgentSessionState::Archived,
+            state: AgentSessionState::Archived,
             ..Default::default()
         })
         .await
@@ -482,7 +483,7 @@ async fn agent_manager_connects_over_unix_socket_and_sends_invocation_token() {
                 }],
                 ..Default::default()
             }],
-            tool_source: NativeAgentToolSourceMode::McpCatalog,
+            tool_source: AgentToolSourceMode::McpCatalog,
             ..Default::default()
         })
         .await
@@ -544,7 +545,7 @@ async fn agent_manager_connects_over_unix_socket_and_sends_invocation_token() {
     assert_eq!(turn_events.events.len(), 1);
     assert_eq!(interactions.interactions.len(), 1);
     assert_eq!(resolved.id, "interaction-1");
-    assert_eq!(resolved.state, NativeAgentInteractionState::Resolved);
+    assert_eq!(resolved.state, AgentInteractionState::Resolved);
 
     let seen = server.seen.lock().expect("lock seen").clone();
     assert_eq!(
@@ -695,7 +696,7 @@ async fn agent_manager_create_turn_accepts_native_values() {
                 connection: "default".to_string(),
                 ..Default::default()
             }],
-            tool_source: NativeAgentToolSourceMode::McpCatalog,
+            tool_source: AgentToolSourceMode::McpCatalog,
             response_schema: Some(serde_json::json!({ "type": "object" })),
             metadata: Some(serde_json::json!({ "request": "native" })),
             model_options: Some(serde_json::json!({ "temperature": 0 })),
@@ -718,7 +719,7 @@ async fn agent_manager_create_turn_accepts_native_values() {
     assert_eq!(request.model, "gpt-5.1");
     assert_eq!(
         request.tool_source,
-        NativeAgentToolSourceMode::McpCatalog as i32
+        ProtoAgentToolSourceMode::McpCatalog as i32
     );
     assert_eq!(request.messages.len(), 1);
     assert_eq!(request.messages[0].role, "user");

--- a/sdk/rust/tests/agent_transport.rs
+++ b/sdk/rust/tests/agent_transport.rs
@@ -17,14 +17,14 @@ use gestalt::{
     AgentMessagePartType, AgentProvider, AgentProviderCapabilities, AgentSession,
     AgentSessionState, AgentToolSourceMode, AgentTurn, AgentTurnEvent,
     CancelAgentProviderTurnRequest, CreateAgentProviderSessionRequest,
-    CreateAgentProviderTurnRequest, ENV_AGENT_HOST_SOCKET_TOKEN,
-    GetAgentProviderCapabilitiesRequest, GetAgentProviderInteractionRequest,
-    GetAgentProviderSessionRequest, GetAgentProviderTurnRequest,
-    ListAgentProviderInteractionsRequest, ListAgentProviderInteractionsResponse,
-    ListAgentProviderSessionsRequest, ListAgentProviderSessionsResponse,
-    ListAgentProviderTurnEventsRequest, ListAgentProviderTurnEventsResponse,
-    ListAgentProviderTurnsRequest, ListAgentProviderTurnsResponse,
-    ResolveAgentProviderInteractionRequest, RuntimeMetadata, UpdateAgentProviderSessionRequest,
+    CreateAgentProviderTurnRequest, GetAgentProviderCapabilitiesRequest,
+    GetAgentProviderInteractionRequest, GetAgentProviderSessionRequest,
+    GetAgentProviderTurnRequest, ListAgentProviderInteractionsRequest,
+    ListAgentProviderInteractionsResponse, ListAgentProviderSessionsRequest,
+    ListAgentProviderSessionsResponse, ListAgentProviderTurnEventsRequest,
+    ListAgentProviderTurnEventsResponse, ListAgentProviderTurnsRequest,
+    ListAgentProviderTurnsResponse, ResolveAgentProviderInteractionRequest, RuntimeMetadata,
+    UpdateAgentProviderSessionRequest,
 };
 use hyper_util::rt::tokio::TokioIo;
 use serde::Serialize;
@@ -32,6 +32,8 @@ use tokio::net::{TcpListener, UnixListener, UnixStream};
 use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
 use tonic::transport::{Endpoint, Server};
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
+
+const ENV_AGENT_HOST_SOCKET_TOKEN: &str = "GESTALT_AGENT_HOST_SOCKET_TOKEN";
 
 #[derive(Serialize)]
 struct LookupArguments {

--- a/sdk/rust/tests/authorization_transport.rs
+++ b/sdk/rust/tests/authorization_transport.rs
@@ -38,10 +38,10 @@ use gestalt::{
     ActionSearchResponse, Authorization, AuthorizationAction, AuthorizationMetadata,
     AuthorizationModelRef, AuthorizationProvider as SdkAuthorizationProvider,
     AuthorizationRelationshipTarget, AuthorizationResource, AuthorizationSubject,
-    AuthorizationSubjectSet, ENV_AUTHORIZATION_SOCKET, ENV_AUTHORIZATION_SOCKET_TOKEN,
-    EffectiveSubjectSearchRequest, ExpandRequest, GetActiveModelResponse, ListModelsResponse,
-    ReadRelationshipsResponse, Relationship, ResourceSearchRequest, ResourceSearchResponse,
-    SubjectSearchRequest, SubjectSearchResponse, WriteRelationshipsRequest,
+    AuthorizationSubjectSet, ENV_AUTHORIZATION_SOCKET, EffectiveSubjectSearchRequest,
+    ExpandRequest, GetActiveModelResponse, ListModelsResponse, ReadRelationshipsResponse,
+    Relationship, ResourceSearchRequest, ResourceSearchResponse, SubjectSearchRequest,
+    SubjectSearchResponse, WriteRelationshipsRequest,
 };
 use hyper_util::rt::TokioIo;
 use tokio::net::{UnixListener, UnixStream};
@@ -49,6 +49,8 @@ use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::{Endpoint, Server};
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 use tower::service_fn;
+
+const ENV_AUTHORIZATION_SOCKET_TOKEN: &str = "GESTALT_AUTHORIZATION_SOCKET_TOKEN";
 
 #[derive(Clone, Default)]
 struct TestAuthorizationServer {

--- a/sdk/rust/tests/cache_transport.rs
+++ b/sdk/rust/tests/cache_transport.rs
@@ -14,10 +14,7 @@ use gestalt::proto::v1::{
     CacheSetManyRequest, CacheSetRequest, CacheTouchRequest, CacheTouchResponse,
     ConfigureProviderRequest, ProviderKind,
 };
-use gestalt::{
-    CacheEntry, CacheProvider, CacheSetOptions, ENV_CACHE_SOCKET, ENV_CACHE_SOCKET_TOKEN,
-    RuntimeMetadata,
-};
+use gestalt::{CacheEntry, CacheProvider, CacheSetOptions, ENV_CACHE_SOCKET, RuntimeMetadata};
 use hyper_util::rt::tokio::TokioIo;
 use tokio::net::{TcpListener, UnixStream};
 use tokio_stream::wrappers::TcpListenerStream;
@@ -26,6 +23,7 @@ use tonic::{Code, Request as GrpcRequest, Response as GrpcResponse, Status};
 use tower::service_fn;
 
 const CACHE_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
+const ENV_CACHE_SOCKET_TOKEN: &str = "GESTALT_CACHE_SOCKET_TOKEN";
 
 #[derive(Default)]
 struct TestCacheProvider {

--- a/sdk/rust/tests/component_transport.rs
+++ b/sdk/rust/tests/component_transport.rs
@@ -10,13 +10,19 @@ use gestalt::proto::v1::authentication_provider_client::AuthenticationProviderCl
 use gestalt::proto::v1::provider_lifecycle_client::ProviderLifecycleClient;
 use gestalt::proto::v1::s3_client::S3Client;
 use gestalt::proto::v1::{
-    BeginLoginRequest, CompleteLoginRequest, ConfigureProviderRequest, CopyObjectRequest,
-    CopyObjectResponse, DeleteObjectRequest, HeadObjectRequest, HeadObjectResponse,
-    ListObjectsRequest, ListObjectsResponse, PresignObjectRequest, PresignObjectResponse,
-    ProviderKind, ReadObjectChunk, ReadObjectRequest, S3ObjectMeta, S3ObjectRef,
-    ValidateExternalTokenRequest, WriteObjectRequest, WriteObjectResponse,
+    BeginLoginRequest as ProtoBeginLoginRequest, CompleteLoginRequest as ProtoCompleteLoginRequest,
+    ConfigureProviderRequest, HeadObjectRequest as ProtoHeadObjectRequest,
+    ListObjectsRequest as ProtoListObjectsRequest, ProviderKind,
+    ReadObjectRequest as ProtoReadObjectRequest, S3ObjectRef, ValidateExternalTokenRequest,
+    WriteObjectRequest as ProtoWriteObjectRequest,
 };
-use gestalt::{AuthenticationProvider, RuntimeMetadata};
+use gestalt::s3::{
+    CopyObjectRequest, CopyObjectResponse, DeleteObjectRequest, HeadObjectRequest,
+    HeadObjectResponse, ListObjectsRequest, ListObjectsResponse, ObjectMeta, ObjectRef,
+    PresignObjectRequest, PresignObjectResponse, ReadObjectRequest, S3ReadObjectFrame,
+    S3WriteObjectFrame, WriteObjectResponse,
+};
+use gestalt::{AuthenticationProvider, BeginLoginRequest, CompleteLoginRequest, RuntimeMetadata};
 use hyper_util::rt::tokio::TokioIo;
 use tokio::net::UnixStream;
 use tokio_stream::iter as stream_iter;
@@ -143,7 +149,7 @@ impl gestalt::S3Provider for TestS3Provider {
 
     async fn head_object(&self, request: HeadObjectRequest) -> gestalt::Result<HeadObjectResponse> {
         let reference = request
-            .r#ref
+            .reference
             .ok_or_else(|| gestalt::Error::bad_request("missing ref"))?;
         let key = object_key(&reference.bucket, &reference.key);
         let objects = self.objects.lock().expect("lock objects");
@@ -164,7 +170,7 @@ impl gestalt::S3Provider for TestS3Provider {
         request: ReadObjectRequest,
     ) -> gestalt::Result<gestalt::S3ReadObjectStream> {
         let reference = request
-            .r#ref
+            .reference
             .ok_or_else(|| gestalt::Error::bad_request("missing ref"))?;
         let key = object_key(&reference.bucket, &reference.key);
         let objects = self.objects.lock().expect("lock objects");
@@ -174,15 +180,13 @@ impl gestalt::S3Provider for TestS3Provider {
             .ok_or_else(|| gestalt::Error::not_found("object not found"))?;
         drop(objects);
 
-        let mut messages = vec![Ok(ReadObjectChunk {
-            result: Some(gestalt::proto::v1::read_object_chunk::Result::Meta(
-                object_meta(reference, body.len() as i64, "application/octet-stream"),
-            )),
-        })];
+        let mut messages = vec![Ok(S3ReadObjectFrame::Meta(object_meta(
+            reference,
+            body.len() as i64,
+            "application/octet-stream",
+        )))];
         if !body.is_empty() {
-            messages.push(Ok(ReadObjectChunk {
-                result: Some(gestalt::proto::v1::read_object_chunk::Result::Data(body)),
-            }));
+            messages.push(Ok(S3ReadObjectFrame::Data(body)));
         }
 
         Ok(Box::pin(stream_iter(messages)))
@@ -197,15 +201,15 @@ impl gestalt::S3Provider for TestS3Provider {
         let mut body = Vec::new();
 
         while let Some(message) = stream.message().await? {
-            match message.msg {
-                Some(gestalt::proto::v1::write_object_request::Msg::Open(open)) => {
-                    reference = open.r#ref;
+            match message {
+                S3WriteObjectFrame::Open(open) => {
+                    reference = open.reference;
                     content_type = open.content_type;
                 }
-                Some(gestalt::proto::v1::write_object_request::Msg::Data(chunk)) => {
+                S3WriteObjectFrame::Data(chunk) => {
                     body.extend_from_slice(&chunk);
                 }
-                None => {}
+                S3WriteObjectFrame::Empty => {}
             }
         }
 
@@ -223,7 +227,7 @@ impl gestalt::S3Provider for TestS3Provider {
 
     async fn delete_object(&self, request: DeleteObjectRequest) -> gestalt::Result<()> {
         let reference = request
-            .r#ref
+            .reference
             .ok_or_else(|| gestalt::Error::bad_request("missing ref"))?;
         self.objects
             .lock()
@@ -249,7 +253,7 @@ impl gestalt::S3Provider for TestS3Provider {
                 continue;
             }
             metas.push(object_meta(
-                S3ObjectRef {
+                ObjectRef {
                     bucket: bucket.to_string(),
                     key: object_key.to_string(),
                     version_id: String::new(),
@@ -294,7 +298,7 @@ impl gestalt::S3Provider for TestS3Provider {
         request: PresignObjectRequest,
     ) -> gestalt::Result<PresignObjectResponse> {
         let reference = request
-            .r#ref
+            .reference
             .ok_or_else(|| gestalt::Error::bad_request("missing ref"))?;
         Ok(PresignObjectResponse {
             url: format!(
@@ -359,7 +363,7 @@ async fn serves_auth_provider_and_runtime_over_unix_socket() {
     );
 
     let begin = auth
-        .begin_login(BeginLoginRequest {
+        .begin_login(ProtoBeginLoginRequest {
             callback_url: "https://host/callback".to_string(),
             host_state: "host-state".to_string(),
             scopes: vec!["openid".to_string()],
@@ -372,7 +376,7 @@ async fn serves_auth_provider_and_runtime_over_unix_socket() {
     assert_eq!(begin.provider_state, b"provider-state");
 
     let completed = auth
-        .complete_login(CompleteLoginRequest {
+        .complete_login(ProtoCompleteLoginRequest {
             query: BTreeMap::from([("email".to_string(), "complete@example.com".to_string())]),
             provider_state: b"provider-state".to_vec(),
             callback_url: "https://host/callback".to_string(),
@@ -468,7 +472,7 @@ async fn serves_s3_provider_and_runtime_over_unix_socket() {
         version_id: String::new(),
     };
     s3.write_object(stream_iter(vec![
-        WriteObjectRequest {
+        ProtoWriteObjectRequest {
             msg: Some(gestalt::proto::v1::write_object_request::Msg::Open(
                 gestalt::proto::v1::WriteObjectOpen {
                     r#ref: Some(reference.clone()),
@@ -476,7 +480,7 @@ async fn serves_s3_provider_and_runtime_over_unix_socket() {
                 },
             )),
         },
-        WriteObjectRequest {
+        ProtoWriteObjectRequest {
             msg: Some(gestalt::proto::v1::write_object_request::Msg::Data(
                 b"hello".to_vec(),
             )),
@@ -486,7 +490,7 @@ async fn serves_s3_provider_and_runtime_over_unix_socket() {
     .expect("write object");
 
     let head = s3
-        .head_object(HeadObjectRequest {
+        .head_object(ProtoHeadObjectRequest {
             r#ref: Some(reference.clone()),
         })
         .await
@@ -495,10 +499,10 @@ async fn serves_s3_provider_and_runtime_over_unix_socket() {
     assert_eq!(head.meta.expect("meta").size, 5);
 
     let listed = s3
-        .list_objects(ListObjectsRequest {
+        .list_objects(ProtoListObjectsRequest {
             bucket: "bucket".to_string(),
             prefix: "docs/".to_string(),
-            ..ListObjectsRequest::default()
+            ..ProtoListObjectsRequest::default()
         })
         .await
         .expect("list objects")
@@ -510,9 +514,9 @@ async fn serves_s3_provider_and_runtime_over_unix_socket() {
     );
 
     let mut stream = s3
-        .read_object(ReadObjectRequest {
+        .read_object(ProtoReadObjectRequest {
             r#ref: Some(reference),
-            ..ReadObjectRequest::default()
+            ..ProtoReadObjectRequest::default()
         })
         .await
         .expect("read object")
@@ -550,9 +554,9 @@ fn object_key(bucket: &str, key: &str) -> String {
     format!("{bucket}/{key}")
 }
 
-fn object_meta(reference: S3ObjectRef, size: i64, content_type: &str) -> S3ObjectMeta {
-    S3ObjectMeta {
-        r#ref: Some(reference),
+fn object_meta(reference: ObjectRef, size: i64, content_type: &str) -> ObjectMeta {
+    ObjectMeta {
+        reference,
         etag: String::new(),
         size,
         content_type: content_type.to_string(),

--- a/sdk/rust/tests/plugin_invoker_transport.rs
+++ b/sdk/rust/tests/plugin_invoker_transport.rs
@@ -13,10 +13,7 @@ use gestalt::proto::v1::{
     ExchangeInvocationTokenRequest, ExchangeInvocationTokenResponse, OperationResult,
     PluginInvocationGrant, PluginInvokeGraphQlRequest, PluginInvokeRequest,
 };
-use gestalt::{
-    ENV_PLUGIN_INVOKER_SOCKET, ENV_PLUGIN_INVOKER_SOCKET_TOKEN, InvocationGrant, InvokeOptions,
-    PluginInvoker, Request,
-};
+use gestalt::{ENV_PLUGIN_INVOKER_SOCKET, InvocationGrant, InvokeOptions, PluginInvoker, Request};
 use prost_types::Struct;
 use serde::Serialize;
 use tokio::net::{TcpListener, UnixListener};
@@ -24,6 +21,8 @@ use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
 use tonic::codegen::async_trait;
 use tonic::transport::Server;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
+
+const ENV_PLUGIN_INVOKER_SOCKET_TOKEN: &str = "GESTALT_PLUGIN_INVOKER_SOCKET_TOKEN";
 
 #[derive(Serialize)]
 struct IssueParams {

--- a/sdk/rust/tests/plugin_runtime_transport.rs
+++ b/sdk/rust/tests/plugin_runtime_transport.rs
@@ -1,0 +1,413 @@
+#[allow(dead_code)]
+mod helpers;
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, UNIX_EPOCH};
+
+use gestalt::proto::v1::plugin_runtime_provider_client::PluginRuntimeProviderClient;
+use gestalt::proto::v1::provider_lifecycle_client::ProviderLifecycleClient;
+use gestalt::proto::v1::{
+    AgentWorkspace, AgentWorkspaceGitCheckout, ConfigureProviderRequest,
+    GetPluginRuntimeSessionRequest as ProtoGetPluginRuntimeSessionRequest,
+    ListPluginRuntimeSessionsRequest as ProtoListPluginRuntimeSessionsRequest,
+    PluginRuntimeEgressMode as ProtoPluginRuntimeEgressMode,
+    PluginRuntimeImagePullAuth as ProtoPluginRuntimeImagePullAuth, ProviderKind,
+    RemovePluginRuntimeWorkspaceRequest as ProtoRemovePluginRuntimeWorkspaceRequest,
+    StartHostedPluginRequest as ProtoStartHostedPluginRequest,
+    StartPluginRuntimeSessionRequest as ProtoStartPluginRuntimeSessionRequest,
+    StopPluginRuntimeSessionRequest as ProtoStopPluginRuntimeSessionRequest,
+};
+use gestalt::{
+    AgentPreparedWorkspace, HostedPlugin, ListPluginRuntimeSessionsRequest,
+    ListPluginRuntimeSessionsResponse, PluginRuntimeEgressMode, PluginRuntimeProvider,
+    PluginRuntimeSession, PluginRuntimeSessionLifecycle, PluginRuntimeSupport,
+    PreparePluginRuntimeWorkspaceRequest, PreparePluginRuntimeWorkspaceResponse, RuntimeMetadata,
+    StartHostedPluginRequest, StartPluginRuntimeSessionRequest, StopPluginRuntimeSessionRequest,
+};
+use hyper_util::rt::TokioIo;
+use tokio::net::UnixStream;
+use tonic::codegen::async_trait;
+use tonic::transport::Endpoint;
+use tower::service_fn;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct SeenRequest {
+    method: String,
+    session_id: String,
+    plugin_name: String,
+    agent_session_id: String,
+    command: String,
+    cwd: String,
+}
+
+#[derive(Default)]
+struct TestPluginRuntimeProvider {
+    configured_name: Mutex<String>,
+    seen: Mutex<Vec<SeenRequest>>,
+}
+
+#[async_trait]
+impl PluginRuntimeProvider for TestPluginRuntimeProvider {
+    async fn configure(
+        &self,
+        name: &str,
+        _config: serde_json::Map<String, serde_json::Value>,
+    ) -> gestalt::Result<()> {
+        *self.configured_name.lock().expect("lock configured_name") = name.to_string();
+        Ok(())
+    }
+
+    fn metadata(&self) -> Option<RuntimeMetadata> {
+        Some(RuntimeMetadata {
+            name: "runtime-example".to_string(),
+            display_name: "Runtime Example".to_string(),
+            description: "Test plugin runtime provider".to_string(),
+            version: "0.1.0".to_string(),
+        })
+    }
+
+    fn warnings(&self) -> Vec<String> {
+        vec!["set RUNTIME_POOL".to_string()]
+    }
+
+    async fn get_support(&self, _request: ()) -> gestalt::Result<PluginRuntimeSupport> {
+        Ok(PluginRuntimeSupport {
+            can_host_plugins: true,
+            egress_mode: PluginRuntimeEgressMode::Hostname,
+            supports_prepare_workspace: true,
+        })
+    }
+
+    async fn start_session(
+        &self,
+        request: StartPluginRuntimeSessionRequest,
+    ) -> gestalt::Result<PluginRuntimeSession> {
+        self.seen.lock().expect("lock seen").push(SeenRequest {
+            method: "start-session".to_string(),
+            plugin_name: request.plugin_name.clone(),
+            ..Default::default()
+        });
+        assert_eq!(
+            request
+                .image_pull_auth
+                .as_ref()
+                .expect("image pull auth")
+                .docker_config_json,
+            "{}"
+        );
+        Ok(runtime_session("session-1", request.metadata))
+    }
+
+    async fn get_session(
+        &self,
+        request: gestalt::GetPluginRuntimeSessionRequest,
+    ) -> gestalt::Result<PluginRuntimeSession> {
+        self.seen.lock().expect("lock seen").push(SeenRequest {
+            method: "get-session".to_string(),
+            session_id: request.session_id.clone(),
+            ..Default::default()
+        });
+        Ok(runtime_session(&request.session_id, BTreeMap::new()))
+    }
+
+    async fn list_sessions(
+        &self,
+        _request: ListPluginRuntimeSessionsRequest,
+    ) -> gestalt::Result<ListPluginRuntimeSessionsResponse> {
+        Ok(ListPluginRuntimeSessionsResponse {
+            sessions: vec![runtime_session("session-1", BTreeMap::new())],
+        })
+    }
+
+    async fn stop_session(&self, request: StopPluginRuntimeSessionRequest) -> gestalt::Result<()> {
+        self.seen.lock().expect("lock seen").push(SeenRequest {
+            method: "stop-session".to_string(),
+            session_id: request.session_id,
+            ..Default::default()
+        });
+        Ok(())
+    }
+
+    async fn prepare_workspace(
+        &self,
+        request: PreparePluginRuntimeWorkspaceRequest,
+    ) -> gestalt::Result<PreparePluginRuntimeWorkspaceResponse> {
+        self.seen.lock().expect("lock seen").push(SeenRequest {
+            method: "prepare-workspace".to_string(),
+            session_id: request.session_id,
+            agent_session_id: request.agent_session_id,
+            cwd: request
+                .workspace
+                .as_ref()
+                .map(|w| w.cwd.clone())
+                .unwrap_or_default(),
+            ..Default::default()
+        });
+        Ok(PreparePluginRuntimeWorkspaceResponse {
+            workspace: Some(AgentPreparedWorkspace {
+                root: "/workspaces/session-1".to_string(),
+                cwd: "/workspaces/session-1/app".to_string(),
+            }),
+        })
+    }
+
+    async fn remove_workspace(
+        &self,
+        request: gestalt::RemovePluginRuntimeWorkspaceRequest,
+    ) -> gestalt::Result<()> {
+        self.seen.lock().expect("lock seen").push(SeenRequest {
+            method: "remove-workspace".to_string(),
+            session_id: request.session_id,
+            agent_session_id: request.agent_session_id,
+            ..Default::default()
+        });
+        Ok(())
+    }
+
+    async fn start_plugin(
+        &self,
+        request: StartHostedPluginRequest,
+    ) -> gestalt::Result<HostedPlugin> {
+        self.seen.lock().expect("lock seen").push(SeenRequest {
+            method: "start-plugin".to_string(),
+            session_id: request.session_id.clone(),
+            plugin_name: request.plugin_name.clone(),
+            command: request.command,
+            ..Default::default()
+        });
+        Ok(HostedPlugin {
+            id: "hosted-plugin-1".to_string(),
+            session_id: request.session_id,
+            plugin_name: request.plugin_name,
+            dial_target: "unix:///tmp/plugin.sock".to_string(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn plugin_runtime_provider_transport_uses_native_trait_types() {
+    let _env_lock = helpers::env_lock().lock().await;
+    let socket = helpers::temp_socket("gestalt-rust-plugin-runtime.sock");
+    let _socket_guard = helpers::EnvGuard::set(gestalt::ENV_PROVIDER_SOCKET, socket.as_os_str());
+
+    let provider = Arc::new(TestPluginRuntimeProvider::default());
+    let serve_provider = Arc::clone(&provider);
+    let serve_task = tokio::spawn(async move {
+        gestalt::runtime::serve_plugin_runtime_provider(serve_provider)
+            .await
+            .expect("serve plugin runtime provider");
+    });
+
+    helpers::wait_for_socket(&socket).await;
+
+    let channel = connect_unix(&socket).await;
+    let mut runtime = ProviderLifecycleClient::new(channel.clone());
+    let mut client = PluginRuntimeProviderClient::new(channel);
+
+    let metadata = runtime
+        .get_provider_identity(())
+        .await
+        .expect("get provider identity")
+        .into_inner();
+    assert_eq!(
+        ProviderKind::try_from(metadata.kind)
+            .expect("valid provider kind")
+            .as_str_name(),
+        "PROVIDER_KIND_RUNTIME"
+    );
+    assert_eq!(metadata.name, "runtime-example");
+    assert_eq!(metadata.warnings, vec!["set RUNTIME_POOL"]);
+
+    runtime
+        .configure_provider(ConfigureProviderRequest {
+            name: "runtime-provider".to_string(),
+            config: Some(helpers::struct_from_json(serde_json::json!({}))),
+            protocol_version: gestalt::CURRENT_PROTOCOL_VERSION,
+        })
+        .await
+        .expect("configure provider");
+
+    let support = client
+        .get_support(())
+        .await
+        .expect("get support")
+        .into_inner();
+    assert!(support.can_host_plugins);
+    assert_eq!(
+        support.egress_mode,
+        ProtoPluginRuntimeEgressMode::Hostname as i32
+    );
+    assert!(support.supports_prepare_workspace);
+
+    let session = client
+        .start_session(ProtoStartPluginRuntimeSessionRequest {
+            plugin_name: "github".to_string(),
+            template: "default".to_string(),
+            image: "registry.example/plugin:latest".to_string(),
+            metadata: BTreeMap::from([("env".to_string(), "test".to_string())]),
+            image_pull_auth: Some(ProtoPluginRuntimeImagePullAuth {
+                docker_config_json: "{}".to_string(),
+            }),
+        })
+        .await
+        .expect("start session")
+        .into_inner();
+    assert_eq!(session.id, "session-1");
+    assert_eq!(session.state, "running");
+    assert_eq!(
+        session.metadata.get("env").map(String::as_str),
+        Some("test")
+    );
+    assert!(session.lifecycle.and_then(|l| l.started_at).is_some());
+
+    let fetched = client
+        .get_session(ProtoGetPluginRuntimeSessionRequest {
+            session_id: "session-1".to_string(),
+        })
+        .await
+        .expect("get session")
+        .into_inner();
+    assert_eq!(fetched.id, "session-1");
+
+    let listed = client
+        .list_sessions(ProtoListPluginRuntimeSessionsRequest {})
+        .await
+        .expect("list sessions")
+        .into_inner();
+    assert_eq!(listed.sessions.len(), 1);
+
+    let prepared = client
+        .prepare_workspace(gestalt::proto::v1::PreparePluginRuntimeWorkspaceRequest {
+            session_id: "session-1".to_string(),
+            agent_session_id: "agent-session-1".to_string(),
+            workspace: Some(AgentWorkspace {
+                checkouts: vec![AgentWorkspaceGitCheckout {
+                    url: "https://example.invalid/repo.git".to_string(),
+                    r#ref: "main".to_string(),
+                    path: "app".to_string(),
+                }],
+                cwd: "app".to_string(),
+            }),
+        })
+        .await
+        .expect("prepare workspace")
+        .into_inner();
+    assert_eq!(
+        prepared.workspace.expect("workspace").cwd,
+        "/workspaces/session-1/app"
+    );
+
+    client
+        .remove_workspace(ProtoRemovePluginRuntimeWorkspaceRequest {
+            session_id: "session-1".to_string(),
+            agent_session_id: "agent-session-1".to_string(),
+        })
+        .await
+        .expect("remove workspace");
+
+    let hosted = client
+        .start_plugin(ProtoStartHostedPluginRequest {
+            session_id: "session-1".to_string(),
+            plugin_name: "github".to_string(),
+            command: "/bin/plugin".to_string(),
+            args: vec!["serve".to_string()],
+            env: BTreeMap::from([("RUST_LOG".to_string(), "debug".to_string())]),
+            allowed_hosts: vec!["api.github.com".to_string()],
+            default_action: "deny".to_string(),
+            host_binary: "/usr/bin/gestalt-plugin-host".to_string(),
+        })
+        .await
+        .expect("start plugin")
+        .into_inner();
+    assert_eq!(hosted.id, "hosted-plugin-1");
+    assert_eq!(hosted.dial_target, "unix:///tmp/plugin.sock");
+
+    client
+        .stop_session(ProtoStopPluginRuntimeSessionRequest {
+            session_id: "session-1".to_string(),
+        })
+        .await
+        .expect("stop session");
+
+    assert_eq!(
+        *provider
+            .configured_name
+            .lock()
+            .expect("lock configured_name"),
+        "runtime-provider"
+    );
+    assert_eq!(
+        provider.seen.lock().expect("lock seen").clone(),
+        vec![
+            SeenRequest {
+                method: "start-session".to_string(),
+                plugin_name: "github".to_string(),
+                ..Default::default()
+            },
+            SeenRequest {
+                method: "get-session".to_string(),
+                session_id: "session-1".to_string(),
+                ..Default::default()
+            },
+            SeenRequest {
+                method: "prepare-workspace".to_string(),
+                session_id: "session-1".to_string(),
+                agent_session_id: "agent-session-1".to_string(),
+                cwd: "app".to_string(),
+                ..Default::default()
+            },
+            SeenRequest {
+                method: "remove-workspace".to_string(),
+                session_id: "session-1".to_string(),
+                agent_session_id: "agent-session-1".to_string(),
+                ..Default::default()
+            },
+            SeenRequest {
+                method: "start-plugin".to_string(),
+                session_id: "session-1".to_string(),
+                plugin_name: "github".to_string(),
+                command: "/bin/plugin".to_string(),
+                ..Default::default()
+            },
+            SeenRequest {
+                method: "stop-session".to_string(),
+                session_id: "session-1".to_string(),
+                ..Default::default()
+            },
+        ]
+    );
+
+    serve_task.abort();
+    let _ = serve_task.await;
+}
+
+fn runtime_session(id: &str, metadata: BTreeMap<String, String>) -> PluginRuntimeSession {
+    PluginRuntimeSession {
+        id: id.to_string(),
+        state: "running".to_string(),
+        metadata,
+        lifecycle: Some(PluginRuntimeSessionLifecycle {
+            started_at: Some(UNIX_EPOCH + Duration::from_secs(1_778_241_600)),
+            recommended_drain_at: None,
+            expires_at: None,
+        }),
+        state_reason: String::new(),
+        state_message: "ready".to_string(),
+    }
+}
+
+async fn connect_unix(path: &Path) -> tonic::transport::Channel {
+    Endpoint::try_from("http://[::]:50051")
+        .expect("endpoint")
+        .connect_with_connector(service_fn({
+            let path = path.to_path_buf();
+            move |_| {
+                let path = path.clone();
+                async move { UnixStream::connect(path).await.map(TokioIo::new) }
+            }
+        }))
+        .await
+        .expect("connect channel")
+}

--- a/sdk/rust/tests/runtime_log_host_transport.rs
+++ b/sdk/rust/tests/runtime_log_host_transport.rs
@@ -3,6 +3,7 @@ mod helpers;
 
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
 
 use gestalt::proto::v1::plugin_runtime_log_host_server::{
     PluginRuntimeLogHost as ProtoPluginRuntimeLogHost, PluginRuntimeLogHostServer,
@@ -11,14 +12,15 @@ use gestalt::proto::v1::{
     AppendPluginRuntimeLogsRequest, AppendPluginRuntimeLogsResponse, PluginRuntimeLogStream,
 };
 use gestalt::{
-    ENV_RUNTIME_LOG_HOST_SOCKET, ENV_RUNTIME_LOG_HOST_SOCKET_TOKEN, ENV_RUNTIME_SESSION_ID,
-    RuntimeLogHost, RuntimeLogStream,
+    ENV_RUNTIME_LOG_HOST_SOCKET, ENV_RUNTIME_SESSION_ID, RuntimeLogHost, RuntimeLogStream,
 };
 use tokio::net::UnixListener;
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::codegen::async_trait;
 use tonic::transport::Server;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
+
+const ENV_RUNTIME_LOG_HOST_SOCKET_TOKEN: &str = "GESTALT_RUNTIME_LOG_SOCKET_TOKEN";
 
 #[derive(Clone, Default)]
 struct TestRuntimeLogHostServer {
@@ -72,7 +74,7 @@ async fn runtime_log_host_appends_logs_and_forwards_relay_token() {
         .append_current_entry(
             RuntimeLogStream::Runtime,
             "runtime boot\n",
-            Some(helpers::timestamp_now()),
+            Some(SystemTime::now()),
             7,
         )
         .await

--- a/sdk/rust/tests/s3_transport.rs
+++ b/sdk/rust/tests/s3_transport.rs
@@ -8,8 +8,8 @@ use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use gestalt::s3::{
-    ByteRange, ENV_S3_SOCKET, ENV_S3_SOCKET_TOKEN, ListOptions, PresignMethod, PresignOptions,
-    ReadOptions, S3, S3Error, WriteOptions, s3_socket_env, s3_socket_token_env,
+    ByteRange, ENV_S3_SOCKET, ListOptions, PresignMethod, PresignOptions, ReadOptions, S3, S3Error,
+    WriteOptions, s3_socket_env, s3_socket_token_env,
 };
 
 struct Harness {
@@ -243,7 +243,7 @@ async fn tcp_target_round_trip() {
 async fn tcp_target_with_token_round_trip() {
     let _lock = helpers::env_lock().lock().await;
     let _harness = start_tcp_harness(Some("relay-token-rust"), ENV_S3_SOCKET).await;
-    let _token_env = helpers::EnvGuard::set(ENV_S3_SOCKET_TOKEN, "relay-token-rust");
+    let _token_env = helpers::EnvGuard::set(s3_socket_token_env(""), "relay-token-rust");
 
     let s3 = S3::connect().await.expect("connect");
     let mut object = s3.object("bucket", "docs/tcp-token.txt");

--- a/sdk/rust/tests/workflow_builders.rs
+++ b/sdk/rust/tests/workflow_builders.rs
@@ -1,8 +1,7 @@
 use std::time::{Duration, UNIX_EPOCH};
 
-use gestalt::proto::v1::bound_workflow_target;
-use prost_types::value::Kind;
 use serde::Serialize;
+use serde_json::json;
 
 use gestalt::{
     BoundWorkflowPluginTargetInput, BoundWorkflowRunInput, BoundWorkflowTargetInput,
@@ -52,18 +51,11 @@ fn workflow_builders_accept_serde_values_and_system_time() -> gestalt::Result<()
     let plugin = plugin_target(&target)?;
     assert_eq!(plugin.plugin_name, "plugin");
     assert_eq!(
-        plugin
-            .input
-            .as_ref()
-            .and_then(|input| input.fields.get("count"))
-            .and_then(|value| value.kind.as_ref()),
-        Some(&Kind::NumberValue(0.0))
+        plugin.input.as_ref().and_then(|input| input.get("count")),
+        Some(&json!(0))
     );
     assert_eq!(signal.sequence, 0);
-    assert_eq!(
-        run.created_at.as_ref().map(|value| value.seconds),
-        Some(1_778_241_600)
-    );
+    assert_eq!(run.created_at, Some(created_at));
     Ok(())
 }
 
@@ -79,36 +71,16 @@ fn workflow_copy_helpers_do_not_alias_nested_payloads() -> gestalt::Result<()> {
     let copied = new_bound_workflow_target_from_target(&target)?;
 
     let plugin = plugin_target_mut(&mut target)?;
-    let nested = plugin
-        .input
-        .as_mut()
-        .and_then(|input| input.fields.get_mut("nested"))
-        .and_then(|value| value.kind.as_mut())
-        .and_then(|kind| match kind {
-            Kind::StructValue(value) => Some(value),
-            _ => None,
-        })
-        .expect("nested struct");
-    nested.fields.insert(
-        "value".to_string(),
-        prost_types::Value {
-            kind: Some(Kind::StringValue("changed".to_string())),
-        },
-    );
+    plugin.input.as_mut().expect("input")["nested"]["value"] = json!("changed");
 
     let copied_plugin = plugin_target(&copied)?;
     assert_eq!(
         copied_plugin
             .input
             .as_ref()
-            .and_then(|input| input.fields.get("nested"))
-            .and_then(|value| value.kind.as_ref())
-            .and_then(|kind| match kind {
-                Kind::StructValue(value) => value.fields.get("value"),
-                _ => None,
-            })
-            .and_then(|value| value.kind.as_ref()),
-        Some(&Kind::StringValue("original".to_string()))
+            .and_then(|input| input.get("nested"))
+            .and_then(|nested| nested.get("value")),
+        Some(&json!("original"))
     );
     Ok(())
 }
@@ -116,8 +88,8 @@ fn workflow_copy_helpers_do_not_alias_nested_payloads() -> gestalt::Result<()> {
 fn plugin_target(
     target: &gestalt::BoundWorkflowTarget,
 ) -> gestalt::Result<&gestalt::BoundWorkflowPluginTarget> {
-    match target.kind.as_ref() {
-        Some(bound_workflow_target::Kind::Plugin(plugin)) => Ok(plugin),
+    match target {
+        gestalt::BoundWorkflowTarget::Plugin(plugin) => Ok(plugin),
         _ => Err(gestalt::Error::bad_request("expected plugin target")),
     }
 }
@@ -125,8 +97,8 @@ fn plugin_target(
 fn plugin_target_mut(
     target: &mut gestalt::BoundWorkflowTarget,
 ) -> gestalt::Result<&mut gestalt::BoundWorkflowPluginTarget> {
-    match target.kind.as_mut() {
-        Some(bound_workflow_target::Kind::Plugin(plugin)) => Ok(plugin),
+    match target {
+        gestalt::BoundWorkflowTarget::Plugin(plugin) => Ok(plugin),
         _ => Err(gestalt::Error::bad_request("expected plugin target")),
     }
 }

--- a/sdk/rust/tests/workflow_manager_transport.rs
+++ b/sdk/rust/tests/workflow_manager_transport.rs
@@ -25,9 +25,9 @@ use gestalt::proto::v1::{
 };
 use gestalt::{
     AgentMessageInput, AgentMessagePartInput, BoundWorkflowAgentTargetInput,
-    BoundWorkflowPluginTargetInput, BoundWorkflowTargetInput, ENV_WORKFLOW_MANAGER_SOCKET,
-    ENV_WORKFLOW_MANAGER_SOCKET_TOKEN, Request, WorkflowEventInput, WorkflowEventMatchInput,
-    WorkflowManager, WorkflowManagerCreateDefinitionInput, WorkflowManagerCreateEventTriggerInput,
+    BoundWorkflowPluginTargetInput, BoundWorkflowTargetInput, ENV_WORKFLOW_MANAGER_SOCKET, Request,
+    WorkflowEventInput, WorkflowEventMatchInput, WorkflowManager,
+    WorkflowManagerCreateDefinitionInput, WorkflowManagerCreateEventTriggerInput,
     WorkflowManagerCreateScheduleInput, WorkflowManagerDeleteDefinitionInput,
     WorkflowManagerDeleteEventTriggerInput, WorkflowManagerDeleteScheduleInput,
     WorkflowManagerGetDefinitionInput, WorkflowManagerGetEventTriggerInput,
@@ -44,6 +44,8 @@ use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
 use tonic::codegen::async_trait;
 use tonic::transport::Server;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
+
+const ENV_WORKFLOW_MANAGER_SOCKET_TOKEN: &str = "GESTALT_WORKFLOW_MANAGER_SOCKET_TOKEN";
 
 #[derive(Clone, Debug, Default, PartialEq)]
 struct SeenRequest {
@@ -851,7 +853,7 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
     assert_eq!(created_trigger.id, "trg-1");
     assert_eq!(
         created_trigger
-            .r#match
+            .event_match
             .as_ref()
             .expect("created trigger match")
             .event_type,
@@ -866,7 +868,7 @@ async fn workflow_manager_connects_over_unix_socket_and_sends_invocation_token()
     assert!(updated_trigger.paused);
     assert_eq!(
         updated_trigger
-            .r#match
+            .event_match
             .as_ref()
             .expect("updated trigger match")
             .event_type,

--- a/sdk/rust/tests/workflow_transport.rs
+++ b/sdk/rust/tests/workflow_transport.rs
@@ -9,13 +9,17 @@ use gestalt::proto::v1::workflow_host_server::{
 };
 use gestalt::proto::v1::workflow_provider_client::WorkflowProviderClient;
 use gestalt::proto::v1::{
-    self as pb, BoundWorkflowPluginTarget, BoundWorkflowRun, BoundWorkflowTarget,
-    ConfigureProviderRequest, ProviderKind, PublishWorkflowProviderEventRequest,
-    StartWorkflowProviderRunRequest, WorkflowEvent, WorkflowRunStatus, bound_workflow_target,
+    self as pb, BoundWorkflowPluginTarget as ProtoBoundWorkflowPluginTarget,
+    BoundWorkflowTarget as ProtoBoundWorkflowTarget, ConfigureProviderRequest, ProviderKind,
+    PublishWorkflowProviderEventRequest as ProtoPublishWorkflowProviderEventRequest,
+    StartWorkflowProviderRunRequest as ProtoStartWorkflowProviderRunRequest,
+    WorkflowEvent as ProtoWorkflowEvent, WorkflowRunStatus as ProtoWorkflowRunStatus,
+    bound_workflow_target,
 };
 use gestalt::{
-    BoundWorkflowPluginTargetInput, BoundWorkflowTargetInput, ENV_WORKFLOW_HOST_SOCKET_TOKEN,
-    InvokeWorkflowOperationInput, RuntimeMetadata, WorkflowHost, WorkflowProvider,
+    BoundWorkflowPluginTargetInput, BoundWorkflowRun, BoundWorkflowTargetInput,
+    InvokeWorkflowOperationInput, PublishWorkflowProviderEventRequest, RuntimeMetadata,
+    StartWorkflowProviderRunRequest, WorkflowHost, WorkflowProvider, WorkflowRunStatus,
 };
 use hyper_util::rt::tokio::TokioIo;
 use tokio::net::{TcpListener, UnixListener, UnixStream};
@@ -23,6 +27,8 @@ use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
 use tonic::transport::{Endpoint, Server};
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 use tower::service_fn;
+
+const ENV_WORKFLOW_HOST_SOCKET_TOKEN: &str = "GESTALT_WORKFLOW_HOST_SOCKET_TOKEN";
 
 #[derive(Default)]
 struct TestWorkflowProvider {
@@ -68,7 +74,7 @@ impl WorkflowProvider for TestWorkflowProvider {
             .ok_or_else(|| gestalt::Error::bad_request("missing target"))?;
         Ok(BoundWorkflowRun {
             id: request.idempotency_key,
-            status: WorkflowRunStatus::Pending as i32,
+            status: WorkflowRunStatus::Pending,
             target: Some(target),
             ..Default::default()
         })
@@ -84,7 +90,7 @@ impl WorkflowProvider for TestWorkflowProvider {
         self.published_events
             .lock()
             .expect("published_events lock")
-            .push((request.plugin_name, event.r#type));
+            .push((request.plugin_name, event.event_type));
         Ok(())
     }
 }
@@ -170,10 +176,10 @@ async fn workflow_runtime_and_server_round_trip_over_unix_socket() {
 
     let mut client = WorkflowProviderClient::new(channel);
     let started = client
-        .start_run(StartWorkflowProviderRunRequest {
-            target: Some(BoundWorkflowTarget {
+        .start_run(ProtoStartWorkflowProviderRunRequest {
+            target: Some(ProtoBoundWorkflowTarget {
                 kind: Some(bound_workflow_target::Kind::Plugin(
-                    BoundWorkflowPluginTarget {
+                    ProtoBoundWorkflowPluginTarget {
                         plugin_name: "demo".to_string(),
                         operation: "refresh".to_string(),
                         input: Some(helpers::struct_from_json(serde_json::json!({
@@ -191,16 +197,16 @@ async fn workflow_runtime_and_server_round_trip_over_unix_socket() {
         .into_inner();
     assert_eq!(started.id, "run-42");
     assert_eq!(
-        WorkflowRunStatus::try_from(started.status)
+        ProtoWorkflowRunStatus::try_from(started.status)
             .expect("valid workflow run status")
             .as_str_name(),
         "WORKFLOW_RUN_STATUS_PENDING"
     );
     assert_eq!(
         started.target.expect("target"),
-        BoundWorkflowTarget {
+        ProtoBoundWorkflowTarget {
             kind: Some(bound_workflow_target::Kind::Plugin(
-                BoundWorkflowPluginTarget {
+                ProtoBoundWorkflowPluginTarget {
                     plugin_name: "demo".to_string(),
                     operation: "refresh".to_string(),
                     input: Some(helpers::struct_from_json(serde_json::json!({
@@ -213,9 +219,9 @@ async fn workflow_runtime_and_server_round_trip_over_unix_socket() {
     );
 
     client
-        .publish_event(PublishWorkflowProviderEventRequest {
+        .publish_event(ProtoPublishWorkflowProviderEventRequest {
             plugin_name: "demo".to_string(),
-            event: Some(WorkflowEvent {
+            event: Some(ProtoWorkflowEvent {
                 id: "evt_1".to_string(),
                 source: "urn:test".to_string(),
                 spec_version: "1.0".to_string(),


### PR DESCRIPTION
## Summary

Converts the Rust SDK's normal public provider/client/root APIs away from generated protobuf-shaped types. The generated protocol remains available only through the doc-hidden `gestalt::proto::v1` escape hatch.

## Interface Changes
- New/changed interface: auth, workflow, plugin-runtime, S3, runtime-log host, agent-manager, and workflow-manager public APIs now use SDK-owned structs/enums and native values.
- Example usage:

```rust
use gestalt::{AuthenticationProvider, BeginLoginRequest, BeginLoginResponse, RuntimeLogStream};

async fn begin_login(req: BeginLoginRequest) -> gestalt::Result<BeginLoginResponse> {
    Ok(BeginLoginResponse {
        authorization_url: format!("https://auth.example/login?state={}", req.host_state),
        provider_state: Vec::new(),
    })
}
```

- Low-level protocol usage remains explicit:

```rust
use gestalt::proto::v1;
```

## Functional/Integration Tests
- Tests added or augmented: added `sdk/rust/tests/plugin_runtime_transport.rs`; updated auth, workflow, manager, S3, runtime-log, and builder transport/contract tests.
- Contract boundary covered: public SDK types through gRPC transport adapters and rustdoc generation.
- Commands run:
  - `cargo check`
  - `cargo test --no-run`
  - `cargo fmt`
  - `cargo clippy --all-targets -- -D warnings`
  - `cargo test`
  - `cargo doc --no-deps`
  - `bash ../../docs/scripts/check-sdk-doc-leaks.sh rust target/doc/gestalt`
  - `git diff --check`

No follow-up PR dependency; this is stand-alone.
