### PR TITLE
Add server-managed connection presets

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1872,11 +1872,24 @@ type ConnectionDef struct {
 	Exposure          string                                  `yaml:"exposure,omitempty"`
 	Auth              ConnectionAuthDef                       `yaml:"auth"`
 	ConnectionParams  map[string]ConnectionParamDef           `yaml:"params"`
+	Presets           []ConnectionPresetDef                   `yaml:"presets,omitempty"`
 	CredentialRefresh *CredentialRefreshDef                   `yaml:"credentialRefresh,omitempty"`
 	Discovery         *providermanifestv1.ProviderDiscovery   `yaml:"-"`
 	PostConnect       *providermanifestv1.ProviderPostConnect `yaml:"-"`
 	ConnectionID      string                                  `yaml:"-"`
 	BindingResolved   bool                                    `yaml:"-"`
+}
+
+// ConnectionPresetDef declares a fixed, operator-owned instance target for a
+// connection flow. AuthorizationParams are applied only when the preset starts
+// OAuth; ExpectedMetadata is checked after post-connect metadata is available.
+type ConnectionPresetDef struct {
+	ID                  string            `yaml:"id"`
+	DisplayName         string            `yaml:"displayName,omitempty"`
+	Instance            string            `yaml:"instance,omitempty"`
+	ConnectionParams    map[string]string `yaml:"connectionParams,omitempty"`
+	AuthorizationParams map[string]string `yaml:"authorizationParams,omitempty"`
+	ExpectedMetadata    map[string]string `yaml:"expectedMetadata,omitempty"`
 }
 
 type CredentialRefreshDef = providermanifestv1.CredentialRefreshConfig
@@ -2050,6 +2063,9 @@ func MergeConnectionDef(dst *ConnectionDef, src *ConnectionDef) {
 	if len(src.ConnectionParams) > 0 {
 		dst.ConnectionParams = maps.Clone(src.ConnectionParams)
 	}
+	if src.Presets != nil {
+		dst.Presets = cloneConnectionPresets(src.Presets)
+	}
 	if src.CredentialRefresh != nil {
 		dst.CredentialRefresh = cloneCredentialRefreshDef(src.CredentialRefresh)
 	}
@@ -2065,6 +2081,20 @@ func MergeConnectionDef(dst *ConnectionDef, src *ConnectionDef) {
 	if src.BindingResolved {
 		dst.BindingResolved = true
 	}
+}
+
+func cloneConnectionPresets(src []ConnectionPresetDef) []ConnectionPresetDef {
+	if src == nil {
+		return nil
+	}
+	dst := make([]ConnectionPresetDef, len(src))
+	for i, preset := range src {
+		dst[i] = preset
+		dst[i].ConnectionParams = maps.Clone(preset.ConnectionParams)
+		dst[i].AuthorizationParams = maps.Clone(preset.AuthorizationParams)
+		dst[i].ExpectedMetadata = maps.Clone(preset.ExpectedMetadata)
+	}
+	return dst
 }
 
 func ManifestAuthToConnectionAuthDef(auth *providermanifestv1.ProviderAuth) ConnectionAuthDef {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -5809,6 +5809,39 @@ func TestValidateStructureCanonicalizesConnectionAliasBindings(t *testing.T) {
 	}
 }
 
+func TestValidateStructureRejectsTopLevelPresetUnknownConnectionParam(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		APIVersion: ConfigAPIVersion,
+		Connections: map[string]*ConnectionDef{
+			"slack-default": {
+				Mode: providermanifestv1.ConnectionModeUser,
+				Auth: ConnectionAuthDef{Type: providermanifestv1.AuthTypeOAuth2},
+				ConnectionParams: map[string]ConnectionParamDef{
+					"team": {},
+				},
+				Presets: []ConnectionPresetDef{
+					{
+						ID: "valon-mortgage",
+						ConnectionParams: map[string]string{
+							"unknown": "TMORT",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := ValidateStructure(cfg)
+	if err == nil {
+		t.Fatal("ValidateStructure() error = nil, want unknown preset connection parameter")
+	}
+	if !strings.Contains(err.Error(), `presets["valon-mortgage"].connectionParams references unknown parameter "unknown"`) {
+		t.Fatalf("ValidateStructure() error = %v, want unknown preset connection parameter", err)
+	}
+}
+
 func TestValidateStructureConnectionRefPreservesCredentialRefreshOverride(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -385,7 +385,8 @@ func connectionBindingHasCredentialMaterial(conn *ConnectionDef) bool {
 		len(conn.Auth.TokenMetadata) > 0 ||
 		len(conn.Auth.Credentials) > 0 ||
 		conn.Auth.AuthMapping != nil ||
-		len(conn.ConnectionParams) > 0
+		len(conn.ConnectionParams) > 0 ||
+		len(conn.Presets) > 0
 }
 
 func connectionBindingRequiresUserCredential(conn *ConnectionDef) bool {
@@ -404,6 +405,7 @@ func cloneConnectionDef(src ConnectionDef) ConnectionDef {
 	dst := src
 	dst.Auth = cloneConnectionAuthDef(src.Auth)
 	dst.ConnectionParams = maps.Clone(src.ConnectionParams)
+	dst.Presets = cloneConnectionPresets(src.Presets)
 	dst.CredentialRefresh = cloneCredentialRefreshDef(src.CredentialRefresh)
 	dst.PostConnect = providermanifestv1.CloneProviderPostConnect(src.PostConnect)
 	return dst
@@ -701,6 +703,9 @@ func validateTopLevelConnections(cfg *Config) error {
 			return fmt.Errorf("config validation: connections.%s mode %q is not supported", id, conn.Mode)
 		}
 		if err := validateCredentialRefresh(fmt.Sprintf("connections.%s", id), *conn); err != nil {
+			return err
+		}
+		if err := validateConnectionPresets(fmt.Sprintf("connections.%s", id), *conn, conn.ConnectionParams); err != nil {
 			return err
 		}
 		if len(conn.Auth.TokenExchangeDrivers) > 0 {
@@ -2401,6 +2406,9 @@ func validatePluginIntegrationConnections(name string, entry *ProviderEntry) err
 	if err := validateCredentialRefresh(fmt.Sprintf("integration %q plugin connection", name), plan.PluginConnection()); err != nil {
 		return err
 	}
+	if err := validateConnectionPresets(fmt.Sprintf("integration %q plugin connection", name), plan.PluginConnection(), plan.PluginConnection().ConnectionParams); err != nil {
+		return err
+	}
 	for _, connName := range plan.NamedConnectionNames() {
 		conn, _ := plan.NamedConnectionDef(connName)
 		if err := validateConnectionAuthMappings(name, conn.Auth, fmt.Sprintf("connection %q", connName)); err != nil {
@@ -2409,8 +2417,84 @@ func validatePluginIntegrationConnections(name string, entry *ProviderEntry) err
 		if err := validateCredentialRefresh(fmt.Sprintf("integration %q connection %q", name, connName), conn); err != nil {
 			return err
 		}
+		if err := validateConnectionPresets(fmt.Sprintf("integration %q connection %q", name, connName), conn, conn.ConnectionParams); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+func validateConnectionPresets(scope string, conn ConnectionDef, params map[string]ConnectionParamDef) error {
+	if len(conn.Presets) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for i, preset := range conn.Presets {
+		id := strings.TrimSpace(preset.ID)
+		if id == "" {
+			return fmt.Errorf("config validation: %s presets[%d].id is required", scope, i)
+		}
+		if !SafeConnectionValue(id) {
+			return fmt.Errorf("config validation: %s presets[%q].id contains invalid characters", scope, id)
+		}
+		if _, ok := seen[id]; ok {
+			return fmt.Errorf("config validation: %s presets contains duplicate id %q", scope, id)
+		}
+		seen[id] = struct{}{}
+		if instance := strings.TrimSpace(preset.Instance); instance != "" && !SafeInstanceValue(instance) {
+			return fmt.Errorf("config validation: %s presets[%q].instance contains invalid characters", scope, id)
+		}
+		for key, value := range preset.ConnectionParams {
+			if params != nil {
+				if _, ok := params[key]; !ok {
+					return fmt.Errorf("config validation: %s presets[%q].connectionParams references unknown parameter %q", scope, id, key)
+				}
+			}
+			if !safePresetValue(key) || !safePresetValue(value) {
+				return fmt.Errorf("config validation: %s presets[%q].connectionParams[%q] contains invalid characters", scope, id, key)
+			}
+		}
+		for key, value := range preset.AuthorizationParams {
+			if reservedOAuthAuthorizationParam(key) {
+				return fmt.Errorf("config validation: %s presets[%q].authorizationParams[%q] is reserved", scope, id, key)
+			}
+			if !safePresetValue(key) || !safePresetValue(value) {
+				return fmt.Errorf("config validation: %s presets[%q].authorizationParams[%q] contains invalid characters", scope, id, key)
+			}
+		}
+		for key, value := range preset.ExpectedMetadata {
+			if !safePresetValue(key) || !safePresetValue(value) {
+				return fmt.Errorf("config validation: %s presets[%q].expectedMetadata[%q] contains invalid characters", scope, id, key)
+			}
+		}
+	}
+	return nil
+}
+
+func reservedOAuthAuthorizationParam(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "client_id", "redirect_uri", "response_type", "scope", "state", "user_scope":
+		return true
+	default:
+		return false
+	}
+}
+
+func safePresetValue(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, ch := range value {
+		switch {
+		case ch >= 'a' && ch <= 'z':
+		case ch >= 'A' && ch <= 'Z':
+		case ch >= '0' && ch <= '9':
+		case ch == '.', ch == '_', ch == '-', ch == ':', ch == '/':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func validateCredentialRefresh(scope string, conn ConnectionDef) error {

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -44,6 +44,7 @@ type ResolvedConnectionDef struct {
 	Exposure          string
 	Auth              ConnectionAuthDef
 	Params            map[string]ConnectionParamDef
+	Presets           []ConnectionPresetDef
 	Discovery         *providermanifestv1.ProviderDiscovery
 	PostConnect       *providermanifestv1.ProviderPostConnect
 	CredentialRefresh *CredentialRefreshDef
@@ -58,6 +59,7 @@ func (r ResolvedConnectionDef) ConnectionDef() ConnectionDef {
 		Exposure:          r.Exposure,
 		Auth:              r.Auth,
 		ConnectionParams:  r.Params,
+		Presets:           cloneConnectionPresets(r.Presets),
 		Discovery:         r.Discovery,
 		PostConnect:       providermanifestv1.CloneProviderPostConnect(r.PostConnect),
 		CredentialRefresh: r.CredentialRefresh,
@@ -620,6 +622,7 @@ func resolvedConnectionDef(name string, conn ConnectionDef, source ResolvedConne
 		Exposure:          conn.Exposure,
 		Auth:              conn.Auth,
 		Params:            conn.ConnectionParams,
+		Presets:           cloneConnectionPresets(conn.Presets),
 		Discovery:         conn.Discovery,
 		PostConnect:       providermanifestv1.CloneProviderPostConnect(conn.PostConnect),
 		CredentialRefresh: conn.CredentialRefresh,

--- a/gestaltd/internal/server/connection_presets.go
+++ b/gestaltd/internal/server/connection_presets.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"fmt"
+	"maps"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+type resolvedConnectionPreset struct {
+	ID                  string
+	Instance            string
+	ConnectionParams    map[string]string
+	AuthorizationParams map[string]string
+	ExpectedMetadata    map[string]string
+}
+
+func resolveConnectionPreset(conn config.ConnectionDef, hasConnectionDef bool, req startOAuthRequest) (*resolvedConnectionPreset, map[string]string, string, error) {
+	mergedParams := maps.Clone(req.ConnectionParams)
+	requestedInstance := strings.TrimSpace(req.Instance)
+	presetID := strings.TrimSpace(req.Preset)
+	if presetID == "" {
+		return nil, mergedParams, requestedInstance, nil
+	}
+	if !config.SafeConnectionValue(presetID) {
+		return nil, nil, "", fmt.Errorf("preset contains invalid characters")
+	}
+	if !hasConnectionDef {
+		return nil, nil, "", fmt.Errorf("unknown connection preset: %s", presetID)
+	}
+
+	preset, ok := findConnectionPreset(conn.Presets, presetID)
+	if !ok {
+		return nil, nil, "", fmt.Errorf("unknown connection preset: %s", presetID)
+	}
+	if len(req.ConnectionParams) > 0 {
+		return nil, nil, "", fmt.Errorf("preset %q does not accept client connection parameters", presetID)
+	}
+	instance := strings.TrimSpace(preset.Instance)
+	if requestedInstance != "" && instance != "" && requestedInstance != instance {
+		return nil, nil, "", fmt.Errorf("preset %q requires instance %q", presetID, instance)
+	}
+	if instance != "" {
+		requestedInstance = instance
+	}
+	for key, value := range preset.ConnectionParams {
+		if existing, ok := mergedParams[key]; ok && existing != value {
+			return nil, nil, "", fmt.Errorf("preset %q requires connection parameter %q", presetID, key)
+		}
+		mergedParams[key] = value
+	}
+
+	return &resolvedConnectionPreset{
+		ID:                  presetID,
+		Instance:            instance,
+		ConnectionParams:    maps.Clone(preset.ConnectionParams),
+		AuthorizationParams: maps.Clone(preset.AuthorizationParams),
+		ExpectedMetadata:    maps.Clone(preset.ExpectedMetadata),
+	}, mergedParams, requestedInstance, nil
+}
+
+func findConnectionPreset(presets []config.ConnectionPresetDef, id string) (config.ConnectionPresetDef, bool) {
+	for _, preset := range presets {
+		if strings.TrimSpace(preset.ID) == id {
+			return preset, true
+		}
+	}
+	return config.ConnectionPresetDef{}, false
+}
+
+func presetID(preset *resolvedConnectionPreset) string {
+	if preset == nil {
+		return ""
+	}
+	return preset.ID
+}
+
+func presetExpectedMetadata(preset *resolvedConnectionPreset) map[string]string {
+	if preset == nil {
+		return nil
+	}
+	return maps.Clone(preset.ExpectedMetadata)
+}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -68,6 +68,7 @@ type connectionDefInfo struct {
 	Mode             string                         `json:"mode,omitempty"`
 	AuthTypes        []string                       `json:"authTypes"`
 	ConnectionParams map[string]connectionParamInfo `json:"connectionParams,omitempty"`
+	Presets          []connectionPresetInfo         `json:"presets,omitempty"`
 	CredentialFields []credentialFieldInfo          `json:"credentialFields"`
 	Status           string                         `json:"status"`
 	CredentialState  string                         `json:"credentialState"`
@@ -82,6 +83,15 @@ type connectionDefInfo struct {
 	connected      bool
 	connectable    bool
 	disconnectable bool
+}
+
+type connectionPresetInfo struct {
+	ID              string `json:"id"`
+	DisplayName     string `json:"displayName,omitempty"`
+	Instance        string `json:"instance,omitempty"`
+	Status          string `json:"status,omitempty"`
+	CredentialState string `json:"credentialState,omitempty"`
+	HealthState     string `json:"healthState,omitempty"`
 }
 
 type integrationInfo struct {

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -320,19 +320,20 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 type credentialMaterial struct {
-	SubjectID       string
-	AuthSource      string
-	ConnectionID    string
-	Integration     string
-	Connection      string
-	Instance        string
-	AccessToken     string
-	RefreshToken    string
-	TokenExpiresAt  *time.Time
-	MetadataJSON    string
-	ActorSubjectID  string
-	ActorUserID     string
-	ActorAuthSource string
+	SubjectID        string
+	AuthSource       string
+	ConnectionID     string
+	Integration      string
+	Connection       string
+	Instance         string
+	AccessToken      string
+	RefreshToken     string
+	TokenExpiresAt   *time.Time
+	MetadataJSON     string
+	ExpectedMetadata map[string]string
+	ActorSubjectID   string
+	ActorUserID      string
+	ActorAuthSource  string
 }
 
 type credentialActor struct {
@@ -563,6 +564,9 @@ func (s *Server) completeConnection(ctx context.Context, prov core.Provider, tm 
 	if err != nil {
 		return nil, err
 	}
+	if err := validateExpectedMetadata(tm.MetadataJSON, tm.ExpectedMetadata); err != nil {
+		return nil, err
+	}
 	if _, err := s.storeCredentialFromMaterial(ctx, tm); err != nil {
 		return nil, err
 	}
@@ -619,6 +623,26 @@ func (s *Server) applyProviderPostConnect(ctx context.Context, prov core.Provide
 	}
 	tm.MetadataJSON = merged
 	return tm, nil
+}
+
+func validateExpectedMetadata(metadataJSON string, expected map[string]string) error {
+	if len(expected) == 0 {
+		return nil
+	}
+	if strings.TrimSpace(metadataJSON) == "" {
+		return fmt.Errorf("connected account did not match the selected preset")
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
+		return fmt.Errorf("connected account metadata is invalid: %w", err)
+	}
+	for key, want := range expected {
+		got, ok := metadata[key]
+		if !ok || fmt.Sprintf("%v", got) != want {
+			return fmt.Errorf("connected account did not match the selected preset")
+		}
+	}
+	return nil
 }
 
 func manualConnectionAllowed(prov core.Provider, conn config.ConnectionDef, hasConnectionDef bool) bool {

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -20,6 +20,7 @@ type startOAuthRequest struct {
 	Integration      string            `json:"integration"`
 	Connection       string            `json:"connection"`
 	Instance         string            `json:"instance"`
+	Preset           string            `json:"preset"`
 	Scopes           []string          `json:"scopes"`
 	ConnectionParams map[string]string `json:"connectionParams"`
 }
@@ -57,7 +58,8 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, errOperationAccess.Error())
 		return
 	}
-	if conn, ok := s.effectiveConnectionDef(req.Integration, connection); ok {
+	conn, hasConnectionDef := s.effectiveConnectionDef(req.Integration, connection)
+	if hasConnectionDef {
 		if mode := config.ConnectionModeForConnection(conn); mode != "" {
 			connectionMode = metricutil.NormalizeConnectionMode(mode)
 		}
@@ -75,14 +77,21 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	subjectID, instance, err := s.resolveCredentialConnectionSetup(w, r, req.Instance)
+	preset, mergedConnectionParams, requestedInstance, err := resolveConnectionPreset(conn, hasConnectionDef, req)
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	subjectID, instance, err := s.resolveCredentialConnectionSetup(w, r, requestedInstance)
 	if err != nil {
 		auditErr = err
 		return
 	}
 	auditTarget = connectionAuditTarget(req.Integration, connection, instance)
 
-	connParams, ok := resolveConnectionParams(w, prov, req.ConnectionParams)
+	connParams, ok := resolveConnectionParams(w, prov, mergedConnectionParams)
 	if !ok {
 		auditErr = errors.New("invalid connection parameters")
 		return
@@ -100,6 +109,14 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	if authURL == "" {
 		authURL, verifier = handler.StartOAuth("_", req.Scopes)
 	}
+	if preset != nil && len(preset.AuthorizationParams) > 0 {
+		authURL, err = setURLQueryParams(authURL, preset.AuthorizationParams)
+		if err != nil {
+			auditErr = errors.New("failed to prepare oauth URL")
+			writeError(w, http.StatusInternalServerError, "failed to prepare oauth URL")
+			return
+		}
+	}
 
 	authSource := ""
 	if p != nil {
@@ -115,8 +132,10 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		Integration:      req.Integration,
 		Connection:       connection,
 		Instance:         instance,
+		Preset:           presetID(preset),
 		Verifier:         verifier,
 		ConnectionParams: connParams,
+		ExpectedMetadata: presetExpectedMetadata(preset),
 		ExpiresAt:        s.now().Add(integrationOAuthStateTTL).Unix(),
 	})
 	if err != nil {
@@ -267,15 +286,16 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	}
 
 	tm := credentialMaterial{
-		SubjectID:      state.SubjectID,
-		AuthSource:     state.AuthSource,
-		Integration:    providerName,
-		Connection:     state.Connection,
-		Instance:       callbackInstance,
-		AccessToken:    tokenResp.AccessToken,
-		RefreshToken:   tokenResp.RefreshToken,
-		TokenExpiresAt: tokenExpiresAt,
-		MetadataJSON:   metadata,
+		SubjectID:        state.SubjectID,
+		AuthSource:       state.AuthSource,
+		Integration:      providerName,
+		Connection:       state.Connection,
+		Instance:         callbackInstance,
+		AccessToken:      tokenResp.AccessToken,
+		RefreshToken:     tokenResp.RefreshToken,
+		TokenExpiresAt:   tokenExpiresAt,
+		MetadataJSON:     metadata,
+		ExpectedMetadata: state.ExpectedMetadata,
 	}
 	if conn, ok := s.effectiveConnectionDef(providerName, state.Connection); ok {
 		tm.ConnectionID = conn.ConnectionID

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -425,6 +425,7 @@ func (s *Server) connectionInfoFromAuth(integration, _ string, name, instanceCon
 		Mode:             string(displayMode),
 		AuthTypes:        []string{},
 		ConnectionParams: connectionParams,
+		Presets:          connectionPresetInfos(conn.Presets, connectionInstances, len(authTypes) > 0, ownerKindForPrincipal(p)),
 		CredentialFields: []credentialFieldInfo{},
 		Status:           status.Status,
 		CredentialState:  status.CredentialState,
@@ -456,6 +457,43 @@ func (s *Server) connectionInfoFromAuth(integration, _ string, name, instanceCon
 		info.CredentialFields = defaultManualCredentialFieldInfos()
 	}
 	return info, true
+}
+
+func connectionPresetInfos(presets []config.ConnectionPresetDef, instances []instanceInfo, connectable bool, ownerKind string) []connectionPresetInfo {
+	if len(presets) == 0 {
+		return nil
+	}
+	out := make([]connectionPresetInfo, 0, len(presets))
+	for _, preset := range presets {
+		instance := strings.TrimSpace(preset.Instance)
+		statusInstance := instance
+		if statusInstance == "" {
+			statusInstance = defaultTokenInstance
+		}
+		status := subjectConnectionStatus(instancesForPreset(instances, statusInstance), connectable, ownerKind)
+		out = append(out, connectionPresetInfo{
+			ID:              strings.TrimSpace(preset.ID),
+			DisplayName:     preset.DisplayName,
+			Instance:        instance,
+			Status:          status.Status,
+			CredentialState: status.CredentialState,
+			HealthState:     status.HealthState,
+		})
+	}
+	return out
+}
+
+func instancesForPreset(instances []instanceInfo, presetInstance string) []instanceInfo {
+	if presetInstance == "" {
+		return nil
+	}
+	out := make([]instanceInfo, 0, 1)
+	for _, instance := range instances {
+		if instance.Name == presetInstance {
+			out = append(out, instance)
+		}
+	}
+	return out
 }
 
 func cloneConnectionParamInfos(params map[string]connectionParamInfo) map[string]connectionParamInfo {

--- a/gestaltd/internal/server/oauth_state.go
+++ b/gestaltd/internal/server/oauth_state.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -26,8 +27,10 @@ type integrationOAuthState struct {
 	Integration      string            `json:"int"`
 	Connection       string            `json:"con,omitempty"`
 	Instance         string            `json:"ins,omitempty"`
+	Preset           string            `json:"pre,omitempty"`
 	Verifier         string            `json:"ver,omitempty"`
 	ConnectionParams map[string]string `json:"cp,omitempty"`
+	ExpectedMetadata map[string]string `json:"em,omitempty"`
 	ExpiresAt        int64             `json:"exp"`
 }
 
@@ -378,6 +381,24 @@ func setURLQueryParam(rawURL, key, value string) (string, error) {
 	}
 	q := u.Query()
 	q.Set(key, value)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func setURLQueryParams(rawURL string, params map[string]string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse URL: %w", err)
+	}
+	q := u.Query()
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		q.Set(key, params[key])
+	}
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -15622,6 +15622,196 @@ func TestStartIntegrationOAuth(t *testing.T) {
 	}
 }
 
+func TestListIntegrations_ConnectionPresets(t *testing.T) {
+	t.Parallel()
+
+	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack"}
+	handler := &testOAuthHandler{authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize"}
+	svc := testutil.NewStubServices(t)
+	user := seedUser(t, svc, "anonymous@gestalt")
+	seedSubjectToken(t, svc, principal.UserSubjectID(user.ID), "slack", testDefaultConnection, "default", "test-token")
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"slack": {
+				Connections: map[string]*config.ConnectionDef{
+					testDefaultConnection: {
+						Auth: config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeOAuth2},
+						Presets: []config.ConnectionPresetDef{
+							{
+								ID:          "default-workspace",
+								DisplayName: "Default Workspace",
+							},
+							{
+								ID:                  "valon-technologies",
+								DisplayName:         "Valon Technologies",
+								Instance:            "valon-technologies",
+								AuthorizationParams: map[string]string{"team": "TTECH"},
+								ExpectedMetadata:    map[string]string{"slack.team_id": "TTECH"},
+							},
+							{
+								ID:                  "valon-mortgage",
+								DisplayName:         "Valon Mortgage",
+								Instance:            "valon-mortgage",
+								AuthorizationParams: map[string]string{"team": "TMORT"},
+								ExpectedMetadata:    map[string]string{"slack.team_id": "TMORT"},
+							},
+						},
+					},
+				},
+			},
+		}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	text := string(body)
+	for _, fragment := range []string{"authorizationParams", "expectedMetadata"} {
+		if strings.Contains(text, fragment) {
+			t.Fatalf("integration response exposed server-only preset field %q: %s", fragment, text)
+		}
+	}
+
+	type presetInfo struct {
+		ID              string `json:"id"`
+		DisplayName     string `json:"displayName"`
+		Instance        string `json:"instance"`
+		Status          string `json:"status"`
+		CredentialState string `json:"credentialState"`
+	}
+	var integrations []struct {
+		Name        string `json:"name"`
+		Connections []struct {
+			Name    string       `json:"name"`
+			Presets []presetInfo `json:"presets"`
+		} `json:"connections"`
+	}
+	if err := json.Unmarshal(body, &integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 1 || len(integrations[0].Connections) != 1 {
+		t.Fatalf("integrations = %+v, want one slack connection", integrations)
+	}
+	presets := integrations[0].Connections[0].Presets
+	if !reflect.DeepEqual(presets, []presetInfo{
+		{ID: "default-workspace", DisplayName: "Default Workspace", Status: "ready", CredentialState: "connected"},
+		{ID: "valon-technologies", DisplayName: "Valon Technologies", Instance: "valon-technologies", Status: "needs_user_connection", CredentialState: "missing"},
+		{ID: "valon-mortgage", DisplayName: "Valon Mortgage", Instance: "valon-mortgage", Status: "needs_user_connection", CredentialState: "missing"},
+	}) {
+		t.Fatalf("presets = %+v", presets)
+	}
+}
+
+func TestStartIntegrationOAuth_ConnectionPreset(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubIntegrationWithAuthURL{
+		StubIntegration: coretesting.StubIntegration{N: "slack"},
+		authURL:         "https://slack.com/oauth/v2/authorize",
+	}
+	handler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"slack": {
+				Connections: map[string]*config.ConnectionDef{
+					testDefaultConnection: {
+						Auth: config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeOAuth2},
+						Presets: []config.ConnectionPresetDef{
+							{
+								ID:                  "valon-mortgage",
+								DisplayName:         "Valon Mortgage",
+								Instance:            "valon-mortgage",
+								AuthorizationParams: map[string]string{"team": "TMORT"},
+								ExpectedMetadata:    map[string]string{"slack.team_id": "TMORT"},
+							},
+						},
+					},
+				},
+			},
+		}
+		cfg.Services = testutil.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"integration":"slack","preset":"valon-mortgage"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	parsedURL, err := url.Parse(result["url"])
+	if err != nil {
+		t.Fatalf("parse auth URL: %v", err)
+	}
+	if got := parsedURL.Query().Get("team"); got != "TMORT" {
+		t.Fatalf("auth URL team = %q, want TMORT", got)
+	}
+	if got := parsedURL.Query().Get("state"); got != result["state"] {
+		t.Fatalf("auth URL state = %q, want returned state %q", got, result["state"])
+	}
+
+	conflictBody := bytes.NewBufferString(`{"integration":"slack","preset":"valon-mortgage","instance":"other"}`)
+	conflictReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", conflictBody)
+	conflictReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	conflictReq.Header.Set("Content-Type", "application/json")
+	conflictResp, err := http.DefaultClient.Do(conflictReq)
+	if err != nil {
+		t.Fatalf("conflict request: %v", err)
+	}
+	defer func() { _ = conflictResp.Body.Close() }()
+	if conflictResp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(conflictResp.Body)
+		t.Fatalf("expected 400 for conflicting preset instance, got %d: %s", conflictResp.StatusCode, body)
+	}
+
+	paramsBody := bytes.NewBufferString(`{"integration":"slack","preset":"valon-mortgage","connectionParams":{"team":"TMORT"}}`)
+	paramsReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", paramsBody)
+	paramsReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	paramsReq.Header.Set("Content-Type", "application/json")
+	paramsResp, err := http.DefaultClient.Do(paramsReq)
+	if err != nil {
+		t.Fatalf("connection params request: %v", err)
+	}
+	defer func() { _ = paramsResp.Body.Close() }()
+	if paramsResp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(paramsResp.Body)
+		t.Fatalf("expected 400 for client params with preset, got %d: %s", paramsResp.StatusCode, body)
+	}
+}
+
 func TestStartIntegrationOAuth_ServiceAccountDeniedByPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -16376,6 +16566,150 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			t.Fatalf("linked subject after conflict = %q, want %q", got, principal.UserSubjectID(admin.ID))
 		}
 	})
+}
+
+func TestIntegrationOAuthCallback_ConnectionPresetMetadata(t *testing.T) {
+	t.Parallel()
+
+	svc := testutil.NewStubServices(t)
+	handler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+		exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+			teamID := "TMORT"
+			if code == "wrong-workspace" {
+				teamID = "TTECH"
+			}
+			return &core.TokenResponse{
+				AccessToken: "slack-token-" + teamID,
+				Extra: map[string]any{
+					"team": map[string]any{"id": teamID},
+				},
+			}, nil
+		},
+	}
+	stub := &stubIntegrationWithAuthURL{
+		StubIntegration: coretesting.StubIntegration{N: "slack"},
+		authURL:         "https://slack.com/oauth/v2/authorize",
+		connectionParams: map[string]core.ConnectionParamDef{
+			"team_id": {
+				Required: true,
+				From:     "token_response",
+				Field:    "team.id",
+			},
+		},
+		postConnect: func(_ context.Context, token *core.ExternalCredential) (map[string]string, error) {
+			var metadata map[string]string
+			if err := json.Unmarshal([]byte(token.MetadataJSON), &metadata); err != nil {
+				return nil, err
+			}
+			return map[string]string{"slack.team_id": metadata["team_id"]}, nil
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, fmt.Errorf("bad token")
+				}
+				return &core.UserIdentity{Email: "user@example.com"}, nil
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"slack": {
+				Connections: map[string]*config.ConnectionDef{
+					testDefaultConnection: {
+						Auth: config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeOAuth2},
+						Presets: []config.ConnectionPresetDef{
+							{
+								ID:                  "valon-mortgage",
+								DisplayName:         "Valon Mortgage",
+								Instance:            "valon-mortgage",
+								AuthorizationParams: map[string]string{"team": "TMORT"},
+								ExpectedMetadata:    map[string]string{"slack.team_id": "TMORT"},
+							},
+						},
+					},
+				},
+			},
+		}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	start := func(t *testing.T) string {
+		t.Helper()
+		startBody := bytes.NewBufferString(`{"integration":"slack","preset":"valon-mortgage"}`)
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+		startReq.Header.Set("Content-Type", "application/json")
+		startReq.Header.Set("Authorization", "Bearer session-token")
+		startResp, err := http.DefaultClient.Do(startReq)
+		if err != nil {
+			t.Fatalf("start request: %v", err)
+		}
+		defer func() { _ = startResp.Body.Close() }()
+		if startResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(startResp.Body)
+			t.Fatalf("expected 200 from start-oauth, got %d: %s", startResp.StatusCode, body)
+		}
+		var startResult map[string]string
+		if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+			t.Fatalf("decoding start response: %v", err)
+		}
+		return startResult["state"]
+	}
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(start(t)), nil)
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusSeeOther {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 303, got %d: %s", resp.StatusCode, body)
+	}
+
+	u, _ := svc.Users.FindOrCreateUser(context.Background(), "user@example.com")
+	tokens, _ := svc.ExternalCredentials.ListCredentials(context.Background(), principal.UserSubjectID(u.ID))
+	if len(tokens) != 1 {
+		t.Fatalf("stored tokens = %+v, want one", tokens)
+	}
+	stored := tokens[0]
+	if stored.Instance != "valon-mortgage" {
+		t.Fatalf("stored instance = %q, want valon-mortgage", stored.Instance)
+	}
+	var metadata map[string]string
+	if err := json.Unmarshal([]byte(stored.MetadataJSON), &metadata); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if metadata["slack.team_id"] != "TMORT" {
+		t.Fatalf("stored slack.team_id = %q, want TMORT", metadata["slack.team_id"])
+	}
+
+	wrongReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=wrong-workspace&state="+url.QueryEscape(start(t)), nil)
+	wrongResp, err := noRedirect.Do(wrongReq)
+	if err != nil {
+		t.Fatalf("wrong callback request: %v", err)
+	}
+	defer func() { _ = wrongResp.Body.Close() }()
+	if wrongResp.StatusCode != http.StatusBadGateway {
+		body, _ := io.ReadAll(wrongResp.Body)
+		t.Fatalf("expected 502 for wrong workspace, got %d: %s", wrongResp.StatusCode, body)
+	}
+	tokens, _ = svc.ExternalCredentials.ListCredentials(context.Background(), principal.UserSubjectID(u.ID))
+	if len(tokens) != 1 {
+		t.Fatalf("wrong-workspace callback stored a credential: %+v", tokens)
+	}
 }
 
 func TestIntegrationOAuthCallback_InvalidState(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add connection preset config for OAuth-backed connections, including server-only authorization params and expected metadata checks.
- Thread preset selection through OAuth start/state/callback so credentials are stored only after the provider metadata matches the selected preset.
- Expose safe preset status data in integration listing without leaking server-only preset policy fields.

## Test plan
- [x] `go test ./internal/config ./internal/server`
- [x] Independent implementation review for preset validation, OAuth state, and callback enforcement