### PR TITLE
Remove visible docs version label

### DIFF
--- a/docs/components/VersionPicker.tsx
+++ b/docs/components/VersionPicker.tsx
@@ -124,7 +124,6 @@ export default function VersionPicker() {
 
   return (
     <label className="docs-version-picker">
-      <span className="docs-version-picker-label">Docs version</span>
       <select
         aria-label="Docs version"
         value={selected}

--- a/docs/versioning.css
+++ b/docs/versioning.css
@@ -1,14 +1,9 @@
 .docs-version-picker {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
   min-width: 0;
   color: var(--valon-secondary);
   font-size: 0.875rem;
-}
-
-.docs-version-picker-label {
-  white-space: nowrap;
 }
 
 .docs-version-picker select {
@@ -27,18 +22,6 @@
 }
 
 @media (max-width: 720px) {
-  .docs-version-picker-label {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-
   .docs-version-picker select {
     max-width: 9.5rem;
   }


### PR DESCRIPTION
## Summary

- remove the visible `Docs version` text from the docs version picker
- keep the select's `aria-label` so the control remains accessible
- remove the now-unused picker label CSS

## Tests

- `npm run typecheck`
- `npm run build:versioned:test`

Note: the first `npm run typecheck` attempt failed before validation because this isolated worktree did not have `docs/node_modules`; I ran `npm ci` and reran it successfully.