### PR TITLE
Parallelize locked local UI sync

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -23,7 +23,7 @@ import { Callout } from 'nextra/components'
 | `gestaltd serve --lockfile PATH` | Override the lockfile location. `PATH` resolves like a normal CLI path. |
 | `gestaltd lock --config PATH` | Resolve published provider sources and write canonical lock metadata. Repeat `--config` to layer overrides. |
 | `gestaltd lock --check --config PATH` | Verify that the checked-in lockfile matches the current config without rewriting it. |
-| `gestaltd sync --locked --config PATH` | Materialize prepared provider artifacts from an existing lockfile. |
+| `gestaltd sync --locked --config PATH` | Materialize prepared provider artifacts from an existing lockfile. Local source UI preparation uses bounded parallelism by default. |
 | `gestaltd sync --locked --check --config PATH` | Verify that prepared artifacts exist and match the lockfile without rewriting them. |
 | `gestaltd validate --config PATH` | Validate config without serving. Repeat `--config` to layer overrides. |
 | `gestaltd validate --lockfile PATH` | Accept the same explicit lockfile path used by `lock`, `sync`, and `serve` without mutating it. |
@@ -75,12 +75,18 @@ view. `provider add`, `provider remove`, and `provider upgrade NAME --version`
 update the lockfile by default. `provider add` and `provider remove` accept
 `--no-lock` when you need to edit config only.
 
+`gestaltd sync --locked --parallelism N` caps concurrent preparation for local
+`source.path` UI bundles. The default is up to four workers, capped by
+`GOMAXPROCS`; `--parallelism 1` forces sequential preparation. Other provider
+types and `sync --locked --check` remain sequential.
+
 ## Examples
 
 ```sh
 gestaltd
 gestaltd lock --config ./config.yaml
 gestaltd sync --locked --config ./config.yaml
+gestaltd sync --locked --config ./config.yaml --parallelism 2
 gestaltd serve --locked --config ./config.yaml
 gestaltd validate --config ./config.yaml
 gestaltd lock --config ./config.yaml --lockfile ./local/gestalt.lock.json

--- a/gestaltd/internal/daemon/lifecycle.go
+++ b/gestaltd/internal/daemon/lifecycle.go
@@ -48,11 +48,15 @@ func lockConfigWithStatePaths(configFlags []string, state operator.StatePaths, p
 }
 
 func syncConfigWithStatePaths(configFlags []string, state operator.StatePaths, check bool) error {
+	return syncConfigWithStatePathsOptions(configFlags, state, check, operator.SyncOptions{Parallelism: 1})
+}
+
+func syncConfigWithStatePathsOptions(configFlags []string, state operator.StatePaths, check bool, opts operator.SyncOptions) error {
 	configPaths := operator.ResolveConfigPaths(configFlags)
 	if check {
-		return operatorLifecycle().CheckSyncAtPathsWithStatePaths(configPaths, state)
+		return operatorLifecycle().CheckSyncAtPathsWithStatePathsOptions(configPaths, state, opts)
 	}
-	return operatorLifecycle().SyncAtPathsWithStatePaths(configPaths, state)
+	return operatorLifecycle().SyncAtPathsWithStatePathsOptions(configPaths, state, opts)
 }
 
 func loadConfigForExecutionAtPathsWithStatePaths(configPaths []string, state operator.StatePaths, locked bool) (*config.Config, error) {

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -39,7 +39,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "sync",
 			args:      []string{"sync", "--help"},
-			wantParts: []string{"gestaltd sync --locked", "Materialize prepared artifacts", "--artifacts-dir", "--check"},
+			wantParts: []string{"gestaltd sync --locked", "Materialize prepared artifacts", "--artifacts-dir", "--parallelism", "--check"},
 		},
 		{
 			name:      "provider",
@@ -87,6 +87,47 @@ func TestE2ECLIHelp(t *testing.T) {
 				if strings.Contains(string(out), notWant) {
 					t.Fatalf("expected output to omit %q, got: %s", notWant, out)
 				}
+			}
+		})
+	}
+}
+
+func TestRunSyncParallelismValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		wantError string
+	}{
+		{
+			name:      "zero",
+			args:      []string{"--locked", "--parallelism", "0", "--config", filepath.Join(t.TempDir(), "missing.yaml")},
+			wantError: "invalid --parallelism 0: must be at least 1",
+		},
+		{
+			name:      "negative",
+			args:      []string{"--locked", "--parallelism", "-1", "--config", filepath.Join(t.TempDir(), "missing.yaml")},
+			wantError: "invalid --parallelism -1: must be at least 1",
+		},
+		{
+			name:      "one accepted",
+			args:      []string{"--parallelism", "1"},
+			wantError: "gestaltd sync currently requires --locked",
+		},
+		{
+			name:      "two accepted",
+			args:      []string{"--parallelism", "2"},
+			wantError: "gestaltd sync currently requires --locked",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := runSync(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("runSync(%v) error = %v, want %q", tc.args, err, tc.wantError)
 			}
 		})
 	}

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -302,20 +302,28 @@ func runSync(args []string) error {
 	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
 	locked := fs.Bool("locked", false, "require an existing lockfile; do not resolve new metadata")
 	check := fs.Bool("check", false, "fail if artifacts would need to be materialized")
+	parallelism := fs.Int("parallelism", defaultSyncParallelism(), "maximum concurrent local UI source preparations")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() > 0 {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
+	if *parallelism < 1 {
+		return fmt.Errorf("invalid --parallelism %d: must be at least 1", *parallelism)
+	}
 	if !*locked {
 		return fmt.Errorf("gestaltd sync currently requires --locked")
 	}
 
-	return syncConfigWithStatePaths(configPaths, operator.StatePaths{
+	return syncConfigWithStatePathsOptions(configPaths, operator.StatePaths{
 		ArtifactsDir: *artifactsDir,
 		LockfilePath: *lockfilePath,
-	}, *check)
+	}, *check, operator.SyncOptions{Parallelism: *parallelism})
+}
+
+func defaultSyncParallelism() int {
+	return operator.DefaultSyncParallelism()
 }
 
 func runValidate(args []string) error {
@@ -449,7 +457,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]")
 	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
-	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--check]")
+	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--check]")
 	writeUsageLine(w, "  gestaltd serve [--plugin NAME] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
 	writeUsageLine(w, "  gestaltd serve --path PATH [--config PATH]... [--name NAME] [--port PORT]")
 	writeUsageLine(w, "  gestaltd serve --remote URL (--path PATH | --config PATH...) [--name NAME]")
@@ -507,10 +515,11 @@ func printLockUsage(w io.Writer) {
 
 func printSyncUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--check]")
+	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--check]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Materialize prepared artifacts from the existing lockfile.")
 	writeUsageLine(w, "Does not resolve new metadata or rewrite the lockfile.")
+	writeUsageLine(w, "--parallelism caps concurrent local source UI preparation; --check remains read-only.")
 	writeUsageLine(w, "When repeated, --config files merge left-to-right.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
@@ -518,6 +527,7 @@ func printSyncUsage(w io.Writer) {
 	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory")
 	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
 	writeUsageLine(w, "  --locked          Require an existing lockfile")
+	writeUsageLine(w, "  --parallelism     Maximum concurrent local source UI preparations")
 	writeUsageLine(w, "  --check           Fail if artifacts would need to be materialized")
 }
 

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -116,6 +116,28 @@ type StatePaths struct {
 	PluginScope  []string
 }
 
+type SyncOptions struct {
+	Parallelism int
+}
+
+func DefaultSyncParallelism() int {
+	parallelism := runtime.GOMAXPROCS(0)
+	if parallelism > 4 {
+		parallelism = 4
+	}
+	if parallelism < 1 {
+		parallelism = 1
+	}
+	return parallelism
+}
+
+func normalizeSyncOptions(opts SyncOptions) SyncOptions {
+	if opts.Parallelism == 0 {
+		opts.Parallelism = DefaultSyncParallelism()
+	}
+	return opts
+}
+
 type artifactMode int
 
 const (
@@ -252,11 +274,19 @@ func (l *Lifecycle) CheckLockAtPathsWithStatePaths(configPaths []string, state S
 }
 
 func (l *Lifecycle) SyncAtPathsWithStatePaths(configPaths []string, state StatePaths) error {
-	return l.syncAtPathsWithStatePaths(configPaths, state, artifactModeMaterialize)
+	return l.SyncAtPathsWithStatePathsOptions(configPaths, state, SyncOptions{})
 }
 
 func (l *Lifecycle) CheckSyncAtPathsWithStatePaths(configPaths []string, state StatePaths) error {
-	return l.syncAtPathsWithStatePaths(configPaths, state, artifactModeCheck)
+	return l.CheckSyncAtPathsWithStatePathsOptions(configPaths, state, SyncOptions{})
+}
+
+func (l *Lifecycle) SyncAtPathsWithStatePathsOptions(configPaths []string, state StatePaths, opts SyncOptions) error {
+	return l.syncAtPathsWithStatePaths(configPaths, state, artifactModeMaterialize, opts)
+}
+
+func (l *Lifecycle) CheckSyncAtPathsWithStatePathsOptions(configPaths []string, state StatePaths, opts SyncOptions) error {
+	return l.syncAtPathsWithStatePaths(configPaths, state, artifactModeCheck, opts)
 }
 
 // PrepareAtPathWithPlatforms runs preparation and additionally downloads and hashes
@@ -396,7 +426,7 @@ func (l *Lifecycle) prepareLockAtPaths(configPaths []string, state StatePaths, d
 	if err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
-	if err := l.applyPreparedProviders(paths, lock, cfg, artifactModeMaterialize); err != nil {
+	if err := l.applyPreparedProviders(paths, lock, cfg, artifactModeMaterialize, SyncOptions{Parallelism: 1}); err != nil {
 		return nil, nil, lifecyclePaths{}, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -1028,7 +1058,7 @@ func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string,
 	if err := config.ValidateRuntime(cfg); err != nil {
 		return nil, err
 	}
-	if err := l.applyPreparedProviders(paths, lock, cfg, artifactModeMaterialize); err != nil {
+	if err := l.applyPreparedProviders(paths, lock, cfg, artifactModeMaterialize, SyncOptions{Parallelism: 1}); err != nil {
 		return nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -1105,7 +1135,8 @@ func (l *Lifecycle) LoadForStaticValidationAtPathsWithStatePaths(configPaths []s
 	return cfg, nil
 }
 
-func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StatePaths, mode artifactMode) error {
+func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StatePaths, mode artifactMode, opts SyncOptions) error {
+	opts = normalizeSyncOptions(opts)
 	cfg, err := loadConfigForLifecycle(configPaths, state, true)
 	if err != nil {
 		return fmt.Errorf("loading config: %v", err)
@@ -1143,7 +1174,7 @@ func (l *Lifecycle) syncAtPathsWithStatePaths(configPaths []string, state StateP
 	if err := config.ValidateRuntime(cfg); err != nil {
 		return err
 	}
-	if err := l.applyPreparedProviders(paths, lock, cfg, mode); err != nil {
+	if err := l.applyPreparedProviders(paths, lock, cfg, mode, opts); err != nil {
 		return err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -3460,7 +3491,7 @@ func (l *Lifecycle) lockCommittedNamedUIProviderArtifact(ctx context.Context, cf
 	return l.writeNamedUIProviderArtifact(ctx, cfg, paths, name, plugin, destDir, subject)
 }
 
-func (l *Lifecycle) applyPreparedProviders(paths lifecyclePaths, lock *Lockfile, cfg *config.Config, mode artifactMode) error {
+func (l *Lifecycle) applyPreparedProviders(paths lifecyclePaths, lock *Lockfile, cfg *config.Config, mode artifactMode, opts SyncOptions) error {
 	if !configHasProviderLoading(cfg) {
 		return nil
 	}
@@ -3516,9 +3547,30 @@ func (l *Lifecycle) applyPreparedProviders(paths lifecyclePaths, lock *Lockfile,
 			}
 		}
 	}
-	for name, entry := range cfg.Providers.UI {
+	return l.applyPreparedUIProviders(paths, lock, cfg, mode, opts)
+}
+
+type preparedUIWork struct {
+	name      string
+	entry     *config.UIEntry
+	lockEntry *LockEntry
+	configMap map[string]any
+	subject   string
+	destDir   string
+	install   *preparedInstall
+}
+
+func (l *Lifecycle) applyPreparedUIProviders(paths lifecyclePaths, lock *Lockfile, cfg *config.Config, mode artifactMode, opts SyncOptions) error {
+	var localWork []*preparedUIWork
+	var ordered []*preparedUIWork
+	for _, name := range slices.Sorted(maps.Keys(cfg.Providers.UI)) {
+		entry := cfg.Providers.UI[name]
 		if entry == nil {
 			continue
+		}
+		configMap, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			return fmt.Errorf("decode ui %q config: %w", name, err)
 		}
 		var lockEntry *LockEntry
 		if lock != nil {
@@ -3526,14 +3578,117 @@ func (l *Lifecycle) applyPreparedProviders(paths lifecyclePaths, lock *Lockfile,
 				lockEntry = &le
 			}
 		}
-		resolvedAssetRoot, err := l.applyConfiguredUIProvider(paths, lockEntry, &entry.ProviderEntry, name, "ui "+strconv.Quote(name), uiDestDir(paths, name), mode)
+		work := &preparedUIWork{
+			name:      name,
+			entry:     entry,
+			lockEntry: lockEntry,
+			configMap: configMap,
+			subject:   "ui " + strconv.Quote(name),
+			destDir:   uiDestDir(paths, name),
+		}
+		ordered = append(ordered, work)
+		if localUIParallelPrepareCandidate(paths, entry, mode) {
+			localWork = append(localWork, work)
+		}
+	}
+
+	if err := l.prepareLocalUIProviders(paths, localWork, opts); err != nil {
+		return err
+	}
+
+	for _, work := range ordered {
+		if work.install != nil {
+			resolvedAssetRoot, err := bindPreparedUIInstall(&work.entry.ProviderEntry, work.subject, work.destDir, work.configMap, work.install)
+			if err != nil {
+				return err
+			}
+			work.entry.ResolvedAssetRoot = resolvedAssetRoot
+			continue
+		}
+		resolvedAssetRoot, err := l.applyConfiguredUIProvider(paths, work.lockEntry, &work.entry.ProviderEntry, work.name, work.subject, work.destDir, mode)
 		if err != nil {
 			return err
 		}
-		entry.ResolvedAssetRoot = resolvedAssetRoot
+		work.entry.ResolvedAssetRoot = resolvedAssetRoot
 	}
-
 	return nil
+}
+
+func localUIParallelPrepareCandidate(paths lifecyclePaths, entry *config.UIEntry, mode artifactMode) bool {
+	if mode != artifactModeMaterialize || entry == nil || !entry.HasLocalSource() {
+		return false
+	}
+	if strings.TrimSpace(entry.OwnerPlugin) != "" {
+		return false
+	}
+	if pathWithinRoot(filepath.Join(paths.artifactsDir, ".gestaltd"), entry.SourcePath()) {
+		return false
+	}
+	return true
+}
+
+func (l *Lifecycle) prepareLocalUIProviders(paths lifecyclePaths, work []*preparedUIWork, opts SyncOptions) error {
+	if len(work) == 0 {
+		return nil
+	}
+	opts = normalizeSyncOptions(opts)
+	tasks := make([]pathDomainTask, 0, len(work))
+	for _, work := range work {
+		work := work
+		domains, err := localUISourcePathDomains(paths, work.name, work.entry, work.destDir)
+		if err != nil {
+			return err
+		}
+		tasks = append(tasks, pathDomainTask{
+			name:    work.name,
+			domains: domains,
+			run: func() error {
+				install, err := l.ensureLocalPreparedInstall(paths, providermanifestv1.KindUI, work.name, &work.entry.ProviderEntry, work.configMap, work.destDir, work.subject, artifactModeMaterialize)
+				if err != nil {
+					return err
+				}
+				work.install = install
+				return nil
+			},
+		})
+	}
+	slices.SortFunc(tasks, func(a, b pathDomainTask) int {
+		return cmp.Compare(a.name, b.name)
+	})
+	return runPathDomainTasks(tasks, opts.Parallelism)
+}
+
+func localUISourcePathDomains(paths lifecyclePaths, name string, entry *config.UIEntry, destDir string) ([]string, error) {
+	if entry == nil {
+		return nil, nil
+	}
+	normalized, err := normalizeLocalSource(entry.SourcePath())
+	if err != nil {
+		return nil, fmt.Errorf("manifest for ui %q not found at %s: %w", name, entry.SourcePath(), err)
+	}
+	domainPaths := []string{
+		normalized.sourceDir,
+		normalized.manifestPath,
+		destDir,
+	}
+	_, manifest, err := providerpkg.ReadSourceManifestFile(normalized.manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", normalized.manifestPath, err)
+	}
+	build := providerpkg.EffectiveSourceBuild(manifest)
+	if build != nil {
+		workdir := normalized.sourceDir
+		if build.Workdir != "" && build.Workdir != "." {
+			workdir = filepath.Join(normalized.sourceDir, filepath.FromSlash(build.Workdir))
+		}
+		domainPaths = append(domainPaths, workdir)
+		outputRel, _, err := providerpkg.SourceBuildOutput(manifest)
+		if err != nil {
+			return nil, err
+		}
+		domainPaths = append(domainPaths, filepath.Join(normalized.sourceDir, filepath.FromSlash(outputRel)))
+	}
+	return normalizePathDomains(domainPaths...)
 }
 
 func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths, cfg *config.Config, locked bool, bootstrapLock *Lockfile, mode artifactMode) (bool, error) {
@@ -3565,7 +3720,7 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths,
 		}
 		return false, fmt.Errorf("source-backed providers require lock metadata; full config mode prepares all source-backed providers. For local single-plugin development, use `gestaltd serve --plugin NAME` or `gestaltd serve --path PATH`; otherwise run `%s` then `%s`: %w", formatLockCommand(paths), formatSyncLockedCommand(paths), err)
 	}
-	if err := l.applyPreparedProviders(paths, lock, cfg, mode); err != nil {
+	if err := l.applyPreparedProviders(paths, lock, cfg, mode, SyncOptions{Parallelism: 1}); err != nil {
 		return false, err
 	}
 	return validatedDuringPrepare, nil

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -14,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -190,6 +192,222 @@ server:
 	}
 	if got, want := filepath.ToSlash(ui.ResolvedAssetRoot), filepath.ToSlash(filepath.Join(artifactsDir, ".gestaltd", "ui", "roadmap", "dist")); got != want {
 		t.Fatalf("ResolvedAssetRoot = %q, want %q", got, want)
+	}
+}
+
+func TestLifecycleSyncLockedPreparesIndependentLocalUIsInParallel(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("source UI build fixture uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	syncDir := filepath.Join(dir, "sync")
+	if err := os.MkdirAll(syncDir, 0o755); err != nil {
+		t.Fatalf("mkdir sync dir: %v", err)
+	}
+	alphaDir := filepath.Join(dir, "ui", "alpha")
+	betaDir := filepath.Join(dir, "ui", "beta")
+	writeBlockingSourceUITree(t, alphaDir, "github.com/acme/ui/alpha", "1.2.3", fmt.Sprintf(`#!/bin/sh
+set -eu
+touch %s/alpha.started
+i=0
+while [ ! -f %s/beta.started ]; do
+  i=$((i + 1))
+  if [ "$i" -gt 100 ]; then
+    echo "timed out waiting for beta" >&2
+    exit 42
+  fi
+  sleep 0.05
+done
+mkdir -p dist
+printf '<html>alpha</html>\n' > dist/index.html
+`, syncDir, syncDir))
+	writeBlockingSourceUITree(t, betaDir, "github.com/acme/ui/beta", "1.2.3", fmt.Sprintf(`#!/bin/sh
+set -eu
+touch %s/beta.started
+i=0
+while [ ! -f %s/alpha.started ]; do
+  i=$((i + 1))
+  if [ "$i" -gt 100 ]; then
+    echo "timed out waiting for alpha" >&2
+    exit 42
+  fi
+  sleep 0.05
+done
+mkdir -p dist
+printf '<html>beta</html>\n' > dist/index.html
+`, syncDir, syncDir))
+
+	configPath := writeLocalUITestConfig(t, dir, map[string]string{
+		"alpha": filepath.Join(alphaDir, "manifest.yaml"),
+		"beta":  filepath.Join(betaDir, "manifest.yaml"),
+	})
+	if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 2}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	}
+	for _, name := range []string{"alpha", "beta"} {
+		if _, err := os.Stat(filepath.Join(dir, "artifacts", ".gestaltd", "ui", name, "dist", "index.html")); err != nil {
+			t.Fatalf("prepared ui %s not found: %v", name, err)
+		}
+	}
+}
+
+func TestLifecycleSyncLockedParallelismOnePreparesLocalUIsSequentially(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("source UI build fixture uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "build.log")
+	alphaDir := filepath.Join(dir, "ui", "alpha")
+	betaDir := filepath.Join(dir, "ui", "beta")
+	writeBlockingSourceUITree(t, alphaDir, "github.com/acme/ui/alpha", "1.2.3", fmt.Sprintf(`#!/bin/sh
+set -eu
+printf 'alpha start\n' >> %s
+mkdir -p dist
+printf '<html>alpha</html>\n' > dist/index.html
+printf 'alpha end\n' >> %s
+`, logPath, logPath))
+	writeBlockingSourceUITree(t, betaDir, "github.com/acme/ui/beta", "1.2.3", fmt.Sprintf(`#!/bin/sh
+set -eu
+printf 'beta start\n' >> %s
+mkdir -p dist
+printf '<html>beta</html>\n' > dist/index.html
+printf 'beta end\n' >> %s
+`, logPath, logPath))
+
+	configPath := writeLocalUITestConfig(t, dir, map[string]string{
+		"alpha": filepath.Join(alphaDir, "manifest.yaml"),
+		"beta":  filepath.Join(betaDir, "manifest.yaml"),
+	})
+	if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 1}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read build log: %v", err)
+	}
+	want := "alpha start\nalpha end\nbeta start\nbeta end\n"
+	if string(data) != want {
+		t.Fatalf("build log = %q, want %q", data, want)
+	}
+}
+
+func TestLifecycleSyncLockedSerializesLocalUIsWithSharedOutput(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("source UI build fixture uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	uiDir := filepath.Join(dir, "ui", "shared")
+	if err := os.MkdirAll(uiDir, 0o755); err != nil {
+		t.Fatalf("mkdir ui dir: %v", err)
+	}
+	writeNamedBlockingSourceUIManifest(t, uiDir, "manifest-alpha.yaml", "github.com/acme/ui/alpha", "1.2.3", "build-alpha.sh")
+	writeNamedBlockingSourceUIManifest(t, uiDir, "manifest-beta.yaml", "github.com/acme/ui/beta", "1.2.3", "build-beta.sh")
+	script := `#!/bin/sh
+set -eu
+if [ -f running ]; then
+  echo overlap > overlap
+  exit 43
+fi
+touch running
+sleep 0.2
+rm running
+mkdir -p dist
+printf '<html>ok</html>\n' > dist/index.html
+`
+	if err := os.WriteFile(filepath.Join(uiDir, "build-alpha.sh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write alpha build: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(uiDir, "build-beta.sh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write beta build: %v", err)
+	}
+
+	configPath := writeLocalUITestConfig(t, dir, map[string]string{
+		"alpha": filepath.Join(uiDir, "manifest-alpha.yaml"),
+		"beta":  filepath.Join(uiDir, "manifest-beta.yaml"),
+	})
+	if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 2}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(uiDir, "overlap")); !os.IsNotExist(err) {
+		t.Fatalf("shared-output builds overlapped, stat overlap err=%v", err)
+	}
+}
+
+func TestLifecycleCheckSyncWithParallelismDoesNotMaterializeLocalUI(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("source UI build fixture uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	startedPath := filepath.Join(dir, "started")
+	uiDir := filepath.Join(dir, "ui", "alpha")
+	writeBlockingSourceUITree(t, uiDir, "github.com/acme/ui/alpha", "1.2.3", fmt.Sprintf(`#!/bin/sh
+set -eu
+touch %s
+mkdir -p dist
+printf '<html>alpha</html>\n' > dist/index.html
+`, startedPath))
+	configPath := writeLocalUITestConfig(t, dir, map[string]string{
+		"alpha": filepath.Join(uiDir, "manifest.yaml"),
+	})
+	err := NewLifecycle().CheckSyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 2})
+	if err == nil || !strings.Contains(err.Error(), `prepared artifact`) {
+		t.Fatalf("CheckSyncAtPathsWithStatePathsOptions error = %v, want stale prepared artifact", err)
+	}
+	if _, err := os.Stat(startedPath); !os.IsNotExist(err) {
+		t.Fatalf("sync --check materialized local ui, stat started err=%v", err)
+	}
+}
+
+func TestLocalUIParallelPrepareCandidateScope(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	paths := lifecyclePaths{artifactsDir: filepath.Join(dir, "artifacts")}
+	localEntry := &config.UIEntry{
+		ProviderEntry: config.ProviderEntry{
+			Source: config.ProviderSource{Path: filepath.Join(dir, "ui", "manifest.yaml")},
+		},
+	}
+	if !localUIParallelPrepareCandidate(paths, localEntry, artifactModeMaterialize) {
+		t.Fatal("configured local source ui should be eligible")
+	}
+	if localUIParallelPrepareCandidate(paths, localEntry, artifactModeCheck) {
+		t.Fatal("check mode local source ui should not be eligible")
+	}
+	ownedEntry := &config.UIEntry{
+		ProviderEntry: localEntry.ProviderEntry,
+		OwnerPlugin:   "plugin",
+	}
+	if localUIParallelPrepareCandidate(paths, ownedEntry, artifactModeMaterialize) {
+		t.Fatal("plugin-owned ui should not be eligible")
+	}
+	preparedEntry := &config.UIEntry{
+		ProviderEntry: config.ProviderEntry{
+			Source: config.ProviderSource{Path: filepath.Join(paths.artifactsDir, ".gestaltd", "ui", "plugin", "manifest.yaml")},
+		},
+	}
+	if localUIParallelPrepareCandidate(paths, preparedEntry, artifactModeMaterialize) {
+		t.Fatal("prepared path-backed ui should not be eligible")
+	}
+	gitEntry := &config.UIEntry{
+		ProviderEntry: config.ProviderEntry{
+			Source: config.ProviderSource{Git: &config.GitSourceDef{Repo: "file:///tmp/repo", Ref: "HEAD", Path: "ui/manifest.yaml"}},
+		},
+	}
+	if localUIParallelPrepareCandidate(paths, gitEntry, artifactModeMaterialize) {
+		t.Fatal("source.git ui should not be eligible")
 	}
 }
 
@@ -1119,6 +1337,66 @@ func writeSourceUITree(t *testing.T, dir, source, version string) {
 	if err := os.WriteFile(filepath.Join(dir, "build.sh"), []byte("mkdir -p dist\nprintf '<html>roadmap</html>\\n' > dist/index.html\n"), 0o755); err != nil {
 		t.Fatalf("write ui build script: %v", err)
 	}
+}
+
+func writeBlockingSourceUITree(t *testing.T, dir, source, version, buildScript string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir source ui dir: %v", err)
+	}
+	writeNamedBlockingSourceUIManifest(t, dir, "manifest.yaml", source, version, "build.sh")
+	if err := os.WriteFile(filepath.Join(dir, "build.sh"), []byte(buildScript), 0o755); err != nil {
+		t.Fatalf("write ui build script: %v", err)
+	}
+}
+
+func writeNamedBlockingSourceUIManifest(t *testing.T, dir, manifestName, source, version, buildScript string) {
+	t.Helper()
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindUI,
+		Source:  source,
+		Version: version,
+		Build: &providermanifestv1.SourceBuild{
+			Command: []string{"sh", "./" + buildScript},
+			Inputs:  []string{buildScript},
+		},
+		Spec: &providermanifestv1.Spec{AssetRoot: "dist"},
+	}
+	data, err := providerpkg.EncodeSourceManifestFormat(manifest, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("encode ui manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, manifestName), data, 0o644); err != nil {
+		t.Fatalf("write ui manifest: %v", err)
+	}
+}
+
+func writeLocalUITestConfig(t *testing.T, dir string, uiManifests map[string]string) string {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("apiVersion: gestaltd.config/v5\n")
+	b.WriteString(requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")))
+	b.WriteString("  ui:\n")
+	for _, name := range slices.Sorted(maps.Keys(uiManifests)) {
+		b.WriteString("    " + name + ":\n")
+		b.WriteString("      source:\n")
+		b.WriteString("        path: " + filepath.ToSlash(uiManifests[name]) + "\n")
+		b.WriteString("      path: /" + name + "\n")
+	}
+	b.WriteString("server:\n")
+	b.WriteString("  providers:\n")
+	b.WriteString("    indexeddb: sqlite\n")
+	b.WriteString("  artifactsDir: " + filepath.ToSlash(filepath.Join(dir, "artifacts")) + "\n")
+	b.WriteString("  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n")
+
+	configPath := filepath.Join(dir, "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+		t.Fatalf("write lockfile: %v", err)
+	}
+	return configPath
 }
 
 func runGitTestCommand(t *testing.T, dir string, args ...string) {

--- a/gestaltd/internal/operator/path_domain_scheduler.go
+++ b/gestaltd/internal/operator/path_domain_scheduler.go
@@ -1,0 +1,167 @@
+package operator
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+type pathDomainTask struct {
+	name    string
+	domains []string
+	run     func() error
+}
+
+func runPathDomainTasks(tasks []pathDomainTask, parallelism int) error {
+	if len(tasks) == 0 {
+		return nil
+	}
+	if parallelism < 1 {
+		parallelism = 1
+	}
+	if parallelism > len(tasks) {
+		parallelism = len(tasks)
+	}
+
+	pending := make([]queuedPathDomainTask, 0, len(tasks))
+	for i, task := range tasks {
+		pending = append(pending, queuedPathDomainTask{index: i, task: task})
+	}
+	var errs []taskError
+
+	for len(pending) > 0 && len(errs) == 0 {
+		batch := nextPathDomainBatch(pending, parallelism)
+		results := make(chan taskError, len(batch))
+		for _, queued := range batch {
+			queued := queued
+			go func() {
+				results <- taskError{index: queued.index, err: queued.task.run()}
+			}()
+		}
+		for range batch {
+			result := <-results
+			if result.err != nil {
+				errs = append(errs, result)
+			}
+		}
+		pending = removeQueuedPathDomainTasks(pending, batch)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	slices.SortFunc(errs, func(a, b taskError) int {
+		return a.index - b.index
+	})
+	return errs[0].err
+}
+
+type taskError struct {
+	index int
+	err   error
+}
+
+type queuedPathDomainTask struct {
+	index int
+	task  pathDomainTask
+}
+
+func nextPathDomainBatch(pending []queuedPathDomainTask, parallelism int) []queuedPathDomainTask {
+	batch := make([]queuedPathDomainTask, 0, parallelism)
+	activeDomains := make([]string, 0)
+	for _, queued := range pending {
+		if len(batch) == parallelism {
+			break
+		}
+		if pathDomainsConflictAny(activeDomains, queued.task.domains) {
+			continue
+		}
+		batch = append(batch, queued)
+		activeDomains = append(activeDomains, queued.task.domains...)
+	}
+	return batch
+}
+
+func removeQueuedPathDomainTasks(pending, batch []queuedPathDomainTask) []queuedPathDomainTask {
+	selected := make(map[int]struct{}, len(batch))
+	for _, queued := range batch {
+		selected[queued.index] = struct{}{}
+	}
+	next := pending[:0]
+	for _, queued := range pending {
+		if _, ok := selected[queued.index]; ok {
+			continue
+		}
+		next = append(next, queued)
+	}
+	return next
+}
+
+func pathDomainsConflictAny(active []string, requested []string) bool {
+	for _, activeDomain := range active {
+		for _, requestedDomain := range requested {
+			if pathDomainsConflict(activeDomain, requestedDomain) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func pathDomainsConflict(a, b string) bool {
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
+	return a == b || pathWithinRoot(a, b) || pathWithinRoot(b, a)
+}
+
+func normalizePathDomains(paths ...string) ([]string, error) {
+	domains := make([]string, 0, len(paths))
+	seen := map[string]struct{}{}
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		domain, err := canonicalPathDomain(path)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[domain]; ok {
+			continue
+		}
+		seen[domain] = struct{}{}
+		domains = append(domains, domain)
+	}
+	slices.Sort(domains)
+	return domains, nil
+}
+
+func canonicalPathDomain(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve path domain %q: %w", path, err)
+	}
+	clean := filepath.Clean(abs)
+	current := clean
+	suffix := ""
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			if suffix != "" {
+				return filepath.Clean(filepath.Join(resolved, suffix)), nil
+			}
+			return filepath.Clean(resolved), nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return clean, nil
+		}
+		if suffix == "" {
+			suffix = filepath.Base(current)
+		} else {
+			suffix = filepath.Join(filepath.Base(current), suffix)
+		}
+		current = parent
+	}
+}

--- a/gestaltd/internal/operator/path_domain_scheduler_test.go
+++ b/gestaltd/internal/operator/path_domain_scheduler_test.go
@@ -1,0 +1,322 @@
+package operator
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRunPathDomainTasksHonorsWorkerCap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	started := make(chan struct{}, 4)
+	release := make(chan struct{})
+	var active int32
+	var maxActive int32
+
+	var tasks []pathDomainTask
+	for _, name := range []string{"a", "b", "c", "d"} {
+		name := name
+		tasks = append(tasks, pathDomainTask{
+			name:    name,
+			domains: mustNormalizePathDomains(t, filepath.Join(dir, name)),
+			run: func() error {
+				now := atomic.AddInt32(&active, 1)
+				for {
+					max := atomic.LoadInt32(&maxActive)
+					if now <= max || atomic.CompareAndSwapInt32(&maxActive, max, now) {
+						break
+					}
+				}
+				started <- struct{}{}
+				<-release
+				atomic.AddInt32(&active, -1)
+				return nil
+			},
+		})
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runPathDomainTasks(tasks, 2) }()
+
+	waitForStarts(t, started, 2)
+	select {
+	case <-started:
+		t.Fatal("third task started before worker cap allowed it")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	if err := waitForScheduler(t, done); err != nil {
+		t.Fatalf("runPathDomainTasks: %v", err)
+	}
+	if got := atomic.LoadInt32(&maxActive); got != 2 {
+		t.Fatalf("max active tasks = %d, want 2", got)
+	}
+}
+
+func TestRunPathDomainTasksAllowsDisjointOverlap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	tasks := []pathDomainTask{
+		{
+			name:    "a",
+			domains: mustNormalizePathDomains(t, filepath.Join(dir, "a")),
+			run: func() error {
+				started <- struct{}{}
+				<-release
+				return nil
+			},
+		},
+		{
+			name:    "b",
+			domains: mustNormalizePathDomains(t, filepath.Join(dir, "b")),
+			run: func() error {
+				started <- struct{}{}
+				<-release
+				return nil
+			},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runPathDomainTasks(tasks, 2) }()
+	waitForStarts(t, started, 2)
+	close(release)
+	if err := waitForScheduler(t, done); err != nil {
+		t.Fatalf("runPathDomainTasks: %v", err)
+	}
+}
+
+func TestRunPathDomainTasksSerializesAncestorDescendantDomains(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	parent := filepath.Join(dir, "project")
+	child := filepath.Join(parent, "ui")
+	started := make(chan string, 2)
+	releaseA := make(chan struct{})
+
+	tasks := []pathDomainTask{
+		{
+			name:    "a",
+			domains: mustNormalizePathDomains(t, parent),
+			run: func() error {
+				started <- "a"
+				<-releaseA
+				return nil
+			},
+		},
+		{
+			name:    "b",
+			domains: mustNormalizePathDomains(t, child),
+			run: func() error {
+				started <- "b"
+				return nil
+			},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runPathDomainTasks(tasks, 2) }()
+	if got := waitForStart(t, started); got != "a" {
+		t.Fatalf("first started task = %q, want a", got)
+	}
+	select {
+	case got := <-started:
+		t.Fatalf("task %q started while ancestor domain was active", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(releaseA)
+	if got := waitForStart(t, started); got != "b" {
+		t.Fatalf("second started task = %q, want b", got)
+	}
+	if err := waitForScheduler(t, done); err != nil {
+		t.Fatalf("runPathDomainTasks: %v", err)
+	}
+}
+
+func TestRunPathDomainTasksDoesNotDeadlockWithMultipleDomains(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	tasks := []pathDomainTask{
+		{
+			name:    "a",
+			domains: mustNormalizePathDomains(t, a, b),
+			run:     func() error { return nil },
+		},
+		{
+			name:    "b",
+			domains: mustNormalizePathDomains(t, b, a),
+			run:     func() error { return nil },
+		},
+	}
+	done := make(chan error, 1)
+	go func() { done <- runPathDomainTasks(tasks, 2) }()
+	if err := waitForScheduler(t, done); err != nil {
+		t.Fatalf("runPathDomainTasks: %v", err)
+	}
+}
+
+func TestRunPathDomainTasksDoesNotRunBlockedTaskAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	shared := filepath.Join(dir, "shared")
+	aStarted := make(chan struct{})
+	cStarted := make(chan struct{})
+	releaseA := make(chan struct{})
+	var bRan atomic.Bool
+	errC := errors.New("c failed")
+
+	tasks := []pathDomainTask{
+		{
+			name:    "a",
+			domains: mustNormalizePathDomains(t, shared),
+			run: func() error {
+				close(aStarted)
+				<-releaseA
+				return nil
+			},
+		},
+		{
+			name:    "b",
+			domains: mustNormalizePathDomains(t, shared),
+			run: func() error {
+				bRan.Store(true)
+				return nil
+			},
+		},
+		{
+			name:    "c",
+			domains: mustNormalizePathDomains(t, filepath.Join(dir, "c")),
+			run: func() error {
+				close(cStarted)
+				return errC
+			},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runPathDomainTasks(tasks, 2) }()
+	<-aStarted
+	<-cStarted
+	close(releaseA)
+	if err := waitForScheduler(t, done); !errors.Is(err, errC) {
+		t.Fatalf("runPathDomainTasks error = %v, want %v", err, errC)
+	}
+	if bRan.Load() {
+		t.Fatal("blocked task ran after scheduler failure")
+	}
+}
+
+func TestRunPathDomainTasksReturnsLowestSortedRunningError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	errA := errors.New("a failed")
+	errB := errors.New("b failed")
+	bFailed := make(chan struct{})
+	tasks := []pathDomainTask{
+		{
+			name:    "a",
+			domains: mustNormalizePathDomains(t, filepath.Join(dir, "a")),
+			run: func() error {
+				<-bFailed
+				return errA
+			},
+		},
+		{
+			name:    "b",
+			domains: mustNormalizePathDomains(t, filepath.Join(dir, "b")),
+			run: func() error {
+				close(bFailed)
+				return errB
+			},
+		},
+	}
+	if err := runPathDomainTasks(tasks, 2); !errors.Is(err, errA) {
+		t.Fatalf("runPathDomainTasks error = %v, want %v", err, errA)
+	}
+}
+
+func TestCanonicalPathDomainResolvesExistingSymlinkPrefixForMissingPath(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior differs on Windows")
+	}
+	dir := t.TempDir()
+	realRoot := filepath.Join(dir, "real")
+	if err := os.MkdirAll(realRoot, 0o755); err != nil {
+		t.Fatalf("mkdir real root: %v", err)
+	}
+	linkRoot := filepath.Join(dir, "link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	got, err := canonicalPathDomain(filepath.Join(linkRoot, "dist", "index.html"))
+	if err != nil {
+		t.Fatalf("canonicalPathDomain: %v", err)
+	}
+	resolvedRealRoot, err := filepath.EvalSymlinks(realRoot)
+	if err != nil {
+		t.Fatalf("resolve real root: %v", err)
+	}
+	want := filepath.Join(resolvedRealRoot, "dist", "index.html")
+	if got != want {
+		t.Fatalf("canonicalPathDomain = %q, want %q", got, want)
+	}
+}
+
+func mustNormalizePathDomains(t *testing.T, paths ...string) []string {
+	t.Helper()
+	domains, err := normalizePathDomains(paths...)
+	if err != nil {
+		t.Fatalf("normalizePathDomains: %v", err)
+	}
+	return domains
+}
+
+func waitForStarts(t *testing.T, started <-chan struct{}, count int) {
+	t.Helper()
+	for range count {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for %d task starts", count)
+		}
+	}
+}
+
+func waitForStart(t *testing.T, started <-chan string) string {
+	t.Helper()
+	select {
+	case got := <-started:
+		return got
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for task start")
+		return ""
+	}
+}
+
+func waitForScheduler(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler timed out")
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
- Add `gestaltd sync --locked --parallelism N` for bounded parallel preparation of configured local `source.path` UI bundles.
- Keep lock generation, validate, serve/autosync, source.git, archive/release providers, plugin-owned UI, and `sync --locked --check` sequential/read-only.
- Split local UI sync into a parallel non-mutating prepare phase followed by sorted main-goroutine binding, guarded by canonical path-domain reservations for source, workdir, output, and prepared destinations.
- Example: `gestaltd sync --locked --config ./config.yaml --parallelism 2`.

## Test plan
- [x] `cd gestaltd && go test ./internal/operator`
- [x] `cd gestaltd && go test ./internal/daemon -run 'Sync|Parallelism|CLIHelp'`
- [x] `cd gestaltd && go test -race ./internal/operator -run 'TestRunPathDomainTasks|TestLifecycleSyncLocked(PreparesIndependentLocalUIsInParallel|ParallelismOnePreparesLocalUIsSequentially|SerializesLocalUIsWithSharedOutput|CheckSyncWithParallelismDoesNotMaterializeLocalUI)|TestLocalUIParallelPrepareCandidateScope'`
- [x] `git diff --check`