### PR TITLE
[codex] Document plugin-admin authorization grants

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -288,8 +288,11 @@ streaming output to interaction prompts when a provider requests input.
 ## Authorization
 
 `gestalt authorization` covers service account subjects and the dynamic
-authorization admin surface. Admin subcommands may require `--url` pointing at
-the management base URL when public and management listeners are split.
+authorization admin surface. Built-in Gestalt admins can manage all dynamic
+grants. Plugin admins can manage members for the specific plugins they
+administer, so they can grant users or service accounts access without being
+global Gestalt admins. Admin subcommands may require `--url` pointing at the
+management base URL when public and management listeners are split.
 
 ```sh
 gestalt authorization subjects list
@@ -336,6 +339,9 @@ gestalt authorization plugins members list github
 gestalt authorization plugins members set github \
   --subject-id service_account:release-bot \
   --role viewer
+gestalt authorization plugins members set github \
+  --email operator@example.com \
+  --role admin
 gestalt authorization plugins members remove github service_account:release-bot
 
 gestalt authorization admins members list

--- a/docs/content/providers/authorization.mdx
+++ b/docs/content/providers/authorization.mdx
@@ -72,6 +72,37 @@ If static and dynamic grants both match the same subject and resource, static
 wins. For example, if config grants Alice `admin` on the admin policy, Gestalt
 does not ask the provider for Alice's admin role.
 
+## Grant Dynamic Plugin Access
+
+Use the `gestalt authorization` CLI to grant plugin access after the server is
+running. Built-in Gestalt admins can manage every plugin. Plugin admins can
+manage members for plugins they administer.
+
+```sh
+gestalt authorization plugins list
+gestalt authorization plugins members list github
+
+gestalt authorization plugins members set github \
+  --email operator@example.com \
+  --role viewer
+
+gestalt authorization plugins members set github \
+  --subject-id service_account:release-bot \
+  --role editor
+```
+
+Create service account subjects first, then grant those subjects plugin roles:
+
+```sh
+gestalt authorization subjects create release-bot \
+  --display-name "Release Bot"
+gestalt authorization subjects grants set service_account:release-bot github \
+  --role viewer
+```
+
+Deployments that split public and management listeners may need `--url` set to
+the management base URL for these admin commands.
+
 ## Where Gestalt Uses Authorization
 
 Gestalt checks authorization before serving protected surfaces:


### PR DESCRIPTION
## Summary
- Document that plugin admins can manage members for plugins they administer without being global Gestalt admins.
- Add dynamic plugin grant examples to the authorization provider docs.
- Keep the command audit scoped: the client CLI reference already covers the current `gestalt` command tree broadly, so this PR only tightens the authorization-granting guidance.

## Validation
- `npm run build:single` from `docs/`