### PR TITLE
Remove gestaltd agent read projections

### DIFF
--- a/gestaltd/core/agent/agent.go
+++ b/gestaltd/core/agent/agent.go
@@ -575,6 +575,13 @@ type ManagerCancelTurnRequest struct {
 	Reason string
 }
 
+// Provider is the authoritative agent data boundary. Read methods for
+// sessions, turns, turn events, and interactions must be served from
+// provider-owned control-plane state and must not require a live execution
+// sandbox, pod IP, cached tunnel, or other transport attachment. Execution
+// methods may require runtime transport and should return an unavailable error
+// when the provider has durable state but cannot attach to the execution
+// runtime.
 type Provider interface {
 	CreateSession(ctx context.Context, req CreateSessionRequest) (*Session, error)
 	GetSession(ctx context.Context, req GetSessionRequest) (*Session, error)

--- a/gestaltd/internal/gen/v1/agent_grpc.pb.go
+++ b/gestaltd/internal/gen/v1/agent_grpc.pb.go
@@ -37,6 +37,11 @@ const (
 // AgentProviderClient is the client API for AgentProvider service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// AgentProvider is the authoritative agent data boundary. Read RPCs for
+// sessions, turns, turn events, and interactions should use provider-owned
+// control-plane state and should not require a live execution sandbox,
+// pod-level transport, or cached tunnel.
 type AgentProviderClient interface {
 	CreateSession(ctx context.Context, in *CreateAgentProviderSessionRequest, opts ...grpc.CallOption) (*AgentSession, error)
 	GetSession(ctx context.Context, in *GetAgentProviderSessionRequest, opts ...grpc.CallOption) (*AgentSession, error)
@@ -194,6 +199,11 @@ func (c *agentProviderClient) GetCapabilities(ctx context.Context, in *GetAgentP
 // AgentProviderServer is the server API for AgentProvider service.
 // All implementations must embed UnimplementedAgentProviderServer
 // for forward compatibility.
+//
+// AgentProvider is the authoritative agent data boundary. Read RPCs for
+// sessions, turns, turn events, and interactions should use provider-owned
+// control-plane state and should not require a live execution sandbox,
+// pod-level transport, or cached tunnel.
 type AgentProviderServer interface {
 	CreateSession(context.Context, *CreateAgentProviderSessionRequest) (*AgentSession, error)
 	GetSession(context.Context, *GetAgentProviderSessionRequest) (*AgentSession, error)

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -1472,6 +1472,11 @@ func (s *Server) writeAgentProviderError(ctx context.Context, w http.ResponseWri
 		writeError(w, http.StatusNotFound, fmt.Sprintf("%s %q not found", resource, id))
 	case grpcstatus.Code(err) == codes.InvalidArgument:
 		writeError(w, http.StatusBadRequest, grpcstatus.Convert(err).Message())
+	case grpcstatus.Code(err) == codes.Unavailable ||
+		grpcstatus.Code(err) == codes.DeadlineExceeded ||
+		errors.Is(err, context.DeadlineExceeded):
+		slog.WarnContext(ctx, "agent provider unavailable", "resource", resource, "id", id, "error", err)
+		writeError(w, http.StatusServiceUnavailable, "agent provider unavailable")
 	default:
 		slog.ErrorContext(ctx, "agent provider error", "resource", resource, "id", id, "error", err)
 		writeError(w, http.StatusInternalServerError, "agent request failed")

--- a/gestaltd/internal/server/handlers_agent_internal_test.go
+++ b/gestaltd/internal/server/handlers_agent_internal_test.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWriteAgentProviderErrorMapsContextDeadlineToUnavailable(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	s := &Server{}
+
+	s.writeAgentProviderError(context.Background(), w, "agent turn", "turn-1", context.DeadlineExceeded)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+	if !strings.Contains(w.Body.String(), "agent provider unavailable") {
+		t.Fatalf("body = %q, want unavailable message", w.Body.String())
+	}
+}

--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -50,6 +50,8 @@ var (
 	ErrAgentSessionMetadataInvalid      = errors.New("agent session metadata is invalid")
 	ErrAgentInvalidListRequest          = errors.New("agent list request is invalid")
 	ErrAgentStructuredOutputUnsupported = errors.New("agent provider does not support structured output")
+
+	errAgentSessionInaccessible = fmt.Errorf("%w: agent session is not accessible", core.ErrNotFound)
 )
 
 const (
@@ -61,6 +63,7 @@ const (
 	maxAgentRouteCacheEntries    = 20_000
 	AgentListSummaryDefaultLimit = 100
 	AgentListMaxLimit            = 500
+	agentReadHydrationTimeout    = 750 * time.Millisecond
 )
 
 type AgentProviderNotAvailableError struct {
@@ -717,7 +720,9 @@ func (m *Manager) GetSession(ctx context.Context, p *principal.Principal, sessio
 	ctx, finish := startAgentOperation(ctx, "get_session")
 	defer func() { finish(err) }()
 
-	owned, err := m.findAccessibleSession(ctx, p, sessionID, "", authorization.ProviderAgentSessionActionView)
+	hydrationCtx, cancel := context.WithTimeout(ctx, agentReadHydrationTimeout)
+	owned, err := m.findAccessibleSession(hydrationCtx, p, sessionID, "", authorization.ProviderAgentSessionActionView)
+	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -753,12 +758,14 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 				return nil, err
 			}
 		}
-		sessions, err := candidate.provider.ListSessions(ctx, coreagent.ListSessionsRequest{
+		hydrationCtx, cancel := context.WithTimeout(ctx, agentReadHydrationTimeout)
+		sessions, err := candidate.provider.ListSessions(hydrationCtx, coreagent.ListSessionsRequest{
 			Subject:     agentSubjectFromPrincipal(p),
 			State:       req.State,
 			Limit:       limit,
 			SummaryOnly: req.SummaryOnly,
 		})
+		cancel()
 		if err != nil {
 			return nil, err
 		}
@@ -787,7 +794,10 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 			out = append(out, normalized)
 		}
 	}
-	sharedSessions := m.listSharedAgentSessions(ctx, p, req, limit)
+	sharedSessions, err := m.listSharedAgentSessions(ctx, p, req, limit)
+	if err != nil {
+		return nil, err
+	}
 	for _, session := range sharedSessions {
 		if session == nil {
 			continue
@@ -814,13 +824,13 @@ func (m *Manager) ListSessions(ctx context.Context, p *principal.Principal, req 
 	return out, nil
 }
 
-func (m *Manager) listSharedAgentSessions(ctx context.Context, p *principal.Principal, req coreagent.ManagerListSessionsRequest, limit int) []*coreagent.Session {
+func (m *Manager) listSharedAgentSessions(ctx context.Context, p *principal.Principal, req coreagent.ManagerListSessionsRequest, limit int) ([]*coreagent.Session, error) {
 	if m == nil || m.authorizationProvider == nil {
-		return nil
+		return nil, nil
 	}
 	subjectID := strings.TrimSpace(principalSubjectID(principal.Canonicalized(p)))
 	if subjectID == "" {
-		return nil
+		return nil, nil
 	}
 	pageSize := limit
 	if pageSize <= 0 || pageSize > AgentListSummaryDefaultLimit {
@@ -842,7 +852,7 @@ func (m *Manager) listSharedAgentSessions(ctx context.Context, p *principal.Prin
 			PageToken:    pageToken,
 		})
 		if err != nil {
-			return out
+			return nil, err
 		}
 		for _, resource := range resp.GetResources() {
 			if resource == nil || strings.TrimSpace(resource.GetType()) != authorization.ProviderResourceTypeAgentSession {
@@ -856,9 +866,14 @@ func (m *Manager) listSharedAgentSessions(ctx context.Context, p *principal.Prin
 				continue
 			}
 			seen[sessionID] = struct{}{}
-			session, err := m.findAccessibleSession(ctx, p, sessionID, providerName, authorization.ProviderAgentSessionActionView)
+			hydrationCtx, cancel := context.WithTimeout(ctx, agentReadHydrationTimeout)
+			session, err := m.findAccessibleSession(hydrationCtx, p, sessionID, providerName, authorization.ProviderAgentSessionActionView)
+			cancel()
 			if err != nil {
-				continue
+				if agentProviderReturnedNotFound(err) || errors.Is(err, invocation.ErrAuthorizationDenied) {
+					continue
+				}
+				return nil, err
 			}
 			if req.State != "" && session.session.State != req.State {
 				continue
@@ -871,7 +886,7 @@ func (m *Manager) listSharedAgentSessions(ctx context.Context, p *principal.Prin
 		}
 		pageToken = strings.TrimSpace(resp.GetNextPageToken())
 		if pageToken == "" {
-			return out
+			return out, nil
 		}
 	}
 }
@@ -1052,7 +1067,9 @@ func (m *Manager) GetTurn(ctx context.Context, p *principal.Principal, turnID st
 	ctx, finish := startAgentOperation(ctx, "get_turn")
 	defer func() { finish(err) }()
 
-	owned, err := m.findAccessibleTurn(ctx, p, turnID, "", "", authorization.ProviderAgentSessionActionView)
+	hydrationCtx, cancel := context.WithTimeout(ctx, agentReadHydrationTimeout)
+	owned, err := m.findAccessibleTurn(hydrationCtx, p, turnID, "", "", authorization.ProviderAgentSessionActionView)
+	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -1064,26 +1081,30 @@ func (m *Manager) ListTurns(ctx context.Context, p *principal.Principal, req cor
 	ctx, finish := startAgentOperation(ctx, "list_turns")
 	defer func() { finish(err) }()
 
-	ownedSession, err := m.findAccessibleSession(ctx, p, req.SessionID, "", authorization.ProviderAgentSessionActionView)
-	if err != nil {
-		return nil, err
-	}
-	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ownedSession.providerName))
 	limit, err := normalizeAgentListLimit(req.Limit, req.SummaryOnly)
 	if err != nil {
 		return nil, err
 	}
+	hydrationCtx, cancel := context.WithTimeout(ctx, agentReadHydrationTimeout)
+	ownedSession, err := m.findAccessibleSession(hydrationCtx, p, req.SessionID, "", authorization.ProviderAgentSessionActionView)
+	cancel()
+	if err != nil {
+		return nil, err
+	}
+	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(ownedSession.providerName))
 	if req.SummaryOnly || limit > 0 {
 		if err := requireAgentProviderBoundedListHydration(ctx, ownedSession.providerName, ownedSession.provider); err != nil {
 			return nil, err
 		}
 	}
-	turns, err = ownedSession.provider.ListTurns(ctx, coreagent.ListTurnsRequest{
+	hydrationCtx, cancel = context.WithTimeout(ctx, agentReadHydrationTimeout)
+	turns, err = ownedSession.provider.ListTurns(hydrationCtx, coreagent.ListTurnsRequest{
 		SessionID:   ownedSession.session.ID,
 		Status:      req.Status,
 		Limit:       limit,
 		SummaryOnly: req.SummaryOnly,
 	})
+	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -1162,16 +1183,20 @@ func (m *Manager) ListTurnEvents(ctx context.Context, p *principal.Principal, tu
 	ctx, finish := startAgentOperation(ctx, "list_turn_events")
 	defer func() { finish(err) }()
 
-	owned, err := m.findAccessibleTurn(ctx, p, turnID, "", "", authorization.ProviderAgentSessionActionView)
+	hydrationCtx, cancel := context.WithTimeout(ctx, agentReadHydrationTimeout)
+	owned, err := m.findAccessibleTurn(hydrationCtx, p, turnID, "", "", authorization.ProviderAgentSessionActionView)
+	cancel()
 	if err != nil {
 		return nil, err
 	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(owned.providerName))
-	events, err = owned.provider.ListTurnEvents(ctx, coreagent.ListTurnEventsRequest{
+	hydrationCtx, cancel = context.WithTimeout(ctx, agentReadHydrationTimeout)
+	events, err = owned.provider.ListTurnEvents(hydrationCtx, coreagent.ListTurnEventsRequest{
 		TurnID:   owned.turn.ID,
 		AfterSeq: afterSeq,
 		Limit:    limit,
 	})
+	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -1182,14 +1207,18 @@ func (m *Manager) ListInteractions(ctx context.Context, p *principal.Principal, 
 	ctx, finish := startAgentOperation(ctx, "list_interactions")
 	defer func() { finish(err) }()
 
-	owned, err := m.findAccessibleTurn(ctx, p, turnID, "", "", authorization.ProviderAgentSessionActionView)
+	hydrationCtx, cancel := context.WithTimeout(ctx, agentReadHydrationTimeout)
+	owned, err := m.findAccessibleTurn(hydrationCtx, p, turnID, "", "", authorization.ProviderAgentSessionActionView)
+	cancel()
 	if err != nil {
 		return nil, err
 	}
 	observability.SetSpanAttributes(ctx, observability.AttrAgentProvider.String(owned.providerName))
-	interactions, err := owned.provider.ListInteractions(ctx, coreagent.ListInteractionsRequest{
+	hydrationCtx, cancel = context.WithTimeout(ctx, agentReadHydrationTimeout)
+	interactions, err := owned.provider.ListInteractions(hydrationCtx, coreagent.ListInteractionsRequest{
 		TurnID: owned.turn.ID,
 	})
+	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -1321,6 +1350,39 @@ func (m *Manager) providerCandidates(providerName string) ([]namedAgentProvider,
 	return candidates, nil
 }
 
+func (m *Manager) directReadProviderCandidates(providerName string, exclude map[string]struct{}) ([]namedAgentProvider, error, error) {
+	providerName = strings.TrimSpace(providerName)
+	if providerName != "" {
+		candidates, err := m.providerCandidates(providerName)
+		return candidates, nil, err
+	}
+	if m == nil || m.agent == nil {
+		return nil, nil, ErrAgentNotConfigured
+	}
+	names := m.agent.ProviderNames()
+	candidates := make([]namedAgentProvider, 0, len(names))
+	var retainedErr error
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := exclude[name]; ok {
+			continue
+		}
+		provider, err := m.resolveProviderByName(name)
+		if err != nil {
+			if agentProviderReadFallbackAllowed(err) {
+				retainedErr = retainAgentProviderReadError(retainedErr, err)
+				continue
+			}
+			return nil, nil, err
+		}
+		candidates = append(candidates, namedAgentProvider{name: name, provider: provider})
+	}
+	return candidates, retainedErr, nil
+}
+
 func (m *Manager) authorizedProviderCandidates(ctx context.Context, p *principal.Principal, providerName string) ([]namedAgentProvider, error) {
 	candidates, err := m.providerCandidates(providerName)
 	if err != nil {
@@ -1371,49 +1433,76 @@ func (m *Manager) findAccessibleSession(ctx context.Context, p *principal.Princi
 		m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
 		return found, nil
 	}
+	var retainedErr error
+	attemptedProviders := map[string]struct{}{}
 	if storedRoute, ok, err := m.storedSessionRoute(ctx, sessionID); err != nil {
 		return nil, err
 	} else if ok {
+		attemptedProviders[strings.TrimSpace(storedRoute.ProviderName)] = struct{}{}
 		found, findErr := m.findAccessibleSessionInProviders(ctx, p, sessionID, storedRoute.ProviderName, action)
 		if findErr == nil {
 			m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
 			return found, nil
 		}
-		if errors.Is(findErr, ErrAgentProviderNotAvailable) {
-			if m.agentProviderConfigured(storedRoute.ProviderName) {
-				return nil, findErr
-			}
+		switch {
+		case agentProviderConfirmedMissing(findErr):
 			if err := m.forgetSessionRoute(ctx, sessionID, storedRoute.ProviderName); err != nil {
 				return nil, err
 			}
-		} else if !errors.Is(findErr, core.ErrNotFound) {
+		case agentProviderReadFallbackAllowed(findErr):
+			if errors.Is(findErr, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(storedRoute.ProviderName) {
+				if err := m.forgetSessionRoute(ctx, sessionID, storedRoute.ProviderName); err != nil {
+					return nil, err
+				}
+			} else {
+				retainedErr = retainAgentProviderReadError(retainedErr, findErr)
+			}
+		default:
 			return nil, findErr
 		}
 	}
 	if cachedRoute, ok := m.cachedSessionRoute(sessionID); ok {
-		found, err := m.findAccessibleSessionInProviders(ctx, p, sessionID, cachedRoute.ProviderName, action)
-		if err == nil {
-			m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
-			return found, nil
-		}
-		m.forgetCachedSessionRoute(sessionID, cachedRoute.ProviderName)
-		if !errors.Is(err, core.ErrNotFound) && !errors.Is(err, ErrAgentProviderNotAvailable) {
-			return nil, err
-		}
-		if errors.Is(err, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(cachedRoute.ProviderName) {
-			_ = m.forgetSessionRoute(ctx, sessionID, cachedRoute.ProviderName)
+		cachedProviderName := strings.TrimSpace(cachedRoute.ProviderName)
+		if _, alreadyTried := attemptedProviders[cachedProviderName]; !alreadyTried {
+			attemptedProviders[cachedProviderName] = struct{}{}
+			found, err := m.findAccessibleSessionInProviders(ctx, p, sessionID, cachedRoute.ProviderName, action)
+			if err == nil {
+				m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
+				return found, nil
+			}
+			switch {
+			case agentProviderConfirmedMissing(err):
+				m.forgetCachedSessionRoute(sessionID, cachedRoute.ProviderName)
+				_ = m.forgetSessionRoute(ctx, sessionID, cachedRoute.ProviderName)
+			case agentProviderReadFallbackAllowed(err):
+				if errors.Is(err, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(cachedRoute.ProviderName) {
+					m.forgetCachedSessionRoute(sessionID, cachedRoute.ProviderName)
+					_ = m.forgetSessionRoute(ctx, sessionID, cachedRoute.ProviderName)
+				} else {
+					retainedErr = retainAgentProviderReadError(retainedErr, err)
+				}
+			default:
+				return nil, err
+			}
 		}
 	}
-	found, err := m.findAccessibleSessionInProviders(ctx, p, sessionID, "", action)
+	found, err := m.findAccessibleSessionInProviders(ctx, p, sessionID, "", action, attemptedProviders)
 	if err != nil {
+		if agentProviderReturnedNotFound(err) && retainedErr != nil {
+			return nil, retainedErr
+		}
 		return nil, err
 	}
 	m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
 	return found, nil
 }
 
-func (m *Manager) findAccessibleSessionInProviders(ctx context.Context, p *principal.Principal, sessionID, providerName, action string) (*accessibleAgentSession, error) {
-	candidates, err := m.providerCandidates(providerName)
+func (m *Manager) findAccessibleSessionInProviders(ctx context.Context, p *principal.Principal, sessionID, providerName, action string, exclude ...map[string]struct{}) (*accessibleAgentSession, error) {
+	var excluded map[string]struct{}
+	if len(exclude) > 0 {
+		excluded = exclude[0]
+	}
+	candidates, retainedErr, err := m.directReadProviderCandidates(providerName, excluded)
 	if err != nil {
 		return nil, err
 	}
@@ -1423,6 +1512,7 @@ func (m *Manager) findAccessibleSessionInProviders(ctx context.Context, p *princ
 	}
 	var found *accessibleAgentSession
 	authDenied := false
+	inaccessible := false
 	for _, candidate := range candidates {
 		if m.authorizationProvider == nil && !m.allowsAgentProvider(ctx, p, candidate.name) {
 			authDenied = true
@@ -1435,6 +1525,10 @@ func (m *Manager) findAccessibleSessionInProviders(ctx context.Context, p *princ
 			if agentProviderReturnedNotFound(err) {
 				continue
 			}
+			if strings.TrimSpace(providerName) == "" && agentProviderReadFallbackAllowed(err) {
+				retainedErr = retainAgentProviderReadError(retainedErr, err)
+				continue
+			}
 			return nil, err
 		}
 		normalized, err := normalizeProviderSession(candidate.name, sessionID, session)
@@ -1445,6 +1539,8 @@ func (m *Manager) findAccessibleSessionInProviders(ctx context.Context, p *princ
 		if !allowed {
 			if owned {
 				authDenied = true
+			} else {
+				inaccessible = true
 			}
 			continue
 		}
@@ -1465,6 +1561,12 @@ func (m *Manager) findAccessibleSessionInProviders(ctx context.Context, p *princ
 			}
 			return nil, invocation.ErrAuthorizationDenied
 		}
+		if retainedErr != nil {
+			return nil, retainedErr
+		}
+		if inaccessible {
+			return nil, errAgentSessionInaccessible
+		}
 		return nil, core.ErrNotFound
 	}
 	return found, nil
@@ -1484,49 +1586,76 @@ func (m *Manager) findAccessibleTurn(ctx context.Context, p *principal.Principal
 		m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
 		return found, nil
 	}
+	var retainedErr error
+	attemptedProviders := map[string]struct{}{}
 	if storedRoute, ok, err := m.storedTurnRoute(ctx, turnID); err != nil {
 		return nil, err
 	} else if ok {
+		attemptedProviders[strings.TrimSpace(storedRoute.ProviderName)] = struct{}{}
 		found, findErr := m.findAccessibleTurnInProviders(ctx, p, turnID, storedRoute.ProviderName, storedRoute.SessionID, action)
 		if findErr == nil {
 			m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
 			return found, nil
 		}
-		if errors.Is(findErr, ErrAgentProviderNotAvailable) {
-			if m.agentProviderConfigured(storedRoute.ProviderName) {
-				return nil, findErr
-			}
+		switch {
+		case agentProviderConfirmedMissing(findErr):
 			if err := m.forgetTurnRoute(ctx, turnID, storedRoute.ProviderName); err != nil {
 				return nil, err
 			}
-		} else if !errors.Is(findErr, core.ErrNotFound) {
+		case agentProviderReadFallbackAllowed(findErr):
+			if errors.Is(findErr, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(storedRoute.ProviderName) {
+				if err := m.forgetTurnRoute(ctx, turnID, storedRoute.ProviderName); err != nil {
+					return nil, err
+				}
+			} else {
+				retainedErr = retainAgentProviderReadError(retainedErr, findErr)
+			}
+		default:
 			return nil, findErr
 		}
 	}
 	if cachedRoute, ok := m.cachedTurnRoute(turnID); ok {
-		found, err := m.findAccessibleTurnInProviders(ctx, p, turnID, cachedRoute.ProviderName, cachedRoute.SessionID, action)
-		if err == nil {
-			m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
-			return found, nil
-		}
-		m.forgetCachedTurnRoute(turnID, cachedRoute.ProviderName)
-		if !errors.Is(err, core.ErrNotFound) && !errors.Is(err, ErrAgentProviderNotAvailable) {
-			return nil, err
-		}
-		if errors.Is(err, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(cachedRoute.ProviderName) {
-			_ = m.forgetTurnRoute(ctx, turnID, cachedRoute.ProviderName)
+		cachedProviderName := strings.TrimSpace(cachedRoute.ProviderName)
+		if _, alreadyTried := attemptedProviders[cachedProviderName]; !alreadyTried {
+			attemptedProviders[cachedProviderName] = struct{}{}
+			found, err := m.findAccessibleTurnInProviders(ctx, p, turnID, cachedRoute.ProviderName, cachedRoute.SessionID, action)
+			if err == nil {
+				m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
+				return found, nil
+			}
+			switch {
+			case agentProviderConfirmedMissing(err):
+				m.forgetCachedTurnRoute(turnID, cachedRoute.ProviderName)
+				_ = m.forgetTurnRoute(ctx, turnID, cachedRoute.ProviderName)
+			case agentProviderReadFallbackAllowed(err):
+				if errors.Is(err, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(cachedRoute.ProviderName) {
+					m.forgetCachedTurnRoute(turnID, cachedRoute.ProviderName)
+					_ = m.forgetTurnRoute(ctx, turnID, cachedRoute.ProviderName)
+				} else {
+					retainedErr = retainAgentProviderReadError(retainedErr, err)
+				}
+			default:
+				return nil, err
+			}
 		}
 	}
-	found, err := m.findAccessibleTurnInProviders(ctx, p, turnID, "", expectedSessionID, action)
+	found, err := m.findAccessibleTurnInProviders(ctx, p, turnID, "", expectedSessionID, action, attemptedProviders)
 	if err != nil {
+		if agentProviderReturnedNotFound(err) && retainedErr != nil {
+			return nil, retainedErr
+		}
 		return nil, err
 	}
 	m.rememberTurnRouteBestEffort(ctx, found.turn.ID, found.turn.SessionID, found.providerName)
 	return found, nil
 }
 
-func (m *Manager) findAccessibleTurnInProviders(ctx context.Context, p *principal.Principal, turnID, providerName, expectedSessionID, action string) (*accessibleAgentTurn, error) {
-	candidates, err := m.providerCandidates(providerName)
+func (m *Manager) findAccessibleTurnInProviders(ctx context.Context, p *principal.Principal, turnID, providerName, expectedSessionID, action string, exclude ...map[string]struct{}) (*accessibleAgentTurn, error) {
+	var excluded map[string]struct{}
+	if len(exclude) > 0 {
+		excluded = exclude[0]
+	}
+	candidates, retainedErr, err := m.directReadProviderCandidates(providerName, excluded)
 	if err != nil {
 		return nil, err
 	}
@@ -1541,6 +1670,10 @@ func (m *Manager) findAccessibleTurnInProviders(ctx context.Context, p *principa
 		})
 		if err != nil {
 			if agentProviderReturnedNotFound(err) {
+				continue
+			}
+			if strings.TrimSpace(providerName) == "" && agentProviderReadFallbackAllowed(err) {
+				retainedErr = retainAgentProviderReadError(retainedErr, err)
 				continue
 			}
 			return nil, err
@@ -1558,7 +1691,11 @@ func (m *Manager) findAccessibleTurnInProviders(ctx context.Context, p *principa
 		}
 		session, err := m.findAccessibleSessionInProviders(ctx, p, normalized.SessionID, candidate.name, action)
 		if err != nil {
-			if errors.Is(err, core.ErrNotFound) {
+			if agentProviderConfirmedMissing(err) {
+				continue
+			}
+			if strings.TrimSpace(providerName) == "" && agentProviderReadFallbackAllowed(err) {
+				retainedErr = retainAgentProviderReadError(retainedErr, err)
 				continue
 			}
 			return nil, err
@@ -1575,6 +1712,9 @@ func (m *Manager) findAccessibleTurnInProviders(ctx context.Context, p *principa
 		}
 	}
 	if found == nil {
+		if retainedErr != nil {
+			return nil, retainedErr
+		}
 		return nil, core.ErrNotFound
 	}
 	return found, nil
@@ -1650,60 +1790,101 @@ func (m *Manager) findOwnedSession(ctx context.Context, p *principal.Principal, 
 		m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
 		return found, nil
 	}
+	var retainedErr error
+	attemptedProviders := map[string]struct{}{}
 	if storedRoute, ok, err := m.storedSessionRoute(ctx, sessionID); err != nil {
 		return nil, err
 	} else if ok {
+		attemptedProviders[strings.TrimSpace(storedRoute.ProviderName)] = struct{}{}
 		found, findErr := m.findOwnedSessionInProviders(ctx, p, sessionID, storedRoute.ProviderName)
 		if findErr == nil {
 			m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
 			return found, nil
 		}
-		if errors.Is(findErr, ErrAgentProviderNotAvailable) {
-			if m.agentProviderConfigured(storedRoute.ProviderName) {
-				return nil, findErr
-			}
+		switch {
+		case agentProviderConfirmedMissing(findErr):
 			if err := m.forgetSessionRoute(ctx, sessionID, storedRoute.ProviderName); err != nil {
 				return nil, err
 			}
-		} else if !errors.Is(findErr, core.ErrNotFound) {
+		case agentProviderReadFallbackAllowed(findErr):
+			if errors.Is(findErr, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(storedRoute.ProviderName) {
+				if err := m.forgetSessionRoute(ctx, sessionID, storedRoute.ProviderName); err != nil {
+					return nil, err
+				}
+			} else {
+				retainedErr = retainAgentProviderReadError(retainedErr, findErr)
+			}
+		default:
 			return nil, findErr
 		}
 	}
 	if cachedRoute, ok := m.cachedSessionRoute(sessionID); ok {
-		found, err := m.findOwnedSessionInProviders(ctx, p, sessionID, cachedRoute.ProviderName)
-		if err == nil {
-			m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
-			return found, nil
-		}
-		m.forgetCachedSessionRoute(sessionID, cachedRoute.ProviderName)
-		if !errors.Is(err, core.ErrNotFound) && !errors.Is(err, ErrAgentProviderNotAvailable) {
-			return nil, err
-		}
-		if errors.Is(err, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(cachedRoute.ProviderName) {
-			_ = m.forgetSessionRoute(ctx, sessionID, cachedRoute.ProviderName)
+		cachedProviderName := strings.TrimSpace(cachedRoute.ProviderName)
+		if _, alreadyTried := attemptedProviders[cachedProviderName]; !alreadyTried {
+			attemptedProviders[cachedProviderName] = struct{}{}
+			found, err := m.findOwnedSessionInProviders(ctx, p, sessionID, cachedRoute.ProviderName)
+			if err == nil {
+				m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
+				return found, nil
+			}
+			switch {
+			case agentProviderConfirmedMissing(err):
+				m.forgetCachedSessionRoute(sessionID, cachedRoute.ProviderName)
+				_ = m.forgetSessionRoute(ctx, sessionID, cachedRoute.ProviderName)
+			case agentProviderReadFallbackAllowed(err):
+				if errors.Is(err, ErrAgentProviderNotAvailable) && !m.agentProviderConfigured(cachedRoute.ProviderName) {
+					m.forgetCachedSessionRoute(sessionID, cachedRoute.ProviderName)
+					_ = m.forgetSessionRoute(ctx, sessionID, cachedRoute.ProviderName)
+				} else {
+					retainedErr = retainAgentProviderReadError(retainedErr, err)
+				}
+			default:
+				return nil, err
+			}
 		}
 	}
-	found, err := m.findOwnedSessionInProviders(ctx, p, sessionID, "")
+	found, err := m.findOwnedSessionInProviders(ctx, p, sessionID, "", attemptedProviders)
 	if err != nil {
+		if agentProviderReturnedNotFound(err) && retainedErr != nil {
+			return nil, retainedErr
+		}
 		return nil, err
 	}
 	m.rememberSessionRouteBestEffort(ctx, found.session.ID, found.providerName)
 	return found, nil
 }
 
-func (m *Manager) findOwnedSessionInProviders(ctx context.Context, p *principal.Principal, sessionID, providerName string) (*ownedAgentSession, error) {
-	candidates, err := m.authorizedProviderCandidates(ctx, p, providerName)
+func (m *Manager) findOwnedSessionInProviders(ctx context.Context, p *principal.Principal, sessionID, providerName string, exclude ...map[string]struct{}) (*ownedAgentSession, error) {
+	var excluded map[string]struct{}
+	if len(exclude) > 0 {
+		excluded = exclude[0]
+	}
+	candidates, retainedErr, err := m.directReadProviderCandidates(providerName, excluded)
+	if err != nil {
+		return nil, err
+	}
+	candidates, err = filterProviderCandidatesByTokenPermission(p, candidates, providerName)
 	if err != nil {
 		return nil, err
 	}
 	var found *ownedAgentSession
+	authDenied := false
+	inaccessible := false
 	for _, candidate := range candidates {
+		if !m.allowsAgentProvider(ctx, p, candidate.name) {
+			authDenied = true
+			continue
+		}
 		session, err := candidate.provider.GetSession(ctx, coreagent.GetSessionRequest{
 			SessionID: sessionID,
 			Subject:   agentSubjectFromPrincipal(p),
 		})
 		if err != nil {
 			if agentProviderReturnedNotFound(err) {
+				continue
+			}
+			if strings.TrimSpace(providerName) == "" && agentProviderReadFallbackAllowed(err) {
+				retainedErr = retainAgentProviderReadError(retainedErr, err)
 				continue
 			}
 			return nil, err
@@ -1713,6 +1894,7 @@ func (m *Manager) findOwnedSessionInProviders(ctx context.Context, p *principal.
 			return nil, err
 		}
 		if !providerSessionOwnedBy(normalized, p) {
+			inaccessible = true
 			continue
 		}
 		if found != nil {
@@ -1725,6 +1907,18 @@ func (m *Manager) findOwnedSessionInProviders(ctx context.Context, p *principal.
 		}
 	}
 	if found == nil {
+		if authDenied {
+			if providerName = strings.TrimSpace(providerName); providerName != "" {
+				return nil, fmt.Errorf("%w: %s", invocation.ErrAuthorizationDenied, providerName)
+			}
+			return nil, invocation.ErrAuthorizationDenied
+		}
+		if retainedErr != nil {
+			return nil, retainedErr
+		}
+		if inaccessible {
+			return nil, errAgentSessionInaccessible
+		}
 		return nil, core.ErrNotFound
 	}
 	return found, nil
@@ -1732,6 +1926,47 @@ func (m *Manager) findOwnedSessionInProviders(ctx context.Context, p *principal.
 
 func agentProviderReturnedNotFound(err error) bool {
 	return errors.Is(err, core.ErrNotFound) || status.Code(err) == codes.NotFound
+}
+
+func agentProviderConfirmedMissing(err error) bool {
+	return agentProviderReturnedNotFound(err) && !errors.Is(err, errAgentSessionInaccessible)
+}
+
+func retainAgentProviderReadError(existing, err error) error {
+	if existing != nil {
+		return existing
+	}
+	return err
+}
+
+func agentProviderReadFallbackAllowed(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrAgentProviderNotAvailable) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"connection error",
+		"connection refused",
+		"connection reset",
+		"dial tcp",
+		"i/o timeout",
+		"no route to host",
+		"pod not found",
+		"sandbox pod",
+		"transport is closing",
+	} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Manager) mintRunGrant(ctx context.Context, p *principal.Principal, providerName, sessionID, turnID, callerPluginName string, toolRefs []coreagent.ToolRef, tools []coreagent.Tool, toolSource coreagent.ToolSourceMode, inheritedOutputDelivery *coreworkflow.OutputDelivery) (string, error) {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -151,6 +151,10 @@ type routeCountingAgentProvider struct {
 	listTurnReqs      []coreagent.ListTurnsRequest
 	turnIDOverride    string
 	cancelStatus      coreagent.ExecutionStatus
+	getSessionErr     error
+	listSessionsErr   error
+	getTurnErr        error
+	listTurnsErr      error
 	getSessionCalls   int
 	getTurnCalls      int
 }
@@ -272,6 +276,9 @@ func (p *routeCountingAgentProvider) SupportsWorkspaceRequests() bool {
 
 func (p *routeCountingAgentProvider) GetSession(_ context.Context, req coreagent.GetSessionRequest) (*coreagent.Session, error) {
 	p.getSessionCalls++
+	if p.getSessionErr != nil {
+		return nil, p.getSessionErr
+	}
 	session := p.sessions[strings.TrimSpace(req.SessionID)]
 	if session == nil {
 		return nil, core.ErrNotFound
@@ -281,6 +288,9 @@ func (p *routeCountingAgentProvider) GetSession(_ context.Context, req coreagent
 
 func (p *routeCountingAgentProvider) ListSessions(_ context.Context, req coreagent.ListSessionsRequest) ([]*coreagent.Session, error) {
 	p.listSessionReqs = append(p.listSessionReqs, req)
+	if p.listSessionsErr != nil {
+		return nil, p.listSessionsErr
+	}
 	var sessions []*coreagent.Session
 	requested := map[string]struct{}{}
 	for _, id := range req.SessionIDs {
@@ -348,6 +358,9 @@ func (p *routeCountingAgentProvider) CreateTurn(_ context.Context, req coreagent
 
 func (p *routeCountingAgentProvider) GetTurn(_ context.Context, req coreagent.GetTurnRequest) (*coreagent.Turn, error) {
 	p.getTurnCalls++
+	if p.getTurnErr != nil {
+		return nil, p.getTurnErr
+	}
 	turn := p.turns[strings.TrimSpace(req.TurnID)]
 	if turn == nil {
 		return nil, core.ErrNotFound
@@ -357,6 +370,9 @@ func (p *routeCountingAgentProvider) GetTurn(_ context.Context, req coreagent.Ge
 
 func (p *routeCountingAgentProvider) ListTurns(_ context.Context, req coreagent.ListTurnsRequest) ([]*coreagent.Turn, error) {
 	p.listTurnReqs = append(p.listTurnReqs, req)
+	if p.listTurnsErr != nil {
+		return nil, p.listTurnsErr
+	}
 	var turns []*coreagent.Turn
 	requested := map[string]struct{}{}
 	for _, id := range req.TurnIDs {
@@ -890,6 +906,130 @@ func TestManagerUsesDurableProviderRoutesAcrossManagers(t *testing.T) {
 	}
 }
 
+func TestManagerGetSessionContinuesAfterHintedProviderUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	routeStore := newTestRouteStore(t, db)
+	alpha := newRouteCountingAgentProvider("alpha")
+	beta := newRouteCountingAgentProvider("beta")
+	control := &routeCountingAgentControl{
+		defaultName: "alpha",
+		names:       []string{"beta", "alpha"},
+		providers: map[string]*routeCountingAgentProvider{
+			"alpha": alpha,
+			"beta":  beta,
+		},
+	}
+	manager := newTestManager(t, Config{Agent: control, RouteStore: routeStore})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	session := &coreagent.Session{
+		ID:           "session-1",
+		ProviderName: "alpha",
+		State:        coreagent.SessionStateActive,
+		CreatedBy:    coreagent.Actor{SubjectID: principal.UserSubjectID("user-1")},
+	}
+	alpha.sessions[session.ID] = session
+	beta.getSessionErr = status.Error(codes.Unavailable, "provider restarting")
+	if err := routeStore.RememberSession(ctx, session.ID, "beta"); err != nil {
+		t.Fatalf("RememberSession: %v", err)
+	}
+
+	got, err := manager.GetSession(ctx, p, session.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if got.ProviderName != "alpha" || got.ID != session.ID {
+		t.Fatalf("GetSession = %+v, want alpha session", got)
+	}
+	if beta.getSessionCalls != 1 || alpha.getSessionCalls != 1 {
+		t.Fatalf("GetSession calls = beta:%d alpha:%d, want 1 each", beta.getSessionCalls, alpha.getSessionCalls)
+	}
+}
+
+func TestManagerGetSessionReturnsRetainedProviderErrorAfterFanoutMiss(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	routeStore := newTestRouteStore(t, db)
+	alpha := newRouteCountingAgentProvider("alpha")
+	beta := newRouteCountingAgentProvider("beta")
+	control := &routeCountingAgentControl{
+		defaultName: "alpha",
+		names:       []string{"beta", "alpha"},
+		providers: map[string]*routeCountingAgentProvider{
+			"alpha": alpha,
+			"beta":  beta,
+		},
+	}
+	manager := newTestManager(t, Config{Agent: control, RouteStore: routeStore})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	beta.getSessionErr = status.Error(codes.Unavailable, "provider restarting")
+	if err := routeStore.RememberSession(ctx, "session-1", "beta"); err != nil {
+		t.Fatalf("RememberSession: %v", err)
+	}
+
+	_, err := manager.GetSession(ctx, p, "session-1")
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("GetSession error = %v, want retained unavailable", err)
+	}
+	if beta.getSessionCalls != 1 || alpha.getSessionCalls != 1 {
+		t.Fatalf("GetSession calls = beta:%d alpha:%d, want 1 each", beta.getSessionCalls, alpha.getSessionCalls)
+	}
+}
+
+func TestManagerGetTurnContinuesAfterHintedProviderUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	routeStore := newTestRouteStore(t, db)
+	alpha := newRouteCountingAgentProvider("alpha")
+	beta := newRouteCountingAgentProvider("beta")
+	control := &routeCountingAgentControl{
+		defaultName: "alpha",
+		names:       []string{"beta", "alpha"},
+		providers: map[string]*routeCountingAgentProvider{
+			"alpha": alpha,
+			"beta":  beta,
+		},
+	}
+	manager := newTestManager(t, Config{Agent: control, RouteStore: routeStore})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	session := &coreagent.Session{
+		ID:           "session-1",
+		ProviderName: "alpha",
+		State:        coreagent.SessionStateActive,
+		CreatedBy:    coreagent.Actor{SubjectID: principal.UserSubjectID("user-1")},
+	}
+	turn := &coreagent.Turn{
+		ID:           "turn-1",
+		SessionID:    session.ID,
+		ProviderName: "alpha",
+		Status:       coreagent.ExecutionStatusSucceeded,
+		CreatedBy:    coreagent.Actor{SubjectID: principal.UserSubjectID("user-1")},
+	}
+	alpha.sessions[session.ID] = session
+	alpha.turns[turn.ID] = turn
+	beta.getTurnErr = status.Error(codes.Unavailable, "provider restarting")
+	if err := routeStore.RememberTurn(ctx, turn.ID, session.ID, "beta"); err != nil {
+		t.Fatalf("RememberTurn: %v", err)
+	}
+
+	got, err := manager.GetTurn(ctx, p, turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if got.ProviderName != "alpha" || got.ID != turn.ID {
+		t.Fatalf("GetTurn = %+v, want alpha turn", got)
+	}
+	if beta.getTurnCalls != 1 || alpha.getTurnCalls != 1 {
+		t.Fatalf("GetTurn calls = beta:%d alpha:%d, want 1 each", beta.getTurnCalls, alpha.getTurnCalls)
+	}
+}
+
 func TestManagerWrongPrincipalDoesNotDeleteDurableSessionRoute(t *testing.T) {
 	t.Parallel()
 
@@ -929,6 +1069,101 @@ func TestManagerWrongPrincipalDoesNotDeleteDurableSessionRoute(t *testing.T) {
 	}
 	if _, err := managerC.GetSession(ctx, owner, session.ID); err != nil {
 		t.Fatalf("GetSession(owner after wrong principal): %v", err)
+	}
+}
+
+func TestManagerWrongPrincipalDoesNotDeleteDurableTurnRoute(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	routeStore := newTestRouteStore(t, db)
+	alpha := newRouteCountingAgentProvider("alpha")
+	control := &routeCountingAgentControl{
+		defaultName: "alpha",
+		names:       []string{"alpha"},
+		providers: map[string]*routeCountingAgentProvider{
+			"alpha": alpha,
+		},
+	}
+	managerA := newTestManager(t, Config{Agent: control, RouteStore: routeStore})
+	managerB := newTestManager(t, Config{Agent: control, RouteStore: newTestRouteStore(t, db)})
+	managerC := newTestManager(t, Config{Agent: control, RouteStore: newTestRouteStore(t, db)})
+	owner := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	other := &principal.Principal{SubjectID: principal.UserSubjectID("user-2")}
+
+	session, err := managerA.CreateSession(ctx, owner, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	turn, err := managerA.CreateTurn(ctx, owner, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := managerB.GetTurn(ctx, other, turn.ID); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetTurn(wrong principal) error = %v, want not found", err)
+	}
+	route, ok, err := routeStore.LookupTurn(ctx, turn.ID)
+	if err != nil {
+		t.Fatalf("LookupTurn: %v", err)
+	}
+	if !ok || route.ProviderName != "alpha" || route.SessionID != session.ID {
+		t.Fatalf("LookupTurn route = %+v, %t, want alpha session route", route, ok)
+	}
+	if _, err := managerC.GetTurn(ctx, owner, turn.ID); err != nil {
+		t.Fatalf("GetTurn(owner after wrong principal): %v", err)
+	}
+}
+
+func TestManagerWrongPrincipalDoesNotDeleteOwnedSessionRoute(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	routeStore := newTestRouteStore(t, db)
+	alpha := newRouteCountingAgentProvider("alpha")
+	control := &routeCountingAgentControl{
+		defaultName: "alpha",
+		names:       []string{"alpha"},
+		providers: map[string]*routeCountingAgentProvider{
+			"alpha": alpha,
+		},
+	}
+	managerA := newTestManager(t, Config{Agent: control, RouteStore: routeStore})
+	managerB := newTestManager(t, Config{Agent: control, RouteStore: newTestRouteStore(t, db)})
+	managerC := newTestManager(t, Config{Agent: control, RouteStore: newTestRouteStore(t, db)})
+	owner := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	other := &principal.Principal{SubjectID: principal.UserSubjectID("user-2")}
+
+	session, err := managerA.CreateSession(ctx, owner, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := managerB.UpdateSession(ctx, other, coreagent.ManagerUpdateSessionRequest{
+		SessionID: session.ID,
+		ClientRef: "wrong-user",
+	}); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("UpdateSession(wrong principal) error = %v, want not found", err)
+	}
+	route, ok, err := routeStore.LookupSession(ctx, session.ID)
+	if err != nil {
+		t.Fatalf("LookupSession: %v", err)
+	}
+	if !ok || route.ProviderName != "alpha" {
+		t.Fatalf("LookupSession route = %+v, %t, want alpha", route, ok)
+	}
+	if _, err := managerC.GetSession(ctx, owner, session.ID); err != nil {
+		t.Fatalf("GetSession(owner after wrong principal update): %v", err)
 	}
 }
 
@@ -1206,6 +1441,80 @@ func TestManagerListSessionsRequiresBoundedHydrationForLimitedLists(t *testing.T
 	}
 }
 
+func TestManagerListSessionsReturnsCapabilityErrorWhenCapabilityReadUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	provider := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": provider},
+		},
+		RouteStore: newTestRouteStore(t, db),
+		RunGrants:  newAgentManagerTestRunGrants(t),
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	if _, err := manager.CreateSession(ctx, p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	provider.capabilitiesErr = status.Error(codes.Unavailable, "sandbox is redeploying")
+
+	_, err := manager.ListSessions(ctx, p, coreagent.ManagerListSessionsRequest{
+		ProviderName: "alpha",
+		SummaryOnly:  true,
+		Limit:        10,
+	})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("ListSessions error = %v, want unavailable capability error", err)
+	}
+	if len(provider.listSessionReqs) != 0 {
+		t.Fatalf("provider ListSessions calls = %d, want 0 after capability error", len(provider.listSessionReqs))
+	}
+}
+
+func TestManagerListSessionsReturnsProviderErrorWithoutPartialResults(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	alpha := newRouteCountingAgentProvider("alpha")
+	beta := newRouteCountingAgentProvider("beta")
+	control := &routeCountingAgentControl{
+		defaultName: "alpha",
+		names:       []string{"alpha", "beta"},
+		providers: map[string]*routeCountingAgentProvider{
+			"alpha": alpha,
+			"beta":  beta,
+		},
+	}
+	manager := newTestManager(t, Config{
+		Agent:      control,
+		RouteStore: newTestRouteStore(t, db),
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	if _, err := manager.CreateSession(ctx, p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	beta.listSessionsErr = status.Error(codes.Unavailable, "sandbox is redeploying")
+
+	_, err := manager.ListSessions(ctx, p, coreagent.ManagerListSessionsRequest{
+		SummaryOnly: true,
+		Limit:       10,
+	})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("ListSessions error = %v, want unavailable from provider without projection", err)
+	}
+}
+
 func TestManagerListSharedSessionsUsesEffectiveSearchResources(t *testing.T) {
 	t.Parallel()
 
@@ -1244,6 +1553,135 @@ func TestManagerListSharedSessionsUsesEffectiveSearchResources(t *testing.T) {
 	}
 	if authz.searchResourceCalls != 0 {
 		t.Fatalf("SearchResources calls = %d, want 0", authz.searchResourceCalls)
+	}
+}
+
+func TestManagerListSharedSessionsReturnsSearchError(t *testing.T) {
+	t.Parallel()
+
+	provider := newRouteCountingAgentProvider("alpha")
+	authz := &sharedSessionAuthorizationProvider{
+		effectiveErr: status.Error(codes.Unavailable, "authorization search unavailable"),
+	}
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": provider},
+		},
+		AuthorizationProvider: authz,
+	})
+
+	_, err := manager.ListSessions(context.Background(), &principal.Principal{SubjectID: principal.UserSubjectID("viewer")}, coreagent.ManagerListSessionsRequest{
+		SummaryOnly: true,
+		Limit:       10,
+	})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("ListSessions error = %v, want unavailable search error", err)
+	}
+	if authz.searchResourceCalls != 0 {
+		t.Fatalf("SearchResources calls = %d, want no fallback after transient effective search error", authz.searchResourceCalls)
+	}
+}
+
+func TestManagerListSharedSessionsReturnsProviderErrorWhenProviderUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	provider := newRouteCountingAgentProvider("alpha")
+	authz := &sharedSessionAuthorizationProvider{
+		allowedSessions: map[string]struct{}{},
+	}
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": provider},
+		},
+		RouteStore:            newTestRouteStore(t, db),
+		AuthorizationProvider: authz,
+		RunGrants:             newAgentManagerTestRunGrants(t),
+	})
+	owner := &principal.Principal{SubjectID: principal.UserSubjectID("owner")}
+	viewer := &principal.Principal{SubjectID: principal.UserSubjectID("viewer")}
+
+	session, err := manager.CreateSession(ctx, owner, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	authz.effectiveResources = []*core.ResourceRef{{Type: authorization.ProviderResourceTypeAgentSession, Id: session.ID}}
+	authz.allowedSessions[session.ID] = struct{}{}
+	unavailable := status.Error(codes.Unavailable, "sandbox is redeploying")
+	provider.getSessionErr = unavailable
+
+	_, err = manager.ListSessions(ctx, viewer, coreagent.ManagerListSessionsRequest{
+		SummaryOnly: true,
+		Limit:       10,
+	})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("ListSessions error = %v, want unavailable shared hydration error", err)
+	}
+	if provider.getSessionCalls != 1 {
+		t.Fatalf("GetSession calls = %d, want one failed shared hydration", provider.getSessionCalls)
+	}
+}
+
+func TestManagerListSharedSessionsHonorsProviderFilter(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	alpha := newRouteCountingAgentProvider("alpha")
+	beta := newRouteCountingAgentProvider("beta")
+	authz := &sharedSessionAuthorizationProvider{
+		allowedSessions: map[string]struct{}{},
+	}
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha", "beta"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+				"beta":  beta,
+			},
+		},
+		RouteStore:            newTestRouteStore(t, db),
+		AuthorizationProvider: authz,
+		RunGrants:             newAgentManagerTestRunGrants(t),
+	})
+	owner := &principal.Principal{SubjectID: principal.UserSubjectID("owner")}
+	viewer := &principal.Principal{SubjectID: principal.UserSubjectID("viewer")}
+
+	session, err := manager.CreateSession(ctx, owner, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	authz.effectiveResources = []*core.ResourceRef{{Type: authorization.ProviderResourceTypeAgentSession, Id: session.ID}}
+	authz.allowedSessions[session.ID] = struct{}{}
+
+	sessions, err := manager.ListSessions(ctx, viewer, coreagent.ManagerListSessionsRequest{
+		ProviderName: "beta",
+		SummaryOnly:  true,
+		Limit:        10,
+	})
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("ListSessions shared sessions = %#v, want none for beta filter", sessions)
+	}
+	if beta.getSessionCalls != 1 {
+		t.Fatalf("beta GetSession calls = %d, want one failed shared hydration", beta.getSessionCalls)
+	}
+	if alpha.getSessionCalls != 0 {
+		t.Fatalf("alpha GetSession calls = %d, want 0 for beta filter", alpha.getSessionCalls)
 	}
 }
 
@@ -1324,6 +1762,51 @@ func TestManagerListTurnsRequiresBoundedHydrationForSummaryLists(t *testing.T) {
 	}
 	if len(provider.listTurnReqs) != 0 {
 		t.Fatalf("provider ListTurns calls = %d, want 0", len(provider.listTurnReqs))
+	}
+}
+
+func TestManagerListTurnsReturnsCapabilityErrorWhenCapabilityReadUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := &coretesting.StubIndexedDB{}
+	provider := newRouteCountingAgentProvider("alpha")
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": provider},
+		},
+		RouteStore: newTestRouteStore(t, db),
+		RunGrants:  newAgentManagerTestRunGrants(t),
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+	session, err := manager.CreateSession(ctx, p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := manager.CreateTurn(ctx, p, coreagent.ManagerCreateTurnRequest{
+		SessionID: session.ID,
+		Model:     "test-model",
+		Messages:  []coreagent.Message{{Role: "user", Text: "hello"}},
+	}); err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	provider.capabilitiesErr = status.Error(codes.Unavailable, "sandbox is redeploying")
+
+	_, err = manager.ListTurns(ctx, p, coreagent.ManagerListTurnsRequest{
+		SessionID:   session.ID,
+		SummaryOnly: true,
+		Limit:       10,
+	})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("ListTurns error = %v, want unavailable capability error", err)
+	}
+	if len(provider.listTurnReqs) != 0 {
+		t.Fatalf("provider ListTurns calls = %d, want 0 after capability error", len(provider.listTurnReqs))
 	}
 }
 

--- a/sdk/go/agent_provider.go
+++ b/sdk/go/agent_provider.go
@@ -10,7 +10,10 @@ import (
 // AgentProvider is implemented by providers that serve the agent base
 // primitive. The SDK owns the gRPC/protobuf transport adapter; provider code
 // implements this typed interface instead of importing generated protobuf
-// service bindings.
+// service bindings. Read methods for sessions, turns, turn events, and
+// interactions must be served from provider-owned control-plane state. They
+// must not require a live execution sandbox, pod IP, cached tunnel, or other
+// transport attachment.
 type AgentProvider interface {
 	Provider
 	// CreateSession creates or idempotently returns an agent session.

--- a/sdk/go/internal/gen/v1/agent_grpc.pb.go
+++ b/sdk/go/internal/gen/v1/agent_grpc.pb.go
@@ -37,6 +37,11 @@ const (
 // AgentProviderClient is the client API for AgentProvider service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// AgentProvider is the authoritative agent data boundary. Read RPCs for
+// sessions, turns, turn events, and interactions should use provider-owned
+// control-plane state and should not require a live execution sandbox,
+// pod-level transport, or cached tunnel.
 type AgentProviderClient interface {
 	CreateSession(ctx context.Context, in *CreateAgentProviderSessionRequest, opts ...grpc.CallOption) (*AgentSession, error)
 	GetSession(ctx context.Context, in *GetAgentProviderSessionRequest, opts ...grpc.CallOption) (*AgentSession, error)
@@ -194,6 +199,11 @@ func (c *agentProviderClient) GetCapabilities(ctx context.Context, in *GetAgentP
 // AgentProviderServer is the server API for AgentProvider service.
 // All implementations must embed UnimplementedAgentProviderServer
 // for forward compatibility.
+//
+// AgentProvider is the authoritative agent data boundary. Read RPCs for
+// sessions, turns, turn events, and interactions should use provider-owned
+// control-plane state and should not require a live execution sandbox,
+// pod-level transport, or cached tunnel.
 type AgentProviderServer interface {
 	CreateSession(context.Context, *CreateAgentProviderSessionRequest) (*AgentSession, error)
 	GetSession(context.Context, *GetAgentProviderSessionRequest) (*AgentSession, error)

--- a/sdk/proto/v1/agent.proto
+++ b/sdk/proto/v1/agent.proto
@@ -565,6 +565,10 @@ message AgentManagerResolveInteractionRequest {
   string invocation_token = 5;
 }
 
+// AgentProvider is the authoritative agent data boundary. Read RPCs for
+// sessions, turns, turn events, and interactions should use provider-owned
+// control-plane state and should not require a live execution sandbox,
+// pod-level transport, or cached tunnel.
 service AgentProvider {
   rpc CreateSession(CreateAgentProviderSessionRequest) returns (AgentSession);
   rpc GetSession(GetAgentProviderSessionRequest) returns (AgentSession);

--- a/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.tonic.rs
+++ b/sdk/rust/src/generated/gestalt/provider/v1/gestalt.provider.v1.tonic.rs
@@ -1035,7 +1035,11 @@ pub mod agent_provider_client {
     )]
     use tonic::codegen::http::Uri;
     use tonic::codegen::*;
-    ///
+    /** AgentProvider is the authoritative agent data boundary. Read RPCs for
+     sessions, turns, turn events, and interactions should use provider-owned
+     control-plane state and should not require a live execution sandbox,
+     pod-level transport, or cached tunnel.
+    */
     #[derive(Debug, Clone)]
     pub struct AgentProviderClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1467,7 +1471,11 @@ pub mod agent_provider_server {
             request: tonic::Request<super::GetAgentProviderCapabilitiesRequest>,
         ) -> std::result::Result<tonic::Response<super::AgentProviderCapabilities>, tonic::Status>;
     }
-    ///
+    /** AgentProvider is the authoritative agent data boundary. Read RPCs for
+     sessions, turns, turn events, and interactions should use provider-owned
+     control-plane state and should not require a live execution sandbox,
+     pod-level transport, or cached tunnel.
+    */
     #[derive(Debug)]
     pub struct AgentProviderServer<T> {
         inner: Arc<T>,


### PR DESCRIPTION
## Summary
- Remove the gestaltd-owned agent session/turn projection store and bootstrap wiring so providers remain authoritative for agent read data.
- Keep route stores as advisory hints, with direct-read fanout that preserves transient errors, avoids deleting valid routes for inaccessible resources, and fails closed instead of returning stale projection data.
- Document the provider-owned durable read contract for sessions, turns, turn events, and interactions across server core, SDK Go, and the provider proto surface.

## Test plan
- [x] `cd gestaltd && go test ./services/agents/agentmanager`
- [x] `cd gestaltd && go test ./internal/bootstrap ./internal/server`
- [x] `cd gestaltd && go test ./...`
- [x] `cd sdk/go && go test ./...`
- [x] `git diff --check`
