### PR TITLE
Trim secrets provider docs

### DIFF
--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -10,9 +10,9 @@ starts. That lets provider config, OAuth app secrets, DSNs, and other sensitive
 values stay out of the main YAML file while still being injected into the final
 runtime config.
 
-## Configuring built-in providers
+## Configuring `providers.secrets`
 
-Use environment variables:
+Use the built-in `env` provider to resolve secrets from environment variables:
 
 ```yaml
 providers:
@@ -29,7 +29,7 @@ server:
       name: GESTALT_ENCRYPTION_KEY
 ```
 
-Or use a directory of mounted files:
+Use the built-in `file` provider to resolve one secret per mounted file:
 
 ```yaml
 providers:
@@ -40,21 +40,12 @@ providers:
         dir: /run/secrets
 ```
 
-## Configuring external secret providers
+External secret managers use the same `providers.secrets.<name>` shape with a
+package source. For package names, config fields, and auth behavior, see
+[Config File](/reference/config-file#providerssecrets).
 
-```yaml
-providers:
-  secrets:
-    google:
-      source:
-        package: github.com/valon-technologies/gestalt-providers/secrets/google
-        version: 0.0.1-alpha.1
-      config:
-        project: my-gcp-project
-```
-
-The configured provider resolves each structured secret ref before any auth
-provider, plugin provider, or datastore provider receives its config.
+Gestalt resolves structured secret refs through the configured provider before
+any auth provider, plugin provider, or datastore provider receives its config.
 
 ## Building your own secrets provider
 
@@ -74,139 +65,159 @@ spec:
 
 The optional `spec.configSchemaPath` field points to a JSON Schema that validates the `config` block in the server config.
 
-### Interface
+### Provider interface
 
-A secrets provider implements two methods: `Configure` and `GetSecret`. `Configure` receives the provider name and the raw config map. `GetSecret` receives a secret name and returns the resolved value as a string.
+Implement the SDK's secrets provider surface. `configure` receives the provider
+name and config block when the entry starts. `get_secret` / `GetSecret`
+receives a logical secret name and returns the resolved plaintext value.
+
+| Method | Purpose |
+| --- | --- |
+| Configure | Read provider config and initialize backing clients. |
+| Get secret | Resolve one named secret to a string value. |
 
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    package googlesecrets
+    package examplesecrets
 
     import (
         "context"
         "fmt"
 
-        secretmanager "cloud.google.com/go/secretmanager/apiv1"
-        "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+        gestalt "github.com/valon-technologies/gestalt/sdk/go"
     )
 
-    type GoogleSecrets struct {
-        client  *secretmanager.Client
-        project string
-        version string
+    type Provider struct {
+        values map[string]string
     }
 
-    func New() *GoogleSecrets { return &GoogleSecrets{} }
+    func New() *Provider { return &Provider{values: map[string]string{}} }
 
-    func (s *GoogleSecrets) Configure(ctx context.Context, _ string, config map[string]any) error {
-        s.project, _ = config["project"].(string)
-        if s.project == "" {
-            return fmt.Errorf("project is required")
+    func (p *Provider) Configure(_ context.Context, _ string, config map[string]any) error {
+        values := map[string]string{}
+        if raw, ok := config["values"].(map[string]any); ok {
+            for name, value := range raw {
+                values[name] = fmt.Sprint(value)
+            }
         }
-        s.version, _ = config["version"].(string)
-        if s.version == "" {
-            s.version = "latest"
-        }
-        var err error
-        s.client, err = secretmanager.NewClient(ctx)
-        return err
+        p.values = values
+        return nil
     }
 
-    func (s *GoogleSecrets) GetSecret(ctx context.Context, name string) (string, error) {
-        resp, err := s.client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
-            Name: fmt.Sprintf("projects/%s/secrets/%s/versions/%s", s.project, name, s.version),
-        })
-        if err != nil {
-            return "", err
+    func (p *Provider) GetSecret(_ context.Context, name string) (string, error) {
+        value, ok := p.values[name]
+        if !ok {
+            return "", fmt.Errorf("%w: %s", gestalt.ErrSecretNotFound, name)
         }
-        return string(resp.Payload.Data), nil
+        return value, nil
     }
 
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```python
-    from google.cloud import secretmanager
     from gestalt import SecretsProvider
 
-    class GoogleSecrets(SecretsProvider):
+    class ExampleSecrets(SecretsProvider):
+        def __init__(self) -> None:
+            self.values: dict[str, str] = {}
+
         def configure(self, name: str, config: dict) -> None:
-            self.project = config["project"]
-            self.version = config.get("version", "latest")
-            self.client = secretmanager.SecretManagerServiceClient()
+            self.values = {
+                str(key): str(value)
+                for key, value in config.get("values", {}).items()
+            }
 
         def get_secret(self, name: str) -> str:
-            resource = f"projects/{self.project}/secrets/{name}/versions/{self.version}"
-            response = self.client.access_secret_version(request={"name": resource})
-            return response.payload.data.decode("utf-8")
+            try:
+                return self.values[name]
+            except KeyError as error:
+                raise KeyError(f"secret {name!r} not found") from error
+
+    provider = ExampleSecrets()
 
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
+    use std::collections::BTreeMap;
     use std::sync::Mutex;
-    use gestalt::SecretsProvider;
 
-    pub struct GoogleSecrets {
-        project: Mutex<String>,
-        version: Mutex<String>,
+    #[derive(Default)]
+    pub struct ExampleSecrets {
+        values: Mutex<BTreeMap<String, String>>,
     }
 
     #[gestalt::async_trait]
-    impl SecretsProvider for GoogleSecrets {
+    impl gestalt::SecretsProvider for ExampleSecrets {
         async fn configure(
             &self, _name: &str, config: serde_json::Map<String, serde_json::Value>,
         ) -> gestalt::Result<()> {
-            *self.project.lock().unwrap() = config
-                .get("project").and_then(|v| v.as_str())
-                .ok_or_else(|| gestalt::Error::config("project is required"))?
-                .to_string();
-            *self.version.lock().unwrap() = config
-                .get("version").and_then(|v| v.as_str())
-                .unwrap_or("latest").to_string();
+            let values = config
+                .get("values")
+                .and_then(|value| value.as_object())
+                .map(|object| {
+                    object
+                        .iter()
+                        .map(|(name, value)| {
+                            (name.clone(), value.as_str().unwrap_or_default().to_string())
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            *self.values.lock().unwrap() = values;
             Ok(())
         }
 
         async fn get_secret(&self, name: &str) -> gestalt::Result<String> {
-            let project = self.project.lock().unwrap().clone();
-            let version = self.version.lock().unwrap().clone();
-            // Call Secret Manager API with projects/{project}/secrets/{name}/versions/{version}
-            todo!()
+            self.values
+                .lock()
+                .unwrap()
+                .get(name)
+                .cloned()
+                .ok_or_else(|| gestalt::Error::not_found(format!("secret {name} not found")))
         }
     }
 
-    gestalt::export_secrets_provider!(constructor = GoogleSecrets::default);
+    gestalt::export_secrets_provider!(constructor = ExampleSecrets::default);
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```typescript
-    import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
     import { defineSecretsProvider } from "@valon-technologies/gestalt";
 
-    let client: SecretManagerServiceClient;
-    let project = "";
-    let version = "latest";
+    let values: Record<string, string> = {};
 
     export const provider = defineSecretsProvider({
       configure(_name, config) {
-        project = config.project as string;
-        if (!project) throw new Error("project is required");
-        version = (config.version as string) ?? "latest";
-        client = new SecretManagerServiceClient();
+        const raw = config.values;
+        values =
+          typeof raw === "object" && raw !== null
+            ? Object.fromEntries(
+                Object.entries(raw as Record<string, unknown>).map(([name, value]) => [
+                  name,
+                  String(value),
+                ]),
+              )
+            : {};
       },
       async getSecret(name) {
-        const [resp] = await client.accessSecretVersion({
-          name: `projects/${project}/secrets/${name}/versions/${version}`,
-        });
-        return resp.payload?.data?.toString() ?? "";
+        const value = values[name];
+        if (value === undefined) throw new Error(`secret ${name} not found`);
+        return value;
       },
     });
     ```
   </Tabs.Tab>
 </Tabs>
 
+### Release flow
+
+For packaging, lock/sync, and release behavior, see
+[Releasing provider packages](/providers#releasing-provider-packages).
+
 ## What to read next
 
-- [Configuration](/reference/configuration): using structured secret refs across the server config
+- [Config File](/reference/config-file#providerssecrets): exact `providers.secrets` fields
 - [Built-in Providers](/reference/built-in-providers): built-in `env` and `file`

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -7,7 +7,7 @@ powers plugins. The first-party implementations are published from
 [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers)
 and maintained alongside the server.
 
-Two simple secrets providers (`env` and `file`), telemetry, and audit remain built into the binary. Cloud secret backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). See [Secrets Providers](/providers/secrets) for the full list and configuration.
+Two simple secrets providers (`env` and `file`), telemetry, and audit remain built into the binary. Cloud secret backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). See [Config File](/reference/config-file#providerssecrets) for package names and configuration.
 
 ## Authentication Providers
 
@@ -225,7 +225,7 @@ Two secret managers are compiled into the `gestaltd` binary and resolve structur
 | `env` | Resolves secrets from environment variables. Default when `providers.secrets` is omitted. |
 | `file` | Resolves secrets from files in a configured directory. Works with Kubernetes volume-mounted secrets. |
 
-For cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault), see [Secrets Providers](/providers/secrets#available-providers). These use a `source:` config key under `providers.secrets.<name>`.
+For cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault), see [Config File](/reference/config-file#providerssecrets). These use a `source:` config key under `providers.secrets.<name>`.
 
 ## Telemetry Providers (built-in)
 


### PR DESCRIPTION
## Summary

- Consolidates the secrets provider config section around `providers.secrets` and keeps the built-in `env`/`file` examples.
- Moves cloud provider package/config detail to the config-file reference instead of duplicating first-party package examples on the provider page.
- Replaces provider-specific Google Secret Manager sample code with generic SecretsProvider interface examples across SDK languages.

## Tests

- `cd docs && npm ci && npm run build:single`