### PR TITLE
Fix default HTTPBin provider version

### DIFF
--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -15,7 +15,7 @@ const (
 	localConfigDirName = ".gestaltd"
 
 	defaultHTTPBinProvider = config.DefaultProviderRepo + "/plugins/httpbin"
-	defaultHTTPBinVersion  = "0.0.1-alpha.2"
+	defaultHTTPBinVersion  = "0.0.1-alpha.1"
 )
 
 func DefaultLocalConfigPath() string {


### PR DESCRIPTION
## Summary
- Pin the generated local HTTPBin provider default to v0.0.1-alpha.1
- Avoid generating configs that point at the unpublished v0.0.1-alpha.2 release metadata URL

## Test
- go test ./internal/operator