### PR TITLE
Allow session-catalog invoke declarations

### DIFF
--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1051,7 +1051,7 @@ server:
 	}
 }
 
-func TestPrepareAtPath_RejectsSessionCatalogOnlyInvokesTarget(t *testing.T) {
+func TestPrepareAtPath_AllowsSessionCatalogOnlyInvokesTarget(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -1066,6 +1066,11 @@ func TestPrepareAtPath_RejectsSessionCatalogOnlyInvokesTarget(t *testing.T) {
       invokes:
         - plugin: target
           operation: private_search
+          runAs:
+            subject:
+              id: service_account:agent
+              kind: service_account
+            applyByDefault: false
     target:
       source:
         path: %q
@@ -1076,9 +1081,8 @@ server:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 
-	_, err := NewLifecycle().PrepareAtPath(cfgPath)
-	if err == nil || !strings.Contains(err.Error(), `session-catalog-only operation "private_search" on plugin "target"`) {
-		t.Fatalf("PrepareAtPath error = %v, want session catalog invokes error", err)
+	if _, err := NewLifecycle().PrepareAtPath(cfgPath); err != nil {
+		t.Fatalf("PrepareAtPath: %v", err)
 	}
 }
 

--- a/gestaltd/services/plugins/validation.go
+++ b/gestaltd/services/plugins/validation.go
@@ -152,7 +152,10 @@ func validateDependencies(ctx context.Context, cfg *ValidationConfig, cache *cat
 				continue
 			}
 			if resolved.sessionOnly {
-				return fmt.Errorf("config validation: plugins.%s.invokes[%d] references session-catalog-only operation %q on plugin %q, which is unsupported during init/validate", callerName, i, dependency.Operation, dependency.Plugin)
+				// Static validation cannot prove session-catalog-only operations,
+				// but runtime resolution still enforces that the operation exists
+				// for the effective subject before invocation.
+				continue
 			}
 			return fmt.Errorf("config validation: plugins.%s.invokes[%d] references unknown effective operation %q on plugin %q", callerName, i, dependency.Operation, dependency.Plugin)
 		}


### PR DESCRIPTION
## Summary
- Allow exact `plugins.<caller>.invokes` entries to target operations whose catalogs are session-scoped and unavailable during static validation.
- Preserve static unknown-operation validation for normal effective catalogs.
- Add lifecycle coverage for a session-catalog-only invoke declaration that carries opt-in `runAs`.
- Published a linux/amd64 CI image for Valon Tools validation: `us-east1-docker.pkg.dev/gitlab-peach-street/gestaltd-ci/gestaltd:sha-1be7329cf61b5ca8e9f40171779cda16c3380306@sha256:44787b60ab022b0db4ad3f1d72d99e49ad9738a4058876185850d356a60a90e8`.

## Test plan
- [x] `go test ./internal/operator ./services/plugins -run 'TestPrepareAtPath_AllowsSessionCatalogOnlyInvokesTarget|TestPrepareAtPath_DoesNotWriteLockfileWhenInvokesValidationFails|TestPrepareAtPath_RejectsHybridMCPTypoAsUnknownOperation'`
- [x] `go mod tidy && git diff --exit-code go.mod go.sum`
- [x] `golangci-lint run ./...`
- [x] `docker buildx build --platform linux/amd64 --file gestaltd/Dockerfile --target static --push --tag us-east1-docker.pkg.dev/gitlab-peach-street/gestaltd-ci/gestaltd:sha-1be7329cf61b5ca8e9f40171779cda16c3380306 ...`
- [x] `docker run --rm us-east1-docker.pkg.dev/gitlab-peach-street/gestaltd-ci/gestaltd:sha-1be7329cf61b5ca8e9f40171779cda16c3380306@sha256:44787b60ab022b0db4ad3f1d72d99e49ad9738a4058876185850d356a60a90e8 version`