### PR TITLE
Add Rust post-connect hook support

### DIFF
--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -1020,9 +1020,31 @@ metadata; Gestalt already stores access and refresh tokens separately.
     ```
   </Tabs.Tab>
   <Tabs.Tab>
-    The Rust high-level plugin SDK currently exposes dynamic session catalogs
-    but does not expose a post-connect hook. Use Go, Python, or TypeScript when
-    your provider needs to derive connection metadata during the connect flow.
+    ```rust
+    #[gestalt::async_trait]
+    impl gestalt::Provider for Provider {
+        fn supports_post_connect(&self) -> bool {
+            true
+        }
+
+        async fn post_connect(
+            &self,
+            token: &gestalt::ConnectedToken,
+        ) -> gestalt::Result<std::collections::BTreeMap<String, String>> {
+            Ok([
+                (
+                    "slack_team_id".to_string(),
+                    token.metadata.get("team_id").cloned().unwrap_or_default(),
+                ),
+                ("subject_id".to_string(), token.subject_id.clone()),
+                ("connection".to_string(), token.connection.clone()),
+                ("instance".to_string(), token.instance.clone()),
+            ]
+            .into_iter()
+            .collect())
+        }
+    }
+    ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```typescript

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -20,7 +20,7 @@ provider code imports from the crate root after renaming `gestalt-sdk` to
 
 | Section | Start with | Use it for |
 | --- | --- | --- |
-| Provider authoring | [`Provider`], [`Operation`], [`Router`], [`Request`], [`HTTPSubjectRequest`], [`Response`], [`ok`] | Executable plugin providers, typed request handlers, hosted HTTP subject hooks, and operation results. |
+| Provider authoring | [`Provider`], [`Operation`], [`Router`], [`Request`], [`HTTPSubjectRequest`], [`ConnectedToken`], [`Response`], [`ok`] | Executable plugin providers, typed request handlers, hosted HTTP subject hooks, post-connect metadata hooks, and operation results. |
 | Catalog metadata | [`Catalog`], [`CatalogOperation`], [`Router::register`] | Schema-derived operation catalogs from `serde` and `schemars` types. |
 | Provider runtimes | [`AuthenticationProvider`], [`CacheProvider`], [`S3Provider`], [`SecretsProvider`], [`WorkflowProvider`], [`AgentProvider`], [`PluginRuntimeProvider`] | Host-service backends implemented as Rust providers. |
 | Workflow and agent models | [`new_bound_workflow_target`], [`new_workflow_signal`], [`new_bound_workflow_run`], [`new_workflow_execution_reference`], [`new_agent_message`], [`new_agent_tool_ref`] | Native workflow values, agent messages, tool refs, and copy helpers. |
@@ -110,8 +110,8 @@ asking provider code to assemble transport objects.
 
 The crate exposes higher-level authoring APIs:
 
-- `Provider`, `Request`, `Response`, and `ok(...)` model integration
-  providers.
+- `Provider`, `Request`, `ConnectedToken`, `Response`, and `ok(...)` model
+  integration providers.
 - `HTTPSubjectRequest` and `Provider::resolve_http_subject` let executable
   plugins map verified hosted HTTP requests to concrete subjects.
 - `Router` and `Operation` register typed operations and derive catalog

--- a/sdk/rust/src/api.rs
+++ b/sdk/rust/src/api.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::convert::Infallible;
+use std::time::SystemTime;
 
 use tonic::codegen::async_trait;
 
@@ -88,6 +89,41 @@ pub struct Request {
     pub workflow: serde_json::Map<String, serde_json::Value>,
     /// Invocation token used to call host services.
     pub invocation_token: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+/// Host-managed connection payload passed into post-connect hooks.
+pub struct ConnectedToken {
+    /// Stable connection token id.
+    pub id: String,
+    /// Subject id associated with the connected credential.
+    pub subject_id: String,
+    /// Provider integration name.
+    pub integration: String,
+    /// Connection id or name associated with the credential.
+    pub connection: String,
+    /// Provider instance id or name associated with the credential.
+    pub instance: String,
+    /// Access token stored by the host for the connected credential.
+    pub access_token: String,
+    /// Refresh token stored by the host for the connected credential.
+    pub refresh_token: String,
+    /// Space- or provider-formatted scope string returned by the upstream provider.
+    pub scopes: String,
+    /// Access-token expiration timestamp, when known.
+    pub expires_at: Option<SystemTime>,
+    /// Last refresh timestamp, when known.
+    pub last_refreshed_at: Option<SystemTime>,
+    /// Consecutive refresh failure count tracked by the host.
+    pub refresh_error_count: i32,
+    /// Raw JSON metadata stored with the connected credential.
+    pub metadata_json: String,
+    /// String-valued metadata parsed from [`Self::metadata_json`].
+    pub metadata: BTreeMap<String, String>,
+    /// Credential creation timestamp, when known.
+    pub created_at: Option<SystemTime>,
+    /// Credential update timestamp, when known.
+    pub updated_at: Option<SystemTime>,
 }
 
 impl Request {
@@ -259,6 +295,18 @@ pub trait Provider: Send + Sync + 'static {
         _context: &Request,
     ) -> Result<Option<Subject>> {
         Ok(None)
+    }
+
+    /// Reports whether this provider can derive additional connection metadata
+    /// after the host completes the credential exchange.
+    fn supports_post_connect(&self) -> bool {
+        false
+    }
+
+    /// Returns provider-defined, non-secret connection metadata to persist after
+    /// a successful credential exchange.
+    async fn post_connect(&self, _token: &ConnectedToken) -> Result<BTreeMap<String, String>> {
+        Ok(BTreeMap::new())
     }
 
     /// Shuts the provider down before the runtime exits.

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -71,8 +71,8 @@ pub use agent_manager::{
     AgentManagerResolveInteraction, AgentManagerUpdateSession, ENV_AGENT_MANAGER_SOCKET,
 };
 pub use api::{
-    Access, Credential, ExternalIdentity, HTTPSubjectRequest, Host, Provider, Request, Response,
-    RuntimeMetadata, Subject, ok,
+    Access, ConnectedToken, Credential, ExternalIdentity, HTTPSubjectRequest, Host, Provider,
+    Request, Response, RuntimeMetadata, Subject, ok,
 };
 pub use auth::{
     AuthSessionSettings, AuthenticatedUser, AuthenticationProvider, BeginLoginRequest,

--- a/sdk/rust/src/provider_server.rs
+++ b/sdk/rust/src/provider_server.rs
@@ -1,11 +1,15 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::SystemTime;
 
+use prost_types::Timestamp;
 use serde::Serialize;
 use serde_json::Value;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 
 use crate::api::{
-    Access, Credential, ExternalIdentity, HTTPSubjectRequest, Request, Response, Subject,
+    Access, ConnectedToken, Credential, ExternalIdentity, HTTPSubjectRequest, Request, Response,
+    Subject,
 };
 use crate::catalog::{catalog_to_proto, object_map};
 use crate::env::CURRENT_PROTOCOL_VERSION;
@@ -13,10 +17,11 @@ use crate::error::{Error, HTTP_INTERNAL_SERVER_ERROR, INTERNAL_ERROR_MESSAGE};
 use crate::generated::v1::integration_provider_server::IntegrationProvider;
 use crate::generated::v1::{
     ExecuteRequest, GetSessionCatalogRequest, GetSessionCatalogResponse, HttpSubjectRequest,
-    OperationResult as ProtoOperationResult, PostConnectRequest, PostConnectResponse,
-    ProviderMetadata, ResolveHttpSubjectRequest, ResolveHttpSubjectResponse, StartProviderRequest,
-    StartProviderResponse, SubjectContext,
+    OperationResult as ProtoOperationResult, PostConnectCredential, PostConnectRequest,
+    PostConnectResponse, ProviderMetadata, ResolveHttpSubjectRequest, ResolveHttpSubjectResponse,
+    StartProviderRequest, StartProviderResponse, SubjectContext,
 };
+use crate::protocol;
 use crate::rpc_status::{require_protocol_version, rpc_status};
 use crate::{Provider, Router};
 
@@ -86,6 +91,7 @@ where
     ) -> std::result::Result<GrpcResponse<ProviderMetadata>, Status> {
         Ok(GrpcResponse::new(ProviderMetadata {
             supports_session_catalog: self.provider.supports_session_catalog(),
+            supports_post_connect: self.provider.supports_post_connect(),
             min_protocol_version: CURRENT_PROTOCOL_VERSION,
             max_protocol_version: CURRENT_PROTOCOL_VERSION,
             ..ProviderMetadata::default()
@@ -203,11 +209,24 @@ where
 
     async fn post_connect(
         &self,
-        _request: GrpcRequest<PostConnectRequest>,
+        request: GrpcRequest<PostConnectRequest>,
     ) -> std::result::Result<GrpcResponse<PostConnectResponse>, Status> {
-        Err(Status::unimplemented(
-            "provider does not support post connect",
-        ))
+        if !self.provider.supports_post_connect() {
+            return Err(Status::unimplemented(
+                "provider does not support post connect",
+            ));
+        }
+
+        let request = request.into_inner();
+        let token = connected_token_from_proto(request.token.as_ref())
+            .map_err(|error| rpc_status("post connect", error))?;
+        let metadata = self
+            .provider
+            .post_connect(&token)
+            .await
+            .map_err(|error| rpc_status("post connect", error))?;
+
+        Ok(GrpcResponse::new(PostConnectResponse { metadata }))
     }
 }
 
@@ -235,6 +254,52 @@ fn request_context(
         workflow: request_workflow(context),
         invocation_token,
     }
+}
+
+fn connected_token_from_proto(
+    token: Option<&PostConnectCredential>,
+) -> crate::Result<ConnectedToken> {
+    let Some(token) = token else {
+        return Ok(ConnectedToken::default());
+    };
+    let metadata_json = token.metadata_json.clone();
+    Ok(ConnectedToken {
+        id: token.id.clone(),
+        subject_id: token.subject_id.clone(),
+        integration: token.integration.clone(),
+        connection: token.connection.clone(),
+        instance: token.instance.clone(),
+        access_token: token.access_token.clone(),
+        refresh_token: token.refresh_token.clone(),
+        scopes: token.scopes.clone(),
+        expires_at: time_from_timestamp(token.expires_at.as_ref())?,
+        last_refreshed_at: time_from_timestamp(token.last_refreshed_at.as_ref())?,
+        refresh_error_count: token.refresh_error_count,
+        metadata_json: metadata_json.clone(),
+        metadata: metadata_from_json(&metadata_json),
+        created_at: time_from_timestamp(token.created_at.as_ref())?,
+        updated_at: time_from_timestamp(token.updated_at.as_ref())?,
+    })
+}
+
+fn time_from_timestamp(value: Option<&Timestamp>) -> crate::Result<Option<SystemTime>> {
+    value.map(protocol::system_time_from_timestamp).transpose()
+}
+
+fn metadata_from_json(value: &str) -> BTreeMap<String, String> {
+    if value.trim().is_empty() {
+        return BTreeMap::new();
+    }
+    let Ok(Value::Object(object)) = serde_json::from_str::<Value>(value) else {
+        return BTreeMap::new();
+    };
+    object
+        .into_iter()
+        .filter_map(|(key, value)| match value {
+            Value::String(value) => Some((key, value)),
+            _ => None,
+        })
+        .collect()
 }
 
 fn request_subject(context: Option<&crate::generated::v1::RequestContext>) -> Subject {

--- a/sdk/rust/tests/transport.rs
+++ b/sdk/rust/tests/transport.rs
@@ -1,16 +1,20 @@
 #[allow(dead_code)]
 mod helpers;
 
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use gestalt::proto::v1::integration_provider_client::IntegrationProviderClient;
 use gestalt::proto::v1::{
     AccessContext, CredentialContext, ExecuteRequest, ExternalIdentityContext,
-    GetSessionCatalogRequest, HostContext, HttpSubjectRequest, PostConnectRequest, RequestContext,
-    ResolveHttpSubjectRequest, StartProviderRequest, StringList, SubjectContext,
+    GetSessionCatalogRequest, HostContext, HttpSubjectRequest, PostConnectCredential,
+    PostConnectRequest, RequestContext, ResolveHttpSubjectRequest, StartProviderRequest,
+    StringList, SubjectContext,
 };
 use gestalt::{Catalog, CatalogOperation, Operation, Provider, Request, Response, Router, ok};
 use hyper_util::rt::tokio::TokioIo;
+use prost_types::Timestamp;
 use tokio::net::UnixStream;
 use tonic::Code;
 use tonic::codegen::async_trait;
@@ -159,6 +163,74 @@ impl Provider for TestProvider {
             _ => Ok(None),
         }
     }
+
+    fn supports_post_connect(&self) -> bool {
+        true
+    }
+
+    async fn post_connect(
+        &self,
+        token: &gestalt::ConnectedToken,
+    ) -> gestalt::Result<BTreeMap<String, String>> {
+        Ok([
+            ("id".to_string(), token.id.clone()),
+            ("subject_id".to_string(), token.subject_id.clone()),
+            ("integration".to_string(), token.integration.clone()),
+            ("connection".to_string(), token.connection.clone()),
+            ("instance".to_string(), token.instance.clone()),
+            (
+                "access_token_len".to_string(),
+                token.access_token.len().to_string(),
+            ),
+            (
+                "refresh_token_present".to_string(),
+                (!token.refresh_token.is_empty()).to_string(),
+            ),
+            ("scopes".to_string(), token.scopes.clone()),
+            (
+                "expires_at".to_string(),
+                unix_seconds(token.expires_at.as_ref()),
+            ),
+            (
+                "last_refreshed_at".to_string(),
+                unix_seconds(token.last_refreshed_at.as_ref()),
+            ),
+            (
+                "refresh_error_count".to_string(),
+                token.refresh_error_count.to_string(),
+            ),
+            ("metadata_json".to_string(), token.metadata_json.clone()),
+            (
+                "metadata_count".to_string(),
+                token.metadata.len().to_string(),
+            ),
+            (
+                "team_id".to_string(),
+                token.metadata.get("team_id").cloned().unwrap_or_default(),
+            ),
+            (
+                "has_count".to_string(),
+                token.metadata.contains_key("count").to_string(),
+            ),
+            (
+                "created_at".to_string(),
+                unix_seconds(token.created_at.as_ref()),
+            ),
+            (
+                "updated_at".to_string(),
+                unix_seconds(token.updated_at.as_ref()),
+            ),
+        ]
+        .into_iter()
+        .collect())
+    }
+}
+
+fn unix_seconds(value: Option<&SystemTime>) -> String {
+    value
+        .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_secs().to_string())
+        .unwrap_or_default()
 }
 
 struct PlainProvider;
@@ -294,6 +366,7 @@ async fn serves_provider_requests_over_unix_socket() {
         .expect("get metadata")
         .into_inner();
     assert!(metadata.supports_session_catalog);
+    assert!(metadata.supports_post_connect);
     assert_eq!(
         metadata.min_protocol_version,
         gestalt::CURRENT_PROTOCOL_VERSION
@@ -592,6 +665,174 @@ async fn serves_provider_requests_over_unix_socket() {
         .expect("resolve http subject with missing request")
         .into_inner();
     assert!(missing.subject.is_none());
+
+    let post_connect = client
+        .post_connect(PostConnectRequest {
+            token: Some(PostConnectCredential {
+                id: "token-1".to_string(),
+                subject_id: "user:user-123".to_string(),
+                integration: "slack".to_string(),
+                connection: "workspace".to_string(),
+                instance: "default".to_string(),
+                access_token: "access-secret".to_string(),
+                refresh_token: "refresh-secret".to_string(),
+                scopes: "channels:read chat:write".to_string(),
+                expires_at: Some(Timestamp {
+                    seconds: 100,
+                    nanos: 0,
+                }),
+                last_refreshed_at: Some(Timestamp {
+                    seconds: 200,
+                    nanos: 0,
+                }),
+                refresh_error_count: 2,
+                metadata_json: r#"{"team_id":"T123","count":3,"nested":{},"empty":""}"#.to_string(),
+                created_at: Some(Timestamp {
+                    seconds: 300,
+                    nanos: 0,
+                }),
+                updated_at: Some(Timestamp {
+                    seconds: 400,
+                    nanos: 0,
+                }),
+            }),
+        })
+        .await
+        .expect("post connect")
+        .into_inner();
+    let metadata = post_connect.metadata;
+    assert_eq!(metadata.get("id").map(String::as_str), Some("token-1"));
+    assert_eq!(
+        metadata.get("subject_id").map(String::as_str),
+        Some("user:user-123")
+    );
+    assert_eq!(
+        metadata.get("integration").map(String::as_str),
+        Some("slack")
+    );
+    assert_eq!(
+        metadata.get("connection").map(String::as_str),
+        Some("workspace")
+    );
+    assert_eq!(
+        metadata.get("instance").map(String::as_str),
+        Some("default")
+    );
+    assert_eq!(
+        metadata.get("access_token_len").map(String::as_str),
+        Some("13")
+    );
+    assert_eq!(
+        metadata.get("refresh_token_present").map(String::as_str),
+        Some("true")
+    );
+    assert_eq!(
+        metadata.get("scopes").map(String::as_str),
+        Some("channels:read chat:write")
+    );
+    assert_eq!(metadata.get("expires_at").map(String::as_str), Some("100"));
+    assert_eq!(
+        metadata.get("last_refreshed_at").map(String::as_str),
+        Some("200")
+    );
+    assert_eq!(
+        metadata.get("refresh_error_count").map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(
+        metadata.get("metadata_json").map(String::as_str),
+        Some(r#"{"team_id":"T123","count":3,"nested":{},"empty":""}"#)
+    );
+    assert_eq!(
+        metadata.get("metadata_count").map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(metadata.get("team_id").map(String::as_str), Some("T123"));
+    assert_eq!(metadata.get("has_count").map(String::as_str), Some("false"));
+    assert_eq!(metadata.get("created_at").map(String::as_str), Some("300"));
+    assert_eq!(metadata.get("updated_at").map(String::as_str), Some("400"));
+
+    let invalid_metadata = client
+        .post_connect(PostConnectRequest {
+            token: Some(PostConnectCredential {
+                metadata_json: "{not json".to_string(),
+                ..Default::default()
+            }),
+        })
+        .await
+        .expect("post connect with invalid metadata json")
+        .into_inner()
+        .metadata;
+    assert_eq!(
+        invalid_metadata.get("metadata_count").map(String::as_str),
+        Some("0")
+    );
+
+    let default_token = client
+        .post_connect(PostConnectRequest::default())
+        .await
+        .expect("post connect with missing token")
+        .into_inner()
+        .metadata;
+    assert_eq!(default_token.get("id").map(String::as_str), Some(""));
+    assert_eq!(
+        default_token.get("metadata_count").map(String::as_str),
+        Some("0")
+    );
+
+    let err = client
+        .post_connect(PostConnectRequest {
+            token: Some(PostConnectCredential {
+                expires_at: Some(Timestamp {
+                    seconds: 0,
+                    nanos: 1_000_000_000,
+                }),
+                ..Default::default()
+            }),
+        })
+        .await
+        .expect_err("invalid timestamp should fail");
+    assert_eq!(err.code(), Code::InvalidArgument);
+
+    serve_task.abort();
+    let _ = serve_task.await;
+}
+
+#[tokio::test]
+async fn rejects_post_connect_for_unsupported_provider() {
+    let _env_lock = helpers::env_lock().lock().await;
+    let socket = helpers::temp_socket("rust-sdk-nopc.sock");
+    let _socket_guard = helpers::EnvGuard::set(gestalt::ENV_PROVIDER_SOCKET, socket.as_os_str());
+
+    let provider = Arc::new(PlainProvider);
+    let serve_provider = Arc::clone(&provider);
+    let serve_task = tokio::spawn(async move {
+        gestalt::runtime::serve_provider(serve_provider, Router::new())
+            .await
+            .expect("serve provider");
+    });
+
+    helpers::wait_for_socket(&socket).await;
+
+    let channel = Endpoint::try_from("http://[::]:50051")
+        .expect("endpoint")
+        .connect_with_connector(service_fn({
+            let socket = socket.clone();
+            move |_| {
+                let socket = socket.clone();
+                async move { UnixStream::connect(socket).await.map(TokioIo::new) }
+            }
+        }))
+        .await
+        .expect("connect channel");
+    let mut client = IntegrationProviderClient::new(channel);
+
+    let metadata = client
+        .get_metadata(())
+        .await
+        .expect("get metadata")
+        .into_inner();
+    assert!(!metadata.supports_post_connect);
 
     let err = client
         .post_connect(PostConnectRequest::default())


### PR DESCRIPTION
## Summary

- Add Rust SDK support for post-connect metadata hooks through `ConnectedToken` and new `Provider` methods.
- Route `PostConnect` requests through the Rust `ProviderServer`, including token conversion, metadata JSON parsing, and timestamp validation.
- Update Rust transport coverage plus provider docs and the Rust README with the new post-connect API.

## Interface Changes

- New/changed interface: `gestalt::ConnectedToken`, `Provider::supports_post_connect`, and `Provider::post_connect`.
- Example usage:

```rust
fn supports_post_connect(&self) -> bool {
    true
}

async fn post_connect(&self, token: &ConnectedToken) -> gestalt::Result<BTreeMap<String, String>> {
    Ok(token.metadata.clone())
}
```

## Functional/Integration Tests

- Tests added or augmented: `sdk/rust/tests/transport.rs`.
- Contract boundary covered: gRPC `IntegrationProvider` `GetMetadata` and `PostConnect` over the Rust provider transport, including supported/unsupported providers, full token conversion, malformed metadata JSON, missing token defaults, and invalid timestamp rejection.
- Commands run:
  - `cargo fmt --check`
  - `cargo test --test transport`
  - `cargo test`
  - `cargo clippy --all-targets -- -D warnings`
  - `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`
  - `bash ../../docs/scripts/check-sdk-doc-leaks.sh rust target/doc/gestalt`
  - `npm run build`
  - `npm run test:sdk-docs`
  - `npm run test:sdk-api-docs`

No follow-up PRs are planned; this is a standalone Rust SDK parity change.