### PR TITLE
[codex] Add explicit GraphQL allowlist selections

### DIFF
--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -425,10 +425,10 @@ selection set. GraphQL manifests that use per-operation `graphql` blocks must
 not also use legacy
 `spec.surfaces.graphql.operationSelections`. For older `gestaltd` compatibility,
 manifests may instead keep selection bodies in `operationSelections` and use
-`allowedOperations` only as the provider-wide exposure allowlist. In that legacy
-mode, GraphQL catalog generation applies only allowlisted schema root fields and
-selection override names so OpenAPI or MCP-only entries can remain in the same
-provider-wide allowlist.
+`allowedOperations` only as the provider-wide exposure allowlist. In the bare
+provider-wide mode, GraphQL catalog generation applies only allowlisted schema
+root fields and selection override names so OpenAPI or MCP-only entries can
+remain in the same allowlist.
 If an upstream schema defines the same root field name on both query and mutation
 roots, set `graphql.operationType` to bind the allowlisted operation to one root.
 For providers that combine GraphQL with another surface, mark each GraphQL entry

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -189,6 +189,7 @@ Surfaces load operation catalogs from external specifications. They are configur
 | ------------ | ------ | --------------------------------------- |
 | `url`        | string | URL of the upstream GraphQL endpoint.   |
 | `connection` | string | Connection name used for GraphQL calls. |
+| `operationSelections` | object | Legacy per-operation selection overrides for generated GraphQL catalogs. Do not combine with GraphQL `allowedOperations`. |
 
 GraphQL surfaces expose a raw GraphQL passthrough immediately. Generated GraphQL operation catalogs are resolved lazily from the upstream schema when a real request runs under that surface's connection. Gestalt does not introspect GraphQL endpoints during package build, `gestaltd lock`, or config validation.
 
@@ -385,6 +386,8 @@ The `allowedOperations` map selectively exposes and customizes operations from a
 | `allowedRoles` | string[]                 | Restrict the operation to callers whose resolved human role matches one of these values. This only takes effect when the deployment binds the plugin to `authorizationPolicy`. |
 | `paginate`     | bool                     | Enable automatic pagination for this operation. Uses the plugin-level pagination config.                                                                                       |
 | `pagination`   | ManifestPaginationConfig | Per-operation pagination config that overrides the plugin-level default.                                                                                                       |
+| `graphql.operationType` | `"query"` or `"mutation"` | GraphQL root operation type. Required when the same allowlisted field name exists on both query and mutation roots. |
+| `graphql.selectionSet` | string | GraphQL selection-set body for an allowlisted GraphQL root field. Required for object, interface, and union return types when `allowedOperations` is set on a GraphQL surface. |
 
 ```yaml
 spec:
@@ -397,6 +400,36 @@ spec:
       alias: get_ticket
       allowedRoles: [admin]
 ```
+
+For GraphQL surfaces, `allowedOperations` keys are the upstream schema root
+field names. When a GraphQL surface declares `allowedOperations`, Gestalt treats
+the allowlist as an explicit operation contract and does not generate response
+selections for object-like return types. Provide `graphql.selectionSet` without
+outer braces:
+
+```yaml
+spec:
+  allowedOperations:
+    issues:
+      graphql:
+        selectionSet: |
+          nodes { id identifier title url team { id name key } }
+          pageInfo { hasNextPage endCursor }
+```
+
+Selection sets may include aliases, nested selections, `__typename`, and inline
+fragments. Named fragment spreads, fragment definitions, directives, and field
+arguments in selection sets are not supported. GraphQL manifests that use
+per-operation `graphql` blocks must not also use legacy
+`spec.surfaces.graphql.operationSelections`. For older `gestaltd` compatibility,
+manifests may instead keep selection bodies in `operationSelections` and use
+`allowedOperations` only as the exposure allowlist.
+If an upstream schema defines the same root field name on both query and mutation
+roots, set `graphql.operationType` to bind the allowlisted operation to one root.
+For providers that combine GraphQL with another surface, mark each GraphQL entry
+with a `graphql` block; entries without that block are left for the other surface.
+This only controls generated GraphQL catalog operations; raw GraphQL passthrough
+access remains a separate surface permission.
 
 ### Response Mapping
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -419,11 +419,16 @@ spec:
 
 Selection sets may include aliases, nested selections, `__typename`, and inline
 fragments. Named fragment spreads, fragment definitions, directives, and field
-arguments in selection sets are not supported. GraphQL manifests that use
-per-operation `graphql` blocks must not also use legacy
+arguments in selection sets are not supported; fields that require arguments are
+rejected because Gestalt cannot synthesize nested argument values from a
+selection set. GraphQL manifests that use per-operation `graphql` blocks must
+not also use legacy
 `spec.surfaces.graphql.operationSelections`. For older `gestaltd` compatibility,
 manifests may instead keep selection bodies in `operationSelections` and use
-`allowedOperations` only as the exposure allowlist.
+`allowedOperations` only as the provider-wide exposure allowlist. In that legacy
+mode, GraphQL catalog generation applies only allowlisted schema root fields and
+selection override names so OpenAPI or MCP-only entries can remain in the same
+provider-wide allowlist.
 If an upstream schema defines the same root field name on both query and mutation
 roots, set `graphql.operationType` to bind the allowlisted operation to one root.
 For providers that combine GraphQL with another surface, mark each GraphQL entry

--- a/gestaltd/internal/bootstrap/graphql_session_provider_test.go
+++ b/gestaltd/internal/bootstrap/graphql_session_provider_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
 	"github.com/valon-technologies/gestalt/server/services/plugins/graphql"
 )
@@ -84,10 +85,11 @@ func TestGraphQLSessionCatalogProviderLoadsCatalogOnDemand(t *testing.T) {
 	}
 
 	wrapped := wrapGraphQLSessionCatalogProvider(base, "linear", srv.URL, map[string]*config.OperationOverride{
-		"viewer": {Tags: []string{"profile"}},
-	}, map[string]string{
-		"viewer": "id",
-	})
+		"viewer": {
+			Tags:    []string{"profile"},
+			GraphQL: &providermanifestv1.ManifestGraphQLOperation{SelectionSet: "id"},
+		},
+	}, nil)
 	if got := len(wrapped.Catalog().Operations); got != 0 {
 		t.Fatalf("static catalog ops = %d, want 0", got)
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -619,7 +619,9 @@ func buildConfiguredSpecComposite(ctx context.Context, name string, entry *confi
 		return apiProv, authFallback, nil
 	}
 
-	mcpProv, _, err := buildConfiguredSpecProvider(ctx, name, mcpResolved, meta, cfg, deps)
+	mcpCfg := cfg
+	mcpCfg.allowedOperations = nil
+	mcpProv, _, err := buildConfiguredSpecProvider(ctx, name, mcpResolved, meta, mcpCfg, deps)
 	if err != nil {
 		closeIfPossible(apiProv)
 		return nil, nil, err
@@ -630,8 +632,16 @@ func buildConfiguredSpecComposite(ctx context.Context, name string, entry *confi
 		return nil, nil, fmt.Errorf("unexpected mcp provider type %T", mcpProv)
 	}
 
-	filtered := operationexposure.MatchingAllowedOperations(allowedOperations, mcpUp.Catalog())
-	if len(filtered) > 0 {
+	var apiCatalog *catalog.Catalog
+	if apiProv != nil {
+		apiCatalog = apiProv.Catalog()
+	}
+	mcpAllowedOperations, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, apiProv != nil, apiCatalog, mcpUp.Catalog())
+	if !includeMCP {
+		closeIfPossible(mcpUp)
+		return apiProv, authFallback, nil
+	}
+	if mcpAllowedOperations != nil {
 		filterable, ok := any(mcpUp).(interface {
 			FilterOperations(map[string]*operationexposure.OperationOverride) error
 		})
@@ -639,7 +649,7 @@ func buildConfiguredSpecComposite(ctx context.Context, name string, entry *confi
 			closeIfPossible(mcpUp, apiProv)
 			return nil, nil, fmt.Errorf("unexpected non-filterable mcp provider type %T", mcpProv)
 		}
-		if err := filterable.FilterOperations(filtered); err != nil {
+		if err := filterable.FilterOperations(mcpAllowedOperations); err != nil {
 			closeIfPossible(mcpUp, apiProv)
 			return nil, nil, fmt.Errorf("filter mcp operations: %w", err)
 		}
@@ -649,6 +659,55 @@ func buildConfiguredSpecComposite(ctx context.Context, name string, entry *confi
 		return mcpUp, nil, nil
 	}
 	return composite.New(name, apiProv, mcpUp), authFallback, nil
+}
+
+func mcpAllowedOperationsForSpecComposite(allowedOperations map[string]*config.OperationOverride, hasAPI bool, apiCatalog, mcpCatalog *catalog.Catalog) (map[string]*config.OperationOverride, bool) {
+	if allowedOperations == nil {
+		return nil, true
+	}
+	if !hasAPI {
+		return allowedOperations, true
+	}
+	if mcpCatalog != nil && len(mcpCatalog.Operations) > 0 {
+		matched := operationexposure.MatchingAllowedOperations(allowedOperations, mcpCatalog)
+		return matched, len(matched) > 0
+	}
+	filtered := dynamicMCPAllowedOperations(allowedOperations, apiCatalog)
+	if len(filtered) == 0 {
+		return nil, false
+	}
+	return filtered, true
+}
+
+func dynamicMCPAllowedOperations(allowedOperations map[string]*config.OperationOverride, apiCatalog *catalog.Catalog) map[string]*config.OperationOverride {
+	apiOps := catalogOperationIDs(apiCatalog)
+	filtered := make(map[string]*config.OperationOverride)
+	for name, override := range allowedOperations {
+		if override != nil && override.GraphQL != nil {
+			continue
+		}
+		if _, ok := apiOps[name]; ok {
+			continue
+		}
+		if override != nil && override.Alias != "" {
+			if _, ok := apiOps[override.Alias]; ok {
+				continue
+			}
+		}
+		filtered[name] = override
+	}
+	return filtered
+}
+
+func catalogOperationIDs(cat *catalog.Catalog) map[string]struct{} {
+	ids := make(map[string]struct{})
+	if cat == nil {
+		return ids
+	}
+	for i := range cat.Operations {
+		ids[cat.Operations[i].ID] = struct{}{}
+	}
+	return ids
 }
 
 func buildConfiguredAPIProvider(ctx context.Context, name string, plan config.StaticConnectionPlan, meta providerMetadata, cfg specProviderConfig, deps Deps) (core.Provider, *specAuthFallback, error) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -636,7 +636,11 @@ func buildConfiguredSpecComposite(ctx context.Context, name string, entry *confi
 	if apiProv != nil {
 		apiCatalog = apiProv.Catalog()
 	}
-	mcpAllowedOperations, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, apiProv != nil, apiCatalog, mcpUp.Catalog())
+	var graphQLSelections map[string]string
+	if resolved, ok := plan.ResolvedSurface(config.SpecSurfaceGraphQL); ok {
+		graphQLSelections = resolved.GraphQLSelections
+	}
+	mcpAllowedOperations, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, apiProv != nil, apiCatalog, mcpUp.Catalog(), graphQLSelections)
 	if !includeMCP {
 		closeIfPossible(mcpUp)
 		return apiProv, authFallback, nil
@@ -661,14 +665,14 @@ func buildConfiguredSpecComposite(ctx context.Context, name string, entry *confi
 	return composite.New(name, apiProv, mcpUp), authFallback, nil
 }
 
-func mcpAllowedOperationsForSpecComposite(allowedOperations map[string]*config.OperationOverride, hasAPI bool, apiCatalog, mcpCatalog *catalog.Catalog) (map[string]*config.OperationOverride, bool) {
+func mcpAllowedOperationsForSpecComposite(allowedOperations map[string]*config.OperationOverride, hasAPI bool, apiCatalog, mcpCatalog *catalog.Catalog, graphQLSelections map[string]string) (map[string]*config.OperationOverride, bool) {
 	if allowedOperations == nil {
 		return nil, true
 	}
 	if !hasAPI {
 		return allowedOperations, true
 	}
-	mcpAllowed := dynamicMCPAllowedOperations(allowedOperations, apiCatalog)
+	mcpAllowed := dynamicMCPAllowedOperations(allowedOperations, apiCatalog, graphQLSelections)
 	if mcpCatalog != nil && len(mcpCatalog.Operations) > 0 {
 		matched := operationexposure.MatchingAllowedOperations(mcpAllowed, mcpCatalog)
 		return matched, len(matched) > 0
@@ -679,11 +683,14 @@ func mcpAllowedOperationsForSpecComposite(allowedOperations map[string]*config.O
 	return mcpAllowed, true
 }
 
-func dynamicMCPAllowedOperations(allowedOperations map[string]*config.OperationOverride, apiCatalog *catalog.Catalog) map[string]*config.OperationOverride {
+func dynamicMCPAllowedOperations(allowedOperations map[string]*config.OperationOverride, apiCatalog *catalog.Catalog, graphQLSelections map[string]string) map[string]*config.OperationOverride {
 	apiOps := catalogOperationIDs(apiCatalog)
 	filtered := make(map[string]*config.OperationOverride)
 	for name, override := range allowedOperations {
 		if override != nil && override.GraphQL != nil {
+			continue
+		}
+		if _, ok := graphQLSelections[name]; ok {
 			continue
 		}
 		if _, ok := apiOps[name]; ok {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -668,15 +668,15 @@ func mcpAllowedOperationsForSpecComposite(allowedOperations map[string]*config.O
 	if !hasAPI {
 		return allowedOperations, true
 	}
+	mcpAllowed := dynamicMCPAllowedOperations(allowedOperations, apiCatalog)
 	if mcpCatalog != nil && len(mcpCatalog.Operations) > 0 {
-		matched := operationexposure.MatchingAllowedOperations(allowedOperations, mcpCatalog)
+		matched := operationexposure.MatchingAllowedOperations(mcpAllowed, mcpCatalog)
 		return matched, len(matched) > 0
 	}
-	filtered := dynamicMCPAllowedOperations(allowedOperations, apiCatalog)
-	if len(filtered) == 0 {
+	if len(mcpAllowed) == 0 {
 		return nil, false
 	}
-	return filtered, true
+	return mcpAllowed, true
 }
 
 func dynamicMCPAllowedOperations(allowedOperations map[string]*config.OperationOverride, apiCatalog *catalog.Catalog) map[string]*config.OperationOverride {

--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -90,7 +90,7 @@ func TestMCPAllowedOperationsForSpecCompositeFiltersOnlyWhenAPIIsPresent(t *test
 		{ID: "mcp_lookup"},
 	}}
 
-	filtered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, true, apiCatalog, mcpCatalog)
+	filtered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, true, apiCatalog, mcpCatalog, nil)
 	if !includeMCP {
 		t.Fatal("includeMCP = false, want true for matching static MCP catalog")
 	}
@@ -101,7 +101,7 @@ func TestMCPAllowedOperationsForSpecCompositeFiltersOnlyWhenAPIIsPresent(t *test
 		t.Fatal("GraphQL-tagged operation should not be passed to MCP filter when API surface exists")
 	}
 
-	unfiltered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, false, nil, mcpCatalog)
+	unfiltered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, false, nil, mcpCatalog, nil)
 	if !includeMCP {
 		t.Fatal("includeMCP = false, want true for MCP-only provider")
 	}
@@ -127,12 +127,34 @@ func TestMCPAllowedOperationsForSpecCompositePreservesDynamicAllowlist(t *testin
 		{ID: "listNotes"},
 	}}
 
-	filtered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, true, apiCatalog, &catalog.Catalog{})
+	filtered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, true, apiCatalog, &catalog.Catalog{}, nil)
 	if !includeMCP {
 		t.Fatal("includeMCP = false, want true for dynamic MCP allowlist")
 	}
 	if len(filtered) != 1 || filtered["lookup"] == nil {
 		t.Fatalf("filtered allowedOperations = %#v, want only dynamic MCP operation", filtered)
+	}
+}
+
+func TestMCPAllowedOperationsForSpecCompositeFiltersLegacyGraphQLSelections(t *testing.T) {
+	t.Parallel()
+
+	allowedOperations := map[string]*config.OperationOverride{
+		"searchIssues": {Description: "legacy GraphQL search"},
+		"lookup":       {Description: "MCP lookup"},
+	}
+
+	filtered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, true, &catalog.Catalog{}, &catalog.Catalog{}, map[string]string{
+		"searchIssues": "nodes { id }",
+	})
+	if !includeMCP {
+		t.Fatal("includeMCP = false, want true for dynamic MCP allowlist")
+	}
+	if len(filtered) != 1 || filtered["lookup"] == nil {
+		t.Fatalf("filtered allowedOperations = %#v, want only lookup", filtered)
+	}
+	if _, ok := filtered["searchIssues"]; ok {
+		t.Fatal("legacy GraphQL selection operation should not be passed to dynamic MCP filter")
 	}
 }
 
@@ -148,7 +170,7 @@ func TestMCPAllowedOperationsForSpecCompositeOmitsMCPWhenNoMCPAllowlistEntries(t
 		},
 	}
 
-	filtered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, true, nil, &catalog.Catalog{})
+	filtered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, true, nil, &catalog.Catalog{}, nil)
 	if includeMCP {
 		t.Fatalf("includeMCP = true with filtered allowedOperations %#v, want false", filtered)
 	}

--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
@@ -65,5 +66,92 @@ func TestApplyProviderPaginationUsesExposedAlias(t *testing.T) {
 	}
 	if _, ok := def.Operations["mcp_only"]; ok {
 		t.Fatal("applyProviderPagination created absent mcp_only operation")
+	}
+}
+
+func TestMCPAllowedOperationsForSpecCompositeFiltersOnlyWhenAPIIsPresent(t *testing.T) {
+	t.Parallel()
+
+	allowedOperations := map[string]*config.OperationOverride{
+		"searchIssues": {
+			Description: "GraphQL search",
+			GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+				SelectionSet: "nodes { id }",
+			},
+		},
+		"lookup":     {Description: "MCP lookup"},
+		"list_notes": {Alias: "listNotes"},
+	}
+	apiCatalog := &catalog.Catalog{Operations: []catalog.CatalogOperation{
+		{ID: "listNotes"},
+	}}
+	mcpCatalog := &catalog.Catalog{Operations: []catalog.CatalogOperation{
+		{ID: "lookup"},
+	}}
+
+	filtered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, true, apiCatalog, mcpCatalog)
+	if !includeMCP {
+		t.Fatal("includeMCP = false, want true for matching static MCP catalog")
+	}
+	if len(filtered) != 1 || filtered["lookup"] == nil {
+		t.Fatalf("filtered allowedOperations = %#v, want only lookup", filtered)
+	}
+	if _, ok := filtered["searchIssues"]; ok {
+		t.Fatal("GraphQL-only operation should not be passed to MCP filter when API surface exists")
+	}
+
+	unfiltered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, false, nil, mcpCatalog)
+	if !includeMCP {
+		t.Fatal("includeMCP = false, want true for MCP-only provider")
+	}
+	if len(unfiltered) != len(allowedOperations) {
+		t.Fatalf("unfiltered allowedOperations = %#v, want all operations for MCP-only provider", unfiltered)
+	}
+}
+
+func TestMCPAllowedOperationsForSpecCompositePreservesDynamicAllowlist(t *testing.T) {
+	t.Parallel()
+
+	allowedOperations := map[string]*config.OperationOverride{
+		"searchIssues": {
+			Description: "GraphQL search",
+			GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+				SelectionSet: "nodes { id }",
+			},
+		},
+		"lookup":     {Description: "MCP lookup"},
+		"list_notes": {Alias: "listNotes"},
+	}
+	apiCatalog := &catalog.Catalog{Operations: []catalog.CatalogOperation{
+		{ID: "listNotes"},
+	}}
+
+	filtered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, true, apiCatalog, &catalog.Catalog{})
+	if !includeMCP {
+		t.Fatal("includeMCP = false, want true for dynamic MCP allowlist")
+	}
+	if len(filtered) != 1 || filtered["lookup"] == nil {
+		t.Fatalf("filtered allowedOperations = %#v, want only dynamic MCP operation", filtered)
+	}
+}
+
+func TestMCPAllowedOperationsForSpecCompositeOmitsMCPWhenNoMCPAllowlistEntries(t *testing.T) {
+	t.Parallel()
+
+	allowedOperations := map[string]*config.OperationOverride{
+		"searchIssues": {
+			Description: "GraphQL search",
+			GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+				SelectionSet: "nodes { id }",
+			},
+		},
+	}
+
+	filtered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, true, nil, &catalog.Catalog{})
+	if includeMCP {
+		t.Fatalf("includeMCP = true with filtered allowedOperations %#v, want false", filtered)
+	}
+	if filtered != nil {
+		t.Fatalf("filtered allowedOperations = %#v, want nil", filtered)
 	}
 }

--- a/gestaltd/internal/bootstrap/provider_build_test.go
+++ b/gestaltd/internal/bootstrap/provider_build_test.go
@@ -73,13 +73,13 @@ func TestMCPAllowedOperationsForSpecCompositeFiltersOnlyWhenAPIIsPresent(t *test
 	t.Parallel()
 
 	allowedOperations := map[string]*config.OperationOverride{
-		"searchIssues": {
+		"lookup": {
 			Description: "GraphQL search",
 			GraphQL: &providermanifestv1.ManifestGraphQLOperation{
 				SelectionSet: "nodes { id }",
 			},
 		},
-		"lookup":     {Description: "MCP lookup"},
+		"mcp_lookup": {Description: "MCP lookup"},
 		"list_notes": {Alias: "listNotes"},
 	}
 	apiCatalog := &catalog.Catalog{Operations: []catalog.CatalogOperation{
@@ -87,17 +87,18 @@ func TestMCPAllowedOperationsForSpecCompositeFiltersOnlyWhenAPIIsPresent(t *test
 	}}
 	mcpCatalog := &catalog.Catalog{Operations: []catalog.CatalogOperation{
 		{ID: "lookup"},
+		{ID: "mcp_lookup"},
 	}}
 
 	filtered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, true, apiCatalog, mcpCatalog)
 	if !includeMCP {
 		t.Fatal("includeMCP = false, want true for matching static MCP catalog")
 	}
-	if len(filtered) != 1 || filtered["lookup"] == nil {
-		t.Fatalf("filtered allowedOperations = %#v, want only lookup", filtered)
+	if len(filtered) != 1 || filtered["mcp_lookup"] == nil {
+		t.Fatalf("filtered allowedOperations = %#v, want only mcp_lookup", filtered)
 	}
-	if _, ok := filtered["searchIssues"]; ok {
-		t.Fatal("GraphQL-only operation should not be passed to MCP filter when API surface exists")
+	if _, ok := filtered["lookup"]; ok {
+		t.Fatal("GraphQL-tagged operation should not be passed to MCP filter when API surface exists")
 	}
 
 	unfiltered, includeMCP := mcpAllowedOperationsForSpecComposite(allowedOperations, false, nil, mcpCatalog)

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -1282,6 +1282,26 @@
         },
         "pagination": {
           "$ref": "#/$defs/paginationConfig"
+        },
+        "graphql": {
+          "$ref": "#/$defs/manifestGraphQLOperation"
+        }
+      }
+    },
+    "manifestGraphQLOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "operationType": {
+          "type": "string",
+          "enum": [
+            "query",
+            "mutation"
+          ]
+        },
+        "selectionSet": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -402,6 +402,12 @@ type ManifestOperationOverride struct {
 	Tags         []string                  `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Paginate     bool                      `json:"paginate,omitempty" yaml:"paginate,omitempty"`
 	Pagination   *ManifestPaginationConfig `json:"pagination,omitempty" yaml:"pagination,omitempty"`
+	GraphQL      *ManifestGraphQLOperation `json:"graphql,omitempty" yaml:"graphql,omitempty"`
+}
+
+type ManifestGraphQLOperation struct {
+	OperationType string `json:"operationType,omitempty" yaml:"operationType,omitempty"`
+	SelectionSet  string `json:"selectionSet,omitempty" yaml:"selectionSet,omitempty"`
 }
 
 type ManifestConnectionDef struct {

--- a/gestaltd/services/plugins/graphql/introspect.go
+++ b/gestaltd/services/plugins/graphql/introspect.go
@@ -88,7 +88,7 @@ const introspectionQuery = `query IntrospectionQuery {
       kind
       name
       description
-      fields(includeDeprecated: false) {
+      fields(includeDeprecated: true) {
         name
         description
         args {

--- a/gestaltd/services/plugins/graphql/introspect.go
+++ b/gestaltd/services/plugins/graphql/introspect.go
@@ -12,6 +12,8 @@ import (
 const (
 	KindScalar      = "SCALAR"
 	KindObject      = "OBJECT"
+	KindInterface   = "INTERFACE"
+	KindUnion       = "UNION"
 	KindEnum        = "ENUM"
 	KindInputObject = "INPUT_OBJECT"
 	KindNonNull     = "NON_NULL"
@@ -30,12 +32,13 @@ type TypeName struct {
 }
 
 type FullType struct {
-	Kind        string       `json:"kind"`
-	Name        string       `json:"name"`
-	Description string       `json:"description"`
-	Fields      []Field      `json:"fields"`
-	InputFields []InputValue `json:"inputFields"`
-	EnumValues  []EnumValue  `json:"enumValues"`
+	Kind          string       `json:"kind"`
+	Name          string       `json:"name"`
+	Description   string       `json:"description"`
+	Fields        []Field      `json:"fields"`
+	InputFields   []InputValue `json:"inputFields"`
+	EnumValues    []EnumValue  `json:"enumValues"`
+	PossibleTypes []TypeName   `json:"possibleTypes"`
 }
 
 type Field struct {
@@ -105,6 +108,9 @@ const introspectionQuery = `query IntrospectionQuery {
       enumValues(includeDeprecated: false) {
         name
         description
+      }
+      possibleTypes {
+        name
       }
     }
   }

--- a/gestaltd/services/plugins/graphql/loader.go
+++ b/gestaltd/services/plugins/graphql/loader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -13,6 +14,18 @@ import (
 	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
 	"github.com/valon-technologies/gestalt/server/services/plugins/operationexposure"
 )
+
+const (
+	graphQLOperationTypeQuery    = "query"
+	graphQLOperationTypeMutation = "mutation"
+)
+
+type rootAvailability struct {
+	query       bool
+	mutation    bool
+	queryRef    TypeRef
+	mutationRef TypeRef
+}
 
 func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) (*declarative.Definition, error) {
 	schema, err := introspect(ctx, endpoint)
@@ -33,16 +46,54 @@ func StaticDefinition(name, endpoint string) *declarative.Definition {
 }
 
 func DefinitionFromSchema(name, endpoint string, schema *Schema, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) (*declarative.Definition, error) {
+	if hasGraphQLAllowedOperationConfig(allowedOps) && len(selectionOverrides) > 0 {
+		return nil, fmt.Errorf("graphql %s: operationSelections cannot be combined with allowedOperations", name)
+	}
+	allowedOps = graphQLAllowedOperations(allowedOps)
+	if err := validateAllowedOperationRoots(schema, allowedOps, selectionOverrides); err != nil {
+		return nil, err
+	}
 	def := StaticDefinition(name, endpoint)
 	def.Operations = make(map[string]declarative.OperationDef)
-	addOperations(schema, def, schema.QueryType, false, allowedOps, selectionOverrides)
-	addOperations(schema, def, schema.MutationType, true, allowedOps, selectionOverrides)
+	if err := addOperations(schema, def, schema.QueryType, false, allowedOps, selectionOverrides); err != nil {
+		return nil, err
+	}
+	if err := addOperations(schema, def, schema.MutationType, true, allowedOps, selectionOverrides); err != nil {
+		return nil, err
+	}
 
 	if len(def.Operations) == 0 {
 		return nil, fmt.Errorf("no operations found for %s", endpoint)
 	}
 
 	return def, nil
+}
+
+func graphQLAllowedOperations(allowedOps map[string]*operationexposure.OperationOverride) map[string]*operationexposure.OperationOverride {
+	if len(allowedOps) == 0 {
+		return allowedOps
+	}
+
+	if !hasGraphQLAllowedOperationConfig(allowedOps) {
+		return allowedOps
+	}
+
+	filtered := make(map[string]*operationexposure.OperationOverride)
+	for name, override := range allowedOps {
+		if override != nil && override.GraphQL != nil {
+			filtered[name] = override
+		}
+	}
+	return filtered
+}
+
+func hasGraphQLAllowedOperationConfig(allowedOps map[string]*operationexposure.OperationOverride) bool {
+	for _, override := range allowedOps {
+		if override != nil && override.GraphQL != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func SchemaFromBody(body []byte) (*Schema, error) {
@@ -71,13 +122,13 @@ func SchemaFromResult(result *core.OperationResult) (*Schema, error) {
 	return SchemaFromBody([]byte(result.Body))
 }
 
-func addOperations(schema *Schema, def *declarative.Definition, root *TypeName, isMutation bool, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) {
+func addOperations(schema *Schema, def *declarative.Definition, root *TypeName, isMutation bool, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) error {
 	if root == nil {
-		return
+		return nil
 	}
 	rootType := schema.lookupType(root.Name)
 	if rootType == nil {
-		return
+		return nil
 	}
 
 	for _, field := range rootType.Fields {
@@ -89,13 +140,20 @@ func addOperations(schema *Schema, def *declarative.Definition, root *TypeName, 
 			if _, ok := allowedOps[field.Name]; !ok {
 				continue
 			}
+			if !allowedOperationMatchesRoot(allowedOps[field.Name], isMutation) {
+				continue
+			}
+			if !legacySelectionMatchesRoot(schema, field, allowedOps[field.Name], selectionOverrides[field.Name]) {
+				continue
+			}
 		}
 
 		desc := field.Description
 		opName := field.Name
 		var allowedRoles []string
 		var tags []string
-		if override := allowedOps[field.Name]; override != nil {
+		override := allowedOps[field.Name]
+		if override != nil {
 			if override.Description != "" {
 				desc = override.Description
 			}
@@ -106,7 +164,10 @@ func addOperations(schema *Schema, def *declarative.Definition, root *TypeName, 
 			tags = catalog.MergeTags(override.Tags)
 		}
 
-		query := generateQuery(schema, field, isMutation, selectionOverrides[field.Name])
+		query, err := operationQuery(schema, field, isMutation, allowedOps, override, selectionOverrides)
+		if err != nil {
+			return err
+		}
 
 		opDef := declarative.OperationDef{
 			Description:  declarative.TruncateDescription(desc),
@@ -120,6 +181,169 @@ func addOperations(schema *Schema, def *declarative.Definition, root *TypeName, 
 
 		def.Operations[opName] = opDef
 	}
+	return nil
+}
+
+func operationQuery(schema *Schema, field Field, isMutation bool, allowedOps map[string]*operationexposure.OperationOverride, override *operationexposure.OperationOverride, selectionOverrides map[string]string) (string, error) {
+	if len(allowedOps) == 0 {
+		return generateQuery(schema, field, isMutation, selectionOverrides[field.Name]), nil
+	}
+
+	selectionSet := ""
+	if override != nil && override.GraphQL != nil {
+		selectionSet = strings.TrimSpace(override.GraphQL.SelectionSet)
+	}
+	if selectionSet == "" {
+		selectionSet = strings.TrimSpace(selectionOverrides[field.Name])
+	}
+	if selectionSet == "" && explicitSelectionRequired(schema, field.Type) {
+		return "", fmt.Errorf("graphql operation %q requires allowedOperations.%s.graphql.selectionSet", field.Name, field.Name)
+	}
+	if err := validateExplicitSelectionSet(schema, field.Name, field.Type, selectionSet); err != nil {
+		return "", err
+	}
+	return generateQueryWithExplicitSelection(schema, field, isMutation, selectionSet), nil
+}
+
+func validateAllowedOperationRoots(schema *Schema, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) error {
+	if len(allowedOps) == 0 {
+		return nil
+	}
+
+	roots := map[string]rootAvailability{}
+	collectRootFields := func(root *TypeName, isMutation bool) {
+		if root == nil {
+			return
+		}
+		rootType := schema.lookupType(root.Name)
+		if rootType == nil {
+			return
+		}
+		for _, field := range rootType.Fields {
+			availability := roots[field.Name]
+			if isMutation {
+				availability.mutation = true
+				availability.mutationRef = field.Type
+			} else {
+				availability.query = true
+				availability.queryRef = field.Type
+			}
+			roots[field.Name] = availability
+		}
+	}
+	collectRootFields(schema.QueryType, false)
+	collectRootFields(schema.MutationType, true)
+
+	names := make([]string, 0, len(allowedOps))
+	for name := range allowedOps {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		availability, ok := roots[name]
+		if !ok {
+			return fmt.Errorf("graphql allowed operation %q is not defined in schema", name)
+		}
+		operationType, err := graphQLOperationType(allowedOps[name])
+		if err != nil {
+			return fmt.Errorf("graphql allowed operation %q: %w", name, err)
+		}
+		switch operationType {
+		case graphQLOperationTypeQuery:
+			if !availability.query {
+				return fmt.Errorf("graphql allowed operation %q declares operationType %q but is not defined on the query root", name, operationType)
+			}
+		case graphQLOperationTypeMutation:
+			if !availability.mutation {
+				return fmt.Errorf("graphql allowed operation %q declares operationType %q but is not defined on the mutation root", name, operationType)
+			}
+		default:
+			if availability.query && availability.mutation {
+				if legacySelectionDisambiguatesRoot(schema, name, availability, allowedOps[name], selectionOverrides[name]) {
+					continue
+				}
+				return fmt.Errorf("graphql allowed operation %q is defined on both query and mutation roots; set allowedOperations.%s.graphql.operationType", name, name)
+			}
+		}
+	}
+	return nil
+}
+
+func allowedOperationMatchesRoot(override *operationexposure.OperationOverride, isMutation bool) bool {
+	operationType, _ := graphQLOperationType(override)
+	switch operationType {
+	case graphQLOperationTypeQuery:
+		return !isMutation
+	case graphQLOperationTypeMutation:
+		return isMutation
+	default:
+		return true
+	}
+}
+
+func graphQLOperationType(override *operationexposure.OperationOverride) (string, error) {
+	if override == nil || override.GraphQL == nil {
+		return "", nil
+	}
+	operationType := strings.ToLower(strings.TrimSpace(override.GraphQL.OperationType))
+	switch operationType {
+	case "", graphQLOperationTypeQuery, graphQLOperationTypeMutation:
+		return operationType, nil
+	default:
+		return "", fmt.Errorf("unsupported graphql.operationType %q", override.GraphQL.OperationType)
+	}
+}
+
+func legacySelectionDisambiguatesRoot(schema *Schema, name string, availability rootAvailability, override *operationexposure.OperationOverride, selectionOverride string) bool {
+	if override != nil && override.GraphQL != nil {
+		return false
+	}
+	selectionOverride = strings.TrimSpace(selectionOverride)
+	if selectionOverride == "" {
+		return false
+	}
+	matches := 0
+	if availability.query && validateExplicitSelectionSet(schema, name, availability.queryRef, selectionOverride) == nil {
+		matches++
+	}
+	if availability.mutation && validateExplicitSelectionSet(schema, name, availability.mutationRef, selectionOverride) == nil {
+		matches++
+	}
+	return matches == 1
+}
+
+func legacySelectionMatchesRoot(schema *Schema, field Field, override *operationexposure.OperationOverride, selectionOverride string) bool {
+	if override != nil && override.GraphQL != nil {
+		return true
+	}
+	selectionOverride = strings.TrimSpace(selectionOverride)
+	if selectionOverride == "" {
+		return true
+	}
+	if !rootFieldIsAmbiguous(schema, field.Name) {
+		return true
+	}
+	return validateExplicitSelectionSet(schema, field.Name, field.Type, selectionOverride) == nil
+}
+
+func rootFieldIsAmbiguous(schema *Schema, name string) bool {
+	if schema == nil {
+		return false
+	}
+	foundQuery := rootHasField(schema, schema.QueryType, name)
+	foundMutation := rootHasField(schema, schema.MutationType, name)
+	return foundQuery && foundMutation
+}
+
+func rootHasField(schema *Schema, root *TypeName, name string) bool {
+	if root == nil {
+		return false
+	}
+	rootType := schema.lookupType(root.Name)
+	if rootType == nil {
+		return false
+	}
+	return lookupField(rootType, name) != nil
 }
 
 func argsToParams(schema *Schema, args []InputValue) []declarative.ParameterDef {

--- a/gestaltd/services/plugins/graphql/loader.go
+++ b/gestaltd/services/plugins/graphql/loader.go
@@ -49,7 +49,7 @@ func DefinitionFromSchema(name, endpoint string, schema *Schema, allowedOps map[
 	if hasGraphQLAllowedOperationConfig(allowedOps) && len(selectionOverrides) > 0 {
 		return nil, fmt.Errorf("graphql %s: operationSelections cannot be combined with allowedOperations", name)
 	}
-	allowedOps = graphQLAllowedOperations(allowedOps)
+	allowedOps = graphQLAllowedOperations(schema, allowedOps, selectionOverrides)
 	if err := validateAllowedOperationRoots(schema, allowedOps, selectionOverrides); err != nil {
 		return nil, err
 	}
@@ -69,12 +69,15 @@ func DefinitionFromSchema(name, endpoint string, schema *Schema, allowedOps map[
 	return def, nil
 }
 
-func graphQLAllowedOperations(allowedOps map[string]*operationexposure.OperationOverride) map[string]*operationexposure.OperationOverride {
+func graphQLAllowedOperations(schema *Schema, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) map[string]*operationexposure.OperationOverride {
 	if len(allowedOps) == 0 {
 		return allowedOps
 	}
 
 	if !hasGraphQLAllowedOperationConfig(allowedOps) {
+		if len(selectionOverrides) > 0 {
+			return legacyGraphQLAllowedOperations(schema, allowedOps, selectionOverrides)
+		}
 		return allowedOps
 	}
 
@@ -85,6 +88,40 @@ func graphQLAllowedOperations(allowedOps map[string]*operationexposure.Operation
 		}
 	}
 	return filtered
+}
+
+func legacyGraphQLAllowedOperations(schema *Schema, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) map[string]*operationexposure.OperationOverride {
+	roots := graphQLRootNames(schema)
+	filtered := make(map[string]*operationexposure.OperationOverride)
+	for name, override := range allowedOps {
+		if _, ok := roots[name]; ok {
+			filtered[name] = override
+			continue
+		}
+		if _, ok := selectionOverrides[name]; ok {
+			filtered[name] = override
+		}
+	}
+	return filtered
+}
+
+func graphQLRootNames(schema *Schema) map[string]struct{} {
+	roots := make(map[string]struct{})
+	addRoot := func(root *TypeName) {
+		if root == nil {
+			return
+		}
+		rootType := schema.lookupType(root.Name)
+		if rootType == nil {
+			return
+		}
+		for _, field := range rootType.Fields {
+			roots[field.Name] = struct{}{}
+		}
+	}
+	addRoot(schema.QueryType)
+	addRoot(schema.MutationType)
+	return roots
 }
 
 func hasGraphQLAllowedOperationConfig(allowedOps map[string]*operationexposure.OperationOverride) bool {

--- a/gestaltd/services/plugins/graphql/loader.go
+++ b/gestaltd/services/plugins/graphql/loader.go
@@ -75,10 +75,7 @@ func graphQLAllowedOperations(schema *Schema, allowedOps map[string]*operationex
 	}
 
 	if !hasGraphQLAllowedOperationConfig(allowedOps) {
-		if len(selectionOverrides) > 0 {
-			return legacyGraphQLAllowedOperations(schema, allowedOps, selectionOverrides)
-		}
-		return allowedOps
+		return legacyGraphQLAllowedOperations(schema, allowedOps, selectionOverrides)
 	}
 
 	filtered := make(map[string]*operationexposure.OperationOverride)

--- a/gestaltd/services/plugins/graphql/loader_test.go
+++ b/gestaltd/services/plugins/graphql/loader_test.go
@@ -496,6 +496,14 @@ func TestLoadDefinitionWithAllowedOpsIgnoresMixedSurfaceEntriesWithoutSelectionO
 	}
 }
 
+func TestIntrospectionQueryIncludesDeprecatedFields(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(IntrospectionRequest().Document, "fields(includeDeprecated: true)") {
+		t.Fatal("introspection query should include deprecated fields for selection-set validation")
+	}
+}
+
 func TestLoadDefinitionWithAllowedOpsValidatesSelectionSet(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/plugins/graphql/loader_test.go
+++ b/gestaltd/services/plugins/graphql/loader_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"github.com/valon-technologies/gestalt/server/services/plugins/operationexposure"
 )
 
@@ -142,7 +143,12 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 	defer srv.Close()
 
 	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
-		"teams": {Description: "My custom description", AllowedRoles: []string{"workspace-admin"}, Tags: []string{"workspace"}},
+		"teams": {
+			Description:  "My custom description",
+			AllowedRoles: []string{"workspace-admin"},
+			Tags:         []string{"workspace"},
+			GraphQL:      &providermanifestv1.ManifestGraphQLOperation{SelectionSet: "nodes { id name } pageInfo { hasNextPage endCursor }"},
+		},
 	}, nil)
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)
@@ -161,6 +167,9 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 	}
 	if got, want := teams.AllowedRoles, []string{"workspace-admin"}; !slices.Equal(got, want) {
 		t.Errorf("teams.AllowedRoles: got %#v, want %#v", got, want)
+	}
+	if strings.Contains(teams.Query, "createdAt") || !strings.Contains(teams.Query, "nodes { id name }") {
+		t.Errorf("teams.Query should use allowed operation selectionSet; got: %s", teams.Query)
 	}
 }
 
@@ -188,6 +197,404 @@ func TestLoadDefinitionWithSelectionOverride(t *testing.T) {
 	teams := def.Operations["teams"]
 	if strings.Contains(teams.Query, "success issue") {
 		t.Errorf("override should only apply to named op; teams query: %s", teams.Query)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsRejectsLegacySelections(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newTestSchema())
+	defer srv.Close()
+
+	_, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"teams": {
+			GraphQL: &providermanifestv1.ManifestGraphQLOperation{SelectionSet: "nodes { id } pageInfo { hasNextPage endCursor }"},
+		},
+	}, map[string]string{
+		"createIssue": "success",
+	})
+	if err == nil || !strings.Contains(err.Error(), "operationSelections cannot be combined with allowedOperations") {
+		t.Fatalf("LoadDefinition error = %v, want operationSelections conflict", err)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsAllowsLegacySelectionOverrides(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newTestSchema())
+	defer srv.Close()
+
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"teams": nil,
+	}, map[string]string{
+		"teams": "nodes { id name } pageInfo { hasNextPage endCursor }",
+	})
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+	if len(def.Operations) != 1 {
+		t.Fatalf("Operations: got %d, want 1", len(def.Operations))
+	}
+	if got := def.Operations["teams"].Query; !strings.Contains(got, "nodes { id name }") {
+		t.Fatalf("teams query = %q, want legacy selection override", got)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsRequiresObjectSelection(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newTestSchema())
+	defer srv.Close()
+
+	_, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"teams": nil,
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "teams.graphql.selectionSet") {
+		t.Fatalf("LoadDefinition error = %v, want missing selectionSet", err)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsRejectsUnknownOperation(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newTestSchema())
+	defer srv.Close()
+
+	_, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"missing": {
+			GraphQL: &providermanifestv1.ManifestGraphQLOperation{SelectionSet: "id"},
+		},
+		"teams": {
+			GraphQL: &providermanifestv1.ManifestGraphQLOperation{SelectionSet: "nodes { id name } pageInfo { hasNextPage endCursor }"},
+		},
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), `allowed operation "missing" is not defined in schema`) {
+		t.Fatalf("LoadDefinition error = %v, want unknown allowed operation", err)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsIgnoresNonGraphQLEntriesWhenGraphQLEntriesAreExplicit(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newTestSchema())
+	defer srv.Close()
+
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"teams": {
+			GraphQL: &providermanifestv1.ManifestGraphQLOperation{SelectionSet: "nodes { id name } pageInfo { hasNextPage endCursor }"},
+		},
+		"lookup": nil,
+	}, nil)
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+	if len(def.Operations) != 1 {
+		t.Fatalf("Operations: got %d, want 1", len(def.Operations))
+	}
+	if _, ok := def.Operations["teams"]; !ok {
+		t.Fatalf("Operations = %#v, want teams", def.Operations)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsDisambiguatesDuplicateRootField(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newDuplicateRootFieldSchema())
+	defer srv.Close()
+
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"projectUpdate": {
+			GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+				OperationType: "mutation",
+				SelectionSet:  "success lastSyncId project { id }",
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+	if len(def.Operations) != 1 {
+		t.Fatalf("Operations: got %d, want 1", len(def.Operations))
+	}
+	got := def.Operations["projectUpdate"].Query
+	if !strings.HasPrefix(got, "mutation { projectUpdate") {
+		t.Fatalf("projectUpdate query = %q, want mutation root", got)
+	}
+	if !strings.Contains(got, "{ success lastSyncId project { id } }") {
+		t.Fatalf("projectUpdate query = %q, want mutation payload selection", got)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsDisambiguatesDuplicateRootFieldFromLegacySelection(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newDuplicateRootFieldSchema())
+	defer srv.Close()
+
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"projectUpdate": nil,
+	}, map[string]string{
+		"projectUpdate": "success lastSyncId project { id }",
+	})
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+	if len(def.Operations) != 1 {
+		t.Fatalf("Operations: got %d, want 1", len(def.Operations))
+	}
+	got := def.Operations["projectUpdate"].Query
+	if !strings.HasPrefix(got, "mutation { projectUpdate") {
+		t.Fatalf("projectUpdate query = %q, want mutation root", got)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsRejectsAmbiguousDuplicateRootField(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newDuplicateRootFieldSchema())
+	defer srv.Close()
+
+	_, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"projectUpdate": {
+			GraphQL: &providermanifestv1.ManifestGraphQLOperation{SelectionSet: "success lastSyncId project { id }"},
+		},
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), `defined on both query and mutation roots`) {
+		t.Fatalf("LoadDefinition error = %v, want duplicate root field ambiguity", err)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsRejectsUnsupportedOperationType(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newDuplicateRootFieldSchema())
+	defer srv.Close()
+
+	_, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"projectUpdate": {
+			GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+				OperationType: "subscription",
+				SelectionSet:  "success lastSyncId project { id }",
+			},
+		},
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), `unsupported graphql.operationType "subscription"`) {
+		t.Fatalf("LoadDefinition error = %v, want unsupported operation type", err)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsAllowsScalarWithoutSelection(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, Schema{
+		QueryType: &TypeName{Name: "Query"},
+		Types: []FullType{
+			{Kind: KindObject, Name: "Query", Fields: []Field{
+				{Name: "version", Type: TypeRef{Kind: KindScalar, Name: strPtr("String")}},
+			}},
+		},
+	})
+	defer srv.Close()
+
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"version": nil,
+	}, nil)
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+	if got := def.Operations["version"].Query; got != "query { version }" {
+		t.Fatalf("version query = %q, want scalar query without selection", got)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsValidatesSelectionSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		selection string
+		wantErr   string
+	}{
+		{
+			name:      "alias is validated by field name",
+			selection: "nodes { teamName: name } pageInfo { hasNextPage endCursor }",
+		},
+		{
+			name:      "unknown field",
+			selection: "nodes { missing } pageInfo { hasNextPage endCursor }",
+			wantErr:   `field "missing" does not exist on type "Team"`,
+		},
+		{
+			name:      "field arguments rejected",
+			selection: "nodes { name(format: SHORT) } pageInfo { hasNextPage endCursor }",
+			wantErr:   "field arguments are not supported",
+		},
+		{
+			name:      "fragment spreads rejected",
+			selection: "nodes { ...TeamFields } pageInfo { hasNextPage endCursor }",
+			wantErr:   "fragment spreads are not supported",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := startIntrospectionServer(t, newTestSchema())
+			defer srv.Close()
+
+			def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+				"teams": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{SelectionSet: tc.selection},
+				},
+			}, nil)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("LoadDefinition error = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadDefinition: %v", err)
+			}
+			if got := def.Operations["teams"].Query; !strings.Contains(got, "teamName: name") {
+				t.Fatalf("teams query = %q, want alias selection", got)
+			}
+		})
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsValidatesInlineFragments(t *testing.T) {
+	t.Parallel()
+
+	schema := Schema{
+		QueryType: &TypeName{Name: "Query"},
+		Types: []FullType{
+			{Kind: KindObject, Name: "Query", Fields: []Field{
+				{Name: "node", Type: TypeRef{Kind: KindInterface, Name: strPtr("Node")}},
+				{Name: "search", Type: TypeRef{Kind: KindUnion, Name: strPtr("SearchResult")}},
+				{Name: "unresolved", Type: TypeRef{Kind: KindInterface, Name: strPtr("UnresolvedNode")}},
+				{Name: "viewer", Type: TypeRef{Kind: KindObject, Name: strPtr("Viewer")}},
+			}},
+			{Kind: KindInterface, Name: "Node", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: KindScalar, Name: strPtr("ID")}},
+			}, PossibleTypes: []TypeName{{Name: "User"}}},
+			{Kind: KindInterface, Name: "UnresolvedNode", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: KindScalar, Name: strPtr("ID")}},
+			}},
+			{Kind: KindUnion, Name: "SearchResult", PossibleTypes: []TypeName{{Name: "User"}, {Name: "Team"}}},
+			{Kind: KindObject, Name: "User", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: KindScalar, Name: strPtr("ID")}},
+				{Name: "name", Type: TypeRef{Kind: KindScalar, Name: strPtr("String")}},
+			}},
+			{Kind: KindObject, Name: "Viewer", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: KindScalar, Name: strPtr("ID")}},
+				{Name: "name", Type: TypeRef{Kind: KindScalar, Name: strPtr("String")}},
+			}},
+			{Kind: KindObject, Name: "Team", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: KindScalar, Name: strPtr("ID")}},
+			}},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		selection string
+		wantErr   string
+	}{
+		{
+			name:      "valid inline fragment",
+			selection: "__typename id ... on User { name }",
+		},
+		{
+			name:      "valid interface inline fragment with overlapping possible types",
+			selection: "__typename ... on Node { id }",
+		},
+		{
+			name:      "invalid inline fragment type",
+			selection: "__typename ... on Team { id }",
+			wantErr:   `inline fragment type "Team" is not valid for parent type "Node"`,
+		},
+		{
+			name:      "unknown inline fragment field",
+			selection: "__typename ... on User { email }",
+			wantErr:   `field "email" does not exist on type "User"`,
+		},
+		{
+			name:      "object parent rejects unrelated inline fragment",
+			selection: "__typename ... on User { id }",
+			wantErr:   `inline fragment type "User" is not valid for parent type "Viewer"`,
+		},
+		{
+			name:      "interface parent rejects fragment when possible types unavailable",
+			selection: "__typename ... on User { id }",
+			wantErr:   `inline fragment type "User" is not valid for parent type "UnresolvedNode"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := startIntrospectionServer(t, schema)
+			defer srv.Close()
+
+			operation := "node"
+			if strings.Contains(tc.name, "object parent") {
+				operation = "viewer"
+			} else if strings.Contains(tc.name, "overlapping possible types") {
+				operation = "search"
+			} else if strings.Contains(tc.name, "possible types unavailable") {
+				operation = "unresolved"
+			}
+			_, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+				operation: {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{SelectionSet: tc.selection},
+				},
+			}, nil)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("LoadDefinition error = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadDefinition: %v", err)
+			}
+		})
+	}
+}
+
+func newDuplicateRootFieldSchema() Schema {
+	return Schema{
+		QueryType:    &TypeName{Name: "Query"},
+		MutationType: &TypeName{Name: "Mutation"},
+		Types: []FullType{
+			{Kind: KindObject, Name: "Query", Fields: []Field{
+				{
+					Name: "projectUpdate",
+					Type: TypeRef{Kind: KindObject, Name: strPtr("ProjectUpdate")},
+				},
+			}},
+			{Kind: KindObject, Name: "Mutation", Fields: []Field{
+				{
+					Name: "projectUpdate",
+					Type: TypeRef{Kind: KindObject, Name: strPtr("ProjectPayload")},
+				},
+			}},
+			{Kind: KindObject, Name: "ProjectUpdate", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: KindScalar, Name: strPtr("ID")}},
+				{Name: "body", Type: TypeRef{Kind: KindScalar, Name: strPtr("String")}},
+			}},
+			{Kind: KindObject, Name: "ProjectPayload", Fields: []Field{
+				{Name: "success", Type: TypeRef{Kind: KindScalar, Name: strPtr("Boolean")}},
+				{Name: "lastSyncId", Type: TypeRef{Kind: KindScalar, Name: strPtr("Float")}},
+				{Name: "project", Type: TypeRef{Kind: KindObject, Name: strPtr("Project")}},
+			}},
+			{Kind: KindObject, Name: "Project", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: KindScalar, Name: strPtr("ID")}},
+			}},
+		},
 	}
 }
 

--- a/gestaltd/services/plugins/graphql/loader_test.go
+++ b/gestaltd/services/plugins/graphql/loader_test.go
@@ -54,6 +54,28 @@ func newTestSchema() Schema {
 			{Kind: "OBJECT", Name: "Team", Fields: []Field{
 				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
 				{Name: "name", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+				{
+					Name: "displayName",
+					Args: []InputValue{
+						{Name: "format", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+					},
+					Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")},
+				},
+				{
+					Name: "comments",
+					Args: []InputValue{
+						{Name: "first", Type: TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("Int")}}},
+					},
+					Type: TypeRef{Kind: "OBJECT", Name: strPtr("CommentConnection")},
+				},
+			}},
+			{Kind: "OBJECT", Name: "CommentConnection", Fields: []Field{
+				{Name: "nodes", Type: TypeRef{Kind: "LIST", OfType: &TypeRef{Kind: "OBJECT", Name: strPtr("Comment")}}},
+				{Name: "pageInfo", Type: TypeRef{Kind: "OBJECT", Name: strPtr("PageInfo")}},
+			}},
+			{Kind: "OBJECT", Name: "Comment", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
+				{Name: "body", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
 			}},
 			{Kind: "OBJECT", Name: "Issue", Fields: []Field{
 				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
@@ -240,6 +262,45 @@ func TestLoadDefinitionWithAllowedOpsAllowsLegacySelectionOverrides(t *testing.T
 	}
 }
 
+func TestLoadDefinitionWithAllowedOpsIgnoresMixedSurfaceEntriesInLegacySelectionMode(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newTestSchema())
+	defer srv.Close()
+
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"teams":     nil,
+		"get_issue": nil,
+	}, map[string]string{
+		"teams": "nodes { id name } pageInfo { hasNextPage endCursor }",
+	})
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+	if len(def.Operations) != 1 {
+		t.Fatalf("Operations: got %d, want 1", len(def.Operations))
+	}
+	if _, ok := def.Operations["teams"]; !ok {
+		t.Fatalf("Operations = %#v, want teams", def.Operations)
+	}
+}
+
+func TestLoadDefinitionWithAllowedOpsRejectsUnknownLegacySelectionOverride(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newTestSchema())
+	defer srv.Close()
+
+	_, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"missing": nil,
+	}, map[string]string{
+		"missing": "id",
+	})
+	if err == nil || !strings.Contains(err.Error(), `allowed operation "missing" is not defined in schema`) {
+		t.Fatalf("LoadDefinition error = %v, want unknown allowed operation", err)
+	}
+}
+
 func TestLoadDefinitionWithAllowedOpsRequiresObjectSelection(t *testing.T) {
 	t.Parallel()
 
@@ -420,6 +481,10 @@ func TestLoadDefinitionWithAllowedOpsValidatesSelectionSet(t *testing.T) {
 			selection: "nodes { teamName: name } pageInfo { hasNextPage endCursor }",
 		},
 		{
+			name:      "optional argument field can be selected without arguments",
+			selection: "nodes { teamName: name displayName } pageInfo { hasNextPage endCursor }",
+		},
+		{
 			name:      "unknown field",
 			selection: "nodes { missing } pageInfo { hasNextPage endCursor }",
 			wantErr:   `field "missing" does not exist on type "Team"`,
@@ -428,6 +493,11 @@ func TestLoadDefinitionWithAllowedOpsValidatesSelectionSet(t *testing.T) {
 			name:      "field arguments rejected",
 			selection: "nodes { name(format: SHORT) } pageInfo { hasNextPage endCursor }",
 			wantErr:   "field arguments are not supported",
+		},
+		{
+			name:      "required argument field rejected",
+			selection: "nodes { comments { nodes { id } } } pageInfo { hasNextPage endCursor }",
+			wantErr:   `field "comments" on "Team" requires argument "first"`,
 		},
 		{
 			name:      "fragment spreads rejected",

--- a/gestaltd/services/plugins/graphql/loader_test.go
+++ b/gestaltd/services/plugins/graphql/loader_test.go
@@ -468,6 +468,34 @@ func TestLoadDefinitionWithAllowedOpsAllowsScalarWithoutSelection(t *testing.T) 
 	}
 }
 
+func TestLoadDefinitionWithAllowedOpsIgnoresMixedSurfaceEntriesWithoutSelectionOverrides(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, Schema{
+		QueryType: &TypeName{Name: "Query"},
+		Types: []FullType{
+			{Kind: KindObject, Name: "Query", Fields: []Field{
+				{Name: "version", Type: TypeRef{Kind: KindScalar, Name: strPtr("String")}},
+			}},
+		},
+	})
+	defer srv.Close()
+
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*operationexposure.OperationOverride{
+		"version":   nil,
+		"get_issue": nil,
+	}, nil)
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+	if len(def.Operations) != 1 {
+		t.Fatalf("Operations: got %d, want 1", len(def.Operations))
+	}
+	if got := def.Operations["version"].Query; got != "query { version }" {
+		t.Fatalf("version query = %q, want scalar query without selection", got)
+	}
+}
+
 func TestLoadDefinitionWithAllowedOpsValidatesSelectionSet(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/plugins/graphql/query.go
+++ b/gestaltd/services/plugins/graphql/query.go
@@ -8,6 +8,14 @@ import (
 const defaultMaxDepth = 2
 
 func generateQuery(schema *Schema, field Field, isMutation bool, selectionOverride string) string {
+	return generateQueryWithSelection(schema, field, isMutation, selectionOverride, false)
+}
+
+func generateQueryWithExplicitSelection(schema *Schema, field Field, isMutation bool, selectionSet string) string {
+	return generateQueryWithSelection(schema, field, isMutation, selectionSet, true)
+}
+
+func generateQueryWithSelection(schema *Schema, field Field, isMutation bool, selectionOverride string, explicit bool) string {
 	var b strings.Builder
 
 	if isMutation {
@@ -44,7 +52,7 @@ func generateQuery(schema *Schema, field Field, isMutation bool, selectionOverri
 	var selectionSet string
 	if trimmed := strings.TrimSpace(selectionOverride); trimmed != "" {
 		selectionSet = "{ " + trimmed + " }"
-	} else {
+	} else if !explicit {
 		selectionSet = buildSelectionSet(schema, field.Type, defaultMaxDepth, nil)
 	}
 	if selectionSet != "" {

--- a/gestaltd/services/plugins/graphql/selection.go
+++ b/gestaltd/services/plugins/graphql/selection.go
@@ -115,6 +115,9 @@ func validateFieldSelection(schema *Schema, operation string, parent *FullType, 
 	if field == nil {
 		return fmt.Errorf("operation %q field %q does not exist on type %q", operation, sel.Name, parent.Name)
 	}
+	if required := requiredArgumentNames(field.Args); len(required) > 0 {
+		return fmt.Errorf("operation %q field %q on %q requires argument %q, but selectionSet arguments are not supported", operation, sel.Name, parent.Name, required[0])
+	}
 	fieldType := schema.lookupType(field.Type.innerType().namedType())
 	fieldComposite := isCompositeType(fieldType)
 	if fieldComposite {
@@ -127,6 +130,16 @@ func validateFieldSelection(schema *Schema, operation string, parent *FullType, 
 		return fmt.Errorf("operation %q field %q on %q cannot have a nested selection", operation, sel.Name, parent.Name)
 	}
 	return nil
+}
+
+func requiredArgumentNames(args []InputValue) []string {
+	var required []string
+	for _, arg := range args {
+		if arg.Type.isNonNull() && arg.DefaultValue == nil {
+			required = append(required, arg.Name)
+		}
+	}
+	return required
 }
 
 func lookupField(ft *FullType, name string) *Field {

--- a/gestaltd/services/plugins/graphql/selection.go
+++ b/gestaltd/services/plugins/graphql/selection.go
@@ -1,0 +1,362 @@
+package graphql
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+type selection interface {
+	selectionNode()
+}
+
+type fieldSelection struct {
+	Alias      string
+	Name       string
+	Selections []selection
+}
+
+func (fieldSelection) selectionNode() {}
+
+type inlineFragmentSelection struct {
+	TypeCondition string
+	Selections    []selection
+}
+
+func (inlineFragmentSelection) selectionNode() {}
+
+func validateExplicitSelectionSet(schema *Schema, operation string, ref TypeRef, raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	inner := ref.innerType()
+	typeName := inner.namedType()
+	ft := schema.lookupType(typeName)
+	if !isCompositeType(ft) {
+		if trimmed != "" {
+			kind := "unknown"
+			if ft != nil {
+				kind = ft.Kind
+			}
+			return fmt.Errorf("operation %q selectionSet is not valid for %s return type %q", operation, kind, typeName)
+		}
+		return nil
+	}
+	if trimmed == "" {
+		return fmt.Errorf("operation %q requires graphql.selectionSet for %s return type %q", operation, ft.Kind, typeName)
+	}
+
+	p := selectionParser{input: trimmed}
+	selections, err := p.parseSelectionList(false)
+	if err != nil {
+		return fmt.Errorf("operation %q graphql.selectionSet: %w", operation, err)
+	}
+	if err := p.expectEnd(); err != nil {
+		return fmt.Errorf("operation %q graphql.selectionSet: %w", operation, err)
+	}
+	if len(selections) == 0 {
+		return fmt.Errorf("operation %q requires at least one selection", operation)
+	}
+	if err := validateSelections(schema, operation, ft, selections); err != nil {
+		return err
+	}
+	return nil
+}
+
+func explicitSelectionRequired(schema *Schema, ref TypeRef) bool {
+	return isCompositeType(schema.lookupType(ref.innerType().namedType()))
+}
+
+func isCompositeType(ft *FullType) bool {
+	if ft == nil {
+		return false
+	}
+	return ft.Kind == KindObject || ft.Kind == KindInterface || ft.Kind == KindUnion
+}
+
+func validateSelections(schema *Schema, operation string, parent *FullType, selections []selection) error {
+	for _, sel := range selections {
+		switch s := sel.(type) {
+		case fieldSelection:
+			if err := validateFieldSelection(schema, operation, parent, s); err != nil {
+				return err
+			}
+		case inlineFragmentSelection:
+			target := schema.lookupType(s.TypeCondition)
+			if !isCompositeType(target) {
+				return fmt.Errorf("operation %q inline fragment references unknown composite type %q", operation, s.TypeCondition)
+			}
+			if !fragmentTypeAllowed(parent, target) {
+				return fmt.Errorf("operation %q inline fragment type %q is not valid for parent type %q", operation, target.Name, parent.Name)
+			}
+			if len(s.Selections) == 0 {
+				return fmt.Errorf("operation %q inline fragment on %q requires at least one selection", operation, target.Name)
+			}
+			if err := validateSelections(schema, operation, target, s.Selections); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("operation %q contains unsupported selection", operation)
+		}
+	}
+	return nil
+}
+
+func validateFieldSelection(schema *Schema, operation string, parent *FullType, sel fieldSelection) error {
+	if sel.Name == "__typename" {
+		if len(sel.Selections) > 0 {
+			return fmt.Errorf("operation %q field %q on %q cannot have a nested selection", operation, sel.Name, parent.Name)
+		}
+		return nil
+	}
+	if parent.Kind == KindUnion {
+		return fmt.Errorf("operation %q field %q cannot be selected directly on union %q", operation, sel.Name, parent.Name)
+	}
+
+	field := lookupField(parent, sel.Name)
+	if field == nil {
+		return fmt.Errorf("operation %q field %q does not exist on type %q", operation, sel.Name, parent.Name)
+	}
+	fieldType := schema.lookupType(field.Type.innerType().namedType())
+	fieldComposite := isCompositeType(fieldType)
+	if fieldComposite {
+		if len(sel.Selections) == 0 {
+			return fmt.Errorf("operation %q field %q on %q requires a nested selection", operation, sel.Name, parent.Name)
+		}
+		return validateSelections(schema, operation, fieldType, sel.Selections)
+	}
+	if len(sel.Selections) > 0 {
+		return fmt.Errorf("operation %q field %q on %q cannot have a nested selection", operation, sel.Name, parent.Name)
+	}
+	return nil
+}
+
+func lookupField(ft *FullType, name string) *Field {
+	if ft == nil {
+		return nil
+	}
+	for i := range ft.Fields {
+		if ft.Fields[i].Name == name {
+			return &ft.Fields[i]
+		}
+	}
+	return nil
+}
+
+func fragmentTypeAllowed(parent, target *FullType) bool {
+	if parent == nil || target == nil {
+		return false
+	}
+	if parent.Name == target.Name {
+		return true
+	}
+
+	parentPossible, parentKnown := possibleObjectNames(parent)
+	if !parentKnown {
+		return false
+	}
+	targetPossible, targetKnown := possibleObjectNames(target)
+	if !targetKnown {
+		return false
+	}
+	for name := range parentPossible {
+		if _, ok := targetPossible[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func possibleObjectNames(ft *FullType) (map[string]struct{}, bool) {
+	if ft == nil {
+		return nil, false
+	}
+	if ft.Kind == KindObject {
+		return map[string]struct{}{ft.Name: {}}, true
+	}
+	if ft.Kind != KindInterface && ft.Kind != KindUnion {
+		return nil, false
+	}
+	if len(ft.PossibleTypes) == 0 {
+		return nil, false
+	}
+	names := make(map[string]struct{}, len(ft.PossibleTypes))
+	for _, possible := range ft.PossibleTypes {
+		names[possible.Name] = struct{}{}
+	}
+	return names, true
+}
+
+type selectionParser struct {
+	input string
+	pos   int
+}
+
+func (p *selectionParser) parseSelectionList(stopOnBrace bool) ([]selection, error) {
+	var selections []selection
+	for {
+		p.skipIgnored()
+		if p.eof() {
+			if stopOnBrace {
+				return nil, fmt.Errorf("missing closing brace")
+			}
+			return selections, nil
+		}
+		if p.peek() == '}' {
+			if !stopOnBrace {
+				return nil, fmt.Errorf("unexpected closing brace")
+			}
+			p.pos++
+			return selections, nil
+		}
+		sel, err := p.parseSelection()
+		if err != nil {
+			return nil, err
+		}
+		selections = append(selections, sel)
+	}
+}
+
+func (p *selectionParser) parseSelection() (selection, error) {
+	if p.consume("...") {
+		p.skipIgnored()
+		if !p.consumeName("on") {
+			return nil, fmt.Errorf("fragment spreads are not supported")
+		}
+		p.skipIgnored()
+		typeName, err := p.readName()
+		if err != nil {
+			return nil, fmt.Errorf("inline fragment missing type condition")
+		}
+		p.skipIgnored()
+		selections, err := p.parseBracedSelectionList()
+		if err != nil {
+			return nil, err
+		}
+		return inlineFragmentSelection{TypeCondition: typeName, Selections: selections}, nil
+	}
+
+	first, err := p.readName()
+	if err != nil {
+		return nil, err
+	}
+	p.skipIgnored()
+	name := first
+	alias := ""
+	if p.consume(":") {
+		alias = first
+		p.skipIgnored()
+		name, err = p.readName()
+		if err != nil {
+			return nil, fmt.Errorf("alias %q missing field name", alias)
+		}
+		p.skipIgnored()
+	}
+	if p.peekOrZero() == '(' {
+		return nil, fmt.Errorf("field arguments are not supported in selectionSet")
+	}
+	if p.peekOrZero() == '@' {
+		return nil, fmt.Errorf("directives are not supported in selectionSet")
+	}
+
+	var selections []selection
+	if p.peekOrZero() == '{' {
+		var err error
+		selections, err = p.parseBracedSelectionList()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return fieldSelection{Alias: alias, Name: name, Selections: selections}, nil
+}
+
+func (p *selectionParser) parseBracedSelectionList() ([]selection, error) {
+	if !p.consume("{") {
+		return nil, fmt.Errorf("expected opening brace")
+	}
+	return p.parseSelectionList(true)
+}
+
+func (p *selectionParser) expectEnd() error {
+	p.skipIgnored()
+	if !p.eof() {
+		return fmt.Errorf("unexpected input %q", p.input[p.pos:])
+	}
+	return nil
+}
+
+func (p *selectionParser) readName() (string, error) {
+	if p.eof() {
+		return "", fmt.Errorf("expected name")
+	}
+	r := rune(p.input[p.pos])
+	if !isNameStart(r) {
+		return "", fmt.Errorf("expected name at %q", p.input[p.pos:])
+	}
+	start := p.pos
+	p.pos++
+	for !p.eof() {
+		r = rune(p.input[p.pos])
+		if !isNameContinue(r) {
+			break
+		}
+		p.pos++
+	}
+	return p.input[start:p.pos], nil
+}
+
+func (p *selectionParser) consumeName(name string) bool {
+	start := p.pos
+	got, err := p.readName()
+	if err != nil || got != name {
+		p.pos = start
+		return false
+	}
+	return true
+}
+
+func (p *selectionParser) skipIgnored() {
+	for !p.eof() {
+		r := rune(p.input[p.pos])
+		if unicode.IsSpace(r) || r == ',' {
+			p.pos++
+			continue
+		}
+		if r == '#' {
+			for !p.eof() && p.input[p.pos] != '\n' && p.input[p.pos] != '\r' {
+				p.pos++
+			}
+			continue
+		}
+		return
+	}
+}
+
+func (p *selectionParser) consume(s string) bool {
+	if strings.HasPrefix(p.input[p.pos:], s) {
+		p.pos += len(s)
+		return true
+	}
+	return false
+}
+
+func (p *selectionParser) peek() byte {
+	return p.input[p.pos]
+}
+
+func (p *selectionParser) peekOrZero() byte {
+	if p.eof() {
+		return 0
+	}
+	return p.input[p.pos]
+}
+
+func (p *selectionParser) eof() bool {
+	return p.pos >= len(p.input)
+}
+
+func isNameStart(r rune) bool {
+	return r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z'
+}
+
+func isNameContinue(r rune) bool {
+	return isNameStart(r) || r >= '0' && r <= '9'
+}


### PR DESCRIPTION
## Summary
- Add explicit GraphQL selection sets to `allowedOperations` so allowlisted object/interface/union roots no longer rely on generated broad selections.
- Add optional `graphql.operationType` disambiguation for schemas that expose the same root field name on both query and mutation roots.
- Scope GraphQL validation to explicit GraphQL entries in mixed-surface allowlists, preserve dynamic MCP allowlists, and accept inline fragments when interface/union possible types overlap.
- Keep a compatibility path where `allowedOperations` supplies exposure and legacy `operationSelections` supplies GraphQL response selections for older provider manifests.

## Test plan
- [x] `go test ./services/plugins/graphql ./internal/bootstrap -run 'GraphQL|LoadDefinitionWithAllowedOps|LoadDefinitionWithSelectionOverride|MCPAllowedOperationsForSpecComposite'`
- [x] `go test ./services/plugins/mcpupstream ./services/plugins/operationexposure`
- [x] `go test ./internal/bootstrap ./services/plugins/graphql ./sdk/providermanifest/v1 ./services/plugins/providerpkg ./services/plugins/mcpupstream ./services/plugins/operationexposure`
- [x] Local Linear provider release using patched core.
- [x] Local Linear provider release using `gestaltd` built from current `origin/main`.
- [x] `git diff --check`
