### PR TITLE
Add dev docs channel

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -160,6 +160,9 @@ jobs:
       - name: Check SDK API docs publish contract
         run: npm run test:sdk-api-docs
 
+      - name: Fetch main docs source
+        run: git fetch origin main --tags
+
       - name: Build versioned docs smoke site
         run: npm run build:versioned:test
 

--- a/.github/workflows/deploy-gestalt-docs.yml
+++ b/.github/workflows/deploy-gestalt-docs.yml
@@ -89,6 +89,9 @@ jobs:
         working-directory: docs
         run: npm run test:sdk-docs
 
+      - name: Fetch main docs source
+        run: git fetch origin main --tags
+
       - name: Build versioned docs
         working-directory: docs
         run: npm run build:versioned

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -59,11 +59,15 @@ server {
         return 301 /latest/;
     }
 
+    location = /dev {
+        return 301 /dev/;
+    }
+
     location ~ ^(/versions/v[^/]+)$ {
         return 301 $1/;
     }
 
-    location ~ ^(/latest/.+)/$ {
+    location ~ ^(/(dev|latest)/.+)/$ {
         return 301 $1;
     }
 
@@ -71,9 +75,13 @@ server {
         return 301 $1;
     }
 
-    location ~ ^/(latest|versions/v[^/]+)/_next/ {
+    location ~ ^/(dev|latest|versions/v[^/]+)/_next/ {
         add_header Cache-Control "public, max-age=31536000, immutable" always;
         try_files $uri =404;
+    }
+
+    location /dev/ {
+        try_files $uri $uri.html $uri/ =404;
     }
 
     location /latest/ {

--- a/docs/components/VersionPicker.tsx
+++ b/docs/components/VersionPicker.tsx
@@ -3,15 +3,18 @@
 import { useEffect, useMemo, useState } from "react";
 
 type DocsVersion = {
+  development?: boolean;
   label: string;
   pathPrefix: string;
   stable?: boolean;
   tag: string;
+  version?: string;
 };
 
 type VersionsManifest = {
+  development?: DocsVersion & { development: true; version: string };
   latest: DocsVersion & { version: string };
-  versions: DocsVersion[];
+  versions: Array<DocsVersion & { version: string }>;
 };
 
 const currentPrefix = process.env.NEXT_PUBLIC_GESTALT_DOCS_BASE_PATH || "";
@@ -64,6 +67,14 @@ export default function VersionPicker() {
         ...manifest.latest,
         label: `${manifest.latest.label} (${manifest.latest.version})`,
       },
+      ...(manifest.development
+        ? [
+            {
+              ...manifest.development,
+              label: `${manifest.development.label} (${manifest.development.version})`,
+            },
+          ]
+        : []),
       ...manifest.versions,
     ];
   }, [manifest]);

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "build": "npm run build:single && pagefind --site out --output-subdir _pagefind",
     "build:single": "next build --webpack",
     "build:versioned": "node scripts/build-versioned-site.mjs --out out --include-all-gestaltd-tags --latest-policy supported",
-    "build:versioned:test": "node scripts/build-versioned-site.mjs --out out --tag gestaltd/v0.0.1-alpha.24 --latest-tag gestaltd/v0.0.1-alpha.24",
+    "build:versioned:test": "node scripts/build-versioned-site.mjs --out out --latest-only --latest-policy supported",
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "next lint",

--- a/docs/scripts/build-versioned-site.mjs
+++ b/docs/scripts/build-versioned-site.mjs
@@ -19,6 +19,7 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const docsRoot = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(docsRoot, "..");
 const defaultOut = path.join(docsRoot, "out");
+const developmentPathPrefix = "/dev";
 
 const options = parseArgs(process.argv.slice(2));
 const outDir = path.resolve(docsRoot, options.out ?? defaultOut);
@@ -47,6 +48,7 @@ async function main() {
   if (!tags.includes(latestTag)) {
     tags.push(latestTag);
   }
+  await assertDocsTree(options.developmentRef, "development docs ref");
   await assertDocsTrees(tags);
   tags.sort((left, right) => compareTagVersions(right, left));
 
@@ -54,6 +56,7 @@ async function main() {
   await mkdir(outDir, { recursive: true });
 
   const manifest = {
+    development: developmentManifestEntry(),
     latest: manifestEntry(latestTag, "/latest", isStableTag(latestTag), true),
     versions: tags.map((tag) =>
       manifestEntry(tag, `/versions/${versionWithV(tag)}`, isStableTag(tag)),
@@ -64,7 +67,7 @@ async function main() {
     path.join(os.tmpdir(), `gestalt-docs-versioned-${process.pid}-`),
   );
   try {
-    const rootBuild = await createBuildTree(tempRoot, "root", null);
+    const rootBuild = await createBuildTree(tempRoot, "root");
     await runNextBuild(rootBuild, {
       basePath: "",
       label: "Unversioned",
@@ -76,25 +79,38 @@ async function main() {
 
     const targets = [
       {
-        tag: latestTag,
+        basePath: developmentPathPrefix,
+        currentTag: "",
+        label: "Dev (main)",
+        overlayRef: options.developmentRef,
+        repositoryRef: "main",
+      },
+      {
         basePath: "/latest",
+        currentTag: latestTag,
         label: `Latest (${versionWithV(latestTag)})`,
+        overlayRef: latestTag,
+        repositoryRef: latestTag,
       },
       ...tags.map((tag) => ({
-        tag,
         basePath: `/versions/${versionWithV(tag)}`,
+        currentTag: tag,
         label: versionWithV(tag),
+        overlayRef: tag,
+        repositoryRef: tag,
       })),
     ];
 
     for (const target of targets) {
       const name = target.basePath.replace(/\//g, "_").replace(/^_/, "");
-      const buildDir = await createBuildTree(tempRoot, name, target.tag);
+      const buildDir = await createBuildTree(tempRoot, name, {
+        overlayRef: target.overlayRef,
+      });
       await runNextBuild(buildDir, {
         basePath: target.basePath,
         label: target.label,
-        repositoryRef: target.tag,
-        tag: target.tag,
+        repositoryRef: target.repositoryRef,
+        tag: target.currentTag,
       });
       const nestedPrefixOut = path.join(buildDir, "out", target.basePath.slice(1));
       const prefixOut = existsSync(nestedPrefixOut)
@@ -122,7 +138,9 @@ async function main() {
 
 function parseArgs(args) {
   const parsed = {
+    developmentRef: "origin/main",
     includeAll: false,
+    latestOnly: false,
     latestPolicy: "supported",
     latestTag: "",
     out: "",
@@ -134,8 +152,14 @@ function parseArgs(args) {
       case "--include-all-gestaltd-tags":
         parsed.includeAll = true;
         break;
+      case "--development-ref":
+        parsed.developmentRef = needValue(args, ++index, arg);
+        break;
       case "--latest-policy":
         parsed.latestPolicy = needValue(args, ++index, arg);
+        break;
+      case "--latest-only":
+        parsed.latestOnly = true;
         break;
       case "--latest-tag":
         parsed.latestTag = normalizeTag(needValue(args, ++index, arg));
@@ -150,8 +174,10 @@ function parseArgs(args) {
         throw new Error(`unknown option: ${arg}`);
     }
   }
-  if (!parsed.includeAll && parsed.tags.length === 0) {
-    throw new Error("pass --include-all-gestaltd-tags or at least one --tag");
+  if (!parsed.includeAll && !parsed.latestOnly && parsed.tags.length === 0) {
+    throw new Error(
+      "pass --include-all-gestaltd-tags, --latest-only, or at least one --tag",
+    );
   }
   if (!["stable", "supported"].includes(parsed.latestPolicy)) {
     throw new Error("--latest-policy must be stable or supported");
@@ -168,28 +194,32 @@ function needValue(args, index, flag) {
 }
 
 async function selectedTags() {
-  const tags = options.includeAll
-    ? gitOutput(["tag", "--list", "gestaltd/v*"])
-        .split("\n")
-        .filter(Boolean)
-    : [...options.tags];
+  const tags =
+    options.includeAll || options.latestOnly
+      ? gitOutput(["tag", "--list", "gestaltd/v*"])
+          .split("\n")
+          .filter(Boolean)
+      : [...options.tags];
   const normalized = [...new Set(tags.map(normalizeTag))];
   normalized.forEach((tag) => {
     if (!parseTag(tag)) {
       throw new Error(`unsupported gestaltd tag format: ${tag}`);
     }
   });
+  if (options.latestOnly) {
+    const latest =
+      options.latestPolicy === "stable"
+        ? chooseLatestStable(normalized)
+        : chooseLatestSupported(normalized);
+    return latest ? [latest] : [];
+  }
   return normalized;
 }
 
 async function assertDocsTrees(tags) {
   const missing = [];
   for (const tag of tags) {
-    const result = spawnSync("git", ["cat-file", "-e", `${tag}:docs/content`], {
-      cwd: repoRoot,
-      encoding: "utf8",
-    });
-    if (result.status !== 0) {
+    if (!hasDocsContentTree(tag)) {
       missing.push(tag);
     }
   }
@@ -198,6 +228,22 @@ async function assertDocsTrees(tags) {
       `cannot build exact docs snapshots because these tags have no docs/content tree: ${missing.join(", ")}`,
     );
   }
+}
+
+async function assertDocsTree(ref, description) {
+  if (!hasDocsContentTree(ref)) {
+    throw new Error(
+      `cannot build ${description} because ${ref}:docs/content does not exist; fetch the ref or pass --development-ref`,
+    );
+  }
+}
+
+function hasDocsContentTree(ref) {
+  const result = spawnSync("git", ["cat-file", "-e", `${ref}:docs/content`], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  return result.status === 0;
 }
 
 function chooseLatestStable(tags) {
@@ -220,6 +266,17 @@ function manifestEntry(tag, pathPrefix, stable, latest = false) {
     stable,
     tag,
     version,
+  };
+}
+
+function developmentManifestEntry() {
+  return {
+    development: true,
+    label: "Dev",
+    pathPrefix: developmentPathPrefix,
+    stable: false,
+    tag: "",
+    version: "main",
   };
 }
 
@@ -299,7 +356,7 @@ function compareTagVersions(left, right) {
   return 0;
 }
 
-async function createBuildTree(tempRoot, name, tag) {
+async function createBuildTree(tempRoot, name, { overlayRef = "" } = {}) {
   const buildDir = path.join(tempRoot, name);
   await rm(buildDir, { force: true, recursive: true });
   await cp(docsRoot, buildDir, {
@@ -318,20 +375,20 @@ async function createBuildTree(tempRoot, name, tag) {
     path.join(buildDir, "node_modules"),
     "dir",
   );
-  if (tag) {
-    await overlayTaggedDocs(buildDir, tag);
+  if (overlayRef) {
+    await overlayDocsFromRef(buildDir, overlayRef);
   }
   return buildDir;
 }
 
-async function overlayTaggedDocs(buildDir, tag) {
+async function overlayDocsFromRef(buildDir, ref) {
   const archiveRoot = path.join(buildDir, ".tagged-docs");
   const archivePath = path.join(buildDir, ".tagged-docs.tar");
   run("git", [
     "archive",
     "--format=tar",
     `--output=${archivePath}`,
-    tag,
+    ref,
     "docs/content",
     "docs/components",
     "docs/public",
@@ -448,6 +505,8 @@ function shouldPrefixPath(value, prefix) {
   if (
     pathname === prefix ||
     pathname.startsWith(`${prefix}/`) ||
+    pathname === developmentPathPrefix ||
+    pathname.startsWith(`${developmentPathPrefix}/`) ||
     pathname === "/latest" ||
     pathname.startsWith("/latest/") ||
     pathname.startsWith("/versions/")
@@ -475,6 +534,7 @@ function shouldPrefixPath(value, prefix) {
 
 async function assertNoUnversionedDocLinks(finalOut) {
   const versionRoots = [
+    path.join(finalOut, developmentPathPrefix.slice(1)),
     path.join(finalOut, "latest"),
     path.join(finalOut, "versions"),
   ];
@@ -486,7 +546,7 @@ async function assertNoUnversionedDocLinks(finalOut) {
   }
   const bad = [];
   const patterns = [
-    /\b(?:href|src|action)=["']\/(?!latest(?:\/|["'])|versions(?:\/|["'])|api\/|admin(?:\/|["'])|favicon\.svg|fonts\/|install(?:-|\.sh)|mcp(?:\/|["'])|registry(?:\/|["'])|versions\.json|_pagefind\/)/g,
+    /\b(?:href|src|action)=["']\/(?!dev(?:\/|["'])|latest(?:\/|["'])|versions(?:\/|["'])|api\/|admin(?:\/|["'])|favicon\.svg|fonts\/|install(?:-|\.sh)|mcp(?:\/|["'])|registry(?:\/|["'])|versions\.json|_pagefind\/)/g,
   ];
   for (const file of files.filter((candidate) => candidate.endsWith(".html"))) {
     const body = await readFile(file, "utf8");
@@ -549,6 +609,10 @@ function flightHrefValues(text) {
 
 async function versionedOutputRoots(finalOut) {
   const roots = [];
+  const development = path.join(finalOut, developmentPathPrefix.slice(1));
+  if (existsSync(development)) {
+    roots.push({ prefix: developmentPathPrefix, root: development });
+  }
   const latest = path.join(finalOut, "latest");
   if (existsSync(latest)) {
     roots.push({ prefix: "/latest", root: latest });

--- a/docs/scripts/check-nginx-routing.mjs
+++ b/docs/scripts/check-nginx-routing.mjs
@@ -25,8 +25,17 @@ try {
     throw new Error(`could not determine mapped port for ${container}`);
   }
   const baseUrl = `http://127.0.0.1:${port}`;
+  const devAssetPath = findStaticAssetPath("dev/_next/static");
   const latestAssetPath = findStaticAssetPath("latest/_next/static");
   await waitForNginx(baseUrl);
+  const versionsManifest = await readVersionsManifest(
+    `${baseUrl}/versions.json`,
+    "gestaltd.ai",
+  );
+  const exactVersionPrefix = versionsManifest.versions[0]?.pathPrefix;
+  if (!exactVersionPrefix) {
+    throw new Error("/versions.json did not contain any exact versions");
+  }
 
   await assertResponse({
     url: `${baseUrl}/`,
@@ -40,16 +49,54 @@ try {
     status: 301,
     location: "/latest/getting-started",
   });
+  await readVersionsManifest(`${baseUrl}/versions.json`, "gestaltd.ai");
   await assertResponse({
-    url: `${baseUrl}/versions.json`,
+    url: `${baseUrl}/dev`,
+    host: "gestaltd.ai",
+    status: 301,
+    location: "/dev/",
+  });
+  await assertResponse({
+    url: `${baseUrl}/dev/`,
     host: "gestaltd.ai",
     status: 200,
-    json: (body) => {
-      const manifest = JSON.parse(body);
-      if (!manifest.latest?.pathPrefix || !Array.isArray(manifest.versions)) {
-        throw new Error("/versions.json did not contain a versions manifest");
-      }
-    },
+    cacheControlIncludes: "no-cache",
+    includes: "Gestalt",
+    excludes: "registry_shell__",
+  });
+  await assertResponse({
+    url: `${baseUrl}/dev/providers`,
+    host: "gestaltd.ai",
+    status: 200,
+    cacheControlIncludes: "no-cache",
+    includes: "Providers",
+    excludes: "registry_shell__",
+  });
+  await assertResponse({
+    url: `${baseUrl}/dev/providers.txt`,
+    host: "gestaltd.ai",
+    status: 200,
+    cacheControlIncludes: "no-cache",
+    includes: "What Providers Do",
+    excludes: "registry_shell__",
+  });
+  await assertResponse({
+    url: `${baseUrl}${devAssetPath}`,
+    host: "gestaltd.ai",
+    status: 200,
+    cacheControlIncludes: "immutable",
+  });
+  await assertResponse({
+    url: `${baseUrl}/dev/providers/`,
+    host: "gestaltd.ai",
+    status: 301,
+    location: "/dev/providers",
+  });
+  await assertResponse({
+    url: `${baseUrl}/dev/does-not-exist`,
+    host: "gestaltd.ai",
+    status: 404,
+    excludes: "registry_shell__",
   });
   await assertResponse({
     url: `${baseUrl}/latest/`,
@@ -88,17 +135,17 @@ try {
     location: "/latest/getting-started",
   });
   await assertResponse({
-    url: `${baseUrl}/versions/v0.0.1-alpha.24/reference/cli`,
+    url: `${baseUrl}${exactVersionPrefix}/reference/cli`,
     host: "gestaltd.ai",
     status: 200,
     includes: "Server CLI",
     excludes: "registry_shell__",
   });
   await assertResponse({
-    url: `${baseUrl}/versions/v0.0.1-alpha.24/reference/cli/`,
+    url: `${baseUrl}${exactVersionPrefix}/reference/cli/`,
     host: "gestaltd.ai",
     status: 301,
-    location: "/versions/v0.0.1-alpha.24/reference/cli",
+    location: `${exactVersionPrefix}/reference/cli`,
   });
   await assertResponse({
     url: `${baseUrl}/versions/v9.9.9/`,
@@ -164,7 +211,6 @@ async function assertResponse({
   includes,
   excludes,
   location,
-  json,
   cacheControlIncludes,
 }) {
   const response = await httpGet(url, host);
@@ -192,9 +238,25 @@ async function assertResponse({
   if (excludes && body.includes(excludes)) {
     throw new Error(`${host} ${url} unexpectedly included ${excludes}`);
   }
-  if (json) {
-    json(body);
+}
+
+async function readVersionsManifest(url, host) {
+  const response = await httpGet(url, host);
+  if (response.status !== 200) {
+    throw new Error(`${host} ${url} returned ${response.status}, want 200`);
   }
+  const manifest = JSON.parse(response.body);
+  if (!manifest.latest?.pathPrefix || !Array.isArray(manifest.versions)) {
+    throw new Error("/versions.json did not contain a versions manifest");
+  }
+  if (
+    manifest.development?.pathPrefix !== "/dev" ||
+    manifest.development?.version !== "main" ||
+    manifest.development?.development !== true
+  ) {
+    throw new Error("/versions.json did not contain the /dev development channel");
+  }
+  return manifest;
 }
 
 function httpGet(url, host) {

--- a/docs/scripts/check-registry-static.mjs
+++ b/docs/scripts/check-registry-static.mjs
@@ -1,6 +1,6 @@
 import { createServer } from "node:http";
 import { readFile } from "node:fs/promises";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 
 const siteRoot = path.resolve("out");
@@ -53,6 +53,15 @@ await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
 try {
   const { port } = server.address();
   const baseUrl = `http://127.0.0.1:${port}`;
+  const devAssetPath = findStaticAssetPath("dev/_next/static");
+  const versionsManifest = await readVersionsManifest(
+    `${baseUrl}/versions.json`,
+    "gestaltd.ai",
+  );
+  const exactVersionPrefix = versionsManifest.versions[0]?.pathPrefix;
+  if (!exactVersionPrefix) {
+    throw new Error("/versions.json did not contain any exact versions");
+  }
   await assertResponse({
     url: `${baseUrl}/`,
     host: "registry.gestaltd.ai",
@@ -104,6 +113,48 @@ try {
     host: "gestaltd.ai",
     location: "/latest/",
   });
+  await assertRedirect({
+    url: `${baseUrl}/dev`,
+    host: "gestaltd.ai",
+    location: "/dev/",
+  });
+  await assertResponse({
+    url: `${baseUrl}/dev/`,
+    host: "gestaltd.ai",
+    status: 200,
+    includes: "Gestalt",
+    excludes: registryMarker,
+  });
+  await assertResponse({
+    url: `${baseUrl}/dev/providers`,
+    host: "gestaltd.ai",
+    status: 200,
+    includes: "Providers",
+    excludes: registryMarker,
+  });
+  await assertResponse({
+    url: `${baseUrl}/dev/providers.txt`,
+    host: "gestaltd.ai",
+    status: 200,
+    includes: "What Providers Do",
+    excludes: registryMarker,
+  });
+  await assertResponse({
+    url: `${baseUrl}${devAssetPath}`,
+    host: "gestaltd.ai",
+    status: 200,
+  });
+  await assertRedirect({
+    url: `${baseUrl}/dev/providers/`,
+    host: "gestaltd.ai",
+    location: "/dev/providers",
+  });
+  await assertResponse({
+    url: `${baseUrl}/dev/does-not-exist`,
+    host: "gestaltd.ai",
+    status: 404,
+    excludes: registryMarker,
+  });
   await assertResponse({
     url: `${baseUrl}/latest/`,
     host: "gestaltd.ai",
@@ -124,35 +175,28 @@ try {
     location: "/latest/getting-started",
   });
   await assertRedirect({
-    url: `${baseUrl}/versions/v0.0.1-alpha.24`,
+    url: `${baseUrl}${exactVersionPrefix}`,
     host: "gestaltd.ai",
-    location: "/versions/v0.0.1-alpha.24/",
+    location: `${exactVersionPrefix}/`,
   });
   await assertResponse({
-    url: `${baseUrl}/versions/v0.0.1-alpha.24/`,
+    url: `${baseUrl}${exactVersionPrefix}/`,
     host: "gestaltd.ai",
     status: 200,
     includes: "Gestalt",
     excludes: registryMarker,
   });
   await assertResponse({
-    url: `${baseUrl}/versions/v0.0.1-alpha.24/reference/cli`,
+    url: `${baseUrl}${exactVersionPrefix}/reference/cli`,
     host: "gestaltd.ai",
     status: 200,
     includes: "Server CLI",
     excludes: registryMarker,
   });
   await assertRedirect({
-    url: `${baseUrl}/versions/v0.0.1-alpha.24/reference/cli/`,
+    url: `${baseUrl}${exactVersionPrefix}/reference/cli/`,
     host: "gestaltd.ai",
-    location: "/versions/v0.0.1-alpha.24/reference/cli",
-  });
-  await assertResponse({
-    url: `${baseUrl}/versions/v0.0.1-alpha.24/reference/sdk/python`,
-    host: "gestaltd.ai",
-    status: 200,
-    includes: "Python SDK",
-    excludes: registryMarker,
+    location: `${exactVersionPrefix}/reference/cli`,
   });
   await assertResponse({
     url: `${baseUrl}/versions/v9.9.9/`,
@@ -160,12 +204,7 @@ try {
     status: 404,
     excludes: registryMarker,
   });
-  await assertResponse({
-    url: `${baseUrl}/versions.json`,
-    host: "gestaltd.ai",
-    status: 200,
-    includes: "\"versions\"",
-  });
+  await readVersionsManifest(`${baseUrl}/versions.json`, "gestaltd.ai");
   await assertResponse({
     url: `${baseUrl}/api/does-not-exist`,
     host: "gestaltd.ai",
@@ -238,19 +277,26 @@ async function serveDocsHost(pathname, response) {
   if (pathname === "/latest") {
     return redirect(response, "/latest/");
   }
+  if (pathname === "/dev") {
+    return redirect(response, "/dev/");
+  }
   const versionWithoutSlash = pathname.match(/^\/versions\/v[^/]+$/);
   if (versionWithoutSlash) {
     return redirect(response, `${pathname}/`);
   }
-  const latestPageWithSlash = pathname.match(/^(\/latest\/.+)\/$/);
-  if (latestPageWithSlash) {
-    return redirect(response, latestPageWithSlash[1]);
+  const docsPageWithSlash = pathname.match(/^(\/(?:dev|latest)\/.+)\/$/);
+  if (docsPageWithSlash) {
+    return redirect(response, docsPageWithSlash[1]);
   }
   const versionPageWithSlash = pathname.match(/^(\/versions\/v[^/]+\/.+)\/$/);
   if (versionPageWithSlash) {
     return redirect(response, versionPageWithSlash[1]);
   }
-  if (pathname.startsWith("/latest/") || pathname.startsWith("/versions/")) {
+  if (
+    pathname.startsWith("/dev/") ||
+    pathname.startsWith("/latest/") ||
+    pathname.startsWith("/versions/")
+  ) {
     return serveFile(pathname, response, true, null);
   }
   if (pathname === "/registry" || pathname.startsWith("/registry/")) {
@@ -327,7 +373,14 @@ function candidateFiles(pathname) {
   ];
 }
 
-async function assertResponse({ url, host, status, includes, excludes, location }) {
+async function assertResponse({
+  url,
+  host,
+  status,
+  includes,
+  excludes,
+  location,
+}) {
   const response = await fetch(url, {
     headers: { "x-test-host": host },
     redirect: "manual",
@@ -367,4 +420,51 @@ async function assertRedirect({ url, host, location }) {
   if (actualLocation !== location) {
     throw new Error(`${host} ${url} redirected to ${actualLocation}, want ${location}`);
   }
+}
+
+async function readVersionsManifest(url, host) {
+  const response = await fetch(url, {
+    headers: { "x-test-host": host },
+    redirect: "manual",
+  });
+  const body = await response.text();
+  if (response.status !== 200) {
+    throw new Error(`${host} ${url} returned ${response.status}, want 200`);
+  }
+  return assertVersionsManifest(body);
+}
+
+function assertVersionsManifest(body) {
+  const manifest = JSON.parse(body);
+  if (!manifest.latest?.pathPrefix || !Array.isArray(manifest.versions)) {
+    throw new Error("/versions.json did not contain a versions manifest");
+  }
+  if (
+    manifest.development?.pathPrefix !== "/dev" ||
+    manifest.development?.version !== "main" ||
+    manifest.development?.development !== true
+  ) {
+    throw new Error("/versions.json did not contain the /dev development channel");
+  }
+  return manifest;
+}
+
+function findStaticAssetPath(relativeRoot) {
+  const root = path.join(siteRoot, relativeRoot);
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    for (const entry of readdirSync(current)) {
+      const fullPath = path.join(current, entry);
+      const stat = statSync(fullPath);
+      if (stat.isDirectory()) {
+        stack.push(fullPath);
+        continue;
+      }
+      if (/\.(?:css|js)$/.test(entry)) {
+        return `/${path.relative(siteRoot, fullPath).split(path.sep).join("/")}`;
+      }
+    }
+  }
+  throw new Error(`could not find a CSS or JS asset under out/${relativeRoot}`);
 }


### PR DESCRIPTION
## Summary

Adds a moving `/dev` docs channel for main-branch documentation while keeping `/latest` release-backed and `/versions/v...` as exact release snapshots.

## Interface Changes
- New/changed interface: `versions.json` now includes a `development` entry with `pathPrefix: "/dev"`, `version: "main"`, and `development: true`.
- New/changed interface: `/dev/...` routes are served like `/latest/...`, including `/dev` -> `/dev/`, slash canonicalization, no-cache HTML/txt, and immutable `_next/static` assets.
- Example usage: `/dev/providers` serves main-branch provider docs; the version picker shows `Latest (...)`, `Dev (main)`, then exact versions.

## Functional/Integration Tests
- Tests added or augmented: versioned docs build, static docs routing, Nginx docs routing checks.
- Contract boundary covered: generated static export shape, `versions.json` manifest contract, docs host routing, and versioned asset cache behavior.
- Commands run:
  - `node --check docs/scripts/build-versioned-site.mjs && node --check docs/scripts/check-registry-static.mjs && node --check docs/scripts/check-nginx-routing.mjs`
  - `git diff --check`
  - `npm ci`
  - `npm run build:versioned:test`
  - `npm run test:registry`
  - `npm run typecheck`
  - `npm run test:nginx-routing` attempted locally, but Docker daemon was unavailable: `failed to connect to the docker API at unix:///Users/hugh/.docker/run/docker.sock`

## Follow-up
- After this merges, tag current main as `gestaltd/v0.0.1`, verify release/docs deploy, then purge old `gestaltd/v0.0.1-alpha*` GitHub releases/tags, Docker Hub tags, and Helm chart artifacts.