### PR TITLE
Clean up deploy docs guidance

### DIFF
--- a/docs/content/client/cli/docker.mdx
+++ b/docs/content/client/cli/docker.mdx
@@ -4,7 +4,7 @@ Gestalt publishes a CLI Docker image for use in CI pipelines and containerized e
 
 | Property | Value |
 | --- | --- |
-| Image | `valontechnologies/gestalt:latest` |
+| Image | [`valontechnologies/gestalt:latest`](https://hub.docker.com/r/valontechnologies/gestalt) |
 | Platforms | `linux/amd64`, `linux/arm64`, `linux/arm/v7` |
 | Base | Distroless (`gcr.io/distroless/cc-debian12`) |
 | Entrypoint | `/gestalt` |

--- a/docs/content/deploy/docker.mdx
+++ b/docs/content/deploy/docker.mdx
@@ -38,7 +38,7 @@ volumes:
 
 | Property | Value |
 | --- | --- |
-| Image | `valontechnologies/gestaltd:latest` |
+| Image | [`valontechnologies/gestaltd:latest`](https://hub.docker.com/r/valontechnologies/gestaltd) |
 | Platforms | `linux/amd64`, `linux/arm64`, `linux/arm/v7` |
 | Base | Static (`scratch` with CA certificates) |
 | Variants | `:latest-alpine` (Alpine, has shell) |
@@ -52,7 +52,12 @@ For the CLI client image, see [Client Docker Image](/client/cli/docker).
 
 ## Production image
 
-For deterministic production deployments, run `gestaltd lock` and `gestaltd sync --locked` during image build, then bake the lockfile and prepared artifacts into a derived image:
+For deterministic production deployments, prepare lock state before the image is built, then bake the lockfile and prepared artifacts into a derived image:
+
+```sh
+gestaltd lock --config deploy/config.yaml
+gestaltd sync --locked --config deploy/config.yaml --artifacts-dir deploy
+```
 
 ```
 deploy/
@@ -87,7 +92,7 @@ docker run --rm \
 ```
 
 For production, use a dedicated secret manager with structured secret refs. See
-[Configuration](/reference/configuration) for details.
+[Secrets Providers](/providers/secrets) and [Configuration](/reference/configuration).
 
 ## Health endpoints
 
@@ -97,4 +102,4 @@ For production, use a dedicated secret manager with structured secret refs. See
 
 SQLite works for local development, demos, and single-instance deployments. Store the database on a mounted volume (e.g. `/data/gestalt.db`) to persist data across container restarts.
 
-For horizontally scaled deployments, use Postgres or MySQL instead.
+For horizontally scaled deployments, use a networked IndexedDB provider such as RelationalDB with Postgres, MySQL, or SQL Server, or the first-party MongoDB or DynamoDB providers. See [IndexedDB](/providers/indexeddb).

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -1,8 +1,8 @@
 # Helm
 
-`gestaltd` publishes a Helm chart for deploying the daemon to Kubernetes.
+`gestaltd` publishes an OCI Helm chart for Kubernetes deployments.
 
-## Install The Chart
+## Install the chart
 
 ```sh
 helm upgrade --install gestaltd \
@@ -12,101 +12,26 @@ helm upgrade --install gestaltd \
   -f values.yaml
 ```
 
-Provide a `values.yaml` file that sets the required datastore and server
-settings, and auth settings when you enable platform login, along with the
-matching `extraEnv` entries.
+The default chart profile is for local or disposable testing only:
 
-The default chart profile is intentionally minimal:
-
-- platform authentication omitted
-- SQLite on a PVC mounted at `/data`
-- a static dev-only `server.encryptionKey`
+- platform authentication is omitted
+- SQLite uses a PVC mounted at `/data`
+- `server.encryptionKey` is a static dev-only value
 - one replica
 - no ingress
 
-That profile is suitable for local development and trusted internal clusters.
-It is not a production-ready security posture. Override `config.server.encryptionKey`
-before any shared, persistent, or production deployment.
+Before any shared or production deployment, set a real encryption key,
+configure authentication, use a networked datastore, and set `server.baseUrl`
+to the public HTTPS URL.
 
-## Production Install Pattern
+## Production values
 
-For production, override the default authentication and datastore settings and provide
-the required environment variables through `extraEnv`. Prefer enabling the
-separate management listener and internal management Service so `/admin` and
-`/metrics` do not share the public listener.
-
-```yaml
-config:
-  server:
-    baseUrl: "${GESTALT_BASE_URL}"
-    encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
-    providers:
-      auth: oidc
-      indexeddb: main
-  providers:
-      auth:
-        oidc:
-          source:
-            package: github.com/valon-technologies/gestalt-providers/auth/oidc
-            version: 0.0.1-alpha.1
-        config:
-          issuerUrl: "${OIDC_ISSUER_URL}"
-          clientId: "${OIDC_CLIENT_ID}"
-          clientSecret: "${OIDC_CLIENT_SECRET}"
-      indexeddb:
-        main:
-          source:
-            package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-            version: 0.0.1-alpha.1
-        config:
-          dsn: "${DATABASE_URL}"
-
-extraEnv:
-  - name: GESTALT_BASE_URL
-    value: "https://gestalt.example.com"
-  - name: GESTALT_ENCRYPTION_KEY
-    valueFrom:
-      secretKeyRef:
-        name: gestaltd-secrets
-        key: encryption-key
-  - name: DATABASE_URL
-    valueFrom:
-      secretKeyRef:
-        name: gestaltd-secrets
-        key: database-url
-
-preparation:
-  enabled: true
-```
-
-Apply that with:
-
-```sh
-helm upgrade --install gestaltd \
-  oci://ghcr.io/valon-technologies/charts/gestaltd \
-  --namespace gestalt \
-  --set image.tag=<version> \
-  -f values-production.yaml
-```
-
-## Important Chart Values
-
-| Value | Purpose |
-| --- | --- |
-| `config` | Rendered as `/etc/gestaltd/config.yaml`. |
-| `extraEnv` | Environment variables used by `${VAR}` placeholders in `config`. |
-| `persistence` | PVC settings for SQLite or other local state. |
-| `preparation.enabled` | Runs `gestaltd lock` and `gestaltd sync --locked` in init containers before the main server starts. Use it when the chart should prepare locked state for published provider packages or packaged UI bundles. |
-| `lockedServe.enabled` | Adds `--locked` to the main container without enabling the chart preparation container. Use it when lock state and prepared artifacts are baked into the image or mounted by external automation. |
-| `ingress` | Standard ingress settings. |
-| `ingress.hosts[].paths` | Per-host ingress paths and path types. |
-| `managementService` | Optional internal Service for a separate management listener. |
-
-## Example Values
+This example uses OIDC authentication, a networked RelationalDB datastore, and
+an internal management listener for `/admin` and `/metrics`:
 
 ```yaml
 service:
-  type: LoadBalancer
+  type: ClusterIP
   port: 8080
 
 managementService:
@@ -124,24 +49,23 @@ config:
     baseUrl: "${GESTALT_BASE_URL}"
     encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
     providers:
-      auth: oidc
+      authentication: oidc
       indexeddb: main
   providers:
-      auth:
-        oidc:
-          source:
-            package: github.com/valon-technologies/gestalt-providers/auth/oidc
-            version: 0.0.1-alpha.1
+    authentication:
+      oidc:
+        source:
+          package: github.com/valon-technologies/gestalt-providers/auth/oidc
+          version: 0.0.1-alpha.1
         config:
           issuerUrl: "${OIDC_ISSUER_URL}"
           clientId: "${OIDC_CLIENT_ID}"
           clientSecret: "${OIDC_CLIENT_SECRET}"
-          redirectUrl: "${OIDC_REDIRECT_URL}"
-      indexeddb:
-        main:
-          source:
-            package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-            version: 0.0.1-alpha.1
+    indexeddb:
+      main:
+        source:
+          package: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+          version: 0.0.1-alpha.1
         config:
           dsn: "${DATABASE_URL}"
 
@@ -165,8 +89,6 @@ extraEnv:
       secretKeyRef:
         name: gestaltd-secrets
         key: oidc-client-secret
-  - name: OIDC_REDIRECT_URL
-    value: "https://gestalt.example.com/api/v1/auth/login/callback"
   - name: DATABASE_URL
     valueFrom:
       secretKeyRef:
@@ -177,27 +99,54 @@ preparation:
   enabled: true
 ```
 
-This configuration keeps the public UI and API on port `8080` while exposing
-`/admin` and `/metrics` only through the internal `gestaltd-management` Service
-on port `9090`. If operators need browser access to `/admin`, place an
-internal-only ingress, VPN, or identity-aware proxy in front of that management
-Service rather than exposing it on the public ingress.
+Apply the values file with:
 
-## When to enable `preparation`
+```sh
+helm upgrade --install gestaltd \
+  oci://ghcr.io/valon-technologies/charts/gestaltd \
+  --namespace gestalt \
+  --set image.tag=<version> \
+  -f values-production.yaml
+```
 
-Enable the preparation init containers when your config uses published package sources or metadata URLs under `plugins.*.source`, `providers.authentication.*.source`, `providers.indexeddb.*.source`, or `providers.ui.*.source` and you want that state prepared before the main container starts. The chart runs:
+Keep the management Service internal. If operators need browser access to
+`/admin`, put an internal-only ingress, VPN, or identity-aware proxy in front
+of the management Service.
 
-`/gestaltd lock --config /etc/gestaltd-config/config.yaml --lockfile /etc/gestaltd-state/gestalt.lock.json`
+If you protect `/admin` with `server.admin.authorizationPolicy` on a split
+public/management deployment, also set `config.server.management.baseUrl`.
 
-followed by:
+## Important values
 
-`/gestaltd sync --locked --config /etc/gestaltd-config/config.yaml --lockfile /etc/gestaltd-state/gestalt.lock.json --artifacts-dir /etc/gestaltd-state/artifacts`
+| Value | Purpose |
+| --- | --- |
+| `config` | Rendered as `/etc/gestaltd/config.yaml`. |
+| `extraEnv` | Environment variables used by `${VAR}` placeholders in `config`. |
+| `persistence` | PVC settings for SQLite or other local state. |
+| `preparation.enabled` | Runs `gestaltd lock` and `gestaltd sync --locked` in init containers before the main server starts. |
+| `lockedServe.enabled` | Adds `--locked` to the main container without running the chart preparation containers. |
+| `ingress` | Public ingress settings. |
+| `managementService` | Optional internal Service for the management listener. |
 
-The main container then starts in locked mode against the prepared state.
+## Lock state
 
-If you prepare lock state outside the chart, leave `preparation.enabled: false`
-and set `lockedServe.enabled: true` so the main container still starts with
-`serve --locked`.
+Enable `preparation.enabled` when the chart should prepare locked state from
+published provider packages or packaged UI bundles. The chart runs:
 
-See [Configuration](/reference/configuration) for how the lockfile and prepared artifacts
-fit together.
+```sh
+/gestaltd lock \
+  --config /etc/gestaltd-config/config.yaml \
+  --lockfile /etc/gestaltd-state/gestalt.lock.json
+
+/gestaltd sync --locked \
+  --config /etc/gestaltd-config/config.yaml \
+  --lockfile /etc/gestaltd-state/gestalt.lock.json \
+  --artifacts-dir /etc/gestaltd-state/artifacts
+```
+
+For strict reproducibility, prepare lock state outside the chart, set
+`preparation.enabled: false`, set `lockedServe.enabled: true`, and bake or
+mount `gestalt.lock.json` and the prepared artifacts before startup.
+
+See [Configuration](/reference/configuration) for the lockfile and prepared
+artifact model.

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -8,29 +8,21 @@ import { Callout } from 'nextra/components'
 
 <Callout type="warning">
   For production, strongly prefer `gestaltd lock`, `gestaltd sync --locked`,
-  and then `gestaltd serve --locked`. Without a lockfile, startup can resolve
-  newly published provider artifacts or changed registry metadata, which weakens
-  reproducibility and integrity checks. Locked serve is read-only and will not
-  repair missing artifacts at runtime.
+  and then `gestaltd serve --locked`.
+
+  Without a lockfile, startup can resolve newly published provider artifacts or
+  changed registry metadata, which weakens reproducibility and integrity checks.
 </Callout>
 
-The server image `valontechnologies/gestaltd:latest` is published for `linux/amd64`, `linux/arm64`, and `linux/arm/v7`. An Alpine variant is available as `:latest-alpine`. For the CLI client image, see [Client Docker Image](/client/cli/docker).
+Server images are available at [`valontechnologies/gestaltd`](https://hub.docker.com/r/valontechnologies/gestaltd). For the CLI client image, see [Client Docker Image](/client/cli/docker).
 
 ## Production considerations
 
-**Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use a networked datastore provider such as the first-party `indexeddb/relationaldb`, `indexeddb/dynamodb`, or `indexeddb/mongodb` packages. See [IndexedDB](/providers/indexeddb) for the provider model.
+**Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use a production-ready [IndexedDB](/providers/indexeddb) provider.
 
-**Secrets.** Use `file` or a cloud secret manager instead of `env` in production. `file` is built in and works with Kubernetes volume-mounted secrets. Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). Gestalt config supports structured secret refs that are resolved at boot time through the configured secrets provider. See [Secrets Providers](/providers/secrets) for setup details.
+**Secrets.** Use a cloud secret manager instead of `env` in production. See [Secrets](/providers/secrets).
 
 **TLS.** Gestalt does not terminate TLS. Deploy behind a reverse proxy or load balancer that handles TLS termination. Set `server.baseUrl` to the public HTTPS URL so that OAuth callback URLs are derived correctly.
-
-**Startup workflows.** `gestaltd serve` resolves providers on first boot and is suitable for development and single-instance deployments. For deterministic, reproducible deployments, split startup into three phases:
-
-1. **Lock** -- run `gestaltd lock` locally or in CI to resolve every provider and write a lock file.
-2. **Sync** -- run `gestaltd sync --locked` during image build or release preparation to materialize prepared artifacts from the lock file.
-3. **Serve** -- run `gestaltd serve --locked` in production. The server reads the lock file and prepared artifacts and refuses to start if either is missing or stale.
-
-This guarantees that the image you test is byte-for-byte the image you deploy.
 
 **Prepared state and lockfiles.** `gestaltd lock` writes `gestalt.lock.json`; `gestaltd sync --locked` writes prepared artifacts under `.gestaltd/`:
 
@@ -62,13 +54,6 @@ The lock file is a JSON document that records resolved plugins and host-scoped p
   }
 }
 ```
-
-For production, bake or mount both the lockfile and the prepared `.gestaltd/`
-directory before starting with `serve --locked`. For development and local
-single-instance deployments, omit `--locked` and let `gestaltd serve` resolve
-and prepare providers at startup.
-
-See [Configuration](/reference/configuration) for the config model and [Docker](/deploy/docker) for the recommended production image pattern.
 
 ## Deployment guides
 

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -2,7 +2,7 @@
 asIndexPage: true
 ---
 
-import { Cards, Tabs } from 'nextra/components'
+import { Callout, Cards, Tabs } from 'nextra/components'
 
 # Providers
 
@@ -159,6 +159,13 @@ plugins:
 ```
 
 ## Provider Installation
+
+<Callout type="warning">
+  The `gestaltd provider` commands are under active development and are not yet
+  stable. Breaking changes may happen between releases without warning.
+  Feedback and bug reports are welcome via
+  [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
+</Callout>
 
 Use the provider CLI to add, inspect, lock, sync, upgrade, and remove configured
 providers. Mutating commands accept one `--config` path and update the lockfile

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -2,42 +2,16 @@ import { Tabs } from 'nextra/components'
 
 # IndexedDB
 
-IndexedDB providers back Gestalt's persistent state layer. Gestalt adopts the
-IndexedDB model so a single provider contract can map cleanly to relational,
-document, or key-value backends. The contract is modeled on the
-[W3C Indexed Database API](https://www.w3.org/TR/IndexedDB/).
-
-## How IndexedDB providers work
-
-The active datastore is selected by `server.providers.indexeddb`, which points
-to one of the named entries under `providers.indexeddb`. Gestalt talks to that provider
-through the IndexedDB service contract while keeping plugin state isolated with
-plugin-scoped datastore instances. Plugins may override that host selection
-with `plugins.<name>.indexeddb.provider`; otherwise they inherit the
-selected/default host IndexedDB. `plugins.<name>.indexeddb.db` defaults to the
-plugin key and controls the plugin-visible database name used for backend
-scoping. With the first-party RelationalDB provider, Postgres, MySQL, and SQL
-Server receive that value as `schema`, while SQLite falls back to `<db>_`
-table prefixes because it has no schema support. First-party MongoDB and
-DynamoDB providers receive the same value as their configured database or
-table namespace. Gestalt does not rewrite plugin object-store names at the
-transport layer. Plugins may also set `plugins.<name>.indexeddb.objectStores`
-to allowlist logical stores such as `tasks`.
+IndexedDB providers back Gestalt's persistent state layer, modeled on the
+[W3C Indexed Database API](https://www.w3.org/TR/IndexedDB/). This contract
+allows Gestalt to be agnostic of relational, document, or key-value backends.
 
 ## Using IndexedDB from a plugin
 
-Executable plugins do not choose raw database DSNs or relational schemas at
-runtime. They receive one IndexedDB SDK socket from the host, and the host
-decides what that socket points to from config.
-
-In plugin code, use the IndexedDB client from the language SDK. The
-`plugins.<name>.indexeddb.provider` field selects which named
-`providers.indexeddb` entry backs that client, and `plugins.<name>.indexeddb.db`
-selects the plugin-visible database name used for backend scoping. On
-schema-capable backends such as RelationalDB, that becomes the backend schema
-name. If the plugin omits `plugins.<name>.indexeddb`, it inherits the
-host-selected IndexedDB provider and uses the plugin key as the default `db`
-name.
+Plugins use the IndexedDB client from the language SDK. By default, Gestalt
+uses the host IndexedDB provider and the plugin name as the database scope.
+Configure `plugins.<name>.indexeddb` only when a plugin needs a different
+provider or database scope.
 
 For example:
 
@@ -414,6 +388,8 @@ roll back together.
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
+    import "time"
+
     tx, err := db.Transaction(
         ctx,
         []string{"tasks"},
@@ -642,189 +618,83 @@ spec:
 
 ### Provider interface
 
-You implement the [IndexedDB](https://www.w3.org/TR/IndexedDB/#object-store-interface) contract, which covers object store lifecycle, primary key CRUD, bulk operations, and index queries. Go providers should implement `gestalt.IndexedDBProvider`; the SDK adapts that typed surface to the underlying transport. The examples below show the core CRUD methods. See the [W3C IndexedDB specification](https://www.w3.org/TR/IndexedDB/) for the full interface contract.
+You implement the [IndexedDB](https://www.w3.org/TR/IndexedDB/#object-store-interface) contract, which covers object store lifecycle, primary key CRUD, bulk operations, and index queries. Go providers implement `gestalt.IndexedDBProvider`.
 
-<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
-  <Tabs.Tab>
-    ```go
-    package relationaldb
+```go
+package relationaldb
 
-    import (
-      "context"
-      "database/sql"
-      "fmt"
-      "strings"
+import (
+  "context"
+  "database/sql"
+  "fmt"
+  "strings"
 
-      gestalt "github.com/valon-technologies/gestalt/sdk/go"
-    )
+  gestalt "github.com/valon-technologies/gestalt/sdk/go"
+)
 
-    type RelationalDB struct {
-      db *sql.DB
-    }
+type RelationalDB struct {
+  db *sql.DB
+}
 
-    func New() *RelationalDB { return &RelationalDB{} }
+func New() *RelationalDB { return &RelationalDB{} }
 
-    func (r *RelationalDB) Configure(_ context.Context, _ string, config map[string]any) error {
-      dsn, _ := config["dsn"].(string)
-      if dsn == "" {
-        return fmt.Errorf("relationaldb: dsn is required")
-      }
-      driver := "sqlite"
-      connStr := dsn
-      switch {
-      case strings.HasPrefix(dsn, "postgres://"):
-        driver, connStr = "pgx", dsn
-      case strings.HasPrefix(dsn, "mysql://"):
-        driver, connStr = "mysql", strings.TrimPrefix(dsn, "mysql://")
-      case strings.HasPrefix(dsn, "sqlserver://"):
-        driver, connStr = "sqlserver", dsn
-      case strings.HasPrefix(dsn, "sqlite://"):
-        driver, connStr = "sqlite", strings.TrimPrefix(dsn, "sqlite://")
-      }
-      var err error
-      r.db, err = sql.Open(driver, connStr)
-      return err
-    }
+func (r *RelationalDB) Configure(_ context.Context, _ string, config map[string]any) error {
+  dsn, _ := config["dsn"].(string)
+  if dsn == "" {
+    return fmt.Errorf("relationaldb: dsn is required")
+  }
+  driver := "sqlite"
+  connStr := dsn
+  switch {
+  case strings.HasPrefix(dsn, "postgres://"):
+    driver, connStr = "pgx", dsn
+  case strings.HasPrefix(dsn, "mysql://"):
+    driver, connStr = "mysql", strings.TrimPrefix(dsn, "mysql://")
+  case strings.HasPrefix(dsn, "sqlserver://"):
+    driver, connStr = "sqlserver", dsn
+  case strings.HasPrefix(dsn, "sqlite://"):
+    driver, connStr = "sqlite", strings.TrimPrefix(dsn, "sqlite://")
+  }
+  var err error
+  r.db, err = sql.Open(driver, connStr)
+  return err
+}
 
-    func (r *RelationalDB) HealthCheck(ctx context.Context) error {
-      return r.db.PingContext(ctx)
-    }
+func (r *RelationalDB) HealthCheck(ctx context.Context) error {
+  return r.db.PingContext(ctx)
+}
 
-    func (r *RelationalDB) CreateObjectStore(ctx context.Context, name string, schema gestalt.ObjectStoreSchema) error {
-      return nil
-    }
+func (r *RelationalDB) CreateObjectStore(ctx context.Context, name string, schema gestalt.ObjectStoreSchema) error {
+  return nil
+}
 
-    func (r *RelationalDB) DeleteObjectStore(ctx context.Context, name string) error {
-      return nil
-    }
+func (r *RelationalDB) DeleteObjectStore(ctx context.Context, name string) error {
+  return nil
+}
 
-    // Get retrieves a single record by primary key.
-    func (r *RelationalDB) Get(ctx context.Context, req gestalt.IndexedDBObjectStoreRequest) (gestalt.Record, error) {
-      return gestalt.Record{}, nil
-    }
+// Get retrieves a single record by primary key.
+func (r *RelationalDB) Get(ctx context.Context, req gestalt.IndexedDBObjectStoreRequest) (gestalt.Record, error) {
+  return gestalt.Record{}, nil
+}
 
-    // Add inserts a new record. Fails if the key already exists.
-    func (r *RelationalDB) Add(ctx context.Context, req gestalt.IndexedDBRecordRequest) error {
-      return nil
-    }
+// Add inserts a new record. Fails if the key already exists.
+func (r *RelationalDB) Add(ctx context.Context, req gestalt.IndexedDBRecordRequest) error {
+  return nil
+}
 
-    // Put inserts or replaces the record at the given key.
-    func (r *RelationalDB) Put(ctx context.Context, req gestalt.IndexedDBRecordRequest) error {
-      return nil
-    }
+// Put inserts or replaces the record at the given key.
+func (r *RelationalDB) Put(ctx context.Context, req gestalt.IndexedDBRecordRequest) error {
+  return nil
+}
 
-    // Delete removes a record by primary key.
-    func (r *RelationalDB) Delete(ctx context.Context, req gestalt.IndexedDBObjectStoreRequest) error {
-      return nil
-    }
+// Delete removes a record by primary key.
+func (r *RelationalDB) Delete(ctx context.Context, req gestalt.IndexedDBObjectStoreRequest) error {
+  return nil
+}
 
-    // See the W3C IndexedDB specification for the remaining methods:
-    // https://www.w3.org/TR/IndexedDB/#object-store-interface
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```python
-    from typing import Any
-
-    from gestalt import IndexedDBProvider
-
-    class RelationalDB(IndexedDBProvider):
-        def configure(self, name: str, config: dict) -> None:
-            dsn = config.get("dsn", "")
-            if not dsn:
-                raise ValueError("relationaldb: dsn is required")
-            self.dsn = dsn
-
-        def get(self, store: str, id: str) -> dict[str, Any]:
-            """Retrieve a single record by primary key."""
-            ...
-
-        def add(self, store: str, record: dict[str, Any]) -> None:
-            """Insert a new record. Fails if the key already exists."""
-            ...
-
-        def put(self, store: str, record: dict[str, Any]) -> None:
-            """Insert or replace the record at the given key."""
-            ...
-
-        def delete(self, store: str, id: str) -> None:
-            """Remove a record by primary key."""
-            ...
-
-        # See the W3C IndexedDB specification for the remaining methods:
-        # https://www.w3.org/TR/IndexedDB/#object-store-interface
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```rust
-    pub struct RelationalDB { /* database connection */ }
-
-    #[gestalt::async_trait]
-    impl gestalt::IndexedDBProvider for RelationalDB {
-        async fn configure(&self, _name: &str, config: serde_json::Map<String, serde_json::Value>) -> gestalt::Result<()> {
-            let dsn = config.get("dsn")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| gestalt::Error::Config("dsn is required"))?;
-            // Parse DSN prefix to select driver, open connection.
-            Ok(())
-        }
-
-        /// Retrieves a single record by primary key.
-        async fn get(&self, req: proto::ObjectStoreRequest) -> gestalt::Result<proto::RecordResponse> {
-            todo!()
-        }
-
-        /// Inserts a new record. Fails if the key already exists.
-        async fn add(&self, req: proto::RecordRequest) -> gestalt::Result<()> {
-            todo!()
-        }
-
-        /// Inserts or replaces the record at the given key.
-        async fn put(&self, req: proto::RecordRequest) -> gestalt::Result<()> {
-            todo!()
-        }
-
-        /// Removes a record by primary key.
-        async fn delete(&self, req: proto::ObjectStoreRequest) -> gestalt::Result<()> {
-            todo!()
-        }
-
-        // See the W3C IndexedDB specification for the remaining methods:
-        // https://www.w3.org/TR/IndexedDB/#object-store-interface
-    }
-
-    gestalt::export_indexeddb_provider!(constructor = RelationalDB::default);
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```ts
-    import { defineIndexedDBProvider } from "@valon-technologies/gestalt";
-
-    export const provider = defineIndexedDBProvider({
-      async configure(name, config) {
-        const dsn = config.dsn;
-        if (!dsn) throw new Error("relationaldb: dsn is required");
-        // Parse DSN prefix to select driver, open connection.
-      },
-
-      /** Retrieves a single record by primary key. */
-      async get(store: string, id: string): Promise<Record> {},
-
-      /** Inserts a new record. Fails if the key already exists. */
-      async add(store: string, record: Record): Promise<void> {},
-
-      /** Inserts or replaces the record at the given key. */
-      async put(store: string, record: Record): Promise<void> {},
-
-      /** Removes a record by primary key. */
-      async delete(store: string, id: string): Promise<void> {},
-
-      // See the W3C IndexedDB specification for the remaining methods:
-      // https://www.w3.org/TR/IndexedDB/#object-store-interface
-    });
-    ```
-  </Tabs.Tab>
-</Tabs>
+// See the W3C IndexedDB specification for the remaining methods:
+// https://www.w3.org/TR/IndexedDB/#object-store-interface
+```
 
 ### Plugin access, scoping, and deployment
 

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -2,10 +2,10 @@ import { Tabs } from 'nextra/components'
 
 # IndexedDB
 
-IndexedDB providers back Gestalt's persistent state layer. The host uses them
-for users, sessions, plugin tokens, API tokens, OAuth registrations, and other
-system records. Gestalt adopts the IndexedDB model so a single provider
-contract can map cleanly to relational, document, or key-value backends.
+IndexedDB providers back Gestalt's persistent state layer. Gestalt adopts the
+IndexedDB model so a single provider contract can map cleanly to relational,
+document, or key-value backends. The contract is modeled on the
+[W3C Indexed Database API](https://www.w3.org/TR/IndexedDB/).
 
 ## How IndexedDB providers work
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -1,4 +1,4 @@
-import { Tabs } from 'nextra/components'
+import { Callout, Tabs } from 'nextra/components'
 
 # Plugins
 
@@ -12,11 +12,11 @@ and MCP exposure.
 A plugin package includes a manifest that defines metadata, connections, and
 optional passthrough API surfaces. Some plugins are fully executable, some are
 fully declarative, and some are hybrid packages that combine both models.
+Plugins support:
 
-From a deployment point of view, `source` chooses the package and `config`
-passes provider-specific settings such as OAuth app credentials. Dedicated
-sections below cover invocation authorization, connections, runtime placement,
-operation filtering, egress policy, and local development.
+> REST/OpenAPI, GraphQL, MCP and executable custom-defined code
+
+as stated in [Overview](/).
 
 If the manifest enables MCP, the same operations are also exposed through the
 server's `/mcp` endpoint.
@@ -27,30 +27,10 @@ Gestalt resolves every plugin request to a canonical subject, then
 [authorization](/providers/authorization) decides whether that subject may use
 the plugin or operation.
 
-Connection resolution is separate. When a selected connection uses
-`mode: subject`, the [external credentials provider](/providers/external-credentials)
-resolves credentials for the request's effective credential subject.
-
-When executable plugins call other configured plugin operations, use the SDK
-plugin invoker for request-scoped nested calls. For application examples, see
-[Applications > Calling another plugin from your application](/applications#calling-another-plugin-from-your-application).
-Use a [service account](/service-accounts) and subject-owned API token when a
-plugin should call the Gestalt HTTP API as a stable automation subject.
-
-## First-party plugin packages
-
-First-party plugins live under
-[`valon-technologies/gestalt-providers/plugins`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins).
-Examples include:
-
-| Provider |
-| --- |
-| [`github.com/valon-technologies/gestalt-providers/plugins/github`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/github) |
-| [`github.com/valon-technologies/gestalt-providers/plugins/jira`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/jira) |
-| [`github.com/valon-technologies/gestalt-providers/plugins/httpbin`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) |
-
-See the repository directory for the broader catalog of first-party plugins and
-their package layouts.
+When executable
+[plugins call other configured plugin operations](/applications#calling-another-plugin-from-your-application),
+authorization scopes are threaded through the call stack for both users and
+[service accounts](/service-accounts).
 
 ## Configuring a plugin provider
 
@@ -79,64 +59,25 @@ plugins:
 ```
 
 Hosted HTTP route overrides are deployment-specific; see
-[Hosted HTTP endpoints](#hosted-http-endpoints). By default, executable plugins
-run on the same machine as `gestaltd`; see [Choosing a runtime](#choosing-a-runtime)
-when a plugin should run in a hosted runtime.
-
-## Choosing a runtime
-
-Runtime selection is explicit and per-plugin:
-
-```yaml
-runtime:
-  providers:
-    modal:
-      source:
-        path: ./vendor/gestalt-providers/runtime/modal/manifest.yaml
-      default: true
-      config:
-        app: gestalt-runtime
-        environment: main
-
-server:
-  runtime:
-    defaultProvider: modal
-
-plugins:
-  support:
-    source: ./plugins/support/manifest.yaml
-    runtime:
-      template: python-dev
-      image: ghcr.io/example/support-plugin:2026-04-21
-      metadata:
-        environment: production
-```
-
-`plugins.<name>.runtime.provider` selects a named backend from
-`runtime.providers`; when omitted, Gestalt uses `server.runtime.defaultProvider`
-or the runtime entry marked `default: true`. `template`, `image`, and `metadata`
-are forwarded to the runtime backend.
-
-Hosted execution depends on the selected runtime provider's support profile.
-Plugins that need host services, nested invokes, or hostname-based egress stay
-local unless the runtime advertises support for those capabilities. See
-[Runtime](/providers/runtime) for provider setup and compatibility details.
+[Hosted HTTP endpoints](#hosted-http-endpoints).
 
 ## Connections and credentials
 
-Plugin manifests declare connection needs; deployment config binds or overrides
-those connections. Connection `mode` is either `none`, which requires no
-upstream credential, or `subject`, which resolves credentials for the effective
-credential subject. That subject may be the caller, a subject-owned API token
-owner, or a [`runAs`](/service-accounts#runas) subject.
+The [external credentials provider](/providers/external-credentials) resolves
+credentials for configured connections. Plugin manifests declare connection
+needs; deployment config binds or overrides them. Use
+[`mode: none`](/providers/external-credentials#connection-modes) or
+[`mode: subject`](/providers/external-credentials#connection-modes) depending
+on whether the connection should resolve credentials for the effective
+credential subject, including a caller, subject-owned API token owner, or
+[`runAs`](/service-accounts#runas) subject.
 
-Common auth types are `oauth2`, `mcp_oauth`, `bearer`, `manual`, and `none`.
-Operator-supplied app credentials such as `clientId` and `clientSecret` go in
-the plugin's `config` block when the provider requires them. See
-[External Credentials](/providers/external-credentials) and
+Auth types: `oauth2`, `mcp_oauth`, `bearer`, `manual`, `none`. See
 [Config File > connections](/reference/config-file#connections).
 
 ## Filtering operations and egress
+
+### `allowedOperations`
 
 Use `allowedOperations` to publish only a subset of a large plugin catalog:
 
@@ -153,6 +94,13 @@ plugins:
         alias: get_issue
 ```
 
+### `allowedHosts`
+
+<Callout type="warning">
+  `allowedHosts` is under active development and is not yet stable. Breaking
+  changes may happen between releases without warning.
+</Callout>
+
 Use `egress.allowedHosts` when a plugin needs explicit outbound access:
 
 ```yaml
@@ -165,11 +113,7 @@ plugins:
 ```
 
 For executable plugins, `egress.allowedHosts` is only a complete security
-boundary when the plugin is running inside a runtime backend that preserves
-Gestalt's hostname-based policy model. Provider-level `allowedHosts` is no
-longer accepted; use `egress.allowedHosts`. The current host-local wrappers are
-OS-dependent, so operators should treat `egress.allowedHosts` as declarative
-policy plus best-effort enforcement unless the selected runtime explicitly
+boundary when the plugin runs inside a [runtime](/providers/runtime) that
 supports hostname-based egress controls.
 
 
@@ -239,9 +183,7 @@ You declare static metadata, connections, and passthrough surfaces in a manifest
   </Tabs.Tab>
 </Tabs>
 
-The manifest is the source of truth for display name, description, the connection model, and any passthrough API surfaces (REST, OpenAPI, GraphQL, or MCP). Setting `spec.mcp: true` exposes the plugin's operations through Gestalt's MCP server. See [Provider Manifests](/reference/plugin-manifests) for the full field reference.
-
-`source` may include nested segments after the repository, such as `github.com/your-org/plugins/catalog/slack`. Gestalt keeps the final segment as the plugin name and uses the full path for release tag resolution.
+See [Provider Manifests](/reference/plugin-manifests) for the full field reference.
 
 ### Creating a project
 
@@ -549,91 +491,23 @@ The following example defines a `conversations.getMessage` operation that fetche
   </Tabs.Tab>
 </Tabs>
 
-By default, input decode failures return a structured `400` response, and unhandled errors return a structured `500` response. Return a non-2xx response explicitly when the operation wants to signal a deliberate application-level error.
-
-### Input parameter conventions
-
-The router derives catalog parameters from the input type. Fields are required by default unless marked optional. Nested types are emitted as `object` parameters and collections as `array`.
-
-<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
-  <Tabs.Tab>
-    ```go
-    type ListMessagesInput struct {
-      Channel string `json:"channel"            doc:"Channel ID"              required:"true"`
-      Limit   int    `json:"limit,omitempty"    doc:"Maximum messages"        default:"100"`
-      Oldest  string `json:"oldest,omitempty"   doc:"Unix timestamp bound"`
-    }
-    ```
-
-    `json:"name"` sets the parameter name. `json:",omitempty"` makes the parameter optional. `doc:"..."` sets the description, `required:"true|false"` overrides the default inference, and `default:"..."` sets a scalar default.
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```python
-    from gestalt import Model, field
-
-    class ListMessagesInput(Model):
-        channel: str = field(description="Channel ID")
-        limit: int = field(description="Maximum messages", default=100)
-        oldest: str | None = field(description="Unix timestamp bound", default=None)
-    ```
-
-    Fields without a default are required. Use `field(description="...")` for descriptions and `default=...` for default values.
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```rust
-    #[derive(serde::Deserialize, schemars::JsonSchema)]
-    struct ListMessagesInput {
-        #[schemars(description = "Channel ID")]
-        channel: String,
-        #[serde(default = "default_limit")]
-        #[schemars(description = "Maximum messages")]
-        limit: u32,
-        #[schemars(description = "Unix timestamp bound")]
-        oldest: Option<String>,
-    }
-
-    fn default_limit() -> u32 {
-        100
-    }
-    ```
-
-    Fields are required unless you model them as `Option<T>` or provide a serde default. Use `schemars(description = "...")` for catalog descriptions and serde defaults for scalar defaults.
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```ts
-    const ListMessagesInput = s.object({
-      channel: s.string({ description: "Channel ID" }),
-      limit: s.integer({ description: "Maximum messages", default: 100 }),
-      oldest: s.optional(s.string({ description: "Unix timestamp bound" })),
-    });
-    ```
-
-    TypeScript plugins describe runtime input schemas explicitly. Requiredness,
-    descriptions, defaults, nested objects, and arrays come from that schema
-    definition rather than from erased TypeScript types.
-  </Tabs.Tab>
-</Tabs>
+By default, input decode failures return a structured `400` response, and unhandled errors return a structured `500` response.
 
 ### Hosted HTTP endpoints
 
 Hosted HTTP endpoints let an external product call a plugin through a stable
 HTTP route, while the plugin still handles the request as a normal operation.
-They are useful for webhooks, Slack slash commands, Slack event callbacks, and
-other inbound requests whose path, signature verification, body shape, or
-acknowledgment response needs to match the calling product.
+They are useful for webhooks and other inbound requests whose path, signature
+verification, body shape, or acknowledgment response needs to match the calling
+product.
 
 The endpoint declaration belongs in the plugin manifest under `spec.http` and
 `spec.securitySchemes`. Deployment config selects the plugin and may override
-fields, but most deployments do not need a separate route declaration. If the
-configured plugin key is `slack` and the binding path is `/commands/support`,
-Gestalt mounts the route at `/api/v1/slack/commands/support` on
-`server.baseUrl`.
+fields, but most deployments do not need a separate route declaration.
 
-Each binding names a security scheme. Use `type: none` only for routes that are
-intentionally unsigned; signed production webhooks should use `hmac`, `apiKey`,
-or `http` verification. The binding then targets an operation ID. Gestalt
-verifies the request, decodes query/body parameters, optionally resolves a more
-specific subject, and invokes the target operation.
+See [Hosted HTTP Bindings](/reference/plugin-manifests#hosted-http-bindings)
+for security schemes, request decoding, subject resolution, and target
+operations.
 
 ```yaml
 kind: plugin


### PR DESCRIPTION
## Summary
- tighten the deploy overview production guidance and remove redundant startup workflow prose
- add Docker Hub links for the server and CLI images
- simplify the Helm page around production values, management listener setup, and lock state
- add an active-development warning for `gestaltd provider` commands

## Validation
- `git diff --check`
- `npm --prefix docs run typecheck`
- `npm --prefix docs run build:single`