### PR TITLE
Preserve CI publisher service account metadata

### DIFF
--- a/gestaltd/terraform/main.tf
+++ b/gestaltd/terraform/main.tf
@@ -155,8 +155,8 @@ resource "google_service_account" "chart_publisher" {
 resource "google_service_account" "ci_image_publisher" {
   project      = var.project_id
   account_id   = var.ci_image_publisher_service_account_id
-  display_name = "gestaltd CI image publisher"
-  description  = "Publishes immutable gestaltd CI images to Artifact Registry from GitHub Actions."
+  display_name = "gestaltd CI binary publisher"
+  description  = "Publishes immutable gestaltd CI binary artifacts to GCS from GitHub Actions."
 
   depends_on = [
     google_project_service.required,


### PR DESCRIPTION
## Summary
- Keep the existing gestaltd CI publisher service account display name and description unchanged during the CI image migration.
- Avoid requiring `iam.serviceAccounts.update` from the artifact Terraform deployer while the failed apply resumes creating the image publisher IAM grant.

## Test plan
- [x] `terraform fmt -check -recursive gestaltd/terraform`
- [x] `terraform -chdir=gestaltd/terraform validate`
- [x] `git diff --check`