### PR TITLE
Remove unused NewGitSource constructor

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -384,10 +384,6 @@ func NewLocalReleaseMetadataSource(rawPath string) ProviderSource {
 	return ProviderSource{metadataPath: strings.TrimSpace(rawPath)}
 }
 
-func NewGitSource(src GitSourceDef) ProviderSource {
-	return ProviderSource{Git: cloneGitSourceDef(&src)}
-}
-
 func cloneSourceAuthDef(src *SourceAuthDef) *SourceAuthDef {
 	if src == nil {
 		return nil


### PR DESCRIPTION
## Summary
- Remove the unused `NewGitSource` constructor from `gestaltd/internal/config/config.go`
- This exported function had zero callers and was dead code in an internal package

Addresses review comment from PR #1889: https://github.com/valon-technologies/gestalt/pull/1889#discussion_r3212269408

Slack thread: https://valon-technologies.slack.com/archives/C0AH7JWFYM8/p1778294661016549

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/config` passes

https://claude.ai/code/session_01CgDkjKTTPWsqnr5x3b3YuW

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgDkjKTTPWsqnr5x3b3YuW)_