### PR TITLE
Thread workflow event owner context

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -1774,15 +1774,16 @@ func (m *stubWorkflowManager) SignalOrStartRun(context.Context, *principal.Princ
 	return nil, core.ErrNotFound
 }
 
-func (m *stubWorkflowManager) PublishEvent(_ context.Context, p *principal.Principal, providerName string, event coreworkflow.Event) (coreworkflow.Event, error) {
+func (m *stubWorkflowManager) PublishEvent(_ context.Context, p *principal.Principal, req workflowmanager.EventPublish) (coreworkflow.Event, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.subjects = append(m.subjects, subjectIDOf(p))
+	event := req.Event
 	if strings.TrimSpace(event.ID) == "" {
 		event.ID = fmt.Sprintf("evt-%d", len(m.publishedEvents)+1)
 	}
 	m.publishedEvents = append(m.publishedEvents, cloneWorkflowEvent(event))
-	m.publishedProviderNames = append(m.publishedProviderNames, providerName)
+	m.publishedProviderNames = append(m.publishedProviderNames, req.ProviderName)
 	return cloneWorkflowEvent(event), nil
 }
 

--- a/gestaltd/internal/bootstrap/lazy_workflow_manager.go
+++ b/gestaltd/internal/bootstrap/lazy_workflow_manager.go
@@ -217,12 +217,12 @@ func (l *lazyWorkflowManager) SignalOrStartRun(ctx context.Context, p *principal
 	return target.SignalOrStartRun(ctx, p, req)
 }
 
-func (l *lazyWorkflowManager) PublishEvent(ctx context.Context, p *principal.Principal, providerName string, event coreworkflow.Event) (coreworkflow.Event, error) {
+func (l *lazyWorkflowManager) PublishEvent(ctx context.Context, p *principal.Principal, req workflowmanager.EventPublish) (coreworkflow.Event, error) {
 	target, err := l.current()
 	if err != nil {
 		return coreworkflow.Event{}, err
 	}
-	return target.PublishEvent(ctx, p, providerName, event)
+	return target.PublishEvent(ctx, p, req)
 }
 
 func (l *lazyWorkflowManager) current() (workflowmanager.Service, error) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -2450,7 +2450,7 @@ func (unavailableWorkflowManager) SignalOrStartRun(context.Context, *principal.P
 	return nil, fmt.Errorf("workflow manager is not available")
 }
 
-func (unavailableWorkflowManager) PublishEvent(context.Context, *principal.Principal, string, coreworkflow.Event) (coreworkflow.Event, error) {
+func (unavailableWorkflowManager) PublishEvent(context.Context, *principal.Principal, workflowmanager.EventPublish) (coreworkflow.Event, error) {
 	return coreworkflow.Event{}, fmt.Errorf("workflow manager is not available")
 }
 

--- a/gestaltd/internal/server/handlers_workflow_events.go
+++ b/gestaltd/internal/server/handlers_workflow_events.go
@@ -43,7 +43,9 @@ func (s *Server) publishWorkflowEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	event, err := s.workflowSchedules.PublishEvent(r.Context(), p, "", workflowEventFromPublishRequest(req))
+	event, err := s.workflowSchedules.PublishEvent(r.Context(), p, workflowmanager.EventPublish{
+		Event: workflowEventFromPublishRequest(req),
+	})
 	if err != nil {
 		s.writeWorkflowPublishEventError(w, r, err)
 		return

--- a/gestaltd/services/workflows/manager_server.go
+++ b/gestaltd/services/workflows/manager_server.go
@@ -621,7 +621,11 @@ func (s *ManagerServer) PublishEvent(ctx context.Context, req *proto.WorkflowMan
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "event: %v", err)
 	}
-	published, err := s.manager.PublishEvent(plugininvokerservice.RestoreTokenContext(ctx, tokenCtx, ""), tokenCtx.Principal(), req.GetProviderName(), event)
+	published, err := s.manager.PublishEvent(plugininvokerservice.RestoreTokenContext(ctx, tokenCtx, ""), tokenCtx.Principal(), workflowmanager.EventPublish{
+		ProviderName: strings.TrimSpace(req.GetProviderName()),
+		PluginName:   strings.TrimSpace(s.pluginName),
+		Event:        event,
+	})
 	if err != nil {
 		return nil, workflowManagerStatusError(err)
 	}

--- a/gestaltd/services/workflows/manager_server_test.go
+++ b/gestaltd/services/workflows/manager_server_test.go
@@ -2,11 +2,15 @@ package workflows
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
+	"github.com/valon-technologies/gestalt/server/services/workflows/workflowmanager"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -61,4 +65,180 @@ func TestWorkflowManagerTargetOrDefinitionAllowsDefinitionOnlyRequests(t *testin
 			}
 		})
 	}
+}
+
+func TestManagerServerPublishEventThreadsCallerPluginToSelectedProvider(t *testing.T) {
+	t.Parallel()
+
+	tokens, err := NewInvocationTokenManager([]byte("workflow-manager-publish-selected-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	token := mintPublishEventToken(t, tokens, "valonSats")
+	selected := &recordingWorkflowProvider{}
+	other := &recordingWorkflowProvider{}
+	manager := workflowmanager.New(workflowmanager.Config{
+		Workflow: managerServerWorkflowControl{
+			defaultName: "selected",
+			names:       []string{"selected", "other"},
+			providers: map[string]coreworkflow.Provider{
+				"selected": selected,
+				"other":    other,
+			},
+		},
+	})
+	server := NewManagerServer("valonSats", manager, tokens)
+
+	_, err = server.PublishEvent(context.Background(), &proto.WorkflowManagerPublishEventRequest{
+		ProviderName:    "selected",
+		InvocationToken: token,
+		Event:           &proto.WorkflowEvent{Type: "valon_sats.attempt.submitted"},
+	})
+	if err != nil {
+		t.Fatalf("PublishEvent: %v", err)
+	}
+	if len(selected.publishReqs) != 1 {
+		t.Fatalf("selected publish requests = %d, want 1", len(selected.publishReqs))
+	}
+	if got := selected.publishReqs[0].PluginName; got != "valonSats" {
+		t.Fatalf("selected publish plugin = %q, want valonSats", got)
+	}
+	if len(other.publishReqs) != 0 {
+		t.Fatalf("other publish requests = %d, want 0", len(other.publishReqs))
+	}
+}
+
+func TestManagerServerPublishEventThreadsCallerPluginToFanoutProviders(t *testing.T) {
+	t.Parallel()
+
+	tokens, err := NewInvocationTokenManager([]byte("workflow-manager-publish-fanout-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	token := mintPublishEventToken(t, tokens, "valonSats")
+	first := &recordingWorkflowProvider{}
+	second := &recordingWorkflowProvider{}
+	manager := workflowmanager.New(workflowmanager.Config{
+		Workflow: managerServerWorkflowControl{
+			defaultName: "first",
+			names:       []string{"first", "second"},
+			providers: map[string]coreworkflow.Provider{
+				"first":  first,
+				"second": second,
+			},
+		},
+	})
+	server := NewManagerServer(" valonSats ", manager, tokens)
+
+	_, err = server.PublishEvent(context.Background(), &proto.WorkflowManagerPublishEventRequest{
+		InvocationToken: token,
+		Event:           &proto.WorkflowEvent{Type: "valon_sats.attempt.submitted"},
+	})
+	if err != nil {
+		t.Fatalf("PublishEvent: %v", err)
+	}
+	for name, provider := range map[string]*recordingWorkflowProvider{
+		"first":  first,
+		"second": second,
+	} {
+		if len(provider.publishReqs) != 1 {
+			t.Fatalf("%s publish requests = %d, want 1", name, len(provider.publishReqs))
+		}
+		if got := provider.publishReqs[0].PluginName; got != "valonSats" {
+			t.Fatalf("%s publish plugin = %q, want valonSats", name, got)
+		}
+	}
+}
+
+func TestWorkflowManagerPublishEventSelectedProviderPreservesBlankPlugin(t *testing.T) {
+	t.Parallel()
+
+	selected := &recordingWorkflowProvider{}
+	manager := workflowmanager.New(workflowmanager.Config{
+		Workflow: managerServerWorkflowControl{
+			defaultName: "selected",
+			names:       []string{"selected"},
+			providers: map[string]coreworkflow.Provider{
+				"selected": selected,
+			},
+		},
+	})
+
+	_, err := manager.PublishEvent(context.Background(), publishEventPrincipal(), workflowmanager.EventPublish{
+		ProviderName: "selected",
+		PluginName:   "   ",
+		Event:        coreworkflow.Event{Type: "valon_sats.attempt.submitted"},
+	})
+	if err != nil {
+		t.Fatalf("PublishEvent: %v", err)
+	}
+	if len(selected.publishReqs) != 1 {
+		t.Fatalf("selected publish requests = %d, want 1", len(selected.publishReqs))
+	}
+	if got := selected.publishReqs[0].PluginName; got != "" {
+		t.Fatalf("selected publish plugin = %q, want empty", got)
+	}
+}
+
+func mintPublishEventToken(t *testing.T, tokens *InvocationTokenManager, callerPlugin string) string {
+	t.Helper()
+	token, err := tokens.MintRootTokenWithWorkflowGrants(
+		principal.WithPrincipal(context.Background(), publishEventPrincipal()),
+		callerPlugin,
+		nil,
+		workflowgrants.Grants{workflowgrants.OperationEventsPublish: {}},
+	)
+	if err != nil {
+		t.Fatalf("MintRootTokenWithWorkflowGrants: %v", err)
+	}
+	return token
+}
+
+func publishEventPrincipal() *principal.Principal {
+	return &principal.Principal{
+		SubjectID: "user:user-123",
+		UserID:    "user-123",
+		Kind:      principal.KindUser,
+		Source:    principal.SourceSession,
+	}
+}
+
+type managerServerWorkflowControl struct {
+	defaultName string
+	names       []string
+	providers   map[string]coreworkflow.Provider
+}
+
+func (c managerServerWorkflowControl) ResolveProvider(name string) (coreworkflow.Provider, error) {
+	provider := c.providers[strings.TrimSpace(name)]
+	if provider == nil {
+		return nil, errors.New("provider not found")
+	}
+	return provider, nil
+}
+
+func (c managerServerWorkflowControl) ResolveProviderSelection(name string) (string, coreworkflow.Provider, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = c.defaultName
+	}
+	provider, err := c.ResolveProvider(name)
+	if err != nil {
+		return "", nil, err
+	}
+	return name, provider, nil
+}
+
+func (c managerServerWorkflowControl) ProviderNames() []string {
+	return append([]string(nil), c.names...)
+}
+
+type recordingWorkflowProvider struct {
+	coreworkflow.Provider
+	publishReqs []coreworkflow.PublishEventRequest
+}
+
+func (p *recordingWorkflowProvider) PublishEvent(_ context.Context, req coreworkflow.PublishEventRequest) error {
+	p.publishReqs = append(p.publishReqs, req)
+	return nil
 }

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -88,7 +88,7 @@ type Service interface {
 	CancelRun(ctx context.Context, p *principal.Principal, runID, reason string) (*ManagedRun, error)
 	SignalRun(ctx context.Context, p *principal.Principal, req RunSignal) (*ManagedRunSignal, error)
 	SignalOrStartRun(ctx context.Context, p *principal.Principal, req RunSignalOrStart) (*ManagedRunSignal, error)
-	PublishEvent(ctx context.Context, p *principal.Principal, providerName string, event coreworkflow.Event) (coreworkflow.Event, error)
+	PublishEvent(ctx context.Context, p *principal.Principal, req EventPublish) (coreworkflow.Event, error)
 }
 
 type Config struct {
@@ -171,6 +171,14 @@ type RunSignalOrStart struct {
 	IdempotencyKey   string
 	Signal           coreworkflow.Signal
 	CallerPluginName string
+}
+
+type EventPublish struct {
+	ProviderName string
+	// PluginName is trusted owner context. Callers must derive or authorize it before
+	// entering the workflow manager; the manager only normalizes and forwards it.
+	PluginName string
+	Event      coreworkflow.Event
 }
 
 type ManagedDefinition struct {
@@ -674,7 +682,7 @@ func workflowManagerErrorType(err error) string {
 	return "unknown"
 }
 
-func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, providerSelection string, event coreworkflow.Event) (coreworkflow.Event, error) {
+func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, req EventPublish) (coreworkflow.Event, error) {
 	p = principal.Canonicalized(p)
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
 		return coreworkflow.Event{}, ErrWorkflowSubjectRequired
@@ -683,18 +691,22 @@ func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, prov
 		return coreworkflow.Event{}, ErrWorkflowNotConfigured
 	}
 
+	providerSelection := strings.TrimSpace(req.ProviderName)
+	pluginName := strings.TrimSpace(req.PluginName)
+	event := req.Event
 	event = normalizePublishedEvent(event, m.now())
 	if strings.TrimSpace(event.Type) == "" {
 		return coreworkflow.Event{}, ErrWorkflowEventTypeRequired
 	}
 	publishedBy := workflowActorFromPrincipal(p)
 
-	if strings.TrimSpace(providerSelection) != "" {
+	if providerSelection != "" {
 		_, provider, err := m.resolveProviderSelection(providerSelection)
 		if err != nil {
 			return coreworkflow.Event{}, err
 		}
 		if err := provider.PublishEvent(ctx, coreworkflow.PublishEventRequest{
+			PluginName:  pluginName,
 			Event:       event,
 			PublishedBy: publishedBy,
 		}); err != nil {
@@ -710,6 +722,7 @@ func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, prov
 			return coreworkflow.Event{}, err
 		}
 		if err := provider.PublishEvent(ctx, coreworkflow.PublishEventRequest{
+			PluginName:  pluginName,
 			Event:       event,
 			PublishedBy: publishedBy,
 		}); err != nil {


### PR DESCRIPTION
## Summary

- Thread the workflow manager server's trusted caller plugin name into internal event publish requests.
- Preserve public HTTP event publish behavior as an empty-owner/global publish, with no new HTTP or CLI surface.
- Cover selected-provider, fanout, and blank-owner publish contracts.

## Interface Changes
- New/changed interface: `workflowmanager.Service.PublishEvent(ctx, principal, workflowmanager.EventPublish)` replaces the `(providerName, event)` pair so trusted internal callers can pass `ProviderName`, `PluginName`, and `Event` together.
- Example usage:

```go
manager.PublishEvent(ctx, p, workflowmanager.EventPublish{
    ProviderName: "default",
    PluginName:   "valonSats",
    Event:        coreworkflow.Event{Type: "valon_sats.attempt.submitted"},
})
```

- Public HTTP `/api/v1/workflow/events` publish requests remain unchanged and continue to publish with an empty plugin owner.

## Functional/Integration Tests
- Tests added or augmented: manager server publish-event contract tests for selected providers, fanout providers, and blank-plugin internal publish.
- Contract boundary covered: plugin SDK host server -> workflow manager -> workflow provider `PublishEventRequest.PluginName`.
- Commands run:
  - `go test ./services/workflows -run 'TestManagerServerPublishEvent|TestWorkflowManagerPublishEventSelectedProvider|TestManagerServerEmptyWorkflowGrants|TestWorkflowManagerTargetOrDefinition'`
  - `go test ./internal/server -run 'TestWorkflowEventPublish'`
  - `go test ./services/workflows/...`
  - `go test ./internal/bootstrap -run 'Test.*Workflow|Test.*Plugin'`
