### PR TITLE
Add generic Python provider build cache

### DIFF
--- a/docs/content/deploy/docker.mdx
+++ b/docs/content/deploy/docker.mdx
@@ -59,6 +59,18 @@ gestaltd lock --config deploy/config.yaml
 gestaltd sync --locked --config deploy/config.yaml --artifacts-dir deploy
 ```
 
+If the deployment builds local source providers during `sync`, you can opt into
+the generic Gestalt build cache during the build stage:
+
+```dockerfile
+RUN --mount=type=cache,target=/root/.cache/gestalt-build,sharing=locked \
+    GESTALT_BUILD_CACHE_DIR=/root/.cache/gestalt-build \
+    gestaltd sync --locked --config deploy/config.yaml --artifacts-dir deploy
+```
+
+The cache stores build accelerators only. It is safe to delete, and unsetting
+`GESTALT_BUILD_CACHE_DIR` returns `sync` to the default clean build behavior.
+
 ```
 deploy/
   config.yaml

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -49,6 +49,19 @@ routes, passthrough surfaces, and release metadata. Use Python code for
 executable operations, provider lifecycle hooks, host-service clients, and
 provider-specific runtimes.
 
+## Build cache
+
+Python executable provider builds can opt into the generic Gestalt build cache
+by setting `GESTALT_BUILD_CACHE_DIR` to a writable directory before running
+`gestaltd sync` or another provider packaging command. The cache stores
+SDK-internal packaging accelerators only; it is safe to delete, and unsetting
+the variable returns builds to the default clean temporary behavior.
+
+```sh
+GESTALT_BUILD_CACHE_DIR="$PWD/.gestalt-build-cache" \
+  gestaltd sync --locked --config deploy/config.yaml
+```
+
 ## Public surface
 
 The top-level `gestalt` package exposes the supported authoring API:

--- a/sdk/python/gestalt/_build.py
+++ b/sdk/python/gestalt/_build.py
@@ -1,8 +1,15 @@
+import contextlib
+import hashlib
+import importlib.metadata
+import json
 import os
 import pathlib
+import platform
 import subprocess
 import sys
+import sysconfig
 import tempfile
+import time
 from dataclasses import dataclass
 from typing import Final
 
@@ -15,6 +22,8 @@ from ._bootstrap import (
 USAGE: Final[str] = (
     "usage: python -m gestalt._build ROOT MODULE[:ATTRIBUTE] OUTPUT PLUGIN_NAME RUNTIME_KIND GOOS GOARCH"
 )
+BUILD_CACHE_DIR_ENV_VAR: Final[str] = "GESTALT_BUILD_CACHE_DIR"
+BUILD_CACHE_SCHEMA_VERSION: Final[str] = "python-provider-package-v1"
 
 
 @dataclass(frozen=True)
@@ -70,23 +79,39 @@ def build_plugin_binary(args: BuildArgs) -> None:
             runtime_kind=args.runtime_kind,
         )
 
+        cache_dir = _build_cache_dir(
+            args=args,
+            root_path=root_path,
+            module_name=plugin_target.module_name,
+        )
+        clean_cache = cache_dir is None
+        pyinstaller_config_dir = (
+            work_path / "pyinstaller-config"
+            if cache_dir is None
+            else cache_dir / "pyinstaller-config"
+        )
+        if cache_dir is not None:
+            pyinstaller_config_dir.mkdir(parents=True, exist_ok=True)
+
         env = os.environ.copy()
-        env["PYINSTALLER_CONFIG_DIR"] = str(work_path / "pyinstaller-config")
+        env["PYINSTALLER_CONFIG_DIR"] = str(pyinstaller_config_dir)
         env["SOURCE_DATE_EPOCH"] = "0"
 
-        subprocess.run(
-            _pyinstaller_command(
-                root_path=root_path,
-                output_path=output_path,
-                module_name=plugin_target.module_name,
-                bundle_config_path=bundle_config_path,
-                target_goos=args.goos,
-                target_goarch=args.goarch,
-            ),
-            cwd=root_path,
-            env=env,
-            check=True,
-        )
+        with _build_cache_lock(None if cache_dir is None else cache_dir / "build.lock"):
+            subprocess.run(
+                _pyinstaller_command(
+                    root_path=root_path,
+                    output_path=output_path,
+                    module_name=plugin_target.module_name,
+                    bundle_config_path=bundle_config_path,
+                    target_goos=args.goos,
+                    target_goarch=args.goarch,
+                    clean_cache=clean_cache,
+                ),
+                cwd=root_path,
+                env=env,
+                check=True,
+            )
 
 
 def _pyinstaller_command(
@@ -97,6 +122,7 @@ def _pyinstaller_command(
     bundle_config_path: pathlib.Path,
     target_goos: str,
     target_goarch: str,
+    clean_cache: bool,
 ) -> list[str]:
     pyinstaller_name = (
         output_path.name.removesuffix(".exe")
@@ -109,7 +135,7 @@ def _pyinstaller_command(
         "-m",
         "PyInstaller",
         "--noconfirm",
-        "--clean",
+        "--noupx",
         "--onefile",
         "--distpath",
         str(output_path.parent),
@@ -131,11 +157,168 @@ def _pyinstaller_command(
         f"{bundle_config_path}{os.pathsep}.",
         str(pathlib.Path(__file__).with_name("_pyinstaller.py")),
     ]
+    if clean_cache:
+        command.insert(command.index("--onefile"), "--clean")
     if sys.platform == "darwin" and target_goos == "darwin":
         target_arch = _darwin_target_arch(target_goarch)
         if target_arch:
             command.extend(["--target-arch", target_arch])
     return command
+
+
+def _build_cache_dir(
+    *,
+    args: BuildArgs,
+    root_path: pathlib.Path,
+    module_name: str,
+) -> pathlib.Path | None:
+    cache_root = _build_cache_root()
+    if cache_root is None:
+        return None
+    namespace = _build_cache_namespace(
+        args=args,
+        root_path=root_path,
+        module_name=module_name,
+    )
+    return cache_root / "python-provider-packages" / namespace
+
+
+def _build_cache_root() -> pathlib.Path | None:
+    raw = os.environ.get(BUILD_CACHE_DIR_ENV_VAR, "").strip()
+    if raw == "":
+        return None
+
+    path = pathlib.Path(raw).expanduser()
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as err:
+        raise RuntimeError(
+            f"{BUILD_CACHE_DIR_ENV_VAR} {path}: create cache directory: {err}"
+        ) from err
+    if not path.is_dir():
+        raise RuntimeError(f"{BUILD_CACHE_DIR_ENV_VAR} {path} is not a directory")
+    return path.resolve()
+
+
+def _build_cache_namespace(
+    *,
+    args: BuildArgs,
+    root_path: pathlib.Path,
+    module_name: str,
+) -> str:
+    payload = {
+        "schema": BUILD_CACHE_SCHEMA_VERSION,
+        "root": str(root_path),
+        "target": args.target,
+        "module": module_name,
+        "plugin_name": args.plugin_name,
+        "runtime_kind": args.runtime_kind,
+        "goos": args.goos,
+        "goarch": args.goarch,
+        "python": {
+            "implementation": platform.python_implementation(),
+            "cache_tag": sys.implementation.cache_tag,
+            "version": list(sys.version_info[:3]),
+            "platform": sys.platform,
+            "machine": platform.machine(),
+            "sysconfig_platform": _sysconfig_platform(),
+            "soabi": _sysconfig_config_var("SOABI"),
+            "executable": str(pathlib.Path(sys.executable).resolve()),
+            "prefix": sys.prefix,
+            "base_prefix": sys.base_prefix,
+        },
+        "packager": {
+            "pyinstaller": _package_version("pyinstaller"),
+            "pyinstaller_hooks_contrib": _package_version(
+                "pyinstaller-hooks-contrib"
+            ),
+        },
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    return "v1-" + hashlib.sha256(encoded).hexdigest()[:48]
+
+
+def _package_version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return ""
+
+
+def _sysconfig_platform() -> str:
+    try:
+        return sysconfig.get_platform()
+    except Exception:
+        return ""
+
+
+def _sysconfig_config_var(name: str) -> str:
+    try:
+        value = sysconfig.get_config_var(name)
+    except Exception:
+        return ""
+    return "" if value is None else str(value)
+
+
+@contextlib.contextmanager
+def _build_cache_lock(lock_path: pathlib.Path | None):
+    if lock_path is None:
+        yield
+        return
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        if os.name == "nt":
+            _lock_file_windows(lock_file)
+            try:
+                yield
+            finally:
+                _unlock_file_windows(lock_file)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _lock_file_windows(lock_file) -> None:
+    import importlib
+
+    msvcrt = importlib.import_module("msvcrt")
+    locking = getattr(msvcrt, "locking")
+    nonblocking_lock = getattr(msvcrt, "LK_NBLCK")
+
+    _ensure_lock_byte(lock_file)
+    while True:
+        lock_file.seek(0)
+        try:
+            locking(lock_file.fileno(), nonblocking_lock, 1)
+            return
+        except OSError:
+            time.sleep(0.1)
+
+
+def _unlock_file_windows(lock_file) -> None:
+    import importlib
+
+    msvcrt = importlib.import_module("msvcrt")
+    locking = getattr(msvcrt, "locking")
+    unlock = getattr(msvcrt, "LK_UNLCK")
+
+    lock_file.seek(0)
+    locking(lock_file.fileno(), unlock, 1)
+
+
+def _ensure_lock_byte(lock_file) -> None:
+    lock_file.seek(0, os.SEEK_END)
+    if lock_file.tell() == 0:
+        lock_file.write(b"\0")
+        lock_file.flush()
 
 
 def _darwin_target_arch(goarch: str) -> str | None:

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -16,12 +16,82 @@ class CapturedBuildRun:
     env: dict[str, str]
     binary_name: str
     target_arch: str | None
+    pyinstaller_config_dir: pathlib.Path
+    work_path: pathlib.Path
+    spec_path: pathlib.Path
+    add_data_source: pathlib.Path
     destination: str
     bundle_config: dict[str, str]
 
 
 class BuildTests(unittest.TestCase):
     """Build entrypoint tests."""
+
+    def capture_build_run(
+        self,
+        *,
+        root: pathlib.Path,
+        output: pathlib.Path,
+        platform_name: str = "linux",
+        target: str = "provider",
+        plugin_name: str = "released-plugin",
+        runtime_kind: str = "integration",
+        goos: str = "linux",
+        goarch: str = "amd64",
+    ) -> CapturedBuildRun:
+        captured: CapturedBuildRun | None = None
+
+        def fake_run(
+            command: list[str],
+            cwd: pathlib.Path,
+            env: dict[str, str],
+            check: bool,
+        ) -> None:
+            nonlocal captured
+
+            add_data = command[command.index("--add-data") + 1]
+            separator = _build.os.pathsep
+            source, destination = add_data.split(separator, 1)
+            captured = CapturedBuildRun(
+                command=command,
+                cwd=cwd,
+                check=check,
+                env=env,
+                binary_name=command[command.index("--name") + 1],
+                target_arch=command[command.index("--target-arch") + 1]
+                if "--target-arch" in command
+                else None,
+                pyinstaller_config_dir=pathlib.Path(env["PYINSTALLER_CONFIG_DIR"]),
+                work_path=pathlib.Path(command[command.index("--workpath") + 1]),
+                spec_path=pathlib.Path(command[command.index("--specpath") + 1]),
+                add_data_source=pathlib.Path(source),
+                destination=destination,
+                bundle_config=json.loads(pathlib.Path(source).read_text(encoding="utf-8")),
+            )
+
+        with (
+            mock.patch.object(_build.sys, "platform", platform_name),
+            mock.patch.object(
+                _build.subprocess,
+                "run",
+                side_effect=fake_run,
+            ),
+        ):
+            _build.build_plugin_binary(
+                _build.BuildArgs(
+                    root=root,
+                    target=target,
+                    output_path=output,
+                    plugin_name=plugin_name,
+                    runtime_kind=runtime_kind,
+                    goos=goos,
+                    goarch=goarch,
+                )
+            )
+
+        self.assertIsNotNone(captured)
+        assert captured is not None
+        return captured
 
     def test_build_plugin_binary_writes_bundle_config_and_uses_target_platform_settings(
         self,
@@ -50,64 +120,26 @@ class BuildTests(unittest.TestCase):
                     root = pathlib.Path(tmpdir) / "plugin"
                     output = root / "dist" / output_name
                     root.mkdir()
-                    captured: CapturedBuildRun | None = None
-
-                    def fake_run(
-                        command: list[str],
-                        cwd: pathlib.Path,
-                        env: dict[str, str],
-                        check: bool,
-                    ) -> None:
-                        nonlocal captured
-
-                        add_data = command[command.index("--add-data") + 1]
-                        separator = _build.os.pathsep
-                        source, destination = add_data.split(separator, 1)
-                        captured = CapturedBuildRun(
-                            command=command,
-                            cwd=cwd,
-                            check=check,
-                            env=env,
-                            binary_name=command[command.index("--name") + 1],
-                            target_arch=command[command.index("--target-arch") + 1]
-                            if "--target-arch" in command
-                            else None,
-                            destination=destination,
-                            bundle_config=json.loads(
-                                pathlib.Path(source).read_text(encoding="utf-8")
-                            ),
+                    with mock.patch.dict(_build.os.environ, {}, clear=False):
+                        _build.os.environ.pop(_build.BUILD_CACHE_DIR_ENV_VAR, None)
+                        captured = self.capture_build_run(
+                            root=root,
+                            output=output,
+                            platform_name=platform,
+                            goos=target_goos,
+                            goarch=target_goarch,
                         )
 
-                    with (
-                        mock.patch.object(_build.sys, "platform", platform),
-                        mock.patch.object(
-                            _build.subprocess,
-                            "run",
-                            side_effect=fake_run,
-                        ),
-                    ):
-                        _build.build_plugin_binary(
-                            _build.BuildArgs(
-                                root=root,
-                                target="provider",
-                                output_path=output,
-                                plugin_name="released-plugin",
-                                runtime_kind="integration",
-                                goos=target_goos,
-                                goarch=target_goarch,
-                            )
-                        )
-
-                self.assertIsNotNone(captured)
-                assert captured is not None
                 self.assertIn("--add-data", captured.command)
+                self.assertIn("--clean", captured.command)
+                self.assertIn("--noupx", captured.command)
                 self.assertEqual(captured.cwd, root.resolve())
                 self.assertTrue(captured.check)
                 self.assertEqual(captured.binary_name, expected_binary_name)
                 self.assertEqual(captured.target_arch, expected_target_arch)
                 self.assertEqual(captured.destination, ".")
                 self.assertEqual(
-                    pathlib.Path(captured.env["PYINSTALLER_CONFIG_DIR"]).name,
+                    captured.pyinstaller_config_dir.name,
                     "pyinstaller-config",
                 )
                 self.assertEqual(captured.env["SOURCE_DATE_EPOCH"], "0")
@@ -134,6 +166,129 @@ class BuildTests(unittest.TestCase):
                     str(pathlib.Path(_build.__file__).with_name("_pyinstaller.py")),
                     captured.command,
                 )
+
+    def test_build_plugin_binary_uses_generic_build_cache_when_configured(self) -> None:
+        """Cache mode should persist only private packager cache state."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = pathlib.Path(tmpdir)
+            root = base / "plugin"
+            output = root / "dist" / "provider-bin"
+            cache_root = base / "cache"
+            root.mkdir()
+
+            with mock.patch.dict(
+                _build.os.environ,
+                {_build.BUILD_CACHE_DIR_ENV_VAR: str(cache_root)},
+                clear=False,
+            ):
+                captured = self.capture_build_run(root=root, output=output)
+
+            resolved_cache_root = cache_root.resolve()
+            self.assertNotIn("--clean", captured.command)
+            self.assertTrue(captured.pyinstaller_config_dir.is_relative_to(resolved_cache_root))
+            self.assertEqual(captured.pyinstaller_config_dir.name, "pyinstaller-config")
+            self.assertTrue((captured.pyinstaller_config_dir.parent / "build.lock").exists())
+            self.assertFalse(captured.work_path.is_relative_to(resolved_cache_root))
+            self.assertFalse(captured.spec_path.is_relative_to(resolved_cache_root))
+            self.assertFalse(captured.add_data_source.is_relative_to(resolved_cache_root))
+            self.assertEqual(
+                captured.bundle_config,
+                {
+                    "target": "provider",
+                    "plugin_name": "released-plugin",
+                    "runtime_kind": "integration",
+                },
+            )
+
+    def test_build_cache_namespace_separates_source_target_and_platform(self) -> None:
+        """Distinct build domains should not share private packager cache dirs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = pathlib.Path(tmpdir)
+            cache_root = base / "cache"
+            root_a = base / "plugin-a"
+            root_b = base / "plugin-b"
+            root_a.mkdir()
+            root_b.mkdir()
+
+            with mock.patch.dict(
+                _build.os.environ,
+                {_build.BUILD_CACHE_DIR_ENV_VAR: str(cache_root)},
+                clear=False,
+            ):
+                source_a = self.capture_build_run(
+                    root=root_a,
+                    output=root_a / "dist" / "provider-bin",
+                )
+                source_b = self.capture_build_run(
+                    root=root_b,
+                    output=root_b / "dist" / "provider-bin",
+                )
+                target_b = self.capture_build_run(
+                    root=root_a,
+                    output=root_a / "dist" / "provider-other",
+                    target="other_provider",
+                )
+                platform_b = self.capture_build_run(
+                    root=root_a,
+                    output=root_a / "dist" / "provider-arm64",
+                    goarch="arm64",
+                )
+
+            cache_dirs = {
+                source_a.pyinstaller_config_dir.parent,
+                source_b.pyinstaller_config_dir.parent,
+                target_b.pyinstaller_config_dir.parent,
+                platform_b.pyinstaller_config_dir.parent,
+            }
+            self.assertEqual(len(cache_dirs), 4)
+
+    def test_whitespace_build_cache_dir_keeps_default_clean_build(self) -> None:
+        """Blank cache env values should behave like unset env values."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir) / "plugin"
+            output = root / "dist" / "provider-bin"
+            root.mkdir()
+
+            with mock.patch.dict(
+                _build.os.environ,
+                {_build.BUILD_CACHE_DIR_ENV_VAR: "   "},
+                clear=False,
+            ):
+                captured = self.capture_build_run(root=root, output=output)
+
+            self.assertIn("--clean", captured.command)
+            self.assertEqual(captured.pyinstaller_config_dir.name, "pyinstaller-config")
+
+    def test_build_cache_dir_file_fails_before_packager_invocation(self) -> None:
+        """A non-directory cache path should fail with a clear SDK error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir) / "plugin"
+            output = root / "dist" / "provider-bin"
+            cache_file = pathlib.Path(tmpdir) / "cache-file"
+            root.mkdir()
+            cache_file.write_text("not a directory", encoding="utf-8")
+
+            with (
+                mock.patch.dict(
+                    _build.os.environ,
+                    {_build.BUILD_CACHE_DIR_ENV_VAR: str(cache_file)},
+                    clear=False,
+                ),
+                mock.patch.object(_build.subprocess, "run") as run_mock,
+            ):
+                with self.assertRaisesRegex(RuntimeError, _build.BUILD_CACHE_DIR_ENV_VAR):
+                    _build.build_plugin_binary(
+                        _build.BuildArgs(
+                            root=root,
+                            target="provider",
+                            output_path=output,
+                            plugin_name="released-plugin",
+                            runtime_kind="integration",
+                            goos="linux",
+                            goarch="amd64",
+                        )
+                    )
+            run_mock.assert_not_called()
 
     def test_parse_build_args_rejects_wrong_count(self) -> None:
         """Build arg parser should reject incorrect argument counts."""


### PR DESCRIPTION
## Summary
- Add `GESTALT_BUILD_CACHE_DIR` as a generic opt-in build cache for Python executable provider packaging.
- Keep PyInstaller-specific details private inside the Python SDK while preserving default clean temporary builds when the env var is unset.
- No `gestaltd` CLI command or flag changes are required; existing `gestaltd sync` calls can opt in through the environment.

## Usage
Local usage:

```sh
GESTALT_BUILD_CACHE_DIR="$PWD/.gestalt-build-cache" \
  gestaltd sync --locked --config deploy/config.yaml --artifacts-dir deploy
```

Docker BuildKit usage:

```dockerfile
RUN --mount=type=cache,target=/root/.cache/gestalt-build,sharing=locked \
    GESTALT_BUILD_CACHE_DIR=/root/.cache/gestalt-build \
    gestaltd sync --locked --config deploy/config.yaml --artifacts-dir deploy
```

The cache stores build accelerators only. It is safe to delete, and unsetting `GESTALT_BUILD_CACHE_DIR` returns Python provider packaging to the default clean temporary build behavior.
