### PR TITLE
Tighten native SDK docs and conversions

### DIFF
--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -332,8 +332,8 @@ details. Those come from the deployment bindings.
       if err != nil {
         return gestalt.Response[NightlyReportOutput]{}, err
       }
-      _, err = workflows.PublishEvent(ctx, gestalt.WorkflowManagerPublishEventInput{
-        Event: &gestalt.WorkflowEventInput{
+      _, err = workflows.PublishEvent(ctx, gestalt.WorkflowManagerPublishEvent{
+        Event: &gestalt.WorkflowEvent{
           Type:            "workspace_review.report.generated",
           Source:          "workspace_review",
           Subject:         "nightly",
@@ -378,8 +378,8 @@ details. Those come from the deployment bindings.
         WriteOptions,
         PresignOptions,
         PresignMethod,
-        WorkflowEventInput,
-        WorkflowManagerPublishEventInput,
+        WorkflowEvent,
+        WorkflowManagerPublishEvent,
     )
 
     plugin = Plugin("workspace_review")
@@ -436,8 +436,8 @@ details. Those come from the deployment bindings.
 
         with request.workflow_manager() as workflows:
             workflows.publish_event(
-                WorkflowManagerPublishEventInput(
-                    event=WorkflowEventInput(
+                WorkflowManagerPublishEvent(
+                    event=WorkflowEvent(
                         type="workspace_review.report.generated",
                         source="workspace_review",
                         subject="nightly",
@@ -457,8 +457,8 @@ details. Those come from the deployment bindings.
     use std::collections::BTreeMap;
 
     use gestalt::{
-        IndexedDB, PresignMethod, PresignOptions, S3, WorkflowEventInput,
-        WorkflowManagerPublishEventInput,
+        IndexedDB, PresignMethod, PresignOptions, S3, WorkflowEvent,
+        WorkflowManagerPublishEvent,
     };
     use serde::{Deserialize, Serialize};
     use serde_json::json;
@@ -540,8 +540,8 @@ details. Those come from the deployment bindings.
 
         let mut workflows = request.workflow_manager().await?;
         workflows
-            .publish_event(WorkflowManagerPublishEventInput {
-                event: Some(WorkflowEventInput {
+            .publish_event(WorkflowManagerPublishEvent {
+                event: Some(WorkflowEvent {
                     event_type: "workspace_review.report.generated".to_string(),
                     source: "workspace_review".to_string(),
                     subject: "nightly".to_string(),

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -228,16 +228,16 @@ Provider code can invoke agents through the SDK agent manager:
         }
         defer agents.Close()
 
-        session, err := agents.CreateSession(ctx, gestalt.AgentManagerCreateSessionInput{
+        session, err := agents.CreateSession(ctx, gestalt.AgentManagerCreateSession{
             ClientRef: "roadmap-risk",
         })
         if err != nil {
             return "", err
         }
 
-        turn, err := agents.CreateTurn(ctx, gestalt.AgentManagerCreateTurnInput{
+        turn, err := agents.CreateTurn(ctx, gestalt.AgentManagerCreateTurn{
             SessionID: session.GetId(),
-            Messages: []gestalt.AgentMessageInput{{
+            Messages: []gestalt.AgentMessage{{
                 Role: "user",
                 Text: "Summarize the latest roadmap risk.",
             }},
@@ -251,19 +251,19 @@ Provider code can invoke agents through the SDK agent manager:
   </Tabs.Tab>
   <Tabs.Tab>
     ```python
-    from gestalt import AgentManagerCreateSessionInput, AgentManagerCreateTurnInput
-    from gestalt import AgentMessageInput, Request
+    from gestalt import AgentManagerCreateSession, AgentManagerCreateTurn
+    from gestalt import AgentMessage, Request
 
     def summarize(request: Request) -> str:
         with request.agent_manager() as agents:
             session = agents.create_session(
-                AgentManagerCreateSessionInput(client_ref="roadmap-risk")
+                AgentManagerCreateSession(client_ref="roadmap-risk")
             )
             turn = agents.create_turn(
-                AgentManagerCreateTurnInput(
+                AgentManagerCreateTurn(
                     session_id=session.id,
                     messages=[
-                        AgentMessageInput(
+                        AgentMessage(
                             role="user",
                             text="Summarize the latest roadmap risk.",
                         )
@@ -276,20 +276,20 @@ Provider code can invoke agents through the SDK agent manager:
   <Tabs.Tab>
     ```rust
     use gestalt::{
-        AgentManagerCreateSessionInput, AgentManagerCreateTurnInput,
-        AgentMessageInput, Request,
+        AgentManagerCreateSession, AgentManagerCreateTurn,
+        AgentMessage, Request,
     };
 
     async fn summarize(req: &Request) -> Result<String, Box<dyn std::error::Error>> {
         let mut agents = req.agent_manager().await?;
-        let session = agents.create_session(AgentManagerCreateSessionInput {
+        let session = agents.create_session(AgentManagerCreateSession {
             client_ref: "roadmap-risk".into(),
             ..Default::default()
         }).await?;
 
-        let turn = agents.create_turn(AgentManagerCreateTurnInput {
+        let turn = agents.create_turn(AgentManagerCreateTurn {
             session_id: session.id,
-            messages: vec![AgentMessageInput {
+            messages: vec![AgentMessage {
                 role: "user".into(),
                 text: "Summarize the latest roadmap risk.".into(),
                 ..Default::default()

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -494,9 +494,9 @@ definition do not silently change existing automation.
         }
         defer workflows.Close()
 
-        published, err := workflows.PublishEvent(ctx, gestalt.WorkflowManagerPublishEventInput{
+        published, err := workflows.PublishEvent(ctx, gestalt.WorkflowManagerPublishEvent{
             ProviderName: "local",
-            Event: &gestalt.WorkflowEventInput{
+            Event: &gestalt.WorkflowEvent{
                 Type:            "slack.event.received",
                 Source:          "slack",
                 Subject:         "route:knowledge-ingest",
@@ -513,7 +513,7 @@ definition do not silently change existing automation.
   </Tabs.Tab>
   <Tabs.Tab>
     ```python
-    from gestalt import Request, WorkflowEventInput, WorkflowManagerPublishEventInput
+    from gestalt import Request, WorkflowEvent, WorkflowManagerPublishEvent
 
     def publish_slack_event(
         request: Request,
@@ -521,9 +521,9 @@ definition do not silently change existing automation.
     ) -> str:
         with request.workflow_manager() as workflows:
             published = workflows.publish_event(
-                WorkflowManagerPublishEventInput(
+                WorkflowManagerPublishEvent(
                     provider_name="local",
-                    event=WorkflowEventInput(
+                    event=WorkflowEvent(
                         type="slack.event.received",
                         source="slack",
                         subject="route:knowledge-ingest",
@@ -538,7 +538,7 @@ definition do not silently change existing automation.
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use gestalt::{WorkflowEventInput, WorkflowManagerPublishEventInput};
+    use gestalt::{WorkflowEvent, WorkflowManagerPublishEvent};
     use serde_json::json;
 
     async fn publish_slack_event(
@@ -547,9 +547,9 @@ definition do not silently change existing automation.
     ) -> Result<String, Box<dyn std::error::Error>> {
         let mut workflows = request.workflow_manager().await?;
         let event = workflows
-            .publish_event(WorkflowManagerPublishEventInput {
+            .publish_event(WorkflowManagerPublishEvent {
                 provider_name: "local".to_string(),
-                event: Some(WorkflowEventInput {
+                event: Some(WorkflowEvent {
                     event_type: "slack.event.received".to_string(),
                     source: "slack".to_string(),
                     subject: "route:knowledge-ingest".to_string(),
@@ -820,16 +820,16 @@ signal sequence numbers exactly as stored.
         return nil
     }
 
-    func (p *Provider) StartRun(_ context.Context, req *gestalt.StartWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRunInput, error) {
-        return &gestalt.BoundWorkflowRunInput{
+    func (p *Provider) StartRun(_ context.Context, req *gestalt.StartWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
+        return &gestalt.BoundWorkflowRun{
             ID:     "workflow:run-1",
             Status: gestalt.WorkflowRunStatusValuePending,
             Target: req.Target,
         }, nil
     }
 
-    func (p *Provider) GetRun(_ context.Context, req *gestalt.GetWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRunInput, error) {
-        return &gestalt.BoundWorkflowRunInput{
+    func (p *Provider) GetRun(_ context.Context, req *gestalt.GetWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
+        return &gestalt.BoundWorkflowRun{
             ID: req.RunID,
         }, nil
     }
@@ -838,8 +838,8 @@ signal sequence numbers exactly as stored.
         return &gestalt.ListWorkflowProviderRunsResponse{}, nil
     }
 
-    func (p *Provider) CancelRun(_ context.Context, req *gestalt.CancelWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRunInput, error) {
-        return &gestalt.BoundWorkflowRunInput{
+    func (p *Provider) CancelRun(_ context.Context, req *gestalt.CancelWorkflowProviderRunRequest) (*gestalt.BoundWorkflowRun, error) {
+        return &gestalt.BoundWorkflowRun{
             ID:     req.RunID,
             Status: gestalt.WorkflowRunStatusValueCanceled,
         }, nil
@@ -847,14 +847,14 @@ signal sequence numbers exactly as stored.
 
     func (p *Provider) SignalRun(_ context.Context, req *gestalt.SignalWorkflowProviderRunRequest) (*gestalt.SignalWorkflowRunResponse, error) {
         return &gestalt.SignalWorkflowRunResponse{
-            Run:    &gestalt.BoundWorkflowRunInput{ID: req.RunID},
+            Run:    &gestalt.BoundWorkflowRun{ID: req.RunID},
             Signal: req.Signal,
         }, nil
     }
 
     func (p *Provider) SignalOrStartRun(_ context.Context, req *gestalt.SignalOrStartWorkflowProviderRunRequest) (*gestalt.SignalWorkflowRunResponse, error) {
         return &gestalt.SignalWorkflowRunResponse{
-            Run: &gestalt.BoundWorkflowRunInput{
+            Run: &gestalt.BoundWorkflowRun{
                 ID:     req.WorkflowKey + ":run-1",
                 Status: gestalt.WorkflowRunStatusValuePending,
                 Target: req.Target,
@@ -865,8 +865,8 @@ signal sequence numbers exactly as stored.
         }, nil
     }
 
-    func (p *Provider) UpsertSchedule(_ context.Context, req *gestalt.UpsertWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowScheduleInput, error) {
-        return &gestalt.BoundWorkflowScheduleInput{
+    func (p *Provider) UpsertSchedule(_ context.Context, req *gestalt.UpsertWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
+        return &gestalt.BoundWorkflowSchedule{
             ID:     req.ScheduleID,
             Cron:   req.Cron,
             Target: req.Target,
@@ -874,8 +874,8 @@ signal sequence numbers exactly as stored.
         }, nil
     }
 
-    func (p *Provider) GetSchedule(_ context.Context, req *gestalt.GetWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowScheduleInput, error) {
-        return &gestalt.BoundWorkflowScheduleInput{ID: req.ScheduleID}, nil
+    func (p *Provider) GetSchedule(_ context.Context, req *gestalt.GetWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
+        return &gestalt.BoundWorkflowSchedule{ID: req.ScheduleID}, nil
     }
 
     func (p *Provider) ListSchedules(context.Context, *gestalt.ListWorkflowProviderSchedulesRequest) (*gestalt.ListWorkflowProviderSchedulesResponse, error) {
@@ -886,16 +886,16 @@ signal sequence numbers exactly as stored.
         return nil
     }
 
-    func (p *Provider) PauseSchedule(_ context.Context, req *gestalt.PauseWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowScheduleInput, error) {
-        return &gestalt.BoundWorkflowScheduleInput{ID: req.ScheduleID, Paused: true}, nil
+    func (p *Provider) PauseSchedule(_ context.Context, req *gestalt.PauseWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
+        return &gestalt.BoundWorkflowSchedule{ID: req.ScheduleID, Paused: true}, nil
     }
 
-    func (p *Provider) ResumeSchedule(_ context.Context, req *gestalt.ResumeWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowScheduleInput, error) {
-        return &gestalt.BoundWorkflowScheduleInput{ID: req.ScheduleID, Paused: false}, nil
+    func (p *Provider) ResumeSchedule(_ context.Context, req *gestalt.ResumeWorkflowProviderScheduleRequest) (*gestalt.BoundWorkflowSchedule, error) {
+        return &gestalt.BoundWorkflowSchedule{ID: req.ScheduleID, Paused: false}, nil
     }
 
-    func (p *Provider) UpsertEventTrigger(_ context.Context, req *gestalt.UpsertWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTriggerInput, error) {
-        return &gestalt.BoundWorkflowEventTriggerInput{
+    func (p *Provider) UpsertEventTrigger(_ context.Context, req *gestalt.UpsertWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
+        return &gestalt.BoundWorkflowEventTrigger{
             ID:     req.TriggerID,
             Match:  req.Match,
             Target: req.Target,
@@ -903,8 +903,8 @@ signal sequence numbers exactly as stored.
         }, nil
     }
 
-    func (p *Provider) GetEventTrigger(_ context.Context, req *gestalt.GetWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTriggerInput, error) {
-        return &gestalt.BoundWorkflowEventTriggerInput{ID: req.TriggerID}, nil
+    func (p *Provider) GetEventTrigger(_ context.Context, req *gestalt.GetWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
+        return &gestalt.BoundWorkflowEventTrigger{ID: req.TriggerID}, nil
     }
 
     func (p *Provider) ListEventTriggers(context.Context, *gestalt.ListWorkflowProviderEventTriggersRequest) (*gestalt.ListWorkflowProviderEventTriggersResponse, error) {
@@ -915,12 +915,12 @@ signal sequence numbers exactly as stored.
         return nil
     }
 
-    func (p *Provider) PauseEventTrigger(_ context.Context, req *gestalt.PauseWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTriggerInput, error) {
-        return &gestalt.BoundWorkflowEventTriggerInput{ID: req.TriggerID, Paused: true}, nil
+    func (p *Provider) PauseEventTrigger(_ context.Context, req *gestalt.PauseWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
+        return &gestalt.BoundWorkflowEventTrigger{ID: req.TriggerID, Paused: true}, nil
     }
 
-    func (p *Provider) ResumeEventTrigger(_ context.Context, req *gestalt.ResumeWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTriggerInput, error) {
-        return &gestalt.BoundWorkflowEventTriggerInput{ID: req.TriggerID, Paused: false}, nil
+    func (p *Provider) ResumeEventTrigger(_ context.Context, req *gestalt.ResumeWorkflowProviderEventTriggerRequest) (*gestalt.BoundWorkflowEventTrigger, error) {
+        return &gestalt.BoundWorkflowEventTrigger{ID: req.TriggerID, Paused: false}, nil
     }
 
     func (p *Provider) PublishEvent(context.Context, *gestalt.PublishWorkflowProviderEventRequest) error {
@@ -932,8 +932,8 @@ signal sequence numbers exactly as stored.
   <Tabs.Tab>
     ```python
     from gestalt import (
-        BoundWorkflowRunInput,
-        BoundWorkflowScheduleInput,
+        BoundWorkflowRun,
+        BoundWorkflowSchedule,
         CancelWorkflowProviderRunRequest,
         GetWorkflowProviderRunRequest,
         ListWorkflowProviderRunsResponse,
@@ -951,29 +951,29 @@ signal sequence numbers exactly as stored.
         def configure(self, name: str, config: dict) -> None:
             pass
 
-        def start_run(self, request: StartWorkflowProviderRunRequest) -> BoundWorkflowRunInput:
+        def start_run(self, request: StartWorkflowProviderRunRequest) -> BoundWorkflowRun:
             plugin = request.target.plugin if request.target else None
-            return BoundWorkflowRunInput(
+            return BoundWorkflowRun(
                 id=f"{plugin.plugin_name if plugin else 'workflow'}:run-1",
                 status=WORKFLOW_RUN_STATUS_PENDING,
                 target=request.target,
             )
 
-        def get_run(self, request: GetWorkflowProviderRunRequest) -> BoundWorkflowRunInput:
-            return BoundWorkflowRunInput(id=request.run_id)
+        def get_run(self, request: GetWorkflowProviderRunRequest) -> BoundWorkflowRun:
+            return BoundWorkflowRun(id=request.run_id)
 
         def list_runs(self, request) -> ListWorkflowProviderRunsResponse:
             return ListWorkflowProviderRunsResponse(runs=[])
 
-        def cancel_run(self, request: CancelWorkflowProviderRunRequest) -> BoundWorkflowRunInput:
-            return BoundWorkflowRunInput(
+        def cancel_run(self, request: CancelWorkflowProviderRunRequest) -> BoundWorkflowRun:
+            return BoundWorkflowRun(
                 id=request.run_id,
                 status=WORKFLOW_RUN_STATUS_CANCELED,
             )
 
         def signal_run(self, request: SignalWorkflowProviderRunRequest) -> SignalWorkflowRunResponse:
             return SignalWorkflowRunResponse(
-                run=BoundWorkflowRunInput(id=request.run_id),
+                run=BoundWorkflowRun(id=request.run_id),
                 signal=request.signal,
             )
 
@@ -998,8 +998,8 @@ signal sequence numbers exactly as stored.
 
         def upsert_schedule(
             self, request: UpsertWorkflowProviderScheduleRequest
-        ) -> BoundWorkflowScheduleInput:
-            return BoundWorkflowScheduleInput(
+        ) -> BoundWorkflowSchedule:
+            return BoundWorkflowSchedule(
                 id=request.schedule_id,
                 cron=request.cron,
                 target=request.target,
@@ -1277,8 +1277,8 @@ invoke target plugin operations.
     defer host.Close()
 
     resp, err := host.InvokeOperation(ctx, gestalt.InvokeWorkflowOperationInput{
-        Target: &gestalt.BoundWorkflowTargetInput{
-            Plugin: &gestalt.BoundWorkflowPluginTargetInput{
+        Target: &gestalt.BoundWorkflowTarget{
+            Plugin: &gestalt.BoundWorkflowPluginTarget{
                 PluginName: "roadmap",
                 Operation:  "sync_items",
             },
@@ -1292,15 +1292,15 @@ invoke target plugin operations.
     from gestalt import (
         WorkflowHost,
         InvokeWorkflowOperationInput,
-        BoundWorkflowTargetInput,
-        BoundWorkflowPluginTargetInput,
+        BoundWorkflowTarget,
+        BoundWorkflowPluginTarget,
     )
 
     with WorkflowHost() as host:
         resp = host.invoke_operation(
             InvokeWorkflowOperationInput(
-                target=BoundWorkflowTargetInput(
-                    plugin=BoundWorkflowPluginTargetInput(
+                target=BoundWorkflowTarget(
+                    plugin=BoundWorkflowPluginTarget(
                         plugin_name="roadmap",
                         operation="sync_items",
                     ),
@@ -1315,8 +1315,8 @@ invoke target plugin operations.
     let mut host = gestalt::WorkflowHost::connect().await?;
     let resp = host
         .invoke_operation(gestalt::InvokeWorkflowOperationInput {
-            target: Some(gestalt::BoundWorkflowTargetInput::Plugin(
-                gestalt::BoundWorkflowPluginTargetInput {
+            target: Some(gestalt::BoundWorkflowTarget::Plugin(
+                gestalt::BoundWorkflowPluginTarget {
                     plugin_name: "roadmap".into(),
                     operation: "sync_items".into(),
                     ..Default::default()

--- a/sdk/go/agent_builders.go
+++ b/sdk/go/agent_builders.go
@@ -145,37 +145,6 @@ func AgentToolRefFromRef(value *AgentToolRef) AgentToolRef {
 	}
 }
 
-// NewAgentWorkspace creates an agent workspace.
-func NewAgentWorkspace(input AgentWorkspace) *AgentProtocolWorkspace {
-	checkouts := make([]AgentProtocolWorkspaceGitCheckout, 0, len(input.Checkouts))
-	for _, checkout := range input.Checkouts {
-		checkouts = append(checkouts, AgentProtocolWorkspaceGitCheckout{
-			URL:  checkout.URL,
-			Ref:  checkout.Ref,
-			Path: checkout.Path,
-		})
-	}
-	return &AgentProtocolWorkspace{
-		Checkouts: checkouts,
-		Cwd:       input.CWD,
-	}
-}
-
-func agentMessagesFromInputs(values []AgentMessage) ([]*AgentMessage, error) {
-	if len(values) == 0 {
-		return nil, nil
-	}
-	out := make([]*AgentMessage, 0, len(values))
-	for index, value := range values {
-		message, err := NewAgentMessage(value)
-		if err != nil {
-			return nil, fmt.Errorf("messages[%d]: %w", index, err)
-		}
-		out = append(out, message)
-	}
-	return out, nil
-}
-
 func agentMessageInputsFromMessages(values []*AgentMessage) ([]AgentMessage, error) {
 	if len(values) == 0 {
 		return nil, nil

--- a/sdk/go/agent_conversions.go
+++ b/sdk/go/agent_conversions.go
@@ -74,24 +74,6 @@ func agentMessagesToProto(values []AgentMessage) ([]*proto.AgentMessage, error) 
 	return out, nil
 }
 
-func agentMessagePtrsToProto(values []*AgentMessage) ([]*proto.AgentMessage, error) {
-	if len(values) == 0 {
-		return nil, nil
-	}
-	out := make([]*proto.AgentMessage, 0, len(values))
-	for _, value := range values {
-		if value == nil {
-			continue
-		}
-		pbValue, err := agentMessageToProto(*value)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, pbValue)
-	}
-	return out, nil
-}
-
 func agentMessagePartsFromProto(values []*proto.AgentMessagePart) []AgentMessagePart {
 	if len(values) == 0 {
 		return nil
@@ -133,6 +115,10 @@ func agentMessagePartsToProto(values []AgentMessagePart) ([]*proto.AgentMessageP
 }
 
 func agentMessagePartToProto(value AgentMessagePart) (*proto.AgentMessagePart, error) {
+	partType := value.Type
+	if partType == AgentMessagePartTypeUnspecified {
+		partType = inferAgentMessagePartType(value)
+	}
 	jsonValue, err := StructFromAny(value.JSON)
 	if err != nil {
 		return nil, err
@@ -146,7 +132,7 @@ func agentMessagePartToProto(value AgentMessagePart) (*proto.AgentMessagePart, e
 		return nil, err
 	}
 	return &proto.AgentMessagePart{
-		Type:       proto.AgentMessagePartType(value.Type),
+		Type:       proto.AgentMessagePartType(partType),
 		Text:       value.Text,
 		Json:       jsonValue,
 		ToolCall:   toolCall,
@@ -273,24 +259,6 @@ func agentPreparedWorkspaceFromProto(value *proto.PreparedAgentWorkspace) *Agent
 	return &AgentPreparedWorkspace{
 		Root: value.GetRoot(),
 		Cwd:  value.GetCwd(),
-	}
-}
-
-func agentProtocolWorkspaceToProto(value *AgentProtocolWorkspace) *proto.AgentWorkspace {
-	if value == nil {
-		return nil
-	}
-	checkouts := make([]*proto.AgentWorkspaceGitCheckout, 0, len(value.Checkouts))
-	for _, checkout := range value.Checkouts {
-		checkouts = append(checkouts, &proto.AgentWorkspaceGitCheckout{
-			Url:  checkout.URL,
-			Ref:  checkout.Ref,
-			Path: checkout.Path,
-		})
-	}
-	return &proto.AgentWorkspace{
-		Checkouts: checkouts,
-		Cwd:       value.Cwd,
 	}
 }
 

--- a/sdk/go/agent_manager_inputs.go
+++ b/sdk/go/agent_manager_inputs.go
@@ -96,7 +96,7 @@ func newAgentManagerCreateSessionRequest(input AgentManagerCreateSession) (*prot
 	}
 	var workspace *proto.AgentWorkspace
 	if input.Workspace != nil {
-		workspace = agentProtocolWorkspaceToProto(NewAgentWorkspace(*input.Workspace))
+		workspace = agentWorkspaceToProto(input.Workspace)
 	}
 	return &proto.AgentManagerCreateSessionRequest{
 		ProviderName:   input.ProviderName,
@@ -135,11 +135,7 @@ func newAgentManagerUpdateSessionRequest(input AgentManagerUpdateSession) (*prot
 }
 
 func newAgentManagerCreateTurnRequest(input AgentManagerCreateTurn) (*proto.AgentManagerCreateTurnRequest, error) {
-	nativeMessages, err := agentMessagesFromInputs(input.Messages)
-	if err != nil {
-		return nil, err
-	}
-	messages, err := agentMessagePtrsToProto(nativeMessages)
+	messages, err := agentMessagesToProto(input.Messages)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/agent_provider.go
+++ b/sdk/go/agent_provider.go
@@ -152,17 +152,6 @@ type AgentSubjectContext struct {
 	AuthSource          string
 }
 
-type AgentProtocolWorkspace struct {
-	Checkouts []AgentProtocolWorkspaceGitCheckout
-	Cwd       string
-}
-
-type AgentProtocolWorkspaceGitCheckout struct {
-	URL  string
-	Ref  string
-	Path string
-}
-
 type AgentPreparedWorkspace struct {
 	Root string
 	Cwd  string

--- a/sdk/go/workflow_manager.go
+++ b/sdk/go/workflow_manager.go
@@ -69,7 +69,7 @@ func (c *WorkflowManagerClient) StartRun(ctx context.Context, input WorkflowMana
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req, err := NewWorkflowManagerStartRunRequest(input)
+	req, err := newWorkflowManagerStartRunRequest(input)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (c *WorkflowManagerClient) SignalRun(ctx context.Context, input WorkflowMan
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req, err := NewWorkflowManagerSignalRunRequest(input)
+	req, err := newWorkflowManagerSignalRunRequest(input)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (c *WorkflowManagerClient) SignalOrStartRun(ctx context.Context, input Work
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req, err := NewWorkflowManagerSignalOrStartRunRequest(input)
+	req, err := newWorkflowManagerSignalOrStartRunRequest(input)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (c *WorkflowManagerClient) CreateDefinition(ctx context.Context, input Work
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req, err := NewWorkflowManagerCreateDefinitionRequest(input)
+	req, err := newWorkflowManagerCreateDefinitionRequest(input)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (c *WorkflowManagerClient) GetDefinition(ctx context.Context, input Workflo
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req := NewWorkflowManagerGetDefinitionRequest(input)
+	req := newWorkflowManagerGetDefinitionRequest(input)
 	req.InvocationToken = c.invocationToken
 	resp, err := c.client.GetDefinition(ctx, req)
 	if err != nil {
@@ -160,7 +160,7 @@ func (c *WorkflowManagerClient) UpdateDefinition(ctx context.Context, input Work
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req, err := NewWorkflowManagerUpdateDefinitionRequest(input)
+	req, err := newWorkflowManagerUpdateDefinitionRequest(input)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (c *WorkflowManagerClient) DeleteDefinition(ctx context.Context, input Work
 	if c == nil || c.client == nil {
 		return fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req := NewWorkflowManagerDeleteDefinitionRequest(input)
+	req := newWorkflowManagerDeleteDefinitionRequest(input)
 	req.InvocationToken = c.invocationToken
 	_, err := c.client.DeleteDefinition(ctx, req)
 	return err
@@ -188,7 +188,7 @@ func (c *WorkflowManagerClient) CreateSchedule(ctx context.Context, input Workfl
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req, err := NewWorkflowManagerCreateScheduleRequest(input)
+	req, err := newWorkflowManagerCreateScheduleRequest(input)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (c *WorkflowManagerClient) GetSchedule(ctx context.Context, input WorkflowM
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req := NewWorkflowManagerGetScheduleRequest(input)
+	req := newWorkflowManagerGetScheduleRequest(input)
 	req.InvocationToken = c.invocationToken
 	resp, err := c.client.GetSchedule(ctx, req)
 	if err != nil {
@@ -222,7 +222,7 @@ func (c *WorkflowManagerClient) UpdateSchedule(ctx context.Context, input Workfl
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req, err := NewWorkflowManagerUpdateScheduleRequest(input)
+	req, err := newWorkflowManagerUpdateScheduleRequest(input)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (c *WorkflowManagerClient) DeleteSchedule(ctx context.Context, input Workfl
 	if c == nil || c.client == nil {
 		return fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req := NewWorkflowManagerDeleteScheduleRequest(input)
+	req := newWorkflowManagerDeleteScheduleRequest(input)
 	req.InvocationToken = c.invocationToken
 	_, err := c.client.DeleteSchedule(ctx, req)
 	return err
@@ -250,7 +250,7 @@ func (c *WorkflowManagerClient) PauseSchedule(ctx context.Context, input Workflo
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req := NewWorkflowManagerPauseScheduleRequest(input)
+	req := newWorkflowManagerPauseScheduleRequest(input)
 	req.InvocationToken = c.invocationToken
 	resp, err := c.client.PauseSchedule(ctx, req)
 	if err != nil {
@@ -264,7 +264,7 @@ func (c *WorkflowManagerClient) ResumeSchedule(ctx context.Context, input Workfl
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req := NewWorkflowManagerResumeScheduleRequest(input)
+	req := newWorkflowManagerResumeScheduleRequest(input)
 	req.InvocationToken = c.invocationToken
 	resp, err := c.client.ResumeSchedule(ctx, req)
 	if err != nil {
@@ -278,7 +278,7 @@ func (c *WorkflowManagerClient) CreateTrigger(ctx context.Context, input Workflo
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req, err := NewWorkflowManagerCreateEventTriggerRequest(input)
+	req, err := newWorkflowManagerCreateEventTriggerRequest(input)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +298,7 @@ func (c *WorkflowManagerClient) GetTrigger(ctx context.Context, input WorkflowMa
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req := NewWorkflowManagerGetEventTriggerRequest(input)
+	req := newWorkflowManagerGetEventTriggerRequest(input)
 	req.InvocationToken = c.invocationToken
 	resp, err := c.client.GetEventTrigger(ctx, req)
 	if err != nil {
@@ -312,7 +312,7 @@ func (c *WorkflowManagerClient) UpdateTrigger(ctx context.Context, input Workflo
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req, err := NewWorkflowManagerUpdateEventTriggerRequest(input)
+	req, err := newWorkflowManagerUpdateEventTriggerRequest(input)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +329,7 @@ func (c *WorkflowManagerClient) DeleteTrigger(ctx context.Context, input Workflo
 	if c == nil || c.client == nil {
 		return fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req := NewWorkflowManagerDeleteEventTriggerRequest(input)
+	req := newWorkflowManagerDeleteEventTriggerRequest(input)
 	req.InvocationToken = c.invocationToken
 	_, err := c.client.DeleteEventTrigger(ctx, req)
 	return err
@@ -340,7 +340,7 @@ func (c *WorkflowManagerClient) PauseTrigger(ctx context.Context, input Workflow
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req := NewWorkflowManagerPauseEventTriggerRequest(input)
+	req := newWorkflowManagerPauseEventTriggerRequest(input)
 	req.InvocationToken = c.invocationToken
 	resp, err := c.client.PauseEventTrigger(ctx, req)
 	if err != nil {
@@ -354,7 +354,7 @@ func (c *WorkflowManagerClient) ResumeTrigger(ctx context.Context, input Workflo
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req := NewWorkflowManagerResumeEventTriggerRequest(input)
+	req := newWorkflowManagerResumeEventTriggerRequest(input)
 	req.InvocationToken = c.invocationToken
 	resp, err := c.client.ResumeEventTrigger(ctx, req)
 	if err != nil {
@@ -368,7 +368,7 @@ func (c *WorkflowManagerClient) PublishEvent(ctx context.Context, input Workflow
 	if c == nil || c.client == nil {
 		return nil, fmt.Errorf("workflow manager: client is not initialized")
 	}
-	req, err := NewWorkflowManagerPublishEventRequest(input)
+	req, err := newWorkflowManagerPublishEventRequest(input)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/workflow_manager_inputs.go
+++ b/sdk/go/workflow_manager_inputs.go
@@ -199,7 +199,7 @@ type WorkflowManagerEventTrigger struct {
 
 type WorkflowManagerPublishedEvent = WorkflowEvent
 
-func NewWorkflowManagerStartRunRequest(input WorkflowManagerStartRun) (*proto.WorkflowManagerStartRunRequest, error) {
+func newWorkflowManagerStartRunRequest(input WorkflowManagerStartRun) (*proto.WorkflowManagerStartRunRequest, error) {
 	target, err := newOptionalBoundWorkflowTarget(input.Target)
 	if err != nil {
 		return nil, err
@@ -213,7 +213,7 @@ func NewWorkflowManagerStartRunRequest(input WorkflowManagerStartRun) (*proto.Wo
 	}, nil
 }
 
-func NewWorkflowManagerSignalRunRequest(input WorkflowManagerSignalRun) (*proto.WorkflowManagerSignalRunRequest, error) {
+func newWorkflowManagerSignalRunRequest(input WorkflowManagerSignalRun) (*proto.WorkflowManagerSignalRunRequest, error) {
 	signal, err := newOptionalWorkflowSignal(input.Signal)
 	if err != nil {
 		return nil, err
@@ -224,7 +224,7 @@ func NewWorkflowManagerSignalRunRequest(input WorkflowManagerSignalRun) (*proto.
 	}, nil
 }
 
-func NewWorkflowManagerSignalOrStartRunRequest(input WorkflowManagerSignalOrStartRun) (*proto.WorkflowManagerSignalOrStartRunRequest, error) {
+func newWorkflowManagerSignalOrStartRunRequest(input WorkflowManagerSignalOrStartRun) (*proto.WorkflowManagerSignalOrStartRunRequest, error) {
 	target, err := newOptionalBoundWorkflowTarget(input.Target)
 	if err != nil {
 		return nil, err
@@ -243,7 +243,7 @@ func NewWorkflowManagerSignalOrStartRunRequest(input WorkflowManagerSignalOrStar
 	}, nil
 }
 
-func NewWorkflowManagerCreateDefinitionRequest(input WorkflowManagerCreateDefinition) (*proto.WorkflowManagerCreateDefinitionRequest, error) {
+func newWorkflowManagerCreateDefinitionRequest(input WorkflowManagerCreateDefinition) (*proto.WorkflowManagerCreateDefinitionRequest, error) {
 	target, err := newOptionalBoundWorkflowTarget(input.Target)
 	if err != nil {
 		return nil, err
@@ -255,11 +255,11 @@ func NewWorkflowManagerCreateDefinitionRequest(input WorkflowManagerCreateDefini
 	}, nil
 }
 
-func NewWorkflowManagerGetDefinitionRequest(input WorkflowManagerGetDefinition) *proto.WorkflowManagerGetDefinitionRequest {
+func newWorkflowManagerGetDefinitionRequest(input WorkflowManagerGetDefinition) *proto.WorkflowManagerGetDefinitionRequest {
 	return &proto.WorkflowManagerGetDefinitionRequest{DefinitionId: input.DefinitionID}
 }
 
-func NewWorkflowManagerUpdateDefinitionRequest(input WorkflowManagerUpdateDefinition) (*proto.WorkflowManagerUpdateDefinitionRequest, error) {
+func newWorkflowManagerUpdateDefinitionRequest(input WorkflowManagerUpdateDefinition) (*proto.WorkflowManagerUpdateDefinitionRequest, error) {
 	target, err := newOptionalBoundWorkflowTarget(input.Target)
 	if err != nil {
 		return nil, err
@@ -271,11 +271,11 @@ func NewWorkflowManagerUpdateDefinitionRequest(input WorkflowManagerUpdateDefini
 	}, nil
 }
 
-func NewWorkflowManagerDeleteDefinitionRequest(input WorkflowManagerDeleteDefinition) *proto.WorkflowManagerDeleteDefinitionRequest {
+func newWorkflowManagerDeleteDefinitionRequest(input WorkflowManagerDeleteDefinition) *proto.WorkflowManagerDeleteDefinitionRequest {
 	return &proto.WorkflowManagerDeleteDefinitionRequest{DefinitionId: input.DefinitionID}
 }
 
-func NewWorkflowManagerCreateScheduleRequest(input WorkflowManagerCreateSchedule) (*proto.WorkflowManagerCreateScheduleRequest, error) {
+func newWorkflowManagerCreateScheduleRequest(input WorkflowManagerCreateSchedule) (*proto.WorkflowManagerCreateScheduleRequest, error) {
 	target, err := newOptionalBoundWorkflowTarget(input.Target)
 	if err != nil {
 		return nil, err
@@ -291,11 +291,11 @@ func NewWorkflowManagerCreateScheduleRequest(input WorkflowManagerCreateSchedule
 	}, nil
 }
 
-func NewWorkflowManagerGetScheduleRequest(input WorkflowManagerGetSchedule) *proto.WorkflowManagerGetScheduleRequest {
+func newWorkflowManagerGetScheduleRequest(input WorkflowManagerGetSchedule) *proto.WorkflowManagerGetScheduleRequest {
 	return &proto.WorkflowManagerGetScheduleRequest{ScheduleId: input.ScheduleID}
 }
 
-func NewWorkflowManagerUpdateScheduleRequest(input WorkflowManagerUpdateSchedule) (*proto.WorkflowManagerUpdateScheduleRequest, error) {
+func newWorkflowManagerUpdateScheduleRequest(input WorkflowManagerUpdateSchedule) (*proto.WorkflowManagerUpdateScheduleRequest, error) {
 	target, err := newOptionalBoundWorkflowTarget(input.Target)
 	if err != nil {
 		return nil, err
@@ -311,19 +311,19 @@ func NewWorkflowManagerUpdateScheduleRequest(input WorkflowManagerUpdateSchedule
 	}, nil
 }
 
-func NewWorkflowManagerDeleteScheduleRequest(input WorkflowManagerDeleteSchedule) *proto.WorkflowManagerDeleteScheduleRequest {
+func newWorkflowManagerDeleteScheduleRequest(input WorkflowManagerDeleteSchedule) *proto.WorkflowManagerDeleteScheduleRequest {
 	return &proto.WorkflowManagerDeleteScheduleRequest{ScheduleId: input.ScheduleID}
 }
 
-func NewWorkflowManagerPauseScheduleRequest(input WorkflowManagerPauseSchedule) *proto.WorkflowManagerPauseScheduleRequest {
+func newWorkflowManagerPauseScheduleRequest(input WorkflowManagerPauseSchedule) *proto.WorkflowManagerPauseScheduleRequest {
 	return &proto.WorkflowManagerPauseScheduleRequest{ScheduleId: input.ScheduleID}
 }
 
-func NewWorkflowManagerResumeScheduleRequest(input WorkflowManagerResumeSchedule) *proto.WorkflowManagerResumeScheduleRequest {
+func newWorkflowManagerResumeScheduleRequest(input WorkflowManagerResumeSchedule) *proto.WorkflowManagerResumeScheduleRequest {
 	return &proto.WorkflowManagerResumeScheduleRequest{ScheduleId: input.ScheduleID}
 }
 
-func NewWorkflowManagerCreateEventTriggerRequest(input WorkflowManagerCreateEventTrigger) (*proto.WorkflowManagerCreateEventTriggerRequest, error) {
+func newWorkflowManagerCreateEventTriggerRequest(input WorkflowManagerCreateEventTrigger) (*proto.WorkflowManagerCreateEventTriggerRequest, error) {
 	target, err := newOptionalBoundWorkflowTarget(input.Target)
 	if err != nil {
 		return nil, err
@@ -338,11 +338,11 @@ func NewWorkflowManagerCreateEventTriggerRequest(input WorkflowManagerCreateEven
 	}, nil
 }
 
-func NewWorkflowManagerGetEventTriggerRequest(input WorkflowManagerGetEventTrigger) *proto.WorkflowManagerGetEventTriggerRequest {
+func newWorkflowManagerGetEventTriggerRequest(input WorkflowManagerGetEventTrigger) *proto.WorkflowManagerGetEventTriggerRequest {
 	return &proto.WorkflowManagerGetEventTriggerRequest{TriggerId: input.TriggerID}
 }
 
-func NewWorkflowManagerUpdateEventTriggerRequest(input WorkflowManagerUpdateEventTrigger) (*proto.WorkflowManagerUpdateEventTriggerRequest, error) {
+func newWorkflowManagerUpdateEventTriggerRequest(input WorkflowManagerUpdateEventTrigger) (*proto.WorkflowManagerUpdateEventTriggerRequest, error) {
 	target, err := newOptionalBoundWorkflowTarget(input.Target)
 	if err != nil {
 		return nil, err
@@ -357,19 +357,19 @@ func NewWorkflowManagerUpdateEventTriggerRequest(input WorkflowManagerUpdateEven
 	}, nil
 }
 
-func NewWorkflowManagerDeleteEventTriggerRequest(input WorkflowManagerDeleteEventTrigger) *proto.WorkflowManagerDeleteEventTriggerRequest {
+func newWorkflowManagerDeleteEventTriggerRequest(input WorkflowManagerDeleteEventTrigger) *proto.WorkflowManagerDeleteEventTriggerRequest {
 	return &proto.WorkflowManagerDeleteEventTriggerRequest{TriggerId: input.TriggerID}
 }
 
-func NewWorkflowManagerPauseEventTriggerRequest(input WorkflowManagerPauseEventTrigger) *proto.WorkflowManagerPauseEventTriggerRequest {
+func newWorkflowManagerPauseEventTriggerRequest(input WorkflowManagerPauseEventTrigger) *proto.WorkflowManagerPauseEventTriggerRequest {
 	return &proto.WorkflowManagerPauseEventTriggerRequest{TriggerId: input.TriggerID}
 }
 
-func NewWorkflowManagerResumeEventTriggerRequest(input WorkflowManagerResumeEventTrigger) *proto.WorkflowManagerResumeEventTriggerRequest {
+func newWorkflowManagerResumeEventTriggerRequest(input WorkflowManagerResumeEventTrigger) *proto.WorkflowManagerResumeEventTriggerRequest {
 	return &proto.WorkflowManagerResumeEventTriggerRequest{TriggerId: input.TriggerID}
 }
 
-func NewWorkflowManagerPublishEventRequest(input WorkflowManagerPublishEvent) (*proto.WorkflowManagerPublishEventRequest, error) {
+func newWorkflowManagerPublishEventRequest(input WorkflowManagerPublishEvent) (*proto.WorkflowManagerPublishEventRequest, error) {
 	event, err := newOptionalWorkflowEvent(input.Event)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- avoid the remaining double conversion for Go agent manager turn messages while preserving inferred message-part types
- remove Go AgentProtocolWorkspace and convert AgentWorkspace directly
- make Go workflow-manager proto request builders internal
- update application, agent, and workflow docs to use unsuffixed native SDK types

## Tests
- `go test ./...` (`sdk/go`)
- `npm run typecheck` (`docs`)
- `npm run build:single` (`docs`)
- `npm run test:sdk-docs` (`docs`)
- `go test ./internal/bootstrap -run TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartFails -count=1` (`gestaltd`)
- `go test ./internal/bootstrap -count=1` (`gestaltd`)

Note: a full `go test ./...` from `gestaltd` initially hit the hosted agent runtime proactive replacement timing test once; the focused test and package rerun passed afterward.