### PR TITLE
Publish gestaltd CI binary artifacts

### DIFF
--- a/.github/scripts/build-gestaltd-ci-artifact.sh
+++ b/.github/scripts/build-gestaltd-ci-artifact.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_dir="${GESTALTD_SOURCE_DIR:-$(git rev-parse --show-toplevel)}"
+source_dir="$(cd "${source_dir}" && pwd)"
+commit="${GESTALTD_COMMIT:?GESTALTD_COMMIT is required}"
+version="${GESTALTD_VERSION:?GESTALTD_VERSION is required}"
+output_dir="${GESTALTD_OUTPUT_DIR:-${source_dir}/dist/gestaltd-ci}"
+artifact_base_url="${GESTALTD_ARTIFACT_BASE_URL:-}"
+run_id="${GITHUB_RUN_ID:-local}"
+created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [[ ! "${commit}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "GESTALTD_COMMIT must be a full lowercase 40-character commit SHA." >&2
+  exit 1
+fi
+
+if [[ "${output_dir}" != /* ]]; then
+  output_dir="${PWD}/${output_dir}"
+fi
+
+rm -rf "${output_dir}"
+mkdir -p "${output_dir}/build"
+
+(
+  cd "${source_dir}/gestaltd"
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -trimpath \
+    -ldflags "-X main.version=${version}" \
+    -o "${output_dir}/build/gestaltd" \
+    ./cmd/gestaltd
+)
+
+if [[ "$(uname -s)" == "Linux" && "$(uname -m)" == "x86_64" ]]; then
+  version_output="$("${output_dir}/build/gestaltd" version)"
+  if [[ "${version_output}" != "${version}" ]]; then
+    echo "gestaltd version output '${version_output}' did not match expected '${version}'." >&2
+    exit 1
+  fi
+fi
+
+if [[ "${GESTALTD_SKIP_ALPINE_SMOKE:-}" != "1" ]]; then
+  docker run --rm \
+    -v "${output_dir}/build:/build:ro" \
+    alpine:3.23 \
+    /build/gestaltd version > "${output_dir}/alpine-version.txt"
+  alpine_version="$(cat "${output_dir}/alpine-version.txt")"
+  if [[ "${alpine_version}" != "${version}" ]]; then
+    echo "Alpine gestaltd version output '${alpine_version}' did not match expected '${version}'." >&2
+    exit 1
+  fi
+fi
+
+archive="gestaltd-linux-x86_64.tar.gz"
+tar -czf "${output_dir}/${archive}" -C "${output_dir}/build" gestaltd
+(
+  cd "${output_dir}"
+  sha256sum "${archive}" > "${archive}.sha256"
+)
+
+archive_sha256="$(awk '{print $1}' "${output_dir}/${archive}.sha256")"
+
+export GESTALTD_METADATA_ARTIFACT_BASE_URL="${artifact_base_url}"
+export GESTALTD_METADATA_ARCHIVE="${archive}"
+export GESTALTD_METADATA_ARCHIVE_SHA256="${archive_sha256}"
+export GESTALTD_METADATA_COMMIT="${commit}"
+export GESTALTD_METADATA_CREATED_AT="${created_at}"
+export GESTALTD_METADATA_OUTPUT="${output_dir}/metadata.json"
+export GESTALTD_METADATA_RUN_ID="${run_id}"
+export GESTALTD_METADATA_VERSION="${version}"
+
+python3 - <<'PY'
+import json
+import os
+
+base_url = os.environ["GESTALTD_METADATA_ARTIFACT_BASE_URL"].rstrip("/")
+archive = os.environ["GESTALTD_METADATA_ARCHIVE"]
+archive_url = f"{base_url}/{archive}" if base_url else None
+
+metadata = {
+    "schema": "gestaltd-ci-artifact",
+    "schemaVersion": 1,
+    "repository": "github.com/valon-technologies/gestalt",
+    "commit": os.environ["GESTALTD_METADATA_COMMIT"],
+    "version": os.environ["GESTALTD_METADATA_VERSION"],
+    "createdAt": os.environ["GESTALTD_METADATA_CREATED_AT"],
+    "createdBy": "github-actions",
+    "githubRunID": os.environ["GESTALTD_METADATA_RUN_ID"],
+    "artifacts": {
+        "linux/amd64": {
+            "path": archive,
+            "sha256": os.environ["GESTALTD_METADATA_ARCHIVE_SHA256"],
+            "url": archive_url,
+            "cgoEnabled": False,
+        },
+    },
+}
+
+with open(os.environ["GESTALTD_METADATA_OUTPUT"], "w", encoding="utf-8") as f:
+    json.dump(metadata, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+
+find "${output_dir}" -maxdepth 1 -type f -print | sort

--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -7,13 +7,67 @@ on:
   pull_request:
 
   workflow_dispatch:
+    inputs:
+      gestalt_ref:
+        description: Optional full commit SHA to validate, build, and publish as a CI artifact.
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 jobs:
+  resolve-ref:
+    name: Resolve Build Ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      publish: ${{ steps.resolve.outputs.publish }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve commit
+        id: resolve
+        env:
+          REQUESTED_GESTALT_REF: ${{ github.event.inputs.gestalt_ref || '' }}
+        run: |
+          set -euo pipefail
+
+          requested_ref="${REQUESTED_GESTALT_REF}"
+          if [[ -n "${requested_ref}" && ! "${requested_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "gestalt_ref must be a full lowercase 40-character commit SHA." >&2
+            exit 1
+          fi
+
+          ref="${requested_ref:-${GITHUB_SHA}}"
+          sha="$(git rev-parse "${ref}^{commit}")"
+          if [[ ! "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Resolved ref '${ref}' to invalid commit '${sha}'." >&2
+            exit 1
+          fi
+
+          publish="false"
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            publish="true"
+          fi
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${requested_ref}" ]]; then
+            publish="true"
+          fi
+
+          {
+            echo "sha=${sha}"
+            echo "publish=${publish}"
+            echo "version=0.0.0-ci.${GITHUB_RUN_NUMBER}+g${sha:0:12}"
+          } >> "${GITHUB_OUTPUT}"
+
   lint:
     name: Go Lint & Vet
+    needs: resolve-ref
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.gestalt_ref == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -22,6 +76,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -60,6 +116,8 @@ jobs:
 
   test:
     name: Go Tests
+    needs: resolve-ref
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.gestalt_ref == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -68,6 +126,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -83,6 +143,8 @@ jobs:
 
   coverage:
     name: Go Coverage
+    needs: resolve-ref
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.gestalt_ref == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -91,6 +153,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -109,7 +173,8 @@ jobs:
 
   race:
     name: Go Race Tests
-    if: ${{ github.event_name != 'pull_request' }}
+    needs: resolve-ref
+    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || github.event.inputs.gestalt_ref == '') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
@@ -118,6 +183,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -130,6 +197,8 @@ jobs:
 
   docs-build:
     name: Docs Build
+    needs: resolve-ref
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.gestalt_ref == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -139,6 +208,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
           fetch-depth: 0
 
       - name: Set up Node.js
@@ -174,10 +244,14 @@ jobs:
 
   helm-validate:
     name: Helm Chart Validation
+    needs: resolve-ref
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.gestalt_ref == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
@@ -245,10 +319,14 @@ jobs:
 
   docker-build:
     name: Docker Image Build
+    needs: resolve-ref
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.gestalt_ref == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
 
       - name: Build static image
         env:
@@ -271,3 +349,147 @@ jobs:
             --build-arg GESTALT_VERSION=ci \
             --tag gestaltd:ci-alpine \
             .
+
+  publish-ci-artifact:
+    name: Publish CI Artifact
+    needs: [resolve-ref, lint, test, coverage, race, docs-build, helm-validate, docker-build]
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.resolve-ref.outputs.publish == 'true' && vars.GESTALTD_CI_ARTIFACT_PUBLISH_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: workflow
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
+          path: source
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: source/gestaltd/go.mod
+          cache-dependency-path: source/gestaltd/go.sum
+
+      - name: Validate artifact configuration
+        env:
+          GESTALTD_CI_ARTIFACT_BUCKET: ${{ vars.GESTALTD_CI_ARTIFACT_BUCKET }}
+          GESTALTD_CI_ARTIFACT_BASE_URL: ${{ vars.GESTALTD_CI_ARTIFACT_BASE_URL }}
+        run: |
+          set -euo pipefail
+          : "${GESTALTD_CI_ARTIFACT_BUCKET:?GESTALTD_CI_ARTIFACT_BUCKET repository variable is required}"
+          : "${GESTALTD_CI_ARTIFACT_BASE_URL:?GESTALTD_CI_ARTIFACT_BASE_URL repository variable is required}"
+
+      - name: Build CI artifact
+        env:
+          GESTALTD_ARTIFACT_BASE_URL: ${{ vars.GESTALTD_CI_ARTIFACT_BASE_URL }}/${{ needs.resolve-ref.outputs.sha }}
+          GESTALTD_COMMIT: ${{ needs.resolve-ref.outputs.sha }}
+          GESTALTD_OUTPUT_DIR: ${{ github.workspace }}/dist/gestaltd-ci
+          GESTALTD_SOURCE_DIR: ${{ github.workspace }}/source
+          GESTALTD_VERSION: ${{ needs.resolve-ref.outputs.version }}
+        run: workflow/.github/scripts/build-gestaltd-ci-artifact.sh
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ vars.GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+
+      - name: Upload immutable artifact
+        env:
+          GESTALTD_CI_ARTIFACT_BUCKET: ${{ vars.GESTALTD_CI_ARTIFACT_BUCKET }}
+          GESTALTD_COMMIT: ${{ needs.resolve-ref.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          artifact_prefix="gs://${GESTALTD_CI_ARTIFACT_BUCKET}/github.com/valon-technologies/gestalt/${GESTALTD_COMMIT}"
+          for artifact in \
+            gestaltd-linux-x86_64.tar.gz \
+            gestaltd-linux-x86_64.tar.gz.sha256 \
+            metadata.json
+          do
+            gcloud storage cp \
+              --if-generation-match=0 \
+              "dist/gestaltd-ci/${artifact}" \
+              "${artifact_prefix}/${artifact}"
+          done
+
+  backfill-ci-artifact:
+    name: Backfill CI Artifact
+    needs: resolve-ref
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gestalt_ref != '' && vars.GESTALTD_CI_ARTIFACT_PUBLISH_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: workflow
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve-ref.outputs.sha }}
+          path: source
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: source/gestaltd/go.mod
+          cache-dependency-path: source/gestaltd/go.sum
+
+      - name: Validate artifact configuration
+        env:
+          GESTALTD_CI_ARTIFACT_BUCKET: ${{ vars.GESTALTD_CI_ARTIFACT_BUCKET }}
+          GESTALTD_CI_ARTIFACT_BASE_URL: ${{ vars.GESTALTD_CI_ARTIFACT_BASE_URL }}
+        run: |
+          set -euo pipefail
+          : "${GESTALTD_CI_ARTIFACT_BUCKET:?GESTALTD_CI_ARTIFACT_BUCKET repository variable is required}"
+          : "${GESTALTD_CI_ARTIFACT_BASE_URL:?GESTALTD_CI_ARTIFACT_BASE_URL repository variable is required}"
+
+      - name: Build CI artifact
+        env:
+          GESTALTD_ARTIFACT_BASE_URL: ${{ vars.GESTALTD_CI_ARTIFACT_BASE_URL }}/${{ needs.resolve-ref.outputs.sha }}
+          GESTALTD_COMMIT: ${{ needs.resolve-ref.outputs.sha }}
+          GESTALTD_OUTPUT_DIR: ${{ github.workspace }}/dist/gestaltd-ci
+          GESTALTD_SOURCE_DIR: ${{ github.workspace }}/source
+          GESTALTD_VERSION: ${{ needs.resolve-ref.outputs.version }}
+        run: workflow/.github/scripts/build-gestaltd-ci-artifact.sh
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ vars.GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GESTALTD_CI_GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+
+      - name: Upload immutable artifact
+        env:
+          GESTALTD_CI_ARTIFACT_BUCKET: ${{ vars.GESTALTD_CI_ARTIFACT_BUCKET }}
+          GESTALTD_COMMIT: ${{ needs.resolve-ref.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          artifact_prefix="gs://${GESTALTD_CI_ARTIFACT_BUCKET}/github.com/valon-technologies/gestalt/${GESTALTD_COMMIT}"
+          for artifact in \
+            gestaltd-linux-x86_64.tar.gz \
+            gestaltd-linux-x86_64.tar.gz.sha256 \
+            metadata.json
+          do
+            gcloud storage cp \
+              --if-generation-match=0 \
+              "dist/gestaltd-ci/${artifact}" \
+              "${artifact_prefix}/${artifact}"
+          done

--- a/gestaltd/terraform/README.md
+++ b/gestaltd/terraform/README.md
@@ -1,15 +1,18 @@
 # gestaltd Artifact Infrastructure
 
-This Terraform root owns the GCP resources used by the `gestaltd` release
-workflow to publish Helm charts.
+This Terraform root owns the GCP resources used by `gestaltd` workflows to
+publish Helm charts and immutable CI binary artifacts.
 
 It creates:
 
 - deployer IAM grants required by this Terraform root
 - Artifact Registry Docker repository for OCI Helm charts
+- public-read GCS bucket for commit-addressed `gestaltd` CI binary artifacts
 - GitHub Actions Workload Identity Pool and provider
 - chart publisher service account
+- CI binary publisher service account
 - Artifact Registry writer access for the publisher service account
+- GCS object-create access for the CI binary publisher service account
 - Artifact Registry reader access for configured `valon-tools` Terraform
   service accounts
 
@@ -19,9 +22,35 @@ values into the `valon-technologies/gestalt` repository variables:
 ```text
 GESTALTD_ARTIFACT_REGISTRY_HOST
 GESTALTD_CHART_REPOSITORY
+GESTALTD_CI_ARTIFACT_BASE_URL
+GESTALTD_CI_ARTIFACT_BUCKET
+GESTALTD_CI_GCP_SERVICE_ACCOUNT
 GESTALTD_GCP_SERVICE_ACCOUNT
 GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER
 ```
+
+CI binary artifacts are published under:
+
+```text
+${GESTALTD_CI_ARTIFACT_BASE_URL}/<40-character-commit-sha>/gestaltd-linux-x86_64.tar.gz
+${GESTALTD_CI_ARTIFACT_BASE_URL}/<40-character-commit-sha>/gestaltd-linux-x86_64.tar.gz.sha256
+${GESTALTD_CI_ARTIFACT_BASE_URL}/<40-character-commit-sha>/metadata.json
+```
+
+Consumers should pin full commit SHA paths. Mutable marker files, if added
+later, should remain informational only.
+
+The `Build Gestaltd` workflow publishes CI binary artifacts after its validation
+jobs pass on `main`. To backfill an older commit, run that workflow manually
+with `gestalt_ref` set to the full commit SHA. Manual backfill runs the
+build/package/upload contract against that resolved SHA and loads the packaging
+script from the current workflow checkout, so older commits can be backfilled
+even if they predate current lint or docs workflow helpers.
+
+Set `GESTALTD_CI_ARTIFACT_PUBLISH_ENABLED=true` only after the bucket, publisher
+service account, Workload Identity binding, and repository variables are ready.
+Until then, the publish job is skipped and the existing validation jobs continue
+to run normally.
 
 `valon-tools` environments should consume the chart repository location as input
 variables instead of creating their own per-environment chart repository.

--- a/gestaltd/terraform/main.tf
+++ b/gestaltd/terraform/main.tf
@@ -29,7 +29,9 @@ locals {
 
   artifact_registry_host     = "${var.region}-docker.pkg.dev"
   chart_repository           = "oci://${local.artifact_registry_host}/${var.project_id}/${var.artifact_registry_repository_id}"
+  ci_artifact_base_url       = "https://storage.googleapis.com/${google_storage_bucket.gestaltd_ci_binaries.name}/github.com/valon-technologies/gestalt"
   deployer_member            = "serviceAccount:${var.deployer_service_account_id}@${var.project_id}.iam.gserviceaccount.com"
+  github_ref_condition       = "assertion.ref.startsWith(\"${var.github_ref_prefix}\") || assertion.ref == \"${var.ci_binary_github_ref}\""
   workload_identity_provider = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.gestaltd_github_actions.workload_identity_pool_provider_id}"
 }
 
@@ -38,6 +40,7 @@ resource "google_project_iam_member" "deployer_permissions" {
     "roles/artifactregistry.admin",
     "roles/iam.workloadIdentityPoolAdmin",
     "roles/serviceusage.serviceUsageAdmin",
+    "roles/storage.admin",
   ])
 
   project = var.project_id
@@ -50,6 +53,7 @@ resource "google_project_service" "required" {
     "artifactregistry.googleapis.com",
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
+    "storage.googleapis.com",
     "sts.googleapis.com",
   ])
 
@@ -76,11 +80,39 @@ resource "google_artifact_registry_repository" "gestaltd_charts" {
   ]
 }
 
+resource "google_storage_bucket" "gestaltd_ci_binaries" {
+  project                     = var.project_id
+  name                        = var.ci_binary_bucket_name
+  location                    = var.ci_binary_bucket_location
+  uniform_bucket_level_access = true
+  force_destroy               = false
+  labels                      = local.labels
+
+  versioning {
+    enabled = true
+  }
+
+  depends_on = [
+    google_project_service.required,
+  ]
+}
+
 resource "google_service_account" "chart_publisher" {
   project      = var.project_id
   account_id   = var.chart_publisher_service_account_id
   display_name = "gestaltd chart publisher"
   description  = "Publishes gestaltd Helm charts to Artifact Registry from GitHub Actions."
+
+  depends_on = [
+    google_project_service.required,
+  ]
+}
+
+resource "google_service_account" "ci_binary_publisher" {
+  project      = var.project_id
+  account_id   = var.ci_binary_publisher_service_account_id
+  display_name = "gestaltd CI binary publisher"
+  description  = "Publishes immutable gestaltd CI binary artifacts to GCS from GitHub Actions."
 
   depends_on = [
     google_project_service.required,
@@ -113,7 +145,7 @@ resource "google_iam_workload_identity_pool_provider" "gestaltd_github_actions" 
     "attribute.ref"              = "assertion.ref"
   }
 
-  attribute_condition = "assertion.repository == \"${var.github_repository}\" && assertion.ref.startsWith(\"${var.github_ref_prefix}\")"
+  attribute_condition = "assertion.repository == \"${var.github_repository}\" && (${local.github_ref_condition})"
 
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"
@@ -124,6 +156,24 @@ resource "google_service_account_iam_member" "github_actions_workload_identity_u
   service_account_id = google_service_account.chart_publisher.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.repository/${var.github_repository}"
+
+  condition {
+    title       = "GestaltdReleaseTags"
+    description = "Only gestaltd release tag workflows may impersonate the chart publisher."
+    expression  = "attribute.ref.startsWith(\"${var.github_ref_prefix}\")"
+  }
+}
+
+resource "google_service_account_iam_member" "ci_binary_github_actions_workload_identity_user" {
+  service_account_id = google_service_account.ci_binary_publisher.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.repository/${var.github_repository}"
+
+  condition {
+    title       = "GestaltdMainBranch"
+    description = "Only the main branch workflow may impersonate the CI binary publisher."
+    expression  = "attribute.ref == \"${var.ci_binary_github_ref}\""
+  }
 }
 
 resource "google_artifact_registry_repository_iam_member" "chart_publisher" {
@@ -142,4 +192,16 @@ resource "google_artifact_registry_repository_iam_member" "chart_readers" {
   repository = google_artifact_registry_repository.gestaltd_charts.repository_id
   role       = "roles/artifactregistry.reader"
   member     = "serviceAccount:${each.value}"
+}
+
+resource "google_storage_bucket_iam_member" "ci_binary_publisher" {
+  bucket = google_storage_bucket.gestaltd_ci_binaries.name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.ci_binary_publisher.email}"
+}
+
+resource "google_storage_bucket_iam_member" "ci_binary_public_readers" {
+  bucket = google_storage_bucket.gestaltd_ci_binaries.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
 }

--- a/gestaltd/terraform/outputs.tf
+++ b/gestaltd/terraform/outputs.tf
@@ -3,6 +3,9 @@ output "github_actions_variables" {
   value = {
     GESTALTD_ARTIFACT_REGISTRY_HOST         = local.artifact_registry_host
     GESTALTD_CHART_REPOSITORY               = local.chart_repository
+    GESTALTD_CI_ARTIFACT_BASE_URL           = local.ci_artifact_base_url
+    GESTALTD_CI_ARTIFACT_BUCKET             = google_storage_bucket.gestaltd_ci_binaries.name
+    GESTALTD_CI_GCP_SERVICE_ACCOUNT         = google_service_account.ci_binary_publisher.email
     GESTALTD_GCP_SERVICE_ACCOUNT            = google_service_account.chart_publisher.email
     GESTALTD_GCP_WORKLOAD_IDENTITY_PROVIDER = local.workload_identity_provider
   }
@@ -21,6 +24,21 @@ output "chart_repository" {
 output "chart_publisher_service_account" {
   description = "Service account used by GitHub Actions to publish gestaltd Helm charts."
   value       = google_service_account.chart_publisher.email
+}
+
+output "ci_artifact_base_url" {
+  description = "Base HTTPS URL for immutable gestaltd CI binary artifacts."
+  value       = local.ci_artifact_base_url
+}
+
+output "ci_artifact_bucket" {
+  description = "GCS bucket that stores immutable gestaltd CI binary artifacts."
+  value       = google_storage_bucket.gestaltd_ci_binaries.name
+}
+
+output "ci_binary_publisher_service_account" {
+  description = "Service account used by GitHub Actions to publish gestaltd CI binary artifacts."
+  value       = google_service_account.ci_binary_publisher.email
 }
 
 output "workload_identity_provider" {

--- a/gestaltd/terraform/terraform.tfvars.example
+++ b/gestaltd/terraform/terraform.tfvars.example
@@ -2,3 +2,4 @@ project_id = "<gestaltd artifact GCP project ID>"
 region     = "us-east1"
 
 artifact_registry_repository_id = "gestaltd-charts"
+ci_binary_bucket_name           = "<project>-gestaltd-ci-artifacts"

--- a/gestaltd/terraform/variables.tf
+++ b/gestaltd/terraform/variables.tf
@@ -15,6 +15,18 @@ variable "artifact_registry_repository_id" {
   default     = "gestaltd-charts"
 }
 
+variable "ci_binary_bucket_name" {
+  description = "GCS bucket name for immutable gestaltd CI binary artifacts."
+  type        = string
+  default     = "gitlab-peach-street-gestaltd-ci-artifacts"
+}
+
+variable "ci_binary_bucket_location" {
+  description = "GCS location for immutable gestaltd CI binary artifacts."
+  type        = string
+  default     = "US"
+}
+
 variable "gestaltd_chart_reader_service_accounts" {
   description = "Service account emails allowed to read gestaltd Helm charts from Artifact Registry."
   type        = set(string)
@@ -34,6 +46,12 @@ variable "chart_publisher_service_account_id" {
   description = "Service account ID used by GitHub Actions to publish gestaltd charts."
   type        = string
   default     = "gestaltd-chart-publisher"
+}
+
+variable "ci_binary_publisher_service_account_id" {
+  description = "Service account ID used by GitHub Actions to publish gestaltd CI binary artifacts."
+  type        = string
+  default     = "gestaltd-ci-binary-publisher"
 }
 
 variable "github_actions_workload_identity_pool_id" {
@@ -58,6 +76,12 @@ variable "github_ref_prefix" {
   description = "Git ref prefix allowed to publish gestaltd charts."
   type        = string
   default     = "refs/tags/gestaltd/v"
+}
+
+variable "ci_binary_github_ref" {
+  description = "Exact Git ref allowed to publish gestaltd CI binary artifacts."
+  type        = string
+  default     = "refs/heads/main"
 }
 
 variable "labels" {

--- a/sdk/proto/buf.go.server.gen.yaml
+++ b/sdk/proto/buf.go.server.gen.yaml
@@ -14,7 +14,7 @@ plugins:
       - paths=source_relative
 
   # Go gRPC stubs
-  - remote: buf.build/grpc/go:v1.6.1
+  - remote: buf.build/grpc/go:v1.6.2
     out: ../../gestaltd/internal/gen
     opt:
       - paths=source_relative


### PR DESCRIPTION
## Summary

- Adds a gated `gestaltd` CI artifact publisher behind the existing `Build Gestaltd` validation workflow.
- Adds a backfill interface that validates/builds/publishes an explicit full Gestalt commit SHA, with the packaging script loaded from the current workflow checkout so older commits can be backfilled.
- Adds Terraform-managed GCS storage, publisher identity, public-read artifact URLs, and repository-variable outputs for commit-addressed linux/amd64 binary artifacts.

## Interface Changes

- New/changed interface: `Build Gestaltd` accepts optional `workflow_dispatch` input `gestalt_ref` as a full 40-character commit SHA.
- New/changed interface: CI artifact publishing is enabled only when repo variable `GESTALTD_CI_ARTIFACT_PUBLISH_ENABLED=true`, so the initial landing path does not fail before infra/repo variables exist.
- New/changed interface: CI artifacts publish under `${GESTALTD_CI_ARTIFACT_BASE_URL}/<sha>/gestaltd-linux-x86_64.tar.gz`, with `.sha256` and `metadata.json` alongside it.
- Example usage: run the workflow manually with `gestalt_ref=dec35e9202bf63aa079db5893fd6ab4b6a17f521` to backfill that exact commit.

## Functional/Integration Tests

- Tests added or augmented: CI artifact packaging script verifies the deterministic version string and keeps the Alpine smoke enabled in GitHub Actions.
- Contract boundary covered: workflow ref resolution, older-commit backfill packaging, immutable artifact packaging metadata/checksum, Terraform storage/IAM configuration.
- Commands run: `actionlint .github/workflows/build-gestaltd.yml .github/workflows/deploy-gestaltd-artifacts.yml`; `shellcheck .github/scripts/build-gestaltd-ci-artifact.sh`; `terraform init -backend=false`; `terraform fmt -check`; `terraform validate`; backfill-style package/checksum for `dec35e9202bf63aa079db5893fd6ab4b6a17f521`; backfill-style package/checksum for `0ed12c33c673e5ecc900ac9275845cf0340aa4ad`.

## Test plan

- [x] `actionlint .github/workflows/build-gestaltd.yml .github/workflows/deploy-gestaltd-artifacts.yml`
- [x] `shellcheck .github/scripts/build-gestaltd-ci-artifact.sh`
- [x] `terraform init -backend=false`
- [x] `terraform fmt -check`
- [x] `terraform validate`
- [x] Backfill-style build/package/checksum for current Toolshed API pin with `GESTALTD_SKIP_ALPINE_SMOKE=1`
- [x] Backfill-style build/package/checksum for current Toolshed agent-runtime pin with `GESTALTD_SKIP_ALPINE_SMOKE=1`
- [ ] Alpine smoke via Docker locally; Docker daemon was not running on this machine, so this remains covered by the GitHub Actions publisher path

Follow-up: after this lands and the GCS bucket/repository variables are available, set `GESTALTD_CI_ARTIFACT_PUBLISH_ENABLED=true`, backfill the Valon Tools pins, and merge the Toolshed consumer PR.