### PR TITLE
[codex] Move local source freshness to prepared metadata

### DIFF
--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -816,7 +816,36 @@ func TestE2EValidatePlatformUsesLockedStaticMetadataWithoutArchiveDownload(t *te
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := writeValidValidateConfig(t, dir)
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+	externalCredentialsManifest := componentProviderManifestPath(t, setupExternalCredentialsProviderDir(t, dir))
+	pluginDir := setupPrebuiltPluginDir(t, dir)
+	if err := writeLocalProviderReleaseMetadata(pluginDir); err != nil {
+		t.Fatalf("write plugin provider-release metadata: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v5
+server:
+  baseUrl: %s
+  encryptionKey: valid-config-e2e-key
+  providers:
+    indexeddb: inmem
+    externalCredentials: default
+providers:
+  externalCredentials:
+    default:
+      source:
+        path: %s
+  indexeddb:
+    inmem:
+      source:
+        path: %s
+plugins:
+  example:
+    source: %s
+`, e2eLoopbackBaseURL(8080), externalCredentialsManifest, indexedDBManifest, filepath.Join(pluginDir, "provider-release.yaml"))
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 	lockPath := filepath.Join(dir, "gestalt.lock.json")
 	out, err := exec.Command(gestaltdBin, "lock", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
 	if err != nil {

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -901,7 +901,11 @@ func TestE2EValidateStaticRejectsStaleCatalogExposureMetadata(t *testing.T) {
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 	externalCredentialsManifest := componentProviderManifestPath(t, setupExternalCredentialsProviderDir(t, dir))
 	callerManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, filepath.Join(dir, "caller")))
-	targetManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, filepath.Join(dir, "target")))
+	targetDir := setupPrebuiltPluginDir(t, filepath.Join(dir, "target"))
+	if err := writeLocalProviderReleaseMetadata(targetDir); err != nil {
+		t.Fatalf("write target provider-release metadata: %v", err)
+	}
+	targetReleaseMetadata := filepath.Join(targetDir, "provider-release.yaml")
 	lockPath := filepath.Join(dir, "gestalt.lock.json")
 	cfgPath := filepath.Join(dir, "config.yaml")
 	writeConfig := func(targetOperation string) {
@@ -930,11 +934,10 @@ plugins:
       - plugin: target
         operation: echo
   target:
-    source:
-      path: %s
+    source: %s
     allowedOperations:
       %s: {}
-`, e2eLoopbackBaseURL(8080), externalCredentialsManifest, indexedDBManifest, callerManifest, targetManifest, targetOperation)
+`, e2eLoopbackBaseURL(8080), externalCredentialsManifest, indexedDBManifest, callerManifest, targetReleaseMetadata, targetOperation)
 		if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 			t.Fatalf("write config: %v", err)
 		}
@@ -3109,28 +3112,24 @@ func TestE2ELockSyncLocalProviders(t *testing.T) {
 	if err == nil {
 		t.Fatalf("gestaltd sync --check with stale lock unexpectedly succeeded\noutput: %s", out)
 	}
-	if !strings.Contains(string(out), "gestaltd lock") {
-		t.Fatalf("stale lock output should point at lock, got: %s", out)
+	if !strings.Contains(string(out), "prepared artifact for provider") ||
+		!strings.Contains(string(out), "renamed") ||
+		!strings.Contains(string(out), "gestaltd sync --locked") {
+		t.Fatalf("stale local source output should point at sync, got: %s", out)
 	}
-	if strings.Contains(string(out), "--artifacts-dir") {
-		t.Fatalf("lock remediation should not include --artifacts-dir, got: %s", out)
+	if !strings.Contains(string(out), "--artifacts-dir") {
+		t.Fatalf("sync remediation should include --artifacts-dir, got: %s", out)
 	}
 	if strings.Contains(string(out), "--lockfile") {
-		t.Fatalf("lock remediation should not include default --lockfile, got: %s", out)
+		t.Fatalf("sync remediation should not include default --lockfile, got: %s", out)
 	}
 	staleArtifactsDir := filepath.Join(dir, "prepared-stale")
 	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--config", staleCfgPath, "--artifacts-dir", staleArtifactsDir).CombinedOutput()
-	if err == nil {
-		t.Fatalf("gestaltd sync with stale lock unexpectedly succeeded\noutput: %s", out)
+	if err != nil {
+		t.Fatalf("gestaltd sync with renamed local provider should materialize from source: %v\noutput: %s", err, out)
 	}
-	if !strings.Contains(string(out), "lockfile is out of date") || !strings.Contains(string(out), "gestaltd lock") {
-		t.Fatalf("stale lock materialize output should point at lock, got: %s", out)
-	}
-	if strings.Contains(string(out), "lock entry for provider") {
-		t.Fatalf("stale lock materialize should fail before per-provider materialization, got: %s", out)
-	}
-	if _, err := os.Stat(staleArtifactsDir); !os.IsNotExist(err) {
-		t.Fatalf("stale sync should not create artifacts dir, stat err=%v", err)
+	if _, err := os.Stat(filepath.Join(staleArtifactsDir, ".gestaltd", "providers", "renamed")); err != nil {
+		t.Fatalf("renamed local provider should be prepared from source, stat err=%v", err)
 	}
 
 	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--check", "--config", staleCfgPath, "--lockfile", lockPath, "--artifacts-dir", filepath.Join(dir, "prepared")).CombinedOutput()
@@ -3138,10 +3137,10 @@ func TestE2ELockSyncLocalProviders(t *testing.T) {
 		t.Fatalf("gestaltd sync --check with stale lock unexpectedly succeeded\noutput: %s", out)
 	}
 	if !strings.Contains(string(out), "--lockfile "+lockPath) {
-		t.Fatalf("lock remediation should preserve explicit --lockfile, got: %s", out)
+		t.Fatalf("sync remediation should preserve explicit --lockfile, got: %s", out)
 	}
-	if strings.Contains(string(out), "--artifacts-dir") {
-		t.Fatalf("lock remediation should not include --artifacts-dir, got: %s", out)
+	if !strings.Contains(string(out), "--artifacts-dir") {
+		t.Fatalf("sync remediation should include --artifacts-dir, got: %s", out)
 	}
 
 	out, err = exec.Command(gestaltdBin, "sync", "--locked", "--check", "--config", cfgPath).CombinedOutput()

--- a/gestaltd/internal/daemon/provider_lifecycle.go
+++ b/gestaltd/internal/daemon/provider_lifecycle.go
@@ -287,6 +287,10 @@ func providerLifecycleRowFor(kind providerLifecycleKind, name string, entry *con
 		row.Status = "builtin"
 		return row
 	}
+	if entry.Source.IsLocal() {
+		row.Status = "source"
+		return row
+	}
 	if !providerSourceBacked(entry) {
 		return row
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1211,7 +1211,8 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 			}
 
 			if sourceBacked(provider) {
-				if provider.HasLocalSource() {
+				switch {
+				case provider.HasLocalSource():
 					if lock == nil {
 						entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config)
 						if err != nil {
@@ -1222,7 +1223,7 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 					if err := l.applyLocalComponentEntry(paths, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), mode); err != nil {
 						return nil, err
 					}
-				} else if lock != nil {
+				case lock != nil:
 					lockEntry, ok := lock.Secrets[name]
 					if !ok {
 						return nil, lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", providermanifestv1.KindSecrets, name)
@@ -1230,7 +1231,7 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 					if err := l.applyLockedComponentEntry(paths, &lockEntry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), mode); err != nil {
 						return nil, err
 					}
-				} else {
+				default:
 					entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config)
 					if err != nil {
 						return nil, err

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -907,7 +907,7 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	paths := resolveLifecyclePaths(configPaths, cfg, state)
 	lock, err := ReadLockfile(paths.lockfilePath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if os.IsNotExist(err) && !configRequiresCommittedLock(cfg) {
 			lock = newLockfile()
 		} else {
 			if paths.pluginScope != "" {
@@ -1108,7 +1108,7 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, state StatePat
 
 	lock, err := ReadLockfile(paths.lockfilePath)
 	validatedDuringPrepare := false
-	if locked && err != nil && os.IsNotExist(err) {
+	if locked && err != nil && os.IsNotExist(err) && !configRequiresCommittedLock(cfg) {
 		lock = newLockfile()
 		err = nil
 	}
@@ -2771,33 +2771,40 @@ func stageLocalSourceInstall(kind, name, manifestPath, destDir string) (*prepare
 	}
 
 	commitInstall := func() error {
-		backupDir := ""
-		if _, err := os.Stat(destDir); err == nil {
-			backupDir = destDir + ".backup-" + strconv.FormatInt(time.Now().UnixNano(), 10)
-			if err := os.Rename(destDir, backupDir); err != nil {
-				return fmt.Errorf("stage existing provider cache at %s: %w", destDir, err)
-			}
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("inspect existing provider cache at %s: %w", destDir, err)
-		}
-		if err := os.Rename(tempDir, destDir); err != nil {
-			if backupDir != "" {
-				if restoreErr := os.Rename(backupDir, destDir); restoreErr != nil {
-					return fmt.Errorf("activate prepared install at %s: %w (rollback failed: %v)", destDir, err, restoreErr)
-				}
-			}
-			return fmt.Errorf("activate prepared install at %s: %w", destDir, err)
+		if err := activatePreparedInstallDir(destDir, tempDir); err != nil {
+			return err
 		}
 		cleanupDir = ""
-		if backupDir != "" {
-			if err := os.RemoveAll(backupDir); err != nil {
-				return fmt.Errorf("remove staged provider cache backup at %s: %w", backupDir, err)
-			}
-		}
 		return nil
 	}
 
 	return install, cleanupInstall, commitInstall, nil
+}
+
+func activatePreparedInstallDir(destDir, tempDir string) error {
+	backupDir := ""
+	if _, err := os.Stat(destDir); err == nil {
+		backupDir = destDir + ".backup-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+		if err := os.Rename(destDir, backupDir); err != nil {
+			return fmt.Errorf("stage existing provider cache at %s: %w", destDir, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect existing provider cache at %s: %w", destDir, err)
+	}
+	if err := os.Rename(tempDir, destDir); err != nil {
+		if backupDir != "" {
+			if restoreErr := os.Rename(backupDir, destDir); restoreErr != nil {
+				return fmt.Errorf("activate prepared install at %s: %w (rollback failed: %v)", destDir, err, restoreErr)
+			}
+		}
+		return fmt.Errorf("activate prepared install at %s: %w", destDir, err)
+	}
+	if backupDir != "" {
+		if err := os.RemoveAll(backupDir); err != nil {
+			return fmt.Errorf("remove staged provider cache backup at %s: %w", backupDir, err)
+		}
+	}
+	return nil
 }
 
 func relativePreparedPath(artifactsDir, path string) (string, error) {
@@ -3290,27 +3297,8 @@ func installLockedPackageAtomic(packagePath, destDir string) (*installedPackage,
 		return nil, nil, nil, err
 	}
 	commit := func() error {
-		backupDir := ""
-		if _, err := os.Stat(destDir); err == nil {
-			backupDir = destDir + ".backup-" + strconv.FormatInt(time.Now().UnixNano(), 10)
-			if err := os.Rename(destDir, backupDir); err != nil {
-				return fmt.Errorf("stage existing provider cache at %s: %w", destDir, err)
-			}
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("inspect existing provider cache at %s: %w", destDir, err)
-		}
-		if err := os.Rename(tempDir, destDir); err != nil {
-			if backupDir != "" {
-				if restoreErr := os.Rename(backupDir, destDir); restoreErr != nil {
-					return fmt.Errorf("activate prepared install at %s: %w (rollback failed: %v)", destDir, err, restoreErr)
-				}
-			}
-			return fmt.Errorf("activate prepared install at %s: %w", destDir, err)
-		}
-		if backupDir != "" {
-			if err := os.RemoveAll(backupDir); err != nil {
-				return fmt.Errorf("remove staged provider cache backup at %s: %w", backupDir, err)
-			}
+		if err := activatePreparedInstallDir(destDir, tempDir); err != nil {
+			return err
 		}
 		cleanupDir = ""
 		return nil
@@ -4193,35 +4181,35 @@ func (l *Lifecycle) ensureLocalPreparedInstall(paths lifecyclePaths, kind, name 
 	return install, nil
 }
 
+func bindPreparedProviderInstall(paths lifecyclePaths, name string, plugin *config.ProviderEntry, configMap map[string]any, install *preparedInstall) error {
+	if err := bindResolvedProviderManifest(name, plugin, install.manifestPath, install.manifest, configMap); err != nil {
+		return err
+	}
+	if install.executablePath == "" {
+		return nil
+	}
+	if _, err := os.Stat(install.executablePath); err != nil {
+		return preparedArtifactStaleError(paths, "prepared executable for provider %q not found at %s", name, install.executablePath)
+	}
+	args, err := providerEntrypointArgs(install.manifest)
+	if err != nil {
+		return fmt.Errorf("resolve entrypoint for provider %q: %w", name, err)
+	}
+	plugin.Command = install.executablePath
+	plugin.Args = append([]string(nil), args...)
+	return nil
+}
+
 func (l *Lifecycle) applyLocalProviderEntry(paths lifecyclePaths, name string, plugin *config.ProviderEntry, configMap map[string]any, mode artifactMode) error {
 	subject := "provider " + strconv.Quote(name)
 	install, err := l.ensureLocalPreparedInstall(paths, providermanifestv1.KindPlugin, name, plugin, configMap, providerDestDir(paths, name), subject, mode)
 	if err != nil {
 		return err
 	}
-	if err := bindResolvedProviderManifest(name, plugin, install.manifestPath, install.manifest, configMap); err != nil {
-		return err
-	}
-	if install.executablePath != "" {
-		if _, err := os.Stat(install.executablePath); err != nil {
-			return preparedArtifactStaleError(paths, "prepared executable for provider %q not found at %s", name, install.executablePath)
-		}
-		args, err := providerEntrypointArgs(install.manifest)
-		if err != nil {
-			return fmt.Errorf("resolve entrypoint for provider %q: %w", name, err)
-		}
-		plugin.Command = install.executablePath
-		plugin.Args = append([]string(nil), args...)
-	}
-	return nil
+	return bindPreparedProviderInstall(paths, name, plugin, configMap, install)
 }
 
-func (l *Lifecycle) applyLocalComponentEntry(paths lifecyclePaths, kind, name string, plugin *config.ProviderEntry, configMap map[string]any, destDir string, mode artifactMode) error {
-	subject := fmt.Sprintf("%s %q", kind, name)
-	install, err := l.ensureLocalPreparedInstall(paths, kind, name, plugin, configMap, destDir, subject, mode)
-	if err != nil {
-		return err
-	}
+func bindPreparedComponentInstall(paths lifecyclePaths, kind, name string, plugin *config.ProviderEntry, configMap map[string]any, destDir string, install *preparedInstall) error {
 	if install.executablePath == "" {
 		return preparedArtifactStaleError(paths, "prepared executable for %s %q not found in %s", kind, name, destDir)
 	}
@@ -4240,11 +4228,16 @@ func (l *Lifecycle) applyLocalComponentEntry(paths lifecyclePaths, kind, name st
 	return nil
 }
 
-func (l *Lifecycle) applyLocalUIProvider(paths lifecyclePaths, provider *config.ProviderEntry, logicalName, subject, destDir string, configMap map[string]any, mode artifactMode) (string, error) {
-	install, err := l.ensureLocalPreparedInstall(paths, providermanifestv1.KindUI, logicalName, provider, configMap, destDir, subject, mode)
+func (l *Lifecycle) applyLocalComponentEntry(paths lifecyclePaths, kind, name string, plugin *config.ProviderEntry, configMap map[string]any, destDir string, mode artifactMode) error {
+	subject := fmt.Sprintf("%s %q", kind, name)
+	install, err := l.ensureLocalPreparedInstall(paths, kind, name, plugin, configMap, destDir, subject, mode)
 	if err != nil {
-		return "", err
+		return err
 	}
+	return bindPreparedComponentInstall(paths, kind, name, plugin, configMap, destDir, install)
+}
+
+func bindPreparedUIInstall(provider *config.ProviderEntry, subject, destDir string, configMap map[string]any, install *preparedInstall) (string, error) {
 	if install.assetRootPath == "" {
 		return "", fmt.Errorf("prepared asset root for %s not found in %s", subject, destDir)
 	}
@@ -4255,6 +4248,14 @@ func (l *Lifecycle) applyLocalUIProvider(paths lifecyclePaths, provider *config.
 		return "", err
 	}
 	return install.assetRootPath, nil
+}
+
+func (l *Lifecycle) applyLocalUIProvider(paths lifecyclePaths, provider *config.ProviderEntry, logicalName, subject, destDir string, configMap map[string]any, mode artifactMode) (string, error) {
+	install, err := l.ensureLocalPreparedInstall(paths, providermanifestv1.KindUI, logicalName, provider, configMap, destDir, subject, mode)
+	if err != nil {
+		return "", err
+	}
+	return bindPreparedUIInstall(provider, subject, destDir, configMap, install)
 }
 
 func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *LockEntry, provider *config.ProviderEntry, logicalName, subject, destDir string, mode artifactMode) (string, error) {
@@ -4345,16 +4346,7 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 				return "", fmt.Errorf("read prepared manifest for %s: %w", subject, err)
 			}
 		}
-		if install.assetRootPath == "" {
-			return "", fmt.Errorf("prepared asset root for %s not found in %s", subject, destDir)
-		}
-		if _, err := os.Stat(install.assetRootPath); err != nil {
-			return "", fmt.Errorf("prepared asset root for %s not found at %s", subject, install.assetRootPath)
-		}
-		if err := bindResolvedUIManifest(provider, install.manifestPath, install.manifest, configMap); err != nil {
-			return "", err
-		}
-		return install.assetRootPath, nil
+		return bindPreparedUIInstall(provider, subject, destDir, configMap, install)
 	default:
 		return "", nil
 	}
@@ -4486,21 +4478,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 			return fmt.Errorf("read prepared manifest for provider %q: %w", name, err)
 		}
 	}
-	if err := bindResolvedProviderManifest(name, plugin, install.manifestPath, install.manifest, configMap); err != nil {
-		return err
-	}
-	if install.executablePath != "" {
-		if _, err := os.Stat(install.executablePath); err != nil {
-			return preparedArtifactStaleError(paths, "prepared executable for provider %q not found at %s", name, install.executablePath)
-		}
-		args, err := providerEntrypointArgs(install.manifest)
-		if err != nil {
-			return fmt.Errorf("resolve entrypoint for provider %q: %w", name, err)
-		}
-		plugin.Command = install.executablePath
-		plugin.Args = append([]string(nil), args...)
-	}
-	return nil
+	return bindPreparedProviderInstall(paths, name, plugin, configMap, install)
 }
 
 func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockEntry, kind, name string, plugin *config.ProviderEntry, configMap map[string]any, destDir string, mode artifactMode) error {
@@ -4589,22 +4567,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 			return fmt.Errorf("read prepared manifest for %s %q: %w", kind, name, err)
 		}
 	}
-	if install.executablePath == "" {
-		return preparedArtifactStaleError(paths, "prepared executable for %s %q not found in %s", kind, name, destDir)
-	}
-	if err := bindResolvedComponentManifest(kind, name, plugin, install.manifestPath, install.manifest, configMap); err != nil {
-		return err
-	}
-	if _, err := os.Stat(install.executablePath); err != nil {
-		return preparedArtifactStaleError(paths, "prepared executable for %s %q not found at %s", kind, name, install.executablePath)
-	}
-	args, err := componentEntrypointArgs(install.manifest, kind)
-	if err != nil {
-		return fmt.Errorf("resolve entrypoint for %s %q: %w", kind, name, err)
-	}
-	plugin.Command = install.executablePath
-	plugin.Args = append([]string(nil), args...)
-	return nil
+	return bindPreparedComponentInstall(paths, kind, name, plugin, configMap, destDir, install)
 }
 
 func bindResolvedProviderManifest(name string, plugin *config.ProviderEntry, manifestPath string, manifest *providermanifestv1.Manifest, configMap map[string]any) error {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -236,6 +236,9 @@ func (l *Lifecycle) CheckLockAtPathsWithStatePaths(configPaths []string, state S
 	}
 	currentLock, err := ReadLockfile(paths.lockfilePath)
 	if err != nil {
+		if os.IsNotExist(err) && !configRequiresCommittedLock(cfg) {
+			return nil
+		}
 		return fmt.Errorf("lockfile is missing or unreadable; run `%s`: %w", formatLockCommand(paths), err)
 	}
 	current, err := canonicalLockfileJSON(currentLock)
@@ -310,6 +313,9 @@ func (l *Lifecycle) prepareLockAtPathsInScratch(configPaths []string, state Stat
 	if err != nil {
 		return nil, nil, lifecyclePaths{}, cleanup, err
 	}
+	actualPaths := resolveLifecyclePaths(configPaths, cfg, state)
+	paths.lockfilePath = actualPaths.lockfilePath
+	paths.lockFlags = actualPaths.lockFlags
 	return lock, cfg, paths, cleanup, nil
 }
 
@@ -390,7 +396,9 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 		return nil, err
 	}
 	for name := range resolvedProviders {
-		lock.Providers[name] = resolvedProviders[name]
+		if providerRequiresCommittedLock(cfg.Plugins[name]) {
+			lock.Providers[name] = resolvedProviders[name]
+		}
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		for name, entry := range collection.entries {
@@ -407,7 +415,9 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 			if err != nil {
 				return nil, err
 			}
-			lockEntriesForKind(lock, collection.kind)[name] = lockEntry
+			if providerRequiresCommittedLock(entry) {
+				lockEntriesForKind(lock, collection.kind)[name] = lockEntry
+			}
 		}
 	}
 	for name, entry := range cfg.Runtime.Providers {
@@ -419,7 +429,9 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 		if err != nil {
 			return nil, err
 		}
-		lock.Runtimes[name] = lockEntry
+		if runtimeRequiresCommittedLock(entry) {
+			lock.Runtimes[name] = lockEntry
+		}
 	}
 	if err := l.resolveConfiguredPlugins(paths, lock, cfg, artifactModeMaterialize); err != nil {
 		return nil, err
@@ -432,7 +444,9 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 		return nil, err
 	}
 	for name := range secretsEntries {
-		lock.Secrets[name] = secretsEntries[name]
+		if providerRequiresCommittedLock(cfg.Providers.Secrets[name]) {
+			lock.Secrets[name] = secretsEntries[name]
+		}
 	}
 	for name, def := range cfg.Providers.IndexedDB {
 		if sourceBacked(def) {
@@ -440,7 +454,9 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 			if err != nil {
 				return nil, err
 			}
-			lock.IndexedDBs[name] = entry
+			if providerRequiresCommittedLock(def) {
+				lock.IndexedDBs[name] = entry
+			}
 		}
 	}
 	for name, def := range cfg.Providers.S3 {
@@ -449,7 +465,9 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 			if err != nil {
 				return nil, err
 			}
-			lock.S3[name] = entry
+			if providerRequiresCommittedLock(def) {
+				lock.S3[name] = entry
+			}
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
@@ -463,7 +481,9 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfigWithSecretMode(ctx context
 			if err != nil {
 				return nil, err
 			}
-			lock.UIs[name] = uiEntry
+			if providerRequiresCommittedLock(&entry.ProviderEntry) {
+				lock.UIs[name] = uiEntry
+			}
 		}
 	}
 	return lock, nil
@@ -887,10 +907,14 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	paths := resolveLifecyclePaths(configPaths, cfg, state)
 	lock, err := ReadLockfile(paths.lockfilePath)
 	if err != nil {
-		if paths.pluginScope != "" {
-			return fmt.Errorf("scoped local plugin lock metadata is missing or unreadable for plugin %q; rerun without --locked to prepare it: %w", paths.pluginScope, err)
+		if os.IsNotExist(err) {
+			lock = newLockfile()
+		} else {
+			if paths.pluginScope != "" {
+				return fmt.Errorf("scoped local plugin lock metadata is missing or unreadable for plugin %q; rerun without --locked to prepare it: %w", paths.pluginScope, err)
+			}
+			return fmt.Errorf("source-backed providers require lock metadata; run `%s`: %w", formatLockCommand(paths), err)
 		}
-		return fmt.Errorf("source-backed providers require lock metadata; run `%s`: %w", formatLockCommand(paths), err)
 	}
 	if !lockMetadataMatchesConfigForSync(cfg, paths, lock) {
 		if paths.pluginScope != "" {
@@ -1084,6 +1108,10 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, state StatePat
 
 	lock, err := ReadLockfile(paths.lockfilePath)
 	validatedDuringPrepare := false
+	if locked && err != nil && os.IsNotExist(err) {
+		lock = newLockfile()
+		err = nil
+	}
 	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock) || configHasLocalProviderSources(cfg) || configHasMetadataProviderSources(cfg)) {
 		lock, err = l.PrepareAtPathsWithStatePaths(configPaths, state)
 		validatedDuringPrepare = err == nil
@@ -1183,7 +1211,18 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 			}
 
 			if sourceBacked(provider) {
-				if lock != nil {
+				if provider.HasLocalSource() {
+					if lock == nil {
+						entry, err := l.writeComponentArtifact(ctx, cfg, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config)
+						if err != nil {
+							return nil, err
+						}
+						prepared[name] = entry
+					}
+					if err := l.applyLocalComponentEntry(paths, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), mode); err != nil {
+						return nil, err
+					}
+				} else if lock != nil {
 					lockEntry, ok := lock.Secrets[name]
 					if !ok {
 						return nil, lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", providermanifestv1.KindSecrets, name)
@@ -1342,6 +1381,14 @@ func runtimeSourceBacked(entry *config.RuntimeProviderEntry) bool {
 	return entry != nil && sourceBacked(&entry.ProviderEntry)
 }
 
+func providerRequiresCommittedLock(entry *config.ProviderEntry) bool {
+	return sourceBacked(entry) && !entry.HasLocalSource()
+}
+
+func runtimeRequiresCommittedLock(entry *config.RuntimeProviderEntry) bool {
+	return entry != nil && providerRequiresCommittedLock(&entry.ProviderEntry)
+}
+
 func hostProviderCollections(cfg *config.Config) []struct {
 	kind    config.HostProviderKind
 	entries map[string]*config.ProviderEntry
@@ -1396,6 +1443,10 @@ func lockEntriesForKind(lock *Lockfile, kind config.HostProviderKind) map[string
 
 func configHasProviderLoading(cfg *config.Config) bool {
 	return configHasMatchingProviderEntry(cfg, sourceBacked)
+}
+
+func configRequiresCommittedLock(cfg *config.Config) bool {
+	return configHasMatchingProviderEntry(cfg, providerRequiresCommittedLock)
 }
 
 func configHasLocalProviderSources(cfg *config.Config) bool {
@@ -1642,12 +1693,26 @@ type preparedInstall struct {
 	manifest       *providermanifestv1.Manifest
 }
 
-const preparedLockMetadataFile = ".gestaltd-lock-metadata.json"
+const (
+	preparedLockMetadataFile          = ".gestaltd-lock-metadata.json"
+	preparedLockMetadataSchema        = "gestaltd-prepared-provider"
+	preparedLockMetadataSchemaVersion = 2
+)
 
 type preparedLockMetadata struct {
-	InputDigest string `json:"inputDigest"`
-	Kind        string `json:"kind"`
-	Name        string `json:"name"`
+	Schema            string `json:"schema,omitempty"`
+	SchemaVersion     int    `json:"schemaVersion,omitempty"`
+	InputDigest       string `json:"inputDigest"`
+	SourceIdentity    string `json:"sourceIdentity,omitempty"`
+	ConfiguredSource  string `json:"configuredSource,omitempty"`
+	SourceInputDigest string `json:"sourceInputDigest,omitempty"`
+	Kind              string `json:"kind"`
+	Name              string `json:"name"`
+	ManifestSource    string `json:"manifestSource,omitempty"`
+	ManifestVersion   string `json:"manifestVersion,omitempty"`
+	Runtime           string `json:"runtime,omitempty"`
+	Platform          string `json:"platform,omitempty"`
+	OutputDigest      string `json:"outputDigest,omitempty"`
 }
 
 type preparedLockMetadataState int
@@ -1684,15 +1749,113 @@ func inspectPreparedInstall(destDir string) (*preparedInstall, error) {
 	return install, nil
 }
 
-func writePreparedLockMetadata(install *preparedInstall, kind, name string, entry LockEntry) error {
+func preparedInstallOutputDigest(install *preparedInstall) (string, error) {
 	if install == nil || strings.TrimSpace(install.manifestPath) == "" {
-		return fmt.Errorf("prepared install manifest path is required")
+		return "", fmt.Errorf("prepared install manifest path is required")
 	}
-	data, err := json.MarshalIndent(preparedLockMetadata{
-		InputDigest: strings.TrimSpace(entry.Fingerprint),
-		Kind:        providermanifestv1.NormalizeKind(kind),
-		Name:        name,
-	}, "", "  ")
+	return preparedDirectoryDigest(filepath.Dir(install.manifestPath))
+}
+
+func preparedDirectoryDigest(root string) (string, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return "", fmt.Errorf("prepared install root is required")
+	}
+	root = filepath.Clean(root)
+	var digests []string
+	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Name() == preparedLockMetadataFile {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		sum, err := providerpkg.FileSHA256(path)
+		if err != nil {
+			return err
+		}
+		digests = append(digests, filepath.ToSlash(filepath.Clean(rel))+"="+sum)
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	slices.Sort(digests)
+	combined := sha256.Sum256([]byte(strings.Join(digests, "\n")))
+	return hex.EncodeToString(combined[:]), nil
+}
+
+func localSourceDigestForKind(kind string, provider *config.ProviderEntry) (string, error) {
+	if provider == nil || !provider.HasLocalSource() {
+		return "", fmt.Errorf("local source provider is required")
+	}
+	if providermanifestv1.NormalizeKind(kind) == providermanifestv1.KindUI {
+		return fingerprintLocalUISourceDigest(provider.SourcePath())
+	}
+	return fingerprintLocalSourceDigest(provider.SourcePath())
+}
+
+func localPreparedFingerprintName(kind, name string) string {
+	if providermanifestv1.NormalizeKind(kind) == providermanifestv1.KindUI {
+		return "ui:" + name
+	}
+	return name
+}
+
+func expectedPreparedLockMetadata(paths lifecyclePaths, install *preparedInstall, kind, name string, provider *config.ProviderEntry, includeSource bool) (preparedLockMetadata, error) {
+	if install == nil || strings.TrimSpace(install.manifestPath) == "" {
+		return preparedLockMetadata{}, fmt.Errorf("prepared install manifest path is required")
+	}
+	outputDigest, err := preparedInstallOutputDigest(install)
+	if err != nil {
+		return preparedLockMetadata{}, err
+	}
+	metadata := preparedLockMetadata{
+		Schema:           preparedLockMetadataSchema,
+		SchemaVersion:    preparedLockMetadataSchemaVersion,
+		ConfiguredSource: fingerprintLocalSourcePath(provider.SourcePath(), paths.configDir),
+		Kind:             providermanifestv1.NormalizeKind(kind),
+		Name:             name,
+		Platform:         providerpkg.CurrentPlatformString(),
+		OutputDigest:     outputDigest,
+	}
+	if install.manifest != nil {
+		metadata.ManifestSource = strings.TrimSpace(install.manifest.Source)
+		metadata.ManifestVersion = strings.TrimSpace(install.manifest.Version)
+		metadata.Runtime = releaseRuntimeForManifest(install.manifest, archivePolicyKind(kind))
+	}
+	if includeSource {
+		fingerprint, err := ProviderFingerprint(localPreparedFingerprintName(kind, name), provider, paths.configDir)
+		if err != nil {
+			return preparedLockMetadata{}, err
+		}
+		sourceIdentity, err := localSourceIdentity(provider.SourcePath(), paths.configDir)
+		if err != nil {
+			return preparedLockMetadata{}, err
+		}
+		sourceDigest, err := localSourceDigestForKind(kind, provider)
+		if err != nil {
+			return preparedLockMetadata{}, err
+		}
+		metadata.InputDigest = fingerprint
+		metadata.SourceIdentity = sourceIdentity
+		metadata.SourceInputDigest = sourceDigest
+	}
+	return metadata, nil
+}
+
+func writePreparedLockMetadata(paths lifecyclePaths, install *preparedInstall, kind, name string, provider *config.ProviderEntry) error {
+	metadata, err := expectedPreparedLockMetadata(paths, install, kind, name, provider, true)
+	if err != nil {
+		return fmt.Errorf("prepare local source metadata: %w", err)
+	}
+	data, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode prepared lock metadata: %w", err)
 	}
@@ -1704,7 +1867,7 @@ func writePreparedLockMetadata(install *preparedInstall, kind, name string, entr
 	return nil
 }
 
-func inspectPreparedLockMetadata(install *preparedInstall, kind, name string, entry LockEntry) preparedLockMetadataState {
+func inspectPreparedLockMetadata(paths lifecyclePaths, install *preparedInstall, kind, name string, provider *config.ProviderEntry, mode artifactMode) preparedLockMetadataState {
 	if install == nil || strings.TrimSpace(install.manifestPath) == "" {
 		return preparedLockMetadataStale
 	}
@@ -1719,12 +1882,32 @@ func inspectPreparedLockMetadata(install *preparedInstall, kind, name string, en
 	if err := json.Unmarshal(data, &metadata); err != nil {
 		return preparedLockMetadataStale
 	}
-	if strings.TrimSpace(metadata.InputDigest) == strings.TrimSpace(entry.Fingerprint) &&
-		providermanifestv1.NormalizeKind(metadata.Kind) == providermanifestv1.NormalizeKind(kind) &&
-		strings.TrimSpace(metadata.Name) == strings.TrimSpace(name) {
-		return preparedLockMetadataMatch
+	if metadata.Schema != preparedLockMetadataSchema ||
+		metadata.SchemaVersion != preparedLockMetadataSchemaVersion ||
+		providermanifestv1.NormalizeKind(metadata.Kind) != providermanifestv1.NormalizeKind(kind) ||
+		strings.TrimSpace(metadata.Name) != strings.TrimSpace(name) {
+		return preparedLockMetadataStale
 	}
-	return preparedLockMetadataStale
+	expected, err := expectedPreparedLockMetadata(paths, install, kind, name, provider, mode != artifactModeReadOnly)
+	if err != nil {
+		return preparedLockMetadataStale
+	}
+	if strings.TrimSpace(metadata.ConfiguredSource) != strings.TrimSpace(expected.ConfiguredSource) ||
+		strings.TrimSpace(metadata.ManifestSource) != strings.TrimSpace(expected.ManifestSource) ||
+		strings.TrimSpace(metadata.ManifestVersion) != strings.TrimSpace(expected.ManifestVersion) ||
+		strings.TrimSpace(metadata.Runtime) != strings.TrimSpace(expected.Runtime) ||
+		strings.TrimSpace(metadata.Platform) != strings.TrimSpace(expected.Platform) ||
+		strings.TrimSpace(metadata.OutputDigest) != strings.TrimSpace(expected.OutputDigest) {
+		return preparedLockMetadataStale
+	}
+	if mode != artifactModeReadOnly {
+		if strings.TrimSpace(metadata.InputDigest) != strings.TrimSpace(expected.InputDigest) ||
+			strings.TrimSpace(metadata.SourceIdentity) != strings.TrimSpace(expected.SourceIdentity) ||
+			strings.TrimSpace(metadata.SourceInputDigest) != strings.TrimSpace(expected.SourceInputDigest) {
+			return preparedLockMetadataStale
+		}
+	}
+	return preparedLockMetadataMatch
 }
 
 func providerManifestKind(kind config.HostProviderKind) string {
@@ -1801,7 +1984,7 @@ func lockMatchesConfig(cfg *config.Config, paths lifecyclePaths, lock *Lockfile)
 		return false
 	}
 	for name, entry := range cfg.Plugins {
-		if !sourceBacked(entry) {
+		if !providerRequiresCommittedLock(entry) {
 			continue
 		}
 		lockEntry, found := lock.Providers[name]
@@ -1812,7 +1995,7 @@ func lockMatchesConfig(cfg *config.Config, paths lifecyclePaths, lock *Lockfile)
 	for _, collection := range hostProviderCollections(cfg) {
 		lockEntries := lockEntriesForKind(lock, collection.kind)
 		for name, entry := range collection.entries {
-			if entry == nil || !sourceBacked(entry) {
+			if entry == nil || !providerRequiresCommittedLock(entry) {
 				continue
 			}
 			lockEntry, found := lockEntries[name]
@@ -1822,7 +2005,7 @@ func lockMatchesConfig(cfg *config.Config, paths lifecyclePaths, lock *Lockfile)
 		}
 	}
 	for name, entry := range cfg.Runtime.Providers {
-		if !runtimeSourceBacked(entry) {
+		if !runtimeRequiresCommittedLock(entry) {
 			continue
 		}
 		lockEntry, found := lock.Runtimes[name]
@@ -1831,7 +2014,7 @@ func lockMatchesConfig(cfg *config.Config, paths lifecyclePaths, lock *Lockfile)
 		}
 	}
 	for name, entry := range cfg.Providers.IndexedDB {
-		if !sourceBacked(entry) {
+		if !providerRequiresCommittedLock(entry) {
 			continue
 		}
 		lockEntry, found := lock.IndexedDBs[name]
@@ -1840,7 +2023,7 @@ func lockMatchesConfig(cfg *config.Config, paths lifecyclePaths, lock *Lockfile)
 		}
 	}
 	for name, entry := range cfg.Providers.S3 {
-		if !sourceBacked(entry) {
+		if !providerRequiresCommittedLock(entry) {
 			continue
 		}
 		lockEntry, found := lock.S3[name]
@@ -1849,7 +2032,7 @@ func lockMatchesConfig(cfg *config.Config, paths lifecyclePaths, lock *Lockfile)
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
-		if entry == nil || !sourceBacked(&entry.ProviderEntry) {
+		if entry == nil || !providerRequiresCommittedLock(&entry.ProviderEntry) {
 			continue
 		}
 		lockEntry, ok := lock.UIs[name]
@@ -1881,7 +2064,7 @@ func lockMetadataMatchesConfigForSync(cfg *config.Config, paths lifecyclePaths, 
 		return false
 	}
 	for name, entry := range cfg.Plugins {
-		if !sourceBacked(entry) {
+		if !providerRequiresCommittedLock(entry) {
 			continue
 		}
 		lockEntry, found := lock.Providers[name]
@@ -1892,7 +2075,7 @@ func lockMetadataMatchesConfigForSync(cfg *config.Config, paths lifecyclePaths, 
 	for _, collection := range hostProviderCollections(cfg) {
 		lockEntries := lockEntriesForKind(lock, collection.kind)
 		for name, entry := range collection.entries {
-			if entry == nil || !sourceBacked(entry) {
+			if entry == nil || !providerRequiresCommittedLock(entry) {
 				continue
 			}
 			kind := providerManifestKind(collection.kind)
@@ -1903,7 +2086,7 @@ func lockMetadataMatchesConfigForSync(cfg *config.Config, paths lifecyclePaths, 
 		}
 	}
 	for name, entry := range cfg.Runtime.Providers {
-		if !runtimeSourceBacked(entry) {
+		if !runtimeRequiresCommittedLock(entry) {
 			continue
 		}
 		lockEntry, found := lock.Runtimes[name]
@@ -1912,7 +2095,7 @@ func lockMetadataMatchesConfigForSync(cfg *config.Config, paths lifecyclePaths, 
 		}
 	}
 	for name, entry := range cfg.Providers.IndexedDB {
-		if !sourceBacked(entry) {
+		if !providerRequiresCommittedLock(entry) {
 			continue
 		}
 		lockEntry, found := lock.IndexedDBs[name]
@@ -1921,7 +2104,7 @@ func lockMetadataMatchesConfigForSync(cfg *config.Config, paths lifecyclePaths, 
 		}
 	}
 	for name, entry := range cfg.Providers.S3 {
-		if !sourceBacked(entry) {
+		if !providerRequiresCommittedLock(entry) {
 			continue
 		}
 		lockEntry, found := lock.S3[name]
@@ -1930,7 +2113,7 @@ func lockMetadataMatchesConfigForSync(cfg *config.Config, paths lifecyclePaths, 
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
-		if entry == nil || !sourceBacked(&entry.ProviderEntry) {
+		if entry == nil || !providerRequiresCommittedLock(&entry.ProviderEntry) {
 			continue
 		}
 		lockEntry, found := lock.UIs[name]
@@ -1984,9 +2167,12 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 		Source: providerSourceFingerprintLocation(entry, configDir),
 	}
 	if entry.HasLocalSource() {
-		input.Path = fingerprintLocalSourcePath(entry.SourcePath(), configDir)
+		sourceIdentity, err := localSourceIdentity(entry.SourcePath(), configDir)
+		if err != nil {
+			return "", err
+		}
+		input.Path = sourceIdentity
 		var digest string
-		var err error
 		if strings.HasPrefix(name, "ui:") {
 			digest, err = fingerprintLocalUISourceDigest(entry.SourcePath())
 		} else {
@@ -2131,48 +2317,63 @@ func fingerprintLocalSourcePath(sourcePath, configDir string) string {
 	return filepath.ToSlash(path)
 }
 
-func fingerprintLocalSourceDigest(sourcePath string) (string, error) {
-	manifestPath := sourcePath
-	sourceDir := sourcePath
+type normalizedLocalSource struct {
+	sourceDir    string
+	manifestPath string
+}
 
+func normalizeLocalSource(sourcePath string) (normalizedLocalSource, error) {
+	sourcePath = strings.TrimSpace(sourcePath)
+	if sourcePath == "" {
+		return normalizedLocalSource{}, fmt.Errorf("local source path is required")
+	}
+	sourcePath = filepath.Clean(sourcePath)
 	info, err := os.Stat(sourcePath)
 	if err != nil {
-		return "", err
+		return normalizedLocalSource{}, err
 	}
+	sourceDir := sourcePath
+	manifestPath := sourcePath
 	if info.IsDir() {
 		manifestPath, err = providerpkg.FindManifestFile(sourcePath)
 		if err != nil {
-			return "", err
+			return normalizedLocalSource{}, err
 		}
 	} else {
 		sourceDir = filepath.Dir(sourcePath)
 	}
+	return normalizedLocalSource{
+		sourceDir:    filepath.Clean(sourceDir),
+		manifestPath: filepath.Clean(manifestPath),
+	}, nil
+}
 
-	_, manifest, err := providerpkg.PrepareSourceManifest(manifestPath)
+func localSourceIdentity(sourcePath, configDir string) (string, error) {
+	normalized, err := normalizeLocalSource(sourcePath)
 	if err != nil {
 		return "", err
 	}
-	return providerpkg.DirectoryDigest(sourceDir, manifestPath, manifest)
+	return fingerprintLocalSourcePath(normalized.manifestPath, configDir), nil
+}
+
+func fingerprintLocalSourceDigest(sourcePath string) (string, error) {
+	normalized, err := normalizeLocalSource(sourcePath)
+	if err != nil {
+		return "", err
+	}
+	_, manifest, err := providerpkg.PrepareSourceManifest(normalized.manifestPath)
+	if err != nil {
+		return "", err
+	}
+	return providerpkg.DirectoryDigest(normalized.sourceDir, normalized.manifestPath, manifest)
 }
 
 func fingerprintLocalUISourceDigest(sourcePath string) (string, error) {
-	manifestPath := sourcePath
-	sourceDir := sourcePath
-
-	info, err := os.Stat(sourcePath)
+	normalized, err := normalizeLocalSource(sourcePath)
 	if err != nil {
 		return "", err
 	}
-	if info.IsDir() {
-		manifestPath, err = providerpkg.FindManifestFile(sourcePath)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		sourceDir = filepath.Dir(sourcePath)
-	}
-
-	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	_, manifest, err := providerpkg.ReadSourceManifestFile(normalized.manifestPath)
 	if err != nil {
 		return "", err
 	}
@@ -2182,9 +2383,9 @@ func fingerprintLocalUISourceDigest(sourcePath string) (string, error) {
 	}
 	build := providerpkg.EffectiveSourceBuild(manifest)
 	if kind != providermanifestv1.KindUI || build == nil {
-		return providerpkg.DirectoryDigest(sourceDir, manifestPath, manifest)
+		return providerpkg.DirectoryDigest(normalized.sourceDir, normalized.manifestPath, manifest)
 	}
-	return fingerprintLocalUIBuildInputs(sourceDir, manifestPath, manifest, build)
+	return fingerprintLocalUIBuildInputs(normalized.sourceDir, normalized.manifestPath, manifest, build)
 }
 
 func fingerprintLocalUIBuildInputs(sourceDir, manifestPath string, manifest *providermanifestv1.Manifest, build *providerpkg.ResolvedSourceBuild) (string, error) {
@@ -2309,61 +2510,8 @@ func fingerprintLocalReleaseMetadataDigest(sourcePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if digest, ok, err := fingerprintLocalReleaseSourceTreeDigest(sourcePath); err != nil {
-		return "", err
-	} else if ok {
-		input := struct {
-			SourceDigest string          `json:"sourceDigest"`
-			Metadata     json.RawMessage `json:"metadata"`
-		}{
-			SourceDigest: digest,
-			Metadata:     payload,
-		}
-		data, err := json.Marshal(input)
-		if err != nil {
-			return "", err
-		}
-		sum := sha256.Sum256(data)
-		return hex.EncodeToString(sum[:]), nil
-	}
 	sum := sha256.Sum256(payload)
 	return hex.EncodeToString(sum[:]), nil
-}
-
-func fingerprintLocalReleaseSourceTreeDigest(sourcePath string) (string, bool, error) {
-	cleaned := filepath.Clean(sourcePath)
-	if filepath.Base(cleaned) != "provider-release.yaml" {
-		return "", false, nil
-	}
-	distDir := filepath.Dir(cleaned)
-	if filepath.Base(distDir) != "dist" {
-		return "", false, nil
-	}
-	sourceDir := filepath.Dir(distDir)
-
-	var manifestPath string
-	for _, name := range providerpkg.ManifestFiles {
-		candidate := filepath.Join(sourceDir, name)
-		if _, err := os.Stat(candidate); err == nil {
-			manifestPath = candidate
-			break
-		} else if !os.IsNotExist(err) {
-			return "", false, err
-		}
-	}
-	if manifestPath == "" {
-		return "", false, nil
-	}
-
-	_, manifest, err := providerpkg.PrepareSourceManifest(manifestPath)
-	if err != nil {
-		return "", false, err
-	}
-	digest, err := providerpkg.DirectoryDigest(sourceDir, manifestPath, manifest)
-	if err != nil {
-		return "", false, err
-	}
-	return digest, true, nil
 }
 
 func archivePolicyKind(kind string) string {
@@ -2546,34 +2694,11 @@ func preparedManifestMatchesLock(entry LockEntry, manifest *providermanifestv1.M
 }
 
 func preparedInstallMatchesLockForMode(kind, name string, provider *config.ProviderEntry, entry LockEntry, install *preparedInstall, mode artifactMode) bool {
-	if install == nil || !preparedManifestMatchesLock(entry, install.manifest) {
-		return false
-	}
-	if providerHasReadOnlyLocalSource(provider) {
-		switch inspectPreparedLockMetadata(install, kind, name, entry) {
-		case preparedLockMetadataMatch:
-			return true
-		case preparedLockMetadataMissing:
-			return mode == artifactModeMaterialize
-		default:
-			return false
-		}
-	}
-	return true
+	return install != nil && preparedManifestMatchesLock(entry, install.manifest)
 }
 
 func backfillPreparedLockMetadataIfNeeded(kind, name string, provider *config.ProviderEntry, entry LockEntry, install *preparedInstall, mode artifactMode) error {
-	if mode != artifactModeMaterialize || !providerHasReadOnlyLocalSource(provider) {
-		return nil
-	}
-	switch inspectPreparedLockMetadata(install, kind, name, entry) {
-	case preparedLockMetadataMatch:
-		return nil
-	case preparedLockMetadataMissing:
-		return writePreparedLockMetadata(install, kind, name, entry)
-	default:
-		return fmt.Errorf("prepared lock metadata for %s %q is stale", kind, name)
-	}
+	return nil
 }
 
 // resolveArchiveForPlatform looks up a LockArchive for the given platform
@@ -2608,9 +2733,11 @@ func stageLocalSourceInstall(kind, name, manifestPath, destDir string) (*prepare
 	if strings.TrimSpace(manifestPath) == "" {
 		return nil, nil, nil, fmt.Errorf("manifest path for %s %q is required", kind, name)
 	}
-	if _, err := os.Stat(manifestPath); err != nil {
+	normalized, err := normalizeLocalSource(manifestPath)
+	if err != nil {
 		return nil, nil, nil, fmt.Errorf("manifest for %s %q not found at %s: %w", kind, name, manifestPath, err)
 	}
+	manifestPath = normalized.manifestPath
 	parentDir := filepath.Dir(destDir)
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
 		return nil, nil, nil, fmt.Errorf("create destination parent directory: %w", err)
@@ -2713,11 +2840,17 @@ func localLockEntryFromPreparedInstall(paths lifecyclePaths, kind, name string, 
 	}
 	entry := LockEntry{
 		Fingerprint: fingerprint,
+		Package:     strings.TrimSpace(install.manifest.Source),
+		Kind:        providermanifestv1.NormalizeKind(install.manifest.Kind),
+		Runtime:     releaseRuntimeForManifest(install.manifest, archivePolicyKind(kind)),
+		Version:     strings.TrimSpace(install.manifest.Version),
 		Manifest:    manifestPath,
 		Executable:  executablePath,
 	}
-	if err := writePreparedLockMetadata(install, kind, name, entry); err != nil {
-		return LockEntry{}, fmt.Errorf("write prepared lock metadata for %s %q: %w", kind, name, err)
+	if plugin != nil && plugin.HasLocalSource() {
+		if err := writePreparedLockMetadata(paths, install, kind, name, plugin); err != nil {
+			return LockEntry{}, fmt.Errorf("write prepared lock metadata for %s %q: %w", kind, name, err)
+		}
 	}
 	return entry, nil
 }
@@ -2737,11 +2870,17 @@ func localUILockEntryFromPreparedInstall(paths lifecyclePaths, name string, plug
 	}
 	entry := LockEntry{
 		Fingerprint: fingerprint,
+		Package:     strings.TrimSpace(install.manifest.Source),
+		Kind:        providermanifestv1.NormalizeKind(install.manifest.Kind),
+		Runtime:     releaseRuntimeForManifest(install.manifest, providermanifestv1.KindUI),
+		Version:     strings.TrimSpace(install.manifest.Version),
 		Manifest:    manifestPath,
 		AssetRoot:   assetRoot,
 	}
-	if err := writePreparedLockMetadata(install, providermanifestv1.KindUI, name, entry); err != nil {
-		return LockEntry{}, fmt.Errorf("write prepared lock metadata for ui %q: %w", name, err)
+	if plugin != nil && plugin.HasLocalSource() {
+		if err := writePreparedLockMetadata(paths, install, providermanifestv1.KindUI, name, plugin); err != nil {
+			return LockEntry{}, fmt.Errorf("write prepared lock metadata for ui %q: %w", name, err)
+		}
 	}
 	return entry, nil
 }
@@ -3111,6 +3250,10 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths,
 	validatedDuringPrepare := false
 	if lock == nil {
 		lock, err = ReadLockfile(paths.lockfilePath)
+		if locked && err != nil && os.IsNotExist(err) {
+			lock = newLockfile()
+			err = nil
+		}
 	}
 	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock) || (bootstrapLock == nil && configHasLocalProviderSources(cfg)) || (bootstrapLock == nil && configHasMetadataProviderSources(cfg))) {
 		lock, err = l.PrepareAtPathsWithStatePaths(configPaths, state)
@@ -3393,9 +3536,7 @@ func staticManifestReferencesPackageFiles(manifest *providermanifestv1.Manifest)
 }
 
 func configRequiresStaticLock(cfg *config.Config) bool {
-	return configHasMatchingProviderEntry(cfg, func(entry *config.ProviderEntry) bool {
-		return sourceBacked(entry) && !entry.HasLocalSource()
-	})
+	return configRequiresCommittedLock(cfg)
 }
 
 func configRequiresRemoteStaticLock(cfg *config.Config) bool {
@@ -3550,6 +3691,22 @@ func (l *Lifecycle) applyStaticValidationEntry(ctx context.Context, paths lifecy
 	if provider == nil || !sourceBacked(provider) {
 		return nil
 	}
+	if provider.HasLocalSource() {
+		install, cleanup, _, err := stageLocalSourceInstall(kind, name, provider.SourcePath(), destDir)
+		if err != nil {
+			if cleanup != nil {
+				_ = cleanup()
+			}
+			return err
+		}
+		if err := bind(install.manifestPath, install.manifest); err != nil {
+			if cleanup != nil {
+				_ = cleanup()
+			}
+			return err
+		}
+		return nil
+	}
 	var entry LockEntry
 	found := false
 	if lockEntries != nil {
@@ -3587,28 +3744,6 @@ func (l *Lifecycle) applyStaticValidationEntry(ctx context.Context, paths lifecy
 			provider.ResolvedCatalogSessionOnly = entry.StaticCatalogSessionOnly
 			return bind("", entry.StaticManifest)
 		}
-	}
-	if provider.HasLocalSource() {
-		install, cleanup, _, err := stageLocalSourceInstall(kind, name, provider.SourcePath(), destDir)
-		if err != nil {
-			if cleanup != nil {
-				_ = cleanup()
-			}
-			return err
-		}
-		if found && !preparedManifestMatchesLock(entry, install.manifest) {
-			if cleanup != nil {
-				_ = cleanup()
-			}
-			return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
-		}
-		if err := bind(install.manifestPath, install.manifest); err != nil {
-			if cleanup != nil {
-				_ = cleanup()
-			}
-			return err
-		}
-		return nil
 	}
 	if provider.HasGitSource() && found && len(entry.Archives) == 0 {
 		install, cleanup, _, err := l.stageGitSourceInstall(ctx, paths, kind, name, destDir, provider)
@@ -4013,6 +4148,118 @@ func equivalentProviderManifestPath(current, expected string) bool {
 		currentManifest.Version == expectedManifest.Version
 }
 
+func (l *Lifecycle) ensureLocalPreparedInstall(paths lifecyclePaths, kind, name string, provider *config.ProviderEntry, configMap map[string]any, destDir, subject string, mode artifactMode) (*preparedInstall, error) {
+	if provider == nil || !provider.HasLocalSource() {
+		return nil, fmt.Errorf("%s requires local source configuration", subject)
+	}
+	install, err := inspectPreparedInstall(destDir)
+	needMaterialize := err != nil
+	if !needMaterialize {
+		switch inspectPreparedLockMetadata(paths, install, kind, name, provider, mode) {
+		case preparedLockMetadataMatch:
+			needMaterialize = false
+		default:
+			needMaterialize = true
+		}
+	}
+	if needMaterialize {
+		if !mode.canMaterialize() {
+			return nil, preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
+		}
+		stagedInstall, cleanupStaged, commitStaged, err := stageLocalSourceInstall(kind, name, provider.SourcePath(), destDir)
+		if cleanupStaged != nil {
+			defer func() { _ = cleanupStaged() }()
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := validateInstalledManifestKind(kind, name, stagedInstall.manifest); err != nil {
+			return nil, err
+		}
+		if err := providerpkg.ValidateConfigForManifest(stagedInstall.manifestPath, stagedInstall.manifest, kind, configMap); err != nil {
+			return nil, fmt.Errorf("provider config validation for %s: %w", subject, err)
+		}
+		if err := writePreparedLockMetadata(paths, stagedInstall, kind, name, provider); err != nil {
+			return nil, err
+		}
+		if err := commitStaged(); err != nil {
+			return nil, err
+		}
+		install, err = inspectPreparedInstall(destDir)
+		if err != nil {
+			return nil, fmt.Errorf("read prepared manifest for %s: %w", subject, err)
+		}
+	}
+	if inspectPreparedLockMetadata(paths, install, kind, name, provider, mode) != preparedLockMetadataMatch {
+		return nil, preparedArtifactStaleError(paths, "prepared artifact for %s is missing or stale", subject)
+	}
+	return install, nil
+}
+
+func (l *Lifecycle) applyLocalProviderEntry(paths lifecyclePaths, name string, plugin *config.ProviderEntry, configMap map[string]any, mode artifactMode) error {
+	subject := "provider " + strconv.Quote(name)
+	install, err := l.ensureLocalPreparedInstall(paths, providermanifestv1.KindPlugin, name, plugin, configMap, providerDestDir(paths, name), subject, mode)
+	if err != nil {
+		return err
+	}
+	if err := bindResolvedProviderManifest(name, plugin, install.manifestPath, install.manifest, configMap); err != nil {
+		return err
+	}
+	if install.executablePath != "" {
+		if _, err := os.Stat(install.executablePath); err != nil {
+			return preparedArtifactStaleError(paths, "prepared executable for provider %q not found at %s", name, install.executablePath)
+		}
+		args, err := providerEntrypointArgs(install.manifest)
+		if err != nil {
+			return fmt.Errorf("resolve entrypoint for provider %q: %w", name, err)
+		}
+		plugin.Command = install.executablePath
+		plugin.Args = append([]string(nil), args...)
+	}
+	return nil
+}
+
+func (l *Lifecycle) applyLocalComponentEntry(paths lifecyclePaths, kind, name string, plugin *config.ProviderEntry, configMap map[string]any, destDir string, mode artifactMode) error {
+	subject := fmt.Sprintf("%s %q", kind, name)
+	install, err := l.ensureLocalPreparedInstall(paths, kind, name, plugin, configMap, destDir, subject, mode)
+	if err != nil {
+		return err
+	}
+	if install.executablePath == "" {
+		return preparedArtifactStaleError(paths, "prepared executable for %s %q not found in %s", kind, name, destDir)
+	}
+	if err := bindResolvedComponentManifest(kind, name, plugin, install.manifestPath, install.manifest, configMap); err != nil {
+		return err
+	}
+	if _, err := os.Stat(install.executablePath); err != nil {
+		return preparedArtifactStaleError(paths, "prepared executable for %s %q not found at %s", kind, name, install.executablePath)
+	}
+	args, err := componentEntrypointArgs(install.manifest, kind)
+	if err != nil {
+		return fmt.Errorf("resolve entrypoint for %s %q: %w", kind, name, err)
+	}
+	plugin.Command = install.executablePath
+	plugin.Args = append([]string(nil), args...)
+	return nil
+}
+
+func (l *Lifecycle) applyLocalUIProvider(paths lifecyclePaths, provider *config.ProviderEntry, logicalName, subject, destDir string, configMap map[string]any, mode artifactMode) (string, error) {
+	install, err := l.ensureLocalPreparedInstall(paths, providermanifestv1.KindUI, logicalName, provider, configMap, destDir, subject, mode)
+	if err != nil {
+		return "", err
+	}
+	if install.assetRootPath == "" {
+		return "", fmt.Errorf("prepared asset root for %s not found in %s", subject, destDir)
+	}
+	if _, err := os.Stat(install.assetRootPath); err != nil {
+		return "", fmt.Errorf("prepared asset root for %s not found at %s", subject, install.assetRootPath)
+	}
+	if err := bindResolvedUIManifest(provider, install.manifestPath, install.manifest, configMap); err != nil {
+		return "", err
+	}
+	return install.assetRootPath, nil
+}
+
 func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *LockEntry, provider *config.ProviderEntry, logicalName, subject, destDir string, mode artifactMode) (string, error) {
 	if provider == nil {
 		return "", nil
@@ -4023,10 +4270,13 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 	}
 	switch {
 	case sourceBacked(provider):
-		if lockEntry == nil {
-			if provider.HasLocalSource() && pathWithinRoot(filepath.Join(paths.artifactsDir, ".gestaltd"), provider.SourcePath()) {
+		if provider.HasLocalSource() {
+			if pathWithinRoot(filepath.Join(paths.artifactsDir, ".gestaltd"), provider.SourcePath()) {
 				return bindPathBackedUIManifest(provider, configMap)
 			}
+			return l.applyLocalUIProvider(paths, provider, logicalName, subject, destDir, configMap, mode)
+		}
+		if lockEntry == nil {
 			return "", lockMetadataStaleError(paths, "lock entry for %s is missing or stale", subject)
 		}
 		if !lockEntrySourceMatchesProvider(paths, provider, *lockEntry) {
@@ -4086,7 +4336,7 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 					return "", lockMetadataStaleError(paths, "lock entry for %s is stale", subject)
 				}
 				if provider.HasLocalSource() {
-					if err := writePreparedLockMetadata(stagedInstall, providermanifestv1.KindUI, logicalName, *lockEntry); err != nil {
+					if err := writePreparedLockMetadata(paths, stagedInstall, providermanifestv1.KindUI, logicalName, provider); err != nil {
 						return "", err
 					}
 				}
@@ -4131,6 +4381,12 @@ func (l *Lifecycle) applyComponentProvider(paths lifecyclePaths, lockEntries map
 	}
 	switch {
 	case sourceBacked(provider):
+		if provider.HasLocalSource() {
+			if err := l.applyLocalComponentEntry(paths, kind, name, provider, configMap, destDir, mode); err != nil {
+				return err
+			}
+			break
+		}
 		if lockEntries == nil {
 			return lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", kind, name)
 		}
@@ -4154,6 +4410,9 @@ func (l *Lifecycle) applyComponentProvider(paths lifecyclePaths, lockEntries map
 }
 
 func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfile, name string, plugin *config.ProviderEntry, configMap map[string]any, mode artifactMode) error {
+	if plugin != nil && plugin.HasLocalSource() {
+		return l.applyLocalProviderEntry(paths, name, plugin, configMap, mode)
+	}
 	if lock == nil {
 		return lockMetadataStaleError(paths, "lock entry for provider %q is missing or stale", name)
 	}
@@ -4226,7 +4485,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 				return lockMetadataStaleError(paths, "lock entry for provider %q is stale", name)
 			}
 			if plugin.HasLocalSource() {
-				if err := writePreparedLockMetadata(stagedInstall, providermanifestv1.KindPlugin, name, entry); err != nil {
+				if err := writePreparedLockMetadata(paths, stagedInstall, providermanifestv1.KindPlugin, name, plugin); err != nil {
 					return err
 				}
 			}
@@ -4264,6 +4523,9 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 }
 
 func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockEntry, kind, name string, plugin *config.ProviderEntry, configMap map[string]any, destDir string, mode artifactMode) error {
+	if plugin != nil && plugin.HasLocalSource() {
+		return l.applyLocalComponentEntry(paths, kind, name, plugin, configMap, destDir, mode)
+	}
 	if entry == nil {
 		return lockMetadataStaleError(paths, "lock entry for %s %q is missing or stale", kind, name)
 	}
@@ -4334,7 +4596,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 				return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
 			}
 			if plugin.HasLocalSource() {
-				if err := writePreparedLockMetadata(stagedInstall, kind, name, *entry); err != nil {
+				if err := writePreparedLockMetadata(paths, stagedInstall, kind, name, plugin); err != nil {
 					return err
 				}
 			}
@@ -4419,9 +4681,11 @@ func bindPathBackedUIManifest(plugin *config.ProviderEntry, configMap map[string
 	if strings.TrimSpace(manifestPath) == "" {
 		return "", fmt.Errorf("resolved ui manifest path is required")
 	}
-	if _, err := os.Stat(manifestPath); err != nil {
+	normalized, err := normalizeLocalSource(manifestPath)
+	if err != nil {
 		return "", fmt.Errorf("ui provider manifest not found at %s: %w", manifestPath, err)
 	}
+	manifestPath = normalized.manifestPath
 	_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
 	if err != nil {
 		return "", fmt.Errorf("prepare manifest for ui provider: %w", err)

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -2698,10 +2698,6 @@ func preparedInstallMatchesLockForMode(kind, name string, provider *config.Provi
 	return install != nil && preparedManifestMatchesLock(entry, install.manifest)
 }
 
-func backfillPreparedLockMetadataIfNeeded(kind, name string, provider *config.ProviderEntry, entry LockEntry, install *preparedInstall, mode artifactMode) error {
-	return nil
-}
-
 // resolveArchiveForPlatform looks up a LockArchive for the given platform
 // string using a fallback chain: exact match → generic.
 func resolveArchiveForPlatform(entry LockEntry, platform string) (LockArchive, string, bool) {
@@ -4336,11 +4332,6 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 				if !preparedManifestMatchesLock(*lockEntry, stagedInstall.manifest) {
 					return "", lockMetadataStaleError(paths, "lock entry for %s is stale", subject)
 				}
-				if provider.HasLocalSource() {
-					if err := writePreparedLockMetadata(paths, stagedInstall, providermanifestv1.KindUI, logicalName, provider); err != nil {
-						return "", err
-					}
-				}
 				if err := commitStaged(); err != nil {
 					return "", err
 				}
@@ -4353,9 +4344,6 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths lifecyclePaths, lockEntry *L
 			if err != nil {
 				return "", fmt.Errorf("read prepared manifest for %s: %w", subject, err)
 			}
-		}
-		if err := backfillPreparedLockMetadataIfNeeded(providermanifestv1.KindUI, logicalName, provider, *lockEntry, install, mode); err != nil {
-			return "", err
 		}
 		if install.assetRootPath == "" {
 			return "", fmt.Errorf("prepared asset root for %s not found in %s", subject, destDir)
@@ -4485,11 +4473,6 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 			if !preparedManifestMatchesLock(entry, stagedInstall.manifest) {
 				return lockMetadataStaleError(paths, "lock entry for provider %q is stale", name)
 			}
-			if plugin.HasLocalSource() {
-				if err := writePreparedLockMetadata(paths, stagedInstall, providermanifestv1.KindPlugin, name, plugin); err != nil {
-					return err
-				}
-			}
 			if err := commitStaged(); err != nil {
 				return err
 			}
@@ -4502,9 +4485,6 @@ func (l *Lifecycle) applyLockedProviderEntry(paths lifecyclePaths, lock *Lockfil
 		if err != nil {
 			return fmt.Errorf("read prepared manifest for provider %q: %w", name, err)
 		}
-	}
-	if err := backfillPreparedLockMetadataIfNeeded(providermanifestv1.KindPlugin, name, plugin, entry, install, mode); err != nil {
-		return err
 	}
 	if err := bindResolvedProviderManifest(name, plugin, install.manifestPath, install.manifest, configMap); err != nil {
 		return err
@@ -4596,11 +4576,6 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 			if !preparedManifestMatchesLock(*entry, stagedInstall.manifest) {
 				return lockMetadataStaleError(paths, "lock entry for %s %q is stale", kind, name)
 			}
-			if plugin.HasLocalSource() {
-				if err := writePreparedLockMetadata(paths, stagedInstall, kind, name, plugin); err != nil {
-					return err
-				}
-			}
 			if err := commitStaged(); err != nil {
 				return err
 			}
@@ -4613,9 +4588,6 @@ func (l *Lifecycle) applyLockedComponentEntry(paths lifecyclePaths, entry *LockE
 		if err != nil {
 			return fmt.Errorf("read prepared manifest for %s %q: %w", kind, name, err)
 		}
-	}
-	if err := backfillPreparedLockMetadataIfNeeded(kind, name, plugin, *entry, install, mode); err != nil {
-		return err
 	}
 	if install.executablePath == "" {
 		return preparedArtifactStaleError(paths, "prepared executable for %s %q not found in %s", kind, name, destDir)

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -235,8 +235,56 @@ plugins:
 	}
 
 	lc := NewLifecycle()
-	if _, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+	lock, err := lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	if err != nil {
 		t.Fatalf("LockAtPathsWithStatePaths: %v", err)
+	}
+	if _, ok := lock.Providers["alpha"]; ok {
+		t.Fatalf("local source provider lock entry should be omitted: %#v", lock.Providers)
+	}
+	if _, ok := lock.UIs["roadmap"]; ok {
+		t.Fatalf("local source ui lock entry should be omitted: %#v", lock.UIs)
+	}
+	lockPath := filepath.Join(dir, LockfileName)
+	for _, schemaVersion := range []int{5, 6, 7} {
+		legacyEntry := portableLockEntry{
+			InputDigest: "legacy-local",
+			Kind:        providermanifestv1.KindPlugin,
+			Runtime:     providerReleaseRuntimeExecutable,
+		}
+		if schemaVersion == 7 {
+			legacyEntry.SourceRef = &LockSourceRef{Type: "legacy-local"}
+		}
+		if err := writeJSONFile(lockPath, providerLockfile{
+			Schema:        providerLockSchemaName,
+			SchemaVersion: schemaVersion,
+			Revision:      providerLockRevision,
+			Providers: providerLockBuckets{
+				Plugin: map[string]portableLockEntry{"alpha": legacyEntry},
+				UI: map[string]portableLockEntry{
+					"roadmap": {
+						InputDigest: "legacy-local",
+						Kind:        providermanifestv1.KindUI,
+						Runtime:     providerReleaseRuntimeUI,
+					},
+				},
+			},
+		}); err != nil {
+			t.Fatalf("write schema v%d legacy local source lockfile: %v", schemaVersion, err)
+		}
+		if err := lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{}, nil); err == nil || !strings.Contains(err.Error(), "lockfile is out of date") {
+			t.Fatalf("CheckLockAtPathsWithStatePaths with schema v%d legacy local entries error = %v, want out of date", schemaVersion, err)
+		}
+	}
+	lock, err = lc.LockAtPathsWithStatePaths([]string{configPath}, StatePaths{})
+	if err != nil {
+		t.Fatalf("restore canonical LockAtPathsWithStatePaths: %v", err)
+	}
+	if _, ok := lock.Providers["alpha"]; ok {
+		t.Fatalf("restored local source provider lock entry should be omitted: %#v", lock.Providers)
+	}
+	if _, ok := lock.UIs["roadmap"]; ok {
+		t.Fatalf("restored local source ui lock entry should be omitted: %#v", lock.UIs)
 	}
 	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
 		t.Fatalf("SyncAtPathsWithStatePaths: %v", err)
@@ -261,10 +309,6 @@ plugins:
 	preparedUIMetadata := filepath.Join(filepath.Dir(preparedUI), preparedLockMetadataFile)
 	if _, err := os.Stat(preparedUIMetadata); err != nil {
 		t.Fatalf("prepared ui lock metadata missing before source removal: %v", err)
-	}
-	uiMetadata, err := os.ReadFile(preparedUIMetadata)
-	if err != nil {
-		t.Fatalf("read prepared ui lock metadata before source removal: %v", err)
 	}
 	if err := os.RemoveAll(filepath.Join(dir, "plugins")); err != nil {
 		t.Fatalf("remove plugin source tree: %v", err)
@@ -291,29 +335,11 @@ plugins:
 	if got, want := filepath.ToSlash(ui.ResolvedAssetRoot), filepath.ToSlash(preparedUI); got != want {
 		t.Fatalf("ResolvedAssetRoot = %q, want %q", got, want)
 	}
-	if err := lc.CheckSyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
-		t.Fatalf("CheckSyncAtPathsWithStatePaths without local source tree: %v", err)
+	if err := lc.CheckSyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err == nil || !strings.Contains(err.Error(), `prepared artifact for provider "alpha" is missing or stale`) {
+		t.Fatalf("CheckSyncAtPathsWithStatePaths without local source tree error = %v, want stale provider artifact", err)
 	}
-	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
-		t.Fatalf("SyncAtPathsWithStatePaths without local source tree: %v", err)
-	}
-	if err := os.Remove(preparedProviderMetadata); err != nil {
-		t.Fatalf("remove prepared provider lock metadata without source tree: %v", err)
-	}
-	if err := lc.CheckSyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err == nil || !strings.Contains(err.Error(), "lockfile is out of date") {
-		t.Fatalf("CheckSyncAtPathsWithStatePaths without source tree or provider metadata error = %v, want stale lockfile", err)
-	}
-	if err := os.WriteFile(preparedProviderMetadata, providerMetadata, 0o644); err != nil {
-		t.Fatalf("restore prepared provider lock metadata without source tree: %v", err)
-	}
-	if err := os.Remove(preparedUIMetadata); err != nil {
-		t.Fatalf("remove prepared ui lock metadata without source tree: %v", err)
-	}
-	if err := lc.CheckSyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err == nil || !strings.Contains(err.Error(), "lockfile is out of date") {
-		t.Fatalf("CheckSyncAtPathsWithStatePaths without source tree or ui metadata error = %v, want stale lockfile", err)
-	}
-	if err := os.WriteFile(preparedUIMetadata, uiMetadata, 0o644); err != nil {
-		t.Fatalf("restore prepared ui lock metadata without source tree: %v", err)
+	if err := lc.SyncAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err == nil || !strings.Contains(err.Error(), `manifest for plugin "alpha" not found`) {
+		t.Fatalf("SyncAtPathsWithStatePaths without local source tree error = %v, want missing source manifest", err)
 	}
 
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
@@ -400,6 +426,12 @@ func TestLoadForExecutionPluginScopeIgnoresUnrelatedLocalSources(t *testing.T) {
 
 	dir := t.TempDir()
 	writeSourceProviderTree(t, filepath.Join(dir, "plugins", "alpha"), "github.com/acme/tools/plugins/alpha", "1.2.3", "alpha-binary")
+	externalCredentialsManifestPath := writeExecutableSourceManifest(t, dir, "external-credentials-local", "github.com/acme/tools/external-credentials/local", "0.1.0", providermanifestv1.KindExternalCredentials, []localExecutableManifestArtifact{{
+		goos:       runtime.GOOS,
+		goarch:     runtime.GOARCH,
+		binaryName: "external-credentials-local",
+		data:       []byte("external-credentials-local-binary"),
+	}})
 
 	artifactsDir := filepath.Join(dir, "artifacts")
 	configPath := filepath.Join(dir, "gestaltd.yaml")
@@ -425,6 +457,10 @@ workflows:
           id: test
           kind: test
 %s
+  externalCredentials:
+    local:
+      source:
+        path: %s
   secrets:
     runtime_env:
       source: env
@@ -447,6 +483,7 @@ workflows:
 server:
   providers:
     indexeddb: sqlite
+    externalCredentials: local
     secrets: runtime_env
   artifactsDir: %s
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -463,7 +500,7 @@ plugins:
     connections:
       default:
         ref: ${GESTALT_SCOPED_PLUGIN_TEST_MISSING_CONNECTION_REF}
-`, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), filepath.ToSlash(artifactsDir))
+`, requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), externalCredentialsManifestPath, filepath.ToSlash(artifactsDir))
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -506,11 +543,17 @@ plugins:
 	if err != nil {
 		t.Fatalf("read scoped lockfile: %v", err)
 	}
-	if _, ok := lock.Providers["alpha"]; !ok {
-		t.Fatalf("scoped lock missing alpha provider: %+v", lock.Providers)
+	if len(lock.Providers) != 0 {
+		t.Fatalf("scoped local-source lock should not include providers: %+v", lock.Providers)
 	}
 	if _, ok := lock.Providers["beta"]; ok {
 		t.Fatalf("scoped lock should not include beta provider: %+v", lock.Providers)
+	}
+	if err := os.Remove(scopedLockPath); err != nil {
+		t.Fatalf("remove empty scoped lockfile: %v", err)
+	}
+	if err := lc.CheckLockAtPathsWithStatePaths([]string{configPath}, StatePaths{PluginScope: []string{"alpha"}}, nil); err != nil {
+		t.Fatalf("CheckLockAtPathsWithStatePaths should allow missing local-only scoped lockfile: %v", err)
 	}
 
 	explicitArtifactsDir := filepath.Join(dir, "explicit-artifacts")
@@ -606,8 +649,9 @@ plugins:
 	if err == nil {
 		t.Fatal("locked scoped load unexpectedly succeeded without scoped state")
 	}
-	if !strings.Contains(err.Error(), `scoped local plugin state is missing or stale for plugin "alpha"`) {
-		t.Fatalf("error = %v, want scoped local plugin state guidance", err)
+	if !strings.Contains(err.Error(), `prepared artifact for provider "alpha" is missing or stale`) ||
+		!strings.Contains(err.Error(), `scoped local state for plugin "alpha"`) {
+		t.Fatalf("error = %v, want scoped prepared artifact guidance", err)
 	}
 }
 
@@ -1100,6 +1144,60 @@ func writeProviderReleaseMetadataFile(t *testing.T, path string, metadata provid
 	}
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		t.Fatalf("write metadata: %v", err)
+	}
+}
+
+func TestFingerprintLocalReleaseMetadataIgnoresAdjacentSourceTree(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sourceDir := filepath.Join(dir, "provider")
+	writeSourceProviderTree(t, sourceDir, "github.com/acme/providers/alpha", "1.0.0", "alpha-binary")
+	metadataPath := filepath.Join(sourceDir, "dist", "provider-release.yaml")
+	writeProviderReleaseMetadataFile(t, metadataPath, providerReleaseMetadata{
+		Schema:        providerReleaseSchemaName,
+		SchemaVersion: providerReleaseSchemaVersion,
+		Package:       "github.com/acme/providers/alpha",
+		Kind:          providermanifestv1.KindPlugin,
+		Runtime:       providerReleaseRuntimeExecutable,
+		Version:       "1.0.0",
+		Artifacts: map[string]providerReleaseArtifact{
+			platformKeyGeneric: {Path: "alpha.tar.gz", SHA256: "abc123"},
+		},
+	})
+
+	first, err := fingerprintLocalReleaseMetadataDigest(metadataPath)
+	if err != nil {
+		t.Fatalf("fingerprintLocalReleaseMetadataDigest first: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "provider.go"), []byte("source changed\n"), 0o644); err != nil {
+		t.Fatalf("mutate adjacent source tree: %v", err)
+	}
+	second, err := fingerprintLocalReleaseMetadataDigest(metadataPath)
+	if err != nil {
+		t.Fatalf("fingerprintLocalReleaseMetadataDigest second: %v", err)
+	}
+	if second != first {
+		t.Fatalf("local release metadata digest changed after adjacent source edit: %q != %q", second, first)
+	}
+
+	writeProviderReleaseMetadataFile(t, metadataPath, providerReleaseMetadata{
+		Schema:        providerReleaseSchemaName,
+		SchemaVersion: providerReleaseSchemaVersion,
+		Package:       "github.com/acme/providers/alpha",
+		Kind:          providermanifestv1.KindPlugin,
+		Runtime:       providerReleaseRuntimeExecutable,
+		Version:       "1.0.1",
+		Artifacts: map[string]providerReleaseArtifact{
+			platformKeyGeneric: {Path: "alpha.tar.gz", SHA256: "abc123"},
+		},
+	})
+	third, err := fingerprintLocalReleaseMetadataDigest(metadataPath)
+	if err != nil {
+		t.Fatalf("fingerprintLocalReleaseMetadataDigest third: %v", err)
+	}
+	if third == first {
+		t.Fatalf("local release metadata digest did not change after metadata edit: %q", third)
 	}
 }
 
@@ -4801,14 +4899,8 @@ func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.
 	if err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
-	if len(lock.IndexedDBs) != 2 {
-		t.Fatalf("lock.IndexedDBs = %#v, want 2 entries", lock.IndexedDBs)
-	}
-	if _, ok := lock.IndexedDBs["main"]; !ok {
-		t.Fatal(`lock.IndexedDBs["main"] not found`)
-	}
-	if _, ok := lock.IndexedDBs["archive"]; !ok {
-		t.Fatal(`lock.IndexedDBs["archive"] not found`)
+	if len(lock.IndexedDBs) != 0 {
+		t.Fatalf("lock.IndexedDBs = %#v, want no local source entries", lock.IndexedDBs)
 	}
 
 	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
@@ -4816,6 +4908,10 @@ func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
 
+	wantBinaries := map[string]string{
+		"main":    "indexeddb-main",
+		"archive": "indexeddb-archive",
+	}
 	for _, name := range []string{"main", "archive"} {
 		entry := cfg.Providers.IndexedDB[name]
 		if entry == nil {
@@ -4826,7 +4922,7 @@ func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.
 			t.Fatalf("cfg.Providers.IndexedDB[%q].ResolvedManifest = nil", name)
 			return
 		}
-		wantCommand := resolveLockPath(artifactsDir, lock.IndexedDBs[name].Executable)
+		wantCommand := filepath.Join(artifactsDir, "indexeddb", name, "artifacts", runtime.GOOS, runtime.GOARCH, wantBinaries[name])
 		if entry.Command != wantCommand {
 			t.Fatalf("cfg.Providers.IndexedDB[%q].Command = %q, want %q", name, entry.Command, wantCommand)
 		}
@@ -4906,14 +5002,8 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrepareAtPath: %v", err)
 	}
-	if len(lock.Caches) != 2 {
-		t.Fatalf("lock.Caches = %#v, want 2 entries", lock.Caches)
-	}
-	if _, ok := lock.Caches["session"]; !ok {
-		t.Fatal(`lock.Caches["session"] not found`)
-	}
-	if _, ok := lock.Caches["rate_limit"]; !ok {
-		t.Fatal(`lock.Caches["rate_limit"] not found`)
+	if len(lock.Caches) != 0 {
+		t.Fatalf("lock.Caches = %#v, want no local source entries", lock.Caches)
 	}
 	lockPath := filepath.Join(dir, LockfileName)
 	lockData, err := os.ReadFile(lockPath)
@@ -4924,11 +5014,8 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 	if err := json.Unmarshal(lockData, &diskLock); err != nil {
 		t.Fatalf("Unmarshal lockfile: %v", err)
 	}
-	if _, ok := diskLock.Providers.Cache["session"]; !ok {
-		t.Fatal(`disk lock cache["session"] not found`)
-	}
-	if _, ok := diskLock.Providers.Cache["rate_limit"]; !ok {
-		t.Fatal(`disk lock cache["rate_limit"] not found`)
+	if len(diskLock.Providers.Cache) != 0 {
+		t.Fatalf("disk lock cache entries = %#v, want no local source entries", diskLock.Providers.Cache)
 	}
 
 	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
@@ -4940,6 +5027,10 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 		"session":    "generated-secret-value",
 		"rate_limit": "ghp_inline_auth_source_token",
 	}
+	wantBinaries := map[string]string{
+		"session":    "cache-session",
+		"rate_limit": "cache-rate-limit",
+	}
 	for _, name := range []string{"session", "rate_limit"} {
 		entry := cfg.Providers.Cache[name]
 		if entry == nil {
@@ -4950,7 +5041,7 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 			t.Fatalf("cfg.Providers.Cache[%q].ResolvedManifest = nil", name)
 			return
 		}
-		wantCommand := resolveLockPath(artifactsDir, lock.Caches[name].Executable)
+		wantCommand := filepath.Join(artifactsDir, ".gestaltd", "cache", name, "artifacts", runtime.GOOS, runtime.GOARCH, wantBinaries[name])
 		if entry.Command != wantCommand {
 			t.Fatalf("cfg.Providers.Cache[%q].Command = %q, want %q", name, entry.Command, wantCommand)
 		}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1589,7 +1589,7 @@ plugins:
 	}
 }
 
-func TestLoadForExecutionAtPath_RejectsLockedExplicitLocalUIWithoutPreparedUILockEntry(t *testing.T) {
+func TestLoadForExecutionAtPath_AllowsLockedExplicitLocalUIWithoutPreparedUILockEntry(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -1644,8 +1644,12 @@ server:
 		t.Fatalf("WriteLockfile: %v", err)
 	}
 
-	if _, _, err := lc.LoadForExecutionAtPath(cfgPath, true); err == nil || !strings.Contains(err.Error(), `lock entry for ui "roadmap" is missing or stale`) {
-		t.Fatalf("LoadForExecutionAtPath locked error = %v, want missing lock entry", err)
+	cfgLoaded, _, err := lc.LoadForExecutionAtPath(cfgPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath locked: %v", err)
+	}
+	if cfgLoaded.Providers.UI["roadmap"].ResolvedManifest == nil {
+		t.Fatal(`Providers.UI["roadmap"].ResolvedManifest = nil`)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stop serializing `source.path` local providers into canonical `gestalt.lock.json`; committed lockfiles now pin external/release-resolved sources only.
- Move local source freshness checks into prepared artifact metadata with source identity, source input digest, manifest/runtime/platform, and output digest.
- Allow missing lockfiles only for effective local-only source-tree configs, while keeping external/package/git/release-backed configs locked.
- Update static validation and provider status so local source providers are staged from checkout and reported as source-backed rather than lock-drifted.

## Why

Local source edits were churning committed lockfiles even though those providers are defined by the checkout itself. The committed lockfile should review stable external/release inputs, while local build correctness should be proven by prepared artifact metadata.

## Impact

`gestaltd lock` rewrites legacy local source lock entries out of the canonical lockfile. `lock --check` fails when older schema v5/v6/v7 lockfiles still contain those local entries. `serve --locked` verifies prepared outputs without reading source, while `sync --locked --check` remains the build-phase gate that verifies prepared artifacts match the current checkout.

## Validation

- `go test ./internal/operator`
- `go test ./internal/daemon -run '^$'`
- `go test ./internal/daemon -run 'TestE2EProviderListOfflineAndLockStatus'`
- `git diff --check -- gestaltd/internal/operator/lifecycle.go gestaltd/internal/operator/lifecycle_source_test.go gestaltd/internal/operator/lifecycle_test.go gestaltd/internal/daemon/provider_lifecycle.go`
