### PR TITLE
Preserve CLI auth state for PKCE callbacks

### DIFF
--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -418,14 +418,19 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 
 	var identity *core.UserIdentity
 	var originalState string
+	callbackQuery := r.URL.Query()
+	providerCallbackState := stateForProviderCallback(loginState.State, callbackQuery.Get("state"))
 
 	if handler, ok := auth.provider.(RequestCallbackHandler); ok {
-		identity, originalState, err = handler.HandleCallbackRequest(r.Context(), r.URL.Query())
+		if providerCallbackState != callbackQuery.Get("state") {
+			callbackQuery = cloneCallbackQuery(callbackQuery)
+			callbackQuery.Set("state", providerCallbackState)
+		}
+		identity, originalState, err = handler.HandleCallbackRequest(r.Context(), callbackQuery)
 	} else if stateful, ok := auth.provider.(StatefulCallbackHandler); ok {
-		state := r.URL.Query().Get("state")
-		identity, originalState, err = stateful.HandleCallbackWithState(r.Context(), code, state)
+		identity, originalState, err = stateful.HandleCallbackWithState(r.Context(), code, providerCallbackState)
 	} else {
-		originalState = r.URL.Query().Get("state")
+		originalState = callbackQuery.Get("state")
 		identity, err = auth.provider.HandleCallback(r.Context(), code)
 	}
 	if err != nil {
@@ -537,6 +542,24 @@ func loginStatesMatch(expectedState, originalState string) bool {
 		return true
 	}
 	return false
+}
+
+func stateForProviderCallback(expectedState, callbackState string) string {
+	if rawState, ok := stripCLIStatePrefix(expectedState); ok && rawState == callbackState {
+		return expectedState
+	}
+	return callbackState
+}
+
+func cloneCallbackQuery(values url.Values) url.Values {
+	if len(values) == 0 {
+		return url.Values{}
+	}
+	cloned := make(url.Values, len(values))
+	for key, candidates := range values {
+		cloned[key] = append([]string(nil), candidates...)
+	}
+	return cloned
 }
 
 func stripCLIStatePrefix(state string) (string, bool) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -15350,6 +15350,65 @@ func TestLoginCallbackForCLIWithCallbackPortStrippedState(t *testing.T) {
 	}
 }
 
+func TestLoginCallbackForCLIWithRequestCallbackProviderUsesPrefixedState(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	u := seedUser(t, svc, "request@example.com")
+	auth := &stubRequestCallbackAuth{
+		wantCallbackState: "cli:54305:test-state",
+		email:             "request@example.com",
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = auth
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	body := bytes.NewBufferString(`{"state":"test-state","callbackPort":54305}`)
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+	if auth.capturedState != auth.wantCallbackState {
+		t.Fatalf("login state = %q, want %q", auth.capturedState, auth.wantCallbackState)
+	}
+
+	resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state&cli=1")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if result["id"] == "" {
+		t.Fatal("expected id in CLI login response")
+	}
+	if result["token"] == "" {
+		t.Fatal("expected token in CLI login response")
+	}
+
+	tokens, err := svc.APITokens.ListAPITokens(context.Background(), u.ID)
+	if err != nil {
+		t.Fatalf("list api tokens: %v", err)
+	}
+	if len(tokens) == 0 {
+		t.Fatal("expected API token to be stored")
+	}
+}
+
 func TestLoginCallbackStateMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -22505,6 +22564,36 @@ func (s *stubHostIssuedSessionAuth) ValidateToken(_ context.Context, token strin
 
 func (s *stubHostIssuedSessionAuth) SessionTokenTTL() time.Duration {
 	return time.Hour
+}
+
+type stubRequestCallbackAuth struct {
+	coretesting.StubAuthProvider
+	capturedState     string
+	wantCallbackState string
+	email             string
+}
+
+func (s *stubRequestCallbackAuth) Name() string {
+	return "request-callback"
+}
+
+func (s *stubRequestCallbackAuth) LoginURL(state string) (string, error) {
+	s.capturedState = state
+	return "https://idp.example.test/login?state=" + url.QueryEscape(state), nil
+}
+
+func (s *stubRequestCallbackAuth) HandleCallbackRequest(_ context.Context, query url.Values) (*core.UserIdentity, string, error) {
+	if query.Get("code") != "good-code" {
+		return nil, "", fmt.Errorf("unexpected code %q", query.Get("code"))
+	}
+	if query.Get("state") != s.wantCallbackState {
+		return nil, "", fmt.Errorf("missing verifier for state %q", query.Get("state"))
+	}
+	email := s.email
+	if email == "" {
+		email = "request@example.com"
+	}
+	return &core.UserIdentity{Email: email, DisplayName: "Request Callback"}, query.Get("state"), nil
 }
 
 func TestCookieAuth(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve the original CLI-prefixed auth state when dispatching login callbacks to request/stateful auth providers
- add regression coverage for CLI callbacks that strip the local callback port from state

## Test plan
- [x] go test ./internal/server -run 'Test(LoginCallbackForCLI|LoginCallbackStateMismatch|StartLoginWithCallbackPort)' -count=1