### PR TITLE
[codex] Restore Rust SDK proto module export

### DIFF
--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -34,6 +34,11 @@ pub mod telemetry;
 mod workflow;
 mod workflow_manager;
 
+#[doc(hidden)]
+pub mod proto {
+    pub use crate::generated::v1;
+}
+
 pub use agent::{
     AgentActor, AgentExecutionStatus, AgentHost, AgentHostError, AgentHostExecuteToolInput,
     AgentHostListToolsInput, AgentHostResolveConnectionInput, AgentInteraction,


### PR DESCRIPTION
## Summary
- Restore the public `gestalt::proto::v1` Rust SDK re-export that downstream provider tests use for generated gRPC test servers.
- Hide the generated proto module from rustdoc so the published SDK docs surface remains clean.

## Test plan
- [x] `cargo test` from `sdk/rust`
- [x] `cargo doc --no-deps && bash ../../docs/scripts/check-sdk-doc-leaks.sh rust target/doc/gestalt` from `sdk/rust`