### PR TITLE
Support non-strict TypeScript protocol consumers

### DIFF
--- a/sdk/typescript/src/protocol.ts
+++ b/sdk/typescript/src/protocol.ts
@@ -145,7 +145,10 @@ function normalizeJsonValue(
   path: string,
   seen: WeakSet<object>,
 ): JsonValue {
-  if (value === null || typeof value === "string" || typeof value === "boolean") {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === "string" || typeof value === "boolean") {
     return value;
   }
   if (typeof value === "number") {


### PR DESCRIPTION
## Summary
- Split `normalizeJsonValue` null handling from string/boolean handling so TypeScript can narrow the return type when consuming the published SDK sources from non-strict tsconfigs.
- This was surfaced while bumping Valon Tools plugins to the newly published SDK: their plugin tsconfigs use `strict: false`, which compiled alpha.19 SDK sources differently than the SDK's own strict config.

## Interface Changes
- New/changed interface: none.
- Example usage: no user-facing API change.

## Functional/Integration Tests
- Tests added or augmented: none; this is a TypeScript narrowing-only compatibility fix.
- Contract boundary covered: published SDK source consumption from non-strict TypeScript projects.
- Commands run:
  - `./node_modules/.bin/tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --allowImportingTsExtensions --skipLibCheck --types bun --strict false src/protocol.ts`
  - `bun run check`