### PR TITLE
Add versioned SDK docs publishing groundwork

### DIFF
--- a/.github/scripts/check-sdk-package-exists.py
+++ b/.github/scripts/check-sdk-package-exists.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check whether an SDK package version exists.")
+    parser.add_argument("registry", choices=["pypi", "npm"])
+    parser.add_argument("package")
+    parser.add_argument("version")
+    parser.add_argument(
+        "--metadata-file",
+        type=Path,
+        help="Read registry metadata from this file instead of the network.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    metadata = read_metadata(args.registry, args.package, args.metadata_file)
+    exists = version_exists(args.registry, metadata, args.version)
+    value = "true" if exists else "false"
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as output:
+            output.write(f"exists={value}\n")
+    print(f"exists={value}")
+
+
+def read_metadata(registry: str, package: str, metadata_file: Path | None) -> dict:
+    if metadata_file:
+        return json.loads(metadata_file.read_text())
+    url = registry_url(registry, package)
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return {}
+        raise
+
+
+def registry_url(registry: str, package: str) -> str:
+    if registry == "pypi":
+        return f"https://pypi.org/pypi/{urllib.parse.quote(package)}/json"
+    return "https://registry.npmjs.org/" + urllib.parse.quote(package, safe="@")
+
+
+def version_exists(registry: str, metadata: dict, version: str) -> bool:
+    if registry == "pypi":
+        return version in metadata.get("releases", {})
+    return version in metadata.get("versions", {})
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/.github/workflows/bootstrap-sdk-api-docs.yml
+++ b/.github/workflows/bootstrap-sdk-api-docs.yml
@@ -1,0 +1,202 @@
+name: Bootstrap SDK API Docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      python-ref:
+        description: Git ref containing the Python SDK source to publish
+        required: false
+        type: string
+      python-version:
+        description: Python SDK tag version without the sdk/python/v prefix, such as 0.0.1-alpha.19
+        required: false
+        type: string
+      typescript-ref:
+        description: Git ref containing the TypeScript SDK source to publish
+        required: false
+        type: string
+      typescript-version:
+        description: TypeScript SDK tag version without the sdk/typescript/v prefix, such as 0.0.1-alpha.18
+        required: false
+        type: string
+      latest-policy:
+        description: Latest alias update policy
+        required: true
+        default: force
+        type: choice
+        options:
+          - force
+          - auto
+          - never
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  DOCS_SDK_API_BUCKET: ${{ vars.DOCS_SDK_API_BUCKET || format('{0}-sdk-api-docs', vars.DOCS_RESOURCE_PREFIX) }}
+
+jobs:
+  bootstrap-python:
+    if: ${{ inputs.python-ref != '' && inputs.python-version != '' }}
+    name: Bootstrap Python SDK API Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: sdk-python-docs-release
+      cancel-in-progress: false
+    env:
+      UV_PYTHON: "3.14"
+    steps:
+      - name: Checkout helpers
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: helpers
+
+      - name: Checkout Python SDK source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.python-ref }}
+          path: source
+
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install Python
+        working-directory: source/sdk/python
+        run: uv python install 3.14
+
+      - name: Normalize package version
+        id: version
+        working-directory: source/sdk/python
+        env:
+          VERSION: ${{ inputs.python-version }}
+        run: |
+          python3 ../../../helpers/.github/scripts/normalize-python-sdk-version.py pyproject.toml "${VERSION}"
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import tomllib
+
+          with open("pyproject.toml", "rb") as pyproject:
+              data = tomllib.load(pyproject)
+          print(f"pep440={data['project']['version']}")
+          PY
+
+      - name: Build Python SDK API docs
+        working-directory: source/sdk/python
+        run: |
+          docs_out="${RUNNER_TEMP}/python-sdk-api-docs"
+          rm -rf "${docs_out}"
+          uv build
+          wheel="$(ls dist/*.whl)"
+          GESTALT_SDK_DOCS_VERSION="${{ steps.version.outputs.pep440 }}" \
+            uv run --with "$wheel" --with sphinx==8.1.3 --no-project \
+              sphinx-build -W -b html -d docs/_build/bootstrap-doctrees docs "${docs_out}"
+          bash ../../../helpers/docs/scripts/check-sdk-doc-leaks.sh python "${docs_out}"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ vars.GCP_WIF_POOL_ID }}/providers/${{ vars.GCP_WIF_PROVIDER_ID }}
+          service_account: github-actions@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          token_format: access_token
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+
+      - name: Upload Python SDK API docs
+        working-directory: helpers
+        run: |
+          if [ -z "${DOCS_SDK_API_BUCKET}" ]; then
+            echo "DOCS_SDK_API_BUCKET repository variable must be configured" >&2
+            exit 1
+          fi
+          python3 docs/scripts/publish-sdk-api-docs.py \
+            --mode upload \
+            --language python \
+            --version "${{ steps.version.outputs.pep440 }}" \
+            --source-tag "${{ inputs.python-ref }}" \
+            --source-dir "${RUNNER_TEMP}/python-sdk-api-docs" \
+            --bucket "${DOCS_SDK_API_BUCKET}" \
+            --latest-policy "${{ inputs.latest-policy }}"
+
+  bootstrap-typescript:
+    if: ${{ inputs.typescript-ref != '' && inputs.typescript-version != '' }}
+    name: Bootstrap TypeScript SDK API Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: sdk-typescript-docs-release
+      cancel-in-progress: false
+    steps:
+      - name: Checkout helpers
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: helpers
+
+      - name: Checkout TypeScript SDK source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.typescript-ref }}
+          path: source
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.11
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+
+      - name: Normalize package version
+        working-directory: source/sdk/typescript
+        env:
+          VERSION: ${{ inputs.typescript-version }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("package.json")
+          data = json.loads(path.read_text())
+          data["version"] = os.environ["VERSION"]
+          path.write_text(json.dumps(data, indent=2) + "\n")
+          PY
+
+      - name: Install dependencies
+        working-directory: source/sdk/typescript
+        run: bun install --frozen-lockfile
+
+      - name: Build TypeScript SDK API docs
+        working-directory: source/sdk/typescript
+        run: |
+          docs_out="${RUNNER_TEMP}/typescript-sdk-api-docs"
+          rm -rf "${docs_out}"
+          bun run docs:lint
+          ./node_modules/.bin/typedoc --options typedoc.json --out "${docs_out}"
+          bash ../../../helpers/docs/scripts/check-sdk-doc-leaks.sh typescript "${docs_out}"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ vars.GCP_WIF_POOL_ID }}/providers/${{ vars.GCP_WIF_PROVIDER_ID }}
+          service_account: github-actions@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          token_format: access_token
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+
+      - name: Upload TypeScript SDK API docs
+        working-directory: helpers
+        run: |
+          if [ -z "${DOCS_SDK_API_BUCKET}" ]; then
+            echo "DOCS_SDK_API_BUCKET repository variable must be configured" >&2
+            exit 1
+          fi
+          python3 docs/scripts/publish-sdk-api-docs.py \
+            --mode upload \
+            --language typescript \
+            --version "${{ inputs.typescript-version }}" \
+            --source-tag "${{ inputs.typescript-ref }}" \
+            --source-dir "${RUNNER_TEMP}/typescript-sdk-api-docs" \
+            --bucket "${DOCS_SDK_API_BUCKET}" \
+            --latest-policy "${{ inputs.latest-policy }}"

--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Check SDK docs
         run: npm run test:sdk-docs
 
+      - name: Check SDK API docs publish contract
+        run: npm run test:sdk-api-docs
+
       - name: Build versioned docs smoke site
         run: npm run build:versioned:test
 

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -45,7 +45,7 @@ jobs:
         Go SDK for building against Gestalt's plugin and protocol surfaces, including the generated protobuf types used by the server and plugins.
       install-markdown: |
         - Go modules: `go get github.com/valon-technologies/gestalt/sdk/go@v${version}`
-        - Package docs: [pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go](https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go)
+        - Package docs: [pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go@v${version}](https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go@v${version})
 
   warm-go-sdk-module-proxy:
     if: ${{ startsWith(github.ref_name, 'sdk/go/v') }}
@@ -194,7 +194,7 @@ jobs:
       install-markdown: |
         - Crate: `cargo add gestalt-sdk`
         - In code, continue importing the library as `gestalt`
-        - API docs: [docs.rs/gestalt-sdk/latest/gestalt](https://docs.rs/gestalt-sdk/latest/gestalt/)
+        - API docs: [docs.rs/gestalt-sdk/${version}/gestalt](https://docs.rs/gestalt-sdk/${version}/gestalt/)
         - Package page: [crates.io/crates/gestalt-sdk](https://crates.io/crates/gestalt-sdk)
 
   publish-python-sdk:
@@ -208,8 +208,12 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: sdk-python-docs-release
+      cancel-in-progress: false
     env:
       UV_PYTHON: "3.14"
+      DOCS_SDK_API_BUCKET: ${{ vars.DOCS_SDK_API_BUCKET || format('{0}-sdk-api-docs', vars.DOCS_RESOURCE_PREFIX) }}
     defaults:
       run:
         working-directory: sdk/python
@@ -222,10 +226,18 @@ jobs:
         run: uv python install 3.14
 
       - name: Normalize package version from tag
+        id: version
         run: |
           python3 ../../.github/scripts/normalize-python-sdk-version.py \
             pyproject.toml \
             "${GITHUB_REF_NAME#sdk/python/v}"
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import tomllib
+
+          with open("pyproject.toml", "rb") as pyproject:
+              data = tomllib.load(pyproject)
+          print(f"pep440={data['project']['version']}")
+          PY
 
       - name: Build distributions
         run: uv build
@@ -235,10 +247,58 @@ jobs:
           wheel="$(ls dist/*.whl)"
           uv run --with "$wheel" --no-project python -c "import gestalt"
 
+      - name: Build Python SDK API docs
+        run: |
+          docs_out="${RUNNER_TEMP}/python-sdk-api-docs"
+          rm -rf "${docs_out}"
+          wheel="$(ls dist/*.whl)"
+          GESTALT_SDK_DOCS_VERSION="${{ steps.version.outputs.pep440 }}" \
+            uv run --with "$wheel" --with sphinx==8.1.3 --no-project \
+              sphinx-build -W -b html -d docs/_build/release-doctrees docs "${docs_out}"
+          bash ../../docs/scripts/check-sdk-doc-leaks.sh python "${docs_out}"
+
+      - name: Check PyPI version
+        id: pypi-version
+        run: |
+          python3 ../../.github/scripts/check-sdk-package-exists.py \
+            pypi \
+            gestalt-sdk \
+            "${{ steps.version.outputs.pep440 }}"
+
       - name: Publish distributions
+        if: ${{ steps.pypi-version.outputs.exists != 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: sdk/python/dist/
+
+      - name: Skip existing PyPI version
+        if: ${{ steps.pypi-version.outputs.exists == 'true' }}
+        run: echo "gestalt-sdk ${{ steps.version.outputs.pep440 }} already exists on PyPI; skipping package publish"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ vars.GCP_WIF_POOL_ID }}/providers/${{ vars.GCP_WIF_PROVIDER_ID }}
+          service_account: github-actions@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          token_format: access_token
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+
+      - name: Upload Python SDK API docs
+        run: |
+          if [ -z "${DOCS_SDK_API_BUCKET}" ]; then
+            echo "DOCS_SDK_API_BUCKET repository variable must be configured" >&2
+            exit 1
+          fi
+          python3 ../../docs/scripts/publish-sdk-api-docs.py \
+            --mode upload \
+            --language python \
+            --version "${{ steps.version.outputs.pep440 }}" \
+            --source-tag "${GITHUB_REF_NAME}" \
+            --source-dir "${RUNNER_TEMP}/python-sdk-api-docs" \
+            --bucket "${DOCS_SDK_API_BUCKET}" \
+            --latest-policy auto
 
   publish-typescript-sdk:
     if: ${{ startsWith(github.ref_name, 'sdk/typescript/v') }}
@@ -248,6 +308,11 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: sdk-typescript-docs-release
+      cancel-in-progress: false
+    env:
+      DOCS_SDK_API_BUCKET: ${{ vars.DOCS_SDK_API_BUCKET || format('{0}-sdk-api-docs', vars.DOCS_RESOURCE_PREFIX) }}
     defaults:
       run:
         working-directory: sdk/typescript
@@ -299,8 +364,57 @@ jobs:
       - name: Run SDK checks
         run: bun run check
 
+      - name: Lint TSDoc comments
+        run: bun run docs:lint
+
+      - name: Build TypeScript SDK API docs
+        run: |
+          docs_out="${RUNNER_TEMP}/typescript-sdk-api-docs"
+          rm -rf "${docs_out}"
+          TYPEDOC_OUT_DIR="${docs_out}" bun run docs:build
+          bash ../../docs/scripts/check-sdk-doc-leaks.sh typescript "${docs_out}"
+
+      - name: Check npm version
+        id: npm-version
+        run: |
+          python3 ../../.github/scripts/check-sdk-package-exists.py \
+            npm \
+            '@valon-technologies/gestalt' \
+            "${{ steps.version.outputs.version }}"
+
       - name: Dry-run publish
+        if: ${{ steps.npm-version.outputs.exists != 'true' }}
         run: npm publish --dry-run --access public --tag "${{ steps.version.outputs.tag }}"
 
       - name: Publish package
+        if: ${{ steps.npm-version.outputs.exists != 'true' }}
         run: npm publish --access public --tag "${{ steps.version.outputs.tag }}"
+
+      - name: Skip existing npm version
+        if: ${{ steps.npm-version.outputs.exists == 'true' }}
+        run: echo "@valon-technologies/gestalt ${{ steps.version.outputs.version }} already exists on npm; skipping package publish"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ vars.GCP_WIF_POOL_ID }}/providers/${{ vars.GCP_WIF_PROVIDER_ID }}
+          service_account: github-actions@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          token_format: access_token
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+
+      - name: Upload TypeScript SDK API docs
+        run: |
+          if [ -z "${DOCS_SDK_API_BUCKET}" ]; then
+            echo "DOCS_SDK_API_BUCKET repository variable must be configured" >&2
+            exit 1
+          fi
+          python3 ../../docs/scripts/publish-sdk-api-docs.py \
+            --mode upload \
+            --language typescript \
+            --version "${{ steps.version.outputs.version }}" \
+            --source-tag "${GITHUB_REF_NAME}" \
+            --source-dir "${RUNNER_TEMP}/typescript-sdk-api-docs" \
+            --bucket "${DOCS_SDK_API_BUCKET}" \
+            --latest-policy auto

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "next lint",
     "test:sdk-docs": "bash scripts/check-sdk-doc-leaks.sh docs out",
+    "test:sdk-api-docs": "node scripts/check-sdk-api-docs-publish.mjs",
     "test:installer": "bash scripts/test-installer.sh",
     "test:linux-installer": "npm run test:installer",
     "test:nginx-routing": "node scripts/check-nginx-routing.mjs",

--- a/docs/scripts/check-sdk-api-docs-publish.mjs
+++ b/docs/scripts/check-sdk-api-docs-publish.mjs
@@ -1,0 +1,175 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve("..");
+const publishScript = path.join("scripts", "publish-sdk-api-docs.py");
+const packageExistsScript = path.join("..", ".github", "scripts", "check-sdk-package-exists.py");
+
+const tempRoot = await mkdtemp(path.join(tmpdir(), "gestalt-sdk-api-docs-"));
+
+try {
+  const docsRoot = path.join(tempRoot, "html");
+  await mkdir(path.join(docsRoot, "_static"), { recursive: true });
+  await writeFile(path.join(docsRoot, "index.html"), "<!doctype html><title>SDK</title>");
+  await writeFile(path.join(docsRoot, "_static", "style.css"), "body { color: black; }");
+
+  const pythonManifest = await manifest({
+    language: "python",
+    version: "0.0.1a2",
+    sourceTag: "sdk/python/v0.0.1-alpha.2",
+    sourceDir: docsRoot,
+    currentLatestVersion: "0.0.1a1",
+  });
+  assert(pythonManifest.updatesLatest === true, "newer Python version should update latest");
+  assert(
+    pythonManifest.cleanupLatestPrefix === "api/python/latest/",
+    "latest-updating Python manifest should clean the latest prefix",
+  );
+  assertKeys(pythonManifest, [
+    "api/python/0.0.1a2/",
+    "api/python/0.0.1a2/index.html",
+    "api/python/0.0.1a2/_static/style.css",
+    "api/python/latest/",
+    "api/python/latest/index.html",
+    "api/python/latest/_static/style.css",
+    "api/python",
+    "api/python/",
+    "api/python/index.html",
+    "api/python/latest.json",
+  ]);
+  assertCache(
+    pythonManifest,
+    "api/python/0.0.1a2/index.html",
+    "public, max-age=31536000, immutable",
+  );
+  assertCache(pythonManifest, "api/python/latest/index.html", "public, max-age=60, must-revalidate");
+  assertCache(pythonManifest, "api/python/index.html", "no-cache");
+  assertCache(pythonManifest, "api/python/latest.json", "no-cache");
+
+  const olderManifest = await manifest({
+    language: "python",
+    version: "0.0.1a1",
+    sourceTag: "sdk/python/v0.0.1-alpha.1",
+    sourceDir: docsRoot,
+    currentLatestVersion: "0.0.1a2",
+  });
+  assert(olderManifest.updatesLatest === false, "older Python version must not update latest");
+  assert(
+    olderManifest.cleanupLatestPrefix === null,
+    "non-latest Python manifest must not clean the latest prefix",
+  );
+  assertKeys(olderManifest, [
+    "api/python/0.0.1a1/",
+    "api/python/0.0.1a1/index.html",
+    "api/python/0.0.1a1/_static/style.css",
+  ]);
+
+  const typescriptManifest = await manifest({
+    language: "typescript",
+    version: "0.0.1-alpha.10",
+    sourceTag: "sdk/typescript/v0.0.1-alpha.10",
+    sourceDir: docsRoot,
+    currentLatestVersion: "0.0.1-alpha.9",
+  });
+  assert(typescriptManifest.updatesLatest === true, "semver prerelease comparison should work");
+  assert(
+    typescriptManifest.cleanupLatestPrefix === "api/typescript/latest/",
+    "latest-updating TypeScript manifest should clean the latest prefix",
+  );
+  assertKeys(typescriptManifest, [
+    "api/typescript/0.0.1-alpha.10/",
+    "api/typescript/0.0.1-alpha.10/index.html",
+    "api/typescript/0.0.1-alpha.10/_static/style.css",
+    "api/typescript/latest/",
+    "api/typescript/latest/index.html",
+    "api/typescript/latest/_static/style.css",
+    "api/typescript",
+    "api/typescript/",
+    "api/typescript/index.html",
+    "api/typescript/latest.json",
+  ]);
+
+  const pypiMetadata = path.join(tempRoot, "pypi.json");
+  await writeFile(pypiMetadata, JSON.stringify({ releases: { "0.0.1a2": [] } }));
+  await assertPackageExists(["pypi", "gestalt-sdk", "0.0.1a2", "--metadata-file", pypiMetadata], true);
+  await assertPackageExists(["pypi", "gestalt-sdk", "0.0.1a3", "--metadata-file", pypiMetadata], false);
+
+  const npmMetadata = path.join(tempRoot, "npm.json");
+  await writeFile(
+    npmMetadata,
+    JSON.stringify({ versions: { "0.0.1-alpha.10": { name: "@valon-technologies/gestalt" } } }),
+  );
+  await assertPackageExists(
+    ["npm", "@valon-technologies/gestalt", "0.0.1-alpha.10", "--metadata-file", npmMetadata],
+    true,
+  );
+  await assertPackageExists(
+    ["npm", "@valon-technologies/gestalt", "0.0.1-alpha.11", "--metadata-file", npmMetadata],
+    false,
+  );
+} finally {
+  await rm(tempRoot, { force: true, recursive: true });
+}
+
+async function manifest({
+  language,
+  version,
+  sourceTag,
+  sourceDir,
+  currentLatestVersion,
+}) {
+  const { stdout } = await execFileAsync("python3", [
+    publishScript,
+    "--mode",
+    "manifest",
+    "--language",
+    language,
+    "--version",
+    version,
+    "--source-tag",
+    sourceTag,
+    "--source-dir",
+    sourceDir,
+    "--current-latest-version",
+    currentLatestVersion,
+    "--generated-at",
+    "2026-01-01T00:00:00+00:00",
+  ], { cwd: path.join(repoRoot, "docs") });
+  return JSON.parse(stdout);
+}
+
+async function assertPackageExists(args, expected) {
+  const { stdout } = await execFileAsync("python3", [packageExistsScript, ...args], {
+    cwd: path.join(repoRoot, "docs"),
+  });
+  const actual = stdout.includes("exists=true");
+  assert(actual === expected, `package exists check ${args.join(" ")} returned ${stdout}`);
+}
+
+function assertKeys(manifest, expectedKeys) {
+  const actualKeys = manifest.objects.map((object) => object.key).sort();
+  const expected = [...expectedKeys].sort();
+  assert(
+    JSON.stringify(actualKeys) === JSON.stringify(expected),
+    `manifest keys mismatch:\nactual=${JSON.stringify(actualKeys, null, 2)}\nexpected=${JSON.stringify(expected, null, 2)}`,
+  );
+}
+
+function assertCache(manifest, key, expectedCacheControl) {
+  const object = manifest.objects.find((candidate) => candidate.key === key);
+  assert(object, `missing manifest object ${key}`);
+  assert(
+    object.cacheControl === expectedCacheControl,
+    `${key} cacheControl = ${object.cacheControl}, want ${expectedCacheControl}`,
+  );
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/docs/scripts/publish-sdk-api-docs.py
+++ b/docs/scripts/publish-sdk-api-docs.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import base64
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+import mimetypes
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+
+
+VERSION_CACHE_CONTROL = "public, max-age=31536000, immutable"
+LATEST_CACHE_CONTROL = "public, max-age=60, must-revalidate"
+REDIRECT_CACHE_CONTROL = "no-cache"
+MARKER_CACHE_CONTROL = "no-cache"
+
+
+@dataclasses.dataclass(frozen=True)
+class ObjectSpec:
+    key: str
+    cache_control: str
+    content_type: str
+    source: str
+    content: bytes
+    immutable: bool
+
+    def manifest_entry(self) -> dict[str, object]:
+        return {
+            "key": self.key,
+            "cacheControl": self.cache_control,
+            "contentType": self.content_type,
+            "source": self.source,
+            "immutable": self.immutable,
+            "sha256ContentBase64": base64.b64encode(hashlib.sha256(self.content).digest()).decode(
+                "ascii"
+            ),
+            "bytes": len(self.content),
+        }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Publish versioned SDK API docs to the Gestalt docs bucket.",
+    )
+    parser.add_argument("--language", choices=["python", "typescript"], required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--source-dir", type=Path, required=True)
+    parser.add_argument("--bucket")
+    parser.add_argument("--source-tag", required=True)
+    parser.add_argument(
+        "--latest-policy",
+        choices=["auto", "force", "never"],
+        default="auto",
+        help="Whether this release may update the moving latest alias.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["manifest", "upload"],
+        default="upload",
+        help="manifest prints the upload plan without contacting GCS.",
+    )
+    parser.add_argument(
+        "--current-latest-version",
+        help="Testing override for the latest marker comparison in manifest mode.",
+    )
+    parser.add_argument(
+        "--force-version-overwrite",
+        action="store_true",
+        help="Allow replacing existing immutable version objects with different content.",
+    )
+    parser.add_argument(
+        "--generated-at",
+        help="Testing override for latest.json generatedAt.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    validate_version(args.language, args.version)
+    source_dir = args.source_dir.resolve()
+    if not source_dir.is_dir():
+        raise SystemExit(f"source dir does not exist: {source_dir}")
+
+    current_latest = args.current_latest_version
+    if args.mode == "upload":
+        if not args.bucket:
+            raise SystemExit("--bucket is required in upload mode")
+        current_latest = read_current_latest(args.bucket, args.language)
+
+    update_latest = should_update_latest(
+        language=args.language,
+        candidate=args.version,
+        current=current_latest,
+        latest_policy=args.latest_policy,
+    )
+    objects = build_objects(
+        language=args.language,
+        version=args.version,
+        source_tag=args.source_tag,
+        source_dir=source_dir,
+        update_latest=update_latest,
+        generated_at=args.generated_at,
+    )
+
+    manifest = {
+        "language": args.language,
+        "version": args.version,
+        "sourceTag": args.source_tag,
+        "latestPolicy": args.latest_policy,
+        "currentLatestVersion": current_latest,
+        "updatesLatest": update_latest,
+        "cleanupLatestPrefix": f"api/{args.language}/latest/" if update_latest else None,
+        "objects": [obj.manifest_entry() for obj in objects],
+    }
+
+    if args.mode == "manifest":
+        print(json.dumps(manifest, indent=2, sort_keys=True))
+        return
+
+    token = gcloud_access_token()
+    for obj in objects:
+        upload_object(
+            bucket=args.bucket,
+            spec=obj,
+            token=token,
+            force_version_overwrite=args.force_version_overwrite,
+        )
+    if update_latest:
+        cleanup_latest_prefix(
+            bucket=args.bucket,
+            language=args.language,
+            keep_keys={obj.key for obj in objects},
+            token=token,
+        )
+    print(json.dumps({"uploaded": len(objects), "updatesLatest": update_latest}, sort_keys=True))
+
+
+def validate_version(language: str, version: str) -> None:
+    parse_version(language, version)
+
+
+def parse_version(language: str, version: str) -> tuple[int, int, int, int, int]:
+    if language == "python":
+        match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?", version)
+        rank = {"a": 0, "b": 1, "rc": 2, None: 3}
+    else:
+        match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)\.(\d+))?", version)
+        rank = {"alpha": 0, "beta": 1, "rc": 2, None: 3}
+    if match is None:
+        raise SystemExit(f"unsupported {language} SDK docs version: {version}")
+    major, minor, patch, phase, phase_num = match.groups()
+    return (
+        int(major),
+        int(minor),
+        int(patch),
+        rank[phase],
+        int(phase_num or 0),
+    )
+
+
+def should_update_latest(
+    *,
+    language: str,
+    candidate: str,
+    current: str | None,
+    latest_policy: str,
+) -> bool:
+    if latest_policy == "force":
+        return True
+    if latest_policy == "never":
+        return False
+    if not current:
+        return True
+    return parse_version(language, candidate) >= parse_version(language, current)
+
+
+def build_objects(
+    *,
+    language: str,
+    version: str,
+    source_tag: str,
+    source_dir: Path,
+    update_latest: bool,
+    generated_at: str | None,
+) -> list[ObjectSpec]:
+    objects: list[ObjectSpec] = []
+    version_prefix = f"api/{language}/{version}/"
+    latest_prefix = f"api/{language}/latest/"
+
+    files = sorted(path for path in source_dir.rglob("*") if path.is_file())
+    if not any(path.relative_to(source_dir).as_posix() == "index.html" for path in files):
+        raise SystemExit(f"SDK docs root is missing index.html: {source_dir}")
+
+    for path in files:
+        rel = path.relative_to(source_dir).as_posix()
+        content = path.read_bytes()
+        content_type = guess_content_type(path)
+        objects.append(
+            ObjectSpec(
+                key=version_prefix + rel,
+                cache_control=VERSION_CACHE_CONTROL,
+                content_type=content_type,
+                source=str(path),
+                content=content,
+                immutable=True,
+            )
+        )
+        if rel == "index.html":
+            objects.append(
+                ObjectSpec(
+                    key=version_prefix,
+                    cache_control=VERSION_CACHE_CONTROL,
+                    content_type=content_type,
+                    source=str(path),
+                    content=content,
+                    immutable=True,
+                )
+            )
+        if update_latest:
+            objects.append(
+                ObjectSpec(
+                    key=latest_prefix + rel,
+                    cache_control=LATEST_CACHE_CONTROL,
+                    content_type=content_type,
+                    source=str(path),
+                    content=content,
+                    immutable=False,
+                )
+            )
+            if rel == "index.html":
+                objects.append(
+                    ObjectSpec(
+                        key=latest_prefix,
+                        cache_control=LATEST_CACHE_CONTROL,
+                        content_type=content_type,
+                        source=str(path),
+                        content=content,
+                        immutable=False,
+                    )
+                )
+
+    if update_latest:
+        redirect = redirect_html(f"/api/{language}/latest/")
+        for key in [f"api/{language}", f"api/{language}/", f"api/{language}/index.html"]:
+            objects.append(
+                ObjectSpec(
+                    key=key,
+                    cache_control=REDIRECT_CACHE_CONTROL,
+                    content_type="text/html; charset=utf-8",
+                    source="generated legacy redirect",
+                    content=redirect,
+                    immutable=False,
+                )
+            )
+        marker = {
+            "language": language,
+            "version": version,
+            "sourceTag": source_tag,
+            "generatedAt": generated_at or dt.datetime.now(dt.UTC).isoformat(),
+        }
+        objects.append(
+            ObjectSpec(
+                key=f"api/{language}/latest.json",
+                cache_control=MARKER_CACHE_CONTROL,
+                content_type="application/json; charset=utf-8",
+                source="generated latest marker",
+                content=(json.dumps(marker, indent=2, sort_keys=True) + "\n").encode("utf-8"),
+                immutable=False,
+            )
+        )
+
+    keys = [obj.key for obj in objects]
+    if len(keys) != len(set(keys)):
+        duplicates = sorted({key for key in keys if keys.count(key) > 1})
+        raise SystemExit(f"duplicate object keys in SDK docs manifest: {duplicates}")
+    return objects
+
+
+def guess_content_type(path: Path) -> str:
+    content_type, _ = mimetypes.guess_type(path.name)
+    if path.suffix == ".js":
+        return "text/javascript"
+    return content_type or "application/octet-stream"
+
+
+def redirect_html(target: str) -> bytes:
+    return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url={target}">
+    <link rel="canonical" href="{target}">
+    <script>location.replace({json.dumps(target)});</script>
+    <title>Redirecting</title>
+  </head>
+  <body><a href="{target}">Redirecting to {target}</a></body>
+</html>
+""".encode("utf-8")
+
+
+def read_current_latest(bucket: str, language: str) -> str | None:
+    token = gcloud_access_token()
+    key = f"api/{language}/latest.json"
+    try:
+        data = download_object(bucket, key, token)
+    except FileNotFoundError:
+        return None
+    marker = json.loads(data.decode("utf-8"))
+    return marker.get("version")
+
+
+def gcloud_access_token() -> str:
+    token = os.environ.get("GOOGLE_OAUTH_ACCESS_TOKEN")
+    if token:
+        return token
+    try:
+        result = subprocess.run(
+            ["gcloud", "auth", "print-access-token"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise SystemExit(f"failed to get gcloud access token: {error}") from error
+    return result.stdout.strip()
+
+
+def upload_object(
+    *,
+    bucket: str,
+    spec: ObjectSpec,
+    token: str,
+    force_version_overwrite: bool,
+) -> None:
+    existing = None
+    try:
+        existing = download_object(bucket, spec.key, token)
+    except FileNotFoundError:
+        pass
+
+    if spec.immutable and existing is not None:
+        if existing == spec.content:
+            print(f"skip identical immutable object gs://{bucket}/{spec.key}")
+            return
+        if not force_version_overwrite:
+            raise SystemExit(
+                f"immutable SDK docs object already exists with different content: "
+                f"gs://{bucket}/{spec.key}"
+            )
+
+    metadata = {
+        "name": spec.key,
+        "cacheControl": spec.cache_control,
+        "contentType": spec.content_type,
+    }
+    multipart_upload(bucket, metadata, spec.content, token)
+    print(f"uploaded gs://{bucket}/{spec.key}")
+
+
+def download_object(bucket: str, key: str, token: str) -> bytes:
+    encoded_key = urllib.parse.quote(key, safe="")
+    request = urllib.request.Request(
+        f"https://storage.googleapis.com/storage/v1/b/{bucket}/o/{encoded_key}?alt=media",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read()
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            raise FileNotFoundError(key) from error
+        raise
+
+
+def multipart_upload(bucket: str, metadata: dict[str, str], content: bytes, token: str) -> None:
+    boundary = f"gestalt-sdk-docs-{uuid.uuid4().hex}"
+    body = b"".join(
+        [
+            f"--{boundary}\r\n".encode("ascii"),
+            b"Content-Type: application/json; charset=UTF-8\r\n\r\n",
+            json.dumps(metadata, sort_keys=True).encode("utf-8"),
+            b"\r\n",
+            f"--{boundary}\r\n".encode("ascii"),
+            f"Content-Type: {metadata['contentType']}\r\n\r\n".encode("ascii"),
+            content,
+            b"\r\n",
+            f"--{boundary}--\r\n".encode("ascii"),
+        ]
+    )
+    request = urllib.request.Request(
+        f"https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o?uploadType=multipart",
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": f"multipart/related; boundary={boundary}",
+            "Content-Length": str(len(body)),
+        },
+    )
+    with urllib.request.urlopen(request, timeout=60):
+        pass
+
+
+def cleanup_latest_prefix(
+    *,
+    bucket: str,
+    language: str,
+    keep_keys: set[str],
+    token: str,
+) -> None:
+    prefix = f"api/{language}/latest/"
+    for key in list_object_keys(bucket, prefix, token):
+        if key not in keep_keys:
+            delete_object(bucket, key, token)
+            print(f"deleted stale latest object gs://{bucket}/{key}")
+
+
+def list_object_keys(bucket: str, prefix: str, token: str) -> list[str]:
+    keys: list[str] = []
+    page_token: str | None = None
+    while True:
+        query = {
+            "prefix": prefix,
+            "fields": "items/name,nextPageToken",
+        }
+        if page_token:
+            query["pageToken"] = page_token
+        url = (
+            f"https://storage.googleapis.com/storage/v1/b/{bucket}/o?"
+            + urllib.parse.urlencode(query)
+        )
+        request = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+        keys.extend(item["name"] for item in payload.get("items", []))
+        page_token = payload.get("nextPageToken")
+        if not page_token:
+            return keys
+
+
+def delete_object(bucket: str, key: str, token: str) -> None:
+    encoded_key = urllib.parse.quote(key, safe="")
+    request = urllib.request.Request(
+        f"https://storage.googleapis.com/storage/v1/b/{bucket}/o/{encoded_key}",
+        method="DELETE",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30):
+            pass
+    except urllib.error.HTTPError as error:
+        if error.code != 404:
+            raise
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -20,7 +20,10 @@ provider "google" {
 }
 
 locals {
-  docs_cert_name = "${var.resource_prefix}-cert-${replace(var.domain, ".", "-")}-${replace(var.registry_domain, ".", "-")}"
+  docs_cert_name            = "${var.resource_prefix}-cert-${replace(var.domain, ".", "-")}-${replace(var.registry_domain, ".", "-")}"
+  github_actions_email      = "github-actions@${var.project_id}.iam.gserviceaccount.com"
+  sdk_api_docs_bucket_name  = var.sdk_api_docs_bucket_name != "" ? var.sdk_api_docs_bucket_name : "${var.resource_prefix}-sdk-api-docs"
+  sdk_api_docs_backend_name = "${var.resource_prefix}-sdk-api-docs-backend"
 }
 
 # ---------- Cloud Run ----------
@@ -77,6 +80,34 @@ resource "google_compute_backend_service" "docs" {
   backend {
     group = google_compute_region_network_endpoint_group.docs.id
   }
+}
+
+resource "google_storage_bucket" "sdk_api_docs" {
+  name                        = local.sdk_api_docs_bucket_name
+  location                    = var.sdk_api_docs_bucket_location
+  uniform_bucket_level_access = true
+
+  # Public objects are required for the external HTTPS load-balancer backend
+  # bucket serving model used by gestaltd.ai/api/* in the follow-up PR.
+  public_access_prevention = "inherited"
+}
+
+resource "google_storage_bucket_iam_member" "sdk_api_docs_public_read" {
+  bucket = google_storage_bucket.sdk_api_docs.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+resource "google_storage_bucket_iam_member" "sdk_api_docs_github_actions_upload" {
+  bucket = google_storage_bucket.sdk_api_docs.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${local.github_actions_email}"
+}
+
+resource "google_compute_backend_bucket" "sdk_api_docs" {
+  name        = local.sdk_api_docs_backend_name
+  bucket_name = google_storage_bucket.sdk_api_docs.name
+  enable_cdn  = false
 }
 
 resource "google_compute_url_map" "docs" {
@@ -173,7 +204,7 @@ resource "google_dns_record_set" "registry" {
 # ---------- Workload Identity Federation ----------
 
 resource "google_service_account_iam_member" "github_actions_wif" {
-  service_account_id = "projects/${var.project_id}/serviceAccounts/github-actions@${var.project_id}.iam.gserviceaccount.com"
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${local.github_actions_email}"
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.wif_pool_id}/attribute.repository/${var.github_repository}"
 }

--- a/docs/terraform/outputs.tf
+++ b/docs/terraform/outputs.tf
@@ -18,6 +18,11 @@ output "cloud_run_url" {
   value       = google_cloud_run_v2_service.docs.uri
 }
 
+output "sdk_api_docs_bucket_name" {
+  description = "GCS bucket for versioned SDK API docs"
+  value       = google_storage_bucket.sdk_api_docs.name
+}
+
 output "dns_zone_nameservers" {
   description = "Nameservers for the DNS zone - set these in your domain registrar"
   value       = google_dns_managed_zone.docs.name_servers

--- a/docs/terraform/variables.tf
+++ b/docs/terraform/variables.tf
@@ -40,6 +40,18 @@ variable "resource_prefix" {
   type        = string
 }
 
+variable "sdk_api_docs_bucket_name" {
+  description = "Optional explicit GCS bucket name for versioned SDK API docs"
+  type        = string
+  default     = ""
+}
+
+variable "sdk_api_docs_bucket_location" {
+  description = "Location for the versioned SDK API docs GCS bucket"
+  type        = string
+  default     = "US"
+}
+
 variable "wif_pool_id" {
   description = "Workload Identity Pool ID for GitHub Actions OIDC"
   type        = string

--- a/sdk/python/docs/conf.py
+++ b/sdk/python/docs/conf.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.metadata
+import os
 import pathlib
 import sys
 
@@ -13,10 +14,12 @@ if str(ROOT) not in sys.path:
 project = "Gestalt Python SDK"
 author = "Valon Technologies"
 
-try:
-    release = importlib.metadata.version("gestalt-sdk")
-except importlib.metadata.PackageNotFoundError:
-    release = "development"
+release = os.environ.get("GESTALT_SDK_DOCS_VERSION")
+if release is None:
+    try:
+        release = importlib.metadata.version("gestalt-sdk")
+    except importlib.metadata.PackageNotFoundError:
+        release = "development"
 version = release
 
 extensions = [

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -33,8 +33,8 @@
   "scripts": {
     "build:proto": "buf generate --template ../proto/buf.typescript.gen.yaml ../proto",
     "docs:lint": "eslint --max-warnings=0 \"src/**/*.ts\" \"docs/entrypoints/**/*.ts\"",
-    "docs:build": "typedoc --options typedoc.json --out docs/_build/html",
-    "docs:build:deploy": "typedoc --options typedoc.json --out ../../docs/public/api/typescript",
+    "docs:build": "typedoc --options typedoc.json --out \"${TYPEDOC_OUT_DIR:-docs/_build/html}\"",
+    "docs:build:deploy": "TYPEDOC_OUT_DIR=../../docs/public/api/typescript bun run docs:build",
     "docs:check": "bun run docs:lint && bun run docs:build",
     "typecheck": "tsc --noEmit",
     "test": "bun test --max-concurrency 1",


### PR DESCRIPTION
## Summary

Adds the groundwork for versioned Python and TypeScript SDK API docs without switching public `/api/*` traffic yet:

- Creates a dedicated SDK API docs GCS bucket, public-read IAM, GitHub Actions upload IAM, and backend bucket in docs Terraform.
- Adds a deterministic docs upload helper for immutable version paths, moving `latest` aliases, legacy redirect objects, cache-control classes, and latest marker handling.
- Adds a manual bootstrap workflow that uses separate helper and SDK-source checkouts.
- Updates Python/TypeScript SDK release jobs to build docs before package publish, skip package publish on reruns when the version already exists, and upload docs after publish.
- Updates Go/Rust release-note doc links to version-specific registry docs.

This intentionally does not route `gestaltd.ai/api/*` to GCS yet. The follow-up rollout is: deploy this PR, run bootstrap for the chosen current Python/TypeScript versions, then switch traffic in a later PR.

## Interface Changes

- New public object layout prepared for follow-up routing:
  - `/api/python/{pep440}/` and `/api/python/{pep440}/index.html`
  - `/api/typescript/{semver}/` and `/api/typescript/{semver}/index.html`
  - `/api/{language}/latest/` and `/api/{language}/latest/index.html`
  - `/api/{language}`, `/api/{language}/`, and `/api/{language}/index.html` redirect to latest
- New release/bootstrap workflow inputs:
  - `DOCS_SDK_API_BUCKET`, defaulting to `${DOCS_RESOURCE_PREFIX}-sdk-api-docs`
  - bootstrap refs and versions for Python/TypeScript
  - `latest-policy`: `force`, `auto`, or `never`
- Example usage:
  - `sdk/python/v0.0.1-alpha.19` publishes docs under `/api/python/0.0.1a19/`
  - `sdk/typescript/v0.0.1-alpha.18` publishes docs under `/api/typescript/0.0.1-alpha.18/`

## Functional/Integration Tests

- Tests added or augmented:
  - `docs/scripts/check-sdk-api-docs-publish.mjs`
  - docs CI now runs `npm run test:sdk-api-docs`
- Contract boundary covered:
  - SDK docs object layout, cache-control classes, legacy redirect objects, trailing-slash objects, latest marker behavior, no-backward latest guard, and package-exists checks.
- Commands run:
  - `actionlint .github/workflows/release-sdk.yml .github/workflows/bootstrap-sdk-api-docs.yml .github/workflows/build-gestaltd.yml`
  - `node scripts/check-sdk-api-docs-publish.mjs` from `docs`
  - `npm run test:sdk-api-docs` from `docs`
  - `npm ci && npm run build && npm run test:sdk-docs` from `docs`
  - `python3 -m py_compile docs/scripts/publish-sdk-api-docs.py .github/scripts/check-sdk-package-exists.py`
  - `terraform fmt -check` from `docs/terraform`
  - `terraform init -backend=false && terraform validate` from `docs/terraform`
  - Python release-style docs build with `uv build`, `sphinx-build`, and leak check
  - TypeScript release-style TypeDoc build and leak check
