### PR TITLE
Support source-built UI providers

### DIFF
--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -38,12 +38,9 @@ workspace-review/
     provider.ts
   ui/
     manifest.yaml
+    package.json
     src/
       app.tsx
-    out/
-      index.html
-      app.js
-      styles.css
 ```
 
 The plugin manifest owns the operations and points at the sibling UI bundle.
@@ -66,12 +63,11 @@ spec:
     path: ../ui/manifest.yaml
 ```
 
-The UI bundle is static assets. Its `assetRoot` points at built browser files,
-not at the frontend source tree. The directory name is not special; `out`,
-`dist`, or `build` all work as long as the directory contains static assets
-such as `index.html`, JavaScript, CSS, and images. Route rules are required
-when the mounted plugin binds an `authorizationPolicy`. For UI package details,
-see [Providers > UI](/providers/ui).
+The UI bundle produces static assets. A source UI manifest can declare a
+`build` command and `output` directory, so the generated `out/` or `dist/`
+directory does not need to be checked in. Route rules are required when the
+mounted plugin binds an `authorizationPolicy`. For UI package details, see
+[Providers > UI](/providers/ui).
 
 ```yaml
 kind: ui
@@ -79,8 +75,16 @@ source: github.com/acme/ui/workspace-review
 version: 0.1.0
 displayName: Workspace Review UI
 description: Browser UI for workspace review.
+build:
+  command:
+    - npm
+    - run
+    - build
+  output: out
+  inputs:
+    - package.json
+    - src
 spec:
-  assetRoot: out
   routes:
     - path: /
       allowedRoles: [viewer, admin]

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -143,9 +143,9 @@ plugins:
 
 Git sources point at an external repository, full commit SHA, and manifest path.
 Use them for reproducible provider revisions before provider-index publication.
-`artifactMode` controls whether Gestalt builds from source or uses a prebuilt
-snapshot. See [Config File](/reference/config-file#pluginssource) for the full
-`source.git` shape.
+`materialization` controls whether Gestalt prepares from source or uses a
+prebuilt snapshot. See [Config File](/reference/config-file#pluginssource) for
+the full `source.git` shape.
 
 ```yaml
 plugins:
@@ -155,7 +155,7 @@ plugins:
         repo: https://github.com/acme/gestalt-providers.git
         ref: 60fa7e0521eeedea8b28abdd9b43284e9ea246e2
         path: plugins/support/manifest.yaml
-        artifactMode: source
+        materialization: source
 ```
 
 ## Provider Installation
@@ -495,27 +495,39 @@ packaging.
   </Tabs.Tab>
 </Tabs>
 
-#### Source release builds
+#### Source UI builds
 
-Source manifests may optionally define a `release.build` command. Gestalt runs
-it before source-manifest preparation, which lets UI packages generate
-static assets and lets provider/authentication/datastore packages generate support files
-such as config schemas before packaging.
+Source UI manifests may define top-level `build`. Gestalt runs it before
+source-manifest preparation, which lets UI packages generate static assets
+without checking built files into source control. The environment running
+`gestaltd lock`, `gestaltd sync --locked`, provider dev, or
+`gestaltd provider release` must have the command's build tools available.
+`gestaltd serve --locked` only serves prepared static assets.
 
 ```yaml
 kind: ui
 source: github.com/acme/plugins/gestalt-ui
 version: 1.2.0
-release:
-  build:
-    workdir: ui
-    command:
-      - npm
-      - run
-      - build
+build:
+  workdir: ui
+  command:
+    - npm
+    - run
+    - build
+  output: ui/out
+  inputs:
+    - ui/package.json
+    - ui/src
 spec:
-  assetRoot: ui/out
+  routes:
+    - path: /
+      allowedRoles: [viewer, admin]
 ```
+
+Released UI packages still contain a concrete `spec.assetRoot`; Gestalt adds it
+to the prepared manifest from `build.output` and strips build metadata.
+`release.build` remains supported as a legacy source build hook, but new UI
+manifests should use top-level `build` and must not set both.
 
 #### Release manifest for an executable provider
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -1359,9 +1359,9 @@ bundled for the local provider session automatically. Raw GraphQL surfaces are
 not tunneled in v1.
 
 For TypeScript plugins, `provider dev` runs `bun install` automatically when the
-plugin has a `package.json` but no `node_modules`. Source UI release builds use
-the same dependency bootstrap for Bun-managed build workdirs before
-`release.build.command` when dependencies are missing. Keep
+plugin has a `package.json` but no `node_modules`. Source UI builds use the
+same dependency bootstrap for Bun-managed build workdirs before `build.command`
+or legacy `release.build.command` when dependencies are missing. Keep
 `@valon-technologies/gestalt` current enough for the host-service features your
 plugin uses; for example, remote IndexedDB host-service calls require an SDK
 version with `tls://` host-service transport support.

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -133,6 +133,11 @@ That writes `gestalt.lock.json` and prepares the bundle under `.gestaltd/`.
 Afterward, `gestaltd serve --locked` serves the prepared assets from the
 configured path prefix.
 
+When a source UI manifest declares `build`, `gestaltd lock` and
+`gestaltd sync --locked` may need the build tool named by `build.command`
+available in the preparation environment. `gestaltd serve --locked` does not
+run UI builds; it serves only the prepared static assets.
+
 ## The admin UI
 
 The built-in admin UI is always served at `/admin`, regardless of whether
@@ -153,8 +158,11 @@ the built-in admin UI continue using the server-wide auth provider.
 
 ### Manifest
 
-The UI manifest declares `spec.assetRoot`, which points to the directory
-containing built static assets. The source field identifies the provider in the
+Released UI manifests declare `spec.assetRoot`, which points to the directory
+containing built static assets. Source UI manifests may declare either
+`spec.assetRoot` when the static assets are checked in, or top-level `build`
+with `output` when Gestalt should generate the static assets during lock, sync,
+dev, or release preparation. The source field identifies the provider in the
 registry.
 
 ```yaml
@@ -163,13 +171,18 @@ source: github.com/valon-technologies/gestalt-providers/ui/default
 version: 0.0.1
 displayName: Default UI
 description: Default Gestalt UI bundle.
-release:
-  build:
-    command:
-      - sh
-      - ./build.sh
+build:
+  workdir: app
+  command:
+    - npm
+    - run
+    - build
+  output: app/out
+  inputs:
+    - app/package.json
+    - app/package-lock.json
+    - app/src
 spec:
-  assetRoot: out
   routes:
     - path: /
       allowedRoles: [viewer, admin]
@@ -177,17 +190,21 @@ spec:
       allowedRoles: [admin]
 ```
 
-The `assetRoot` path is relative to the manifest file. It should contain the
-output of your frontend build, typically an `index.html` and accompanying JS,
-CSS, and image files. The directory does not need to be named `out`; common
-names include `out`, `dist`, and `build`.
+`build.output` and `spec.assetRoot` paths are relative to the manifest file.
+They identify the directory containing static output, typically an `index.html`
+and accompanying JS, CSS, and image files. The directory does not need to be
+named `out`; common names include `out`, `dist`, and `build`.
+
+For source manifests, `spec.assetRoot` is optional when `build.output` is set.
+For released or prepared manifests, `spec.assetRoot` is required and Gestalt
+strips the top-level `build` block after generating the assets. If a source
+manifest sets both `spec.assetRoot` and `build.output`, the values must match.
 
 Gestalt serves and packages static assets rather than frontend source files
-because it does not own each project's frontend build lifecycle. Frameworks,
-package managers, build commands, and environment handling vary by project, so
-production serving stays deterministic and framework-agnostic. If the frontend
-needs a build step, declare it with `release.build` and write the result into
-`assetRoot`.
+because `serve --locked` is runtime-agnostic. Frameworks, package managers,
+build commands, and environment handling vary by project, so production serving
+stays deterministic after `lock` and `sync --locked` have prepared the static
+asset root.
 
 `spec.routes` is optional unless a deployment binds the UI to
 `providers.ui.<name>.authorizationPolicy`. In that case, Gestalt uses these
@@ -197,32 +214,52 @@ declare non-empty `allowedRoles`.
 
 ### Build step
 
-If your UI needs a build step before packaging, use `release.build` to run it
-automatically during `gestaltd provider release`. This runs before
-source-manifest preparation, so the built assets are included in the release
-archive.
+If your source UI needs a build step, use top-level `build`. Gestalt runs the
+command before source-manifest preparation for local paths, git source
+materialization, provider dev, and `gestaltd provider release`. The deployer
+does not need to check in the generated `out/` or `dist/` directory, but the
+environment doing lock or sync must have the tools required by
+`build.command`.
 
-The Default UI uses a shell script that runs `npm ci && npm run build` to produce the static output:
+The Default UI can use npm to produce static output:
 
 ```yaml
 kind: ui
 source: github.com/valon-technologies/gestalt-providers/ui/default
 version: 0.0.1
-release:
-  build:
-    command:
-      - npm
-      - run
-      - build
+build:
+  workdir: app
+  command:
+    - npm
+    - run
+    - build
+  output: app/out
+  inputs:
+    - app/package.json
+    - app/package-lock.json
+    - app/src
 spec:
-  assetRoot: out
+  routes:
+    - path: /
+      allowedRoles: [viewer, admin]
 ```
 
-The command runs relative to the manifest directory. After the build completes,
-Gestalt packages everything under `assetRoot` into the release archive. You can
-use any build tool here -- `npm run build`, `vite build`, `next build && next
-export` -- as long as it writes output to the directory specified in
-`assetRoot`.
+`command` is an argv array, not a shell string. It runs in `build.workdir`
+relative to the manifest directory, or in the manifest directory when
+`workdir` is omitted. `output` is manifest-relative, not workdir-relative.
+`inputs` is optional and contains literal manifest-relative files or
+directories. Gestalt uses it to fingerprint local source UI builds while
+excluding the output directory, `.git`, `.gestaltd`, and `node_modules`.
+Glob syntax is not supported in `inputs`.
+
+After the build completes, Gestalt prepares or packages everything under
+`build.output`. You can use any build tool here -- `npm run build`,
+`vite build`, or `next build` configured for static export -- as long as it
+writes static files to the declared output directory.
+
+`release.build` remains supported as a legacy build hook for source manifests,
+but new UI manifests should prefer top-level `build`. A manifest may not set
+both `build` and `release.build`.
 
 ### Deploying the bundle
 

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -198,7 +198,8 @@ Raw GraphQL surfaces are not tunneled in v1.
 
 For TypeScript source plugins, `provider dev` installs dependencies with
 `bun install` when a `package.json` is present and `node_modules` is missing.
-Source UI release builds use the same bootstrap for Bun-managed build workdirs
-before `release.build.command` when dependencies are missing.
+Source UI builds use the same bootstrap for Bun-managed build workdirs before
+`build.command` or legacy `release.build.command` when dependencies are
+missing.
 
 See [Configuration](/reference/configuration) for the relationship between `lock`, `sync --locked`, `serve --locked`, and `validate`.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1230,8 +1230,8 @@ source:
 upgrade behavior.
 
 For commit-pinned first-party development, use a git source. `ref` must be a
-full commit SHA. `artifactMode: source` fetches and builds from the git source
-when prepared artifacts are missing:
+full commit SHA. `materialization: source` fetches and prepares from the git
+source when prepared artifacts are missing:
 
 ```yaml
 source:
@@ -1239,11 +1239,12 @@ source:
     repo: https://github.com/acme/gestalt-providers.git
     ref: 60fa7e0521eeedea8b28abdd9b43284e9ea246e2
     path: plugins/github/manifest.yaml
-    artifactMode: source
+    materialization: source
 ```
 
 To consume prebuilt snapshots, set `artifactRepository` and an explicit
-`artifactMode`. `require` never falls back to git or provider indexes:
+`materialization: snapshot`. Snapshot materialization never falls back to git
+or provider indexes:
 
 ```yaml
 providerSnapshotRepositories:
@@ -1258,7 +1259,7 @@ plugins:
         ref: 60fa7e0521eeedea8b28abdd9b43284e9ea246e2
         path: plugins/github/manifest.yaml
         artifactRepository: acme
-        artifactMode: require
+        materialization: snapshot
 ```
 
 For exact published releases, point at a `provider-release.yaml` URL:

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -496,10 +496,14 @@ artifacts:
 ## UI Metadata
 
 The `spec` block for a `kind: ui` manifest describes a static UI package.
+Source UI manifests can either point at checked-in static assets with
+`spec.assetRoot` or declare top-level `build.output` to generate those assets
+during preparation. Released and prepared UI manifests always contain
+`spec.assetRoot` and do not contain top-level `build`.
 
 | Field       | Type         | Required | Purpose                                                                                                                     |
 | ----------- | ------------ | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `assetRoot` | string       | yes      | Directory containing the built static assets.                                                                               |
+| `assetRoot` | string       | released: yes; source: when `build.output` is absent | Directory containing the built static assets.                                                                               |
 | `routes`    | UIRoute[] | no       | Optional route-level authorization rules used when a deployment binds this UI to `providers.ui.<name>.authorizationPolicy`. |
 
 Each `spec.routes` entry declares a mounted path and the allowed human roles for that path. Path matching is exact or longest-prefix with a terminal `/*`. When a deployment sets `authorizationPolicy`, route definitions must have non-empty `allowedRoles`, and the manifest must include a route that covers `/`.
@@ -514,14 +518,33 @@ kind: ui
 source: github.com/acme/plugins/gestalt-ui
 version: 1.0.0
 displayName: Custom UI
+build:
+  workdir: ui
+  command:
+    - npm
+    - run
+    - build
+  output: ui/out
+  inputs:
+    - ui/package.json
+    - ui/src
 spec:
-  assetRoot: ui/out
   routes:
     - path: /
       allowedRoles: [viewer, admin]
     - path: /admin/*
       allowedRoles: [admin]
 ```
+
+Top-level `build` is source-only and currently supported for `kind: ui`
+manifests.
+
+| Build field | Type     | Required | Purpose                                                                                           |
+| ----------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `command`   | string[] | yes      | Command argv to run before preparing the static assets.                                           |
+| `workdir`   | string   | no       | Manifest-relative directory where `command` runs. Defaults to the manifest directory.             |
+| `output`    | string   | source UI: yes when `spec.assetRoot` is absent | Manifest-relative directory containing generated static assets. Must match `spec.assetRoot` when both are set. |
+| `inputs`    | string[] | no       | Literal manifest-relative files or directories used to fingerprint local source UI builds. Glob syntax is not supported. |
 
 ## Artifacts
 
@@ -820,25 +843,34 @@ authoring flow.
   </Tabs.Tab>
 </Tabs>
 
-Release-only build steps can be declared in source manifests with `release.build`.
-Gestalt runs that command before source-manifest preparation, which lets
-packages generate support files or UI bundles without checking built artifacts
-into source control.
+Source UI build steps should be declared with top-level `build`. Gestalt runs
+that command before source-manifest preparation during lock, sync, dev, and
+release packaging. This lets UI packages generate static bundles without
+checking built artifacts into source control.
 
 ```yaml
 kind: ui
 source: github.com/acme/plugins/gestalt-ui
 version: 1.0.0
-release:
-  build:
-    workdir: ui
-    command:
-      - npm
-      - run
-      - build
+build:
+  workdir: ui
+  command:
+    - npm
+    - run
+    - build
+  output: ui/out
+  inputs:
+    - ui/package.json
+    - ui/src
 spec:
-  assetRoot: ui/out
+  routes:
+    - path: /
+      allowedRoles: [viewer, admin]
 ```
+
+`release.build` remains supported as a legacy build hook for source manifests,
+but new UI manifests should prefer top-level `build`. A manifest may not set
+both `build` and `release.build`.
 
 ## Release
 

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -562,11 +562,12 @@ func releaseIncludesBuiltPluginArtifact(archives []releaseArchive) bool {
 	return false
 }
 func validateReleaseOutputDir(manifest *providermanifestv1.Manifest, sourceDir, outputDir string) error {
-	if manifest == nil || manifest.Spec == nil || manifest.Spec.AssetRoot == "" {
+	assetRootValue := providerpkg.EffectiveUIAssetRoot(manifest)
+	if manifest == nil || assetRootValue == "" {
 		return nil
 	}
 
-	assetRoot, err := normalizeReleasePath(manifest.Spec.AssetRoot)
+	assetRoot, err := normalizeReleasePath(assetRootValue)
 	if err != nil {
 		return err
 	}
@@ -588,7 +589,7 @@ func validateReleaseOutputDir(manifest *providermanifestv1.Manifest, sourceDir, 
 		return fmt.Errorf("compare output dir to ui asset_root: %w", err)
 	}
 	if insideAssetRoot {
-		return fmt.Errorf("--output %q must not be inside ui.asset_root %q", outputDir, manifest.Spec.AssetRoot)
+		return fmt.Errorf("--output %q must not be inside ui asset root %q", outputDir, assetRootValue)
 	}
 
 	return nil

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -996,10 +996,11 @@ func sourceUIHandler(manifestPath string) (http.Handler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read ui manifest after release build: %w", err)
 	}
-	if manifest.Spec == nil || strings.TrimSpace(manifest.Spec.AssetRoot) == "" {
-		return nil, fmt.Errorf("ui manifest %q missing spec.assetRoot", manifestPath)
+	assetRootValue := providerpkg.EffectiveUIAssetRoot(manifest)
+	if strings.TrimSpace(assetRootValue) == "" {
+		return nil, fmt.Errorf("ui manifest %q missing spec.assetRoot or build.output", manifestPath)
 	}
-	assetRoot := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.Spec.AssetRoot))
+	assetRoot := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(assetRootValue))
 	if _, err := os.Stat(assetRoot); err != nil {
 		return nil, fmt.Errorf("ui asset root not found at %s: %w", assetRoot, err)
 	}

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -1858,6 +1858,13 @@ func TestRun_ProviderReleaseStagesOwnedUIPackage(t *testing.T) {
 			wantAssetRoot: filepath.Join("_owned_ui", "roadmap-ui", "ui", "dist"),
 			skipOnWin:     true,
 		},
+		{
+			name:          "source-built owned ui assets",
+			fixture:       newSourceProviderReleaseFixtureWithSourceBuiltOwnedUI,
+			wantFiles:     []string{"_owned_ui/roadmap-ui/branding/icon.svg", "_owned_ui/roadmap-ui/ui/dist/index.html", "_owned_ui/roadmap-ui/ui/dist/static/app.js"},
+			wantAssetRoot: filepath.Join("_owned_ui", "roadmap-ui", "ui", "dist"),
+			skipOnWin:     true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1899,6 +1906,9 @@ func TestRun_ProviderReleaseStagesOwnedUIPackage(t *testing.T) {
 			}
 			if ownedUIManifest.Release != nil {
 				t.Fatalf("owned ui manifest unexpectedly retained release metadata: %+v", ownedUIManifest.Release)
+			}
+			if ownedUIManifest.Build != nil {
+				t.Fatalf("owned ui manifest unexpectedly retained build metadata: %+v", ownedUIManifest.Build)
 			}
 			metadata := readProviderReleaseMetadata(t, outputDir)
 			if metadata.Schema != providerReleaseSchemaName {
@@ -2045,6 +2055,71 @@ func TestRun_ProviderReleaseBuildsUIAssetsBeforePackaging(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
 			t.Fatalf("expected %s in archive: %v", rel, err)
 		}
+	}
+}
+
+func TestRun_ProviderReleaseBuildsSourceUIAssetsBeforePackaging(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("source build fixture uses POSIX shell")
+	}
+
+	pluginDir := newSourceBuiltUIReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.3-source-build-ui"
+
+	runProviderReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-ui-test_v" + testVersion + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	if manifest.Build != nil {
+		t.Fatalf("released manifest unexpectedly retained build metadata: %+v", manifest.Build)
+	}
+	if manifest.Spec == nil || manifest.Spec.AssetRoot != "ui/out" {
+		t.Fatalf("released manifest spec.assetRoot = %+v, want ui/out", manifest.Spec)
+	}
+	for _, rel := range []string{
+		"branding/icon.svg",
+		"ui/out/index.html",
+		"ui/out/static/app.js",
+	} {
+		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
+			t.Fatalf("expected %s in archive: %v", rel, err)
+		}
+	}
+}
+
+func TestSourceUIHandlerBuildsSourceUIOutput(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("source build fixture uses POSIX shell")
+	}
+
+	uiDir := newSourceBuiltUIReleaseFixture(t, t.TempDir())
+	manifestPath := filepath.Join(uiDir, providerpkg.ManifestFile)
+
+	handler, err := sourceUIHandler(manifestPath)
+	if err != nil {
+		t.Fatalf("sourceUIHandler: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(uiDir, "ui", "out", "index.html")); err != nil {
+		t.Fatalf("expected built index.html: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET / status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "<html>") {
+		t.Fatalf("GET / body = %q, want built html", rec.Body.String())
 	}
 }
 
@@ -2308,7 +2383,7 @@ func TestRun_ProviderReleaseRejectsOutputInsideUIAssetRoot(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected provider release to fail, got output: %s", out)
 	}
-	if !strings.Contains(string(out), "must not be inside ui.asset_root") {
+	if !strings.Contains(string(out), "must not be inside ui asset root") {
 		t.Fatalf("expected overlap error, got: %s", out)
 	}
 }
@@ -3889,6 +3964,31 @@ func newBuiltUIReleaseFixture(t *testing.T, dir string) string {
 	return pluginDir
 }
 
+func newSourceBuiltUIReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, uiTestPluginName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeReleaseTestManifest(t, pluginDir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindUI,
+		Source:      uiTestSource,
+		Version:     "0.0.1",
+		DisplayName: "UI Test",
+		IconFile:    releaseTestIconPath,
+		Build: &providermanifestv1.SourceBuild{
+			Workdir: "ui",
+			Command: []string{"sh", "./build.sh"},
+			Output:  "ui/out",
+			Inputs:  []string{"ui/build.sh"},
+		},
+	})
+	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0o644)
+	writeReleaseBuildScript(t, pluginDir, filepath.Join("ui", "build.sh"), "mkdir -p out/static\nprintf '<html></html>\\n' > out/index.html\nprintf 'console.log(\"ok\")\\n' > out/static/app.js\n")
+	return pluginDir
+}
+
 func newSourceProviderReleaseFixtureWithOwnedUI(t *testing.T, dir string) string {
 	t.Helper()
 
@@ -3944,6 +4044,41 @@ func newSourceProviderReleaseFixtureWithBuiltOwnedUI(t *testing.T, dir string) s
 		},
 		Spec: &providermanifestv1.Spec{
 			AssetRoot: "ui/dist",
+		},
+	})
+	writeTestFile(t, uiDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0o644)
+	writeReleaseBuildScript(t, uiDir, filepath.Join("ui", "build.sh"), "mkdir -p dist/static\nprintf '<html>roadmap</html>\\n' > dist/index.html\nprintf 'console.log(\"roadmap\")\\n' > dist/static/app.js\n")
+
+	manifestPath := filepath.Join(pluginDir, providerpkg.ManifestFile)
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile(%s): %v", providerpkg.ManifestFile, err)
+	}
+	manifest.Spec.UI = &providermanifestv1.OwnedUI{Path: "../roadmap-ui/" + providerpkg.ManifestFile}
+	writeReleaseTestManifest(t, pluginDir, manifest)
+
+	return pluginDir
+}
+
+func newSourceProviderReleaseFixtureWithSourceBuiltOwnedUI(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := newSourceProviderReleaseFixture(t, dir)
+	uiDir := filepath.Join(dir, "roadmap-ui")
+	if err := os.MkdirAll(uiDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(uiDir): %v", err)
+	}
+	writeReleaseTestManifest(t, uiDir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindUI,
+		Source:      "github.com/testowner/web/roadmap-ui",
+		Version:     "0.0.1",
+		DisplayName: "Roadmap UI",
+		IconFile:    releaseTestIconPath,
+		Build: &providermanifestv1.SourceBuild{
+			Workdir: "ui",
+			Command: []string{"sh", "./build.sh"},
+			Output:  "ui/dist",
+			Inputs:  []string{"ui/build.sh"},
 		},
 	})
 	writeTestFile(t, uiDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0o644)

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1649,7 +1649,13 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 	}
 	if entry.HasLocalSource() {
 		input.Path = fingerprintLocalSourcePath(entry.SourcePath(), configDir)
-		digest, err := fingerprintLocalSourceDigest(entry.SourcePath())
+		var digest string
+		var err error
+		if strings.HasPrefix(name, "ui:") {
+			digest, err = fingerprintLocalUISourceDigest(entry.SourcePath())
+		} else {
+			digest, err = fingerprintLocalSourceDigest(entry.SourcePath())
+		}
 		if err != nil {
 			return "", err
 		}
@@ -1797,6 +1803,155 @@ func fingerprintLocalSourceDigest(sourcePath string) (string, error) {
 		return "", err
 	}
 	return providerpkg.DirectoryDigest(sourceDir, manifestPath, manifest)
+}
+
+func fingerprintLocalUISourceDigest(sourcePath string) (string, error) {
+	manifestPath := sourcePath
+	sourceDir := sourcePath
+
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		manifestPath, err = providerpkg.FindManifestFile(sourcePath)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		sourceDir = filepath.Dir(sourcePath)
+	}
+
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return "", err
+	}
+	kind, err := providerpkg.ManifestKind(manifest)
+	if err != nil {
+		return "", err
+	}
+	build := providerpkg.EffectiveSourceBuild(manifest)
+	if kind != providermanifestv1.KindUI || build == nil {
+		return providerpkg.DirectoryDigest(sourceDir, manifestPath, manifest)
+	}
+	return fingerprintLocalUIBuildInputs(sourceDir, manifestPath, manifest, build)
+}
+
+func fingerprintLocalUIBuildInputs(sourceDir, manifestPath string, manifest *providermanifestv1.Manifest, build *providerpkg.ResolvedSourceBuild) (string, error) {
+	var digests []string
+	seen := map[string]struct{}{}
+
+	addFile := func(path string) error {
+		rel, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(filepath.Clean(rel))
+		if _, ok := seen[rel]; ok {
+			return nil
+		}
+		seen[rel] = struct{}{}
+		sum, err := providerpkg.FileSHA256(path)
+		if err != nil {
+			return err
+		}
+		digests = append(digests, rel+"="+sum)
+		return nil
+	}
+
+	if err := addFile(manifestPath); err != nil {
+		return "", fmt.Errorf("digest manifest: %w", err)
+	}
+
+	assetRoot := providerpkg.EffectiveUIAssetRoot(manifest)
+	outputAbs := ""
+	if assetRoot != "" {
+		outputAbs = filepath.Clean(filepath.Join(sourceDir, filepath.FromSlash(assetRoot)))
+	}
+	excludedDirs := map[string]struct{}{
+		".git":         {},
+		".gestaltd":    {},
+		"node_modules": {},
+	}
+	shouldSkip := func(path string, d os.DirEntry) bool {
+		cleanPath := filepath.Clean(path)
+		if outputAbs != "" && pathWithinRoot(outputAbs, cleanPath) {
+			return true
+		}
+		if d.IsDir() {
+			_, excluded := excludedDirs[d.Name()]
+			return excluded
+		}
+		return false
+	}
+	walkInput := func(inputAbs string) error {
+		return filepath.WalkDir(inputAbs, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if shouldSkip(path, d) {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if err := addFile(path); err != nil {
+				return fmt.Errorf("digest input %s: %w", path, err)
+			}
+			return nil
+		})
+	}
+
+	inputs := append([]string(nil), build.Inputs...)
+	if len(inputs) == 0 {
+		workdir := "."
+		if strings.TrimSpace(build.Workdir) != "" {
+			workdir = build.Workdir
+		}
+		inputs = []string{workdir}
+	}
+	for _, input := range inputs {
+		inputAbs := filepath.Clean(filepath.Join(sourceDir, filepath.FromSlash(input)))
+		info, err := os.Stat(inputAbs)
+		if err != nil {
+			return "", fmt.Errorf("stat build input %q: %w", input, err)
+		}
+		if shouldSkip(inputAbs, dirEntryFromFileInfo(info)) {
+			continue
+		}
+		if !info.IsDir() {
+			if err := addFile(inputAbs); err != nil {
+				return "", fmt.Errorf("digest build input %q: %w", input, err)
+			}
+			continue
+		}
+		if err := walkInput(inputAbs); err != nil {
+			return "", fmt.Errorf("digest build input %q: %w", input, err)
+		}
+	}
+
+	slices.Sort(digests)
+	combined := sha256.Sum256([]byte(strings.Join(digests, "\n")))
+	return hex.EncodeToString(combined[:]), nil
+}
+
+type fileInfoDirEntry struct {
+	os.FileInfo
+}
+
+func (d fileInfoDirEntry) Type() os.FileMode {
+	return d.FileInfo.Mode().Type()
+}
+
+func (d fileInfoDirEntry) Info() (os.FileInfo, error) {
+	return d.FileInfo, nil
+}
+
+func dirEntryFromFileInfo(info os.FileInfo) os.DirEntry {
+	return fileInfoDirEntry{FileInfo: info}
 }
 
 func fingerprintLocalReleaseMetadataDigest(sourcePath string) (string, error) {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -111,6 +111,86 @@ plugins:
 	}
 }
 
+func TestLifecycleGitSourceUIBuildLockSyncContract(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("source UI build fixture uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "providers")
+	const packageSource = "github.com/acme/providers/ui/roadmap"
+	writeSourceUITree(t, filepath.Join(repoDir, "ui", "roadmap"), packageSource, "1.2.3")
+	runGitTestCommand(t, repoDir, "init")
+	runGitTestCommand(t, repoDir, "config", "user.email", "test@example.com")
+	runGitTestCommand(t, repoDir, "config", "user.name", "Test")
+	runGitTestCommand(t, repoDir, "add", ".")
+	runGitTestCommand(t, repoDir, "commit", "-m", "ui")
+	ref := strings.TrimSpace(runGitTestOutput(t, repoDir, "rev-parse", "HEAD"))
+
+	artifactsDir := filepath.Join(dir, "artifacts")
+	configPath := filepath.Join(dir, "gestaltd.yaml")
+	configYAML := fmt.Sprintf(`
+apiVersion: gestaltd.config/v5
+%s
+  ui:
+    roadmap:
+      source:
+        git:
+          repo: file://%s
+          ref: %s
+          path: ui/roadmap/manifest.yaml
+          materialization: source
+      path: /roadmap
+server:
+  providers:
+    indexeddb: sqlite
+  artifactsDir: %s
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), filepath.ToSlash(repoDir), ref, filepath.ToSlash(artifactsDir))
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle()
+	lock, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	if err != nil {
+		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	}
+	entry := lock.UIs["roadmap"]
+	if entry.SourceRef == nil {
+		t.Fatal("sourceRef missing")
+	}
+	if entry.SourceRef.Materialization != gitMaterializationSource {
+		t.Fatalf("sourceRef materialization = %q", entry.SourceRef.Materialization)
+	}
+	preparedIndex := filepath.Join(artifactsDir, ".gestaltd", "ui", "roadmap", "dist", "index.html")
+	if err := os.RemoveAll(filepath.Join(artifactsDir, ".gestaltd", "ui", "roadmap")); err != nil {
+		t.Fatalf("remove prepared ui: %v", err)
+	}
+	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePaths after removing prepared ui: %v", err)
+	}
+	if _, err := os.Stat(preparedIndex); err != nil {
+		t.Fatalf("prepared ui index not restored: %v", err)
+	}
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	ui := cfg.Providers.UI["roadmap"]
+	if ui == nil || ui.ResolvedManifest == nil {
+		t.Fatalf("ui resolved manifest = %+v", ui)
+	}
+	if ui.ResolvedManifest.Build != nil {
+		t.Fatalf("prepared ui manifest retained build metadata: %+v", ui.ResolvedManifest.Build)
+	}
+	if got, want := filepath.ToSlash(ui.ResolvedAssetRoot), filepath.ToSlash(filepath.Join(artifactsDir, ".gestaltd", "ui", "roadmap", "dist")); got != want {
+		t.Fatalf("ResolvedAssetRoot = %q, want %q", got, want)
+	}
+}
+
 func TestLifecycleGitSourceSnapshotRequireContract(t *testing.T) {
 	t.Parallel()
 
@@ -372,6 +452,33 @@ func writeSourceProviderTree(t *testing.T, dir, source, version, binaryContent s
 	}
 	if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), data, 0o644); err != nil {
 		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func writeSourceUITree(t *testing.T, dir, source, version string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir source ui dir: %v", err)
+	}
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindUI,
+		Source:  source,
+		Version: version,
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"sh", "./build.sh"},
+			Output:  "dist",
+			Inputs:  []string{"build.sh"},
+		},
+	}
+	data, err := providerpkg.EncodeSourceManifestFormat(manifest, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("encode ui manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), data, 0o644); err != nil {
+		t.Fatalf("write ui manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "build.sh"), []byte("mkdir -p dist\nprintf '<html>roadmap</html>\\n' > dist/index.html\n"), 0o755); err != nil {
+		t.Fatalf("write ui build script: %v", err)
 	}
 }
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1269,6 +1269,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalMountedUIWithoutLockfile(t *testing
 		wantPolicy   string
 		ownedUIPath  string
 		uiManifest   string
+		sourceBuild  bool
 		wantErr      string
 	}{
 		{
@@ -1281,6 +1282,18 @@ func TestLoadForExecutionAtPath_ResolvesLocalMountedUIWithoutLockfile(t *testing
 `,
 			uiKey:    "roadmap",
 			wantPath: "/create-customer-roadmap-review",
+		},
+		{
+			name: "direct mounted source-built ui",
+			uiConfigYAML: `  ui:
+    roadmap:
+      source:
+        path: ./ui/manifest.yaml
+      path: /create-customer-roadmap-review
+`,
+			uiKey:       "roadmap",
+			wantPath:    "/create-customer-roadmap-review",
+			sourceBuild: true,
 		},
 		{
 			name: "plugin ui object binds explicit ui",
@@ -1331,6 +1344,20 @@ plugins:
 			wantPath:    "/create-customer-roadmap-review",
 			wantPolicy:  "roadmap_policy",
 			ownedUIPath: "../ui/manifest.yaml",
+		},
+		{
+			name: "plugin owned source-built ui via plugin ui path",
+			uiConfigYAML: `plugins:
+    roadmap:
+      source:
+        path: ./plugin/manifest.yaml
+      ui:
+        path: /create-customer-roadmap-review
+`,
+			uiKey:       "roadmap",
+			wantPath:    "/create-customer-roadmap-review",
+			ownedUIPath: "../ui/manifest.yaml",
+			sourceBuild: true,
 		},
 		{
 			name: "plugin owned ui via plugin ui path with noncanonical manifest filename",
@@ -1392,16 +1419,35 @@ plugins:
 
 			dir := t.TempDir()
 			uiDir := filepath.Join(dir, "ui")
-			if err := os.MkdirAll(filepath.Join(uiDir, "dist"), 0o755); err != nil {
-				t.Fatalf("MkdirAll ui dist: %v", err)
-			}
-			if err := os.WriteFile(filepath.Join(uiDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
-				t.Fatalf("WriteFile index.html: %v", err)
+			if err := os.MkdirAll(uiDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll ui dir: %v", err)
 			}
 			manifestName := cmp.Or(tc.uiManifest, "manifest.yaml")
 			manifestPath := filepath.Join(uiDir, manifestName)
-			spec := &providermanifestv1.Spec{AssetRoot: "dist"}
+			var spec *providermanifestv1.Spec
+			var build *providermanifestv1.SourceBuild
+			if tc.sourceBuild {
+				build = &providermanifestv1.SourceBuild{
+					Command: []string{"sh", "./build.sh"},
+					Output:  "dist",
+					Inputs:  []string{"build.sh"},
+				}
+				if err := os.WriteFile(filepath.Join(uiDir, "build.sh"), []byte("mkdir -p dist\nprintf '<html>roadmap</html>\\n' > dist/index.html\n"), 0o755); err != nil {
+					t.Fatalf("WriteFile build.sh: %v", err)
+				}
+			} else {
+				if err := os.MkdirAll(filepath.Join(uiDir, "dist"), 0o755); err != nil {
+					t.Fatalf("MkdirAll ui dist: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(uiDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
+					t.Fatalf("WriteFile index.html: %v", err)
+				}
+				spec = &providermanifestv1.Spec{AssetRoot: "dist"}
+			}
 			if tc.wantPolicy != "" {
+				if spec == nil {
+					spec = &providermanifestv1.Spec{}
+				}
 				spec.Routes = []providermanifestv1.UIRoute{
 					{Path: "/", AllowedRoles: []string{"viewer"}},
 				}
@@ -1411,6 +1457,7 @@ plugins:
 				Source:      "github.com/testowner/web/roadmap",
 				Version:     "0.0.1-alpha.1",
 				DisplayName: "Roadmap UI",
+				Build:       build,
 				Spec:        spec,
 			}, providerpkg.ManifestFormatYAML)
 			if err != nil {

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -46,6 +46,9 @@
     "release": {
       "$ref": "#/$defs/release"
     },
+    "build": {
+      "$ref": "#/$defs/sourceBuild"
+    },
     "artifacts": {
       "type": "array",
       "items": {
@@ -83,6 +86,38 @@
         "command": {
           "type": "array",
           "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "sourceBuild": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "workdir": {
+          "type": "string",
+          "minLength": 1
+        },
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "output": {
+          "type": "string",
+          "minLength": 1
+        },
+        "inputs": {
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -69,6 +69,7 @@ type Manifest struct {
 	Description string           `json:"description,omitempty" yaml:"description,omitempty"`
 	IconFile    string           `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
 	Release     *ReleaseMetadata `json:"release,omitempty" yaml:"release,omitempty"`
+	Build       *SourceBuild     `json:"build,omitempty" yaml:"build,omitempty"`
 	Artifacts   []Artifact       `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
 	Entrypoint  *Entrypoint      `json:"entrypoint,omitempty" yaml:"entrypoint,omitempty"`
 	Spec        *Spec            `json:"spec,omitempty" yaml:"spec,omitempty"`
@@ -81,6 +82,13 @@ type ReleaseMetadata struct {
 type ReleaseBuild struct {
 	Workdir string   `json:"workdir,omitempty" yaml:"workdir,omitempty"`
 	Command []string `json:"command" yaml:"command"`
+}
+
+type SourceBuild struct {
+	Workdir string   `json:"workdir,omitempty" yaml:"workdir,omitempty"`
+	Command []string `json:"command" yaml:"command"`
+	Output  string   `json:"output,omitempty" yaml:"output,omitempty"`
+	Inputs  []string `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 }
 
 // Spec is a union type validated per kind. For auth/datastore/secrets only

--- a/gestaltd/services/plugins/packageio/manifest.go
+++ b/gestaltd/services/plugins/packageio/manifest.go
@@ -159,6 +159,20 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 	if err != nil {
 		return err
 	}
+	if manifest.Build != nil {
+		if !sourceMode {
+			return fmt.Errorf("build metadata is only allowed in source ui manifests")
+		}
+		if kind != providermanifestv1.KindUI {
+			return fmt.Errorf("build metadata is only supported for ui manifests")
+		}
+		if manifest.Release != nil && manifest.Release.Build != nil {
+			return fmt.Errorf("build and release.build may not both be set")
+		}
+		if err := validateSourceBuild(manifest.Build); err != nil {
+			return err
+		}
+	}
 
 	allowsSourceEntrypointOmission := sourceMode && manifest.Entrypoint == nil
 
@@ -241,14 +255,38 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 		if manifest.Entrypoint != nil {
 			return fmt.Errorf("ui manifests may not define entrypoints")
 		}
-		if spec == nil || spec.AssetRoot == "" {
+		assetRoot := ""
+		if spec != nil {
+			assetRoot = spec.AssetRoot
+		}
+		buildOutput := ""
+		if manifest.Build != nil {
+			buildOutput = manifest.Build.Output
+		}
+		if sourceMode {
+			if assetRoot == "" && buildOutput == "" {
+				return fmt.Errorf("spec.assetRoot or build.output is required for source ui manifests")
+			}
+		} else if assetRoot == "" {
 			return fmt.Errorf("spec.assetRoot is required for ui manifests")
 		}
-		if err := validateRelativePackagePath(spec.AssetRoot, "spec.assetRoot"); err != nil {
-			return err
+		if assetRoot != "" {
+			if err := validateRelativePackagePath(assetRoot, "spec.assetRoot"); err != nil {
+				return err
+			}
 		}
-		if err := validateUIRoutes(spec.Routes); err != nil {
-			return err
+		if buildOutput != "" {
+			if err := validateRelativePackagePath(buildOutput, "build.output"); err != nil {
+				return err
+			}
+		}
+		if assetRoot != "" && buildOutput != "" && assetRoot != buildOutput {
+			return fmt.Errorf("build.output %q must match spec.assetRoot %q", buildOutput, assetRoot)
+		}
+		if spec != nil {
+			if err := validateUIRoutes(spec.Routes); err != nil {
+				return err
+			}
 		}
 	default:
 		return fmt.Errorf("unsupported manifest kind %q", kind)
@@ -390,12 +428,32 @@ func validateRelativePackagePath(value, label string) error {
 	return nil
 }
 
+func validateRelativeSourcePath(value, label string) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", label)
+	}
+	if strings.HasPrefix(value, "/") {
+		return fmt.Errorf("%s must be relative", label)
+	}
+	cleaned := path.Clean(value)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return fmt.Errorf("%s must stay within the package", label)
+	}
+	if strings.Contains(value, "\\") {
+		return fmt.Errorf("%s must use forward slashes", label)
+	}
+	if cleaned != value {
+		return fmt.Errorf("%s must be normalized", label)
+	}
+	return nil
+}
+
 func validateReleaseMetadata(release *providermanifestv1.ReleaseMetadata) error {
 	if release == nil || release.Build == nil {
 		return nil
 	}
 	if release.Build.Workdir != "" {
-		if err := validateRelativePackagePath(release.Build.Workdir, "release.build.workdir"); err != nil {
+		if err := validateRelativeSourcePath(release.Build.Workdir, "release.build.workdir"); err != nil {
 			return err
 		}
 	}
@@ -408,6 +466,53 @@ func validateReleaseMetadata(release *providermanifestv1.ReleaseMetadata) error 
 		}
 	}
 	return nil
+}
+
+func validateSourceBuild(build *providermanifestv1.SourceBuild) error {
+	if build == nil {
+		return nil
+	}
+	if build.Workdir != "" {
+		if err := validateRelativeSourcePath(build.Workdir, "build.workdir"); err != nil {
+			return err
+		}
+	}
+	if len(build.Command) == 0 {
+		return fmt.Errorf("build.command is required")
+	}
+	for i, arg := range build.Command {
+		if strings.TrimSpace(arg) == "" {
+			return fmt.Errorf("build.command[%d] is required", i)
+		}
+	}
+	if build.Output != "" {
+		if err := validateRelativePackagePath(build.Output, "build.output"); err != nil {
+			return err
+		}
+	}
+	for i, input := range build.Inputs {
+		label := fmt.Sprintf("build.inputs[%d]", i)
+		if strings.ContainsAny(input, "*?[") {
+			return fmt.Errorf("%s does not support glob syntax", label)
+		}
+		if err := validateRelativeSourcePath(input, label); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func EffectiveUIAssetRoot(manifest *providermanifestv1.Manifest) string {
+	if manifest == nil {
+		return ""
+	}
+	if manifest.Spec != nil && manifest.Spec.AssetRoot != "" {
+		return manifest.Spec.AssetRoot
+	}
+	if manifest.Build != nil {
+		return manifest.Build.Output
+	}
+	return ""
 }
 
 func validateProviderAuth(path string, auth *providermanifestv1.ProviderAuth) error {

--- a/gestaltd/services/plugins/providerpkg/manifest.go
+++ b/gestaltd/services/plugins/providerpkg/manifest.go
@@ -74,6 +74,10 @@ func ManifestEqual(a, b *providermanifestv1.Manifest) bool {
 	return packageio.ManifestEqual(a, b)
 }
 
+func EffectiveUIAssetRoot(manifest *providermanifestv1.Manifest) string {
+	return packageio.EffectiveUIAssetRoot(manifest)
+}
+
 func cloneManifest(manifest *providermanifestv1.Manifest) (*providermanifestv1.Manifest, error) {
 	return packageio.CloneManifest(manifest)
 }

--- a/gestaltd/services/plugins/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/services/plugins/providerpkg/manifest_workflow_test.go
@@ -433,6 +433,125 @@ spec:
 	}
 }
 
+func TestManifestWorkflow_SourceUIBuildValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		manifest   string
+		readSource bool
+		wantErr    string
+	}{
+		{
+			name: "source ui may use build output without asset root",
+			manifest: `
+kind: ui
+source: github.com/acme/plugins/source-ui
+version: 1.0.0
+build:
+  command: [npm, run, build]
+  output: dist
+`,
+			readSource: true,
+		},
+		{
+			name: "released ui rejects build metadata",
+			manifest: `
+kind: ui
+source: github.com/acme/plugins/released-ui
+version: 1.0.0
+build:
+  command: [npm, run, build]
+  output: dist
+spec:
+  assetRoot: dist
+`,
+			wantErr: "build metadata is only allowed in source ui manifests",
+		},
+		{
+			name: "source ui rejects build and release build together",
+			manifest: `
+kind: ui
+source: github.com/acme/plugins/source-ui
+version: 1.0.0
+build:
+  command: [npm, run, build]
+  output: dist
+release:
+  build:
+    command: [npm, run, build]
+spec:
+  assetRoot: dist
+`,
+			readSource: true,
+			wantErr:    "build and release.build may not both be set",
+		},
+		{
+			name: "source ui rejects mismatched build output",
+			manifest: `
+kind: ui
+source: github.com/acme/plugins/source-ui
+version: 1.0.0
+build:
+  command: [npm, run, build]
+  output: dist
+spec:
+  assetRoot: out
+`,
+			readSource: true,
+			wantErr:    "build.output \"dist\" must match spec.assetRoot \"out\"",
+		},
+		{
+			name: "source ui rejects input globs",
+			manifest: `
+kind: ui
+source: github.com/acme/plugins/source-ui
+version: 1.0.0
+build:
+  command: [npm, run, build]
+  output: dist
+  inputs:
+    - src/**
+`,
+			readSource: true,
+			wantErr:    "build.inputs[0] does not support glob syntax",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(tc.manifest))
+
+			var manifest *providermanifestv1.Manifest
+			var err error
+			if tc.readSource {
+				_, manifest, err = ReadSourceManifestFile(manifestPath)
+			} else {
+				_, manifest, err = ReadManifestFile(manifestPath)
+			}
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("read manifest: %v", err)
+			}
+			if got := EffectiveUIAssetRoot(manifest); got != "dist" {
+				t.Fatalf("EffectiveUIAssetRoot = %q, want dist", got)
+			}
+		})
+	}
+}
+
 func TestManifestWorkflow_AcceptsPluginRouteAuthReference(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/plugins/providerpkg/prepared_stage.go
+++ b/gestaltd/services/plugins/providerpkg/prepared_stage.go
@@ -290,6 +290,15 @@ func buildPreparedInstallSourceManifest(srcManifest *providermanifestv1.Manifest
 	}
 	manifest.Version = version
 	manifest.Release = nil
+	if manifest.Kind == providermanifestv1.KindUI {
+		if assetRoot := EffectiveUIAssetRoot(srcManifest); assetRoot != "" {
+			if manifest.Spec == nil {
+				manifest.Spec = &providermanifestv1.Spec{}
+			}
+			manifest.Spec.AssetRoot = assetRoot
+		}
+	}
+	manifest.Build = nil
 
 	for i, artifact := range srcManifest.Artifacts {
 		digest, err := FileSHA256(filepath.Join(sourceDir, filepath.FromSlash(artifact.Path)))
@@ -312,6 +321,7 @@ func buildPreparedInstallManifest(srcManifest *providermanifestv1.Manifest, vers
 	}
 	manifest.Version = version
 	manifest.Release = nil
+	manifest.Build = nil
 	manifest.Artifacts = []providermanifestv1.Artifact{
 		{OS: goos, Arch: goarch, Path: binaryName, SHA256: digest},
 	}

--- a/gestaltd/services/plugins/providerpkg/source_build.go
+++ b/gestaltd/services/plugins/providerpkg/source_build.go
@@ -9,67 +9,102 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
-func RunSourceReleaseBuild(manifestPath string, manifest *providermanifestv1.Manifest) error {
-	if manifest == nil || manifest.Release == nil || manifest.Release.Build == nil {
+type ResolvedSourceBuild struct {
+	Label   string
+	Workdir string
+	Command []string
+	Output  string
+	Inputs  []string
+}
+
+func EffectiveSourceBuild(manifest *providermanifestv1.Manifest) *ResolvedSourceBuild {
+	if manifest == nil {
 		return nil
 	}
-
-	rootDir := filepath.Dir(manifestPath)
-	workdir := rootDir
-	if manifest.Release.Build.Workdir != "" {
-		workdir = filepath.Join(rootDir, filepath.FromSlash(manifest.Release.Build.Workdir))
+	if manifest.Build != nil {
+		return &ResolvedSourceBuild{
+			Label:   "build",
+			Workdir: manifest.Build.Workdir,
+			Command: append([]string(nil), manifest.Build.Command...),
+			Output:  manifest.Build.Output,
+			Inputs:  append([]string(nil), manifest.Build.Inputs...),
+		}
 	}
-
-	info, err := os.Stat(workdir)
-	if err != nil {
-		return fmt.Errorf("stat release.build.workdir %q: %w", manifest.Release.Build.Workdir, err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("release.build.workdir %q is not a directory", manifest.Release.Build.Workdir)
-	}
-	if err := ensureReleaseBuildDependencies(workdir); err != nil {
-		return err
-	}
-
-	cmd := exec.Command(manifest.Release.Build.Command[0], manifest.Release.Build.Command[1:]...)
-	cmd.Dir = workdir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("run release.build.command: %w", err)
+	if manifest.Release != nil && manifest.Release.Build != nil {
+		return &ResolvedSourceBuild{
+			Label:   "release.build",
+			Workdir: manifest.Release.Build.Workdir,
+			Command: append([]string(nil), manifest.Release.Build.Command...),
+		}
 	}
 	return nil
 }
 
-func ensureReleaseBuildDependencies(workdir string) error {
+func RunSourceReleaseBuild(manifestPath string, manifest *providermanifestv1.Manifest) error {
+	build := EffectiveSourceBuild(manifest)
+	if build == nil {
+		return nil
+	}
+	if len(build.Command) == 0 {
+		return fmt.Errorf("%s.command is required", build.Label)
+	}
+
+	rootDir := filepath.Dir(manifestPath)
+	workdir := rootDir
+	if build.Workdir != "" && build.Workdir != "." {
+		workdir = filepath.Join(rootDir, filepath.FromSlash(build.Workdir))
+	}
+
+	info, err := os.Stat(workdir)
+	if err != nil {
+		return fmt.Errorf("stat %s.workdir %q: %w", build.Label, build.Workdir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s.workdir %q is not a directory", build.Label, build.Workdir)
+	}
+	if err := ensureReleaseBuildDependencies(workdir, build.Label); err != nil {
+		return err
+	}
+
+	cmd := exec.Command(build.Command[0], build.Command[1:]...)
+	cmd.Dir = workdir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run %s.command: %w", build.Label, err)
+	}
+	return nil
+}
+
+func ensureReleaseBuildDependencies(workdir, label string) error {
 	packagePath := filepath.Join(workdir, typeScriptProjectFile)
 	if _, err := os.Stat(packagePath); err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("stat release.build package.json: %w", err)
+		return fmt.Errorf("stat %s package.json: %w", label, err)
 	}
 	if _, err := os.Stat(filepath.Join(workdir, "bun.lock")); err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("stat release.build bun.lock: %w", err)
+		return fmt.Errorf("stat %s bun.lock: %w", label, err)
 	}
 	if info, err := os.Stat(filepath.Join(workdir, "node_modules")); err == nil {
 		if info.IsDir() {
 			return nil
 		}
-		return fmt.Errorf("release build node_modules path %q is not a directory", filepath.Join(workdir, "node_modules"))
+		return fmt.Errorf("%s node_modules path %q is not a directory", label, filepath.Join(workdir, "node_modules"))
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat release build node_modules: %w", err)
+		return fmt.Errorf("stat %s node_modules: %w", label, err)
 	}
 
 	bunPath, err := DetectBunExecutable()
 	if err != nil {
 		return err
 	}
-	if err := ensureTypeScriptDependencies(bunPath, workdir, "release build"); err != nil {
-		return fmt.Errorf("prepare release.build dependencies: %w", err)
+	if err := ensureTypeScriptDependencies(bunPath, workdir, label); err != nil {
+		return fmt.Errorf("prepare %s dependencies: %w", label, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds first-class source UI build metadata so UI provider authors can check in frontend source and let Gestalt generate static assets during preparation, without checking in `out/` or `dist/` bundles.

## Interface Changes
- New/changed interface: source `kind: ui` manifests may declare top-level `build` with `command`, optional `workdir`, optional `output`, and optional literal `inputs`.
- New/changed interface: source UI manifests may omit `spec.assetRoot` when `build.output` is set. Prepared/released manifests still contain concrete `spec.assetRoot` and strip build metadata.
- New/changed interface: `release.build` remains as a legacy build hook, but manifests may not set both `build` and `release.build`.
- New/changed interface: git source docs now use the implemented `source.git.materialization` field instead of `artifactMode`.

Example source UI manifest:

```yaml
kind: ui
source: github.com/acme/ui/workspace-review
version: 0.1.0
build:
  workdir: app
  command:
    - npm
    - run
    - build
  output: app/out
  inputs:
    - app/package.json
    - app/package-lock.json
    - app/src
spec:
  routes:
    - path: /
      allowedRoles: [viewer, admin]
```

Example deployer config using a commit-pinned source UI:

```yaml
providers:
  ui:
    roadmap:
      source:
        git:
          repo: https://github.com/acme/gestalt-providers.git
          ref: 60fa7e0521eeedea8b28abdd9b43284e9ea246e2
          path: ui/roadmap/manifest.yaml
          materialization: source
      path: /roadmap
```

## Functional/Integration Tests
- Tests added or augmented:
  - Source UI manifest workflow validation for `build.output`, released-manifest rejection, `build`/`release.build` conflicts, output mismatches, and glob input rejection.
  - Provider release packaging for source-built UI packages and plugin-owned source-built UI packages.
  - Source UI dev/static handler builds the declared output before serving.
  - Lifecycle local mounted UI loading without a lockfile for direct and plugin-owned source-built UIs.
  - Lifecycle git source UI lock/sync contract for source materialization.
- Contract boundary covered: manifest validation, provider release packaging, local dev serving, prepared install staging, git source lock/sync, portable lock metadata, and docs build.
- Commands run:
  - `go test -count=1 ./services/plugins/packageio ./services/plugins/providerpkg`
  - `go test -count=1 ./internal/operator -run 'TestLoadForExecutionAtPath_ResolvesLocalMountedUIWithoutLockfile|TestLifecycleGitSourceUIBuildLockSyncContract|TestLifecycleGitSourceBuildLockSyncContract'`
  - `go test -count=1 ./internal/daemon -run 'TestRun_ProviderReleaseBuildsUIAssetsBeforePackaging|TestRun_ProviderReleaseBuildsSourceUIAssetsBeforePackaging|TestRun_ProviderReleaseStagesOwnedUIPackage|TestSourceUIHandlerBuildsSourceUIOutput'`
  - `npm run build:single` from `docs/`
