### PR TITLE
Align server Buf gRPC plugin pin

### DIFF
--- a/sdk/proto/buf.go.server.gen.yaml
+++ b/sdk/proto/buf.go.server.gen.yaml
@@ -14,7 +14,7 @@ plugins:
       - paths=source_relative
 
   # Go gRPC stubs
-  - remote: buf.build/grpc/go:v1.6.2
+  - remote: buf.build/grpc/go:v1.6.1
     out: ../../gestaltd/internal/gen
     opt:
       - paths=source_relative


### PR DESCRIPTION
## Summary
- pin the server Buf gRPC plugin to v1.6.1 to match the checked-in gestaltd generated bindings
- fixes the main Build Gestaltd generated-bindings failure after #1952 squash-merged the v1.6.2 template without regenerated server files

## Validation
- `buf generate --template buf.go.server.gen.yaml`
- `git diff --exit-code -- gestaltd/internal/gen/v1/*.pb.go gestaltd/internal/gen/v1/*_grpc.pb.go`
- `git diff --check`