### PR TITLE
Align README and docs overview sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,8 @@ When you need production controls, add them through the [provider](https://gesta
 - **Authentication and Authorization as primitives.** [Authentication](https://gestaltd.ai/providers/authentication) flows, [credential storage](https://gestaltd.ai/providers/external-credentials), encryption at rest, token refresh, and [RBAC](https://gestaltd.ai/providers/authorization) run on infrastructure you control.
 - **Declarative configuration.** A single YAML config defines tools, auth flows, connections, agents, workflows, and schedules.
 - **Observability and audit logging.** [OpenTelemetry](https://opentelemetry.io/) compatible [observability](https://gestaltd.ai/observability) and [audit logging](https://gestaltd.ai/audit-logging).
-- **Runtimes.** [Runtimes](https://gestaltd.ai/providers/runtime) provide agent and code sandboxing.*
-- **Workflows and agents.** [Workflows](https://gestaltd.ai/providers/workflow) and [agents](https://gestaltd.ai/providers/agent) run with durable state, retries, and delegated invocations.†
-
-\* Runtimes are an alpha feature, and not yet stable.
-
-† Workflows and agents are both alpha features, and not yet stable.
+- **Runtimes.** [Runtimes](https://gestaltd.ai/providers/runtime) provide agent and code sandboxing.<sup><a href="#runtimes-alpha-note">*</a></sup>
+- **Workflows and agents.** [Workflows](https://gestaltd.ai/providers/workflow) and [agents](https://gestaltd.ai/providers/agent) run with durable state, retries, and delegated invocations.<sup><a href="#workflows-agents-alpha-note">†</a></sup>
 
 ## What Gestalt Is Not
 
@@ -87,3 +83,8 @@ For the full walkthrough, see [Getting Started](https://gestaltd.ai/getting-star
 | [`gestalt`](./gestalt) | Rust CLI client for setup, auth, plugin invocation, workflow and agent runs, and token management. |
 | [`sdk`](./sdk) | Go, Python, Rust, and TypeScript SDKs plus shared protocol definitions. |
 | [`docs`](./docs) | Source for the public documentation site at [gestaltd.ai](https://gestaltd.ai). |
+
+## Footnotes
+
+<div id="runtimes-alpha-note"><sup>*</sup> Runtimes are an alpha feature, and not yet stable.</div>
+<div id="workflows-agents-alpha-note"><sup>†</sup> Workflows and agents are both alpha features, and not yet stable.</div>

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -40,12 +40,13 @@ When you need production controls, add them through the [provider](/providers) e
 
 ### What Gestalt provides
 
-- Plug-and-play [providers](/providers), inspired by [Terraform providers](https://developer.hashicorp.com/terraform/language/providers), so you add only what you need.
-- A unified tool surface for agents over MCP, HTTP, and CLI, usable by cloud agents, local coding assistants, and human operators. See [Plugin](/providers/plugins).
-- [Authentication](/providers/authentication) flows, [credential storage](/providers/external-credentials), encryption at rest, token refresh, and [RBAC](/providers/authorization) on infrastructure you control.
-- [OpenTelemetry](https://opentelemetry.io/) compatible [observability](/observability) and [audit logging](/audit-logging).
-- [Runtimes](/providers/runtime) for agent and code sandboxing.<sup className="gestalt-footnote-ref">*</sup>
-- [Workflows](/providers/workflow) and [agents](/providers/agent) with durable state, retries, and delegated invocations.<sup className="gestalt-footnote-ref">†</sup>
+- **Plug-and-play [providers](https://gestaltd.ai/providers).** Inspired by [Terraform providers](https://developer.hashicorp.com/terraform/language/providers), so you add only what you need.
+- **A unified tool surface for agents.** The same operations are exposed over MCP, HTTP, and CLI, usable by cloud agents, local coding assistants, and human operators. See [Plugin](https://gestaltd.ai/providers/plugins).
+- **Authentication and Authorization as primitives.** [Authentication](https://gestaltd.ai/providers/authentication) flows, [credential storage](https://gestaltd.ai/providers/external-credentials), encryption at rest, token refresh, and [RBAC](https://gestaltd.ai/providers/authorization) run on infrastructure you control.
+- **Declarative configuration.** A single YAML config defines tools, auth flows, connections, agents, workflows, and schedules.
+- **Observability and audit logging.** [OpenTelemetry](https://opentelemetry.io/) compatible [observability](https://gestaltd.ai/observability) and [audit logging](https://gestaltd.ai/audit-logging).
+- **Runtimes.** [Runtimes](https://gestaltd.ai/providers/runtime) provide agent and code sandboxing.<sup><a href="#runtimes-alpha-note">*</a></sup>
+- **Workflows and agents.** [Workflows](https://gestaltd.ai/providers/workflow) and [agents](https://gestaltd.ai/providers/agent) run with durable state, retries, and delegated invocations.<sup><a href="#workflows-agents-alpha-note">†</a></sup>
 
 ## What Gestalt is not
 
@@ -80,6 +81,6 @@ Gestalt is not a mono-repo with hundreds or thousands of integrations built out-
 </Cards>
 
 <div className="gestalt-footnote">
-  <div><sup>*</sup> Runtimes are an alpha feature, and not yet stable.</div>
-  <div><sup>†</sup> Workflows and agents are both alpha features, and not yet stable.</div>
+  <div id="runtimes-alpha-note"><sup>*</sup> Runtimes are an alpha feature, and not yet stable.</div>
+  <div id="workflows-agents-alpha-note"><sup>†</sup> Workflows and agents are both alpha features, and not yet stable.</div>
 </div>


### PR DESCRIPTION
## Summary
- make README and docs "What Gestalt provides" sections use identical text and links
- turn runtime/workflow footnote markers into links to bottom-of-page footnotes
- move README footnotes to the bottom of the README

## Tests
- git diff --check HEAD~1..HEAD
- compared extracted "What Gestalt provides" sections byte-for-byte
- npm run build:single (ran in the primary checkout before creating the clean PR branch)