### PR TITLE
Add Rust hosted HTTP subject resolver

### DIFF
--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -656,15 +656,46 @@ Implement the target operation in the plugin SDK:
     ```
   </Tabs.Tab>
   <Tabs.Tab>
-    The Rust high-level plugin SDK can serve the webhook target operation. It
-    does not currently expose an HTTP subject hook, so use Go, Python, or
-    TypeScript when the webhook must derive a custom subject.
-
     ```rust
     use serde::{Deserialize, Serialize};
     use std::sync::Arc;
 
+    #[derive(Default)]
     pub struct Provider;
+
+    #[gestalt::async_trait]
+    impl gestalt::Provider for Provider {
+        async fn resolve_http_subject(
+            &self,
+            request: gestalt::HTTPSubjectRequest,
+            _context: &gestalt::Request,
+        ) -> gestalt::Result<Option<gestalt::Subject>> {
+            let team_id = request
+                .params
+                .get("team_id")
+                .and_then(|value| value.as_str())
+                .unwrap_or("");
+            let user_id = request
+                .params
+                .get("user_id")
+                .and_then(|value| value.as_str())
+                .unwrap_or("");
+
+            if team_id.is_empty() || user_id.is_empty() {
+                return Err(gestalt::Error::bad_request(
+                    "missing Slack subject fields",
+                ));
+            }
+
+            Ok(Some(gestalt::Subject {
+                id: format!("slack:{team_id}:{user_id}"),
+                kind: "user".to_string(),
+                display_name: user_id.to_string(),
+                auth_source: "slack".to_string(),
+                ..Default::default()
+            }))
+        }
+    }
 
     #[derive(Deserialize, schemars::JsonSchema)]
     pub struct SlackCommandInput {
@@ -694,7 +725,7 @@ Implement the target operation in the plugin SDK:
         )
     }
 
-    gestalt::export_provider!(constructor = Provider, router = router);
+    gestalt::export_provider!(constructor = Provider::default, router = router);
     ```
   </Tabs.Tab>
   <Tabs.Tab>

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -20,7 +20,7 @@ provider code imports from the crate root after renaming `gestalt-sdk` to
 
 | Section | Start with | Use it for |
 | --- | --- | --- |
-| Provider authoring | [`Provider`], [`Operation`], [`Router`], [`Request`], [`Response`], [`ok`] | Executable plugin providers, typed request handlers, and operation results. |
+| Provider authoring | [`Provider`], [`Operation`], [`Router`], [`Request`], [`HTTPSubjectRequest`], [`Response`], [`ok`] | Executable plugin providers, typed request handlers, hosted HTTP subject hooks, and operation results. |
 | Catalog metadata | [`Catalog`], [`CatalogOperation`], [`Router::register`] | Schema-derived operation catalogs from `serde` and `schemars` types. |
 | Provider runtimes | [`AuthenticationProvider`], [`CacheProvider`], [`S3Provider`], [`SecretsProvider`], [`WorkflowProvider`], [`AgentProvider`], [`PluginRuntimeProvider`] | Host-service backends implemented as Rust providers. |
 | Workflow and agent models | [`new_bound_workflow_target`], [`new_workflow_signal`], [`new_bound_workflow_run`], [`new_workflow_execution_reference`], [`new_agent_message`], [`new_agent_tool_ref`] | Native workflow values, agent messages, tool refs, and copy helpers. |
@@ -112,6 +112,8 @@ The crate exposes higher-level authoring APIs:
 
 - `Provider`, `Request`, `Response`, and `ok(...)` model integration
   providers.
+- `HTTPSubjectRequest` and `Provider::resolve_http_subject` let executable
+  plugins map verified hosted HTTP requests to concrete subjects.
 - `Router` and `Operation` register typed operations and derive catalog
   metadata from `serde` and `schemars`.
 - `AuthenticationProvider`, `CacheProvider`, `S3Provider`, `SecretsProvider`,

--- a/sdk/rust/src/api.rs
+++ b/sdk/rust/src/api.rs
@@ -127,6 +127,33 @@ impl Request {
     }
 }
 
+#[derive(Clone, Debug, Default, PartialEq)]
+/// Carries one verified hosted HTTP request into a provider subject resolver.
+pub struct HTTPSubjectRequest {
+    /// Hosted HTTP binding name from the plugin manifest.
+    pub binding: String,
+    /// HTTP method used for the inbound request.
+    pub method: String,
+    /// Request path received by the hosted HTTP binding.
+    pub path: String,
+    /// Request content type.
+    pub content_type: String,
+    /// Request headers after host-side verification.
+    pub headers: BTreeMap<String, Vec<String>>,
+    /// Request query parameters.
+    pub query: BTreeMap<String, Vec<String>>,
+    /// Decoded request parameters.
+    pub params: serde_json::Map<String, serde_json::Value>,
+    /// Raw request body bytes.
+    pub raw_body: Vec<u8>,
+    /// Security scheme used to verify the request.
+    pub security_scheme: String,
+    /// Subject string verified by the security scheme, when available.
+    pub verified_subject: String,
+    /// Claims verified by the security scheme.
+    pub verified_claims: BTreeMap<String, String>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// Wraps a typed handler response plus an optional explicit HTTP status code.
 pub struct Response<T> {
@@ -222,6 +249,15 @@ pub trait Provider: Send + Sync + 'static {
 
     /// Returns an optional request-scoped catalog extension.
     async fn catalog_for_request(&self, _request: &Request) -> Result<Option<Catalog>> {
+        Ok(None)
+    }
+
+    /// Resolves a hosted HTTP request to a concrete subject before dispatch.
+    async fn resolve_http_subject(
+        &self,
+        _request: HTTPSubjectRequest,
+        _context: &Request,
+    ) -> Result<Option<Subject>> {
         Ok(None)
     }
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -71,8 +71,8 @@ pub use agent_manager::{
     AgentManagerResolveInteraction, AgentManagerUpdateSession, ENV_AGENT_MANAGER_SOCKET,
 };
 pub use api::{
-    Access, Credential, ExternalIdentity, Host, Provider, Request, Response, RuntimeMetadata,
-    Subject, ok,
+    Access, Credential, ExternalIdentity, HTTPSubjectRequest, Host, Provider, Request, Response,
+    RuntimeMetadata, Subject, ok,
 };
 pub use auth::{
     AuthSessionSettings, AuthenticatedUser, AuthenticationProvider, BeginLoginRequest,

--- a/sdk/rust/src/provider_server.rs
+++ b/sdk/rust/src/provider_server.rs
@@ -4,16 +4,18 @@ use serde::Serialize;
 use serde_json::Value;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 
-use crate::api::{Access, Credential, ExternalIdentity, Request, Response, Subject};
+use crate::api::{
+    Access, Credential, ExternalIdentity, HTTPSubjectRequest, Request, Response, Subject,
+};
 use crate::catalog::{catalog_to_proto, object_map};
 use crate::env::CURRENT_PROTOCOL_VERSION;
 use crate::error::{Error, HTTP_INTERNAL_SERVER_ERROR, INTERNAL_ERROR_MESSAGE};
 use crate::generated::v1::integration_provider_server::IntegrationProvider;
 use crate::generated::v1::{
-    ExecuteRequest, GetSessionCatalogRequest, GetSessionCatalogResponse,
+    ExecuteRequest, GetSessionCatalogRequest, GetSessionCatalogResponse, HttpSubjectRequest,
     OperationResult as ProtoOperationResult, PostConnectRequest, PostConnectResponse,
     ProviderMetadata, ResolveHttpSubjectRequest, ResolveHttpSubjectResponse, StartProviderRequest,
-    StartProviderResponse,
+    StartProviderResponse, SubjectContext,
 };
 use crate::rpc_status::{require_protocol_version, rpc_status};
 use crate::{Provider, Router};
@@ -117,26 +119,13 @@ where
                 Arc::clone(&self.provider),
                 &request.operation,
                 Value::Object(object_map(request.params)),
-                Request {
-                    token: request.token,
-                    connection_params: request.connection_params.into_iter().collect(),
-                    subject: request_subject(request.context.as_ref()),
-                    agent_subject: request_subject_field(request.context.as_ref(), "agent_subject"),
-                    external_identity: request_external_identity_field(
-                        request.context.as_ref(),
-                        "external_identity",
-                    ),
-                    agent_external_identity: request_external_identity_field(
-                        request.context.as_ref(),
-                        "agent_external_identity",
-                    ),
-                    credential: request_credential(request.context.as_ref()),
-                    access: request_access(request.context.as_ref()),
-                    host: request_host(request.context.as_ref()),
-                    idempotency_key: request.idempotency_key.trim().to_string(),
-                    workflow: request_workflow(request.context.as_ref()),
-                    invocation_token: request.invocation_token,
-                },
+                request_context(
+                    request.context.as_ref(),
+                    request.token,
+                    request.connection_params.into_iter().collect(),
+                    request.idempotency_key.trim().to_string(),
+                    request.invocation_token,
+                ),
             )
             .await;
 
@@ -157,26 +146,13 @@ where
         }
 
         let request = request.into_inner();
-        let request = Request {
-            token: request.token,
-            connection_params: request.connection_params.into_iter().collect(),
-            subject: request_subject(request.context.as_ref()),
-            agent_subject: request_subject_field(request.context.as_ref(), "agent_subject"),
-            external_identity: request_external_identity_field(
-                request.context.as_ref(),
-                "external_identity",
-            ),
-            agent_external_identity: request_external_identity_field(
-                request.context.as_ref(),
-                "agent_external_identity",
-            ),
-            credential: request_credential(request.context.as_ref()),
-            access: request_access(request.context.as_ref()),
-            host: request_host(request.context.as_ref()),
-            workflow: request_workflow(request.context.as_ref()),
-            idempotency_key: String::new(),
-            invocation_token: String::new(),
-        };
+        let request = request_context(
+            request.context.as_ref(),
+            request.token,
+            request.connection_params.into_iter().collect(),
+            String::new(),
+            String::new(),
+        );
         let catalog = self
             .provider
             .catalog_for_request(&request)
@@ -190,9 +166,39 @@ where
 
     async fn resolve_http_subject(
         &self,
-        _request: GrpcRequest<ResolveHttpSubjectRequest>,
+        request: GrpcRequest<ResolveHttpSubjectRequest>,
     ) -> std::result::Result<GrpcResponse<ResolveHttpSubjectResponse>, Status> {
-        Ok(GrpcResponse::new(ResolveHttpSubjectResponse::default()))
+        let request = request.into_inner();
+        let subject = self
+            .provider
+            .resolve_http_subject(
+                http_subject_request(request.request.as_ref()),
+                &request_context(
+                    request.context.as_ref(),
+                    String::new(),
+                    Default::default(),
+                    String::new(),
+                    String::new(),
+                ),
+            )
+            .await;
+
+        let subject = match subject {
+            Ok(subject) => subject,
+            Err(error) if error.status().is_some() && error.expose_message() => {
+                return Ok(GrpcResponse::new(ResolveHttpSubjectResponse {
+                    reject_status: i32::from(error.status().unwrap_or_default()),
+                    reject_message: error.message().to_owned(),
+                    ..Default::default()
+                }));
+            }
+            Err(error) => return Err(rpc_status("resolve http subject", error)),
+        };
+
+        Ok(GrpcResponse::new(ResolveHttpSubjectResponse {
+            subject: subject.map(subject_to_proto),
+            ..Default::default()
+        }))
     }
 
     async fn post_connect(
@@ -202,6 +208,32 @@ where
         Err(Status::unimplemented(
             "provider does not support post connect",
         ))
+    }
+}
+
+fn request_context(
+    context: Option<&crate::generated::v1::RequestContext>,
+    token: String,
+    connection_params: std::collections::BTreeMap<String, String>,
+    idempotency_key: String,
+    invocation_token: String,
+) -> Request {
+    Request {
+        token,
+        connection_params,
+        subject: request_subject(context),
+        agent_subject: request_subject_field(context, "agent_subject"),
+        external_identity: request_external_identity_field(context, "external_identity"),
+        agent_external_identity: request_external_identity_field(
+            context,
+            "agent_external_identity",
+        ),
+        credential: request_credential(context),
+        access: request_access(context),
+        host: request_host(context),
+        idempotency_key,
+        workflow: request_workflow(context),
+        invocation_token,
     }
 }
 
@@ -299,4 +331,42 @@ fn request_workflow(
         return serde_json::Map::new();
     };
     crate::catalog::object_map(context.workflow.clone())
+}
+
+fn http_subject_request(request: Option<&HttpSubjectRequest>) -> HTTPSubjectRequest {
+    let Some(request) = request else {
+        return HTTPSubjectRequest::default();
+    };
+    HTTPSubjectRequest {
+        binding: request.binding.clone(),
+        method: request.method.clone(),
+        path: request.path.clone(),
+        content_type: request.content_type.clone(),
+        headers: string_lists(&request.headers),
+        query: string_lists(&request.query),
+        params: object_map(request.params.clone()),
+        raw_body: request.raw_body.clone(),
+        security_scheme: request.security_scheme.clone(),
+        verified_subject: request.verified_subject.clone(),
+        verified_claims: request.verified_claims.clone(),
+    }
+}
+
+fn string_lists(
+    values: &std::collections::BTreeMap<String, crate::generated::v1::StringList>,
+) -> std::collections::BTreeMap<String, Vec<String>> {
+    values
+        .iter()
+        .map(|(key, value)| (key.clone(), value.values.clone()))
+        .collect()
+}
+
+fn subject_to_proto(subject: Subject) -> SubjectContext {
+    SubjectContext {
+        id: subject.id,
+        kind: subject.kind,
+        display_name: subject.display_name,
+        auth_source: subject.auth_source,
+        email: subject.email,
+    }
 }

--- a/sdk/rust/tests/transport.rs
+++ b/sdk/rust/tests/transport.rs
@@ -5,8 +5,9 @@ use std::sync::{Arc, Mutex};
 
 use gestalt::proto::v1::integration_provider_client::IntegrationProviderClient;
 use gestalt::proto::v1::{
-    AccessContext, CredentialContext, ExecuteRequest, GetSessionCatalogRequest, HostContext,
-    PostConnectRequest, RequestContext, StartProviderRequest, SubjectContext,
+    AccessContext, CredentialContext, ExecuteRequest, ExternalIdentityContext,
+    GetSessionCatalogRequest, HostContext, HttpSubjectRequest, PostConnectRequest, RequestContext,
+    ResolveHttpSubjectRequest, StartProviderRequest, StringList, SubjectContext,
 };
 use gestalt::{Catalog, CatalogOperation, Operation, Provider, Request, Response, Router, ok};
 use hyper_util::rt::tokio::TokioIo;
@@ -80,7 +81,90 @@ impl Provider for TestProvider {
             }],
         }))
     }
+
+    async fn resolve_http_subject(
+        &self,
+        request: gestalt::HTTPSubjectRequest,
+        context: &Request,
+    ) -> gestalt::Result<Option<gestalt::Subject>> {
+        match request.binding.as_str() {
+            "command" => {
+                let team_id = request
+                    .params
+                    .get("team_id")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                let user_id = request
+                    .params
+                    .get("user_id")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                Ok(Some(gestalt::Subject {
+                    id: format!("slack:{team_id}:{user_id}"),
+                    kind: "user".to_string(),
+                    display_name: format!(
+                        "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+                        request.method.as_str(),
+                        request.path.as_str(),
+                        request.content_type.as_str(),
+                        request
+                            .headers
+                            .get("x-slack-signature")
+                            .and_then(|values| values.first())
+                            .map(String::as_str)
+                            .unwrap_or_default(),
+                        request
+                            .query
+                            .get("trace")
+                            .and_then(|values| values.first())
+                            .map(String::as_str)
+                            .unwrap_or_default(),
+                        String::from_utf8_lossy(&request.raw_body),
+                        request.security_scheme.as_str(),
+                        request.verified_subject.as_str(),
+                        request
+                            .verified_claims
+                            .get("team")
+                            .map(String::as_str)
+                            .unwrap_or_default(),
+                        context.subject.email.as_str(),
+                        context.agent_subject.email.as_str(),
+                        context.external_identity.id.as_str(),
+                        context.agent_external_identity.id.as_str(),
+                        context.credential.mode.as_str(),
+                        context.access.role.as_str(),
+                        context.host.public_base_url.as_str(),
+                    ),
+                    auth_source: context
+                        .workflow
+                        .get("runId")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    ..Default::default()
+                }))
+            }
+            "none" => Ok(None),
+            "reject" => Err(gestalt::Error::permission_denied("unmapped slack subject")),
+            "boom" => Err(gestalt::Error::new("boom")),
+            "defaults" => Ok(Some(gestalt::Subject {
+                id: format!(
+                    "defaults:{}:{}",
+                    request.binding.as_str(),
+                    context.subject.id.as_str()
+                ),
+                kind: "system".to_string(),
+                ..Default::default()
+            })),
+            _ => Ok(None),
+        }
+    }
 }
+
+struct PlainProvider;
+
+#[async_trait]
+impl Provider for PlainProvider {}
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
 struct Input {
@@ -359,11 +443,207 @@ async fn serves_provider_requests_over_unix_socket() {
         "acme|user:user-123|ada@example.com|user|viewer|https://gestalt.example.test|schedule"
     );
 
+    let resolved = client
+        .resolve_http_subject(ResolveHttpSubjectRequest {
+            request: Some(HttpSubjectRequest {
+                binding: "command".to_string(),
+                method: "POST".to_string(),
+                path: "/api/v1/slack/commands/support".to_string(),
+                content_type: "application/x-www-form-urlencoded".to_string(),
+                headers: [(
+                    "x-slack-signature".to_string(),
+                    StringList {
+                        values: vec!["v0=abc123".to_string()],
+                    },
+                )]
+                .into_iter()
+                .collect(),
+                query: [(
+                    "trace".to_string(),
+                    StringList {
+                        values: vec!["trace-123".to_string()],
+                    },
+                )]
+                .into_iter()
+                .collect(),
+                params: Some(helpers::struct_from_json(serde_json::json!({
+                    "team_id": "T123",
+                    "user_id": "U456"
+                }))),
+                raw_body: b"team_id=T123&user_id=U456".to_vec(),
+                security_scheme: "slack_signed".to_string(),
+                verified_subject: "slack-app".to_string(),
+                verified_claims: [("team".to_string(), "T123".to_string())]
+                    .into_iter()
+                    .collect(),
+            }),
+            context: Some(RequestContext {
+                subject: Some(SubjectContext {
+                    id: "user:user-123".to_string(),
+                    kind: "user".to_string(),
+                    email: "ada@example.com".to_string(),
+                    ..Default::default()
+                }),
+                agent_subject: Some(SubjectContext {
+                    id: "user:user-456".to_string(),
+                    kind: "user".to_string(),
+                    email: "grace@example.com".to_string(),
+                    ..Default::default()
+                }),
+                external_identity: Some(ExternalIdentityContext {
+                    r#type: "slack".to_string(),
+                    id: "external-ada".to_string(),
+                }),
+                agent_external_identity: Some(ExternalIdentityContext {
+                    r#type: "slack".to_string(),
+                    id: "external-grace".to_string(),
+                }),
+                credential: Some(CredentialContext {
+                    mode: "subject".to_string(),
+                    ..Default::default()
+                }),
+                access: Some(AccessContext {
+                    policy: "sample_policy".to_string(),
+                    role: "admin".to_string(),
+                }),
+                workflow: Some(helpers::struct_from_json(serde_json::json!({
+                    "runId": "run-123"
+                }))),
+                host: Some(HostContext {
+                    public_base_url: "https://gestalt.example.test".to_string(),
+                }),
+            }),
+        })
+        .await
+        .expect("resolve http subject")
+        .into_inner();
+    let subject = resolved.subject.expect("resolved subject");
+    assert_eq!(subject.id, "slack:T123:U456");
+    assert_eq!(subject.kind, "user");
+    assert_eq!(
+        subject.display_name,
+        "POST|/api/v1/slack/commands/support|application/x-www-form-urlencoded|v0=abc123|trace-123|team_id=T123&user_id=U456|slack_signed|slack-app|T123|ada@example.com|grace@example.com|external-ada|external-grace|subject|admin|https://gestalt.example.test"
+    );
+    assert_eq!(subject.auth_source, "run-123");
+
+    let fallback = client
+        .resolve_http_subject(ResolveHttpSubjectRequest {
+            request: Some(HttpSubjectRequest {
+                binding: "none".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect("resolve http subject fallback")
+        .into_inner();
+    assert!(fallback.subject.is_none());
+    assert_eq!(fallback.reject_status, 0);
+
+    let rejection = client
+        .resolve_http_subject(ResolveHttpSubjectRequest {
+            request: Some(HttpSubjectRequest {
+                binding: "reject".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect("resolve http subject rejection")
+        .into_inner();
+    assert_eq!(rejection.reject_status, 403);
+    assert_eq!(rejection.reject_message, "unmapped slack subject");
+
+    let err = client
+        .resolve_http_subject(ResolveHttpSubjectRequest {
+            request: Some(HttpSubjectRequest {
+                binding: "boom".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect_err("resolve http subject should return gRPC error");
+    assert_eq!(err.code(), Code::Unknown);
+    assert_eq!(err.message(), "resolve http subject: boom");
+
+    let defaults = client
+        .resolve_http_subject(ResolveHttpSubjectRequest {
+            request: Some(HttpSubjectRequest {
+                binding: "defaults".to_string(),
+                ..Default::default()
+            }),
+            context: None,
+        })
+        .await
+        .expect("resolve http subject with default context")
+        .into_inner();
+    assert_eq!(
+        defaults.subject.expect("default subject").id,
+        "defaults:defaults:"
+    );
+
+    let missing = client
+        .resolve_http_subject(ResolveHttpSubjectRequest {
+            request: None,
+            context: None,
+        })
+        .await
+        .expect("resolve http subject with missing request")
+        .into_inner();
+    assert!(missing.subject.is_none());
+
     let err = client
         .post_connect(PostConnectRequest::default())
         .await
         .expect_err("post connect should be unimplemented");
     assert_eq!(err.code(), Code::Unimplemented);
+
+    serve_task.abort();
+    let _ = serve_task.await;
+}
+
+#[tokio::test]
+async fn default_http_subject_resolver_returns_empty_response() {
+    let _env_lock = helpers::env_lock().lock().await;
+    let socket = helpers::temp_socket("rust-http-subject.sock");
+    let _socket_guard = helpers::EnvGuard::set(gestalt::ENV_PROVIDER_SOCKET, socket.as_os_str());
+
+    let serve_task = tokio::spawn(async move {
+        gestalt::runtime::serve_provider(Arc::new(PlainProvider), Router::new())
+            .await
+            .expect("serve provider");
+    });
+
+    helpers::wait_for_socket(&socket).await;
+
+    let channel = Endpoint::try_from("http://[::]:50051")
+        .expect("endpoint")
+        .connect_with_connector(service_fn({
+            let socket = socket.clone();
+            move |_| {
+                let socket = socket.clone();
+                async move { UnixStream::connect(socket).await.map(TokioIo::new) }
+            }
+        }))
+        .await
+        .expect("connect channel");
+    let mut client = IntegrationProviderClient::new(channel);
+
+    let response = client
+        .resolve_http_subject(ResolveHttpSubjectRequest {
+            request: Some(HttpSubjectRequest {
+                binding: "command".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect("resolve http subject")
+        .into_inner();
+    assert!(response.subject.is_none());
+    assert_eq!(response.reject_status, 0);
+    assert_eq!(response.reject_message, "");
 
     serve_task.abort();
     let _ = serve_task.await;


### PR DESCRIPTION
## Summary
- add a high-level Rust SDK `HTTPSubjectRequest` and `Provider::resolve_http_subject` hook for hosted HTTP subject resolution
- wire the Rust integration-provider server to return resolved subjects, fallback responses, explicit HTTP rejections, and gRPC errors through the existing `ResolveHTTPSubject` RPC
- update the Rust SDK README and plugin provider docs with the Rust webhook subject resolver example

## Interface Changes
- New/changed interface: `gestalt::HTTPSubjectRequest` and default `Provider::resolve_http_subject(&self, HTTPSubjectRequest, &Request) -> Result<Option<Subject>>`
- Example usage:

```rust
#[gestalt::async_trait]
impl gestalt::Provider for Provider {
    async fn resolve_http_subject(
        &self,
        request: gestalt::HTTPSubjectRequest,
        _context: &gestalt::Request,
    ) -> gestalt::Result<Option<gestalt::Subject>> {
        let user_id = request.params.get("user_id").and_then(|value| value.as_str()).unwrap_or("");
        Ok(Some(gestalt::Subject {
            id: format!("slack:{user_id}"),
            kind: "user".to_string(),
            ..Default::default()
        }))
    }
}
```

## Functional/Integration Tests
- Tests added or augmented: `sdk/rust/tests/transport.rs`
- Contract boundary covered: Rust SDK Unix-socket integration-provider gRPC transport for `ResolveHTTPSubject`
- Commands run:
  - `cargo test --manifest-path sdk/rust/Cargo.toml --test transport`
  - `cargo doc --manifest-path sdk/rust/Cargo.toml --no-deps`
  - `npm --prefix docs ci`
  - `npm --prefix docs run build:single`
  - `git diff --check`