### PR TITLE
Keep SDK-native source provider builds

### DIFF
--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -333,7 +333,7 @@ See [Provider Manifests](/reference/plugin-manifests) for the full field referen
 
 ### Defining operations
 
-Operations are the callable units of a plugin. Each operation has an ID, an HTTP method, input and output types, and a handler function. Executable source plugins must declare `build.command` and `entrypoint.artifactPath`; Gestalt runs the build and then starts the declared artifact for local source execution and release.
+Operations are the callable units of a plugin. Each operation has an ID, an HTTP method, input and output types, and a handler function. Executable source plugins can use SDK-native source package metadata, or declare `build.command` and `entrypoint.artifactPath` when they need a custom build.
 
 The following example defines a `conversations.getMessage` operation that fetches a single Slack message by channel and timestamp. The handler uses the resolved runtime token from the request context to call the Slack API.
 

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -57,7 +57,7 @@ import { Callout } from 'nextra/components'
 | `gestaltd provider attach detach --remote URL ATTACH_ID` | Detach a stuck remote provider-dev attachment owned by your authenticated principal. |
 | `gestaltd provider validate --path PATH` | Validate a local source plugin or UI bundle inside the same synthesized Gestalt config used by `gestaltd serve --path`. |
 | `gestaltd provider validate --config PATH` | Validate the target provider together with selected supporting providers and `null` deletions from layered config overlays. |
-| `gestaltd provider release --version VERSION` | Build and package a provider release. Executable source providers require `build.command` and default to the host platform; UI and declarative providers default to a generic archive. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
+| `gestaltd provider release --version VERSION` | Build and package a provider release. Executable source providers use SDK-native source packages or `build.command` and default to the host platform; UI and declarative providers default to a generic archive. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
 | `gestaltd provider release --output DIR` | Output directory for the release archive. Defaults to `dist/`. |
 
 For config-free local development, inferred UI mount paths use the manifest

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -809,14 +809,12 @@ and MCP may be added alongside either or both.
 
 A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `spec.surfaces.mcp` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
 
-Executable source providers must declare top-level `build.command` and
-`entrypoint.artifactPath`. Gestalt runs the command before source-manifest
-preparation and requires the command to produce that artifact path. The command
-can call any language runtime or compiler available in the preparation
-environment; Gestalt does not infer a language, read language-specific target
-metadata, or synthesize executable wrappers. Source manifests must not include
-`artifacts`; prepared and released manifests include `artifacts` and omit
-`build`.
+Executable source providers may either use the SDK-native Go, Rust, Python, or
+TypeScript source-package metadata, or declare top-level `build.command` with
+`entrypoint.artifactPath`. When `build.command` is present, Gestalt runs it
+before source-manifest preparation and requires the command to produce that
+artifact path. Source manifests must not include `artifacts`; prepared and
+released manifests include `artifacts` and omit `build`.
 
 ```yaml
 kind: indexeddb

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1001,7 +1001,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 			}
 			return nil, fmt.Errorf("resolved manifest path is required for synthesized source provider execution")
 		}
-		command, args, err = providerpkg.SourceManifestExecutionCommand(entry.ResolvedManifestPath, providermanifestv1.KindPlugin, providerpkg.SourceBuildOptions{})
+		command, args, cleanup, err = providerpkg.SourceManifestExecutionCommand(entry.ResolvedManifestPath, providermanifestv1.KindPlugin, providerpkg.SourceBuildOptions{})
 		if err != nil {
 			if runtimeOwned {
 				_ = runtimeProvider.Close()
@@ -1016,9 +1016,15 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		}
 		return nil, err
 	}
+	cleanup = nil
+	launchCleanup := launch.cleanup
+	defer func() {
+		if launchCleanup != nil {
+			launchCleanup()
+		}
+	}()
 	command = launch.command
 	args = launch.args
-	cleanup = launch.cleanup
 	session, err := runtimeProvider.StartSession(ctx, buildHostedRuntimeStartSessionRequest(providermanifestv1.KindPlugin, name, runtimeConfig))
 	if err != nil {
 		if runtimeOwned {
@@ -1050,7 +1056,8 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	if err != nil {
 		return nil, err
 	}
-	cleanup = chainCleanup(cleanup, runtimeCleanup, publicHostServicesCleanup)
+	cleanup = chainCleanup(launchCleanup, runtimeCleanup, publicHostServicesCleanup)
+	launchCleanup = nil
 	startEnv := maps.Clone(env)
 	startEnv = withRuntimeSessionEnv(startEnv, sessionID)
 	startEnv = withHostServiceTLSCAEnv(startEnv, deps)

--- a/gestaltd/internal/daemon/provider.go
+++ b/gestaltd/internal/daemon/provider.go
@@ -72,8 +72,9 @@ type releasePlatform struct {
 }
 
 type releaseBuildTarget struct {
-	Executable bool
-	Build      bool
+	Kind          string
+	DeclaredBuild bool
+	Prebuilt      bool
 }
 
 type releaseArchive struct {
@@ -158,12 +159,12 @@ func runProviderRelease(args []string) (err error) {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
-	buildTarget, err := resolveReleaseBuildTarget(releaseManifest)
+	buildTarget, err := resolveReleaseBuildTarget(sourceDir, releaseManifest)
 	if err != nil {
 		return err
 	}
 
-	buildPlatforms, err := resolveReleaseBuildPlatforms(releaseManifest, buildTarget, *platforms, platformFlagExplicit)
+	buildPlatforms, err := resolveReleaseBuildPlatforms(sourceDir, releaseManifest, buildTarget, *platforms, platformFlagExplicit)
 	if err != nil {
 		return err
 	}
@@ -261,30 +262,52 @@ func (s *sourceStaticCatalogSnapshot) Restore() error {
 	return nil
 }
 
-func resolveReleaseBuildTarget(manifest *providermanifestv1.Manifest) (*releaseBuildTarget, error) {
+func resolveReleaseBuildTarget(root string, manifest *providermanifestv1.Manifest) (*releaseBuildTarget, error) {
 	kind, err := providerpkg.ManifestKind(manifest)
 	if err != nil {
 		return nil, err
 	}
 	if kind == providermanifestv1.KindUI {
-		return &releaseBuildTarget{}, nil
-	}
-	entry := providerpkg.EntrypointForKind(manifest, kind)
-	return &releaseBuildTarget{
-		Executable: entry != nil && strings.TrimSpace(entry.ArtifactPath) != "",
-		Build:      providerpkg.EffectiveSourceBuild(manifest) != nil,
-	}, nil
-}
-
-func resolveReleaseBuildPlatforms(manifest *providermanifestv1.Manifest, target *releaseBuildTarget, value string, explicit bool) ([]releasePlatform, error) {
-	if target == nil || !target.Executable {
 		return nil, nil
 	}
-	if !target.Build {
+	if providerpkg.EffectiveSourceBuild(manifest) != nil {
+		entry := providerpkg.EntrypointForKind(manifest, kind)
+		if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
+			return nil, nil
+		}
+		return &releaseBuildTarget{Kind: kind, DeclaredBuild: true}, nil
+	}
+	hasSource, err := providerpkg.HasSourceReleaseTarget(root, kind)
+	if err != nil {
+		return nil, fmt.Errorf("detect source %s package: %w", kind, err)
+	}
+	if !hasSource {
+		entry := providerpkg.EntrypointForKind(manifest, kind)
+		if entry != nil && strings.TrimSpace(entry.ArtifactPath) != "" {
+			return &releaseBuildTarget{Kind: kind, Prebuilt: true}, nil
+		}
+		if providerpkg.ReleaseRequiresBuild(manifest) {
+			return nil, providerpkg.MissingSourceReleaseTargetError(kind)
+		}
+		return nil, nil
+	}
+	return &releaseBuildTarget{Kind: kind}, nil
+}
+
+func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Manifest, target *releaseBuildTarget, value string, explicit bool) ([]releasePlatform, error) {
+	if target == nil {
+		return nil, nil
+	}
+	if target.Prebuilt {
 		if explicit {
 			return nil, fmt.Errorf("--platform requires build.command for executable source providers")
 		}
 		return nil, fmt.Errorf("provider release requires build.command for executable source providers")
+	}
+
+	buildRequired := target.DeclaredBuild || providerpkg.ReleaseRequiresBuild(manifest)
+	if !buildRequired && !explicit {
+		return nil, nil
 	}
 
 	if explicit {
@@ -299,6 +322,13 @@ func resolveReleaseBuildPlatforms(manifest *providermanifestv1.Manifest, target 
 	platforms, err := parseReleasePlatforms(value)
 	if err != nil {
 		return nil, err
+	}
+	if !target.DeclaredBuild {
+		for _, platform := range platforms {
+			if err := providerpkg.ValidateSourceReleaseTarget(root, target.Kind, platform.GOOS, platform.GOARCH); err != nil {
+				return nil, fmt.Errorf("validate %s source release target for %s: %w", target.Kind, providerpkg.PlatformString(platform.GOOS, platform.GOARCH), err)
+			}
+		}
 	}
 	return platforms, nil
 }
@@ -590,7 +620,7 @@ func printProviderReleaseUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd provider release --version VERSION [--output DIR] [--platform PLATFORMS]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Build provider release archives.")
-	writeUsageLine(w, "Executable source providers require build.command and default to the host platform.")
+	writeUsageLine(w, "Executable source providers use SDK-native source packages or build.command and default to the host platform.")
 	writeUsageLine(w, "UI and declarative providers default to a generic archive.")
 	writeUsageLine(w, "Pass --platform with a comma-separated os/arch list or --platform all")
 	writeUsageLine(w, "to build multiple per-platform tar.gz archives plus a checksums file.")

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -836,7 +836,7 @@ func startProviderRemoteProcess(ctx context.Context, target providerRemoteTarget
 			return nil, fmt.Errorf("plugins.%s resolved manifest path is required for source provider execution", target.Name)
 		}
 		var err error
-		command, args, err = providerpkg.SourceManifestExecutionCommand(entry.ResolvedManifestPath, providermanifestv1.KindPlugin, providerpkg.SourceBuildOptions{})
+		command, args, cleanup, err = providerpkg.SourceManifestExecutionCommand(entry.ResolvedManifestPath, providermanifestv1.KindPlugin, providerpkg.SourceBuildOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("plugins.%s: prepare source provider execution: %w", target.Name, err)
 		}

--- a/gestaltd/internal/daemon/provider_test.go
+++ b/gestaltd/internal/daemon/provider_test.go
@@ -1887,6 +1887,54 @@ func TestRun_ProviderReleaseCompilesProviderWithoutSourceArtifacts(t *testing.T)
 	}
 }
 
+func TestRun_ProviderReleaseCompilesSDKSourceProviderWithoutBuildCommand(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newSourceProviderReleaseFixtureWithoutCatalog(t, t.TempDir())
+	writeReleaseTestManifest(t, pluginDir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      releaseTestSource,
+		Version:     "0.0.1",
+		DisplayName: "Release Test",
+		IconFile:    releaseTestIconPath,
+		Spec: &providermanifestv1.Spec{
+			ConfigSchemaPath: releaseProviderSchemaPath,
+		},
+	})
+	_ = os.Remove(filepath.Join(pluginDir, providerpkg.StaticCatalogFile))
+	_ = os.Remove(filepath.Join(pluginDir, "build.sh"))
+	_ = os.RemoveAll(filepath.Join(pluginDir, "cmd"))
+
+	outputDir := t.TempDir()
+	const testVersion = "0.0.4-sdk-source.1"
+	runProviderReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-" + releaseTestPluginName + "_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	wantBinary := "gestalt-plugin-" + releaseTestPluginName
+	if runtime.GOOS == "windows" {
+		wantBinary += ".exe"
+	}
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != wantBinary {
+		t.Fatalf("artifacts = %+v, want one artifact at %q", manifest.Artifacts, wantBinary)
+	}
+	if manifest.Entrypoint == nil || manifest.Entrypoint.ArtifactPath != wantBinary {
+		t.Fatalf("provider entrypoint = %+v, want artifact path %q", manifest.Entrypoint, wantBinary)
+	}
+	data, err := os.ReadFile(filepath.Join(extractDir, providerpkg.StaticCatalogFile))
+	if err != nil {
+		t.Fatalf("read generated catalog: %v", err)
+	}
+	if !strings.Contains(string(data), "generated_op") {
+		t.Fatalf("unexpected generated catalog: %s", data)
+	}
+}
+
 func TestRun_ProviderReleaseRejectsPrebuiltExecutableProvider(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/plugins/packageio/manifest.go
+++ b/gestaltd/services/plugins/packageio/manifest.go
@@ -164,6 +164,8 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 		return fmt.Errorf("artifacts are not allowed in source manifests; prepared and released manifests generate them")
 	}
 
+	allowsSourceEntrypointOmission := sourceMode && manifest.Entrypoint == nil && manifest.Build == nil
+
 	needsArtifacts := len(manifest.Artifacts) > 0
 	switch kind {
 	case providermanifestv1.KindPlugin:
@@ -228,11 +230,12 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 			return fmt.Errorf("entrypoint is required when build is set")
 		case manifest.IsDeclarativeOnlyProvider():
 		case spec != nil && spec.IsSpecLoaded():
+		case allowsSourceEntrypointOmission:
 		default:
 			return fmt.Errorf("entrypoint is required")
 		}
 	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
-		if manifest.Entrypoint == nil {
+		if manifest.Entrypoint == nil && !allowsSourceEntrypointOmission {
 			return fmt.Errorf("entrypoint is required")
 		}
 		if manifest.Entrypoint != nil {

--- a/gestaltd/services/plugins/providerpkg/go_executable_wrapper.go.tmpl
+++ b/gestaltd/services/plugins/providerpkg/go_executable_wrapper.go.tmpl
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	providerpkg {{printf "%q" .ImportPath}}
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := {{.ServeCall}}; err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/gestaltd/services/plugins/providerpkg/go_provider.go
+++ b/gestaltd/services/plugins/providerpkg/go_provider.go
@@ -1,0 +1,528 @@
+package providerpkg
+
+import (
+	"bufio"
+	"bytes"
+	_ "embed"
+	"errors"
+	"fmt"
+	"go/format"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"text/template"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+const goProviderPackageTarget = "."
+const goReadonlyFlag = "-mod=readonly"
+
+var ErrNoGoProviderPackage = errors.New("no Go provider package found")
+var ErrNoSourceComponentPackage = errors.New("no source component package found")
+var ErrGoToolUnavailable = errors.New("go tool unavailable")
+var goProviderNameSlugPattern = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+type goExecutableWrapperData struct {
+	ImportPath string
+	ServeCall  string
+}
+
+//go:embed go_executable_wrapper.go.tmpl
+var goExecutableWrapperSource string
+
+var goExecutableWrapperTemplate = template.Must(template.New("go-executable-wrapper").Parse(goExecutableWrapperSource))
+
+func DetectGoProviderImportPath(root, goos, goarch string) (string, error) {
+	return detectGoPackageImportPath(root, goProviderPackageTarget, ErrNoGoProviderPackage, goProviderSourceExists, goos, goarch)
+}
+
+func BuildGoProviderTempBinary(root, goos, goarch string) (string, func(), error) {
+	pluginName := sourcePluginName(root)
+	return buildGoTempBinary("gestalt-go-provider-bin-*", "provider", goos, func(outputPath string) error {
+		return BuildGoProviderBinary(root, outputPath, pluginName, goos, goarch)
+	})
+}
+
+func BuildGoProviderBinary(root, outputPath, pluginName, goos, goarch string) error {
+	return buildGoSourceBinary(root, outputPath, goos, goarch, ErrNoGoProviderPackage, goProviderSourceExists, "gestalt-go-provider-*.go", "Go provider wrapper", func(importPath string) (goExecutableWrapperData, error) {
+		return goExecutableWrapperData{
+			ImportPath: importPath,
+			ServeCall:  fmt.Sprintf("gestalt.ServeProvider(ctx, providerpkg.New(), providerpkg.Router.WithName(%q))", pluginName),
+		}, nil
+	})
+}
+
+func DetectGoComponentImportPath(root, kind, goos, goarch string) (string, error) {
+	if err := validateSourceComponentKind(kind); err != nil {
+		return "", err
+	}
+	return detectGoPackageImportPath(root, goProviderPackageTarget, ErrNoSourceComponentPackage, goComponentSourceExists, goos, goarch)
+}
+
+func BuildGoComponentTempBinary(root, kind, goos, goarch string) (string, func(), error) {
+	return buildGoTempBinary("gestalt-go-component-bin-*", kind, goos, func(outputPath string) error {
+		return BuildGoComponentBinary(root, outputPath, kind, goos, goarch)
+	})
+}
+
+func BuildGoComponentBinary(root, outputPath, kind, goos, goarch string) error {
+	if err := validateSourceComponentKind(kind); err != nil {
+		return err
+	}
+	return buildGoSourceBinary(root, outputPath, goos, goarch, ErrNoSourceComponentPackage, goComponentSourceExists, "gestalt-go-component-*.go", fmt.Sprintf("Go %s wrapper", kind), func(importPath string) (goExecutableWrapperData, error) {
+		serveCall, err := componentServeCall(kind)
+		if err != nil {
+			return goExecutableWrapperData{}, err
+		}
+		return goExecutableWrapperData{
+			ImportPath: importPath,
+			ServeCall:  serveCall,
+		}, nil
+	})
+}
+
+func SourceComponentExecutionCommand(root, kind, goos, goarch string) (string, []string, func(), error) {
+	sourceKind, target, err := detectSourceComponent(root, kind, goos, goarch)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	switch sourceKind {
+	case sourceProviderKindGo:
+		command, cleanup, err := BuildGoComponentTempBinary(root, kind, goos, goarch)
+		if err != nil {
+			if errors.Is(err, ErrNoSourceComponentPackage) {
+				return "", nil, nil, err
+			}
+			return "", nil, nil, fmt.Errorf("build source %s temp binary: %w", kind, err)
+		}
+		return command, nil, cleanup, nil
+	case sourceProviderKindRust:
+		return rustComponentExecutionCommand(root, kind, goos, goarch)
+	case sourceProviderKindPython:
+		runtimeKind, err := pythonRuntimeKind(kind)
+		if err != nil {
+			return "", nil, nil, err
+		}
+		return pythonComponentExecutionCommand(root, target, runtimeKind)
+	case sourceProviderKindTypeScript:
+		return typeScriptExecutionCommand(root, target)
+	default:
+		return "", nil, nil, ErrNoSourceComponentPackage
+	}
+}
+
+func SourceComponentExecutionEnv(root, kind, goos, goarch string) (map[string]string, error) {
+	sourceKind, _, err := detectSourceComponent(root, kind, goos, goarch)
+	if err != nil {
+		return nil, err
+	}
+	if sourceKind != sourceProviderKindPython {
+		return nil, nil
+	}
+	return pythonBackendEnvMap()
+}
+
+func ValidateSourceComponentRelease(root, kind, goos, goarch string) error {
+	sourceKind, _, err := detectSourceComponent(root, kind, goos, goarch)
+	if err != nil {
+		return err
+	}
+	switch sourceKind {
+	case sourceProviderKindPython:
+		_, err = DetectPythonInterpreter(root, goos, goarch)
+		return err
+	case sourceProviderKindRust:
+		return ValidateRustComponentRelease(root, kind, goos, goarch)
+	case sourceProviderKindTypeScript:
+		_, err = DetectBunExecutable()
+		return err
+	default:
+		return nil
+	}
+}
+
+func BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch string) (string, error) {
+	sourceKind, target, err := detectSourceComponent(root, kind, goos, goarch)
+	if err != nil {
+		return "", err
+	}
+	switch sourceKind {
+	case sourceProviderKindGo:
+		return "", BuildGoComponentBinary(root, outputPath, kind, goos, goarch)
+	case sourceProviderKindRust:
+		return BuildRustComponentBinary(root, outputPath, kind, goos, goarch)
+	case sourceProviderKindPython:
+		runtimeKind, err := pythonRuntimeKind(kind)
+		if err != nil {
+			return "", err
+		}
+		pluginName := sourcePluginName(root)
+		return BuildPythonComponentBinary(root, outputPath, pluginName, target, runtimeKind, goos, goarch)
+	case sourceProviderKindTypeScript:
+		return BuildTypeScriptComponentBinary(root, outputPath, kind, target, goos, goarch)
+	default:
+		return "", ErrNoSourceComponentPackage
+	}
+}
+
+func HasSourceComponentPackage(root, kind string) (bool, error) {
+	_, _, err := detectSourceComponent(root, kind, runtime.GOOS, runtime.GOARCH)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, ErrNoSourceComponentPackage):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func detectSourceComponent(root, kind, goos, goarch string) (sourceKind string, target string, err error) {
+	if err := validateSourceComponentKind(kind); err != nil {
+		return "", "", err
+	}
+
+	var goToolUnavailable error
+	if _, err := DetectGoComponentImportPath(root, kind, goos, goarch); err == nil {
+		return sourceProviderKindGo, "", nil
+	} else if errors.Is(err, ErrGoToolUnavailable) {
+		goToolUnavailable = err
+	} else if !errors.Is(err, ErrNoSourceComponentPackage) {
+		return "", "", err
+	}
+	if kind == providermanifestv1.KindExternalCredentials {
+		if goToolUnavailable != nil {
+			return "", "", goToolUnavailable
+		}
+		return "", "", ErrNoSourceComponentPackage
+	}
+
+	if _, err := detectRustPackage(root); err == nil {
+		return sourceProviderKindRust, "", nil
+	} else if !errors.Is(err, ErrNoRustProviderPackage) {
+		return "", "", err
+	}
+
+	target, err = DetectPythonComponentTarget(root, kind)
+	switch {
+	case err == nil:
+		return sourceProviderKindPython, target, nil
+	case !errors.Is(err, ErrNoPythonSourceComponentPackage):
+		return "", "", err
+	default:
+		target, err = DetectTypeScriptComponentTarget(root, kind)
+		switch {
+		case err == nil:
+			return sourceProviderKindTypeScript, target, nil
+		case !errors.Is(err, ErrNoSourceComponentPackage):
+			return "", "", err
+		case goToolUnavailable != nil:
+			return "", "", goToolUnavailable
+		default:
+			return "", "", ErrNoSourceComponentPackage
+		}
+	}
+}
+
+func detectGoPackageImportPath(root, buildTarget string, noSourceErr error, sourceExists func(string) bool, goos, goarch string) (string, error) {
+	importPath, err := goPackageField(root, buildTarget, "{{.ImportPath}}", goos, goarch)
+	if err != nil {
+		if errors.Is(err, ErrGoToolUnavailable) {
+			if !sourceExists(root) {
+				return "", noSourceErr
+			}
+			return "", err
+		}
+		if isMissingGoPackageError(err) {
+			return "", noSourceErr
+		}
+		return "", fmt.Errorf("%s: %w", buildTarget, err)
+	}
+	importPath = strings.TrimSpace(importPath)
+	if importPath != "" && importPath != "." {
+		return importPath, nil
+	}
+
+	fallbackModulePath, moduleErr := goModulePathFromFile(root)
+	if moduleErr != nil {
+		return "", moduleErr
+	}
+	modulePath, err := goPackageField(root, buildTarget, "{{if .Module}}{{.Module.Path}}{{end}}", goos, goarch)
+	if err == nil {
+		modulePath = strings.TrimSpace(modulePath)
+		if modulePath != "" {
+			return modulePath, nil
+		}
+	}
+	if fallbackModulePath != "" {
+		return fallbackModulePath, nil
+	}
+	return importPath, nil
+}
+
+func goModulePathFromFile(root string) (string, error) {
+	file, err := os.Open(filepath.Join(root, "go.mod"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read go.mod: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(stripGoModComment(scanner.Text()))
+		if line == "" || !strings.HasPrefix(line, "module") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return "", fmt.Errorf("parse go.mod: module path is required")
+		}
+		return strings.Trim(fields[1], `"`), nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scan go.mod: %w", err)
+	}
+	return "", nil
+}
+
+func stripGoModComment(line string) string {
+	if idx := strings.Index(line, "//"); idx >= 0 {
+		return line[:idx]
+	}
+	return line
+}
+
+func newGoSourceWrapper(root, goos, goarch string, noSourceErr error, sourceExists func(string) bool, tempPattern, description string, wrapperData func(string) (goExecutableWrapperData, error)) (string, func(), error) {
+	importPath, err := detectGoPackageImportPath(root, goProviderPackageTarget, noSourceErr, sourceExists, goos, goarch)
+	if err != nil {
+		return "", nil, err
+	}
+	data, err := wrapperData(importPath)
+	if err != nil {
+		return "", nil, err
+	}
+	return newGoWrapper(tempPattern, description, goExecutableWrapperTemplate, data)
+}
+
+func buildGoSourceBinary(root, outputPath, goos, goarch string, noSourceErr error, sourceExists func(string) bool, tempPattern, description string, wrapperData func(string) (goExecutableWrapperData, error)) error {
+	wrapperPath, cleanup, err := newGoSourceWrapper(root, goos, goarch, noSourceErr, sourceExists, tempPattern, description, wrapperData)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return buildGoWrapperBinary(root, outputPath, wrapperPath, goos, goarch)
+}
+
+func newGoWrapper(tempPattern, description string, tmpl *template.Template, data any) (string, func(), error) {
+	file, err := os.CreateTemp("", tempPattern)
+	if err != nil {
+		return "", nil, fmt.Errorf("create %s: %w", description, err)
+	}
+	path := file.Name()
+	cleanup := func() { _ = os.Remove(path) }
+	defer func() { _ = file.Close() }()
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("render %s: %w", description, err)
+	}
+	source, err := format.Source(buf.Bytes())
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("format %s: %w", description, err)
+	}
+	if _, err := file.Write(source); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("write %s: %w", description, err)
+	}
+	return path, cleanup, nil
+}
+
+func buildGoTempBinary(tempDirPattern, binaryBaseName, goos string, build func(outputPath string) error) (string, func(), error) {
+	tempDir, err := os.MkdirTemp("", tempDirPattern)
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tempDir) }
+
+	binaryName := binaryBaseName
+	if goos == "windows" {
+		binaryName += ".exe"
+	}
+	binaryPath := filepath.Join(tempDir, binaryName)
+	if err := build(binaryPath); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return binaryPath, cleanup, nil
+}
+
+func buildGoWrapperBinary(root, outputPath, wrapperPath, goos, goarch string) error {
+	cmd := exec.Command("go", "-C", root, "build", goReadonlyFlag, "-trimpath", "-ldflags", "-s -w", "-o", outputPath, wrapperPath)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS="+goos, "GOARCH="+goarch)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("go build: %w", err)
+	}
+	return nil
+}
+
+func goPackageField(root, buildTarget, field, goos, goarch string) (string, error) {
+	cmd := exec.Command("go", "list", goReadonlyFlag, "-f", field, buildTarget)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if isMissingGoToolError(err) {
+			return "", fmt.Errorf("%w: %v", ErrGoToolUnavailable, err)
+		}
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", errors.New(msg)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func isMissingGoToolError(err error) bool {
+	if errors.Is(err, exec.ErrNotFound) {
+		return true
+	}
+	var execErr *exec.Error
+	if errors.As(err, &execErr) && errors.Is(execErr.Err, exec.ErrNotFound) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, `exec: "go": executable file not found`) ||
+		strings.Contains(msg, "executable file not found in $PATH")
+}
+
+func goProviderSourceExists(root string) bool {
+	return goSourceExists(filepath.Join(root, "provider"))
+}
+
+func goComponentSourceExists(root string) bool {
+	return goSourceExists(root)
+}
+
+func goSourceExists(root string) bool {
+	if _, err := os.Stat(root); err != nil {
+		return false
+	}
+
+	stop := errors.New("found go source")
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(d.Name(), ".go") && !strings.HasSuffix(d.Name(), "_test.go") {
+			return stop
+		}
+		return nil
+	})
+	return errors.Is(err, stop)
+}
+
+func isMissingGoPackageError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "directory not found") ||
+		strings.Contains(msg, "no such file or directory") ||
+		strings.Contains(msg, "go.mod file not found") ||
+		strings.Contains(msg, "cannot find main module") ||
+		strings.Contains(msg, "does not contain main module or its selected dependencies") ||
+		strings.Contains(msg, "no Go files") ||
+		strings.Contains(msg, "build constraints exclude all Go files") ||
+		strings.Contains(msg, "matched no packages")
+}
+
+func sourcePluginName(root string) string {
+	fallback := filepath.Base(filepath.Clean(root))
+	manifestPath, err := FindManifestFile(root)
+	if err != nil {
+		return slugPluginName(fallback)
+	}
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return slugPluginName(fallback)
+	}
+	return sourcePluginManifestName(manifest, fallback)
+}
+
+func sourcePluginManifestName(manifest *providermanifestv1.Manifest, fallback string) string {
+	if manifest != nil {
+		if manifest.Source != "" {
+			parts := strings.Split(strings.TrimSpace(manifest.Source), "/")
+			if last := parts[len(parts)-1]; last != "" {
+				return slugPluginName(last)
+			}
+		}
+		if manifest.DisplayName != "" {
+			return slugPluginName(manifest.DisplayName)
+		}
+	}
+	return slugPluginName(fallback)
+}
+
+func slugPluginName(value string) string {
+	cleaned := goProviderNameSlugPattern.ReplaceAllString(strings.TrimSpace(value), "-")
+	cleaned = strings.Trim(cleaned, "-")
+	if cleaned == "" {
+		return "plugin"
+	}
+	return cleaned
+}
+
+func validateSourceComponentKind(kind string) error {
+	kind = providermanifestv1.NormalizeKind(kind)
+	switch kind {
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		return nil
+	default:
+		return fmt.Errorf("unsupported source component kind %q", kind)
+	}
+}
+
+func componentServeCall(kind string) (string, error) {
+	kind = providermanifestv1.NormalizeKind(kind)
+	switch kind {
+	case providermanifestv1.KindAuthentication:
+		return "gestalt.ServeAuthenticationProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindAuthorization:
+		return "gestalt.ServeAuthorizationProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindExternalCredentials:
+		return "gestalt.ServeExternalCredentialProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindIndexedDB:
+		return "gestalt.ServeIndexedDBProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindCache:
+		return "gestalt.ServeCacheProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindS3:
+		return "gestalt.ServeS3Provider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindWorkflow:
+		return "gestalt.ServeWorkflowProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindAgent:
+		return "gestalt.ServeAgentProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindSecrets:
+		return "gestalt.ServeSecretsProvider(ctx, providerpkg.New())", nil
+	case providermanifestv1.KindRuntime:
+		return "gestalt.ServePluginRuntimeProvider(ctx, providerpkg.New())", nil
+	default:
+		return "", fmt.Errorf("unsupported source component kind %q", kind)
+	}
+}

--- a/gestaltd/services/plugins/providerpkg/local_sdk.go
+++ b/gestaltd/services/plugins/providerpkg/local_sdk.go
@@ -1,0 +1,27 @@
+package providerpkg
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func localRepositorySubdir(parts ...string) string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+	for dir := filepath.Dir(file); ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "gestaltd", "go.mod")); err == nil {
+			path := filepath.Join(append([]string{dir}, parts...)...)
+			if _, err := os.Stat(path); err == nil {
+				return filepath.Clean(path)
+			}
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+	}
+}

--- a/gestaltd/services/plugins/providerpkg/prepared_stage.go
+++ b/gestaltd/services/plugins/providerpkg/prepared_stage.go
@@ -1,6 +1,7 @@
 package providerpkg
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -15,8 +16,10 @@ import (
 )
 
 const (
-	releaseOwnedUIRoot = "_owned_ui"
-	windowsOS          = "windows"
+	releaseOwnedUIRoot          = "_owned_ui"
+	preparedReleaseBinaryPrefix = "gestalt-plugin-"
+	windowsOS                   = "windows"
+	windowsExecutableSuffix     = ".exe"
 )
 
 type StagePreparedInstallOptions struct {
@@ -158,12 +161,13 @@ func stagePreparedInstallDir(manifestPath, stagingDir string, srcManifest *provi
 	if strings.TrimSpace(opts.VersionOverride) != "" {
 		version = strings.TrimSpace(opts.VersionOverride)
 	}
-	if strings.TrimSpace(opts.PluginName) == "" {
+	pluginName := strings.TrimSpace(opts.PluginName)
+	if pluginName == "" {
 		src, err := source.Parse(srcManifest.Source)
 		if err != nil {
 			return nil, fmt.Errorf("invalid source in manifest: %w", err)
 		}
-		_ = src.PluginName()
+		pluginName = src.PluginName()
 	}
 
 	goos := opts.GOOS
@@ -174,12 +178,43 @@ func stagePreparedInstallDir(manifestPath, stagingDir string, srcManifest *provi
 	if goarch == "" {
 		goarch = runtime.GOARCH
 	}
-	stagedManifest, err := buildPreparedInstallSourceManifest(srcManifest, version, sourceDir, goos, goarch)
-	if err != nil {
-		return nil, err
+
+	var stagedManifest *providermanifestv1.Manifest
+	buildKind := ""
+	if EffectiveSourceBuild(srcManifest) == nil {
+		var err error
+		buildKind, err = resolvePreparedInstallBuildKind(sourceDir, srcManifest, "")
+		if err != nil {
+			return nil, err
+		}
 	}
-	if err := copyPreparedInstallSupportFiles(stagedManifest, sourceDir, stagingDir, true); err != nil {
-		return nil, err
+	if buildKind != "" {
+		binaryName := stagedReleaseBinaryName(pluginName, goos)
+		binaryPath := filepath.Join(stagingDir, binaryName)
+		if _, err := buildPreparedInstallBinary(sourceDir, binaryPath, pluginName, buildKind, goos, goarch); err != nil {
+			return nil, err
+		}
+		digest, digestErr := FileSHA256(binaryPath)
+		if digestErr != nil {
+			return nil, fmt.Errorf("hash binary: %w", digestErr)
+		}
+		var err error
+		stagedManifest, err = buildPreparedInstallManifest(srcManifest, version, binaryName, goos, goarch, digest)
+		if err != nil {
+			return nil, err
+		}
+		if err := copyPreparedInstallSupportFiles(stagedManifest, sourceDir, stagingDir, false); err != nil {
+			return nil, err
+		}
+	} else {
+		var err error
+		stagedManifest, err = buildPreparedInstallSourceManifest(srcManifest, version, sourceDir, goos, goarch)
+		if err != nil {
+			return nil, err
+		}
+		if err := copyPreparedInstallSupportFiles(stagedManifest, sourceDir, stagingDir, true); err != nil {
+			return nil, err
+		}
 	}
 
 	stagedManifestPath := filepath.Join(stagingDir, manifestFile)
@@ -201,6 +236,113 @@ func preparedManifestFileName(format string) string {
 		return "manifest.yaml"
 	default:
 		return ManifestFile
+	}
+}
+
+func resolvePreparedInstallBuildKind(root string, manifest *providermanifestv1.Manifest, kind string) (string, error) {
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		var err error
+		kind, err = ManifestKind(manifest)
+		if err != nil {
+			return "", err
+		}
+	}
+	if kind == providermanifestv1.KindUI {
+		return "", nil
+	}
+
+	if buildKind, err := resolvePreparedInstallBuildTarget(root, kind); err == nil {
+		return buildKind, nil
+	} else if !isMissingPreparedInstallBuildTarget(err, kind) {
+		return "", err
+	}
+
+	entry := EntrypointForKind(manifest, kind)
+	if artifactExistsForEntrypoint(root, entry) {
+		return "", nil
+	}
+
+	if preparedInstallRequiresBuild(manifest, kind) {
+		return "", missingPreparedInstallBuildTargetError(kind)
+	}
+	return "", nil
+}
+
+func preparedInstallRequiresBuild(manifest *providermanifestv1.Manifest, kind string) bool {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return manifest != nil && manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		return EntrypointForKind(manifest, kind) == nil
+	default:
+		return false
+	}
+}
+
+func resolvePreparedInstallBuildTarget(root, kind string) (string, error) {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		ok, err := HasSourceProviderPackage(root)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", ErrNoSourceProviderPackage
+		}
+		return kind, nil
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		ok, err := HasSourceComponentPackage(root, kind)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", ErrNoSourceComponentPackage
+		}
+		return kind, nil
+	default:
+		return "", fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}
+
+func isMissingPreparedInstallBuildTarget(err error, kind string) bool {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return errors.Is(err, ErrNoSourceProviderPackage)
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		return errors.Is(err, ErrNoSourceComponentPackage)
+	default:
+		return false
+	}
+}
+
+func missingPreparedInstallBuildTargetError(kind string) error {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return ErrNoSourceProviderPackage
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		return ErrNoSourceComponentPackage
+	default:
+		return fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}
+
+func artifactExistsForEntrypoint(root string, entry *providermanifestv1.Entrypoint) bool {
+	if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(root, filepath.FromSlash(entry.ArtifactPath)))
+	return err == nil
+}
+
+func buildPreparedInstallBinary(root, outputPath, pluginName, kind, goos, goarch string) (string, error) {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch)
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		return BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch)
+	default:
+		return "", fmt.Errorf("unsupported release build target kind %q", kind)
 	}
 }
 
@@ -229,6 +371,20 @@ func buildPreparedInstallSourceManifest(srcManifest *providermanifestv1.Manifest
 		}
 	}
 
+	return manifest, nil
+}
+
+func buildPreparedInstallManifest(srcManifest *providermanifestv1.Manifest, version, binaryName, goos, goarch, digest string) (*providermanifestv1.Manifest, error) {
+	manifest, err := cloneManifest(srcManifest)
+	if err != nil {
+		return nil, fmt.Errorf("clone manifest: %w", err)
+	}
+	manifest.Version = version
+	manifest.Build = nil
+	manifest.Artifacts = []providermanifestv1.Artifact{
+		{OS: goos, Arch: goarch, Path: binaryName, SHA256: digest},
+	}
+	EnsureEntrypoint(manifest).ArtifactPath = binaryName
 	return manifest, nil
 }
 
@@ -399,6 +555,14 @@ func packagedOwnedUIDir(rel string) string {
 		return releaseOwnedUIRoot
 	}
 	return path.Join(releaseOwnedUIRoot, parent)
+}
+
+func stagedReleaseBinaryName(pluginName, goos string) string {
+	binaryName := preparedReleaseBinaryPrefix + pluginName
+	if goos == windowsOS {
+		return binaryName + windowsExecutableSuffix
+	}
+	return binaryName
 }
 
 func normalizePreparedInstallPath(rel string) (string, error) {

--- a/gestaltd/services/plugins/providerpkg/python_provider.go
+++ b/gestaltd/services/plugins/providerpkg/python_provider.go
@@ -1,0 +1,433 @@
+package providerpkg
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+const (
+	pythonProjectFile   = "pyproject.toml"
+	pythonRuntimeModule = "gestalt._runtime"
+	pythonBuildModule   = "gestalt._build"
+	pythonEnvVarPrefix  = "GESTALT_PYTHON_"
+	pythonSDKDirEnvVar  = "GESTALT_PYTHON_SDK_DIR"
+)
+
+var ErrNoPythonProviderPackage = errors.New("no Python provider package found")
+var ErrNoPythonSourceComponentPackage = errors.New("no Python source component package found")
+
+var pythonIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func DetectPythonProviderTarget(root string) (string, error) {
+	target, err := detectPythonProjectTarget(root, "provider")
+	if err != nil {
+		if errors.Is(err, ErrNoPythonSourceComponentPackage) {
+			return "", ErrNoPythonProviderPackage
+		}
+		return "", err
+	}
+	return target, nil
+}
+
+func DetectPythonComponentTarget(root, kind string) (string, error) {
+	kind = providermanifestv1.NormalizeKind(kind)
+	if err := validateSourceComponentKind(kind); err != nil {
+		return "", err
+	}
+	if _, err := pythonRuntimeKind(kind); err != nil {
+		return "", err
+	}
+	return detectPythonProjectTarget(root, kind)
+}
+
+func detectPythonProjectTarget(root, key string) (string, error) {
+	projectPath := filepath.Join(root, pythonProjectFile)
+	if _, err := os.Stat(projectPath); err != nil {
+		if os.IsNotExist(err) {
+			if key == "plugin" {
+				return "", ErrNoPythonProviderPackage
+			}
+			return "", ErrNoPythonSourceComponentPackage
+		}
+		return "", fmt.Errorf("stat %s: %w", pythonProjectFile, err)
+	}
+
+	data, err := os.ReadFile(projectPath)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", pythonProjectFile, err)
+	}
+
+	target, err := pythonProjectTarget(data, key)
+	if err != nil {
+		return "", fmt.Errorf("parse %s: %w", pythonProjectFile, err)
+	}
+	target = strings.TrimSpace(target)
+	if target == "" {
+		if key == "plugin" {
+			return "", ErrNoPythonProviderPackage
+		}
+		return "", ErrNoPythonSourceComponentPackage
+	}
+	if _, _, err := SplitPythonProviderTarget(target); err != nil {
+		return "", fmt.Errorf("%s tool.gestalt.%s: %w", pythonProjectFile, key, err)
+	}
+	return target, nil
+}
+
+func pythonProviderExecutionCommand(root, target string) (string, []string, func(), error) {
+	return pythonExecutionCommand(root, target, pythonRuntimeKindIntegration)
+}
+
+func pythonComponentExecutionCommand(root, target, runtimeKind string) (string, []string, func(), error) {
+	return pythonExecutionCommand(root, target, runtimeKind)
+}
+
+func pythonExecutionCommand(root, target, runtimeKind string) (string, []string, func(), error) {
+	interpreter, err := DetectPythonInterpreter(root, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	return interpreter, []string{"-m", pythonRuntimeModule, root, target, runtimeKind}, nil, nil
+}
+
+func BuildPythonProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) (string, error) {
+	return BuildPythonComponentBinary(sourceDir, binaryPath, pluginName, target, pythonRuntimeKindIntegration, goos, goarch)
+}
+
+func BuildPythonComponentBinary(sourceDir, binaryPath, pluginName, target, runtimeKind, goos, goarch string) (string, error) {
+	interpreter, err := DetectPythonInterpreter(sourceDir, goos, goarch)
+	if err != nil {
+		return "", fmt.Errorf("detect Python release interpreter for %s/%s: %w", goos, goarch, err)
+	}
+
+	cmd := exec.Command(interpreter, "-m", pythonBuildModule, sourceDir, target, binaryPath, pluginName, runtimeKind, goos, goarch)
+	cmd.Dir = sourceDir
+	env, err := pythonBackendEnv(os.Environ())
+	if err != nil {
+		return "", fmt.Errorf("prepare Python release build environment: %w", err)
+	}
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("python release build: %w (ensure gestalt and PyInstaller are installed in the selected Python environment)", err)
+	}
+	return "", nil
+}
+
+func DetectPythonInterpreter(root, goos, goarch string) (string, error) {
+	for _, candidate := range pythonInterpreterCandidates(root, goos, goarch) {
+		if candidate == "" {
+			continue
+		}
+		if filepath.IsAbs(candidate) {
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				return candidate, nil
+			}
+			continue
+		}
+		if resolved, err := exec.LookPath(candidate); err == nil {
+			return resolved, nil
+		}
+	}
+	envVar := pythonInterpreterEnvVar(goos, goarch)
+	if goos == runtime.GOOS && goarch == runtime.GOARCH {
+		return "", fmt.Errorf("detect Python interpreter: %w", exec.ErrNotFound)
+	}
+	return "", fmt.Errorf("detect Python interpreter: %w (set %s or provide a target-specific virtualenv)", exec.ErrNotFound, envVar)
+}
+
+func pythonBackendEnv(base []string) ([]string, error) {
+	env, err := pythonBackendEnvMap()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(base)+len(env))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && key == "PYTHONPATH" {
+			continue
+		}
+		out = append(out, entry)
+	}
+	for key, value := range env {
+		out = append(out, key+"="+value)
+	}
+	return out, nil
+}
+
+func pythonBackendEnvMap() (map[string]string, error) {
+	value, err := pythonBackendPythonPath()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"PYTHONPATH": value}, nil
+}
+
+func pythonBackendPythonPath() (string, error) {
+	sdkPath, err := explicitPythonSDKPath()
+	if err != nil {
+		return "", err
+	}
+	if sdkPath == "" {
+		return "", nil
+	}
+	value := sdkPath
+	if existing := os.Getenv("PYTHONPATH"); existing != "" {
+		value += string(os.PathListSeparator) + existing
+	}
+	return value, nil
+}
+
+func explicitPythonSDKPath() (string, error) {
+	raw := strings.TrimSpace(os.Getenv(pythonSDKDirEnvVar))
+	if raw == "" {
+		return "", nil
+	}
+	path, err := filepath.Abs(raw)
+	if err != nil {
+		return "", fmt.Errorf("%s %q: resolve absolute path: %w", pythonSDKDirEnvVar, raw, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("%s %q: %w", pythonSDKDirEnvVar, path, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s %q is not a directory", pythonSDKDirEnvVar, path)
+	}
+	if _, err := os.Stat(filepath.Join(path, pythonProjectFile)); err != nil {
+		return "", fmt.Errorf("%s %q: missing %s: %w", pythonSDKDirEnvVar, path, pythonProjectFile, err)
+	}
+	if info, err := os.Stat(filepath.Join(path, "gestalt")); err != nil {
+		return "", fmt.Errorf("%s %q: missing gestalt package: %w", pythonSDKDirEnvVar, path, err)
+	} else if !info.IsDir() {
+		return "", fmt.Errorf("%s %q: gestalt package is not a directory", pythonSDKDirEnvVar, path)
+	}
+	return path, nil
+}
+
+func pythonInterpreterCandidates(root, goos, goarch string) []string {
+	candidates := []string{
+		os.Getenv(pythonInterpreterEnvVar(goos, goarch)),
+	}
+	suffix := goos + "-" + goarch
+	if goos == "windows" {
+		candidates = append(candidates,
+			filepath.Join(root, ".venv-"+suffix, "Scripts", "python.exe"),
+			filepath.Join(root, "venv-"+suffix, "Scripts", "python.exe"),
+			filepath.Join(root, ".venv", suffix, "Scripts", "python.exe"),
+			filepath.Join(root, "venv", suffix, "Scripts", "python.exe"),
+		)
+	} else {
+		candidates = append(candidates,
+			filepath.Join(root, ".venv-"+suffix, "bin", "python"),
+			filepath.Join(root, "venv-"+suffix, "bin", "python"),
+			filepath.Join(root, ".venv", suffix, "bin", "python"),
+			filepath.Join(root, "venv", suffix, "bin", "python"),
+		)
+	}
+	if goos == runtime.GOOS && goarch == runtime.GOARCH {
+		candidates = append(candidates, pythonGenericInterpreterCandidates(root)...)
+	}
+	return candidates
+}
+
+func pythonGenericInterpreterCandidates(root string) []string {
+	if runtime.GOOS == "windows" {
+		return []string{
+			os.Getenv("GESTALT_PYTHON"),
+			filepath.Join(root, ".venv", "Scripts", "python.exe"),
+			filepath.Join(root, "venv", "Scripts", "python.exe"),
+			"py",
+			"python",
+		}
+	}
+	return []string{
+		os.Getenv("GESTALT_PYTHON"),
+		filepath.Join(root, ".venv", "bin", "python"),
+		filepath.Join(root, "venv", "bin", "python"),
+		"python3",
+		"python",
+	}
+}
+
+func pythonInterpreterEnvVar(goos, goarch string) string {
+	replacer := strings.NewReplacer("-", "_", ".", "_", "/", "_")
+	return pythonEnvVarPrefix + strings.ToUpper(replacer.Replace(goos)) + "_" + strings.ToUpper(replacer.Replace(goarch))
+}
+
+func SplitPythonProviderTarget(target string) (module string, attr string, err error) {
+	raw := strings.TrimSpace(target)
+	module, attr, hasAttr := strings.Cut(raw, ":")
+	module = strings.TrimSpace(module)
+	attr = strings.TrimSpace(attr)
+	switch {
+	case module == "":
+		return "", "", fmt.Errorf("module is required")
+	case !isPythonModulePath(module):
+		return "", "", fmt.Errorf("module must be a dot-separated Python identifier path")
+	case hasAttr && attr == "":
+		return "", "", fmt.Errorf("attribute is required")
+	case hasAttr && !isPythonIdentifier(attr):
+		return "", "", fmt.Errorf("attribute must be a Python identifier")
+	default:
+		return module, attr, nil
+	}
+}
+
+const (
+	pythonRuntimeKindIntegration    = "integration"
+	pythonRuntimeKindAuthentication = "authentication"
+	pythonRuntimeKindAuthorization  = "authorization"
+	pythonRuntimeKindCache          = "cache"
+	pythonRuntimeKindIndexedDB      = "indexeddb"
+	pythonRuntimeKindS3             = "s3"
+	pythonRuntimeKindWorkflow       = "workflow"
+	pythonRuntimeKindAgent          = "agent"
+	pythonRuntimeKindSecrets        = "secrets"
+	pythonRuntimeKindRuntime        = "runtime"
+)
+
+func pythonRuntimeKind(kind string) (string, error) {
+	kind = providermanifestv1.NormalizeKind(kind)
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return pythonRuntimeKindIntegration, nil
+	case providermanifestv1.KindAuthentication:
+		return pythonRuntimeKindAuthentication, nil
+	case providermanifestv1.KindAuthorization:
+		return pythonRuntimeKindAuthorization, nil
+	case providermanifestv1.KindCache:
+		return pythonRuntimeKindCache, nil
+	case providermanifestv1.KindIndexedDB:
+		return pythonRuntimeKindIndexedDB, nil
+	case providermanifestv1.KindS3:
+		return pythonRuntimeKindS3, nil
+	case providermanifestv1.KindWorkflow:
+		return pythonRuntimeKindWorkflow, nil
+	case providermanifestv1.KindAgent:
+		return pythonRuntimeKindAgent, nil
+	case providermanifestv1.KindSecrets:
+		return pythonRuntimeKindSecrets, nil
+	case providermanifestv1.KindRuntime:
+		return pythonRuntimeKindRuntime, nil
+	default:
+		return "", fmt.Errorf("unsupported Python runtime kind %q", kind)
+	}
+}
+
+func isPythonModulePath(value string) bool {
+	parts := strings.Split(value, ".")
+	if len(parts) == 0 {
+		return false
+	}
+	for _, part := range parts {
+		if !isPythonIdentifier(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func isPythonIdentifier(value string) bool {
+	return pythonIdentifierPattern.MatchString(value)
+}
+
+func pythonProjectTarget(data []byte, wantedKey string) (string, error) {
+	return pythonProjectTargetValue(data, wantedKey)
+}
+
+func pythonProjectTargetValue(data []byte, wantedKey string) (string, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	inGestaltSection := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(stripTOMLComment(scanner.Text()))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			inGestaltSection = section == "tool.gestalt"
+			continue
+		}
+		if !inGestaltSection {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != wantedKey {
+			continue
+		}
+		return parseTOMLString(value)
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+func stripTOMLComment(line string) string {
+	inBasicString := false
+	inLiteralString := false
+	escaped := false
+	for i, r := range line {
+		switch {
+		case escaped:
+			escaped = false
+		case inBasicString:
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == '"' {
+				inBasicString = false
+			}
+		case inLiteralString:
+			if r == '\'' {
+				inLiteralString = false
+			}
+		default:
+			switch r {
+			case '#':
+				return line[:i]
+			case '"':
+				inBasicString = true
+			case '\'':
+				inLiteralString = true
+			}
+		}
+	}
+	return line
+}
+
+func parseTOMLString(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("value is required")
+	}
+	switch value[0] {
+	case '"':
+		parsed, err := strconv.Unquote(value)
+		if err != nil {
+			return "", fmt.Errorf("invalid quoted string: %w", err)
+		}
+		return parsed, nil
+	case '\'':
+		if len(value) < 2 || value[len(value)-1] != '\'' {
+			return "", fmt.Errorf("invalid literal string")
+		}
+		return value[1 : len(value)-1], nil
+	default:
+		return "", fmt.Errorf("must be a quoted string")
+	}
+}

--- a/gestaltd/services/plugins/providerpkg/release_target.go
+++ b/gestaltd/services/plugins/providerpkg/release_target.go
@@ -1,0 +1,88 @@
+package providerpkg
+
+import (
+	"errors"
+	"fmt"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func ReleaseRequiresBuild(manifest *providermanifestv1.Manifest) bool {
+	kind, err := ManifestKind(manifest)
+	if err != nil {
+		return false
+	}
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		return EntrypointForKind(manifest, kind) == nil
+	default:
+		return false
+	}
+}
+
+func HasSourceReleaseTarget(root, kind string) (bool, error) {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return HasSourceProviderPackage(root)
+	case providermanifestv1.KindUI:
+		return false, nil
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		return HasSourceComponentPackage(root, kind)
+	default:
+		return false, fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}
+
+func ValidateSourceReleaseTarget(root, kind, goos, goarch string) error {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return ValidateSourceProviderRelease(root, goos, goarch)
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		return ValidateSourceComponentRelease(root, kind, goos, goarch)
+	default:
+		return fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}
+
+func BuildSourceReleaseBinary(root, outputPath, pluginName, kind, goos, goarch string) error {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		_, err := BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch)
+		return err
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		_, err := BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch)
+		return err
+	default:
+		return fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}
+
+func IsMissingSourceReleaseTarget(err error, kind string) bool {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return errors.Is(err, ErrNoSourceProviderPackage)
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		return errors.Is(err, ErrNoSourceComponentPackage)
+	default:
+		return false
+	}
+}
+
+func MissingSourceReleaseTargetError(kind string) error {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
+	case providermanifestv1.KindAuthorization:
+		return fmt.Errorf("no Go, Rust, Python, or TypeScript authorization source package found")
+	case providermanifestv1.KindExternalCredentials:
+		return fmt.Errorf("no Go externalcredentials source package found")
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets:
+		return fmt.Errorf("no Go, Rust, Python, or TypeScript %s source package found", kind)
+	case providermanifestv1.KindRuntime:
+		return fmt.Errorf("no Go runtime source package found")
+	default:
+		return fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}

--- a/gestaltd/services/plugins/providerpkg/rust_provider.go
+++ b/gestaltd/services/plugins/providerpkg/rust_provider.go
@@ -1,0 +1,406 @@
+package providerpkg
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+const (
+	rustProjectFile       = "Cargo.toml"
+	rustWrapperBinaryName = "gestalt-provider-wrapper"
+)
+
+var (
+	ErrNoRustProviderPackage = errors.New("no Rust provider package found")
+	ErrRustToolUnavailable   = errors.New("cargo tool unavailable")
+)
+
+type rustProviderTarget struct {
+	PackageName string
+}
+
+type rustWrapperData struct {
+	PluginNameLiteral  string
+	RootPathLiteral    string
+	PackageNameLiteral string
+	ServeFunction      string
+	SupportsCatalog    bool
+}
+
+var rustWrapperCargoTemplate = template.Must(template.New("rust-wrapper-cargo").Parse(`[package]
+name = "gestalt-provider-wrapper"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+provider_plugin = { package = {{.PackageNameLiteral}}, path = {{.RootPathLiteral}} }
+`))
+
+var rustWrapperMainTemplate = template.Must(template.New("rust-wrapper-main").Parse(`use std::error::Error;
+
+const PLUGIN_NAME: &str = {{.PluginNameLiteral}};
+
+fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+{{- if .SupportsCatalog }}
+    if let Ok(path) = std::env::var("GESTALT_PLUGIN_WRITE_CATALOG") {
+        provider_plugin::__gestalt_write_catalog(PLUGIN_NAME, &path)?;
+    } else {
+        provider_plugin::{{.ServeFunction}}(PLUGIN_NAME)?;
+    }
+{{- else }}
+    provider_plugin::{{.ServeFunction}}(PLUGIN_NAME)?;
+{{- end }}
+    Ok(())
+}
+`))
+
+func detectRustProviderPackage(root string) (*rustProviderTarget, error) {
+	return detectRustPackage(root)
+}
+
+func detectRustPackage(root string) (*rustProviderTarget, error) {
+	projectPath := filepath.Join(root, rustProjectFile)
+	if _, err := os.Stat(projectPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNoRustProviderPackage
+		}
+		return nil, fmt.Errorf("stat %s: %w", rustProjectFile, err)
+	}
+
+	data, err := os.ReadFile(projectPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", rustProjectFile, err)
+	}
+	target, err := rustProjectPackageTarget(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", rustProjectFile, err)
+	}
+	if target == nil {
+		return nil, ErrNoRustProviderPackage
+	}
+	return target, nil
+}
+
+func rustProviderExecutionCommand(root, goos, goarch string) (string, []string, func(), error) {
+	pluginName := sourcePluginName(root)
+	command, cleanup, err := BuildRustProviderTempBinary(root, pluginName, goos, goarch)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	return command, nil, cleanup, nil
+}
+
+func rustComponentExecutionCommand(root, kind, goos, goarch string) (string, []string, func(), error) {
+	command, cleanup, err := BuildRustComponentTempBinary(root, kind, goos, goarch)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	return command, nil, cleanup, nil
+}
+
+func BuildRustProviderTempBinary(root, pluginName, goos, goarch string) (string, func(), error) {
+	return buildRustTempBinary(root, pluginName, providermanifestv1.KindPlugin, goos, goarch)
+}
+
+func BuildRustComponentTempBinary(root, kind, goos, goarch string) (string, func(), error) {
+	if err := validateRustComponentKind(kind); err != nil {
+		return "", nil, err
+	}
+	return buildRustTempBinary(root, sourcePluginName(root), kind, goos, goarch)
+}
+
+func buildRustTempBinary(root, pluginName, kind, goos, goarch string) (string, func(), error) {
+	return buildGoTempBinary("gestalt-rust-provider-bin-*", rustBinaryName(kind), goos, func(outputPath string) error {
+		_, err := buildRustBinary(root, outputPath, pluginName, kind, goos, goarch)
+		return err
+	})
+}
+
+func ValidateRustProviderRelease(root, goos, goarch string) error {
+	if _, err := detectRustPackage(root); err != nil {
+		return err
+	}
+	if _, err := rustTargetTriple(goos, goarch); err != nil {
+		return err
+	}
+	return ensureCargoAvailable()
+}
+
+func ValidateRustComponentRelease(root, kind, goos, goarch string) error {
+	if err := validateRustComponentKind(kind); err != nil {
+		return err
+	}
+	if _, err := detectRustPackage(root); err != nil {
+		return err
+	}
+	if _, err := rustTargetTriple(goos, goarch); err != nil {
+		return err
+	}
+	return ensureCargoAvailable()
+}
+
+func BuildRustProviderBinary(root, outputPath, pluginName, goos, goarch string) (string, error) {
+	return buildRustBinary(root, outputPath, pluginName, providermanifestv1.KindPlugin, goos, goarch)
+}
+
+func BuildRustComponentBinary(root, outputPath, kind, goos, goarch string) (string, error) {
+	if err := validateRustComponentKind(kind); err != nil {
+		return "", err
+	}
+	return buildRustBinary(root, outputPath, sourcePluginName(root), kind, goos, goarch)
+}
+
+func validateRustComponentKind(kind string) error {
+	return validateSourceComponentKind(kind)
+}
+
+func buildRustBinary(root, outputPath, pluginName, kind, goos, goarch string) (string, error) {
+	target, err := detectRustPackage(root)
+	if err != nil {
+		return "", err
+	}
+	targetTriple, err := rustTargetTriple(goos, goarch)
+	if err != nil {
+		return "", err
+	}
+	if err := ensureCargoAvailable(); err != nil {
+		return "", err
+	}
+
+	wrapperDir, cleanup, err := newRustWrapperProject(root, target.PackageName, pluginName, kind)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+
+	targetDir := filepath.Join(wrapperDir, "target")
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return "", fmt.Errorf("create output directory: %w", err)
+	}
+
+	cmd := exec.Command("cargo", "build",
+		"--manifest-path", filepath.Join(wrapperDir, rustProjectFile),
+		"--release",
+		"--target", targetTriple,
+		"--target-dir", targetDir,
+	)
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("cargo build: %w", err)
+	}
+
+	builtBinaryPath := filepath.Join(targetDir, targetTriple, "release", rustWrapperBinaryName)
+	if goos == "windows" {
+		builtBinaryPath += ".exe"
+	}
+	if err := copyRustBuiltBinary(builtBinaryPath, outputPath); err != nil {
+		return "", err
+	}
+
+	return "", nil
+}
+
+func rustProjectPackageTarget(data []byte) (*rustProviderTarget, error) {
+	var (
+		inPackageSection  bool
+		sawPackageSection bool
+		packageName       string
+	)
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(stripTOMLComment(scanner.Text()))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			inPackageSection = section == "package"
+			if inPackageSection {
+				sawPackageSection = true
+			}
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		if inPackageSection && key == "name" {
+			parsed, err := parseTOMLString(value)
+			if err != nil {
+				return nil, fmt.Errorf("package.name: %w", err)
+			}
+			packageName = strings.TrimSpace(parsed)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if !sawPackageSection {
+		return nil, nil
+	}
+	if packageName == "" {
+		return nil, fmt.Errorf("package.name is required")
+	}
+	return &rustProviderTarget{PackageName: packageName}, nil
+}
+
+func ensureCargoAvailable() error {
+	if _, err := exec.LookPath("cargo"); err != nil {
+		return fmt.Errorf("%w: %v", ErrRustToolUnavailable, err)
+	}
+	return nil
+}
+
+func rustTargetTriple(goos, goarch string) (string, error) {
+	switch goos {
+	case "darwin":
+		switch goarch {
+		case "amd64":
+			return "x86_64-apple-darwin", nil
+		case "arm64":
+			return "aarch64-apple-darwin", nil
+		}
+	case "linux":
+		switch goarch {
+		case "amd64":
+			return "x86_64-unknown-linux-musl", nil
+		case "arm64":
+			return "aarch64-unknown-linux-musl", nil
+		}
+	case "windows":
+		if goarch == "amd64" {
+			return "x86_64-pc-windows-gnu", nil
+		}
+	}
+	return "", fmt.Errorf("unsupported Rust target platform %s/%s", goos, goarch)
+}
+
+func rustServeFunction(kind string) (string, bool, error) {
+	kind = providermanifestv1.NormalizeKind(kind)
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return "__gestalt_serve", true, nil
+	case providermanifestv1.KindAuthentication:
+		return "__gestalt_serve_authentication", false, nil
+	case providermanifestv1.KindAuthorization:
+		return "__gestalt_serve_authorization", false, nil
+	case providermanifestv1.KindCache:
+		return "__gestalt_serve_cache", false, nil
+	case providermanifestv1.KindIndexedDB:
+		return "__gestalt_serve_indexeddb", false, nil
+	case providermanifestv1.KindS3:
+		return "__gestalt_serve_s3", false, nil
+	case providermanifestv1.KindRuntime:
+		return "__gestalt_serve_runtime", false, nil
+	case providermanifestv1.KindWorkflow:
+		return "__gestalt_serve_workflow", false, nil
+	case providermanifestv1.KindAgent:
+		return "__gestalt_serve_agent", false, nil
+	case providermanifestv1.KindSecrets:
+		return "__gestalt_serve_secrets", false, nil
+	default:
+		return "", false, fmt.Errorf("unsupported Rust provider kind %q", kind)
+	}
+}
+
+func rustBinaryName(kind string) string {
+	kind = providermanifestv1.NormalizeKind(kind)
+	switch kind {
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindS3, providermanifestv1.KindRuntime, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets:
+		return kind
+	default:
+		return "provider"
+	}
+}
+
+func newRustWrapperProject(root, packageName, pluginName, kind string) (string, func(), error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve Rust package root: %w", err)
+	}
+	serveFunction, supportsCatalog, err := rustServeFunction(kind)
+	if err != nil {
+		return "", nil, err
+	}
+
+	wrapperDir, err := os.MkdirTemp("", "gestalt-rust-wrapper-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create Rust wrapper directory: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(wrapperDir) }
+
+	srcDir := filepath.Join(wrapperDir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("create Rust wrapper src directory: %w", err)
+	}
+
+	data := rustWrapperData{
+		PluginNameLiteral:  strconv.Quote(pluginName),
+		RootPathLiteral:    strconv.Quote(absRoot),
+		PackageNameLiteral: strconv.Quote(packageName),
+		ServeFunction:      serveFunction,
+		SupportsCatalog:    supportsCatalog,
+	}
+	if err := writeRustWrapperFile(filepath.Join(wrapperDir, rustProjectFile), rustWrapperCargoTemplate, data); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	if err := writeRustWrapperFile(filepath.Join(srcDir, "main.rs"), rustWrapperMainTemplate, data); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return wrapperDir, cleanup, nil
+}
+
+func writeRustWrapperFile(path string, tmpl *template.Template, data rustWrapperData) error {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("render %s: %w", filepath.Base(path), err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func copyRustBuiltBinary(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open built Rust binary %q: %w", src, err)
+	}
+	defer func() { _ = in.Close() }()
+
+	info, err := in.Stat()
+	if err != nil {
+		return fmt.Errorf("stat built Rust binary %q: %w", src, err)
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return fmt.Errorf("create Rust provider binary %q: %w", dst, err)
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy Rust provider binary: %w", err)
+	}
+	return out.Close()
+}

--- a/gestaltd/services/plugins/providerpkg/source_build.go
+++ b/gestaltd/services/plugins/providerpkg/source_build.go
@@ -185,24 +185,33 @@ func SourceBuildInputs(manifest *providermanifestv1.Manifest) []string {
 	return append([]string(nil), build.Inputs...)
 }
 
-func SourceManifestExecutionCommand(manifestPath, kind string, opts SourceBuildOptions) (string, []string, error) {
+func SourceManifestExecutionCommand(manifestPath, kind string, opts SourceBuildOptions) (string, []string, func(), error) {
 	_, manifest, err := ReadSourceManifestFile(manifestPath)
 	if err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 	if err := EnsureSourceBuildOutput(manifestPath, manifest, opts); err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 	if strings.TrimSpace(kind) == "" {
 		kind, err = ManifestKind(manifest)
 		if err != nil {
-			return "", nil, err
+			return "", nil, nil, err
 		}
 	}
 	entry := EntrypointForKind(manifest, kind)
-	if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
-		return "", nil, fmt.Errorf("manifest does not define a %s entrypoint", kind)
+	if entry != nil && strings.TrimSpace(entry.ArtifactPath) != "" {
+		command := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(entry.ArtifactPath))
+		return command, append([]string(nil), entry.Args...), nil, nil
 	}
-	command := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(entry.ArtifactPath))
-	return command, append([]string(nil), entry.Args...), nil
+	rootDir := filepath.Dir(manifestPath)
+	goos, goarch := SourceBuildTarget(opts)
+	switch providermanifestv1.NormalizeKind(kind) {
+	case providermanifestv1.KindPlugin:
+		return SourceProviderExecutionCommand(rootDir, goos, goarch)
+	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindExternalCredentials, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime:
+		return SourceComponentExecutionCommand(rootDir, kind, goos, goarch)
+	default:
+		return "", nil, nil, fmt.Errorf("manifest does not define a %s entrypoint", kind)
+	}
 }

--- a/gestaltd/services/plugins/providerpkg/source_component_test.go
+++ b/gestaltd/services/plugins/providerpkg/source_component_test.go
@@ -1,0 +1,60 @@
+package providerpkg
+
+import (
+	"path/filepath"
+	"testing"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestHasSourceComponentPackage_RuntimeWithoutSourceReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	ok, err := HasSourceComponentPackage(t.TempDir(), providermanifestv1.KindRuntime)
+	if err != nil {
+		t.Fatalf("HasSourceComponentPackage(runtime) error = %v", err)
+	}
+	if ok {
+		t.Fatal("HasSourceComponentPackage(runtime) = true, want false")
+	}
+}
+
+func TestHasSourceComponentPackage_DetectsPythonRuntimeProvider(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
+runtime = "provider:runtime"
+`), 0o644)
+
+	ok, err := HasSourceComponentPackage(root, providermanifestv1.KindRuntime)
+	if err != nil {
+		t.Fatalf("HasSourceComponentPackage(runtime) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("HasSourceComponentPackage(runtime) = false, want true")
+	}
+}
+
+func TestHasSourceComponentPackage_DetectsTypeScriptRuntimeProvider(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "package.json"), []byte(`{
+  "gestalt": {
+    "provider": {
+      "kind": "runtime",
+      "target": "./runtime.ts#provider"
+    }
+  }
+}
+`), 0o644)
+
+	ok, err := HasSourceComponentPackage(root, providermanifestv1.KindRuntime)
+	if err != nil {
+		t.Fatalf("HasSourceComponentPackage(runtime) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("HasSourceComponentPackage(runtime) = false, want true")
+	}
+}

--- a/gestaltd/services/plugins/providerpkg/source_prepare.go
+++ b/gestaltd/services/plugins/providerpkg/source_prepare.go
@@ -2,10 +2,12 @@ package providerpkg
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
@@ -73,18 +75,40 @@ func EnsureSourceStaticCatalog(manifestPath string, manifest *providermanifestv1
 }
 
 func generateSourceStaticCatalog(rootDir string, manifest *providermanifestv1.Manifest, catalogPath string) error {
+	var execEnv map[string]string
+	var cleanup func()
 	entry := EntrypointForKind(manifest, providermanifestv1.KindPlugin)
-	if entry == nil || entry.ArtifactPath == "" {
-		return nil
+	command := ""
+	var args []string
+	if entry != nil && entry.ArtifactPath != "" {
+		command = filepath.Join(rootDir, filepath.FromSlash(entry.ArtifactPath))
+		args = append([]string(nil), entry.Args...)
+	} else {
+		var err error
+		command, args, cleanup, err = SourceProviderExecutionCommand(rootDir, runtime.GOOS, runtime.GOARCH)
+		if err != nil {
+			if errors.Is(err, ErrNoSourceProviderPackage) {
+				return nil
+			}
+			return fmt.Errorf("prepare synthesized source provider for static catalog: %w", err)
+		}
+		execEnv, err = SourceProviderExecutionEnv(rootDir, runtime.GOOS, runtime.GOARCH)
+		if err != nil {
+			return fmt.Errorf("prepare synthesized source provider environment for static catalog: %w", err)
+		}
+	}
+	if cleanup != nil {
+		defer cleanup()
 	}
 
-	command := filepath.Join(rootDir, filepath.FromSlash(entry.ArtifactPath))
-	args := append([]string(nil), entry.Args...)
 	cmd := exec.Command(command, args...)
 	cmd.Env = append(
 		os.Environ(),
 		envWriteCatalog+"="+catalogPath,
 	)
+	for key, value := range execEnv {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output

--- a/gestaltd/services/plugins/providerpkg/source_provider.go
+++ b/gestaltd/services/plugins/providerpkg/source_provider.go
@@ -1,0 +1,136 @@
+package providerpkg
+
+import (
+	"errors"
+	"runtime"
+)
+
+var ErrNoSourceProviderPackage = errors.New("no source provider package found")
+
+const (
+	sourceProviderKindGo         = "go"
+	sourceProviderKindRust       = "rust"
+	sourceProviderKindPython     = "python"
+	sourceProviderKindTypeScript = "typescript"
+)
+
+func detectSourceProvider(root, goos, goarch string) (kind string, target string, err error) {
+	var goToolUnavailable error
+	if _, err := DetectGoProviderImportPath(root, goos, goarch); err == nil {
+		return sourceProviderKindGo, "", nil
+	} else if errors.Is(err, ErrGoToolUnavailable) {
+		goToolUnavailable = err
+	} else if !errors.Is(err, ErrNoGoProviderPackage) {
+		return "", "", err
+	}
+
+	if _, err := detectRustProviderPackage(root); err == nil {
+		return sourceProviderKindRust, "", nil
+	} else if !errors.Is(err, ErrNoRustProviderPackage) {
+		return "", "", err
+	}
+
+	target, err = DetectPythonProviderTarget(root)
+	switch {
+	case err == nil:
+		return sourceProviderKindPython, target, nil
+	case !errors.Is(err, ErrNoPythonProviderPackage):
+		return "", "", err
+	default:
+		target, err = DetectTypeScriptProviderTarget(root)
+		switch {
+		case err == nil:
+			return sourceProviderKindTypeScript, target, nil
+		case !errors.Is(err, ErrNoTypeScriptProviderPackage):
+			return "", "", err
+		case goToolUnavailable != nil:
+			return "", "", goToolUnavailable
+		default:
+			return "", "", ErrNoSourceProviderPackage
+		}
+	}
+}
+
+func SourceProviderExecutionCommand(root, goos, goarch string) (string, []string, func(), error) {
+	kind, target, err := detectSourceProvider(root, goos, goarch)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	switch kind {
+	case sourceProviderKindGo:
+		command, cleanup, err := BuildGoProviderTempBinary(root, goos, goarch)
+		if err != nil {
+			return "", nil, nil, err
+		}
+		return command, nil, cleanup, nil
+	case sourceProviderKindRust:
+		return rustProviderExecutionCommand(root, goos, goarch)
+	case sourceProviderKindPython:
+		return pythonProviderExecutionCommand(root, target)
+	case sourceProviderKindTypeScript:
+		return typeScriptExecutionCommand(root, target)
+	default:
+		return "", nil, nil, ErrNoSourceProviderPackage
+	}
+}
+
+func SourceProviderExecutionEnv(root, goos, goarch string) (map[string]string, error) {
+	kind, _, err := detectSourceProvider(root, goos, goarch)
+	if err != nil {
+		return nil, err
+	}
+	if kind != sourceProviderKindPython {
+		return nil, nil
+	}
+	return pythonBackendEnvMap()
+}
+
+func ValidateSourceProviderRelease(root, goos, goarch string) error {
+	kind, _, err := detectSourceProvider(root, goos, goarch)
+	if err != nil {
+		return err
+	}
+	switch kind {
+	case sourceProviderKindRust:
+		return ValidateRustProviderRelease(root, goos, goarch)
+	case sourceProviderKindPython:
+		_, err = DetectPythonInterpreter(root, goos, goarch)
+		return err
+	case sourceProviderKindTypeScript:
+		_, err = DetectBunExecutable()
+		return err
+	default:
+		return nil
+	}
+}
+
+func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch string) (string, error) {
+	kind, target, err := detectSourceProvider(root, goos, goarch)
+	if err != nil {
+		return "", err
+	}
+	switch kind {
+	case sourceProviderKindGo:
+		return "", BuildGoProviderBinary(root, outputPath, pluginName, goos, goarch)
+	case sourceProviderKindRust:
+		return BuildRustProviderBinary(root, outputPath, pluginName, goos, goarch)
+	case sourceProviderKindPython:
+		return BuildPythonProviderBinary(root, outputPath, pluginName, target, goos, goarch)
+	case sourceProviderKindTypeScript:
+		return BuildTypeScriptProviderBinary(root, outputPath, pluginName, target, goos, goarch)
+	default:
+		return "", ErrNoSourceProviderPackage
+	}
+}
+
+func HasSourceProviderPackage(root string) (bool, error) {
+	_, _, err := detectSourceProvider(root, runtime.GOOS, runtime.GOARCH)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, ErrNoSourceProviderPackage):
+		return false, nil
+	default:
+		return false, err
+	}
+}

--- a/gestaltd/services/plugins/providerpkg/typescript_provider.go
+++ b/gestaltd/services/plugins/providerpkg/typescript_provider.go
@@ -1,0 +1,421 @@
+package providerpkg
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+const (
+	typeScriptProjectFile  = "package.json"
+	typeScriptRuntimeBin   = "gestalt-ts-runtime"
+	typeScriptBuildBin     = "gestalt-ts-build"
+	typeScriptBunEnvVar    = "GESTALT_BUN"
+	typeScriptSDKDirEnvVar = "GESTALT_TYPESCRIPT_SDK_DIR"
+	typeScriptProviderKey  = "provider"
+	typeScriptPluginKey    = "plugin"
+	typeScriptAuthKey      = "auth"
+	typeScriptCacheKey     = "cache"
+	typeScriptIndexedDBKey = "indexeddb"
+	typeScriptS3Key        = "s3"
+	typeScriptWorkflowKey  = "workflow"
+	typeScriptAgentKey     = "agent"
+)
+
+var ErrNoTypeScriptProviderPackage = errors.New("no TypeScript provider package found")
+
+var typeScriptExportPattern = regexp.MustCompile(`^[A-Za-z_$][A-Za-z0-9_$]*$`)
+
+type typeScriptPackageConfig struct {
+	Gestalt map[string]any `json:"gestalt"`
+}
+
+func DetectTypeScriptProviderTarget(root string) (string, error) {
+	return detectTypeScriptTarget(root, "integration", ErrNoTypeScriptProviderPackage)
+}
+
+func DetectTypeScriptComponentTarget(root, kind string) (string, error) {
+	providerKind, err := typeScriptComponentKind(kind)
+	if err != nil {
+		return "", err
+	}
+	return detectTypeScriptTarget(root, providerKind, ErrNoSourceComponentPackage)
+}
+
+func detectTypeScriptTarget(root, expectedKind string, missingErr error) (string, error) {
+	projectPath := filepath.Join(root, typeScriptProjectFile)
+	data, err := os.ReadFile(projectPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", missingErr
+		}
+		return "", fmt.Errorf("read %s: %w", typeScriptProjectFile, err)
+	}
+
+	var config typeScriptPackageConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return "", fmt.Errorf("parse %s: %w", typeScriptProjectFile, err)
+	}
+
+	if rawProvider, ok := config.Gestalt[typeScriptProviderKey]; ok {
+		kind, target, err := parseTypeScriptProviderConfig(rawProvider)
+		if err != nil {
+			return "", fmt.Errorf("%s gestalt.%s: %w", typeScriptProjectFile, typeScriptProviderKey, err)
+		}
+		if kind == expectedKind {
+			return formatTypeScriptRuntimeTarget(kind, target), nil
+		}
+	}
+	return "", missingErr
+}
+
+func typeScriptExecutionCommand(root, target string) (string, []string, func(), error) {
+	bunPath, err := DetectBunExecutable()
+	if err != nil {
+		return "", nil, nil, err
+	}
+	if err := ensureTypeScriptProjectDependencies(bunPath, root); err != nil {
+		return "", nil, nil, err
+	}
+	sdkPath, err := prepareLocalTypeScriptSDK(bunPath)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	if sdkPath != "" {
+		return bunPath, []string{
+			"--cwd", sdkPath,
+			filepath.Join(sdkPath, "src", "runtime.ts"),
+			"--",
+			root,
+			target,
+		}, nil, nil
+	}
+	return bunPath, []string{
+		"run",
+		"--cwd", root,
+		typeScriptRuntimeBin,
+		"--",
+		root,
+		target,
+	}, nil, nil
+}
+
+func BuildTypeScriptProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) (string, error) {
+	return buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goarch)
+}
+
+func BuildTypeScriptComponentBinary(sourceDir, binaryPath, kind, target, goos, goarch string) (string, error) {
+	if err := validateSourceComponentKind(kind); err != nil {
+		return "", err
+	}
+	return buildTypeScriptBinary(sourceDir, binaryPath, sourcePluginName(sourceDir), target, goos, goarch)
+}
+
+func buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) (string, error) {
+	bunPath, err := DetectBunExecutable()
+	if err != nil {
+		return "", fmt.Errorf("detect Bun executable: %w", err)
+	}
+	if err := ensureTypeScriptProjectDependencies(bunPath, sourceDir); err != nil {
+		return "", fmt.Errorf("prepare TypeScript provider dependencies: %w", err)
+	}
+
+	var args []string
+	sdkPath, err := prepareLocalTypeScriptSDK(bunPath)
+	if err != nil {
+		return "", fmt.Errorf("prepare local TypeScript SDK: %w", err)
+	}
+	if sdkPath != "" {
+		args = []string{
+			"--cwd", sdkPath,
+			filepath.Join(sdkPath, "src", "build.ts"),
+			"--",
+			sourceDir,
+			target,
+			binaryPath,
+			pluginName,
+			goos,
+			goarch,
+		}
+	} else {
+		args = []string{
+			"run",
+			"--cwd", sourceDir,
+			typeScriptBuildBin,
+			"--",
+			sourceDir,
+			target,
+			binaryPath,
+			pluginName,
+			goos,
+			goarch,
+		}
+	}
+
+	cmd := exec.Command(bunPath, args...)
+	cmd.Dir = sourceDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("TypeScript release build: %w (ensure Bun and @valon-technologies/gestalt are available)", err)
+	}
+	return "", nil
+}
+
+func typeScriptComponentKind(kind string) (string, error) {
+	kind = providermanifestv1.NormalizeKind(kind)
+	switch kind {
+	case providermanifestv1.KindAuthentication:
+		return "authentication", nil
+	case providermanifestv1.KindAuthorization:
+		return "authorization", nil
+	case providermanifestv1.KindCache:
+		return "cache", nil
+	case providermanifestv1.KindIndexedDB:
+		return "indexeddb", nil
+	case providermanifestv1.KindS3:
+		return "s3", nil
+	case providermanifestv1.KindWorkflow:
+		return "workflow", nil
+	case providermanifestv1.KindAgent:
+		return "agent", nil
+	case providermanifestv1.KindSecrets:
+		return "secrets", nil
+	case providermanifestv1.KindRuntime:
+		return "runtime", nil
+	default:
+		return "", fmt.Errorf("unsupported source component kind %q", kind)
+	}
+}
+
+func DetectBunExecutable() (string, error) {
+	for _, candidate := range bunExecutableCandidates() {
+		if candidate == "" {
+			continue
+		}
+		if filepath.IsAbs(candidate) {
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				return candidate, nil
+			}
+			continue
+		}
+		if resolved, err := exec.LookPath(candidate); err == nil {
+			return resolved, nil
+		}
+	}
+	return "", fmt.Errorf("detect Bun executable: %w (set %s if Bun is installed outside PATH)", exec.ErrNotFound, typeScriptBunEnvVar)
+}
+
+func bunExecutableCandidates() []string {
+	candidates := []string{
+		os.Getenv(typeScriptBunEnvVar),
+		"bun",
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		candidates = append(candidates, filepath.Join(home, ".bun", "bin", "bun"))
+	}
+	return candidates
+}
+
+func prepareLocalTypeScriptSDK(bunPath string) (string, error) {
+	sdkPath := localTypeScriptSDKPath()
+	if sdkPath == "" {
+		return "", nil
+	}
+	if err := ensureLocalTypeScriptSDKDependencies(bunPath, sdkPath); err != nil {
+		return "", err
+	}
+	return sdkPath, nil
+}
+
+func ensureTypeScriptProjectDependencies(bunPath, root string) error {
+	return ensureTypeScriptDependencies(bunPath, root, "TypeScript provider")
+}
+
+func ensureLocalTypeScriptSDKDependencies(bunPath, sdkPath string) error {
+	return ensureTypeScriptDependencies(bunPath, sdkPath, "local TypeScript SDK")
+}
+
+func ensureTypeScriptDependencies(bunPath, root, label string) error {
+	nodeModulesPath := filepath.Join(root, "node_modules")
+	if info, err := os.Stat(nodeModulesPath); err == nil {
+		if info.IsDir() {
+			return nil
+		}
+		return fmt.Errorf("%s node_modules path %q is not a directory", label, nodeModulesPath)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s node_modules: %w", label, err)
+	}
+
+	args := []string{"install", "--cwd", root}
+	lockfilePath := filepath.Join(root, "bun.lock")
+	if _, err := os.Stat(lockfilePath); err == nil {
+		args = append(args, "--frozen-lockfile")
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s bun.lock: %w", label, err)
+	}
+
+	cmd := exec.Command(bunPath, args...)
+	cmd.Dir = root
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("bun install for %s: %w", label, err)
+	}
+	return nil
+}
+
+func localTypeScriptSDKPath() string {
+	if override := strings.TrimSpace(os.Getenv(typeScriptSDKDirEnvVar)); override != "" {
+		path := filepath.Clean(override)
+		if _, err := os.Stat(filepath.Join(path, "package.json")); err == nil {
+			return path
+		}
+		return ""
+	}
+	path := localRepositorySubdir("sdk", "typescript")
+	if path == "" {
+		return ""
+	}
+	return path
+}
+
+func SplitTypeScriptProviderTarget(target string) (modulePath string, exportName string, err error) {
+	raw := strings.TrimSpace(target)
+	modulePath, exportName, _ = strings.Cut(raw, "#")
+	modulePath = strings.TrimSpace(modulePath)
+	exportName = strings.TrimSpace(exportName)
+	if modulePath == "" {
+		return "", "", fmt.Errorf("module path is required")
+	}
+	if exportName != "" && !typeScriptExportPattern.MatchString(exportName) {
+		return "", "", fmt.Errorf("export must be a JavaScript identifier")
+	}
+	if err := validateTypeScriptModulePath(modulePath); err != nil {
+		return "", "", err
+	}
+	return modulePath, exportName, nil
+}
+
+func parseTypeScriptProviderConfig(raw any) (kind string, target string, err error) {
+	switch value := raw.(type) {
+	case string:
+		return parseTypeScriptProviderString(value)
+	case map[string]any:
+		rawKind, _ := value["kind"].(string)
+		rawTarget, _ := value["target"].(string)
+		kind = normalizeTypeScriptProviderKind(rawKind)
+		if strings.TrimSpace(rawKind) != "" && kind == "" {
+			return "", "", fmt.Errorf("unsupported provider kind %q", rawKind)
+		}
+		if strings.TrimSpace(rawTarget) == "" {
+			return "", "", fmt.Errorf("target is required")
+		}
+		target = strings.TrimSpace(rawTarget)
+		if _, _, err := SplitTypeScriptProviderTarget(target); err != nil {
+			return "", "", err
+		}
+		return kind, target, nil
+	default:
+		return "", "", fmt.Errorf("must be a string or object")
+	}
+}
+
+func parseTypeScriptProviderString(raw string) (kind string, target string, err error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", "", fmt.Errorf("target is required")
+	}
+	if prefix, rest, ok := parseTypeScriptKindPrefixedTarget(trimmed); ok {
+		if _, _, err := SplitTypeScriptProviderTarget(rest); err != nil {
+			return "", "", err
+		}
+		return prefix, rest, nil
+	}
+	if _, _, err := SplitTypeScriptProviderTarget(trimmed); err != nil {
+		if prefix, _, found := strings.Cut(trimmed, ":"); found {
+			prefix = strings.TrimSpace(prefix)
+			if prefix != "" && !strings.HasPrefix(prefix, ".") && !strings.HasPrefix(prefix, "/") {
+				return "", "", fmt.Errorf("unsupported provider kind %q", prefix)
+			}
+		}
+		return "", "", err
+	}
+	return "integration", trimmed, nil
+}
+
+func parseTypeScriptKindPrefixedTarget(raw string) (kind string, target string, ok bool) {
+	prefix, rest, found := strings.Cut(raw, ":")
+	if !found {
+		return "", "", false
+	}
+	if strings.TrimSpace(prefix) == "" {
+		return "", "", false
+	}
+	kind = normalizeTypeScriptProviderKind(prefix)
+	if kind == "" {
+		return "", "", false
+	}
+	return kind, strings.TrimSpace(rest), true
+}
+
+func normalizeTypeScriptProviderKind(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "", "plugin":
+		return "integration"
+	case "authentication", "auth":
+		return "authentication"
+	case "authorization", "authz":
+		return "authorization"
+	case "cache":
+		return "cache"
+	case "indexeddb":
+		return "indexeddb"
+	case "s3":
+		return "s3"
+	case "workflow":
+		return "workflow"
+	case "agent":
+		return "agent"
+	case "secrets":
+		return "secrets"
+	case "runtime":
+		return "runtime"
+	case "telemetry":
+		return "telemetry"
+	default:
+		return ""
+	}
+}
+
+func formatTypeScriptRuntimeTarget(kind, target string) string {
+	if kind == "integration" {
+		return "plugin:" + strings.TrimSpace(target)
+	}
+	return kind + ":" + strings.TrimSpace(target)
+}
+
+func validateTypeScriptModulePath(value string) error {
+	if !strings.HasPrefix(value, "./") && !strings.HasPrefix(value, "../") {
+		return fmt.Errorf("module path must be relative")
+	}
+	cleanPath := path.Clean(strings.ReplaceAll(value, "\\", "/"))
+	if path.IsAbs(cleanPath) || cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") {
+		return fmt.Errorf("module path must stay within the plugin root")
+	}
+	ext := path.Ext(cleanPath)
+	switch ext {
+	case ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs":
+		return nil
+	default:
+		return fmt.Errorf("module path must end in a TypeScript or JavaScript file extension")
+	}
+}

--- a/gestaltd/services/providerdrivers/componentprovider/factory.go
+++ b/gestaltd/services/providerdrivers/componentprovider/factory.go
@@ -58,12 +58,13 @@ func PrepareExecution(params PrepareParams) (PreparedConfig, error) {
 	var cleanup func()
 
 	if cfg.Command == "" && cfg.ManifestPath != "" {
-		command, args, err := providerpkg.SourceManifestExecutionCommand(cfg.ManifestPath, params.Kind, providerpkg.SourceBuildOptions{})
+		command, args, tempCleanup, err := providerpkg.SourceManifestExecutionCommand(cfg.ManifestPath, params.Kind, providerpkg.SourceBuildOptions{})
 		if err != nil {
 			return PreparedConfig{}, fmt.Errorf("%s: prepare source execution: %w", params.Subject, err)
 		}
 		cfg.Command = command
 		cfg.Args = args
+		cleanup = tempCleanup
 	}
 
 	if cfg.Command == "" {


### PR DESCRIPTION
## Summary

- Restores SDK-native Go/Rust/Python/TypeScript source provider detection for executable providers that do not declare `build.command`.
- Keeps explicit `build.command` support for custom executable builds, with `entrypoint.artifactPath` as the declared output.
- Keeps source UI manifests on the explicit `build.command` + `spec.assetRoot` contract.
- Preserves rejection for prebuilt executable source releases without a build/source package, so they do not silently get platform-specific archives.
- Updates docs to describe SDK-native source packages vs custom build commands.

This replaces the downstream manifest-script approach: provider authors should not need shell snippets in manifests just to keep existing TypeScript/Python/Go/Rust source providers working.

## Validation

- `go test ./services/plugins/providerpkg ./services/plugins/packageio ./services/providerdrivers/componentprovider ./internal/bootstrap ./internal/daemon`
- `go test ./internal/daemon -run 'TestRun_ProviderRelease(CompilesSDKSourceProviderWithoutBuildCommand|RejectsPrebuiltExecutableProvider|RejectsExplicitPlatformForPrebuiltProvider|RejectsGoModuleWithoutBuildCommand)'`
- `git diff --check`