### PR TITLE
Align README overview with docs copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,12 @@ When you need production controls, add them through the [provider](https://gesta
 
 ### What Gestalt provides
 
-- **Plug-and-play [providers](https://gestaltd.ai/providers).** Inspired by [Terraform providers](https://developer.hashicorp.com/terraform/language/providers), so you add only what you need.
-- **A unified tool surface for agents.** The same operations are exposed over MCP, HTTP, and CLI, usable by cloud agents, local coding assistants, and human operators. See [Plugin](https://gestaltd.ai/providers/plugins).
-- **Authentication and Authorization as primitives.** [Authentication](https://gestaltd.ai/providers/authentication) flows, [credential storage](https://gestaltd.ai/providers/external-credentials), encryption at rest, token refresh, and [RBAC](https://gestaltd.ai/providers/authorization) run on infrastructure you control.
-- **Declarative configuration.** A single YAML config defines tools, auth flows, connections, agents, workflows, and schedules.
-- **Observability and audit logging.** [OpenTelemetry](https://opentelemetry.io/) compatible [observability](https://gestaltd.ai/observability) and [audit logging](https://gestaltd.ai/audit-logging).
-- **Runtimes.** [Runtimes](https://gestaltd.ai/providers/runtime) provide agent and code sandboxing.<sup><a href="#runtimes-alpha-note">*</a></sup>
-- **Workflows and agents.** [Workflows](https://gestaltd.ai/providers/workflow) and [agents](https://gestaltd.ai/providers/agent) run with durable state, retries, and delegated invocations.<sup><a href="#workflows-agents-alpha-note">†</a></sup>
+- Plug-and-play [providers](/providers), inspired by [Terraform providers](https://developer.hashicorp.com/terraform/language/providers), so you add only what you need.
+- A unified tool surface for agents over MCP, HTTP, and CLI, usable by cloud agents, local coding assistants, and human operators. See [Plugin](/providers/plugins).
+- [Authentication](/providers/authentication) flows, [credential storage](/providers/external-credentials), encryption at rest, token refresh, and [RBAC](/providers/authorization) on infrastructure you control.
+- [OpenTelemetry](https://opentelemetry.io/) compatible [observability](/observability) and [audit logging](/audit-logging).
+- [Runtimes](/providers/runtime) for agent and code sandboxing.<sup><a href="#runtimes-alpha-note">*</a></sup>
+- [Workflows](/providers/workflow) and [agents](/providers/agent) with durable state, retries, and delegated invocations.<sup><a href="#workflows-agents-alpha-note">†</a></sup>
 
 ## What Gestalt Is Not
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -40,13 +40,12 @@ When you need production controls, add them through the [provider](/providers) e
 
 ### What Gestalt provides
 
-- **Plug-and-play [providers](https://gestaltd.ai/providers).** Inspired by [Terraform providers](https://developer.hashicorp.com/terraform/language/providers), so you add only what you need.
-- **A unified tool surface for agents.** The same operations are exposed over MCP, HTTP, and CLI, usable by cloud agents, local coding assistants, and human operators. See [Plugin](https://gestaltd.ai/providers/plugins).
-- **Authentication and Authorization as primitives.** [Authentication](https://gestaltd.ai/providers/authentication) flows, [credential storage](https://gestaltd.ai/providers/external-credentials), encryption at rest, token refresh, and [RBAC](https://gestaltd.ai/providers/authorization) run on infrastructure you control.
-- **Declarative configuration.** A single YAML config defines tools, auth flows, connections, agents, workflows, and schedules.
-- **Observability and audit logging.** [OpenTelemetry](https://opentelemetry.io/) compatible [observability](https://gestaltd.ai/observability) and [audit logging](https://gestaltd.ai/audit-logging).
-- **Runtimes.** [Runtimes](https://gestaltd.ai/providers/runtime) provide agent and code sandboxing.<sup><a href="#runtimes-alpha-note">*</a></sup>
-- **Workflows and agents.** [Workflows](https://gestaltd.ai/providers/workflow) and [agents](https://gestaltd.ai/providers/agent) run with durable state, retries, and delegated invocations.<sup><a href="#workflows-agents-alpha-note">†</a></sup>
+- Plug-and-play [providers](/providers), inspired by [Terraform providers](https://developer.hashicorp.com/terraform/language/providers), so you add only what you need.
+- A unified tool surface for agents over MCP, HTTP, and CLI, usable by cloud agents, local coding assistants, and human operators. See [Plugin](/providers/plugins).
+- [Authentication](/providers/authentication) flows, [credential storage](/providers/external-credentials), encryption at rest, token refresh, and [RBAC](/providers/authorization) on infrastructure you control.
+- [OpenTelemetry](https://opentelemetry.io/) compatible [observability](/observability) and [audit logging](/audit-logging).
+- [Runtimes](/providers/runtime) for agent and code sandboxing.<sup><a href="#runtimes-alpha-note">*</a></sup>
+- [Workflows](/providers/workflow) and [agents](/providers/agent) with durable state, retries, and delegated invocations.<sup><a href="#workflows-agents-alpha-note">†</a></sup>
 
 ## What Gestalt is not
 


### PR DESCRIPTION
## Summary
- restore the docs overview "What Gestalt provides" copy to the shorter index.mdx wording
- make README.md use that same wording word-for-word
- keep the footnote markers linked to bottom-of-page footnotes

Fixes the direction of #2002.

## Tests
- compared extracted "What Gestalt provides" sections byte-for-byte
- git diff --check HEAD~1..HEAD
- npm run build:single