### PR TITLE
Route SDK API docs to GCS

### DIFF
--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -113,6 +113,26 @@ resource "google_compute_backend_bucket" "sdk_api_docs" {
 resource "google_compute_url_map" "docs" {
   name            = "${var.resource_prefix}-url-map"
   default_service = google_compute_backend_service.docs.id
+
+  host_rule {
+    hosts        = ["*"]
+    path_matcher = "docs"
+  }
+
+  path_matcher {
+    name            = "docs"
+    default_service = google_compute_backend_service.docs.id
+
+    path_rule {
+      paths = [
+        "/api/python",
+        "/api/python/*",
+        "/api/typescript",
+        "/api/typescript/*",
+      ]
+      service = google_compute_backend_bucket.sdk_api_docs.id
+    }
+  }
 }
 
 resource "google_compute_managed_ssl_certificate" "docs" {


### PR DESCRIPTION
## Summary

Routes public Python and TypeScript SDK API docs traffic to the versioned SDK API docs GCS backend bucket created in #1942.

- Adds URL map path routing for `/api/python`, `/api/python/*`, `/api/typescript`, and `/api/typescript/*`.
- Leaves all other docs and registry traffic on the existing Cloud Run docs backend.
- Keeps Go on pkg.go.dev and Rust on docs.rs via existing docs links.

## Rollout

This should merge after the SDK API docs bucket has been bootstrapped with current Python and TypeScript docs. The routing change will take effect through the existing Deploy Gestalt Docs workflow on `main`.

## Validation

- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate`
- `git diff --check`
