### PR TITLE
Recommend source-built UI bundles in docs

### DIFF
--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -39,6 +39,7 @@ workspace-review/
   ui/
     manifest.yaml
     package.json
+    package-lock.json
     src/
       app.tsx
 ```
@@ -63,11 +64,12 @@ spec:
     path: ../ui/manifest.yaml
 ```
 
-The UI bundle produces static assets. A source UI manifest can declare a
-`build` command and `output` directory, so the generated `out/` or `dist/`
-directory does not need to be checked in. Route rules are required when the
-mounted plugin binds an `authorizationPolicy`. For UI package details, see
-[Providers > UI](/providers/ui).
+The UI bundle should be authored from source. Check in the UI source and
+dependency lockfile, declare a `build` command and `output` directory, and leave
+the generated `out/` or `dist/` directory out of source control. Gestalt builds
+the static assets during preparation and serves the prepared output at runtime.
+Route rules are required when the mounted plugin binds an `authorizationPolicy`.
+For UI package details, see [Providers > UI](/providers/ui).
 
 ```yaml
 kind: ui
@@ -83,6 +85,7 @@ build:
   output: out
   inputs:
     - package.json
+    - package-lock.json
     - src
 spec:
   routes:
@@ -806,7 +809,9 @@ export async function saveItem(item) {
 ```
 
 Use [Providers > UI](/providers/ui) for UI bundle configuration and route
-authorization rules.
+authorization rules. Source-built UI packages are the recommended shape for
+new applications; generated static output is prepared by Gestalt and should not
+normally be checked in.
 
 ## Local Development
 

--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -71,6 +71,13 @@ the static assets during preparation and serves the prepared output at runtime.
 Route rules are required when the mounted plugin binds an `authorizationPolicy`.
 For UI package details, see [Providers > UI](/providers/ui).
 
+<Callout type="info">
+  Source-built UI packages are the recommended shape for new applications, but
+  the workflow is still alpha. Current manifests need explicit build commands,
+  output paths, and build tools in the preparation environment; improving those
+  ergonomics is on the radar.
+</Callout>
+
 ```yaml
 kind: ui
 source: github.com/acme/ui/workspace-review

--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -45,9 +45,13 @@ Public UI bundles are configured through the `providers.ui` map.
 
 - Omit `providers.ui` to run headless with no public UI bundles.
 - Add `ui.<name>` entries with `source` and explicit `path` fields to mount static SPAs under public URL prefixes.
-- UI bundles serve built static assets from `spec.assetRoot`, commonly `out`,
-  `dist`, or `build`. Gestalt does not serve frontend source directories
-  because it does not own each project's build lifecycle.
+- New custom UI bundles should usually check in frontend source and declare
+  top-level `build` in the UI manifest. Gestalt prepares the generated
+  `out`, `dist`, or `build` directory, records it as `spec.assetRoot`, and
+  serves those static assets.
+- Gestalt does not serve frontend source directories at runtime. `serve --locked`
+  only serves prepared assets, so build tools are needed during lock, sync, dev,
+  or release preparation when the configured UI source declares `build`.
 - UI bundles use the normal `/api/v1` and `/mcp` surfaces; there is no separate plugin-local browser route surface.
 
 The built-in admin UI at `/admin` remains available regardless. See

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -495,9 +495,9 @@ packaging.
 
 #### Source UI builds
 
-Source UI manifests may define top-level `build`. Gestalt runs it before
-source-manifest preparation, which lets UI packages generate static assets
-without checking built files into source control. The environment running
+Source UI manifests should normally define top-level `build`. Gestalt runs it
+before source-manifest preparation, which lets UI packages generate static
+assets without checking built files into source control. The environment running
 `gestaltd lock`, `gestaltd sync --locked`, provider dev, or
 `gestaltd provider release` must have the command's build tools available.
 `gestaltd serve --locked` only serves prepared static assets.
@@ -515,6 +515,7 @@ build:
   output: ui/out
   inputs:
     - ui/package.json
+    - ui/package-lock.json
     - ui/src
 spec:
   routes:

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -19,6 +19,14 @@ for simple prebuilt bundles, but source-built UI packages are the recommended
 authoring model. The built-in admin UI at `/admin` remains available regardless
 of whether public UI bundles are configured.
 
+<Callout type="info">
+  Source-built UI packages are still part of the alpha UI surface. They are the
+  recommended path for new custom UIs, but the ergonomics are not final: today
+  you must declare the build command, output directory, and preparation
+  environment build tools explicitly. Smoother build-tool detection and
+  packaging workflows are on the radar for future releases.
+</Callout>
+
 ## How UI providers work
 
 Unlike executable providers, a UI provider is served from a static asset root.

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -8,18 +8,27 @@ import { Callout, Tabs } from 'nextra/components'
   are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
 </Callout>
 
-UI providers are static asset bundles. Gestalt serves each configured
-bundle either directly from `providers.ui.<name>.path` or via
-`plugins.<name>.ui.path`. The built-in admin UI at `/admin` remains available
-regardless of whether public UI bundles are configured.
+UI providers are served as static asset bundles. For new custom UIs, prefer
+checking in the frontend source and declaring a top-level `build` command in the
+UI manifest. Gestalt runs that command during preparation, records the generated
+static output in the prepared manifest, and serves the prepared assets from
+`providers.ui.<name>.path` or `plugins.<name>.ui.path`.
+
+Checking in an already-built `out/`, `dist/`, or `build/` directory still works
+for simple prebuilt bundles, but source-built UI packages are the recommended
+authoring model. The built-in admin UI at `/admin` remains available regardless
+of whether public UI bundles are configured.
 
 ## How UI providers work
 
-Unlike executable providers, a UI provider is just a packaged asset root.
-`gestaltd` resolves the bundle during `gestaltd lock`, prepares it during
-`gestaltd sync --locked`, and then
-serves the pinned assets from the configured public path prefix when the server
-starts.
+Unlike executable providers, a UI provider is served from a static asset root.
+When a source UI manifest declares `build`, `gestaltd lock`,
+`gestaltd sync --locked`, `gestaltd provider dev`, and
+`gestaltd provider release` run the build command before preparing or packaging
+the assets. Prepared and released UI manifests contain `spec.assetRoot` and do
+not retain the source-only `build` block. `gestaltd serve --locked` does not run
+frontend builds; it only serves the prepared assets from the configured public
+path prefix.
 
 ## How UI routes use authorization
 
@@ -133,10 +142,17 @@ That writes `gestalt.lock.json` and prepares the bundle under `.gestaltd/`.
 Afterward, `gestaltd serve --locked` serves the prepared assets from the
 configured path prefix.
 
-When a source UI manifest declares `build`, `gestaltd lock` and
-`gestaltd sync --locked` may need the build tool named by `build.command`
-available in the preparation environment. `gestaltd serve --locked` does not
-run UI builds; it serves only the prepared static assets.
+When a source UI manifest declares `build`, the environment that prepares the
+bundle must have the build tools named by `build.command`. The production
+`serve --locked` environment does not.
+
+| Workflow | Needs frontend build tools? |
+| --- | --- |
+| `gestaltd lock` or `gestaltd sync --locked` against source UI packages | Yes |
+| `gestaltd provider dev` against source UI packages | Yes |
+| `gestaltd provider release` from source UI packages | Yes |
+| `gestaltd sync --locked` for already-released UI packages | No |
+| `gestaltd serve --locked` | No |
 
 ## The admin UI
 
@@ -156,14 +172,30 @@ the built-in admin UI continue using the server-wide auth provider.
 
 ## Building your own UI bundle
 
+For new UI bundles, check in source files and a dependency lockfile, then ignore
+the generated output directory:
+
+```text
+ui/
+  manifest.yaml
+  package.json
+  package-lock.json
+  src/
+    app.tsx
+```
+
+The manifest's top-level `build` block tells Gestalt how to turn that source
+tree into static files. Use `spec.assetRoot` without `build` only when the
+static asset directory is intentionally checked in or generated outside of
+Gestalt's preparation flow.
+
 ### Manifest
 
-Released UI manifests declare `spec.assetRoot`, which points to the directory
-containing built static assets. Source UI manifests may declare either
-`spec.assetRoot` when the static assets are checked in, or top-level `build`
-with `output` when Gestalt should generate the static assets during lock, sync,
-dev, or release preparation. The source field identifies the provider in the
-registry.
+Source UI manifests should normally declare top-level `build` with an `output`
+directory. Gestalt uses that output as the asset root during lock, sync, dev, or
+release preparation. Released UI manifests declare `spec.assetRoot`, which
+points to the directory containing built static assets. The source field
+identifies the provider in the registry.
 
 ```yaml
 kind: ui
@@ -200,11 +232,11 @@ For released or prepared manifests, `spec.assetRoot` is required and Gestalt
 strips the top-level `build` block after generating the assets. If a source
 manifest sets both `spec.assetRoot` and `build.output`, the values must match.
 
-Gestalt serves and packages static assets rather than frontend source files
-because `serve --locked` is runtime-agnostic. Frameworks, package managers,
-build commands, and environment handling vary by project, so production serving
-stays deterministic after `lock` and `sync --locked` have prepared the static
-asset root.
+Gestalt builds from frontend source when `build` is present, but it still serves
+and packages static assets rather than serving `src/` directly. Frameworks,
+package managers, build commands, and environment handling vary by project, so
+production serving stays deterministic after `lock` and `sync --locked` have
+prepared the static asset root.
 
 `spec.routes` is optional unless a deployment binds the UI to
 `providers.ui.<name>.authorizationPolicy`. In that case, Gestalt uses these
@@ -214,11 +246,11 @@ declare non-empty `allowedRoles`.
 
 ### Build step
 
-If your source UI needs a build step, use top-level `build`. Gestalt runs the
-command before source-manifest preparation for local paths, git source
-materialization, provider dev, and `gestaltd provider release`. The deployer
-does not need to check in the generated `out/` or `dist/` directory, but the
-environment doing lock or sync must have the tools required by
+Use top-level `build` for source-authored UIs. Gestalt runs the command before
+source-manifest preparation for local paths, git source materialization,
+provider dev, and `gestaltd provider release`. The deployer does not need to
+check in the generated `out/` or `dist/` directory, but the environment doing
+lock, sync, dev, or release preparation must have the tools required by
 `build.command`.
 
 The Default UI can use npm to produce static output:
@@ -250,12 +282,20 @@ relative to the manifest directory, or in the manifest directory when
 `inputs` is optional and contains literal manifest-relative files or
 directories. Gestalt uses it to fingerprint local source UI builds while
 excluding the output directory, `.git`, `.gestaltd`, and `node_modules`.
-Glob syntax is not supported in `inputs`.
+Glob syntax is not supported in `inputs`. Include the files and directories
+that affect the build, such as `package.json`, the package manager lockfile,
+`src`, and `public`.
 
 After the build completes, Gestalt prepares or packages everything under
 `build.output`. You can use any build tool here -- `npm run build`,
 `vite build`, or `next build` configured for static export -- as long as it
 writes static files to the declared output directory.
+
+For Vite and similar React single-page apps, point `build.output` at the
+configured `build.outDir`, commonly `dist`. For Next.js, configure static export
+with `output: 'export'` so `next build` writes static files, commonly to `out`.
+Next.js features that require a server are not compatible with Gestalt UI
+bundles because Gestalt serves static assets only.
 
 `release.build` remains supported as a legacy build hook for source manifests,
 but new UI manifests should prefer top-level `build`. A manifest may not set

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -496,10 +496,11 @@ artifacts:
 ## UI Metadata
 
 The `spec` block for a `kind: ui` manifest describes a static UI package.
-Source UI manifests can either point at checked-in static assets with
-`spec.assetRoot` or declare top-level `build.output` to generate those assets
-during preparation. Released and prepared UI manifests always contain
-`spec.assetRoot` and do not contain top-level `build`.
+Source UI manifests should normally declare top-level `build.output` to
+generate static assets during preparation. They may point at checked-in static
+assets with `spec.assetRoot` when the bundle is intentionally prebuilt.
+Released and prepared UI manifests always contain `spec.assetRoot` and do not
+contain top-level `build`.
 
 | Field       | Type         | Required | Purpose                                                                                                                     |
 | ----------- | ------------ | -------- | --------------------------------------------------------------------------------------------------------------------------- |
@@ -527,6 +528,7 @@ build:
   output: ui/out
   inputs:
     - ui/package.json
+    - ui/package-lock.json
     - ui/src
 spec:
   routes:
@@ -537,7 +539,8 @@ spec:
 ```
 
 Top-level `build` is source-only and currently supported for `kind: ui`
-manifests.
+manifests. It is the recommended form for new UI packages authored from
+TypeScript, React, Next.js static export, Vite, or similar frontend source.
 
 | Build field | Type     | Required | Purpose                                                                                           |
 | ----------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
@@ -861,6 +864,7 @@ build:
   output: ui/out
   inputs:
     - ui/package.json
+    - ui/package-lock.json
     - ui/src
 spec:
   routes:


### PR DESCRIPTION
## Summary
- Document source-built UI packages as the recommended authoring model
- Clarify when build tools are required versus when `serve --locked` only serves prepared assets
- Update application, provider, manifest, and client UI docs to avoid recommending checked-in `out`/`dist` bundles for new UIs

## Validation
- `npm ci`
- `npm run typecheck`
- `npm run build`
- Rendered locally at http://127.0.0.1:3000 and checked `/providers/ui` and `/applications` return 200