### PR TITLE
[codex] Make integration listing use static overlays

### DIFF
--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -169,7 +169,12 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	}
 
 	names := s.providers.List()
-	out := make([]integrationInfo, 0, len(names))
+	type authorizedProvider struct {
+		name string
+		prov core.Provider
+	}
+	authorized := make([]authorizedProvider, 0, len(names))
+	authorizedNames := make([]string, 0, len(names))
 	for _, name := range names {
 		if !s.allowProviderContext(r.Context(), p, name) {
 			continue
@@ -178,26 +183,44 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			continue
 		}
-		surfaceProv := prov
-		if override, ok, err := s.providerOverrideForContext(r.Context(), p, name); err != nil {
-			slog.ErrorContext(r.Context(), "resolving provider dev override", "provider", name, "error", err)
-			writeError(w, http.StatusInternalServerError, "failed to resolve provider dev override")
-			return
-		} else if ok {
-			surfaceProv = override
+		authorized = append(authorized, authorizedProvider{name: name, prov: prov})
+		authorizedNames = append(authorizedNames, name)
+	}
+	overlays, err := s.providerDevSessions.ResolveListOverlays(r.Context(), p, authorizedNames)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "resolving provider dev list overlays", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to resolve provider dev overrides")
+		return
+	}
+
+	out := make([]integrationInfo, 0, len(authorized))
+	for _, item := range authorized {
+		name := item.name
+		prov := item.prov
+		overlay, hasOverlay := overlays[name]
+		displayName := prov.DisplayName()
+		if hasOverlay && overlay.DisplayName != "" {
+			displayName = overlay.DisplayName
+		}
+		description := prov.Description()
+		if hasOverlay && overlay.Description != "" {
+			description = overlay.Description
 		}
 		info := integrationInfo{
 			Name:            name,
-			DisplayName:     surfaceProv.DisplayName(),
-			Description:     surfaceProv.Description(),
+			DisplayName:     displayName,
+			Description:     description,
 			Connections:     []connectionDefInfo{},
 			Status:          connectionStatusUnknown,
 			CredentialState: credentialStateUnknown,
 			HealthState:     healthStateUnknown,
 			Actions:         []string{},
 		}
-		if cat := surfaceProv.Catalog(); cat != nil {
+		if cat := prov.Catalog(); cat != nil {
 			info.IconSVG = cat.IconSVG
+		}
+		if hasOverlay && strings.TrimSpace(overlay.IconSVG) != "" {
+			info.IconSVG = strings.TrimSpace(overlay.IconSVG)
 		}
 		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
@@ -206,7 +229,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		authTypes := s.populateIntegrationSettings(&info, prov, instances, p)
 		s.applyIntegrationConnectionStatus(&info, prov, instances, authTypes, p)
 		info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, info.MountedPath)
-		if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, surfaceProv, info) {
+		if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, prov, info, overlay.Catalog) {
 			continue
 		}
 		out = append(out, info)

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -5,18 +5,19 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/services/identity/principal"
 	"github.com/valon-technologies/gestalt/server/services/invocation"
 )
 
-func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider, info integrationInfo) bool {
+func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider, info integrationInfo, catalogOverride *catalog.Catalog) bool {
 	if info.MountedPath != "" {
 		return true
 	}
 	if s.integrationHasSettingsSurface(p, info) {
 		return true
 	}
-	return s.integrationHasVisibleHTTPOperationsContext(ctx, p, provider, prov)
+	return s.integrationHasVisibleHTTPOperationsContext(ctx, p, provider, prov, catalogOverride)
 }
 
 func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
@@ -29,8 +30,11 @@ func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info inte
 		len(info.Connections) > 0
 }
 
-func (s *Server) integrationHasVisibleHTTPOperationsContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider) bool {
-	cat := prov.Catalog()
+func (s *Server) integrationHasVisibleHTTPOperationsContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider, catalogOverride *catalog.Catalog) bool {
+	cat := catalogOverride
+	if cat == nil {
+		cat = prov.Catalog()
+	}
 	if cat == nil {
 		return false
 	}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -9149,6 +9149,126 @@ func TestListIntegrations(t *testing.T) {
 	}
 }
 
+func TestListIntegrations_ProviderDevListOverlayDoesNotResolveProviderProcess(t *testing.T) {
+	t.Parallel()
+
+	const iconSVG = `<svg viewBox="0 0 1 1"></svg>`
+	svc := testutil.NewStubServices(t)
+	seedUserRecord(t, svc, "user-123", "owner@example.test", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+
+	manager, err := providerdev.NewManager([]providerdev.Target{{
+		Name: "roadmap",
+		Spec: pluginservice.StaticProviderSpec{
+			Name:           "roadmap",
+			DisplayName:    "Remote Roadmap",
+			Description:    "Remote description",
+			ConnectionMode: core.ConnectionModeUser,
+			Catalog: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{{
+					ID:        "remote-only",
+					Transport: catalog.TransportPlugin,
+				}},
+			},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	owner := &principal.Principal{SubjectID: principal.UserSubjectID("user-123"), UserID: "user-123", Kind: principal.KindUser}
+	if _, err := manager.CreateSession(context.Background(), owner, providerdev.CreateSessionRequest{Providers: []providerdev.AttachProvider{{
+		Name: "roadmap",
+		Spec: pluginservice.StaticProviderSpec{
+			Name:           "roadmap",
+			DisplayName:    "Local Roadmap",
+			Description:    "Local description",
+			IconSVG:        iconSVG,
+			ConnectionMode: core.ConnectionModeUser,
+			AuthTypes:      []string{"oauth2"},
+			CredentialFields: []core.CredentialFieldDef{{
+				Name:  "api_key",
+				Label: "API key",
+			}},
+			Catalog: &catalog.Catalog{
+				Operations: []catalog.CatalogOperation{{
+					ID: "local-only",
+				}},
+			},
+		},
+	}}}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	staticProvider := &coretesting.StubIntegration{
+		N:        "roadmap",
+		DN:       "Static Roadmap",
+		Desc:     "Static description",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{{
+				ID:        "static-only",
+				Transport: catalog.TransportPlugin,
+			}},
+		},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "owner-session" {
+					return nil, principal.ErrInvalidToken
+				}
+				return &core.UserIdentity{Email: "owner@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Providers = testutil.NewProviderRegistry(t, staticProvider)
+		cfg.ProviderDevSessions = manager
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("Authorization", "Bearer owner-session")
+	client := ts.Client()
+	client.Timeout = 2 * time.Second
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, body)
+	}
+
+	var integrations []struct {
+		Name            string   `json:"name"`
+		DisplayName     string   `json:"displayName"`
+		Description     string   `json:"description"`
+		IconSVG         string   `json:"iconSvg"`
+		Status          string   `json:"status"`
+		CredentialState string   `json:"credentialState"`
+		Actions         []string `json:"actions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 1 {
+		t.Fatalf("integrations = %#v, want one", integrations)
+	}
+	got := integrations[0]
+	if got.Name != "roadmap" || got.DisplayName != "Local Roadmap" || got.Description != "Local description" {
+		t.Fatalf("integration metadata = %#v, want provider-dev display overlay", got)
+	}
+	if got.IconSVG != iconSVG {
+		t.Fatalf("iconSvg = %q, want overlay icon", got.IconSVG)
+	}
+	if got.Status != "ready" || got.CredentialState != "not_required" || len(got.Actions) != 0 {
+		t.Fatalf("status = {%q, %q, %v}, want static provider no-credential status", got.Status, got.CredentialState, got.Actions)
+	}
+}
+
 func TestListIntegrations_IncludesMountedPath(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/providerdev/indexeddb_store.go
+++ b/gestaltd/services/providerdev/indexeddb_store.go
@@ -799,6 +799,50 @@ func (s *indexedDBSessionStore) latestTarget(ctx context.Context, owner, provide
 	return latest, latestTarget, true, nil
 }
 
+func (s *indexedDBSessionStore) latestTargetsForProviders(ctx context.Context, owner string, providerNames map[string]struct{}, now time.Time) (map[string]Target, error) {
+	if s == nil || len(providerNames) == 0 {
+		return nil, nil
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	records, err := s.db.ObjectStore(indexedDBAttachmentStore).Index("by_owner").GetAll(ctx, nil, owner)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list provider dev attachments: %v", err)
+	}
+	latest := make(map[string]indexedDBSessionRecord, len(providerNames))
+	targets := make(map[string]Target, len(providerNames))
+	for _, raw := range records {
+		session, err := sessionFromRecord(raw)
+		if err != nil {
+			return nil, err
+		}
+		if session.owner != owner || !attachmentActive(session, now) {
+			continue
+		}
+		for i := range session.targets {
+			target := &session.targets[i]
+			if _, ok := providerNames[target.Name]; !ok {
+				continue
+			}
+			current, ok := latest[target.Name]
+			if ok && !sessionNewerThan(session, current) {
+				continue
+			}
+			latest[target.Name] = session
+			targets[target.Name] = target.target()
+		}
+	}
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	return targets, nil
+}
+
+func sessionNewerThan(a, b indexedDBSessionRecord) bool {
+	return a.createdAt.After(b.createdAt) || (a.createdAt.Equal(b.createdAt) && a.id > b.id)
+}
+
 func (s *indexedDBSessionStore) getActiveAttachment(ctx context.Context, id string, now time.Time) (*indexedDBSessionRecord, error) {
 	raw, err := s.db.ObjectStore(indexedDBAttachmentStore).Get(ctx, strings.TrimSpace(id))
 	if err != nil {

--- a/gestaltd/services/providerdev/session.go
+++ b/gestaltd/services/providerdev/session.go
@@ -91,6 +91,13 @@ type AttachProvider struct {
 	UI     bool                             `json:"ui,omitempty"`
 }
 
+type ProviderListOverlay struct {
+	DisplayName string
+	Description string
+	IconSVG     string
+	Catalog     *catalog.Catalog
+}
+
 type CreateSessionResponse struct {
 	AttachID         string                  `json:"attachId,omitempty"`
 	DispatcherSecret string                  `json:"dispatcherSecret,omitempty"`
@@ -926,6 +933,86 @@ func (m *Manager) ResolveProviderOverride(ctx context.Context, p *principal.Prin
 		return prov, true, nil
 	}
 	return nil, false, nil
+}
+
+func (m *Manager) ResolveListOverlays(ctx context.Context, p *principal.Principal, providerNames []string) (map[string]ProviderListOverlay, error) {
+	if m == nil {
+		return nil, nil
+	}
+	owner := principalSubjectID(p)
+	if owner == "" {
+		return nil, nil
+	}
+	names := normalizeProviderNameSet(providerNames)
+	if len(names) == 0 {
+		return nil, nil
+	}
+	now := time.Now()
+	if m.shared != nil {
+		targets, err := m.shared.latestTargetsForProviders(ctx, owner, names, now)
+		if err != nil {
+			return nil, err
+		}
+		out := make(map[string]ProviderListOverlay, len(targets))
+		for name := range targets {
+			target := m.hydrateSharedTarget(targets[name])
+			out[name] = providerListOverlayFromTarget(target)
+		}
+		return out, nil
+	}
+
+	sessions := m.sessionsForOwner(owner)
+	out := make(map[string]ProviderListOverlay, len(names))
+	for i := range sessions {
+		session := sessions[i]
+		if session == nil || session.isIdleExpired(now) {
+			continue
+		}
+		session.mu.Lock()
+		if !session.closed {
+			for name := range names {
+				target := session.targets[name]
+				if target == nil {
+					continue
+				}
+				out[name] = providerListOverlayFromTarget(target.target)
+			}
+		}
+		session.mu.Unlock()
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func normalizeProviderNameSet(providerNames []string) map[string]struct{} {
+	if len(providerNames) == 0 {
+		return nil
+	}
+	names := make(map[string]struct{}, len(providerNames))
+	for _, name := range providerNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		names[name] = struct{}{}
+	}
+	return names
+}
+
+func providerListOverlayFromTarget(target Target) ProviderListOverlay {
+	spec := target.Spec
+	var cat *catalog.Catalog
+	if spec.Catalog != nil {
+		cat = spec.Catalog.Clone()
+	}
+	return ProviderListOverlay{
+		DisplayName: strings.TrimSpace(spec.DisplayName),
+		Description: strings.TrimSpace(spec.Description),
+		IconSVG:     strings.TrimSpace(spec.IconSVG),
+		Catalog:     cat,
+	}
 }
 
 func (m *Manager) hydrateSharedTarget(target Target) Target {

--- a/gestaltd/services/providerdev/session_test.go
+++ b/gestaltd/services/providerdev/session_test.go
@@ -860,6 +860,69 @@ func TestCreateSessionMatchesProviderBySource(t *testing.T) {
 	}
 }
 
+func TestResolveListOverlaysReturnsMetadataWithoutDispatcher(t *testing.T) {
+	t.Parallel()
+
+	const iconSVG = `<svg viewBox="0 0 1 1"></svg>`
+	manager, err := NewManager([]Target{{
+		Name:   "roadmap",
+		Source: "github.com/acme/plugins/roadmap",
+		Spec: pluginservice.StaticProviderSpec{
+			Name:        "roadmap",
+			DisplayName: "Remote Roadmap",
+			Description: "Remote description",
+			IconSVG:     iconSVG,
+			Catalog: &catalog.Catalog{
+				Operations: []catalog.CatalogOperation{{
+					ID: "remote-only",
+				}},
+			},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	if _, err := manager.CreateSession(context.Background(), p, CreateSessionRequest{Providers: []AttachProvider{{
+		Name: "roadmap",
+		Spec: pluginservice.StaticProviderSpec{
+			Name:        "roadmap",
+			DisplayName: "Local Roadmap",
+			Description: "Local description",
+			IconSVG:     iconSVG,
+			Catalog: &catalog.Catalog{
+				Operations: []catalog.CatalogOperation{{
+					ID: "local-only",
+				}},
+			},
+		},
+	}}}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	overlays, err := manager.ResolveListOverlays(context.Background(), p, []string{"roadmap"})
+	if err != nil {
+		t.Fatalf("ResolveListOverlays: %v", err)
+	}
+	overlay, ok := overlays["roadmap"]
+	if !ok {
+		t.Fatalf("ResolveListOverlays missing roadmap overlay: %#v", overlays)
+	}
+	if overlay.DisplayName != "Local Roadmap" || overlay.Description != "Local description" {
+		t.Fatalf("overlay metadata = {%q, %q}, want local metadata", overlay.DisplayName, overlay.Description)
+	}
+	if overlay.IconSVG != iconSVG {
+		t.Fatalf("overlay icon = %q, want %q", overlay.IconSVG, iconSVG)
+	}
+	if overlay.Catalog == nil {
+		t.Fatal("overlay catalog is nil")
+	}
+	if len(overlay.Catalog.Operations) != 1 || overlay.Catalog.Operations[0].ID != "local-only" {
+		t.Fatalf("overlay operations = %#v, want local-only", overlay.Catalog.Operations)
+	}
+}
+
 func TestHTTPTransportCreateSessionExplicitConfigOverridesRemoteConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
`/api/v1/integrations` now authorizes static provider names first, then asks provider-dev once for list-only overlays for those names. This replaces the old per-provider `ResolveProviderOverride` list path, avoiding provider-dev cleanup, provider construction, dispatcher calls, and process resolution while listing integrations. Static providers remain authoritative for connection/status/auth/settings; provider-dev only supplies list display metadata and catalog visibility input.

## Interfaces
Added internal Go API `(*providerdev.Manager).ResolveListOverlays(ctx, principal, providerNames) (map[string]ProviderListOverlay, error)`. Server list visibility helpers now accept `catalogOverride *catalog.Catalog` so list visibility can use provider-dev catalog data without wrapping or constructing providers.

## Data
`ProviderListOverlay` is a new read model owned by `services/providerdev` and consumed by `internal/server`: `DisplayName`, `Description`, `IconSVG`, `Catalog`.

Shared provider-dev data is read from the existing IndexedDB object store `provider_dev_attachments`, owned by `services/providerdev`: columns `id`, `owner`, `dispatcher_secret_hash`, `targets_json`, `created_at`, `last_seen_at`, `closed`, `closed_at`; indexes `by_owner(owner)` and `by_owner_created_at(owner, created_at)`. `targets_json` decodes to `[]storedTarget{name, source, spec, config, configSet, ui, uiPath}`; this PR reads `spec` to build overlays.

In-memory provider-dev sessions use existing `Session.targets`, also owned by `services/providerdev`. The `/api/v1/integrations` response assembly remains owned by `internal/server`.

## Test plan
Passed from a clean detached worktree at `cff64e159`: `go test ./internal/server ./services/providerdev ./services/authorization` and `golangci-lint run --path-prefix=gestaltd ./services/providerdev ./internal/server`. The shared worktree test run is blocked by unrelated dirty workflow edits (`services/workflows/workflowmanager/manager.go` unused import).
