### PR TITLE
Remove Python agent proto testing helpers

### DIFF
--- a/sdk/python/gestalt/_agent.py
+++ b/sdk/python/gestalt/_agent.py
@@ -15,8 +15,6 @@ from ._protocol import (
     JsonObjectInput,
     datetime_from_timestamp,
     has_field,
-    message_from_dict,
-    message_to_dict,
     struct_from_dict,
     struct_to_dict,
     timestamp_from_datetime,
@@ -1659,36 +1657,6 @@ def agent_messages_from_dicts(messages: Iterable[Mapping[str, Any]]) -> list[Any
     """Create agent messages from dictionaries."""
 
     return [agent_message_from_dict(message) for message in messages]
-
-
-def agent_message_to_proto_dict(message: Any) -> dict[str, Any]:
-    """Convert an ``AgentMessage`` to protobuf JSON dictionary form."""
-
-    value = message_to_dict(
-        agent_message_to_proto(message),
-        preserving_proto_field_name=True,
-    )
-    if not isinstance(value, dict):
-        raise TypeError("AgentMessage protobuf JSON projection must be an object")
-    return value
-
-
-def agent_message_from_proto_dict(value: Mapping[str, Any]) -> Any:
-    """Create an ``AgentMessage`` from protobuf JSON dictionary form."""
-
-    return agent_message_from_proto(message_from_dict(dict(value), pb.AgentMessage()))
-
-
-def agent_messages_to_proto_dicts(messages: Iterable[Any]) -> list[dict[str, Any]]:
-    """Convert agent protocol messages to protobuf JSON dictionaries."""
-
-    return [agent_message_to_proto_dict(message) for message in messages]
-
-
-def agent_messages_from_proto_dicts(messages: Iterable[Mapping[str, Any]]) -> list[Any]:
-    """Create agent protocol messages from protobuf JSON dictionaries."""
-
-    return [agent_message_from_proto_dict(message) for message in messages]
 
 
 class AgentHost:

--- a/sdk/python/gestalt/testing/__init__.py
+++ b/sdk/python/gestalt/testing/__init__.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 from .._agent import (
-    agent_message_from_proto_dict,
-    agent_message_to_proto_dict,
-    agent_messages_from_proto_dicts,
-    agent_messages_to_proto_dicts,
+    agent_message_from_dict,
+    agent_message_to_dict,
+    agent_messages_from_dicts,
+    agent_messages_to_dicts,
 )
 
 __all__ = [
-    "agent_message_from_proto_dict",
-    "agent_message_to_proto_dict",
-    "agent_messages_from_proto_dicts",
-    "agent_messages_to_proto_dicts",
+    "agent_message_from_dict",
+    "agent_message_to_dict",
+    "agent_messages_from_dicts",
+    "agent_messages_to_dicts",
 ]

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -65,7 +65,6 @@ from gestalt._gen.v1 import agent_pb2 as _agent_pb2
 from gestalt._gen.v1 import agent_pb2_grpc as _agent_pb2_grpc
 from gestalt._gen.v1 import runtime_pb2 as _runtime_pb2
 from gestalt._gen.v1 import runtime_pb2_grpc as _runtime_pb2_grpc
-from gestalt.testing import agent_message_from_proto_dict, agent_message_to_proto_dict
 
 agent_pb2: Any = _agent_pb2
 agent_pb2_grpc: Any = _agent_pb2_grpc
@@ -855,7 +854,7 @@ class AgentTransportTests(unittest.TestCase):
         )
         self.assertEqual(direct_part.tool_call.id, "call-2")
 
-    def test_agent_message_proto_dict_helpers_preserve_protobuf_json_shape(
+    def test_agent_message_dict_helpers_preserve_native_shape(
         self,
     ) -> None:
         message = AgentMessage(
@@ -869,7 +868,7 @@ class AgentTransportTests(unittest.TestCase):
             ],
         )
 
-        raw = agent_message_to_proto_dict(message)
+        raw = agent_message_to_dict(message)
 
         self.assertEqual(
             raw,
@@ -877,17 +876,14 @@ class AgentTransportTests(unittest.TestCase):
                 "role": "assistant",
                 "parts": [
                     {
-                        "type": "AGENT_MESSAGE_PART_TYPE_TEXT",
+                        "type": agent_pb2.AGENT_MESSAGE_PART_TYPE_TEXT,
                         "text": "hello",
                     },
                 ],
                 "metadata": {"tenant": "acme"},
             },
         )
-        self.assertEqual(
-            agent_message_to_proto_dict(agent_message_from_proto_dict(raw)),
-            raw,
-        )
+        self.assertEqual(agent_message_to_dict(agent_message_from_dict(raw)), raw)
 
     def test_agent_runtime_and_server_roundtrip(self) -> None:
         channel = grpc.insecure_channel(f"unix:{_runtime_socket}")

--- a/sdk/python/tests/test_protocol_helpers.py
+++ b/sdk/python/tests/test_protocol_helpers.py
@@ -5,12 +5,12 @@ from gestalt import testing
 
 
 class ProtocolHelperTests(unittest.TestCase):
-    def test_testing_exports_proto_fixture_helpers(self) -> None:
-        proto_dict = testing.agent_message_to_proto_dict(
+    def test_testing_exports_native_fixture_helpers(self) -> None:
+        message_dict = testing.agent_message_to_dict(
             gestalt.AgentMessage(role="user", text="hi")
         )
 
-        self.assertEqual(proto_dict["role"], "user")
+        self.assertEqual(message_dict["role"], "user")
 
     def test_public_low_level_imports_fail(self) -> None:
         with self.assertRaises(ImportError):
@@ -21,7 +21,6 @@ class ProtocolHelperTests(unittest.TestCase):
             __import__("gestalt.protocol.v1")
         for name in (
             "struct_from_dict",
-            "agent_message_to_proto_dict",
             "indexeddb_record_to_proto",
             "AuthorizationResource",
         ):


### PR DESCRIPTION
## Summary\n- remove Python agent testing helpers that exposed protobuf JSON dictionary shapes\n- re-export native agent message dict helpers from gestalt.testing\n- update Python SDK tests to validate native helper behavior\n\n## Tests\n- uv run pytest tests/test_protocol_helpers.py tests/test_agent_transport.py\n- uv run ruff check .\n- git diff --check