### PR TITLE
Use gestalt release title

### DIFF
--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -47,7 +47,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/publish-scoped-github-release.yml
     with:
-      component-name: gestalt CLI
+      component-name: gestalt
       version-prefix: 'gestalt/v'
       tag-glob: 'gestalt/v*'
       path-filters: |


### PR DESCRIPTION
## Summary

- use `gestalt` as the release component name for `gestalt/v*` releases
- keeps future generated GitHub release titles and release-note headings as `gestalt <version>` instead of `gestalt CLI <version>`

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-gestalt-cli.yml"); puts "yaml ok"'`

## Manual follow-up already applied

Updated the existing `gestalt/v0.0.1` GitHub release title and release-note heading in place to `gestalt 0.0.1`.