### PR TITLE
Add workflow manager audit observability

### DIFF
--- a/gestaltd/core/audit.go
+++ b/gestaltd/core/audit.go
@@ -31,6 +31,12 @@ type AuditEntry struct {
 	WorkflowCreatedBySubjectKind string
 	WorkflowCreatedByDisplayName string
 	WorkflowCreatedByAuthSource  string
+	WorkflowKeySHA256            string
+	CallerPlugin                 string
+	WorkflowTargetKind           string
+	WorkflowTargetComponent      string
+	WorkflowTargetProvider       string
+	WorkflowTargetOperation      string
 	TargetID                     string
 	TargetKind                   string
 	TargetName                   string

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1192,12 +1192,23 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	prepared.Deps.WorkflowRuntime.SetInvoker(sharedInvoker)
 	prepared.Deps.AgentRuntime.SetInvoker(sharedInvoker)
 	prepared.Deps.AgentRuntime.SetSystemToolExecutor(workflowTools)
+	audit, auditClose, err := buildAuditSink(ctx, cfg, factories, prepared.Telemetry)
+	if err != nil {
+		return nil, err
+	}
+	closeAudit := true
+	defer func() {
+		if closeAudit && auditClose != nil {
+			_ = auditClose(context.Background())
+		}
+	}()
 	workflowManager.SetTarget(workflowmanager.New(workflowmanager.Config{
 		Providers:         providers,
 		Workflow:          prepared.Deps.WorkflowRuntime,
 		Agent:             prepared.Deps.AgentRuntime,
 		AgentManager:      agentManager,
 		Invoker:           sharedInvoker,
+		Audit:             audit,
 		Authorizer:        authz,
 		DefaultConnection: connMaps.DefaultConnection,
 		CatalogConnection: connMaps.APIConnection,
@@ -1238,16 +1249,6 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	defer func() {
 		if closeAgentsOnError {
 			_ = closeAgents(extraAgents...)
-		}
-	}()
-	audit, auditClose, err := buildAuditSink(ctx, cfg, factories, prepared.Telemetry)
-	if err != nil {
-		return nil, err
-	}
-	closeAudit := true
-	defer func() {
-		if closeAudit && auditClose != nil {
-			_ = auditClose(context.Background())
 		}
 	}()
 	pluginInvoker.SetTarget(invocation.NewGuarded(sharedInvoker, nil, "plugin", audit, invocation.WithoutRateLimit()))

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -397,6 +397,7 @@ func New(cfg Config) (*Server, error) {
 		Agent:             cfg.Agent,
 		AgentManager:      cfg.AgentManager,
 		Invoker:           cfg.Invoker,
+		Audit:             cfg.AuditSink,
 		Authorizer:        cfg.Authorizer,
 		DefaultConnection: cfg.DefaultConnection,
 		CatalogConnection: cfg.CatalogConnection,

--- a/gestaltd/services/invocation/audit.go
+++ b/gestaltd/services/invocation/audit.go
@@ -202,6 +202,24 @@ func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
 	if entry.WorkflowCreatedByAuthSource != "" {
 		attrs = append(attrs, slog.String("workflow_created_by_auth_source", entry.WorkflowCreatedByAuthSource))
 	}
+	if entry.WorkflowKeySHA256 != "" {
+		attrs = append(attrs, slog.String("workflow_key_sha256", entry.WorkflowKeySHA256))
+	}
+	if entry.CallerPlugin != "" {
+		attrs = append(attrs, slog.String("caller_plugin", entry.CallerPlugin))
+	}
+	if entry.WorkflowTargetKind != "" {
+		attrs = append(attrs, slog.String("workflow_target_kind", entry.WorkflowTargetKind))
+	}
+	if entry.WorkflowTargetComponent != "" {
+		attrs = append(attrs, slog.String("workflow_target_component", entry.WorkflowTargetComponent))
+	}
+	if entry.WorkflowTargetProvider != "" {
+		attrs = append(attrs, slog.String("workflow_target_provider", entry.WorkflowTargetProvider))
+	}
+	if entry.WorkflowTargetOperation != "" {
+		attrs = append(attrs, slog.String("workflow_target_operation", entry.WorkflowTargetOperation))
+	}
 	if entry.TargetID != "" {
 		attrs = append(attrs, slog.String("target_id", entry.TargetID))
 	}

--- a/gestaltd/services/invocation/audit_test.go
+++ b/gestaltd/services/invocation/audit_test.go
@@ -24,15 +24,21 @@ func TestSlogAuditSink_AllowedEntry(t *testing.T) {
 
 	eventTime := time.Date(2026, 3, 15, 12, 30, 0, 0, time.UTC)
 	entry := core.AuditEntry{
-		Timestamp:   eventTime,
-		RequestID:   "req-abc-123",
-		Source:      "binding:test-hook",
-		SubjectID:   principal.UserSubjectID("user-42"),
-		SubjectKind: string(principal.KindUser),
-		Provider:    "alpha",
-		Operation:   "fetch",
-		Depth:       1,
-		Allowed:     true,
+		Timestamp:               eventTime,
+		RequestID:               "req-abc-123",
+		Source:                  "binding:test-hook",
+		SubjectID:               principal.UserSubjectID("user-42"),
+		SubjectKind:             string(principal.KindUser),
+		Provider:                "alpha",
+		Operation:               "fetch",
+		Depth:                   1,
+		Allowed:                 true,
+		WorkflowKeySHA256:       "workflow-key-hash",
+		CallerPlugin:            "slack",
+		WorkflowTargetKind:      "plugin",
+		WorkflowTargetComponent: "plugin_target",
+		WorkflowTargetProvider:  "github",
+		WorkflowTargetOperation: "reviewPullRequest",
 	}
 
 	sink.Log(context.Background(), entry)
@@ -81,6 +87,24 @@ func TestSlogAuditSink_AllowedEntry(t *testing.T) {
 	}
 	if record["allowed"] != true {
 		t.Errorf("expected allowed=true, got %v", record["allowed"])
+	}
+	if record["workflow_key_sha256"] != "workflow-key-hash" {
+		t.Errorf("expected workflow_key_sha256=workflow-key-hash, got %v", record["workflow_key_sha256"])
+	}
+	if record["caller_plugin"] != "slack" {
+		t.Errorf("expected caller_plugin=slack, got %v", record["caller_plugin"])
+	}
+	if record["workflow_target_kind"] != "plugin" {
+		t.Errorf("expected workflow_target_kind=plugin, got %v", record["workflow_target_kind"])
+	}
+	if record["workflow_target_component"] != "plugin_target" {
+		t.Errorf("expected workflow_target_component=plugin_target, got %v", record["workflow_target_component"])
+	}
+	if record["workflow_target_provider"] != "github" {
+		t.Errorf("expected workflow_target_provider=github, got %v", record["workflow_target_provider"])
+	}
+	if record["workflow_target_operation"] != "reviewPullRequest" {
+		t.Errorf("expected workflow_target_operation=reviewPullRequest, got %v", record["workflow_target_operation"])
 	}
 	if _, hasError := record["error"]; hasError {
 		t.Errorf("expected no error field for allowed entry, got %v", record["error"])

--- a/gestaltd/services/workflows/manager_server_test.go
+++ b/gestaltd/services/workflows/manager_server_test.go
@@ -1,7 +1,9 @@
 package workflows
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -9,6 +11,7 @@ import (
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowmanager"
 	"google.golang.org/grpc/codes"
@@ -77,6 +80,7 @@ func TestManagerServerPublishEventThreadsCallerPluginToSelectedProvider(t *testi
 	token := mintPublishEventToken(t, tokens, "valonSats")
 	selected := &recordingWorkflowProvider{}
 	other := &recordingWorkflowProvider{}
+	var auditBuf bytes.Buffer
 	manager := workflowmanager.New(workflowmanager.Config{
 		Workflow: managerServerWorkflowControl{
 			defaultName: "selected",
@@ -86,6 +90,7 @@ func TestManagerServerPublishEventThreadsCallerPluginToSelectedProvider(t *testi
 				"other":    other,
 			},
 		},
+		Audit: invocation.NewSlogAuditSink(&auditBuf),
 	})
 	server := NewManagerServer("valonSats", manager, tokens)
 
@@ -106,6 +111,20 @@ func TestManagerServerPublishEventThreadsCallerPluginToSelectedProvider(t *testi
 	if len(other.publishReqs) != 0 {
 		t.Fatalf("other publish requests = %d, want 0", len(other.publishReqs))
 	}
+	assertManagerServerWorkflowAudit(t, auditBuf.String(), map[string]any{
+		"level":          "INFO",
+		"log.type":       "audit",
+		"source":         "workflow_manager",
+		"provider":       "selected",
+		"operation":      "workflow.event.publish",
+		"target_kind":    "workflow_event",
+		"target_name":    "valon_sats.attempt.submitted",
+		"caller_plugin":  "valonSats",
+		"subject_id":     "user:user-123",
+		"subject_kind":   "user",
+		"request_id_set": true,
+		"allowed":        true,
+	})
 }
 
 func TestManagerServerPublishEventThreadsCallerPluginToFanoutProviders(t *testing.T) {
@@ -118,6 +137,7 @@ func TestManagerServerPublishEventThreadsCallerPluginToFanoutProviders(t *testin
 	token := mintPublishEventToken(t, tokens, "valonSats")
 	first := &recordingWorkflowProvider{}
 	second := &recordingWorkflowProvider{}
+	var auditBuf bytes.Buffer
 	manager := workflowmanager.New(workflowmanager.Config{
 		Workflow: managerServerWorkflowControl{
 			defaultName: "first",
@@ -127,6 +147,7 @@ func TestManagerServerPublishEventThreadsCallerPluginToFanoutProviders(t *testin
 				"second": second,
 			},
 		},
+		Audit: invocation.NewSlogAuditSink(&auditBuf),
 	})
 	server := NewManagerServer(" valonSats ", manager, tokens)
 
@@ -147,6 +168,22 @@ func TestManagerServerPublishEventThreadsCallerPluginToFanoutProviders(t *testin
 		if got := provider.publishReqs[0].PluginName; got != "valonSats" {
 			t.Fatalf("%s publish plugin = %q, want valonSats", name, got)
 		}
+	}
+	for _, providerName := range []string{"first", "second"} {
+		assertManagerServerWorkflowAudit(t, auditBuf.String(), map[string]any{
+			"level":          "INFO",
+			"log.type":       "audit",
+			"source":         "workflow_manager",
+			"provider":       providerName,
+			"operation":      "workflow.event.publish",
+			"target_kind":    "workflow_event",
+			"target_name":    "valon_sats.attempt.submitted",
+			"caller_plugin":  "valonSats",
+			"subject_id":     "user:user-123",
+			"subject_kind":   "user",
+			"request_id_set": true,
+			"allowed":        true,
+		})
 	}
 }
 
@@ -178,6 +215,46 @@ func TestWorkflowManagerPublishEventSelectedProviderPreservesBlankPlugin(t *test
 	if got := selected.publishReqs[0].PluginName; got != "" {
 		t.Fatalf("selected publish plugin = %q, want empty", got)
 	}
+}
+
+func assertManagerServerWorkflowAudit(t *testing.T, output string, want map[string]any) {
+	t.Helper()
+
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("audit line is not valid JSON: %q: %v", line, err)
+		}
+		if record["log.type"] != "audit" {
+			continue
+		}
+		matches := true
+		for key, value := range want {
+			if key == "request_id_set" {
+				if value == true && !managerServerAuditStringPresent(record, "request_id") {
+					matches = false
+					break
+				}
+				continue
+			}
+			if got := record[key]; got != value {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return
+		}
+	}
+	t.Fatalf("workflow audit record not found in %q", output)
+}
+
+func managerServerAuditStringPresent(record map[string]any, key string) bool {
+	value, ok := record[key].(string)
+	return ok && value != ""
 }
 
 func mintPublishEventToken(t *testing.T, tokens *InvocationTokenManager, callerPlugin string) string {

--- a/gestaltd/services/workflows/telemetry_test.go
+++ b/gestaltd/services/workflows/telemetry_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -17,7 +18,9 @@ import (
 	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentmanager"
+	"github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
+	"github.com/valon-technologies/gestalt/server/services/invocation"
 	"github.com/valon-technologies/gestalt/server/services/observability"
 	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"github.com/valon-technologies/gestalt/server/services/workflows/workflowgrants"
@@ -391,10 +394,22 @@ func TestWorkflowManagerHostRecordsSignalOrStartMetricsAcrossTransport(t *testin
 	t.Cleanup(func() { slog.SetDefault(prevLogger) })
 
 	provider := newWorkflowManagerTelemetryProvider()
+	var auditBuf bytes.Buffer
+	authz, err := authorization.New(authorization.StaticConfig{
+		Policies: map[string]authorization.StaticSubjectPolicy{
+			"deny": {Default: "deny"},
+		},
+		ProviderPolicies: map[string]string{"datadog": "deny"},
+	})
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
 	manager := workflowmanager.New(workflowmanager.Config{
 		Workflow:     workflowManagerTelemetryControl{provider: provider},
 		Agent:        workflowManagerTelemetryAgentControl{},
 		AgentManager: workflowManagerTelemetryAgentManager{},
+		Audit:        invocation.NewSlogAuditSink(&auditBuf),
+		Authorizer:   authz,
 	})
 	tokens, err := NewInvocationTokenManager([]byte("workflow-manager-telemetry-test-secret"))
 	if err != nil {
@@ -413,6 +428,41 @@ func TestWorkflowManagerHostRecordsSignalOrStartMetricsAcrossTransport(t *testin
 	)
 	if err != nil {
 		t.Fatalf("MintRootTokenWithWorkflowGrants: %v", err)
+	}
+	principalDeniedToken, err := tokens.MintRootTokenWithWorkflowGrants(
+		principal.WithPrincipal(context.Background(), &principal.Principal{
+			SubjectID: "user:restricted",
+			UserID:    "restricted",
+			Kind:      principal.KindUser,
+			Source:    principal.SourceSession,
+			TokenPermissions: principal.CompilePermissions([]core.AccessPermission{
+				{Plugin: "simple"},
+			}),
+		}),
+		"slack",
+		nil,
+		workflowgrants.Grants{workflowgrants.OperationRunsSignalOrStart: {}},
+	)
+	if err != nil {
+		t.Fatalf("MintRootTokenWithWorkflowGrants(principal denied): %v", err)
+	}
+	authorizerDeniedToken, err := tokens.MintRootTokenWithWorkflowGrants(
+		principal.WithPrincipal(context.Background(), &principal.Principal{
+			SubjectID: "user:authorizer-denied",
+			UserID:    "authorizer-denied",
+			Kind:      principal.KindUser,
+			Source:    principal.SourceSession,
+			TokenPermissions: principal.CompilePermissions([]core.AccessPermission{
+				{Plugin: "simple"},
+				{Plugin: "datadog", Operations: []string{"listAlerts"}},
+			}),
+		}),
+		"slack",
+		nil,
+		workflowgrants.Grants{workflowgrants.OperationRunsSignalOrStart: {}},
+	)
+	if err != nil {
+		t.Fatalf("MintRootTokenWithWorkflowGrants(authorizer denied): %v", err)
 	}
 
 	lis := bufconn.Listen(1024 * 1024)
@@ -462,6 +512,49 @@ func TestWorkflowManagerHostRecordsSignalOrStartMetricsAcrossTransport(t *testin
 	if status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("SignalOrStartRun invalid target = %v, want InvalidArgument", err)
 	}
+	principalDeniedKey := "slack:T123:C123:1712161832.000600"
+	_, err = client.SignalOrStartRun(context.Background(), &proto.WorkflowManagerSignalOrStartRunRequest{
+		ProviderName:    "local",
+		WorkflowKey:     principalDeniedKey,
+		IdempotencyKey:  "idem-principal-denied",
+		InvocationToken: principalDeniedToken,
+		Signal:          &proto.WorkflowSignal{Name: "slack.message"},
+		Target: &proto.BoundWorkflowTarget{Kind: &proto.BoundWorkflowTarget_Agent{
+			Agent: &proto.BoundWorkflowAgentTarget{
+				ProviderName: "simple",
+				Prompt:       "handle the Slack message",
+				ToolRefs: []*proto.AgentToolRef{
+					{Plugin: "github", Operation: "reviewPullRequest"},
+				},
+			},
+		}},
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("SignalOrStartRun principal denied = %v, want NotFound", err)
+	}
+	authorizerDeniedKey := "slack:T123:C123:1712161833.000700"
+	_, err = client.SignalOrStartRun(context.Background(), &proto.WorkflowManagerSignalOrStartRunRequest{
+		ProviderName:    "local",
+		WorkflowKey:     authorizerDeniedKey,
+		IdempotencyKey:  "idem-authorizer-denied",
+		InvocationToken: authorizerDeniedToken,
+		Signal:          &proto.WorkflowSignal{Name: "slack.message"},
+		Target: &proto.BoundWorkflowTarget{Kind: &proto.BoundWorkflowTarget_Agent{
+			Agent: &proto.BoundWorkflowAgentTarget{
+				ProviderName: "simple",
+				Prompt:       "handle the Slack message",
+				ToolRefs: []*proto.AgentToolRef{
+					{Plugin: "datadog", Operation: "listAlerts"},
+				},
+			},
+		}},
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("SignalOrStartRun authorizer denied = %v, want NotFound", err)
+	}
+	if got := provider.signalOrStartCalls.Load(); got != 2 {
+		t.Fatalf("provider SignalOrStartRun calls = %d, want 2", got)
+	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	successAttrs := map[string]string{
@@ -490,10 +583,20 @@ func TestWorkflowManagerHostRecordsSignalOrStartMetricsAcrossTransport(t *testin
 		"gestaltd.workflow.telemetry.source": observability.WorkflowTelemetrySourceCore,
 		"error.type":                         "grpc.invalid_argument",
 	}
+	notFoundFailureAttrs := map[string]string{
+		"gestaltd.workflow.provider.name":    "unknown",
+		"gestaltd.workflow.operation.name":   observability.WorkflowOperationSignalOrStartRun,
+		"gestaltd.workflow.trigger.kind":     observability.WorkflowTriggerKindSignal,
+		"gestaltd.workflow.target.kind":      observability.WorkflowTargetKindAgent,
+		"gestaltd.workflow.run.status":       observability.WorkflowRunStatusUnknown,
+		"gestaltd.workflow.telemetry.source": observability.WorkflowTelemetrySourceCore,
+		"error.type":                         "grpc.not_found",
+	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.workflows.manager.operation.count", 1, successAttrs)
 	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.workflows.manager.operation.duration", successAttrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.workflows.manager.operation.error_count", 1, failureAttrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.workflows.manager.operation.error_count", 1, untrustedFailureAttrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.workflows.manager.operation.error_count", 2, notFoundFailureAttrs)
 	untrustedProviderMetricAttrs := map[string]string{}
 	for key, value := range untrustedFailureAttrs {
 		untrustedProviderMetricAttrs[key] = value
@@ -512,13 +615,128 @@ func TestWorkflowManagerHostRecordsSignalOrStartMetricsAcrossTransport(t *testin
 	}
 
 	logOutput := logBuf.String()
-	if strings.Contains(logOutput, failureKey) {
-		t.Fatalf("manager log contains raw workflow key %q", failureKey)
+	for _, forbidden := range []string{failureKey, principalDeniedKey, authorizerDeniedKey} {
+		if strings.Contains(logOutput, forbidden) {
+			t.Fatalf("manager log contains raw workflow key %q", forbidden)
+		}
 	}
-	if strings.Contains(logOutput, "idem-failure") {
-		t.Fatal("manager log contains raw idempotency key")
+	for _, forbidden := range []string{"idem-failure", "idem-principal-denied", "idem-authorizer-denied"} {
+		if strings.Contains(logOutput, forbidden) {
+			t.Fatalf("manager log contains raw idempotency key %q", forbidden)
+		}
 	}
-	assertWorkflowManagerFailureLog(t, logOutput, failureKey)
+	assertWorkflowManagerFailureLog(t, logOutput, failureKey, "provider_signal_or_start", map[string]any{
+		"level":          "WARN",
+		"request_id_set": true,
+		"error_type":     "grpc_status",
+		"error_code":     "failed_precondition",
+	})
+	assertWorkflowManagerFailureLog(t, logOutput, principalDeniedKey, "authorize_target", map[string]any{
+		"level":                     "WARN",
+		"request_id_set":            true,
+		"error_type":                "not_found",
+		"workflow_target_component": "agent_tool_ref",
+		"authorization_decision":    "workflow_target_principal_operation_permission_denied",
+	})
+	assertWorkflowManagerFailureLog(t, logOutput, authorizerDeniedKey, "authorize_target", map[string]any{
+		"level":                     "WARN",
+		"request_id_set":            true,
+		"error_type":                "not_found",
+		"workflow_target_component": "agent_tool_ref",
+		"authorization_decision":    "workflow_target_authorizer_provider_denied",
+	})
+	assertWorkflowManagerFailureLogsOmitFields(t, logOutput,
+		"provider_selection",
+		"workflow_provider",
+		"target_kind",
+		"caller_plugin",
+		"subject_id",
+		"subject_kind",
+		"execution_ref_id",
+		"target_authorization_provider",
+		"target_authorization_operation",
+		"target_authorization_tool_ref_index",
+	)
+
+	auditOutput := auditBuf.String()
+	for _, forbidden := range []string{failureKey, principalDeniedKey, authorizerDeniedKey, "idem-failure", "idem-principal-denied", "idem-authorizer-denied", "provider echoed"} {
+		if strings.Contains(auditOutput, forbidden) {
+			t.Fatalf("workflow audit contains raw sensitive value %q", forbidden)
+		}
+	}
+	assertWorkflowAuditLog(t, auditOutput, successKey, map[string]any{
+		"level":                "INFO",
+		"request_id_set":       true,
+		"source":               "workflow_manager",
+		"provider":             "local",
+		"operation":            "workflow.run.signal_or_start",
+		"target_kind":          "workflow_run",
+		"target_id":            "run-signal-started",
+		"allowed":              true,
+		"caller_plugin":        "slack",
+		"subject_id":           "user:user-123",
+		"subject_kind":         "user",
+		"workflow_target_kind": "agent",
+	})
+	assertWorkflowAuditLog(t, auditOutput, failureKey, map[string]any{
+		"level":                "WARN",
+		"request_id_set":       true,
+		"source":               "workflow_manager",
+		"provider":             "local",
+		"operation":            "workflow.run.signal_or_start",
+		"target_kind":          "workflow_run",
+		"allowed":              false,
+		"error":                "grpc_status",
+		"caller_plugin":        "slack",
+		"subject_id":           "user:user-123",
+		"subject_kind":         "user",
+		"workflow_target_kind": "agent",
+	})
+	assertWorkflowAuditLog(t, auditOutput, principalDeniedKey, map[string]any{
+		"level":                     "WARN",
+		"request_id_set":            true,
+		"source":                    "workflow_manager",
+		"provider":                  "local",
+		"operation":                 "workflow.run.signal_or_start",
+		"target_kind":               "workflow_run",
+		"allowed":                   false,
+		"error":                     "not_found",
+		"authorization_decision":    "workflow_target_principal_operation_permission_denied",
+		"caller_plugin":             "slack",
+		"subject_id":                "user:restricted",
+		"subject_kind":              "user",
+		"workflow_target_kind":      "agent",
+		"workflow_target_component": "agent_tool_ref",
+		"workflow_target_provider":  "github",
+		"workflow_target_operation": "reviewPullRequest",
+	})
+	assertWorkflowAuditLog(t, auditOutput, authorizerDeniedKey, map[string]any{
+		"level":                     "WARN",
+		"request_id_set":            true,
+		"source":                    "workflow_manager",
+		"provider":                  "local",
+		"operation":                 "workflow.run.signal_or_start",
+		"target_kind":               "workflow_run",
+		"allowed":                   false,
+		"error":                     "not_found",
+		"authorization_decision":    "workflow_target_authorizer_provider_denied",
+		"caller_plugin":             "slack",
+		"subject_id":                "user:authorizer-denied",
+		"subject_kind":              "user",
+		"workflow_target_kind":      "agent",
+		"workflow_target_component": "agent_tool_ref",
+		"workflow_target_provider":  "datadog",
+		"workflow_target_operation": "listAlerts",
+	})
+	assertWorkflowAuditLogsOmitFields(t, auditOutput,
+		"idempotency_key",
+		"result_body",
+		"result_body_bytes",
+		"result_body_truncated",
+		"result_body_sha256",
+		"workflow_target_tool_ref_index",
+		"target_authorization_tool_ref_index",
+	)
 }
 
 func newTelemetryRemoteWorkflow(t *testing.T) coreworkflow.Provider {
@@ -576,7 +794,7 @@ func workflowManagerTelemetrySignalOrStartRequest(token, workflowKey, idempotenc
 	}
 }
 
-func assertWorkflowManagerFailureLog(t *testing.T, output, workflowKey string) {
+func assertWorkflowManagerFailureLog(t *testing.T, output, workflowKey, phase string, want map[string]any) {
 	t.Helper()
 
 	expectedHash := workflowManagerTelemetrySHA256(workflowKey)
@@ -591,32 +809,132 @@ func assertWorkflowManagerFailureLog(t *testing.T, output, workflowKey string) {
 		if record["msg"] != "workflow manager signal-or-start failed" {
 			continue
 		}
-		for key, want := range map[string]string{
-			"level":               "WARN",
-			"phase":               "provider_signal_or_start",
-			"provider_selection":  "local",
-			"workflow_provider":   "local",
-			"target_kind":         "agent",
-			"caller_plugin":       "slack",
-			"subject_id":          "user:user-123",
-			"subject_kind":        "user",
-			"workflow_key_sha256": expectedHash,
-			"error_type":          "grpc_status",
-			"error_code":          "failed_precondition",
-		} {
-			if got := record[key]; got != want {
-				t.Fatalf("log field %s = %#v, want %q in record %#v", key, got, want, record)
-			}
+		if record["workflow_key_sha256"] != expectedHash || record["phase"] != phase {
+			continue
 		}
 		if _, ok := record["error"]; ok {
 			t.Fatalf("log record includes raw error field %#v", record)
 		}
-		if record["execution_ref_id"] == "" {
-			t.Fatalf("execution_ref_id missing from record %#v", record)
+		assertWorkflowManagerLogField(t, record, "workflow_key_sha256", expectedHash)
+		assertWorkflowManagerLogField(t, record, "phase", phase)
+		for key, value := range want {
+			if key == "execution_ref_id_set" {
+				if value == true && !workflowManagerLogStringPresent(record, "execution_ref_id") {
+					t.Fatalf("execution_ref_id missing from record %#v", record)
+				}
+				continue
+			}
+			if key == "request_id_set" {
+				if value == true && !workflowManagerLogStringPresent(record, "request_id") {
+					t.Fatalf("request_id missing from record %#v", record)
+				}
+				continue
+			}
+			assertWorkflowManagerLogField(t, record, key, value)
 		}
 		return
 	}
-	t.Fatalf("workflow manager failure log not found in %q", output)
+	t.Fatalf("workflow manager failure log for key %q phase %q not found in %q", workflowKey, phase, output)
+}
+
+func assertWorkflowManagerFailureLogsOmitFields(t *testing.T, output string, fields ...string) {
+	t.Helper()
+
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("log line is not valid JSON: %q: %v", line, err)
+		}
+		if record["msg"] != "workflow manager signal-or-start failed" {
+			continue
+		}
+		for _, field := range fields {
+			if _, ok := record[field]; ok {
+				t.Fatalf("workflow manager failure log includes %s in record %#v", field, record)
+			}
+		}
+	}
+}
+
+func assertWorkflowAuditLog(t *testing.T, output, workflowKey string, want map[string]any) {
+	t.Helper()
+
+	expectedHash := workflowManagerTelemetrySHA256(workflowKey)
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("audit line is not valid JSON: %q: %v", line, err)
+		}
+		if record["log.type"] != "audit" || record["workflow_key_sha256"] != expectedHash {
+			continue
+		}
+		assertWorkflowManagerLogField(t, record, "workflow_key_sha256", expectedHash)
+		for key, value := range want {
+			if key == "request_id_set" {
+				if value == true && !workflowManagerLogStringPresent(record, "request_id") {
+					t.Fatalf("request_id missing from audit record %#v", record)
+				}
+				continue
+			}
+			assertWorkflowManagerLogField(t, record, key, value)
+		}
+		return
+	}
+	t.Fatalf("workflow audit for key %q not found in %q", workflowKey, output)
+}
+
+func assertWorkflowAuditLogsOmitFields(t *testing.T, output string, fields ...string) {
+	t.Helper()
+
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("audit line is not valid JSON: %q: %v", line, err)
+		}
+		if record["log.type"] != "audit" {
+			continue
+		}
+		for _, field := range fields {
+			if _, ok := record[field]; ok {
+				t.Fatalf("workflow audit includes %s in record %#v", field, record)
+			}
+		}
+	}
+}
+
+func workflowManagerLogStringPresent(record map[string]any, key string) bool {
+	value, ok := record[key].(string)
+	return ok && value != ""
+}
+
+func assertWorkflowManagerLogField(t *testing.T, record map[string]any, key string, want any) {
+	t.Helper()
+
+	got := record[key]
+	switch want := want.(type) {
+	case string:
+		if got != want {
+			t.Fatalf("log field %s = %#v, want %q in record %#v", key, got, want, record)
+		}
+	case int:
+		number, ok := got.(float64)
+		if !ok || number != float64(want) {
+			t.Fatalf("log field %s = %#v, want %d in record %#v", key, got, want, record)
+		}
+	default:
+		if got != want {
+			t.Fatalf("log field %s = %#v, want %#v in record %#v", key, got, want, record)
+		}
+	}
 }
 
 func workflowManagerTelemetrySHA256(value string) string {
@@ -660,8 +978,9 @@ type workflowManagerTelemetryAgentManager struct {
 
 type workflowManagerTelemetryProvider struct {
 	coreworkflow.Provider
-	refs             map[string]*coreworkflow.ExecutionReference
-	signalOrStartErr error
+	refs               map[string]*coreworkflow.ExecutionReference
+	signalOrStartCalls atomic.Int64
+	signalOrStartErr   error
 }
 
 func newWorkflowManagerTelemetryProvider() *workflowManagerTelemetryProvider {
@@ -669,6 +988,7 @@ func newWorkflowManagerTelemetryProvider() *workflowManagerTelemetryProvider {
 }
 
 func (p *workflowManagerTelemetryProvider) SignalOrStartRun(_ context.Context, req coreworkflow.SignalOrStartRunRequest) (*coreworkflow.SignalRunResponse, error) {
+	p.signalOrStartCalls.Add(1)
 	if p.signalOrStartErr != nil {
 		return nil, p.signalOrStartErr
 	}

--- a/gestaltd/services/workflows/workflowmanager/manager.go
+++ b/gestaltd/services/workflows/workflowmanager/manager.go
@@ -97,6 +97,7 @@ type Config struct {
 	Agent             AgentControl
 	AgentManager      agentmanager.Service
 	Invoker           invocation.Invoker
+	Audit             core.AuditSink
 	Authorizer        authorization.RuntimeAuthorizer
 	DefaultConnection map[string]string
 	CatalogConnection map[string]string
@@ -110,6 +111,7 @@ type Manager struct {
 	agent             AgentControl
 	agentManager      agentmanager.Service
 	invoker           invocation.Invoker
+	audit             core.AuditSink
 	authorizer        authorization.RuntimeAuthorizer
 	defaultConnection map[string]string
 	catalogConnection map[string]string
@@ -218,6 +220,40 @@ type ManagedRunSignal struct {
 	provider     coreworkflow.Provider
 }
 
+const (
+	workflowAuditSource = "workflow_manager"
+
+	workflowAuditOperationDefinitionCreate   = "workflow.definition.create"
+	workflowAuditOperationDefinitionUpdate   = "workflow.definition.update"
+	workflowAuditOperationDefinitionDelete   = "workflow.definition.delete"
+	workflowAuditOperationScheduleCreate     = "workflow.schedule.create"
+	workflowAuditOperationScheduleUpdate     = "workflow.schedule.update"
+	workflowAuditOperationScheduleDelete     = "workflow.schedule.delete"
+	workflowAuditOperationSchedulePause      = "workflow.schedule.pause"
+	workflowAuditOperationScheduleResume     = "workflow.schedule.resume"
+	workflowAuditOperationEventTriggerCreate = "workflow.event_trigger.create"
+	workflowAuditOperationEventTriggerUpdate = "workflow.event_trigger.update"
+	workflowAuditOperationEventTriggerDelete = "workflow.event_trigger.delete"
+	workflowAuditOperationEventTriggerPause  = "workflow.event_trigger.pause"
+	workflowAuditOperationEventTriggerResume = "workflow.event_trigger.resume"
+	workflowAuditOperationRunStart           = "workflow.run.start"
+	workflowAuditOperationRunSignal          = "workflow.run.signal"
+	workflowAuditOperationRunSignalOrStart   = "workflow.run.signal_or_start"
+	workflowAuditOperationRunCancel          = "workflow.run.cancel"
+	workflowAuditOperationEventPublish       = "workflow.event.publish"
+
+	workflowAuditTargetDefinition   = "workflow_definition"
+	workflowAuditTargetSchedule     = "workflow_schedule"
+	workflowAuditTargetEventTrigger = "workflow_event_trigger"
+	workflowAuditTargetRun          = "workflow_run"
+	workflowAuditTargetEvent        = "workflow_event"
+)
+
+type workflowAuditEvent struct {
+	sink  core.AuditSink
+	entry core.AuditEntry
+}
+
 func New(cfg Config) *Manager {
 	now := cfg.Now
 	if now == nil {
@@ -229,6 +265,7 @@ func New(cfg Config) *Manager {
 		agent:             cfg.Agent,
 		agentManager:      cfg.AgentManager,
 		invoker:           cfg.Invoker,
+		audit:             cfg.Audit,
 		authorizer:        cfg.Authorizer,
 		defaultConnection: maps.Clone(cfg.DefaultConnection),
 		catalogConnection: maps.Clone(cfg.CatalogConnection),
@@ -237,8 +274,130 @@ func New(cfg Config) *Manager {
 	}
 }
 
-func (m *Manager) CreateDefinition(ctx context.Context, p *principal.Principal, req DefinitionUpsert) (*ManagedDefinition, error) {
+func (m *Manager) beginWorkflowAudit(ctx context.Context, p *principal.Principal, operation string) (context.Context, *workflowAuditEvent) {
+	ctx, entry := invocation.BuildAuditEntry(ctx, p, workflowAuditSource, "", operation)
+	var sink core.AuditSink
+	if m != nil {
+		sink = m.audit
+	}
+	return ctx, &workflowAuditEvent{sink: sink, entry: entry}
+}
+
+func (a *workflowAuditEvent) setProvider(providerName string) {
+	if a == nil {
+		return
+	}
+	a.entry.Provider = strings.TrimSpace(providerName)
+}
+
+func (a *workflowAuditEvent) setCallerPlugin(callerPlugin string) {
+	if a == nil {
+		return
+	}
+	a.entry.CallerPlugin = strings.TrimSpace(callerPlugin)
+}
+
+func (a *workflowAuditEvent) setWorkflowKey(workflowKey string) {
+	if a == nil {
+		return
+	}
+	a.entry.WorkflowKeySHA256 = workflowManagerSHA256(workflowKey)
+}
+
+func (a *workflowAuditEvent) setObjectTarget(kind, id, name string) {
+	if a == nil {
+		return
+	}
+	a.entry.TargetKind = strings.TrimSpace(kind)
+	a.entry.TargetID = strings.TrimSpace(id)
+	a.entry.TargetName = strings.TrimSpace(name)
+}
+
+func (a *workflowAuditEvent) setWorkflowTarget(target coreworkflow.Target) {
+	if a == nil {
+		return
+	}
+	a.entry.WorkflowTargetKind = workflowAuditTargetKind(target)
+	if target.Plugin == nil {
+		return
+	}
+	pluginName := strings.TrimSpace(target.Plugin.PluginName)
+	operation := strings.TrimSpace(target.Plugin.Operation)
+	if pluginName == "" || operation == "" {
+		return
+	}
+	a.entry.WorkflowTargetProvider = pluginName
+	a.entry.WorkflowTargetOperation = operation
+}
+
+func (a *workflowAuditEvent) setWorkflowTargetAuthorizationFailure(target coreworkflow.Target, failure targetAuthorizationFailure) {
+	if a == nil {
+		return
+	}
+	a.entry.AuthorizationDecision = workflowAuditTargetAuthorizationDecision(failure)
+	a.entry.WorkflowTargetKind = workflowAuditTargetKind(target)
+	a.entry.WorkflowTargetComponent = strings.TrimSpace(failure.component)
+	a.entry.WorkflowTargetProvider = strings.TrimSpace(failure.provider)
+	a.entry.WorkflowTargetOperation = strings.TrimSpace(failure.operation)
+}
+
+func (a *workflowAuditEvent) clone() *workflowAuditEvent {
+	if a == nil {
+		return nil
+	}
+	copied := *a
+	return &copied
+}
+
+func (a *workflowAuditEvent) finish(ctx context.Context, err error) {
+	if a == nil || a.sink == nil {
+		return
+	}
+	a.entry.Allowed = err == nil
+	if err != nil {
+		a.entry.Error = workflowManagerErrorType(err)
+	}
+	a.sink.Log(ctx, a.entry)
+}
+
+func workflowAuditTargetKind(target coreworkflow.Target) string {
+	switch {
+	case target.Plugin != nil:
+		return "plugin"
+	case target.Agent != nil:
+		return "agent"
+	default:
+		return ""
+	}
+}
+
+func workflowAuditTargetAuthorizationDecision(failure targetAuthorizationFailure) string {
+	reason := strings.TrimSpace(failure.reason)
+	if reason == "" {
+		return ""
+	}
+	return "workflow_target_" + reason
+}
+
+func workflowRunID(run *coreworkflow.Run) string {
+	if run == nil {
+		return ""
+	}
+	return strings.TrimSpace(run.ID)
+}
+
+func (m *Manager) CreateDefinition(ctx context.Context, p *principal.Principal, req DefinitionUpsert) (out *ManagedDefinition, err error) {
 	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationDefinitionCreate)
+	audit.setCallerPlugin(req.CallerPluginName)
+	defer func() {
+		if out != nil && out.Definition != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetDefinition, out.Definition.ID, "")
+			audit.setWorkflowTarget(out.Definition.Target)
+		}
+		audit.finish(ctx, err)
+	}()
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
 		return nil, ErrWorkflowSubjectRequired
 	}
@@ -250,6 +409,8 @@ func (m *Manager) CreateDefinition(ctx context.Context, p *principal.Principal, 
 	if err != nil {
 		return nil, err
 	}
+	audit.setProvider(providerName)
+	audit.setWorkflowTarget(target)
 
 	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
 	definitionID := newDefinitionID("")
@@ -260,12 +421,14 @@ func (m *Manager) CreateDefinition(ctx context.Context, p *principal.Principal, 
 			if !managedDefinitionMatchesUpsert(existing, providerName, target) {
 				return nil, fmt.Errorf("%w: workflow definition idempotency key reused with different request", invocation.ErrInvalidInvocation)
 			}
+			audit.setObjectTarget(workflowAuditTargetDefinition, existing.Definition.ID, "")
 			return existing, nil
 		}
 		if !errors.Is(err, core.ErrNotFound) {
 			return nil, err
 		}
 	}
+	audit.setObjectTarget(workflowAuditTargetDefinition, definitionID, "")
 	ref, err := m.putExecutionRefWithPermissions(ctx, definitionID, providerName, provider, target, p, req.CallerPluginName, "", req.Permissions)
 	if err != nil {
 		return nil, err
@@ -281,8 +444,19 @@ func (m *Manager) GetDefinition(ctx context.Context, p *principal.Principal, def
 	return m.requireOwnedDefinition(ctx, definitionID, p)
 }
 
-func (m *Manager) UpdateDefinition(ctx context.Context, p *principal.Principal, definitionID string, req DefinitionUpsert) (*ManagedDefinition, error) {
+func (m *Manager) UpdateDefinition(ctx context.Context, p *principal.Principal, definitionID string, req DefinitionUpsert) (out *ManagedDefinition, err error) {
 	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationDefinitionUpdate)
+	audit.setCallerPlugin(req.CallerPluginName)
+	audit.setObjectTarget(workflowAuditTargetDefinition, definitionID, "")
+	defer func() {
+		if out != nil && out.Definition != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetDefinition, out.Definition.ID, "")
+			audit.setWorkflowTarget(out.Definition.Target)
+		}
+		audit.finish(ctx, err)
+	}()
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
 		return nil, ErrWorkflowSubjectRequired
 	}
@@ -290,6 +464,7 @@ func (m *Manager) UpdateDefinition(ctx context.Context, p *principal.Principal, 
 	if err != nil {
 		return nil, err
 	}
+	audit.setProvider(existing.ProviderName)
 	providerName, provider, err := m.resolveProviderSelection(strings.TrimSpace(req.ProviderName))
 	if err != nil {
 		return nil, err
@@ -298,6 +473,8 @@ func (m *Manager) UpdateDefinition(ctx context.Context, p *principal.Principal, 
 	if err != nil {
 		return nil, err
 	}
+	audit.setProvider(providerName)
+	audit.setWorkflowTarget(target)
 	if strings.TrimSpace(existing.ProviderName) != providerName {
 		if _, err := m.revokeExecutionRefWithError(ctx, existing.Definition); err != nil {
 			return nil, err
@@ -324,10 +501,20 @@ func (m *Manager) UpdateDefinition(ctx context.Context, p *principal.Principal, 
 	}, nil
 }
 
-func (m *Manager) DeleteDefinition(ctx context.Context, p *principal.Principal, definitionID string) error {
+func (m *Manager) DeleteDefinition(ctx context.Context, p *principal.Principal, definitionID string) (err error) {
+	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationDefinitionDelete)
+	audit.setObjectTarget(workflowAuditTargetDefinition, definitionID, "")
+	defer func() {
+		audit.finish(ctx, err)
+	}()
 	existing, err := m.requireOwnedDefinition(ctx, definitionID, p)
 	if err != nil {
 		return err
+	}
+	audit.setProvider(existing.ProviderName)
+	if existing.Definition != nil {
+		audit.setWorkflowTarget(existing.Definition.Target)
 	}
 	m.revokeExecutionRef(ctx, existing.Definition)
 	return nil
@@ -395,8 +582,22 @@ func (m *Manager) ListRuns(ctx context.Context, p *principal.Principal) ([]*Mana
 	return out, nil
 }
 
-func (m *Manager) StartRun(ctx context.Context, p *principal.Principal, req RunStart) (*ManagedRun, error) {
+func (m *Manager) StartRun(ctx context.Context, p *principal.Principal, req RunStart) (out *ManagedRun, err error) {
 	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationRunStart)
+	audit.setCallerPlugin(req.CallerPluginName)
+	audit.setWorkflowKey(req.WorkflowKey)
+	audit.setObjectTarget(workflowAuditTargetRun, "", "")
+	defer func() {
+		if out != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetRun, workflowRunID(out.Run), "")
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		audit.finish(ctx, err)
+	}()
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
 		return nil, ErrWorkflowSubjectRequired
 	}
@@ -404,6 +605,8 @@ func (m *Manager) StartRun(ctx context.Context, p *principal.Principal, req RunS
 	if err != nil {
 		return nil, err
 	}
+	audit.setProvider(providerName)
+	audit.setWorkflowTarget(target)
 
 	executionRefID := newRunExecutionRefID(workflowCreateIdempotencyScope(p, req.CallerPluginName, req.IdempotencyKey), req.WorkflowKey)
 	ref, createdRef, err := m.putRunExecutionRef(ctx, executionRefID, providerName, provider, target, p, req.CallerPluginName, req.DefinitionID, req.Permissions)
@@ -480,10 +683,27 @@ func (m *Manager) GetRun(ctx context.Context, p *principal.Principal, runID stri
 	return nil, core.ErrNotFound
 }
 
-func (m *Manager) CancelRun(ctx context.Context, p *principal.Principal, runID, reason string) (*ManagedRun, error) {
+func (m *Manager) CancelRun(ctx context.Context, p *principal.Principal, runID, reason string) (out *ManagedRun, err error) {
+	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationRunCancel)
+	audit.setObjectTarget(workflowAuditTargetRun, runID, "")
+	defer func() {
+		if out != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetRun, workflowRunID(out.Run), "")
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		audit.finish(ctx, err)
+	}()
 	value, err := m.GetRun(ctx, p, runID)
 	if err != nil {
 		return nil, err
+	}
+	audit.setProvider(value.ProviderName)
+	if value.ExecutionRef != nil {
+		audit.setWorkflowTarget(value.ExecutionRef.Target)
 	}
 	run, err := existingRunProvider(value).CancelRun(ctx, coreworkflow.CancelRunRequest{
 		RunID:  strings.TrimSpace(runID),
@@ -499,10 +719,28 @@ func (m *Manager) CancelRun(ctx context.Context, p *principal.Principal, runID, 
 	return value, nil
 }
 
-func (m *Manager) SignalRun(ctx context.Context, p *principal.Principal, req RunSignal) (*ManagedRunSignal, error) {
+func (m *Manager) SignalRun(ctx context.Context, p *principal.Principal, req RunSignal) (out *ManagedRunSignal, err error) {
+	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationRunSignal)
+	audit.setObjectTarget(workflowAuditTargetRun, req.RunID, "")
+	defer func() {
+		if out != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetRun, workflowRunID(out.Run), "")
+			audit.setWorkflowKey(out.WorkflowKey)
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		audit.finish(ctx, err)
+	}()
 	value, err := m.GetRun(ctx, p, req.RunID)
 	if err != nil {
 		return nil, err
+	}
+	audit.setProvider(value.ProviderName)
+	if value.ExecutionRef != nil {
+		audit.setWorkflowTarget(value.ExecutionRef.Target)
 	}
 	signal, err := m.normalizeSignal(req.Signal, p)
 	if err != nil {
@@ -523,10 +761,27 @@ func (m *Manager) SignalOrStartRun(ctx context.Context, p *principal.Principal, 
 	providerName := ""
 	var target coreworkflow.Target
 	executionRefID := ""
+	var targetAuthFailure *targetAuthorizationFailure
 	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationRunSignalOrStart)
+	audit.setCallerPlugin(req.CallerPluginName)
+	audit.setWorkflowKey(req.WorkflowKey)
+	audit.setObjectTarget(workflowAuditTargetRun, "", "")
 	defer func() {
+		if out != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetRun, workflowRunID(out.Run), "")
+			audit.setWorkflowKey(out.WorkflowKey)
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		if targetAuthFailure != nil {
+			audit.setWorkflowTargetAuthorizationFailure(target, *targetAuthFailure)
+		}
+		audit.finish(ctx, err)
 		if err != nil {
-			logWorkflowSignalOrStartFailure(ctx, p, req, phase, providerName, target, executionRefID, err)
+			logWorkflowSignalOrStartFailure(ctx, req, phase, targetAuthFailure, err)
 		}
 	}()
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
@@ -543,6 +798,8 @@ func (m *Manager) SignalOrStartRun(ctx context.Context, p *principal.Principal, 
 	if err != nil {
 		return nil, err
 	}
+	audit.setProvider(providerName)
+	audit.setWorkflowTarget(target)
 	phase = "normalize_signal"
 	signal, err := m.normalizeSignal(req.Signal, p)
 	if err != nil {
@@ -551,7 +808,9 @@ func (m *Manager) SignalOrStartRun(ctx context.Context, p *principal.Principal, 
 
 	phase = "authorize_target"
 	executionRefPermissions := m.executionRefPermissions(p, target, req.CallerPluginName)
-	if !m.allowTarget(ctx, executionRefPrincipal(p, executionRefPermissions), target) {
+	targetAuth := m.checkTargetAuthorization(ctx, executionRefPrincipal(p, executionRefPermissions), target)
+	if !targetAuth.allowed {
+		targetAuthFailure = &targetAuth.failure
 		return nil, core.ErrNotFound
 	}
 	phase = "derive_execution_ref"
@@ -580,48 +839,35 @@ func (m *Manager) SignalOrStartRun(ctx context.Context, p *principal.Principal, 
 	return m.managedSignalResponse(ctx, p, providerName, provider, resp, ref, signalTargetPrincipalExecutionRef)
 }
 
-func logWorkflowSignalOrStartFailure(ctx context.Context, p *principal.Principal, req RunSignalOrStart, phase, providerName string, target coreworkflow.Target, executionRefID string, err error) {
+func logWorkflowSignalOrStartFailure(ctx context.Context, req RunSignalOrStart, phase string, targetAuthFailure *targetAuthorizationFailure, err error) {
 	if err == nil {
 		return
 	}
 	attrs := []any{
 		"phase", strings.TrimSpace(phase),
-		"provider_selection", strings.TrimSpace(req.ProviderName),
-		"target_kind", workflowSignalOrStartTargetKind(target),
-		"caller_plugin", strings.TrimSpace(req.CallerPluginName),
-		"subject_id", principalSubjectID(p),
-		"subject_kind", workflowManagerSubjectKind(p),
 		"workflow_key_sha256", workflowManagerSHA256(req.WorkflowKey),
 		"error_type", workflowManagerErrorType(err),
 	}
-	if providerName = strings.TrimSpace(providerName); providerName != "" {
-		attrs = append(attrs, "workflow_provider", providerName)
-	}
-	if executionRefID = strings.TrimSpace(executionRefID); executionRefID != "" {
-		attrs = append(attrs, "execution_ref_id", executionRefID)
+	if meta := invocation.MetaFromContext(ctx); meta != nil && strings.TrimSpace(meta.RequestID) != "" {
+		attrs = append(attrs, "request_id", strings.TrimSpace(meta.RequestID))
 	}
 	if errorCode := workflowManagerErrorCode(err); errorCode != "" {
 		attrs = append(attrs, "error_code", errorCode)
 	}
+	if targetAuthFailure != nil {
+		attrs = appendTargetAuthorizationFailureAttrs(attrs, *targetAuthFailure)
+	}
 	slog.WarnContext(ctx, "workflow manager signal-or-start failed", attrs...)
 }
 
-func workflowManagerSubjectKind(p *principal.Principal) string {
-	if p == nil {
-		return ""
+func appendTargetAuthorizationFailureAttrs(attrs []any, failure targetAuthorizationFailure) []any {
+	if component := strings.TrimSpace(failure.component); component != "" {
+		attrs = append(attrs, "workflow_target_component", component)
 	}
-	return string(p.Kind)
-}
-
-func workflowSignalOrStartTargetKind(target coreworkflow.Target) string {
-	switch {
-	case target.Plugin != nil:
-		return "plugin"
-	case target.Agent != nil:
-		return "agent"
-	default:
-		return "unknown"
+	if decision := workflowAuditTargetAuthorizationDecision(failure); decision != "" {
+		attrs = append(attrs, "authorization_decision", decision)
 	}
+	return attrs
 }
 
 func workflowManagerSHA256(value string) string {
@@ -682,8 +928,21 @@ func workflowManagerErrorType(err error) string {
 	return "unknown"
 }
 
-func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, req EventPublish) (coreworkflow.Event, error) {
+func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, req EventPublish) (out coreworkflow.Event, err error) {
 	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationEventPublish)
+	audit.setCallerPlugin(req.PluginName)
+	finishAudit := true
+	defer func() {
+		eventType := out.Type
+		if eventType == "" {
+			eventType = req.Event.Type
+		}
+		audit.setObjectTarget(workflowAuditTargetEvent, "", eventType)
+		if finishAudit {
+			audit.finish(ctx, err)
+		}
+	}()
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
 		return coreworkflow.Event{}, ErrWorkflowSubjectRequired
 	}
@@ -701,10 +960,11 @@ func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, req 
 	publishedBy := workflowActorFromPrincipal(p)
 
 	if providerSelection != "" {
-		_, provider, err := m.resolveProviderSelection(providerSelection)
+		providerName, provider, err := m.resolveProviderSelection(providerSelection)
 		if err != nil {
 			return coreworkflow.Event{}, err
 		}
+		audit.setProvider(providerName)
 		if err := provider.PublishEvent(ctx, coreworkflow.PublishEventRequest{
 			PluginName:  pluginName,
 			Event:       event,
@@ -716,9 +976,16 @@ func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, req 
 	}
 
 	providerNames := m.workflow.ProviderNames()
+	if len(providerNames) > 0 {
+		finishAudit = false
+	}
 	for _, providerName := range providerNames {
+		providerAudit := audit.clone()
+		providerAudit.setProvider(providerName)
+		providerAudit.setObjectTarget(workflowAuditTargetEvent, "", event.Type)
 		provider, err := m.resolveProviderByName(providerName)
 		if err != nil {
+			providerAudit.finish(ctx, err)
 			return coreworkflow.Event{}, err
 		}
 		if err := provider.PublishEvent(ctx, coreworkflow.PublishEventRequest{
@@ -726,8 +993,10 @@ func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, req 
 			Event:       event,
 			PublishedBy: publishedBy,
 		}); err != nil {
+			providerAudit.finish(ctx, err)
 			return coreworkflow.Event{}, err
 		}
+		providerAudit.finish(ctx, nil)
 	}
 	return event, nil
 }
@@ -786,8 +1055,20 @@ func (m *Manager) ListSchedules(ctx context.Context, p *principal.Principal) ([]
 	return out, nil
 }
 
-func (m *Manager) CreateSchedule(ctx context.Context, p *principal.Principal, req ScheduleUpsert) (*ManagedSchedule, error) {
+func (m *Manager) CreateSchedule(ctx context.Context, p *principal.Principal, req ScheduleUpsert) (out *ManagedSchedule, err error) {
 	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationScheduleCreate)
+	audit.setCallerPlugin(req.CallerPluginName)
+	defer func() {
+		if out != nil && out.Schedule != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetSchedule, out.Schedule.ID, "")
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		audit.finish(ctx, err)
+	}()
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
 		return nil, ErrWorkflowSubjectRequired
 	}
@@ -795,11 +1076,13 @@ func (m *Manager) CreateSchedule(ctx context.Context, p *principal.Principal, re
 	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
 	idempotencyScope := workflowCreateIdempotencyScope(p, req.CallerPluginName, idempotencyKey)
 	scheduleID := newScheduleID(idempotencyScope)
+	audit.setObjectTarget(workflowAuditTargetSchedule, scheduleID, "")
 	var existing *ManagedSchedule
 	if idempotencyKey != "" {
 		var err error
 		existing, err = m.requireOwnedSchedule(ctx, scheduleID, p)
 		if err == nil {
+			audit.setProvider(existing.ProviderName)
 			if strings.TrimSpace(req.DefinitionID) != "" {
 				if workflowTargetIsSet(req.Target) {
 					return nil, fmt.Errorf("%w: workflow request must set either target or definition_id, not both", invocation.ErrInvalidInvocation)
@@ -821,6 +1104,8 @@ func (m *Manager) CreateSchedule(ctx context.Context, p *principal.Principal, re
 	if err != nil {
 		return nil, err
 	}
+	audit.setProvider(providerName)
+	audit.setWorkflowTarget(target)
 	if existing != nil {
 		if !managedScheduleMatchesUpsert(existing, providerName, target, req) {
 			return nil, fmt.Errorf("%w: workflow schedule idempotency key reused with different request", invocation.ErrInvalidInvocation)
@@ -899,8 +1184,21 @@ func (m *Manager) GetSchedule(ctx context.Context, p *principal.Principal, sched
 	return m.requireOwnedSchedule(ctx, scheduleID, p)
 }
 
-func (m *Manager) UpdateSchedule(ctx context.Context, p *principal.Principal, scheduleID string, req ScheduleUpsert) (*ManagedSchedule, error) {
+func (m *Manager) UpdateSchedule(ctx context.Context, p *principal.Principal, scheduleID string, req ScheduleUpsert) (out *ManagedSchedule, err error) {
 	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationScheduleUpdate)
+	audit.setCallerPlugin(req.CallerPluginName)
+	audit.setObjectTarget(workflowAuditTargetSchedule, scheduleID, "")
+	defer func() {
+		if out != nil && out.Schedule != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetSchedule, out.Schedule.ID, "")
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		audit.finish(ctx, err)
+	}()
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
 		return nil, ErrWorkflowSubjectRequired
 	}
@@ -908,10 +1206,13 @@ func (m *Manager) UpdateSchedule(ctx context.Context, p *principal.Principal, sc
 	if err != nil {
 		return nil, err
 	}
+	audit.setProvider(existing.ProviderName)
 	nextProviderName, nextProvider, target, err := m.resolveRequestProviderTarget(ctx, p, req.ProviderName, req.Target, req.DefinitionID, req.CallerPluginName)
 	if err != nil {
 		return nil, err
 	}
+	audit.setProvider(nextProviderName)
+	audit.setWorkflowTarget(target)
 
 	executionRefID := scheduleExecutionRefID(strings.TrimSpace(existing.Schedule.ID))
 	nextRef, err := m.putExecutionRefWithPermissions(ctx, executionRefID, nextProviderName, nextProvider, target, p, req.CallerPluginName, scheduleUpsertSourceDefinitionID(req), req.Permissions)
@@ -953,10 +1254,20 @@ func (m *Manager) UpdateSchedule(ctx context.Context, p *principal.Principal, sc
 	}, nil
 }
 
-func (m *Manager) DeleteSchedule(ctx context.Context, p *principal.Principal, scheduleID string) error {
+func (m *Manager) DeleteSchedule(ctx context.Context, p *principal.Principal, scheduleID string) (err error) {
+	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationScheduleDelete)
+	audit.setObjectTarget(workflowAuditTargetSchedule, scheduleID, "")
+	defer func() {
+		audit.finish(ctx, err)
+	}()
 	value, err := m.requireOwnedSchedule(ctx, scheduleID, p)
 	if err != nil {
 		return err
+	}
+	audit.setProvider(value.ProviderName)
+	if value.ExecutionRef != nil {
+		audit.setWorkflowTarget(value.ExecutionRef.Target)
 	}
 	if err := existingProvider(value).DeleteSchedule(ctx, coreworkflow.DeleteScheduleRequest{
 		ScheduleID: strings.TrimSpace(value.Schedule.ID),
@@ -967,10 +1278,27 @@ func (m *Manager) DeleteSchedule(ctx context.Context, p *principal.Principal, sc
 	return nil
 }
 
-func (m *Manager) PauseSchedule(ctx context.Context, p *principal.Principal, scheduleID string) (*ManagedSchedule, error) {
+func (m *Manager) PauseSchedule(ctx context.Context, p *principal.Principal, scheduleID string) (out *ManagedSchedule, err error) {
+	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationSchedulePause)
+	audit.setObjectTarget(workflowAuditTargetSchedule, scheduleID, "")
+	defer func() {
+		if out != nil && out.Schedule != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetSchedule, out.Schedule.ID, "")
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		audit.finish(ctx, err)
+	}()
 	value, err := m.requireOwnedSchedule(ctx, scheduleID, p)
 	if err != nil {
 		return nil, err
+	}
+	audit.setProvider(value.ProviderName)
+	if value.ExecutionRef != nil {
+		audit.setWorkflowTarget(value.ExecutionRef.Target)
 	}
 	schedule, err := existingProvider(value).PauseSchedule(ctx, coreworkflow.PauseScheduleRequest{
 		ScheduleID: strings.TrimSpace(value.Schedule.ID),
@@ -982,10 +1310,27 @@ func (m *Manager) PauseSchedule(ctx context.Context, p *principal.Principal, sch
 	return value, nil
 }
 
-func (m *Manager) ResumeSchedule(ctx context.Context, p *principal.Principal, scheduleID string) (*ManagedSchedule, error) {
+func (m *Manager) ResumeSchedule(ctx context.Context, p *principal.Principal, scheduleID string) (out *ManagedSchedule, err error) {
+	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationScheduleResume)
+	audit.setObjectTarget(workflowAuditTargetSchedule, scheduleID, "")
+	defer func() {
+		if out != nil && out.Schedule != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetSchedule, out.Schedule.ID, "")
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		audit.finish(ctx, err)
+	}()
 	value, err := m.requireOwnedSchedule(ctx, scheduleID, p)
 	if err != nil {
 		return nil, err
+	}
+	audit.setProvider(value.ProviderName)
+	if value.ExecutionRef != nil {
+		audit.setWorkflowTarget(value.ExecutionRef.Target)
 	}
 	schedule, err := existingProvider(value).ResumeSchedule(ctx, coreworkflow.ResumeScheduleRequest{
 		ScheduleID: strings.TrimSpace(value.Schedule.ID),
@@ -1051,8 +1396,20 @@ func (m *Manager) ListEventTriggers(ctx context.Context, p *principal.Principal)
 	return out, nil
 }
 
-func (m *Manager) CreateEventTrigger(ctx context.Context, p *principal.Principal, req EventTriggerUpsert) (*ManagedEventTrigger, error) {
+func (m *Manager) CreateEventTrigger(ctx context.Context, p *principal.Principal, req EventTriggerUpsert) (out *ManagedEventTrigger, err error) {
 	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationEventTriggerCreate)
+	audit.setCallerPlugin(req.CallerPluginName)
+	defer func() {
+		if out != nil && out.Trigger != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetEventTrigger, out.Trigger.ID, "")
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		audit.finish(ctx, err)
+	}()
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
 		return nil, ErrWorkflowSubjectRequired
 	}
@@ -1064,11 +1421,13 @@ func (m *Manager) CreateEventTrigger(ctx context.Context, p *principal.Principal
 	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
 	idempotencyScope := workflowCreateIdempotencyScope(p, req.CallerPluginName, idempotencyKey)
 	triggerID := newEventTriggerID(idempotencyScope)
+	audit.setObjectTarget(workflowAuditTargetEventTrigger, triggerID, "")
 	var existing *ManagedEventTrigger
 	if idempotencyKey != "" {
 		var err error
 		existing, err = m.requireOwnedEventTrigger(ctx, triggerID, p)
 		if err == nil {
+			audit.setProvider(existing.ProviderName)
 			if strings.TrimSpace(req.DefinitionID) != "" {
 				if workflowTargetIsSet(req.Target) {
 					return nil, fmt.Errorf("%w: workflow request must set either target or definition_id, not both", invocation.ErrInvalidInvocation)
@@ -1090,6 +1449,8 @@ func (m *Manager) CreateEventTrigger(ctx context.Context, p *principal.Principal
 	if err != nil {
 		return nil, err
 	}
+	audit.setProvider(providerName)
+	audit.setWorkflowTarget(target)
 	if existing != nil {
 		if !managedEventTriggerMatchesUpsert(existing, providerName, target, match, req) {
 			return nil, fmt.Errorf("%w: workflow trigger idempotency key reused with different request", invocation.ErrInvalidInvocation)
@@ -1154,8 +1515,21 @@ func (m *Manager) GetEventTrigger(ctx context.Context, p *principal.Principal, t
 	return m.requireOwnedEventTrigger(ctx, triggerID, p)
 }
 
-func (m *Manager) UpdateEventTrigger(ctx context.Context, p *principal.Principal, triggerID string, req EventTriggerUpsert) (*ManagedEventTrigger, error) {
+func (m *Manager) UpdateEventTrigger(ctx context.Context, p *principal.Principal, triggerID string, req EventTriggerUpsert) (out *ManagedEventTrigger, err error) {
 	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationEventTriggerUpdate)
+	audit.setCallerPlugin(req.CallerPluginName)
+	audit.setObjectTarget(workflowAuditTargetEventTrigger, triggerID, "")
+	defer func() {
+		if out != nil && out.Trigger != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetEventTrigger, out.Trigger.ID, "")
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		audit.finish(ctx, err)
+	}()
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
 		return nil, ErrWorkflowSubjectRequired
 	}
@@ -1163,10 +1537,13 @@ func (m *Manager) UpdateEventTrigger(ctx context.Context, p *principal.Principal
 	if err != nil {
 		return nil, err
 	}
+	audit.setProvider(existing.ProviderName)
 	nextProviderName, nextProvider, target, err := m.resolveRequestProviderTarget(ctx, p, req.ProviderName, req.Target, req.DefinitionID, req.CallerPluginName)
 	if err != nil {
 		return nil, err
 	}
+	audit.setProvider(nextProviderName)
+	audit.setWorkflowTarget(target)
 	match := normalizeEventMatch(req.Match)
 	if strings.TrimSpace(match.Type) == "" {
 		return nil, ErrWorkflowEventMatchRequired
@@ -1211,10 +1588,20 @@ func (m *Manager) UpdateEventTrigger(ctx context.Context, p *principal.Principal
 	}, nil
 }
 
-func (m *Manager) DeleteEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) error {
+func (m *Manager) DeleteEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (err error) {
+	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationEventTriggerDelete)
+	audit.setObjectTarget(workflowAuditTargetEventTrigger, triggerID, "")
+	defer func() {
+		audit.finish(ctx, err)
+	}()
 	value, err := m.requireOwnedEventTrigger(ctx, triggerID, p)
 	if err != nil {
 		return err
+	}
+	audit.setProvider(value.ProviderName)
+	if value.ExecutionRef != nil {
+		audit.setWorkflowTarget(value.ExecutionRef.Target)
 	}
 	if err := existingEventTriggerProvider(value).DeleteEventTrigger(ctx, coreworkflow.DeleteEventTriggerRequest{
 		TriggerID: strings.TrimSpace(value.Trigger.ID),
@@ -1225,10 +1612,27 @@ func (m *Manager) DeleteEventTrigger(ctx context.Context, p *principal.Principal
 	return nil
 }
 
-func (m *Manager) PauseEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (*ManagedEventTrigger, error) {
+func (m *Manager) PauseEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (out *ManagedEventTrigger, err error) {
+	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationEventTriggerPause)
+	audit.setObjectTarget(workflowAuditTargetEventTrigger, triggerID, "")
+	defer func() {
+		if out != nil && out.Trigger != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetEventTrigger, out.Trigger.ID, "")
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		audit.finish(ctx, err)
+	}()
 	value, err := m.requireOwnedEventTrigger(ctx, triggerID, p)
 	if err != nil {
 		return nil, err
+	}
+	audit.setProvider(value.ProviderName)
+	if value.ExecutionRef != nil {
+		audit.setWorkflowTarget(value.ExecutionRef.Target)
 	}
 	trigger, err := existingEventTriggerProvider(value).PauseEventTrigger(ctx, coreworkflow.PauseEventTriggerRequest{
 		TriggerID: strings.TrimSpace(value.Trigger.ID),
@@ -1240,10 +1644,27 @@ func (m *Manager) PauseEventTrigger(ctx context.Context, p *principal.Principal,
 	return value, nil
 }
 
-func (m *Manager) ResumeEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (*ManagedEventTrigger, error) {
+func (m *Manager) ResumeEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (out *ManagedEventTrigger, err error) {
+	p = principal.Canonicalized(p)
+	ctx, audit := m.beginWorkflowAudit(ctx, p, workflowAuditOperationEventTriggerResume)
+	audit.setObjectTarget(workflowAuditTargetEventTrigger, triggerID, "")
+	defer func() {
+		if out != nil && out.Trigger != nil {
+			audit.setProvider(out.ProviderName)
+			audit.setObjectTarget(workflowAuditTargetEventTrigger, out.Trigger.ID, "")
+			if out.ExecutionRef != nil {
+				audit.setWorkflowTarget(out.ExecutionRef.Target)
+			}
+		}
+		audit.finish(ctx, err)
+	}()
 	value, err := m.requireOwnedEventTrigger(ctx, triggerID, p)
 	if err != nil {
 		return nil, err
+	}
+	audit.setProvider(value.ProviderName)
+	if value.ExecutionRef != nil {
+		audit.setWorkflowTarget(value.ExecutionRef.Target)
 	}
 	trigger, err := existingEventTriggerProvider(value).ResumeEventTrigger(ctx, coreworkflow.ResumeEventTriggerRequest{
 		TriggerID: strings.TrimSpace(value.Trigger.ID),
@@ -1948,76 +2369,157 @@ func (m *Manager) providerAccessContext(ctx context.Context, p *principal.Princi
 	return access
 }
 
+const (
+	targetAuthorizationComponentTarget               = "target"
+	targetAuthorizationComponentAgentProvider        = "agent_provider"
+	targetAuthorizationComponentAgentToolRef         = "agent_tool_ref"
+	targetAuthorizationComponentOutputDelivery       = "output_delivery"
+	targetAuthorizationComponentSessionReadyDelivery = "session_ready_delivery"
+	targetAuthorizationComponentPluginTarget         = "plugin_target"
+
+	targetAuthorizationReasonMissingAgentProvider               = "missing_agent_provider"
+	targetAuthorizationReasonAuthorizerProviderDenied           = "authorizer_provider_denied"
+	targetAuthorizationReasonPrincipalProviderPermissionDenied  = "principal_provider_permission_denied"
+	targetAuthorizationReasonMissingToolProvider                = "missing_tool_provider"
+	targetAuthorizationReasonInvalidSystemToolRef               = "invalid_system_tool_ref"
+	targetAuthorizationReasonNonExactToolRefWithSystemTools     = "non_exact_tool_ref_with_system_tools"
+	targetAuthorizationReasonAuthorizerOperationDenied          = "authorizer_operation_denied"
+	targetAuthorizationReasonPrincipalOperationPermissionDenied = "principal_operation_permission_denied"
+	targetAuthorizationReasonMissingPluginTarget                = "missing_plugin_target"
+	targetAuthorizationReasonMissingPluginProvider              = "missing_plugin_provider"
+	targetAuthorizationReasonMissingPluginOperation             = "missing_plugin_operation"
+)
+
+type targetAuthorizationDecision struct {
+	allowed bool
+	failure targetAuthorizationFailure
+}
+
+type targetAuthorizationFailure struct {
+	component    string
+	reason       string
+	provider     string
+	operation    string
+	toolRefIndex int
+}
+
 func (m *Manager) allowTarget(ctx context.Context, p *principal.Principal, target coreworkflow.Target) bool {
+	return m.checkTargetAuthorization(ctx, p, target).allowed
+}
+
+func (m *Manager) checkTargetAuthorization(ctx context.Context, p *principal.Principal, target coreworkflow.Target) targetAuthorizationDecision {
 	if target.Agent != nil {
 		agentProviderName := strings.TrimSpace(target.Agent.ProviderName)
-		if agentProviderName == "" || !m.allowProvider(ctx, p, agentProviderName) || !principal.AllowsProviderPermission(p, agentProviderName) {
-			return false
+		if agentProviderName == "" {
+			return targetAuthorizationDenied(targetAuthorizationComponentAgentProvider, targetAuthorizationReasonMissingAgentProvider, "", "", -1)
+		}
+		if !m.allowProvider(ctx, p, agentProviderName) {
+			return targetAuthorizationDenied(targetAuthorizationComponentAgentProvider, targetAuthorizationReasonAuthorizerProviderDenied, agentProviderName, "", -1)
+		}
+		if !principal.AllowsProviderPermission(p, agentProviderName) {
+			return targetAuthorizationDenied(targetAuthorizationComponentAgentProvider, targetAuthorizationReasonPrincipalProviderPermissionDenied, agentProviderName, "", -1)
 		}
 		hasSystemTools := workflowAgentToolRefsContainSystem(target.Agent.ToolRefs)
 		for i := range target.Agent.ToolRefs {
 			tool := target.Agent.ToolRefs[i]
 			if systemName := strings.TrimSpace(tool.System); systemName != "" {
 				if systemName != coreagent.SystemToolWorkflow || strings.TrimSpace(tool.Operation) == "" {
-					return false
+					return targetAuthorizationDenied(targetAuthorizationComponentAgentToolRef, targetAuthorizationReasonInvalidSystemToolRef, "", "", i)
 				}
 				if strings.TrimSpace(tool.Plugin) != "" || strings.TrimSpace(tool.Connection) != "" || strings.TrimSpace(tool.Instance) != "" || tool.CredentialMode != "" {
-					return false
+					return targetAuthorizationDenied(targetAuthorizationComponentAgentToolRef, targetAuthorizationReasonInvalidSystemToolRef, "", "", i)
 				}
 				continue
 			}
 			pluginName := strings.TrimSpace(tool.Plugin)
 			operation := strings.TrimSpace(tool.Operation)
 			if pluginName == "" {
-				return false
+				return targetAuthorizationDenied(targetAuthorizationComponentAgentToolRef, targetAuthorizationReasonMissingToolProvider, "", operation, i)
 			}
 			if hasSystemTools && (pluginName == "*" || operation == "") {
-				return false
+				return targetAuthorizationDenied(targetAuthorizationComponentAgentToolRef, targetAuthorizationReasonNonExactToolRefWithSystemTools, pluginName, operation, i)
 			}
 			if operation == "" {
-				if !m.allowProvider(ctx, p, pluginName) || !principal.AllowsProviderPermission(p, pluginName) {
-					return false
+				if !m.allowProvider(ctx, p, pluginName) {
+					return targetAuthorizationDenied(targetAuthorizationComponentAgentToolRef, targetAuthorizationReasonAuthorizerProviderDenied, pluginName, "", i)
+				}
+				if !principal.AllowsProviderPermission(p, pluginName) {
+					return targetAuthorizationDenied(targetAuthorizationComponentAgentToolRef, targetAuthorizationReasonPrincipalProviderPermissionDenied, pluginName, "", i)
 				}
 				continue
 			}
-			if !m.allowProvider(ctx, p, pluginName) || !m.allowOperation(ctx, p, pluginName, operation) {
-				return false
+			if !m.allowProvider(ctx, p, pluginName) {
+				return targetAuthorizationDenied(targetAuthorizationComponentAgentToolRef, targetAuthorizationReasonAuthorizerProviderDenied, pluginName, operation, i)
+			}
+			if !m.allowOperation(ctx, p, pluginName, operation) {
+				return targetAuthorizationDenied(targetAuthorizationComponentAgentToolRef, targetAuthorizationReasonAuthorizerOperationDenied, pluginName, operation, i)
 			}
 			if !principal.AllowsOperationPermission(p, pluginName, operation) {
-				return false
+				return targetAuthorizationDenied(targetAuthorizationComponentAgentToolRef, targetAuthorizationReasonPrincipalOperationPermissionDenied, pluginName, operation, i)
 			}
 		}
 		if pluginName, operation, ok := workflowOutputDeliveryOperation(target.Agent.OutputDelivery); ok {
-			if !m.allowProvider(ctx, p, pluginName) || !m.allowOperation(ctx, p, pluginName, operation) {
-				return false
+			if !m.allowProvider(ctx, p, pluginName) {
+				return targetAuthorizationDenied(targetAuthorizationComponentOutputDelivery, targetAuthorizationReasonAuthorizerProviderDenied, pluginName, operation, -1)
+			}
+			if !m.allowOperation(ctx, p, pluginName, operation) {
+				return targetAuthorizationDenied(targetAuthorizationComponentOutputDelivery, targetAuthorizationReasonAuthorizerOperationDenied, pluginName, operation, -1)
 			}
 			if !principal.AllowsOperationPermission(p, pluginName, operation) {
-				return false
+				return targetAuthorizationDenied(targetAuthorizationComponentOutputDelivery, targetAuthorizationReasonPrincipalOperationPermissionDenied, pluginName, operation, -1)
 			}
 		}
 		if pluginName, operation, ok := workflowOutputDeliveryOperation(target.Agent.SessionReadyDelivery); ok {
-			if !m.allowProvider(ctx, p, pluginName) || !m.allowOperation(ctx, p, pluginName, operation) {
-				return false
+			if !m.allowProvider(ctx, p, pluginName) {
+				return targetAuthorizationDenied(targetAuthorizationComponentSessionReadyDelivery, targetAuthorizationReasonAuthorizerProviderDenied, pluginName, operation, -1)
+			}
+			if !m.allowOperation(ctx, p, pluginName, operation) {
+				return targetAuthorizationDenied(targetAuthorizationComponentSessionReadyDelivery, targetAuthorizationReasonAuthorizerOperationDenied, pluginName, operation, -1)
 			}
 			if !principal.AllowsOperationPermission(p, pluginName, operation) {
-				return false
+				return targetAuthorizationDenied(targetAuthorizationComponentSessionReadyDelivery, targetAuthorizationReasonPrincipalOperationPermissionDenied, pluginName, operation, -1)
 			}
 		}
-		return true
+		return targetAuthorizationAllowed()
 	}
 	if target.Plugin == nil {
-		return false
+		return targetAuthorizationDenied(targetAuthorizationComponentTarget, targetAuthorizationReasonMissingPluginTarget, "", "", -1)
 	}
 	pluginTarget := *target.Plugin
 	pluginName := strings.TrimSpace(pluginTarget.PluginName)
 	operation := strings.TrimSpace(pluginTarget.Operation)
-	if pluginName == "" || operation == "" {
-		return false
+	if pluginName == "" {
+		return targetAuthorizationDenied(targetAuthorizationComponentPluginTarget, targetAuthorizationReasonMissingPluginProvider, "", operation, -1)
 	}
-	if !m.allowProvider(ctx, p, pluginName) || !m.allowOperation(ctx, p, pluginName, operation) {
-		return false
+	if operation == "" {
+		return targetAuthorizationDenied(targetAuthorizationComponentPluginTarget, targetAuthorizationReasonMissingPluginOperation, pluginName, "", -1)
 	}
-	return principal.AllowsOperationPermission(p, pluginName, operation)
+	if !m.allowProvider(ctx, p, pluginName) {
+		return targetAuthorizationDenied(targetAuthorizationComponentPluginTarget, targetAuthorizationReasonAuthorizerProviderDenied, pluginName, operation, -1)
+	}
+	if !m.allowOperation(ctx, p, pluginName, operation) {
+		return targetAuthorizationDenied(targetAuthorizationComponentPluginTarget, targetAuthorizationReasonAuthorizerOperationDenied, pluginName, operation, -1)
+	}
+	if !principal.AllowsOperationPermission(p, pluginName, operation) {
+		return targetAuthorizationDenied(targetAuthorizationComponentPluginTarget, targetAuthorizationReasonPrincipalOperationPermissionDenied, pluginName, operation, -1)
+	}
+	return targetAuthorizationAllowed()
+}
+
+func targetAuthorizationAllowed() targetAuthorizationDecision {
+	return targetAuthorizationDecision{allowed: true}
+}
+
+func targetAuthorizationDenied(component, reason, provider, operation string, toolRefIndex int) targetAuthorizationDecision {
+	return targetAuthorizationDecision{
+		failure: targetAuthorizationFailure{
+			component:    component,
+			reason:       reason,
+			provider:     provider,
+			operation:    operation,
+			toolRefIndex: toolRefIndex,
+		},
+	}
 }
 
 func workflowAgentToolRefsContainSystem(refs []coreagent.ToolRef) bool {


### PR DESCRIPTION
## Summary

- Add workflow-manager audit records for mutating/action workflow methods through the existing audit sink.
- Add minimal workflow audit metadata for workflow key hashes, caller plugin, and denied/single direct workflow targets.
- Keep `workflow manager signal-or-start failed` as the operational log surface, limited to request correlation, phase, stable error class/code, and authorization decision/component.

## Interface Changes

- New optional `core.AuditEntry` fields emitted by `SlogAuditSink`: `workflow_key_sha256`, `caller_plugin`, `workflow_target_kind`, `workflow_target_component`, `workflow_target_provider`, and `workflow_target_operation`.
- Workflow manager audit records use `source=workflow_manager` and operations such as `workflow.run.signal_or_start`, `workflow.event.publish`, and the definition/schedule/trigger/run action names.
- Example denial audit shape: `operation=workflow.run.signal_or_start`, `allowed=false`, `authorization_decision=workflow_target_principal_operation_permission_denied`, `workflow_target_component=agent_tool_ref`, `workflow_target_provider=github`, `workflow_target_operation=reviewPullRequest`.
- Example operational warning shape: `request_id`, `phase=authorize_target`, `workflow_key_sha256`, `error_type=not_found`, `authorization_decision`, and `workflow_target_component`; no caller/subject/provider/operation/tool index.

## Test plan

- [x] `go test ./services/workflows -run 'TestManagerServerPublishEventThreadsCallerPluginToSelectedProvider|TestManagerServerPublishEventThreadsCallerPluginToFanoutProviders|TestWorkflowManagerHostRecordsSignalOrStartMetricsAcrossTransport' -count=1`
- [x] `go test ./services/workflows/... -count=1`
- [x] `go test ./services/invocation -count=1`
- [x] `go test ./internal/bootstrap -run TestDoesNotExist -count=1`
- [x] `go test ./internal/server -run TestDoesNotExist -count=1`
- [x] `go test ./internal/bootstrap -run TestAgentRuntimeWorkflowSystemToolStartsRunWithInheritedOutputDelivery -count=1`
