### PR TITLE
Resolve provider snapshots by Gestalt toolchain

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -133,7 +133,9 @@ supply a token.
 
 `providerSnapshotRepositories` declares immutable artifact roots for commit-pinned
 git provider sources. Snapshot repositories are used by `source.git` entries
-that set `artifactRepository`.
+that set `artifactRepository`. Snapshot artifact paths include both the Gestalt
+toolchain commit and the provider commit, so the repository must declare the
+Gestalt commit used to package the snapshots.
 
 ```yaml
 providerSnapshotRepositories:
@@ -145,7 +147,7 @@ providerSnapshotRepositories:
 | Field | Description |
 | --- | --- |
 | `providerSnapshotRepositories.<name>.url` | HTTP(S) root containing deterministic snapshot `provider-release.yaml` files and archives. |
-| `providerSnapshotRepositories.<name>.gestaltRef` | Optional full Gestalt commit SHA expected for snapshots from this repository. |
+| `providerSnapshotRepositories.<name>.gestaltRef` | Full Gestalt commit SHA used to package snapshots from this repository. Required when `source.git.materialization` is `snapshot`. |
 
 ## `server`
 
@@ -1244,12 +1246,14 @@ source:
 
 To consume prebuilt snapshots, set `artifactRepository` and an explicit
 `materialization: snapshot`. Snapshot materialization never falls back to git
-or provider indexes:
+or provider indexes. The metadata URL is resolved under
+`<url>/gestalt/<gestaltRef>/github.com/<owner>/<repo>/<providerRef>/<providerPath>/provider-release.yaml`:
 
 ```yaml
 providerSnapshotRepositories:
   acme:
     url: https://storage.googleapis.com/acme-gestalt-provider-snapshots
+    gestaltRef: 651a5c30feb995c9364c38f63d0d5c3880bc2055
 
 plugins:
   github:

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -6275,6 +6275,35 @@ func TestLoadErrors(t *testing.T) {
 	})
 }
 
+func TestValidateProviderSnapshotRepositoryReferencesRequiresGestaltRef(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		ProviderSnapshotRepositories: map[string]ProviderSnapshotRepositoryConfig{
+			"valon": {URL: "https://example.invalid/snapshots"},
+		},
+		Plugins: map[string]*ProviderEntry{
+			"alpha": {
+				Source: ProviderSource{Git: &GitSourceDef{
+					Repo:               "https://github.com/acme/providers.git",
+					Ref:                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Path:               "plugins/alpha/manifest.yaml",
+					ArtifactRepository: "valon",
+					Materialization:    "snapshot",
+				}},
+			},
+		},
+	}
+
+	err := validateProviderSnapshotRepositoryReferences(cfg)
+	if err == nil {
+		t.Fatal("expected missing gestaltRef error")
+	}
+	if !strings.Contains(err.Error(), "providerSnapshotRepositories.valon.gestaltRef") {
+		t.Fatalf("error = %v, want gestaltRef", err)
+	}
+}
+
 func TestLoad_ResolvesRelativePluginSourcePath(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -93,6 +93,9 @@ func ValidateCanonicalStructure(cfg *Config) error {
 	if err := validateProviderSnapshotRepositories(cfg); err != nil {
 		return err
 	}
+	if err := validateProviderSnapshotRepositoryReferences(cfg); err != nil {
+		return err
+	}
 
 	for _, collection := range []struct {
 		kind    HostProviderKind
@@ -237,6 +240,42 @@ func validateProviderSnapshotRepositories(cfg *Config) error {
 		}
 	}
 	return nil
+}
+
+func validateProviderSnapshotRepositoryReferences(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	var validationErr error
+	collectProviderSources(cfg, func(source ProviderSource) {
+		if validationErr != nil {
+			return
+		}
+		git := source.GitSource()
+		if git == nil {
+			return
+		}
+		materialization := strings.TrimSpace(git.Materialization)
+		if materialization == "" {
+			materialization = "source"
+		}
+		if materialization != "snapshot" {
+			return
+		}
+		repoName := strings.TrimSpace(git.ArtifactRepository)
+		if repoName == "" {
+			return
+		}
+		repo, ok := cfg.ProviderSnapshotRepositories[repoName]
+		if !ok {
+			validationErr = fmt.Errorf("config validation: providerSnapshotRepositories.%s is required by source.git.artifactRepository", repoName)
+			return
+		}
+		if strings.TrimSpace(repo.GestaltRef) == "" {
+			validationErr = fmt.Errorf("config validation: providerSnapshotRepositories.%s.gestaltRef is required for source.git.materialization %q", repoName, materialization)
+		}
+	})
+	return validationErr
 }
 
 func isFullGitSHA(value string) bool {

--- a/gestaltd/internal/operator/git_source.go
+++ b/gestaltd/internal/operator/git_source.go
@@ -111,6 +111,10 @@ func resolveGitSnapshotSource(cfg *config.Config, entry *config.ProviderEntry) (
 	if !ok {
 		return gitSnapshotSource{}, fmt.Errorf("providerSnapshotRepositories.%s is not configured", repoName)
 	}
+	gestaltRef := strings.ToLower(strings.TrimSpace(repo.GestaltRef))
+	if gestaltRef == "" {
+		return gitSnapshotSource{}, fmt.Errorf("providerSnapshotRepositories.%s.gestaltRef is required for source.git snapshots", repoName)
+	}
 	owner, name, err := githubRepoPath(git.Repo)
 	if err != nil {
 		return gitSnapshotSource{}, err
@@ -121,14 +125,14 @@ func resolveGitSnapshotSource(cfg *config.Config, entry *config.ProviderEntry) (
 	if providerDir == "." {
 		providerDir = ""
 	}
-	parts := []string{base, "github.com", owner, name, ref}
+	parts := []string{base, "gestalt", gestaltRef, "github.com", owner, name, ref}
 	if providerDir != "" {
 		parts = append(parts, strings.Split(providerDir, "/")...)
 	}
 	parts = append(parts, "provider-release.yaml")
 	return gitSnapshotSource{
 		MetadataURL: strings.Join(parts, "/"),
-		GestaltRef:  strings.TrimSpace(repo.GestaltRef),
+		GestaltRef:  gestaltRef,
 	}, nil
 }
 

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -688,7 +688,7 @@ func TestLifecycleGitSourceSnapshotRequireContract(t *testing.T) {
 		ref           = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 		gestaltRef    = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 		packageSource = "github.com/acme/providers/plugins/alpha"
-		version       = "0.0.0-snapshot.gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		version       = "0.0.0-snapshot.gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.gestalt.gbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	)
 	archivePath := buildV2Archive(t, dir, packageSource, version, "snapshot-binary")
 	archiveData, err := os.ReadFile(archivePath)
@@ -703,7 +703,7 @@ func TestLifecycleGitSourceSnapshotRequireContract(t *testing.T) {
 	var archiveCount atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/snapshots/github.com/acme/providers/" + ref + "/plugins/alpha/provider-release.yaml":
+		case "/snapshots/gestalt/" + gestaltRef + "/github.com/acme/providers/" + ref + "/plugins/alpha/provider-release.yaml":
 			metadataCount.Add(1)
 			metadata := providerReleaseMetadata{
 				Schema:        providerReleaseSchemaName,
@@ -724,7 +724,7 @@ func TestLifecycleGitSourceSnapshotRequireContract(t *testing.T) {
 				t.Fatalf("marshal metadata: %v", err)
 			}
 			_, _ = w.Write(data)
-		case "/snapshots/github.com/acme/providers/" + ref + "/plugins/alpha/alpha.tar.gz":
+		case "/snapshots/gestalt/" + gestaltRef + "/github.com/acme/providers/" + ref + "/plugins/alpha/alpha.tar.gz":
 			archiveCount.Add(1)
 			_, _ = w.Write(archiveData)
 		default:
@@ -775,7 +775,7 @@ plugins:
 	if entry.SourceRef.ResolvedGestaltRef != gestaltRef {
 		t.Fatalf("resolvedGestaltRef = %q, want %q", entry.SourceRef.ResolvedGestaltRef, gestaltRef)
 	}
-	if entry.Source != srv.URL+"/snapshots/github.com/acme/providers/"+ref+"/plugins/alpha/provider-release.yaml" {
+	if entry.Source != srv.URL+"/snapshots/gestalt/"+gestaltRef+"/github.com/acme/providers/"+ref+"/plugins/alpha/provider-release.yaml" {
 		t.Fatalf("source = %q", entry.Source)
 	}
 	if entry.Version != version {
@@ -797,7 +797,7 @@ func TestLifecycleGitSourceSnapshotRequirePrimesSecretsProvider(t *testing.T) {
 		ref           = "cccccccccccccccccccccccccccccccccccccccc"
 		gestaltRef    = "dddddddddddddddddddddddddddddddddddddddd"
 		packageSource = "github.com/acme/providers/secrets/google"
-		version       = "0.0.0-snapshot.gcccccccccccccccccccccccccccccccccccccccc"
+		version       = "0.0.0-snapshot.gcccccccccccccccccccccccccccccccccccccccc.gestalt.gdddddddddddddddddddddddddddddddddddddddd"
 	)
 	archivePath := buildV2ArchiveForKind(t, dir, providermanifestv1.KindSecrets, packageSource, version, artifactRelPath("secrets-provider"), "secrets-binary")
 	archiveData, err := os.ReadFile(archivePath)
@@ -812,7 +812,7 @@ func TestLifecycleGitSourceSnapshotRequirePrimesSecretsProvider(t *testing.T) {
 	var archiveCount atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/snapshots/github.com/acme/providers/" + ref + "/secrets/google/provider-release.yaml":
+		case "/snapshots/gestalt/" + gestaltRef + "/github.com/acme/providers/" + ref + "/secrets/google/provider-release.yaml":
 			metadataCount.Add(1)
 			metadata := providerReleaseMetadata{
 				Schema:        providerReleaseSchemaName,
@@ -833,7 +833,7 @@ func TestLifecycleGitSourceSnapshotRequirePrimesSecretsProvider(t *testing.T) {
 				t.Fatalf("marshal metadata: %v", err)
 			}
 			_, _ = w.Write(data)
-		case "/snapshots/github.com/acme/providers/" + ref + "/secrets/google/secrets.tar.gz":
+		case "/snapshots/gestalt/" + gestaltRef + "/github.com/acme/providers/" + ref + "/secrets/google/secrets.tar.gz":
 			archiveCount.Add(1)
 			_, _ = w.Write(archiveData)
 		default:


### PR DESCRIPTION
## Summary

- Resolve `source.git.materialization: snapshot` URLs under `providerSnapshotRepositories.<name>.url/gestalt/<gestaltRef>/...` so snapshot identity includes both the Gestalt toolchain commit and provider commit.
- Require `providerSnapshotRepositories.<name>.gestaltRef` when a config uses that repository for git snapshot materialization.
- Update docs and snapshot lifecycle tests for the toolchain-qualified URL shape.

## Correctness Issue Without This

Today, snapshot lookup is keyed only by provider commit:

```diff
- <root>/github.com/<owner>/<repo>/<provider-ref>/<provider-path>/provider-release.yaml
+ <root>/gestalt/<gestalt-ref>/github.com/<owner>/<repo>/<provider-ref>/<provider-path>/provider-release.yaml
```

That is not enough identity. Snapshot archive bytes are produced by a specific `gestaltd provider release` binary and SDK, not just by the provider repo commit.

Concrete failures without the toolchain key:

- A config can record `ResolvedGestaltRef = B` while resolving metadata that was actually built with Gestalt `A`, because the URL ignores `gestaltRef`.
- Publishing the same provider commit with Gestalt `A` and then Gestalt `B` targets the same metadata URL even though generated SDK/protocol/runtime bits can differ.
- Backfilling one platform later can create mixed metadata: Linux built with Gestalt `A`, Darwin built with Gestalt `B`, both advertised by one `provider-release.yaml`.
- Local macOS serve and Linux deploy can then run different provider binaries for what appears to be the same locked snapshot.

Keying by `gestaltRef` makes each snapshot set immutable and unambiguous: one provider commit, one Gestalt toolchain commit, one artifact namespace.

## Test plan

- [x] `go test ./internal/operator -run 'TestLifecycleGitSourceSnapshotRequire(Contract|PrimesSecretsProvider)'`
- [x] `go test ./internal/config -run TestValidateProviderSnapshotRepositoryReferencesRequiresGestaltRef`
- [x] `go test ./services/plugins/source`