### PR TITLE
Preserve agent workflow transport semantics

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -1405,7 +1405,7 @@ func TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartF
 			ExpiresAt: &expiresAt,
 		}
 		if index == 1 {
-			recommendedDrainAt := startedAt.Add(3 * time.Second)
+			recommendedDrainAt := startedAt.Add(8 * time.Second)
 			lifecycle.RecommendedDrainAt = &recommendedDrainAt
 		}
 		return lifecycle
@@ -1468,7 +1468,7 @@ func TestAgentRuntimeConfigKeepsHostedAgentServingWhenProactiveReplacementStartF
 		t.Fatalf("ready backends = %d, want 1", len(backends))
 	}
 	first := backends[0]
-	waitForAgentRuntimeCondition(t, 2*time.Second, func() bool {
+	waitForAgentRuntimeCondition(t, 6*time.Second, func() bool {
 		pool.mu.Lock()
 		defer pool.mu.Unlock()
 		return len(runtimeProvider.startSessionRequests()) >= 2 && !first.replacing

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -6489,9 +6489,73 @@ func TestBootstrapConfigManagedAgentTargetsPreserveWorkflowSystemToolRefs(t *tes
 		if err != nil {
 			t.Fatalf("Get execution ref %q: %v", executionRef, err)
 		}
-		if len(ref.Permissions) != 1 || ref.Permissions[0].Plugin != "roadmap" || len(ref.Permissions[0].Operations) != 1 || ref.Permissions[0].Operations[0] != "sync" {
-			t.Fatalf("permissions = %#v", ref.Permissions)
+		wantPermissions := []core.AccessPermission{
+			{Plugin: "managed"},
+			{Plugin: "roadmap", Operations: []string{"sync"}},
 		}
+		if !reflect.DeepEqual(ref.Permissions, wantPermissions) {
+			t.Fatalf("permissions = %#v, want %#v", ref.Permissions, wantPermissions)
+		}
+	}
+}
+
+func TestBootstrapConfigManagedAgentStepPermissionsIncludeAgentProvider(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Providers.Agent = map[string]*config.ProviderEntry{
+		"managed": {Source: config.ProviderSource{Path: "stub"}},
+	}
+	cfg.Workflows.Schedules = map[string]config.WorkflowScheduleConfig{
+		"agent_schedule": {
+			Provider: "temporal",
+			Cron:     "*/10 * * * *",
+			Timezone: "UTC",
+			Target: &config.WorkflowTargetConfig{Agent: &config.WorkflowAgentConfig{
+				Provider: "managed",
+				Steps: []config.WorkflowAgentStepConfig{{
+					ID:     "sync",
+					Prompt: "Sync the roadmap",
+					Tools: []config.WorkflowAgentToolRef{
+						{Plugin: "roadmap", Operation: "sync"},
+					},
+				}},
+			}},
+		},
+	}
+
+	factories := validFactories()
+	factories.Agent = func(context.Context, string, yaml.Node, []runtimehost.HostService, bootstrap.Deps) (coreagent.Provider, error) {
+		return newRecordingAgentProvider(), nil
+	}
+	recorders := map[string]*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []runtimehost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		recorders[name] = recorder
+		return recorder, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	recorder := recorders["temporal"]
+	if recorder == nil || len(recorder.upsertedSchedules) != 1 {
+		t.Fatalf("recorded schedules = %#v", recorders)
+	}
+	ref, err := recorder.GetExecutionReference(context.Background(), recorder.upsertedSchedules[0].ExecutionRef)
+	if err != nil {
+		t.Fatalf("Get execution ref: %v", err)
+	}
+	wantPermissions := []core.AccessPermission{
+		{Plugin: "managed"},
+		{Plugin: "roadmap", Operations: []string{"sync"}},
+	}
+	if !reflect.DeepEqual(ref.Permissions, wantPermissions) {
+		t.Fatalf("permissions = %#v, want %#v", ref.Permissions, wantPermissions)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -564,7 +564,10 @@ func workflowEnsureConfigExecutionRef(
 func workflowExecutionRefPermissionsForTarget(target coreworkflow.Target, explicit ...[]core.AccessPermission) []core.AccessPermission {
 	var base []core.AccessPermission
 	if target.Agent != nil {
-		base = make([]core.AccessPermission, 0, len(target.Agent.ToolRefs)+2)
+		base = make([]core.AccessPermission, 0, len(target.Agent.ToolRefs)+3)
+		if providerName := strings.TrimSpace(target.Agent.ProviderName); providerName != "" {
+			base = append(base, core.AccessPermission{Plugin: providerName})
+		}
 		for i := range target.Agent.ToolRefs {
 			tool := target.Agent.ToolRefs[i]
 			pluginName := strings.TrimSpace(tool.Plugin)
@@ -643,6 +646,7 @@ func workflowMergeExecutionRefPermissions(groups ...[]core.AccessPermission) []c
 	out := make([]core.AccessPermission, 0)
 	pluginIndexes := map[string]int{}
 	seenOperations := map[string]map[string]struct{}{}
+	allOperations := map[string]bool{}
 	for _, group := range groups {
 		for _, value := range group {
 			plugin := strings.TrimSpace(value.Plugin)
@@ -657,6 +661,18 @@ func workflowMergeExecutionRefPermissions(groups ...[]core.AccessPermission) []c
 				}
 			}
 			if len(operations) == 0 {
+				if len(value.Actions) > 0 {
+					continue
+				}
+				idx, ok := pluginIndexes[plugin]
+				if !ok {
+					idx = len(out)
+					pluginIndexes[plugin] = idx
+					seenOperations[plugin] = map[string]struct{}{}
+					out = append(out, core.AccessPermission{Plugin: plugin})
+				}
+				out[idx].Operations = nil
+				allOperations[plugin] = true
 				continue
 			}
 			idx, ok := pluginIndexes[plugin]
@@ -665,6 +681,9 @@ func workflowMergeExecutionRefPermissions(groups ...[]core.AccessPermission) []c
 				pluginIndexes[plugin] = idx
 				seenOperations[plugin] = map[string]struct{}{}
 				out = append(out, core.AccessPermission{Plugin: plugin})
+			}
+			if allOperations[plugin] {
+				continue
 			}
 			for _, operation := range operations {
 				if _, exists := seenOperations[plugin][operation]; exists {

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -585,6 +585,28 @@ type workflowAgentTargetResponse struct {
 	} `json:"toolRefs"`
 	OutputDelivery       *workflowOutputDeliveryResponse `json:"outputDelivery"`
 	SessionReadyDelivery *workflowOutputDeliveryResponse `json:"sessionReadyDelivery"`
+	Steps                []workflowAgentStepResponse     `json:"steps"`
+}
+
+type workflowAgentStepResponse struct {
+	ID             string                          `json:"id"`
+	Prompt         string                          `json:"prompt"`
+	TimeoutSeconds int                             `json:"timeoutSeconds"`
+	ToolRefs       []workflowAgentToolRefResponse  `json:"toolRefs"`
+	OutputDelivery *workflowOutputDeliveryResponse `json:"outputDelivery"`
+	When           *workflowAgentStepWhenResponse  `json:"when"`
+}
+
+type workflowAgentToolRefResponse struct {
+	System    string `json:"system"`
+	Plugin    string `json:"plugin"`
+	Operation string `json:"operation"`
+}
+
+type workflowAgentStepWhenResponse struct {
+	StepID     string `json:"stepId"`
+	OutputPath string `json:"outputPath"`
+	Equals     any    `json:"equals"`
 }
 
 type workflowOutputDeliveryResponse struct {
@@ -949,6 +971,109 @@ func TestWorkflowScheduleAgentTargetCreateAndList(t *testing.T) {
 	}
 	if listed[0].Target.Agent.SessionReadyDelivery == nil || listed[0].Target.Agent.SessionReadyDelivery.InputBindings[0].Value.AgentSession != "id" {
 		t.Fatalf("listed agent session ready delivery = %#v", listed[0].Target.Agent.SessionReadyDelivery)
+	}
+}
+
+func TestWorkflowScheduleAgentTargetPreservesSteps(t *testing.T) {
+	t.Parallel()
+
+	services := testutil.NewStubServices(t)
+	user := seedUser(t, services, "ada-agent-steps@example.test")
+	provider := newMemoryWorkflowProvider()
+	agentProvider := newMemoryAgentProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name:       "roadmap",
+				Operations: []catalog.CatalogOperation{{ID: "sync", Method: http.MethodPost}},
+			},
+		})
+		cfg.Agent = &stubAgentControl{defaultProviderName: "managed", provider: agentProvider}
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Providers: cfg.Providers,
+			Agent:     cfg.Agent,
+			Invoker:   cfg.Invoker,
+			RunGrants: newServerTestAgentRunGrants(t),
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			provider:            provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createBody := bytes.NewBufferString(`{"cron":"*/5 * * * *","timezone":"UTC","target":{"agent":{"provider":"managed","model":"deep","steps":[{"id":"diagnosis","prompt":"Diagnose","timeoutSeconds":30,"toolRefs":[{"plugin":"roadmap","operation":"sync"}],"outputDelivery":{"target":{"name":"roadmap","operation":"sync"},"inputBindings":[{"inputField":"text","value":{"agentOutput":"text"}}]}},{"id":"pr_fix","messages":[{"role":"user","text":"Fix it"}],"when":{"stepId":"diagnosis","outputPath":"structured_output.actionable_for_pr","equals":true}}]}}}`)
+	createReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/workflow/schedules/", createBody)
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(createResp.Body)
+		t.Fatalf("expected 201, got %d: %s", createResp.StatusCode, body)
+	}
+	var created workflowScheduleResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Target.Agent == nil || len(created.Target.Agent.Steps) != 2 {
+		t.Fatalf("created agent steps = %#v", created.Target.Agent)
+	}
+	if created.Target.Agent.Steps[0].ID != "diagnosis" || created.Target.Agent.Steps[0].ToolRefs[0].Plugin != "roadmap" || created.Target.Agent.Steps[0].TimeoutSeconds != 30 {
+		t.Fatalf("created first step = %#v", created.Target.Agent.Steps[0])
+	}
+	if created.Target.Agent.Steps[1].When == nil || created.Target.Agent.Steps[1].When.StepID != "diagnosis" || created.Target.Agent.Steps[1].When.Equals != true {
+		t.Fatalf("created second step when = %#v", created.Target.Agent.Steps[1].When)
+	}
+	if len(provider.upsertReqs) != 1 {
+		t.Fatalf("upsert requests = %d, want 1", len(provider.upsertReqs))
+	}
+	storedTarget := provider.upsertReqs[0].Target
+	if storedTarget.Agent == nil || len(storedTarget.Agent.Steps) != 2 {
+		t.Fatalf("stored agent steps = %#v", storedTarget.Agent)
+	}
+	if storedTarget.Agent.Steps[0].OutputDelivery == nil || storedTarget.Agent.Steps[0].OutputDelivery.Target.PluginName != "roadmap" {
+		t.Fatalf("stored first step output delivery = %#v", storedTarget.Agent.Steps[0].OutputDelivery)
+	}
+	if storedTarget.Agent.Steps[1].When == nil || !storedTarget.Agent.Steps[1].When.EqualsSet {
+		t.Fatalf("stored second step when = %#v", storedTarget.Agent.Steps[1].When)
+	}
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/schedules/", nil)
+	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("expected 200, got %d: %s", listResp.StatusCode, body)
+	}
+	var listed []workflowScheduleResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Target.Agent == nil || len(listed[0].Target.Agent.Steps) != 2 {
+		t.Fatalf("listed schedules = %#v", listed)
+	}
+	if listed[0].Target.Agent.Steps[1].When == nil || listed[0].Target.Agent.Steps[1].When.OutputPath != "structured_output.actionable_for_pr" {
+		t.Fatalf("listed second step when = %#v", listed[0].Target.Agent.Steps[1].When)
 	}
 }
 

--- a/gestaltd/services/agents/agentmanager/manager_test.go
+++ b/gestaltd/services/agents/agentmanager/manager_test.go
@@ -1068,6 +1068,48 @@ func TestManagerCreateTurnLeavesToolSourceUnsetWhenNoToolsRequested(t *testing.T
 	}
 }
 
+func TestManagerCreateTurnForwardsTimeoutToProvider(t *testing.T) {
+	t.Parallel()
+
+	alpha := newRouteCountingAgentProvider("alpha")
+	alpha.capabilities = &coreagent.ProviderCapabilities{
+		BoundedListHydration: true,
+	}
+	manager := newTestManager(t, Config{
+		Agent: &routeCountingAgentControl{
+			defaultName: "alpha",
+			names:       []string{"alpha"},
+			providers: map[string]*routeCountingAgentProvider{
+				"alpha": alpha,
+			},
+		},
+		RunGrants: newAgentManagerTestRunGrants(t),
+	})
+	p := &principal.Principal{SubjectID: principal.UserSubjectID("user-1")}
+
+	session, err := manager.CreateSession(context.Background(), p, coreagent.ManagerCreateSessionRequest{
+		ProviderName: "alpha",
+		Model:        "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	_, err = manager.CreateTurn(context.Background(), p, coreagent.ManagerCreateTurnRequest{
+		SessionID:      session.ID,
+		Model:          "test-model",
+		TimeoutSeconds: 45,
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if len(alpha.createTurnReqs) != 1 {
+		t.Fatalf("CreateTurn requests = %d, want 1", len(alpha.createTurnReqs))
+	}
+	if got := alpha.createTurnReqs[0].TimeoutSeconds; got != 45 {
+		t.Fatalf("CreateTurn timeout seconds = %d, want 45", got)
+	}
+}
+
 func TestManagerCreateTurnDefaultsToCatalogToolsForCatalogOnlyProvider(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/services/agents/manager_server_test.go
+++ b/gestaltd/services/agents/manager_server_test.go
@@ -189,6 +189,51 @@ func TestManagerServerCreateTurnForwardsStructuredOutputInputs(t *testing.T) {
 	}
 }
 
+func TestManagerServerCreateTurnPreservesExplicitEmptyToolRefs(t *testing.T) {
+	t.Parallel()
+
+	tokens, err := NewInvocationTokenManager([]byte("agent-manager-server-turn-tool-refs-secret"))
+	if err != nil {
+		t.Fatalf("NewInvocationTokenManager: %v", err)
+	}
+	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "user-1",
+		Kind:      principal.KindUser,
+	})
+	token, err := tokens.MintRootToken(ctx, "caller-plugin", nil)
+	if err != nil {
+		t.Fatalf("MintRootToken: %v", err)
+	}
+	server := NewManagerServer("caller-plugin", &recordingManagerService{
+		createTurn: func(_ context.Context, _ *principal.Principal, req coreagent.ManagerCreateTurnRequest) (*coreagent.Turn, error) {
+			if !req.ToolRefsSet {
+				t.Fatal("ToolRefsSet = false, want true for explicit empty tool refs")
+			}
+			if len(req.ToolRefs) != 0 {
+				t.Fatalf("ToolRefs len = %d, want 0", len(req.ToolRefs))
+			}
+			if req.TimeoutSeconds != 17 {
+				t.Fatalf("TimeoutSeconds = %d, want 17", req.TimeoutSeconds)
+			}
+			return &coreagent.Turn{
+				ID:        "turn-1",
+				SessionID: req.SessionID,
+				Status:    coreagent.ExecutionStatusRunning,
+			}, nil
+		},
+	}, tokens)
+
+	_, err = server.CreateTurn(context.Background(), &proto.AgentManagerCreateTurnRequest{
+		SessionId:       "session-1",
+		InvocationToken: token,
+		ToolRefsSet:     true,
+		TimeoutSeconds:  17,
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+}
+
 func TestManagerServerMapsStructuredOutputUnsupportedToFailedPrecondition(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/go/agent_manager_transport_test.go
+++ b/sdk/go/agent_manager_transport_test.go
@@ -136,6 +136,9 @@ func TestTransport_AgentManagerTCPTargetTokenEnv(t *testing.T) {
 	if len(harness.turnRequests[0].GetToolRefs()) != 0 {
 		t.Fatalf("turn tool refs len = %d, want 0", len(harness.turnRequests[0].GetToolRefs()))
 	}
+	if harness.turnRequests[0].GetToolRefsSet() {
+		t.Fatal("turn tool_refs_set = true, want false for unset tool refs")
+	}
 	if harness.turnRequests[0].GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_UNSPECIFIED {
 		t.Fatalf("turn tool source = %s, want unspecified", harness.turnRequests[0].GetToolSource())
 	}
@@ -186,6 +189,7 @@ func TestTransport_AgentManagerCreateTurnNativeValues(t *testing.T) {
 		ResponseSchema: map[string]any{"type": "object"},
 		Metadata:       map[string]any{"request": "native"},
 		ModelOptions:   map[string]any{"temperature": 0},
+		TimeoutSeconds: 23,
 	})
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
@@ -212,7 +216,63 @@ func TestTransport_AgentManagerCreateTurnNativeValues(t *testing.T) {
 	if got.GetToolRefs()[0].GetPlugin() != "github" || got.GetToolRefs()[0].GetConnection() != "default" {
 		t.Fatalf("tool refs = %#v", got.GetToolRefs())
 	}
+	if !got.GetToolRefsSet() {
+		t.Fatal("tool_refs_set = false, want true for non-empty tool refs")
+	}
+	if got.GetTimeoutSeconds() != 23 {
+		t.Fatalf("timeout_seconds = %d, want 23", got.GetTimeoutSeconds())
+	}
 	if schema := got.GetResponseSchema().AsMap(); schema["type"] != "object" {
 		t.Fatalf("response schema = %#v", schema)
+	}
+}
+
+func TestTransport_AgentManagerCreateTurnExplicitEmptyToolRefs(t *testing.T) {
+	address := reserveTCPAddress()
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+
+	harness := &agentManagerTransportHarness{}
+	srv := grpc.NewServer()
+	proto.RegisterAgentManagerHostServer(srv, harness)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.Stop)
+
+	t.Setenv(gestalt.EnvAgentManagerSocket, "tcp://"+address)
+	t.Setenv(gestalt.EnvAgentManagerSocketToken, "relay-token-go")
+
+	client, err := gestalt.AgentManager("parent-token")
+	if err != nil {
+		t.Fatalf("AgentManager: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.CreateTurn(context.Background(), gestalt.AgentManagerCreateTurn{
+		SessionID:      "session-1",
+		ToolRefsSet:    true,
+		TimeoutSeconds: 7,
+	}); err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+
+	harness.mu.Lock()
+	defer harness.mu.Unlock()
+	if len(harness.turnRequests) != 1 {
+		t.Fatalf("turn requests len = %d, want 1", len(harness.turnRequests))
+	}
+	got := harness.turnRequests[0]
+	if !got.GetToolRefsSet() {
+		t.Fatal("tool_refs_set = false, want true")
+	}
+	if len(got.GetToolRefs()) != 0 {
+		t.Fatalf("tool refs len = %d, want 0", len(got.GetToolRefs()))
+	}
+	if got.GetTimeoutSeconds() != 7 {
+		t.Fatalf("timeout_seconds = %d, want 7", got.GetTimeoutSeconds())
 	}
 }

--- a/sdk/python/gestalt/_agent.py
+++ b/sdk/python/gestalt/_agent.py
@@ -1980,8 +1980,7 @@ def _agent_manager_create_turn_request(value: Any | None = None, **kwargs: Any) 
         tool_refs=[
             _agent_tool_ref_value(item) for item in (data.get("tool_refs") or [])
         ],
-        tool_refs_set=data.get("tool_refs_set", False)
-        or bool(data.get("tool_refs") or []),
+        tool_refs_set=data.get("tool_refs_set", False) or data.get("tool_refs") is not None,
         tool_source=data.get("tool_source", AGENT_TOOL_SOURCE_MODE_UNSPECIFIED),
         idempotency_key=data.get("idempotency_key", ""),
         timeout_seconds=data.get("timeout_seconds", 0),

--- a/sdk/python/gestalt/_workflow.py
+++ b/sdk/python/gestalt/_workflow.py
@@ -938,10 +938,7 @@ def bound_workflow_agent_target(value: Any | None = None, **kwargs: Any) -> Any:
         session_ready_delivery=workflow_output_delivery(session_ready_delivery)
         if session_ready_delivery is not None
         else None,
-        steps=[
-            workflow_agent_step(step)
-            for step in (data.get("steps") or [])
-        ],
+        steps=[workflow_agent_step(step) for step in (data.get("steps") or [])],
     )
 
 
@@ -978,7 +975,7 @@ def bound_workflow_agent_target_input_from_target(
         )
         if has_field(value, "session_ready_delivery")
         else None,
-        steps=[workflow_agent_step_input_from_step(step) for step in value.steps],
+        steps=[workflow_agent_step_input_from_step(step) for step in (value.steps or [])],
     )
 
 
@@ -1043,10 +1040,11 @@ def workflow_agent_step_when(value: Any | None = None, **kwargs: Any) -> Any:
     if isinstance(value, pb.WorkflowAgentStepWhen):
         return _copy(value)
     data = _data(value, kwargs)
+    equals = _value(data["equals"]) if "equals" in data else None
     return pb.WorkflowAgentStepWhen(
         step_id=data.get("step_id", ""),
         output_path=data.get("output_path", ""),
-        equals=_optional_value(data.get("equals")),
+        equals=equals,
     )
 
 

--- a/sdk/python/tests/test_agent_transport.py
+++ b/sdk/python/tests/test_agent_transport.py
@@ -87,7 +87,7 @@ _host_relay_tokens: list[str] = []
 _host_list_requests: list[dict[str, Any]] = []
 _host_execute_requests: list[dict[str, Any]] = []
 _host_connection_requests: list[dict[str, Any]] = []
-_manager_requests: list[dict[str, str]] = []
+_manager_requests: list[dict[str, Any]] = []
 _manager_relay_tokens: list[str] = []
 
 
@@ -473,6 +473,7 @@ class _AgentManagerServicer(agent_pb2_grpc.AgentManagerHostServicer):
                 "tool_refs_set": request.tool_refs_set,
                 "timeout_seconds": request.timeout_seconds,
                 "has_response_schema": request.HasField("response_schema"),
+                "tool_refs_len": len(request.tool_refs),
             }
         )
         return agent_pb2.AgentTurn(
@@ -1294,6 +1295,7 @@ class AgentTransportTests(unittest.TestCase):
                     "tool_refs_set": False,
                     "timeout_seconds": 0,
                     "has_response_schema": True,
+                    "tool_refs_len": 0,
                 },
                 {
                     "method": "get_turn",
@@ -1406,6 +1408,14 @@ class AgentTransportTests(unittest.TestCase):
                     timeout_seconds=120,
                 )
             )
+            empty_tools_turn = manager.create_turn(
+                AgentManagerCreateTurn(
+                    session_id="session-managed-1",
+                    model="gpt-5.1",
+                    tool_refs=[],
+                    timeout_seconds=7,
+                )
+            )
             resolved = manager.resolve_interaction(
                 AgentManagerResolveInteraction(
                     turn_id="turn-managed-1",
@@ -1415,6 +1425,7 @@ class AgentTransportTests(unittest.TestCase):
             )
 
         self.assertEqual(created_turn.id, "turn-managed-1")
+        self.assertEqual(empty_tools_turn.id, "turn-managed-1")
         self.assertEqual(created_turn.messages[0].role, "user")
         self.assertEqual(created_turn.messages[0].metadata["source"], "native")
         self.assertEqual(
@@ -1422,15 +1433,23 @@ class AgentTransportTests(unittest.TestCase):
             agent_pb2.AGENT_MESSAGE_PART_TYPE_TEXT,
         )
         self.assertEqual(resolved.id, "interaction-1")
-        self.assertEqual(_manager_relay_tokens, ["relay-token-py", "relay-token-py"])
+        self.assertEqual(
+            _manager_relay_tokens,
+            ["relay-token-py", "relay-token-py", "relay-token-py"],
+        )
         self.assertEqual(
             [item["method"] for item in _manager_requests],
-            ["create_turn", "resolve_interaction"],
+            ["create_turn", "create_turn", "resolve_interaction"],
         )
         self.assertEqual(_manager_requests[0]["tool_source"], agent_pb2.AGENT_TOOL_SOURCE_MODE_NONE)
         self.assertTrue(_manager_requests[0]["tool_refs_set"])
         self.assertEqual(_manager_requests[0]["timeout_seconds"], 120)
         self.assertTrue(_manager_requests[0]["has_response_schema"])
+        self.assertTrue(_manager_requests[0]["tool_refs_set"])
+        self.assertEqual(_manager_requests[0]["tool_refs_len"], 1)
+        self.assertTrue(_manager_requests[1]["tool_refs_set"])
+        self.assertEqual(_manager_requests[1]["tool_refs_len"], 0)
+        self.assertEqual(_manager_requests[1]["timeout_seconds"], 7)
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/test_workflow_helpers.py
+++ b/sdk/python/tests/test_workflow_helpers.py
@@ -150,6 +150,25 @@ class WorkflowHelperTests(unittest.TestCase):
         self.assertIsInstance(copied.tool_refs[0], gestalt.AgentToolRef)
         self.assertEqual(copied.tool_refs[0].plugin, "github")
 
+    def test_agent_step_when_preserves_explicit_null_equals(self) -> None:
+        when = gestalt.workflow_agent_step_when(
+            step_id="extract",
+            output_path="$.value",
+            equals=None,
+        )
+
+        self.assertTrue(when.HasField("equals"))
+        self.assertEqual(when.equals.WhichOneof("kind"), "null_value")
+
+        copied = gestalt.workflow_agent_step_when_input_from_when(when)
+        round_tripped = gestalt.workflow_agent_step_when(copied)
+
+        self.assertTrue(round_tripped.HasField("equals"))
+        self.assertEqual(round_tripped.equals.WhichOneof("kind"), "null_value")
+
+        absent = gestalt.workflow_agent_step_when(step_id="extract")
+        self.assertFalse(absent.HasField("equals"))
+
     def test_agent_target_steps_round_trip(self) -> None:
         self.assertIsNotNone(gestalt.workflow_agent_step)
         self.assertIsNotNone(gestalt.workflow_agent_step_when)

--- a/sdk/rust/tests/agent_manager_transport.rs
+++ b/sdk/rust/tests/agent_manager_transport.rs
@@ -717,19 +717,31 @@ async fn agent_manager_create_turn_accepts_native_values() {
             response_schema: Some(serde_json::json!({ "type": "object" })),
             metadata: Some(serde_json::json!({ "request": "native" })),
             model_options: Some(serde_json::json!({ "temperature": 0 })),
+            timeout_seconds: 23,
             ..Default::default()
         })
         .await
         .expect("create turn");
+    let empty_tools_turn = manager
+        .create_turn(AgentManagerCreateTurn {
+            session_id: "session-managed-1".to_string(),
+            model: "gpt-5.1".to_string(),
+            tool_refs_set: true,
+            timeout_seconds: 7,
+            ..Default::default()
+        })
+        .await
+        .expect("create turn with explicit empty tools");
 
     assert_eq!(created_turn.id, "turn-managed-1");
+    assert_eq!(empty_tools_turn.id, "turn-managed-1");
 
     let requests = server
         .create_turn_requests
         .lock()
         .expect("lock create turn requests")
         .clone();
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 2);
     let request = &requests[0];
     assert_eq!(request.invocation_token, "token-123");
     assert_eq!(request.session_id, "session-managed-1");
@@ -752,6 +764,8 @@ async fn agent_manager_create_turn_accepts_native_values() {
     );
     assert_eq!(request.messages[0].parts[0].text, "Summarize this");
     assert_eq!(request.tool_refs.len(), 1);
+    assert!(request.tool_refs_set);
+    assert_eq!(request.timeout_seconds, 23);
     assert_eq!(request.tool_refs[0].plugin, "github");
     assert_eq!(request.tool_refs[0].operation, "issues.get");
     assert_eq!(request.tool_refs[0].connection, "default");
@@ -779,6 +793,10 @@ async fn agent_manager_create_turn_accepts_native_values() {
         support_protocol::json_from_struct(request.model_options.as_ref().unwrap()),
         serde_json::json!({ "temperature": 0.0 })
     );
+    let empty_tools_request = &requests[1];
+    assert!(empty_tools_request.tool_refs_set);
+    assert!(empty_tools_request.tool_refs.is_empty());
+    assert_eq!(empty_tools_request.timeout_seconds, 7);
 
     serve_task.abort();
     let _ = serve_task.await;

--- a/sdk/typescript/src/agent-manager.ts
+++ b/sdk/typescript/src/agent-manager.ts
@@ -239,7 +239,7 @@ export class AgentManager {
         model: request.model ?? "",
         messages: request.messages?.map(agentMessageToProto) ?? [],
         toolRefs: request.toolRefs?.map(agentToolRefToProto) ?? [],
-        toolRefsSet: request.toolRefsSet ?? (request.toolRefs !== undefined && request.toolRefs.length > 0),
+        toolRefsSet: request.toolRefsSet ?? (request.toolRefs !== undefined),
         toolSource: request.toolSource ?? AgentToolSourceMode.UNSPECIFIED,
         responseSchema: optionalStruct(request.responseSchema),
         metadata: optionalStruct(request.metadata),

--- a/sdk/typescript/tests/agent-manager.transport.test.ts
+++ b/sdk/typescript/tests/agent-manager.transport.test.ts
@@ -44,6 +44,9 @@ test("AgentManager forwards invocation tokens across session, turn, and interact
     turnId?: string;
     interactionId?: string;
     reason?: string;
+    toolRefsSet?: boolean;
+    timeoutSeconds?: number;
+    toolRefsLength?: number;
   }> = [];
 
   const handler = connectNodeAdapter({
@@ -122,6 +125,9 @@ test("AgentManager forwards invocation tokens across session, turn, and interact
             method: "createTurn",
             invocationToken: input.invocationToken,
             sessionId: input.sessionId,
+            toolRefsSet: input.toolRefsSet,
+            timeoutSeconds: input.timeoutSeconds,
+            toolRefsLength: input.toolRefs.length,
           });
           return create(AgentTurnSchema, {
             id: "turn-1",
@@ -302,6 +308,13 @@ test("AgentManager forwards invocation tokens across session, turn, and interact
       ],
       idempotencyKey: "turn-req-1",
     });
+    const noToolTurn = await fromRequest.createTurn({
+      sessionId: "session-1",
+      model: "gpt-test",
+      toolRefs: [],
+      timeoutSeconds: 7,
+      idempotencyKey: "turn-req-2",
+    });
     const fetchedTurn = await fromRequest.getTurn({ turnId: "turn-1" });
     const listedTurns = await fromRequest.listTurns({ sessionId: "session-1" });
     const events = await fromRequest.listTurnEvents({
@@ -328,6 +341,7 @@ test("AgentManager forwards invocation tokens across session, turn, and interact
     expect(updatedSession.state).toBe(AgentSessionState.ARCHIVED);
     expect(turn.id).toBe("turn-1");
     expect(turn.status).toBe(AgentExecutionStatus.WAITING_FOR_INPUT);
+    expect(noToolTurn.id).toBe("turn-1");
     expect(fetchedTurn.statusMessage).toBe("waiting for input");
     expect(listedTurns.map((entry) => entry.id)).toEqual(["turn-1"]);
     expect(events.map((entry) => entry.type)).toEqual(["turn.started"]);
@@ -361,6 +375,17 @@ test("AgentManager forwards invocation tokens across session, turn, and interact
         method: "createTurn",
         invocationToken: "invocation-token-456",
         sessionId: "session-1",
+        toolRefsSet: true,
+        timeoutSeconds: 0,
+        toolRefsLength: 1,
+      },
+      {
+        method: "createTurn",
+        invocationToken: "invocation-token-456",
+        sessionId: "session-1",
+        toolRefsSet: true,
+        timeoutSeconds: 7,
+        toolRefsLength: 0,
       },
       {
         method: "getTurn",


### PR DESCRIPTION
## Summary

This PR contains the agent/workflow compatibility fixes that were separated from the IndexedDB factory work.

It preserves existing behavior around:

- explicit empty tool refs, so callers can intentionally disable default tool selection;
- per-turn timeout propagation across the manager service and SDK request builders;
- multi-step workflow agent targets across proto, config, HTTP schedule APIs, workflow runtime, and SDK helpers;
- workflow execution-reference permissions when steps introduce tool refs or output delivery.

## Split Notes

This PR is independent of the IndexedDB protocol and bootstrap PRs. It can be reviewed and merged on its own.

## Agent Manager Contract

The public agent turn surface continues to distinguish explicit empty tool refs from omitted tool refs, and preserves per-turn timeout propagation:

```diff
 type ManagerCreateTurnRequest struct {
     SessionID string
     Prompt string
     Messages []Message
     ToolRefs []ToolRef
+    ToolRefsSet bool
+    TimeoutSeconds int32
 }
```

Semantics:

- `ToolRefsSet == false && len(ToolRefs) == 0` means the provider/default tool source may be used.
- `ToolRefsSet == true && len(ToolRefs) == 0` means tools were explicitly set to empty and defaults must not be injected.
- `TimeoutSeconds` is forwarded to provider turn creation instead of being dropped by the manager layer.

The non-Go SDKs preserve the same wire behavior. For example, TypeScript request construction treats an explicit `toolRefs: []` as an intentional set:

```diff
 const request = {
   sessionId,
   prompt,
   messages,
   toolRefs,
+  toolRefsSet: input.toolRefs !== undefined,
+  timeoutSeconds: input.timeoutSeconds,
 }
```

Python follows the same distinction when serializing request dictionaries:

```diff
-tool_refs_set = data.get("tool_refs_set", False)
+tool_refs_set = data.get("tool_refs_set", False) or "tool_refs" in data
```

## Workflow Agent Step Contract

Workflow agent targets continue to support both a top-level single-turn target and a multi-step target:

```diff
 type WorkflowAgentTarget struct {
     ProviderName string
     Prompt string
     Messages []AgentMessage
     ToolRefs []AgentToolRef
+    Steps []WorkflowAgentStep
 }
```

The step shape remains part of the public workflow API:

```go
type WorkflowAgentStep struct {
    ID             string
    Prompt         string
    Messages       []AgentMessage
    ToolRefs       []AgentToolRef
    TimeoutSeconds int32
    OutputDelivery *WorkflowOutputDelivery
    When           *WorkflowStepCondition
}

type WorkflowStepCondition struct {
    StepID     string
    OutputPath string
    Equals     *structpb.Value
}
```

Validation keeps the previous behavior:

- A top-level agent target must provide prompt/messages unless it defines `Steps`.
- A stepped target may have empty top-level prompt/messages because each step supplies its own work.
- Step `when.equals` is considered present by field presence, so an explicit JSON/protobuf `null` is valid and round-trips.

The HTTP schedule/config and SDK shapes continue to expose `steps`. TypeScript keeps the public shape:

```ts
type WorkflowAgentStep = {
  id?: string
  prompt?: string
  messages?: AgentMessage[]
  toolRefs?: AgentToolRef[]
  timeoutSeconds?: number
  outputDelivery?: WorkflowOutputDelivery
  when?: {
    stepId?: string
    outputPath?: string
    equals?: unknown
  }
}
```

Python keeps helper support for explicit null conditions:

```python
WorkflowAgentStep(
    id="check",
    when=WorkflowStepCondition(
        step_id="previous",
        output_path="$.result",
        equals=None,
    ),
)
```

## Execution Permission Contract

When config-managed workflow steps add per-step tool refs or output delivery, the runtime permissions remain additive. The agent provider permission is preserved alongside step-specific plugin permissions:

```diff
 ExecutionReferencePermissions{
     Plugins: []PluginPermission{
+        {Plugin: target.Agent.ProviderName},
         {Plugin: stepTool.ProviderName, Operation: stepTool.OperationName},
     },
 }
```

A provider-level permission for the agent provider is preserved so `agentmanager.CreateSession` can still create the agent session before step-specific tools are evaluated.

## Test Plan

- `cd gestaltd && go test -count=1 ./services/agents/... ./internal/server ./internal/bootstrap -run 'Agent|WorkflowSchedule|ExecutionRef'`
- `cd sdk/go && go test -count=1 ./... -run 'AgentManager|IndexedDB'`
- `cd sdk/python && uv sync --frozen --group dev && uv run pytest -q tests/test_agent_transport.py tests/test_workflow_helpers.py`
- `cd sdk/typescript && bun install && bun test tests/agent-manager.transport.test.ts`
- `cd sdk/rust && cargo test agent_manager`
