### PR TITLE
[codex] Add gestaltd config watch mode

### DIFF
--- a/gestaltd/go.mod
+++ b/gestaltd/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/blevesearch/bleve/v2 v2.6.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0

--- a/gestaltd/go.sum
+++ b/gestaltd/go.sum
@@ -61,6 +61,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/gestaltd/internal/daemon/e2e_test.go
+++ b/gestaltd/internal/daemon/e2e_test.go
@@ -1455,6 +1455,18 @@ func setPluginManifestSource(t *testing.T, pluginDir, source string) {
 	writeManifestFile(t, pluginDir, manifest)
 }
 
+func setPluginManifestDisplayName(t *testing.T, manifestPath, displayName string) {
+	t.Helper()
+
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile(%s): %v", manifestPath, err)
+	}
+	manifest.Kind = providermanifestv1.KindPlugin
+	manifest.DisplayName = displayName
+	writeManifestFile(t, filepath.Dir(manifestPath), manifest)
+}
+
 func setUIManifestSource(t *testing.T, manifestPath, source string) {
 	t.Helper()
 
@@ -2263,8 +2275,18 @@ func startGestaltdWithConfigs(t *testing.T, cfgPaths []string, locked bool) stri
 func startCommandAndWaitReady(t *testing.T, cmd *exec.Cmd, baseURL string) {
 	t.Helper()
 
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
+	startCommandAndWaitReadyWithOutput(t, cmd, baseURL, nil)
+}
+
+func startCommandAndWaitReadyWithOutput(t *testing.T, cmd *exec.Cmd, baseURL string, output io.Writer) {
+	t.Helper()
+
+	cmdOutput := io.Writer(os.Stderr)
+	if output != nil {
+		cmdOutput = io.MultiWriter(os.Stderr, output)
+	}
+	cmd.Stdout = cmdOutput
+	cmd.Stderr = cmdOutput
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start gestaltd: %v", err)
 	}
@@ -2393,6 +2415,36 @@ func waitForHTTPBody(t *testing.T, client *http.Client, url, wantBody string) st
 			lastStatus = resp.StatusCode
 			lastBody = string(body)
 			if resp.StatusCode == http.StatusOK && strings.Contains(lastBody, wantBody) {
+				return lastBody
+			}
+		}
+	}
+}
+
+func waitForFileBody(t *testing.T, path, wantBody string) string {
+	t.Helper()
+
+	tick := time.NewTicker(250 * time.Millisecond)
+	defer tick.Stop()
+	timeout := time.After(60 * time.Second)
+	var lastBody string
+	var lastErr error
+	for {
+		select {
+		case <-timeout:
+			if lastErr != nil {
+				t.Fatalf("%s did not become readable within 60 seconds; last error: %v", path, lastErr)
+			}
+			t.Fatalf("%s did not contain expected body within 60 seconds; body=%s", path, lastBody)
+		case <-tick.C:
+			body, err := os.ReadFile(path)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			lastErr = nil
+			lastBody = string(body)
+			if strings.Contains(lastBody, wantBody) {
 				return lastBody
 			}
 		}
@@ -2623,6 +2675,119 @@ func TestE2EServePathAutoMountsSiblingUIForPlugin(t *testing.T) {
 	client := &http.Client{Timeout: 2 * time.Second}
 	_ = waitForHTTPBody(t, client, baseURL+"/vm-style-guide/sync", "Roadmap Review UI")
 	_ = waitForHTTPBody(t, client, baseURL+"/vm-style-guide/assets/app.js", "ready")
+}
+
+func TestE2EServeConfigWatchReloadsAndKeepsLastGoodOnFailedPreflight(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping serve --watch config test in short mode")
+	}
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+	manifestPath := componentProviderManifestPath(t, pluginDir)
+	port, holder := reservePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	_ = holder.Close()
+	cfgPath := writeE2EConfig(t, dir, pluginDir, port)
+	originalConfig, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	cmd := exec.Command(gestaltdBin, "serve", "--config", cfgPath, "--plugin", "example", "--watch")
+	cmd.Env = append(os.Environ(), "GOTELEMETRY=off")
+	startCommandAndWaitReady(t, cmd, baseURL)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	_ = waitForHTTPBody(t, client, baseURL+"/api/v1/integrations", "Example Provider")
+
+	setPluginManifestDisplayName(t, manifestPath, "Config Watch Provider")
+	_ = waitForHTTPBody(t, client, baseURL+"/api/v1/integrations", "Config Watch Provider")
+
+	invalidConfig := strings.Replace(string(originalConfig), manifestPath, filepath.Join(dir, "missing", "manifest.yaml"), 1)
+	if invalidConfig == string(originalConfig) {
+		t.Fatalf("test config did not contain manifest path %s", manifestPath)
+	}
+	if err := os.WriteFile(cfgPath, []byte(invalidConfig), 0o644); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+	time.Sleep(750 * time.Millisecond)
+	_ = waitForHTTPBody(t, client, baseURL+"/api/v1/integrations", "Config Watch Provider")
+
+	if err := os.WriteFile(cfgPath, originalConfig, 0o644); err != nil {
+		t.Fatalf("restore config: %v", err)
+	}
+	setPluginManifestDisplayName(t, manifestPath, "Recovered Config Watch Provider")
+	_ = waitForHTTPBody(t, client, baseURL+"/api/v1/integrations", "Recovered Config Watch Provider")
+}
+
+func TestE2EServeConfigWatchReloadsLocalReleaseMetadata(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping serve --watch local release metadata test in short mode")
+	}
+
+	dir := t.TempDir()
+	pluginDir := setupPrebuiltPluginDir(t, dir)
+	metadataPath := filepath.Join(pluginDir, "provider-release.yaml")
+	if err := writeLocalProviderReleaseMetadata(pluginDir); err != nil {
+		t.Fatalf("write provider-release metadata: %v", err)
+	}
+	port, holder := reservePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	_ = holder.Close()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`apiVersion: gestaltd.config/v5
+server:
+  baseUrl: %s
+  public:
+    port: %d
+  encryptionKey: test-watch-release-key
+%splugins:
+  example:
+    source: %s
+`, e2eLoopbackBaseURL(port), port, authIndexedDBConfigYAML(t, dir, "", "sqlite", filepath.Join(dir, "gestalt.db")), metadataPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	logPath := filepath.Join(dir, "gestaltd-watch.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		t.Fatalf("create watch log: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logFile.Close()
+	})
+
+	cmd := exec.Command(gestaltdBin, "serve", "--config", cfgPath, "--plugin", "example", "--watch")
+	cmd.Env = append(os.Environ(), "GOTELEMETRY=off")
+	startCommandAndWaitReadyWithOutput(t, cmd, baseURL, logFile)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	_ = waitForHTTPBody(t, client, baseURL+"/api/v1/integrations", "Example Provider")
+
+	missingArchive := "missing-after-watch.tar.gz"
+	metadata := fmt.Sprintf(`schema: gestaltd-provider-release
+schemaVersion: 1
+package: github.com/test/plugins/provider
+kind: plugin
+version: 0.0.1-alpha.1
+runtime: %s
+artifacts:
+  %s:
+    path: %s
+    sha256: %s
+`, "executable", providerpkg.CurrentPlatformString(), missingArchive, strings.Repeat("0", 64))
+	if err := os.WriteFile(metadataPath, []byte(metadata), 0o644); err != nil {
+		t.Fatalf("write %s: %v", metadataPath, err)
+	}
+
+	_ = waitForFileBody(t, logPath, missingArchive)
+	_ = waitForHTTPBody(t, client, baseURL+"/api/v1/integrations", "Example Provider")
 }
 
 //nolint:paralleltest // Uses the default 8080 startup path intentionally.

--- a/gestaltd/internal/daemon/factories.go
+++ b/gestaltd/internal/daemon/factories.go
@@ -35,12 +35,16 @@ type bootstrapEnv struct {
 }
 
 func setupBootstrapWithConfigPaths(configPaths []string, state operator.StatePaths, locked bool) (*bootstrapEnv, error) {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	return setupBootstrapWithConfigPathsContext(ctx, stop, configPaths, state, locked)
+}
+
+func setupBootstrapWithConfigPathsContext(ctx context.Context, stop context.CancelFunc, configPaths []string, state operator.StatePaths, locked bool) (*bootstrapEnv, error) {
 	cfg, err := loadConfigForExecutionAtPathsWithStatePaths(configPaths, state, locked)
 	if err != nil {
+		stop()
 		return nil, err
 	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	factories := buildFactories()
 

--- a/gestaltd/internal/daemon/main_test.go
+++ b/gestaltd/internal/daemon/main_test.go
@@ -50,7 +50,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "serve",
 			args:      []string{"serve", "--help"},
-			wantParts: []string{"gestaltd serve --path PATH", "gestaltd serve --remote URL", "--plugin NAME", "--port PORT"},
+			wantParts: []string{"gestaltd serve --path PATH", "gestaltd serve --remote URL", "--plugin NAME", "--port PORT", "--watch"},
 		},
 		{
 			name:      "provider repo",
@@ -237,6 +237,21 @@ func TestE2ECLIRejectsBadArgs(t *testing.T) {
 			name:     "serve path trailing args",
 			args:     []string{"serve", "--path", ".", "extra"},
 			wantPart: "unexpected arguments: extra",
+		},
+		{
+			name:     "serve watch rejects locked",
+			args:     []string{"serve", "--watch", "--locked"},
+			wantPart: "--watch cannot be combined with --locked",
+		},
+		{
+			name:     "serve watch rejects remote",
+			args:     []string{"serve", "--remote", "https://gestalt.example.com", "--path", ".", "--watch"},
+			wantPart: "--watch cannot be combined with --remote",
+		},
+		{
+			name:     "serve watch rejects path",
+			args:     []string{"serve", "--path", ".", "--watch"},
+			wantPart: "--watch cannot be combined with --path",
 		},
 	}
 

--- a/gestaltd/internal/daemon/provider_local.go
+++ b/gestaltd/internal/daemon/provider_local.go
@@ -115,6 +115,7 @@ func runServeProviderLocal(opts providerLocalCommandOptions) error {
 		}
 		port = selectedPort
 	}
+	opts.Port = port
 
 	session, err := prepareProviderLocalSession(providerLocalCommandOptions{
 		Path:        opts.Path,

--- a/gestaltd/internal/daemon/provider_local_watch.go
+++ b/gestaltd/internal/daemon/provider_local_watch.go
@@ -1,0 +1,364 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/services/plugins/providerpkg"
+)
+
+type providerLocalWatchPlan struct {
+	Files     []string
+	Roots     []string
+	WatchDirs []string
+}
+
+type providerLocalWatchPlanBuilder struct {
+	files map[string]struct{}
+	roots map[string]struct{}
+}
+
+func newProviderLocalWatchPlan(configPaths []string, cfg *config.Config) (providerLocalWatchPlan, error) {
+	builder := newProviderLocalWatchPlanBuilder()
+	for _, configPath := range configPaths {
+		if err := builder.addRequiredPath(configPath); err != nil {
+			return providerLocalWatchPlan{}, fmt.Errorf("watch config %q: %w", configPath, err)
+		}
+	}
+
+	for _, sourcePath := range providerLocalSourcePaths(cfg) {
+		if err := builder.addSourcePath(sourcePath); err != nil {
+			return providerLocalWatchPlan{}, err
+		}
+	}
+	for _, metadataPath := range providerLocalReleaseMetadataPaths(cfg) {
+		if err := builder.addRequiredFile(metadataPath); err != nil {
+			return providerLocalWatchPlan{}, fmt.Errorf("watch release metadata %q: %w", metadataPath, err)
+		}
+	}
+	return builder.build()
+}
+
+func providerLocalSourcePaths(cfg *config.Config) []string {
+	return providerLocalEntryPaths(cfg, func(entry *config.ProviderEntry) (string, bool) {
+		if entry.HasLocalSource() {
+			return entry.SourcePath(), true
+		}
+		return "", false
+	})
+}
+
+func providerLocalReleaseMetadataPaths(cfg *config.Config) []string {
+	return providerLocalEntryPaths(cfg, func(entry *config.ProviderEntry) (string, bool) {
+		if entry.HasLocalReleaseSource() {
+			return entry.SourceReleasePath(), true
+		}
+		return "", false
+	})
+}
+
+func providerLocalEntryPaths(cfg *config.Config, entryPath func(*config.ProviderEntry) (string, bool)) []string {
+	if cfg == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var paths []string
+	add := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return
+		}
+		cleaned := filepath.Clean(path)
+		if _, ok := seen[cleaned]; ok {
+			return
+		}
+		seen[cleaned] = struct{}{}
+		paths = append(paths, cleaned)
+	}
+	addProviderEntries := func(entries map[string]*config.ProviderEntry) {
+		for _, entry := range entries {
+			if entry != nil {
+				if path, ok := entryPath(entry); ok {
+					add(path)
+				}
+			}
+		}
+	}
+	addProviderEntries(cfg.Plugins)
+	addProviderEntries(cfg.Providers.Authentication)
+	addProviderEntries(cfg.Providers.Authorization)
+	addProviderEntries(cfg.Providers.ExternalCredentials)
+	addProviderEntries(cfg.Providers.Secrets)
+	addProviderEntries(cfg.Providers.Telemetry)
+	addProviderEntries(cfg.Providers.Audit)
+	addProviderEntries(cfg.Providers.IndexedDB)
+	addProviderEntries(cfg.Providers.Cache)
+	addProviderEntries(cfg.Providers.S3)
+	addProviderEntries(cfg.Providers.Workflow)
+	addProviderEntries(cfg.Providers.Agent)
+	for _, entry := range cfg.Runtime.Providers {
+		if entry != nil {
+			if path, ok := entryPath(&entry.ProviderEntry); ok {
+				add(path)
+			}
+		}
+	}
+	for _, entry := range cfg.Providers.UI {
+		if entry != nil {
+			if path, ok := entryPath(&entry.ProviderEntry); ok {
+				add(path)
+			}
+		}
+	}
+	slices.Sort(paths)
+	return paths
+}
+
+func newProviderLocalWatchPlanBuilder() *providerLocalWatchPlanBuilder {
+	return &providerLocalWatchPlanBuilder{
+		files: map[string]struct{}{},
+		roots: map[string]struct{}{},
+	}
+}
+
+func (b *providerLocalWatchPlanBuilder) addSourcePath(sourcePath string) error {
+	manifestPath, err := watchSourceManifestPath(sourcePath)
+	if err != nil {
+		return fmt.Errorf("watch source %q: %w", sourcePath, err)
+	}
+	return b.addRequiredRoot(filepath.Dir(manifestPath))
+}
+
+func watchSourceManifestPath(sourcePath string) (string, error) {
+	sourcePath = strings.TrimSpace(sourcePath)
+	if sourcePath == "" {
+		return "", fmt.Errorf("source path is required")
+	}
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return "", err
+	}
+	manifestPath := sourcePath
+	if info.IsDir() {
+		manifestPath, err = providerpkg.FindManifestFile(sourcePath)
+		if err != nil {
+			return "", err
+		}
+	} else if !providerpkg.IsManifestFile(sourcePath) {
+		return "", fmt.Errorf("source %q must point to a provider manifest file or directory", sourcePath)
+	}
+	return canonicalPath(manifestPath)
+}
+
+func (b *providerLocalWatchPlanBuilder) addRequiredPath(path string) error {
+	canonical, err := canonicalPath(path)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return b.addRequiredRoot(canonical)
+	}
+	return b.addRequiredFile(canonical)
+}
+
+func (b *providerLocalWatchPlanBuilder) addRequiredFile(path string) error {
+	canonical, err := canonicalPath(path)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s is a directory", canonical)
+	}
+	b.files[canonical] = struct{}{}
+	return nil
+}
+
+func (b *providerLocalWatchPlanBuilder) addRequiredRoot(path string) error {
+	canonical, err := canonicalPath(path)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", canonical)
+	}
+	b.roots[canonical] = struct{}{}
+	return nil
+}
+
+func (b *providerLocalWatchPlanBuilder) build() (providerLocalWatchPlan, error) {
+	plan := providerLocalWatchPlan{
+		Files: sortedMapKeys(b.files),
+		Roots: sortedMapKeys(b.roots),
+	}
+	watchDirs, err := plan.collectWatchDirs()
+	if err != nil {
+		return providerLocalWatchPlan{}, err
+	}
+	plan.WatchDirs = watchDirs
+	return plan, nil
+}
+
+func sortedMapKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+func (p providerLocalWatchPlan) collectWatchDirs() ([]string, error) {
+	dirs := map[string]struct{}{}
+	addDir := func(path string) error {
+		canonical, err := canonicalPath(path)
+		if err != nil {
+			return err
+		}
+		info, err := os.Stat(canonical)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%s is not a directory", canonical)
+		}
+		dirs[canonical] = struct{}{}
+		return nil
+	}
+	for _, file := range p.Files {
+		if err := addDir(filepath.Dir(file)); err != nil {
+			return nil, fmt.Errorf("watch parent for %s: %w", file, err)
+		}
+	}
+	for _, root := range p.Roots {
+		if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if p.shouldSkipPath(path, d) {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !d.IsDir() {
+				return nil
+			}
+			dirs[filepath.Clean(path)] = struct{}{}
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("collect watch dirs for %s: %w", root, err)
+		}
+	}
+	return sortedMapKeys(dirs), nil
+}
+
+func (p providerLocalWatchPlan) includesEventPath(path string) bool {
+	canonical, err := canonicalPath(path)
+	if err != nil {
+		return false
+	}
+	for _, file := range p.Files {
+		if canonical == file {
+			return true
+		}
+	}
+	for _, root := range p.Roots {
+		if providerLocalWatchPathWithinRoot(root, canonical) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p providerLocalWatchPlan) includesRootPath(path string) bool {
+	canonical, err := canonicalPath(path)
+	if err != nil {
+		return false
+	}
+	for _, root := range p.Roots {
+		if providerLocalWatchPathWithinRoot(root, canonical) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p providerLocalWatchPlan) shouldSkipPath(_ string, d os.DirEntry) bool {
+	if d.IsDir() {
+		_, excluded := providerLocalWatchExcludedDirs[d.Name()]
+		return excluded
+	}
+	return false
+}
+
+var providerLocalWatchExcludedDirs = map[string]struct{}{
+	".git":         {},
+	".gestalt":     {},
+	".gestaltd":    {},
+	"node_modules": {},
+	"target":       {},
+}
+
+func providerLocalWatchPathWithinRoot(root, target string) bool {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(target))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func newProviderLocalFSWatcher(plan providerLocalWatchPlan) (*fsnotify.Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create filesystem watcher: %w", err)
+	}
+	for _, dir := range plan.WatchDirs {
+		if err := watcher.Add(dir); err != nil {
+			_ = watcher.Close()
+			return nil, fmt.Errorf("watch %s: %w", dir, err)
+		}
+	}
+	return watcher, nil
+}
+
+func addProviderLocalCreatedWatchDirs(watcher *fsnotify.Watcher, plan providerLocalWatchPlan, path string) {
+	if !plan.includesRootPath(path) {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return
+	}
+	_ = filepath.WalkDir(path, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if plan.shouldSkipPath(path, d) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			_ = watcher.Add(path)
+		}
+		return nil
+	})
+}

--- a/gestaltd/internal/daemon/run.go
+++ b/gestaltd/internal/daemon/run.go
@@ -100,6 +100,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	var portFlag *int
 	var remoteFlag *string
 	var remoteTokenFlag *string
+	var watchFlag *bool
 	if opts.allowProviderLocal {
 		pluginFlag = fs.String("plugin", "", "run only the named plugin and its local dependency closure")
 		pathFlag = fs.String("path", "", "provider manifest path or directory for local source serve")
@@ -107,6 +108,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 		portFlag = fs.Int("port", 0, "public port for --path (defaults to a free localhost port)")
 		remoteFlag = fs.String("remote", "", "remote gestaltd base URL to attach local source plugins to")
 		remoteTokenFlag = fs.String("remote-token", "", "bearer token for --remote (defaults to GESTALT_API_KEY)")
+		watchFlag = fs.Bool("watch", false, "watch local source files and restart/rebuild after changes")
 	}
 	var lockedFlag *bool
 	if opts.allowLocked {
@@ -134,6 +136,10 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	if lockedFlag != nil {
 		locked = *lockedFlag
 	}
+	watch := flagBoolValue(watchFlag)
+	if watch && locked {
+		return fmt.Errorf("--watch cannot be combined with --locked")
+	}
 
 	if opts.allowProviderLocal {
 		ranProviderLocal, err := maybeRunServeProviderLocal(serveProviderLocalOptions{
@@ -148,10 +154,18 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 			LockfilePath:  *lockfilePath,
 			Locked:        locked,
 			LockedAllowed: lockedFlag != nil,
+			Watch:         watch,
 		})
 		if ranProviderLocal || err != nil {
 			return err
 		}
+	}
+	if watch {
+		return runServeWatch(resolvedConfigPaths, operator.StatePaths{
+			ArtifactsDir: *artifactsDir,
+			LockfilePath: *lockfilePath,
+			PluginScope:  []string{flagStringValue(pluginFlag)},
+		})
 	}
 
 	env, err := setupBootstrapWithConfigPaths(resolvedConfigPaths, operator.StatePaths{
@@ -177,6 +191,7 @@ type serveProviderLocalOptions struct {
 	LockfilePath  string
 	Locked        bool
 	LockedAllowed bool
+	Watch         bool
 }
 
 func maybeRunServeProviderLocal(opts serveProviderLocalOptions) (bool, error) {
@@ -198,6 +213,9 @@ func maybeRunServeProviderLocal(opts serveProviderLocalOptions) (bool, error) {
 		}
 		if opts.LockedAllowed && opts.Locked {
 			return true, fmt.Errorf("--locked cannot be combined with --remote")
+		}
+		if opts.Watch {
+			return true, fmt.Errorf("--watch cannot be combined with --remote")
 		}
 		if plugin != "" && path != "" {
 			return true, fmt.Errorf("--plugin cannot be combined with --path")
@@ -221,6 +239,9 @@ func maybeRunServeProviderLocal(opts serveProviderLocalOptions) (bool, error) {
 	if path != "" {
 		if plugin != "" {
 			return true, fmt.Errorf("--plugin cannot be combined with --path")
+		}
+		if opts.Watch {
+			return true, fmt.Errorf("--watch cannot be combined with --path")
 		}
 		if opts.ArtifactsDir != "" {
 			return true, fmt.Errorf("--artifacts-dir cannot be combined with --path")
@@ -264,6 +285,13 @@ func flagStringValue(flag *string) string {
 func flagIntValue(flag *int) int {
 	if flag == nil {
 		return 0
+	}
+	return *flag
+}
+
+func flagBoolValue(flag *bool) bool {
+	if flag == nil {
+		return false
 	}
 	return *flag
 }
@@ -458,7 +486,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]")
 	writeUsageLine(w, "  gestaltd lock [--config PATH]... [--lockfile PATH] [--platform PLATFORMS] [--check]")
 	writeUsageLine(w, "  gestaltd sync --locked [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--parallelism N] [--check]")
-	writeUsageLine(w, "  gestaltd serve [--plugin NAME] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
+	writeUsageLine(w, "  gestaltd serve [--plugin NAME] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--watch]")
 	writeUsageLine(w, "  gestaltd serve --path PATH [--config PATH]... [--name NAME] [--port PORT]")
 	writeUsageLine(w, "  gestaltd serve --remote URL (--path PATH | --config PATH...) [--name NAME]")
 	writeUsageLine(w, "  gestaltd agent <command> [flags]")
@@ -482,7 +510,7 @@ func printMainUsage(w io.Writer) {
 
 func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd serve [--plugin NAME] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
+	writeUsageLine(w, "  gestaltd serve [--plugin NAME] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--watch]")
 	writeUsageLine(w, "  gestaltd serve --path PATH [--config PATH]... [--name NAME] [--port PORT]")
 	writeUsageLine(w, "  gestaltd serve --remote URL --config PATH [--config PATH]... [--name NAME]")
 	writeUsageLine(w, "  gestaltd serve --remote URL --path PATH [--config PATH]... [--name NAME]")
@@ -490,6 +518,7 @@ func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "Start the server. Without --locked, auto lock/syncs if state is missing or stale.")
 	writeUsageLine(w, "Use --plugin for local scoped development of one configured plugin without preparing the full config.")
 	writeUsageLine(w, "Use --path to serve one local source plugin or UI bundle inside a synthesized Gestalt config.")
+	writeUsageLine(w, "Use --watch to rebuild/restart after debounced local file changes.")
 	writeUsageLine(w, "Use --remote to attach local source plugins to an authenticated remote gestaltd session.")
 	writeUsageLine(w, "For production, strongly prefer --locked so startup uses the pinned")
 	writeUsageLine(w, "lockfile and prepared artifacts instead of resolving or mutating state.")

--- a/gestaltd/internal/daemon/serve_watch.go
+++ b/gestaltd/internal/daemon/serve_watch.go
@@ -1,0 +1,161 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+)
+
+const defaultServeWatchDebounce = 500 * time.Millisecond
+
+type serveWatchCandidate struct {
+	env  *bootstrapEnv
+	plan providerLocalWatchPlan
+	done chan error
+}
+
+func runServeWatch(configPaths []string, state operator.StatePaths) error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	active, err := prepareServeWatchCandidate(ctx, configPaths, state)
+	if err != nil {
+		return err
+	}
+	active.start()
+
+	watcher, err := newProviderLocalFSWatcher(active.plan)
+	if err != nil {
+		_ = active.stop()
+		return err
+	}
+	defer func() { _ = watcher.Close() }()
+
+	slog.Info("watch mode enabled",
+		"debounce", defaultServeWatchDebounce.String(),
+		"files", len(active.plan.Files),
+		"roots", len(active.plan.Roots),
+		"watch_dirs", len(active.plan.WatchDirs),
+	)
+
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	var timerC <-chan time.Time
+	scheduleReload := func() {
+		if timerC == nil {
+			timer.Reset(defaultServeWatchDebounce)
+			timerC = timer.C
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(defaultServeWatchDebounce)
+	}
+
+	for {
+		select {
+		case err := <-active.done:
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		case <-ctx.Done():
+			return active.stop()
+		case event, ok := <-watcher.Events:
+			if !ok {
+				continue
+			}
+			if !active.plan.includesEventPath(event.Name) {
+				continue
+			}
+			if event.Op&fsnotify.Create != 0 {
+				addProviderLocalCreatedWatchDirs(watcher, active.plan, event.Name)
+			}
+			if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove|fsnotify.Rename|fsnotify.Chmod) != 0 {
+				scheduleReload()
+			}
+		case err, ok := <-watcher.Errors:
+			if ok && err != nil {
+				slog.Warn("watch filesystem event error", "error", err)
+			}
+		case <-timerC:
+			timerC = nil
+			next, err := prepareServeWatchCandidate(ctx, configPaths, state)
+			if err != nil {
+				slog.Error("watch reload failed; keeping current server", "error", err)
+				continue
+			}
+			nextWatcher, err := newProviderLocalFSWatcher(next.plan)
+			if err != nil {
+				next.close()
+				slog.Error("watch reload failed; keeping current server", "error", err)
+				continue
+			}
+			if err := active.stop(); err != nil {
+				slog.Warn("watch reload replacing exited server", "error", err)
+			}
+			next.start()
+			_ = watcher.Close()
+			watcher = nextWatcher
+			active = next
+			slog.Info("watch reload complete",
+				"files", len(active.plan.Files),
+				"roots", len(active.plan.Roots),
+				"watch_dirs", len(active.plan.WatchDirs),
+			)
+		}
+	}
+}
+
+func prepareServeWatchCandidate(parent context.Context, configPaths []string, state operator.StatePaths) (*serveWatchCandidate, error) {
+	ctx, cancel := context.WithCancel(parent)
+	env, err := setupBootstrapWithConfigPathsContext(ctx, cancel, configPaths, state, false)
+	if err != nil {
+		return nil, err
+	}
+	plan, err := newProviderLocalWatchPlan(configPaths, env.Config)
+	if err != nil {
+		env.Close()
+		return nil, err
+	}
+	return &serveWatchCandidate{
+		env:  env,
+		plan: plan,
+		done: make(chan error, 1),
+	}, nil
+}
+
+func (c *serveWatchCandidate) start() {
+	go func() {
+		err := server.Run(c.env.Ctx, c.env.Config, c.env.Result)
+		c.close()
+		c.done <- err
+	}()
+}
+
+func (c *serveWatchCandidate) stop() error {
+	if c == nil || c.env == nil {
+		return nil
+	}
+	c.env.Stop()
+	return <-c.done
+}
+
+func (c *serveWatchCandidate) close() {
+	if c == nil || c.env == nil {
+		return
+	}
+	c.env.Close()
+}


### PR DESCRIPTION
## Problem Statement

Config-based local development currently requires manually restarting `gestaltd` after changing a source-backed provider, local release metadata, plugin manifest, or local overlay. That slows the feedback loop, especially when developing a single configured plugin with `--plugin NAME` and layered local config.

## Solution

Add `gestaltd serve --watch` for config-based serve flows. Watch mode starts the server normally, builds a simple filesystem watch plan from the layered config files, local source provider roots, and local `provider-release.yaml` metadata files referenced by the loaded config, then reloads after local changes settle for a fixed internal 500ms debounce.

Reloads are driven by matching filesystem events after the debounce window. If a reload preflight fails, the current server stays running and the failure is logged instead of taking down the local session. If the active server exits while a replacement is being prepared, a ready replacement is still installed instead of discarding it.

## Functional Requirements

- `--watch` is supported for config-based `gestaltd serve`, including scoped local development with `--plugin NAME`.
- `--watch` watches layered config files, local source roots, and local release metadata files referenced by plugins, host providers, runtime providers, and UI providers.
- Watch mode uses a fixed directory-name denylist for `.git`, `.gestalt`, `.gestaltd`, `node_modules`, and `target`.
- `--watch` is rejected with `--locked`, `--path`, and `--remote`; those flows remain unchanged.

## Precedent

- [Vite hard-codes watcher ignores](https://github.com/vitejs/vite/blob/b413bcee941b2436205397a67729c9475b0e32f8/packages/vite/src/node/watch.ts#L58-L63) for `.git`, `node_modules`, test output, and cache/build output paths.
- [nodemon wires default ignores through `ignore-by-default`](https://github.com/remy/nodemon/blob/db572028eafb0748916dff73725a18446d682ea4/lib/config/defaults.js#L1-L16), whose [hard-coded directory list](https://github.com/novemberborn/ignore-by-default/blob/c2fefc478188edca24a2e3fb2a7bda9f558fbe2f/index.js#L3-L12) includes `.git` and `node_modules`.
- [cargo-watch v7 hard-coded default ignores](https://github.com/watchexec/cargo-watch/blob/be52bde3d2734bab8092b96e1a3b15d5634ff329/src/options.rs#L104-L124) for VCS folders including `.git` and Rust build output under `target`.

## Interface Diffs

```diff
-gestaltd serve [--plugin NAME] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]
+gestaltd serve [--plugin NAME] [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked] [--watch]
```

## Example

```sh
gestaltd serve \
  --config config.yaml \
  --config local/config.yaml \
  --plugin example \
  --watch
```