### PR TITLE
Pin gestaltd gRPC generator to checked-in bindings

### DIFF
--- a/sdk/proto/buf.go.server.gen.yaml
+++ b/sdk/proto/buf.go.server.gen.yaml
@@ -14,7 +14,7 @@ plugins:
       - paths=source_relative
 
   # Go gRPC stubs
-  - remote: buf.build/grpc/go:v1.6.1
+  - remote: buf.build/grpc/go:v1.6.2
     out: ../../gestaltd/internal/gen
     opt:
       - paths=source_relative


### PR DESCRIPTION
## Summary
- Pin the gestaltd server Buf gRPC plugin to `buf.build/grpc/go:v1.6.2`.
- Keep the generator config aligned with the checked-in v1.6.2-generated gRPC bindings currently on `main`.

## Test plan
- [x] `git diff --check`
- [ ] CI `Verify checked-in generated bindings`