### PR TITLE
[codex] Use published external credentials default

### DIFF
--- a/docs/content/providers/external-credentials.mdx
+++ b/docs/content/providers/external-credentials.mdx
@@ -152,7 +152,7 @@ providers:
     default:
       source:
         package: github.com/valon-technologies/gestalt-providers/externalcredentials/default
-        version: 0.0.1-alpha.5
+        version: 0.0.1-alpha.1
       config:
         indexeddb: main
 ```

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -37,7 +37,7 @@ const (
 	DefaultIndexedDBProvider           = DefaultProviderRepo + "/indexeddb/relationaldb"
 	DefaultIndexedDBVersion            = "0.0.1-alpha.4"
 	DefaultExternalCredentialsProvider = DefaultProviderRepo + "/externalcredentials/default"
-	DefaultExternalCredentialsVersion  = "0.0.1-alpha.5"
+	DefaultExternalCredentialsVersion  = "0.0.1-alpha.1"
 	DefaultUIProvider                  = DefaultProviderRepo + "/ui/default"
 	DefaultUIVersion                   = "0.0.1"
 	DefaultProviderInstance            = "default"


### PR DESCRIPTION
## Summary
- Point the built-in `externalcredentials/default` provider version at the published `0.0.1-alpha.1` release instead of unpublished `0.0.1-alpha.5`.
- Update the external credentials docs example to match the published default version.

Root cause: synthesized configs used the baked gestaltd default version, and that value referenced an unpublished provider release, causing local `gestaltd serve --path ...` flows to fail during metadata fetch.

## Test plan
- [x] `go test ./internal/config`
- [x] `go test ./internal/operator`