### PR TITLE
[codex] Resolve CLI artifacts dirs from cwd

### DIFF
--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -6140,7 +6140,7 @@ server:
 	}
 }
 
-func TestLoadPaths_ResolvesRelativeScalarSourcePathsPerFile(t *testing.T) {
+func TestLoadPaths_ResolvesRelativePathsPerFile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -6150,6 +6150,8 @@ func TestLoadPaths_ResolvesRelativeScalarSourcePathsPerFile(t *testing.T) {
 	}
 	if err := os.WriteFile(basePath, []byte(`
 apiVersion: gestaltd.config/v5
+server:
+  artifactsDir: ../base-artifacts
 providers:
 plugins:
     sample:
@@ -6164,6 +6166,8 @@ plugins:
 	}
 	if err := os.WriteFile(overridePath, []byte(`
 apiVersion: gestaltd.config/v5
+server:
+  artifactsDir: ./override-artifacts
 providers:
 plugins:
     sample:
@@ -6180,6 +6184,9 @@ plugins:
 	wantPath := filepath.Join(filepath.Dir(overridePath), "override-plugin", "manifest.yaml")
 	if got := cfg.Plugins["sample"].SourcePath(); got != wantPath {
 		t.Fatalf("SourcePath = %q, want %q", got, wantPath)
+	}
+	if got, want := cfg.Server.ArtifactsDir, filepath.Join(filepath.Dir(overridePath), "override-artifacts"); got != want {
+		t.Fatalf("Server.ArtifactsDir = %q, want %q", got, want)
 	}
 }
 

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -3164,6 +3164,28 @@ func TestE2ELockSyncLocalProviders(t *testing.T) {
 		t.Fatalf("gestaltd lock --check failed: %v\noutput: %s", err, out)
 	}
 
+	cmdDir := filepath.Join(dir, "command-cwd")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatalf("create command cwd: %v", err)
+	}
+	relCfgPath, err := filepath.Rel(cmdDir, cfgPath)
+	if err != nil {
+		t.Fatalf("relative config path: %v", err)
+	}
+	relativeArtifactsDir := "relative-prepared"
+	cmd := exec.Command(gestaltdBin, "sync", "--locked", "--config", relCfgPath, "--artifacts-dir", relativeArtifactsDir)
+	cmd.Dir = cmdDir
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd sync with relative artifacts dir failed: %v\noutput: %s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(cmdDir, relativeArtifactsDir, ".gestaltd", "providers", "example")); err != nil {
+		t.Fatalf("relative artifacts dir should be rooted at command cwd, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, relativeArtifactsDir, ".gestaltd", "providers", "example")); !os.IsNotExist(err) {
+		t.Fatalf("relative artifacts dir should not be rooted at config dir, stat err=%v", err)
+	}
+
 	staleCfgPath := filepath.Join(dir, "config-stale.yaml")
 	cfgBytes, err := os.ReadFile(cfgPath)
 	if err != nil {

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -476,7 +476,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
-	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory for sync/serve")
+	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory for sync/serve; relative paths use the current working directory")
 	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
 }
 
@@ -496,6 +496,7 @@ func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "When locked, run `gestaltd lock` before deploy and `gestaltd sync --locked` during build.")
 	writeUsageLine(w, "When repeated, --config files merge left-to-right. Maps deep-merge,")
 	writeUsageLine(w, "later scalars win, lists replace, and null deletes inherited keys.")
+	writeUsageLine(w, "Relative --artifacts-dir paths use the current working directory.")
 }
 
 func printLockUsage(w io.Writer) {
@@ -524,7 +525,7 @@ func printSyncUsage(w io.Writer) {
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
-	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory")
+	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory; relative paths use the current working directory")
 	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
 	writeUsageLine(w, "  --locked          Require an existing lockfile")
 	writeUsageLine(w, "  --parallelism     Maximum concurrent local source UI preparations")
@@ -540,8 +541,7 @@ func printValidateUsage(w io.Writer) {
 	writeUsageLine(w, "Static validation uses locked provider metadata and temporary scratch state.")
 	writeUsageLine(w, "Use --runtime to opt into deep validation that starts configured providers.")
 	writeUsageLine(w, "Repeated --config flags merge left-to-right.")
-	writeUsageLine(w, "The --lockfile path follows normal CLI path resolution; --artifacts-dir keeps")
-	writeUsageLine(w, "the same config-relative resolution used by sync and serve.")
+	writeUsageLine(w, "The --lockfile path follows normal CLI path resolution.")
 }
 
 func writeUsageLine(w io.Writer, line string) {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1823,17 +1823,40 @@ func resolveLockPath(baseDir, provider string) string {
 }
 
 func resolveArtifactsDir(configPath string, cfg *config.Config, override string) string {
-	dir := override
-	if dir == "" && cfg != nil {
-		dir = cfg.Server.ArtifactsDir
+	if override != "" {
+		return resolveCLIArtifactsDir(override)
 	}
-	if dir == "" {
-		return filepath.Dir(configPath)
+	if cfg != nil {
+		if cfg.Server.ArtifactsDir != "" {
+			return resolveConfigArtifactsDir(configPath, cfg.Server.ArtifactsDir)
+		}
 	}
+	return absoluteConfigDir(configPath)
+}
+
+func resolveCLIArtifactsDir(dir string) string {
 	if filepath.IsAbs(dir) {
-		return dir
+		return filepath.Clean(dir)
 	}
-	return filepath.Join(filepath.Dir(configPath), dir)
+	if abs, err := filepath.Abs(dir); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(dir)
+}
+
+func resolveConfigArtifactsDir(configPath, dir string) string {
+	if filepath.IsAbs(dir) {
+		return filepath.Clean(dir)
+	}
+	return filepath.Join(absoluteConfigDir(configPath), dir)
+}
+
+func absoluteConfigDir(configPath string) string {
+	dir := filepath.Dir(configPath)
+	if abs, err := filepath.Abs(dir); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(dir)
 }
 
 func resolveLockfilePath(configPath, override string) string {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1046,6 +1046,25 @@ plugins:
 	if _, err := os.Stat(filepath.Join(explicitArtifactsDir, LockfileName)); !os.IsNotExist(err) {
 		t.Fatalf("explicit artifacts root lockfile should not be written, stat err=%v", err)
 	}
+	relativeArtifactsRoot := filepath.Join(dir, "relative-artifacts")
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	relativeArtifactsDir, err := filepath.Rel(cwd, relativeArtifactsRoot)
+	if err != nil {
+		t.Fatalf("relative artifacts dir: %v", err)
+	}
+	if _, _, err := lc.LoadForExecutionAtPathsWithStatePaths([]string{configPath}, StatePaths{
+		ArtifactsDir: relativeArtifactsDir,
+		PluginScope:  []string{"alpha"},
+	}, false); err != nil {
+		t.Fatalf("scoped LoadForExecutionAtPathsWithStatePaths with relative artifacts dir: %v", err)
+	}
+	relativeScopedLockPath := filepath.Join(relativeArtifactsRoot, ".gestaltd", "scopes", "plugins", "alpha", LockfileName)
+	if _, err := os.Stat(relativeScopedLockPath); err != nil {
+		t.Fatalf("relative artifacts scoped lockfile missing: %v", err)
+	}
 }
 
 func TestLoadForExecutionPluginScopeKeepsReferencedSecretsProvider(t *testing.T) {


### PR DESCRIPTION
## Summary
- Resolve CLI `--artifacts-dir` values relative to the command working directory while keeping `server.artifactsDir` config-relative.
- Canonicalize artifacts roots before scoped plugin state is derived so local provider builds and hashing use the same absolute paths.
- Refresh the built-in CLI help text for the changed `--artifacts-dir` behavior.

## Test plan
- [x] `go test ./internal/operator -run 'TestLoadForExecutionPluginScopeIgnoresUnrelatedLocalSources'`
- [x] `go test -count=1 ./internal/config ./internal/operator ./internal/daemon`
