### PR TITLE
Add static declarative GraphQL arguments

### DIFF
--- a/gestaltd/internal/bootstrap/graphql_session_provider_test.go
+++ b/gestaltd/internal/bootstrap/graphql_session_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -134,6 +135,258 @@ func TestGraphQLSessionCatalogProviderLoadsCatalogOnDemand(t *testing.T) {
 	}
 }
 
+func TestConfiguredStaticGraphQLProviderSkipsSessionCatalog(t *testing.T) {
+	t.Parallel()
+
+	type graphQLRequestPayload struct {
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables"`
+	}
+
+	var (
+		mu                 sync.Mutex
+		seenRequests       []graphQLRequestPayload
+		introspectionCalls atomic.Int32
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload graphQLRequestPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if strings.Contains(payload.Query, "__schema") {
+			introspectionCalls.Add(1)
+			http.Error(w, "introspection should not be requested", http.StatusTeapot)
+			return
+		}
+		mu.Lock()
+		seenRequests = append(seenRequests, payload)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		data := map[string]any{"searchRecords": []any{}}
+		if strings.Contains(payload.Query, "record(") {
+			data = map[string]any{"record": map[string]any{"id": payload.Variables["id"]}}
+		} else if strings.Contains(payload.Query, "status") {
+			data = map[string]any{"status": "ok"}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+	}))
+	t.Cleanup(srv.Close)
+
+	prov, _, err := buildConfiguredSpecProvider(
+		context.Background(),
+		"exampleGraphQL",
+		config.ResolvedSpecSurface{
+			Surface: config.SpecSurfaceGraphQL,
+			URL:     srv.URL,
+			Connection: config.ConnectionDef{
+				Auth: config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeNone},
+			},
+		},
+		providerMetadata{},
+		specProviderConfig{
+			allowedOperations: map[string]*config.OperationOverride{
+				"status": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						OperationType: "query",
+						Arguments:     graphQLTestArgs(),
+					},
+				},
+				"record": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						OperationType: "query",
+						Arguments: graphQLTestArgs(providermanifestv1.ManifestGraphQLArgument{
+							Name: "id",
+							Type: "String!",
+						}),
+						SelectionSet: "id",
+					},
+				},
+				"searchRecords": {
+					Alias:        "records.search",
+					Description:  "Search record metadata.",
+					AllowedRoles: []string{"viewer"},
+					Tags:         []string{"records"},
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						OperationType: "query",
+						Arguments: graphQLTestArgs(providermanifestv1.ManifestGraphQLArgument{
+							Name:        "recordType",
+							Type:        "RecordType",
+							Description: "Optional record type filter.",
+						}),
+						SelectionSet: "records { id name }",
+					},
+				},
+			},
+		},
+		Deps{},
+	)
+	if err != nil {
+		t.Fatalf("buildConfiguredSpecProvider: %v", err)
+	}
+	if _, ok := prov.(core.SessionCatalogProvider); ok {
+		t.Fatal("static GraphQL provider implements SessionCatalogProvider; want static catalog only")
+	}
+	searchOp, ok := graphQLCatalogOperation(prov.Catalog(), "records.search")
+	if !ok {
+		t.Fatalf("catalog operations = %#v, want records.search", prov.Catalog().Operations)
+	}
+	if got, want := searchOp.AllowedRoles, []string{"viewer"}; !slices.Equal(got, want) {
+		t.Fatalf("records.search roles = %#v, want %#v", got, want)
+	}
+	if got, want := searchOp.Tags, []string{"records"}; !slices.Equal(got, want) {
+		t.Fatalf("records.search tags = %#v, want %#v", got, want)
+	}
+	if len(searchOp.Parameters) != 1 || searchOp.Parameters[0].Name != "recordType" || searchOp.Parameters[0].Type != "string" || searchOp.Parameters[0].Required {
+		t.Fatalf("records.search parameters = %#v, want optional string recordType", searchOp.Parameters)
+	}
+	recordOp, ok := graphQLCatalogOperation(prov.Catalog(), "record")
+	if !ok {
+		t.Fatalf("catalog operations = %#v, want record", prov.Catalog().Operations)
+	}
+	if len(recordOp.Parameters) != 1 || recordOp.Parameters[0].Name != "id" || recordOp.Parameters[0].Type != "string" || !recordOp.Parameters[0].Required {
+		t.Fatalf("record parameters = %#v, want required string id", recordOp.Parameters)
+	}
+
+	result, err := prov.Execute(context.Background(), "records.search", map[string]any{"recordType": "ACTIVE"}, "")
+	if err != nil {
+		t.Fatalf("Execute(records.search): %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
+	result, err = prov.Execute(context.Background(), "record", map[string]any{"id": "rec_123"}, "")
+	if err != nil {
+		t.Fatalf("Execute(record): %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
+	result, err = prov.Execute(context.Background(), "status", nil, "")
+	if err != nil {
+		t.Fatalf("Execute(status): %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
+	if got := introspectionCalls.Load(); got != 0 {
+		t.Fatalf("introspection calls = %d, want 0", got)
+	}
+
+	mu.Lock()
+	gotRequests := append([]graphQLRequestPayload(nil), seenRequests...)
+	mu.Unlock()
+	wantRequests := []graphQLRequestPayload{
+		{
+			Query:     "query($recordType: RecordType) { searchRecords(recordType: $recordType) { records { id name } } }",
+			Variables: map[string]any{"recordType": "ACTIVE"},
+		},
+		{
+			Query:     "query($id: String!) { record(id: $id) { id } }",
+			Variables: map[string]any{"id": "rec_123"},
+		},
+		{
+			Query: "query { status }",
+		},
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+}
+
+func TestConfiguredStaticGraphQLProviderRejectsInvalidStaticConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		operations map[string]*config.OperationOverride
+		wantErr    string
+	}{
+		{
+			name: "all graphql operations must opt in with arguments",
+			operations: map[string]*config.OperationOverride{
+				"status": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						Arguments: graphQLTestArgs(),
+					},
+				},
+				"viewer": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						SelectionSet: "id",
+					},
+				},
+			},
+			wantErr: `allowed operation "viewer" must set graphql.arguments`,
+		},
+		{
+			name: "invalid argument type",
+			operations: map[string]*config.OperationOverride{
+				"searchRecords": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						Arguments: graphQLTestArgs(providermanifestv1.ManifestGraphQLArgument{
+							Name: "recordType",
+							Type: "RecordType!!",
+						}),
+						SelectionSet: "records { id }",
+					},
+				},
+			},
+			wantErr: `unexpected input "!"`,
+		},
+		{
+			name: "invalid argument name",
+			operations: map[string]*config.OperationOverride{
+				"searchRecords": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						Arguments: graphQLTestArgs(providermanifestv1.ManifestGraphQLArgument{
+							Name: "record-type",
+							Type: "String",
+						}),
+						SelectionSet: "records { id }",
+					},
+				},
+			},
+			wantErr: `argument "record-type" is not a valid GraphQL name`,
+		},
+		{
+			name: "empty nested selection",
+			operations: map[string]*config.OperationOverride{
+				"viewer": {
+					GraphQL: &providermanifestv1.ManifestGraphQLOperation{
+						Arguments:    graphQLTestArgs(),
+						SelectionSet: "user { }",
+					},
+				},
+			},
+			wantErr: "empty selection set",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := buildConfiguredSpecProvider(
+				context.Background(),
+				"exampleGraphQL",
+				config.ResolvedSpecSurface{
+					Surface: config.SpecSurfaceGraphQL,
+					URL:     "https://graphql.example/query",
+					Connection: config.ConnectionDef{
+						Auth: config.ConnectionAuthDef{Type: providermanifestv1.AuthTypeNone},
+					},
+				},
+				providerMetadata{},
+				specProviderConfig{allowedOperations: tc.operations},
+				Deps{},
+			)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("buildConfiguredSpecProvider error = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 type graphQLPostConnectProvider struct {
 	metadata map[string]string
 }
@@ -207,4 +460,11 @@ func TestGraphQLSessionCatalogProviderPreservesPostConnectCapability(t *testing.
 
 func stringPtr(value string) *string {
 	return &value
+}
+
+func graphQLTestArgs(args ...providermanifestv1.ManifestGraphQLArgument) *[]providermanifestv1.ManifestGraphQLArgument {
+	if args == nil {
+		args = []providermanifestv1.ManifestGraphQLArgument{}
+	}
+	return &args
 }

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -894,7 +894,7 @@ func buildConfiguredSpecProvider(ctx context.Context, name string, resolved conf
 		if err != nil {
 			return nil, nil, err
 		}
-		if resolved.Surface == config.SpecSurfaceGraphQL {
+		if resolved.Surface == config.SpecSurfaceGraphQL && len(def.Operations) == 0 {
 			prov = wrapGraphQLSessionCatalogProvider(prov, name, resolved.URL, cfg.allowedOperations, resolved.GraphQLSelections)
 		}
 		return prov, def, nil
@@ -933,6 +933,9 @@ func loadSpecDefinition(ctx context.Context, name string, resolved config.Resolv
 	case config.SpecSurfaceOpenAPI:
 		return openapi.LoadDefinition(ctx, name, resolved.URL, allowedOperations)
 	case config.SpecSurfaceGraphQL:
+		if def, err := graphql.StaticAllowedOperationsDefinition(name, resolved.URL, allowedOperations, resolved.GraphQLSelections); def != nil || err != nil {
+			return def, err
+		}
 		return graphql.StaticDefinition(name, resolved.URL), nil
 	default:
 		return nil, fmt.Errorf("unsupported spec definition surface %q", resolved.Surface)

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -1297,6 +1297,44 @@
         "selectionSet": {
           "type": "string",
           "minLength": 1
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/manifestGraphQLArgument"
+          }
+        }
+      }
+    },
+    "manifestGraphQLArgument": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "parameterType": {
+          "type": "string",
+          "enum": [
+            "string",
+            "integer",
+            "number",
+            "boolean",
+            "array",
+            "object"
+          ]
         }
       }
     },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -496,8 +496,16 @@ type ManifestOperationOverride struct {
 }
 
 type ManifestGraphQLOperation struct {
-	OperationType string `json:"operationType,omitempty" yaml:"operationType,omitempty"`
-	SelectionSet  string `json:"selectionSet,omitempty" yaml:"selectionSet,omitempty"`
+	OperationType string                     `json:"operationType,omitempty" yaml:"operationType,omitempty"`
+	SelectionSet  string                     `json:"selectionSet,omitempty" yaml:"selectionSet,omitempty"`
+	Arguments     *[]ManifestGraphQLArgument `json:"arguments,omitempty" yaml:"arguments,omitempty"`
+}
+
+type ManifestGraphQLArgument struct {
+	Name          string `json:"name" yaml:"name"`
+	Type          string `json:"type" yaml:"type"`
+	Description   string `json:"description,omitempty" yaml:"description,omitempty"`
+	ParameterType string `json:"parameterType,omitempty" yaml:"parameterType,omitempty"`
 }
 
 type ManifestConnectionDef struct {

--- a/gestaltd/services/plugins/graphql/loader.go
+++ b/gestaltd/services/plugins/graphql/loader.go
@@ -381,14 +381,22 @@ func rootHasField(schema *Schema, root *TypeName, name string) bool {
 }
 
 func argsToParams(schema *Schema, args []InputValue) []declarative.ParameterDef {
+	return argsToParamsWithTypeOverrides(schema, args, nil)
+}
+
+func argsToParamsWithTypeOverrides(schema *Schema, args []InputValue, typeOverrides map[string]string) []declarative.ParameterDef {
 	if len(args) == 0 {
 		return nil
 	}
 	params := make([]declarative.ParameterDef, 0, len(args))
 	for _, arg := range args {
+		paramType := graphqlParamType(schema, arg.Type)
+		if override := strings.TrimSpace(typeOverrides[arg.Name]); override != "" {
+			paramType = declarative.NormalizeType(override)
+		}
 		params = append(params, declarative.ParameterDef{
 			Name:        arg.Name,
-			Type:        graphqlParamType(schema, arg.Type),
+			Type:        paramType,
 			Description: arg.Description,
 			Required:    arg.Type.isNonNull(),
 		})
@@ -402,23 +410,25 @@ func graphqlParamType(schema *Schema, ref TypeRef) string {
 	}
 
 	typeName := ref.innerType().namedType()
-	ft := schema.lookupType(typeName)
-	if ft == nil || ft.Kind != KindInputObject {
-		return graphqlTypeToSimple(schema, ref)
-	}
-	if len(ft.InputFields) == 0 {
-		return "object"
-	}
+	if schema != nil {
+		ft := schema.lookupType(typeName)
+		if ft != nil && ft.Kind == KindInputObject {
+			if len(ft.InputFields) == 0 {
+				return "object"
+			}
 
-	fields := make([]string, 0, len(ft.InputFields))
-	for _, field := range ft.InputFields {
-		name := field.Name
-		if field.Type.isNonNull() {
-			name += "!"
+			fields := make([]string, 0, len(ft.InputFields))
+			for _, field := range ft.InputFields {
+				name := field.Name
+				if field.Type.isNonNull() {
+					name += "!"
+				}
+				fields = append(fields, name)
+			}
+			return "object{" + strings.Join(fields, ", ") + "}"
 		}
-		fields = append(fields, name)
 	}
-	return "object{" + strings.Join(fields, ", ") + "}"
+	return graphqlTypeToSimple(schema, ref)
 }
 
 func graphqlTypeToSimple(schema *Schema, ref TypeRef) string {
@@ -437,9 +447,12 @@ func graphqlTypeToSimple(schema *Schema, ref TypeRef) string {
 	case "Boolean":
 		return "boolean"
 	default:
-		if ft := schema.lookupType(typeName); ft != nil && (ft.Kind == KindEnum || ft.Kind == KindScalar) {
-			return "string"
+		if schema != nil {
+			if ft := schema.lookupType(typeName); ft != nil && (ft.Kind == KindEnum || ft.Kind == KindScalar) {
+				return "string"
+			}
+			return "object"
 		}
-		return "object"
+		return "string"
 	}
 }

--- a/gestaltd/services/plugins/graphql/selection.go
+++ b/gestaltd/services/plugins/graphql/selection.go
@@ -44,12 +44,8 @@ func validateExplicitSelectionSet(schema *Schema, operation string, ref TypeRef,
 		return fmt.Errorf("operation %q requires graphql.selectionSet for %s return type %q", operation, ft.Kind, typeName)
 	}
 
-	p := selectionParser{input: trimmed}
-	selections, err := p.parseSelectionList(false)
+	selections, err := parseSelectionSet(trimmed)
 	if err != nil {
-		return fmt.Errorf("operation %q graphql.selectionSet: %w", operation, err)
-	}
-	if err := p.expectEnd(); err != nil {
 		return fmt.Errorf("operation %q graphql.selectionSet: %w", operation, err)
 	}
 	if len(selections) == 0 {
@@ -198,6 +194,22 @@ func possibleObjectNames(ft *FullType) (map[string]struct{}, bool) {
 	return names, true
 }
 
+func parseSelectionSet(raw string) ([]selection, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	p := selectionParser{input: trimmed}
+	selections, err := p.parseSelectionList(false)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.expectEnd(); err != nil {
+		return nil, err
+	}
+	return selections, nil
+}
+
 type selectionParser struct {
 	input string
 	pos   int
@@ -285,7 +297,14 @@ func (p *selectionParser) parseBracedSelectionList() ([]selection, error) {
 	if !p.consume("{") {
 		return nil, fmt.Errorf("expected opening brace")
 	}
-	return p.parseSelectionList(true)
+	selections, err := p.parseSelectionList(true)
+	if err != nil {
+		return nil, err
+	}
+	if len(selections) == 0 {
+		return nil, fmt.Errorf("empty selection set")
+	}
+	return selections, nil
 }
 
 func (p *selectionParser) expectEnd() error {

--- a/gestaltd/services/plugins/graphql/static.go
+++ b/gestaltd/services/plugins/graphql/static.go
@@ -1,0 +1,189 @@
+package graphql
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"github.com/valon-technologies/gestalt/server/services/plugins/declarative"
+	"github.com/valon-technologies/gestalt/server/services/plugins/operationexposure"
+)
+
+func StaticAllowedOperationsDefinition(name, endpoint string, allowedOps map[string]*operationexposure.OperationOverride, selectionOverrides map[string]string) (*declarative.Definition, error) {
+	graphQLNames := make([]string, 0)
+	hasStaticArgs := false
+	for opName, override := range allowedOps {
+		if override == nil || override.GraphQL == nil {
+			continue
+		}
+		graphQLNames = append(graphQLNames, opName)
+		if override.GraphQL.Arguments != nil {
+			hasStaticArgs = true
+		}
+	}
+	if !hasStaticArgs {
+		return nil, nil
+	}
+	if len(selectionOverrides) > 0 {
+		return nil, fmt.Errorf("graphql %s: operationSelections cannot be combined with static allowedOperations", name)
+	}
+
+	sort.Strings(graphQLNames)
+	for _, opName := range graphQLNames {
+		if allowedOps[opName].GraphQL.Arguments == nil {
+			return nil, fmt.Errorf("graphql %s: allowed operation %q must set graphql.arguments to use static GraphQL catalogs", name, opName)
+		}
+	}
+
+	def := StaticDefinition(name, endpoint)
+	for _, opName := range graphQLNames {
+		override := allowedOps[opName]
+		opDef, exposedName, err := staticOperationDefinition(opName, override)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := def.Operations[exposedName]; exists {
+			return nil, fmt.Errorf("graphql %s: duplicate exposed operation %q", name, exposedName)
+		}
+		def.Operations[exposedName] = opDef
+	}
+
+	return def, nil
+}
+
+func staticOperationDefinition(name string, override *operationexposure.OperationOverride) (declarative.OperationDef, string, error) {
+	if !isGraphQLName(name) {
+		return declarative.OperationDef{}, "", fmt.Errorf("graphql allowed operation %q is not a valid GraphQL field name", name)
+	}
+	operationType, err := graphQLOperationType(override)
+	if err != nil {
+		return declarative.OperationDef{}, "", fmt.Errorf("graphql allowed operation %q: %w", name, err)
+	}
+	if operationType == "" {
+		operationType = graphQLOperationTypeQuery
+	}
+
+	query, params, err := staticOperationQuery(operationType, name, override.GraphQL)
+	if err != nil {
+		return declarative.OperationDef{}, "", fmt.Errorf("graphql allowed operation %q: %w", name, err)
+	}
+
+	exposedName := name
+	if override.Alias != "" {
+		exposedName = override.Alias
+	}
+	return declarative.OperationDef{
+		Description:  declarative.TruncateDescription(override.Description),
+		AllowedRoles: slices.Clone(override.AllowedRoles),
+		Tags:         catalog.MergeTags(override.Tags),
+		Transport:    "graphql",
+		Query:        query,
+		Parameters:   params,
+	}, exposedName, nil
+}
+
+func staticOperationQuery(operationType, fieldName string, graphQLOp *providermanifestv1.ManifestGraphQLOperation) (string, []declarative.ParameterDef, error) {
+	args, typeOverrides, err := staticInputValues(*graphQLOp.Arguments)
+	if err != nil {
+		return "", nil, err
+	}
+
+	selectionSet := strings.TrimSpace(graphQLOp.SelectionSet)
+	if _, err := parseSelectionSet(selectionSet); err != nil {
+		return "", nil, fmt.Errorf("graphql.selectionSet: %w", err)
+	}
+
+	field := Field{Name: fieldName, Args: args}
+	query := generateQueryWithExplicitSelection(nil, field, operationType == graphQLOperationTypeMutation, selectionSet)
+	return query, argsToParamsWithTypeOverrides(nil, args, typeOverrides), nil
+}
+
+func staticInputValues(args []providermanifestv1.ManifestGraphQLArgument) ([]InputValue, map[string]string, error) {
+	if len(args) == 0 {
+		return nil, nil, nil
+	}
+	values := make([]InputValue, 0, len(args))
+	var typeOverrides map[string]string
+	argNames := make(map[string]struct{}, len(args))
+	for _, arg := range args {
+		if !isGraphQLName(arg.Name) {
+			return nil, nil, fmt.Errorf("argument %q is not a valid GraphQL name", arg.Name)
+		}
+		if _, exists := argNames[arg.Name]; exists {
+			return nil, nil, fmt.Errorf("duplicate argument %q", arg.Name)
+		}
+		argNames[arg.Name] = struct{}{}
+
+		typ, err := parseGraphQLType(arg.Type)
+		if err != nil {
+			return nil, nil, fmt.Errorf("argument %q type: %w", arg.Name, err)
+		}
+		values = append(values, InputValue{
+			Name:        arg.Name,
+			Description: arg.Description,
+			Type:        typ,
+		})
+		if override := strings.TrimSpace(arg.ParameterType); override != "" {
+			if typeOverrides == nil {
+				typeOverrides = make(map[string]string)
+			}
+			typeOverrides[arg.Name] = override
+		}
+	}
+	return values, typeOverrides, nil
+}
+
+func parseGraphQLType(raw string) (TypeRef, error) {
+	p := selectionParser{input: strings.TrimSpace(raw)}
+	typ, err := parseGraphQLTypeRef(&p)
+	if err != nil {
+		return TypeRef{}, err
+	}
+	p.skipIgnored()
+	if !p.eof() {
+		return TypeRef{}, fmt.Errorf("unexpected input %q", p.input[p.pos:])
+	}
+	return typ, nil
+}
+
+func parseGraphQLTypeRef(p *selectionParser) (TypeRef, error) {
+	p.skipIgnored()
+	if p.eof() {
+		return TypeRef{}, fmt.Errorf("expected GraphQL type")
+	}
+	var typ TypeRef
+	if p.consume("[") {
+		inner, err := parseGraphQLTypeRef(p)
+		if err != nil {
+			return TypeRef{}, err
+		}
+		p.skipIgnored()
+		if !p.consume("]") {
+			return TypeRef{}, fmt.Errorf("missing closing bracket")
+		}
+		typ = TypeRef{Kind: KindList, OfType: &inner}
+	} else {
+		name, err := p.readName()
+		if err != nil {
+			return TypeRef{}, err
+		}
+		typ = TypeRef{Kind: KindScalar, Name: &name}
+	}
+	p.skipIgnored()
+	if p.consume("!") {
+		inner := typ
+		typ = TypeRef{Kind: KindNonNull, OfType: &inner}
+	}
+	return typ, nil
+}
+
+func isGraphQLName(value string) bool {
+	p := selectionParser{input: value}
+	if _, err := p.readName(); err != nil {
+		return false
+	}
+	return p.eof()
+}


### PR DESCRIPTION
## Problem Statement

Declarative GraphQL providers currently need runtime introspection to discover argument metadata and build per-operation query documents. That makes explicitly allowlisted operations depend on a per-user `__schema` request before listing or invocation, which is slow and can time out for large schemas such as Front Porch.

## Solution

Add an explicit `graphql.arguments` contract under `allowedOperations`. When every GraphQL allowed operation opts in with `arguments`, Gestalt builds those operations into the static catalog and skips the GraphQL session catalog wrapper entirely. Existing manifests that omit `arguments` keep the current runtime introspection behavior.

## Functional Requirements

- Declarative GraphQL plugins can expose a known, allowlisted operation catalog without requiring runtime schema introspection.
- Users can list and invoke explicitly declared GraphQL operations even when the upstream schema is too large or slow to introspect on demand.
- Allowed GraphQL operations can accept typed CLI/API parameters and forward those values as GraphQL variables to the upstream service.
- Existing GraphQL plugins that have not opted into static operation metadata continue to behave as they do today.
- Invalid static GraphQL operation configuration fails during provider build instead of producing malformed upstream requests.

## Interface Diffs

```diff
 allowedOperations:
   vdsOperations:
     alias: vds.operations
     graphql:
       operationType: query
+      arguments:
+        - name: operationType
+          type: VDSOperationType
       selectionSet: |
         entityName
         operations { id name }
 
   healthcheck:
     graphql:
       operationType: query
+      arguments: []
```

## Example

```yaml
allowedOperations:
  vdsOperations:
    alias: vds.operations
    description: List Front Porch VDS operation metadata.
    graphql:
      operationType: query
      arguments:
        - name: operationType
          type: VDSOperationType
          description: Optional VDS operation type filter.
      selectionSet: |
        entityName
        operations {
          id
          name
          operationType
        }
```

This generates the following request document:

```graphql
query($operationType: VDSOperationType) {
  vdsOperations(operationType: $operationType) {
    entityName
    operations {
      id
      name
      operationType
    }
  }
}
```