### PR TITLE
docs: update secrets provider page

### DIFF
--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -1,23 +1,17 @@
-import { Tabs } from 'nextra/components'
+import { Callout, Tabs } from 'nextra/components'
 
 # Secret
+
+<Callout type="warning">
+  **Alpha**. Secrets are under active development and not yet stable. Breaking
+  changes may happen between releases without warning. Feedback and bug reports
+  are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
+</Callout>
 
 Secrets providers resolve structured secret refs before the rest of the server
 starts. That lets provider config, OAuth app secrets, DSNs, and other sensitive
 values stay out of the main YAML file while still being injected into the final
 runtime config.
-
-## Built-in vs external secret managers
-
-Two simple secret managers are built into `gestaltd`:
-
-| Provider | How it works |
-| --- | --- |
-| `env` | Reads secrets from environment variables |
-| `file` | Reads secrets from files in a configured directory |
-
-Cloud or vault-backed secret managers are external providers published from
-[`valon-technologies/gestalt-providers/secrets`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets).
 
 ## Configuring built-in providers
 
@@ -64,18 +58,6 @@ providers:
 
 The configured provider resolves each structured secret ref before any auth
 provider, plugin provider, or datastore provider receives its config.
-
-## First-party external secret providers
-
-| Provider |
-| --- |
-| [`github.com/valon-technologies/gestalt-providers/secrets/aws`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/aws) |
-| [`github.com/valon-technologies/gestalt-providers/secrets/azure`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/azure) |
-| [`github.com/valon-technologies/gestalt-providers/secrets/google`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/google) |
-| [`github.com/valon-technologies/gestalt-providers/secrets/vault`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/vault) |
-
-See each provider directory for its config schema and backend-specific settings.
-
 
 ## Building your own secrets provider
 
@@ -226,16 +208,6 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
     ```
   </Tabs.Tab>
 </Tabs>
-
-### Deploying the provider
-
-Reference a custom secrets provider in `providers.secrets` with the same config
-shape shown in
-[Configuring external secret providers](/providers/secrets#configuring-external-secret-providers).
-The built-in `env` and `file` providers are documented in
-[Configuring built-in providers](/providers/secrets#configuring-built-in-providers),
-and the first-party cloud and vault providers are listed in
-[First-party external secret providers](/providers/secrets#first-party-external-secret-providers).
 
 ## What to read next
 


### PR DESCRIPTION
## Summary
- add the alpha warning callout to the secrets provider docs
- remove the built-in vs external managers, first-party external providers, and deploy provider sections

## Test
- npm run build:single