### PR TITLE
[gestaltd] support plugin operation sets

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -356,9 +356,9 @@ func buildProvider(ctx context.Context, name string, entry *config.ProviderEntry
 		return nil, fmt.Errorf("integration %q must resolve to a provider manifest", name)
 	}
 
-	allowedOperations := entry.AllowedOperations
-	if allowedOperations == nil {
-		allowedOperations = maps.Clone(manifestPlugin.AllowedOperations)
+	allowedOperations, err := entry.EffectiveAllowedOperations()
+	if err != nil {
+		return nil, fmt.Errorf("resolve allowed operations for %q: %w", name, err)
 	}
 
 	switch {
@@ -409,9 +409,10 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 	if err != nil {
 		return nil, err
 	}
-	allowedOperations := entry.AllowedOperations
-	if allowedOperations == nil && manifestPlugin != nil {
-		allowedOperations = maps.Clone(manifestPlugin.AllowedOperations)
+	allowedOperations, err := entry.EffectiveAllowedOperations()
+	if err != nil {
+		closeIfPossible(pluginProv)
+		return nil, fmt.Errorf("resolve allowed operations for %q: %w", name, err)
 	}
 	staticAllowedOperations := operationexposure.MatchingAllowedOperations(allowedOperations, pluginProv.Catalog())
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -496,18 +496,20 @@ type ProviderEntry struct {
 	Dev                 *ProviderEntryDevConfig `yaml:"dev,omitempty"`
 
 	// Plugin-specific runtime fields populated from the canonical ui object.
-	MountPath         string                        `yaml:"-"`
-	UI                string                        `yaml:"-"`
-	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
-	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
-	Invokes           []PluginInvocationDependency  `yaml:"invokes,omitempty"`
-	Capabilities      *PluginCapabilitiesConfig     `yaml:"capabilities,omitempty"`
-	IndexedDB         *HostIndexedDBBindingConfig   `yaml:"indexeddb,omitempty"`
-	Cache             []string                      `yaml:"cache,omitempty"`
-	S3                []string                      `yaml:"s3,omitempty"`
-	Runtime           *RuntimePlacementConfig       `yaml:"runtime,omitempty"`
-	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
-	MCP               bool                          `yaml:"mcp,omitempty"`
+	MountPath           string                        `yaml:"-"`
+	UI                  string                        `yaml:"-"`
+	Connections         map[string]*ConnectionDef     `yaml:"connections,omitempty"`
+	AllowedOperations   map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
+	AllowedOperationSet string                        `yaml:"allowedOperationSet,omitempty"`
+	DefaultAllowedRoles []string                      `yaml:"defaultAllowedRoles,omitempty"`
+	Invokes             []PluginInvocationDependency  `yaml:"invokes,omitempty"`
+	Capabilities        *PluginCapabilitiesConfig     `yaml:"capabilities,omitempty"`
+	IndexedDB           *HostIndexedDBBindingConfig   `yaml:"indexeddb,omitempty"`
+	Cache               []string                      `yaml:"cache,omitempty"`
+	S3                  []string                      `yaml:"s3,omitempty"`
+	Runtime             *RuntimePlacementConfig       `yaml:"runtime,omitempty"`
+	Surfaces            *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
+	MCP                 bool                          `yaml:"mcp,omitempty"`
 
 	// Runtime-resolved fields (populated during init/bootstrap, not from YAML)
 	Command                    string                                `yaml:"-"`
@@ -1668,6 +1670,70 @@ func (e *ProviderEntry) ManifestSpec() *providermanifestv1.Spec {
 		return nil
 	}
 	return e.ResolvedManifest.Spec
+}
+
+func (e *ProviderEntry) EffectiveAllowedOperations() (map[string]*OperationOverride, error) {
+	if e == nil {
+		return nil, nil
+	}
+	spec := e.ManifestSpec()
+	allowed := e.AllowedOperations
+	switch {
+	case allowed != nil:
+		allowed = cloneOperationOverrides(allowed)
+	case strings.TrimSpace(e.AllowedOperationSet) != "":
+		if spec == nil {
+			return nil, fmt.Errorf("allowedOperationSet %q requires a resolved provider manifest", e.AllowedOperationSet)
+		}
+		operationSet, ok := spec.OperationSets[strings.TrimSpace(e.AllowedOperationSet)]
+		if !ok || operationSet == nil {
+			return nil, fmt.Errorf("allowedOperationSet %q is not defined by the provider manifest", e.AllowedOperationSet)
+		}
+		allowed = cloneOperationOverrides(operationSet.Operations)
+	case spec != nil && spec.OperationSets != nil && spec.OperationSets["default"] != nil:
+		allowed = cloneOperationOverrides(spec.OperationSets["default"].Operations)
+	case spec != nil:
+		allowed = cloneOperationOverrides(spec.AllowedOperations)
+	}
+	if len(e.DefaultAllowedRoles) > 0 {
+		allowed = applyDefaultAllowedRoles(allowed, e.DefaultAllowedRoles)
+	}
+	return allowed, nil
+}
+
+func cloneOperationOverrides(src map[string]*OperationOverride) map[string]*OperationOverride {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]*OperationOverride, len(src))
+	for name, override := range src {
+		if override == nil {
+			dst[name] = nil
+			continue
+		}
+		clone := *override
+		clone.AllowedRoles = slices.Clone(override.AllowedRoles)
+		clone.Tags = slices.Clone(override.Tags)
+		dst[name] = &clone
+	}
+	return dst
+}
+
+func applyDefaultAllowedRoles(allowed map[string]*OperationOverride, roles []string) map[string]*OperationOverride {
+	if allowed == nil {
+		return nil
+	}
+	defaultRoles := trimStringSlice(roles)
+	for name, override := range allowed {
+		if override == nil {
+			override = &OperationOverride{}
+			allowed[name] = override
+		}
+		if override.AllowedRoles == nil {
+			override.AllowedRoles = slices.Clone(defaultRoles)
+		}
+	}
+	return allowed
 }
 
 func (e *ProviderEntry) EffectiveHTTPSecuritySchemes() map[string]*HTTPSecurityScheme {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -45,6 +45,84 @@ func withDefaultConfigAPIVersion(content string) string {
 	return "\napiVersion: " + ConfigAPIVersion + "\n" + strings.TrimLeft(content, "\r\n")
 }
 
+func TestProviderEntryEffectiveAllowedOperationsUsesOperationSetDefaultRoles(t *testing.T) {
+	t.Parallel()
+
+	entry := &ProviderEntry{
+		AllowedOperationSet: "default",
+		DefaultAllowedRoles: []string{"user"},
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Spec: &providermanifestv1.Spec{
+				OperationSets: map[string]*providermanifestv1.ManifestOperationSet{
+					"default": {
+						Operations: map[string]*providermanifestv1.ManifestOperationOverride{
+							"Companies.List": {},
+							"Employees.Get":  {AllowedRoles: []string{"admin"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	allowed, err := entry.EffectiveAllowedOperations()
+	if err != nil {
+		t.Fatalf("EffectiveAllowedOperations() error = %v", err)
+	}
+	if got, want := allowed["Companies.List"].AllowedRoles, []string{"user"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Companies.List AllowedRoles = %#v, want %#v", got, want)
+	}
+	if got, want := allowed["Employees.Get"].AllowedRoles, []string{"admin"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Employees.Get AllowedRoles = %#v, want %#v", got, want)
+	}
+}
+
+func TestProviderEntryEffectiveAllowedOperationsFallsBackToDefaultOperationSet(t *testing.T) {
+	t.Parallel()
+
+	entry := &ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Spec: &providermanifestv1.Spec{
+				OperationSets: map[string]*providermanifestv1.ManifestOperationSet{
+					"default": {
+						Operations: map[string]*providermanifestv1.ManifestOperationOverride{
+							"Companies.List": {Description: "List companies"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	allowed, err := entry.EffectiveAllowedOperations()
+	if err != nil {
+		t.Fatalf("EffectiveAllowedOperations() error = %v", err)
+	}
+	if got, want := allowed["Companies.List"].Description, "List companies"; got != want {
+		t.Fatalf("Companies.List Description = %q, want %q", got, want)
+	}
+}
+
+func TestProviderEntryEffectiveAllowedOperationsRejectsUnknownSet(t *testing.T) {
+	t.Parallel()
+
+	entry := &ProviderEntry{
+		AllowedOperationSet: "restricted",
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Spec: &providermanifestv1.Spec{
+				OperationSets: map[string]*providermanifestv1.ManifestOperationSet{
+					"default": {Operations: map[string]*providermanifestv1.ManifestOperationOverride{}},
+				},
+			},
+		},
+	}
+
+	_, err := entry.EffectiveAllowedOperations()
+	if err == nil || !strings.Contains(err.Error(), `allowedOperationSet "restricted"`) {
+		t.Fatalf("EffectiveAllowedOperations() error = %v, want unknown set error", err)
+	}
+}
+
 func TestValidateStructureRejectsPlatformOAuth2RefreshToken(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/plugin_validation.go
+++ b/gestaltd/internal/config/plugin_validation.go
@@ -19,10 +19,11 @@ func PluginValidationEntry(entry *ProviderEntry) *pluginservice.ValidationPlugin
 	if entry == nil {
 		return nil
 	}
+	allowedOperations, _ := entry.EffectiveAllowedOperations()
 	return &pluginservice.ValidationPlugin{
 		Manifest:                    entry.ResolvedManifest,
 		ManifestPath:                entry.ResolvedManifestPath,
-		AllowedOperations:           entry.AllowedOperations,
+		AllowedOperations:           allowedOperations,
 		Invokes:                     pluginInvocationDependencies(entry.Invokes),
 		SurfaceURLOverrides:         pluginSurfaceURLOverrides(entry),
 		EffectiveCatalog:            entry.ResolvedCatalog,

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -3244,21 +3244,29 @@ func catalogFromStaticOperationIDs(ids []string, available bool) *catalog.Catalo
 
 func staticCatalogInputFingerprint(entry *config.ProviderEntry) (string, error) {
 	type input struct {
-		AllowedOperations map[string]*config.OperationOverride `json:"allowedOperations,omitempty"`
-		GraphQLSurfaceURL string                               `json:"graphqlSurfaceUrl,omitempty"`
-		MCPSurfaceURL     string                               `json:"mcpSurfaceUrl,omitempty"`
+		AllowedOperations   map[string]*config.OperationOverride `json:"allowedOperations,omitempty"`
+		AllowedOperationSet string                               `json:"allowedOperationSet,omitempty"`
+		DefaultAllowedRoles []string                             `json:"defaultAllowedRoles,omitempty"`
+		GraphQLSurfaceURL   string                               `json:"graphqlSurfaceUrl,omitempty"`
+		MCPSurfaceURL       string                               `json:"mcpSurfaceUrl,omitempty"`
 	}
 	var allowed map[string]*config.OperationOverride
+	var allowedOperationSet string
+	var defaultAllowedRoles []string
 	var graphQLURL, mcpURL string
 	if entry != nil {
 		allowed = entry.AllowedOperations
+		allowedOperationSet = entry.AllowedOperationSet
+		defaultAllowedRoles = entry.DefaultAllowedRoles
 		graphQLURL = config.ProviderSurfaceURLOverride(entry, config.SpecSurfaceGraphQL)
 		mcpURL = config.ProviderSurfaceURLOverride(entry, config.SpecSurfaceMCP)
 	}
 	payload, err := json.Marshal(input{
-		AllowedOperations: allowed,
-		GraphQLSurfaceURL: graphQLURL,
-		MCPSurfaceURL:     mcpURL,
+		AllowedOperations:   allowed,
+		AllowedOperationSet: allowedOperationSet,
+		DefaultAllowedRoles: defaultAllowedRoles,
+		GraphQLSurfaceURL:   graphQLURL,
+		MCPSurfaceURL:       mcpURL,
 	})
 	if err != nil {
 		return "", err

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -175,6 +175,12 @@
             "$ref": "#/$defs/manifestOperationOverride"
           }
         },
+        "operationSets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/manifestOperationSet"
+          }
+        },
         "surfaces": {
           "$ref": "#/$defs/surfaces"
         },
@@ -1282,6 +1288,24 @@
         },
         "pagination": {
           "$ref": "#/$defs/paginationConfig"
+        }
+      }
+    },
+    "manifestOperationSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operations"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "operations": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/manifestOperationOverride"
+          }
         }
       }
     },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -106,6 +106,7 @@ type Spec struct {
 	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty" yaml:"managedParameters,omitempty"`
 	Surfaces          *ProviderSurfaces                     `json:"surfaces,omitempty" yaml:"surfaces,omitempty"`
 	AllowedOperations map[string]*ManifestOperationOverride `json:"allowedOperations,omitempty" yaml:"allowedOperations,omitempty"`
+	OperationSets     map[string]*ManifestOperationSet      `json:"operationSets,omitempty" yaml:"operationSets,omitempty"`
 	DefaultConnection string                                `json:"defaultConnection,omitempty" yaml:"defaultConnection,omitempty"`
 	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty" yaml:"connections,omitempty"`
 	ResponseMapping   *ManifestResponseMapping              `json:"responseMapping,omitempty" yaml:"responseMapping,omitempty"`
@@ -404,6 +405,11 @@ type ManifestOperationOverride struct {
 	Pagination   *ManifestPaginationConfig `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 }
 
+type ManifestOperationSet struct {
+	Description string                                `json:"description,omitempty" yaml:"description,omitempty"`
+	Operations  map[string]*ManifestOperationOverride `json:"operations,omitempty" yaml:"operations,omitempty"`
+}
+
 type ManifestConnectionDef struct {
 	DisplayName       string                             `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	Mode              ConnectionMode                     `json:"mode,omitempty" yaml:"mode,omitempty"`
@@ -597,6 +603,7 @@ type specJSONWire struct {
 	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty"`
 	Surfaces          *ProviderSurfaces                     `json:"surfaces,omitempty"`
 	AllowedOperations map[string]*ManifestOperationOverride `json:"allowedOperations,omitempty"`
+	OperationSets     map[string]*ManifestOperationSet      `json:"operationSets,omitempty"`
 	DefaultConnection string                                `json:"defaultConnection,omitempty"`
 	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty"`
 	ResponseMapping   *ManifestResponseMapping              `json:"responseMapping,omitempty"`
@@ -617,6 +624,7 @@ type specYAMLWire struct {
 	ManagedParameters []ManagedParameter                    `yaml:"managedParameters,omitempty"`
 	Surfaces          *ProviderSurfaces                     `yaml:"surfaces,omitempty"`
 	AllowedOperations map[string]*ManifestOperationOverride `yaml:"allowedOperations,omitempty"`
+	OperationSets     map[string]*ManifestOperationSet      `yaml:"operationSets,omitempty"`
 	DefaultConnection string                                `yaml:"defaultConnection,omitempty"`
 	Connections       map[string]*ManifestConnectionDef     `yaml:"connections,omitempty"`
 	ResponseMapping   *ManifestResponseMapping              `yaml:"responseMapping,omitempty"`
@@ -637,6 +645,7 @@ type specWire struct {
 	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty" yaml:"managedParameters,omitempty"`
 	Surfaces          *ProviderSurfaces                     `json:"surfaces,omitempty" yaml:"surfaces,omitempty"`
 	AllowedOperations map[string]*ManifestOperationOverride `json:"allowedOperations,omitempty" yaml:"allowedOperations,omitempty"`
+	OperationSets     map[string]*ManifestOperationSet      `json:"operationSets,omitempty" yaml:"operationSets,omitempty"`
 	DefaultConnection string                                `json:"defaultConnection,omitempty" yaml:"defaultConnection,omitempty"`
 	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty" yaml:"connections,omitempty"`
 	ResponseMapping   *ManifestResponseMapping              `json:"responseMapping,omitempty" yaml:"responseMapping,omitempty"`
@@ -667,6 +676,7 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 		ManagedParameters: raw.ManagedParameters,
 		Surfaces:          raw.Surfaces,
 		AllowedOperations: raw.AllowedOperations,
+		OperationSets:     raw.OperationSets,
 		DefaultConnection: raw.DefaultConnection,
 		Connections:       raw.Connections,
 		ResponseMapping:   raw.ResponseMapping,
@@ -716,6 +726,7 @@ func (s *Spec) UnmarshalYAML(value *yaml.Node) error {
 		ManagedParameters: raw.ManagedParameters,
 		Surfaces:          raw.Surfaces,
 		AllowedOperations: raw.AllowedOperations,
+		OperationSets:     raw.OperationSets,
 		DefaultConnection: raw.DefaultConnection,
 		Connections:       raw.Connections,
 		ResponseMapping:   raw.ResponseMapping,
@@ -748,6 +759,7 @@ func (s Spec) canonicalWire() (specWire, error) {
 		ManagedParameters: s.ManagedParameters,
 		Surfaces:          s.Surfaces,
 		AllowedOperations: s.AllowedOperations,
+		OperationSets:     s.OperationSets,
 		DefaultConnection: s.DefaultConnection,
 		Connections:       cloneManifestConnections(s.Connections),
 		ResponseMapping:   s.ResponseMapping,
@@ -1011,6 +1023,7 @@ var specWireFields = map[string]struct{}{
 	"managedParameters": {},
 	"surfaces":          {},
 	"allowedOperations": {},
+	"operationSets":     {},
 	"defaultConnection": {},
 	"connections":       {},
 	"responseMapping":   {},


### PR DESCRIPTION
## Description

Adds provider manifest operation sets and lets deployments select an allowed operation set with default roles for authorization.