### PR TITLE
Fix versioned SDK API doc links

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -67,6 +67,10 @@ server {
         return 301 $1/;
     }
 
+    location ~ ^/(dev|latest|versions/v[^/]+)(/api/.*)$ {
+        return 301 $2;
+    }
+
     location ~ ^(/(dev|latest)/.+)/$ {
         return 301 $1;
     }

--- a/docs/content/reference/sdk/_meta.ts
+++ b/docs/content/reference/sdk/_meta.ts
@@ -1,11 +1,11 @@
 export default {
   python: {
     title: "Python SDK",
-    href: "/api/python/index.html",
+    href: "https://gestaltd.ai/api/python/index.html",
   },
   typescript: {
     title: "TypeScript SDK",
-    href: "/api/typescript/index.html",
+    href: "https://gestaltd.ai/api/typescript/index.html",
   },
   go: {
     title: "Go SDK",

--- a/docs/content/reference/sdk/index.mdx
+++ b/docs/content/reference/sdk/index.mdx
@@ -14,8 +14,8 @@ providers programmatically instead of declaratively, or to build custom
 Read the language-specific SDK page for examples and runtime details:
 
 <Cards num={4} className="provider-kind-cards">
-  <Cards.Card title="Python SDK" href="/api/python/index.html" />
-  <Cards.Card title="TypeScript SDK" href="/api/typescript/index.html" />
+  <Cards.Card title="Python SDK" href="https://gestaltd.ai/api/python/index.html" />
+  <Cards.Card title="TypeScript SDK" href="https://gestaltd.ai/api/typescript/index.html" />
   <Cards.Card title="Go SDK" href="https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go" />
   <Cards.Card title="Rust SDK" href="https://docs.rs/gestalt-sdk/latest/gestalt/" />
 </Cards>

--- a/docs/scripts/build-versioned-site.mjs
+++ b/docs/scripts/build-versioned-site.mjs
@@ -20,6 +20,20 @@ const docsRoot = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(docsRoot, "..");
 const defaultOut = path.join(docsRoot, "out");
 const developmentPathPrefix = "/dev";
+const globalPrefixes = [
+  "/api/",
+  "/admin",
+  "/favicon.svg",
+  "/fonts/",
+  "/install-gestalt.sh",
+  "/install-gestaltd.sh",
+  "/install.sh",
+  "/mcp",
+  "/registry",
+  "/versions.json",
+  "/_pagefind/",
+];
+const unversionedApiPathPattern = /^\/(?:dev|latest|versions\/v[^/]+)(\/api\/.*)$/;
 
 const options = parseArgs(process.argv.slice(2));
 const outDir = path.resolve(docsRoot, options.out ?? defaultOut);
@@ -129,6 +143,7 @@ async function main() {
       `${JSON.stringify(manifest, null, 2)}\n`,
     );
     await runPagefind(outDir);
+    await assertNoVersionedApiLinks(outDir);
     await assertNoUnversionedDocLinks(outDir);
     await assertFlightPayloadsUseUnprefixedInternalLinks(outDir);
   } finally {
@@ -471,6 +486,10 @@ function rewriteHtmlDocumentPaths(html, prefix) {
       /\b(href|src|action)=(["'])\/([^"'\s>]*)/g,
       (match, attr, quote, rest) => {
         const absolute = `/${rest}`;
+        const unversioned = unversionedApiPath(absolute);
+        if (unversioned) {
+          return `${attr}=${quote}${unversioned}`;
+        }
         return shouldPrefixPath(absolute, prefix)
           ? `${attr}=${quote}${prefix}${absolute}`
           : match;
@@ -490,6 +509,10 @@ function rewriteNonScriptHtml(html, rewriteChunk) {
   }
   rewritten += rewriteChunk(html.slice(lastIndex));
   return rewritten;
+}
+
+function unversionedApiPath(value) {
+  return value.match(unversionedApiPathPattern)?.[1] ?? "";
 }
 
 function shouldPrefixPath(value, prefix) {
@@ -513,23 +536,30 @@ function shouldPrefixPath(value, prefix) {
   ) {
     return false;
   }
-  const globalPrefixes = [
-    "/api/",
-    "/admin",
-    "/favicon.svg",
-    "/fonts/",
-    "/install-gestalt.sh",
-    "/install-gestaltd.sh",
-    "/install.sh",
-    "/mcp",
-    "/registry",
-    "/versions.json",
-    "/_pagefind/",
-  ];
   return !globalPrefixes.some(
     (globalPrefix) =>
       pathname === globalPrefix || pathname.startsWith(globalPrefix),
   );
+}
+
+async function assertNoVersionedApiLinks(finalOut) {
+  const files = await walk(finalOut);
+  const bad = [];
+  const pattern =
+    /\b(?:href|src|action)=["']\/(?:dev|latest|versions\/v[^/]+)\/api\//g;
+  for (const file of files.filter((candidate) => candidate.endsWith(".html"))) {
+    const body = await readFile(file, "utf8");
+    const visibleHtml = body.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+    const matches = visibleHtml.match(pattern) ?? [];
+    if (matches.length > 0) {
+      bad.push(`${path.relative(finalOut, file)}: ${matches.slice(0, 5).join(", ")}`);
+    }
+  }
+  if (bad.length > 0) {
+    throw new Error(
+      `versioned docs contain version-prefixed SDK API links:\n${bad.join("\n")}`,
+    );
+  }
 }
 
 async function assertNoUnversionedDocLinks(finalOut) {

--- a/docs/scripts/check-nginx-routing.mjs
+++ b/docs/scripts/check-nginx-routing.mjs
@@ -148,6 +148,18 @@ try {
     location: `${exactVersionPrefix}/reference/cli`,
   });
   await assertResponse({
+    url: `${baseUrl}/latest/api/python/index.html`,
+    host: "gestaltd.ai",
+    status: 301,
+    location: "/api/python/index.html",
+  });
+  await assertResponse({
+    url: `${baseUrl}${exactVersionPrefix}/api/typescript/index.html`,
+    host: "gestaltd.ai",
+    status: 301,
+    location: "/api/typescript/index.html",
+  });
+  await assertResponse({
     url: `${baseUrl}/versions/v9.9.9/`,
     host: "gestaltd.ai",
     status: 404,

--- a/docs/scripts/check-registry-static.mjs
+++ b/docs/scripts/check-registry-static.mjs
@@ -198,6 +198,16 @@ try {
     host: "gestaltd.ai",
     location: `${exactVersionPrefix}/reference/cli`,
   });
+  await assertRedirect({
+    url: `${baseUrl}/latest/api/python/index.html`,
+    host: "gestaltd.ai",
+    location: "/api/python/index.html",
+  });
+  await assertRedirect({
+    url: `${baseUrl}${exactVersionPrefix}/api/typescript/index.html`,
+    host: "gestaltd.ai",
+    location: "/api/typescript/index.html",
+  });
   await assertResponse({
     url: `${baseUrl}/versions/v9.9.9/`,
     host: "gestaltd.ai",
@@ -283,6 +293,12 @@ async function serveDocsHost(pathname, response) {
   const versionWithoutSlash = pathname.match(/^\/versions\/v[^/]+$/);
   if (versionWithoutSlash) {
     return redirect(response, `${pathname}/`);
+  }
+  const versionedApiPath = pathname.match(
+    /^\/(?:dev|latest|versions\/v[^/]+)(\/api\/.*)$/,
+  );
+  if (versionedApiPath) {
+    return redirect(response, versionedApiPath[1]);
   }
   const docsPageWithSlash = pathname.match(/^(\/(?:dev|latest)\/.+)\/$/);
   if (docsPageWithSlash) {


### PR DESCRIPTION
## Summary
- keep Python and TypeScript SDK API docs linked at the global /api paths from versioned docs
- redirect accidental /latest/api and /versions/.../api requests back to /api
- add versioned build and routing coverage for the bad prefixed SDK API URLs

## Verification
- npm run build:versioned:test
- npm run test:registry
- npm run test:sdk-docs
- npm run test:registry-docs
- npm run test:nginx-routing (blocked locally: Docker daemon is not running)