### PR TITLE
Add quick demo video to docs overview

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -14,15 +14,18 @@ import ArchitectureDiagram from '../components/ArchitectureDiagram'
 
 Gestalt is a self-hostable, open source platform for managing agentic tools and services, with declarative configuration and primitives for authentication and authorization. External REST/OpenAPI, GraphQL, MCP and executable custom-defined code are all supported, while exposing the same operation model to callers.
 
+### Quick Demo
+
 <video
   className="gestalt-demo-video"
   controls
   playsInline
   preload="metadata"
+  src="https://github.com/user-attachments/assets/08fd7bf3-cc9b-4436-ab71-418d6db4e6e7"
+  title="Gestalt Claude Code terminal demo"
   aria-label="Gestalt terminal demo with Claude Code"
 >
-  <source src="/videos/gestalt-claude-code-demo.mp4" type="video/mp4" />
-  <a href="/videos/gestalt-claude-code-demo.mp4">Watch the Gestalt Claude Code demo.</a>
+  <a href="https://github.com/user-attachments/assets/08fd7bf3-cc9b-4436-ab71-418d6db4e6e7">Watch the Gestalt Claude Code demo.</a>
 </video>
 
 ## Why Gestalt


### PR DESCRIPTION
## Summary
- add a Quick Demo section to the docs overview
- point the docs video at the same GitHub attachment used by the README

## Test
- npm run build:single