### PR TITLE
Require build output for source UI providers

### DIFF
--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -45,8 +45,8 @@ Public UI bundles are configured through the `providers.ui` map.
 
 - Omit `providers.ui` to run headless with no public UI bundles.
 - Add `ui.<name>` entries with `source` and explicit `path` fields to mount static SPAs under public URL prefixes.
-- New custom UI bundles should usually check in frontend source and declare
-  top-level `build` in the UI manifest. Gestalt prepares the generated
+- New custom UI bundles should check in frontend source and declare top-level
+  `build.command` and `build.output` in the UI manifest. Gestalt prepares the generated
   `out`, `dist`, or `build` directory, records it as `spec.assetRoot`, and
   serves those static assets.
 - Gestalt does not serve frontend source directories at runtime. `serve --locked`

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -500,9 +500,10 @@ packaging.
 
 #### Source UI builds
 
-Source UI manifests should normally define top-level `build`. Gestalt runs it
-before source-manifest preparation, which lets UI packages generate static
-assets without checking built files into source control. The environment running
+Source UI manifests must define top-level `build.command` and `build.output`.
+Gestalt runs the command before source-manifest preparation, which lets UI
+packages generate static assets without checking built files into source
+control. The environment running
 `gestaltd lock`, `gestaltd sync --locked`, `gestaltd serve --path`, or
 `gestaltd provider release` must have the command's build tools available.
 `gestaltd serve --locked` only serves prepared static assets.
@@ -530,8 +531,7 @@ spec:
 
 Released UI packages still contain a concrete `spec.assetRoot`; Gestalt adds it
 to the prepared manifest from `build.output` and strips build metadata.
-`release.build` remains supported as a legacy source build hook, but new UI
-manifests should use top-level `build` and must not set both.
+`release.build` is not supported for UI source manifests.
 
 #### Release manifest for an executable provider
 

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -109,8 +109,8 @@ ui/
 
 ### Manifest
 
-A UI manifest declares `kind: ui`. Source manifests should normally use
-top-level `build` with an `output` directory. `spec.routes` is optional unless a
+A UI manifest declares `kind: ui`. Source manifests must use top-level `build`
+with an `output` directory. `spec.routes` is optional unless a
 deployment binds the UI to an `authorizationPolicy`.
 
 ```yaml

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -199,7 +199,6 @@ Raw GraphQL surfaces are not tunneled in v1.
 For TypeScript source plugins, `gestaltd serve --path` installs dependencies with
 `bun install` when a `package.json` is present and `node_modules` is missing.
 Source UI builds use the same bootstrap for Bun-managed build workdirs before
-`build.command` or legacy `release.build.command` when dependencies are
-missing.
+`build.command` when dependencies are missing.
 
 See [Configuration](/reference/configuration) for the relationship between `lock`, `sync --locked`, `serve --locked`, and `validate`.

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -103,14 +103,11 @@ The `spec` block for a `kind: plugin` manifest describes a plugin. It supports d
 
 Plugins that back mounted apps may declare their UI artifact in the plugin manifest. Deployment config still chooses whether to mount the app, which public path to use, and which authorization policy to bind. The manifest only says which UI bundle belongs to the plugin.
 
-`spec.ui` supports two mutually exclusive forms:
+`spec.ui` supports a path reference:
 
-| Field        | Type   | Purpose                                                                                                                                                                            |
-| ------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `path`       | string | Relative path to a co-packaged `kind: ui` manifest. Source releases may point at sibling UI packages; `gestaltd provider release` rewrites them into the archive automatically. |
-| `ref`        | string | Managed provider source ref for the owned UI bundle.                                                                                                                               |
-| `version`    | string | Optional version for `ref`. Defaults to the plugin manifest version when omitted.                                                                                                  |
-| `auth.token` | string | Optional source token used when resolving a private managed `ref`. Only valid with `ref`.                                                                                          |
+| Field  | Type   | Purpose                                                                                                                                                                         |
+| ------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `path` | string | Relative path to a co-packaged `kind: ui` manifest. Source releases may point at sibling UI packages; `gestaltd provider release` rewrites them into the archive automatically. |
 
 When a deployment sets `plugins.<name>.ui.path` and omits `plugins.<name>.ui.bundle`, Gestalt synthesizes the mounted UI binding from this block.
 
@@ -131,28 +128,8 @@ spec:
     path: ../ui/manifest.yaml
 ```
 
-Published-manifest example:
-
-```yaml
-kind: plugin
-source: github.com/acme/plugins/roadmap-review
-version: 1.0.0
-spec:
-  auth:
-    provider: server
-  connections:
-    default:
-      auth:
-        type: none
-  ui:
-    ref: github.com/acme/web/roadmap-review
-    version: 1.0.0
-    auth:
-      token:
-        secret:
-          provider: default
-          name: roadmap-review-ui-source-token
-```
+Released plugin manifests keep the same `spec.ui.path` shape, but the path is
+rewritten to the co-packaged UI manifest inside the archive.
 
 ### Connections
 
@@ -534,15 +511,13 @@ artifacts:
 ## UI Metadata
 
 The `spec` block for a `kind: ui` manifest describes a static UI package.
-Source UI manifests should normally declare top-level `build.output` to
-generate static assets during preparation. They may point at checked-in static
-assets with `spec.assetRoot` when the bundle is intentionally prebuilt.
-Released and prepared UI manifests always contain `spec.assetRoot` and do not
-contain top-level `build`.
+Source UI manifests must declare top-level `build.command` and `build.output`.
+Generated assets should stay out of source control. Released and prepared UI
+manifests always contain `spec.assetRoot` and do not contain top-level `build`.
 
 | Field       | Type         | Required | Purpose                                                                                                                     |
 | ----------- | ------------ | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `assetRoot` | string       | released: yes; source: when `build.output` is absent | Directory containing the built static assets.                                                                               |
+| `assetRoot` | string       | released: yes; source: no | Directory containing the built static assets in released and prepared packages. Source UI manifests use `build.output` instead. |
 | `routes`    | UIRoute[] | no       | Optional route-level authorization rules used when a deployment binds this UI to `providers.ui.<name>.authorizationPolicy`. |
 
 Each `spec.routes` entry declares a mounted path and the allowed human roles for that path. Path matching is exact or longest-prefix with a terminal `/*`. When a deployment sets `authorizationPolicy`, route definitions must have non-empty `allowedRoles`, and the manifest must include a route that covers `/`.
@@ -584,7 +559,7 @@ TypeScript, React, Next.js static export, Vite, or similar frontend source.
 | ----------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `command`   | string[] | yes      | Command argv to run before preparing the static assets.                                           |
 | `workdir`   | string   | no       | Manifest-relative directory where `command` runs. Defaults to the manifest directory.             |
-| `output`    | string   | source UI: yes when `spec.assetRoot` is absent | Manifest-relative directory containing generated static assets. Must match `spec.assetRoot` when both are set. |
+| `output`    | string   | source UI: yes | Manifest-relative directory containing generated static assets. |
 | `inputs`    | string[] | no       | Literal manifest-relative files or directories used to fingerprint local source UI builds. Glob syntax is not supported. |
 
 ## Artifacts
@@ -884,7 +859,7 @@ authoring flow.
   </Tabs.Tab>
 </Tabs>
 
-Source UI build steps should be declared with top-level `build`. Gestalt runs
+Source UI build steps must be declared with top-level `build`. Gestalt runs
 that command before source-manifest preparation during lock, sync, dev, and
 release packaging. This lets UI packages generate static bundles without
 checking built artifacts into source control.
@@ -910,9 +885,8 @@ spec:
       allowedRoles: [viewer, admin]
 ```
 
-`release.build` remains supported as a legacy build hook for source manifests,
-but new UI manifests should prefer top-level `build`. A manifest may not set
-both `build` and `release.build`.
+`release.build` remains supported for non-UI source manifests. UI source
+manifests must use top-level `build` instead.
 
 ## Release
 

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -1921,9 +1921,12 @@ func setupMountedUIDirAt(t *testing.T, uiDir string, routes []providermanifestv1
 		Source:      "github.com/test/ui/roadmap-review",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Roadmap Review UI",
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"go", "version"},
+			Output:  "dist",
+		},
 		Spec: &providermanifestv1.Spec{
-			AssetRoot: "dist",
-			Routes:    routes,
+			Routes: routes,
 		},
 	})
 
@@ -2008,7 +2011,10 @@ func setupDefaultLocalProvidersDir(t *testing.T, baseDir string) string {
 		Source:      "github.com/test/ui/default",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Default Gestalt UI",
-		Spec:        &providermanifestv1.Spec{AssetRoot: "dist"},
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"go", "version"},
+			Output:  "dist",
+		},
 	})
 
 	return providersDir

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -560,7 +560,7 @@ func releaseIncludesBuiltPluginArtifact(archives []releaseArchive) bool {
 	return false
 }
 func validateReleaseOutputDir(manifest *providermanifestv1.Manifest, sourceDir, outputDir string) error {
-	assetRootValue := providerpkg.EffectiveUIAssetRoot(manifest)
+	assetRootValue := providerpkg.SourceUIBuildOutput(manifest)
 	if manifest == nil || assetRootValue == "" {
 		return nil
 	}

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -972,9 +972,9 @@ func sourceUIHandler(manifestPath string) (http.Handler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read ui manifest after release build: %w", err)
 	}
-	assetRootValue := providerpkg.EffectiveUIAssetRoot(manifest)
+	assetRootValue := providerpkg.SourceUIBuildOutput(manifest)
 	if strings.TrimSpace(assetRootValue) == "" {
-		return nil, fmt.Errorf("ui manifest %q missing spec.assetRoot or build.output", manifestPath)
+		return nil, fmt.Errorf("ui manifest %q missing build.output", manifestPath)
 	}
 	assetRoot := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(assetRootValue))
 	if _, err := os.Stat(assetRoot); err != nil {

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -1846,17 +1846,10 @@ func TestRun_ProviderReleaseStagesOwnedUIPackage(t *testing.T) {
 		skipOnWin     bool
 	}{
 		{
-			name:          "prebuilt owned ui assets",
+			name:          "checked-in owned ui assets with build command",
 			fixture:       newSourceProviderReleaseFixtureWithOwnedUI,
 			wantFiles:     []string{"_owned_ui/roadmap-ui/branding/icon.svg", "_owned_ui/roadmap-ui/dist/index.html", "_owned_ui/roadmap-ui/dist/static/app.js"},
 			wantAssetRoot: filepath.Join("_owned_ui", "roadmap-ui", "dist"),
-		},
-		{
-			name:          "built owned ui assets",
-			fixture:       newSourceProviderReleaseFixtureWithBuiltOwnedUI,
-			wantFiles:     []string{"_owned_ui/roadmap-ui/branding/icon.svg", "_owned_ui/roadmap-ui/ui/dist/index.html", "_owned_ui/roadmap-ui/ui/dist/static/app.js"},
-			wantAssetRoot: filepath.Join("_owned_ui", "roadmap-ui", "ui", "dist"),
-			skipOnWin:     true,
 		},
 		{
 			name:          "source-built owned ui assets",
@@ -2025,36 +2018,23 @@ func TestRun_ProviderReleaseBuildsProviderSupportFilesBeforePackaging(t *testing
 	}
 }
 
-func TestRun_ProviderReleaseBuildsUIAssetsBeforePackaging(t *testing.T) {
+func TestRun_ProviderReleaseRejectsUILegacyReleaseBuild(t *testing.T) {
 	t.Parallel()
 
 	if runtime.GOOS == "windows" {
-		t.Skip("release build fixture uses POSIX shell")
+		t.Skip("legacy release-build fixture uses POSIX shell")
 	}
 
 	pluginDir := newBuiltUIReleaseFixture(t, t.TempDir())
-	outputDir := t.TempDir()
-	const testVersion = "0.0.3-build-ui"
-
-	runProviderReleaseCommand(t, pluginDir,
-		"--version", testVersion,
-		"--output", outputDir,
+	out, err := runProviderReleaseCommandResult(pluginDir,
+		"--version", "0.0.3-legacy-build-ui",
+		"--output", t.TempDir(),
 	)
-
-	archiveName := "gestalt-plugin-ui-test_v" + testVersion + ".tar.gz"
-	extractDir := extractReleasedArchive(t, outputDir, archiveName)
-	manifest := readReleasedManifest(t, outputDir, archiveName)
-	if manifest.Release != nil {
-		t.Fatalf("released manifest unexpectedly retained release metadata: %+v", manifest.Release)
+	if err == nil {
+		t.Fatalf("expected provider release to reject UI release.build\n%s", out)
 	}
-	for _, rel := range []string{
-		"branding/icon.svg",
-		"ui/out/index.html",
-		"ui/out/static/app.js",
-	} {
-		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
-			t.Fatalf("expected %s in archive: %v", rel, err)
-		}
+	if !strings.Contains(string(out), "release metadata is not supported for source ui manifests; use build instead") {
+		t.Fatalf("expected release.build rejection, got: %s", out)
 	}
 }
 
@@ -2136,8 +2116,9 @@ func TestRun_ProviderReleaseAllowsOverlappingSupportPaths(t *testing.T) {
 		Version:     "0.0.1",
 		DisplayName: "UI Overlap",
 		IconFile:    "out/icon.svg",
-		Spec: &providermanifestv1.Spec{
-			AssetRoot: "out",
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"go", "version"},
+			Output:  "out",
 		},
 	})
 	writeTestFile(t, pluginDir, "out/icon.svg", []byte("<svg></svg>\n"), 0o644)
@@ -3943,22 +3924,16 @@ func newBuiltUIReleaseFixture(t *testing.T, dir string) string {
 	if err := os.MkdirAll(pluginDir, 0755); err != nil {
 		t.Fatalf("MkdirAll(pluginDir): %v", err)
 	}
-	writeReleaseTestManifest(t, pluginDir, &providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindUI,
-		Source:      uiTestSource,
-		Version:     "0.0.1",
-		DisplayName: "UI Test",
-		IconFile:    releaseTestIconPath,
-		Release: &providermanifestv1.ReleaseMetadata{
-			Build: &providermanifestv1.ReleaseBuild{
-				Workdir: "ui",
-				Command: []string{"sh", "./build.sh"},
-			},
-		},
-		Spec: &providermanifestv1.Spec{
-			AssetRoot: "ui/out",
-		},
-	})
+	writeTestFile(t, pluginDir, providerpkg.ManifestFile, []byte(fmt.Sprintf(`{
+  "kind": "ui",
+  "source": %q,
+  "version": "0.0.1",
+  "displayName": "UI Test",
+  "iconFile": %q,
+  "release": {"build": {"workdir": "ui", "command": ["sh", "./build.sh"]}},
+  "spec": {"assetRoot": "ui/out"}
+}
+`, uiTestSource, releaseTestIconPath)), 0o644)
 	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
 	writeReleaseBuildScript(t, pluginDir, filepath.Join("ui", "build.sh"), "mkdir -p out/static\nprintf '<html></html>\\n' > out/index.html\nprintf 'console.log(\"ok\")\\n' > out/static/app.js\n")
 	return pluginDir
@@ -4003,51 +3978,14 @@ func newSourceProviderReleaseFixtureWithOwnedUI(t *testing.T, dir string) string
 		Version:     "0.0.1",
 		DisplayName: "Roadmap UI",
 		IconFile:    releaseTestIconPath,
-		Spec: &providermanifestv1.Spec{
-			AssetRoot: "dist",
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"go", "version"},
+			Output:  "dist",
 		},
 	})
 	writeTestFile(t, uiDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0o644)
 	writeTestFile(t, uiDir, "dist/index.html", []byte("<html>roadmap</html>\n"), 0o644)
 	writeTestFile(t, uiDir, "dist/static/app.js", []byte("console.log('roadmap')\n"), 0o644)
-
-	manifestPath := filepath.Join(pluginDir, providerpkg.ManifestFile)
-	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
-	if err != nil {
-		t.Fatalf("ReadSourceManifestFile(%s): %v", providerpkg.ManifestFile, err)
-	}
-	manifest.Spec.UI = &providermanifestv1.OwnedUI{Path: "../roadmap-ui/" + providerpkg.ManifestFile}
-	writeReleaseTestManifest(t, pluginDir, manifest)
-
-	return pluginDir
-}
-
-func newSourceProviderReleaseFixtureWithBuiltOwnedUI(t *testing.T, dir string) string {
-	t.Helper()
-
-	pluginDir := newSourceProviderReleaseFixture(t, dir)
-	uiDir := filepath.Join(dir, "roadmap-ui")
-	if err := os.MkdirAll(uiDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(uiDir): %v", err)
-	}
-	writeReleaseTestManifest(t, uiDir, &providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindUI,
-		Source:      "github.com/testowner/web/roadmap-ui",
-		Version:     "0.0.1",
-		DisplayName: "Roadmap UI",
-		IconFile:    releaseTestIconPath,
-		Release: &providermanifestv1.ReleaseMetadata{
-			Build: &providermanifestv1.ReleaseBuild{
-				Workdir: "ui",
-				Command: []string{"sh", "./build.sh"},
-			},
-		},
-		Spec: &providermanifestv1.Spec{
-			AssetRoot: "ui/dist",
-		},
-	})
-	writeTestFile(t, uiDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0o644)
-	writeReleaseBuildScript(t, uiDir, filepath.Join("ui", "build.sh"), "mkdir -p dist/static\nprintf '<html>roadmap</html>\\n' > dist/index.html\nprintf 'console.log(\"roadmap\")\\n' > dist/static/app.js\n")
 
 	manifestPath := filepath.Join(pluginDir, providerpkg.ManifestFile)
 	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
@@ -4108,8 +4046,9 @@ func newUIReleaseFixtureWithAssetRoot(t *testing.T, dir, assetRoot string) strin
 		Version:     "0.0.1",
 		DisplayName: "UI Test",
 		IconFile:    releaseTestIconPath,
-		Spec: &providermanifestv1.Spec{
-			AssetRoot: assetRoot,
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"go", "version"},
+			Output:  assetRoot,
 		},
 	})
 	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)

--- a/gestaltd/internal/daemon/testmain_test.go
+++ b/gestaltd/internal/daemon/testmain_test.go
@@ -226,7 +226,10 @@ func writeDefaultProvidersDir(baseDir string) (string, error) {
 		Source:      "github.com/test/ui/default",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Default Gestalt UI",
-		Spec:        &providermanifestv1.Spec{AssetRoot: "dist"},
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"go", "version"},
+			Output:  "dist",
+		},
 	}); err != nil {
 		return "", err
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -2213,7 +2213,7 @@ func fingerprintLocalUIBuildInputs(sourceDir, manifestPath string, manifest *pro
 		return "", fmt.Errorf("digest manifest: %w", err)
 	}
 
-	assetRoot := providerpkg.EffectiveUIAssetRoot(manifest)
+	assetRoot := providerpkg.SourceUIBuildOutput(manifest)
 	outputAbs := ""
 	if assetRoot != "" {
 		outputAbs = filepath.Clean(filepath.Join(sourceDir, filepath.FromSlash(assetRoot)))
@@ -3997,7 +3997,13 @@ func equivalentProviderManifestPath(current, expected string) bool {
 		return false
 	}
 	_, currentManifest, currentErr := providerpkg.ReadManifestFile(current)
+	if currentErr != nil {
+		_, currentManifest, currentErr = providerpkg.ReadSourceManifestFile(current)
+	}
 	_, expectedManifest, expectedErr := providerpkg.ReadManifestFile(expected)
+	if expectedErr != nil {
+		_, expectedManifest, expectedErr = providerpkg.ReadSourceManifestFile(expected)
+	}
 	if currentErr != nil || expectedErr != nil {
 		return false
 	}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -231,11 +231,17 @@ func writeLocalUIManifest(t *testing.T, dir, name, source, version string, spec 
 		}
 	}
 	manifestPath := filepath.Join(root, "manifest.yaml")
+	build := &providermanifestv1.SourceBuild{Command: []string{"go", "version"}, Output: "dist"}
+	if spec != nil && spec.AssetRoot != "" {
+		build.Output = spec.AssetRoot
+		spec.AssetRoot = ""
+	}
 	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindUI,
 		Source:      source,
 		Version:     version,
 		DisplayName: testDisplayName(name),
+		Build:       build,
 		Spec:        spec,
 	}, providerpkg.ManifestFormatYAML)
 	if err != nil {
@@ -1442,7 +1448,10 @@ plugins:
 				if err := os.WriteFile(filepath.Join(uiDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
 					t.Fatalf("WriteFile index.html: %v", err)
 				}
-				spec = &providermanifestv1.Spec{AssetRoot: "dist"}
+				build = &providermanifestv1.SourceBuild{
+					Command: []string{"go", "version"},
+					Output:  "dist",
+				}
 			}
 			if tc.wantPolicy != "" {
 				if spec == nil {
@@ -1596,7 +1605,10 @@ func TestLoadForExecutionAtPath_RejectsLockedExplicitLocalUIWithoutPreparedUILoc
 		Source:      "github.com/testowner/web/roadmap",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Roadmap UI",
-		Spec:        &providermanifestv1.Spec{AssetRoot: "dist"},
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"go", "version"},
+			Output:  "dist",
+		},
 	}, providerpkg.ManifestFormatYAML)
 	if err != nil {
 		t.Fatalf("EncodeManifest: %v", err)
@@ -3457,7 +3469,7 @@ func TestProviderFingerprint_Stable(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(assetRoot, "index.html"), []byte("<html></html>"), 0o644); err != nil {
 				t.Fatalf("WriteFile(asset): %v", err)
 			}
-			manifest += "spec:\n  assetRoot: assets\n"
+			manifest += "build:\n  command: [go, version]\n  output: assets\n"
 		}
 		if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
 			t.Fatalf("WriteFile(%q): %v", manifestPath, err)

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -97,7 +97,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "command"
+        "command",
+        "output"
       ],
       "properties": {
         "workdir": {

--- a/gestaltd/services/plugins/packageio/manifest.go
+++ b/gestaltd/services/plugins/packageio/manifest.go
@@ -147,17 +147,20 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 			return err
 		}
 	}
+	kind, err := ManifestKind(manifest)
+	if err != nil {
+		return err
+	}
 	if manifest.Release != nil {
 		if !sourceMode {
 			return fmt.Errorf("release metadata is only allowed in source manifests")
 		}
+		if kind == providermanifestv1.KindUI {
+			return fmt.Errorf("release metadata is not supported for source ui manifests; use build instead")
+		}
 		if err := validateReleaseMetadata(manifest.Release); err != nil {
 			return err
 		}
-	}
-	kind, err := ManifestKind(manifest)
-	if err != nil {
-		return err
 	}
 	if manifest.Build != nil {
 		if !sourceMode {
@@ -165,9 +168,6 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 		}
 		if kind != providermanifestv1.KindUI {
 			return fmt.Errorf("build metadata is only supported for ui manifests")
-		}
-		if manifest.Release != nil && manifest.Release.Build != nil {
-			return fmt.Errorf("build and release.build may not both be set")
 		}
 		if err := validateSourceBuild(manifest.Build); err != nil {
 			return err
@@ -259,13 +259,16 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 		if spec != nil {
 			assetRoot = spec.AssetRoot
 		}
-		buildOutput := ""
-		if manifest.Build != nil {
-			buildOutput = manifest.Build.Output
-		}
+		buildOutput := SourceUIBuildOutput(manifest)
 		if sourceMode {
-			if assetRoot == "" && buildOutput == "" {
-				return fmt.Errorf("spec.assetRoot or build.output is required for source ui manifests")
+			if assetRoot != "" {
+				return fmt.Errorf("spec.assetRoot is not allowed in source ui manifests; use build.output")
+			}
+			if manifest.Build == nil {
+				return fmt.Errorf("build is required for source ui manifests")
+			}
+			if buildOutput == "" {
+				return fmt.Errorf("build.output is required for source ui manifests")
 			}
 		} else if assetRoot == "" {
 			return fmt.Errorf("spec.assetRoot is required for ui manifests")
@@ -279,9 +282,6 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 			if err := validateRelativePackagePath(buildOutput, "build.output"); err != nil {
 				return err
 			}
-		}
-		if assetRoot != "" && buildOutput != "" && assetRoot != buildOutput {
-			return fmt.Errorf("build.output %q must match spec.assetRoot %q", buildOutput, assetRoot)
 		}
 		if spec != nil {
 			if err := validateUIRoutes(spec.Routes); err != nil {
@@ -502,12 +502,9 @@ func validateSourceBuild(build *providermanifestv1.SourceBuild) error {
 	return nil
 }
 
-func EffectiveUIAssetRoot(manifest *providermanifestv1.Manifest) string {
+func SourceUIBuildOutput(manifest *providermanifestv1.Manifest) string {
 	if manifest == nil {
 		return ""
-	}
-	if manifest.Spec != nil && manifest.Spec.AssetRoot != "" {
-		return manifest.Spec.AssetRoot
 	}
 	if manifest.Build != nil {
 		return manifest.Build.Output

--- a/gestaltd/services/plugins/providerpkg/manifest.go
+++ b/gestaltd/services/plugins/providerpkg/manifest.go
@@ -74,8 +74,8 @@ func ManifestEqual(a, b *providermanifestv1.Manifest) bool {
 	return packageio.ManifestEqual(a, b)
 }
 
-func EffectiveUIAssetRoot(manifest *providermanifestv1.Manifest) string {
-	return packageio.EffectiveUIAssetRoot(manifest)
+func SourceUIBuildOutput(manifest *providermanifestv1.Manifest) string {
+	return packageio.SourceUIBuildOutput(manifest)
 }
 
 func cloneManifest(manifest *providermanifestv1.Manifest) (*providermanifestv1.Manifest, error) {

--- a/gestaltd/services/plugins/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/services/plugins/providerpkg/manifest_workflow_test.go
@@ -115,20 +115,18 @@ func TestManifestWorkflow_RoundTripsUIPackage(t *testing.T) {
 
 	root := t.TempDir()
 	sourceDir := filepath.Join(root, "ui")
-	manifest := &providermanifestv1.Manifest{
-		Kind:    providermanifestv1.KindUI,
-		Source:  "github.com/acme/plugins/ui",
-		Version: "1.0.0",
-		Spec: &providermanifestv1.Spec{
-			AssetRoot: "ui/dist",
-			Routes: []providermanifestv1.UIRoute{
-				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
-				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
-			},
-		},
-	}
-
-	mustWriteManifestData(t, sourceDir, "manifest.yml", mustManifestYAML(t, manifest))
+	mustWriteManifestData(t, sourceDir, "manifest.yml", []byte(`
+kind: ui
+source: github.com/acme/plugins/ui
+version: 1.0.0
+spec:
+  assetRoot: ui/dist
+  routes:
+    - path: /admin/*
+      allowedRoles: [admin]
+    - path: /*
+      allowedRoles: [viewer, admin]
+`))
 	mustWriteFile(t, filepath.Join(sourceDir, "ui", "dist", "index.html"), []byte("<!doctype html><title>ui</title>"), 0o644)
 
 	_, manifest, gotPath, err := LoadManifestFromPath(sourceDir)
@@ -222,15 +220,9 @@ func TestLoadManifestFromPath_PrefersManifestFileOrder(t *testing.T) {
 				case "manifest.yaml":
 					source = "github.com/acme/plugins/yaml-first"
 				}
-				manifest := &providermanifestv1.Manifest{
-					Kind:    providermanifestv1.KindUI,
-					Source:  source,
-					Version: "1.0.0",
-					Spec:    &providermanifestv1.Spec{AssetRoot: "ui"},
-				}
-				data := mustManifestYAML(t, manifest)
+				data := []byte(fmt.Sprintf("kind: ui\nsource: %s\nversion: 1.0.0\nspec:\n  assetRoot: ui\n", source))
 				if filepath.Ext(name) == ".json" {
-					data = mustManifestJSON(t, manifest)
+					data = []byte(fmt.Sprintf(`{"kind":"ui","source":%q,"version":"1.0.0","spec":{"assetRoot":"ui"}}`, source))
 				}
 				mustWriteManifestData(t, dir, name, data)
 			}
@@ -443,7 +435,31 @@ func TestManifestWorkflow_SourceUIBuildValidation(t *testing.T) {
 		wantErr    string
 	}{
 		{
-			name: "source ui may use build output without asset root",
+			name: "source ui rejects asset root",
+			manifest: `
+kind: ui
+source: github.com/acme/plugins/source-ui
+version: 1.0.0
+spec:
+  assetRoot: dist
+`,
+			readSource: true,
+			wantErr:    "spec.assetRoot is not allowed in source ui manifests; use build.output",
+		},
+		{
+			name: "source ui requires build output",
+			manifest: `
+kind: ui
+source: github.com/acme/plugins/source-ui
+version: 1.0.0
+build:
+  command: [npm, run, build]
+`,
+			readSource: true,
+			wantErr:    "build.output is required for source ui manifests",
+		},
+		{
+			name: "source ui uses build output",
 			manifest: `
 kind: ui
 source: github.com/acme/plugins/source-ui
@@ -453,6 +469,16 @@ build:
   output: dist
 `,
 			readSource: true,
+		},
+		{
+			name: "released ui uses asset root",
+			manifest: `
+kind: ui
+source: github.com/acme/plugins/released-ui
+version: 1.0.0
+spec:
+  assetRoot: dist
+`,
 		},
 		{
 			name: "released ui rejects build metadata",
@@ -469,7 +495,7 @@ spec:
 			wantErr: "build metadata is only allowed in source ui manifests",
 		},
 		{
-			name: "source ui rejects build and release build together",
+			name: "source ui rejects release metadata",
 			manifest: `
 kind: ui
 source: github.com/acme/plugins/source-ui
@@ -480,26 +506,9 @@ build:
 release:
   build:
     command: [npm, run, build]
-spec:
-  assetRoot: dist
 `,
 			readSource: true,
-			wantErr:    "build and release.build may not both be set",
-		},
-		{
-			name: "source ui rejects mismatched build output",
-			manifest: `
-kind: ui
-source: github.com/acme/plugins/source-ui
-version: 1.0.0
-build:
-  command: [npm, run, build]
-  output: dist
-spec:
-  assetRoot: out
-`,
-			readSource: true,
-			wantErr:    "build.output \"dist\" must match spec.assetRoot \"out\"",
+			wantErr:    "release metadata is not supported for source ui manifests; use build instead",
 		},
 		{
 			name: "source ui rejects input globs",
@@ -526,12 +535,11 @@ build:
 			dir := t.TempDir()
 			manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(tc.manifest))
 
-			var manifest *providermanifestv1.Manifest
 			var err error
 			if tc.readSource {
-				_, manifest, err = ReadSourceManifestFile(manifestPath)
+				_, _, err = ReadSourceManifestFile(manifestPath)
 			} else {
-				_, manifest, err = ReadManifestFile(manifestPath)
+				_, _, err = ReadManifestFile(manifestPath)
 			}
 			if tc.wantErr != "" {
 				if err == nil {
@@ -544,9 +552,6 @@ build:
 			}
 			if err != nil {
 				t.Fatalf("read manifest: %v", err)
-			}
-			if got := EffectiveUIAssetRoot(manifest); got != "dist" {
-				t.Fatalf("EffectiveUIAssetRoot = %q, want dist", got)
 			}
 		})
 	}

--- a/gestaltd/services/plugins/providerpkg/prepared_stage.go
+++ b/gestaltd/services/plugins/providerpkg/prepared_stage.go
@@ -291,7 +291,7 @@ func buildPreparedInstallSourceManifest(srcManifest *providermanifestv1.Manifest
 	manifest.Version = version
 	manifest.Release = nil
 	if manifest.Kind == providermanifestv1.KindUI {
-		if assetRoot := EffectiveUIAssetRoot(srcManifest); assetRoot != "" {
+		if assetRoot := SourceUIBuildOutput(srcManifest); assetRoot != "" {
 			if manifest.Spec == nil {
 				manifest.Spec = &providermanifestv1.Spec{}
 			}

--- a/gestaltd/services/plugins/providerpkg/source_build.go
+++ b/gestaltd/services/plugins/providerpkg/source_build.go
@@ -30,6 +30,9 @@ func EffectiveSourceBuild(manifest *providermanifestv1.Manifest) *ResolvedSource
 			Inputs:  append([]string(nil), manifest.Build.Inputs...),
 		}
 	}
+	if providermanifestv1.NormalizeKind(manifest.Kind) == providermanifestv1.KindUI {
+		return nil
+	}
 	if manifest.Release != nil && manifest.Release.Build != nil {
 		return &ResolvedSourceBuild{
 			Label:   "release.build",


### PR DESCRIPTION
## Summary
- Remove the legacy source UI interfaces that used `spec.assetRoot` or `release.build`; source `kind: ui` manifests now require top-level `build.command` and `build.output`.
- Keep prepared/released UI serving unchanged: package preparation writes `spec.assetRoot` from `build.output` and strips build metadata before runtime serving.
- Replace the mixed `EffectiveUIAssetRoot` fallback with phase-specific helpers for source build output and released asset roots.
- Update plugin-owned UI release, local `serve --path`, release output validation, schema, tests, and docs to match the narrowed interface.
- Example source UI manifest:

```yaml
kind: ui
source: github.com/acme/apps/roadmap-ui
version: 0.0.1
build:
  command: [npm, run, build]
  output: dist
```

## Test plan
- [x] `cd gestaltd && go test ./services/plugins/providerpkg ./services/plugins/packageio`
- [x] `cd gestaltd && go test ./internal/operator ./internal/daemon ./internal/config ./internal/server`
- [x] `cd gestaltd && go test ./services/plugins/providerpkg ./services/plugins/packageio ./internal/operator ./internal/daemon ./internal/config ./internal/server`