### PR TITLE
Add broker observability for plugin 5xx results

### DIFF
--- a/gestaltd/services/invocation/broker.go
+++ b/gestaltd/services/invocation/broker.go
@@ -28,6 +28,7 @@ import (
 const (
 	tracerName         = "gestaltd"
 	graphQLOperationID = "graphql"
+	resultBodyLogLimit = 4096
 
 	attrProvider       = metricutil.AttrProvider
 	attrOperation      = metricutil.AttrOperation
@@ -355,8 +356,65 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	if err != nil {
 		return fail(err)
 	}
+	observePlugin5xxResult(ctx, span, p, providerName, opMeta.ID, transport, result)
 
 	return result, nil
+}
+
+func observePlugin5xxResult(ctx context.Context, span trace.Span, p *principal.Principal, providerName, operation, transport string, result *core.OperationResult) {
+	if result == nil || transport != catalog.TransportPlugin || !validHTTPStatus(result.Status) || result.Status < http.StatusInternalServerError {
+		return
+	}
+
+	status, statusClass := resultStatusAttributes(result.Status)
+	span.SetStatus(codes.Error, "provider operation returned 5xx result")
+	span.SetAttributes(
+		metricutil.AttrResultStatus.String(status),
+		metricutil.AttrResultStatusClass.String(statusClass),
+	)
+
+	attrs := []any{
+		"provider", strings.TrimSpace(providerName),
+		"operation", strings.TrimSpace(operation),
+		"transport", strings.TrimSpace(transport),
+		"result_status", result.Status,
+		"result_status_class", statusClass,
+		"result_body", truncateResultBodyForLog(result.Body),
+	}
+	if surface := InvocationSurfaceFromContext(ctx); surface != "" {
+		attrs = append(attrs, "surface", string(surface))
+	}
+	if binding := HTTPBindingFromContext(ctx); binding != "" {
+		attrs = append(attrs, "http_binding", binding)
+	}
+	if subjectID, subjectKind := resultSubjectFields(p); subjectID != "" {
+		attrs = append(attrs, "subject_id", subjectID)
+		if subjectKind != "" {
+			attrs = append(attrs, "subject_kind", subjectKind)
+		}
+	}
+
+	slog.WarnContext(ctx, "provider operation returned 5xx result", attrs...)
+}
+
+func truncateResultBodyForLog(body string) string {
+	if len(body) <= resultBodyLogLimit {
+		return body
+	}
+	return body[:resultBodyLogLimit]
+}
+
+func resultSubjectFields(p *principal.Principal) (string, string) {
+	p = principal.Canonicalized(p)
+	if p == nil {
+		return "", ""
+	}
+	subjectID := strings.TrimSpace(p.SubjectID)
+	subjectKind := strings.TrimSpace(string(p.Kind))
+	if subjectKind == "" && subjectID != "" {
+		subjectKind = string(principal.KindFromSubjectID(subjectID))
+	}
+	return subjectID, subjectKind
 }
 
 func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, providerName, instance string, request GraphQLRequest) (result *core.OperationResult, err error) {

--- a/gestaltd/services/invocation/structured_logging_test.go
+++ b/gestaltd/services/invocation/structured_logging_test.go
@@ -10,10 +10,15 @@ import (
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
+	"go.opentelemetry.io/otel"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestBrokerMalformedMetadataJSON_StructuredLog(t *testing.T) { //nolint:paralleltest // mutates slog.Default
@@ -90,4 +95,175 @@ func TestBrokerMalformedMetadataJSON_StructuredLog(t *testing.T) { //nolint:para
 	if !foundWarning {
 		t.Errorf("did not find 'malformed metadata JSON' warning in output:\n%s", output)
 	}
+}
+
+func TestBrokerPlugin5xxResultObservability(t *testing.T) { //nolint:paralleltest // mutates slog.Default and the global tracer provider
+	longBody := `{"error":"` + strings.Repeat("x", 5000) + `"}`
+	tests := []struct {
+		name          string
+		operation     string
+		transport     string
+		ctx           context.Context
+		wantWarning   bool
+		wantSpanError bool
+	}{
+		{
+			name:      "plugin transport",
+			operation: "assistant.reconcileStuckRequests",
+			transport: catalog.TransportPlugin,
+			ctx: invocation.WithHTTPBinding(
+				invocation.WithInvocationSurface(context.Background(), invocation.InvocationSurfaceHTTPBinding),
+				"slack_events",
+			),
+			wantWarning:   true,
+			wantSpanError: true,
+		},
+		{
+			name:      "rest transport",
+			operation: "chat.postMessage",
+			transport: catalog.TransportREST,
+			ctx:       context.Background(),
+		},
+	}
+
+	for _, tt := range tests { //nolint:paralleltest // subtests mutate slog.Default and the global tracer provider
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			installTestLogger(t, &buf)
+			exporter := installTestTracerProvider(t)
+			prov := &coretesting.StubIntegration{
+				N:        "slack",
+				ConnMode: core.ConnectionModeNone,
+				CatalogVal: &catalog.Catalog{
+					Name: "slack",
+					Operations: []catalog.CatalogOperation{{
+						ID:        tt.operation,
+						Method:    http.MethodPost,
+						Transport: tt.transport,
+					}},
+				},
+				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					return &core.OperationResult{Status: http.StatusInternalServerError, Body: longBody}, nil
+				},
+			}
+
+			svc := testutil.NewStubServices(t)
+			broker := invocation.NewBroker(testutil.NewProviderRegistry(t, prov), svc.Users, svc.ExternalCredentials)
+			result, err := broker.Invoke(
+				tt.ctx,
+				&principal.Principal{SubjectID: "service_account:workflow-config"},
+				"slack",
+				"",
+				tt.operation,
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("Invoke: %v", err)
+			}
+			if result.Status != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want %d", result.Status, http.StatusInternalServerError)
+			}
+
+			record, found := findStructuredLogRecord(t, buf.String(), "provider operation returned 5xx result")
+			if found != tt.wantWarning {
+				t.Fatalf("warning found = %v, want %v; output:\n%s", found, tt.wantWarning, buf.String())
+			}
+			if tt.wantWarning {
+				assertStructuredLogField(t, record, "provider", "slack")
+				assertStructuredLogField(t, record, "operation", tt.operation)
+				assertStructuredLogField(t, record, "transport", catalog.TransportPlugin)
+				assertStructuredLogField(t, record, "surface", string(invocation.InvocationSurfaceHTTPBinding))
+				assertStructuredLogField(t, record, "http_binding", "slack_events")
+				assertStructuredLogField(t, record, "subject_id", "service_account:workflow-config")
+				assertStructuredLogField(t, record, "subject_kind", "service_account")
+				assertStructuredLogField(t, record, "result_status_class", "5xx")
+				if got := record["result_status"]; got != float64(http.StatusInternalServerError) {
+					t.Fatalf("result_status = %v, want %d", got, http.StatusInternalServerError)
+				}
+				body, ok := record["result_body"].(string)
+				if !ok {
+					t.Fatalf("result_body = %T, want string", record["result_body"])
+				}
+				if len(body) != 4096 {
+					t.Fatalf("result_body length = %d, want 4096", len(body))
+				}
+				if !strings.HasPrefix(longBody, body) {
+					t.Fatal("result_body is not a prefix of the operation result body")
+				}
+				for _, field := range []string{"result_body_bytes", "result_body_truncated", "result_body_sha256"} {
+					if _, ok := record[field]; ok {
+						t.Fatalf("unexpected %q field in structured log", field)
+					}
+				}
+			}
+
+			span := findTestSpan(t, exporter.GetSpans(), "broker.invoke")
+			if tt.wantSpanError && span.Status.Code != otelcodes.Error {
+				t.Fatalf("broker.invoke span status = %v, want %v", span.Status.Code, otelcodes.Error)
+			}
+			if !tt.wantSpanError && span.Status.Code == otelcodes.Error {
+				t.Fatalf("broker.invoke span status = %v, want non-error", span.Status.Code)
+			}
+			for _, event := range span.Events {
+				if event.Name == "exception" {
+					t.Fatal("broker.invoke span recorded an exception event for a nil-error result")
+				}
+			}
+		})
+	}
+}
+
+func installTestLogger(t *testing.T, buf *bytes.Buffer) {
+	t.Helper()
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+}
+
+func installTestTracerProvider(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+	return exporter
+}
+
+func findStructuredLogRecord(t *testing.T, output, msg string) (map[string]any, bool) {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("log line is not valid JSON: %q: %v", line, err)
+		}
+		if record["msg"] == msg {
+			return record, true
+		}
+	}
+	return nil, false
+}
+
+func assertStructuredLogField(t *testing.T, record map[string]any, field string, want string) {
+	t.Helper()
+	if got := record[field]; got != want {
+		t.Fatalf("%s = %v, want %s", field, got, want)
+	}
+}
+
+func findTestSpan(t *testing.T, spans tracetest.SpanStubs, name string) *tracetest.SpanStub {
+	t.Helper()
+	for i := range spans {
+		if spans[i].Name == name {
+			return &spans[i]
+		}
+	}
+	t.Fatalf("span %q not found; got %d spans", name, len(spans))
+	return nil
 }


### PR DESCRIPTION
## Summary
- Add a broker-level warning when plugin transport operations return an HTTP 5xx `OperationResult` with nil Go error.
- Mark the active `broker.invoke` span as errored and attach result status attributes without recording an exception event.
- Keep the signal broker-scoped with provider, operation, transport, surface, HTTP binding, normalized subject, result status, result status class, and bounded result body fields.

## Interface Changes
- None. This is internal observability only; no provider SDK, protobuf, gRPC, config, or public API changes.

## Test plan
- [x] `go test ./services/invocation -run 'TestBroker(Plugin5xxResultObservability|MalformedMetadataJSON_StructuredLog)$' -count=1`
- [x] `go test ./services/invocation -count=1`
- [x] `golangci-lint run ./services/invocation`