### PR TITLE
Fix versioned docs cache and client navigation

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -8,8 +8,10 @@ server {
     port_in_redirect off;
     root /usr/share/nginx/html;
     index index.html;
+    add_header Cache-Control "no-cache, max-age=0, must-revalidate" always;
 
     location /_next/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
         try_files $uri =404;
     }
 
@@ -47,6 +49,7 @@ server {
     port_in_redirect off;
     root /usr/share/nginx/html;
     index index.html;
+    add_header Cache-Control "no-cache, max-age=0, must-revalidate" always;
 
     location = / {
         return 301 /latest/;
@@ -66,6 +69,11 @@ server {
 
     location ~ ^(/versions/v[^/]+/.+)/$ {
         return 301 $1;
+    }
+
+    location ~ ^/(latest|versions/v[^/]+)/_next/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
     }
 
     location /latest/ {
@@ -109,6 +117,7 @@ server {
     }
 
     location /_next/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
         try_files $uri =404;
     }
 

--- a/docs/scripts/build-versioned-site.mjs
+++ b/docs/scripts/build-versioned-site.mjs
@@ -114,6 +114,7 @@ async function main() {
     );
     await runPagefind(outDir);
     await assertNoUnversionedDocLinks(outDir);
+    await assertFlightPayloadsUseUnprefixedInternalLinks(outDir);
   } finally {
     await rm(tempRoot, { force: true, recursive: true });
   }
@@ -398,34 +399,40 @@ async function copyRootOutputs(rootOut, finalOut) {
 
 async function rewriteVersionedPaths(root, prefix) {
   const files = await walk(root);
-  for (const file of files.filter((candidate) => /\.(html|txt)$/.test(candidate))) {
+  for (const file of files.filter((candidate) => candidate.endsWith(".html"))) {
     const original = await readFile(file, "utf8");
-    const rewritten = original
-      .replace(
-        /\b(href|src|action)=(["'])\/([^"'\s>]*)/g,
-        (match, attr, quote, rest) => {
-          const absolute = `/${rest}`;
-          return shouldPrefixPath(absolute, prefix)
-            ? `${attr}=${quote}${prefix}${absolute}`
-            : match;
-        },
-      )
-      .replace(/("href"\s*:\s*")\/([^"]*)/g, (match, start, rest) => {
-        const absolute = `/${rest}`;
-        return shouldPrefixPath(absolute, prefix)
-          ? `${start}${prefix}${absolute}`
-          : match;
-      })
-      .replace(/(\\"href\\":\\")\/([^"\\]*)/g, (match, start, rest) => {
-        const absolute = `/${rest}`;
-        return shouldPrefixPath(absolute, prefix)
-          ? `${start}${prefix}${absolute}`
-          : match;
-      });
+    const rewritten = rewriteHtmlDocumentPaths(original, prefix);
     if (rewritten !== original) {
       await writeFile(file, rewritten);
     }
   }
+}
+
+function rewriteHtmlDocumentPaths(html, prefix) {
+  return rewriteNonScriptHtml(html, (chunk) =>
+    chunk.replace(
+      /\b(href|src|action)=(["'])\/([^"'\s>]*)/g,
+      (match, attr, quote, rest) => {
+        const absolute = `/${rest}`;
+        return shouldPrefixPath(absolute, prefix)
+          ? `${attr}=${quote}${prefix}${absolute}`
+          : match;
+      },
+    ),
+  );
+}
+
+function rewriteNonScriptHtml(html, rewriteChunk) {
+  const scriptPattern = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
+  let rewritten = "";
+  let lastIndex = 0;
+  for (const match of html.matchAll(scriptPattern)) {
+    rewritten += rewriteChunk(html.slice(lastIndex, match.index));
+    rewritten += match[0];
+    lastIndex = match.index + match[0].length;
+  }
+  rewritten += rewriteChunk(html.slice(lastIndex));
+  return rewritten;
 }
 
 function shouldPrefixPath(value, prefix) {
@@ -480,12 +487,11 @@ async function assertNoUnversionedDocLinks(finalOut) {
   const bad = [];
   const patterns = [
     /\b(?:href|src|action)=["']\/(?!latest(?:\/|["'])|versions(?:\/|["'])|api\/|admin(?:\/|["'])|favicon\.svg|fonts\/|install(?:-|\.sh)|mcp(?:\/|["'])|registry(?:\/|["'])|versions\.json|_pagefind\/)/g,
-    /"href"\s*:\s*"\/(?!latest(?:\/|")|versions(?:\/|")|api\/|admin(?:\/|")|favicon\.svg|fonts\/|install(?:-|\.sh)|mcp(?:\/|")|registry(?:\/|")|versions\.json|_pagefind\/)/g,
-    /\\"href\\":\\"\/(?!latest(?:\/|\\")|versions(?:\/|\\")|api\/|admin(?:\/|\\")|favicon\.svg|fonts\/|install(?:-|\.sh)|mcp(?:\/|\\")|registry(?:\/|\\")|versions\.json|_pagefind\/)/g,
   ];
-  for (const file of files.filter((candidate) => /\.(html|txt)$/.test(candidate))) {
+  for (const file of files.filter((candidate) => candidate.endsWith(".html"))) {
     const body = await readFile(file, "utf8");
-    const matches = patterns.flatMap((pattern) => body.match(pattern) ?? []);
+    const visibleHtml = body.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+    const matches = patterns.flatMap((pattern) => visibleHtml.match(pattern) ?? []);
     if (matches.length > 0) {
       bad.push(`${path.relative(finalOut, file)}: ${matches.slice(0, 5).join(", ")}`);
     }
@@ -495,6 +501,70 @@ async function assertNoUnversionedDocLinks(finalOut) {
       `versioned docs contain unversioned internal links:\n${bad.join("\n")}`,
     );
   }
+}
+
+async function assertFlightPayloadsUseUnprefixedInternalLinks(finalOut) {
+  const versionedRoots = await versionedOutputRoots(finalOut);
+  const bad = [];
+  for (const { root, prefix } of versionedRoots) {
+    const files = await walk(root);
+    for (const file of files.filter((candidate) => /\.(html|txt)$/.test(candidate))) {
+      const body = await readFile(file, "utf8");
+      const flightText = file.endsWith(".html")
+        ? [...body.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/gi)]
+            .map((match) => match[1])
+            .join("\n")
+        : body;
+      for (const value of flightHrefValues(flightText)) {
+        if (
+          (value === prefix || value.startsWith(`${prefix}/`)) &&
+          !value.startsWith(`${prefix}/_next/`)
+        ) {
+          bad.push(`${path.relative(finalOut, file)}: href ${value}`);
+          break;
+        }
+      }
+    }
+  }
+  if (bad.length > 0) {
+    throw new Error(
+      `versioned docs flight payloads contain base-prefixed internal links:\n${bad.join("\n")}`,
+    );
+  }
+}
+
+function flightHrefValues(text) {
+  const values = [];
+  const patterns = [
+    /"href"\s*:\s*"([^"]+)"/g,
+    /\\"href\\":\\"([^"\\]+)\\"/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      values.push(match[1]);
+    }
+  }
+  return values;
+}
+
+async function versionedOutputRoots(finalOut) {
+  const roots = [];
+  const latest = path.join(finalOut, "latest");
+  if (existsSync(latest)) {
+    roots.push({ prefix: "/latest", root: latest });
+  }
+  const versions = path.join(finalOut, "versions");
+  if (existsSync(versions)) {
+    for (const entry of await readdir(versions, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        roots.push({
+          prefix: `/versions/${entry.name}`,
+          root: path.join(versions, entry.name),
+        });
+      }
+    }
+  }
+  return roots;
 }
 
 async function runPagefind(finalOut) {

--- a/docs/scripts/check-nginx-routing.mjs
+++ b/docs/scripts/check-nginx-routing.mjs
@@ -1,7 +1,11 @@
 import { spawnSync } from "node:child_process";
+import { readdirSync, statSync } from "node:fs";
 import { request } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const image = `gestalt-docs-nginx-routing:${process.pid}`;
+const docsRoot = fileURLToPath(new URL("..", import.meta.url));
 let container = "";
 
 try {
@@ -21,6 +25,7 @@ try {
     throw new Error(`could not determine mapped port for ${container}`);
   }
   const baseUrl = `http://127.0.0.1:${port}`;
+  const latestAssetPath = findStaticAssetPath("latest/_next/static");
   await waitForNginx(baseUrl);
 
   await assertResponse({
@@ -50,8 +55,31 @@ try {
     url: `${baseUrl}/latest/`,
     host: "gestaltd.ai",
     status: 200,
+    cacheControlIncludes: "no-cache",
     includes: "Gestalt",
     excludes: "registry_shell__",
+  });
+  await assertResponse({
+    url: `${baseUrl}/latest/providers`,
+    host: "gestaltd.ai",
+    status: 200,
+    cacheControlIncludes: "no-cache",
+    includes: "Providers",
+    excludes: "registry_shell__",
+  });
+  await assertResponse({
+    url: `${baseUrl}/latest/providers.txt`,
+    host: "gestaltd.ai",
+    status: 200,
+    cacheControlIncludes: "no-cache",
+    includes: "What Providers Do",
+    excludes: "registry_shell__",
+  });
+  await assertResponse({
+    url: `${baseUrl}${latestAssetPath}`,
+    host: "gestaltd.ai",
+    status: 200,
+    cacheControlIncludes: "immutable",
   });
   await assertResponse({
     url: `${baseUrl}/latest/getting-started/`,
@@ -100,6 +128,7 @@ try {
     url: `${baseUrl}/providers/plugin/slack/`,
     host: "registry.gestaltd.ai",
     status: 200,
+    cacheControlIncludes: "no-cache",
     includes: "registry_shell__",
   });
 } finally {
@@ -136,6 +165,7 @@ async function assertResponse({
   excludes,
   location,
   json,
+  cacheControlIncludes,
 }) {
   const response = await httpGet(url, host);
   const body = response.body;
@@ -146,6 +176,14 @@ async function assertResponse({
     const actualLocation = response.headers.location;
     if (actualLocation !== location) {
       throw new Error(`${host} ${url} redirected to ${actualLocation}, want ${location}`);
+    }
+  }
+  if (cacheControlIncludes) {
+    const cacheControl = response.headers["cache-control"] ?? "";
+    if (!cacheControl.includes(cacheControlIncludes)) {
+      throw new Error(
+        `${host} ${url} returned Cache-Control ${cacheControl}, want ${cacheControlIncludes}`,
+      );
     }
   }
   if (includes && !body.includes(includes)) {
@@ -207,4 +245,28 @@ function output(command, args) {
     throw new Error(result.stderr || `${command} ${args.join(" ")} failed`);
   }
   return result.stdout.trim();
+}
+
+function findStaticAssetPath(relativeRoot) {
+  const root = path.join(docsRoot, "out", relativeRoot);
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    for (const entry of readdirSync(current)) {
+      const fullPath = path.join(current, entry);
+      const stat = statSync(fullPath);
+      if (stat.isDirectory()) {
+        stack.push(fullPath);
+        continue;
+      }
+      if (/\.(?:css|js)$/.test(entry)) {
+        const relative = path
+          .relative(path.join(docsRoot, "out"), fullPath)
+          .split(path.sep)
+          .join("/");
+        return `/${relative}`;
+      }
+    }
+  }
+  throw new Error(`could not find a CSS or JS asset under out/${relativeRoot}`);
 }


### PR DESCRIPTION
## Summary
- add explicit no-cache headers for docs HTML/RSC responses while keeping hashed Next static assets immutable
- stop rewriting Next flight payload hrefs with the version base path so client-side navigation does not request /latest/latest/... paths
- extend static/nginx routing checks and add a build assertion for base-prefixed flight hrefs

## Verification
- npm run build:versioned:test
- npm run test:registry
- browser smoke against built docs/out: /latest/getting-started -> sidebar Providers -> /latest/providers
- GitHub Actions Build Gestaltd run 25756737850 passed