### PR TITLE
Allow scoped validate to prepare scratch lock metadata

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -830,7 +830,10 @@ func (l *Lifecycle) LoadForStaticValidationAtPathsWithStatePaths(configPaths []s
 	if configHasProviderLoading(cfg) {
 		lock, lockErr = ReadLockfile(paths.lockfilePath)
 		if lockErr != nil && configRequiresStaticLock(cfg) {
-			if configRequiresRemoteStaticLock(cfg) || platform != providerpkg.CurrentPlatformString() || !os.IsNotExist(lockErr) {
+			canPrepareScratchLock := os.IsNotExist(lockErr) &&
+				platform == providerpkg.CurrentPlatformString() &&
+				(paths.pluginScope != "" || !configRequiresRemoteStaticLock(cfg))
+			if !canPrepareScratchLock {
 				if paths.pluginScope != "" {
 					return nil, fmt.Errorf("scoped validation for plugin %q requires an existing scoped lockfile for platform %q; pass --lockfile with that metadata or validate on the current platform without --platform: %w", paths.pluginScope, platform, lockErr)
 				}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -4315,6 +4315,92 @@ func TestLockAndSyncResolveSourceAuthSecretRefs(t *testing.T) {
 	}
 }
 
+func TestLoadForStaticValidationPluginScopePreparesMissingCurrentPlatformLock(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const (
+		packageSource = "github.com/acme/tools/private"
+		version       = "0.0.1-alpha.1"
+	)
+	archivePath := buildExecutableArchive(t, dir, "private-src", packageSource, version, providermanifestv1.KindPlugin, "private-plugin", "private-plugin-binary")
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSHA := sha256.Sum256(archiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/providers/private/provider-release.yaml":
+			metadataCount.Add(1)
+			data, err := yaml.Marshal(providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   "private.tar.gz",
+						SHA256: hex.EncodeToString(archiveSHA[:]),
+					},
+				},
+			})
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write(data)
+		case "/providers/private/private.tar.gz":
+			archiveCount.Add(1)
+			_, _ = w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	configPath := filepath.Join(dir, "gestaltd.yaml")
+	configYAML := "apiVersion: " + config.ConfigAPIVersion + "\n" +
+		requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) +
+		strings.Join([]string{
+			"server:",
+			"  providers:",
+			"    indexeddb: sqlite",
+			"  artifactsDir: " + filepath.ToSlash(filepath.Join(dir, "artifacts")),
+			"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"plugins:",
+			"  private:",
+			"    source: " + srv.URL + "/providers/private/provider-release.yaml",
+			"  unrelated:",
+			"    source: https://example.invalid/unrelated/provider-release.yaml",
+			"",
+		}, "\n")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err = NewLifecycle().
+		WithHTTPClient(srv.Client()).
+		LoadForStaticValidationAtPathsWithStatePaths([]string{configPath}, StatePaths{PluginScope: []string{"private"}}, StaticValidationOptions{})
+	if err != nil {
+		t.Fatalf("LoadForStaticValidationAtPathsWithStatePaths: %v", err)
+	}
+	if got := metadataCount.Load(); got == 0 {
+		t.Fatal("metadata server was not called")
+	}
+	if got := archiveCount.Load(); got == 0 {
+		t.Fatal("archive server was not called")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "artifacts", ".gestaltd", "scopes")); !os.IsNotExist(err) {
+		t.Fatalf("static validation should not leave scoped state in artifacts dir, got err=%v", err)
+	}
+}
+
 func TestStaticValidationNeedsSourceAuthSecretsSkipsNilRuntimeProviders(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Fix `gestaltd validate --plugin NAME` so current-platform local validation can prepare missing scoped lock metadata in scratch.
- Keep lock metadata required for unscoped remote validation and non-current `--platform` validation.

## Interface / behavior diff

No new CLI flags.

```diff
 gestaltd validate [--plugin NAME] [--config PATH]... [--lockfile PATH] [--platform os/arch] [--runtime]
```

```diff
- gestaltd validate --plugin workplaceHub --config valon-tools/deploy/config.yaml
- # failed if scoped lockfile was absent
+ gestaltd validate --plugin workplaceHub --config valon-tools/deploy/config.yaml
+ # prepares temporary scoped lock metadata, validates, then cleans it up
```

Code path change:

```diff
- if configRequiresRemoteStaticLock(cfg) || platform != providerpkg.CurrentPlatformString() || !os.IsNotExist(lockErr) {
+ canPrepareScratchLock := os.IsNotExist(lockErr) &&
+   platform == providerpkg.CurrentPlatformString() &&
+   (paths.pluginScope != "" || !configRequiresRemoteStaticLock(cfg))
+ if !canPrepareScratchLock {
```

Still locked:

```sh
gestaltd validate --plugin workplaceHub --platform linux/amd64 --config valon-tools/deploy/config.yaml
```

## Example

```sh
GITHUB_PAT="$(gh auth token)" gestaltd validate \
  --plugin workplaceHub \
  --config valon-tools/deploy/config.yaml
```

Note: this gets Valon Tools past the missing scoped-lock error. On macOS, `workplaceHub` still hits the separate `google` auth provider `darwin/arm64` package gap.

## Test plan

- [x] `go test ./internal/operator -run 'TestLoadForStaticValidationPluginScopePreparesMissingCurrentPlatformLock|Test.*StaticValidation' -count=1`
- [x] `go test ./internal/daemon -run 'TestE2EValidate(UsesScratchPreparedInstallsForLocalSourceConfigs|StaticPlatformRejectsExplicitMissingLockfile)' -count=1`
- [x] `git diff --check`

Test note: I changed the broad E2E regression into a focused operator lifecycle test. Existing tests cover unscoped/local-source scratch validation; this covers the missing scoped remote-source branch.