### PR TITLE
Parallelize local plugin sync preparation

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -3496,7 +3496,7 @@ func (l *Lifecycle) applyPreparedProviders(paths lifecyclePaths, lock *Lockfile,
 		return nil
 	}
 
-	if err := l.resolveConfiguredPlugins(paths, lock, cfg, mode); err != nil {
+	if err := l.resolveConfiguredPluginsWithOptions(paths, lock, cfg, mode, opts); err != nil {
 		return err
 	}
 	if err := synthesizePluginOwnedUIEntries(cfg); err != nil {
@@ -3675,20 +3675,31 @@ func localUISourcePathDomains(paths lifecyclePaths, name string, entry *config.U
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", normalized.manifestPath, err)
 	}
-	build := providerpkg.EffectiveSourceBuild(manifest)
-	if build != nil {
-		workdir := normalized.sourceDir
-		if build.Workdir != "" && build.Workdir != "." {
-			workdir = filepath.Join(normalized.sourceDir, filepath.FromSlash(build.Workdir))
-		}
-		domainPaths = append(domainPaths, workdir)
-		outputRel, _, err := providerpkg.SourceBuildOutput(manifest)
-		if err != nil {
-			return nil, err
-		}
-		domainPaths = append(domainPaths, filepath.Join(normalized.sourceDir, filepath.FromSlash(outputRel)))
+	buildDomains, err := sourceBuildPathDomains(normalized.sourceDir, manifest)
+	if err != nil {
+		return nil, err
 	}
+	domainPaths = append(domainPaths, buildDomains...)
 	return normalizePathDomains(domainPaths...)
+}
+
+func sourceBuildPathDomains(sourceDir string, manifest *providermanifestv1.Manifest) ([]string, error) {
+	build := providerpkg.EffectiveSourceBuild(manifest)
+	if build == nil {
+		return nil, nil
+	}
+	workdir := sourceDir
+	if build.Workdir != "" && build.Workdir != "." {
+		workdir = filepath.Join(sourceDir, filepath.FromSlash(build.Workdir))
+	}
+	outputRel, _, err := providerpkg.SourceBuildOutput(manifest)
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		workdir,
+		filepath.Join(sourceDir, filepath.FromSlash(outputRel)),
+	}, nil
 }
 
 func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths, cfg *config.Config, locked bool, bootstrapLock *Lockfile, mode artifactMode) (bool, error) {
@@ -4516,8 +4527,23 @@ func installPackageForStaticValidation(packagePath, destDir string) (*preparedIn
 	return &preparedInstall{manifestPath: manifestPath, manifest: manifest}, nil
 }
 
+type preparedPluginWork struct {
+	name          string
+	entry         *config.ProviderEntry
+	configMap     map[string]any
+	localParallel bool
+	install       *preparedInstall
+}
+
 func (l *Lifecycle) resolveConfiguredPlugins(paths lifecyclePaths, lock *Lockfile, cfg *config.Config, mode artifactMode) error {
-	for name, entry := range cfg.Plugins {
+	return l.resolveConfiguredPluginsWithOptions(paths, lock, cfg, mode, SyncOptions{Parallelism: 1})
+}
+
+func (l *Lifecycle) resolveConfiguredPluginsWithOptions(paths lifecyclePaths, lock *Lockfile, cfg *config.Config, mode artifactMode, opts SyncOptions) error {
+	var localWork []*preparedPluginWork
+	var ordered []*preparedPluginWork
+	for _, name := range slices.Sorted(maps.Keys(cfg.Plugins)) {
+		entry := cfg.Plugins[name]
 		if entry == nil {
 			continue
 		}
@@ -4525,21 +4551,124 @@ func (l *Lifecycle) resolveConfiguredPlugins(paths lifecyclePaths, lock *Lockfil
 		if err != nil {
 			return fmt.Errorf("decode provider config for provider %q: %w", name, err)
 		}
-		switch {
-		case sourceBacked(entry):
-			if err := l.applyLockedProviderEntry(paths, lock, name, entry, configMap, mode); err != nil {
-				return err
-			}
-		default:
+		work := &preparedPluginWork{
+			name:          name,
+			entry:         entry,
+			configMap:     configMap,
+			localParallel: localPluginParallelPrepareCandidate(paths, entry, mode),
+		}
+		ordered = append(ordered, work)
+		if work.localParallel {
+			localWork = append(localWork, work)
+		}
+	}
+	for _, work := range ordered {
+		if work.localParallel || !sourceBacked(work.entry) {
 			continue
 		}
-		if manifest := entry.ResolvedManifest; manifest != nil {
-			entry.DisplayName = cmp.Or(entry.DisplayName, manifest.DisplayName)
-			entry.Description = cmp.Or(entry.Description, manifest.Description)
+		if err := l.applyLockedProviderEntry(paths, lock, work.name, work.entry, work.configMap, mode); err != nil {
+			return err
 		}
-		entry.IconFile = cmp.Or(entry.IconFile, entry.ResolvedIconFile)
+	}
+	if err := l.prepareLocalPluginProviders(paths, localWork, opts); err != nil {
+		return err
+	}
+	for _, work := range ordered {
+		if work.install != nil {
+			if err := bindPreparedProviderInstall(paths, work.name, work.entry, work.configMap, work.install); err != nil {
+				return err
+			}
+		}
+		if manifest := work.entry.ResolvedManifest; manifest != nil {
+			work.entry.DisplayName = cmp.Or(work.entry.DisplayName, manifest.DisplayName)
+			work.entry.Description = cmp.Or(work.entry.Description, manifest.Description)
+		}
+		work.entry.IconFile = cmp.Or(work.entry.IconFile, work.entry.ResolvedIconFile)
 	}
 	return nil
+}
+
+func localPluginParallelPrepareCandidate(paths lifecyclePaths, entry *config.ProviderEntry, mode artifactMode) bool {
+	if mode != artifactModeMaterialize || entry == nil || !entry.HasLocalSource() {
+		return false
+	}
+	if pathWithinRoot(filepath.Join(paths.artifactsDir, ".gestaltd"), entry.SourcePath()) {
+		return false
+	}
+	return true
+}
+
+func (l *Lifecycle) prepareLocalPluginProviders(paths lifecyclePaths, work []*preparedPluginWork, opts SyncOptions) error {
+	if len(work) == 0 {
+		return nil
+	}
+	opts = normalizeSyncOptions(opts)
+	tasks := make([]pathDomainTask, 0, len(work))
+	for _, work := range work {
+		work := work
+		domains, err := localPluginSourcePathDomains(paths, work.name, work.entry)
+		if err != nil {
+			return err
+		}
+		tasks = append(tasks, pathDomainTask{
+			name:    work.name,
+			domains: domains,
+			run: func() error {
+				install, err := l.ensureLocalPreparedInstall(paths, providermanifestv1.KindPlugin, work.name, work.entry, work.configMap, providerDestDir(paths, work.name), "provider "+strconv.Quote(work.name), artifactModeMaterialize)
+				if err != nil {
+					return err
+				}
+				work.install = install
+				return nil
+			},
+		})
+	}
+	slices.SortFunc(tasks, func(a, b pathDomainTask) int {
+		return cmp.Compare(a.name, b.name)
+	})
+	return runPathDomainTasks(tasks, opts.Parallelism)
+}
+
+func localPluginSourcePathDomains(paths lifecyclePaths, name string, entry *config.ProviderEntry) ([]string, error) {
+	if entry == nil {
+		return nil, nil
+	}
+	normalized, err := normalizeLocalSource(entry.SourcePath())
+	if err != nil {
+		return nil, fmt.Errorf("manifest for plugin %q not found at %s: %w", name, entry.SourcePath(), err)
+	}
+	domainPaths := []string{
+		normalized.sourceDir,
+		normalized.manifestPath,
+		providerDestDir(paths, name),
+	}
+	_, manifest, err := providerpkg.ReadSourceManifestFile(normalized.manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", normalized.manifestPath, err)
+	}
+	buildDomains, err := sourceBuildPathDomains(normalized.sourceDir, manifest)
+	if err != nil {
+		return nil, err
+	}
+	domainPaths = append(domainPaths, buildDomains...)
+	if manifest != nil && manifest.Kind == providermanifestv1.KindPlugin && manifest.Spec != nil && manifest.Spec.UI != nil && strings.TrimSpace(manifest.Spec.UI.Path) != "" {
+		uiManifestPath := filepath.Join(normalized.sourceDir, filepath.FromSlash(manifest.Spec.UI.Path))
+		uiNormalized, err := normalizeLocalSource(uiManifestPath)
+		if err != nil {
+			return nil, fmt.Errorf("manifest for provider %q owned ui not found at %s: %w", name, uiManifestPath, err)
+		}
+		domainPaths = append(domainPaths, uiNormalized.sourceDir, uiNormalized.manifestPath)
+		_, uiManifest, err := providerpkg.ReadSourceManifestFile(uiNormalized.manifestPath)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", uiNormalized.manifestPath, err)
+		}
+		uiBuildDomains, err := sourceBuildPathDomains(uiNormalized.sourceDir, uiManifest)
+		if err != nil {
+			return nil, err
+		}
+		domainPaths = append(domainPaths, uiBuildDomains...)
+	}
+	return normalizePathDomains(domainPaths...)
 }
 
 func synthesizePluginOwnedUIEntries(cfg *config.Config) error {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -297,6 +297,152 @@ printf 'beta end\n' >> %s
 	}
 }
 
+func TestLifecycleSyncLockedParallelizesPluginOwnedUIs(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("source UI build fixture uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	syncDir := filepath.Join(dir, "sync")
+	if err := os.MkdirAll(syncDir, 0o755); err != nil {
+		t.Fatalf("mkdir sync dir: %v", err)
+	}
+	alphaPlugin := filepath.Join(dir, "plugins", "alpha")
+	betaPlugin := filepath.Join(dir, "plugins", "beta")
+	alphaUI := filepath.Join(dir, "ui", "alpha")
+	betaUI := filepath.Join(dir, "ui", "beta")
+	alphaManifest := writeOwnedUISourcePluginTree(t, alphaPlugin, alphaUI, "alpha", fmt.Sprintf(`#!/bin/sh
+set -eu
+touch %s/alpha.started
+i=0
+while [ ! -f %s/beta.started ]; do
+  i=$((i + 1))
+  if [ "$i" -gt 100 ]; then
+    echo "timed out waiting for beta" >&2
+    exit 42
+  fi
+  sleep 0.05
+done
+mkdir -p dist
+printf '<html>alpha</html>\n' > dist/index.html
+`, syncDir, syncDir))
+	betaManifest := writeOwnedUISourcePluginTree(t, betaPlugin, betaUI, "beta", fmt.Sprintf(`#!/bin/sh
+set -eu
+touch %s/beta.started
+i=0
+while [ ! -f %s/alpha.started ]; do
+  i=$((i + 1))
+  if [ "$i" -gt 100 ]; then
+    echo "timed out waiting for alpha" >&2
+    exit 42
+  fi
+  sleep 0.05
+done
+mkdir -p dist
+printf '<html>beta</html>\n' > dist/index.html
+`, syncDir, syncDir))
+
+	configPath := writeOwnedUIPluginTestConfig(t, dir, map[string]string{
+		"alpha": alphaManifest,
+		"beta":  betaManifest,
+	})
+	if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 2}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	}
+	for _, name := range []string{"alpha", "beta"} {
+		if _, err := os.Stat(filepath.Join(dir, "artifacts", ".gestaltd", "providers", name, "_owned_ui", name, "dist", "index.html")); err != nil {
+			t.Fatalf("prepared owned ui %s not found: %v", name, err)
+		}
+	}
+}
+
+func TestLifecycleSyncLockedParallelismOnePreparesPluginOwnedUIsSequentially(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("source UI build fixture uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "build.log")
+	alphaManifest := writeOwnedUISourcePluginTree(t, filepath.Join(dir, "plugins", "alpha"), filepath.Join(dir, "ui", "alpha"), "alpha", fmt.Sprintf(`#!/bin/sh
+set -eu
+printf 'alpha start\n' >> %s
+mkdir -p dist
+printf '<html>alpha</html>\n' > dist/index.html
+printf 'alpha end\n' >> %s
+`, logPath, logPath))
+	betaManifest := writeOwnedUISourcePluginTree(t, filepath.Join(dir, "plugins", "beta"), filepath.Join(dir, "ui", "beta"), "beta", fmt.Sprintf(`#!/bin/sh
+set -eu
+printf 'beta start\n' >> %s
+mkdir -p dist
+printf '<html>beta</html>\n' > dist/index.html
+printf 'beta end\n' >> %s
+`, logPath, logPath))
+
+	configPath := writeOwnedUIPluginTestConfig(t, dir, map[string]string{
+		"alpha": alphaManifest,
+		"beta":  betaManifest,
+	})
+	if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 1}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read build log: %v", err)
+	}
+	want := "alpha start\nalpha end\nbeta start\nbeta end\n"
+	if string(data) != want {
+		t.Fatalf("build log = %q, want %q", data, want)
+	}
+}
+
+func TestLifecycleSyncLockedSerializesPluginOwnedUIsWithSharedSource(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("source UI build fixture uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "build.log")
+	lockDir := filepath.Join(dir, "owned-ui.lock")
+	sharedUI := filepath.Join(dir, "ui", "shared")
+	writeBlockingSourceUITree(t, sharedUI, "github.com/acme/ui/shared", "1.2.3", fmt.Sprintf(`#!/bin/sh
+set -eu
+if ! mkdir %s; then
+  printf 'overlap\n' >> %s
+  exit 43
+fi
+trap 'rmdir %s' EXIT
+printf 'start\n' >> %s
+sleep 0.1
+mkdir -p dist
+printf '<html>shared</html>\n' > dist/index.html
+printf 'end\n' >> %s
+`, lockDir, logPath, lockDir, logPath, logPath))
+	alphaManifest := writeOwnedUISourcePluginForUI(t, filepath.Join(dir, "plugins", "alpha"), filepath.Join(sharedUI, "manifest.yaml"), "alpha")
+	betaManifest := writeOwnedUISourcePluginForUI(t, filepath.Join(dir, "plugins", "beta"), filepath.Join(sharedUI, "manifest.yaml"), "beta")
+
+	configPath := writeOwnedUIPluginTestConfig(t, dir, map[string]string{
+		"alpha": alphaManifest,
+		"beta":  betaManifest,
+	})
+	if err := NewLifecycle().SyncAtPathsWithStatePathsOptions([]string{configPath}, StatePaths{}, SyncOptions{Parallelism: 2}); err != nil {
+		t.Fatalf("SyncAtPathsWithStatePathsOptions: %v", err)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read build log: %v", err)
+	}
+	want := "start\nend\nstart\nend\n"
+	if string(data) != want {
+		t.Fatalf("build log = %q, want %q", data, want)
+	}
+}
+
 func TestLifecycleSyncLockedSerializesLocalUIsWithSharedOutput(t *testing.T) {
 	t.Parallel()
 
@@ -1312,6 +1458,48 @@ func writeSourceProviderTree(t *testing.T, dir, source, version, binaryContent s
 	}
 }
 
+func writeOwnedUISourcePluginTree(t *testing.T, pluginDir, uiDir, name, uiBuildScript string) string {
+	t.Helper()
+	writeBlockingSourceUITree(t, uiDir, "github.com/acme/ui/"+name, "1.2.3", uiBuildScript)
+	return writeOwnedUISourcePluginForUI(t, pluginDir, filepath.Join(uiDir, "manifest.yaml"), name)
+}
+
+func writeOwnedUISourcePluginForUI(t *testing.T, pluginDir, uiManifestPath, name string) string {
+	t.Helper()
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("create source plugin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "provider"), []byte(name+"-provider"), 0o755); err != nil {
+		t.Fatalf("write provider binary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "catalog.yaml"), []byte("name: "+name+"\noperations:\n  - id: ping\n    method: GET\n"), 0o644); err != nil {
+		t.Fatalf("write catalog: %v", err)
+	}
+	ownedUIPath, err := filepath.Rel(pluginDir, uiManifestPath)
+	if err != nil {
+		t.Fatalf("relative owned ui path: %v", err)
+	}
+	manifest := &providermanifestv1.Manifest{
+		Source:      "github.com/acme/plugins/" + name,
+		Version:     "1.2.3",
+		Kind:        providermanifestv1.KindPlugin,
+		DisplayName: name,
+		Spec: withNoAuthDefaultConnection(&providermanifestv1.Spec{
+			UI: &providermanifestv1.OwnedUI{Path: filepath.ToSlash(ownedUIPath)},
+		}),
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: "provider"},
+	}
+	data, err := providerpkg.EncodeSourceManifestFormat(manifest, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("encode plugin manifest: %v", err)
+	}
+	manifestPath := filepath.Join(pluginDir, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+		t.Fatalf("write plugin manifest: %v", err)
+	}
+	return manifestPath
+}
+
 func writeSourceUITree(t *testing.T, dir, source, version string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -1381,6 +1569,35 @@ func writeLocalUITestConfig(t *testing.T, dir string, uiManifests map[string]str
 		b.WriteString("    " + name + ":\n")
 		b.WriteString("      source:\n")
 		b.WriteString("        path: " + filepath.ToSlash(uiManifests[name]) + "\n")
+		b.WriteString("      path: /" + name + "\n")
+	}
+	b.WriteString("server:\n")
+	b.WriteString("  providers:\n")
+	b.WriteString("    indexeddb: sqlite\n")
+	b.WriteString("  artifactsDir: " + filepath.ToSlash(filepath.Join(dir, "artifacts")) + "\n")
+	b.WriteString("  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n")
+
+	configPath := filepath.Join(dir, "gestaltd.yaml")
+	if err := os.WriteFile(configPath, []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := NewLifecycle().LockAtPathsWithStatePaths([]string{configPath}, StatePaths{}); err != nil {
+		t.Fatalf("write lockfile: %v", err)
+	}
+	return configPath
+}
+
+func writeOwnedUIPluginTestConfig(t *testing.T, dir string, plugins map[string]string) string {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("apiVersion: gestaltd.config/v5\n")
+	b.WriteString(requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")))
+	b.WriteString("plugins:\n")
+	for _, name := range slices.Sorted(maps.Keys(plugins)) {
+		b.WriteString("  " + name + ":\n")
+		b.WriteString("    source:\n")
+		b.WriteString("      path: " + filepath.ToSlash(plugins[name]) + "\n")
+		b.WriteString("    ui:\n")
 		b.WriteString("      path: /" + name + "\n")
 	}
 	b.WriteString("server:\n")


### PR DESCRIPTION
## Summary
- Extend the existing `gestaltd sync --locked --parallelism N` behavior to parallelize local source plugin preparation, including plugin-owned UI builds staged during plugin preparation.
- Keep non-local locked plugin checks before local plugin builds, and keep provider binding/config mutation deterministic on the main goroutine after workers finish.
- Reuse the existing path-domain scheduler for plugin source, plugin build output, provider destination, owned UI source, and owned UI build output domains.
- Example: `gestaltd sync --locked --parallelism 4 --config gestaltd.yaml` now parallelizes local plugin-owned UI preparation in addition to direct local UI preparation.

## Test plan
- [x] `go test ./internal/operator -run 'TestLifecycleSyncLockedParallelizesPluginOwnedUIs|TestLifecycleSyncLockedParallelismOnePreparesPluginOwnedUIsSequentially|TestLifecycleSyncLockedSerializesPluginOwnedUIsWithSharedSource|TestLocalUIParallelPrepareCandidateScope|TestLifecycleSyncLockedSerializesLocalUIsWithSharedOutput'`
- [x] `go test ./internal/operator ./internal/daemon`