### PR TITLE
Clean up provider docs

### DIFF
--- a/docs/components/ActiveDevelopmentCallout.tsx
+++ b/docs/components/ActiveDevelopmentCallout.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+import { Callout } from "nextra/components";
+import { Link } from "nextra-theme-docs";
+
+const DEFAULT_CHANGE_NOTE =
+  "Breaking changes may happen between releases without warning.";
+const ISSUES_URL = "https://github.com/valon-technologies/gestalt/issues";
+
+type ActiveDevelopmentCalloutProps = {
+  children: ReactNode;
+  changeNote?: ReactNode;
+  verb?: "is" | "are";
+};
+
+export default function ActiveDevelopmentCallout({
+  children,
+  changeNote = DEFAULT_CHANGE_NOTE,
+  verb = "is",
+}: ActiveDevelopmentCalloutProps) {
+  const stabilityVerb = verb === "are" ? "are" : "is";
+
+  return (
+    <Callout type="warning">
+      {children} {verb} under active development and {stabilityVerb} not yet
+      stable. {changeNote} Feedback and bug reports are welcome via{" "}
+      <Link href={ISSUES_URL}>GitHub Issues</Link>.
+    </Callout>
+  );
+}

--- a/docs/content/applications.mdx
+++ b/docs/content/applications.mdx
@@ -1,12 +1,9 @@
 import { Callout, Tabs } from 'nextra/components'
+import ActiveDevelopmentCallout from '../components/ActiveDevelopmentCallout'
 
 # Applications
 
-<Callout type="warning">
-  Alpha. Applications are under active development and not yet stable. Breaking
-  changes may happen between releases without warning. Feedback and bug reports
-  are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
-</Callout>
+<ActiveDevelopmentCallout verb="are">Applications</ActiveDevelopmentCallout>
 
 <Callout type="info">
   Build a plugin when you need new operations. Build an application when that

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -1,12 +1,9 @@
-import { Callout, Tabs } from 'nextra/components'
+import { Tabs } from 'nextra/components'
+import ActiveDevelopmentCallout from '../../components/ActiveDevelopmentCallout'
 
 # Agent
 
-<Callout type="warning">
-  Alpha. Agents are under active development and not yet stable. Breaking
-  changes may happen between releases without warning. Feedback and bug reports
-  are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
-</Callout>
+<ActiveDevelopmentCallout verb="are">Agents</ActiveDevelopmentCallout>
 
 Gestalt agent providers expose one portable session-and-turn interface for
 agent backends such as Claude Code, Codex, Cursor, or custom harnesses.

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -2,7 +2,8 @@
 asIndexPage: true
 ---
 
-import { Callout, Cards, Tabs } from 'nextra/components'
+import { Cards, Tabs } from 'nextra/components'
+import ActiveDevelopmentCallout from '../../components/ActiveDevelopmentCallout'
 
 # Providers
 
@@ -160,12 +161,9 @@ plugins:
 
 ## Provider Installation
 
-<Callout type="warning">
-  The `gestaltd provider` commands are under active development and are not yet
-  stable. Breaking changes may happen between releases without warning.
-  Feedback and bug reports are welcome via
-  [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
-</Callout>
+<ActiveDevelopmentCallout verb="are">
+  The <code>gestaltd provider</code> commands
+</ActiveDevelopmentCallout>
 
 Use the provider CLI to add, inspect, lock, sync, upgrade, and remove configured
 providers. Mutating commands accept one `--config` path and update the lockfile

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -515,17 +515,6 @@ roll back together.
   </Tabs.Tab>
 </Tabs>
 
-## First-party IndexedDB providers
-
-First-party storage backends live under
-[`valon-technologies/gestalt-providers/indexeddb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb).
-
-| Provider | Notes |
-| --- | --- |
-| [`github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) | Supports PostgreSQL, MySQL, SQLite, and SQL Server through a `dsn` config value |
-| [`github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/dynamodb) | Uses Amazon DynamoDB with `table`, `region`, and optional `endpoint` config |
-| [`github.com/valon-technologies/gestalt-providers/indexeddb/mongodb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/mongodb) | Uses MongoDB with `uri` and optional `database` config |
-
 ## Configuring storage
 
 For local development, SQLite keeps setup simple:
@@ -626,8 +615,6 @@ package relationaldb
 import (
   "context"
   "database/sql"
-  "fmt"
-  "strings"
 
   gestalt "github.com/valon-technologies/gestalt/sdk/go"
 )
@@ -637,28 +624,6 @@ type RelationalDB struct {
 }
 
 func New() *RelationalDB { return &RelationalDB{} }
-
-func (r *RelationalDB) Configure(_ context.Context, _ string, config map[string]any) error {
-  dsn, _ := config["dsn"].(string)
-  if dsn == "" {
-    return fmt.Errorf("relationaldb: dsn is required")
-  }
-  driver := "sqlite"
-  connStr := dsn
-  switch {
-  case strings.HasPrefix(dsn, "postgres://"):
-    driver, connStr = "pgx", dsn
-  case strings.HasPrefix(dsn, "mysql://"):
-    driver, connStr = "mysql", strings.TrimPrefix(dsn, "mysql://")
-  case strings.HasPrefix(dsn, "sqlserver://"):
-    driver, connStr = "sqlserver", dsn
-  case strings.HasPrefix(dsn, "sqlite://"):
-    driver, connStr = "sqlite", strings.TrimPrefix(dsn, "sqlite://")
-  }
-  var err error
-  r.db, err = sql.Open(driver, connStr)
-  return err
-}
 
 func (r *RelationalDB) HealthCheck(ctx context.Context) error {
   return r.db.PingContext(ctx)
@@ -695,28 +660,6 @@ func (r *RelationalDB) Delete(ctx context.Context, req gestalt.IndexedDBObjectSt
 // See the W3C IndexedDB specification for the remaining methods:
 // https://www.w3.org/TR/IndexedDB/#object-store-interface
 ```
-
-### Plugin access, scoping, and deployment
-
-Plugin-side IndexedDB usage is documented in
-[Using IndexedDB from a plugin](/providers/indexeddb#using-indexeddb-from-a-plugin).
-Provider authors should still support logical store names: when a plugin binds a
-datastore with `plugins.<name>.indexeddb`, Gestalt rebuilds the selected provider
-with plugin-scoped config before exposing it over the SDK socket.
-
-Object store names remain logical inside plugins. The host scopes plugin data
-by rebuilding providers with provider-native namespace config instead of
-rewriting object-store names at the SDK transport layer.
-
-For SQL-backed providers such as `indexeddb/relationaldb`, honor `columns` on
-`CreateObjectStore` so the backend can materialize concrete table schemas.
-Document-style providers may ignore `columns`, but preserving the schema in the
-SDK contract keeps stores portable across backend styles.
-
-Configure IndexedDB providers with the shape shown in
-[Configuring storage](/providers/indexeddb#configuring-storage). For package
-publishing, lock/sync, and release behavior, see
-[Releasing provider packages](/providers#releasing-provider-packages).
 
 ## What to read next
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -1,4 +1,5 @@
-import { Callout, Tabs } from 'nextra/components'
+import { Tabs } from 'nextra/components'
+import ActiveDevelopmentCallout from '../../components/ActiveDevelopmentCallout'
 
 # Plugins
 
@@ -12,7 +13,7 @@ and MCP exposure.
 A plugin package includes a manifest that defines metadata, connections, and
 optional passthrough API surfaces. Plugins can be
 [executable](#defining-operations), [declarative](#declarative-plugins), or
-both.
+[both](#hybrid-providers).
 Plugins support:
 
 > REST/OpenAPI, GraphQL, MCP and executable custom-defined code
@@ -97,10 +98,7 @@ plugins:
 
 ### `allowedHosts`
 
-<Callout type="warning">
-  `allowedHosts` is under active development and is not yet stable. Breaking
-  changes may happen between releases without warning.
-</Callout>
+<ActiveDevelopmentCallout><code>allowedHosts</code></ActiveDevelopmentCallout>
 
 Use `egress.allowedHosts` when a plugin needs explicit outbound access:
 
@@ -838,6 +836,17 @@ parameters or request body fields.
 
 You can also declare OpenAPI, GraphQL, and MCP surfaces using `spec.surfaces.openapi`, `spec.surfaces.graphql`, and `spec.surfaces.mcp`. See [Provider Manifests](/reference/plugin-manifests) for the full surface schema.
 
+#### Hybrid providers
+
+A plugin can combine declarative passthrough surfaces with executable
+operations. The host forwards declarative operations directly to the upstream
+API, while executable operations run in the provider process. Both appear in the
+same catalog.
+
+Do not define the same operation ID in more than one surface. If two surfaces
+expose the same ID, provider validation fails. Use `allowedOperations` to filter
+or alias collisions when needed.
+
 ### Operation ID conventions
 
 Operation IDs should use period-separated hierarchical names. The Slack plugin uses `conversations.list`, `conversations.history`, `chat.postMessage`, and `users.info`.
@@ -1014,19 +1023,8 @@ metadata; Gestalt already stores access and refresh tokens separately.
 
 ### Testing locally
 
-Use the provider-local commands when you are iterating on a source plugin.
-`gestaltd provider dev` and `gestaltd provider validate` synthesize a local
-Gestalt config around the target plugin instead of requiring a hand-written
-temp config. If the plugin manifest declares `spec.ui.path`, Gestalt mounts
-that owned UI automatically. For the common `plugin/` + sibling `ui/` layout,
-the local commands also detect `../ui/manifest.yaml` and wire it in
-automatically during local development.
-
-When no config file supplies an explicit `plugins.<name>.ui.path`, the inferred
-local UI path comes from the manifest `source` slug. For example,
-`github.com/acme/tools/plugins/vm-style-guide` mounts at `/vm-style-guide`.
-The plugin key remains API-safe, so the same plugin may still be addressed as
-`vm_style_guide` in local integration APIs.
+Use `gestaltd provider validate` and `gestaltd provider dev` when iterating on
+source plugins.
 
 Validate the plugin in isolation:
 
@@ -1061,6 +1059,8 @@ entries. That makes it possible to boot some supporting providers while
 suppressing others for a local session.
 
 #### Attaching local code to a remote server
+
+<ActiveDevelopmentCallout changeNote="Behavior, authorization requirements, and attach-session semantics may change between releases without warning.">Remote provider dev</ActiveDevelopmentCallout>
 
 Use remote provider dev when you want a remote Gestalt instance to handle auth,
 authorization, connections, secrets, and host services, but route a selected
@@ -1116,14 +1116,6 @@ Once the local server is running, invoke an operation:
 ```sh
 gestalt plugin invoke slack conversations.getMessage -p channel=C01ABC23DEF -p ts=1712161829.000300
 ```
-
-### Hybrid providers
-
-A manifest can define passthrough surfaces alongside executable operations. The passthrough surfaces are forwarded by the host directly to the upstream API, while the executable operations are handled by the provider process.
-
-The first-party Slack plugin is a hybrid provider. It declares 14 REST operations in its manifest (such as `chat.postMessage`, `conversations.list`, and `users.info`) that Gestalt forwards directly to the Slack API. On top of those, it defines 3 executable operations (such as `conversations.getMessage`) that add custom logic like URL parsing and multi-API orchestration. Both sets of operations appear in the same catalog.
-
-Do not define the same operation ID in both a passthrough surface and an executable operation. If two surfaces expose the same ID, the provider fails validation at startup. Use `allowedOperations` to filter or alias collisions when needed.
 
 ## What to read next
 

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -1,48 +1,24 @@
-import { Callout, Tabs } from 'nextra/components'
+import ActiveDevelopmentCallout from '../../components/ActiveDevelopmentCallout'
 
 # Runtime
 
-<Callout type="warning">
-  Alpha. Runtimes are under active development and not yet stable. Breaking
-  changes may happen between releases without warning. Feedback and bug reports
-  are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
-</Callout>
+<ActiveDevelopmentCallout verb="are">Runtimes</ActiveDevelopmentCallout>
 
-Runtime providers manage **where executable plugins, hosted agent providers, and hosted workflow providers run**.
+Runtime providers manage **where executable plugins, hosted agent providers, and
+hosted workflow providers run**.
 
-A runtime provider is not the plugin or hosted provider itself, and it is not a
-host provider like authentication, IndexedDB, or workflow. Instead, it is a
-control-plane backend that lets `gestaltd` create a runtime session, prepare
-relay-backed host-service environment variables, start the provider process
-there, and dial the provider back over gRPC.
+By default, executable providers run on the same machine as `gestaltd`. A
+runtime provider lets an operator place selected providers in another execution
+environment, such as a local driver, container host, or hosted sandbox.
 
-## Scope
+## When to use a runtime
 
-Runtime providers apply to executable plugins under `plugins.<name>`, agent
-providers under `providers.agent.<name>`, and workflow providers under
-`providers.workflow.<name>` when they opt into hosted execution.
-They do **not** replace host-local infrastructure providers such as
-authentication, authorization, IndexedDB, cache, S3, secrets, or workflow.
-Those providers still live on the `gestaltd` host. A runtime provider only
-changes where the configured provider process runs.
+Use a runtime when the provider needs a stronger execution boundary, a hosted
+Linux environment, runtime-managed image startup, sandboxing, or specific egress
+policy enforcements.
 
-## Mental model
-
-By default, executable plugins, agent providers, and workflow providers run on the same machine as
-`gestaltd`. A provider only uses a runtime provider when it opts in with
-`runtime` and selects a backend with `runtime`.
-
-When a provider does opt in, Gestalt selects a backend from `runtime.providers`,
-reads the backend's support profile, starts a runtime session, waits for that
-session to become ready, prepares any required host-service relay bindings,
-starts the provider process inside the session, then dials it back over gRPC.
-From that point on, the hosted provider behaves like any other configured
-provider from the caller's point of view. Gestalt stops the runtime session
-during shutdown or after a bootstrap failure.
-
-That is why the runtime interface is bigger than a single `StartPlugin` call:
-Gestalt needs an explicit lifecycle boundary, not just a fire-and-forget launch
-RPC.
+Keep the provider host-local when it is trusted, lightweight, and does not need
+runtime-specific isolation or deployment controls.
 
 ## Configuring a runtime provider
 
@@ -74,88 +50,16 @@ plugins:
 ```
 
 Selection is intentionally two-step. `runtime.providers` defines named
-backends, while `runtime` opts a specific plugin, agent provider, or workflow
-provider into hosted execution. `server.runtime.defaultProvider` is only
-a default selector for providers that already opted into hosted execution.
-
-## Runtime profiles
-
-Runtime backends are not interchangeable, but the compatibility check is meant
-to read in terms of behavior, not implementation details. Gestalt asks whether
-the runtime can host plugins, how hosted plugins reach Gestalt-owned services,
-and whether the runtime can preserve hostname-based `egress.allowedHosts`.
-
-Host-service access is derived by Gestalt from the current host deployment.
-`none` means host services are unavailable for that runtime, while `relay`
-means Gestalt can provide those services through the relay path exposed at
-`server.baseUrl`, or at `server.runtime.relayBaseUrl` when hosted runtimes need
-a private callback origin such as the management listener or an internal reverse
-proxy. Egress support is separate: a runtime must preserve Gestalt's
-hostname-based policy model before plugins with `egress.allowedHosts` or a
-default-deny egress policy can run there.
-
-The admin inspection API exposes both sides of that decision. `GET
-/admin/api/v1/runtime/providers` includes `profile.advertised`, which is what
-the runtime reports, and `profile.effective`, which is what this `gestaltd`
-deployment can actually provide after relay and public proxy prerequisites are
-considered.
-
-## Host services and hosted plugins
-
-Plugins do not talk directly to host-local services over the public network.
-`gestaltd` starts those services on the host and gives the runtime relay-backed
-bindings. The hosted plugin talks back to `gestaltd` over a scoped relay target,
-and `gestaltd` forwards the request to the real host-local service.
-
-That same split shows up in hostname-based egress. A runtime may preserve
-`egress.allowedHosts` internally, or it may preserve it by routing hosted
-HTTP(S) traffic through Gestalt's public egress proxy. Either way, the contract
-is that the meaning of `egress.allowedHosts` stays the same from the plugin's
-point of view.
-
-The runtime provider is also responsible for the plugin's own listener endpoint.
-`StartPlugin` must start the plugin, allocate or inject its provider listener,
-and return a **host-reachable** `dial_target`. Gestalt currently supports
-`unix://`, `tcp://`, and `tls://` dial targets.
-
-## Agent workspaces
-
-Hosted agent providers can request a prepared workspace when a caller creates an
-agent session. Gestalt does not clone repositories on the `gestaltd` host and
-does not ask the agent provider to clone them. Instead, it calls
-`PrepareWorkspace` on the selected runtime session before it calls the hosted
-agent provider's `CreateSession`.
-
-The runtime receives the runtime `session_id`, the agent `session_id`, and the
-normalized `AgentWorkspace` request. It prepares a per-agent-session directory
-inside the runtime, clones the requested repositories, and returns absolute
-`root` and `cwd` paths. The agent provider then launches the vendor harness from
-that prepared `cwd`. When a non-idempotent session create fails, or when the
-session is removed, Gestalt calls `RemoveWorkspace` so the runtime can clean up
-that per-agent workspace.
-
-Runtime providers that implement this must advertise
-`supports_prepare_workspace`. The local runtime prepares workspaces under the
-runtime session directory; hosted runtimes should prepare them inside the same
-sandbox that will run the agent provider so credentials, filesystem state, and
-cleanup all stay on one side of the runtime boundary.
-
-## Local vs hosted backends
-
-Today there are two main runtime choices:
-
-| Backend | Type | Notes |
-| --- | --- | --- |
-| `local` | Built-in driver | Runs the plugin on the same machine as `gestaltd`. Supports host-path execution and the existing host-local runtime behavior. |
-| `modal` | Installable `kind: runtime` provider | Runs the plugin in a hosted Linux sandbox. Requires `runtime.providers.<name>.config.app` and `plugins.<name>.runtime.image`. When the host is configured for the public relay and proxy path, Modal can run plugins that need Gestalt-owned services and hostname-based egress. |
+backends, while a plugin, agent provider, or workflow provider opts into hosted
+execution with its own `runtime` block. `server.runtime.defaultProvider` only
+selects a default backend for entries that already opted into hosted execution.
 
 ## Provider images
 
 Hosted runtime providers run prebuilt provider images. Gestalt does not upload
-provider bundles into those sessions. Instead, the configured image must contain
-the provider package at the image working directory and preserve the release
-package layout. Gestalt starts the manifest entrypoint path from that working
-directory and passes the manifest entrypoint args.
+provider bundles into hosted sessions. The configured image should contain the
+provider package at the image working directory and preserve the release package
+layout.
 
 ```yaml
 plugins:
@@ -168,445 +72,42 @@ plugins:
       image: ghcr.io/example/support-plugin@sha256:...
 ```
 
-This is why `plugins.<name>.runtime.image`, `template`,
-`imagePullAuth`, and `metadata` are forwarded to the runtime backend: they are
-runtime-specific session hints, not universal plugin semantics. For private OCI
-images, `imagePullAuth.dockerConfigJson` carries Docker config JSON, matching
-the registry auth material used by Docker and Kubernetes image pull secrets.
-Keep the manifest release and image digest in sync; Gestalt does not inspect the
-image to prove that the manifest entrypoint exists inside it.
+Keep the manifest release and image digest in sync. Gestalt does not inspect
+the image to prove that the manifest entrypoint exists inside it.
+
+For private OCI images, configure `imagePullAuth.dockerConfigJson` with Docker
+config JSON, matching the registry auth material used by Docker and Kubernetes
+image pull secrets.
 
 ## Building your own runtime provider
 
-The [scope](/providers/runtime#scope) and
-[mental model](/providers/runtime#mental-model) sections define what runtime
-providers do. This section focuses on the provider manifest and RPC contract.
-
-### Manifest
-
-A runtime provider manifest declares `kind: runtime`:
+Build a runtime provider only when you need to add a new execution backend.
+Runtime providers use the same package model as other executable providers:
+manifest, entrypoint, optional config schema, release archive, and published
+`provider-release.yaml` metadata.
 
 ```yaml
 kind: runtime
 source: github.com/your-org/runtime/example
 version: 0.0.1
 displayName: Example Runtime
-description: Hosted runtime backend for executable plugins.
+description: Hosted runtime backend for executable providers.
 entrypoint:
   artifactPath: ./bin/example-runtime
 spec:
   configSchemaPath: ./schemas/config.schema.yaml
 ```
 
-Like authentication, cache, IndexedDB, S3, secrets, and workflow providers,
-runtime providers use the common provider package model: manifest, executable
-entrypoint, optional config schema, and the normal `provider-release.yaml`
-packaging flow.
-
-### Deployment config
-
-Operators configure runtime providers under top-level `runtime.providers`, and
-plugins, agent providers, or workflow providers opt into hosted execution with
-their own `runtime` blocks. The canonical config example lives in
-[Configuring a runtime provider](/providers/runtime#configuring-a-runtime-provider).
-
-### Provider interface
-
-The runtime surface is intentionally small but lifecycle-oriented:
-
-| Method | Purpose |
-| --- | --- |
-| `GetSupport` | Advertise grouped runtime support for this backend. |
-| `StartSession` | Create a hosted runtime session for the placed plugin, agent provider, or workflow provider. |
-| `GetSession` | Report session status so Gestalt can wait for readiness. |
-| `ListSessions` | Return sessions currently known to the runtime backend. |
-| `StopSession` | Tear a session down on shutdown or bootstrap failure. |
-| `PrepareWorkspace` | Optional. Prepare a per-agent workspace inside an existing runtime session before the hosted agent provider creates a session. |
-| `RemoveWorkspace` | Optional. Remove a per-agent workspace by runtime session and agent session ID. |
-| `StartPlugin` | Start the hosted provider process with the provided env and return a host-reachable dial target. The RPC name is retained for wire compatibility even when the placed provider is an agent or workflow provider. |
-
-In addition to the runtime-specific RPCs, the provider still implements the
-normal provider lifecycle surface, including `Configure`.
-
-Go, Rust, and TypeScript expose runtime-provider helpers. The examples below
-define provider exports for the source-provider flow, so they do not need a
-hand-written `main` function. Gestalt's build and local-source tooling wraps
-the exported provider for the selected language.
-
-### SDK examples
-
-<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
-  <Tabs.Tab>
-    ```go
-    package exampleruntime
-
-    import (
-        "context"
-
-        gestalt "github.com/valon-technologies/gestalt/sdk/go"
-    )
-
-    type Provider struct{}
-
-    func New() *Provider { return &Provider{} }
-
-    func (p *Provider) Configure(context.Context, string, map[string]any) error {
-        return nil
-    }
-
-    func (p *Provider) GetSupport(context.Context) (gestalt.PluginRuntimeSupport, error) {
-        return gestalt.PluginRuntimeSupport{
-            CanHostPlugins:           true,
-            EgressMode:               gestalt.PluginRuntimeEgressModeHostname,
-            SupportsPrepareWorkspace: true,
-        }, nil
-    }
-
-    func (p *Provider) StartSession(context.Context, gestalt.StartPluginRuntimeSessionRequest) (gestalt.PluginRuntimeSession, error) {
-        return gestalt.PluginRuntimeSession{
-            ID:    "session-1",
-            State: "ready",
-        }, nil
-    }
-
-    func (p *Provider) GetSession(context.Context, string) (gestalt.PluginRuntimeSession, error) {
-        return gestalt.PluginRuntimeSession{
-            ID:    "session-1",
-            State: "ready",
-        }, nil
-    }
-
-    func (p *Provider) ListSessions(context.Context) ([]gestalt.PluginRuntimeSession, error) {
-        return []gestalt.PluginRuntimeSession{{ID: "session-1", State: "ready"}}, nil
-    }
-
-    func (p *Provider) StopSession(context.Context, string) error {
-        return nil
-    }
-
-    func (p *Provider) PrepareWorkspace(context.Context, gestalt.PreparePluginRuntimeWorkspaceRequest) (gestalt.PreparePluginRuntimeWorkspaceResponse, error) {
-        return gestalt.PreparePluginRuntimeWorkspaceResponse{
-            Workspace: &gestalt.PreparedAgentWorkspace{
-                Root: "/sandboxes/runtime-session-1/workspaces/agent-session-1",
-                CWD:  "/sandboxes/runtime-session-1/workspaces/agent-session-1/repo",
-            },
-        }, nil
-    }
-
-    func (p *Provider) RemoveWorkspace(context.Context, gestalt.RemovePluginRuntimeWorkspaceRequest) error {
-        return nil
-    }
-
-    func (p *Provider) StartPlugin(context.Context, req gestalt.StartHostedPluginRequest) (gestalt.HostedPlugin, error) {
-        return gestalt.HostedPlugin{
-            ID:         "plugin-1",
-            SessionID:  req.SessionID,
-            PluginName: req.PluginName,
-            DialTarget: "unix:///tmp/example-runtime/plugin.sock",
-        }, nil
-    }
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    The Python SDK exposes runtime-log host helpers for hosted runtimes. New
-    custom runtime-provider implementations should use the Go or TypeScript
-    authored provider surface until the Python server-side runtime adapter is
-    promoted to the same level.
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```rust
-    #[derive(Default)]
-    struct ExampleRuntime;
-
-    #[gestalt::async_trait]
-    impl gestalt::PluginRuntimeProvider for ExampleRuntime {
-        async fn get_support(
-            &self,
-            _request: (),
-        ) -> gestalt::Result<gestalt::PluginRuntimeSupport> {
-            Ok(gestalt::PluginRuntimeSupport {
-                can_host_plugins: true,
-                supports_prepare_workspace: true,
-                ..Default::default()
-            })
-        }
-
-        async fn start_session(
-            &self,
-            _request: gestalt::StartPluginRuntimeSessionRequest,
-        ) -> gestalt::Result<gestalt::PluginRuntimeSession> {
-            Ok(gestalt::PluginRuntimeSession {
-                id: "session-1".into(),
-                state: "ready".into(),
-                ..Default::default()
-            })
-        }
-
-        async fn get_session(
-            &self,
-            request: gestalt::GetPluginRuntimeSessionRequest,
-        ) -> gestalt::Result<gestalt::PluginRuntimeSession> {
-            Ok(gestalt::PluginRuntimeSession {
-                id: request.session_id,
-                state: "ready".into(),
-                ..Default::default()
-            })
-        }
-
-        async fn list_sessions(
-            &self,
-            _request: gestalt::ListPluginRuntimeSessionsRequest,
-        ) -> gestalt::Result<gestalt::ListPluginRuntimeSessionsResponse> {
-            Ok(gestalt::ListPluginRuntimeSessionsResponse {
-                sessions: vec![gestalt::PluginRuntimeSession {
-                    id: "session-1".into(),
-                    state: "ready".into(),
-                    ..Default::default()
-                }],
-            })
-        }
-
-        async fn stop_session(
-            &self,
-            _request: gestalt::StopPluginRuntimeSessionRequest,
-        ) -> gestalt::Result<()> {
-            Ok(())
-        }
-
-        async fn prepare_workspace(
-            &self,
-            _request: gestalt::PreparePluginRuntimeWorkspaceRequest,
-        ) -> gestalt::Result<gestalt::PreparePluginRuntimeWorkspaceResponse> {
-            Ok(gestalt::PreparePluginRuntimeWorkspaceResponse {
-                workspace: Some(gestalt::AgentPreparedWorkspace {
-                    root: "/sandboxes/runtime-session-1/workspaces/agent-session-1".into(),
-                    cwd: "/sandboxes/runtime-session-1/workspaces/agent-session-1/repo".into(),
-                }),
-            })
-        }
-
-        async fn remove_workspace(
-            &self,
-            _request: gestalt::RemovePluginRuntimeWorkspaceRequest,
-        ) -> gestalt::Result<()> {
-            Ok(())
-        }
-
-        async fn start_plugin(
-            &self,
-            req: gestalt::StartHostedPluginRequest,
-        ) -> gestalt::Result<gestalt::HostedPlugin> {
-            Ok(gestalt::HostedPlugin {
-                id: "plugin-1".into(),
-                session_id: req.session_id,
-                plugin_name: req.plugin_name,
-                dial_target: "unix:///tmp/example-runtime/plugin.sock".into(),
-                ..Default::default()
-            })
-        }
-    }
-
-    gestalt::export_plugin_runtime_provider!(constructor = ExampleRuntime::default);
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```ts
-	    import {
-	      PluginRuntimeEgressMode,
-	      definePluginRuntimeProvider,
-	    } from "@valon-technologies/gestalt";
-
-    export const runtime = definePluginRuntimeProvider({
-      getSupport() {
-        return {
-          canHostPlugins: true,
-          egressMode: PluginRuntimeEgressMode.HOSTNAME,
-          supportsPrepareWorkspace: true,
-        };
-      },
-
-      startSession() {
-        return { id: "session-1", state: "ready" };
-      },
-
-      getSession(request) {
-        return { id: request.sessionId, state: "ready" };
-      },
-
-      listSessions() {
-        return [{ id: "session-1", state: "ready" }];
-      },
-
-      async stopSession() {},
-
-      prepareWorkspace() {
-        return {
-          workspace: {
-            root: "/sandboxes/runtime-session-1/workspaces/agent-session-1",
-            cwd: "/sandboxes/runtime-session-1/workspaces/agent-session-1/repo",
-          },
-        };
-      },
-
-      async removeWorkspace() {},
-
-      startPlugin(request) {
-        return {
-          id: "plugin-1",
-          sessionId: request.sessionId,
-          pluginName: request.pluginName,
-          dialTarget: "unix:///tmp/example-runtime/plugin.sock",
-        };
-      },
-    });
-    ```
-  </Tabs.Tab>
-</Tabs>
-
-### Support guidelines
-
-Advertise the smallest truthful grouped support surface you can.
-
-`can_host_plugins` should only be true when the backend can actually launch a
-host-reachable executable plugin session. If that is false, Gestalt will reject
-hosted execution for that runtime immediately instead of failing later during
-bootstrap.
-
-Gestalt derives effective host-service access from its own public relay
-configuration. Runtime providers do not advertise host-service access.
-
-`egress_mode` should be `hostname` only when the runtime can preserve
-Gestalt's hostname-based `allowedHosts` model. `cidr` is useful metadata, but
-it is not equivalent to hostname-based policy. If your backend can only express
-network controls at firewall or CIDR granularity, advertise `cidr`.
-
-`supports_prepare_workspace` should only be true when `PrepareWorkspace` creates
-the requested checkout inside the same runtime session that will run the hosted
-agent provider, returns absolute `root` and `cwd` paths, and can remove that
-workspace through `RemoveWorkspace`.
-Rust providers that implement the generated tonic trait directly must still add
-`prepare_workspace` and `remove_workspace` methods; return `Status::unimplemented`
-when the runtime does not advertise `supports_prepare_workspace`.
-
-Hosted runtime providers should run provider images rather than expect Gestalt
-to upload a provider bundle into the session. The `StartSession` request carries
-the selected image, template, metadata, and optional `imagePullAuth`
-configuration. `StartPlugin` then carries the manifest-derived `command`,
-`args`, environment variables, and egress policy to apply inside the image.
-Execute those values exactly as provided by the host.
-
-New providers should populate `support`. That grouped support shape is the
-runtime contract operators see in inspection.
-
-### Sessions and host services
-
-The critical design point is that `StartPlugin` is **not** the whole runtime
-API. Gestalt needs an explicit session lifecycle because it may need to create
-the session, wait until it is ready, register host-local services for public
-relay access, and only then start the plugin.
-
-Current Gestalt releases pass host-service relay configuration directly in the
-`StartPlugin` env map. For each configured host service, the socket env var
-contains a public `tls://host:port` relay target and the corresponding
-`<ENV>_TOKEN` var contains the scoped relay token. Runtime providers should pass
-those env vars through to the plugin process unchanged.
-
-Older SDKs exposed a `BindHostService` RPC, but current `gestaltd` does not call
-that method and current SDKs no longer include it in the runtime-provider
-surface. Upgrade `gestaltd` first before rebuilding a runtime provider against
-an SDK that has removed `BindHostService`; older servers still expect that RPC.
-
-### Dial targets
-
-`StartPlugin` returns a host-reachable `dial_target`, not a guest-local socket
-path. Gestalt currently supports `unix://...`, `tcp://host:port`, and
-`tls://host:port`.
-
-If your backend starts the plugin behind a guest-local listener, the runtime
-provider is responsible for bridging that listener back into one of the
-host-reachable forms above.
-
-### Runtime logs
-
-Runtime providers can stream provider-process logs back to Gestalt through the
-runtime log host service. The SDK environment exposes that service as
-`GESTALT_RUNTIME_LOG_SOCKET`; Go providers can use `gestalt.RuntimeLogHost()`.
-Use this for logs that originate in the runtime backend or in hosted provider
-processes before Gestalt has dialed the provider directly.
-
-<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
-  <Tabs.Tab>
-    ```go
-    import (
-        "context"
-
-        gestalt "github.com/valon-technologies/gestalt/sdk/go"
-    )
-
-    func recordRuntimeStartup(ctx context.Context) error {
-        logs, err := gestalt.RuntimeLogHost()
-        if err != nil {
-            return err
-        }
-        defer logs.Close()
-
-        return logs.Append(
-            ctx,
-            "started hosted provider process",
-            gestalt.WithRuntimeLogStream(gestalt.RuntimeLogStreamRuntime),
-        )
-    }
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```python
-    from gestalt import RuntimeLogHost
-
-    def record_runtime_startup() -> None:
-        with RuntimeLogHost() as logs:
-            logs.append(
-                "started hosted provider process",
-                stream="runtime",
-            )
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```rust
-    async fn record_runtime_startup() -> Result<(), Box<dyn std::error::Error>> {
-        let mut logs = gestalt::RuntimeLogHost::connect().await?;
-        logs.append_current_runtime("started hosted provider process")
-            .await?;
-        Ok(())
-    }
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```ts
-    import { RuntimeLogHost } from "@valon-technologies/gestalt";
-
-    export async function recordRuntimeStartup() {
-      const logs = new RuntimeLogHost();
-
-      await logs.append({
-        stream: "runtime",
-        message: "started hosted provider process",
-      });
-    }
-    ```
-  </Tabs.Tab>
-</Tabs>
-
-`append` uses `GESTALT_RUNTIME_SESSION_ID` by default. Pass an explicit session
-ID only when the runtime backend is forwarding logs for a different hosted
-session. Python and TypeScript also expose writer helpers for redirecting
-standard streams.
-
-### Publishing the provider
-
-Runtime providers use the same package publishing flow as other executable
-providers. See [Releasing provider packages](/providers#releasing-provider-packages)
-for release commands, archive layout, and published `provider-release.yaml`
-metadata URLs.
+A runtime provider should advertise its capabilities, create and tear down
+runtime sessions, start the hosted provider image or process, and optionally
+support agent workspace preparation and runtime-originated logs. Keep those
+capabilities truthful: they are what operators see when they inspect configured
+runtimes and what Gestalt uses to reject unsupported placements early.
+
+For packaging and publishing, see
+[Releasing provider packages](/providers#releasing-provider-packages). For the
+full generated SDK surface, use the SDK reference for the language you are
+implementing.
 
 ## What to read next
 

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -1,12 +1,9 @@
-import { Callout, Tabs } from 'nextra/components'
+import { Tabs } from 'nextra/components'
+import ActiveDevelopmentCallout from '../../components/ActiveDevelopmentCallout'
 
 # Secret
 
-<Callout type="warning">
-  **Alpha**. Secrets are under active development and not yet stable. Breaking
-  changes may happen between releases without warning. Feedback and bug reports
-  are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
-</Callout>
+<ActiveDevelopmentCallout verb="are">Secrets</ActiveDevelopmentCallout>
 
 Secrets providers resolve structured secret refs before the rest of the server
 starts. That lets provider config, OAuth app secrets, DSNs, and other sensitive

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -1,12 +1,9 @@
 import { Callout, Tabs } from 'nextra/components'
+import ActiveDevelopmentCallout from '../../components/ActiveDevelopmentCallout'
 
 # UI
 
-<Callout type="warning">
-  Alpha. UI providers are under active development and not yet stable. Breaking
-  changes may happen between releases without warning. Feedback and bug reports
-  are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
-</Callout>
+<ActiveDevelopmentCallout verb="are">UI providers</ActiveDevelopmentCallout>
 
 UI providers are served as static asset bundles. For new custom UIs, prefer
 checking in the frontend source and declaring a top-level `build` command in the

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -1,12 +1,9 @@
 import { Callout, Tabs } from 'nextra/components'
+import ActiveDevelopmentCallout from '../../components/ActiveDevelopmentCallout'
 
 # Workflow
 
-<Callout type="warning">
-  Alpha. Workflows are under active development and not yet stable. Breaking
-  changes may happen between releases without warning. Feedback and bug reports
-  are welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
-</Callout>
+<ActiveDevelopmentCallout verb="are">Workflows</ActiveDevelopmentCallout>
 
 <Callout type="info">
   The public workflow surface now covers schedules, triggers, event publishing,


### PR DESCRIPTION
## Summary
- remove redundant IndexedDB provider sections and examples
- trim plugin local-development and hybrid-provider guidance
- add a shared active-development callout with consistent GitHub Issues links
- simplify runtime provider docs to focus on operator-facing guidance

## Test plan
- npm run build:single