### PR TITLE
Fix overview docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ When you need production controls, add them through the [provider](https://gesta
 
 ### What Gestalt provides
 
-- Plug-and-play [providers](/providers), inspired by [Terraform providers](https://developer.hashicorp.com/terraform/language/providers), so you add only what you need.
-- A unified tool surface for agents over MCP, HTTP, and CLI, usable by cloud agents, local coding assistants, and human operators. See [Plugin](/providers/plugins).
-- [Authentication](/providers/authentication) flows, [credential storage](/providers/external-credentials), encryption at rest, token refresh, and [RBAC](/providers/authorization) on infrastructure you control.
-- [OpenTelemetry](https://opentelemetry.io/) compatible [observability](/observability) and [audit logging](/audit-logging).
-- [Runtimes](/providers/runtime) for agent and code sandboxing.<sup><a href="#runtimes-alpha-note">*</a></sup>
-- [Workflows](/providers/workflow) and [agents](/providers/agent) with durable state, retries, and delegated invocations.<sup><a href="#workflows-agents-alpha-note">†</a></sup>
+- Plug-and-play [providers](https://gestaltd.ai/providers), inspired by [Terraform providers](https://developer.hashicorp.com/terraform/language/providers), so you add only what you need.
+- A [unified tool surface](https://gestaltd.ai/providers/plugins) over MCP, HTTP, and CLI, usable by cloud agents, local coding assistants, and human operators.
+- [Authentication](https://gestaltd.ai/providers/authentication) flows, [credential storage](https://gestaltd.ai/providers/external-credentials), encryption at rest, token refresh, and [RBAC](https://gestaltd.ai/providers/authorization) on infrastructure you control.
+- [OpenTelemetry](https://opentelemetry.io/) compatible [observability](https://gestaltd.ai/observability) and [audit logging](https://gestaltd.ai/audit-logging).
+- [Runtimes](https://gestaltd.ai/providers/runtime) for agent and code sandboxing.<sup><a href="#runtimes-alpha-note">*</a></sup>
+- [Workflows](https://gestaltd.ai/providers/workflow) and [agents](https://gestaltd.ai/providers/agent) with durable state, retries, and delegated invocations.<sup><a href="#workflows-agents-alpha-note">†</a></sup>
 
 ## What Gestalt Is Not
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -41,7 +41,7 @@ When you need production controls, add them through the [provider](/providers) e
 ### What Gestalt provides
 
 - Plug-and-play [providers](/providers), inspired by [Terraform providers](https://developer.hashicorp.com/terraform/language/providers), so you add only what you need.
-- A unified tool surface for agents over MCP, HTTP, and CLI, usable by cloud agents, local coding assistants, and human operators. See [Plugin](/providers/plugins).
+- A [unified tool surface](/providers/plugins) over MCP, HTTP, and CLI, usable by cloud agents, local coding assistants, and human operators.
 - [Authentication](/providers/authentication) flows, [credential storage](/providers/external-credentials), encryption at rest, token refresh, and [RBAC](/providers/authorization) on infrastructure you control.
 - [OpenTelemetry](https://opentelemetry.io/) compatible [observability](/observability) and [audit logging](/audit-logging).
 - [Runtimes](/providers/runtime) for agent and code sandboxing.<sup><a href="#runtimes-alpha-note">*</a></sup>


### PR DESCRIPTION
## Summary
- Make the README overview links use the public `gestaltd.ai` URLs that correspond to the docs index links.
- Move the plugin link onto "unified tool surface" and remove the separate "See Plugin" sentence in both the README and docs index.
- Remove the "for agents" wording from the unified tool surface line.

## Test plan
- [x] `git diff --check`
- [x] `npm ci` in `docs/`
- [x] `npm run build:single` in `docs/` (passes; Nextra emitted worktree last-modified timestamp warnings)