### PR TITLE
Improve plugin selector UX in the CLI

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -179,6 +179,12 @@ pub struct DescribeArgs {
     pub plugin: String,
     /// Operation name
     pub operation: String,
+    /// Select a named connection for this operation catalog
+    #[arg(long)]
+    pub connection: Option<String>,
+    /// Select a stored connection instance for this operation catalog
+    #[arg(long)]
+    pub instance: Option<String>,
 }
 
 #[derive(Subcommand)]

--- a/gestalt/cli/src/commands/describe.rs
+++ b/gestalt/cli/src/commands/describe.rs
@@ -4,11 +4,76 @@ use crate::api::ApiClient;
 use crate::catalog;
 use crate::output::{self, Format};
 
-pub fn describe(client: &ApiClient, plugin: &str, operation: &str, format: Format) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin, None, None)?;
+use super::plugin_errors;
+
+pub fn describe(
+    client: &ApiClient,
+    plugin: &str,
+    operation: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    format: Format,
+) -> Result<()> {
+    let selector_resolution = plugin_errors::resolve_selector(
+        client,
+        plugin,
+        operation,
+        connection,
+        instance,
+        plugin_errors::SelectorCommand::Describe,
+    );
+    let resolved_selector = match selector_resolution {
+        plugin_errors::SelectorResolution::Selected(selector) => Some(selector),
+        plugin_errors::SelectorResolution::Message(message) => bail!(message),
+        plugin_errors::SelectorResolution::Unchanged => None,
+    };
+    let connection = resolved_selector
+        .as_ref()
+        .map(|selector| selector.connection.as_str())
+        .or(connection);
+    let instance = resolved_selector
+        .as_ref()
+        .map(|selector| selector.instance.as_str())
+        .or(instance);
+
+    let cat = plugin_errors::map_catalog_error(
+        client,
+        plugin,
+        operation,
+        connection,
+        instance,
+        plugin_errors::SelectorCommand::Describe,
+        catalog::fetch_catalog(client, plugin, connection, instance),
+    )?;
 
     let op = match cat.find_operation(operation) {
-        Some(op) => op,
+        Some(op) => op.clone(),
+        None if connection.is_some() || instance.is_some() || cat.operations().is_empty() => {
+            let fallback_cat = plugin_errors::map_catalog_error(
+                client,
+                plugin,
+                operation,
+                None,
+                None,
+                plugin_errors::SelectorCommand::Describe,
+                catalog::fetch_catalog(client, plugin, None, None),
+            )?;
+            match fallback_cat.find_operation(operation) {
+                Some(op) => op.clone(),
+                None => {
+                    let available: Vec<&str> = fallback_cat
+                        .operations()
+                        .iter()
+                        .map(|o| o.id.as_str())
+                        .collect();
+                    bail!(
+                        "operation '{}' not found; available operations: {}",
+                        operation,
+                        available.join(", ")
+                    );
+                }
+            }
+        }
         None => {
             let available: Vec<&str> = cat.operations().iter().map(|o| o.id.as_str()).collect();
             bail!(
@@ -21,11 +86,20 @@ pub fn describe(client: &ApiClient, plugin: &str, operation: &str, format: Forma
 
     match format {
         Format::Json => {
-            let val = serde_json::to_value(op)?;
+            let val = serde_json::to_value(&op)?;
             output::print_json(&val);
         }
         Format::Table => {
             println!("Operation:   {}", op.id);
+            if let Some(connection) = connection {
+                println!("Connection:  {connection}");
+            }
+            if let Some(instance) = instance {
+                println!("Instance:    {instance}");
+            }
+            if !op.transport.is_empty() {
+                println!("Transport:   {}", op.transport);
+            }
             if !op.method.is_empty() {
                 println!("Method:      {}", op.method);
             }

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -1,13 +1,15 @@
 use anyhow::{Context, Result};
 
-use crate::api::{ApiClient, ApiError};
+use crate::api::ApiClient;
 use crate::catalog::{
     self, CatalogOperation, CatalogParameter, OperationsCatalog, ResolvedOperation,
 };
 use crate::output::{self, Format};
 use crate::params::{self, ParamEntry};
 
-#[derive(Default)]
+use super::plugin_errors;
+
+#[derive(Clone, Copy, Default)]
 pub struct InvokeOptions<'a> {
     pub connection: Option<&'a str>,
     pub instance: Option<&'a str>,
@@ -24,7 +26,34 @@ pub fn run(
     format: Format,
 ) -> Result<()> {
     let query = segments.join(".");
-    let cat =
+    let resolved_selector = match plugin_errors::resolve_selector(
+        client,
+        plugin,
+        &query,
+        options.connection,
+        options.instance,
+        plugin_errors::SelectorCommand::Invoke,
+    ) {
+        plugin_errors::SelectorResolution::Selected(selector) => Some(selector),
+        plugin_errors::SelectorResolution::Message(message) => {
+            anyhow::bail!(message);
+        }
+        plugin_errors::SelectorResolution::Unchanged => None,
+    };
+    let options = InvokeOptions {
+        connection: resolved_selector
+            .as_ref()
+            .map(|selector| selector.connection.as_str())
+            .or(options.connection),
+        instance: resolved_selector
+            .as_ref()
+            .map(|selector| selector.instance.as_str())
+            .or(options.instance),
+        select: options.select,
+        input_file: options.input_file,
+    };
+
+    let mut cat =
         match load_catalog_for_invoke(client, plugin, &query, options.connection, options.instance)
         {
             Ok(cat) => cat,
@@ -35,25 +64,51 @@ pub fn run(
                 return Err(err);
             }
         };
+    if cat.operations().is_empty() && (options.connection.is_some() || options.instance.is_some()) {
+        let fallback_cat = load_catalog_for_invoke(client, plugin, &query, None, None)?;
+        if !fallback_cat.operations().is_empty() {
+            cat = fallback_cat;
+        }
+    }
 
-    match cat.resolve(&query)? {
-        ResolvedOperation::All(ops) => {
-            warn_ignored_params(params, "no operation specified");
-            display_operations(ops, format)
+    let handle_resolved =
+        |cat: &OperationsCatalog, resolved: ResolvedOperation<'_>, options: InvokeOptions<'_>| {
+            match resolved {
+                ResolvedOperation::All(ops) => {
+                    warn_ignored_params(params, "no operation specified");
+                    display_operations(ops, format, options.connection, options.instance)
+                }
+                ResolvedOperation::Exact(_) => {
+                    execute(client, Some(cat), plugin, &query, params, options, format)
+                }
+                ResolvedOperation::Prefix(matches) => {
+                    let n = matches.len();
+                    let reason = format!(
+                        "prefix matched {} operation{}",
+                        n,
+                        if n == 1 { "" } else { "s" }
+                    );
+                    warn_ignored_params(params, &reason);
+                    display_operations(matches, format, options.connection, options.instance)
+                }
+            }
+        };
+
+    match cat.resolve(&query) {
+        Ok(resolved) => handle_resolved(&cat, resolved, options),
+        Err(err)
+            if !query.is_empty()
+                && (options.connection.is_some() || options.instance.is_some()) =>
+        {
+            match load_catalog_for_invoke(client, plugin, &query, None, None) {
+                Ok(fallback_cat) => match fallback_cat.resolve(&query) {
+                    Ok(resolved) => handle_resolved(&fallback_cat, resolved, options),
+                    Err(_) => Err(err),
+                },
+                Err(_) => Err(err),
+            }
         }
-        ResolvedOperation::Exact(_) => {
-            execute(client, Some(&cat), plugin, &query, params, options, format)
-        }
-        ResolvedOperation::Prefix(matches) => {
-            let n = matches.len();
-            let reason = format!(
-                "prefix matched {} operation{}",
-                n,
-                if n == 1 { "" } else { "s" }
-            );
-            warn_ignored_params(params, &reason);
-            display_operations(matches, format)
-        }
+        Err(err) => Err(err),
     }
 }
 
@@ -65,6 +120,32 @@ pub fn invoke(
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
+    let selector_resolution = plugin_errors::resolve_selector(
+        client,
+        plugin,
+        operation,
+        options.connection,
+        options.instance,
+        plugin_errors::SelectorCommand::Invoke,
+    );
+    let resolved_selector = match selector_resolution {
+        plugin_errors::SelectorResolution::Selected(selector) => Some(selector),
+        plugin_errors::SelectorResolution::Message(message) => anyhow::bail!(message),
+        plugin_errors::SelectorResolution::Unchanged => None,
+    };
+    let options = InvokeOptions {
+        connection: resolved_selector
+            .as_ref()
+            .map(|selector| selector.connection.as_str())
+            .or(options.connection),
+        instance: resolved_selector
+            .as_ref()
+            .map(|selector| selector.instance.as_str())
+            .or(options.instance),
+        select: options.select,
+        input_file: options.input_file,
+    };
+
     let cat = match load_catalog_for_invoke(
         client,
         plugin,
@@ -92,8 +173,26 @@ pub fn invoke(
 }
 
 pub fn list_operations(client: &ApiClient, plugin: &str, format: Format) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin, None, None)?;
-    display_operations(cat.operations(), format)
+    list_operations_with_selector(client, plugin, None, None, format)
+}
+
+pub fn list_operations_with_selector(
+    client: &ApiClient,
+    plugin: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    format: Format,
+) -> Result<()> {
+    let cat = plugin_errors::map_catalog_error(
+        client,
+        plugin,
+        "",
+        connection,
+        instance,
+        plugin_errors::SelectorCommand::Invoke,
+        catalog::fetch_catalog(client, plugin, connection, instance),
+    )?;
+    display_operations(cat.operations(), format, connection, instance)
 }
 
 fn execute(
@@ -131,7 +230,17 @@ fn execute(
     } else {
         client.post(&path, &serde_json::Value::Object(param_map))
     })
-    .map_err(|err| rewrite_connect_error(err, plugin, options.connection, options.instance))
+    .map_err(|err| {
+        plugin_errors::rewrite_connect_error(
+            client,
+            err,
+            plugin,
+            operation,
+            options.connection,
+            options.instance,
+            plugin_errors::SelectorCommand::Invoke,
+        )
+    })
     .with_context(|| format!("failed to invoke {}.{}", plugin, operation))?;
 
     let output_value = match options.select {
@@ -148,15 +257,14 @@ fn execute(
 }
 
 fn should_retry_without_catalog(err: &anyhow::Error, operation: &str) -> bool {
-    matches!(
-        connect_error_kind(err),
-        Some(ConnectErrorKind::NotConnected | ConnectErrorKind::ReconnectRequired)
-    ) && !operation.is_empty()
+    plugin_errors::should_retry_without_catalog(err, operation)
 }
 
 fn display_operations<'a>(
     operations: impl IntoIterator<Item = &'a CatalogOperation>,
     format: Format,
+    connection: Option<&str>,
+    instance: Option<&str>,
 ) -> Result<()> {
     let ops: Vec<&CatalogOperation> = operations.into_iter().collect();
 
@@ -165,6 +273,15 @@ fn display_operations<'a>(
             output::print_json(&serde_json::to_value(&ops).unwrap());
         }
         Format::Table => {
+            if connection.is_some() || instance.is_some() {
+                if let Some(connection) = connection {
+                    println!("Connection: {connection}");
+                }
+                if let Some(instance) = instance {
+                    println!("Instance:   {instance}");
+                }
+                println!();
+            }
             let rows: Vec<Vec<String>> = ops
                 .iter()
                 .map(|op| {
@@ -196,49 +313,16 @@ fn load_catalog_for_invoke(
     connection: Option<&str>,
     instance: Option<&str>,
 ) -> Result<OperationsCatalog> {
-    catalog::fetch_catalog(client, plugin, connection, instance)
-        .map_err(|err| rewrite_connect_error(err, plugin, connection, instance))
-        .with_context(|| format!("failed to invoke {}", invoke_target(plugin, operation)))
-}
-
-fn rewrite_connect_error(
-    err: anyhow::Error,
-    plugin: &str,
-    connection: Option<&str>,
-    instance: Option<&str>,
-) -> anyhow::Error {
-    let connect_command = connect_command(plugin, connection, instance);
-
-    match connect_error_kind(&err) {
-        Some(ConnectErrorKind::NotConnected) => anyhow::anyhow!(
-            "plugin {:?} is not connected. Connect it first with `{}`",
-            plugin,
-            connect_command,
-        ),
-        Some(ConnectErrorKind::ReconnectRequired) => anyhow::anyhow!(
-            "token for plugin {:?} expired or was revoked. Reconnect it with `{}`",
-            plugin,
-            connect_command,
-        ),
-        Some(ConnectErrorKind::InstanceSelectionRequired) => anyhow::anyhow!(
-            "plugin {:?} has multiple connected instances. Pass --instance to choose one",
-            plugin,
-        ),
-        None => err,
-    }
-}
-
-fn connect_command(plugin: &str, connection: Option<&str>, instance: Option<&str>) -> String {
-    let mut connect_command = format!("gestalt plugin connect {}", plugin);
-    if let Some(connection) = connection {
-        connect_command.push_str(" --connection ");
-        connect_command.push_str(connection);
-    }
-    if let Some(instance) = instance {
-        connect_command.push_str(" --instance ");
-        connect_command.push_str(instance);
-    }
-    connect_command
+    plugin_errors::map_catalog_error(
+        client,
+        plugin,
+        operation,
+        connection,
+        instance,
+        plugin_errors::SelectorCommand::Invoke,
+        catalog::fetch_catalog(client, plugin, connection, instance),
+    )
+    .with_context(|| format!("failed to invoke {}", invoke_target(plugin, operation)))
 }
 
 fn invoke_target(plugin: &str, operation: &str) -> String {
@@ -247,42 +331,6 @@ fn invoke_target(plugin: &str, operation: &str) -> String {
     } else {
         format!("{plugin}.{operation}")
     }
-}
-
-enum ConnectErrorKind {
-    NotConnected,
-    ReconnectRequired,
-    InstanceSelectionRequired,
-}
-
-fn connect_error_kind(err: &anyhow::Error) -> Option<ConnectErrorKind> {
-    for cause in err.chain() {
-        if let Some(api_error) = cause.downcast_ref::<ApiError>() {
-            match api_error.code() {
-                Some("not_connected") => return Some(ConnectErrorKind::NotConnected),
-                Some("reconnect_required") => return Some(ConnectErrorKind::ReconnectRequired),
-                Some("instance_selection_required") => {
-                    return Some(ConnectErrorKind::InstanceSelectionRequired);
-                }
-                _ => {}
-            }
-        }
-
-        let message = cause.to_string();
-        if message.contains("no token stored for integration") {
-            return Some(ConnectErrorKind::NotConnected);
-        }
-        if message.contains("is not connected. Connect it first with `") {
-            return Some(ConnectErrorKind::NotConnected);
-        }
-        if message.contains("expired or was revoked") {
-            return Some(ConnectErrorKind::ReconnectRequired);
-        }
-        if message.contains("specify which instance") || message.contains("Pass --instance") {
-            return Some(ConnectErrorKind::InstanceSelectionRequired);
-        }
-    }
-    None
 }
 
 fn format_parameters(params: &[CatalogParameter]) -> String {

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod describe;
 pub mod init;
 pub mod invoke;
+mod plugin_errors;
 pub mod plugins;
 pub mod tokens;
 pub mod workflows;

--- a/gestalt/cli/src/commands/plugin_errors.rs
+++ b/gestalt/cli/src/commands/plugin_errors.rs
@@ -1,0 +1,282 @@
+use std::collections::BTreeSet;
+
+use anyhow::Result;
+
+use crate::{
+    api::{ApiClient, ApiError},
+    output,
+};
+
+#[derive(PartialEq, Eq)]
+pub(crate) enum ConnectErrorKind {
+    NotConnected,
+    ReconnectRequired,
+    InstanceSelectionRequired,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum SelectorCommand {
+    Invoke,
+    Describe,
+}
+
+pub(crate) fn should_retry_without_catalog(err: &anyhow::Error, operation: &str) -> bool {
+    matches!(
+        connect_error_kind(err),
+        Some(ConnectErrorKind::NotConnected | ConnectErrorKind::ReconnectRequired)
+    ) && !operation.is_empty()
+}
+
+pub(crate) fn map_catalog_error(
+    client: &ApiClient,
+    plugin: &str,
+    operation: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    selector_command: SelectorCommand,
+    result: Result<crate::catalog::OperationsCatalog>,
+) -> Result<crate::catalog::OperationsCatalog> {
+    result.map_err(|err| {
+        rewrite_connect_error(
+            client,
+            err,
+            plugin,
+            operation,
+            connection,
+            instance,
+            selector_command,
+        )
+    })
+}
+
+pub(crate) fn rewrite_connect_error(
+    client: &ApiClient,
+    err: anyhow::Error,
+    plugin: &str,
+    operation: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    selector_command: SelectorCommand,
+) -> anyhow::Error {
+    let connect_command = connect_command(plugin, connection, instance);
+
+    match connect_error_kind(&err) {
+        Some(ConnectErrorKind::NotConnected) => anyhow::anyhow!(
+            "plugin {:?} is not connected. Connect it first with `{}`",
+            plugin,
+            connect_command,
+        ),
+        Some(ConnectErrorKind::ReconnectRequired) => anyhow::anyhow!(
+            "token for plugin {:?} expired or was revoked. Reconnect it with `{}`",
+            plugin,
+            connect_command,
+        ),
+        Some(ConnectErrorKind::InstanceSelectionRequired) => {
+            instance_selection_message(client, plugin, operation, connection, selector_command)
+                .map(anyhow::Error::msg)
+                .unwrap_or_else(|| {
+                    anyhow::anyhow!(
+                        "plugin {:?} has multiple connected instances. Pass --connection and --instance to choose one",
+                        plugin,
+                    )
+                })
+        }
+        None => err,
+    }
+}
+
+fn connect_command(plugin: &str, connection: Option<&str>, instance: Option<&str>) -> String {
+    let mut connect_command = format!("gestalt plugin connect {}", shell_word(plugin));
+    if let Some(connection) = connection {
+        connect_command.push_str(" --connection ");
+        connect_command.push_str(&shell_word(connection));
+    }
+    if let Some(instance) = instance {
+        connect_command.push_str(" --instance ");
+        connect_command.push_str(&shell_word(instance));
+    }
+    connect_command
+}
+
+fn connect_error_kind(err: &anyhow::Error) -> Option<ConnectErrorKind> {
+    for cause in err.chain() {
+        if let Some(api_error) = cause.downcast_ref::<ApiError>() {
+            match api_error.code() {
+                Some("not_connected") => return Some(ConnectErrorKind::NotConnected),
+                Some("reconnect_required") => return Some(ConnectErrorKind::ReconnectRequired),
+                Some("instance_selection_required") => {
+                    return Some(ConnectErrorKind::InstanceSelectionRequired);
+                }
+                _ => {}
+            }
+        }
+
+        let message = cause.to_string();
+        if message.contains("no token stored for integration") {
+            return Some(ConnectErrorKind::NotConnected);
+        }
+        if message.contains("is not connected. Connect it first with `") {
+            return Some(ConnectErrorKind::NotConnected);
+        }
+        if message.contains("expired or was revoked") {
+            return Some(ConnectErrorKind::ReconnectRequired);
+        }
+    }
+    None
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ResolvedSelector {
+    pub(crate) connection: String,
+    pub(crate) instance: String,
+}
+
+pub(crate) enum SelectorResolution {
+    Selected(ResolvedSelector),
+    Message(String),
+    Unchanged,
+}
+
+fn instance_selection_message(
+    client: &ApiClient,
+    plugin: &str,
+    operation: &str,
+    connection: Option<&str>,
+    selector_command: SelectorCommand,
+) -> Option<String> {
+    let integrations = client.get("/api/v1/integrations").ok()?;
+    let pairs =
+        selector_pairs_for_plugin_matching_selector(&integrations, plugin, connection, None);
+    match selector_resolution_from_pairs(plugin, operation, selector_command, pairs) {
+        SelectorResolution::Message(message) => Some(message),
+        SelectorResolution::Selected(_) | SelectorResolution::Unchanged => None,
+    }
+}
+
+pub(crate) fn resolve_selector(
+    client: &ApiClient,
+    plugin: &str,
+    operation: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    selector_command: SelectorCommand,
+) -> SelectorResolution {
+    if connection.is_some() && instance.is_some() {
+        return SelectorResolution::Unchanged;
+    }
+    let Ok(integrations) = client.get("/api/v1/integrations") else {
+        return SelectorResolution::Unchanged;
+    };
+    let pairs =
+        selector_pairs_for_plugin_matching_selector(&integrations, plugin, connection, instance);
+    selector_resolution_from_pairs(plugin, operation, selector_command, pairs)
+}
+
+fn selector_resolution_from_pairs(
+    plugin: &str,
+    operation: &str,
+    selector_command: SelectorCommand,
+    pairs: Vec<ResolvedSelector>,
+) -> SelectorResolution {
+    if pairs.len() >= 2 {
+        let rows: Vec<Vec<String>> = pairs
+            .iter()
+            .map(|pair| {
+                vec![
+                    pair.connection.clone(),
+                    pair.instance.clone(),
+                    selector_command.render(plugin, operation, pair),
+                ]
+            })
+            .collect();
+        let selectors = output::render_table(&["Connection", "Instance", "Example"], &rows);
+        return SelectorResolution::Message(format!(
+            "plugin {:?} has multiple connected instances. Choose a connection and instance.\n\n{}",
+            plugin, selectors
+        ));
+    }
+
+    if pairs.len() == 1 {
+        return SelectorResolution::Selected(pairs.into_iter().next().unwrap());
+    }
+
+    SelectorResolution::Unchanged
+}
+
+fn selector_pairs_for_plugin_matching_selector(
+    integrations: &serde_json::Value,
+    plugin: &str,
+    connection_filter: Option<&str>,
+    instance_filter: Option<&str>,
+) -> Vec<ResolvedSelector> {
+    let mut unique = BTreeSet::new();
+
+    if let Some(item) = integrations.as_array().and_then(|items| {
+        items
+            .iter()
+            .find(|item| item["name"].as_str() == Some(plugin))
+    }) && let Some(connections) = item["connections"].as_array()
+    {
+        for connection in connections {
+            let connection_name = connection["name"].as_str().unwrap_or("");
+            if let Some(instances) = connection["instances"].as_array() {
+                for instance in instances {
+                    let Some(instance_name) = instance["name"].as_str() else {
+                        continue;
+                    };
+                    let connection_name =
+                        instance["connection"].as_str().unwrap_or(connection_name);
+                    if connection_filter.is_some_and(|filter| filter != connection_name) {
+                        continue;
+                    }
+                    if instance_filter.is_some_and(|filter| filter != instance_name) {
+                        continue;
+                    }
+                    if connection_name.is_empty() || instance_name.is_empty() {
+                        continue;
+                    }
+                    unique.insert(ResolvedSelector {
+                        connection: connection_name.to_string(),
+                        instance: instance_name.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    unique.into_iter().collect()
+}
+
+impl SelectorCommand {
+    fn render(self, plugin: &str, operation: &str, pair: &ResolvedSelector) -> String {
+        let mut command = match self {
+            SelectorCommand::Invoke => format!("gestalt plugin invoke {}", shell_word(plugin)),
+            SelectorCommand::Describe => format!(
+                "gestalt plugin describe {} {}",
+                shell_word(plugin),
+                shell_word(operation)
+            ),
+        };
+        if matches!(self, SelectorCommand::Invoke) && !operation.is_empty() {
+            command.push(' ');
+            command.push_str(&shell_word(operation));
+        }
+        command.push_str(" --connection ");
+        command.push_str(&shell_word(&pair.connection));
+        command.push_str(" --instance ");
+        command.push_str(&shell_word(&pair.instance));
+        command
+    }
+}
+
+fn shell_word(value: &str) -> String {
+    if !value.is_empty()
+        && !value.starts_with('-')
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"@%_+=:,./-".contains(&b))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}

--- a/gestalt/cli/src/commands/plugin_errors.rs
+++ b/gestalt/cli/src/commands/plugin_errors.rs
@@ -121,6 +121,12 @@ fn connect_error_kind(err: &anyhow::Error) -> Option<ConnectErrorKind> {
         if message.contains("expired or was revoked") {
             return Some(ConnectErrorKind::ReconnectRequired);
         }
+        let lower_message = message.to_ascii_lowercase();
+        if lower_message.contains("specify which instance")
+            || lower_message.contains("pass --instance")
+        {
+            return Some(ConnectErrorKind::InstanceSelectionRequired);
+        }
     }
     None
 }
@@ -224,6 +230,9 @@ fn selector_pairs_for_plugin_matching_selector(
                     let Some(instance_name) = instance["name"].as_str() else {
                         continue;
                     };
+                    if !is_connected_selector(connection, instance) {
+                        continue;
+                    }
                     let connection_name =
                         instance["connection"].as_str().unwrap_or(connection_name);
                     if connection_filter.is_some_and(|filter| filter != connection_name) {
@@ -245,6 +254,15 @@ fn selector_pairs_for_plugin_matching_selector(
     }
 
     unique.into_iter().collect()
+}
+
+fn is_connected_selector(connection: &serde_json::Value, instance: &serde_json::Value) -> bool {
+    let status = instance["credentialState"]
+        .as_str()
+        .or_else(|| instance["status"].as_str())
+        .or_else(|| connection["credentialState"].as_str())
+        .or_else(|| connection["status"].as_str());
+    matches!(status, Some("connected" | "ready"))
 }
 
 impl SelectorCommand {

--- a/gestalt/cli/src/commands/plugins.rs
+++ b/gestalt/cli/src/commands/plugins.rs
@@ -12,6 +12,9 @@ pub use connect::{
 
 const PLUGIN_CONNECTION_NAME: &str = "_plugin";
 const PLUGIN_CONNECTION_ALIAS: &str = "plugin";
+const PLUGIN_GROUP_DIVIDER: char = '┄';
+const PLUGIN_GROUP_DIVIDER_SENTINEL: &str = "\u{E000}";
+const PLUGIN_LIST_HEADERS: [&str; 5] = ["Name", "Description", "Connection", "Instance", "Status"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ConnectionName<'a> {
@@ -60,23 +63,53 @@ pub fn list(client: &ApiClient, format: Format) -> Result<()> {
     match format {
         Format::Json => output::print_json(&resp),
         Format::Table => {
-            let rows: Vec<Vec<String>> = resp
-                .as_array()
-                .unwrap_or(&Vec::new())
-                .iter()
-                .map(|item| {
-                    vec![
-                        item["name"].as_str().unwrap_or("-").to_string(),
-                        item["description"].as_str().unwrap_or("-").to_string(),
-                        plugin_status(item),
-                        plugin_connections(item),
-                    ]
-                })
-                .collect();
-            output::print_table(&["Name", "Description", "Status", "Connections"], &rows);
+            let mut rows = Vec::new();
+            for (index, item) in resp.as_array().unwrap_or(&Vec::new()).iter().enumerate() {
+                if index > 0 {
+                    rows.push(plugin_group_divider_row());
+                }
+                rows.extend(plugin_rows(item));
+            }
+            print_plugin_list_table(&rows);
         }
     }
     Ok(())
+}
+
+fn print_plugin_list_table(rows: &[Vec<String>]) {
+    println!("{}", render_plugin_list_table(rows));
+}
+
+fn render_plugin_list_table(rows: &[Vec<String>]) -> String {
+    let rendered = output::render_table(&PLUGIN_LIST_HEADERS, rows);
+    rendered
+        .lines()
+        .map(expand_plugin_group_divider_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn expand_plugin_group_divider_line(line: &str) -> String {
+    if !line.contains(PLUGIN_GROUP_DIVIDER_SENTINEL) {
+        return line.to_string();
+    }
+
+    let Some(left_border) = line.find('│') else {
+        return line.to_string();
+    };
+    let Some(right_border) = line.rfind('│').filter(|index| *index > left_border) else {
+        return line.to_string();
+    };
+
+    let interior_width = line[left_border + '│'.len_utf8()..right_border]
+        .chars()
+        .count();
+    format!(
+        "{}{}{}",
+        &line[..left_border + '│'.len_utf8()],
+        PLUGIN_GROUP_DIVIDER.to_string().repeat(interior_width),
+        &line[right_border..],
+    )
 }
 
 fn plugin_status(item: &serde_json::Value) -> String {
@@ -86,26 +119,93 @@ fn plugin_status(item: &serde_json::Value) -> String {
         .unwrap_or_else(|| "unknown".to_string())
 }
 
-fn plugin_connections(item: &serde_json::Value) -> String {
-    if let Some(connections) = item["connections"]
-        .as_array()
-        .filter(|connections| !connections.is_empty())
-    {
-        return connections
-            .iter()
-            .map(|connection| {
-                let name = connection["name"].as_str().unwrap_or("-");
-                let status = connection["status"]
-                    .as_str()
-                    .map(str::to_string)
-                    .unwrap_or_else(|| "unknown".to_string());
-                format!("{name}: {status}")
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
+fn plugin_rows(item: &serde_json::Value) -> Vec<Vec<String>> {
+    let mut connections = plugin_connection_rows(item);
+    if connections.is_empty() {
+        connections.push((plugin_status(item), "-".to_string(), "-".to_string()));
     }
 
-    "-".to_string()
+    connections
+        .into_iter()
+        .enumerate()
+        .map(|(index, (status, connection, instance))| {
+            vec![
+                if index == 0 {
+                    item["name"].as_str().unwrap_or("-").to_string()
+                } else {
+                    String::new()
+                },
+                if index == 0 {
+                    item["description"].as_str().unwrap_or("-").to_string()
+                } else {
+                    String::new()
+                },
+                connection,
+                instance,
+                status,
+            ]
+        })
+        .collect()
+}
+
+fn plugin_group_divider_row() -> Vec<String> {
+    vec![
+        PLUGIN_GROUP_DIVIDER_SENTINEL.to_string(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+    ]
+}
+
+fn plugin_connection_rows(item: &serde_json::Value) -> Vec<(String, String, String)> {
+    item["connections"]
+        .as_array()
+        .map(|connections| connections.iter().flat_map(connection_rows).collect())
+        .unwrap_or_default()
+}
+
+fn connection_rows(connection: &serde_json::Value) -> Vec<(String, String, String)> {
+    let name = connection["name"].as_str().unwrap_or("-");
+    if let Some(instances) = connection["instances"]
+        .as_array()
+        .filter(|instances| !instances.is_empty())
+    {
+        return instances
+            .iter()
+            .filter_map(|instance| {
+                let instance_name = instance["name"].as_str()?;
+                let connection_name = instance["connection"].as_str().unwrap_or(name);
+                Some((
+                    connection_status(connection, Some(instance)),
+                    connection_name.to_string(),
+                    instance_name.to_string(),
+                ))
+            })
+            .collect();
+    }
+
+    vec![(
+        connection_status(connection, None),
+        name.to_string(),
+        "-".to_string(),
+    )]
+}
+
+fn connection_status(
+    connection: &serde_json::Value,
+    instance: Option<&serde_json::Value>,
+) -> String {
+    instance
+        .and_then(|instance| {
+            instance["credentialState"]
+                .as_str()
+                .or_else(|| instance["status"].as_str())
+        })
+        .or_else(|| connection["credentialState"].as_str())
+        .or_else(|| connection["status"].as_str())
+        .unwrap_or("unknown")
+        .to_string()
 }
 
 pub fn disconnect(

--- a/gestalt/cli/src/commands/plugins.rs
+++ b/gestalt/cli/src/commands/plugins.rs
@@ -171,7 +171,7 @@ fn connection_rows(connection: &serde_json::Value) -> Vec<(String, String, Strin
         .as_array()
         .filter(|instances| !instances.is_empty())
     {
-        return instances
+        let rows: Vec<_> = instances
             .iter()
             .filter_map(|instance| {
                 let instance_name = instance["name"].as_str()?;
@@ -183,6 +183,9 @@ fn connection_rows(connection: &serde_json::Value) -> Vec<(String, String, Strin
                 ))
             })
             .collect();
+        if !rows.is_empty() {
+            return rows;
+        }
     }
 
     vec![(

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -362,9 +362,19 @@ fn dispatch_plugin_command(
             },
             format,
         ),
-        PluginCommands::Describe(DescribeArgs { plugin, operation }) => {
-            commands::describe::describe(&client, &plugin, &operation, format)
-        }
+        PluginCommands::Describe(DescribeArgs {
+            plugin,
+            operation,
+            connection,
+            instance,
+        }) => commands::describe::describe(
+            &client,
+            &plugin,
+            &operation,
+            connection.as_deref(),
+            instance.as_deref(),
+            format,
+        ),
     }
 }
 

--- a/gestalt/cli/src/output.rs
+++ b/gestalt/cli/src/output.rs
@@ -63,10 +63,15 @@ pub fn print_table(headers: &[&str], rows: &[Vec<String>]) {
         return;
     }
 
-    println!(
-        "{}",
-        render_table_with_style(headers, rows, TableStyle::BordersOnly)
-    );
+    println!("{}", render_table(headers, rows));
+}
+
+pub fn render_table(headers: &[&str], rows: &[Vec<String>]) -> String {
+    if rows.is_empty() {
+        return "No results.".to_string();
+    }
+
+    render_table_with_style(headers, rows, TableStyle::BordersOnly)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/gestalt/cli/tests/invoke_contract.rs
+++ b/gestalt/cli/tests/invoke_contract.rs
@@ -109,7 +109,7 @@ fn test_invoke_instance_selection_error_suggests_instance_flag() {
         "/api/v1/slack/channels",
         StatusCode::CONFLICT
     )
-    .with_body(r#"{"error":"ambiguous instance: integration \"slack\" has 2 connections ([team-a team-b]); specify which instance to use with the \"_instance\" parameter","code":"instance_selection_required","integration":"slack"}"#)
+    .with_body(r#"{"error":"ambiguous instance: integration \"slack\" has 2 connections ([team-a team-b]); specify which instance to use with the \"_instance\" parameter","integration":"slack"}"#)
     .create();
 
     let _integrations_mock =
@@ -204,7 +204,7 @@ fn test_list_operations_infers_only_connected_instance_before_catalog_resolution
             "connections":[
                 {"name":"dev","credentialState":"missing","instances":[]},
                 {"name":"prod","credentialState":"connected","status":"ready","instances":[{"connection":"prod","name":"default"}]},
-                {"name":"stage","credentialState":"missing","instances":[]}
+                {"name":"stage","credentialState":"disconnected","instances":[{"connection":"stage","name":"default"}]}
             ]
         }]"#,
             )

--- a/gestalt/cli/tests/invoke_contract.rs
+++ b/gestalt/cli/tests/invoke_contract.rs
@@ -112,14 +112,240 @@ fn test_invoke_instance_selection_error_suggests_instance_flag() {
     .with_body(r#"{"error":"ambiguous instance: integration \"slack\" has 2 connections ([team-a team-b]); specify which instance to use with the \"_instance\" parameter","code":"instance_selection_required","integration":"slack"}"#)
     .create();
 
+    let _integrations_mock =
+        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+            .with_body(
+                r#"[{
+            "name":"slack",
+            "connections":[
+                {"name":"workspace","credentialState":"connected","instances":[{"name":"default"}]},
+                {"name":"--sandbox","credentialState":"connected","instances":[{"name":"-team"}]}
+            ]
+        }]"#,
+            )
+            .create();
+
     cli_command_for_server(home.path(), &server)
         .args(["plugin", "invoke", "slack", "channels"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "plugin \"slack\" has multiple connected instances. Pass --instance to choose one",
+            "plugin \"slack\" has multiple connected instances.",
         ))
+        .stderr(predicate::str::contains(
+            "Choose a connection and instance.",
+        ))
+        .stderr(predicate::str::contains("Connection"))
+        .stderr(predicate::str::contains("Instance"))
+        .stderr(predicate::str::contains("Example"))
+        .stderr(predicate::str::contains("workspace"))
+        .stderr(predicate::str::contains("default"))
+        .stderr(predicate::str::contains("--sandbox"))
+        .stderr(predicate::str::contains("-team"))
+        .stderr(predicate::str::contains(
+            "gestalt plugin invoke slack channels",
+        ))
+        .stderr(predicate::str::contains("'--sandbox'"))
+        .stderr(predicate::str::contains("'-team'"))
         .stderr(predicate::str::contains("gestalt plugin connect").not());
+}
+
+#[test]
+fn test_invoke_requires_selector_before_catalog_resolution_when_multiple_connections_exist() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let integrations_mock =
+        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+            .with_body(
+                r#"[{
+            "name":"multi_svc",
+            "connections":[
+                {"name":"dev","credentialState":"connected","instances":[{"name":"default"}]},
+                {"name":"stage","credentialState":"connected","instances":[{"name":"default"}]}
+            ]
+        }]"#,
+            )
+            .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args(["plugin", "invoke", "multi_svc", "healthcheck"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Choose a connection and instance.",
+        ))
+        .stderr(predicate::str::contains("Connection"))
+        .stderr(predicate::str::contains("Instance"))
+        .stderr(predicate::str::contains("Example"))
+        .stderr(predicate::str::contains("dev"))
+        .stderr(predicate::str::contains("stage"))
+        .stderr(predicate::str::contains("default"))
+        .stderr(predicate::str::contains(
+            "gestalt plugin invoke multi_svc healthcheck",
+        ))
+        .stderr(predicate::str::contains("--connection dev"))
+        .stderr(predicate::str::contains("--instance default"))
+        .stderr(predicate::str::contains("no operation matching").not());
+
+    integrations_mock.assert();
+}
+
+#[test]
+fn test_list_operations_infers_only_connected_instance_before_catalog_resolution() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let integrations_mock =
+        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+            .with_body(
+                r#"[{
+            "name":"frontPorch",
+            "connections":[
+                {"name":"dev","credentialState":"missing","instances":[]},
+                {"name":"prod","credentialState":"connected","status":"ready","instances":[{"connection":"prod","name":"default"}]},
+                {"name":"stage","credentialState":"missing","instances":[]}
+            ]
+        }]"#,
+            )
+            .create();
+
+    let catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/frontPorch/operations?_connection=prod&_instance=default",
+        StatusCode::OK
+    )
+    .with_body(single_operation_catalog("healthcheck"))
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args(["plugin", "invoke", "frontPorch"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Connection: prod"))
+        .stdout(predicate::str::contains("Instance:   default"))
+        .stdout(predicate::str::contains("healthcheck"))
+        .stderr(predicate::str::contains("plugin \"frontPorch\" is not connected").not());
+
+    integrations_mock.assert();
+    catalog_mock.assert();
+}
+
+#[test]
+fn test_invoke_with_connection_infers_only_matching_instance() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let integrations_mock =
+        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+            .with_body(
+                r#"[{
+            "name":"multi_svc",
+            "connections":[
+                {"name":"dev","credentialState":"connected","instances":[{"name":"default"}]},
+                {"name":"stage","credentialState":"connected","instances":[{"name":"default"}]}
+            ]
+        }]"#,
+            )
+            .create();
+
+    let catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/multi_svc/operations?_connection=dev&_instance=default",
+        StatusCode::OK
+    )
+    .with_body(single_operation_catalog("healthcheck"))
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/multi_svc/healthcheck",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"_connection":"dev","_instance":"default"}"#.to_string(),
+    ))
+    .with_body(r#"{"healthcheck":"OK"}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugin",
+            "invoke",
+            "multi_svc",
+            "healthcheck",
+            "--connection",
+            "dev",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("healthcheck"))
+        .stdout(predicate::str::contains("OK"));
+
+    integrations_mock.assert();
+    catalog_mock.assert();
+    invoke_mock.assert();
+}
+
+#[test]
+fn test_invoke_with_unknown_connection_does_not_infer_unrelated_instance() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let integrations_mock =
+        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+            .with_body(
+                r#"[{
+            "name":"multi_svc",
+            "connections":[
+                {"name":"dev","credentialState":"connected","instances":[{"name":"default"}]}
+            ]
+        }]"#,
+            )
+            .create();
+
+    let catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/multi_svc/operations?_connection=stage",
+        StatusCode::OK
+    )
+    .with_body(single_operation_catalog("healthcheck"))
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/multi_svc/healthcheck",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"_connection":"stage"}"#.to_string(),
+    ))
+    .with_body(r#"{"healthcheck":"OK"}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugin",
+            "invoke",
+            "multi_svc",
+            "healthcheck",
+            "--connection",
+            "stage",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("OK"));
+
+    integrations_mock.assert();
+    catalog_mock.assert();
+    invoke_mock.assert();
 }
 
 #[test]
@@ -380,6 +606,40 @@ fn test_invoke_with_connection_and_instance() {
 }
 
 #[test]
+fn test_list_operations_uses_unselected_catalog_when_selected_catalog_is_empty() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let selected_catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/sample_svc/operations?_connection=dev",
+        StatusCode::OK
+    )
+    .with_body(r#"[]"#)
+    .create();
+    let fallback_catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/sample_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(single_operation_catalog("healthcheck"))
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args(["plugin", "invoke", "sample_svc", "--connection", "dev"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Connection: dev"))
+        .stdout(predicate::str::contains("healthcheck"))
+        .stdout(predicate::str::contains("No results.").not());
+
+    selected_catalog_mock.assert();
+    fallback_catalog_mock.assert();
+}
+
+#[test]
 fn test_invoke_retries_without_catalog_when_preflight_masks_surface_error() {
     let mut server = Server::new();
     let home = TempDir::new().unwrap();
@@ -455,6 +715,9 @@ fn test_cli_lists_operations_with_connection_and_instance() {
     ]);
     cmd.assert()
         .success()
+        .stdout(predicate::str::contains("Connection: workspace"))
+        .stdout(predicate::str::contains("Instance:   team-a"))
+        .stdout(predicate::str::contains("Selector:").not())
         .stdout(predicate::str::contains("do_thing"));
 
     catalog_mock.assert();
@@ -474,8 +737,14 @@ fn test_describe_operation() {
     .create();
 
     let client = create_client(&server);
-    let result =
-        gestalt::commands::describe::describe(&client, "test_svc", "do_thing", Format::Table);
+    let result = gestalt::commands::describe::describe(
+        &client,
+        "test_svc",
+        "do_thing",
+        None,
+        None,
+        Format::Table,
+    );
 
     mock.assert();
     assert!(result.is_ok());
@@ -513,6 +782,90 @@ fn test_describe_operation() {
         String::from_utf8_lossy(&output.stderr)
     );
     mock.assert();
+}
+
+#[test]
+fn test_cli_describe_operation_with_connection_and_instance() {
+    let mut server = Server::new();
+
+    let mock = json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
+        StatusCode::OK
+    )
+    .with_body(catalog_body())
+    .create();
+
+    let output = run_cli(
+        &server,
+        &[
+            "plugin",
+            "describe",
+            "test_svc",
+            "do_thing",
+            "--connection",
+            "workspace",
+            "--instance",
+            "team-a",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Connection:  workspace"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("Instance:    team-a"), "stdout: {stdout}");
+    assert!(!stdout.contains("Selector:"), "stdout: {stdout}");
+    assert!(stdout.contains("Transport:   rest"), "stdout: {stdout}");
+    mock.assert();
+}
+
+#[test]
+fn test_cli_describe_fallback_error_lists_unselected_catalog_operations() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let selected_catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/sample_svc/operations?_connection=dev",
+        StatusCode::OK
+    )
+    .with_body(r#"[]"#)
+    .create();
+
+    let fallback_catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/sample_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(single_operation_catalog("healthcheck"))
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugin",
+            "describe",
+            "sample_svc",
+            "missing",
+            "--connection",
+            "dev",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "operation 'missing' not found; available operations: healthcheck",
+        ));
+
+    selected_catalog_mock.assert();
+    fallback_catalog_mock.assert();
 }
 
 #[test]

--- a/gestalt/cli/tests/plugins_connect.rs
+++ b/gestalt/cli/tests/plugins_connect.rs
@@ -597,20 +597,34 @@ fn test_cli_plugins_list_table_output() {
     );
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
 		.with_body(
-			r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","status":"ready","connections":[{"name":"workspace","status":"ready"}]}]"#,
+			r#"[
+                {"name":"acme_crm","description":"Acme CRM plugin with a longer description","status":"ready","connections":[{"name":"workspace","status":"ready"}]},
+                {"name":"multi_svc","description":"Multi-instance service","status":"needs_instance_selection","connections":[{"name":"workspace","status":"needs_instance_selection","credentialState":"connected","instances":[{"name":"team-a"},{"name":"team-b"}]}]}
+            ]"#,
 		)
         .create();
 
     let mut cmd = cli_command(home.path());
     cmd.args(["plugin", "list"]);
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::contains("ACME_CRM").or(predicate::str::contains("acme_crm")))
-        .stdout(predicate::str::contains("Acme CRM plugin"))
-        .stdout(predicate::str::contains("Status"))
-        .stdout(predicate::str::contains("Connections"))
-        .stdout(predicate::str::contains("ready"))
-        .stdout(predicate::str::contains("workspace: ready"));
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("acme_crm"), "stdout: {stdout}");
+    assert!(stdout.contains("Acme CRM plugin"), "stdout: {stdout}");
+    assert!(stdout.contains("Status"), "stdout: {stdout}");
+    assert!(stdout.contains("Connection"), "stdout: {stdout}");
+    assert!(stdout.contains("Instance"), "stdout: {stdout}");
+    assert!(!stdout.contains("Connections"), "stdout: {stdout}");
+    assert!(stdout.contains("ready"), "stdout: {stdout}");
+    assert!(stdout.contains("workspace"), "stdout: {stdout}");
+    assert!(stdout.contains("team-a"), "stdout: {stdout}");
+    assert!(stdout.contains("team-b"), "stdout: {stdout}");
+    assert!(stdout.contains("connected"), "stdout: {stdout}");
+    assert_eq!(stdout.matches("Multi-instance service").count(), 1);
 
     mock.assert();
 

--- a/gestalt/cli/tests/plugins_connect.rs
+++ b/gestalt/cli/tests/plugins_connect.rs
@@ -599,6 +599,7 @@ fn test_cli_plugins_list_table_output() {
 		.with_body(
 			r#"[
                 {"name":"acme_crm","description":"Acme CRM plugin with a longer description","status":"ready","connections":[{"name":"workspace","status":"ready"}]},
+                {"name":"legacy_svc","description":"Legacy service","status":"ready","connections":[{"name":"legacy","status":"ready","instances":[{"displayName":"Legacy"}]}]},
                 {"name":"multi_svc","description":"Multi-instance service","status":"needs_instance_selection","connections":[{"name":"workspace","status":"needs_instance_selection","credentialState":"connected","instances":[{"name":"team-a"},{"name":"team-b"}]}]}
             ]"#,
 		)
@@ -621,6 +622,8 @@ fn test_cli_plugins_list_table_output() {
     assert!(!stdout.contains("Connections"), "stdout: {stdout}");
     assert!(stdout.contains("ready"), "stdout: {stdout}");
     assert!(stdout.contains("workspace"), "stdout: {stdout}");
+    assert!(stdout.contains("legacy_svc"), "stdout: {stdout}");
+    assert!(stdout.contains("legacy"), "stdout: {stdout}");
     assert!(stdout.contains("team-a"), "stdout: {stdout}");
     assert!(stdout.contains("team-b"), "stdout: {stdout}");
     assert!(stdout.contains("connected"), "stdout: {stdout}");


### PR DESCRIPTION
## Summary
- Add `--connection` and `--instance` to `gestalt plugin describe`, and use the selected pair when fetching operation catalogs.
- Resolve the only connected connection/instance before catalog resolution for both named operation invocation and bare operation listing, so `gestalt plugin invoke frontPorch` can list operations through `prod/default` when that is the only connected pair.
- Fall back to the unselected catalog when a selected catalog is empty for operation listing, so users do not see `No results.` when the base catalog has operations.
- Keep explicit selector filters explicit when they match no connected instance, quote dash-leading selector values in suggested commands, and make `describe` fallback errors list operations from the fallback catalog.
- Show selected connection and instance as separate labels in table-mode operation listings and describe output while keeping JSON catalog output unchanged.
- Render `gestalt plugin list` with `Connection`, `Instance`, and `Status` columns, one row per connection/instance, plugin name and description only on the first row for each plugin, and `┄` divider rows between plugin groups.

Example bare invoke with one connected instance:

```text
$ gestalt plugin invoke frontPorch
Connection: prod
Instance:   default

╭──────────────────────────────────────────────────────────────────────╮
│ Name              Description                       Method Parameters │
╞══════════════════════════════════════════════════════════════════════╡
│ currentIdentity   Return the Front Porch identity                    │
│ healthcheck       Execute the Front Porch GraphQL                    │
│ vds.operations    List Front Porch VDS operation     -p operationType=<string> │
╰──────────────────────────────────────────────────────────────────────╯
```

Example ambiguous invoke:

```text
$ gestalt plugin invoke multi_svc healthcheck
error: plugin "multi_svc" has multiple connected instances. Choose a connection and instance.

╭──────────────────────────────────────────────────────────────────────╮
│ Connection   Instance   Example                                      │
╞══════════════════════════════════════════════════════════════════════╡
│ dev          default    gestalt plugin invoke multi_svc healthcheck  │
│                         --connection dev --instance default          │
│ stage        default    gestalt plugin invoke multi_svc healthcheck  │
│                         --connection stage --instance default        │
╰──────────────────────────────────────────────────────────────────────╯
```

Example plugin list rows:

```text
$ gestalt plugin list
╭─────────────────────────────────────────────────────────────────────╮
│ Name       Description              Connection Instance Status      │
╞═════════════════════════════════════════════════════════════════════╡
│ frontPorch Subject-scoped GraphQL   dev        default  connected   │
│                                     stage      default  connected   │
│┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄│
│ github     Repository operations    default    default  connected   │
╰─────────────────────────────────────────────────────────────────────╯
```

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p gestalt --test invoke_contract -- --nocapture`
- [x] `cargo test -p gestalt --test plugins_connect test_cli_plugins_list_table_output -- --nocapture`
- [x] `cargo build -p gestalt --bin gestalt`
- [x] `git diff --check`
- [x] `./target/debug/gestalt --url https://valon.tools plugin invoke frontPorch --format json`
