### PR TITLE
Hide TypeScript provider metadata wire helpers

### DIFF
--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -240,8 +240,6 @@ export {
 export {
   type ConnectedToken,
   PluginProvider,
-  connectionModeToProtoValue,
-  connectionParamToProto,
   definePlugin,
   isPluginProvider,
   operation,

--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -507,9 +507,9 @@ function errorResult(status: number, message: string): OperationResult {
 }
 
 /**
- * Converts a connection mode into the shared protocol enum value.
+ * Encodes a connection mode for provider metadata.
  */
-export function connectionModeToProtoValue(mode: ConnectionMode): number {
+export function encodeConnectionMode(mode: ConnectionMode): number {
   switch (mode) {
     case "none":
       return 1;
@@ -524,9 +524,9 @@ export function connectionModeToProtoValue(mode: ConnectionMode): number {
 }
 
 /**
- * Converts a connection parameter definition into protocol wire metadata.
+ * Encodes a connection parameter definition for provider metadata.
  */
-export function connectionParamToProto(value: ConnectionParamDefinition): {
+export function encodeConnectionParam(value: ConnectionParamDefinition): {
   required?: boolean;
   description?: string;
   defaultValue?: string;

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -103,8 +103,8 @@ import {
 import {
   type ConnectedToken,
   PluginProvider,
-  connectionModeToProtoValue,
-  connectionParamToProto,
+  encodeConnectionMode,
+  encodeConnectionParam,
   isPluginProvider,
 } from "./plugin.ts";
 import {
@@ -542,14 +542,14 @@ export function createProviderService(
           name: provider.name,
           displayName: provider.displayName,
           description: provider.description,
-          connectionMode: connectionModeToProtoValue(
+          connectionMode: encodeConnectionMode(
             provider.connectionMode,
           ) as ProviderConnectionMode,
           authTypes: [...provider.authTypes],
           connectionParams: Object.fromEntries(
             Object.entries(provider.connectionParams).map(([key, value]) => [
               key,
-              connectionParamToProto(value),
+              encodeConnectionParam(value),
             ]),
           ),
           staticCatalog: catalogToProto(provider.staticCatalog()),

--- a/sdk/typescript/tests/public-api-contract.ts
+++ b/sdk/typescript/tests/public-api-contract.ts
@@ -23,6 +23,10 @@ import { AppendPluginRuntimeLogsRequestSchema as RootAppendPluginRuntimeLogsRequ
 import { PluginRuntimeLogStream as RootPluginRuntimeLogStream } from "@valon-technologies/gestalt";
 // @ts-expect-error Root package must not expose protobuf message helper types.
 import type { MessageInitShape } from "@valon-technologies/gestalt";
+// @ts-expect-error Root package must not expose provider metadata wire helpers.
+import { connectionModeToProtoValue } from "@valon-technologies/gestalt";
+// @ts-expect-error Root package must not expose provider metadata wire helpers.
+import { connectionParamToProto } from "@valon-technologies/gestalt";
 // @ts-expect-error Protocol helper subpath is not public.
 import type { Struct as ProtocolStruct } from "@valon-technologies/gestalt/protocol";
 // @ts-expect-error Generated protocol subpath is not public.
@@ -54,3 +58,5 @@ void egressMode;
 void (undefined as unknown as ProtocolStruct);
 void (undefined as unknown as ProtocolRequest);
 void (undefined as unknown as typeof agentContractSchemas);
+void connectionModeToProtoValue;
+void connectionParamToProto;


### PR DESCRIPTION
## Summary\n- stop re-exporting TypeScript provider metadata wire helpers from the root package\n- rename the runtime-only helpers away from proto-shaped API names\n- add public API contract coverage so the old helper names stay hidden\n\n## Tests\n- bun test --max-concurrency 1\n- bun run typecheck\n- bun run docs:lint\n- bun run docs:build\n- git diff --check