### PR TITLE
Use subject-scoped credential mode

### DIFF
--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -282,7 +282,7 @@ These metrics carry low-cardinality attributes: `gestalt.provider` (the
 plugin key), `gestalt.operation` (the catalog operation id),
 `gestalt.transport` (how the operation is implemented: `plugin`, `rest`, or
 `mcp-passthrough`), and `gestalt.connection_mode` (the provider auth mode:
-`none` or `user`). When the invocation came from a known surface, they also
+`none` or `subject`). When the invocation came from a known surface, they also
 carry `gestalt.invocation_surface`. Hosted HTTP binding invocations also carry
 `gestalt.http_binding`, which is the configured binding name.
 
@@ -326,7 +326,7 @@ These metrics carry low-cardinality attributes: `gestalt.provider` (the
 plugin key), `gestalt.type` (`oauth` or `manual`),
 `gestalt.action` (`start`, `complete`, or `refresh`), and
 `gestalt.connection_mode` (the provider authentication mode: `none`
-or `user`).
+or `subject`).
 
 When a request references an unknown plugin, `gestaltd` records
 `unknown` for the provider and connection mode metric attributes instead of
@@ -383,7 +383,7 @@ session catalog with stored or identity credentials.
 
 These metrics carry low-cardinality attributes: `gestalt.provider` (the plugin
 key), `gestalt.action` (currently `list_operations`), and
-`gestalt.connection_mode` (the provider auth mode: `none` or `user`).
+`gestalt.connection_mode` (the provider auth mode: `none` or `subject`).
 `gestaltd.discovery.error_count` increments when the
 credentialed session-catalog path fails, even if `gestaltd` falls back to a
 static catalog and still serves a successful HTTP response.

--- a/docs/content/providers/authentication.mdx
+++ b/docs/content/providers/authentication.mdx
@@ -2,10 +2,11 @@ import { Tabs } from 'nextra/components'
 
 # Authentication
 
-Authentication providers handle platform login for the Gestalt server. They are separate
-from plugin connections: `providers.authentication.<name>` decides how users sign in to the
-deployment itself, while plugin connections decide how Gestalt authenticates to
-upstream APIs on behalf of callers.
+Authentication providers handle platform login for the Gestalt server.
+Authentication is separate from [Authorization](/providers/authorization), which
+decides what the caller may access, and
+[External Credentials](/providers/external-credentials), which provide upstream
+credentials for configured connections.
 
 ## How authentication providers work
 

--- a/docs/content/providers/authorization.mdx
+++ b/docs/content/providers/authorization.mdx
@@ -3,8 +3,10 @@ import { Tabs } from 'nextra/components'
 # Authorization
 
 Authorization providers store relationship data and answer access checks for
-Gestalt. They are separate from [Authentication](/providers/authentication),
-which identifies the caller.
+Gestalt. Authorization is separate from
+[Authentication](/providers/authentication), which identifies the caller, and
+[External Credentials](/providers/external-credentials), which provide upstream
+credentials for configured connections.
 
 Gestalt's model follows the core ideas from
 [Google Zanzibar](https://research.google/pubs/zanzibar-googles-consistent-global-authorization-system/):

--- a/docs/content/providers/cache.mdx
+++ b/docs/content/providers/cache.mdx
@@ -6,29 +6,8 @@ Cache providers are plugin-bound utilities for short-lived key/value state.
 They are configured under `providers.cache` and attached to plugins with
 `plugins.<name>.cache`.
 
-Unlike IndexedDB, cache providers are not selected through `server.providers`.
-They are only exposed to plugins that request them.
-
-## How cache providers work
-
-Each entry under `providers.cache` defines a named cache backend. Plugins opt
-into those backends with `plugins.<name>.cache`, which is just a list of named
-bindings. Every binding name must already exist under `providers.cache`, and
-duplicate bindings are rejected during config validation.
-
-In plugin code you usually open a cache by binding name, such as `session` or
-`rate_limit`. If a plugin binds exactly one cache, the SDKs also support the
-default unnamed cache handle, but using the explicit binding name is usually
-clearer.
-
-## First-party cache providers
-
-First-party cache providers live under
-[`valon-technologies/gestalt-providers/cache`](https://github.com/valon-technologies/gestalt-providers/tree/main/cache).
-
-| Provider | Use case |
-| --- | --- |
-| [`github.com/valon-technologies/gestalt-providers/cache/valkey`](https://github.com/valon-technologies/gestalt-providers/tree/main/cache/valkey) | Valkey or Redis-compatible cache backend for short-lived plugin state |
+Cache providers use the same provider-entry plus plugin SDK binding pattern as
+IndexedDB.
 
 ## Configuring `providers.cache`
 
@@ -37,19 +16,17 @@ providers:
   cache:
     session:
       source:
-        package: github.com/valon-technologies/gestalt-providers/cache/valkey
-        version: 0.0.1-alpha.1
+        package: github.com/your-org/gestalt-cache-provider
+        version: 0.0.1
       config:
-        address: ${VALKEY_ADDR}
-        database: 0
+        namespace: session
 
     rate_limit:
       source:
-        package: github.com/valon-technologies/gestalt-providers/cache/valkey
-        version: 0.0.1-alpha.1
+        package: github.com/your-org/gestalt-cache-provider
+        version: 0.0.1
       config:
-        address: ${VALKEY_ADDR}
-        database: 1
+        namespace: rate_limit
 
 plugins:
   search:
@@ -60,9 +37,9 @@ plugins:
 ```
 
 This example binds two caches into the `search` plugin. Both bindings use the
-same provider package, but they point at different logical databases. That is a
-common pattern for keeping session and rate-limit state separate without
-introducing a second cache technology.
+same provider package, but they receive different provider-specific config.
+That is a common pattern for keeping session and rate-limit state separate
+without introducing a second cache technology.
 
 ## Using `Cache` from a plugin
 
@@ -143,17 +120,8 @@ introducing a second cache technology.
 </Tabs>
 
 The host resolves the configured cache bindings and exposes them to the plugin
-through the language SDK. Plugin code does not choose raw Redis or Valkey
-endpoints directly at runtime. It just opens the bound cache by name.
-
-## Operational notes
-
-Cache providers are best for short-lived, non-authoritative state such as
-sessions, idempotency helpers, and rate-limit counters. They remain
-plugin-bound, so they do not participate in the host-wide `server.providers`
-selection model. The exact `config` block depends on the selected provider
-package. For the first-party `cache/valkey` provider, that usually means an
-address plus any backend-specific connection settings.
+through the language SDK. Plugin code does not choose backend endpoints
+directly at runtime. It just opens the bound cache by name.
 
 ## Building your own cache provider
 
@@ -163,32 +131,18 @@ A cache provider manifest declares `kind: cache`:
 
 ```yaml
 kind: cache
-source: github.com/valon-technologies/gestalt-providers/cache/valkey
+source: github.com/your-org/gestalt-cache-provider
 version: 0.0.1
-displayName: Valkey Cache
-description: Cache provider backed by Valkey or Redis.
+displayName: Example Cache
+description: Cache provider backed by your cache service.
 spec:
   configSchemaPath: ./cache_config.json
 ```
 
-### Provider interface
-
-The Cache service includes:
-
-| Method | Purpose |
-| --- | --- |
-| `Get` | Read a value by key |
-| `GetMany` | Read multiple keys in one request |
-| `Set` | Write a value with optional TTL |
-| `SetMany` | Write multiple values with one TTL policy |
-| `Delete` | Remove one key |
-| `DeleteMany` | Remove multiple keys |
-| `Touch` | Refresh TTL for an existing key |
-
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    package valkeycache
+    package examplecache
 
     import (
         "context"
@@ -197,29 +151,36 @@ The Cache service includes:
         gestalt "github.com/valon-technologies/gestalt/sdk/go"
     )
 
-    type Provider struct{}
+    type ExampleCache struct{}
 
-    func New() *Provider { return &Provider{} }
+    func New() *ExampleCache { return &ExampleCache{} }
 
-    func (p *Provider) Configure(_ context.Context, _ string, config map[string]any) error {
-        return nil
+    func (p *ExampleCache) Get(ctx context.Context, key string) ([]byte, bool, error) {
+        panic("implement cache get")
     }
 
-    func (p *Provider) Get(ctx context.Context, key string) ([]byte, bool, error) {
-        return nil, false, nil
+    func (p *ExampleCache) GetMany(ctx context.Context, keys []string) (map[string][]byte, error) {
+        panic("implement cache get many")
     }
 
-    func (p *Provider) Set(ctx context.Context, key string, value []byte, opts gestalt.CacheSetOptions) error {
-        _ = opts.TTL
-        return nil
+    func (p *ExampleCache) Set(ctx context.Context, key string, value []byte, opts gestalt.CacheSetOptions) error {
+        panic("implement cache set")
     }
 
-    func (p *Provider) Delete(ctx context.Context, key string) (bool, error) {
-        return false, nil
+    func (p *ExampleCache) SetMany(ctx context.Context, entries []gestalt.CacheEntry, opts gestalt.CacheSetOptions) error {
+        panic("implement cache set many")
     }
 
-    func (p *Provider) Touch(ctx context.Context, key string, ttl time.Duration) (bool, error) {
-        return false, nil
+    func (p *ExampleCache) Delete(ctx context.Context, key string) (bool, error) {
+        panic("implement cache delete")
+    }
+
+    func (p *ExampleCache) DeleteMany(ctx context.Context, keys []string) (int64, error) {
+        panic("implement cache delete many")
+    }
+
+    func (p *ExampleCache) Touch(ctx context.Context, key string, ttl time.Duration) (bool, error) {
+        panic("implement cache touch")
     }
     ```
   </Tabs.Tab>
@@ -227,11 +188,16 @@ The Cache service includes:
     ```python
     import datetime as dt
 
-    from gestalt import CacheProvider
+    from gestalt import CacheEntry, CacheProvider
 
-    class ValkeyCache(CacheProvider):
+    class ExampleCache(CacheProvider):
         def get(self, key: str) -> bytes | None:
-            return None
+            """Read a value by key."""
+            raise NotImplementedError
+
+        def get_many(self, keys: list[str]) -> dict[str, bytes]:
+            """Read multiple keys in one request."""
+            raise NotImplementedError
 
         def set(
             self,
@@ -239,25 +205,46 @@ The Cache service includes:
             value: bytes,
             ttl: dt.timedelta | None = None,
         ) -> None:
-            pass
+            """Write a value with an optional TTL."""
+            raise NotImplementedError
+
+        def set_many(
+            self,
+            entries: list[CacheEntry],
+            ttl: dt.timedelta | None = None,
+        ) -> None:
+            """Write multiple values with one TTL policy."""
+            raise NotImplementedError
 
         def delete(self, key: str) -> bool:
-            return False
+            """Remove one key."""
+            raise NotImplementedError
+
+        def delete_many(self, keys: list[str]) -> int:
+            """Remove multiple keys."""
+            raise NotImplementedError
 
         def touch(self, key: str, ttl: dt.timedelta) -> bool:
-            return False
+            """Refresh TTL for an existing key."""
+            raise NotImplementedError
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
     #[derive(Default)]
-    struct ValkeyCache;
+    struct ExampleCache;
 
     #[gestalt::async_trait]
-    impl gestalt::CacheProvider for ValkeyCache {
+    impl gestalt::CacheProvider for ExampleCache {
         async fn get(&self, key: &str) -> gestalt::Result<Option<Vec<u8>>> {
-            let _ = key;
-            Ok(None)
+            todo!("read a value by key")
+        }
+
+        async fn get_many(
+            &self,
+            keys: &[String],
+        ) -> gestalt::Result<std::collections::BTreeMap<String, Vec<u8>>> {
+            todo!("read multiple keys in one request")
         }
 
         async fn set(
@@ -266,22 +253,31 @@ The Cache service includes:
             value: &[u8],
             options: gestalt::CacheSetOptions,
         ) -> gestalt::Result<()> {
-            let _ = (key, value, options.ttl);
-            Ok(())
+            todo!("write a value with an optional TTL")
+        }
+
+        async fn set_many(
+            &self,
+            entries: &[gestalt::CacheEntry],
+            options: gestalt::CacheSetOptions,
+        ) -> gestalt::Result<()> {
+            todo!("write multiple values with one TTL policy")
         }
 
         async fn delete(&self, key: &str) -> gestalt::Result<bool> {
-            let _ = key;
-            Ok(false)
+            todo!("remove one key")
+        }
+
+        async fn delete_many(&self, keys: &[String]) -> gestalt::Result<i64> {
+            todo!("remove multiple keys")
         }
 
         async fn touch(&self, key: &str, ttl: std::time::Duration) -> gestalt::Result<bool> {
-            let _ = (key, ttl);
-            Ok(false)
+            todo!("refresh TTL for an existing key")
         }
     }
 
-    gestalt::export_cache_provider!(constructor = ValkeyCache::default);
+    gestalt::export_cache_provider!(constructor = ExampleCache::default);
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -290,44 +286,39 @@ The Cache service includes:
 
     export const cache = defineCacheProvider({
       async get(key) {
-        return undefined;
+        throw new Error("read a value by key");
+      },
+
+      async getMany(keys) {
+        throw new Error("read multiple keys in one request");
       },
 
       async set(key, value, options) {
-        void key;
-        void value;
-        void options?.ttlMs;
+        throw new Error("write a value with an optional TTL");
+      },
+
+      async setMany(entries, options) {
+        throw new Error("write multiple values with one TTL policy");
       },
 
       async delete(key) {
-        void key;
-        return false;
+        throw new Error("remove one key");
+      },
+
+      async deleteMany(keys) {
+        throw new Error("remove multiple keys");
       },
 
       async touch(key, ttlMs) {
-        void key;
-        void ttlMs;
-        return false;
+        throw new Error("refresh TTL for an existing key");
       },
     });
     ```
   </Tabs.Tab>
 </Tabs>
 
-Python, Rust, and TypeScript cache providers inherit default implementations
-for `GetMany`, `SetMany`, and `DeleteMany`. Override the batch helpers only
-when the backing cache can do better than repeated single-key calls.
+### Release flow
 
-### Plugin access and release flow
-
-Plugin-side cache usage is documented in
-[Using `Cache` from a plugin](/providers/cache#using-cache-from-a-plugin).
-Provider authors only implement the cache service; Gestalt resolves configured
-bindings and exposes the matching SDK sockets to plugins.
-
-Configure cache providers with the same `providers.cache` and
-`plugins.<name>.cache` shape shown in
-[Configuring `providers.cache`](/providers/cache#configuring-providerscache).
 For packaging, lock/sync, and release behavior, see
 [Releasing provider packages](/providers#releasing-provider-packages).
 

--- a/docs/content/providers/external-credentials.mdx
+++ b/docs/content/providers/external-credentials.mdx
@@ -1,5 +1,3 @@
-import { Tabs } from 'nextra/components'
-
 # External Credentials
 
 The external credentials provider is the Gestalt provider responsible for
@@ -8,19 +6,19 @@ a credential is provisioned for a managed subject, Gestalt uses the configured
 external credentials provider to validate, exchange, store, and resolve the
 runtime credential for that connection.
 
-External credentials are separate from Gestalt sign-in. A session cookie or API
-token proves who the caller is to Gestalt. An external credential is the
-credential Gestalt uses to call an upstream API for a configured connection.
+External credentials are separate from Gestalt
+[authentication](/providers/authentication), which identifies the caller, and
+[authorization](/providers/authorization), which decides what the caller may
+access. An external credential is the credential Gestalt uses to call an
+upstream API for a configured connection.
 
 ## Core concepts
 
 ### Subject scoping
 
-Every external credential is scoped to exactly one canonical subject. The
-subject is usually a user like `user:alice` or a managed subject like
-`service_account:deploy-bot`. User-mode connections resolve credentials for the
-effective credential subject of the current request. Automation should use
-managed subjects and `runAs`, not deployer-owned connection modes.
+External credentials are scoped to a canonical
+[subject](/providers/authorization#subjects). Connections resolve credentials
+for the effective credential subject of the current request.
 
 ### Integration and connection
 
@@ -41,15 +39,15 @@ Connection `mode` controls credential ownership:
 | Mode | Credential ownership |
 | --- | --- |
 | `none` | No upstream credential is required. |
-| `user` | Credentials are owned by the effective subject of the request. |
+| `subject` | Credentials are owned by the effective subject of the request. |
 
-Use `user` for SaaS APIs that should act as the caller. For shared service
+Use `subject` for SaaS APIs that should act as the caller. For shared service
 accounts, service-to-service credentials, and model/API credentials, provision
 the credential for a service account subject and execute with `runAs`.
 
 ### Credential lifecycle
 
-The external credentials provider participates in two parts of the lifecycle:
+External credentials move through three phases:
 
 1. **Connect time.** Gestalt validates the connection auth config, completes
    OAuth or manual auth, optionally exchanges submitted credentials, and stores
@@ -77,7 +75,7 @@ server config, and callers select a connection and instance when needed.
 ```yaml
 connections:
   github-user:
-    mode: user
+    mode: subject
     auth:
       type: oauth2
       authorizationUrl: https://github.com/login/oauth/authorize
@@ -93,13 +91,13 @@ plugins:
         ref: github-user
 ```
 
-For automation-owned credentials, define a normal user-mode connection and
+For automation-owned credentials, define a normal subject-scoped connection and
 provision the credential for the service account subject that will run it:
 
 ```yaml
 connections:
   model-api:
-    mode: user
+    mode: subject
     auth:
       type: bearer
     params:
@@ -121,108 +119,6 @@ and agents select that subject with `runAs`.
 At runtime, providers that support connection bindings receive resolved runtime
 connection material from Gestalt. They should treat that material as the
 connection contract and avoid depending on how the credential was obtained.
-
-## Provider interface
-
-External credential providers implement this SDK interface:
-
-| Method | Purpose |
-| --- | --- |
-| `UpsertCredential` | Create or update a stored connection credential. |
-| `GetCredential` | Fetch one stored credential by lookup. |
-| `ListCredentials` | List stored credentials for a subject, with optional connection or instance filters. |
-| `DeleteCredential` | Delete one stored credential. |
-| `ValidateCredentialConfig` | Validate that a connection auth config is supported by this provider. |
-| `ExchangeCredential` | Exchange user-supplied connection material during connect, such as manual credentials submitted through `gestalt plugin connect`. |
-| `ResolveCredential` | Resolve a configured connection into usable runtime credential material. |
-
-Most deployments should use the first-party external credentials provider. Write
-a custom external credentials provider when you need a different storage backend,
-different encryption boundary, or custom validation/exchange/resolution behavior
-for your organization's connection model.
-
-### Validation
-
-`ValidateCredentialConfig` runs against configured connection auth. Return an
-error when the config is incomplete or unsupported. This lets deployers catch
-invalid connection config before users try to connect or invoke the provider.
-
-### Connect-time exchange
-
-`ExchangeCredential` runs when a connection flow submits credential material that
-must be exchanged before storage. For example, a manual credential form may
-submit an API token or account identifier that the external credentials provider
-exchanges for a short-lived access token and refresh material.
-
-If no exchange is required, return an empty response and let Gestalt store the
-submitted credential according to the connection auth type.
-
-### Runtime resolution
-
-`ResolveCredential` runs when a configured connection needs runtime credential
-material. It receives the selected provider, connection, instance, credential
-subject, connection mode, auth config, and connection params. It returns the
-runtime token, expiry metadata, resolved params, and any metadata needed by the
-caller.
-
-Runtime resolution is where providers can refresh expiring subject-owned
-credentials or apply provider-specific token exchange behavior. Callers should
-not need to know which of those paths was used.
-
-### Proactive maintenance
-
-Connections can declare `credentialRefresh` in a provider manifest or deployment
-config. Gestalt resolves that metadata with the final connection definition and
-passes a `resolvedConnections` catalog into the configured external credentials
-provider only when at least one connection declares proactive refresh.
-
-The catalog includes the provider name, connection name, stable connection ID,
-mode, resolved auth config, and canonical `credentialRefresh` durations. It is
-intentionally provider-neutral: Gestalt does not run a refresh scheduler itself
-and does not add a separate refresh RPC. The external credentials provider
-decides whether a resolved connection is refreshable and owns any scheduler,
-token endpoint call, retry, and persistence behavior.
-
-The first-party `externalcredentials/default` provider supports proactive
-refresh for user-mode credentials whose resolved auth can refresh tokens. For
-OAuth-style connections that means the auth config must include a token URL and
-client credentials. The provider scans credentials on `refreshInterval`,
-refreshes credentials expiring within `refreshBeforeExpiry`, persists rotated
-access and refresh tokens, preserves existing credentials on transient refresh
-failures, and removes credentials only when the upstream token endpoint returns
-a terminal invalid-grant style response.
-
-This is preventative maintenance, not credential recovery. If the upstream
-provider has already revoked or expired the refresh token, the user or operator
-must reconnect the connection to obtain a new refresh token.
-
-### SDK request fields
-
-External credential SDK requests include both display-oriented connection
-context and a stable lookup key:
-
-| Field | Purpose |
-| --- | --- |
-| `provider` | Configured provider name, useful for validation and diagnostics. |
-| `connection` | Named connection as written in provider or deployment config. |
-| `connection_id` | Canonical connection identifier for credential lookup. |
-| `credential_subject_id` | Subject whose credential should be resolved or exchanged. |
-| `actor_subject_id` | Subject that initiated the request, when different from the credential owner. |
-| `instance` | Optional selected account or workspace instance. |
-| `auth` | Connection auth config after manifest and deployment config are combined. |
-| `connection_params` | Resolved connection parameters available to exchange and resolution. |
-
-Use `connection_id` with `subject_id` and `instance` for stored credential
-lookups. Use `provider`, `connection`, `auth`, and `connection_params` to decide
-whether the request is valid and how to exchange or resolve the credential.
-
-### Token exchange drivers
-
-Connection auth config delivered over the external credentials transport may
-include provider-specific token exchange metadata. Gestalt config does not
-support declarative `tokenExchangeDrivers`; keep provisioning and exchange
-details inside the external credentials provider or the managed credential
-workflow.
 
 ## First-party external credentials providers
 
@@ -246,7 +142,7 @@ providers:
     main:
       source:
         package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.4
       config:
         dsn: ${DATABASE_URL}
 
@@ -254,7 +150,7 @@ providers:
     default:
       source:
         package: github.com/valon-technologies/gestalt-providers/externalcredentials/default
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.5
       config:
         indexeddb: main
 ```
@@ -266,29 +162,10 @@ If you omit `providers.externalCredentials`, Gestalt uses the first-party
 `externalcredentials/default` provider with the selected host IndexedDB
 provider.
 
-## Relationship to other providers
-
-| Provider | How it relates |
-| --- | --- |
-| `providers.authentication` | Creates sessions and identifies subjects |
-| `providers.authorization` | Decides whether a subject may access a resource |
-| `providers.externalCredentials` | Stores the upstream tokens used to invoke resources |
-| `providers.indexeddb` | Often the storage backend for the other three |
-
-Authentication answers who the caller is. Authorization answers what the caller
-may do. External credentials answer which upstream token the caller uses to do it.
-These are three independent systems that compose at runtime.
-
-## Operational notes
-
 `server.providers.externalCredentials` selects the host external credentials
 provider. If more than one entry exists under `providers.externalCredentials`,
 set `server.providers.externalCredentials` explicitly or mark one entry
 `default: true`.
-
-Credentials are encrypted at rest using the deployment's encryption key. Check
-the provider's documentation to understand its storage and encryption
-guarantees.
 
 `providers.externalCredentials` is a deployment-wide provider selection. Plugin,
 workflow, and agent providers do not select their own external credentials
@@ -311,9 +188,9 @@ spec:
   configSchemaPath: ./externalcredentials_config.json
 ```
 
-### Provider interface
+### Provider contract
 
-The external credential provider contract has three responsibilities:
+The Go SDK external credential provider contract has three responsibilities:
 
 | Area | Methods |
 | --- | --- |
@@ -325,9 +202,6 @@ The external credential provider contract has three responsibilities:
 receives the configured connection, credential subject, and instance, then
 returns the token or connection parameters that Gestalt should pass to the
 target provider.
-
-<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
-  <Tabs.Tab>
 
 ```go
 package vaultcredentials
@@ -507,42 +381,10 @@ func cloneTime(in *time.Time) *time.Time {
 }
 ```
 
-  </Tabs.Tab>
-  <Tabs.Tab>
-    External credential provider implementation is currently exposed through
-    the Go SDK. Python plugins and providers can consume credentials by
-    declaring or binding connections; Gestalt resolves those through the
-    configured external credential provider before invoking the target
-    operation.
-  </Tabs.Tab>
-  <Tabs.Tab>
-    External credential provider implementation is currently exposed through
-    the Go SDK. Rust plugins and providers can consume credentials by declaring
-    or binding connections; Gestalt resolves those through the configured
-    external credential provider before invoking the target operation.
-  </Tabs.Tab>
-  <Tabs.Tab>
-    External credential provider implementation is currently exposed through
-    the Go SDK. TypeScript plugins and providers can consume credentials by
-    declaring or binding connections; Gestalt resolves those through the
-    configured external credential provider before invoking the target
-    operation.
-  </Tabs.Tab>
-</Tabs>
-
 This example keeps credentials in memory to show the SDK shape. Production
 providers should persist credentials durably, encrypt at rest, preserve created
 and updated timestamps, and implement refresh or exchange behavior that matches
 the supported connection auth modes.
-
-### Deploying the provider
-
-Custom external credential providers are selected globally with
-`server.providers.externalCredentials`, using the same config shape shown in
-[Configuring `providers.externalCredentials`](/providers/external-credentials#configuring-providersexternalcredentials).
-Plugins, workflows, and agent providers do not select external credential
-providers directly; they declare or bind connections and let Gestalt resolve
-those connections through the selected deployment-wide provider.
 
 ## What to read next
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -757,7 +757,7 @@ workflows:
 | `target.plugin.instance` | Optional target instance name. |
 | `target.plugin.input` | Optional static input merged into the invocation payload. |
 | `target.agent` | Optional agent target using the same shape as workflow agent requests: `provider`, `model`, `prompt`, `messages`, `tools`, `responseSchema`, `metadata`, `modelOptions`, and `timeout`. |
-| `runAs.subject.id` | Optional service-account subject ID, such as `service_account:roadmap-sync`, used as the runtime principal and credential subject. Without `runAs`, config-managed workflows run as `system:config` and cannot target user-mode credentials. |
+| `runAs.subject.id` | Optional service-account subject ID, such as `service_account:roadmap-sync`, used as the runtime principal and credential subject. Without `runAs`, config-managed workflows run as `system:config` and cannot target subject-scoped credentials. |
 | `runAs.subject.kind` | Optional subject kind. When set, it must match the kind in `runAs.subject.id`; declarative workflows currently support only `service_account`. |
 | `runAs.subject.displayName` / `runAs.subject.authSource` | Optional metadata copied into the runtime principal and run-as audit fields. |
 | `invokes` | Optional additional plugin-operation grants as `{ plugin, operation }` entries. The direct target operation is always included. These grants are a token permission ceiling; they do not create credentials or replace `plugins.<target>.invokes` for nested plugin calls. |
@@ -1166,7 +1166,7 @@ plugins:
         - snapshots
     connections:
       default:
-        mode: user
+        mode: subject
         auth:
           type: oauth2
     allowedOperations:
@@ -1442,7 +1442,7 @@ provider refers to the connection at runtime.
 ```yaml
 connections:
   slack-workspace:
-    mode: user
+    mode: subject
     auth:
       type: oauth2
       authorizationUrl: https://accounts.example.com/oauth/authorize
@@ -1469,7 +1469,7 @@ receiving secrets in static config:
 ```yaml
 connections:
   vertex-kimi:
-    mode: user
+    mode: subject
     auth:
       type: bearer
     params:
@@ -1498,7 +1498,7 @@ subject-owned connections.
 ```yaml
 connections:
   gmail-service-mailbox:
-    mode: user
+    mode: subject
     auth:
       type: oauth2
       tokenUrl: https://oauth2.googleapis.com/token
@@ -1527,7 +1527,7 @@ connection literally named `default`, then the only named connection when there
 is exactly one.
 
 Connection `mode` determines how credentials are managed: `none` requires no
-credentials, and `user` stores credentials for the caller's effective subject.
+credentials, and `subject` stores credentials for the caller's effective subject.
 For humans that is typically `user:<id>`; for non-human API token callers it can
 be `service_account:<id>` or another canonical non-system subject ID. Runtime
 surfaces can also supply system subjects such as
@@ -1536,7 +1536,7 @@ surfaces can also supply system subjects such as
 Binding entries that use `ref` may set only binding metadata such as
 `displayName` and `credentialRefresh`; they cannot override `mode`, `auth`, or
 `params`. Top-level connections cannot set `ref`. Inline connection bindings are
-available for simple single-use `none` cases; user-owned connections that
+available for simple single-use `none` cases; subject-scoped connections that
 collect or exchange credentials must be declared at the top level and referenced
 by `ref`.
 
@@ -1549,7 +1549,7 @@ on-demand refresh path.
 ```yaml
 connections:
   google-workspace:
-    mode: user
+    mode: subject
     auth:
       type: oauth2
       tokenUrl: https://oauth2.googleapis.com/token
@@ -1676,7 +1676,7 @@ Post-connect discovery lets a connection fetch a list of resources after the use
 ```yaml
 connections:
   default:
-    mode: user
+    mode: subject
     auth:
       type: oauth2
       authorizationUrl: https://accounts.example.com/oauth/authorize
@@ -1787,7 +1787,7 @@ must be present.
 allowed when their corresponding source is set.
 
 Top-level connections cannot set `ref` or `exposure`. Connection bindings that
-set `ref` cannot also set `mode`, `auth`, or `params`. User-owned inline
+set `ref` cannot also set `mode`, `auth`, or `params`. Subject-scoped inline
 connections that collect or exchange credentials are not supported; declare a
 top-level connection and reference it with `ref`. All connections in a plugin
 must share the same mode.

--- a/docs/content/reference/configuration.mdx
+++ b/docs/content/reference/configuration.mdx
@@ -204,7 +204,7 @@ Gestalt. Do not use a shared placeholder value in a real deployment.
 ## Full Example
 
 A production deployment with OIDC auth, external credential storage, a GitHub
-plugin with per-user connections, and MCP enabled:
+plugin with subject-scoped connections, and MCP enabled:
 
 ```yaml
 server:
@@ -266,14 +266,14 @@ plugins:
         baseUrl: https://api.github.com
     connections:
       api:
-        mode: user
+        mode: subject
         auth:
           type: bearer
           credentials:
             - name: token
               label: Personal Access Token
       mcp:
-        mode: user
+        mode: subject
         auth:
           type: mcp_oauth
 ```

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -167,7 +167,7 @@ following fields:
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `mode` | string | One of `none` or `user`. |
+| `mode` | string | One of `none` or `subject`. |
 | `auth` | ProviderAuth | Authentication configuration for this connection. |
 | `params` | map[string]ConnectionParam | Connection parameters populated during or after connect. |
 | `discovery` | Discovery | Post-connect discovery configuration. |
@@ -583,7 +583,7 @@ This manifest shows a plugin with an executable entrypoint, multiple connections
           value: primary
       connections:
         default:
-          mode: user
+          mode: subject
           auth:
             type: oauth2
             authorizationUrl: https://accounts.support.example.com/oauth/authorize
@@ -604,7 +604,7 @@ This manifest shows a plugin with an executable entrypoint, multiple connections
             metadata:
               workspace_id: id
         mcp:
-          mode: user
+          mode: subject
           auth:
             type: mcp_oauth
       surfaces:
@@ -658,7 +658,7 @@ This manifest shows a plugin with an executable entrypoint, multiple connections
         ],
         "connections": {
           "default": {
-            "mode": "user",
+            "mode": "subject",
             "auth": {
               "type": "oauth2",
               "authorizationUrl": "https://accounts.support.example.com/oauth/authorize",
@@ -678,7 +678,7 @@ This manifest shows a plugin with an executable entrypoint, multiple connections
             }
           },
           "mcp": {
-            "mode": "user",
+            "mode": "subject",
             "auth": { "type": "mcp_oauth" }
           }
         },

--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 )
@@ -9,19 +10,37 @@ import (
 type ConnectionMode string
 
 const (
-	ConnectionModeNone ConnectionMode = "none"
-	ConnectionModeUser ConnectionMode = "user"
+	ConnectionModeNone    ConnectionMode = "none"
+	ConnectionModeSubject ConnectionMode = "subject"
+
+	// ConnectionModeUser is the legacy name for subject-scoped credentials.
+	ConnectionModeUser = ConnectionModeSubject
+
+	connectionModeLegacyUser ConnectionMode = "user"
 )
 
 func NormalizeConnectionMode(mode ConnectionMode) ConnectionMode {
-	switch mode {
-	case "", ConnectionModeUser:
-		return ConnectionModeUser
+	normalized := normalizeConnectionModeValue(mode)
+	switch normalized {
+	case "", ConnectionModeSubject, connectionModeLegacyUser:
+		return ConnectionModeSubject
 	case ConnectionModeNone:
 		return ConnectionModeNone
 	default:
-		return mode
+		return normalized
 	}
+}
+
+func NormalizeOptionalConnectionMode(mode ConnectionMode) ConnectionMode {
+	normalized := normalizeConnectionModeValue(mode)
+	if normalized == "" {
+		return ""
+	}
+	return NormalizeConnectionMode(normalized)
+}
+
+func normalizeConnectionModeValue(mode ConnectionMode) ConnectionMode {
+	return ConnectionMode(strings.ToLower(strings.TrimSpace(string(mode))))
 }
 
 type Provider interface {

--- a/gestaltd/core/testing/stubs.go
+++ b/gestaltd/core/testing/stubs.go
@@ -252,9 +252,9 @@ func (s *StubIntegration) Description() string { return s.Desc }
 
 func (s *StubIntegration) ConnectionMode() core.ConnectionMode {
 	if s.ConnMode == "" {
-		return core.ConnectionModeUser
+		return core.ConnectionModeSubject
 	}
-	return s.ConnMode
+	return core.NormalizeConnectionMode(s.ConnMode)
 }
 func (s *StubIntegration) AuthTypes() []string { return nil }
 func (s *StubIntegration) ConnectionParamDefs() map[string]core.ConnectionParamDef {

--- a/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
+++ b/gestaltd/internal/bootstrap/agent_workflow_tools_test.go
@@ -1333,7 +1333,7 @@ func TestAgentRuntimeWorkflowSystemToolRejectsUnsupportedScheduleTargetFields(t 
 							map[string]any{
 								"plugin":         "roadmap",
 								"operation":      "sync",
-								"credentialMode": "user",
+								"credentialMode": "subject",
 							},
 						},
 					},

--- a/gestaltd/internal/bootstrap/connections_test.go
+++ b/gestaltd/internal/bootstrap/connections_test.go
@@ -200,7 +200,7 @@ func TestBuildExternalCredentialsRuntimeConfigNodeResolvedConnectionsContract(t 
 	if conn == nil {
 		t.Fatalf("gmail default resolved connection missing from %#v", connections)
 	}
-	if conn["provider"] != "gmail" || conn["connection"] != "default" || conn["connectionId"] != "google-workspace" || conn["mode"] != "user" {
+	if conn["provider"] != "gmail" || conn["connection"] != "default" || conn["connectionId"] != "google-workspace" || conn["mode"] != "subject" {
 		t.Fatalf("resolved connection identity = %#v", conn)
 	}
 	auth, ok := conn["auth"].(map[string]any)

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -836,8 +836,9 @@ func buildConfiguredSpecProvider(ctx context.Context, name string, resolved conf
 	case config.SpecSurfaceMCP:
 		connMode := core.ConnectionMode(resolved.Connection.Mode)
 		if connMode == "" {
-			connMode = core.ConnectionModeUser
+			connMode = core.ConnectionModeSubject
 		}
+		connMode = core.NormalizeConnectionMode(connMode)
 		up, err := mcpupstream.New(
 			ctx,
 			name,

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -278,7 +278,7 @@ func workflowConfigTarget(target *config.WorkflowTargetConfig) coreworkflow.Targ
 		Operation:      plugin.Operation,
 		Connection:     plugin.Connection,
 		Instance:       plugin.Instance,
-		CredentialMode: core.ConnectionMode(strings.ToLower(strings.TrimSpace(string(plugin.CredentialMode)))),
+		CredentialMode: core.NormalizeOptionalConnectionMode(core.ConnectionMode(plugin.CredentialMode)),
 		Input:          maps.Clone(plugin.Input),
 	}
 	return coreworkflow.Target{
@@ -343,7 +343,7 @@ func workflowConfigOutputDelivery(delivery *config.WorkflowOutputDeliveryConfig)
 			Instance:   strings.TrimSpace(delivery.Target.Instance),
 			Input:      maps.Clone(delivery.Target.Input),
 		},
-		CredentialMode: core.ConnectionMode(strings.ToLower(strings.TrimSpace(string(delivery.CredentialMode)))),
+		CredentialMode: core.NormalizeOptionalConnectionMode(core.ConnectionMode(delivery.CredentialMode)),
 		InputBindings:  make([]coreworkflow.OutputBinding, 0, len(delivery.InputBindings)),
 	}
 	for _, binding := range delivery.InputBindings {
@@ -645,7 +645,7 @@ func workflowConfigExecutionReference(cfg *config.Config, providerName string, t
 }
 
 func workflowConfigValidateNoUserCredentialTarget(cfg *config.Config, target coreworkflow.PluginTarget, hasRunAs bool) error {
-	modeOverride := core.ConnectionMode(strings.ToLower(strings.TrimSpace(string(target.CredentialMode))))
+	modeOverride := core.NormalizeOptionalConnectionMode(target.CredentialMode)
 	switch modeOverride {
 	case "":
 	case core.ConnectionModeNone:

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -250,7 +250,7 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 		return nil, fmt.Errorf("workflow target plugin is required")
 	}
 	pluginTarget := target.Plugin
-	credentialMode := core.ConnectionMode(strings.ToLower(strings.TrimSpace(string(pluginTarget.CredentialMode))))
+	credentialMode := core.NormalizeOptionalConnectionMode(pluginTarget.CredentialMode)
 	switch credentialMode {
 	case "":
 	case core.ConnectionModeNone, core.ConnectionModeUser:

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5588,7 +5588,7 @@ plugins:
         path: ./plugins/dummy/manifest.yaml
       connections:
         named:
-          mode: user
+          mode: subject
           auth:
             type: none
           params:

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -873,7 +873,7 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 		entry.Invokes[i].Plugin = strings.TrimSpace(entry.Invokes[i].Plugin)
 		entry.Invokes[i].Operation = strings.TrimSpace(entry.Invokes[i].Operation)
 		entry.Invokes[i].Surface = strings.ToLower(strings.TrimSpace(entry.Invokes[i].Surface))
-		entry.Invokes[i].CredentialMode = providermanifestv1.ConnectionMode(strings.ToLower(strings.TrimSpace(string(entry.Invokes[i].CredentialMode))))
+		entry.Invokes[i].CredentialMode = providermanifestv1.NormalizeOptionalConnectionMode(entry.Invokes[i].CredentialMode)
 		switch {
 		case entry.Invokes[i].Plugin == "":
 			return fmt.Errorf("config validation: plugins.%s.invokes[%d].plugin is required", name, i)
@@ -2056,7 +2056,7 @@ func normalizeWorkflowPluginTargetConfig(path string, plugin *WorkflowPluginTarg
 	plugin.Operation = strings.TrimSpace(plugin.Operation)
 	plugin.Connection = strings.TrimSpace(plugin.Connection)
 	plugin.Instance = strings.TrimSpace(plugin.Instance)
-	plugin.CredentialMode = providermanifestv1.ConnectionMode(strings.ToLower(strings.TrimSpace(string(plugin.CredentialMode))))
+	plugin.CredentialMode = providermanifestv1.NormalizeOptionalConnectionMode(plugin.CredentialMode)
 	if plugin.Name == "" {
 		return fmt.Errorf("config validation: %s.name is required", path)
 	}
@@ -2160,7 +2160,7 @@ func normalizeWorkflowOutputDeliveryConfig(path string, delivery *WorkflowOutput
 	if err := normalizeWorkflowPluginTargetConfig(path+".target", &delivery.Target, false); err != nil {
 		return err
 	}
-	delivery.CredentialMode = providermanifestv1.ConnectionMode(strings.ToLower(strings.TrimSpace(string(delivery.CredentialMode))))
+	delivery.CredentialMode = providermanifestv1.NormalizeOptionalConnectionMode(delivery.CredentialMode)
 	switch delivery.CredentialMode {
 	case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser:
 	default:

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -2277,8 +2277,8 @@ func TestRun_ProviderReleasePreservesYAMLManifestFormatAndConnectionDefaults(t *
 	if manifest.Spec == nil || manifest.Spec.Connections["default"] == nil || len(manifest.Spec.Connections["default"].Params) != 1 || !manifest.Spec.Connections["default"].Params["tenant"].Required {
 		t.Fatalf("provider connection_params = %+v", manifest.Spec)
 	}
-	if manifest.Spec.Connections["default"].Mode != "user" {
-		t.Fatalf("provider default connection mode = %q, want %q", manifest.Spec.Connections["default"].Mode, "user")
+	if manifest.Spec.Connections["default"].Mode != providermanifestv1.ConnectionModeSubject {
+		t.Fatalf("provider default connection mode = %q, want %q", manifest.Spec.Connections["default"].Mode, providermanifestv1.ConnectionModeSubject)
 	}
 
 	manifestData, err := os.ReadFile(manifestPath)
@@ -2289,7 +2289,7 @@ func TestRun_ProviderReleasePreservesYAMLManifestFormatAndConnectionDefaults(t *
 		"spec:",
 		"connections:",
 		"default:",
-		"mode: user",
+		"mode: subject",
 		"params:",
 		"mcp: true",
 		"entrypoint:",

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -565,7 +565,7 @@ spec:
       connection: mcp
   connections:
     mcp:
-      mode: user
+      mode: subject
       auth:
         type: mcp_oauth
 `)

--- a/gestaltd/internal/server/audit_metadata_test.go
+++ b/gestaltd/internal/server/audit_metadata_test.go
@@ -427,8 +427,8 @@ func TestAuditMetadata_ServiceAccountSubjectAndCredentialPath(t *testing.T) {
 	if record["subject_kind"] != "service_account" {
 		t.Fatalf("expected subject_kind=service_account, got %v", record["subject_kind"])
 	}
-	if record["credential_mode"] != "user" {
-		t.Fatalf("expected credential_mode=user, got %v", record["credential_mode"])
+	if record["credential_mode"] != "subject" {
+		t.Fatalf("expected credential_mode=subject, got %v", record["credential_mode"])
 	}
 	if record["credential_subject_id"] != "service_account:triage-bot" {
 		t.Fatalf("expected credential_subject_id service account principal, got %v", record["credential_subject_id"])

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -1031,7 +1031,7 @@ func agentToolRefsFromRequest(refs []agentToolRefRequest) []coreagent.ToolRef {
 			Operation:      strings.TrimSpace(ref.Operation),
 			Connection:     strings.TrimSpace(ref.Connection),
 			Instance:       strings.TrimSpace(ref.Instance),
-			CredentialMode: core.ConnectionMode(strings.ToLower(strings.TrimSpace(ref.CredentialMode))),
+			CredentialMode: core.NormalizeOptionalConnectionMode(core.ConnectionMode(ref.CredentialMode)),
 			Title:          strings.TrimSpace(ref.Title),
 			Description:    strings.TrimSpace(ref.Description),
 		})

--- a/gestaltd/internal/server/handlers_workflow.go
+++ b/gestaltd/internal/server/handlers_workflow.go
@@ -296,7 +296,7 @@ func workflowScheduleTargetFromRequest(target workflowScheduleTargetRequest) cor
 		Operation:      strings.TrimSpace(plugin.Operation),
 		Connection:     strings.TrimSpace(plugin.Connection),
 		Instance:       strings.TrimSpace(plugin.Instance),
-		CredentialMode: core.ConnectionMode(strings.ToLower(strings.TrimSpace(plugin.CredentialMode))),
+		CredentialMode: core.NormalizeOptionalConnectionMode(core.ConnectionMode(plugin.CredentialMode)),
 		Input:          maps.Clone(plugin.Input),
 	}
 	return coreworkflow.Target{
@@ -373,11 +373,11 @@ func workflowOutputDeliveryFromRequest(delivery *workflowOutputDeliveryRequest) 
 			Operation:      strings.TrimSpace(delivery.Target.Operation),
 			Connection:     strings.TrimSpace(delivery.Target.Connection),
 			Instance:       strings.TrimSpace(delivery.Target.Instance),
-			CredentialMode: core.ConnectionMode(strings.ToLower(strings.TrimSpace(delivery.Target.CredentialMode))),
+			CredentialMode: core.NormalizeOptionalConnectionMode(core.ConnectionMode(delivery.Target.CredentialMode)),
 			Input:          maps.Clone(delivery.Target.Input),
 		},
 		InputBindings:  workflowOutputBindingsFromRequest(delivery.InputBindings),
-		CredentialMode: core.ConnectionMode(strings.ToLower(strings.TrimSpace(delivery.CredentialMode))),
+		CredentialMode: core.NormalizeOptionalConnectionMode(core.ConnectionMode(delivery.CredentialMode)),
 	}
 }
 

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -187,7 +187,7 @@ func validateMountedHTTPBinding(pluginName, bindingName string, binding *config.
 		return fmt.Errorf("%s.method %q is not a valid HTTP method", path, binding.Method)
 	}
 	binding.Method = method
-	binding.CredentialMode = providermanifestv1.ConnectionMode(strings.TrimSpace(string(binding.CredentialMode)))
+	binding.CredentialMode = providermanifestv1.NormalizeOptionalConnectionMode(binding.CredentialMode)
 	switch binding.CredentialMode {
 	case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser:
 	default:

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -200,19 +200,19 @@ func TestConnectionAuthMetrics(t *testing.T) {
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "start",
-		"gestalt.connection_mode": "user",
+		"gestalt.connection_mode": "subject",
 	})
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.count", 2, map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "complete",
-		"gestalt.connection_mode": "user",
+		"gestalt.connection_mode": "subject",
 	})
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.error_count", 1, map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "complete",
-		"gestalt.connection_mode": "user",
+		"gestalt.connection_mode": "subject",
 	})
 	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.connection.auth.duration", map[string]string{
 		"gestalt.provider": providerName,
@@ -318,13 +318,13 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "refresh",
-		"gestalt.connection_mode": "user",
+		"gestalt.connection_mode": "subject",
 	})
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.error_count", 1, map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "refresh",
-		"gestalt.connection_mode": "user",
+		"gestalt.connection_mode": "subject",
 	})
 	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.connection.auth.duration", map[string]string{
 		"gestalt.provider": providerName,
@@ -335,7 +335,7 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 		"gestalt.provider":            providerName,
 		"gestalt.operation":           "list",
 		"gestalt.transport":           "rest",
-		"gestalt.connection_mode":     "user",
+		"gestalt.connection_mode":     "subject",
 		"gestalt.result_status":       "200",
 		"gestalt.result_status_class": "2xx",
 	})
@@ -343,7 +343,7 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 		"gestalt.provider":            providerName,
 		"gestalt.operation":           "list",
 		"gestalt.transport":           "rest",
-		"gestalt.connection_mode":     "user",
+		"gestalt.connection_mode":     "subject",
 		"gestalt.result_status":       "412",
 		"gestalt.result_status_class": "4xx",
 	})
@@ -351,7 +351,7 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 		"gestalt.provider":            providerName,
 		"gestalt.operation":           "list",
 		"gestalt.transport":           "rest",
-		"gestalt.connection_mode":     "user",
+		"gestalt.connection_mode":     "subject",
 		"gestalt.result_status":       "412",
 		"gestalt.result_status_class": "4xx",
 	})
@@ -500,7 +500,7 @@ func TestManualConnectionMetrics(t *testing.T) {
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "manual",
 		"gestalt.action":          "complete",
-		"gestalt.connection_mode": "user",
+		"gestalt.connection_mode": "subject",
 	})
 }
 
@@ -883,7 +883,7 @@ func TestHTTPDiscoveryMetrics(t *testing.T) {
 	attrs := map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.action":          "list_operations",
-		"gestalt.connection_mode": "user",
+		"gestalt.connection_mode": "subject",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.discovery.count", 1, attrs)
 	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.discovery.error_count", attrs)
@@ -943,7 +943,7 @@ func TestHTTPDiscoveryMetrics_FailureRecordsErrorCount(t *testing.T) {
 	attrs := map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.action":          "list_operations",
-		"gestalt.connection_mode": "user",
+		"gestalt.connection_mode": "subject",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.discovery.count", 1, attrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.discovery.error_count", 1, attrs)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -13295,11 +13295,11 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 	if slackStatus != "ready" || slackCredentialState != "connected" {
 		t.Fatalf("slack status = {%q, %q}, want ready/connected", slackStatus, slackCredentialState)
 	}
-	if defaultConnection.Mode != "user" || defaultConnection.Status != "ready" || defaultConnection.CredentialState != "connected" || !reflect.DeepEqual(defaultConnection.Actions, []string{"disconnect", "add_instance"}) {
-		t.Fatalf("default connection metadata = %+v, want connected user connection", *defaultConnection)
+	if defaultConnection.Mode != "subject" || defaultConnection.Status != "ready" || defaultConnection.CredentialState != "connected" || !reflect.DeepEqual(defaultConnection.Actions, []string{"disconnect", "add_instance"}) {
+		t.Fatalf("default connection metadata = %+v, want connected subject-scoped connection", *defaultConnection)
 	}
-	if botConnection.Mode != "user" || botConnection.Status != "ready" || botConnection.CredentialState != "connected" {
-		t.Fatalf("bot connection metadata = %+v, want connected user-owned bot connection", *botConnection)
+	if botConnection.Mode != "subject" || botConnection.Status != "ready" || botConnection.CredentialState != "connected" {
+		t.Fatalf("bot connection metadata = %+v, want connected subject-scoped bot connection", *botConnection)
 	}
 
 	opsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/slack/operations", nil)
@@ -13412,9 +13412,9 @@ func TestExecuteOperation_DeclarativeRESTConnectionSelectorRoutesCredentialAndOm
 		"gestaltd.operation.name":     "chat.postMessage",
 		"gestaltd.invocation.surface": "http",
 	}
-	userAttrs := maps.Clone(httpOperationAttrs)
-	userAttrs["gestaltd.connection.mode"] = "user"
-	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", userAttrs)
+	subjectAttrs := maps.Clone(httpOperationAttrs)
+	subjectAttrs["gestaltd.connection.mode"] = "subject"
+	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", subjectAttrs)
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -361,6 +361,7 @@
           "type": "string",
           "enum": [
             "none",
+            "subject",
             "user"
           ]
         },
@@ -411,6 +412,7 @@
           "type": "string",
           "enum": [
             "none",
+            "subject",
             "user"
           ]
         },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -471,9 +471,38 @@ const (
 type ConnectionMode string
 
 const (
-	ConnectionModeNone ConnectionMode = "none"
-	ConnectionModeUser ConnectionMode = "user"
+	ConnectionModeNone    ConnectionMode = "none"
+	ConnectionModeSubject ConnectionMode = "subject"
+
+	// ConnectionModeUser is the legacy name for subject-scoped credentials.
+	ConnectionModeUser = ConnectionModeSubject
+
+	connectionModeLegacyUser ConnectionMode = "user"
 )
+
+func NormalizeConnectionMode(mode ConnectionMode) ConnectionMode {
+	normalized := normalizeConnectionModeValue(mode)
+	switch normalized {
+	case "", ConnectionModeSubject, connectionModeLegacyUser:
+		return ConnectionModeSubject
+	case ConnectionModeNone:
+		return ConnectionModeNone
+	default:
+		return normalized
+	}
+}
+
+func NormalizeOptionalConnectionMode(mode ConnectionMode) ConnectionMode {
+	normalized := normalizeConnectionModeValue(mode)
+	if normalized == "" {
+		return ""
+	}
+	return NormalizeConnectionMode(normalized)
+}
+
+func normalizeConnectionModeValue(mode ConnectionMode) ConnectionMode {
+	return ConnectionMode(strings.ToLower(strings.TrimSpace(string(mode))))
+}
 
 type PaginationStyle string
 

--- a/gestaltd/services/agents/agentgrant/seal.go
+++ b/gestaltd/services/agents/agentgrant/seal.go
@@ -38,7 +38,7 @@ func (m *Manager) MintToolID(target coreagent.ToolTarget) (string, error) {
 		Operation:             strings.TrimSpace(target.Operation),
 		Connection:            strings.TrimSpace(target.Connection),
 		Instance:              strings.TrimSpace(target.Instance),
-		CredentialMode:        core.ConnectionMode(strings.TrimSpace(string(target.CredentialMode))),
+		CredentialMode:        core.NormalizeOptionalConnectionMode(target.CredentialMode),
 		Unavailable:           normalizeUnavailableToolTarget(target.Unavailable),
 		RunAs:                 core.NormalizeRunAsSubject(target.RunAs),
 		RunAsExternalIdentity: core.NormalizeExternalIdentityRef(target.RunAsExternalIdentity),
@@ -78,7 +78,7 @@ func (m *Manager) ResolveToolID(id string) (coreagent.ToolTarget, error) {
 	target.Operation = strings.TrimSpace(target.Operation)
 	target.Connection = strings.TrimSpace(target.Connection)
 	target.Instance = strings.TrimSpace(target.Instance)
-	target.CredentialMode = core.ConnectionMode(strings.TrimSpace(string(target.CredentialMode)))
+	target.CredentialMode = core.NormalizeOptionalConnectionMode(target.CredentialMode)
 	target.Unavailable = normalizeUnavailableToolTarget(target.Unavailable)
 	target.RunAs = core.NormalizeRunAsSubject(target.RunAs)
 	target.RunAsExternalIdentity = core.NormalizeExternalIdentityRef(target.RunAsExternalIdentity)

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -4220,7 +4220,7 @@ func summarizeAgentTurn(turn *coreagent.Turn) *coreagent.Turn {
 }
 
 func normalizeAgentToolCredentialMode(mode core.ConnectionMode) (core.ConnectionMode, error) {
-	switch core.ConnectionMode(strings.ToLower(strings.TrimSpace(string(mode)))) {
+	switch core.NormalizeOptionalConnectionMode(mode) {
 	case "":
 		return "", nil
 	case core.ConnectionModeNone:

--- a/gestaltd/services/externalcredentials/client.go
+++ b/gestaltd/services/externalcredentials/client.go
@@ -239,7 +239,7 @@ func validateCredentialConfigToProto(req *core.ValidateExternalCredentialConfigR
 		Provider:         strings.TrimSpace(req.Provider),
 		Connection:       strings.TrimSpace(req.Connection),
 		ConnectionId:     strings.TrimSpace(req.ConnectionID),
-		Mode:             string(req.Mode),
+		Mode:             string(core.NormalizeConnectionMode(req.Mode)),
 		Auth:             externalCredentialAuthConfigToProto(req.Auth),
 		ConnectionParams: cloneStringMap(req.ConnectionParams),
 	}
@@ -253,7 +253,7 @@ func resolveCredentialRequestToProto(req *core.ResolveExternalCredentialRequest)
 		Provider:            strings.TrimSpace(req.Provider),
 		Connection:          strings.TrimSpace(req.Connection),
 		ConnectionId:        strings.TrimSpace(req.ConnectionID),
-		Mode:                string(req.Mode),
+		Mode:                string(core.NormalizeConnectionMode(req.Mode)),
 		CredentialSubjectId: strings.TrimSpace(req.CredentialSubjectID),
 		ActorSubjectId:      strings.TrimSpace(req.ActorSubjectID),
 		Instance:            strings.TrimSpace(req.Instance),

--- a/gestaltd/services/externalcredentials/server.go
+++ b/gestaltd/services/externalcredentials/server.go
@@ -113,7 +113,7 @@ func (s *externalCredentialProviderServer) ValidateCredentialConfig(ctx context.
 		Provider:         strings.TrimSpace(req.GetProvider()),
 		Connection:       strings.TrimSpace(req.GetConnection()),
 		ConnectionID:     strings.TrimSpace(req.GetConnectionId()),
-		Mode:             core.ConnectionMode(req.GetMode()),
+		Mode:             core.NormalizeConnectionMode(core.ConnectionMode(req.GetMode())),
 		Auth:             externalCredentialAuthConfigFromProto(req.GetAuth()),
 		ConnectionParams: cloneStringMap(req.GetConnectionParams()),
 	})
@@ -131,7 +131,7 @@ func (s *externalCredentialProviderServer) ResolveCredential(ctx context.Context
 		Provider:            strings.TrimSpace(req.GetProvider()),
 		Connection:          strings.TrimSpace(req.GetConnection()),
 		ConnectionID:        strings.TrimSpace(req.GetConnectionId()),
-		Mode:                core.ConnectionMode(req.GetMode()),
+		Mode:                core.NormalizeConnectionMode(core.ConnectionMode(req.GetMode())),
 		CredentialSubjectID: strings.TrimSpace(req.GetCredentialSubjectId()),
 		ActorSubjectID:      strings.TrimSpace(req.GetActorSubjectId()),
 		Instance:            strings.TrimSpace(req.GetInstance()),

--- a/gestaltd/services/invocation/credential_mode.go
+++ b/gestaltd/services/invocation/credential_mode.go
@@ -35,10 +35,7 @@ func effectiveConnectionMode(ctx context.Context, prov core.Provider) core.Conne
 }
 
 func normalizeCredentialModeOverride(mode core.ConnectionMode) core.ConnectionMode {
-	if mode == "" {
-		return ""
-	}
-	normalized := core.NormalizeConnectionMode(mode)
+	normalized := core.NormalizeOptionalConnectionMode(mode)
 	switch normalized {
 	case core.ConnectionModeNone, core.ConnectionModeUser:
 		return normalized

--- a/gestaltd/services/plugininvoker/invocation_grants.go
+++ b/gestaltd/services/plugininvoker/invocation_grants.go
@@ -186,7 +186,7 @@ func decodeInvocationGrantClaims(src map[string]invocationGrantClaims) Invocatio
 			if _, ok := decoded.Operations[operation]; !ok {
 				continue
 			}
-			decoded.Operations[operation] = core.ConnectionMode(strings.TrimSpace(mode))
+			decoded.Operations[operation] = core.NormalizeOptionalConnectionMode(core.ConnectionMode(mode))
 		}
 		for _, surface := range grant.Surfaces {
 			surface = strings.ToLower(strings.TrimSpace(surface))

--- a/gestaltd/services/plugininvoker/invocation_token.go
+++ b/gestaltd/services/plugininvoker/invocation_token.go
@@ -172,7 +172,7 @@ func (m *InvocationTokenManager) resolveToken(token, pluginName string) (invocat
 			UserAgent:  claims.RequestMeta.UserAgent,
 		},
 		credential: invocation.CredentialContext{
-			Mode:       core.ConnectionMode(strings.TrimSpace(claims.Credential.Mode)),
+			Mode:       core.NormalizeOptionalConnectionMode(core.ConnectionMode(claims.Credential.Mode)),
 			SubjectID:  claims.Credential.SubjectID,
 			Connection: claims.Credential.Connection,
 			Instance:   claims.Credential.Instance,

--- a/gestaltd/services/plugins/composite/merged.go
+++ b/gestaltd/services/plugins/composite/merged.go
@@ -89,10 +89,12 @@ func NewMergedWithConnections(name, displayName, desc, iconSVG string, providers
 	return m, nil
 }
 
-func (m *MergedProvider) Name() string                        { return m.catalog.Name }
-func (m *MergedProvider) DisplayName() string                 { return m.catalog.DisplayName }
-func (m *MergedProvider) Description() string                 { return m.catalog.Description }
-func (m *MergedProvider) ConnectionMode() core.ConnectionMode { return m.connMode }
+func (m *MergedProvider) Name() string        { return m.catalog.Name }
+func (m *MergedProvider) DisplayName() string { return m.catalog.DisplayName }
+func (m *MergedProvider) Description() string { return m.catalog.Description }
+func (m *MergedProvider) ConnectionMode() core.ConnectionMode {
+	return core.NormalizeConnectionMode(m.connMode)
+}
 
 func (m *MergedProvider) AuthTypes() []string {
 	for _, provider := range m.owned {

--- a/gestaltd/services/plugins/composite/provider.go
+++ b/gestaltd/services/plugins/composite/provider.go
@@ -66,6 +66,8 @@ var connectionModeRank = map[core.ConnectionMode]int{
 }
 
 func stricterConnectionMode(a, b core.ConnectionMode) core.ConnectionMode {
+	a = core.NormalizeConnectionMode(a)
+	b = core.NormalizeConnectionMode(b)
 	if connectionModeRank[b] > connectionModeRank[a] {
 		return b
 	}

--- a/gestaltd/services/plugins/declarative/base.go
+++ b/gestaltd/services/plugins/declarative/base.go
@@ -84,9 +84,9 @@ func (b *Base) Description() string { return b.IntegrationDesc }
 
 func (b *Base) ConnectionMode() core.ConnectionMode {
 	if b.ConnMode == "" {
-		return core.ConnectionModeUser
+		return core.ConnectionModeSubject
 	}
-	return b.ConnMode
+	return core.NormalizeConnectionMode(b.ConnMode)
 }
 
 func (b *Base) AuthTypes() []string {

--- a/gestaltd/services/plugins/declarative/build.go
+++ b/gestaltd/services/plugins/declarative/build.go
@@ -82,6 +82,7 @@ func Build(def *Definition, conn ConnectionDef, opts ...BuildOption) (core.Provi
 	if connMode == "" {
 		connMode = providermanifestv1.ConnectionMode(def.ConnectionMode)
 	}
+	connMode = providermanifestv1.NormalizeOptionalConnectionMode(connMode)
 	switch connMode {
 	case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser:
 		if connMode != "" {

--- a/gestaltd/services/plugins/declarative_provider.go
+++ b/gestaltd/services/plugins/declarative_provider.go
@@ -291,12 +291,12 @@ func cloneOperationConnectionSelectors(src map[string]core.OperationConnectionSe
 
 func declarativeConnectionMode(override core.ConnectionMode, auth *providermanifestv1.ProviderAuth) core.ConnectionMode {
 	if override != "" {
-		return override
+		return core.NormalizeConnectionMode(override)
 	}
 	if auth == nil || auth.Type == "" || auth.Type == providermanifestv1.AuthTypeNone {
 		return core.ConnectionModeNone
 	}
-	return core.ConnectionModeUser
+	return core.ConnectionModeSubject
 }
 
 func declarativeCredentialFields(auth *providermanifestv1.ProviderAuth) []core.CredentialFieldDef {

--- a/gestaltd/services/plugins/packageio/manifest.go
+++ b/gestaltd/services/plugins/packageio/manifest.go
@@ -592,7 +592,7 @@ func validateHTTPBinding(path string, binding *providermanifestv1.HTTPBinding, s
 		return fmt.Errorf("%s.method %q is not a valid HTTP method", path, binding.Method)
 	}
 	binding.Method = method
-	binding.CredentialMode = providermanifestv1.ConnectionMode(strings.TrimSpace(string(binding.CredentialMode)))
+	binding.CredentialMode = providermanifestv1.NormalizeOptionalConnectionMode(binding.CredentialMode)
 	switch binding.CredentialMode {
 	case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser:
 	default:
@@ -664,13 +664,11 @@ func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error
 		if conn.Auth != nil && conn.Auth.Type == providermanifestv1.AuthTypeMCPOAuth && provider.MCPURL() == "" {
 			return fmt.Errorf("provider.connections.%s.auth.type %q requires an MCP surface", name, providermanifestv1.AuthTypeMCPOAuth)
 		}
-		if conn.Mode == "" {
-		} else {
-			switch conn.Mode {
-			case providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser:
-			default:
-				return fmt.Errorf("unsupported provider.connections.%s.mode %q", name, conn.Mode)
-			}
+		conn.Mode = providermanifestv1.NormalizeOptionalConnectionMode(conn.Mode)
+		switch conn.Mode {
+		case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser:
+		default:
+			return fmt.Errorf("unsupported provider.connections.%s.mode %q", name, conn.Mode)
 		}
 		if conn.Exposure != "" {
 			return fmt.Errorf("provider.connections.%s.exposure is not supported", name)

--- a/gestaltd/services/plugins/provider_client.go
+++ b/gestaltd/services/plugins/provider_client.go
@@ -169,9 +169,9 @@ func (p *remoteProviderBase) Description() string { return p.description }
 
 func (p *remoteProviderBase) ConnectionMode() core.ConnectionMode {
 	if p.connection == "" {
-		return core.ConnectionModeUser
+		return core.ConnectionModeSubject
 	}
-	return p.connection
+	return core.NormalizeConnectionMode(p.connection)
 }
 
 func (p *remoteProviderBase) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {

--- a/gestaltd/services/plugins/provider_test.go
+++ b/gestaltd/services/plugins/provider_test.go
@@ -225,8 +225,8 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 				Identity:    &core.UserIdentity{DisplayName: "Ada"},
 				Source:      principal.SourceAPIToken,
 			},
-			wantExecuteBody:    "echo|secret-token|hi|acme|user:user-123|user|Ada|true|api_token|user|user:user-123|roadmap|admin|tool-call-123|https://gestalt.example.test",
-			wantSessionCatalog: "token-123|user:user-123|user|Ada|true|api_token|user|roadmap|admin|https://gestalt.example.test",
+			wantExecuteBody:    "echo|secret-token|hi|acme|user:user-123|user|Ada|true|api_token|subject|user:user-123|roadmap|admin|tool-call-123|https://gestalt.example.test",
+			wantSessionCatalog: "token-123|user:user-123|user|Ada|true|api_token|subject|roadmap|admin|https://gestalt.example.test",
 		},
 		{
 			name: "service account subject",
@@ -236,8 +236,8 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 				Kind:        principal.Kind("service_account"),
 				Source:      principal.SourceAPIToken,
 			},
-			wantExecuteBody:    "echo|secret-token|hi|acme|service_account:triage-bot|service_account|Triage Bot|false|api_token|user|service_account:triage-bot|roadmap|admin|tool-call-123|https://gestalt.example.test",
-			wantSessionCatalog: "token-123|service_account:triage-bot|service_account|Triage Bot|false|api_token|user|roadmap|admin|https://gestalt.example.test",
+			wantExecuteBody:    "echo|secret-token|hi|acme|service_account:triage-bot|service_account|Triage Bot|false|api_token|subject|service_account:triage-bot|roadmap|admin|tool-call-123|https://gestalt.example.test",
+			wantSessionCatalog: "token-123|service_account:triage-bot|service_account|Triage Bot|false|api_token|subject|roadmap|admin|https://gestalt.example.test",
 		},
 	}
 

--- a/gestaltd/services/plugins/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/services/plugins/providerpkg/manifest_workflow_test.go
@@ -636,7 +636,7 @@ spec:
   defaultConnection: default
   connections:
     default:
-      mode: user
+      mode: subject
       auth:
         type: oauth2
         authorizationUrl: https://auth.example.com/authorize
@@ -1077,7 +1077,7 @@ spec:
   connections:
     mcp:
       displayName: MCP
-      mode: user
+      mode: subject
       auth:
         type: mcp_oauth
   surfaces:
@@ -1159,7 +1159,7 @@ spec:
       auth:
         type: none
     api:
-      mode: user
+      mode: subject
       auth:
         type: oauth2
         authorizationUrl: https://auth.example.com/authorize

--- a/gestaltd/services/workflows/convert_workflow.go
+++ b/gestaltd/services/workflows/convert_workflow.go
@@ -98,7 +98,7 @@ func workflowPluginTargetFromProto(target *proto.BoundWorkflowPluginTarget) core
 		Operation:      strings.TrimSpace(target.GetOperation()),
 		Connection:     strings.TrimSpace(target.GetConnection()),
 		Instance:       strings.TrimSpace(target.GetInstance()),
-		CredentialMode: core.ConnectionMode(strings.ToLower(strings.TrimSpace(target.GetCredentialMode()))),
+		CredentialMode: core.NormalizeOptionalConnectionMode(core.ConnectionMode(target.GetCredentialMode())),
 		Input:          mapFromStruct(target.GetInput()),
 	}
 }
@@ -200,7 +200,7 @@ func workflowOutputDeliveryFromProto(delivery *proto.WorkflowOutputDelivery) *co
 	}
 	out := &coreworkflow.OutputDelivery{
 		Target:         workflowPluginTargetFromProto(delivery.GetTarget()),
-		CredentialMode: core.ConnectionMode(strings.ToLower(strings.TrimSpace(delivery.GetCredentialMode()))),
+		CredentialMode: core.NormalizeOptionalConnectionMode(core.ConnectionMode(delivery.GetCredentialMode())),
 	}
 	for _, binding := range delivery.GetInputBindings() {
 		if binding == nil {

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -1290,7 +1290,7 @@ func (m *Manager) resolvePluginTarget(ctx context.Context, p *principal.Principa
 }
 
 func (m *Manager) normalizeWorkflowPluginTargetCredentialMode(mode core.ConnectionMode, callerPluginName, pluginName, operation string) (core.ConnectionMode, error) {
-	mode = core.ConnectionMode(strings.ToLower(strings.TrimSpace(string(mode))))
+	mode = core.NormalizeOptionalConnectionMode(mode)
 	switch mode {
 	case "":
 		return "", nil
@@ -1938,8 +1938,8 @@ func (m *Manager) normalizeWorkflowAgentDelivery(delivery *coreworkflow.OutputDe
 	delivery.Target.Operation = strings.TrimSpace(delivery.Target.Operation)
 	delivery.Target.Connection = strings.TrimSpace(delivery.Target.Connection)
 	delivery.Target.Instance = strings.TrimSpace(delivery.Target.Instance)
-	delivery.Target.CredentialMode = core.ConnectionMode(strings.ToLower(strings.TrimSpace(string(delivery.Target.CredentialMode))))
-	delivery.CredentialMode = core.ConnectionMode(strings.ToLower(strings.TrimSpace(string(delivery.CredentialMode))))
+	delivery.Target.CredentialMode = core.NormalizeOptionalConnectionMode(delivery.Target.CredentialMode)
+	delivery.CredentialMode = core.NormalizeOptionalConnectionMode(delivery.CredentialMode)
 	if delivery.Target.PluginName == "" {
 		return fmt.Errorf("%w: workflow agent %s.target.plugin_name is required", invocation.ErrProviderNotFound, fieldName)
 	}
@@ -2002,7 +2002,7 @@ func (m *Manager) callerPluginInvokeCredentialMode(callerPluginName, pluginName,
 		if strings.TrimSpace(invoke.Plugin) != pluginName || strings.TrimSpace(invoke.Operation) != operation {
 			continue
 		}
-		mode := core.ConnectionMode(strings.ToLower(strings.TrimSpace(string(invoke.CredentialMode))))
+		mode := core.NormalizeOptionalConnectionMode(invoke.CredentialMode)
 		switch mode {
 		case "":
 			return "", false, nil

--- a/sdk/go/router_test.go
+++ b/sdk/go/router_test.go
@@ -179,15 +179,15 @@ func TestRouterOperationExecution(t *testing.T) {
 		AuthSource: "api_token",
 	})
 	ctxWithRequest = gestalt.WithCredential(ctxWithRequest, gestalt.Credential{
-		Mode:      "user",
+		Mode:      "subject",
 		SubjectID: "user:user-123",
 	})
 	result, err = router.Execute(ctxWithRequest, provider, "echo", map[string]any{"value": "hello"}, "tok")
 	if err != nil {
 		t.Fatalf("Execute(with params): %v", err)
 	}
-	if result.Body != `{"echo":"hello","region":"iad","region_present":true,"subject_id":"user:user-123","subject_kind":"user","credential_mode":"user","credential_subject_id":"user:user-123"}` {
-		t.Fatalf("body with params = %q, want %q", result.Body, `{"echo":"hello","region":"iad","region_present":true,"subject_id":"user:user-123","subject_kind":"user","credential_mode":"user","credential_subject_id":"user:user-123"}`)
+	if result.Body != `{"echo":"hello","region":"iad","region_present":true,"subject_id":"user:user-123","subject_kind":"user","credential_mode":"subject","credential_subject_id":"user:user-123"}` {
+		t.Fatalf("body with params = %q, want %q", result.Body, `{"echo":"hello","region":"iad","region_present":true,"subject_id":"user:user-123","subject_kind":"user","credential_mode":"subject","credential_subject_id":"user:user-123"}`)
 	}
 
 	result, err = router.Execute(ctx, provider, "nonexistent", nil, "tok")

--- a/sdk/go/serve_test.go
+++ b/sdk/go/serve_test.go
@@ -323,7 +323,7 @@ func TestProviderServerGetSessionCatalog(t *testing.T) {
 					Kind: "user",
 				},
 				Credential: &proto.CredentialContext{
-					Mode: "user",
+					Mode: "subject",
 				},
 				Access: &proto.AccessContext{
 					Policy: "roadmap",
@@ -340,8 +340,8 @@ func TestProviderServerGetSessionCatalog(t *testing.T) {
 		if resp.GetCatalog() == nil {
 			t.Fatal("expected session catalog")
 		}
-		if resp.GetCatalog().GetDisplayName() != "user:user-123|user|roadmap|viewer|https://gestalt.example.test" {
-			t.Fatalf("DisplayName = %q, want %q", resp.GetCatalog().GetDisplayName(), "user:user-123|user|roadmap|viewer|https://gestalt.example.test")
+		if resp.GetCatalog().GetDisplayName() != "user:user-123|subject|roadmap|viewer|https://gestalt.example.test" {
+			t.Fatalf("DisplayName = %q, want %q", resp.GetCatalog().GetDisplayName(), "user:user-123|subject|roadmap|viewer|https://gestalt.example.test")
 		}
 		if got := resp.GetCatalog().GetOperations()[0].GetAllowedRoles(); len(got) != 1 || got[0] != "viewer" {
 			t.Fatalf("AllowedRoles = %#v, want %#v", got, []string{"viewer"})
@@ -400,7 +400,7 @@ func TestProviderServerExecute(t *testing.T) {
 			name:       "success",
 			router:     stubRouter,
 			wantStatus: http.StatusOK,
-			wantBody:   `{"operation":"test_op","subject_id":"user:user-123","subject_kind":"user","subject_email":"ada@example.com","agent_subject_id":"user:user-456","agent_external_type":"github_identity","agent_external_id":"user:12345678","credential_mode":"user","credential_subject_id":"user:user-123","access_policy":"roadmap","access_role":"admin","host_base_url":"https://gestalt.example.test","idempotency_key":"tool-call-123"}`,
+			wantBody:   `{"operation":"test_op","subject_id":"user:user-123","subject_kind":"user","subject_email":"ada@example.com","agent_subject_id":"user:user-456","agent_external_type":"github_identity","agent_external_id":"user:12345678","credential_mode":"subject","credential_subject_id":"user:user-123","access_policy":"roadmap","access_role":"admin","host_base_url":"https://gestalt.example.test","idempotency_key":"tool-call-123"}`,
 			request: &proto.ExecuteRequest{
 				Operation: "test_op",
 				Params: func() *structpb.Struct {
@@ -423,7 +423,7 @@ func TestProviderServerExecute(t *testing.T) {
 						Id:   "user:12345678",
 					},
 					Credential: &proto.CredentialContext{
-						Mode:      "user",
+						Mode:      "subject",
 						SubjectId: "user:user-123",
 					},
 					Access: &proto.AccessContext{

--- a/sdk/go/workflow_builders_test.go
+++ b/sdk/go/workflow_builders_test.go
@@ -114,7 +114,7 @@ func TestNewBoundWorkflowPluginTargetUsesNativeInput(t *testing.T) {
 			}{Channel: "C123"},
 			Connection:     "workspace",
 			Instance:       "T123",
-			CredentialMode: "user",
+			CredentialMode: "subject",
 		},
 	})
 	if err != nil {

--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -36,6 +36,7 @@ import type { Schema } from "./schema.ts";
 export type ConnectionMode =
   | "unspecified"
   | "none"
+  | "subject"
   | "user";
 
 /**
@@ -512,6 +513,8 @@ export function connectionModeToProtoValue(mode: ConnectionMode): number {
   switch (mode) {
     case "none":
       return 1;
+    case "subject":
+      return 2;
     case "user":
       return 2;
     case "unspecified":

--- a/sdk/typescript/tests/agent.transport.test.ts
+++ b/sdk/typescript/tests/agent.transport.test.ts
@@ -275,7 +275,7 @@ test("AgentHost executes tools through the configured unix socket", async () => 
             connectionId: "vertex-ai",
             connection: input.connection,
             instance: input.instance,
-            mode: "user",
+            mode: "subject",
             headers: {
               authorization: "Bearer token",
             },

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -325,7 +325,7 @@ test("buildProviderBinary compiles a runnable plugin provider executable", async
               authSource: "api_token",
             }),
             credential: create(CredentialContextSchema, {
-              mode: "user",
+              mode: "subject",
               subjectId: "user:user-123",
             }),
             access: create(AccessContextSchema, {
@@ -342,7 +342,7 @@ test("buildProviderBinary compiles a runnable plugin provider executable", async
         configuredRegion: "use1",
         subjectId: "user:user-123",
         subjectEmail: "",
-        credentialMode: "user",
+        credentialMode: "subject",
         accessPolicy: "sample_policy",
         accessRole: "admin",
         invocationToken: "",
@@ -387,7 +387,7 @@ test("buildProviderBinary compiles a runnable plugin provider executable", async
               kind: "user",
             }),
             credential: create(CredentialContextSchema, {
-              mode: "user",
+              mode: "subject",
             }),
             access: create(AccessContextSchema, {
               policy: "sample_policy",
@@ -403,7 +403,7 @@ test("buildProviderBinary compiles a runnable plugin provider executable", async
       expect(sessionOperation?.id).toBe("session-hello");
       expect(sessionOperation?.allowedRoles).toEqual(["viewer", "admin"]);
       expect(sessionOperation?.title).toBe(
-        `Session Hello ${label} user:user-123 user viewer`,
+        `Session Hello ${label} user:user-123 subject viewer`,
       );
     } finally {
       if (child) {

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -671,7 +671,7 @@ test("integration provider service exposes metadata, configure, execute, and ses
           email: "ada@example.com",
         }),
         credential: create(CredentialContextSchema, {
-          mode: "user",
+          mode: "subject",
           subjectId: "user:user-123",
         }),
         access: create(AccessContextSchema, {
@@ -690,7 +690,7 @@ test("integration provider service exposes metadata, configure, execute, and ses
     configuredRegion: "use1",
     subjectId: "user:user-123",
     subjectEmail: "ada@example.com",
-    credentialMode: "user",
+    credentialMode: "subject",
     accessPolicy: "sample_policy",
     accessRole: "admin",
     invocationToken: "invocation-token-123",
@@ -709,7 +709,7 @@ test("integration provider service exposes metadata, configure, execute, and ses
           kind: "user",
         }),
         credential: create(CredentialContextSchema, {
-          mode: "user",
+          mode: "subject",
         }),
         access: create(AccessContextSchema, {
           policy: "sample_policy",
@@ -727,7 +727,7 @@ test("integration provider service exposes metadata, configure, execute, and ses
     "admin",
   ]);
   expect(sessionCatalog.catalog?.operations[0].title).toBe(
-    "Session Hello ops user:user-123 user viewer",
+    "Session Hello ops user:user-123 subject viewer",
   );
 
   const postConnect = await (service.postConnect as any)(


### PR DESCRIPTION
## Summary
- make `subject` the canonical connection and credential mode while accepting legacy `user` as an alias
- normalize connection mode values across gestaltd provider manifests, config, runtime grant paths, and SDK boundaries
- update provider docs and examples to describe subject-scoped credentials and remove duplicate external-credentials implementation detail

## Tests
- `go test ./core ./services/invocation ./services/plugins/... ./internal/config ./services/workflows/... ./services/agents/... ./internal/bootstrap ./internal/server ./services/externalcredentials ./internal/daemon ./internal/operator`
- `go test ./...` in `sdk/go`
- `bun run typecheck` in `sdk/typescript`
- `bun test --max-concurrency 1` in `sdk/typescript`
- `npm run typecheck` in `docs`
- `git diff --check`