### PR TITLE
Avoid hard-coded SDK API doc domain

### DIFF
--- a/docs/content/reference/sdk/_meta.ts
+++ b/docs/content/reference/sdk/_meta.ts
@@ -1,11 +1,11 @@
 export default {
   python: {
     title: "Python SDK",
-    href: "https://gestaltd.ai/api/python/index.html",
+    href: "/api/python/index.html",
   },
   typescript: {
     title: "TypeScript SDK",
-    href: "https://gestaltd.ai/api/typescript/index.html",
+    href: "/api/typescript/index.html",
   },
   go: {
     title: "Go SDK",

--- a/docs/content/reference/sdk/index.mdx
+++ b/docs/content/reference/sdk/index.mdx
@@ -14,8 +14,8 @@ providers programmatically instead of declaratively, or to build custom
 Read the language-specific SDK page for examples and runtime details:
 
 <Cards num={4} className="provider-kind-cards">
-  <Cards.Card title="Python SDK" href="https://gestaltd.ai/api/python/index.html" />
-  <Cards.Card title="TypeScript SDK" href="https://gestaltd.ai/api/typescript/index.html" />
+  <Cards.Card title="Python SDK" href="/api/python/index.html" />
+  <Cards.Card title="TypeScript SDK" href="/api/typescript/index.html" />
   <Cards.Card title="Go SDK" href="https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go" />
   <Cards.Card title="Rust SDK" href="https://docs.rs/gestalt-sdk/latest/gestalt/" />
 </Cards>

--- a/docs/scripts/build-versioned-site.mjs
+++ b/docs/scripts/build-versioned-site.mjs
@@ -144,6 +144,7 @@ async function main() {
     );
     await runPagefind(outDir);
     await assertNoVersionedApiLinks(outDir);
+    await assertNoAbsoluteSdkApiLinks(outDir);
     await assertNoUnversionedDocLinks(outDir);
     await assertFlightPayloadsUseUnprefixedInternalLinks(outDir);
   } finally {
@@ -471,9 +472,11 @@ async function copyRootOutputs(rootOut, finalOut) {
 
 async function rewriteVersionedPaths(root, prefix) {
   const files = await walk(root);
-  for (const file of files.filter((candidate) => candidate.endsWith(".html"))) {
+  for (const file of files.filter((candidate) => /\.(html|txt)$/.test(candidate))) {
     const original = await readFile(file, "utf8");
-    const rewritten = rewriteHtmlDocumentPaths(original, prefix);
+    const rewritten = file.endsWith(".html")
+      ? rewriteHtmlDocumentPaths(original, prefix)
+      : rewriteSdkApiLinks(original);
     if (rewritten !== original) {
       await writeFile(file, rewritten);
     }
@@ -481,7 +484,7 @@ async function rewriteVersionedPaths(root, prefix) {
 }
 
 function rewriteHtmlDocumentPaths(html, prefix) {
-  return rewriteNonScriptHtml(html, (chunk) =>
+  const rewrittenVisibleLinks = rewriteNonScriptHtml(html, (chunk) =>
     chunk.replace(
       /\b(href|src|action)=(["'])\/([^"'\s>]*)/g,
       (match, attr, quote, rest) => {
@@ -496,6 +499,19 @@ function rewriteHtmlDocumentPaths(html, prefix) {
       },
     ),
   );
+  return rewriteSdkApiLinks(rewrittenVisibleLinks);
+}
+
+function rewriteSdkApiLinks(value) {
+  return value
+    .replace(
+      /https?:\/\/[^"'<>\s\\]+(\/api\/(?:python|typescript)\/index\.html)/g,
+      "$1",
+    )
+    .replace(
+      /https?:\\\/\\\/[^"'<>\\\s]+(\\\/api\\\/(?:python|typescript)\\\/index\.html)/g,
+      "$1",
+    );
 }
 
 function rewriteNonScriptHtml(html, rewriteChunk) {
@@ -558,6 +574,27 @@ async function assertNoVersionedApiLinks(finalOut) {
   if (bad.length > 0) {
     throw new Error(
       `versioned docs contain version-prefixed SDK API links:\n${bad.join("\n")}`,
+    );
+  }
+}
+
+async function assertNoAbsoluteSdkApiLinks(finalOut) {
+  const files = await walk(finalOut);
+  const bad = [];
+  const patterns = [
+    /https?:\/\/[^"'<>\s\\]+\/api\/(?:python|typescript)\/index\.html/g,
+    /https?:\\\/\\\/[^"'<>\\\s]+\\\/api\\\/(?:python|typescript)\\\/index\.html/g,
+  ];
+  for (const file of files.filter((candidate) => /\.(html|txt)$/.test(candidate))) {
+    const body = await readFile(file, "utf8");
+    const matches = patterns.flatMap((pattern) => body.match(pattern) ?? []);
+    if (matches.length > 0) {
+      bad.push(`${path.relative(finalOut, file)}: ${matches.slice(0, 5).join(", ")}`);
+    }
+  }
+  if (bad.length > 0) {
+    throw new Error(
+      `versioned docs contain absolute SDK API links:\n${bad.join("\n")}`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- use root-relative `/api/...` links for Python and TypeScript SDK docs
- normalize absolute SDK API doc links from generated HTML and RSC payloads back to `/api/...`
- add a build assertion so absolute SDK API links do not regress

## Verification
- `npm run build:versioned:test`
- `npm run test:sdk-docs`
- `npm run test:registry`
- `npm run test:registry-docs`
- checked generated output has no version-prefixed or absolute Python/TypeScript SDK API links