### PR TITLE
[codex] Honor company-wide agent session grants

### DIFF
--- a/gestaltd/services/agents/agentmanager/manager.go
+++ b/gestaltd/services/agents/agentmanager/manager.go
@@ -20,6 +20,7 @@ import (
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/services/agents/agentgrant"
 	"github.com/valon-technologies/gestalt/server/services/authorization"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
@@ -840,6 +841,37 @@ func (m *Manager) listSharedAgentSessions(ctx context.Context, p *principal.Prin
 	pageToken := ""
 	out := make([]*coreagent.Session, 0)
 	seen := map[string]struct{}{}
+	appendSharedResource := func(resource *core.ResourceRef) error {
+		if resource == nil || strings.TrimSpace(resource.GetType()) != authorization.ProviderResourceTypeAgentSession {
+			return nil
+		}
+		sessionID := strings.TrimSpace(resource.GetId())
+		if sessionID == "" {
+			return nil
+		}
+		if _, ok := seen[sessionID]; ok {
+			return nil
+		}
+		seen[sessionID] = struct{}{}
+		hydrationCtx, cancel := context.WithTimeout(ctx, agentReadHydrationTimeout)
+		session, err := m.findAccessibleSession(hydrationCtx, p, sessionID, providerName, authorization.ProviderAgentSessionActionView)
+		cancel()
+		if err != nil {
+			if agentProviderReturnedNotFound(err) || errors.Is(err, invocation.ErrAuthorizationDenied) {
+				return nil
+			}
+			return err
+		}
+		if req.State != "" && session.session.State != req.State {
+			return nil
+		}
+		if req.SummaryOnly {
+			out = append(out, summarizeAgentSession(session.session))
+		} else {
+			out = append(out, session.session)
+		}
+		return nil
+	}
 	for {
 		resp, err := m.searchSharedAgentSessionResources(ctx, &core.ResourceSearchRequest{
 			Subject: &core.SubjectRef{
@@ -855,40 +887,25 @@ func (m *Manager) listSharedAgentSessions(ctx context.Context, p *principal.Prin
 			return nil, err
 		}
 		for _, resource := range resp.GetResources() {
-			if resource == nil || strings.TrimSpace(resource.GetType()) != authorization.ProviderResourceTypeAgentSession {
-				continue
-			}
-			sessionID := strings.TrimSpace(resource.GetId())
-			if sessionID == "" {
-				continue
-			}
-			if _, ok := seen[sessionID]; ok {
-				continue
-			}
-			seen[sessionID] = struct{}{}
-			hydrationCtx, cancel := context.WithTimeout(ctx, agentReadHydrationTimeout)
-			session, err := m.findAccessibleSession(hydrationCtx, p, sessionID, providerName, authorization.ProviderAgentSessionActionView)
-			cancel()
-			if err != nil {
-				if agentProviderReturnedNotFound(err) || errors.Is(err, invocation.ErrAuthorizationDenied) {
-					continue
-				}
+			if err := appendSharedResource(resource); err != nil {
 				return nil, err
-			}
-			if req.State != "" && session.session.State != req.State {
-				continue
-			}
-			if req.SummaryOnly {
-				out = append(out, summarizeAgentSession(session.session))
-			} else {
-				out = append(out, session.session)
 			}
 		}
 		pageToken = strings.TrimSpace(resp.GetNextPageToken())
 		if pageToken == "" {
-			return out, nil
+			break
 		}
 	}
+	everyoneResources, err := m.listEveryoneSharedAgentSessionResources(ctx, pageSize)
+	if err != nil {
+		return nil, err
+	}
+	for _, resource := range everyoneResources {
+		if err := appendSharedResource(resource); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
 }
 
 func (m *Manager) searchSharedAgentSessionResources(ctx context.Context, req *core.ResourceSearchRequest) (*core.ResourceSearchResponse, error) {
@@ -905,6 +922,53 @@ func (m *Manager) searchSharedAgentSessionResources(ctx context.Context, req *co
 		}
 	}
 	return m.authorizationProvider.SearchResources(ctx, req)
+}
+
+func (m *Manager) listEveryoneSharedAgentSessionResources(ctx context.Context, pageSize int) ([]*core.ResourceRef, error) {
+	if m == nil || m.authorizationProvider == nil {
+		return nil, nil
+	}
+	if pageSize <= 0 {
+		pageSize = AgentListSummaryDefaultLimit
+	}
+	out := make([]*core.ResourceRef, 0)
+	seen := map[string]struct{}{}
+	pageToken := ""
+	for {
+		resp, err := m.authorizationProvider.ReadRelationships(ctx, &core.ReadRelationshipsRequest{
+			Target:    agentSessionEveryoneTarget(),
+			Relation:  authorization.ProviderAgentSessionRelationViewer,
+			PageSize:  int32(pageSize),
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, rel := range resp.GetRelationships() {
+			resource := rel.GetResource()
+			if resource == nil || strings.TrimSpace(resource.GetType()) != authorization.ProviderResourceTypeAgentSession {
+				continue
+			}
+			sessionID := strings.TrimSpace(resource.GetId())
+			if sessionID == "" {
+				continue
+			}
+			key := strings.TrimSpace(resource.GetType()) + "\x00" + sessionID
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, &core.ResourceRef{
+				Type: strings.TrimSpace(resource.GetType()),
+				Id:   sessionID,
+			})
+		}
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			break
+		}
+	}
+	return out, nil
 }
 
 func (m *Manager) UpdateSession(ctx context.Context, p *principal.Principal, req coreagent.ManagerUpdateSessionRequest) (session *coreagent.Session, err error) {
@@ -1746,9 +1810,12 @@ func (m *Manager) allowsAgentSessionAccess(ctx context.Context, p *principal.Pri
 		Resource: agentSessionResourceRef(session.ID),
 	})
 	if err != nil {
-		return false, owned
+		return m.agentSessionSharedWithEveryone(ctx, session.ID, action), owned
 	}
-	return decision.GetAllowed(), owned
+	if decision.GetAllowed() {
+		return true, owned
+	}
+	return m.agentSessionSharedWithEveryone(ctx, session.ID, action), owned
 }
 
 func agentSessionResourceRef(sessionID string) *core.ResourceRef {
@@ -1756,6 +1823,35 @@ func agentSessionResourceRef(sessionID string) *core.ResourceRef {
 		Type: authorization.ProviderResourceTypeAgentSession,
 		Id:   strings.TrimSpace(sessionID),
 	}
+}
+
+func (m *Manager) agentSessionSharedWithEveryone(ctx context.Context, sessionID, action string) bool {
+	if m == nil ||
+		m.authorizationProvider == nil ||
+		strings.TrimSpace(sessionID) == "" ||
+		strings.TrimSpace(action) != authorization.ProviderAgentSessionActionView {
+		return false
+	}
+	resp, err := m.authorizationProvider.ReadRelationships(ctx, &core.ReadRelationshipsRequest{
+		Target:   agentSessionEveryoneTarget(),
+		Relation: authorization.ProviderAgentSessionRelationViewer,
+		Resource: agentSessionResourceRef(sessionID),
+		PageSize: 1,
+	})
+	if err != nil {
+		return false
+	}
+	return len(resp.GetRelationships()) > 0
+}
+
+func agentSessionEveryoneTarget() *core.RelationshipTargetRef {
+	return &core.RelationshipTargetRef{Kind: &proto.RelationshipTarget_SubjectSet{SubjectSet: &core.SubjectSetRef{
+		Resource: &core.ResourceRef{
+			Type: authorization.ProviderResourceTypeEveryone,
+			Id:   authorization.ProviderResourceIDEveryoneGlobal,
+		},
+		Relation: authorization.ProviderRelationMember,
+	}}}
 }
 
 func filterProviderCandidatesByTokenPermission(p *principal.Principal, candidates []namedAgentProvider, providerName string) ([]namedAgentProvider, error) {

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -162,10 +162,13 @@ type routeCountingAgentProvider struct {
 type sharedSessionAuthorizationProvider struct {
 	directResources              []*core.ResourceRef
 	effectiveResources           []*core.ResourceRef
+	relationships                []*core.Relationship
 	effectiveErr                 error
+	readErr                      error
 	allowedSessions              map[string]struct{}
 	searchResourceCalls          int
 	effectiveSearchResourceCalls int
+	readRelationshipCalls        int
 }
 
 func (p *sharedSessionAuthorizationProvider) Name() string { return "shared-session-authz" }
@@ -216,8 +219,18 @@ func (*sharedSessionAuthorizationProvider) GetMetadata(context.Context) (*core.A
 	return &core.AuthorizationMetadata{}, nil
 }
 
-func (*sharedSessionAuthorizationProvider) ReadRelationships(context.Context, *core.ReadRelationshipsRequest) (*core.ReadRelationshipsResponse, error) {
-	return &core.ReadRelationshipsResponse{}, nil
+func (p *sharedSessionAuthorizationProvider) ReadRelationships(_ context.Context, req *core.ReadRelationshipsRequest) (*core.ReadRelationshipsResponse, error) {
+	p.readRelationshipCalls++
+	if p.readErr != nil {
+		return nil, p.readErr
+	}
+	out := make([]*core.Relationship, 0, len(p.relationships))
+	for _, rel := range p.relationships {
+		if sharedSessionRelationshipMatches(rel, req) {
+			out = append(out, rel)
+		}
+	}
+	return &core.ReadRelationshipsResponse{Relationships: out}, nil
 }
 
 func (*sharedSessionAuthorizationProvider) WriteRelationships(context.Context, *core.WriteRelationshipsRequest) error {
@@ -245,6 +258,37 @@ func cloneAuthzResources(resources []*core.ResourceRef) []*core.ResourceRef {
 		out = append(out, &core.ResourceRef{Type: resource.GetType(), Id: resource.GetId()})
 	}
 	return out
+}
+
+func sharedSessionRelationshipMatches(rel *core.Relationship, req *core.ReadRelationshipsRequest) bool {
+	if rel == nil || req == nil {
+		return rel != nil
+	}
+	if target := req.GetTarget(); target != nil {
+		if authorization.RelationshipTargetMapKey(rel.GetTarget(), rel.GetSubject()) != authorization.RelationshipTargetMapKey(target, nil) {
+			return false
+		}
+	}
+	if relation := strings.TrimSpace(req.GetRelation()); relation != "" && rel.GetRelation() != relation {
+		return false
+	}
+	if resource := req.GetResource(); resource != nil {
+		if got := rel.GetResource(); got == nil || got.GetType() != resource.GetType() || got.GetId() != resource.GetId() {
+			return false
+		}
+	}
+	return true
+}
+
+func everyoneAgentSessionViewerRelationship(sessionID string) *core.Relationship {
+	return &core.Relationship{
+		Relation: authorization.ProviderAgentSessionRelationViewer,
+		Resource: &core.ResourceRef{
+			Type: authorization.ProviderResourceTypeAgentSession,
+			Id:   sessionID,
+		},
+		Target: agentSessionEveryoneTarget(),
+	}
 }
 
 func newRouteCountingAgentProvider(name string) *routeCountingAgentProvider {
@@ -1553,6 +1597,81 @@ func TestManagerListSharedSessionsUsesEffectiveSearchResources(t *testing.T) {
 	}
 	if authz.searchResourceCalls != 0 {
 		t.Fatalf("SearchResources calls = %d, want 0", authz.searchResourceCalls)
+	}
+}
+
+func TestManagerGetSessionAllowsEveryoneSharedSession(t *testing.T) {
+	t.Parallel()
+
+	provider := newRouteCountingAgentProvider("alpha")
+	provider.sessions["shared-session"] = &coreagent.Session{
+		ID:           "shared-session",
+		ProviderName: "alpha",
+		State:        coreagent.SessionStateActive,
+		CreatedBy:    coreagent.Actor{SubjectID: principal.UserSubjectID("owner")},
+	}
+	authz := &sharedSessionAuthorizationProvider{
+		relationships: []*core.Relationship{
+			everyoneAgentSessionViewerRelationship("shared-session"),
+		},
+	}
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": provider},
+		},
+		AuthorizationProvider: authz,
+	})
+
+	session, err := manager.GetSession(context.Background(), &principal.Principal{SubjectID: principal.UserSubjectID("viewer")}, "shared-session")
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if session.ID != "shared-session" {
+		t.Fatalf("GetSession ID = %q, want shared-session", session.ID)
+	}
+	if authz.readRelationshipCalls == 0 {
+		t.Fatal("ReadRelationships calls = 0, want everyone grant lookup")
+	}
+}
+
+func TestManagerListSharedSessionsIncludesEveryoneSharedSessions(t *testing.T) {
+	t.Parallel()
+
+	provider := newRouteCountingAgentProvider("alpha")
+	provider.sessions["shared-session"] = &coreagent.Session{
+		ID:           "shared-session",
+		ProviderName: "alpha",
+		State:        coreagent.SessionStateActive,
+		CreatedBy:    coreagent.Actor{SubjectID: principal.UserSubjectID("owner")},
+	}
+	authz := &sharedSessionAuthorizationProvider{
+		relationships: []*core.Relationship{
+			everyoneAgentSessionViewerRelationship("shared-session"),
+		},
+	}
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers:   map[string]*routeCountingAgentProvider{"alpha": provider},
+		},
+		AuthorizationProvider: authz,
+	})
+
+	sessions, err := manager.ListSessions(context.Background(), &principal.Principal{SubjectID: principal.UserSubjectID("viewer")}, coreagent.ManagerListSessionsRequest{
+		SummaryOnly: true,
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "shared-session" {
+		t.Fatalf("ListSessions shared sessions = %#v, want shared-session", sessions)
+	}
+	if authz.readRelationshipCalls == 0 {
+		t.Fatal("ReadRelationships calls = 0, want everyone grant lookup")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Treat `agent_session#viewer@everyone:global#member` as an authenticated-user viewer grant for agent session reads.
- Include company-wide shared sessions when listing shared agent sessions.
- Keep the behavior scoped to agent-session viewer access so Slack sharing stays simple without adding Slack membership sync.

## Test plan
- [x] `go test ./services/agents/agentmanager -run 'TestManager(GetSessionAllowsEveryoneSharedSession|ListSharedSessionsIncludesEveryoneSharedSessions|ListSharedSessionsUsesEffectiveSearchResources|ListSharedSessionsReturnsSearchError|ListSharedSessionsFallsBackWhenEffectiveSearchUnimplemented|ListSharedSessionsHonorsProviderFilter|ListSharedSessionsReturnsProviderErrorWhenProviderUnavailable)$'`
- [x] `go test ./services/agents/agentmanager`
- [x] `go test ./services/agents/...`