### PR TITLE
Route core data through IndexedDB system database

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -958,7 +958,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		_ = store.Close()
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, svcErr)
 	}
-	hostIndexedDBs := map[string]indexeddb.IndexedDB{selectedIndexedDBName: store}
+	hostIndexedDBs := map[string]indexeddb.IndexedDB{selectedIndexedDBName: svc.DB}
 	var extraIndexedDBs []indexeddb.IndexedDB
 	for name, entry := range cfg.Providers.IndexedDB {
 		if name == selectedIndexedDBName || entry == nil {
@@ -1647,12 +1647,15 @@ func buildExternalCredentialsHostServices(name string, deps Deps) ([]runtimehost
 }
 
 func externalCredentialsIndexedDBHostService(envVar, providerName string, ds indexeddb.IndexedDB) runtimehost.HostService {
+	registry := indexeddbservice.NewConnectionRegistry()
 	return runtimehost.HostService{
 		Name:   "indexeddb",
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, providerName, indexeddbservice.ServerOptions{
-				AllowedStores: []string{"external_credentials"},
+				AllowedStores:      []string{"external_credentials"},
+				AllowedDatabases:   []string{coredata.SystemDatabaseName},
+				ConnectionRegistry: registry,
 			}))
 		},
 	}
@@ -1833,11 +1836,14 @@ func buildHostIndexedDBHostServices(selectedName string, indexeddbs map[string]i
 }
 
 func indexedDBHostService(envVar, name string, ds indexeddb.IndexedDB) runtimehost.HostService {
+	registry := indexeddbservice.NewConnectionRegistry()
 	return runtimehost.HostService{
 		Name:   "indexeddb",
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, name, indexeddbservice.ServerOptions{}))
+			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, name, indexeddbservice.ServerOptions{
+				ConnectionRegistry: registry,
+			}))
 		},
 	}
 }

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -32,6 +32,7 @@ import (
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	proto "github.com/valon-technologies/gestalt/server/internal/gen/v1"
 	"github.com/valon-technologies/gestalt/server/internal/indexeddbcodec"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
@@ -1613,6 +1614,113 @@ func (t *trackedIndexedDB) Close() error {
 		t.closed.Add(1)
 	}
 	return nil
+}
+
+type splitFactoryIndexedDB struct {
+	legacy    *coretesting.StubIndexedDB
+	mu        sync.Mutex
+	databases map[string]*coretesting.StubIndexedDB
+}
+
+func newSplitFactoryIndexedDB() *splitFactoryIndexedDB {
+	return &splitFactoryIndexedDB{
+		legacy:    &coretesting.StubIndexedDB{},
+		databases: make(map[string]*coretesting.StubIndexedDB),
+	}
+}
+
+func (s *splitFactoryIndexedDB) database(name string) *coretesting.StubIndexedDB {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	db := s.databases[name]
+	if db == nil {
+		db = &coretesting.StubIndexedDB{}
+		s.databases[name] = db
+	}
+	return db
+}
+
+func (s *splitFactoryIndexedDB) Open(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error) {
+	return s.database(name).Open(ctx, name, opts)
+}
+
+func (s *splitFactoryIndexedDB) OpenCurrent(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error) {
+	s.mu.Lock()
+	db := s.databases[name]
+	s.mu.Unlock()
+	if db == nil {
+		return nil, indexeddb.ErrNotFound
+	}
+	return db.OpenCurrent(ctx, name, opts)
+}
+
+func (s *splitFactoryIndexedDB) DeleteDatabase(ctx context.Context, name string, opts indexeddb.DeleteOptions) (indexeddb.DeleteDatabaseResult, error) {
+	s.mu.Lock()
+	db := s.databases[name]
+	s.mu.Unlock()
+	if db == nil {
+		return indexeddb.DeleteDatabaseResult{Name: name}, nil
+	}
+	return db.DeleteDatabase(ctx, name, opts)
+}
+
+func (s *splitFactoryIndexedDB) Databases(ctx context.Context) ([]indexeddb.DatabaseInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	infos := make([]indexeddb.DatabaseInfo, 0, len(s.databases))
+	for name, db := range s.databases {
+		current, err := db.OpenCurrent(ctx, name, indexeddb.OpenOptions{})
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		infos = append(infos, indexeddb.DatabaseInfo{Name: current.Name(), Version: current.Version()})
+	}
+	slices.SortFunc(infos, func(a, b indexeddb.DatabaseInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return infos, nil
+}
+
+func (s *splitFactoryIndexedDB) CompareKeys(first any, second any) (int, error) {
+	return s.legacy.CompareKeys(first, second)
+}
+
+func (s *splitFactoryIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	return s.legacy.ObjectStore(name)
+}
+
+func (s *splitFactoryIndexedDB) Transaction(ctx context.Context, stores []string, mode indexeddb.TransactionMode, opts indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+	return s.legacy.Transaction(ctx, stores, mode, opts)
+}
+
+func (s *splitFactoryIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	return s.legacy.CreateObjectStore(ctx, name, schema)
+}
+
+func (s *splitFactoryIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
+	return s.legacy.DeleteObjectStore(ctx, name)
+}
+
+func (s *splitFactoryIndexedDB) Ping(ctx context.Context) error {
+	return s.legacy.Ping(ctx)
+}
+
+func (s *splitFactoryIndexedDB) Close() error {
+	s.mu.Lock()
+	databases := make([]*coretesting.StubIndexedDB, 0, len(s.databases))
+	for _, db := range s.databases {
+		databases = append(databases, db)
+	}
+	s.mu.Unlock()
+
+	errs := []error{s.legacy.Close()}
+	for _, db := range databases {
+		errs = append(errs, db.Close())
+	}
+	return errors.Join(errs...)
 }
 
 func validConfig() *config.Config {
@@ -4397,6 +4505,62 @@ func TestBootstrapPassesIndexedDBHostSocketsToAuthorizationProviders(t *testing.
 	}
 }
 
+func TestBootstrapSelectedIndexedDBHostUsesSystemDatabase(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.Authorization = map[string]*config.ProviderEntry{
+		"indexeddb": {
+			Source: config.ProviderSource{Path: "stub"},
+			Config: mustYAMLNode(t, map[string]any{"indexeddb": "test"}),
+		},
+	}
+	cfg.Server.Providers.Authorization = "indexeddb"
+
+	systemDB := newSplitFactoryIndexedDB()
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) {
+		return systemDB, nil
+	}
+	var hostServices []runtimehost.HostService
+	factories.Authorization = func(_ yaml.Node, services []runtimehost.HostService, _ bootstrap.Deps) (core.AuthorizationProvider, error) {
+		hostServices = append([]runtimehost.HostService(nil), services...)
+		return &stubAuthorizationProvider{name: "test-authorization"}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	user, err := result.Services.Users.FindOrCreateUser(context.Background(), "ada@example.test")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	if len(hostServices) == 0 || hostServices[0].EnvVar != indexeddbservice.DefaultSocketEnv {
+		t.Fatalf("missing default indexeddb host service: %#v", hostServices)
+	}
+
+	withIndexedDBHostClient(t, hostServices[0], func(client proto.IndexedDBClient) {
+		resp, err := client.Get(context.Background(), &proto.ObjectStoreRequest{
+			Store: coredata.StoreUsers,
+			Id:    user.ID,
+		})
+		if err != nil {
+			t.Fatalf("Get(%s, %s): %v", coredata.StoreUsers, user.ID, err)
+		}
+		got, err := indexeddbcodec.RecordFromProto(resp.GetRecord())
+		if err != nil {
+			t.Fatalf("RecordFromProto: %v", err)
+		}
+		if got["email"] != "ada@example.test" {
+			t.Fatalf("email = %#v, want %q", got["email"], "ada@example.test")
+		}
+	})
+}
+
 func TestBootstrapClosesWorkflowIndexedDBAndAppliesScopedConfig(t *testing.T) {
 	t.Parallel()
 
@@ -4533,6 +4697,35 @@ func TestBootstrapRoutesExternalCredentialsIndexedDBHostServices(t *testing.T) {
 			Schema: &proto.ObjectStoreSchema{},
 		}); err == nil {
 			t.Fatal("CreateObjectStore(plugin_credentials) succeeded, want allowlist failure")
+		}
+
+		stream, err := client.OpenDatabase(context.Background())
+		if err != nil {
+			t.Fatalf("OpenDatabase: %v", err)
+		}
+		if err := stream.Send(&proto.OpenDatabaseClientMessage{
+			Msg: &proto.OpenDatabaseClientMessage_Open{Open: &proto.OpenDatabaseRequest{Name: "system"}},
+		}); err != nil {
+			t.Fatalf("OpenDatabase send: %v", err)
+		}
+		msg, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("OpenDatabase recv: %v", err)
+		}
+		if got := status.FromProto(msg.GetError()).Code(); got != codes.NotFound {
+			t.Fatalf("OpenDatabase outside allowed database code = %v, want %v", got, codes.NotFound)
+		}
+
+		deleteStream, err := client.DeleteDatabase(context.Background(), &proto.DeleteDatabaseRequest{Name: "system"})
+		if err != nil {
+			t.Fatalf("DeleteDatabase: %v", err)
+		}
+		deleteMsg, err := deleteStream.Recv()
+		if err != nil {
+			t.Fatalf("DeleteDatabase recv: %v", err)
+		}
+		if got := status.FromProto(deleteMsg.GetError()).Code(); got != codes.NotFound {
+			t.Fatalf("DeleteDatabase outside allowed database code = %v, want %v", got, codes.NotFound)
 		}
 	})
 }

--- a/gestaltd/internal/bootstrap/plugin_indexeddb.go
+++ b/gestaltd/internal/bootstrap/plugin_indexeddb.go
@@ -18,10 +18,17 @@ func newIndexedDBStoreAllowlist(ds indexeddb.IndexedDB, opts indexedDBStoreAllow
 	for _, store := range opts.AllowedStores {
 		allowed[store] = struct{}{}
 	}
-	return &indexedDBStoreAllowlist{
+	base := &indexedDBStoreAllowlist{
 		inner:   ds,
 		allowed: allowed,
 	}
+	if factory, ok := ds.(indexeddb.Factory); ok {
+		return &indexedDBFactoryStoreAllowlist{
+			indexedDBStoreAllowlist: base,
+			factory:                 factory,
+		}
+	}
+	return base
 }
 
 type indexedDBStoreAllowlist struct {
@@ -76,6 +83,193 @@ func (d *indexedDBStoreAllowlist) Ping(ctx context.Context) error {
 
 func (d *indexedDBStoreAllowlist) Close() error {
 	return d.inner.Close()
+}
+
+type indexedDBFactoryStoreAllowlist struct {
+	*indexedDBStoreAllowlist
+	factory indexeddb.Factory
+}
+
+func (d *indexedDBFactoryStoreAllowlist) Open(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error) {
+	opts.Upgrade = d.wrapUpgrade(opts.Upgrade)
+	db, err := d.factory.Open(ctx, name, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &indexedDBDatabaseAllowlist{allowlist: d.indexedDBStoreAllowlist, inner: db}, nil
+}
+
+func (d *indexedDBFactoryStoreAllowlist) OpenCurrent(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error) {
+	db, err := d.factory.OpenCurrent(ctx, name, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &indexedDBDatabaseAllowlist{allowlist: d.indexedDBStoreAllowlist, inner: db}, nil
+}
+
+func (d *indexedDBFactoryStoreAllowlist) DeleteDatabase(ctx context.Context, name string, opts indexeddb.DeleteOptions) (indexeddb.DeleteDatabaseResult, error) {
+	return d.factory.DeleteDatabase(ctx, name, opts)
+}
+
+func (d *indexedDBFactoryStoreAllowlist) Databases(ctx context.Context) ([]indexeddb.DatabaseInfo, error) {
+	return d.factory.Databases(ctx)
+}
+
+func (d *indexedDBFactoryStoreAllowlist) CompareKeys(first any, second any) (int, error) {
+	return d.factory.CompareKeys(first, second)
+}
+
+func (d *indexedDBStoreAllowlist) wrapUpgrade(upgrade func(context.Context, indexeddb.UpgradeContext) error) func(context.Context, indexeddb.UpgradeContext) error {
+	if upgrade == nil {
+		return nil
+	}
+	return func(ctx context.Context, inner indexeddb.UpgradeContext) error {
+		return upgrade(ctx, indexedDBUpgradeContextAllowlist{allowlist: d, inner: inner})
+	}
+}
+
+func (d *indexedDBStoreAllowlist) filterStoreNames(names []string) []string {
+	if len(d.allowed) == 0 {
+		return append([]string(nil), names...)
+	}
+	filtered := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, ok := d.allowed[name]; ok {
+			filtered = append(filtered, name)
+		}
+	}
+	return filtered
+}
+
+type indexedDBDatabaseAllowlist struct {
+	allowlist *indexedDBStoreAllowlist
+	inner     indexeddb.Database
+}
+
+func (d *indexedDBDatabaseAllowlist) Name() string { return d.inner.Name() }
+
+func (d *indexedDBDatabaseAllowlist) Version() uint64 { return d.inner.Version() }
+
+func (d *indexedDBDatabaseAllowlist) ObjectStoreNames(ctx context.Context) ([]string, error) {
+	names, err := d.inner.ObjectStoreNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.allowlist.filterStoreNames(names), nil
+}
+
+func (d *indexedDBDatabaseAllowlist) ObjectStore(name string) indexeddb.ObjectStore {
+	if err := d.allowlist.checkStore(name); err != nil {
+		return missingObjectStore{}
+	}
+	return d.inner.ObjectStore(name)
+}
+
+func (d *indexedDBDatabaseAllowlist) Transaction(ctx context.Context, stores []string, mode indexeddb.TransactionMode, opts indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+	for _, store := range stores {
+		if err := d.allowlist.checkStore(store); err != nil {
+			return nil, err
+		}
+	}
+	tx, err := d.inner.Transaction(ctx, stores, mode, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &indexedDBStoreAllowlistTransaction{allowlist: d.allowlist, inner: tx}, nil
+}
+
+func (d *indexedDBDatabaseAllowlist) Close() error { return d.inner.Close() }
+
+type indexedDBUpgradeContextAllowlist struct {
+	allowlist *indexedDBStoreAllowlist
+	inner     indexeddb.UpgradeContext
+}
+
+func (u indexedDBUpgradeContextAllowlist) OldVersion() uint64 { return u.inner.OldVersion() }
+
+func (u indexedDBUpgradeContextAllowlist) NewVersion() uint64 { return u.inner.NewVersion() }
+
+func (u indexedDBUpgradeContextAllowlist) Database() indexeddb.UpgradeDatabase {
+	return indexedDBUpgradeDatabaseAllowlist{allowlist: u.allowlist, inner: u.inner.Database()}
+}
+
+func (u indexedDBUpgradeContextAllowlist) ObjectStoreNames(ctx context.Context) ([]string, error) {
+	names, err := u.inner.ObjectStoreNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return u.allowlist.filterStoreNames(names), nil
+}
+
+func (u indexedDBUpgradeContextAllowlist) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	if err := u.allowlist.checkStore(name); err != nil {
+		return err
+	}
+	return u.inner.CreateObjectStore(ctx, name, schema)
+}
+
+func (u indexedDBUpgradeContextAllowlist) DeleteObjectStore(ctx context.Context, name string) error {
+	if err := u.allowlist.checkStore(name); err != nil {
+		return err
+	}
+	return u.inner.DeleteObjectStore(ctx, name)
+}
+
+func (u indexedDBUpgradeContextAllowlist) CreateIndex(ctx context.Context, store string, index indexeddb.IndexSchema) error {
+	if err := u.allowlist.checkStore(store); err != nil {
+		return err
+	}
+	return u.inner.CreateIndex(ctx, store, index)
+}
+
+func (u indexedDBUpgradeContextAllowlist) DeleteIndex(ctx context.Context, store string, name string) error {
+	if err := u.allowlist.checkStore(store); err != nil {
+		return err
+	}
+	return u.inner.DeleteIndex(ctx, store, name)
+}
+
+type indexedDBUpgradeDatabaseAllowlist struct {
+	allowlist *indexedDBStoreAllowlist
+	inner     indexeddb.UpgradeDatabase
+}
+
+func (d indexedDBUpgradeDatabaseAllowlist) Name() string { return d.inner.Name() }
+
+func (d indexedDBUpgradeDatabaseAllowlist) ObjectStoreNames(ctx context.Context) ([]string, error) {
+	names, err := d.inner.ObjectStoreNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.allowlist.filterStoreNames(names), nil
+}
+
+func (d indexedDBUpgradeDatabaseAllowlist) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	if err := d.allowlist.checkStore(name); err != nil {
+		return err
+	}
+	return d.inner.CreateObjectStore(ctx, name, schema)
+}
+
+func (d indexedDBUpgradeDatabaseAllowlist) DeleteObjectStore(ctx context.Context, name string) error {
+	if err := d.allowlist.checkStore(name); err != nil {
+		return err
+	}
+	return d.inner.DeleteObjectStore(ctx, name)
+}
+
+func (d indexedDBUpgradeDatabaseAllowlist) CreateIndex(ctx context.Context, store string, index indexeddb.IndexSchema) error {
+	if err := d.allowlist.checkStore(store); err != nil {
+		return err
+	}
+	return d.inner.CreateIndex(ctx, store, index)
+}
+
+func (d indexedDBUpgradeDatabaseAllowlist) DeleteIndex(ctx context.Context, store string, name string) error {
+	if err := d.allowlist.checkStore(store); err != nil {
+		return err
+	}
+	return d.inner.DeleteIndex(ctx, store, name)
 }
 
 type indexedDBStoreAllowlistTransaction struct {

--- a/gestaltd/internal/bootstrap/plugin_indexeddb_test.go
+++ b/gestaltd/internal/bootstrap/plugin_indexeddb_test.go
@@ -38,3 +38,82 @@ func TestIndexedDBStoreAllowlistTransactionMissingStoreAbortsInnerTransaction(t 
 		t.Fatalf("task-1 after aborted transaction error = %v, want indexeddb.ErrNotFound", err)
 	}
 }
+
+func TestIndexedDBStoreAllowlistFactoryCapability(t *testing.T) {
+	t.Parallel()
+
+	t.Run("legacy_inner_does_not_satisfy_factory", func(t *testing.T) {
+		t.Parallel()
+
+		db := newIndexedDBStoreAllowlist(&legacyOnlyIndexedDB{inner: &coretesting.StubIndexedDB{}}, indexedDBStoreAllowlistOptions{
+			AllowedStores: []string{"tasks"},
+		})
+		if _, ok := db.(indexeddb.Factory); ok {
+			t.Fatal("allowlisted legacy IndexedDB unexpectedly satisfies indexeddb.Factory")
+		}
+	})
+
+	t.Run("factory_inner_satisfies_factory_and_enforces_upgrade_allowlist", func(t *testing.T) {
+		t.Parallel()
+
+		db := newIndexedDBStoreAllowlist(&coretesting.StubIndexedDB{}, indexedDBStoreAllowlistOptions{
+			AllowedStores: []string{"tasks"},
+		})
+		factory, ok := db.(indexeddb.Factory)
+		if !ok {
+			t.Fatal("allowlisted factory IndexedDB does not satisfy indexeddb.Factory")
+		}
+		version := uint64(1)
+		_, err := factory.Open(context.Background(), "app", indexeddb.OpenOptions{
+			Version: &version,
+			Upgrade: func(ctx context.Context, upgrade indexeddb.UpgradeContext) error {
+				if err := upgrade.CreateObjectStore(ctx, "tasks", indexeddb.ObjectStoreSchema{}); err != nil {
+					return err
+				}
+				return upgrade.CreateObjectStore(ctx, "notes", indexeddb.ObjectStoreSchema{})
+			},
+		})
+		if !errors.Is(err, indexeddb.ErrNotFound) {
+			t.Fatalf("disallowed upgrade CreateObjectStore error = %v, want ErrNotFound", err)
+		}
+	})
+}
+
+func TestIndexedDBStoreAllowlistFilterStoreNamesDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	allowlist := &indexedDBStoreAllowlist{allowed: map[string]struct{}{"tasks": {}}}
+	names := []string{"notes", "tasks", "events"}
+	filtered := allowlist.filterStoreNames(names)
+
+	if got, want := filtered, []string{"tasks"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("filtered names = %v, want %v", got, want)
+	}
+	if got, want := names, []string{"notes", "tasks", "events"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Fatalf("input names mutated to %v, want %v", got, want)
+	}
+}
+
+type legacyOnlyIndexedDB struct {
+	inner indexeddb.IndexedDB
+}
+
+func (d *legacyOnlyIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	return d.inner.ObjectStore(name)
+}
+
+func (d *legacyOnlyIndexedDB) Transaction(ctx context.Context, stores []string, mode indexeddb.TransactionMode, opts indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+	return d.inner.Transaction(ctx, stores, mode, opts)
+}
+
+func (d *legacyOnlyIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	return d.inner.CreateObjectStore(ctx, name, schema)
+}
+
+func (d *legacyOnlyIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
+	return d.inner.DeleteObjectStore(ctx, name)
+}
+
+func (d *legacyOnlyIndexedDB) Ping(ctx context.Context) error { return d.inner.Ping(ctx) }
+
+func (d *legacyOnlyIndexedDB) Close() error { return d.inner.Close() }

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -2179,12 +2179,14 @@ func buildPluginIndexedDBHostServices(pluginName string, effective config.Effect
 		return nil, nil, err
 	}
 
+	registry := indexeddbservice.NewConnectionRegistry()
 	hostServices := []runtimehost.HostService{{
 		Name:   "indexeddb",
 		EnvVar: indexeddbservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, pluginName, indexeddbservice.ServerOptions{
-				AllowedStores: effective.ObjectStores,
+				AllowedStores:      effective.ObjectStores,
+				ConnectionRegistry: registry,
 			}))
 		},
 	}}
@@ -2299,12 +2301,14 @@ func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveH
 		return nil, nil, err
 	}
 
+	registry := indexeddbservice.NewConnectionRegistry()
 	hostServices := []runtimehost.HostService{{
 		Name:   "indexeddb",
 		EnvVar: indexeddbservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, name, indexeddbservice.ServerOptions{
-				AllowedStores: effective.ObjectStores,
+				AllowedStores:      effective.ObjectStores,
+				ConnectionRegistry: registry,
 			}))
 		},
 	}}
@@ -2323,12 +2327,14 @@ func buildAgentIndexedDBHostServices(name string, effective config.EffectiveHost
 		return nil, nil, err
 	}
 
+	registry := indexeddbservice.NewConnectionRegistry()
 	hostServices := []runtimehost.HostService{{
 		Name:   "indexeddb",
 		EnvVar: indexeddbservice.DefaultSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, indexeddbservice.NewServer(ds, name, indexeddbservice.ServerOptions{
-				AllowedStores: effective.ObjectStores,
+				AllowedStores:      effective.ObjectStores,
+				ConnectionRegistry: registry,
 			}))
 		},
 	}}

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -2,10 +2,13 @@ package coredata
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/services/observability/metricutil"
 	"github.com/valon-technologies/gestalt/server/services/runtimehost/runtimelogs"
 )
 
@@ -18,6 +21,21 @@ type Services struct {
 	DB                  indexeddb.IndexedDB
 }
 
+// SystemDatabaseName is the logical IndexedDB database that stores gestaltd
+// core object stores.
+const SystemDatabaseName = "gestalt"
+
+const systemDatabaseName = SystemDatabaseName
+
+var systemObjectStores = []struct {
+	name   string
+	schema indexeddb.ObjectStoreSchema
+}{
+	{name: StoreUsers, schema: UsersSchema},
+	{name: StoreAPITokens, schema: APITokensSchema},
+	{name: StoreManagedSubjects, schema: ManagedSubjectsSchema},
+}
+
 func New(ds indexeddb.IndexedDB) (*Services, error) {
 	return NewWithContext(context.Background(), ds)
 }
@@ -26,29 +44,713 @@ func NewWithContext(ctx context.Context, ds indexeddb.IndexedDB) (*Services, err
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if err := ds.CreateObjectStore(ctx, StoreUsers, UsersSchema); err != nil {
-		return nil, fmt.Errorf("create users store: %w", err)
-	}
-	if err := ds.CreateObjectStore(ctx, StoreAPITokens, APITokensSchema); err != nil {
-		return nil, fmt.Errorf("create api_tokens store: %w", err)
-	}
-	if err := ds.CreateObjectStore(ctx, StoreManagedSubjects, ManagedSubjectsSchema); err != nil {
-		return nil, fmt.Errorf("create managed_subjects store: %w", err)
+	db, err := prepareSystemDatabase(ctx, ds)
+	if err != nil {
+		return nil, err
 	}
 
 	runtimeSessionLogs := runtimelogs.NewMemoryStore()
 
-	users := NewUserService(ds)
-	apiTokens := NewAPITokenService(ds)
-	managedSubjects := NewManagedSubjectService(ds)
+	users := NewUserService(db)
+	apiTokens := NewAPITokenService(db)
+	managedSubjects := NewManagedSubjectService(db)
 	return &Services{
 		ExternalCredentials: nil,
 		Users:               users,
 		APITokens:           apiTokens,
 		ManagedSubjects:     managedSubjects,
 		RuntimeSessionLogs:  runtimeSessionLogs,
-		DB:                  ds,
+		DB:                  db,
 	}, nil
+}
+
+func prepareSystemDatabase(ctx context.Context, ds indexeddb.IndexedDB) (indexeddb.IndexedDB, error) {
+	factory, ok := metricutil.UnwrapIndexedDB(ds).(indexeddb.Factory)
+	if !ok || metricutil.IndexedDBName(ds) == "" {
+		for _, store := range systemObjectStores {
+			if err := ds.CreateObjectStore(ctx, store.name, store.schema); err != nil {
+				return nil, fmt.Errorf("create %s store: %w", store.name, err)
+			}
+		}
+		return ds, nil
+	}
+
+	db, err := openDatabaseWithObjectStores(ctx, factory, systemDatabaseName, systemObjectStores)
+	if err != nil {
+		return nil, err
+	}
+	return &databaseBackedIndexedDB{
+		root:         ds,
+		factory:      factory,
+		dbName:       systemDatabaseName,
+		db:           db,
+		metricDBName: metricutil.IndexedDBName(ds),
+	}, nil
+}
+
+func openDatabaseWithObjectStores(
+	ctx context.Context,
+	factory indexeddb.Factory,
+	name string,
+	stores []struct {
+		name   string
+		schema indexeddb.ObjectStoreSchema
+	},
+) (indexeddb.Database, error) {
+	db, err := factory.OpenCurrent(ctx, name, indexeddb.OpenOptions{})
+	if errors.Is(err, indexeddb.ErrNotFound) {
+		version := uint64(1)
+		return factory.Open(ctx, name, indexeddb.OpenOptions{
+			Version: &version,
+			Upgrade: func(ctx context.Context, upgrade indexeddb.UpgradeContext) error {
+				return createObjectStores(ctx, upgrade, stores)
+			},
+		})
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	names, err := db.ObjectStoreNames(ctx)
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	missing := missingObjectStores(names, stores)
+	if len(missing) == 0 {
+		return db, nil
+	}
+	version := db.Version() + 1
+	_ = db.Close()
+	return factory.Open(ctx, name, indexeddb.OpenOptions{
+		Version: &version,
+		Upgrade: func(ctx context.Context, upgrade indexeddb.UpgradeContext) error {
+			return createObjectStores(ctx, upgrade, missing)
+		},
+	})
+}
+
+func missingObjectStores(
+	names []string,
+	stores []struct {
+		name   string
+		schema indexeddb.ObjectStoreSchema
+	},
+) []struct {
+	name   string
+	schema indexeddb.ObjectStoreSchema
+} {
+	existing := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		existing[name] = struct{}{}
+	}
+	missing := make([]struct {
+		name   string
+		schema indexeddb.ObjectStoreSchema
+	}, 0, len(stores))
+	for _, store := range stores {
+		if _, ok := existing[store.name]; !ok {
+			missing = append(missing, store)
+		}
+	}
+	return missing
+}
+
+func createObjectStores(
+	ctx context.Context,
+	upgrade interface {
+		CreateObjectStore(context.Context, string, indexeddb.ObjectStoreSchema) error
+	},
+	stores []struct {
+		name   string
+		schema indexeddb.ObjectStoreSchema
+	},
+) error {
+	for _, store := range stores {
+		if err := upgrade.CreateObjectStore(ctx, store.name, store.schema); err != nil && !errors.Is(err, indexeddb.ErrAlreadyExists) {
+			return fmt.Errorf("create %s store: %w", store.name, err)
+		}
+	}
+	return nil
+}
+
+type databaseBackedIndexedDB struct {
+	mu           sync.RWMutex
+	root         indexeddb.IndexedDB
+	factory      indexeddb.Factory
+	dbName       string
+	db           indexeddb.Database
+	metricDBName string
+}
+
+func (d *databaseBackedIndexedDB) currentFactory() (indexeddb.Factory, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.root == nil || d.factory == nil {
+		return nil, indexeddb.ErrNotFound
+	}
+	return d.factory, nil
+}
+
+func (d *databaseBackedIndexedDB) Open(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error) {
+	factory, err := d.currentFactory()
+	if err != nil {
+		return nil, err
+	}
+	return factory.Open(ctx, name, opts)
+}
+
+func (d *databaseBackedIndexedDB) OpenCurrent(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error) {
+	factory, err := d.currentFactory()
+	if err != nil {
+		return nil, err
+	}
+	return factory.OpenCurrent(ctx, name, opts)
+}
+
+func (d *databaseBackedIndexedDB) DeleteDatabase(ctx context.Context, name string, opts indexeddb.DeleteOptions) (indexeddb.DeleteDatabaseResult, error) {
+	factory, err := d.currentFactory()
+	if err != nil {
+		return indexeddb.DeleteDatabaseResult{Name: name}, err
+	}
+	return factory.DeleteDatabase(ctx, name, opts)
+}
+
+func (d *databaseBackedIndexedDB) Databases(ctx context.Context) ([]indexeddb.DatabaseInfo, error) {
+	factory, err := d.currentFactory()
+	if err != nil {
+		return nil, err
+	}
+	return factory.Databases(ctx)
+}
+
+func (d *databaseBackedIndexedDB) CompareKeys(first any, second any) (int, error) {
+	factory, err := d.currentFactory()
+	if err != nil {
+		return 0, err
+	}
+	return factory.CompareKeys(first, second)
+}
+
+func (d *databaseBackedIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	store := databaseBackedObjectStore{db: d, name: name}
+	if d.metricDBName == "" {
+		return store
+	}
+	return metricutil.InstrumentObjectStore(store, metricutil.IndexedDBMetricLabels{
+		DB:          d.metricDBName,
+		ObjectStore: name,
+	})
+}
+
+func (d *databaseBackedIndexedDB) Transaction(ctx context.Context, stores []string, mode indexeddb.TransactionMode, opts indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+	d.mu.RLock()
+	db := d.db
+	if db == nil {
+		d.mu.RUnlock()
+		return nil, indexeddb.ErrNotFound
+	}
+	tx, err := db.Transaction(ctx, stores, mode, opts)
+	if err != nil {
+		d.mu.RUnlock()
+		return nil, err
+	}
+	wrapped := &databaseBackedTransaction{inner: tx, release: d.mu.RUnlock}
+	if d.metricDBName == "" {
+		return wrapped, nil
+	}
+	return metricutil.InstrumentTransaction(wrapped, d.metricDBName), nil
+}
+
+func (d *databaseBackedIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	return d.upgrade(ctx, func(ctx context.Context, upgrade indexeddb.UpgradeContext) error {
+		if err := upgrade.CreateObjectStore(ctx, name, schema); err != nil && !errors.Is(err, indexeddb.ErrAlreadyExists) {
+			return err
+		}
+		return nil
+	})
+}
+
+func (d *databaseBackedIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
+	return d.upgrade(ctx, func(ctx context.Context, upgrade indexeddb.UpgradeContext) error {
+		return upgrade.DeleteObjectStore(ctx, name)
+	})
+}
+
+func (d *databaseBackedIndexedDB) Ping(ctx context.Context) error {
+	d.mu.RLock()
+	root := d.root
+	if root == nil {
+		d.mu.RUnlock()
+		return indexeddb.ErrNotFound
+	}
+	defer d.mu.RUnlock()
+	return root.Ping(ctx)
+}
+
+func (d *databaseBackedIndexedDB) Close() error {
+	d.mu.Lock()
+	db := d.db
+	root := d.root
+	d.db = nil
+	d.root = nil
+	d.mu.Unlock()
+	var errs []error
+	if db != nil {
+		errs = append(errs, db.Close())
+	}
+	if root != nil {
+		errs = append(errs, root.Close())
+	}
+	return errors.Join(errs...)
+}
+
+func (d *databaseBackedIndexedDB) upgrade(ctx context.Context, fn func(context.Context, indexeddb.UpgradeContext) error) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.db == nil {
+		return indexeddb.ErrNotFound
+	}
+	version := d.db.Version() + 1
+	_ = d.db.Close()
+	d.db = nil
+	db, err := d.factory.Open(ctx, d.dbName, indexeddb.OpenOptions{
+		Version: &version,
+		Upgrade: fn,
+	})
+	if err != nil {
+		current, currentErr := d.factory.OpenCurrent(ctx, d.dbName, indexeddb.OpenOptions{})
+		if currentErr == nil {
+			d.db = current
+		}
+		return err
+	}
+	d.db = db
+	return nil
+}
+
+type databaseBackedObjectStore struct {
+	db   *databaseBackedIndexedDB
+	name string
+}
+
+func (s databaseBackedObjectStore) current() (indexeddb.ObjectStore, func(), error) {
+	s.db.mu.RLock()
+	db := s.db.db
+	if db == nil {
+		s.db.mu.RUnlock()
+		return nil, nil, indexeddb.ErrNotFound
+	}
+	store := db.ObjectStore(s.name)
+	if store == nil {
+		s.db.mu.RUnlock()
+		return nil, nil, indexeddb.ErrNotFound
+	}
+	return store, s.db.mu.RUnlock, nil
+}
+
+func (s databaseBackedObjectStore) Get(ctx context.Context, id string) (indexeddb.Record, error) {
+	store, release, err := s.current()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return store.Get(ctx, id)
+}
+
+func (s databaseBackedObjectStore) GetKey(ctx context.Context, id string) (string, error) {
+	store, release, err := s.current()
+	if err != nil {
+		return "", err
+	}
+	defer release()
+	return store.GetKey(ctx, id)
+}
+
+func (s databaseBackedObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
+	store, release, err := s.current()
+	if err != nil {
+		return err
+	}
+	defer release()
+	return store.Add(ctx, record)
+}
+
+func (s databaseBackedObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
+	store, release, err := s.current()
+	if err != nil {
+		return err
+	}
+	defer release()
+	return store.Put(ctx, record)
+}
+
+func (s databaseBackedObjectStore) Delete(ctx context.Context, id string) error {
+	store, release, err := s.current()
+	if err != nil {
+		return err
+	}
+	defer release()
+	return store.Delete(ctx, id)
+}
+
+func (s databaseBackedObjectStore) Clear(ctx context.Context) error {
+	store, release, err := s.current()
+	if err != nil {
+		return err
+	}
+	defer release()
+	return store.Clear(ctx)
+}
+
+func (s databaseBackedObjectStore) GetAll(ctx context.Context, r *indexeddb.KeyRange) ([]indexeddb.Record, error) {
+	store, release, err := s.current()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return store.GetAll(ctx, r)
+}
+
+func (s databaseBackedObjectStore) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange) ([]string, error) {
+	store, release, err := s.current()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return store.GetAllKeys(ctx, r)
+}
+
+func (s databaseBackedObjectStore) Count(ctx context.Context, r *indexeddb.KeyRange) (int64, error) {
+	store, release, err := s.current()
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+	return store.Count(ctx, r)
+}
+
+func (s databaseBackedObjectStore) DeleteRange(ctx context.Context, r indexeddb.KeyRange) (int64, error) {
+	store, release, err := s.current()
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+	return store.DeleteRange(ctx, r)
+}
+
+func (s databaseBackedObjectStore) Index(name string) indexeddb.Index {
+	return databaseBackedIndex{db: s.db, storeName: s.name, name: name}
+}
+
+func (s databaseBackedObjectStore) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	store, release, err := s.current()
+	if err != nil {
+		return nil, err
+	}
+	cursor, err := store.OpenCursor(ctx, r, dir)
+	if err != nil || cursor == nil {
+		release()
+		return cursor, err
+	}
+	return &databaseBackedCursor{inner: cursor, release: release}, nil
+}
+
+func (s databaseBackedObjectStore) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	store, release, err := s.current()
+	if err != nil {
+		return nil, err
+	}
+	cursor, err := store.OpenKeyCursor(ctx, r, dir)
+	if err != nil || cursor == nil {
+		release()
+		return cursor, err
+	}
+	return &databaseBackedCursor{inner: cursor, release: release}, nil
+}
+
+type databaseBackedIndex struct {
+	db        *databaseBackedIndexedDB
+	storeName string
+	name      string
+}
+
+func (i databaseBackedIndex) current() (indexeddb.Index, func(), error) {
+	i.db.mu.RLock()
+	db := i.db.db
+	if db == nil {
+		i.db.mu.RUnlock()
+		return nil, nil, indexeddb.ErrNotFound
+	}
+	store := db.ObjectStore(i.storeName)
+	if store == nil {
+		i.db.mu.RUnlock()
+		return nil, nil, indexeddb.ErrNotFound
+	}
+	index := store.Index(i.name)
+	if index == nil {
+		i.db.mu.RUnlock()
+		return nil, nil, indexeddb.ErrNotFound
+	}
+	return index, i.db.mu.RUnlock, nil
+}
+
+func (i databaseBackedIndex) Get(ctx context.Context, values ...any) (indexeddb.Record, error) {
+	index, release, err := i.current()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return index.Get(ctx, values...)
+}
+
+func (i databaseBackedIndex) GetKey(ctx context.Context, values ...any) (string, error) {
+	index, release, err := i.current()
+	if err != nil {
+		return "", err
+	}
+	defer release()
+	return index.GetKey(ctx, values...)
+}
+
+func (i databaseBackedIndex) GetAll(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]indexeddb.Record, error) {
+	index, release, err := i.current()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return index.GetAll(ctx, r, values...)
+}
+
+func (i databaseBackedIndex) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]string, error) {
+	index, release, err := i.current()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return index.GetAllKeys(ctx, r, values...)
+}
+
+func (i databaseBackedIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
+	index, release, err := i.current()
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+	return index.Count(ctx, r, values...)
+}
+
+func (i databaseBackedIndex) Delete(ctx context.Context, values ...any) (int64, error) {
+	index, release, err := i.current()
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+	return index.Delete(ctx, values...)
+}
+
+func (i databaseBackedIndex) DeleteRange(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
+	index, release, err := i.current()
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+	return index.DeleteRange(ctx, r, values...)
+}
+
+func (i databaseBackedIndex) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
+	index, release, err := i.current()
+	if err != nil {
+		return nil, err
+	}
+	cursor, err := index.OpenCursor(ctx, r, dir, values...)
+	if err != nil || cursor == nil {
+		release()
+		return cursor, err
+	}
+	return &databaseBackedCursor{inner: cursor, release: release}, nil
+}
+
+func (i databaseBackedIndex) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
+	index, release, err := i.current()
+	if err != nil {
+		return nil, err
+	}
+	cursor, err := index.OpenKeyCursor(ctx, r, dir, values...)
+	if err != nil || cursor == nil {
+		release()
+		return cursor, err
+	}
+	return &databaseBackedCursor{inner: cursor, release: release}, nil
+}
+
+type databaseBackedTransaction struct {
+	inner   indexeddb.Transaction
+	release func()
+	once    sync.Once
+}
+
+func (tx *databaseBackedTransaction) ObjectStore(name string) indexeddb.TransactionObjectStore {
+	return tx.inner.ObjectStore(name)
+}
+
+func (tx *databaseBackedTransaction) Commit(ctx context.Context) error {
+	err := tx.inner.Commit(ctx)
+	tx.once.Do(tx.release)
+	return err
+}
+
+func (tx *databaseBackedTransaction) Abort(ctx context.Context) error {
+	err := tx.inner.Abort(ctx)
+	tx.once.Do(tx.release)
+	return err
+}
+
+type databaseBackedCursor struct {
+	inner    indexeddb.Cursor
+	release  func()
+	once     sync.Once
+	closeErr error
+}
+
+func (c *databaseBackedCursor) Continue() bool {
+	return c.inner.Continue()
+}
+
+func (c *databaseBackedCursor) ContinueToKey(key any) bool {
+	return c.inner.ContinueToKey(key)
+}
+
+func (c *databaseBackedCursor) Advance(count int) bool {
+	return c.inner.Advance(count)
+}
+
+func (c *databaseBackedCursor) Key() any {
+	return c.inner.Key()
+}
+
+func (c *databaseBackedCursor) PrimaryKey() string {
+	return c.inner.PrimaryKey()
+}
+
+func (c *databaseBackedCursor) Value() (indexeddb.Record, error) {
+	return c.inner.Value()
+}
+
+func (c *databaseBackedCursor) Delete() error {
+	return c.inner.Delete()
+}
+
+func (c *databaseBackedCursor) Update(value indexeddb.Record) error {
+	return c.inner.Update(value)
+}
+
+func (c *databaseBackedCursor) Err() error {
+	return c.inner.Err()
+}
+
+func (c *databaseBackedCursor) Close() error {
+	c.once.Do(func() {
+		c.closeErr = c.inner.Close()
+		c.release()
+	})
+	return c.closeErr
+}
+
+type errObjectStore struct {
+	err error
+}
+
+func (s errObjectStore) Get(context.Context, string) (indexeddb.Record, error) {
+	return nil, s.err
+}
+
+func (s errObjectStore) GetKey(context.Context, string) (string, error) {
+	return "", s.err
+}
+
+func (s errObjectStore) Add(context.Context, indexeddb.Record) error {
+	return s.err
+}
+
+func (s errObjectStore) Put(context.Context, indexeddb.Record) error {
+	return s.err
+}
+
+func (s errObjectStore) Delete(context.Context, string) error {
+	return s.err
+}
+
+func (s errObjectStore) Clear(context.Context) error {
+	return s.err
+}
+
+func (s errObjectStore) GetAll(context.Context, *indexeddb.KeyRange) ([]indexeddb.Record, error) {
+	return nil, s.err
+}
+
+func (s errObjectStore) GetAllKeys(context.Context, *indexeddb.KeyRange) ([]string, error) {
+	return nil, s.err
+}
+
+func (s errObjectStore) Count(context.Context, *indexeddb.KeyRange) (int64, error) {
+	return 0, s.err
+}
+
+func (s errObjectStore) DeleteRange(context.Context, indexeddb.KeyRange) (int64, error) {
+	return 0, s.err
+}
+
+func (s errObjectStore) Index(string) indexeddb.Index {
+	return errIndex(s)
+}
+
+func (s errObjectStore) OpenCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return nil, s.err
+}
+
+func (s errObjectStore) OpenKeyCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return nil, s.err
+}
+
+type errIndex struct {
+	err error
+}
+
+func (i errIndex) Get(context.Context, ...any) (indexeddb.Record, error) {
+	return nil, i.err
+}
+
+func (i errIndex) GetKey(context.Context, ...any) (string, error) {
+	return "", i.err
+}
+
+func (i errIndex) GetAll(context.Context, *indexeddb.KeyRange, ...any) ([]indexeddb.Record, error) {
+	return nil, i.err
+}
+
+func (i errIndex) GetAllKeys(context.Context, *indexeddb.KeyRange, ...any) ([]string, error) {
+	return nil, i.err
+}
+
+func (i errIndex) Count(context.Context, *indexeddb.KeyRange, ...any) (int64, error) {
+	return 0, i.err
+}
+
+func (i errIndex) Delete(context.Context, ...any) (int64, error) {
+	return 0, i.err
+}
+
+func (i errIndex) DeleteRange(context.Context, *indexeddb.KeyRange, ...any) (int64, error) {
+	return 0, i.err
+}
+
+func (i errIndex) OpenCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection, ...any) (indexeddb.Cursor, error) {
+	return nil, i.err
+}
+
+func (i errIndex) OpenKeyCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection, ...any) (indexeddb.Cursor, error) {
+	return nil, i.err
 }
 
 func (s *Services) Ping(ctx context.Context) error {

--- a/gestaltd/internal/coredata/services_internal_test.go
+++ b/gestaltd/internal/coredata/services_internal_test.go
@@ -1,0 +1,338 @@
+package coredata
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+func TestDatabaseBackedIndexedDBClearsClosedHandleWhenUpgradeRecoveryFails(t *testing.T) {
+	t.Parallel()
+
+	upgradeErr := errors.New("upgrade failed")
+	recoveryErr := errors.New("recovery failed")
+	db := &failingUpgradeDatabase{version: 3}
+	adapter := &databaseBackedIndexedDB{
+		factory: &failingUpgradeFactory{
+			openErr:        upgradeErr,
+			openCurrentErr: recoveryErr,
+		},
+		dbName: "gestalt",
+		db:     db,
+	}
+
+	err := adapter.CreateObjectStore(context.Background(), "sessions", indexeddb.ObjectStoreSchema{})
+	if !errors.Is(err, upgradeErr) {
+		t.Fatalf("CreateObjectStore error = %v, want %v", err, upgradeErr)
+	}
+	if !db.closed {
+		t.Fatal("previous database handle was not closed")
+	}
+	if adapter.db != nil {
+		t.Fatalf("database handle after failed recovery = %#v, want nil", adapter.db)
+	}
+	if _, err := adapter.ObjectStore("sessions").Get(context.Background(), "session-1"); !errors.Is(err, indexeddb.ErrNotFound) {
+		t.Fatalf("ObjectStore after failed recovery error = %v, want ErrNotFound", err)
+	}
+	if _, err := adapter.Transaction(context.Background(), []string{"sessions"}, indexeddb.TransactionReadonly, indexeddb.TransactionOptions{}); !errors.Is(err, indexeddb.ErrNotFound) {
+		t.Fatalf("Transaction after failed recovery error = %v, want ErrNotFound", err)
+	}
+	if err := adapter.CreateObjectStore(context.Background(), "sessions", indexeddb.ObjectStoreSchema{}); !errors.Is(err, indexeddb.ErrNotFound) {
+		t.Fatalf("CreateObjectStore after failed recovery error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDatabaseBackedIndexedDBCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	root := &closeCountingIndexedDB{}
+	db := &failingUpgradeDatabase{version: 1}
+	adapter := &databaseBackedIndexedDB{
+		root: root,
+		db:   db,
+	}
+
+	if err := adapter.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := adapter.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if root.closeCount != 1 {
+		t.Fatalf("root Close count = %d, want 1", root.closeCount)
+	}
+	if db.closeCount != 1 {
+		t.Fatalf("database Close count = %d, want 1", db.closeCount)
+	}
+	if err := adapter.Ping(context.Background()); !errors.Is(err, indexeddb.ErrNotFound) {
+		t.Fatalf("Ping after Close error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDatabaseBackedIndexedDBObjectStoreBlocksConcurrentUpgrade(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := &blockingObjectStore{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	oldDB := newObservableDatabase(1)
+	oldDB.store = store
+	adapter := &databaseBackedIndexedDB{
+		factory: &replacementFactory{db: newObservableDatabase(2)},
+		dbName:  "gestalt",
+		db:      oldDB,
+	}
+
+	getDone := make(chan error, 1)
+	go func() {
+		_, err := adapter.ObjectStore("sessions").Get(ctx, "session-1")
+		getDone <- err
+	}()
+	<-store.started
+
+	upgradeDone := make(chan error, 1)
+	go func() {
+		upgradeDone <- adapter.CreateObjectStore(ctx, "sessions", indexeddb.ObjectStoreSchema{})
+	}()
+
+	assertNotClosedSoon(t, oldDB.closed, "old database was closed while object-store operation was still running")
+	close(store.release)
+	if err := <-getDone; err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	select {
+	case err := <-upgradeDone:
+		if err != nil {
+			t.Fatalf("CreateObjectStore: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CreateObjectStore did not complete after object-store operation finished")
+	}
+	select {
+	case <-oldDB.closed:
+	case <-time.After(time.Second):
+		t.Fatal("old database was not closed during upgrade")
+	}
+}
+
+func TestDatabaseBackedIndexedDBTransactionBlocksConcurrentUpgrade(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	oldDB := newObservableDatabase(1)
+	oldDB.tx = &blockingTransaction{}
+	adapter := &databaseBackedIndexedDB{
+		factory: &replacementFactory{db: newObservableDatabase(2)},
+		dbName:  "gestalt",
+		db:      oldDB,
+	}
+
+	tx, err := adapter.Transaction(ctx, []string{"sessions"}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		t.Fatalf("Transaction: %v", err)
+	}
+
+	upgradeDone := make(chan error, 1)
+	go func() {
+		upgradeDone <- adapter.CreateObjectStore(ctx, "sessions", indexeddb.ObjectStoreSchema{})
+	}()
+
+	assertNotClosedSoon(t, oldDB.closed, "old database was closed while transaction was still running")
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	select {
+	case err := <-upgradeDone:
+		if err != nil {
+			t.Fatalf("CreateObjectStore: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CreateObjectStore did not complete after transaction committed")
+	}
+	select {
+	case <-oldDB.closed:
+	case <-time.After(time.Second):
+		t.Fatal("old database was not closed during upgrade")
+	}
+}
+
+func assertNotClosedSoon(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal(message)
+	case <-time.After(25 * time.Millisecond):
+	}
+}
+
+type failingUpgradeFactory struct {
+	openErr        error
+	openCurrentErr error
+}
+
+func (f *failingUpgradeFactory) Open(context.Context, string, indexeddb.OpenOptions) (indexeddb.Database, error) {
+	return nil, f.openErr
+}
+
+func (f *failingUpgradeFactory) OpenCurrent(context.Context, string, indexeddb.OpenOptions) (indexeddb.Database, error) {
+	return nil, f.openCurrentErr
+}
+
+func (f *failingUpgradeFactory) DeleteDatabase(context.Context, string, indexeddb.DeleteOptions) (indexeddb.DeleteDatabaseResult, error) {
+	return indexeddb.DeleteDatabaseResult{}, nil
+}
+
+func (f *failingUpgradeFactory) Databases(context.Context) ([]indexeddb.DatabaseInfo, error) {
+	return nil, nil
+}
+
+func (f *failingUpgradeFactory) CompareKeys(any, any) (int, error) { return 0, nil }
+
+func (f *failingUpgradeFactory) Close() error { return nil }
+
+type failingUpgradeDatabase struct {
+	version    uint64
+	closed     bool
+	closeCount int
+}
+
+func (d *failingUpgradeDatabase) Name() string { return "gestalt" }
+
+func (d *failingUpgradeDatabase) Version() uint64 { return d.version }
+
+func (d *failingUpgradeDatabase) ObjectStoreNames(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (d *failingUpgradeDatabase) ObjectStore(string) indexeddb.ObjectStore { return nil }
+
+func (d *failingUpgradeDatabase) Transaction(context.Context, []string, indexeddb.TransactionMode, indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+func (d *failingUpgradeDatabase) Close() error {
+	d.closed = true
+	d.closeCount++
+	return nil
+}
+
+type closeCountingIndexedDB struct {
+	closeCount int
+}
+
+func (d *closeCountingIndexedDB) ObjectStore(string) indexeddb.ObjectStore { return nil }
+
+func (d *closeCountingIndexedDB) Transaction(context.Context, []string, indexeddb.TransactionMode, indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+func (d *closeCountingIndexedDB) CreateObjectStore(context.Context, string, indexeddb.ObjectStoreSchema) error {
+	return nil
+}
+
+func (d *closeCountingIndexedDB) DeleteObjectStore(context.Context, string) error {
+	return nil
+}
+
+func (d *closeCountingIndexedDB) Ping(context.Context) error { return nil }
+
+func (d *closeCountingIndexedDB) Close() error {
+	d.closeCount++
+	return nil
+}
+
+type replacementFactory struct {
+	db indexeddb.Database
+}
+
+func (f *replacementFactory) Open(context.Context, string, indexeddb.OpenOptions) (indexeddb.Database, error) {
+	return f.db, nil
+}
+
+func (f *replacementFactory) OpenCurrent(context.Context, string, indexeddb.OpenOptions) (indexeddb.Database, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+func (f *replacementFactory) DeleteDatabase(context.Context, string, indexeddb.DeleteOptions) (indexeddb.DeleteDatabaseResult, error) {
+	return indexeddb.DeleteDatabaseResult{}, nil
+}
+
+func (f *replacementFactory) Databases(context.Context) ([]indexeddb.DatabaseInfo, error) {
+	return nil, nil
+}
+
+func (f *replacementFactory) CompareKeys(any, any) (int, error) { return 0, nil }
+
+func (f *replacementFactory) Close() error { return nil }
+
+type observableDatabase struct {
+	version uint64
+	store   indexeddb.ObjectStore
+	tx      indexeddb.Transaction
+	closed  chan struct{}
+	once    sync.Once
+}
+
+func newObservableDatabase(version uint64) *observableDatabase {
+	return &observableDatabase{
+		version: version,
+		closed:  make(chan struct{}),
+	}
+}
+
+func (d *observableDatabase) Name() string { return "gestalt" }
+
+func (d *observableDatabase) Version() uint64 { return d.version }
+
+func (d *observableDatabase) ObjectStoreNames(context.Context) ([]string, error) {
+	return []string{"sessions"}, nil
+}
+
+func (d *observableDatabase) ObjectStore(string) indexeddb.ObjectStore { return d.store }
+
+func (d *observableDatabase) Transaction(context.Context, []string, indexeddb.TransactionMode, indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
+	if d.tx == nil {
+		return nil, indexeddb.ErrNotFound
+	}
+	return d.tx, nil
+}
+
+func (d *observableDatabase) Close() error {
+	d.once.Do(func() {
+		close(d.closed)
+	})
+	return nil
+}
+
+type blockingObjectStore struct {
+	errObjectStore
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingObjectStore) Get(_ context.Context, id string) (indexeddb.Record, error) {
+	s.once.Do(func() {
+		close(s.started)
+	})
+	<-s.release
+	return indexeddb.Record{"id": id}, nil
+}
+
+type blockingTransaction struct{}
+
+func (tx *blockingTransaction) ObjectStore(string) indexeddb.TransactionObjectStore { return nil }
+
+func (tx *blockingTransaction) Commit(context.Context) error { return tx.finish() }
+
+func (tx *blockingTransaction) Abort(context.Context) error { return tx.finish() }
+
+func (tx *blockingTransaction) finish() error {
+	return nil
+}

--- a/gestaltd/services/observability/metricutil/indexeddb.go
+++ b/gestaltd/services/observability/metricutil/indexeddb.go
@@ -41,6 +41,11 @@ func InstrumentObjectStore(store indexeddb.ObjectStore, labels IndexedDBMetricLa
 	return &instrumentedObjectStore{inner: store, labels: labels}
 }
 
+// InstrumentTransaction wraps a Transaction to record metrics for transaction-scoped operations.
+func InstrumentTransaction(tx indexeddb.Transaction, dbName string) indexeddb.Transaction {
+	return &instrumentedTransaction{inner: tx, db: dbName}
+}
+
 func (d *instrumentedIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
 	return InstrumentObjectStore(d.inner.ObjectStore(name), IndexedDBMetricLabels{
 		DB:          d.db,
@@ -49,7 +54,11 @@ func (d *instrumentedIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
 }
 
 func (d *instrumentedIndexedDB) Transaction(ctx context.Context, stores []string, mode indexeddb.TransactionMode, opts indexeddb.TransactionOptions) (indexeddb.Transaction, error) {
-	return d.inner.Transaction(ctx, stores, mode, opts)
+	tx, err := d.inner.Transaction(ctx, stores, mode, opts)
+	if err != nil {
+		return nil, err
+	}
+	return InstrumentTransaction(tx, d.db), nil
 }
 
 func (d *instrumentedIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
@@ -229,4 +238,162 @@ func (i *instrumentedIndex) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyR
 	c, err := i.inner.OpenKeyCursor(ctx, r, dir, values...)
 	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.OpenKeyCursor", err)
 	return c, err
+}
+
+type instrumentedTransaction struct {
+	inner indexeddb.Transaction
+	db    string
+}
+
+func (tx *instrumentedTransaction) ObjectStore(name string) indexeddb.TransactionObjectStore {
+	return &instrumentedTransactionObjectStore{
+		inner: tx.inner.ObjectStore(name),
+		labels: IndexedDBMetricLabels{
+			DB:          tx.db,
+			ObjectStore: name,
+		},
+	}
+}
+
+func (tx *instrumentedTransaction) Commit(ctx context.Context) error {
+	return tx.inner.Commit(ctx)
+}
+
+func (tx *instrumentedTransaction) Abort(ctx context.Context) error {
+	return tx.inner.Abort(ctx)
+}
+
+type instrumentedTransactionObjectStore struct {
+	inner  indexeddb.TransactionObjectStore
+	labels IndexedDBMetricLabels
+}
+
+func (s *instrumentedTransactionObjectStore) Get(ctx context.Context, id string) (indexeddb.Record, error) {
+	startedAt := time.Now()
+	rec, err := s.inner.Get(ctx, id)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Get", err)
+	return rec, err
+}
+
+func (s *instrumentedTransactionObjectStore) GetKey(ctx context.Context, id string) (string, error) {
+	startedAt := time.Now()
+	key, err := s.inner.GetKey(ctx, id)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "GetKey", err)
+	return key, err
+}
+
+func (s *instrumentedTransactionObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
+	startedAt := time.Now()
+	err := s.inner.Add(ctx, record)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Add", err)
+	return err
+}
+
+func (s *instrumentedTransactionObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
+	startedAt := time.Now()
+	err := s.inner.Put(ctx, record)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Put", err)
+	return err
+}
+
+func (s *instrumentedTransactionObjectStore) Delete(ctx context.Context, id string) error {
+	startedAt := time.Now()
+	err := s.inner.Delete(ctx, id)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Delete", err)
+	return err
+}
+
+func (s *instrumentedTransactionObjectStore) Clear(ctx context.Context) error {
+	startedAt := time.Now()
+	err := s.inner.Clear(ctx)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Clear", err)
+	return err
+}
+
+func (s *instrumentedTransactionObjectStore) GetAll(ctx context.Context, r *indexeddb.KeyRange) ([]indexeddb.Record, error) {
+	startedAt := time.Now()
+	recs, err := s.inner.GetAll(ctx, r)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "GetAll", err)
+	return recs, err
+}
+
+func (s *instrumentedTransactionObjectStore) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange) ([]string, error) {
+	startedAt := time.Now()
+	keys, err := s.inner.GetAllKeys(ctx, r)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "GetAllKeys", err)
+	return keys, err
+}
+
+func (s *instrumentedTransactionObjectStore) Count(ctx context.Context, r *indexeddb.KeyRange) (int64, error) {
+	startedAt := time.Now()
+	n, err := s.inner.Count(ctx, r)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "Count", err)
+	return n, err
+}
+
+func (s *instrumentedTransactionObjectStore) DeleteRange(ctx context.Context, r indexeddb.KeyRange) (int64, error) {
+	startedAt := time.Now()
+	n, err := s.inner.DeleteRange(ctx, r)
+	RecordIndexedDBOperation(ctx, startedAt, s.labels, "DeleteRange", err)
+	return n, err
+}
+
+func (s *instrumentedTransactionObjectStore) Index(name string) indexeddb.TransactionIndex {
+	labels := s.labels
+	labels.IndexName = name
+	return &instrumentedTransactionIndex{inner: s.inner.Index(name), labels: labels}
+}
+
+type instrumentedTransactionIndex struct {
+	inner  indexeddb.TransactionIndex
+	labels IndexedDBMetricLabels
+}
+
+func (i *instrumentedTransactionIndex) Get(ctx context.Context, values ...any) (indexeddb.Record, error) {
+	startedAt := time.Now()
+	rec, err := i.inner.Get(ctx, values...)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.Get", err)
+	return rec, err
+}
+
+func (i *instrumentedTransactionIndex) GetKey(ctx context.Context, values ...any) (string, error) {
+	startedAt := time.Now()
+	key, err := i.inner.GetKey(ctx, values...)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.GetKey", err)
+	return key, err
+}
+
+func (i *instrumentedTransactionIndex) GetAll(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]indexeddb.Record, error) {
+	startedAt := time.Now()
+	recs, err := i.inner.GetAll(ctx, r, values...)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.GetAll", err)
+	return recs, err
+}
+
+func (i *instrumentedTransactionIndex) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]string, error) {
+	startedAt := time.Now()
+	keys, err := i.inner.GetAllKeys(ctx, r, values...)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.GetAllKeys", err)
+	return keys, err
+}
+
+func (i *instrumentedTransactionIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
+	startedAt := time.Now()
+	n, err := i.inner.Count(ctx, r, values...)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.Count", err)
+	return n, err
+}
+
+func (i *instrumentedTransactionIndex) Delete(ctx context.Context, values ...any) (int64, error) {
+	startedAt := time.Now()
+	n, err := i.inner.Delete(ctx, values...)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.Delete", err)
+	return n, err
+}
+
+func (i *instrumentedTransactionIndex) DeleteRange(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
+	startedAt := time.Now()
+	n, err := i.inner.DeleteRange(ctx, r, values...)
+	RecordIndexedDBOperation(ctx, startedAt, i.labels, "Index.DeleteRange", err)
+	return n, err
 }

--- a/gestaltd/services/observability/metricutil/indexeddb_test.go
+++ b/gestaltd/services/observability/metricutil/indexeddb_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 )
@@ -44,4 +45,47 @@ func TestInstrumentIndexedDBRecordsDBAndObjectStoreAttributes(t *testing.T) {
 	metrictest.RequireNoMetric(t, rm, "gestaltd.indexeddb.count")
 	metrictest.RequireNoMetric(t, rm, "gestaltd.indexeddb.error_count")
 	metrictest.RequireNoMetric(t, rm, "gestaltd.indexeddb.duration")
+}
+
+func TestInstrumentIndexedDBRecordsTransactionScopedOperations(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := WithMeterProvider(context.Background(), metrics.Provider)
+
+	db := InstrumentIndexedDB(&coretesting.StubIndexedDB{}, "system")
+	if err := db.CreateObjectStore(ctx, "users", indexeddb.ObjectStoreSchema{
+		Indexes: []indexeddb.IndexSchema{{Name: "by_email", KeyPath: []string{"email"}}},
+	}); err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+	tx, err := db.Transaction(ctx, []string{"users"}, indexeddb.TransactionReadwrite, indexeddb.TransactionOptions{})
+	if err != nil {
+		t.Fatalf("Transaction: %v", err)
+	}
+	txStore := tx.ObjectStore("users")
+	if err := txStore.Put(ctx, indexeddb.Record{"id": "user-1", "email": "user@example.com"}); err != nil {
+		t.Fatalf("transaction Put: %v", err)
+	}
+	if _, err := txStore.Index("by_email").Get(ctx, "user@example.com"); err != nil {
+		t.Fatalf("transaction index Get: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	metrictest.RequireFloat64Histogram(t, rm, "db.client.operation.duration", map[string]string{
+		"db.system.name":     "gestaltd.indexeddb",
+		"db.namespace":       "system",
+		"db.collection.name": "users",
+		"db.operation.name":  "put",
+	})
+	metrictest.RequireFloat64Histogram(t, rm, "db.client.operation.duration", map[string]string{
+		"db.system.name":                "gestaltd.indexeddb",
+		"db.namespace":                  "system",
+		"db.collection.name":            "users",
+		"db.operation.name":             "index_get",
+		"gestaltd.indexeddb.index.name": "by_email",
+	})
 }


### PR DESCRIPTION
## Summary

This PR stacks on #2061 and wires the new IndexedDB factory lifecycle into the system database/bootstrap path without bypassing the opened `gestalt` database handle.

It:

- Opens and prepares coredata stores through a named system database, currently `gestalt`.
- Routes the selected host IndexedDB service through the opened `svc.DB` wrapper, so legacy store operations and core services share the same database namespace.
- Adds a factory-aware store allowlist wrapper that only satisfies `indexeddb.Factory` when the wrapped provider already does.
- Adds shared connection registries to host services so factory lifecycle RPCs observe consistent connection state.
- Restricts store-scoped bindings such as external credentials to the system database and blocks destructive database deletion when store allowlists are active.
- Extends metrics wrapping to database-backed stores and transactions.

## Split Notes

This is the system-database/bootstrap slice from the former mega PR. It depends on #2061 for the `indexeddb.Factory` core interfaces and RPC surface, but does not depend on the agent/workflow or Python lockfile PRs.

## Internal Interfaces

The coredata wrapper now preserves an opened system database handle while still delegating factory lifecycle operations to the root provider:

```diff
 type databaseBackedIndexedDB struct {
     root indexeddb.IndexedDB
+    factory indexeddb.Factory
+    dbName string
+    db indexeddb.Database
 }
```

Legacy store-scoped operations route through the opened database handle:

```go
func (d *databaseBackedIndexedDB) ObjectStore(name string) indexeddb.ObjectStore
func (d *databaseBackedIndexedDB) Transaction(
    ctx context.Context,
    stores []string,
    mode indexeddb.TransactionMode,
    opts indexeddb.TransactionOptions,
) (indexeddb.Transaction, error)
func (d *databaseBackedIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error
func (d *databaseBackedIndexedDB) DeleteObjectStore(ctx context.Context, name string) error
```

Factory lifecycle methods are exposed by delegating to the underlying factory when present:

```diff
 type databaseBackedIndexedDB struct { /* ... */ }
+
+func (d *databaseBackedIndexedDB) Open(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error)
+func (d *databaseBackedIndexedDB) OpenCurrent(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error)
+func (d *databaseBackedIndexedDB) DeleteDatabase(ctx context.Context, name string, opts indexeddb.DeleteOptions) (indexeddb.DeleteDatabaseResult, error)
+func (d *databaseBackedIndexedDB) Databases(ctx context.Context) ([]indexeddb.DatabaseInfo, error)
+func (d *databaseBackedIndexedDB) CompareKeys(first any, second any) (int, error)
```

Behavior:

- `ObjectStore`, `Transaction`, `CreateObjectStore`, and `DeleteObjectStore` operate through the opened system database handle.
- `Open`, `OpenCurrent`, `DeleteDatabase`, `Databases`, and `CompareKeys` delegate to the underlying factory when present.
- `Close` closes the opened database handle and clears it so retries cannot accidentally reuse a closed handle after failed upgrade recovery.
- Concurrent upgrade/store access is serialized by taking a retained handle under lock and failing cleanly if the handle was closed before use.

## Store Allowlist Wrapper

The allowlist layer keeps legacy and factory capability detection separate:

```diff
 type indexedDBStoreAllowlist struct {
     inner indexeddb.IndexedDB
     // filters store names, schema operations, transactions, and object-store access
 }
+
+type indexedDBFactoryStoreAllowlist struct {
+    *indexedDBStoreAllowlist
+    factory indexeddb.Factory
+}
```

Only `indexedDBFactoryStoreAllowlist` exposes lifecycle methods:

```diff
 type indexedDBFactoryStoreAllowlist struct { /* ... */ }
+
+func (d *indexedDBFactoryStoreAllowlist) Open(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error)
+func (d *indexedDBFactoryStoreAllowlist) OpenCurrent(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error)
+func (d *indexedDBFactoryStoreAllowlist) DeleteDatabase(ctx context.Context, name string, opts indexeddb.DeleteOptions) (indexeddb.DeleteDatabaseResult, error)
+func (d *indexedDBFactoryStoreAllowlist) Databases(ctx context.Context) ([]indexeddb.DatabaseInfo, error)
+func (d *indexedDBFactoryStoreAllowlist) CompareKeys(first any, second any) (int, error)
```

This means an old store-only provider still type-asserts as `indexeddb.IndexedDB`, not `indexeddb.Factory`, so feature detection keeps returning `Unimplemented` for lifecycle RPCs instead of advertising partial support.

## Bootstrap Contracts

The selected system IndexedDB registration now stores the database-backed wrapper instead of the raw instrumented factory:

```diff
-hostIndexedDBs[selectedIndexedDBName] = instrumentedFactory
+hostIndexedDBs[selectedIndexedDBName] = svc.DB
```

Host service configuration adds database scoping and a shared lifecycle registry for store-scoped bindings:

```diff
 indexeddb.ServerOptions{
+    AllowedDatabases: []string{"gestalt"},
     AllowedStores: []string{"external_credentials"},
+    Registry: sharedConnectionRegistry,
 }
```

- Store allowlists restrict object-store visibility, upgrade schema operations, store operations, and index operations.
- Database allowlists restrict lifecycle methods such as `Open`, `OpenCurrent`, `Databases`, and `DeleteDatabase`.
- `DeleteDatabase` is rejected when a store allowlist is active unless a future explicit delete grant is added.
- Existing legacy-compatible host bindings continue routing no-connection calls through the configured default database path.

## Metrics Wrapping

The metric wrapper now handles database-backed operations in addition to direct object-store calls:

```diff
 type metricIndexedDB struct { /* ... */ }
+
+func (m *metricIndexedDB) Open(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error)
+func (m *metricIndexedDB) OpenCurrent(ctx context.Context, name string, opts indexeddb.OpenOptions) (indexeddb.Database, error)
+func (m *metricIndexedDB) DeleteDatabase(ctx context.Context, name string, opts indexeddb.DeleteOptions) (indexeddb.DeleteDatabaseResult, error)
+func (m *metricIndexedDB) Databases(ctx context.Context) ([]indexeddb.DatabaseInfo, error)
```

Metric labels continue to avoid exposing `connection_id` values.

## Test Plan

- `cd gestaltd && go test -count=1 ./internal/coredata ./services/observability/metricutil ./internal/bootstrap -run 'IndexedDB|Coredata|System|HostService|Bootstrap|Metric'`
