### PR TITLE
[gestaltd] grant valon-tools deploy chart readers

### DIFF
--- a/gestaltd/terraform/README.md
+++ b/gestaltd/terraform/README.md
@@ -13,8 +13,8 @@ It creates:
 - CI binary publisher service account
 - Artifact Registry writer access for the publisher service account
 - GCS object-create access for the CI binary publisher service account
-- Artifact Registry reader access for configured `valon-tools` Terraform
-  service accounts
+- Artifact Registry reader access for configured `valon-tools` Terraform and
+  GitHub deploy service accounts
 
 The release workflow consumes the `github_actions_variables` output. Copy those
 values into the `valon-technologies/gestalt` repository variables:
@@ -56,9 +56,9 @@ to run normally.
 `valon-tools` environments should consume the chart repository location as input
 variables instead of creating their own per-environment chart repository.
 The `gestaltd_chart_reader_service_accounts` variable controls which
-environment Terraform service accounts can read the chart repository. By
-default this grants read access to the dev and stage `valon-tools` Terraform
-service accounts.
+environment Terraform and GitHub deploy service accounts can read the chart
+repository. By default this grants read access to the dev and stage
+`valon-tools` Terraform and GitHub deploy service accounts.
 
 ## Continuous Deployment
 

--- a/gestaltd/terraform/variables.tf
+++ b/gestaltd/terraform/variables.tf
@@ -31,6 +31,8 @@ variable "gestaltd_chart_reader_service_accounts" {
   description = "Service account emails allowed to read gestaltd Helm charts from Artifact Registry."
   type        = set(string)
   default = [
+    "github-deploy-dev@valon-tools-dev.iam.gserviceaccount.com",
+    "github-deploy-stage@valon-tools-stage.iam.gserviceaccount.com",
     "terraform-dev@valon-tools-dev.iam.gserviceaccount.com",
     "terraform-stage@valon-tools-stage.iam.gserviceaccount.com",
   ]


### PR DESCRIPTION
## Description

Grants the valon-tools GitHub deploy service accounts Artifact Registry reader access to the gestaltd Helm chart repository so the Kubernetes deploy workflow can pull charts.